### PR TITLE
test(cli): keep parser coverage without formatter self-comparison

### DIFF
--- a/src/cli/program/root-command-descriptions.test.ts
+++ b/src/cli/program/root-command-descriptions.test.ts
@@ -5,8 +5,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cliCommandCatalog } from "../command-catalog.js";
 import { isReservedNonPluginCommandRoot } from "../command-registration-policy.js";
 import { collectShellCompletionCommandTree } from "../completion-command-tree.js";
-import { formatCliJsonFailure } from "../failure-output.js";
-import { runCliWithExitFinalization } from "../one-shot-exit.js";
 import { getCoreCliCommandNames, registerCoreCliByName } from "./command-registry-core.js";
 import { createProgramContext } from "./context.js";
 import { getCoreCliCommandDescriptors } from "./core-command-descriptors.js";
@@ -253,7 +251,7 @@ function requiredCommandArgs(command: Command): string[] {
     if (!argument.required) {
       return [];
     }
-    return argument.variadic ? ["guard-value"] : ["guard-value"];
+    return ["guard-value"];
   });
   for (const option of command.options) {
     if (!option.mandatory) {
@@ -427,38 +425,23 @@ describe("root command descriptions", () => {
     ).toEqual([]);
   });
 
-  it("routes every registered JSON command failure through the canonical envelope", async () => {
+  it("accepts declared JSON output options through the registered command parsers", async () => {
     const program = await registerAllBuiltInCommands();
     const contexts = collectShellCompletionCommandTree(program).descendants.filter((context) => {
       const path = context.pathVariants[0]?.join(" ") ?? "";
-      return supportsJsonOutput(path, context.command);
+      return supportsJsonOutput(path, context.command) && hasOwnJsonOption(context.command);
     });
-    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
 
     expect(contexts.length).toBeGreaterThan(0);
     for (const context of contexts) {
       const path = context.pathVariants[0]?.join(" ") ?? "";
       const failure = new Error(`synthetic failure for ${path}`);
-      const payloads: unknown[] = [];
       context.command.action(async () => {
         throw failure;
       });
-      const args = requiredCommandArgs(context.command);
-      if (hasOwnJsonOption(context.command)) {
-        args.push("--json");
-      }
+      const args = [...requiredCommandArgs(context.command), "--json"];
 
-      await runCliWithExitFinalization({
-        runtime,
-        run: async () => {
-          await context.command.parseAsync(args, { from: "user" });
-        },
-        onError: (error) => {
-          payloads.push(formatCliJsonFailure(error));
-        },
-      });
-
-      expect(payloads, path).toEqual([formatCliJsonFailure(failure)]);
+      await expect(context.command.parseAsync(args, { from: "user" }), path).rejects.toBe(failure);
     }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The registered-command test replaced real actions with synthetic failures, injected its own JSON formatter, then compared that formatter with itself. It could verify parser acceptance but could not independently detect broken JSON failure output.

## Why This Change Was Made

Keep real command registration and declared output-flag parsing, and assert that each parser reaches the original synthetic failure. Remove the injected formatter/runtime and name the test for the parser contract it actually checks. Simplify the adjacent required-argument fixture's identical variadic and nonvariadic branches.

## User Impact

No CLI behavior or JSON schema changes. The preceding inventory still checks route-first JSON support. Independent literal formatter/redaction assertions, asynchronous exit-finalization tests, and real entrypoint process tests for routed and Commander failures remain.

## Evidence

Direct Commander source confirms that replacing action handlers bypasses the original commands, and the retained throw preserves hook ordering. The real CLI entrypoints own JSON error output; their callbacks and existing process assertions were inspected. No test execution is removed.

All 58 focused tests passed before and after across command registration/parsing, literal failure formatting, and one-shot exit behavior. Codex autoreview found no accepted actionable findings. The changed-file gate passed, including dead-export scans, core-test typechecking, formatting, lint, and repository guards. Tests +5/-22 lines (net -17); production and test support unchanged.
