### PR TITLE
fix: reduce memory spikes when preparing long session histories

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -223,7 +223,7 @@ extensions/codex/src/app-server/sandbox-exec-server/processes.ts	1
 extensions/codex/src/app-server/sandbox-guard.ts	2
 extensions/codex/src/app-server/scheduled-app-authority.ts	5
 extensions/codex/src/app-server/session-binding.ts	4
-extensions/codex/src/app-server/session-history.ts	6
+extensions/codex/src/app-server/session-history.ts	4
 extensions/codex/src/app-server/settled-turn-context.ts	3
 extensions/codex/src/app-server/shared-client.ts	4
 extensions/codex/src/app-server/side-question.ts	8
@@ -1967,7 +1967,7 @@ src/agents/session-placement-admission.ts	1
 src/agents/session-raw-append-message.ts	2
 src/agents/session-suspension.ts	1
 src/agents/session-tool-result-guard.ts	24
-src/agents/session-transcript-repair.ts	15
+src/agents/session-transcript-repair.ts	14
 src/agents/sessions/agent-session-base.ts	3
 src/agents/sessions/agent-session-extensions.ts	1
 src/agents/sessions/agent-session-inspection.ts	2
@@ -2700,7 +2700,6 @@ src/config/sessions/session-sqlite-target.ts	3
 src/config/sessions/session-store-config.ts	2
 src/config/sessions/session-suggestion-store.ts	4
 src/config/sessions/session-transcript-projection-rebuild.ts	6
-src/config/sessions/session-transcript-read-fence.ts	1
 src/config/sessions/session-transcript-reconcile.worker.ts	1
 src/config/sessions/session-transcript-search.ts	1
 src/config/sessions/skill-prompt-blobs.ts	5

--- a/docs/plugins/hooks.md
+++ b/docs/plugins/hooks.md
@@ -781,6 +781,8 @@ restrictions intersect. A nested ordinary `before_prompt_build` dispatch on
 the same runner is skipped while its outer dispatch is active; other hook
 families and independent turns remain available.
 
+Message-consuming prompt hooks receive a detached model-context snapshot. Mutating nested messages does not change the caller's history, including when a handler retains its input after returning. Registrations within one dispatch share that snapshot in priority order; prepare, ordinary prompt-build, authorized enrichment, and subsequent prompt rebuilds receive separate snapshots. Storage-only native prompt text and tool-result details are excluded from these snapshots.
+
 ### Authorized prompt enrichment
 
 Register `before_prompt_build` with `requiresToolAuthority: true` when a plugin

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -186,6 +186,8 @@ Notable entry types:
 
 History readers keep the latest reset window across later compactions: explicitly retained reset messages and messages after that reset remain visible, but older messages and compaction summaries do not reappear. Model context follows the latest reset or compaction instead, so compaction can summarize the current conversation without reopening its earlier history.
 
+Model-only callers can use `SessionManager.openModelContext()` to create a detached, non-persisting view. The reader selects payloads in SQLite and retains lightweight navigation outside the model window, without introducing a history size cutoff. Storage-only native prompt text and tool-result details stay out of that view; mirror identity, sender and media facts, tool content, and valid provider replay state remain available. Native fork verification, replay, exports, and doctor operations continue to use full-fidelity evidence readers.
+
 OpenClaw intentionally does not "fix up" transcripts; the Gateway uses `SessionManager` to read/write them.
 
 ## Context windows vs tracked tokens

--- a/docs/tools/self-learning.md
+++ b/docs/tools/self-learning.md
@@ -212,8 +212,10 @@ Experience review adds one bounded model run on the configured provider only
 after a substantial turn, not after every message. The review can make more
 than one provider request while it inspects or drafts its single proposal.
 
-The review forks the foreground transcript in memory and appends one small user
-message. It uses a private detached session identity while preserving the
+The review creates a detached view of the foreground model context and appends
+one small user message. Storage-only native prompt payloads stay in the original
+transcript, whose stored bytes the review does not change. It uses a private
+detached session identity while preserving the
 foreground provider, model, auth profile, bootstrap context, skills prompt, tool
 schemas, and prompt-cache affinity. The provider can reuse the finished turn's
 cached request prefix without making the review part of the foreground session.

