### PR TITLE
docs(session): document the fixed main-session key

### DIFF
--- a/docs/channels/channel-routing.md
+++ b/docs/channels/channel-routing.md
@@ -32,7 +32,7 @@ Target-kind and service prefixes such as `channel:<id>`, `user:<id>`, `room:<id>
 
 Direct messages collapse to the agent's **main** session by default:
 
-- `agent:<agentId>:<mainKey>` (default: `agent:main:main`)
+- `agent:<agentId>:main` (for example: `agent:main:main`)
 
 `session.dmScope` controls DM collapsing: `main` (default) shares one main
 session, while `per-peer`, `per-channel-peer`, and `per-account-channel-peer`

--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -766,7 +766,7 @@ Key settings (see [/gateway/configuration](/gateway/configuration) for shared ch
 ## Routing and sessions
 
 - Session keys follow the standard agent format (see [/concepts/session](/concepts/session)):
-  - Direct messages share the main session (`agent:<agentId>:<mainKey>`).
+  - Direct messages share the main session (`agent:<agentId>:main`) by default.
   - Channel/group messages use conversation id:
     - `agent:<agentId>:msteams:channel:<conversationId>`
     - `agent:<agentId>:msteams:group:<conversationId>`

--- a/docs/concepts/main-session.md
+++ b/docs/concepts/main-session.md
@@ -13,9 +13,9 @@ lands in **one rolling conversation**: the main session. Ask something on your
 phone, follow up from your laptop, and the agent has the same context in both
 places. There is one brain, and this is where it thinks.
 
-Under the hood the main session is an ordinary session with the default key
-`agent:<agentId>:main` (for example `agent:main:main`; `session.mainKey` can
-change the final segment). What makes it special
+Under the hood the main session is an ordinary session with the canonical key
+`agent:<agentId>:main` (for example `agent:main:main`). The suffix is fixed;
+custom `session.mainKey` values are ignored. What makes it special
 is that the default DM scope collapses all direct messages into it, and that
 the rest of the system treats it as the agent's root: heartbeats wake it,
 background work reports back to it, and activity elsewhere flows up to it.

--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -62,7 +62,7 @@ when personas must not share compiled wiki knowledge.
 If you configure nothing, OpenClaw runs one agent:
 
 - `agentId` defaults to `main`.
-- Sessions key as `agent:main:<mainKey>` (default `mainKey` is `main`).
+- The main session key is `agent:main:main`.
 - Workspace defaults to `<stateDir>/workspace` (`~/.openclaw/workspace` for the default install and `~/.openclaw-<profile>/workspace` for a named profile).
 - State defaults to `~/.openclaw/agents/main/agent`.
 
@@ -247,7 +247,7 @@ Channels supporting multiple accounts: `discord`, `feishu`, `googlechat`, `imess
 - `agentId`: one "brain" (workspace, per-agent auth, per-agent session store).
 - `accountId`: one channel account instance (e.g. WhatsApp account `personal` vs `biz`).
 - `binding`: routes inbound messages to an `agentId` by `(channel, accountId, peer)`, and optionally guild/team ids.
-- Direct chats collapse to `agent:<agentId>:<mainKey>` (per-agent "main"; see `session.mainKey`).
+- Direct chats collapse to `agent:<agentId>:main` by default (the per-agent [main session](/concepts/main-session)).
 
 ## Platform examples
 

--- a/docs/gateway/config-agents.md
+++ b/docs/gateway/config-agents.md
@@ -1284,7 +1284,6 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
       suggest: true,
       drafts: true,
     },
