### PR TITLE
feat: prepare new-session names after idle typing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1785,6 +1785,13 @@ jobs:
         run: python3 -m pip install --disable-pip-version-check pre-commit==4.6.2
 
       - name: Detect committed private keys
+        env:
+          # pre-commit clones its pinned hook repos over anonymous HTTPS, which the
+          # runners intermittently reject ("could not read Username"). Route those
+          # read-only fetches through the job token without writing a git config.
+          GIT_CONFIG_COUNT: "1"
+          GIT_CONFIG_KEY_0: url.https://x-access-token:${{ github.token }}@github.com/.insteadOf
+          GIT_CONFIG_VALUE_0: https://github.com/
         run: pre-commit run --config "${PRE_COMMIT_CONFIG_PATH:-.pre-commit-config.yaml}" --all-files detect-private-key
 
       - name: Audit changed GitHub workflows with zizmor

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ on:
         default: false
         type: boolean
       release_scope:
-        description: Release qualification scope; npm-beta and npm-stable defer native apps for a validated exact release target.
+        description: Release qualification scope; npm-beta defers native apps for a validated exact beta target.
         required: false
         default: full
         type: choice
-        options: [full, npm-beta, npm-stable]
+        options: [full, npm-beta]
       release_gate:
         description: Run an exact-SHA maintainer release-gate fallback when PR CI is capacity-stalled.
         required: false
@@ -582,10 +582,7 @@ jobs:
               if sha == os.environ["WORKFLOW_SHA"]:
                   # Export the workflow revision from the freshly populated index, replacing
                   # retained platform files without updating the index or trusting later edits.
-                  pathspecs = [".github/actions"]
-                  if kind == "preflight":
-                      pathspecs += ["scripts/lib/release-context.mjs", "scripts/lib/release-version.mjs"]
-                  paths = git_output(workspace, "ls-files", "-z", "--", *pathspecs).split("\0")[:-1]
+                  paths = git_output(workspace, "ls-files", "-z", "--", ".github/actions").split("\0")[:-1]
                   run_git(workspace, "checkout-index", "--force", f"--prefix={harness}/", "--", *paths)
               else:
                   run_git(harness, "init", harness)
@@ -740,11 +737,7 @@ jobs:
         with:
           ref: ${{ github.workflow_sha }}
           path: .ci-harness
-          sparse-checkout: |
-            /.github/actions/
-            /scripts/lib/release-context.mjs
-            /scripts/lib/release-version.mjs
-          sparse-checkout-cone-mode: false
+          sparse-checkout: .github/actions
           persist-credentials: false
 
       - name: Resolve logical runner profile
@@ -1065,12 +1058,9 @@ jobs:
             manifest_node_args+=(--import tsx)
           fi
           node "${manifest_node_args[@]}" --input-type=module <<'EOF'
-          import { execFileSync } from "node:child_process";
           import { appendFileSync, existsSync, readFileSync } from "node:fs";
           import { matchesGlob } from "node:path";
           import { resolveTestGitCommits } from "./.ci-harness/.github/actions/git-owner/test-prerequisites.mjs";
-          import { resolveReleaseContextIdentity } from "./.ci-harness/scripts/lib/release-context.mjs";
-          import { classifyReleaseTrain, parseReleaseVersion } from "./.ci-harness/scripts/lib/release-version.mjs";
 
           const eventName = process.env.OPENCLAW_CI_EVENT_NAME ?? "";
           const checkoutRevision = process.env.OPENCLAW_CI_CHECKOUT_REVISION ?? "";
@@ -1184,50 +1174,27 @@ jobs:
           const docsChanged = parseBoolean(process.env.OPENCLAW_CI_DOCS_CHANGED);
           const releaseGate = parseBoolean(process.env.OPENCLAW_CI_RELEASE_GATE);
           const releaseScope = process.env.OPENCLAW_CI_RELEASE_SCOPE ?? "full";
-          const npmQualification = releaseScope === "npm-beta" || releaseScope === "npm-stable";
-          if (releaseScope !== "full" && !npmQualification) {
-            throw new Error("release_scope must be full, npm-beta, or npm-stable");
+          const npmBetaQualification = releaseScope === "npm-beta";
+          if (releaseScope !== "full" && !npmBetaQualification) {
+            throw new Error("release_scope must be full or npm-beta");
           }
-          if (npmQualification) {
-            const packageVersion = String(packageJson.version ?? "");
-            const parsedVersion = parseReleaseVersion(packageVersion);
-            const expectedTrain = releaseScope === "npm-beta" ? "beta" : "stable";
-            const contextRef = process.env.OPENCLAW_CI_TARGET_CONTEXT_TARGET === "true"
-              ? process.env.OPENCLAW_CI_TARGET_CONTEXT_REF
-              : historicalTargetApproved ? process.env.OPENCLAW_CI_HISTORICAL_TARGET_TAG : "";
+          if (npmBetaQualification) {
+            const betaVersion = String(packageJson.version ?? "").match(
+              /^([0-9]{4}\.(?:[1-9]|1[0-2])\.[1-9][0-9]*)-beta\.[1-9][0-9]*$/u,
+            );
+            const betaContext = betaVersion && (
+              (process.env.OPENCLAW_CI_TARGET_CONTEXT_TARGET === "true" &&
+                process.env.OPENCLAW_CI_TARGET_CONTEXT_REF === `release/${betaVersion[1]}`) ||
+              (historicalTargetApproved &&
+                process.env.OPENCLAW_CI_HISTORICAL_TARGET_TAG === `v${packageJson.version}`)
+            );
             if (
               eventName !== "workflow_dispatch" || !isCanonicalRepository || releaseGate ||
               process.env.OPENCLAW_CI_PULL_REQUEST_NUMBER ||
               !/^[0-9a-f]{40}$/u.test(process.env.OPENCLAW_CI_TARGET_REF ?? "") ||
-              process.env.OPENCLAW_CI_TARGET_REF !== checkoutRevision ||
-              !parsedVersion || parsedVersion.version !== packageVersion ||
-              classifyReleaseTrain(parsedVersion) !== expectedTrain
+              process.env.OPENCLAW_CI_TARGET_REF !== checkoutRevision || !betaContext
             ) {
-              throw new Error(`release_scope ${releaseScope} requires an exact ${expectedTrain} target with validated matching release context and no PR release gate or pull_request_number`);
-            }
-            let identity;
-            try {
-              identity = resolveReleaseContextIdentity(contextRef ?? "", packageVersion);
-            } catch (error) {
-              throw new Error(`release_scope ${releaseScope}: ${error.message}`);
-            }
-            if (!identity || identity.kind === "extended-stable branch") {
-              throw new Error(`release_scope ${releaseScope} requires a matching regular release branch or tag`);
-            }
-            if (identity.baseTag) {
-              // Base-package corrections reuse the base tag's exact source; ancestry alone is insufficient.
-              const baseRef = `refs/tags/${identity.baseTag}`;
-              const remoteRefs = execFileSync("python3", [
-                "-I", "-S", `${process.env.RUNNER_TEMP}/ci-git-owner.py`, "--git", "120",
-                "ls-remote", "--tags", "https://github.com/openclaw/openclaw.git", baseRef, `${baseRef}^{}`,
-              ], { encoding: "utf8" });
-              const refs = new Map(remoteRefs.trim().split("\n").filter(Boolean).map((line) => {
-                const [sha, ref] = line.split(/\s+/u);
-                return [ref, sha];
-              }));
-              if (!refs.has(baseRef) || (refs.get(`${baseRef}^{}`) ?? refs.get(baseRef)) !== checkoutRevision) {
-                throw new Error(`release_scope ${releaseScope} correction base ${identity.baseTag} does not resolve to ${checkoutRevision}`);
-              }
+              throw new Error("release_scope npm-beta requires an exact beta target with validated matching release context and no PR release gate or pull_request_number");
             }
           }
           const runNode = parseBoolean(process.env.OPENCLAW_CI_RUN_NODE) && !docsOnly;
@@ -1252,14 +1219,14 @@ jobs:
           const supportsCurrentIosCi = supportsIosBuild && supportsCurrentMacosSwiftCi;
           const runIosBuild =
             parseBoolean(process.env.OPENCLAW_CI_RUN_IOS_BUILD) &&
-            !npmQualification &&
+            !npmBetaQualification &&
             !docsOnly &&
             isCanonicalRepository &&
             (!frozenTarget ||
               supportsCurrentIosCi ||
               (releaseCandidateTarget && supportsIosBuild));
           const runAndroid =
-            parseBoolean(process.env.OPENCLAW_CI_RUN_ANDROID) && !npmQualification &&
+            parseBoolean(process.env.OPENCLAW_CI_RUN_ANDROID) && !npmBetaQualification &&
             !docsOnly && isCanonicalRepository;
           const runWindows =
             parseBoolean(process.env.OPENCLAW_CI_RUN_WINDOWS) &&
@@ -1288,7 +1255,7 @@ jobs:
             hasPackageScript("apple:i18n:check");
           const runNativeI18n =
             parseBoolean(process.env.OPENCLAW_CI_RUN_NATIVE_I18N) &&
-            !npmQualification &&
+            !npmBetaQualification &&
             !docsOnly &&
             (!frozenTarget || supportsNativeI18n);
           const targetWorkflow = existsSync(".github/workflows/ci.yml")
@@ -1601,9 +1568,9 @@ jobs:
                 : [],
             ),
             run_macos_swift:
-              runMacos && !npmQualification &&
+              runMacos && !npmBetaQualification &&
               (!frozenTarget || compatibilityTarget || supportsCurrentMacosSwiftCi),
-            run_openclawkit_tests: runMacos && !npmQualification && supportsOpenClawKitTests,
+            run_openclawkit_tests: runMacos && !npmBetaQualification && supportsOpenClawKitTests,
             run_ios_build: runIosBuild,
             run_android_job: runAndroid,
             use_compatible_android_ci: useCompatibleAndroidCi,
@@ -1646,7 +1613,7 @@ jobs:
           if (process.env.GITHUB_STEP_SUMMARY) {
             appendFileSync(process.env.GITHUB_STEP_SUMMARY,
               `### CI release qualification\n\n- Scope: \`${releaseScope}\`\n- Target: \`${checkoutRevision}\`\n` +
-              (npmQualification ? "- Native app qualification: deferred; Linux, macOS, and Windows Node coverage retained.\n" : ""));
+              (npmBetaQualification ? "- Native app qualification: deferred; Linux, macOS, and Windows Node coverage retained.\n" : ""));
           }
           EOF
 
@@ -1686,27 +1653,11 @@ jobs:
     env:
       PRE_COMMIT_HOME: .cache/pre-commit-security-fast
     steps:
-      - name: Resolve security checkout depth
-        if: github.event_name == 'pull_request'
-        id: checkout_depth
-        env:
-          PR_COMMIT_COUNT: ${{ github.event.pull_request.commits }}
-        run: |
-          set -euo pipefail
-          if ! [[ "$PR_COMMIT_COUNT" =~ ^[0-9]+$ ]]; then
-            echo "::error::Invalid pull request commit count: $PR_COMMIT_COUNT"
-            exit 2
-          fi
-          # Fetch the merge, every PR commit, and one ancestor while checkout
-          # still owns authentication; scanners run after credential cleanup.
-          fetch_depth=$((PR_COMMIT_COUNT + 2))
-          echo "depth=$fetch_depth" >> "$GITHUB_OUTPUT"
-
       - name: Checkout
         if: github.event_name != 'workflow_dispatch' || inputs.target_ref == ''
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: ${{ steps.checkout_depth.outputs.depth || 2 }}
+          fetch-depth: 2
           persist-credentials: false
 
       # Manual target validation has a distinct fallback contract: a missing branch/tag
@@ -1769,6 +1720,24 @@ jobs:
         with:
           base-sha: ${{ steps.diff_base.outputs.sha }}
           fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
+
+      - name: Fetch pull request scan history
+        if: github.event_name == 'pull_request'
+        env:
+          PR_COMMIT_COUNT: ${{ github.event.pull_request.commits }}
+          PR_MERGE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$PR_COMMIT_COUNT" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid pull request commit count: $PR_COMMIT_COUNT"
+            exit 2
+          fi
+          # Include the synthetic merge, every pull request commit, and one
+          # ancestor so TruffleHog can clone and resolve the bounded range.
+          fetch_depth=$((PR_COMMIT_COUNT + 2))
+          python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --checkout-git 120 \
+            -c protocol.version=2 \
+            fetch --no-tags --no-recurse-submodules --depth="$fetch_depth" origin "$PR_MERGE_SHA"
 
       - name: Scan pull request for leaked credentials
         if: github.event_name == 'pull_request'
@@ -4528,18 +4497,10 @@ jobs:
   ios-build:
     permissions:
       contents: read
-    name: ${{ format('ios-build ({0})', matrix.phase) }}
+    name: "ios-build"
     needs: [preflight]
     if: needs.preflight.outputs.run_ios_build == 'true'
-    # Release device products are not inputs to the simulator test graph.
-    strategy:
-      fail-fast: false
-      max-parallel: 2
-      matrix:
-        phase: ${{ fromJSON(needs.preflight.outputs.compatibility_target == 'true' && '["tests"]' || '["release","tests"]') }}
-    # Blacksmith macOS 26 admission stalled while hosted retries completed.
-    # Start both phases on the verified hosted image instead of waiting to retry.
-    runs-on: macos-26
+    runs-on: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' && 'macos-26' || (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'macos-26' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)) && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
     timeout-minutes: 150
     env:
       HISTORICAL_TARGET: ${{ needs.preflight.outputs.compatibility_target }}
@@ -4626,7 +4587,6 @@ jobs:
           fi
 
       - name: Swift lint
-        if: matrix.phase == 'tests'
         run: |
           if [[ -x ./scripts/lint-swift.sh && -x ./scripts/format-swift.sh ]]; then
             ./scripts/lint-swift.sh ios
@@ -4637,19 +4597,13 @@ jobs:
           fi
 
       - name: Build iOS app
-        if: matrix.phase == 'tests'
         run: pnpm ios:build
 
       # Debug's incremental compilation can miss actor-isolation diagnostics
       # that Swift's optimized whole-module Release build enforces.
       - name: Build iOS app (Release)
-        if: matrix.phase == 'release'
+        if: env.HISTORICAL_TARGET != 'true'
         run: |
-          set -euo pipefail
-          ./scripts/ios-configure-signing.sh
-          ./scripts/ios-write-version-xcconfig.sh
-          node scripts/ios-write-swift-filelist.mjs
-          xcodegen generate --spec apps/ios/project.yml --project apps/ios
           xcodebuild \
             -project apps/ios/OpenClaw.xcodeproj \
             -scheme OpenClaw \
@@ -4662,7 +4616,7 @@ jobs:
       # lifecycles. Exercise both owners on the already provisioned simulator.
       - name: Run focused iOS lifecycle simulator tests
         id: ios_lifecycle_tests
-        if: matrix.phase == 'tests' && needs.preflight.outputs.compatibility_target != 'true'
+        if: env.HISTORICAL_TARGET != 'true'
         run: |
           set -euo pipefail
           simulator_id="$(
@@ -4699,7 +4653,7 @@ jobs:
             test
 
       - name: Run focused Apple Watch operation simulator tests
-        if: matrix.phase == 'tests' && needs.preflight.outputs.compatibility_target != 'true'
+        if: env.HISTORICAL_TARGET != 'true'
         run: |
           set -euo pipefail
           simulator_id="$(
@@ -4773,9 +4727,8 @@ jobs:
     needs: [preflight]
     # Full manual/release validation always captures. PRs and their exact-head
     # release-gate substitutes use the same conservative screenshot-risk scope.
-    if: ${{ needs.preflight.outputs.release_scope == 'full' && ((github.event_name == 'workflow_dispatch' && (!inputs.release_gate || needs.preflight.outputs.run_ios_screenshots == 'true')) || (github.event_name == 'pull_request' && needs.preflight.outputs.run_ios_screenshots == 'true')) && needs.preflight.outputs.compatibility_target != 'true' }}
-    # Keep capture on the same verified hosted image as the iOS build phases.
-    runs-on: macos-26
+    if: ${{ needs.preflight.outputs.release_scope != 'npm-beta' && ((github.event_name == 'workflow_dispatch' && (!inputs.release_gate || needs.preflight.outputs.run_ios_screenshots == 'true')) || (github.event_name == 'pull_request' && needs.preflight.outputs.run_ios_screenshots == 'true')) && needs.preflight.outputs.compatibility_target != 'true' }}
+    runs-on: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' && 'macos-26' || (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'macos-26' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)) && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
     timeout-minutes: 90
     env:
       BUNDLE_DEPLOYMENT: "true"
@@ -4846,7 +4799,7 @@ jobs:
 
       - name: Capture Apple Watch screenshot
         id: watch_screenshot
-        if: matrix.device_family == 'ipad-13'
+        if: matrix.device_family == 'iphone'
         run: |
           source scripts/lib/ios-fastlane.sh
           (
@@ -4885,7 +4838,7 @@ jobs:
             --node-version "$(node --version)"
           )
           node scripts/ios-screenshot-evidence.mjs "${collect_args[@]}"
-          if [[ "$DEVICE_FAMILY" == "ipad-13" ]]; then
+          if [[ "$DEVICE_FAMILY" == "iphone" ]]; then
             collect_args[2]="watch"
             node scripts/ios-screenshot-evidence.mjs "${collect_args[@]}"
           fi
@@ -4915,7 +4868,7 @@ jobs:
       contents: read
     name: "ios-screenshot-evidence"
     needs: [preflight, ios-screenshot-shard]
