### PR TITLE
fix(ui): restore attachment stylesheet build budget

### DIFF
--- a/ui/src/pages/chat/components/chat-attachment-file-icon.ts
+++ b/ui/src/pages/chat/components/chat-attachment-file-icon.ts
@@ -271,12 +271,18 @@ export function renderAttachmentFileIcon(options: {
   unavailable?: boolean;
 }) {
   const resolved = resolveAttachmentFileIcon(options.filename, options.mimeType);
-  const compactLight = resolved.compact
-    ? fileIconAssetPath(`compact/light/${resolved.compact}`)
-    : fileIconAssetPath("compact/unknown-light");
-  const compactDark = resolved.compact
-    ? fileIconAssetPath(`compact/dark/${resolved.compact}`)
-    : fileIconAssetPath("compact/unknown-dark");
+  const large = options.mode === "large-placeholder";
+  const size = large ? "44px" : "20px";
+  const light = large
+    ? fileIconAssetPath("large/shell-light")
+    : resolved.compact
+      ? fileIconAssetPath(`compact/light/${resolved.compact}`)
+      : fileIconAssetPath("compact/unknown-light");
+  const dark = large
+    ? fileIconAssetPath("large/shell-dark")
+    : resolved.compact
+      ? fileIconAssetPath(`compact/dark/${resolved.compact}`)
+      : fileIconAssetPath("compact/unknown-dark");
   return html`<span
     class="chat-attachment-file-icon ${options.unavailable
       ? "chat-attachment-file-icon--unavailable"
@@ -285,16 +291,14 @@ export function renderAttachmentFileIcon(options: {
     data-mode=${options.mode}
     aria-hidden="true"
     style=${styleMap({
-      "--chat-file-icon-shell-light": `url("${fileIconAssetPath("large/shell-light")}")`,
-      "--chat-file-icon-shell-dark": `url("${fileIconAssetPath("large/shell-dark")}")`,
+      width: size,
+      height: size,
+      "--chat-file-icon-light": `url("${light}")`,
+      "--chat-file-icon-dark": `url("${dark}")`,
       "--chat-file-icon-overlay": `url("${fileIconAssetPath(`overlays/${resolved.family}`)}")`,
       "--chat-file-icon-accent": resolved.accent,
-      "--chat-file-icon-compact-light": `url("${compactLight}")`,
-      "--chat-file-icon-compact-dark": `url("${compactDark}")`,
     })}
   >
-    ${options.mode === "large-placeholder"
-      ? html`<span class="chat-attachment-file-icon__overlay"></span>`
-      : null}
+    ${large ? html`<span class="chat-attachment-file-icon__overlay"></span>` : null}
   </span>`;
 }

--- a/ui/src/styles/chat/attachments.css
+++ b/ui/src/styles/chat/attachments.css
@@ -2,24 +2,12 @@
   position: relative;
   display: inline-block;
   flex: none;
-  width: 44px;
-  height: 44px;
   color: var(--file-icon-glyph);
-  background: var(--chat-file-icon-shell-dark) center / contain no-repeat;
-}
-
-.chat-attachment-file-icon[data-mode="preview-with-favicon"] {
-  width: 20px;
-  height: 20px;
-  background-image: var(--chat-file-icon-compact-dark);
+  background: var(--chat-file-icon-dark) center / contain no-repeat;
 }
 
 :root[data-theme-mode="light"] .chat-attachment-file-icon {
-  background-image: var(--chat-file-icon-shell-light);
-}
-
-:root[data-theme-mode="light"] .chat-attachment-file-icon[data-mode="preview-with-favicon"] {
-  background-image: var(--chat-file-icon-compact-light);
+  background-image: var(--chat-file-icon-light);
 }
 
 .chat-attachment-file-icon__overlay {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Control UI builds fail the existing stylesheet budget, blocking unrelated PRs. Current main reproducibly emits a 54,809-byte gzip CSS chunk against the 54,784-byte limit; four jobs in [Doctor CI](https://github.com/openclaw/openclaw/actions/runs/33355344186) fail on the same asset.

## Why This Change Was Made

The attachment icon renderer already knows whether it is a large placeholder or a compact preview. Prepare that mode's dimensions and light/dark asset pair once, then let the stylesheet handle theme selection. This removes unused asset preparation and duplicated mode rules while retaining the static CSS import that prevents unstyled offline renders. `data-mode` remains because the card layout uses it for padding.

No budget, baseline, chunking, dependency, public setting or fallback changes. Production LOC: +19/−27 (net −8); tests unchanged. Raising the limit or reverting static CSS loading would leave the underlying duplication in place.

## User Impact

Attachment cards retain the same appearance and behavior, and the canonical UI build passes again. This is a small build and renderer cleanup; no end-to-end latency or memory improvement is claimed.

## Evidence

- `pnpm ui:build`: before fails at **54,809 B**, after passes at **54,753 B** largest CSS gzip. Startup remains 8 JS requests and 1 CSS request; startup JS gzip 345,585→345,576 B and startup CSS unchanged at 45,347 B. All budgets pass. The first partial cleanup saved only 22 B and still failed; the final change also removes duplicated sizing policy.
- Existing `attachment-file-styles.e2e.test.ts` passes against fresh browser bundles before and after: large/compact geometry, both themes, PDF masks, unavailable colors/opacity/strikethrough and card layout. Computed styles are identical after excluding ephemeral fixture ports; full viewport PNGs are byte-identical in both themes. The Gateway is mocked in this suite; it is real Chromium rendering the built UI, not live provider or channel proof.
- Task-only screenshot capture was removed exactly; no test assertion, timeout or production seam was changed. Browser contexts/server returned through existing cleanup and the fixture ports are closed.
- Independent managed review found no actionable issues (scoped clean, confidence 0.95). Full changed-file checks passed, including core-test/UI type checking, formatting, lint/stylelint, dead exports and i18n verification (170.64 s).

The exact commit that first crossed the combined CSS budget is not established. Recent static stylesheet ownership is intentionally preserved.

Before:

![Attachment cards before](https://github.com/user-attachments/assets/6deb33db-0314-47f5-a149-cfe796cafb0f)

After:

![Attachment cards after](https://github.com/user-attachments/assets/d8d67c0d-4a09-4cf3-93fa-72ca53f0c126)
