### PR TITLE
fix(ui): avoid false Gateway-change warnings during session startup

### DIFF
--- a/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
@@ -9,6 +9,7 @@ import {
   createNewSessionPageE2eSuite,
   createdSessionListResult,
   installMockGateway,
+  waitForGatewayRecoveryScope,
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
@@ -293,8 +294,8 @@ suite.define(() => {
       const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
       const page = await context.newPage();
       if (preference.kind === "cloud") {
-        // Settle recovery scope after discovery starts: both the retired and
-        // replacement catalog request must stay held until restoration resumes.
+        // Browser recovery hydration must not restart the authenticated catalog
+        // request or let a remembered remote destination fall back to Local.
         await page.addInitScript(() => {
           const originalDigest = crypto.subtle.digest.bind(crypto.subtle);
           const delayed = new Promise<void>((resolve) => {
@@ -361,7 +362,8 @@ suite.define(() => {
           await page.evaluate(() => {
             window.dispatchEvent(new Event("test-release-recovery-scope"));
           });
-          await gateway.waitForRequest("environments.list", { after: 1 });
+          await waitForGatewayRecoveryScope(page);
+          expect(await gateway.getRequests("environments.list")).toHaveLength(1);
         }
         await page.locator(".new-session-page__message").fill("keep my chosen remote destination");
         const start = page.getByRole("button", { name: "Start session" });

--- a/ui/src/e2e/new-session-page.projects-places.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.projects-places.e2e.test.ts
@@ -10,6 +10,7 @@ import {
   installMockGateway,
   pollLocatorText,
   replaceGatewayClient,
+  waitForGatewayRecoveryScope,
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
@@ -203,7 +204,8 @@ suite.define(() => {
           await expect.poll(() => tooltipTitleText(local)).toBe("Gateway · QA-Gateway");
           const catalogRequests = (await gateway.getRequests("environments.list")).length;
           await page.evaluate(() => window.dispatchEvent(new Event("test-release-recovery-scope")));
-          await gateway.waitForRequest("environments.list", { after: catalogRequests });
+          await waitForGatewayRecoveryScope(page);
+          expect(await gateway.getRequests("environments.list")).toHaveLength(catalogRequests);
           await page.keyboard.press("Escape");
         }
         await page.locator("#new-session-project-trigger").click();

--- a/ui/src/e2e/new-session-page.test-support.ts
+++ b/ui/src/e2e/new-session-page.test-support.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { errors, type Locator, type Page } from "playwright";
 import { expect } from "vitest";
+import type { ApplicationContext } from "../app/context.ts";
 import {
   controlUiSessionPath,
   controlUiSessionUrl,
@@ -218,6 +219,15 @@ export async function waitForCommittedNewSessionDraft(
     params.get("group")?.trim() ?? "",
   ]);
   await waitForCommittedComposerDraft(page, scopeKey, expectedText, expectedAttachments);
+}
+
+export async function waitForGatewayRecoveryScope(page: Page, ready = true) {
+  await page.waitForFunction((expected) => {
+    const app = document.querySelector("openclaw-app") as HTMLElement & {
+      runtime?: { context: ApplicationContext };
+    };
+    return app.runtime?.context.gateway.snapshot.client?.recoveryScopeReady === expected;
+  }, ready);
 }
 
 export async function replaceGatewayClient(page: Page) {

--- a/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts
@@ -1,10 +1,11 @@
 import type { BrowserContextOptions, Page } from "playwright";
 import { expect, it } from "vitest";
+import type { ApplicationContext } from "../app/context.ts";
 import {
   waitForControlUiGatewayReady,
   waitForControlUiGatewayReconnecting,
 } from "../test-helpers/control-ui-e2e-readiness.ts";
-import { tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
+import { holdModuleResponse, tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 import {
   SOURCE_REPO,
   TARGET_REPO,
@@ -14,6 +15,7 @@ import {
   installMockGateway,
   pollLocatorText,
   replaceGatewayClient,
+  waitForGatewayRecoveryScope,
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
@@ -419,6 +421,65 @@ suite.define(() => {
     });
   });
 
+  it.each(["before acceptance", "during chat preparation"] as const)(
+    "keeps a local start owned when recovery scope hydrates %s",
+    async (hydration) => {
+      await withNewSessionPage(DESKTOP_CONTEXT, async (page) => {
+        await page.addInitScript(() => {
+          const digest = crypto.subtle.digest.bind(crypto.subtle);
+          const ready = new Promise<void>((resolve) => {
+            window.addEventListener("test-release-recovery-scope", () => resolve(), { once: true });
+          });
+          crypto.subtle.digest = async (algorithm, data) => {
+            if (new TextDecoder().decode(data) === "e2e-device-token") {
+              await ready;
+            }
+            return digest(algorithm, data);
+          };
+        });
+        const chatModule = await holdModuleResponse(page, /\/assets\/chat-page-[^/]+\.js/);
+        const sessionKey = "agent:main:late-recovery-scope";
+        const gateway = await installMockGateway(page, {
+          deferredMethods: ["sessions.create"],
+          methodResponses: {
+            "sessions.create": { key: sessionKey, runStarted: true, runId: "late-scope-run" },
+          },
+        });
+        try {
+          await page.goto(`${suite.server.baseUrl}new`);
+          const message = page.locator(".new-session-page__message");
+          const start = page.locator("button.new-session-page__start-submit");
+          await message.fill("keep this admitted task");
+          await waitForGatewayRecoveryScope(page, false);
+          await start.click();
+          await gateway.waitForRequest("sessions.create");
+          if (hydration === "during chat preparation") {
+            await gateway.resolveDeferred("sessions.create");
+            await chatModule.request;
+          }
+
+          await page.evaluate(() => window.dispatchEvent(new Event("test-release-recovery-scope")));
+          await waitForGatewayRecoveryScope(page);
+          await page.locator("openclaw-new-session-page").evaluate(async (element) => {
+            await (element as HTMLElement & { updateComplete: Promise<unknown> }).updateComplete;
+          });
+          expect(await page.locator(".new-session-page__error").allTextContents()).toEqual([]);
+          await expectPendingNewSession(page, "keep this admitted task");
+          expect(await gateway.getSocketCount()).toBe(1);
+          expect(await gateway.getRequests("sessions.create")).toHaveLength(1);
+
+          if (hydration === "before acceptance") {
+            await gateway.resolveDeferred("sessions.create");
+          }
+          chatModule.release();
+          await page.waitForURL((url) => url.pathname === controlUiSessionPath(sessionKey));
+        } finally {
+          chatModule.release();
+        }
+      });
+    },
+  );
+
   for (const reconnectKind of ["same-client reconnect", "client replacement"] as const) {
     it(`automatically resumes an idempotent session creation after ${reconnectKind}`, async () => {
       await withNewSessionPage(DESKTOP_CONTEXT, async (page) => {
@@ -479,44 +540,71 @@ suite.define(() => {
     });
   }
 
-  it("keeps an interrupted creation fail-closed after the Gateway process restarts", async () => {
-    await withNewSessionPage(DESKTOP_CONTEXT, async (page) => {
-      const gateway = await installMockGateway(page, {
-        methodResponses: {
-          "agents.list": mainAgentList(),
-          "worktrees.branches": branchList(),
-        },
+  it.each(["process restarts", "recovery owner changes", "recovery owner disappears"] as const)(
+    "keeps an interrupted creation fail-closed after the Gateway %s",
+    async (change) => {
+      await withNewSessionPage(DESKTOP_CONTEXT, async (page) => {
+        const gateway = await installMockGateway(page, {
+          methodResponses: {
+            "agents.list": mainAgentList(),
+            "worktrees.branches": branchList(),
+          },
+        });
+        await page.goto(`${suite.server.baseUrl}new`);
+        await page.getByRole("heading", { name: "Main" }).waitFor();
+        await waitForGatewayRecoveryScope(page);
+        await page.locator(".new-session-page__message").fill("do not duplicate this task");
+        await gateway.deferNext("sessions.create");
+        await page.getByRole("button", { name: "Start session" }).click();
+        await gateway.waitForRequest("sessions.create");
+        await expectPendingNewSession(page, "do not duplicate this task");
+
+        if (change === "process restarts") {
+          await gateway.setGatewayBootId("different-gateway-process");
+        } else {
+          const hello = await page.evaluate(() => {
+            const app = document.querySelector("openclaw-app") as HTMLElement & {
+              runtime: { context: ApplicationContext };
+            };
+            return app.runtime.context.gateway.snapshot.hello;
+          });
+          await gateway.setMethodResponse("connect", {
+            ...hello,
+            auth: {
+              role: hello?.auth?.role,
+              scopes: hello?.auth?.scopes,
+              ...(change === "recovery owner changes"
+                ? { recoveryScope: "different-recovery-owner" }
+                : {}),
+            },
+          });
+        }
+        await gateway.setOnline(false);
+        await waitForControlUiGatewayReconnecting(page);
+        await gateway.setOnline(true);
+        await waitForControlUiGatewayReady(page);
+        await waitForGatewayRecoveryScope(page);
+
+        await page
+          .getByRole("alert")
+          .filter({
+            hasText:
+              "The Gateway changed while this session was starting. Check recent sessions before starting this task again.",
+          })
+          .waitFor();
+        // A restarted process retains the same owner's draft; a different or
+        // missing principal must not inherit the previous owner's prompt.
+        const retainedMessage = change === "process restarts" ? "do not duplicate this task" : "";
+        await expect
+          .poll(() => page.locator(".new-session-page__message").inputValue())
+          .toBe(retainedMessage);
+        expect(await page.locator(".new-session-page__starting").isVisible()).toBe(false);
+        expect(await page.getByRole("button", { name: "Start session" }).isDisabled()).toBe(true);
+        expect(await gateway.getRequests("sessions.create")).toHaveLength(1);
+        expect(new URL(page.url()).pathname).toBe("/new");
       });
-      await page.goto(`${suite.server.baseUrl}new`);
-      await page.getByRole("heading", { name: "Main" }).waitFor();
-      await page.locator(".new-session-page__message").fill("do not duplicate this task");
-      await gateway.deferNext("sessions.create");
-      await page.getByRole("button", { name: "Start session" }).click();
-      await gateway.waitForRequest("sessions.create");
-      await expectPendingNewSession(page, "do not duplicate this task");
-
-      await gateway.setOnline(false);
-      await waitForControlUiGatewayReconnecting(page);
-      await gateway.setGatewayBootId("different-gateway-process");
-      await gateway.setOnline(true);
-      await waitForControlUiGatewayReady(page);
-
-      await page
-        .getByRole("alert")
-        .filter({
-          hasText:
-            "The Gateway changed while this session was starting. Check recent sessions before starting this task again.",
-        })
-        .waitFor();
-      await expect
-        .poll(() => page.locator(".new-session-page__message").inputValue())
-        .toBe("do not duplicate this task");
-      expect(await page.locator(".new-session-page__starting").isVisible()).toBe(false);
-      expect(await page.getByRole("button", { name: "Start session" }).isDisabled()).toBe(true);
-      expect(await gateway.getRequests("sessions.create")).toHaveLength(1);
-      expect(new URL(page.url()).pathname).toBe("/new");
-    });
-  });
+    },
+  );
 
   it("resets agent-derived workspace state when retargeted to a catalog", async () => {
     await withNewSessionPage(DESKTOP_CONTEXT, async (page) => {

--- a/ui/src/pages/new-session/cloud-profile-discovery.ts
+++ b/ui/src/pages/new-session/cloud-profile-discovery.ts
@@ -4,15 +4,6 @@ import type { DraftCloudProfile, DraftEnvironment } from "./discovery.ts";
 
 export const CLOUD_PROFILE_RETRY_DELAYS_MS = [1_000, 3_000, 10_000, 30_000, 60_000] as const;
 
-export function selectProfiles(
-  profiles: DraftCloudProfile[],
-  client: { recoveryScopeReady?: boolean } | null,
-  recoveryScope: string,
-) {
-  const unsupported = profiles.length > 0 && client?.recoveryScopeReady === true && !recoveryScope;
-  return { profiles: unsupported ? [] : profiles, unsupported };
-}
-
 export function discoverPlaceCatalog(
   client: Pick<GatewayBrowserClient, "request">,
   canWrite: boolean,

--- a/ui/src/pages/new-session/draft-gateway-state.ts
+++ b/ui/src/pages/new-session/draft-gateway-state.ts
@@ -10,11 +10,7 @@ import { t } from "../../i18n/index.ts";
 import { isGatewayMethodAdvertised } from "../../lib/gateway-methods.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
 import * as catalog from "./catalog-target.ts";
-import {
-  CLOUD_PROFILE_RETRY_DELAYS_MS,
-  discoverPlaceCatalog,
-  selectProfiles,
-} from "./cloud-profile-discovery.ts";
+import { CLOUD_PROFILE_RETRY_DELAYS_MS, discoverPlaceCatalog } from "./cloud-profile-discovery.ts";
 import type { DraftCloudProfile, DraftEnvironment } from "./discovery.ts";
 import { discoverGatewayName } from "./gateway-name-discovery.ts";
 import type { NewSessionRouteData } from "./location.ts";
@@ -29,7 +25,6 @@ import {
   type NewSessionPreference,
 } from "./preferences.ts";
 import {
-  resolveScope,
   resolveSubmissionOutcomeReason,
   type SubmissionOutcomeReason,
 } from "./session-placement-recovery-state.ts";
@@ -234,16 +229,17 @@ export class DraftGatewayState {
     const becameConnected = connected && (identityChanged || !this.gatewayConnectedValue);
     const recoveryScopeBecameReady =
       connected && snapshot.client?.recoveryScopeReady === true && !this.gatewayRecoveryScopeReady;
-    const recoveryScope = resolveScope(
-      { client: snapshot.client, connected },
-      this.gatewayRecoveryScopeValue,
-      firstBind,
-    );
+    // Hello owns authentication; browser recovery migration may finish later.
+    // Delaying this binding revokes live starts and lets reconnects replay under the old scope.
+    const recoveryScope = connected
+      ? (snapshot.hello?.auth?.recoveryScope ?? "")
+      : this.gatewayRecoveryScopeValue;
+    const recoveryScopeChanged = !firstBind && this.gatewayRecoveryScopeValue !== recoveryScope;
     this.gatewaySource = gateway;
     this.gatewayClientValue = snapshot.client;
     this.gatewayUrlValue = gateway.connection.gatewayUrl;
     this.gatewayBootIdValue = bootId;
-    this.gatewayRecoveryScopeValue = recoveryScope.next;
+    this.gatewayRecoveryScopeValue = recoveryScope;
     this.gatewayRecoveryScopeReady = snapshot.client?.recoveryScopeReady === true;
     this.gatewayConnectedValue = connected;
     if (this.read().visibility === "draft" && !this.read().canStartAsDraft) {
@@ -254,10 +250,10 @@ export class DraftGatewayState {
       gatewayBootChanged ||
       identityChanged ||
       connectionChanged ||
-      recoveryScope.changed
+      recoveryScopeChanged
     ) {
-      const ownerChanged = gatewaySourceChanged || gatewayUrlChanged || recoveryScope.changed;
-      const gatewayIdentityChanged = gatewayUrlChanged || recoveryScope.changed;
+      const ownerChanged = gatewaySourceChanged || gatewayUrlChanged || recoveryScopeChanged;
+      const gatewayIdentityChanged = gatewayUrlChanged || recoveryScopeChanged;
       this.invalidateDiscovery(
         ownerChanged,
         resolveSubmissionOutcomeReason({
@@ -269,7 +265,7 @@ export class DraftGatewayState {
     if (
       firstBind ||
       gatewayUrlChanged ||
-      recoveryScope.changed ||
+      recoveryScopeChanged ||
       recoveryScopeBecameReady ||
       becameConnected
     ) {
@@ -463,12 +459,8 @@ export class DraftGatewayState {
   }
 
   private applyCloudProfiles(profiles: DraftCloudProfile[]) {
-    const recovery = selectProfiles(
-      profiles,
-      this.gatewayClientValue,
-      this.gatewayRecoveryScopeValue,
-    );
-    this.cloudProfilesValue = recovery.profiles;
+    const recoveryUnsupported = profiles.length > 0 && !this.gatewayRecoveryScopeValue;
+    this.cloudProfilesValue = recoveryUnsupported ? [] : profiles;
     const snapshot = this.read();
     const pendingPlacement = Boolean(snapshot.pendingPlacement.sessionKey);
     const canWrite = hasOperatorWriteAccess(snapshot.context?.gateway.snapshot.hello?.auth ?? null);
@@ -481,7 +473,7 @@ export class DraftGatewayState {
       !profiles.some((profile) => profile.id === snapshot.cloudProfileId);
     if (selectionUnavailable) {
       this.callbacks.onCloudState(t("newSession.catalogUnavailable"));
-    } else if (recovery.unsupported) {
+    } else if (recoveryUnsupported) {
       this.callbacks.onCloudState(t("newSession.cloudRecoveryUnavailable"));
     } else {
       this.callbacks.onCloudState(null);

--- a/ui/src/pages/new-session/draft-place-browser.test.ts
+++ b/ui/src/pages/new-session/draft-place-browser.test.ts
@@ -20,7 +20,7 @@ function createBrowser(request: (method: string) => Promise<unknown>, data?: New
   vi.spyOn(host, "addController").mockImplementation((controller) => controllers.push(controller));
   const client = { request, recoveryScope: "principal-a", recoveryScopeReady: true };
   const hello = {
-    auth: { role: "operator", scopes: ["operator.read"] },
+    auth: { recoveryScope: client.recoveryScope, role: "operator", scopes: ["operator.read"] },
     features: { methods: ["projects.list"] },
   };
   const context = {

--- a/ui/src/pages/new-session/draft-submission-flow.test-support.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test-support.ts
@@ -40,6 +40,7 @@ export function createDraftFixture(options: FixtureOptions = {}) {
             ? {
                 server: { bootId: "gateway-boot-a" },
                 auth: {
+                  recoveryScope: client.recoveryScope,
                   role: "operator",
                   scopes: options.scopes ?? ["operator.read", "operator.write"],
                 },

--- a/ui/src/pages/new-session/draft-submission-flow.test.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test.ts
@@ -744,6 +744,7 @@ describe("DraftSubmissionFlow", () => {
           sessionKey: "",
           hello: {
             auth: {
+              recoveryScope: client.recoveryScope,
               role: "operator",
               scopes: ["operator.admin", "operator.read", "operator.write"],
             },

--- a/ui/src/pages/new-session/session-placement-recovery-state.ts
+++ b/ui/src/pages/new-session/session-placement-recovery-state.ts
@@ -23,22 +23,6 @@ export function resolveSubmissionOutcomeReason(params: {
     : "placement-interrupted";
 }
 
-export function resolveScope(
-  snapshot: {
-    client: { recoveryScope?: string; recoveryScopeReady?: boolean } | null;
-    connected: boolean;
-  },
-  current: string,
-  firstBind: boolean,
-): { next: string; changed: boolean } {
-  // Retain the verified scope until replacement auth arrives; a different scope invalidates it.
-  const next =
-    snapshot.connected && snapshot.client?.recoveryScopeReady
-      ? (snapshot.client.recoveryScope ?? "")
-      : current;
-  return { next, changed: !firstBind && snapshot.connected && current !== next };
-}
-
 export class PendingSessionPlacementRecoveryState {
   sessionKey = "";
   messageId = "";


### PR DESCRIPTION
Closes #133785 (false Gateway-change warning during New session startup).

<!-- Created as draft; marking ready after merge-ref computation only attaches native CI and is not a landing attestation. -->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users starting a task from Control UI **New session** would see “The Gateway changed while this session was starting” when browser recovery initialization finished, even though the same connection had already accepted the task. The recorded flow later opened that same running chat, leaving the warning at odds with the task's actual state.

The same ownership timing also allowed a reconnect to replay a pending create before the replacement principal's recovery scope had been adopted.

## Why This Change Was Made

The draft Gateway owner now binds its scope directly from the authenticated hello, while browser recovery readiness continues to gate saved-recovery restoration. Catalog eligibility reads that same canonical identity, so finishing browser migration neither invalidates a current start nor restarts authenticated catalog discovery; the redundant scope/profile projection helpers are removed.

This changes only Control UI ownership projection. It does not change server authentication, authorization, the idempotency ledger, configuration, protocol, persistence formats, or migration behavior. Existing Gateway URL, client, boot, and scope fences remain in place.

## User Impact

Normal first-message startup stays busy and opens the admitted session without a false Gateway-change warning. Same-owner reconnects retain the frozen idempotent request; changed principals or Gateway processes remain fail-closed rather than replaying uncertain work. Folder, runner, model, and recovery behavior remain covered by the existing sibling tests. No new operator configuration is required.

Production LOC: **+15/−48 (net −33)**. Tests and test support: **+139/−37 (net +102)**.

## Evidence

### Refreshed source after the canonical CSS repair

Published refreshed source head: `2a0ab2b09a40bb36bbf6664e6f89c14e820246e1`, based on `f7f38bcc88a329a0b050a1ffa221496803ccf1ff`. That main commit contains #133791 (rewind confirmation and CSS-selector repair), merged as `0ee6e0575a90f8c3fce8cd54e173d6b31b0923ef`. Its final head was `e3c93f8dd99130916e01252d748c371c9bf123ba`; comparison with the previously inspected `84b2e4c99a296a519b4026bce87d4cd2db4420ec` shows only deletion of one changelog line. The canonical three-file UI diff was inspected directly, and the CSS budget remains **54,784 B**.

The refresh was a conflict-free standard rebase, with no source edits or hook suppression. `git range-diff` marks the Task41 commit equal, and stable patch-id remains `d7fd0cb0163c147de9927311512ebd35365af242`. The complete refreshed diff SHA256 is `7e4e43ce5c0ed917000d61cc4a3145d5bef555fe3f161310401fe97b74eae9d3`; its different blob/header identity reflects the new base, not new repair logic. The ten-file scope and production/test LOC are unchanged. No additional managed review was run for this patch-identical mechanical refresh; the original review and explicit adjudication below remain preserved.

```bash
git rebase --onto f7f38bcc88a329a0b050a1ffa221496803ccf1ff c29f34dc5312530761529e7133afa083911e7959
```

The same unit and four-file E2E commands below were rerun on this head: **361 unit tests across 33 files** and **35 browser E2E tests across 4 files passed**. The complete ten-file changed gate and diff check also passed:

```bash
git diff --name-only -z f7f38bcc88a329a0b050a1ffa221496803ccf1ff HEAD | xargs -0 node scripts/check-changed.mjs --
```

The original commit, proof ledger, runtime metadata, and complete original UI bundle were preserved; all 1,191 original UI asset entries were reverified. The fresh canonical full build and subsequent standalone UI rebuild both completed with exit 0. The full build took 41m 57.3s, principally nine serialized runtime/declaration invocations; the final UI bundle built in 1m 33s. No declaration skip, budget increase, timeout override, or retry was used.

Fresh `dist/build-info.json`, AST-parsed UI metadata, and the service worker all match commit `2a0ab2b09a40bb36bbf6664e6f89c14e820246e1` and build ID `2026.8.1-2a0ab2b09a40-2026-08-31T05-49-40.341Z`. All **1,188** new asset-manifest entries match their actual sizes and SHA256 digests; **792** precompressed sidecars verified. The largest CSS asset is **54,583 B gzip**, under the unchanged **54,784 B** limit; the complete performance report has no violations.

The UI's advisory dirty field is `null`, not a claim of dirty or clean source: its bounded Git reader explicitly permits unknown metadata (`ui/vite.config.ts:153-159,225-233`). Clean source and the unchanged complete patch were verified independently before and after building. The artifact verifier initially overrequired `dirty=false`; that unsupported assumption was corrected against the producer contract without relaxing commit/version/timestamp/build-ID or asset-hash checks. No product code or build bytes were changed to alter this metadata. These are fresh artifacts of the new commit, not restamped copies of the original build; the build-verification step alone was not live proof; the real-flow evidence below uses the refreshed build.

Replacement [CI run 33365031747](https://github.com/openclaw/openclaw/actions/runs/33365031747) **completed successfully, attempt 1**, on exact head `2a0ab2b09a40bb36bbf6664e6f89c14e820246e1`. Its recorded main base is `9e444a9ea517f2a4004e7caae74a5f4284acdc52`; GitHub computed merge `9ca35c9ab570981847177baff4f2d83bbc38e3eb`. The single watcher exited 0 with `SUCCESS`, zero pending checks, and `GREEN`; structured run readback and the current PR head match. No watcher remains active, and the old failed watcher was not restarted. This is CI proof, not real repaired-flow or media proof.

### Real rebuilt-Control-UI proof

The [complete live-proof report](https://github.com/openclaw/openclaw/pull/133789#issuecomment-5477106316) now includes inspected before/after media and a continuous recording from the refreshed exact-head build. A fresh Chrome profile on an isolated Gateway completed one Start and one accepted create, opened the original session, displayed the exact requested synthetic reply, and returned to an idle composer without the false warning. No tools or children were produced.

The primary qualified run, `startup-live-02`, exited 0 in 36.47 seconds including setup/checks/cleanup. Its sole console error was the selected session's optional workspace-icon 404, paired with actual `no-store` and a visible fallback SVG; no unclassified console/HTTP errors or page exceptions remained. All 472 frames of the 18.88-second video were inspected. The browser/context and isolated Gateway were stopped; operator state was untouched.

Hydration was already ready at Start: this is normal real-flow proof, not a live delayed-hydration reproduction. Existing controlled browser regressions cover delayed hydration and changed-owner/process fencing. No timing manipulation or recovery-feature override was used. The visible repository badge references the separate public Swarm guidance checkout; runtime/UI identity was independently verified against this PR's `2a0ab2b09a40` build.

**Before — observed false warning after an accepted start:**

![Before: false Gateway-change warning](https://github.com/user-attachments/assets/6d33b5f6-4880-4fd1-8c22-1da2bf40af91)

**After — original chat, exact reply, idle composer:**

![After: successful startup without the false warning](https://github.com/user-attachments/assets/ffaf6ec0-47a4-47f7-9e70-d94e6d589a7f)

**Complete recording:**

https://github.com/user-attachments/assets/0acf269e-d12b-4e97-99d8-dffa64ef05a0

### Original reproduction and focused proof

The inspected before recording contains one accepted UI `sessions.create` request followed by the exact warning and later navigation to the running chat. That recording subsequently hit an independent completion-observer failure; it is not successful Swarm-completion evidence.

The new tests reproduce both warning timings by holding browser recovery hydration: before create acceptance, and after acceptance during chat preparation. No reconnect is injected into either case. On exact original production at `c29f34dc5312530761529e7133afa083911e7959`, all **6 targeted regressions failed for their intended reasons**; after restoring the byte-identical repair, all **6 passed**. Those cases also pin changed/missing handshake-owner replay fences and eliminate redundant hydration-triggered catalog fetches. Missing-owner hello injection is defensive wire-boundary coverage, not a claim that the current supported Control UI producer emits that state.

Full focused UI E2E: **35 passed across 4 files**:

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/new-session-page.workspace-validation.e2e.test.ts ui/src/e2e/new-session-page.transition.e2e.test.ts ui/src/e2e/new-session-page.projects-places.e2e.test.ts ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
```

New-session units: **351 passed across 33 files**:

```bash
node scripts/run-vitest.mjs ui/src/pages/new-session
```

Existing admission/browser identity contracts: **10 passed across 2 shards**:

```bash
node scripts/run-vitest.mjs src/gateway/server/ws-connection/connect-policy.test.ts ui/src/lib/nodes/device-identity.insecure-context.test.ts
```

Existing build-admission, browser-client, and application-Gateway contracts: **139 passed across 3 files / 2 shards**, including retained build identity on older-schema rejection:

```bash
node scripts/run-vitest.mjs ui/src/api/gateway.node.test.ts src/gateway/server/ws-connection/control-ui-build-admission.test.ts ui/src/app/gateway-store.test.ts
```

Before committing, the full changed-file gate and diff check passed for the ten-file candidate:

```bash
git diff --name-only -z | xargs -0 node scripts/check-changed.mjs --
```

```bash
git diff --check
```

### Original completed build checkpoint

The original canonical full build followed by the final standalone UI rebuild completed with exit 0:

```bash
pnpm build
```

```bash
pnpm ui:build
```

The canonical full build's phase total was 5m 47.8s; the final UI bundle built in 4.38s, followed by successful precompression and performance checks (794 finalized sidecars verified).

After all runtime writers completed, the final UI rebuild reused the runtime identity. `dist/build-info.json`, the compiled UI metadata, and `sw.js` all contain build ID `2026.8.1-c29f34dc5312-2026-08-31T03-36-37.786Z`. All 1,191 UI asset-manifest entries were verified against their actual sizes and SHA256 digests. The source patch hash remained unchanged before and after building. This is build/artifact proof, not a running-Gateway or live-provider result.

### Review disposition

Fresh managed Codex review at P0 completed cleanly. The explicitly broader P2 pass returned one finding about an unbound device-placement hello. That finding was rejected after reading the complete producer chain: ordinary Control UI admission requires a device, and its sole device-less exception is trusted-proxy authentication with a required nonempty user principal already attached before hello (`src/gateway/server/ws-connection/connect-policy.ts:81-92`, `src/gateway/auth.ts:239-253`, `src/gateway/server/ws-connection/connect-session.ts:418-432`). The backend self-pairing exception is a different client id/mode and does not apply to Control UI. Insecure origins and blocked browser storage still mint a device identity.

The historical older-v4 promise in #121671 (trusted-proxy cloud recovery) was explicitly superseded by #124971 (one-install/one-version UI coupling) and clarified by #125108 (deliberate admission exemptions). All are included in stable `v2026.8.1`; the current and tagged admission sources match. The actual app always sends its build identity, and the older `v2026.6.34` closed connect schema rejects that field before hello. The current browser no longer retries without it. Cross-origin, custom-root, and development version mismatch are explicitly unsupported, not hidden compatibility paths (`ui/AGENTS.md:39-43`). The lower-level legacy-scope test injects hello into a client without the application's build identity; it does not establish supported cross-version admission.

The raw P2 report remains `findings`/exit 1, not relabeled clean. Effective accepted/actionable findings: **0**. No speculative hardening or authentication-policy changes were added. Separate cleanup follow-up: remove the obsolete older-v4 scope fallback/test under Gateway Coupling while preserving credential hashing required by current recovery migration.

### Related history and source identity

Archive-first discovery and live checks found no open duplicate. #120953 (cloud-draft interruption/dead-end cleanup), fixed by #120970 (accurate interrupted-setup outcomes), concerned tab interruption and worker cleanup rather than this initial-hydration race. #106372 (stale New session discovery after reconnect) is also closed and covers a different trigger.

Original published source head: `934a1e72ea1b5d272e5b18f35d4d68d5967c31ab`. The normal-hook commit contains exactly the tested ten-file patch over `c29f34dc5312530761529e7133afa083911e7959`: SHA256 `1005400c3ee1c638d51e807e38cad0e9d98cb51aa970b87e8c9df596c50dd143` (stable patch-id `d7fd0cb0163c147de9927311512ebd35365af242`). The local build ran before that commit. Its artifacts were not restamped and intentionally retain the original base commit and dirty-build identity; source equivalence is established by the unchanged complete patch, not by pretending the build ran at the new commit.

Current-main comparison at `8249fd61a9183a14063278741093645f8f3b238f` found the three production owners, startup/submission path, and relevant handshake/authentication producers unchanged. Neighboring preference/persistence refactors do not implement this repair; the only overlap among the ten touched files is a non-overlapping test change in `draft-place-browser.test.ts`. The earlier ten-path byte-identity comparison at `9f6d8c5a60b4ce251157e354b459d29037179f57` remains historical evidence, not a claim that every neighbor is unchanged today.

### Remaining landing gates and prior CI history

**Real repaired-flow and inspected before/after media proof are complete on the exact refreshed head. Exact-head CI is green; repository-native prepare/merge gates remain outstanding.** Marking this PR ready after merge-ref computation was only the native CI attachment procedure, not a landing attestation.

- Completed: inspected real-flow before/after media and video are linked above. The live startup proof is separate from controlled timing E2E and does not claim Swarm-completion or changed-owner live replay proof.
- Replacement exact-head CI is green as recorded above; the original failed [run 33357188954](https://github.com/openclaw/openclaw/actions/runs/33357188954) is historical evidence, not reusable success. It tested merge `3f6ab7556c1bf3d786274fdaf9fad6f8185b68d5`: Task41 head `934a1e72ea1b5d272e5b18f35d4d68d5967c31ab` into main `10f5ef53cdc1619d9a8271c66c71ad6e83892934`, not the bare locally built source. Four completed jobs stopped at the same largest-CSS gzip gate: **54,809 B versus 54,784 B (+25 B)** — [real-Gateway UI](https://github.com/openclaw/openclaw/actions/runs/33357188954/job/99381594900), [build-artifacts](https://github.com/openclaw/openclaw/actions/runs/33357188954/job/99381594963), [compact-small-29](https://github.com/openclaw/openclaw/actions/runs/33357188954/job/99381595792), and [compact-small-27](https://github.com/openclaw/openclaw/actions/runs/33357188954/job/99381595912). Their tests never ran. Missing Discord proof files are consequential to the aborted build. The single watcher exited 15 while other jobs were still running; no retry or budget change was made.

  **#133791 (rewind confirmation and theme-selector repair) has now merged** as `0ee6e0575a90f8c3fce8cd54e173d6b31b0923ef`, and the refreshed base above includes it. Its actual final head and canonical source were verified rather than assuming that earlier head `84b2e4c99a296a519b4026bce87d4cd2db4420ec` was what landed. The earlier [owner CI run 33357237325](https://github.com/openclaw/openclaw/actions/runs/33357237325), including its passing build-artifacts and real-Gateway UI jobs against the same original main base, remains historical owner evidence only. It is not green CI for this PR. No competing CSS patch or budget increase was added; the demonstrated red-base failure is the reason for the mechanical refresh.
- Complete the repository-native review/prepare/merge gates. The current execution environment cannot write the required native review artifacts; no alternative writer or landing bypass was used. This PR remains open and unmerged. CI and live proof belonging to another source candidate are not claimed here.
