### PR TITLE
fix: settle cancelled runs without ending cron retries early

### DIFF
--- a/docs/concepts/agent-loop.md
+++ b/docs/concepts/agent-loop.md
@@ -20,7 +20,7 @@ execution, streaming, persistence.
 1. `agent` RPC validates params, resolves the session (`sessionKey`/`sessionId`), persists session metadata, and returns `{ runId, acceptedAt }` immediately.
 2. `agentCommand` runs the turn: resolves model + thinking/verbose/trace defaults, loads the skills snapshot, calls `runEmbeddedAgent`, and emits a fallback **lifecycle end/error** if the embedded loop did not already emit one.
 3. `runEmbeddedAgent`: serializes runs via per-session and global queues, resolves model + auth profile, builds the OpenClaw session, subscribes to runtime events, streams assistant/tool deltas, enforces the run timeout (aborting on expiry), and returns payloads plus usage metadata. For Codex app-server turns, native Codex owns provider liveness and the exact `turn/completed` outcome; quiet periods and assistant output do not end the turn.
-4. `subscribeEmbeddedAgentSession` bridges runtime events to the `agent` stream: tool events to `stream: "tool"`, assistant deltas to `stream: "assistant"`, lifecycle events to `stream: "lifecycle"` (`phase: "start" | "end" | "error"`).
+4. `subscribeEmbeddedAgentSession` bridges runtime events to the `agent` stream: tool events to `stream: "tool"`, assistant deltas to `stream: "assistant"`, lifecycle events to `stream: "lifecycle"` (`phase: "start" | "finishing" | "end" | "error"`).
 5. `agent.wait` (`waitForAgentRun`) waits for **lifecycle end/error** on a `runId` and returns `{ status: ok|error|timeout, startedAt, endedAt, error? }`.
 
 ## Queueing and concurrency
@@ -124,7 +124,27 @@ or raw errors out of the transcript/runtime path.
 
 ## Chat channel handling
 
-Assistant deltas buffer into chat `delta` messages. A chat `final` is emitted on **lifecycle end/error**.
+Assistant deltas buffer into chat `delta` messages. Terminal lifecycle events
+produce chat `final`, `error`, or `aborted` messages. Definitive cancellation and
+timeout events finalize immediately, including when the runtime reports them as
+`phase: "error"`. Retryable errors keep a 15-second grace window for a fallback
+or restart of the same run. Once the outer execution owner has finished its
+attempts, it publishes `executionSettled: true`. The Gateway and `agent.wait`
+consume that fact immediately, including preparation failures that never reached
+a model or emitted a fallback step. Unmarked timeout and bare-abort observations
+retain their existing wait-layer retry handling.
+
+Cron attempt completions remain `finishing` across model fallbacks and
+interim-acknowledgment retries; worker `finishing` events do not claim execution
+settlement. Completed execution facts are captured before cron bookkeeping, but
+finality is published only after execution settles. A new attempt clears the
+prior outcome before preparation. Later workflow errors or aborts cannot
+reclassify completed execution; cron persistence, delivery, and yielded-parent
+continuation retain their separate outcomes.
+
+History keeps a run active while its terminal session write is pending. Once
+that write succeeds, history and session activity show the recorded end time
+and duration without waiting for retry grace.
 
 Live snapshots are scoped to their assistant message. A correction can shorten or clear the current preview without erasing earlier messages. Pending text is flushed before the terminal event; pacing live updates does not delay tool execution or transcript writes.
 

--- a/extensions/browser/chrome-extension/background.fetch-continuation.test.ts
+++ b/extensions/browser/chrome-extension/background.fetch-continuation.test.ts
@@ -1,0 +1,423 @@
+import assert from "node:assert/strict";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ExtensionRelayBridge } from "../src/browser/extension-relay/relay-bridge.js";
+import { FakeSocket } from "../src/browser/extension-relay/relay-bridge.test-support.js";
+import {
+  cleanupBackgroundHarnesses,
+  loadRelayCommandHarness,
+  sendRuntimeMessage,
+} from "./background.test-harness.js";
+
+type Frame = {
+  id?: number;
+  method?: string;
+  result?: Record<string, unknown>;
+  error?: { message: string };
+  params?: {
+    sessionId?: string;
+    requestId?: string;
+    targetId?: string;
+    targetInfo?: { targetId?: string };
+  };
+};
+type FetchOperation = {
+  method: string;
+  stage?: "response" | "auth";
+  params?: Record<string, unknown>;
+  result?: Record<string, unknown>;
+};
+const continueRequest: FetchOperation = { method: "Fetch.continueRequest" };
+const siblingContinuations: FetchOperation[] = [
+  { method: "Fetch.continueResponse", stage: "response" },
+  {
+    method: "Fetch.continueWithAuth",
+    stage: "auth",
+    params: { authChallengeResponse: { response: "Default" } },
+  },
+  { method: "Fetch.failRequest", params: { errorReason: "Aborted" } },
+  { method: "Fetch.fulfillRequest", params: { responseCode: 200 } },
+];
+const bodyReads: FetchOperation[] = [
+  {
+    method: "Fetch.getResponseBody",
+    stage: "response",
+    result: { body: "private", base64Encoded: false },
+  },
+  {
+    method: "Fetch.takeResponseBodyAsStream",
+    stage: "response",
+    result: { stream: "native-body" },
+  },
+];
+const releases = new Set<() => void>();
+const cleanups: Array<() => Promise<void>> = [];
+function deferred() {
+  let release = () => {};
+  const promise = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const finish = () => {
+    releases.delete(finish);
+    release();
+  };
+  releases.add(finish);
+  return { promise, resolve: finish };
+}
+
+beforeEach(() => vi.resetModules());
+afterEach(async () => {
+  for (const release of releases) {
+    release();
+  }
+  await cleanupBackgroundHarnesses();
+  for (const cleanup of cleanups.splice(0).toReversed()) {
+    await cleanup();
+  }
+  vi.unstubAllGlobals();
+});
+
+function connectClient(bridge: ExtensionRelayBridge) {
+  const socket = new FakeSocket();
+  const handlers = bridge.attachCdpClientSocket(socket);
+  const frames = () => socket.frames() as Frame[];
+  let id = 0;
+  const send = (method: string, params: Record<string, unknown> = {}, sessionId?: string) => {
+    const requestId = ++id;
+    handlers.onMessage(JSON.stringify({ id: requestId, method, params, sessionId }));
+    return requestId;
+  };
+  const response = async (requestId: number) =>
+    await vi.waitFor(() => {
+      const frame = frames().find((entry) => entry.id === requestId);
+      assert(frame, `missing CDP reply ${requestId}`);
+      return frame;
+    });
+  return {
+    frames,
+    close: handlers.onClose,
+    send,
+    response,
+    request: async (method: string, params: Record<string, unknown> = {}, sessionId?: string) =>
+      await response(send(method, params, sessionId)),
+    root(targetId: string) {
+      const attached = frames().find(
+        (frame) =>
+          frame.method === "Target.attachedToTarget" &&
+          frame.params?.targetInfo?.targetId === targetId,
+      );
+      const sessionId = attached?.params?.sessionId;
+      assert(typeof sessionId === "string");
+      return sessionId;
+    },
+  };
+}
+
+async function setupTarget(mode: "all" | "selected", operation = continueRequest) {
+  const harness = await loadRelayCommandHarness(mode);
+  const bridge = new ExtensionRelayBridge();
+  const extension = bridge.attachExtensionSocket({
+    send: (raw) => harness.socket.receive(JSON.parse(raw)),
+    close: () => harness.socket.close(),
+  });
+  harness.socket.addEventListener("close", extension.onClose);
+  const hello = harness.frames().find((frame) => frame.type === "hello");
+  assert(hello);
+  harness.socket.send.mockImplementation(extension.onMessage);
+  extension.onMessage(JSON.stringify(hello));
+  const owner = connectClient(bridge);
+  const observer = connectClient(bridge);
+  cleanups.push(async () => {
+    await Promise.all([owner.close(), observer.close()]);
+    bridge.dispose();
+  });
+  for (const client of [owner, observer]) {
+    expect(
+      await client.request("Target.setAutoAttach", { autoAttach: true, flatten: true }),
+    ).toMatchObject({ result: {} });
+  }
+  const created = await owner.request("Target.createTarget", { url: "about:blank" });
+  expect(created).toMatchObject({ result: { targetId: "tab-101" } });
+  const targetId = "tab-101";
+  const session = owner.root(targetId);
+  const observerSession = observer.root(targetId);
+  const target = bridge.captureOperationTarget(targetId);
+  assert(target);
+  return {
+    harness,
+    bridge,
+    owner,
+    observer,
+    session,
+    observerSession,
+    target,
+    targetId,
+    operation,
+  };
+}
+
+async function setup(mode: "all" | "selected", operation = continueRequest) {
+  const rig = await setupTarget(mode, operation);
+  const { harness, owner, observer, session, observerSession, target, targetId } = rig;
+  expect(await owner.request("Fetch.enable", { handleAuthRequests: true }, session)).toMatchObject({
+    result: {},
+  });
+  const event = operation.stage === "auth" ? "Fetch.authRequired" : "Fetch.requestPaused";
+  harness.debuggerEventListener?.({ tabId: 101 }, event, {
+    requestId: "native-navigation-request",
+    request: { url: "https://example.com/destination", method: "GET", headers: {} },
+    frameId: "frame-101",
+    resourceType: "Document",
+    ...(operation.stage === "response" ? { responseStatusCode: 200 } : {}),
+    ...(operation.stage === "auth"
+      ? { authChallenge: { origin: "https://example.com", scheme: "basic", realm: "test" } }
+      : {}),
+  });
+  const requestId = owner.frames().findLast((frame) => frame.method === event)?.params?.requestId;
+  assert(typeof requestId === "string");
+  assert.notEqual(requestId, "native-navigation-request");
+  expect(observer.frames().filter((frame) => frame.method === event)).toEqual([]);
+  const params: Record<string, unknown> = { ...operation.params, requestId };
+  const beforeForeign = harness.debuggerSendCommand.mock.calls.length;
+  expect(await observer.request(operation.method, params, observerSession)).toMatchObject({
+    error: { message: expect.stringContaining("another session") },
+  });
+  expect(harness.debuggerSendCommand.mock.calls).toHaveLength(beforeForeign);
+  expect(target()).toBe(targetId);
+  return { ...rig, params };
+}
+
+async function setupConfiguration(mode: "all" | "selected", method: string) {
+  const rig = await setupTarget(mode, { method });
+  if (method === "Fetch.disable") {
+    expect(await rig.owner.request("Fetch.enable", {}, rig.session)).toMatchObject({ result: {} });
+  }
+  return { ...rig, params: {} };
+}
+
+async function holdNativeCompletion(rig: Awaited<ReturnType<typeof setup>>) {
+  const started = deferred();
+  const completed = deferred();
+  const native = rig.harness.debuggerSendCommand.getMockImplementation()!;
+  rig.harness.debuggerSendCommand.mockImplementation(async (source, method, params) => {
+    if (method !== rig.operation.method) {
+      return await native(source, method, params);
+    }
+    const expectedParams = Object.hasOwn(rig.params, "requestId")
+      ? { ...rig.params, requestId: "native-navigation-request" }
+      : rig.params;
+    expect(params).toEqual(expectedParams);
+    started.resolve();
+    await completed.promise;
+    return rig.operation.result ?? {};
+  });
+  const id = rig.owner.send(rig.operation.method, rig.params, rig.session);
+  await started.promise;
+  return { id, complete: completed.resolve };
+}
+
+function commitAllowed(rig: Awaited<ReturnType<typeof setup>>) {
+  rig.harness.updateTab(101, { url: "https://example.com/destination", pendingUrl: undefined });
+  rig.harness.debuggerEventListener?.({ tabId: 101 }, "Page.frameNavigated", {
+    frame: {
+      id: "frame-101",
+      url: "https://example.com/destination",
+      loaderId: "destination-loader",
+    },
+  });
+  rig.harness.debuggerEventListener?.({ tabId: 101 }, "Page.lifecycleEvent", {
+    name: "load",
+    frameId: "frame-101",
+  });
+}
+
+function nativeCalls(rig: Awaited<ReturnType<typeof setup>>) {
+  return rig.harness.debuggerSendCommand.mock.calls.filter(
+    ([, method]) => method === rig.operation.method,
+  );
+}
+
+async function assertReceiptAndContinuity(rig: Awaited<ReturnType<typeof setup>>, response: Frame) {
+  const ownerRead = await rig.owner.request("Page.getFrameTree", {}, rig.session);
+  const observerRead = await rig.observer.request("Page.getFrameTree", {}, rig.observerSession);
+  expect.soft(response).toMatchObject({ result: {} });
+  expect.soft(response.error).toBeUndefined();
+  expect.soft(rig.target()).toBe(rig.targetId);
+  for (const client of [rig.owner, rig.observer]) {
+    expect
+      .soft(
+        client
+          .frames()
+          .filter(
+            (frame) =>
+              frame.method === "Target.detachedFromTarget" &&
+              frame.params?.targetId === rig.targetId,
+          ),
+      )
+      .toHaveLength(0);
+  }
+  expect.soft(ownerRead).toMatchObject({ result: {} });
+  expect.soft(observerRead).toMatchObject({ result: {} });
+  expect(nativeCalls(rig)).toHaveLength(1);
+  expect(rig.bridge.cdpClientCount).toBe(2);
+}
+
+// The native completion is the only fault-injected boundary. Real background
+// policy, Fetch lease/pause ownership, and both logical relay sessions participate.
+describe.each(["all", "selected"] as const)("Fetch continuation in %s", (mode) => {
+  it.each(["completion-first", "commit-first"] as const)(
+    "preserves receipt and both target sessions: %s",
+    async (order) => {
+      const rig = await setup(mode);
+      const held = await holdNativeCompletion(rig);
+      if (order === "commit-first") {
+        commitAllowed(rig);
+      }
+      held.complete();
+      const response = await rig.owner.response(held.id);
+      if (order === "completion-first") {
+        commitAllowed(rig);
+      }
+      await assertReceiptAndContinuity(rig, response);
+    },
+  );
+
+  it.each(siblingContinuations)(
+    "preserves $method receipt across an allowed document commit",
+    async (operation) => {
+      const rig = await setup(mode, operation);
+      const held = await holdNativeCompletion(rig);
+      commitAllowed(rig);
+      held.complete();
+      await assertReceiptAndContinuity(rig, await rig.owner.response(held.id));
+    },
+  );
+
+  it.each(
+    ["Fetch.enable", "Fetch.disable"].flatMap((method) =>
+      ["completion-first", "commit-first"].map((order) => ({ method, order })),
+    ),
+  )(
+    "preserves configuration $method completion ($order) and lease ownership",
+    async ({ method, order }) => {
+      const rig = await setupConfiguration(mode, method);
+      const held = await holdNativeCompletion(rig);
+      expect(await rig.observer.request("Fetch.enable", {}, rig.observerSession)).toMatchObject({
+        error: { message: expect.stringContaining("another session") },
+      });
+      expect(nativeCalls(rig)).toHaveLength(1);
+      if (order === "commit-first") {
+        commitAllowed(rig);
+      }
+      held.complete();
+      const response = await rig.owner.response(held.id);
+      if (order === "completion-first") {
+        commitAllowed(rig);
+      }
+      await assertReceiptAndContinuity(rig, response);
+      const successor = await rig.observer.request("Fetch.enable", {}, rig.observerSession);
+      if (method === "Fetch.disable") {
+        expect.soft(successor).toMatchObject({ result: {} });
+      } else {
+        expect.soft(successor).toMatchObject({
+          error: { message: expect.stringContaining("another session") },
+        });
+        expect(nativeCalls(rig)).toHaveLength(1);
+      }
+    },
+  );
+
+  it.each(["Fetch.enable", "Fetch.disable"])(
+    "rejects configuration %s completion after access revocation",
+    async (method) => {
+      const rig = await setupConfiguration(mode, method);
+      const held = await holdNativeCompletion(rig);
+      await sendRuntimeMessage(rig.harness, {
+        type: "toggleTabAccess",
+        tabId: 101,
+        accessMode: mode,
+        grant: false,
+      });
+      held.complete();
+      const response = await rig.owner.response(held.id);
+      expect(response.error).toBeDefined();
+      expect(response).not.toHaveProperty("result");
+      expect(await rig.owner.request("Page.getFrameTree", {}, rig.session)).toHaveProperty("error");
+      expect(nativeCalls(rig)).toHaveLength(1);
+    },
+  );
+
+  it("rejects disable with an unresolved streamed response without retiring its owner", async () => {
+    const operation = bodyReads.find((entry) => entry.method === "Fetch.takeResponseBodyAsStream");
+    assert(operation);
+    const rig = await setup(mode, operation);
+    const held = await holdNativeCompletion(rig);
+    held.complete();
+    const response = await rig.owner.response(held.id);
+    expect(response).toMatchObject({
+      result: { stream: expect.stringMatching(/^openclaw-fetch-stream:/) },
+    });
+    expect(await rig.owner.request("Fetch.disable", {}, rig.session)).toMatchObject({
+      error: { message: expect.stringContaining("streamed responses") },
+    });
+    expect(
+      rig.harness.debuggerSendCommand.mock.calls.filter(([, method]) => method === "Fetch.disable"),
+    ).toHaveLength(0);
+    await assertReceiptAndContinuity(rig, response);
+  });
+
+  it.each(bodyReads)("keeps $method data document-sensitive", async (operation) => {
+    const rig = await setup(mode, operation);
+    const held = await holdNativeCompletion(rig);
+    commitAllowed(rig);
+    held.complete();
+    const response = await rig.owner.response(held.id);
+    expect(response.error).toBeDefined();
+    expect(response).not.toHaveProperty("result");
+    expect(nativeCalls(rig)).toHaveLength(1);
+  });
+
+  it.each(["access", "tab-removal", "attachment", "connection"] as const)(
+    "rejects completion after genuine %s revocation",
+    async (revocation) => {
+      const rig = await setup(mode);
+      const held = await holdNativeCompletion(rig);
+      switch (revocation) {
+        case "access":
+          await sendRuntimeMessage(rig.harness, {
+            type: "toggleTabAccess",
+            tabId: 101,
+            accessMode: mode,
+            grant: false,
+          });
+          break;
+        case "tab-removal":
+          await rig.harness.tabsRemove(101);
+          break;
+        case "attachment":
+          rig.harness.debuggerDetachListener?.({ tabId: 101 }, "target_closed");
+          break;
+        case "connection":
+          rig.harness.socket.close();
+          break;
+      }
+      held.complete();
+      const response = await rig.owner.response(held.id);
+      const successor = await rig.owner.request("Page.getFrameTree", {}, rig.session);
+      expect(response.error).toBeDefined();
+      expect(response).not.toHaveProperty("result");
+      expect(successor.error).toBeDefined();
+      expect(nativeCalls(rig)).toHaveLength(1);
+    },
+  );
+});
+
+it("selected-group removal rejects the pending continuation", async () => {
+  const rig = await setup("selected");
+  const held = await holdNativeCompletion(rig);
+  rig.harness.updateTab(101, { groupId: -1 });
+  held.complete();
+  const response = await rig.owner.response(held.id);
+  expect(response.error).toBeDefined();
+  expect(response).not.toHaveProperty("result");
+  expect(nativeCalls(rig)).toHaveLength(1);
+});

--- a/extensions/browser/chrome-extension/modules/tab-access-command-scope.js
+++ b/extensions/browser/chrome-extension/modules/tab-access-command-scope.js
@@ -1,5 +1,5 @@
-// CDP navigation receipts and session configuration survive an allowed document
-// change. Page data, execution contexts, and actions still require that document.
+// CDP navigation/request-continuation receipts and session configuration survive
+// allowed document changes. Page data, execution contexts, and actions do not.
 // These are exact protocol methods, never a caller-supplied access override.
 export const TAB_SCOPED_COMMANDS = new Set([
   "Page.navigate",
@@ -7,6 +7,13 @@ export const TAB_SCOPED_COMMANDS = new Set([
   "Page.navigateToHistoryEntry",
   "Page.enable",
   "Page.setLifecycleEventsEnabled",
+  "Fetch.enable",
+  "Fetch.disable",
+  "Fetch.continueRequest",
+  "Fetch.continueResponse",
+  "Fetch.continueWithAuth",
+  "Fetch.failRequest",
+  "Fetch.fulfillRequest",
   "Network.enable",
   "Network.setAttachDebugStack",
   "Runtime.enable",

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -5115,7 +5115,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
           data: expect.objectContaining({
             phase: "error",
             error: "All fallback candidates ended incomplete",
-            fallbackExhaustedFailure: true,
+            executionSettled: true,
           }),
         }),
       ]),
@@ -5178,6 +5178,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
           data: expect.objectContaining({
             phase: "error",
             error: "Command may have changed state",
+            executionSettled: true,
             replayInvalid: true,
           }),
         }),

