### PR TITLE
docs: link latest release notes from changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ﻿# Changelog
 
 Docs: https://docs.openclaw.ai
+Latest release notes: https://docs.openclaw.ai/releases/2026.8.1
 
 ## Unreleased
 


### PR DESCRIPTION
## What Problem This Solves

The repository changelog does not point readers to the published 2026.8.1 release notes.

## Why This Change Was Made

Adds the canonical release-notes URL beside the existing documentation link at the top of `CHANGELOG.md`.

## User Impact

Readers can open the latest release notes directly from the changelog.

## Evidence

- `git diff --check` passes.
- The release-notes URL returns HTTP 200.
- The diff is one Markdown line.

AI-assisted: yes.
