### PR TITLE
improve: load and scroll chat history with less repeated work

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2206,7 +2206,7 @@ src/auto-reply/reply/session.ts	3
 src/auto-reply/reply/source-reply-delivery-runtime.ts	2
 src/auto-reply/reply/source-turn-id.ts	4
 src/auto-reply/reply/stage-sandbox-media.ts	1
-src/auto-reply/reply/strip-inbound-meta.ts	5
+src/auto-reply/reply/strip-inbound-meta.ts	4
 src/auto-reply/reply/system-event-session-key.ts	1
 src/auto-reply/templating.ts	1
 src/auto-reply/thinking.ts	1

--- a/src/auto-reply/reply/strip-inbound-meta.test.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.test.ts
@@ -161,10 +161,15 @@ Actual user message`;
     expect(stripInboundMetadata(input)).toBe("Actual message");
   });
 
-  it("preserves leading spaces in user content after stripping", () => {
-    const input = `${CONV_BLOCK}\n\n  Indented message`;
-    expect(stripInboundMetadata(input)).toBe("  Indented message");
-  });
+  it.each(["\n", "\r\n"])(
+    "preserves visible whitespace when stripping metadata with %j newlines",
+    (newline) => {
+      const body = `  Indented message${newline}Second line  `;
+      const input = `${CONV_BLOCK.replaceAll("\n", newline)}${newline}${body}`;
+      expect(stripInboundMetadata(input)).toBe(body);
+      expect(stripLeadingInboundMetadata(input)).toBe(body);
+    },
+  );
 
   it("strips trailing Untrusted context metadata suffix blocks", () => {
     const input = `Actual message body\n\n${UNTRUSTED_CONTEXT_BLOCK}`;
@@ -245,8 +250,11 @@ What should I grab on the way?`;
     );
   });
 
