### PR TITLE
refactor(browser): simplify relay lifecycle helpers

### DIFF
--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
@@ -9,7 +9,7 @@ import {
 } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { withEnvAsync, withTempDir } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it } from "vitest";
-import { WebSocket, type ClientOptions, type RawData } from "ws";
+import { WebSocket, type RawData } from "ws";
 import { parsePairingString } from "../../../chrome-extension/modules/relay-core.js";
 import { relayTestKey } from "../../../chrome-extension/relay-key.test-support.js";
 import {
@@ -83,33 +83,21 @@ async function relayInventory(port: number): Promise<unknown> {
   }
 }
 
-function upgradeWithFrames(messages: object[]): {
-  bytes: number;
-  finishRequest: NonNullable<ClientOptions["finishRequest"]>;
-} {
-  const frames = messages.map((message) => {
-    const payload = Buffer.from(JSON.stringify(message));
-    const extended = payload.length >= 126;
-    const header = Buffer.alloc(extended ? 8 : 6);
-    header[0] = 0x81;
-    header[1] = 0x80 | (extended ? 126 : payload.length);
-    if (extended) {
-      header.writeUInt16BE(payload.length, 2);
-    }
-    // The fixed zero mask leaves these synthetic payload bytes unchanged.
-    return Buffer.concat([header, payload]);
-  });
-  const finishRequest: NonNullable<ClientOptions["finishRequest"]> = (request) => {
-    request.once("socket", (socket) => {
-      socket.once("connect", () => {
-        socket.cork();
-        request.end();
-        socket.write(Buffer.concat(frames));
-        socket.uncork();
-      });
-    });
-  };
-  return { bytes: frames.reduce((sum, frame) => sum + frame.byteLength, 0), finishRequest };
+function encodeUpgradeHead(messages: object[]): Buffer {
+  return Buffer.concat(
+    messages.map((message) => {
+      const payload = Buffer.from(JSON.stringify(message));
+      const extended = payload.length >= 126;
+      const header = Buffer.alloc(extended ? 8 : 6);
+      header[0] = 0x81;
+      header[1] = 0x80 | (extended ? 126 : payload.length);
+      if (extended) {
+        header.writeUInt16BE(payload.length, 2);
+      }
+      // The fixed zero mask leaves these synthetic payload bytes unchanged.
+      return Buffer.concat([header, payload]);
+    }),
+  );
 }
 
 function rawDataText(data: RawData): string {
@@ -219,14 +207,29 @@ describe.sequential("local Gateway extension relay wakeup", () => {
             OPENCLAW_GATEWAY_PORT: String(gatewayPort),
           },
           async () => {
+            const inventory = {
+              type: "tabs",
+              tabs: [
+                {
+                  tabId: 7,
+                  url: "https://example.test/initial",
+                  title: "Coalesced inventory",
+                  active: true,
+                },
+              ],
+            };
+            const coalesced =
+              legacy === "head" ? encodeUpgradeHead([EXTENSION_HELLO, inventory]) : undefined;
             const gatewayServer = http.createServer((_req, res) => {
               res.writeHead(426);
               res.end();
             });
             let upgradeHeadBytes = 0;
             gatewayServer.on("upgrade", (req, socket, head) => {
-              upgradeHeadBytes = head.byteLength;
-              void handleGatewayExtensionUpgrade(req, socket, head);
+              // TCP writes cannot guarantee Node's upgrade-head size; supply that exact boundary.
+              const initialHead = coalesced ?? head;
+              upgradeHeadBytes = initialHead.byteLength;
+              void handleGatewayExtensionUpgrade(req, socket, initialHead);
             });
             let extension: WebSocket | undefined;
             let daemon: Awaited<ReturnType<typeof runExtensionRelayDaemon>> | undefined;
@@ -261,22 +264,8 @@ describe.sequential("local Gateway extension relay wakeup", () => {
               const protocols = legacy
                 ? ["openclaw-extension-relay", `openclaw-extension-token.${RELAY_KEY}`]
                 : BROWSER_RELAY_EXTENSION_SUBPROTOCOL;
-              const inventory = {
-                type: "tabs",
-                tabs: [
-                  {
-                    tabId: 7,
-                    url: "https://example.test/initial",
-                    title: "Coalesced inventory",
-                    active: true,
-                  },
-                ],
-              };
-              const coalesced =
-                legacy === "head" ? upgradeWithFrames([EXTENSION_HELLO, inventory]) : undefined;
               extension = new WebSocket(parsed.relayUrl, protocols, {
                 origin: "chrome-extension://gateway-wakeup-integration",
-                finishRequest: coalesced?.finishRequest,
               });
               await once(extension, "open");
               if (!legacy) {
@@ -307,7 +296,7 @@ describe.sequential("local Gateway extension relay wakeup", () => {
                 expect(JSON.parse(rawDataText(okData))).toMatchObject({ type: "auth.ok", v: 2 });
               }
               if (legacy === "head") {
-                expect(upgradeHeadBytes).toBe(coalesced?.bytes);
+                expect(upgradeHeadBytes).toBe(coalesced?.byteLength);
               } else {
                 extension.send(JSON.stringify(EXTENSION_HELLO));
               }

--- a/extensions/browser/src/browser/extension-relay/owner-client.ts
+++ b/extensions/browser/src/browser/extension-relay/owner-client.ts
@@ -14,6 +14,9 @@ import {
   type RelayOwnerStatus,
 } from "./owner-protocol.js";
 
+const nullableIdResult = z.string().nullable();
+const streamIdResult = z.number().int().positive();
+
 type OwnerStream = {
   send: (raw: string) => void;
   close: () => Promise<void>;
@@ -43,23 +46,12 @@ export class RelayOwnerClient {
   private retirementAcknowledged = false;
   private closing: Promise<void> | undefined;
 
-  private constructor(
-    private readonly ws: WebSocket,
-    readonly owner: string,
-  ) {
+  private constructor(private readonly ws: WebSocket) {
     ws.on("message", (raw) => {
       const parsed = parseStrictJsonObject(rawDataToString(raw));
       if (relayOwnerRetired.safeParse(parsed).success) {
         this.retirementAcknowledged = true;
-        this.closed = true;
-        for (const pending of this.pending.values()) {
-          pending.reject(new Error("Relay owner retired"));
-        }
-        this.pending.clear();
-        for (const stream of this.streams.values()) {
-          stream.onClose?.();
-        }
-        this.streams.clear();
+        this.invalidate("Relay owner retired");
         return;
       }
       const reply = relayOwnerReply.safeParse(parsed);
@@ -86,17 +78,19 @@ export class RelayOwnerClient {
       }
       ws.close(4003, "invalid relay owner response");
     });
-    ws.once("close", () => {
-      this.closed = true;
-      for (const pending of this.pending.values()) {
-        pending.reject(new Error("Relay owner connection lost"));
-      }
-      this.pending.clear();
-      for (const stream of this.streams.values()) {
-        stream.onClose?.();
-      }
-      this.streams.clear();
-    });
+    ws.once("close", () => this.invalidate("Relay owner connection lost"));
+  }
+
+  private invalidate(message: string): void {
+    this.closed = true;
+    for (const pending of this.pending.values()) {
+      pending.reject(new Error(message));
+    }
+    this.pending.clear();
+    for (const stream of this.streams.values()) {
+      stream.onClose?.();
+    }
+    this.streams.clear();
   }
 
   static async connect(params: {
@@ -105,8 +99,8 @@ export class RelayOwnerClient {
     token: string;
     signal: AbortSignal;
   }) {
-    const { ws, owner } = await authenticateRelayOwner(params);
-    return new RelayOwnerClient(ws, owner);
+    const { ws } = await authenticateRelayOwner(params);
+    return new RelayOwnerClient(ws);
   }
 
   adoptProfileLease(assertCurrent: () => void): void {
@@ -162,10 +156,7 @@ export class RelayOwnerClient {
   ): Promise<RelayOperationReference> {
     this.assertCurrent();
     assertOperationCurrent();
-    const ref = z
-      .string()
-      .nullable()
-      .parse(await this.request("capture", { targetId }));
+    const ref = nullableIdResult.parse(await this.request("capture", { targetId }));
     try {
       this.assertCurrent();
       assertOperationCurrent();
@@ -186,10 +177,7 @@ export class RelayOwnerClient {
     return {
       resolve: async () => {
         assertReference();
-        const target = z
-          .string()
-          .nullable()
-          .parse(await this.request("resolve", { ref }));
+        const target = nullableIdResult.parse(await this.request("resolve", { ref }));
         assertReference();
         return target ?? undefined;
       },
@@ -223,11 +211,7 @@ export class RelayOwnerClient {
 
   private async openStream(op: "cdp.open" | "ingress.open", ref?: string): Promise<OwnerStream> {
     this.assertCurrent();
-    const id = z
-      .number()
-      .int()
-      .positive()
-      .parse(await this.request(op, ref ? { ref } : {}));
+    const id = streamIdResult.parse(await this.request(op, ref ? { ref } : {}));
     this.assertCurrent();
     let closed = false;
     let closing: Promise<void> | undefined;

--- a/extensions/browser/src/browser/extension-relay/relay-access.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-access.ts
@@ -13,20 +13,16 @@ export type BorrowedRelayAccess = {
 export type ExtensionRelayResource = ExtensionRelayHandle | BorrowedRelayAccess;
 
 // Prepared by the profile lifecycle only. This registry never discovers keys or listeners.
-const borrowedCdpAccess = new Map<
-  string,
-  { relay: BorrowedRelayAccess; assertCurrent: () => void }
->();
+const borrowedCdpAccess = new Map<string, { relay: BorrowedRelayAccess }>();
 
 export function registerBorrowedRelayCdpAccess(
   cdpUrl: string,
   relay: BorrowedRelayAccess,
-  assertCurrent: () => void,
 ): () => void {
-  const entry = { relay, assertCurrent };
-  borrowedCdpAccess.set(cdpUrl.replace(/\/$/u, ""), entry);
+  const key = cdpUrl.replace(/\/$/u, "");
+  const entry = { relay };
+  borrowedCdpAccess.set(key, entry);
   return () => {
-    const key = cdpUrl.replace(/\/$/u, "");
     if (borrowedCdpAccess.get(key) === entry) {
       borrowedCdpAccess.delete(key);
     }
@@ -34,11 +30,7 @@ export function registerBorrowedRelayCdpAccess(
 }
 
 export function getBorrowedRelayCdpAccess(cdpUrl: string): BorrowedRelayAccess | undefined {
-  const entry = borrowedCdpAccess.get(cdpUrl.replace(/\/$/u, ""));
-  if (!entry) {
-    return undefined;
-  }
-  entry.assertCurrent();
-  entry.relay.client.assertCurrent();
-  return entry.relay;
+  const relay = borrowedCdpAccess.get(cdpUrl.replace(/\/$/u, ""))?.relay;
+  relay?.client.assertCurrent();
+  return relay;
 }

--- a/extensions/browser/src/browser/extension-relay/relay-bridge.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-bridge.ts
@@ -441,12 +441,9 @@ export class ExtensionRelayBridge {
           if (!client.autoAttach) {
             continue;
           }
-          void this.withAttachedTab(client, info.tabId, ({ targetId, sessionId }) => {
+          void this.withAttachedTab(client, info.tabId, (attached) => {
             if (client.autoAttach) {
-              this.announceAttachedTab(info.tabId, targetId, sessionId, {
-                onlyAutoAttach: false,
-                onlyClient: client,
-              });
+              this.announceAttachedTab(info.tabId, attached, [client]);
             }
           }).catch((err: unknown) =>
             log.warn(`auto-attach of accessible tab ${info.tabId} failed: ${String(err)}`),
@@ -612,27 +609,21 @@ export class ExtensionRelayBridge {
 
   private announceAttachedTab(
     tabId: number,
-    targetId: string,
-    sessionId: string,
-    opts: { onlyAutoAttach: boolean; onlyClient?: CdpClientState },
+    attached: { targetId: string; sessionId: string },
+    recipients: readonly CdpClientState[],
   ): void {
     const tab = this.tabs.get(tabId);
+    const { targetId, sessionId } = attached;
     if (tab?.target?.sessionId !== sessionId) {
       return;
     }
-    const event = {
-      method: "Target.attachedToTarget",
-      params: {
-        sessionId,
-        targetInfo: this.targetInfoForTab(tab, targetId),
-        waitingForDebugger: false,
-      },
+    const params = {
+      sessionId,
+      targetInfo: this.targetInfoForTab(tab, targetId),
+      waitingForDebugger: false,
     };
-    const recipients = opts.onlyClient
-      ? [opts.onlyClient]
-      : [...this.clients].filter((client) => !opts.onlyAutoAttach || client.autoAttach);
     for (const client of recipients) {
-      this.sessions.announce(client, sessionId, sessionId, event.params);
+      this.sessions.announce(client, sessionId, sessionId, params);
     }
   }
 
@@ -843,13 +834,9 @@ export class ExtensionRelayBridge {
       client,
       tabId,
       (attached) => {
-        this.announceAttachedTab(tabId, attached.targetId, attached.sessionId, {
-          onlyAutoAttach: true,
-        });
-        this.announceAttachedTab(tabId, attached.targetId, attached.sessionId, {
-          onlyAutoAttach: false,
-          onlyClient: client,
-        });
+        const recipients = [...this.clients].filter((recipient) => recipient.autoAttach);
+        this.announceAttachedTab(tabId, attached, recipients);
+        this.announceAttachedTab(tabId, attached, [client]);
         this.respond(client, request, { targetId: attached.targetId });
       },
       typeof created.targetId === "string" ? created.targetId : undefined,
@@ -1063,12 +1050,9 @@ export class ExtensionRelayBridge {
         if (autoAttach) {
           const attachResults = await Promise.allSettled(
             [...this.tabs.keys()].map((tabId) =>
-              this.withAttachedTab(client, tabId, ({ targetId, sessionId }) => {
+              this.withAttachedTab(client, tabId, (attached) => {
                 if (client.autoAttach) {
-                  this.announceAttachedTab(tabId, targetId, sessionId, {
-                    onlyAutoAttach: false,
-                    onlyClient: client,
-                  });
+                  this.announceAttachedTab(tabId, attached, [client]);
                 }
               }),
             ),

--- a/extensions/browser/src/browser/extension-relay/relay-lifecycle.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-lifecycle.ts
@@ -261,7 +261,6 @@ async function ensureDesiredRelay(params: {
           unregister = registerBorrowedRelayCdpAccess(
             `http://127.0.0.1:${profile.cdpPort}`,
             borrowed,
-            assertCurrent,
           );
         }
         actor.cleanupRelays.add(handle);

--- a/extensions/browser/src/browser/relay-daemon.ts
+++ b/extensions/browser/src/browser/relay-daemon.ts
@@ -1,3 +1,4 @@
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { getRuntimeConfig } from "../config/config.js";
 import { extractErrorCode } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -50,18 +51,13 @@ export async function runExtensionRelayDaemon(params: {
   const now = params.now ?? Date.now;
   const idleExitMs = params.idleExitMs ?? RELAY_DAEMON_IDLE_EXIT_MS;
   const pollMs = params.pollMs ?? IDLE_POLL_MS;
-  let resolveDone: (reason: RelayDaemonExitReason) => void = () => {};
-  let rejectDone: (error: unknown) => void = () => {};
-  const done = new Promise<RelayDaemonExitReason>((resolve, reject) => {
-    resolveDone = resolve;
-    rejectDone = reject;
-  });
+  const completion = createDeferred<RelayDaemonExitReason>();
 
   const token = readToken();
   if (!token) {
     log.warn("relay daemon refused to start: no extension relay credential");
-    resolveDone("no-credential");
-    return { done, port: null, stop: () => {} };
+    completion.resolve("no-credential");
+    return { done: completion.promise, port: null, stop: () => {} };
   }
 
   let handle: ExtensionRelayHandle;
@@ -83,8 +79,8 @@ export async function runExtensionRelayDaemon(params: {
   } catch (error) {
     if (extractErrorCode(error) === "EADDRINUSE") {
       log.info(`relay port ${params.port} is already served; standalone daemon not needed`);
-      resolveDone("port-in-use");
-      return { done, port: null, stop: () => {} };
+      completion.resolve("port-in-use");
+      return { done: completion.promise, port: null, stop: () => {} };
     }
     throw error;
   }
@@ -98,7 +94,7 @@ export async function runExtensionRelayDaemon(params: {
     }
     stopped = true;
     clearInterval(idleTimer);
-    void handle.close().then(() => resolveDone(reason), rejectDone);
+    void handle.close().then(() => completion.resolve(reason), completion.reject);
   };
   const idleTimer = setInterval(() => {
     if (handle.bridge.extensionConnected || handle.bridge.cdpClientCount > 0) {
@@ -113,7 +109,7 @@ export async function runExtensionRelayDaemon(params: {
   idleTimer.unref?.();
 
   return {
-    done,
+    done: completion.promise,
     port: handle.port,
     stop: () => finish("stopped"),
   };

--- a/extensions/browser/src/browser/routes/agent.act.ts
+++ b/extensions/browser/src/browser/routes/agent.act.ts
@@ -171,29 +171,6 @@ async function assertExistingSessionPostInteractionNavigationAllowed(
   throw new Error("Unable to verify stable post-interaction navigation");
 }
 
-async function runExistingSessionActionWithNavigationGuard<T>(params: {
-  execute: () => Promise<T>;
-  guard?: Parameters<typeof assertExistingSessionPostInteractionNavigationAllowed>[0];
-}): Promise<T> {
-  let actionError: unknown;
-  let result: T | undefined;
-  try {
-    result = await params.execute();
-  } catch (error) {
-    actionError = error;
-  }
-
-  if (params.guard) {
-    await assertExistingSessionPostInteractionNavigationAllowed(params.guard);
-  }
-
-  if (actionError) {
-    throw toErrorObject(actionError, "Non-Error thrown");
-  }
-
-  return result as T;
-}
-
 function buildExistingSessionWaitPredicate(params: {
   text?: string;
   textGone?: string;
@@ -552,115 +529,112 @@ export function registerBrowserAgentActRoutes(
                 unsupportedMessage,
               );
             }
+            const runGuardedAction = async <T>(execute: () => Promise<T>): Promise<T> => {
+              let actionError: unknown;
+              let result: T | undefined;
+              try {
+                result = await execute();
+              } catch (error) {
+                actionError = error;
+              }
+              await assertExistingSessionPostInteractionNavigationAllowed(
+                existingSessionNavigationGuard,
+              );
+              if (actionError) {
+                throw toErrorObject(actionError, "Non-Error thrown");
+              }
+              return result as T;
+            };
             switch (action.kind) {
               case "click":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    clickChromeMcpElement({
-                      ...existingSessionTarget,
-                      uid: action.ref!,
-                      doubleClick: action.doubleClick ?? false,
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
+                await runGuardedAction(() =>
+                  clickChromeMcpElement({
+                    ...existingSessionTarget,
+                    uid: action.ref!,
+                    doubleClick: action.doubleClick ?? false,
+                  }),
+                );
                 return await jsonOk(undefined, { resolveCurrentTarget: true });
               case "clickCoords":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    clickChromeMcpCoords({
-                      ...existingSessionTarget,
-                      x: action.x,
-                      y: action.y,
-                      doubleClick: action.doubleClick ?? false,
-                      button: action.button as "left" | "right" | "middle" | undefined,
-                      delayMs: action.delayMs,
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
+                await runGuardedAction(() =>
+                  clickChromeMcpCoords({
+                    ...existingSessionTarget,
+                    x: action.x,
+                    y: action.y,
+                    doubleClick: action.doubleClick ?? false,
+                    button: action.button as "left" | "right" | "middle" | undefined,
+                    delayMs: action.delayMs,
+                  }),
+                );
                 return await jsonOk(undefined, { resolveCurrentTarget: true });
               case "type":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: async () => {
-                    await fillChromeMcpElement({
+                await runGuardedAction(async () => {
+                  await fillChromeMcpElement({
+                    ...existingSessionTarget,
+                    uid: action.ref!,
+                    value: action.text,
+                  });
+                  if (action.submit) {
+                    await pressChromeMcpKey({
                       ...existingSessionTarget,
-                      uid: action.ref!,
-                      value: action.text,
+                      key: "Enter",
                     });
-                    if (action.submit) {
-                      await pressChromeMcpKey({
-                        ...existingSessionTarget,
-                        key: "Enter",
-                      });
-                    }
-                  },
-                  guard: existingSessionNavigationGuard,
+                  }
                 });
                 return await jsonOk(undefined, { resolveCurrentTarget: true });
               case "press":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    pressChromeMcpKey({
-                      ...existingSessionTarget,
-                      key: action.key,
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
+                await runGuardedAction(() =>
+                  pressChromeMcpKey({
+                    ...existingSessionTarget,
+                    key: action.key,
+                  }),
+                );
                 return await jsonOk(undefined, { resolveCurrentTarget: true });
               case "hover":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    hoverChromeMcpElement({
-                      ...existingSessionTarget,
-                      uid: action.ref!,
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
+                await runGuardedAction(() =>
+                  hoverChromeMcpElement({
+                    ...existingSessionTarget,
+                    uid: action.ref!,
+                  }),
+                );
                 return await jsonOk(undefined, { resolveCurrentTarget: true });
               case "scrollIntoView":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    evaluateChromeMcpScript({
-                      ...existingSessionTarget,
-                      fn: `(el) => { el.scrollIntoView({ block: "center", inline: "center" }); return true; }`,
-                      args: [action.ref!],
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
+                await runGuardedAction(() =>
+                  evaluateChromeMcpScript({
+                    ...existingSessionTarget,
+                    fn: `(el) => { el.scrollIntoView({ block: "center", inline: "center" }); return true; }`,
+                    args: [action.ref!],
+                  }),
+                );
                 return await jsonOk(undefined, { resolveCurrentTarget: true });
               case "drag":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    dragChromeMcpElement({
-                      ...existingSessionTarget,
-                      fromUid: action.startRef!,
-                      toUid: action.endRef!,
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
+                await runGuardedAction(() =>
+                  dragChromeMcpElement({
+                    ...existingSessionTarget,
+                    fromUid: action.startRef!,
+                    toUid: action.endRef!,
+                  }),
+                );
                 return await jsonOk(undefined, { resolveCurrentTarget: true });
               case "select":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    fillChromeMcpElement({
-                      ...existingSessionTarget,
-                      uid: action.ref!,
-                      value: action.values[0] ?? "",
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
+                await runGuardedAction(() =>
+                  fillChromeMcpElement({
+                    ...existingSessionTarget,
+                    uid: action.ref!,
+                    value: action.values[0] ?? "",
+                  }),
+                );
                 return await jsonOk(undefined, { resolveCurrentTarget: true });
               case "fill":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    fillChromeMcpForm({
-                      ...existingSessionTarget,
-                      elements: action.fields.map((field) => ({
-                        uid: field.ref,
-                        value: String(field.value ?? ""),
-                      })),
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
+                await runGuardedAction(() =>
+                  fillChromeMcpForm({
+                    ...existingSessionTarget,
+                    elements: action.fields.map((field) => ({
+                      uid: field.ref,
+                      value: String(field.value ?? ""),
+                    })),
+                  }),
+                );
                 return await jsonOk(undefined, { resolveCurrentTarget: true });
               case "resize":
                 await resizeChromeMcpPage({
@@ -670,35 +644,31 @@ export function registerBrowserAgentActRoutes(
                 });
                 return await jsonOk();
               case "wait":
-                await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    waitForExistingSessionCondition({
-                      ...existingSessionTarget,
-                      timeMs: action.timeMs,
-                      text: action.text,
-                      textGone: action.textGone,
-                      selector: action.selector,
-                      url: action.url,
-                      loadState: action.loadState,
-                      fn: action.fn,
-                      ...navigationPolicy,
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
+                await runGuardedAction(() =>
+                  waitForExistingSessionCondition({
+                    ...existingSessionTarget,
+                    timeMs: action.timeMs,
+                    text: action.text,
+                    textGone: action.textGone,
+                    selector: action.selector,
+                    url: action.url,
+                    loadState: action.loadState,
+                    fn: action.fn,
+                    ...navigationPolicy,
+                  }),
+                );
                 return await jsonOk();
               case "evaluate": {
-                const result = await runExistingSessionActionWithNavigationGuard({
-                  execute: () =>
-                    evaluateChromeMcpScript({
-                      ...existingSessionTarget,
-                      fn: normalizeBrowserEvaluateFunctionSource(
-                        action.fn,
-                        action.ref ? { argumentName: "el" } : undefined,
-                      ),
-                      args: action.ref ? [action.ref] : undefined,
-                    }),
-                  guard: existingSessionNavigationGuard,
-                });
+                const result = await runGuardedAction(() =>
+                  evaluateChromeMcpScript({
+                    ...existingSessionTarget,
+                    fn: normalizeBrowserEvaluateFunctionSource(
+                      action.fn,
+                      action.ref ? { argumentName: "el" } : undefined,
+                    ),
+                    args: action.ref ? [action.ref] : undefined,
+                  }),
+                );
                 return await jsonOk({ result }, { resolveCurrentTarget: true });
               }
               case "close":


### PR DESCRIPTION
Related: [standalone browser relay and native-host wake-up](https://github.com/openclaw/openclaw/pull/128379).

<details>
<summary>Additional instructions</summary>

Maintainer-requested cleanup. This same-repository branch remains editable by maintainers.

</details>

## What Problem This Solves

The landed standalone browser relay and adjacent action handling contain repeated lifecycle bookkeeping and action wrappers that make their ownership boundaries harder to maintain. This follows an explicit maintainer request to simplify that code and reduce production LOC.

The focused baseline also exposed a flaky Gateway ingress fixture: it assumed corked TCP writes would arrive entirely in Node's WebSocket upgrade `head`, but received zero head bytes instead of the expected 243.

## Why This Change Was Made

Keep the existing owners and remove duplication: the owner client alone enforces its adopted profile admission; retirement and disconnection share terminal invalidation without conflating acknowledgement; immutable RPC result schemas are reused; unused retained owner metadata is removed; target announcements receive explicit recipient snapshots; daemon completion uses the existing deferred helper; existing-session actions bind their navigation guard once.

The ingress fixture supplies its encoded bytes at the existing production upgrade-head boundary, as the pre-auth boundary tests already do. It still exercises real HTTP/WebSocket authentication, buffered-frame consumption, hello promotion and inventory publication. Node's `OutgoingMessage.end()` fully uncorks the socket, and TCP writes cannot guarantee parser head boundaries. No retry, timeout increase or weakened assertion was added.

## User Impact

No intended user-visible behavior change. Authentication, live-key checks, checks across asynchronous boundaries, reference and registration identity, cleanup acknowledgements, recipient ordering, action error precedence and cancellation remain unchanged. No new configuration, protocol, storage, dependency or public SDK surface.

Production: **+161/-236, net -75 lines** across six files. Tests/support: **+34/-45, net -11 lines** in one file. This does not claim to repair separately tracked correctness issues in unchanged relay code.

## Evidence

- Untouched baseline: **112 passed, 1 failed**. The failure was the borrowed legacy upgrade-head fixture described above.
- After cleanup and deterministic fixture repair: **203 passed, 0 failed, 0 pending** across 19 focused files. Coverage includes owned/borrowed relay bootstrap, profile/key drift, retirement, reference fencing, Gateway ingress, announcement/creation, daemon shutdown and action/navigation guards.
- Complete changed-scope checks passed: formatting, production/test types, lint, doctor contracts, dependency/export and ownership guards, and import cycles. No skip override.
- Full build passed with unchanged source and no ineffective-dynamic-import diagnostic.
- Four independent cleanup reviews and a final quality/equivalence review completed. Fresh managed Codex autoreview of the uncommitted diff at P0 is scoped-clean with no findings. Exact-head CI will be verified before native preparation and merge.

This is a bounded behavior-preserving refactor. No operator browser/Gateway was touched, no new installed/live-browser claim is made, and no visual behavior changed.

<details>
<summary>Exact local validation commands</summary>

```bash
OPENCLAW_VITEST_MAX_WORKERS=4 node scripts/run-vitest.mjs \
  extensions/browser/src/browser/extension-relay/owner-auth-client.test.ts \
  extensions/browser/src/browser/extension-relay/owner-server.test.ts \
  extensions/browser/src/browser/extension-relay/owner-connection.integration.test.ts \
  extensions/browser/src/browser/extension-relay/relay-coexistence.integration.test.ts \
  extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts \
  extensions/browser/src/browser/extension-relay/gateway-relay-ingress.integration.test.ts \
  extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts \
  extensions/browser/src/browser/extension-relay/relay-lifecycle.test.ts \
  extensions/browser/src/browser/extension-relay/relay-bootstrap.integration.test.ts \
  extensions/browser/src/browser/pw-session.pinned-transport.test.ts \
  extensions/browser/src/browser/server-context.extension-readiness.test.ts \
  extensions/browser/src/browser/relay-daemon.test.ts \
  extensions/browser/src/browser/extension-relay-daemon-spawn.test.ts \
  extensions/browser/src/browser/extension-install-layout.test.ts \
  extensions/browser/src/browser/extension-relay/relay-bridge.test.ts \
  extensions/browser/src/browser/extension-relay/relay-targets.test.ts \
  extensions/browser/src/browser/extension-relay/relay-bridge.cleanup.test.ts \
  extensions/browser/src/browser/relay-daemon.shutdown.test.ts \
  extensions/browser/src/browser/routes/agent.act.existing-session-navigation-guard.test.ts \
  --reporter=default --reporter=json --outputFile=.artifacts/relay-simplify-20260831/after-vitest.json
```

```bash
node scripts/check-changed.mjs --timed -- \
  extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts \
  extensions/browser/src/browser/extension-relay/owner-client.ts \
  extensions/browser/src/browser/extension-relay/relay-access.ts \
  extensions/browser/src/browser/extension-relay/relay-bridge.ts \
  extensions/browser/src/browser/extension-relay/relay-lifecycle.ts \
  extensions/browser/src/browser/relay-daemon.ts \
  extensions/browser/src/browser/routes/agent.act.ts
```

```bash
pnpm build
```

```bash
git diff --check
```

</details>
