### PR TITLE
test: remove identical core fixture replays

### DIFF
--- a/src/agents/embedded-agent-runner/extra-params.kilocode.test.ts
+++ b/src/agents/embedded-agent-runner/extra-params.kilocode.test.ts
@@ -156,14 +156,6 @@ describe("extra-params: Kilocode kilo-auto/balanced reasoning", () => {
     expect(capturedPayload?.reasoning).toEqual({ effort: "high" });
   });
 
-  it("still normalizes reasoning for Kilocode under restrictive plugins.allow", () => {
-    const capturedPayload = applyAndCaptureReasoning({
-      modelId: "anthropic/claude-sonnet-4",
-    });
-
-    expect(capturedPayload?.reasoning).toEqual({ effort: "high" });
-  });
-
   it("does not inject reasoning.effort for x-ai models", () => {
     const capturedPayload = applyAndCaptureReasoning({
       modelId: "x-ai/grok-3",

--- a/src/gateway/origin-check.test.ts
+++ b/src/gateway/origin-check.test.ts
@@ -96,15 +96,6 @@ describe("checkBrowserOrigin", () => {
       expected: { ok: false as const, reason: "origin not allowed" },
     },
     {
-      name: "rejects same-origin loopback host matches for non-local clients",
-      input: {
-        requestHost: "127.0.0.1:18789",
-        origin: "http://127.0.0.1:18789",
-        isLocalClient: false,
-      },
-      expected: { ok: false as const, reason: "origin not allowed" },
-    },
-    {
       name: "accepts trimmed lowercase-normalized allowlist matches",
       input: {
         requestHost: "gateway.example.com:18789",

--- a/src/gateway/server/hooks.early-failure.test.ts
+++ b/src/gateway/server/hooks.early-failure.test.ts
@@ -228,13 +228,6 @@ describe("gateway hook early-failure recovery", () => {
       events: 0,
     },
     {
-      name: "does not duplicate message-tool delivery",
-      outcome: { status: "ok", delivered: true, deliveryAttempted: true },
-      level: "info",
-      deliver: true,
-      events: 0,
-    },
-    {
       name: "leaves missing delivery facts unknown for deliver false",
       outcome: { status: "ok" },
       level: "info",

--- a/src/scripts/test-projects.test.ts
+++ b/src/scripts/test-projects.test.ts
@@ -293,11 +293,6 @@ describe("test-projects args", () => {
       config: "test/vitest/vitest.extension-line.config.ts",
     },
     {
-      title: "routes matrix extension file targets to the matrix config",
-      target: "extensions/matrix/src/channel.test.ts",
-      config: "test/vitest/vitest.extension-matrix.config.ts",
-    },
-    {
       title: "routes direct OpenAI provider extension file targets to the OpenAI provider config",
       target: "extensions/openai/openai-chatgpt-provider.test.ts",
       config: "test/vitest/vitest.extension-provider-openai.config.ts",


### PR DESCRIPTION
## What Problem This Solves

Four test cases repeat the same setup, inputs, and assertions under different names. The Kilocode case labeled restrictive plugin configuration never supplies that configuration; the hook message-tool label never constructs a distinct message-tool outcome.

## Why This Change Was Made

Keep one exact fixture for Kilocode reasoning injection, nonlocal loopback-origin rejection, completed hook delivery without another announcement, and Matrix test-project routing. All distinct provider, origin-security, delivery/error, and project-routing cases remain.

## User Impact

No runtime or test-support changes. Four fewer duplicate test executions; production +0/-0 and tests +0/-29.

## Evidence

The retained cases invoke the same owners with identical inputs and common setup. Origin security still has the identical deny row and browser-admission coverage; hook terminal logging, redaction, and zero-wakeup assertions remain in the common callback. Matrix routing still asserts the full run plan, and the Kilocode wrapper still tests normal, automatic, and unsupported reasoning variants.

Focused validation passed all four files: 159 cases before and 155 after. The Gateway shard passed 67 cases before and 65 after (10.47s / 3.86s elapsed; 1.38s / 1.21s test execution). This single before/after run is coverage proof, not a performance benchmark. Codex autoreview found no accepted findings. The required changed-file gate passed, including all three dead-export scans, core-test type checking, and scoped lint.
