### PR TITLE
test: exercise tooling owners instead of private facades

### DIFF
--- a/scripts/control-ui-i18n.ts
+++ b/scripts/control-ui-i18n.ts
@@ -40,8 +40,6 @@ import { toErrorObject as toLintErrorObject } from "./lib/error-format.mts";
 import { sleep } from "./lib/sleep.mjs";
 import { resolveWindowsTaskkillPath } from "./lib/windows-taskkill.mjs";
 
-export { shouldReuseExistingTranslation } from "./lib/control-ui-i18n-sync-plan.ts";
-
 type RunProcessParentSignalState = {
   done: boolean;
   signal: NodeJS.Signals | null;

--- a/scripts/lib/control-ui-i18n-sync-plan.ts
+++ b/scripts/lib/control-ui-i18n-sync-plan.ts
@@ -65,14 +65,6 @@ export function flattenTranslations(
   return out;
 }
 
-export function shouldReuseExistingTranslation(options: {
-  allowTranslate: boolean;
-  force: boolean;
-  isFallback: boolean;
-}): boolean {
-  return !options.isFallback || (!options.allowTranslate && !options.force);
-}
-
 export function resolveLocaleMetaProvenance(options: {
   didTranslate: boolean;
   model: string;
@@ -129,11 +121,7 @@ export function createControlUiLocaleSyncPlan(input: {
     const cachedByText = translationMemoryByTextHash.get(textHash);
     const existing = input.existingFlat.get(key);
     const shouldRefreshFallback = previousFallbackKeys.has(key);
-    const shouldReuse = shouldReuseExistingTranslation({
-      allowTranslate: input.allowTranslate,
-      force: input.force,
-      isFallback: shouldRefreshFallback,
-    });
+    const shouldReuse = !shouldRefreshFallback || (!input.allowTranslate && !input.force);
 
     if (cached && shouldReuse) {
       nextFlat.set(key, cached.translated);

--- a/scripts/verify-plugin-npm-published-runtime.mts
+++ b/scripts/verify-plugin-npm-published-runtime.mts
@@ -16,8 +16,6 @@ import {
 import { readPositiveIntEnv } from "./e2e/lib/env-limits.mjs";
 import { sleep } from "./lib/sleep.mjs";
 
-export { readPositiveIntEnv };
-
 const DEFAULT_NPM_COMMAND_TIMEOUT_MS = 5 * 60 * 1000;
 const DEFAULT_NPM_COMMAND_MAX_BUFFER_BYTES = 16 * 1024 * 1024;
 

--- a/test/scripts/control-ui-i18n-sync-plan.test.ts
+++ b/test/scripts/control-ui-i18n-sync-plan.test.ts
@@ -275,6 +275,33 @@ describe("createControlUiLocaleSyncPlan", () => {
     );
   });
 
+  it("refreshes recorded fallback copy when forced without a provider", () => {
+    const plan = createControlUiLocaleSyncPlan({
+      allowTranslate: false,
+      cacheKeyFor,
+      entry,
+      existingFlat: new Map([["title", "Old English"]]),
+      force: true,
+      hashText,
+      previousMeta: localeMeta({ fallbackKeys: ["title"] }),
+      sourceFlat: new Map([["title", "New English"]]),
+      sourceHash: "next-source",
+      translationMemory: new Map(),
+    });
+
+    expect(plan.newFallbackCount).toBe(0);
+    const artifacts = plan.render({
+      defaultGlossary: [],
+      generatedAt: "2026-03-03T00:00:00.000Z",
+      glossary: [],
+      model: "legacy-model",
+      provider: "legacy-provider",
+      workflow: 1,
+    });
+    expect(artifacts.nextFlat.get("title")).toBe("New English");
+    expect(JSON.parse(artifacts.meta).fallbackKeys).toEqual(["title"]);
+  });
+
   it("preserves generatedAt when semantic metadata is unchanged", () => {
     const sourceFlat = flattenTranslations({ title: "Titre" });
     const previousMeta = localeMeta({

--- a/test/scripts/control-ui-i18n.test.ts
+++ b/test/scripts/control-ui-i18n.test.ts
@@ -24,7 +24,6 @@ import {
   filterPlaceholderCompatibleTranslations,
   parseTranslationBatchReply,
   runProcess,
-  shouldReuseExistingTranslation,
 } from "../../scripts/control-ui-i18n.ts";
 import { collectControlUiRawCopyFromSource } from "../../scripts/lib/control-ui-i18n-raw-copy.ts";
 import { waitForPidFile } from "../helpers/process-wait.js";
@@ -410,23 +409,6 @@ describe("control-ui-i18n process runner", () => {
         { fallbackCount: 0, locale: "fr" },
       ]),
     ).not.toThrow();
-  });
-
-  it("refreshes recorded fallback copy when sync is forced without a provider", () => {
-    expect(
-      shouldReuseExistingTranslation({
-        allowTranslate: false,
-        force: true,
-        isFallback: true,
-      }),
-    ).toBe(false);
-    expect(
-      shouldReuseExistingTranslation({
-        allowTranslate: false,
-        force: false,
-        isFallback: true,
-      }),
-    ).toBe(true);
   });
 
   it("keeps a bounded process output tail", () => {

--- a/test/scripts/verify-plugin-npm-published-runtime.test.ts
+++ b/test/scripts/verify-plugin-npm-published-runtime.test.ts
@@ -6,7 +6,6 @@ import {
   parseVerifyPublishedPluginRuntimeArgs,
   parseNpmReadmeMetadata,
   readPluginNpmCommandOptions,
-  readPositiveIntEnv,
   resolveNpmPackFilename,
   runPluginNpmCommand,
   usage,
@@ -29,35 +28,6 @@ describe("plugin npm publish verifier args", () => {
     expect(() =>
       parseVerifyPublishedPluginRuntimeArgs(["@openclaw/discord@2026.5.2", "extra"]),
     ).toThrow("Unexpected plugin npm verifier argument: extra");
-  });
-});
-
-describe("plugin npm publish verifier retry limits", () => {
-  it("rejects loose numeric retry env values instead of parsing prefixes", () => {
-    expect(() =>
-      readPositiveIntEnv("OPENCLAW_PLUGIN_NPM_VERIFY_ATTEMPTS", 90, {
-        OPENCLAW_PLUGIN_NPM_VERIFY_ATTEMPTS: "2tries",
-      }),
-    ).toThrow("invalid OPENCLAW_PLUGIN_NPM_VERIFY_ATTEMPTS: 2tries");
-    expect(() =>
-      readPositiveIntEnv("OPENCLAW_PLUGIN_NPM_VERIFY_DELAY_MS", 10000, {
-        OPENCLAW_PLUGIN_NPM_VERIFY_DELAY_MS: "1e3",
-      }),
-    ).toThrow("invalid OPENCLAW_PLUGIN_NPM_VERIFY_DELAY_MS: 1e3");
-    expect(() =>
-      readPositiveIntEnv("OPENCLAW_PLUGIN_NPM_README_VERIFY_ATTEMPTS", 6, {
-        OPENCLAW_PLUGIN_NPM_README_VERIFY_ATTEMPTS: "0",
-      }),
-    ).toThrow("invalid OPENCLAW_PLUGIN_NPM_README_VERIFY_ATTEMPTS: 0");
-  });
-
-  it("accepts strict positive retry env values and defaults", () => {
-    expect(readPositiveIntEnv("OPENCLAW_PLUGIN_NPM_VERIFY_ATTEMPTS", 90, {})).toBe(90);
-    expect(
-      readPositiveIntEnv("OPENCLAW_PLUGIN_NPM_README_VERIFY_DELAY_MS", 10000, {
-        OPENCLAW_PLUGIN_NPM_README_VERIFY_DELAY_MS: "2500",
-      }),
-    ).toBe(2500);
   });
 });
 
@@ -85,11 +55,11 @@ describe("plugin npm publish verifier command limits", () => {
   });
 
   it("rejects loose npm command timeout and buffer overrides", () => {
-    expect(() =>
-      readPluginNpmCommandOptions({
-        OPENCLAW_PLUGIN_NPM_COMMAND_TIMEOUT_MS: "60s",
-      }),
-    ).toThrow("invalid OPENCLAW_PLUGIN_NPM_COMMAND_TIMEOUT_MS: 60s");
+    for (const value of ["60s", "1e3", "0"]) {
+      expect(() =>
+        readPluginNpmCommandOptions({ OPENCLAW_PLUGIN_NPM_COMMAND_TIMEOUT_MS: value }),
+      ).toThrow(`invalid OPENCLAW_PLUGIN_NPM_COMMAND_TIMEOUT_MS: ${value}`);
+    }
     expect(() =>
       readPluginNpmCommandOptions({
         OPENCLAW_PLUGIN_NPM_COMMAND_MAX_BUFFER_BYTES: "16mb",


### PR DESCRIPTION
## What Problem This Solves

The plugin npm verifier re-exports a shared integer parser solely for tests that supply their own environment names and defaults. The i18n CLI similarly exposes a private plan predicate for two boolean assertions. These tests keep incidental exports alive without proving their consumers use them correctly.

## Why This Change Was Made

Remove both test-only exports. Preserve the verifier's exponent and zero rejection inputs in its existing command-options test. Inline the one-use i18n predicate at the plan decision and move its forced, keyless fallback scenario to the plan/render test, which checks updated English text and fallback metadata.

## User Impact

No command, translation, package-validation, configuration, or persistence behavior changes. Published-package path checks, bounded process behavior, deterministic metadata, cached fallback reuse, and translated replacement coverage remain.

## Evidence

The removed exports have only test importers. The verifier still calls the canonical integer parser internally, and the i18n plan uses the same boolean expression at its only runtime call site. No locale artifacts or external npm state are changed.

Focused owner tests passed on the current-main composition before and after: 60 → 58 cases across the verifier, i18n CLI, and sync-plan suites. The real verifier CLI help path passed. The changed-file gate passed, including i18n verification, script and test typechecks, formatting, lint, and boundary checks. Codex autoreview found no accepted actionable findings.

Tooling: +1/-17 lines (net -16). Tests: +32/-53 lines (net -21). Runtime product code: unchanged. No new tests were added; the unique i18n scenario moved to its existing owner suite.

## Current-main composition

The original CI run [33354976622](https://github.com/openclaw/openclaw/actions/runs/33354976622) failed its build prerequisites on the Control UI CSS budget. The canonical repair [#133791](https://github.com/openclaw/openclaw/pull/133791) is landed. A later main change, [#117199](https://github.com/openclaw/openclaw/pull/117199), moved package-entrypoint resolution into its canonical helper and added eight verifier cases. This branch preserves that owner, its release-workflow trigger and all eight cases.

The refreshed cleanup has the same stable patch as the original six-file change. The three complete composed suites pass 60 → 58 cases; the real verifier CLI help, full changed gate and fresh Codex review also pass. New exact-head CI must complete before merge.
