### PR TITLE
refactor(xai): remove unused web-search credential test seam

### DIFF
--- a/extensions/xai/src/web-search-provider.runtime.ts
+++ b/extensions/xai/src/web-search-provider.runtime.ts
@@ -179,14 +179,6 @@ function resolveXaiToolSearchConfig(ctx: {
   );
 }
 
-function resolveXaiWebSearchCredential(searchConfig?: Record<string, unknown>): string | undefined {
-  return resolveWebSearchProviderCredential({
-    credentialValue: getScopedCredentialValue(searchConfig, "grok"),
-    path: "plugins.entries.xai.config.webSearch.apiKey",
-    envVars: ["XAI_API_KEY"],
-  });
-}
-
 function resolveConfiguredXaiWebSearchCredential(
   searchConfig?: Record<string, unknown>,
 ): string | undefined {
@@ -421,7 +413,6 @@ export const testing = {
   buildXaiWebSearchPayload,
   resolveXaiToolSearchConfig,
   resolveXaiInlineCitations,
-  resolveXaiWebSearchCredential,
   resolveXaiWebSearchModel,
   resolveXaiWebSearchTimeoutSeconds,
 };

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -2,7 +2,7 @@
 import { createTestWizardPrompter } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { NON_ENV_SECRETREF_MARKER } from "openclaw/plugin-sdk/provider-auth-runtime";
 import { createNonExitingRuntime } from "openclaw/plugin-sdk/runtime-env";
-import { withEnv, withEnvAsync, withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
+import { withEnvAsync, withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildXaiCatalogModels, resolveXaiCatalogEntry } from "./model-definitions.js";
 import { isModernXaiModel, resolveXaiForwardCompatModel } from "./provider-models.js";
@@ -46,7 +46,6 @@ vi.mock("openclaw/plugin-sdk/provider-auth-runtime", async (importOriginal) => {
 const {
   resolveXaiInlineCitations,
   resolveXaiToolSearchConfig,
-  resolveXaiWebSearchCredential,
   resolveXaiWebSearchModel,
   resolveXaiWebSearchTimeoutSeconds,
 } = testing;
@@ -212,40 +211,6 @@ describe("xai web search config resolution", () => {
     expect(createXaiWebSearchContractProvider().authProviderId).toBe("xai");
   });
 
-  it("prefers configured api keys and resolves grok scoped defaults", () => {
-    expect(resolveXaiWebSearchCredential({ grok: { apiKey: "xai-secret" } })).toBe("xai-secret");
-    expect(resolveXaiWebSearchModel()).toBe("grok-4.3");
-    expect(resolveXaiInlineCitations()).toBe(false);
-  });
-
-  it("uses config apiKey when provided", () => {
-    expect(resolveXaiWebSearchCredential({ grok: { apiKey: "xai-test-key" } })).toBe(
-      "xai-test-key",
-    );
-  });
-
-  it("returns undefined when no apiKey is available", () => {
-    withEnv({ XAI_API_KEY: undefined }, () => {
-      expect(resolveXaiWebSearchCredential({})).toBeUndefined();
-    });
-  });
-
-  it("resolves env SecretRefs without requiring a runtime snapshot", () => {
-    withEnv({ XAI_WEB_SEARCH_KEY: "xai-env-ref-key" }, () => {
-      expect(
-        resolveXaiWebSearchCredential({
-          grok: {
-            apiKey: {
-              source: "env",
-              provider: "default",
-              id: "XAI_WEB_SEARCH_KEY",
-            },
-          },
-        }),
-      ).toBe("xai-env-ref-key");
-    });
-  });
-
   it("merges canonical plugin config into the tool search config", () => {
     const searchConfig = resolveXaiToolSearchConfig({
       config: xaiPluginConfig({
@@ -259,7 +224,7 @@ describe("xai web search config resolution", () => {
       searchConfig: { provider: "grok" },
     });
 
-    expect(resolveXaiWebSearchCredential(searchConfig)).toBe("plugin-key");
+    expect(searchConfig?.grok).toMatchObject({ apiKey: "plugin-key" });
     expect(resolveXaiInlineCitations(searchConfig)).toBe(true);
     expect(resolveXaiWebSearchModel(searchConfig)).toBe("grok-4-fast");
   });


### PR DESCRIPTION
## What Problem This Solves

The API-key-only xAI web-search credential resolver remained after the OAuth migration replaced its runtime caller. Four tests kept that unused implementation and its private testing export alive.

## Why This Change Was Made

Delete the unreachable resolver and its redundant tests. Assert the retained config-merge result directly, keeping the canonical OAuth-aware authentication path as the only runtime implementation. The shared credential resolver remains covered at its owner, and actual web-search execution still tests OAuth precedence, refresh, fallback, configured credentials, and unresolved SecretRef fencing.

## User Impact

No authentication, configuration, public API, or persistence behavior changes. Production +0/-9; tests +2/-37, with four fewer test executions.

## Evidence

Repository-wide references show only the helper definition, private testing property, and deleted test calls. Commit 65471a2da629 replaced its sole execution call with the OAuth-aware resolver. Public plugin API barrels do not expose the helper. Actual web-search calls never reach the removed code, so a live API request would not exercise the deleted path.

Focused validation passed all three files: 79 cases before and 75 after, preserving the real authentication and shared-credential coverage. Codex autoreview found no accepted findings. The required changed-file gate passed, including doctor contracts, plugin/source test type checks, dead-export scans, scoped lint, boundary guards, and the runtime import-cycle check.
