### PR TITLE
fix(macos): redact values marked private in app logs

### DIFF
--- a/apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift
+++ b/apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 @_exported import Logging
 import os
@@ -78,13 +79,39 @@ extension Logging.Logger {
     }
 }
 
-extension Logger.Message.StringInterpolation {
-    // periphery:ignore:parameters privacy - Call sites need OSLog syntax that swift-log otherwise cannot parse.
+enum AppLogPrivacy {
+    enum Mask {
+        case none, hash
+    }
+
+    case `public`
+    case `private`(mask: Mask)
+
+    static var `private`: Self {
+        .private(mask: .none)
+    }
+
+    /// Correlate within this process without persisting a key or exposing guessable identifiers.
+    fileprivate static let hashKey = SymmetricKey(size: .bits256)
+}
+
+/// swift-log uses DefaultStringInterpolation, including for concatenated String messages.
+/// Redact here: its Message stores only text, so neither sink can recover privacy afterward.
+extension DefaultStringInterpolation {
     mutating func appendInterpolation(
-        _ value: some Any,
-        privacy: OSLogPrivacy)
+        _ value: @autoclosure () -> some Any,
+        privacy: AppLogPrivacy)
     {
-        self.appendInterpolation(String(describing: value))
+        switch privacy {
+        case .public:
+            self.appendInterpolation(String(describing: value()))
+        case .private(mask: .none):
+            self.appendLiteral("<private>")
+        case .private(mask: .hash):
+            let bytes = Data(String(describing: value()).utf8)
+            let hash = HMAC<SHA256>.authenticationCode(for: bytes, using: AppLogPrivacy.hashKey)
+            self.appendLiteral("<private:\(Data(hash).base64EncodedString())>")
+        }
     }
 }
 

--- a/apps/macos/Tests/OpenClawIPCTests/OpenClawLoggingTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OpenClawLoggingTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+struct OpenClawLoggingTests {
+    @Test(arguments: ["synthetic-private-payload", "first line\nsecond line", ""])
+    func `private values are removed before sink delivery`(privateValue: String) {
+        let publicValue = "synthetic-public-value"
+        let message: Logger.Message =
+            "event public=\(publicValue, privacy: .public) private=\(privateValue, privacy: .private) count=\(3)"
+        #expect(message.description == "event public=synthetic-public-value private=<private> count=3")
+
+        // Voice diagnostics concatenate ordinary Strings before converting to Logger.Message.
+        let joined = "first=\(privateValue, privacy: .private) " + "second=\(privateValue, privacy: .private)"
+        let forwarded: Logger.Message = "\(joined)"
+        #expect(forwarded.description == "first=<private> second=<private>")
+    }
+
+    @Test
+    func `private hash correlates without retaining the value`() {
+        let firstUID = "synthetic-microphone-a"
+        let secondUID = "synthetic-microphone-b"
+        let first: Logger.Message = "uid=\(firstUID, privacy: .private(mask: .hash))"
+        let repeated: Logger.Message = "uid=\(firstUID, privacy: .private(mask: .hash))"
+        let different: Logger.Message = "uid=\(secondUID, privacy: .private(mask: .hash))"
+
+        #expect(first == repeated)
+        #expect(first != different)
+        #expect(!first.description.contains(firstUID))
+        #expect(!different.description.contains(secondUID))
+        #expect(first.description != "uid=<private>")
+    }
+
+    @Test
+    func `private values are not described`() {
+        let value = DescribedValue()
+        let hidden: Logger.Message = "value=\(value, privacy: .private)"
+        #expect(hidden.description == "value=<private>")
+        #expect(value.descriptionReads == 0)
+
+        let visible: Logger.Message = "value=\(value, privacy: .public)"
+        #expect(visible.description == "value=synthetic-description")
+        #expect(value.descriptionReads == 1)
+    }
+}
+
+private final class DescribedValue: CustomStringConvertible {
+    var descriptionReads = 0
+
+    var description: String {
+        self.descriptionReads += 1
+        return "synthetic-description"
+    }
+}

--- a/docs/platforms/mac/logging.md
+++ b/docs/platforms/mac/logging.md
@@ -1,5 +1,5 @@
 ---
-summary: "OpenClaw logging: rolling diagnostics file log + unified log privacy flags"
+summary: "macOS app log redaction, opt-in diagnostics files, and native OSLog privacy flags"
 read_when:
   - Capturing macOS logs or investigating private data logging
   - Debugging voice wake/session lifecycle issues
@@ -18,7 +18,7 @@ The macOS app logs through swift-log (unified logging by default) and can also w
 - Rotation: rotates at 5 MB; up to 5 backups suffixed `.1`...`.5` (oldest dropped).
 - Clear: **Debug pane -> Logs -> App logging -> "Clear"** deletes the active file and all backups.
 
