### PR TITLE
fix(infra): default isWindowsPlatform to process.platform

### DIFF
--- a/src/infra/windows-shell-command.test.ts
+++ b/src/infra/windows-shell-command.test.ts
@@ -1,0 +1,61 @@
+// Tests for Windows shell command analysis and platform detection.
+import { describe, expect, it } from "vitest";
+import { analyzeWindowsShellCommand, isWindowsPlatform } from "./windows-shell-command.js";
+
+describe("isWindowsPlatform", () => {
+  it("defaults to process.platform when called without arguments", () => {
+    expect(isWindowsPlatform()).toBe(process.platform.startsWith("win"));
+  });
+
+  it("defaults to process.platform when passed undefined", () => {
+    expect(isWindowsPlatform(undefined)).toBe(process.platform.startsWith("win"));
+  });
+
+  it("defaults to process.platform when passed null", () => {
+    expect(isWindowsPlatform(null)).toBe(process.platform.startsWith("win"));
+  });
+
+  it("respects explicit platform overrides", () => {
+    expect(isWindowsPlatform("win32")).toBe(true);
+    expect(isWindowsPlatform("linux")).toBe(false);
+    expect(isWindowsPlatform("darwin")).toBe(false);
+    expect(isWindowsPlatform("freebsd")).toBe(false);
+  });
+
+  it("returns true on Windows hosts when no override is provided", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    try {
+      expect(isWindowsPlatform()).toBe(true);
+      expect(isWindowsPlatform(undefined)).toBe(true);
+      expect(isWindowsPlatform(null)).toBe(true);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
+  });
+
+  it("returns false on non-Windows hosts when no override is provided", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+    try {
+      expect(isWindowsPlatform()).toBe(false);
+      expect(isWindowsPlatform(undefined)).toBe(false);
+      expect(isWindowsPlatform(null)).toBe(false);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
+  });
+});
+
+describe("analyzeWindowsShellCommand", () => {
+  it("defaults to process.platform when platform is omitted", () => {
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, "platform", { value: "win32", configurable: true });
+    try {
+      const result = analyzeWindowsShellCommand({ command: "Get-Process" });
+      expect(result.ok).toBe(true);
+    } finally {
+      Object.defineProperty(process, "platform", { value: originalPlatform, configurable: true });
+    }
+  });
+});

--- a/src/infra/windows-shell-command.ts
+++ b/src/infra/windows-shell-command.ts
@@ -190,7 +190,7 @@ export function analyzeWindowsShellCommand(params: {
 }
 
 export function isWindowsPlatform(platform?: string | null): boolean {
-  const normalized = normalizeLowercaseStringOrEmpty(platform);
+  const normalized = normalizeLowercaseStringOrEmpty(platform ?? process.platform);
   return normalized.startsWith("win");
 }
 


### PR DESCRIPTION
Closes #133311

## What Problem This Solves

Fixes an issue where Windows users would see shell allowlist evaluation fail or misroute into POSIX planners when `platform` was not explicitly passed to `evaluateShellAllowlist()` or `evaluateShellAllowlistWithAuthorization()`. On Windows hosts, `isWindowsPlatform()` returned `false` even though the host was Windows, because the function did not fall back to `process.platform`.

## Why This Change Was Made

`isWindowsPlatform(platform?: string | null)` in `src/infra/windows-shell-command.ts` normalized the provided `platform` argument without a default. When called with `undefined` or `null`, `normalizeLowercaseStringOrEmpty()` returned `""`, causing `"".startsWith("win")` to be `false` on every host. The fix changes the normalization to use `platform ?? process.platform`, so the helper defaults to the current host platform when no override is supplied. This matches the function's name and the behavior callers reasonably expect.

## User Impact

- Windows users and plugin authors no longer need to remember to pass `platform: process.platform` to get correct Windows detection.
- Shell authorization on Windows now correctly routes through the Windows analysis path when `platform` is omitted.
- No impact on Linux or macOS hosts: `isWindowsPlatform()` still returns `false` there by default.

## Evidence

### Before fix

On a host where `process.platform` is mocked to `"win32"`:

```text
process.platform: win32
isWindowsPlatform(): false
isWindowsPlatform(undefined): false
isWindowsPlatform(null): false
```

This caused `evaluateShellAllowlist({ command: "dir", ... })` without an explicit `platform` to return `analysisFailure()` on Windows.

### After fix

On the same mocked Windows host:

```text
process.platform: win32
isWindowsPlatform(): true
isWindowsPlatform(undefined): true
isWindowsPlatform(null): true
```

### Test verification

- Added `src/infra/windows-shell-command.test.ts` with 7 focused tests covering default behavior, `undefined`/`null` fallback, explicit overrides, and host-platform mocking for Windows and non-Windows hosts.
- Ran `pnpm test src/infra/windows-shell-command.test.ts --run`: 7/7 passed.
- Ran related infra regression tests (`exec-safe-builtins`, `exec-authorization-allowlist`, `exec-approvals-safe-bins`, `exec-approvals-allow-always`): 220/220 passed.
- `node scripts/run-oxlint.mjs` on changed files: 0 warnings, 0 errors.
- `pnpm format:check` on changed files: passed.
- `pnpm tsgo:core`: passed.

### CI proof: real Windows authorization-path before/after

Proved this change at exact heads on a real Windows runner (`windows-latest`) by exercising `evaluateShellAllowlistWithAuthorization({ command: "dir", allowlist: [], safeBins: new Set() })` without passing `platform`:

- Before (main): `346fae9a762d8a54ed2d0a49f1c7fdf076ca2710`
- After (PR head): `791a2a90abf2bd2f5cf77af12fed413ba7e744ba`
- Proof run: https://github.com/xialonglee/openclaw/actions/runs/33359435514
- Artifact download: https://github.com/xialonglee/openclaw/actions/runs/33359435514/artifacts/9746241897

Key markers from the artifact logs:

```text
--- BEFORE ---
[proof] platform=win32
[proof] isWindowsPlatform()=false
[proof] hasAuthorizationPlan=true
[proof] scene=windows-omitted-platform before=expected-bug-reproduced

--- AFTER ---
[proof] platform=win32
[proof] isWindowsPlatform()=true
[proof] hasAuthorizationPlan=false
[proof] scene=windows-omitted-platform after=expected-fix-verified
```

Before the fix, omitting `platform` on Windows caused the shell authorization path to fall through to POSIX planning (`hasAuthorizationPlan=true`). After the fix, the same call correctly enters Windows analysis (`isWindowsPlatform()=true`, `hasAuthorizationPlan=false`).