-    mainKey: "main", // canonical main-session suffix
     sendPolicy: {
       rules: [{ action: "deny", match: { channel: "discord", chatType: "group" } }],
       default: "allow",
@@ -1310,7 +1309,7 @@ See [Multi-Agent Sandbox & Tools](/tools/multi-agent-sandbox-tools) for preceden
 - **`reset`**: primary reset policy. `none` disables automatic reset and is the default; compaction bounds active context instead. `daily` resets at `atHour` local time; `idle` resets after `idleMinutes`. When both configured, whichever expires first wins. `/new` and `/reset` remain available in every mode. Daily reset freshness uses the session row's `sessionStartedAt`; idle reset freshness uses `lastInteractionAt`. Background/system-event writes such as heartbeat, cron wakeups, exec notifications, and gateway bookkeeping can update `updatedAt`, but they do not keep daily/idle sessions fresh.
   - **`resetByType`**: per-type overrides (`direct`, `group`, `thread`). Doctor migrates legacy `dm` entries to `direct`; the schema rejects `dm`.
 - **`resetByChannel`**: per-channel reset overrides keyed by provider/channel id. When the session's channel has a matching entry, it wins outright over `resetByType`/`reset` for that session. Use only when one channel needs reset behavior different from the type-level policy.
-- **`mainKey`**: canonical main-session suffix. Keep it stable unless you intentionally need a custom main-session key.
+- **`mainKey`**: accepted but ignored. The per-agent main-session suffix is always `main`; omit this field. Global session scope uses `global` instead.
 - **`sendPolicy`**: match by `channel`, `chatType` (`direct|group|channel`, with legacy `dm` alias), `keyPrefix`, or `rawKeyPrefix`. First deny wins.
 - **`maintenance`**: session-store cleanup + retention controls.
   - `mode`: `enforce` applies cleanup and is the default; `warn` emits warnings only.

--- a/docs/gateway/heartbeat.md
+++ b/docs/gateway/heartbeat.md
@@ -308,7 +308,7 @@ Heartbeat configuration is strict: only the fields listed above are accepted. Ac
 
 <AccordionGroup>
   <Accordion title="Session and target routing">
-    - Heartbeats run in the agent's main session by default (`agent:<id>:<mainKey>`), or `global` when `session.scope = "global"`. Set `session` to override to a specific channel session (Discord/WhatsApp/etc.).
+    - Heartbeats run in the agent's main session by default (`agent:<id>:main`), or `global` when `session.scope = "global"`. Set `session` to override to a specific channel session (Discord/WhatsApp/etc.).
     - `session` only affects the run context; delivery is controlled by `target` and `to`.
     - The default `owner` target chooses an explicitly configured owner identity. It reuses the exact account/thread only when the session's last route is a direct chat to that owner.
     - A wake that carries a channel and recipient uses that named origin before owner discovery. This event destination can be a group because it is explicit, not inferred.

--- a/docs/gateway/tools-invoke-http-api.md
+++ b/docs/gateway/tools-invoke-http-api.md
@@ -65,7 +65,7 @@ Fields:
 - `tool` / `name` (string, required): tool name to invoke. `name` takes precedence if both are sent.
 - `action` (string, optional): merged into `args.action` if the tool schema supports an `action` property and `args` did not already set one.
 - `args` (object, optional): tool-specific arguments.
-- `sessionKey` (string, optional): target session key. If omitted or `"main"`, the Gateway uses the configured main session key (honors `session.mainKey` and the default agent, or `global` in global session scope).
+- `sessionKey` (string, optional): target session key. If omitted or `"main"`, the Gateway resolves the agent's canonical main session (`agent:<agentId>:main`, or `global` in global session scope). Custom `session.mainKey` values are ignored.
 - `agentId` (string, optional): resolves the session key for that agent. Errors with `400` if it conflicts with an explicit `sessionKey` that already maps to a different agent.
 - `idempotencyKey` (string, optional): used to derive a stable tool-call id for the invocation.
 - `dryRun` (boolean, optional): reserved for future use; currently ignored.

--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -246,16 +246,16 @@ booking, IVR, or Google Meet bridge flows where the same phone number may
 represent different meetings.
 
 Set `sessionScope: "main"` to route every call into the configured agent's main
-session. This honors the core `session.mainKey` setting and resolves to
-`global` when core `session.scope` is `"global"`. Raw call turns then share
-history with the agent's primary session, so use this only when that shared
-context is intentional.
+session, `agent:<agentId>:main`, or `global` when core `session.scope` is
+`"global"`. Custom core `session.mainKey` values are ignored. Raw call turns
+then share history with the agent's primary session, so use this only when
+that shared context is intentional.
 
 For `per-phone` and `per-call`, Voice Call stores generated session keys under
 the configured agent namespace (`agent:<agentId>:voice:*`). Raw explicit
 integration keys resolve into the same namespace: a canonical
 `agent:<configuredAgentId>:*` key keeps that owner and honors core
-`session.mainKey`/global-scope aliasing; foreign or malformed `agent:*` input
+main-session/global-scope aliasing; foreign or malformed `agent:*` input
 is scoped as an opaque key under the configured agent; `global` and `unknown`
 remain global sentinels.
 

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -120,7 +120,7 @@ A `sessionKey` identifies which conversation bucket you are in (routing + isolat
 
 | Pattern                      | Example                                                     |
 | ---------------------------- | ----------------------------------------------------------- |
-| Main/direct chat (per agent) | `agent:<agentId>:<mainKey>` (default `main`)                |
+| Main/direct chat (per agent) | `agent:<agentId>:main`                                      |
 | Group                        | `agent:<agentId>:<channel>:group:<id>`                      |
 | Room/channel (Discord/Slack) | `agent:<agentId>:<channel>:channel:<id>` or `...:room:<id>` |
 | Cron                         | `cron:<job.id>`                                             |

--- a/docs/web/urls.md
+++ b/docs/web/urls.md
@@ -59,15 +59,15 @@ the builder inserts `~key` before it, for example
 and appears only when the unescaped form would be ambiguous.
 
 The reserved single-segment literal rest names are `main`, `global`, `boot`,
-and `sessions`. The configured `session.mainKey` joins that set at runtime.
-Exactly one segment after the agent id is literal when it is reserved or does
-not contain a valid short id; otherwise it is a short reference. Two or more
-segments after the agent id are always literal.
+and `sessions`. Exactly one segment after the agent id is literal when it is
+reserved or does not contain a valid short id; otherwise it is a short reference.
+Two or more segments after the agent id are always literal.
 
-Only the configured `session.mainKey` collapses to the agent-only main-session
-path. With `session.mainKey: "workspace"`, `agent:research:workspace` becomes
-`/chat/research`, while the distinct key `agent:research:main` remains the
-literal path `/chat/research/main`.
+The canonical main session `agent:research:main` uses the agent-only path
+`/chat/research`. Custom `session.mainKey` values are ignored by config loading;
+setting it to `"workspace"` does not make `/chat/research/workspace` a main-session
+route. It follows ordinary session lookup; if no existing session matches, it shows
+**Session not found**.
 
 ### Stability contract
 

--- a/docs/web/webchat.md
+++ b/docs/web/webchat.md
@@ -80,7 +80,7 @@ Related global options:
   Serve identity headers when enabled.
 - `gateway.auth.mode: "trusted-proxy"`: reverse-proxy auth for browser clients behind an identity-aware **non-loopback** proxy source (see [Trusted Proxy Auth](/gateway/trusted-proxy-auth)).
 - `gateway.remote.url`, `gateway.remote.token`, `gateway.remote.password`: remote gateway target.
-- `session.*`: session storage and main key defaults.
+- `session.*`: session routing and storage.
 
 ## Related
 

--- a/extensions/voice-call/README.md
+++ b/extensions/voice-call/README.md
@@ -105,7 +105,7 @@ Notes:
 - Runtime accepts canonical config only. If older configs still use `provider: "log"`, `twilio.from`, or legacy `streaming.*` OpenAI keys, run `openclaw doctor --fix` to rewrite them.
 - advanced webhook, streaming, and tunnel notes: `https://docs.openclaw.ai/plugins/voice-call`
 - `responseModel` is optional. When unset, voice responses use the runtime default model.
-- `sessionScope` defaults to `per-phone`, preserving caller memory across calls. Use `per-call` for reception, booking, IVR, and bridge flows where each carrier call should start fresh. Use `main` to share the configured agent's main session, honoring core `session.mainKey` and global scope.
+- `sessionScope` defaults to `per-phone`, preserving caller memory across calls. Use `per-call` for reception, booking, IVR, and bridge flows where each carrier call should start fresh. Use `main` to share the configured agent's main session (`agent:<agentId>:main`, or `global` when core `session.scope` is `"global"`). Custom core `session.mainKey` values are ignored.
 - `realtime.consultThinkingLevel` is optional. When set, it overrides the thinking level used by the model behind realtime `openclaw_agent_consult` calls.
 - `realtime.consultFastMode` is optional. When set, it toggles fast mode for realtime `openclaw_agent_consult` calls.
 

--- a/src/config/schema.help.automation.ts
+++ b/src/config/schema.help.automation.ts
@@ -33,7 +33,7 @@ export const AUTOMATION_FIELD_HELP: Record<string, string> = {
   "session.store":
     "Sets the session storage file path used to persist session records across restarts. Use an explicit path only when you need custom disk layout, backup routing, or mounted-volume storage.",
   "session.mainKey":
-    'Overrides the canonical main session key used for continuity when dmScope or routing logic points to "main". Use a stable value only if you intentionally need custom session anchoring.',
+    'Accepted but ignored: the per-agent main session suffix is always "main". Omit this field; global session scope uses "global" instead.',
   "session.sendPolicy":
     "Controls cross-session send permissions using allow/deny rules evaluated against channel, chatType, and key prefixes. Use this to fence where session tools can deliver messages in complex environments.",
   "session.sendPolicy.default":


### PR DESCRIPTION
Related: #41790 (custom main-session feature request), #42317 (closed, unmerged custom-key implementation).

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer branch and is available for maintainer edits.

</details>

## What Problem This Solves

Resolves a problem where operators following the main-session documentation and config help expected `session.mainKey: "workspace"` to rename their primary session, but the loaded Gateway still used `agent:<agentId>:main`. Opening the corresponding nonexistent workspace session correctly produced **Session not found**.

The contradiction also appeared in the config reference, URL guide, channel/multi-agent examples, heartbeat, tools-invoke, and Voice Call documentation. The sandbox guide already documented the fixed suffix correctly.

## Why This Change Was Made

The maintainer explicitly selected the existing fixed-main contract after reviewing current source, both config materialization owners, loaded-config evidence, history, and stable tags. This patch reconciles 11 documentation pages, the packaged Voice Call README, and the config-help string, removes the ineffective field from the recommended config example, and explains ordinary missing-session lookup in the URL guide. The packaged README correction addresses ClawSweeper's review finding and rank-up move.

`applySessionDefaults` and the reduced Gateway dispatch reader both force supplied values to `main`; the same behavior exists in stable `v2026.7.1`. History is not an unambiguous rejection of customization: the January 3 fixed-main change was deliberate, while January 6 multi-agent documentation promised custom support again without removing the load-time coercion. This PR resolves the documentation contract, not the separate feature request.

Restoring custom keys would activate previously ignored settings and change routing/persisted identity. That requires a separate accepted migration policy. This patch deliberately leaves config schema acceptance, coercion/warnings, helper APIs/tests, routing, persistence, global scope, and missing-session checks unchanged.

## User Impact

Operators are told to omit `session.mainKey`: the per-agent main-session suffix is always `main`; global session scope continues to use `global`. Existing configuration files remain accepted, and no sessions are renamed, migrated, or newly created.

No new dependency, configuration option, schema/protocol change, or executable runtime behavior is introduced. Production-source LOC: **+1/-1 (net 0)**, solely help text. Tests: **+0/-0**. Docs: **+27/-28**.

## Evidence

A fresh synthetic home/config fixture exercised the production `createConfigIO` full validation/load/snapshot path and `readGatewayDispatchConfig`, with plugins disabled and no operator state or credentials. The source file remained unchanged after reads.

| Authored `mainKey` | Direct helper input | File load, runtime snapshot, dispatch |
| --- | --- | --- |
| omitted / `main` / empty | `agent:main:main` | `agent:main:main` |
| `workspace` / ` Workspace ` | `agent:main:workspace` | `agent:main:main` |

A second agent similarly loaded as `agent:work:main`. Direct-input helper/migration tests are intentionally distinguished from actual loaded-config behavior; even some Gateway integration fixtures bypass normal materialization.

Previously captured isolated Gateway evidence at baseline `706965ab953b63c2634ba3254986ce269dfe6b86` recorded connected hello defaults `mainKey: main`, `mainSessionKey: agent:main:main`, and `scope: per-sender` on `/chat/main/workspace`. This is prior live behavior evidence, not a claim that the documentation patch changed or reran that live flow.

Validation on the candidate patch:

- `node scripts/run-vitest.mjs src/config/schema.help.quality.test.ts src/config/gateway-dispatch-config.test.ts` — **26 passed**.
- `node scripts/run-vitest.mjs src/commands/doctor-session-canonical-keys.test.ts -t 'rehomes matching in-store transcript generations|replaces same-store membership|rehomes suggestions from a stale same-store alias'` — **3 passed**, 12 intentionally filtered; direct-input migration preservation only.
- `node_modules/.bin/oxfmt --check` with the original 12 changed paths plus the packaged README — passed.
- `node scripts/check-docs-mdx.mjs` with the 11 changed docs — passed, zero errors; rerun for `docs/plugins/voice-call.md extensions/voice-call/README.md` after the review correction also passed.
- `node scripts/docs-link-audit.mjs` — **7,209 internal links**, zero broken links.
- `git diff --check` — passed.

No full build, broad suite, new browser capture, or provider/channel live run was needed for this documentation/static-help correction; no UI rendering, protocol, or runtime flow is changed. Fresh review and exact-head CI results are recorded in the landing proof comment.

A separate local follow-up tracks the unrelated stale legacy-storage migration paragraph in the channel-routing guide; it is not mixed into this main-key reconciliation.
