### PR TITLE
test(agents): repair runner admission fixture ownership

### DIFF
--- a/src/agents/admitted-run-context.test-support.test.ts
+++ b/src/agents/admitted-run-context.test-support.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import type { PreparedAgentRunAdmission } from "./admitted-run-context.js";
+import { wrapRunWithTestPreparedAdmission } from "./admitted-run-context.test-support.js";
+
+describe("runner fixture admission ownership", () => {
+  it.each(["resolve", "reject"] as const)(
+    "keeps a post-reset admission active across retries and closes after %s",
+    async (outcome) => {
+      vi.resetModules();
+      const { resolvePreparedRunAdmission, resolveAdmittedRunActiveAssertion } =
+        await import("./admitted-run-context.js");
+      const failure = new Error("fixture run failed");
+      let assertActive: (() => void) | undefined;
+      const run = wrapRunWithTestPreparedAdmission(
+        async (params: { runId: string; preparedRunAdmission?: PreparedAgentRunAdmission }) => {
+          const first = await resolvePreparedRunAdmission({ ...params, runtimeKind: "embedded" });
+          assertActive = resolveAdmittedRunActiveAssertion(first);
+          expect(assertActive).toBeTypeOf("function");
+          expect(assertActive).not.toThrow();
+          await Promise.resolve();
+          const retry = await resolvePreparedRunAdmission({ ...params, runtimeKind: "embedded" });
+          expect(retry).toBe(first);
+          expect(assertActive).not.toThrow();
+          if (outcome === "reject") {
+            throw failure;
+          }
+          return "complete";
+        },
+      );
+
+      const result = run({ runId: `fixture-owner-${outcome}` });
+      if (outcome === "reject") {
+        await expect(result).rejects.toBe(failure);
+      } else {
+        await expect(result).resolves.toBe("complete");
+      }
+      expect(assertActive).toThrow("admitted run authority is no longer active");
+    },
+  );
+});

--- a/src/agents/admitted-run-context.test-support.ts
+++ b/src/agents/admitted-run-context.test-support.ts
@@ -25,24 +25,28 @@ export function withTestAdmittedRunContext<T extends { runId: string }>(
   };
 }
 
