### PR TITLE
fix(feishu): apply reloaded group bindings without gateway restart

### DIFF
--- a/extensions/feishu/src/bot.broadcast.test.ts
+++ b/extensions/feishu/src/bot.broadcast.test.ts
@@ -143,9 +143,10 @@ describe("broadcast dispatch", () => {
     path: "/tmp/inbound-clip.mp4",
     contentType: "video/mp4",
   });
+  const mockCurrentConfig = vi.fn(() => createBroadcastConfig());
   const runtimeStub = {
     config: {
-      current: vi.fn(() => createBroadcastConfig()),
+      current: mockCurrentConfig,
     },
     system: {
       enqueueSystemEvent: vi.fn(),
@@ -225,7 +226,7 @@ describe("broadcast dispatch", () => {
   } as unknown as PluginRuntime;
 
   async function handleFeishuMessage(params: Parameters<typeof handleFeishuMessageImpl>[0]) {
-    runtimeStub.config.current.mockReturnValue(params.cfg);
+    mockCurrentConfig.mockReturnValue(params.cfg);
     await handleFeishuMessageImpl(params);
   }
 

--- a/extensions/feishu/src/bot.broadcast.test.ts
+++ b/extensions/feishu/src/bot.broadcast.test.ts
@@ -4,7 +4,7 @@ import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vites
 import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
 import { feishuGroupNameCache } from "./bot-group-name-state.js";
 import type { FeishuMessageEvent } from "./bot.js";
-import { handleFeishuMessage } from "./bot.js";
+import { handleFeishuMessage as handleFeishuMessageImpl } from "./bot.js";
 import { feishuDedupeState } from "./dedup-state.js";
 import type { FeishuMessageProcessingClaim } from "./dedup.js";
 import type { FeishuIngressLifecycle } from "./feishu-ingress.js";
@@ -144,6 +144,9 @@ describe("broadcast dispatch", () => {
     contentType: "video/mp4",
   });
   const runtimeStub = {
+    config: {
+      current: vi.fn(() => createBroadcastConfig()),
+    },
     system: {
       enqueueSystemEvent: vi.fn(),
     },
@@ -220,6 +223,11 @@ describe("broadcast dispatch", () => {
       detectMime: vi.fn(async () => "application/octet-stream"),
     },
   } as unknown as PluginRuntime;
+
+  async function handleFeishuMessage(params: Parameters<typeof handleFeishuMessageImpl>[0]) {
+    runtimeStub.config.current.mockReturnValue(params.cfg);
+    await handleFeishuMessageImpl(params);
+  }
 
   afterAll(() => {
     vi.doUnmock("./reply-dispatcher.js");

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -6,8 +6,9 @@ import type {
   getSessionBindingService,
   resolveConfiguredBindingRoute,
 } from "openclaw/plugin-sdk/conversation-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { createRuntimeEnv } from "openclaw/plugin-sdk/plugin-test-runtime";
-import type { ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
+import { resolveAgentRoute, type ResolvedAgentRoute } from "openclaw/plugin-sdk/routing";
 import { resolveGroupSessionKey } from "openclaw/plugin-sdk/session-store-runtime";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ClawdbotConfig, PluginRuntime } from "../runtime-api.js";
@@ -1280,6 +1281,64 @@ describe("handleFeishuMessage command authorization", () => {
     );
   });
 
+  it("routes Feishu groups with exact bindings from the live runtime config", async () => {
+    mockResolveAgentRoute.mockImplementation((params) =>
+      resolveAgentRoute(params as Parameters<typeof resolveAgentRoute>[0]),
+    );
+
+    const startupCfg = createFeishuTestConfig(
+      {
+        enabled: true,
+        groups: { oc_target: { allow: true, requireMention: false } },
+      },
+      {
+        agents: { list: [{ id: "main" }, { id: "oc1" }] },
+        bindings: [
+          {
+            agentId: "oc1",
+            match: {
+              channel: "feishu",
+              accountId: "default",
+              peer: { kind: "group", id: "*" },
+            },
+          },
+        ],
+      },
+    );
+    const liveCfg = {
+      ...startupCfg,
+      bindings: [
+        {
+          agentId: "main",
+          match: {
+            channel: "feishu",
+            accountId: "default",
+            peer: { kind: "group", id: "oc_target" },
+          },
+        },
+        ...(startupCfg.bindings ?? []),
+      ],
+    } as ClawdbotConfig;
+
+    await dispatchMessage({
+      cfg: startupCfg,
+      currentCfg: liveCfg,
+      event: createFeishuTestEvent({
+        messageId: "msg-group-live-binding",
+        senderOpenId: "ou_sender",
+        chatId: "oc_target",
+        chatType: "group",
+      }),
+    });
+
+    expect(mockCreateFeishuReplyDispatcher).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "main",
+        sessionKey: "agent:main:feishu:group:oc_target",
+      }),
+    );
+  });
+
   it("drops a DM denied by refreshed dynamic-agent policy", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
 
@@ -1324,6 +1383,52 @@ describe("handleFeishuMessage command authorization", () => {
     });
 
     expect(mockFinalizeInboundContext).not.toHaveBeenCalled();
+    expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
+  it("drops a bound DM revoked while sender lookup is pending", async () => {
+    const lookupStarted = createDeferred<void>();
+    const releaseLookup = createDeferred<void>();
+    mockCreateFeishuClient.mockReturnValue({
+      contact: {
+        user: {
+          get: vi.fn(async () => {
+            lookupStarted.resolve();
+            await releaseLookup.promise;
+            return { data: {} };
+          }),
+        },
+      },
+    });
+    mockResolveAgentRoute.mockReturnValue({
+      ...createFeishuTestRoute(),
+      matchedBy: "binding.peer",
+    });
+    const cfg = createFeishuTestConfig({
+      appId: "cli_test",
+      appSecret: "test-secret",
+      dmPolicy: "open",
+      allowFrom: ["*"],
+      resolveSenderNames: true,
+    });
+    const channelRuntime = createFeishuBotRuntime().channel;
+    const pending = dispatchMessage({
+      cfg,
+      channelRuntime,
+      event: createFeishuTestEvent({
+        messageId: "msg-revoked-during-lookup",
+        senderOpenId: "ou_revoked_during_lookup",
+      }),
+    });
+    await lookupStarted.promise;
+    currentRuntimeConfig = createFeishuTestConfig({
+      ...cfg.channels?.feishu,
+      dmPolicy: "disabled",
+    });
+    releaseLookup.resolve();
+    await pending;
+
+    expect(channelRuntime.inbound.run).not.toHaveBeenCalled();
     expect(mockDispatchReplyFromConfig).not.toHaveBeenCalled();
   });
 

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -301,7 +301,6 @@ export async function handleFeishuMessage(params: {
   turnAdoptionLifecycle?: FeishuIngressLifecycle;
 }): Promise<void> {
   const {
-    cfg: accountStartCfg,
     event,
     botOpenId,
     botName,
@@ -314,11 +313,8 @@ export async function handleFeishuMessage(params: {
     turnAdoptionLifecycle,
   } = params;
 
-  // Start each message with live routing config instead of the long-lived account snapshot.
-  // Direct messages still reauthorize below if policy changes during awaited work.
-  const cfg =
-    // SAFETY: The host supplies the same validated config shape as the account-start snapshot.
-    (getFeishuRuntime().config?.current() as ClawdbotConfig | undefined) ?? accountStartCfg;
+  // Resolve each turn from live config; DMs reauthorize after awaited work below.
+  const cfg = getFeishuRuntime().config.current() as ClawdbotConfig;
 
   // Resolve account with merged config
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -315,7 +315,6 @@ export async function handleFeishuMessage(params: {
 
   // Resolve each turn from live config; DMs reauthorize after awaited work below.
   const cfg = getFeishuRuntime().config.current() as ClawdbotConfig;
-
   // Resolve account with merged config
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });
   const feishuCfg = account.config;

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -313,6 +313,7 @@ export async function handleFeishuMessage(params: {
     turnAdoptionLifecycle,
   } = params;
 
+  // SAFETY: config.current() returns the canonical host-validated ClawdbotConfig.
   // Resolve each turn from live config; DMs reauthorize after awaited work below.
   const cfg = getFeishuRuntime().config.current() as ClawdbotConfig;
   // Resolve account with merged config

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -313,8 +313,8 @@ export async function handleFeishuMessage(params: {
     turnAdoptionLifecycle,
   } = params;
 
-  // SAFETY: config.current() returns the canonical host-validated ClawdbotConfig.
   // Resolve each turn from live config; DMs reauthorize after awaited work below.
+  // SAFETY: config.current() returns the canonical host-validated ClawdbotConfig.
   const cfg = getFeishuRuntime().config.current() as ClawdbotConfig;
   // Resolve account with merged config
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });

--- a/extensions/feishu/src/bot.ts
+++ b/extensions/feishu/src/bot.ts
@@ -301,7 +301,7 @@ export async function handleFeishuMessage(params: {
   turnAdoptionLifecycle?: FeishuIngressLifecycle;
 }): Promise<void> {
   const {
-    cfg,
+    cfg: accountStartCfg,
     event,
     botOpenId,
     botName,
@@ -313,6 +313,12 @@ export async function handleFeishuMessage(params: {
     messageDedupeKey: messageDedupeKeyOverride,
     turnAdoptionLifecycle,
   } = params;
+
+  // Start each message with live routing config instead of the long-lived account snapshot.
+  // Direct messages still reauthorize below if policy changes during awaited work.
+  const cfg =
+    // SAFETY: The host supplies the same validated config shape as the account-start snapshot.
+    (getFeishuRuntime().config?.current() as ClawdbotConfig | undefined) ?? accountStartCfg;
 
   // Resolve account with merged config
   const account = resolveFeishuRuntimeAccount({ cfg, accountId });


### PR DESCRIPTION
Fixes #133757

## What Problem This Solves

Feishu group messages continued routing to the previously bound agent after an accepted `bindings` reload. The new exact group binding took effect only after restarting the Gateway.

## Solution

Each inbound Feishu message now reads the required current runtime configuration before admission and routing. There is no startup-config fallback or parallel routing path.

The existing direct-message reauthorization remains in place: after awaited sender lookup, a DM is checked again against current policy before route selection and agent execution.

The broadcast runtime fixture now provides each scenario's actual current configuration, including overrides.

## User impact

The next admitted Feishu group message follows an accepted new group binding without a Gateway restart. A private-message authorization revoked during sender lookup is rejected before agent execution or reply dispatch.

## Evidence

- Exact PR head: `3561978f7f228d3cccfb6ab7d16546e601a354c7`.
- Sanitized AWS merge proof against main `29ba80f738dfd59b7ca71313081242b05206040d`: extension test typecheck passed; targeted oxlint reported zero warnings and errors; `bot.broadcast.test.ts` passed 16/16; `build:ci-artifacts` passed; `git diff --check` passed.
- Earlier same-behavior candidate proof passed the complete Feishu extension suite: 102 files and 2,031 tests. The later changes only attach the assertion safety annotation and preserve the typed broadcast config mock.
- Assertion safety ratchet and exact-head formatting passed.
- Conflict-free merge simulation passed against fetched main `a7175b2af3aa297143aa62117644d03d04df443a`.
- Exact-head P3 autoreview is scoped-clean with no findings and 0.92 confidence.
- The contributor's authenticated Feishu A/B proof exercised the real Gateway and Feishu APIs: an accepted binding reload changed routing from the wildcard-bound agent to the exact-bound agent without restarting the measured Gateway or channel.

The fresh exact-head PR context and evidence check passed. The remaining hosted CI and ClawSweeper re-review are tracked separately and are not claimed complete here.

## Boundaries

No shared routing algorithm, public configuration, SDK contract, dependency, storage format, or protocol changes. The authenticated platform proof covers mentioned group messages; the deterministic handler test covers the DM revocation race.
