### PR TITLE
fix(models): refresh native pricing without pinning defaults

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -288,8 +288,13 @@ build stamp is ignored.
 
 The hosted file is published from the public
 [`openclaw/catalog`](https://github.com/openclaw/catalog) GitHub repository.
-Its scheduled workflow refreshes from OpenClaw's shipped plugin manifests and
-pricing sources; every catalog content change is preserved as a public commit.
+Its scheduled workflow checks OpenClaw's default-branch plugin manifests and
+public pricing sources every four hours; every catalog content change is
+preserved as a public commit. Provider-owned policies select complete price
+schedules, including context tiers, without mixing rates from different sources.
+Declared native sources read OpenCode's official catalog or Venice's public model
+API, so connected installations can receive advertised price changes without a
+new OpenClaw release.
 
 Run `openclaw models refresh` for an immediate metadata and pricing check, or
 disable every hosted catalog request with `models.catalogRefresh.enabled:

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -150,7 +150,7 @@ See [Plugins](/tools/plugin) for the full plugin system guide, and [Capability m
 | `providerCatalogEntry`               | No       | `string`                     | Lightweight provider-catalog module path, relative to the plugin root, for manifest-scoped provider catalog metadata that can be loaded without activating the full plugin runtime.                                                                                                                                                                                                              |
 | `modelSupport`                       | No       | `object`                     | Manifest-owned shorthand model-family metadata used to auto-load the plugin before runtime.                                                                                                                                                                                                                                                                                                      |
 | `modelCatalog`                       | No       | `object`                     | Declarative model catalog metadata for providers owned by this plugin. This is the control-plane contract for future read-only listing, onboarding, model pickers, aliases, and suppression without loading plugin runtime.                                                                                                                                                                      |
-| `modelPricing`                       | No       | `object`                     | Provider-owned hosted-pricing publication policy. Use it to opt local/self-hosted providers out of published pricing or map provider refs to OpenRouter/LiteLLM catalog ids without hardcoding provider ids in core.                                                                                                                                                                             |
+| `modelPricing`                       | No       | `object`                     | Provider-owned hosted-pricing publication policy. Use it to opt local/self-hosted providers out of published pricing or map provider refs to supported public pricing catalogs without hardcoding provider ids in core.                                                                                                                                                                          |
 | `modelIdNormalization`               | No       | `object`                     | Provider-owned model-id alias/prefix cleanup that must run before provider runtime loads.                                                                                                                                                                                                                                                                                                        |
 | `providerEndpoints`                  | No       | `object[]`                   | Manifest-owned endpoint host/baseUrl metadata for provider routes that core must classify before provider runtime loads.                                                                                                                                                                                                                                                                         |
 | `providerRequest`                    | No       | `object`                     | Cheap provider-family and request-compatibility metadata used by generic request policy before provider runtime loads.                                                                                                                                                                                                                                                                           |
@@ -1295,11 +1295,13 @@ Use `modelPricing` when the hosted catalog publisher needs provider-specific pri
 
 Provider fields:
 
-| Field        | Type              | What it means                                                                                 |
-| ------------ | ----------------- | --------------------------------------------------------------------------------------------- |
-| `external`   | `boolean`         | Set `false` for local/self-hosted providers that should never use published external pricing. |
-| `openRouter` | `false \| object` | OpenRouter publication-key mapping. `false` disables OpenRouter matching for this provider.   |
-| `liteLLM`    | `false \| object` | LiteLLM publication-key mapping. `false` disables LiteLLM matching for this provider.         |
+| Field        | Type              | What it means                                                                                   |
+| ------------ | ----------------- | ----------------------------------------------------------------------------------------------- |
+| `external`   | `boolean`         | Set `false` for local/self-hosted providers that should never use published external pricing.   |
+| `openCode`   | `false \| object` | Explicit mapping to the public `models.opencode.ai/api.json` catalog. Never enabled implicitly. |
+| `openRouter` | `false \| object` | OpenRouter publication-key mapping. `false` disables OpenRouter matching for this provider.     |
+| `liteLLM`    | `false \| object` | LiteLLM publication-key mapping. `false` disables LiteLLM matching for this provider.           |
+| `venice`     | `false \| object` | Explicit mapping to the public Venice `/api/v1/models` catalog. Never enabled implicitly.       |
 
 Source fields:
 
@@ -1308,6 +1310,36 @@ Source fields:
 | `provider`                 | `string`           | External catalog provider id when it differs from the OpenClaw provider id, for example `z-ai` for a `zai` provider. |
 | `passthroughProviderModel` | `boolean`          | Treat slash-containing model ids as nested provider/model refs, useful for proxy providers such as OpenRouter.       |
 | `modelIdTransforms`        | `"version-dots"[]` | Extra external catalog model-id variants. `version-dots` tries dotted version ids like `claude-opus-4.6`.            |
+
+A declared provider policy enables only its declared source mappings. Without a
+policy, publication tries OpenRouter, then LiteLLM. Each selected price is a
+complete schedule: base rates and context tiers are never combined across sources.
+OpenRouter's native prompt-length overrides are supported; time-based overrides
+are not represented as static context tiers.
+
+For authoritative native source mappings, use:
+
+```json
+{
+  "providers": ["opencode", "venice"],
+  "modelPricing": {
+    "providers": {
+      "opencode": { "openCode": { "provider": "opencode" } },
+      "venice": { "venice": { "provider": "venice" } }
+    }
+  }
+}
+```
+
+The publisher fetches the fixed OpenCode or Venice public endpoint without
+credentials only when its source is declared, and publishes native prices only
+in explicitly mapped owner namespaces. Venice's lightweight public
+`pricing-api.ts` keeps its payload parsing in the plugin and shares the complete
+schedule parser with runtime discovery. Fetch failure, malformed response
+bodies, or missing or invalid pricing for a paid bundled model stops
+publication, leaving the previous hosted catalog intact rather than publishing
+stale seed rates with a new timestamp. This authoring metadata does not add an
+operator setting or change the Gateway's existing refresh and restart lifecycle.
 
 ### OpenClaw Provider Index
 

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -412,9 +412,13 @@ catalog, API-key auth, and dynamic model resolution.
     The same subpath exposes `normalizeOpenRouterModelPricing(pricing)` for
     native OpenRouter pricing objects. It converts per-token rates and static
     prompt-length overrides into a complete per-million cost schedule, without
-    network access or prices from another source. Missing cache rates become zero;
-    invalid required rates or conflicting context tiers return `undefined`.
-    Time-based overrides are not represented as static context tiers.
+    network access or prices from another source. Overrides apply strictly above
+    `min_prompt_tokens`, counting uncached input, cache reads, and cache writes.
+    Matching entries apply in source order: later entries win per price key,
+    including at equal thresholds; omitted keys inherit the native base or an
+    earlier matching entry. Cache rates absent from the base default to zero.
+    Invalid effective token rates return `undefined`. Entries with time-based or
+    unknown conditions are skipped; other known charge dimensions are ignored.
 
     When `ctx.providerIds` is present, it contains the normalized provider
     identities selected for that catalog owner. Return `null` before resolving

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -409,6 +409,13 @@ catalog, API-key auth, and dynamic model resolution.
     Public metadata never establishes account entitlement or expands the
     credential scope of discovery.
 
+    The same subpath exposes `normalizeOpenRouterModelPricing(pricing)` for
+    native OpenRouter pricing objects. It converts per-token rates and static
+    prompt-length overrides into a complete per-million cost schedule, without
+    network access or prices from another source. Missing cache rates become zero;
+    invalid required rates or conflicting context tiers return `undefined`.
+    Time-based overrides are not represented as static context tiers.
+
     When `ctx.providerIds` is present, it contains the normalized provider
     identities selected for that catalog owner. Return `null` before resolving
     credentials or making network requests when the hook serves none of them;

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -119,6 +119,12 @@ deprecated models are excluded from active discovery and its offline fallback.
 Deprecated explicit refs remain resolvable for existing configurations but are
 not shown as current recommendations.
 
+Price estimates also refresh through the [hosted model catalog](/concepts/models#hosted-catalog-updates),
+using the same public OpenCode pricing feed as live discovery. Hosted updates
+activate after the next Gateway restart; the bundled snapshot remains available
+offline. Explicit model prices in your configuration or agent-local `models.json`
+keep precedence. These are advertised-price estimates, not verified invoice totals.
+
 ### Go
 
 | Property         | Value                                                                             |

--- a/docs/providers/venice.md
+++ b/docs/providers/venice.md
@@ -164,24 +164,46 @@ Venice uses a credit-based system. Anonymized models cost roughly the same as
 direct API pricing plus a small Venice fee. See
 [venice.ai/pricing](https://venice.ai/pricing) for current rates.
 
-OpenClaw uses the Venice plugin manifest's prices for bundled models, including
-when those models appear in live discovery. Newly discovered models outside the
-manifest keep zero estimates until pricing is configured; zero does not mean the
-model is free.
+OpenClaw reads live prices from Venice's public
+[`GET /api/v1/models`](https://docs.venice.ai/api-reference/endpoint/models/list)
+response during model discovery. The same plugin parser supplies the hosted
+catalog publisher. Known and newly discovered models use the API's complete
+schedule in USD per million tokens; the manifest prices are an offline seed.
+Missing or invalid live prices retain the complete seed schedule for known
+models. Unknown models without valid pricing keep zero estimates; that does not
+mean the model is free. Explicit API zero rates are valid.
 
-The bundled prices include extended-context tiers for `grok-4-5` and
-`qwen-3-7-plus`. Higher rates apply to the entire request when total prompt
-input exceeds 200,000 or 256,000 tokens, respectively. Prompt input includes
-uncached tokens, cache reads, and cache writes; output tokens do not select the
-tier. A request exactly at the threshold still uses base rates. See Venice's
-[model pricing contract](https://docs.venice.ai/api-reference/endpoint/models/list).
+When the API supplies extended pricing, its rates apply to the entire request
+only when total prompt input **exceeds** `context_token_threshold`. Prompt input
+includes uncached input, cache reads, and cache writes; output tokens do not
+select the tier. A request exactly at the threshold still uses base rates.
+Base and extended rates always come from one schedule. An invalid extended
+schedule is not combined with seed or other-source prices.
 
-Existing explicit model prices take precedence, including zero. Onboarding
-preserves existing model entries rather than replacing their prices. If an older
-configuration contains obsolete zero rates, back up your configuration and update
-only the affected `models.providers.venice.models[].cost` fields to current rates.
-Keep intentional custom prices. See [Token use and costs](/reference/token-use)
-for pricing units and usage reporting.
+Explicit `models.providers.venice.models[].cost` entries override catalog
+estimates, including zero. Omitted `cost` or `{}` inherits the catalog schedule.
+Partial flat overrides inherit missing base rates and remove inherited tiers;
+explicit `tieredPricing` wins, and `tieredPricing: []` selects flat pricing.
+Agent-local root `models.json` prices retain highest priority.
+
+New onboarding in `models.mode: "merge"` leaves generated catalog rows out of the
+configuration so they cannot become price pins. Re-onboarding preserves existing
+model entries, aliases, and model selection. In `models.mode: "replace"`,
+onboarding retains explicit seed rows because that mode disables discovery.
+Existing serialized costs are never automatically removed or migrated, even if
+they match an old seed. With merge mode enabled, back up your configuration and
+remove only unwanted `cost` fields to resume catalog pricing; keep intentional
+overrides.
+
+Discovery reuses its existing fetched rows and cache. Usage display makes no
+price requests, and a running Gateway does not immediately adopt every upstream
+price change. Hosted catalog updates activate at the existing restart boundary;
+see [Hosted model catalog](/concepts/models#hosted-catalog-updates).
+Make sizing-only edits in your source configuration without copying generated
+model rows back into it: replacing an entire model array from a runtime snapshot
+can persist inherited costs as explicit overrides. Historical estimated costs
+remain subject to the existing repricing policy; provider-billed amounts are
+unchanged. See [Token use and costs](/reference/token-use).
 
 ## Usage examples
 
@@ -250,7 +272,6 @@ More help: [Troubleshooting](/help/troubleshooting) and [FAQ](/help/faq).
                 name: "GLM 4.7",
                 reasoning: true,
                 input: ["text"],
-                cost: { input: 0.55, output: 2.65, cacheRead: 0.11, cacheWrite: 0 },
                 contextWindow: 198000,
                 maxTokens: 16384,
               },

--- a/docs/reference/token-use.md
+++ b/docs/reference/token-use.md
@@ -206,11 +206,16 @@ Explicit flat or all-zero model prices do not inherit a catalog tier schedule.
 Omitted flat-rate fields can still inherit catalog defaults. An explicit
 `tieredPricing` schedule takes precedence over the catalog schedule.
 
-Pricing updates ship in the hosted model catalog alongside model metadata.
-OpenClaw does not fetch OpenRouter or LiteLLM directly. Set
-`models.catalogRefresh.enabled: false` to disable hosted catalog traffic on
-offline or restricted networks; bundled pricing and explicit
-`models.providers.*.models[].cost` entries still drive local cost estimates.
+Pricing updates ship in the hosted model catalog alongside model metadata. Its
+publisher reads public pricing sources, including OpenCode's official catalog
+and Venice's public model API when the provider declares the native source.
+Base rates and context tiers come from the same source; usage rendering makes no
+network requests. Hosted updates activate after
+the next Gateway restart. Set `models.catalogRefresh.enabled: false` to disable
+hosted catalog traffic on offline or restricted networks; bundled pricing still
+works. Agent-local `models.json` prices take precedence over explicit
+`models.providers.*.models[].cost` entries, and both override catalog estimates,
+including explicit flat and zero rates.
 
 ## Cache TTL and pruning impact
 

--- a/extensions/opencode/index.test.ts
+++ b/extensions/opencode/index.test.ts
@@ -161,6 +161,17 @@ describe("opencode provider plugin", () => {
       throw new Error("expected registered OpenCode Zen static provider");
     }
     expectSeedModels(result.provider.models);
+    // Official public-feed snapshot, 2026-08-30; connected pricing refreshes independently.
+    expect(result.provider.models.find((model) => model.id === "gpt-5.6-sol")?.cost).toEqual({
+      input: 2,
+      output: 10,
+      cacheRead: 0.2,
+      cacheWrite: 2.5,
+      tieredPricing: [
+        { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5, range: [0, 272_000] },
+        { input: 4, output: 15, cacheRead: 0.4, cacheWrite: 5, range: [272_000] },
+      ],
+    });
     expectSeedModels(manifest.modelCatalog.providers.opencode.models);
     for (const modelId of OFFLINE_MODEL_IDS) {
       expect(provider.resolveDynamicModel?.({ modelId } as never)).toMatchObject({ id: modelId });

--- a/extensions/opencode/openclaw.plugin.json
+++ b/extensions/opencode/openclaw.plugin.json
@@ -45,23 +45,23 @@
             "reasoning": true,
             "input": ["text", "image"],
             "cost": {
-              "input": 5,
-              "output": 30,
-              "cacheRead": 0.5,
-              "cacheWrite": 6.25,
+              "input": 2,
+              "output": 10,
+              "cacheRead": 0.2,
+              "cacheWrite": 2.5,
               "tieredPricing": [
                 {
-                  "input": 5,
-                  "output": 30,
-                  "cacheRead": 0.5,
-                  "cacheWrite": 6.25,
+                  "input": 2,
+                  "output": 10,
+                  "cacheRead": 0.2,
+                  "cacheWrite": 2.5,
                   "range": [0, 272000]
                 },
                 {
-                  "input": 10,
-                  "output": 45,
-                  "cacheRead": 1,
-                  "cacheWrite": 12.5,
+                  "input": 4,
+                  "output": 15,
+                  "cacheRead": 0.4,
+                  "cacheWrite": 5,
                   "range": [272000]
                 }
               ]
@@ -178,6 +178,7 @@
     },
     "discovery": { "opencode": "runtime" }
   },
+  "modelPricing": { "providers": { "opencode": { "openCode": { "provider": "opencode" } } } },
   "setup": {
     "providers": [
       { "id": "opencode", "envVars": ["OPENCODE_API_KEY", "OPENCODE_ZEN_API_KEY"] }

--- a/extensions/openrouter/provider-catalog.test.ts
+++ b/extensions/openrouter/provider-catalog.test.ts
@@ -32,6 +32,15 @@ describe("OpenRouter provider catalog", () => {
               prompt: "0.0000015",
               completion: "0.0000075",
               input_cache_read: "0.00000015",
+              overrides: [
+                {
+                  min_prompt_tokens: 272_000,
+                  prompt: "0.000004",
+                  completion: "0.000015",
+                  input_cache_read: "0.0000004",
+                  input_cache_write: "0.000005",
+                },
+              ],
             },
           },
           {
@@ -74,7 +83,22 @@ describe("OpenRouter provider catalog", () => {
       input: ["text", "image"],
       contextWindow: 1_048_576,
       maxTokens: 65_536,
-      cost: { input: 1.5, output: 7.5, cacheRead: 0.15, cacheWrite: 0 },
+      cost: {
+        input: 1.5,
+        output: 7.5,
+        cacheRead: 0.15,
+        cacheWrite: 0,
+        tieredPricing: [
+          { input: 1.5, output: 7.5, cacheRead: 0.15, cacheWrite: 0, range: [0, 272_000] },
+          {
+            input: 4,
+            output: 15,
+            cacheRead: expect.closeTo(0.4, 12),
+            cacheWrite: 5,
+            range: [272_000],
+          },
+        ],
+      },
     });
     expect(
       new Headers(vi.mocked(fetchGuard).mock.calls[0]?.[0].init?.headers).get("authorization"),

--- a/extensions/openrouter/provider-catalog.test.ts
+++ b/extensions/openrouter/provider-catalog.test.ts
@@ -16,8 +16,8 @@ describe("OpenRouter provider catalog", () => {
       response: Response.json({
         data: [
           {
-            id: "google/gemini-3.6-flash",
-            name: "Google: Gemini 3.6 Flash",
+            id: "acme/partial-pricing",
+            name: "Partial Pricing Fixture",
             architecture: {
               input_modalities: ["text", "image", "audio", "video"],
               output_modalities: ["text"],
@@ -32,13 +32,11 @@ describe("OpenRouter provider catalog", () => {
               prompt: "0.0000015",
               completion: "0.0000075",
               input_cache_read: "0.00000015",
+              input_cache_write: "0.0000025",
               overrides: [
                 {
                   min_prompt_tokens: 272_000,
                   prompt: "0.000004",
-                  completion: "0.000015",
-                  input_cache_read: "0.0000004",
-                  input_cache_write: "0.000005",
                 },
               ],
             },
@@ -73,12 +71,12 @@ describe("OpenRouter provider catalog", () => {
       expect.arrayContaining([
         "openrouter/auto",
         "google/gemini-3.5-flash-lite",
-        "google/gemini-3.6-flash",
+        "acme/partial-pricing",
       ]),
     );
     expect(provider.models.map((model) => model.id)).not.toContain("google/gemini-3.1-flash-image");
-    expect(provider.models.find((model) => model.id === "google/gemini-3.6-flash")).toMatchObject({
-      name: "Google: Gemini 3.6 Flash",
+    expect(provider.models.find((model) => model.id === "acme/partial-pricing")).toMatchObject({
+      name: "Partial Pricing Fixture",
       reasoning: true,
       input: ["text", "image"],
       contextWindow: 1_048_576,
@@ -87,15 +85,15 @@ describe("OpenRouter provider catalog", () => {
         input: 1.5,
         output: 7.5,
         cacheRead: 0.15,
-        cacheWrite: 0,
+        cacheWrite: 2.5,
         tieredPricing: [
-          { input: 1.5, output: 7.5, cacheRead: 0.15, cacheWrite: 0, range: [0, 272_000] },
+          { input: 1.5, output: 7.5, cacheRead: 0.15, cacheWrite: 2.5, range: [0, 272_001] },
           {
             input: 4,
-            output: 15,
-            cacheRead: expect.closeTo(0.4, 12),
-            cacheWrite: 5,
-            range: [272_000],
+            output: 7.5,
+            cacheRead: 0.15,
+            cacheWrite: 2.5,
+            range: [272_001],
           },
         ],
       },

--- a/extensions/openrouter/provider-catalog.ts
+++ b/extensions/openrouter/provider-catalog.ts
@@ -1,6 +1,7 @@
 // Openrouter provider module implements model/runtime integration.
 import {
   buildLiveModelProviderConfig,
+  normalizeOpenRouterModelPricing,
   type LiveModelCatalogFetchGuard,
 } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import {
@@ -144,13 +145,6 @@ function readStringArray(record: Record<string, unknown> | undefined, key: strin
   return filterStringEntries(record?.[key]);
 }
 
-function readTokenPrice(record: Record<string, unknown> | undefined, key: string): number {
-  const value = record?.[key];
-  const parsed =
-    typeof value === "number" ? value : typeof value === "string" ? Number(value) : Number.NaN;
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed * 1_000_000 : 0;
-}
-
 function readOpenRouterModalities(
   architecture: Record<string, unknown> | undefined,
   direction: "input" | "output",
@@ -178,7 +172,6 @@ function buildOpenRouterLiveModel(row: unknown): ModelDefinitionConfig | undefin
   const inputModalities = readOpenRouterModalities(architecture, "input");
   const supportedParameters = readStringArray(record, "supported_parameters");
   const topProvider = asOptionalRecord(record?.top_provider);
-  const pricing = asOptionalRecord(record?.pricing);
   return {
     id,
     name: normalizeOptionalString(record?.name) ?? id,
@@ -186,12 +179,7 @@ function buildOpenRouterLiveModel(row: unknown): ModelDefinitionConfig | undefin
       supportedParameters.includes("reasoning") ||
       supportedParameters.includes("include_reasoning"),
     input: inputModalities.includes("image") ? ["text", "image"] : ["text"],
-    cost: {
-      input: readTokenPrice(pricing, "prompt"),
-      output: readTokenPrice(pricing, "completion"),
-      cacheRead: readTokenPrice(pricing, "input_cache_read"),
-      cacheWrite: readTokenPrice(pricing, "input_cache_write"),
-    },
+    cost: normalizeOpenRouterModelPricing(record?.pricing) ?? { ...OPENROUTER_DEFAULT_COST },
     contextWindow:
       asPositiveSafeInteger(topProvider?.context_length) ??
       asPositiveSafeInteger(record?.context_length) ??

--- a/extensions/venice/models.test.ts
+++ b/extensions/venice/models.test.ts
@@ -72,6 +72,7 @@ type ModelSpecOverride = {
     supportsFunctionCalling?: boolean;
   };
   includeModelSpec?: boolean;
+  pricing?: unknown;
 };
 
 function makeModelRow(params: ModelSpecOverride) {
@@ -82,6 +83,7 @@ function makeModelRow(params: ModelSpecOverride) {
     id: params.id,
     model_spec: {
       name: params.id,
+      ...(params.pricing === undefined ? {} : { pricing: params.pricing }),
       privacy: "private",
       ...(params.availableContextTokens === undefined
         ? {}
@@ -185,7 +187,7 @@ describe("venice-models", () => {
     }
   });
 
-  it("preserves authoritative manifest pricing in every bundled Venice model", () => {
+  it("preserves offline seed pricing in every bundled Venice model", () => {
     expect(
       VENICE_MODEL_CATALOG.map(({ id, cost, compat }) => ({
         id,
@@ -222,6 +224,126 @@ describe("venice-models", () => {
       },
     ]);
   });
+
+  it("uses complete live prices for known, new, and free models in the fetched rows", async () => {
+    const fetchMock = stubVeniceModelsFetch([
+      { id: "grok-4-5", pricing: { input: { usd: 7 }, output: { usd: 11 } } },
+      {
+        id: "new-priced-model",
+        pricing: {
+          input: { usd: 3 },
+          output: { usd: 5 },
+          cache_input: { usd: 0.3 },
+          cache_write: { usd: 3.75 },
+        },
+      },
+      { id: "qwen-3-7-plus", pricing: { input: { usd: 0 }, output: { usd: 0 } } },
+    ]);
+    const models = await runWithDiscoveryEnabled(() => discoverVeniceModels());
+    expect(models.map(({ cost }) => cost)).toEqual([
+      { input: 7, output: 11, cacheRead: 0, cacheWrite: 0 },
+      { input: 3, output: 5, cacheRead: 0.3, cacheWrite: 3.75 },
+      { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    ]);
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    undefined,
+    { input: { usd: 9 } },
+    { input: { usd: -1 }, output: { usd: 3 } },
+    { input: { usd: "9" }, output: { usd: 3 } },
+    { input: { usd: 9 }, output: { usd: 3 }, cache_write: null },
+    { input: { usd: 9 }, output: { usd: 3 }, extended: null },
+    {
+      input: { usd: 9 },
+      output: { usd: 3 },
+      extended: { context_token_threshold: 17, input: { usd: 12 } },
+    },
+    {
+      input: { usd: 9 },
+      output: { usd: 3 },
+      extended: { context_token_threshold: -1, input: { usd: 12 }, output: { usd: 4 } },
+    },
+    {
+      input: { usd: 9 },
+      output: { usd: 3 },
+      cache_input: { usd: 1 },
+      extended: { context_token_threshold: 17, input: { usd: 12 }, output: { usd: 4 } },
+    },
+  ])("keeps the whole offline schedule for missing or invalid live pricing %j", async (pricing) => {
+    stubVeniceModelsFetch([
+      { id: "grok-4-5", pricing },
+      { id: "unknown-invalid-price", pricing },
+    ]);
+    const models = await runWithDiscoveryEnabled(() => discoverVeniceModels());
+    expect(models[0]?.cost).toEqual(VENICE_MODEL_CATALOG.find(({ id }) => id === "grok-4-5")?.cost);
+    expect(models[1]?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+  });
+
+  it.each([0, 17, 200_000, 256_000, 272_000, 17.5])(
+    "prices the entire request only above live threshold %s, including cached tokens",
+    async (threshold) => {
+      stubVeniceModelsFetch([
+        {
+          id: "new-tiered-model",
+          pricing: {
+            input: { usd: 3 },
+            output: { usd: 5 },
+            cache_input: { usd: 0.3 },
+            cache_write: { usd: 3.75 },
+            extended: {
+              context_token_threshold: threshold,
+              input: { usd: 6 },
+              output: { usd: 10 },
+              cache_input: { usd: 0.6 },
+              cache_write: { usd: 7.5 },
+            },
+          },
+        },
+      ]);
+      const [model] = await runWithDiscoveryEnabled(() => discoverVeniceModels());
+      const start = Math.floor(threshold) + 1;
+      expect(model?.cost.tieredPricing).toEqual([
+        { input: 3, output: 5, cacheRead: 0.3, cacheWrite: 3.75, range: [0, start] },
+        { input: 6, output: 10, cacheRead: 0.6, cacheWrite: 7.5, range: [start] },
+      ]);
+      for (const prompt of [Math.floor(threshold), start]) {
+        const cacheRead = Math.floor(prompt / 3);
+        const cacheWrite = Math.floor(prompt / 3);
+        const input = prompt - cacheRead - cacheWrite;
+        const usage: Usage = {
+          input,
+          output: 100,
+          cacheRead,
+          cacheWrite,
+          totalTokens: prompt + 100,
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        };
+        const cost = calculateCost(
+          {
+            id: "new-tiered-model",
+            name: "New tiered model",
+            provider: "venice",
+            api: "openai-completions",
+            baseUrl: VENICE_BASE_URL,
+            reasoning: false,
+            input: ["text"],
+            cost: model!.cost,
+            contextWindow: 1_000_000,
+            maxTokens: 4096,
+          },
+          usage,
+        );
+        expect(cost.total).toBeCloseTo(
+          ((input * 3 + 100 * 5 + cacheRead * 0.3 + cacheWrite * 3.75) *
+            (prompt > threshold ? 2 : 1)) /
+            1_000_000,
+          10,
+        );
+      }
+    },
+  );
 
   // Venice's public model/pricing contract (2026-08-30) applies extended rates
   // to the whole request only when total prompt tokens exceed the threshold.

--- a/extensions/venice/models.ts
+++ b/extensions/venice/models.ts
@@ -8,6 +8,7 @@ import type {
 } from "openclaw/plugin-sdk/provider-model-shared";
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
+import { parseVeniceModelPricing } from "./pricing-api.js";
 
 const VENICE_MANIFEST_CATALOG = manifest.modelCatalog.providers.venice;
 
@@ -48,6 +49,7 @@ interface VeniceModelSpec {
   privacy: "private" | "anonymized";
   availableContextTokens?: number;
   maxCompletionTokens?: number;
+  pricing?: unknown;
   capabilities?: {
     supportsReasoning?: boolean;
     supportsVision?: boolean;
@@ -105,6 +107,7 @@ function projectVeniceModels(
       continue;
     }
     const catalogEntry = catalogById.get(apiModel.id);
+    const liveCost = parseVeniceModelPricing(apiModel.model_spec?.pricing);
     const apiMaxTokens = resolveApiMaxCompletionTokens({
       apiModel,
       knownMaxTokens: catalogEntry?.maxTokens,
@@ -114,7 +117,7 @@ function projectVeniceModels(
       const definition: ModelDefinitionConfig = {
         ...catalogEntry,
         input: [...catalogEntry.input],
-        cost: { ...catalogEntry.cost },
+        cost: liveCost ?? { ...catalogEntry.cost },
         ...(catalogEntry.compat ? { compat: { ...catalogEntry.compat } } : {}),
       };
       if (apiMaxTokens !== undefined) {
@@ -141,7 +144,7 @@ function projectVeniceModels(
         name: apiSpec?.name || apiModel.id,
         reasoning: isReasoning,
         input: hasVision ? ["text", "image"] : ["text"],
-        cost: VENICE_DEFAULT_COST,
+        cost: liveCost ?? VENICE_DEFAULT_COST,
         contextWindow:
           normalizePositiveInt(apiSpec?.availableContextTokens) ?? VENICE_DEFAULT_CONTEXT_WINDOW,
         maxTokens: apiMaxTokens ?? VENICE_DEFAULT_MAX_TOKENS,

--- a/extensions/venice/onboard.test.ts
+++ b/extensions/venice/onboard.test.ts
@@ -1,16 +1,15 @@
 import { resolveAgentModelPrimaryValue } from "openclaw/plugin-sdk/provider-onboard";
 import { describe, expect, it } from "vitest";
-import { VENICE_DEFAULT_MODEL_REF } from "./models.js";
+import { VENICE_DEFAULT_MODEL_REF, VENICE_MODEL_CATALOG } from "./models.js";
 import { applyVeniceConfig } from "./onboard.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 describe("Venice onboarding", () => {
-  it("applies the manifest catalog, default, and alias", () => {
+  it("keeps generated model prices out of merge-mode config while selecting the default and alias", () => {
     const config = applyVeniceConfig({});
 
-    expect(config.models?.providers?.venice?.models.map(({ id, cost }) => ({ id, cost }))).toEqual(
-      manifest.modelCatalog.providers.venice.models.map(({ id, cost }) => ({ id, cost })),
-    );
+    expect(config.models?.providers?.venice?.models).toEqual([]);
+    expect(config.models?.mode).toBe("merge");
     expect(resolveAgentModelPrimaryValue(config.agents?.defaults?.model)).toBe(
       VENICE_DEFAULT_MODEL_REF,
     );
@@ -25,15 +24,34 @@ describe("Venice onboarding", () => {
     { label: "custom", cost: { input: 1, output: 2, cacheRead: 0.25, cacheWrite: 0.5 } },
   ])("preserves existing $label pricing when onboarding again", ({ cost }) => {
     const config = applyVeniceConfig({});
-    const model = config.models!.providers!.venice!.models.find(
-      ({ id }) => id === "qwen-3-7-plus",
-    )!;
-    model.cost = { ...cost };
+    const [seed] = VENICE_MODEL_CATALOG;
+    if (!seed) {
+      throw new Error("expected a Venice seed model");
+    }
+    const model = {
+      ...structuredClone(seed),
+      cost,
+    };
+    config.models!.providers!.venice!.models = [model];
+    config.models!.providers!.venice!.apiKey = "fixture-key";
+    config.agents!.defaults!.model = { primary: "custom/primary", fallbacks: ["custom/fallback"] };
+    config.agents!.defaults!.models = { [VENICE_DEFAULT_MODEL_REF]: { alias: "My alias" } };
 
     const reapplied = applyVeniceConfig(config);
 
     expect(
       reapplied.models?.providers?.venice?.models.find(({ id }) => id === model.id)?.cost,
     ).toEqual(cost);
+    expect(reapplied.models?.providers?.venice?.models).toEqual([model]);
+    expect(reapplied.models?.providers?.venice?.apiKey).toBe("fixture-key");
+    expect(reapplied.agents?.defaults).toEqual(config.agents?.defaults);
+  });
+
+  it("retains the explicit offline seed in replace mode where discovery is disabled", () => {
+    const config = applyVeniceConfig({ models: { mode: "replace" } });
+    expect(config.models?.mode).toBe("replace");
+    expect(config.models?.providers?.venice?.models.map(({ id, cost }) => ({ id, cost }))).toEqual(
+      manifest.modelCatalog.providers.venice.models.map(({ id, cost }) => ({ id, cost })),
+    );
   });
 });

--- a/extensions/venice/onboard.ts
+++ b/extensions/venice/onboard.ts
@@ -4,11 +4,12 @@ import { VENICE_BASE_URL, VENICE_DEFAULT_MODEL_REF, VENICE_MODEL_CATALOG } from 
 
 export const { applyConfig: applyVeniceConfig } = createModelCatalogPresetAppliers<[]>({
   primaryModelRef: VENICE_DEFAULT_MODEL_REF,
-  resolveParams: () => ({
+  resolveParams: (cfg) => ({
     providerId: "venice",
     api: "openai-completions",
     baseUrl: VENICE_BASE_URL,
-    catalogModels: structuredClone(VENICE_MODEL_CATALOG),
+    // Replace mode skips discovery; merge mode must not persist generated pricing as authored pins.
+    catalogModels: cfg.models?.mode === "replace" ? structuredClone(VENICE_MODEL_CATALOG) : [],
     aliases: [{ modelRef: VENICE_DEFAULT_MODEL_REF, alias: "GLM 4.7" }],
   }),
 });

--- a/extensions/venice/openclaw.plugin.json
+++ b/extensions/venice/openclaw.plugin.json
@@ -8,6 +8,11 @@
   "contracts": {
     "usageProviders": ["venice"]
   },
+  "modelPricing": {
+    "providers": {
+      "venice": { "venice": { "provider": "venice" } }
+    }
+  },
   "providerAuthChoices": [
     {
       "provider": "venice",

--- a/extensions/venice/pricing-api.ts
+++ b/extensions/venice/pricing-api.ts
@@ -1,0 +1,91 @@
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  asFiniteNumberInRange,
+  asOptionalRecord,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+
+function readVeniceRates(value: unknown): ModelDefinitionConfig["cost"] | undefined {
+  const row = asOptionalRecord(value);
+  const [input, output, cacheRead, cacheWrite] = [
+    "input",
+    "output",
+    "cache_input",
+    "cache_write",
+  ].map((field, index) => {
+    // Venice omits cache prices when caching is unsupported or writes are not charged.
+    if (index >= 2 && row?.[field] === undefined) {
+      return 0;
+    }
+    return asFiniteNumberInRange(asOptionalRecord(row?.[field])?.usd, { min: 0 });
+  });
+  if (
+    input === undefined ||
+    output === undefined ||
+    cacheRead === undefined ||
+    cacheWrite === undefined
+  ) {
+    return undefined;
+  }
+  return { input, output, cacheRead, cacheWrite };
+}
+
+/** Venice's public /models prices are USD per million tokens, for the whole request. */
+export function parseVeniceModelPricing(value: unknown): ModelDefinitionConfig["cost"] | undefined {
+  const row = asOptionalRecord(value);
+  const base = readVeniceRates(row);
+  if (!base || row?.extended === undefined) {
+    return base;
+  }
+  const extended = asOptionalRecord(row.extended);
+  const rates = readVeniceRates(extended);
+  const threshold = asFiniteNumberInRange(extended?.context_token_threshold, {
+    min: 0,
+    max: Number.MAX_SAFE_INTEGER,
+    maxExclusive: true,
+  });
+  if (!rates || threshold === undefined) {
+    return undefined;
+  }
+  // A missing extended cache price cannot establish the charge for a supported
+  // cache bucket. Reject the schedule instead of borrowing its base rate.
+  if (
+    ["cache_input", "cache_write"].some(
+      (field) => row[field] !== undefined && extended?.[field] === undefined,
+    )
+  ) {
+    return undefined;
+  }
+  // Token counts are integral; Venice switches strictly above the threshold.
+  const start = Math.floor(threshold) + 1;
+  return {
+    ...base,
+    tieredPricing: [
+      { ...base, range: [0, start] },
+      { ...rates, range: [start] },
+    ],
+  };
+}
+
+/** Public lightweight publisher entrypoint; vendor payload interpretation stays in this plugin. */
+export function parseVenicePricingCatalog(
+  payload: unknown,
+): Map<string, ModelDefinitionConfig["cost"]> | undefined {
+  const data = asOptionalRecord(payload)?.data;
+  if (!Array.isArray(data)) {
+    return undefined;
+  }
+  const prices = new Map<string, ModelDefinitionConfig["cost"]>();
+  for (const value of data) {
+    const row = asOptionalRecord(value);
+    const id = normalizeOptionalString(row?.id);
+    if (!id || row?.type !== "text") {
+      continue;
+    }
+    const price = parseVeniceModelPricing(asOptionalRecord(row.model_spec)?.pricing);
+    if (price) {
+      prices.set(id, price);
+    }
+  }
+  return prices;
+}

--- a/packages/model-catalog-core/package.json
+++ b/packages/model-catalog-core/package.json
@@ -33,6 +33,11 @@
       "import": "./dist/model-catalog-normalize.mjs",
       "default": "./dist/model-catalog-normalize.mjs"
     },
+    "./model-catalog-pricing": {
+      "types": "./dist/model-catalog-pricing.d.mts",
+      "import": "./dist/model-catalog-pricing.mjs",
+      "default": "./dist/model-catalog-pricing.mjs"
+    },
     "./model-catalog-types": {
       "types": "./dist/model-catalog-types.d.mts",
       "import": "./dist/model-catalog-types.mjs",

--- a/packages/model-catalog-core/src/model-catalog-pricing.test.ts
+++ b/packages/model-catalog-core/src/model-catalog-pricing.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeModelPricingProvider,
+  normalizeOpenRouterModelPricing,
+  normalizeUpstreamModelPricing,
+} from "./model-catalog-pricing.js";
+
+const BASE_COST = { input: 2, output: 10, cacheRead: 0, cacheWrite: 0 };
+
+describe("model pricing source policy", () => {
+  it("normalizes all source mappings without losing explicit opt-outs", () => {
+    expect(
+      normalizeModelPricingProvider({
+        external: false,
+        openCode: { provider: " OpenCode ", modelIdTransforms: ["version-dots", "unknown", null] },
+        venice: { provider: " Venice " },
+        openRouter: { passthroughProviderModel: true },
+        liteLLM: false,
+      }),
+    ).toEqual({
+      external: false,
+      openCode: { provider: "opencode", modelIdTransforms: ["version-dots"] },
+      venice: { provider: "venice" },
+      openRouter: { passthroughProviderModel: true },
+      liteLLM: false,
+    });
+  });
+
+  it.each([
+    { value: undefined },
+    { value: null },
+    { value: [] },
+    { value: {} },
+    {
+      value: {
+        openCode: {},
+        openRouter: { provider: " " },
+        liteLLM: { modelIdTransforms: ["unknown"] },
+      },
+    },
+  ])("ignores empty or unrecognized policy $value", ({ value }) =>
+    expect(normalizeModelPricingProvider(value)).toBeUndefined(),
+  );
+});
+
+describe.each([
+  {
+    source: "OpenRouter",
+    normalize: normalizeOpenRouterModelPricing,
+    base: { prompt: "0.000002", completion: "0.00001" },
+    input: "prompt",
+    output: "completion",
+    cache: "input_cache_read",
+  },
+  {
+    source: "upstream",
+    normalize: normalizeUpstreamModelPricing,
+    base: { input: 2, output: 10 },
+    input: "input",
+    output: "output",
+    cache: "cache_read",
+  },
+])("$source pricing integrity", ({ normalize, base, input, output, cache }) => {
+  it("returns complete per-million rates with absent cache charges defaulted to zero", () => {
+    expect(normalize(base)).toEqual(BASE_COST);
+    expect(normalize({ [input]: 0, [output]: 0 })).toEqual({
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    });
+  });
+
+  it.each([undefined, null, "", " ", "1usd", -1, Infinity, Number.NaN, true])(
+    "rejects invalid required or declared cache rates %j instead of inventing free prices",
+    (invalid) => {
+      for (const field of [input, output, cache]) {
+        if (field === cache && invalid === undefined) {
+          continue;
+        }
+        expect(normalize({ ...base, [field]: invalid })).toBeUndefined();
+      }
+    },
+  );
+});
+
+describe("OpenRouter native pricing", () => {
+  it("sorts static prompt tiers and ignores scheduled overrides without borrowing foreign prices", () => {
+    const pricing = {
+      prompt: "0.000002",
+      completion: "0.00001",
+      input_cache_read: "0.0000002",
+      input_cache_write: "0.0000025",
+      // Other feed formats must not supply native OpenRouter rates or tiers.
+      input: 99,
+      context_over_200k: { input: 99, output: 99 },
+      overrides: [
+        { min_prompt_tokens: 500_000, prompt: "0.000006", completion: "0.00002" },
+        { utc_days: [0], utc_start: "00:00", utc_end: "12:00", prompt: "0", completion: "0" },
+        { min_prompt_tokens: 100_000, utc_start: "00:00", prompt: "0", completion: "0" },
+        {
+          min_prompt_tokens: 272_000,
+          prompt: "0.000004",
+          completion: "0.000015",
+          input_cache_read: "0.0000004",
+          input_cache_write: "0.000005",
+        },
+      ],
+    };
+    const cost = { input: 2, output: 10, cacheRead: expect.closeTo(0.2, 12), cacheWrite: 2.5 };
+    expect(normalizeOpenRouterModelPricing(pricing)).toEqual({
+      ...cost,
+      tieredPricing: [
+        { ...cost, range: [0, 272_000] },
+        {
+          input: 4,
+          output: 15,
+          cacheRead: expect.closeTo(0.4, 12),
+          cacheWrite: 5,
+          range: [272_000, 500_000],
+        },
+        { input: 6, output: 20, cacheRead: 0, cacheWrite: 0, range: [500_000] },
+      ],
+    });
+  });
+
+  it("rejects an incomplete native context override and per-million overflow", () => {
+    expect(
+      normalizeOpenRouterModelPricing({
+        prompt: "0.000002",
+        completion: "0.00001",
+        overrides: [{ min_prompt_tokens: 272_000, prompt: "0.000004" }],
+      }),
+    ).toBeUndefined();
+    expect(normalizeOpenRouterModelPricing({ prompt: "1e308", completion: "0" })).toBeUndefined();
+    expect(normalizeOpenRouterModelPricing({ input: 2, output: 10 })).toBeUndefined();
+  });
+});
+
+describe("upstream pricing tiers", () => {
+  it("sorts positive safe-integer context thresholds and ignores other tier dimensions", () => {
+    expect(
+      normalizeUpstreamModelPricing({
+        input: 2,
+        output: 10,
+        tiers: [
+          { tier: { type: "context", size: 500_000 }, input: 6, output: 20 },
+          { tier: { type: "context", size: 272_000 }, input: 4, output: 15 },
+          ...[0, -1, 1.5, "100000", Number.MAX_SAFE_INTEGER + 1].map((size) => ({
+            tier: { type: "context", size },
+          })),
+          { tier: { type: "time", size: 100_000 } },
+        ],
+      }),
+    ).toEqual({
+      ...BASE_COST,
+      tieredPricing: [
+        { ...BASE_COST, range: [0, 272_000] },
+        { input: 4, output: 15, cacheRead: 0, cacheWrite: 0, range: [272_000, 500_000] },
+        { input: 6, output: 20, cacheRead: 0, cacheWrite: 0, range: [500_000] },
+      ],
+    });
+  });
+
+  it.each([
+    {
+      tiers: [{ tier: { type: "context", size: 200_000 }, input: 4 }],
+      context_over_200k: { input: 4, output: 15 },
+    },
+    { context_over_200k: { input: 4 } },
+    {
+      tiers: [
+        { tier: { type: "context", size: 272_000 }, input: 4, output: 15 },
+        { tier: { type: "context", size: 272_000 }, input: 8, output: 30 },
+      ],
+    },
+  ])(
+    "rejects incomplete or conflicting context tiers rather than selecting lower prices: %j",
+    (tiers) => {
+      expect(normalizeUpstreamModelPricing({ input: 2, output: 10, ...tiers })).toBeUndefined();
+    },
+  );
+});

--- a/packages/model-catalog-core/src/model-catalog-pricing.test.ts
+++ b/packages/model-catalog-core/src/model-catalog-pricing.test.ts
@@ -1,3 +1,4 @@
+import { calculateUsageCost } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
 import {
   normalizeModelPricingProvider,
@@ -85,12 +86,17 @@ describe.each([
 });
 
 describe("OpenRouter native pricing", () => {
-  it("sorts static prompt tiers and ignores scheduled overrides without borrowing foreign prices", () => {
+  const base = {
+    prompt: "0.000002",
+    completion: "0.00001",
+    input_cache_read: "0.00000025",
+    input_cache_write: "0.0000025",
+  };
+  const cost = { input: 2, output: 10, cacheRead: 0.25, cacheWrite: 2.5 };
+
+  it("compiles unordered overrides in source order per key without borrowing foreign prices", () => {
     const pricing = {
-      prompt: "0.000002",
-      completion: "0.00001",
-      input_cache_read: "0.0000002",
-      input_cache_write: "0.0000025",
+      ...base,
       // Other feed formats must not supply native OpenRouter rates or tiers.
       input: 99,
       context_over_200k: { input: 99, output: 99 },
@@ -107,31 +113,190 @@ describe("OpenRouter native pricing", () => {
         },
       ],
     };
-    const cost = { input: 2, output: 10, cacheRead: expect.closeTo(0.2, 12), cacheWrite: 2.5 };
     expect(normalizeOpenRouterModelPricing(pricing)).toEqual({
       ...cost,
       tieredPricing: [
-        { ...cost, range: [0, 272_000] },
+        { ...cost, range: [0, 272_001] },
         {
           input: 4,
           output: 15,
           cacheRead: expect.closeTo(0.4, 12),
           cacheWrite: 5,
-          range: [272_000, 500_000],
+          range: [272_001, 500_001],
         },
-        { input: 6, output: 20, cacheRead: 0, cacheWrite: 0, range: [500_000] },
+        {
+          input: 4,
+          output: 15,
+          cacheRead: expect.closeTo(0.4, 12),
+          cacheWrite: 5,
+          range: [500_001],
+        },
       ],
     });
   });
 
-  it("rejects an incomplete native context override and per-million overflow", () => {
+  it.each([
+    { prices: { prompt: "0.000004" }, expected: { input: 4 } },
+    { prices: { completion: "0.00002" }, expected: { output: 20 } },
+    { prices: { input_cache_read: "0.0000005" }, expected: { cacheRead: 0.5 } },
+    { prices: { input_cache_write: "0.000005" }, expected: { cacheWrite: 5 } },
+    { prices: { prompt: "0", input_cache_read: "0" }, expected: { input: 0, cacheRead: 0 } },
+  ])("inherits omitted native rates for partial overrides: $prices", ({ prices, expected }) => {
     expect(
       normalizeOpenRouterModelPricing({
-        prompt: "0.000002",
-        completion: "0.00001",
-        overrides: [{ min_prompt_tokens: 272_000, prompt: "0.000004" }],
+        ...base,
+        overrides: [{ min_prompt_tokens: 100, ...prices }],
       }),
-    ).toBeUndefined();
+    ).toEqual({
+      ...cost,
+      tieredPricing: [
+        { ...cost, range: [0, 101] },
+        { ...cost, ...expected, range: [101] },
+      ],
+    });
+  });
+
+  it("lets equal and lower thresholds override only their supplied keys in source order", () => {
+    expect(
+      normalizeOpenRouterModelPricing({
+        ...base,
+        overrides: [
+          { min_prompt_tokens: 500, prompt: "0.000006", completion: "0.00002" },
+          { min_prompt_tokens: 200, prompt: "0.000004", input_cache_read: "0.0000005" },
+          { min_prompt_tokens: 200, input_cache_write: "0" },
+        ],
+      }),
+    ).toEqual({
+      ...cost,
+      tieredPricing: [
+        { ...cost, range: [0, 201] },
+        { input: 4, output: 10, cacheRead: 0.5, cacheWrite: 0, range: [201, 501] },
+        { input: 4, output: 20, cacheRead: 0.5, cacheWrite: 0, range: [501] },
+      ],
+    });
+  });
+
+  it.each([
+    { input: 39, output: 7, cacheRead: 30, cacheWrite: 30, expected: 0.0002305 },
+    { input: 40, output: 7, cacheRead: 30, cacheWrite: 30, expected: 0.0002325 },
+    { input: 41, output: 7, cacheRead: 30, cacheWrite: 30, expected: 0.0003865 },
+    { input: 0, output: 7, cacheRead: 101, cacheWrite: 0, expected: 0.00016525 },
+    { input: 0, output: 7, cacheRead: 0, cacheWrite: 101, expected: 0.0003925 },
+    { input: 0, output: 1_000, cacheRead: 0, cacheWrite: 0, expected: 0.01 },
+  ])(
+    "bills strict total-prompt boundaries with inherited cache prices: %j",
+    ({ expected, ...usage }) => {
+      const pricing = normalizeOpenRouterModelPricing({
+        ...base,
+        overrides: [{ min_prompt_tokens: 100, prompt: "0.000004", completion: "0.00002" }],
+      });
+      expect(pricing).toBeDefined();
+      if (!pricing) {
+        throw new Error("Expected a complete native schedule");
+      }
+      expect(calculateUsageCost(usage, pricing).total).toBeCloseTo(expected, 12);
+    },
+  );
+
+  it.each([0, 100.5, Number.MAX_SAFE_INTEGER - 1])(
+    "compiles a strict threshold %j to the first matching integral prompt size",
+    (threshold) => {
+      const start = Math.floor(threshold) + 1;
+      expect(
+        normalizeOpenRouterModelPricing({
+          ...base,
+          overrides: [{ min_prompt_tokens: threshold, prompt: "0" }],
+        }),
+      ).toEqual({
+        ...cost,
+        tieredPricing: [
+          { ...cost, range: [0, start] },
+          { ...cost, input: 0, range: [start] },
+        ],
+      });
+    },
+  );
+
+  it.each([
+    { future_condition: true },
+    { future_price: "0" },
+    { utc_start: 1630 },
+    { utc_end: 30 },
+    { utc_days: ["monday"] },
+    ...[undefined, null, -1, "100", Infinity, Number.NaN, Number.MAX_SAFE_INTEGER].map(
+      (min_prompt_tokens) => ({ min_prompt_tokens }),
+    ),
+  ])("skips unsupported or invalid predicates: %j", (condition) => {
+    expect(
+      normalizeOpenRouterModelPricing({
+        ...base,
+        overrides: [{ min_prompt_tokens: 100, prompt: "0", ...condition }],
+      }),
+    ).toEqual(cost);
+  });
+
+  it("ignores known non-token charge dimensions without dropping token overrides", () => {
+    expect(
+      normalizeOpenRouterModelPricing({
+        ...base,
+        overrides: [
+          {
+            min_prompt_tokens: 100,
+            prompt: "0.000004",
+            request: "1",
+            image: "1",
+            web_search: "1",
+            internal_reasoning: "1",
+            audio: "1",
+            input_audio_cache: "1",
+            input_cache_write_1h: "1",
+            image_output: "1",
+            audio_output: "1",
+          },
+        ],
+      }),
+    ).toEqual({
+      ...cost,
+      tieredPricing: [
+        { ...cost, range: [0, 101] },
+        { ...cost, input: 4, range: [101] },
+      ],
+    });
+  });
+
+  it.each([null, "", "1usd", -1, Infinity, "1e308"])(
+    "invalidates the schedule for malformed effective prices %j",
+    (invalid) => {
+      for (const field of Object.keys(base)) {
+        expect(
+          normalizeOpenRouterModelPricing({
+            ...base,
+            overrides: [{ min_prompt_tokens: 100, [field]: invalid }],
+          }),
+        ).toBeUndefined();
+      }
+    },
+  );
+
+  it("validates effective prices after later matching entries replace malformed fields", () => {
+    expect(
+      normalizeOpenRouterModelPricing({
+        ...base,
+        overrides: [
+          { min_prompt_tokens: 100, prompt: "bad" },
+          { min_prompt_tokens: 100, prompt: "0" },
+        ],
+      }),
+    ).toEqual({
+      ...cost,
+      tieredPricing: [
+        { ...cost, range: [0, 101] },
+        { ...cost, input: 0, range: [101] },
+      ],
+    });
+  });
+
+  it("rejects per-million overflow and foreign base prices", () => {
     expect(normalizeOpenRouterModelPricing({ prompt: "1e308", completion: "0" })).toBeUndefined();
     expect(normalizeOpenRouterModelPricing({ input: 2, output: 10 })).toBeUndefined();
   });

--- a/packages/model-catalog-core/src/model-catalog-pricing.ts
+++ b/packages/model-catalog-core/src/model-catalog-pricing.ts
@@ -1,4 +1,5 @@
 import {
+  asFiniteNumberInRange,
   asNonNegativeFiniteNumber,
   asPositiveSafeInteger,
   parseStrictFiniteNumber,
@@ -9,8 +10,26 @@ import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-
 import { normalizeModelCatalogProviderId } from "./model-catalog-refs.js";
 import type { ModelCatalogCost, ModelCatalogTieredCost } from "./model-catalog-types.js";
 
-const MODEL_PRICING_SOURCES = ["openCode", "venice", "openRouter", "liteLLM"] as const;
-export type ModelPricingSourceId = (typeof MODEL_PRICING_SOURCES)[number];
+export const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
+export const LITELLM_PRICING_URL =
+  "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+export const MODEL_PRICING_SOURCES = [
+  {
+    id: "openCode",
+    label: "OpenCode",
+    url: "https://models.opencode.ai/api.json",
+    authoritative: true,
+  },
+  {
+    id: "venice",
+    label: "Venice",
+    url: "https://api.venice.ai/api/v1/models",
+    authoritative: true,
+  },
+  { id: "openRouter", label: "OpenRouter", url: OPENROUTER_MODELS_URL, authoritative: false },
+  { id: "liteLLM", label: "LiteLLM", url: LITELLM_PRICING_URL, authoritative: false },
+] as const;
+export type ModelPricingSourceId = (typeof MODEL_PRICING_SOURCES)[number]["id"];
 export type ModelPricingSource = {
   provider?: string;
   passthroughProviderModel?: boolean;
@@ -32,7 +51,7 @@ export function normalizeModelPricingProvider(value: unknown): ModelPricingProvi
   }
   const policy: ModelPricingProvider =
     typeof record.external === "boolean" ? { external: record.external } : {};
-  for (const sourceId of MODEL_PRICING_SOURCES) {
+  for (const { id: sourceId } of MODEL_PRICING_SOURCES) {
     const raw = record[sourceId];
     if (raw === false) {
       policy[sourceId] = false;
@@ -114,24 +133,59 @@ function withContextPrices(
   return { ...cost, tieredPricing };
 }
 
+// OpenRouter's /models price keys include charge dimensions outside our four token rates.
+// Keep this closed so unknown predicates cannot silently become unconditional prices.
+const OPENROUTER_PRICE_FIELDS = new Set([
+  "prompt",
+  "completion",
+  "request",
+  "image",
+  "web_search",
+  "internal_reasoning",
+  "input_cache_read",
+  "input_cache_write",
+  "audio",
+  "input_audio_cache",
+  "input_cache_write_1h",
+  "image_output",
+  "audio_output",
+]);
+
 /** Read native OpenRouter per-token prices and static prompt-length overrides. */
 export function normalizeOpenRouterModelPricing(value: unknown): CompleteModelCost | undefined {
   const row = asOptionalRecord(value);
-  const tiers: ContextPrice[] = [];
+  const overrides: { size: number; prices: Record<string, unknown> }[] = [];
   for (const raw of Array.isArray(row?.overrides) ? row.overrides : []) {
     const override = asOptionalRecord(raw);
-    // UTC schedules are not static context tiers, even when a prompt threshold is also present.
+    // All predicates must match; UTC schedules and unknown conditions are not static tiers.
     if (
       !override ||
-      ["utc_days", "utc_start", "utc_end"].some((key) => override[key] !== undefined)
+      Object.keys(override).some(
+        (key) => key !== "min_prompt_tokens" && !OPENROUTER_PRICE_FIELDS.has(key),
+      )
     ) {
       continue;
     }
-    const size = asPositiveSafeInteger(override.min_prompt_tokens);
-    if (size) {
-      tiers.push({ size, cost: readPricingCost(override, "openRouter") });
+    const threshold = asFiniteNumberInRange(override.min_prompt_tokens, {
+      min: 0,
+      max: Number.MAX_SAFE_INTEGER,
+      maxExclusive: true,
+    });
+    if (threshold !== undefined) {
+      overrides.push({ size: Math.floor(threshold) + 1, prices: override });
     }
   }
+  // Token counts are integral and thresholds strict. Resolve every boundary from the
+  // native base, then apply matching overrides per key in their original source order.
+  const tiers = [...new Set(overrides.map(({ size }) => size))].map((size) => {
+    const prices = { ...row };
+    for (const override of overrides) {
+      if (size >= override.size) {
+        Object.assign(prices, override.prices);
+      }
+    }
+    return { size, cost: readPricingCost(prices, "openRouter") };
+  });
   return withContextPrices(readPricingCost(value, "openRouter"), tiers);
 }
 

--- a/packages/model-catalog-core/src/model-catalog-pricing.ts
+++ b/packages/model-catalog-core/src/model-catalog-pricing.ts
@@ -1,0 +1,154 @@
+import {
+  asNonNegativeFiniteNumber,
+  asPositiveSafeInteger,
+  parseStrictFiniteNumber,
+} from "@openclaw/normalization-core/number-coercion";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { normalizeTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
+import { normalizeModelCatalogProviderId } from "./model-catalog-refs.js";
+import type { ModelCatalogCost, ModelCatalogTieredCost } from "./model-catalog-types.js";
+
+const MODEL_PRICING_SOURCES = ["openCode", "venice", "openRouter", "liteLLM"] as const;
+export type ModelPricingSourceId = (typeof MODEL_PRICING_SOURCES)[number];
+export type ModelPricingSource = {
+  provider?: string;
+  passthroughProviderModel?: boolean;
+  modelIdTransforms?: "version-dots"[];
+};
+export type ModelPricingProvider = { external?: boolean } & Partial<
+  Record<ModelPricingSourceId, ModelPricingSource | false>
+>;
+
+type CompleteModelCost = Omit<ModelCatalogTieredCost, "range"> &
+  Pick<ModelCatalogCost, "tieredPricing">;
+type ContextPrice = { size: number; cost: CompleteModelCost | undefined };
+
+/** Normalize source policy without deciding which plugin owns the provider. */
+export function normalizeModelPricingProvider(value: unknown): ModelPricingProvider | undefined {
+  const record = asOptionalRecord(value);
+  if (!record) {
+    return undefined;
+  }
+  const policy: ModelPricingProvider =
+    typeof record.external === "boolean" ? { external: record.external } : {};
+  for (const sourceId of MODEL_PRICING_SOURCES) {
+    const raw = record[sourceId];
+    if (raw === false) {
+      policy[sourceId] = false;
+      continue;
+    }
+    const row = asOptionalRecord(raw);
+    const provider = normalizeModelCatalogProviderId(normalizeOptionalString(row?.provider) ?? "");
+    const modelIdTransforms = normalizeTrimmedStringList(row?.modelIdTransforms).filter(
+      (entry): entry is "version-dots" => entry === "version-dots",
+    );
+    const source: ModelPricingSource = {
+      ...(provider ? { provider } : {}),
+      ...(row?.passthroughProviderModel === true ? { passthroughProviderModel: true } : {}),
+      ...(modelIdTransforms.length > 0 ? { modelIdTransforms } : {}),
+    };
+    if (Object.keys(source).length > 0) {
+      policy[sourceId] = source;
+    }
+  }
+  return Object.keys(policy).length > 0 ? policy : undefined;
+}
+
+function readPricingCost(
+  value: unknown,
+  source: "openRouter" | "upstream",
+): CompleteModelCost | undefined {
+  const row = asOptionalRecord(value);
+  const perToken = source === "openRouter";
+  const fields = perToken
+    ? ["prompt", "completion", "input_cache_read", "input_cache_write"]
+    : ["input", "output", "cache_read", "cache_write"];
+  const [input, output, cacheRead, cacheWrite] = fields.map((field, index) => {
+    const raw = row?.[field];
+    // Missing cache rates mean no cache charge; required rates must distinguish unknown from free.
+    if (index >= 2 && raw === undefined) {
+      return 0;
+    }
+    const rate = perToken ? parseStrictFiniteNumber(raw) : asNonNegativeFiniteNumber(raw);
+    return rate === undefined
+      ? undefined
+      : asNonNegativeFiniteNumber(rate * (perToken ? 1_000_000 : 1));
+  });
+  if (
+    input === undefined ||
+    output === undefined ||
+    cacheRead === undefined ||
+    cacheWrite === undefined
+  ) {
+    return undefined;
+  }
+  return { input, output, cacheRead, cacheWrite };
+}
+
+function withContextPrices(
+  cost: CompleteModelCost | undefined,
+  tiers: ContextPrice[],
+): CompleteModelCost | undefined {
+  if (!cost) {
+    return undefined;
+  }
+  tiers.sort((left, right) => left.size - right.size);
+  const firstTier = tiers[0];
+  if (!firstTier) {
+    return cost;
+  }
+  const tieredPricing: ModelCatalogTieredCost[] = [{ ...cost, range: [0, firstTier.size] }];
+  for (const [index, tier] of tiers.entries()) {
+    // A recognized context tier with unknown rates invalidates the price, not just that tier.
+    if (!tier.cost) {
+      return undefined;
+    }
+    const next = tiers[index + 1]?.size;
+    // Conflicting thresholds cannot select one whole-request price; never publish zero-width tiers.
+    if (next === tier.size) {
+      return undefined;
+    }
+    tieredPricing.push({ ...tier.cost, range: next ? [tier.size, next] : [tier.size] });
+  }
+  return { ...cost, tieredPricing };
+}
+
+/** Read native OpenRouter per-token prices and static prompt-length overrides. */
+export function normalizeOpenRouterModelPricing(value: unknown): CompleteModelCost | undefined {
+  const row = asOptionalRecord(value);
+  const tiers: ContextPrice[] = [];
+  for (const raw of Array.isArray(row?.overrides) ? row.overrides : []) {
+    const override = asOptionalRecord(raw);
+    // UTC schedules are not static context tiers, even when a prompt threshold is also present.
+    if (
+      !override ||
+      ["utc_days", "utc_start", "utc_end"].some((key) => override[key] !== undefined)
+    ) {
+      continue;
+    }
+    const size = asPositiveSafeInteger(override.min_prompt_tokens);
+    if (size) {
+      tiers.push({ size, cost: readPricingCost(override, "openRouter") });
+    }
+  }
+  return withContextPrices(readPricingCost(value, "openRouter"), tiers);
+}
+
+/** Read upstream per-million prices, preferring modern context tiers over context_over_200k. */
+export function normalizeUpstreamModelPricing(value: unknown): CompleteModelCost | undefined {
+  const row = asOptionalRecord(value);
+  const tiers: ContextPrice[] = [];
+  for (const raw of Array.isArray(row?.tiers) ? row.tiers : []) {
+    const price = asOptionalRecord(raw);
+    const tier = asOptionalRecord(price?.tier);
+    const size = asPositiveSafeInteger(tier?.size);
+    if (tier?.type === "context" && size) {
+      tiers.push({ size, cost: readPricingCost(price, "upstream") });
+    }
+  }
+  if (tiers.length === 0 && asOptionalRecord(row?.context_over_200k)) {
+    tiers.push({ size: 200_000, cost: readPricingCost(row?.context_over_200k, "upstream") });
+  }
+  return withContextPrices(readPricingCost(value, "upstream"), tiers);
+}

--- a/scripts/publish-model-catalog.mts
+++ b/scripts/publish-model-catalog.mts
@@ -2,46 +2,70 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import {
+  normalizeModelPricingProvider,
+  normalizeOpenRouterModelPricing,
+  normalizeUpstreamModelPricing,
+  type ModelPricingProvider,
+  type ModelPricingSource,
+  type ModelPricingSourceId,
+} from "@openclaw/model-catalog-core/model-catalog-pricing";
+import { normalizeModelCatalogProviderId } from "@openclaw/model-catalog-core/model-catalog-refs";
+import { parseStrictFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { parseVenicePricingCatalog } from "../extensions/venice/pricing-api.js";
 import type {
   RemoteModelCatalogBundle,
   RemoteModelCatalogPricing,
 } from "../packages/model-catalog-core/src/remote-catalog-bundle.js";
-import type {
-  PluginManifestModelPricingProvider,
-  PluginManifestModelPricingSource,
-} from "../src/plugins/manifest-types.js";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 
 type ModelCatalogManifestInput = {
   pluginId: string;
   manifestPath: string;
   manifest: {
-    modelCatalog?: {
-      providers?: Record<string, unknown>;
-    };
-    modelPricing?: {
-      providers?: Record<string, unknown>;
-    };
+    providers?: string[];
+    modelCatalog?: { providers?: Record<string, unknown> };
+    modelPricing?: { providers?: Record<string, unknown> };
   };
 };
 
 type PublishedModelPricing = RemoteModelCatalogPricing;
 type PublishedModelCatalogBundle = RemoteModelCatalogBundle;
-
-type PricingSource = Exclude<keyof PluginManifestModelPricingProvider, "external">;
-type PricingPolicies = Map<string, PluginManifestModelPricingProvider>;
+type PricingPolicies = Map<string, ModelPricingProvider>;
 type PricingCatalog = Map<string, PublishedModelPricing>;
-type RuntimePricingEntries = Map<
-  string,
-  Partial<Record<PricingSource, PublishedModelPricing | undefined>>
->;
+type PricingSource = {
+  id: ModelPricingSourceId;
+  label: string;
+  url: string;
+  authoritative?: boolean;
+};
+type LoadedPricingSource = PricingSource & {
+  catalog: PricingCatalog;
+  aliases: string[][];
+};
 type BundleValidator = (bundle: unknown) => PublishedModelCatalogBundle;
 const MODEL_CATALOG_MIN_VERSION = "2026.7.0";
 export const MODEL_CATALOG_MIN_MODELS = 200;
 export const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
 export const LITELLM_PRICING_URL =
   "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+const PRICING_SOURCES: readonly PricingSource[] = [
+  {
+    id: "openCode",
+    label: "OpenCode",
+    url: "https://models.opencode.ai/api.json",
+    authoritative: true,
+  },
+  {
+    id: "venice",
+    label: "Venice",
+    url: "https://api.venice.ai/api/v1/models",
+    authoritative: true,
+  },
+  { id: "openRouter", label: "OpenRouter", url: OPENROUTER_MODELS_URL },
+  { id: "liteLLM", label: "LiteLLM", url: LITELLM_PRICING_URL },
+];
 
 const SCRIPT_LABEL = "publish-model-catalog";
 const PRICING_FETCH_TIMEOUT_MS = 60_000;
@@ -129,11 +153,7 @@ export async function assembleModelCatalogBundle(options: {
   const providers: Record<string, unknown> = {};
   for (const entry of options.manifests) {
     const declaredProviders = entry.manifest?.modelCatalog?.providers;
-    if (
-      !declaredProviders ||
-      typeof declaredProviders !== "object" ||
-      Array.isArray(declaredProviders)
-    ) {
+    if (!isRecord(declaredProviders)) {
       continue;
     }
     for (const [providerId, provider] of Object.entries(declaredProviders)) {
@@ -147,7 +167,6 @@ export async function assembleModelCatalogBundle(options: {
   if (!Object.hasOwn(providers, "anthropic") || !Object.hasOwn(providers, "openai")) {
     throw new Error("catalog must include anthropic and openai providers");
   }
-
   const bundle = {
     schemaVersion: 1,
     generatedAt: options.generatedAt,
@@ -179,36 +198,8 @@ export function summarizeModelCatalogBundle(bundle: PublishedModelCatalogBundle)
   };
 }
 
-function parseNumberString(value: unknown): number | null {
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return value;
-  }
-  if (typeof value !== "string" || !value.trim()) {
-    return null;
-  }
-  const parsed = Number(value.trim());
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
-function toPricePerMillion(value: number | null): number {
-  return value === null || value < 0 || !Number.isFinite(value) ? 0 : value * 1_000_000;
-}
-
-function parseOpenRouterPricing(value: unknown): PublishedModelPricing | null {
-  if (!isRecord(value)) {
-    return null;
-  }
-  const prompt = parseNumberString(value.prompt);
-  const completion = parseNumberString(value.completion);
-  if (prompt === null || completion === null || prompt < 0 || completion < 0) {
-    return null;
-  }
-  return {
-    input: toPricePerMillion(prompt),
-    output: toPricePerMillion(completion),
-    cacheRead: toPricePerMillion(parseNumberString(value.input_cache_read)),
-    cacheWrite: toPricePerMillion(parseNumberString(value.input_cache_write)),
-  };
+function toPricePerMillion(value: number | undefined): number {
+  return value === undefined || value < 0 ? 0 : value * 1_000_000;
 }
 
 function parseLiteLLMTieredPricing(
@@ -219,26 +210,29 @@ function parseLiteLLMTieredPricing(
   }
   const tiers: NonNullable<PublishedModelPricing["tieredPricing"]> = [];
   for (const raw of value) {
-    if (!isRecord(raw)) {
+    if (!isRecord(raw) || !Array.isArray(raw.range)) {
       continue;
     }
-    if (!Array.isArray(raw.range)) {
+    const input = parseStrictFiniteNumber(raw.input_cost_per_token);
+    const output = parseStrictFiniteNumber(raw.output_cost_per_token);
+    const start = parseStrictFiniteNumber(raw.range[0]);
+    if (
+      input === undefined ||
+      output === undefined ||
+      start === undefined ||
+      input < 0 ||
+      output < 0
+    ) {
       continue;
     }
-    const input = parseNumberString(raw.input_cost_per_token);
-    const output = parseNumberString(raw.output_cost_per_token);
-    const start = parseNumberString(raw.range[0]);
-    if (input === null || output === null || start === null || input < 0 || output < 0) {
-      continue;
-    }
-    const rawEnd = raw.range.length >= 2 ? parseNumberString(raw.range[1]) : null;
+    const rawEnd = raw.range.length >= 2 ? parseStrictFiniteNumber(raw.range[1]) : undefined;
     const range: [number] | [number, number] =
-      rawEnd === null || rawEnd <= start ? [start] : [start, rawEnd];
+      rawEnd === undefined || rawEnd <= start ? [start] : [start, rawEnd];
     tiers.push({
       input: toPricePerMillion(input),
       output: toPricePerMillion(output),
-      cacheRead: toPricePerMillion(parseNumberString(raw.cache_read_input_token_cost)),
-      cacheWrite: toPricePerMillion(parseNumberString(raw.cache_creation_input_token_cost)),
+      cacheRead: toPricePerMillion(parseStrictFiniteNumber(raw.cache_read_input_token_cost)),
+      cacheWrite: toPricePerMillion(parseStrictFiniteNumber(raw.cache_creation_input_token_cost)),
       range,
     });
   }
@@ -247,21 +241,21 @@ function parseLiteLLMTieredPricing(
     : undefined;
 }
 
-function parseLiteLLMPricing(value: unknown): PublishedModelPricing | null {
+function parseLiteLLMPricing(value: unknown): PublishedModelPricing | undefined {
   if (!isRecord(value)) {
-    return null;
+    return undefined;
   }
-  const input = parseNumberString(value.input_cost_per_token);
-  const output = parseNumberString(value.output_cost_per_token);
-  if (input === null || output === null || input < 0 || output < 0) {
-    return null;
+  const input = parseStrictFiniteNumber(value.input_cost_per_token);
+  const output = parseStrictFiniteNumber(value.output_cost_per_token);
+  if (input === undefined || output === undefined || input < 0 || output < 0) {
+    return undefined;
   }
   const tieredPricing = parseLiteLLMTieredPricing(value.tiered_pricing);
   return {
     input: toPricePerMillion(input),
     output: toPricePerMillion(output),
-    cacheRead: toPricePerMillion(parseNumberString(value.cache_read_input_token_cost)),
-    cacheWrite: toPricePerMillion(parseNumberString(value.cache_creation_input_token_cost)),
+    cacheRead: toPricePerMillion(parseStrictFiniteNumber(value.cache_read_input_token_cost)),
+    cacheWrite: toPricePerMillion(parseStrictFiniteNumber(value.cache_creation_input_token_cost)),
     ...(tieredPricing ? { tieredPricing } : {}),
   };
 }
@@ -276,268 +270,86 @@ function compactPricing(pricing: PublishedModelPricing): PublishedModelPricing {
   };
 }
 
-function mergePricing(
-  primary: PublishedModelPricing | undefined,
-  secondary: PublishedModelPricing | undefined,
-): PublishedModelPricing | undefined {
-  if (!primary || !hasKnownPricing(primary)) {
-    return secondary;
-  }
-  if (!secondary || !hasKnownPricing(secondary)) {
-    return primary;
-  }
-  if (!secondary?.tieredPricing) {
-    return primary;
-  }
-  return { ...primary, tieredPricing: secondary.tieredPricing };
-}
-
 function hasKnownPricing(pricing: Partial<PublishedModelPricing>): boolean {
   return (
     (pricing.input ?? 0) > 0 ||
     (pricing.output ?? 0) > 0 ||
     (pricing.cacheRead ?? 0) > 0 ||
     (pricing.cacheWrite ?? 0) > 0 ||
-    Boolean(
-      pricing.tieredPricing?.some(
-        (tier) => tier.input > 0 || tier.output > 0 || tier.cacheRead > 0 || tier.cacheWrite > 0,
-      ),
-    )
+    Boolean(pricing.tieredPricing?.some(hasKnownPricing))
   );
 }
 
-function applyModelIdTransforms(modelId: string, transforms?: string[]): string[] {
-  const variants = new Set([modelId]);
-  for (const transform of transforms ?? []) {
-    if (transform !== "version-dots") {
-      continue;
-    }
-    for (const variant of Array.from(variants)) {
-      variants.add(
-        variant
-          .replace(/^claude-(\d+)-(\d+)-/u, "claude-$1.$2-")
-          .replace(/^claude-([a-z]+)-(\d+)-(\d+)$/u, "claude-$1-$2.$3"),
-      );
-    }
+function modelIdVariants(modelId: string, transforms?: string[], reverse = false): string[] {
+  if (!transforms?.includes("version-dots")) {
+    return [modelId];
   }
-  return [...variants];
+  const variant = reverse
+    ? modelId
+        .replace(/^claude-(\d+)\.(\d+)-/u, "claude-$1-$2-")
+        .replace(/^claude-([a-z]+)-(\d+)\.(\d+)$/u, "claude-$1-$2-$3")
+    : modelId
+        .replace(/^claude-(\d+)-(\d+)-/u, "claude-$1.$2-")
+        .replace(/^claude-([a-z]+)-(\d+)-(\d+)$/u, "claude-$1-$2.$3");
+  return [...new Set([modelId, variant])];
 }
 
-function buildPricingCandidates({
-  providerId,
-  modelId,
-  source,
-  policies,
-  seen = new Set<string>(),
-}: {
-  providerId: string;
-  modelId: string;
-  source: PricingSource;
-  policies: PricingPolicies;
-  seen?: Set<string>;
-}): string[] {
-  const ref = `${providerId}/${modelId}`;
-  if (seen.has(ref)) {
-    return [];
-  }
-  const nextSeen = new Set(seen).add(ref);
-  const policy = policies.get(providerId);
-  if (policy?.external === false) {
-    return [];
-  }
-  const configuredSource = policy?.[source];
-  const sourcePolicy = configuredSource === false ? undefined : configuredSource;
-  if (policy && !sourcePolicy) {
-    return [];
-  }
-  const externalProvider = sourcePolicy?.provider ?? providerId;
-  const candidates = new Set(
-    applyModelIdTransforms(modelId, sourcePolicy?.modelIdTransforms).map(
-      (candidate) => `${externalProvider}/${candidate}`,
-    ),
-  );
-  if (sourcePolicy?.passthroughProviderModel && modelId.includes("/")) {
-    const slash = modelId.indexOf("/");
-    for (const candidate of buildPricingCandidates({
-      providerId: modelId.slice(0, slash),
-      modelId: modelId.slice(slash + 1),
-      source,
-      policies,
-      seen: nextSeen,
-    })) {
-      candidates.add(candidate);
-    }
-  }
-  return [...candidates];
-}
-
-function reverseModelIdTransforms(modelId: string, transforms?: string[]): string[] {
-  const variants = new Set([modelId]);
-  for (const transform of transforms ?? []) {
-    if (transform !== "version-dots") {
-      continue;
-    }
-    for (const variant of Array.from(variants)) {
-      variants.add(
-        variant
-          .replace(/^claude-(\d+)\.(\d+)-/u, "claude-$1-$2-")
-          .replace(/^claude-([a-z]+)-(\d+)\.(\d+)$/u, "claude-$1-$2-$3"),
-      );
-    }
-  }
-  return [...variants];
-}
-
-function setRuntimePricingSource(
-  entries: RuntimePricingEntries,
-  key: string,
+function sourcePolicy(
+  policies: PricingPolicies,
+  providerId: string,
   source: PricingSource,
-  pricing: PublishedModelPricing | undefined,
-): void {
-  const entry = entries.get(key) ?? {};
-  entry[source] = pricing;
-  entries.set(key, entry);
-}
-
-function collectPolicyRuntimePricingAliases({
-  providerId,
-  policy,
-  source,
-  catalog,
-  entries,
-}: {
-  providerId: string;
-  policy: PluginManifestModelPricingProvider | undefined;
-  source: PricingSource;
-  catalog: PricingCatalog;
-  entries: RuntimePricingEntries;
-}): void {
-  const configuredSource = policy?.[source];
-  const sourcePolicy = configuredSource === false ? undefined : configuredSource;
-  const sourceProvider = sourcePolicy?.provider ?? providerId;
-  for (const [sourceKey, pricing] of catalog) {
-    const slash = sourceKey.indexOf("/");
-    if (slash <= 0 || slash === sourceKey.length - 1) {
-      continue;
-    }
-    const keyProvider = sourceKey.slice(0, slash);
-    const sourceModel = sourceKey.slice(slash + 1);
-    if (keyProvider === sourceProvider) {
-      for (const runtimeModel of reverseModelIdTransforms(
-        sourceModel,
-        sourcePolicy?.modelIdTransforms,
-      )) {
-        setRuntimePricingSource(
-          entries,
-          `${providerId}/${runtimeModel}`,
-          source,
-          sourcePolicy ? pricing : undefined,
-        );
-      }
-    }
-    if (sourcePolicy?.passthroughProviderModel) {
-      setRuntimePricingSource(entries, `${providerId}/${sourceKey}`, source, pricing);
-    }
-  }
-}
-
-function materializePolicyRuntimePricing({
-  hostedPricing,
-  policies,
-  openRouterCatalog,
-  liteLlmCatalog,
-  pricedProviderModelKeys,
-}: {
-  hostedPricing: PricingCatalog;
-  policies: PricingPolicies;
-  openRouterCatalog: PricingCatalog;
-  liteLlmCatalog: PricingCatalog;
-  pricedProviderModelKeys: Set<string>;
-}): void {
-  for (const [providerId, policy] of policies) {
-    for (const key of hostedPricing.keys()) {
-      if (key.startsWith(`${providerId}/`)) {
-        hostedPricing.delete(key);
-      }
-    }
-    if (policy?.external === false) {
-      continue;
-    }
-    const entries: RuntimePricingEntries = new Map();
-    collectPolicyRuntimePricingAliases({
-      providerId,
-      policy,
-      source: "openRouter",
-      catalog: openRouterCatalog,
-      entries,
-    });
-    collectPolicyRuntimePricingAliases({
-      providerId,
-      policy,
-      source: "liteLLM",
-      catalog: liteLlmCatalog,
-      entries,
-    });
-    for (const [key, entry] of entries) {
-      if (pricedProviderModelKeys.has(key)) {
-        hostedPricing.delete(key);
-        continue;
-      }
-      const pricing = mergePricing(entry.openRouter, entry.liteLLM);
-      if (pricing) {
-        hostedPricing.set(key, pricing);
-      } else {
-        hostedPricing.delete(key);
-      }
-    }
-  }
-}
-
-function normalizePricingSource(
-  value: unknown,
-): PluginManifestModelPricingSource | false | undefined {
-  if (value === false) {
-    return false;
-  }
-  if (!isRecord(value)) {
+): ModelPricingSource | undefined {
+  const policy = policies.get(providerId);
+  const selected = policy?.[source.id];
+  if (
+    policy?.external === false ||
+    selected === false ||
+    (!selected && (policy || source.authoritative))
+  ) {
     return undefined;
   }
-  const modelIdTransforms = Array.isArray(value.modelIdTransforms)
-    ? value.modelIdTransforms.filter(
-        (transform): transform is "version-dots" => transform === "version-dots",
-      )
-    : undefined;
-  return {
-    ...(typeof value.provider === "string" ? { provider: value.provider } : {}),
-    ...(typeof value.passthroughProviderModel === "boolean"
-      ? { passthroughProviderModel: value.passthroughProviderModel }
-      : {}),
-    ...(modelIdTransforms && modelIdTransforms.length > 0 ? { modelIdTransforms } : {}),
-  };
+  return selected ?? {};
 }
 
-function normalizePricingPolicy(value: unknown): PluginManifestModelPricingProvider | undefined {
-  if (!isRecord(value)) {
-    return undefined;
+function buildPricingCandidates(
+  providerId: string,
+  modelId: string,
+  source: PricingSource,
+  policies: PricingPolicies,
+  seen = new Set<string>(),
+): string[] {
+  const ref = `${providerId}/${modelId}`;
+  const policy = sourcePolicy(policies, providerId, source);
+  if (seen.has(ref) || !policy) {
+    return [];
   }
-  const openRouter = normalizePricingSource(value.openRouter);
-  const liteLLM = normalizePricingSource(value.liteLLM);
-  return {
-    ...(typeof value.external === "boolean" ? { external: value.external } : {}),
-    ...(openRouter !== undefined ? { openRouter } : {}),
-    ...(liteLLM !== undefined ? { liteLLM } : {}),
-  };
+  const candidates = modelIdVariants(modelId, policy.modelIdTransforms).map(
+    (id) => `${policy.provider ?? providerId}/${id}`,
+  );
+  const slash = modelId.indexOf("/");
+  if (policy.passthroughProviderModel && slash > 0) {
+    candidates.push(
+      ...buildPricingCandidates(
+        modelId.slice(0, slash),
+        modelId.slice(slash + 1),
+        source,
+        policies,
+        new Set(seen).add(ref),
+      ),
+    );
+  }
+  return [...new Set(candidates)];
 }
 
 function readPricingPolicies(manifests: ModelCatalogManifestInput[]): PricingPolicies {
   const policies: PricingPolicies = new Map();
-  for (const entry of manifests) {
-    for (const [providerId, rawPolicy] of Object.entries(
-      entry.manifest?.modelPricing?.providers ?? {},
-    )) {
-      const policy = normalizePricingPolicy(rawPolicy);
+  for (const { manifest } of manifests) {
+    const owners = new Set((manifest.providers ?? []).map(normalizeModelCatalogProviderId));
+    for (const [rawId, value] of Object.entries(manifest.modelPricing?.providers ?? {})) {
+      const id = normalizeModelCatalogProviderId(rawId);
+      const policy = owners.has(id) ? normalizeModelPricingProvider(value) : undefined;
       if (policy) {
-        policies.set(providerId, policy);
+        policies.set(id, policy);
       }
     }
   }
@@ -588,33 +400,154 @@ async function readJsonResponse(response: Response, source: string) {
   return payload;
 }
 
-async function fetchPricingSources(fetchImpl: typeof fetch) {
-  const signal = AbortSignal.timeout(PRICING_FETCH_TIMEOUT_MS);
-  const results = await Promise.allSettled([
-    fetchImpl(OPENROUTER_MODELS_URL, {
-      headers: { Accept: "application/json" },
-      signal,
-    }).then((response) => readJsonResponse(response, "OpenRouter")),
-    fetchImpl(LITELLM_PRICING_URL, {
-      headers: { Accept: "application/json" },
-      signal,
-    }).then((response) => readJsonResponse(response, "LiteLLM")),
-  ]);
-  const [openRouterResult, liteLlmResult] = results;
-  for (const { label, result } of [
-    { label: "OpenRouter", result: openRouterResult },
-    { label: "LiteLLM", result: liteLlmResult },
-  ]) {
-    if (result.status === "rejected") {
-      process.stderr.write(
-        `[${SCRIPT_LABEL}] warning: ${label} pricing unavailable: ${String(result.reason)}\n`,
-      );
+function parsePricingCatalog(
+  source: PricingSource,
+  body: Record<string, unknown>,
+  policies: PricingPolicies,
+): LoadedPricingSource {
+  const catalog: PricingCatalog = new Map();
+  const aliases: string[][] = [];
+  if (source.id === "openCode") {
+    for (const [providerId] of policies) {
+      const policy = sourcePolicy(policies, providerId, source);
+      if (!policy) {
+        continue;
+      }
+      const upstreamId = policy.provider ?? providerId;
+      const provider = body[upstreamId];
+      if (!isRecord(provider) || provider.id !== upstreamId || !isRecord(provider.models)) {
+        throw new Error(`${source.label} pricing missing provider ${upstreamId}`);
+      }
+      for (const [id, model] of Object.entries(provider.models)) {
+        const pricing =
+          isRecord(model) && model.id === id
+            ? normalizeUpstreamModelPricing(model.cost)
+            : undefined;
+        if (pricing) {
+          catalog.set(`${upstreamId}/${id}`, pricing);
+        }
+      }
+    }
+  } else if (source.id === "venice") {
+    const prices = parseVenicePricingCatalog(body);
+    if (!prices) {
+      throw new Error(`${source.label} pricing response is malformed`);
+    }
+    for (const [id, pricing] of prices) {
+      catalog.set(`venice/${id}`, pricing);
+    }
+  } else if (source.id === "openRouter") {
+    for (const row of Array.isArray(body.data) ? body.data : []) {
+      if (!isRecord(row)) {
+        continue;
+      }
+      const pricing = normalizeOpenRouterModelPricing(row.pricing);
+      if (typeof row.id === "string" && pricing) {
+        catalog.set(row.id, pricing);
+      }
+    }
+  } else {
+    for (const [id, row] of Object.entries(body)) {
+      const pricing = parseLiteLLMPricing(row);
+      if (!pricing || !isRecord(row)) {
+        continue;
+      }
+      const keys = [id];
+      if (typeof row.litellm_provider === "string" && !id.includes("/")) {
+        keys.push(`${row.litellm_provider}/${id}`);
+      }
+      for (const key of keys) {
+        catalog.set(key, pricing);
+      }
+      aliases.push(keys);
     }
   }
-  return {
-    openRouter: openRouterResult.status === "fulfilled" ? openRouterResult.value : {},
-    liteLlm: liteLlmResult.status === "fulfilled" ? liteLlmResult.value : {},
-  };
+  return { ...source, catalog, aliases };
+}
+
+async function fetchPricingSources(fetchImpl: typeof fetch, policies: PricingPolicies) {
+  const sources = PRICING_SOURCES.filter(
+    (source) =>
+      !source.authoritative ||
+      [...policies.keys()].some((id) => sourcePolicy(policies, id, source)),
+  );
+  const signal = AbortSignal.timeout(PRICING_FETCH_TIMEOUT_MS);
+  const loaded = await Promise.all(
+    sources.map(async (source) => {
+      try {
+        const response = await fetchImpl(source.url, {
+          headers: { Accept: "application/json" },
+          signal,
+        });
+        const body = await readJsonResponse(response, source.label);
+        return parsePricingCatalog(source, body, policies);
+      } catch (cause) {
+        return {
+          source,
+          error: new Error(`${source.label} pricing unavailable: ${String(cause)}`, { cause }),
+        };
+      }
+    }),
+  );
+  // Join all fetches before the final failure marker, and never re-stamp stale owner prices.
+  const failure = loaded.find((entry) => "error" in entry && entry.source.authoritative);
+  if (failure && "error" in failure) {
+    throw failure.error;
+  }
+  const result: LoadedPricingSource[] = [];
+  for (const entry of loaded) {
+    if ("error" in entry) {
+      process.stderr.write(`[${SCRIPT_LABEL}] warning: ${entry.error.message}\n`);
+      result.push({ ...entry.source, catalog: new Map(), aliases: [] });
+    } else {
+      result.push(entry);
+    }
+  }
+  return result;
+}
+
+function materializePolicyRuntimePricing(
+  hosted: PricingCatalog,
+  policies: PricingPolicies,
+  sources: LoadedPricingSource[],
+  pricedModels: Set<string>,
+): void {
+  for (const [providerId] of policies) {
+    for (const key of hosted.keys()) {
+      if (key.startsWith(`${providerId}/`)) {
+        hosted.delete(key);
+      }
+    }
+    for (const source of sources) {
+      const policy = sourcePolicy(policies, providerId, source);
+      if (!policy) {
+        continue;
+      }
+      for (const [key, pricing] of source.catalog) {
+        if (!source.authoritative && !hasKnownPricing(pricing)) {
+          continue;
+        }
+        const slash = key.indexOf("/");
+        if (slash <= 0 || slash === key.length - 1) {
+          continue;
+        }
+        const runtimeKeys =
+          key.slice(0, slash) === (policy.provider ?? providerId)
+            ? modelIdVariants(key.slice(slash + 1), policy.modelIdTransforms, true).map(
+                (id) => `${providerId}/${id}`,
+              )
+            : [];
+        if (policy.passthroughProviderModel) {
+          runtimeKeys.push(`${providerId}/${key}`);
+        }
+        for (const runtimeKey of runtimeKeys) {
+          if (!pricedModels.has(runtimeKey) && !hosted.has(runtimeKey)) {
+            hosted.set(runtimeKey, pricing);
+          }
+        }
+      }
+    }
+  }
 }
 
 export async function enrichModelCatalogPricing(options: {
@@ -624,104 +557,78 @@ export async function enrichModelCatalogPricing(options: {
   validateBundle?: BundleValidator;
 }): Promise<{ modelsEnriched: number; pricingEntries: number }> {
   const policies = readPricingPolicies(options.manifests);
-  const sources = await fetchPricingSources(options.fetchImpl ?? fetch);
-  const openRouterCatalog: PricingCatalog = new Map();
-  for (const row of Array.isArray(sources.openRouter.data) ? sources.openRouter.data : []) {
-    if (!isRecord(row)) {
-      continue;
-    }
-    const pricing = parseOpenRouterPricing(row.pricing);
-    if (typeof row.id === "string" && pricing) {
-      openRouterCatalog.set(row.id, pricing);
-    }
-  }
-  const liteLlmCatalog: PricingCatalog = new Map();
-  const liteLlmAliasGroups: string[][] = [];
-  for (const [id, row] of Object.entries(sources.liteLlm)) {
-    if (!isRecord(row)) {
-      continue;
-    }
-    const pricing = parseLiteLLMPricing(row);
-    if (pricing) {
-      const aliases = [id];
-      if (typeof row?.litellm_provider === "string" && !id.includes("/")) {
-        aliases.push(`${row.litellm_provider}/${id}`);
-      }
-      for (const alias of aliases) {
-        liteLlmCatalog.set(alias, pricing);
-      }
-      liteLlmAliasGroups.push(aliases);
-    }
-  }
-
+  const sources = await fetchPricingSources(options.fetchImpl ?? fetch, policies);
   let enriched = 0;
-  const coveredPricingKeys = new Set<string>();
-  const pricedProviderModelKeys = new Set<string>();
+  const coveredKeys = new Set<string>();
+  const pricedModels = new Set<string>();
   for (const [providerId, provider] of Object.entries(options.bundle.providers)) {
     for (const model of provider.models) {
-      const openRouterCandidates = buildPricingCandidates({
-        providerId,
-        modelId: model.id,
-        source: "openRouter",
-        policies,
+      const matches = sources.map((source) => {
+        const candidates = buildPricingCandidates(providerId, model.id, source, policies);
+        return {
+          source,
+          candidates,
+          pricing: candidates.map((key) => source.catalog.get(key)).find(Boolean),
+        };
       });
-      const openRouterPricing = openRouterCandidates
-        .map((candidate) => openRouterCatalog.get(candidate))
-        .find(Boolean);
-      const liteLlmCandidates = buildPricingCandidates({
-        providerId,
-        modelId: model.id,
-        source: "liteLLM",
-        policies,
-      });
-      const liteLlmPricing = liteLlmCandidates
-        .map((candidate) => liteLlmCatalog.get(candidate))
-        .find(Boolean);
-      const cost = mergePricing(openRouterPricing, liteLlmPricing);
-      if (cost && hasKnownPricing(cost)) {
-        model.cost = cost;
+      for (const { source, candidates, pricing } of matches) {
+        if (
+          source.authoritative &&
+          candidates.length > 0 &&
+          model.cost &&
+          hasKnownPricing(model.cost) &&
+          !pricing
+        ) {
+          throw new Error(
+            `${source.label} pricing missing or invalid for ${providerId}/${model.id}`,
+          );
+        }
+      }
+      const chosen = matches.find(
+        ({ source, pricing }) => pricing && (source.authoritative || hasKnownPricing(pricing)),
+      );
+      if (chosen?.pricing) {
+        model.cost = chosen.pricing;
         enriched += 1;
       }
       if (model.cost && hasKnownPricing(model.cost)) {
-        const providerModelKey = `${providerId}/${model.id}`;
-        coveredPricingKeys.add(providerModelKey);
-        pricedProviderModelKeys.add(providerModelKey);
-        for (const candidate of [...openRouterCandidates, ...liteLlmCandidates]) {
-          coveredPricingKeys.add(candidate);
+        const key = `${providerId}/${model.id}`;
+        coveredKeys.add(key);
+        pricedModels.add(key);
+        for (const { candidates } of matches) {
+          for (const candidate of candidates) {
+            coveredKeys.add(candidate);
+          }
         }
       }
     }
   }
 
-  const hostedPricing: PricingCatalog = new Map();
-  for (const [key, pricing] of openRouterCatalog) {
-    hostedPricing.set(key, pricing);
-  }
-  for (const [key, pricing] of liteLlmCatalog) {
-    const merged = mergePricing(hostedPricing.get(key), pricing);
-    if (merged) {
-      hostedPricing.set(key, merged);
+  const hosted: PricingCatalog = new Map();
+  for (const source of sources) {
+    // Opted-in feeds only enter the owner's mapped namespace, never the global fallback map.
+    if (!source.authoritative) {
+      for (const [key, pricing] of source.catalog) {
+        const existing = hosted.get(key);
+        if (!existing || !hasKnownPricing(existing)) {
+          hosted.set(key, pricing);
+        }
+      }
     }
-  }
-  for (const aliases of liteLlmAliasGroups) {
-    if (aliases.some((alias) => coveredPricingKeys.has(alias))) {
-      for (const alias of aliases) {
-        coveredPricingKeys.add(alias);
+    for (const aliases of source.aliases) {
+      if (aliases.some((key) => coveredKeys.has(key))) {
+        for (const key of aliases) {
+          coveredKeys.add(key);
+        }
       }
     }
   }
-  for (const key of coveredPricingKeys) {
-    hostedPricing.delete(key);
+  for (const key of coveredKeys) {
+    hosted.delete(key);
   }
-  materializePolicyRuntimePricing({
-    hostedPricing,
-    policies,
-    openRouterCatalog,
-    liteLlmCatalog,
-    pricedProviderModelKeys,
-  });
+  materializePolicyRuntimePricing(hosted, policies, sources, pricedModels);
   options.bundle.pricing = Object.fromEntries(
-    [...hostedPricing.entries()]
+    [...hosted.entries()]
       .toSorted(([left], [right]) => left.localeCompare(right))
       .map(([key, pricing]) => [key, compactPricing(pricing)]),
   );
@@ -729,7 +636,7 @@ export async function enrichModelCatalogPricing(options: {
   const validated = validateBundle(options.bundle);
   options.bundle.providers = validated.providers;
   options.bundle.pricing = validated.pricing;
-  return { modelsEnriched: enriched, pricingEntries: hostedPricing.size };
+  return { modelsEnriched: enriched, pricingEntries: hosted.size };
 }
 
 function sortCatalogValue(value: unknown): unknown {
@@ -783,11 +690,7 @@ async function runPublishModelCatalog(
   const generatedAt = (options.now ?? Date.now)();
   const sourceCommit = options.sourceCommit ?? resolveSourceCommit(rootDir);
   const manifests = readModelCatalogManifests({ rootDir });
-  const bundle = await assembleModelCatalogBundle({
-    manifests,
-    generatedAt,
-    sourceCommit,
-  });
+  const bundle = await assembleModelCatalogBundle({ manifests, generatedAt, sourceCommit });
   const pricingResult = args.pricing
     ? await enrichModelCatalogPricing({ bundle, manifests, fetchImpl: options.fetchImpl })
     : { modelsEnriched: 0, pricingEntries: 0 };
@@ -809,7 +712,6 @@ async function runPublishModelCatalog(
     process.stdout.write(`[${SCRIPT_LABEL}] dry-run ${stats}\n`);
     return { bundle, summary, pricingEnriched: pricingResult.modelsEnriched, wrote: false };
   }
-
   if (!args.out) {
     throw new Error("output path is required outside dry-run mode");
   }

--- a/scripts/publish-model-catalog.mts
+++ b/scripts/publish-model-catalog.mts
@@ -3,12 +3,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
+  MODEL_PRICING_SOURCES,
   normalizeModelPricingProvider,
   normalizeOpenRouterModelPricing,
   normalizeUpstreamModelPricing,
   type ModelPricingProvider,
   type ModelPricingSource,
-  type ModelPricingSourceId,
 } from "@openclaw/model-catalog-core/model-catalog-pricing";
 import { normalizeModelCatalogProviderId } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { parseStrictFiniteNumber } from "@openclaw/normalization-core/number-coercion";
@@ -19,6 +19,10 @@ import type {
   RemoteModelCatalogPricing,
 } from "../packages/model-catalog-core/src/remote-catalog-bundle.js";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
+export {
+  LITELLM_PRICING_URL,
+  OPENROUTER_MODELS_URL,
+} from "@openclaw/model-catalog-core/model-catalog-pricing";
 
 type ModelCatalogManifestInput = {
   pluginId: string;
@@ -34,12 +38,7 @@ type PublishedModelPricing = RemoteModelCatalogPricing;
 type PublishedModelCatalogBundle = RemoteModelCatalogBundle;
 type PricingPolicies = Map<string, ModelPricingProvider>;
 type PricingCatalog = Map<string, PublishedModelPricing>;
-type PricingSource = {
-  id: ModelPricingSourceId;
-  label: string;
-  url: string;
-  authoritative?: boolean;
-};
+type PricingSource = (typeof MODEL_PRICING_SOURCES)[number];
 type LoadedPricingSource = PricingSource & {
   catalog: PricingCatalog;
   aliases: string[][];
@@ -47,25 +46,6 @@ type LoadedPricingSource = PricingSource & {
 type BundleValidator = (bundle: unknown) => PublishedModelCatalogBundle;
 const MODEL_CATALOG_MIN_VERSION = "2026.7.0";
 export const MODEL_CATALOG_MIN_MODELS = 200;
-export const OPENROUTER_MODELS_URL = "https://openrouter.ai/api/v1/models";
-export const LITELLM_PRICING_URL =
-  "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
-const PRICING_SOURCES: readonly PricingSource[] = [
-  {
-    id: "openCode",
-    label: "OpenCode",
-    url: "https://models.opencode.ai/api.json",
-    authoritative: true,
-  },
-  {
-    id: "venice",
-    label: "Venice",
-    url: "https://api.venice.ai/api/v1/models",
-    authoritative: true,
-  },
-  { id: "openRouter", label: "OpenRouter", url: OPENROUTER_MODELS_URL },
-  { id: "liteLLM", label: "LiteLLM", url: LITELLM_PRICING_URL },
-];
 
 const SCRIPT_LABEL = "publish-model-catalog";
 const PRICING_FETCH_TIMEOUT_MS = 60_000;
@@ -466,7 +446,7 @@ function parsePricingCatalog(
 }
 
 async function fetchPricingSources(fetchImpl: typeof fetch, policies: PricingPolicies) {
-  const sources = PRICING_SOURCES.filter(
+  const sources = MODEL_PRICING_SOURCES.filter(
     (source) =>
       !source.authoritative ||
       [...policies.keys()].some((id) => sourcePolicy(policies, id, source)),

--- a/src/agents/embedded-agent-runner/model.configured-fallback.ts
+++ b/src/agents/embedded-agent-runner/model.configured-fallback.ts
@@ -16,6 +16,7 @@ import {
   findConfiguredProviderModel,
   hasConfiguredFallbackSurface,
   mergeConfiguredRuntimeModelParams,
+  mergeConfiguredModelCost,
   resolveConfiguredProviderConfig,
   resolveConfiguredProviderDefaultApi,
   shouldSuppressConfiguredModel,
@@ -184,7 +185,12 @@ export function buildConfiguredFallbackModel(params: {
             ...(configuredModel?.thinkingLevelMap !== undefined
               ? { thinkingLevelMap: configuredModel.thinkingLevelMap }
               : {}),
-            cost: metadataModel?.cost ?? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            cost: mergeConfiguredModelCost({
+              provider,
+              cfg,
+              configuredModel,
+              catalogCost: staticCatalogModel?.cost,
+            }),
             contextWindow: resolvedFallbackContextWindow,
             contextTokens: configuredModel?.contextTokens ?? staticCatalogModel?.contextTokens,
             // maxTokens is a wire-level output cap, not a context-budget fallback.

--- a/src/agents/embedded-agent-runner/model.configured-overrides.ts
+++ b/src/agents/embedded-agent-runner/model.configured-overrides.ts
@@ -1,5 +1,9 @@
+import { normalizeResolvedPricing } from "@openclaw/llm-core";
+import { normalizeConfiguredProviderCatalogModelId } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { asOptionalRecord as readModelParams } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { mergeModelCost } from "../../config/model-cost.js";
+import { projectConfigOntoRuntimeSourceSnapshot } from "../../config/runtime-source-projection.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { Api, Model } from "../../llm/types.js";
 import type { PluginMetadataSnapshotOwnerMaps } from "../../plugins/plugin-metadata-snapshot.types.js";
@@ -175,6 +179,43 @@ export function findConfiguredProviderModel(
   return providerConfig?.models?.find((candidate) =>
     matchesProviderScopedModelId({ candidateId: candidate.id, provider, modelId }),
   );
+}
+
+/** Merge authored rates after discovery; runtime defaults must not become price pins. */
+export function mergeConfiguredModelCost(params: {
+  provider: string;
+  cfg?: OpenClawConfig;
+  configuredModel?: NonNullable<InlineProviderConfig["models"]>[number];
+  catalogCost?: Model["cost"];
+}): Model["cost"] {
+  let authoredCost = params.configuredModel?.cost;
+  if (params.cfg && params.configuredModel) {
+    const source = projectConfigOntoRuntimeSourceSnapshot(params.cfg);
+    if (source !== params.cfg) {
+      const modelId = normalizeConfiguredProviderCatalogModelId(
+        params.provider,
+        params.configuredModel.id,
+      ).trim();
+      const sourceModels = resolveConfiguredProviderConfig(source, params.provider)?.models?.filter(
+        (model) =>
+          matchesProviderScopedModelId({
+            candidateId: normalizeConfiguredProviderCatalogModelId(
+              params.provider,
+              model.id,
+            ).trim(),
+            provider: params.provider,
+            modelId,
+          }),
+      );
+      if (sourceModels?.length) {
+        authoredCost = sourceModels.reduce<Model["cost"] | undefined>(
+          (cost, model) => mergeModelCost(model.cost, cost),
+          undefined,
+        );
+      }
+    }
+  }
+  return normalizeResolvedPricing(mergeModelCost(params.catalogCost, authoredCost) ?? {});
 }
 
 export function mergeStaticCatalogInlineModel(
@@ -573,7 +614,12 @@ export function applyConfiguredProviderOverrides(params: {
           baseUrl: requestConfig.baseUrl ?? discoveredModel.baseUrl,
           reasoning: resolvedReasoning,
           input: normalizedInput,
-          cost: metadataOverrideModel?.cost ?? discoveredModel.cost,
+          cost: mergeConfiguredModelCost({
+            provider: params.provider,
+            cfg: params.cfg,
+            configuredModel: metadataOverrideModel,
+            catalogCost: discoveredModel.cost,
+          }),
           contextWindow: resolvedContextWindow ?? discoveredModel.contextWindow,
           contextTokens: metadataOverrideModel?.contextTokens ?? discoveredModel.contextTokens,
           ...(normalizedResolvedMaxTokens !== undefined

--- a/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
+++ b/src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts
@@ -1,8 +1,14 @@
 // Coverage for forward-compatible model fallback errors and provider overrides.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelProviderConfig, OpenClawConfig } from "../../config/config.js";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../../config/runtime-snapshot.js";
+import type { ModelDefinitionConfig } from "../../config/types.models.js";
 import { discoverModels } from "../agent-model-discovery.js";
 import type { PreparedModelRuntimeSnapshot } from "../prepared-model-runtime.js";
+import { buildConfiguredFallbackModel } from "./model.configured-fallback.js";
 import { buildInlineProviderModels } from "./model.inline-provider.js";
 import { createProviderRuntimeTestMock } from "./model.provider-runtime.test-support.js";
 
@@ -148,6 +154,7 @@ import {
 beforeEach(() => {
   resetMockDiscoverModels(discoverModels);
 });
+afterEach(clearRuntimeConfigSnapshot);
 
 function createRuntimeHooks() {
   // Dynamic provider hooks are opt-in here so tests can distinguish runtime
@@ -202,6 +209,117 @@ async function resolveAnthropicModelWithProviderOverrides(overrides: Partial<Mod
 }
 
 describe("resolveModel forward-compat errors and overrides", () => {
+  const catalogCost = {
+    input: 11,
+    output: 22,
+    cacheRead: 3,
+    cacheWrite: 4,
+    tieredPricing: [
+      {
+        input: 33,
+        output: 44,
+        cacheRead: 5,
+        cacheWrite: 6,
+        range: [0, Infinity] as [number, number],
+      },
+    ],
+  };
+  const staleCost = { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 };
+  const zeroCost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+  it.each<{
+    name: string;
+    cost?: Partial<ModelDefinitionConfig["cost"]>;
+    expected: ModelDefinitionConfig["cost"];
+    missingSource?: boolean;
+  }>([
+    { name: "omitted", expected: catalogCost },
+    { name: "empty", cost: {}, expected: catalogCost },
+    {
+      name: "partial",
+      cost: { input: 7 },
+      expected: { input: 7, output: 22, cacheRead: 3, cacheWrite: 4 },
+    },
+    { name: "zero", cost: zeroCost, expected: zeroCost },
+    { name: "full", cost: staleCost, expected: staleCost },
+    {
+      name: "empty tiers",
+      cost: { tieredPricing: [] },
+      expected: { input: 11, output: 22, cacheRead: 3, cacheWrite: 4 },
+    },
+    {
+      name: "authored tiers",
+      cost: { tieredPricing: [{ ...staleCost, range: [0] }] },
+      expected: { ...catalogCost, tieredPricing: [{ ...staleCost, range: [0, Infinity] }] },
+    },
+    { name: "missing source row", missingSource: true, expected: staleCost },
+  ])(
+    "resolves authored $name cost over the complete discovered schedule",
+    async ({ cost, expected, missingSource }) => {
+      const provider = "pricing-fixture";
+      const modelId = "priced-model";
+      const model = {
+        ...makeModel(modelId),
+        api: "openai-completions" as const,
+        input: ["text", "image"] as Array<"text" | "image">,
+        contextWindow: 8192,
+        maxTokens: 512,
+        compat: { supportsTools: false },
+        cost: { ...staleCost, ...cost },
+      };
+      const providerConfig = { baseUrl: "https://models.example/v1", models: [model] };
+      const runtime: OpenClawConfig = { models: { providers: { [provider]: providerConfig } } };
+      const source = {
+        models: {
+          providers: {
+            " Pricing-Fixture ": {
+              ...providerConfig,
+              models: missingSource
+                ? []
+                : [
+                    {
+                      id: " priced-model ",
+                      contextWindow: 8192,
+                      ...(cost === undefined ? {} : { cost }),
+                    },
+                  ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      const catalogModel = {
+        ...model,
+        provider,
+        baseUrl: providerConfig.baseUrl,
+        cost: catalogCost,
+      };
+      mockDiscoveredModel(discoverModels, { provider, modelId, templateModel: catalogModel });
+      setRuntimeConfigSnapshot(runtime, source);
+
+      const result = await resolveModelForTest(provider, modelId, "/tmp/agent", runtime);
+      const fallback = buildConfiguredFallbackModel({
+        provider,
+        modelId,
+        cfg: runtime,
+        manifestAlias: { provider },
+        getStaticCatalogModel: () => catalogModel,
+        runtimeHooks: createRuntimeHooks(),
+      });
+
+      expect(result.error).toBeUndefined();
+      expect(result.model).toMatchObject({
+        provider,
+        id: modelId,
+        input: model.input,
+        contextWindow: 8192,
+        maxTokens: 512,
+        compat: { supportsTools: false },
+        cost: expected,
+      });
+      expect(result.model?.cost).toEqual(expected);
+      expect(fallback?.cost).toEqual(expected);
+    },
+  );
+
   it("builds a forward-compat fallback for supported antigravity thinking ids", async () => {
     expectResolvedForwardCompatFallbackResult({
       result: await resolveModelForTest(

--- a/src/agents/embedded-agent-runner/model.registry-resolution.ts
+++ b/src/agents/embedded-agent-runner/model.registry-resolution.ts
@@ -93,6 +93,9 @@ export function resolveExplicitModelWithRegistry(params: {
       return { kind: "suppressed" };
     }
     const staticCatalogModel = params.getStaticCatalogModel?.();
+    // Inline config owns transport and sizing; the current registry owns the lower price schedule.
+    const catalogCost =
+      modelRegistry.find(provider, modelId)?.cost ?? staticCatalogModel?.cost ?? inlineMatch.cost;
     return {
       kind: "resolved",
       source: "configured",
@@ -103,7 +106,10 @@ export function resolveExplicitModelWithRegistry(params: {
         workspaceDir,
         model: applyConfiguredProviderOverrides({
           provider,
-          discoveredModel: mergeStaticCatalogInlineModel(staticCatalogModel, inlineMatch as Model),
+          discoveredModel: {
+            ...mergeStaticCatalogInlineModel(staticCatalogModel, inlineMatch as Model),
+            cost: catalogCost,
+          },
           providerConfig,
           modelId,
           cfg,

--- a/src/agents/embedded-agent-runner/model.static-catalog.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelDefinitionConfig } from "../../config/types.models.js";
 import { createManifestRecord } from "./model.static-catalog.test-helpers.js";
 
 const manifestMocks = vi.hoisted(() => ({
@@ -87,6 +88,7 @@ function setManifestPlugins(plugins: unknown[]) {
 function createMistralManifestPlugin(overrides?: {
   discovery?: "static" | "refreshable" | "runtime";
   origin?: string;
+  cost?: ModelDefinitionConfig["cost"];
 }) {
   return {
     id: "mistral",
@@ -106,7 +108,7 @@ function createMistralManifestPlugin(overrides?: {
               contextWindow: 262144,
               maxTokens: 8192,
               thinkingLevelMap: { off: null, minimal: "low", max: "max" },
-              cost: { input: 1.5, output: 7.5, cacheRead: 0, cacheWrite: 0 },
+              cost: overrides?.cost ?? { input: 1.5, output: 7.5, cacheRead: 0, cacheWrite: 0 },
               mediaInput: {
                 image: { maxSidePx: 2048, preferredSidePx: 1536, tokenMode: "provider" },
               },
@@ -177,35 +179,74 @@ describe("resolveBundledStaticCatalogModel", () => {
     expect(manifestMocks.listOpenClawPluginManifestMetadata).toHaveBeenCalledTimes(1);
   });
 
-  it("synthesizes a runtime model from an exact bundled static manifest catalog row", () => {
-    setManifestPlugins([createMistralManifestPlugin()]);
+  it.each([false, true])(
+    "synthesizes a runtime model with complete static pricing (tiered=%s)",
+    (tiered) => {
+      const cost = {
+        input: 1.5,
+        output: 7.5,
+        cacheRead: 0,
+        cacheWrite: 0,
+        ...(tiered
+          ? {
+              tieredPricing: [
+                {
+                  input: 1.5,
+                  output: 7.5,
+                  cacheRead: 0.1,
+                  cacheWrite: 0.2,
+                  range: [0, 200_001] as [number, number],
+                },
+                {
+                  input: 3,
+                  output: 15,
+                  cacheRead: 0.3,
+                  cacheWrite: 0.4,
+                  range: [200_001] as [number],
+                },
+              ],
+            }
+          : {}),
+      };
+      setManifestPlugins([createMistralManifestPlugin({ cost })]);
 
-    const model = resolveBundledStaticCatalogModel({
-      provider: "mistral",
-      modelId: "mistral-medium-3-5",
-      cfg: {},
-    });
+      const model = resolveBundledStaticCatalogModel({
+        provider: "mistral",
+        modelId: "mistral-medium-3-5",
+        cfg: {},
+      });
 
-    expect(model).toEqual({
-      api: "openai-completions",
-      baseUrl: "https://api.mistral.ai/v1",
-      compat: undefined,
-      contextTokens: undefined,
-      contextWindow: 262144,
-      cost: { input: 1.5, output: 7.5, cacheRead: 0, cacheWrite: 0 },
-      headers: undefined,
-      id: "mistral-medium-3-5",
-      input: ["text", "image"],
-      maxTokens: 8192,
-      mediaInput: {
-        image: { maxSidePx: 2048, preferredSidePx: 1536, tokenMode: "provider" },
-      },
-      name: "Mistral Medium 3.5",
-      provider: "mistral",
-      reasoning: true,
-      thinkingLevelMap: { off: null, minimal: "low", max: "max" },
-    });
-  });
+      expect(model).toEqual({
+        api: "openai-completions",
+        baseUrl: "https://api.mistral.ai/v1",
+        compat: undefined,
+        contextTokens: undefined,
+        contextWindow: 262144,
+        cost: {
+          ...cost,
+          ...(tiered
+            ? {
+                tieredPricing: [
+                  cost.tieredPricing![0],
+                  { ...cost.tieredPricing![1], range: [200_001, Infinity] },
+                ],
+              }
+            : {}),
+        },
+        headers: undefined,
+        id: "mistral-medium-3-5",
+        input: ["text", "image"],
+        maxTokens: 8192,
+        mediaInput: {
+          image: { maxSidePx: 2048, preferredSidePx: 1536, tokenMode: "provider" },
+        },
+        name: "Mistral Medium 3.5",
+        provider: "mistral",
+        reasoning: true,
+        thinkingLevelMap: { off: null, minimal: "low", max: "max" },
+      });
+    },
+  );
 
   it("ignores non-bundled and non-static manifest catalog rows", () => {
     // Workspace plugins and refreshable/runtime catalogs are not process-stable

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -1,6 +1,7 @@
 /**
  * Resolves bundled static catalog rows for embedded-agent model selection.
  */
+import { normalizeResolvedPricing } from "@openclaw/llm-core";
 import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/model-catalog-types";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { ModelProviderConfig } from "../../config/types.models.js";
@@ -65,17 +66,6 @@ function normalizeStaticCatalogInput(
   return normalizedInput.length > 0 ? normalizedInput : ["text"];
 }
 
-function normalizeStaticCatalogCost(
-  cost: NormalizedModelCatalogRow["cost"],
-): ProviderRuntimeModel["cost"] {
-  return {
-    input: cost?.input ?? 0,
-    output: cost?.output ?? 0,
-    cacheRead: cost?.cacheRead ?? 0,
-    cacheWrite: cost?.cacheWrite ?? 0,
-  };
-}
-
 /** Converts a normalized catalog row into the provider runtime model shape. */
 function modelFromStaticCatalogRow(row: NormalizedModelCatalogRow): ProviderRuntimeModel {
   return {
@@ -86,7 +76,7 @@ function modelFromStaticCatalogRow(row: NormalizedModelCatalogRow): ProviderRunt
     baseUrl: row.baseUrl ?? "",
     reasoning: row.reasoning,
     input: normalizeStaticCatalogInput(row.input),
-    cost: normalizeStaticCatalogCost(row.cost),
+    cost: normalizeResolvedPricing(row.cost ?? {}),
     contextWindow: row.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
     contextWindows: row.contextWindows?.map((option) => ({ ...option })),
     contextWindowDefault: row.contextWindowDefault,
@@ -110,7 +100,7 @@ function completeProviderStaticCatalogModel(
     baseUrl: model.baseUrl ?? "",
     reasoning: model.reasoning ?? false,
     input: normalizeStaticCatalogInput(model.input),
-    cost: model.cost ?? normalizeStaticCatalogCost(undefined),
+    cost: model.cost ?? normalizeResolvedPricing({}),
     contextWindow: model.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
     contextTokens: model.contextTokens,
     maxTokens: model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,

--- a/src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts
+++ b/src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts
@@ -228,7 +228,7 @@ describe("openrouter-model-capabilities", () => {
     });
   });
 
-  it("preserves native OpenRouter pricing tiers in memory and across SQLite reads", async () => {
+  it("preserves partial native OpenRouter pricing overrides in memory and across SQLite reads", async () => {
     await withOpenRouterStateDir(async () => {
       const cost = {
         input: 2,
@@ -241,14 +241,14 @@ describe("openrouter-model-capabilities", () => {
             output: 10,
             cacheRead: expect.closeTo(0.2, 12),
             cacheWrite: 2.5,
-            range: [0, 272_000],
+            range: [0, 272_001],
           },
           {
             input: 4,
-            output: 15,
-            cacheRead: expect.closeTo(0.4, 12),
-            cacheWrite: 5,
-            range: [272_000],
+            output: 10,
+            cacheRead: expect.closeTo(0.2, 12),
+            cacheWrite: 2.5,
+            range: [272_001],
           },
         ],
       };
@@ -273,9 +273,6 @@ describe("openrouter-model-capabilities", () => {
                       {
                         min_prompt_tokens: 272_000,
                         prompt: "0.000004",
-                        completion: "0.000015",
-                        input_cache_read: "0.0000004",
-                        input_cache_write: "0.000005",
                       },
                     ],
                   },

--- a/src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts
+++ b/src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts
@@ -228,8 +228,30 @@ describe("openrouter-model-capabilities", () => {
     });
   });
 
-  it("loads cached OpenRouter capabilities from SQLite on the next import", async () => {
+  it("preserves native OpenRouter pricing tiers in memory and across SQLite reads", async () => {
     await withOpenRouterStateDir(async () => {
+      const cost = {
+        input: 2,
+        output: 10,
+        cacheRead: expect.closeTo(0.2, 12),
+        cacheWrite: 2.5,
+        tieredPricing: [
+          {
+            input: 2,
+            output: 10,
+            cacheRead: expect.closeTo(0.2, 12),
+            cacheWrite: 2.5,
+            range: [0, 272_000],
+          },
+          {
+            input: 4,
+            output: 15,
+            cacheRead: expect.closeTo(0.4, 12),
+            cacheWrite: 5,
+            range: [272_000],
+          },
+        ],
+      };
       const fetchSpy = vi.fn(
         async () =>
           new Response(
@@ -242,7 +264,21 @@ describe("openrouter-model-capabilities", () => {
                   supported_parameters: ["tools"],
                   context_length: 8765,
                   max_completion_tokens: 4321,
-                  pricing: { prompt: "0.000005", completion: "0.000006" },
+                  pricing: {
+                    prompt: "0.000002",
+                    completion: "0.00001",
+                    input_cache_read: "0.0000002",
+                    input_cache_write: "0.0000025",
+                    overrides: [
+                      {
+                        min_prompt_tokens: 272_000,
+                        prompt: "0.000004",
+                        completion: "0.000015",
+                        input_cache_read: "0.0000004",
+                        input_cache_write: "0.000005",
+                      },
+                    ],
+                  },
                 },
               ],
             }),
@@ -256,6 +292,9 @@ describe("openrouter-model-capabilities", () => {
 
       const firstModule = await importOpenRouterModelCapabilities("sqlite-cache-writer");
       await firstModule.loadOpenRouterModelCapabilities("acme/sqlite-cached-model");
+      expect(firstModule.getOpenRouterModelCapabilities("acme/sqlite-cached-model")?.cost).toEqual(
+        cost,
+      );
       expect(fetchSpy).toHaveBeenCalledTimes(1);
 
       const secondModule = await importOpenRouterModelCapabilities("sqlite-cache-reader");
@@ -265,6 +304,7 @@ describe("openrouter-model-capabilities", () => {
           supportsTools: true,
           contextWindow: 8765,
           maxTokens: 4321,
+          cost,
         },
       );
       expect(fetchSpy).toHaveBeenCalledTimes(1);

--- a/src/agents/embedded-agent-runner/openrouter-model-capabilities.ts
+++ b/src/agents/embedded-agent-runner/openrouter-model-capabilities.ts
@@ -18,7 +18,7 @@
  * capabilities instead of the text-only fallback.
  */
 
-import { parseStrictFiniteNumber } from "@openclaw/normalization-core/number-coercion";
+import { normalizeOpenRouterModelPricing } from "@openclaw/model-catalog-core/model-catalog-pricing";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { cancelUnreadResponseBody } from "../../infra/http-body.js";
 import { resolveProxyFetchFromEnv } from "../../infra/net/proxy-fetch.js";
@@ -53,12 +53,7 @@ interface OpenRouterApiModel {
     context_length?: number;
     max_completion_tokens?: number;
   };
-  pricing?: {
-    prompt?: string;
-    completion?: string;
-    input_cache_read?: string;
-    input_cache_write?: string;
-  };
+  pricing?: unknown;
 }
 
 interface OpenRouterModelCapabilities {
@@ -68,12 +63,7 @@ interface OpenRouterModelCapabilities {
   supportsTools?: boolean;
   contextWindow: number;
   maxTokens: number;
-  cost: {
-    input: number;
-    output: number;
-    cacheRead: number;
-    cacheWrite: number;
-  };
+  cost: NonNullable<ReturnType<typeof normalizeOpenRouterModelPricing>>;
 }
 
 // ---------------------------------------------------------------------------
@@ -165,11 +155,11 @@ function parseModel(model: OpenRouterApiModel): OpenRouterModelCapabilities {
       model.max_completion_tokens ??
       model.max_output_tokens ??
       8192,
-    cost: {
-      input: (parseStrictFiniteNumber(model.pricing?.prompt) ?? 0) * 1_000_000,
-      output: (parseStrictFiniteNumber(model.pricing?.completion) ?? 0) * 1_000_000,
-      cacheRead: (parseStrictFiniteNumber(model.pricing?.input_cache_read) ?? 0) * 1_000_000,
-      cacheWrite: (parseStrictFiniteNumber(model.pricing?.input_cache_write) ?? 0) * 1_000_000,
+    cost: normalizeOpenRouterModelPricing(model.pricing) ?? {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
     },
   };
 }

--- a/src/agents/models-config.merge.test.ts
+++ b/src/agents/models-config.merge.test.ts
@@ -135,7 +135,9 @@ describe("models-config merge helpers", () => {
     expect(
       mergeProviderModels(implicit, explicit, {
         providerId: "ollama",
-        sourceModelInputOmissions: new Set(["ollama/qwen3-vl:latest"]),
+        sourceModelFields: new Map([
+          ["ollama/qwen3-vl:latest", { inputOmitted: true, cost: undefined }],
+        ]),
       }).models?.[0]?.input,
     ).toEqual(["text", "image"]);
   });

--- a/src/agents/models-config.merge.ts
+++ b/src/agents/models-config.merge.ts
@@ -6,6 +6,7 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { asPositiveFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { mergeModelCost } from "../config/model-cost.js";
 import { isNonSecretApiKeyMarker } from "./model-auth-markers.js";
 import { resolveCatalogOwnedModelCompat } from "./model-compat-catalog.js";
 import {
@@ -49,6 +50,11 @@ export type ExistingProviderConfig = ProviderConfig & {
   api?: string;
 };
 
+export type SourceModelFields = ReadonlyMap<
+  string,
+  { inputOmitted: boolean; cost: ProviderConfig["models"][number]["cost"] | undefined }
+>;
+
 function getProviderModelId(model: unknown): string {
   if (!model || typeof model !== "object") {
     return "";
@@ -63,7 +69,7 @@ export function mergeProviderModels(
   explicit: ProviderConfig,
   options?: {
     providerId: string;
-    sourceModelInputOmissions?: ReadonlySet<string>;
+    sourceModelFields?: SourceModelFields;
     manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"];
     preserveConfiguredModelMembership?: boolean;
   },
@@ -111,15 +117,28 @@ export function mergeProviderModels(
     if (!implicitModel) {
       return explicitModel;
     }
-    const sourceOmittedInput =
-      options &&
-      options.sourceModelInputOmissions?.has(
-        modelKey(normalizeProviderId(options.providerId), normalizeModelId(options.providerId, id)),
-      ) === true;
+    const sourceFields = options?.sourceModelFields?.get(
+      modelKey(normalizeProviderId(options.providerId), normalizeModelId(options.providerId, id)),
+    );
+    // Materialized defaults are not authored pins. Reuse raw source cost in both
+    // merge passes so the final pass cannot restore an older catalog schedule.
+    const cost = mergeModelCost(
+      implicitModel.cost,
+      sourceFields ? sourceFields.cost : explicitModel.cost,
+    );
+    const input =
+      sourceFields?.inputOmitted && implicitModel.input !== undefined
+        ? implicitModel.input
+        : "input" in explicitModel
+          ? explicitModel.input
+          : implicitModel.input;
     if (options?.preserveConfiguredModelMembership) {
-      return sourceOmittedInput && implicitModel.input !== undefined
-        ? Object.assign({}, explicitModel, { input: implicitModel.input })
-        : explicitModel;
+      return Object.assign(
+        {},
+        explicitModel,
+        { cost },
+        sourceFields?.inputOmitted ? { input } : {},
+      );
     }
 
     const contextWindow =
@@ -149,12 +168,8 @@ export function mergeProviderModels(
       {},
       explicitModel,
       {
-        input:
-          sourceOmittedInput && implicitModel.input !== undefined
-            ? implicitModel.input
-            : "input" in explicitModel
-              ? explicitModel.input
-              : implicitModel.input,
+        input,
+        cost,
         reasoning: `reasoning` in explicitModel ? explicitModel.reasoning : implicitModel.reasoning,
       },
       contextWindow === undefined ? {} : { contextWindow },
@@ -194,7 +209,7 @@ export function mergeProviderModels(
 export function mergeProviders(params: {
   implicit?: Record<string, ProviderConfig> | null;
   explicit?: Record<string, ProviderConfig> | null;
-  sourceModelInputOmissions?: ReadonlySet<string>;
+  sourceModelFields?: SourceModelFields;
   manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"];
 }): Record<string, ProviderConfig> {
   const out = normalizeProviderMapKeys(params.implicit);
@@ -203,7 +218,7 @@ export function mergeProviders(params: {
     out[providerKey] = implicit
       ? mergeProviderModels(implicit, explicit, {
           providerId: providerKey,
-          sourceModelInputOmissions: params.sourceModelInputOmissions,
+          sourceModelFields: params.sourceModelFields,
           manifestPlugins: params.manifestPlugins,
         })
       : explicit;

--- a/src/agents/models-config.model-input-presence.test.ts
+++ b/src/agents/models-config.model-input-presence.test.ts
@@ -1,6 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../config/runtime-snapshot.js";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import type { ProviderPlugin } from "../plugins/types.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { planOpenClawModelsJsonSource } from "./models-config.js";
 import { planOpenClawModelsJsonWithDeps } from "./models-config.plan.test-support.js";
+import { createPreparedModelCatalogWorkerInput } from "./prepared-model-catalog-worker.js";
+
+afterEach(clearRuntimeConfigSnapshot);
 
 type ResolveImplicitProviders = NonNullable<
   NonNullable<Parameters<typeof planOpenClawModelsJsonWithDeps>[1]>["resolveImplicitProviders"]
@@ -31,7 +43,7 @@ describe("models config input presence", () => {
       expected: ["text"],
     },
     {
-      name: "keeps materialized input when the source row is missing",
+      name: "keeps independent input when the active secrets source has no row",
       sourceModels: [],
       expected: ["text"],
     },
@@ -64,7 +76,8 @@ describe("models config input presence", () => {
 
     const plan = await planOpenClawModelsJsonWithDeps(
       {
-        cfg,
+        cfg: sourceModels.length ? sourceConfigForSecrets : cfg,
+        discoveryAuthConfig: cfg,
         sourceConfigForSecrets,
         agentDir: "/tmp/openclaw-model-input-presence",
         env: { AWS_PROFILE: "default" },
@@ -83,4 +96,179 @@ describe("models config input presence", () => {
     };
     expect(generated.providers["amazon-bedrock"]?.models?.[0]?.input).toEqual(expected);
   });
+
+  const liveCost = {
+    input: 11,
+    output: 22,
+    cacheRead: 3,
+    cacheWrite: 4,
+    tieredPricing: [{ input: 33, output: 44, cacheRead: 5, cacheWrite: 6, range: [0] as [number] }],
+  };
+  const oldCost = { input: 1, output: 2, cacheRead: 0, cacheWrite: 0 };
+  const authoredRates = { input: 7, output: 8, cacheRead: 0.7, cacheWrite: 0.8 };
+  const authoredTiers = [{ ...authoredRates, range: [0] as [number] }];
+  it.each<{
+    name: string;
+    cost?: Partial<ModelDefinitionConfig["cost"]>;
+    expected: ModelDefinitionConfig["cost"];
+    missingSource?: boolean;
+    independent?: boolean;
+    duplicateCost?: Partial<ModelDefinitionConfig["cost"]>;
+  }>([
+    { name: "omitted cost", cost: undefined, expected: liveCost },
+    { name: "empty cost", cost: {}, expected: liveCost },
+    {
+      name: "partial cost",
+      cost: { input: 7 },
+      expected: { ...liveCost, input: 7, tieredPricing: undefined },
+    },
+    { name: "full cost", cost: authoredRates, expected: authoredRates },
+    {
+      name: "zero cost",
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      expected: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    },
+    {
+      name: "authored tiers",
+      cost: { tieredPricing: authoredTiers },
+      expected: { ...liveCost, tieredPricing: authoredTiers },
+    },
+    {
+      name: "empty tiers",
+      cost: { tieredPricing: [] },
+      expected: { ...liveCost, tieredPricing: [] },
+    },
+    {
+      name: "independent missing source row",
+      missingSource: true,
+      cost: undefined,
+      expected: oldCost,
+    },
+    { name: "independent config", independent: true, expected: oldCost },
+    {
+      name: "duplicate partial costs",
+      cost: { input: 7 },
+      duplicateCost: { input: 9, output: 8 },
+      expected: { input: 7, output: 8, cacheRead: 3, cacheWrite: 4 },
+    },
+  ])(
+    "uses authored $name through discovery and final catalog merging",
+    async ({ cost, expected, missingSource, independent, duplicateCost }) => {
+      const providerId = "catalog-price-fixture";
+      const configuredModel = {
+        ...model("priced-model", ["text", "image"]),
+        cost: { ...oldCost, ...cost },
+        contextWindow: 4096,
+        maxTokens: 512,
+        compat: { supportsTools: false },
+      };
+      const configuredProvider = {
+        baseUrl: "https://models.example/v1",
+        apiKey: "CATALOG_FIXTURE_KEY",
+        models: [configuredModel],
+      };
+      const cfg: OpenClawConfig = { models: { providers: { [providerId]: configuredProvider } } };
+      const sourceConfigForSecrets = {
+        models: {
+          providers: {
+            " Catalog-Price-Fixture ": {
+              ...configuredProvider,
+              models: missingSource
+                ? []
+                : [
+                    {
+                      id: "priced-model",
+                      name: "priced-model",
+                      reasoning: false,
+                      input: ["text", "image"],
+                      contextWindow: 4096,
+                      maxTokens: 512,
+                      compat: configuredModel.compat,
+                      ...(cost === undefined ? {} : { cost }),
+                    },
+                    ...(duplicateCost ? [{ ...configuredModel, cost: duplicateCost }] : []),
+                  ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      const discovered = {
+        ...configuredProvider,
+        models: [
+          { ...model("priced-model"), cost: liveCost, compat: configuredModel.compat },
+          model("discovered-only"),
+        ],
+      };
+      const plugin: ProviderPlugin = {
+        id: providerId,
+        pluginId: providerId,
+        label: "Catalog price fixture",
+        auth: [],
+        staticCatalog: { run: async () => ({ provider: discovered }) },
+      };
+      const pluginMetadataSnapshot = createPluginMetadataSnapshotFixture();
+      const options = {
+        authStore: { version: 1, profiles: {} },
+        pluginMetadataSnapshot,
+        providerDiscoveryEntriesOnly: true,
+        providerDiscoveryProviderIds: [providerId],
+        preparedStaticProviderCatalog: {
+          providers: [plugin],
+          entries: [{ provider: plugin, result: { provider: discovered } }],
+        },
+      };
+      if (independent || missingSource) {
+        // Missing top-level runtime state makes this an independent supplied config.
+        setRuntimeConfigSnapshot({ ...cfg, gateway: { mode: "local" } }, sourceConfigForSecrets);
+        await withOpenClawTestState({ label: "independent-model-cost" }, async (state) => {
+          const plan = await planOpenClawModelsJsonSource(cfg, state.agentDir(), {
+            ...options,
+            env: state.env,
+          });
+          expect(JSON.parse(plan.modelsJsonContents!).providers[providerId].models).toEqual([
+            { ...configuredModel, cost: expected },
+          ]);
+        });
+        return;
+      }
+      setRuntimeConfigSnapshot(cfg, sourceConfigForSecrets);
+      const cloned = structuredClone(
+        createPreparedModelCatalogWorkerInput({
+          agentFacts: {
+            input: { config: cfg, agentDir: "/tmp/openclaw-model-cost-presence" },
+            env: {},
+            authStore: options.authStore,
+            credentials: {},
+            providerIds: [providerId],
+            configuredModelRefs: [],
+            configuredRuntimeModels: [],
+            runtimeCapabilityModels: [],
+            configuredGeneratedCatalogPluginIds: [],
+            templateAuthStorage: {} as never,
+          },
+          pluginMetadataSnapshot,
+        }),
+      );
+      // Workers retain the captured pair after losing the parent's process-local snapshot.
+      clearRuntimeConfigSnapshot();
+      const plan = await planOpenClawModelsJsonWithDeps({
+        ...options,
+        cfg: cloned.sourceConfigForSecrets,
+        discoveryAuthConfig: cloned.input.config,
+        sourceConfigForSecrets: cloned.sourceConfigForSecrets,
+        agentDir: cloned.input.agentDir,
+        env: {},
+        existingRaw: "",
+        existingParsed: {},
+      });
+      expect(plan.action).toBe("write");
+      if (plan.action !== "write") {
+        throw new Error(`expected write plan, got ${plan.action}`);
+      }
+      const generated = JSON.parse(plan.contents);
+      expect(generated.providers[providerId].models).toEqual([
+        { ...configuredModel, cost: expected },
+      ]);
+    },
+  );
 });

--- a/src/agents/models-config.plan.test-support.ts
+++ b/src/agents/models-config.plan.test-support.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import "./models-config.plan.js";
+import type { SourceModelFields } from "./models-config.merge.js";
 import type { PreparedModelsConfigContext } from "./models-config.plan.js";
 import type { ProviderConfig } from "./models-config.providers.secrets.js";
 
@@ -15,7 +16,7 @@ type ResolveImplicitProvidersForModelsJson = (params: {
   providerDiscoveryProviderIds?: readonly string[];
   providerDiscoveryTimeoutMs?: number;
   providerDiscoveryEntriesOnly?: boolean;
-  sourceModelInputOmissions?: ReadonlySet<string>;
+  sourceModelFields?: SourceModelFields;
 }) => Promise<Record<string, ProviderConfig>>;
 
 type PreparedPlanParams = Parameters<

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -3,6 +3,7 @@
  * this module to merge implicit provider discovery, explicit config, and
  * preserved secrets before touching models.json.
  */
+import { mergeModelCost } from "../config/model-cost.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { ProviderCatalogOutcome } from "../plugins/provider-catalog.types.js";
@@ -15,6 +16,7 @@ import {
   mergeWithExistingProviderSecrets,
   normalizeProviderMapKeys,
   type ExistingProviderConfig,
+  type SourceModelFields,
 } from "./models-config.merge.js";
 import {
   enforceSourceManagedProviderSecrets,
@@ -65,7 +67,7 @@ type ResolveImplicitProvidersForModelsJson = (params: {
   providerDiscoveryProviderIds?: readonly string[];
   providerDiscoveryTimeoutMs?: number;
   providerDiscoveryEntriesOnly?: boolean;
-  sourceModelInputOmissions?: ReadonlySet<string>;
+  sourceModelFields?: SourceModelFields;
 }) => Promise<Record<string, ProviderConfig>>;
 
 /**
@@ -122,18 +124,27 @@ function buildPluginCatalogWrites(
   );
 }
 
-function buildSourceModelInputOmissions(
+function buildSourceModelFields(
   sourceProviders: Record<string, ProviderConfig> | undefined,
   manifestPlugins: PluginMetadataSnapshot["manifestRegistry"]["plugins"] | undefined,
-): ReadonlySet<string> {
+): SourceModelFields {
   const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer({ manifestPlugins });
-  return new Set(
-    Object.entries(normalizeProviderMapKeys(sourceProviders)).flatMap(([providerId, provider]) =>
-      (provider.models ?? [])
-        .filter((model) => !Object.hasOwn(model, "input"))
-        .map((model) => modelKey(providerId, normalizeModelId(providerId, model.id))),
-    ),
-  );
+  const fields = new Map<
+    string,
+    { inputOmitted: boolean; cost: ReturnType<typeof mergeModelCost> }
+  >();
+  for (const [providerId, provider] of Object.entries(normalizeProviderMapKeys(sourceProviders))) {
+    for (const model of provider.models ?? []) {
+      const key = modelKey(providerId, normalizeModelId(providerId, model.id));
+      const existing = fields.get(key);
+      fields.set(key, {
+        inputOmitted: existing?.inputOmitted || !Object.hasOwn(model, "input"),
+        // Duplicate source rows keep the same first-authored priority as publication.
+        cost: mergeModelCost(model.cost, existing?.cost),
+      });
+    }
+  }
+  return fields;
 }
 
 /** Resolves providers for models.json with injectable implicit-provider discovery. */
@@ -153,10 +164,7 @@ async function resolveProvidersForModelsJsonWithDeps(
     ? { ...context.cfg, models: { ...context.cfg.models, providers: explicitProviders } }
     : context.cfg;
   const manifestPlugins = context.pluginMetadataSnapshot?.manifestRegistry.plugins;
-  const sourceModelInputOmissions = buildSourceModelInputOmissions(
-    context.sourceConfigForSecrets.models?.providers,
-    manifestPlugins,
-  );
+  const sourceModelFields = buildSourceModelFields(context.cfg.models?.providers, manifestPlugins);
   // When models.mode is "replace" the user opts out of provider discovery, so
   // skip the (potentially slow) implicit-provider resolver entirely and return
   // only the explicit providers. See openclaw#66957.
@@ -173,7 +181,7 @@ async function resolveProvidersForModelsJsonWithDeps(
     env,
     ...(context.workspaceDir ? { workspaceDir: context.workspaceDir } : {}),
     explicitProviders,
-    sourceModelInputOmissions,
+    sourceModelFields,
     ...(context.pluginMetadataSnapshot
       ? { pluginMetadataSnapshot: context.pluginMetadataSnapshot }
       : {}),
@@ -196,7 +204,7 @@ async function resolveProvidersForModelsJsonWithDeps(
   return mergeProviders({
     implicit: implicitProviders,
     explicit: explicitProviders,
-    sourceModelInputOmissions,
+    sourceModelFields,
     manifestPlugins,
   });
 }

--- a/src/agents/models-config.providers.implicit.discovery-scope.test.ts
+++ b/src/agents/models-config.providers.implicit.discovery-scope.test.ts
@@ -774,7 +774,9 @@ describe("resolveImplicitProviders startup discovery scope", () => {
       config: { models: { providers: { "amazon-bedrock": explicitProvider } } },
       env: { AWS_PROFILE: "default" } as NodeJS.ProcessEnv,
       explicitProviders: { "amazon-bedrock": explicitProvider },
-      sourceModelInputOmissions: new Set(["amazon-bedrock/vision-model"]),
+      sourceModelFields: new Map([
+        ["amazon-bedrock/vision-model", { inputOmitted: true, cost: undefined }],
+      ]),
     });
 
     expect(providers?.["amazon-bedrock"]?.models).toMatchObject([

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -32,7 +32,7 @@ import {
   resolveNonEnvSecretRefApiKeyMarker,
 } from "./model-auth-markers.js";
 import { parseConfiguredModelVisibilityEntries } from "./model-selection-shared.js";
-import { mergeProviderModels } from "./models-config.merge.js";
+import { mergeProviderModels, type SourceModelFields } from "./models-config.merge.js";
 import type {
   ProviderApiKeyResolver,
   ProviderAuthResolver,
@@ -73,7 +73,7 @@ type ImplicitProviderParams = {
   providerDiscoveryTimeoutMs?: number;
   providerDiscoveryEntriesOnly?: boolean;
   onProviderCatalogOutcome?: (outcome: ProviderCatalogOutcome) => void;
-  sourceModelInputOmissions?: ReadonlySet<string>;
+  sourceModelFields?: SourceModelFields;
 };
 
 type ImplicitProviderContext = ImplicitProviderParams & {
@@ -267,7 +267,7 @@ function mergeImplicitProviderConfig(params: {
   existing: ProviderConfig | undefined;
   implicit: ProviderConfig;
   dynamicProviderModels?: boolean;
-  sourceModelInputOmissions?: ReadonlySet<string>;
+  sourceModelFields?: SourceModelFields;
   manifestPlugins?: PluginMetadataSnapshot["manifestRegistry"]["plugins"];
 }): ProviderConfig {
   const { providerId, existing, implicit } = params;
@@ -280,7 +280,7 @@ function mergeImplicitProviderConfig(params: {
   }
   return mergeProviderModels(implicit, existing, {
     providerId,
-    sourceModelInputOmissions: params.sourceModelInputOmissions,
+    sourceModelFields: params.sourceModelFields,
     manifestPlugins: params.manifestPlugins,
     preserveConfiguredModelMembership:
       !params.dynamicProviderModels && Array.isArray(existing.models) && existing.models.length > 0,
@@ -482,7 +482,7 @@ async function resolvePluginImplicitProviders(
           config: ctx.config,
           providerId,
         }),
-        sourceModelInputOmissions: ctx.sourceModelInputOmissions,
+        sourceModelFields: ctx.sourceModelFields,
         manifestPlugins: ctx.pluginMetadataSnapshot?.manifestRegistry.plugins,
       });
       discovered[providerId] = resolveImplicitProviderAuthMarker({

--- a/src/model-catalog/pricing.test.ts
+++ b/src/model-catalog/pricing.test.ts
@@ -1,5 +1,11 @@
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../config/runtime-snapshot.js";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   resolveModelCostConfig,
@@ -26,6 +32,19 @@ beforeEach(() => {
         openai: {
           models: [
             { id: "gpt-catalog", cost: { input: 1, output: 2 } },
+            {
+              id: "gpt-authored",
+              cost: {
+                input: 2,
+                output: 8,
+                cacheRead: 0.5,
+                cacheWrite: 1,
+                tieredPricing: [
+                  { input: 2, output: 8, cacheRead: 0.5, cacheWrite: 1, range: [0, 201] },
+                  { input: 4, output: 16, cacheRead: 1, cacheWrite: 2, range: [201] },
+                ],
+              },
+            },
             {
               id: "gpt-zero-tier",
               cost: {
@@ -59,6 +78,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  clearRuntimeConfigSnapshot();
   setRemoteModelCatalogOverlaySourcesForTest();
   resetRemoteModelCatalogOverlayForTest();
 });
@@ -77,6 +97,125 @@ function configFor(baseUrl: string): OpenClawConfig {
 }
 
 describe("hosted model pricing", () => {
+  const catalogRates = { input: 2, output: 8, cacheRead: 0.5, cacheWrite: 1 };
+  const catalogTiers = [
+    { ...catalogRates, range: [0, 201] },
+    { input: 4, output: 16, cacheRead: 1, cacheWrite: 2, range: [201, Infinity] },
+  ];
+
+  it.each([
+    {
+      name: "sizing-only",
+      cost: undefined,
+      expected: { ...catalogRates, tieredPricing: catalogTiers },
+    },
+    { name: "empty cost", cost: {}, expected: { ...catalogRates, tieredPricing: catalogTiers } },
+    { name: "partial cost", cost: { output: 3 }, expected: { ...catalogRates, output: 3 } },
+    {
+      name: "full cost",
+      cost: { input: 7, output: 9, cacheRead: 1, cacheWrite: 2 },
+      expected: { input: 7, output: 9, cacheRead: 1, cacheWrite: 2 },
+    },
+    {
+      name: "zero cost",
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      expected: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    },
+    { name: "empty tiers", cost: { tieredPricing: [] }, expected: catalogRates },
+    {
+      name: "authored tiers",
+      cost: { tieredPricing: [{ input: 7, output: 9, cacheRead: 1, cacheWrite: 2, range: [0] }] },
+      expected: {
+        ...catalogRates,
+        tieredPricing: [{ input: 7, output: 9, cacheRead: 1, cacheWrite: 2, range: [0, Infinity] }],
+      },
+    },
+  ])(
+    "resolves $name from authored source rather than materialized runtime rates",
+    ({ cost, expected }) => {
+      const source = {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              models: [
+                {
+                  id: "gpt-authored",
+                  name: "Authored GPT",
+                  contextWindow: 64_000,
+                  ...(cost ? { cost } : {}),
+                },
+              ],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      const runtime = structuredClone(source);
+      const model = expectDefined(
+        runtime.models?.providers?.openai?.models[0],
+        "materialized model",
+      );
+      model.cost = { input: 99, output: 99, cacheRead: 99, cacheWrite: 99 };
+      setRuntimeConfigSnapshot(runtime, source);
+      const agentDir = tempDirs.make("openclaw-authored-pricing-");
+      for (const config of [runtime, structuredClone(runtime)]) {
+        expect(
+          resolveModelCostConfig({ config, agentDir, provider: "openai", model: "gpt-authored" }),
+        ).toEqual(expected);
+        expect(resolveModelCostConfigFingerprint(config, agentDir)).toBe(
+          resolveModelCostConfigFingerprint(source, agentDir),
+        );
+      }
+      expect(model.contextWindow).toBe(64_000);
+    },
+  );
+
+  it.each(["unpaired", "incompatible"] as const)(
+    "preserves independent configured pricing with an %s runtime snapshot",
+    (snapshot) => {
+      const runtime = { agents: { defaults: {} } } satisfies OpenClawConfig;
+      setRuntimeConfigSnapshot(runtime, snapshot === "unpaired" ? undefined : {});
+      const config = {
+        models: {
+          providers: {
+            openai: {
+              baseUrl: "https://api.openai.com/v1",
+              models: [{ id: "gpt-authored", name: "Authored GPT", cost: { output: 3 } }],
+            },
+          },
+        },
+      } as unknown as OpenClawConfig;
+      const agentDir = tempDirs.make("openclaw-independent-pricing-");
+      expect(
+        resolveModelCostConfig({ config, agentDir, provider: "openai", model: "gpt-authored" }),
+      ).toEqual({ ...catalogRates, output: 3 });
+    },
+  );
+
+  it("invalidates pricing fingerprints when authored empty tiers replace inherited tiers", () => {
+    const cost = {} as ModelDefinitionConfig["cost"];
+    const config = {
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            models: [{ id: "gpt-authored", name: "Authored GPT", cost }],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    const agentDir = tempDirs.make("openclaw-empty-tier-pricing-");
+    expect(
+      resolveModelCostConfig({ config, agentDir, provider: "openai", model: "gpt-authored" }),
+    ).toEqual({ ...catalogRates, tieredPricing: catalogTiers });
+    const before = resolveModelCostConfigFingerprint(config, agentDir);
+    cost.tieredPricing = [];
+    expect(resolveModelCostConfigFingerprint(config, agentDir)).not.toBe(before);
+    expect(
+      resolveModelCostConfig({ config, agentDir, provider: "openai", model: "gpt-authored" }),
+    ).toEqual(catalogRates);
+  });
+
   it("resolves a non-catalog model from the stored hosted pricing map", () => {
     const agentDir = tempDirs.make("openclaw-hosted-pricing-");
     expect(

--- a/src/model-catalog/pricing.test.ts
+++ b/src/model-catalog/pricing.test.ts
@@ -1,13 +1,21 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import * as runtimeNormalization from "../agents/provider-model-normalization.runtime.js";
+import { resolveResponseUsageLine } from "../auto-reply/reply/agent-runner-usage-line.js";
 import {
   clearRuntimeConfigSnapshot,
   setRuntimeConfigSnapshot,
 } from "../config/runtime-snapshot.js";
 import type { ModelDefinitionConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import * as manifestNormalization from "../plugins/manifest-model-id-normalization.js";
+import { normalizeManifestModelPricing } from "../plugins/manifest-model-provider-normalizers.js";
+import * as pluginMetadata from "../plugins/plugin-metadata-snapshot.js";
+import { buildStatusMessageParts } from "../status/status-message.js";
 import {
+  estimateAggregateUsageCost,
+  resetUsageFormatCachesForTest,
   resolveModelCostConfig,
   resolveModelCostConfigFingerprint,
 } from "../utils/usage-format.js";
@@ -20,6 +28,8 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const readStoredCatalog = vi.fn();
 
 beforeEach(() => {
+  clearRuntimeConfigSnapshot();
+  resetUsageFormatCachesForTest();
   resetRemoteModelCatalogOverlayForTest();
   readStoredCatalog.mockReset().mockReturnValue({
     source_url: "https://catalog.openclaw.ai/models/v1/catalog.json",
@@ -79,6 +89,10 @@ beforeEach(() => {
 
 afterEach(() => {
   clearRuntimeConfigSnapshot();
+  resetUsageFormatCachesForTest();
+  vi.unstubAllEnvs();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
   setRemoteModelCatalogOverlaySourcesForTest();
   resetRemoteModelCatalogOverlayForTest();
 });
@@ -97,43 +111,217 @@ function configFor(baseUrl: string): OpenClawConfig {
 }
 
 describe("hosted model pricing", () => {
+  it.each([
+    { name: "native owner", policy: { venice: { provider: "venice" } }, known: true },
+    { name: "other native source", policy: { openCode: { provider: "upstream" } }, known: true },
+    { name: "missing policy", policy: undefined, known: false },
+    {
+      name: "external disabled",
+      policy: { external: false, venice: { provider: "venice" } },
+      known: false,
+    },
+    { name: "source disabled", policy: { venice: false }, known: false },
+    {
+      name: "non-authoritative source",
+      policy: { openRouter: { provider: "venice" } },
+      known: false,
+    },
+    {
+      name: "unowned policy",
+      policy: { venice: { provider: "venice" } },
+      unowned: true,
+      known: false,
+    },
+    {
+      name: "disabled plugin",
+      policy: { venice: { provider: "venice" } },
+      disabled: true,
+      known: false,
+    },
+    {
+      name: "private endpoint",
+      policy: { venice: { provider: "venice" } },
+      private: true,
+      known: false,
+    },
+    {
+      name: "normalized hosted alias",
+      policy: { venice: { provider: "venice" } },
+      alias: true,
+      known: false,
+    },
+    { name: "policy-free hosted alias", policy: undefined, alias: true, known: false },
+    {
+      name: "foreign owner key",
+      policy: { venice: { provider: "venice" } },
+      foreign: true,
+      known: false,
+    },
+  ])("requires exact authoritative hosted zero evidence: $name", (scenario) => {
+    const agentDir = tempDirs.make("openclaw-native-zero-policy-");
+    vi.stubEnv("OPENCLAW_STATE_DIR", agentDir);
+    const config: OpenClawConfig = {
+      plugins: { allow: ["venice"], entries: { venice: { enabled: !scenario.disabled } } },
+      ...(scenario.private
+        ? {
+            models: { providers: { venice: { baseUrl: "http://127.0.0.1:8080/v1", models: [] } } },
+          }
+        : {}),
+    };
+    const snapshot = pluginMetadata.resolvePluginMetadataSnapshot({ config, env: process.env });
+    const plugins = [...snapshot.manifestRegistry.plugins];
+    const ownerIndex = plugins.findIndex((plugin) => plugin.id === "venice");
+    plugins[ownerIndex] = {
+      ...expectDefined(plugins[ownerIndex], "Venice manifest owner"),
+      modelPricing: normalizeManifestModelPricing(
+        { providers: { venice: scenario.policy } },
+        { ownedProviders: new Set(scenario.unowned ? [] : ["venice"]) },
+      ),
+    };
+    vi.spyOn(pluginMetadata, "resolvePluginMetadataSnapshot").mockReturnValue({
+      ...snapshot,
+      manifestRegistry: { ...snapshot.manifestRegistry, plugins },
+    });
+    readStoredCatalog.mockReturnValue({
+      source_url: "https://catalog.openclaw.ai/models/v1/catalog.json",
+      bundle_json: JSON.stringify({
+        schemaVersion: 1,
+        generatedAt: 200,
+        sourceCommit: "native-zero-policy",
+        providers: { venice: { models: [{ id: "zero-fixture", cost: { input: 0, output: 0 } }] } },
+        pricing: {
+          [`${scenario.foreign ? "opencode" : scenario.alias ? "Venice" : "venice"}/zero-fixture`]:
+            { input: 0, output: 0 },
+        },
+      }),
+    });
+    const cost = resolveModelCostConfig({
+      config,
+      agentDir,
+      provider: "venice",
+      model: "zero-fixture",
+    });
+    expect(cost).toEqual(
+      scenario.known ? { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } : undefined,
+    );
+  });
+
   const catalogRates = { input: 2, output: 8, cacheRead: 0.5, cacheWrite: 1 };
   const catalogTiers = [
     { ...catalogRates, range: [0, 201] },
     { input: 4, output: 16, cacheRead: 1, cacheWrite: 2, range: [201, Infinity] },
   ];
+  const preparedRates = { input: 11, output: 13, cacheRead: 17, cacheWrite: 19 };
+  const preparedTiers = [{ ...preparedRates, range: [0, Infinity] }];
 
-  it.each([
-    {
-      name: "sizing-only",
-      cost: undefined,
-      expected: { ...catalogRates, tieredPricing: catalogTiers },
-    },
-    { name: "empty cost", cost: {}, expected: { ...catalogRates, tieredPricing: catalogTiers } },
-    { name: "partial cost", cost: { output: 3 }, expected: { ...catalogRates, output: 3 } },
-    {
-      name: "full cost",
-      cost: { input: 7, output: 9, cacheRead: 1, cacheWrite: 2 },
-      expected: { input: 7, output: 9, cacheRead: 1, cacheWrite: 2 },
-    },
-    {
-      name: "zero cost",
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      expected: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    },
-    { name: "empty tiers", cost: { tieredPricing: [] }, expected: catalogRates },
-    {
-      name: "authored tiers",
-      cost: { tieredPricing: [{ input: 7, output: 9, cacheRead: 1, cacheWrite: 2, range: [0] }] },
-      expected: {
-        ...catalogRates,
-        tieredPricing: [{ input: 7, output: 9, cacheRead: 1, cacheWrite: 2, range: [0, Infinity] }],
+  it.each(
+    [
+      {
+        name: "sizing-only",
+        cost: undefined,
+        expected: { ...catalogRates, tieredPricing: catalogTiers },
+        preparedExpected: { ...preparedRates, tieredPricing: preparedTiers },
+        total: undefined,
+        price: undefined,
       },
-    },
-  ])(
-    "resolves $name from authored source rather than materialized runtime rates",
-    ({ cost, expected }) => {
+      {
+        name: "empty cost",
+        cost: {},
+        expected: { ...catalogRates, tieredPricing: catalogTiers },
+        preparedExpected: { ...preparedRates, tieredPricing: preparedTiers },
+        total: undefined,
+        price: undefined,
+      },
+      {
+        name: "omitted cost with flat prepared rates",
+        cost: undefined,
+        flatPrepared: true,
+        expected: { ...catalogRates, tieredPricing: catalogTiers },
+        preparedExpected: preparedRates,
+        total: 0.06,
+        price: "$0.06",
+      },
+      {
+        name: "empty cost with flat prepared rates",
+        cost: {},
+        flatPrepared: true,
+        expected: { ...catalogRates, tieredPricing: catalogTiers },
+        preparedExpected: preparedRates,
+        total: 0.06,
+        price: "$0.06",
+      },
+      {
+        name: "partial cost",
+        cost: { output: 3 },
+        expected: { ...catalogRates, output: 3 },
+        preparedExpected: { ...preparedRates, output: 3 },
+        total: 0.05,
+        price: "$0.05",
+      },
+      {
+        name: "input/output-only cost",
+        cost: { input: 1, output: 2 },
+        expected: { ...catalogRates, input: 1, output: 2 },
+        preparedExpected: { ...preparedRates, input: 1, output: 2 },
+        total: 0.039,
+        price: "$0.04",
+      },
+      {
+        name: "full cost",
+        cost: { input: 7, output: 9, cacheRead: 1, cacheWrite: 2 },
+        expected: { input: 7, output: 9, cacheRead: 1, cacheWrite: 2 },
+        preparedExpected: { input: 7, output: 9, cacheRead: 1, cacheWrite: 2 },
+        total: 0.019,
+        price: "$0.02",
+      },
+      {
+        name: "zero cost",
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        expected: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        preparedExpected: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        total: 0,
+        price: "$0.0000",
+      },
+      {
+        name: "empty tiers",
+        cost: { tieredPricing: [] },
+        expected: catalogRates,
+        preparedExpected: preparedRates,
+        total: 0.06,
+        price: "$0.06",
+      },
+      {
+        name: "authored tiers",
+        cost: { tieredPricing: [{ input: 7, output: 9, cacheRead: 1, cacheWrite: 2, range: [0] }] },
+        expected: {
+          ...catalogRates,
+          tieredPricing: [
+            { input: 7, output: 9, cacheRead: 1, cacheWrite: 2, range: [0, Infinity] },
+          ],
+        },
+        preparedExpected: {
+          ...preparedRates,
+          tieredPricing: [
+            { input: 7, output: 9, cacheRead: 1, cacheWrite: 2, range: [0, Infinity] },
+          ],
+        },
+        total: undefined,
+        price: undefined,
+      },
+    ].flatMap(({ preparedExpected, ...testCase }) => [
+      { ...testCase, mode: "catalog", allowPluginNormalization: true },
+      {
+        ...testCase,
+        mode: "prepared",
+        allowPluginNormalization: false,
+        expected: preparedExpected,
+      },
+    ]),
+  )(
+    "resolves $name from authored source over $mode pricing",
+    ({ cost, expected, allowPluginNormalization, total, price, flatPrepared }) => {
       const source = {
+        messages: { responseUsage: "full" },
         models: {
           providers: {
             openai: {
@@ -155,17 +343,78 @@ describe("hosted model pricing", () => {
         runtime.models?.providers?.openai?.models[0],
         "materialized model",
       );
-      model.cost = { input: 99, output: 99, cacheRead: 99, cacheWrite: 99 };
+      model.cost = {
+        ...preparedRates,
+        ...(flatPrepared ? {} : { tieredPricing: [{ ...preparedRates, range: [0] }] }),
+      };
       setRuntimeConfigSnapshot(runtime, source);
       const agentDir = tempDirs.make("openclaw-authored-pricing-");
+      vi.stubEnv("OPENCLAW_STATE_DIR", agentDir);
+      const fetch = vi.fn(() => {
+        throw new Error("pricing display must not use the network");
+      });
+      vi.stubGlobal("fetch", fetch);
       for (const config of [runtime, structuredClone(runtime)]) {
-        expect(
-          resolveModelCostConfig({ config, agentDir, provider: "openai", model: "gpt-authored" }),
-        ).toEqual(expected);
-        expect(resolveModelCostConfigFingerprint(config, agentDir)).toBe(
-          resolveModelCostConfigFingerprint(source, agentDir),
+        resetUsageFormatCachesForTest();
+        const discoverySpies = allowPluginNormalization
+          ? []
+          : [
+              vi.spyOn(manifestNormalization, "normalizeProviderModelIdWithManifest"),
+              vi.spyOn(runtimeNormalization, "normalizeProviderModelIdWithRuntime"),
+              vi.spyOn(pluginMetadata, "resolvePluginMetadataSnapshot"),
+            ];
+        const params = { config, agentDir, provider: "openai", model: "gpt-authored" };
+        const resolvedCost = resolveModelCostConfig({ ...params, allowPluginNormalization });
+        expect.soft(resolvedCost).toEqual(expected);
+        if (allowPluginNormalization) {
+          expect(resolveModelCostConfigFingerprint(config, agentDir)).toBe(
+            resolveModelCostConfigFingerprint(source, agentDir),
+          );
+          continue;
+        }
+        const usage = { input: 1000, output: 1000, cacheRead: 1000, cacheWrite: 1000 };
+        const estimate = estimateAggregateUsageCost({ usage, cost: resolvedCost });
+        if (total === undefined) {
+          expect.soft(estimate).toBeUndefined();
+        } else {
+          expect.soft(estimate).toBeCloseTo(total);
+        }
+        expect
+          .soft(resolveResponseUsageLine({ ...params, usage }))
+          .toBe(
+            `Usage: 1.0k in / 1.0k out · cache 1.0k cached / 1.0k new${price ? ` · est ${price}` : ""}`,
+          );
+        for (const spy of discoverySpies) {
+          expect.soft(spy).not.toHaveBeenCalled();
+          spy.mockRestore();
+        }
+        const status = buildStatusMessageParts({
+          config,
+          agent: { model: "openai/gpt-authored" },
+          modelAuth: "api-key",
+          activeModelAuth: "api-key",
+          sessionEntry: {
+            sessionId: "prepared-pricing",
+            updatedAt: 0,
+            modelProvider: "openai",
+            model: "gpt-authored",
+            inputTokens: 1000,
+            outputTokens: 1000,
+            cacheRead: 1000,
+            cacheWrite: 1000,
+          },
+        });
+        if (price) {
+          expect.soft(status.text).toContain(`Cost: ${price}`);
+        } else {
+          expect.soft(status.text).not.toContain("Cost:");
+        }
+        const rows = status.presentation.blocks.flatMap((block) =>
+          block.type === "table" ? block.rows : [],
         );
+        expect.soft(rows.find((row) => row[0] === "💵 Cost")?.[1]).toBe(price);
       }
+      expect(fetch).not.toHaveBeenCalled();
       expect(model.contextWindow).toBe(64_000);
     },
   );
@@ -189,6 +438,24 @@ describe("hosted model pricing", () => {
       expect(
         resolveModelCostConfig({ config, agentDir, provider: "openai", model: "gpt-authored" }),
       ).toEqual({ ...catalogRates, output: 3 });
+      expect(
+        resolveModelCostConfig({
+          config,
+          agentDir,
+          provider: "openai",
+          model: "gpt-authored",
+          allowPluginNormalization: false,
+        }),
+      ).toEqual({ input: 0, output: 3, cacheRead: 0, cacheWrite: 0 });
+      expect(
+        resolveModelCostConfig({
+          config,
+          agentDir,
+          provider: "openai",
+          model: "missing",
+          allowPluginNormalization: false,
+        }),
+      ).toBeUndefined();
     },
   );
 

--- a/src/model-catalog/pricing.ts
+++ b/src/model-catalog/pricing.ts
@@ -1,5 +1,6 @@
 import { isIP } from "node:net";
 import type { RemoteModelCatalogPricing } from "@openclaw/model-catalog-core";
+import { MODEL_PRICING_SOURCES } from "@openclaw/model-catalog-core/model-catalog-pricing";
 import type { ModelCatalogCost } from "@openclaw/model-catalog-core/model-catalog-types";
 import { modelKey, normalizeModelRef } from "../agents/model-selection.js";
 import type { ModelDefinitionConfig } from "../config/types.models.js";
@@ -17,6 +18,7 @@ type PricingValue = RemoteModelCatalogPricing | ModelCatalogCost;
 type ManifestPlugins = readonly PluginManifestRegistry["plugins"][number][];
 type ExternalPricingPolicy = {
   external: boolean;
+  authoritative: boolean;
 };
 type PricingContext = {
   snapshot?: PluginMetadataSnapshot;
@@ -29,15 +31,6 @@ type PricingContext = {
 
 const EMPTY_CONFIG: OpenClawConfig = {};
 const pricingContextByConfig = new WeakMap<OpenClawConfig, PricingContext>();
-
-function normalizePolicy(
-  policy: { external?: boolean } | undefined,
-): ExternalPricingPolicy | undefined {
-  if (!policy) {
-    return undefined;
-  }
-  return { external: policy.external !== false };
-}
 
 function activeManifestRegistry(
   snapshot: PluginMetadataSnapshot,
@@ -87,11 +80,13 @@ function buildPricingContext(config: OpenClawConfig): PricingContext {
   }
   const policies = new Map<string, ExternalPricingPolicy>();
   for (const plugin of registry.plugins) {
-    for (const [provider, rawPolicy] of Object.entries(plugin.modelPricing?.providers ?? {})) {
-      const policy = normalizePolicy(rawPolicy);
-      if (policy) {
-        policies.set(provider, policy);
-      }
+    for (const [provider, policy] of Object.entries(plugin.modelPricing?.providers ?? {})) {
+      policies.set(provider, {
+        external: policy.external !== false,
+        authoritative: MODEL_PRICING_SOURCES.some(
+          ({ id, authoritative }) => authoritative && Boolean(policy[id]),
+        ),
+      });
     }
   }
   // Hosted aliases are policy-resolved against installed manifests. If that metadata is
@@ -229,13 +224,14 @@ export function resolveCatalogModelPricing(params: {
   if (catalog && hasKnownPricing(catalog)) {
     return catalog;
   }
-  if (context.policies.get(normalized.provider)?.external === false) {
+  const policy = context.policies.get(normalized.provider);
+  if (policy?.external === false) {
     return undefined;
   }
-  const hosted =
-    context.hosted[key] ??
-    (context.policies.has(normalized.provider) ? undefined : context.normalizedHosted.get(key));
-  return hosted && hasKnownPricing(hosted) ? hosted : undefined;
+  const hosted = context.hosted[key] ?? (policy ? undefined : context.normalizedHosted.get(key));
+  // The publisher retains validated native zeros under exact owner keys. Catalog
+  // placeholders and normalized aliases cannot establish an authoritative free rate.
+  return hosted && (hasKnownPricing(hosted) || policy?.authoritative) ? hosted : undefined;
 }
 
 export function modelCatalogPricingFingerprint(config?: OpenClawConfig): string {

--- a/src/model-catalog/pricing.ts
+++ b/src/model-catalog/pricing.ts
@@ -224,31 +224,18 @@ export function resolveCatalogModelPricing(params: {
   ) {
     return undefined;
   }
-  const pricing = context.catalog.get(modelKey(normalized.provider, normalized.model));
-  return pricing && hasKnownPricing(pricing) ? pricing : undefined;
-}
-
-export function resolveHostedModelPricing(params: {
-  config?: OpenClawConfig;
-  provider: string;
-  model: string;
-}): PricingValue | undefined {
-  const config = params.config ?? EMPTY_CONFIG;
-  const context = getPricingContext(config);
-  const normalized = normalizeModelRef(params.provider, params.model, {
-    manifestPlugins: context.snapshot?.plugins,
-  });
-  if (
-    context.policies.get(normalized.provider)?.external === false ||
-    !allowsHostedPricing(config, normalized.provider, normalized.model, context.snapshot?.plugins)
-  ) {
+  const key = modelKey(normalized.provider, normalized.model);
+  const catalog = context.catalog.get(key);
+  if (catalog && hasKnownPricing(catalog)) {
+    return catalog;
+  }
+  if (context.policies.get(normalized.provider)?.external === false) {
     return undefined;
   }
-  const key = modelKey(normalized.provider, normalized.model);
-  const pricing =
+  const hosted =
     context.hosted[key] ??
     (context.policies.has(normalized.provider) ? undefined : context.normalizedHosted.get(key));
-  return pricing && hasKnownPricing(pricing) ? pricing : undefined;
+  return hosted && hasKnownPricing(hosted) ? hosted : undefined;
 }
 
 export function modelCatalogPricingFingerprint(config?: OpenClawConfig): string {

--- a/src/plugin-sdk/provider-catalog-live-normalize.internal.ts
+++ b/src/plugin-sdk/provider-catalog-live-normalize.internal.ts
@@ -1,3 +1,4 @@
+import { normalizeUpstreamModelPricing } from "@openclaw/model-catalog-core/model-catalog-pricing";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "./provider-model-shared.js";
 
@@ -358,53 +359,6 @@ export function buildOpenAICompatibleLiveModels(
   );
 }
 
-function readUpstreamProviderCatalogCostValue(value: unknown): number {
-  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : 0;
-}
-
-function readUpstreamProviderCatalogCost(rawCost: Record<string, unknown> | undefined) {
-  return {
-    input: readUpstreamProviderCatalogCostValue(rawCost?.input),
-    output: readUpstreamProviderCatalogCostValue(rawCost?.output),
-    cacheRead: readUpstreamProviderCatalogCostValue(rawCost?.cache_read),
-    cacheWrite: readUpstreamProviderCatalogCostValue(rawCost?.cache_write),
-  };
-}
-
-function buildUpstreamProviderCatalogCost(value: unknown): ModelDefinitionConfig["cost"] {
-  const rawCost = readLiveModelCatalogRecord(value);
-  const cost = readUpstreamProviderCatalogCost(rawCost);
-  const upstreamTiers = (Array.isArray(rawCost?.tiers) ? rawCost.tiers : [])
-    .flatMap((rawTier) => {
-      const row = readLiveModelCatalogRecord(rawTier);
-      const tier = readLiveModelCatalogRecord(row?.tier);
-      const size = readLiveModelCatalogPositiveSafeIntegerField(tier, "size");
-      return tier?.type === "context" && size
-        ? [{ size, cost: readUpstreamProviderCatalogCost(row) }]
-        : [];
-    })
-    .toSorted((left, right) => left.size - right.size);
-  const legacyCost = readLiveModelCatalogRecord(rawCost?.context_over_200k);
-  if (upstreamTiers.length === 0 && legacyCost) {
-    upstreamTiers.push({ size: 200_000, cost: readUpstreamProviderCatalogCost(legacyCost) });
-  }
-  const firstTier = upstreamTiers[0];
-  if (!firstTier) {
-    return cost;
-  }
-  const tieredPricing: NonNullable<ModelDefinitionConfig["cost"]["tieredPricing"]> = [
-    { ...cost, range: [0, firstTier.size] },
-  ];
-  for (const [index, tier] of upstreamTiers.entries()) {
-    const nextThreshold = upstreamTiers[index + 1]?.size;
-    tieredPricing.push({
-      ...tier.cost,
-      range: nextThreshold ? [tier.size, nextThreshold] : [tier.size],
-    });
-  }
-  return { ...cost, tieredPricing };
-}
-
 function parseUpstreamProviderCatalogUrl(value: string): URL | undefined {
   try {
     return new URL(value);
@@ -501,7 +455,12 @@ export function projectUpstreamProviderCatalogModel(params: {
     baseUrl,
     reasoning: readLiveModelCatalogBooleanField(model, "reasoning") ?? false,
     input,
-    cost: buildUpstreamProviderCatalogCost(model.cost),
+    cost: normalizeUpstreamModelPricing(model.cost) ?? {
+      input: 0,
+      output: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+    },
     contextWindow,
     ...(contextTokens && contextTokens <= contextWindow ? { contextTokens } : {}),
     maxTokens,

--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -21,7 +21,6 @@ import {
 } from "./provider-catalog-live-normalize.internal.js";
 import {
   buildSingleProviderApiKeyCatalog,
-  clearLiveCatalogCacheForTests,
   getCachedLiveCatalogValue,
 } from "./provider-catalog-shared.js";
 import type { ManifestProviderCatalogEntry } from "./provider-catalog-shared.js";
@@ -44,7 +43,8 @@ export type LiveModelCatalogHeaderContext = {
   discoveryApiKey?: string;
 };
 
-export { clearLiveCatalogCacheForTests };
+export { normalizeOpenRouterModelPricing } from "@openclaw/model-catalog-core/model-catalog-pricing";
+export { clearLiveCatalogCacheForTests } from "./provider-catalog-shared.js";
 export {
   readLiveModelCatalogBooleanField,
   readLiveModelCatalogPositiveSafeIntegerField,

--- a/src/plugins/manifest-model-provider-normalizers.ts
+++ b/src/plugins/manifest-model-provider-normalizers.ts
@@ -1,3 +1,4 @@
+import { normalizeModelPricingProvider } from "@openclaw/model-catalog-core/model-catalog-pricing";
 import { normalizeModelCatalogProviderId } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { normalizeOptionalString } from "../../packages/normalization-core/src/string-coerce.js";
 import { normalizeTrimmedStringList } from "../../packages/normalization-core/src/string-normalization.js";
@@ -10,9 +11,6 @@ import type {
   PluginManifestModelIdNormalizationProvider,
   PluginManifestModelIdPrefixRule,
   PluginManifestModelPricing,
-  PluginManifestModelPricingModelIdTransform,
-  PluginManifestModelPricingProvider,
-  PluginManifestModelPricingSource,
   PluginManifestModelSupport,
   PluginManifestProviderEndpoint,
   PluginManifestProviderRequest,
@@ -42,43 +40,6 @@ export function normalizeManifestModelSupport(
   } satisfies PluginManifestModelSupport;
 
   return Object.keys(modelSupport).length > 0 ? modelSupport : undefined;
-}
-
-function normalizeManifestModelPricingSource(
-  value: unknown,
-): PluginManifestModelPricingSource | false | undefined {
-  if (value === false) {
-    return false;
-  }
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const provider = normalizeModelCatalogProviderId(normalizeOptionalString(value.provider) ?? "");
-  const modelIdTransforms = normalizeTrimmedStringList(value.modelIdTransforms).filter(
-    (entry): entry is PluginManifestModelPricingModelIdTransform => entry === "version-dots",
-  );
-  const source = {
-    ...(provider ? { provider } : {}),
-    ...(value.passthroughProviderModel === true ? { passthroughProviderModel: true } : {}),
-    ...(modelIdTransforms.length > 0 ? { modelIdTransforms } : {}),
-  } satisfies PluginManifestModelPricingSource;
-  return Object.keys(source).length > 0 ? source : undefined;
-}
-
-function normalizeManifestModelPricingProvider(
-  value: unknown,
-): PluginManifestModelPricingProvider | undefined {
-  if (!isRecord(value)) {
-    return undefined;
-  }
-  const openRouter = normalizeManifestModelPricingSource(value.openRouter);
-  const liteLLM = normalizeManifestModelPricingSource(value.liteLLM);
-  const policy = {
-    ...(typeof value.external === "boolean" ? { external: value.external } : {}),
-    ...(openRouter !== undefined ? { openRouter } : {}),
-    ...(liteLLM !== undefined ? { liteLLM } : {}),
-  } satisfies PluginManifestModelPricingProvider;
-  return Object.keys(policy).length > 0 ? policy : undefined;
 }
 
 function normalizeOwnedProviderMap<T>(
@@ -112,7 +73,7 @@ export function normalizeManifestModelPricing(
   const providers = normalizeOwnedProviderMap(
     value,
     params.ownedProviders,
-    normalizeManifestModelPricingProvider,
+    normalizeModelPricingProvider,
   );
   return providers ? { providers } : undefined;
 }

--- a/src/plugins/manifest-types.ts
+++ b/src/plugins/manifest-types.ts
@@ -1,3 +1,4 @@
+import type { ModelPricingProvider } from "@openclaw/model-catalog-core/model-catalog-pricing";
 import type { ModelCatalog } from "@openclaw/model-catalog-core/model-catalog-types";
 import type { ChannelConfigRuntimeSchema } from "../channels/plugins/types.config.js";
 import type { ConfigUiPresentation } from "../shared/config-ui-hints-types.js";
@@ -73,22 +74,8 @@ export type PluginManifestModelSupport = {
 
 export type PluginManifestModelCatalog = ModelCatalog;
 
-export type PluginManifestModelPricingModelIdTransform = "version-dots";
-
-export type PluginManifestModelPricingSource = {
-  provider?: string;
-  passthroughProviderModel?: boolean;
-  modelIdTransforms?: PluginManifestModelPricingModelIdTransform[];
-};
-
-export type PluginManifestModelPricingProvider = {
-  external?: boolean;
-  openRouter?: PluginManifestModelPricingSource | false;
-  liteLLM?: PluginManifestModelPricingSource | false;
-};
-
 export type PluginManifestModelPricing = {
-  providers?: Record<string, PluginManifestModelPricingProvider>;
+  providers?: Record<string, ModelPricingProvider>;
 };
 
 export type PluginManifestModelIdPrefixRule = {

--- a/src/plugins/sdk-alias.test.ts
+++ b/src/plugins/sdk-alias.test.ts
@@ -1293,6 +1293,11 @@ describe("plugin sdk alias helpers", () => {
       ["@openclaw/net-policy/ip", "net-policy", "ip"],
       ["@openclaw/net-policy/url-protocol", "net-policy", "url-protocol"],
       ["@openclaw/model-catalog-core/provider-id", "model-catalog-core", "provider-id"],
+      [
+        "@openclaw/model-catalog-core/model-catalog-pricing",
+        "model-catalog-core",
+        "model-catalog-pricing",
+      ],
     ]);
     for (const entry of workspaceAliases) {
       fs.rmSync(entry.distFile);
@@ -1345,6 +1350,11 @@ describe("plugin sdk alias helpers", () => {
         "@openclaw/model-catalog-core/provider-model-id-normalize",
         "model-catalog-core",
         "provider-model-id-normalize",
+      ],
+      [
+        "@openclaw/model-catalog-core/model-catalog-pricing",
+        "model-catalog-core",
+        "model-catalog-pricing",
       ],
     ]);
     const sourcePluginEntry = writePluginEntry(

--- a/src/plugins/sdk-alias.ts
+++ b/src/plugins/sdk-alias.ts
@@ -573,6 +573,7 @@ const WORKSPACE_PACKAGE_ALIAS_SUBPATHS = [
       "configured-model-refs",
       "model-catalog-refs",
       "model-catalog-normalize",
+      "model-catalog-pricing",
       "model-catalog-types",
       "provider-id",
       "provider-model-id-normalization",

--- a/src/utils/usage-format.test.ts
+++ b/src/utils/usage-format.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
 import * as manifestModelIdNormalization from "../plugins/manifest-model-id-normalization.js";
 import { captureEnv } from "../test-utils/env.js";
 import {
@@ -431,6 +432,134 @@ describe("usage-format", () => {
       cacheWrite: 4,
     });
     expect(manifestSpy).not.toHaveBeenCalled();
+  });
+
+  const firstRates = { input: 1, output: 2, cacheRead: 0.1, cacheWrite: 0.2 };
+  const laterRates = { input: 7, output: 8, cacheRead: 0.7, cacheWrite: 0.8 };
+  const laterTiers = [{ ...laterRates, range: [0, Infinity] as [number, number] }];
+  it.each([
+    { name: "full", cost: firstRates, expected: firstRates },
+    { name: "partial", cost: { output: 0 }, expected: { ...laterRates, output: 0 } },
+    {
+      name: "zero",
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      expected: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    },
+    { name: "empty", cost: {}, expected: { ...laterRates, tieredPricing: laterTiers } },
+    { name: "omitted", cost: undefined, expected: { ...laterRates, tieredPricing: laterTiers } },
+    { name: "empty tiers", cost: { tieredPricing: [] }, expected: laterRates },
+    {
+      name: "authored tiers",
+      cost: { tieredPricing: [{ ...firstRates, range: [0] }] },
+      expected: {
+        ...laterRates,
+        tieredPricing: [{ ...firstRates, range: [0, Infinity] }],
+      },
+    },
+  ])("merges duplicate model rows with first-authored $name cost", ({ cost, expected }) => {
+    const config = {
+      models: {
+        providers: {
+          venice: {
+            models: [
+              { id: "priced-fixture", cost },
+              { id: "priced-fixture", cost: { ...laterRates, tieredPricing: laterTiers } },
+            ],
+          },
+        },
+      },
+    } as unknown as OpenClawConfig;
+    expect(
+      resolveModelCostConfig({ config, agentDir, provider: "venice", model: "priced-fixture" }),
+    ).toEqual(expected);
+  });
+
+  it("refreshes duplicate model prices and fingerprints after ordered source mutations", () => {
+    type SourceModel = { id: string; cost?: Partial<ModelDefinitionConfig["cost"]> };
+    const first: SourceModel = { id: "priced-fixture", cost: { ...firstRates } };
+    const later: SourceModel = { id: "priced-fixture", cost: { ...laterRates } };
+    const models = [first, later];
+    const config = {
+      models: { providers: { venice: { models } } },
+    } as unknown as OpenClawConfig;
+    let previousFingerprint: string | undefined;
+    const check = (label: string, expected: ModelCostConfig | undefined) => {
+      expect
+        .soft(
+          resolveModelCostConfig({ config, agentDir, provider: "venice", model: "priced-fixture" }),
+          label,
+        )
+        .toEqual(expected);
+      const fingerprint = resolveModelCostConfigFingerprint(config, agentDir);
+      expect.soft(fingerprint, label).not.toBe(previousFingerprint);
+      previousFingerprint = fingerprint;
+      // Fingerprinting refreshes the full index; it must agree with direct lookups.
+      expect
+        .soft(
+          resolveModelCostConfig({ config, agentDir, provider: "venice", model: "priced-fixture" }),
+          label,
+        )
+        .toEqual(expected);
+    };
+    check("initial duplicates", firstRates);
+    first.cost!.input = 9;
+    check("mutated first cost", { ...firstRates, input: 9 });
+    delete first.cost;
+    check("removed first cost", laterRates);
+    first.cost = { output: 0 };
+    check("restored partial cost", { ...laterRates, output: 0 });
+    const inserted = { id: "priced-fixture", cost: { ...firstRates, input: 3 } };
+    models.unshift(inserted);
+    check("inserted duplicate", inserted.cost);
+    models.reverse();
+    check("reordered duplicates", laterRates);
+    models[0] = { id: "priced-fixture", cost: { ...firstRates, input: 4 } };
+    check("replaced same-id row", { ...firstRates, input: 4 });
+    models.shift();
+    check("removed duplicate", { ...inserted.cost, output: 0 });
+    models.splice(0);
+    check("removed all rows", undefined);
+  });
+
+  it.each(["canonical first", "canonical last", "aliases only"])(
+    "selects the canonical provider price owner with %s",
+    (order) => {
+      const canonical = { models: [{ id: "priced-fixture", cost: firstRates }] };
+      const alias = { models: [{ id: "priced-fixture", cost: laterRates }] };
+      const providers =
+        order === "canonical first"
+          ? { venice: canonical, " VENICE ": alias }
+          : order === "canonical last"
+            ? { " VENICE ": alias, venice: canonical }
+            : { " Venice ": alias, " VENICE ": canonical };
+      const config = { models: { providers } } as unknown as OpenClawConfig;
+      expect(
+        resolveModelCostConfig({ config, agentDir, provider: "venice", model: "priced-fixture" }),
+      ).toEqual(firstRates);
+    },
+  );
+
+  it("preserves explicit models.json precedence while merging its duplicate rows and provider keys", async () => {
+    const config = {
+      models: { providers: { venice: { models: [{ id: "priced-fixture", cost: laterRates }] } } },
+    } as unknown as OpenClawConfig;
+    await fs.writeFile(
+      path.join(agentDir, "models.json"),
+      JSON.stringify({
+        providers: {
+          venice: {
+            models: [
+              { id: "priced-fixture", cost: { output: 0 } },
+              { id: "priced-fixture", cost: firstRates },
+            ],
+          },
+          " VENICE ": { models: [{ id: "priced-fixture", cost: laterRates }] },
+        },
+      }),
+    );
+    expect(
+      resolveModelCostConfig({ config, agentDir, provider: "venice", model: "priced-fixture" }),
+    ).toEqual({ ...firstRates, output: 0 });
   });
 
   it("observes in-place config pricing changes after a cached lookup", () => {

--- a/src/utils/usage-format.test.ts
+++ b/src/utils/usage-format.test.ts
@@ -431,6 +431,14 @@ describe("usage-format", () => {
       cacheRead: 3,
       cacheWrite: 4,
     });
+    expect(
+      resolveModelCostConfig({
+        provider: "anthropic",
+        model: "missing-model",
+        config,
+        allowPluginNormalization: false,
+      }),
+    ).toBeUndefined();
     expect(manifestSpy).not.toHaveBeenCalled();
   });
 

--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -18,8 +18,11 @@ import {
   tryResolveDefaultAgentId,
 } from "../agents/agent-scope-config.js";
 import { modelKey, normalizeModelRef, normalizeProviderId } from "../agents/model-selection.js";
+import { normalizeProviderMapKeys } from "../agents/models-config.merge.js";
 import type { NormalizedUsage } from "../agents/usage.js";
+import { mergeModelCost } from "../config/model-cost.js";
 import { resolveStateDir } from "../config/paths.js";
+import { projectConfigOntoRuntimeSourceSnapshot } from "../config/runtime-source-projection.js";
 import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { tryReadJsonSync } from "../infra/json-files.js";
@@ -27,7 +30,6 @@ import { pruneMapToMaxSize } from "../infra/map-size.js";
 import {
   modelCatalogPricingFingerprint,
   resolveCatalogModelPricing,
-  resolveHostedModelPricing,
 } from "../model-catalog/pricing.js";
 export { formatTokenCount } from "./token-format.js";
 export type { ModelCostConfig } from "@openclaw/llm-core";
@@ -35,8 +37,8 @@ export type { ModelCostConfig } from "@openclaw/llm-core";
 type ModelsJsonCostCache = {
   path: string;
   providers: Record<string, ModelProviderConfig> | undefined;
-  normalizedEntries: Map<string, ModelCostConfig> | null;
-  rawEntries: Map<string, ModelCostConfig> | null;
+  normalizedEntries: Map<string, RawModelCostConfig> | null;
+  rawEntries: Map<string, RawModelCostConfig> | null;
 };
 
 type ProviderCostIndexCacheEntry = {
@@ -45,19 +47,18 @@ type ProviderCostIndexCacheEntry = {
 };
 
 type ProviderCostIndexSource = {
-  fingerprint: string;
   model: NonNullable<ModelProviderConfig["models"]>[number];
   providerKey: string;
-  rawCost: RawModelCostConfig;
+  modelId: string;
 };
 
 type ProviderCostIndex = {
-  entries: Map<string, ModelCostConfig>;
-  sources: Map<string, ProviderCostIndexSource>;
-  structureFingerprint: string;
+  entries: Map<string, RawModelCostConfig>;
+  sources: Map<string, ProviderCostIndexSource["model"][]>;
+  structure: ProviderCostIndexSource[];
 };
 
-const EMPTY_PROVIDER_COST_INDEX = new Map<string, ModelCostConfig>();
+const EMPTY_PROVIDER_COST_INDEX = new Map<string, RawModelCostConfig>();
 const MODELS_JSON_COST_CACHE_LIMIT = 128;
 const MODEL_KEY_CACHE_LIMIT = 4096;
 
@@ -144,70 +145,55 @@ function isRawModelCostConfig(value: unknown): value is RawModelCostConfig {
   return value !== null && typeof value === "object";
 }
 
-function buildProviderCostStructureFingerprint(
-  providers: Record<string, ModelProviderConfig> | undefined,
-): string {
-  if (!providers) {
-    return "";
-  }
-  return Object.entries(providers)
-    .toSorted(([a], [b]) => a.localeCompare(b))
-    .flatMap(([providerKey, providerConfig]) =>
-      (providerConfig?.models ?? []).map(
-        (model) =>
-          `${providerKey}\0${model.id}\0${isRawModelCostConfig(model.cost) ? "cost" : "metadata"}`,
-      ),
-    )
-    .join("\0");
+function collectProviderCostSources(
+  providers: Record<string, ModelProviderConfig>,
+): ProviderCostIndexSource[] {
+  return Object.entries(normalizeProviderMapKeys(providers)).flatMap(([providerKey, provider]) =>
+    (provider?.models ?? []).map((model) => ({ providerKey, model, modelId: model.id })),
+  );
 }
 
 function buildProviderCostIndexBundle(
-  providers: Record<string, ModelProviderConfig> | undefined,
+  structure: ProviderCostIndexSource[],
   options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
 ): ProviderCostIndex {
-  const entries = new Map<string, ModelCostConfig>();
-  const sources = new Map<string, ProviderCostIndexSource>();
-  const structureFingerprint = buildProviderCostStructureFingerprint(providers);
-  if (!providers) {
-    return { entries, sources, structureFingerprint };
+  const sources: ProviderCostIndex["sources"] = new Map();
+  for (const { providerKey, model, modelId } of structure) {
+    const normalized = normalizeModelRef(providerKey, modelId, {
+      allowManifestNormalization:
+        options?.allowManifestNormalization ??
+        (options?.allowPluginNormalization === false ? false : undefined),
+      allowPluginNormalization: options?.allowPluginNormalization,
+    });
+    const key = modelKey(normalized.provider, normalized.model);
+    const rows = sources.get(key) ?? [];
+    rows.push(model);
+    sources.set(key, rows);
   }
-  for (const [providerKey, providerConfig] of Object.entries(providers)) {
-    const normalizedProvider = normalizeProviderId(providerKey);
-    for (const model of providerConfig?.models ?? []) {
-      const normalized = normalizeModelRef(normalizedProvider, model.id, {
-        allowManifestNormalization:
-          options?.allowManifestNormalization ??
-          (options?.allowPluginNormalization === false ? false : undefined),
-        allowPluginNormalization: options?.allowPluginNormalization,
-      });
-      const key = modelKey(normalized.provider, normalized.model);
-      if (!isRawModelCostConfig(model.cost)) {
-        continue;
-      }
-      const rawCost = model.cost;
-      entries.set(key, normalizeModelCostConfig(rawCost));
-      sources.set(key, {
-        fingerprint: buildModelCostFingerprint(rawCost),
-        model,
-        providerKey,
-        rawCost,
-      });
-    }
-  }
-  return { entries, sources, structureFingerprint };
+  return { entries: new Map(), sources, structure };
 }
 
-function buildProviderCostIndex(
-  providers: Record<string, ModelProviderConfig> | undefined,
-  options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
-): Map<string, ModelCostConfig> {
-  return buildProviderCostIndexBundle(providers, options).entries;
+function refreshProviderCostIndexEntry(index: ProviderCostIndex, key: string): void {
+  // Retain every row, including metadata-only rows, so edits cannot resurrect
+  // a later duplicate's price or turn a removed cost into an authored pin.
+  let cost: RawModelCostConfig | undefined;
+  for (const model of index.sources.get(key) ?? []) {
+    if (isRawModelCostConfig(model.cost)) {
+      cost = mergeModelCost(model.cost, cost);
+    }
+  }
+  if (cost) {
+    index.entries.set(key, cost);
+  } else {
+    index.entries.delete(key);
+  }
 }
 
 function getProviderCostIndex(
   providers: Record<string, ModelProviderConfig> | undefined,
   options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
-): Map<string, ModelCostConfig> {
+  key?: string,
+): Map<string, RawModelCostConfig> {
   if (!providers) {
     return EMPTY_PROVIDER_COST_INDEX;
   }
@@ -218,51 +204,45 @@ function getProviderCostIndex(
   const isDefaultNormalizedLookup =
     options?.allowPluginNormalization !== false &&
     options?.allowManifestNormalization === undefined;
-  if (!isRawLookup && !isDefaultNormalizedLookup) {
-    return buildProviderCostIndex(providers, options);
-  }
-
   let cache = providerCostIndexByConfig.get(providers);
   if (!cache) {
     cache = {};
     providerCostIndexByConfig.set(providers, cache);
   }
-  if (isRawLookup) {
-    cache.rawEntries ??= buildProviderCostIndexBundle(providers, {
-      allowManifestNormalization: false,
-      allowPluginNormalization: false,
-    });
-    const rawOptions = {
-      allowManifestNormalization: false,
-      allowPluginNormalization: false,
-    };
-    if (refreshProviderCostIndexMutations(cache.rawEntries, providers, rawOptions) === "rebuild") {
-      cache.rawEntries = buildProviderCostIndexBundle(providers, rawOptions);
-    }
-    if (
-      cache.rawEntries.structureFingerprint !== buildProviderCostStructureFingerprint(providers)
-    ) {
-      cache.rawEntries = buildProviderCostIndexBundle(providers, rawOptions);
-    }
-    return cache.rawEntries.entries;
-  }
-  cache.normalizedEntries ??= buildProviderCostIndexBundle(providers);
-  if (refreshProviderCostIndexMutations(cache.normalizedEntries, providers) === "rebuild") {
-    cache.normalizedEntries = buildProviderCostIndexBundle(providers);
-  }
+  const cacheKey = isRawLookup ? "rawEntries" : "normalizedEntries";
+  const cacheable = isRawLookup || isDefaultNormalizedLookup;
+  let index = cacheable ? cache[cacheKey] : undefined;
+  const structure = collectProviderCostSources(providers);
+  // Identity and order matter even when duplicate rows have the same id.
+  // Prices stay live on their source rows; only membership/id changes rebuild keys.
   if (
-    cache.normalizedEntries.structureFingerprint !==
-    buildProviderCostStructureFingerprint(providers)
+    !index ||
+    index.structure.length !== structure.length ||
+    index.structure.some((source, position) => {
+      const current = structure[position];
+      return (
+        !current ||
+        source.model !== current.model ||
+        source.modelId !== current.modelId ||
+        source.providerKey !== current.providerKey
+      );
+    })
   ) {
-    cache.normalizedEntries = buildProviderCostIndexBundle(providers);
+    index = buildProviderCostIndexBundle(structure, options);
+    if (cacheable) {
+      cache[cacheKey] = index;
+    }
   }
-  return cache.normalizedEntries.entries;
+  for (const entryKey of key === undefined ? index.sources.keys() : [key]) {
+    refreshProviderCostIndexEntry(index, entryKey);
+  }
+  return index.entries;
 }
 
 function loadModelsJsonCostIndex(options?: {
   agentDir?: string;
   allowPluginNormalization?: boolean;
-}): Map<string, ModelCostConfig> {
+}): Map<string, RawModelCostConfig> {
   const useRawEntries = options?.allowPluginNormalization === false;
   const agentDir = options?.agentDir;
   if (!agentDir) {
@@ -320,14 +300,16 @@ function findConfiguredProviderCost(params: {
   model?: string;
   config?: OpenClawConfig;
   allowPluginNormalization?: boolean;
-}): ModelCostConfig | undefined {
+}): RawModelCostConfig | undefined {
   const key = toResolvedModelKey(params);
   if (!key) {
     return undefined;
   }
-  return getProviderCostFromIndex(params.config?.models?.providers, key, {
-    allowPluginNormalization: params.allowPluginNormalization,
-  });
+  return getProviderCostIndex(
+    params.config?.models?.providers,
+    { allowPluginNormalization: params.allowPluginNormalization },
+    key,
+  ).get(key);
 }
 
 function stableCostFingerprintValue(value: unknown): string {
@@ -348,163 +330,9 @@ function stableCostFingerprintValue(value: unknown): string {
     .join(",")}}`;
 }
 
