### PR TITLE
refactor(meetings): share command argv splitting

### DIFF
--- a/src/meeting-bot/command-argv.ts
+++ b/src/meeting-bot/command-argv.ts
@@ -1,0 +1,7 @@
+export function splitCommandArgv(argv: readonly string[], commandLabel: string) {
+  const [command, ...args] = argv;
+  if (!command) {
+    throw new Error(`${commandLabel} must not be empty`);
+  }
+  return { command, args };
+}

--- a/src/meeting-bot/node-host.audio.test.ts
+++ b/src/meeting-bot/node-host.audio.test.ts
@@ -164,8 +164,8 @@ describe("meeting node host audio backend", () => {
     const prepareAudio = vi.fn(async () => ({
       backend: "pipewire-pulse" as const,
       deviceLabel: "OpenClaw Meeting Audio",
-      inputCommand: ["parec", "--node-default"],
-      outputCommand: ["pacat", "--node-default"],
+      inputCommand: ["parec", "--device", "input name", ""],
+      outputCommand: ["pacat", "--device", "output name", ""],
     }));
     const host = createHost({ prepareAudio });
 
@@ -192,12 +192,22 @@ describe("meeting node host audio backend", () => {
       },
       10_000,
     );
-    expect(childProcessMocks.spawn).toHaveBeenNthCalledWith(1, "pacat", ["--node-default"], {
-      stdio: ["pipe", "ignore", "pipe"],
-    });
-    expect(childProcessMocks.spawn).toHaveBeenNthCalledWith(2, "parec", ["--node-default"], {
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    expect(childProcessMocks.spawn).toHaveBeenNthCalledWith(
+      1,
+      "pacat",
+      ["--device", "output name", ""],
+      {
+        stdio: ["pipe", "ignore", "pipe"],
+      },
+    );
+    expect(childProcessMocks.spawn).toHaveBeenNthCalledWith(
+      2,
+      "parec",
+      ["--device", "input name", ""],
+      {
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    );
     expect(started).toMatchObject({
       audioBackend: "pipewire-pulse",
       audioDeviceLabel: "OpenClaw Meeting Audio",
@@ -260,6 +270,25 @@ describe("meeting node host audio backend", () => {
       audioBackend: "pipewire-pulse",
       audioDeviceLabel: "OpenClaw Meeting Audio",
     });
+    expect(childProcessMocks.spawn).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { name: "input", inputCommand: [], outputCommand: ["play"] },
+    { name: "output", inputCommand: ["capture"], outputCommand: [] },
+  ])("rejects an empty $name command before spawning", async ({ inputCommand, outputCommand }) => {
+    const host = createHost({
+      prepareAudio: vi.fn(async () => ({
+        backend: "pipewire-pulse" as const,
+        deviceLabel: "OpenClaw Meeting Audio",
+        inputCommand,
+        outputCommand,
+      })),
+    });
+
+    await expect(invokeHost(host, { ...AUDIO_START_PARAMS, launch: false })).rejects.toThrow(
+      "audio command must not be empty",
+    );
     expect(childProcessMocks.spawn).not.toHaveBeenCalled();
   });
 });

--- a/src/meeting-bot/node-host.ts
+++ b/src/meeting-bot/node-host.ts
@@ -7,6 +7,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import type { MeetingAudioBackendSelection, MeetingAudioRuntime } from "./audio-backend.js";
 import { decodeMeetingAudioBase64 } from "./audio-base64.js";
 import { terminateMeetingBridgeProcess } from "./bridge-process.js";
+import { splitCommandArgv } from "./command-argv.js";
 import {
   prepareMeetingNodeAudio,
   readMeetingNodeCommand,
@@ -97,10 +98,7 @@ function readOutputGeneration(value: unknown): number | undefined {
 }
 
 function runCommandWithTimeout(argv: string[], timeoutMs: number) {
-  const [command, ...args] = argv;
-  if (!command) {
-    throw new Error("command must not be empty");
-  }
+  const { command, args } = splitCommandArgv(argv, "command");
   const result = spawnSync(command, args, { encoding: "utf8", timeout: timeoutMs });
   const errorMessage = result.error ? formatErrorMessage(result.error) : "";
   const stderr =
@@ -112,14 +110,6 @@ function runCommandWithTimeout(argv: string[], timeoutMs: number) {
     stdout: result.stdout ?? "",
     stderr,
   };
-}
-
-function splitCommand(argv: string[]): { command: string; args: string[] } {
-  const [command, ...args] = argv;
-  if (!command) {
-    throw new Error("audio command must not be empty");
-  }
-  return { command, args };
 }
 
 function waitForInputDrain(
@@ -277,8 +267,8 @@ export function createMeetingNodeHost(options: MeetingNodeHostOptions): {
     url?: string;
     mode?: string;
   }): NodeBridgeSession => {
-    const input = splitCommand(params.inputCommand);
-    const output = splitCommand(params.outputCommand);
+    const input = splitCommandArgv(params.inputCommand, "audio command");
+    const output = splitCommandArgv(params.outputCommand, "audio command");
     const session: NodeBridgeSession = {
       id: `${options.bridgeIdPrefix}${randomUUID()}`,
       url: params.url,

--- a/src/meeting-bot/realtime-local-audio-transport.test.ts
+++ b/src/meeting-bot/realtime-local-audio-transport.test.ts
@@ -51,13 +51,10 @@ function createProcess(params: { stdin?: TestStdin | null; stdout?: EventEmitter
   return proc;
 }
 
-function createTransport(outputStdin: TestStdin, replacementStdin = createStdin(true)) {
-  const output = createProcess({ stdin: outputStdin });
-  const input = createProcess({ stdout: new EventEmitter() });
-  const replacementOutput = createProcess({ stdin: replacementStdin });
-  const spawn = vi.fn().mockReturnValueOnce(output).mockReturnValueOnce(input);
-  spawn.mockReturnValueOnce(replacementOutput);
-  const transport = createLocalMeetingRealtimeAudioTransport({
+function createTransportWith(
+  overrides: Partial<Parameters<typeof createLocalMeetingRealtimeAudioTransport>[0]> = {},
+) {
+  return createLocalMeetingRealtimeAudioTransport({
     bargeInCooldownMs: 0,
     bargeInPeakThreshold: 0,
     bargeInRmsThreshold: 0,
@@ -65,14 +62,56 @@ function createTransport(outputStdin: TestStdin, replacementStdin = createStdin(
     logger: { debug: vi.fn(), warn: vi.fn() } as never,
     logScope: "[meeting]",
     outputCommand: ["play"],
-    spawn: spawn as never,
+    ...overrides,
   });
+}
+
+function createTransport(outputStdin: TestStdin, replacementStdin = createStdin(true)) {
+  const output = createProcess({ stdin: outputStdin });
+  const input = createProcess({ stdout: new EventEmitter() });
+  const replacementOutput = createProcess({ stdin: replacementStdin });
+  const spawn = vi.fn().mockReturnValueOnce(output).mockReturnValueOnce(input);
+  spawn.mockReturnValueOnce(replacementOutput);
+  const transport = createTransportWith({ spawn: spawn as never });
   return { replacementOutput, spawn, transport };
 }
 
 describe("local meeting realtime audio transport", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["input", [], ["play"]],
+    ["output", ["capture"], []],
+  ] as const)("rejects an empty %s command before spawning", (_, inputCommand, outputCommand) => {
+    const spawn = vi.fn();
+
+    expect(() =>
+      createTransportWith({
+        inputCommand: [...inputCommand],
+        outputCommand: [...outputCommand],
+        spawn: spawn as never,
+      }),
+    ).toThrow("audio bridge command must not be empty");
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("keeps empty barge-in validation lazy until monitoring starts", async () => {
+    const output = createProcess({ stdin: createStdin(true) });
+    const input = createProcess({ stdout: new EventEmitter() });
+    const spawn = vi.fn().mockReturnValueOnce(output).mockReturnValueOnce(input);
+    const transport = createTransportWith({
+      bargeInInputCommand: [],
+      spawn: spawn as never,
+    });
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(() => transport.startBargeInMonitor?.(() => false)).toThrow(
+      "audio bridge command must not be empty",
+    );
+    expect(spawn).toHaveBeenCalledTimes(2);
+    await transport.stop();
   });
 
   it("waits for output drain after the child stream backpressures", async () => {
@@ -120,18 +159,24 @@ describe("local meeting realtime audio transport", () => {
       processes.set(command, proc);
       return proc;
     });
-    const transport = createLocalMeetingRealtimeAudioTransport({
-      bargeInCooldownMs: 0,
-      bargeInPeakThreshold: 0,
-      bargeInRmsThreshold: 0,
-      inputCommand: ["capture"],
+    const transport = createTransportWith({
+      inputCommand: ["capture", "--device", "input name", ""],
       logger: { debug, warn: vi.fn() } as never,
-      logScope: "[meeting]",
-      outputCommand: ["play"],
-      bargeInInputCommand: ["barge"],
+      outputCommand: ["play", "--device", "output name", ""],
+      bargeInInputCommand: ["barge", "--device", "barge name", ""],
       spawn: spawn as never,
     });
     transport.startBargeInMonitor?.(() => false);
+
+    expect(spawn).toHaveBeenNthCalledWith(1, "play", ["--device", "output name", ""], {
+      stdio: ["pipe", "ignore", "pipe"],
+    });
+    expect(spawn).toHaveBeenNthCalledWith(2, "capture", ["--device", "input name", ""], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    expect(spawn).toHaveBeenNthCalledWith(3, "barge", ["--device", "barge name", ""], {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
 
     for (const [command, label] of [
       ["play", "audio output"],

--- a/src/meeting-bot/realtime-local-audio-transport.ts
+++ b/src/meeting-bot/realtime-local-audio-transport.ts
@@ -6,6 +6,7 @@ import { onDecodedOutput } from "../process/decoded-output.js";
 import { createSpeechThresholdGate, readPcm16AudioStats } from "../talk/audio-energy.js";
 import { truncateUtf8Suffix } from "../utils/utf8-truncate.js";
 import { terminateMeetingBridgeProcess } from "./bridge-process.js";
+import { splitCommandArgv } from "./command-argv.js";
 import { createMeetingOutputLoopbackVerifier } from "./output-loopback-verifier.js";
 import type { MeetingRealtimeAudioFormat } from "./realtime-audio-format.js";
 import type { MeetingRealtimeAudioTransport } from "./realtime-audio-transport.js";
@@ -56,14 +57,6 @@ type OutputWriteWaiter = {
   release: () => void;
 };
 
-function splitCommand(argv: string[]): { command: string; args: string[] } {
-  const [command, ...args] = argv;
-  if (!command) {
-    throw new Error("audio bridge command must not be empty");
-  }
-  return { command, args };
-}
-
 function attachStderrLineLogger(params: {
   stderr: BridgeProcess["stderr"];
   logger: RuntimeLogger;
@@ -108,8 +101,8 @@ export function createLocalMeetingRealtimeAudioTransport(params: {
   audioFormat?: MeetingRealtimeAudioFormat;
   spawn?: MeetingRealtimeAudioSpawn;
 }): MeetingRealtimeAudioTransport {
-  const input = splitCommand(params.inputCommand);
-  const output = splitCommand(params.outputCommand);
+  const input = splitCommandArgv(params.inputCommand, "audio bridge command");
+  const output = splitCommandArgv(params.outputCommand, "audio bridge command");
   const spawnFn: MeetingRealtimeAudioSpawn =
     params.spawn ?? ((command, args, options) => spawn(command, args, options));
   const spawnOutputProcess = () =>
@@ -320,7 +313,7 @@ export function createLocalMeetingRealtimeAudioTransport(params: {
       if (bargeInInputProcess || stopped) {
         return;
       }
-      const command = splitCommand(params.bargeInInputCommand ?? []);
+      const command = splitCommandArgv(params.bargeInInputCommand ?? [], "audio bridge command");
       const bargeInGate = createSpeechThresholdGate({
         rmsThreshold: params.bargeInRmsThreshold,
         peakThreshold: params.bargeInPeakThreshold,


### PR DESCRIPTION
## What Problem This Solves

The meeting-bot runtime had three independent implementations of the same command-array split and empty-executable validation. Keeping those copies aligned made error text, argument preservation, and validation timing easier to drift across node audio, local audio, and lazy barge-in startup.

## Why This Change Was Made

This maintainer-requested refactor moves the shared invariant into one private `src/meeting-bot` leaf module. Node health/launch commands retain `command must not be empty`; node audio retains `audio command must not be empty`; local audio and barge-in retain `audio bridge command must not be empty`.

The helper preserves executable separation and every trailing argument byte without trimming, filtering, or shell parsing. Local input still validates before output, and an empty barge-in command still fails only when monitoring starts. `configured-node-host.ts` remains unchanged because it intentionally returns a structured command failure instead of throwing.

## User Impact

No intended user-visible behavior change. The meeting audio paths now share one command-array contract, reducing future drift while preserving existing failures and process startup order.

## Evidence

- Focused Vitest: 3 files, 32 tests passed.
- Core changed-file gates: formatting, core and core-test typechecks, changed-file lint, architecture guards, and import-cycle check passed.
- Sparse-worktree caveat: the dead-export scan could not load omitted UI config modules, so the documented deadcode skip was used for the remaining changed-file gates. The native schema guard was rerun after adding its exact omitted tracked file and passed at v15.
- Import cycles: 0 runtime value cycles.
- Autoreview: scoped-clean, patch correct at 0.99 confidence.
- AWS/Linux Crabbox fresh-PR proof: run `run_22d5e789bd11` verified exact head `9da2d8f61a26daffef4587cd2c1376bf91c0f33e`, no instance IAM role, public network without Tailscale, and 3 focused files / 32 tests passed. The task-owned lease was released after the run.
- Codebase-memory MCP was unavailable in this session; exact current source, callers, sibling behavior, tests, history, and live GitHub path searches were inspected instead.
- No open PR matched either affected meeting-bot production path in live GitHub path searches.
- Codex gate inspected directly: `../codex/codex-rs/cli/src/main.rs:220-245` and `../codex/codex-rs/cli/src/main.rs:2840-2870`; those CLI argument/completion paths do not own meeting command spawning.
- Production LOC: +15 / -25, net -10.
- Test LOC: +98 / -24, net +74.
