### PR TITLE
fix(telegram): drop grammy rich-message members the pinned types no longer declare

### DIFF
--- a/extensions/telegram/src/allowed-updates.ts
+++ b/extensions/telegram/src/allowed-updates.ts
@@ -7,11 +7,9 @@ const DEFAULT_TELEGRAM_UPDATE_TYPES: ReadonlyArray<TelegramUpdateType> =
   API_CONSTANTS.DEFAULT_UPDATE_TYPES;
 
 export function resolveTelegramAllowedUpdates(): ReadonlyArray<TelegramUpdateType> {
-  // OpenClaw does not request stoppable drafts. Subscribing without a handler
-  // would acknowledge the user's stop action without a visible outcome.
-  const updates = DEFAULT_TELEGRAM_UPDATE_TYPES.filter(
-    (type) => type !== "stopped_message_generation",
-  );
+  // OpenClaw does not request stoppable drafts, and grammy's default update
+  // list no longer offers one to exclude; only the additions below matter.
+  const updates: TelegramUpdateType[] = [...DEFAULT_TELEGRAM_UPDATE_TYPES];
   if (!updates.includes("message_reaction")) {
     updates.push("message_reaction");
   }

--- a/extensions/telegram/src/bot/body-helpers.ts
+++ b/extensions/telegram/src/bot/body-helpers.ts
@@ -5,7 +5,6 @@ import type {
   MessageOrigin,
   RichBlock,
   RichBlockCaption,
-  RichMessageButton,
   RichText,
   User,
 } from "grammy/types";
@@ -121,10 +120,6 @@ function joinRichText(parts: string[], separator: string): string {
   return parts.map(compactRichText).filter(Boolean).join(separator);
 }
 
-function renderRichMessageButton(button: RichMessageButton): string {
-  return renderRichInlineText(button.text);
-}
-
 function renderRichInlineText(value: RichText | undefined): string {
   if (value === undefined) {
     return "";
@@ -138,8 +133,6 @@ function renderRichInlineText(value: RichText | undefined): string {
   switch (value.type) {
     case "anchor":
       return "";
-    case "button":
-      return renderRichMessageButton(value.button);
     case "custom_emoji":
       return value.alternative_text;
     case "mathematical_expression":
@@ -166,7 +159,6 @@ function renderRichBlock(block: RichBlock): string {
     case "footer":
     case "thinking":
       return renderRichInlineText(block.text);
-    case "expandable_blockquote":
     case "pullquote":
       return joinRichText(
         [renderRichInlineText(block.text), renderRichInlineText(block.credit ?? "")],
@@ -202,14 +194,11 @@ function renderRichBlock(block: RichBlock): string {
       );
     case "animation":
     case "audio":
-    case "document":
     case "map":
     case "photo":
     case "video":
     case "voice_note":
       return renderRichCaption(block.caption);
-    case "buttons":
-      return joinRichText(block.buttons.map(renderRichMessageButton), "\n");
     case "anchor":
     case "divider":
       return "";


### PR DESCRIPTION
## What Problem This Solves

`pnpm tsgo:extensions` is red on current `main` (verified at `6107afa7`): the grammy 1.46.0 upgrade removed the rich-message members the Telegram plugin still references, so the pinned unions no longer compile — `RichMessageButton` is gone as an export, the `buttons`/`document`/`expandable_blockquote`/`button` block and inline cases no longer exist in the `RichBlock`/`RichText` unions, and `API_CONSTANTS.DEFAULT_UPDATE_TYPES` no longer contains `stopped_message_generation`. The retired switch cases narrow the pinned union to `never`, producing four TS errors across two files.

The extensions typecheck lane runs on extension-touching PRs rather than plain `main` pushes, so the upgrade landed green and the breakage is invisible until the next extension PR touches the lane.

Fixes #133749

## Why This Change Was Made

The broken references are dead code, not missing behavior: the removed cases were unreachable under the pinned grammy types (the switch already exhausted the real union before reaching them), and the default update list already satisfies by construction the `stopped_message_generation` exclusion the filter tried to apply. Deleting them restores the owning contract — the Telegram plugin compiling against the grammy types it pins — instead of widening a type or suppressing a checker.

## User Impact

None at runtime. No observable Telegram behavior changes: the unreachable cases never executed, and the subscribed update types are byte-identical (`expected` list in `extensions/telegram/src/allowed-updates.test.ts` is unchanged and still passes). The only change is that `pnpm tsgo:extensions` is green again for every extension author and the next extension PR.

## Evidence

- **Before (main, `6107afa7`)**: `pnpm tsgo:extensions` fails with 4 errors —
  - `extensions/telegram/src/allowed-updates.ts(13,15)`: TS2367 `"stopped_message_generation"` has no overlap with the pinned update-type union
  - `extensions/telegram/src/bot/body-helpers.ts(8,3)`: TS2305 `grammy/types` has no exported member `RichMessageButton`
  - `extensions/telegram/src/bot/body-helpers.ts(141,10)`: TS2678 `"button"` not comparable to the pinned `RichText` union
  - `extensions/telegram/src/bot/body-helpers.ts(142,44)`: TS2339 `value.button` on `never`
  - (removing the first dead `case` in sequence then exposed `"buttons"`, `"document"`, and `"expandable_blockquote"` as further TS2678s; all removed here)
- **After (this branch)**: `pnpm tsgo:extensions` passes clean.
- Dependency contract check: `node_modules/@grammyjs/types/rich.d.ts` — the `RichBlock` union lists exactly `paragraph | heading | pre | footer | divider | mathematical_expression | anchor | list | blockquote | pullquote | collage | slideshow | table | details | map | animation | audio | photo | video | voice_note | thinking` (no `buttons`/`document`), the inline `RichText` union has no `button` member, and no grammy package exports `RichMessageButton` any more; `node_modules/grammy/out/bot.js` `DEFAULT_UPDATE_TYPES` has no `stopped_message_generation`.
- Tests: `node scripts/run-vitest.mjs extensions/telegram/src/allowed-updates.test.ts extensions/telegram/src/bot/body-helpers.inbound.test.ts` — pass (2 shards), expectations untouched.
- Diff: 2 files, +3/−16 (net-negative, production-only dead code removal).