-function buildModelCostFingerprint(cost: RawModelCostConfig): string {
-  const tierFingerprint = Array.isArray(cost.tieredPricing)
-    ? cost.tieredPricing.flatMap((tier) => {
-        const range = Array.isArray(tier.range) ? tier.range : [];
-        return [tier.input, tier.output, tier.cacheRead, tier.cacheWrite, ...range];
-      })
-    : [];
-  return [cost.input, cost.output, cost.cacheRead, cost.cacheWrite, ...tierFingerprint].join("|");
-}
-
-function isProviderCostSourceCurrent(
-  providers: Record<string, ModelProviderConfig>,
-  source: ProviderCostIndexSource,
-  key: string,
-  options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
-): boolean {
-  const providerConfig = providers[source.providerKey];
-  if (!providerConfig?.models?.includes(source.model)) {
-    return false;
-  }
-  const normalized = normalizeModelRef(normalizeProviderId(source.providerKey), source.model.id, {
-    allowManifestNormalization:
-      options?.allowManifestNormalization ??
-      (options?.allowPluginNormalization === false ? false : undefined),
-    allowPluginNormalization: options?.allowPluginNormalization,
-  });
-  return modelKey(normalized.provider, normalized.model) === key;
-}
-
-function refreshProviderCostIndexEntry(
-  index: ProviderCostIndex,
-  key: string,
-  providers?: Record<string, ModelProviderConfig>,
-  options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
-): "current" | "rebuild" {
-  const source = index.sources.get(key);
-  if (!source) {
-    return "current";
-  }
-  if (providers && !isProviderCostSourceCurrent(providers, source, key, options)) {
-    return "rebuild";
-  }
-  if (!isRawModelCostConfig(source.model.cost)) {
-    return "rebuild";
-  }
-  if (source.model.cost !== source.rawCost) {
-    source.rawCost = source.model.cost;
-  }
-  const fingerprint = buildModelCostFingerprint(source.rawCost);
-  if (source.fingerprint === fingerprint) {
-    return "current";
-  }
-  source.fingerprint = fingerprint;
-  index.entries.set(key, normalizeModelCostConfig(source.rawCost));
-  return "current";
-}
-
-function refreshProviderCostIndexMutations(
-  index: ProviderCostIndex,
-  providers?: Record<string, ModelProviderConfig>,
-  options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
-): "current" | "rebuild" {
-  for (const key of index.sources.keys()) {
-    if (refreshProviderCostIndexEntry(index, key, providers, options) === "rebuild") {
-      return "rebuild";
-    }
-  }
-  return "current";
-}
-
-function hasProviderCostSourceForKey(
-  providers: Record<string, ModelProviderConfig>,
-  key: string,
-  options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
-): boolean {
-  for (const [providerKey, providerConfig] of Object.entries(providers)) {
-    const normalizedProvider = normalizeProviderId(providerKey);
-    for (const model of providerConfig?.models ?? []) {
-      if (!isRawModelCostConfig(model.cost)) {
-        continue;
-      }
-      const normalized = normalizeModelRef(normalizedProvider, model.id, {
-        allowManifestNormalization:
-          options?.allowManifestNormalization ??
-          (options?.allowPluginNormalization === false ? false : undefined),
-        allowPluginNormalization: options?.allowPluginNormalization,
-      });
-      if (modelKey(normalized.provider, normalized.model) === key) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
-function getProviderCostFromIndex(
-  providers: Record<string, ModelProviderConfig> | undefined,
-  key: string,
-  options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
-): ModelCostConfig | undefined {
-  if (!providers) {
-    return undefined;
-  }
-  const isRawLookup =
-    options?.allowPluginNormalization === false &&
-    (options.allowManifestNormalization === false ||
-      options.allowManifestNormalization === undefined);
-  const isDefaultNormalizedLookup =
-    options?.allowPluginNormalization !== false &&
-    options?.allowManifestNormalization === undefined;
-  if (!isRawLookup && !isDefaultNormalizedLookup) {
-    return buildProviderCostIndex(providers, options).get(key);
-  }
-
-  let cache = providerCostIndexByConfig.get(providers);
-  if (!cache) {
-    cache = {};
-    providerCostIndexByConfig.set(providers, cache);
-  }
-  const index = isRawLookup
-    ? (cache.rawEntries ??= buildProviderCostIndexBundle(providers, {
-        allowManifestNormalization: false,
-        allowPluginNormalization: false,
-      }))
-    : (cache.normalizedEntries ??= buildProviderCostIndexBundle(providers));
-  const sourceMissingWithStructuralChange =
-    !index.sources.has(key) &&
-    index.structureFingerprint !== buildProviderCostStructureFingerprint(providers);
-  const sourceMissingWithNewCost =
-    !index.sources.has(key) && hasProviderCostSourceForKey(providers, key, options);
-  if (
-    refreshProviderCostIndexEntry(index, key, providers, options) === "rebuild" ||
-    sourceMissingWithStructuralChange ||
-    sourceMissingWithNewCost
-  ) {
-    const rebuilt = buildProviderCostIndexBundle(
-      providers,
-      isRawLookup
-        ? {
-            allowManifestNormalization: false,
-            allowPluginNormalization: false,
-          }
-        : undefined,
-    );
-    if (isRawLookup) {
-      cache.rawEntries = rebuilt;
-    } else {
-      cache.normalizedEntries = rebuilt;
-    }
-    return rebuilt.entries.get(key);
-  }
-  return index.entries.get(key);
-}
-
 function serializeCostIndex(
-  entries: Map<string, ModelCostConfig>,
-): Array<[string, ModelCostConfig]> {
+  entries: Map<string, RawModelCostConfig>,
+): Array<[string, RawModelCostConfig]> {
   return Array.from(entries.entries()).toSorted(([a], [b]) => a.localeCompare(b));
 }
 
@@ -517,11 +345,12 @@ export function resolveModelCostConfigFingerprint(
   agentDir?: string,
 ): string {
   const resolvedAgentDir = resolveCostAgentDir(config, agentDir);
+  const sourceConfig = config ? projectConfigOntoRuntimeSourceSnapshot(config) : undefined;
   const serialized = stableCostFingerprintValue({
     configuredRaw: serializeCostIndex(
-      getProviderCostIndex(config?.models?.providers, { allowPluginNormalization: false }),
+      getProviderCostIndex(sourceConfig?.models?.providers, { allowPluginNormalization: false }),
     ),
-    configuredNormalized: serializeCostIndex(getProviderCostIndex(config?.models?.providers)),
+    configuredNormalized: serializeCostIndex(getProviderCostIndex(sourceConfig?.models?.providers)),
     modelsJsonRaw: serializeCostIndex(
       loadModelsJsonCostIndex({
         agentDir: resolvedAgentDir,
@@ -537,8 +366,8 @@ export function resolveModelCostConfigFingerprint(
 }
 
 /**
- * Resolves pricing for a provider/model pair from local models.json, configured models, then gateway cache.
- * Direct keys win before plugin normalization so configured pricing does not trigger provider discovery.
+ * Resolves local models.json first, then authored overrides over effective catalog prices.
+ * Complete direct prices need no plugin normalization or provider discovery.
  */
 export function resolveModelCostConfig(params: {
   provider?: string;
@@ -559,51 +388,55 @@ export function resolveModelCostConfig(params: {
     allowPluginNormalization: false,
   }).get(rawKey);
   if (rawModelsJsonCost) {
-    return rawModelsJsonCost;
+    return normalizeModelCostConfig(rawModelsJsonCost);
   }
 
-  const rawConfiguredCost = findConfiguredProviderCost({
+  // Materialized catalog defaults are not authored overrides. Keep raw partial
+  // fields and empty tiers until they have been merged with current catalog rates.
+  const sourceConfig = params.config
+    ? projectConfigOntoRuntimeSourceSnapshot(params.config)
+    : undefined;
+  let configuredCost = findConfiguredProviderCost({
     ...params,
+    config: sourceConfig,
     allowPluginNormalization: false,
   });
-  if (rawConfiguredCost) {
-    return rawConfiguredCost;
-  }
 
   if (params.allowPluginNormalization === false) {
-    return undefined;
+    return configuredCost ? normalizeModelCostConfig(configuredCost) : undefined;
   }
 
-  if (shouldUseNormalizedCostLookup(params)) {
+  if (!configuredCost && shouldUseNormalizedCostLookup(params)) {
     const key = toResolvedModelKey(params);
     if (key && key !== rawKey) {
       const modelsJsonCost = loadModelsJsonCostIndex({ agentDir }).get(key);
       if (modelsJsonCost) {
-        return modelsJsonCost;
+        return normalizeModelCostConfig(modelsJsonCost);
       }
 
-      const configuredCost = findConfiguredProviderCost(params);
-      if (configuredCost) {
-        return configuredCost;
-      }
+      configuredCost = findConfiguredProviderCost({ ...params, config: sourceConfig });
     }
   }
 
+  if (
+    configuredCost &&
+    configuredCost.input !== undefined &&
+    configuredCost.output !== undefined &&
+    configuredCost.cacheRead !== undefined &&
+    configuredCost.cacheWrite !== undefined
+  ) {
+    return normalizeModelCostConfig(configuredCost);
+  }
   const catalogPricing = resolveCatalogModelPricing({
     config: params.config,
     provider: params.provider ?? "",
     model: params.model ?? "",
   });
-  if (catalogPricing) {
-    return normalizeResolvedPricing(catalogPricing);
-  }
-
-  const hostedPricing = resolveHostedModelPricing({
-    config: params.config,
-    provider: params.provider ?? "",
-    model: params.model ?? "",
-  });
-  return hostedPricing ? normalizeResolvedPricing(hostedPricing) : undefined;
+  const merged = mergeModelCost(
+    catalogPricing ? normalizeResolvedPricing(catalogPricing) : undefined,
+    configuredCost,
+  );
+  return merged ? normalizeResolvedPricing(merged) : undefined;
 }
 
 /** Estimates one call's USD cost; tier selection includes cached prompt tokens. */

--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -391,8 +391,8 @@ export function resolveModelCostConfig(params: {
     return normalizeModelCostConfig(rawModelsJsonCost);
   }
 
-  // Materialized catalog defaults are not authored overrides. Keep raw partial
-  // fields and empty tiers until they have been merged with current catalog rates.
+  // Materialized catalog defaults are not authored overrides. Preserve raw
+  // partial fields and empty tiers until merging with the inherited schedule.
   const sourceConfig = params.config
     ? projectConfigOntoRuntimeSourceSnapshot(params.config)
     : undefined;
@@ -402,11 +402,11 @@ export function resolveModelCostConfig(params: {
     allowPluginNormalization: false,
   });
 
-  if (params.allowPluginNormalization === false) {
-    return configuredCost ? normalizeModelCostConfig(configuredCost) : undefined;
-  }
-
-  if (!configuredCost && shouldUseNormalizedCostLookup(params)) {
+  if (
+    params.allowPluginNormalization !== false &&
+    !configuredCost &&
+    shouldUseNormalizedCostLookup(params)
+  ) {
     const key = toResolvedModelKey(params);
     if (key && key !== rawKey) {
       const modelsJsonCost = loadModelsJsonCostIndex({ agentDir }).get(key);
@@ -427,13 +427,18 @@ export function resolveModelCostConfig(params: {
   ) {
     return normalizeModelCostConfig(configuredCost);
   }
-  const catalogPricing = resolveCatalogModelPricing({
-    config: params.config,
-    provider: params.provider ?? "",
-    model: params.model ?? "",
-  });
+  // Display-only lookups reuse prepared prices without discovering plugins;
+  // ordinary lookups inherit current catalog rates, never materialized defaults.
+  const inheritedCost =
+    params.allowPluginNormalization === false
+      ? findConfiguredProviderCost(params)
+      : resolveCatalogModelPricing({
+          config: params.config,
+          provider: params.provider ?? "",
+          model: params.model ?? "",
+        });
   const merged = mergeModelCost(
-    catalogPricing ? normalizeResolvedPricing(catalogPricing) : undefined,
+    inheritedCost ? normalizeResolvedPricing(inheritedCost) : undefined,
     configuredCost,
   );
   return merged ? normalizeResolvedPricing(merged) : undefined;

--- a/test/scripts/publish-model-catalog.test.ts
+++ b/test/scripts/publish-model-catalog.test.ts
@@ -45,6 +45,73 @@ function writeFixtureManifest(root: string, pluginId: string, providers: Record<
   );
 }
 
+function nativeManifests(source: "OpenCode" | "Venice") {
+  const provider = source === "OpenCode" ? "opencode" : "venice";
+  return [
+    {
+      pluginId: "fixture",
+      manifestPath: "fixture.json",
+      manifest: {
+        providers: ["anthropic", "openai", provider],
+        modelCatalog: {
+          providers: {
+            anthropic: fixtureProvider("claude", 100),
+            openai: fixtureProvider("gpt", 100),
+            [provider]: { models: [{ id: "priced-fixture", cost: { input: 99, output: 99 } }] },
+          },
+        },
+        modelPricing: {
+          providers: {
+            [provider]:
+              source === "OpenCode"
+                ? {
+                    external: true,
+                    openCode: { provider: "upstream-zen" },
+                    openRouter: { provider },
+                    liteLLM: { provider },
+                  }
+                : {
+                    external: true,
+                    venice: { provider },
+                    openRouter: { provider },
+                    liteLLM: { provider },
+                  },
+          },
+        },
+      },
+    },
+  ];
+}
+
+function openCodePrices(cost: Record<string, unknown>) {
+  return {
+    "upstream-zen": {
+      id: "upstream-zen",
+      models: {
+        "priced-fixture": { id: "priced-fixture", cost },
+        "new-priced-fixture": { id: "new-priced-fixture", cost },
+      },
+    },
+  };
+}
+
+function venicePrices(pricing: Record<string, unknown>) {
+  return {
+    data: ["priced-fixture", "new-priced-fixture"].map((id) => ({
+      id,
+      type: "text",
+      model_spec: { pricing },
+    })),
+  };
+}
+
+const OPENCODE_PRICING_URL = "https://models.opencode.ai/api.json";
+const VENICE_PRICING_URL = "https://api.venice.ai/api/v1/models";
+const NATIVE_SOURCES = [
+  { source: "OpenCode", provider: "opencode", url: OPENCODE_PRICING_URL },
+  { source: "Venice", provider: "venice", url: VENICE_PRICING_URL },
+] as const;
+
 describe("publish model catalog", () => {
   it("assembles and validates fixture manifests at the 200-model floor", async () => {
     const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-publish-catalog-"));
@@ -140,6 +207,7 @@ describe("publish model catalog", () => {
         pluginId: "anthropic",
         manifestPath: "anthropic.json",
         manifest: {
+          providers: ["anthropic"],
           modelCatalog: { providers: { anthropic } },
           modelPricing: {
             providers: { anthropic: { openRouter: { modelIdTransforms: ["version-dots"] } } },
@@ -155,6 +223,7 @@ describe("publish model catalog", () => {
         pluginId: "openrouter",
         manifestPath: "openrouter.json",
         manifest: {
+          providers: ["openrouter"],
           modelPricing: {
             providers: {
               openrouter: {
@@ -169,6 +238,7 @@ describe("publish model catalog", () => {
         pluginId: "mapped",
         manifestPath: "mapped.json",
         manifest: {
+          providers: ["mapped"],
           modelPricing: {
             providers: {
               mapped: { openRouter: { provider: "approved-source" }, liteLLM: false },
@@ -193,7 +263,13 @@ describe("publish model catalog", () => {
             },
             {
               id: "openai/gpt-special",
-              pricing: { prompt: "0.000003", completion: "0.000004" },
+              pricing: {
+                prompt: "0.000003",
+                completion: "0.000004",
+                overrides: [
+                  { min_prompt_tokens: 1000, prompt: "0.000007", completion: "0.000008" },
+                ],
+              },
             },
             { id: "openai/gpt-2", pricing: { prompt: "-1", completion: "0.000004" } },
             { id: "unknown/new-model", pricing: { prompt: "1", completion: "1" } },
@@ -246,10 +322,16 @@ describe("publish model catalog", () => {
       pricingEntries: 11,
     });
     expect(bundle.providers.anthropic?.models[0]?.cost).toMatchObject({ input: 1, output: 2 });
-    expect(bundle.providers.openai?.models[0]?.cost).toMatchObject({
+    const tieredPricing = [
+      { input: 3, output: 4, cacheRead: 0, cacheWrite: 0, range: [0, 1000] },
+      { input: 7, output: 8, cacheRead: 0, cacheWrite: 0, range: [1000] },
+    ];
+    expect(bundle.providers.openai?.models[0]?.cost).toEqual({
       input: 3,
       output: 4,
-      tieredPricing: [{ input: 5, output: 6, range: [1000] }],
+      cacheRead: 0,
+      cacheWrite: 0,
+      tieredPricing,
     });
     expect(bundle.providers.openai?.models[1]?.cost).toEqual({ input: 5, output: 6 });
     expect(bundle.providers.openai?.models[2]?.cost).toBeUndefined();
@@ -261,7 +343,7 @@ describe("publish model catalog", () => {
       "forbidden-model": { input: 9, output: 10 },
       "openrouter/anthropic/claude-3.5-sonnet": { input: 1, output: 2 },
       "openrouter/mapped/wrong-source": { input: 13, output: 14 },
-      "openrouter/openai/gpt-special": { input: 3, output: 4 },
+      "openrouter/openai/gpt-special": { input: 3, output: 4, tieredPricing },
       "openrouter/unknown/new-model": { input: 1_000_000, output: 1_000_000 },
       "secondary-wins": { input: 11, output: 12 },
       "unknown/new-model": { input: 1_000_000, output: 1_000_000 },
@@ -276,6 +358,210 @@ describe("publish model catalog", () => {
       pricingEntries: 11,
     });
     expect(Object.hasOwn(bundle.providers, "unknown")).toBe(false);
+  });
+
+  describe.each(NATIVE_SOURCES)("$source native source", ({ source, provider, url }) => {
+    it("refreshes one complete owner schedule and publishes new models in that namespace only", async () => {
+      const manifests = nativeManifests(source);
+      const bundle = await assembleModelCatalogBundle({
+        manifests,
+        generatedAt: Date.now(),
+        sourceCommit: "fixture",
+      });
+      const base = { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 };
+      const extended = { input: 4, output: 15, cacheRead: 0.4, cacheWrite: 5 };
+      const payload =
+        source === "OpenCode"
+          ? {
+              ...openCodePrices({
+                input: 2,
+                output: 10,
+                cache_read: 0.2,
+                cache_write: 2.5,
+                tiers: [
+                  {
+                    input: 4,
+                    output: 15,
+                    cache_read: 0.4,
+                    cache_write: 5,
+                    tier: { type: "context", size: 272_000 },
+                  },
+                ],
+                context_over_200k: { input: 88, output: 88 },
+              }),
+              unrelated: {
+                id: "unrelated",
+                models: { hidden: { id: "hidden", cost: { input: 99, output: 99 } } },
+              },
+            }
+          : {
+              data: [
+                ...venicePrices({
+                  input: { usd: 2 },
+                  output: { usd: 10 },
+                  cache_input: { usd: 0.2 },
+                  cache_write: { usd: 2.5 },
+                  extended: {
+                    context_token_threshold: 272_000,
+                    input: { usd: 4 },
+                    output: { usd: 15 },
+                    cache_input: { usd: 0.4 },
+                    cache_write: { usd: 5 },
+                  },
+                }).data,
+                {
+                  id: "unrelated/hidden",
+                  type: "text",
+                  model_spec: { pricing: { input: { usd: 3 }, output: { usd: 4 } } },
+                },
+                {
+                  id: "non-text",
+                  type: "image",
+                  model_spec: { pricing: { input: { usd: 3 }, output: { usd: 4 } } },
+                },
+              ],
+            };
+      const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+        expect(new Headers(init?.headers).has("authorization")).toBe(false);
+        const request = requestUrl(input);
+        if (request === url) {
+          return Response.json(payload);
+        }
+        if (request === OPENROUTER_MODELS_URL) {
+          return Response.json({
+            data: [{ id: `${provider}/priced-fixture`, pricing: { prompt: "1", completion: "1" } }],
+          });
+        }
+        expect(request).toBe(LITELLM_PRICING_URL);
+        return Response.json({});
+      });
+
+      await enrichModelCatalogPricing({ bundle, manifests, fetchImpl });
+
+      const boundary = source === "Venice" ? 272_001 : 272_000;
+      const expectedPricing = {
+        ...base,
+        tieredPricing: [
+          { ...base, range: [0, boundary] },
+          { ...extended, range: [boundary] },
+        ],
+      };
+      expect(bundle.providers[provider]?.models[0]?.cost).toEqual(expectedPricing);
+      expect(bundle.pricing?.[`${provider}/new-priced-fixture`]).toEqual(expectedPricing);
+      expect(fetchImpl.mock.calls.filter(([input]) => requestUrl(input) === url)).toHaveLength(1);
+      expect(bundle.providers).not.toHaveProperty("unrelated");
+      expect(bundle.pricing).not.toHaveProperty("unrelated/hidden");
+      expect(bundle.pricing).not.toHaveProperty("upstream-zen/priced-fixture");
+      expect(bundle.pricing).not.toHaveProperty(`${provider}/priced-fixture`);
+      expect(bundle.pricing).not.toHaveProperty(`${provider}/non-text`);
+      if (source === "Venice") {
+        expect(bundle.pricing?.["venice/unrelated/hidden"]).toEqual({ input: 3, output: 4 });
+      }
+    });
+
+    it("accepts authoritative zero schedules for paid seeds and new models", async () => {
+      const manifests = nativeManifests(source);
+      const bundle = await assembleModelCatalogBundle({
+        manifests,
+        generatedAt: Date.now(),
+        sourceCommit: "fixture",
+      });
+      const fetchImpl: typeof fetch = async (input) => {
+        if (requestUrl(input) === url) {
+          return Response.json(
+            source === "OpenCode"
+              ? openCodePrices({ input: 0, output: 0 })
+              : venicePrices({ input: { usd: 0 }, output: { usd: 0 } }),
+          );
+        }
+        return Response.json({ data: [] });
+      };
+      await enrichModelCatalogPricing({ bundle, manifests, fetchImpl });
+      expect(bundle.providers[provider]?.models[0]?.cost).toEqual({
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      });
+      expect(bundle.pricing?.[`${provider}/new-priced-fixture`]).toEqual({ input: 0, output: 0 });
+    });
+
+    it.each(["unreachable", "malformed JSON", "malformed body", "missing model", "invalid price"])(
+      "rejects %s instead of re-stamping stale paid seed rates",
+      async (scenario) => {
+        const manifests = nativeManifests(source);
+        const bundle = await assembleModelCatalogBundle({
+          manifests,
+          generatedAt: Date.now(),
+          sourceCommit: "fixture",
+        });
+        const fetchImpl: typeof fetch = async (input) => {
+          const request = requestUrl(input);
+          if (request === OPENROUTER_MODELS_URL) {
+            return Response.json({ data: [] });
+          }
+          if (request === LITELLM_PRICING_URL) {
+            return Response.json({});
+          }
+          expect(request).toBe(url);
+          if (scenario === "unreachable") {
+            throw new Error("source unavailable");
+          }
+          if (scenario === "malformed JSON") {
+            return new Response("not JSON");
+          }
+          if (scenario === "malformed body") {
+            return Response.json({});
+          }
+          if (scenario === "missing model") {
+            return Response.json(
+              source === "OpenCode"
+                ? { "upstream-zen": { id: "upstream-zen", models: {} } }
+                : { data: [] },
+            );
+          }
+          return Response.json(
+            source === "OpenCode"
+              ? openCodePrices({ input: -1, output: 2 })
+              : venicePrices({
+                  input: { usd: 2 },
+                  output: { usd: 10 },
+                  extended: { context_token_threshold: 200_000, input: { usd: 4 } },
+                }),
+          );
+        };
+        await expect(enrichModelCatalogPricing({ bundle, manifests, fetchImpl })).rejects.toThrow(
+          `${source} pricing`,
+        );
+      },
+    );
+
+    it.each(["missing policy", "unowned policy", "disabled policy"])(
+      "does not fetch without an owning opt-in: %s",
+      async (scenario) => {
+        const manifests = nativeManifests(source);
+        if (scenario === "missing policy") {
+          delete manifests[0]!.manifest.modelPricing.providers[provider];
+        }
+        if (scenario === "unowned policy") {
+          manifests[0]!.manifest.providers = ["anthropic", "openai"];
+        }
+        if (scenario === "disabled policy") {
+          manifests[0]!.manifest.modelPricing.providers[provider]!.external = false;
+        }
+        const bundle = await assembleModelCatalogBundle({
+          manifests,
+          generatedAt: Date.now(),
+          sourceCommit: "fixture",
+        });
+        const fetchImpl = vi.fn<typeof fetch>(async (input) => {
+          expect(requestUrl(input)).not.toBe(url);
+          return Response.json({ data: [] });
+        });
+        await enrichModelCatalogPricing({ bundle, manifests, fetchImpl });
+        expect(fetchImpl).toHaveBeenCalledTimes(2);
+      },
+    );
   });
 
   it("fails soft when pricing sources are unreachable or malformed", async () => {
@@ -344,16 +630,65 @@ describe("publish model catalog", () => {
     expect(serializeModelCatalogBundle(left)).toBe(serializeModelCatalogBundle(right));
   });
 
-  it("ends failures with the stable wrapper marker", () => {
-    const result = spawnSync(
-      process.execPath,
-      ["--import", "tsx", "scripts/publish-model-catalog.mts"],
-      {
-        cwd: process.cwd(),
-        encoding: "utf8",
-      },
-    );
-    expect(result.status).toBe(1);
-    expect(result.stderr.trim().split("\n").at(-1)).toBe("[publish-model-catalog] FAILED (exit 1)");
-  });
+  it.each([
+    { source: "OpenCode", scenario: "unreachable" },
+    ...["unreachable", "malformed body", "missing model", "invalid price"].map((scenario) => ({
+      source: "Venice",
+      scenario,
+    })),
+  ])(
+    "leaves published output untouched when $source pricing is $scenario",
+    ({ source, scenario }) => {
+      const root = fs.realpathSync(
+        fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-publish-failure-")),
+      );
+      tempDirs.push(root);
+      const out = path.join(root, "catalog.json");
+      const preload = path.join(root, "offline.mjs");
+      fs.writeFileSync(out, "previous published catalog\n");
+      fs.writeFileSync(
+        preload,
+        `const manifests = ${JSON.stringify(readModelCatalogManifests().map((entry) => entry.manifest))};
+const openCode = {};
+for (const manifest of manifests) {
+  for (const [provider, policy] of Object.entries(manifest.modelPricing?.providers ?? {})) {
+    if (!policy.openCode) continue;
+    const id = policy.openCode.provider ?? provider;
+    const models = manifest.modelCatalog?.providers?.[provider]?.models ?? [];
+    openCode[id] = { id, models: Object.fromEntries(models.map((model) => [model.id, { id: model.id, cost: { input: 1, output: 2 } }])) };
+  }
+}
+globalThis.fetch = async (url) => {
+  if (${JSON.stringify(source)} === "OpenCode") throw new Error("fixture outage");
+  if (url === ${JSON.stringify(OPENCODE_PRICING_URL)}) return Response.json(openCode);
+  if (url === ${JSON.stringify(VENICE_PRICING_URL)}) {
+    if (${JSON.stringify(scenario)} === "unreachable") throw new Error("fixture outage");
+    if (${JSON.stringify(scenario)} === "malformed body") return Response.json({});
+    if (${JSON.stringify(scenario)} === "invalid price") return Response.json({ data: manifests.flatMap((manifest) => (manifest.modelCatalog?.providers?.venice?.models ?? []).map((model) => ({ id: model.id, type: "text", model_spec: { pricing: { input: { usd: -1 }, output: { usd: 2 } } } }))) });
+  }
+  return Response.json({ data: [] });
+};`,
+      );
+      const result = spawnSync(
+        process.execPath,
+        [
+          "--import",
+          "tsx",
+          "--import",
+          preload,
+          "scripts/publish-model-catalog.mts",
+          "--pricing",
+          "--out",
+          out,
+        ],
+        { cwd: process.cwd(), encoding: "utf8" },
+      );
+      expect(result.status, result.stderr).toBe(1);
+      expect(result.stderr).toContain(`${source} pricing`);
+      expect(result.stderr.trim().split("\n").at(-1)).toBe(
+        "[publish-model-catalog] FAILED (exit 1)",
+      );
+      expect(fs.readFileSync(out, "utf8")).toBe("previous published catalog\n");
+    },
+  );
 });

--- a/test/scripts/publish-model-catalog.test.ts
+++ b/test/scripts/publish-model-catalog.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import type { RemoteModelCatalogBundle } from "@openclaw/model-catalog-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   assembleModelCatalogBundle,
@@ -14,10 +15,20 @@ import {
   serializeModelCatalogBundle,
   summarizeModelCatalogBundle,
 } from "../../scripts/publish-model-catalog.mts";
+import type { OpenClawConfig } from "../../src/config/types.openclaw.js";
+import { setRemoteModelCatalogOverlaySourcesForTest } from "../../src/model-catalog/remote-overlay.test-support.js";
+import {
+  estimateAggregateUsageCost,
+  resetUsageFormatCachesForTest,
+  resolveModelCostConfig,
+} from "../../src/utils/usage-format.js";
 
 const tempDirs: string[] = [];
 
 afterEach(() => {
+  setRemoteModelCatalogOverlaySourcesForTest();
+  resetUsageFormatCachesForTest();
+  vi.unstubAllEnvs();
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }
@@ -34,6 +45,29 @@ function fixtureProvider(
 
 function requestUrl(input: string | URL | Request): string {
   return typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+}
+
+function publishedPricingParams(bundle: RemoteModelCatalogBundle, provider: string) {
+  const agentDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-native-pricing-"));
+  tempDirs.push(agentDir);
+  vi.stubEnv("OPENCLAW_STATE_DIR", agentDir);
+  setRemoteModelCatalogOverlaySourcesForTest({
+    bundledGeneratedAt: () => 1,
+    readStoredCatalog: () => ({
+      id: 1,
+      source_url: "https://catalog.openclaw.ai/models/v1/catalog.json",
+      bundle_json: serializeModelCatalogBundle(bundle),
+      generated_at: bundle.generatedAt,
+      min_version: bundle.minVersion ?? null,
+      etag: null,
+      last_modified: null,
+      checked_at: bundle.generatedAt,
+    }),
+  });
+  const config: OpenClawConfig = {
+    plugins: { allow: [provider], entries: { [provider]: { enabled: true } } },
+  };
+  return { config, agentDir, provider };
 }
 
 function writeFixtureManifest(root: string, pluginId: string, providers: Record<string, unknown>) {
@@ -266,9 +300,9 @@ describe("publish model catalog", () => {
               pricing: {
                 prompt: "0.000003",
                 completion: "0.000004",
-                overrides: [
-                  { min_prompt_tokens: 1000, prompt: "0.000007", completion: "0.000008" },
-                ],
+                input_cache_read: "0.0000005",
+                input_cache_write: "0.0000025",
+                overrides: [{ min_prompt_tokens: 1000, prompt: "0.000007" }],
               },
             },
             { id: "openai/gpt-2", pricing: { prompt: "-1", completion: "0.000004" } },
@@ -323,14 +357,14 @@ describe("publish model catalog", () => {
     });
     expect(bundle.providers.anthropic?.models[0]?.cost).toMatchObject({ input: 1, output: 2 });
     const tieredPricing = [
-      { input: 3, output: 4, cacheRead: 0, cacheWrite: 0, range: [0, 1000] },
-      { input: 7, output: 8, cacheRead: 0, cacheWrite: 0, range: [1000] },
+      { input: 3, output: 4, cacheRead: 0.5, cacheWrite: 2.5, range: [0, 1001] },
+      { input: 7, output: 4, cacheRead: 0.5, cacheWrite: 2.5, range: [1001] },
     ];
     expect(bundle.providers.openai?.models[0]?.cost).toEqual({
       input: 3,
       output: 4,
-      cacheRead: 0,
-      cacheWrite: 0,
+      cacheRead: 0.5,
+      cacheWrite: 2.5,
       tieredPricing,
     });
     expect(bundle.providers.openai?.models[1]?.cost).toEqual({ input: 5, output: 6 });
@@ -343,7 +377,13 @@ describe("publish model catalog", () => {
       "forbidden-model": { input: 9, output: 10 },
       "openrouter/anthropic/claude-3.5-sonnet": { input: 1, output: 2 },
       "openrouter/mapped/wrong-source": { input: 13, output: 14 },
-      "openrouter/openai/gpt-special": { input: 3, output: 4, tieredPricing },
+      "openrouter/openai/gpt-special": {
+        input: 3,
+        output: 4,
+        cacheRead: 0.5,
+        cacheWrite: 2.5,
+        tieredPricing,
+      },
       "openrouter/unknown/new-model": { input: 1_000_000, output: 1_000_000 },
       "secondary-wins": { input: 11, output: 12 },
       "unknown/new-model": { input: 1_000_000, output: 1_000_000 },
@@ -459,7 +499,7 @@ describe("publish model catalog", () => {
       }
     });
 
-    it("accepts authoritative zero schedules for paid seeds and new models", async () => {
+    it("resolves published native zeros as free for paid seeds and standalone models", async () => {
       const manifests = nativeManifests(source);
       const bundle = await assembleModelCatalogBundle({
         manifests,
@@ -483,8 +523,61 @@ describe("publish model catalog", () => {
         cacheRead: 0,
         cacheWrite: 0,
       });
-      expect(bundle.pricing?.[`${provider}/new-priced-fixture`]).toEqual({ input: 0, output: 0 });
+      const params = publishedPricingParams(bundle, provider);
+      for (const model of ["priced-fixture", "new-priced-fixture"]) {
+        expect(bundle.pricing?.[`${provider}/${model}`]).toEqual({ input: 0, output: 0 });
+        const cost = resolveModelCostConfig({ ...params, model });
+        expect.soft(cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+        expect
+          .soft(estimateAggregateUsageCost({ cost, usage: { input: 1000, output: 1000 } }))
+          .toBe(0);
+      }
     });
+
+    it.each(["missing", "invalid"])(
+      "keeps zero seeds unknown when native pricing is %s",
+      async (scenario) => {
+        const manifests = nativeManifests(source);
+        const bundle = await assembleModelCatalogBundle({
+          manifests,
+          generatedAt: Date.now(),
+          sourceCommit: "fixture",
+        });
+        bundle.providers[provider]!.models[0]!.cost = { input: 0, output: 0 };
+        await enrichModelCatalogPricing({
+          bundle,
+          manifests,
+          fetchImpl: async (input) => {
+            if (requestUrl(input) === OPENROUTER_MODELS_URL) {
+              return Response.json({
+                data: [
+                  { id: `${provider}/priced-fixture`, pricing: { prompt: "0", completion: "0" } },
+                ],
+              });
+            }
+            if (requestUrl(input) !== url) {
+              return Response.json({ data: [] });
+            }
+            return Response.json(
+              source === "OpenCode"
+                ? scenario === "missing"
+                  ? { "upstream-zen": { id: "upstream-zen", models: {} } }
+                  : openCodePrices({ input: 0 })
+                : scenario === "missing"
+                  ? { data: [] }
+                  : venicePrices({ input: { usd: 0 } }),
+            );
+          },
+        });
+        expect(bundle.pricing).toEqual({});
+        expect(
+          resolveModelCostConfig({
+            ...publishedPricingParams(bundle, provider),
+            model: "priced-fixture",
+          }),
+        ).toBeUndefined();
+      },
+    );
 
     it.each(["unreachable", "malformed JSON", "malformed body", "missing model", "invalid price"])(
       "rejects %s instead of re-stamping stale paid seed rates",

--- a/test/vitest/vitest.shared.config.ts
+++ b/test/vitest/vitest.shared.config.ts
@@ -367,6 +367,7 @@ export const sharedVitestConfig = {
           "model-catalog-normalize.ts",
         ),
       },
+      sourcePackageAlias("model-catalog-core", "model-catalog-pricing"),
       {
         find: "@openclaw/model-catalog-core/model-catalog-types",
         replacement: path.join(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -55,6 +55,9 @@
       "@openclaw/model-catalog-core/model-catalog-normalize": [
         "./packages/model-catalog-core/src/model-catalog-normalize.ts"
       ],
+      "@openclaw/model-catalog-core/model-catalog-pricing": [
+        "./packages/model-catalog-core/src/model-catalog-pricing.ts"
+      ],
       "@openclaw/model-catalog-core/model-catalog-refs": [
         "./packages/model-catalog-core/src/model-catalog-refs.ts"
       ],


### PR DESCRIPTION
Related: #133349 — merged cached long-context accounting and custom tier support.
Related: #129694 — merged Venice runtime pricing repair that prevents zero overwrites.
Related: #113549 — open OpenCode/Go catalog drift tracker; this change addresses pricing only and does not close its broader ID, context, or hybrid-refresh scope.

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer branch; maintainers can update it.

</details>

## What Problem This Solves

Fixes an issue where users relying on native Venice, OpenCode, or OpenRouter prices could see stale or incomplete cost estimates, and users changing unrelated model settings could accidentally pin generated prices instead of receiving later catalog prices. Explicit partial or zero prices could also disagree between model preparation and usage reporting.

This is a maintainer-requested follow-up to the accounting and Venice runtime repairs linked above. Before this change, generated defaults could become indistinguishable from authored prices while moving through preparation and runtime resolution. Afterward, raw authored costs retain their authority and native catalog prices can refresh wherever the user has not authored a price override.

## Why This Change Was Made

Venice's plugin-owned `pricing-api.ts` reads the existing cached `/models` response and is reused by the shared catalog publisher. A closed native-source registry and shared complete-schedule normalization handle OpenCode, Venice, and the existing sibling pricing paths without grafting base prices and tiers from different sources. Venice's whole-request extended rates begin strictly above the API threshold, including cached prompt tokens.

Authored costs are merged before materialized defaults across worker source capture, both preparation passes, final model resolution, and usage lookup. First-authored duplicate-row and canonical provider spelling precedence agree across those owners. Redundant source-context state and overlapping lookup/index refresh machinery are removed. Adding a downstream reporting guard would leave the preparation owner incorrect; guessing a migration from serialized price values would risk overwriting real user choices.

Display-only lookups merge prepared runtime prices below raw authored overrides without plugin discovery or network access. Valid native free schedules require an enabled owner-normalized authoritative-source policy and an exact hosted owner key; unknown zero seeds, non-authoritative zeros, aliases, disabled/unowned policy, and private endpoints remain unknown. The publisher and resolver share one source registry.

OpenRouter static overrides compile complete schedules from the same native base: thresholds are strictly greater than `min_prompt_tokens`, with integer boundaries at `floor(N)+1`; matching rows apply in source order per price key. Omitted fields inherit, equal thresholds and explicit zero work, and UTC/unknown predicates are excluded. The generic calculator and Venice/OpenCode boundary semantics are unchanged.

There is no new operator option, dependency, pricing store, SQLite schema, protocol version, or inference-time pricing HTTP request. The authoritative publisher refuses failed native pricing instead of replacing output; runtime retains its existing offline seed behavior.

## User Impact

Venice and OpenCode estimates can use current complete native schedules, including cache rates and long-context tiers. Fresh Venice onboarding in merge mode avoids writing generated price pins; replace mode retains its explicit seed. Explicit zero, partial, flat, tiered, and agent-local `models.json` prices remain authoritative. Empty authored cost inherits the applicable schedule; a flat authored cost removes inherited tiers.

Existing serialized costs remain explicit because historical authorship cannot be inferred safely. Copying an entire materialized model array back into config retains the documented authorship limitation. Historical unbilled tiered estimates can still be repriced under the existing policy; provider-billed totals remain authoritative. UTC scheduling and OpenRouter’s existing capability-cache lifecycle are unchanged. The updated model, provider, manifest, and token-use docs describe these boundaries.

Release-note context: refresh native Venice/OpenCode pricing without pinning generated defaults, while preserving user-authored prices through preparation and reporting.

## Evidence

Current repair commit: [a419204e942](https://github.com/openclaw/openclaw/commit/a419204e942b6fffbddd9272214ae8da630f9a2f). All eleven final repair file hashes and the full local diff SHA-256 `366b16a875ca98872ebd233673b51a6ed0d56600a622bfbd726048a35f2e5d07` matched the parent-verified candidate before staging; all hashes were rechecked after the normal commit hook. Final independent Codex autoreview was scoped-clean, with no P0/P1 findings (confidence 0.88). The final review supersedes the earlier review that identified the OpenRouter gap. Tests and runtime probes were performed separately from review.

Final owner/sibling proof: **411 tests passed across 23 files**, complete changed gates passed, and `pnpm build` passed in 269.7 seconds (four dependency eval warnings, no ineffective dynamic-import warnings). Before the OpenRouter repair, owner regressions failed 19 cases in the shared normalizer and one case each in plugin discovery, embedded capabilities, and the publisher. Earlier phases captured 40 intended red regressions plus eight duplicate-owner cases and passed the 262-test integration, 515-test owner/sibling, 268-test duplicate-owner, and 80-test fixture runs; these overlap and are not presented as unique-test totals.

<details>
<summary>Exact final test and gate commands</summary>

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs packages/model-catalog-core/src/model-catalog-pricing.test.ts src/model-catalog/pricing.test.ts test/scripts/publish-model-catalog.test.ts src/model-catalog/remote-overlay.test.ts packages/model-catalog-core/src/remote-catalog-bundle.test.ts src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts
# 163 passed

OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/auto-reply/reply/agent-runner-usage-line.test.ts src/status/status-message.test.ts src/utils/usage-format.test.ts src/utils/usage-format.cost.test.ts src/utils/usage-format.agent-roster.test.ts src/agents/models-config.model-input-presence.test.ts src/agents/models-config.merge.test.ts src/config/io.runtime-snapshot-write.test.ts extensions/venice/models.test.ts extensions/venice/provider-runtime.contract.test.ts extensions/venice/onboard.test.ts extensions/opencode/index.test.ts extensions/opencode/onboard.test.ts extensions/opencode-go/index.test.ts extensions/openrouter/provider-catalog.test.ts extensions/openrouter/provider-runtime.contract.test.ts extensions/openrouter/onboard.test.ts
# 248 passed

OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/check-changed.mjs --base e1f4101e1a2e3e4f4eaf745ef328bbb8092079fa -- docs/plugins/sdk-provider-plugins.md extensions/openrouter/provider-catalog.test.ts packages/model-catalog-core/src/model-catalog-pricing.test.ts packages/model-catalog-core/src/model-catalog-pricing.ts scripts/publish-model-catalog.mts src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts src/model-catalog/pricing.test.ts src/model-catalog/pricing.ts src/utils/usage-format.test.ts src/utils/usage-format.ts test/scripts/publish-model-catalog.test.ts
pnpm build
git diff --check
```

</details>

The parent reran all three real-function probes after the final build in fresh isolated HOME/state/temp directories, with OS-level network denial and no inference. The no-plugin probe resolves `0.003` and the exact footer `Usage: 1.0k in / 1.0k out · est $0.0030`; regression coverage also checks nonzero inherited cache prices, omitted/empty/zero/tiered input, and actual status text/presentation. The native-zero probe publishes and resolves both authoritative native providers to an estimate of exactly `0`. The OpenRouter probe passes independent arithmetic for partial input, strict threshold, omitted cache prices, and later matching rows per key.

Public endpoint proof is real and unauthenticated: Node transport returned HTTP 200 for Venice (111 models) and OpenCode (94 models) at **2026-08-31 02:03:50 UTC**, and OpenRouter at **03:03:35 UTC**. The separate Python client received 403; reviewer-environment DNS failure was a limitation of that environment, not evidence that the Node API request failed.

OpenRouter captured-payload replay: **396 models, 67 overrides, 53 supported static boundaries across 48 models**, including 33 overrides omitting cache prices. An independent oracle scans matching raw keys backwards and computes costs directly per token, rather than using compiled intervals. `node --import tsx .artifacts/venice-dynamic-pricing/openrouter-capture-parity.mjs` passed **15,904 scenarios / 79,520 cost comparisons, zero mismatches**; 14 UTC overrides were excluded, and five negative-base rows explicitly asserted rejection. Capture SHA-256: `1876a950030d3ea9420f6ceb54a6a59ad2fe891b290be703091b209d1e77a30f`. Contract: [OpenRouter pricing object](https://openrouter.ai/docs/guides/overview/models#pricing-object).

Venice real API plus local publisher artifact proof represented all **111 schedules / 14 extended schedules**. Source-blind comparison passed **556 exact decimal rates / 756 boundary scenarios**. Capture SHA-256: `6da350f42aaa171f9bf78d2722b791e7f282cda0934df54239a557a05b28c0aa`. Separate synthetic publisher → real localhost HTTP → existing SQLite → fresh-process proof covers restart activation, process-stable snapshots, ETag/304, authored/local precedence and no lookup HTTP, with owned resources closed.

These are live public metadata requests, captured-artifact arithmetic, and synthetic lifecycle/display proofs. They are not a live operator Gateway/UI session, paid inference, or invoice reconciliation. Missing/malformed/explicit-zero API inputs and namespace isolation are tested through source-aware faults, not inferred from captures that lack such rows. Hosted catalog activation remains a separate owner action after merge; no catalog or release workflow is dispatched by this PR delivery.

### Review findings and before-merge dispositions

The [no-plugin finding](https://github.com/openclaw/openclaw/pull/133695#issuecomment-5472569662), the native-zero finding in the [ClawSweeper review](https://github.com/openclaw/openclaw/pull/133695#issuecomment-5472647418), and the [OpenRouter contract finding](https://github.com/openclaw/openclaw/pull/133695#issuecomment-5473194512) are repaired in the commit above. Original red evidence is retained in the finding comments.

| ClawSweeper before-merge / quality request | Disposition |
| --- | --- |
| Merge prepared prices beneath raw no-plugin costs; prove footer/status (P1 and repeated quality item) | Repaired at the resolver owner; exact footer and status-boundary proof passed, with no plugin/network work. |
| Preserve authoritative native zero through publisher/resolver (P1 and repeated quality item) | Repaired through shared source policy and exact hosted owner-key evidence; both native providers resolve zero, while unknown/untrusted zero cases remain unknown. |
| Fresh/existing-config compatibility and upgrade pricing proof | Final 411-test run covers onboarding merge/replace, existing authored and agent-local prices, source snapshots, fresh runtime, disabled policy, aliases and private endpoints. No provenance migration is guessed. |
| Independently verify public pricing endpoints | Real Node HTTP 200 observations and captured parity results above address the reviewer DNS gap; transport-specific 403/DNS limits are explicit. |
| Rerun focused tests and exact-head CI | Focused tests, changed gates and local build passed. The old CSS/scaffold failures are repaired on main; this PR has been mechanically rebased for fresh exact-head hosted CI, recorded below. |

The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/133695#issuecomment-5472647418) reviewed exact head `2a1ea4b7ad8d78884f7714bab2a4845cd11d9000` at 2026-08-31 06:43 UTC and reports **no actionable code findings**, explicitly accepting the public parser artifact. Its remaining Before merge and Rank-up request is the compatibility decision: **the maintainer explicitly accepts authoritative Venice/OpenCode feeds refreshing unpinned model estimates, existing serialized authored costs remaining authoritative, and merge-mode onboarding remaining non-migrating**. This is the already-approved upgrade contract; no provenance migration is inferred. The required exact-head CI outcome is recorded below.

LOC against fork parent `119720344a871a667f973d5e4eb2ead8935466ed`: runtime/library **+600/-519 (net +81)**; publisher/tooling/manifest/config **+334/-438 (net -104)**; combined non-test implementation **net -23**. Tests/support **+1962/-70 (net +1892)**; docs **+112/-32 (net +80)**. Source metadata moved from publisher to shared ownership is not additional feature growth. Runtime growth implements native schedule parsing/ownership and correct strict per-key compilation while duplicate registries/helpers/lookups are removed.

### Public-artifact boundary disposition

The [maintainer decision and compiled-entrypoint proof](https://github.com/openclaw/openclaw/pull/133695#issuecomment-5473917482) resolves the earlier ClawSweeper P2 and optional Rank-up move; the latest exact-head review accepts this boundary. `extensions/venice/pricing-api.ts` is the intentionally narrow top-level public artifact supported by `extensions/AGENTS.md:71-74`, discovered by public-surface build tooling and shipped as the external official plugin's package-local `dist/pricing-api.js`. Its actual package build and execution of byte-identical compiled files with the existing host SDK passed. It performs no network, auth, setup or plugin activation.

The shared registry is a closed upstream-feed contract. Manifest provider ownership, enablement and source mapping still govern generic runtime policy. The publisher is repository tooling; it does not add a Gateway request-time loader. The proposed extra manifest-dispatched hook or broad catalog-barrel re-export is intentionally skipped because the existing public artifact already provides the required boundary. No temporary private-import exception is accepted. Fresh/existing config and restart coverage above addresses the intended upgrade behavior.

### Repaired-main CI recovery

The prior [CI run 33355046925](https://github.com/openclaw/openclaw/actions/runs/33355046925), attempt 1, failed six jobs on the same largest-CSS budget (54,809 B versus 54,784 B). Main commit `964fa991c0aff81e2ae46a0c9f99ebc0ab349d1a` removes four unconsumed custom properties without changing the limit; the verified build is 54,732 B. Later main also consolidates footer selectors.

The [provider scaffold failure, run 33355046937](https://github.com/openclaw/openclaw/actions/runs/33355046937), attempt 1, is repaired by [PR #133616](https://github.com/openclaw/openclaw/pull/133616), commit `c093e85957b6ac9a3bda486a8de4fd43eafe57c8`. Its scaffold [CI 33357602625](https://github.com/openclaw/openclaw/actions/runs/33357602625) passed. Parent verification on actual main `2013295097918f660a4a8839eb264ad9154b9284` passed 33 owner tests and `pnpm test:plugins:init-provider-scaffold` against installed public OpenClaw 2026.8.1, including compilation, generated catalog behavior and a clean Inspector. [PR #129614 was closed unmerged as superseded](https://github.com/openclaw/openclaw/pull/129614#issuecomment-5474461581); none of its separate candidate commits were imported here.

A single recovery rebase onto main `b047b753b766e3dcbe259efc643a4eadb6d72c2d` produced head `da90f4505b634ebaa016eebc8ec880fa6490d1d2`, with commits `ee4b7a80b9fe75126b8dec225dfd115f7a6b49ba` and `da90f4505b634ebaa016eebc8ec880fa6490d1d2`. Both individual stable patch IDs match their reviewed predecessors and `git range-diff` reports both unchanged. All 45 other touched files retain reviewed bytes; the remaining three test/harness files preserve upstream duplicate-test removal, mock cleanup and the compiled-subprocess plugin. No pricing source, UI patch, budget change or dependency repair was added. Recounted LOC is unchanged from above.

Recovery focused tests passed **342 tests across 12 files / seven shards** in 387.26 seconds, using the command below. `git diff --check`, individual patch IDs, range-diff and the clean source tree were verified. Fresh hosted CI passed on the final byte-identical head; native preparation uses that exact-head evidence.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs packages/model-catalog-core/src/model-catalog-pricing.test.ts src/model-catalog/pricing.test.ts test/scripts/publish-model-catalog.test.ts src/utils/usage-format.test.ts src/agents/models-config.model-input-presence.test.ts src/agents/models-config.merge.test.ts src/agents/embedded-agent-runner/model.forward-compat.errors-and-overrides.test.ts src/agents/embedded-agent-runner/openrouter-model-capabilities.test.ts extensions/venice/models.test.ts extensions/venice/onboard.test.ts extensions/opencode/index.test.ts extensions/openrouter/provider-catalog.test.ts
```


The native wrapper then required one additional guard refresh because main changed `scripts/pr-lib/process-group-runner.mjs` to keep Git maintenance within its owning operation. Refreshing onto `70338624f636fe006b61b9f39db4072f0364ac91` produced final head `2a1ea4b7ad8d78884f7714bab2a4845cd11d9000` (source commits `40a62bc5555b795c3d282cdd629a86dab69debaf`, `2a1ea4b7ad8d78884f7714bab2a4845cd11d9000`). **All 48 tested files are byte-identical to the 342-test recovery head**, and both individual pricing patch IDs remain unchanged. This was an enforced wrapper recovery, not a pricing repair; no additional source review was needed.

Fresh exact-head [CI run 33364429994](https://github.com/openclaw/openclaw/actions/runs/33364429994), attempt 1, **passed** on `2a1ea4b7ad8d78884f7714bab2a4845cd11d9000`. [Provider scaffold run 33364430031](https://github.com/openclaw/openclaw/actions/runs/33364430031), attempt 1, also **passed** on the same head. `node scripts/watch-pr-ci.mjs 133695 2a1ea4b7ad8d78884f7714bab2a4845cd11d9000` exited 0 with `GREEN`, zero pending checks. The intermediate [run 33364286126](https://github.com/openclaw/openclaw/actions/runs/33364286126) was superseded by that mandatory guard refresh. Native review artifacts validate as `READY FOR /prepare-pr` with `issueValidation.status=valid`. `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 133695` passed after green exact-head CI and verified the unchanged remote head. `scripts/pr merge-run 133695` then passed and confirmed **MERGED** as `84da6ded4e27cf6dc67497a2143d685c33221d80` at 2026-08-31 06:50:26 UTC. All 48 touched file blobs match the tested head exactly in the merge commit. The [land-ready proof](https://github.com/openclaw/openclaw/pull/133695#issuecomment-5474797502) and [native completion receipt](https://github.com/openclaw/openclaw/pull/133695#issuecomment-5474805190) record the outcome. Live main rules enforce linear history and `openclaw/ci-gate`, non-strict, with no required-approval rule; no bypass is used.

