### PR TITLE
test: avoid duplicate fs-safe boundary scans

### DIFF
--- a/src/infra/fs-safe-import-boundary.test.ts
+++ b/src/infra/fs-safe-import-boundary.test.ts
@@ -15,29 +15,21 @@ function isSourceFile(filePath: string): boolean {
   return filePath.endsWith(".ts") && !filePath.endsWith(".test.ts") && !filePath.endsWith(".d.ts");
 }
 
-function listSourceFiles(dir: string): string[] {
-  const externalFiles = listExternalSourceFiles(dir);
-  if (externalFiles) {
-    return externalFiles;
+function listSourceFiles(): string[] {
+  const files = listGitTrackedFiles({ repoRoot: REPO_ROOT, pathspecs: SCAN_ROOTS });
+  if (files) {
+    const sourceFiles = files.filter(isSourceFile);
+    return SCAN_ROOTS.flatMap((root) =>
+      sourceFiles
+        .filter((file) => file.startsWith(`${root}/`))
+        .map((file) => path.join(REPO_ROOT, file))
+        .toSorted(),
+    );
   }
-  return walkSourceFiles(dir);
-}
-
-function listExternalSourceFiles(dir: string): string[] | null {
-  const repoPath = toRepoRelativePath(REPO_ROOT, dir);
-  return listGitSourceFiles(repoPath) ?? listFindSourceFiles(dir);
-}
-
-function listGitSourceFiles(repoPath: string): string[] | null {
-  const files = listGitTrackedFiles({ repoRoot: REPO_ROOT, pathspecs: repoPath });
-  if (!files) {
-    return null;
-  }
-  return files
-    .map((filePath) => path.join(REPO_ROOT, filePath))
-    .filter((filePath) => fs.existsSync(filePath))
-    .filter(isSourceFile)
-    .toSorted();
+  return SCAN_ROOTS.flatMap((root) => {
+    const dir = path.join(REPO_ROOT, root);
+    return listFindSourceFiles(dir) ?? walkSourceFiles(dir);
+  });
 }
 
 function listFindSourceFiles(dir: string): string[] | null {
@@ -80,7 +72,7 @@ function walkSourceFiles(dir: string): string[] {
 describe("fs-safe import boundary", () => {
   it("lists source files without scanning boundary roots in-process", () => {
     expectNoReaddirSyncDuring(() => {
-      const files = SCAN_ROOTS.flatMap((root) => listSourceFiles(path.join(REPO_ROOT, root)));
+      const files = listSourceFiles();
 
       expect(files.length).toBeGreaterThan(0);
       expect(files.every(isSourceFile)).toBe(true);
@@ -88,7 +80,7 @@ describe("fs-safe import boundary", () => {
   });
 
   it("keeps direct fs-safe imports behind OpenClaw policy wrappers", () => {
-    const violations = SCAN_ROOTS.flatMap((root) => listSourceFiles(path.join(REPO_ROOT, root)))
+    const violations = listSourceFiles()
       .map((filePath) => toRepoRelativePath(REPO_ROOT, filePath))
       .filter((filePath) => {
         if (ALLOWED_PREFIXES.some((prefix) => filePath.startsWith(prefix))) {


### PR DESCRIPTION
## What Problem This Solves

The fs-safe import-boundary tests enumerate each source root separately and repeat an existence check that the shared Git inventory helper already performs. Across the two cases, this repeats tens of thousands of filesystem operations without adding another ownership or snapshot guarantee.

## Why This Change Was Made

Request the three existing roots in one Git inventory call, reuse the helper's existing-file filtering, and remove the redundant local adapters. Preserve the original root order and sort native absolute paths within each root, including Windows path ordering.

Both named tests still acquire their own inventory and execute the same assertions against real source files. The no-directory-walk assertion still encloses inventory acquisition. Git timeout/buffer limits, per-root find/walk fallbacks, source predicates, policy exemptions, and complete violations assertion are unchanged. No new cache, mock, sharding, concurrency, or deadline change.

## User Impact

Less repeated work in test execution and fewer test helper layers. Production behavior is unchanged.

## Evidence

- Real extracted-helper operation probe on the same checkout: 14,963 source paths in identical order; two-case existence checks decrease from 104,012 to 52,006, cold Git launches from three to one, and in-process directory enumerations remain zero.
- Real temporary Git, find, and recursive-walk fixtures preserve each backend's ordered output. A cached Git lookup still observes a tracked working-tree deletion. A Windows path simulation confirms native ordering; no native Windows run is claimed.
- Two declared warmups and six alternating before/after timing pairs passed both original cases. Three measured pairs improved and three regressed amid large timing swings, so these samples do not establish a repeatable percentage speedup. No timing outliers were removed.
- `node scripts/run-vitest.mjs src/infra/fs-safe-import-boundary.test.ts src/test-utils/repo-files.test.ts test/extension-test-boundary.test.ts` passes all 14 owner/helper/sibling cases.
- `CI=1 node scripts/check-changed.mjs -- src/infra/fs-safe-import-boundary.test.ts` passes all 20 checks, including core test types and lint.
- Codex autoreview is clean at its configured P0 threshold; independent owner/caller/fallback review is clean after preserving native-path sorting.

Production LOC: unchanged. Test LOC: +16/-24, eight fewer lines. This PR removes measured redundant operations and unnecessary helper code; it does not claim a suite-wide timing improvement. The initial historical attribution was checked against raw parents and rejected; original introduction is unknown across the available shallow history.

## Review Follow-through

Exact-head [CI33355435023](https://github.com/openclaw/openclaw/actions/runs/33355435023) succeeded for `f319cc4070e728e93d19dbb4256f505fd66509d4`. The latest completed [ClawSweeper review](https://github.com/openclaw/openclaw/pull/133769#issuecomment-5473847667), reviewed August 31 at 04:45 UTC, found no code or security defect and no before-merge or Rank-up request. The maintainer read that complete comment and retains the original ordered inventory, deletion filtering and per-root fallback contracts.

The earlier failed publication and recovered complete report remain historical evidence; a newer completed public review is now available. Its history limitation agrees with the maintained attribution above: original introduction is unknown. No publisher bypass or policy change was used.
