### PR TITLE
fix(apple): stop JSON numbers becoming booleans

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -395,7 +395,7 @@ struct MacNodeHostWorkerTests {
               IFS= read -r unavailable
               printf '%s' "$unavailable" | grep -q '"type":"gateway-response"' || exit 44
               printf '%s' "$unavailable" | grep -q '"ok":false' || exit 45
-              printf '%s\\n' '{"type":"invoke-result","generation":0,"result":{"id":"worker-run","ok":true,"payload":{"owner":"cli"}}}'
+              printf '%s\\n' '{"type":"invoke-result","generation":0,"result":{"id":"worker-run","ok":true,"payload":{"owner":"cli","generations":[0,1,9007199254740993,18446744073709551615],"flags":[false,true]}}}'
               ;;
           esac
         done
@@ -408,9 +408,22 @@ struct MacNodeHostWorkerTests {
             id: "worker-run",
             command: "system.run",
             paramsJSON: #"{"command":["/usr/bin/true"]}"#))
-        #expect(response.ok)
-        #expect(response.payload != nil)
         await worker.stop()
+        #expect(response.ok)
+
+        struct Response: Decodable {
+            struct Payload: Decodable {
+                let owner: String
+                let generations: [UInt64]
+                let flags: [Bool]
+            }
+
+            let payload: Payload
+        }
+        let decoded = try JSONDecoder().decode(Response.self, from: JSONEncoder().encode(response))
+        #expect(decoded.payload.owner == "cli")
+        #expect(decoded.payload.generations == [0, 1, 9_007_199_254_740_993, UInt64.max])
+        #expect(decoded.payload.flags == [false, true])
     }
 
     @Test func `worker strips inherited CUA values and receives only the app-provided endpoint`() async throws {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/AnyCodable+Helpers.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/AnyCodable+Helpers.swift
@@ -6,25 +6,12 @@ extension AnyCodable {
     }
 
     public var boolValue: Bool? {
-        if let value = self.value as? Bool {
-            return value
-        }
-        if let number = self.value as? NSNumber, CFGetTypeID(number) == CFBooleanGetTypeID() {
-            return number.boolValue
-        }
-        return nil
+        self.value as? Bool
     }
 
     public var intValue: Int? {
-        if let value = self.value as? Int {
-            return value
-        }
-        if let number = self.value as? NSNumber, CFGetTypeID(number) != CFBooleanGetTypeID() {
-            let value = number.doubleValue
-            if value > 0, value.rounded(.towardZero) == value, value <= Double(Int.max) {
-                return Int(value)
-            }
-        }
+        if let value = self.value as? any BinaryInteger { return Int(exactly: value) }
+        if let value = self.value as? any BinaryFloatingPoint { return Int(exactly: value) }
         return nil
     }
 

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/AnyCodable.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/AnyCodable.swift
@@ -1,3 +1,4 @@
+import CoreFoundation
 import Foundation
 
 /// Lightweight `Codable` wrapper that round-trips heterogeneous JSON payloads.
@@ -22,6 +23,10 @@ public struct AnyCodable: Codable, @unchecked Sendable, Hashable {
         }
         if let int64Val = try? container.decode(Int64.self) {
             self.value = int64Val
+            return
+        }
+        if let uint64Val = try? container.decode(UInt64.self) {
+            self.value = uint64Val
             return
         }
         if let doubleVal = try? container.decode(Double.self) {
@@ -49,30 +54,15 @@ public struct AnyCodable: Codable, @unchecked Sendable, Hashable {
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
-        switch self.value {
+        switch self.canonicalValue {
         case let boolVal as Bool: try container.encode(boolVal)
-        case let intVal as Int: try container.encode(intVal)
         case let int64Val as Int64: try container.encode(int64Val)
+        case let uint64Val as UInt64: try container.encode(uint64Val)
         case let doubleVal as Double: try container.encode(doubleVal)
         case let stringVal as String: try container.encode(stringVal)
-        case let number as NSNumber where CFGetTypeID(number) == CFBooleanGetTypeID():
-            try container.encode(number.boolValue)
         case is NSNull: try container.encodeNil()
         case let dict as [String: AnyCodable]: try container.encode(dict)
         case let array as [AnyCodable]: try container.encode(array)
-        case let dict as [String: Any]:
-            try container.encode(dict.mapValues { AnyCodable($0) })
-        case let array as [Any]:
-            try container.encode(array.map { AnyCodable($0) })
-        case let dict as NSDictionary:
-            var converted: [String: AnyCodable] = [:]
-            for (k, v) in dict {
-                guard let key = k as? String else { continue }
-                converted[key] = AnyCodable(v)
-            }
-            try container.encode(converted)
-        case let array as NSArray:
-            try container.encode(array.map { AnyCodable($0) })
         default:
             let context = EncodingError.Context(
                 codingPath: encoder.codingPath,
@@ -82,19 +72,58 @@ public struct AnyCodable: Codable, @unchecked Sendable, Hashable {
     }
 
     private static func normalize(_ value: Any) -> Any {
-        if let number = value as? NSNumber, CFGetTypeID(number) == CFBooleanGetTypeID() {
-            return number.boolValue
+        // Preserve native scalar types; NSNumber bridging can erase their original numeric kind.
+        guard type(of: value) is NSNumber.Type, let number = value as? NSNumber else { return value }
+        // Numeric 0/1 also cast to Bool; only CFBoolean represents a JSON boolean.
+        if CFGetTypeID(number) == CFBooleanGetTypeID() { return number.boolValue }
+        // NSNumber's integer casts can saturate binary floats. Use native exact conversion
+        // before encoding integral floats; decimal boxes retain their original integer precision.
+        if !(number is NSDecimalNumber), ["f", "d"].contains(String(cString: number.objCType)) {
+            let double = number.doubleValue
+            if let int = Int(exactly: double) { return int }
+            if let int64 = Int64(exactly: double) { return int64 }
+            if let uint64 = UInt64(exactly: double) { return uint64 }
+            return double
         }
+        if let int = Int(exactly: number) { return int }
+        if let int64 = Int64(exactly: number) { return int64 }
+        if let uint64 = UInt64(exactly: number) { return uint64 }
+        if let double = Double(exactly: number) { return double }
         return value
     }
 
+    /// Preserve constructed raw collections and decoded wrapped collections on .value.
+    /// All operations share this projection, so both shapes have identical structural semantics.
+    private var canonicalValue: Any {
+        switch self.value {
+        // Equal integer magnitudes share one hash domain, including Int on 32-bit watchOS.
+        case let int as Int:
+            return Int64(int)
+        case let uint as UInt64:
+            if let int64 = Int64(exactly: uint) { return int64 }
+            return uint
+        case is [String: AnyCodable], is [AnyCodable]:
+            return self.value
+        case let dict as [String: Any]:
+            return dict.mapValues(AnyCodable.init)
+        case let array as [Any]:
+            return array.map(AnyCodable.init)
+        case let dict as NSDictionary:
+            var converted: [String: AnyCodable] = [:]
+            for case let (key as String, raw) in dict {
+                converted[key] = AnyCodable(raw)
+            }
+            return converted
+        default:
+            return self.value
+        }
+    }
+
     public static func == (lhs: AnyCodable, rhs: AnyCodable) -> Bool {
-        switch (lhs.value, rhs.value) {
+        switch (lhs.canonicalValue, rhs.canonicalValue) {
         case let (l as Bool, r as Bool): l == r
-        case let (l as Int, r as Int): l == r
         case let (l as Int64, r as Int64): l == r
-        case let (l as Int, r as Int64): Int64(l) == r
-        case let (l as Int64, r as Int): l == Int64(r)
+        case let (l as UInt64, r as UInt64): l == r
         case let (l as Double, r as Double): l == r
         case let (l as String, r as String): l == r
         case (_ as NSNull, _ as NSNull): true
@@ -106,15 +135,15 @@ public struct AnyCodable: Codable, @unchecked Sendable, Hashable {
     }
 
     public func hash(into hasher: inout Hasher) {
-        switch self.value {
+        switch self.canonicalValue {
         case let v as Bool:
             hasher.combine(2)
             hasher.combine(v)
-        case let v as Int:
-            hasher.combine(0)
-            hasher.combine(Int64(v))
         case let v as Int64:
             hasher.combine(0)
+            hasher.combine(v)
+        case let v as UInt64:
+            hasher.combine(7)
             hasher.combine(v)
         case let v as Double:
             hasher.combine(1)
@@ -126,15 +155,10 @@ public struct AnyCodable: Codable, @unchecked Sendable, Hashable {
             hasher.combine(4)
         case let v as [String: AnyCodable]:
             hasher.combine(5)
-            for (k, val) in v.sorted(by: { $0.key < $1.key }) {
-                hasher.combine(k)
-                hasher.combine(val)
-            }
+            hasher.combine(v)
         case let v as [AnyCodable]:
             hasher.combine(6)
-            for item in v {
-                hasher.combine(item)
-            }
+            hasher.combine(v)
         default:
             hasher.combine(999)
         }

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/AnyCodableTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/AnyCodableTests.swift
@@ -1,56 +1,192 @@
 import Foundation
-import Testing
+import OpenClawKit
 import OpenClawProtocol
+import Testing
 
 struct AnyCodableTests {
     @Test
-    func roundTripsEpochMillisecondsBeyondInt32() throws {
+    func `round trips epoch milliseconds beyond int 32`() throws {
         let epochMilliseconds: Int64 = 1_800_000_000_000
-        let original = AnyCodable(epochMilliseconds)
+        let values = try self.representations([epochMilliseconds], json: "1800000000000")
 
-        let data = try JSONEncoder().encode(original)
-        let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)
-        let decodedMilliseconds = (decoded.value as? Int64)
-            ?? (decoded.value as? Int).map(Int64.init)
+        #expect(try String(decoding: JSONEncoder().encode(values[0]), as: UTF8.self) == "1800000000000")
+        try self.expectRoundTrips(values, as: epochMilliseconds)
+    }
 
-        #expect(String(decoding: data, as: UTF8.self) == "1800000000000")
-        #expect(decodedMilliseconds == epochMilliseconds)
-        #expect(decoded == original)
-        #expect(Set([decoded, original]).count == 1)
+    @Test(arguments: [Int64.min, -42, -1, 0, 1, 42, 9_007_199_254_740_993, Int64.max])
+    func `round trips signed numbers from native and foundation`(_ value: Int64) throws {
+        var native: [Any] = [value, NSNumber(value: value)]
+        if let integer = Int(exactly: value) { native.append(integer) }
+        let values = try self.representations(native, json: String(value))
+        try self.expectRoundTrips(values, as: value)
+    }
+
+    @Test(arguments: [UInt64(Int64.max) + 1, UInt64(Int64.max) + 2, UInt64.max])
+    func `round trips unsigned numbers beyond int 64`(_ value: UInt64) throws {
+        let values = try self.representations([value, NSNumber(value: value)], json: String(value))
+        try self.expectRoundTrips(values, as: value)
+    }
+
+    @Test(arguments: [0.0, 1.0, -0.5, 0.5, 1.5, Double(Int64.min), Double(Int64.max), Double(UInt64.max)])
+    func `round trips floating numbers from native and foundation`(_ value: Double) throws {
+        let values = try self.representations([value, NSNumber(value: value)], json: String(value))
+        for wrapped in values {
+            let data = try JSONEncoder().encode(wrapped)
+            #expect(try JSONDecoder().decode(Double.self, from: data) == value)
+        }
     }
 
     @Test
-    func encodesNSNumberBooleansAsJSONBooleans() throws {
-        let trueData = try JSONEncoder().encode(AnyCodable(NSNumber(value: true)))
-        let falseData = try JSONEncoder().encode(AnyCodable(NSNumber(value: false)))
+    func `boxed floating point values do not saturate integer bounds`() throws {
+        let signedOverflow = try JSONEncoder().encode(AnyCodable(NSNumber(value: Double(Int64.max))))
+        #expect(try JSONDecoder().decode(UInt64.self, from: signedOverflow) == UInt64(Int64.max) + 1)
 
-        #expect(String(data: trueData, encoding: .utf8) == "true")
-        #expect(String(data: falseData, encoding: .utf8) == "false")
+        let unsignedOverflow = try JSONEncoder().encode(AnyCodable(NSNumber(value: Double(UInt64.max))))
+        #expect(throws: DecodingError.self) {
+            try JSONDecoder().decode(UInt64.self, from: unsignedOverflow)
+        }
     }
 
     @Test
-    func preservesBooleanLiteralsFromJSONSerializationBridge() throws {
-        let raw = try #require(
-            JSONSerialization.jsonObject(with: Data(#"{"enabled":true,"nested":{"active":false}}"#.utf8))
-                as? [String: Any]
-        )
-        let enabled = try #require(raw["enabled"])
-        let nested = try #require(raw["nested"])
+    func `preserves exact decimal integers from nested JSON serialization`() throws {
+        let json = #"{"values":[9223372036854775807.0,18446744073709551615.0]}"#
+        let foundation = try JSONSerialization.jsonObject(with: Data(json.utf8))
+        let data = try JSONEncoder().encode(AnyCodable(foundation))
+        let decoded = try JSONDecoder().decode([String: [UInt64]].self, from: data)
+        #expect(decoded["values"] == [UInt64(Int64.max), UInt64.max])
+    }
 
-        struct RequestEnvelope: Codable {
-            let params: [String: AnyCodable]
+    @Test(arguments: [false, true])
+    func `round trips booleans without equating them to numbers`(_ value: Bool) throws {
+        let booleans = try self.representations([value, NSNumber(value: value)], json: value ? "true" : "false")
+        try self.expectRoundTrips(booleans, as: value)
+
+        let number = value ? 1 : 0
+        let numbers = try self.representations(
+            [number, NSNumber(value: number), Double(number), NSNumber(value: Double(number))],
+            json: String(number))
+        for numeric in numbers {
+            #expect(numeric.boolValue == nil)
+        }
+        for boolean in booleans {
+            #expect(boolean.boolValue == value)
+            for numeric in numbers {
+                #expect(boolean != numeric)
+                #expect(numeric != boolean)
+                #expect(Set([boolean, numeric]).count == 2)
+                #expect(Set([numeric, boolean]).count == 2)
+            }
+        }
+    }
+
+    @Test
+    func `round trips nested mixed payloads from native and foundation`() throws {
+        struct Row: Decodable, Equatable {
+            let signed: Int64
+            let unsigned: UInt64
+            let enabled: Bool
+            let fraction: Double
+
+            init(from decoder: Decoder) throws {
+                var row = try decoder.unkeyedContainer()
+                self.signed = try row.decode(Int64.self)
+                self.unsigned = try row.decode(UInt64.self)
+                self.enabled = try row.decode(Bool.self)
+                self.fraction = try row.decode(Double.self)
+            }
         }
 
-        let envelope = RequestEnvelope(
-            params: [
-                "enabled": AnyCodable(enabled),
-                "nested": AnyCodable(nested),
-            ]
-        )
-        let data = try JSONEncoder().encode(envelope)
-        let json = try #require(String(data: data, encoding: .utf8))
+        struct Payload: Decodable, Equatable {
+            let generation: UInt64
+            let enabled: Bool
+            let nested: [String: [Row]]
+        }
 
-        #expect(json.contains(#""enabled":true"#))
-        #expect(json.contains(#""active":false"#))
+        let json = """
+        {"generation":1,"enabled":true,"nested":{"rows":[
+          [-42,1,false,0.5],
+          [0,42,true,1.5]
+        ]}}
+        """
+        let native: [String: Any] = [
+            "generation": 1,
+            "enabled": true,
+            "nested": ["rows": [
+                [Int64(-42), 1, false, 0.5] as [Any],
+                [Int64(0), 42, true, 1.5] as [Any],
+            ]],
+        ]
+        let foundation = NSDictionary(dictionary: [
+            "generation": NSNumber(value: 1),
+            "enabled": NSNumber(value: true),
+            "nested": NSDictionary(dictionary: ["rows": NSArray(array: [
+                NSArray(array: [
+                    NSNumber(value: -42), NSNumber(value: 1),
+                    NSNumber(value: false), NSNumber(value: 0.5),
+                ]),
+                NSArray(array: [
+                    NSNumber(value: 0), NSNumber(value: 42),
+                    NSNumber(value: true), NSNumber(value: 1.5),
+                ]),
+            ])]),
+        ])
+        let expected = try JSONDecoder().decode(Payload.self, from: Data(json.utf8))
+        let values = try self.representations([native, foundation], json: json)
+
+        try self.expectRoundTrips(values, as: expected)
+    }
+
+    private func representations(_ values: [Any], json: String) throws -> [AnyCodable] {
+        let data = Data(json.utf8)
+        return try values.map(AnyCodable.init) + [
+            AnyCodable(JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])),
+            JSONDecoder().decode(AnyCodable.self, from: data),
+        ]
+    }
+
+    private func expectRoundTrips<Value: Decodable & Equatable>(
+        _ values: [AnyCodable],
+        as expected: Value,
+        sourceLocation: SourceLocation = #_sourceLocation) throws
+    {
+        for lhs in values {
+            for rhs in values {
+                #expect(lhs == rhs, sourceLocation: sourceLocation)
+            }
+        }
+        #expect(Set(values).count == 1, sourceLocation: sourceLocation)
+        #expect(Set(values.reversed()).count == 1, sourceLocation: sourceLocation)
+
+        for value in values {
+            let data = try JSONEncoder().encode(value)
+            #expect(try JSONDecoder().decode(Value.self, from: data) == expected, sourceLocation: sourceLocation)
+
+            let decoded = try JSONDecoder().decode(AnyCodable.self, from: data)
+            #expect(value == decoded, sourceLocation: sourceLocation)
+            #expect(decoded == value, sourceLocation: sourceLocation)
+            #expect(Set([value, decoded]).count == 1, sourceLocation: sourceLocation)
+
+            let reencoded = try JSONEncoder().encode(decoded)
+            #expect(try JSONDecoder().decode(Value.self, from: reencoded) == expected, sourceLocation: sourceLocation)
+        }
+    }
+}
+
+struct AnyCodableIntegerAccessTests {
+    @Test
+    func `integer access accepts only exact in-range values`() {
+        let cases: [(Any, Int?)] = [
+            (0, 0), (1, 1), (-1.0, -1), (-0.0, 0), (1.5, nil),
+            (Int64.min, Int(exactly: Int64.min)),
+            (Int64.max, Int(exactly: Int64.max)),
+            (UInt64(Int.max) + 1, nil),
+            (NSNumber(value: UInt64(Int.max) + 1), nil),
+            (Double(Int.max) + 1, nil),
+            (NSNumber(value: Double(Int.max) + 1), nil),
+            (UInt64.max, nil), (Double.infinity, nil), (true, nil), (false, nil),
+        ]
+        for (value, expected) in cases {
+            #expect(AnyCodable(value).intValue == expected)
+        }
     }
 }


### PR DESCRIPTION
Closes #133704

## What Problem This Solves

Resolves a problem where native Apple clients re-encoding Foundation JSON payloads could send booleans in numeric fields, causing incorrect response data or strict decoder failures. Numeric `0`/`1` and large signed/unsigned values are affected; genuine booleans must remain booleans.

## Why This Change Was Made

The shared `AnyCodable` boundary now separates genuine CFBoolean values from Foundation numbers and uses exact integer conversions without routing integer-backed data through `Double`. Encoding, equality and hashing share one structural projection while preserving the existing exposed raw-versus-decoded collection shapes; the integer accessor also avoids Foundation's saturating conversions and rounded bounds.

This repairs the owner rather than adding a worker-specific workaround. Native scalar types remain intact, the watchOS `Int64` path stays supported, and no dependency pins, configuration keys, migrations or protocol version changes are needed.

## User Impact

Native JSON payloads retain numeric fields instead of turning `0`/`1` into `false`/`true`. Full-width integer values remain exact, and numeric values no longer collide with booleans in equality/Set behavior. Callers requesting an out-of-range integer receive `nil` instead of an overflowing conversion.

This concerns the object-valued `result.payload` bridge. The separate `payloadJSON` string path is unchanged. No claim is made that the default TypeScript `system.run` or duplex producer fails; the worker reproduction uses a controlled JSONL subprocess reply through the real native class.

## Evidence

**Fail-before/pass-after:** signed native probes and regression tests reproduce numeric `0`/`1` being encoded as booleans, inconsistent equality/hash behavior, unsigned encoding/precision failures, and integer-accessor overflow. The real `MacNodeHostWorker` pipe regression now re-encodes a mixed payload and successfully decodes `[0, 1, 9007199254740993, UInt64.max]` as `[UInt64]` and `[false, true]` as `[Bool]`.

| Proof | Result |
| --- | --- |
| Shared native suites: `AnyCodableTests`, `AnyCodableIntegerAccessTests`, chat request/payload codec, gateway-model compatibility, talk parsing | 70 tests passed |
| Mac suites: `AnyCodableEncodingTests`, `GatewayFrameDecodeTests`, real worker pipe response case | 6 tests passed |
| Exact decimal/binary-float probes at signed/unsigned transitions | Passed, including exact `2^63`, `2^63+1` and `UInt64.max` |
| iOS arm64 and watchOS arm64_32 Swift 6 typechecking of both repaired owners | Passed; not device execution |
| Local changed checks, including macOS packaging/CI fixtures | 1,019 Node tests across 19 files passed; static gates passed |
| Final Swift-only precision refinement | Both native packages rebuilt; all 76 focused native tests and Swift lint/format rerun successfully |
| Fresh Codex autoreview | Scoped-clean at the configured P0 threshold |

Native execution used Developer ID-signed and verified test bundles/app dependencies, private scratch/module/package caches, explicit test HOME/state/config paths, and a deny-default OS sandbox blocking operator data, preferences/Keychain services, network and unrelated desktop helpers. Native executions were serialized, and the active node-session worktree/caches were not modified. See [native test safety](https://docs.openclaw.ai/platforms/mac/dev-setup#run-native-tests-safely).

**Size:** production `+61/-50` (net **+11**); tests `+191/-42` (net **+149**). The production growth is the explicit Foundation numeric-kind and full-width integer contract; duplicate encoder bridges, Boolean fallbacks and manual collection hashing were removed. Converting everything to Double, reordering casts, or eagerly replacing raw collections would lose precision, corrupt booleans or break callers.

No UI presentation surface changed, so there is no meaningful before/after GUI capture. Proof is native wire data and strict decoding through the actual pipe boundary. Full GUI/device/live-provider suites were not run; hosted exact-head checks will be verified before landing.
