### PR TITLE
test: await QA deadline unwind without sleeps

### DIFF
--- a/extensions/qa-lab/src/scenario-flow-runner.deadline.test.ts
+++ b/extensions/qa-lab/src/scenario-flow-runner.deadline.test.ts
@@ -84,7 +84,19 @@ describe("scenario flow deadline", () => {
     const finallyMutation = vi.fn();
     const laterMutation = vi.fn();
     const detailsMutation = vi.fn(() => "details");
-    let deadlineTimer: ReturnType<typeof setTimeout> | undefined;
+    let markActionStarted!: () => void;
+    let releaseAction!: () => void;
+    let expireDeadline!: (reason: Error) => void;
+    let pendingStep: Promise<string | void> | undefined;
+    const actionStarted = new Promise<void>((resolve) => {
+      markActionStarted = resolve;
+    });
+    const action = new Promise<void>((resolve) => {
+      releaseAction = resolve;
+    });
+    const deadline = new Promise<never>((_resolve, reject) => {
+      expireDeadline = reject;
+    });
     const thenKey = ["th", "en"].join("");
     const ifAction = Object.fromEntries([
       ["expr", "true"],
@@ -102,7 +114,7 @@ describe("scenario flow deadline", () => {
       ],
     ]);
 
-    const result = await runScenarioFlow({
+    const pending = runScenarioFlow({
       api: {
         signal: controller.signal,
         state: createQaBusState(),
@@ -117,9 +129,8 @@ describe("scenario flow deadline", () => {
         },
         config: {},
         delayedAction: async () => {
-          await new Promise<void>((resolve) => {
-            setTimeout(resolve, 40);
-          });
+          markActionStarted();
+          await action;
         },
         nestedMutation,
         catchMutation,
@@ -127,14 +138,9 @@ describe("scenario flow deadline", () => {
         laterMutation,
         detailsMutation,
         runScenario: async (name, steps) => {
-          const deadline = new Promise<never>((_resolve, reject) => {
-            deadlineTimer = setTimeout(() => {
-              controller.abort(timeoutError);
-              reject(timeoutError);
-            }, 10);
-          });
           try {
-            await Promise.race([steps[0]?.run(), deadline]);
+            pendingStep = steps[0]?.run();
+            await Promise.race([pendingStep, deadline]);
             return { name, status: "pass", steps: [] };
           } catch (error) {
             return {
@@ -143,8 +149,6 @@ describe("scenario flow deadline", () => {
               details: error instanceof Error ? error.message : String(error),
               steps: [],
             };
-          } finally {
-            clearTimeout(deadlineTimer);
           }
         },
       },
@@ -169,14 +173,32 @@ describe("scenario flow deadline", () => {
       },
     });
 
-    expect(result).toMatchObject({ status: "fail", details: timeoutError.message });
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 60);
-    });
-    expect(nestedMutation).not.toHaveBeenCalled();
-    expect(catchMutation).not.toHaveBeenCalled();
-    expect(finallyMutation).toHaveBeenCalledOnce();
-    expect(laterMutation).not.toHaveBeenCalled();
-    expect(detailsMutation).not.toHaveBeenCalled();
+    try {
+      await Promise.race([
+        actionStarted,
+        pending.then(() => {
+          throw new Error("flow settled before the delayed action started");
+        }),
+      ]);
+      controller.abort(timeoutError);
+      expireDeadline(timeoutError);
+      const result = await pending;
+
+      expect(result).toMatchObject({ status: "fail", details: timeoutError.message });
+      // The outer deadline returns while the action is held; cleanup belongs to its late unwind.
+      expect(finallyMutation).not.toHaveBeenCalled();
+      releaseAction();
+      await expect(pendingStep).rejects.toBe(timeoutError);
+      expect(nestedMutation).not.toHaveBeenCalled();
+      expect(catchMutation).not.toHaveBeenCalled();
+      expect(finallyMutation).toHaveBeenCalledOnce();
+      expect(laterMutation).not.toHaveBeenCalled();
+      expect(detailsMutation).not.toHaveBeenCalled();
+    } finally {
+      controller.abort(timeoutError);
+      expireDeadline(timeoutError);
+      releaseAction();
+      await Promise.allSettled([pending, pendingStep, deadline]);
+    }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The flow-unwind test waits for a mocked 10 ms deadline, then sleeps another 60 ms to let its losing 40 ms action finish. It tests abort fencing and finally cleanup, not the production watchdog's clock. Waiting a fixed interval makes every execution do unnecessary work and does not directly establish that the losing step has settled.

## Why This Change Was Made

Use explicit action-start, action-release and deadline promises. Hold the action until the outer deadline failure has returned, then release it and await the actual losing step's rejection. The existing nested action, catch, finally, later-action and details assertions remain. Failure cleanup also releases and joins the same owned promises.

The six async-input cases are unchanged. The separate real watchdog tests retain their timer-boundary, precedence, cap and disposal checks. Production deadlines, test timeouts, sharding, concurrency, backend and runner selection are unchanged.

## User Impact

Faster execution of the affected test, with the early outer failure and late cleanup ordering now explicit. No product change or reproduced-flake claim.

## Evidence

- Two declared warmups followed by six alternating before/after pairs through the normal Vitest wrapper: all seven original cases pass in every run, with no discarded timing samples.
- The changed case's median execution falls from 74.31 ms to 1.04 ms. Summed execution across the seven cases falls from 99.17 ms to 24.25 ms. Whole-command wall medians are 5.490 s and 5.495 s, so no command-wall or suite-wide improvement is claimed.
- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-flow-runner.deadline.test.ts extensions/qa-lab/src/scenario-flow-runner.test.ts extensions/qa-lab/src/suite-runtime-flow.test.ts` passes all 46 flow/deadline/watchdog cases after composition with current main’s separate preparation and action deadlines. The earlier 42-case run remains historical evidence.
- The original nested flow shape and every original assertion remain. The new ordering assertion proves finally cleanup has not run before the held action is released; joining the actual losing step proves the cleanup assertions run after unwind.
- Direct Promise.race and Node AbortController inspection confirms racing does not cancel the loser, abort preserves the supplied reason, and repeated cleanup settlement is safe. The test therefore retains and awaits the original step rather than a proxy completion signal.

Production LOC: unchanged. Tests: +45/-23, 22 added lines for explicit execution ordering and failure-path cleanup while removing the three scheduled waits. The original test and flow fences were added together in #126407; its actual parent-to-child patch was inspected. This PR preserves that contract.

Full changed gate passed, including extension test types and lint. Codex autoreview is clean at its configured P0 threshold; separate full owner/caller/dependency review found no actionable issue.

Current-main composition: #133616 changed the watchdog owner after this PR was opened. The branch was rebased onto `9ebf5aed2cfa3b05c9ab5b1d5d13016b4a87b4ff`; the sole test afterimage is unchanged. The preparation-budget, action-budget, cancellation and disposal cases now pass alongside the real DSL unwind test. These are separate owner and DSL tests, not an end-to-end live transport claim. Fresh Codex branch review and the full changed gate also pass. Exact refreshed-head CI [33362860820](https://github.com/openclaw/openclaw/actions/runs/33362860820) completed successfully at `8b77cc63bf6297257758956a836dbe8680f691cd`. The latest completed ClawSweeper review of that exact head found no actionable issue; its outstanding CI prerequisite is now satisfied.
