### PR TITLE
test: remove repeated agent transport and recovery fixtures

### DIFF
--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -3477,18 +3477,9 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     });
   });
 
-  it.each([
-    {
-      name: "does not overwrite another active run's restart recovery context",
-      attemptResult: makeEmptyResult("openai", "gpt-5.4"),
-    },
-    {
-      name: "does not clear another active run's restart recovery context",
-      attemptResult: makeEmptyResult("openai", "gpt-5.4"),
-    },
-  ])("$name", async ({ attemptResult }) => {
+  it("does not overwrite another active run's restart recovery context", async () => {
     setupSingleAttemptFallback();
-    state.runAgentAttemptMock.mockResolvedValue(attemptResult);
+    state.runAgentAttemptMock.mockResolvedValue(makeEmptyResult("openai", "gpt-5.4"));
     const staleEntry = createCommandSessionEntry();
     const laterRunEntry = createCommandSessionEntry({
       updatedAt: 2,

--- a/src/agents/embedded-agent-runner-extraparams.test.ts
+++ b/src/agents/embedded-agent-runner-extraparams.test.ts
@@ -1972,18 +1972,6 @@ describe("applyExtraParamsToAgent", () => {
       expected: "websocket",
     },
     {
-      name: "passes configured websocket transport through stream options for openai gpt-5.4",
-      cfg: buildModelConfig("openai/gpt-5.4", { transport: "websocket" }),
-      modelId: "gpt-5.4",
-      model: {
-        api: "openai-chatgpt-responses",
-        provider: "openai",
-        id: "gpt-5.4",
-      } as Model<"openai-chatgpt-responses">,
-      options: {},
-      expected: "websocket",
-    },
-    {
       name: "defaults Codex transport to auto (WebSocket-first)",
       cfg: undefined,
       modelId: "gpt-5.4",
@@ -3152,19 +3140,6 @@ describe("applyExtraParamsToAgent", () => {
   it.each([
     {
       name: "maps MiniMax /fast to the matching highspeed model",
-      applyProvider: "minimax",
-      applyModelId: "MiniMax-M2.7",
-      fastMode: true,
-      model: {
-        api: "anthropic-messages",
-        provider: "minimax",
-        id: "MiniMax-M2.7",
-        baseUrl: "https://api.minimax.io/anthropic",
-      } as Model<"anthropic-messages">,
-      expectedModelId: "MiniMax-M2.7-highspeed",
-    },
-    {
-      name: "maps MiniMax M2.7 /fast to the matching highspeed model",
       applyProvider: "minimax",
       applyModelId: "MiniMax-M2.7",
       fastMode: true,

--- a/src/agents/provider-transport-fetch.test.ts
+++ b/src/agents/provider-transport-fetch.test.ts
@@ -2127,7 +2127,6 @@ describe("buildGuardedModelFetch", () => {
         retryAfter: "Sun Nov 99 99:99:99 9999",
       },
       { title: "keeps short retry-after 429 responses retryable", status: 429, retryAfter: "30" },
-      { title: "leaves short retry-after values untouched", status: 429, retryAfter: "30" },
       { title: "ignores retry-after on non-retryable responses", status: 400, retryAfter: "239" },
     ])("$title", async ({ status, retryAfter }) => {
       fetchWithSsrFGuardMock.mockResolvedValue({


### PR DESCRIPTION
## What Problem This Solves

Four agent test executions repeat identical fixtures under different names: websocket transport forwarding, MiniMax fast-model selection, short retry-after handling, and preservation of another run's pre-existing recovery claim.

## Why This Change Was Made

Keep one copy of each exact input and its existing assertions. The recovery case becomes a plain test because both table rows produce the same empty attempt result; all four recovery-state assertions remain. Tests that replace a claim during delivery, rotate or delete the session, or let restart win cleanup remain separate.

## User Impact

No runtime, provider, retry, configuration, or persistence behavior changes. Four fewer duplicate test executions; production +0/-0 and tests +2/-37, net -35.

## Evidence

The common callbacks never use the labels, and setup is identical between each removed and retained case. Distinct API/transport defaults, caller SSE overrides, dynamic fast-mode changes, retry limits, and lifecycle races remain covered. Installed Anthropic and OpenAI SDK source confirms the existing retry-suppression header contract. Direct sibling Codex `codex-rs/core/src/client.rs:954-967,1852-1923` at `3b67b03a3f6b` was inspected to distinguish upstream transport behavior from these local options-capture tests; no protocol or live-provider parity claim is made.

The three complete focused files passed before and after: 373 → 369 cases, preserving original file order and all distinct recovery races. The changed-file gate passed, including full dead-export scans, core-test typechecking, formatting, lint, and repository guards. Codex autoreview found no accepted actionable findings.