-Treat the file as sensitive; do not share it without review.
+The file log is a separate, explicit opt-in. Enabling it does not disable the app's interpolation redaction described below. It still includes public and unannotated messages, metadata, and direct diagnostic records, which can contain sensitive data. Enable it only while debugging, turn it off afterward, and review the active file and backups before sharing.
 
 ## Export unified logs as JSON
 
@@ -26,13 +26,23 @@ Run `./scripts/clawlog.sh --json` to write recent unified-log events as one JSON
 
 JSON export cannot be combined with `--follow` or `--list-categories`. Use those options without `--json`.
 
+## App logger redaction
+
+The macOS app's swift-log bridge renders messages as text before handing them to unified logging or the optional file log. Its interpolation annotations are app-side rules, not native OSLog privacy metadata:
+
+- `privacy: .private` replaces the value with `<private>` before either sink receives it.
+- `privacy: .private(mask: .hash)` replaces the value with a keyed hash. Equal values correlate within one app process; hashes change when the app restarts.
+- `privacy: .public`, unannotated interpolations, and swift-log metadata are not automatically redacted. Do not assume that a log is safe to share just because it came from unified logging.
+
+This also protects private interpolations in strings that are concatenated before logging. Verbosity changes, file capture, and macOS private-data overrides cannot restore values removed by the app's bridge.
+
 ## Unified logging private data on macOS
 
