### PR TITLE
fix(bedrock): reject malformed embedding response encoding

### DIFF
--- a/extensions/amazon-bedrock/embedding-provider.test.ts
+++ b/extensions/amazon-bedrock/embedding-provider.test.ts
@@ -402,9 +402,21 @@ describe("bedrock embedding response parsing", () => {
       model: "cohere.embed-english-v3",
       raw: '{"embeddings":[[1],{"bad":true}]}',
     },
+    ...[
+      { model: "amazon.titan-embed-text-v2:0", vector: '"embedding":[3,4]' },
+      { model: "cohere.embed-english-v3", vector: '"embeddings":[[3,4]]' },
+    ].map(({ model, vector }) => ({
+      name: `invalid UTF-8 for ${model}`,
+      model,
+      raw: Buffer.concat([
+        Buffer.from('{"ignored":"bad'),
+        Buffer.from([0xff]),
+        Buffer.from(`",${vector}}`),
+      ]),
+    })),
   ])("rejects $name through the provider boundary", async ({ model, raw }) => {
     vi.spyOn(bedrockRuntimeSdk.BedrockRuntimeClient.prototype, "send").mockResolvedValue({
-      body: new TextEncoder().encode(raw),
+      body: typeof raw === "string" ? new TextEncoder().encode(raw) : raw,
     } as never);
     const { provider } = await createBedrockEmbeddingProvider({ config: {}, model });
     const request = model.startsWith("cohere.")
@@ -412,25 +424,6 @@ describe("bedrock embedding response parsing", () => {
       : provider.embed("private memory", { inputType: "query" });
 
     await expect(request).rejects.toThrow(
-      "Amazon Bedrock embedding response returned malformed JSON",
-    );
-  });
-
-  it("rejects malformed UTF-8 response bytes through the provider boundary", async () => {
-    const body = new Uint8Array([
-      ...new TextEncoder().encode('{"embedding":[3,4],"ignored":"bad'),
-      0xff,
-      ...new TextEncoder().encode('"}'),
-    ]);
-    vi.spyOn(bedrockRuntimeSdk.BedrockRuntimeClient.prototype, "send").mockResolvedValue({
-      body,
-    } as never);
-    const { provider } = await createBedrockEmbeddingProvider({
-      config: {},
-      model: "amazon.titan-embed-text-v2:0",
-    });
-
-    await expect(provider.embed("private memory", { inputType: "query" })).rejects.toThrow(
       "Amazon Bedrock embedding response returned malformed JSON",
     );
   });

--- a/extensions/amazon-bedrock/embedding-provider.test.ts
+++ b/extensions/amazon-bedrock/embedding-provider.test.ts
@@ -415,6 +415,25 @@ describe("bedrock embedding response parsing", () => {
       "Amazon Bedrock embedding response returned malformed JSON",
     );
   });
+
+  it("rejects malformed UTF-8 response bytes through the provider boundary", async () => {
+    const body = new Uint8Array([
+      ...new TextEncoder().encode('{"embedding":[3,4],"ignored":"bad'),
+      0xff,
+      ...new TextEncoder().encode('"}'),
+    ]);
+    vi.spyOn(bedrockRuntimeSdk.BedrockRuntimeClient.prototype, "send").mockResolvedValue({
+      body,
+    } as never);
+    const { provider } = await createBedrockEmbeddingProvider({
+      config: {},
+      model: "amazon.titan-embed-text-v2:0",
+    });
+
+    await expect(provider.embed("private memory", { inputType: "query" })).rejects.toThrow(
+      "Amazon Bedrock embedding response returned malformed JSON",
+    );
+  });
 });
 
 describe("bedrock embedding inference profiles", () => {

--- a/extensions/amazon-bedrock/embedding-provider.ts
+++ b/extensions/amazon-bedrock/embedding-provider.ts
@@ -237,6 +237,15 @@ function malformedBedrockEmbeddingResponse(): Error {
   return new Error("Amazon Bedrock embedding response returned malformed JSON");
 }
 
+// Bedrock returns JSON as bytes; reject invalid UTF-8 instead of admitting replacement characters.
+function decodeBedrockEmbeddingResponseBody(body: Uint8Array): string {
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(body);
+  } catch {
+    throw malformedBedrockEmbeddingResponse();
+  }
+}
+
 function asNumberArray(value: unknown): number[] {
   if (!Array.isArray(value)) {
     throw malformedBedrockEmbeddingResponse();
@@ -329,7 +338,7 @@ export async function createBedrockEmbeddingProvider(
         }),
         signal ? { abortSignal: signal } : undefined,
       );
-      return new TextDecoder().decode(res.body);
+      return decodeBedrockEmbeddingResponseBody(res.body);
     } finally {
       sdk.destroy();
     }

