### PR TITLE
fix(models): keep usage pricing on static model metadata

### DIFF
--- a/src/model-catalog/pricing.test.ts
+++ b/src/model-catalog/pricing.test.ts
@@ -1,3 +1,6 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import * as staticNormalization from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -12,6 +15,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import * as manifestNormalization from "../plugins/manifest-model-id-normalization.js";
 import { normalizeManifestModelPricing } from "../plugins/manifest-model-provider-normalizers.js";
 import * as pluginMetadata from "../plugins/plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { buildStatusMessageParts } from "../status/status-message.js";
 import {
   estimateAggregateUsageCost,
@@ -42,6 +46,8 @@ beforeEach(() => {
         openai: {
           models: [
             { id: "gpt-catalog", cost: { input: 1, output: 2 } },
+            { id: "pricing-model", cost: { input: 1, output: 2 } },
+            { id: "openai/pricing-model", cost: { input: 3, output: 6 } },
             {
               id: "gpt-authored",
               cost: {
@@ -69,6 +75,10 @@ beforeEach(() => {
         },
       },
       pricing: {
+        "openai/pricing-model": { input: 91, output: 92 },
+        "openai/openai/pricing-model": { input: 93, output: 94 },
+        "openai/pricing-hosted": { input: 4, output: 8 },
+        "openai/openai/pricing-hosted": { input: 5, output: 10 },
         "openai/gpt-external": { input: 2.5, output: 10, cacheRead: 1.25 },
         "openai/gpt-zero-hosted": {
           input: 0,
@@ -111,6 +121,235 @@ function configFor(baseUrl: string): OpenClawConfig {
 }
 
 describe("hosted model pricing", () => {
+  it("keeps normalized indexes scoped to their policy while observing configured price changes", async () => {
+    const model = {
+      id: "alias",
+      name: "Alias",
+      reasoning: false,
+      input: ["text" as const],
+      cost: { input: 3, output: 0, cacheRead: 0, cacheWrite: 0 },
+      maxTokens: 8192,
+    };
+    const providers = { fixture: { baseUrl: "https://fixture.invalid", models: [model] } };
+    const firstConfig: OpenClawConfig = { models: { providers } };
+    const secondConfig: OpenClawConfig = { models: { providers } };
+    const enumeratePolicies = vi.fn(Reflect.ownKeys);
+    const snapshotFor = (canonicalModel: string) =>
+      createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "fixture",
+            providers: ["fixture"],
+            modelIdNormalization: {
+              providers: new Proxy(
+                { fixture: { aliases: { alias: canonicalModel } } },
+                { ownKeys: (target) => enumeratePolicies(target) },
+              ),
+            },
+          },
+        ],
+      });
+    const metadataSpy = vi
+      .spyOn(pluginMetadata, "resolvePluginMetadataSnapshot")
+      .mockReturnValueOnce(snapshotFor("first"))
+      .mockReturnValueOnce(snapshotFor("second"));
+    enumeratePolicies.mockClear();
+    const agentDir = tempDirs.make("openclaw-policy-pricing-");
+    const lookup = () =>
+      [firstConfig, secondConfig].flatMap((config) =>
+        ["first", "second"].map(
+          (modelId) =>
+            resolveModelCostConfig({ config, agentDir, provider: "fixture", model: modelId })
+              ?.input,
+        ),
+      );
+    expect(lookup()).toEqual([3, undefined, undefined, 3]);
+    expect(lookup()).toEqual([3, undefined, undefined, 3]);
+
+    model.cost.input = 9;
+    expect(lookup()).toEqual([9, undefined, undefined, 9]);
+    model.cost = { input: 11, output: 0, cacheRead: 0, cacheWrite: 0 };
+    expect(lookup()).toEqual([11, undefined, undefined, 11]);
+    model.id = "unaliased";
+    expect(lookup()).toEqual([undefined, undefined, undefined, undefined]);
+    providers.fixture.models.push({ ...model, id: "alias" });
+    expect(lookup()).toEqual([11, undefined, undefined, 11]);
+
+    const fileModel = { ...model, id: "alias", cost: { ...model.cost, input: 17 } };
+    await fs.writeFile(
+      path.join(agentDir, "models.json"),
+      JSON.stringify({ providers: { fixture: { ...providers.fixture, models: [fileModel] } } }),
+    );
+    expect(lookup()).toEqual([17, undefined, undefined, 17]);
+    expect(metadataSpy).toHaveBeenCalledTimes(2);
+    expect(enumeratePolicies).not.toHaveBeenCalled();
+  });
+
+  it.each(["config", "models.json"] as const)(
+    "reuses normalized pricing indexes for repeated fallbacks from %s",
+    async (source) => {
+      const agentDir = tempDirs.make("openclaw-repeated-pricing-");
+      const providers = {
+        custom: {
+          baseUrl: "https://pricing.example/v1",
+          models: Array.from({ length: 500 }, (_, index) => ({
+            id: `model-${index}`,
+            name: `Model ${index}`,
+            reasoning: false,
+            input: ["text" as const],
+            cost: { input: index + 1, output: 0, cacheRead: 0, cacheWrite: 0 },
+            maxTokens: 8192,
+          })),
+        },
+      };
+      const config: OpenClawConfig = {
+        models: {
+          providers: {
+            openai: { baseUrl: "https://api.openai.com/v1", models: [] },
+            ...(source === "config" ? providers : {}),
+          },
+        },
+      };
+      if (source === "models.json") {
+        await fs.writeFile(path.join(agentDir, "models.json"), JSON.stringify({ providers }));
+      }
+      const lookup = () =>
+        ["gpt-external", "unknown-model"].map(
+          (model) => resolveModelCostConfig({ config, agentDir, provider: "openai", model })?.input,
+        );
+      let prices = lookup();
+      const normalizeKey = vi.spyOn(
+        staticNormalization,
+        "normalizeStaticProviderModelIdWithPolicies",
+      );
+      for (let repeat = 0; repeat < 20; repeat += 1) {
+        prices = lookup();
+      }
+      expect(prices).toEqual([2.5, undefined]);
+      expect(normalizeKey.mock.calls.length).toBeLessThanOrEqual(100);
+    },
+  );
+
+  it("resolves catalog and hosted prices without activating provider runtime", () => {
+    const runtimeSpy = vi.spyOn(runtimeNormalization, "normalizeProviderModelIdWithRuntime");
+    const config = configFor("https://api.openai.com/v1");
+    const agentDir = tempDirs.make("openclaw-static-pricing-");
+    expect(
+      ["gpt-catalog", "gpt-external"].map(
+        (model) => resolveModelCostConfig({ config, agentDir, provider: "openai", model })?.input,
+      ),
+    ).toEqual([1, 2.5]);
+    expect(runtimeSpy).not.toHaveBeenCalled();
+  });
+
+  it.each(["config", "models.json"] as const)(
+    "keeps exact pricing namespaces distinct in %s",
+    async (source) => {
+      const agentDir = tempDirs.make("openclaw-exact-pricing-");
+      const config: OpenClawConfig = {
+        models: {
+          providers: {
+            custom: {
+              baseUrl: "https://custom.example/v1",
+              models: ["model", "custom/model"].map((id, index) => ({
+                id,
+                name: id,
+                reasoning: false,
+                input: ["text" as const],
+                cost: { input: index + 1, output: 0, cacheRead: 0, cacheWrite: 0 },
+                maxTokens: 8192,
+              })),
+            },
+          },
+        },
+      };
+      if (source === "models.json") {
+        await fs.writeFile(path.join(agentDir, "models.json"), JSON.stringify(config.models));
+      }
+
+      expect(
+        ["model", "custom/model"].map(
+          (model) =>
+            resolveModelCostConfig({
+              config: source === "config" ? config : undefined,
+              agentDir,
+              provider: "custom",
+              model,
+              allowPluginNormalization: false,
+            })?.input,
+        ),
+      ).toEqual([1, 2]);
+    },
+  );
+
+  it.each([
+    { provider: "openrouter", model: "openrouter/auto", shortModel: "auto" },
+    { provider: "nvidia", model: "nvidia/nemotron", shortModel: "nemotron" },
+  ])("retains static pricing aliases for $provider", ({ provider, model, shortModel }) => {
+    const agentDir = tempDirs.make("openclaw-static-pricing-alias-");
+    const config: OpenClawConfig = {
+      models: {
+        providers: {
+          [provider]: {
+            baseUrl: "https://pricing.example/v1",
+            models: [
+              {
+                id: model,
+                name: model,
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 3, output: 0, cacheRead: 0, cacheWrite: 0 },
+                maxTokens: 8192,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    expect(
+      [model, shortModel].map(
+        (modelId) =>
+          resolveModelCostConfig({
+            config,
+            agentDir,
+            provider,
+            model: modelId,
+            allowPluginNormalization: false,
+          })?.input,
+      ),
+    ).toEqual([3, 3]);
+  });
+
+  it.each([
+    { source: "catalog", model: "pricing-model", expected: [1, 3] },
+    { source: "hosted", model: "pricing-hosted", expected: [4, 5] },
+  ])("keeps exact pricing namespaces distinct in $source", ({ model, expected }) => {
+    const config = configFor("https://api.openai.com/v1");
+    const agentDir = tempDirs.make("openclaw-catalog-namespaces-");
+    expect(
+      [model, `openai/${model}`].map(
+        (modelId) =>
+          resolveModelCostConfig({ config, agentDir, provider: "openai", model: modelId })?.input,
+      ),
+    ).toEqual(expected);
+  });
+
+  it("checks the exact model endpoint before applying hosted pricing", () => {
+    const config = configFor("https://api.openai.com/v1");
+    const models = expectDefined(config.models?.providers?.openai?.models, "endpoint models");
+    const entry = expectDefined(models[0], "metadata-only endpoint model");
+    entry.id = "pricing-hosted";
+    models.push({ ...entry, id: "openai/pricing-hosted", baseUrl: "http://127.0.0.1:8080/v1" });
+
+    const agentDir = tempDirs.make("openclaw-exact-endpoint-pricing-");
+    expect(
+      ["pricing-hosted", "openai/pricing-hosted"].map(
+        (model) => resolveModelCostConfig({ config, agentDir, provider: "openai", model })?.input,
+      ),
+    ).toEqual([4, undefined]);
+  });
+
   it.each([
     { name: "native owner", policy: { venice: { provider: "venice" } }, known: true },
     { name: "other native source", policy: { openCode: { provider: "upstream" } }, known: true },

--- a/src/model-catalog/pricing.ts
+++ b/src/model-catalog/pricing.ts
@@ -1,13 +1,12 @@
 import { isIP } from "node:net";
 import type { RemoteModelCatalogPricing } from "@openclaw/model-catalog-core";
 import { MODEL_PRICING_SOURCES } from "@openclaw/model-catalog-core/model-catalog-pricing";
+import { buildModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import type { ModelCatalogCost } from "@openclaw/model-catalog-core/model-catalog-types";
 import {
-  modelKey,
-  normalizeModelRef,
-  type ModelManifestNormalizationContext,
-} from "../agents/model-selection.js";
-import type { ModelDefinitionConfig } from "../config/types.models.js";
+  createStaticProviderModelIdNormalizer,
+  normalizeProviderId,
+} from "../agents/model-ref-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isInstalledPluginEnabled } from "../plugins/installed-plugin-index.js";
 import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
@@ -19,13 +18,13 @@ import { planEffectiveModelCatalogRows } from "./index.js";
 import { getRemoteModelCatalogPricing } from "./remote-overlay.js";
 
 type PricingValue = RemoteModelCatalogPricing | ModelCatalogCost;
-type ManifestPlugins = ModelManifestNormalizationContext["manifestPlugins"];
 type ExternalPricingPolicy = {
   external: boolean;
   authoritative: boolean;
 };
 type PricingContext = {
-  snapshot?: PluginMetadataSnapshot;
+  config: OpenClawConfig;
+  normalizeKey: (provider: string, model: string) => string;
   catalog: ReadonlyMap<string, PricingValue>;
   hosted: Readonly<Record<string, RemoteModelCatalogPricing>>;
   normalizedHosted: ReadonlyMap<string, RemoteModelCatalogPricing>;
@@ -51,15 +50,15 @@ function activeManifestRegistry(
   };
 }
 
-function normalizedHostedKey(key: string, manifestPlugins?: ManifestPlugins): string | undefined {
+function normalizedHostedKey(
+  key: string,
+  normalizeKey: PricingContext["normalizeKey"],
+): string | undefined {
   const slash = key.indexOf("/");
   if (slash <= 0 || slash === key.length - 1) {
     return undefined;
   }
-  const normalized = normalizeModelRef(key.slice(0, slash), key.slice(slash + 1), {
-    manifestPlugins,
-  });
-  return modelKey(normalized.provider, normalized.model);
+  return normalizeKey(key.slice(0, slash), key.slice(slash + 1));
 }
 
 function buildPricingContext(config: OpenClawConfig): PricingContext {
@@ -76,10 +75,18 @@ function buildPricingContext(config: OpenClawConfig): PricingContext {
   const registry = snapshot
     ? activeManifestRegistry(snapshot, config)
     : ({ plugins: [], diagnostics: [] } satisfies PluginManifestRegistry);
+  // Pricing reuses prepared static policies without activating provider runtime.
+  const normalizeModel = createStaticProviderModelIdNormalizer({
+    manifestPlugins: snapshot ?? [],
+  });
+  const normalizeKey = (provider: string, model: string) => {
+    const providerId = normalizeProviderId(provider);
+    return buildModelCatalogRef(providerId, normalizeModel(providerId, model.trim()));
+  };
   const catalog = new Map<string, PricingValue>();
   for (const row of planEffectiveModelCatalogRows({ registry, config }).rows) {
     if (row.cost) {
-      catalog.set(modelKey(row.provider, row.id), row.cost);
+      catalog.set(buildModelCatalogRef(row.provider, row.id), row.cost);
     }
   }
   const policies = new Map<string, ExternalPricingPolicy>();
@@ -98,7 +105,7 @@ function buildPricingContext(config: OpenClawConfig): PricingContext {
   const hosted = snapshot ? (getRemoteModelCatalogPricing(config) ?? {}) : {};
   const normalizedHosted = new Map<string, RemoteModelCatalogPricing>();
   for (const [key, pricing] of Object.entries(hosted).toSorted(([a], [b]) => a.localeCompare(b))) {
-    const normalized = normalizedHostedKey(key, snapshot);
+    const normalized = normalizedHostedKey(key, normalizeKey);
     if (normalized && !normalizedHosted.has(normalized)) {
       normalizedHosted.set(normalized, pricing);
     }
@@ -108,11 +115,15 @@ function buildPricingContext(config: OpenClawConfig): PricingContext {
     hosted: Object.entries(hosted).toSorted(([a], [b]) => a.localeCompare(b)),
     normalizedHosted: [...normalizedHosted.entries()].toSorted(([a], [b]) => a.localeCompare(b)),
     policies: [...policies.entries()].toSorted(([a], [b]) => a.localeCompare(b)),
+    normalization: [...(snapshot?.owners.modelIdNormalizationPolicies ?? [])].toSorted(([a], [b]) =>
+      a.localeCompare(b),
+    ),
   });
-  return { snapshot, catalog, hosted, normalizedHosted, policies, fingerprint };
+  return { config, normalizeKey, catalog, hosted, normalizedHosted, policies, fingerprint };
 }
 
-function getPricingContext(config: OpenClawConfig): PricingContext {
+/** Reuses the static pricing policy captured for this config. */
+export function resolveModelPricingContext(config: OpenClawConfig = EMPTY_CONFIG): PricingContext {
   const existing = pricingContextByConfig.get(config);
   if (existing) {
     return existing;
@@ -182,51 +193,27 @@ function isPrivateOrLoopbackUrl(value: string | undefined): boolean {
   }
 }
 
-function findConfiguredModel(
-  config: OpenClawConfig,
-  provider: string,
-  model: string,
-  manifestPlugins?: ManifestPlugins,
-): ModelDefinitionConfig | undefined {
-  return config.models?.providers?.[provider]?.models?.find((entry) => {
-    const normalized = normalizeModelRef(provider, entry.id, { manifestPlugins });
-    return modelKey(normalized.provider, normalized.model) === modelKey(provider, model);
-  });
-}
-
-function allowsHostedPricing(
-  config: OpenClawConfig,
-  provider: string,
-  model: string,
-  manifestPlugins?: ManifestPlugins,
-): boolean {
-  const providerConfig = config.models?.providers?.[provider];
-  const configuredModel = findConfiguredModel(config, provider, model, manifestPlugins);
-  return !(
+/** Resolves catalog-first pricing for a key prepared by this metadata context. */
+export function resolveModelPricing(
+  context: PricingContext,
+  key: string,
+): PricingValue | undefined {
+  const provider = key.slice(0, key.indexOf("/"));
+  const providerConfig = context.config.models?.providers?.[provider];
+  const configuredModel = providerConfig?.models?.find(
+    (entry) => context.normalizeKey(provider, entry.id) === key,
+  );
+  if (
     isPrivateOrLoopbackUrl(configuredModel?.baseUrl) ||
     isPrivateOrLoopbackUrl(providerConfig?.baseUrl)
-  );
-}
-
-export function resolveCatalogModelPricing(params: {
-  config?: OpenClawConfig;
-  provider: string;
-  model: string;
-}): PricingValue | undefined {
-  const config = params.config ?? EMPTY_CONFIG;
-  const context = getPricingContext(config);
-  const normalized = normalizeModelRef(params.provider, params.model, {
-    manifestPlugins: context.snapshot,
-  });
-  if (!allowsHostedPricing(config, normalized.provider, normalized.model, context.snapshot)) {
+  ) {
     return undefined;
   }
-  const key = modelKey(normalized.provider, normalized.model);
   const catalog = context.catalog.get(key);
   if (catalog && hasKnownPricing(catalog)) {
     return catalog;
   }
-  const policy = context.policies.get(normalized.provider);
+  const policy = context.policies.get(provider);
   if (policy?.external === false) {
     return undefined;
   }
@@ -236,9 +223,8 @@ export function resolveCatalogModelPricing(params: {
   return hosted && (hasKnownPricing(hosted) || policy?.authoritative) ? hosted : undefined;
 }
 
-export function modelCatalogPricingFingerprint(config?: OpenClawConfig): string {
-  const resolvedConfig = config ?? EMPTY_CONFIG;
-  const context = getPricingContext(resolvedConfig);
+export function modelCatalogPricingFingerprint(context: PricingContext): string {
+  const resolvedConfig = context.config;
   const configuredEndpoints = Object.entries(resolvedConfig.models?.providers ?? {})
     .toSorted(([a], [b]) => a.localeCompare(b))
     .map(([provider, providerConfig]) => ({

--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -11,13 +11,15 @@ import {
   type ModelCostConfig,
   type RawModelCostConfig,
 } from "@openclaw/llm-core";
+import { buildModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { normalizeBuiltInProviderModelId } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   listAgentEntries,
   resolveAgentDir,
   tryResolveDefaultAgentId,
 } from "../agents/agent-scope-config.js";
-import { modelKey, normalizeModelRef, normalizeProviderId } from "../agents/model-selection.js";
 import { normalizeProviderMapKeys } from "../agents/models-config.merge.js";
 import type { NormalizedUsage } from "../agents/usage.js";
 import { mergeModelCost } from "../config/model-cost.js";
@@ -29,21 +31,16 @@ import { tryReadJsonSync } from "../infra/json-files.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import {
   modelCatalogPricingFingerprint,
-  resolveCatalogModelPricing,
+  resolveModelPricing,
+  resolveModelPricingContext,
 } from "../model-catalog/pricing.js";
 export { formatTokenCount } from "./token-format.js";
 export type { ModelCostConfig } from "@openclaw/llm-core";
 
+type ModelKeyNormalizer = (provider: string, model: string) => string;
 type ModelsJsonCostCache = {
-  path: string;
   providers: Record<string, ModelProviderConfig> | undefined;
-  normalizedEntries: Map<string, RawModelCostConfig> | null;
-  rawEntries: Map<string, RawModelCostConfig> | null;
-};
-
-type ProviderCostIndexCacheEntry = {
-  normalizedEntries?: ProviderCostIndex;
-  rawEntries?: ProviderCostIndex;
+  entries: WeakMap<ModelKeyNormalizer, Map<string, RawModelCostConfig>>;
 };
 
 type ProviderCostIndexSource = {
@@ -60,14 +57,12 @@ type ProviderCostIndex = {
 
 const EMPTY_PROVIDER_COST_INDEX = new Map<string, RawModelCostConfig>();
 const MODELS_JSON_COST_CACHE_LIMIT = 128;
-const MODEL_KEY_CACHE_LIMIT = 4096;
 
 let modelsJsonCostCacheByAgentDir = new Map<string, ModelsJsonCostCache>();
-let providerCostIndexByConfig = new WeakMap<
-  Record<string, ModelProviderConfig>,
-  ProviderCostIndexCacheEntry
+let providerCostIndexByNormalizer = new WeakMap<
+  ModelKeyNormalizer,
+  WeakMap<Record<string, ModelProviderConfig>, ProviderCostIndex>
 >();
-let modelKeyCache = new Map<string, string | null>();
 
 /** Formats a USD amount for usage summaries, keeping tiny costs visible. */
 export function formatUsd(value?: number): string | undefined {
@@ -80,65 +75,13 @@ export function formatUsd(value?: number): string | undefined {
   return `$${value.toFixed(4)}`;
 }
 
-function toResolvedModelKey(params: {
-  provider?: string;
-  model?: string;
-  allowPluginNormalization?: boolean;
-}): string | null {
-  const cacheKey = [
-    "resolved",
-    params.allowPluginNormalization === false ? "raw" : "default",
-    params.provider ?? "",
-    params.model ?? "",
-  ].join("\0");
-  if (modelKeyCache.has(cacheKey)) {
-    return modelKeyCache.get(cacheKey) ?? null;
-  }
-  const provider = normalizeOptionalString(params.provider);
-  const model = normalizeOptionalString(params.model);
-  if (!provider || !model) {
-    cacheModelKey(cacheKey, null);
-    return null;
-  }
-  const normalized = normalizeModelRef(provider, model, {
-    allowManifestNormalization: params.allowPluginNormalization === false ? false : undefined,
-    allowPluginNormalization: params.allowPluginNormalization,
-  });
-  const key = modelKey(normalized.provider, normalized.model);
-  cacheModelKey(cacheKey, key);
-  return key;
-}
-
-function toDirectModelKey(params: { provider?: string; model?: string }): string | null {
-  const cacheKey = ["direct", params.provider ?? "", params.model ?? ""].join("\0");
-  if (modelKeyCache.has(cacheKey)) {
-    return modelKeyCache.get(cacheKey) ?? null;
-  }
-  const provider = normalizeProviderId(normalizeOptionalString(params.provider) ?? "");
-  const model = normalizeOptionalString(params.model);
-  if (!provider || !model) {
-    cacheModelKey(cacheKey, null);
-    return null;
-  }
-  const key = modelKey(provider, model);
-  cacheModelKey(cacheKey, key);
-  return key;
-}
-
-function cacheModelKey(cacheKey: string, key: string | null): void {
-  if (modelKeyCache.size >= MODEL_KEY_CACHE_LIMIT) {
-    modelKeyCache.clear();
-  }
-  modelKeyCache.set(cacheKey, key);
-}
-
-function shouldUseNormalizedCostLookup(params: { provider?: string; model?: string }): boolean {
-  const provider = normalizeProviderId(normalizeOptionalString(params.provider) ?? "");
-  const model = normalizeOptionalString(params.model) ?? "";
-  if (!provider || !model) {
-    return false;
-  }
-  return provider === "anthropic" || provider === "openrouter" || provider === "vercel-ai-gateway";
+function normalizeRawModelKey(provider: string, model: string): string {
+  const providerId = normalizeProviderId(provider);
+  // Built-in aliases remain valid; a provider-shaped prefix alone is model data.
+  return buildModelCatalogRef(
+    providerId,
+    normalizeBuiltInProviderModelId(providerId, model.trim()),
+  );
 }
 
 function isRawModelCostConfig(value: unknown): value is RawModelCostConfig {
@@ -155,17 +98,11 @@ function collectProviderCostSources(
 
 function buildProviderCostIndexBundle(
   structure: ProviderCostIndexSource[],
-  options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
+  normalizeKey: ModelKeyNormalizer,
 ): ProviderCostIndex {
   const sources: ProviderCostIndex["sources"] = new Map();
   for (const { providerKey, model, modelId } of structure) {
-    const normalized = normalizeModelRef(providerKey, modelId, {
-      allowManifestNormalization:
-        options?.allowManifestNormalization ??
-        (options?.allowPluginNormalization === false ? false : undefined),
-      allowPluginNormalization: options?.allowPluginNormalization,
-    });
-    const key = modelKey(normalized.provider, normalized.model);
+    const key = normalizeKey(providerKey, modelId);
     const rows = sources.get(key) ?? [];
     rows.push(model);
     sources.set(key, rows);
@@ -191,27 +128,19 @@ function refreshProviderCostIndexEntry(index: ProviderCostIndex, key: string): v
 
 function getProviderCostIndex(
   providers: Record<string, ModelProviderConfig> | undefined,
-  options?: { allowManifestNormalization?: boolean; allowPluginNormalization?: boolean },
+  normalizeKey: ModelKeyNormalizer = normalizeRawModelKey,
   key?: string,
 ): Map<string, RawModelCostConfig> {
   if (!providers) {
     return EMPTY_PROVIDER_COST_INDEX;
   }
-  const isRawLookup =
-    options?.allowPluginNormalization === false &&
-    (options.allowManifestNormalization === false ||
-      options.allowManifestNormalization === undefined);
-  const isDefaultNormalizedLookup =
-    options?.allowPluginNormalization !== false &&
-    options?.allowManifestNormalization === undefined;
-  let cache = providerCostIndexByConfig.get(providers);
+  // Captured policy owns normalized keys; provider config identity alone is insufficient.
+  let cache = providerCostIndexByNormalizer.get(normalizeKey);
   if (!cache) {
-    cache = {};
-    providerCostIndexByConfig.set(providers, cache);
+    cache = new WeakMap();
+    providerCostIndexByNormalizer.set(normalizeKey, cache);
   }
-  const cacheKey = isRawLookup ? "rawEntries" : "normalizedEntries";
-  const cacheable = isRawLookup || isDefaultNormalizedLookup;
-  let index = cacheable ? cache[cacheKey] : undefined;
+  let index = cache.get(providers);
   const structure = collectProviderCostSources(providers);
   // Identity and order matter even when duplicate rows have the same id.
   // Prices stay live on their source rows; only membership/id changes rebuild keys.
@@ -228,10 +157,8 @@ function getProviderCostIndex(
       );
     })
   ) {
-    index = buildProviderCostIndexBundle(structure, options);
-    if (cacheable) {
-      cache[cacheKey] = index;
-    }
+    index = buildProviderCostIndexBundle(structure, normalizeKey);
+    cache.set(providers, index);
   }
   for (const entryKey of key === undefined ? index.sources.keys() : [key]) {
     refreshProviderCostIndexEntry(index, entryKey);
@@ -241,9 +168,8 @@ function getProviderCostIndex(
 
 function loadModelsJsonCostIndex(options?: {
   agentDir?: string;
-  allowPluginNormalization?: boolean;
+  normalizeKey?: ModelKeyNormalizer;
 }): Map<string, RawModelCostConfig> {
-  const useRawEntries = options?.allowPluginNormalization === false;
   const agentDir = options?.agentDir;
   if (!agentDir) {
     return EMPTY_PROVIDER_COST_INDEX;
@@ -259,24 +185,20 @@ function loadModelsJsonCostIndex(options?: {
         return EMPTY_PROVIDER_COST_INDEX;
       }
       modelsJsonCostCache = {
-        path: modelsPath,
         providers: parsed?.providers,
-        normalizedEntries: null,
-        rawEntries: null,
+        entries: new WeakMap(),
       };
       pruneMapToMaxSize(modelsJsonCostCacheByAgentDir, MODELS_JSON_COST_CACHE_LIMIT - 1);
       modelsJsonCostCacheByAgentDir.set(agentDir, modelsJsonCostCache);
     }
 
-    if (useRawEntries) {
-      modelsJsonCostCache.rawEntries ??= getProviderCostIndex(modelsJsonCostCache.providers, {
-        allowPluginNormalization: false,
-      });
-      return modelsJsonCostCache.rawEntries;
+    const normalizeKey = options?.normalizeKey ?? normalizeRawModelKey;
+    let entries = modelsJsonCostCache.entries.get(normalizeKey);
+    if (!entries) {
+      entries = getProviderCostIndex(modelsJsonCostCache.providers, normalizeKey);
+      modelsJsonCostCache.entries.set(normalizeKey, entries);
     }
-
-    modelsJsonCostCache.normalizedEntries ??= getProviderCostIndex(modelsJsonCostCache.providers);
-    return modelsJsonCostCache.normalizedEntries;
+    return entries;
   } catch {
     return EMPTY_PROVIDER_COST_INDEX;
   }
@@ -293,23 +215,6 @@ function resolveCostAgentDir(config?: OpenClawConfig, agentDir?: string): string
   // Config-less and pricing-only lookups are shipped APIs for the historical
   // main models.json. Full runtime configs resolve their roster default above.
   return path.join(resolveStateDir(), "agents", "main", "agent");
-}
-
-function findConfiguredProviderCost(params: {
-  provider?: string;
-  model?: string;
-  config?: OpenClawConfig;
-  allowPluginNormalization?: boolean;
-}): RawModelCostConfig | undefined {
-  const key = toResolvedModelKey(params);
-  if (!key) {
-    return undefined;
-  }
-  return getProviderCostIndex(
-    params.config?.models?.providers,
-    { allowPluginNormalization: params.allowPluginNormalization },
-    key,
-  ).get(key);
 }
 
 function stableCostFingerprintValue(value: unknown): string {
@@ -346,21 +251,24 @@ export function resolveModelCostConfigFingerprint(
 ): string {
   const resolvedAgentDir = resolveCostAgentDir(config, agentDir);
   const sourceConfig = config ? projectConfigOntoRuntimeSourceSnapshot(config) : undefined;
+  const pricingContext = resolveModelPricingContext(config);
   const serialized = stableCostFingerprintValue({
-    configuredRaw: serializeCostIndex(
-      getProviderCostIndex(sourceConfig?.models?.providers, { allowPluginNormalization: false }),
+    configuredRaw: serializeCostIndex(getProviderCostIndex(sourceConfig?.models?.providers)),
+    configuredNormalized: serializeCostIndex(
+      getProviderCostIndex(sourceConfig?.models?.providers, pricingContext.normalizeKey),
     ),
-    configuredNormalized: serializeCostIndex(getProviderCostIndex(sourceConfig?.models?.providers)),
     modelsJsonRaw: serializeCostIndex(
       loadModelsJsonCostIndex({
         agentDir: resolvedAgentDir,
-        allowPluginNormalization: false,
       }),
     ),
     modelsJsonNormalized: serializeCostIndex(
-      loadModelsJsonCostIndex({ agentDir: resolvedAgentDir }),
+      loadModelsJsonCostIndex({
+        agentDir: resolvedAgentDir,
+        normalizeKey: pricingContext.normalizeKey,
+      }),
     ),
-    catalogPricing: modelCatalogPricingFingerprint(config),
+    catalogPricing: modelCatalogPricingFingerprint(pricingContext),
   });
   return createHash("sha256").update(serialized).digest("hex");
 }
@@ -376,17 +284,16 @@ export function resolveModelCostConfig(params: {
   agentDir?: string;
   allowPluginNormalization?: boolean;
 }): ModelCostConfig | undefined {
-  const rawKey = toDirectModelKey(params);
-  if (!rawKey) {
+  const provider = normalizeProviderId(normalizeOptionalString(params.provider) ?? "");
+  const model = normalizeOptionalString(params.model);
+  if (!provider || !model) {
     return undefined;
   }
+  const rawKey = normalizeRawModelKey(provider, model);
   const agentDir = resolveCostAgentDir(params.config, params.agentDir);
   // Favor direct configured keys first so local pricing/status lookups stay
   // synchronous and do not drag plugin/provider discovery into the hot path.
-  const rawModelsJsonCost = loadModelsJsonCostIndex({
-    agentDir,
-    allowPluginNormalization: false,
-  }).get(rawKey);
+  const rawModelsJsonCost = loadModelsJsonCostIndex({ agentDir }).get(rawKey);
   if (rawModelsJsonCost) {
     return normalizeModelCostConfig(rawModelsJsonCost);
   }
@@ -396,26 +303,25 @@ export function resolveModelCostConfig(params: {
   const sourceConfig = params.config
     ? projectConfigOntoRuntimeSourceSnapshot(params.config)
     : undefined;
-  let configuredCost = findConfiguredProviderCost({
-    ...params,
-    config: sourceConfig,
-    allowPluginNormalization: false,
-  });
-
-  if (
-    params.allowPluginNormalization !== false &&
-    !configuredCost &&
-    shouldUseNormalizedCostLookup(params)
-  ) {
-    const key = toResolvedModelKey(params);
-    if (key && key !== rawKey) {
-      const modelsJsonCost = loadModelsJsonCostIndex({ agentDir }).get(key);
-      if (modelsJsonCost) {
-        return normalizeModelCostConfig(modelsJsonCost);
-      }
-
-      configuredCost = findConfiguredProviderCost({ ...params, config: sourceConfig });
+  let configuredCost = getProviderCostIndex(sourceConfig?.models?.providers, undefined, rawKey).get(
+    rawKey,
+  );
+  let pricingContext: ReturnType<typeof resolveModelPricingContext> | undefined;
+  if (params.allowPluginNormalization !== false && !configuredCost) {
+    pricingContext = resolveModelPricingContext(params.config);
+    const key = pricingContext.normalizeKey(provider, model);
+    const modelsJsonCost = loadModelsJsonCostIndex({
+      agentDir,
+      normalizeKey: pricingContext.normalizeKey,
+    }).get(key);
+    if (modelsJsonCost) {
+      return normalizeModelCostConfig(modelsJsonCost);
     }
+    configuredCost = getProviderCostIndex(
+      sourceConfig?.models?.providers,
+      pricingContext.normalizeKey,
+      key,
+    ).get(key);
   }
 
   if (
@@ -429,14 +335,12 @@ export function resolveModelCostConfig(params: {
   }
   // Display-only lookups reuse prepared prices without discovering plugins;
   // ordinary lookups inherit current catalog rates, never materialized defaults.
-  const inheritedCost =
-    params.allowPluginNormalization === false
-      ? findConfiguredProviderCost(params)
-      : resolveCatalogModelPricing({
-          config: params.config,
-          provider: params.provider ?? "",
-          model: params.model ?? "",
-        });
+  if (params.allowPluginNormalization !== false) {
+    pricingContext ??= resolveModelPricingContext(params.config);
+  }
+  const inheritedCost = pricingContext
+    ? resolveModelPricing(pricingContext, pricingContext.normalizeKey(provider, model))
+    : getProviderCostIndex(params.config?.models?.providers, undefined, rawKey).get(rawKey);
   const merged = mergeModelCost(
     inheritedCost ? normalizeResolvedPricing(inheritedCost) : undefined,
     configuredCost,
@@ -479,6 +383,5 @@ export function estimateAggregateUsageCost(params: {
 
 export function resetUsageFormatCachesForTest(): void {
   modelsJsonCostCacheByAgentDir = new Map();
-  providerCostIndexByConfig = new WeakMap();
-  modelKeyCache = new Map();
+  providerCostIndexByNormalizer = new WeakMap();
 }


### PR DESCRIPTION
Related: #130324. Split from #130706; the broader Gateway CPU issue remains separate.

## What Problem This Solves

Usage-cost lookup could collapse distinct provider-prefixed model IDs or activate executable provider normalization when it only needed pricing metadata.

## Why This Change Was Made

One static pricing context captures the prepared normalization policy and uses it consistently for configured, local model-file, catalog, and hosted pricing. Normalized indexes belong to that policy context. The old runtime-capable resolver, duplicated raw/normalized branches, and normalized-string cache are removed.

The refresh preserves main's prepared policy maps, authored partial costs, ordered duplicate rows, live price mutations, endpoint rules, pricing tiers, authoritative zero costs, and source projection. Pricing no longer re-enumerates raw policy declarations. There is no new operator setting, dependency, persistent state, or provider API change.

## User Impact

Distinct model IDs keep their own rates. Provider-supplied charges, including zero, remain authoritative. Reading prices does not activate provider hooks or use hosted rates for private endpoints.

## Evidence

Current head: `fe20d8f7cad105a3e9bcdbd4447565f959d3b307`, integrated on main `e27a72435258a05d09ff5e98b2c2ac2fe18d49f4`. Main `2846c3ca8b0f81852d6df04208d787e55071a8b9` adds no further changes in these three files.

- Fresh unchanged-main reproduction: **7 intended failures / 47 passes** in the complete pricing file.
- A mechanical port of the old repair failed the extended policy-reuse assertion: four raw declaration enumerations after preparation. The repaired consumer uses main's prepared map and preserves every existing assertion.
- Final formatted source passed **215 tests across 10 files**, including all 54 pricing cases. The complete changed gate passed. QA/test audit and deslop are complete.
- Managed Codex P0 review found no actionable findings. An initial context-size admission failure ran no reviewer; the same complete context was split through the helper's supported dataset interface, with equality verified before the successful review. No threshold or sandbox was weakened.
- The ordinary full build passed on this exact head in 278 seconds, including complete declaration output. All 15,050 emitted files and 642 required SDK artifacts were verified against their canonical owners.
- Fresh built Gateway/CLI proof passed once. Four synthetic canonical SQLite usage records retained distinct **$1 / $2** estimates and authoritative **$0.25 / $0** charges. Both `sessions.usage` and `usage.cost` reported **$3.25 / 4,000,000 tokens**, with no missing cost entries. The cold rollup moved from `refreshing` to `fresh` through the normal readiness loop. Read-scope status preserved the four-session count while redacting paths, recent rows, and model details.
- All 35,860 source records and 15,050 outputs stayed unchanged. Native controller and observer joined; ten recorded process identities were gone, the Gateway port refused connections, and both owned temporary roots were removed. The runtime terminal receipt SHA-256 is `b67a1d4138d47578944ead140e4b9d2d71ecf002a5998e51211138705b4d90b5`.
- [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33442482610). Its actual integrated checkout was `4c273b9a029f692330b21be3134f1519d2427254`; the dist cache missed, so the current main SDK build recipe and export validation ran successfully. This CI-artifact result complements the ordinary full build; it is not relabeled as another full/package build.

Historical fac13 proof remains bound to that old head: ordinary build passed, and four synthetic canonical usage records retained distinct $1/$2 rates and authoritative $0.25/$0 charges. Both usage APIs reported $3.25 and 4,000,000 tokens. That run was a minimal synthetic Gateway, not authenticated billing, a provider turn, production startup, or a CPU benchmark; it is not new-head proof.

Telegram remains explicitly waived, not passed. Workspace-sensitive pricing-context lifetime is separate remaining work, not represented as fixed here.

## Review Follow-through and Size

The latest ClawSweeper review inspected this head at 21:47 UTC with no concrete correctness or security finding. Its exact-head integration rank-up move is addressed by the fresh source, built CLI/Gateway, and CI results above. Configured/local/catalog/hosted lookup and endpoint restrictions are covered by the source cohort; the built proof is specifically a minimal synthetic usage flow, not authenticated billing or a provider turn.

Production: **+116 / -227 = -111 lines** across two files. Tests: **+239 lines** in the existing file; the extra policy assertion extends an existing case. No new test-support file or committed proof harness. Changelogs are written at release time.
