### PR TITLE
fix(ui): keep rewind confirmation controls accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,6 @@ Latest release notes: https://docs.openclaw.ai/releases/2026.8.1
 
 ### Fixes
 
-- **Control UI rewind:** keep confirmation buttons above their context menu and preserve the dialog while toggling its confirmation preference.
 - **Subagent completion:** recognize visible final answers delivered to internal and nested parent sessions, preventing false delivery failures while preserving external channel delivery checks.
 - Codex/Linux: wait for a live app-server process to expose its startup command line within the existing inspection deadline, preserving process identity checks and preventing intermittent startup failures.
 - **Cloud session lifecycle:** prevent archive, delete, and restart recovery from deadlocking behind an earlier worker move, keep work admission closed through cleanup, and preserve the same successor for concurrent recovery requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Latest release notes: https://docs.openclaw.ai/releases/2026.8.1
 
 ### Fixes
 
+- **Control UI rewind:** keep confirmation buttons above their context menu and preserve the dialog while toggling its confirmation preference.
 - **Subagent completion:** recognize visible final answers delivered to internal and nested parent sessions, preventing false delivery failures while preserving external channel delivery checks.
 - Codex/Linux: wait for a live app-server process to expose its startup command line within the existing inspection deadline, preserving process identity checks and preventing intermittent startup failures.
 - **Cloud session lifecycle:** prevent archive, delete, and restart recovery from deadlocking behind an earlier worker move, keep work admission closed through cleanup, and preserve the same successor for concurrent recovery requests.

