### PR TITLE
fix(docs): document nodes invoke transport timeout

### DIFF
--- a/docs/cli/nodes.md
+++ b/docs/cli/nodes.md
@@ -12,7 +12,7 @@ Manage paired nodes (devices) and invoke node capabilities.
 
 Related: [Nodes overview](/nodes) - [Active computer presence](/nodes/presence) - [Camera nodes](/nodes/camera) - [Image nodes](/nodes/images)
 
-Common options on every subcommand: `--url <url>`, `--token <token>`, `--timeout <ms>` (default `10000`), `--json`.
+Common options on every subcommand: `--url <url>`, `--token <token>`, `--timeout <ms>` (default `10000`; `nodes invoke` uses `30000`), `--json`.
 
 ## Status
 
@@ -60,6 +60,7 @@ Flags:
 - `--command <command>` (required): e.g. `device.info`.
 - `--params <json>`: JSON object string (default `{}`).
 - `--invoke-timeout <ms>`: node invoke timeout (default `15000`).
+- `--timeout <ms>`: Gateway transport timeout (default `30000` for `invoke`; other `nodes` commands default to `10000`).
 - `--idempotency-key <key>`: optional idempotency key.
 
 `system.run` and `system.run.prepare` are blocked here; use the `exec` tool with `host=node` for shell execution instead. `system.which` is allowed through `invoke`.

--- a/docs/cli/nodes.md
+++ b/docs/cli/nodes.md
@@ -12,7 +12,7 @@ Manage paired nodes (devices) and invoke node capabilities.
 
 Related: [Nodes overview](/nodes) - [Active computer presence](/nodes/presence) - [Camera nodes](/nodes/camera) - [Image nodes](/nodes/images)
 
-Common options on every subcommand: `--url <url>`, `--token <token>`, `--timeout <ms>` (default `10000`; `nodes invoke` uses `30000`), `--json`.
+Common options on every subcommand: `--url <url>`, `--token <token>`, `--timeout <ms>` (default varies by command), `--json`.
 
 ## Status
 
@@ -60,7 +60,7 @@ Flags:
 - `--command <command>` (required): e.g. `device.info`.
 - `--params <json>`: JSON object string (default `{}`).
 - `--invoke-timeout <ms>`: node invoke timeout (default `15000`).
-- `--timeout <ms>`: Gateway transport timeout (default `30000` for `invoke`; other `nodes` commands default to `10000`).
+- `--timeout <ms>`: Gateway transport timeout (default `30000`).
 - `--idempotency-key <key>`: optional idempotency key.
 
 `system.run` and `system.run.prepare` are blocked here; use the `exec` tool with `host=node` for shell execution instead. `system.which` is allowed through `invoke`.


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where operators following the `openclaw nodes` CLI reference could assume that `nodes invoke --timeout` defaults to 10 seconds, while the command's Gateway transport timeout is actually 30 seconds.

## Why This Change Was Made

Clarifies the command-specific transport timeout override in the existing `nodes` CLI reference. The node invocation deadline remains documented separately as `--invoke-timeout`; no runtime behavior changes.

## User Impact

Operators and scripts now have an accurate timeout contract for `openclaw nodes invoke` and can distinguish the 30-second transport timeout from the 15-second node invocation timeout.

## Evidence

- Source contract: `src/cli/nodes-cli/register.invoke.ts` passes `{ timeoutMs: 30_000 }` to `nodesCallOpts`, while `src/cli/nodes-cli/rpc.ts` defines the shared fallback as `10_000`.
- Sibling command contract: `nodes location get` uses a `30_000` transport default and camera commands use `60_000`, so the shared CLI reference now says the default varies by command rather than assigning `10000` universally.
- Inspectable after-fix output:
  ```text
  Common options ... --timeout <ms> (default varies by command) ...
  --timeout <ms>: Gateway transport timeout (default `30000`).
  ```
- Final documentation checks: targeted `oxfmt --check docs/cli/nodes.md` and `git diff --check` passed.
- Proof boundary: documentation and source-contract accuracy only; no runtime behavior changed, so no live node/device proof is required.
- Exact head: `615358e0a3bc1f99c7243b954b220e35565aebae`.

Maintainer validation: the invoke, shared RPC, camera, and location owners match current main. Trusted MDX parsing, explicit-config formatting, diff whitespace checks, and independent Codex review passed. Exact-head CI and Workflow Sanity are green. Thanks @qingminglong.
