### PR TITLE
perf(normalization): reuse schema branches and JSON traversal state

### DIFF
--- a/packages/normalization-core/src/balanced-json.ts
+++ b/packages/normalization-core/src/balanced-json.ts
@@ -13,13 +13,12 @@ function isJsonOpeningDelimiter(
   return (char === "{" || char === "[") && openers.includes(char);
 }
 
-/** Extracts the first balanced JSON object/array from text. */
-export function extractBalancedJsonPrefix(
+function extractBalancedJsonAt(
   raw: string,
-  opts: { openers?: readonly JsonOpeningDelimiter[] } = {},
+  opts: { openers?: readonly JsonOpeningDelimiter[] },
+  start: number,
 ): BalancedJsonFragment | null {
   const openers = opts.openers ?? (["{", "["] as const);
-  let start = 0;
   while (start < raw.length && !isJsonOpeningDelimiter(raw[start], openers)) {
     start += 1;
   }
@@ -50,6 +49,14 @@ export function extractBalancedJsonPrefix(
   return null;
 }
 
+/** Extracts the first balanced JSON object/array from text. */
+export function extractBalancedJsonPrefix(
+  raw: string,
+  opts: { openers?: readonly JsonOpeningDelimiter[] } = {},
+): BalancedJsonFragment | null {
+  return extractBalancedJsonAt(raw, opts, 0);
+}
+
 /** Extracts every balanced JSON object/array fragment from arbitrary text. */
 export function extractBalancedJsonFragments(
   raw: string,
@@ -57,16 +64,12 @@ export function extractBalancedJsonFragments(
 ): BalancedJsonFragment[] {
   const fragments: BalancedJsonFragment[] = [];
   for (let offset = 0; offset < raw.length;) {
-    const fragment = extractBalancedJsonPrefix(raw.slice(offset), opts);
+    const fragment = extractBalancedJsonAt(raw, opts, offset);
     if (!fragment) {
       break;
     }
-    fragments.push({
-      json: fragment.json,
-      startIndex: offset + fragment.startIndex,
-      endIndex: offset + fragment.endIndex,
-    });
-    offset += fragment.endIndex + 1;
+    fragments.push(fragment);
+    offset = fragment.endIndex + 1;
   }
   return fragments;
 }

--- a/packages/normalization-core/src/balanced-json.ts
+++ b/packages/normalization-core/src/balanced-json.ts
@@ -16,9 +16,10 @@ function isJsonOpeningDelimiter(
 function extractBalancedJsonAt(
   raw: string,
   opts: { openers?: readonly JsonOpeningDelimiter[] },
-  start: number,
+  offset: number,
 ): BalancedJsonFragment | null {
   const openers = opts.openers ?? (["{", "["] as const);
+  let start = offset;
   while (start < raw.length && !isJsonOpeningDelimiter(raw[start], openers)) {
     start += 1;
   }

--- a/packages/normalization-core/src/json-schema.ts
+++ b/packages/normalization-core/src/json-schema.ts
@@ -108,15 +108,14 @@ function expandJsonSchemaTypeArray(schema: Record<string, unknown>): Record<stri
   if (types.length === 1 && !Array.isArray(type)) {
     return schema;
   }
-  const resourceEntries = Object.entries(rest).filter(([key]) => schemaResourceKeywords.has(key));
-  const branchEntries = Object.entries(rest).filter(([key]) => !schemaResourceKeywords.has(key));
+  const entries = Object.entries(rest);
+  const resourceEntries = entries.filter(([key]) => schemaResourceKeywords.has(key));
+  const branch = Object.fromEntries(entries.filter(([key]) => !schemaResourceKeywords.has(key)));
   // Keep value-wide constraints on every branch: const, enum, and applicators
   // must still decide whether null is valid. Type-specific keywords ignore null.
   return {
     ...Object.fromEntries(resourceEntries),
-    anyOf: types.map((entry) =>
-      Object.assign({}, Object.fromEntries(branchEntries), { type: entry }),
-    ),
+    anyOf: types.map((entry) => Object.assign({}, branch, { type: entry })),
   };
 }
 

--- a/packages/normalization-core/src/stable-stringify.ts
+++ b/packages/normalization-core/src/stable-stringify.ts
@@ -82,6 +82,15 @@ function stringifyObjectValue(
     return `[${serializedEntries.join(",")}]`;
   }
   const record = value as Record<string, unknown>;
+  if (normalizeString === preserveString) {
+    const fields: string[] = [];
+    for (const key of Object.keys(record).toSorted()) {
+      fields.push(
+        `${JSON.stringify(key)}:${stringifyStableValue(record[key], stack, normalizeString)}`,
+      );
+    }
+    return `{${fields.join(",")}}`;
+  }
   const entries = Object.keys(record)
     .map((key) => ({ key, normalizedKey: normalizeString(key) }))
     .toSorted((left, right) => {


### PR DESCRIPTION
Shared normalization repeated preparation that its callers had already made unnecessary: stable serialization decorated default keys, schema expansion rebuilt identical branch properties, and successive JSON extraction sliced the remaining input and translated offsets again.

This keeps those facts local to their owners. Default stable serialization sorts the existing string keys, while the custom-normalizer path remains unchanged. JSON Schema expansion prepares branch properties once and still creates each branch separately. Balanced JSON extraction carries an absolute cursor through one scanner, preserving both public APIs. No output bytes, ordering, schema semantics, configuration, protocol, persistence, permission or cache policy changes are intended. The diff is +28/−16 production lines (net +12), with no test growth. The small increase retains the custom-normalizer contract and public prefix API without introducing another cache or compatibility path.

All 610 existing tests passed before and after on the current integration base: 573 core/package/plugin tests and 37 Control UI constraints/composition tests, including Chromium. This covers provider prompt state, continuation hashes, tool-loop detection/admission, native hook relay, schema validation/defaults, CLI output, provider errors, payload redaction and UI schema behavior. Complete formatted production ASTs match the separately measured candidates. The lint-required local cursor refinement was separately rebuilt, proved and measured through current complete scanner, redaction and CLI owners. Independent owner reviews and managed Codex review supplement the canonical tests.

The retained differential evidence is separate for each owner: serializer 5,076 comparisons plus 108 workload and 108 operation comparisons; schema 632 comparisons plus 589 supplemental comparisons, including 570 exact TypeBox Compile.Errors result tuples; balanced JSON originally 151,808 cases / 455,424 comparisons across alternatives, followed by 151,808 comparisons of the exact final scanner against the baseline. These are overlapping or differently structured proof units, not one aggregate scenario count. Historical source graphs retain their original revisions; current production owners still matched their measured baseline bytes before integration, and current canonical tests were rerun after pulling main.

Fresh forward/reverse processes retained all samples and slower controls. Selected results:

- Default serializer: complete small prompt preparation about 1.05–1.10×, eight-tool preparation about 1.09–1.10×, and larger argument hashing about 1.10–1.15×. Custom identity/collision/surrogate controls cost roughly 0.13–0.36 µs more; long-history/trace controls are mixed.
- Schema expansion: nullable normalization about 1.1×, four-type unions about 1.15–1.22×, and complete validation about 1.1×. Plain/default-fill controls are retained.
- Balanced JSON, refreshed final source: repeated 16/128-fragment extraction saves about 22–27% elapsed time, complete CLI decoding 11–17%, and redaction 6–8%. No-JSON 1 KiB extraction costs 17.7/25.8% (0.32/0.42 µs), while the corresponding complete CLI path costs 6.65/1.40%. Plain short prefix costs about 1–2 ns. All 2,112 samples from four fresh forward/reverse children remain in the final-source table. A structural-token alternative was rejected for slower complete decoding.

These are scoped owner measurements, not Gateway, native process, model/network latency or memory claims. There is no documented behavior change or new operator action.

Verification:

```sh
pnpm test packages/normalization-core/src/stable-stringify.test.ts src/agents/tool-loop-detection.test.ts src/agents/tool-loop-admission.test.ts src/agents/embedded-agent-runner/provider-prompt-state.test.ts packages/ai/src/transports/openai-responses-continuation.test.ts src/agents/cache-trace.test.ts src/agents/harness/native-hook-relay.test.ts src/shared/json-schema-defaults.test.ts src/plugins/config-schema.test.ts src/agents/cli-output-records.test.ts packages/ai/src/utils/provider-error.test.ts src/agents/payload-redaction.test.ts src/commands/status-all/gateway.test.ts src/agents/embedded-agent-runner/run/attempt.tool-call-argument-repair.test.ts -- --maxWorkers=1
pnpm --dir ui test src/components/config-form.constraints.test.ts src/components/config-form-composition-integrity.browser.test.ts
pnpm check:changed --base c00b5f4f7b2ea396da57770bca3819e15e00b500
```

The initial changed-file check caught a reassigned private scanner parameter. A follow-up commit uses a local cursor, preserving observation order; the original failed check is retained and final checks are rerun without suppressing lint.

Final changed-file checks passed on `22de90ea211824ccb5935d52ef9d3d90267a5341`, including production/test types, lint, unused-export analysis and all selected architecture guards. ClawSweeper's exact-head review found no actionable correctness or security issue. Its stored-data heuristic identifies the serializer's filename, but no serialized format, stored shape, schema or migration changes here: exact-byte differential comparisons and the prompt-state/continuation/hash tests preserve compatibility with existing values. No migration is needed for an unchanged representation.