--- a/ui/src/e2e/session-management.archived-actions.e2e.test.ts
+++ b/ui/src/e2e/session-management.archived-actions.e2e.test.ts
@@ -139,6 +139,19 @@ suite.define(() => {
         await rewind.click();
         await page.locator(".chat-confirm-popover").waitFor({ state: "visible" });
 
+        const confirmation = page.locator(".chat-confirm-popover");
+        const remember = confirmation.getByRole("checkbox");
+        await remember.check();
+        expect(await remember.isChecked()).toBe(true);
+        await remember.uncheck();
+        await confirmation.getByRole("button", { name: "Cancel", exact: true }).click();
+        await confirmation.waitFor({ state: "detached" });
+        expect(await gateway.getRequests("sessions.rewind")).toHaveLength(0);
+        expect(await initialMenu.isVisible()).toBe(true);
+        expect(await rewind.evaluate((element) => element === document.activeElement)).toBe(true);
+        await rewind.click();
+        await confirmation.waitFor({ state: "visible" });
+
         await gateway.emitGatewayEvent("sessions.changed", {
           ...session,
           archived: true,

--- a/ui/src/pages/chat/components/chat-message-confirmation.ts
+++ b/ui/src/pages/chat/components/chat-message-confirmation.ts
@@ -260,6 +260,8 @@ function openConfirmedActionPopover(btn: HTMLElement, params: ConfirmedActionPar
     dismissPopover();
     params.action();
   });
+  // Keep this portaled dialog's clicks from dismissing its owning context menu.
+  popover.addEventListener("click", (event) => event.stopPropagation());
   popover.addEventListener("keydown", containKeyboardFocus);
   document.addEventListener("contextmenu", closeOnContextMenu, true);
   window.addEventListener("keydown", closeOnEscape, true);

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -1194,7 +1194,8 @@ img.chat-avatar.chat-avatar--logo {
   min-width: 200px;
   max-width: calc(100vw - 48px);
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
-  z-index: 100;
+  /* Above the still-connected .chat-reply-context-menu (9999). */
+  z-index: 10000;
   animation: scale-in 0.15s ease-out;
   transform-origin: top right;
 }
@@ -1252,21 +1253,20 @@ img.chat-avatar.chat-avatar--logo {
   color: var(--media-foreground);
 }
 
-:root[data-theme="dark"] .chat-confirm-popover__yes {
-  background: var(--destructive);
-  color: var(--destructive-foreground);
-}
-
-:root[data-theme="openknot"] .chat-confirm-popover__yes,
-:root[data-theme="dash"] .chat-confirm-popover__yes,
-:root[data-theme="absolutely"] .chat-confirm-popover__yes,
-:root[data-theme="tide"] .chat-confirm-popover__yes,
-:root[data-theme="phosphor"] .chat-confirm-popover__yes,
-:root[data-theme="crt"] .chat-confirm-popover__yes,
-:root[data-theme="manuscript"] .chat-confirm-popover__yes,
-:root[data-theme="rose"] .chat-confirm-popover__yes,
-:root[data-theme="miami"] .chat-confirm-popover__yes,
-:root[data-theme="beacon"] .chat-confirm-popover__yes {
+:root:is(
+    [data-theme="dark"],
+    [data-theme="openknot"],
+    [data-theme="dash"],
+    [data-theme="absolutely"],
+    [data-theme="tide"],
+    [data-theme="phosphor"],
+    [data-theme="crt"],
+    [data-theme="manuscript"],
+    [data-theme="rose"],
+    [data-theme="miami"],
+    [data-theme="beacon"]
+  )
+  .chat-confirm-popover__yes {
   background: var(--destructive);
   color: var(--destructive-foreground);
 }
@@ -1275,20 +1275,20 @@ img.chat-avatar.chat-avatar--logo {
   background: var(--danger-solid-hover);
 }
 
-:root[data-theme="dark"] .chat-confirm-popover__yes:hover {
-  background: var(--destructive-hover);
-}
-
-:root[data-theme="openknot"] .chat-confirm-popover__yes:hover,
-:root[data-theme="dash"] .chat-confirm-popover__yes:hover,
-:root[data-theme="absolutely"] .chat-confirm-popover__yes:hover,
-:root[data-theme="tide"] .chat-confirm-popover__yes:hover,
-:root[data-theme="phosphor"] .chat-confirm-popover__yes:hover,
-:root[data-theme="crt"] .chat-confirm-popover__yes:hover,
-:root[data-theme="manuscript"] .chat-confirm-popover__yes:hover,
-:root[data-theme="rose"] .chat-confirm-popover__yes:hover,
-:root[data-theme="miami"] .chat-confirm-popover__yes:hover,
-:root[data-theme="beacon"] .chat-confirm-popover__yes:hover {
+:root:is(
+    [data-theme="dark"],
+    [data-theme="openknot"],
+    [data-theme="dash"],
+    [data-theme="absolutely"],
+    [data-theme="tide"],
+    [data-theme="phosphor"],
+    [data-theme="crt"],
+    [data-theme="manuscript"],
+    [data-theme="rose"],
+    [data-theme="miami"],
+    [data-theme="beacon"]
+  )
+  .chat-confirm-popover__yes:hover {
   background: var(--destructive-hover);
 }
 


### PR DESCRIPTION
## What Problem This Solves

Opening Rewind from a message context menu places its confirmation below the still-connected menu, which intercepts pointer actions. Clicking the dialog's checkbox also bubbles to the menu's outside-click handler and removes both owners. Separately, repeated theme selectors leave the current UI bundle 25 compressed bytes over its existing CSS limit, failing build and test-runtime CI jobs.

## Why This Change Was Made

Keep the confirmation portaled into the document body above its menu and contain its bubbling clicks at the dialog owner. Direct Cancel/Confirm handlers, checkbox activation, capture-phase dismissal, Escape, and cleanup remain intact. Cancel retains the menu and restores focus to its Rewind control.

Factor identical confirmation-button theme selectors while preserving all theme membership, declarations, specificity and source order. Attachment styles remain in the boot bundle for first-use offline rendering. Performance budgets are unchanged.

## User Impact

Rewind confirmation controls are clickable and its preference checkbox no longer dismisses the dialog. The theme colors remain unchanged, and CI can build the UI within the existing budget.

## Evidence

The unchanged baseline failed a real mocked-app pointer interaction, and the extended existing archived-actions E2E failed when checking the checkbox before production edits. The baseline canonical UI build reproduced 54,809 CSS gzip bytes against a 54,784-byte limit. The candidate full build passes at 54,758 bytes, saving 51 bytes without changing the limit; finalized sidecar verification also passes.

The built-app archived-actions E2E passes all three existing desktop, mobile, and cold-archive cases. The extended case now checks preference toggling, Cancel without an RPC, retained menu/focus, reopening, and the original archived-session inertness behavior. The focused confirmation unit selection passes 18 tests; all five contrast tests pass.

Real browser interactions against the synthetic Gateway fixture compare 24 normal/hover theme states before and after: computed paint values match exactly. The repaired context-menu flow also verifies preference toggling, Cancel, one correctly addressed rewind RPC on confirmation, and restored draft text. This is local browser proof with a synthetic Gateway, not an authenticated external-provider session.

The required changed-file gate passes formatting, dead exports, i18n verification, core-test/UI types, lint and style checks. Independent Codex review is scoped-clean at its configured P0 threshold. Production is +32/-30 (net +2 for the dialog-owned event boundary), tests +13/-0; no changelog diff. No test cases were added.

Provenance: the failure is reproduced on the current baseline. The exact commit that first crossed the CSS budget is unknown; the repair preserves the existing attachment boot-loading fix.

## Screenshots

Synthetic captures of the same context-menu confirmation, before and after. The original capture shows the menu covering the buttons; the repaired capture shows the accessible controls.

| Before | After |
|---|---|
| ![Menu obscures confirmation controls](https://github.com/user-attachments/assets/be3ca78a-1833-4258-8098-adf848cae55e) | ![Confirmation controls accessible](https://github.com/user-attachments/assets/9e718e2c-9e01-432c-b952-eb08471f99df) |

## Review follow-up

Removed the direct changelog entry requested by the completed ClawSweeper review. Release-note context stays in this body for release generation. The UI source and E2E files are byte-identical to the originally validated commit; the follow-up changes only that changelog line.
