### PR TITLE
improve(gateway): reduce repeated turn preparation work

### DIFF
--- a/src/agents/agent-command.compaction.test-support.ts
+++ b/src/agents/agent-command.compaction.test-support.ts
@@ -70,11 +70,7 @@ vi.mock("../config/io.js", () => ({
 }));
 
 vi.mock("./agent-runtime-config.js", () => ({
-  resolveAgentRuntimeConfig: async () => ({
-    loadedRaw: compactionTestState.cfg,
-    sourceConfig: compactionTestState.cfg,
-    cfg: compactionTestState.cfg,
-  }),
+  resolveAgentRuntimeConfig: async () => compactionTestState.cfg,
 }));
 
 vi.mock("../plugins/plugin-metadata-snapshot.js", async () => {

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -402,11 +402,7 @@ vi.mock("../config/io.js", () => ({
 
 vi.mock("./agent-runtime-config.js", () => {
   return {
-    resolveAgentRuntimeConfig: async () => ({
-      loadedRaw: state.runtimeConfigMock ?? state.defaultRuntimeConfig,
-      sourceConfig: state.runtimeConfigMock ?? state.defaultRuntimeConfig,
-      cfg: state.runtimeConfigMock ?? state.defaultRuntimeConfig,
-    }),
+    resolveAgentRuntimeConfig: async () => state.runtimeConfigMock ?? state.defaultRuntimeConfig,
   };
 });
 

--- a/src/agents/agent-runtime-config.secret-owners.test.ts
+++ b/src/agents/agent-runtime-config.secret-owners.test.ts
@@ -111,7 +111,7 @@ afterEach(async () => {
 });
 
 describe("agent execution respects prepared secret owners", () => {
-  it("reads active config without copying reload-only plugin metadata", async () => {
+  it("reuses active config without copying source or reload-only plugin metadata", async () => {
     const config: OpenClawConfig = {
       plugins: { enabled: false },
       agents: { defaults: { workspace: "/fixture/workspace" } },
@@ -147,13 +147,9 @@ describe("agent execution respects prepared secret owners", () => {
 
     const result = await resolveAgentRuntimeConfig(runtime);
 
-    expect(result.cfg).toBe(active?.config);
-    expect(result.loadedRaw).toBe(result.cfg);
-    expect(result.sourceConfig).toEqual(config);
-    expect(result.sourceConfig).not.toBe(active?.sourceConfig);
-    expect(getConfigResolutionFacts(result.sourceConfig)).toBe(facts);
-    result.sourceConfig.agents!.defaults!.workspace = "/fixture/changed-by-caller";
-    expect(active?.sourceConfig.agents?.defaults?.workspace).toBe("/fixture/workspace");
+    expect(clone).not.toHaveBeenCalledWith(active?.sourceConfig);
+    expect(result).toBe(active?.config);
+    expect(getConfigResolutionFacts(result)).toBe(facts);
     expect(getRuntimeConfigSnapshotMetadata()?.revision).toBe(revision);
     expect(clone).not.toHaveBeenCalledWith(manifestRegistry);
   });
@@ -167,7 +163,7 @@ describe("agent execution respects prepared secret owners", () => {
       const config =
         entry === "reply"
           ? await resolveQueuedReplyExecutionConfig(snapshot.sourceConfig)
-          : (await resolveAgentRuntimeConfig(runtime)).cfg;
+          : await resolveAgentRuntimeConfig(runtime);
       expect(config).toBe(getRuntimeConfigSnapshot());
       expect(config.models?.providers?.healthy?.apiKey).toBe("prepared-fixture-key");
       expect(config.models?.providers?.ollama?.apiKey).toEqual(
@@ -252,7 +248,7 @@ describe("agent execution respects prepared secret owners", () => {
       vi.stubEnv("OLLAMA_API_KEY", "ambient-fixture-key");
       for (const config of [
         await resolveQueuedReplyExecutionConfig(snapshot.sourceConfig),
-        (await resolveAgentRuntimeConfig(runtime)).cfg,
+        await resolveAgentRuntimeConfig(runtime),
       ]) {
         await expect(
           resolveApiKeyForProviderCore({
@@ -323,7 +319,7 @@ describe("agent execution respects prepared secret owners", () => {
       expect(getActiveSecretsRuntimeConfigSnapshot()?.configRefsPrepared).toBe(true);
       for (const config of [
         await resolveQueuedReplyExecutionConfig(snapshot.sourceConfig),
-        (await resolveAgentRuntimeConfig(runtime)).cfg,
+        await resolveAgentRuntimeConfig(runtime),
       ]) {
         expect(config.skills).toEqual(source.skills);
         await expect(
@@ -467,7 +463,7 @@ describe("agent execution respects prepared secret owners", () => {
       resolveAgentRuntimeConfig(runtime, {
         runtimeChannelSecretScope: { channel: "telegram", accountId: "healthy" },
       }),
-    ).resolves.toMatchObject({ cfg: snapshot.config });
+    ).resolves.toEqual(snapshot.config);
     expect(callGatewayMock).not.toHaveBeenCalled();
     await expect(
       resolveQueuedReplyExecutionConfig(snapshot.sourceConfig, {
@@ -510,10 +506,10 @@ describe("agent execution respects prepared secret owners", () => {
     vi.stubEnv("TEST_HEALTHY_PROVIDER_KEY", "local-fixture-key");
     const resolveRef = vi.spyOn(secretResolver, "resolveSecretRefValue");
     const result = await resolveAgentRuntimeConfig(runtime);
-    expect(result.cfg.models?.providers?.healthy?.apiKey).toBe("local-fixture-key");
-    expect(result.cfg.channels).toEqual(config.channels);
-    expect(result.cfg.gateway).toEqual(config.gateway);
-    expect(result.cfg.plugins).toEqual(config.plugins);
+    expect(result.models?.providers?.healthy?.apiKey).toBe("local-fixture-key");
+    expect(result.channels).toEqual(config.channels);
+    expect(result.gateway).toEqual(config.gateway);
+    expect(result.plugins).toEqual(config.plugins);
     expect(resolveRef.mock.calls.map(([ref]) => ref.id)).toEqual(["TEST_HEALTHY_PROVIDER_KEY"]);
   });
 });

--- a/src/agents/agent-runtime-config.ts
+++ b/src/agents/agent-runtime-config.ts
@@ -5,7 +5,6 @@ import {
   getScopedChannelsCommandSecretTargets,
 } from "../cli/command-secret-targets.js";
 import { getRuntimeConfig, readConfigFileSnapshotForWrite } from "../config/io.js";
-import { cloneConfigWithResolutionFacts } from "../config/resolution-facts.js";
 import { setRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isSecretRef } from "../config/types.secrets.js";
@@ -24,12 +23,7 @@ export async function resolveAgentRuntimeConfig(
     runtimeTargetsChannelSecrets?: boolean;
     runtimeChannelSecretScope?: { channel: string; accountId?: string };
   },
-): Promise<{
-  loadedRaw: OpenClawConfig;
-  sourceConfig: OpenClawConfig;
-  cfg: OpenClawConfig;
-  pluginMetadataSnapshot?: PluginMetadataSnapshot;
-}> {
+): Promise<OpenClawConfig> {
   const loadedRaw = getRuntimeConfig();
   const includeChannelTargets = params?.runtimeTargetsChannelSecrets === true;
   const channelSecretScope = params?.runtimeChannelSecretScope;
@@ -40,9 +34,8 @@ export async function resolveAgentRuntimeConfig(
   });
   const activeSecretsConfig = getActiveSecretsRuntimeConfigSnapshot();
   let pluginMetadataSnapshot: PluginMetadataSnapshot | undefined;
-  // Callers own mutable source config, but do not need cloned auth stores or reload metadata.
   const sourceConfig = activeSecretsConfig
-    ? cloneConfigWithResolutionFacts(activeSecretsConfig.sourceConfig)
+    ? activeSecretsConfig.sourceConfig
     : await measureAgentStartup(
         "config-source",
         async () => {
@@ -110,12 +103,7 @@ export async function resolveAgentRuntimeConfig(
     );
     secretsRuntime.activateSecretsRuntimeSnapshot(snapshot);
   }
-  return {
-    loadedRaw,
-    sourceConfig,
-    cfg,
-    ...(pluginMetadataSnapshot ? { pluginMetadataSnapshot } : {}),
-  };
+  return cfg;
 }
 
 function hasNestedSecretRef(value: unknown): boolean {

--- a/src/agents/command/prepare.ts
+++ b/src/agents/command/prepare.ts
@@ -8,6 +8,7 @@ import {
   normalizeVerboseLevel,
 } from "../../auto-reply/thinking.js";
 import { formatCliCommand } from "../../cli/command-format.js";
+import type { InternalSessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveAgentExplicitRecipientSession } from "../../infra/outbound/agent-delivery.js";
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
@@ -50,7 +51,6 @@ import {
 } from "./attempt-execution.shared.js";
 import { resolveExplicitAgentCommandSessionKey } from "./explicit-session-key.js";
 import { loadAcpManagerRuntime } from "./runtime-loaders.js";
-import { createAgentCommandSessionWorkingCopy } from "./session-helpers.js";
 import { resolveSession } from "./session.js";
 import type { AgentCommandOpts } from "./types.js";
 
@@ -122,7 +122,7 @@ export async function prepareAgentCommandExecution(
     );
   }
 
-  const { cfg } = await resolveAgentRuntimeConfig(runtime, {
+  const cfg = await resolveAgentRuntimeConfig(runtime, {
     runtimeTargetsChannelSecrets: opts.deliver === true,
     runtimeChannelSecretScope:
       opts.deliver !== true && shouldResolveExplicitRecipientSession && recipientChannel
@@ -234,11 +234,11 @@ export async function prepareAgentCommandExecution(
     sessionId: commandOpts.sessionId,
     sessionKey: explicitSessionKey ?? explicitRecipientSession?.sessionKey,
     agentId: agentIdOverride,
-    clone: false,
   });
   const {
     sessionId,
     sessionKey,
+    sessionEntry: sessionEntryRaw,
     storePath,
     isNewSession,
     previousSessionId,
@@ -246,24 +246,17 @@ export async function prepareAgentCommandExecution(
     persistedVerbose,
   } = sessionResolution;
   const harnessSessionError = sessionKey
-    ? resolveAgentHarnessSessionContextError(sessionKey, sessionResolution.sessionEntry)
+    ? resolveAgentHarnessSessionContextError(sessionKey, sessionEntryRaw)
     : undefined;
   if (harnessSessionError) {
     throw new Error(harnessSessionError);
   }
   const isOneShotModelRun = opts.modelRun === true || opts.promptMode === "none";
-  if (
-    isOneShotModelRun &&
-    sessionKey &&
-    sessionResolution.sessionEntry?.modelSelectionLocked === true
-  ) {
+  if (isOneShotModelRun && sessionKey && sessionEntryRaw?.modelSelectionLocked === true) {
     throw new Error(AGENT_HARNESS_MODEL_RUN_FORBIDDEN_MESSAGE);
   }
-  const { sessionEntry: sessionEntryRaw, sessionStore } = createAgentCommandSessionWorkingCopy({
-    sessionKey,
-    sessionEntry: sessionResolution.sessionEntry,
-    sessionStore: sessionResolution.sessionStore,
-  });
+  const sessionStore: Record<string, InternalSessionEntry> =
+    sessionKey && sessionEntryRaw ? { [sessionKey]: sessionEntryRaw } : {};
   const sessionAgentId =
     agentIdOverride ??
     resolveSessionAgentId({ sessionKey: sessionKey ?? explicitSessionKey, config: cfg });

--- a/src/agents/command/session-helpers.ts
+++ b/src/agents/command/session-helpers.ts
@@ -115,30 +115,6 @@ export async function prepareCurrentRunDelivery(params: {
   return context ? { context, targetMode } : undefined;
 }
 
-export function createAgentCommandSessionWorkingCopy(params: {
-  sessionKey?: string;
-  sessionEntry?: SessionEntry;
-  sessionStore?: Record<string, SessionEntry>;
-}): {
-  sessionEntry?: SessionEntry;
-  sessionStore?: Record<string, SessionEntry>;
-} {
-  const result: {
-    sessionEntry?: SessionEntry;
-    sessionStore?: Record<string, SessionEntry>;
-  } = {};
-  if (params.sessionEntry) {
-    result.sessionEntry = { ...params.sessionEntry };
-  }
-  if (params.sessionStore || params.sessionKey) {
-    result.sessionStore = {};
-  }
-  if (params.sessionKey && result.sessionEntry && result.sessionStore) {
-    result.sessionStore[params.sessionKey] = result.sessionEntry;
-  }
-  return result;
-}
-
 export function resolveInternalSessionEffectsSource(params: {
   agentId: string;
   sessionId: string;

--- a/src/agents/command/session-store.test.ts
+++ b/src/agents/command/session-store.test.ts
@@ -1069,7 +1069,7 @@ describe("updateSessionStoreAfterAgentRun", () => {
         sessionId: first.sessionId,
         sessionKey: first.sessionKey!,
         storePath: first.storePath,
-        sessionStore: first.sessionStore!,
+        sessionStore: {},
         defaultProvider: "claude-cli",
         defaultModel: "claude-sonnet-4-6",
         result: {

--- a/src/agents/command/session.exact-target.test.ts
+++ b/src/agents/command/session.exact-target.test.ts
@@ -1,0 +1,103 @@
+import fs from "node:fs";
+import { expect, it, vi } from "vitest";
+import { resolveInternalSessionEffectsIdentity } from "../../config/sessions/internal-session-key.js";
+import * as sessionAccessor from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  isOpenClawAgentDatabaseOpen,
+  resolveIncognitoOpenClawAgentSqlitePath,
+} from "../../state/openclaw-agent-db.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { resolveSession, resolveSessionKeyForRequestCore } from "./session.js";
+
+it.each(["work", "dashboard:incognito-work"])(
+  "resolves the exact %s session without enumerating unrelated rows",
+  async (key) => {
+    await withOpenClawTestState({ label: "command-exact-session" }, async (state) => {
+      const storePath = state.path("sessions.sqlite");
+      const sessionKey = `agent:main:${key}`;
+      const incognito = key.startsWith("dashboard:incognito-");
+      const cfg = {
+        agents: { defaults: {} },
+        session: { store: storePath, reset: { mode: "idle", idleMinutes: 60 } },
+      } satisfies OpenClawConfig;
+      const entry = {
+        sessionId: "selected-session",
+        updatedAt: Date.now(),
+        sessionStartedAt: Date.now(),
+        lastInteractionAt: Date.now(),
+        thinkingLevel: "high",
+        modelOverride: "gpt-5.6-luna",
+        providerOverride: "openai",
+        lifecycleRevision: "selected-revision",
+        skillsSnapshot: { prompt: "selected prompt", skills: [] },
+        ...(incognito ? { incognito: true as const } : {}),
+      };
+      await sessionAccessor.replaceSessionEntry({ sessionKey, storePath }, entry);
+      const persisted = sessionAccessor.loadExactSessionEntryReadOnly({
+        sessionKey,
+        storePath,
+      })?.entry;
+      expect(persisted).toMatchObject({
+        thinkingLevel: "high",
+        modelOverride: "gpt-5.6-luna",
+        providerOverride: "openai",
+        lifecycleRevision: expect.any(String),
+      });
+      if (!incognito) {
+        await sessionAccessor.replaceSessionEntry(
+          { sessionKey: "agent:main:unrelated", storePath },
+          { sessionId: "unrelated-session", updatedAt: Date.now() },
+        );
+      }
+      const list = vi.spyOn(sessionAccessor, "listSessionEntriesCore");
+      try {
+        const resolved = resolveSession({ cfg, sessionKey });
+        expect(resolved).toMatchObject({
+          sessionId: entry.sessionId,
+          sessionKey,
+          isNewSession: false,
+          persistedThinking: "high",
+          sessionEntry: persisted,
+        });
+        if (!resolved.sessionEntry?.skillsSnapshot) {
+          throw new Error("expected the selected session's skills");
+        }
+        resolved.sessionEntry.skillsSnapshot.prompt = "caller-owned edit";
+        expect(
+          sessionAccessor.loadExactSessionEntryReadOnly({ sessionKey, storePath })?.entry
+            .skillsSnapshot?.prompt,
+        ).toBe("selected prompt");
+        expect(list).not.toHaveBeenCalled();
+        if (incognito) {
+          expect(fs.existsSync(storePath)).toBe(false);
+        }
+      } finally {
+        list.mockRestore();
+      }
+    });
+  },
+);
+
+it("does not provision a missing incognito lookup or select a hidden run-owned entry", async () => {
+  await withOpenClawTestState({ label: "command-private-session" }, async (state) => {
+    const storePath = state.path("sessions.sqlite");
+    const cfg = { agents: { defaults: {} }, session: { store: storePath } };
+    const incognitoPath = resolveIncognitoOpenClawAgentSqlitePath({ agentId: "main" });
+    expect(
+      resolveSessionKeyForRequestCore({ cfg, sessionKey: "agent:main:dashboard:incognito-missing" })
+        .sessionEntry,
+    ).toBeUndefined();
+    expect(isOpenClawAgentDatabaseOpen(incognitoPath)).toBe(false);
+    expect(fs.existsSync(storePath)).toBe(false);
+
+    const hidden = resolveInternalSessionEffectsIdentity({ agentId: "main", runId: "hidden-run" });
+    await sessionAccessor.replaceSessionEntry(
+      { sessionKey: hidden.sessionKey, storePath },
+      { sessionId: hidden.sessionId, updatedAt: Date.now() },
+    );
+    expect(
+      resolveSessionKeyForRequestCore({ cfg, sessionKey: hidden.sessionKey }).sessionEntry,
+    ).toBeUndefined();
+  });
+});

--- a/src/agents/command/session.provider-owned-reset.test.ts
+++ b/src/agents/command/session.provider-owned-reset.test.ts
@@ -8,6 +8,10 @@ const hoisted = vi.hoisted(() => ({
 }));
 
 vi.mock("../../config/sessions/session-accessor.js", () => ({
+  loadExactSessionEntryReadOnly: ({ sessionKey }: { sessionKey: string }) => {
+    const entry = hoisted.store[sessionKey];
+    return entry ? { sessionKey, entry: structuredClone(entry) } : undefined;
+  },
   listSessionEntriesCore: () =>
     Object.entries(hoisted.store).map(([sessionKey, entry]) => ({
       sessionKey,

--- a/src/agents/command/session.resolve-session-key.test.ts
+++ b/src/agents/command/session.resolve-session-key.test.ts
@@ -12,12 +12,20 @@ const hoisted = vi.hoisted(() => ({
       sessionKey: string;
     }>
   >(),
+  loadExactSessionEntryMock:
+    vi.fn<
+      (scope: {
+        storePath?: string;
+        sessionKey: string;
+      }) => { sessionKey: string; entry: SessionEntry } | undefined
+    >(),
   listAgentIdsMock: vi.fn<() => string[]>(),
 }));
 
 vi.mock("../../config/sessions/session-accessor.js", () => ({
   listSessionEntriesCore: (scope?: { agentId?: string; storePath?: string; clone?: boolean }) =>
     hoisted.listSessionEntriesMock(scope),
+  loadExactSessionEntryReadOnly: hoisted.loadExactSessionEntryMock,
 }));
 
 vi.mock("../../config/sessions/paths.js", () => ({
@@ -43,6 +51,10 @@ const { resolveSessionKeyForRequestCore, resolveStoredSessionKeyForSessionId } =
 const resolveSessionKeyForRequest = resolveSessionKeyForRequestCore;
 
 function mockSessionStores(storesByPath: Record<string, Record<string, SessionEntry>>): void {
+  hoisted.loadExactSessionEntryMock.mockImplementation(({ storePath, sessionKey }) => {
+    const entry = storesByPath[storePath ?? ""]?.[sessionKey];
+    return entry ? { sessionKey, entry: structuredClone(entry) } : undefined;
+  });
   hoisted.listSessionEntriesMock.mockImplementation((scope) =>
     Object.entries(storesByPath[scope?.storePath ?? ""] ?? {}).map(([sessionKey, entry]) => ({
       sessionKey,
@@ -67,13 +79,14 @@ function expectResolvedRequestSession(params: {
   });
 
   expect(result.sessionKey).toBe(params.sessionKey);
-  expect(result.sessionStore).toEqual(params.sessionStore);
+  expect(result.sessionEntry).toEqual(params.sessionStore[params.sessionKey]);
   expect(result.storePath).toBe(params.storePath);
 }
 
 describe("resolveSessionKeyForRequest", () => {
   beforeEach(() => {
     hoisted.listSessionEntriesMock.mockReset();
+    hoisted.loadExactSessionEntryMock.mockReset();
     hoisted.listAgentIdsMock.mockReset();
     hoisted.listAgentIdsMock.mockReturnValue(["main", "other"]);
   });
@@ -138,7 +151,7 @@ describe("resolveSessionKeyForRequest", () => {
     });
 
     expect(result.sessionKey).toBe("agent:embedded-agent:work");
-    expect(result.sessionStore).toEqual(embeddedAgentStore);
+    expect(result.sessionEntry).toEqual(embeddedAgentStore["agent:embedded-agent:work"]);
     expect(result.storePath).toBe("/stores/embedded-agent.json");
     expect(hoisted.listSessionEntriesMock).toHaveBeenCalledTimes(1);
   });
@@ -164,7 +177,7 @@ describe("resolveSessionKeyForRequest", () => {
 
     expect(result.agentId).toBe("ops");
     expect(result.sessionKey).toBe("main");
-    expect(result.sessionStore).toEqual(sharedStore);
+    expect(result.sessionEntry).toEqual(sharedStore.main);
     expect(result.storePath).toBe("/stores/shared.sqlite");
     expect(hoisted.listSessionEntriesMock.mock.calls.map(([scope]) => scope?.agentId)).toEqual([
       "research",
@@ -194,7 +207,7 @@ describe("resolveSessionKeyForRequest", () => {
     ).toMatchObject({
       agentId: "ops",
       sessionKey: "main",
-      sessionStore: sharedStore,
+      sessionEntry: sharedStore.main,
       storePath: "/stores/shared.sqlite",
     });
   });
@@ -241,7 +254,7 @@ describe("resolveSessionKeyForRequest", () => {
     ).toMatchObject({
       agentId: "research",
       sessionKey: "agent:research:work",
-      sessionStore: sharedStore,
+      sessionEntry: sharedStore["agent:research:work"],
       storePath: "/stores/shared.sqlite",
     });
   });
@@ -286,7 +299,7 @@ describe("resolveSessionKeyForRequest", () => {
     ).toMatchObject({
       agentId: "research",
       sessionKey: "agent:research:work",
-      sessionStore: researchStore,
+      sessionEntry: researchStore["agent:research:work"],
       storePath: "/stores/shared.sqlite",
     });
   });
@@ -452,7 +465,7 @@ describe("resolveSessionKeyForRequest", () => {
     ).toMatchObject({
       agentId: "research",
       sessionKey: "agent:research:work",
-      sessionStore: researchStore,
+      sessionEntry: researchStore["agent:research:work"],
       storePath: "/stores/research.json",
     });
   });
@@ -478,7 +491,7 @@ describe("resolveSessionKeyForRequest", () => {
 
     expect(result.agentId).toBe("ops");
     expect(result.sessionKey).toBe("main");
-    expect(result.sessionStore).toEqual(sharedStore);
+    expect(result.sessionEntry).toEqual(sharedStore.main);
     expect(result.storePath).toBe("/stores/shared.sqlite");
     expect(hoisted.listSessionEntriesMock).toHaveBeenCalledTimes(1);
     expect(hoisted.listSessionEntriesMock).toHaveBeenCalledWith(
@@ -550,14 +563,16 @@ describe("resolveSessionKeyForRequest", () => {
     );
   });
 
-  it("borrows session stores when requested", () => {
-    // clone=false is used by callers that intend to mutate the selected store,
-    // so the resolver must pass that option through every candidate load.
+  it("detaches the selected session entry from borrowed store rows", () => {
     const mainStore = {
       "agent:main:main": { sessionId: "sid", updatedAt: 10 },
     } satisfies Record<string, SessionEntry>;
     const otherStore = {
-      "agent:other:acp:sid": { sessionId: "sid", updatedAt: 20 },
+      "agent:other:acp:sid": {
+        sessionId: "sid",
+        updatedAt: 20,
+        skillsSnapshot: { prompt: "selected prompt", skills: [] },
+      },
     } satisfies Record<string, SessionEntry>;
     mockSessionStores({
       "/stores/main.json": mainStore,
@@ -571,11 +586,15 @@ describe("resolveSessionKeyForRequest", () => {
         },
       } satisfies OpenClawConfig,
       sessionId: "sid",
-      clone: false,
     });
 
     expect(result.sessionKey).toBe("agent:other:acp:sid");
-    expect(result.sessionStore).toEqual(otherStore);
+    expect(result.sessionEntry).toEqual(otherStore["agent:other:acp:sid"]);
+    if (!result.sessionEntry?.skillsSnapshot) {
+      throw new Error("expected the selected session's skills");
+    }
+    result.sessionEntry.skillsSnapshot.prompt = "caller-owned edit";
+    expect(otherStore["agent:other:acp:sid"].skillsSnapshot.prompt).toBe("selected prompt");
     expect(hoisted.listSessionEntriesMock).toHaveBeenCalledWith(
       expect.objectContaining({
         storePath: "/stores/main.json",

--- a/src/agents/command/session.ts
+++ b/src/agents/command/session.ts
@@ -12,6 +12,7 @@ import {
 } from "../../auto-reply/thinking.js";
 import { tryResolveLegacyCompatibilityAgentId } from "../../config/legacy.default-agent-owner.js";
 import { hasProviderOwnedSession } from "../../config/sessions/entry-freshness.js";
+import { isInternalSessionEffectsKey } from "../../config/sessions/internal-session-key.js";
 import {
   hasTerminalMainSessionTranscriptNewerThanRegistrySync,
   resolveSessionLifecycleTimestamps,
@@ -27,7 +28,11 @@ import {
   resolveSessionResetPolicy,
 } from "../../config/sessions/reset-policy.js";
 import { resolveChannelResetConfig, resolveSessionResetType } from "../../config/sessions/reset.js";
-import { listSessionEntriesCore } from "../../config/sessions/session-accessor.js";
+import {
+  listSessionEntriesCore,
+  loadExactSessionEntryReadOnly,
+  type SessionEntrySummary,
+} from "../../config/sessions/session-accessor.js";
 import { resolveSessionKey } from "../../config/sessions/session-key.js";
 import {
   resolvePersistedSessionStoreOwner,
@@ -59,7 +64,6 @@ type SessionResolution = {
   sessionId: string;
   sessionKey?: string;
   sessionEntry?: InternalSessionEntry;
-  sessionStore?: Record<string, InternalSessionEntry>;
   storePath: string;
   isNewSession: boolean;
   previousSessionId?: string;
@@ -70,7 +74,7 @@ type SessionResolution = {
 type SessionKeyResolution = {
   agentId?: string;
   sessionKey?: string;
-  sessionStore: Record<string, InternalSessionEntry>;
+  sessionEntry?: InternalSessionEntry;
   storePath: string;
 };
 
@@ -122,7 +126,7 @@ type SessionIdMatchSet = {
 type SessionIdMatchCandidate = {
   sessionKey: string;
   entry: InternalSessionEntry;
-  resolution: SessionKeyResolution;
+  resolution: Omit<SessionKeyResolution, "sessionEntry">;
   primary: boolean;
 };
 
@@ -151,18 +155,15 @@ function selectSessionIdMatchCandidate(
     })[0];
 }
 
-function loadCommandSessionStore(params: {
+function loadCommandSessionEntries(params: {
   agentId?: string;
-  clone?: boolean;
   storePath: string;
-}): Record<string, InternalSessionEntry> {
-  return Object.fromEntries(
-    listSessionEntriesCore({
-      storePath: params.storePath,
-      ...(params.agentId ? { agentId: params.agentId } : {}),
-      ...(params.clone === false ? { clone: false } : {}),
-    }).map(({ sessionKey, entry }) => [sessionKey, entry]),
-  );
+}): SessionEntrySummary[] {
+  return listSessionEntriesCore({
+    storePath: params.storePath,
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    clone: false,
+  });
 }
 
 /** Builds the synthetic session key used for explicit session-id runs. */
@@ -175,12 +176,11 @@ export function buildExplicitSessionIdSessionKey(params: {
 
 function collectSessionIdMatchesForRequest(opts: {
   cfg: OpenClawConfig;
-  sessionStore: Record<string, InternalSessionEntry>;
+  sessionEntries: SessionEntrySummary[];
   storePath: string;
   storeAgentId?: string;
   sessionId: string;
   searchOtherAgentStores: boolean;
-  clone?: boolean;
 }): SessionIdMatchSet {
   const candidates: SessionIdMatchCandidate[] = [];
   let ownerConflict = false;
@@ -198,12 +198,12 @@ function collectSessionIdMatchesForRequest(opts: {
   }
 
   const addMatches = (
-    candidateStore: Record<string, InternalSessionEntry>,
+    candidateEntries: SessionEntrySummary[],
     candidateStorePath: string,
     candidateAgentId: string | undefined,
     options?: { primary?: boolean },
   ): void => {
-    for (const [candidateKey, candidateEntry] of Object.entries(candidateStore)) {
+    for (const { sessionKey: candidateKey, entry: candidateEntry } of candidateEntries) {
       if (candidateEntry?.sessionId !== opts.sessionId) {
         continue;
       }
@@ -259,14 +259,13 @@ function collectSessionIdMatchesForRequest(opts: {
         resolution: {
           ...(matchedAgentId ? { agentId: normalizeAgentId(matchedAgentId) } : {}),
           sessionKey: candidateKey,
-          sessionStore: candidateStore,
           storePath: candidateStorePath,
         },
       });
     }
   };
 
-  addMatches(opts.sessionStore, opts.storePath, opts.storeAgentId, { primary: true });
+  addMatches(opts.sessionEntries, opts.storePath, opts.storeAgentId, { primary: true });
   if (!opts.searchOtherAgentStores) {
     return { candidates, ownerConflict };
   }
@@ -277,10 +276,9 @@ function collectSessionIdMatchesForRequest(opts: {
     }
     const candidateStorePath = resolveSessionStorePathCore(opts.cfg.session?.store, { agentId });
     addMatches(
-      loadCommandSessionStore({
+      loadCommandSessionEntries({
         agentId,
         storePath: candidateStorePath,
-        ...(opts.clone === false ? { clone: false } : {}),
       }),
       candidateStorePath,
       agentId,
@@ -314,12 +312,12 @@ export function resolveStoredSessionKeyForSessionId(opts: {
   const storePath = resolveSessionStorePathCore(opts.cfg.session?.store, {
     agentId: storeAgentId,
   });
-  const sessionStore = loadCommandSessionStore({
+  const sessionEntries = loadCommandSessionEntries({
     storePath,
     agentId: storeAgentId,
   });
   if (!sessionId) {
-    return { sessionKey: undefined, sessionStore, storePath };
+    return { sessionKey: undefined, storePath };
   }
 
   const resolveMatchedAgentId = (sessionKey: string): string | undefined => {
@@ -334,12 +332,10 @@ export function resolveStoredSessionKeyForSessionId(opts: {
         ? undefined
         : (requestedAgentId ?? tryResolveLegacyCompatibilityAgentId(opts.cfg));
   };
-  const sessionIdMatches = Object.entries(sessionStore).filter(
-    ([, entry]) => entry?.sessionId === sessionId,
-  );
+  const sessionIdMatches = sessionEntries.filter(({ entry }) => entry.sessionId === sessionId);
   const selectionMatches = requestedAgentId
     ? sessionIdMatches.filter(
-        ([sessionKey]) => resolveMatchedAgentId(sessionKey) === requestedAgentId,
+        ({ sessionKey }) => resolveMatchedAgentId(sessionKey) === requestedAgentId,
       )
     : sessionIdMatches;
   if (requestedAgentId && selectionMatches.length === 0 && sessionIdMatches.length > 0) {
@@ -348,9 +344,12 @@ export function resolveStoredSessionKeyForSessionId(opts: {
       hint: `The matching rows belong to a different agent than agent "${requestedAgentId}".`,
     });
   }
-  const selection = resolveSessionIdMatchSelection(selectionMatches, sessionId);
+  const selection = resolveSessionIdMatchSelection(
+    selectionMatches.map(({ sessionKey, entry }) => [sessionKey, entry]),
+    sessionId,
+  );
   if (selection.kind !== "selected") {
-    return { agentId: requestedAgentId, sessionKey: undefined, sessionStore, storePath };
+    return { agentId: requestedAgentId, sessionKey: undefined, storePath };
   }
 
   const sessionKey = selection.sessionKey;
@@ -374,7 +373,9 @@ export function resolveStoredSessionKeyForSessionId(opts: {
   return {
     agentId: resolvedAgentId,
     sessionKey,
-    sessionStore,
+    sessionEntry: structuredClone(
+      selectionMatches.find((match) => match.sessionKey === sessionKey)?.entry,
+    ),
     storePath,
   };
 }
@@ -385,7 +386,6 @@ function resolveSessionKeyForRequestInternal(opts: {
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
-  clone?: boolean;
   createMissingSessionId: boolean;
 }): SessionKeyResolution {
   const sessionCfg = opts.cfg.session;
@@ -470,13 +470,6 @@ function resolveSessionKeyForRequestInternal(opts: {
   const storePath = resolveSessionStorePathCore(sessionCfg?.store, {
     agentId: storeAgentId,
   });
-  const loadOptions = opts.clone === false ? { clone: false as const } : undefined;
-  const sessionStore = loadCommandSessionStore({
-    storePath,
-    agentId: storeAgentId,
-    ...(loadOptions ? { clone: false } : {}),
-  });
-
   const ctx: MsgContext | undefined = opts.to?.trim() ? { From: opts.to } : undefined;
   let sessionKey: string | undefined =
     (!unownedBareSessionKey && explicitSessionKey
@@ -490,8 +483,12 @@ function resolveSessionKeyForRequestInternal(opts: {
       ? resolveSessionKey(scope, ctx, mainKey, storeAgentId)
       : undefined);
 
-  // Entrypoint migration owners canonicalize legacy state before runtime reads. A missing target
-  // row is not evidence that another agent's main session belongs to the configured default agent.
+  // Command preparation needs one owned entry. Exact reads preserve the SQLite target and
+  // Doctor guards without enumerating the agent store or exposing hidden run-owned rows.
+  const sessionEntry =
+    sessionKey && !isInternalSessionEffectsKey(sessionKey)
+      ? loadExactSessionEntryReadOnly({ agentId: storeAgentId, storePath, sessionKey })?.entry
+      : undefined;
 
   // If a session id was provided, prefer to re-use its existing entry (by id) even when no key was
   // derived. When duplicates exist across agent stores, pick the same deterministic best match used
@@ -500,23 +497,25 @@ function resolveSessionKeyForRequestInternal(opts: {
   if (
     requestedSessionId &&
     (!explicitSessionKey || unownedBareSessionKey) &&
-    (!sessionKey || sessionStore[sessionKey]?.sessionId !== requestedSessionId)
+    (!sessionKey || sessionEntry?.sessionId !== requestedSessionId)
   ) {
     const { candidates, ownerConflict } = collectSessionIdMatchesForRequest({
       cfg: opts.cfg,
-      sessionStore,
+      sessionEntries: loadCommandSessionEntries({ storePath, agentId: storeAgentId }),
       storePath,
       storeAgentId,
       sessionId: requestedSessionId,
       searchOtherAgentStores: requestedAgentId === undefined,
-      ...(opts.clone === false ? { clone: false } : {}),
     });
     const selectedMatch = selectSessionIdMatchCandidate(
       candidates.filter((candidate) => candidate.resolution.agentId !== undefined),
       requestedSessionId,
     );
     if (selectedMatch) {
-      return selectedMatch.resolution;
+      return {
+        ...selectedMatch.resolution,
+        sessionEntry: structuredClone(selectedMatch.entry),
+      };
     }
     if (ownerConflict) {
       throw new AgentSelectionRequiredError(listAgentIds(opts.cfg), {
@@ -543,12 +542,11 @@ function resolveSessionKeyForRequestInternal(opts: {
     return {
       agentId: explicitSessionAgentId,
       sessionKey,
-      sessionStore,
       storePath,
     };
   }
 
-  return { agentId: storeAgentId, sessionKey, sessionStore, storePath };
+  return { agentId: storeAgentId, sessionKey, sessionEntry, storePath };
 }
 
 /** Resolves an existing session-id row across agent stores without creating a fallback key. */
@@ -556,7 +554,6 @@ export function resolveExistingSessionKeyForRequest(opts: {
   cfg: OpenClawConfig;
   sessionId: string;
   agentId?: string;
-  clone?: boolean;
 }): SessionKeyResolution {
   return resolveSessionKeyForRequestInternal({ ...opts, createMissingSessionId: false });
 }
@@ -568,7 +565,6 @@ function resolveSessionKeyForRequest(opts: {
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
-  clone?: boolean;
 }): SessionKeyResolution {
   return resolveSessionKeyForRequestInternal({ ...opts, createMissingSessionId: true });
 }
@@ -587,13 +583,12 @@ export function resolveSession(opts: {
   sessionId?: string;
   sessionKey?: string;
   agentId?: string;
-  clone?: boolean;
 }): SessionResolution {
   const sessionCfg = opts.cfg.session;
   const {
     agentId: resolvedAgentId,
     sessionKey,
-    sessionStore,
+    sessionEntry,
     storePath,
   } = resolveSessionKeyForRequestCore({
     cfg: opts.cfg,
@@ -601,11 +596,9 @@ export function resolveSession(opts: {
     sessionId: opts.sessionId,
     sessionKey: opts.sessionKey,
     agentId: opts.agentId,
-    ...(opts.clone === false ? { clone: false } : {}),
   });
   const now = Date.now();
 
-  const sessionEntry = sessionKey ? sessionStore[sessionKey] : undefined;
   const sessionAgentId =
     (opts.agentId?.trim() ? normalizeAgentId(opts.agentId) : undefined) ??
     resolvedAgentId ??
@@ -681,7 +674,6 @@ export function resolveSession(opts: {
     sessionId,
     sessionKey,
     sessionEntry: resolvedSessionEntry,
-    sessionStore,
     storePath,
     isNewSession,
     previousSessionId: isNewSession ? sessionEntry?.sessionId : undefined,

--- a/src/agents/embedded-agent-runner.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.e2e.test.ts
@@ -943,7 +943,6 @@ describe("runEmbeddedAgent", () => {
       cfg,
       sessionId: "resume-123",
       agentId: undefined,
-      clone: false,
     });
     expect(firstRunEmbeddedAttemptParams().sessionKey).toBe("agent:test:resolved");
   });
@@ -984,7 +983,6 @@ describe("runEmbeddedAgent", () => {
       cfg,
       sessionId: "resume-124",
       agentId: undefined,
-      clone: false,
     });
     expect(firstRunEmbeddedAttemptParams().sessionKey).toBe("agent:main:resume-124");
   });

--- a/src/agents/embedded-agent-runner/run.recovery-cancellation.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.recovery-cancellation.test-support.ts
@@ -418,8 +418,6 @@ describe("recovery cancellation through the public run owner", () => {
       session = await createSharedRunIntegrationSession();
       const { runParams } = session;
       const { sessionId, sessionKey, sessionTarget } = runParams;
-      const { createAgentCommandSessionWorkingCopy } =
-        await import("../command/session-helpers.js");
       const { createCommandCompactionAccounting } =
         await import("../command/compaction-accounting.js");
       const { updateSessionStoreAfterAgentRun } = await import("../command/session-store.js");
@@ -436,14 +434,11 @@ describe("recovery cancellation through the public run owner", () => {
         totalTokensVersion: SESSION_TOTAL_TOKENS_VERSION,
       };
       await sessionAccessor.replaceSessionEntry(sessionTarget, initialEntry);
-      const { sessionEntry, sessionStore } = createAgentCommandSessionWorkingCopy({
-        sessionKey,
-        sessionEntry: initialEntry,
-        sessionStore: { [sessionKey]: initialEntry },
-      });
-      if (!sessionEntry || !sessionStore) {
+      const sessionEntry = sessionAccessor.loadExactSessionEntryReadOnly(sessionTarget)?.entry;
+      if (!sessionEntry) {
         throw new Error("The command must retain its pre-claim working copy");
       }
+      const sessionStore = { [sessionKey]: sessionEntry };
       const accounting = createCommandCompactionAccounting({
         sessionStore,
         persistCounts: true,

--- a/src/agents/embedded-agent-runner/run/session-bootstrap.ts
+++ b/src/agents/embedded-agent-runner/run/session-bootstrap.ts
@@ -218,7 +218,6 @@ export function backfillSessionKey(params: {
       : resolveSessionKeyForRequestCore({
           cfg: params.config,
           sessionId: params.sessionId,
-          clone: false,
         });
     return normalizeOptionalString(resolved.sessionKey);
   } catch (err) {

--- a/src/agents/run-session-target.ts
+++ b/src/agents/run-session-target.ts
@@ -166,7 +166,7 @@ export async function resolveAgentRunSessionTarget(params: {
           sessionId,
           agentId,
         })
-      : resolveExistingSessionKeyForRequest({ cfg: config, sessionId, clone: false })
+      : resolveExistingSessionKeyForRequest({ cfg: config, sessionId })
     : undefined;
   const lookupAgentId =
     (hasCompleteTypedTarget || trustExplicitAlternateStoreAgent ? targetAgentId : undefined) ??

--- a/src/agents/sessions/settings-manager.test.ts
+++ b/src/agents/sessions/settings-manager.test.ts
@@ -26,6 +26,19 @@ class InspectableSettingsStorage implements SettingsStorage {
 }
 
 describe("SettingsManager scoped persistence", () => {
+  it("loads settings from a backend that supplies the pure read contract", () => {
+    const manager = SettingsManager.fromStorage({
+      readSettingsScope: (scope) => JSON.stringify({ theme: scope }),
+      withLock: () => {
+        throw new Error("This backend only supports pure reads");
+      },
+    });
+    expect(manager.drainErrors()).toEqual([]);
+    expect(manager.getGlobalSettings()).toEqual({ theme: "global" });
+    expect(manager.getProjectSettings()).toEqual({ theme: "project" });
+    expect(manager.getTheme()).toBe("project");
+  });
+
   it("preserves external sibling changes while writing global and project scopes", async () => {
     const storage = new InspectableSettingsStorage();
     storage.set("global", {

--- a/src/agents/sessions/settings-manager.ts
+++ b/src/agents/sessions/settings-manager.ts
@@ -98,10 +98,14 @@ export class SettingsManager {
   private static loadScope(storage: SettingsStorage, scope: SettingsScope): SettingsScopeState {
     let content: string | undefined;
     try {
-      storage.withLock(scope, (current) => {
-        content = current;
-        return undefined;
-      });
+      if (storage.readSettingsScope) {
+        content = storage.readSettingsScope(scope);
+      } else {
+        storage.withLock(scope, (current) => {
+          content = current;
+          return undefined;
+        });
+      }
       const settings = content
         ? SettingsManager.migrateSettings(JSON.parse(content) as Record<string, unknown>)
         : {};

--- a/src/agents/sessions/settings-storage.test.ts
+++ b/src/agents/sessions/settings-storage.test.ts
@@ -2,6 +2,7 @@ import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { acquireFileLockSyncWithRetry } from "../../infra/file-lock-sync.js";
 import { SettingsManager } from "./settings-manager.js";
 import { FileSettingsStorage } from "./settings-storage.js";
 
@@ -17,6 +18,40 @@ describe("FileSettingsStorage", () => {
     expect(existsSync(settingsDir)).toBe(false);
     expect(existsSync(join(root, ".openclaw"))).toBe(false);
   });
+
+  it.each(["global", "project"] as const)(
+    "loads absent %s settings without waiting for an uncommitted first writer",
+    (scope) => {
+      const root = tempDirs.make("openclaw-settings-absent-");
+      const agentDir = join(root, "agent");
+      const settingsDir = scope === "global" ? agentDir : join(root, ".openclaw");
+      const settingsPath = join(settingsDir, "settings.json");
+      mkdirSync(settingsDir);
+      const release = acquireFileLockSyncWithRetry(settingsPath);
+      try {
+        const manager = SettingsManager.create(root, agentDir);
+        expect(manager.drainErrors()).toEqual([]);
+        expect(manager.getGlobalSettings()).toEqual({});
+        expect(manager.getProjectSettings()).toEqual({});
+        expect(existsSync(settingsPath)).toBe(false);
+      } finally {
+        release();
+      }
+
+      const storage = new FileSettingsStorage(root, agentDir);
+      storage.withLock(scope, () => JSON.stringify({ theme: "newly-created" }));
+      expect(SettingsManager.create(root, agentDir).getTheme()).toBe("newly-created");
+
+      const releaseExisting = acquireFileLockSyncWithRetry(settingsPath);
+      try {
+        expect(SettingsManager.create(root, agentDir).drainErrors()).toEqual([
+          { scope, error: expect.objectContaining({ code: "file_lock_timeout" }) },
+        ]);
+      } finally {
+        releaseExisting();
+      }
+    },
+  );
 
   it("locks before reading when the settings directory exists", () => {
     const root = tempDirs.make("openclaw-settings-lock-");

--- a/src/agents/sessions/settings-storage.test.ts
+++ b/src/agents/sessions/settings-storage.test.ts
@@ -1,16 +1,19 @@
-import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import fs, { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
-import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import { acquireFileLockSyncWithRetry } from "../../infra/file-lock-sync.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createFixtureLifetime } from "../../../test/helpers/fixture-lifetime.js";
+import { waitForFile } from "../../../test/helpers/process-wait.js";
+import { runNodeScript } from "../../../test/helpers/run-node-script.js";
 import { SettingsManager } from "./settings-manager.js";
 import { FileSettingsStorage } from "./settings-storage.js";
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const fixtures = createFixtureLifetime();
+afterEach(() => fixtures.cleanup());
 
 describe("FileSettingsStorage", () => {
   it("loads missing settings without creating their directories", () => {
-    const root = tempDirs.make("openclaw-settings-read-");
+    const root = fixtures.createTempDir("openclaw-settings-read-");
     const settingsDir = join(root, "agent");
 
     SettingsManager.create(root, settingsDir);
@@ -19,42 +22,148 @@ describe("FileSettingsStorage", () => {
     expect(existsSync(join(root, ".openclaw"))).toBe(false);
   });
 
+  it("loads absent unlocked settings without syncing writer sidecars", () => {
+    const root = fixtures.createTempDir("openclaw-settings-unlocked-");
+    const agentDir = join(root, "agent");
+    mkdirSync(agentDir);
+    mkdirSync(join(root, ".openclaw"));
+    const fsync = vi.spyOn(fs, "fsyncSync");
+    syncBuiltinESMExports();
+    try {
+      const manager = SettingsManager.create(root, agentDir);
+      expect(manager.drainErrors()).toEqual([]);
+      expect(manager.getGlobalSettings()).toEqual({});
+      expect(manager.getProjectSettings()).toEqual({});
+      expect(fsync).not.toHaveBeenCalled();
+    } finally {
+      fsync.mockRestore();
+      syncBuiltinESMExports();
+    }
+  });
+
   it.each(["global", "project"] as const)(
-    "loads absent %s settings without waiting for an uncommitted first writer",
-    (scope) => {
-      const root = tempDirs.make("openclaw-settings-absent-");
-      const agentDir = join(root, "agent");
-      const settingsDir = scope === "global" ? agentDir : join(root, ".openclaw");
-      const settingsPath = join(settingsDir, "settings.json");
+    "reads committed %s settings from an already-owned first write",
+    (scope) =>
+      fixtures.run(async () => {
+        const root = fixtures.createTempDir("openclaw-settings-first-writer-");
+        const agentDir = join(root, "agent");
+        const settingsDir = scope === "global" ? agentDir : join(root, ".openclaw");
+        const settingsPath = join(settingsDir, "settings.json");
+        const readyPath = join(root, "writer-ready");
+        const continuePath = join(root, "writer-continue");
+        const committedPath = join(root, "writer-committed");
+        mkdirSync(settingsDir);
+        const abort = new AbortController();
+        const writer = fixtures.track(
+          runNodeScript(
+            [
+              "--import",
+              new URL("../../../scripts/tsx.mjs", import.meta.url).href,
+              "--input-type=module",
+              "--eval",
+              String.raw`
+                import { existsSync, writeFileSync } from "node:fs";
+                const [moduleUrl, root, agentDir, scope, readyPath, continuePath, committedPath] = process.argv.slice(1);
+                const { FileSettingsStorage } = await import(moduleUrl);
+                new FileSettingsStorage(root, agentDir).withLock(scope, (current) => {
+                  if (current !== undefined) throw new Error("first-writer fixture already has settings");
+                  writeFileSync(readyPath, "ready");
+                  const deadline = Date.now() + 5_000;
+                  const pause = new Int32Array(new SharedArrayBuffer(4));
+                  while (!existsSync(continuePath)) {
+                    if (Date.now() >= deadline) throw new Error("missing reader signal");
+                    Atomics.wait(pause, 0, 0, 2);
+                  }
+                  return JSON.stringify({ theme: scope + "-committed" });
+                });
+                writeFileSync(committedPath, "committed");
+              `,
+              new URL("./settings-storage.ts", import.meta.url).href,
+              root,
+              agentDir,
+              scope,
+              readyPath,
+              continuePath,
+              committedPath,
+            ],
+            process.env,
+            10_000,
+            { signal: abort.signal, requireProcessTreeExit: true },
+          ),
+        );
+        const originalExists = fs.existsSync;
+        let committedDuringRead = false;
+        try {
+          await Promise.race([
+            waitForFile(readyPath, 10_000),
+            writer.then((result) => {
+              throw new Error(`first writer exited before its reader: ${result.stderr}`);
+            }),
+          ]);
+          expect(existsSync(settingsPath)).toBe(false);
+          expect(existsSync(`${settingsPath}.lock`)).toBe(true);
+          // Return the real observation, but let the independently locked writer
+          // commit before the next probe. File-first probing then returns stale defaults.
+          vi.spyOn(fs, "existsSync").mockImplementation((filePath) => {
+            const observed = originalExists(filePath);
+            if (!committedDuringRead && (filePath === settingsPath || filePath === settingsDir)) {
+              committedDuringRead = true;
+              fs.writeFileSync(continuePath, "continue");
+              const deadline = Date.now() + 5_000;
+              const pause = new Int32Array(new SharedArrayBuffer(4));
+              while (!originalExists(committedPath)) {
+                if (Date.now() >= deadline) {
+                  throw new Error("first writer did not commit");
+                }
+                Atomics.wait(pause, 0, 0, 2);
+              }
+            }
+            return observed;
+          });
+          syncBuiltinESMExports();
+
+          const manager = SettingsManager.create(root, agentDir);
+          expect(committedDuringRead).toBe(true);
+          expect(manager.drainErrors()).toEqual([]);
+          expect(manager.getTheme()).toBe(`${scope}-committed`);
+          expect(await writer).toMatchObject({ error: undefined, status: 0 });
+          expect(existsSync(`${settingsPath}.lock`)).toBe(false);
+        } finally {
+          vi.restoreAllMocks();
+          syncBuiltinESMExports();
+          abort.abort();
+          await writer;
+        }
+      }),
+    20_000,
+  );
+
+  it.each([".lock", ".lock.reclaim"])(
+    "does not skip an existing %s namespace when settings are absent",
+    (suffix) => {
+      const root = fixtures.createTempDir("openclaw-settings-lock-namespace-");
+      const settingsDir = join(root, "agent");
       mkdirSync(settingsDir);
-      const release = acquireFileLockSyncWithRetry(settingsPath);
-      try {
-        const manager = SettingsManager.create(root, agentDir);
-        expect(manager.drainErrors()).toEqual([]);
-        expect(manager.getGlobalSettings()).toEqual({});
-        expect(manager.getProjectSettings()).toEqual({});
-        expect(existsSync(settingsPath)).toBe(false);
-      } finally {
-        release();
-      }
-
-      const storage = new FileSettingsStorage(root, agentDir);
-      storage.withLock(scope, () => JSON.stringify({ theme: "newly-created" }));
-      expect(SettingsManager.create(root, agentDir).getTheme()).toBe("newly-created");
-
-      const releaseExisting = acquireFileLockSyncWithRetry(settingsPath);
-      try {
-        expect(SettingsManager.create(root, agentDir).drainErrors()).toEqual([
-          { scope, error: expect.objectContaining({ code: "file_lock_timeout" }) },
-        ]);
-      } finally {
-        releaseExisting();
-      }
+      mkdirSync(join(settingsDir, `settings.json${suffix}`));
+      const storage = new FileSettingsStorage(root, settingsDir);
+      expect(() => storage.readSettingsScope("global")).toThrow(
+        suffix === ".lock" ? /Legacy storage lock/ : /file lock timeout/,
+      );
     },
   );
 
+  it.skipIf(process.platform === "win32")("does not skip a dangling lock symlink", () => {
+    const root = fixtures.createTempDir("openclaw-settings-lock-symlink-");
+    const settingsDir = join(root, "agent");
+    mkdirSync(settingsDir);
+    fs.symlinkSync(join(root, "missing"), join(settingsDir, "settings.json.lock"));
+    expect(() => new FileSettingsStorage(root, settingsDir).readSettingsScope("global")).toThrow(
+      /unsupported legacy type/,
+    );
+  });
+
   it("locks before reading when the settings directory exists", () => {
-    const root = tempDirs.make("openclaw-settings-lock-");
+    const root = fixtures.createTempDir("openclaw-settings-lock-");
     const settingsDir = join(root, "agent");
     const settingsPath = join(settingsDir, "settings.json");
     mkdirSync(settingsDir);
@@ -72,7 +181,7 @@ describe("FileSettingsStorage", () => {
   });
 
   it("creates a missing directory when the callback writes", () => {
-    const root = tempDirs.make("openclaw-settings-write-");
+    const root = fixtures.createTempDir("openclaw-settings-write-");
     const settingsDir = join(root, "agent");
     const settingsPath = join(settingsDir, "settings.json");
     const storage = new FileSettingsStorage(settingsDir, settingsDir);

--- a/src/agents/sessions/settings-storage.ts
+++ b/src/agents/sessions/settings-storage.ts
@@ -118,6 +118,8 @@ export type SettingsScope = "global" | "project";
 export const SETTINGS_SCOPES: SettingsScope[] = ["global", "project"];
 
 export interface SettingsStorage {
+  /** Pure scope reads; existing custom backends may serve reads through withLock. */
+  readSettingsScope?(scope: SettingsScope): string | undefined;
   withLock(scope: SettingsScope, fn: (current: string | undefined) => string | undefined): void;
 }
 
@@ -134,6 +136,20 @@ export class FileSettingsStorage implements SettingsStorage {
       global: join(agentDir, "settings.json"),
       project: join(cwd, CONFIG_DIR_NAME, "settings.json"),
     };
+  }
+
+  readSettingsScope(scope: SettingsScope): string | undefined {
+    // Absence is a complete read: do not create and fsync a sidecar for defaults.
+    // Present files still use the writer lock so readers cannot observe partial writes.
+    if (!existsSync(this.paths[scope])) {
+      return undefined;
+    }
+    let content: string | undefined;
+    this.withLock(scope, (current) => {
+      content = current;
+      return undefined;
+    });
+    return content;
   }
 
   withLock(scope: SettingsScope, fn: (current: string | undefined) => string | undefined): void {

--- a/src/agents/sessions/settings-storage.ts
+++ b/src/agents/sessions/settings-storage.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, lstatSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { acquireFileLockSyncWithRetry } from "../../infra/file-lock-sync.js";
 import type { Transport } from "../../llm/types.js";
@@ -139,9 +139,14 @@ export class FileSettingsStorage implements SettingsStorage {
   }
 
   readSettingsScope(scope: SettingsScope): string | undefined {
-    // Absence is a complete read: do not create and fsync a sidecar for defaults.
-    // Present files still use the writer lock so readers cannot observe partial writes.
-    if (!existsSync(this.paths[scope])) {
+    const path = this.paths[scope];
+    // Observe ownership before absence: a first writer may commit between probes.
+    // Existing lock names and reclaim guards still go through the canonical lock checks.
+    if (
+      !lstatSync(`${path}.lock`, { throwIfNoEntry: false }) &&
+      !lstatSync(`${path}.lock.reclaim`, { throwIfNoEntry: false }) &&
+      !existsSync(path)
+    ) {
       return undefined;
     }
     let content: string | undefined;

--- a/src/commands/agent.runtime-config.test.ts
+++ b/src/commands/agent.runtime-config.test.ts
@@ -288,7 +288,7 @@ describe("agentCommand runtime config", () => {
       expect(targetIds.has("models.providers.*.apiKey")).toBe(true);
       expect(targetIds.has("channels.telegram.botToken")).toBe(false);
       expect(setRuntimeConfigSnapshotMock).toHaveBeenCalledWith(resolvedConfig, sourceConfig);
-      expect(prepared.cfg).toBe(resolvedConfig);
+      expect(prepared).toBe(resolvedConfig);
     });
   });
 
@@ -440,9 +440,7 @@ describe("agentCommand runtime config", () => {
       expect(readConfigFileSnapshotForWriteMock).not.toHaveBeenCalled();
       expect(resolveCommandConfigWithSecretsMock).not.toHaveBeenCalled();
       expect(setRuntimeConfigSnapshotMock).not.toHaveBeenCalled();
-      expect(prepared.cfg).toBe(loadedConfig);
-      expect(prepared.sourceConfig).toEqual(loadedConfig);
-      expect(prepared.sourceConfig).not.toBe(loadedConfig);
+      expect(prepared).toBe(loadedConfig);
     });
   });
 

--- a/src/commands/agent.session.test.ts
+++ b/src/commands/agent.session.test.ts
@@ -340,14 +340,15 @@ describe("agent session resolution", () => {
       expect(resolution.sessionEntry?.endedAt).toBe(registryUpdatedAt - 100);
       expect(resolution.sessionEntry?.runtimeMs).toBe(900);
 
-      if (!resolution.sessionKey || !resolution.sessionStore) {
-        throw new Error("expected resolved explicit session store");
+      if (!resolution.sessionKey || !resolution.sessionEntry) {
+        throw new Error("expected resolved explicit session entry");
       }
+      const sessionStore = { [resolution.sessionKey]: resolution.sessionEntry };
       const resolvedTranscript = await resolveSessionTranscriptFile({
         sessionId: resolution.sessionId,
         sessionKey: resolution.sessionKey,
         sessionEntry: resolution.sessionEntry,
-        sessionStore: resolution.sessionStore,
+        sessionStore,
         storePath: resolution.storePath,
         agentId: "main",
       });
@@ -357,7 +358,7 @@ describe("agent session resolution", () => {
           sessionId: resolution.sessionId,
           sessionKey: resolution.sessionKey,
           sessionEntry: undefined,
-          sessionStore: resolution.sessionStore,
+          sessionStore,
           storePath: resolution.storePath,
           agentId: "main",
         }),

--- a/src/commands/agent/session.test.ts
+++ b/src/commands/agent/session.test.ts
@@ -5,6 +5,7 @@ import { resolveSessionKeyForRequest } from "./session.runtime.js";
 
 const mocks = vi.hoisted(() => ({
   listSessionEntriesCore: vi.fn(),
+  loadExactSessionEntryReadOnly: vi.fn(),
   resolveStorePath: vi.fn(),
   listAgentIds: vi.fn(),
   resolveExplicitAgentSessionKey: vi.fn(),
@@ -22,6 +23,7 @@ vi.mock("../../config/sessions/main-session.js", async () => {
 
 vi.mock("../../config/sessions/session-accessor.js", () => ({
   listSessionEntriesCore: mocks.listSessionEntriesCore,
+  loadExactSessionEntryReadOnly: mocks.loadExactSessionEntryReadOnly,
 }));
 
 vi.mock("../../config/sessions/paths.js", () => ({
@@ -61,6 +63,12 @@ describe("resolveSessionKeyForRequest", () => {
   };
 
   const mockStoresByPath = (stores: Partial<Record<string, SessionStoreMap>>) => {
+    mocks.loadExactSessionEntryReadOnly.mockImplementation(
+      ({ storePath, sessionKey }: { storePath: string; sessionKey: string }) => {
+        const entry = stores[storePath]?.[sessionKey];
+        return entry ? { sessionKey, entry: structuredClone(entry) } : undefined;
+      },
+    );
     mocks.listSessionEntriesCore.mockImplementation((scope?: { storePath?: string }) =>
       Object.entries(stores[scope?.storePath ?? ""] ?? {}).map(([sessionKey, entry]) => ({
         sessionKey,
@@ -71,6 +79,7 @@ describe("resolveSessionKeyForRequest", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.loadExactSessionEntryReadOnly.mockReset();
     mocks.listAgentIds.mockReturnValue(["main"]);
     mocks.resolveExplicitAgentSessionKey.mockReturnValue(undefined);
   });
@@ -165,9 +174,8 @@ describe("resolveSessionKeyForRequest", () => {
     });
 
     expect(result.sessionKey).toBe("agent:mybot:main");
-    expect(result.sessionStore).toEqual(mybotStore);
+    expect(result.sessionEntry).toBeUndefined();
     expect(result.storePath).toBe(MYBOT_STORE_PATH);
-    expect(result.sessionStore["agent:mybot:main"]).toBeUndefined();
   });
 
   it("does not adopt another agent's main session from a literal shared store", () => {
@@ -187,14 +195,9 @@ describe("resolveSessionKeyForRequest", () => {
     });
 
     expect(result.sessionKey).toBe("agent:mybot:main");
-    expect(result.sessionStore).toEqual(sharedStore);
+    expect(result.sessionEntry).toBeUndefined();
     expect(result.storePath).toBe(SHARED_STORE_PATH);
-    expect(result.sessionStore["agent:mybot:main"]).toBeUndefined();
-    expect(mocks.listSessionEntriesCore).toHaveBeenCalledTimes(1);
-    expect(mocks.listSessionEntriesCore).toHaveBeenCalledWith({
-      agentId: "mybot",
-      storePath: SHARED_STORE_PATH,
-    });
+    expect(mocks.listSessionEntriesCore).not.toHaveBeenCalled();
   });
 
   it("prefers the configured default-agent session over legacy main-store rows", () => {
@@ -217,7 +220,7 @@ describe("resolveSessionKeyForRequest", () => {
     });
 
     expect(result.sessionKey).toBe("agent:mybot:main");
-    expect(result.sessionStore).toEqual(mybotStore);
+    expect(result.sessionEntry).toEqual(mybotStore["agent:mybot:main"]);
     expect(result.storePath).toBe(MYBOT_STORE_PATH);
   });
 
@@ -318,10 +321,11 @@ describe("resolveSessionKeyForRequest", () => {
     expect(mocks.listSessionEntriesCore).toHaveBeenCalledWith({
       agentId: "mybot",
       storePath: MYBOT_STORE_PATH,
+      clone: false,
     });
   });
 
-  it("returns correct sessionStore when session found in non-primary agent store", () => {
+  it("returns the selected entry when session is found in a non-primary agent store", () => {
     const mybotStore = {
       "agent:mybot:main": { sessionId: "target-session-id", updatedAt: 0 },
     };
@@ -334,7 +338,7 @@ describe("resolveSessionKeyForRequest", () => {
       cfg: baseCfg,
       sessionId: "target-session-id",
     });
-    expect(result.sessionStore["agent:mybot:main"]?.sessionId).toBe("target-session-id");
+    expect(result.sessionEntry?.sessionId).toBe("target-session-id");
   });
 
   it("returns a deterministic explicit sessionKey when sessionId not found in any store", () => {

--- a/src/gateway/agent-turn/agent-request-routing.ts
+++ b/src/gateway/agent-turn/agent-request-routing.ts
@@ -120,7 +120,6 @@ export async function prepareAgentRequestRouting(params: {
         cfg: params.cfg,
         sessionId: requestedSessionId,
         agentId,
-        clone: false,
       });
       agentId = sessionIdTarget.agentId ?? agentId;
     } catch (error) {

--- a/src/gateway/server-methods/sessions-diff.test.ts
+++ b/src/gateway/server-methods/sessions-diff.test.ts
@@ -495,6 +495,41 @@ describe("loadSessionDiff", () => {
     expect(result.files.find((file) => file.path === "loose.txt")?.untracked).toBe(true);
   });
 
+  it.skipIf(process.platform === "win32").each(["unborn", "branch", "detached"])(
+    "preserves checkout path bytes for %s baseline and diff reads",
+    async (revision) => {
+      const checkout = path.join(repoRoot, "checkout \n");
+      const nested = path.join(checkout, "nested");
+      fs.mkdirSync(nested, { recursive: true });
+      initRepo(checkout);
+      fs.writeFileSync(path.join(checkout, "tracked.txt"), "initial\n");
+      git(checkout, "add", "tracked.txt");
+      if (revision !== "unborn") {
+        git(checkout, "commit", "-qm", "initial");
+        if (revision === "detached") {
+          git(checkout, "checkout", "--detach", "-q");
+        }
+      }
+      fs.appendFileSync(path.join(checkout, "tracked.txt"), "changed\n");
+      fs.writeFileSync(path.join(checkout, "loose.txt"), "new\n");
+      mockSession(nested);
+
+      const baseline = await captureSessionDiffBaseline({ cwd: nested, sessionId: "s1" });
+      expect(baseline?.root).toBe(checkout);
+      expect(baseline?.files.map((file) => file.path)).toEqual(["loose.txt", "tracked.txt"]);
+      const result = await loadSessionDiff({ sessionKey: "agent:main:s1" });
+      expect(result.root).toBe(checkout);
+      expect(result.branch).toBe(revision === "branch" ? "main" : undefined);
+      expect(result.files.map((file) => file.path)).toEqual(["loose.txt", "tracked.txt"]);
+
+      mockSession(nested, { sessionDiffBaseline: baseline });
+      expect((await loadSessionDiff({ sessionKey: "agent:main:s1" })).files).toEqual([]);
+      fs.appendFileSync(path.join(checkout, "tracked.txt"), "later edit\n");
+      const changed = await loadSessionDiff({ sessionKey: "agent:main:s1" });
+      expect(changed.files.map((file) => file.path)).toEqual(["tracked.txt"]);
+    },
+  );
+
   it("hides unchanged files captured at session start and resurfaces later edits", async () => {
     initRepo(repoRoot);
     fs.writeFileSync(path.join(repoRoot, "AGENTS.md"), "existing bootstrap\n");

--- a/src/sessions/session-diff.ts
+++ b/src/sessions/session-diff.ts
@@ -49,6 +49,37 @@ async function gitOut(
   }
 }
 
+async function loadCheckoutRevision(
+  cwd: string,
+): Promise<{ root: string; head?: string; branch?: string } | undefined> {
+  try {
+    // Git emits the root before verifying HEAD; exit 1 keeps an unborn checkout's root.
+    // Split only the final OID on success so embedded newlines in paths remain intact.
+    const result = await runGit(cwd, [
+      "rev-parse",
+      "--show-toplevel",
+      "--verify",
+      "--quiet",
+      "HEAD",
+    ]);
+    if (result.termination !== "exit" || (result.code !== 0 && result.code !== 1)) {
+      return undefined;
+    }
+    const lines = result.stdout.replace(/\n$/, "").split("\n");
+    const head = result.code === 0 ? lines.pop() : undefined;
+    const root = lines.join("\n");
+    if (!root) {
+      return undefined;
+    }
+    const branchOut = head
+      ? (await gitOut(root, ["rev-parse", "--abbrev-ref", "HEAD"]))?.trim()
+      : undefined;
+    return { root, head, branch: branchOut && branchOut !== "HEAD" ? branchOut : undefined };
+  } catch {
+    return undefined;
+  }
+}
+
 /** Parses `git diff --name-status -z -M` output; R/C entries consume two paths. */
 export function parseNameStatusZ(text: string): NameStatusEntry[] {
   const tokens = text.split("\0");
@@ -372,16 +403,14 @@ export async function loadCheckoutDiff(params: CheckoutDiffParams): Promise<Sess
     deletions: 0,
     ...(unavailableReason ? { unavailableReason } : {}),
   });
-  const root = (await gitOut(params.cwd, ["rev-parse", "--show-toplevel"]))?.trim();
-  if (!root) {
+  const checkout = await loadCheckoutRevision(params.cwd);
+  if (!checkout) {
     return empty("not_git");
   }
+  const { root, head, branch } = checkout;
   // Canonical root for the hardlink/escape guard: show-toplevel can contain
   // symlinked path segments, and containment is compared against realpaths.
   const realRoot = await fs.realpath(root).catch(() => root);
-  const branchOut = (await gitOut(root, ["rev-parse", "--abbrev-ref", "HEAD"]))?.trim();
-  const branch = branchOut && branchOut !== "HEAD" ? branchOut : undefined;
-  const head = (await gitOut(root, ["rev-parse", "--verify", "--quiet", "HEAD"]))?.trim();
   const branchBase = head
     ? await resolveSessionDiffBase({ branch, gitOut, root })
     : await resolveSessionDiffEmptyTree(root);
@@ -603,14 +632,12 @@ async function gitOutForBaseline(cwd: string, args: string[]): Promise<string | 
 async function collectBaselineCandidates(params: {
   cwd: string;
 }): Promise<{ candidates: BaselineCandidate[]; root: string; truncated: boolean } | undefined> {
-  const root = (await gitOut(params.cwd, ["rev-parse", "--show-toplevel"]))?.trim();
-  if (!root) {
+  const checkout = await loadCheckoutRevision(params.cwd);
+  if (!checkout) {
     return undefined;
   }
-  const branchOut = (await gitOut(root, ["rev-parse", "--abbrev-ref", "HEAD"]))?.trim();
-  const branch = branchOut && branchOut !== "HEAD" ? branchOut : undefined;
-  const hasHead = (await gitOut(root, ["rev-parse", "--verify", "--quiet", "HEAD"])) !== null;
-  const baseInfo = hasHead
+  const { root, head, branch } = checkout;
+  const baseInfo = head
     ? await resolveSessionDiffBase({ branch, gitOut, root })
     : await resolveSessionDiffEmptyTree(root);
   const trackedText = baseInfo


### PR DESCRIPTION
## What Problem This Solves

Concurrent agent turns repeat preparation work on the Gateway event loop: a known session key loads a whole session map that preparation immediately discards, absent settings files acquire and fsync writer-lock sidecars, and session diff preparation repeats Git revision discovery. This is a scoped follow-up to #133683; the remaining saturation tail is still under investigation.

## Why This Change Was Made

Use the existing canonical read-only exact-session accessor for known keys and return one caller-owned entry. ID-only and ambiguous input still use deterministic cross-store selection, cloning only the winner. Preparation no longer creates a discarded full-store working copy, and runtime config preparation returns only its used configuration result. The exact accessor also preserves incognito session facts without provisioning a durable database for a missing incognito read; canonical/schema validation and post-await admission checks remain intact.

Restore the optional `SettingsStorage.readSettingsScope` contract present in stable `v2026.8.1`. The file owner returns absence without locking when its ordered probes observe no writer-lock or reclaim namespace and no settings file. It checks ownership before file absence so an already active first writer cannot commit between probes and leave a reader with stale defaults. Existing namespaces and present files enter the canonical locked read; writes retain their existing locking, freshness, and cleanup behavior. Backends implementing only `withLock` remain supported. Both session baseline capture and diff display now share fresh Git root/HEAD discovery, preserve exact root path bytes, and skip branch discovery when HEAD does not exist. No cache, dependency patch, config option, SQLite schema/storage design, protocol, or timeout changes.

Production delta: **−1 line**; tests and test support: **+302 lines**. The removed paths are the discarded session working copy, unused config clone/return metadata, absent-file writer-lock acquisition, and duplicate Git revision probes.

## User Impact

Agent preparation performs less synchronous work while preserving session ownership, fresh settings and Git state. Incognito command targeting retains its in-memory session facts. This PR does **not** claim that all control-plane stalls are fixed or establish an overall throughput improvement.

The retained pre-correction preparation candidate passed all three standard runs of the unchanged 32-turn synthetic mix with zero operation failures: maximum `sessions.list` 1970ms, history 1700ms, Control UI HTTP 525ms, readiness 377ms. The 2000ms control/handshake budgets remain unchanged. Adding a real built Control UI still exposes a latency tail: matched baseline and candidate browser repeats each passed once and failed twice. Valid browser-inclusive CPU runs also failed the latency budget on both revisions; the worst list request spent about 13ms from server receive to first send on baseline and 9ms on the candidate, including dispatch and authorization, with most elapsed time before its server receive callback. Callback timing is not proof of TCP arrival. Both recovered to two eligible healthy samples within about 4.01 seconds after load. Those failures are retained and motivate the separate scheduling follow-up; they are not waived, attributed to host noise, or described as a memory leak.

## Evidence

- Tests were applied before production changes. Baseline failures cover full-store enumeration, lost incognito facts, unwanted durable database provisioning, custom pure-read settings storage, unnecessary writer-sidecar fsync for absent unlocked files, and exact Git root paths containing newlines. The corresponding owner tests pass: preparation **9 files / 298 tests**, final settings owner/preparation siblings **4 files / 30 tests**, Git baseline/diff/lifecycle/execution **3 files / 79 tests**.
- Actual source-owner subprocess observation preserves returned files, status, and branch facts: unborn capture **6→4** / diff **9→7**; committed or detached capture **6→5** / diff **9→8**; non-Git capture/diff remain **1/1**. Git's `rev-parse` implementation and the installed file-lock dependency were inspected directly.
- `env -u OPENCLAW_TESTBOX node scripts/check-changed.mjs --base 4eb10567c9073f2385c394e6302c4dba24f91e70 --timed` passed for the complete 25-file change, including core/test types, formatting, lint, and guards. Codex autoreview completed with no accepted findings at its requested P0 scope; a fresh review of the first-writer correction also completed P0 scoped-clean.
- The retained pre-correction source-performance builds and real browser proof used isolated synthetic HOME/state, owned loopback ports, a fresh browser profile, 32 turns, 48 seed sessions, 128 updates from four clients, three history clients × five burst, six subscribers, a visible observer, 100ms cadence, and a 1000ms mock stream delay. Real UI labels and streamed replies appeared without page errors. No production or operator Gateway was stressed. Full source afterimage hashes matched before and after the baseline/candidate comparison and commit.

The first two hosted runs failed the unchanged CSS gzip gate in four build jobs (54809 B versus 54784 B), before those jobs ran tests. The branch now incorporates main `964fa991c0aff81e2ae46a0c9f99ebc0ab349d1a`, whose UI owner removes unused microphone-picker variables. The resulting tree exactly matches the reviewed patch merged with that main revision: 24 reviewed file afterimages are identical, and one test file also retains main's disjoint duplicate-case cleanup. That intermediate head passed the full hosted CI run, including the previously failing CSS build. The corrected head passed [CI 33361987934](https://github.com/openclaw/openclaw/actions/runs/33361987934); no size or latency threshold was increased.

The earlier ClawSweeper already-owned-first-writer finding is accepted and fixed. A managed independent writer proves both global and project reads observe its committed value after lock release; the old candidate fails these cases and three existing-lock namespace cases. The correction passes all nine storage cases. A separate test against exact pre-PR settings owner files observes two real fsync calls for absent, unlocked settings, versus zero after the correction. This retains the measured preparation optimization without weakening writer serialization. The full changed-file gate for the final correction passed, including core/test types, lint, formatting, storage/import boundaries and all guards.

The SDK rank-up is addressed as a restoration, rather than a new API: the live `v2026.8.1` tag peels to `ea806575e6450e4d1efdfc72c19f04be982a1b9b`, whose [settings storage interface already declares the optional method](https://github.com/openclaw/openclaw/blob/ea806575e6450e4d1efdfc72c19f04be982a1b9b/src/agents/sessions/settings-storage.ts#L120) and whose [extension SDK exports SettingsStorage](https://github.com/openclaw/openclaw/blob/ea806575e6450e4d1efdfc72c19f04be982a1b9b/src/agents/sessions/extension-sdk.ts#L22). The remote content blob matches the inspected local blob. This preserves the tagged custom-backend contract; it does not justify the older first-writer bypass, which this correction removes.

The later-writer review finding was checked separately and is not accepted as a correctness defect. The shipped pure-read API does not promise to observe a write that starts after the read is already in progress. For a supported first creation, absence remains a valid earlier snapshot while that overlapping writer is still uncommitted. If the writer commits before the final file-presence probe, the reader instead enters the canonical locked path and returns the committed value. Existing-file reads and every mutation callback remain locked; a new preparation after a completed write sees the new value, as required by the existing prepared-settings freshness test.

A managed two-process probe forced the requested schedule: the first lock probe observed no owner, then the real writer acquired its lock. With the writer held uncommitted, the read returned defaults and a subsequent read after commit returned the new value. With the writer committed before the file-presence probe, the same first read returned the new value. Both child processes exited successfully, released their locks, and their synthetic fixture directories were removed after awaited cleanup. This differs from the already-owned-first-writer case, which the committed regression now waits for. The stronger unconditional-lock rank-up is skipped because it changes this allowed overlapping-read ordering and restores the measured sidecar fsync cost without fixing a lost prior commit. The after-probe schedule is covered by that additional source-owner probe; no further code or review-head change is needed for this finding.
