### PR TITLE
test(ui): remove redundant title and working-phrase renders

### DIFF
--- a/ui/src/app-navigation.test.ts
+++ b/ui/src/app-navigation.test.ts
@@ -162,19 +162,9 @@ describe("settingsSearchTextMatches", () => {
 });
 
 describe("formatDocumentTitle", () => {
-  it("suffixes the brand after a plain context", () => {
-    expect(formatDocumentTitle({ context: "Usage" })).toBe("Usage — OpenClaw");
-  });
-
   it("does not duplicate a context ending in the brand", () => {
     expect(formatDocumentTitle({ context: "Ask OpenClaw" })).toBe("Ask OpenClaw");
     expect(formatDocumentTitle({ context: "OpenClaw" })).toBe("OpenClaw");
-  });
-
-  it("prefixes a positive attention count", () => {
-    expect(formatDocumentTitle({ context: "Usage", attentionCount: 2 })).toBe(
-      "(2) Usage — OpenClaw",
-    );
   });
 
   it("names the disconnected gateway without implying internet loss", () => {
@@ -183,20 +173,8 @@ describe("formatDocumentTitle", () => {
     ).toBe("(Disconnected) Usage — OpenClaw");
   });
 
-  it("includes the queued outbox count in the disconnected marker", () => {
-    expect(
-      formatDocumentTitle({ context: "Usage", gatewayDisconnected: true, queuedCount: 3 }),
-    ).toBe("(Disconnected · 3 queued) Usage — OpenClaw");
-  });
-
   it("ignores a queued count while online", () => {
     expect(formatDocumentTitle({ context: "Usage", queuedCount: 3 })).toBe("Usage — OpenClaw");
-  });
-
-  it("suppresses the attention count while disconnected", () => {
-    expect(
-      formatDocumentTitle({ context: "Usage", attentionCount: 2, gatewayDisconnected: true }),
-    ).toBe("(Disconnected) Usage — OpenClaw");
   });
 });
 

--- a/ui/src/app/app-host.document-title.test.ts
+++ b/ui/src/app/app-host.document-title.test.ts
@@ -67,13 +67,6 @@ describe("OpenClaw shell document title", () => {
     expect(document.title).toBe("OpenClaw Control");
   });
 
-  it("uses the route title for a connected route", () => {
-    const shell = createShell(createContext({ sessions: null }));
-    shell.routeState = { routeId: "usage" };
-    shell.syncDocumentTitle();
-    expect(document.title).toBe("Usage — OpenClaw");
-  });
-
   it("does not read stored outboxes for a connected document title", () => {
     const shell = createShell(createContext({}));
     const summarizeStoredChatOutboxes = vi.fn(() => ({ total: 3 }));

--- a/ui/src/components/working-phrase.test.ts
+++ b/ui/src/components/working-phrase.test.ts
@@ -50,12 +50,9 @@ describe("openclaw-working-phrase", () => {
     expect(await textAt(element, WORKING_PHRASE_SHOW_AFTER_MS - 5_000)).toBe("");
   });
 
-  it("shows a phrase once the wait drags on", async () => {
-    expect(await textAt(element, WORKING_PHRASE_SHOW_AFTER_MS + 1_000)).toMatch(PHRASE_TEXT);
-  });
-
   it("is stable within a rotation and changes across rotations", async () => {
     const first = await textAt(element, WORKING_PHRASE_SHOW_AFTER_MS + 1_000);
+    expect(first).toMatch(PHRASE_TEXT);
     const stillFirst = await textAt(element, WORKING_PHRASE_SHOW_AFTER_MS + 10_000);
     expect(stillFirst).toBe(first);
 


### PR DESCRIPTION
## What Problem This Solves

Several document-title utility tests repeat the output assertions already made through the real application shell. One connected-title shell case also repeats a stronger case that verifies the same title without reading stored outboxes. The working-phrase suite repeats its first visible render before testing rotation.

## Why This Change Was Made

Keep the real shell title coverage and the utility inputs that add distinct behavior. Move the initial phrase assertion into the existing rotation test, which renders the identical first state before checking stability and change.

## User Impact

No UI or runtime changes. Six fewer repeated test executions; production +0/-0, tests +1/-33.

## Evidence

The retained shell tests call the real title formatter and assert plain, attention, disconnected, and queued titles. Direct utility coverage still checks branding, explicit zero queue, and online queue suppression. The phrase rotation case retains the same initial wait threshold and phrase regex before its later states.

Focused validation passed all four files: 102 cases before and 96 after. Codex autoreview found no accepted findings; direct source inspection confirms the retained shell invokes the real formatter. The required changed-file gate passed, including i18n verification, dead-export scans, core-test type checking, formatting, and scoped lint.
