### PR TITLE
perf(update): reduce preflight work and unattended prompts

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -63,6 +63,10 @@ are labeled explicitly. The final total includes plugin updates and requested
 Gateway restart checks. `--json` keeps stdout machine-readable and does not
 print progress steps.
 
+`--yes` also skips the optional shell-completion setup prompt. Existing
+completion profiles and caches are still repaired when needed; installing
+completion in a new shell profile remains an interactive choice.
+
 For source checkouts, `--dry-run` previews the update flow without fetching Git
 refs or checking working-tree changes. The real update checks for uncommitted
 changes before modifying the checkout. Use `openclaw update status` to inspect
@@ -153,6 +157,10 @@ Interactive flow to pick an update channel and confirm whether to restart the
 Gateway afterward (defaults to restart). Selecting `dev` without a git
 checkout offers to create one.
 
+The channel picker reads the local install identity without checking Git
+freshness or dependencies. Those checks run when you apply the update; use
+`openclaw update status` to inspect availability first.
+
 | Flag                    | Default | Description                                                  |
 | ----------------------- | ------- | ------------------------------------------------------------ |
 | `--timeout <seconds>`   | `1800`  | Timeout for each update step.                                |
@@ -198,6 +206,8 @@ package-manager and git-checkout updates stop the running service before
 replacing the package tree or mutating the checkout/build output. The updater
 then refreshes service metadata, restarts the service, and verifies the
 restarted Gateway before reporting `Gateway: restarted and verified.`.
+Doctor repair and plugin validation run before restart; a verified restart
+does not run another Doctor from the old updater process.
 Package-manager updates additionally verify the restarted Gateway reports the
 expected package version; git-checkout updates verify gateway health and
 service readiness after the rebuild.

--- a/scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh
+++ b/scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh
@@ -40,7 +40,10 @@ pack_fixture_plugin "$npm_pack_dir" /tmp/demo-corrupt-plugin.tgz demo-corrupt-pl
 start_npm_fixture_registry "@openclaw/demo-corrupt-plugin" "0.0.1" /tmp/demo-corrupt-plugin.tgz "$npm_registry_dir"
 
 echo "Installing managed external plugin..."
-node "$entry" plugins install "npm:@openclaw/demo-corrupt-plugin@0.0.1" --force >/tmp/openclaw-corrupt-plugin-install.log 2>&1
+if ! openclaw_e2e_fixture_plugin_command node "$entry" -- plugins install "npm:@openclaw/demo-corrupt-plugin@0.0.1" --force >/tmp/openclaw-corrupt-plugin-install.log 2>&1; then
+  openclaw_e2e_print_log /tmp/openclaw-corrupt-plugin-install.log >&2
+  exit 1
+fi
 node "$entry" config set plugins.allow '["demo-corrupt-plugin"]' >/dev/null
 node "$entry" plugins inspect demo-corrupt-plugin --runtime --json >/tmp/openclaw-corrupt-plugin-before.json
 unset NPM_CONFIG_REGISTRY npm_config_registry

--- a/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
@@ -235,12 +235,30 @@ process.on("SIGINT", stop);
 process.on("SIGTERM", stop);
 start();
 SUPERVISOR
-  (
-    OPENCLAW_SYSTEMCTL_SHIM_EXEC_START="$exec_start" \
-      OPENCLAW_SYSTEMCTL_SHIM_DAEMON_LOG="$daemon_log" \
-      nohup node "$supervisor_script" </dev/null >>"${daemon_log}.bootstrap.log" 2>&1 &
-    printf '%s\n' "$!" >"$pid_file"
-  )
+  # The manager must outlive the calling terminal, just like systemd. nohup alone
+  # leaves Node in that terminal session and can strand its detached gateway.
+  OPENCLAW_SYSTEMCTL_SHIM_EXEC_START="$exec_start" \
+    OPENCLAW_SYSTEMCTL_SHIM_DAEMON_LOG="$daemon_log" \
+    node --input-type=module - "$supervisor_script" "$pid_file" "${daemon_log}.bootstrap.log" <<'START_SUPERVISOR'
+import fs from "node:fs";
+import { spawn } from "node:child_process";
+
+const [supervisor, pidFile, logFile] = process.argv.slice(2);
+const output = fs.openSync(logFile, "a");
+const child = spawn("node", [supervisor], {
+  detached: true,
+  stdio: ["ignore", output, output],
+});
+fs.closeSync(output);
+child.once("spawn", () => {
+  fs.writeFileSync(pidFile, `${child.pid}\n`);
+  child.unref();
+});
+child.once("error", (error) => {
+  console.error(error.message);
+  process.exitCode = 1;
+});
+START_SUPERVISOR
 }
 
 case "$command" in

--- a/scripts/e2e/multi-node-update-docker.sh
+++ b/scripts/e2e/multi-node-update-docker.sh
@@ -7,6 +7,7 @@
 #
 # 1. The update stays on node-A's package root and service runtime.
 # 2. The gateway restarts from the preserved entrypoint and becomes healthy.
+# 3. JSON and unattended TTY updates both complete without creating a shell profile.
 #
 # Usage:
 #   ./scripts/e2e/multi-node-update-docker.sh
@@ -166,8 +167,8 @@ echo ""
 echo "── Step 4: Inspect what node path was baked into the service ──"
 
 if [ -f "$GATEWAY_UNIT_PATH" ]; then
-  echo "Service unit contents:"
-  cat "$GATEWAY_UNIT_PATH" | tee "$ARTIFACTS/unit-before-update.txt"
+  echo "Service command before update:"
+  grep "^ExecStart=" "$GATEWAY_UNIT_PATH" | tee "$ARTIFACTS/command-before-update.txt"
   echo ""
   EXEC_START_BEFORE="$(grep "^ExecStart=" "$GATEWAY_UNIT_PATH" | head -1)"
   BAKED_NODE_BEFORE="$(echo "$EXEC_START_BEFORE" | sed "s/^ExecStart=//" | awk "{print \$1}")"
@@ -198,34 +199,64 @@ echo "which openclaw: $(command -v openclaw)"
 echo "process.execPath will be: $(node -e "console.log(process.execPath)")"
 
 echo ""
-echo "── Step 6: Run openclaw update (this is the bug) ──"
+for OUTPUT_MODE in json tty; do
+echo "── Step 6: Run openclaw update ($OUTPUT_MODE) ──"
 
 UPDATE_FAILED=0
 GATEWAY_START_FAILED=0
 GATEWAY_HEALTH_FAILED=0
 
-# Run the update WITH restart so that the update flow re-runs
-# `gateway install --force` and bakes the current process.execPath
-# (now node-B) into the service unit. This is where the split happens.
-echo "Running openclaw update --yes --json..."
+# Both updates must preserve node-A even though the invoking runtime is node-B.
 UPDATE_EXIT=0