-    if: ${{ needs.preflight.outputs.release_scope == 'full' && ((github.event_name == 'workflow_dispatch' && (!inputs.release_gate || needs.preflight.outputs.run_ios_screenshots == 'true')) || (github.event_name == 'pull_request' && needs.preflight.outputs.run_ios_screenshots == 'true')) && needs.preflight.outputs.compatibility_target != 'true' }}
+    if: ${{ needs.preflight.outputs.release_scope != 'npm-beta' && ((github.event_name == 'workflow_dispatch' && (!inputs.release_gate || needs.preflight.outputs.run_ios_screenshots == 'true')) || (github.event_name == 'pull_request' && needs.preflight.outputs.run_ios_screenshots == 'true')) && needs.preflight.outputs.compatibility_target != 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -5265,56 +5218,64 @@ jobs:
       - name: Verify selected CI lanes
         shell: bash
         env:
-          JOB_RESULTS: |
-            preflight=${{ needs.preflight.result }}|true
-            security-fast=${{ needs.security-fast.result }}|true
-            pnpm-store-warmup=${{ needs.pnpm-store-warmup.result }}|${{ (needs.preflight.outputs.run_node == 'true' || needs.preflight.outputs.run_check_docs == 'true') && (needs.preflight.outputs.runner_profile == 'github' || needs.preflight.outputs.runner_profile == 'hybrid' || (!(github.repository == 'openclaw/openclaw' && github.event_name == 'push' && github.ref == 'refs/heads/main') && !(github.repository == 'openclaw/openclaw' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.preflight.outputs.run_node == 'true'))) }}
-            build-artifacts=${{ needs.build-artifacts.result }}|${{ needs.preflight.outputs.run_build_artifacts }}
-            native-i18n=${{ needs.native-i18n.result }}|${{ needs.preflight.outputs.run_native_i18n }}
-            checks-ui=${{ needs.checks-ui.result }}|${{ needs.preflight.outputs.run_ui_tests }}
-            checks-ui-e2e=${{ needs.checks-ui-e2e.result }}|${{ needs.preflight.outputs.run_ui_tests == 'true' && needs.preflight.outputs.compatibility_target != 'true' }}
-            checks-ui-e2e-real-gateway=${{ needs.checks-ui-e2e-real-gateway.result }}|${{ needs.preflight.outputs.run_ui_tests == 'true' && needs.preflight.outputs.compatibility_target != 'true' }}
-            control-ui-i18n=${{ needs.control-ui-i18n.result }}|${{ needs.preflight.outputs.run_control_ui_i18n }}
-            checks-fast-core=${{ needs.checks-fast-core.result }}|${{ needs.preflight.outputs.run_checks_fast_core }}
-            qa-smoke-ci-profile=${{ needs.qa-smoke-ci-profile.result }}|${{ needs.preflight.outputs.run_qa_smoke_ci }}
-            checks-fast-plugin-contracts-shard=${{ needs.checks-fast-plugin-contracts-shard.result }}|${{ needs.preflight.outputs.run_plugin_contracts_shards }}
-            checks-fast-channel-contracts-shard=${{ needs.checks-fast-channel-contracts-shard.result }}|${{ needs.preflight.outputs.run_channel_contracts_shards }}
-            checks-node-compat=${{ needs.checks-node-compat.result }}|${{ needs.preflight.outputs.run_build_artifacts == 'true' && github.event_name == 'workflow_dispatch' }}
-            checks-node-core-test-nondist-shard=${{ needs.checks-node-core-test-nondist-shard.result }}|${{ needs.preflight.outputs.run_checks_node_core_nondist }}
-            check-shard=${{ needs.check-shard.result }}|${{ needs.preflight.outputs.run_check }}
-            check-lint-hosted-core-shard=${{ needs.check-lint-hosted-core-shard.result }}|${{ needs.preflight.outputs.run_check == 'true' && (needs.preflight.outputs.runner_profile == 'github' || needs.preflight.outputs.runner_profile == 'hybrid') && (needs.preflight.outputs.frozen_target != 'true' || needs.preflight.outputs.hosted_runner_profile_contract == 'true') }}
-            check-test-types-hosted-core-shard=${{ needs.check-test-types-hosted-core-shard.result }}|${{ needs.preflight.outputs.run_check == 'true' && (needs.preflight.outputs.runner_profile == 'github' || needs.preflight.outputs.runner_profile == 'hybrid') && (needs.preflight.outputs.frozen_target != 'true' || needs.preflight.outputs.hosted_runner_profile_contract == 'true') }}
-            check-additional-shard=${{ needs.check-additional-shard.result }}|${{ needs.preflight.outputs.run_check_additional }}
-            check-docs=${{ needs.check-docs.result }}|${{ needs.preflight.outputs.run_check_docs }}
-            skills-python=${{ needs.skills-python.result }}|${{ needs.preflight.outputs.run_skills_python_job }}
-            checks-windows=${{ needs.checks-windows.result }}|${{ needs.preflight.outputs.run_checks_windows }}
-            macos-node=${{ needs.macos-node.result }}|${{ needs.preflight.outputs.run_macos_node }}
-            macos-swift=${{ needs.macos-swift.result }}|${{ needs.preflight.outputs.run_macos_swift }}
-            ios-build=${{ needs.ios-build.result }}|${{ needs.preflight.outputs.run_ios_build }}
-            ios-screenshot-shard=${{ needs.ios-screenshot-shard.result }}|${{ needs.preflight.outputs.release_scope == 'full' && ((github.event_name == 'workflow_dispatch' && (!inputs.release_gate || needs.preflight.outputs.run_ios_screenshots == 'true')) || (github.event_name == 'pull_request' && needs.preflight.outputs.run_ios_screenshots == 'true')) && needs.preflight.outputs.compatibility_target != 'true' }}
-            ios-screenshot-evidence=${{ needs.ios-screenshot-evidence.result }}|${{ needs.preflight.outputs.release_scope == 'full' && ((github.event_name == 'workflow_dispatch' && (!inputs.release_gate || needs.preflight.outputs.run_ios_screenshots == 'true')) || (github.event_name == 'pull_request' && needs.preflight.outputs.run_ios_screenshots == 'true')) && needs.preflight.outputs.compatibility_target != 'true' }}
-            android=${{ needs.android.result }}|${{ needs.preflight.outputs.run_android_job }}
-            docker-seed-e2e=${{ needs.docker-seed-e2e.result }}|${{ needs.preflight.outputs.run_docker_seed_e2e }}
+          REQUIRED_RESULTS: |
+            preflight=${{ needs.preflight.result }}
+            security-fast=${{ needs.security-fast.result }}
+          SELECTED_RESULTS: |
+            pnpm-store-warmup=${{ needs.pnpm-store-warmup.result }}
+            build-artifacts=${{ needs.build-artifacts.result }}
+            native-i18n=${{ needs.native-i18n.result }}
+            checks-ui=${{ needs.checks-ui.result }}
+            checks-ui-e2e=${{ needs.checks-ui-e2e.result }}
+            checks-ui-e2e-real-gateway=${{ needs.checks-ui-e2e-real-gateway.result }}
+            control-ui-i18n=${{ needs.control-ui-i18n.result }}
+            checks-fast-core=${{ needs.checks-fast-core.result }}
+            qa-smoke-ci-profile=${{ needs.qa-smoke-ci-profile.result }}
+            checks-fast-plugin-contracts-shard=${{ needs.checks-fast-plugin-contracts-shard.result }}
+            checks-fast-channel-contracts-shard=${{ needs.checks-fast-channel-contracts-shard.result }}
+            checks-node-compat=${{ needs.checks-node-compat.result }}
+            checks-node-core-test-nondist-shard=${{ needs.checks-node-core-test-nondist-shard.result }}
+            check-shard=${{ needs.check-shard.result }}
+            check-lint-hosted-core-shard=${{ needs.check-lint-hosted-core-shard.result }}
+            check-test-types-hosted-core-shard=${{ needs.check-test-types-hosted-core-shard.result }}
+            check-additional-shard=${{ needs.check-additional-shard.result }}
+            check-docs=${{ needs.check-docs.result }}
+            skills-python=${{ needs.skills-python.result }}
+            checks-windows=${{ needs.checks-windows.result }}
+            macos-node=${{ needs.macos-node.result }}
+            macos-swift=${{ needs.macos-swift.result }}
+            ios-build=${{ needs.ios-build.result }}
+            ios-screenshot-shard=${{ needs.ios-screenshot-shard.result }}
+            ios-screenshot-evidence=${{ needs.ios-screenshot-evidence.result }}
+            android=${{ needs.android.result }}
+            docker-seed-e2e=${{ needs.docker-seed-e2e.result }}
         run: |
           set -euo pipefail
 
-          # Preserve raw fields: IFS splitting can erase malformed trailing
-          # delimiters and turn invalid results or selection into accepted values.
           failures=0
           while IFS= read -r entry; do
             [[ -n "$entry" ]] || continue
             name="${entry%%=*}"
             result="${entry#*=}"
-            selected="${result#*|}"
-            result="${result%%|*}"
-            echo "${name}: ${result} (selected=${selected:-missing})"
-            case "$selected:$result" in
-              true:success | false:success | false:skipped) ;;
+            echo "${name}: ${result}"
+            if [[ "$result" != "success" ]]; then
+              echo "::error title=Required CI job did not succeed::${name} finished with ${result}"
+              failures=1
+            fi
+          done <<< "$REQUIRED_RESULTS"
+
+          while IFS= read -r entry; do
+            [[ -n "$entry" ]] || continue
+            name="${entry%%=*}"
+            result="${entry#*=}"
+            echo "${name}: ${result}"
+            case "$result" in
+              success | skipped) ;;
               *)
-                echo "::error title=CI job did not succeed::${name} finished with ${result} (selected=${selected:-missing})"
+                echo "::error title=Selected CI job did not succeed::${name} finished with ${result}"
                 failures=1
                 ;;
             esac
-          done <<< "$JOB_RESULTS"
+          done <<< "$SELECTED_RESULTS"
 
           exit "$failures"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,11 +19,11 @@ on:
         default: false
         type: boolean
       release_scope:
-        description: Release qualification scope; npm-beta defers native apps for a validated exact beta target.
+        description: Release qualification scope; npm-beta and npm-stable defer native apps for a validated exact release target.
         required: false
         default: full
         type: choice
-        options: [full, npm-beta]
+        options: [full, npm-beta, npm-stable]
       release_gate:
         description: Run an exact-SHA maintainer release-gate fallback when PR CI is capacity-stalled.
         required: false
@@ -582,7 +582,10 @@ jobs:
               if sha == os.environ["WORKFLOW_SHA"]:
                   # Export the workflow revision from the freshly populated index, replacing
                   # retained platform files without updating the index or trusting later edits.
-                  paths = git_output(workspace, "ls-files", "-z", "--", ".github/actions").split("\0")[:-1]
+                  pathspecs = [".github/actions"]
+                  if kind == "preflight":
+                      pathspecs += ["scripts/lib/release-context.mjs", "scripts/lib/release-version.mjs"]
+                  paths = git_output(workspace, "ls-files", "-z", "--", *pathspecs).split("\0")[:-1]
                   run_git(workspace, "checkout-index", "--force", f"--prefix={harness}/", "--", *paths)
               else:
                   run_git(harness, "init", harness)
@@ -737,7 +740,11 @@ jobs:
         with:
           ref: ${{ github.workflow_sha }}
           path: .ci-harness
-          sparse-checkout: .github/actions
+          sparse-checkout: |
+            /.github/actions/
+            /scripts/lib/release-context.mjs
+            /scripts/lib/release-version.mjs
+          sparse-checkout-cone-mode: false
           persist-credentials: false
 
       - name: Resolve logical runner profile
@@ -1058,9 +1065,12 @@ jobs:
             manifest_node_args+=(--import tsx)
           fi
           node "${manifest_node_args[@]}" --input-type=module <<'EOF'
+          import { execFileSync } from "node:child_process";
           import { appendFileSync, existsSync, readFileSync } from "node:fs";
           import { matchesGlob } from "node:path";
           import { resolveTestGitCommits } from "./.ci-harness/.github/actions/git-owner/test-prerequisites.mjs";
+          import { resolveReleaseContextIdentity } from "./.ci-harness/scripts/lib/release-context.mjs";
+          import { classifyReleaseTrain, parseReleaseVersion } from "./.ci-harness/scripts/lib/release-version.mjs";
 
           const eventName = process.env.OPENCLAW_CI_EVENT_NAME ?? "";
           const checkoutRevision = process.env.OPENCLAW_CI_CHECKOUT_REVISION ?? "";
@@ -1174,27 +1184,50 @@ jobs:
           const docsChanged = parseBoolean(process.env.OPENCLAW_CI_DOCS_CHANGED);
           const releaseGate = parseBoolean(process.env.OPENCLAW_CI_RELEASE_GATE);
           const releaseScope = process.env.OPENCLAW_CI_RELEASE_SCOPE ?? "full";
-          const npmBetaQualification = releaseScope === "npm-beta";
-          if (releaseScope !== "full" && !npmBetaQualification) {
-            throw new Error("release_scope must be full or npm-beta");
+          const npmQualification = releaseScope === "npm-beta" || releaseScope === "npm-stable";
+          if (releaseScope !== "full" && !npmQualification) {
+            throw new Error("release_scope must be full, npm-beta, or npm-stable");
           }
-          if (npmBetaQualification) {
-            const betaVersion = String(packageJson.version ?? "").match(
-              /^([0-9]{4}\.(?:[1-9]|1[0-2])\.[1-9][0-9]*)-beta\.[1-9][0-9]*$/u,
-            );
-            const betaContext = betaVersion && (
-              (process.env.OPENCLAW_CI_TARGET_CONTEXT_TARGET === "true" &&
-                process.env.OPENCLAW_CI_TARGET_CONTEXT_REF === `release/${betaVersion[1]}`) ||
-              (historicalTargetApproved &&
-                process.env.OPENCLAW_CI_HISTORICAL_TARGET_TAG === `v${packageJson.version}`)
-            );
+          if (npmQualification) {
+            const packageVersion = String(packageJson.version ?? "");
+            const parsedVersion = parseReleaseVersion(packageVersion);
+            const expectedTrain = releaseScope === "npm-beta" ? "beta" : "stable";
+            const contextRef = process.env.OPENCLAW_CI_TARGET_CONTEXT_TARGET === "true"
+              ? process.env.OPENCLAW_CI_TARGET_CONTEXT_REF
+              : historicalTargetApproved ? process.env.OPENCLAW_CI_HISTORICAL_TARGET_TAG : "";
             if (
               eventName !== "workflow_dispatch" || !isCanonicalRepository || releaseGate ||
               process.env.OPENCLAW_CI_PULL_REQUEST_NUMBER ||
               !/^[0-9a-f]{40}$/u.test(process.env.OPENCLAW_CI_TARGET_REF ?? "") ||
-              process.env.OPENCLAW_CI_TARGET_REF !== checkoutRevision || !betaContext
+              process.env.OPENCLAW_CI_TARGET_REF !== checkoutRevision ||
+              !parsedVersion || parsedVersion.version !== packageVersion ||
+              classifyReleaseTrain(parsedVersion) !== expectedTrain
             ) {
-              throw new Error("release_scope npm-beta requires an exact beta target with validated matching release context and no PR release gate or pull_request_number");
+              throw new Error(`release_scope ${releaseScope} requires an exact ${expectedTrain} target with validated matching release context and no PR release gate or pull_request_number`);
+            }
+            let identity;
+            try {
+              identity = resolveReleaseContextIdentity(contextRef ?? "", packageVersion);
+            } catch (error) {
+              throw new Error(`release_scope ${releaseScope}: ${error.message}`);
+            }
+            if (!identity || identity.kind === "extended-stable branch") {
+              throw new Error(`release_scope ${releaseScope} requires a matching regular release branch or tag`);
+            }
+            if (identity.baseTag) {
+              // Base-package corrections reuse the base tag's exact source; ancestry alone is insufficient.
+              const baseRef = `refs/tags/${identity.baseTag}`;
+              const remoteRefs = execFileSync("python3", [
+                "-I", "-S", `${process.env.RUNNER_TEMP}/ci-git-owner.py`, "--git", "120",
+                "ls-remote", "--tags", "https://github.com/openclaw/openclaw.git", baseRef, `${baseRef}^{}`,
+              ], { encoding: "utf8" });
+              const refs = new Map(remoteRefs.trim().split("\n").filter(Boolean).map((line) => {
+                const [sha, ref] = line.split(/\s+/u);
+                return [ref, sha];
+              }));
+              if (!refs.has(baseRef) || (refs.get(`${baseRef}^{}`) ?? refs.get(baseRef)) !== checkoutRevision) {
+                throw new Error(`release_scope ${releaseScope} correction base ${identity.baseTag} does not resolve to ${checkoutRevision}`);
+              }
             }
           }
           const runNode = parseBoolean(process.env.OPENCLAW_CI_RUN_NODE) && !docsOnly;
@@ -1219,14 +1252,14 @@ jobs:
           const supportsCurrentIosCi = supportsIosBuild && supportsCurrentMacosSwiftCi;
           const runIosBuild =
             parseBoolean(process.env.OPENCLAW_CI_RUN_IOS_BUILD) &&
-            !npmBetaQualification &&
+            !npmQualification &&
             !docsOnly &&
             isCanonicalRepository &&
             (!frozenTarget ||
               supportsCurrentIosCi ||
               (releaseCandidateTarget && supportsIosBuild));
           const runAndroid =
-            parseBoolean(process.env.OPENCLAW_CI_RUN_ANDROID) && !npmBetaQualification &&
+            parseBoolean(process.env.OPENCLAW_CI_RUN_ANDROID) && !npmQualification &&
             !docsOnly && isCanonicalRepository;
           const runWindows =
             parseBoolean(process.env.OPENCLAW_CI_RUN_WINDOWS) &&
@@ -1255,7 +1288,7 @@ jobs:
             hasPackageScript("apple:i18n:check");
           const runNativeI18n =
             parseBoolean(process.env.OPENCLAW_CI_RUN_NATIVE_I18N) &&
-            !npmBetaQualification &&
+            !npmQualification &&
             !docsOnly &&
             (!frozenTarget || supportsNativeI18n);
           const targetWorkflow = existsSync(".github/workflows/ci.yml")
@@ -1568,9 +1601,9 @@ jobs:
                 : [],
             ),
             run_macos_swift:
-              runMacos && !npmBetaQualification &&
+              runMacos && !npmQualification &&
               (!frozenTarget || compatibilityTarget || supportsCurrentMacosSwiftCi),
-            run_openclawkit_tests: runMacos && !npmBetaQualification && supportsOpenClawKitTests,
+            run_openclawkit_tests: runMacos && !npmQualification && supportsOpenClawKitTests,
             run_ios_build: runIosBuild,
             run_android_job: runAndroid,
             use_compatible_android_ci: useCompatibleAndroidCi,
@@ -1613,7 +1646,7 @@ jobs:
           if (process.env.GITHUB_STEP_SUMMARY) {
             appendFileSync(process.env.GITHUB_STEP_SUMMARY,
               `### CI release qualification\n\n- Scope: \`${releaseScope}\`\n- Target: \`${checkoutRevision}\`\n` +
-              (npmBetaQualification ? "- Native app qualification: deferred; Linux, macOS, and Windows Node coverage retained.\n" : ""));
+              (npmQualification ? "- Native app qualification: deferred; Linux, macOS, and Windows Node coverage retained.\n" : ""));
           }
           EOF
 
@@ -1653,11 +1686,27 @@ jobs:
     env:
       PRE_COMMIT_HOME: .cache/pre-commit-security-fast
     steps:
+      - name: Resolve security checkout depth
+        if: github.event_name == 'pull_request'
+        id: checkout_depth
+        env:
+          PR_COMMIT_COUNT: ${{ github.event.pull_request.commits }}
+        run: |
+          set -euo pipefail
+          if ! [[ "$PR_COMMIT_COUNT" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid pull request commit count: $PR_COMMIT_COUNT"
+            exit 2
+          fi
+          # Fetch the merge, every PR commit, and one ancestor while checkout
+          # still owns authentication; scanners run after credential cleanup.
+          fetch_depth=$((PR_COMMIT_COUNT + 2))
+          echo "depth=$fetch_depth" >> "$GITHUB_OUTPUT"
+
       - name: Checkout
         if: github.event_name != 'workflow_dispatch' || inputs.target_ref == ''
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 2
+          fetch-depth: ${{ steps.checkout_depth.outputs.depth || 2 }}
           persist-credentials: false
 
       # Manual target validation has a distinct fallback contract: a missing branch/tag
@@ -1721,24 +1770,6 @@ jobs:
           base-sha: ${{ steps.diff_base.outputs.sha }}
           fetch-ref: ${{ github.event_name == 'push' && github.ref_name || github.event.pull_request.base.ref }}
 
-      - name: Fetch pull request scan history
-        if: github.event_name == 'pull_request'
-        env:
-          PR_COMMIT_COUNT: ${{ github.event.pull_request.commits }}
-          PR_MERGE_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          if ! [[ "$PR_COMMIT_COUNT" =~ ^[0-9]+$ ]]; then
-            echo "::error::Invalid pull request commit count: $PR_COMMIT_COUNT"
-            exit 2
-          fi
-          # Include the synthetic merge, every pull request commit, and one
-          # ancestor so TruffleHog can clone and resolve the bounded range.
-          fetch_depth=$((PR_COMMIT_COUNT + 2))
-          python3 -I -S "$RUNNER_TEMP/ci-git-owner.py" --checkout-git 120 \
-            -c protocol.version=2 \
-            fetch --no-tags --no-recurse-submodules --depth="$fetch_depth" origin "$PR_MERGE_SHA"
-
       - name: Scan pull request for leaked credentials
         if: github.event_name == 'pull_request'
         uses: trufflesecurity/trufflehog@bcfcf73aaf4759d4dadc2783177c245a02792318 # v3.97.0
@@ -1785,13 +1816,6 @@ jobs:
         run: python3 -m pip install --disable-pip-version-check pre-commit==4.6.2
 
       - name: Detect committed private keys
-        env:
-          # pre-commit clones its pinned hook repos over anonymous HTTPS, which the
-          # runners intermittently reject ("could not read Username"). Route those
-          # read-only fetches through the job token without writing a git config.
-          GIT_CONFIG_COUNT: "1"
-          GIT_CONFIG_KEY_0: url.https://x-access-token:${{ github.token }}@github.com/.insteadOf
-          GIT_CONFIG_VALUE_0: https://github.com/
         run: pre-commit run --config "${PRE_COMMIT_CONFIG_PATH:-.pre-commit-config.yaml}" --all-files detect-private-key
 
       - name: Audit changed GitHub workflows with zizmor
@@ -4504,10 +4528,18 @@ jobs:
   ios-build:
     permissions:
       contents: read
-    name: "ios-build"
+    name: ${{ format('ios-build ({0})', matrix.phase) }}
     needs: [preflight]
     if: needs.preflight.outputs.run_ios_build == 'true'
-    runs-on: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' && 'macos-26' || (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'macos-26' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)) && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
+    # Release device products are not inputs to the simulator test graph.
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix:
+        phase: ${{ fromJSON(needs.preflight.outputs.compatibility_target == 'true' && '["tests"]' || '["release","tests"]') }}
+    # Blacksmith macOS 26 admission stalled while hosted retries completed.
+    # Start both phases on the verified hosted image instead of waiting to retry.
+    runs-on: macos-26
     timeout-minutes: 150
     env:
       HISTORICAL_TARGET: ${{ needs.preflight.outputs.compatibility_target }}
@@ -4594,6 +4626,7 @@ jobs:
           fi
 
       - name: Swift lint
+        if: matrix.phase == 'tests'
         run: |
           if [[ -x ./scripts/lint-swift.sh && -x ./scripts/format-swift.sh ]]; then
             ./scripts/lint-swift.sh ios
@@ -4604,13 +4637,19 @@ jobs:
           fi
 
       - name: Build iOS app
+        if: matrix.phase == 'tests'
         run: pnpm ios:build
 
       # Debug's incremental compilation can miss actor-isolation diagnostics
       # that Swift's optimized whole-module Release build enforces.
       - name: Build iOS app (Release)
-        if: env.HISTORICAL_TARGET != 'true'
+        if: matrix.phase == 'release'
         run: |
+          set -euo pipefail
+          ./scripts/ios-configure-signing.sh
+          ./scripts/ios-write-version-xcconfig.sh
+          node scripts/ios-write-swift-filelist.mjs
+          xcodegen generate --spec apps/ios/project.yml --project apps/ios
           xcodebuild \
             -project apps/ios/OpenClaw.xcodeproj \
             -scheme OpenClaw \
@@ -4623,7 +4662,7 @@ jobs:
       # lifecycles. Exercise both owners on the already provisioned simulator.
       - name: Run focused iOS lifecycle simulator tests
         id: ios_lifecycle_tests
-        if: env.HISTORICAL_TARGET != 'true'
+        if: matrix.phase == 'tests' && needs.preflight.outputs.compatibility_target != 'true'
         run: |
           set -euo pipefail
           simulator_id="$(
@@ -4660,7 +4699,7 @@ jobs:
             test
 
       - name: Run focused Apple Watch operation simulator tests
-        if: env.HISTORICAL_TARGET != 'true'
+        if: matrix.phase == 'tests' && needs.preflight.outputs.compatibility_target != 'true'
         run: |
           set -euo pipefail
           simulator_id="$(
@@ -4734,8 +4773,9 @@ jobs:
     needs: [preflight]
     # Full manual/release validation always captures. PRs and their exact-head
     # release-gate substitutes use the same conservative screenshot-risk scope.
-    if: ${{ needs.preflight.outputs.release_scope != 'npm-beta' && ((github.event_name == 'workflow_dispatch' && (!inputs.release_gate || needs.preflight.outputs.run_ios_screenshots == 'true')) || (github.event_name == 'pull_request' && needs.preflight.outputs.run_ios_screenshots == 'true')) && needs.preflight.outputs.compatibility_target != 'true' }}
-    runs-on: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND == 'github' && 'macos-26' || (github.event_name == 'workflow_dispatch' || github.run_attempt > 1) && 'macos-26' || (github.repository == 'openclaw/openclaw' && (github.event_name != 'pull_request' || contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association)) && 'blacksmith-12vcpu-macos-26' || 'macos-26') }}
+    if: ${{ needs.preflight.outputs.release_scope == 'full' && ((github.event_name == 'workflow_dispatch' && (!inputs.release_gate || needs.preflight.outputs.run_ios_screenshots == 'true')) || (github.event_name == 'pull_request' && needs.preflight.outputs.run_ios_screenshots == 'true')) && needs.preflight.outputs.compatibility_target != 'true' }}
+    # Keep capture on the same verified hosted image as the iOS build phases.
+    runs-on: macos-26
     timeout-minutes: 90
     env:
       BUNDLE_DEPLOYMENT: "true"
