### PR TITLE
refactor: simplify quiet channel progress rendering

### DIFF
--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -1,18 +1,12 @@
 import { EmbeddedBlockChunker } from "openclaw/plugin-sdk/agent-runtime";
 import {
-  type AgentPlanStep,
-  buildChannelProgressDraftLine,
-  buildChannelProgressDraftLineForEntry,
   type ChannelProgressDraftLine,
   createChannelProgressDraftCompositor,
   resolveChannelStreamingBlockEnabled,
   resolveChannelStreamingPreviewCommandText,
-  resolveChannelStreamingPreviewToolProgress,
   resolveChannelStreamingProgressNarration,
-  resolveChannelStreamingSuppressDefaultToolProgressMessages,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-// Discord plugin module implements message handlerraft preview behavior.
 import { expectDefined } from "openclaw/plugin-sdk/expect-runtime";
 import { getGlobalHookRunner } from "openclaw/plugin-sdk/plugin-runtime";
 import {
@@ -95,9 +89,6 @@ export function createDiscordDraftPreviewController(params: {
   let progressDraftStartedBeforeFinal = false;
   let progressDraftCollapsed = false;
   let progressNarratorLifecycle: { beginTurn: () => void; stopTurn: () => void } | undefined;
-  const previewToolProgressEnabled =
-    Boolean(draftStream) &&
-    resolveChannelStreamingPreviewToolProgress(params.discordConfig, true, discordStreamMode);
   const narrationProgressEnabled =
     Boolean(draftStream) &&
     discordStreamMode === "progress" &&
@@ -108,12 +99,6 @@ export function createDiscordDraftPreviewController(params: {
   const narrationHideCommandText =
     narrationProgressEnabled &&
     resolveChannelStreamingPreviewCommandText(params.discordConfig) === "status";
-  const suppressDefaultToolProgressMessages =
-    Boolean(draftStream) &&
-    resolveChannelStreamingSuppressDefaultToolProgressMessages(params.discordConfig, {
-      draftStreamActive: true,
-      previewToolProgressEnabled,
-    });
   const progressSeed = `${params.accountId}:${params.deliverChannelId}`;
   const progressDraft = createChannelProgressDraftCompositor({
     presentation: discordStreamMode === "progress" ? "summary" : undefined,
@@ -122,13 +107,7 @@ export function createDiscordDraftPreviewController(params: {
     active: Boolean(draftStream),
     seed: progressSeed,
     reasoningLinePrefix: "🧠 ",
-    commentaryLinePrefix: "",
-    reasoningGate: previewToolProgressEnabled,
     commentaryItalics: false,
-    buildProgressEventLine: (input, options) =>
-      input.event === "tool" || input.event === "item" || input.event === "command-output"
-        ? buildChannelProgressDraftLineForEntry(params.discordConfig, input, options)
-        : buildChannelProgressDraftLine(input, options),
     update: async (previewText, options) => {
       if (!draftStream) {
         return false;
@@ -171,13 +150,6 @@ export function createDiscordDraftPreviewController(params: {
     resetProgressState();
   };
 
-  const pushPreambleHeadline = async (text?: string, options?: { itemId?: string }) => {
-    if (discordStreamMode === "progress") {
-      return await progressDraft.pushPreambleHeadline(text, options);
-    }
-    return false;
-  };
-
   const beginNewProgressTurn = (options?: { force?: boolean }) => {
     const beganNewTurn = progressDraft.beginNewTurn(options);
     if (beganNewTurn) {
@@ -199,11 +171,10 @@ export function createDiscordDraftPreviewController(params: {
 
   return {
     draftStream,
-    previewToolProgressEnabled,
     narrationProgressEnabled,
     narrationHideCommandText,
     commentaryProgressEnabled: progressDraft.commentaryProgressEnabled,
-    suppressDefaultToolProgressMessages,
+    suppressDefaultToolProgressMessages: progressDraft.suppressDefaultToolProgressMessages,
     get isProgressMode() {
       return discordStreamMode === "progress";
     },
@@ -264,28 +235,14 @@ export function createDiscordDraftPreviewController(params: {
     disableBlockStreamingForDraft: draftStream ? true : undefined,
     pushToolEvent: progressDraft.pushToolEvent,
     pushItemEvent: progressDraft.pushItemEvent,
-    pushApprovalEvent: (payload: Parameters<typeof progressDraft.pushApprovalEvent>[0]) =>
-      progressDraft.pushApprovalEvent(payload),
+    pushApprovalEvent: progressDraft.pushApprovalEvent,
     pushCommandOutputEvent: progressDraft.pushCommandOutputEvent,
     pushPatchEvent: progressDraft.pushPatchEvent,
-    async pushToolProgress(
-      line?: string | ChannelProgressDraftLine,
-      options?: { toolName?: string },
-    ) {
-      return await progressDraft.pushToolProgress(line, options);
-    },
-    async pushPlanProgress(steps?: AgentPlanStep[], options?: { explanation?: string }) {
-      return await progressDraft.pushPlanProgress(steps, options);
-    },
-    async pushReasoningProgress(text?: string, options?: { snapshot?: boolean }) {
-      return await progressDraft.pushReasoningProgress(text, options);
-    },
-    async pushNarrationProgress(text?: string) {
-      return await progressDraft.pushNarrationProgress(text);
-    },
-    pushPreambleHeadline,
+    pushPlanProgress: progressDraft.pushPlanProgress,
+    pushReasoningProgress: progressDraft.pushReasoningProgress,
+    pushNarrationProgress: progressDraft.pushNarrationProgress,
     async pushPreambleItemEvent(payload: { itemId?: string; progressText?: string }) {
-      const headlineAccepted = await pushPreambleHeadline(payload.progressText, {
+      const headlineAccepted = await progressDraft.pushPreambleHeadline(payload.progressText, {
         itemId: payload.itemId,
       });
       if (!progressDraft.commentaryProgressEnabled) {
@@ -295,9 +252,6 @@ export function createDiscordDraftPreviewController(params: {
         itemId: payload.itemId,
       });
       return headlineAccepted || commentaryAccepted;
-    },
-    async pushCommentaryProgress(text?: string, options?: { itemId?: string }) {
-      return await progressDraft.pushCommentaryProgress(text, options);
     },
     resolvePreviewFinalText(text?: string) {
       if (typeof text !== "string") {

--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -235,12 +235,12 @@ export function createDiscordDraftPreviewController(params: {
     disableBlockStreamingForDraft: draftStream ? true : undefined,
     pushToolEvent: progressDraft.pushToolEvent,
     pushItemEvent: progressDraft.pushItemEvent,
-    pushApprovalEvent: progressDraft.pushApprovalEvent,
+    pushApprovalEvent: progressDraft.pushApprovalEvent.bind(progressDraft),
     pushCommandOutputEvent: progressDraft.pushCommandOutputEvent,
     pushPatchEvent: progressDraft.pushPatchEvent,
-    pushPlanProgress: progressDraft.pushPlanProgress,
-    pushReasoningProgress: progressDraft.pushReasoningProgress,
-    pushNarrationProgress: progressDraft.pushNarrationProgress,
+    pushPlanProgress: progressDraft.pushPlanProgress.bind(progressDraft),
+    pushReasoningProgress: progressDraft.pushReasoningProgress.bind(progressDraft),
+    pushNarrationProgress: progressDraft.pushNarrationProgress.bind(progressDraft),
     async pushPreambleItemEvent(payload: { itemId?: string; progressText?: string }) {
       const headlineAccepted = await progressDraft.pushPreambleHeadline(payload.progressText, {
         itemId: payload.itemId,

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress-render.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress-render.ts
@@ -3,7 +3,6 @@ import type {
   ChannelProgressDraftCompositorSnapshot,
   ChannelProgressDraftLine,
 } from "openclaw/plugin-sdk/channel-outbound";
-import { buildSlackProgressStreamChunks } from "../../progress-blocks.js";
 
 export function resolveStructuredProgressLines(
   lines: readonly ChannelProgressDraftCompositorLine[],
@@ -41,15 +40,4 @@ export function combineProgressHeadlineAndExplanation(
   return headline && explanation && headline !== explanation
     ? `${headline} — ${explanation}`
     : (headline ?? explanation);
-}
-
-export function buildNativeProgressChunks(params: {
-  snapshot: ChannelProgressDraftCompositorSnapshot;
-  title?: string;
-}) {
-  return buildSlackProgressStreamChunks({
-    title: params.title,
-    lines: resolveNativeProgressLines(params.snapshot),
-    plan: params.snapshot.plan,
-  });
 }

--- a/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
+++ b/extensions/slack/src/monitor/message-handler/dispatch-progress.ts
@@ -1,7 +1,5 @@
 import {
   type AgentPlanStep,
-  buildChannelProgressDraftLine,
-  buildChannelProgressDraftLineForEntry,
   createChannelProgressDraftCompositor,
   createDraftStreamLoop,
   formatChannelProgressDraftText,
@@ -19,7 +17,7 @@ import { createSlackDraftStream } from "../../draft-stream.js";
 import { formatSlackError } from "../../errors.js";
 import { SLACK_EDIT_TEXT_MAX_BYTES, SLACK_TEXT_LIMIT } from "../../limits.js";
 import {
-  buildSlackProgressStreamCompletionChunks,
+  buildSlackProgressStreamChunks,
   reconcileSlackNativeTaskChunks,
   EMPTY_SLACK_NATIVE_STREAM_SNAPSHOT,
   type SlackNativeStreamSnapshot,
@@ -36,7 +34,6 @@ import {
 } from "./dispatch-progress-card.js";
 import { createSlackNativeProgressTransport } from "./dispatch-progress-native.js";
 import {
-  buildNativeProgressChunks as buildRenderedNativeProgressChunks,
   combineProgressHeadlineAndExplanation,
   resolveNativeProgressLines,
   resolveNativeProgressNarration,
@@ -193,12 +190,6 @@ export function createSlackProgressRuntime(runtimeParams: {
       snapshot.planExplanation,
     );
 
-  const buildNativeProgressChunks = (snapshot: ChannelProgressDraftCompositorSnapshot) =>
-    buildRenderedNativeProgressChunks({
-      snapshot,
-      title: resolveNativeProgressTitle(snapshot) ?? "Working",
-    });
-
   const normalizeProgressText = (text: string | undefined) =>
     text?.replace(/\s+/gu, " ").trim() ?? "";
 
@@ -235,7 +226,11 @@ export function createSlackProgressRuntime(runtimeParams: {
     }
     const reconciled = reconcileSlackNativeTaskChunks({
       previous: nativeStreamSnapshot,
-      chunks: buildNativeProgressChunks(snapshot),
+      chunks: buildSlackProgressStreamChunks({
+        title: resolveNativeProgressTitle(snapshot) ?? "Working",
+        lines: resolveNativeProgressLines(snapshot),
+        plan: snapshot.plan,
+      }),
     });
     const chunks = reconciled.chunks;
     if (!chunks?.length && !narrationUpdate.delta) {
@@ -342,13 +337,7 @@ export function createSlackProgressRuntime(runtimeParams: {
     seed: progressSeed,
     formatLine: formatSlackProgressDraftLine,
     reasoningLinePrefix: "🧠 ",
-    commentaryLinePrefix: "",
     reasoningGate: previewToolProgressEnabled,
-    commentaryItalics: true,
-    buildProgressEventLine: (input, options) =>
-      input.event === "tool" || input.event === "item" || input.event === "command-output"
-        ? buildChannelProgressDraftLineForEntry(account.config, input, options)
-        : buildChannelProgressDraftLine(input, options),
     updateOnLineChange: useNativeProgressStreaming || useDraftProgressCard,
     update: async (previewText, options) => {
       if (useNativeProgressStreaming) {
@@ -439,7 +428,7 @@ export function createSlackProgressRuntime(runtimeParams: {
     }
     const completion = reconcileSlackNativeTaskChunks({
       previous: nativeStreamSnapshot,
-      chunks: buildSlackProgressStreamCompletionChunks({
+      chunks: buildSlackProgressStreamChunks({
         title:
           resolveNativeProgressTitle(snapshot) ??
           (lines.length === 0 && !snapshot.plan?.length ? "Working" : undefined),

--- a/extensions/slack/src/progress-blocks.test.ts
+++ b/extensions/slack/src/progress-blocks.test.ts
@@ -1,9 +1,7 @@
-// Slack tests cover progress blocks plugin behavior.
 import type { ChannelProgressDraftLine } from "openclaw/plugin-sdk/channel-outbound";
 import { describe, expect, it } from "vitest";
 import {
   buildSlackProgressCardBlocks,
-  buildSlackProgressStreamCompletionChunks,
   buildSlackProgressStreamChunks,
   EMPTY_SLACK_NATIVE_STREAM_SNAPSHOT,
   reconcileSlackNativeTaskChunks,
@@ -216,7 +214,7 @@ describe("Slack progress presentation", () => {
         previous: EMPTY_SLACK_NATIVE_STREAM_SNAPSHOT,
         chunks: buildSlackProgressStreamChunks({ title: "Checking the workspace", lines: [] }),
       });
-      const completion = buildSlackProgressStreamCompletionChunks({
+      const completion = buildSlackProgressStreamChunks({
         title: "Checking the workspace",
         lines: [],
         finalInProgressStatus: status,
@@ -241,7 +239,7 @@ describe("Slack progress presentation", () => {
 
   it("shows terminal failure even when all authored milestones were already completed", () => {
     expect(
-      buildSlackProgressStreamCompletionChunks({
+      buildSlackProgressStreamChunks({
         title: "Checking the workspace",
         lines: [],
         finalInProgressStatus: "error",
@@ -274,9 +272,10 @@ describe("Slack progress presentation", () => {
     }
     const complete = reconcileSlackNativeTaskChunks({
       previous: snapshot,
-      chunks: buildSlackProgressStreamCompletionChunks({
+      chunks: buildSlackProgressStreamChunks({
         title: "Checking the workspace",
         lines: [progressLine(59)],
+        finalInProgressStatus: "complete",
       }),
     });
     expect(complete.chunks).toEqual([

--- a/extensions/slack/src/progress-blocks.ts
+++ b/extensions/slack/src/progress-blocks.ts
@@ -1,4 +1,3 @@
-// Slack plugin module implements progress blocks behavior.
 import type { AnyChunk, TaskUpdateChunk } from "@slack/types";
 import type { Block, KnownBlock } from "@slack/web-api";
 import type { AgentPlanStep, ChannelProgressDraftLine } from "openclaw/plugin-sdk/channel-outbound";
@@ -13,26 +12,13 @@ const DEFAULT_SLACK_PROGRESS_DETAIL_MAX_CHARS = 120;
 const SLACK_PROGRESS_CHUNK_TEXT_MAX = 256;
 const SLACK_PROGRESS_TASK_TITLE_MAX = 120;
 
-type SlackPlanTaskStatus = "pending" | "in_progress" | "complete" | "error";
-
-type SlackPlanTask = {
-  id: string;
-  title: string;
-  status: SlackPlanTaskStatus;
-};
+type SlackPlanTask = Pick<TaskUpdateChunk, "id" | "title" | "status">;
 
 function buildSessionSources(url: string): NonNullable<TaskUpdateChunk["sources"]> {
   // The live Slack API requires url_source; @slack/types 3.0.0 still declares the old `url` tag.
   return [{ type: "url_source", url, text: "Open in OpenClaw" }] as unknown as NonNullable<
     TaskUpdateChunk["sources"]
   >;
-}
-
-function field(text: string) {
-  return {
-    type: "mrkdwn" as const,
-    text: truncateSlackText(text, SLACK_PROGRESS_FIELD_MAX),
-  };
 }
 
 function resolveMaxLineChars(value: number | undefined, fallback: number): number {
@@ -107,8 +93,7 @@ export function buildSlackProgressStreamChunks(params: {
   title?: string;
   lines: readonly ChannelProgressDraftLine[];
   plan?: readonly AgentPlanStep[];
-  completeInProgress?: boolean;
-  finalInProgressStatus?: SlackPlanTaskStatus;
+  finalInProgressStatus?: "complete" | "error";
   sessionUrl?: string;
 }): AnyChunk[] | undefined {
   const title = compactChunkText(params.title?.trim() || params.label?.trim() || "Working");
@@ -141,7 +126,7 @@ export function buildSlackProgressStreamChunks(params: {
       status: "error",
     };
   }
-  if (attention && !(params.completeInProgress && attention.status === "pending")) {
+  if (attention && !(params.finalInProgressStatus && attention.status === "pending")) {
     tasks.push(attention);
   }
   const finalTaskIndex = tasks.length - 1;
@@ -151,9 +136,7 @@ export function buildSlackProgressStreamChunks(params: {
       id: task.id,
       title: task.title,
       status:
-        task.status === "in_progress"
-          ? (params.finalInProgressStatus ?? (params.completeInProgress ? "complete" : task.status))
-          : task.status,
+        task.status === "in_progress" ? (params.finalInProgressStatus ?? task.status) : task.status,
     };
     if (index === finalTaskIndex && params.sessionUrl) {
       chunk.sources = buildSessionSources(params.sessionUrl);
@@ -192,60 +175,36 @@ export function buildSlackProgressCardBlocks(params: {
   const attention = resolveProgressAttention(params.lines);
   const status =
     params.state === "success" ? "Completed: " : params.state === "error" ? "Failed: " : "";
-  const blocks: (Block | KnownBlock)[] = [
-    {
-      type: "section" as const,
-      text: field(`${status}*${escapeSlackMrkdwn(params.title.trim() || "Working")}*`),
-    },
-    ...(narration
-      ? [
-          {
-            type: "section" as const,
-            text: field(`_${escapeSlackMrkdwn(narration)}_`),
-          },
-        ]
-      : []),
-    ...(planLines.length > 0
-      ? [
-          {
-            type: "section" as const,
-            text: field(planLines.map((line) => escapeSlackMrkdwn(line)).join("\n")),
-          },
-        ]
-      : []),
-    ...(authoredText
-      ? [
-          {
-            type: "section" as const,
-            text: field(authoredText),
-          },
-        ]
-      : []),
-    ...(attention && !(params.state !== "working" && attention.status === "pending")
-      ? [{ type: "section" as const, text: field(escapeSlackMrkdwn(attention.title)) }]
-      : []),
-    ...(params.state !== "working" && params.sessionUrl
-      ? [
-          {
-            type: "actions" as const,
-            elements: [
-              {
-                type: "button" as const,
-                action_id: SLACK_SESSION_LINK_ACTION_ID,
-                text: { type: "plain_text" as const, text: "Open in OpenClaw" },
-                url: params.sessionUrl,
-              },
-            ],
-          },
-        ]
-      : []),
+  const sections = [
+    `${status}*${escapeSlackMrkdwn(params.title.trim() || "Working")}*`,
+    narration ? `_${escapeSlackMrkdwn(narration)}_` : "",
+    planLines.map((line) => escapeSlackMrkdwn(line)).join("\n"),
+    authoredText,
+    attention && !(params.state !== "working" && attention.status === "pending")
+      ? escapeSlackMrkdwn(attention.title)
+      : "",
   ];
+  const blocks: (Block | KnownBlock)[] = sections.filter(Boolean).map((text) => ({
+    type: "section",
+    text: { type: "mrkdwn", text: truncateSlackText(text, SLACK_PROGRESS_FIELD_MAX) },
+  }));
+  if (params.state !== "working" && params.sessionUrl) {
+    blocks.push({
+      type: "actions",
+      elements: [
+        {
+          type: "button",
+          action_id: SLACK_SESSION_LINK_ACTION_ID,
+          text: { type: "plain_text", text: "Open in OpenClaw" },
+          url: params.sessionUrl,
+        },
+      ],
+    });
+  }
   return blocks.slice(0, SLACK_MAX_BLOCKS);
 }
 
-type SlackNativeTaskRow = {
-  title: string;
-  status: SlackPlanTaskStatus;
+type SlackNativeTaskRow = Pick<TaskUpdateChunk, "title" | "status"> & {
   sourcesSent?: boolean;
 };
 
@@ -327,15 +286,4 @@ export function reconcileSlackNativeTaskChunks(params: {
     chunks: emitted.length > 0 ? emitted : undefined,
     snapshot: { ...(planTitle ? { planTitle } : {}), tasks: nextTasks },
   };
-}
-
-export function buildSlackProgressStreamCompletionChunks(params: {
-  label?: string;
-  title?: string;
-  lines: readonly ChannelProgressDraftLine[];
-  plan?: readonly AgentPlanStep[];
-  finalInProgressStatus?: SlackPlanTaskStatus;
-  sessionUrl?: string;
-}): AnyChunk[] | undefined {
-  return buildSlackProgressStreamChunks({ ...params, completeInProgress: true });
 }

--- a/src/channels/status-reactions.ts
+++ b/src/channels/status-reactions.ts
@@ -170,22 +170,7 @@ export function resolveToolEmoji(
   if (Object.hasOwn(TOOL_DISPLAY_CONFIG.tools, normalized)) {
     return resolveToolDisplay({ name: toolName }).emoji;
   }
-  if (category === "deploy") {
-    return emojis.deploy;
-  }
-  if (category === "build") {
-    return emojis.build;
-  }
-  if (category === "concierge") {
-    return emojis.concierge;
-  }
-  if (category === "web") {
-    return emojis.web;
-  }
-  if (category === "coding") {
-    return emojis.coding;
-  }
-  return emojis.tool;
+  return emojis[category];
 }
 
 /**
@@ -240,10 +225,7 @@ export function createStatusReactionController(params: {
   }
 
   function clearActivityTimers(): void {
-    if (debounceTimer) {
-      clearTimeout(debounceTimer);
-      debounceTimer = null;
-    }
+    clearDebounceTimer();
     if (stallSoftTimer) {
       clearTimeout(stallSoftTimer);
       stallSoftTimer = null;


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested cleanup following #133516 (quiet Discord and Slack progress). The same progress policy and rendering decisions were repeated in channel adapters, with unused forwarding methods and separate active/completion builder paths.

## Why This Change Was Made

- Let the shared compositor own Discord preview admission, tool-message suppression, and event-line formatting; delete unconsumed controller methods and bind the remaining callbacks to their original compositor receiver.
- Let both channel adapters use the compositor's existing default event formatter.
- Use one Slack native chunk builder with an optional terminal status instead of a completion wrapper and parallel completion boolean. Derive task shapes from the installed Slack types.
- Build Block Kit sections once from ordered text; retain escaping, truncation, authored content, attention, and session-link ordering.
- Replace the reaction category field-copy cascade with an indexed lookup and reuse the existing debounce cleanup.

No new abstraction, dependency, configuration, SDK export, or storage change. Production: **+45 / −184 = −139 lines**. Tests: **+4 / −5 = −1 line**; all existing assertions retained.

## User Impact

None intended. Discord/Slack remain quiet: stable acknowledgements, authored milestones, bounded attention, batched progress, and unchanged final delivery. Other channels retain their existing activity reactions. This does not deploy or restart an operator Gateway.

## Evidence

- Before refactor: 30 Slack renderer and delivery wire-trace tests passed. Wire snapshots are unchanged.
- Final focused tests: **354 passed** (112 Discord draft/REST/final/recovery; 191 Slack renderer/dispatch/wire trace; 51 shared reaction/lifecycle). One initial Discord import hook timed out; the unchanged cache-warm rerun passed all tests. No timeout or assertion changes.
- Fresh autoreview: scoped-clean at its configured P0 threshold, including the receiver-binding follow-up. All changed-scope guards, core/plugin/test typechecks, and core/plugin lint passed. The receiver-binding follow-up also reran all 112 Discord tests successfully.
- Commands: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs` with the 11 focused files listed by this PR's renderer/dispatch/visibility/final/recovery/reaction suites; `node scripts/check-changed.mjs`; `.agents/skills/autoreview/scripts/autoreview --mode uncommitted`.
- Source proof: Discord controller → shared progress compositor → event formatter; Slack dispatch → native chunk/card renderer → stream reconciler; status-reaction selector/controller.
- Direct dependency inspection: installed `@slack/types/dist/chunk.d.ts`, `@slack/web-api/dist/chat-stream.js`; sibling Codex `codex-rs/app-server-protocol/src/protocol/v2/turn.rs:524` and `codex-rs/protocol/src/plan_tool.rs:17`. Authored plan snapshots remain distinct from tool activity.
- Bounded behavior-neutral refactor: focused dispatch/render/wire tests and exact-head CI are the proof; no fresh authenticated channel send or visual change is claimed. No snapshot updates.

Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/33349557303 (head `73e7927669bc280da995501742f34772aebd8239`), **green**. The first CI run caught four unbound method references; callbacks now bind their original compositor receiver. No test expectations, timeouts, or snapshots were weakened. ClawSweeper’s exact-head validation rank-up is satisfied.
