### PR TITLE
fix(sessions): count successful zero-byte artifact deletions

### DIFF
--- a/docs/cli/sessions.md
+++ b/docs/cli/sessions.md
@@ -232,7 +232,8 @@ openclaw sessions cleanup --json
 - Cleanup also prunes unreferenced legacy/archive transcript artifacts,
   compaction checkpoints, and trajectory sidecars older than
   `session.maintenance.pruneAfter`; artifacts still referenced by SQLite
-  session rows are preserved.
+  session rows are preserved. Eligible empty files count as removed artifacts
+  in both dry-run and applied summaries, even though they free zero bytes.
 - Cleanup reports short-lived Gateway model-run probe cleanup separately as
   `modelRunPruned`. This only matches strict explicit keys shaped like
   `agent:*:explicit:model-run-<uuid>`. Retention is a fixed `24h` and is

--- a/src/config/sessions/cleanup-service.applied-summary.test.ts
+++ b/src/config/sessions/cleanup-service.applied-summary.test.ts
@@ -1,3 +1,4 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
@@ -49,6 +50,48 @@ describe("sessions cleanup applied summary", () => {
     cleanupRace.postCommitFailureStorePath = undefined;
     closeOpenClawAgentDatabasesForTest();
   });
+
+  it.each([true, false])(
+    "reports a sole empty orphan as a mutation (dryRun=%s)",
+    async (dryRun) => {
+      await withOpenClawTestState({}, async (state) => {
+        const storePath = path.join(state.sessionsDir(), "sessions.json");
+        const cfg = {
+          session: { maintenance: { mode: "enforce", maxDiskBytes: false, pruneAfter: "1s" } },
+        } satisfies OpenClawConfig;
+        await state.writeConfig(cfg);
+        await fs.mkdir(state.sessionsDir(), { recursive: true });
+        const orphan = path.join(state.sessionsDir(), "orphan.jsonl");
+        await fs.writeFile(orphan, "");
+        const old = new Date(Date.now() - 60_000);
+        await fs.utimes(orphan, old, old);
+
+        const result = await runSessionsCleanup({
+          cfg,
+          opts: { dryRun, enforce: true },
+          targets: [{ agentId: "main", storePath }],
+        });
+
+        const expected = {
+          beforeCount: 0,
+          afterCount: 0,
+          wouldMutate: true,
+          diskBudget: null,
+          unreferencedArtifacts: { removedFiles: 1, freedBytes: 0 },
+        };
+        expect(result.previewResults[0]?.summary).toMatchObject({ ...expected, dryRun });
+        if (dryRun) {
+          expect(result.appliedSummaries).toEqual([]);
+          await expect(fs.readFile(orphan, "utf8")).resolves.toBe("");
+        } else {
+          expect(result.appliedSummaries).toMatchObject([
+            { ...expected, applied: true, dryRun: false },
+          ]);
+          await expect(fs.stat(orphan)).rejects.toMatchObject({ code: "ENOENT" });
+        }
+      });
+    },
+  );
 
   it("applies the selected agent's preview without pruning a sibling behind the same selector", async () => {
     await withOpenClawTestState({ layout: "state-only" }, async (state) => {

--- a/src/config/sessions/disk-budget.ts
+++ b/src/config/sessions/disk-budget.ts
@@ -1,6 +1,7 @@
 // Session disk-budget enforcement prunes orphaned artifacts before deleting store entries.
 import fs from "node:fs";
 import path from "node:path";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
@@ -338,7 +339,7 @@ export async function pruneSessionTranscriptArchivesToHighWater(params: {
     if (usage.totalBytes <= params.highWaterBytes) {
       break;
     }
-    if ((await removeFileIfExists(file.path)) <= 0) {
+    if (!(await removeFileIfExists(file.path)).ok) {
       continue;
     }
     removedFiles += 1;
@@ -459,14 +460,18 @@ function isDiskBudgetRemovableSessionFile(
   );
 }
 
-async function removeFileIfExists(filePath: string): Promise<number> {
+// A removed empty file is success; bytes alone cannot signal removal.
+type FileRemovalResult = Result<number, "not-removed">;
+
+async function removeFileIfExists(filePath: string): Promise<FileRemovalResult> {
   const stat = await fs.promises.stat(filePath).catch(() => null);
   if (!stat?.isFile()) {
-    return 0;
+    return err("not-removed");
   }
-  return await fs.promises.rm(filePath, { force: true }).then(
-    () => stat.size,
-    () => 0,
+  // Forced removal would count paths another cleanup already removed after stat.
+  return fs.promises.rm(filePath).then(
+    () => ok(stat.size),
+    () => err("not-removed"),
   );
 }
 
@@ -477,28 +482,28 @@ async function removeFileForBudget(params: {
   fileSizesByPath: Map<string, number>;
   simulatedRemovedPaths: Set<string>;
   onRemovedPath?: (canonicalPath: string) => void;
-}): Promise<number> {
+}): Promise<FileRemovalResult> {
   const resolvedPath = path.resolve(params.filePath);
   const canonicalPath = params.canonicalPath ?? canonicalizePathForComparison(resolvedPath);
   if (params.dryRun) {
     // Dry-run deletion is path-deduped so a transcript and pointer alias cannot count the same
     // artifact twice against the simulated budget.
     if (params.simulatedRemovedPaths.has(canonicalPath)) {
-      return 0;
+      return err("not-removed");
     }
-    const size = params.fileSizesByPath.get(canonicalPath) ?? 0;
-    if (size <= 0) {
-      return 0;
+    const size = params.fileSizesByPath.get(canonicalPath);
+    if (size === undefined) {
+      return err("not-removed");
     }
     params.simulatedRemovedPaths.add(canonicalPath);
     params.onRemovedPath?.(canonicalPath);
-    return size;
+    return ok(size);
   }
-  const size = await removeFileIfExists(resolvedPath);
-  if (size > 0) {
+  const removal = await removeFileIfExists(resolvedPath);
+  if (removal.ok) {
     params.onRemovedPath?.(canonicalPath);
   }
-  return size;
+  return removal;
 }
 
 async function removePromptBlobFileForBudget(params: {
@@ -510,12 +515,12 @@ async function removePromptBlobFileForBudget(params: {
   fileSizesByPath: Map<string, number>;
   simulatedRemovedPaths: Set<string>;
   onRemovedPath?: (canonicalPath: string) => void;
-}): Promise<number> {
+}): Promise<FileRemovalResult> {
   let file = params.file;
   if (!params.dryRun) {
     const stat = await fs.promises.stat(file.path).catch(() => null);
     if (!stat?.isFile()) {
-      return 0;
+      return err("not-removed");
     }
     file = {
       ...file,
@@ -531,7 +536,7 @@ async function removePromptBlobFileForBudget(params: {
       params.tempCutoffMs,
     )
   ) {
-    return 0;
+    return err("not-removed");
   }
   return await removeFileForBudget({
     filePath: file.path,
@@ -611,7 +616,7 @@ export async function pruneUnreferencedSessionArtifacts(params: {
   let freedBytes = 0;
   const dryRun = params.dryRun === true;
   for (const item of removableFiles) {
-    const deletedBytes =
+    const removal =
       item.kind === "promptBlob"
         ? await removePromptBlobFileForBudget({
             file: item.file,
@@ -629,11 +634,11 @@ export async function pruneUnreferencedSessionArtifacts(params: {
             fileSizesByPath,
             simulatedRemovedPaths,
           });
-    if (deletedBytes <= 0) {
+    if (!removal.ok) {
       continue;
     }
     removedFiles += 1;
-    freedBytes += deletedBytes;
+    freedBytes += removal.value;
   }
 
   return {
@@ -763,7 +768,7 @@ export async function enforceSessionDiskBudget(params: {
     if (total <= highWaterBytes) {
       break;
     }
-    const deletedBytes = await removePromptBlobFileForBudget({
+    const removal = await removePromptBlobFileForBudget({
       file,
       projectedPromptBlobRefCounts,
       promptBlobCutoffMs: promptBlobOrphanCutoffMs,
@@ -773,11 +778,11 @@ export async function enforceSessionDiskBudget(params: {
       simulatedRemovedPaths,
       onRemovedPath: params.onRemoveFile,
     });
-    if (deletedBytes <= 0) {
+    if (!removal.ok) {
       continue;
     }
-    total -= deletedBytes;
-    freedBytes += deletedBytes;
+    total -= removal.value;
+    freedBytes += removal.value;
     removedFiles += 1;
   }
 
@@ -791,7 +796,7 @@ export async function enforceSessionDiskBudget(params: {
     if (total <= highWaterBytes) {
       break;
     }
-    const deletedBytes = await removeFileForBudget({
+    const removal = await removeFileForBudget({
       filePath: file.path,
       canonicalPath: file.canonicalPath,
       dryRun,
@@ -799,11 +804,11 @@ export async function enforceSessionDiskBudget(params: {
       simulatedRemovedPaths,
       onRemovedPath: params.onRemoveFile,
     });
-    if (deletedBytes <= 0) {
+    if (!removal.ok) {
       continue;
     }
-    total -= deletedBytes;
-    freedBytes += deletedBytes;
+    total -= removal.value;
+    freedBytes += removal.value;
     removedFiles += 1;
   }
 
@@ -881,7 +886,7 @@ export async function enforceSessionDiskBudget(params: {
           } else {
             const blobFile = existingPromptBlobFilesByHash.get(promptBlobHash);
             if (blobFile && (dryRun || commitEvictedIndex)) {
-              const deletedBytes = await removePromptBlobFileForBudget({
+              const removal = await removePromptBlobFileForBudget({
                 file: blobFile,
                 projectedPromptBlobRefCounts,
                 promptBlobCutoffMs: promptBlobOrphanCutoffMs,
@@ -891,9 +896,9 @@ export async function enforceSessionDiskBudget(params: {
                 simulatedRemovedPaths,
                 onRemovedPath: dryRun ? undefined : params.onRemoveFile,
               });
-              if (deletedBytes > 0) {
-                total -= deletedBytes;
-                freedBytes += deletedBytes;
+              if (removal.ok) {
+                total -= removal.value;
+                freedBytes += removal.value;
                 removedFiles += 1;
               }
             }
@@ -915,18 +920,18 @@ export async function enforceSessionDiskBudget(params: {
         continue;
       }
       for (const artifactPath of resolveSessionArtifactPathsForEntry({ sessionsDir, entry })) {
-        const deletedBytes = await removeFileForBudget({
+        const removal = await removeFileForBudget({
           filePath: artifactPath,
           dryRun,
           fileSizesByPath,
           simulatedRemovedPaths,
           onRemovedPath: dryRun ? undefined : params.onRemoveFile,
         });
-        if (deletedBytes <= 0) {
+        if (!removal.ok) {
           continue;
         }
-        total -= deletedBytes;
-        freedBytes += deletedBytes;
+        total -= removal.value;
+        freedBytes += removal.value;
         removedFiles += 1;
       }
     }

--- a/src/config/sessions/disk-budget.zero-byte.test.ts
+++ b/src/config/sessions/disk-budget.zero-byte.test.ts
@@ -1,0 +1,243 @@
+import nodeFs from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it, vi } from "vitest";
+import { withTestDir } from "../../test-helpers/temp-dir.js";
+import {
+  enforceSessionDiskBudget,
+  measureSessionPhysicalDiskUsage,
+  pruneSessionTranscriptArchivesToHighWater,
+  pruneUnreferencedSessionArtifacts,
+} from "./disk-budget.js";
+import type { SessionEntry } from "./types.js";
+
+const EMPTY_PROMPT_HASH = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+const PROMPT_FILE = `skills-prompts/sha256/e3/${EMPTY_PROMPT_HASH}.txt`;
+const TEMP_SUFFIX = ".123.0f9c1a2b-3c4d-4e5f-8a9b-0c1d2e3f4a5b.tmp";
+const ARCHIVE_STAMP = "2026-01-01T00-00-00.000Z";
+const PRESSURE = { maxDiskBytes: 64, highWaterBytes: 64 };
+const EMPTY_ARTIFACTS = [
+  { kind: "transcript", name: "orphan.jsonl" },
+  { kind: "trajectory", name: "orphan.trajectory.jsonl" },
+  { kind: "trajectory pointer", name: "orphan.trajectory-path.json" },
+  { kind: "checkpoint", name: "orphan.checkpoint.0f9c1a2b-3c4d-4e5f-8a9b-0c1d2e3f4a5b.jsonl" },
+  { kind: "prompt blob", name: PROMPT_FILE },
+  { kind: "prompt temp", name: `${PROMPT_FILE}${TEMP_SUFFIX}` },
+  { kind: "store temp", name: `sessions.json${TEMP_SUFFIX}` },
+];
+
+async function writeOldFile(dir: string, name: string, content = ""): Promise<string> {
+  const filePath = path.join(dir, name);
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, content);
+  const old = new Date(Date.now() - 60 * 60_000);
+  await fs.utimes(filePath, old, old);
+  return filePath;
+}
+
+describe.each([false, true])("zero-byte artifact accounting (dryRun=%s)", (dryRun) => {
+  describe.each(["unreferenced", "budget"] as const)("%s cleanup", (cleanup) => {
+    it.each(EMPTY_ARTIFACTS)(
+      "counts an empty $kind once without freeing bytes",
+      async ({ name }) => {
+        await withTestDir({ prefix: "openclaw-zero-byte-" }, async (dir) => {
+          const storePath = path.join(dir, "sessions.json");
+          const artifact = await writeOldFile(dir, name);
+          await fs.writeFile(path.join(dir, "filler.bin"), Buffer.alloc(128));
+          const removedPaths: string[] = [];
+          const run = () =>
+            cleanup === "unreferenced"
+              ? pruneUnreferencedSessionArtifacts({
+                  store: {},
+                  storePath,
+                  olderThanMs: 1000,
+                  dryRun,
+                })
+              : enforceSessionDiskBudget({
+                  store: {},
+                  storePath,
+                  maintenance: PRESSURE,
+                  warnOnly: false,
+                  dryRun,
+                  onRemoveFile: (removedPath) => removedPaths.push(removedPath),
+                });
+
+          const result = await run();
+
+          expect(result).toMatchObject({ removedFiles: 1, freedBytes: 0 });
+          expect(nodeFs.existsSync(artifact)).toBe(dryRun);
+          if (cleanup === "budget") {
+            expect(result).toMatchObject({
+              removedEntries: 0,
+              totalBytesBefore: 130,
+              totalBytesAfter: 130,
+            });
+            expect(removedPaths).toEqual([artifact]);
+          }
+          if (!dryRun) {
+            expect(await run()).toMatchObject({ removedFiles: 0, freedBytes: 0 });
+            expect(removedPaths).toEqual(cleanup === "budget" ? [artifact] : []);
+          }
+        });
+      },
+    );
+  });
+
+  it("counts shared empty evicted artifacts once and notifies only when applied", async () => {
+    await withTestDir({ prefix: "openclaw-zero-byte-evicted-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const artifacts = await Promise.all(
+        ["old.jsonl", "old.trajectory.jsonl", "old.trajectory-path.json", PROMPT_FILE].map((name) =>
+          writeOldFile(dir, name),
+        ),
+      );
+      const store: Record<string, SessionEntry> = {};
+      for (const sessionId of ["old", "alias"]) {
+        store[`agent:main:subagent:${sessionId}`] = {
+          sessionId,
+          sessionFile: path.join(dir, "old.jsonl"),
+          updatedAt: 1,
+          skillsSnapshot: {
+            prompt: "",
+            skills: [],
+            promptRef: { version: 1, algorithm: "sha256", hash: EMPTY_PROMPT_HASH, bytes: 0 },
+          },
+        };
+      }
+      await fs.writeFile(storePath, JSON.stringify(store, null, 2));
+      await fs.writeFile(path.join(dir, "filler.bin"), Buffer.alloc(128));
+      const removedPaths: string[] = [];
+
+      const result = await enforceSessionDiskBudget({
+        store,
+        storePath,
+        maintenance: PRESSURE,
+        warnOnly: false,
+        dryRun,
+        commitEvictedIndex: async () => {
+          await fs.writeFile(storePath, JSON.stringify(store, null, 2));
+        },
+        onRemoveFile: (removedPath) => removedPaths.push(removedPath),
+      });
+
+      expect(result).toMatchObject({
+        removedEntries: 2,
+        removedFiles: artifacts.length,
+        freedBytes: 0,
+        totalBytesAfter: 130,
+      });
+      expect(store).toEqual({});
+      expect(artifacts.map((artifact) => nodeFs.existsSync(artifact))).toEqual(
+        artifacts.map(() => dryRun),
+      );
+      expect(removedPaths.toSorted()).toEqual(dryRun ? [] : artifacts.toSorted());
+    });
+  });
+});
+
+it("counts empty retained archives under pressure and returns real disk usage", async () => {
+  await withTestDir({ prefix: "openclaw-zero-byte-archives-" }, async (dir) => {
+    const storePath = path.join(dir, "sessions.json");
+    const archives = await Promise.all(
+      ["deleted", "reset", "bak"].map((reason) =>
+        writeOldFile(dir, `old.jsonl.${reason}.${ARCHIVE_STAMP}`),
+      ),
+    );
+    const excludedName = `keep.jsonl.deleted.${ARCHIVE_STAMP}`;
+    const excluded = await writeOldFile(dir, excludedName);
+    await fs.writeFile(path.join(dir, "filler.bin"), Buffer.alloc(128));
+    const params = { storePath, highWaterBytes: 64, excludeNames: new Set([excludedName]) };
+
+    const result = await pruneSessionTranscriptArchivesToHighWater(params);
+
+    expect(result.removedFiles).toBe(3);
+    expect(result.usage).toEqual(await measureSessionPhysicalDiskUsage(storePath));
+    expect(result.usage.totalBytes).toBe(128);
+    expect(archives.map((archive) => nodeFs.existsSync(archive))).toEqual([false, false, false]);
+    expect(nodeFs.existsSync(excluded)).toBe(true);
+    expect(await pruneSessionTranscriptArchivesToHighWater(params)).toEqual({
+      removedFiles: 0,
+      usage: result.usage,
+    });
+  });
+});
+
+it("does not count or notify an empty file removed by another cleanup before rm", async () => {
+  await withTestDir({ prefix: "openclaw-missing-removal-" }, async (dir) => {
+    const artifact = await writeOldFile(dir, "orphan.jsonl");
+    await fs.writeFile(path.join(dir, "filler.bin"), Buffer.alloc(128));
+    const onRemoveFile = vi.fn();
+    const originalRm = nodeFs.promises.rm.bind(nodeFs.promises);
+    const rm = vi.spyOn(nodeFs.promises, "rm").mockImplementation(async (target, options) => {
+      if (target === artifact) {
+        await originalRm(target);
+      }
+      return originalRm(target, options);
+    });
+    try {
+      const result = await enforceSessionDiskBudget({
+        store: {},
+        storePath: path.join(dir, "sessions.json"),
+        maintenance: PRESSURE,
+        warnOnly: false,
+        onRemoveFile,
+      });
+
+      expect(result).toMatchObject({ removedFiles: 0, freedBytes: 0 });
+      expect(onRemoveFile).not.toHaveBeenCalled();
+      await expect(fs.stat(artifact)).rejects.toMatchObject({ code: "ENOENT" });
+    } finally {
+      rm.mockRestore();
+    }
+  });
+});
+
+it.each(["unreferenced", "budget", "archives"] as const)(
+  "%s cleanup does not count a rejected nonempty removal or dispatch its callback",
+  async (cleanup) => {
+    await withTestDir({ prefix: "openclaw-rejected-removal-" }, async (dir) => {
+      const storePath = path.join(dir, "sessions.json");
+      const name = cleanup === "archives" ? `old.jsonl.deleted.${ARCHIVE_STAMP}` : "orphan.jsonl";
+      const content = "x".repeat(64);
+      const artifact = await writeOldFile(dir, name, content);
+      await fs.writeFile(path.join(dir, "filler.bin"), Buffer.alloc(128));
+      const removedPaths: string[] = [];
+      const originalRm = nodeFs.promises.rm.bind(nodeFs.promises);
+      const rm = vi.spyOn(nodeFs.promises, "rm").mockImplementation(async (target, options) => {
+        if (target === artifact) {
+          throw new Error("injected removal failure");
+        }
+        return originalRm(target, options);
+      });
+      try {
+        if (cleanup === "archives") {
+          const result = await pruneSessionTranscriptArchivesToHighWater({
+            storePath,
+            highWaterBytes: 64,
+          });
+          expect(result.removedFiles).toBe(0);
+          expect(result.usage.totalBytes).toBe(192);
+        } else {
+          const result =
+            cleanup === "unreferenced"
+              ? await pruneUnreferencedSessionArtifacts({ store: {}, storePath, olderThanMs: 1000 })
+              : await enforceSessionDiskBudget({
+                  store: {},
+                  storePath,
+                  maintenance: PRESSURE,
+                  warnOnly: false,
+                  onRemoveFile: (removedPath) => removedPaths.push(removedPath),
+                });
+          expect(result).toMatchObject({ removedFiles: 0, freedBytes: 0 });
+          if (cleanup === "budget") {
+            expect(result).toMatchObject({ totalBytesBefore: 194, totalBytesAfter: 194 });
+          }
+        }
+        expect(await fs.readFile(artifact, "utf8")).toBe(content);
+        expect(removedPaths).toEqual([]);
+      } finally {
+        rm.mockRestore();
+      }
+    });
+  },
+);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

Closes #133681 (session cleanup undercounts successful zero-byte artifact deletions).

Built on #133668 (failed-deletion accounting and deferred-enforcement repair), merged as [5781ef3e986910ec412f283d2b3747519748d2d2](https://github.com/openclaw/openclaw/commit/5781ef3e986910ec412f283d2b3747519748d2d2).

## What Problem This Solves

Fixes an issue where operators cleaning up eligible empty session artifacts saw zero removed files and `wouldMutate: false`, even though applied cleanup deleted the file. Dry-run omitted the same removals, and disk-budget callbacks did not report successful empty-file deletions.

## Why This Change Was Made

The removal owner used a numeric byte count as its success signal, so successful zero-byte deletion was indistinguishable from absence or failure. A small internal `Result<number, "not-removed">` reuses the repository contract and carries success independently from reclaimed bytes. All removal consumers and dry-run simulation now follow that outcome, with canonical-path deduplication preserved. The removal call also no longer forces acknowledgement of a file that disappeared after stat.

This change preserves the companion failed-deletion repair's durable-index-before-unlink ordering and actual-reclamation enforcement. It adds no configuration, schema, protocol, dependency, public result-shape, or test-only production exports.

## User Impact

Eligible empty artifacts count as one removal and zero freed bytes. Dry-run and apply agree on that count, actual removals trigger their existing callbacks, and missing files or rejected removals do not create false success notifications. Cleanup summaries now correctly identify empty-file removal as a mutation. Retention eligibility and protected-session behavior are unchanged.

The [session cleanup documentation](https://docs.openclaw.ai/cli/sessions#cleanup-maintenance) explains that file counts are independent from reclaimed bytes.

## Evidence

The original real-filesystem reproduction used an isolated temporary state directory and the public `runSessionsCleanup` boundary, with disk budgeting disabled. No operator state, live Gateway, channel, or provider was used.

| Observation | Before | After |
| --- | --- | --- |
| Preview artifact removals / freed bytes / would mutate | 0 / 0 / false | 1 / 0 / true |
| Empty orphan still exists after preview | yes | yes |
| Applied artifact removals / freed bytes / would mutate | 0 / 0 / false | 1 / 0 / true |
| Empty orphan still exists after apply | no | no |
| Repeated cleanup removals / would mutate | 0 / false | 0 / false |

Regression-first proof produced 36 failing cases on the original code. An additional disappearance-race regression failed against the initial result-type patch, then passed after removing forced acknowledgement. After rebasing onto the merged companion, the combined proof passed 164 tests across eight owner/sibling suites, including all 12 companion removal-failure cases. Both standalone temporary-filesystem reproductions passed again on the integrated source. Coverage includes transcript, trajectory, checkpoint, stale prompt/store artifacts, retained archives, shared-path deduplication, callbacks, dry-run, missing-file idempotence, nonempty removal errors, service summaries, and existing archive-retention behavior.

```bash
node scripts/run-vitest.mjs src/config/sessions/disk-budget.zero-byte.test.ts src/config/sessions/disk-budget.removal-failures.test.ts src/config/sessions/disk-budget.test.ts src/config/sessions/cleanup-service.applied-summary.test.ts src/config/sessions/session-history-eviction.test.ts src/config/sessions/store.pruning.test.ts src/config/sessions/store-maintenance-recent-preservation.test.ts src/gateway/session-transcript-files.fs.archive-cleanup.test.ts
```

```bash
node scripts/check-changed.mjs -- src/config/sessions/disk-budget.ts src/config/sessions/disk-budget.zero-byte.test.ts src/config/sessions/cleanup-service.applied-summary.test.ts docs/cli/sessions.md
```

```bash
git diff --check
```

The explicit-path changed gate passed core and test typechecks, lint, formatting, dead-export scanning, storage guards, and runtime import-cycle checks. Fresh isolated Codex autoreview was scoped-clean at its default P0 threshold. The source investigation covered cleanup callers, legacy enforcement, SQLite archive pruning, Gateway archive retention, existing `Result`, and Node's `rm`/file-size contracts. The numeric sentinel was verified in the original introducing diff and stable `v2026.2.23`.

Production LOC against the merged companion: +42/-37 (net +5); regression tests: +286/-0; documentation: +2/-1 (net +1). The five added production lines are the existing Result import, the private removal-outcome alias, and two invariant comments. All consumers reuse the canonical flow; the companion's obsolete deferred planner stays deleted. No public result shapes change.

Exact-head hosted CI passed on `528d33ada5053473421ecfa3cf7a2a6dbe50adae`: [CI run 33347889112](https://github.com/openclaw/openclaw/actions/runs/33347889112), attempt 1, completed successfully. The required `openclaw/ci-gate` passed, and the native watcher returned `GREEN` with no pending checks.

[ClawSweeper reviewed this exact head](https://github.com/openclaw/openclaw/pull/133697#issuecomment-5472664506) and found no introduced correctness or security issue. Its merge note accepts the private tagged outcome and the justified net +5 production lines; the check set that was pending at review time is now green. There were no separate rank-up moves or code changes requested, and no review items were skipped.
