### PR TITLE
fix(ui): keep submenu parent rows highlighted

### DIFF
--- a/ui/src/components/menu-surface.browser.test.ts
+++ b/ui/src/components/menu-surface.browser.test.ts
@@ -135,3 +135,55 @@ describe.skipIf(!hasPopoverApi)("sidebar menu stacking", () => {
     expect(dropdown.contains(hit)).toBe(true);
   });
 });
+
+describe.skipIf(!hasPopoverApi)("submenu parent highlight", () => {
+  it.each([
+    ["session-menu__item", "keyboard"],
+    ["session-menu__item", "pointer"],
+    ["sidebar-customize-menu__item", "keyboard"],
+    ["sidebar-customize-menu__item", "pointer"],
+  ])("keeps %s highlighted during %s submenu navigation", async (className, input) => {
+    await useDesktopViewport();
+    const { page, userEvent } = await import("vitest/browser");
+    const dropdown = document.createElement("wa-dropdown");
+    const trigger = document.createElement("button");
+    trigger.slot = "trigger";
+    trigger.textContent = "Actions";
+    const parent = document.createElement("wa-dropdown-item");
+    parent.className = className;
+    parent.append("Parent");
+    const child = document.createElement("wa-dropdown-item");
+    child.className = className;
+    child.slot = "submenu";
+    child.textContent = "Child";
+    parent.append(child);
+    const sibling = document.createElement("wa-dropdown-item");
+    sibling.className = className;
+    sibling.textContent = "Other action";
+    dropdown.append(trigger, parent, sibling);
+    document.body.append(dropdown);
+    const swatch = document.createElement("div");
+    swatch.style.backgroundColor = "var(--bg-hover)";
+    document.body.append(swatch);
+    const highlight = getComputedStyle(swatch).backgroundColor;
+
+    await page.elementLocator(trigger).click();
+    await expect.poll(() => document.activeElement).toBe(parent);
+    if (input === "keyboard") {
+      await userEvent.keyboard("{ArrowRight}");
+    } else {
+      await page.elementLocator(parent).hover();
+      await page.elementLocator(child).hover();
+    }
+    await expect.poll(() => document.activeElement).toBe(child);
+    await expect.poll(() => parent.getAttribute("aria-expanded")).toBe("true");
+    await expect.poll(() => getComputedStyle(parent).backgroundColor).toBe(highlight);
+
+    await userEvent.keyboard("{ArrowLeft}");
+    await expect.poll(() => document.activeElement).toBe(parent);
+    await userEvent.keyboard("{ArrowDown}");
+    await expect.poll(() => document.activeElement).toBe(sibling);
+    await expect.poll(() => parent.getAttribute("aria-expanded")).toBe("false");
+    await expect.poll(() => getComputedStyle(parent).backgroundColor).toBe("rgba(0, 0, 0, 0)");
+  });
+});

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2390,7 +2390,10 @@ wa-dropdown.sidebar-customize-menu::part(menu) {
   text-decoration: none;
 }
 