-openclaw update --yes --json \
-  --tag /tmp/openclaw-current.tgz \
-  >"$ARTIFACTS/update.json" 2>"$ARTIFACTS/update.err" || UPDATE_EXIT=$?
+UPDATE_LOG="$ARTIFACTS/update.$OUTPUT_MODE.log"
+if [ "$OUTPUT_MODE" = json ]; then
+  openclaw update --yes --json \
+    --tag /tmp/openclaw-current.tgz \
+    >"$ARTIFACTS/update.json" 2>"$UPDATE_LOG" || UPDATE_EXIT=$?
+  node --input-type=module - "$ARTIFACTS/update.json" "$PACKAGE_ROOT_A" <<"NODE"
+import assert from "node:assert/strict";
+import fs from "node:fs";
+const result = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+assert.equal(result.status, "ok");
+assert.equal(result.root, process.argv[3]);
+NODE
+else
+  TTY_PROFILE_DIR="$(mktemp -d /tmp/openclaw-update-tty-profile.XXXXXX)"
+  # Python is part of the bare image. Keep a real terminal open without sending
+  # consent input; a stray prompt must time out and fail, never accept a default.
+  SHELL=/bin/zsh ZDOTDIR="$TTY_PROFILE_DIR" python3 - >"$UPDATE_LOG" 2>&1 <<"PYTHON" || UPDATE_EXIT=$?
+import os
+import pty
+
+wait_status = pty.spawn([
+    "timeout", "--kill-after=10s", "120s", "bash", "-c",
+    "test -t 0 && test -t 1 && exec \"$@\"", "openclaw-tty",
+    "openclaw", "update", "--yes", "--tag", "/tmp/openclaw-current.tgz",
+], stdin_read=lambda _: b"")
+exit_code = os.waitstatus_to_exitcode(wait_status)
+raise SystemExit(exit_code if exit_code >= 0 else 128 - exit_code)
+PYTHON
+  if [ -e "$TTY_PROFILE_DIR/.zshrc" ]; then
+    echo "FAIL: unattended TTY update created an optional shell profile"
+    exit 1
+  fi
+  rmdir "$TTY_PROFILE_DIR"
+  if [ "$UPDATE_EXIT" -eq 0 ]; then
+    echo "OK: TTY update --yes completed without input or shell profile changes"
+  fi
+fi
 
 echo ""
 echo "Update exit code: $UPDATE_EXIT"
-echo "Update stderr (if any):"
-cat "$ARTIFACTS/update.err" 2>/dev/null | tail -10 || true
 if [ "$UPDATE_EXIT" -ne 0 ]; then
   UPDATE_FAILED=1
+  openclaw_e2e_print_log "$UPDATE_LOG"
 fi
 
 # Keep inspecting after a non-zero update so the log shows whether the unit was
 # rewritten, but fail immediately if update never reached the service refresh.
-if [ "$UPDATE_EXIT" -ne 0 ] && ! grep -q "gateway" "$ARTIFACTS/update.err" 2>/dev/null; then
+if [ "$UPDATE_EXIT" -ne 0 ] && ! grep -q "gateway" "$UPDATE_LOG" 2>/dev/null; then
   echo "FAIL: openclaw update failed before reaching the package install step"
-  cat "$ARTIFACTS/update.err" 2>/dev/null || true
   exit 1
 fi
 
@@ -233,8 +264,8 @@ echo ""
 echo "── Step 7: Inspect the service unit AFTER update ──"
 
 if [ -f "$GATEWAY_UNIT_PATH" ]; then
-  echo "Service unit contents after update:"
-  cat "$GATEWAY_UNIT_PATH" | tee "$ARTIFACTS/unit-after-update.txt"
+  echo "Service command after $OUTPUT_MODE update:"
+  grep "^ExecStart=" "$GATEWAY_UNIT_PATH" | tee "$ARTIFACTS/command-after-$OUTPUT_MODE.txt"
   echo ""
   EXEC_START_AFTER="$(grep "^ExecStart=" "$GATEWAY_UNIT_PATH" | head -1)"
   BAKED_NODE_AFTER="$(echo "$EXEC_START_AFTER" | sed "s/^ExecStart=//" | awk "{print \$1}")"
@@ -284,22 +315,25 @@ else
 fi
 
 # Check 4: Were there any warnings about split install in the update output?
-if [ -f "$ARTIFACTS/update.err" ]; then
-  if grep -qi "Shell OpenClaw root differs" "$ARTIFACTS/update.err" 2>/dev/null; then
+if [ -f "$UPDATE_LOG" ]; then
+  if grep -qi "Shell OpenClaw root differs" "$UPDATE_LOG" 2>/dev/null; then
     echo "OK: Update warned about split root"
   fi
-  if grep -qi "Managed gateway service Node" "$ARTIFACTS/update.err" 2>/dev/null; then
+  if grep -qi "Managed gateway service Node" "$UPDATE_LOG" 2>/dev/null; then
     echo "OK: Update showed the managed service Node path"
   fi
 fi
 
-# Check 5: Try to start the gateway and see if it works.
+# Check 5: The update itself must leave the service running and healthy.
 echo ""
-echo "── Step 9: Try starting the gateway with the post-update unit ──"
+echo "── Step 9: Verify the gateway after $OUTPUT_MODE update ──"
 
 GATEWAY_START_FAILED=0
 if [ -f "$GATEWAY_UNIT_PATH" ]; then
-  systemctl --user restart openclaw-gateway.service 2>&1 || true
+  if ! systemctl --user is-active --quiet openclaw-gateway.service; then
+    echo "FAIL: update did not leave the managed gateway running"
+    exit 1
+  fi
   if PORT=18789 node <<NODE
 const url = "http://127.0.0.1:" + process.env.PORT + "/healthz";
 const deadline = Date.now() + 30000;
@@ -332,9 +366,8 @@ NODE
     echo "BUG: Gateway healthz probe failed with the post-update unit"
     GATEWAY_START_FAILED=1
     GATEWAY_HEALTH_FAILED=1
-    cat "$GATEWAY_DAEMON_LOG" 2>/dev/null | tail -20 || true
+    openclaw_e2e_print_log "$GATEWAY_DAEMON_LOG"
   fi
-  systemctl --user stop openclaw-gateway.service 2>&1 || true
 fi
 
 echo ""
@@ -364,7 +397,11 @@ fi
 if [ "$GATEWAY_HEALTH_FAILED" -ne 0 ]; then
   EXIT_CODE=1
 fi
