### PR TITLE
perf(ci): stripe the tallest node test group across three jobs

### DIFF
--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -172,8 +172,9 @@ const GATEWAY_STARTUP_HEALTH_RUNTIME_ENV = {
 const AGENTS_EMBEDDED_AGENT_ENV = {
   OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS: "660000",
 };
+const COMPACT_EMBEDDED_BASE_GROUP_NAME = "agentic-agents-embedded-base";
 const COMPACT_EMBEDDED_GROUP_NAMES = [
-  "agentic-agents-embedded-base",
+  COMPACT_EMBEDDED_BASE_GROUP_NAME,
   "agentic-agents-embedded-incomplete-turn",
   "agentic-agents-embedded-overflow-compaction",
   "agentic-agents-embedded-run",
@@ -211,6 +212,12 @@ const AGENTIC_GATEWAY_CORE_STRIPES = 3;
 const CORE_RUNTIME_MEDIA_UI_STRIPES = 3;
 const CORE_UNIT_SRC_SECURITY_STRIPES = 3;
 const UNIT_FAST_NODE_TEST_STRIPES = 2;
+// The embedded base config owns 107 serial files and measured 258.1s/256.4s/
+// 253.7s/269.4s on main runs 33319465485, 33318725438, 33319958268, and
+// 33319413324 - the tallest compact job on every one of them. Three stripes
+// keep every stripe under COMPACT_GITHUB_MAX_PREDICTED_SECONDS on both runner
+// classes, so the hosted splitter never has to divide them again.
+const EMBEDDED_BASE_NODE_TEST_STRIPES = 3;
 // Cold-start fallback when committed CI measurements are missing. Refresh
 // config/ci-test-timings.json with pnpm ci:timings:refit, not these literals.
 const COMPACT_GROUP_SECONDS_HINTS = new Map<string, number>([
@@ -228,8 +235,10 @@ const COMPACT_GROUP_SECONDS_HINTS = new Map<string, number>([
   ["agentic-agents-core-tools", 39],
   // The composite hint sets the job count before its independent configs are
   // striped across those jobs; its estimate is the sum of the split medians.
-  ["agentic-agents-embedded", 166],
-  ["agentic-agents-embedded-base", 81],
+  ["agentic-agents-embedded", 343],
+  ["agentic-agents-embedded-base-1", 86],
+  ["agentic-agents-embedded-base-2", 86],
+  ["agentic-agents-embedded-base-3", 86],
   ["agentic-agents-embedded-incomplete-turn", 19],
   ["agentic-agents-embedded-overflow-compaction", 20],
   ["agentic-agents-embedded-run", 46],
@@ -381,7 +390,9 @@ const COMPACT_LARGE_GROUP_STRIPE_SECONDS_HINTS = new Map<string, number>([
   ["agentic-agents-core-runtime", 119],
   ["agentic-agents-core-subagents", 21],
   ["agentic-agents-core-tools", 47],
-  ["agentic-agents-embedded-base", 79],
+  ["agentic-agents-embedded-base-1", 86],
+  ["agentic-agents-embedded-base-2", 86],
+  ["agentic-agents-embedded-base-3", 86],
   ["agentic-agents-embedded-incomplete-turn", 20],
   ["agentic-agents-embedded-overflow-compaction", 21],
   ["agentic-agents-embedded-run", 47],
@@ -436,8 +447,10 @@ const COMPACT_GITHUB_GROUP_SECONDS_HINTS = new Map<string, number>([
   ["agentic-agents-core-runtime", 185],
   ["agentic-agents-core-subagents", 29],
   ["agentic-agents-core-tools", 83],
-  ["agentic-agents-embedded", 234],
-  ["agentic-agents-embedded-base", 139],
+  ["agentic-agents-embedded", 510],
+  ["agentic-agents-embedded-base-1", 138],
+  ["agentic-agents-embedded-base-2", 138],
+  ["agentic-agents-embedded-base-3", 138],
   ["agentic-agents-embedded-incomplete-turn", 3],
   ["agentic-agents-embedded-overflow-compaction", 31],
   ["agentic-agents-embedded-run", 62],
@@ -601,6 +614,14 @@ const STRIPE_FILE_SECONDS_HINTS = new Map<string, number>([
   ["src/auto-reply/reply/commands-plugins.install.test.ts", 6],
   ["src/auto-reply/reply/commands-status.test.ts", 12],
   ["src/auto-reply/reply/commands-system-prompt.test.ts", 8],
+  // Embedded base stripe anchors: per-test sums from main run 33319465485's
+  // 258.07s group wall. Three files own 169s of it, so without these the
+  // equal-weight default packs them into one stripe and rebuilds the whale.
+  ["src/agents/embedded-agent-runner/compact.hooks.test.ts", 39],
+  ["src/agents/embedded-agent-runner/model.test.ts", 13],
+  ["src/agents/embedded-agent-runner/run.compaction-runtime.test.ts", 53],
+  ["src/agents/embedded-agent-runner/run.harness-auth-failover.test.ts", 8],
+  ["src/agents/embedded-agent-runner/run.shared-integration.test.ts", 77],
   ["src/gateway/dashboard-session-title.test.ts", 23],
   // Successful run 32172905415: 26.9s and 15.9s. Without direct hints the
   // hosted agent-chat splitter prices both at 3s and puts them in one stripe.
@@ -760,7 +781,7 @@ function estimateCompactStripeSeconds(
 // Equal-weight sibling stripes can otherwise land in one bin and recreate the
 // indivisible critical-path floor that striping removes.
 function compactGiantStripeFamily(group: NodeTestShardGroup): string | undefined {
-  return /^(agentic-gateway-core|core-runtime-media-ui|core-unit-src-security)-\d+$/u.exec(
+  return /^(agentic-agents-embedded-base|agentic-gateway-core|core-runtime-media-ui|core-unit-src-security)-\d+$/u.exec(
     group.shard_name,
   )?.[1];
 }
@@ -779,11 +800,28 @@ function expandCompactGroup(group: NodeTestShardGroup): NodeTestShardGroup[] {
     if (!shardName) {
       throw new Error("embedded compact group name is missing");
     }
-    expandedGroups.push({
-      ...group,
-      configs: [config],
-      shard_name: shardName,
-    });
+    if (shardName !== COMPACT_EMBEDDED_BASE_GROUP_NAME) {
+      expandedGroups.push({ ...group, configs: [config], shard_name: shardName });
+      continue;
+    }
+    const stripes = createStripedBatches(
+      listAgentEmbeddedBaseTestFiles(),
+      EMBEDDED_BASE_NODE_TEST_STRIPES,
+      stripeFileWeight,
+    );
+    for (const [stripeIndex, includePatterns] of stripes.entries()) {
+      // An empty include list makes the shard runner drop the include file and
+      // run the whole config, so every stripe would replay the entire suite.
+      if (includePatterns.length === 0) {
+        throw new Error("embedded base stripe cannot be empty");
+      }
+      expandedGroups.push({
+        ...group,
+        configs: [config],
+        includePatterns,
+        shard_name: `${shardName}-${stripeIndex + 1}`,
+      });
+    }
   }
   return expandedGroups;
 }
@@ -2248,13 +2286,28 @@ export function createNodeTestShardBundles(
   return [...unbundled, ...bundled].toSorted(compareFullNodeTestAdmissionOrder);
 }
 
-function listAgentSupportTestFiles(): string[] {
-  const owner = agentVitestProjectOwners.support;
+function listAgentOwnerTestFiles(owner: {
+  root: string;
+  include: string[];
+  exclude: string[];
+}): string[] {
+  // Scoped configs drop unit-fast files, so a lister that keeps them prices
+  // stripes on files the shard never runs and hands Vitest inert patterns.
+  const unitFastFiles = new Set(getUnitFastTestFiles());
   return listTestFiles(owner.root).filter(
     (file) =>
+      isStripeEligibleTestFile(file, unitFastFiles) &&
       owner.include.some((pattern) => matchesGlob(file, pattern)) &&
       !owner.exclude.some((pattern) => matchesGlob(file, pattern)),
   );
+}
+
+function listAgentSupportTestFiles(): string[] {
+  return listAgentOwnerTestFiles(agentVitestProjectOwners.support);
+}
+
+function listAgentEmbeddedBaseTestFiles(): string[] {
+  return listAgentOwnerTestFiles(agentVitestProjectOwners.embedded);
 }
 
 // Whole-config groups the hosted splitter may stripe by file: each lister

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -1,6 +1,6 @@
 // Ci Node Test Plan tests cover ci node test plan script behavior.
 import { existsSync, globSync, readdirSync } from "node:fs";
-import { isAbsolute, join, relative, resolve } from "node:path";
+import { isAbsolute, join, matchesGlob, relative, resolve } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   createChangedExtensionFallbackShards,
@@ -33,6 +33,7 @@ import { createToolingVitestConfig } from "../vitest/vitest.tooling.config.ts";
 import { createTuiVitestConfig } from "../vitest/vitest.tui.config.ts";
 import { createUiIsolatedVitestConfig } from "../vitest/vitest.ui-isolated.config.ts";
 import { createUiVitestConfig } from "../vitest/vitest.ui.config.ts";
+import { getUnitFastTestFilesForIncludePatterns } from "../vitest/vitest.unit-fast-paths.mjs";
 import { createUnitVitestConfigWithOptions } from "../vitest/vitest.unit.config.ts";
 import { createWizardVitestConfig } from "../vitest/vitest.wizard.config.ts";
 
@@ -476,11 +477,32 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       ).length,
     ).toBeGreaterThan(0);
     const expectedEmbeddedAgentGroupNames = [
-      "agentic-agents-embedded-base",
+      "agentic-agents-embedded-base-1",
+      "agentic-agents-embedded-base-2",
+      "agentic-agents-embedded-base-3",
       "agentic-agents-embedded-incomplete-turn",
       "agentic-agents-embedded-overflow-compaction",
       "agentic-agents-embedded-run",
     ];
+    // Scoped configs drop unit-fast files and the shared live/e2e suffixes, so
+    // a striped owner covers only the files its config runs; the rest are inert.
+    const ownerScopedTestFiles = (owner: { dir: string; include: string[]; exclude: string[] }) => {
+      const unitFastFiles = new Set(
+        getUnitFastTestFilesForIncludePatterns(owner.include, { dir: owner.dir }),
+      );
+      return globSync(owner.include)
+        .map(toRepoPath)
+        .filter(
+          (file) =>
+            !unitFastFiles.has(file) &&
+            !file.endsWith(".live.test.ts") &&
+            !file.endsWith(".e2e.test.ts") &&
+            !owner.exclude.some((pattern) => matchesGlob(file, pattern)),
+        );
+    };
+    // The embedded composite is the one shard the compact layer subdivides:
+    // it expands into per-config groups and stripes the serial base config.
+    const embeddedBaseOwnerFiles = ownerScopedTestFiles(agentVitestProjectOwners.embedded);
     const compactGroups = compact.flatMap((shard) => shard.groups);
     const pullRequestCompactGroups = pullRequestCompact.flatMap((shard) => shard.groups);
     const expectedGroupNames = base.flatMap((shard) =>
@@ -523,9 +545,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
         if (owner.includePatterns) {
           expect(actual.toSorted(), owner.shardName).toEqual(owner.includePatterns.toSorted());
         } else if (owner.shardName === "agentic-agents-support") {
-          const expected = globSync(agentVitestProjectOwners.support.include, {
-            exclude: agentVitestProjectOwners.support.exclude,
-          }).map(toRepoPath);
+          const expected = ownerScopedTestFiles(agentVitestProjectOwners.support);
           expect(actual.toSorted()).toEqual(expected.toSorted());
         }
       }
@@ -544,6 +564,7 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       base
         .filter((shard) => !pushExcludedShardNames.has(shard.shardName))
         .flatMap((shard) => shard.includePatterns ?? [])
+        .concat(embeddedBaseOwnerFiles)
         .toSorted((a, b) => a.localeCompare(b)),
     );
     expect(
@@ -551,7 +572,10 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
         .flatMap((group) => group.includePatterns ?? [])
         .toSorted((a, b) => a.localeCompare(b)),
     ).toEqual(
-      base.flatMap((shard) => shard.includePatterns ?? []).toSorted((a, b) => a.localeCompare(b)),
+      base
+        .flatMap((shard) => shard.includePatterns ?? [])
+        .concat(embeddedBaseOwnerFiles)
+        .toSorted((a, b) => a.localeCompare(b)),
     );
     expect(compact.every((shard) => shard.groups.every((group) => group.configs.length > 0))).toBe(
       true,
@@ -650,14 +674,31 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
         shard.groups.some((group) => group.shard_name === "agentic-agents-embedded"),
       ),
     ).toBe(false);
-    expect(embeddedAgentGroups.flatMap((group) => group.configs).toSorted()).toEqual(
-      embeddedAgentVitestProjectOwners.map((owner) => owner.config).toSorted(),
+    // The base config repeats once per stripe; its files stay partitioned below.
+    expect(new Set(embeddedAgentGroups.flatMap((group) => group.configs))).toEqual(
+      new Set(embeddedAgentVitestProjectOwners.map((owner) => owner.config)),
     );
     expect(
       embeddedAgentGroups.every(
         (group) => group.env?.OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS === "660000",
       ),
     ).toBe(true);
+    // The base config runs serially with a shared module graph, so its stripes
+    // must partition the owner's files: a repeat re-runs a suite, a miss drops it.
+    const embeddedBaseGroups = embeddedAgentGroups.filter((group) =>
+      /^agentic-agents-embedded-base-\d+$/u.test(group.shard_name),
+    );
+    const embeddedBaseFiles = embeddedBaseGroups.flatMap((group) => group.includePatterns ?? []);
+    expect(embeddedBaseGroups).toHaveLength(3);
+    expect(
+      embeddedBaseGroups.every(
+        (group) => group.configs[0] === agentVitestProjectOwners.embedded.config,
+      ),
+    ).toBe(true);
+    expect(new Set(embeddedBaseFiles).size).toBe(embeddedBaseFiles.length);
+    expect(embeddedBaseFiles.toSorted((a, b) => a.localeCompare(b))).toEqual(
+      embeddedBaseOwnerFiles.toSorted((a, b) => a.localeCompare(b)),
+    );
     expect(
       compact
         .filter((shard) => shard.groups.some((group) => !group.includePatterns))


### PR DESCRIPTION
## What Problem This Solves

`checks-node-compact-large-14` is the tallest job in every recent main CI run, and it sets the wall clock everyone waits on. It takes 340s (21s checkout + 30s setup + 276s shard) while the next-slowest job finishes in 258s, so shaving anything else buys nothing until this one comes down.

Roughly 94% of that shard is a single group, `agentic-agents-embedded-base`. Its body measured 258.1s / 256.4s / 253.7s / 269.4s on runs 33319465485, 33318725438, 33319958268, and 33319413324, while the planner priced it at 79-139s. Under-predicting it by ~3x is why the packer kept treating it as a light group and stacking the wall onto one runner.

## Why This Change Was Made

The group could not be split at all. `splitOversizedGithubCompactGroup` resolves a file lister via `WHOLE_CONFIG_SPLIT_FILE_LISTERS.get(group.shard_name)`, but at that point the group is still the composite `agentic-agents-embedded`; `expandCompactGroup` does not rename it to the four `COMPACT_EMBEDDED_GROUP_NAMES` until after the first-fit bin loop. That late expansion is deliberate — first-fit over the composite sets the bounded worker count — so a lister keyed on the expanded name is unreachable by construction.

Rather than reorder that, this declares `EMBEDDED_BASE_NODE_TEST_STRIPES` and stripes the base config inside `expandCompactGroup`, which is how the other permanently-oversized owners are already handled (`AGENTIC_GATEWAY_CORE_STRIPES`, `CORE_UNIT_SRC_SECURITY_STRIPES`, `UNIT_FAST_NODE_TEST_STRIPES`). First-fit still packs the unexpanded composite, so the bounded-worker property is preserved and **job counts are unchanged: 62 hybrid, 82 github, 38 blacksmith**. The stripes are redistributed into bins that already existed.

The hosted splitter would have been the wrong lever here: its threshold is the hosted 150s cap and hybrid only inherits its splits so a retry is not oversized, which means a Blacksmith-profile wall fixed that way silently regresses if a hosted hint ever drops back under 150. Three stripes rather than two because two would predict 206s hosted each — over the cap — and the hosted splitter would then re-divide them into four on hybrid. At three, each sits at 138s hosted / 86s Blacksmith, under the cap on both profiles, and if the suite later grows past 150 hosted the existing splitter takes over automatically because the stripes now carry `includePatterns`.

Two supporting fixes. The owner lister shared with `agentic-agents-support` over-enumerated: scoped configs drop unit-fast files and the shared `*.live`/`*.e2e` suffixes, so it returned 101 files for a config that runs 73 (and 337 for support, which runs 232). Those extra patterns are inert for Vitest but carried phantom stripe weight, which is exactly what the lister contract forbids. And stripe balance needs anchors: three files own 169s of the 258s wall, so they get `STRIPE_FILE_SECONDS_HINTS` entries measured from run 33319465485 — without them LPT reassembles the whale into one stripe.

## User Impact

Maintainers and contributors wait less on CI. The group's job drops from 340s to a projected ~183s, below the 258s next-slowest, so it stops being the wall. No behavior change to the product, no test coverage change: the same 73 files run, just partitioned across three jobs instead of one.

The one real cost is ~57s of extra CPU fleet-wide, because two additional cold module graphs get imported (`transform` + `import` is ~28s per group run for this config).

## Evidence

**Correctness.** This config is `fileParallelism: false` with `isolate: false`, so its files share a module graph and run serially — splitting them is only safe if nothing is order-dependent. Each stripe was run as its own Vitest process exactly as the shard runner invokes it (`OPENCLAW_VITEST_INCLUDE_FILE` + `scripts/test-projects.mts`):

```
stripe 1  19 files  364 tests  passed
stripe 2  27 files  393 tests  passed
stripe 3  27 files  706 tests  passed
          73 files 1463 tests
```

73 files matches the file count in the whole-group CI run. An earlier, different partition of the same files also ran green — two independent groupings pass, which is the actual evidence against order-dependence.

**Balance.** Per-test sums extracted from run 33319465485's 258.07s group log give 84.8 / 60.6 / 81.4 measured test-seconds per stripe. Stripe 1 is floored by a single 77.3s file, so this is near-optimal for three ways. Packed with their partners the three jobs project to ~183s / 166s / 170s.

**Wall measurements confirmed directly from the job logs:**

```
33319465485  Duration 258.07s
33318725438  Duration 256.35s
33319958268  Duration 253.70s
33319413324  Duration 269.42s
```

**Gates.** `node scripts/run-vitest.mjs test/scripts/ci-node-test-plan.test.ts` — 37 passed. `node scripts/check-changed.mjs` — exit 0. Fresh `$autoreview` (codex/gpt-5.6-sol, xhigh) — `scoped-clean`, no accepted findings.

**Test changes.** The group-name contract now lists the three stripes, plus a new partition guard asserting the stripes cover every owner file exactly once — a repeat re-runs a suite, a miss silently drops it — and a guard that an empty stripe throws, since an empty include list makes the shard runner drop the include file and replay the whole config.

**LOC.** Production `+67/-14` (net +53), tests `+49/-8`. Of the 65 added production lines, 12 are comments and 16 are measurement literals (11 timing-hint entries replacing 5, plus 5 per-file stripe anchors); the remaining logic is the striping branch in `expandCompactGroup` and the extracted `listAgentOwnerTestFiles`, which absorbed the existing support lister rather than adding a parallel one. This is a capability change (a stripe axis for an owner that had none), not a bug fix.
