### PR TITLE
fix(ci): raise the boot CSS flat cap for the shipped themes

### DIFF
--- a/scripts/check-control-ui-performance.mts
+++ b/scripts/check-control-ui-performance.mts
@@ -41,8 +41,10 @@ const controlUiPerformanceBudgets = {
   // Composer multiline surface (stack #124301) legitimately grew boot CSS;
   // operator decision 2026-08-25 rejected boot splitting due to precedence risk.
   // 53.0 KiB was exhausted by organic growth (main sat at 99.94% by 2026-08-29);
-  // bumped with operator approval on PR #132054.
-  largestCssGzipBytes: 53.5 * KIB,
+  // bumped with operator approval on PR #132054. Bumped again to 54.0 KiB with
+  // operator approval 2026-08-31: #133593 + #133495 shipped four themes whose
+  // in-boot control styling crossed 53.5 KiB by 25 B only once both merged.
+  largestCssGzipBytes: 54 * KIB,
 } satisfies Record<string, number>;
 export const CONTROL_UI_PERFORMANCE_BUDGETS = Object.freeze(controlUiPerformanceBudgets);
 


### PR DESCRIPTION
## What Problem This Solves

Main is red on the Control UI performance gate: the boot CSS chunk measures 25 gzip bytes over the 53.5 KiB `largestCssGzipBytes` flat cap. #133593 (Manuscript/Rosé/Miami themes) and #133495 (CRT theme) each passed PR CI individually; the combined growth crossed the cap only after both merged — the classic pairwise-green/combined-red flat-cap breach.

## Why This Change Was Made

Operator-approved cap bump (2026-08-31, in-session) to 54.0 KiB, recorded with the same comment-trail convention as the prior bumps in `scripts/check-control-ui-performance.mts`. The growth is legitimate shipped product CSS; dieting 25 bytes out of theme styling would break again on the next theme, and lazy-loading theme CSS out of the boot chunk is a separate design decision the cap history already documents as operator-rejected once (precedence risk).

## User Impact

None — CI gate configuration only. Unblocks main and every PR behind the red gate.

## Evidence

`node scripts/ui.js build` on this branch: largest CSS 53.4–53.5 KiB against the 54.0 KiB limit, all budgets green, no violations. Pristine `origin/main` reproduces the failure (54,809 B vs 54,784 B cap) — verified in a detached checkout before this fix.