-.sidebar-customize-menu__item:hover {
+/* Keep expanded state separate from :hover so hover media scoping preserves
+   the parent highlight for keyboard and touch navigation too. */
+.sidebar-customize-menu__item:hover,
+.sidebar-customize-menu__item[aria-expanded="true"] {
   background: var(--bg-hover);
 }
 
@@ -2587,6 +2590,7 @@ wa-dropdown-item.session-menu__item::part(submenu-icon) {
 }
 
 .session-menu__item:hover:not(:disabled):not([aria-disabled="true"]),
+.session-menu__item[aria-expanded="true"],
 .session-menu__item:focus-visible,
 .sidebar-session-sort-menu__item:hover,
 .sidebar-session-sort-menu__item:focus-visible {


### PR DESCRIPTION
Closes #133711

## What Problem This Solves

Fixes an issue where users navigating a Control UI submenu lose the parent row highlight as keyboard focus or the pointer enters the submenu. This makes **Move to group**, **Copy**, **Open in**, **Assign to**, and sidebar **Help** lose their visible menu hierarchy.

## Why This Change Was Made

The shared session/sidebar row styles override Web Awesome's host background with transparent, but previously restored the highlight only on hover/focus. Extend those same rules to the dependency-owned `aria-expanded="true"` state. Keep it as a separate selector: the UI's hover-media transform would otherwise scope keyboard/touch highlighting to hover-capable pointers.

No new JS state, focus handlers, dependency patches, or fallback paths. Existing compact/mobile drilldown behavior is unchanged.

## User Impact

Open submenu parents stay highlighted while users navigate their children. The old parent clears when its submenu closes and selection moves away. Both session menus (including header/diff consumers) and sidebar identity menus use the repaired styles.

## Evidence

- **Failing before:** four real Chromium regressions failed on the original CSS: session/sidebar row styles × keyboard/pointer. The parent had `aria-expanded="true"` and the child held focus, but parent background was transparent.
- **Passing after:** 9 browser tests, including those four regressions, close/focus-return cleanup, existing identity keyboard navigation, menu stacking, and check alignment.
- **Sibling action coverage:** 73 unit tests across session menus, work-menu resolution, and chat-header session menus.
- **Build:** `pnpm ui:build` passed, including finalized asset sidecars and performance budgets.
- **Review:** fresh `autoreview --mode uncommitted` scoped-clean; no accepted/actionable findings.
- **Real UI:** isolated loopback Gateway on port 19198, fresh state directory and clean environment, no operator state/provider/channel credentials. Open Account → Help → ArrowRight. Before/after served index hashes changed from `index-QFVUHFK3.js` to `index-F5z-nWTT.js`; parent remains expanded, child focused, and highlight changes from transparent to the hover color. Captures inspected visually.
- **Reported session flow:** running Control UI with deterministic mock Gateway data, session context menu → Move to group → ArrowRight. Captures inspected visually. This is mock-data app proof, not a live provider invocation.

Commands:

```sh
# From ui/
node ../scripts/run-vitest.mjs run --config vitest.config.ts --configLoader runner --project browser src/components/menu-surface.browser.test.ts src/components/app-sidebar-identity-keyboard.browser.test.ts src/components/menu-check-alignment.browser.test.ts
# From repo root
node scripts/run-vitest.mjs ui/src/components/session-menu.test.ts ui/src/components/session-menu-work.test.ts ui/src/pages/chat/components/chat-header-session-menu.test.ts
pnpm ui:build
node scripts/check-changed.mjs -- ui/src/styles/layout.css ui/src/components/menu-surface.browser.test.ts
```

Full `pnpm build` passed (20m02s). `check:changed` passed all selected guards, dead-export scans, core-test/UI type checks, and changed-file lint. Exact-head CI: https://github.com/openclaw/openclaw/actions/runs/33349566602 — **green** for `dffe2a5cdaf40b495956d23d73ac27e7b88f3b8e`, including all UI browser/E2E/real-Gateway lanes. All four uploaded screenshot URLs return HTTP 200 and authenticated downloaded bytes match the inspected local captures.

### Session submenu: before / after

| Before | After |
| --- | --- |
| ![Move to group loses its parent highlight](https://github.com/user-attachments/assets/b0aaf470-3ce2-4627-a1c7-4982561fb989) | ![Move to group keeps its parent highlight](https://github.com/user-attachments/assets/68963701-b659-42ef-a7a0-e3286c4c884d) |

### Isolated live Gateway: before / after

| Before | After |
| --- | --- |
| ![Help loses its parent highlight](https://github.com/user-attachments/assets/823f6b28-23c0-4eb9-a426-c1f54a14d623) | ![Help keeps its parent highlight](https://github.com/user-attachments/assets/e4b19f54-d20d-4189-bd21-db86685a438d) |

### Scope and review notes

- Architectural owner: shared menu-row appearance in `ui/src/styles/layout.css`; Web Awesome owns the open/close lifecycle and updates ARIA in `openSubmenu`/`closeSubmenu` (3.11.0 dropdown-item source inspected).
- Best-fix choice: repair the existing style override, not per-menu focus handlers or a global override that changes unrelated Web Awesome menu variants.
- Production LOC: **+5/-1 (net +4)**: two selectors plus a two-line comment explaining the hover-transform constraint. Combining open state inside `:is(:hover, ...)` was tested and rejected because the transform made it hover-only. Tests: **+52/-0**. No removed runtime paths; no runtime paths added.
- Provenance: exact first introduction unknown. The transparent/hover rules predate the Web Awesome migration and are carried through raw commit `8590655190d` (2026-07-13, author Peter Steinberger); the same omission is present in stable `v2026.8.1`. No historical runtime reproduction or merger attribution is claimed.
- Named test-harness follow-up: `ui/src/test-helpers/lit-warnings.setup.ts` replaces native `ElementInternals` in the Chromium lane as well as jsdom, preventing native `:state()` assertions. This regression uses the real dependency-owned ARIA state and rendered background; native-internals cleanup is separate from the menu fix.
