### PR TITLE
improve: prepare the first cloud-session runtime archive faster

### DIFF
--- a/src/gateway/worker-environments/node-bootstrap-artifact.test.ts
+++ b/src/gateway/worker-environments/node-bootstrap-artifact.test.ts
@@ -42,6 +42,7 @@ async function fixture(mode: "source" | "package" | "external-plugin" = "source"
   };
   await write(packageRoot, "package.json", sourcePackage);
   await write(packageRoot, "openclaw.mjs", 'import "./dist/entry.js";');
+  await fs.chmod(path.join(packageRoot, "openclaw.mjs"), 0o755);
   await write(packageRoot, "node-version.mjs", "export const supported = true;");
   await write(
     packageRoot,
@@ -146,11 +147,13 @@ describe("node bootstrap distribution", () => {
       const installed = path.join(root, "node");
       await fs.mkdir(installed);
       const entries: string[] = [];
+      const modes = new Map<string, number | undefined>();
       await tar.extract({
         file: artifact.tarballPath,
         cwd: installed,
         onReadEntry: (entry) => {
           entries.push(entry.path);
+          modes.set(entry.path, entry.mode);
         },
       });
       expect(
@@ -158,6 +161,10 @@ describe("node bootstrap distribution", () => {
           /(?:\.env|private\.ts|host-native|\.map|\.buildstamp)$/u.test(entry),
         ),
       ).toBe(false);
+      if (process.platform !== "win32") {
+        expect(modes.get("package/openclaw.mjs")).toBe(0o755 & ~process.umask());
+        expect(modes.get("package/dist/shared.js")).toBe(0o644 & ~process.umask());
+      }
       if (mode === "external-plugin") {
         expect(entries).not.toContain("package/dist/extensions/remote-runtime/index.js");
       }
@@ -284,5 +291,29 @@ describe("node bootstrap distribution", () => {
     const [left, right] = await Promise.all([first.provider.prepare(), second.provider.prepare()]);
     expect(left.openclawVersion).toBe(right.openclawVersion);
     expect(left.tarballSha256).not.toBe(right.tarballSha256);
+  });
+
+  it("rejects staged bytes substituted after copying the running build", async () => {
+    const { provider } = await fixture();
+    const writeFile = fs.writeFile.bind(fs);
+    let substituted = false;
+    const writer = vi.spyOn(fs, "writeFile").mockImplementation(async (...args) => {
+      await writeFile(...args);
+      if (
+        typeof args[0] === "string" &&
+        args[0].endsWith(path.join("package", "dist", "shared.js"))
+      ) {
+        await writeFile(args[0], 'export const answer = "cloud-wrong";');
+        substituted = true;
+      }
+    });
+    try {
+      await expect(provider.prepare()).rejects.toThrow(
+        "Node bootstrap archive does not match the staged distribution",
+      );
+      expect(substituted).toBe(true);
+    } finally {
+      writer.mockRestore();
+    }
   });
 });

--- a/src/gateway/worker-environments/node-bootstrap-artifact.ts
+++ b/src/gateway/worker-environments/node-bootstrap-artifact.ts
@@ -19,13 +19,19 @@ import {
 import {
   DEFAULT_WORKER_BUNDLE_ARCHIVE_LIMITS,
   readWorkerBundleArchiveManifest,
-  readWorkerBundleDirectoryManifest,
 } from "../../shared/worker-bundle-archive.js";
-import { hashWorkerBundleManifest } from "../../shared/worker-bundle-hash.js";
+import {
+  compareWorkerBundlePaths,
+  hashWorkerBundleManifest,
+  WORKER_BUNDLE_ARTIFACT_MODE,
+  type WorkerBundleHashEntry,
+} from "../../shared/worker-bundle-hash.js";
 import { MAX_WORKER_BUNDLE_ARCHIVE_BYTES } from "../../shared/worker-bundle-limits.js";
+import { runTasksWithConcurrency } from "../../utils/run-with-concurrency.js";
 
 const INSTALL_GUARD_PATH = "dist/openclaw-install-guard";
 const BOOTSTRAP_LAUNCHER_FILES = ["openclaw.mjs", "node-version.mjs"];
+const BOOTSTRAP_COPY_CONCURRENCY = 16;
 const IGNORED_PLUGIN_DIRECTORIES = new Set(["node_modules", "src", "test", "tests"]);
 const METADATA_KEYS = [
   "name",
@@ -170,22 +176,50 @@ async function prepareNodeBootstrapArtifact(
   const packageJson = composePackagePlugins(sourcePackage, plugins);
   const stagingRoot = path.join(temporaryRoot, "package");
   await fs.mkdir(stagingRoot, { mode: 0o700 });
-  const staged = new Set<string>();
+  const staged = new Map<string, WorkerBundleHashEntry>();
+  const directories = new Map<string, Promise<string | undefined>>();
   let expandedBytes = 0;
+  let reservedEntries = 0;
 
-  const writeFile = async (relative: string, contents: Buffer | string, executable = false) => {
+  const reserveFile = (relative: string, bytes: number) => {
     bootstrapPath(relative);
-    expandedBytes += Buffer.byteLength(contents);
+    expandedBytes += bytes;
+    reservedEntries += 1;
     if (
-      staged.size >= DEFAULT_WORKER_BUNDLE_ARCHIVE_LIMITS.maxEntries ||
+      reservedEntries > DEFAULT_WORKER_BUNDLE_ARCHIVE_LIMITS.maxEntries ||
       expandedBytes > DEFAULT_WORKER_BUNDLE_ARCHIVE_LIMITS.maxExpandedBytes
     ) {
       throw new Error("Node bootstrap distribution exceeds its artifact limits");
     }
+  };
+  const writeStagedFile = async (
+    relative: string,
+    contents: Buffer | string,
+    executable: boolean,
+  ) => {
     const target = path.join(stagingRoot, relative);
-    await fs.mkdir(path.dirname(target), { recursive: true, mode: 0o700 });
-    await fs.writeFile(target, contents, { mode: executable ? 0o755 : 0o644 });
-    staged.add(relative);
+    const directory = path.dirname(target);
+    let created = directories.get(directory);
+    if (!created) {
+      created = fs.mkdir(directory, { recursive: true, mode: 0o700 });
+      directories.set(directory, created);
+    }
+    await created;
+    const mode = executable ? 0o755 : 0o644;
+    // Record the verified bytes before writing; the final archive comparison also
+    // detects staging changes without reopening and hashing the entire directory.
+    const entry = {
+      path: `package/${relative}`,
+      mode: process.platform === "win32" ? WORKER_BUNDLE_ARTIFACT_MODE : mode & ~process.umask(),
+      size: Buffer.byteLength(contents),
+      sha256: createHash("sha256").update(contents).digest("hex"),
+    };
+    await fs.writeFile(target, contents, { mode });
+    staged.set(relative, entry);
+  };
+  const writeFile = async (relative: string, contents: string) => {
+    reserveFile(relative, Buffer.byteLength(contents));
+    await writeStagedFile(relative, contents, false);
   };
   const copyFile = async (root: string, relative: string, destination = relative) => {
     bootstrapPath(relative);
@@ -196,16 +230,16 @@ async function prepareNodeBootstrapArtifact(
     const handle = await fs.open(source, fsConstants.O_RDONLY | (fsConstants.O_NOFOLLOW ?? 0));
     try {
       const before = await handle.stat();
-      if (
-        !before.isFile() ||
-        before.size > DEFAULT_WORKER_BUNDLE_ARCHIVE_LIMITS.maxExpandedBytes - expandedBytes
-      ) {
+      if (!before.isFile()) {
         throw new Error(`Invalid node distribution file: ${relative}`);
       }
+      // Reserve before reading so concurrent copies share the same byte/entry budget.
+      reserveFile(destination, before.size);
       const contents = await handle.readFile();
       const after = await handle.stat();
       const current = await fs.lstat(source);
       if (
+        contents.byteLength !== before.size ||
         before.size !== after.size ||
         before.mtimeMs !== after.mtimeMs ||
         before.ctimeMs !== after.ctimeMs ||
@@ -216,9 +250,22 @@ async function prepareNodeBootstrapArtifact(
       ) {
         throw new Error(`Node distribution changed while packaging: ${relative}`);
       }
-      await writeFile(destination, contents, (before.mode & 0o111) !== 0);
+      await writeStagedFile(destination, contents, (before.mode & 0o111) !== 0);
     } finally {
       await handle.close();
+    }
+  };
+  const copyFiles = async (root: string, files: readonly string[], prefix = "") => {
+    const result = await runTasksWithConcurrency({
+      tasks: [...new Set(files)].map(
+        (relative) => () => copyFile(root, relative, `${prefix}${relative}`),
+      ),
+      limit: BOOTSTRAP_COPY_CONCURRENCY,
+      errorMode: "stop",
+    });
+    // The pool must drain in-flight writes before preparation removes staging on failure.
+    if (result.hasError) {
+      throw result.firstError;
     }
   };
 
@@ -233,16 +280,16 @@ async function prepareNodeBootstrapArtifact(
       "Cloud bootstrap is missing its built CLI entry; run pnpm build and restart the Gateway",
     );
   }
-  for (const relative of [...BOOTSTRAP_LAUNCHER_FILES, ...files]) {
-    if (relative !== INSTALL_GUARD_PATH) {
-      await copyFile(packageRoot, relative);
-    }
-  }
-  for (const relative of sourcePackage.files ?? []) {
-    if (relative.startsWith("scripts/") && !relative.includes("*") && !relative.endsWith("/")) {
-      await copyFile(packageRoot, relative);
-    }
-  }
+  const scripts = (sourcePackage.files ?? []).filter(
+    (relative) =>
+      relative.startsWith("scripts/") && !relative.includes("*") && !relative.endsWith("/"),
+  );
+  await copyFiles(
+    packageRoot,
+    [...BOOTSTRAP_LAUNCHER_FILES, ...files, ...scripts].filter(
+      (relative) => relative !== INSTALL_GUARD_PATH,
+    ),
+  );
   // Keep real install guards/pruning, but source-only prepare/prepack commands must not run on a node.
   packageJson.scripts = Object.fromEntries(
     Object.entries(packageJson.scripts ?? {}).filter(([name]) =>
@@ -254,6 +301,7 @@ async function prepareNodeBootstrapArtifact(
     if (plugin.bundled) {
       continue;
     }
+    const pluginFiles: string[] = [];
     const visit = async (directory: string, relativeRoot = ""): Promise<void> => {
       for (const child of await fs.readdir(directory, { withFileTypes: true })) {
         if (child.name.startsWith(".") || IGNORED_PLUGIN_DIRECTORIES.has(child.name)) {
@@ -266,11 +314,12 @@ async function prepareNodeBootstrapArtifact(
         if (child.isDirectory()) {
           await visit(path.join(directory, child.name), relative);
         } else if (/\.(?:[cm]?js|json|wasm)$/u.test(child.name)) {
-          await copyFile(plugin.root, relative, `dist/extensions/${plugin.id}/${relative}`);
+          pluginFiles.push(relative);
         }
       }
     };
     await visit(plugin.root);
+    await copyFiles(plugin.root, pluginFiles, `dist/extensions/${plugin.id}/`);
   }
 
   // Only declared bundled/workspace packages cross as JavaScript artifacts. Native dependencies
@@ -302,9 +351,7 @@ async function prepareNodeBootstrapArtifact(
         `Bundled node dependency ${name} needs its compiled distribution; rebuild the Gateway`,
       );
     }
-    for (const relative of bundledFiles) {
-      await copyFile(root, relative, `node_modules/${name}/${relative}`);
-    }
+    await copyFiles(root, bundledFiles, `node_modules/${name}/`);
     delete bundled.dependencies;
     delete bundled.devDependencies;
     delete bundled.scripts;
@@ -327,10 +374,10 @@ async function prepareNodeBootstrapArtifact(
     }
   }
   await writeFile("package.json", `${JSON.stringify(packageJson, null, 2)}\n`);
-  const inventory = [...staged].filter((entry) => entry.startsWith("dist/")).toSorted();
+  const inventory = [...staged.keys()].filter((entry) => entry.startsWith("dist/")).toSorted();
   await writeFile(PACKAGE_DIST_INVENTORY_RELATIVE_PATH, `${JSON.stringify(inventory)}\n`);
   await writeFile(INSTALL_GUARD_PATH, "OpenClaw package preinstall has not completed.\n");
-  assertBuiltImportClosure(stagingRoot, [...staged], packageJson.name);
+  assertBuiltImportClosure(stagingRoot, [...staged.keys()], packageJson.name);
   if (
     (await fs.readFile(buildInfoPath, "utf8")) !== buildInfo ||
     !isDeepStrictEqual(await readPackageManifest(packageRoot), sourcePackage)
@@ -340,10 +387,9 @@ async function prepareNodeBootstrapArtifact(
     );
   }
   const tarballPath = path.join(temporaryRoot, "node-runtime.tgz");
-  const manifest = await readWorkerBundleDirectoryManifest({
-    root: temporaryRoot,
-    limits: DEFAULT_WORKER_BUNDLE_ARCHIVE_LIMITS,
-  });
+  const manifest = [...staged.values()].toSorted((left, right) =>
+    compareWorkerBundlePaths(left.path, right.path),
+  );
   await tar.create(
     {
       cwd: temporaryRoot,


### PR DESCRIPTION
Related: #133447 (prepared project snapshots for cloud sessions).

## What Problem This Solves

The first cloud session in a Gateway process can spend minutes preparing its node-runtime archive before the provider starts allocating a machine. Subsequent sessions reuse the prepared archive, but that cache does not reduce the first preparation cost.

## Why This Change Was Made

Stage files through the existing bounded worker pool, reserve shared entry and byte budgets before reading, and coalesce parent-directory creation. Record hashes from the verified source bytes and compare the completed archive against that manifest, removing the second full directory walk and read. Failed batches stop scheduling and drain active copies before cleanup.

The complete package contents, exact native dependency pins, import-closure validation, source identity checks, permissions, archive verification, and producer lifetime remain intact. This is shared Gateway behavior; no cloud provider API, configuration, dependencies, persistent state, or archive format changes.

## User Impact

The first cloud session prepares its runtime sooner. Later sessions retain the existing process cache and snapshot reuse. This does not reduce native VM allocation time or change the runtime installed on the cloud node.

## Evidence

Real producer A/B runs used the same built installation as the preceding Machine0 proof: 10,352 files and 194,486,451 expanded bytes. Each run started a fresh Node process/provider, used a real filesystem and tar implementation, and fixed the actual process umask to 022. No OS-cache purge; host load was uncontrolled. There were no overlapping benchmark, test, build, or review jobs from this task during the candidate runs.

| Implementation | Preparation runs |
| --- | --- |
| Original | 126.7 s, 213.8 s |
| Candidate | 91.9 s, 66.0 s |

Both candidate runs were faster than either baseline. The wide host variance means these samples are evidence of improvement, not a precise speedup guarantee. All four archives were byte-identical: 58,155,406 bytes, SHA-256 `cec465b518a2846874bcd00b8f6907033ae10b7d7fa71accd316668755e1bb95`. Full manifests also matched, including file hashes and permissions. Warm preparation returned the same cached object in under 0.1 ms; staging was removed before return and the archive was removed on close.

This directly exercises the changed producer against a real built package, not a mock or a new end-to-end cloud dispatch. Package source is pinned to `0098afe0c47f17a7db1073b58981b25d51d48ade`; original owner bytes match the base of this PR. The candidate owner is pinned by SHA-256 `79924b12ca30b3772b808fa8c3ef27e857c6aa7c7ff345f978b36b4cbea4ebf2`. No provider API changed; the preceding Machine0 flow remains useful context but is not counted as a new run of this PR.

Focused validation passed 23 cases across artifact, shared archive, and concurrency owners. All 14 artifact cases also passed under a real `umask 077`, including source/package/external-plugin execution and executable/non-executable permissions. A deterministic regression case failed on the original code: substituted valid JavaScript in staging was accepted into the artifact. The candidate rejects that substitution using the expected source-byte manifest and real archive verifier. Independent contract/diff review found no actionable defects; the required Codex P0 review was scoped-clean.

The complete changed-code gate passed, including formatting, production/test types, lint, import cycles, dead exports, and repository guards. A full local build of commit `0b90276f912b6720e62407b292540b7091173694` passed, including runtime, package, plugin, and Control UI output. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33350283569) passed with 163 successful jobs and no retries.

ClawSweeper follow-through: its only next step was exact-head CI, now complete; no code findings or Rank-up moves remain. The generic stored-data warning is not applicable: this changes an in-memory staging map and temporary files, with no database, durable schema, persisted state, or serialized archive-format change. The byte-identical archive/manifests above verify the unchanged transfer contract; no migration is needed.

Production delta: +80/-34, net +46 lines. Tests: +31/-0. Growth owns bounded concurrent staging, reservation before reads, shared directory creation, and the expected-byte manifest; it replaces serial copy loops and the redundant directory-manifest pass. No declaration or runtime payload is removed.

Remaining performance follow-up: import-closure parsing still uses the existing TypeScript parser and substantial memory (candidate peak RSS about 2.2 GiB). This change leaves that validation contract intact. Native VM allocation remains a separate provider-owned cost.
