### PR TITLE
test(line): remove redundant adapter and webhook checks

### DIFF
--- a/extensions/line/src/channel.allowlist.test.ts
+++ b/extensions/line/src/channel.allowlist.test.ts
@@ -6,12 +6,6 @@ import { linePlugin } from "./channel.js";
 const allowlist = linePlugin.allowlist;
 
 describe("line allowlist adapter", () => {
-  it("exposes the config-edit contract", () => {
-    expect(allowlist?.applyConfigEdit).toBeTypeOf("function");
-    expect(allowlist?.readConfig).toBeTypeOf("function");
-    expect(allowlist?.supportsScope).toBeTypeOf("function");
-  });
-
   it.each([
     { scope: "dm", expected: true },
     { scope: "group", expected: true },

--- a/extensions/line/src/webhook-node.test.ts
+++ b/extensions/line/src/webhook-node.test.ts
@@ -331,17 +331,6 @@ describe("LINE webhook shared POST contract", () => {
     },
   );
 
-  it.each(sharedWebhookPostContractCases)("$name dispatches signed events", async ({ invoke }) => {
-    const result = await invoke({
-      rawBody: JSON.stringify({ events: [{ type: "message" }] }),
-      signed: true,
-    });
-
-    expect(result.status).toBe(200);
-    expect(result.body).toEqual({ status: "ok" });
-    expect(result.dispatched).toHaveBeenCalledTimes(1);
-  });
-
   it.each(sharedWebhookPostContractCases)(
     "$name returns 500 when durable admission fails",
     async ({ invoke }) => {
@@ -443,19 +432,6 @@ describe("createLineNodeWebhookHandler", () => {
     expect(bot.handleWebhook).not.toHaveBeenCalled();
   });
 
-  it("durably admits signed POST events before acknowledging", async () => {
-    runDetachedWebhookWorkSpy.mockClear();
-    const rawBody = JSON.stringify({ events: [{ type: "message" }] });
-    const { bot, handler, secret } = createPostWebhookTestHarness(rawBody);
-
-    const { res } = createRes();
-    await runSignedPost({ handler, rawBody, secret, res });
-
-    expect(res.statusCode).toBe(200);
-    expect(runDetachedWebhookWorkSpy).not.toHaveBeenCalled();
-    expect(bot.handleWebhook).toHaveBeenCalledTimes(1);
-  });
-
   it("uses strict pre-auth limits for signed POST requests", async () => {
     const rawBody = JSON.stringify({ events: [{ type: "message" }] });
     const bot = { handleWebhook: vi.fn(async () => {}) };
@@ -503,6 +479,7 @@ describe("createLineNodeWebhookHandler", () => {
     await runSignedPost({ handler, rawBody, secret, res });
 
     expect(res.statusCode).toBe(200);
+    expect(parseResponseBody(res.body)).toEqual({ status: "ok" });
     expect(bot.handleWebhook).toHaveBeenCalledTimes(1);
     const payload = firstParsedPayload(bot.handleWebhook, "LINE node webhook payload");
     expect(payload.events).toEqual([{ type: "message" }]);
@@ -583,6 +560,7 @@ describe("createLineWebhookMiddleware", () => {
   ])("parses JSON from %s", async (_label, body, expectedEvents) => {
     const { res, onEvents } = await invokeWebhook({ body });
     expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({ status: "ok" });
     expect(onEvents).toHaveBeenCalledTimes(1);
     const payload = firstParsedPayload(onEvents, "LINE middleware payload");
     expect(payload.events).toEqual(expectedEvents);


### PR DESCRIPTION
## What Problem This Solves

LINE's tests repeat checks already protected by stronger behavior tests: an adapter-method presence check, two signed-webhook success executions, and a Node acknowledgement test that only observes the absence of one detached-work helper call.

## Why This Change Was Made

Remove those four redundant executions. Keep the allowlist tests that invoke every method and assert config outcomes, the webhook tests that assert exact dispatched events, and the Node test that holds admission pending and verifies no response is sent until it finishes. Move the success-response assertions into the retained dispatch tests.

## User Impact

No runtime behavior changes. Less duplicate test maintenance, with the same meaningful allowlist, dispatch, and acknowledgement coverage.

## Evidence

- Before: the two affected suites passed all 44 cases.
- After: `node scripts/run-vitest.mjs extensions/line/src/channel.allowlist.test.ts extensions/line/src/webhook-node.test.ts` passed all 40 retained cases.
- Signature rejection, signed raw-body trust, size limits, malformed payloads, admission failures, and the actual pending-admission ordering test remain unchanged.
- The middleware helper-spy test remains because it does not yet have the same independent ordering proof as the Node handler.
- Production: +0/-0. Tests: +2/-30 (net -28).
- Targeted formatting and `git diff --check` passed. Structured Codex autoreview returned scoped-clean. The actual changed gate passed (guards, extension typecheck, and focused lint): `env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs -- extensions/line/src/channel.allowlist.test.ts extensions/line/src/webhook-node.test.ts`.
