### PR TITLE
fix(macos): unblock builds with custom SwiftPM scratch paths

### DIFF
--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "968e194c612eba837efbd28e8bc9106127fc9828d7b60c4ed148444598af84c6",
+  "originHash" : "17b9162713f42b8657499bec84c7caad30103a0379c7b457c25aa3b5fd79699a",
   "pins" : [
     {
       "identity" : "axorcist",
@@ -51,7 +51,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openclaw/Peekaboo.git",
       "state" : {
-        "revision" : "c11453112e92e3b856826b04f68a9042e3a1e18c"
+        "revision" : "d80cc3cae6e9f2978b909d65ef1a21f15aed4706"
       }
     },
     {

--- a/apps/macos/Package.resolved
+++ b/apps/macos/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "73bced8a90c16e889ed097913c7c40cddb0761066ad974d76b4f9f3d40d315e5",
+  "originHash" : "968e194c612eba837efbd28e8bc9106127fc9828d7b60c4ed148444598af84c6",
   "pins" : [
     {
       "identity" : "axorcist",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openclaw/AXorcist.git",
       "state" : {
-        "revision" : "dba24f0a2dd4a0ccfb285d7e11cf899f8b603ef6",
-        "version" : "0.1.6"
+        "revision" : "bab3f2228bac0ce3a34786b8395b65bb36242221",
+        "version" : "0.1.8"
       }
     },
     {
@@ -51,7 +51,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/openclaw/Peekaboo.git",
       "state" : {
-        "revision" : "028cd9eb2d7b413c26f02f169c5f6224b2fcb3e0"
+        "revision" : "c11453112e92e3b856826b04f68a9042e3a1e18c"
       }
     },
     {

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.6"),
         .package(
             url: "https://github.com/openclaw/Peekaboo.git",
-            revision: "028cd9eb2d7b413c26f02f169c5f6224b2fcb3e0"),
+            revision: "c11453112e92e3b856826b04f68a9042e3a1e18c"),
         .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.4.1"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../shared/OpenClawMLXTTSProtocol"),

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.6"),
         .package(
             url: "https://github.com/openclaw/Peekaboo.git",
-            revision: "c11453112e92e3b856826b04f68a9042e3a1e18c"),
+            revision: "d80cc3cae6e9f2978b909d65ef1a21f15aed4706"),
         .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.4.1"),
         .package(path: "../shared/OpenClawKit"),
         .package(path: "../shared/OpenClawMLXTTSProtocol"),

--- a/docs/platforms/mac/peekaboo.md
+++ b/docs/platforms/mac/peekaboo.md
@@ -8,7 +8,7 @@ read_when:
 title: "Peekaboo bridge"
 ---
 
-OpenClaw can host **PeekabooBridge** as a local, permission-aware UI automation broker (`PeekabooBridgeHostCoordinator`, backed by the `steipete/Peekaboo` Swift package). This lets the `peekaboo` CLI drive UI automation while reusing the macOS app's TCC permissions.
+OpenClaw can host **PeekabooBridge** as a local, permission-aware UI automation broker (`PeekabooBridgeHostCoordinator`, backed by the `openclaw/Peekaboo` Swift package). This lets the `peekaboo` CLI drive UI automation while reusing the macOS app's TCC permissions.
 
 ## What this is (and is not)
 


### PR DESCRIPTION
Related: https://github.com/openclaw/AXorcist/pull/53
Upstream merged: https://github.com/openclaw/Peekaboo/pull/672

## What Problem This Solves

Fixes an issue where developers building the macOS app in an isolated custom SwiftPM scratch directory hit a frozen-resolution failure: Commander was resolved to 0.2.4 but now has an unversioned requirement.

The real cold macOS build reproduced the failure before this update. AXorcist 0.1.6 treated a sibling Commander checkout as a developer override because its manifest recognized only the default `.build/checkouts` layout. That conflicts with Swabble's versioned Commander dependency.

## Why This Change Was Made

Adopt Peekaboo's public-package pin to the published [AXorcist 0.1.8 release](https://github.com/openclaw/AXorcist/releases/tag/v0.1.8). The repair belongs to AXorcist's manifest: distributed dependencies stay versioned, and local development uses explicit workspace overrides. This change preserves an exact Peekaboo revision and Commander 0.2.4; it does not patch dependency caches or weaken pins.

Only the Peekaboo and AXorcist lock entries change, plus SwiftPM's generated origin hash. Every other package pin is unchanged. The documentation's package-owner spelling is corrected to `openclaw/Peekaboo`.

The manifest and lockfile now pin the actual Peekaboo merge commit `d80cc3cae6e9f2978b909d65ef1a21f15aed4706`. Its complete source tree `c2d8f885404a26453f9fa4a7efadc125f6fe71fb` exactly matches the previously reviewed and tested PR head; there is no provisional source-branch pin. The fresh frozen custom-scratch build was repeated successfully for this final revision. This revision update also includes newer upstream public Bridge code, so actual app compilation and a separate isolated Bridge handshake check are included rather than treating the effective dependency change as metadata-only.

## User Impact

Custom scratch directories, including paths containing spaces, work without AXorcist silently changing Commander into an unversioned local package. No OpenClaw configuration keys are added and the Commander requirement is unchanged. The wider Peekaboo revision update does carry upstream runtime changes, covered by the app build, native CI, and the isolated lifecycle smoke below. The separate AnyCodable repair and its worktree are untouched.

## Evidence

- Before: the real `swift build --package-path apps/macos --scratch-path <fresh-custom-path> --disable-automatic-resolution --build-tests` failed with the exact Commander versioned/unversioned diagnostic.
- After resolving the intended pin update: the same frozen custom-scratch build passed and compiled the macOS app and all test products on Swift 6.4. Tests were compiled, not run on the operator desktop.
- Peekaboo's existing public-consumer contract compiled all four products in release mode. A separate cold custom-scratch `PeekabooBridge` release build passed with AXorcist 0.1.8 and Commander 0.2.4.
- Applicable pin, source-policy, formatting, native schema-version, and native lint checks passed. Native lint initially stopped at its tool-version guard (installed SwiftLint 0.65.1 versus required 0.65.0), then passed with zero violations using task-local checksum-pinned tools. Full native test execution belongs to disposable CI.
- Fresh Codex autoreview: no accepted/actionable findings.
- AXorcist's release passed its full checks and Swift suites, Apple notarization, public archive/signature verification, and a [clean macOS Homebrew install and byte-preservation check](https://github.com/openclaw/AXorcist/actions/runs/33350625963).
- [Final OpenClaw native CI](https://github.com/openclaw/openclaw/actions/runs/33354377560) passed `macos-swift`, `macos-node`, and `openclaw/ci-gate` on exact head `eb98d0a13df9726c4b6c6e3ac9fd2c7e29e8d866`.
- [Final isolated Bridge proof](https://github.com/openclaw/AXorcist/actions/runs/33354535661) checked out that exact head and passed all six existing `PeekabooBridgeHostCoordinatorTests` on a disposable macOS worker with the verified release-signed Peekaboo 4.2.2 client. The real handshake passed in 3.578 seconds; the suite passed in 3.613 seconds. The real handshake test was required to pass, not skip; it verifies coordinator startup, exact custom-socket handshake, shutdown, and socket removal. No unsigned-client override, allowlist change, or production test hook was added. This covers the existing custom-socket protocol-1.28 lifecycle, not release-host attestation or protocol-1.29 operation receipts.

Production manifest LOC: +1/-1 (net 0). Lock data: +4/-4. Docs: +1/-1. No new production logic, configuration, dependency overrides, or tests are introduced here.