--- a/src/agents/agent-run-terminal-outcome.test.ts
+++ b/src/agents/agent-run-terminal-outcome.test.ts
@@ -32,6 +32,16 @@ describe("agent run terminal outcome", () => {
   it.each([
     { label: "retryable provider failure", data: { error: "provider failed" }, definitive: false },
     {
+      label: "settled execution failure",
+      data: { error: "preparation failed", executionSettled: true },
+      definitive: true,
+    },
+    {
+      label: "unsettled execution failure",
+      data: { error: "provider failed", executionSettled: false },
+      definitive: false,
+    },
+    {
       label: "exhausted provider failure",
       data: { error: "provider failed", fallbackExhaustedFailure: true },
       definitive: true,
@@ -42,6 +52,10 @@ describe("agent run terminal outcome", () => {
     { label: "provider timeout", data: { timeoutPhase: "provider" }, definitive: true },
   ])("recognizes whether $label is a definitive lifecycle error", ({ data, definitive }) => {
     expect(isDefinitiveRunLifecycle({ phase: "error", data })).toBe(definitive);
+  });
+
+  it.each(["start", "finishing"])("does not settle the %s lifecycle phase", (phase) => {
+    expect(isDefinitiveRunLifecycle({ phase, data: { executionSettled: true } })).toBe(false);
   });
 
   it("normalizes lifecycle signals with timeout, cancellation, failure precedence", () => {

--- a/src/agents/agent-run-terminal-outcome.ts
+++ b/src/agents/agent-run-terminal-outcome.ts
@@ -621,6 +621,11 @@ export function buildAgentRunTerminalOutcomeFromLifecycleEvent(input: {
   return stopReason && outcome.stopReason !== stopReason ? { ...outcome, stopReason } : outcome;
 }
 
+/** Reads the outer execution owner's publication fact, independent of outcome. */
+export function hasExecutionSettlement(data?: Record<string, unknown>): boolean {
+  return data?.executionSettled === true;
+}
+
 /** True for lifecycle events that cannot be followed by a same-run retry. */
 export function isDefinitiveRunLifecycle(input: AgentRunLifecycleInput) {
   if (input.phase === "end") {
@@ -633,7 +638,11 @@ export function isDefinitiveRunLifecycle(input: AgentRunLifecycleInput) {
     phase: "error",
     data: input.data,
   });
-  return input.data?.fallbackExhaustedFailure === true || outcome.reason !== "failed";
+  return (
+    hasExecutionSettlement(input.data) ||
+    input.data?.fallbackExhaustedFailure === true ||
+    outcome.reason !== "failed"
+  );
 }
 
 function hasNestedAbortReason(value: unknown, matches: (candidate: unknown) => boolean): boolean {

--- a/src/agents/command/attempt-execution.error-propagation.test.ts
+++ b/src/agents/command/attempt-execution.error-propagation.test.ts
@@ -520,6 +520,7 @@ describe("ACP diagnostic events", () => {
 
     expect(captured.at(-1)?.data).toMatchObject({
       phase: "end",
+      executionSettled: true,
       aborted: true,
       stopReason: "stop",
       status: "cancelled",
@@ -654,6 +655,7 @@ describe("emitAcpLifecycleError preserves AcpRuntimeError detail (regression: op
     const data = captured[0]?.data as Record<string, unknown> | undefined;
     expect(data?.phase).toBe("error");
     expect(data?.error).toBe("Error: something went wrong");
+    expect(data?.executionSettled).toBe(true);
   });
 
   it("formats non-Error values without crashing", () => {

--- a/src/agents/command/attempt-execution.ts
+++ b/src/agents/command/attempt-execution.ts
@@ -1767,6 +1767,7 @@ function emitAcpTerminalLifecycle(
 ) {
   const data = {
     ...terminal,
+    executionSettled: true,
     ...(params.completionSource ? { completionSource: params.completionSource } : {}),
   };
   const emit = params.auditOnly ? emitAgentAuditEvent : emitAgentEvent;

--- a/src/agents/command/lifecycle.test.ts
+++ b/src/agents/command/lifecycle.test.ts
@@ -189,11 +189,14 @@ describe("createAgentCommandLifecycle", () => {
             livenessState: "blocked",
             yielded: true,
             replayInvalid: true,
-            ...(phase === "error" ? { fallbackExhaustedFailure: true } : {}),
+            ...(phase !== "finishing" ? { executionSettled: true } : {}),
           }),
         }),
       );
       const event = emitAgentEvent.mock.calls[0]?.[0];
+      if (phase === "finishing") {
+        expect(event.data).not.toHaveProperty("executionSettled");
+      }
       expect(event.data.terminalDelivery).toEqual({ status: "sent", resultCount: 2 });
       expect(JSON.stringify(event)).not.toContain(secret);
       expect(event.data).not.toHaveProperty("unsafeMetadata");
@@ -343,6 +346,7 @@ describe("createAgentCommandLifecycle", () => {
         renderFailoverCodeUserCopy("selected_auth_profile_unavailable"),
       );
       expect(event.data.error).toContain("stderr: credential staging failed.");
+      expect(event.data.executionSettled).toBe(true);
       expect(JSON.stringify(event)).not.toContain(profileId);
       expect(JSON.stringify(event)).not.toContain(rawCause);
       expect(JSON.stringify(event)).not.toContain(secret);

--- a/src/agents/command/lifecycle.ts
+++ b/src/agents/command/lifecycle.ts
@@ -70,7 +70,6 @@ export function createAgentCommandLifecycle(params: {
     phase: "finishing" | "end" | "error",
     terminal: EmbeddedAgentRunEntryTerminal,
     error = terminal.outcome.status === "timeout" ? terminal.outcome.error : undefined,
-    fallbackExhausted?: boolean,
   ) => {
     const { aborted, yielded, replayInvalid, terminalReply } = terminal.metadata;
     const terminalDelivery = normalizeAgentRunTerminalDeliverySnapshot(
@@ -98,7 +97,8 @@ export function createAgentCommandLifecycle(params: {
         ...(error && params.state.lifecycleErrorObservation
           ? { errorObservation: params.state.lifecycleErrorObservation }
           : {}),
-        ...(fallbackExhausted ? { fallbackExhaustedFailure: true } : {}),
+        // Finishing is an attempt fence, not the outer execution's final publication.
+        ...(phase !== "finishing" ? { executionSettled: true } : {}),
         ...(terminalDelivery ? { terminalDelivery } : {}),
         ...(terminalReceipt ? { terminalReceipt } : {}),
         ...(terminalReply ? { terminalReply } : {}),
@@ -128,6 +128,7 @@ export function createAgentCommandLifecycle(params: {
             ? { errorObservation: params.state.lifecycleErrorObservation }
             : {}),
           ...extraData,
+          executionSettled: true,
         },
       });
     },
@@ -171,7 +172,7 @@ export function createAgentCommandLifecycle(params: {
           ? terminal.outcome.error
           : resolveResultError(runResult, fallbackExhausted)) ??
         (fallbackExhausted ? "All model fallback candidates failed" : "Agent run failed");
-      emitTerminalPhase("error", terminal, error, fallbackExhausted);
+      emitTerminalPhase("error", terminal, error);
     },
     emitPostTurnError(error: unknown, terminal: EmbeddedAgentRunEntryTerminal) {
       if (params.state.lifecycleEnded) {
@@ -192,6 +193,7 @@ export function createAgentCommandLifecycle(params: {
           error: formatLifecycleError(error),
           ...(terminalDelivery ? { terminalDelivery } : {}),
           ...resolveAgentRunErrorLifecycleFields(error, params.abortSignal),
+          executionSettled: true,
         },
       });
     },

--- a/src/agents/embedded-agent-runner/run.prepared-harness-source-delivery.integration.test.ts
+++ b/src/agents/embedded-agent-runner/run.prepared-harness-source-delivery.integration.test.ts
@@ -56,7 +56,7 @@ import {
 import type { RunEmbeddedAgentInternalParams } from "./run/internal-params.js";
 import { buildEmbeddedSystemPrompt } from "./system-prompt.js";
 
-const runnerState = setupAgentRunnerExecutionTestState();
+const runnerState = await setupAgentRunnerExecutionTestState();
 
 type TestRouteStage = { stage: "initial" } | { stage: "fallback"; fallbackReason: FailoverReason };
 

--- a/src/agents/failover/error.ts
+++ b/src/agents/failover/error.ts
@@ -1,5 +1,5 @@
-// Error identity and timeout recognition must not load provider classification.
-import { readErrorName } from "../../infra/errors.js";
+// Error identity and timeout recognition must not load logging or provider runtime.
+import { readErrorName } from "@openclaw/normalization-core/error-coercion";
 import { isProviderRequestSizeCeilingError, isTimeoutErrorMessage } from "./message-patterns.js";
 import type { FailoverReason } from "./signal.js";
 

--- a/src/agents/model-fallback-runner.ts
+++ b/src/agents/model-fallback-runner.ts
@@ -88,10 +88,6 @@ const modelFallbackAuthRuntimeLoader = createLazyImportLoader<ModelFallbackAuthR
   () => import("./auth-profiles.runtime.js"),
 );
 
-async function loadModelFallbackAuthRuntime() {
-  return await modelFallbackAuthRuntimeLoader.load();
-}
-
 type RunWithModelFallbackParams<T> = {
   cfg: OpenClawConfig | undefined;
   provider: string;
@@ -178,7 +174,7 @@ async function runWithModelFallbackInternal<T>(
   const userLockedAuthProfileId = params.userLockedAuthProfileId?.trim() || undefined;
   const authRuntime =
     !params.skipAuthProfileRuntime && params.cfg && hasAnyAuthProfileStoreSource(params.agentDir)
-      ? await loadModelFallbackAuthRuntime()
+      ? await modelFallbackAuthRuntimeLoader.load()
       : null;
   const authStore = authRuntime
     ? authRuntime.ensureAuthProfileStore(params.agentDir, {
@@ -196,13 +192,22 @@ async function runWithModelFallbackInternal<T>(
   let exhaustionResult: ModelFallbackExhaustionResult<T> | undefined;
   const cooldownProbeUsedProviders = new Set<string>();
   const tlsFailedProviders = new Set<string>();
+  const notifyFallbackStep: ModelFallbackStepHandler = async (step) => {
+    // Observations cannot replace candidate outcomes or stop a usable fallback.
+    // Policy-bearing callbacks such as onError retain their own failure semantics.
+    try {
+      await params.onFallbackStep?.(step);
+    } catch {
+      log.warn("Model fallback observer failed; preserving execution outcome.");
+    }
+  };
   const observeDecision = async (decision: ModelFallbackDecisionParams) => {
     if (!params.onFallbackStep && !isModelFallbackDecisionLogEnabled()) {
       return;
     }
     const fallbackStep = logModelFallbackDecision(decision);
     if (fallbackStep) {
-      await params.onFallbackStep?.(fallbackStep);
+      await notifyFallbackStep(fallbackStep);
     }
   };
   const observeFailedCandidate = async (
@@ -213,7 +218,7 @@ async function runWithModelFallbackInternal<T>(
     } else {
       const fallbackStep = recordFailedCandidateAttempt(failedAttempt);
       if (fallbackStep) {
-        await params.onFallbackStep?.(fallbackStep);
+        await notifyFallbackStep(fallbackStep);
       }
     }
     // Emit only real candidate-to-candidate transitions. Terminal candidates

--- a/src/agents/model-fallback.terminal-boundary.test.ts
+++ b/src/agents/model-fallback.terminal-boundary.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./failover-error.js";
 import { AgentHarnessPreflightError, recordAgentHarnessPreflightOwner } from "./harness/errors.js";
 import {
+  type ModelFallbackStepHandler,
   runFallbackAttempt,
   shouldDiscardDeferredSessionSuspension,
 } from "./model-fallback-attempt.js";
@@ -169,6 +170,33 @@ it("honors cancellation in the failure callback before starting another candidat
   expect(onError).toHaveBeenCalledTimes(1);
   expect(providerHook).not.toHaveBeenCalled();
 });
+
+it.each(["throw", "reject"] as const)(
+  "preserves recovery when its fallback observer fails by %s",
+  async (observerFailure) => {
+    const observerError = new Error("fallback observer failed");
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new FailoverError("provider overloaded", { reason: "overloaded" }))
+      .mockResolvedValueOnce("recovered");
+    const onError = vi.fn();
+    const onFallbackStep = vi.fn<ModelFallbackStepHandler>(() => {
+      if (observerFailure === "throw") {
+        throw observerError;
+      }
+      return Promise.reject(observerError);
+    });
+    await expect(
+      runWithModelFallback({ ...fallbackOptions, run, onError, onFallbackStep }),
+    ).resolves.toMatchObject({ outcome: "completed", result: "recovered" });
+    expect(run).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onFallbackStep.mock.calls.map(([step]) => step.fallbackStepFinalOutcome)).toEqual([
+      "next_fallback",
+      "succeeded",
+    ]);
+  },
+);
 
 it("does not replay a terminal failure returned by result classification", async () => {
   const error = new AggregateError([maxTurns()], "wrapper");

--- a/src/auto-reply/reply/agent-lifecycle-terminal.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.ts
@@ -7,6 +7,8 @@ import { emitAgentEvent } from "../../infra/agent-events.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 
 export type AgentLifecycleTerminalBackstop = {
+  beginAttempt: () => void;
+  capture: AgentLifecycleTerminalBackstop["emit"];
   emit: (
     phase: "end" | "error",
     resultOrError: unknown,
@@ -15,6 +17,17 @@ export type AgentLifecycleTerminalBackstop = {
   getDeferredError: () => string | undefined;
   note: (evt: { stream: string; data: Record<string, unknown> }) => void;
 };
+
+type PendingLifecycleTerminal = {
+  kind: "pending";
+  deferredError?: string;
+  metadata: Record<string, unknown>;
+};
+
+type LifecycleTerminalState =
+  | PendingLifecycleTerminal
+  | { kind: "captured"; event: Parameters<typeof emitAgentEvent>[0] }
+  | { kind: "emitted" };
 
 const DEFERRED_TERMINAL_METADATA_KEYS = [
   "stopReason",
@@ -52,49 +65,48 @@ export function createAgentLifecycleTerminalBackstop(params: {
     timeoutPhase?: string;
   };
 }): AgentLifecycleTerminalBackstop {
-  let terminalEmitted = false;
+  let state: LifecycleTerminalState = { kind: "pending", metadata: {} };
   // Preparation can fail before a lifecycle start. Capture its real boundary
   // without signaling readiness; an observed model start replaces it below.
   let startedAt = params.startedAt ?? Date.now();
-  let deferredError: string | undefined;
-  const deferredTerminalMetadata: Record<string, unknown> = {};
+  const beginAttempt = () => {
+    if (state.kind !== "emitted") {
+      state = { kind: "pending", metadata: {} };
+    }
+  };
 
   const note = (evt: { stream: string; data: Record<string, unknown> }) => {
-    if (evt.stream !== "lifecycle") {
+    if (state.kind === "emitted" || evt.stream !== "lifecycle") {
       return;
     }
     const phase = readStringValue(evt.data.phase);
     if (phase === "start") {
+      beginAttempt();
       if (typeof evt.data.startedAt === "number") {
         startedAt = evt.data.startedAt;
       }
-      // A same-candidate retry replaces deferred terminal state from the
-      // preceding attempt; retaining it would abort a recovered run.
-      deferredError = undefined;
-      for (const key of DEFERRED_TERMINAL_METADATA_KEYS) {
-        delete deferredTerminalMetadata[key];
-      }
     }
-    if (phase === "finishing") {
-      deferredError = readStringValue(evt.data.error) ?? deferredError;
-      Object.assign(deferredTerminalMetadata, resolveAgentLifecycleTerminalMetadata(evt.data));
+    if (phase === "finishing" && state.kind === "pending") {
+      state.deferredError = readStringValue(evt.data.error) ?? state.deferredError;
+      Object.assign(state.metadata, resolveAgentLifecycleTerminalMetadata(evt.data));
     }
     if (phase === "end" || phase === "error") {
-      terminalEmitted = true;
+      state = { kind: "emitted" };
     }
   };
 
-  const emit: AgentLifecycleTerminalBackstop["emit"] = (phase, resultOrError, extraData) => {
-    if (terminalEmitted) {
-      return;
-    }
-    terminalEmitted = true;
+  const prepareTerminal = (
+    pending: PendingLifecycleTerminal,
+    phase: "end" | "error",
+    resultOrError: unknown,
+    extraData?: Record<string, unknown>,
+  ): Parameters<typeof emitAgentEvent>[0] => {
     const terminationFields = params.resolveTerminationFields(
       phase === "error" ? resultOrError : undefined,
     );
     const restartAbort = terminationFields.stopReason === AGENT_RUN_RESTART_ABORT_STOP_REASON;
     const data: Record<string, unknown> = {
-      ...deferredTerminalMetadata,
+      ...pending.metadata,
       phase: restartAbort ? "end" : phase,
       endedAt: Date.now(),
       startedAt,
@@ -134,18 +146,43 @@ export function createAgentLifecycleTerminalBackstop(params: {
     if (extraData) {
       Object.assign(data, extraData);
     }
-    emitAgentEvent({
+    return {
       runId: params.runId,
       lifecycleGeneration: params.getLifecycleGeneration(),
       ...(params.sessionKey ? { sessionKey: params.sessionKey } : {}),
       stream: "lifecycle",
       data,
-    });
+    };
+  };
+
+  const capture: AgentLifecycleTerminalBackstop["capture"] = (phase, resultOrError, extraData) => {
+    if (state.kind === "pending") {
+      // Record bounded terminal facts before awaited bookkeeping can change
+      // the abort signal, lifecycle generation, or subsequent workflow outcome.
+      const event = prepareTerminal(state, phase, resultOrError, extraData);
+      state = { kind: "captured", event };
+    }
+  };
+  const emit: AgentLifecycleTerminalBackstop["emit"] = (phase, resultOrError, extraData) => {
+    const current = state;
+    if (current.kind === "emitted") {
+      return;
+    }
+    state = { kind: "emitted" };
+    const event =
+      current.kind === "captured"
+        ? current.event
+        : prepareTerminal(current, phase, resultOrError, extraData);
+    // Captured candidates can still be replaced by retries. Only publication
+    // settles execution; delivery and yielded-parent continuation remain separate.
+    emitAgentEvent({ ...event, data: { ...event.data, executionSettled: true } });
   };
 
   return {
+    beginAttempt,
+    capture,
     emit,
-    getDeferredError: () => deferredError,
+    getDeferredError: () => (state.kind === "pending" ? state.deferredError : undefined),
     note,
   };
 }

--- a/src/auto-reply/reply/agent-runner-error-handler.ts
+++ b/src/auto-reply/reply/agent-runner-error-handler.ts
@@ -90,9 +90,8 @@ export async function handleAgentExecutionError(params: {
   };
   const settleFailure = async (
     payload: ReplyPayload,
-    terminalMetadata?: { fallbackExhaustedFailure: true },
   ): Promise<Extract<AgentTurnInternalResult, { kind: "final" }>> => {
-    takePendingLifecycleTerminal().emit("error", err, terminalMetadata);
+    takePendingLifecycleTerminal().emit("error", err);
     turn.replyOperation?.fail("run_failed", err);
     await params.modelPatch.fail(err);
     return {
@@ -330,13 +329,10 @@ export async function handleAgentExecutionError(params: {
     isGenericRunnerFailure: externalRunFailureReply?.isGenericRunnerFailure ?? false,
     cfg: turn.followupRun.run.config,
   });
-  return await settleFailure(
-    {
-      text: userVisibleFallbackText,
-      ...(externalRunFailureReply?.presentation
-        ? { presentation: externalRunFailureReply.presentation }
-        : {}),
-    },
-    { fallbackExhaustedFailure: true },
-  );
+  return await settleFailure({
+    text: userVisibleFallbackText,
+    ...(externalRunFailureReply?.presentation
+      ? { presentation: externalRunFailureReply.presentation }
+      : {}),
+  });
 }

--- a/src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-auth-failures.test.ts
@@ -14,7 +14,7 @@ import {
 } from "./agent-runner-execution.test-support.js";
 import { buildKnownAgentRunFailureReplyPayload } from "./agent-runner-failure-reply.js";
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 
 const CODEX_LOGIN_PRESENTATION = {
   blocks: [

--- a/src/auto-reply/reply/agent-runner-execution-cli-commentary.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-commentary.test.ts
@@ -13,7 +13,7 @@ import {
 } from "./agent-runner-execution.test-support.js";
 import type { FallbackRunnerParams } from "./agent-runner-execution.test-support.js";
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 
 const scriptedCliProgram = String.raw`
 let input = "";

--- a/src/auto-reply/reply/agent-runner-execution-cli-delegation.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-delegation.test.ts
@@ -12,7 +12,7 @@ import {
 } from "./agent-runner-execution.test-support.js";
 import type { FallbackRunnerParams } from "./agent-runner-execution.test-support.js";
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 
 function resolveMockedCliGrantCapability() {
   const run = requireMockCall(state.runCliAgentMock, 0, "CLI run params")[0] as RunCliAgentParams;

--- a/src/auto-reply/reply/agent-runner-execution-cli-progress.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-progress.test.ts
@@ -17,7 +17,7 @@ import type {
   EmbeddedAgentParams,
 } from "./agent-runner-execution.test-support.js";
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 
 describe("executeAgentTurn: CLI progress bridging", () => {
   it("bridges CLI assistant agent events into onPartialReply for live preview (#76869)", async () => {

--- a/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-cli-sessions.test.ts
@@ -29,7 +29,7 @@ import {
 } from "./agent-runner-execution.test-support.js";
 import type { FallbackRunnerParams } from "./agent-runner-execution.test-support.js";
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 afterEach(resetGeneratedMediaTaskActivityForTests);
 
 function rejectUnexpectedCompactionSuccessor(): never {

--- a/src/auto-reply/reply/agent-runner-execution-command-events.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-command-events.test.ts
@@ -9,7 +9,7 @@ import {
 } from "./agent-runner-execution.test-support.js";
 import type { EmbeddedAgentParams } from "./agent-runner-execution.test-support.js";
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 
 describe("executeAgentTurn: command events", () => {
   it("forwards plan, approval, command output, and patch events", async () => {

--- a/src/auto-reply/reply/agent-runner-execution-compaction.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-compaction.test.ts
@@ -17,7 +17,7 @@ import type {
 } from "./agent-runner-execution.test-support.js";
 import type { AgentTurnParams } from "./agent-runner-execution.types.js";
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 
 async function executeTestTurn(
   params?: Parameters<typeof createMinimalRunAgentTurnParams>[0],

--- a/src/auto-reply/reply/agent-runner-execution-context-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-context-failures.test.ts
@@ -18,7 +18,7 @@ import {
 } from "./agent-runner-execution.test-support.js";
 import type { FallbackRunnerParams } from "./agent-runner-execution.test-support.js";
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 
 describe("executeAgentTurn: context failures", () => {
   it("preserves the active session when embedded overflow recovery fails", async () => {

--- a/src/auto-reply/reply/agent-runner-execution-contract.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-contract.test.ts
@@ -5,7 +5,7 @@ import {
   setupAgentRunnerExecutionTestState,
 } from "./agent-runner-execution.test-support.js";
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 const { executeAgentTurn } = await import("./agent-runner-execution.js");
 
 describe("executeAgentTurn contract", () => {

--- a/src/auto-reply/reply/agent-runner-execution-conversation-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-conversation-failures.test.ts
@@ -13,7 +13,7 @@ import {
   createNonDirectFailureSessionCtx,
 } from "./agent-runner-execution.test-support.js";
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 
 describe("executeAgentTurn: conversation failures", () => {
   it.each(NON_DIRECT_FAILURE_SURFACE_CASES)(

--- a/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-lifecycle.test.ts
@@ -46,9 +46,7 @@ import {
   type ReplyOperation,
 } from "./reply-run-registry.js";
 
-const state = setupAgentRunnerExecutionTestState();
-// Register shared mocks before loading the execution graph. A timed-out import
-// must not resume later and consume the next case's one-shot mock.
+const state = await setupAgentRunnerExecutionTestState();
 const execution = await import("./agent-runner-execution.js");
 const { emitAgentEvent } = await import("../../infra/agent-events.js");
 const compactionTarget = {

--- a/src/auto-reply/reply/agent-runner-execution-message-tools.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-message-tools.test.ts
@@ -16,7 +16,7 @@ import type {
 } from "./agent-runner-execution.test-support.js";
 import type { InternalGetReplyOptions } from "./get-reply.types.js";
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 
 describe("executeAgentTurn: message tool progress", () => {
   it("suppresses progress callbacks after message-tool-only delivery completes", async () => {

--- a/src/auto-reply/reply/agent-runner-execution-probes.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-probes.test.ts
@@ -22,7 +22,7 @@ import type {
   EmbeddedAgentParams,
 } from "./agent-runner-execution.test-support.js";
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 
 describe("executeAgentTurn: primary probe routing", () => {
   it("rechecks queued auto fallback primary probes before running", async () => {
@@ -392,7 +392,7 @@ describe("executeAgentTurn: primary probe routing", () => {
           (event) =>
             event.stream === "lifecycle" &&
             event.data.phase === "error" &&
-            event.data.fallbackExhaustedFailure === true &&
+            event.data.executionSettled === true &&
             event.data.livenessState === "blocked" &&
             event.data.providerStarted === true &&
             event.data.replayInvalid === true &&
@@ -456,6 +456,7 @@ describe("executeAgentTurn: primary probe routing", () => {
           data: expect.objectContaining({
             phase: "error",
             error: "Command may have changed state",
+            executionSettled: true,
             replayInvalid: true,
           }),
         }),
@@ -529,11 +530,14 @@ describe("executeAgentTurn: primary probe routing", () => {
     expect(failMock).toHaveBeenCalledWith("run_failed", expect.any(Error));
   });
 
-  it("reports exhausted CLI results without a success lifecycle terminal", async () => {
+  it.each([
+    { label: "last candidate", attemptedModel: "gpt-5.4" },
+    { label: "preserved earlier candidate", attemptedModel: "gpt-5.5" },
+  ])("reports exhausted CLI $label without a success terminal", async ({ attemptedModel }) => {
     state.isCliProviderMock.mockReturnValue(true);
     state.runWithModelFallbackMock.mockImplementationOnce(async (params: FallbackRunnerParams) => ({
       outcome: "exhausted",
-      result: await params.run("codex-cli", "gpt-5.4", initialFallbackAttemptOptions(params)),
+      result: await params.run("codex-cli", attemptedModel, initialFallbackAttemptOptions(params)),
       provider: "codex-cli",
       model: "gpt-5.4",
       attempts: [{ provider: "codex-cli", model: "gpt-5.4", error: "incomplete" }],
@@ -578,7 +582,7 @@ describe("executeAgentTurn: primary probe routing", () => {
         expect.objectContaining({
           data: expect.objectContaining({
             phase: "error",
-            fallbackExhaustedFailure: true,
+            executionSettled: true,
           }),
         }),
       ]),
@@ -623,7 +627,7 @@ describe("executeAgentTurn: primary probe routing", () => {
     ).toMatchObject({
       stopReason: "timeout",
       timeoutPhase: "provider",
-      fallbackExhaustedFailure: true,
+      executionSettled: true,
     });
   });
 

--- a/src/auto-reply/reply/agent-runner-execution-progress.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-progress.test.ts
@@ -42,8 +42,7 @@ vi.mock("../../agents/embedded-agent-helpers/sanitize-user-facing-text.js", asyn
   };
 });
 
-const state = setupAgentRunnerExecutionTestState();
-// Prepare before cases can time out and resume against a later case's mocks.
+const state = await setupAgentRunnerExecutionTestState();
 const executeAgentTurn = await getExecuteAgentTurnForTest();
 
 beforeEach(() => {

--- a/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
@@ -27,7 +27,7 @@ import {
 import type { AgentTurnParams } from "./agent-runner-execution.types.js";
 import { buildKnownAgentRunFailureReplyPayload } from "./agent-runner-failure-reply.js";
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 
 async function executeTestTurn(
   params?: Parameters<typeof createMinimalRunAgentTurnParams>[0],
@@ -771,7 +771,7 @@ describe("executeAgentTurn: provider failures", () => {
     expect(vi.mocked(agentEvents.emitAgentEvent)).toHaveBeenCalledWith(
       expect.objectContaining({
         stream: "lifecycle",
-        data: expect.objectContaining({ phase: "error", fallbackExhaustedFailure: true }),
+        data: expect.objectContaining({ phase: "error", executionSettled: true }),
       }),
     );
   });

--- a/src/auto-reply/reply/agent-runner-execution-results.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-results.test.ts
@@ -21,7 +21,7 @@ import type {
   EmbeddedAgentParams,
 } from "./agent-runner-execution.test-support.js";
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 
 describe("executeAgentTurn: result and tool delivery", () => {
   it("forwards media-only tool results without typing text", async () => {

--- a/src/auto-reply/reply/agent-runner-execution-runtime.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-runtime.test.ts
@@ -15,7 +15,7 @@ import {
 } from "./agent-runner-execution.test-support.js";
 import type { FallbackRunnerParams } from "./agent-runner-execution.test-support.js";
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 
 describe("executeAgentTurn: runtime selection", () => {
   it.each(["group", "channel"] as const)(

--- a/src/auto-reply/reply/agent-runner-execution-state.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-state.test.ts
@@ -14,7 +14,7 @@ import {
 } from "./agent-runner-execution.test-support.js";
 import type { FallbackRunnerParams } from "./agent-runner-execution.test-support.js";
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 
 describe("executeAgentTurn: session state", () => {
   it("restarts the active prompt when a live model switch is requested", async () => {

--- a/src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts
@@ -27,7 +27,7 @@ import {
 import { buildKnownAgentRunFailureReplyPayload } from "./agent-runner-failure-reply.js";
 import { createReplyOperation } from "./reply-run-registry.js";
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 
 describe("executeAgentTurn: terminal failures", () => {
   it("surfaces billing guidance for mixed-cause fallback exhaustion", async () => {
@@ -563,7 +563,7 @@ describe("executeAgentTurn: terminal failures", () => {
           (event as { runId?: unknown }).runId === "run-provider-failure" &&
           (event as { stream?: unknown }).stream === "lifecycle" &&
           data?.phase === "error" &&
-          data.fallbackExhaustedFailure === true
+          data.executionSettled === true
         );
       });
     expect(terminalFailureEvent).toBeDefined();

--- a/src/auto-reply/reply/agent-runner-execution-timing.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-timing.test.ts
@@ -10,7 +10,7 @@ import {
 
 vi.mock("../../gateway/session-utils.js", () => ({ loadSessionEntry: vi.fn() }));
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 
 it.each(["embedded preparation", "fallback preparation"])(
   "times %s failure between successful turns without borrowing the previous start",

--- a/src/auto-reply/reply/agent-runner-execution.test-support.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test-support.ts
@@ -670,7 +670,11 @@ export function createNonDirectFailureSessionCtx(
   } as unknown as TemplateContext;
 }
 
-export function setupAgentRunnerExecutionTestState() {
+export async function setupAgentRunnerExecutionTestState() {
+  // Each suite awaits collection readiness after its imported mock harnesses register.
+  // Hook timeouts cannot cancel imports; cleanup must not overtake module readiness.
+  await getExecuteAgentTurnForTest();
+
   beforeEach(() => {
     vi.useRealTimers();
     state.runEmbeddedAgentMock.mockReset();

--- a/src/auto-reply/reply/agent-runner-fallback-settlement.ts
+++ b/src/auto-reply/reply/agent-runner-fallback-settlement.ts
@@ -84,7 +84,13 @@ export async function settleAgentFallbackCycle(params: {
       lifecycleGeneration: cycle.state.lifecycleGeneration,
       ...(turn.sessionKey ? { sessionKey: turn.sessionKey } : {}),
       stream: "lifecycle",
-      data: { phase: "error", error: error.message, endedAt: Date.now(), ...extraData },
+      data: {
+        phase: "error",
+        error: error.message,
+        endedAt: Date.now(),
+        ...extraData,
+        executionSettled: true,
+      },
     });
   };
   if (embeddedError && isContextOverflowError(embeddedError.message)) {
@@ -159,10 +165,7 @@ export async function settleAgentFallbackCycle(params: {
     if (cycle.modelPatch.captureFallbackFailure(fallbackAttempts) === undefined) {
       cycle.modelPatch.captureFailure(embeddedError ?? exhaustionError);
     }
-    emitSettledLifecycleError(exhaustionError, {
-      ...terminalMetadata,
-      fallbackExhaustedFailure: true,
-    });
+    emitSettledLifecycleError(exhaustionError, terminalMetadata);
     turn.replyOperation?.retainFailureUntilComplete();
     turn.replyOperation?.fail("run_failed", exhaustionError);
   } else if (deferredLifecycleError || embeddedError || terminalOutcome.status === "timeout") {

--- a/src/auto-reply/reply/agent-runner-node-authority.test.ts
+++ b/src/auto-reply/reply/agent-runner-node-authority.test.ts
@@ -18,7 +18,7 @@ vi.mock("../../agents/agent-tools.js", () => ({
   }),
 }));
 
-const state = setupAgentRunnerExecutionTestState();
+const state = await setupAgentRunnerExecutionTestState();
 
 let execute: Awaited<ReturnType<typeof getExecuteAgentTurnForTest>>;
 let fixture: typeof import("../../gateway/worker-environments/worker-turn-launcher.test-support.js");

--- a/src/cron/isolated-agent/run-executor.ts
+++ b/src/cron/isolated-agent/run-executor.ts
@@ -25,6 +25,10 @@ import { withLocalSessionPlacementTurnSettlement } from "../../agents/session-pl
 import { resolveSessionRuntimeOverrideForProvider } from "../../agents/session-runtime-compat.js";
 import { hasResolvedThinkingCatalogEntry } from "../../agents/thinking-runtime.js";
 import { withPostAdmissionExecutionOwnerBinding } from "../../audit/execution-owner-binding.js";
+import {
+  resolveAgentLifecycleTerminalMetadata,
+  type AgentLifecycleTerminalBackstop,
+} from "../../auto-reply/reply/agent-lifecycle-terminal.js";
 import type { ThinkLevel, VerboseLevel } from "../../auto-reply/thinking.js";
 import type { CliSessionBinding } from "../../config/sessions.js";
 import type { AgentDefaultsConfig } from "../../config/types.agent-defaults.js";
@@ -244,8 +248,7 @@ export type CronExecutionResult = {
   liveSelection: CronLiveSelection;
 };
 
-/** Creates the model-fallback executor for one isolated cron prompt run. */
-function createCronPromptExecutor(params: {
+type CronRunExecutionParams = {
   cfg: OpenClawConfig;
   cfgWithAgentDefaults: OpenClawConfig;
   job: CronStoredJob;
@@ -257,7 +260,7 @@ function createCronPromptExecutor(params: {
   workspaceDir: string;
   pluginRegistry?: PluginRegistry;
   lane?: string;
-  resolvedVerboseLevel: VerboseLevel;
+  agentVerboseDefault: AgentDefaultsConfig["verboseDefault"];
   immutableThinkLevel: ThinkLevel | undefined;
   thinkingCatalog?: ModelCatalogEntry[];
   loadThinkingCatalog: (provider: string, model: string) => Promise<ModelCatalogEntry[]>;
@@ -282,11 +285,14 @@ function createCronPromptExecutor(params: {
   modelFallbacksOverride?: string[];
   liveSelection: CronLiveSelection;
   cronSession: MutableCronSession;
+  commandBody: string;
   persistSessionEntry: PersistCronSessionEntry;
   persistRunContinuationSession?: () => Promise<void>;
   setRunContinuationCliExecutionProvider?: (provider?: string) => Promise<void>;
   abortSignal?: AbortSignal;
   abortReason: () => string;
+  isAborted: () => boolean;
+  lifecycle: Omit<AgentLifecycleTerminalBackstop, "emit">;
   onExecutionStarted?: (info?: CronRunnerStartedInfo) => void;
   onExecutionPhase?: (
     info: Pick<CronAgentExecutionPhaseUpdate, "phase"> &
@@ -294,7 +300,16 @@ function createCronPromptExecutor(params: {
   ) => void;
   onLaneWait?: (info?: { waiting?: boolean }) => void;
   executionIdentity?: import("../service/state.js").CronExecutionIdentityAdmission;
-}) {
+  runStartedAt?: number;
+};
+
+/** Creates the model-fallback executor for one isolated cron prompt run. */
+function createCronPromptExecutor(
+  params: Omit<
+    CronRunExecutionParams,
+    "commandBody" | "isAborted" | "agentVerboseDefault" | "runStartedAt"
+  > & { resolvedVerboseLevel: VerboseLevel },
+) {
   const sessionFile = params.runSessionKey;
   const cronFallbacksOverride =
     params.modelFallbacksOverride ??
@@ -377,6 +392,8 @@ function createCronPromptExecutor(params: {
     hasNewGeneratedMediaTaskForSessionKey(params.runSessionKey, attemptMediaTaskIds);
 
   const runPrompt = async (promptText: string) => {
+    // A retry can fail during preparation, before any backend start callback.
+    params.lifecycle.beginAttempt();
     let candidateStarted = false;
     const sessionTarget = {
       agentId: params.agentId,
@@ -469,6 +486,7 @@ function createCronPromptExecutor(params: {
           cfg: params.cfgWithAgentDefaults,
         }),
       prepareAgentHarnessRuntime: async ({ provider, model, agentHarnessRuntimeOverride }) => {
+        params.lifecycle.beginAttempt();
         await ensureSelectedAgentHarnessPlugin({
           config: params.cfgWithAgentDefaults,
           provider,
@@ -492,6 +510,8 @@ function createCronPromptExecutor(params: {
       canFallbackAfterError: () => !currentAttemptCommittedMedia(),
       mergeExhaustedResult: mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
       run: async (providerOverride, modelOverride, runOptions) => {
+        // Default native and direct CLI candidates skip harness preparation.
+        params.lifecycle.beginAttempt();
         const isFallback = candidateStarted;
         candidateStarted = true;
         const notifyExecutionStarted = (info?: { lifecycleGeneration?: string }) =>
@@ -788,6 +808,8 @@ function createCronPromptExecutor(params: {
             : undefined,
           sourceReplyDeliveryMode,
           runId: params.cronSession.sessionEntry.sessionId,
+          deferTerminalLifecycle: true,
+          onAgentEvent: params.lifecycle.note,
           allowEmptyAssistantReplyAsSilent,
           // Cron owns the resolved delivery contract. A valid announce route
           // still needs a final payload; none, webhook, and invalid routes do not.
@@ -821,6 +843,7 @@ function createCronPromptExecutor(params: {
       },
     })
       .catch(async (error: unknown) => {
+        params.lifecycle.capture("error", error);
         await contextEngineLogicalTurnLease.dispose();
         throw error;
       })
@@ -828,6 +851,20 @@ function createCronPromptExecutor(params: {
         unregisterCronRunExecSource();
         preparedRunAdmission.close();
       });
+    const executionError =
+      params.lifecycle.getDeferredError() ??
+      (fallbackResult.result.meta.error || fallbackResult.outcome === "exhausted"
+        ? "Agent run failed"
+        : undefined);
+    if (executionError) {
+      params.lifecycle.capture(
+        "error",
+        executionError,
+        resolveAgentLifecycleTerminalMetadata(fallbackResult.result.meta),
+      );
+    } else {
+      params.lifecycle.capture("end", fallbackResult.result);
+    }
     try {
       if (
         acceptedContextEngineTurnCandidate &&
@@ -872,59 +909,7 @@ function createCronPromptExecutor(params: {
 }
 
 /** Executes an isolated cron prompt, including live model-switch and interim-ack retries. */
-export async function executeCronRun(params: {
-  cfg: OpenClawConfig;
-  cfgWithAgentDefaults: OpenClawConfig;
-  job: CronStoredJob;
-  agentId: string;
-  agentDir: string;
-  agentSessionKey: string;
-  runSessionKey: string;
-  usesDetachedRunSession?: boolean;
-  workspaceDir: string;
-  lane?: string;
-  resolvedDelivery: {
-    channel?: string;
-    accountId?: string;
-    to?: string;
-    threadId?: string | number;
-    ok?: boolean;
-  };
-  resolvedDeliveryOk: boolean;
-  deliveryRequested?: boolean;
-  sourceDelivery: SourceDeliveryPlan;
-  skillsSnapshot: SkillSnapshot;
-  agentPayload: AgentTurnPayload;
-  useSubagentFallbacks: boolean;
-  inheritDefaultFallbacksForAgentStringModel?: boolean;
-  modelFallbacksOverride?: string[];
-  agentVerboseDefault: AgentDefaultsConfig["verboseDefault"];
-  liveSelection: CronLiveSelection;
-  cronSession: MutableCronSession;
-  commandBody: string;
-  persistSessionEntry: PersistCronSessionEntry;
-  persistRunContinuationSession?: () => Promise<void>;
-  setRunContinuationCliExecutionProvider?: (provider?: string) => Promise<void>;
-  abortSignal?: AbortSignal;
-  abortReason: () => string;
-  isAborted: () => boolean;
-  onExecutionStarted?: (info?: CronRunnerStartedInfo) => void;
-  onExecutionPhase?: (
-    info: Pick<CronAgentExecutionPhaseUpdate, "phase"> &
-      Partial<Omit<CronAgentExecutionPhaseUpdate, "jobId" | "phase">>,
-  ) => void;
-  onLaneWait?: (info?: { waiting?: boolean }) => void;
-  executionIdentity?: import("../service/state.js").CronExecutionIdentityAdmission;
-  immutableThinkLevel: ThinkLevel | undefined;
-  thinkingCatalog?: ModelCatalogEntry[];
-  loadThinkingCatalog: (provider: string, model: string) => Promise<ModelCatalogEntry[]>;
-  timeoutMs: number;
-  /** Set when the cron payload's `timeoutSeconds` was explicitly configured. */
-  runTimeoutOverrideMs?: number;
-  suppressExecNotifyOnExit: boolean;
-  runStartedAt?: number;
-  pluginRegistry?: PluginRegistry;
-}): Promise<CronExecutionResult> {
+export async function executeCronRun(params: CronRunExecutionParams): Promise<CronExecutionResult> {
   const resolvedVerboseLevel: VerboseLevel =
     normalizeVerboseLevel(params.cronSession.sessionEntry.verboseLevel) ??
     normalizeVerboseLevel(params.agentVerboseDefault) ??
@@ -969,6 +954,7 @@ export async function executeCronRun(params: {
     setRunContinuationCliExecutionProvider: params.setRunContinuationCliExecutionProvider,
     abortSignal: params.abortSignal,
     abortReason: params.abortReason,
+    lifecycle: params.lifecycle,
     onExecutionStarted: params.onExecutionStarted,
     onExecutionPhase: params.onExecutionPhase,
     onLaneWait: params.onLaneWait,

--- a/src/cron/isolated-agent/run.message-tool-policy.test.ts
+++ b/src/cron/isolated-agent/run.message-tool-policy.test.ts
@@ -1,6 +1,8 @@
 // Message tool policy tests cover message tool availability during cron runs.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createAgentLifecycleTerminalBackstop } from "../../auto-reply/reply/agent-lifecycle-terminal.js";
+import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { createSourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
 import type { SkillSnapshot } from "../../skills/types.js";
 import { applyJobPatch } from "../service/jobs.js";
@@ -408,6 +410,12 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
           cronSession: makeCronSession() as unknown as MutableCronSession,
           commandBody,
           persistSessionEntry: async () => undefined,
+          lifecycle: createAgentLifecycleTerminalBackstop({
+            runId: "test-session-id",
+            sessionKey: "cron:message-tool-policy:run:test-session-id",
+            getLifecycleGeneration: getAgentEventLifecycleGeneration,
+            resolveTerminationFields: () => ({}),
+          }),
           abortReason: () => "aborted",
           isAborted: () => false,
           ...overrides,
@@ -1172,7 +1180,6 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     resolveCronSessionMock.mockImplementation(() => makeCronSession());
     const { claimAgentRunContext, getAgentRunContext } =
       await import("../../infra/agent-run-registry.js");
-    const { getAgentEventLifecycleGeneration } = await import("../../infra/agent-events.js");
     let invocationCount = 0;
     let releaseFirst = () => {};
     let releaseSecond = () => {};
@@ -1235,8 +1242,7 @@ describe("runCronIsolatedAgentTurn message tool policy", () => {
     runEmbeddedAgentMock.mockRejectedValueOnce(new Error("runner failed"));
     const { claimAgentRunContext, getAgentRunContext } =
       await import("../../infra/agent-run-registry.js");
-    const { getAgentEventLifecycleGeneration, rotateAgentEventLifecycleGeneration } =
-      await import("../../infra/agent-events.js");
+    const { rotateAgentEventLifecycleGeneration } = await import("../../infra/agent-events.js");
     claimAgentRunContext("test-session-id", {
       sessionKey: "agent:default:cron:message-tool-policy",
       sessionId: "test-session-id",

--- a/src/cron/isolated-agent/run.payload-fallbacks.test.ts
+++ b/src/cron/isolated-agent/run.payload-fallbacks.test.ts
@@ -16,7 +16,6 @@ import {
   patchSessionEntryMock,
   resolveAgentConfigMock,
   resolveConfiguredModelRefMock,
-  resolveCliRuntimeExecutionProviderMock,
   resolveEffectiveAgentRuntimeMock,
   resolveAgentModelFallbacksOverrideMock,
   runCliAgentMock,
@@ -226,9 +225,6 @@ describe("runCronIsolatedAgentTurn — payload.fallbacks", () => {
 
   it("plans Anthropic fallbacks canonically while executing compatible attempts through Claude CLI", async () => {
     isCliProviderMock.mockImplementation((provider: string) => provider === "claude-cli");
-    resolveCliRuntimeExecutionProviderMock.mockImplementation(
-      ({ provider }: { provider: string }) => (provider === "anthropic" ? "claude-cli" : undefined),
-    );
     resolveConfiguredModelRefMock.mockReturnValue({
       provider: "anthropic",
       model: "claude-opus-4-6",

--- a/src/cron/isolated-agent/run.source-delivery-guard.test.ts
+++ b/src/cron/isolated-agent/run.source-delivery-guard.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createAgentLifecycleTerminalBackstop } from "../../auto-reply/reply/agent-lifecycle-terminal.js";
+import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { createSourceDeliveryPlan } from "../../infra/outbound/source-delivery-plan.js";
 import type { SkillSnapshot } from "../../skills/types.js";
 import type { CronJob } from "../types.js";
@@ -405,6 +407,12 @@ function makeExecuteCronRunParams(overrides: Record<string, unknown> = {}) {
     cronSession: makeCronSession() as unknown as MutableCronSession,
     commandBody: "run a task",
     persistSessionEntry: vi.fn().mockResolvedValue(undefined),
+    lifecycle: createAgentLifecycleTerminalBackstop({
+      runId: "test-session-id",
+      sessionKey: "cron:source-delivery-guard:run:test-session-id",
+      getLifecycleGeneration: getAgentEventLifecycleGeneration,
+      resolveTerminationFields: () => ({}),
+    }),
     abortReason: () => "aborted",
     isAborted: () => false,
     immutableThinkLevel: undefined,

--- a/src/cron/isolated-agent/run.terminal-lifecycle.test.ts
+++ b/src/cron/isolated-agent/run.terminal-lifecycle.test.ts
@@ -1,0 +1,500 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { resolvePreparedRunAdmission } from "../../agents/admitted-run-context.js";
+import type { RunCliAgentParams } from "../../agents/cli-runner/types.js";
+import {
+  classifyEmbeddedAgentRunResultForModelFallback,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+} from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
+import { prepareEmbeddedAttemptStream } from "../../agents/embedded-agent-runner/run/attempt-stream-prepare.js";
+import type { RunEmbeddedAgentParams } from "../../agents/embedded-agent-runner/run/params.js";
+import { clearActiveEmbeddedRun } from "../../agents/embedded-agent-runner/runs.js";
+import { createStubSessionHarness } from "../../agents/embedded-agent-subscribe.e2e-harness.js";
+import { FailoverError } from "../../agents/failover-error.js";
+import { GENERIC_EXTERNAL_RUN_FAILURE_TEXT } from "../../agents/failover/user-copy.js";
+import { AgentHarnessPreflightError } from "../../agents/harness/errors.js";
+import { runWithModelFallback } from "../../agents/model-fallback-runner.js";
+import { AuthStorage } from "../../agents/sessions/auth-storage.js";
+import { ModelRegistry } from "../../agents/sessions/model-registry.js";
+import { makeAssistantMessageFixture } from "../../agents/test-helpers/assistant-message-fixtures.js";
+import { makeProviderModelFixture } from "../../agents/test-helpers/provider-model-fixture.js";
+import {
+  createChatRunState,
+  createSessionEventSubscriberRegistry,
+  createSessionMessageSubscriberRegistry,
+} from "../../gateway/server-chat-state.js";
+import {
+  createAgentEventHandler,
+  type AgentEventHandlerOptions,
+} from "../../gateway/server-chat.js";
+import { onAgentRuntimeEvent } from "../../infra/agent-events.js";
+import {
+  clearAgentRunContext,
+  getAgentRunContextOwnership,
+} from "../../infra/agent-run-registry.js";
+import { createDiagnosticEmbeddedRunOwner } from "../../logging/diagnostic-run-activity.js";
+import { getGlobalHookRunner } from "../../plugins/hook-runner-global.js";
+import { makeIsolatedAgentJobFixture, makeIsolatedAgentParamsFixture } from "./job-fixtures.js";
+import {
+  classifyEmbeddedAgentRunResultForModelFallbackMock,
+  mergeEmbeddedAgentRunResultForModelFallbackExhaustionMock,
+  dispatchCronDeliveryMock,
+  loadRunCronIsolatedAgentTurn,
+  loadSessionEntryMock,
+  makeCronSession,
+  makeCronSessionEntry,
+  mockRunCronFallbackPassthrough,
+  patchSessionEntryMock,
+  resetRunCronIsolatedAgentTurnHarness,
+  resolveCronSessionMock,
+  resolveCronPayloadOutcomeMock,
+  runEmbeddedAgentMock,
+  runCliAgentMock,
+  isCliProviderMock,
+  runWithModelFallbackMock,
+  resolveConfiguredModelRefMock,
+  resolveAllowedModelRefMock,
+  resolveAgentModelFallbacksOverrideMock,
+} from "./run.test-harness.js";
+
+const runCronIsolatedAgentTurn = await loadRunCronIsolatedAgentTurn();
+const inMemoryStorePath = "/tmp/store.json";
+
+describe("runCronIsolatedAgentTurn terminal lifecycle", () => {
+  beforeEach(() => {
+    resetRunCronIsolatedAgentTurnHarness();
+    mockRunCronFallbackPassthrough();
+  });
+
+  it.each([
+    "success",
+    "failure",
+    "cancelled",
+    "cli-success",
+    "cli-cancelled",
+    "cli-timeout",
+    "cli-exhausted-throw",
+    "cli-exhausted-result",
+    "outer-failure",
+    "finalize-failure",
+    "continuation-failure",
+    "post-execution-abort",
+    "retry-prepare-failure",
+    "retry-preflight-failure",
+    "retry-exhausted",
+  ] as const)("keeps a cron fallback active until outer $0 settlement", async (outcome) => {
+    const sessionKey = "agent:main:cron:lifecycle-fallback";
+    const sessionId = "cron-lifecycle-fallback";
+    const usesContinuation =
+      outcome === "continuation-failure" || outcome === "post-execution-abort";
+    const initialSessionEntry = makeCronSessionEntry({ sessionId });
+    resolveCronSessionMock.mockReturnValue(
+      makeCronSession({
+        storePath: inMemoryStorePath,
+        store: { [sessionKey]: { ...initialSessionEntry } },
+        initialSessionEntry,
+        isNewSession: usesContinuation,
+        sessionEntry: { ...initialSessionEntry },
+      }),
+    );
+    loadSessionEntryMock.mockImplementation((_storePath, key) =>
+      key === sessionKey ? { ...initialSessionEntry } : undefined,
+    );
+    resolveConfiguredModelRefMock.mockReturnValue({ provider: "openai", model: "gpt-5.6-luna" });
+    resolveAllowedModelRefMock.mockReturnValue({
+      ref: { provider: "openai", model: "gpt-5.6-luna" },
+    });
+    const exhausted = outcome.includes("exhausted");
+    const cliFallback = outcome.startsWith("cli-");
+    const cancelled = outcome === "cancelled" || outcome === "cli-cancelled";
+    resolveAgentModelFallbacksOverrideMock.mockReturnValue([
+      cliFallback ? "claude-cli/fallback-model" : "openai/fallback-model",
+    ]);
+    if (cliFallback) {
+      isCliProviderMock.mockImplementation((provider: string) => provider === "claude-cli");
+    }
+    const retryPreparationFailure =
+      outcome === "retry-prepare-failure" || outcome === "retry-preflight-failure";
+    const retryPreparationError =
+      outcome === "retry-preflight-failure"
+        ? new AgentHarnessPreflightError("retry preparation failed")
+        : new Error("retry preparation failed");
+    const retriesInterimAck = retryPreparationFailure || outcome === "retry-exhausted";
+    if (outcome === "outer-failure" || retriesInterimAck) {
+      resolveCronPayloadOutcomeMock.mockImplementation(
+        (await vi.importActual<typeof import("./helpers.js")>("./helpers.js"))
+          .resolveCronPayloadOutcome,
+      );
+    }
+    if (outcome === "finalize-failure") {
+      dispatchCronDeliveryMock.mockRejectedValueOnce(new Error("delivery finalization failed"));
+    }
+    runWithModelFallbackMock.mockImplementation(runWithModelFallback);
+    classifyEmbeddedAgentRunResultForModelFallbackMock.mockImplementation(
+      classifyEmbeddedAgentRunResultForModelFallback,
+    );
+    mergeEmbeddedAgentRunResultForModelFallbackExhaustionMock.mockImplementation(
+      mergeEmbeddedAgentRunResultForModelFallbackExhaustion,
+    );
+    const firstStarted = createDeferred();
+    const releaseFirst = createDeferred();
+    const secondPreparing = createDeferred();
+    const releaseSecond = createDeferred();
+    const postExecutionWriteStarted = createDeferred();
+    const releasePostExecutionWrite = createDeferred();
+    const controller = new AbortController();
+    const onExecutionStarted = vi.fn();
+    let completedContinuationSessionKey: string | undefined;
+    if (usesContinuation) {
+      const patchSessionEntry = patchSessionEntryMock.getMockImplementation();
+      if (!patchSessionEntry) {
+        throw new Error("expected guarded cron writer");
+      }
+      patchSessionEntryMock.mockImplementation(
+        async (
+          ...args: Parameters<
+            typeof import("../../config/sessions/session-accessor.js").patchSessionEntryCore
+          >
+        ) => {
+          if (args[0].sessionKey === completedContinuationSessionKey) {
+            completedContinuationSessionKey = undefined;
+            if (outcome === "continuation-failure") {
+              throw new Error("continuation write failed");
+            }
+            postExecutionWriteStarted.resolve();
+            await releasePostExecutionWrite.promise;
+          }
+          return patchSessionEntry(...args);
+        },
+      );
+    }
+    const chatRunState = createChatRunState();
+    const broadcast = vi.fn();
+    const clearTrackedActiveRun = vi.fn();
+    const persist = vi.fn<
+      NonNullable<AgentEventHandlerOptions["persistGatewaySessionLifecycleEventForEvent"]>
+    >(async () => {});
+    const handler = createAgentEventHandler({
+      broadcast,
+      broadcastToConnIds: vi.fn(),
+      nodeSendToSession: vi.fn(),
+      agentRunSeq: new Map(),
+      chatRunState,
+      clearAgentRunContext,
+      resolveSessionKeyForRun: () => sessionKey,
+      toolEventRecipients: chatRunState.toolEventRecipients,
+      sessionEventSubscribers: createSessionEventSubscriberRegistry(),
+      sessionMessageSubscribers: createSessionMessageSubscriberRegistry(),
+      persistGatewaySessionLifecycleEventForEvent: persist,
+      clearTrackedActiveRun,
+    });
+    const unsubscribe = onAgentRuntimeEvent(handler);
+    let attemptIndex = 0;
+    runCliAgentMock.mockImplementation(async (runParams: RunCliAgentParams) => {
+      attemptIndex++;
+      runParams.onExecutionStarted?.();
+      secondPreparing.resolve();
+      await releaseSecond.promise;
+      if (outcome === "cli-exhausted-throw") {
+        throw new FailoverError("CLI provider unavailable", { reason: "server_error" });
+      }
+      if (outcome === "cli-exhausted-result") {
+        // The real classifier rejects generic CLI failure copy; exhaustion
+        // merges this candidate's metadata with the native incomplete reply.
+        return {
+          payloads: [{ text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT }],
+          meta: { agentMeta: {} },
+        };
+      }
+      if (cancelled || outcome === "cli-timeout") {
+        return {
+          payloads: [],
+          meta: {
+            agentMeta: {},
+            aborted: true,
+            providerStarted: true,
+            stopReason: cancelled ? "aborted" : "timeout",
+            ...(outcome === "cli-timeout" ? { timeoutPhase: "provider" } : {}),
+          },
+        };
+      }
+      return { payloads: [{ text: "Final report" }], meta: { agentMeta: {} } };
+    });
+    runEmbeddedAgentMock.mockImplementation(async (runParams: RunEmbeddedAgentParams) => {
+      const first = attemptIndex++ === 0;
+      if (retriesInterimAck && attemptIndex > 2) {
+        throw retryPreparationFailure
+          ? retryPreparationError
+          : new FailoverError("retry provider unavailable", { reason: "server_error" });
+      }
+      if (!first) {
+        secondPreparing.resolve();
+        await releaseSecond.promise;
+      }
+      const { provider, model, thinkLevel } = runParams;
+      if (!provider || !model || !thinkLevel) {
+        throw new Error("Cron did not prepare the model attempt");
+      }
+      const admittedRunContext = await resolvePreparedRunAdmission({
+        ...runParams,
+        runtimeKind: "embedded",
+      });
+      runParams.onExecutionStarted?.();
+      const authStorage = AuthStorage.inMemory();
+      const native = createStubSessionHarness();
+      const stream = prepareEmbeddedAttemptStream({
+        attempt: {
+          runId: runParams.runId,
+          sessionId: runParams.sessionId,
+          sessionKey: runParams.sessionKey,
+          agentId: runParams.agentId,
+          workspaceDir: runParams.workspaceDir,
+          prompt: runParams.prompt,
+          timeoutMs: runParams.timeoutMs,
+          config: runParams.config,
+          trigger: runParams.trigger,
+          abortSignal: runParams.abortSignal,
+          deferTerminalLifecycle: runParams.deferTerminalLifecycle,
+          onAgentEvent: runParams.onAgentEvent,
+          admittedRunContext,
+          provider,
+          modelId: model,
+          model: makeProviderModelFixture({
+            provider,
+            id: model,
+            api: "openai-responses",
+            baseUrl: "https://provider.test",
+          }),
+          thinkLevel,
+          sessionFile: sessionKey,
+          authStorage,
+          authProfileStore: { version: 1, profiles: {} },
+          modelRegistry: ModelRegistry.inMemory(authStorage),
+          startedAtMs: Date.now(),
+        },
+        activeSession: native.session,
+        hookRunner: getGlobalHookRunner(),
+        hookAgentId: "main",
+        diagnosticTrace: { traceId: "1".repeat(32) },
+        diagnosticOwner: createDiagnosticEmbeddedRunOwner({
+          sessionId,
+          sessionKey,
+          runId: runParams.runId,
+        }),
+        clientToolCallSlots: [],
+        nestedToolActivities: [],
+        isReplaySafeTool: () => false,
+        runAbortController: new AbortController(),
+        abortRun: vi.fn(),
+        markExternalAbort: vi.fn(),
+        getRunState: () => ({
+          aborted: controller.signal.aborted,
+          promptError: undefined,
+          timedOut: false,
+          yieldDetected: false,
+        }),
+        hasDeliveredSourceReply: () => false,
+        markSourceReplyDelivered: vi.fn(),
+        onBlockReply: undefined,
+        onBlockReplyFlush: undefined,
+        sandboxSessionKey: sessionKey,
+        builtinToolNames: new Set(),
+        replaySafeToolNames: new Set(),
+      });
+      try {
+        native.emit({ type: "agent_start" });
+        if (first || outcome === "failure") {
+          if (first) {
+            firstStarted.resolve();
+            await releaseFirst.promise;
+          }
+          const incomplete = outcome === "cli-exhausted-result";
+          native.emit({
+            type: "message_update",
+            message: makeAssistantMessageFixture({
+              provider,
+              model,
+              stopReason: incomplete ? "stop" : "error",
+              errorMessage: incomplete ? undefined : "429 rate limit",
+              content: incomplete ? [{ type: "thinking", thinking: "Still reasoning" }] : [],
+            }),
+          });
+          native.emit({ type: "agent_end" });
+          if (incomplete) {
+            // Native terminal resolution preserves a safe incomplete reply after
+            // its internal retries; the later CLI candidate supplies no liveness.
+            return {
+              payloads: [{ text: "Incomplete provider response", isError: true }],
+              meta: {
+                agentMeta: {},
+                livenessState: "abandoned",
+                replayInvalid: true,
+                error: {
+                  kind: "incomplete_turn",
+                  message: "Incomplete provider response",
+                  fallbackSafe: true,
+                },
+              },
+            };
+          }
+          throw new FailoverError("429 rate limit", { reason: "rate_limit", provider, model });
+        }
+        if (outcome === "cancelled") {
+          native.emit({
+            type: "message_update",
+            message: makeAssistantMessageFixture({
+              provider,
+              model,
+              stopReason: "aborted",
+              errorMessage: undefined,
+              content: [],
+            }),
+          });
+          native.emit({ type: "agent_end" });
+          return { payloads: [], meta: { aborted: true, stopReason: "aborted", agentMeta: {} } };
+        }
+        const text = retriesInterimAck ? "On it." : "Final report";
+        const assistantMessage = makeAssistantMessageFixture({
+          provider,
+          model,
+          stopReason: "stop",
+          errorMessage: undefined,
+          content: [{ type: "text", text }],
+          timestamp: Date.now(),
+        });
+        native.emit({ type: "message_start", message: assistantMessage });
+        native.emit({ type: "message_end", message: assistantMessage });
+        native.emit({ type: "agent_end" });
+        if (usesContinuation) {
+          expect(runParams.sessionKey).toContain(":run:");
+          completedContinuationSessionKey = runParams.sessionKey;
+        }
+        return {
+          payloads: [
+            { text },
+            ...(outcome === "outer-failure"
+              ? [{ text: "Tool execution failed", isError: true }]
+              : []),
+          ],
+          meta: { agentMeta: {}, stopReason: "stop" },
+        };
+      } finally {
+        stream.subscription.unsubscribe();
+        clearActiveEmbeddedRun(sessionId, stream.queueHandle, sessionKey);
+      }
+    });
+    const run = runCronIsolatedAgentTurn({
+      ...makeIsolatedAgentParamsFixture({
+        agentId: "main",
+        sessionKey,
+        job: makeIsolatedAgentJobFixture({
+          sessionTarget: usesContinuation ? "isolated" : `session:${sessionKey}`,
+          delivery: { mode: "none" },
+        }),
+      }),
+      abortSignal: controller.signal,
+      onExecutionStarted,
+    });
+    const exited = run.then((result) => {
+      throw new Error(`Cron exited before fallback boundary: ${JSON.stringify(result)}`);
+    });
+    try {
+      await Promise.race([firstStarted.promise, exited]);
+      vi.useFakeTimers();
+      releaseFirst.resolve();
+      await Promise.race([secondPreparing.promise, exited]);
+      await vi.advanceTimersByTimeAsync(15_000);
+      expect(attemptIndex).toBe(2);
+      expect(runCliAgentMock).toHaveBeenCalledTimes(cliFallback ? 1 : 0);
+      expect(broadcast.mock.calls.filter(([event]) => event === "chat")).toHaveLength(0);
+      expect(
+        persist.mock.calls.filter(([params]) => params.event.data?.phase === "error"),
+      ).toHaveLength(0);
+      expect(getAgentRunContextOwnership(sessionId)?.clearRequested).toBe(false);
+      expect(clearTrackedActiveRun).not.toHaveBeenCalled();
+      if (cancelled) {
+        controller.abort();
+      }
+      releaseSecond.resolve();
+      if (outcome === "post-execution-abort") {
+        await Promise.race([postExecutionWriteStarted.promise, exited]);
+        controller.abort(new Error("post-execution abort"));
+        releasePostExecutionWrite.resolve();
+      }
+      const succeeded = outcome === "success" || outcome === "cli-success";
+      await expect(run).resolves.toMatchObject({ status: succeeded ? "ok" : "error" });
+      if (outcome === "outer-failure" || outcome === "finalize-failure") {
+        const error =
+          outcome === "outer-failure" ? "Tool execution failed" : "delivery finalization failed";
+        await expect(run).resolves.toMatchObject({ error });
+      }
+      if (outcome === "finalize-failure") {
+        await expect(run).resolves.toMatchObject({ executionStarted: true });
+      }
+      if (outcome === "continuation-failure") {
+        await expect(run).resolves.toMatchObject({ error: "continuation write failed" });
+      }
+      if (outcome === "post-execution-abort") {
+        await expect(run).resolves.toMatchObject({ error: "post-execution abort" });
+      }
+      if (retryPreparationFailure) {
+        await expect(run).resolves.toMatchObject({
+          error: expect.stringContaining("retry preparation failed"),
+        });
+        await expect(runWithModelFallbackMock.mock.results[1]?.value).rejects.toBe(
+          retryPreparationError,
+        );
+      }
+      // Final failures settle without advancing retry grace, including preflight
+      // failures that never emitted a candidate lifecycle or fallback step.
+      if (exhausted || retryPreparationFailure) {
+        if (outcome === "cli-exhausted-result") {
+          await expect(runWithModelFallbackMock.mock.results[0]?.value).resolves.toMatchObject({
+            outcome: "exhausted",
+            result: { meta: { error: { kind: "incomplete_turn" } } },
+          });
+        }
+        expect({
+          terminalWrites: persist.mock.calls.filter(
+            ([params]) => params.event.data?.phase === "error",
+          ).length,
+          activityClears: clearTrackedActiveRun.mock.calls.length,
+        }).toEqual({ terminalWrites: 1, activityClears: 1 });
+        expect(clearTrackedActiveRun).toHaveBeenCalledExactlyOnceWith({
+          runId: sessionId,
+          clientRunId: sessionId,
+          sessionKey,
+        });
+      }
+      expect(onExecutionStarted).toHaveBeenCalledTimes(2);
+      const state = cancelled
+        ? "aborted"
+        : outcome === "failure" || outcome === "cli-timeout" || retryPreparationFailure || exhausted
+          ? "error"
+          : "final";
+      expect(
+        broadcast.mock.calls.filter(
+          ([event, payload]) => event === "chat" && payload.state !== "delta",
+        ),
+      ).toEqual([
+        [
+          "chat",
+          expect.objectContaining({
+            runId: sessionId,
+            state,
+            ...(outcome === "cli-timeout" ? { stopReason: "timeout", errorKind: "timeout" } : {}),
+          }),
+          expect.anything(),
+        ],
+      ]);
+    } finally {
+      releaseFirst.resolve();
+      releaseSecond.resolve();
+      releasePostExecutionWrite.resolve();
+      await run.catch(() => {});
+      unsubscribe();
+      handler.dispose();
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/cron/isolated-agent/run.terminal-lifecycle.test.ts
+++ b/src/cron/isolated-agent/run.terminal-lifecycle.test.ts
@@ -301,6 +301,11 @@ describe("runCronIsolatedAgentTurn terminal lifecycle", () => {
         builtinToolNames: new Set(),
         replaySafeToolNames: new Set(),
       });
+      const emitAssistantEnd = (message: ReturnType<typeof makeAssistantMessageFixture>) => {
+        native.emit({ type: "message_start", message });
+        native.emit({ type: "message_end", message });
+        native.emit({ type: "agent_end", messages: [message], willRetry: false });
+      };
       try {
         native.emit({ type: "agent_start" });
         if (first || outcome === "failure") {
@@ -309,17 +314,14 @@ describe("runCronIsolatedAgentTurn terminal lifecycle", () => {
             await releaseFirst.promise;
           }
           const incomplete = outcome === "cli-exhausted-result";
-          native.emit({
-            type: "message_update",
-            message: makeAssistantMessageFixture({
-              provider,
-              model,
-              stopReason: incomplete ? "stop" : "error",
-              errorMessage: incomplete ? undefined : "429 rate limit",
-              content: incomplete ? [{ type: "thinking", thinking: "Still reasoning" }] : [],
-            }),
+          const assistantMessage = makeAssistantMessageFixture({
+            provider,
+            model,
+            stopReason: incomplete ? "stop" : "error",
+            errorMessage: incomplete ? undefined : "429 rate limit",
+            content: incomplete ? [{ type: "thinking", thinking: "Still reasoning" }] : [],
           });
-          native.emit({ type: "agent_end" });
+          emitAssistantEnd(assistantMessage);
           if (incomplete) {
             // Native terminal resolution preserves a safe incomplete reply after
             // its internal retries; the later CLI candidate supplies no liveness.
@@ -340,17 +342,14 @@ describe("runCronIsolatedAgentTurn terminal lifecycle", () => {
           throw new FailoverError("429 rate limit", { reason: "rate_limit", provider, model });
         }
         if (outcome === "cancelled") {
-          native.emit({
-            type: "message_update",
-            message: makeAssistantMessageFixture({
-              provider,
-              model,
-              stopReason: "aborted",
-              errorMessage: undefined,
-              content: [],
-            }),
+          const assistantMessage = makeAssistantMessageFixture({
+            provider,
+            model,
+            stopReason: "aborted",
+            errorMessage: undefined,
+            content: [],
           });
-          native.emit({ type: "agent_end" });
+          emitAssistantEnd(assistantMessage);
           return { payloads: [], meta: { aborted: true, stopReason: "aborted", agentMeta: {} } };
         }
         const text = retriesInterimAck ? "On it." : "Final report";
@@ -362,9 +361,7 @@ describe("runCronIsolatedAgentTurn terminal lifecycle", () => {
           content: [{ type: "text", text }],
           timestamp: Date.now(),
         });
-        native.emit({ type: "message_start", message: assistantMessage });
-        native.emit({ type: "message_end", message: assistantMessage });
-        native.emit({ type: "agent_end" });
+        emitAssistantEnd(assistantMessage);
         if (usesContinuation) {
           expect(runParams.sessionKey).toContain(":run:");
           completedContinuationSessionKey = runParams.sessionKey;

--- a/src/cron/isolated-agent/run.test-harness.ts
+++ b/src/cron/isolated-agent/run.test-harness.ts
@@ -4,6 +4,7 @@ import { vi, type Mock } from "vitest";
 import { resolveFastModeState as resolveFastModeStateImpl } from "../../agents/fast-mode.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import { resolveAgentModelFallbackValues } from "../../config/model-input.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 
 // Central mock harness for isolated cron agent run orchestration tests.
@@ -63,7 +64,6 @@ export const resolveAgentModelFallbacksOverrideMock = createMock();
 export const resolveAgentSkillsFilterMock = createMock();
 const getModelRefStatusMock = createMock();
 export const isCliProviderMock = createMock();
-export const resolveCliRuntimeExecutionProviderMock = createMock();
 export const resolveAllowedModelRefMock = createMock();
 export const resolveConfiguredModelRefMock = createMock();
 const resolveHooksGmailModelMock = createMock();
@@ -172,13 +172,6 @@ vi.mock("./run.runtime.js", async () => ({
   isExternalHookSession: isExternalHookSessionMock,
   resolveHookExternalContentSource: resolveHookExternalContentSourceMock,
   getRemoteSkillEligibility: getRemoteSkillEligibilityMock,
-}));
-
-vi.mock("../../agents/model-runtime-aliases.js", async () => ({
-  ...(await vi.importActual<typeof import("../../agents/model-runtime-aliases.js")>(
-    "../../agents/model-runtime-aliases.js",
-  )),
-  resolveCliRuntimeExecutionProvider: resolveCliRuntimeExecutionProviderMock,
 }));
 
 vi.mock("./run-external-content.runtime.js", () => ({
@@ -315,7 +308,8 @@ vi.mock("./run-execution.runtime.js", () => ({
     mergeEmbeddedAgentRunResultForModelFallbackExhaustionMock,
 }));
 
-vi.mock("../../agents/model-runtime-aliases.js", () => ({
+vi.mock("../../agents/model-runtime-aliases.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../agents/model-runtime-aliases.js")>()),
   resolveCliRuntimeExecutionProvider: ({
     provider,
     cfg,
@@ -546,7 +540,6 @@ function resetRunConfigMocks(): void {
   resolveAgentModelFallbacksOverrideMock.mockReturnValue(undefined);
   resolveAgentSkillsFilterMock.mockReturnValue(undefined);
   resolveConfiguredModelRefMock.mockReturnValue({ provider: "openai", model: "gpt-5.4" });
-  resolveCliRuntimeExecutionProviderMock.mockReturnValue(undefined);
   resolveAllowedModelRefMock.mockReturnValue({ ref: { provider: "openai", model: "gpt-5.4" } });
   resolveHooksGmailModelMock.mockReturnValue(null);
   resolveThinkingDefaultMock.mockReturnValue("off");
@@ -592,8 +585,10 @@ function resetRunConfigMocks(): void {
   loadPublishedReplyDispatchRuntimeMock.mockResolvedValue(undefined);
   acquirePreparedModelRuntimeMock.mockImplementation(async (input, options) => {
     const registry = preparedRunPluginRegistryMock();
-    const metadata = options?.pluginGeneration?.pluginMetadataSnapshot ??
-      options?.pluginMetadataSnapshot ?? { plugins: [], index: { plugins: [] } };
+    const metadata =
+      options?.pluginGeneration?.pluginMetadataSnapshot ??
+      options?.pluginMetadataSnapshot ??
+      createPluginMetadataSnapshotFixture();
     return {
       snapshot: { ...input, metadataSnapshot: metadata, pluginRegistry: registry },
       pluginGeneration: {

--- a/src/cron/isolated-agent/run.ts
+++ b/src/cron/isolated-agent/run.ts
@@ -1,7 +1,11 @@
 import { retireSessionMcpRuntime } from "../../agents/agent-bundle-mcp-tools.js";
 import { withPreparedModelRuntimePluginGenerationScope } from "../../agents/prepared-model-runtime-generation-scope.js";
 import type { PreparedModelRuntimeLease } from "../../agents/prepared-model-runtime.types.js";
-import { createAgentRunRestartAbortError } from "../../agents/run-termination.js";
+import {
+  createAgentRunRestartAbortError,
+  resolveAgentRunErrorLifecycleFields,
+} from "../../agents/run-termination.js";
+import { createAgentLifecycleTerminalBackstop } from "../../auto-reply/reply/agent-lifecycle-terminal.js";
 import { cleanupBrowserSessionsForLifecycleEnd } from "../../browser-lifecycle-cleanup.js";
 import type { CliDeps } from "../../cli/outbound-send-deps.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -197,6 +201,15 @@ export async function runCronIsolatedAgentTurn(params: {
   let outcome: "completed" | "error" = "completed";
   let outcomeError: string | undefined;
   let cronRunSessionCleanupHandled = false;
+  // The execution owner spans fallback and interim-ack retries. Individual
+  // attempts must not retire the shared run before that execution settles.
+  const lifecycle = createAgentLifecycleTerminalBackstop({
+    runId: initialSessionId,
+    sessionKey: prepared.context.runSessionKey,
+    startedAt: turnStartedAtMs,
+    getLifecycleGeneration: () => runLifecycleGeneration,
+    resolveTerminationFields: (error) => resolveAgentRunErrorLifecycleFields(error, abortSignal),
+  });
   try {
     assertAgentRunLifecycleGenerationCurrent(runLifecycleGeneration);
     const existingRunContext = getAgentRunContext(initialSessionId);
@@ -254,6 +267,7 @@ export async function runCronIsolatedAgentTurn(params: {
       setRunContinuationCliExecutionProvider:
         prepared.context.runContinuationSession?.setCliExecutionProvider,
       abortSignal,
+      lifecycle,
       onExecutionStarted: notifyExecutionStarted,
       onExecutionPhase: notifyExecutionPhase,
       onLaneWait: params.onLaneWait,
@@ -287,6 +301,9 @@ export async function runCronIsolatedAgentTurn(params: {
     } finally {
       releasePreparedRuntime();
     }
+    // Publish the execution fact captured before bookkeeping; cron persistence
+    // and delivery retain their separate workflow outcome.
+    lifecycle.emit("end", execution.runResult);
     const finalized = await finalizeCronRun({
       prepared: prepared.context,
       execution,
@@ -308,6 +325,7 @@ export async function runCronIsolatedAgentTurn(params: {
       ? finalized
       : { ...finalized, nextCheck: { delayMs } };
   } catch (err) {
+    lifecycle.emit("error", err);
     consumeCronNextCheckProposal(initialSessionId, params.job.id);
     const isCronLaneTimeout = isAborted() || isCronNestedLaneTaskTimeoutError(err);
     const error = isCronLaneTimeout ? abortReason() : normalizeCronRunErrorText(err);

--- a/src/gateway/agent-turn/agent-job.execution-settlement.test.ts
+++ b/src/gateway/agent-turn/agent-job.execution-settlement.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AgentHarnessPreflightError } from "../../agents/harness/errors.js";
+import { createAgentLifecycleTerminalBackstop } from "../../auto-reply/reply/agent-lifecycle-terminal.js";
+import { emitAgentEvent, getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
+import { waitForAgentJob } from "./agent-job.js";
+
+let runSequence = 0;
+
+describe("waitForAgentJob settled execution", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it.each([
+    {
+      label: "preflight failure",
+      phase: "error",
+      result: new AgentHarnessPreflightError("execution preparation failed"),
+      termination: {},
+      expected: { status: "error", error: "execution preparation failed" },
+    },
+    {
+      label: "explicit cancellation",
+      phase: "error",
+      result: new Error("execution cancelled"),
+      termination: { aborted: true, stopReason: "rpc" },
+      expected: { status: "error", stopReason: "rpc" },
+    },
+    {
+      label: "bare abort from a settled backend",
+      phase: "end",
+      result: { meta: { aborted: true } },
+      termination: {},
+      expected: { status: "error", stopReason: "aborted" },
+    },
+    {
+      label: "provider timeout",
+      phase: "end",
+      result: {
+        meta: {
+          aborted: true,
+          stopReason: "timeout",
+          timeoutPhase: "provider",
+          providerStarted: true,
+        },
+      },
+      termination: {},
+      expected: { status: "timeout", stopReason: "timeout", timeoutPhase: "provider" },
+    },
+    {
+      label: "yielded execution",
+      phase: "end",
+      result: { meta: { yielded: true } },
+      termination: {},
+      expected: { status: "ok", yielded: true },
+    },
+  ] as const)(
+    "publishes $label without retry grace",
+    async ({ phase, result, termination, expected }) => {
+      const runId = `settled-execution-${runSequence++}`;
+      const waiter = waitForAgentJob({ runId, timeoutMs: 60_000 });
+      const lifecycle = createAgentLifecycleTerminalBackstop({
+        runId,
+        startedAt: 1_000,
+        getLifecycleGeneration: getAgentEventLifecycleGeneration,
+        resolveTerminationFields: () => termination,
+      });
+      emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "start", startedAt: 1_000 } });
+      try {
+        lifecycle.capture(phase, result);
+        await expect(waitForAgentJob({ runId, timeoutMs: 0 })).resolves.toBeNull();
+        lifecycle.emit(phase, result);
+        // Assert before advancing clocks: an active waiter and a new reader must
+        // observe the producer's final result, not its eventual deadline fallback.
+        await expect(waitForAgentJob({ runId, timeoutMs: 0 })).resolves.toMatchObject(expected);
+        await expect(waiter).resolves.toMatchObject(expected);
+      } finally {
+        await vi.advanceTimersByTimeAsync(60_000);
+        await waiter;
+      }
+    },
+  );
+});

--- a/src/gateway/agent-turn/agent-job.ts
+++ b/src/gateway/agent-turn/agent-job.ts
@@ -11,6 +11,7 @@ import {
   AGENT_RUN_TERMINAL_RETRY_GRACE_MS,
   buildAgentRunTerminalOutcome,
   buildAgentRunTerminalOutcomeFromLifecycleEvent,
+  hasExecutionSettlement,
   isStickyAgentRunTerminalOutcome,
   mergeAgentRunTerminalOutcome,
   type AgentRunTerminalOutcome,
@@ -311,7 +312,10 @@ function createSnapshotFromLifecycleEvent(params: {
   // agent.wait historically treats a bare abort flag as a retryable timeout.
   // Modern explicit stop reasons keep the canonical cancellation projection.
   const legacyBareAbort =
-    terminalOutcome.reason === "aborted" && data?.stopReason == null && data?.status == null;
+    !hasExecutionSettlement(data) &&
+    terminalOutcome.reason === "aborted" &&
+    data?.stopReason == null &&
+    data?.status == null;
   const terminalDelivery = normalizeAgentRunTerminalDeliverySnapshot(data?.terminalDelivery);
   const terminalReply = normalizeAgentRunTerminalReplySnapshot(data?.terminalReply);
   const normalizedTerminalReceipt = normalizeAgentRunTerminalReceipt(data?.terminalReceipt);
@@ -363,11 +367,12 @@ function ensureAgentRunListener() {
       data: evt.data,
     });
     agentRunStarts.delete(evt.runId);
-    if (phase === "error" && evt.data?.fallbackExhaustedFailure !== true) {
+    const executionSettled = hasExecutionSettlement(evt.data);
+    if (!executionSettled && phase === "error" && evt.data?.fallbackExhaustedFailure !== true) {
       schedulePendingAgentRunTerminal(pendingAgentRunErrors, snapshot);
       return;
     }
-    if (phase === "end" && snapshot.status === "timeout") {
+    if (!executionSettled && phase === "end" && snapshot.status === "timeout") {
       schedulePendingAgentRunTerminal(pendingAgentRunTimeouts, snapshot);
       return;
     }

--- a/src/gateway/server-chat.agent-events.test.ts
+++ b/src/gateway/server-chat.agent-events.test.ts
@@ -1598,10 +1598,10 @@ describe("agent event handler", () => {
     nowSpy.mockRestore();
   });
 
-  it("carries buffered text in the terminal message when an error classifies as cancellation", () => {
+  it("immediately carries buffered text when a native error definitively cancels the run", () => {
     let now = 10_000;
     const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
-    const { broadcast, chatRunState, handler } = createHarness({ lifecycleErrorRetryGraceMs: 0 });
+    const { broadcast, chatRunState, handler } = createHarness();
     registerNamedChatRun(chatRunState, "err-cancel");
 
     emitAgentEvent(handler, "run-err-cancel", "assistant", { text: "Hello" });
@@ -1614,7 +1614,7 @@ describe("agent event handler", () => {
       handler,
       "run-err-cancel",
       "lifecycle",
-      { phase: "error", aborted: true },
+      { phase: "error", aborted: true, stopReason: "aborted" },
       { seq: 2 },
     );
 
@@ -2894,7 +2894,6 @@ describe("agent event handler", () => {
       clientRunId: "completed-during-marker-write",
       sessionKey: "session-recovery",
       sessionId: "session-recovery",
-      observedAt: 2_100,
       persistence: expect.any(Promise),
     });
     await waitForFast(() => {
@@ -4375,6 +4374,50 @@ describe("agent event handler", () => {
     }),
   );
 
+  it.each([
+    { name: "fallback exhaustion", data: { fallbackExhaustedFailure: true }, state: "error" },
+    {
+      name: "native cancellation",
+      data: { aborted: true, stopReason: "aborted" },
+      state: "aborted",
+    },
+    {
+      name: "provider timeout",
+      data: { stopReason: "timeout", timeoutPhase: "provider" },
+      state: "error",
+    },
+  ])("finalizes $name immediately and retires the preceding retryable error", ({ data, state }) => {
+    vi.useFakeTimers();
+    const { broadcast, clearAgentRunContext, agentRunSeq, handler } = createHarness({
+      resolveSessionKeyForRun: () => "session-terminal-error",
+    });
+    const runId = "run-terminal-final-failure";
+    registerAgentRunContext(runId, { sessionKey: "session-terminal-error" });
+    emitAgentEvent(handler, runId, "lifecycle", { phase: "error", error: "retryable failure" });
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(0);
+
+    emitAgentEvent(
+      handler,
+      runId,
+      "lifecycle",
+      {
+        phase: "error",
+        error: "Terminal failure",
+        ...data,
+      },
+      { seq: 2 },
+    );
+
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(1);
+    expect(chatBroadcastCalls(broadcast)[0]?.[1]).toMatchObject({ runId, state });
+    expect(clearAgentRunContext).toHaveBeenCalledWith(runId);
+    expect(agentRunSeq.has(runId)).toBe(false);
+    expect(persistGatewaySessionLifecycleEventMock).toHaveBeenCalledOnce();
+    vi.advanceTimersByTime(15_000);
+    expect(chatBroadcastCalls(broadcast)).toHaveLength(1);
+    expect(persistGatewaySessionLifecycleEventMock).toHaveBeenCalledOnce();
+  });
+
   it("keeps deferred lifecycle-error cleanup across later non-terminal events", () => {
     vi.useFakeTimers();
     const { broadcast, clearAgentRunContext, agentRunSeq, handler } = createHarness({
@@ -4451,11 +4494,10 @@ describe("agent event handler", () => {
     expect(agentRunSeq.has("run-terminal-late-lifecycle")).toBe(false);
   });
 
-  it("cancels deferred lifecycle-error cleanup when the run restarts", () => {
+  it("cancels default-grace lifecycle-error cleanup when the run restarts", () => {
     vi.useFakeTimers();
     const { broadcast, clearAgentRunContext, agentRunSeq, handler } = createHarness({
       resolveSessionKeyForRun: () => "session-terminal-retry",
-      lifecycleErrorRetryGraceMs: 100,
     });
     registerAgentRunContext("run-terminal-retry", {
       sessionKey: "session-terminal-retry",
@@ -4467,7 +4509,7 @@ describe("agent event handler", () => {
       ["lifecycle", { phase: "start" }],
     ]);
 
-    vi.advanceTimersByTime(100);
+    vi.advanceTimersByTime(15_000);
 
     expect(
       chatBroadcastCalls(broadcast).some(
@@ -4600,9 +4642,14 @@ describe("agent event handler", () => {
     "projects subscribed provider %s terminals through %s ownership",
     (stopReason, owner) => {
       const runId = `run-provider-${stopReason}`;
-      const { broadcast, nodeSendToSession, handler, chatRunState } = createHarness({
-        lifecycleErrorRetryGraceMs: 0,
-      });
+      // Unowned subscription errors retain legacy grace; outer owners must settle at defaults.
+      const { broadcast, nodeSendToSession, handler, chatRunState } = createHarness(
+        owner === "direct" ? { lifecycleErrorRetryGraceMs: 0 } : undefined,
+      );
+      const chatTerminals = () =>
+        chatBroadcastCalls(broadcast).filter(([, event]) =>
+          ["final", "error", "aborted"].includes(event.state),
+        );
       registerChatRun(chatRunState, runId, "session-provider-detail", runId);
       const state: AgentAttemptLifecycleState = {
         currentTurnUserMessagePersisted: true,
@@ -4647,6 +4694,9 @@ describe("agent event handler", () => {
         };
         emit({ type: "message_end", message });
         emit({ type: "agent_end" });
+        if (owner !== "direct") {
+          expect(chatTerminals()).toHaveLength(0);
+        }
         const terminal = {
           metadata: {},
           outcome: buildAgentRunTerminalOutcome({
@@ -4656,18 +4706,28 @@ describe("agent event handler", () => {
         };
         if (owner === "command") {
           if (stopReason === "error") {
-            command.emitResultError({ payloads: [], meta: { durationMs: 0 } }, true, terminal);
+            command.emitResultError({ payloads: [], meta: { durationMs: 0 } }, false, terminal);
           } else {
             command.emitEnd(terminal);
           }
         }
         if (owner === "reply") {
-          reply.emit(
-            stopReason === "error" ? "error" : "end",
-            stopReason === "error" ? "Provider failed" : { meta: {} },
-          );
+          const phase = stopReason === "error" ? "error" : "end";
+          const result = stopReason === "error" ? "Provider failed" : { meta: {} };
+          reply.capture(phase, result);
+          expect(chatTerminals()).toHaveLength(0);
+          reply.emit(phase, result);
         }
-        const payload = chatBroadcastCalls(broadcast).at(-1)?.[1];
+        expect(chatTerminals()).toHaveLength(1);
+        const payload = chatTerminals()[0]?.[1];
+        const runtimeTerminal = agentBroadcastCalls(broadcast).find(
+          ([, event]) =>
+            event.stream === "lifecycle" &&
+            event.data.phase === (stopReason === "error" ? "error" : "end"),
+        )?.[1];
+        if (owner !== "direct") {
+          expect(runtimeTerminal.data.executionSettled).toBe(true);
+        }
         const serialized = JSON.stringify(payload);
         const wire = JSON.parse(serialized);
         expect(Value.Check(ChatEventSchema, wire)).toBe(true);
@@ -4685,9 +4745,6 @@ describe("agent event handler", () => {
           const callbackTerminal = onAgentEvent.mock.calls.find(
             ([event]) => event.stream === "lifecycle" && event.data.error,
           )?.[0];
-          const runtimeTerminal = agentBroadcastCalls(broadcast).find(
-            ([, event]) => event.stream === "lifecycle" && event.data.phase === "error",
-          )?.[1];
           expect(callbackTerminal.data.errorObservation).toMatchObject({
             provider: "openai",
             model: "gpt-5.6-luna",
@@ -4810,9 +4867,14 @@ describe("agent event handler", () => {
     expect(agentRunSeq.has("run-chat-send")).toBe(false);
   });
 
-  it.each([false, true])(
-    "preserves reply-dispatch completion ownership through error grace (settled=%s)",
-    async (settled) => {
+  it.each([
+    { settled: false, executionSettled: false },
+    { settled: true, executionSettled: false },
+    { settled: false, executionSettled: true },
+    { settled: true, executionSettled: true },
+  ])(
+    "preserves reply-dispatch ownership (delivery=$settled, execution=$executionSettled)",
+    async ({ settled, executionSettled }) => {
       vi.useFakeTimers();
       const settleTrackedTerminal = vi.fn();
       const harness = createHarness({
@@ -4829,7 +4891,11 @@ describe("agent event handler", () => {
         phase: "error",
         error: "ACP turn failed",
         completionSource: "reply-dispatch",
+        ...(executionSettled ? { executionSettled: true } : {}),
       });
+      expect(persistGatewaySessionLifecycleEventMock).toHaveBeenCalledTimes(
+        executionSettled ? 1 : 0,
+      );
       expect.soft(chatRunState.runs.get(runId)?.buffer).toBe("pending delivered reply");
       expect(agentRunSeq.get(runId)).toBe(1);
       if (settled) {
@@ -4843,7 +4909,7 @@ describe("agent event handler", () => {
         chatRunState.registry.remove(runId, runId);
       }
 
-      // Run the production grace timer, even after the dispatch owner settled.
+      // Drain pending persistence or legacy grace after the dispatch owner's action.
       await vi.runAllTimersAsync();
 
       const terminals = chatBroadcastCalls(broadcast);

--- a/src/gateway/server-chat.ts
+++ b/src/gateway/server-chat.ts
@@ -356,7 +356,6 @@ export type AgentEventHandlerOptions = {
     clientRunId: string;
     sessionKey: string;
     sessionId?: string;
-    observedAt: number;
     persistence: Promise<void>;
   }) => void;
   resolveActiveLifecycleGenerationForRun?: (runId: string) => string | undefined;
@@ -713,6 +712,7 @@ export function createAgentEventHandler({
     if (isSupersededRestartRecoveryEvent) {
       return;
     }
+    clearPendingTerminalLifecycleError(evt.runId, evt.lifecycleGeneration);
     let terminalPersistence: Promise<void> | undefined;
 
     if (
@@ -817,7 +817,6 @@ export function createAgentEventHandler({
           clientRunId,
           sessionKey,
           sessionId: evt.sessionId,
-          observedAt: evt.ts,
           persistence,
         });
         const broadcastSessionChange = (snapshotEvent?: AgentEventPayload) => {
@@ -1715,10 +1714,9 @@ export function createAgentEventHandler({
         phase: lifecyclePhase,
         data: evt.data,
       });
-      // Only retryable errors get grace. Definitive timeouts must persist their
-      // reason before dispatch closes the run and the sidebar reads its status.
+      // Only retryable failures get grace. Definitive cancellation and timeout
+      // must persist before dispatch closes the run and the sidebar reads its status.
       if (isAborted || definitiveTerminal || lifecycleErrorRetryGraceMs <= 0) {
-        clearPendingTerminalLifecycleError(evt.runId);
         // finalizeLifecycleEvent clears the buffer itself, after emitChatTerminal
         // has flushed the throttled tail and resolved the terminal message.
         finalizeLifecycleEvent(evt, { skipChatErrorFinal, restartRecoveryState });

--- a/src/gateway/server-runtime-subscriptions.ts
+++ b/src/gateway/server-runtime-subscriptions.ts
@@ -1,4 +1,5 @@
 // Gateway event subscription wiring for agent, heartbeat, transcript, and lifecycle broadcasts.
+import { isDefinitiveRunLifecycle } from "../agents/agent-run-terminal-outcome.js";
 import {
   isAuditLedgerEnabled,
   isExecutionIdentityCollectionEnabled,
@@ -200,7 +201,6 @@ export function startGatewayEventSubscriptions(params: {
     runId: string;
     clientRunId: string;
     sessionId?: string;
-    observedAt: number;
     persistence: Promise<void>;
   }) => {
     let tracked = false;
@@ -217,6 +217,8 @@ export function startGatewayEventSubscriptions(params: {
       const lifecycleGeneration = entry.lifecycleGeneration?.trim();
       const sessionKey = entry.sessionKey.trim();
       const sessionId = run.sessionId?.trim() || entry.sessionId.trim();
+      // Lazy chat consumption must retain the terminal time stamped at ingress.
+      const observedAt = entry.projectSessionTerminalObservedAt;
       if (entry.controlUiVisible !== false && lifecycleGeneration && sessionKey && sessionId) {
         void run.persistence.catch(() => {
           params.restartRecoveryCandidates.set(candidateRunId, {
@@ -224,7 +226,7 @@ export function startGatewayEventSubscriptions(params: {
             lifecycleGeneration,
             sessionKey,
             sessionId,
-            observedAt: run.observedAt,
+            observedAt,
           });
         });
       }
@@ -379,7 +381,7 @@ export function startGatewayEventSubscriptions(params: {
         trackedEntry.lifecycleGeneration === eventLifecycleGeneration;
       const claimIsComplete = !evt.contextClaimId || terminalAuthority !== undefined;
       const canPersistTerminal =
-        lifecyclePhase === "end" &&
+        isDefinitiveRunLifecycle({ phase: lifecyclePhase, data: evt.data }) &&
         evt.projectSessionLifecycle !== false &&
         trackedOwnerIsCurrent &&
         claimIsComplete;
@@ -409,7 +411,6 @@ export function startGatewayEventSubscriptions(params: {
           runId: evt.runId,
           clientRunId,
           sessionId: evt.sessionId,
-          observedAt,
           persistence,
         });
         if (!tracked) {

--- a/src/gateway/session-lifecycle-persistence-owner.test.ts
+++ b/src/gateway/session-lifecycle-persistence-owner.test.ts
@@ -231,14 +231,20 @@ describe("session lifecycle persistence owner", () => {
     expect(sessionStatus).toBe("running");
   });
 
-  it("does not restart a terminal write after its prepared promise expires", async () => {
+  it.each([
+    { name: "end", data: { phase: "end" } },
+    { name: "native cancellation", data: { phase: "error", aborted: true, stopReason: "aborted" } },
+    { name: "fallback exhaustion", data: { phase: "error", fallbackExhaustedFailure: true } },
+    { name: "settled execution failure", data: { phase: "error", executionSettled: true } },
+  ])("does not restart $name after its prepared promise expires", async ({ data }) => {
     vi.useFakeTimers();
     persistLifecycle.mockResolvedValue(undefined);
     const owner = createSessionLifecyclePersistenceOwner();
-    await owner.observe(terminal);
+    const event = { ...terminal, event: { ...terminal.event, data } };
+    await owner.observe(event);
     await vi.advanceTimersByTimeAsync(60_000);
 
-    await expect(owner.persist(terminal)).rejects.toMatchObject({
+    await expect(owner.persist(event)).rejects.toMatchObject({
       code: "ERR_STALE_GATEWAY_LIFECYCLE",
     });
     expect(persistLifecycle).toHaveBeenCalledOnce();

--- a/src/gateway/session-lifecycle-persistence-owner.ts
+++ b/src/gateway/session-lifecycle-persistence-owner.ts
@@ -1,4 +1,7 @@
-import { AGENT_RUN_TERMINAL_RETRY_GRACE_MS } from "../agents/agent-run-terminal-outcome.js";
+import {
+  AGENT_RUN_TERMINAL_RETRY_GRACE_MS,
+  isDefinitiveRunLifecycle,
+} from "../agents/agent-run-terminal-outcome.js";
 import type { AgentEventRuntimePayload } from "../infra/agent-events.js";
 import { createAgentRunStaleLifecycleError } from "../infra/agent-lifecycle-error.js";
 import { getAgentRunContextOwnerStatus } from "../infra/agent-run-registry.js";
@@ -61,7 +64,7 @@ function terminalEventKey(event: {
   return `${event.contextClaimId ?? ""}\0${event.lifecycleGeneration ?? ""}\0${event.runId}\0${event.seq}`;
 }
 
-/** Owns each lifecycle end write before optional chat presentation code runs. */
+/** Owns each definitive lifecycle write before optional chat presentation code runs. */
 export function createSessionLifecyclePersistenceOwner() {
   const prepared = new Map<string, PreparedPersistence>();
   const inFlight = new Set<Promise<void>>();
@@ -150,10 +153,12 @@ export function createSessionLifecyclePersistenceOwner() {
       if (preparedPersistence) {
         return preparedPersistence;
       }
-      const phase = params.event.data?.phase;
-      if (phase === "end" && terminalEventKey(params.event)) {
-        // Every admitted lifecycle end is prepared by observe(). A missing
-        // promise means its exact owner expired or shutdown retired it.
+      if (
+        isDefinitiveRunLifecycle({ phase: params.event.data?.phase, data: params.event.data }) &&
+        terminalEventKey(params.event)
+      ) {
+        // Every definitive lifecycle is prepared by observe(). A missing promise
+        // means its exact owner expired or shutdown retired it.
         return Promise.reject(createAgentRunStaleLifecycleError());
       }
       const authority = terminalEventAuthority(params.event);

--- a/src/gateway/session-lifecycle-state.persistence.test.ts
+++ b/src/gateway/session-lifecycle-state.persistence.test.ts
@@ -1,8 +1,9 @@
 import path from "node:path";
-import { expect, it, vi } from "vitest";
+import { expect, it, vi, type MockInstance } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { createAgentLifecycleTerminalBackstop } from "../auto-reply/reply/agent-lifecycle-terminal.js";
+import { setRuntimeConfigSnapshot } from "../config/io.js";
 import {
   loadSessionEntry,
   patchSessionEntryCore,
@@ -21,13 +22,19 @@ import {
 } from "../infra/agent-run-registry.js";
 import type { SubsystemLogger } from "../logging/subsystem.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { waitForChatAbortControllerRemoval } from "./chat-abort-lifecycle-internal.js";
+import { registerChatAbortController } from "./chat-abort.js";
 import {
   createChatRunState,
   createSessionEventSubscriberRegistry,
   createSessionMessageSubscriberRegistry,
 } from "./server-chat-state.js";
+import { chatHistoryHandlers } from "./server-methods/chat-history-handler.js";
+import { resolveVisibleActiveSessionRunState } from "./server-methods/session-active-runs.js";
+import type { GatewayRequestContext } from "./server-methods/types.js";
 import { startGatewayEventSubscriptions } from "./server-runtime-subscriptions.js";
-import { persistGatewaySessionLifecycleEvent } from "./session-lifecycle-state.js";
+import * as lifecycleState from "./session-lifecycle-state.js";
 
 const routing = vi.hoisted(() => ({ loadSessionEntry: vi.fn() }));
 vi.mock("./session-utils.js", async (importOriginal) => ({
@@ -66,7 +73,10 @@ it("persists current-run timing after pre-start failure and clears it on the nex
   const unsubscribe = onAgentEvent((event) => {
     if (event.sessionKey === target.sessionKey && event.stream === "lifecycle") {
       persistence = persistence.then(() =>
-        persistGatewaySessionLifecycleEvent({ sessionKey: target.sessionKey, event }),
+        lifecycleState.persistGatewaySessionLifecycleEvent({
+          sessionKey: target.sessionKey,
+          event,
+        }),
       );
     }
   });
@@ -139,105 +149,333 @@ it("persists current-run timing after pre-start failure and clears it on the nex
   }
 });
 
-it("keeps an owner claim active until its queued terminal write commits", async () => {
-  const tempDirs = createTempDirTracker();
-  const target = {
-    storePath: path.join(tempDirs.make("openclaw-owner-terminal-"), "sessions.json"),
-    sessionKey: "agent:main:worker-terminal",
-  };
-  const runId = "worker-terminal-run";
-  const sessionId = "worker-terminal-session";
-  const lifecycleGeneration = getAgentEventLifecycleGeneration();
-  const writerStarted = createDeferred();
-  const releaseWriter = createDeferred();
-  let claimId: string | undefined;
-  let subscriptions: ReturnType<typeof startGatewayEventSubscriptions> | undefined;
-  let heldWriter: Promise<unknown> | undefined;
-  persistenceTestWarnings.mockReset();
-  routing.loadSessionEntry.mockImplementation(() => ({
-    ...target,
-    canonicalKey: target.sessionKey,
-    entry: loadSessionEntry(target),
-  }));
-  try {
-    await replaceSessionEntry(target, {
-      lifecycleRunId: runId,
-      sessionId,
-      startedAt: 1_000,
-      status: "running",
-      updatedAt: 1_000,
-    });
-    heldWriter = patchSessionEntryCore(target, async () => {
-      writerStarted.resolve();
-      await releaseWriter.promise;
-      return null;
-    });
-    await writerStarted.promise;
-    claimId = claimAgentRunContext(
-      runId,
-      { lifecycleGeneration, sessionId, sessionKey: target.sessionKey },
-      { exclusive: true, ownsContext: true, trackOwner: true },
-    );
-    if (!claimId) {
-      throw new Error("expected worker terminal claim");
-    }
-    const terminalClaimId = claimId;
+it.each(["success", "failed-write"])(
+  "settles native child cancellation through %s without retry grace",
+  async (outcome) => {
+    const state = await createOpenClawTestState({ label: "native-cancel-lifecycle" });
+    const cfg = { agents: { entries: { main: {} } } };
+    setRuntimeConfigSnapshot(cfg, cfg);
+    const target = {
+      storePath: path.join(state.sessionsDir(), "sessions.json"),
+      sessionKey: "agent:main:subagent:native-cancel",
+    };
+    const sessionId = "native-cancel-session";
+    const runId = "native-cancel-run";
     const chatRunState = createChatRunState();
-    const markFinal = vi.spyOn(chatRunState.toolEventRecipients, "markFinal");
-    const agentRunSeq = new Map<string, number>();
-    subscriptions = startGatewayEventSubscriptions({
-      log: silentLog,
-      broadcast: vi.fn(),
-      broadcastToConnIds: vi.fn(),
-      nodeSendToSession: vi.fn(),
-      agentRunSeq,
+    const broadcast = vi.fn();
+    const broadcastToConnIds = vi.fn();
+    const context = {
       chatRunState,
-      toolEventRecipients: chatRunState.toolEventRecipients,
-      sessionEventSubscribers: createSessionEventSubscriberRegistry(),
-      sessionMessageSubscribers: createSessionMessageSubscriberRegistry(),
       chatAbortControllers: new Map(),
-      restartRecoveryCandidates: new Map(),
-      terminalSessions: { closeTaskSessions: vi.fn() },
+      getRuntimeConfig: () => cfg,
+      logGateway: silentLog,
+    } as unknown as GatewayRequestContext;
+    const registration = registerChatAbortController({
+      chatAbortControllers: context.chatAbortControllers,
+      runId,
+      sessionId,
+      sessionKey: target.sessionKey,
+      agentId: "main",
+      timeoutMs: 60_000,
+      kind: "agent",
     });
-
-    emitAgentEventForOwner(
-      {
+    registration.markExecutionStarted();
+    const entry = registration.entry;
+    if (!entry) {
+      throw new Error("expected registered child");
+    }
+    const startPersisted = createDeferred();
+    const terminalWrite = createDeferred();
+    let persistenceSpy:
+      | MockInstance<typeof lifecycleState.persistGatewaySessionLifecycleEvent>
+      | undefined;
+    const restartRecoveryCandidates = new Map();
+    const writerStarted = createDeferred();
+    const releaseWriter = createDeferred();
+    let heldWriter: Promise<unknown> | undefined;
+    let subscriptions: ReturnType<typeof startGatewayEventSubscriptions> | undefined;
+    const actual = await vi.importActual<typeof import("./session-utils.js")>("./session-utils.js");
+    routing.loadSessionEntry.mockImplementation(actual.loadSessionEntry);
+    const readHistory = async () => {
+      const respond = vi.fn();
+      await chatHistoryHandlers["chat.history"]!({
+        req: { type: "req", id: "native-cancel-history", method: "chat.history" },
+        params: { sessionKey: target.sessionKey, agentId: "main" },
+        client: null,
+        isWebchatConnect: () => false,
+        respond,
+        context,
+      });
+      expect(respond.mock.calls[0]?.[0]).toBe(true);
+      return respond.mock.calls[0]?.[1];
+    };
+    try {
+      await replaceSessionEntry(target, {
+        sessionId,
+        spawnedBy: "agent:main:main",
+        updatedAt: 1_000,
+      });
+      const sessionEventSubscribers = createSessionEventSubscriberRegistry();
+      sessionEventSubscribers.subscribe("session-observer");
+      subscriptions = startGatewayEventSubscriptions({
+        log: silentLog,
+        broadcast,
+        broadcastToConnIds,
+        nodeSendToSession: vi.fn(),
+        agentRunSeq: new Map(),
+        chatRunState,
+        toolEventRecipients: chatRunState.toolEventRecipients,
+        sessionEventSubscribers,
+        sessionMessageSubscribers: createSessionMessageSubscriberRegistry(),
+        chatAbortControllers: context.chatAbortControllers,
+        restartRecoveryCandidates,
+        terminalSessions: { closeTaskSessions: vi.fn() },
+      });
+      const persistLifecycleEvent = lifecycleState.persistGatewaySessionLifecycleEvent;
+      persistenceSpy = vi
+        .spyOn(lifecycleState, "persistGatewaySessionLifecycleEvent")
+        .mockImplementation((params) => {
+          const persistence = persistLifecycleEvent(params);
+          if (params.event.runId === runId && params.event.data?.phase === "start") {
+            startPersisted.resolve(persistence);
+          }
+          return persistence;
+        });
+      emitAgentEvent({
         runId,
         sessionId,
         sessionKey: target.sessionKey,
         stream: "lifecycle",
-        data: { phase: "end", startedAt: 1_000, endedAt: 2_000 },
-      },
-      claimId,
-    );
-    await vi.waitFor(
-      () =>
-        expect(
-          markFinal.mock.calls.length + persistenceTestWarnings.mock.calls.length,
-        ).toBeGreaterThan(0),
-      { timeout: 10_000 },
-    );
-    expect(persistenceTestWarnings).not.toHaveBeenCalled();
-    expect(markFinal).toHaveBeenCalledWith(runId);
+        data: { phase: "start", startedAt: 1_000 },
+      });
+      // The first start crosses lazy handler loading; await its real commit,
+      // not a polling deadline that also measures cold module initialization.
+      await startPersisted.promise;
+      expect(loadSessionEntry(target)?.status).toBe("running");
+      expect(await readHistory()).toMatchObject({
+        sessionInfo: { status: "running", hasActiveRun: true, activeRunIds: [runId] },
+      });
+      heldWriter = patchSessionEntryCore(target, async () => {
+        writerStarted.resolve();
+        await releaseWriter.promise;
+        return null;
+      });
+      await writerStarted.promise;
+      if (outcome === "failed-write") {
+        persistenceSpy.mockReturnValueOnce(terminalWrite.promise);
+      }
 
-    expect(getAgentRunContextOwnerStatus(runId, terminalClaimId, lifecycleGeneration)).toBe(
-      "active",
-    );
-    releaseWriter.resolve();
-    await heldWriter;
-    await vi.waitFor(() => expect(loadSessionEntry(target)?.status).toBe("done"));
-    await vi.waitFor(() =>
+      emitAgentEvent({
+        runId,
+        sessionId,
+        sessionKey: target.sessionKey,
+        stream: "lifecycle",
+        data: { phase: "error", aborted: true, stopReason: "aborted", endedAt: 2_000 },
+      });
+      registration.cleanup();
+      expect(chatRunState.runs.get(runId)?.abortMarker).toBeUndefined();
+      expect(context.chatAbortControllers.get(runId)).toBe(registration.entry);
+      expect(registration.entry?.projectSessionTerminalPersistence).toBeInstanceOf(Promise);
+      expect(
+        resolveVisibleActiveSessionRunState({
+          context,
+          requestedKey: target.sessionKey,
+          canonicalKey: target.sessionKey,
+          sessionId,
+          agentId: "main",
+        }),
+      ).toEqual({ active: false, runIds: [] });
+      expect(await readHistory()).toMatchObject({
+        sessionInfo: { status: "running", hasActiveRun: true },
+      });
+
+      if (outcome === "failed-write") {
+        const removed = waitForChatAbortControllerRemoval({
+          entries: context.chatAbortControllers,
+          targets: [{ runId, entry }],
+          timeoutMs: 1_000,
+        });
+        terminalWrite.reject(new Error("terminal write failed"));
+        expect(await removed).toBe(false);
+        expect(restartRecoveryCandidates.get(runId)).toMatchObject({
+          sessionId,
+          observedAt: 2_000,
+        });
+        expect(entry.projectSessionTerminalPersisted).toBe(false);
+        expect(loadSessionEntry(target)?.status).toBe("running");
+        return;
+      }
+      releaseWriter.resolve();
+      await heldWriter;
+      await vi.waitFor(() => expect(context.chatAbortControllers.has(runId)).toBe(false));
+      await vi.waitFor(() =>
+        expect(broadcast).toHaveBeenCalledWith(
+          "chat",
+          expect.objectContaining({ runId, state: "aborted", stopReason: "aborted" }),
+          expect.anything(),
+        ),
+      );
+      expect(await readHistory()).toMatchObject({
+        sessionInfo: {
+          status: "killed",
+          hasActiveRun: false,
+          activeRunIds: [],
+          startedAt: 1_000,
+          endedAt: 2_000,
+          runtimeMs: 1_000,
+          abortedLastRun: true,
+        },
+      });
+      expect(broadcastToConnIds).toHaveBeenCalledWith(
+        "sessions.changed",
+        expect.objectContaining({ runId, status: "killed", hasActiveRun: false, runtimeMs: 1_000 }),
+        new Set(["session-observer"]),
+        { dropIfSlow: true },
+      );
+      closeOpenClawAgentDatabasesForTest();
+      expect(loadSessionEntry({ ...target, readConsistency: "latest" })).toMatchObject({
+        status: "killed",
+        lastRunId: runId,
+        endedAt: 2_000,
+        runtimeMs: 1_000,
+      });
+    } finally {
+      terminalWrite.resolve();
+      releaseWriter.resolve();
+      await heldWriter;
+      await subscriptions?.agentUnsub();
+      subscriptions?.heartbeatUnsub();
+      subscriptions?.transcriptUnsub();
+      subscriptions?.lifecycleUnsub();
+      await subscriptions?.taskUnsub();
+      registration.cleanup();
+      persistenceSpy?.mockRestore();
+      routing.loadSessionEntry.mockReset();
+      await state.cleanup();
+    }
+  },
+);
+
+it.each([
+  { label: "end", phase: "end", data: {}, status: "done" },
+  {
+    label: "cancellation",
+    phase: "error",
+    data: { aborted: true, stopReason: "aborted" },
+    status: "killed",
+  },
+  {
+    label: "settled failure",
+    phase: "error",
+    data: { executionSettled: true, error: "Preparation failed" },
+    status: "failed",
+  },
+])(
+  "keeps an owner claim active until its queued $label write commits",
+  async ({ phase, data, status }) => {
+    const tempDirs = createTempDirTracker();
+    const target = {
+      storePath: path.join(tempDirs.make("openclaw-owner-terminal-"), "sessions.json"),
+      sessionKey: "agent:main:worker-terminal",
+    };
+    const runId = "worker-terminal-run";
+    const sessionId = "worker-terminal-session";
+    const lifecycleGeneration = getAgentEventLifecycleGeneration();
+    const writerStarted = createDeferred();
+    const releaseWriter = createDeferred();
+    let claimId: string | undefined;
+    let subscriptions: ReturnType<typeof startGatewayEventSubscriptions> | undefined;
+    let heldWriter: Promise<unknown> | undefined;
+    persistenceTestWarnings.mockReset();
+    routing.loadSessionEntry.mockImplementation(() => ({
+      ...target,
+      canonicalKey: target.sessionKey,
+      entry: loadSessionEntry(target),
+    }));
+    try {
+      await replaceSessionEntry(target, {
+        lifecycleRunId: runId,
+        sessionId,
+        startedAt: 1_000,
+        status: "running",
+        updatedAt: 1_000,
+      });
+      heldWriter = patchSessionEntryCore(target, async () => {
+        writerStarted.resolve();
+        await releaseWriter.promise;
+        return null;
+      });
+      await writerStarted.promise;
+      claimId = claimAgentRunContext(
+        runId,
+        { lifecycleGeneration, sessionId, sessionKey: target.sessionKey },
+        { exclusive: true, ownsContext: true, trackOwner: true },
+      );
+      if (!claimId) {
+        throw new Error("expected worker terminal claim");
+      }
+      const terminalClaimId = claimId;
+      const chatRunState = createChatRunState();
+      const markFinal = vi.spyOn(chatRunState.toolEventRecipients, "markFinal");
+      const agentRunSeq = new Map<string, number>();
+      subscriptions = startGatewayEventSubscriptions({
+        log: silentLog,
+        broadcast: vi.fn(),
+        broadcastToConnIds: vi.fn(),
+        nodeSendToSession: vi.fn(),
+        agentRunSeq,
+        chatRunState,
+        toolEventRecipients: chatRunState.toolEventRecipients,
+        sessionEventSubscribers: createSessionEventSubscriberRegistry(),
+        sessionMessageSubscribers: createSessionMessageSubscriberRegistry(),
+        chatAbortControllers: new Map(),
+        restartRecoveryCandidates: new Map(),
+        terminalSessions: { closeTaskSessions: vi.fn() },
+      });
+
+      emitAgentEventForOwner(
+        {
+          runId,
+          sessionId,
+          sessionKey: target.sessionKey,
+          stream: "lifecycle",
+          data: { phase, ...data, startedAt: 1_000, endedAt: 2_000 },
+        },
+        claimId,
+      );
+      await vi.waitFor(
+        () =>
+          expect(
+            markFinal.mock.calls.length + persistenceTestWarnings.mock.calls.length,
+          ).toBeGreaterThan(0),
+        { timeout: 10_000 },
+      );
+      expect(persistenceTestWarnings).not.toHaveBeenCalled();
+      expect(markFinal).toHaveBeenCalledWith(runId);
+
       expect(getAgentRunContextOwnerStatus(runId, terminalClaimId, lifecycleGeneration)).toBe(
-        "clear-requested",
-      ),
-    );
-  } finally {
-    releaseWriter.resolve();
-    await heldWriter;
-    await subscriptions?.agentUnsub();
-    releaseAgentRunContext(runId, claimId);
-    routing.loadSessionEntry.mockReset();
-    closeOpenClawAgentDatabasesForTest();
-    tempDirs.cleanup();
-  }
-});
+        "active",
+      );
+      releaseWriter.resolve();
+      await heldWriter;
+      await vi.waitFor(() => expect(loadSessionEntry(target)?.status).toBe(status));
+      await vi.waitFor(() =>
+        expect(getAgentRunContextOwnerStatus(runId, terminalClaimId, lifecycleGeneration)).toBe(
+          "clear-requested",
+        ),
+      );
+    } finally {
+      releaseWriter.resolve();
+      await heldWriter;
+      await subscriptions?.agentUnsub();
+      subscriptions?.heartbeatUnsub();
+      subscriptions?.transcriptUnsub();
+      subscriptions?.lifecycleUnsub();
+      await subscriptions?.taskUnsub();
+      releaseAgentRunContext(runId, claimId);
+      routing.loadSessionEntry.mockReset();
+      closeOpenClawAgentDatabasesForTest();
+      tempDirs.cleanup();
+    }
+  },
+);

--- a/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
@@ -9,6 +9,7 @@ import {
   createNewSessionPageE2eSuite,
   createdSessionListResult,
   installMockGateway,
+  waitForGatewayRecoveryScope,
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
@@ -293,8 +294,8 @@ suite.define(() => {
       const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
       const page = await context.newPage();
       if (preference.kind === "cloud") {
-        // Settle recovery scope after discovery starts: both the retired and
-        // replacement catalog request must stay held until restoration resumes.
+        // Browser recovery hydration must not restart the authenticated catalog
+        // request or let a remembered remote destination fall back to Local.
         await page.addInitScript(() => {
           const originalDigest = crypto.subtle.digest.bind(crypto.subtle);
           const delayed = new Promise<void>((resolve) => {
@@ -361,7 +362,8 @@ suite.define(() => {
           await page.evaluate(() => {
             window.dispatchEvent(new Event("test-release-recovery-scope"));
           });
-          await gateway.waitForRequest("environments.list", { after: 1 });
+          await waitForGatewayRecoveryScope(page);
+          expect(await gateway.getRequests("environments.list")).toHaveLength(1);
         }
         await page.locator(".new-session-page__message").fill("keep my chosen remote destination");
         const start = page.getByRole("button", { name: "Start session" });

--- a/ui/src/e2e/new-session-page.projects-places.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.projects-places.e2e.test.ts
@@ -10,6 +10,7 @@ import {
   installMockGateway,
   pollLocatorText,
   replaceGatewayClient,
+  waitForGatewayRecoveryScope,
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
@@ -203,7 +204,8 @@ suite.define(() => {
           await expect.poll(() => tooltipTitleText(local)).toBe("Gateway · QA-Gateway");
           const catalogRequests = (await gateway.getRequests("environments.list")).length;
           await page.evaluate(() => window.dispatchEvent(new Event("test-release-recovery-scope")));
-          await gateway.waitForRequest("environments.list", { after: catalogRequests });
+          await waitForGatewayRecoveryScope(page);
+          expect(await gateway.getRequests("environments.list")).toHaveLength(catalogRequests);
           await page.keyboard.press("Escape");
         }
         await page.locator("#new-session-project-trigger").click();

--- a/ui/src/e2e/new-session-page.test-support.ts
+++ b/ui/src/e2e/new-session-page.test-support.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { errors, type Locator, type Page } from "playwright";
 import { expect } from "vitest";
+import type { ApplicationContext } from "../app/context.ts";
 import {
   controlUiSessionPath,
   controlUiSessionUrl,
@@ -218,6 +219,15 @@ export async function waitForCommittedNewSessionDraft(
     params.get("group")?.trim() ?? "",
   ]);
   await waitForCommittedComposerDraft(page, scopeKey, expectedText, expectedAttachments);
+}
+
+export async function waitForGatewayRecoveryScope(page: Page, ready = true) {
+  await page.waitForFunction((expected) => {
+    const app = document.querySelector("openclaw-app") as HTMLElement & {
+      runtime?: { context: ApplicationContext };
+    };
+    return app.runtime?.context.gateway.snapshot.client?.recoveryScopeReady === expected;
+  }, ready);
 }
 
 export async function replaceGatewayClient(page: Page) {

--- a/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
@@ -603,9 +603,11 @@ suite.define(() => {
               "The Gateway changed while this session was starting. Check recent sessions before starting this task again.",
           })
           .waitFor();
+        // Restarts keep the same draft owner; changed or missing owners cannot inherit its text.
+        const expectedMessage = change === "process restarts" ? "do not duplicate this task" : "";
         await expect
           .poll(() => page.locator(".new-session-page__message").inputValue())
-          .toBe("do not duplicate this task");
+          .toBe(expectedMessage);
         expect(await page.locator(".new-session-page__starting").isVisible()).toBe(false);
         expect(await page.getByRole("button", { name: "Start session" }).isDisabled()).toBe(true);
         expect(await gateway.getRequests("sessions.create")).toHaveLength(1);

--- a/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
@@ -1,10 +1,11 @@
 import type { BrowserContextOptions, Page } from "playwright";
 import { expect, it } from "vitest";
+import type { ApplicationContext } from "../app/context.ts";
 import {
   waitForControlUiGatewayReady,
   waitForControlUiGatewayReconnecting,
 } from "../test-helpers/control-ui-e2e-readiness.ts";
-import { tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
+import { holdModuleResponse, tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 import {
   SOURCE_REPO,
   TARGET_REPO,
@@ -14,6 +15,7 @@ import {
   installMockGateway,
   pollLocatorText,
   replaceGatewayClient,
+  waitForGatewayRecoveryScope,
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
@@ -419,6 +421,76 @@ suite.define(() => {
     });
   });
 
+  it.each(["before acceptance", "during chat preparation"] as const)(
+    "keeps a local start owned when recovery scope hydrates %s",
+    async (hydration) => {
+      await withNewSessionPage(DESKTOP_CONTEXT, async (page) => {
+        await page.addInitScript(() => {
+          const digest = crypto.subtle.digest.bind(crypto.subtle);
+          const ready = new Promise<void>((resolve) => {
+            window.addEventListener("test-release-recovery-scope", () => resolve(), { once: true });
+          });
+          crypto.subtle.digest = async (algorithm, data) => {
+            if (new TextDecoder().decode(data) === "e2e-device-token") {
+              await ready;
+            }
+            return digest(algorithm, data);
+          };
+        });
+        const chatModule = await holdModuleResponse(page, /\/assets\/chat-page-[^/]+\.js/);
+        const sessionKey = "agent:main:late-recovery-scope";
+        const gateway = await installMockGateway(page, {
+          deferredMethods: ["sessions.create"],
+          methodResponses: {
+            "sessions.create": { key: sessionKey, runStarted: true, runId: "late-scope-run" },
+          },
+        });
+        try {
+          await page.goto(`${suite.server.baseUrl}new`);
+          const message = page.locator(".new-session-page__message");
+          const start = page.locator("button.new-session-page__start-submit");
+          await message.fill("keep this admitted task");
+          await waitForGatewayRecoveryScope(page, false);
+          await start.click();
+          await gateway.waitForRequest("sessions.create");
+          if (hydration === "during chat preparation") {
+            await gateway.resolveDeferred("sessions.create");
+            // Navigation selects the accepted session before awaiting route preparation.
+            await expect
+              .poll(() =>
+                page.locator("openclaw-app").evaluate((element) => {
+                  const app = element as HTMLElement & {
+                    runtime: { context: ApplicationContext };
+                  };
+                  return app.runtime.context.gateway.snapshot.sessionKey;
+                }),
+              )
+              .toBe(sessionKey);
+            await chatModule.request;
+          }
+
+          await page.evaluate(() => window.dispatchEvent(new Event("test-release-recovery-scope")));
+          await waitForGatewayRecoveryScope(page);
+          await page.locator("openclaw-new-session-page").evaluate(async (element) => {
+            await (element as HTMLElement & { updateComplete: Promise<unknown> }).updateComplete;
+          });
+          expect(await page.locator(".new-session-page__error").allTextContents()).toEqual([]);
+          await expectPendingNewSession(page, "keep this admitted task");
+          expect(await gateway.getSocketCount()).toBe(1);
+          expect(await gateway.getRequests("sessions.create")).toHaveLength(1);
+
+          if (hydration === "before acceptance") {
+            await gateway.resolveDeferred("sessions.create");
+          }
+          chatModule.release();
+          await page.waitForURL((url) => url.pathname === controlUiSessionPath(sessionKey));
+        } finally {
+          chatModule.release();
+        }
+      });
+    },
+  );
+
   for (const reconnectKind of ["same-client reconnect", "client replacement"] as const) {
     it(`automatically resumes an idempotent session creation after ${reconnectKind}`, async () => {
       await withNewSessionPage(DESKTOP_CONTEXT, async (page) => {
@@ -479,44 +551,68 @@ suite.define(() => {
     });
   }
 
-  it("keeps an interrupted creation fail-closed after the Gateway process restarts", async () => {
-    await withNewSessionPage(DESKTOP_CONTEXT, async (page) => {
-      const gateway = await installMockGateway(page, {
-        methodResponses: {
-          "agents.list": mainAgentList(),
-          "worktrees.branches": branchList(),
-        },
+  it.each(["process restarts", "recovery owner changes", "recovery owner disappears"] as const)(
+    "keeps an interrupted creation fail-closed after the Gateway %s",
+    async (change) => {
+      await withNewSessionPage(DESKTOP_CONTEXT, async (page) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "agents.list": mainAgentList(),
+            "worktrees.branches": branchList(),
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}new`);
+        await page.getByRole("heading", { name: "Main" }).waitFor();
+        await waitForGatewayRecoveryScope(page);
+        await page.locator(".new-session-page__message").fill("do not duplicate this task");
+        await gateway.deferNext("sessions.create");
+        await page.getByRole("button", { name: "Start session" }).click();
+        await gateway.waitForRequest("sessions.create");
+        await expectPendingNewSession(page, "do not duplicate this task");
+
+        if (change === "process restarts") {
+          await gateway.setGatewayBootId("different-gateway-process");
+        } else {
+          const hello = await page.evaluate(() => {
+            const app = document.querySelector("openclaw-app") as HTMLElement & {
+              runtime: { context: ApplicationContext };
+            };
+            return app.runtime.context.gateway.snapshot.hello;
+          });
+          await gateway.setMethodResponse("connect", {
+            ...hello,
+            auth: {
+              role: hello?.auth?.role,
+              scopes: hello?.auth?.scopes,
+              ...(change === "recovery owner changes"
+                ? { recoveryScope: "different-recovery-owner" }
+                : {}),
+            },
+          });
+        }
+        await gateway.setOnline(false);
+        await waitForControlUiGatewayReconnecting(page);
+        await gateway.setOnline(true);
+        await waitForControlUiGatewayReady(page);
+        await waitForGatewayRecoveryScope(page);
+
+        await page
+          .getByRole("alert")
+          .filter({
+            hasText:
+              "The Gateway changed while this session was starting. Check recent sessions before starting this task again.",
+          })
+          .waitFor();
+        await expect
+          .poll(() => page.locator(".new-session-page__message").inputValue())
+          .toBe("do not duplicate this task");
+        expect(await page.locator(".new-session-page__starting").isVisible()).toBe(false);
+        expect(await page.getByRole("button", { name: "Start session" }).isDisabled()).toBe(true);
+        expect(await gateway.getRequests("sessions.create")).toHaveLength(1);
+        expect(new URL(page.url()).pathname).toBe("/new");
       });
-      await page.goto(`${suite.server.baseUrl}new`);
-      await page.getByRole("heading", { name: "Main" }).waitFor();
-      await page.locator(".new-session-page__message").fill("do not duplicate this task");
-      await gateway.deferNext("sessions.create");
-      await page.getByRole("button", { name: "Start session" }).click();
-      await gateway.waitForRequest("sessions.create");
-      await expectPendingNewSession(page, "do not duplicate this task");
-
-      await gateway.setOnline(false);
-      await waitForControlUiGatewayReconnecting(page);
-      await gateway.setGatewayBootId("different-gateway-process");
-      await gateway.setOnline(true);
-      await waitForControlUiGatewayReady(page);
-
-      await page
-        .getByRole("alert")
-        .filter({
-          hasText:
-            "The Gateway changed while this session was starting. Check recent sessions before starting this task again.",
-        })
-        .waitFor();
-      await expect
-        .poll(() => page.locator(".new-session-page__message").inputValue())
-        .toBe("do not duplicate this task");
-      expect(await page.locator(".new-session-page__starting").isVisible()).toBe(false);
-      expect(await page.getByRole("button", { name: "Start session" }).isDisabled()).toBe(true);
-      expect(await gateway.getRequests("sessions.create")).toHaveLength(1);
-      expect(new URL(page.url()).pathname).toBe("/new");
-    });
-  });
+    },
+  );
 
   it("resets agent-derived workspace state when retargeted to a catalog", async () => {
     await withNewSessionPage(DESKTOP_CONTEXT, async (page) => {

--- a/ui/src/pages/new-session/cloud-profile-discovery.ts
+++ b/ui/src/pages/new-session/cloud-profile-discovery.ts
@@ -4,15 +4,6 @@ import type { DraftCloudProfile, DraftEnvironment } from "./discovery.ts";
 
 export const CLOUD_PROFILE_RETRY_DELAYS_MS = [1_000, 3_000, 10_000, 30_000, 60_000] as const;
 
-export function selectProfiles(
-  profiles: DraftCloudProfile[],
-  client: { recoveryScopeReady?: boolean } | null,
-  recoveryScope: string,
-) {
-  const unsupported = profiles.length > 0 && client?.recoveryScopeReady === true && !recoveryScope;
-  return { profiles: unsupported ? [] : profiles, unsupported };
-}
-
 export function discoverPlaceCatalog(
   client: Pick<GatewayBrowserClient, "request">,
   canWrite: boolean,

--- a/ui/src/pages/new-session/draft-gateway-state.ts
+++ b/ui/src/pages/new-session/draft-gateway-state.ts
@@ -10,11 +10,7 @@ import { t } from "../../i18n/index.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
 import * as catalog from "./catalog-target.ts";
-import {
-  CLOUD_PROFILE_RETRY_DELAYS_MS,
-  discoverPlaceCatalog,
-  selectProfiles,
-} from "./cloud-profile-discovery.ts";
+import { CLOUD_PROFILE_RETRY_DELAYS_MS, discoverPlaceCatalog } from "./cloud-profile-discovery.ts";
 import type { DraftCloudProfile, DraftEnvironment } from "./discovery.ts";
 import { discoverGatewayName } from "./gateway-name-discovery.ts";
 import type { NewSessionRouteData } from "./location.ts";
@@ -29,7 +25,6 @@ import {
   type NewSessionPreference,
 } from "./preferences.ts";
 import {
-  resolveScope,
   resolveSubmissionOutcomeReason,
   type SubmissionOutcomeReason,
 } from "./session-placement-recovery-state.ts";
@@ -234,16 +229,17 @@ export class DraftGatewayState {
     const becameConnected = connected && (identityChanged || !this.gatewayConnectedValue);
     const recoveryScopeBecameReady =
       connected && snapshot.client?.recoveryScopeReady === true && !this.gatewayRecoveryScopeReady;
-    const recoveryScope = resolveScope(
-      { client: snapshot.client, connected },
-      this.gatewayRecoveryScopeValue,
-      firstBind,
-    );
+    // Hello owns authentication; browser recovery migration may finish later.
+    // Delaying this binding revokes live starts and lets reconnects replay under the old scope.
+    const recoveryScope = connected
+      ? (snapshot.hello?.auth?.recoveryScope ?? "")
+      : this.gatewayRecoveryScopeValue;
+    const recoveryScopeChanged = !firstBind && this.gatewayRecoveryScopeValue !== recoveryScope;
     this.gatewaySource = gateway;
     this.gatewayClientValue = snapshot.client;
     this.gatewayUrlValue = gateway.connection.gatewayUrl;
     this.gatewayBootIdValue = bootId;
-    this.gatewayRecoveryScopeValue = recoveryScope.next;
+    this.gatewayRecoveryScopeValue = recoveryScope;
     this.gatewayRecoveryScopeReady = snapshot.client?.recoveryScopeReady === true;
     this.gatewayConnectedValue = connected;
     if (this.read().visibility === "draft" && !this.read().canStartAsDraft) {
@@ -254,10 +250,10 @@ export class DraftGatewayState {
       gatewayBootChanged ||
       identityChanged ||
       connectionChanged ||
-      recoveryScope.changed
+      recoveryScopeChanged
     ) {
-      const ownerChanged = gatewaySourceChanged || gatewayUrlChanged || recoveryScope.changed;
-      const gatewayIdentityChanged = gatewayUrlChanged || recoveryScope.changed;
+      const ownerChanged = gatewaySourceChanged || gatewayUrlChanged || recoveryScopeChanged;
+      const gatewayIdentityChanged = gatewayUrlChanged || recoveryScopeChanged;
       this.invalidateDiscovery(
         ownerChanged,
         resolveSubmissionOutcomeReason({
@@ -269,7 +265,7 @@ export class DraftGatewayState {
     if (
       firstBind ||
       gatewayUrlChanged ||
-      recoveryScope.changed ||
+      recoveryScopeChanged ||
       recoveryScopeBecameReady ||
       becameConnected
     ) {
@@ -463,12 +459,8 @@ export class DraftGatewayState {
   }
 
   private applyCloudProfiles(profiles: DraftCloudProfile[]) {
-    const recovery = selectProfiles(
-      profiles,
-      this.gatewayClientValue,
-      this.gatewayRecoveryScopeValue,
-    );
-    this.cloudProfilesValue = recovery.profiles;
+    const recoveryUnsupported = profiles.length > 0 && !this.gatewayRecoveryScopeValue;
+    this.cloudProfilesValue = recoveryUnsupported ? [] : profiles;
     const snapshot = this.read();
     const pendingPlacement = Boolean(snapshot.pendingPlacement.sessionKey);
     const canWrite = hasOperatorWriteAccess(snapshot.context?.gateway.snapshot.hello?.auth ?? null);
@@ -481,7 +473,7 @@ export class DraftGatewayState {
       !profiles.some((profile) => profile.id === snapshot.cloudProfileId);
     if (selectionUnavailable) {
       this.callbacks.onCloudState(t("newSession.catalogUnavailable"));
-    } else if (recovery.unsupported) {
+    } else if (recoveryUnsupported) {
       this.callbacks.onCloudState(t("newSession.cloudRecoveryUnavailable"));
     } else {
       this.callbacks.onCloudState(null);

--- a/ui/src/pages/new-session/draft-place-browser.test.ts
+++ b/ui/src/pages/new-session/draft-place-browser.test.ts
@@ -20,7 +20,7 @@ function createBrowser(request: (method: string) => Promise<unknown>, data?: New
   vi.spyOn(host, "addController").mockImplementation((controller) => controllers.push(controller));
   const client = { request, recoveryScope: "principal-a", recoveryScopeReady: true };
   const hello = {
-    auth: { role: "operator", scopes: ["operator.read"] },
+    auth: { recoveryScope: client.recoveryScope, role: "operator", scopes: ["operator.read"] },
     features: { methods: ["projects.list"] },
   };
   const context = {

--- a/ui/src/pages/new-session/draft-submission-flow.test-support.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test-support.ts
@@ -40,6 +40,7 @@ export function createDraftFixture(options: FixtureOptions = {}) {
             ? {
                 server: { bootId: "gateway-boot-a" },
                 auth: {
+                  recoveryScope: client.recoveryScope,
                   role: "operator",
                   scopes: options.scopes ?? ["operator.read", "operator.write"],
                 },

--- a/ui/src/pages/new-session/draft-submission-flow.test.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test.ts
@@ -744,6 +744,7 @@ describe("DraftSubmissionFlow", () => {
           sessionKey: "",
           hello: {
             auth: {
+              recoveryScope: client.recoveryScope,
               role: "operator",
               scopes: ["operator.admin", "operator.read", "operator.write"],
             },

--- a/ui/src/pages/new-session/session-placement-recovery-state.ts
+++ b/ui/src/pages/new-session/session-placement-recovery-state.ts
@@ -23,22 +23,6 @@ export function resolveSubmissionOutcomeReason(params: {
     : "placement-interrupted";
 }
 
-export function resolveScope(
-  snapshot: {
-    client: { recoveryScope?: string; recoveryScopeReady?: boolean } | null;
-    connected: boolean;
-  },
-  current: string,
-  firstBind: boolean,
-): { next: string; changed: boolean } {
-  // Retain the verified scope until replacement auth arrives; a different scope invalidates it.
-  const next =
-    snapshot.connected && snapshot.client?.recoveryScopeReady
-      ? (snapshot.client.recoveryScope ?? "")
-      : current;
-  return { next, changed: !firstBind && snapshot.connected && current !== next };
-}
-
 export class PendingSessionPlacementRecoveryState {
   sessionKey = "";
   messageId = "";


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled so maintainers can help update this branch.

</details>

Closes #133743 — definitive native cancellation remaining active during retry grace.
Closes #133785 — an accepted New Session start reporting a false Gateway change.

**Merged through the native workflow on September 2, 2026 at 12:38:32 UTC as [b057266d78d0](https://github.com/openclaw/openclaw/commit/b057266d78d0c6a829029484b0006acc121127f9).** Source review, exact-head CI, real native Stop, and recovery final-effect proof passed. Tested head: `513bbb9f9a36a496cca5ce50d2bee025f7968fa4`; tree: `a155dccfb6e5a89668c60fa873582669d4c26913`; reviewed base: `d413210bc7420923d101ce64211511cdac7b9464`. [Native completion receipt](https://github.com/openclaw/openclaw/pull/133747#issuecomment-5509650097).

## What Problem This Solves

A definitive cancelled or timed-out execution could remain visibly active for the 15-second retry grace when its native terminal arrived as `lifecycle:error`. Conversely, isolated cron could publish an attempt's terminal while fallback or interim-ack retries remained, or fail to identify final preparation failure as settled execution.

Live verification also exposed a New Session ownership defect: Gateway accepted the task and started work, but the form stayed visible with a false Gateway-change warning. This is the canonical integration of Peter Steinberger's [startup repair in #133789](https://github.com/openclaw/openclaw/pull/133789); its original reproduction and proof remain preserved there. Shakker's (@shakkernerd) contribution belongs to the lifecycle repair, and the exact co-author trailer is preserved in the landed squash.

A separate deterministic browser defect discarded successful authorized Fetch receipts after an allowed document renewal, unnecessarily retiring the native attachment. This was found while investigating Chromium CI; the causal explanation for the older CI failure remains unproven.

## Why This Change Was Made

The outer execution owner publishes `data.executionSettled: true` when the logical execution has no remaining attempt. Capture and `finishing` do not publish that fact. Backstop, command, ACP, and raw auto-reply terminals use the same fact; cron defers attempt terminals across retries and captures the execution outcome before awaited bookkeeping. Later delivery or continuation failure cannot rewrite captured execution facts.

Gateway presentation, eager persistence, and prepared-write expiry consume canonical terminal policy. `agent.wait` consumes settlement narrowly while preserving unmarked legacy error/timeout/bare-abort grace and sticky precedence. Exact owner/claim/generation checks still govern writes; history remains active while its terminal write is pending. Delivery, announcement, audit, and accepted-child lifetime retain their own owners. Diagnostic fallback observers cannot replace candidate outcomes or stop a usable fallback; policy-bearing callbacks still propagate failures.

New Session binds request ownership directly to authenticated `hello.auth.recoveryScope`. Browser hashing/migration still gates saved-state restoration, but later hydration is not a new authentication event. Genuine URL/client/source/process/recovery-owner changes remain fenced. Redundant readiness-projection helpers and fallback-based finality inference are removed. The rebase preserves main's immediate submitted-message/“Starting…” display and existing draft custody until acceptance.

Seven exact Fetch configuration/continuation methods are classified as tab-lived. This is not a `Fetch.*` exception: body/stream reads remain document-sensitive; exact pause/lease/session ownership, stage checks, and tab/group/attachment/connection revocation remain enforced. The pure terminal-error helper now imports the same canonical error-name reader directly instead of initializing a logging/config/filesystem re-export.

## User Impact

Definitive outcomes settle without unrelated retry grace, while cron remains active across real retries. New Session reaches its accepted task without mistaking local recovery hydration for a changed owner. Same-owner recovery returns the original session; changed or absent owners cannot replay the pending create. Authorized Fetch receipts survive allowed document renewal without weakening data-read or revocation fences.

No configuration option, SQLite schema or stored representation, worker dialect, dependency override, or protocol-version change. [Agent-loop documentation](https://docs.openclaw.ai/concepts/agent-loop) explains execution versus workflow completion and operational versus durable state. No changelog edit before release.

## Evidence

### Current exact-head real behavior

The ordinary dist-backed Gateway and its same-origin bundled Control UI ran with isolated HOME/state/config, a task-owned loopback port, private Chromium profiles, and the real `openai/gpt-5.6-luna` provider. Actual build: `2026.8.1-513bbb9f9a36-2026-09-02T10-41-38.479Z`. Provider: **blacksmith-testbox**, lease `tbx_01m1gv1hekps0jb1a5b4qksgfe`; [backing run 33620309579](https://github.com/openclaw/openclaw/actions/runs/33620309579). Delegated command exits, not the backing workflow's cleanup conclusion, are the proof result.

**Native Stop: PASS, command exit 0.** The same authenticated UI socket admitted the parent and issued exact native Stop. One child was running and one queued. Both became cancelled, the queued child was never admitted and its history remained empty, the original parent session was preserved, and the parent/children returned to quiescent histories and an idle composer. All six assertions passed. Public terminal history was observed **37.5 ms after Stop acknowledgment**, or **176.2 ms after the observed lifecycle error**. These are single-trial observation intervals, not database-commit, guest-exit, scheduler-release, or exact screen-render latency. The normalized UI record does not expose the raw settlement marker.

https://github.com/user-attachments/assets/f96c9670-dda8-4476-8c90-8f519038729e

| Before Stop | After Stop |
|---|---|
| ![Running and queued children before native Stop](https://github.com/user-attachments/assets/e2f0880f-a5b5-4213-8c62-07e5ff9f560e) | ![Cancelled children and idle original parent after Stop](https://github.com/user-attachments/assets/4e7cfd67-7ed2-4959-b38d-05c64f74182f) |

**Recovery final effects: all three cases PASS, command exit 0.** Each case withheld only an actual successful `sessions.create` response after observing its committed session/user turn, then interrupted the connection. The proxy forwarded browser requests—including any incorrect replay—rather than enforcing the product's decision itself.

| Authenticated recovery case | Browser creates / forwarded creates / real responses | Observed final effect |
|---|---|---|
| Same owner | 2 / 2 / 2 | One replay with identical parameters/idempotency key returned the original session and run; UI selected it. |
| Changed owner, **real device-token rotation** | 1 / 1 / 1 | No replay; old draft cleared, Start disabled, New Session remained visible with the intentional warning. |
| Missing owner, **disclosed transport field omission** | 1 / 1 / 1 | No replay; old draft cleared, Start disabled, no navigation. The real server supplied a scope; the fault removed only the second hello's scope field. |

Every case had zero browser `chat.send` calls and no wire violations. Read-only SQLite checks at final assertion and after cleanup showed exactly one new session, one transcript window, one persisted matching user turn, the original last-run identity, and `done`; public history independently verified the original terminal session/run. This is not a separate admitted-run COUNT. Each case had three transport connections and two successful hellos. Raw authentication/RPC/header frames were intentionally not retained; their live assertions are represented by bounded records, not an independently replayable raw trace.

Same-owner recovery:

https://github.com/user-attachments/assets/f1c2508e-9721-40cf-8285-09f1ce6fb6bb

Real token rotation:

https://github.com/user-attachments/assets/4423aa84-7aa0-40f2-b155-c3d8b16672d2

Missing-scope fault:

https://github.com/user-attachments/assets/b6904b58-431f-4c3f-9773-e4d5ffa01f7d

<details>
<summary>Recovery before/after screenshots</summary>

| Case | Before disconnect | After recovery |
|---|---|---|
| Same | ![Same owner pending create](https://github.com/user-attachments/assets/4e413048-1c1e-4059-ad88-a6b944e43d4c) | ![Original session selected with completed reply](https://github.com/user-attachments/assets/bdc2d212-87e2-42d1-995a-1b2b62113b4e) |
| Changed | ![Pending create before token rotation](https://github.com/user-attachments/assets/9058a899-65ee-4785-ab7c-a1af963a0bcf) | ![Changed owner warning and cleared draft](https://github.com/user-attachments/assets/4306d916-a635-4812-85a0-a5909f709d7d) |
| Missing | ![Pending create before scope omission](https://github.com/user-attachments/assets/4d0dc77e-2fee-47fa-99e3-440efc4be6b6) | ![Missing owner warning and cleared draft](https://github.com/user-attachments/assets/37edbbf9-f4df-492b-972b-d7da89a4e69b) |

</details>

**Inspection and cleanup:** the lead inspected every decoded frame through 44 contact sheets (533 Stop + 333 recovery frames), 16 full-resolution checkpoints, and all eight original PNGs. Captures contain synthetic task data, public model names, and password-masked login. Changed-case frame 94 briefly shows warning plus the old draft; frame 95 and the final frame are cleared. The claim is final clearing/no replay, not instantaneous removal. Recovery reused validated synthetic Stop state, not a pristine install. Both Gateway groups, browsers, clients, and driver groups joined; source remained unchanged; the lease reports **stopped (completed)**. No operator Gateway/state was used. No unexpected console/page errors; optional-icon errors were classified separately.

Source/build proof checked the exact clean commit/tree, review binding, authentic build log and static artifact audit, critical source/runtime/helper hashes, actual hello build ID and `controlUiBuildSource: bundled`, and hashes of two actual served UI chunks. Checks repeated before success and after client cleanup. **This is native source/build/served-identity proof, not a recursive dependency seal.** Verified local return archives: Stop `4157a9f4f3d05714fcf2b6f0d2421b28dbed5336765c4e440fe253ac84382d2c`; recovery `d424294607d9628512a13184993cf0fe47fc2fdfc1ca628edfcd5a1e527d9d36`. All 30 members were checked against their archives; raw records remain unchanged.

### Source, regressions, review, and CI

**1,829 focused tests passed:** 1,041 lifecycle/owner/incoming-main sibling tests in 30 files; 429 UI tests in 39 files, including 38 browser cases; 359 Chrome-extension owner/sibling tests in 10 files. Duplicate E2E footers are not counted twice. Both controlled hydration cases failed against exact pre-fix `d413` owners with the original false warning and passed after restoring the candidate. The live Stop run had recovery ready at Start; it is not a live delayed-hydration reproduction.

The UI changed gate and full local `pnpm build` passed. That local build used the final staged tree before the test-only commit and correctly retains `9906cd1bfa05` / `2026-09-02T10:05:08.242Z` metadata; it was not restamped. The later remote build above is genuinely from `513`. Fresh full-candidate managed **Codex review through P2: scoped-clean, no findings**; raw report SHA-256 `3d457682f3db00f74c359fb258b17e24f85ae4f864f267074c464fd1a96bd6d6`. The reviewer did not run tests or inspect unchanged context; lead/independent source and dependency reading are separate evidence.

[Exact-head CI 33618413062](https://github.com/openclaw/openclaw/actions/runs/33618413062) completed **success**. [Native Chromium job 100210073792](https://github.com/openclaw/openclaw/actions/runs/33618413062/job/100210073792) actually executed and passed browser bootstrap **1/1**, including extension load/reload, injected detach/reconnect, All/Selected tab creation, same-target snapshots, unrelated-page preservation, and cleanup. It tested merge commit `43d32643884cf553c48922ab0d4cf42170f709bf` containing exact PR head `513`; it is not a retained Fetch-continuation-across-document trace.

The evidence map includes outer lifecycle producers, cron/auto-reply/command/ACP siblings, Gateway wait/persistence/cache consumers, CLI supervisor/embedded completion, UI submission/navigation/persistence, and native browser relay/Fetch ownership. The lead directly inspected upstream Codex `v2/turn.rs:32–37`, `v2/notification.rs:62–69`, and `bespoke_event_handling.rs:1394–1419,1538–1559`: retryable errors and item completion are not turn completion. Installed Playwright Fetch types/callers and real relay pause/lease contracts were also inspected. Best fix: record facts at the owning boundary; do not blanket-fast-path consumers, add another exhaustion flag, or exempt every Fetch method.

### Remaining qualifications and review requests

The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/133747#issuecomment-5473204026) reported no introduced correctness finding. Its same/changed/missing recovery requests are addressed by the real final-effect proof above; exact-head hosted CI is green. The rank-up request for an extra Fetch trace has a concrete infeasibility: a separate exact-head attempt failed GitHub source fetch with noninteractive authentication exit 128 **before checkout/install/Chromium**. Its lease was stopped. No trace was produced, no provider/auth workaround was used, and this is not called a Chromium failure. Actual CI provides native compatibility proof; original failed-CI causality and the specific trace remain unproven.

The fresh combined cron/control attempt also failed historical-control source fetch after successfully building `513`; no Gateway started in that attempt. A separately labeled candidate-only legacy UI attempt failed its unchanged recursive seal on intentionally generated dependency links. Complete target coverage exceeds its existing root/file/aggregate caps; no limit was raised, dependency excluded, receipt fabricated, or failure relabeled. The successful ordinary native proof above is a distinct method with explicitly narrower integrity coverage.

There is **no successful fresh `513` cron/control comparison**. Earlier exact-`93` real Gateway/SQLite cron evidence observed two sequential synthetic CLI failures and terminal projections at 107/108 ms, but that overall run failed before UI preparation. The [older `da9021` combined proof](https://github.com/openclaw/openclaw/pull/133747#issuecomment-5503871438) remains historical, not current-head media. Current cron owner-boundary tests and exact-head CI are separately green. Historical cold-state timeout attribution, broader ACP integration, and the final repeated Swarm stress campaign remain separate work—not claimed complete here.

### Size

| Category | Added | Removed | Net |
|---|---:|---:|---:|
| Production, 18 files | 218 | 178 | **+40** |
| Tests/support, 45 files | 1707 | 217 | **+1490** |
| Docs, 1 file | 22 | 2 | **+20** |
| Total, 64 files | 1947 | 397 | **+1550** |

No generated, lockfile, config, or tooling delta. The production increase buys the captured logical-execution state/fact and seven exact Fetch lifetime classifications, offset by removal of redundant UI scope projection and fallback-finality inference. The pure import cleanup is net zero. Ignored proof artifacts are not product LOC.