-exit $EXIT_CODE
+if [ "$EXIT_CODE" -ne 0 ]; then
+  exit "$EXIT_CODE"
+fi
+done
+systemctl --user stop openclaw-gateway.service
 ' || CONTAINER_EXIT=$?
 
 echo ""

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -183,9 +183,12 @@ vi.mock("../config/config.js", () => ({
   resolveGatewayPort: vi.fn(() => 18789),
 }));
 
-vi.mock("../infra/update-check.js", () => ({
+vi.mock("../infra/update-check.js", async (importOriginal) => ({
+  formatGitInstallLabel: (await importOriginal<typeof import("../infra/update-check.js")>())
+    .formatGitInstallLabel,
   checkUpdateStatus: vi.fn(),
   resolveUpdateInstallKind: vi.fn(),
+  resolveUpdateInstallIdentity: vi.fn(),
   compareSemverStrings: vi.fn((left: string | null, right: string | null) => {
     const parse = (value: string | null) => {
       if (!value) {
@@ -505,6 +508,7 @@ const {
   resolveExtendedStablePackage,
   resolveNpmChannelTag,
   resolveUpdateInstallKind,
+  resolveUpdateInstallIdentity,
 } = await import("../infra/update-check.js");
 const { fetchNpmPackageTargetStatus } = await import("../infra/update-check-package-target.js");
 const { CONTROL_PLANE_UPDATE_SENTINEL_META_ENV } =
@@ -612,6 +616,7 @@ describe("update-cli", () => {
   const mockPackageInstallStatus = (root: string) => {
     vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue(root);
     vi.mocked(resolveUpdateInstallKind).mockResolvedValue("package");
+    vi.mocked(resolveUpdateInstallIdentity).mockResolvedValue({ installKind: "package" });
     vi.mocked(checkUpdateStatus).mockResolvedValue({
       root,
       installKind: "package",
@@ -1581,6 +1586,10 @@ describe("update-cli", () => {
     primeNpmChannelTag("latest", "9999.0.0");
     nodeVersionSatisfiesEngine.mockReturnValue(true);
     vi.mocked(resolveUpdateInstallKind).mockResolvedValue("git");
+    vi.mocked(resolveUpdateInstallIdentity).mockResolvedValue({
+      installKind: "git",
+      git: { tag: "v1.2.3", branch: "main" },
+    });
     vi.mocked(checkUpdateStatus).mockResolvedValue({
       root: "/test/path",
       installKind: "git",
@@ -2044,6 +2053,20 @@ describe("update-cli", () => {
     expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
   });
 
+  it.each([true, false])("honors --yes=%s for optional shell completion setup", async (yes) => {
+    setTty(true);
+    confirm.mockResolvedValue(true);
+
+    await updateCommand({ yes, restart: false });
+
+    expect(confirm).toHaveBeenCalledTimes(yes ? 0 : 1);
+    if (yes) {
+      expect(installCompletion).not.toHaveBeenCalled();
+    } else {
+      expect(installCompletion).toHaveBeenCalledWith("zsh", false, "openclaw");
+    }
+  });
+
   it("respawns into the updated package root before running post-update tasks", async () => {
     const { entrypoints } = setupUpdatedRootRefresh();
 
@@ -2303,7 +2326,7 @@ describe("update-cli", () => {
     }
   });
 
-  it("keeps post-restart doctor in the stopped service profile", async () => {
+  it("finishes a human restart without rerunning stale doctor or leaking the service profile", async () => {
     mockOwnedGitService();
     mockGitUpdateAfterMutation();
     pathExists.mockImplementation(
@@ -2326,10 +2349,6 @@ describe("update-cli", () => {
     });
     prepareRestartScript.mockResolvedValue(null);
     vi.mocked(runDaemonRestart).mockResolvedValue(true);
-    let doctorProfile: string | undefined;
-    vi.mocked(doctorCommand).mockImplementationOnce(async () => {
-      doctorProfile = process.env.OPENCLAW_PROFILE;
-    });
 
     await withEnvAsync(
       {
@@ -2343,7 +2362,7 @@ describe("update-cli", () => {
       },
     );
 
-    expect(doctorProfile).toBe("work");
+    expect(doctorCommand).not.toHaveBeenCalled();
     expect(runDaemonRestart).toHaveBeenCalledOnce();
     const completionCall = vi
       .mocked(spawnSync)
@@ -7873,7 +7892,7 @@ describe("update-cli", () => {
     { previous: "1", mutatesCore: true },
     { previous: "1", mutatesCore: false },
   ])(
-    "restores update flag $previous after the doctor sub-step (core mutation: $mutatesCore)",
+    "restores update flag $previous after restart (core mutation: $mutatesCore)",
     async ({ previous, mutatesCore }) => {
       await withEnvAsync({ OPENCLAW_UPDATE_IN_PROGRESS: previous }, async () => {
         mockRunningManagedGateway([
@@ -7886,27 +7905,18 @@ describe("update-cli", () => {
         }
         prepareRestartScript.mockResolvedValue(null);
         vi.mocked(runDaemonRestart).mockResolvedValue(true);
-        vi.mocked(doctorCommand).mockResolvedValue(undefined);
         vi.mocked(defaultRuntime.log).mockClear();
 
         await updateCommand({});
 
-        const doctorCall = vi.mocked(doctorCommand).mock.calls[0];
-        expect(doctorCall?.[0]).toBe(defaultRuntime);
-        expect(doctorCall?.[1]?.nonInteractive).toBe(true);
+        expect(doctorCommand).not.toHaveBeenCalled();
         expect(process.env.OPENCLAW_UPDATE_IN_PROGRESS).toBe(previous);
         const snapshotOrders = createPreUpdateConfigSnapshotMock.mock.invocationCallOrder;
-        expect(createPreUpdateConfigSnapshotMock).toHaveBeenCalledTimes(2);
+        expect(createPreUpdateConfigSnapshotMock).toHaveBeenCalledTimes(1);
         expect(requireValue(snapshotOrders[0], "restart snapshot call order")).toBeLessThan(
           requireValue(
             vi.mocked(runDaemonRestart).mock.invocationCallOrder[0],
             "daemon restart call order",
-          ),
-        );
-        expect(requireValue(snapshotOrders[1], "doctor snapshot call order")).toBeLessThan(
-          requireValue(
-            vi.mocked(doctorCommand).mock.invocationCallOrder[0],
-            "doctor command call order",
           ),
         );
 
@@ -7917,7 +7927,10 @@ describe("update-cli", () => {
         expect(
           vi.mocked(defaultRuntime.log).mock.invocationCallOrder[successIndex],
         ).toBeGreaterThan(
-          requireValue(vi.mocked(doctorCommand).mock.invocationCallOrder[0], "doctor call order"),
+          requireValue(
+            vi.mocked(runDaemonRestart).mock.invocationCallOrder[0],
+            "restart call order",
+          ),
         );
       });
     },
@@ -8389,6 +8402,18 @@ describe("update-cli", () => {
           (call) => Array.isArray(call[0]) && call[0][0] === "npm" && call[0][1] === "i",
         ),
     ).toBe(shouldRunPackageUpdate);
+  });
+
+  it("opens and cancels the wizard without inspecting update freshness", async () => {
+    setTty(true);
+    select.mockResolvedValue("cancel");
+    vi.mocked(checkUpdateStatus).mockRejectedValue(new Error("Freshness inspection unavailable"));
+
+    await updateWizardCommand();
+
+    expect(select).toHaveBeenCalledWith(expect.objectContaining({ message: "Update channel" }));
+    expect(defaultRuntime.log).toHaveBeenCalledWith(expect.stringContaining("Update cancelled."));
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
   });
 
   it.each(["before", "after"])(

--- a/src/cli/update-cli/status.ts
+++ b/src/cli/update-cli/status.ts
@@ -12,26 +12,10 @@ import {
   normalizeUpdateChannel,
   resolveUpdateChannelDisplay,
 } from "../../infra/update-channels.js";
-import { checkUpdateStatus } from "../../infra/update-check.js";
+import { checkUpdateStatus, formatGitInstallLabel } from "../../infra/update-check.js";
 import { defaultRuntime } from "../../runtime.js";
 import { VERSION } from "../../version.js";
 import { parseTimeoutMsOrExit, resolveUpdateRoot, type UpdateStatusOptions } from "./shared.js";
-
-function formatGitStatusLine(params: {
-  branch: string | null;
-  tag: string | null;
-  sha: string | null;
-}): string {
-  const shortSha = params.sha ? params.sha.slice(0, 8) : null;
-  const branch = params.branch && params.branch !== "HEAD" ? params.branch : null;
-  const tag = params.tag;
-  const parts = [
-    branch ?? (tag ? "detached" : "git"),
-    tag ? `tag ${tag}` : null,
-    shortSha ? `@ ${shortSha}` : null,
-  ].filter(Boolean);
-  return parts.join(" · ");
-}
 
 /** Print update status in JSON or table form for scripts and humans. */
 export async function updateStatusCommand(opts: UpdateStatusOptions): Promise<void> {
@@ -40,8 +24,7 @@ export async function updateStatusCommand(opts: UpdateStatusOptions): Promise<vo
     return;
   }
 
-  const root = await resolveUpdateRoot();
-  const config = await readSourceConfigBestEffort();
+  const [root, config] = await Promise.all([resolveUpdateRoot(), readSourceConfigBestEffort()]);
   const configChannel = normalizeUpdateChannel(config.update?.channel);
 
   const update = await checkUpdateStatus({
@@ -67,17 +50,7 @@ export async function updateStatusCommand(opts: UpdateStatusOptions): Promise<vo
   });
   const channelLabel = channelInfo.label;
 
-  const gitLabel =
-    update.installKind === "git"
-      ? formatGitStatusLine({
-          branch: update.git?.branch ?? null,
-          tag: update.git?.tag ?? null,
-          sha: update.git?.sha ?? null,
-        })
-      : null;
-
   const updateAvailability = resolveUpdateAvailability(update);
-  const updateLine = formatUpdateOneLiner(update).replace(/^Update:\s*/i, "");
 
   if (opts.json) {
     defaultRuntime.writeJson({
@@ -93,6 +66,8 @@ export async function updateStatusCommand(opts: UpdateStatusOptions): Promise<vo
     return;
   }
 
+  const gitLabel = formatGitInstallLabel(update);
+  const updateLine = formatUpdateOneLiner(update).replace(/^Update:\s*/i, "");
   const tableWidth = getTerminalTableWidth();
   const installLabel =
     update.installKind === "git"

--- a/src/cli/update-cli/update-command-service.ts
+++ b/src/cli/update-cli/update-command-service.ts
@@ -10,8 +10,6 @@ import {
   checkShellCompletionStatus,
   ensureCompletionCacheExists,
 } from "../../commands/doctor-completion.js";
-import { doctorCommand } from "../../commands/doctor.js";
-import { UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV } from "../../commands/doctor/shared/update-phase.js";
 import { resolveGatewayPort } from "../../config/config.js";
 import { createConfigIO } from "../../config/io.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -727,7 +725,7 @@ export async function tryInstallShellCompletion(opts: {
       return;
     }
 
-    if (!status.profileInstalled) {
+    if (!status.profileInstalled && !opts.skipPrompt) {
       defaultRuntime.log("");
       defaultRuntime.log(theme.heading("Shell completion"));
 
@@ -737,20 +735,18 @@ export async function tryInstallShellCompletion(opts: {
       });
 
       if (isCancel(shouldInstall) || !shouldInstall) {
-        if (!opts.skipPrompt) {
-          defaultRuntime.log(
-            theme.muted(
-              `Skipped. Run \`${replaceCliName(formatCliCommand("openclaw completion --install"), CLI_NAME)}\` later to enable.`,
-            ),
-          );
-        }
+        defaultRuntime.log(
+          theme.muted(
+            `Skipped. Run \`${replaceCliName(formatCliCommand("openclaw completion --install"), CLI_NAME)}\` later to enable.`,
+          ),
+        );
         return;
       }
 
       if (!(await ensureCompletionCacheExists(CLI_NAME, generationOptions))) {
         throw new Error("completion cache generation failed");
       }
-      await installCompletion(status.shell, opts.skipPrompt, CLI_NAME);
+      await installCompletion(status.shell, false, CLI_NAME);
     }
   } catch (err) {
     const message = formatErrorMessage(err);
@@ -1072,21 +1068,6 @@ export async function maybeRestartService(params: {
       if (!activation.opts.json && restarted && !preserveDefinition) {
         defaultRuntime.log(theme.success("Daemon restarted successfully."));
         defaultRuntime.log("");
-        await createUpdateConfigSnapshot();
-        process.env.OPENCLAW_UPDATE_IN_PROGRESS = "1";
-        process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV] = "1";
-        try {
-          const interactiveDoctor =
-            process.stdin.isTTY && !activation.opts.json && activation.opts.yes !== true;
-          await doctorCommand(defaultRuntime, {
-            nonInteractive: !interactiveDoctor,
-          });
-        } catch (err) {
-          defaultRuntime.log(theme.warn(`Doctor failed: ${String(err)}`));
-        } finally {
-          delete process.env.OPENCLAW_UPDATE_IN_PROGRESS;
-          delete process.env[UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV];
-        }
       }
     } catch (err) {
       defaultRuntime.error(

--- a/src/cli/update-cli/wizard.ts
+++ b/src/cli/update-cli/wizard.ts
@@ -7,11 +7,10 @@ import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
-  formatUpdateChannelLabel,
   normalizeUpdateChannel,
-  resolveEffectiveUpdateChannel,
+  resolveUpdateChannelDisplay,
 } from "../../infra/update-channels.js";
-import { checkUpdateStatus } from "../../infra/update-check.js";
+import { resolveUpdateInstallIdentity } from "../../infra/update-check.js";
 import { defaultRuntime } from "../../runtime.js";
 import { pathExists } from "../../utils.js";
 import { VERSION } from "../../version.js";
@@ -41,11 +40,9 @@ export async function updateWizardCommand(opts: UpdateWizardOptions = {}): Promi
 
   const root = await resolveUpdateRoot();
   const [updateStatus, configSnapshot] = await Promise.all([
-    checkUpdateStatus({
+    resolveUpdateInstallIdentity({
       root,
       timeoutMs: timeoutMs ?? 3500,
-      fetchGit: false,
-      includeRegistry: false,
     }),
     readConfigFileSnapshot({ observe: false }),
   ]);
@@ -53,17 +50,10 @@ export async function updateWizardCommand(opts: UpdateWizardOptions = {}): Promi
   const configChannel = configSnapshot.valid
     ? normalizeUpdateChannel(configSnapshot.config.update?.channel)
     : null;
-  const channelInfo = resolveEffectiveUpdateChannel({
+  const channelInfo = resolveUpdateChannelDisplay({
     configChannel,
     currentVersion: VERSION,
     installKind: updateStatus.installKind,
-    git: updateStatus.git
-      ? { tag: updateStatus.git.tag, branch: updateStatus.git.branch }
-      : undefined,
-  });
-  const channelLabel = formatUpdateChannelLabel({
-    channel: channelInfo.channel,
-    source: channelInfo.source,
     gitTag: updateStatus.git?.tag ?? null,
     gitBranch: updateStatus.git?.branch ?? null,
   });
@@ -74,7 +64,7 @@ export async function updateWizardCommand(opts: UpdateWizardOptions = {}): Promi
       {
         value: "keep",
         label: `Keep current (${channelInfo.channel})`,
-        hint: channelLabel,
+        hint: channelInfo.label,
       },
       {
         value: "stable",

--- a/src/commands/status.update-channel.test.ts
+++ b/src/commands/status.update-channel.test.ts
@@ -21,15 +21,8 @@ describe("resolveStatusRegistryUpdateChannel", () => {
       resolveStatusRegistryUpdateChannel({
         installKind: "git",
         git: {
-          root: "/tmp/openclaw",
-          sha: null,
           tag: null,
           branch: "main",
-          upstream: "origin/main",
-          dirty: false,
-          ahead: 0,
-          behind: 0,
-          fetchOk: true,
         },
       }),
     ).toBe("dev");

--- a/src/commands/status.update.ts
+++ b/src/commands/status.update.ts
@@ -12,15 +12,16 @@ import {
   checkUpdateStatus,
   compareSemverStrings,
   type UpdateCheckResult,
+  type UpdateInstallIdentity,
 } from "../infra/update-check.js";
 import { VERSION } from "../version.js";
 
 /** Chooses a registry tag only after the status check has identified the install. */
-export function resolveStatusRegistryUpdateChannel(params: {
-  configChannel?: UpdateChannel | null;
-  installKind: UpdateCheckResult["installKind"];
-  git?: UpdateCheckResult["git"];
-}): UpdateChannel {
+export function resolveStatusRegistryUpdateChannel(
+  params: UpdateInstallIdentity & {
+    configChannel?: UpdateChannel | null;
+  },
+): UpdateChannel {
   return resolveEffectiveUpdateChannel({
     configChannel: params.configChannel,
     currentVersion: VERSION,

--- a/src/infra/update-channels.test.ts
+++ b/src/infra/update-channels.test.ts
@@ -2,7 +2,6 @@
 import { describe, expect, it } from "vitest";
 import {
   channelToNpmTag,
-  formatUpdateChannelLabel,
   isBetaTag,
   isStableTag,
   normalizeUpdateChannel,
@@ -140,57 +139,45 @@ describe("resolveEffectiveUpdateChannel", () => {
   });
 });
 
-describe("formatUpdateChannelLabel", () => {
+describe("resolveUpdateChannelDisplay labels", () => {
   it.each([
     {
       name: "formats config labels",
-      params: { channel: "beta", source: "config" as const },
+      params: { configChannel: "beta", installKind: "package" },
       expected: "beta (config)",
     },
     {
       name: "formats git tag labels with tag",
       params: {
-        channel: "stable",
-        source: "git-tag" as const,
+        installKind: "git",
         gitTag: "v2026.2.24",
       },
       expected: "stable (v2026.2.24)",
     },
     {
-      name: "formats git tag labels without tag",
-      params: { channel: "stable", source: "git-tag" as const },
-      expected: "stable (tag)",
-    },
-    {
       name: "formats git branch labels with branch",
       params: {
-        channel: "dev",
-        source: "git-branch" as const,
+        installKind: "git",
         gitBranch: "feature/test",
       },
       expected: "dev (feature/test)",
     },
     {
-      name: "formats git branch labels without branch",
-      params: { channel: "dev", source: "git-branch" as const },
-      expected: "dev (branch)",
-    },
-    {
       name: "formats installed-version labels",
-      params: { channel: "beta", source: "installed-version" as const },
+      params: { currentVersion: "2026.5.2-beta.1", installKind: "package" },
       expected: "beta (installed version)",
     },
     {
       name: "formats default labels",
-      params: { channel: "stable", source: "default" as const },
+      params: { installKind: "package" },
       expected: "stable (default)",
     },
   ] satisfies Array<{
     name: string;
-    params: Parameters<typeof formatUpdateChannelLabel>[0];
+    params: Parameters<typeof resolveUpdateChannelDisplay>[0];
     expected: string;
   }>)("$name", ({ params, expected }) => {
-    expect(formatUpdateChannelLabel(params)).toBe(expected);
+    expect(resolveUpdateChannelDisplay(params).label).toBe(expected);
   });
 });
 

--- a/src/infra/update-channels.ts
+++ b/src/infra/update-channels.ts
@@ -167,7 +167,7 @@ export function resolveEffectiveUpdateChannel(params: {
 }
 
 /** Formats an operator-facing channel label that includes the deciding source. */
-export function formatUpdateChannelLabel(params: {
+function formatUpdateChannelLabel(params: {
   channel: UpdateChannel;
   source: UpdateChannelSource;
   gitTag?: string | null;

--- a/src/infra/update-check-status.test.ts
+++ b/src/infra/update-check-status.test.ts
@@ -3,10 +3,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import * as processExec from "../process/exec.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
-import { checkUpdateStatus } from "./update-check.js";
+import { checkUpdateStatus, resolveUpdateInstallIdentity } from "./update-check.js";
 
 const runCommandWithTimeout = processExec.runCommandWithTimeout;
 const PNPM_PACKAGE_MANAGER = "pnpm@12.0.0";
@@ -38,6 +39,123 @@ afterEach(() => {
 });
 
 describe("checkUpdateStatus", () => {
+  it("starts full-status worktree inspection before Git identity resolves", async () => {
+    await withTestDir({ prefix: "openclaw-update-check-local-overlap-" }, async (root) => {
+      await initGitRepo(root);
+      await commitGit(root, "initial");
+      const identityStarted = createDeferred();
+      const releaseIdentity = createDeferred();
+      const commands = vi
+        .spyOn(processExec, "runCommandWithTimeout")
+        .mockImplementation(async (argv, options) => {
+          if (argv.includes("--abbrev-ref") || argv.includes("describe")) {
+            identityStarted.resolve();
+            await releaseIdentity.promise;
+          }
+          return runCommandWithTimeout(argv, options);
+        });
+      const pending = checkUpdateStatus({ root, includeRegistry: false, timeoutMs: 5000 });
+      try {
+        await identityStarted.promise;
+        expect(commands.mock.calls.some(([argv]) => argv.includes("status"))).toBe(true);
+      } finally {
+        releaseIdentity.resolve();
+        await pending;
+      }
+    });
+  });
+
+  it("reads a tagged install identity without inspecting freshness or dependencies", async () => {
+    await withTestDir({ prefix: "openclaw-update-check-identity-" }, async (root) => {
+      await initGitRepo(root);
+      await commitGit(root, "initial");
+      await runGit(root, "tag", "v2000.1.1-beta.1");
+      await fs.writeFile(path.join(root, "untracked.txt"), "dirty worktree");
+      const runCommand = vi.spyOn(processExec, "runCommandWithTimeout");
+
+      await expect(resolveUpdateInstallIdentity({ root, timeoutMs: 4321 })).resolves.toEqual({
+        installKind: "git",
+        git: { branch: "main", tag: "v2000.1.1-beta.1" },
+      });
+
+      expect(runCommand).toHaveBeenCalledTimes(3);
+      expect(
+        runCommand.mock.calls
+          .slice(1)
+          .every(([, options]) => typeof options !== "number" && options.timeoutMs === 4321),
+      ).toBe(true);
+    });
+  });
+
+  it("keeps an unreadable Git identity unknown in full status", async () => {
+    await withTestDir({ prefix: "openclaw-update-check-unborn-" }, async (root) => {
+      await initGitRepo(root);
+      const identity = await resolveUpdateInstallIdentity({ root });
+      expect(identity).toEqual({
+        installKind: "git",
+        git: { branch: null, tag: null, error: expect.any(String) },
+      });
+      const status = await checkUpdateStatus({ root, includeRegistry: false });
+      expect(status.git).toMatchObject({
+        ...identity.git,
+        sha: null,
+        commitAtMs: null,
+        dirty: null,
+        upstream: null,
+        ahead: null,
+        behind: null,
+        fetchOk: null,
+      });
+    });
+  });
+
+  it("checks the registry while Git freshness is still pending", async () => {
+    await withTestDir({ prefix: "openclaw-update-check-overlap-" }, async (base) => {
+      const remoteRoot = path.join(base, "remote");
+      const localRoot = path.join(base, "local");
+      await initGitRepo(remoteRoot);
+      await commitGit(remoteRoot, "initial");
+      await runGit(base, "clone", "--quiet", remoteRoot, localRoot);
+      await runGit(localRoot, "tag", "v2000.1.1");
+      const fetchStarted = createDeferred();
+      const releaseFetch = createDeferred();
+      vi.spyOn(processExec, "runCommandWithTimeout").mockImplementation(async (argv, options) => {
+        if (argv[0] === "git" && argv.includes("fetch")) {
+          fetchStarted.resolve();
+          await releaseFetch.promise;
+        }
+        return runCommandWithTimeout(argv, options);
+      });
+      const registryFetch = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ version: "2000.1.2" }), {
+          headers: { "content-type": "application/json" },
+        }),
+      );
+      const resolveRegistryChannel = vi.fn(() => "stable" as const);
+      const pending = checkUpdateStatus({
+        root: localRoot,
+        includeRegistry: true,
+        fetchGit: true,
+        timeoutMs: 5000,
+        resolveRegistryChannel,
+      });
+      try {
+        await fetchStarted.promise;
+        expect(resolveRegistryChannel).toHaveBeenCalledWith(
+          expect.objectContaining({
+            installKind: "git",
+            git: expect.objectContaining({ branch: "main", tag: "v2000.1.1" }),
+          }),
+        );
+        expect(registryFetch).toHaveBeenCalledOnce();
+      } finally {
+        releaseFetch.resolve();
+        await pending;
+      }
+      expect((await pending).git).toMatchObject({ fetchOk: true, ahead: 0, behind: 0 });
+    });
+  });
+
   it.each([
     { name: "shared default", timeoutMs: undefined, expectedTimeoutMs: 120_000 },
     { name: "explicit override", timeoutMs: 4321, expectedTimeoutMs: 4321 },

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -41,6 +41,11 @@ type GitUpdateStatus = {
   error?: string;
 };
 
+export type UpdateInstallIdentity = {
+  installKind: "git" | "package" | "unknown";
+  git?: Pick<GitUpdateStatus, "branch" | "tag" | "error">;
+};
+
 type GitTrackingTarget = {
   revision: string;
   display: string;
@@ -237,8 +242,47 @@ export async function resolveUpdateInstallKind(
   return (await resolveGitRoot(runCommandWithTimeout, [root], 4000, root)) ? "git" : "package";
 }
 
+/** Read the install and local Git identity needed to select an update channel. */
+export async function resolveUpdateInstallIdentity(params: {
+  root: string | null;
+  timeoutMs?: number;
+}): Promise<UpdateInstallIdentity> {
+  const { root } = params;
+  const installKind = await resolveUpdateInstallKind(root);
+  return {
+    installKind,
+    git:
+      installKind === "git" && root
+        ? await readGitUpdateIdentity(root, params.timeoutMs)
+        : undefined,
+  };
+}
+
+async function readGitUpdateIdentity(
+  root: string,
+  timeoutMs = 6000,
+): Promise<NonNullable<UpdateInstallIdentity["git"]>> {
+  const [branch, tag] = await Promise.all(
+    [
+      ["rev-parse", "--abbrev-ref", "HEAD"],
+      ["describe", "--tags", "--exact-match"],
+    ].map((args) =>
+      runCommandWithTimeout(["git", "-C", root, ...args], {
+        timeoutMs,
+      }).catch(() => null),
+    ),
+  );
+  return branch?.code === 0
+    ? {
+        branch: branch.stdout.trim() || null,
+        tag: tag?.code === 0 ? tag.stdout.trim() || null : null,
+      }
+    : { branch: null, tag: null, error: branch?.stderr?.trim() || "git unavailable" };
+}
+
 async function checkGitUpdateStatus(params: {
   root: string;
+  identity: Promise<NonNullable<UpdateInstallIdentity["git"]>>;
   timeoutMs: number | undefined;
   fetch?: boolean;
   useDetachedDevUpstream?: boolean;
@@ -266,18 +310,15 @@ async function checkGitUpdateStatus(params: {
     behind: null,
     fetchOk: null,
   };
-
-  const [branchRes, sha, commitAtRaw, tag, dirtyRes] = await Promise.all([
-    runGit("rev-parse", "--abbrev-ref", "HEAD"),
+  const [{ branch, tag, error }, sha, commitAtRaw, dirtyRes] = await Promise.all([
+    params.identity,
     readGit("rev-parse", "HEAD"),
     readGit("show", "-s", "--format=%ct", "HEAD"),
-    readGit("describe", "--tags", "--exact-match"),
     runGit("status", "--porcelain", "--", ":!dist/control-ui/"),
   ]);
-  if (!branchRes || branchRes.code !== 0) {
-    return { ...base, error: branchRes?.stderr?.trim() || "git unavailable" };
+  if (error) {
+    return { ...base, error };
   }
-  const branch = branchRes.stdout.trim() || null;
   const trackingRevisions =
     branch === "HEAD"
       ? params.useDetachedDevUpstream
@@ -583,12 +624,10 @@ export async function checkUpdateStatus(params: {
   gitUpstreamFallback?: { currentSha: string; upstreamRef: string };
   includeRegistry?: boolean;
   registryChannel?: UpdateChannel;
-  resolveRegistryChannel?: (
-    status: Pick<UpdateCheckResult, "installKind" | "git">,
-  ) => UpdateChannel;
+  resolveRegistryChannel?: (status: UpdateInstallIdentity) => UpdateChannel;
 }): Promise<UpdateCheckResult> {
   const timeoutMs = params.timeoutMs ?? 6000;
-  const resolveRegistryChannel = (status: Pick<UpdateCheckResult, "installKind" | "git">) =>
+  const resolveRegistryChannel = (status: UpdateInstallIdentity) =>
     params.registryChannel ?? params.resolveRegistryChannel?.(status);
   const fetchRegistry = (registryChannel: UpdateChannel | undefined) =>
     registryChannel
@@ -622,10 +661,29 @@ export async function checkUpdateStatus(params: {
       ? "npm"
       : detectedPackageManager;
 
-  const [git, deps] = await Promise.all([
-    isGit
+  // Start all local Git reads together; only registry selection needs to wait
+  // for branch/tag identity, independently of worktree and remote freshness.
+  const identity = isGit
+    ? readGitUpdateIdentity(root, params.timeoutMs ?? (params.fetchGit ? GIT_TIMEOUT_MS : 6000))
+    : undefined;
+  const registryPromise = Promise.resolve(identity).then((git) => {
+    const registryChannel = resolveRegistryChannel({ installKind, git });
+    return params.includeRegistry
+      ? registryChannel === "extended-stable" && isGit
+        ? {
+            latestVersion: null,
+            tag: "extended-stable",
+            error: "unsupported_git_channel",
+            reason: "unsupported_git_channel" as const,
+          }
+        : fetchRegistry(registryChannel)
+      : undefined;
+  });
+  const [git, deps, registry] = await Promise.all([
+    identity
       ? checkGitUpdateStatus({
           root,
+          identity,
           timeoutMs: params.timeoutMs,
           fetch: Boolean(params.fetchGit),
           useDetachedDevUpstream: params.useDetachedDevUpstream,
@@ -633,18 +691,8 @@ export async function checkUpdateStatus(params: {
         })
       : Promise.resolve(undefined),
     checkDepsStatus({ root, manager: packageManager }),
+    registryPromise,
   ]);
-  const registryChannel = resolveRegistryChannel({ installKind, git });
-  const registry = params.includeRegistry
-    ? registryChannel === "extended-stable" && isGit
-      ? {
-          latestVersion: null,
-          tag: "extended-stable",
-          error: "unsupported_git_channel",
-          reason: "unsupported_git_channel" as const,
-        }
-      : await fetchRegistry(registryChannel)
-    : undefined;
 
   return {
     root,

--- a/src/infra/update-global.ts
+++ b/src/infra/update-global.ts
@@ -382,7 +382,7 @@ async function collectInstalledPackageDistErrors(params: {
 
   const criticalErrors = await collectInstalledPathErrors({
     packageRoot: params.packageRoot,
-    expectedFiles: await collectLegacyInstalledPackageDistPaths(params.packageRoot),
+    expectedFiles: criticalPaths,
     actualFiles: null,
     missingMessage: (relativePath) => `missing bundled runtime sidecar ${relativePath}`,
   });
@@ -399,10 +399,6 @@ async function collectInstalledPackageDistErrors(params: {
     ];
   }
   return criticalErrors;
-}
-
-async function collectLegacyInstalledPackageDistPaths(packageRoot: string): Promise<string[]> {
-  return await collectCriticalInstalledPackageDistPaths(packageRoot);
 }
 
 async function collectCriticalInstalledPackageDistPaths(packageRoot: string): Promise<string[]> {

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -3623,7 +3623,6 @@ printf '%s\n' "$status" >"$TMPDIR/status"
       expectTextToIncludeAll(script, [
         'supervisor_script="${pid_file}.supervisor.mjs"',
         'OPENCLAW_SYSTEMCTL_SHIM_EXEC_START="$exec_start"',
-        'nohup node "$supervisor_script"',
         'if (key.startsWith("OPENCLAW_UPDATE_")) {',
         "delete childEnv.OPENCLAW_COMPATIBILITY_HOST_VERSION;",
         'process.on("SIGTERM", stop);',

--- a/test/scripts/upgrade-survivor-systemd.test.ts
+++ b/test/scripts/upgrade-survivor-systemd.test.ts
@@ -121,7 +121,7 @@ describe.skipIf(process.platform === "win32")("survivor manager fixture", () => 
     expect(await readSystemdServiceExecStart(env, { requireEffective: true })).toBeNull();
   });
 
-  it("executes the inspected argv, cwd and file environment, rejects an old survivor, and drains restart children", async () => {
+  it("keeps the inspected service alive after the caller terminal closes and drains restart children", async () => {
     const { home, env, shell, systemctl, unit } = fixture();
     const record = join(home, "starts.jsonl");
     const program = join(home, "gateway fixture.mjs");
@@ -173,11 +173,27 @@ setInterval(() => {}, 1000);
     try {
       expect(systemctl("enable", "openclaw-gateway.service").status).toBe(0);
       expect(systemctl("is-enabled", "openclaw-gateway.service").status).toBe(0);
-      expect(
-        shell("OPENCLAW_UPDATE_IN_PROGRESS=1 systemctl --user restart openclaw-gateway.service")
-          .status,
-      ).toBe(0);
+      const restarted = spawnSync(
+        "python3",
+        [
+          "-c",
+          `import os, pty, sys
+status = pty.spawn(["bash", "-c", sys.argv[1], "fixture", sys.argv[2]], stdin_read=lambda _: b"")
+code = os.waitstatus_to_exitcode(status)
+raise SystemExit(code if code >= 0 else 128 - code)
+`,
+          'set -e; systemctl --user restart openclaw-gateway.service; for _ in {1..200}; do [ -s "$1" ] && exit 0; sleep 0.01; done; exit 1',
+          record,
+        ],
+        {
+          env: { ...env, OPENCLAW_UPDATE_IN_PROGRESS: "1" },
+          encoding: "utf8",
+          timeout: 40_000,
+        },
+      );
+      expect(restarted.status, restarted.stderr).toBe(0);
       await waitForStarts(1);
+      expect.soft(systemctl("is-active", "openclaw-gateway.service").status).toBe(0);
       const inspected = await readSystemdServiceExecStart(env, { requireEffective: true });
       expect(records()[0]).toEqual({
         pid: expect.any(Number),
@@ -209,7 +225,14 @@ setInterval(() => {}, 1000);
       const stopped = systemctl("stop", "openclaw-gateway.service");
       expect(stopped.status, stopped.stderr).toBe(0);
       for (const { pid } of records()) {
-        expect(() => process.kill(pid, 0)).toThrow();
+        try {
+          expect.soft(() => process.kill(pid, 0)).toThrow();
+        } finally {
+          // A broken supervisor can strand its detached child; keep failed proof isolated.
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {}
+        }
       }
       expect(existsSync(env.OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE)).toBe(false);
     }


### PR DESCRIPTION
Related: #133698 (previous update CLI cleanup).

## What Problem This Solves

Fixes an issue where users running `openclaw update --yes` could still be prompted to install shell completion in a new profile. The update wizard also collected full Git freshness and dependency status before showing a channel choice, and a successful human-mode restart ran another Doctor from the old updater process.

## Why This Change Was Made

A shared install-identity reader gives the wizard only the install kind, branch, and tag it needs. Full status retains parallel local Git probes and starts its registry request as soon as that identity selects the channel, overlapping remote Git work and dependency inspection. Existing channel/Git formatters replace duplicate output logic, and package verification reuses the critical paths it already collected.

The service lifecycle stops running stale Doctor after verified restart. Target-package Doctor, fresh pre-plugin repair, Git validation/rollback, post-core convergence, service ownership, and final Gateway health/version verification remain with their existing owners. Update notification ordering is unchanged. Optional completion setup honors `--yes`; existing profiles and caches still receive repair.

## User Impact

The wizard does less work before its first prompt, status overlaps independent checks, and unattended updates finish without asking about an optional shell profile. JSON output retains its existing shape. No dependency, configuration, environment-variable, persistence, or public option is added.

Production LOC: +96/-105 (net -9). Tests: +201/-56. Docker test support: +90/-32. Docs: +10.

## Evidence

- Real terminal profiling: wizard Git subprocesses fall from **7 to 3**. A final built-CLI run confirmed the three probes and safe cancellation at the first prompt. Repeated wall-clock samples were noisy (baseline median 1.043s; quiet candidate 1.096s), so this PR claims eliminated work and overlapped I/O, not a percentage latency improvement. Help and dry-run stdout/stderr were byte-identical.
- Regression reproductions failed before repair for the completion prompt, stale post-restart Doctor, wizard dependency on full freshness, and registry scheduling. A separate latch regression caught an initial serialization of local Git reads; it passes on the original baseline and final code.
- 693 affected tests passed across CLI orchestration, service lifecycle, update status/channels, package verification and siblings. The final scheduling correction passed 129 owner/sibling tests and source typechecking; the final status suite passed all 22 tests. All 264 Docker fixture/helper tests passed.
- Local runtime build and import-cycle checks passed. Fresh Codex autoreview has no actionable findings through P2.
- Full changed-file gate passed: [Testbox run 33354179210](https://github.com/openclaw/openclaw/actions/runs/33354179210). Command: `node scripts/check-changed.mjs`.
- Final packaged Docker proof passed all three scenarios in one invocation: [Testbox run 33354178253](https://github.com/openclaw/openclaw/actions/runs/33354178253). A single tarball was built with `scripts/package-openclaw-for-docker.mjs`, then used by `scripts/e2e/multi-node-update-docker.sh`, `scripts/e2e/update-corrupt-plugin-docker.sh`, and `scripts/e2e/update-channel-switch-docker.sh`. JSON and unattended real-TTY updates preserve the original Node/package root, keep the service active, and return a healthy real Gateway. The service manager is a fixture. The other lanes exercise corrupt-plugin recovery and package/Git channel transitions with status and dry-run assertions.
- Frozen Docker source: baseline `4eb10567c9073f2385c394e6302c4dba24f91e70`, changed-file blob fingerprint `d20c893c07069755b6b4f208e21b05cdbb04746967ed4bc58c95ca613a3f0749`. Both proof leases stopped after success; stopped Testboxes may appear cancelled in Actions, while the delegated command receipts report exit 0.

Docker uncovered two fixture defects repaired here: the service manager died when its calling terminal closed, and baseline synthetic-plugin installation omitted required capability consent. The manager now starts detached, with a real-PTY lifecycle regression; the plugin fixture uses the existing feature-detecting consent helper and redacted failure logs. No consent checks were weakened.

Known follow-ups: target-package and pre-plugin Doctor phases still have distinct repair/compatibility contracts and need an explicit completed-phase receipt before deduplication; Doctor can report an unreachable Gateway while the updater has intentionally stopped it. One earlier channel-switch attempt timed out at 300s; diagnostic and original-default reruns, including final proof, passed. No root cause was established, and no timeout or retry was changed.
