### PR TITLE
fix(ui): verify default workspace before group worktrees

### DIFF
--- a/ui/src/components/app-sidebar.ts
+++ b/ui/src/components/app-sidebar.ts
@@ -101,12 +101,9 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
   async inspectSessionGroupRepository(path?: string): Promise<WorktreeRepositoryStatus> {
     const requestedPath = path?.trim();
     const agent = this.activeChipAgent().agent;
-    if (!requestedPath) {
-      return agent?.workspaceGit === true
-        ? "git"
-        : agent?.workspaceGit === false
-          ? "not_git"
-          : "unavailable";
+    const repoRoot = requestedPath || agent?.workspace;
+    if (!repoRoot) {
+      return "unavailable";
     }
     const sessions = this.context?.sessions;
     const scope = sessions?.captureConnectionScope();
@@ -114,7 +111,7 @@ class AppSidebar extends AppSidebarSessionNavigationElement implements SessionLi
       throw new Error(t("sessionsView.groupDefaultsStale"));
     }
     const result = await scope.client.request<WorktreesBranchesResult>("worktrees.branches", {
-      repoRoot: requestedPath,
+      repoRoot,
       includeRepositoryStatus: true,
     });
     if (this.context?.sessions !== sessions || !sessions.isConnectionScopeCurrent(scope)) {

--- a/ui/src/test-helpers/app-sidebar-cases/group-mutations.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/group-mutations.ts
@@ -311,6 +311,29 @@ describe("AppSidebar group mutation collapsed state", () => {
     );
   });
 
+  it("verifies the default agent workspace before offering group worktrees", async () => {
+    const request = vi.fn(async (method: string, _params?: unknown) => {
+      if (method === "worktrees.branches") {
+        return { branches: [], repositoryStatus: "unavailable" };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const gatewayHarness = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+    const harness = createSessionsHarness("main", ["agent:main:main"]);
+    const { sidebar } = await mountSidebar(gatewayHarness.gateway, harness.sessions, "panel", {
+      defaultId: "main",
+      mainKey: "main",
+      scope: "per-sender",
+      agents: [{ id: "main", workspace: "/workspace", workspaceGit: true }],
+    });
+
+    await expect(sidebar.inspectSessionGroupRepository()).resolves.toBe("unavailable");
+    expect(request).toHaveBeenCalledWith("worktrees.branches", {
+      repoRoot: "/workspace",
+      includeRepositoryStatus: true,
+    });
+  });
+
   it("leaves the catalog alone when the delete confirm is cancelled", async () => {
     const { sidebar, harness } = await mountCollapsedGroup({});
     const menu = await openGroupMenu(sidebar);

--- a/ui/src/test-helpers/app-sidebar.ts
+++ b/ui/src/test-helpers/app-sidebar.ts
@@ -5,6 +5,7 @@ import type {
   SessionsCatalogListResult,
   SessionsPatchManyParams,
   SessionsPatchManyResult,
+  WorktreeRepositoryStatus,
 } from "../../../packages/gateway-protocol/src/index.ts";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { AgentsListResult, SessionsListResult } from "../api/types.ts";
@@ -88,7 +89,7 @@ export type SidebarLifecycleState = HTMLElement & {
     home: string;
     entries: Array<{ name: string; path: string; type: "directory" | "file" }>;
   }>;
-  inspectSessionGroupRepository(path?: string): Promise<"git" | "not_git" | "unavailable">;
+  inspectSessionGroupRepository(path?: string): Promise<WorktreeRepositoryStatus>;
   requestUpdate: () => void;
   updateComplete: Promise<boolean>;
   updateAvailable: { currentVersion: string; latestVersion: string; channel: string } | null;


### PR DESCRIPTION
Closes #133700

Related: #133664

## What Problem This Solves

Fixes an issue where session-group defaults could offer Worktree mode for a default agent workspace that had a `.git` marker but no usable checkout. Unlike explicit folders and the New Session flow fixed by #133664, the empty-folder path trusted the coarse agent-roster flag without repository discovery.

## Why This Change Was Made

Session-group defaults now resolves the default agent workspace path and sends it through the existing `worktrees.branches` capability probe, exactly as it already does for an explicitly selected folder. The stale-connection guard remains authoritative for the asynchronous result.

## User Impact

Users can no longer save a Worktree group default for an agent workspace that managed worktrees cannot use. Valid repositories remain available, and unavailable or commit-less workspaces stay in direct mode.

## Evidence

- Added a regression proving an agent roster with `workspaceGit: true` still probes `/workspace` and returns unavailable when repository discovery rejects it.
- `pnpm test ui/src/components/app-sidebar.test.ts` — 324 tests passed.
- `pnpm tsgo:ui` — passed.
- Targeted `oxfmt --check` and `git diff --check` — passed.
- Production LOC: +4/-7 (net -3); tests/test support: +25/-1.
