### PR TITLE
improve: speed up session imports with less code

### DIFF
--- a/src/commands/doctor-session-sqlite-readers.ts
+++ b/src/commands/doctor-session-sqlite-readers.ts
@@ -72,7 +72,7 @@ export function countTranscriptEventsForPath(
   let events = 0;
   try {
     for (const line of iterateJsonlLinesSync(transcriptPath)) {
-      if (!parseJsonlLine(line)) {
+      if (!JSON.parse(line)) {
         continue;
       }
       events += 1;
@@ -90,88 +90,67 @@ export function createTranscriptEventReader(
   sourceFingerprint = readTranscriptFingerprint(transcriptPath),
 ): (append: (event: TranscriptEvent) => void) => () => void {
   return (append) => {
-    for (const event of readTranscriptEventsForImport(
+    // Production import owns the process-wide Gateway/SQLite-maintenance lock
+    // through commit and archive. Fingerprints catch non-cooperating external edits.
+    const plan = planTranscriptImport(transcriptPath, allowMalformedPrefix);
+    assertTranscriptFileUnchanged(transcriptPath, sourceFingerprint);
+    // V1 compactions refer to original row indexes. Stable index-derived IDs let
+    // the second pass resolve those links without retaining the transcript.
+    const idPrefix = createHash("sha256")
+      .update(transcriptPath)
+      .update("\0")
+      .update(sessionId)
+      .digest("hex")
+      .slice(0, 16);
+    assertTranscriptFileUnchanged(transcriptPath, sourceFingerprint);
+    const migratedTargetIds = new Map<number, string>();
+    const migrationState: SessionFileEntryMigrationState = {
+      createEntryId: (originalIndex) => `${idPrefix}-${originalIndex.toString(36)}`,
+      previousId: null,
+      resolveOriginalEntryId: (originalIndex) => migratedTargetIds.get(originalIndex),
+      sourceVersion: plan.sourceVersion,
+    };
+    for (const { event: loadedEvent, originalIndex } of iterateTranscriptEvents(
       transcriptPath,
-      sessionId,
       allowMalformedPrefix,
-      sourceFingerprint,
     )) {
+      let event = loadedEvent;
+      if (plan.sourceVersion >= 2) {
+        recordLegacyCompactionTarget(event, plan.compactionTargetIndexes);
+      }
+      let recognizedEvent: FileEntry | undefined;
+      if (originalIndex === plan.headerIndex) {
+        const canonicalHeader = {
+          ...event,
+          id: sessionId,
+          type: "session" as const,
+          timestamp: typeof event.timestamp === "string" ? event.timestamp : "",
+          cwd: "cwd" in event && typeof event.cwd === "string" ? event.cwd : "",
+        };
+        Reflect.deleteProperty(canonicalHeader, "sessionId");
+        event = canonicalHeader;
+        recognizedEvent = event;
+      } else {
+        const classified = classifySessionFileEntry(event, plan.sourceVersion);
+        // Runtime retains normalized opaque rows; import preserves their loaded bytes.
+        recognizedEvent = classified.recognized ? classified.entry : undefined;
+      }
+
+      if (recognizedEvent) {
+        migrateSessionFileEntryToCurrentVersion(recognizedEvent, originalIndex, migrationState);
+        if (
+          plan.sourceVersion < 2 &&
+          recognizedEvent.type !== "session" &&
+          plan.compactionTargetIndexes.has(originalIndex)
+        ) {
+          migratedTargetIds.set(originalIndex, recognizedEvent.id);
+        }
+        event = recognizedEvent;
+      }
       append(event as TranscriptEvent);
     }
+    assertTranscriptFileUnchanged(transcriptPath, sourceFingerprint);
     return () => assertTranscriptFileUnchanged(transcriptPath, sourceFingerprint);
-  };
-}
-
-function readTranscriptEventsForImport(
-  transcriptPath: string,
-  sessionId: string,
-  allowMalformedPrefix: boolean,
-  sourceFingerprint: TranscriptFileFingerprint,
-): Iterable<FileEntry> {
-  // Production import owns the process-wide Gateway/SQLite-maintenance lock
-  // through commit and archive. Fingerprints catch non-cooperating external edits.
-  const plan = planTranscriptImport(transcriptPath, allowMalformedPrefix);
-  assertTranscriptFileUnchanged(transcriptPath, sourceFingerprint);
-  // V1 compactions refer to original row indexes. Stable index-derived IDs let
-  // the second pass resolve those links without retaining the transcript.
-  const idPrefix = createHash("sha256")
-    .update(transcriptPath)
-    .update("\0")
-    .update(sessionId)
-    .digest("hex")
-    .slice(0, 16);
-
-  return {
-    *[Symbol.iterator]() {
-      assertTranscriptFileUnchanged(transcriptPath, sourceFingerprint);
-      const migratedTargetIds = new Map<number, string>();
-      const migrationState: SessionFileEntryMigrationState = {
-        createEntryId: (originalIndex) => `${idPrefix}-${originalIndex.toString(36)}`,
-        previousId: null,
-        resolveOriginalEntryId: (originalIndex) => migratedTargetIds.get(originalIndex),
-        sourceVersion: plan.sourceVersion,
-      };
-      for (const { event: loadedEvent, originalIndex } of iterateTranscriptEvents(
-        transcriptPath,
-        allowMalformedPrefix,
-      )) {
-        let event = loadedEvent;
-        if (plan.sourceVersion >= 2) {
-          recordLegacyCompactionTarget(event, plan.compactionTargetIndexes);
-        }
-        let recognizedEvent: FileEntry | undefined;
-        if (originalIndex === plan.headerIndex) {
-          const canonicalHeader = {
-            ...event,
-            id: sessionId,
-            type: "session" as const,
-            timestamp: typeof event.timestamp === "string" ? event.timestamp : "",
-            cwd: "cwd" in event && typeof event.cwd === "string" ? event.cwd : "",
-          };
-          Reflect.deleteProperty(canonicalHeader, "sessionId");
-          event = canonicalHeader;
-          recognizedEvent = event;
-        } else {
-          const classified = classifySessionFileEntry(event, plan.sourceVersion);
-          // Runtime retains normalized opaque rows; import preserves their loaded bytes.
-          recognizedEvent = classified.recognized ? classified.entry : undefined;
-        }
-
-        if (recognizedEvent) {
-          migrateSessionFileEntryToCurrentVersion(recognizedEvent, originalIndex, migrationState);
-          if (
-            plan.sourceVersion < 2 &&
-            recognizedEvent.type !== "session" &&
-            plan.compactionTargetIndexes.has(originalIndex)
-          ) {
-            migratedTargetIds.set(originalIndex, recognizedEvent.id);
-          }
-          event = recognizedEvent;
-        }
-        yield event;
-      }
-      assertTranscriptFileUnchanged(transcriptPath, sourceFingerprint);
-    },
   };
 }
 
@@ -271,7 +250,7 @@ function* iterateTranscriptEvents(
   let originalIndex = 0;
   try {
     for (const line of iterateJsonlLinesSync(transcriptPath)) {
-      const parsed = parseJsonlLine(line);
+      const parsed = JSON.parse(line);
       if (!parsed) {
         continue;
       }
@@ -527,7 +506,7 @@ export function listExistingAgentDatabaseTargets(
   );
 }
 
-function* iterateJsonlLinesSync(filePath: string): Generator<{ lineNumber: number; text: string }> {
+function* iterateJsonlLinesSync(filePath: string): Generator<string> {
   const fd = fs.openSync(filePath, "r");
   const decoder = new TextDecoder("utf-8", { fatal: true });
   const buffer = Buffer.allocUnsafe(JSONL_READ_CHUNK_BYTES);
@@ -551,7 +530,7 @@ function* iterateJsonlLinesSync(filePath: string): Generator<{ lineNumber: numbe
         lineNumber += 1;
         const text = parts[index]!.trim();
         if (text) {
-          yield { lineNumber, text };
+          yield text;
         }
       }
       fragments.push(parts.at(-1)!);
@@ -559,7 +538,7 @@ function* iterateJsonlLinesSync(filePath: string): Generator<{ lineNumber: numbe
     fragments.push(decoder.decode());
     const text = fragments.join("").trim();
     if (text) {
-      yield { lineNumber: lineNumber + 1, text };
+      yield text;
     }
   } catch (err) {
     throw new Error(`${filePath}:${lineNumber + 1}: ${String(err)}`, { cause: err });
@@ -576,8 +555,4 @@ function sqliteNumber(value: unknown): number {
     return Number(value);
   }
   return 0;
-}
-
-function parseJsonlLine(line: { text: string }): unknown {
-  return JSON.parse(line.text);
 }

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -67,6 +67,7 @@ type TranscriptAppendCursor = {
   appendToIndex?: ReturnType<typeof createTranscriptIndexAppenderInTransaction>;
   updateWindow?: (createdAt: number) => unknown;
   insertEvent?: ReturnType<typeof createTranscriptEventInserter>;
+  insertIdentity?: ReturnType<typeof createTranscriptIdentityInserter>;
 };
 
 function createTranscriptEventInserter(database: OpenClawAgentDatabase, sessionId: string) {
@@ -81,6 +82,32 @@ function createTranscriptEventInserter(database: OpenClawAgentDatabase, sessionI
           event_json: parameter((row) => row.eventJson),
           created_at: parameter((row) => row.createdAt),
         }),
+  );
+}
+
+function createTranscriptIdentityInserter(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  ignoreConflicts: boolean,
+) {
+  return prepareSqliteQuerySync<
+    NonNullable<ReturnType<typeof readTranscriptEventIdentity>> & { seq: number; createdAt: number }
+  >(database.db, (parameter) =>
+    getSessionKysely(database.db)
+      .insertInto("transcript_event_identities")
+      .values({
+        session_id: sessionId,
+        event_id: parameter((row) => row.eventId),
+        seq: parameter((row) => row.seq),
+        event_type: parameter((row) => row.eventType),
+        parent_id: parameter((row) => row.parentId),
+        // An unowned key is SQL NULL, also the schema default when previously omitted.
+        message_idempotency_key: parameter((row) => row.messageIdempotencyKey),
+        created_at: parameter((row) => row.createdAt),
+      })
+      .$if(ignoreConflicts, (query) =>
+        query.onConflict((conflict) => conflict.columns(["session_id", "event_id"]).doNothing()),
+      ),
   );
 }
 
@@ -164,25 +191,12 @@ function appendTranscriptEvent(
           .where("event_id", "=", idempotencyKeyOwner.eventId),
       );
     }
-    const indexedMessageIdempotencyKey =
+    identity.messageIdempotencyKey =
       idempotencyKeyOwner && options.idempotencyKeyMode !== "relocate-owner"
-        ? undefined
+        ? null
         : identity.messageIdempotencyKey;
-    executeSqliteQuerySync(
-      database.db,
-      db
-        .insertInto("transcript_event_identities")
-        .values({
-          session_id: scope.sessionId,
-          event_id: identity.eventId,
-          seq,
-          event_type: identity.eventType,
-          parent_id: identity.parentId,
-          message_idempotency_key: indexedMessageIdempotencyKey,
-          created_at: createdAt,
-        })
-        .onConflict((conflict) => conflict.columns(["session_id", "event_id"]).doNothing()),
-    );
+    cursor.insertIdentity ??= createTranscriptIdentityInserter(database, scope.sessionId, true);
+    cursor.insertIdentity({ ...identity, seq, createdAt });
   }
   scheduleTranscriptProjectionReconcile(database, scope.sessionId, projectionNeedsRebuild, options);
   return true;
@@ -269,11 +283,11 @@ function appendTranscriptEventRowInTransaction(
     seenEventIds: Set<string>;
     seenMessageIdempotencyKeys: Set<string>;
     insertEvent: ReturnType<typeof createTranscriptEventInserter>;
+    insertIdentity: ReturnType<typeof createTranscriptIdentityInserter>;
   },
   createdAtOverride?: number,
 ): boolean {
   const persistedEvent = canonicalizeTranscriptEventMedia(event);
-  const db = getSessionKysely(database.db);
   const createdAt = createdAtOverride ?? readEventTimestamp(persistedEvent) ?? Date.now();
   const identity = readTranscriptEventIdentity(persistedEvent);
   if (identity && state.seenEventIds.has(identity.eventId)) {
@@ -291,26 +305,14 @@ function appendTranscriptEventRowInTransaction(
     return true;
   }
   state.seenEventIds.add(identity.eventId);
-  const indexedMessageIdempotencyKey =
-    identity.messageIdempotencyKey &&
-    !state.seenMessageIdempotencyKeys.has(identity.messageIdempotencyKey)
-      ? identity.messageIdempotencyKey
-      : undefined;
-  if (indexedMessageIdempotencyKey) {
-    state.seenMessageIdempotencyKeys.add(indexedMessageIdempotencyKey);
+  if (identity.messageIdempotencyKey) {
+    if (state.seenMessageIdempotencyKeys.has(identity.messageIdempotencyKey)) {
+      identity.messageIdempotencyKey = null;
+    } else {
+      state.seenMessageIdempotencyKeys.add(identity.messageIdempotencyKey);
+    }
   }
-  executeSqliteQuerySync(
-    database.db,
-    db.insertInto("transcript_event_identities").values({
-      session_id: scope.sessionId,
-      event_id: identity.eventId,
-      seq,
-      event_type: identity.eventType,
-      parent_id: identity.parentId,
-      message_idempotency_key: indexedMessageIdempotencyKey,
-      created_at: createdAt,
-    }),
-  );
+  state.insertIdentity({ ...identity, seq, createdAt });
   return true;
 }
 
@@ -444,6 +446,7 @@ export function replaceSqliteTranscriptEventsInTransaction(
     seenEventIds: new Set<string>(),
     seenMessageIdempotencyKeys: new Set<string>(),
     insertEvent: createTranscriptEventInserter(database, resolved.sessionId),
+    insertIdentity: createTranscriptIdentityInserter(database, resolved.sessionId, false),
   };
   for (const [eventIndex, event] of events.entries()) {
     if (
@@ -662,14 +665,7 @@ function readTranscriptMessageByIdentity(
   return { messageId: identity.eventId, message: event.message };
 }
 
-function readTranscriptEventIdentity(event: unknown):
-  | {
-      eventId: string;
-      eventType: string | null;
-      parentId: string | null;
-      messageIdempotencyKey: string | null;
-    }
-  | undefined {
+function readTranscriptEventIdentity(event: unknown) {
   if (!isRecord(event)) {
     return undefined;
   }


### PR DESCRIPTION
Related: #133689

## What Problem This Solves

Large legacy session imports still spend CPU rebuilding identical identity inserts and forwarding each parsed row through a private generator whose only consumer is the import callback. This maintainer-requested performance pass also reduces the implementation's size.

## Why This Change Was Made

The existing synchronous batch now owns a prepared identity insert, shared with transcript replacement. Append keeps its conflict-ignore clause; replacement keeps its hard-conflict behavior. An unowned message key binds NULL, equivalent to the existing nullable column's implicit default when omitted. Identity objects are local copies, so caller events remain untouched.

The Doctor reader feeds its existing append callback directly and yields plain JSONL strings. This deletes the unused iterable, forwarding loop, per-line wrapper and parse adapter while preserving the original fingerprint checks, parsing/error boundaries, compaction limits and legacy row indexes. No schema, index, retention, concurrency, dependency, public API or configuration changes.

Production: +101/-130, **net -29 lines** across two existing modules. Tests: unchanged. No new abstraction modules or compatibility paths.

## User Impact

Less CPU and allocation work during session import, with the same stored events, identity ownership and projections. Transcript replacement also reuses the identity-insert compilation. Linux Node 24 measurements show 13.7% less time and 15.4% less CPU for 100,000-event histories; legacy metadata histories take 17.9% less time. Replay is approximately neutral. Local exploratory timings are noisy and are not used as performance claims.

## Evidence

- **345 tests passed**, ten files and three shards, in 126.28s:
  `node scripts/run-vitest.mjs src/commands/doctor-session-sqlite-readers.test.ts src/commands/doctor-session-sqlite.test.ts src/config/sessions/session-accessor.sqlite-import.test.ts src/config/sessions/session-accessor.sqlite-transcript-store.test.ts src/config/sessions/session-transcript-context-eligibility.test.ts src/config/sessions/session-accessor.test.ts src/infra/kysely-sync.test.ts src/config/sessions/session-accessor.conformance.test.ts src/config/sessions/session-accessor.parent-fork.test.ts src/config/sessions/session-accessor.sqlite-message-cut.test.ts`
- Scoped lint and formatting passed. Aggregate changed checks passed structural checks and three Knip scans, then stopped on six pre-existing `src/logging/logger.ts` typing errors because shared `node_modules/tslog/types/BaseLogger.d.ts` is absent; shared dependencies are untouched. [Exact-head CI run 33351712826](https://github.com/openclaw/openclaw/actions/runs/33351712826) completed successfully.
- Independent Codex autoreview: scoped-clean through P3, confidence 0.94.
- Paired pre/post behavior execution matched append and replacement deduplication/ownership, preserved caller inputs, and propagated callback failures while closing both reader descriptors with prefix recovery on and off.
- Existing tests cover UTF-8 chunk splits, BOM/CRLF/blank/giant rows, v1-v4 and opaque rows, malformed tails, target limits, source mutation, import rollback/replay, fork and message-cut siblings.
- Direct contracts inspected: `src/infra/kysely-sync.ts:273`, installed Kysely insert-value parsing and `$if`, and `src/state/openclaw-agent-schema.sql:459`. Reviewer CLI isolation checked in sibling Codex `codex-rs/exec/src/cli.rs:25` and `codex-rs/utils/cli/src/shared_options.rs:35`.
- Linux Node 24.19.0 / SQLite 3.53.3: **45 alternating before/after pairs**, fresh processes, nine shapes, exact persisted data parity (events, identities, windows, active positions, index state and FTS). Timers exclude synthetic fixture creation and parity checks. Baseline `cfc959c35e8ad6d1eaf1a5dc5776ff959a7a7f76`; candidate `c8924b4f8beb9faac7399fd9b1b22d0e30117b90`. Both changed owners were verified in the baseline override build; all other sources/dependencies were identical.
- Traced 10k-event imports retain exactly **100,034 SQL calls across 34 shapes**. Eight import-region CPU profiles completed; deep-history Kysely self samples fell from 1,033.3 to 742.9 ms. Profiles support attribution; unprofiled pairs supply timing claims.
- Worker: [Blacksmith Testbox run 33351665219](https://github.com/openclaw/openclaw/actions/runs/33351665219), lease `tbx_01m1ava13jrc7efa24n26gt2r6`; benchmark command passed in 250.8s.
- Memory is **not uniformly lower**: median peak RSS deep 480.5 → 474.7 MiB, legacy-v2 407.8 → 449.9 MiB, replay 466.3 → 392.1 MiB. No general memory-reduction claim. Both existing 256 MiB heap stress tests passed on Node 26.8.1: 256 large-payload sessions and one 100,000-event history, including branch projections and rerun checks. Command: `node scripts/run-vitest.mjs src/commands/doctor-session-sqlite.memory.test.ts`; two tests in 63.42s, bringing the total to **347 passing tests**.
- **Packaged Docker upgrade passed** from latest stable `2026.7.1-2` to exact candidate `c8924b4f8beb9faac7399fd9b1b22d0e30117b90`: 4,800 sessions, **1,227,946 events**, and **10,000 cron jobs** survived. Automatic migration was asserted immediately after update and before the later standalone idempotence Doctor. Eight Gateway history samples (600 messages across two agents) matched after restart. Idempotence Doctor took 41s (60s budget), startup 11s; health/ready/status probes passed. Lane 548s, total command 850.3s.
- Docker proof command: `env OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 OPENCLAW_DOCKER_ALL_LANES=published-upgrade-survivor OPENCLAW_DOCKER_ALL_LOG_DIR=.artifacts/docker-tests/migration-round12-deep OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS=2026.7.1-2 OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS=sqlite-volume OPENCLAW_UPGRADE_SURVIVOR_VOLUME_SESSIONS=4800 OPENCLAW_UPGRADE_SURVIVOR_VOLUME_EVENTS_PER_SESSION=257 OPENCLAW_UPGRADE_SURVIVOR_VOLUME_CRON_JOBS=10000 node scripts/test-docker-all.mjs` on the same Blacksmith worker.
- Scope limits: explicit candidate tarball, manual Gateway restart, expected synthetic plugin capability consent. This verifies automatic migration during update, **not unattended update-channel switching**. Legacy performance is covered separately by the paired v1/v2 fixtures.

Best-fix judgment: share the existing prepared-query mechanism and remove the reader's unused forwarding layer. Retaining two identity SQL definitions or adding a result cache would increase duplication or change freshness. Codec classification remains unchanged because runtime and import intentionally treat normalized opaque rows differently.

Linux whole-import medians (five pairs per shape):

| Shape | Before ms | After ms | Less time | Less CPU |
|---|---:|---:|---:|---:|
| single | 8.8 | 8.1 | 7.7% | 5.5% |
| deep | 5939.3 | 5123.4 | 13.7% | 15.4% |
| wide | 699.4 | 652.6 | 6.7% | 5.6% |
| branch | 1081.2 | 1020.3 | 5.6% | 2.9% |
| replay | 177.9 | 174.1 | 2.1% | 0.9% |
| legacy-v1 | 684.5 | 595.6 | 13.0% | 14.4% |
| legacy-v2 | 602.8 | 553.5 | 8.2% | 1.6% |
| legacy-metadata-v1 | 326.1 | 267.7 | 17.9% | 19.3% |
| legacy-hooks-v2 | 495.7 | 438.6 | 11.5% | 12.9% |

Four of five deep-history pairs favored the candidate; one was approximately tied/slower. Smaller shapes remain noisy. Per-pair data and all profiles are retained in the task artifacts.

ClawSweeper review disposition (02:58 UTC, exact candidate head): no code/security findings and no Rank-up moves listed. Its current-main source retrieval gap is resolved locally: both complete touched modules are unchanged from the benchmark baseline at the review's cited `237f23b4589795a91dc63778c41d27624bb336dc`, native-review main `bc1dfcd091ddcf51e4c7dd762484a39dabe1c9b7`, and subsequently fetched main `bca1b19867f01d040f31d05f68646d64592d7be2`. Exact-head CI run 33351712826 and the packaged upgrade are now green. Native prepare completed without a rebase or head change.
