### PR TITLE
fix(update): keep persisted and printed completion durations consistent

### DIFF
--- a/src/cli/update-cli/update-command-post-update.test.ts
+++ b/src/cli/update-cli/update-command-post-update.test.ts
@@ -104,6 +104,7 @@ type FinishUpdateParams = Parameters<typeof finishUpdate>[0];
 const stdinIsTTYDescriptor = Object.getOwnPropertyDescriptor(process.stdin, "isTTY");
 
 afterEach(() => {
+  vi.restoreAllMocks();
   vi.unstubAllEnvs();
   if (stdinIsTTYDescriptor) {
     Object.defineProperty(process.stdin, "isTTY", stdinIsTTYDescriptor);
@@ -164,18 +165,24 @@ function createManagedServiceIdentityFixture() {
   };
 }
 
-async function finishSuccessfulPackageSwitch(params: {
-  previousRoot: string;
-  packageRoot: string;
-  restartEnvironment?: NodeJS.ProcessEnv;
-  json?: boolean;
-  sealed?: boolean;
-  updateMode?: UpdateRunResult["mode"];
-  stoppedForUpdate?: boolean;
-  windowsTaskAutoStartRecovery?: NonNullable<
-    FinishUpdateParams["preManagedServiceStop"]
-  >["windowsTaskAutoStartRecovery"];
-}): Promise<void> {
+async function finishSuccessfulPackageSwitch(
+  params: {
+    previousRoot: string;
+    packageRoot: string;
+    restartEnvironment?: NodeJS.ProcessEnv;
+    json?: boolean;
+    sealed?: boolean;
+    updateMode?: UpdateRunResult["mode"];
+    stoppedForUpdate?: boolean;
+    windowsTaskAutoStartRecovery?: NonNullable<
+      FinishUpdateParams["preManagedServiceStop"]
+    >["windowsTaskAutoStartRecovery"];
+  } = {
+    previousRoot: "/tmp/openclaw-update",
+    packageRoot: "/tmp/openclaw-update",
+    restartEnvironment: process.env,
+  },
+): Promise<void> {
   await finishUpdate({
     result: {
       status: "ok",
@@ -258,11 +265,7 @@ describe("successful update finalization ordering", () => {
 
     let failure: unknown;
     try {
-      await finishSuccessfulPackageSwitch({
-        previousRoot: "/tmp/openclaw-update",
-        packageRoot: "/tmp/openclaw-update",
-        restartEnvironment: process.env,
-      });
+      await finishSuccessfulPackageSwitch();
     } catch (err) {
       failure = err;
     }
@@ -312,11 +315,7 @@ describe("successful update finalization ordering", () => {
     });
     mocks.ensureCompletionCache.mockResolvedValueOnce(false);
 
-    await finishSuccessfulPackageSwitch({
-      previousRoot: "/tmp/openclaw-update",
-      packageRoot: "/tmp/openclaw-update",
-      restartEnvironment: process.env,
-    });
+    await finishSuccessfulPackageSwitch();
 
     const output = vi.mocked(defaultRuntime.log).mock.calls.flat().map(String).join("\n");
     expect(output).toContain("completion cache generation failed");
@@ -348,11 +347,7 @@ describe("successful update finalization ordering", () => {
   it("skips interactive completion in non-TTY mode", async () => {
     Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false });
 
-    await finishSuccessfulPackageSwitch({
-      previousRoot: "/tmp/openclaw-update",
-      packageRoot: "/tmp/openclaw-update",
-      restartEnvironment: process.env,
-    });
+    await finishSuccessfulPackageSwitch();
 
     expect(mocks.checkCompletionStatus).not.toHaveBeenCalled();
     expect(mocks.ensureCompletionCache).not.toHaveBeenCalled();
@@ -363,11 +358,7 @@ describe("successful update finalization ordering", () => {
     Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
     mocks.restartService.mockResolvedValueOnce(false);
 
-    await finishSuccessfulPackageSwitch({
-      previousRoot: "/tmp/openclaw-update",
-      packageRoot: "/tmp/openclaw-update",
-      restartEnvironment: process.env,
-    });
+    await finishSuccessfulPackageSwitch();
 
     expect(mocks.printResult).toHaveBeenCalledOnce();
     expect(mocks.printResult).toHaveBeenCalledWith(
@@ -383,7 +374,7 @@ describe("successful update finalization ordering", () => {
 
   it("reports elapsed time through restart and shell completion refresh", async () => {
     let now = 1_000;
-    const clock = vi.spyOn(Date, "now").mockImplementation(() => now);
+    vi.spyOn(Date, "now").mockImplementation(() => now);
     Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: true });
     mocks.restartService.mockImplementationOnce(async () => {
       now += 200;
@@ -393,21 +384,18 @@ describe("successful update finalization ordering", () => {
       now += 300;
       return { shell: "zsh", profileInstalled: true, cacheExists: true, usesSlowPattern: false };
     });
-    try {
-      await finishSuccessfulPackageSwitch({
-        previousRoot: "/tmp/openclaw-update",
-        packageRoot: "/tmp/openclaw-update",
-        restartEnvironment: process.env,
+    mocks.writeSentinel
+      .mockImplementationOnce(async () => undefined)
+      .mockImplementationOnce(async () => {
+        now += 100;
       });
+    await finishSuccessfulPackageSwitch();
 
-      expect(mocks.printResult).toHaveBeenCalledOnce();
-      expect(mocks.printResult.mock.lastCall?.[0]).toMatchObject({ status: "ok", durationMs: 500 });
-      expect(mocks.writeSentinel.mock.lastCall?.[0].result).toEqual(
-        mocks.printResult.mock.lastCall?.[0],
-      );
-    } finally {
-      clock.mockRestore();
-    }
+    expect(mocks.printResult).toHaveBeenCalledOnce();
+    expect(mocks.printResult.mock.lastCall?.[0]).toMatchObject({ status: "ok", durationMs: 500 });
+    expect(mocks.writeSentinel.mock.lastCall?.[0].result).toEqual(
+      mocks.printResult.mock.lastCall?.[0],
+    );
   });
 
   it("reports Windows autostart recovery failure before exiting", async () => {
@@ -702,11 +690,7 @@ describe("successful update finalization ordering", () => {
         },
       });
 
-      await finishSuccessfulPackageSwitch({
-        previousRoot: "/tmp/openclaw-update",
-        packageRoot: "/tmp/openclaw-update",
-        restartEnvironment: process.env,
-      });
+      await finishSuccessfulPackageSwitch();
 
       expect(mocks.restartService).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -780,6 +764,11 @@ describe("successful update finalization ordering", () => {
     it.each(["inspection", "revalidation"] as const)(
       "does not restart a stopped sealed service when fresh %s fails",
       async (failure) => {
+        let now = 1_000;
+        vi.spyOn(Date, "now").mockImplementation(() => now);
+        mocks.writeSentinel.mockImplementationOnce(async () => {
+          now += 100;
+        });
         const error = new Error("inspection-secret-canary");
         mocks.readServiceState.mockResolvedValue({
           installed: true,
@@ -965,19 +954,17 @@ describe("skipped update exit status", () => {
     vi.spyOn(defaultRuntime, "log").mockImplementation(() => undefined);
   });
 
-  it("exits nonzero when local changes block a Git update", async () => {
-    await finishSkippedUpdate("dirty");
-
-    expect(defaultRuntime.error).toHaveBeenCalledWith(
-      expect.stringContaining("Update blocked: local files are edited"),
-    );
-    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
-  });
-
-  it("keeps a non-Git install skip successful", async () => {
-    await finishSkippedUpdate("not-git-install");
-
-    expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
+  it.each([
+    ["dirty", 1],
+    ["not-git-install", 0],
+  ] as const)("handles %s with exit %i", async (reason, exitCode) => {
+    await finishSkippedUpdate(reason);
+    if (reason === "dirty") {
+      expect(defaultRuntime.error).toHaveBeenCalledWith(
+        expect.stringContaining("Update blocked: local files are edited"),
+      );
+    }
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(exitCode);
   });
 });
 
@@ -990,16 +977,22 @@ describe("failed Git update recovery restart", () => {
   it.each(["error", "skipped"] as const)(
     "records the %s outcome before recovery starts the Gateway",
     async (status) => {
+      let now = 1_000;
+      vi.spyOn(Date, "now").mockImplementation(() => now);
       mocks.restart.mockImplementationOnce(async () => {
         expect(mocks.writeSentinel.mock.lastCall?.[0].result).toMatchObject({ status });
+        expect(mocks.writeSentinel.mock.lastCall?.[0].result.durationMs).toBe(0);
         expect(mocks.printResult).not.toHaveBeenCalled();
+        now += 200;
       });
 
       await finishFailedUpdate({ ...failedResult({ serviceRestartSafe: true }), status });
 
       expect(mocks.restart).toHaveBeenCalledWith(expect.objectContaining({ root: "/repo" }));
       expect(mocks.writeSentinel).toHaveBeenCalledOnce();
+      expect(mocks.writeSentinel.mock.lastCall?.[0].result.durationMs).toBe(0);
       expect(mocks.printResult).toHaveBeenCalledOnce();
+      expect(mocks.printResult.mock.lastCall?.[0]).toMatchObject({ status, durationMs: 200 });
     },
   );
 

--- a/src/cli/update-cli/update-command-post-update.ts
+++ b/src/cli/update-cli/update-command-post-update.ts
@@ -91,13 +91,14 @@ export async function finishUpdate(params: {
   invocationCwd?: string;
 }): Promise<void> {
   // Finalization owns the complete outcome, including recovery, restart, and completion work.
+  const completedResult = (result: UpdateRunResult): UpdateRunResult => ({
+    ...result,
+    durationMs: Math.max(0, Date.now() - params.startedAt),
+  });
   const printFinalResult = (result: UpdateRunResult) =>
-    printResult(
-      { ...result, durationMs: Math.max(0, Date.now() - params.startedAt) },
-      { ...params.opts, hideSteps: params.showProgress },
-    );
+    printResult(result, { ...params.opts, hideSteps: params.showProgress });
   const reportResult = async (result: UpdateRunResult, recoverService = false) => {
-    const finalResult = { ...result, durationMs: Math.max(0, Date.now() - params.startedAt) };
+    const finalResult = completedResult(result);
     await writeControlPlaneUpdateRestartSentinelBestEffort({
       meta: params.controlPlaneUpdateSentinelMeta,
       result: finalResult,
@@ -112,7 +113,8 @@ export async function finishUpdate(params: {
         jsonMode: Boolean(params.opts.json),
       });
     }
-    printFinalResult(finalResult);
+    // Only recovery advances the outcome after persistence; ordinary reports share one snapshot.
+    printFinalResult(recoverService ? completedResult(result) : finalResult);
   };
   const restoreWindowsAutoStart = async (result: UpdateRunResult) => {
     try {
@@ -516,11 +518,9 @@ export async function finishUpdate(params: {
       reason: "restart-unhealthy",
       jsonMode: Boolean(params.opts.json),
     });
-    printFinalResult({
-      ...resultWithPostUpdate,
-      status: "error",
-      reason: "restart-unhealthy",
-    });
+    printFinalResult(
+      completedResult({ ...resultWithPostUpdate, status: "error", reason: "restart-unhealthy" }),
+    );
     defaultRuntime.exit(1);
     return;
   }
@@ -558,11 +558,13 @@ export async function finishUpdate(params: {
         reason: "wrapper-retirement-failed",
         jsonMode: Boolean(params.opts.json),
       });
-      printFinalResult({
-        ...resultWithPostUpdate,
-        status: "error",
-        reason: "wrapper-retirement-failed",
-      });
+      printFinalResult(
+        completedResult({
+          ...resultWithPostUpdate,
+          status: "error",
+          reason: "wrapper-retirement-failed",
+        }),
+      );
       defaultRuntime.exit(1);
       return;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw update` could report a different elapsed duration in CLI output and the persisted control-plane result when writing the result crossed a clock tick. This also caused intermittent release-verification CI failures.

Related: #133622 (update finalization reporting), #133616 (release-verification work that exposed the race).

## Why This Change Was Made

Finalization now creates one completed result snapshot and reuses it for ordinary persistence and printing. The printer no longer silently measures time again. Failed-update recovery retains its separate lifecycle boundary: write the notification once before restarting the Gateway, then include recovery time in the CLI result without rewriting or mutating the earlier notification. The restart-health and wrapper-retirement failure paths still measure elapsed time when they finish.

No service ownership, restart policy, storage schema, configuration, or public result shape changes. Production delta is +2 lines: the shared duration projection replaces duplicate measurement and makes the two completion boundaries explicit. Existing tests are strengthened, with repeated fixtures consolidated and clock spies restored in shared teardown; no new production test seam or dropped case.

## User Impact

Ordinary update reports agree across CLI and control-plane output. Recovery still notifies the Gateway before it starts and includes recovery time in the final CLI duration. Existing documentation already describes the retained total-time behavior.

## Evidence

- Hosted reproduction: [CI run 33357602761, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33357602761/attempts/1), job `checks-node-compact-small-2`, failed only on persisted duration `0` versus printed duration `1`. The failed-only rerun passed, but did not repair the race.
- Deterministic before/after: advance the clock during sentinel persistence in existing success and service-inspection/revalidation cases. Before repair: 3 failed, 31 passed. After repair: all 34 owner tests passed. No sleeps, tolerance changes, retry wrapper, or weaker equality assertion.
- `node scripts/run-vitest.mjs src/cli/update-cli/update-command-post-update.test.ts src/cli/update-cli/progress.test.ts src/cli/update-cli/update-command-service.test.ts src/cli/update-cli/update-command-service.integration.test.ts`: 123 passed across 4 files, including actual version guards and preserved native service artifacts. Recovery error/skipped cases explicitly prove one pre-recovery notification, no mutation of its duration, and post-recovery CLI timing.
- Live operator services were not interrupted to force a failed update. The clock boundary is fault-injected in the owner tests; service integration tests provide the neighboring activation proof. This is not a claim of a live managed-service update.
- Final fixture consolidation: all 34 owner cases pass again; two-file formatting, lint, and `git diff --check` pass. Final delta: production +2, tests −7. Shared spy teardown replaces per-case clock cleanup, and repeated successful-switch fixture arguments are evaluated through the same helper at call time.
- Local changed gate passed the conflict/line-count/assertion/deprecation/ownership/dependency/dead-export checks before encountering the shared install's pre-existing `tslog` type mismatch in `src/logging/logger.ts` (`attachTransport`/`settings`). No updater type error was reported. Shared dependencies were not reconciled; clean hosted CI is required before landing.
- Managed Codex autoreview: scoped-clean through P2, no actionable findings. Final source integrity checks passed.
- Direct persistence/output proof on `a0fe0d5a72c5e7d16247f4c15a037a16005b8f44`: an isolated process ran the real finalization function for a synthetic non-restartable failure, wrote through the actual SQLite sentinel owner, and printed actual JSON. A second process read the sentinel: both durations were exactly 250 ms and both status/reason fields agreed. Writer exit 1 was the expected synthetic failure, reader exit 0, parent verification exit 0. Fresh HOME/state/config, no real Gateway touched, no mocked printer or writer.
- Final hosted CI: [run 33359875587](https://github.com/openclaw/openclaw/actions/runs/33359875587) passed on exact `a0fe0d5a72c5e7d16247f4c15a037a16005b8f44`, including the required `openclaw/ci-gate` at 05:31:43 UTC. The latest exact-head ClawSweeper review has no code findings, no before-merge requests, and no rank-up moves. Normal squash landing, without a gate bypass.