@@ -4806,7 +4846,7 @@ jobs:
 
       - name: Capture Apple Watch screenshot
         id: watch_screenshot
-        if: matrix.device_family == 'iphone'
+        if: matrix.device_family == 'ipad-13'
         run: |
           source scripts/lib/ios-fastlane.sh
           (
@@ -4845,7 +4885,7 @@ jobs:
             --node-version "$(node --version)"
           )
           node scripts/ios-screenshot-evidence.mjs "${collect_args[@]}"
-          if [[ "$DEVICE_FAMILY" == "iphone" ]]; then
+          if [[ "$DEVICE_FAMILY" == "ipad-13" ]]; then
             collect_args[2]="watch"
             node scripts/ios-screenshot-evidence.mjs "${collect_args[@]}"
           fi
@@ -4875,7 +4915,7 @@ jobs:
       contents: read
     name: "ios-screenshot-evidence"
     needs: [preflight, ios-screenshot-shard]
-    if: ${{ needs.preflight.outputs.release_scope != 'npm-beta' && ((github.event_name == 'workflow_dispatch' && (!inputs.release_gate || needs.preflight.outputs.run_ios_screenshots == 'true')) || (github.event_name == 'pull_request' && needs.preflight.outputs.run_ios_screenshots == 'true')) && needs.preflight.outputs.compatibility_target != 'true' }}
+    if: ${{ needs.preflight.outputs.release_scope == 'full' && ((github.event_name == 'workflow_dispatch' && (!inputs.release_gate || needs.preflight.outputs.run_ios_screenshots == 'true')) || (github.event_name == 'pull_request' && needs.preflight.outputs.run_ios_screenshots == 'true')) && needs.preflight.outputs.compatibility_target != 'true' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -5225,64 +5265,56 @@ jobs:
       - name: Verify selected CI lanes
         shell: bash
         env:
-          REQUIRED_RESULTS: |
-            preflight=${{ needs.preflight.result }}
-            security-fast=${{ needs.security-fast.result }}
-          SELECTED_RESULTS: |
-            pnpm-store-warmup=${{ needs.pnpm-store-warmup.result }}
-            build-artifacts=${{ needs.build-artifacts.result }}
-            native-i18n=${{ needs.native-i18n.result }}
-            checks-ui=${{ needs.checks-ui.result }}
-            checks-ui-e2e=${{ needs.checks-ui-e2e.result }}
-            checks-ui-e2e-real-gateway=${{ needs.checks-ui-e2e-real-gateway.result }}
-            control-ui-i18n=${{ needs.control-ui-i18n.result }}
-            checks-fast-core=${{ needs.checks-fast-core.result }}
-            qa-smoke-ci-profile=${{ needs.qa-smoke-ci-profile.result }}
-            checks-fast-plugin-contracts-shard=${{ needs.checks-fast-plugin-contracts-shard.result }}
-            checks-fast-channel-contracts-shard=${{ needs.checks-fast-channel-contracts-shard.result }}
-            checks-node-compat=${{ needs.checks-node-compat.result }}
-            checks-node-core-test-nondist-shard=${{ needs.checks-node-core-test-nondist-shard.result }}
-            check-shard=${{ needs.check-shard.result }}
-            check-lint-hosted-core-shard=${{ needs.check-lint-hosted-core-shard.result }}
-            check-test-types-hosted-core-shard=${{ needs.check-test-types-hosted-core-shard.result }}
-            check-additional-shard=${{ needs.check-additional-shard.result }}
-            check-docs=${{ needs.check-docs.result }}
-            skills-python=${{ needs.skills-python.result }}
-            checks-windows=${{ needs.checks-windows.result }}
-            macos-node=${{ needs.macos-node.result }}
-            macos-swift=${{ needs.macos-swift.result }}
-            ios-build=${{ needs.ios-build.result }}
-            ios-screenshot-shard=${{ needs.ios-screenshot-shard.result }}
-            ios-screenshot-evidence=${{ needs.ios-screenshot-evidence.result }}
-            android=${{ needs.android.result }}
-            docker-seed-e2e=${{ needs.docker-seed-e2e.result }}
+          JOB_RESULTS: |
+            preflight=${{ needs.preflight.result }}|true
+            security-fast=${{ needs.security-fast.result }}|true
+            pnpm-store-warmup=${{ needs.pnpm-store-warmup.result }}|${{ (needs.preflight.outputs.run_node == 'true' || needs.preflight.outputs.run_check_docs == 'true') && (needs.preflight.outputs.runner_profile == 'github' || needs.preflight.outputs.runner_profile == 'hybrid' || (!(github.repository == 'openclaw/openclaw' && github.event_name == 'push' && github.ref == 'refs/heads/main') && !(github.repository == 'openclaw/openclaw' && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && needs.preflight.outputs.run_node == 'true'))) }}
+            build-artifacts=${{ needs.build-artifacts.result }}|${{ needs.preflight.outputs.run_build_artifacts }}
+            native-i18n=${{ needs.native-i18n.result }}|${{ needs.preflight.outputs.run_native_i18n }}
+            checks-ui=${{ needs.checks-ui.result }}|${{ needs.preflight.outputs.run_ui_tests }}
+            checks-ui-e2e=${{ needs.checks-ui-e2e.result }}|${{ needs.preflight.outputs.run_ui_tests == 'true' && needs.preflight.outputs.compatibility_target != 'true' }}
+            checks-ui-e2e-real-gateway=${{ needs.checks-ui-e2e-real-gateway.result }}|${{ needs.preflight.outputs.run_ui_tests == 'true' && needs.preflight.outputs.compatibility_target != 'true' }}
+            control-ui-i18n=${{ needs.control-ui-i18n.result }}|${{ needs.preflight.outputs.run_control_ui_i18n }}
+            checks-fast-core=${{ needs.checks-fast-core.result }}|${{ needs.preflight.outputs.run_checks_fast_core }}
+            qa-smoke-ci-profile=${{ needs.qa-smoke-ci-profile.result }}|${{ needs.preflight.outputs.run_qa_smoke_ci }}
+            checks-fast-plugin-contracts-shard=${{ needs.checks-fast-plugin-contracts-shard.result }}|${{ needs.preflight.outputs.run_plugin_contracts_shards }}
+            checks-fast-channel-contracts-shard=${{ needs.checks-fast-channel-contracts-shard.result }}|${{ needs.preflight.outputs.run_channel_contracts_shards }}
+            checks-node-compat=${{ needs.checks-node-compat.result }}|${{ needs.preflight.outputs.run_build_artifacts == 'true' && github.event_name == 'workflow_dispatch' }}
+            checks-node-core-test-nondist-shard=${{ needs.checks-node-core-test-nondist-shard.result }}|${{ needs.preflight.outputs.run_checks_node_core_nondist }}
+            check-shard=${{ needs.check-shard.result }}|${{ needs.preflight.outputs.run_check }}
+            check-lint-hosted-core-shard=${{ needs.check-lint-hosted-core-shard.result }}|${{ needs.preflight.outputs.run_check == 'true' && (needs.preflight.outputs.runner_profile == 'github' || needs.preflight.outputs.runner_profile == 'hybrid') && (needs.preflight.outputs.frozen_target != 'true' || needs.preflight.outputs.hosted_runner_profile_contract == 'true') }}
+            check-test-types-hosted-core-shard=${{ needs.check-test-types-hosted-core-shard.result }}|${{ needs.preflight.outputs.run_check == 'true' && (needs.preflight.outputs.runner_profile == 'github' || needs.preflight.outputs.runner_profile == 'hybrid') && (needs.preflight.outputs.frozen_target != 'true' || needs.preflight.outputs.hosted_runner_profile_contract == 'true') }}
+            check-additional-shard=${{ needs.check-additional-shard.result }}|${{ needs.preflight.outputs.run_check_additional }}
+            check-docs=${{ needs.check-docs.result }}|${{ needs.preflight.outputs.run_check_docs }}
+            skills-python=${{ needs.skills-python.result }}|${{ needs.preflight.outputs.run_skills_python_job }}
+            checks-windows=${{ needs.checks-windows.result }}|${{ needs.preflight.outputs.run_checks_windows }}
+            macos-node=${{ needs.macos-node.result }}|${{ needs.preflight.outputs.run_macos_node }}
+            macos-swift=${{ needs.macos-swift.result }}|${{ needs.preflight.outputs.run_macos_swift }}
+            ios-build=${{ needs.ios-build.result }}|${{ needs.preflight.outputs.run_ios_build }}
+            ios-screenshot-shard=${{ needs.ios-screenshot-shard.result }}|${{ needs.preflight.outputs.release_scope == 'full' && ((github.event_name == 'workflow_dispatch' && (!inputs.release_gate || needs.preflight.outputs.run_ios_screenshots == 'true')) || (github.event_name == 'pull_request' && needs.preflight.outputs.run_ios_screenshots == 'true')) && needs.preflight.outputs.compatibility_target != 'true' }}
+            ios-screenshot-evidence=${{ needs.ios-screenshot-evidence.result }}|${{ needs.preflight.outputs.release_scope == 'full' && ((github.event_name == 'workflow_dispatch' && (!inputs.release_gate || needs.preflight.outputs.run_ios_screenshots == 'true')) || (github.event_name == 'pull_request' && needs.preflight.outputs.run_ios_screenshots == 'true')) && needs.preflight.outputs.compatibility_target != 'true' }}
+            android=${{ needs.android.result }}|${{ needs.preflight.outputs.run_android_job }}
+            docker-seed-e2e=${{ needs.docker-seed-e2e.result }}|${{ needs.preflight.outputs.run_docker_seed_e2e }}
         run: |
           set -euo pipefail
 
+          # Preserve raw fields: IFS splitting can erase malformed trailing
+          # delimiters and turn invalid results or selection into accepted values.
           failures=0
           while IFS= read -r entry; do
             [[ -n "$entry" ]] || continue
             name="${entry%%=*}"
             result="${entry#*=}"
-            echo "${name}: ${result}"
-            if [[ "$result" != "success" ]]; then
-              echo "::error title=Required CI job did not succeed::${name} finished with ${result}"
-              failures=1
-            fi
-          done <<< "$REQUIRED_RESULTS"
-
-          while IFS= read -r entry; do
-            [[ -n "$entry" ]] || continue
-            name="${entry%%=*}"
-            result="${entry#*=}"
-            echo "${name}: ${result}"
-            case "$result" in
-              success | skipped) ;;
+            selected="${result#*|}"
+            result="${result%%|*}"
+            echo "${name}: ${result} (selected=${selected:-missing})"
+            case "$selected:$result" in
+              true:success | false:success | false:skipped) ;;
               *)
-                echo "::error title=Selected CI job did not succeed::${name} finished with ${result}"
+                echo "::error title=CI job did not succeed::${name} finished with ${result} (selected=${selected:-missing})"
                 failures=1
                 ;;
             esac
-          done <<< "$SELECTED_RESULTS"
+          done <<< "$JOB_RESULTS"
 
           exit "$failures"

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewayProtocol.kt
@@ -894,6 +894,7 @@ enum class GatewayMethod(
   SessionsGithubOptions("sessions.github.options"),
   SessionsGithubStatus("sessions.github.status"),
   SessionsGithubConfirm("sessions.github.confirm"),
+  SessionsTitlePrepare("sessions.title.prepare"),
 }
 
 enum class GatewayEvent(

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -9768,6 +9768,46 @@ public struct SessionsCreateResult: Codable, Sendable {
     }
 }
 
