### PR TITLE
improve: speed up session projection indexing with less code

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -158,11 +158,13 @@ function assert(condition, message) {
   }
 }
 
-function seedLegacySessionMetadata(stateDir) {
-  const legacySessionsDir = path.join(stateDir, "sessions");
+function seedLegacySessionMetadata(stateDir, perAgent) {
+  const legacySessionsDir = perAgent
+    ? path.join(stateDir, "agents", "main", "sessions")
+    : path.join(stateDir, "sessions");
   const baseUpdatedAt = Date.now() - 24 * 60 * 60 * 1000;
   writeJson(path.join(legacySessionsDir, "sessions.json"), {
-    main: {
+    [perAgent ? "agent:main:main" : "main"]: {
       sessionId: LEGACY_SESSION_MAIN_ID,
       sessionFile: path.join(legacySessionsDir, `${LEGACY_SESSION_MAIN_ID}.jsonl`),
       provider: "openai",
@@ -178,14 +180,14 @@ function seedLegacySessionMetadata(stateDir) {
         ],
       },
     },
-    "+15551234567": {
+    [perAgent ? "agent:main:+15551234567" : "+15551234567"]: {
       sessionId: LEGACY_SESSION_DIRECT_ID,
       sessionFile: path.join(legacySessionsDir, `${LEGACY_SESSION_DIRECT_ID}.jsonl`),
       provider: "openai",
       model: "gpt-5.5",
       updatedAt: baseUpdatedAt + 100,
     },
-    "slack:channel:CUPGRADE": {
+    [perAgent ? "agent:main:slack:channel:cupgrade" : "slack:channel:CUPGRADE"]: {
       sessionId: LEGACY_SESSION_GROUP_ID,
       sessionFile: path.join(legacySessionsDir, `${LEGACY_SESSION_GROUP_ID}.jsonl`),
       provider: "openai",
@@ -368,7 +370,8 @@ function seedState() {
     agentId: "main",
     title: "Existing user session",
   });
-  seedLegacySessionMetadata(stateDir);
+  // Volume imports start in per-agent JSON; other scenarios cover the older shared-store move.
+  seedLegacySessionMetadata(stateDir, scenario === "sqlite-volume");
   if (scenario === "meeting-transcripts-sqlite") {
     seedLegacyMeetingTranscripts(stateDir);
   }

--- a/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
+++ b/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
@@ -289,6 +289,33 @@ function adaptStepForBaseline(
     }
     return null;
   }
+  if (step.id === "agents") {
+    const agentsJson = step.argv[3];
+    if (agentsJson === undefined) {
+      throw new Error(`config recipe step ${step.id} is missing its JSON value`);
+    }
+    const agents = JSON.parse(agentsJson);
+    // Modern config writes stamp explicit ownership when adding a second agent.
+    // Older baselines need their default marker for ownership migration on upgrade.
+    for (const agent of agents.list ?? []) {
+      if (baselineVersion && !isReleaseBefore(baselineVersion, "2026.8.1")) {
+        delete agent.default;
+      }
+      if (isReleaseBefore(baselineVersion, "2026.4.0")) {
+        delete agent.thinkingDefault;
+        delete agent.fastModeDefault;
+        delete agent.skills;
+      }
+    }
+    if (isReleaseBefore(baselineVersion, "2026.4.0")) {
+      delete agents.defaults?.skills;
+      summary.skippedIntents.push("agent-modern-preferences");
+    }
+    return {
+      ...step,
+      argv: [...step.argv.slice(0, 3), JSON.stringify(agents), ...step.argv.slice(4)],
+    };
+  }
   if (!isReleaseBefore(baselineVersion, "2026.4.0")) {
     return step;
   }
@@ -297,24 +324,6 @@ function adaptStepForBaseline(
       summary.skippedIntents.push("feishu-channel");
     }
     return null;
-  }
-  if (step.id === "agents") {
-    const agentsJson = step.argv[3];
-    if (agentsJson === undefined) {
-      throw new Error(`config recipe step ${step.id} is missing its JSON value`);
-    }
-    const agents = JSON.parse(agentsJson);
-    delete agents.defaults?.skills;
-    for (const agent of agents.list ?? []) {
-      delete agent.thinkingDefault;
-      delete agent.fastModeDefault;
-      delete agent.skills;
-    }
-    summary.skippedIntents.push("agent-modern-preferences");
-    return {
-      ...step,
-      argv: [...step.argv.slice(0, 3), JSON.stringify(agents), ...step.argv.slice(4)],
-    };
   }
   if (step.intent === "plugins") {
     const pluginsJson = step.argv[3];

--- a/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
+++ b/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
@@ -289,59 +289,59 @@ function adaptStepForBaseline(
     }
     return null;
   }
-  if (step.id === "agents") {
-    const agentsJson = step.argv[3];
-    if (agentsJson === undefined) {
-      throw new Error(`config recipe step ${step.id} is missing its JSON value`);
-    }
-    const agents = JSON.parse(agentsJson);
-    // Modern config writes stamp explicit ownership when adding a second agent.
-    // Older baselines need their default marker for ownership migration on upgrade.
-    for (const agent of agents.list ?? []) {
-      if (baselineVersion && !isReleaseBefore(baselineVersion, "2026.8.1")) {
-        delete agent.default;
-      }
-      if (isReleaseBefore(baselineVersion, "2026.4.0")) {
-        delete agent.thinkingDefault;
-        delete agent.fastModeDefault;
-        delete agent.skills;
-      }
-    }
-    if (isReleaseBefore(baselineVersion, "2026.4.0")) {
-      delete agents.defaults?.skills;
-      summary.skippedIntents.push("agent-modern-preferences");
-    }
-    return {
-      ...step,
-      argv: [...step.argv.slice(0, 3), JSON.stringify(agents), ...step.argv.slice(4)],
-    };
-  }
-  if (!isReleaseBefore(baselineVersion, "2026.4.0")) {
-    return step;
-  }
-  if (step.id === "plugins-feishu" || step.id === "channels-feishu") {
+  const legacyBaseline = isReleaseBefore(baselineVersion, "2026.4.0");
+  const modernBaseline = baselineVersion && !isReleaseBefore(baselineVersion, "2026.8.1");
+  if (legacyBaseline && (step.id === "plugins-feishu" || step.id === "channels-feishu")) {
     if (!summary.skippedIntents.includes("feishu-channel")) {
       summary.skippedIntents.push("feishu-channel");
     }
     return null;
   }
-  if (step.intent === "plugins") {
-    const pluginsJson = step.argv[3];
-    if (pluginsJson === undefined) {
-      throw new Error(`config recipe step ${step.id} is missing its JSON value`);
+  if (
+    !(step.id === "agents" && (legacyBaseline || modernBaseline)) &&
+    !(step.id === "channels-discord" && modernBaseline) &&
+    !(step.intent === "plugins" && legacyBaseline)
+  ) {
+    return step;
+  }
+  const configJson = step.argv[3];
+  if (configJson === undefined) {
+    throw new Error(`config recipe step ${step.id} is missing its JSON value`);
+  }
+  const config = JSON.parse(configJson);
+  if (step.id === "agents") {
+    // Modern config writes stamp explicit ownership when adding a second agent.
+    // Older baselines need their default marker for ownership migration on upgrade.
+    for (const agent of config.list ?? []) {
+      if (modernBaseline) {
+        delete agent.default;
+      }
+      if (legacyBaseline) {
+        delete agent.thinkingDefault;
+        delete agent.fastModeDefault;
+        delete agent.skills;
+      }
     }
-    const plugins = JSON.parse(pluginsJson);
-    plugins.allow = (plugins.allow ?? []).filter((id: unknown) => id !== "memory");
-    delete plugins.entries?.memory;
+    if (legacyBaseline) {
+      delete config.defaults?.skills;
+      summary.skippedIntents.push("agent-modern-preferences");
+    }
+  } else if (step.id === "channels-discord") {
+    // Keep retired DM fields as migration specimens only for older baselines.
+    config.dmPolicy = config.dm.policy;
+    config.allowFrom = config.dm.allowFrom;
+    delete config.dm;
+  } else {
+    config.allow = (config.allow ?? []).filter((id: unknown) => id !== "memory");
+    delete config.entries?.memory;
     if (!summary.skippedIntents.includes("memory-plugin-allow")) {
       summary.skippedIntents.push("memory-plugin-allow");
     }
-    return {
-      ...step,
-      argv: [...step.argv.slice(0, 3), JSON.stringify(plugins), ...step.argv.slice(4)],
-    };
   }
-  return step;
+  return {
+    ...step,
+    argv: [...step.argv.slice(0, 3), JSON.stringify(config), ...step.argv.slice(4)],
+  };
 }
 
 export function resolveUpgradeSurvivorConfigStepsForBaseline(

--- a/scripts/e2e/lib/upgrade-survivor/sqlite-volume-shared-state.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/sqlite-volume-shared-state.mjs
@@ -114,15 +114,16 @@ async function seedBaselinePluginState(packageRoot) {
     process.env.OPENCLAW_UPGRADE_SURVIVOR_BASELINE_VERSION,
     "baseline SDK package version differs from the installed CLI",
   );
-  const sdkExport = manifest.exports?.["./plugin-sdk/runtime-doctor"];
-  let hasStoreDeclaration = false;
-  if (sdkExport?.types !== undefined) {
+  const storeExport = manifest.exports?.["./plugin-sdk/plugin-state-store-runtime"];
+  const sdkExport = storeExport ?? manifest.exports?.["./plugin-sdk/runtime-doctor"];
+  let hasStoreDeclaration = Boolean(storeExport);
+  if (!hasStoreDeclaration && sdkExport?.types !== undefined) {
     assert.equal(typeof sdkExport.types, "string", "baseline doctor SDK type declaration missing");
     const declarations = fs.readFileSync(path.resolve(packageRoot, sdkExport.types), "utf8");
     hasStoreDeclaration = /\bcreatePluginStateSyncKeyedStore\b/u.test(declarations);
   }
-  // April/May baselines expose doctor helpers but no keyed store constructor.
-  // A declared constructor whose runtime import is broken must still fail below.
+  // Modern packages expose the dedicated store without declarations. Older doctor
+  // exports need their declaration to distinguish packages with no store constructor.
   if (!hasStoreDeclaration) {
     const reason = "baseline SDK does not declare createPluginStateSyncKeyedStore";
     recordBaselineSharedState(stateDir, {
@@ -138,7 +139,13 @@ async function seedBaselinePluginState(packageRoot) {
   const installedRequire = createRequire(packageJsonPath);
   // Resolve the published SDK from its own package; importing checkout source would
   // silently create the candidate schema and erase the upgrade boundary under test.
-  const sdkUrl = pathToFileURL(installedRequire.resolve("openclaw/plugin-sdk/runtime-doctor"));
+  const sdkUrl = pathToFileURL(
+    installedRequire.resolve(
+      storeExport
+        ? "openclaw/plugin-sdk/plugin-state-store-runtime"
+        : "openclaw/plugin-sdk/runtime-doctor",
+    ),
+  );
   const { createPluginStateSyncKeyedStore } = await import(sdkUrl.href);
   assert.equal(
     typeof createPluginStateSyncKeyedStore,

--- a/scripts/e2e/lib/upgrade-survivor/sqlite-volume.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/sqlite-volume.mjs
@@ -318,23 +318,6 @@ export function assertUpgradeVolumeMigrated(stateDir, stage) {
         readJson(path.join(getVolumeSessionsDir(stateDir, agentId), "sessions.json")),
       ]),
     );
-    // Baseline setup may leave the oldest shared store for the candidate to migrate.
-    // Combine only the known specimens here; survival still requires canonical rows.
-    const legacyStorePath = path.join(stateDir, "sessions", "sessions.json");
-    if (fs.existsSync(legacyStorePath)) {
-      const entries = Object.values(readJson(legacyStorePath));
-      assert(
-        entries.length === PREEXISTING_SESSION_FIXTURES.length,
-        "legacy fixture count changed",
-      );
-      for (const { agentId, sessionId, sessionKey } of PREEXISTING_SESSION_FIXTURES) {
-        const entry = entries.find((candidate) => candidate.sessionId === sessionId);
-        assert(entry, `legacy fixture missing: ${sessionId}`);
-        const store = stores.get(agentId);
-        assert(!Object.hasOwn(store, sessionKey), `duplicate baseline fixture: ${sessionKey}`);
-        store[sessionKey] = entry;
-      }
-    }
     assertVolumeSessionStores(stores, fixtures, "volume baseline");
     for (const fixture of fixtures) {
       if (fixture.missingTranscript) {

--- a/scripts/e2e/lib/upgrade-survivor/sqlite-volume.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/sqlite-volume.mjs
@@ -318,6 +318,23 @@ export function assertUpgradeVolumeMigrated(stateDir, stage) {
         readJson(path.join(getVolumeSessionsDir(stateDir, agentId), "sessions.json")),
       ]),
     );
+    // Baseline setup may leave the oldest shared store for the candidate to migrate.
+    // Combine only the known specimens here; survival still requires canonical rows.
+    const legacyStorePath = path.join(stateDir, "sessions", "sessions.json");
+    if (fs.existsSync(legacyStorePath)) {
+      const entries = Object.values(readJson(legacyStorePath));
+      assert(
+        entries.length === PREEXISTING_SESSION_FIXTURES.length,
+        "legacy fixture count changed",
+      );
+      for (const { agentId, sessionId, sessionKey } of PREEXISTING_SESSION_FIXTURES) {
+        const entry = entries.find((candidate) => candidate.sessionId === sessionId);
+        assert(entry, `legacy fixture missing: ${sessionId}`);
+        const store = stores.get(agentId);
+        assert(!Object.hasOwn(store, sessionKey), `duplicate baseline fixture: ${sessionKey}`);
+        store[sessionKey] = entry;
+      }
+    }
     assertVolumeSessionStores(stores, fixtures, "volume baseline");
     for (const fixture of fixtures) {
       if (fixture.missingTranscript) {

--- a/src/config/sessions/session-transcript-index.ts
+++ b/src/config/sessions/session-transcript-index.ts
@@ -12,6 +12,7 @@ import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
+  prepareSqliteQuerySync,
 } from "../../infra/kysely-sync.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
@@ -21,6 +22,7 @@ import {
   hasUnclassifiedSessionTranscriptEvents,
   shouldProjectActiveEvent,
   transcriptEventContextEligibility,
+  type PreparedSessionTranscriptProjection,
   type TranscriptIndexEntry,
 } from "./session-transcript-projection-rebuild.js";
 import {
@@ -158,56 +160,45 @@ export function sessionTranscriptIndexNeedsReconcile(db: DatabaseSync, sessionId
   );
 }
 
-function writeWatermark(
-  db: DatabaseSync,
-  sessionId: string,
-  watermark: SessionTranscriptProjectionState,
-  now: number,
-  updateExisting = false,
-): SessionTranscriptProjectionState {
-  const kysely = getIndexKysely(db);
-  const values = {
-    active_event_count: watermark.activeEventCount,
-    active_message_count: watermark.activeMessageCount,
-    indexed_seq: watermark.indexedSeq,
-    leaf_event_id: watermark.leafEventId,
-    needs_rebuild: watermark.needsRebuild ? 1 : 0,
-    updated_at: now,
-  };
-  executeSqliteQuerySync(
+function createWatermarkWriter(db: DatabaseSync, sessionId: string, updateExisting = false) {
+  return prepareSqliteQuerySync<SessionTranscriptProjectionState & { updatedAt: number }>(
     db,
-    updateExisting
-      ? kysely
-          .updateTable("session_transcript_index_state")
-          .set(values)
-          .where("session_id", "=", sessionId)
-      : kysely
-          .insertInto("session_transcript_index_state")
-          .values({ session_id: sessionId, ...values })
-          .onConflict((conflict) => conflict.column("session_id").doUpdateSet(values)),
+    (parameter) => {
+      const kysely = getIndexKysely(db);
+      const values = {
+        active_event_count: parameter((row) => row.activeEventCount),
+        active_message_count: parameter((row) => row.activeMessageCount),
+        indexed_seq: parameter((row) => row.indexedSeq),
+        leaf_event_id: parameter((row) => row.leafEventId),
+        needs_rebuild: parameter((row) => (row.needsRebuild ? 1 : 0)),
+        updated_at: parameter((row) => row.updatedAt),
+      };
+      return updateExisting
+        ? kysely
+            .updateTable("session_transcript_index_state")
+            .set(values)
+            .where("session_id", "=", sessionId)
+        : kysely
+            .insertInto("session_transcript_index_state")
+            .values({ session_id: sessionId, ...values })
+            .onConflict((conflict) => conflict.column("session_id").doUpdateSet(values));
+    },
   );
-  return watermark;
 }
 
-function insertActiveEventRow(
-  db: DatabaseSync,
-  params: {
-    activePosition: number;
-    contextEligible: 0 | 1;
-    eventSeq: number;
-    messagePosition: number | null;
-    sessionId: string;
-  },
-): void {
-  executeSqliteQuerySync(
+function createActiveEventInserter(db: DatabaseSync, sessionId: string) {
+  return prepareSqliteQuerySync<PreparedSessionTranscriptProjection["activeRows"][number]>(
     db,
-    getIndexKysely(db).insertInto("session_transcript_active_events").values({
-      session_id: params.sessionId,
-      active_position: params.activePosition,
-      context_eligible: params.contextEligible,
-      event_seq: params.eventSeq,
-      message_position: params.messagePosition,
-    }),
+    (parameter) =>
+      getIndexKysely(db)
+        .insertInto("session_transcript_active_events")
+        .values({
+          session_id: sessionId,
+          active_position: parameter((row) => row.activePosition),
+          context_eligible: parameter((row) => row.contextEligible),
+          event_seq: parameter((row) => row.eventSeq),
+          message_position: parameter((row) => row.messagePosition),
+        }),
   );
 }
 
@@ -220,18 +211,18 @@ function deleteActiveEventRows(db: DatabaseSync, sessionId: string): void {
   );
 }
 
-function insertFtsRow(db: DatabaseSync, sessionId: string, entry: TranscriptIndexEntry): void {
-  executeSqliteQuerySync(
-    db,
-    getIndexKysely(db).insertInto("session_transcript_fts").values({
-      text: entry.text,
-      session_id: sessionId,
-      message_id: entry.messageId,
-      role: entry.role,
-      // FTS5 aux columns are typeless; the local insert type preserves the
-      // numeric timestamp SQLite stores while generated readers stay strings.
-      timestamp: entry.timestamp,
-    }),
+function createFtsInserter(db: DatabaseSync, sessionId: string) {
+  return prepareSqliteQuerySync<TranscriptIndexEntry>(db, (parameter) =>
+    getIndexKysely(db)
+      .insertInto("session_transcript_fts")
+      .values({
+        text: parameter((entry) => entry.text),
+        session_id: sessionId,
+        message_id: parameter((entry) => entry.messageId),
+        role: parameter((entry) => entry.role),
+        // FTS5 aux columns are typeless; preserve the numeric timestamp SQLite stores.
+        timestamp: parameter((entry) => entry.timestamp),
+      }),
   );
 }
 
@@ -257,6 +248,9 @@ export function createTranscriptIndexAppenderInTransaction(
 ): (params: TranscriptIndexAppend) => boolean {
   let watermark = readSessionTranscriptProjectionState(db, sessionId);
   let hasUnclassifiedEvents: boolean | undefined;
+  let insertActiveEvent: ReturnType<typeof createActiveEventInserter> | undefined;
+  let insertFts: ReturnType<typeof createFtsInserter> | undefined;
+  let updateWatermark: ReturnType<typeof createWatermarkWriter> | undefined;
   return (params) => {
     if (!watermark) {
       if (params.seq !== 0) {
@@ -264,7 +258,7 @@ export function createTranscriptIndexAppenderInTransaction(
         // transcripts): stay unindexed until reconcile rebuilds the session.
         return true;
       }
-      watermark = applyForwardIndex(db, sessionId, params, watermark);
+      applyForwardIndex(params);
       return false;
     }
     if (watermark.needsRebuild) {
@@ -311,51 +305,46 @@ export function createTranscriptIndexAppenderInTransaction(
       watermark = markSessionTranscriptIndexDirtyInTransaction(db, sessionId);
       return true;
     }
-    watermark = applyForwardIndex(db, sessionId, params, watermark);
+    applyForwardIndex(params);
     return false;
   };
-}
 
-function applyForwardIndex(
-  db: DatabaseSync,
-  sessionId: string,
-  params: TranscriptIndexAppend,
-  watermark: SessionTranscriptProjectionState | undefined,
-): SessionTranscriptProjectionState {
-  const entry = extractTranscriptIndexEntry(params.event, params.createdAt);
-  if (entry) {
-    insertFtsRow(db, sessionId, entry);
-  }
-  const projectsActiveEvent = shouldProjectActiveEvent(params.event);
-  const projectsMessage = projectsActiveEvent && hasTranscriptMessage(params.event);
-  if (projectsActiveEvent) {
-    insertActiveEventRow(db, {
-      activePosition: watermark?.activeEventCount ?? 0,
-      contextEligible: transcriptEventContextEligibility(params.event),
-      eventSeq: params.seq,
-      messagePosition: projectsMessage ? (watermark?.activeMessageCount ?? 0) : null,
-      sessionId,
-    });
-  }
-  // Mirror scanSessionTranscriptTree's leaf advancement: canonical entries
-  // (parent-linked or parentless) become the tip the next append chains to;
-  // headers and unknown control rows leave the tip untouched.
-  const advancesLeaf = params.eventId !== null && isCanonicalSessionTranscriptEntry(params.event);
-  return writeWatermark(
-    db,
-    sessionId,
-    {
+  function applyForwardIndex(params: TranscriptIndexAppend): void {
+    const entry = extractTranscriptIndexEntry(params.event, params.createdAt);
+    if (entry) {
+      insertFts ??= createFtsInserter(db, sessionId);
+      insertFts(entry);
+    }
+    const projectsActiveEvent = shouldProjectActiveEvent(params.event);
+    const projectsMessage = projectsActiveEvent && hasTranscriptMessage(params.event);
+    if (projectsActiveEvent) {
+      insertActiveEvent ??= createActiveEventInserter(db, sessionId);
+      insertActiveEvent({
+        activePosition: watermark?.activeEventCount ?? 0,
+        contextEligible: transcriptEventContextEligibility(params.event),
+        eventSeq: params.seq,
+        messagePosition: projectsMessage ? (watermark?.activeMessageCount ?? 0) : null,
+      });
+    }
+    // Mirror scanSessionTranscriptTree's leaf advancement: canonical entries
+    // (parent-linked or parentless) become the tip the next append chains to;
+    // headers and unknown control rows leave the tip untouched.
+    const advancesLeaf = params.eventId !== null && isCanonicalSessionTranscriptEntry(params.event);
+    const nextWatermark = {
       activeEventCount: (watermark?.activeEventCount ?? 0) + (projectsActiveEvent ? 1 : 0),
       activeMessageCount: (watermark?.activeMessageCount ?? 0) + (projectsMessage ? 1 : 0),
       indexedSeq: params.seq,
       leafEventId: advancesLeaf ? params.eventId : (watermark?.leafEventId ?? null),
       needsRebuild: false,
-    },
-    params.createdAt,
-    // The synchronous appender owns this row until its batch ends; initialization
-    // still upserts, while subsequent events avoid repeated conflict resolution.
-    watermark !== undefined,
-  );
+      updatedAt: params.createdAt,
+    };
+    // Initialization still upserts; this synchronous batch owns all subsequent updates.
+    const write = watermark
+      ? (updateWatermark ??= createWatermarkWriter(db, sessionId, true))
+      : createWatermarkWriter(db, sessionId);
+    write(nextWatermark);
+    watermark = nextWatermark;
+  }
 }
 
 /** Marks one session for lazy rebuild without touching its FTS rows. */
@@ -365,18 +354,15 @@ export function markSessionTranscriptIndexDirtyInTransaction(
 ): SessionTranscriptProjectionState {
   const now = Date.now();
   const watermark = readSessionTranscriptProjectionState(db, sessionId);
-  return writeWatermark(
-    db,
-    sessionId,
-    {
-      activeEventCount: watermark?.activeEventCount ?? 0,
-      activeMessageCount: watermark?.activeMessageCount ?? 0,
-      indexedSeq: watermark?.indexedSeq ?? -1,
-      leafEventId: watermark?.leafEventId ?? null,
-      needsRebuild: true,
-    },
-    now,
-  );
+  const dirty = {
+    activeEventCount: watermark?.activeEventCount ?? 0,
+    activeMessageCount: watermark?.activeMessageCount ?? 0,
+    indexedSeq: watermark?.indexedSeq ?? -1,
+    leafEventId: watermark?.leafEventId ?? null,
+    needsRebuild: true,
+  };
+  createWatermarkWriter(db, sessionId)({ ...dirty, updatedAt: now });
+  return dirty;
 }
 
 /** In-transaction delete hook: drops index rows alongside transcript rows. */
@@ -403,24 +389,21 @@ function rebuildSessionTranscriptIndexInTransaction(db: DatabaseSync, sessionId:
   deleteFtsRows(db, sessionId);
   deleteActiveEventRows(db, sessionId);
   const projection = visitSessionTranscriptProjection(db, sessionId, {
-    activeRow: (row) => insertActiveEventRow(db, { ...row, sessionId }),
-    ftsRow: (entry) => insertFtsRow(db, sessionId, entry),
+    activeRow: createActiveEventInserter(db, sessionId),
+    ftsRow: createFtsInserter(db, sessionId),
   });
   if (!projection) {
     return;
   }
-  writeWatermark(
-    db,
-    sessionId,
-    {
-      activeEventCount: projection.activeEventCount,
-      activeMessageCount: projection.activeMessageCount,
-      indexedSeq: projection.sourceIndexedSeq,
-      leafEventId: projection.leafEventId,
-      needsRebuild: false,
-    },
-    Date.now(),
-  );
+  const writeWatermark = createWatermarkWriter(db, sessionId);
+  writeWatermark({
+    activeEventCount: projection.activeEventCount,
+    activeMessageCount: projection.activeMessageCount,
+    indexedSeq: projection.sourceIndexedSeq,
+    leafEventId: projection.leafEventId,
+    needsRebuild: false,
+    updatedAt: Date.now(),
+  });
 }
 
 /** Rebuilds one lagging projection under its current write transaction. */

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -1,4 +1,5 @@
 // Upgrade Survivor Assertions tests cover upgrade survivor assertions script behavior.
+import assert from "node:assert/strict";
 import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
@@ -1135,6 +1136,7 @@ process.stdout.write(sessionDir + "\\n");
         ]);
 
         for (const row of seededRows) {
+          assert(row);
           const transcriptPath = join(sessionsDir, `${String(row.sessionId)}.jsonl`);
           expect(row.sessionFile).toBe(transcriptPath);
           expect(JSON.parse(readFileSync(transcriptPath, "utf8")).id).toBe(row.sessionId);

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -821,87 +821,108 @@ function assertUpdateRunSelfUpgrade(summary: ReturnType<typeof createUpdateRunSe
 describe("upgrade survivor assertions", () => {
   it.each([
     {
-      name: "default-only export",
+      name: "legacy default-only doctor export",
+      sdkPath: "runtime-doctor",
       declaresTypes: false,
       runtime: 'throw new Error("undeclared SDK must not be imported");\n',
       failure: undefined,
     },
     {
       name: "declared constructor missing at runtime",
+      sdkPath: "runtime-doctor",
       declaresTypes: true,
       runtime: "export {};\n",
       failure: "declared a keyed store constructor but did not export it",
     },
     {
       name: "declared SDK import failure",
+      sdkPath: "runtime-doctor",
       declaresTypes: true,
       runtime: 'throw new Error("synthetic SDK import failure");\n',
       failure: "synthetic SDK import failure",
     },
-  ])("classifies baseline shared state for $name", ({ declaresTypes, runtime, failure }) => {
-    const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-baseline-sdk-"));
-    try {
-      const packageRoot = join(root, "package");
-      const stateDir = join(root, "state");
-      const version = "1.0.0";
-      mkdirSync(packageRoot);
-      mkdirSync(stateDir);
-      writeJson(join(packageRoot, "package.json"), {
-        name: "openclaw",
-        version,
-        type: "module",
-        exports: {
-          "./plugin-sdk/runtime-doctor": {
-            ...(declaresTypes ? { types: "./runtime-doctor.d.ts" } : {}),
-            default: "./runtime-doctor.js",
-          },
-        },
-      });
-      // An undeclared sibling file must not become a guessed declaration fallback.
-      writeFileSync(
-        join(packageRoot, "runtime-doctor.d.ts"),
-        "export declare function createPluginStateSyncKeyedStore(): unknown;\n",
-      );
-      writeFileSync(join(packageRoot, "runtime-doctor.js"), runtime);
-      const baselinePath = join(stateDir, "survivor-baseline.json");
-      writeJson(baselinePath, { marker: "existing fixture" });
-      const result = spawnSync(
-        process.execPath,
-        [
-          "scripts/e2e/lib/upgrade-survivor/sqlite-volume-shared-state.mjs",
-          "seed-baseline-plugin-state",
-          packageRoot,
-        ],
-        {
-          encoding: "utf8",
-          env: {
-            ...process.env,
-            OPENCLAW_STATE_DIR: stateDir,
-            OPENCLAW_UPGRADE_SURVIVOR_BASELINE_VERSION: version,
-          },
-        },
-      );
-      const baseline = JSON.parse(readFileSync(baselinePath, "utf8"));
-      if (failure) {
-        expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain(failure);
-        expect(baseline).toEqual({ marker: "existing fixture" });
-      } else {
-        expect(result.status, result.stderr).toBe(0);
-        expect(baseline).toEqual({
-          marker: "existing fixture",
-          sharedState: {
-            status: "not-applicable",
-            packageVersion: version,
-            reason: "baseline SDK does not declare createPluginStateSyncKeyedStore",
+    {
+      name: "dedicated default-only store export missing its constructor",
+      sdkPath: "plugin-state-store-runtime",
+      declaresTypes: false,
+      runtime: "export {};\n",
+      failure: "declared a keyed store constructor but did not export it",
+    },
+    {
+      name: "dedicated default-only store constructor failure",
+      sdkPath: "plugin-state-store-runtime",
+      declaresTypes: false,
+      runtime:
+        'export function createPluginStateSyncKeyedStore() { throw new Error("synthetic store failure"); }\n',
+      failure: "synthetic store failure",
+    },
+  ])(
+    "classifies baseline shared state for $name",
+    ({ sdkPath, declaresTypes, runtime, failure }) => {
+      const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-baseline-sdk-"));
+      try {
+        const packageRoot = join(root, "package");
+        const stateDir = join(root, "state");
+        const version = "1.0.0";
+        mkdirSync(packageRoot);
+        mkdirSync(stateDir);
+        writeJson(join(packageRoot, "package.json"), {
+          name: "openclaw",
+          version,
+          type: "module",
+          exports: {
+            [`./plugin-sdk/${sdkPath}`]: {
+              ...(declaresTypes ? { types: "./runtime-doctor.d.ts" } : {}),
+              default: "./runtime-doctor.js",
+            },
           },
         });
-        expect(result.stdout).toContain("not-applicable");
+        // An undeclared sibling file must not become a guessed declaration fallback.
+        writeFileSync(
+          join(packageRoot, "runtime-doctor.d.ts"),
+          "export declare function createPluginStateSyncKeyedStore(): unknown;\n",
+        );
+        writeFileSync(join(packageRoot, "runtime-doctor.js"), runtime);
+        const baselinePath = join(stateDir, "survivor-baseline.json");
+        writeJson(baselinePath, { marker: "existing fixture" });
+        const result = spawnSync(
+          process.execPath,
+          [
+            "scripts/e2e/lib/upgrade-survivor/sqlite-volume-shared-state.mjs",
+            "seed-baseline-plugin-state",
+            packageRoot,
+          ],
+          {
+            encoding: "utf8",
+            env: {
+              ...process.env,
+              OPENCLAW_STATE_DIR: stateDir,
+              OPENCLAW_UPGRADE_SURVIVOR_BASELINE_VERSION: version,
+            },
+          },
+        );
+        const baseline = JSON.parse(readFileSync(baselinePath, "utf8"));
+        if (failure) {
+          expect(result.status).not.toBe(0);
+          expect(result.stderr).toContain(failure);
+          expect(baseline).toEqual({ marker: "existing fixture" });
+        } else {
+          expect(result.status, result.stderr).toBe(0);
+          expect(baseline).toEqual({
+            marker: "existing fixture",
+            sharedState: {
+              status: "not-applicable",
+              packageVersion: version,
+              reason: "baseline SDK does not declare createPluginStateSyncKeyedStore",
+            },
+          });
+          expect(result.stdout).toContain("not-applicable");
+        }
+      } finally {
+        rmSync(root, { force: true, recursive: true });
       }
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
+    },
+  );
 
   it("verifies legacy auth import in the current shared owner without losing credentials or state", () => {
     const fixture = JSON.parse(

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -1087,70 +1087,90 @@ process.stdout.write(sessionDir + "\\n");
     },
   );
 
-  it("seeds recent ordered legacy session timestamps", () => {
-    const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-seed-"));
-    try {
-      const stateDir = join(root, "state");
-      const workspace = join(root, "workspace");
-      mkdirSync(stateDir, { recursive: true });
-      mkdirSync(workspace, { recursive: true });
+  it.each(["base", "sqlite-volume"])(
+    "seeds recent ordered session timestamps for %s",
+    (scenario) => {
+      const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-seed-"));
+      try {
+        const stateDir = join(root, "state");
+        const workspace = join(root, "workspace");
+        mkdirSync(stateDir, { recursive: true });
+        mkdirSync(workspace, { recursive: true });
 
-      const beforeSeed = Date.now();
-      execFileSync(process.execPath, [ASSERTIONS_PATH, "seed"], {
-        env: {
-          ...process.env,
-          OPENCLAW_STATE_DIR: stateDir,
-          OPENCLAW_TEST_WORKSPACE_DIR: workspace,
-          OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: "base",
-        },
-        stdio: "pipe",
-      });
-      const afterSeed = Date.now();
+        const beforeSeed = Date.now();
+        execFileSync(process.execPath, [ASSERTIONS_PATH, "seed"], {
+          env: {
+            ...process.env,
+            OPENCLAW_STATE_DIR: stateDir,
+            OPENCLAW_TEST_WORKSPACE_DIR: workspace,
+            OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: scenario,
+          },
+          stdio: "pipe",
+        });
+        const afterSeed = Date.now();
 
-      const sessions = JSON.parse(
-        readFileSync(join(stateDir, "sessions", "sessions.json"), "utf8"),
-      ) as Record<string, { sessionId?: unknown; updatedAt?: unknown }>;
-      const seededRows = [
-        sessions.main,
-        sessions["+15551234567"],
-        sessions["slack:channel:CUPGRADE"],
-      ];
-      expect(seededRows.map((row) => row?.sessionId)).toEqual([
-        "upgrade-main-session",
-        "upgrade-direct-session",
-        "upgrade-group-session",
-      ]);
+        const sessionsDir = join(
+          stateDir,
+          scenario === "sqlite-volume" ? "agents/main/sessions" : "sessions",
+        );
+        const otherStore = join(
+          stateDir,
+          scenario === "sqlite-volume" ? "sessions" : "agents/main/sessions",
+          "sessions.json",
+        );
+        expect(() => readFileSync(otherStore)).toThrow(/ENOENT/);
+        const sessions = JSON.parse(
+          readFileSync(join(sessionsDir, "sessions.json"), "utf8"),
+        ) as Record<string, { sessionId?: unknown; sessionFile?: unknown; updatedAt?: unknown }>;
+        const keys =
+          scenario === "sqlite-volume"
+            ? ["agent:main:main", "agent:main:+15551234567", "agent:main:slack:channel:cupgrade"]
+            : ["main", "+15551234567", "slack:channel:CUPGRADE"];
+        expect(Object.keys(sessions)).toEqual(keys);
+        const seededRows = keys.map((key) => sessions[key]);
+        expect(seededRows.map((row) => row?.sessionId)).toEqual([
+          "upgrade-main-session",
+          "upgrade-direct-session",
+          "upgrade-group-session",
+        ]);
 
-      const timestamps = seededRows.map((row) => row?.updatedAt);
-      for (const timestamp of timestamps) {
-        expect(typeof timestamp).toBe("number");
+        for (const row of seededRows) {
+          const transcriptPath = join(sessionsDir, `${String(row.sessionId)}.jsonl`);
+          expect(row.sessionFile).toBe(transcriptPath);
+          expect(JSON.parse(readFileSync(transcriptPath, "utf8")).id).toBe(row.sessionId);
+        }
+
+        const timestamps = seededRows.map((row) => row?.updatedAt);
+        for (const timestamp of timestamps) {
+          expect(typeof timestamp).toBe("number");
+        }
+        const [mainUpdatedAt, directUpdatedAt, groupUpdatedAt] = timestamps as [
+          number,
+          number,
+          number,
+        ];
+        expect(directUpdatedAt - mainUpdatedAt).toBe(100);
+        expect(groupUpdatedAt - mainUpdatedAt).toBe(200);
+        expect(mainUpdatedAt).toBeLessThan(directUpdatedAt);
+        expect(directUpdatedAt).toBeLessThan(groupUpdatedAt);
+
+        const dayMs = 24 * 60 * 60 * 1000;
+        const thirtyDaysMs = 30 * dayMs;
+        for (const [timestamp, offset] of [
+          [mainUpdatedAt, 0],
+          [directUpdatedAt, 100],
+          [groupUpdatedAt, 200],
+        ] as const) {
+          expect(timestamp).toBeGreaterThanOrEqual(beforeSeed - dayMs + offset);
+          expect(timestamp).toBeLessThanOrEqual(afterSeed - dayMs + offset);
+          expect(timestamp).toBeGreaterThan(afterSeed - thirtyDaysMs);
+          expect(timestamp).toBeLessThanOrEqual(afterSeed);
+        }
+      } finally {
+        rmSync(root, { force: true, recursive: true });
       }
-      const [mainUpdatedAt, directUpdatedAt, groupUpdatedAt] = timestamps as [
-        number,
-        number,
-        number,
-      ];
-      expect(directUpdatedAt - mainUpdatedAt).toBe(100);
-      expect(groupUpdatedAt - mainUpdatedAt).toBe(200);
-      expect(mainUpdatedAt).toBeLessThan(directUpdatedAt);
-      expect(directUpdatedAt).toBeLessThan(groupUpdatedAt);
-
-      const dayMs = 24 * 60 * 60 * 1000;
-      const thirtyDaysMs = 30 * dayMs;
-      for (const [timestamp, offset] of [
-        [mainUpdatedAt, 0],
-        [directUpdatedAt, 100],
-        [groupUpdatedAt, 200],
-      ] as const) {
-        expect(timestamp).toBeGreaterThanOrEqual(beforeSeed - dayMs + offset);
-        expect(timestamp).toBeLessThanOrEqual(afterSeed - dayMs + offset);
-        expect(timestamp).toBeGreaterThan(afterSeed - thirtyDaysMs);
-        expect(timestamp).toBeLessThanOrEqual(afterSeed);
-      }
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
-  });
+    },
+  );
 
   it("accepts the ACPX OpenClaw tools bridge scenario during seed", () => {
     const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-acpx-"));


### PR DESCRIPTION
## What Problem This Solves

Large session imports still rebuild the same search/history query builders for every event after the preceding importer optimizations. This adds avoidable CPU work as histories grow.

Related: #133742 (streamline importer streaming and identity writes), #133403 (update existing transcript watermarks directly).

## Why This Change Was Made

The transcript projection owner now prepares its FTS insert, active-history insert, and watermark writer once per synchronous append batch. The same insert factories serve full projection rebuilds. Moving forward indexing into its batch owner also removes repeated database/session arguments and duplicated row types.

The first watermark write still upserts; subsequent batch writes still update. Branch selection, dirty-state transitions, timestamps, write ordering, and synchronous transaction ownership are unchanged. No schema, index definition, retention, configuration, dependency, or persistence-semantic change.

Production LOC: **+104 / -121, net -17**. Upgrade harness: **+63 / -44, net +19**. Regression tests: **+167 / -124, net +43**, including table reformatting. Total: +45 across five files. The importer shrinks; harness growth repairs reproduced setup/coverage defects, and the tests protect those contracts. No new parser, raw-SQL path, or cache owner.

## User Impact

Imports and history-index rebuilds spend less CPU building identical SQL queries. Existing session data and search/history results remain unchanged. On Linux, 100,000-event imports improve from **4,950.4 ms to 3,841.9 ms (22.4%)**, with **24.2% less CPU**. Wide and branching histories improve about 19%; replay is approximately unchanged.

## Evidence

- **338 tests passed** in 10 files, including importer idempotence/source revalidation, session conformance, append/replacement, branch forks and cuts, eligibility/reconcile recovery, projection behavior, and Kysely binding/cache contracts:
  ```sh
  node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-import.test.ts src/config/sessions/session-accessor.sqlite-transcript-store.test.ts src/config/sessions/session-transcript-context-eligibility.test.ts src/config/sessions/session-accessor.test.ts src/infra/kysely-sync.test.ts src/config/sessions/session-accessor.conformance.test.ts src/config/sessions/session-accessor.parent-fork.test.ts src/config/sessions/session-accessor.sqlite-message-cut.test.ts src/config/sessions/session-transcript-projection-rebuild.test.ts src/commands/doctor-session-sqlite.test.ts
  ```
- Scoped type-aware lint and formatting passed:
  ```sh
  node scripts/run-oxlint.mjs --type-aware --tsconfig config/tsconfig/oxlint.core.json src/config/sessions/session-transcript-index.ts
  node_modules/.bin/oxfmt --check src/config/sessions/session-transcript-index.ts
  ```
- Independent Codex autoreview: scoped-clean through P3, including a fresh post-rebase pass supplied with the complete projection owner, import caller, shared executor, and binding/cache tests (confidence 0.96). Repeated markers, fresh values, error reporting, authorizers, and re-entry isolation checked.
- `node scripts/check-changed.mjs`: structural gates, all three Knip scans, and core graph boundary passed. Local core typecheck remains blocked by six pre-existing `Logger.attachTransport/settings` errors in unchanged `src/logging/logger.ts`; this worktree's shared dependency tree lacks `tslog/types/BaseLogger.d.ts`. Shared dependencies were not modified. Exact-head hosted checks are required before landing.
- Exploratory 20,000-event baseline/candidate runs preserved the full stored-data digest; local wall times were contended and are not used as a speed claim.

- Both unchanged **256 MiB heap stress tests passed on Linux** (batch 15.955s; deep 19.602s), bringing focused coverage to **340 passing tests** across 11 files. The local wide case passed, but the deep case hit its unchanged 180-second timeout while its child was observed in uninterruptible wait with about 21 seconds of CPU consumed. The failure did not reproduce on clean Linux; neither test nor timeout changed.
  ```sh
  node scripts/run-vitest.mjs src/commands/doctor-session-sqlite.memory.test.ts
  ```

### Linux performance and data parity

[Blacksmith Testbox run 33358682180](https://github.com/openclaw/openclaw/actions/runs/33358682180), Node 24.19.0 / SQLite 3.53.3, benchmark revision `0637c2537a71dd5c84d5e06974b7088542f5f3dd` versus baseline `ee036be7796396868bfa4851210e66c17bb2a25c`. The benchmark overrides only the changed projection owner; build metadata verifies that it is loaded, and all other sources/dependencies are identical. Fresh processes, alternating order, five pairs per shape. Fixture generation and parity checks are outside the import timer.

| Shape | Baseline median | Candidate median | Less time | Less CPU |
| --- | ---: | ---: | ---: | ---: |
| single | 8.9 ms | 8.5 ms | 4.5% | 4.7% |
| deep | 4950.4 ms | 3841.9 ms | 22.4% | 24.2% |
| wide | 545.0 ms | 441.2 ms | 19.1% | 16.0% |
| branch | 927.5 ms | 752.2 ms | 18.9% | 17.0% |
| replay | 162.8 ms | 162.5 ms | 0.2% | 7.4% |
| legacy-v1 | 534.2 ms | 447.1 ms | 16.3% | 17.6% |
| legacy-v2 | 480.2 ms | 372.9 ms | 22.3% | 22.5% |
| legacy-metadata-v1 | 262.1 ms | 181.4 ms | 30.8% | 27.7% |
| legacy-hooks-v2 | 401.4 ms | 312.5 ms | 22.1% | 17.1% |

All **45 pairs** have identical hashes of transcript JSON/timestamps, identities, session windows, active positions/eligibility, index state, and FTS rows. All five deep-history pairs favor the candidate. The SQL trace retains exactly **100,034 calls across 34 shapes** with no count differences, so the improvement removes query construction rather than storage work or validation.

Eight import-region Node CPU profiles cover deep, wide, legacy-v1, and legacy-hooks-v2 before/after. Deep Kysely self samples fall from **773.7 ms to zero sampled time** (not a claim of literally zero setup cost); wide falls 93.4 → 25.8 ms, legacy-v1 76.7 → 1.1 ms, hooks 52.4 → 1.1 ms. This supports the query-compilation attribution; headline timings come from unprofiled runs.

Peak RSS is mixed: deep median 479.8 → 444.4 MiB, but legacy-v2 374.7 → 404.6 MiB and hooks 380.0 → 390.8 MiB. No general memory-reduction claim. Both bounded-heap suites pass.

Local proof artifacts: `.artifacts/migration-cpu-profile/round13/` (harness, results, source hashes, commands, traces, eight profiles). Collected archive SHA-256: `d17cfe5e354041a2449a71183e1fbe562ef011d11d626b081e3a444edf20b9e2`.

### Packaged upgrade and fixture compatibility

The first build hit an existing Control UI CSS budget failure (54,809 bytes versus the unchanged 54,784-byte limit). The branch consumes the already-landed #133787 repair through a mechanical rebase onto `c2d1c256665119d7f441a4fe90cf3c29149983fd`. No authored CSS change or budget bypass. The importer is byte-identical to the benchmarked revision; its surrounding session/importer, Kysely and agent-state owners did not change in the rebase. A fresh independent review and 38 repeated focused tests passed.

Latest stable `2026.8.1` exposed four concrete harness defects during real packaged runs. The repairs are confined to test setup and capability detection:

- Modern config writes stamp explicit fleet ownership and reject the fixture's legacy default marker. The recipe removes it only for modern baselines; older releases keep the migration specimen and its ownership meaning.
- Modern strict Discord CLI input rejects nested DM policy fields. The recipe uses canonical `dmPolicy`/`allowFrom` there while preserving the historical spelling for older baselines, including v2026.2.1. Matrix's separate nested-DM contract is unchanged.
- Volume fixtures mixed the oldest shared-session layout with per-agent JSON. Latest stable leaves the original three sessions in the shared file during setup; candidate Doctor then merges and normalizes the volume store before SQLite archival. The volume seed now authors all sessions in per-agent JSON with canonical keys and matching transcript paths. Other scenarios keep the oldest shared-store specimen. This fixes the producer and leaves every baseline, SQLite and archive assertion unchanged.
- Modern packages publish the dedicated plugin-state-store runtime without declarations. The former declaration-only check silently skipped 512 plugin rows. The harness now selects that explicit runtime export; older packages retain their typed Doctor contract, and broken declared imports/constructors still fail.

Real published-CLI negative controls reproduce the setup errors. All 13 adapted config commands pass. The extended seed test fails before the producer repair and passes after, verifying both layouts, exact keys, transcript paths and absence of the other store. Both new SDK fault cases fail before and pass after. All **48 upgrade assertion tests** and **14 recipe tests** pass, bringing distinct focused coverage to **402 passing cases**, plus 38 post-rebase repeats. Scoped lint and formatting pass. Independent reviews through P3 found no actionable defects.

The corrected fixture also passes a complete small migration through the actual published 2026.8.1 CLI: 20 volume sessions, 90 events, 10 cron jobs and 512 plugin rows in schema 15, with every archive assertion intact. The previous large candidate run verified all canonical session/event, cron and plugin rows before revealing the seed/archive mismatch; it is recorded as failed, not counted as full upgrade success.

The full [Docker upgrade passed on worker 33364788103](https://github.com/openclaw/openclaw/actions/runs/33364788103), built from `8253ae205f6708391be1829d46e5e5912b790cb4`: **4,800 sessions, 1,227,946 events, 10,000 cron jobs and 512 plugin rows**. Automatic migration is asserted immediately after update and before standalone Doctor. All SQLite contents, original archive checks, pairing ownership and workspace data pass. Eight Gateway history samples (600 messages across two agents) match exactly after restart. Idempotence Doctor takes 42s against the unchanged 60s budget; startup 12s, health/readiness/status each 1s. The upgrade lane takes 551s; full build/run 955s. Collected proof archive SHA-256: `8565d0c9ba32f3264c5537452c47c5a7667324d3aff2a50b2e6f9b0ae09113e3`.

Reproduction:
```sh
OPENCLAW_TESTBOX=1 OPENCLAW_TESTBOX_REMOTE_RUN=1 OPENCLAW_DOCKER_ALL_LANES=published-upgrade-survivor OPENCLAW_DOCKER_ALL_LOG_DIR=.artifacts/docker-tests/migration-round13-deep OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPECS=2026.8.1 OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS=sqlite-volume OPENCLAW_UPGRADE_SURVIVOR_VOLUME_SESSIONS=4800 OPENCLAW_UPGRADE_SURVIVOR_VOLUME_EVENTS_PER_SESSION=257 OPENCLAW_UPGRADE_SURVIVOR_VOLUME_CRON_JOBS=10000 node scripts/test-docker-all.mjs
```

Limits: explicit candidate tarball, manual Gateway restart, and expected synthetic-plugin capability consent recovery. This proves automatic data migration during the package update, not unattended release-channel switching. Candidate identity guards and all budgets remain intact. All six task-owned Testbox leases are stopped.

Named follow-ups outside this importer/fixture change:
- The generic cached Docker rerun-command generator omits the source SHA/version/hash tuple required by its registry validator. Supplying it correctly rejects dirty synchronized source identity; this proof uses a fresh committed build.
- The published Discord reader normalizes shipped nested DM aliases, while strict CLI schema input rejects them first. Fresh modern setup uses canonical input; older upgrade coverage is preserved.

Final head: `e7b7fe776e30d037431e2588145b5a9cd28716a5`. Its only delta from the successful Docker build is a two-line test assertion/import fixing three TypeScript narrowing errors reported by hosted CI. The package and every harness file are byte-identical. Both affected test cases pass; review is clean through P3 (confidence 0.99). [Exact-head CI 33366135987 is green](https://github.com/openclaw/openclaw/actions/runs/33366135987), including test typechecking. The Docker proof is intentionally reused across this test-only change, rather than claiming the earlier build has the newer SHA.

Latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/133802#issuecomment-5474000718) reviewed this exact head at 07:02 UTC and found no actionable code defects. Its wait-for-green Rank-up move is satisfied. The automated SQLite-table warning is a false positive: `sqlite-volume-shared-state.mjs` selects an existing published SDK factory to seed synthetic test rows; there is no DDL, table definition, schema, index, retention, concurrency or production persistence-semantic change. The runtime SQL trace is unchanged.