--- a/extensions/amazon-bedrock/embedding-provider.ts
+++ b/extensions/amazon-bedrock/embedding-provider.ts
@@ -221,9 +221,9 @@ type BedrockEmbeddingResponseJson = {
   data?: unknown;
 };
 
-function parseBedrockEmbeddingResponseJson(raw: string): BedrockEmbeddingResponseJson {
+function parseEmbeddingResponseJson(raw: Uint8Array | undefined): BedrockEmbeddingResponseJson {
   try {
-    const parsed = JSON.parse(raw) as unknown;
+    const parsed = JSON.parse(new TextDecoder("utf-8", { fatal: true }).decode(raw)) as unknown;
     if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
       throw new Error("Amazon Bedrock embedding response returned malformed JSON");
     }
@@ -235,15 +235,6 @@ function parseBedrockEmbeddingResponseJson(raw: string): BedrockEmbeddingRespons
 
 function malformedBedrockEmbeddingResponse(): Error {
   return new Error("Amazon Bedrock embedding response returned malformed JSON");
-}
-
-// Bedrock returns JSON as bytes; reject invalid UTF-8 instead of admitting replacement characters.
-function decodeBedrockEmbeddingResponseBody(body: Uint8Array): string {
-  try {
-    return new TextDecoder("utf-8", { fatal: true }).decode(body);
-  } catch {
-    throw malformedBedrockEmbeddingResponse();
-  }
 }
 
 function asNumberArray(value: unknown): number[] {
@@ -265,8 +256,8 @@ function asNumberArrayBatch(value: unknown): number[][] {
   return value.map((entry) => asNumberArray(entry));
 }
 
-function parseSingle(family: Family, raw: string): number[] {
-  const data = parseBedrockEmbeddingResponseJson(raw);
+function parseSingle(family: Family, raw: Uint8Array | undefined): number[] {
+  const data = parseEmbeddingResponseJson(raw);
   switch (family) {
     case "nova":
       return asNumberArray(Array.isArray(data.embeddings) ? data.embeddings[0]?.embedding : null);
@@ -285,8 +276,8 @@ function parseSingle(family: Family, raw: string): number[] {
   }
 }
 
-function parseCohereBatch(family: Family, raw: string): number[][] {
-  const data = parseBedrockEmbeddingResponseJson(raw);
+function parseCohereBatch(family: Family, raw: Uint8Array | undefined): number[][] {
+  const data = parseEmbeddingResponseJson(raw);
   const embeddings = data.embeddings;
   if (!embeddings) {
     throw malformedBedrockEmbeddingResponse();
@@ -320,7 +311,7 @@ export async function createBedrockEmbeddingProvider(
     family,
   });
 
-  const invoke = async (body: string, signal?: AbortSignal): Promise<string> => {
+  const invoke = async (body: string, signal?: AbortSignal): Promise<Uint8Array | undefined> => {
     await refreshAwsSharedConfigCacheForBedrock();
     const sdk = new BedrockRuntimeClient({
       region: client.region,
@@ -338,7 +329,7 @@ export async function createBedrockEmbeddingProvider(
         }),
         signal ? { abortSignal: signal } : undefined,
       );
-      return decodeBedrockEmbeddingResponseBody(res.body);
+      return res.body;
     } finally {
       sdk.destroy();
     }


### PR DESCRIPTION
## What Problem This Solves

Reject malformed UTF-8 in Bedrock embedding responses through the existing malformed-JSON error boundary. The SDK returns response bytes, but decoding them earlier with replacement silently turned invalid bytes into valid JSON. The repair retains bytes until the shared parser and decodes fatally there, covering both single-vector and Cohere batch paths. Production LOC is unchanged and no helper, config or dependency is added.

## Why This Change Was Made

Two malformed-byte rows extend the existing provider-boundary regression table. They fail before the fix by returning normalized vectors;50 provider/adapter tests pass after the repair. All changed-file gates pass and independent P0 review is clean. Thanks @RileyJJY for identifying the defect.

## User Impact

Corrupted embedding response bytes now produce the established malformed-response error; valid vectors remain unchanged.

## Evidence

Actual memory-adapter/AWS-SDK proof makes14 signed HTTP/2 requests to a synthetic TLS server with certificate verification enabled. It covers Titanv1/v2, Nova, TwelveLabs and Coherev3/v4 with valid Unicode and corrupted UTF-8, plus malformed-JSON single/batch controls. Before, all six corrupted cases returned vectors. After, all reject with the existing malformed-response error; valid vectors and other errors stay unchanged. Each HTTP/2 session closes before the next case; final server cleanup leaves zero sessions and the isolated HOME is removed. This proves real SDK transport and parsing against a synthetic service, not a call to AWS Bedrock.

Five direct provider/adapter/vector/SDK-facade source hashes match the executed final proof and virtual merged tree8d66ae658668e2192cddca5a747fe717e1172815 (candidate059554f331eae6bd57083cfdf0aa6769760381a0 plus main433108d2). The installed AWS SDK3.1116.0 matches the owning plugin manifest. Final publication will bind the committed head to that candidate tree and attach exact-head CI. SDK disposal remains owned by the existing invoke finally block.

ClawSweeper September1 07:06UTC: the intentional compatibility change is limited to invalid upstream UTF-8, which now returns the already-established malformed-response error. The one-use decoder and its +9 production lines are eliminated by decoding inside the existing parser; final production net0. Its automatic stored-data warning does not apply: no stored vector shape, dimensions, cache identity, schema or migration changes. These conclusions are supported by the provider/adapter source and unchanged valid-vector transport cases. No separate Rank-up moves were listed.

<details>
<summary>Captured behavior verdict</summary>

```json
{"passed":true,"sourceSha256":"50bdbe6bb45d5d34c208e52cbc09d980ce7a0a8608b39a0a4276eb479e80c2a8","node":"v24.20.0","serverClosed":true,"remainingSessions":0,"cases":[{"model":"amazon.titan-embed-text-v1","mode":"valid","result":[0.6,0.8],"sessionsReleased":true},{"model":"amazon.titan-embed-text-v1","mode":"invalid","error":"Amazon Bedrock embedding response returned malformed JSON","sessionsReleased":true},{"model":"amazon.titan-embed-text-v2:0","mode":"valid","result":[0.6,0.8],"sessionsReleased":true},{"model":"amazon.titan-embed-text-v2:0","mode":"invalid","error":"Amazon Bedrock embedding response returned malformed JSON","sessionsReleased":true},{"model":"amazon.titan-embed-text-v2:0","mode":"json","error":"Amazon Bedrock embedding response returned malformed JSON","sessionsReleased":true},{"model":"amazon.nova-2-multimodal-embeddings-v1:0","mode":"valid","result":[0.6,0.8],"sessionsReleased":true},{"model":"amazon.nova-2-multimodal-embeddings-v1:0","mode":"invalid","error":"Amazon Bedrock embedding response returned malformed JSON","sessionsReleased":true},{"model":"twelvelabs.marengo-embed-3-0-v1:0","mode":"valid","result":[0.6,0.8],"sessionsReleased":true},{"model":"twelvelabs.marengo-embed-3-0-v1:0","mode":"invalid","error":"Amazon Bedrock embedding response returned malformed JSON","sessionsReleased":true},{"model":"cohere.embed-english-v3","mode":"valid","result":[[0.6,0.8],[0.8,0.6]],"sessionsReleased":true},{"model":"cohere.embed-english-v3","mode":"invalid","error":"Amazon Bedrock embedding response returned malformed JSON","sessionsReleased":true},{"model":"cohere.embed-v4:0","mode":"valid","result":[[0.6,0.8],[0.8,0.6]],"sessionsReleased":true},{"model":"cohere.embed-v4:0","mode":"invalid","error":"Amazon Bedrock embedding response returned malformed JSON","sessionsReleased":true},{"model":"cohere.embed-v4:0","mode":"json","error":"Amazon Bedrock embedding response returned malformed JSON","sessionsReleased":true}]}
```
</details>


Reviewed and pushed head: `aca683caa361848b6a0af72aba9a0da731701aea`. Required exact-head CI must pass before landing.
