### PR TITLE
test: isolate fs-safe default mode fixtures

### DIFF
--- a/src/infra/fs-safe-defaults.test.ts
+++ b/src/infra/fs-safe-defaults.test.ts
@@ -1,5 +1,6 @@
 // Covers OpenClaw's default fs-safe native helper configuration.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { withEnvAsync } from "../test-utils/env.js";
 
 const { configureFsSafeNative } = vi.hoisted(() => ({
   configureFsSafeNative: vi.fn(),
@@ -9,23 +10,28 @@ vi.mock("@openclaw/fs-safe/config", () => ({
   configureFsSafeNative,
 }));
 
-async function importDefaults() {
+async function importDefaults(env: Record<string, string | undefined> = {}) {
   vi.resetModules();
-  await import("./fs-safe-defaults.js");
+  await withEnvAsync(
+    {
+      FS_SAFE_NATIVE_MODE: undefined,
+      OPENCLAW_FS_SAFE_NATIVE_MODE: undefined,
+      openclaw_fs_safe_native_mode: undefined,
+      FS_SAFE_PYTHON_MODE: undefined,
+      OPENCLAW_FS_SAFE_PYTHON_MODE: undefined,
+      FS_SAFE_PYTHON: undefined,
+      OPENCLAW_FS_SAFE_PYTHON: undefined,
+      OPENCLAW_PINNED_PYTHON: undefined,
+      OPENCLAW_PINNED_WRITE_PYTHON: undefined,
+    },
+    // Apply overrides after clearing aliases; Windows env names are case-insensitive.
+    () => withEnvAsync(env, () => import("./fs-safe-defaults.js")),
+  );
 }
 
 describe("fs-safe defaults", () => {
   afterEach(() => {
     configureFsSafeNative.mockReset();
-    delete process.env.FS_SAFE_NATIVE_MODE;
-    delete process.env.OPENCLAW_FS_SAFE_NATIVE_MODE;
-    delete process.env.openclaw_fs_safe_native_mode;
-    delete process.env.FS_SAFE_PYTHON_MODE;
-    delete process.env.OPENCLAW_FS_SAFE_PYTHON_MODE;
-    delete process.env.FS_SAFE_PYTHON;
-    delete process.env.OPENCLAW_FS_SAFE_PYTHON;
-    delete process.env.OPENCLAW_PINNED_PYTHON;
-    delete process.env.OPENCLAW_PINNED_WRITE_PYTHON;
   });
 
   it("disables the native helper by default in OpenClaw", async () => {
@@ -35,42 +41,32 @@ describe("fs-safe defaults", () => {
   });
 
   it("lets fs-safe env mode overrides opt back into the helper", async () => {
-    process.env.FS_SAFE_NATIVE_MODE = "require";
-
-    await importDefaults();
+    await importDefaults({ FS_SAFE_NATIVE_MODE: "require" });
 
     expect(configureFsSafeNative).not.toHaveBeenCalled();
   });
 
   it("honors the OpenClaw-specific env mode override", async () => {
-    process.env.OPENCLAW_FS_SAFE_NATIVE_MODE = "auto";
-
-    await importDefaults();
+    await importDefaults({ OPENCLAW_FS_SAFE_NATIVE_MODE: "auto" });
 
     expect(configureFsSafeNative).not.toHaveBeenCalled();
   });
 
   it("honors case-insensitive mode overrides on Windows", async () => {
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-    process.env.openclaw_fs_safe_native_mode = "require";
-
-    await importDefaults();
+    await importDefaults({ openclaw_fs_safe_native_mode: "require" });
 
     expect(configureFsSafeNative).not.toHaveBeenCalled();
   });
 
   it("lets fs-safe migrate legacy require mode without overriding it", async () => {
-    process.env.OPENCLAW_FS_SAFE_PYTHON_MODE = "require";
-
-    await importDefaults();
+    await importDefaults({ OPENCLAW_FS_SAFE_PYTHON_MODE: "require" });
 
     expect(configureFsSafeNative).not.toHaveBeenCalled();
   });
 
   it("does not treat a retired interpreter path as a native mode override", async () => {
-    process.env.OPENCLAW_FS_SAFE_PYTHON = "/usr/bin/python3";
-
-    await importDefaults();
+    await importDefaults({ OPENCLAW_FS_SAFE_PYTHON: "/usr/bin/python3" });
 
     expect(configureFsSafeNative).toHaveBeenCalledWith({ mode: "off" });
   });


### PR DESCRIPTION
## What Problem This Solves

The fs-safe default-mode tests inherit the launching process's mode settings, but their default case assumes no override. Running the unchanged suite with `FS_SAFE_NATIVE_MODE=require` fails that case. Teardown then deletes inherited settings instead of restoring them.

## Why This Change Was Made

Scope the existing nine fixture keys around each fresh module import using the canonical `withEnvAsync` helper. Clear the full key set first, then apply that case's explicit override in a nested scope. Keeping those operations separate handles Windows' case-insensitive environment aliases. Both scopes restore their previous values, including when an import rejects.

All six case names, assertions, module resets, and the existing configuration mock remain. Production defaults, override semantics, test routing, sharding, concurrency, and deadlines are unchanged.

## User Impact

The test suite now runs consistently when developers or CI launch it with explicit filesystem-helper modes. There is no product behavior change.

## Evidence

- Before: `FS_SAFE_NATIVE_MODE=require node scripts/run-vitest.mjs src/infra/fs-safe-defaults.test.ts` failed the default-mode assertion. After: the identical command passes all six original cases.
- Ordinary owner/helper/import-boundary run passes all 18 cases: `node scripts/run-vitest.mjs src/infra/fs-safe-defaults.test.ts src/test-utils/env.test.ts src/infra/fs-safe-import-boundary.test.ts`.
- Separate inherited OpenClaw `auto`, legacy `require`, and lowercase `require` runs each pass all six cases. Exact original case-name equality is verified.
- A private 16-scenario probe exercises the real environment helper with case-sensitive and simulated case-insensitive maps, present/absent inherited values, upper/lower aliases, and resolved/rejected callbacks. Every original value/presence is restored. This is a simulation, not a native Windows run.
- `CI=1 node scripts/check-changed.mjs -- src/infra/fs-safe-defaults.test.ts` passes all 20 checks, including core test types and lint.
- Codex autoreview is clean at its configured P0 threshold; independent owner/dependency review is clean after correcting the Windows alias ordering before publication.

An initial combined run stopped before executing tests with a separate Vitest transform-cache ENOENT. A standalone custom-reporter/lock-transition fixture reproduced that dependency ordering defect; both diagnostic and ordinary same-input validation subsequently passed. No cache was disabled, manual cache deletion performed, assertion weakened, or retry added to this patch. The dependency repair is tracked separately.

Production LOC: unchanged. Test LOC: +22/-26, four fewer lines. This is an inherited-environment stability fix, not a measured execution-time claim. Introduction provenance is unknown across the available shallow history boundary.

## Review Follow-through

Exact-head [CI33353979070](https://github.com/openclaw/openclaw/actions/runs/33353979070) succeeded for `b41153f3a16213bf2f6a2aef89a4fd058b45911a`. The latest completed [ClawSweeper review](https://github.com/openclaw/openclaw/pull/133760#issuecomment-5473651965), reviewed August 31 at 04:17 UTC, found no code or security defect and requests ordinary maintainer handling. It contains no additional Rank-up request.

The maintainer accepts the canonical fixture repair under the requested test-improvement campaign. The targeted proof still binds the unchanged exact head, and current main `072aabb19a1cde908dae600bc3b2715f62f1885e` retains the reviewed parent test, defaults owner and environment-helper blobs. Production defaults and override semantics remain untouched. The earlier review-publication failure and recovered complete report are retained as historical evidence; a completed public review is now available.
