### PR TITLE
fix(ci): keep recent timings on main pushes

### DIFF
--- a/scripts/ci-run-timings.mjs
+++ b/scripts/ci-run-timings.mjs
@@ -294,14 +294,6 @@ function getLatestMainPushCiRunId() {
   return String(databaseId);
 }
 
-function selectRecentMainPushCiRuns(runs, limit) {
-  return runs
-    .filter(
-      (run) => run.event === "push" && run.status === "completed" && run.conclusion === "success",
-    )
-    .slice(0, limit);
-}
-
 function listRecentSuccessfulCiRuns(limit) {
   const raw = execPlainGh(
     [
@@ -320,7 +312,11 @@ function listRecentSuccessfulCiRuns(limit) {
     ],
     { encoding: "utf8" },
   );
-  return selectRecentMainPushCiRuns(JSON.parse(raw), limit);
+  return JSON.parse(raw)
+    .filter(
+      (run) => run.event === "push" && run.status === "completed" && run.conclusion === "success",
+    )
+    .slice(0, limit);
 }
 
 /**

--- a/scripts/ci-run-timings.mjs
+++ b/scripts/ci-run-timings.mjs
@@ -294,6 +294,14 @@ function getLatestMainPushCiRunId() {
   return String(databaseId);
 }
 
+export function selectRecentMainPushCiRuns(runs, limit) {
+  return runs
+    .filter(
+      (run) => run.event === "push" && run.status === "completed" && run.conclusion === "success",
+    )
+    .slice(0, limit);
+}
+
 function listRecentSuccessfulCiRuns(limit) {
   const raw = execPlainGh(
     [
@@ -301,18 +309,18 @@ function listRecentSuccessfulCiRuns(limit) {
       "list",
       "--branch",
       "main",
+      "--event",
+      "push",
       "--workflow",
       "CI",
       "--limit",
       String(Math.max(limit * 4, limit)),
       "--json",
-      "databaseId,headSha,status,conclusion",
+      "databaseId,headSha,event,status,conclusion",
     ],
     { encoding: "utf8" },
   );
-  return JSON.parse(raw)
-    .filter((run) => run.status === "completed" && run.conclusion === "success")
-    .slice(0, limit);
+  return selectRecentMainPushCiRuns(JSON.parse(raw), limit);
 }
 
 /**

--- a/scripts/ci-run-timings.mjs
+++ b/scripts/ci-run-timings.mjs
@@ -294,7 +294,7 @@ function getLatestMainPushCiRunId() {
   return String(databaseId);
 }
 
-export function selectRecentMainPushCiRuns(runs, limit) {
+function selectRecentMainPushCiRuns(runs, limit) {
   return runs
     .filter(
       (run) => run.event === "push" && run.status === "completed" && run.conclusion === "success",

--- a/test/scripts/ci-run-timings.test.ts
+++ b/test/scripts/ci-run-timings.test.ts
@@ -9,6 +9,7 @@ import {
   collectRunJobsFromPages,
   isRetryableGhJsonErrorMessage,
   parseRunTimingArgs,
+  selectRecentMainPushCiRuns,
   selectLatestMainPushCiRun,
   summarizePnpmStoreWarmupBarrier,
   summarizeRunTimings,
@@ -99,6 +100,20 @@ describe("scripts/ci-run-timings.mjs", () => {
       event: "push",
       headSha: "current",
     });
+  });
+
+  it("keeps recent timing comparisons on successful main pushes", () => {
+    expect(
+      selectRecentMainPushCiRuns(
+        [
+          { databaseId: 4, event: "workflow_dispatch", status: "completed", conclusion: "success" },
+          { databaseId: 3, event: "push", status: "in_progress", conclusion: null },
+          { databaseId: 2, event: "push", status: "completed", conclusion: "failure" },
+          { databaseId: 1, event: "push", status: "completed", conclusion: "success" },
+        ],
+        10,
+      ),
+    ).toEqual([{ databaseId: 1, event: "push", status: "completed", conclusion: "success" }]);
   });
 
   it("normalizes paginated GitHub Actions job payloads", () => {

--- a/test/scripts/ci-run-timings.test.ts
+++ b/test/scripts/ci-run-timings.test.ts
@@ -491,65 +491,57 @@ if (endpoint.includes("actions/workflows/ci.yml/runs?")) {
       rmSync(fixtureDir, { force: true, recursive: true });
     }
   });
-
-  it("runs --recent with a push-only GitHub CLI query and output", () => {
+  it("excludes manual, failed, and unfinished runs from recent main timings", () => {
     const fixtureDir = mkdtempSync(path.join(tmpdir(), "openclaw-ci-timings-recent-"));
     const fakeGhPath = path.join(fixtureDir, "gh");
-    const queryArgsPath = path.join(fixtureDir, "query-args.json");
-    const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+    const callsPath = path.join(fixtureDir, "calls.jsonl");
     writeFileSync(
       fakeGhPath,
       `#!/usr/bin/env node
-const { writeFileSync } = require("node:fs");
+const { appendFileSync } = require("node:fs");
 const args = process.argv.slice(2);
+appendFileSync(process.env.FIXTURE_CALLS_PATH, JSON.stringify(args) + "\\n");
 if (args[0] === "run" && args[1] === "list") {
-  writeFileSync(process.env.QUERY_ARGS_PATH, JSON.stringify(args));
   console.log(JSON.stringify([
-    { databaseId: 201, event: "workflow_dispatch", headSha: "dispatch", status: "completed", conclusion: "success" },
-    { databaseId: 202, event: "push", headSha: "push", status: "completed", conclusion: "success" }
+    { databaseId: 201, event: "workflow_dispatch", headSha: "manual", status: "completed", conclusion: "success" },
+    { databaseId: 202, event: "push", headSha: "failed", status: "completed", conclusion: "failure" },
+    { databaseId: 203, event: "push", headSha: "running", status: "in_progress", conclusion: "" },
+    { databaseId: 204, event: "push", headSha: "first", status: "completed", conclusion: "success" },
+    { databaseId: 205, event: "push", headSha: "second", status: "completed", conclusion: "success" }
   ]));
-} else if (args[0] === "run" && args[1] === "view" && args[2] === "202") {
+} else if (args[0] === "run" && args[1] === "view") {
   console.log(JSON.stringify({ status: "completed", conclusion: "success", createdAt: "2026-08-31T00:00:00Z", updatedAt: "2026-08-31T00:01:00Z" }));
-} else if (args.join(" ").includes("actions/runs/202/jobs?")) {
-  console.log(JSON.stringify({ total_count: 1, jobs: [
-    { id: 1, name: "checks-node-compact-small-1", status: "completed", conclusion: "success", created_at: "2026-08-31T00:00:05Z", started_at: "2026-08-31T00:00:10Z", completed_at: "2026-08-31T00:00:40Z" }
-  ] }));
+} else if (args[0] === "api" && args.some((arg) => arg.includes("/jobs?"))) {
+  console.log(JSON.stringify({ total_count: 1, jobs: [{ id: 1, name: "checks", status: "completed", conclusion: "success", started_at: "2026-08-31T00:00:10Z", completed_at: "2026-08-31T00:00:40Z" }] }));
 } else {
-  console.error("unexpected gh invocation", args.join(" "));
   process.exit(2);
 }
 `,
     );
     chmodSync(fakeGhPath, 0o755);
-
     try {
       const result = spawnSync(process.execPath, ["scripts/ci-run-timings.mjs", "--recent", "2"], {
-        cwd: repositoryRoot,
+        cwd: path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../.."),
         encoding: "utf8",
         env: {
           ...process.env,
+          GH_TOKEN: "fixture-token",
           OPENCLAW_GH_BIN: fakeGhPath,
-          QUERY_ARGS_PATH: queryArgsPath,
+          FIXTURE_CALLS_PATH: callsPath,
         },
       });
-
       expect(result.status, result.stderr).toBe(0);
-      expect(result.stdout).toContain("CI run 202");
-      expect(result.stdout).not.toContain("CI run 201");
-      expect(JSON.parse(readFileSync(queryArgsPath, "utf8"))).toEqual([
-        "run",
-        "list",
-        "--branch",
-        "main",
-        "--event",
-        "push",
-        "--workflow",
-        "CI",
-        "--limit",
-        "8",
-        "--json",
-        "databaseId,headSha,event,status,conclusion",
-      ]);
+      expect(result.stdout.match(/CI run \d+/gu)).toEqual(["CI run 204", "CI run 205"]);
+      const calls: string[][] = readFileSync(callsPath, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      expect(calls[0]?.slice(calls[0].indexOf("--event"), calls[0].indexOf("--event") + 2)).toEqual(
+        ["--event", "push"],
+      );
+      expect(
+        calls.filter((args) => args[0] === "run" && args[1] === "view").map((args) => args[2]),
+      ).toEqual(["204", "205"]);
     } finally {
       rmSync(fixtureDir, { force: true, recursive: true });
     }

--- a/test/scripts/ci-run-timings.test.ts
+++ b/test/scripts/ci-run-timings.test.ts
@@ -9,7 +9,6 @@ import {
   collectRunJobsFromPages,
   isRetryableGhJsonErrorMessage,
   parseRunTimingArgs,
-  selectRecentMainPushCiRuns,
   selectLatestMainPushCiRun,
   summarizePnpmStoreWarmupBarrier,
   summarizeRunTimings,
@@ -100,20 +99,6 @@ describe("scripts/ci-run-timings.mjs", () => {
       event: "push",
       headSha: "current",
     });
-  });
-
-  it("keeps recent timing comparisons on successful main pushes", () => {
-    expect(
-      selectRecentMainPushCiRuns(
-        [
-          { databaseId: 4, event: "workflow_dispatch", status: "completed", conclusion: "success" },
-          { databaseId: 3, event: "push", status: "in_progress", conclusion: null },
-          { databaseId: 2, event: "push", status: "completed", conclusion: "failure" },
-          { databaseId: 1, event: "push", status: "completed", conclusion: "success" },
-        ],
-        10,
-      ),
-    ).toEqual([{ databaseId: 1, event: "push", status: "completed", conclusion: "success" }]);
   });
 
   it("normalizes paginated GitHub Actions job payloads", () => {
@@ -501,6 +486,69 @@ if (endpoint.includes("actions/workflows/ci.yml/runs?")) {
       expect(report.runs[0].jobTimings.map((job: { name: string }) => job.name)).toEqual([
         "preflight",
         "checks-node-compact-large-1",
+      ]);
+    } finally {
+      rmSync(fixtureDir, { force: true, recursive: true });
+    }
+  });
+
+  it("runs --recent with a push-only GitHub CLI query and output", () => {
+    const fixtureDir = mkdtempSync(path.join(tmpdir(), "openclaw-ci-timings-recent-"));
+    const fakeGhPath = path.join(fixtureDir, "gh");
+    const queryArgsPath = path.join(fixtureDir, "query-args.json");
+    const repositoryRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+    writeFileSync(
+      fakeGhPath,
+      `#!/usr/bin/env node
+const { writeFileSync } = require("node:fs");
+const args = process.argv.slice(2);
+if (args[0] === "run" && args[1] === "list") {
+  writeFileSync(process.env.QUERY_ARGS_PATH, JSON.stringify(args));
+  console.log(JSON.stringify([
+    { databaseId: 201, event: "workflow_dispatch", headSha: "dispatch", status: "completed", conclusion: "success" },
+    { databaseId: 202, event: "push", headSha: "push", status: "completed", conclusion: "success" }
+  ]));
+} else if (args[0] === "run" && args[1] === "view" && args[2] === "202") {
+  console.log(JSON.stringify({ status: "completed", conclusion: "success", createdAt: "2026-08-31T00:00:00Z", updatedAt: "2026-08-31T00:01:00Z" }));
+} else if (args.join(" ").includes("actions/runs/202/jobs?")) {
+  console.log(JSON.stringify({ total_count: 1, jobs: [
+    { id: 1, name: "checks-node-compact-small-1", status: "completed", conclusion: "success", created_at: "2026-08-31T00:00:05Z", started_at: "2026-08-31T00:00:10Z", completed_at: "2026-08-31T00:00:40Z" }
+  ] }));
+} else {
+  console.error("unexpected gh invocation", args.join(" "));
+  process.exit(2);
+}
+`,
+    );
+    chmodSync(fakeGhPath, 0o755);
+
+    try {
+      const result = spawnSync(process.execPath, ["scripts/ci-run-timings.mjs", "--recent", "2"], {
+        cwd: repositoryRoot,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          OPENCLAW_GH_BIN: fakeGhPath,
+          QUERY_ARGS_PATH: queryArgsPath,
+        },
+      });
+
+      expect(result.status, result.stderr).toBe(0);
+      expect(result.stdout).toContain("CI run 202");
+      expect(result.stdout).not.toContain("CI run 201");
+      expect(JSON.parse(readFileSync(queryArgsPath, "utf8"))).toEqual([
+        "run",
+        "list",
+        "--branch",
+        "main",
+        "--event",
+        "push",
+        "--workflow",
+        "CI",
+        "--limit",
+        "8",
+        "--json",
+        "databaseId,headSha,event,status,conclusion",
       ]);
     } finally {
       rmSync(fixtureDir, { force: true, recursive: true });


### PR DESCRIPTION
## What Problem This Solves

`pnpm ci:timings:recent` could include successful manual dispatches in a sample described as recent main CI runs. Those dispatches can validate other refs, so mixing them with main pushes gives misleading timing comparisons and can crowd a genuine push out of the requested sample.

## Why This Change Was Made

The existing recent-run query now requests push events and verifies the returned event alongside completed/success before applying the requested limit. This stays in the existing selection owner; an extra selector wrapper from the original patch is unnecessary. The latest-main and trend selectors already distinguish pushes and remain unchanged.

Production tooling: +6/-2 (net +4); tests: +55/-0. The four production lines express the missing event filter at the query and result boundaries; no new helper, option, storage format, or dependency is added.

## User Impact

Recent timing comparisons contain successful main pushes, preserving their returned order and excluding manual, failed, and unfinished runs. Thanks @qingminglong.

## Evidence

- A real command-boundary regression invokes `node scripts/ci-run-timings.mjs --recent 2` with a synthetic GitHub CLI transport containing one successful manual dispatch, a failed push, an unfinished push, and two successful pushes. Before the fix, output contained manual run 201 and push 204, crowding out push 205. Afterward, only runs 204 and 205 appear, only their job details are loaded, and the query includes `--event push`.
- `node scripts/run-vitest.mjs test/scripts/ci-run-timings.test.ts`: 1 failed/15 passed before; all 16 passed afterward. This includes latest-main selection, trend/rerun accounting, pagination normalization, error handling, and argument parsing.
- `node scripts/check-changed.mjs -- scripts/ci-run-timings.mjs test/scripts/ci-run-timings.test.ts`: every selected gate passed, including script/test-root types, formatting, and lint.
- The actual default command `node scripts/ci-run-timings.mjs --recent 10` completed and printed ten timing summaries through the configured GitHub CLI route. Those results were served from its existing cache (for example run 31336995116: wall 1448s, execution 730s, 56 jobs); they demonstrate the command/output path, not fresh measurements of today's main. A separate dated query returned current September 1 push-run metadata. The mixed-event regression supplies the causal before/after proof.
- Fresh independent Codex autoreview of the complete two-file candidate passed with no P0 findings. The PR base, trusted proof base, and inspected current main have identical pre-fix bytes for both owning files. Local proof used Node 24.20.0.

The latest ClawSweeper rank-up requests fresh exact-head CI; that remains the final landing gate. The original production-growth concern is addressed by keeping the predicate in its existing owner rather than adding another selector.

Provenance: raw parent `3e956a4982c09a4b355c85178cb1521e6f672a3f` and the parent-relative patch for `dbd7966cfdb` show the original recent selector admitted successful runs without checking their event. This repair does not change the existing bounded query window: `--recent 1` may print no rows if its four fetched pushes have no successful completed run. Improving that empty/underfilled-sample diagnostic is a separate follow-up.

Published head `151d593d4e49ef570b1a7479c066d8123a5d6301` passed [CI 33490855568](https://github.com/openclaw/openclaw/actions/runs/33490855568), including the required `openclaw/ci-gate`.