-/** Adapts a production runner only at a test boundary; production stays fail-closed. */
-export function wrapRunWithTestAdmission<P extends { runId: string }, R>(
-  run: (params: P) => R,
-): (params: Omit<P, "admittedRunContext" | "preparedRunAdmission">) => R {
-  return (params) =>
-    run({
-      ...params,
-      admittedRunContext: createTestAdmittedRunContext(params.runId),
-    } as unknown as P);
+/** Owns one canonical admission across a fixture's complete retry/fallback lifetime. */
+export async function withTestPreparedRunAdmission<R>(
+  runId: string,
+  run: (preparedRunAdmission: PreparedAgentRunAdmission) => Promise<R>,
+): Promise<R> {
+  // Tests reset modules before loading runners; resolve their current lease owner, not
+  // the module instance captured when this helper was first imported.
+  const { prepareSystemAgentRunAdmission } = await import("./admitted-run-context.js");
+  const prepared = prepareSystemAgentRunAdmission({}, runId, "test", "test-runner");
+  try {
+    return await run(prepared);
+  } finally {
+    prepared.close();
+  }
 }
 
-/** Exercises the real post-selection admission boundary without enabling audit collection. */
+/** Exercises post-selection admission and closes it only after the runner settles. */
 export function wrapRunWithTestPreparedAdmission<P extends { runId: string }, R>(
-  run: (params: P) => R,
-): (params: Omit<P, "admittedRunContext" | "preparedRunAdmission">) => R {
+  run: (params: P) => Promise<R>,
+): (params: Omit<P, "admittedRunContext" | "preparedRunAdmission">) => Promise<R> {
   return (params) =>
-    run({
-      ...params,
-      preparedRunAdmission: createTestPreparedRunAdmission(params.runId),
-    } as unknown as P);
+    withTestPreparedRunAdmission(params.runId, (preparedRunAdmission) =>
+      run({ ...params, preparedRunAdmission } as unknown as P),
+    );
 }

--- a/src/agents/cli-runner.before-agent-reply-cron.test.ts
+++ b/src/agents/cli-runner.before-agent-reply-cron.test.ts
@@ -13,7 +13,7 @@ import {
   type DiagnosticEventPayload,
 } from "../infra/diagnostic-events.js";
 import type { HookRunner } from "../plugins/hooks.js";
-import { wrapRunWithTestAdmission } from "./admitted-run-context.test-support.js";
+import { wrapRunWithTestPreparedAdmission } from "./admitted-run-context.test-support.js";
 import { testing as cliBackendsTesting } from "./cli-backends.test-support.js";
 import type { CliOutput } from "./cli-output-contracts.js";
 import { CliAuthProfilePreparationError } from "./cli-runner/auth-profile-preparation-error.js";
@@ -189,7 +189,7 @@ beforeEach(() => {
 
 beforeAll(async () => {
   const cliRunner = await import("./cli-runner.js");
-  runCliAgent = wrapRunWithTestAdmission(cliRunner.runCliAgent);
+  runCliAgent = wrapRunWithTestPreparedAdmission(cliRunner.runCliAgent);
   ({ restoreCliRunnerTestDeps, setCliRunnerTestDeps } = cliRunner);
 });
 

--- a/src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts
@@ -7,7 +7,7 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { redactIdentifier } from "../logging/redact-identifier.js";
-import { wrapRunWithTestAdmission } from "./admitted-run-context.test-support.js";
+import { wrapRunWithTestPreparedAdmission } from "./admitted-run-context.test-support.js";
 import {
   resolveInlineProviderApiKeyUsageId,
   type AuthProfileFailureReason,
@@ -116,7 +116,7 @@ const originalFetch = globalThis.fetch;
 beforeAll(async () => {
   vi.resetModules();
   installRunEmbeddedMocks();
-  runEmbeddedAgent = wrapRunWithTestAdmission(
+  runEmbeddedAgent = wrapRunWithTestPreparedAdmission(
     (await import("./embedded-agent-runner/run.js")).runEmbeddedAgent,
   );
   ({ createDiagnosticLogRecordCapture: createDiagnosticLogRecordCaptureFn } =

--- a/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.fault-sequences.e2e.test.ts
@@ -1,10 +1,9 @@
 // Exercises ordered provider faults through the embedded runner failover boundary.
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { wrapRunWithTestAdmission } from "./admitted-run-context.test-support.js";
+import { withTestPreparedRunAdmission } from "./admitted-run-context.test-support.js";
 import { ensureAuthProfileStore, saveAuthProfileStore } from "./auth-profiles/store.js";
 import {
   classifyEmbeddedAgentRunResultForModelFallback,
@@ -23,10 +22,6 @@ import {
   installEmbeddedRunnerBaseE2eMocks,
   installEmbeddedRunnerFastRunE2eMocks,
 } from "./test-helpers/embedded-agent-runner-e2e-mocks.js";
-import {
-  captureRoutingDecisionWork,
-  createModelRoutingTestAdmission,
-} from "./test-helpers/model-routing-decision-e2e-fixtures.js";
 
 type ProviderFault =
   | { status: 200; text: string }
@@ -71,11 +66,9 @@ vi.mock("./models-config.js", async () => {
 });
 
 type ProductionRunEmbeddedAgent = typeof import("./embedded-agent-runner/run.js").runEmbeddedAgent;
-type TestRunEmbeddedAgent = (
-  params: Omit<Parameters<ProductionRunEmbeddedAgent>[0], "admittedRunContext">,
-) => ReturnType<ProductionRunEmbeddedAgent>;
-let runEmbeddedAgent: TestRunEmbeddedAgent;
 let runEmbeddedAgentWithPreparedAdmission: ProductionRunEmbeddedAgent;
+let captureRoutingDecisionWork: typeof import("./test-helpers/model-routing-decision-e2e-fixtures.js").captureRoutingDecisionWork;
+let createModelRoutingTestAdmission: typeof import("./test-helpers/model-routing-decision-e2e-fixtures.js").createModelRoutingTestAdmission;
 let runWithModelFallback: typeof import("./model-fallback-runner.js").runWithModelFallback;
 
 beforeAll(async () => {
@@ -95,7 +88,8 @@ beforeAll(async () => {
 
   runEmbeddedAgentWithPreparedAdmission = (await import("./embedded-agent-runner/run.js"))
     .runEmbeddedAgent;
-  runEmbeddedAgent = wrapRunWithTestAdmission(runEmbeddedAgentWithPreparedAdmission);
+  ({ captureRoutingDecisionWork, createModelRoutingTestAdmission } =
+    await import("./test-helpers/model-routing-decision-e2e-fixtures.js"));
   ({ runWithModelFallback } = await import("./model-fallback-runner.js"));
 });
 
@@ -137,19 +131,12 @@ function makeProviderConfig(fallbacks: string[]): OpenClawConfig {
 async function withScenarioWorkspace<T>(
   run: (paths: { agentDir: string; workspaceDir: string }) => Promise<T>,
 ): Promise<T> {
-  const rawRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-fault-sequences-"));
-  const root = await fs.realpath(rawRoot);
-  const agentDir = path.join(root, "agent");
-  const workspaceDir = path.join(root, "workspace");
-  await Promise.all([
-    fs.mkdir(agentDir, { recursive: true }),
-    fs.mkdir(workspaceDir, { recursive: true }),
-  ]);
-  try {
-    return await run({ agentDir, workspaceDir });
-  } finally {
-    await fs.rm(root, { recursive: true, force: true });
-  }
+  const { withOpenClawTestState } = await import("../test-utils/openclaw-test-state.js");
+  return await withOpenClawTestState({ label: "fault-sequences" }, async (state) => {
+    const agentDir = state.agentDir("test");
+    await fs.mkdir(agentDir, { recursive: true });
+    return await run({ agentDir, workspaceDir: state.workspaceDir });
+  });
 }
 
 function writeProfiles(agentDir: string, profiles: { openai: 1 | 2; groq?: boolean }): void {
@@ -233,7 +220,12 @@ function makeAttemptForFault(
 function installFaultScript(faults: ProviderFault[], observations: AttemptObservation[]): void {
   let index = 0;
   runEmbeddedAttemptMock.mockImplementation(async (rawParams: unknown) => {
-    const params = rawParams as { provider: string; modelId?: string; authProfileId?: string };
+    const params = rawParams as {
+      provider: string;
+      modelId?: string;
+      authProfileId?: string;
+      sessionId: string;
+    };
     const fault = faults[index];
     if (!fault) {
       throw new Error(`unexpected provider attempt ${index + 1}`);
@@ -241,7 +233,7 @@ function installFaultScript(faults: ProviderFault[], observations: AttemptObserv
     index += 1;
     const ref = { provider: params.provider, model: params.modelId ?? "unknown" };
     observations.push({ ...ref, profileId: params.authProfileId, fault });
-    return makeAttemptForFault(fault, ref);
+    return { ...makeAttemptForFault(fault, ref), sessionIdUsed: params.sessionId };
   });
 }
 
@@ -251,40 +243,59 @@ async function runScenario(params: {
   config: OpenClawConfig;
   runId: string;
 }): Promise<ScenarioOutcome> {
+  const { loadSessionEntry, replaceSessionEntrySync } =
+    await import("../config/sessions/session-accessor.js");
+  const { forgetActiveSessionForShutdown } =
+    await import("../gateway/active-sessions-shutdown-tracker.js");
+  const sessionId = `session:${params.runId}`;
+  const sessionKey = `agent:test:${params.runId}`;
+  const sessionTarget = {
+    agentId: "test",
+    sessionId,
+    sessionKey,
+    storePath: path.join(params.agentDir, "openclaw-agent.sqlite"),
+  };
   try {
-    const outcome = await runWithModelFallback<EmbeddedAgentRunResult>({
-      cfg: params.config,
-      provider: "openai",
-      model: "mock-1",
-      runId: params.runId,
-      sessionId: `session:${params.runId}`,
-      sessionKey: `agent:test:${params.runId}`,
-      agentDir: params.agentDir,
-      classifyResult: ({ provider, model, result }) =>
-        classifyEmbeddedAgentRunResultForModelFallback({ provider, model, result }),
-      mergeExhaustedResult: ({ latestResult, preferredResult }) =>
-        mergeEmbeddedAgentRunResultForModelFallbackExhaustion({
-          latestResult,
-          preferredResult,
-        }),
-      run: async (provider, model, options) =>
-        await runEmbeddedAgent({
-          sessionId: `session:${params.runId}`,
-          sessionKey: `agent:test:${params.runId}`,
-          workspaceDir: params.workspaceDir,
-          agentDir: params.agentDir,
-          config: params.config,
-          prompt: "hello",
-          provider,
-          model,
-          authProfileIdSource: "auto",
-          allowTransientCooldownProbe: options?.allowTransientCooldownProbe,
-          isFinalFallbackAttempt: options?.isFinalFallbackAttempt,
-          timeoutMs: 250,
-          runId: params.runId,
-          enqueue: async (task) => await task(),
-        }),
-    });
+    // The attempt mock skips first-turn persistence; seed an empty row so
+    // the public lane can establish the real writer claim before recovery.
+    replaceSessionEntrySync(sessionTarget, { sessionId, updatedAt: 1 });
+    const outcome = await withTestPreparedRunAdmission(params.runId, (preparedRunAdmission) =>
+      runWithModelFallback<EmbeddedAgentRunResult>({
+        cfg: params.config,
+        provider: "openai",
+        model: "mock-1",
+        runId: params.runId,
+        sessionId,
+        sessionKey,
+        agentDir: params.agentDir,
+        classifyResult: ({ provider, model, result }) =>
+          classifyEmbeddedAgentRunResultForModelFallback({ provider, model, result }),
+        mergeExhaustedResult: ({ latestResult, preferredResult }) =>
+          mergeEmbeddedAgentRunResultForModelFallbackExhaustion({
+            latestResult,
+            preferredResult,
+          }),
+        run: async (provider, model, options) =>
+          await runEmbeddedAgentWithPreparedAdmission({
+            preparedRunAdmission,
+            sessionId,
+            sessionKey,
+            sessionTarget,
+            workspaceDir: params.workspaceDir,
+            agentDir: params.agentDir,
+            config: params.config,
+            prompt: "hello",
+            provider,
+            model,
+            authProfileIdSource: "auto",
+            allowTransientCooldownProbe: options?.allowTransientCooldownProbe,
+            isFinalFallbackAttempt: options?.isFinalFallbackAttempt,
+            timeoutMs: 250,
+            runId: params.runId,
+            enqueue: async (task) => await task(),
+          }),
+      }),
+    );
     return {
       kind: "result",
       provider: outcome.provider,
@@ -297,6 +308,12 @@ async function runScenario(params: {
       throw error;
     }
     return { kind: "error", error };
+  } finally {
+    forgetActiveSessionForShutdown(sessionId);
+    const current = loadSessionEntry({ ...sessionTarget, readConsistency: "latest" });
+    if (current) {
+      forgetActiveSessionForShutdown(current.sessionId);
+    }
   }
 }
 
@@ -305,10 +322,10 @@ async function readUsageStats(agentDir: string) {
 }
 
 function expectResult(outcome: ScenarioOutcome): Extract<ScenarioOutcome, { kind: "result" }> {
-  expect(outcome.kind).toBe("result");
   if (outcome.kind !== "result") {
     throw outcome.error;
   }
+  expect(outcome.kind).toBe("result");
   return outcome;
 }
 
@@ -329,7 +346,7 @@ function deferredVoid() {
 }
 
 async function expectPreparationInvalidationToDropRoutingWork(
-  mode: "close" | "replace",
+  mode: "close" | "replace" | "closed-before-preparation",
 ): Promise<void> {
   await withScenarioWorkspace(async ({ agentDir, workspaceDir }) => {
     const runId = `route-preparation-${mode}`;
@@ -352,7 +369,11 @@ async function expectPreparationInvalidationToDropRoutingWork(
       runId,
       boundary: "route-preparation-e2e",
     });
+    if (mode === "closed-before-preparation") {
+      preparedAdmission.close();
+    }
     let replacementAdmission: ReturnType<typeof createModelRoutingTestAdmission> | undefined;
+    let run: ReturnType<ProductionRunEmbeddedAgent> | undefined;
     const reachedPreparation = deferredVoid();
     const releasePreparation = deferredVoid();
     const realMkdir = fs.mkdir.bind(fs);
@@ -365,7 +386,7 @@ async function expectPreparationInvalidationToDropRoutingWork(
     });
     try {
       const { decisionWork } = await captureRoutingDecisionWork(async () => {
-        const run = runEmbeddedAgentWithPreparedAdmission({
+        run = runEmbeddedAgentWithPreparedAdmission({
           preparedRunAdmission: preparedAdmission,
           sessionId: `session:${runId}`,
           sessionKey: `agent:test:${runId}`,
@@ -379,7 +400,13 @@ async function expectPreparationInvalidationToDropRoutingWork(
           runId,
           enqueue: async (task) => await task(),
         });
-        await reachedPreparation.promise;
+        // Observe early rejection immediately so a failed run cannot strand this
+        // preparation wait and leave the process-wide mkdir spy installed.
+        const preparation = await Promise.race([
+          reachedPreparation.promise.then(() => "prepared"),
+          run.then(() => "completed"),
+        ]);
+        expect(preparation).toBe("prepared");
         if (mode === "close") {
           preparedAdmission.close();
         } else {
@@ -401,6 +428,9 @@ async function expectPreparationInvalidationToDropRoutingWork(
       replacementAdmission?.close();
       preparedAdmission.close();
       mkdirSpy.mockRestore();
+      if (run) {
+        await Promise.allSettled([run]);
+      }
     }
   });
 }
@@ -412,6 +442,14 @@ describe("runEmbeddedAgent provider fault sequences", () => {
 
   it("drops routing work when the admitted run is replaced during attempt preparation", async () => {
     await expectPreparationInvalidationToDropRoutingWork("replace");
+  });
+
+  it("restores the preparation spy when admission fails before preparation", async () => {
+    const mkdirBefore = fs.mkdir;
+    await expect(
+      expectPreparationInvalidationToDropRoutingWork("closed-before-preparation"),
+    ).rejects.toThrow("prepared execution context is already closed");
+    expect(fs.mkdir).toBe(mkdirBefore);
   });
 
   it("429 -> 429 -> 200 consumes two same-model retries without rotating", async () => {

--- a/src/agents/model-fallback.run-embedded.e2e.test.ts
+++ b/src/agents/model-fallback.run-embedded.e2e.test.ts
@@ -4,7 +4,10 @@ import os from "node:os";
 import path from "node:path";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import { wrapRunWithTestAdmission } from "./admitted-run-context.test-support.js";
+import {
+  withTestPreparedRunAdmission,
+  wrapRunWithTestPreparedAdmission,
+} from "./admitted-run-context.test-support.js";
 import type { AuthProfileFailureReason } from "./auth-profiles.js";
 import { ensureAuthProfileStore, saveAuthProfileStore } from "./auth-profiles/store.js";
 import { classifyEmbeddedAgentRunResultForModelFallback } from "./embedded-agent-runner/result-fallback-classifier.js";
@@ -94,7 +97,7 @@ beforeAll(async () => {
   installRunEmbeddedMocks();
   runEmbeddedAgentWithPreparedAdmission = (await import("./embedded-agent-runner/run.js"))
     .runEmbeddedAgent;
-  runEmbeddedAgent = wrapRunWithTestAdmission(runEmbeddedAgentWithPreparedAdmission);
+  runEmbeddedAgent = wrapRunWithTestPreparedAdmission(runEmbeddedAgentWithPreparedAdmission);
   ({ runWithModelFallback } = await import("./model-fallback-runner.js"));
   ({ runEmbeddedAgentEntry } = await import("./embedded-agent-runner/run-entry.js"));
 });
@@ -272,35 +275,38 @@ async function runEmbeddedFallback(params: {
   // keeping provider/model attempts deterministic through mocks.
   const cfg = params.config ?? makeConfig();
   const sessionId = params.sessionId ?? `session:${params.runId}`;
-  return await runWithModelFallback({
-    cfg,
-    provider: params.provider ?? "openai",
-    model: "mock-1",
-    runId: params.runId,
-    sessionId: params.sessionId,
-    lane: params.lane,
-    agentDir: params.agentDir,
-    abortSignal: params.abortSignal,
-    run: (provider, model, options) =>
-      runEmbeddedAgent({
-        sessionId,
-        sessionKey: params.sessionKey,
-        workspaceDir: params.workspaceDir,
-        agentDir: params.agentDir,
-        config: cfg,
-        prompt: "hello",
-        provider,
-        model,
-        lane: params.lane,
-        authProfileIdSource: "auto",
-        allowTransientCooldownProbe: options?.allowTransientCooldownProbe,
-        isFinalFallbackAttempt: options?.isFinalFallbackAttempt,
-        timeoutMs: 5_000,
-        runId: params.runId,
-        abortSignal: params.abortSignal,
-        enqueue: async (task) => await task(),
-      }),
-  });
+  return await withTestPreparedRunAdmission(params.runId, (preparedRunAdmission) =>
+    runWithModelFallback({
+      cfg,
+      provider: params.provider ?? "openai",
+      model: "mock-1",
+      runId: params.runId,
+      sessionId: params.sessionId,
+      lane: params.lane,
+      agentDir: params.agentDir,
+      abortSignal: params.abortSignal,
+      run: (provider, model, options) =>
+        runEmbeddedAgentWithPreparedAdmission({
+          preparedRunAdmission,
+          sessionId,
+          sessionKey: params.sessionKey,
+          workspaceDir: params.workspaceDir,
+          agentDir: params.agentDir,
+          config: cfg,
+          prompt: "hello",
+          provider,
+          model,
+          lane: params.lane,
+          authProfileIdSource: "auto",
+          allowTransientCooldownProbe: options?.allowTransientCooldownProbe,
+          isFinalFallbackAttempt: options?.isFinalFallbackAttempt,
+          timeoutMs: 5_000,
+          runId: params.runId,
+          abortSignal: params.abortSignal,
+          enqueue: async (task) => await task(),
+        }),
+    }),
+  );
 }
 
 async function runEmbeddedEntryFallback(params: {
@@ -809,9 +815,7 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
           sessionKey: "agent:test:direct-embedded-suspension",
           workspaceDir,
           agentDir,
-          config: {
-            ...makeConfig(),
-          },
+          config: makeConfig(),
           prompt: "hello",
           provider: "openai",
           model: "mock-1",
@@ -841,9 +845,7 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
         sessionKey: "agent:test:outer-fallback-suspension",
         lane: "outer-fallback-lane",
         runId: "run:outer-fallback-suspension",
-        config: {
-          ...makeConfig(),
-        },
+        config: makeConfig(),
       });
 
       expect(result.provider).toBe("groq");
@@ -1050,9 +1052,7 @@ describe("runWithModelFallback + runEmbeddedAgent failover behavior", () => {
         workspaceDir,
         sessionKey: "agent:test:rate-limit-retry-limit-fallback",
         runId: "run:rate-limit-retry-limit-fallback",
-        config: {
-          ...makeConfig(),
-        },
+        config: makeConfig(),
       });
 
       expect(result.provider).toBe("openai");


### PR DESCRIPTION
## What Problem This Solves

Resolves runner-test failures caused by fixtures supplying an inert admission context after the runtime began requiring an active, owner-held admission. Module resets also left some fixtures and runners referring to different admission owners, preventing the intended retry and fallback assertions from being exercised.

## Why This Change Was Made

The test helper now acquires one canonical admission from the current module instance, retains it across the entire retry/fallback operation, and closes it in `finally`. A preparation barrier observes early runner rejection and always restores its filesystem spy and joins the run. The fault-sequence fixture uses the existing isolated state owner, a real empty session row, and the actual attempt session identity so transcript recovery has a valid writer claim.

No production admission, transcript, storage, or retry policy changes. No assertion, timeout, or test case is removed. Three redundant copies of newly created fixture configuration objects are eliminated to satisfy the existing file-length limit. The subsequent Snapshot cleanup is intentionally a separate change.

## User Impact

No user-visible behavior change. Developers regain meaningful CLI and embedded-runner coverage of admission lifetime, fallback, authentication rotation, and recovery instead of failing during invalid fixture setup.

## Evidence

The original grouped run exposed admission failures; the fault-sequence diagnosis separately preserved the writer-claim failures. The repaired original six-suite run passed all 116 cases before the final redundant-copy simplification. The first normal 20-check gate passed 19 checks and failed the unchanged 1,000-line limit at 1,004 lines; that failure is retained.

Fresh proof on the final six-file afterimage passed the same 116 cases, preserving their identities and per-file order. The separate two-case admission-helper regression also passed in its earlier unchanged-source run. The final precommit review completed all three full-context passes with no P0 findings; its source and runtime bindings were independently rechecked.

The final full changed gate passed all 20 checks, including type checking, lint, formatting, dead-export scans, and the existing file-length ratchet. Full source/index/runtime checks passed afterward; dependencies were unchanged. Its only generated-file change was the expected incremental compiler state, which was checked against the canonical compiler/config owner.

The signed six-file commit also passed a separate exact-commit review: all three full-context passes completed with no P0 findings. Exact-head hosted CI remains pending and will be recorded against the published head, not inferred from local proof.

Production: unchanged. Tests/test support: +205/−123, net +82. Useful regression coverage is retained; this prerequisite is not claimed as line-removal credit. Historical generated declaration bytes were not retained for one renamed family, so old/new declaration semantic equivalence is not claimed; current source and producer attribution are recorded separately from behavioral test results.