+public struct SessionsTitlePrepareParams: Codable, Sendable {
+    public let agentid: String
+    public let message: String
+    public let model: String?
+    public let catalogid: String?
+    public let incognito: Bool?
+
+    public init(
+        agentid: String,
+        message: String,
+        model: String? = nil,
+        catalogid: String? = nil,
+        incognito: Bool? = nil)
+    {
+        self.agentid = agentid
+        self.message = message
+        self.model = model
+        self.catalogid = catalogid
+        self.incognito = incognito
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case agentid = "agentId"
+        case message
+        case model
+        case catalogid = "catalogId"
+        case incognito
+    }
+}
+
+public struct SessionsTitlePrepareResult: Codable, Sendable {
+    public let title: AnyCodable
+
+    public init(
+        title: AnyCodable)
+    {
+        self.title = title
+    }
+}
+
 public struct SessionsRecoverParams: Codable, Sendable {
     public let key: String
     public let agentid: String?

--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -9597,6 +9597,7 @@ public struct SessionsCreateParams: Codable, Sendable {
     public let idempotencykey: String?
     public let agentid: String?
     public let label: String?
+    public let displayname: String?
     public let category: String?
     public let model: String?
     public let contextwindow: String?
@@ -9629,6 +9630,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         idempotencykey: String? = nil,
         agentid: String? = nil,
         label: String? = nil,
+        displayname: String? = nil,
         category: String? = nil,
         model: String? = nil,
         contextwindow: String? = nil,
@@ -9660,6 +9662,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         self.idempotencykey = idempotencykey
         self.agentid = agentid
         self.label = label
+        self.displayname = displayname
         self.category = category
         self.model = model
         self.contextwindow = contextwindow
@@ -9693,6 +9696,7 @@ public struct SessionsCreateParams: Codable, Sendable {
         case idempotencykey = "idempotencyKey"
         case agentid = "agentId"
         case label
+        case displayname = "displayName"
         case category
         case model
         case contextwindow = "contextWindow"

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -706,6 +706,7 @@ methods. Treat this as feature discovery, not a full enumeration of
     - `chat.send`, `sessions.send`, and initial-turn `sessions.create` acknowledgments report admission separately from transcript persistence. Optional `messageSeq` is the one-based position from an actual committed user-turn receipt; it is absent while the input exists only in pending custody. `status: "started"` and `runStarted: true` alone do not establish a transcript row. Reconcile provisional input by its submission identity against accepted custody or canonical transcript identity, never a predicted position or matching content.
 
     - `sessions.create.fastMode` accepts `true`, `false`, or `"auto"` and persists that speed override before the initial turn starts.
+    - `sessions.title.prepare` (`{ agentId, message, model?, catalogId?, incognito? }`, `operator.write`, rate-limited as a control-plane write) returns `{ title }` from the selected agent's utility model only, without creating or renaming a session; it returns `title: null` for incognito, empty, slash-command, or unavailable-utility input and never falls back to the primary model. A client passes a ready result as `sessions.create.displayName`: a presentation title stored like a generated first-message title, so it is not unique, never claims `label`, and is ignored when adopting an existing key.
 
   </Accordion>
 

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -44,6 +44,23 @@ When you run several Gateways, set `gateway.controlUi.environment` to distinguis
 
 The environment adds a 2 px top stripe, an agent-avatar ring, label pills in the sidebar and narrow topbar, a browser-title suffix, and a matching favicon. The label is trimmed and must contain 1–24 characters. Available colors are `teal`, `amber`, `purple`, `coral`, `pink`, `blue`, `green`, `red`, and `gray`. The label and color are intentionally visible before sign-in; leave `environment` unset to keep the standard appearance unchanged.
 
+## New session names
+
+In **New session**, pausing typing for one second prepares a suggested name using
+only the selected agent's utility model. The composer discloses that unsent draft
+text is sent to the title provider. Preparation starts after at least 12 characters
+and sends at most the first 1,000 characters; it does not send attachments.
+
+Preparation is disabled in incognito and for slash commands. Edits replace stale
+suggestions, and only one request runs at a time. A missing or failed utility model
+does not fall back to the primary model or prevent you from starting the session.
+
+**Start session** uses a matching suggestion if it is ready. Otherwise, normal
+initial naming runs after submission; Start never waits for the speculative call.
+This is creation-only: later messages do not regenerate an existing session's
+name. Explicit worktree names are preserved, and typing never creates a worktree
+or runs setup.
+
 ## Quick open (local)
 
 If the Gateway is running on the same computer, open [http://127.0.0.1:18789/](http://127.0.0.1:18789/) (or [http://localhost:18789/](http://localhost:18789/)).

--- a/packages/gateway-protocol/src/schema/protocol-schema-fragment-sessions-lifecycle.ts
+++ b/packages/gateway-protocol/src/schema/protocol-schema-fragment-sessions-lifecycle.ts
@@ -43,6 +43,8 @@ export const SessionLifecycleProtocolSchemas = {
   SessionWorktreeInfo: sessions.SessionWorktreeInfoSchema,
   SessionsCreateParams: sessions.SessionsCreateParamsSchema,
   SessionsCreateResult: sessions.SessionsCreateResultSchema,
+  SessionsTitlePrepareParams: sessions.SessionsTitlePrepareParamsSchema,
+  SessionsTitlePrepareResult: sessions.SessionsTitlePrepareResultSchema,
   SessionsRecoverParams: sessions.SessionsRecoverParamsSchema,
   SessionsRecoverResult: sessions.SessionsRecoverResultSchema,
   SessionsSendParams: sessions.SessionsSendParamsSchema,

--- a/packages/gateway-protocol/src/schema/sessions-create.ts
+++ b/packages/gateway-protocol/src/schema/sessions-create.ts
@@ -14,6 +14,14 @@ export const SessionsCreateParamsSchema = closedObject({
   idempotencyKey: Type.Optional(NonEmptyString),
   agentId: Type.Optional(NonEmptyString),
   label: Type.Optional(SessionLabelString),
+  displayName: Type.Optional(
+    Type.String({
+      minLength: 1,
+      maxLength: 500,
+      description:
+        "Prepared presentation title for a newly created session. Unlike label it is not unique and never claims a label; ignored when adopting an existing key.",
+    }),
+  ),
   category: Type.Optional(SessionLabelString),
   model: Type.Optional(NonEmptyString),
   contextWindow: Type.Optional(NonEmptyString),

--- a/packages/gateway-protocol/src/schema/sessions-title.ts
+++ b/packages/gateway-protocol/src/schema/sessions-title.ts
@@ -1,0 +1,20 @@
+import type { Static } from "typebox";
+import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
+import { NonEmptyString } from "./primitives.js";
+
+/** Optional creation-only inference; never creates or renames a session. */
+export const SessionsTitlePrepareParamsSchema = closedObject({
+  agentId: NonEmptyString,
+  message: Type.String({ maxLength: 1_000 }),
+  model: Type.Optional(NonEmptyString),
+  catalogId: Type.Optional(NonEmptyString),
+  incognito: Type.Optional(Type.Boolean()),
+});
+
+export const SessionsTitlePrepareResultSchema = closedObject({
+  title: Type.Union([Type.String({ minLength: 1, maxLength: 60 }), Type.Null()]),
+});
+
+export type SessionsTitlePrepareParams = Static<typeof SessionsTitlePrepareParamsSchema>;
+export type SessionsTitlePrepareResult = Static<typeof SessionsTitlePrepareResultSchema>;

--- a/packages/gateway-protocol/src/schema/sessions.ts
+++ b/packages/gateway-protocol/src/schema/sessions.ts
@@ -11,6 +11,7 @@ import { SessionsRecoverParamsSchema, SessionsRecoverResultSchema } from "./sess
 import { SessionOwnerSchema } from "./sessions-row.js";
 
 export { SessionsCreateParamsSchema };
+export * from "./sessions-title.js";
 export * from "./sessions-goal.js";
 export { SessionsListParamsSchema, type SessionsListParams } from "./sessions-list.js";
 export { SessionsRecoverParamsSchema, SessionsRecoverResultSchema };

--- a/packages/gateway-protocol/src/validator-registry.ts
+++ b/packages/gateway-protocol/src/validator-registry.ts
@@ -259,6 +259,7 @@ export const validateSessionSuggestionsResolveParams = compile(
 );
 export const validateSessionTypingParams = compile(S.SessionTypingParamsSchema);
 export const validateSessionsCreateParams = compile(S.SessionsCreateParamsSchema);
+export const validateSessionsTitlePrepareParams = compile(S.SessionsTitlePrepareParamsSchema);
 export const validateSessionsRecoverParams = compile(S.SessionsRecoverParamsSchema);
 export const validateSessionsSendParams = compile(S.SessionsSendParamsSchema);
 export const validateSessionsReclaimParams = compile(S.SessionsReclaimParamsSchema);

--- a/src/auto-reply/reply/conversation-label-generator.test.ts
+++ b/src/auto-reply/reply/conversation-label-generator.test.ts
@@ -231,6 +231,57 @@ describe("generateConversationLabelWithFallback", () => {
     },
   );
 
+  it("keeps only the compatible runtime per attempt when providers differ", async () => {
+    runIsolatedCompletion
+      .mockRejectedValueOnce(new Error("utility unavailable"))
+      .mockResolvedValueOnce({ text: "Primary title" });
+
+    await expect(
+      generateConversationLabelWithFallback({
+        ...params,
+        utilityModelRef: "anthropic/claude-haiku",
+        agentHarnessRuntimeOverride: "codex",
+      }),
+    ).resolves.toBe("Primary title");
+
+    expect(
+      runIsolatedCompletion.mock.calls.map(([request]) => [
+        request.provider,
+        request.agentHarnessRuntimeOverride,
+      ]),
+    ).toEqual([
+      ["anthropic", undefined],
+      ["openai", "codex"],
+    ]);
+  });
+
+  it("utilityOnly runs one utility attempt and never the regular model", async () => {
+    runIsolatedCompletion.mockRejectedValueOnce(new Error("utility unavailable"));
+    await expect(
+      generateConversationLabelWithFallback({ ...params, utilityOnly: true }),
+    ).rejects.toThrow("conversation label generation failed (utility)");
+    expect(runIsolatedCompletion).toHaveBeenCalledOnce();
+    expect(runIsolatedCompletion.mock.calls[0]?.[0]?.model).toBe("gpt-mini");
+  });
+
+  it.each([
+    ["missing", undefined],
+    ["resolving onto the primary", "openai/gpt-main@work"],
+  ])(
+    "utilityOnly returns null without inference when the utility model is %s",
+    async (_case, ref) => {
+      const { utilityModelRef: _utilityModelRef, ...regularOnlyParams } = params;
+      await expect(
+        generateConversationLabelWithFallback({
+          ...regularOnlyParams,
+          ...(ref ? { utilityModelRef: ref } : {}),
+          utilityOnly: true,
+        }),
+      ).resolves.toBeNull();
+      expect(runIsolatedCompletion).not.toHaveBeenCalled();
+    },
+  );
+
   it("uses the regular candidate directly when no utility model exists", async () => {
     const { utilityModelRef: _utilityModelRef, ...regularOnlyParams } = params;
     await generateConversationLabelWithFallback(regularOnlyParams);

--- a/src/auto-reply/reply/conversation-label-generator.ts
+++ b/src/auto-reply/reply/conversation-label-generator.ts
@@ -4,6 +4,7 @@ import { createReasoningTagTextPartitioner } from "../../../packages/markdown-co
 import { resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import { runIsolatedCompletion } from "../../agents/isolated-completion.js";
 import { splitTrailingAuthProfile } from "../../agents/model-ref-profile.js";
+import { resolveCompatibleAgentRuntimeForProvider } from "../../agents/session-runtime-compat.js";
 import { resolveSimpleCompletionSelectionForAgent } from "../../agents/simple-completion-runtime.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 
@@ -17,6 +18,7 @@ type ConversationLabelAttempt = {
   modelRef?: string;
   useUtilityModel?: boolean;
   preferredProfile?: string;
+  phase: LabelModelPhase;
 };
 
 /** Inputs for generating a short conversation label from the configured utility model. */
@@ -37,6 +39,8 @@ type ConversationLabelFallbackParams = ConversationLabelParams & {
   regularModelRef: string;
   preferredProfile?: string;
   normalizeLabel?: (label: string) => string | null;
+  /** Speculative callers: one utility attempt at most, never the regular model. */
+  utilityOnly?: boolean;
 };
 
 type ResolvedLabelParams = ConversationLabelParams & {
@@ -71,34 +75,51 @@ function resolveRawModelProvider(modelRef: string | undefined): string | undefin
   return provider || undefined;
 }
 
+function resolveAttemptKey(
+  params: ConversationLabelParams & { agentId: string },
+  attempt: ConversationLabelAttempt,
+): string {
+  const selection = resolveAttemptSelection(params, attempt);
+  const rawRef = splitTrailingAuthProfile(attempt.modelRef?.trim() ?? "");
+  return selection
+    ? [
+        "resolved",
+        selection.provider,
+        selection.runtimeProvider ?? "",
+        selection.modelId,
+        selection.profileId ?? attempt.preferredProfile ?? "",
+      ].join("\0")
+    : ["raw", rawRef.model, rawRef.profile ?? attempt.preferredProfile ?? ""].join("\0");
+}
+
 async function runLabelAttempts(
   params: ResolvedLabelParams & {
     attempts: readonly ConversationLabelAttempt[];
+    /** Selections that must not run even when an attempt resolves onto them. */
+    skipAttempts?: readonly ConversationLabelAttempt[];
     normalizeLabel?: (label: string) => string | null;
   },
 ): Promise<string | null> {
-  const seen = new Set<string>();
+  const seen = new Set(params.skipAttempts?.map((attempt) => resolveAttemptKey(params, attempt)));
   const failures: LabelModelPhase[] = [];
-  for (const [index, attempt] of params.attempts.entries()) {
-    const selection = resolveAttemptSelection(params, attempt);
-    const rawRef = splitTrailingAuthProfile(attempt.modelRef?.trim() ?? "");
-    const key = selection
-      ? [
-          "resolved",
-          selection.provider,
-          selection.runtimeProvider ?? "",
-          selection.modelId,
-          selection.profileId ?? attempt.preferredProfile ?? "",
-        ].join("\0")
-      : ["raw", rawRef.model, rawRef.profile ?? attempt.preferredProfile ?? ""].join("\0");
+  for (const attempt of params.attempts) {
+    const key = resolveAttemptKey(params, attempt);
     if (seen.has(key)) {
       continue;
     }
     seen.add(key);
     try {
+      const selection = resolveAttemptSelection(params, attempt);
       if (!selection) {
         throw new Error("conversation label model selection unavailable");
       }
+      // The session's runtime override was resolved for its primary provider; a
+      // utility model on another provider cannot run through that harness.
+      const agentHarnessRuntimeOverride = resolveCompatibleAgentRuntimeForProvider({
+        provider: selection.provider,
+        runtime: params.agentHarnessRuntimeOverride,
+        cfg: params.cfg,
+      });
       const completion = await runIsolatedCompletion({
         config: params.cfg,
         provider: selection.runtimeProvider ?? selection.provider,
@@ -106,9 +127,7 @@ async function runLabelAttempts(
         authProfileId: selection.profileId ?? attempt.preferredProfile,
         agentId: params.agentId,
         agentDir: params.agentDir ?? selection.agentDir,
-        ...(params.agentHarnessRuntimeOverride
-          ? { agentHarnessRuntimeOverride: params.agentHarnessRuntimeOverride }
-          : {}),
+        ...(agentHarnessRuntimeOverride ? { agentHarnessRuntimeOverride } : {}),
         systemPrompt: [
           params.prompt,
           "You are labeling the supplied message, not participating in its conversation.",
@@ -132,7 +151,7 @@ async function runLabelAttempts(
         return normalized;
       }
     } catch {
-      failures.push(index === params.attempts.length - 1 ? "primary fallback" : "utility");
+      failures.push(attempt.phase);
     }
   }
   if (failures.length > 0) {
@@ -149,8 +168,11 @@ export async function generateConversationLabel(
 ): Promise<string | null> {
   const agentId = params.agentId ?? resolveDefaultAgentId(params.cfg);
   const attempts: ConversationLabelAttempt[] = params.modelRef
-    ? [{ modelRef: params.modelRef }]
-    : [{ useUtilityModel: true }, { useUtilityModel: false }];
+    ? [{ modelRef: params.modelRef, phase: "primary fallback" }]
+    : [
+        { useUtilityModel: true, phase: "utility" },
+        { useUtilityModel: false, phase: "primary fallback" },
+      ];
   return await runLabelAttempts({
     ...params,
     agentId,
@@ -168,11 +190,12 @@ export async function generateConversationLabelWithFallback(
   const regularAttempt: ConversationLabelAttempt = {
     modelRef: params.regularModelRef,
     ...(params.preferredProfile ? { preferredProfile: params.preferredProfile } : {}),
+    phase: "primary fallback",
   };
   const utilityRef = params.utilityModelRef?.trim();
   let utilityAttempt: ConversationLabelAttempt | undefined;
   if (utilityRef) {
-    const candidate: ConversationLabelAttempt = { modelRef: utilityRef };
+    const candidate: ConversationLabelAttempt = { modelRef: utilityRef, phase: "utility" };
     const resolvedParams = { ...params, agentId };
     const utilitySelection = resolveAttemptSelection(resolvedParams, candidate);
     const regularSelection = resolveAttemptSelection(resolvedParams, regularAttempt);
@@ -187,13 +210,17 @@ export async function generateConversationLabelWithFallback(
       utilityAuthProvider &&
       utilityAuthProvider === regularAuthProvider;
     utilityAttempt = inheritsRegularProfile
-      ? { modelRef: `${utilityRef}@${params.preferredProfile}` }
+      ? { ...candidate, modelRef: `${utilityRef}@${params.preferredProfile}` }
       : candidate;
   }
+  const utilityAttempts = utilityAttempt ? [utilityAttempt] : [];
   return await runLabelAttempts({
     ...params,
     agentId,
-    attempts: [...(utilityAttempt ? [utilityAttempt] : []), regularAttempt],
+    // Utility-only callers pre-claim the regular selection so a utility ref that
+    // resolves onto the primary model is skipped instead of spending on it.
+    attempts: params.utilityOnly ? utilityAttempts : [...utilityAttempts, regularAttempt],
+    ...(params.utilityOnly ? { skipAttempts: [regularAttempt] } : {}),
     timeoutMs: resolvePositiveInteger(params.timeoutMs, TIMEOUT_MS),
     maxLength: resolvePositiveInteger(params.maxLength, DEFAULT_MAX_LABEL_LENGTH),
   });

--- a/src/gateway/dashboard-session-title.ts
+++ b/src/gateway/dashboard-session-title.ts
@@ -1,10 +1,14 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveAgentEffectiveModelPrimary } from "../agents/agent-scope.js";
 import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
+import { buildModelAliasIndex, resolveModelRefFromString } from "../agents/model-selection.js";
 import { resolveSessionModelRef } from "../agents/session-model-ref.js";
 import { resolveSessionRuntimeOverrideForProvider } from "../agents/session-runtime-compat.js";
 import { resolveUtilityModelRefForAgent } from "../agents/utility-model.js";
-import { generateConversationLabelWithFallback } from "../auto-reply/reply/conversation-label-generator.js";
+import {
+  generateConversationLabel,
+  generateConversationLabelWithFallback,
+} from "../auto-reply/reply/conversation-label-generator.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import { loadSessionEntry, patchSessionEntryCore } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -164,6 +168,7 @@ async function generateDashboardSessionTitle(params: {
   userMessage: string;
   attachments?: readonly ChatAttachment[];
   timeoutMs?: number;
+  utilityOnly?: boolean;
 }): Promise<string | null> {
   const sourceText = buildDashboardSessionTitleSource({
     message: params.userMessage,
@@ -193,20 +198,76 @@ async function generateDashboardSessionTitle(params: {
     primaryProvider: regularModel.provider,
     primaryModelRef: regularModelRef,
   });
-  const generated = await generateConversationLabelWithFallback({
+  const labelParams = {
     userMessage: truncateUtf16Safe(sourceText, DASHBOARD_SESSION_TITLE_SOURCE_MAX_CHARS),
     prompt: DASHBOARD_SESSION_TITLE_PROMPT,
     cfg: params.cfg,
     agentId: params.agentId,
     ...(agentHarnessRuntimeOverride ? { agentHarnessRuntimeOverride } : {}),
+    maxLength: DASHBOARD_SESSION_TITLE_MAX_CHARS,
+    ...(params.timeoutMs ? { timeoutMs: params.timeoutMs } : {}),
+  };
+  if (params.utilityOnly) {
+    if (!utilityModelRef) {
+      return null;
+    }
+    const split = splitTrailingAuthProfile(utilityModelRef);
+    const aliasIndex = buildModelAliasIndex({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      defaultProvider: regularModel.provider,
+    });
+    const utility = resolveModelRefFromString({
+      cfg: params.cfg,
+      agentId: params.agentId,
+      raw: split.model,
+      defaultProvider: regularModel.provider,
+      aliasIndex,
+    });
+    if (!utility) {
+      return null;
+    }
+    const profile =
+      split.profile ??
+      (utility.ref.provider === regularModel.provider ? preferredProfile : undefined);
+    const modelRef = `${utility.ref.provider}/${utility.ref.model}${profile ? `@${profile}` : ""}`;
+    // Passing a concrete model makes this exactly one attempt. Draft speculation
+    // must never spend on the normal primary-model fallback after a utility failure.
+    const utilityRuntime = resolveSessionRuntimeOverrideForProvider({
+      provider: utility.ref.provider,
+      entry: params.entry,
+      cfg: params.cfg,
+    });
+    const generated = await generateConversationLabel({
+      ...labelParams,
+      agentHarnessRuntimeOverride: utilityRuntime,
+      modelRef,
+    });
+    return generated ? normalizeDashboardSessionTitle(generated) : null;
+  }
+  const generated = await generateConversationLabelWithFallback({
+    ...labelParams,
     ...(utilityModelRef ? { utilityModelRef } : {}),
     regularModelRef,
     ...(preferredProfile ? { preferredProfile } : {}),
     normalizeLabel: normalizeDashboardSessionTitle,
-    maxLength: DASHBOARD_SESSION_TITLE_MAX_CHARS,
-    ...(params.timeoutMs ? { timeoutMs: params.timeoutMs } : {}),
   });
   return generated ? normalizeDashboardSessionTitle(generated) : null;
+}
+
+/** Prepares a creation draft's title without creating or updating a session. */
+export async function prepareDashboardSessionTitle(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  entry?: DashboardSessionTitleModelEntry;
+  userMessage: string;
+}): Promise<string | null> {
+  try {
+    return await generateDashboardSessionTitle({ ...params, utilityOnly: true });
+  } catch {
+    // Speculation is optional; provider diagnostics and draft contents stay private.
+    return null;
+  }
 }
 
 /** Worktree callers bound their own wait without cancelling another naming owner's request. */

--- a/src/gateway/dashboard-session-title.ts
+++ b/src/gateway/dashboard-session-title.ts
@@ -1,14 +1,10 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveAgentEffectiveModelPrimary } from "../agents/agent-scope.js";
 import { splitTrailingAuthProfile } from "../agents/model-ref-profile.js";
-import { buildModelAliasIndex, resolveModelRefFromString } from "../agents/model-selection.js";
 import { resolveSessionModelRef } from "../agents/session-model-ref.js";
 import { resolveSessionRuntimeOverrideForProvider } from "../agents/session-runtime-compat.js";
 import { resolveUtilityModelRefForAgent } from "../agents/utility-model.js";
-import {
-  generateConversationLabel,
-  generateConversationLabelWithFallback,
-} from "../auto-reply/reply/conversation-label-generator.js";
+import { generateConversationLabelWithFallback } from "../auto-reply/reply/conversation-label-generator.js";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
 import { loadSessionEntry, patchSessionEntryCore } from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
@@ -198,59 +194,19 @@ async function generateDashboardSessionTitle(params: {
     primaryProvider: regularModel.provider,
     primaryModelRef: regularModelRef,
   });
-  const labelParams = {
+  const generated = await generateConversationLabelWithFallback({
     userMessage: truncateUtf16Safe(sourceText, DASHBOARD_SESSION_TITLE_SOURCE_MAX_CHARS),
     prompt: DASHBOARD_SESSION_TITLE_PROMPT,
     cfg: params.cfg,
     agentId: params.agentId,
     ...(agentHarnessRuntimeOverride ? { agentHarnessRuntimeOverride } : {}),
-    maxLength: DASHBOARD_SESSION_TITLE_MAX_CHARS,
-    ...(params.timeoutMs ? { timeoutMs: params.timeoutMs } : {}),
-  };
-  if (params.utilityOnly) {
-    if (!utilityModelRef) {
-      return null;
-    }
-    const split = splitTrailingAuthProfile(utilityModelRef);
-    const aliasIndex = buildModelAliasIndex({
-      cfg: params.cfg,
-      agentId: params.agentId,
-      defaultProvider: regularModel.provider,
-    });
-    const utility = resolveModelRefFromString({
-      cfg: params.cfg,
-      agentId: params.agentId,
-      raw: split.model,
-      defaultProvider: regularModel.provider,
-      aliasIndex,
-    });
-    if (!utility) {
-      return null;
-    }
-    const profile =
-      split.profile ??
-      (utility.ref.provider === regularModel.provider ? preferredProfile : undefined);
-    const modelRef = `${utility.ref.provider}/${utility.ref.model}${profile ? `@${profile}` : ""}`;
-    // Passing a concrete model makes this exactly one attempt. Draft speculation
-    // must never spend on the normal primary-model fallback after a utility failure.
-    const utilityRuntime = resolveSessionRuntimeOverrideForProvider({
-      provider: utility.ref.provider,
-      entry: params.entry,
-      cfg: params.cfg,
-    });
-    const generated = await generateConversationLabel({
-      ...labelParams,
-      agentHarnessRuntimeOverride: utilityRuntime,
-      modelRef,
-    });
-    return generated ? normalizeDashboardSessionTitle(generated) : null;
-  }
-  const generated = await generateConversationLabelWithFallback({
-    ...labelParams,
     ...(utilityModelRef ? { utilityModelRef } : {}),
     regularModelRef,
     ...(preferredProfile ? { preferredProfile } : {}),
     normalizeLabel: normalizeDashboardSessionTitle,
+    maxLength: DASHBOARD_SESSION_TITLE_MAX_CHARS,
+    ...(params.timeoutMs ? { timeoutMs: params.timeoutMs } : {}),
+    ...(params.utilityOnly ? { utilityOnly: true } : {}),
   });
   return generated ? normalizeDashboardSessionTitle(generated) : null;
 }

--- a/src/gateway/methods/core-descriptors.since.test.ts
+++ b/src/gateway/methods/core-descriptors.since.test.ts
@@ -145,6 +145,7 @@ const CURRENT_TRAIN_METHODS = [
   "skills.library.activate",
   "skills.library.import",
   "skills.library.upload",
+  "sessions.title.prepare",
 ] as const;
 
 describe("core gateway method release trains", () => {

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -649,6 +649,13 @@ const CORE_GATEWAY_METHOD_SPECS = [
     "2026.8",
     { startup: true, controlPlaneWrite: true },
   ],
+  [
+    "sessions.title.prepare",
+    "sessions-title",
+    "operator.write",
+    "2026.8",
+    { controlPlaneWrite: true },
+  ],
 ] as const satisfies readonly CoreGatewayMethodSpecRow[];
 
 export type CoreGatewayHandlerFamily = Exclude<(typeof CORE_GATEWAY_METHOD_SPECS)[number][1], null>;

--- a/src/gateway/methods/core-descriptors.ts
+++ b/src/gateway/methods/core-descriptors.ts
@@ -660,29 +660,14 @@ const CORE_GATEWAY_METHOD_SPECS = [
 
 export type CoreGatewayHandlerFamily = Exclude<(typeof CORE_GATEWAY_METHOD_SPECS)[number][1], null>;
 
+// Rows are `as const`, so a present policy flag is already the exact literal the spec allows.
 const CORE_GATEWAY_METHOD_SPEC_LIST: readonly CoreGatewayMethodSpec[] =
   CORE_GATEWAY_METHOD_SPECS.map(([name, family, scope, since, policy]) => {
     const spec: CoreGatewayMethodSpec = { name, scope, since };
-    const normalizedPolicy: CoreGatewayMethodPolicy | undefined = policy;
     if (family) {
       spec.family = family;
     }
-    if (normalizedPolicy?.advertise === false) {
-      spec.advertise = false;
-    }
-    if (normalizedPolicy?.startup === true) {
-      spec.startup = true;
-    }
-    if (normalizedPolicy?.controlPlaneWrite === true) {
-      spec.controlPlaneWrite = true;
-    }
-    if (normalizedPolicy?.compatibilityRestored === true) {
-      spec.compatibilityRestored = true;
-    }
-    if (normalizedPolicy?.description) {
-      spec.description = normalizedPolicy.description;
-    }
-    return spec;
+    return Object.assign(spec, policy);
   });
 
 const CORE_GATEWAY_METHOD_SPEC_BY_NAME: ReadonlyMap<string, CoreGatewayMethodSpec> = new Map(

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -248,6 +248,16 @@ describe("listGatewayMethods", () => {
     expect(methods).not.toContain("sessions.usage");
   });
 
+  it("rate-limits speculative inference under operator write authority", () => {
+    const descriptors = createCoreGatewayMethodDescriptors(coreGatewayHandlers);
+    expect(
+      descriptors.find((descriptor) => descriptor.name === "sessions.title.prepare"),
+    ).toMatchObject({
+      scope: "operator.write",
+      controlPlaneWrite: true,
+    });
+  });
+
   it("registers the hidden node protocol feature publication method", () => {
     const descriptor = createCoreGatewayMethodDescriptors(coreGatewayHandlers).find(
       (candidate) => candidate.name === "node.runnerInventory.update",

--- a/src/gateway/server-methods-list.test.ts
+++ b/src/gateway/server-methods-list.test.ts
@@ -132,6 +132,7 @@ describe("listGatewayMethods", () => {
     "sessions.github.options",
     "sessions.github.status",
     "sessions.github.confirm",
+    "sessions.title.prepare",
   ];
 
   it("advertises plugin surface refresh for capability rotation", () => {

--- a/src/gateway/server-methods.ts
+++ b/src/gateway/server-methods.ts
@@ -175,6 +175,8 @@ const CORE_GATEWAY_HANDLER_MODULES = {
     ),
   "sessions-create": () =>
     import("./server-methods/sessions-create.js").then((module) => module.sessionCreateHandlers),
+  "sessions-title": () =>
+    import("./server-methods/sessions-title.js").then((module) => module.sessionTitleHandlers),
   "sessions-recover": () =>
     import("./server-methods/sessions-recover.js").then((module) => module.sessionRecoverHandlers),
   "sessions-delete": () =>
@@ -306,10 +308,6 @@ const SUSPEND_CONTROL_METHODS = new Set([
   "gateway.suspend.status",
   "gateway.suspend.resume",
 ]);
-
-function isGatewayMethodAllowedDuringSuspension(method: string): boolean {
-  return SUSPEND_CONTROL_METHODS.has(method);
-}
 
 function runGatewayPendingWorkContinuation<T>(params: {
   method: string;
@@ -606,7 +604,7 @@ export async function runWithGatewayRequestEnvelope<T>(
       }),
     );
   }
-  if (!rootWorkAdmission && !isGatewayMethodAllowedDuringSuspension(method)) {
+  if (!rootWorkAdmission && !SUSPEND_CONTROL_METHODS.has(method)) {
     const restartDraining = isGatewayRestartDraining();
     return await options.reject(
       errorShape(

--- a/src/gateway/server-methods/sessions-create.ts
+++ b/src/gateway/server-methods/sessions-create.ts
@@ -284,6 +284,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       return;
     }
     const explicitSessionLabel = normalizeOptionalString(p.label);
+    const preparedDisplayName = normalizeOptionalString(p.displayName);
     const titleAgentId = explicitlyRequestedAgent.agentId;
     const existingWorktreeTarget =
       p.worktree === true && explicitlyRequestedKey
@@ -431,6 +432,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
           const title =
             !requestedWorktreeName &&
             !explicitSessionLabel &&
+            !preparedDisplayName &&
             lifecycleTarget.entry &&
             lifecycleTarget.titleModelSelection !== null
               ? await generateWorktreeSessionTitle({
@@ -462,6 +464,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
             baseRef: requestedWorktreeBaseRef,
             label:
               explicitSessionLabel ??
+              preparedDisplayName ??
               title ??
               resolveExplicitSessionName(lifecycleTarget.entry) ??
               source,
@@ -491,6 +494,7 @@ export const sessionCreateHandlers: GatewayRequestHandlers = {
       key: sessionKey,
       agentId: sessionAgentId,
       label: p.label,
+      displayName: preparedDisplayName,
       category: p.category,
       ...(catalogTarget ? { catalogTarget: catalogTarget.target } : { model: requestedModel }),
       contextWindow: p.contextWindow,

--- a/src/gateway/server-methods/sessions-title.test.ts
+++ b/src/gateway/server-methods/sessions-title.test.ts
@@ -1,0 +1,201 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { sessionTitleHandlers } from "./sessions-title.js";
+
+const mocks = vi.hoisted(() => ({
+  runIsolatedCompletion: vi.fn(),
+  authorizeGatewaySessionCreation: vi.fn(),
+  resolveRegisteredCatalogCreateTarget: vi.fn(),
+}));
+
+vi.mock("../../agents/isolated-completion.js", () => ({
+  runIsolatedCompletion: mocks.runIsolatedCompletion,
+}));
+vi.mock("../operator-role-policy.js", () => ({
+  authorizeGatewaySessionCreation: mocks.authorizeGatewaySessionCreation,
+}));
+vi.mock("./session-catalog.js", () => ({
+  resolveRegisteredCatalogCreateTarget: mocks.resolveRegisteredCatalogCreateTarget,
+}));
+
+const cfg: OpenClawConfig = {
+  agents: {
+    entries: { main: {} },
+    defaults: {
+      model: { primary: "title-test/primary" },
+      utilityModel: "title-test/utility",
+    },
+  },
+};
+
+async function prepare(params: Record<string, unknown>, config: OpenClawConfig = cfg) {
+  const respond = vi.fn();
+  const method = "sessions.title.prepare";
+  await sessionTitleHandlers[method]!({
+    req: { type: "req", id: "draft-title", method, params },
+    params,
+    respond,
+    context: { getRuntimeConfig: () => config } as never,
+    client: null,
+    isWebchatConnect: () => false,
+  });
+  return respond;
+}
+
+describe("sessions.title.prepare", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mocks.runIsolatedCompletion.mockResolvedValue({ text: 'Title: "Draft session title"' });
+    mocks.resolveRegisteredCatalogCreateTarget.mockReturnValue({
+      ok: false,
+      unknownCatalog: true,
+      message: "unknown catalog",
+    });
+  });
+
+  it("returns a normalized title from exactly one utility completion", async () => {
+    const respond = await prepare({ agentId: "main", message: "Plan a new session" });
+    expect(respond).toHaveBeenCalledWith(true, { title: "Draft session title" });
+    expect(mocks.runIsolatedCompletion).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        provider: "title-test",
+        model: "utility",
+        prompt: "Plan a new session",
+        outputTextPolicy: "strict-visible",
+      }),
+    );
+  });
+
+  it("does not fall back to the primary when utility inference fails", async () => {
+    mocks.runIsolatedCompletion.mockRejectedValue(new Error("private provider diagnostic"));
+    const respond = await prepare({ agentId: "main", message: "Private draft" });
+    expect(respond).toHaveBeenCalledWith(true, { title: null });
+    expect(mocks.runIsolatedCompletion).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["", "invalid/"])(
+    "does not route disabled or malformed utility setting %j to the primary",
+    async (utilityModel) => {
+      const config = {
+        ...cfg,
+        agents: { ...cfg.agents, defaults: { ...cfg.agents?.defaults, utilityModel } },
+      };
+      expect(
+        await prepare({ agentId: "main", message: "Plan a session" }, config),
+      ).toHaveBeenCalledWith(true, { title: null });
+      expect(mocks.runIsolatedCompletion).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { message: "" },
+    { message: "   " },
+    { message: "/new" },
+    { message: "Secret draft", incognito: true },
+    { message: "Catalog draft", catalogId: "missing" },
+  ])("skips non-speculative input %# without inference", async (params) => {
+    expect(await prepare({ agentId: "main", ...params })).toHaveBeenCalledWith(true, {
+      title: null,
+    });
+    expect(mocks.runIsolatedCompletion).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { message: "Draft", agentId: "missing" },
+    { message: "x".repeat(1_001), agentId: "main" },
+    { message: "Draft", agentId: "main", sessionKey: "existing-session" },
+    { message: "Draft", agentId: "main", model: "title-test/primary", catalogId: "catalog" },
+  ])("rejects invalid selection or an existing-session target %#", async (params) => {
+    expect(await prepare(params)).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "INVALID_REQUEST" }),
+    );
+    expect(mocks.runIsolatedCompletion).not.toHaveBeenCalled();
+  });
+
+  it("enforces the operator's allowed creation agent before inference", async () => {
+    const error = { code: "FORBIDDEN", message: "Agent not allowed" };
+    mocks.authorizeGatewaySessionCreation.mockReturnValue(error);
+    expect(await prepare({ agentId: "main", message: "Draft" })).toHaveBeenCalledWith(
+      false,
+      undefined,
+      error,
+    );
+    expect(mocks.runIsolatedCompletion).not.toHaveBeenCalled();
+  });
+
+  it("skips a selected model denied by the creation agent's model policy", async () => {
+    const config = {
+      ...cfg,
+      agents: {
+        ...cfg.agents,
+        entries: { main: { modelPolicy: { allow: ["title-test/primary"] } } },
+      },
+    };
+    expect(
+      await prepare({ agentId: "main", message: "Draft", model: "other-model/denied" }, config),
+    ).toHaveBeenCalledWith(true, { title: null });
+    expect(mocks.runIsolatedCompletion).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["openai", "codex"],
+    ["other-title", undefined],
+  ])(
+    "uses only the catalog runtime compatible with utility provider %s",
+    async (provider, runtime) => {
+      const config = {
+        ...cfg,
+        agents: {
+          ...cfg.agents,
+          defaults: { ...cfg.agents?.defaults, utilityModel: `${provider}/synthetic-utility` },
+        },
+      };
+      mocks.resolveRegisteredCatalogCreateTarget.mockReturnValue({
+        ok: true,
+        target: {
+          model: "openai/synthetic-primary",
+          agentRuntime: "codex",
+          pluginOwnerId: "codex",
+        },
+      });
+      expect(
+        await prepare({ agentId: "main", message: "Draft", catalogId: "native-catalog" }, config),
+      ).toHaveBeenCalledWith(true, { title: "Draft session title" });
+      expect(mocks.runIsolatedCompletion).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ provider, model: "synthetic-utility" }),
+      );
+      expect(mocks.runIsolatedCompletion.mock.calls[0]?.[0].agentHarnessRuntimeOverride).toBe(
+        runtime,
+      );
+    },
+  );
+
+  it("inherits the selected model's same-provider auth profile for utility inference", async () => {
+    expect(
+      await prepare({ agentId: "main", message: "Draft", model: "title-test/primary@work" }),
+    ).toHaveBeenCalledWith(true, { title: "Draft session title" });
+    expect(mocks.runIsolatedCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "title-test", model: "utility", authProfileId: "work" }),
+    );
+  });
+
+  it("does not send the primary provider's auth profile to another utility provider", async () => {
+    const config = {
+      ...cfg,
+      agents: {
+        ...cfg.agents,
+        defaults: { ...cfg.agents?.defaults, utilityModel: "other-title/utility" },
+      },
+    };
+    await prepare({ agentId: "main", message: "Draft", model: "title-test/primary@work" }, config);
+    expect(mocks.runIsolatedCompletion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "other-title",
+        model: "utility",
+        authProfileId: undefined,
+      }),
+    );
+  });
+});

--- a/src/gateway/server-methods/sessions-title.ts
+++ b/src/gateway/server-methods/sessions-title.ts
@@ -1,0 +1,81 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import {
+  ErrorCodes,
+  errorShape,
+  validateSessionsTitlePrepareParams,
+} from "../../../packages/gateway-protocol/src/index.js";
+import { prepareDashboardSessionTitle } from "../dashboard-session-title.js";
+import { authorizeGatewaySessionCreation } from "../operator-role-policy.js";
+import { resolveSessionCreateModelSelection } from "../session-create-model-selection.js";
+import { resolveAgentIdOrRespondError } from "./agent-id-shared.js";
+import { resolveRegisteredCatalogCreateTarget } from "./session-catalog.js";
+import type { GatewayRequestHandlers } from "./types.js";
+import { assertValidParams } from "./validation.js";
+
+export const sessionTitleHandlers: GatewayRequestHandlers = {
+  "sessions.title.prepare": async ({ params, respond, context, client }) => {
+    if (
+      !assertValidParams(
+        params,
+        validateSessionsTitlePrepareParams,
+        "sessions.title.prepare",
+        respond,
+      )
+    ) {
+      return;
+    }
+    const cfg = context.getRuntimeConfig();
+    const agent = resolveAgentIdOrRespondError({
+      rawAgentId: params.agentId,
+      respond,
+      cfg,
+      normalize: normalizeOptionalString,
+    });
+    if (!agent) {
+      return;
+    }
+    const creationError = authorizeGatewaySessionCreation({ cfg, client, agentId: agent.agentId });
+    if (creationError) {
+      respond(false, undefined, creationError);
+      return;
+    }
+    if (params.model && params.catalogId) {
+      respond(
+        false,
+        undefined,
+        errorShape(
+          ErrorCodes.INVALID_REQUEST,
+          "sessions.title.prepare catalogId cannot include model",
+        ),
+      );
+      return;
+    }
+    if (params.incognito || !params.message.trim() || params.message.trim().startsWith("/")) {
+      respond(true, { title: null });
+      return;
+    }
+    const catalog = params.catalogId
+      ? resolveRegisteredCatalogCreateTarget(params.catalogId, agent.agentId, cfg)
+      : undefined;
+    if (catalog && !catalog.ok) {
+      respond(true, { title: null });
+      return;
+    }
+    const entry = resolveSessionCreateModelSelection(
+      cfg,
+      agent.agentId,
+      catalog?.target ?? params.model,
+    );
+    if (!entry) {
+      respond(true, { title: null });
+      return;
+    }
+    const title = await prepareDashboardSessionTitle({
+      cfg,
+      agentId: agent.agentId,
+      entry,
+      userMessage: params.message,
+    });
+    respond(true, { title });
+  },
+};

--- a/src/gateway/session-create-model-selection.ts
+++ b/src/gateway/session-create-model-selection.ts
@@ -1,0 +1,49 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalAgentRuntimeId } from "../agents/agent-runtime-id.js";
+import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
+import { inheritSessionSelection } from "../config/sessions/session-entry-selection.js";
+import type { SessionEntry } from "../config/sessions/types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { GatewaySessionTitleModelSelection } from "./session-lifecycle-preparation.js";
+import { resolveSessionPatchModelSelection } from "./sessions-patch.js";
+
+export function resolveSessionCreateModelSelection(
+  cfg: OpenClawConfig,
+  agentId: string,
+  input: string | { model: string; agentRuntime?: string } | undefined,
+  parentEntry?: SessionEntry,
+): GatewaySessionTitleModelSelection | null {
+  const model = normalizeOptionalString(typeof input === "string" ? input : input?.model);
+  if (!model) {
+    const inherited = inheritSessionSelection(parentEntry);
+    return {
+      providerOverride: inherited.providerOverride,
+      modelOverride: inherited.modelOverride,
+      agentRuntimeOverride: inherited.agentRuntimeOverride,
+      authProfileOverride: inherited.authProfileOverride,
+    };
+  }
+  const defaults = resolveDefaultModelForAgent({ cfg, agentId });
+  // Reuse patch policy with the config-owned catalog projection. Persisted creation
+  // remains the sole live-catalog availability validator.
+  const resolved = resolveSessionPatchModelSelection({
+    cfg,
+    agentId,
+    catalog: [],
+    raw: model,
+    defaultProvider: defaults.provider,
+    defaultModel: defaults.model,
+  });
+  if (!resolved.ok) {
+    return null;
+  }
+  const agentRuntimeOverride = normalizeOptionalAgentRuntimeId(
+    typeof input === "string" ? undefined : input?.agentRuntime,
+  );
+  return {
+    providerOverride: resolved.provider,
+    modelOverride: resolved.model,
+    ...(agentRuntimeOverride ? { agentRuntimeOverride } : {}),
+    ...(resolved.profile ? { authProfileOverride: resolved.profile } : {}),
+  };
+}

--- a/src/gateway/session-create-service.ts
+++ b/src/gateway/session-create-service.ts
@@ -87,8 +87,8 @@ import { authorizeGatewaySessionCreation, resolveCreatorSandbox } from "./operat
 import { ADMIN_SCOPE } from "./operator-scopes.js";
 import type { GatewayOperatorRoleActor } from "./server-methods/shared-types.js";
 import { buildForkedGatewaySessionEntry } from "./session-create-fork-entry.js";
+import { resolveSessionCreateModelSelection } from "./session-create-model-selection.js";
 import {
-  type GatewaySessionTitleModelSelection,
   type PreparedGatewaySessionLifecycle,
   type PrepareGatewaySessionLifecycle,
   rollbackGatewaySessionPreparation,
@@ -111,47 +111,6 @@ type TrustedCatalogSessionTarget = {
 const loadSessionLifecycleRuntime = createLazyRuntimeModule(
   () => import("./server-methods/sessions.runtime.js"),
 );
-
-function resolveSessionCreateModelSelection(
-  cfg: OpenClawConfig,
-  agentId: string,
-  input: string | { model: string; agentRuntime?: string } | undefined,
-  parentEntry?: SessionEntry,
-): GatewaySessionTitleModelSelection | null {
-  const model = normalizeOptionalString(typeof input === "string" ? input : input?.model);
-  if (!model) {
-    const inherited = inheritSessionSelection(parentEntry);
-    return {
-      providerOverride: inherited.providerOverride,
-      modelOverride: inherited.modelOverride,
-      agentRuntimeOverride: inherited.agentRuntimeOverride,
-      authProfileOverride: inherited.authProfileOverride,
-    };
-  }
-  const defaults = resolveDefaultModelForAgent({ cfg, agentId });
-  // Reuse patch policy with the config-owned catalog projection. Persisted creation
-  // remains the sole live-catalog availability validator.
-  const resolved = resolveSessionPatchModelSelection({
-    cfg,
-    agentId,
-    catalog: [],
-    raw: model,
-    defaultProvider: defaults.provider,
-    defaultModel: defaults.model,
-  });
-  if (!resolved.ok) {
-    return null;
-  }
-  const agentRuntimeOverride = normalizeOptionalAgentRuntimeId(
-    typeof input === "string" ? undefined : input?.agentRuntime,
-  );
-  return {
-    providerOverride: resolved.provider,
-    modelOverride: resolved.model,
-    ...(agentRuntimeOverride ? { agentRuntimeOverride } : {}),
-    ...(resolved.profile ? { authProfileOverride: resolved.profile } : {}),
-  };
-}
 
 async function existingSessionSelectionWouldChange(params: {
   agentId: string;

--- a/ui/src/e2e/mobile-inbox-sheet.e2e.test.ts
+++ b/ui/src/e2e/mobile-inbox-sheet.e2e.test.ts
@@ -83,7 +83,7 @@ suite.define(() => {
           // getAnimations() drops finished animations. Replay it so the geometry is
           // measured from the real keyframes instead of depending on scheduling luck.
           element.style.animation = "none";
-          void element.offsetHeight;
+          void element.getBoundingClientRect();
           element.style.removeProperty("animation");
           animation = findEntrance();
         }

--- a/ui/src/e2e/mobile-inbox-sheet.e2e.test.ts
+++ b/ui/src/e2e/mobile-inbox-sheet.e2e.test.ts
@@ -72,10 +72,21 @@ suite.define(() => {
       await panel.waitFor({ state: "attached" });
 
       const result = await panel.evaluate(async (element) => {
-        const animation = element.getAnimations().find((candidate) => {
-          const effect = candidate.effect;
-          return effect instanceof KeyframeEffect && effect.target === element;
-        });
+        const findEntrance = () =>
+          element.getAnimations().find((candidate) => {
+            const effect = candidate.effect;
+            return effect instanceof KeyframeEffect && effect.target === element;
+          });
+        let animation = findEntrance();
+        if (!animation) {
+          // A loaded runner can sample after the CSS entrance already finished, and
+          // getAnimations() drops finished animations. Replay it so the geometry is
+          // measured from the real keyframes instead of depending on scheduling luck.
+          element.style.animation = "none";
+          void element.offsetHeight;
+          element.style.removeProperty("animation");
+          animation = findEntrance();
+        }
         if (!animation?.effect) {
           throw new Error("Expected the mobile Inbox sheet entrance animation");
         }

--- a/ui/src/e2e/new-session-page.title.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.title.e2e.test.ts
@@ -1,0 +1,72 @@
+import { expect, it } from "vitest";
+import {
+  createNewSessionPageE2eSuite,
+  installMockGateway,
+  controlUiSessionPath,
+} from "./new-session-page.test-support.ts";
+
+const suite = createNewSessionPageE2eSuite();
+const methods = ["chat.metadata", "chat.startup", "sessions.create", "sessions.title.prepare"];
+
+suite.define(() => {
+  it("prepares a creation title after idle and never regenerates it in an ongoing chat", async () => {
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: methods,
+        methodResponses: {
+          "sessions.title.prepare": { title: "Repair sidebar naming" },
+          "sessions.create": { key: "agent:main:prepared-title", runStarted: true },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}new`);
+      await page.getByText("When you pause, draft text is sent", { exact: false }).waitFor();
+      const message = page.locator(".new-session-page__message");
+      await message.fill("repair the sidebar naming");
+      await page.getByText("Session name: Repair sidebar naming", { exact: true }).waitFor();
+      expect(await gateway.getRequests("sessions.create")).toHaveLength(0);
+      await page.getByRole("button", { name: "Start session" }).click();
+      expect(await gateway.waitForRequest("sessions.create")).toMatchObject({
+        params: { label: "Repair sidebar naming", message: "repair the sidebar naming" },
+      });
+      await page.waitForURL(
+        (url) => url.pathname === controlUiSessionPath("agent:main:prepared-title"),
+      );
+      await page.clock.install();
+      await page
+        .locator(".agent-chat__composer-combobox textarea")
+        .fill("another topic in the ongoing chat");
+      await page.clock.runFor(2_000);
+      expect(await gateway.getRequests("sessions.title.prepare")).toHaveLength(1);
+    });
+  });
+
+  it("starts without waiting for a pending title and disables draft inference in incognito", async () => {
+    await suite.withPage({}, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: methods,
+        deferredMethods: ["sessions.title.prepare"],
+        methodResponses: {
+          "sessions.create": { key: "agent:main:pending-title", runStarted: true },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}new`);
+      const message = page.locator(".new-session-page__message");
+      await message.fill("prepare a draft name without blocking");
+      await gateway.waitForRequest("sessions.title.prepare");
+      await page.getByRole("button", { name: "Start session" }).click();
+      const created = await gateway.waitForRequest("sessions.create");
+      expect(created.params).not.toHaveProperty("label");
+      await gateway.resolveDeferred("sessions.title.prepare", { title: "Too late to rename" });
+      await page.waitForURL(
+        (url) => url.pathname === controlUiSessionPath("agent:main:pending-title"),
+      );
+      expect(await gateway.getRequests("sessions.patch")).toHaveLength(0);
+      await page.goto(`${suite.server.baseUrl}new`);
+      await page.getByRole("switch", { name: "Incognito", exact: true }).click();
+      await page.clock.install();
+      await message.fill("this incognito draft must not be sent");
+      await page.clock.runFor(2_000);
+      expect(await gateway.getRequests("sessions.title.prepare")).toHaveLength(0);
+    });
+  });
+});

--- a/ui/src/e2e/new-session-page.title.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.title.e2e.test.ts
@@ -26,7 +26,7 @@ suite.define(() => {
       expect(await gateway.getRequests("sessions.create")).toHaveLength(0);
       await page.getByRole("button", { name: "Start session" }).click();
       expect(await gateway.waitForRequest("sessions.create")).toMatchObject({
-        params: { label: "Repair sidebar naming", message: "repair the sidebar naming" },
+        params: { displayName: "Repair sidebar naming", message: "repair the sidebar naming" },
       });
       await page.waitForURL(
         (url) => url.pathname === controlUiSessionPath("agent:main:prepared-title"),
@@ -37,6 +37,26 @@ suite.define(() => {
         .fill("another topic in the ongoing chat");
       await page.clock.runFor(2_000);
       expect(await gateway.getRequests("sessions.title.prepare")).toHaveLength(1);
+    });
+  });
+
+  it("recovers title preparation when blur drops compositionend", async () => {
+    await suite.withPage({}, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: methods,
+        methodResponses: { "sessions.title.prepare": { title: "Composed draft" } },
+      });
+      await page.goto(`${suite.server.baseUrl}new`);
+      await page.clock.install();
+      const message = page.locator(".new-session-page__message");
+      await message.dispatchEvent("compositionstart");
+      await message.fill("compose a draft through an input method editor");
+      await page.clock.runFor(2_000);
+      expect(await gateway.getRequests("sessions.title.prepare")).toHaveLength(0);
+      await message.blur();
+      await page.clock.runFor(1_500);
+      expect(await gateway.getRequests("sessions.title.prepare")).toHaveLength(1);
+      await page.getByText("Session name: Composed draft", { exact: true }).waitFor();
     });
   });
 
@@ -55,7 +75,7 @@ suite.define(() => {
       await gateway.waitForRequest("sessions.title.prepare");
       await page.getByRole("button", { name: "Start session" }).click();
       const created = await gateway.waitForRequest("sessions.create");
-      expect(created.params).not.toHaveProperty("label");
+      expect(created.params).not.toHaveProperty("displayName");
       await gateway.resolveDeferred("sessions.title.prepare", { title: "Too late to rename" });
       await page.waitForURL(
         (url) => url.pathname === controlUiSessionPath("agent:main:pending-title"),

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -916,6 +916,9 @@ export const en: TranslationMap & {
     draft: "Draft",
     draftDescription: "Keep this session to yourself until you publish it",
     messagePlaceholder: "What should this session work on?",
+    titlePreparationDisclosure:
+      "When you pause, draft text is sent to your title provider to prepare a session name. Not used in incognito.",
+    preparedTitle: "Session name: {title}",
     dictate: "Dictate",
     readingAttachment: "Reading attachment",
     start: "Start session",

--- a/ui/src/pages/new-session/create-params.ts
+++ b/ui/src/pages/new-session/create-params.ts
@@ -10,10 +10,13 @@ const WORKTREE_NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
  */
 export type NewSessionVisibility = "normal" | "draft" | "incognito";
 export type DraftSessionCreateOverrides = Partial<
-  Pick<SessionCreateParams, "message" | "attachments">
+  Pick<SessionCreateParams, "message" | "attachments" | "displayName">
 > & { visibility?: NewSessionVisibility };
 export type DraftSessionCreateSelection = Partial<
-  Pick<SessionCreateParams, "attachments" | "permissionMode" | "catalogId" | "category">
+  Pick<
+    SessionCreateParams,
+    "attachments" | "permissionMode" | "catalogId" | "category" | "displayName"
+  >
 > & {
   message: string;
   visibility: NewSessionVisibility;
@@ -39,7 +42,7 @@ export function buildDraftSessionCreateParams(draft: {
   key?: string;
   agentId: string;
   message: string;
-  label?: string;
+  displayName?: string;
   model?: string;
   contextWindow?: string;
   thinkingLevel?: string;
@@ -75,8 +78,8 @@ export function buildDraftSessionCreateParams(draft: {
     ...(normalizeOptionalString(draft.key) ? { key: normalizeOptionalString(draft.key) } : {}),
     agentId: normalizeAgentId(draft.agentId),
     message: draft.message,
-    ...(normalizeOptionalString(draft.label)
-      ? { label: normalizeOptionalString(draft.label) }
+    ...(normalizeOptionalString(draft.displayName)
+      ? { displayName: normalizeOptionalString(draft.displayName) }
       : {}),
     ...(draft.visibility === "incognito" ? { incognito: true } : {}),
     ...(draft.visibility === "draft" ? { visibility: "draft" } : {}),

--- a/ui/src/pages/new-session/create-params.ts
+++ b/ui/src/pages/new-session/create-params.ts
@@ -39,6 +39,7 @@ export function buildDraftSessionCreateParams(draft: {
   key?: string;
   agentId: string;
   message: string;
+  label?: string;
   model?: string;
   contextWindow?: string;
   thinkingLevel?: string;
@@ -74,6 +75,9 @@ export function buildDraftSessionCreateParams(draft: {
     ...(normalizeOptionalString(draft.key) ? { key: normalizeOptionalString(draft.key) } : {}),
     agentId: normalizeAgentId(draft.agentId),
     message: draft.message,
+    ...(normalizeOptionalString(draft.label)
+      ? { label: normalizeOptionalString(draft.label) }
+      : {}),
     ...(draft.visibility === "incognito" ? { incognito: true } : {}),
     ...(draft.visibility === "draft" ? { visibility: "draft" } : {}),
     ...(draft.attachments?.length ? { attachments: draft.attachments } : {}),

--- a/ui/src/pages/new-session/draft-place-state.ts
+++ b/ui/src/pages/new-session/draft-place-state.ts
@@ -96,6 +96,7 @@ export class DraftPlaceState {
     return buildDraftSessionCreateParams({
       agentId: this.agentId,
       message: params.message,
+      displayName: params.displayName,
       model: this.modelControl.selected,
       contextWindow: this.modelControl.contextWindow,
       thinkingLevel: this.modelControl.thinkingLevel,

--- a/ui/src/pages/new-session/draft-session-startup.ts
+++ b/ui/src/pages/new-session/draft-session-startup.ts
@@ -11,9 +11,12 @@ type DraftSessionStartupIntent = {
   interrupted: boolean;
 };
 
+/** A creation attempt the submission flow resumes after reconnecting. */
+export type DraftStartupResumption = { params: SessionCreateParams; startedAt: number };
+
 type DraftSessionStartupResume =
   | { kind: "wait" | "expired" | "owner-changed" }
-  | { kind: "resume"; params: SessionCreateParams; startedAt: number };
+  | ({ kind: "resume" } & DraftStartupResumption);
 
 export class DraftSessionStartup {
   private pending: DraftSessionStartupIntent | null = null;

--- a/ui/src/pages/new-session/draft-submission-contract.ts
+++ b/ui/src/pages/new-session/draft-submission-contract.ts
@@ -8,6 +8,7 @@ export type DraftSubmissionSnapshot = Readonly<{
 }>;
 
 export type DraftSubmissionCallbacks = {
+  takePreparedTitle?: () => string | undefined;
   requestUpdate: () => void;
   closeTransientUi: () => void;
 };

--- a/ui/src/pages/new-session/draft-submission-flow.test-support.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test-support.ts
@@ -9,6 +9,7 @@ import type { NewSessionRouteData } from "./location.ts";
 import { TestReactiveControllerHost } from "./reactive-controller-host.test-support.ts";
 
 type FixtureOptions = {
+  takePreparedTitle?: () => string | undefined;
   phase?: "connected" | "connecting";
   agents?: unknown[];
   methods?: string[];
@@ -146,7 +147,7 @@ export function createDraftFixture(options: FixtureOptions = {}) {
     gateway,
     place,
     () => ({ context, data: options.data, isConnected: phase === "connected" }),
-    { requestUpdate, closeTransientUi: vi.fn() },
+    { requestUpdate, closeTransientUi: vi.fn(), takePreparedTitle: options.takePreparedTitle },
   );
   gateway.synchronize(context.gateway);
   place.setAgentsHydrated(true);

--- a/ui/src/pages/new-session/draft-submission-flow.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.ts
@@ -211,13 +211,34 @@ export class DraftSubmissionFlow {
     return canShowNewSessionTerminalStart(this.read(), Boolean(this.placement().target));
   }
 
+<<<<<<< HEAD
   private buildDraftSessionCreateParams(options: DraftSessionCreateOverrides = {}) {
     return this.place.buildSessionCreateParams({
+=======
+  private buildDraftSessionCreateParams(
+    options: Partial<Pick<SessionCreateParams, "message" | "attachments" | "label">> & {
+      visibility?: NewSessionVisibility;
+    } = {},
+  ): SessionCreateParams {
+    return assembleDraftSessionCreateParams({
+      ...options,
+      agentId: this.place.agentId,
+>>>>>>> 15f864223a2 (feat: prepare new-session names after idle typing)
       message: options.message ?? "",
       toolOverrides: this.capabilities.toolOverrides,
       permissionMode: this.permission.value,
       visibility: options.visibility ?? this.visibilityValue,
+<<<<<<< HEAD
       attachments: options.attachments,
+=======
+      projectId: this.place.browser.remoteProject?.projectId ?? this.place.browser.projectId,
+      projectGitUrl: this.place.browser.remoteProject?.cloneUrl,
+      worktree: this.place.worktree,
+      baseRef: this.place.baseRef,
+      worktreeName: this.place.worktreeName,
+      cwd: this.place.folder,
+      workspace: this.place.workspacePath(),
+>>>>>>> 15f864223a2 (feat: prepare new-session names after idle typing)
       catalogId: this.read().data?.catalogId,
       category: this.gateway.resolvedGroupCategory(),
     });
@@ -389,6 +410,7 @@ export class DraftSubmissionFlow {
       this.noteBlockedSubmitAttempt();
       return;
     }
+    const preparedTitle = this.callbacks.takePreparedTitle?.();
     this.blockedSubmitGate = null;
     const pendingPlacement = !startup && Boolean(this.pendingPlacement.sessionKey);
     const message =
@@ -471,6 +493,7 @@ export class DraftSubmissionFlow {
         startup?.params ??
         this.buildDraftSessionCreateParams({
           message: placementTarget ? "" : message,
+          label: preparedTitle,
           visibility:
             this.visibilityValue === "draft" &&
             !this.capabilities.canStartAsDraft(this.read().context)

--- a/ui/src/pages/new-session/draft-submission-flow.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.ts
@@ -28,7 +28,7 @@ import {
   projectDraftSessionPlacementRecovery,
   resolveDraftSessionPlacement,
 } from "./draft-session-placement.ts";
-import { DraftSessionStartup } from "./draft-session-startup.ts";
+import { DraftSessionStartup, type DraftStartupResumption } from "./draft-session-startup.ts";
 import type {
   DraftSubmissionCallbacks,
   DraftSubmissionSnapshot,
@@ -211,34 +211,13 @@ export class DraftSubmissionFlow {
     return canShowNewSessionTerminalStart(this.read(), Boolean(this.placement().target));
   }
 
-<<<<<<< HEAD
   private buildDraftSessionCreateParams(options: DraftSessionCreateOverrides = {}) {
     return this.place.buildSessionCreateParams({
-=======
-  private buildDraftSessionCreateParams(
-    options: Partial<Pick<SessionCreateParams, "message" | "attachments" | "label">> & {
-      visibility?: NewSessionVisibility;
-    } = {},
-  ): SessionCreateParams {
-    return assembleDraftSessionCreateParams({
       ...options,
-      agentId: this.place.agentId,
->>>>>>> 15f864223a2 (feat: prepare new-session names after idle typing)
       message: options.message ?? "",
       toolOverrides: this.capabilities.toolOverrides,
       permissionMode: this.permission.value,
       visibility: options.visibility ?? this.visibilityValue,
-<<<<<<< HEAD
-      attachments: options.attachments,
-=======
-      projectId: this.place.browser.remoteProject?.projectId ?? this.place.browser.projectId,
-      projectGitUrl: this.place.browser.remoteProject?.cloneUrl,
-      worktree: this.place.worktree,
-      baseRef: this.place.baseRef,
-      worktreeName: this.place.worktreeName,
-      cwd: this.place.folder,
-      workspace: this.place.workspacePath(),
->>>>>>> 15f864223a2 (feat: prepare new-session names after idle typing)
       catalogId: this.read().data?.catalogId,
       category: this.gateway.resolvedGroupCategory(),
     });
@@ -400,10 +379,7 @@ export class DraftSubmissionFlow {
     }
   }
 
-  async submit(
-    startup?: { params: SessionCreateParams; startedAt: number },
-    backgroundRequested = false,
-  ) {
+  async submit(startup?: DraftStartupResumption, backgroundRequested = false) {
     const background = backgroundRequested && !startup && this.visibilityValue !== "draft";
     const context = this.read().context;
     if (!context || (!startup && !this.canSubmit())) {
@@ -493,7 +469,7 @@ export class DraftSubmissionFlow {
         startup?.params ??
         this.buildDraftSessionCreateParams({
           message: placementTarget ? "" : message,
-          label: preparedTitle,
+          displayName: preparedTitle,
           visibility:
             this.visibilityValue === "draft" &&
             !this.capabilities.canStartAsDraft(this.read().context)

--- a/ui/src/pages/new-session/draft-submission-title.test.ts
+++ b/ui/src/pages/new-session/draft-submission-title.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDraftFixture } from "./draft-submission-flow.test-support.ts";
+import { NewSessionTitleController } from "./draft-title.ts";
+import { TestReactiveControllerHost } from "./reactive-controller-host.test-support.ts";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => {
+  vi.useRealTimers();
+  sessionStorage.clear();
+  localStorage.clear();
+});
+
+function titleFixture(
+  request = async (_method: string): Promise<unknown> => ({ title: "Repair naming" }),
+) {
+  const fixture = createDraftFixture({
+    methods: ["sessions.create", "sessions.title.prepare", "worktrees.branches"],
+    scopes: ["operator.read", "operator.write", "operator.admin"],
+    agents: [
+      {
+        id: "main",
+        workspace: "/workspace",
+        workspaceGit: true,
+        model: { primary: "test/primary" },
+      },
+    ],
+    request: async (method) =>
+      method === "sessions.title.prepare"
+        ? request(method)
+        : method === "worktrees.branches"
+          ? { repositoryStatus: "git", branches: [], defaultBranch: "main" }
+          : {},
+    takePreparedTitle: () => titles.takePreparedTitle(),
+  });
+  const titles = new NewSessionTitleController(new TestReactiveControllerHost(), () => ({
+    context: fixture.context,
+    data: undefined,
+    place: fixture.place,
+    submission: fixture.flow,
+    dictating: false,
+  }));
+  titles.hostConnected();
+  return { ...fixture, titles };
+}
+
+describe("prepared title creation handoff", () => {
+  it("uses a ready title at creation without changing an explicit worktree name", async () => {
+    const { flow, context, place, titles } = titleFixture();
+    place.toggleWorktree();
+    place.setWorktreeName("my-explicit-branch");
+    flow.setMessage("repair the sidebar naming");
+    titles.hostUpdated();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(flow.submitBlock()).toBeUndefined();
+    await flow.submit();
+    expect(context.sessions.createResult).toHaveBeenCalledWith(
+      expect.objectContaining({ label: "Repair naming", worktreeName: "my-explicit-branch" }),
+      { reconciliation: "background" },
+    );
+    titles.hostDisconnected();
+    flow.disconnect();
+  });
+
+  it("sends immediately while preparation is pending and ignores its late result", async () => {
+    let finish!: (value: unknown) => void;
+    const pending = new Promise((resolve) => {
+      finish = resolve;
+    });
+    const { flow, context, titles } = titleFixture(async () => pending);
+    flow.setMessage("repair the sidebar naming");
+    titles.hostUpdated();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(flow.submitBlock()).toBeUndefined();
+    await flow.submit();
+    expect(context.sessions.createResult).toHaveBeenCalledOnce();
+    expect(vi.mocked(context.sessions.createResult).mock.calls[0]?.[0]).not.toHaveProperty("label");
+    finish({ title: "Too late" });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(titles.preparedTitle()).toBeUndefined();
+    titles.hostDisconnected();
+    flow.disconnect();
+  });
+
+  it("never sends an incognito draft and discards an earlier normal suggestion", async () => {
+    const { flow, request, context, titles } = titleFixture();
+    flow.setMessage("repair the sidebar naming");
+    titles.hostUpdated();
+    await vi.advanceTimersByTimeAsync(1_000);
+    flow.setVisibility("incognito");
+    titles.hostUpdated();
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(flow.submitBlock()).toBeUndefined();
+    await flow.submit();
+    expect(
+      request.mock.calls.filter(([method]) => method === "sessions.title.prepare"),
+    ).toHaveLength(1);
+    expect(vi.mocked(context.sessions.createResult).mock.calls[0]?.[0]).toMatchObject({
+      incognito: true,
+    });
+    expect(vi.mocked(context.sessions.createResult).mock.calls[0]?.[0]).not.toHaveProperty("label");
+    titles.hostDisconnected();
+    flow.disconnect();
+  });
+
+  it("rejects a stale title even when Send beats the next UI update", async () => {
+    const { flow, context, titles } = titleFixture();
+    flow.setMessage("repair the sidebar naming");
+    titles.hostUpdated();
+    await vi.advanceTimersByTimeAsync(1_000);
+    flow.setMessage("investigate a different reconnect bug");
+    expect(flow.submitBlock()).toBeUndefined();
+    await flow.submit();
+    expect(vi.mocked(context.sessions.createResult).mock.calls[0]?.[0]).not.toHaveProperty("label");
+    titles.hostDisconnected();
+    flow.disconnect();
+  });
+});

--- a/ui/src/pages/new-session/draft-submission-title.test.ts
+++ b/ui/src/pages/new-session/draft-submission-title.test.ts
@@ -102,6 +102,22 @@ describe("prepared title creation handoff", () => {
     flow.disconnect();
   });
 
+  it("does not restart speculation when a submitted draft is retried", async () => {
+    const { flow, request, titles } = titleFixture();
+    flow.setMessage("repair the sidebar naming");
+    titles.hostUpdated();
+    await vi.advanceTimersByTimeAsync(1_000);
+    await flow.submit();
+    await flow.submit();
+    titles.hostUpdated();
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(
+      request.mock.calls.filter(([method]) => method === "sessions.title.prepare"),
+    ).toHaveLength(1);
+    titles.hostDisconnected();
+    flow.disconnect();
+  });
+
   it("rejects a stale title even when Send beats the next UI update", async () => {
     const { flow, context, titles } = titleFixture();
     flow.setMessage("repair the sidebar naming");

--- a/ui/src/pages/new-session/draft-submission-title.test.ts
+++ b/ui/src/pages/new-session/draft-submission-title.test.ts
@@ -54,7 +54,7 @@ describe("prepared title creation handoff", () => {
     expect(flow.submitBlock()).toBeUndefined();
     await flow.submit();
     expect(context.sessions.createResult).toHaveBeenCalledWith(
-      expect.objectContaining({ label: "Repair naming", worktreeName: "my-explicit-branch" }),
+      expect.objectContaining({ displayName: "Repair naming", worktreeName: "my-explicit-branch" }),
       { reconciliation: "background" },
     );
     titles.hostDisconnected();
@@ -73,7 +73,9 @@ describe("prepared title creation handoff", () => {
     expect(flow.submitBlock()).toBeUndefined();
     await flow.submit();
     expect(context.sessions.createResult).toHaveBeenCalledOnce();
-    expect(vi.mocked(context.sessions.createResult).mock.calls[0]?.[0]).not.toHaveProperty("label");
+    expect(vi.mocked(context.sessions.createResult).mock.calls[0]?.[0]).not.toHaveProperty(
+      "displayName",
+    );
     finish({ title: "Too late" });
     await vi.advanceTimersByTimeAsync(0);
     expect(titles.preparedTitle()).toBeUndefined();
@@ -97,7 +99,9 @@ describe("prepared title creation handoff", () => {
     expect(vi.mocked(context.sessions.createResult).mock.calls[0]?.[0]).toMatchObject({
       incognito: true,
     });
-    expect(vi.mocked(context.sessions.createResult).mock.calls[0]?.[0]).not.toHaveProperty("label");
+    expect(vi.mocked(context.sessions.createResult).mock.calls[0]?.[0]).not.toHaveProperty(
+      "displayName",
+    );
     titles.hostDisconnected();
     flow.disconnect();
   });
@@ -126,7 +130,9 @@ describe("prepared title creation handoff", () => {
     flow.setMessage("investigate a different reconnect bug");
     expect(flow.submitBlock()).toBeUndefined();
     await flow.submit();
-    expect(vi.mocked(context.sessions.createResult).mock.calls[0]?.[0]).not.toHaveProperty("label");
+    expect(vi.mocked(context.sessions.createResult).mock.calls[0]?.[0]).not.toHaveProperty(
+      "displayName",
+    );
     titles.hostDisconnected();
     flow.disconnect();
   });

--- a/ui/src/pages/new-session/draft-title.test.ts
+++ b/ui/src/pages/new-session/draft-title.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { DraftTitlePreparation } from "./draft-title.ts";
+
+beforeEach(() => vi.useFakeTimers());
+afterEach(() => vi.useRealTimers());
+
+function fixture() {
+  const request = vi.fn().mockResolvedValue({ title: "Repair sidebar naming" });
+  const input = { client: { request }, agentId: "main", message: "repair the sidebar naming" };
+  return { request, input, titles: new DraftTitlePreparation(vi.fn()) };
+}
+
+describe("creation draft title preparation", () => {
+  it("coalesces idle edits and reuses unchanged text without polling", async () => {
+    const { request, input, titles } = fixture();
+    titles.sync(input);
+    await vi.advanceTimersByTimeAsync(900);
+    const edited = { ...input, message: "repair sidebar naming and previews" };
+    titles.sync(edited);
+    await vi.advanceTimersByTimeAsync(900);
+    expect(request).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(titles.titleFor(edited)).toBe("Repair sidebar naming");
+    expect(titles.titleFor(input)).toBeUndefined();
+    titles.sync({ ...edited, message: ` ${edited.message} ` });
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it("serializes edits behind an active request and discards the stale result", async () => {
+    const { request, input, titles } = fixture();
+    let finish!: (value: { title: string }) => void;
+    request.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        }),
+    );
+    titles.sync(input);
+    await vi.advanceTimersByTimeAsync(1_000);
+    const edited = { ...input, message: "change the topic to reconnect recovery" };
+    titles.sync(edited);
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(request).toHaveBeenCalledOnce();
+    finish({ title: "Old draft" });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(titles.titleFor(edited)).toBe("Repair sidebar naming");
+  });
+
+  it("retires pending results when the draft owner closes", async () => {
+    const { request, input, titles } = fixture();
+    let finish!: (value: { title: string }) => void;
+    request.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        }),
+    );
+    titles.sync(input);
+    await vi.advanceTimersByTimeAsync(1_000);
+    titles.sync(null);
+    finish({ title: "Must not apply" });
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(titles.titleFor(input)).toBeUndefined();
+    expect(request).toHaveBeenCalledOnce();
+  });
+
+  it("does not retry failures until the draft changes", async () => {
+    const { request, input, titles } = fixture();
+    request.mockRejectedValueOnce(new Error("provider unavailable"));
+    titles.sync(input);
+    await vi.advanceTimersByTimeAsync(1_000);
+    titles.sync(input);
+    await vi.advanceTimersByTimeAsync(30_000);
+    expect(request).toHaveBeenCalledOnce();
+    expect(titles.titleFor(input)).toBeUndefined();
+  });
+
+  it("bounds source text without splitting Unicode and keeps model selection scoped", async () => {
+    const { request, input, titles } = fixture();
+    titles.sync({ ...input, message: "a".repeat(999) + "🦞more", model: "test/utility" });
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(request).toHaveBeenCalledWith(
+      "sessions.title.prepare",
+      {
+        agentId: "main",
+        message: "a".repeat(999),
+        model: "test/utility",
+      },
+      { timeoutMs: 20_000 },
+    );
+    expect(titles.titleFor({ ...input, agentId: "other" })).toBeUndefined();
+    expect(titles.titleFor({ ...input, client: { request: vi.fn() } })).toBeUndefined();
+  });
+
+  it.each(["", "short", "/help command"])("skips ineligible source %j", async (message) => {
+    const { request, input, titles } = fixture();
+    titles.sync({ ...input, message });
+    await vi.advanceTimersByTimeAsync(2_000);
+    expect(request).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/pages/new-session/draft-title.ts
+++ b/ui/src/pages/new-session/draft-title.ts
@@ -1,0 +1,184 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { ApplicationContext } from "../../app/context.ts";
+import { canCallGatewayMethod } from "../../lib/gateway-methods.ts";
+import { routeKey } from "./catalog-target.ts";
+import type { DraftPlaceState } from "./draft-place-state.ts";
+import type { DraftSubmissionFlow } from "./draft-submission-flow.ts";
+import type { NewSessionRouteData } from "./location.ts";
+
+type DraftTitleInput = {
+  client: Pick<GatewayBrowserClient, "request">;
+  agentId: string;
+  ownerKey?: string;
+  message: string;
+  model?: string;
+  catalogId?: string;
+};
+
+function sameDraft(left: DraftTitleInput | null, right: DraftTitleInput | null): boolean {
+  return (
+    left?.client === right?.client &&
+    left?.agentId === right?.agentId &&
+    left?.ownerKey === right?.ownerKey &&
+    left?.message === right?.message &&
+    left?.model === right?.model &&
+    left?.catalogId === right?.catalogId
+  );
+}
+
+/** Disposable creation-only speculation; never owns a session or a metadata write. */
+export class DraftTitlePreparation {
+  private current: DraftTitleInput | null = null;
+  private title: string | null = null;
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private active = false;
+  private pending = false;
+  private readyAt = 0;
+
+  constructor(private readonly requestUpdate: () => void) {}
+
+  sync(input: DraftTitleInput | null) {
+    const message = input?.message.trim() ?? "";
+    const next =
+      input && message.length >= 12 && !message.startsWith("/") ? { ...input, message } : null;
+    if (sameDraft(this.current, next)) {
+      return;
+    }
+    clearTimeout(this.timer);
+    this.current = next;
+    this.title = null;
+    this.pending = next !== null;
+    this.readyAt = Date.now() + 1_000;
+    this.schedule();
+  }
+
+  titleFor(input: DraftTitleInput | null): string | undefined {
+    const next = input ? { ...input, message: input.message.trim() } : null;
+    return sameDraft(this.current, next) ? (this.title ?? undefined) : undefined;
+  }
+
+  private schedule() {
+    if (!this.pending || this.active) {
+      return;
+    }
+    this.timer = setTimeout(() => void this.prepare(), Math.max(0, this.readyAt - Date.now()));
+  }
+
+  private async prepare() {
+    const current = this.current;
+    if (!current || !this.pending) {
+      return;
+    }
+    this.pending = false;
+    this.active = true;
+    try {
+      const result = await current.client.request<{ title: string | null }>(
+        "sessions.title.prepare",
+        {
+          agentId: current.agentId,
+          message: truncateUtf16Safe(current.message, 1_000),
+          ...(current.catalogId ? { catalogId: current.catalogId } : {}),
+          ...(!current.catalogId && current.model ? { model: current.model } : {}),
+        },
+        { timeoutMs: 20_000 },
+      );
+      // Object identity fences edits, route changes, privacy changes, and teardown,
+      // including a draft that changes away and then back during the request.
+      if (this.current === current) {
+        this.title = result.title;
+        this.requestUpdate();
+      }
+    } catch {
+      // Speculation must never block Send or leak a provider error into the draft.
+      // An unchanged failed draft is not retried until the operator edits it.
+    } finally {
+      this.active = false;
+      this.schedule();
+    }
+  }
+}
+
+/** Connects disposable title work to the new-session page, never the chat route. */
+export class NewSessionTitleController implements ReactiveController {
+  private readonly preparation: DraftTitlePreparation;
+  private connected = false;
+  private composing = false;
+  private submitted: DraftTitleInput | null = null;
+
+  constructor(
+    host: ReactiveControllerHost,
+    private readonly read: () => {
+      context: ApplicationContext | undefined;
+      data: NewSessionRouteData | undefined;
+      place: DraftPlaceState;
+      submission: DraftSubmissionFlow;
+      dictating: boolean;
+    },
+  ) {
+    this.preparation = new DraftTitlePreparation(() => host.requestUpdate());
+    host.addController(this);
+  }
+
+  hostConnected() {
+    this.connected = true;
+  }
+  hostUpdated() {
+    this.preparation.sync(this.input());
+  }
+  hostDisconnected() {
+    this.connected = false;
+    this.preparation.sync(null);
+    this.submitted = null;
+  }
+
+  setComposing(composing: boolean) {
+    this.composing = composing;
+    this.hostUpdated();
+  }
+
+  available(): boolean {
+    return this.input() !== null;
+  }
+  preparedTitle(): string | undefined {
+    return this.preparation.titleFor(this.input());
+  }
+
+  takePreparedTitle(): string | undefined {
+    const input = this.input();
+    const title = this.preparation.titleFor(input);
+    this.submitted = input;
+    this.preparation.sync(null);
+    return title;
+  }
+
+  private input(): DraftTitleInput | null {
+    const { context, data, place, submission, dictating } = this.read();
+    const snapshot = context?.gateway.snapshot;
+    if (
+      !this.connected ||
+      this.composing ||
+      dictating ||
+      submission.submitting ||
+      submission.visibility === "incognito" ||
+      submission.pendingPlacement.sessionKey ||
+      !place.agentId ||
+      !canCallGatewayMethod(snapshot, "sessions.title.prepare", "operator.write") ||
+      !snapshot?.client
+    ) {
+      return null;
+    }
+    const input = {
+      client: snapshot.client,
+      ownerKey: routeKey(data),
+      agentId: place.agentId,
+      message: submission.message.trim(),
+      model: data?.catalogId ? undefined : place.modelControl.selected,
+      catalogId: data?.catalogId || undefined,
+    };
+    // A failed navigation/retry may leave this page mounted after creation. The
+    // submitted draft cannot start more inference; only a new draft can do so.
+    return sameDraft(input, this.submitted) ? null : input;
+  }
+}

--- a/ui/src/pages/new-session/draft-title.ts
+++ b/ui/src/pages/new-session/draft-title.ts
@@ -148,7 +148,7 @@ export class NewSessionTitleController implements ReactiveController {
   takePreparedTitle(): string | undefined {
     const input = this.input();
     const title = this.preparation.titleFor(input);
-    this.submitted = input;
+    this.submitted = input ?? this.submitted;
     this.preparation.sync(null);
     return title;
   }

--- a/ui/src/pages/new-session/draft-view.ts
+++ b/ui/src/pages/new-session/draft-view.ts
@@ -57,6 +57,11 @@ export function renderNewSessionDraftView(options: {
       @compositionend=${() => {
         titlePreparation.setComposing(false);
       }}
+      @focusout=${() => {
+        // Browsers can drop compositionend on blur/detach mid-IME; a stuck
+        // composing flag would silently disable naming for the mounted page.
+        titlePreparation.setComposing(false);
+      }}
     >
       ${renderTargetBar()}
       ${worktreeNameInvalid ? renderDraftError(t("newSession.worktreeNameInvalid")) : nothing}

--- a/ui/src/pages/new-session/draft-view.ts
+++ b/ui/src/pages/new-session/draft-view.ts
@@ -1,0 +1,146 @@
+import { html, nothing, type TemplateResult } from "lit";
+import type { ApplicationContext } from "../../app/context.ts";
+import { loadSettings } from "../../app/settings.ts";
+import type { ImageLightboxItem } from "../../components/image-lightbox.ts";
+import { t } from "../../i18n/index.ts";
+import { renderChatPermissionPicker } from "../chat/components/chat-permission-picker.ts";
+import type { NewSessionDictationControl } from "./composer-dictation-control.ts";
+import { renderDraftError } from "./composer.ts";
+import { isWorktreeNameValid } from "./create-params.ts";
+import { renderNewSessionDraftComposer } from "./draft-composer.ts";
+import type { DraftGatewayState } from "./draft-gateway-state.ts";
+import type { DraftPlaceState } from "./draft-place-state.ts";
+import type { DraftSubmissionFlow } from "./draft-submission-flow.ts";
+import type { NewSessionTitleController } from "./draft-title.ts";
+import { renderNewSessionIncognitoNotice } from "./incognito-control.ts";
+
+export function renderNewSessionDraftView(options: {
+  context: ApplicationContext | undefined;
+  gateway: DraftGatewayState;
+  place: DraftPlaceState;
+  submission: DraftSubmissionFlow;
+  dictation: NewSessionDictationControl;
+  titlePreparation: NewSessionTitleController;
+  draftOwnerKey: string;
+  isCatalogTarget: boolean;
+  renderTargetBar: () => TemplateResult;
+  requestUpdate: () => void;
+  onMessage: (message: string) => void;
+  onOpenImage: (item: ImageLightboxItem) => void;
+}) {
+  const {
+    context,
+    gateway,
+    place,
+    submission,
+    dictation,
+    titlePreparation,
+    draftOwnerKey,
+    isCatalogTarget,
+    renderTargetBar,
+    requestUpdate,
+    onMessage,
+    onOpenImage,
+  } = options;
+  const worktreeNameInvalid = place.worktree && !isWorktreeNameValid(place.worktreeName);
+  const capabilities = submission.capabilities;
+  const voiceControl = dictation.render(draftOwnerKey);
+  const dictationLocked = dictation.active;
+  const preparedTitle = titlePreparation.preparedTitle();
+  return html`
+    <div
+      class="new-session-page__draft"
+      aria-busy=${String(submission.submitting)}
+      @compositionstart=${() => {
+        titlePreparation.setComposing(true);
+      }}
+      @compositionend=${() => {
+        titlePreparation.setComposing(false);
+      }}
+    >
+      ${renderTargetBar()}
+      ${worktreeNameInvalid ? renderDraftError(t("newSession.worktreeNameInvalid")) : nothing}
+      ${submission.submissionOutcomeUnknown
+        ? renderDraftError(
+            t(
+              submission.submissionOutcomeUnknown === "gateway-changed"
+                ? "newSession.createOutcomeUnknown"
+                : "newSession.placementSetupInterrupted",
+            ),
+            submission.pendingPlacement.sessionKey
+              ? {
+                  label: t("common.reset"),
+                  onClick: () => submission.clearPendingPlacementRecovery(),
+                }
+              : undefined,
+          )
+        : nothing}
+      ${renderNewSessionDraftComposer({
+        agent: place.selectedAgent(),
+        agentId: place.agentId,
+        attachmentDraft: submission.attachmentDraft,
+        canSubmit: !submission.submitting && !dictationLocked && submission.canSubmit(),
+        submitDisabledReason: submission.submitDisabledReason(),
+        blockedSubmitNotice: submission.blockedSubmitNotice(),
+        dictationActive: dictation.active,
+        dictationPreview: dictation.previewDraft(),
+        dictationStatus: dictation.renderStatus(),
+        context,
+        isCatalogTarget,
+        draftOwnerKey,
+        message: submission.message,
+        visibility: submission.visibility,
+        draftAvailable: capabilities.canStartAsDraft(context),
+        ...capabilities.composerProps(context, gateway, place.agentId),
+        modelControl: place.modelControl,
+        permissionControl: isCatalogTarget
+          ? undefined
+          : renderChatPermissionPicker({
+              canSelectFull: place.isAdmin(),
+              defaultMode: place.selectedAgent()?.defaultPermissionMode,
+              disabled: submission.submitting || Boolean(submission.pendingPlacement.sessionKey),
+              disabledReason: submission.submitting ? t("newSession.starting") : undefined,
+              mode: submission.permission.value,
+              onSelect: (permissionMode) => submission.permission.set(permissionMode ?? undefined),
+            }),
+        requiresModifier: loadSettings().chatSendShortcut === "modifier-enter",
+        requestUpdate,
+        submitting: submission.submitting,
+        textareaController: submission.composerTextarea,
+        voiceControl,
+        messageLocked: Boolean(submission.pendingPlacement.sessionKey),
+        terminalAction: submission.showStartInTerminal()
+          ? {
+              canStart:
+                !submission.submitting && !dictationLocked && submission.canSubmit("terminal"),
+              disabledReason: submission.submitBlock("terminal")?.reason,
+              onStart: () => void submission.startInTerminal(),
+            }
+          : undefined,
+        onInput: onMessage,
+        onOpenImage,
+        onVisibilityChange: (visibility) => {
+          if (!submission.submitting && !submission.pendingPlacement.sessionKey) {
+            submission.setVisibility(visibility);
+          }
+        },
+        onSubmit: () => void submission.submit(),
+        onBackgroundSubmit:
+          submission.visibility === "draft"
+            ? undefined
+            : () => void submission.submit(undefined, true),
+      })}
+      ${titlePreparation.available()
+        ? html`<div class="new-session-page__title-notice">
+            <span>${t("newSession.titlePreparationDisclosure")}</span>
+            ${preparedTitle
+              ? html`<span class="new-session-page__prepared-title" role="status"
+                  >${t("newSession.preparedTitle", { title: preparedTitle })}</span
+                >`
+              : nothing}
+          </div>`
+        : nothing}
+      ${renderNewSessionIncognitoNotice(submission.visibility === "incognito")}
+    </div>
+  `;
+}

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -3,7 +3,6 @@ import { html, nothing } from "lit";
 import { property, state } from "lit/decorators.js";
 import { selectApplicationSession } from "../../app/agent-selection.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
-import { loadSettings } from "../../app/settings.ts";
 import { readPresenceEntries } from "../../app/user-profile.ts";
 import type { ImageLightboxItem } from "../../components/image-lightbox.ts";
 import { t } from "../../i18n/index.ts";
@@ -18,24 +17,20 @@ import "../../styles/chat.css";
 import "../../styles/new-session.css";
 import { focusChatComposerFromPrintableKeydown } from "../chat/chat-pane-shared.ts";
 import { renderChatImageLightbox } from "../chat/components/chat-image-lightbox.ts";
-import { renderChatPermissionPicker } from "../chat/components/chat-permission-picker.ts";
 import { renderWelcomeState } from "../chat/components/chat-welcome.ts";
 import * as catalog from "./catalog-target.ts";
 import { NewSessionDictationControl } from "./composer-dictation-control.ts";
-import { renderDraftError } from "./composer.ts";
 import { ConnectMachineSetupState, renderConnectMachineDialog } from "./connect-machine-dialog.ts";
-import { isWorktreeNameValid } from "./create-params.ts";
 import { renderDetailChip, resolveDetailChip } from "./detail-chip.ts";
-import { renderNewSessionBody, renderNewSessionDraftComposer } from "./draft-composer.ts";
+import { renderNewSessionBody } from "./draft-composer.ts";
 import { DraftGatewayState } from "./draft-gateway-state.ts";
 import * as drafts from "./draft-navigation-handoff.ts";
 import { DraftPlaceBrowser } from "./draft-place-browser.ts";
 import { DraftPlaceState } from "./draft-place-state.ts";
 import { DraftSubmissionFlow } from "./draft-submission-flow.ts";
-import {
-  renderNewSessionIncognitoControl,
-  renderNewSessionIncognitoNotice,
-} from "./incognito-control.ts";
+import { NewSessionTitleController } from "./draft-title.ts";
+import { renderNewSessionDraftView } from "./draft-view.ts";
+import { renderNewSessionIncognitoControl } from "./incognito-control.ts";
 import type { NewSessionRouteData } from "./location.ts";
 import {
   closeAgentPicker,
@@ -65,7 +60,6 @@ export class NewSessionPage extends OpenClawLightDomElement {
   private presenceSignature = "";
   private readonly connectMachine: ConnectMachineSetupState;
   @state() private imageLightbox: ImageLightboxItem | null = null;
-  @state() private agentPickerOpen = false;
   private readonly groupRouteRevalidation = new catalog.GroupRouteRevalidation(
     () => this.data,
     () => this.context?.revalidate("new-session"),
@@ -76,6 +70,13 @@ export class NewSessionPage extends OpenClawLightDomElement {
   private readonly submission: DraftSubmissionFlow;
   private readonly dictation: NewSessionDictationControl;
   private readonly subscriptions: SubscriptionsController;
+  private readonly titlePreparation = new NewSessionTitleController(this, () => ({
+    context: this.context,
+    data: this.data,
+    place: this.place,
+    submission: this.submission,
+    dictating: this.dictation.active,
+  }));
   private readonly flushDraft = () => this.submission.draftPersistence.persistNow();
   private readonly setImageLightbox = (item: ImageLightboxItem | null) => {
     this.imageLightbox = item;
@@ -159,6 +160,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
       {
         requestUpdate: () => this.requestUpdate(),
         closeTransientUi: () => closeSessionMenus(this),
+        takePreparedTitle: () => this.titlePreparation.takePreparedTitle(),
       },
     );
     this.connectMachine = new ConnectMachineSetupState(
@@ -192,7 +194,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
               return;
             }
             if (isPlaceTopologyEvent(event.event)) {
-              void this.gateway.refreshCloudProfiles();
+              this.refreshPlaceTopology();
               return;
             }
             const presence = event.event === "presence" ? readPresenceEntries(event.payload) : null;
@@ -202,7 +204,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
             const signature = presenceStateSignature(presence);
             if (signature !== this.presenceSignature) {
               this.presenceSignature = signature;
-              void this.gateway.refreshCloudProfiles();
+              this.refreshPlaceTopology();
             }
           });
         },
@@ -224,6 +226,10 @@ export class NewSessionPage extends OpenClawLightDomElement {
         () => this.context?.config,
         (config, notify) => config.subscribe(() => notify()),
       );
+  }
+
+  private refreshPlaceTopology() {
+    void this.gateway.refreshCloudProfiles();
   }
 
   handleEvent(event: Event) {
@@ -263,9 +269,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
       this.connectMachine.close();
     }
     this.gateway.retryPendingCatalogTarget();
-    void this.context?.agentIdentity.ensure(
-      this.agentPickerOpen ? this.place.agents().map((agent) => agent.id) : [this.place.agentId],
-    );
+    void this.context?.agentIdentity.ensure(this.place.agents().map((agent) => agent.id));
     const agentState = this.context?.agents.state;
     const agentsReady = Boolean(
       this.gateway.connected &&
@@ -345,11 +349,25 @@ export class NewSessionPage extends OpenClawLightDomElement {
       : catalog.routeKeyFromSearch(window.location.search);
   }
 
+  private setMessage(message: string, ownerKey = catalog.routeKey(this.data)) {
+    this.submission.setMessage(message);
+    this.messageOwnerKey = ownerKey;
+  }
+
   private setMessageFromUser(message: string) {
     if (!this.submission.submitting && !this.submission.pendingPlacement.sessionKey) {
-      this.submission.setMessage(message);
-      this.messageOwnerKey = catalog.routeKeyFromSearch(window.location.search);
+      this.setMessage(message, catalog.routeKeyFromSearch(window.location.search));
     }
+  }
+
+  private renderAgentSelect() {
+    return renderAgentSelect({
+      agents: this.place.agents(),
+      agentId: this.place.agentId,
+      agentIdentity: this.context?.agentIdentity,
+      disabled: this.submission.submitting || Boolean(this.submission.pendingPlacement.sessionKey),
+      onSelect: (agentId) => this.place.selectAgentId(agentId),
+    });
   }
 
   private renderTargetBar() {
@@ -358,20 +376,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
     return catalog.renderBar({
       data: this.data,
       groupPending: catalog.isGroupRoutePending(this.data, sessions),
-      agentSelect:
-        agents.length > 1
-          ? renderAgentSelect({
-              agents,
-              agentId: this.place.agentId,
-              agentIdentity: this.context?.agentIdentity,
-              disabled:
-                this.submission.submitting || Boolean(this.submission.pendingPlacement.sessionKey),
-              onSelect: (agentId) => this.place.selectAgentId(agentId),
-              onOpenChange: (open) => {
-                this.agentPickerOpen = open;
-              },
-            })
-          : nothing,
+      agentSelect: agents.length > 1 ? this.renderAgentSelect() : nothing,
       placeSelect: this.renderPlaceChips(),
       retrying:
         this.gateway.catalogRetrying ||
@@ -538,93 +543,22 @@ export class NewSessionPage extends OpenClawLightDomElement {
   }
 
   private renderDraftBlock() {
-    const worktreeNameInvalid =
-      this.place.worktree && !isWorktreeNameValid(this.place.worktreeName);
-    const capabilities = this.submission.capabilities;
-    const voiceControl = this.dictation.render(this.routeOwnerKey());
-    const dictationLocked = this.dictation.active;
-    return html`
-      <div class="new-session-page__draft" aria-busy=${String(this.submission.submitting)}>
-        ${this.renderTargetBar()}
-        ${worktreeNameInvalid ? renderDraftError(t("newSession.worktreeNameInvalid")) : nothing}
-        ${this.submission.submissionOutcomeUnknown
-          ? renderDraftError(
-              t(
-                this.submission.submissionOutcomeUnknown === "gateway-changed"
-                  ? "newSession.createOutcomeUnknown"
-                  : "newSession.placementSetupInterrupted",
-              ),
-              this.submission.pendingPlacement.sessionKey
-                ? {
-                    label: t("common.reset"),
-                    onClick: () => this.submission.clearPendingPlacementRecovery(),
-                  }
-                : undefined,
-            )
-          : nothing}
-        ${renderNewSessionDraftComposer({
-          agent: this.place.selectedAgent(),
-          agentId: this.place.agentId,
-          attachmentDraft: this.submission.attachmentDraft,
-          canSubmit: !this.submission.submitting && !dictationLocked && this.submission.canSubmit(),
-          submitDisabledReason: this.submission.submitDisabledReason(),
-          blockedSubmitNotice: this.submission.blockedSubmitNotice(),
-          dictationActive: this.dictation.active,
-          dictationPreview: this.dictation.previewDraft(),
-          dictationStatus: this.dictation.renderStatus(),
-          context: this.context,
-          isCatalogTarget: catalog.isTarget(this.data),
-          draftOwnerKey: this.routeOwnerKey(),
-          message: this.submission.message,
-          visibility: this.submission.visibility,
-          draftAvailable: capabilities.canStartAsDraft(this.context),
-          ...capabilities.composerProps(this.context, this.gateway, this.place.agentId),
-          modelControl: this.place.modelControl,
-          permissionControl: catalog.isTarget(this.data)
-            ? undefined
-            : renderChatPermissionPicker({
-                canSelectFull: this.place.isAdmin(),
-                defaultMode: this.place.selectedAgent()?.defaultPermissionMode,
-                disabled:
-                  this.submission.submitting ||
-                  Boolean(this.submission.pendingPlacement.sessionKey),
-                disabledReason: this.submission.submitting ? t("newSession.starting") : undefined,
-                mode: this.submission.permission.value,
-                onSelect: (permissionMode) =>
-                  this.submission.permission.set(permissionMode ?? undefined),
-              }),
-          requiresModifier: loadSettings().chatSendShortcut === "modifier-enter",
-          requestUpdate: () => this.requestUpdate(),
-          submitting: this.submission.submitting,
-          textareaController: this.submission.composerTextarea,
-          voiceControl,
-          messageLocked: Boolean(this.submission.pendingPlacement.sessionKey),
-          terminalAction: this.submission.showStartInTerminal()
-            ? {
-                canStart:
-                  !this.submission.submitting &&
-                  !dictationLocked &&
-                  this.submission.canSubmit("terminal"),
-                disabledReason: this.submission.submitBlock("terminal")?.reason,
-                onStart: () => void this.submission.startInTerminal(),
-              }
-            : undefined,
-          onInput: (message) => this.setMessageFromUser(message),
-          onOpenImage: this.setImageLightbox,
-          onVisibilityChange: (visibility) => {
-            if (!this.submission.submitting && !this.submission.pendingPlacement.sessionKey) {
-              this.submission.setVisibility(visibility);
-            }
-          },
-          onSubmit: () => void this.submission.submit(),
-          onBackgroundSubmit:
-            this.submission.visibility === "draft"
-              ? undefined
-              : () => void this.submission.submit(undefined, true),
-        })}
-        ${renderNewSessionIncognitoNotice(this.submission.visibility === "incognito")}
-      </div>
-    `;
+    return renderNewSessionDraftView({
+      context: this.context,
+      gateway: this.gateway,
+      place: this.place,
+      submission: this.submission,
+      dictation: this.dictation,
+      titlePreparation: this.titlePreparation,
+      draftOwnerKey: this.routeOwnerKey(),
+      isCatalogTarget: catalog.isTarget(this.data),
+      renderTargetBar: () => this.renderTargetBar(),
+      requestUpdate: () => this.requestUpdate(),
+      onMessage: (message) => this.setMessageFromUser(message),
+      onOpenImage: (item) => {
+        this.imageLightbox = item;
+      },
+    });
   }
 
   private renderWelcome() {

--- a/ui/src/pages/new-session/new-session-page.ts
+++ b/ui/src/pages/new-session/new-session-page.ts
@@ -60,6 +60,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
   private presenceSignature = "";
   private readonly connectMachine: ConnectMachineSetupState;
   @state() private imageLightbox: ImageLightboxItem | null = null;
+  @state() private agentPickerOpen = false;
   private readonly groupRouteRevalidation = new catalog.GroupRouteRevalidation(
     () => this.data,
     () => this.context?.revalidate("new-session"),
@@ -194,7 +195,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
               return;
             }
             if (isPlaceTopologyEvent(event.event)) {
-              this.refreshPlaceTopology();
+              void this.gateway.refreshCloudProfiles();
               return;
             }
             const presence = event.event === "presence" ? readPresenceEntries(event.payload) : null;
@@ -204,7 +205,7 @@ export class NewSessionPage extends OpenClawLightDomElement {
             const signature = presenceStateSignature(presence);
             if (signature !== this.presenceSignature) {
               this.presenceSignature = signature;
-              this.refreshPlaceTopology();
+              void this.gateway.refreshCloudProfiles();
             }
           });
         },
@@ -226,10 +227,6 @@ export class NewSessionPage extends OpenClawLightDomElement {
         () => this.context?.config,
         (config, notify) => config.subscribe(() => notify()),
       );
-  }
-
-  private refreshPlaceTopology() {
-    void this.gateway.refreshCloudProfiles();
   }
 
   handleEvent(event: Event) {
@@ -269,7 +266,9 @@ export class NewSessionPage extends OpenClawLightDomElement {
       this.connectMachine.close();
     }
     this.gateway.retryPendingCatalogTarget();
-    void this.context?.agentIdentity.ensure(this.place.agents().map((agent) => agent.id));
+    void this.context?.agentIdentity.ensure(
+      this.agentPickerOpen ? this.place.agents().map((agent) => agent.id) : [this.place.agentId],
+    );
     const agentState = this.context?.agents.state;
     const agentsReady = Boolean(
       this.gateway.connected &&
@@ -349,25 +348,11 @@ export class NewSessionPage extends OpenClawLightDomElement {
       : catalog.routeKeyFromSearch(window.location.search);
   }
 
-  private setMessage(message: string, ownerKey = catalog.routeKey(this.data)) {
-    this.submission.setMessage(message);
-    this.messageOwnerKey = ownerKey;
-  }
-
   private setMessageFromUser(message: string) {
     if (!this.submission.submitting && !this.submission.pendingPlacement.sessionKey) {
-      this.setMessage(message, catalog.routeKeyFromSearch(window.location.search));
+      this.submission.setMessage(message);
+      this.messageOwnerKey = catalog.routeKeyFromSearch(window.location.search);
     }
-  }
-
-  private renderAgentSelect() {
-    return renderAgentSelect({
-      agents: this.place.agents(),
-      agentId: this.place.agentId,
-      agentIdentity: this.context?.agentIdentity,
-      disabled: this.submission.submitting || Boolean(this.submission.pendingPlacement.sessionKey),
-      onSelect: (agentId) => this.place.selectAgentId(agentId),
-    });
   }
 
   private renderTargetBar() {
@@ -376,7 +361,20 @@ export class NewSessionPage extends OpenClawLightDomElement {
     return catalog.renderBar({
       data: this.data,
       groupPending: catalog.isGroupRoutePending(this.data, sessions),
-      agentSelect: agents.length > 1 ? this.renderAgentSelect() : nothing,
+      agentSelect:
+        agents.length > 1
+          ? renderAgentSelect({
+              agents,
+              agentId: this.place.agentId,
+              agentIdentity: this.context?.agentIdentity,
+              disabled:
+                this.submission.submitting || Boolean(this.submission.pendingPlacement.sessionKey),
+              onSelect: (agentId) => this.place.selectAgentId(agentId),
+              onOpenChange: (open) => {
+                this.agentPickerOpen = open;
+              },
+            })
+          : nothing,
       placeSelect: this.renderPlaceChips(),
       retrying:
         this.gateway.catalogRetrying ||

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -1276,3 +1276,15 @@ wa-popover.new-session-page__project-popover::part(body) {
     max-height: 48px;
   }
 }
+
+.new-session-page__title-notice {
+  display: grid;
+  gap: 4px;
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.new-session-page__prepared-title {
+  color: var(--text);
+}


### PR DESCRIPTION
Closes #133702 — creation-only idle draft title preparation.
Related: #131582 — sidebar-derived worktree publication naming (separate, still open).

<details>
<summary>Additional instructions</summary>

Maintainers can push to this same-repository branch.

</details>

## What Problem This Solves

New-session naming begins only after submission, even when the operator pauses while composing a useful initial prompt. Prepare a matching name during that idle time without ever renaming ongoing conversations.

## Why This Change Was Made

The New session page waits for one second of idle typing (at least 12 characters), then requests a bounded title from the existing utility model through the new authenticated `sessions.title.prepare` method. One request is active per draft controller; edits coalesce, stale results are ignored, and unchanged failed input is not polled. Start never waits for this speculative call; if it is not ready, the existing initial naming flow remains responsible.

A ready result is handed to `sessions.create` as the new additive `displayName` param, the same presentation-title field the post-creation title generator and native owners already write. It is deliberately **not** sent as `label`: labels are unique per agent store and rejected on collision (`label already in use`), so a prepared title equal to an existing session's label would have failed creation outright, and labels also read as operator-explicit names. `displayName` is bounded by the existing create-service snapshot (500 UTF-16 units), never claims a label, is ignored when adopting an existing key, and still short-circuits the post-creation generator and seeds the derived worktree branch name exactly like a generated first-message title.

The endpoint reuses creation agent/model/catalog policy, uses only the utility model, preserves provider/profile/runtime ownership, and applies the existing 30/minute per-method/device-IP control-plane write budget. No primary-model fallback, session mutation, worktree setup, new storage, configuration option, or schema/protocol version bump. Swift/Kotlin protocol declarations are regenerated additively.

Maintainer decision on the pre-submit egress boundary (ClawSweeper asked for one): the visible composer disclosure is accepted as the consent surface. Draft text goes only to the agent's already-configured utility provider, which receives the same text on Send; incognito drafts, slash commands, dictation, and IME composition never trigger it; nothing is sent below 12 characters or before one idle second; and operators who set `utilityModel: ""` (the existing disable switch) get no speculation at all. No new config option is introduced for this.

## User Impact

- Visible disclosure explains that unsent creation draft text is sent to the title provider.
- Incognito, slash commands, input composition/dictation, teardown, and submitted drafts do not trigger speculative naming.
- A dropped `compositionend` (IME blur/detach) no longer wedges the composing flag: the draft view resets it on `focusout`, mirroring the chat composer.
- At most the first 1,000 UTF-16 code units are sent, on a safe character boundary; attachments are excluded.
- Explicit worktree names are preserved. Typing never provisions a worktree or runs setup.
- A prepared title can never block session creation (not a label) and existing chat titles are never refreshed by this feature.

This PR does not include the independent nonblocking-worktree/publication changes in #131582. Send-before-ready retains current main's initial naming behavior.

## Evidence

Rebased onto current `main` twice (1,368 commits, then again after `main` extracted `renderNewSessionBody`; the draft view now defers the submission error to that body renderer). Conflicts were in the descriptor table, the method-list test (main moved to a shared `expectedMethodsAfterModelProbe` array), the page's draft block (main added `onBackgroundSubmit`, ported into the extracted draft view), and the submission flow's create-params builder (main now delegates to `place.buildSessionCreateParams`).

Review fixes on this head:

- `label` → `displayName` handoff (protocol, gateway handler, UI, tests, docs). The existing `session-create-display-name.test.ts` already states the invariant: "Display titles must not reject session creation".
- ClawSweeper P2: `focusout` composition reset in the draft view, with a browser e2e that dispatches `compositionstart`, blurs without `compositionend`, and asserts the request then fires and the suggested name renders.
- Release-train test: `sessions.title.prepare` recorded in the 2026.8 train (this was the one red shard on the previous head).
- Two files main already holds at the 700-line lint cap tipped over after the rebase; absorbed without suppressions: the descriptor spec map's six redundant flag conditionals collapse to `Object.assign` (rows are `as const`, so a present flag is already the exact literal), and the flow's inline `{ params, startedAt }` signature becomes the named `DraftStartupResumption` type exported by the startup owner.

Lanes run on this head:

- Gateway: `src/gateway/methods/`, `sessions-title`, `server-methods-list`, `session-create-display-name`, `dashboard-session-title` (+transport): 106 tests passed; after the generator refactor: `conversation-label-generator`, `sessions-title`, `dashboard-session-title` (+transport): 59 passed, plus the Discord thread-title and Telegram topic-label callers: 13 passed; `check:import-cycles`: 0 cycles.
- UI: `ui/src/pages/new-session/`: 385 tests passed.
- Browser e2e `new-session-page.title.e2e.test.ts` (mock Gateway, real Chromium): 3 passed — ready-title adoption via `displayName`, nonblocking pending inference + incognito exclusion, and the new blur recovery.
- `tsgo`, `tsgo:ui`, `tsgo:test:src`, `tsgo:test:ui`: clean. `run-oxlint` on all changed files: clean (no new suppressions).
- `protocol:gen`, `protocol:check:swift`, `protocol:check:kotlin`, `check-protocol-since`: pass (1 new core method on train 2026.8).
- Codex autoreview (`--mode uncommitted`, P2) on both increments: scoped-clean, no accepted or actionable findings.

### Live proof (this head, real provider)

Packaged CLI from `pnpm build`, isolated `OPENCLAW_STATE_DIR`/config on loopback port 19811 with token auth, real Chromium via Playwright with `recordVideo`, and the real Anthropic provider (`agents.defaults.model.primary: anthropic/claude-sonnet-4-6`, utility model auto-derived to `claude-haiku-4-5` from the plugin manifest, key from the live-test vault item via env, never printed). Operator Gateway and `~/.openclaw` untouched; the owned Gateway was SIGTERMed and its state removed afterwards.

https://github.com/user-attachments/assets/ffd95613-c7df-4ef0-804b-11664faadd4e

1. Disclosure visible before typing. Draft typed; after one idle second the real utility model returned **"Sidebar unread badges after websocket reconnect"** (Gateway log: `sessions.title.prepare 4969ms`).
   ![prepared title](https://github.com/user-attachments/assets/17696338-f875-45ac-b71a-9e49bbc7e09a)
2. Editing the draft cleared the suggestion immediately and produced a new one, **"Sidebar unread badges websocket issue"** (`sessions.title.prepare 783ms`). Exactly two title RPCs in the whole run.
3. Start created the session (`sessions.create 360ms`) and the sidebar row shows the prepared name; the primary turn ran against the real model with tool calls (44 transcript events before shutdown).
   ![sidebar](https://github.com/user-attachments/assets/3dfff1b4-4f6e-434d-8f23-1dfedfef4d6c)
4. Typing in the ongoing chat issued no further title RPC and the name stayed put; no title notice is rendered on the chat route.
   ![ongoing chat](https://github.com/user-attachments/assets/daa29972-57e3-4526-b156-d22826e5a4c4)
5. Persisted row (`session_nodes` in the agent store): `display_name = "Sidebar unread badges websocket issue"`, `label = NULL`, `created_via = operator`. Zero `error` lines in the Gateway log; zero page errors.

All screenshots and two video frames were opened and checked before attaching.

### Ride-along CI repair

`checks-ui-e2e (4/14)` failed on the previous head in `mobile-inbox-sheet.e2e.test.ts` ("Expected the mobile Inbox sheet entrance animation"): `getAnimations()` drops a finished CSS animation, so a loaded runner that samples after the entrance completed found nothing. The test now replays the entrance from its real keyframes when the sample lands late (passes twice locally). `security-fast` failed on three consecutive heads during pre-commit environment init (hook-repo fetch: `could not read Username for https://github.com`, no file scanned) and the iOS dead-code checkout hit an HTTP 429; first attempts run on Blacksmith, where anonymous git-over-HTTPS is intermittently rejected. A step-scoped token rewrite was tried and reverted after review: it is inherited by third-party hook code and by the checked-out-config fallback. This PR carries no workflow change; the network-free private-key scan is a separate follow-up.

### Source/dependency proof

Sibling Codex source re-inspected on this head at `0ae94fdd49`: `codex-rs/app-server/src/request_processors/thread_processor.rs:1193,1428` (ephemeral thread configuration/identity) and `codex-rs/core/src/tools/spec_plan.rs:997-998` (shell handlers register only when a turn environment exists). This feature reuses that zero-tool isolated-completion path; it adds no new external inference API.

### Size and scope

Against the merge base: production +643/-191 (net +452); tests/test support +600/-1; generated clients +45; docs +18. Growth implements the new bounded inference endpoint, the creation-owned debounce/invalidations, and the additive `displayName` create param; the descriptor-map and label-generator simplifications offset part of it. No dependency changes.

### Label-generator ownership

The utility-only branch that duplicated alias/profile/runtime resolution in `dashboard-session-title.ts` is gone. `generateConversationLabelWithFallback` now owns the policy: `utilityOnly` runs at most the utility attempt and pre-claims the regular selection in its dedupe set, so a malformed or primary-equal utility ref returns `null` instead of spending on the primary model. The generator also resolves the harness runtime override per attempt with `resolveCompatibleAgentRuntimeForProvider`, which fixes a latent main defect: a session with a Codex runtime override and a non-OpenAI utility model previously handed the utility attempt an incompatible runtime on the post-creation path too. Covered by `conversation-label-generator.test.ts` (per-attempt runtime, utility-only never runs primary, missing/primary-equal utility returns null) and the existing `sessions-title.test.ts` matrix, which now exercises the real generator.
