### PR TITLE
test(qa): remove duplicate summary file-reader checks

### DIFF
--- a/extensions/qa-lab/src/suite-summary.test.ts
+++ b/extensions/qa-lab/src/suite-summary.test.ts
@@ -592,67 +592,11 @@ describe("qa suite summary helpers", () => {
   it("rejects unsupported summary shapes", async () => {
     await expect(
       readSummary({ counts: { total: 2, passed: 2 } }, readQaSuiteFailedScenarioCountFromFile),
-    ).rejects.toThrow("did not include counts.failed");
+    ).rejects.toThrow(
+      "did not include counts.failed, scenarios[].status, or entries[].result.status",
+    );
     await expect(
       readSummary("not-json-object", readQaSuiteFailedScenarioCountFromFile),
     ).rejects.toMatchObject({ code: "summary_not_completed" });
-  });
-
-  it("reads failed scenario counts from summary files", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "qa-suite-summary-"));
-    const summaryPath = path.join(outputDir, "qa-suite-summary.json");
-    await fs.writeFile(
-      summaryPath,
-      JSON.stringify({
-        run: { status: "completed" },
-        counts: { failed: 0 },
-        scenarios: [{ status: "fail" }],
-      }),
-      "utf8",
-    );
-
-    try {
-      await expect(readQaSuiteFailedScenarioCountFromFile(summaryPath)).resolves.toBe(1);
-    } finally {
-      await fs.rm(outputDir, { recursive: true, force: true });
-    }
-  });
-
-  it("reads failed or skipped scenario counts from summary files", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "qa-suite-summary-"));
-    const summaryPath = path.join(outputDir, "qa-suite-summary.json");
-    await fs.writeFile(
-      summaryPath,
-      JSON.stringify({
-        run: { status: "completed" },
-        counts: { failed: 0, skipped: 1 },
-        scenarios: [{ status: "pass" }],
-      }),
-      "utf8",
-    );
-
-    try {
-      await expect(readQaSuiteFailedOrSkippedScenarioCountFromFile(summaryPath)).resolves.toBe(1);
-    } finally {
-      await fs.rm(outputDir, { recursive: true, force: true });
-    }
-  });
-
-  it("fails summary files without a failure signal", async () => {
-    const outputDir = await fs.mkdtemp(path.join(os.tmpdir(), "qa-suite-summary-"));
-    const summaryPath = path.join(outputDir, "qa-suite-summary.json");
-    await fs.writeFile(
-      summaryPath,
-      JSON.stringify({ run: { status: "completed" }, counts: { total: 1, passed: 1 } }),
-      "utf8",
-    );
-
-    try {
-      await expect(readQaSuiteFailedScenarioCountFromFile(summaryPath)).rejects.toThrow(
-        "did not include counts.failed, scenarios[].status, or entries[].result.status",
-      );
-    } finally {
-      await fs.rm(outputDir, { recursive: true, force: true });
-    }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Three QA summary tests repeat file-reader checks that the shared `readSummary` helper already exercises through real temporary JSON files. The duplicate scaffolding adds no independent filesystem or lifecycle boundary.

## Why This Change Was Made

Keep the existing failure/skip precedence and unsupported-shape tests, remove the repeated manual-file variants, and preserve the full missing-failure-signal diagnostic in the retained assertion. Completion state, execution evidence, inconsistent accounting, optional-skip policy, and unknown-status regressions stay intact.

## User Impact

No runtime behavior change. Maintainers keep the same summary-reader contracts with three fewer test executions and less duplicate cleanup scaffolding.

## Evidence

- Before: `node scripts/run-vitest.mjs extensions/qa-lab/src/suite-summary.test.ts` passed all 64 cases.
- After: the same focused command passed all 61 retained cases.
- Both retained precedence tests call the same file readers; the skipped-count fixture is identical. The retained failure-count fixture additionally contains a passing scenario and checks the opposite aggregate-dominance direction.
- Structured Codex autoreview returned scoped-clean. Production +0/-0; tests +3/-59 (net -56).
- Test-only change; no changelog or live-provider proof is required.
- Local changed gate passed, including extension test types, changed-file lint and boundary checks.
