### PR TITLE
fix(cli): reject malformed approval grant lifetimes

### DIFF
--- a/src/cli/exec-approvals-cli.pending-resolve.test.ts
+++ b/src/cli/exec-approvals-cli.pending-resolve.test.ts
@@ -164,60 +164,73 @@ describe("exec approvals pending and resolve CLI", () => {
     expect(call?.[2]).toEqual({ limit: 25 });
   });
 
-  it.each(["10junk", "1.5", "0", "-1"])(
-    "rejects malformed approval grant lifetime before resolving (%s)",
+  it.each(["10junk", "1.5", "1e3", "", "0", "-1", "3651"])(
+    "rejects an invalid grant lifetime without resolving the approval (%s)",
     async (expiresInDays) => {
-      callGatewayFromCli.mockResolvedValueOnce(pendingApprovalSnapshot({ id: "approval-expiry" }));
+      callGatewayFromCli.mockImplementation(async (method: string) =>
+        method === "approval.get"
+          ? pendingApprovalSnapshot({ id: "lifetime-invalid" })
+          : {
+              applied: true,
+              approval: terminalApprovalSnapshot({
+                id: "lifetime-invalid",
+                decision: "allow-always",
+              }),
+            },
+      );
 
       await expect(
         runApprovalsCommand([
           "approvals",
           "resolve",
-          "approval-expiry",
+          "lifetime-invalid",
           "allow-always",
           "--expires-in-days",
           expiresInDays,
         ]),
       ).rejects.toThrow("__exit__:1");
 
-      expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
-      expect(runtimeErrors[0]).toContain(
+      expect(runtimeErrors).toEqual([
         "--expires-in-days must be a whole number of days between 1 and 3650.",
-      );
+      ]);
+      expect(callGatewayFromCli.mock.calls.map(([method]) => method)).toEqual(["approval.get"]);
     },
   );
 
-  it("forwards a valid approval grant lifetime as a number", async () => {
-    callGatewayFromCli.mockImplementation(async (method: string) => {
-      if (method === "approval.get") {
-        return pendingApprovalSnapshot({ id: "approval-expiry-valid" });
-      }
-      return {
-        applied: true,
-        approval: terminalApprovalSnapshot({
-          id: "approval-expiry-valid",
-          decision: "allow-always",
-        }),
-      };
-    });
+  it.each([undefined, "1", "30", "3650"])(
+    "preserves the numeric or absent grant lifetime (%s)",
+    async (expiresInDays) => {
+      callGatewayFromCli.mockImplementation(async (method: string) =>
+        method === "approval.get"
+          ? pendingApprovalSnapshot({ id: "lifetime-valid" })
+          : {
+              applied: true,
+              approval: terminalApprovalSnapshot({
+                id: "lifetime-valid",
+                decision: "allow-always",
+              }),
+            },
+      );
 
-    await runApprovalsCommand([
-      "approvals",
-      "resolve",
-      "approval-expiry-valid",
-      "allow-always",
-      "--expires-in-days",
-      "30",
-      "--json",
-    ]);
+      await runApprovalsCommand([
+        "approvals",
+        "resolve",
+        "lifetime-valid",
+        "allow-always",
+        ...(expiresInDays === undefined ? [] : ["--expires-in-days", expiresInDays]),
+        "--json",
+      ]);
 
-    expect(callGatewayFromCli.mock.calls[1]?.[2]).toEqual({
-      id: "approval-expiry-valid",
-      kind: "exec",
-      decision: "allow-always",
-      grantExpiresInDays: 30,
-    });
-  });
+      expect(callGatewayFromCli.mock.calls[1]?.[0]).toBe("approval.resolve");
+      expect(callGatewayFromCli.mock.calls[1]?.[2]).toEqual({
+        id: "lifetime-valid",
+        kind: "exec",
+        decision: "allow-always",
+        ...(expiresInDays === undefined ? {} : { grantExpiresInDays: Number(expiresInDays) }),
+      });
+      expect(writtenJson()).toMatchObject({ applied: true, alreadyResolved: false });
+    },
+  );
 
   it("renders pending approvals from all three approval kinds", async () => {
     const now = Date.now();

--- a/src/cli/exec-approvals-cli.pending-resolve.test.ts
+++ b/src/cli/exec-approvals-cli.pending-resolve.test.ts
@@ -164,6 +164,61 @@ describe("exec approvals pending and resolve CLI", () => {
     expect(call?.[2]).toEqual({ limit: 25 });
   });
 
+  it.each(["10junk", "1.5", "0", "-1"])(
+    "rejects malformed approval grant lifetime before resolving (%s)",
+    async (expiresInDays) => {
+      callGatewayFromCli.mockResolvedValueOnce(pendingApprovalSnapshot({ id: "approval-expiry" }));
+
+      await expect(
+        runApprovalsCommand([
+          "approvals",
+          "resolve",
+          "approval-expiry",
+          "allow-always",
+          "--expires-in-days",
+          expiresInDays,
+        ]),
+      ).rejects.toThrow("__exit__:1");
+
+      expect(callGatewayFromCli).toHaveBeenCalledTimes(1);
+      expect(runtimeErrors[0]).toContain(
+        "--expires-in-days must be a whole number of days between 1 and 3650.",
+      );
+    },
+  );
+
+  it("forwards a valid approval grant lifetime as a number", async () => {
+    callGatewayFromCli.mockImplementation(async (method: string) => {
+      if (method === "approval.get") {
+        return pendingApprovalSnapshot({ id: "approval-expiry-valid" });
+      }
+      return {
+        applied: true,
+        approval: terminalApprovalSnapshot({
+          id: "approval-expiry-valid",
+          decision: "allow-always",
+        }),
+      };
+    });
+
+    await runApprovalsCommand([
+      "approvals",
+      "resolve",
+      "approval-expiry-valid",
+      "allow-always",
+      "--expires-in-days",
+      "30",
+      "--json",
+    ]);
+
+    expect(callGatewayFromCli.mock.calls[1]?.[2]).toEqual({
+      id: "approval-expiry-valid",
+      kind: "exec",
+      decision: "allow-always",
+      grantExpiresInDays: 30,
+    });
+  });
+
   it("renders pending approvals from all three approval kinds", async () => {
     const now = Date.now();
     callGatewayFromCli.mockImplementation(async (method: string) => {

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -750,7 +750,10 @@ async function resolvePendingApproval(
   }
 
   const expiresInDaysRaw =
-    opts.expiresInDays === undefined ? undefined : Number.parseInt(opts.expiresInDays, 10);
+    opts.expiresInDays === undefined ? undefined : parseStrictPositiveInteger(opts.expiresInDays);
+  if (opts.expiresInDays !== undefined && expiresInDaysRaw === undefined) {
+    exitWithError("--expires-in-days must be a whole number of days between 1 and 3650.");
+  }
   if (
     expiresInDaysRaw !== undefined &&
     (!Number.isInteger(expiresInDaysRaw) || expiresInDaysRaw < 1 || expiresInDaysRaw > 3650)

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -749,18 +749,11 @@ async function resolvePendingApproval(
     }
   }
 
-  const expiresInDaysRaw =
-    opts.expiresInDays === undefined ? undefined : parseStrictPositiveInteger(opts.expiresInDays);
-  if (opts.expiresInDays !== undefined && expiresInDaysRaw === undefined) {
+  const expiresInDays = parseStrictPositiveInteger(opts.expiresInDays);
+  if (opts.expiresInDays !== undefined && (expiresInDays === undefined || expiresInDays > 3650)) {
     exitWithError("--expires-in-days must be a whole number of days between 1 and 3650.");
   }
-  if (
-    expiresInDaysRaw !== undefined &&
-    (!Number.isInteger(expiresInDaysRaw) || expiresInDaysRaw < 1 || expiresInDaysRaw > 3650)
-  ) {
-    exitWithError("--expires-in-days must be a whole number of days between 1 and 3650.");
-  }
-  if (expiresInDaysRaw !== undefined && decision !== "allow-always") {
+  if (expiresInDays !== undefined && decision !== "allow-always") {
     exitWithError("--expires-in-days only applies to allow-always.");
   }
   const result = (await callGatewayFromCli(
@@ -770,7 +763,7 @@ async function resolvePendingApproval(
       id,
       kind: current.presentation.kind,
       decision,
-      ...(expiresInDaysRaw !== undefined ? { grantExpiresInDays: expiresInDaysRaw } : {}),
+      ...(expiresInDays !== undefined ? { grantExpiresInDays: expiresInDays } : {}),
     },
     approvalCallOptions,
   )) as ApprovalResolveResult;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `approvals resolve --expires-in-days` silently accepted a numeric prefix: `10junk` became 10 days and `1.5` became 1 day. The operator could resolve an approval with a lifetime different from the text supplied.

## Why This Change Was Made

The CLI now uses the shared strict positive-integer parser already used by the standing-grant list command. One validation block rejects a present invalid value or a value above the existing 3650-day limit. The parser already establishes positivity and integrality, so their duplicate checks are removed. Omitted lifetimes still defer to the existing Gateway behavior, and valid lifetimes are forwarded as numbers.

## User Impact

Malformed, fractional, empty, non-positive, and out-of-range values produce the existing whole-day validation error before `approval.resolve`. Scripts that relied on numeric-prefix coercion must pass the intended whole-day value explicitly. The existing 1–3650 range, approval decisions, grant ownership, configuration defaults, and Gateway protocol remain unchanged.

## Evidence

- Trusted main `8655892bb20` and stable `v2026.8.1` contain the permissive parser. Three new tests failed on the baseline because `10junk`, `1.5`, and `1e3` unexpectedly reached resolution; the other 25 cases passed.
- `node scripts/run-vitest.mjs src/cli/exec-approvals-cli.pending-resolve.test.ts packages/normalization-core/src/number-coercion.test.ts` passed all 58 tests after the fix. The CLI cases cover malformed inputs, the lower and upper bounds, a normal 30-day value, and omission of the override. Existing pending-list, decision, identity, and resolution cases remain covered.
- Before the fix, the actual built CLI sent `10junk` and `1.5` to an isolated loopback Gateway and both pending approvals became `allowed`. A valid `30` control also resolved successfully.
- After the fix, the same real CLI rejected both malformed inputs with exit code 1 and `--expires-in-days must be a whole number of days between 1 and 3650.` Follow-up `approval.get` and `exec.approval.list` calls confirmed each approval remained pending and listed. The valid `30` control still resolved successfully.
- Both runtime builds passed. The live proof used synthetic pending requests with no command consumer or automation source; no command ran and no standing grant was minted. The proof verifies the changed CLI/resolution boundary, while numeric forwarding is asserted in the CLI tests. All temporary Gateway state was removed with zero cleanup errors.
- Full two-file Codex autoreview completed with no accepted/actionable findings. The complete changed-scope repository check passed, including types, lint, formatting, unused-export and owner-boundary guards. Published-head CI remains required before merge.

Representative command, using only an isolated test Gateway:

```sh
node dist/entry.js approvals resolve <synthetic-approval-id> allow-always --expires-in-days 10junk --json --url <loopback-url> --token <redacted>
```

## Owner and Scope

The CLI owns parsing operator text before it calls the unified approval resolver. The Gateway already validates `grantExpiresInDays` as an integer from 1 through 3650 and retains ownership of approval transitions and frozen grant terms. This change fixes the malformed value at its producer without changing those contracts.

The permissive block was introduced by [de12e0a06c1b](https://github.com/openclaw/openclaw/commit/de12e0a06c1b1f3300823c001607ad3608edcc61); the raw parent and patch were checked directly. The sibling grant-list parser already uses the strict helper following [#133361](https://github.com/openclaw/openclaw/pull/133361).

Production: `+4/-8` (net −4). Tests: `+68/-0`. The latest ClawSweeper suggestion to consolidate redundant validation is applied. No new dependency, option, environment variable, auth policy, protocol, schema, or persistence behavior.

Thanks @qingminglong for the original fix and reproduction.


Maintainer-reviewed head: `374502a71e3c7053834865c2ff5ca90b7d1fa2a2`. Contributor credit is preserved.

Exact-head CI exposed five 120-second subprocess timeouts in the existing Vitest worker-artifact transform suite. Investigation is in progress; this PR will remain open until the required gate passes. No timeout has been increased.
