### PR TITLE
test: remove redundant plugin construction and stream smoke checks

### DIFF
--- a/extensions/github-copilot/stream.test.ts
+++ b/extensions/github-copilot/stream.test.ts
@@ -778,28 +778,6 @@ describe("wrapCopilotAnthropicStream", () => {
     });
   });
 
-  it("adapts provider stream context without changing wrapper behavior", () => {
-    const baseStreamFn = vi.fn(() => ({ async *[Symbol.asyncIterator]() {} }) as never);
-
-    const wrapped = requireStreamFn(
-      wrapCopilotProviderStream({
-        streamFn: baseStreamFn,
-      } as never),
-    );
-
-    void wrapped(
-      {
-        provider: "github-copilot",
-        api: "openai-responses",
-        id: "gpt-4.1",
-      } as never,
-      { messages: [{ role: "user", content: "hi" }] } as never,
-      {},
-    );
-
-    expect(baseStreamFn).toHaveBeenCalledOnce();
-  });
-
   it("does not claim provider transport before OpenClaw chooses one", () => {
     expect(
       wrapCopilotProviderStream({

--- a/extensions/msteams/src/sdk.test.ts
+++ b/extensions/msteams/src/sdk.test.ts
@@ -74,19 +74,6 @@ describe("createMSTeamsApp", () => {
     expect(app.tokenManager).toBeDefined();
   });
 
-  it("creates app with secret credentials", async () => {
-    const creds: MSTeamsCredentials = {
-      type: "secret",
-
-      appId: "test-app-id",
-      appPassword: "test-secret",
-      tenantId: "test-tenant",
-    };
-
-    const app = await createMSTeamsApp(creds);
-    expect(app).toBeDefined();
-  });
-
   it("keeps private QA App options absent in production", async () => {
     const app = await createMSTeamsApp({
       type: "secret",
@@ -281,20 +268,6 @@ describe("createMSTeamsApp", () => {
       expect(error.message).toContain("Failed to read certificate file");
       expect(error.message).not.toContain(certificatePath);
     }
-  });
-
-  it("creates app with managed identity credentials", async () => {
-    const creds: MSTeamsFederatedCredentials = {
-      type: "federated",
-
-      appId: "test-app-id",
-      tenantId: "test-tenant",
-
-      useManagedIdentity: true,
-    };
-
-    const app = await createMSTeamsApp(creds);
-    expect(app).toBeDefined();
   });
 
   it("creates app with user-assigned managed identity", async () => {


### PR DESCRIPTION
## What Problem This Solves

Three plugin smoke tests repeat success paths already exercised by stronger tests: MS Teams secret and system-managed-identity App construction, and Copilot Responses stream delegation.

## Why This Change Was Made

Remove only the weak existence/call-count replays. Retain the named Teams Express regression and real SDK credential-selection checks, including ambient-secret isolation. Retain the Copilot Responses test that checks exactly one delegation plus headers and sanitized payload, and all transport/replay sibling tests.

## User Impact

No runtime behavior changes. Three fewer test executions, with SDK construction, auth selection, stream payloads, and loopback transport proof retained.

## Evidence

- Before: focused Teams SDK and Copilot stream suites passed all 42 cases.
- After: `node scripts/run-vitest.mjs extensions/msteams/src/sdk.test.ts extensions/github-copilot/stream.test.ts` passed all 39 retained cases.
- Inspected the installed Teams SDK credential getter and credential initialization: the retained test checks the actual SDK selection result, not a mocked constructor argument.
- Copilot's wrapper dispatches by provider/API, so the deleted smoke test's model ID adds no independent branch.
- Structured Codex autoreview returned scoped-clean. Production +0/-0; tests +0/-49.
- Test-only change; no changelog or live-service claim required.
- Local changed gate passed, including extension test types, changed-file lint and package boundary checks.
