### PR TITLE
improve: speed up managed worktree test fixtures

### DIFF
--- a/src/agents/worktrees/service.canonical-paths.test.ts
+++ b/src/agents/worktrees/service.canonical-paths.test.ts
@@ -10,7 +10,7 @@ import {
 } from "../../state/openclaw-state-db.js";
 import { getRegistryWorktree } from "./registry.js";
 import { ManagedWorktreeService } from "./service.js";
-import { initializeManagedWorktreeTestRepository } from "./service.test-support.js";
+import { useManagedWorktreeTestRepository } from "./service.test-support.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -22,6 +22,7 @@ async function git(cwd: string, ...args: string[]): Promise<string> {
 }
 
 describe("ManagedWorktreeService canonical paths", () => {
+  const initializeRepository = useManagedWorktreeTestRepository();
   let root: string;
   let repo: string;
   let stateDir: string;
@@ -45,7 +46,7 @@ describe("ManagedWorktreeService canonical paths", () => {
     root = await fs.mkdtemp(
       path.join(await fs.realpath(os.tmpdir()), "openclaw-worktree-canonical-paths-"),
     );
-    repo = await initializeManagedWorktreeTestRepository(root);
+    repo = await initializeRepository(root);
     stateDir = path.join(root, "state");
     await fs.mkdir(stateDir, { recursive: true });
     env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };

--- a/src/agents/worktrees/service.capacity.test.ts
+++ b/src/agents/worktrees/service.capacity.test.ts
@@ -10,7 +10,7 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import { getRegistryWorktree } from "./registry.js";
 import { ManagedWorktreeService } from "./service.js";
 import {
-  initializeManagedWorktreeTestRepository,
+  useManagedWorktreeTestRepository,
   materializeManagedWorktreeFixture,
 } from "./service.test-support.js";
 
@@ -18,6 +18,7 @@ const execFileAsync = promisify(execFile);
 const GiB = 1024 ** 3;
 
 describe("ManagedWorktreeService capacity", () => {
+  const initializeRepository = useManagedWorktreeTestRepository();
   let root: string;
   let repo: string;
   let stateDir: string;
@@ -46,7 +47,7 @@ describe("ManagedWorktreeService capacity", () => {
     root = await fs.realpath(
       await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-worktree-capacity-")),
     );
-    repo = await initializeManagedWorktreeTestRepository(root);
+    repo = await initializeRepository(root);
     stateDir = path.join(root, "state");
     env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
     service = new ManagedWorktreeService({ env });
@@ -127,7 +128,7 @@ describe("ManagedWorktreeService capacity", () => {
 
   it("serializes distinct repositories competing for the thirtieth checkout", async () => {
     await fill(29);
-    const otherRepo = await initializeManagedWorktreeTestRepository(path.join(root, "other"));
+    const otherRepo = await initializeRepository(path.join(root, "other"));
     const otherService = new ManagedWorktreeService({ env });
     const outcomes = await Promise.allSettled([
       service.create({ repoRoot: repo, name: "last-one", baseRef: "HEAD" }),

--- a/src/agents/worktrees/service.diagnostics.test.ts
+++ b/src/agents/worktrees/service.diagnostics.test.ts
@@ -8,7 +8,7 @@ import * as commandExec from "../../process/exec.js";
 import type { SpawnResult } from "../../process/exec.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { ManagedWorktreeService } from "./service.js";
-import { initializeManagedWorktreeTestRepository } from "./service.test-support.js";
+import { useManagedWorktreeTestRepository } from "./service.test-support.js";
 
 const execFileAsync = promisify(execFile);
 const realRunCommand = commandExec.runCommandWithTimeout;
@@ -82,13 +82,14 @@ const terminationCases: Array<{
 ];
 
 describe("ManagedWorktreeService failure diagnostics", () => {
+  const initializeRepository = useManagedWorktreeTestRepository();
   let root: string;
   let repo: string;
   let service: ManagedWorktreeService;
 
   beforeEach(async () => {
     root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-worktree-errors-"));
-    repo = await initializeManagedWorktreeTestRepository(root);
+    repo = await initializeRepository(root);
     service = new ManagedWorktreeService({
       env: { ...process.env, OPENCLAW_STATE_DIR: path.join(root, "state") },
     });

--- a/src/agents/worktrees/service.gc.test.ts
+++ b/src/agents/worktrees/service.gc.test.ts
@@ -9,7 +9,7 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import { findLiveRegistryWorktreeByPath, getRegistryWorktree } from "./registry.js";
 import { IDLE_GC_MS, ManagedWorktreeService, SNAPSHOT_RETENTION_MS } from "./service.js";
 import {
-  initializeManagedWorktreeTestRepository,
+  useManagedWorktreeTestRepository,
   materializeManagedWorktreeFixture,
 } from "./service.test-support.js";
 
@@ -28,6 +28,7 @@ async function initializeNestedRepository(root: string, name: string): Promise<s
 }
 
 describe("ManagedWorktreeService garbage collection", () => {
+  const initializeRepository = useManagedWorktreeTestRepository();
   let root: string;
   let repo: string;
   let stateDir: string;
@@ -62,7 +63,7 @@ describe("ManagedWorktreeService garbage collection", () => {
 
   beforeEach(async () => {
     root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-worktree-gc-"));
-    repo = await initializeManagedWorktreeTestRepository(root);
+    repo = await initializeRepository(root);
     stateDir = path.join(root, "state");
     env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
     now = 1_700_000_000_000;
@@ -234,7 +235,7 @@ describe("ManagedWorktreeService garbage collection", () => {
   });
 
   it("continues garbage collection when one repository control path is missing", async () => {
-    const otherRepo = await initializeManagedWorktreeTestRepository(path.join(root, "other"));
+    const otherRepo = await initializeRepository(path.join(root, "other"));
     const removable = await materializeDownstreamFixture("other-removable", {
       repoRoot: otherRepo,
       ownerKind: "session",

--- a/src/agents/worktrees/service.hooks.test.ts
+++ b/src/agents/worktrees/service.hooks.test.ts
@@ -9,11 +9,12 @@ import { withTimeout } from "../../infra/fs-safe.js";
 import { SESSION_WORK_ADMISSION_DRAIN_TIMEOUT_MS } from "../../sessions/session-lifecycle-admission.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { ManagedWorktreeService } from "./service.js";
-import { initializeManagedWorktreeTestRepository } from "./service.test-support.js";
+import { useManagedWorktreeTestRepository } from "./service.test-support.js";
 
 const execFileAsync = promisify(execFile);
 
 describe("ManagedWorktreeService repository code isolation", () => {
+  const initializeRepository = useManagedWorktreeTestRepository();
   let root: string;
   let repo: string;
   let sentinel: string;
@@ -21,7 +22,7 @@ describe("ManagedWorktreeService repository code isolation", () => {
 
   beforeEach(async () => {
     root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-worktree-hooks-")));
-    repo = await initializeManagedWorktreeTestRepository(root);
+    repo = await initializeRepository(root);
     sentinel = path.join(repo, ".hook-ran");
     const hooks = path.join(repo, "git-hooks");
     await fs.mkdir(hooks);

--- a/src/agents/worktrees/service.run-end-cleanup.test.ts
+++ b/src/agents/worktrees/service.run-end-cleanup.test.ts
@@ -16,7 +16,7 @@ import { acquireWorktreeRunLease, claimWorktreeRemoval } from "./run-lease.js";
 import { testing as runLeaseTesting } from "./run-lease.test-support.js";
 import { ManagedWorktreeService } from "./service.js";
 import {
-  initializeManagedWorktreeTestRepository,
+  useManagedWorktreeTestRepository,
   materializeManagedWorktreeFixture,
 } from "./service.test-support.js";
 
@@ -28,6 +28,7 @@ async function git(cwd: string, ...args: string[]): Promise<string> {
 }
 
 describe("ManagedWorktreeService run-end cleanup outcomes", () => {
+  const initializeRepository = useManagedWorktreeTestRepository();
   let root: string;
   let repo: string;
   let stateDir: string;
@@ -37,7 +38,7 @@ describe("ManagedWorktreeService run-end cleanup outcomes", () => {
 
   beforeEach(async () => {
     root = await fs.mkdtemp(path.join(await fs.realpath(os.tmpdir()), "openclaw-run-end-cleanup-"));
-    repo = await initializeManagedWorktreeTestRepository(root);
+    repo = await initializeRepository(root);
     stateDir = path.join(root, "state");
     env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
     service = new ManagedWorktreeService({ env, now: () => now });

--- a/src/agents/worktrees/service.test-support.ts
+++ b/src/agents/worktrees/service.test-support.ts
@@ -3,6 +3,8 @@ import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
+import { afterAll, beforeAll } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { insertRegistryWorktree } from "./registry.js";
 import type { ManagedWorktreeOwnerKind, ManagedWorktreeRecord } from "./types.js";
 
@@ -12,9 +14,7 @@ async function git(cwd: string, ...args: string[]): Promise<void> {
   await execFileAsync("git", ["-C", cwd, ...args]);
 }
 
-export async function initializeManagedWorktreeTestRepository(root: string): Promise<string> {
-  const repo = path.join(root, "repo");
-  const remote = path.join(root, "remote.git");
+async function initializeRepository(repo: string): Promise<void> {
   await fs.mkdir(repo, { recursive: true });
   await git(repo, "init", "-b", "main");
   await git(repo, "config", "user.name", "OpenClaw Test");
@@ -22,10 +22,39 @@ export async function initializeManagedWorktreeTestRepository(root: string): Pro
   await fs.writeFile(path.join(repo, "README.md"), "base\n");
   await git(repo, "add", "README.md");
   await git(repo, "commit", "-m", "initial");
+}
+
+async function addRemote(root: string, repo: string): Promise<string> {
+  const remote = path.join(root, "remote.git");
   await git(root, "init", "--bare", remote);
   await git(repo, "remote", "add", "origin", remote);
   await git(repo, "push", "-u", "origin", "main");
   return await fs.realpath(repo);
+}
+
+export async function initializeManagedWorktreeTestRepository(root: string): Promise<string> {
+  const repo = path.join(root, "repo");
+  await initializeRepository(repo);
+  return await addRemote(root, repo);
+}
+
+export function useManagedWorktreeTestRepository(): (root: string) => Promise<string> {
+  const templateDirs = useAutoCleanupTempDirTracker(afterAll);
+  let templateRepo: string;
+  beforeAll(async () => {
+    const templateRoot = templateDirs.make("openclaw-worktree-template-");
+    const repo = path.join(templateRoot, "repo");
+    await initializeRepository(repo);
+    templateRepo = repo;
+  });
+
+  // Only initial history is shared, within this suite. Each case still owns its
+  // Git metadata and real remote; no fetched refs, locks, or state DB are copied.
+  return async (root) => {
+    const repo = path.join(root, "repo");
+    await fs.cp(templateRepo, repo, { recursive: true, mode: fsConstants.COPYFILE_FICLONE });
+    return await addRemote(root, repo);
+  };
 }
 
 async function copyProvisionedFiles(params: {


### PR DESCRIPTION
## What Problem This Solves

Six managed-worktree test suites rebuild identical initial Git history for every case. This spends execution time launching Git before the behavior under test begins.

## Why This Change Was Made

Prepare only the initial commit once per suite, then copy its checkout and Git metadata into each case. Every case still creates its own bare remote and performs the real initial push. The suite owns template cleanup through the existing temp-directory tracker; no module-wide cache, database, fetched refs, or worktree registrations are shared. The three environment-sensitive or infrequent callers keep ordinary initialization.

This removes 350 repeated Git launches across 76 fixture initializations. All 74 test cases, assertions, real process/Git/SQLite coverage, deadlines, concurrency configuration and sharding remain unchanged. Production LOC: +0/-0. Tests and test support: +52/-17.

## User Impact

Faster developer and CI tests; no product behavior change.

## Evidence

- Balanced baseline/candidate/candidate/baseline runs preserve the identical 74-case inventory on macOS and Linux. Execution including suite setup: Linux 21.415s → 18.22s (14.9%); macOS 42.81s → 40.25s (6.0%, same single-worker diagnostic command for both revisions). Linux uses the unchanged default scheduling. Average peak RSS: Linux 902 → 818 MiB; macOS 463 → 473 MiB (about +2%).
- All 102 owner/sibling cases passed locally, including the unchanged Gateway recovery, migration and input-file callers; the worktree suites also ran sequentially in one non-isolated worker.
- Real-Git probes verified separate inodes, config, refs, indexes, hooks, linked worktrees and remotes; no FETCH_HEAD or alternates leak; deleting one copy leaves others usable; two suites using the same imported helper clean up independently.
- Deliberately failing initialization skipped its test body, and a subsequent observer proved the partially created template was removed before fallback cleanup.
- Final 20 changed checks passed locally, including typechecking and lint. Codex autoreview and an independent owner/dependency audit found no actionable findings. The same 102 owner/sibling cases and all isolation/cleanup probes also passed on [Linux Testbox](https://github.com/openclaw/openclaw/actions/runs/33349375274). Provider-owned commands returned 0 and the lease was stopped after proof; its backing Actions job can show cancelled after that cleanup.

Timings measure scoped test execution, including fixture setup, not whole-CI wall time. The initial parallel macOS runs were noisy and are not the performance claim. No permanent probe-only tests or production seams were added.

Scoped timing command (append `--maxWorkers=1` only for the paired macOS diagnostic):

```sh
node scripts/run-vitest.mjs src/agents/worktrees/service.{canonical-paths,capacity,diagnostics,gc,hooks,run-end-cleanup}.test.ts --reporter=verbose --reporter=json --outputFile=/tmp/worktree-perf.json
```
