### PR TITLE
test: consolidate audio contract fixtures

### DIFF
--- a/src/media/audio-transcode.test.ts
+++ b/src/media/audio-transcode.test.ts
@@ -227,49 +227,29 @@ describe("transcodeAudioBuffer", () => {
     expect(runCommandWithTimeoutMock).not.toHaveBeenCalled();
   });
 
-  it("returns noop-same-container when source and target containers match", async () => {
+  it.each([
+    [
+      "returns noop-same-container when source and target containers match",
+      "mp3",
+      ".mp3",
+      "noop-same-container",
+    ],
+    [
+      "returns no-recipe when no afconvert recipe is defined for the requested pair",
+      "mp3",
+      "flac",
+      "no-recipe",
+    ],
+    ["returns invalid-extension for an empty source extension", "", "caf", "invalid-extension"],
+    ["returns invalid-extension for an empty target extension", "mp3", "", "invalid-extension"],
+    ["rejects path-traversal style extensions", "../etc/passwd", "caf", "invalid-extension"],
+  ])("%s", async (_name, sourceExtension, targetExtension, reason) => {
     const result = await transcodeAudioBuffer({
       audioBuffer: Buffer.from("payload"),
-      sourceExtension: "mp3",
-      targetExtension: ".mp3",
+      sourceExtension,
+      targetExtension,
     });
-    expect(result).toEqual({ ok: false, reason: "noop-same-container" });
-  });
-
-  it("returns no-recipe when no afconvert recipe is defined for the requested pair", async () => {
-    const result = await transcodeAudioBuffer({
-      audioBuffer: Buffer.from("payload"),
-      sourceExtension: "mp3",
-      targetExtension: "flac",
-    });
-    expect(result).toEqual({ ok: false, reason: "no-recipe" });
-  });
-
-  it("returns invalid-extension for an empty source extension", async () => {
-    const result = await transcodeAudioBuffer({
-      audioBuffer: Buffer.from("payload"),
-      sourceExtension: "",
-      targetExtension: "caf",
-    });
-    expect(result).toEqual({ ok: false, reason: "invalid-extension" });
-  });
-
-  it("returns invalid-extension for an empty target extension", async () => {
-    const result = await transcodeAudioBuffer({
-      audioBuffer: Buffer.from("payload"),
-      sourceExtension: "mp3",
-      targetExtension: "",
-    });
-    expect(result).toEqual({ ok: false, reason: "invalid-extension" });
-  });
-
-  it("rejects path-traversal style extensions", async () => {
-    const result = await transcodeAudioBuffer({
-      audioBuffer: Buffer.from("payload"),
-      sourceExtension: "../etc/passwd",
-      targetExtension: "caf",
-    });
-    expect(result).toEqual({ ok: false, reason: "invalid-extension" });
+    expect(result).toEqual({ ok: false, reason });
   });
 
   it("returns platform-unsupported off-Darwin without invoking afconvert", async () => {

--- a/src/media/audio.test.ts
+++ b/src/media/audio.test.ts
@@ -3,24 +3,6 @@ import { describe, expect, it } from "vitest";
 import { isVoiceCompatibleAudio } from "./audio.js";
 
 describe("isVoiceCompatibleAudio", () => {
-  function expectVoiceCompatibilityCase(
-    opts: Parameters<typeof isVoiceCompatibleAudio>[0],
-    expected: boolean,
-  ) {
-    expect(isVoiceCompatibleAudio(opts)).toBe(expected);
-  }
-
-  function expectVoiceCompatibilityCases(
-    cases: ReadonlyArray<{
-      opts: Parameters<typeof isVoiceCompatibleAudio>[0];
-      expected: boolean;
-    }>,
-  ) {
-    cases.forEach(({ opts, expected }) => {
-      expectVoiceCompatibilityCase(opts, expected);
-    });
-  }
-
   it.each([
     {
       name: "returns true for supported MIME types",
@@ -78,6 +60,8 @@ describe("isVoiceCompatibleAudio", () => {
       ],
     },
   ])("$name", ({ cases }) => {
-    expectVoiceCompatibilityCases(cases);
+    for (const { opts, expected } of cases) {
+      expect(isVoiceCompatibleAudio(opts)).toBe(expected);
+    }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The audio tests repeat the same container-preflight call five times and route voice-compatibility assertions through two forwarding helpers. The duplication adds code without distinguishing another behavior.

## Why This Change Was Made

Keep all five container-preflight cases as separately named table rows with the exact original input extensions and complete failure outcomes. Inline the existing voice-compatibility assertion into its table callback, retaining all 23 input/expected pairs.

The real staging, output-byte, path-safety, duration-flag, and workspace-cleanup tests remain unchanged, including the failed-staging regression from #126378. Import resets, per-case cleanup hooks, mocked process boundaries, the platform-specific case, and the public compatibility alias remain unchanged. No sharding, concurrency, timeout, production, or dependency change.

## User Impact

A smaller test implementation with the same runtime calls and behavioral expectations. No product or suite-wide timing change is claimed.

## Evidence

- Before and after: `node scripts/run-vitest.mjs src/media/audio-transcode.test.ts src/media/audio.test.ts src/media/ffmpeg-exec.test.ts` passes all 27 owner/sibling cases. All expanded test names and per-file ordering match exactly.
- Static row comparison preserves all five preflight inputs/outcomes and all 23 voice-compatibility oracles, including MIME parameters, unsupported formats, empty input, and MIME-over-filename precedence.
- Direct Vitest inspection confirms each row retains individual registration and cleanup. The installed fs-safe workspace and the actual-parent staging repair were inspected; their real filesystem proof is untouched.
- `CI=1 node scripts/check-changed.mjs -- src/media/audio-transcode.test.ts src/media/audio.test.ts` passes all 20 checks.
- Codex autoreview is clean at its configured P0 threshold; independent full owner/caller/sibling review found no actionable issue.

Production LOC: unchanged. Tests: +23/-59, 36 fewer lines. This is unnecessary-code removal, not a measured speedup.

## Review Follow-through

Exact-head [CI33356321594](https://github.com/openclaw/openclaw/actions/runs/33356321594) succeeded. The completed [ClawSweeper review](https://github.com/openclaw/openclaw/pull/133779#issuecomment-5473666076) found no code defect but could not materialize newer main in its partial clone. The maintainer independently checked current main `999127b41c18fee26b43167555f37d20a308ac58`: both changed test files, both media owners, ffmpeg owner/tests and TTS caller are byte-identical to the reviewed parent. All named contract rows remain accounted for. This closes that inspection gap and satisfies the Rank-up request to complete CI and refresh the current-main review. No rebase or source change was needed.
