### PR TITLE
test(agents): remove duplicate apply-patch byte-preservation cases

### DIFF
--- a/src/agents/apply-patch.test.ts
+++ b/src/agents/apply-patch.test.ts
@@ -427,60 +427,6 @@ describe("applyPatch", () => {
     expect(toolResult.terminate).toBe(true);
   });
 
-  it("preserves line endings and EOF state for no-op update hunks", async () => {
-    const patch = `*** Begin Patch
-*** Update File: source.txt
-@@
- foo
--bar
-+bar
-*** End Patch`;
-    for (const initial of ["foo\r\nbar\r\n", "foo\nbar"]) {
-      const memory = createMemoryPatchSandbox({ "source.txt": initial });
-
-      const result = await applyPatch(patch, memory.options);
-
-      expect(result.noOp).toBe(true);
-      expect(memory.files.get("/sandbox/source.txt")).toBe(initial);
-      expect(memory.writeFile.mock.calls).toHaveLength(0);
-    }
-  });
-
-  it("applies a real deletion of the sole blank line", async () => {
-    const memory = createMemoryPatchSandbox({ "source.txt": "\n" });
-    const patch = `*** Begin Patch
-*** Update File: source.txt
-@@
--
-*** End Patch`;
-
-    const result = await applyPatch(patch, memory.options);
-
-    expect(result.noOp).toBeUndefined();
-    expect(memory.files.get("/sandbox/source.txt")).toBe("");
-    expect(memory.writeFile.mock.calls).toHaveLength(1);
-  });
-
-  it("preserves formatting for same-path move no-op hunks", async () => {
-    const patch = `*** Begin Patch
-*** Update File: source.txt
-*** Move to: ./source.txt
-@@
- foo
--bar
-+bar
-*** End Patch`;
-    for (const initial of ["foo\r\nbar\r\n", "foo\nbar"]) {
-      const memory = createMemoryPatchSandbox({ "source.txt": initial });
-
-      const result = await applyPatch(patch, memory.options);
-
-      expect(result.noOp).toBe(true);
-      expect(memory.files.get("/sandbox/source.txt")).toBe(initial);
-      expect(memory.writeFile.mock.calls).toHaveLength(0);
-    }
-  });
-
   it("normalizes supported punctuation while matching update hunks", async () => {
     const cases = [
       ["a\u2010\u2011\u2012\u2013\u2014\u2015\u2212b", "a-------b"],


### PR DESCRIPTION
## What Problem This Solves

Three byte-preservation tests were copied into the dedicated context-byte suite while their original callbacks remained in the general apply-patch suite. Both copies call the same owner through the same isolated sandbox helper.

## Why This Change Was Made

Delete the redundant copies from the general suite. The complete callbacks remain in `apply-patch-context-bytes.test.ts`: unchanged line endings/EOF, real deletion of a sole blank line, and same-path move no-op behavior. Keep the general suite's terminal tool result and all encoding, permission, path containment, atomic-create, and race tests.

## User Impact

No runtime behavior changes. One owner suite retains the byte-preservation contracts with three fewer duplicate executions.

## Evidence

- Byte-for-byte callback comparisons confirmed identical retained fixtures and assertions, including exact bytes, no-op results, and write counts.
- Before: the apply-patch, context-byte, and update suites passed 81 cases.
- After: `node scripts/run-vitest.mjs src/agents/apply-patch.test.ts src/agents/apply-patch-context-bytes.test.ts src/agents/apply-patch-update.test.ts` passed 78 cases.
- Inspected the complete OpenClaw owner and test helpers and Codex apply-patch `file_update.rs:25,64` and `text_file.rs:35,111` at `3b67b03a3f6b0590589fb85d2be26d0eb58ac159`. This is owner/contract inspection, not a claim of upstream parity; OpenClaw's no-op/EOF behavior stays unchanged.
- Raw #132407 commit diff confirms the copies were added to the context-byte suite while the originals remained.
- Structured Codex autoreview returned scoped-clean. Production +0/-0; tests +0/-54.
- Test-only change; no changelog or live-provider proof is required.
- Local changed gate passed, including core test types, changed-file lint, guards and dead-export checks.
