### PR TITLE
refactor(ui): unify working indicator status rendering

### DIFF
--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -1788,6 +1788,7 @@ describe("grouped chat rendering", () => {
     );
     expect(container.querySelector(".chat-working-indicator__elapsed")).not.toBeNull();
     expect(container.querySelector(".chat-working-indicator__status > .sr-only")).toBeNull();
+    expect(container.querySelector("openclaw-working-phrase")).toBeNull();
   });
 
   it("formats terminal recap durations with full localized units", () => {
@@ -1815,19 +1816,23 @@ describe("grouped chat rendering", () => {
     ).toBe("Done in 30 seconds · 2,400 output tokens");
   });
 
-  it("shows live output usage beside elapsed time", () => {
+  it.each([
+    [0, "0 output tokens"],
+    [1, "1 output token"],
+    [5_500, "5,500 output tokens"],
+  ])("shows %i output tokens beside elapsed time", (outputTokens, label) => {
     const container = document.createElement("div");
 
     render(
       renderStreamGroup([{ kind: "reading-indicator", key: "reading", startedAt: 1_000 }], {
-        runOutputTokens: 5_500,
+        runOutputTokens: outputTokens,
       }),
       container,
     );
 
     expect(container.querySelector(".chat-working-indicator__elapsed")).not.toBeNull();
     expect(container.querySelector(".chat-working-indicator__tokens")?.textContent?.trim()).toBe(
-      "5,500 output tokens",
+      label,
     );
     // Known usage replaces the pre-usage working phrase.
     expect(container.querySelector("openclaw-working-phrase")).toBeNull();

--- a/ui/src/pages/chat/components/chat-working-indicator.ts
+++ b/ui/src/pages/chat/components/chat-working-indicator.ts
@@ -46,16 +46,6 @@ function outputTokensLabel(outputTokens: number): string {
     : t("chat.turnRecap.tokens", { count: outputTokens.toLocaleString(i18n.getLocale()) });
 }
 
-function renderLiveOutputTokens(outputTokens: number | null | undefined) {
-  if (outputTokens === null || outputTokens === undefined) {
-    return nothing;
-  }
-  return html`
-    <span aria-hidden="true">·</span>
-    <span class="chat-working-indicator__tokens">${outputTokensLabel(outputTokens)}</span>
-  `;
-}
-
 export function renderChatWorkingIndicator(
   part: Extract<ChatItem, { kind: "reading-indicator" }>,
   options: {
@@ -67,9 +57,13 @@ export function renderChatWorkingIndicator(
 ) {
   const waitingApproval = options.waitingApproval === true;
   const continuation = options.presentation === "continuation";
+  const statusLabel = waitingApproval
+    ? t("chat.waitingForApproval")
+    : options.startupLabel || t("common.working");
+  const working = !waitingApproval && !options.startupLabel;
   // Providers report exact usage at response boundaries, not per text delta.
   // Keep the latest count visible while the run continues through tools.
-  const hasTokens = options.outputTokens !== null && options.outputTokens !== undefined;
+  const outputTokens = options.outputTokens;
   // The animated claw stays decorative; the text status exposes progress without
   // announcing every elapsed-time tick to screen readers.
   return html`
@@ -91,35 +85,29 @@ export function renderChatWorkingIndicator(
             </div>
           `}
       <span class="chat-working-indicator__status">
+        <span class=${working && !continuation ? "sr-only" : ""}>${statusLabel}</span>
         ${waitingApproval
-          ? html`<span>${t("chat.waitingForApproval")}</span>${renderLiveOutputTokens(
-                options.outputTokens,
-              )}`
-          : options.startupLabel
+          ? nothing
+          : html`
+              <openclaw-elapsed-time
+                class="chat-working-indicator__elapsed"
+                .startMs=${part.startedAt}
+              ></openclaw-elapsed-time>
+            `}
+        ${outputTokens !== null && outputTokens !== undefined
+          ? html`
+              <span aria-hidden="true">·</span>
+              <span class="chat-working-indicator__tokens">${outputTokensLabel(outputTokens)}</span>
+            `
+          : working
             ? html`
-                <span>${options.startupLabel}</span>
-                <openclaw-elapsed-time
-                  class="chat-working-indicator__elapsed"
+                <openclaw-working-phrase
+                  aria-hidden="true"
                   .startMs=${part.startedAt}
-                ></openclaw-elapsed-time>
-                ${renderLiveOutputTokens(options.outputTokens)}
+                  .seed=${part.key}
+                ></openclaw-working-phrase>
               `
-            : html`
-                <span class=${continuation ? "" : "sr-only"}>${t("common.working")}</span>
-                <openclaw-elapsed-time
-                  class="chat-working-indicator__elapsed"
-                  .startMs=${part.startedAt}
-                ></openclaw-elapsed-time>
-                ${hasTokens
-                  ? renderLiveOutputTokens(options.outputTokens)
-                  : html`
-                      <openclaw-working-phrase
-                        aria-hidden="true"
-                        .startMs=${part.startedAt}
-                        .seed=${part.key}
-                      ></openclaw-working-phrase>
-                    `}
-              `}
+            : nothing}
       </span>
     </div>
   `;


### PR DESCRIPTION
Related: #133605 (cumulative, recoverable output-token counter).

## What Problem This Solves

Maintainer-requested cleanup following the token-counter repair. The Control UI's working indicator repeated elapsed-time and output-token rendering across normal work, startup, and approval-wait branches, making future presentation changes easy to apply inconsistently.

## Why This Change Was Made

Use one status label, one conditional elapsed timer, and one output-token/working-phrase slot. Remove the now-unnecessary token-fragment helper. Existing Lit components and localization own formatting; no new abstraction or dependency is needed.

Keep the run accumulator, provider notifications, reconnect snapshot, and exact-run recap reconciliation unchanged. The separate persisted-billing issue #89474 is not part of this cleanup.

## User Impact

No intended behavior or appearance change. Approval waits still override startup and hide elapsed time; startup suppresses the decorative working phrase; known counts, including zero, retain exact localized labels. Standalone working text remains screen-reader-only and continuation text remains visible.

## Evidence

- 274 focused UI tests passed across `chat-working-indicator.test.ts`, `chat-message.test.ts`, `chat-transcript-render.test.ts`, `chat-progress.test.ts`, and `tool-stream.usage.node.test.ts`.
- 16 Chromium E2E tests passed across `chat-startup-progress.e2e.test.ts`, `chat-flow.stream-reconciliation.e2e.test.ts`, and `chat-flow.streaming.e2e.test.ts` using the real UI and mocked Gateway. Includes approval-before-ACK, startup recovery, streaming, final recap, and reconnect flows.
- Extended existing rendering tests for zero/singular output counts and absent startup working phrases. No new test file or production test seam.
- Fresh scoped autoreview: no accepted/actionable findings. Manual diff cleanup and `git diff --check` passed.
- Changed-scope formatting, core-test/UI typechecks, lint, style, i18n, and repository guard checks passed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33349019802) passed for `4e7d2c5629e4ed7fbd96445a7dea83bd85366444`; native watcher exited 0 with no pending checks.
- Production LOC: +24/-36 (net -12). Tests: +8/-3 (net +5).
- Behavior-neutral internal rendering refactor: no new live-provider claim or visual-feature capture. No operator Gateway restart, configuration change, persistence/schema change, or SDK change.

Commands:

```sh
node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-working-indicator.test.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/components/chat-transcript-render.test.ts ui/src/pages/chat/chat-progress.test.ts ui/src/pages/chat/tool-stream.usage.node.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-startup-progress.e2e.test.ts ui/src/e2e/chat-flow.stream-reconciliation.e2e.test.ts ui/src/e2e/chat-flow.streaming.e2e.test.ts
node scripts/check-changed.mjs -- ui/src/pages/chat/components/chat-working-indicator.ts ui/src/pages/chat/components/chat-message.test.ts
```
