### PR TITLE
test(macos): remove reintroduced onboarding subset checks

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingViewSmokeTests.swift
@@ -203,23 +203,6 @@ struct OnboardingViewSmokeTests {
             requiresCLIInstall: false) == [0, 1, 9])
     }
 
-    @Test func `fresh local setup installs CLI before inference setup`() {
-        let order = OnboardingView.pageOrder(
-            for: .local,
-            requiresCLIInstall: true)
-
-        #expect(order.firstIndex(of: 2) == 2)
-        #expect(order.firstIndex(of: 3) == 3)
-    }
-
-    @Test func `configured local setup skips CLI install page`() {
-        let order = OnboardingView.pageOrder(
-            for: .local,
-            requiresCLIInstall: false)
-
-        #expect(!order.contains(2))
-    }
-
     @Test func `reopened onboarding preserves configure later selection`() {
         let state = AppState(preview: true)
         state.onboardingSeen = true


### PR DESCRIPTION
## What Problem This Solves

Two onboarding page-order subset tests were removed in #132410 and then reintroduced by #131466. The suite still asserts the complete expected arrays for those exact local-mode inputs.

## Why This Change Was Made

Remove the restored subset checks while keeping the stricter exact-array contract and the ten-scenario installation-ownership test. CLI-before-inference ordering, the configured local flow, remote/set-up-later flows, and instance page selection remain covered.

## User Impact

No native app behavior or UI changes. Two fewer duplicate Swift test executions; production +0/-0 and tests +0/-17.

## Evidence

- Inspected the canonical `OnboardingView.pageOrder` implementation and its instance/layout callers.
- The retained configured-flows case asserts `[0, 1, 2, 3]` and `[0, 1, 3]` for the exact inputs whose subset assertions are deleted.
- Raw commit diffs verify both the earlier deletion and later reintroduction of these same 17 lines.
- Native Swift execution requires the disposable credentialless `macos-swift` CI worker. No app test or local app launch is run on the operator desktop; exact-head native CI must pass before landing.
- The local changed gate passed with the repository-pinned Swift tools, including all seven Node/Vitest macOS tooling shards and the native state-schema guard. This is separate from the native Swift suite.
- Codex autoreview found no accepted findings; the diff removes only the two duplicate tests.
- Exact-head [CI33353388066](https://github.com/openclaw/openclaw/actions/runs/33353388066) passed, including [native macos-swift](https://github.com/openclaw/openclaw/actions/runs/33353388066/job/99370957482), macos-node, and the final CI gate. This satisfies the ClawSweeper native-validation request.
- Test-only change; no changelog or screenshots are required.