-Unified logging redacts most payloads unless a subsystem opts into `privacy -off`. This is controlled by a plist in `/Library/Preferences/Logging/Subsystems/` keyed by subsystem name. Only new log entries pick up the flag, so enable it before reproducing an issue. Background: [macOS logging privacy shenanigans](https://steipete.me/posts/2025/logging-privacy-shenanigans).
+Some shared components use native OSLog directly rather than the app's swift-log bridge. Native OSLog normally redacts private values; explicitly public values remain visible. For those native events, a subsystem plist in `/Library/Preferences/Logging/Subsystems/` can enable private-data capture. This is not a way to reveal the bridge's `<private>` placeholders or hashes. Background: [macOS logging privacy shenanigans](https://steipete.me/posts/2025/logging-privacy-shenanigans).
 
 ## Enable for OpenClaw (`ai.openclaw`)
 
-Write the plist to a temp file first, then install it atomically as root:
+Use this only when you need private values from **native OSLog** events. Check for an existing `ai.openclaw.plist` first and preserve it so you can restore the prior settings afterward. Write the plist to a temp file, then install it atomically as root:
 
 ```bash
 cat <<'EOF' >/tmp/ai.openclaw.plist
@@ -51,13 +61,13 @@ EOF
 sudo install -m 644 -o root -g wheel /tmp/ai.openclaw.plist /Library/Preferences/Logging/Subsystems/ai.openclaw.plist
 ```
 
-No reboot required; logd picks up the file quickly, but only new log lines include private payloads. View the richer output with `./scripts/clawlog.sh --category WebChat --last 5m` (`--last`/`-l` sets the time range, default `5m`; `--category`/`-c` filters by category).
+Enable the override before reproducing the issue: it affects new native OSLog events, not entries already collected. Inspect the output with `./scripts/clawlog.sh --category WebChat --last 5m` (`--last`/`-l` sets the time range, default `5m`; `--category`/`-c` filters by category).
 
 ## Disable after debugging
 
-- Remove the override: `sudo rm /Library/Preferences/Logging/Subsystems/ai.openclaw.plist`.
-- Optionally run `sudo log config --reload` to force logd to drop the override immediately.
-- This surface can include phone numbers and message bodies; keep the plist in place only while actively needed.
+- If you created the plist for this capture, remove it: `sudo rm /Library/Preferences/Logging/Subsystems/ai.openclaw.plist`. If it existed beforehand, restore the saved version instead.
+- The override can expose phone numbers and message bodies in native events. Keep it enabled only while needed; removing it does not erase data already captured.
+- Turn off rolling file capture separately if you enabled it. The macOS override does not control that sink.
 
 ## Related
 


### PR DESCRIPTION
Closes #133736 — macOS logger ignores private interpolation annotations.

## What Problem This Solves

Fixes an issue where operators collecting macOS app logs could receive plaintext values explicitly marked private, while the logging guide suggested that native unified-log privacy settings protected those values. This was reproduced using synthetic values only; no live secret leak is claimed.

The original logger is byte-identical at stable tag `v2026.8.1`, the reported revision `08d09c4d97044ead11aacbe1cc13d5dd7a02c0a3`, and the local reproduction base `c753bbd1ced5395fb42c113cdabda5d69bdb75d4`.

## Why This Change Was Made

Enforce privacy before swift-log flattens a message into a String. Replace the no-op OSLog privacy argument with an app-owned, closed interpolation contract: private values become `<private>` without evaluating their description, and hash-masked values use CryptoKit HMAC-SHA256 with a process-local key. The existing logger and both sinks remain canonical; no new logging pipeline, configuration, persisted key, dependency, or TypeScript diagnostic path is added.

This is intentionally **app-side redaction, not native OSLog privacy forwarding**. Explicitly private values are absent from the optional file log too; verbosity, file capture, and macOS privacy overrides cannot recover them. Public and unannotated content remains unchanged, and file logging stays off by default behind its existing consent gates. The [operator guide](https://docs.openclaw.ai/platforms/mac/logging) distinguishes the bridge from shared components that use native OSLog directly.

Changing the final sink to mark the entire message private would hide public diagnostics without restoring mixed-field or hash semantics. Encoding raw values into flattened strings or introducing another logger would add an unnecessary alternate path. Redacting at interpolation also protects the existing voice-diagnostic String-concatenation callers.

## User Impact

Private worker/cookie stderr and voice transcript annotations now take effect. Hash-masked microphone identifiers remain correlatable within one app process without exposing their original value; hashes change on restart. Operators can still enable rolling diagnostics capture explicitly, but should review logs before sharing because public messages, unannotated values, metadata, and direct diagnostic records can remain sensitive.

Release-note context: macOS app logging now honors private interpolation and hash masking before both output sinks, preserves opt-in file capture, and documents the distinction from native OSLog private-data overrides.

Production LOC: **+32/-5 (net +27)**. Tests: **+54/-0**. Docs: **+18/-8 (net +10)**. Production growth implements the missing privacy/mask contract and keyed hashing in the existing interpolation owner; there is no new sink or compatibility layer.

## Evidence

- [Exact-head CI run 33351598978](https://github.com/openclaw/openclaw/actions/runs/33351598978) passed for `3738c1e5ec9553710f8c9af6601fb0d7361a608e`, including macOS Swift, macOS Node, docs, and the required `openclaw/ci-gate`. Native logs explicitly show all three `OpenClawLoggingTests` passing within the 1,902-test app suite; the separate profile partition and 1,514 shared-kit tests also passed. macOS and shared-kit Periphery checks are green.
- Fresh pre-commit Codex autoreview was scoped-clean at the configured P0 threshold. The clean rebase preserved the patch and exact native proof source bytes. ClawSweeper found no actionable defects; its exact-head native-CI rank-up move is satisfied. The +27 production-line growth is accepted for the missing privacy/mask contract and process-local HMAC implementation described above.
- New `OpenClawLoggingTests`: three tests/five cases fail against the original logger with 11 assertion failures, then pass on the repair. Covers mixed public/private output, empty and multiline values, ordinary String concatenation, private hash correlation without plaintext, and avoiding private value descriptions.
- Native proof compiled byte-identical logging/settings owners and the new tests with pinned apple/swift-log 1.15.0 (`3ffafb9722d5d918c614feb496c8789a3b59d222`) in a temporary minimal package. The dependency source confirms `Logger.Message` retains only a String; the Apple OSLog interface provides no public privacy-inspection API.
- Real unified-log readback, synthetic payloads only:

  ```text
  Before app bridge: public=SYNTHETIC-PUBLIC-CANARY private=SYNTHETIC-PRIVATE-CANARY
  Native OSLog control: public=SYNTHETIC-PUBLIC-CANARY private=<private>
  After app bridge: public=SYNTHETIC-PUBLIC-CANARY private=<private>
  ```

  Five repaired native log records contain no private canary. Public/unannotated values remain visible, and the native OSLog control remains unchanged. Hashes differ across three independent processes; same-process equality is covered by the regression test.
- The real file handler and diagnostics actor honor off/on/off capture: disabled capture creates no file; enabled capture appends a redacted record to an owned fixture file; disabling again prevents the next append.
- Local changed checks passed with pinned SwiftLint 0.65.0 and SwiftFormat 0.62.1: all guards and Swift lint passed, plus **1,019 TypeScript tests in 19 files across seven shards**. The first attempt stopped at a host tool-version mismatch (SwiftLint 0.65.1); installing the pinned tools in a task-local directory resolved it without changing the shared installation.

  ```bash
  node scripts/check-changed.mjs -- apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift apps/macos/Tests/OpenClawIPCTests/OpenClawLoggingTests.swift docs/platforms/mac/logging.md
  ```

  ```bash
  swiftformat --lint --config config/swiftformat --cache ignore apps/macos/Sources/OpenClaw/Logging/OpenClawLogging.swift apps/macos/Tests/OpenClawIPCTests/OpenClawLoggingTests.swift
  ```

  ```bash
  git diff --check
  ```

**Proof boundaries:** native execution was sandboxed with task-local homes, profiles, Swift caches, and synthetic values; operator files, Keychain/preferences services, network, desktop services, and child process creation were blocked. No operator app/Gateway/live state or other native session checkout was used. Enabled file runs seeded an empty fixture because Foundation first-file creation failed under the restrictive sandbox, so that proof covers append/consent rather than first-file creation or rotation. No full native app launch or local full app test suite is claimed; exact-head macOS CI provides the full integration-suite proof. No system privacy override was installed. The separately owned TypeScript diagnostic-redaction repair is untouched.
