### PR TITLE
test: consolidate token formatting coverage at its owner

### DIFF
--- a/src/commands/status.format.test.ts
+++ b/src/commands/status.format.test.ts
@@ -2,7 +2,6 @@
 import { describe, expect, it } from "vitest";
 import { withEnv } from "../test-utils/env.js";
 import {
-  formatKTokens,
   formatPromptCacheCompact,
   formatStatusConfigDiagnosticEntries,
   formatTokensCompact,
@@ -42,16 +41,6 @@ describe("status cache formatting", () => {
         percentUsed: 50,
       }),
     ).toBe("5.0k/10k (50%) · 🗄️ 67% cached");
-  });
-
-  it("renders sub-1000 token counts as plain integers, not fractional k", () => {
-    expect(formatKTokens(0)).toBe("0");
-    expect(formatKTokens(420)).toBe("420");
-    // 999 must not round up across the boundary into a misleading "1.0k".
-    expect(formatKTokens(999)).toBe("999");
-    expect(formatKTokens(1_000)).toBe("1.0k");
-    expect(formatKTokens(12_000)).toBe("12k");
-    expect(formatKTokens(999_500)).toBe("1.0m");
   });
 
   it("keeps small sessions and cache writes readable in status output", () => {

--- a/src/utils/token-format.test.ts
+++ b/src/utils/token-format.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { formatTokenCount } from "./token-format.js";
+
+describe("formatTokenCount", () => {
+  it("formats token counts", () => {
+    expect(formatTokenCount(999)).toBe("999");
+    expect(formatTokenCount(1234)).toBe("1.2k");
+    expect(formatTokenCount(12000)).toBe("12k");
+    expect(formatTokenCount(999_499)).toBe("999k");
+    expect(formatTokenCount(999_500)).toBe("1.0m");
+    expect(formatTokenCount(2_500_000)).toBe("2.5m");
+  });
+
+  it("formats token counts at exact boundaries", () => {
+    expect(formatTokenCount(1000)).toBe("1.0k");
+    expect(formatTokenCount(1500)).toBe("1.5k");
+    expect(formatTokenCount(10000)).toBe("10k");
+    expect(formatTokenCount(50000)).toBe("50k");
+    expect(formatTokenCount(1_000_000)).toBe("1.0m");
+    expect(formatTokenCount(1_500_000)).toBe("1.5m");
+    expect(formatTokenCount(10_000_000)).toBe("10.0m");
+  });
+
+  it("returns 0 for invalid and non-positive token counts", () => {
+    expect(formatTokenCount(0)).toBe("0");
+    expect(formatTokenCount(-100)).toBe("0");
+    expect(formatTokenCount(undefined)).toBe("0");
+    expect(formatTokenCount(Number.NaN)).toBe("0");
+    expect(formatTokenCount(Number.POSITIVE_INFINITY)).toBe("0");
+    expect(formatTokenCount(Number.NEGATIVE_INFINITY)).toBe("0");
+  });
+
+  it("rounds thousands overflow to millions at the boundary", () => {
+    expect(formatTokenCount(999_999)).toBe("1.0m");
+    expect(formatTokenCount(9_999)).toBe("10.0k");
+  });
+});

--- a/src/utils/usage-format.test.ts
+++ b/src/utils/usage-format.test.ts
@@ -11,7 +11,6 @@ import { captureEnv } from "../test-utils/env.js";
 import {
   resetUsageFormatCachesForTest,
   estimateUsageCost,
-  formatTokenCount,
   formatUsd,
   resolveModelCostConfig,
   resolveModelCostConfigFingerprint,
@@ -59,40 +58,6 @@ describe("usage-format", () => {
     envSnapshot = undefined;
     resetUsageFormatCachesForTest();
     await fs.rm(stateDir, { recursive: true, force: true });
-  });
-
-  it("formats token counts", () => {
-    expect(formatTokenCount(999)).toBe("999");
-    expect(formatTokenCount(1234)).toBe("1.2k");
-    expect(formatTokenCount(12000)).toBe("12k");
-    expect(formatTokenCount(999_499)).toBe("999k");
-    expect(formatTokenCount(999_500)).toBe("1.0m");
-    expect(formatTokenCount(2_500_000)).toBe("2.5m");
-  });
-
-  it("formats token counts at exact boundaries", () => {
-    expect(formatTokenCount(1000)).toBe("1.0k");
-    expect(formatTokenCount(1500)).toBe("1.5k");
-    expect(formatTokenCount(10000)).toBe("10k");
-    expect(formatTokenCount(50000)).toBe("50k");
-    expect(formatTokenCount(1_000_000)).toBe("1.0m");
-    expect(formatTokenCount(1_500_000)).toBe("1.5m");
-    expect(formatTokenCount(10_000_000)).toBe("10.0m");
-  });
-
-  it("returns 0 for invalid and non-positive token counts", () => {
-    expect(formatTokenCount(0)).toBe("0");
-    expect(formatTokenCount(-100)).toBe("0");
-    expect(formatTokenCount(undefined)).toBe("0");
-    expect(formatTokenCount(Number.NaN)).toBe("0");
-    expect(formatTokenCount(Number.POSITIVE_INFINITY)).toBe("0");
-    expect(formatTokenCount(Number.NEGATIVE_INFINITY)).toBe("0");
-  });
-
-  it("rounds thousands overflow to millions at the boundary", () => {
-    // 999,999 / 1000 = 999.999 → toFixed(1) = "1000.0" → crosses to millions
-    expect(formatTokenCount(999_999)).toBe("1.0m");
-    expect(formatTokenCount(9_999)).toBe("10.0k");
   });
 
   it("formats USD values", () => {


### PR DESCRIPTION
## What Problem This Solves

Pure token-count formatting cases run inside the usage-pricing suite's temporary-directory, environment, and cache-reset fixture. Status tests also replay the same numeric examples through a direct alias of that formatter.

## Why This Change Was Made

Move the four formatting cases to `src/utils/token-format.test.ts`, alongside their pure owner, and remove the alias-only status replay. Keep composed session/cache status assertions, including the small-session regression, and every pricing/cache test.

## User Impact

No runtime behavior changes. Formatting coverage has one owner and no longer pays for an unrelated filesystem fixture.

## Evidence

- Existing usage and status suites passed before the change (34 cases).
- Exact thresholds, invalid/non-positive values, decimal precision, and thousands-to-millions overflow fixtures are preserved at the owner.
- The removed alias-only case is covered by those numeric fixtures and the retained composed `420/200k (0%)` status assertion.
- Production: +0/-0. Tests: +37/-46 (net -9); one redundant execution removed and four tests moved out of the pricing fixture.
- No changelog or live provider proof is needed for this test-only ownership cleanup.
- After: `node scripts/run-vitest.mjs src/utils/token-format.test.ts src/utils/usage-format.test.ts src/commands/status.format.test.ts` passed (33 cases).
- Local `check-changed` passed, including core test types, guards, dead-export checks, and changed-file lint. Structured Codex autoreview returned scoped-clean.
