### PR TITLE
fix(voice-call): prevent phantom calls from late callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Voice call history:** preserve the original call and canonical provider ID across delayed callbacks and dial responses, preventing phantom calls and post-completion history changes. (#130059) Thanks @ruel225 and @jackatagenticforce.
 - **Subagent completion:** recognize visible final answers delivered to internal and nested parent sessions, preventing false delivery failures while preserving external channel delivery checks.
 - Codex/Linux: wait for a live app-server process to expose its startup command line within the existing inspection deadline, preserving process identity checks and preventing intermittent startup failures.
 - **Cloud session lifecycle:** prevent archive, delete, and restart recovery from deadlocking behind an earlier worker move, keep work admission closed through cleanup, and preserve the same successor for concurrent recovery requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Voice call history:** preserve the original call and canonical provider ID across delayed callbacks and dial responses, preventing phantom calls and post-completion history changes. (#130059) Thanks @ruel225 and @jackatagenticforce.
 - **Subagent completion:** recognize visible final answers delivered to internal and nested parent sessions, preventing false delivery failures while preserving external channel delivery checks.
 - Codex/Linux: wait for a live app-server process to expose its startup command line within the existing inspection deadline, preserving process identity checks and preventing intermittent startup failures.
 - **Cloud session lifecycle:** prevent archive, delete, and restart recovery from deadlocking behind an earlier worker move, keep work admission closed through cleanup, and preserve the same successor for concurrent recovery requests.

--- a/extensions/voice-call/src/cli.test.ts
+++ b/extensions/voice-call/src/cli.test.ts
@@ -6,7 +6,7 @@ import { Command } from "commander";
 import { MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 const callGatewayFromCliMock = vi.hoisted(() => vi.fn());
-const findCallMatchesInStoreMock = vi.hoisted(() => vi.fn());
+const findCallInStoreMock = vi.hoisted(() => vi.fn());
 const loadActiveCallsFromStoreMock = vi.hoisted(() => vi.fn());
 const tailscaleMocks = vi.hoisted(() => ({
   cleanup: vi.fn(),
@@ -32,7 +32,7 @@ vi.mock("../api.js", async (importOriginal) => ({
 }));
 vi.mock("./manager/store.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./manager/store.js")>()),
-  findCallMatchesInStore: findCallMatchesInStoreMock,
+  findCallInStore: findCallInStoreMock,
   loadActiveCallsFromStore: loadActiveCallsFromStoreMock,
 }));
 vi.mock("./webhook/tailscale.js", async (importOriginal) => ({
@@ -84,7 +84,7 @@ function gatewayCredentialsError(message: string): Error {
 describe("voice-call CLI status fallback", () => {
   afterEach(() => {
     callGatewayFromCliMock.mockReset();
-    findCallMatchesInStoreMock.mockReset();
+    findCallInStoreMock.mockReset();
     loadActiveCallsFromStoreMock.mockReset();
     tailscaleMocks.cleanup.mockReset();
     tailscaleMocks.getSelfInfo.mockReset();
@@ -121,7 +121,7 @@ describe("voice-call CLI status fallback", () => {
     args?: string[];
   }): Promise<unknown> {
     callGatewayFromCliMock.mockRejectedValue(params.error ?? gatewayTransportError());
-    findCallMatchesInStoreMock.mockResolvedValue({ byCallId: params.persisted });
+    findCallInStoreMock.mockReturnValue(params.persisted);
     const ensureRuntime = vi.fn(async () => {
       throw new Error("status fallback must not initialize the telephony runtime");
     });

--- a/extensions/voice-call/src/cli.ts
+++ b/extensions/voice-call/src/cli.ts
@@ -22,7 +22,7 @@ import {
   validateProviderConfig,
   type VoiceCallConfig,
 } from "./config.js";
-import { findCallMatchesInStore, loadActiveCallsFromStore } from "./manager/store.js";
+import { findCallInStore, loadActiveCallsFromStore } from "./manager/store.js";
 import { setVoiceCallStateRuntime, type VoiceCallStateRuntime } from "./runtime-state.js";
 import type { VoiceCallRuntime } from "./runtime.js";
 import { resolveDefaultVoiceCallStoreDir } from "./store-path.js";
@@ -379,8 +379,7 @@ export function registerVoiceCallCli(params: {
       ensureHistoryStateRuntime();
       const storePath = path.dirname(resolveDefaultStorePath(config));
       if (options.callId) {
-        const persisted = await findCallMatchesInStore(storePath, options.callId);
-        const call = persisted.byCallId ?? persisted.byProviderCallId;
+        const call = findCallInStore(storePath, options.callId);
         writeCliJson(call ?? { found: false });
         return;
       }

--- a/extensions/voice-call/src/manager.lifecycle.test.ts
+++ b/extensions/voice-call/src/manager.lifecycle.test.ts
@@ -1,6 +1,17 @@
+import fs from "node:fs";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
-import { describe, expect, it } from "vitest";
-import { createManagerHarness, FakeProvider } from "./manager.test-harness.js";
+import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { describe, expect, it, onTestFinished } from "vitest";
+import { VoiceCallConfigSchema } from "./config.js";
+import { CallManager } from "./manager.js";
+import {
+  createManagerHarness,
+  FakeProvider,
+  finalizeTestManagerCalls,
+  registerTestManagerCleanup,
+} from "./manager.test-harness.js";
+import { PlivoProvider } from "./providers/plivo.js";
+import { TwilioProvider } from "./providers/twilio.js";
 import type { HangupCallInput } from "./types.js";
 
 class DeferredHangupProvider extends FakeProvider {
@@ -27,6 +38,119 @@ async function initiateCall() {
 }
 
 describe("CallManager termination lifecycle", () => {
+  it.each([
+    { providerName: "twilio", restart: false },
+    { providerName: "twilio", restart: true },
+    { providerName: "plivo", restart: true },
+  ] as const)(
+    "keeps finalized identity for fresh $providerName callbacks (restart=$restart)",
+    async ({ providerName, restart }) => {
+      const config = VoiceCallConfigSchema.parse({
+        enabled: true,
+        provider: providerName,
+        fromNumber: "+15550000000",
+        agentId: "default-agent",
+      });
+      const { manager, provider, storePath } = await createManagerHarness(
+        config,
+        new FakeProvider(providerName),
+      );
+      const managers = [manager];
+      onTestFinished(() => {
+        try {
+          for (const owner of managers) {
+            finalizeTestManagerCalls(owner);
+          }
+        } finally {
+          resetPluginStateStoreForTests();
+          fs.rmSync(storePath, { recursive: true, force: true });
+        }
+      });
+      const started = await manager.initiateCall("+15550000001", "agent:sales:voice:fixture", {
+        agentId: "sales",
+      });
+      expect(started.success).toBe(true);
+      const initialProviderId = manager.getCall(started.callId)?.providerCallId;
+      if (!initialProviderId) {
+        throw new Error("expected an initiated provider call");
+      }
+      const parser =
+        providerName === "twilio"
+          ? new TwilioProvider({ accountSid: "AC-fixture", authToken: "synthetic-token" })
+          : new PlivoProvider({ authId: "MA-fixture", authToken: "synthetic-token" });
+      const callback = (providerId: string, callStatus: string, includeInternalId: boolean) => {
+        const query: Record<string, string> = includeInternalId
+          ? { callId: started.callId, type: "status" }
+          : {};
+        const rawBody = new URLSearchParams({
+          CallStatus: callStatus,
+          From: "+15550000000",
+          To: "+15550000001",
+          Direction: providerName === "twilio" ? "outbound-api" : "outbound",
+          ...(providerName === "twilio" ? { CallSid: providerId } : { RequestUUID: providerId }),
+          ...(providerName === "plivo" && includeInternalId ? { CallUUID: "call-uuid" } : {}),
+        }).toString();
+        const parsed = parser.parseWebhookEvent({
+          headers: {},
+          rawBody,
+          url: `https://example.com/voice/webhook?${new URLSearchParams(query)}`,
+          method: "POST",
+          query,
+        });
+        expect(parsed.events).toHaveLength(1);
+        const event = parsed.events[0];
+        if (!event) {
+          throw new Error("expected a normalized provider callback");
+        }
+        return event;
+      };
+      manager.processEvent(callback(initialProviderId, "in-progress", true));
+      await expect(
+        manager.speak(started.callId, "Preserve this call transcript."),
+      ).resolves.toEqual({
+        success: true,
+      });
+      await expect(manager.endCall(started.callId, { reason: "hangup-bot" })).resolves.toEqual({
+        success: true,
+      });
+      const terminal = await manager.getCallFromMemoryOrStore(started.callId);
+      if (!terminal) {
+        throw new Error("expected the finalized call in SQLite");
+      }
+      expect(terminal).toMatchObject({
+        agentId: "sales",
+        sessionKey: "agent:sales:voice:fixture",
+        state: "hangup-bot",
+        transcript: [expect.objectContaining({ text: "Preserve this call transcript." })],
+      });
+      let current = manager;
+      if (restart) {
+        resetPluginStateStoreForTests();
+        current = registerTestManagerCleanup(new CallManager(config, storePath));
+        managers.push(current);
+        await current.initialize(provider, "https://example.com/voice/webhook");
+      }
+
+      const late = callback(
+        initialProviderId,
+        providerName === "plivo" ? "ringing" : "completed",
+        providerName === "twilio",
+      );
+      expect(current.processEvent(late).kind).not.toBe("final-speech");
+
+      const history = await current.getCallHistory();
+      expect(new Set(history.map((call) => call.callId))).toEqual(new Set([started.callId]));
+      expect(await current.getCallFromMemoryOrStore(initialProviderId)).toMatchObject({
+        ...terminal,
+        processedEventIds: expect.arrayContaining(terminal.processedEventIds),
+      });
+      expect(current.getActiveCalls()).toEqual([]);
+      expect(provider.playTtsCalls).toHaveLength(1);
+      expect(provider.hangupCalls).toHaveLength(1);
+      expect(provider.startListeningCalls).toEqual([]);
+    },
+  );
+
   it("preserves the first provider terminal facts when a pending manager hangup settles", async () => {
     const { call, manager, provider } = await initiateCall();
     const endedAt = Date.now() + 1_000;

--- a/extensions/voice-call/src/manager.restore.test.ts
+++ b/extensions/voice-call/src/manager.restore.test.ts
@@ -388,7 +388,7 @@ describe("CallManager verification on restore", () => {
     },
   );
 
-  it("restores dedupe keys from terminal persisted calls so replayed webhooks stay ignored", async () => {
+  it("keeps terminal identity when a replay key is retained or evicted", async () => {
     const storePath = createTestStorePath();
     const replayKeys = Array.from(
       { length: MAX_CALL_REPLAY_KEYS + 2 },
@@ -435,6 +435,9 @@ describe("CallManager verification on restore", () => {
       to: "+15550000001",
     });
 
-    expect(manager.getActiveCalls()).toHaveLength(1);
+    expect(manager.getActiveCalls()).toHaveLength(0);
+    expect(new Set((await manager.getCallHistory()).map((call) => call.callId))).toEqual(
+      new Set([persisted.callId]),
+    );
   });
 });

--- a/extensions/voice-call/src/manager.test-harness.ts
+++ b/extensions/voice-call/src/manager.test-harness.ts
@@ -143,6 +143,7 @@ export async function createManagerHarness(
 ): Promise<{
   manager: CallManager;
   provider: FakeProvider;
+  storePath: string;
 }> {
   const config = VoiceCallConfigSchema.parse({
     enabled: true,
@@ -151,9 +152,10 @@ export async function createManagerHarness(
     ...configOverrides,
   });
   installVoiceCallStateRuntimeForTests();
-  const manager = registerTestManagerCleanup(new CallManager(config, createTestStorePath()));
+  const storePath = createTestStorePath();
+  const manager = registerTestManagerCleanup(new CallManager(config, storePath));
   await manager.initialize(provider, "https://example.com/voice/webhook");
-  return { manager, provider };
+  return { manager, provider, storePath };
 }
 
 export function markCallAnswered(manager: CallManager, callId: string, eventId: string): void {

--- a/extensions/voice-call/src/manager.ts
+++ b/extensions/voice-call/src/manager.ts
@@ -16,7 +16,7 @@ import {
   type SpeakOptions,
 } from "./manager/outbound.js";
 import {
-  findCallMatchesInStore,
+  findCallInStore,
   getCallHistoryFromStore,
   loadActiveCallsFromStore,
   persistCallRecord,
@@ -481,10 +481,7 @@ export class CallManager {
     if (active) {
       return active;
     }
-    const persisted = await findCallMatchesInStore(this.storePath, callId);
-    // Active indexes are canonical for live calls and keep provider-id status
-    // lookups off the retained-store path. Persisted ids are fallback-only.
-    return persisted.byCallId ?? persisted.byProviderCallId;
+    return findCallInStore(this.storePath, callId);
   }
 
   /**

--- a/extensions/voice-call/src/manager/events.test.ts
+++ b/extensions/voice-call/src/manager/events.test.ts
@@ -1,15 +1,19 @@
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 // Voice Call tests cover events plugin behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VoiceCallConfigSchema } from "../config.js";
+import { CallManager } from "../manager.js";
 import {
   createEventManagerHarness,
   EVENT_MANAGER_REPLAY_KEY_LIMIT,
 } from "../manager.test-harness.js";
 import type { VoiceCallProvider } from "../providers/base.js";
+import { getOptionalVoiceCallStateRuntime } from "../runtime-state.js";
 import type { CallRecord, HangupCallInput, NormalizedEvent } from "../types.js";
 import { processEvent } from "./events.js";
 import { speakInitialMessage } from "./outbound.js";
 import { MAX_CALL_REPLAY_KEYS } from "./replay-keys.js";
+import { persistCallRecord } from "./store.js";
 
 const logSpy = vi.hoisted(() => {
   const logEntries: string[] = [];
@@ -133,40 +137,113 @@ describe("processEvent (functional)", () => {
     },
   );
 
-  it("updates providerCallId map when provider ID changes", () => {
-    const now = Date.now();
-    const ctx = createContext();
-    ctx.activeCalls.set("call-1", {
-      callId: "call-1",
-      providerCallId: "request-uuid",
-      provider: "plivo",
-      direction: "outbound",
-      state: "initiated",
-      from: "+15550000000",
-      to: "+15550000001",
-      startedAt: now,
-      transcript: [],
-      processedEventIds: [],
-      metadata: {},
-    });
-    ctx.providerCallIdMap.set("request-uuid", "call-1");
+  it.each(["request-uuid", "call-1"])(
+    "upgrades provider identity without downgrading a known alias via %s",
+    (aliasCallId) => {
+      const now = Date.now();
+      const ctx = createContext();
+      ctx.activeCalls.set("call-1", {
+        callId: "call-1",
+        providerCallId: "request-uuid",
+        provider: "plivo",
+        direction: "outbound",
+        state: "initiated",
+        from: "+15550000000",
+        to: "+15550000001",
+        startedAt: now,
+        transcript: [],
+        processedEventIds: [],
+        metadata: {},
+      });
+      ctx.providerCallIdMap.set("request-uuid", "call-1");
+      const initialCall = ctx.activeCalls.get("call-1");
+      if (!initialCall) {
+        throw new Error("expected the initial call");
+      }
+      persistCallRecord(ctx.storePath, initialCall);
 
-    processEvent(ctx, {
-      id: "evt-provider-id-change",
-      type: "call.answered",
-      callId: "call-1",
-      providerCallId: "call-uuid",
-      timestamp: now + 1,
-    });
+      processEvent(ctx, {
+        id: "evt-provider-id-change",
+        type: "call.answered",
+        callId: "call-1",
+        providerCallId: "call-uuid",
+        timestamp: now + 1,
+      });
 
-    const activeCall = ctx.activeCalls.get("call-1");
-    if (!activeCall) {
-      throw new Error("expected active call after provider id change");
-    }
-    expect(activeCall.providerCallId).toBe("call-uuid");
-    expect(ctx.providerCallIdMap.get("call-uuid")).toBe("call-1");
-    expect(ctx.providerCallIdMap.has("request-uuid")).toBe(false);
-  });
+      const activeCall = ctx.activeCalls.get("call-1");
+      if (!activeCall) {
+        throw new Error("expected active call after provider id change");
+      }
+      expect(activeCall.providerCallId).toBe("call-uuid");
+      expect(ctx.providerCallIdMap.get("call-uuid")).toBe("call-1");
+      expect(ctx.providerCallIdMap.has("request-uuid")).toBe(false);
+
+      const result = processEvent(ctx, {
+        id: "evt-old-provider-alias",
+        type: "call.speech",
+        callId: aliasCallId,
+        providerCallId: "request-uuid",
+        timestamp: now + 2,
+        direction: "outbound",
+        transcript: "Continue the existing call.",
+        isFinal: true,
+      });
+      if (result.kind !== "final-speech") {
+        throw new Error("expected speech for the live call");
+      }
+      expect(result.call).toBe(activeCall);
+      expect(ctx.activeCalls.size).toBe(1);
+      expect(activeCall.providerCallId).toBe("call-uuid");
+      expect(ctx.providerCallIdMap.get("call-uuid")).toBe("call-1");
+      expect(ctx.providerCallIdMap.has("request-uuid")).toBe(false);
+    },
+  );
+
+  it.each(["admission", "status"] as const)(
+    "surfaces call history read failure during %s without claiming absence or writing a call",
+    async (operation) => {
+      const provider = createProvider();
+      const ctx = createContext({ provider });
+      const manager = new CallManager(ctx.config, ctx.storePath);
+      await manager.initialize(provider, "https://example.com/voice/webhook");
+      const state = getOptionalVoiceCallStateRuntime()?.state;
+      if (!state) {
+        throw new Error("expected the fixture state runtime");
+      }
+      const openStore = state.openSyncKeyedStore.bind(state);
+      const fault = vi
+        .spyOn(state, "openSyncKeyedStore")
+        .mockImplementation(<T>(options: OpenKeyedStoreOptions) => {
+          const store = openStore<T>(options);
+          store.entries = () => {
+            throw new Error("synthetic call history read failure");
+          };
+          return store;
+        });
+      try {
+        if (operation === "status") {
+          await expect(manager.getCallFromMemoryOrStore("provider-unknown")).rejects.toThrow(
+            "synthetic call history read failure",
+          );
+        } else {
+          expect(() =>
+            manager.processEvent({
+              ...createInboundInitiatedEvent({
+                id: "event-unreadable-history",
+                providerCallId: "provider-unknown",
+                from: "+15550000001",
+              }),
+              direction: "outbound",
+            }),
+          ).toThrow("synthetic call history read failure");
+        }
+      } finally {
+        fault.mockRestore();
+      }
+      expect(manager.getActiveCalls()).toEqual([]);
+      expect(await manager.getCallHistory()).toEqual([]);
+    },
+  );
 
   it("does not burn replay keys for unknown calls before a later replay can resolve them", () => {
     const now = Date.now();

--- a/extensions/voice-call/src/manager/events.ts
+++ b/extensions/voice-call/src/manager/events.ts
@@ -6,7 +6,7 @@ import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { isAllowlistedCaller, normalizePhoneNumber } from "../allowlist.js";
 import { resolveVoiceCallEffectiveConfig, resolveVoiceCallSessionKey } from "../config.js";
-import type { CallRecord, NormalizedEvent } from "../types.js";
+import { TerminalStates, type CallRecord, type NormalizedEvent } from "../types.js";
 import type { CallManagerContext } from "./context.js";
 import { finalizeCall } from "./lifecycle.js";
 import { findCall } from "./lookup.js";
@@ -18,7 +18,7 @@ import {
   reserveRejectedProviderCall,
 } from "./replay-keys.js";
 import { addTranscriptEntry, transitionState } from "./state.js";
-import { persistCallRecord } from "./store.js";
+import { findCallInStore, persistCallRecord } from "./store.js";
 import { resolveTranscriptWaiter, startMaxDurationTimer } from "./timers.js";
 
 const log = createSubsystemLogger("voice-call/events");
@@ -170,7 +170,33 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
     callIdOrProviderCallId: event.callId,
   });
 
-  const providerCallId = event.providerCallId;
+  let providerCallId = event.providerCallId;
+  let retained: CallRecord | undefined;
+  if (!call) {
+    retained = findCallInStore(ctx.storePath, event.callId);
+    if (!retained && providerCallId && providerCallId !== event.callId) {
+      retained = findCallInStore(ctx.storePath, providerCallId);
+    }
+    // A policy rejection records an attempt, not confirmed carrier termination.
+    if (retained && retained.metadata?.rejectionReason !== "inbound-policy") {
+      call = ctx.activeCalls.get(retained.callId);
+      if (!call) {
+        return TerminalStates.has(retained.state)
+          ? { kind: "ignored" }
+          : { kind: "ignored", replayable: true };
+      }
+    }
+  }
+  if (call && providerCallId && providerCallId !== call.providerCallId) {
+    const providerOwner =
+      providerCallId === event.callId && retained
+        ? retained
+        : findCallInStore(ctx.storePath, providerCallId);
+    // Known aliases cannot replace the live owner's newer provider ID.
+    if (providerOwner?.callId === call.callId) {
+      providerCallId = call.providerCallId;
+    }
+  }
   const eventDirection =
     event.direction === "inbound" || event.direction === "outbound" ? event.direction : undefined;
 
@@ -256,11 +282,11 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
     }
   };
   const publishProviderCallId = (terminal = false) => {
-    if (!event.providerCallId || event.providerCallId === previousCall.providerCallId) {
+    if (!providerCallId || providerCallId === previousCall.providerCallId) {
       return;
     }
     if (!terminal) {
-      ctx.providerCallIdMap.set(event.providerCallId, activeCall.callId);
+      ctx.providerCallIdMap.set(providerCallId, activeCall.callId);
     }
     if (previousCall.providerCallId) {
       const mapped = ctx.providerCallIdMap.get(previousCall.providerCallId);
@@ -271,8 +297,8 @@ export function processEvent(ctx: EventContext, event: NormalizedEvent): Process
   };
 
   try {
-    if (event.providerCallId && event.providerCallId !== activeCall.providerCallId) {
-      activeCall.providerCallId = event.providerCallId;
+    if (providerCallId && providerCallId !== activeCall.providerCallId) {
+      activeCall.providerCallId = providerCallId;
     }
     if (shouldCommitReplayKey) {
       appendCallReplayKey(activeCall.processedEventIds, dedupeKey);

--- a/extensions/voice-call/src/manager/outbound.persistence.test.ts
+++ b/extensions/voice-call/src/manager/outbound.persistence.test.ts
@@ -3,13 +3,85 @@ import path from "node:path";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { createEventManagerHarness } from "../manager.test-harness.js";
+import { PlivoProvider } from "../providers/plivo.js";
 import type { InitiateCallResult } from "../types.js";
-import { initiateCall } from "./outbound.js";
-import { loadActiveCallsFromStore } from "./store.js";
+import { processEvent } from "./events.js";
+import { initiateCall, speak } from "./outbound.js";
+import { getCallHistoryFromStore, loadActiveCallsFromStore } from "./store.js";
 
 const { cleanup, createContext, createProvider, setup } = createEventManagerHarness();
 beforeEach(setup);
 afterEach(cleanup);
+
+it.each([
+  { phase: "active", requestUuid: undefined, payload: "CallUUID-only parser control" },
+  { phase: "active", requestUuid: "request-uuid", payload: "complete callback" },
+  { phase: "ended", requestUuid: "request-uuid", payload: "complete callback" },
+])(
+  "preserves callback-owned identity when initiation settles after the call is $phase ($payload)",
+  async ({ phase, requestUuid }) => {
+    const placement = createDeferred<InitiateCallResult>();
+    const playback = vi.fn(async () => {});
+    const ctx = createContext({
+      provider: createProvider({ initiateCall: () => placement.promise, playTts: playback }),
+      webhookUrl: "https://example.com/voice/webhook",
+    });
+    const parser = new PlivoProvider({ authId: "MA-fixture", authToken: "synthetic-token" });
+    const pending = initiateCall(ctx, "+15550000001");
+    try {
+      const call = [...ctx.activeCalls.values()][0];
+      if (!call) {
+        throw new Error("expected the pending outbound call");
+      }
+      const deliver = (fields: Record<string, string>) => {
+        const parsed = parser.parseWebhookEvent({
+          headers: {},
+          method: "POST",
+          url: `https://example.com/voice/webhook?callId=${call.callId}`,
+          query: { callId: call.callId },
+          rawBody: new URLSearchParams({
+            CallUUID: "canonical-call-uuid",
+            ...(requestUuid ? { RequestUUID: requestUuid } : {}),
+            Direction: "outbound",
+            ...fields,
+          }).toString(),
+        });
+        expect(parsed.events).toHaveLength(1);
+        for (const event of parsed.events) {
+          processEvent(ctx, event);
+        }
+      };
+      deliver({ CallStatus: "in-progress" });
+      expect(call.providerCallId).toBe("canonical-call-uuid");
+      if (phase === "ended") {
+        deliver({ CallStatus: "completed" });
+      }
+      const beforeResult = await getCallHistoryFromStore(ctx.storePath);
+
+      placement.resolve({ providerCallId: "request-uuid", status: "initiated" });
+      await expect(pending).resolves.toEqual({ callId: call.callId, success: true });
+      expect(call.providerCallId).toBe("canonical-call-uuid");
+
+      if (phase === "active") {
+        deliver({ CallStatus: "in-progress", Speech: "Continue the connected call." });
+        await expect(speak(ctx, call.callId, "Still connected.")).resolves.toEqual({
+          success: true,
+        });
+        expect(playback).toHaveBeenCalledWith(
+          expect.objectContaining({ callId: call.callId, providerCallId: "canonical-call-uuid" }),
+        );
+        expect(ctx.providerCallIdMap).toEqual(new Map([["canonical-call-uuid", call.callId]]));
+      } else {
+        expect(await getCallHistoryFromStore(ctx.storePath)).toEqual(beforeResult);
+        expect(ctx.activeCalls.size).toBe(0);
+        expect(ctx.providerCallIdMap.size).toBe(0);
+      }
+    } finally {
+      placement.resolve({ providerCallId: "request-uuid", status: "initiated" });
+      await pending;
+    }
+  },
+);
 
 it("keeps outbound capacity available after storage failure without dialing", async () => {
   const placement = createDeferred<InitiateCallResult>();

--- a/extensions/voice-call/src/manager/outbound.ts
+++ b/extensions/voice-call/src/manager/outbound.ts
@@ -251,11 +251,14 @@ export async function initiateCall(
         : {}),
     });
 
-    callRecord.providerCallId = result.providerCallId;
-    ctx.providerCallIdMap.set(result.providerCallId, callId);
-    persistCallRecord(ctx.storePath, callRecord);
+    // A callback may establish the canonical ID or finalize the call while dialing awaits.
+    if (ctx.activeCalls.get(callId) === callRecord && !callRecord.providerCallId) {
+      callRecord.providerCallId = result.providerCallId;
+      ctx.providerCallIdMap.set(result.providerCallId, callId);
+      persistCallRecord(ctx.storePath, callRecord);
+    }
     console.log(
-      `[voice-call] Outbound call initiated: callId=${callId} providerCallId=${result.providerCallId} mode=${mode} preConnectDtmf=${preConnectTwiml ? "yes" : "no"} initialMessage=${initialMessage ? "yes" : "no"}`,
+      `[voice-call] Outbound call initiated: callId=${callId} providerCallId=${callRecord.providerCallId ?? result.providerCallId} mode=${mode} preConnectDtmf=${preConnectTwiml ? "yes" : "no"} initialMessage=${initialMessage ? "yes" : "no"}`,
     );
 
     return { callId, success: true };

--- a/extensions/voice-call/src/manager/store.test.ts
+++ b/extensions/voice-call/src/manager/store.test.ts
@@ -16,7 +16,7 @@ import { setVoiceCallStateRuntime } from "../runtime-state.js";
 import { CallRecordSchema } from "../types.js";
 import { MAX_CALL_REPLAY_KEYS } from "./replay-keys.js";
 import {
-  findCallMatchesInStore,
+  findCallInStore,
   getCallHistoryFromStore,
   loadActiveCallsFromStore,
   persistCallRecord,
@@ -260,15 +260,11 @@ describe("voice-call call record store", () => {
       );
     }
     expect(await getCallHistoryFromStore(storePath, 100)).toHaveLength(100);
-    const internalMatches = await findCallMatchesInStore(storePath, "call-target");
-    expect(internalMatches.byCallId).toMatchObject({
+    expect(findCallInStore(storePath, "call-target")).toMatchObject({
       callId: "call-target",
       state: "completed",
     });
-    expect(internalMatches.byProviderCallId).toMatchObject({ callId: "noise-100" });
-
-    const providerMatches = await findCallMatchesInStore(storePath, "provider-target");
-    expect(providerMatches.byProviderCallId).toMatchObject({
+    expect(findCallInStore(storePath, "provider-target")).toMatchObject({
       callId: "call-target",
       state: "completed",
     });

--- a/extensions/voice-call/src/manager/store.ts
+++ b/extensions/voice-call/src/manager/store.ts
@@ -67,10 +67,10 @@ function resolvePluginStateEnv(storePath: string): NodeJS.ProcessEnv {
 }
 
 /** Open the plugin state stores when the runtime is available. */
-function createCallRecordStateStores(storePath: string): CallRecordStateStores | null {
+function createCallRecordStateStores(storePath: string): CallRecordStateStores {
   const runtime = getOptionalVoiceCallStateRuntime();
   if (!runtime) {
-    return null;
+    throw new Error("Voice Call state runtime not initialized");
   }
   const env = resolvePluginStateEnv(storePath);
   return {
@@ -326,9 +326,6 @@ function readCallRecordEvents(stores: CallRecordStateStores): CallRecord[] {
 export function persistCallRecord(storePath: string, call: CallRecord): void {
   try {
     const stores = createCallRecordStateStores(storePath);
-    if (!stores) {
-      throw new Error("Voice Call state runtime not initialized");
-    }
     const order = nextCallRecordOrder();
     registerCallRecordEvent(stores, buildNewEventKey(order), call, order);
   } catch (err) {
@@ -397,16 +394,14 @@ function readCallHistoryFromStore(storePath: string): CallRecord[] {
   return [];
 }
 
-/** Find the newest retained snapshots matching each call identifier namespace. */
-export async function findCallMatchesInStore(
-  storePath: string,
-  callId: string,
-): Promise<{ byCallId?: CallRecord; byProviderCallId?: CallRecord }> {
-  const calls = readCallHistoryFromStore(storePath);
-  return {
-    byCallId: calls.findLast((call) => call.callId === callId),
-    byProviderCallId: calls.findLast((call) => call.providerCallId === callId),
-  };
+/** Resolve an internal ID or retained provider alias to its newest logical call snapshot. */
+export function findCallInStore(storePath: string, callId: string): CallRecord | undefined {
+  // Admission and status must distinguish unavailable history from an absent call.
+  const calls = readCallRecordEvents(createCallRecordStateStores(storePath));
+  const match =
+    calls.findLast((call) => call.callId === callId) ??
+    calls.findLast((call) => call.providerCallId === callId);
+  return match ? calls.findLast((call) => call.callId === match.callId) : undefined;
 }
 
 /** Return the newest persisted call history rows up to the requested limit. */

--- a/extensions/voice-call/src/webhook.hangup-once.lifecycle.test.ts
+++ b/extensions/voice-call/src/webhook.hangup-once.lifecycle.test.ts
@@ -1,14 +1,21 @@
 // Voice Call tests cover webhook.hangup once.lifecycle plugin behavior.
+import crypto from "node:crypto";
+import fs from "node:fs";
 import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
   createPluginStateSyncKeyedStoreForTests,
   resetPluginStateStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { VoiceCallConfigSchema, type VoiceCallConfig } from "./config.js";
 import { CallManager } from "./manager.js";
-import { createTestStorePath, FakeProvider } from "./manager.test-harness.js";
-import { setVoiceCallStateRuntime } from "./runtime-state.js";
+import {
+  createTestStorePath,
+  FakeProvider,
+  finalizeTestManagerCalls,
+} from "./manager.test-harness.js";
+import { TwilioProvider } from "./providers/twilio.js";
+import { getOptionalVoiceCallStateRuntime, setVoiceCallStateRuntime } from "./runtime-state.js";
 import type { WebhookContext, WebhookParseOptions } from "./types.js";
 import { VoiceCallWebhookServer } from "./webhook.js";
 
@@ -154,6 +161,116 @@ describe("Voice-call webhook hangup-once lifecycle", () => {
 
   afterEach(() => {
     resetPluginStateStoreForTests();
+    vi.restoreAllMocks();
+  });
+
+  it("preserves finalized identity through signed HTTP callbacks and retries failed history reads", async () => {
+    const authToken = "synthetic-terminal-webhook-token";
+    const config = createConfig({
+      provider: "twilio",
+      agentId: "default-agent",
+      twilio: { accountSid: "AC-fixture", authToken },
+    });
+    const provider = new TwilioProvider({ accountSid: "AC-fixture", authToken });
+    vi.spyOn(provider, "initiateCall").mockResolvedValue({
+      providerCallId: "CA-terminal-identity",
+      status: "initiated",
+    });
+    const playback = vi.spyOn(provider, "playTts").mockResolvedValue();
+    const hangup = vi.spyOn(provider, "hangupCall").mockResolvedValue();
+    const storePath = createTestStorePath();
+    const manager = new CallManager(config, storePath);
+    const processing = vi.spyOn(manager, "processEvent");
+    const server = new VoiceCallWebhookServer(config, manager, provider);
+    try {
+      const baseUrl = await server.start();
+      provider.setPublicUrl(baseUrl);
+      await manager.initialize(provider, baseUrl);
+      const started = await manager.initiateCall("+15550000001", "agent:sales:voice:http", {
+        agentId: "sales",
+      });
+      expect(started.success).toBe(true);
+      const url = new URL(baseUrl);
+      url.searchParams.set("callId", started.callId);
+      url.searchParams.set("type", "status");
+      const send = async (callStatus: string, sequence: string) => {
+        const form = new URLSearchParams({
+          CallSid: "CA-terminal-identity",
+          CallStatus: callStatus,
+          Direction: "outbound-api",
+          From: "+15550000000",
+          To: "+15550000001",
+          SequenceNumber: sequence,
+        });
+        form.sort();
+        const material = url.toString() + [...form].map(([key, value]) => key + value).join("");
+        const signature = crypto.createHmac("sha1", authToken).update(material).digest("base64");
+        const response = await fetch(url, {
+          method: "POST",
+          headers: {
+            "content-type": "application/x-www-form-urlencoded",
+            "x-twilio-signature": signature,
+          },
+          body: form.toString(),
+        });
+        await response.text();
+        return response.status;
+      };
+
+      expect(await send("in-progress", "1")).toBe(200);
+      await expect(manager.speak(started.callId, "Keep the original transcript.")).resolves.toEqual(
+        {
+          success: true,
+        },
+      );
+      await expect(manager.endCall(started.callId)).resolves.toEqual({ success: true });
+      const history = await manager.getCallHistory();
+      expect(history.at(-1)).toMatchObject({
+        callId: started.callId,
+        agentId: "sales",
+        sessionKey: "agent:sales:voice:http",
+        state: "hangup-bot",
+        transcript: [expect.objectContaining({ text: "Keep the original transcript." })],
+      });
+      expect(await send("completed", "2")).toBe(200);
+      const terminalCalls = processing.mock.calls.length;
+      expect(await send("completed", "2")).toBe(200);
+      expect(processing).toHaveBeenCalledTimes(terminalCalls);
+
+      const state = getOptionalVoiceCallStateRuntime()?.state;
+      if (!state) {
+        throw new Error("expected fixture SQLite runtime");
+      }
+      const openStore = state.openSyncKeyedStore.bind(state);
+      const fault = vi
+        .spyOn(state, "openSyncKeyedStore")
+        .mockImplementation(<T>(options: OpenKeyedStoreOptions) => {
+          const store = openStore<T>(options);
+          store.entries = () => {
+            throw new Error("synthetic signed callback history failure");
+          };
+          return store;
+        });
+      try {
+        expect(await send("completed", "3")).toBe(500);
+      } finally {
+        fault.mockRestore();
+      }
+      expect(await send("completed", "3")).toBe(200);
+      expect(processing).toHaveBeenCalledTimes(terminalCalls + 2);
+      expect(await manager.getCallHistory()).toEqual(history);
+      expect(manager.getActiveCalls()).toEqual([]);
+      expect(playback).toHaveBeenCalledTimes(1);
+      expect(hangup).toHaveBeenCalledTimes(1);
+    } finally {
+      try {
+        await server.stop();
+      } finally {
+        finalizeTestManagerCalls(manager);
+        resetPluginStateStoreForTests();
+        fs.rmSync(storePath, { recursive: true, force: true });
+      }
+    }
   });
 
   it("hangs up a rejected inbound replay only once across duplicate webhook delivery", async () => {


### PR DESCRIPTION
Related: #130059. This maintainer-owned replacement continues the established-call repair in #130145, which its author closed to free contributor PR capacity; thanks @ruel225 and reporter @jackatagenticforce.

## What Problem This Solves

Fixes an issue where a late provider callback after a call ended could create a second, zero-duration call under the default agent. Historical Plivo request IDs could also select an outdated snapshot or replace the current live provider ID.

## Why This Change Was Made

The callback admission owner previously searched only active call maps, which finalization deliberately removes. It now resolves retained identity before creating a new call. One existing-store resolver gives internal IDs precedence, resolves provider aliases to their logical call, then selects that call's newest retained snapshot. Manager and CLI status use the same resolver; the duplicate paired-result API and unnecessary async wrapper are removed.

The initiation result publishes an ID only while the exact call is still active and no callback has already established its identity. This prevents a delayed dial response from replacing the final CallUUID or rewriting a completed call. Established terminal callbacks have no further live side effects or history writes. A detached nonterminal record does not become a new live owner. Known historical aliases cannot overwrite a live canonical ID. Storage-read errors propagate before admission or replay commitment, so the existing webhook returns a retryable HTTP 500 instead of fabricating a call; status no longer misreports unreadable history as absence.

Production +54/-34 (net +20) supplies missing active/retained lifecycle classification while deleting duplicate selection. Tests and support +445/-54. Release-note context is kept here for the release-owned changelog. No schema, index, configuration, retention change, extra persistent write, or parallel state store.

## User Impact

Late callbacks preserve the original call's agent, transcript, duration, and identity. Normal callbacks stay on the active path. Existing policy-rejected inbound calls retain their hangup retry behavior: those stored records describe an attempted hangup, not confirmed carrier termination.

Durable rejected-call confirmation remains a separate persistence decision, explicitly outside this established-call repair. The existing rejection metadata is sufficient to preserve its current retry contract, but does not prove that an earlier hangup succeeded. Pruned or malformed historical records remain subject to the existing retention/filtering limitations.

## Evidence

Seven failure-first cases reproduced phantom records, stale alias ownership/downgrade, and read-error handling; **92/92** owner tests passed. An independent review then found a callback-before-dial-response race. Complete documented Plivo callback payloads reproduced the canonical-ID overwrite on both active and ended calls before the three-line handoff fix. A parser-tolerated CallUUID-only control also reproduced lost recovery, but is not claimed as a documented complete carrier payload. After the owner repair, **69/69** affected outbound/event/lifecycle/restore tests passed.

**4/4 HTTP tests passed:** one scenario uses the real loopback webhook server, actual Twilio HMAC verification/parser, CallManager, and canonical SQLite; three existing fake-provider tests cover rejection lifecycle controls. In the signed scenario, only carrier initiation/playback/hangup operations are stubbed. A completed non-default-agent call receives a fresh completion callback and exact replay without changing its complete stored history or invoking another carrier action. A real store-read fault produces HTTP 500; the byte-identical signed retry reaches the manager and returns HTTP 200. Servers and isolated state are cleaned up.

This is signed local HTTP behavior proof, not an authenticated Twilio/Gemini call or recipient-audio proof. The initial fixture typecheck failure was corrected using resolved synthetic Twilio credentials rather than a cast. The HTTP suite was rerun on the final source: **4/4 passed**, with all listeners closed. Final complete-diff autoreview reports no actionable P0–P2 findings. The separate final source review also found no actionable P0–P2 findings, and the full canonical changed-file gate passes. Published candidate: `83fff4f955923ef57b4a1d7aa5178028af123cd7`. [CI passed](https://github.com/openclaw/openclaw/actions/runs/33360253877) on that runtime-identical candidate. Current head `e5851724b0c329532f97a997b47bb507cca02355` removes only the release-owned changelog entry; [exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33361690702).

The latest exact-head review (06:01 UTC) reports no actionable code defects. Its earlier release-owned changelog finding is addressed without runtime/test changes. The retained-call behavior and net20 production growth are accepted as the owner-boundary correction described above. There is no schema, index, retention, serialized record-shape or writer-format change. A complete comparison against main `962ad0e79d53e4220fa08cc7c329eefbcea74303` confirms the affected owner modules still match the failure-first base; the native baseline and exact PR-head inspections are complete, and all13 candidate files match the tested source.

The prior review's proof request is addressed by the signed callback trace. Its durable rejected-inbound confirmation request is intentionally deferred as described above; no new persistence design is implied by this repair.