-  it("does not strip lookalike sentinel lines with extra text", () => {
-    const input = `Conversation info: please ignore
+  it.each([
+    "Conversation info: please ignore",
+    `${markInboundContextLabel("Conversation info:")} please ignore`,
+  ])("does not strip lookalike sentinel line %j", (header) => {
+    const input = `${header}
 \`\`\`json
 {"x": 1}
 \`\`\`
@@ -309,13 +317,20 @@ Hello`;
 });
 
 describe("extractInboundSenderLabel", () => {
-  it("returns the sender label block when present", () => {
-    const input = `${CONV_BLOCK}\n\n${SENDER_BLOCK}\n\nHello from user`;
+  it.each(["\n", "\r\n"])("returns the sender label with %j newlines", (newline) => {
+    const input = `${CONV_BLOCK}\n\n${SENDER_BLOCK}\n\nHello from user`.replaceAll("\n", newline);
     expect(extractInboundSenderLabel(input)).toBe("Alice");
   });
 
-  it("falls back to conversation sender when sender block is absent", () => {
-    const input = `${CONV_BLOCK}\n\nHello from user`;
+  it.each([
+    ["absent", ""],
+    ["empty", `${markInboundContextLabel("Sender:")}\n\`\`\`json\n{}\n\`\`\`\n${SENDER_BLOCK}\n`],
+    [
+      "malformed",
+      `${markInboundContextLabel("Sender:")}\n\`\`\`json\n{invalid}\n\`\`\`\n${SENDER_BLOCK}\n`,
+    ],
+  ])("falls back to conversation sender when the first sender block is %s", (_name, prefix) => {
+    const input = `${prefix}${CONV_BLOCK}\n\nHello from user`;
     expect(extractInboundSenderLabel(input)).toBe("+1555000");
   });
 

--- a/src/auto-reply/reply/strip-inbound-meta.ts
+++ b/src/auto-reply/reply/strip-inbound-meta.ts
@@ -1,41 +1,60 @@
-/**
- * Strips OpenClaw-injected inbound metadata blocks from a user-role message
- * text before it is displayed in any UI surface (TUI, webchat, macOS app) or
- * replayed as historical context to the model.
- *
- * Background: `buildInboundUserContextPrefix` in `inbound-meta.ts` prepends
- * structured metadata blocks (Conversation info, Sender info, reply context,
- * etc.) directly to the stored user message content so the LLM can access
- * them. These blocks are current-turn AI-facing context only and must never
- * surface in user-visible chat history or accumulate in historical prompt
- * replay.
- *
- * Also strips the timestamp prefix injected by `injectTimestamp` so UI surfaces
- * do not show AI-facing envelope metadata as user text.
- *
- * Detection: every OpenClaw-injected context header is stamped with a fixed
- * provenance marker `⟦openclaw:ctx⟧`. Strippers key on this marker rather than
- * on label text, making detection label-agnostic (arbitrary structured labels
- * are supported) and collision-free (user text never carries the marker). This
- * fixes both label collision risks (e.g., `Sender:` in natural prose) and the
- * structured-context over-strip (arbitrary plugin labels are now recognized).
- */
-
+// Generated inbound context is current-turn model input, never historical display text.
 import { safeParseJsonRecord } from "@openclaw/normalization-core";
+import { escapeRegExp } from "../../shared/regexp.js";
 import { MESSAGE_TOOL_DELIVERY_HINTS } from "./delivery-hints.js";
 import { INBOUND_CONTEXT_MARKER } from "./inbound-context-marker.js";
 
 const LEADING_TIMESTAMP_PREFIX_RE = /^\[[A-Za-z]{3} \d{4}-\d{2}-\d{2} \d{2}:\d{2}[^\]]*\] */;
-
 const CHANNEL_CONTEXT_HEADER = `Context: ${INBOUND_CONTEXT_MARKER}`;
 const ACTIVE_MEMORY_CONTEXT_HEADER = "Context:";
 const ACTIVE_MEMORY_OPEN_TAG = "<active_memory_plugin>";
 const ACTIVE_MEMORY_CLOSE_TAG = "</active_memory_plugin>";
+const METADATA_TOKENS_RE = new RegExp(
+  [INBOUND_CONTEXT_MARKER, ...MESSAGE_TOOL_DELIVERY_HINTS].map(escapeRegExp).join("|"),
+  "g",
+);
 
-// Detect a context header line by marker suffix (label-agnostic, collision-free).
+type TextLine = { start: number; end: number; next: number; trimmed: string };
+type LineSpan = { start: number; next: number };
+
+function readTextLine(text: string, start: number): TextLine | undefined {
+  if (start > text.length) {
+    return undefined;
+  }
+  const newline = text.indexOf("\n", start);
+  const end = newline < 0 ? text.length : newline;
+  return { start, end, next: end + 1, trimmed: text.slice(start, end).trim() };
+}
+
+function findTextLine(text: string, value: string, from = 0): TextLine | undefined {
+  let index = text.indexOf(value, from);
+  while (index >= 0) {
+    const start = text.lastIndexOf("\n", index - 1) + 1;
+    const line = readTextLine(text, start)!;
+    if (line.trimmed === value) {
+      return line;
+    }
+    index = text.indexOf(value, line.next);
+  }
+  return undefined;
+}
+
+function skipEmptyLines(text: string, start: number, trimmed = true): number {
+  let next = start;
+  let line = readTextLine(text, next);
+  while (line && (trimmed ? line.trimmed === "" : line.start === line.end)) {
+    next = line.next;
+    line = readTextLine(text, next);
+  }
+  return next;
+}
+
 function isInboundContextHeaderLine(line: string): boolean {
-  const t = line.trim();
-  return t.length > INBOUND_CONTEXT_MARKER.length && t.endsWith(INBOUND_CONTEXT_MARKER);
+  return line.length > INBOUND_CONTEXT_MARKER.length && line.endsWith(INBOUND_CONTEXT_MARKER);
+}
+
+function isMessageToolDeliveryHintLine(line: string): boolean {
+  return MESSAGE_TOOL_DELIVERY_HINTS.some((hint) => hint === line);
 }
 
 /** Fast check for whether text contains any inbound metadata sentinel. */
@@ -43,229 +62,103 @@ export function hasInboundMetadataSentinel(text: string): boolean {
   return (
     text.includes(INBOUND_CONTEXT_MARKER) ||
     MESSAGE_TOOL_DELIVERY_HINTS.some((hint) => text.includes(hint)) ||
-    // Active-memory's bare Context: sentinel is valid only as a complete line.
+    // Bare Context: is a sentinel only as a complete line.
     (text.includes(ACTIVE_MEMORY_CONTEXT_HEADER) && /^[ \t]*Context:[ \t]*$/m.test(text))
   );
 }
 
-function isMessageToolDeliveryHintLine(line: string): boolean {
-  const trimmed = line.trim();
-  return MESSAGE_TOOL_DELIVERY_HINTS.some((hint) => hint === trimmed);
+function metadataBlockEnd(text: string, header: TextLine): number {
+  let line = readTextLine(text, header.next);
+  if (line?.trimmed === "```json") {
+    return findTextLine(text, "```", line.next)?.next ?? text.length + 1;
+  }
+  // Generated prose context ends at the next blank separator, including its blanks.
+  while (line && line.trimmed !== "") {
+    line = readTextLine(text, line.next);
+  }
+  return skipEmptyLines(text, line?.start ?? text.length + 1);
 }
 
-function skipChatWindowContextBlock(lines: string[], index: number): number {
-  let next = index + 1;
-  while (next < lines.length && lines[next]?.trim() !== "") {
-    next++;
-  }
-  while (next < lines.length && lines[next]?.trim() === "") {
-    next++;
-  }
-  return next;
-}
-
-function restoreNeutralizedMarkdownFences(value: unknown): unknown {
-  if (typeof value === "string") {
-    return value.replaceAll("`\u200b``", "```");
-  }
-  if (Array.isArray(value)) {
-    return value.map((entry) => restoreNeutralizedMarkdownFences(entry));
-  }
-  if (!value || typeof value !== "object") {
-    return value;
-  }
-  return Object.fromEntries(
-    Object.entries(value).map(([key, entry]) => [key, restoreNeutralizedMarkdownFences(entry)]),
-  );
-}
-
-function parseJsonObjectRecord(jsonText: string): Record<string, unknown> | null {
-  return safeParseJsonRecord(jsonText) ?? null;
-}
-
-function parseInboundMetaBlock(
-  lines: string[],
-  sentinelBase: string,
-): Record<string, unknown> | null {
-  // Match the marked header line: sentinelBase + marker.
-  const markedSentinel = `${sentinelBase} ${INBOUND_CONTEXT_MARKER}`;
-  for (let i = 0; i < lines.length; i++) {
-    if (lines[i]?.trim() !== markedSentinel) {
-      continue;
-    }
-    if (lines[i + 1]?.trim() !== "```json") {
-      return null;
-    }
-    let end = i + 2;
-    while (end < lines.length && lines[end]?.trim() !== "```") {
-      end += 1;
-    }
-    if (end >= lines.length) {
-      return null;
-    }
-    const jsonText = lines
-      .slice(i + 2, end)
-      .join("\n")
-      .trim();
-    if (!jsonText) {
-      return null;
-    }
-    const parsed = parseJsonObjectRecord(jsonText);
-    return parsed ? (restoreNeutralizedMarkdownFences(parsed) as Record<string, unknown>) : null;
-  }
-  return null;
-}
-
-function firstNonEmptyString(...values: unknown[]): string | null {
-  for (const value of values) {
-    if (typeof value !== "string") {
-      continue;
-    }
-    const trimmed = value.trim();
-    if (trimmed) {
-      return trimmed;
-    }
-  }
-  return null;
-}
-
-function shouldStripTrailingContextBlock(lines: string[], index: number): boolean {
-  return lines[index]?.trim() === CHANNEL_CONTEXT_HEADER;
-}
-
-function stripTrailingContextBlockSuffix(lines: string[]): string[] {
-  for (let i = 0; i < lines.length; i++) {
-    if (!shouldStripTrailingContextBlock(lines, i)) {
-      continue;
-    }
-    let end = i;
-    while (end > 0 && lines[end - 1]?.trim() === "") {
-      end -= 1;
-    }
-    return lines.slice(0, end);
-  }
-  return lines;
-}
-
-function stripActiveMemoryPromptPrefixBlocks(lines: string[]): string[] {
-  const result: string[] = [];
-
-  for (let index = 0; index < lines.length; index += 1) {
-    const line = lines.at(index);
-    if (line === undefined) {
-      break;
-    }
-    if (
-      line.trim() === ACTIVE_MEMORY_CONTEXT_HEADER &&
-      lines[index + 1]?.trim() === ACTIVE_MEMORY_OPEN_TAG
-    ) {
-      let closeIndex = -1;
-      for (let probe = index + 2; probe < lines.length; probe += 1) {
-        if (lines[probe]?.trim() === ACTIVE_MEMORY_CLOSE_TAG) {
-          closeIndex = probe;
-          break;
-        }
-      }
-      if (closeIndex !== -1) {
-        index = closeIndex;
-        while (index + 1 < lines.length && lines[index + 1]?.trim() === "") {
-          index += 1;
-        }
-        continue;
-      }
-    }
-
-    result.push(line);
-  }
-
-  return result;
-}
-
-/**
- * Remove all injected inbound metadata prefix blocks from `text`.
- *
- * Each block has the shape:
- *
- * ```
- * <header-with-marker>
- * ```json
- * { … }
- * ```
- * ```
- *
- * Returns the original string reference unchanged when no metadata is present
- * (fast path — zero allocation).
- */
-/** Strips all injected inbound metadata blocks from user-visible text. */
-export function stripInboundMetadata(text: string): string {
-  if (!text) {
+function removeLineSpans(text: string, spans: LineSpan[]): string {
+  if (spans.length === 0) {
     return text;
   }
+  const parts: string[] = [];
+  let cursor = 0;
+  for (const span of spans) {
+    // A removed final line also owns the preceding separator, like split/filter/join.
+    const start = span.next > text.length && span.start > 0 ? span.start - 1 : span.start;
+    parts.push(text.slice(cursor, Math.max(cursor, start)));
+    cursor = span.next;
+  }
+  parts.push(text.slice(cursor));
+  return parts.join("");
+}
 
+function stripActiveMemoryPromptPrefixBlocks(text: string): string {
+  if (!text.includes(ACTIVE_MEMORY_OPEN_TAG)) {
+    return text;
+  }
+  const spans: LineSpan[] = [];
+  let header = findTextLine(text, ACTIVE_MEMORY_CONTEXT_HEADER);
+  while (header) {
+    const open = readTextLine(text, header.next);
+    const close =
+      open?.trimmed === ACTIVE_MEMORY_OPEN_TAG
+        ? findTextLine(text, ACTIVE_MEMORY_CLOSE_TAG, open.next)
+        : undefined;
+    const next = close ? skipEmptyLines(text, close.next) : header.next;
+    if (close) {
+      spans.push({ start: header.start, next });
+    }
+    header = findTextLine(text, ACTIVE_MEMORY_CONTEXT_HEADER, next);
+  }
+  return removeLineSpans(text, spans);
+}
+
+function stripTrailingContextBlockSuffix(text: string): string {
+  const header = findTextLine(text, CHANNEL_CONTEXT_HEADER);
+  if (!header) {
+    return text;
+  }
+  let end = header.start;
+  while (end > 0) {
+    const previous = end === 1 ? 0 : text.lastIndexOf("\n", end - 2) + 1;
+    if (text.slice(previous, end - 1).trim() !== "") {
+      break;
+    }
+    end = previous;
+  }
+  return text.slice(0, Math.max(0, end - 1));
+}
+
+/** Strips all injected inbound metadata blocks from user-visible text. */
+export function stripInboundMetadata(text: string): string {
   const withoutTimestamp = text.replace(LEADING_TIMESTAMP_PREFIX_RE, "");
   if (!hasInboundMetadataSentinel(withoutTimestamp)) {
     return withoutTimestamp;
   }
-
-  const lines = withoutTimestamp.split("\n");
-  const strippedLeadingPrefixLines = stripActiveMemoryPromptPrefixBlocks(lines);
-  const result: string[] = [];
-  let inMetaBlock = false;
-  let inFencedJson = false;
-
-  for (let i = 0; i < strippedLeadingPrefixLines.length; i++) {
-    const line = strippedLeadingPrefixLines.at(i);
-    if (line === undefined) {
+  // Active-memory removal precedes fence parsing, including blocks inside metadata JSON.
+  const source = stripActiveMemoryPromptPrefixBlocks(withoutTimestamp);
+  const spans: LineSpan[] = [];
+  const tokens = new RegExp(METADATA_TOKENS_RE);
+  let match: RegExpExecArray | null;
+  while ((match = tokens.exec(source))) {
+    const start = source.lastIndexOf("\n", match.index - 1) + 1;
+    const line = readTextLine(source, start)!;
+    tokens.lastIndex = line.next;
+    if (line.trimmed === CHANNEL_CONTEXT_HEADER) {
+      spans.push({ start, next: source.length + 1 });
       break;
     }
-    // Channel context is appended by OpenClaw as a terminal metadata suffix.
-    // When this structured header appears, drop it and everything that follows.
-    if (!inMetaBlock && shouldStripTrailingContextBlock(strippedLeadingPrefixLines, i)) {
-      break;
+    if (isInboundContextHeaderLine(line.trimmed)) {
+      tokens.lastIndex = metadataBlockEnd(source, line);
+      spans.push({ start, next: tokens.lastIndex });
+    } else if (isMessageToolDeliveryHintLine(line.trimmed)) {
+      spans.push({ start, next: line.next });
     }
-
-    if (!inMetaBlock && isMessageToolDeliveryHintLine(line)) {
-      continue;
-    }
-
-    // Detect start of a metadata block: header line ending with marker.
-    if (!inMetaBlock && isInboundContextHeaderLine(line)) {
-      const next = strippedLeadingPrefixLines[i + 1];
-      if (next?.trim() !== "```json") {
-        // Prose body (no JSON fence) — skip to blank line.
-        i = skipChatWindowContextBlock(strippedLeadingPrefixLines, i) - 1;
-        continue;
-      }
-      inMetaBlock = true;
-      inFencedJson = false;
-      continue;
-    }
-
-    if (inMetaBlock) {
-      if (!inFencedJson && line.trim() === "```json") {
-        inFencedJson = true;
-        continue;
-      }
-      if (inFencedJson) {
-        if (line.trim() === "```") {
-          inMetaBlock = false;
-          inFencedJson = false;
-        }
-        continue;
-      }
-      // Blank separator lines between consecutive blocks are dropped.
-      if (line.trim() === "") {
-        continue;
-      }
-      // Unexpected non-blank line outside a fence — treat as user content.
-      inMetaBlock = false;
-    }
-
-    result.push(line);
   }
-
-  return result
-    .join("\n")
+  return removeLineSpans(source, spans)
     .replace(/^\n+/, "")
     .replace(/\n+$/, "")
     .replace(LEADING_TIMESTAMP_PREFIX_RE, "");
@@ -276,76 +169,45 @@ export function stripLeadingInboundMetadata(text: string): string {
   if (!hasInboundMetadataSentinel(text)) {
     return text;
   }
-
-  const lines = stripActiveMemoryPromptPrefixBlocks(text.split("\n"));
-  let index = 0;
-
-  while (lines.at(index) === "") {
-    index++;
+  const source = stripActiveMemoryPromptPrefixBlocks(text);
+  let start = skipEmptyLines(source, 0, false);
+  let line = readTextLine(source, start);
+  const strippedDeliveryHint = Boolean(line && isMessageToolDeliveryHintLine(line.trimmed));
+  while (line && isMessageToolDeliveryHintLine(line.trimmed)) {
+    start = skipEmptyLines(source, line.next, false);
+    line = readTextLine(source, start);
   }
-  const firstLine = lines.at(index);
-  if (firstLine === undefined) {
+  if (!line) {
     return "";
   }
+  if (!isInboundContextHeaderLine(line.trimmed)) {
+    return stripTrailingContextBlockSuffix(strippedDeliveryHint ? source.slice(start) : source);
+  }
+  while (line && isInboundContextHeaderLine(line.trimmed)) {
+    start = skipEmptyLines(source, metadataBlockEnd(source, line));
+    line = readTextLine(source, start);
+  }
+  return stripTrailingContextBlockSuffix(source.slice(start));
+}
 
-  const strippedDeliveryHint = isMessageToolDeliveryHintLine(firstLine);
-  while (true) {
-    const line = lines.at(index);
-    if (line === undefined || !isMessageToolDeliveryHintLine(line)) {
-      break;
-    }
-    index++;
-    while (lines.at(index) === "") {
-      index++;
+function parseInboundMetaBlock(text: string, label: string): Record<string, unknown> | null {
+  const header = findTextLine(text, `${label} ${INBOUND_CONTEXT_MARKER}`);
+  const open = header && readTextLine(text, header.next);
+  if (open?.trimmed !== "```json") {
+    return null;
+  }
+  const close = findTextLine(text, "```", open.next);
+  return close ? (safeParseJsonRecord(text.slice(open.next, close.start).trim()) ?? null) : null;
+}
+
+function firstNonEmptyString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) {
+      // Only selected label strings escape the parser; do not recursively clone metadata.
+      return value.trim().replaceAll("`\u200b``", "```");
     }
   }
-  const firstContentLine = lines.at(index);
-  if (firstContentLine === undefined) {
-    return "";
-  }
-
-  if (!isInboundContextHeaderLine(firstContentLine)) {
-    const strippedNoLeading = stripTrailingContextBlockSuffix(
-      strippedDeliveryHint ? lines.slice(index) : lines,
-    );
-    return strippedNoLeading.join("\n");
-  }
-
-  while (index < lines.length) {
-    const line = lines.at(index);
-    if (line === undefined) {
-      break;
-    }
-    if (!isInboundContextHeaderLine(line)) {
-      break;
-    }
-
-    if (lines[index + 1]?.trim() !== "```json") {
-      // Prose body — skip to blank line.
-      index = skipChatWindowContextBlock(lines, index);
-      continue;
-    }
-
-    index++;
-    if (lines.at(index)?.trim() === "```json") {
-      index++;
-      while (index < lines.length && lines.at(index)?.trim() !== "```") {
-        index++;
-      }
-      if (lines.at(index)?.trim() === "```") {
-        index++;
-      }
-    } else {
-      return text;
-    }
-
-    while (lines.at(index)?.trim() === "") {
-      index++;
-    }
-  }
-
-  const strippedRemainder = stripTrailingContextBlockSuffix(lines.slice(index));
-  return strippedRemainder.join("\n");
+  return null;
 }
 
 /** Extracts the sender label from injected inbound metadata when present. */
@@ -353,28 +215,26 @@ export function extractInboundSenderLabel(text: string): string | null {
   if (!text.includes(INBOUND_CONTEXT_MARKER)) {
     return null;
   }
-
-  const lines = text.split("\n");
-  const senderInfo = parseInboundMetaBlock(lines, "Sender:");
-  const conversationInfo = parseInboundMetaBlock(lines, "Conversation info:");
-  const conversationSender = conversationInfo?.sender;
-  const conversationSenderFields =
-    conversationSender &&
+  const sender = parseInboundMetaBlock(text, "Sender:");
+  const label = firstNonEmptyString(
+    sender?.label,
+    sender?.name,
+    sender?.username,
+    sender?.e164,
+    sender?.id,
+  );
+  if (label) {
+    return label;
+  }
+  const conversationSender = parseInboundMetaBlock(text, "Conversation info:")?.sender;
+  return conversationSender &&
     typeof conversationSender === "object" &&
     !Array.isArray(conversationSender)
-      ? [
-          (conversationSender as Record<string, unknown>)["name"],
-          (conversationSender as Record<string, unknown>)["username"],
-          (conversationSender as Record<string, unknown>)["e164"],
-          (conversationSender as Record<string, unknown>)["id"],
-        ]
-      : [conversationSender];
-  return firstNonEmptyString(
-    senderInfo?.label,
-    senderInfo?.name,
-    senderInfo?.username,
-    senderInfo?.e164,
-    senderInfo?.id,
-    ...conversationSenderFields,
-  );
+    ? firstNonEmptyString(
+        (conversationSender as Record<string, unknown>).name,
+        (conversationSender as Record<string, unknown>).username,
+        (conversationSender as Record<string, unknown>).e164,
+        (conversationSender as Record<string, unknown>).id,
+      )
+    : firstNonEmptyString(conversationSender);
 }

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -45,15 +45,13 @@ function extractMessageSenderLabel(entry: Record<string, unknown>): string | nul
 
 // Text content blocks need role-aware stripping because user messages carry
 // inbound envelopes while assistant/tool content may carry internal metadata.
-function stripEnvelopeFromContentWithRole(
-  content: unknown[],
-  role: string,
-): { content: unknown[]; changed: boolean } {
+function stripEnvelopeFromContentWithRole(content: unknown[], role: string): unknown[] {
   const stripUserEnvelope = role === "user";
-  let changed = false;
-  const next = content.map((item) => {
+  let next: unknown[] | undefined;
+  for (let index = 0; index < content.length; index++) {
+    const item = content[index];
     if (!item || typeof item !== "object") {
-      return item;
+      continue;
     }
     const entry = item as Record<string, unknown>;
     const isRoleTextBlock =
@@ -61,21 +59,21 @@ function stripEnvelopeFromContentWithRole(
       (role === "user" && entry.type === "input_text") ||
       (role === "assistant" && (entry.type === "input_text" || entry.type === "output_text"));
     if (!isRoleTextBlock || typeof entry.text !== "string") {
-      return item;
+      continue;
     }
     const stripped = stripUserEnvelope
       ? stripUserEnvelopeForDisplay(entry.text)
       : stripInternalMetadataForDisplay(entry.text);
     if (stripped === entry.text) {
-      return item;
+      continue;
     }
-    changed = true;
-    return {
+    next ??= content.slice();
+    next[index] = {
       ...entry,
       text: stripped,
     };
-  });
-  return { content: next, changed };
+  }
+  return next ?? content;
 }
 
 /** Strips OpenClaw envelope metadata from one display message without mutating it. */
@@ -87,12 +85,11 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
   const role = typeof entry.role === "string" ? normalizeLowercaseStringOrEmpty(entry.role) : "";
   const stripUserEnvelope = role === "user";
 
-  let changed = false;
-  const next: Record<string, unknown> = { ...entry };
+  let next: Record<string, unknown> | undefined;
+  // Labels come from the raw message before runtime-context and envelope removal.
   const senderLabel = stripUserEnvelope ? extractMessageSenderLabel(entry) : null;
   if (senderLabel && entry.senderLabel !== senderLabel) {
-    next.senderLabel = senderLabel;
-    changed = true;
+    next = { ...entry, senderLabel };
   }
 
   if (typeof entry.content === "string") {
@@ -100,40 +97,38 @@ export function stripEnvelopeFromMessage(message: unknown): unknown {
       ? stripUserEnvelopeForDisplay(entry.content)
       : stripInternalMetadataForDisplay(entry.content);
     if (stripped !== entry.content) {
+      next ??= { ...entry };
       next.content = stripped;
-      changed = true;
     }
   } else if (Array.isArray(entry.content)) {
     const updated = stripEnvelopeFromContentWithRole(entry.content, role);
-    if (updated.changed) {
-      next.content = updated.content;
-      changed = true;
+    if (updated !== entry.content) {
+      next ??= { ...entry };
+      next.content = updated;
     }
   } else if (typeof entry.text === "string") {
     const stripped = stripUserEnvelope
       ? stripUserEnvelopeForDisplay(entry.text)
       : stripInternalMetadataForDisplay(entry.text);
     if (stripped !== entry.text) {
+      next ??= { ...entry };
       next.text = stripped;
-      changed = true;
     }
   }
 
-  return changed ? next : message;
+  return next ?? message;
 }
 
 /** Strips envelope metadata from a message array, preserving the original array when unchanged. */
 export function stripEnvelopeFromMessages(messages: unknown[]): unknown[] {
-  if (messages.length === 0) {
-    return messages;
-  }
-  let changed = false;
-  const next = messages.map((message) => {
+  let next: unknown[] | undefined;
+  for (let index = 0; index < messages.length; index++) {
+    const message = messages[index];
     const stripped = stripEnvelopeFromMessage(message);
     if (stripped !== message) {
-      changed = true;
+      next ??= messages.slice();
+      next[index] = stripped;
     }
-    return stripped;
-  });
-  return changed ? next : messages;
+  }
+  return next ?? messages;
 }

--- a/ui/src/pages/chat/chat-pane-history.test.ts
+++ b/ui/src/pages/chat/chat-pane-history.test.ts
@@ -357,7 +357,7 @@ describe("chat pane native history pagination", () => {
     expect(scrollToOffset).not.toHaveBeenCalled();
   });
 
-  it("auto-loads a visible sentinel when the initial tail is not scrollable", async () => {
+  it("bootstraps a visible history tail once the viewport can fit it", async () => {
     const request = vi.fn(async () => ({
       messages: [nativeHistoryMessage(1), nativeHistoryMessage(2)],
       hasMore: false,
@@ -369,8 +369,9 @@ describe("chat pane native history pagination", () => {
     state.chatHistoryPagination = { hasMore: true, nextOffset: 2, totalMessages: 4 };
     const thread = document.createElement("div");
     thread.className = "chat-thread";
-    Object.defineProperty(thread, "scrollHeight", { value: 100 });
-    Object.defineProperty(thread, "clientHeight", { value: 200 });
+    Object.defineProperty(thread, "scrollHeight", { value: 400 });
+    let clientHeight = 200;
+    Object.defineProperty(thread, "clientHeight", { get: () => clientHeight });
     const sentinel = document.createElement("div");
     sentinel.className = "chat-history-sentinel";
     thread.append(sentinel);
@@ -390,6 +391,9 @@ describe("chat pane native history pagination", () => {
     }
     vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
     try {
+      pane.syncHistoryObserver();
+      expect(request).not.toHaveBeenCalled();
+      clientHeight = 600;
       pane.syncHistoryObserver();
       await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
       expect(observe).toHaveBeenCalledWith(sentinel);
@@ -641,8 +645,9 @@ describe("chat pane native history pagination", () => {
     expect(pane.historyAutoLoadBlocked).toBe(false);
   });
 
-  it("reuses an unchanged armed history observer across pane updates", () => {
-    const client = { request: vi.fn() } as unknown as GatewayBrowserClient;
+  it("reuses an armed history observer and ignores its queued callback after reset", async () => {
+    const request = vi.fn();
+    const client = { request } as unknown as GatewayBrowserClient;
     const { pane, state } = createTestChatPane({ client, sessions: {} as SessionCapability });
     state.chatHistoryPagination = { hasMore: true, nextOffset: 2, totalMessages: 4 };
     pane.historyObserverArmed = true;
@@ -657,10 +662,11 @@ describe("chat pane native history pagination", () => {
     vi.spyOn(pane.transcript, "scrollElement", "get").mockReturnValue(thread);
     const observe = vi.fn();
     const disconnect = vi.fn();
-    const construct = vi.fn();
+    const construct =
+      vi.fn<(callback: IntersectionObserverCallback, observer: IntersectionObserver) => void>();
     class FakeIntersectionObserver {
-      constructor() {
-        construct();
+      constructor(callback: IntersectionObserverCallback) {
+        construct(callback, this as unknown as IntersectionObserver);
       }
       disconnect() {
         disconnect();
@@ -678,6 +684,12 @@ describe("chat pane native history pagination", () => {
       expect(observe).toHaveBeenCalledOnce();
       expect(observe).toHaveBeenCalledWith(sentinel);
       expect(disconnect).not.toHaveBeenCalled();
+
+      pane.resetOlderMessagesViewport();
+      const [notify, observer] = construct.mock.calls[0]!;
+      notify([{ isIntersecting: true } as IntersectionObserverEntry], observer);
+      await Promise.resolve();
+      expect(request).not.toHaveBeenCalled();
     } finally {
       vi.unstubAllGlobals();
     }

--- a/ui/src/pages/chat/chat-pane-history.ts
+++ b/ui/src/pages/chat/chat-pane-history.ts
@@ -130,18 +130,9 @@ export abstract class ChatPaneHistory extends ChatPaneReplyNavigation {
       return;
     }
     this.transcriptScrollTop ??= root.scrollTop;
-    const threadIsScrollable = root.scrollHeight > root.clientHeight;
-    const bootstrap = !this.historyObserverArmed && !threadIsScrollable;
+    const bootstrap = !this.historyObserverArmed;
     if (this.historyAutoLoadBlocked) {
       this.clearHistoryObserver();
-      return;
-    }
-    if (!this.historyObserverArmed && !bootstrap) {
-      this.clearHistoryObserver();
-      if (!threadIsScrollable) {
-        this.historyAutoLoadBlocked = true;
-        this.requestUpdate();
-      }
       return;
     }
     if (
@@ -154,11 +145,20 @@ export abstract class ChatPaneHistory extends ChatPaneReplyNavigation {
     }
     this.clearHistoryObserver();
     this.historyObserver = new IntersectionObserver(
-      (entries) => {
-        if (entries.some((entry) => entry.isIntersecting)) {
-          this.historyObserverArmed = false;
-          void this.loadOlderMessages();
+      (entries, observer) => {
+        // Disconnecting does not cancel queued notifications. Only the current
+        // observer may consume this pane's history intent.
+        if (this.historyObserver !== observer || !entries.some((entry) => entry.isIntersecting)) {
+          return;
         }
+        this.clearHistoryObserver();
+        // Bootstrap geometry matters only at the visible history boundary.
+        // Measuring here avoids forcing layout during every pane update.
+        if (bootstrap && root.scrollHeight > root.clientHeight) {
+          return;
+        }
+        this.historyObserverArmed = false;
+        void this.loadOlderMessages();
       },
       // Fire well before the wall: a page fetch takes long enough that a short
       // margin guarantees the user hits the top before the prepend lands. The

--- a/ui/src/pages/chat/chat-thread-build.ts
+++ b/ui/src/pages/chat/chat-thread-build.ts
@@ -38,7 +38,6 @@ import {
   shouldRenderQueuedSendInThread,
 } from "./chat-progress.ts";
 import { chatMessagesContainQueuedSend } from "./chat-send-support.ts";
-import { collapseSequentialDuplicateMessages } from "./chat-thread-duplicates.ts";
 import { groupMessages } from "./chat-thread-grouping.ts";
 import {
   appendCanvasBlockToAssistantMessage,
@@ -695,5 +694,5 @@ export function buildChatItems(props: BuildChatItemsProps): Array<ChatItem | Mes
       props.searchOpen ? props.searchQuery : undefined,
     ),
   );
-  return groupMessages(collapseSequentialDuplicateMessages(coalesceToolActivityMessages(items)));
+  return groupMessages(coalesceToolActivityMessages(items));
 }

--- a/ui/src/pages/chat/chat-thread-duplicates.ts
+++ b/ui/src/pages/chat/chat-thread-duplicates.ts
@@ -1,23 +1,24 @@
 import { escapeRegExp } from "../../../../src/shared/regexp.js";
-import type { ChatItem } from "../../lib/chat/chat-types.ts";
-import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
+import type { ChatItem, NormalizedMessage } from "../../lib/chat/chat-types.ts";
+import { normalizeMessage, normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import { senderIdentityKey } from "../../lib/chat/sender-label.ts";
 import { isPendingSendMessage, readChatThreadMessageIdentity } from "./chat-thread-items.ts";
-import { safeNormalizeMessage } from "./chat-turn-boundary.ts";
 
-function collapseDuplicateSourceKey(message: unknown): string | null {
-  if (isPendingSendMessage(message)) {
-    return null;
-  }
-  const normalized = safeNormalizeMessage(message);
-  if (!normalized) {
-    return null;
-  }
-  const role = normalizeRoleForGrouping(normalized.role).toLowerCase();
+type PreparedChatItem =
+  | Exclude<ChatItem, { kind: "message" }>
+  | {
+      kind: "message";
+      item: Extract<ChatItem, { kind: "message" }>;
+      normalized: NormalizedMessage;
+    };
+
+function collapseDuplicateSourceKey(
+  identity: ReturnType<typeof readChatThreadMessageIdentity>,
+  role: string,
+): string | null {
   if (role !== "assistant" && role !== "user") {
     return null;
   }
-  const identity = readChatThreadMessageIdentity(message);
   if (!identity?.isImported) {
     return identity?.id ? `${role}:${identity.id}` : null;
   }
@@ -27,26 +28,12 @@ function collapseDuplicateSourceKey(message: unknown): string | null {
   return identity.sequence === null ? null : `${role}:import-seq:${identity.sequence}`;
 }
 
-function prefersNativeChatSurface(message: unknown): boolean {
-  const normalized = safeNormalizeMessage(message);
-  if (!normalized) {
-    return false;
-  }
-  const role = normalizeRoleForGrouping(normalized.role).toLowerCase();
-  return (role === "user" || role === "assistant") && !(normalized.senderLabel ?? "").trim();
-}
-
 function stripSenderLabelPrefix(text: string, senderLabel: string): string {
-  const label = senderLabel.trim();
-  if (!label) {
-    return text;
-  }
-  return text.replace(new RegExp(`^${escapeRegExp(label)}(?::|：|-|—)?[ \\t]+`), "");
+  return text.replace(new RegExp(`^${escapeRegExp(senderLabel)}(?::|：|-|—)?[ \\t]+`), "");
 }
 
-function textOnlyMessageParts(message: unknown) {
-  const normalized = safeNormalizeMessage(message);
-  if (!normalized || normalized.content.length === 0) {
+function textOnlyMessageParts(normalized: NormalizedMessage, role: string) {
+  if (normalized.content.length === 0) {
     return null;
   }
   const textParts: string[] = [];
@@ -57,7 +44,7 @@ function textOnlyMessageParts(message: unknown) {
     textParts.push(block.text);
   }
   return {
-    role: normalizeRoleForGrouping(normalized.role).toLowerCase(),
+    role,
     senderLabel: (normalized.senderLabel ?? "").trim(),
     senderKey: senderIdentityKey(normalized.sender),
     senderSession: normalized.senderSession,
@@ -65,18 +52,19 @@ function textOnlyMessageParts(message: unknown) {
   };
 }
 
-function sourceDuplicateDisplayParts(message: unknown) {
-  const parts = textOnlyMessageParts(message);
-  return parts?.role === "assistant" && parts.text.trim() ? parts : null;
-}
+type TextOnlyMessageParts = ReturnType<typeof textOnlyMessageParts>;
 
-function isSameSourceRelayNativeDuplicate(previousMessage: unknown, nextMessage: unknown): boolean {
-  const previous = sourceDuplicateDisplayParts(previousMessage);
-  const next = sourceDuplicateDisplayParts(nextMessage);
-  if (!previous || !next || previous.role !== next.role) {
-    return false;
-  }
-  if (Boolean(previous.senderLabel) === Boolean(next.senderLabel)) {
+function isSameSourceRelayNativeDuplicate(
+  previous: TextOnlyMessageParts,
+  next: TextOnlyMessageParts,
+): boolean {
+  if (
+    previous?.role !== "assistant" ||
+    next?.role !== "assistant" ||
+    !previous.text.trim() ||
+    !next.text.trim() ||
+    Boolean(previous.senderLabel) === Boolean(next.senderLabel)
+  ) {
     return false;
   }
   const labeled = previous.senderLabel ? previous : next;
@@ -87,11 +75,7 @@ function isSameSourceRelayNativeDuplicate(previousMessage: unknown, nextMessage:
   );
 }
 
-function collapseDuplicateDisplaySignature(message: unknown): string | null {
-  if (isPendingSendMessage(message)) {
-    return null;
-  }
-  const parts = textOnlyMessageParts(message);
+function collapseDuplicateDisplaySignature(parts: TextOnlyMessageParts): string | null {
   if (!parts || !parts.role || parts.role === "tool") {
     return null;
   }
@@ -109,8 +93,9 @@ function collapseDuplicateDisplaySignature(message: unknown): string | null {
   ]);
 }
 
-export function collapseSequentialDuplicateMessages(items: ChatItem[]): ChatItem[] {
-  const collapsed: ChatItem[] = [];
+export function prepareMessagesForGrouping(items: ChatItem[]): PreparedChatItem[] {
+  const collapsed: PreparedChatItem[] = [];
+  let previousParts: TextOnlyMessageParts = null;
   let previousSignature: string | null = null;
   let previousSourceKey: string | null = null;
   let previousSourceIsUnprovenImport = false;
@@ -118,14 +103,22 @@ export function collapseSequentialDuplicateMessages(items: ChatItem[]): ChatItem
   for (const item of items) {
     if (item.kind !== "message") {
       collapsed.push(item);
+      previousParts = null;
       previousSignature = null;
       previousSourceKey = null;
       previousSourceIsUnprovenImport = false;
       continue;
     }
-    const signature = collapseDuplicateDisplaySignature(item.message);
-    const sourceKey = collapseDuplicateSourceKey(item.message);
+    // These facts belong to this grouping pass, after canvas/tool projections
+    // finish changing content. A later build must see fresh message metadata.
+    const normalized = normalizeMessage(item.message);
+    const prepared = { kind: "message" as const, item, normalized };
+    const role = normalizeRoleForGrouping(normalized.role).toLowerCase();
+    const pending = isPendingSendMessage(item.message);
+    const parts = pending ? null : textOnlyMessageParts(normalized, role);
+    const signature = collapseDuplicateDisplaySignature(parts);
     const identity = readChatThreadMessageIdentity(item.message);
+    const sourceKey = pending ? null : collapseDuplicateSourceKey(identity, role);
     const sourceIsUnprovenImport =
       sourceKey === null &&
       identity?.isImported === true &&
@@ -136,10 +129,11 @@ export function collapseSequentialDuplicateMessages(items: ChatItem[]): ChatItem
       sourceKey &&
       previousSourceKey === sourceKey &&
       previous?.kind === "message" &&
-      isSameSourceRelayNativeDuplicate(previous.message, item.message)
+      isSameSourceRelayNativeDuplicate(previousParts, parts)
     ) {
-      if (!prefersNativeChatSurface(previous.message) && prefersNativeChatSurface(item.message)) {
-        collapsed[collapsed.length - 1] = item;
+      if (!parts?.senderLabel) {
+        collapsed[collapsed.length - 1] = prepared;
+        previousParts = parts;
         previousSignature = signature;
       }
       continue;
@@ -152,10 +146,11 @@ export function collapseSequentialDuplicateMessages(items: ChatItem[]): ChatItem
       !previousSourceIsUnprovenImport &&
       !(sourceKey && previousSourceKey && sourceKey !== previousSourceKey)
     ) {
-      previous.duplicateCount = (previous.duplicateCount ?? 1) + 1;
+      previous.item.duplicateCount = (previous.item.duplicateCount ?? 1) + 1;
       continue;
     }
-    collapsed.push(item);
+    collapsed.push(prepared);
+    previousParts = parts;
     previousSignature = signature;
     previousSourceKey = sourceKey;
     previousSourceIsUnprovenImport = sourceIsUnprovenImport;

--- a/ui/src/pages/chat/chat-thread-grouping.ts
+++ b/ui/src/pages/chat/chat-thread-grouping.ts
@@ -6,9 +6,10 @@ import {
 } from "../../../../src/chat/tool-content.js";
 import type { ChatItem, MessageGroup } from "../../lib/chat/chat-types.ts";
 import { extractTextCached } from "../../lib/chat/message-extract.ts";
-import { normalizeMessage, normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
+import { normalizeRoleForGrouping } from "../../lib/chat/message-normalizer.ts";
 import { senderIdentityKey } from "../../lib/chat/sender-label.ts";
 import { isContextCompactionActivity } from "./chat-progress.ts";
+import { prepareMessagesForGrouping } from "./chat-thread-duplicates.ts";
 import { userTurnRunId } from "./chat-thread-items.ts";
 import {
   isKeyedAssistantStreamFallbackMessage,
@@ -64,17 +65,17 @@ export function groupMessages(items: ChatItem[]): Array<ChatItem | MessageGroup>
   let currentGroup: MessageGroup | null = null;
   let currentUserTurnIdentity: string | null = null;
 
-  for (const item of items) {
-    if (item.kind !== "message") {
+  for (const prepared of prepareMessagesForGrouping(items)) {
+    if (prepared.kind !== "message") {
       if (currentGroup) {
         result.push(currentGroup);
         currentGroup = null;
       }
-      result.push(item);
+      result.push(prepared);
       continue;
     }
 
-    const normalized = normalizeMessage(item.message);
+    const { item, normalized } = prepared;
     const role = normalizeRoleForGrouping(normalized.role);
     const senderLabel =
       role === "user" || role === "assistant" ? (normalized.senderLabel ?? null) : null;


### PR DESCRIPTION
## What Problem This Solves

Long Control UI histories spend unnecessary time preparing and rendering messages, making initial loads and older-page prepends less responsive. A queued history observer callback can also request a page after its viewport has been reset.

Related: #133734.

## Why This Change Was Made

Prepare display metadata and normalized grouping facts once at their owning boundaries. The metadata parser uses string spans instead of repeated whole-body line arrays; sender extraction reads only relevant blocks; Gateway sanitization copies only changed values. Grouping carries fresh normalized facts through duplicate detection and grouping within one build, preserving raw-message identities and in-place updates.

History bootstrap geometry is measured only when the history boundary intersects. Consumed observers disconnect before loading, and callbacks from replaced observers cannot consume current history intent. This removes repeated update-time layout reads and the obsolete disarmed branch without adding a cache or another scheduling path.

## User Impact

Initial history loads and older-page prepends become faster with the existing 800-message initial and 1,000-message older-page limits. Sender labels, metadata removal, grouping, virtualized rows and scroll anchoring retain their existing behavior. Stale callbacks after viewport reset no longer issue history requests.

## Evidence

Paired runs on the same prepared Linux Testbox, Chromium 144.0.7559.0, built Control UI, 1280×800 viewport. Five fresh contexts per browser cell, rotated initial-size order, normal and 4× throttled CPU; 100 total browser measurements. Browser timing starts at synthetic Gateway response serialization/release and ends at the first painted transcript frame, excluding Gateway execution and network latency.

| Scenario | Before median | After median | Reduction |
| --- | ---: | ---: | ---: |
| Initial 800, normal CPU | 238.9 ms | 209.7 ms | 12.2% |
| Initial 800, 4× CPU | 1,022.3 ms | 824.2 ms | 19.4% |
| Prepend 1,000 onto 800, normal CPU | 227.3 ms | 194.9 ms | 14.3% |
| Prepend 1,000 onto 800, 4× CPU | 1,005.6 ms | 843.7 ms | 16.1% |
| 24 scroll steps, 4× CPU | 1,234.8 ms | 1,059.0 ms | 14.2% |
| Gateway initial 800, conversation metadata | 37.301 ms | 27.794 ms | 25.5% |
| Gateway initial 800, sender metadata | 39.795 ms | 31.688 ms | 20.4% |
| Gateway older 1,000, long sender metadata | 22.244 ms | 14.394 ms | 35.3% |

Normal-CPU scrolling is essentially unchanged (773.7→770.7 ms). These observed browser medians do not establish statistical significance. The 4× scrolling profile's `syncHistoryObserver` subtree falls from 170.0 ms to no samples; 168.7 ms previously came from `scrollHeight`. Those are cumulative samples from one scrolling run, not per-frame latency. Initial rendering remains seven rows, prepend rendering remains 15, maximum anchor drift remains 1.875 px, and normal-CPU initial-800 resident JS heap is effectively unchanged at 20.39→20.41 MB.

Node inspector measurements use real isolated SQLite, seven 3,000-message fixtures, five warmups and 30 rotated measurements for initial 400/800/1,000 and older 1,000. Metadata and sender fixtures improve; plain and retained-reset controls show small mixed changes. No general server-wide speedup is claimed. All 28 before/after output pages (22,400 messages) compare equal after normalizing only the per-database transcript-position source identity; payload byte counts match.

- 672 permanent focused tests passed across UI, metadata, Gateway, TUI, outbound payloads, doctor migration and session-title owners.
- 15 real-browser pagination/recovery E2E tests passed, covering stale geometry, overlapping requests, retained history, malformed blocks, reconnect and reply-preview recovery.
- 27,341 metadata/Gateway differential comparisons and 1,454 grouping comparisons passed, including complete values, serialization, retained identities, frozen inputs, sender precedence and in-place mutations.
- The queued-observer regression failed on the baseline with one unwanted `chat.history` request, then passed on the candidate. Initial-tail coverage also checks a viewport growing from scrollable to fitting.
- Core types, all 16 core-test type shards, UI types, formatting, architecture/export guards and UI catalog validation passed. Full core lint found two mechanical cursor/mock-reference issues; after correction, 87 focused tests, the 27,341 parser comparisons, full core/script/style lint and all remaining classified guards passed. Earlier successful type stages were retained. Performance samples precede only that mechanical cleanup.
- Final independent Codex autoreview of all nine changed files is scoped-clean at the configured P0 threshold. The rebase preserves patch identity and all eight production/test files.

[Prepared Testbox run](https://github.com/openclaw/openclaw/actions/runs/33353234115): candidate measurements/tests and final check-completion commands exited 0. The baseline command intentionally exited 1 for the reproduced observer regression after both benchmarks passed. The task-owned lease was stopped and verified completed.

Landing validation: the first CI run stopped in five build-dependent lanes because its parent already exceeded the existing CSS cap (54,809 B versus 54,784 B). A clean Testbox build of the exact parent reproduced the identical CSS asset. The branch is rebased onto `0febe37e3ce7a8df5d66b96a70c25f7fc6703441`, including the existing #133787 fix; no budget was raised and the performance patch is byte-identical. This also resolves the fresh-main source-comparison gap in the ClawSweeper review. [Reproduction run](https://github.com/openclaw/openclaw/actions/runs/33358570045); the lease is stopped. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33358857525) is green on `3a953d5ed6718ccd38bb6b9306455a5b77f0c66d`, including the production build, real-Gateway E2E and all Node shards. The [latest CRLF review disposition](https://github.com/openclaw/openclaw/pull/133798#issuecomment-5474000959) records 72 additional exact-parent/candidate comparisons, all equal, and the named pre-existing newline-normalization follow-up.

Production LOC: +260/-410, net **−150**. Tests: +45/-18, net **+27**. One assertion-baseline allowance shrinks from five to four. No new dependency, configuration, schema, persistence or protocol surface. Root changelog remains release-owned; this body supplies release-note context.

### Before and after

Synthetic-only initial-800 captures were visually inspected and are byte-identical. The UI appearance and bounded virtualized rows stay the same; timing/profile evidence above demonstrates the change. One identical asset is embedded for both captures.

Before:

![Initial 800 before optimization](https://github.com/user-attachments/assets/3be2ff4b-9f8a-4526-a225-f1a570429e23)

After:

![Initial 800 after optimization](https://github.com/user-attachments/assets/3be2ff4b-9f8a-4526-a225-f1a570429e23)
