### PR TITLE
docs: correct session migration and discovery guidance

### DIFF
--- a/docs/channels/channel-routing.md
+++ b/docs/channels/channel-routing.md
@@ -151,25 +151,34 @@ Example:
 
 ## Session storage
 
-Runtime session rows live in each agent's SQLite database under the state
-directory (default `~/.openclaw`):
+Runtime session rows and transcripts live in each agent's SQLite database under
+the state directory (default `~/.openclaw`):
 
 - `~/.openclaw/agents/<agentId>/agent/openclaw-agent.sqlite`
 
 Older installs may have legacy transcript JSONL files and a `sessions.json` row
-store under `~/.openclaw/agents/<agentId>/sessions/`. Gateway startup and
-`openclaw doctor --fix` import hot legacy rows/history into SQLite
-automatically. Use `openclaw doctor --session-sqlite inspect
+store under `~/.openclaw/agents/<agentId>/sessions/`. To import that history into
+SQLite, stop the Gateway, back up its state, and run `openclaw doctor --fix`
+before restarting it. Gateway startup does not import legacy session files: if
+it finds a legacy store, it refuses readiness and prints the Doctor command for
+the active profile. Use `openclaw doctor --session-sqlite inspect
 --session-sqlite-all-agents` and the
-[Doctor](/cli/doctor#session-sqlite-migration) validation sequence when you need
-explicit migration evidence.
-You can still select a legacy store path via `session.store` and `{agentId}`
-templating for migration and offline-maintenance workflows.
+[Doctor](/cli/doctor#session-sqlite-migration) migration sequence for inspection
+and validation.
 
-Gateway and ACP session discovery also scans disk-backed agent stores under the
-default `agents/` root and under templated `session.store` roots. Discovered
-stores must stay inside that resolved agent root and use a regular legacy
-`sessions.json` file. Symlinks and out-of-root paths are ignored.
+`session.store` supports `{agentId}` templating. At runtime, a legacy store path
+selects its corresponding SQLite database; the JSON file itself is only a
+migration input or an explicit offline-maintenance target.
+
+Gateway session discovery can include on-disk stores under the default `agents/`
+root and templated `session.store` roots that use the
+`agents/<agentId>/sessions/sessions.json` layout. It recognizes the corresponding
+`agent/openclaw-agent.sqlite` database without requiring a legacy `sessions.json`
+file. Discovered store files must be regular files within the resolved agent
+root; symlinked store files and out-of-root paths are ignored.
+
+ACP session discovery reads SQLite ACP metadata and joins it to the corresponding
+session entries.
 
 ## WebChat behavior
 


### PR DESCRIPTION
## What Problem This Solves

Resolves contradictory session-storage guidance on the [channel-routing page](https://docs.openclaw.ai/channels/channel-routing#session-storage). The page tells operators that Gateway startup automatically imports legacy `sessions.json` and transcript history, even though startup refuses readiness and directs them to Doctor. It also incorrectly requires a legacy JSON file for discovery and describes Gateway and ACP as sharing a directory scan.

## Why This Change Was Made

Align this page with the existing storage owners and the session-management and Doctor documentation. Legacy import belongs to Doctor; runtime session rows and transcripts remain in SQLite. The correction preserves `session.store` templating, qualifies discoverable per-agent layouts, and distinguishes Gateway disk discovery from ACP's SQLite metadata lookup.

This is a one-page documentation correction. Runtime, storage, configuration, schemas, and migration semantics are unchanged. The [startup migration ownership correction](https://github.com/openclaw/openclaw/commit/df905a6cb652ca9a7c441c6c9a881bb6bdc1f13e) updated the primary session docs but left this page behind.

## User Impact

Operators are directed to stop the Gateway, back up its state, and run `openclaw doctor --fix` before restarting. They are no longer told that a legacy JSON file must exist for SQLite session discovery. Existing path-containment and symlink safeguards are preserved in the explanation.

## Evidence

Source audit covered the complete startup, target-discovery, path-resolution, Doctor import, Gateway combined-store, ACP metadata, and SQLite session-reader owners, relevant history, and existing regression coverage. The relevant owners and channel-routing page still match freshly fetched `main` at `0ee6e0575a90f8c3fce8cd54e173d6b31b0923ef`.

Key evidence:

- `src/config/sessions/startup-migration.ts:39-49`: preserve legacy files and refuse startup with a profile-aware Doctor command.
- `src/commands/doctor-session-transcripts.ts:475-515`: Doctor repair selects the explicit import mode.
- `src/config/sessions/targets.ts:153-180` and `src/config/sessions/paths.ts:368-382`: recognize the corresponding SQLite artifact and qualify discoverable agent-root layouts.
- `src/acp/runtime/session-meta.ts:469-528`: list SQLite ACP rows and join current session entries.
- Existing tests inspected: `src/gateway/session-startup-migration.test.ts:117-148`, `src/config/sessions/targets-discovery.test.ts`, and ACP listing cases in `src/acp/runtime/session-meta.test.ts:881-965`.

Local validation:

```bash
pnpm docs:list
```

```bash
node scripts/check-docs-mdx.mjs docs/channels/channel-routing.md
```

```bash
./node_modules/.bin/oxfmt --check docs/channels/channel-routing.md
```

```bash
git diff --check
```

All four checks passed. The fresh MDX check initially encountered a missing `property-information` dependency; `pnpm install` completed and the same scoped check passed on retry, with no tracked dependency changes.

Docs LOC: +23/-14. Production LOC: +0/-0. Tests: +0/-0. No new regression test is needed for a prose-only correction; existing behavior tests were inspected, not rerun. No Gateway/Doctor process was started, and no credentials, `.runtime` directories, or live operator state were accessed. Full builds and runtime/live suites are intentionally out of scope.

The separate stale downgrade statement in `docs/reference/session-management-compaction.md:95-100` was recorded as a follow-up and is not changed here.

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer branch, available for maintainer edits.

</details>