--- a/extensions/codex/src/app-server/attempt-context.ts
+++ b/extensions/codex/src/app-server/attempt-context.ts
@@ -90,7 +90,11 @@ export async function readMirroredSessionHistoryMessages(params: {
   admission?: TranscriptTurnAdmission;
 }): Promise<AgentMessage[] | undefined> {
   const { admission, ...target } = params;
-  const messages = await readCodexMirroredSessionHistoryMessages(target, admission);
+  const messages = await readCodexMirroredSessionHistoryMessages(
+    target,
+    admission,
+    "model-context",
+  );
   if (!messages) {
     embeddedAgentLog.warn("failed to read mirrored session history for codex harness hooks", {
       sessionFile: params.sessionFile,

--- a/extensions/codex/src/app-server/run-attempt-prompt.ts
+++ b/extensions/codex/src/app-server/run-attempt-prompt.ts
@@ -198,7 +198,7 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
           return promptState.developerInstructions;
         },
       },
-      messages: structuredClone(historyState.messages),
+      messages: historyState.messages,
       ctx: hookContext,
       bootstrapContextRunKind: params.bootstrapContextRunKind,
       toolAuthority: {

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -3044,6 +3044,101 @@ describe("runCodexAppServerAttempt", () => {
     expect(JSON.stringify(result.messagesSnapshot)).not.toContain("tool_search");
     expect(JSON.stringify(result.messagesSnapshot)).not.toContain("function_call_output");
   });
+  it.each(["none", "heartbeat", "ordinary", "authorized"])(
+    "keeps private native history out of prompt acquisition and clones (%s)",
+    async (kind) => {
+      const marker = "synthetic-native-payload:";
+      const privateText = marker + "x".repeat(1024 * 1024);
+      const hook = vi.fn(() => ({ prependContext: "hook context" }));
+      initializeGlobalHookRunner(
+        createMockPluginRegistry(
+          kind === "none"
+            ? []
+            : [
+                {
+                  hookName:
+                    kind === "heartbeat" ? "heartbeat_prompt_contribution" : "before_prompt_build",
+                  ...(kind === "authorized" ? { requiresToolAuthority: true as const } : {}),
+                  handler: hook,
+                },
+              ],
+        ),
+      );
+      const { sessionFile, workspaceDir } = createRunPaths();
+      const params = createParams(sessionFile, workspaceDir);
+      await attachSqliteSessionTarget(params, path.join(tempDir, "memory.sqlite"), "session-1");
+      await appendSqliteHistoryMessage(params, {
+        ...userMessage("previous visible request", 1),
+        __openclaw: { upstreamUserText: privateText },
+      } as ReturnType<typeof userMessage>);
+      const originalParse = JSON.parse;
+      let privateParseBytes = 0;
+      const parseSpy = vi.spyOn(JSON, "parse").mockImplementation((text, reviver) => {
+        if (typeof text === "string" && text.includes(marker)) {
+          privateParseBytes += text.length;
+        }
+        return originalParse(text, reviver);
+      });
+      const originalClone = structuredClone;
+      let historyClones = 0;
+      let privateCloneBytes = 0;
+      const cloneSpy = vi
+        .spyOn(globalThis, "structuredClone")
+        .mockImplementation((value, options) => {
+          const seen = new WeakSet<object>();
+          const visit = (node: unknown): void => {
+            if (typeof node === "string" && node.startsWith(marker)) {
+              privateCloneBytes += node.length;
+            }
+            if (!node || typeof node !== "object" || seen.has(node)) {
+              return;
+            }
+            seen.add(node);
+            if (
+              "role" in node &&
+              node.role === "user" &&
+              "content" in node &&
+              Array.isArray(node.content) &&
+              node.content[0]?.text === "previous visible request"
+            ) {
+              historyClones += 1;
+            }
+            for (const child of Object.values(node)) {
+              visit(child);
+            }
+          };
+          visit(value);
+          return originalClone(value, options);
+        });
+      try {
+        const harness = createStartedThreadHarness();
+        if (kind === "heartbeat") {
+          params.trigger = "heartbeat";
+        }
+        if (kind === "authorized") {
+          params.toolAuthorityFingerprint = "synthetic-authority";
+        }
+        const run = runCodexAppServerAttempt(params);
+        await harness.waitForMethod("turn/start");
+        await harness.completeTurn({ threadId: "thread-1", turnId: "turn-1" });
+        await run;
+        expect(privateParseBytes).toBe(0);
+        expect(privateCloneBytes).toBe(0);
+        if (kind === "none" || kind === "heartbeat") {
+          expect(historyClones).toBe(0);
+        } else {
+          expect(historyClones).toBeGreaterThan(0);
+        }
+        if (kind !== "none") {
+          expect(hook).toHaveBeenCalled();
+        }
+      } finally {
+        parseSpy.mockRestore();
+        cloneSpy.mockRestore();
+      }
+    },
+  );
+
   it("applies before_prompt_build to Codex developer instructions and turn input", async () => {
     const llmInput = vi.fn();
     const beforePromptBuild = vi.fn(async () => ({

--- a/extensions/codex/src/app-server/session-history.test.ts
+++ b/extensions/codex/src/app-server/session-history.test.ts
@@ -1,4 +1,5 @@
 // Codex tests cover mirrored session-history branch selection.
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -7,6 +8,7 @@ import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
 import { afterEach, describe, expect, it } from "vitest";
 import { readCodexMirroredSessionHistoryMessages } from "./session-history.js";
+import { readMirrorIdentity, readUpstreamUserText } from "./upstream-prompt-provenance.js";
 
 const tempDirs: string[] = [];
 
@@ -130,6 +132,44 @@ async function writeSqliteSession(params: { storedSessionFile?: string } = {}): 
 }
 
 describe("readCodexMirroredSessionHistoryMessages", () => {
+  it("preserves native prompt evidence across explicit model-only reads", async () => {
+    const { marker, sessionTarget } = await writeSqliteSession();
+    const upstreamUserText = "synthetic-native-prompt:" + "x".repeat(1024 * 1024);
+    const message = {
+      role: "user" as const,
+      content: "native visible",
+      timestamp: 3,
+      __openclaw: {
+        upstreamUserText,
+        mirrorIdentity: "synthetic-native-turn",
+        mirrorOrigin: "codex",
+        turnTainted: true,
+      },
+    };
+    await appendSessionTranscriptMessageByIdentity({ ...sessionTarget, message });
+    const target = { ...sessionTarget, sessionTarget, sessionFile: marker };
+    const hash = (text: string | undefined) =>
+      createHash("sha256")
+        .update(text ?? "")
+        .digest("hex");
+    const before = (await readCodexMirroredSessionHistoryMessages(target))!.at(-1)!;
+    expect(hash(readUpstreamUserText(before))).toBe(hash(upstreamUserText));
+    const model = (await readCodexMirroredSessionHistoryMessages(
+      target,
+      undefined,
+      "model-context",
+    ))!.at(-1)!;
+    expect(readUpstreamUserText(model)).toBeUndefined();
+    expect(readMirrorIdentity(model)).toBe("synthetic-native-turn");
+    expect(model).toMatchObject({
+      content: "native visible",
+      timestamp: 3,
+      __openclaw: { mirrorOrigin: "codex", turnTainted: true },
+    });
+    const after = (await readCodexMirroredSessionHistoryMessages(target))!.at(-1)!;
+    expect(hash(readUpstreamUserText(after))).toBe(hash(upstreamUserText));
+    expect(readMirrorIdentity(after)).toBe("synthetic-native-turn");
+  });
   it("treats a missing mirrored session file as empty history", async () => {
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-session-history-"));
     tempDirs.push(dir);

--- a/extensions/codex/src/app-server/session-history.ts
+++ b/extensions/codex/src/app-server/session-history.ts
@@ -9,6 +9,7 @@ import {
   buildSessionContext,
   migrateSessionEntries,
   parseSessionEntries,
+  SessionManager,
 } from "openclaw/plugin-sdk/agent-sessions";
 import { readCodexSessionTranscriptEventsBeforeAdmission } from "openclaw/plugin-sdk/codex-session-transcript-runtime";
 import {
@@ -40,9 +41,20 @@ export type CodexMirroredSessionHistoryTarget = {
 export async function readCodexMirroredSessionHistoryMessages(
   target: CodexMirroredSessionHistoryTarget,
   admission?: TranscriptTurnAdmission,
+  view: "native-evidence" | "model-context" = "native-evidence",
 ): Promise<AgentMessage[] | undefined> {
   try {
-    const entries = await readCodexMirroredSessionEntries(target, admission);
+    const loaded = await readCodexMirroredSessionEntries(target, admission, view);
+    if (!Array.isArray(loaded)) {
+      if (loaded.getHeader()?.id !== target.sessionId) {
+        return [];
+      }
+      return sanitizeCodexHistoryImagePayloads(
+        loaded.buildSessionContext().messages,
+        "codex mirrored model context",
+      );
+    }
+    const entries = loaded;
     if (entries.length === 0) {
       return [];
     }
@@ -87,8 +99,19 @@ export async function readCodexMirroredSessionHistoryMessages(
 
 async function readCodexMirroredSessionEntries(
   target: CodexMirroredSessionHistoryTarget,
-  admission?: TranscriptTurnAdmission,
-): Promise<SessionEntry[]> {
+  admission: TranscriptTurnAdmission | undefined,
+  view: "native-evidence" | "model-context",
+): Promise<SessionEntry[] | SessionManager> {
+  const readTarget = async (
+    transcriptTarget: Required<
+      Pick<SessionTranscriptTargetParams, "agentId" | "sessionId" | "sessionKey" | "storePath">
+    >,
+  ) =>
+    view === "model-context"
+      ? SessionManager.openModelContext(transcriptTarget, { admission })
+      : ((await (admission
+          ? readCodexSessionTranscriptEventsBeforeAdmission(transcriptTarget, admission)
+          : readSessionTranscriptEvents(transcriptTarget))) as SessionEntry[]);
   if (target.sessionTarget) {
     const { agentId, sessionId, sessionKey, storePath } = target.sessionTarget;
     if (
@@ -108,9 +131,7 @@ async function readCodexMirroredSessionEntries(
       sessionKey,
       storePath,
     };
-    return (await (admission
-      ? readCodexSessionTranscriptEventsBeforeAdmission(transcriptTarget, admission)
-      : readSessionTranscriptEvents(transcriptTarget))) as SessionEntry[];
+    return readTarget(transcriptTarget);
   }
   const sqliteMarker = parseSqliteSessionFileMarker(target.sessionFile);
   if (sqliteMarker) {
@@ -130,9 +151,7 @@ async function readCodexMirroredSessionEntries(
       sessionKey,
       storePath: sqliteMarker.storePath,
     };
-    return (await (admission
-      ? readCodexSessionTranscriptEventsBeforeAdmission(transcriptTarget, admission)
-      : readSessionTranscriptEvents(transcriptTarget))) as SessionEntry[];
+    return readTarget(transcriptTarget);
   }
   if (admission) {
     if (
@@ -142,15 +161,12 @@ async function readCodexMirroredSessionEntries(
     ) {
       return [];
     }
-    return (await readCodexSessionTranscriptEventsBeforeAdmission(
-      {
-        agentId: admission.agentId,
-        sessionId: admission.sessionId,
-        sessionKey: admission.sessionKey,
-        storePath: admission.storePath,
-      },
-      admission,
-    )) as SessionEntry[];
+    return readTarget({
+      agentId: admission.agentId,
+      sessionId: admission.sessionId,
+      sessionKey: admission.sessionKey,
+      storePath: admission.storePath,
+    });
   }
   return parseSessionEntries(await fs.readFile(target.sessionFile, "utf-8")) as SessionEntry[];
 }

--- a/packages/agent-core/src/harness/session/session.ts
+++ b/packages/agent-core/src/harness/session/session.ts
@@ -12,6 +12,23 @@ import { selectResetKeptEntries } from "./tool-result-pairing.js";
 type ContextBoundary = CompactionEntry | ResetEntry;
 const SESSION_HISTORY_PRELUDE = Symbol.for("openclaw.sessionHistoryPrelude");
 
+/** The same semantic cut is used before payload acquisition and when building messages. */
+export function resolveSessionContextWindow(
+  entries: readonly { id: string; type: string; firstKeptEntryId?: string }[],
+): { boundaryIndex: number; firstKeptIndex: number } {
+  const boundaryIndex = entries.findLastIndex(
+    (entry) => entry.type === "reset" || entry.type === "compaction",
+  );
+  const firstKeptIndex = entries.findIndex(
+    (entry) => entry.id === entries[boundaryIndex]?.firstKeptEntryId,
+  );
+  return {
+    boundaryIndex,
+    firstKeptIndex:
+      firstKeptIndex >= 0 && firstKeptIndex < boundaryIndex ? firstKeptIndex : boundaryIndex,
+  };
+}
+
 /** Project persisted session entries into the message shared by replay and summarization. */
 export function projectSessionEntryMessage(entry: SessionTreeEntry): AgentMessage | undefined {
   switch (entry.type) {
@@ -106,8 +123,8 @@ export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionCon
         messages.push(summary);
       }
     }
-    const boundaryIdx = pathEntries.findIndex((entry) => entry.id === boundary.id);
-    const firstKeptIdx = pathEntries.findIndex((entry) => entry.id === boundary.firstKeptEntryId);
+    const { boundaryIndex: boundaryIdx, firstKeptIndex: firstKeptIdx } =
+      resolveSessionContextWindow(pathEntries);
     const keptEntries =
       firstKeptIdx >= 0 && firstKeptIdx < boundaryIdx
         ? pathEntries.slice(firstKeptIdx, boundaryIdx)

--- a/packages/agent-core/src/harness/session/tool-result-pairing.ts
+++ b/packages/agent-core/src/harness/session/tool-result-pairing.ts
@@ -3,8 +3,8 @@ import type { AgentMessage } from "../../types.js";
 import type { SessionTreeEntry } from "../types.js";
 
 const TOOL_CALL_TYPES = new Set(["toolCall", "toolUse", "functionCall"]);
-const SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY = "openclawSyntheticMissingToolResult";
-const DEFAULT_MISSING_TOOL_RESULT_TEXT =
+export const SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY = "openclawSyntheticMissingToolResult";
+export const DEFAULT_MISSING_TOOL_RESULT_TEXT =
   "[openclaw] missing tool result in session history; inserted synthetic error result for transcript repair.";
 
 type ToolCallLike = {

--- a/src/agents/harness/prompt-compaction-hook-helpers.test.ts
+++ b/src/agents/harness/prompt-compaction-hook-helpers.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  getGlobalHookRunner,
   initializeGlobalHookRunner,
   resetGlobalHookRunner,
 } from "../../plugins/hook-runner-global.js";
@@ -12,6 +13,105 @@ afterEach(() => {
 });
 
 describe("resolveAgentHarnessBeforePromptBuildResult", () => {
+  it.each([false, true])(
+    "isolates nested prompt history across rebuilds (authorized=%s)",
+    async (authorized) => {
+      const messages = [
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", arguments: { nested: { value: "original" } } }],
+          __openclaw: { upstreamUserText: "x".repeat(1024 * 1024), mirrorIdentity: "synthetic" },
+        },
+      ];
+      const retained: (typeof messages)[] = [];
+      initializeGlobalHookRunner(
+        createMockPluginRegistry([
+          {
+            hookName: "before_prompt_build",
+            ...(authorized ? { requiresToolAuthority: true as const } : {}),
+            handler: (event) => {
+              const snapshot = (event as { messages: typeof messages }).messages;
+              expect(snapshot[0]!["__openclaw"]).toEqual({ mirrorIdentity: "synthetic" });
+              expect(snapshot[0]!.content[0]!.arguments.nested.value).toBe("original");
+              retained.push(snapshot);
+              snapshot[0]!.content[0]!.arguments.nested.value = "immediate mutation";
+              return { prependContext: "contribution" };
+            },
+          },
+        ]),
+      );
+      const build = () =>
+        resolveAgentHarnessBeforePromptBuildResult({
+          prompt: "hello",
+          developerInstructions: "base",
+          messages,
+          ctx: {},
+          toolAuthority: {
+            fingerprint: "synthetic-authority",
+            activeToolNames: () => ["read"],
+            assertActive: () => undefined,
+          },
+        });
+      expect((await build()).prompt).toBe("contribution\n\nhello");
+      expect(messages[0]!.content[0]!.arguments.nested.value).toBe("original");
+      retained[0]![0]!.content[0]!.arguments.nested.value = "retained mutation";
+      expect((await build()).prompt).toBe("contribution\n\nhello");
+      expect(retained[0]).not.toBe(retained[1]);
+      expect(messages[0]!.content[0]!.arguments.nested.value).toBe("original");
+    },
+  );
+  it("preserves registration chaining while isolating prepare and authorized dispatches", async () => {
+    const messages = [{ role: "user", content: [{ type: "text", text: "original" }] }];
+    const calls: string[] = [];
+    const mutate = (event: unknown, expected: string, next: string) => {
+      const snapshot = (event as { messages: typeof messages }).messages;
+      expect(snapshot[0]!.content[0]!.text).toBe(expected);
+      snapshot[0]!.content[0]!.text = next;
+      calls.push(next);
+      return { prependContext: next };
+    };
+    initializeGlobalHookRunner(
+      createMockPluginRegistry([
+        {
+          hookName: "agent_turn_prepare",
+          handler: (event) => mutate(event, "original", "prepare"),
+        },
+        {
+          hookName: "before_prompt_build",
+          priority: 10,
+          handler: (event) => mutate(event, "original", "first"),
+        },
+        {
+          hookName: "before_prompt_build",
+          priority: 0,
+          handler: (event) => mutate(event, "first", "second"),
+        },
+        {
+          hookName: "before_prompt_build",
+          requiresToolAuthority: true,
+          handler: (event) => mutate(event, "original", "authorized"),
+        },
+      ]),
+    );
+    await getGlobalHookRunner()!.runAgentTurnPrepare(
+      { prompt: "hello", messages, queuedInjections: [] },
+      {},
+    );
+    const result = await resolveAgentHarnessBeforePromptBuildResult({
+      prompt: "hello",
+      developerInstructions: "base",
+      messages,
+      ctx: {},
+      toolAuthority: {
+        fingerprint: "synthetic",
+        activeToolNames: () => [],
+        assertActive: () => undefined,
+      },
+    });
+    expect(calls).toEqual(["prepare", "first", "second", "authorized"]);
+    expect(result.prompt).toBe("first\n\nsecond\n\nauthorized\n\nhello");
+    expect(messages[0]!.content[0]!.text).toBe("original");
+  });
   it("runs a lazy builder with hook tool policy while preserving replacement order", async () => {
     initializeGlobalHookRunner(
       createMockPluginRegistry([

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -210,25 +210,7 @@ type ToolUseResultPairingOptions = {
   preserveUnframedToolResults?: boolean;
 };
 
-export function stripToolResultDetails(messages: AgentMessage[]): AgentMessage[] {
-  let touched = false;
-  const out: AgentMessage[] = [];
-  for (const msg of messages) {
-    if (!msg || typeof msg !== "object" || (msg as { role?: unknown }).role !== "toolResult") {
-      out.push(msg);
-      continue;
-    }
-    if (!("details" in msg)) {
-      out.push(msg);
-      continue;
-    }
-    const sanitized = { ...msg };
-    Reflect.deleteProperty(sanitized, "details");
-    touched = true;
-    out.push(sanitized);
-  }
-  return touched ? out : messages;
-}
+export { stripToolResultDetails } from "../shared/model-context-message.js";
 
 function collectFollowingToolResults(
   messages: AgentMessage[],

--- a/src/agents/sessions/session-manager-model-context.test.ts
+++ b/src/agents/sessions/session-manager-model-context.test.ts
@@ -1,0 +1,528 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { expect, it, vi } from "vitest";
+import {
+  appendTranscriptEvent,
+  upsertSessionEntryCore,
+} from "../../config/sessions/session-accessor.js";
+import { runWithSessionTranscriptReadFence } from "../../config/sessions/session-transcript-read-fence.js";
+import { waitForSessionTranscriptProjection } from "../../config/sessions/session-transcript-reconcile.js";
+import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
+import { SessionManager } from "./session-manager.js";
+
+it.each(["whole", "reset", "compaction", "reset-compaction", "leaf", "opaque"])(
+  "acquires detached %s context without native payloads or changing stored evidence",
+  async (scenario) => {
+    await withOpenClawTestState({ label: "model-context" }, async (state) => {
+      const scope = {
+        agentId: "main",
+        sessionId: "model-view",
+        sessionKey: "agent:main:model-view",
+        storePath: path.join(state.agentDir("main"), "openclaw-agent.sqlite"),
+      };
+      await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+      const source = SessionManager.open(scope);
+      const marker = "synthetic-native-memory:";
+      const metadata = {
+        upstreamUserText: marker + "x".repeat(256 * 1024),
+        mirrorIdentity: "synthetic-identity",
+        mirrorOrigin: "synthetic-origin",
+        turnTainted: true,
+        sender: { id: "synthetic-sender" },
+        media: { type: "synthetic" },
+      };
+      source.appendThinkingLevelChange("high");
+      source.appendModelChange("openai", "gpt-5.6-luna");
+      const old = source.appendMessage({
+        role: "user",
+        content: "old",
+        timestamp: 1,
+        __openclaw: metadata,
+      } as Parameters<SessionManager["appendMessage"]>[0]);
+      const excluded = source.appendMessage({
+        role: "custom",
+        customType: "display",
+        content: marker + "d".repeat(256 * 1024),
+        display: true,
+        excludeFromContext: true,
+        timestamp: 1,
+      });
+      const kept = source.appendMessage({
+        role: "user",
+        content: "kept",
+        timestamp: 2,
+        __openclaw: metadata,
+      } as Parameters<SessionManager["appendMessage"]>[0]);
+      source.appendMessage(
+        makeAgentAssistantMessage({
+          model: "gpt-5.6-luna",
+          providerReplay: {
+            v: 1,
+            type: "openai-responses-compaction",
+            data: "synthetic-checkpoint",
+            provider: "openai",
+            api: "openai-responses",
+            model: "gpt-5.6-luna",
+            baseUrlHash: "synthetic",
+          },
+          content: [
+            {
+              type: "toolCall",
+              id: "paired",
+              name: "read",
+              arguments: { nested: { path: "synthetic.txt" } },
+            },
+          ],
+          stopReason: "toolUse",
+        }),
+      );
+      const result = source.appendMessage({
+        role: "toolResult",
+        toolName: "read",
+        toolCallId: "paired",
+        isError: false,
+        timestamp: 3,
+        content: [{ type: "text", text: "tool output" }],
+      });
+      source.appendCustomMessageEntry("synthetic-context", "custom context", true, {
+        source: "synthetic",
+      });
+      source.branchWithSummary(source.getLeafId(), "branch summary");
+      if (scenario === "reset" || scenario === "reset-compaction") {
+        source.appendResetBoundary("new", kept);
+      }
+      if (scenario === "compaction" || scenario === "reset-compaction") {
+        source.appendCompaction("summary", scenario === "compaction" ? excluded : kept, 100);
+      }
+      if (scenario === "leaf") {
+        source.branch(old);
+        const inactive = source.appendMessage({
+          role: "user",
+          content: marker + "abandoned".repeat(4096),
+          timestamp: 4,
+        });
+        source.appendLeafControl({
+          targetId: result,
+          appendParentId: inactive,
+          appendMode: "side",
+        });
+      }
+      if (scenario === "opaque") {
+        await appendTranscriptEvent(scope, {
+          type: "opaque-synthetic",
+          id: "opaque",
+          parentId: result,
+          data: marker + "o".repeat(256 * 1024),
+        });
+        source.reloadPersistedTranscript();
+      }
+      source.appendMessage({ role: "user", content: "latest", timestamp: 5 });
+      const expected = source.buildSessionContext();
+      const visible = (messages: typeof expected.messages) =>
+        messages.map((message) => ({
+          role: message.role,
+          content: "content" in message ? message.content : undefined,
+          summary: "summary" in message ? message.summary : undefined,
+        }));
+      const database = openOpenClawAgentDatabase({ agentId: scope.agentId, path: scope.storePath });
+      const fingerprint = () => {
+        const hash = createHash("sha256");
+        for (const row of database.db
+          .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? ORDER BY seq")
+          .iterate(scope.sessionId)) {
+          hash.update(String(row.event_json));
+        }
+        return hash.digest("hex");
+      };
+      const before = fingerprint();
+      const originalParse = JSON.parse;
+      let privateBytes = 0;
+      const parseSpy = vi.spyOn(JSON, "parse").mockImplementation((text, reviver) => {
+        if (typeof text === "string" && text.includes(marker)) {
+          privateBytes += text.length;
+        }
+        return originalParse(text, reviver);
+      });
+      let detached: SessionManager;
+      try {
+        detached = SessionManager.openModelContext(scope);
+      } finally {
+        parseSpy.mockRestore();
+      }
+      expect(privateBytes).toBe(0);
+      expect(detached.isPersisted()).toBe(false);
+      expect(detached.getHeader()?.id).toBe(scope.sessionId);
+      expect(detached.migrated).toBe(false);
+      expect(detached.getBoundaryCount()).toBe(source.getBoundaryCount());
+      const context = detached.buildSessionContext();
+      expect(visible(context.messages)).toEqual(visible(expected.messages));
+      expect(context.model).toEqual(expected.model);
+      expect(
+        context.messages
+          .filter((message) => message.role === "assistant")
+          .map((message) => message.providerReplay),
+      ).toEqual(
+        expected.messages
+          .filter((message) => message.role === "assistant")
+          .map((message) => message.providerReplay),
+      );
+      expect(context.thinkingLevel).toBe("high");
+      const retainedUser = context.messages.find(
+        (message) => message.role === "user" && message.content === "kept",
+      );
+      expect(retainedUser).toMatchObject({
+        __openclaw: {
+          mirrorIdentity: "synthetic-identity",
+          mirrorOrigin: "synthetic-origin",
+          turnTainted: true,
+          sender: metadata.sender,
+          media: metadata.media,
+        },
+      });
+      expect(
+        Object.hasOwn(
+          (retainedUser as unknown as { __openclaw: object })["__openclaw"],
+          "upstreamUserText",
+        ),
+      ).toBe(false);
+      if (scenario === "reset") {
+        expect(
+          (retainedUser as unknown as Record<symbol, unknown>)[
+            Symbol.for("openclaw.sessionHistoryPrelude")
+          ],
+        ).toBe(true);
+      }
+      detached.appendMessage({ role: "user", content: "review only", timestamp: 6 });
+      expect(fingerprint()).toBe(before);
+      source.branch(source.getLeafId()!);
+      await waitForSessionTranscriptProjection(scope);
+      const admitted = source.appendMessageWithTranscriptAnchor({
+        role: "user",
+        content: "current turn",
+        timestamp: 7,
+      });
+      if (!admitted.anchor) {
+        throw new Error("missing admission");
+      }
+      const admission = {
+        ...admitted.anchor,
+        role: "user" as const,
+        logicalTurnId: "synthetic-turn",
+      };
+      const earlier = runWithSessionTranscriptReadFence(admission, () =>
+        SessionManager.openModelContext(scope).buildSessionContext(),
+      );
+      if (scenario === "whole") {
+        for (const patch of [
+          { generation: "wrong-generation" },
+          { rawSeq: admission.rawSeq + 1 },
+          { effectiveParentId: "wrong-parent" },
+          { activeMessagePosition: admission.activeMessagePosition + 1 },
+          { role: "assistant" },
+          { sessionKey: "agent:main:wrong" },
+          { storePath: path.join(state.agentDir("main"), "wrong.sqlite") },
+        ]) {
+          expect(() =>
+            SessionManager.openModelContext(scope, {
+              admission: { ...admission, ...patch } as typeof admission,
+            }),
+          ).toThrow(/Current-turn transcript admission/);
+        }
+      }
+      source.appendResetBoundary("new");
+      source.appendCompaction("later summary", admitted.entryId, 100);
+      expect(
+        runWithSessionTranscriptReadFence(admission, () =>
+          SessionManager.openModelContext(scope).buildSessionContext(),
+        ),
+      ).toEqual(earlier);
+    });
+  },
+);
+
+it.each(
+  ["reset", "compaction", "whole"].flatMap((boundary) =>
+    (["user", "assistant", "toolResult"] as const).map((role) => ({ boundary, role })),
+  ),
+)("preserves excluded $role payload selection across $boundary", async ({ boundary, role }) => {
+  await withOpenClawTestState({ label: "model-excluded-retention" }, async (state) => {
+    const scope = {
+      agentId: "main",
+      sessionId: "excluded-retention",
+      sessionKey: "agent:main:excluded-retention",
+      storePath: path.join(state.agentDir("main"), "openclaw-agent.sqlite"),
+    };
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+    const source = SessionManager.open(scope);
+    const pairedCall =
+      role === "toolResult"
+        ? source.appendMessage(
+            makeAgentAssistantMessage({
+              content: [{ type: "toolCall", id: "paired", name: "read", arguments: {} }],
+            }),
+          )
+        : undefined;
+    const content = [{ type: "text" as const, text: "synthetic retained text" }];
+    const message = {
+      ...(role === "assistant"
+        ? makeAgentAssistantMessage({ content })
+        : role === "user"
+          ? { role, content: "synthetic retained text", timestamp: 1 }
+          : {
+              role,
+              content,
+              toolCallId: "paired",
+              toolName: "read",
+              isError: false,
+              timestamp: 1,
+            }),
+      excludeFromContext: true,
+      __openclaw: { upstreamUserText: "private-retained:" + "x".repeat(256 * 1024) },
+    };
+    const retained = source.appendMessage(message);
+    if (boundary === "reset") {
+      source.appendResetBoundary("new", pairedCall ?? retained);
+    } else if (boundary === "compaction") {
+      source.appendCompaction("summary", pairedCall ?? retained, 100);
+    }
+    const ordinaryExcluded = {
+      role: "user" as const,
+      content: "ordinary-excluded:" + "x".repeat(256 * 1024),
+      timestamp: 2,
+      excludeFromContext: true,
+    };
+    source.appendMessage(ordinaryExcluded);
+    source.appendMessage({ role: "user", content: "synthetic current text", timestamp: 3 });
+    const expected = source.buildSessionContext();
+    expect(
+      expected.messages.some(
+        (entry) => "excludeFromContext" in entry && entry.excludeFromContext === true,
+      ),
+    ).toBe(boundary === "reset");
+    const database = openOpenClawAgentDatabase({ agentId: scope.agentId, path: scope.storePath });
+    const fingerprint = () => {
+      const hash = createHash("sha256");
+      for (const row of database.db
+        .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? ORDER BY seq")
+        .iterate(scope.sessionId)) {
+        hash.update(String(row.event_json));
+      }
+      return hash.digest("hex");
+    };
+    const before = fingerprint();
+    const originalParse = JSON.parse;
+    let excludedBytes = 0;
+    const spy = vi.spyOn(JSON, "parse").mockImplementation((text, reviver) => {
+      if (
+        typeof text === "string" &&
+        (text.includes("private-retained:") || text.includes("ordinary-excluded:"))
+      ) {
+        excludedBytes += text.length;
+      }
+      return originalParse(text, reviver);
+    });
+    let actual: typeof expected;
+    try {
+      actual = SessionManager.openModelContext(scope).buildSessionContext();
+    } finally {
+      spy.mockRestore();
+    }
+    expect(excludedBytes).toBe(0);
+    expect(fingerprint()).toBe(before);
+    expect(actual.model).toEqual(expected.model);
+    expect(
+      actual.messages.map((entry) => ("content" in entry ? entry.content : undefined)),
+    ).toEqual(expected.messages.map((entry) => ("content" in entry ? entry.content : undefined)));
+  });
+});
+
+it.each([false, true])("keeps model reads non-persisting (incognito=%s)", async (incognito) => {
+  await withOpenClawTestState({ label: "model-readonly" }, async (state) => {
+    const scope = {
+      agentId: "main",
+      sessionId: "readonly",
+      sessionKey: incognito ? "agent:main:dashboard:incognito-readonly" : "agent:main:readonly",
+      storePath: path.join(state.agentDir("main"), "openclaw-agent.sqlite"),
+    };
+    expect(SessionManager.openModelContext(scope).buildSessionContext().messages).toEqual([]);
+    expect(fs.existsSync(scope.storePath)).toBe(false);
+    await upsertSessionEntryCore(scope, {
+      sessionId: scope.sessionId,
+      updatedAt: 1,
+      ...(incognito ? { incognito: true } : {}),
+    });
+    const source = SessionManager.open(scope);
+    source.appendMessage({ role: "user", content: "visible", timestamp: 1 });
+    const view = SessionManager.openModelContext(scope);
+    expect(view.buildSessionContext()).toEqual(source.buildSessionContext());
+    expect(view.isPersisted()).toBe(false);
+    if (incognito) {
+      expect(fs.existsSync(scope.storePath)).toBe(false);
+    } else {
+      const database = openOpenClawAgentDatabase({ agentId: "main", path: scope.storePath });
+      // A transient reader reconstructs navigation from its own read snapshot, not a stale cache.
+      database.db
+        .prepare("UPDATE session_transcript_index_state SET needs_rebuild = 1 WHERE session_id = ?")
+        .run(scope.sessionId);
+      expect(SessionManager.openModelContext(scope).buildSessionContext()).toEqual(
+        source.buildSessionContext(),
+      );
+      database.db
+        .prepare("DELETE FROM session_transcript_index_state WHERE session_id = ?")
+        .run(scope.sessionId);
+      expect(SessionManager.openModelContext(scope).buildSessionContext()).toEqual(
+        source.buildSessionContext(),
+      );
+      expect(
+        database.db
+          .prepare("SELECT COUNT(*) AS n FROM session_transcript_index_state WHERE session_id = ?")
+          .get(scope.sessionId)?.n,
+      ).toBe(0);
+      const parse = JSON.parse;
+      const parseSpy = vi.spyOn(JSON, "parse").mockImplementation((text, reviver) => {
+        if (typeof text === "string" && text.includes('"role":"user"')) {
+          throw new Error("synthetic decode failure");
+        }
+        return parse(text, reviver);
+      });
+      try {
+        expect(() => SessionManager.openModelContext(scope)).toThrow("synthetic decode failure");
+      } finally {
+        parseSpy.mockRestore();
+      }
+      expect(database.db.isTransaction).toBe(false);
+      expect(SessionManager.openModelContext(scope).buildSessionContext()).toEqual(
+        source.buildSessionContext(),
+      );
+    }
+  });
+});
+
+it("keeps the real result when reset retention replaces a synthetic missing result", async () => {
+  await withOpenClawTestState({ label: "model-pairing" }, async (state) => {
+    const scope = {
+      agentId: "main",
+      sessionId: "pairing",
+      sessionKey: "agent:main:pairing",
+      storePath: path.join(state.agentDir("main"), "openclaw-agent.sqlite"),
+    };
+    await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+    const source = SessionManager.open(scope);
+    const firstKept = source.appendMessage(
+      makeAgentAssistantMessage({
+        content: [{ type: "toolCall", id: "repeat", name: "read", arguments: {} }],
+      }),
+    );
+    source.appendMessage({
+      role: "toolResult",
+      toolCallId: "repeat",
+      toolName: "read",
+      isError: true,
+      content: [{ type: "text", text: "missing" }],
+      details: { openclawSyntheticMissingToolResult: true },
+      timestamp: 1,
+    });
+    source.appendMessage({
+      role: "toolResult",
+      toolCallId: "repeat",
+      toolName: "read",
+      isError: false,
+      content: [{ type: "text", text: "real output" }],
+      timestamp: 2,
+    });
+    source.appendMessage({
+      role: "toolResult",
+      toolCallId: "orphan",
+      toolName: "read",
+      isError: false,
+      content: [{ type: "text", text: "orphan-body:" + "x".repeat(512 * 1024) }],
+      timestamp: 3,
+    });
+    source.appendResetBoundary("new", firstKept);
+    const originalParse = JSON.parse;
+    let orphanBytes = 0;
+    const spy = vi.spyOn(JSON, "parse").mockImplementation((text, reviver) => {
+      if (typeof text === "string" && text.includes("orphan-body:")) {
+        orphanBytes += text.length;
+      }
+      return originalParse(text, reviver);
+    });
+    let messages: ReturnType<SessionManager["buildSessionContext"]>["messages"];
+    try {
+      messages = SessionManager.openModelContext(scope).buildSessionContext().messages;
+    } finally {
+      spy.mockRestore();
+    }
+    expect(orphanBytes).toBe(0);
+    expect(
+      messages.filter((message) => message.role === "toolResult").map((message) => message.content),
+    ).toEqual([[{ type: "text", text: "real output" }]]);
+  });
+});
+
+it.each(["reset", "compaction"])(
+  "does not acquire checkpoints invalidated by %s",
+  async (boundary) => {
+    await withOpenClawTestState({ label: "model-checkpoint" }, async (state) => {
+      const scope = {
+        agentId: "main",
+        sessionId: "checkpoint",
+        sessionKey: "agent:main:checkpoint",
+        storePath: path.join(state.agentDir("main"), "openclaw-agent.sqlite"),
+      };
+      await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+      const source = SessionManager.open(scope);
+      const kept = source.appendMessage({ role: "user", content: "visible", timestamp: 1 });
+      const marker = "synthetic-obsolete-checkpoint-";
+      const checkpoint = {
+        v: 1 as const,
+        type: "openai-responses-compaction",
+        data: marker + "x".repeat(1024 * 1024),
+        provider: "openai",
+        api: "openai-responses",
+        model: "gpt-5.6-luna",
+        baseUrlHash: "synthetic",
+      };
+      source.appendMessage(
+        makeAgentAssistantMessage({
+          content: [{ type: "text", text: "kept answer" }],
+          model: "gpt-5.6-luna",
+          providerReplay: checkpoint,
+        }),
+      );
+      if (boundary === "reset") {
+        source.appendResetBoundary("new", kept);
+      } else {
+        source.appendCompaction("summary", kept, 100);
+      }
+      const valid = { ...checkpoint, data: "valid-post-boundary-checkpoint" };
+      source.appendMessage(
+        makeAgentAssistantMessage({
+          content: [{ type: "text", text: "new answer" }],
+          model: "gpt-5.6-luna",
+          providerReplay: valid,
+        }),
+      );
+      const parse = JSON.parse;
+      let obsoleteBytes = 0;
+      const spy = vi.spyOn(JSON, "parse").mockImplementation((text, reviver) => {
+        if (typeof text === "string" && text.includes(marker)) {
+          obsoleteBytes += text.length;
+        }
+        return parse(text, reviver);
+      });
+      let context: ReturnType<SessionManager["buildSessionContext"]>;
+      try {
+        context = SessionManager.openModelContext(scope).buildSessionContext();
+      } finally {
+        spy.mockRestore();
+      }
+      expect(obsoleteBytes).toBe(0);
+      expect(context).toEqual(source.buildSessionContext());
+      expect(context.messages.at(-1)).toMatchObject({ providerReplay: valid });
+    });
+  },
+);

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -10,8 +10,14 @@ import {
   type SessionTranscriptRuntimeTarget,
 } from "../../config/sessions/session-accessor.js";
 import { readSessionTranscriptBoundedActiveContextCore } from "../../config/sessions/session-accessor.sqlite-active-context.js";
+import { readSessionTranscriptModelContext } from "../../config/sessions/session-accessor.sqlite-model-context.js";
+import {
+  runWithSessionTranscriptReadFence,
+  SessionTranscriptReadFenceError,
+} from "../../config/sessions/session-transcript-read-fence.js";
 import { CURRENT_SESSION_VERSION } from "../../config/sessions/version.js";
 import type { Message } from "../../llm/types.js";
+import type { UserTurnTranscriptAdmissionReceipt } from "../../sessions/user-turn-transcript.types.js";
 import type { BashExecutionMessage, CustomMessage } from "./messages.js";
 import { SessionManagerBranching } from "./session-manager-branching.js";
 import type {
@@ -118,6 +124,39 @@ export class SessionManager extends SessionManagerBranching {
       ...context,
       limits,
     });
+  }
+
+  /** Detached model view: selected payloads plus lightweight ancestry, never raw replay evidence. */
+  static openModelContext(
+    target: SessionTranscriptRuntimeTarget,
+    options: {
+      cwd?: string;
+      admission?: UserTurnTranscriptAdmissionReceipt;
+    } = {},
+  ): SessionManager {
+    const { admission } = options;
+    if (
+      admission &&
+      (target.agentId !== admission.agentId ||
+        target.sessionId !== admission.sessionId ||
+        target.sessionKey !== admission.sessionKey)
+    ) {
+      throw new SessionTranscriptReadFenceError(
+        "Current-turn transcript admission belongs to a different transcript target",
+      );
+    }
+    const contextEntries = runWithSessionTranscriptReadFence(admission, () =>
+      readSessionTranscriptModelContext(target),
+    );
+    // SAFETY: The transcript owner preserves the entry union; the constructor applies the normal codec.
+    const entries = contextEntries as FileEntry[];
+    const header = entries.find((entry) => entry.type === "session");
+    if (entries.length > 0 && (!header || (header.version ?? 1) < CURRENT_SESSION_VERSION)) {
+      throw new Error(
+        "Persisted legacy session transcripts require doctor/import migration before runtime use",
+      );
+    }
+    return new SessionManager(options.cwd ?? header?.cwd ?? process.cwd(), undefined, entries);
   }
 
   /** Appends to the current transcript leaf without hydrating its history. */

--- a/src/config/sessions/session-accessor.sqlite-bounded-context.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-bounded-context.test.ts
@@ -512,3 +512,35 @@ it("counts paired reset tool results without counting discarded orphan results",
     expect(readSessionTranscriptActiveStats(scope).eventCount).toBe(3);
   });
 });
+
+it("counts retained raw bytes without hydrating private native payloads", async () => {
+  await withBoundedContextScope(async (scope) => {
+    const marker = "synthetic-retained-native-payload:";
+    const privateText = marker + "x".repeat(1024 * 1024);
+    const manager = SessionManager.open(scope);
+    const kept = manager.appendMessage({
+      role: "user",
+      content: "kept",
+      timestamp: 1,
+      __openclaw: { upstreamUserText: privateText },
+    } as Parameters<SessionManager["appendMessage"]>[0]);
+    manager.appendResetBoundary("new", kept);
+    await waitForSessionTranscriptProjection(scope);
+    const originalParse = JSON.parse;
+    let privateBytes = 0;
+    const parseSpy = vi.spyOn(JSON, "parse").mockImplementation((text, reviver) => {
+      if (typeof text === "string" && text.includes(marker)) {
+        privateBytes += text.length;
+      }
+      return originalParse(text, reviver);
+    });
+    try {
+      const stats = readSessionTranscriptActiveStats(scope);
+      expect(stats.eventCount).toBe(1);
+      expect(stats.sizeBytes).toBeGreaterThan(privateText.length);
+      expect(privateBytes).toBe(0);
+    } finally {
+      parseSpy.mockRestore();
+    }
+  });
+});

--- a/src/config/sessions/session-accessor.sqlite-model-context.ts
+++ b/src/config/sessions/session-accessor.sqlite-model-context.ts
@@ -1,0 +1,149 @@
+import type { SessionTreeEntry } from "@openclaw/agent-core";
+import { isCompactionReplayCheckpoint } from "@openclaw/ai/transports";
+import { sql } from "kysely";
+import { resolveSessionContextWindow } from "../../../packages/agent-core/src/harness/session/session.js";
+import { selectResetKeptEntries } from "../../../packages/agent-core/src/harness/session/tool-result-pairing.js";
+import {
+  executeSqliteQueryTakeFirstSync,
+  iterateSqliteQuerySync,
+  prepareSqliteQuerySync,
+} from "../../infra/kysely-sync.js";
+import { runSqliteDeferredTransactionSync } from "../../infra/sqlite-transaction.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
+import type {
+  SessionTranscriptReadScope,
+  TranscriptEvent,
+} from "./session-accessor.sqlite-contract.js";
+import {
+  getSessionKysely,
+  resolveSqliteTranscriptReadScope,
+  toDatabaseOptions,
+} from "./session-accessor.sqlite-scope.js";
+import {
+  projectModelContextEventSql,
+  projectModelContextNavigationSql,
+} from "./session-model-context-projection.js";
+import { resolveSqliteSessionTranscriptReadFence } from "./session-transcript-read-fence.js";
+import {
+  scanSessionTranscriptTree,
+  selectSessionTranscriptTreePathNodes,
+} from "./transcript-tree.js";
+
+/** Read a transient context without opening the writer lifecycle or copying native evidence. */
+export function readSessionTranscriptModelContext(
+  scope: SessionTranscriptReadScope,
+): TranscriptEvent[] {
+  const resolved = resolveSqliteTranscriptReadScope(scope);
+  const result = withOpenClawAgentDatabaseReadOnly(
+    (database) =>
+      runSqliteDeferredTransactionSync(
+        database.db,
+        () => {
+          const db = getSessionKysely(database.db);
+          const fence = resolveSqliteSessionTranscriptReadFence({ database, ...resolved });
+          const base = db
+            .selectFrom("transcript_events")
+            .where("session_id", "=", resolved.sessionId)
+            .$if(fence !== undefined, (query) => query.where("seq", "<", fence!.beforeRawSeq));
+          /* kysely-allow-raw: canonical JSON column used by the query-time projection owner. */
+          const eventJson = sql<string>`event_json`;
+          const header = executeSqliteQueryTakeFirstSync(
+            database.db,
+            base
+              .select("event_json")
+              .where(
+                /* kysely-allow-raw: the header discriminator is owned by the transcript codec. */
+                sql<string>`json_extract(event_json, '$.type')`,
+                "=",
+                "session",
+              )
+              .orderBy("seq", "asc")
+              .limit(1),
+          );
+          const tree = scanSessionTranscriptTree(
+            (function* () {
+              for (const row of iterateSqliteQuerySync(
+                database.db,
+                base
+                  .select([
+                    "seq",
+                    projectModelContextNavigationSql(eventJson).as("navigation_json"),
+                  ])
+                  .orderBy("seq", "asc"),
+              )) {
+                // The navigation projection preserves discriminants and state, with empty
+                // bodies. Only selected model messages are subsequently hydrated.
+                // SAFETY: SQL retains entry discriminants/state; the detached manager validates readability.
+                yield { ...(JSON.parse(row.navigation_json) as SessionTreeEntry), seq: row.seq };
+              }
+            })(),
+          );
+          const selected = selectSessionTranscriptTreePathNodes(tree, tree.leafId);
+          const entries = selected.map((node) => node.entry);
+          const window = resolveSessionContextWindow(entries);
+          const boundary = entries[window.boundaryIndex];
+          const kept = entries.slice(window.firstKeptIndex, window.boundaryIndex);
+          const resetKept =
+            boundary?.type === "reset" ? new Set(selectResetKeptEntries(kept)) : undefined;
+          const readPayload = prepareSqliteQuerySync<
+            { seq: number; omitCheckpoint: number },
+            { event_json: string }
+          >(database.db, (parameter) =>
+            base
+              .select(
+                projectModelContextEventSql(
+                  eventJson,
+                  parameter((row) => row.omitCheckpoint),
+                ).as("event_json"),
+              )
+              .where(
+                "seq",
+                "=",
+                parameter((row) => row.seq),
+              ),
+          );
+          const events: TranscriptEvent[] = header ? [JSON.parse(header.event_json)] : [];
+          for (const [index, node] of selected.entries()) {
+            const entry = node.entry;
+            const retained = index >= window.firstKeptIndex && index < window.boundaryIndex;
+            const inContext =
+              window.boundaryIndex < 0 ||
+              index >= window.boundaryIndex ||
+              (retained && (!resetKept || resetKept.has(entry)));
+            const hasModelPayload =
+              entry.type === "message" ||
+              entry.type === "custom_message" ||
+              entry.type === "branch_summary" ||
+              index === window.boundaryIndex;
+            // appendResetKeptMessage consumes explicit reset retention regardless of ordinary exclusion.
+            const excluded =
+              !resetKept?.has(entry) &&
+              entry.type === "message" &&
+              "excludeFromContext" in entry.message &&
+              entry.message.excludeFromContext === true;
+            const row =
+              inContext && hasModelPayload && !excluded
+                ? readPayload({
+                    seq: node.entry.seq,
+                    omitCheckpoint:
+                      retained &&
+                      entry.type === "message" &&
+                      entry.message.role === "assistant" &&
+                      isCompactionReplayCheckpoint(entry.message.providerReplay)
+                        ? 1
+                        : 0,
+                  }).rows[0]
+                : undefined;
+            // SAFETY: Payload selection changes only storage-only message fields, not the persisted entry union.
+            const projected = row ? (JSON.parse(row.event_json) as SessionTreeEntry) : entry;
+            events.push({ ...projected, parentId: node.parentId });
+          }
+          return events;
+        },
+        { operationLabel: "session model-context read" },
+      ),
+    toDatabaseOptions(resolved),
+    { throwOnMissingTable: true },
+  );
+  return result.found ? result.value : [];
+}

--- a/src/config/sessions/session-accessor.sqlite-model-context.ts
+++ b/src/config/sessions/session-accessor.sqlite-model-context.ts
@@ -45,8 +45,6 @@ export function readSessionTranscriptModelContext(
             .selectFrom("transcript_events")
             .where("session_id", "=", resolved.sessionId)
             .$if(fence !== undefined, (query) => query.where("seq", "<", fence!.beforeRawSeq));
-          /* kysely-allow-raw: canonical JSON column used by the query-time projection owner. */
-          const eventJson = sql<string>`event_json`;
           const header = executeSqliteQueryTakeFirstSync(
             database.db,
             base
@@ -65,9 +63,9 @@ export function readSessionTranscriptModelContext(
               for (const row of iterateSqliteQuerySync(
                 database.db,
                 base
-                  .select([
+                  .select((eb) => [
                     "seq",
-                    projectModelContextNavigationSql(eventJson).as("navigation_json"),
+                    projectModelContextNavigationSql(eb.ref("event_json")).as("navigation_json"),
                   ])
                   .orderBy("seq", "asc"),
               )) {
@@ -90,9 +88,9 @@ export function readSessionTranscriptModelContext(
             { event_json: string }
           >(database.db, (parameter) =>
             base
-              .select(
+              .select((eb) =>
                 projectModelContextEventSql(
-                  eventJson,
+                  eb.ref("event_json"),
                   parameter((row) => row.omitCheckpoint),
                 ).as("event_json"),
               )

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -238,10 +238,9 @@ function findLatestResetMessageWindow(
               .onRef("event.session_id", "=", "active.session_id")
               .onRef("event.seq", "=", "active.event_seq"),
           )
-          .select([
+          .select((eb) => [
             "active.message_position",
-            /* kysely-allow-raw: private native payloads never cross the retained-tail read boundary. */
-            projectModelContextNavigationSql(sql<string>`event.event_json`).as("event_json"),
+            projectModelContextNavigationSql(eb.ref("event.event_json")).as("event_json"),
             /* kysely-allow-raw: raw-byte accounting stays independent of the transient projection. */
             sql<number>`OCTET_LENGTH(event.event_json) + 1`.as("serialized_bytes"),
           ])

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -6,12 +6,14 @@ import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
+  iterateSqliteQuerySync,
 } from "../../infra/kysely-sync.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import type { TranscriptEvent } from "./session-accessor.sqlite-contract.js";
 import { resolveSqliteTranscriptReadScope } from "./session-accessor.sqlite-scope.js";
+import { projectModelContextNavigationSql } from "./session-model-context-projection.js";
 import type { SessionTranscriptProjectionState } from "./session-transcript-index.js";
 
 type ResetWindowDatabase = Pick<
@@ -227,7 +229,7 @@ function findLatestResetMessageWindow(
         .where("identity.event_id", "=", boundary.firstKeptEntryId),
     );
     if (firstKept && firstKept.active_position < latestBoundary.active_position) {
-      const candidates = executeSqliteQuerySync(
+      const candidateRows = iterateSqliteQuerySync(
         projection.database.db,
         db
           .selectFrom("session_transcript_active_events as active")
@@ -236,20 +238,33 @@ function findLatestResetMessageWindow(
               .onRef("event.session_id", "=", "active.session_id")
               .onRef("event.seq", "=", "active.event_seq"),
           )
-          .select(["active.message_position", "event.event_json"])
+          .select([
+            "active.message_position",
+            /* kysely-allow-raw: private native payloads never cross the retained-tail read boundary. */
+            projectModelContextNavigationSql(sql<string>`event.event_json`).as("event_json"),
+            /* kysely-allow-raw: raw-byte accounting stays independent of the transient projection. */
+            sql<number>`OCTET_LENGTH(event.event_json) + 1`.as("serialized_bytes"),
+          ])
           .where("active.session_id", "=", projection.resolved.sessionId)
           .where("active.active_position", ">=", firstKept.active_position)
           .where("active.active_position", "<", latestBoundary.active_position)
           .where("active.message_position", "is not", null)
           .$if(scope === "context", (query) => query.where("active.context_eligible", "=", 1))
           .orderBy("active.active_position", "asc"),
-      ).rows.flatMap((row) => {
+      );
+      const candidates = Array.from(candidateRows, (row) => {
         try {
-          return [{ ...row, event: JSON.parse(row.event_json) as SessionTreeEntry }];
+          return [
+            {
+              message_position: row.message_position,
+              serialized_bytes: row.serialized_bytes,
+              event: JSON.parse(row.event_json) as SessionTreeEntry,
+            },
+          ];
         } catch {
           return [];
         }
-      });
+      }).flat();
       const candidateEntries = candidates.map((row) => row.event);
       // A compaction keeps its whole tail; a reset replays only the paired subset.
       const keptEntries = new Set(
@@ -259,10 +274,7 @@ function findLatestResetMessageWindow(
       );
       const keptRows = candidates.filter((row) => keptEntries.has(row.event));
       contextPrefixEventCount += keptRows.length;
-      contextPrefixSizeBytes += keptRows.reduce(
-        (total, row) => total + Buffer.byteLength(row.event_json, "utf8") + 1,
-        0,
-      );
+      contextPrefixSizeBytes += keptRows.reduce((total, row) => total + row.serialized_bytes, 0);
       // History presentation exposes user/assistant rows, while fresh-thread context
       // also retains paired tool results. The fuse stats above must cover that context.
       keptMessagePositions = keptRows.flatMap((row) => {

--- a/src/config/sessions/session-accessor.sqlite-transcript-parent.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-parent.ts
@@ -6,8 +6,8 @@ import {
 } from "../../infra/kysely-sync.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import type { TranscriptMessageAppendOptions } from "./session-accessor.sqlite-contract.js";
+import { readTranscriptIdentityByEventId } from "./session-accessor.sqlite-read.js";
 import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
-import { readTranscriptIdentityByEventId } from "./session-accessor.sqlite-transcript-store.js";
 import { projectTranscriptNavigationSql } from "./session-model-context-projection.js";
 import {
   isSessionTranscriptLeafControl,

--- a/src/config/sessions/session-accessor.sqlite-transcript-parent.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-parent.ts
@@ -1,5 +1,4 @@
 /** Resolves the effective parent for a transcript message append inside the write transaction. */
-import { sql } from "kysely";
 import {
   executeSqliteQueryTakeFirstSync,
   iterateSqliteQuerySync,
@@ -75,10 +74,9 @@ function readActiveTranscriptAppendParentId(
       .innerJoin("transcript_events as te", (join) =>
         join.onRef("te.session_id", "=", "ti.session_id").onRef("te.seq", "=", "ti.seq"),
       )
-      .select([
+      .select((eb) => [
         "ti.event_type",
-        /* kysely-allow-raw: append-parent resolution consumes navigation, never native replay bodies. */
-        projectTranscriptNavigationSql(sql<string>`te.event_json`).as("event_json"),
+        projectTranscriptNavigationSql(eb.ref("te.event_json")).as("event_json"),
       ])
       .where("ti.session_id", "=", sessionId)
       .orderBy("ti.seq", "desc")
@@ -94,8 +92,7 @@ function readActiveTranscriptAppendParentId(
           database.db,
           db
             .selectFrom("transcript_events")
-            /* kysely-allow-raw: tolerant tree reconstruction retains only navigation fields. */
-            .select(projectTranscriptNavigationSql(sql<string>`event_json`).as("event_json"))
+            .select((eb) => projectTranscriptNavigationSql(eb.ref("event_json")).as("event_json"))
             .where("session_id", "=", sessionId)
             .orderBy("seq", "asc"),
         ),

--- a/src/config/sessions/session-accessor.sqlite-transcript-parent.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-parent.ts
@@ -1,9 +1,19 @@
 /** Resolves the effective parent for a transcript message append inside the write transaction. */
-import { executeSqliteQueryTakeFirstSync } from "../../infra/kysely-sync.js";
+import { sql } from "kysely";
+import {
+  executeSqliteQueryTakeFirstSync,
+  iterateSqliteQuerySync,
+} from "../../infra/kysely-sync.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import type { TranscriptMessageAppendOptions } from "./session-accessor.sqlite-contract.js";
 import { getSessionKysely } from "./session-accessor.sqlite-scope.js";
-import { readActiveTranscriptAppendParentId } from "./session-accessor.sqlite-transcript-store.js";
+import { readTranscriptIdentityByEventId } from "./session-accessor.sqlite-transcript-store.js";
+import { projectTranscriptNavigationSql } from "./session-model-context-projection.js";
+import {
+  isSessionTranscriptLeafControl,
+  parseSessionTranscriptTreeEntry,
+} from "./transcript-tree.js";
+import { resolveVisibleTranscriptAppendParentId } from "./transcript-visible-events.js";
 
 export function resolveTranscriptMessageAppendParent<TMessage>(
   database: OpenClawAgentDatabase,
@@ -51,4 +61,75 @@ export function resolveTranscriptMessageAppendParent<TMessage>(
     ancestorId = row.parent_id;
   }
   return options.parentId;
+}
+
+function readActiveTranscriptAppendParentId(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+): string | null {
+  const db = getSessionKysely(database.db);
+  const latest = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("transcript_event_identities as ti")
+      .innerJoin("transcript_events as te", (join) =>
+        join.onRef("te.session_id", "=", "ti.session_id").onRef("te.seq", "=", "ti.seq"),
+      )
+      .select([
+        "ti.event_type",
+        /* kysely-allow-raw: append-parent resolution consumes navigation, never native replay bodies. */
+        projectTranscriptNavigationSql(sql<string>`te.event_json`).as("event_json"),
+      ])
+      .where("ti.session_id", "=", sessionId)
+      .orderBy("ti.seq", "desc")
+      .limit(1),
+  );
+  if (!latest) {
+    return null;
+  }
+  const resolveFromNavigation = () =>
+    resolveVisibleTranscriptAppendParentId(
+      Array.from(
+        iterateSqliteQuerySync(
+          database.db,
+          db
+            .selectFrom("transcript_events")
+            /* kysely-allow-raw: tolerant tree reconstruction retains only navigation fields. */
+            .select(projectTranscriptNavigationSql(sql<string>`event_json`).as("event_json"))
+            .where("session_id", "=", sessionId)
+            .orderBy("seq", "asc"),
+        ),
+        (row) => JSON.parse(row.event_json) as unknown,
+      ),
+    );
+  try {
+    const event = JSON.parse(latest.event_json) as unknown;
+    const treeEntry = parseSessionTranscriptTreeEntry(event);
+    if (!treeEntry) {
+      return resolveFromNavigation();
+    }
+    if (latest.event_type !== "leaf") {
+      return treeEntry.appendParentId;
+    }
+    const leafReferencesKnown =
+      treeEntry.leafId !== undefined &&
+      transcriptTreeReferenceExists(database, sessionId, treeEntry.leafId) &&
+      transcriptTreeReferenceExists(database, sessionId, treeEntry.appendParentId);
+    if (isSessionTranscriptLeafControl(event) && leafReferencesKnown) {
+      return treeEntry.appendParentId;
+    }
+  } catch {
+    // Fall through to the tolerant full-tree resolver.
+  }
+  return resolveFromNavigation();
+}
+
+function transcriptTreeReferenceExists(
+  database: OpenClawAgentDatabase,
+  sessionId: string,
+  eventId: string | null,
+): boolean {
+  return (
+    eventId === null || readTranscriptIdentityByEventId(database, sessionId, eventId) !== undefined
+  );
 }

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -20,7 +20,6 @@ import type {
 import {
   createTranscriptIdentityReader,
   findTranscriptEventInDatabase,
-  loadTranscriptEventsFromDatabase,
   readTranscriptEventId,
   readTranscriptEventMessage,
   readTranscriptIdentityByEventId,
@@ -46,11 +45,6 @@ import {
 } from "./session-transcript-index.js";
 import { startSessionTranscriptIndexReconcile } from "./session-transcript-reconcile.js";
 import { createSessionTranscriptHeader } from "./transcript-header.js";
-import {
-  isSessionTranscriptLeafControl,
-  parseSessionTranscriptTreeEntry,
-} from "./transcript-tree.js";
-import { resolveVisibleTranscriptAppendParentId } from "./transcript-visible-events.js";
 
 type TranscriptAppendOptions = {
   allowStoredAlias?: boolean;
@@ -335,62 +329,6 @@ export function ensureTranscriptHeader(
     database,
     scope,
     createSessionTranscriptHeader({ cwd, sessionId: scope.sessionId }),
-  );
-}
-
-export function readActiveTranscriptAppendParentId(
-  database: OpenClawAgentDatabase,
-  sessionId: string,
-): string | null {
-  const db = getSessionKysely(database.db);
-  const latest = executeSqliteQueryTakeFirstSync(
-    database.db,
-    db
-      .selectFrom("transcript_event_identities as ti")
-      .innerJoin("transcript_events as te", (join) =>
-        join.onRef("te.session_id", "=", "ti.session_id").onRef("te.seq", "=", "ti.seq"),
-      )
-      .select(["ti.event_type", "te.event_json"])
-      .where("ti.session_id", "=", sessionId)
-      .orderBy("ti.seq", "desc")
-      .limit(1),
-  );
-  if (!latest) {
-    return null;
-  }
-  try {
-    const event = JSON.parse(latest.event_json) as unknown;
-    const treeEntry = parseSessionTranscriptTreeEntry(event);
-    if (!treeEntry) {
-      return resolveVisibleTranscriptAppendParentId(
-        loadTranscriptEventsFromDatabase(database, sessionId),
-      );
-    }
-    if (latest.event_type !== "leaf") {
-      return treeEntry.appendParentId;
-    }
-    const leafReferencesKnown =
-      treeEntry.leafId !== undefined &&
-      transcriptTreeReferenceExists(database, sessionId, treeEntry.leafId) &&
-      transcriptTreeReferenceExists(database, sessionId, treeEntry.appendParentId);
-    if (isSessionTranscriptLeafControl(event) && leafReferencesKnown) {
-      return treeEntry.appendParentId;
-    }
-  } catch {
-    // Fall through to the tolerant full-tree resolver.
-  }
-  return resolveVisibleTranscriptAppendParentId(
-    loadTranscriptEventsFromDatabase(database, sessionId),
-  );
-}
-
-function transcriptTreeReferenceExists(
-  database: OpenClawAgentDatabase,
-  sessionId: string,
-  eventId: string | null,
-): boolean {
-  return (
-    eventId === null || readTranscriptIdentityByEventId(database, sessionId, eventId) !== undefined
   );
 }
 

--- a/src/config/sessions/session-model-context-projection.ts
+++ b/src/config/sessions/session-model-context-projection.ts
@@ -1,0 +1,109 @@
+import { sql, type RawBuilder } from "kysely";
+import {
+  DEFAULT_MISSING_TOOL_RESULT_TEXT,
+  SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY,
+} from "../../../packages/agent-core/src/harness/session/tool-result-pairing.js";
+import { MODEL_CONTEXT_PRIVATE_METADATA_KEYS } from "../../shared/model-context-message.js";
+
+/** Exclude storage-only fields in SQLite, before a row's JSON crosses into JavaScript. */
+export function projectModelContextEventSql(
+  event: RawBuilder<string>,
+  omitCheckpoint: RawBuilder<number>,
+): RawBuilder<string> {
+  const paths = MODEL_CONTEXT_PRIVATE_METADATA_KEYS.map((key) => `$.message.__openclaw.${key}`);
+  /* kysely-allow-raw: query-time JSON projection preserves durable transcript bytes. */
+  const projected = sql<string>`json_remove(${event}, ${sql.join(paths)})`;
+  /* kysely-allow-raw: tool result details are not model input; other details can be runtime context. */
+  const modelEvent = sql<string>`CASE WHEN json_extract(${event}, '$.message.role') = 'toolResult'
+    THEN json_remove(${projected}, '$.message.details') ELSE ${projected} END`;
+  // The context owner classifies invalidated prefix checkpoints using the transport
+  // contract. Other replay state must survive, including checkpoints after the cut.
+  /* kysely-allow-raw: exclude invalidated replay before hydrating a retained prefix. */
+  return sql<string>`CASE WHEN ${omitCheckpoint} = 1
+    THEN json_remove(${modelEvent}, '$.message.providerReplay') ELSE ${modelEvent} END`;
+}
+
+function pickJsonObject(value: RawBuilder<string>, keys: readonly string[]): RawBuilder<string> {
+  // json_each distinguishes absent properties from explicit nulls. Preserve JSON
+  // subtypes so booleans and nested navigation facts do not become strings/numbers.
+  /* kysely-allow-raw: narrow JSON member selection, with bound property names. */
+  return sql<string>`(SELECT json_group_object(key, CASE type
+    WHEN 'object' THEN json(value) WHEN 'array' THEN json(value)
+    WHEN 'true' THEN json('true') WHEN 'false' THEN json('false')
+    ELSE value END) FROM json_each(${value}) WHERE key IN (${sql.join(keys)}))`;
+}
+
+const TRANSCRIPT_NAVIGATION_KEYS = [
+  "type",
+  "id",
+  "parentId",
+  "targetId",
+  "appendParentId",
+  "appendMode",
+] as const;
+
+/** Cursor resolution needs only tree facts, even when a row has an opaque body. */
+export function projectTranscriptNavigationSql(event: RawBuilder<string>): RawBuilder<string> {
+  return pickJsonObject(event, TRANSCRIPT_NAVIGATION_KEYS);
+}
+
+/** Lightweight tree/state records; these never serve as persisted transcript evidence. */
+export function projectModelContextNavigationSql(event: RawBuilder<string>): RawBuilder<string> {
+  const entry = pickJsonObject(event, [
+    ...TRANSCRIPT_NAVIGATION_KEYS,
+    "timestamp",
+    "version",
+    "cwd",
+    "firstKeptEntryId",
+    "reason",
+    "tokensBefore",
+    "thinkingLevel",
+    "provider",
+    "modelId",
+    "fromId",
+    "customType",
+    "display",
+    "label",
+    "name",
+  ]);
+  /* kysely-allow-raw: JSON message metadata is selected without content or native replay payloads. */
+  const message = sql<string>`json_extract(${event}, '$.message')`;
+  const messageFacts = pickJsonObject(message, [
+    "role",
+    "provider",
+    "model",
+    "timestamp",
+    "excludeFromContext",
+    "toolCallId",
+    "toolUseId",
+    "tool_call_id",
+    "tool_use_id",
+    "callId",
+    "call_id",
+    "toolName",
+    "isError",
+    "stopReason",
+    "customType",
+    "display",
+  ]);
+  /* kysely-allow-raw: pairing needs call identities, never tool arguments or result bodies. */
+  const calls = sql<string>`(SELECT json_group_array(json_object(
+    'type', json_extract(value, '$.type'), 'id', json_extract(value, '$.id'),
+    'name', json_extract(value, '$.name')))
+    FROM json_each(${event}, '$.message.content') WHERE type = 'object'
+    AND json_extract(value, '$.type') IN ('toolCall', 'toolUse', 'functionCall'))`;
+  /* kysely-allow-raw: pairing prefers real results over synthetic missing-result placeholders. */
+  const synthetic = sql<number>`COALESCE(json_extract(${event}, ${`$.message.details.${SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY}`}), 0) = 1 OR EXISTS (
+    SELECT 1 FROM json_each(${event}, '$.message.content') WHERE type = 'object'
+    AND json_extract(value, '$.type') = 'text' AND json_extract(value, '$.text') = ${DEFAULT_MISSING_TOOL_RESULT_TEXT})`;
+  /* kysely-allow-raw: retain readable empty bodies only for navigation outside the model window. */
+  return sql<string>`CASE json_extract(${event}, '$.type')
+    WHEN 'message' THEN json_set(${entry}, '$.message', json_set(${messageFacts},
+      '$.content', json(${calls}), '$.command', '', '$.output', '',
+      '$.providerReplay', json_object('type', json_extract(${event}, '$.message.providerReplay.type')),
+      '$.details', json_object(${SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY}, json(CASE WHEN (${synthetic}) THEN 'true' ELSE 'false' END))))
+    WHEN 'custom_message' THEN json_set(${entry}, '$.content', json('[]'))
+    WHEN 'compaction' THEN json_set(${entry}, '$.summary', '')
+    WHEN 'branch_summary' THEN json_set(${entry}, '$.summary', '')
+    ELSE ${entry} END`;
+}

--- a/src/config/sessions/session-model-context-projection.ts
+++ b/src/config/sessions/session-model-context-projection.ts
@@ -1,4 +1,4 @@
-import { sql, type RawBuilder } from "kysely";
+import { sql, type Expression, type RawBuilder } from "kysely";
 import {
   DEFAULT_MISSING_TOOL_RESULT_TEXT,
   SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY,
@@ -7,27 +7,23 @@ import { MODEL_CONTEXT_PRIVATE_METADATA_KEYS } from "../../shared/model-context-
 
 /** Exclude storage-only fields in SQLite, before a row's JSON crosses into JavaScript. */
 export function projectModelContextEventSql(
-  event: RawBuilder<string>,
-  omitCheckpoint: RawBuilder<number>,
+  event: Expression<string>,
+  omitCheckpoint: Expression<number>,
 ): RawBuilder<string> {
   const paths = MODEL_CONTEXT_PRIVATE_METADATA_KEYS.map((key) => `$.message.__openclaw.${key}`);
-  /* kysely-allow-raw: query-time JSON projection preserves durable transcript bytes. */
-  const projected = sql<string>`json_remove(${event}, ${sql.join(paths)})`;
-  /* kysely-allow-raw: tool result details are not model input; other details can be runtime context. */
-  const modelEvent = sql<string>`CASE WHEN json_extract(${event}, '$.message.role') = 'toolResult'
+  const projected = /* kysely-allow-raw: query-time JSON projection preserves durable transcript bytes. */ sql<string>`json_remove(${event}, ${sql.join(paths)})`;
+  const modelEvent = /* kysely-allow-raw: tool result details are not model input; other details can be runtime context. */ sql<string>`CASE WHEN json_extract(${event}, '$.message.role') = 'toolResult'
     THEN json_remove(${projected}, '$.message.details') ELSE ${projected} END`;
   // The context owner classifies invalidated prefix checkpoints using the transport
   // contract. Other replay state must survive, including checkpoints after the cut.
-  /* kysely-allow-raw: exclude invalidated replay before hydrating a retained prefix. */
-  return sql<string>`CASE WHEN ${omitCheckpoint} = 1
+  return /* kysely-allow-raw: exclude invalidated replay before hydrating a retained prefix. */ sql<string>`CASE WHEN ${omitCheckpoint} = 1
     THEN json_remove(${modelEvent}, '$.message.providerReplay') ELSE ${modelEvent} END`;
 }
 
-function pickJsonObject(value: RawBuilder<string>, keys: readonly string[]): RawBuilder<string> {
+function pickJsonObject(value: Expression<string>, keys: readonly string[]): RawBuilder<string> {
   // json_each distinguishes absent properties from explicit nulls. Preserve JSON
   // subtypes so booleans and nested navigation facts do not become strings/numbers.
-  /* kysely-allow-raw: narrow JSON member selection, with bound property names. */
-  return sql<string>`(SELECT json_group_object(key, CASE type
+  return /* kysely-allow-raw: narrow JSON member selection, with bound property names. */ sql<string>`(SELECT json_group_object(key, CASE type
     WHEN 'object' THEN json(value) WHEN 'array' THEN json(value)
     WHEN 'true' THEN json('true') WHEN 'false' THEN json('false')
     ELSE value END) FROM json_each(${value}) WHERE key IN (${sql.join(keys)}))`;
@@ -43,12 +39,12 @@ const TRANSCRIPT_NAVIGATION_KEYS = [
 ] as const;
 
 /** Cursor resolution needs only tree facts, even when a row has an opaque body. */
-export function projectTranscriptNavigationSql(event: RawBuilder<string>): RawBuilder<string> {
+export function projectTranscriptNavigationSql(event: Expression<string>): RawBuilder<string> {
   return pickJsonObject(event, TRANSCRIPT_NAVIGATION_KEYS);
 }
 
 /** Lightweight tree/state records; these never serve as persisted transcript evidence. */
-export function projectModelContextNavigationSql(event: RawBuilder<string>): RawBuilder<string> {
+export function projectModelContextNavigationSql(event: Expression<string>): RawBuilder<string> {
   const entry = pickJsonObject(event, [
     ...TRANSCRIPT_NAVIGATION_KEYS,
     "timestamp",
@@ -66,8 +62,7 @@ export function projectModelContextNavigationSql(event: RawBuilder<string>): Raw
     "label",
     "name",
   ]);
-  /* kysely-allow-raw: JSON message metadata is selected without content or native replay payloads. */
-  const message = sql<string>`json_extract(${event}, '$.message')`;
+  const message = /* kysely-allow-raw: JSON message metadata is selected without content or native replay payloads. */ sql<string>`json_extract(${event}, '$.message')`;
   const messageFacts = pickJsonObject(message, [
     "role",
     "provider",
@@ -86,18 +81,15 @@ export function projectModelContextNavigationSql(event: RawBuilder<string>): Raw
     "customType",
     "display",
   ]);
-  /* kysely-allow-raw: pairing needs call identities, never tool arguments or result bodies. */
-  const calls = sql<string>`(SELECT json_group_array(json_object(
+  const calls = /* kysely-allow-raw: pairing needs call identities, never tool arguments or result bodies. */ sql<string>`(SELECT json_group_array(json_object(
     'type', json_extract(value, '$.type'), 'id', json_extract(value, '$.id'),
     'name', json_extract(value, '$.name')))
     FROM json_each(${event}, '$.message.content') WHERE type = 'object'
     AND json_extract(value, '$.type') IN ('toolCall', 'toolUse', 'functionCall'))`;
-  /* kysely-allow-raw: pairing prefers real results over synthetic missing-result placeholders. */
-  const synthetic = sql<number>`COALESCE(json_extract(${event}, ${`$.message.details.${SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY}`}), 0) = 1 OR EXISTS (
+  const synthetic = /* kysely-allow-raw: pairing prefers real results over synthetic missing-result placeholders. */ sql<number>`COALESCE(json_extract(${event}, ${`$.message.details.${SYNTHETIC_MISSING_TOOL_RESULT_DETAIL_KEY}`}), 0) = 1 OR EXISTS (
     SELECT 1 FROM json_each(${event}, '$.message.content') WHERE type = 'object'
     AND json_extract(value, '$.type') = 'text' AND json_extract(value, '$.text') = ${DEFAULT_MISSING_TOOL_RESULT_TEXT})`;
-  /* kysely-allow-raw: retain readable empty bodies only for navigation outside the model window. */
-  return sql<string>`CASE json_extract(${event}, '$.type')
+  return /* kysely-allow-raw: retain readable empty bodies only for navigation outside the model window. */ sql<string>`CASE json_extract(${event}, '$.type')
     WHEN 'message' THEN json_set(${entry}, '$.message', json_set(${messageFacts},
       '$.content', json(${calls}), '$.command', '', '$.output', '',
       '$.providerReplay', json_object('type', json_extract(${event}, '$.message.providerReplay.type')),

--- a/src/config/sessions/session-transcript-read-fence.ts
+++ b/src/config/sessions/session-transcript-read-fence.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { sql } from "kysely";
 import { executeSqliteQueryTakeFirstSync } from "../../infra/kysely-sync.js";
 import type { UserTurnTranscriptAdmissionReceipt } from "../../sessions/user-turn-transcript.types.js";
 import type { OpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
@@ -37,7 +38,7 @@ function resolveSessionTranscriptReadFence(session: {
 }
 
 export function resolveSqliteSessionTranscriptReadFence(params: {
-  database: OpenClawAgentDatabase;
+  database: Pick<OpenClawAgentDatabase, "db" | "path">;
   agentId: string;
   sessionId: string;
   sessionKey?: string;
@@ -84,7 +85,10 @@ export function resolveSqliteSessionTranscriptReadFence(params: {
         "identity.parent_id",
         "active.message_position",
         "rewrite.generation",
-        "event.event_json",
+        /* kysely-allow-raw: validate the admission role without acquiring its private payload. */
+        sql<string>`json_extract(event.event_json, '$.type')`.as("event_type"),
+        /* kysely-allow-raw: admission validation needs the exact role, not the message body. */
+        sql<string>`json_extract(event.event_json, '$.message.role')`.as("message_role"),
       ])
       .where("identity.session_id", "=", params.sessionId)
       .where("identity.event_id", "=", receipt.entryId)
@@ -105,8 +109,7 @@ export function resolveSqliteSessionTranscriptReadFence(params: {
       `Current-turn transcript admission identity changed: ${receipt.entryId}`,
     );
   }
-  const event = JSON.parse(boundary.event_json) as { type?: unknown; message?: { role?: unknown } };
-  if (event.type !== "message" || event.message?.role !== "user") {
+  if (boundary.event_type !== "message" || boundary.message_role !== "user") {
     throw new SessionTranscriptReadFenceError(
       `Current-turn transcript admission is not a user message: ${receipt.entryId}`,
     );

--- a/src/plugins/hooks.ts
+++ b/src/plugins/hooks.ts
@@ -22,6 +22,7 @@ import { recordRuntimeActionDecision } from "../audit/runtime-action-decision.js
 import { copyReplyPayloadMetadata, type ReplyPayload } from "../auto-reply/reply-payload.js";
 import { formatHookErrorForLog } from "../hooks/fire-and-forget.js";
 import { formatErrorMessage } from "../infra/errors.js";
+import { projectModelContextMessages } from "../shared/model-context-message.js";
 import { concatOptionalTextSegments } from "../shared/text/join-segments.js";
 import {
   type GateHookResult,
@@ -835,6 +836,18 @@ export function createHookRunner(
       return undefined;
     }
 
+    // Snapshot only after registration/authority filtering. Handlers in this dispatch
+    // intentionally share its event, while later dispatches and the caller stay isolated.
+    const dispatchEvent =
+      (hookName === "before_prompt_build" || hookName === "agent_turn_prepare") &&
+      "messages" in event &&
+      Array.isArray(event.messages)
+        ? cloneHookIsolationValue(hookName, {
+            ...event,
+            messages: projectModelContextMessages(event.messages),
+          })
+        : event;
+
     logger?.debug?.(`[hooks] running ${hookName} (${selectedHooks.length} handlers, sequential)`);
 
     let result: TResult | undefined;
@@ -845,8 +858,8 @@ export function createHookRunner(
       try {
         const handler = hook.handler as (event: unknown, ctx: unknown) => Promise<TResult>;
         const handlerEvent = policy.isolateEventPerHandler
-          ? cloneHookIsolationValue(hookName, event)
-          : event;
+          ? cloneHookIsolationValue(hookName, dispatchEvent)
+          : dispatchEvent;
         const promise = Promise.resolve(handler(handlerEvent, ctx));
         const timeoutMs = getModifyingHookTimeoutMs(hookName, hook);
         const handlerResult = timeoutMs ? await withHookTimeout(promise, timeoutMs) : await promise;

--- a/src/shared/model-context-message.ts
+++ b/src/shared/model-context-message.ts
@@ -1,0 +1,42 @@
+import type { AgentMessage } from "@openclaw/agent-core";
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+
+// Native replay retains the exact submitted prompt. Model-context consumers already
+// have its visible content; copying this storage-only payload duplicates the prompt.
+export const MODEL_CONTEXT_PRIVATE_METADATA_KEYS = ["upstreamUserText"] as const;
+
+export function stripToolResultDetails(messages: AgentMessage[]): AgentMessage[];
+export function stripToolResultDetails(messages: unknown[]): unknown[];
+export function stripToolResultDetails(messages: unknown[]): unknown[] {
+  let touched = false;
+  const out = messages.map((message) => {
+    const record = asOptionalRecord(message);
+    if (record?.role !== "toolResult" || !("details" in record)) {
+      return message;
+    }
+    const sanitized = { ...record };
+    delete sanitized.details;
+    touched = true;
+    return sanitized;
+  });
+  return touched ? out : messages;
+}
+
+/** A transient view; evidence and persistence readers must retain the original messages. */
+export function projectModelContextMessages(messages: unknown[]): unknown[] {
+  const output: unknown[] = [];
+  for (const message of stripToolResultDetails(messages)) {
+    const record = asOptionalRecord(message);
+    const metadata = asOptionalRecord(record?.["__openclaw"]);
+    if (!metadata || !MODEL_CONTEXT_PRIVATE_METADATA_KEYS.some((key) => key in metadata)) {
+      output.push(message);
+      continue;
+    }
+    const projected = { ...metadata };
+    for (const key of MODEL_CONTEXT_PRIVATE_METADATA_KEYS) {
+      delete projected[key];
+    }
+    output.push({ ...record, __openclaw: projected });
+  }
+  return output;
+}

--- a/src/skills/workshop/experience-review-observation.test-support.ts
+++ b/src/skills/workshop/experience-review-observation.test-support.ts
@@ -7,12 +7,12 @@ import { readExperienceReviewMessageText } from "./experience-review-message-tex
 export async function observeExperienceReview(run: () => Promise<void>) {
   let session: SessionManager | undefined;
   const requests: Array<{ toolNames: string[]; outputs: unknown[] }> = [];
-  const fromEntries = SessionManager.fromEntries.bind(SessionManager);
+  const openModelContext = SessionManager.openModelContext.bind(SessionManager);
   const createEgressObserver = responsesEgress.createResponsesPromptEgressObserver;
   // Keep the actual runner and transport. Silent reviews suppress public assistant events;
   // the detached transcript and final provider request own the facts this smoke needs.
-  const sessionSpy = vi.spyOn(SessionManager, "fromEntries").mockImplementation((...args) => {
-    session = fromEntries(...args);
+  const sessionSpy = vi.spyOn(SessionManager, "openModelContext").mockImplementation((...args) => {
+    session = openModelContext(...args);
     return session;
   });
   const providerSpy = vi

--- a/src/skills/workshop/experience-review.apply.test.ts
+++ b/src/skills/workshop/experience-review.apply.test.ts
@@ -6,10 +6,12 @@ import { resolveSessionLane } from "../../agents/embedded-agent-runner/lanes.js"
 import type { EmbeddedForegroundPromptContext } from "../../agents/embedded-agent-runner/run/params.js";
 import { resolveSessionBoundaryPromptCacheKey } from "../../agents/embedded-agent-runner/run/session-boundary-prompt-cache-key.js";
 import type { EmbeddedAgentRunResult } from "../../agents/embedded-agent-runner/types.js";
+import { SessionManager } from "../../agents/sessions/index.js";
 import { runWithCanonicalSkillWorkspace } from "../../agents/skill-workshop-workspace-context.js";
 import { createSkillWorkshopTool } from "../../agents/tools/skill-workshop-tool.js";
 import { emitAgentEvent, onAgentRuntimeEvent } from "../../infra/agent-events.js";
 import { getAgentRunContext } from "../../infra/agent-run-registry.js";
+import * as agentRunRegistry from "../../infra/agent-run-registry.js";
 import { enqueueCommandInLane } from "../../process/command-queue.js";
 import {
   isGatewaySubordinateWorkAdmissionClosed,
@@ -40,8 +42,7 @@ vi.mock("../../agents/run-session-target.js", () => ({
 }));
 vi.mock("../../agents/sessions/index.js", () => ({
   SessionManager: {
-    open: vi.fn(() => ({ getEntries: () => [] })),
-    fromEntries: vi.fn(() => ({})),
+    openModelContext: vi.fn(() => ({})),
   },
 }));
 
@@ -76,6 +77,40 @@ afterEach(async () => {
 });
 
 describe("experience review auto apply", () => {
+  it("records acquisition failure and releases its registered review", async () => {
+    const workspaceDir = await tempDirs.make("openclaw-experience-read-failure-");
+    const registration = vi.spyOn(agentRunRegistry, "registerAgentRunContext");
+    vi.spyOn(SessionManager, "openModelContext").mockImplementationOnce(() => {
+      throw new Error("synthetic acquisition failure");
+    });
+    try {
+      await expect(
+        runSkillExperienceReview(
+          {
+            ctx: {
+              sessionId: "foreground-session",
+              sessionKey: "agent:main:read-failure",
+              workspaceDir,
+              modelProviderId: "openai",
+              modelId: "gpt-test",
+              foregroundPromptContext: foregroundPromptContext(workspaceDir),
+            },
+            config: { skills: { workshop: { autonomous: { mode: "propose" } } } },
+          },
+          { getCurrentConfig: () => ({}) },
+        ),
+      ).rejects.toThrow("synthetic acquisition failure");
+      expect(runEmbeddedAgent).not.toHaveBeenCalled();
+      expect(registration).toHaveBeenCalledOnce();
+      expect(getAgentRunContext(registration.mock.calls[0]![0])).toBeUndefined();
+      expect(Object.values(readSkillReviewOutcomes().experienceReviews)[0]).toMatchObject({
+        outcome: "failed",
+        error: "Error: synthetic acquisition failure",
+      });
+    } finally {
+      registration.mockRestore();
+    }
+  });
   it("does not occupy the foreground session lane", async () => {
     const workspaceDir = await tempDirs.make("openclaw-experience-session-lane-");
     const foregroundSessionKey = "agent:main:main";

--- a/src/skills/workshop/experience-review.e2e.test.ts
+++ b/src/skills/workshop/experience-review.e2e.test.ts
@@ -1,7 +1,8 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import type { ServerResponse } from "node:http";
 import { text as readText } from "node:stream/consumers";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   writeOpenAiResponsesSse,
   writeOpenAiResponsesText,
@@ -9,6 +10,7 @@ import {
 import { loadAgentRuntimePluginRegistryHandle } from "../../agents/runtime-plugins.js";
 import { sanitizeToolUseResultPairingForModel } from "../../agents/session-transcript-repair.js";
 import { withServer } from "../../plugin-sdk/test-helpers/http-test-server.js";
+import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -130,6 +132,12 @@ describe("Workshop experience review through the real provider and tool owners",
           const workspaceDir = await tempDirs.make(`workshop-contract-${scenario}-`);
           const runId = `owner-contract-${scenario}`;
           const messages = scenario === "interrupted" ? interruptedMessages() : positiveMessages();
+          const privateMarker = "synthetic-workshop-native-payload:";
+          if (scenario === "nothing") {
+            Object.assign(messages[0]!, {
+              __openclaw: { upstreamUserText: privateMarker + "x".repeat(2 * 1024 * 1024) },
+            });
+          }
           const replay = sanitizeToolUseResultPairingForModel(messages, true);
           const candidate = await createExperienceReviewCandidate(runId, messages, {
             workspaceDir,
@@ -141,20 +149,46 @@ describe("Workshop experience review through the real provider and tool owners",
           // Load the real provider plugin before entering the review lane, as the live proof does.
           loadAgentRuntimePluginRegistryHandle({ config: candidate.config ?? {}, workspaceDir });
           const outcomesBefore = new Set(Object.keys(readSkillReviewOutcomes().experienceReviews));
+          const database = openOpenClawAgentDatabase({ agentId: "main" });
+          const foregroundFingerprint = () => {
+            const hash = createHash("sha256");
+            for (const row of database.db
+              .prepare("SELECT event_json FROM transcript_events WHERE session_id = ? ORDER BY seq")
+              .iterate(candidate.ctx.sessionId!)) {
+              hash.update(String(row.event_json));
+            }
+            return hash.digest("hex");
+          };
+          const storedBefore = foregroundFingerprint();
           const startedAt = Date.now();
+          const originalParse = JSON.parse;
+          let privateAcquisitionBytes = 0;
+          const parseSpy = vi.spyOn(JSON, "parse").mockImplementation((text, reviver) => {
+            if (typeof text === "string" && text.includes(privateMarker)) {
+              privateAcquisitionBytes += text.length;
+            }
+            return originalParse(text, reviver);
+          });
           const run = observeExperienceReview(() =>
             runSkillExperienceReview(candidate, {
               getCurrentConfig: () => candidate.config ?? {},
             }),
           );
           let observation: Awaited<ReturnType<typeof observeExperienceReview>> | undefined;
-          if (scenario === "failed") {
-            await expect(run).rejects.toThrow(
-              "provider rejected the request schema or tool payload",
-            );
-          } else {
-            observation = await run;
+          try {
+            if (scenario === "failed") {
+              await expect(run).rejects.toThrow(
+                "provider rejected the request schema or tool payload",
+              );
+            } else {
+              observation = await run;
+            }
+          } finally {
+            parseSpy.mockRestore();
           }
+
+          expect(privateAcquisitionBytes).toBe(0);
+          expect(foregroundFingerprint()).toBe(storedBefore);
 
           expect(handlerErrors).toEqual([]);
           expect(requests).toHaveLength(scenario === "proposed" || scenario === "rejected" ? 2 : 1);

--- a/src/skills/workshop/experience-review.ts
+++ b/src/skills/workshop/experience-review.ts
@@ -410,27 +410,6 @@ async function runSkillExperienceReviewInner(
     remaining: 1,
     readSkillHashes: new Map(),
   };
-  const foregroundSessionTarget = await resolveAgentRunSessionTarget({
-    agentId: foregroundPromptContext.agentId,
-    config,
-    sessionId: foregroundSessionId,
-    sessionKey: foregroundSessionKey,
-    missingSessionKey: "resolve-existing",
-  });
-  const foregroundSession = SessionManager.open(foregroundSessionTarget, workspaceDir);
-  const detachedSession = SessionManager.fromEntries(foregroundSession.getEntries(), workspaceDir);
-  const { listWritableWorkspaceSkillSummaries } = await import("./workspace-skill-read.js");
-  const existingSkills = listWritableWorkspaceSkillSummaries(workspaceDir, {
-    config,
-    agentId: foregroundPromptContext.agentId,
-  });
-  const { runEmbeddedAgent } = await import("../../agents/embedded-agent.js");
-  const preparedRunAdmission = prepareSystemAgentRunAdmission(
-    config,
-    runId,
-    foregroundPromptContext.agentId,
-    "skill-workshop.experience",
-  );
   const attemptedAtMs = Date.now();
   let outcome: "applied" | "proposed" | "nothing";
   let proposalId: string | undefined;
@@ -447,6 +426,28 @@ async function runSkillExperienceReviewInner(
     projectSessionMessages: false,
   });
   try {
+    const foregroundSessionTarget = await resolveAgentRunSessionTarget({
+      agentId: foregroundPromptContext.agentId,
+      config,
+      sessionId: foregroundSessionId,
+      sessionKey: foregroundSessionKey,
+      missingSessionKey: "resolve-existing",
+    });
+    const detachedSession = SessionManager.openModelContext(foregroundSessionTarget, {
+      cwd: workspaceDir,
+    });
+    const { listWritableWorkspaceSkillSummaries } = await import("./workspace-skill-read.js");
+    const existingSkills = listWritableWorkspaceSkillSummaries(workspaceDir, {
+      config,
+      agentId: foregroundPromptContext.agentId,
+    });
+    const { runEmbeddedAgent } = await import("../../agents/embedded-agent.js");
+    const preparedRunAdmission = prepareSystemAgentRunAdmission(
+      config,
+      runId,
+      foregroundPromptContext.agentId,
+      "skill-workshop.experience",
+    );
     let embeddedResult: Awaited<ReturnType<typeof runEmbeddedAgent>>;
     try {
       const run = () =>


### PR DESCRIPTION
Closes #133738 — prompt preparation and detached experience review copy storage-only history payloads.

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer branch and remains editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where users continuing long native Codex conversations, or running detached Skill Workshop experience reviews, would incur large memory spikes when the stored transcript contains substantial native replay metadata. Model-only readers acquired those private payloads before selecting context, and prompt preparation could clone them even when no message-consuming hook existed.

The issue and proof use synthetic data only. This change repairs demonstrated allocation boundaries; it does not attribute or claim to resolve every separately reported Gateway OOM.

## Why This Change Was Made

The session owner now supplies a detached model-context view that selects the existing branch/reset/compaction window before hydrating payloads. Query-time SQLite projection excludes storage-only native prompt text and tool-result details, and skips invalidated retained-prefix replay checkpoints. It reuses the existing tree, context-window, and occurrence-based tool-pairing algorithms rather than introducing a history cutoff.

Prompt-hook dispatch owns isolated snapshots after actual registration filtering. Registrations within a dispatch retain their existing ordering and shared-event behavior; separate prepare, ordinary, authorized, and rebuild dispatches cannot mutate the caller's history. Codex no longer clones eagerly, and Workshop no longer opens and clones the complete foreground transcript. Retained-tail statistics and append-parent resolution also use narrow navigation facts while preserving exact raw-byte accounting.

Native mirror attestations, fork drift validation, settled-turn replay, exports, and doctor operations retain full-fidelity evidence. No stored conversation bytes, schema, persisted projection, configuration, dependency, heap/timeout limit, or feature-enable setting changes.

Production LOC after main integration and CI repair: **+535/-143 (net +392)**. Tests/support: **+876/-12 (net +864)**. Growth establishes the missing read/projection ownership boundary and equivalent SQL/in-memory field contract; existing selection algorithms are reused and the raw acquire-then-clone paths are removed. The assertion baseline only shrinks.

## User Impact

Long-history prompt preparation and detached reviews avoid allocating private native replay text that is not part of their model context. Hook isolation, visible content, reset/compaction retained tails, tool pairing, sender/media/taint facts, and admission fencing remain intact. Ordinary acquisition failures in experience review now receive the existing recorded failure outcome and cleanup.

Full-fidelity native evidence readers, direct legacy file-only reads, BTW captured-leaf reads, and CLI reseed-budget paths keep their different contracts. This PR does not silently migrate them or promise constant memory for arbitrarily large genuine model-visible output.

## Evidence

### Failing before, passing after

- Four actual Codex attempt cases cover no hooks, heartbeat-only, ordinary prompt hooks, and authorized-only hooks. The pre-fix canonical SQLite path parsed 2,097,714 private JSON characters per case from a one-MiB fixture; repaired cases observe **zero private parse/clone bytes**. No-hook and heartbeat-only cases clone no history.
- Shared hook regressions initially showed immediate nested mutation escaping into caller history. The repaired dispatcher preserves caller and subsequent-dispatch isolation, including retained references.
- Real detached experience review against a local synthetic HTTP provider initially parsed 2,097,490 private JSON characters. The repaired path observes zero and preserves the foreground stored-data fingerprint.
- Retained-tail statistics initially parsed 1,048,821 private JSON characters; repaired reads preserve byte/count facts without acquiring that payload.
- Reset/compaction checkpoint cases initially acquired 1,049,250 obsolete JSON characters; the repaired reader excludes invalidated checkpoints while preserving valid post-boundary replay.
- Independent parity verification caught an intermediate mismatch for explicitly retained reset messages marked `excludeFromContext`. The acquisition owner now follows the existing reset-kept contract; all nine user/assistant/paired-result cases across reset, compaction, and ordinary history pass.

The independent pre-integration boundary rerun passed **98 tests**, covering selected context, retained tools, opaque/leaf ancestry, admission tampering and post-admission reset/compaction, incognito, absent/stale index state, cursor cleanup, hook isolation, native fingerprints, settled-turn matching, and fork drift rejection. After integrating main, the expanded boundary run passed **107 tests**, plus **six actual Codex attempt cases**. This includes main's sparse retained-tail batching and transcript import/store coverage. All five synthetic HTTP Workshop E2E outcomes also passed before integration: proposal, no-op, interrupted, rejected, and failed. The last retained-reset predicate correction was reverified with focused tests rather than another unrelated full runtime preparation.

```bash
node scripts/run-vitest.mjs src/agents/sessions/session-manager-model-context.test.ts src/config/sessions/session-accessor.sqlite-bounded-context.test.ts src/agents/harness/prompt-compaction-hook-helpers.test.ts extensions/codex/src/app-server/session-history.test.ts extensions/codex/src/app-server/settled-turn-context.test.ts extensions/codex/src/app-server/upstream-fork-boundary.test.ts src/config/sessions/session-accessor.sqlite-history-events.test.ts src/config/sessions/session-accessor.sqlite-import.test.ts src/config/sessions/session-accessor.sqlite-transcript-store.test.ts
```

```bash
node scripts/run-vitest.mjs extensions/codex/src/app-server/run-attempt.test.ts -t 'keeps private native history|applies before_prompt_build|rebuilding'
```

```bash
node scripts/run-vitest.mjs src/skills/workshop/experience-review.e2e.test.ts
```

Focused core/plugin production and affected test types, type-aware lint, formatting, assertion/max-lines/schema guards, and `git diff --check` passed before integration. Independent architecture checks found zero runtime import cycles and passed the session-accessor, transcript-reader, and SQLite transaction boundaries. These are scoped checks, not a claim that the entire repository suite ran locally.

Integration base: `237f23b4589795a91dc63778c41d27624bb336dc`. Main's retained-history batching (#133680), import identity query compilation reuse (#133689), and legacy codec validation optimization (#133641) are preserved. The new append-parent reader now imports identity lookup from the canonical `session-accessor.sqlite-read.ts` owner. The expected stale import failed the post-rebase core typecheck with TS2459 before that correction; the same typecheck then passed. Post-integration focused lint, formatting, and `git diff --check` passed.

Independent isolated Codex autoreview of the complete integrated candidate returned `scoped-clean` with no findings at its **P0-only** reporting threshold. This is not an all-priority review certificate.

`pnpm build` passed before integration (22m47s) and again on the corrected integrated candidate (5m14s). Post-integration commands also passed:

```bash
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile .artifacts/tsgo-cache/core.tsbuildinfo
```

```bash
node scripts/run-oxlint.mjs src/config/sessions/session-accessor.sqlite-transcript-parent.ts src/config/sessions/session-accessor.sqlite-reset-window.ts src/config/sessions/session-accessor.sqlite-transcript-store.ts
```

```bash
node_modules/.bin/oxfmt --check src/config/sessions/session-accessor.sqlite-transcript-parent.ts
```

```bash
git diff --check
```

### CI repair

[Initial exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33352879877) failed only the runtime-topology architecture job and its aggregate gate. The Kysely guard identified raw column references and SQLite JSON exceptions attached to declarations rather than the primitive expressions.

The correction passes schema-checked `eb.ref(...)` column expressions into the projection owner, which accepts Kysely `Expression<string>` and retains typed results. It removes raw identifier snippets; the eight JSON primitive templates, interpolations, and value-parameter order are unchanged. Existing narrowly justified SQLite JSON exceptions now attach directly to their expressions. No casts, guard changes, or allowlist/baseline expansion were used. The formerly failing `pnpm lint:kysely`, full `pnpm check:architecture`, 113 boundary/native tests, core typecheck, focused lint/formatting, and `pnpm build` (5m16s) pass after the correction. Fresh isolated review of the correction is also `scoped-clean` at P0 with no findings.

```bash
pnpm lint:kysely
```

```bash
pnpm check:architecture
```

Final head: `83fd69c4bfbc01eaa07ce6a3b5ee38218f99877e`. [Exact-head pull-request CI run 33354235862](https://github.com/openclaw/openclaw/actions/runs/33354235862) completed **success** on attempt 1, including the required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33354235862/job/99375380581), repaired [runtime architecture gate](https://github.com/openclaw/openclaw/actions/runs/33354235862/job/99373389480), [built artifacts](https://github.com/openclaw/openclaw/actions/runs/33354235862/job/99373388999), and [SQLite session lifecycle proof](https://github.com/openclaw/openclaw/actions/runs/33354235862/job/99374020669). Native prepare and merge completed without rewriting this head; landed as [c09f1360bbe49e3f8cf28926c47e4998b6d37bf0](https://github.com/openclaw/openclaw/commit/c09f1360bbe49e3f8cf28926c47e4998b6d37bf0). A post-merge rerun on that exact commit passed 38 model-context, transcript-store/import, and retained-tail tests, including the overlapping mainline identity-insert optimization. [Issue closure proof and the post-merge command](https://github.com/openclaw/openclaw/issues/133738#issuecomment-5473520820) are recorded; the issue is closed as completed.

### Synthetic allocation measurement

Fixed 24 small visible user messages; only native metadata grows to 1 MiB per message (24 MiB aggregate). Fresh Node v26.8.1 processes; imports and fixture seeding are outside the timer. No heap limit was raised. Baseline is source `0b392310b92d90bd37b884c4469b0ec799ad2521`; these samples precede mechanical main integration.

| Measurement | Before | Repaired |
| --- | ---: | ---: |
| JS heap growth during acquisition | 49.92 MiB | 0.82 MiB |
| RSS growth during acquisition | 45.56 MiB | 3.13 MiB |
| Acquisition time | 23.21 ms | 50.84 ms |
| Visible messages returned | 24 | 24 |

These are individual synthetic samples, not a production peak/soak guarantee. SQLite still processes stored bytes, so query-time projection spends additional CPU to avoid aggregate JavaScript allocation.

### Native contract inspection and limits

Personally inspected the sibling Codex source and then the public source for the pinned `@openai/codex` **0.151.0** tag, which resolves to `78c290807ce710180111df227df3b7a4fe845452`:

- [Resume/fork protocol](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/app-server-protocol/src/protocol/v2/thread.rs#L321-L600).
- [Fork snapshot ownership](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/core/src/thread_manager.rs#L1232-L1393) and [interruption semantics](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/core/src/thread_manager.rs#L2159-L2336).
- [Canonical fork boundary application](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/app-server/src/request_processors/thread_processor.rs#L4651-L4965).

Those contracts require exact native evidence; the model-only view does not replace it. No native protocol behavior changed and no live native-provider request is claimed as proof. The real runner/SQLite proof uses synthetic fixtures and a local HTTP provider. No production state was accessed or modified, and no historical crash caller or production stability soak is claimed.

### ClawSweeper review disposition

The [review and rank-up moves](https://github.com/openclaw/openclaw/pull/133753#issuecomment-5473276954) have been read. They contain no concrete code or security finding, but request these maintainer decisions and evidence:

- **Prompt-hook contract:** The documented model-context snapshot is the intended contract for this repair. Public hook types describe messages prepared for the run, not full native transcript evidence; the existing [tool-result contract](https://docs.openclaw.ai/plugins/hooks#tool-result-persistence) puts model-visible output in `content`, not `details`. This deliberately narrows incidental storage-field exposure. Third-party prompt hooks reading private `upstreamUserText` or tool-result `details` may need adjustment. No installed-plugin or production inventory was inspected, and universal backward compatibility is not claimed. Full-fidelity evidence readers and tool/persistence hook owners are unchanged.
- **Production growth:** The final net +392 production lines establish a missing transient read owner that selects navigation, branch/reset/compaction context, and admission before payload hydration. Existing tree/window/pairing algorithms remain canonical. Stripping or wrapping the raw reader afterward preserves the demonstrated allocation failure; globally reducing evidence breaks native fork/replay; arbitrary cutoffs change context semantics. Old eager-clone and full-foreground-acquisition paths are removed rather than kept as parallel fallbacks.
- **Codex contract:** Personal sibling-source inspection and the pinned 0.151.0 source checks linked above satisfy this inspection step. These are source-contract checks, not live native-provider proof.
- **Persistent-data heuristic:** No schema, index, migration, retention, or write-format change occurs. This is query-time `SELECT` projection and read-snapshot ownership, with exact stored-byte fingerprint regression proof. A data migration would be inappropriate.

Exact-head CI remains a separate gate and is not inferred from these dispositions. No additional code change is required by the published rank-up moves.

Docs: [session management](https://docs.openclaw.ai/reference/session-management-compaction), [plugin hooks](https://docs.openclaw.ai/plugins/hooks), and [self-learning](https://docs.openclaw.ai/tools/self-learning).
