### PR TITLE
test(qa): join fixture owners before removing resources

### DIFF
--- a/test/e2e/qa-lab/plugins/discord-show-widget-contextual-presenter.e2e.test.ts
+++ b/test/e2e/qa-lab/plugins/discord-show-widget-contextual-presenter.e2e.test.ts
@@ -95,8 +95,8 @@ function writeJson(res: ServerResponse, statusCode: number, value: unknown): voi
 
 async function startDiscordRestLoopback() {
   const requests: DiscordRestRequest[] = [];
-  const server = createServer(async (req, res) => {
-    try {
+  const server = createServer((req, res) => {
+    void (async () => {
       const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
       const method = req.method ?? "GET";
       const payload = await readRequestBody(req);
@@ -110,9 +110,9 @@ async function startDiscordRestLoopback() {
         return;
       }
       writeJson(res, 404, { message: `unexpected Discord REST request: ${method} ${pathname}` });
-    } catch (error) {
+    })().catch((error: unknown) => {
       writeJson(res, 500, { message: error instanceof Error ? error.message : String(error) });
-    }
+    });
   });
   await new Promise<void>((resolve, reject) => {
     server.once("error", reject);
@@ -126,9 +126,9 @@ async function startDiscordRestLoopback() {
     baseUrl: `http://127.0.0.1:${address.port}`,
     requests,
     stop: async () =>
-      await new Promise<void>((resolve, reject) =>
-        server.close((error) => (error ? reject(error) : resolve())),
-      ),
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
   };
 }
 

--- a/test/e2e/qa-lab/runtime/gateway-compaction-abort.ts
+++ b/test/e2e/qa-lab/runtime/gateway-compaction-abort.ts
@@ -491,6 +491,8 @@ async function runCases(runtime: Runtime, repoRoot: string, artifactBase: string
       path.join(artifactBase, "channel-transcript.json"),
       `${JSON.stringify(state.getSnapshot().messages, null, 2)}\n`,
     );
+  } catch (error) {
+    failures.push(error instanceof Error ? error.message : String(error));
   } finally {
     active?.releaseSummary.resolve();
     active?.releaseAfterHook.resolve();
@@ -538,6 +540,11 @@ async function runCases(runtime: Runtime, repoRoot: string, artifactBase: string
         await provider?.stop();
       },
       () => bus.stop(),
+      async () => {
+        if (cleanupErrors.length === 0) {
+          await fs.writeFile(path.join(tmpRoot, "gateway-stopped"), "confirmed\n");
+        }
+      },
     ];
     for (const stop of cleanup) {
       try {
@@ -547,9 +554,10 @@ async function runCases(runtime: Runtime, repoRoot: string, artifactBase: string
       }
     }
     if (cleanupErrors.length) {
-      throw new AggregateError(cleanupErrors, "Gateway proof cleanup failed");
+      failures.push(
+        `Gateway proof cleanup failed: ${cleanupErrors.map((error) => (error instanceof Error ? error.message : String(error))).join("; ")}`,
+      );
     }
-    await fs.writeFile(path.join(tmpRoot, "gateway-stopped"), "confirmed\n");
   }
   return failures;
 }

--- a/test/e2e/qa-lab/runtime/gateway-mcp-app-grant-revalidation.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-mcp-app-grant-revalidation.e2e.test.ts
@@ -1,5 +1,4 @@
 import { randomUUID } from "node:crypto";
-import { watch } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
@@ -20,54 +19,14 @@ import {
   createChildEnv,
   startHttpFixture,
   stopChild,
+  waitForMcpFixtureGate,
   type GatewayHandle,
   type HttpFixture,
 } from "./gateway-node-mcp.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-const GATE_WAIT_TIMEOUT_MS = 30_000;
 const APP_TOOL_NAME = "streamableHttp__parity_app";
 const POST_REVOCATION_MARKER = "post-revocation";
-
-async function waitForFile(filePath: string): Promise<void> {
-  try {
-    await fs.access(filePath);
-    return;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw error;
-    }
-  }
-  await new Promise<void>((resolve, reject) => {
-    const timeout = setTimeout(() => {
-      watcher.close();
-      reject(new Error(`timed out waiting for fixture gate: ${path.basename(filePath)}`));
-    }, GATE_WAIT_TIMEOUT_MS);
-    timeout.unref();
-    const finish = (error?: unknown) => {
-      clearTimeout(timeout);
-      watcher.close();
-      error ? reject(error) : resolve();
-    };
-    const inspect = () => {
-      void fs.access(filePath).then(
-        () => finish(),
-        (error: NodeJS.ErrnoException) => {
-          if (error.code !== "ENOENT") {
-            finish(error);
-          }
-        },
-      );
-    };
-    const watcher = watch(path.dirname(filePath), (_event, filename) => {
-      if (!filename || filename.toString() === path.basename(filePath)) {
-        inspect();
-      }
-    });
-    watcher.once("error", finish);
-    inspect();
-  });
-}
 
 function requireMcpAppViewId(messages: unknown[]): string {
   for (const message of messages) {
@@ -298,7 +257,7 @@ describe("Gateway MCP App board grant revalidation", () => {
         expect(notificationCall.status).toBe(200);
 
         pendingCall = postStandalone({ gateway, ticket, marker: POST_REVOCATION_MARKER });
-        await waitForFile(startedPath);
+        await waitForMcpFixtureGate(startedPath);
         await gateway.call("board.update", {
           sessionKey,
           ops: [{ kind: "widget_remove", name: widget.name }],

--- a/test/e2e/qa-lab/runtime/gateway-node-mcp.test-support.test.ts
+++ b/test/e2e/qa-lab/runtime/gateway-node-mcp.test-support.test.ts
@@ -1,7 +1,10 @@
+import { once } from "node:events";
+import nodeFs from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../helpers/temp-dir.js";
 import {
   createChildEnv,
@@ -9,11 +12,82 @@ import {
   processIsAlive,
   startHttpFixture,
   stopChild,
+  waitForMcpFixtureGate,
 } from "./gateway-node-mcp.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("gateway node MCP fixture ownership", () => {
+  it.each(["existing", "published"] as const)(
+    "joins its watcher when the gate is %s",
+    async (mode) => {
+      const root = tempDirs.make("mcp-gate-publication-");
+      const gate = path.join(root, "gate");
+      if (mode === "existing") {
+        await fs.writeFile(gate, "ready");
+      }
+      const watching = createDeferred<nodeFs.FSWatcher>();
+      const watch = nodeFs.watch;
+      const observeWatch = vi.fn((...args: Parameters<typeof watch>) => {
+        const watcher = watch(...args);
+        watching.resolve(watcher);
+        return watcher;
+      });
+      vi.resetModules();
+      vi.doMock("node:fs", () => ({ ...nodeFs, watch: observeWatch }));
+      const { waitForMcpFixtureGate: waitForGate } =
+        await import("./gateway-node-mcp.test-support.js");
+      let watcher: nodeFs.FSWatcher | undefined;
+      const waiting = waitForGate(gate);
+      try {
+        if (mode === "published") {
+          watcher = await watching.promise;
+          const closed = once(watcher, "close");
+          await fs.writeFile(gate, "ready");
+          await waiting;
+          await closed;
+        } else {
+          await waiting;
+          expect(observeWatch).not.toHaveBeenCalled();
+        }
+        expect(await fs.readFile(gate, "utf8")).toBe("ready");
+      } finally {
+        watcher?.close();
+        await waiting;
+        vi.doUnmock("node:fs");
+        vi.resetModules();
+      }
+    },
+  );
+
+  it("releases its deadline when the real gate watcher cannot be constructed", async () => {
+    const root = tempDirs.make("mcp-gate-watch-failure-");
+    const timers = vi.spyOn(globalThis, "setTimeout");
+    const cleared = vi.spyOn(globalThis, "clearTimeout");
+    try {
+      await expect(waitForMcpFixtureGate(path.join(root, "missing", "gate"))).rejects.toMatchObject(
+        {
+          code: "ENOENT",
+          syscall: "watch",
+        },
+      );
+      const allocated = timers.mock.results.flatMap((result, index) =>
+        result.type === "return" && timers.mock.calls[index]?.[1] === 30_000 ? [result.value] : [],
+      );
+      expect(
+        allocated.filter((timer) => !cleared.mock.calls.some(([value]) => value === timer)).length,
+      ).toBe(0);
+    } finally {
+      for (const result of timers.mock.results) {
+        if (result.type === "return") {
+          clearTimeout(result.value);
+        }
+      }
+      timers.mockRestore();
+      cleared.mockRestore();
+    }
+  });
+
   it.each([
     ["direct", (payload: object) => payload],
     ["node.invoke", (payload: object) => ({ ok: true, payload })],

--- a/test/e2e/qa-lab/runtime/gateway-node-mcp.test-support.ts
+++ b/test/e2e/qa-lab/runtime/gateway-node-mcp.test-support.ts
@@ -1,14 +1,18 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { once } from "node:events";
+import { watch } from "node:fs";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { setTimeout as delay } from "node:timers/promises";
+import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { expect, vi } from "vitest";
 import type { QaGatewayChild } from "../../../../extensions/qa-lab/api.js";
 import type { NodePluginToolDescriptor } from "../../../../packages/gateway-protocol/src/schema/nodes.js";
 import type { McpServerConfig } from "../../../../src/config/types.mcp.js";
+import { hasErrnoCode } from "../../../../src/infra/errno.js";
 import { signalProcessTree } from "../../../../src/process/kill-tree.js";
 
 export const TEST_TIMEOUT_MS = 180_000;
@@ -58,6 +62,51 @@ export type ToolsEffectiveResult = {
 };
 
 const CHILD_ENV_KEYS = ["PATH", "PATHEXT", "SystemRoot", "WINDIR", "ComSpec"] as const;
+
+export async function waitForMcpFixtureGate(filePath: string): Promise<void> {
+  try {
+    await fs.access(filePath);
+    return;
+  } catch (error) {
+    if (!hasErrnoCode(error, "ENOENT")) {
+      throw error;
+    }
+  }
+  await new Promise<void>((resolve, reject) => {
+    const finish = (error?: Error) => {
+      clearTimeout(timeout);
+      watcher.close();
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    };
+    const inspect = () => {
+      void fs.access(filePath).then(
+        () => finish(),
+        (error: unknown) => {
+          if (!hasErrnoCode(error, "ENOENT")) {
+            finish(toErrorObject(error, "Fixture gate inspection failed"));
+          }
+        },
+      );
+    };
+    const watcher = watch(path.dirname(filePath), (_event, filename) => {
+      if (!filename || filename === path.basename(filePath)) {
+        inspect();
+      }
+    });
+    // watch() can throw synchronously; only a constructed watcher owns a deadline.
+    const timeout = setTimeout(() => {
+      watcher.close();
+      reject(new Error(`timed out waiting for fixture gate: ${path.basename(filePath)}`));
+    }, WAIT_TIMEOUT_MS);
+    timeout.unref();
+    watcher.once("error", finish);
+    inspect();
+  });
+}
 
 function captureChild(child: ChildProcess): CapturedChild {
   let stdout = "";

--- a/test/e2e/qa-lab/runtime/worker-inference-generation-reload.ts
+++ b/test/e2e/qa-lab/runtime/worker-inference-generation-reload.ts
@@ -4,6 +4,7 @@ import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { coerceErrorMessage, toErrorObject } from "@openclaw/normalization-core/error-coercion";
 import { GatewayClient } from "openclaw/plugin-sdk/gateway-runtime";
 import {
   createQaBusState,
@@ -15,6 +16,7 @@ import {
   type QaEvidenceSummaryJson,
 } from "../../../../extensions/qa-lab/api.js";
 import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
+import { collectErrorGraphCandidates } from "../../../../src/infra/errors.js";
 import { stopQaGatewayFixture } from "../../../helpers/qa-gateway-cleanup.js";
 import {
   MODEL_REF as DEFAULT_MOCK_MODEL_REF,
@@ -125,7 +127,7 @@ async function startAuthInspectingProxy(targetBaseUrl: string) {
       });
       response.writeHead(upstream.status, responseHeaders);
       response.end(Buffer.from(await upstream.arrayBuffer()));
-    })().catch((error) => {
+    })().catch((error: unknown) => {
       response.writeHead(502, { "content-type": "text/plain; charset=utf-8" });
       response.end(error instanceof Error ? error.message : String(error));
     });
@@ -455,7 +457,7 @@ async function runProof(options: ProducerOptions) {
   let operator: GatewayClient | undefined;
   let worker: PairedNodeWorkerHost | undefined;
   let published: PublishedWireWorkspace | undefined;
-  let proofError: unknown;
+  let proofError: Error | undefined;
   let verdict: Record<string, unknown> | undefined;
   try {
     await fs.mkdir(options.artifactBase, { recursive: true });
@@ -563,22 +565,26 @@ async function runProof(options: ProducerOptions) {
     const requestFacts = requests.map((request) => ({
       model: request.model,
       outcome: request.outcome,
-      generationA: String(request.allInputText ?? "").includes(GENERATION_A_REPLY),
-      generationB: String(request.allInputText ?? "").includes(GENERATION_B_REPLY),
-      generationC: String(request.allInputText ?? "").includes(GENERATION_C_REPLY),
+      generationA: (request.allInputText ?? "").includes(GENERATION_A_REPLY),
+      generationB: (request.allInputText ?? "").includes(GENERATION_B_REPLY),
+      generationC: (request.allInputText ?? "").includes(GENERATION_C_REPLY),
     }));
+    const [firstRequest, secondRequest, thirdRequest] = requestFacts;
     if (
       requests.length !== 3 ||
       requests.some((request) => request.outcome !== "success") ||
-      requestFacts[0]?.generationA !== true ||
-      requestFacts[0]?.generationB !== false ||
-      requestFacts[0]?.generationC !== false ||
-      requestFacts[1]?.generationA !== true ||
-      requestFacts[1]?.generationB !== true ||
-      requestFacts[1]?.generationC !== false ||
-      requestFacts[2]?.generationA !== true ||
-      requestFacts[2]?.generationB !== true ||
-      requestFacts[2]?.generationC !== true
+      !firstRequest ||
+      !secondRequest ||
+      !thirdRequest ||
+      !firstRequest.generationA ||
+      firstRequest.generationB ||
+      firstRequest.generationC ||
+      !secondRequest.generationA ||
+      !secondRequest.generationB ||
+      secondRequest.generationC ||
+      !thirdRequest.generationA ||
+      !thirdRequest.generationB ||
+      !thirdRequest.generationC
     ) {
       throw new Error(`unexpected mock-openai worker requests: ${JSON.stringify(requestFacts)}`);
     }
@@ -691,7 +697,7 @@ async function runProof(options: ProducerOptions) {
       "utf8",
     );
   } catch (error) {
-    proofError = error;
+    proofError = toErrorObject(error, "Worker inference generation proof failed");
   }
 
   const cleanup = await Promise.allSettled([
@@ -702,11 +708,19 @@ async function runProof(options: ProducerOptions) {
     authProxy.stop(),
     mock.stop(),
     channelBus.stop(),
-    fs.rm(root, { recursive: true, force: true }),
   ]);
   const cleanupFailures = cleanup.flatMap((result) =>
     result.status === "rejected" ? [result.reason] : [],
   );
+  // The worker and published workspace still use this namespace during stop.
+  // A failed shutdown retains it for independent cleanup after confirmed joins.
+  if (cleanupFailures.length === 0) {
+    try {
+      await fs.rm(root, { recursive: true, force: true });
+    } catch (error) {
+      cleanupFailures.push(error);
+    }
+  }
   if (cleanupFailures.length > 0) {
     proofError = new AggregateError(
       proofError ? [proofError, ...cleanupFailures] : cleanupFailures,
@@ -757,7 +771,12 @@ async function runProducer(options: ProducerOptions): Promise<QaEvidenceSummaryJ
       status: "pass",
     });
   } catch (error) {
-    const details = error instanceof Error ? error.message : String(error);
+    const details = collectErrorGraphCandidates(error, (current) => [
+      current.cause,
+      ...(current instanceof AggregateError ? current.errors : []),
+    ])
+      .map(coerceErrorMessage)
+      .join("; ");
     writer.appendLog(`fail: ${details}\n`);
     return await writer.write({
       details,

--- a/test/helpers/qa-gateway-cleanup.test.ts
+++ b/test/helpers/qa-gateway-cleanup.test.ts
@@ -1,7 +1,16 @@
+import { once } from "node:events";
+import fs from "node:fs/promises";
+import { connect, type Socket } from "node:net";
+import path from "node:path";
+import type { Duplex } from "node:stream";
+import { setImmediate } from "node:timers/promises";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveRelativeBundledPluginPublicModuleId } from "../../src/test-utils/bundled-plugin-public-surface.js";
 import { createDeferred } from "./promise.js";
 import { runQaGatewayFixture, stopQaGatewayFixture } from "./qa-gateway-cleanup.js";
+import { useAutoCleanupTempDirTracker } from "./temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const qaApiModuleId = resolveRelativeBundledPluginPublicModuleId({
   fromModuleUrl: import.meta.url,
@@ -23,6 +32,10 @@ afterEach(() => {
   vi.doUnmock("../../src/gateway/client.js");
   vi.doUnmock("../../scripts/e2e/lib/plugin-index-sqlite.mjs");
   vi.doUnmock("../e2e/qa-lab/runtime/otel-test-support.js");
+  vi.doUnmock("../e2e/qa-lab/runtime/script-evidence.js");
+  vi.doUnmock("../e2e/qa-lab/runtime/paired-node-worker-wire-fixture.js");
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
   vi.resetModules();
 });
 
@@ -31,6 +44,246 @@ function errorTree(error: unknown): unknown[] {
 }
 
 describe("QA gateway fixture error composition", () => {
+  it.each(["joined", "unconfirmed", "rejected"] as const)(
+    "keeps the generation workspace through a held server close and %s Gateway cleanup",
+    async (shutdown) => {
+      const root = await fs.realpath(tempDirs.make("qa-generation-cleanup-"));
+      for (const key of ["TMPDIR", "TMP", "TEMP"]) {
+        vi.stubEnv(key, root);
+      }
+      const cleanupStarted = createDeferred();
+      const evidenceWritten = createDeferred();
+      const cleaned: string[] = [];
+      const written: Array<{ status: string; details?: string }> = [];
+      let workspaceRoot = "";
+      let socket: Socket | undefined;
+      let peer: Duplex | undefined;
+      let serverJoined = false;
+      let removal: Promise<void> | undefined;
+      const remove = fs.rm.bind(fs);
+      vi.spyOn(fs, "rm").mockImplementation((target, options) => {
+        const operation = remove(target, options);
+        if (target === workspaceRoot) {
+          removal = operation;
+        }
+        return operation;
+      });
+      vi.doMock(
+        "../e2e/qa-lab/runtime/paired-node-worker-wire-fixture.js",
+        async (importOriginal) => {
+          const actual =
+            await importOriginal<
+              typeof import("../e2e/qa-lab/runtime/paired-node-worker-wire-fixture.js")
+            >();
+          return {
+            ...actual,
+            createPublishedWireWorkspace: async (ownedRoot: string) => {
+              workspaceRoot = ownedRoot;
+              const published = await actual.createPublishedWireWorkspace(ownedRoot);
+              const address = published.server.address();
+              if (!address || typeof address === "string") {
+                throw new Error("workspace server did not bind");
+              }
+              published.server.once("close", () => {
+                serverJoined = true;
+              });
+              published.server.once("upgrade", (_request, upgraded) => {
+                peer = upgraded;
+                upgraded.write(
+                  "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: fixture\r\n\r\n",
+                );
+              });
+              socket = connect(address.port, "127.0.0.1");
+              await once(socket, "connect");
+              const upgraded = once(socket, "data");
+              socket.write(
+                "GET /repo.git/ HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: fixture\r\n\r\n",
+              );
+              await upgraded;
+              return published;
+            },
+          };
+        },
+      );
+      vi.doMock(qaApiModuleId, () => ({
+        QA_EVIDENCE_FILENAME: "qa-evidence.json",
+        createQaBusState: () => ({}),
+        createQaChannelTransport: () => ({}),
+        startQaBusServer: async () => ({
+          baseUrl: "http://127.0.0.1:1",
+          stop: async () => {
+            cleaned.push("bus");
+            cleanupStarted.resolve();
+          },
+        }),
+        startQaMockOpenAiServer: async () => ({
+          baseUrl: "http://127.0.0.1:1",
+          stop: async () => {
+            cleaned.push("provider");
+          },
+        }),
+        createQaGatewayChild: () => ({
+          start: async () => {
+            throw new Error("generation startup failed");
+          },
+          stop: async () => {
+            cleaned.push("gateway");
+            if (shutdown === "rejected") {
+              throw new Error("generation shutdown rejected");
+            }
+            return shutdown === "unconfirmed"
+              ? { process: "unconfirmed", errors: [new Error("generation shutdown unconfirmed")] }
+              : { process: "never-spawned", errors: [] };
+          },
+        }),
+      }));
+      vi.doMock("../e2e/qa-lab/runtime/script-evidence.js", () => ({
+        createQaScriptEvidenceWriter: () => ({
+          appendLog: () => {},
+          write: async (result: { status: string; details?: string }) => {
+            written.push(result);
+            evidenceWritten.resolve();
+            return { entries: [{ result }] };
+          },
+        }),
+      }));
+      const previousExitCode = process.exitCode;
+      const argv = process.argv;
+      process.argv = [
+        process.execPath,
+        path.resolve("test/e2e/qa-lab/runtime/worker-inference-generation-reload.ts"),
+        "--artifact-base",
+        path.join(root, "evidence"),
+      ];
+      try {
+        await import("../e2e/qa-lab/runtime/worker-inference-generation-reload.js");
+        await cleanupStarted.promise;
+        // Join an already-started removal before observing the namespace. On the
+        // fixed owner, removal cannot start while the real server close is held.
+        await removal;
+        expect(serverJoined).toBe(false);
+        await expect(fs.stat(workspaceRoot)).resolves.toBeDefined();
+      } finally {
+        const closed = socket ? once(socket, "close") : Promise.resolve();
+        socket?.destroy();
+        peer?.destroy();
+        await closed;
+        await evidenceWritten.promise;
+        // The failure footer only has promise continuations after evidence write.
+        // The next check phase observes its exit code without replacing process.
+        await setImmediate();
+        const exitCode = process.exitCode;
+        process.exitCode = previousExitCode;
+        process.argv = argv;
+        expect(exitCode).toBe(1);
+      }
+      expect(serverJoined).toBe(true);
+      expect(cleaned).toEqual(["gateway", "provider", "bus"]);
+      expect(written[0]?.status).toBe("fail");
+      expect(written[0]?.details).toContain("generation startup failed");
+      if (shutdown === "joined") {
+        await expect(fs.stat(workspaceRoot)).rejects.toMatchObject({ code: "ENOENT" });
+      } else {
+        await expect(fs.stat(workspaceRoot)).resolves.toBeDefined();
+        expect(written[0]?.details).toContain(`generation shutdown ${shutdown}`);
+      }
+    },
+  );
+
+  it("records compaction startup and cleanup failures after joining the provider", async () => {
+    const root = await fs.realpath(tempDirs.make("qa-compaction-cleanup-"));
+    const repoRoot = path.join(root, "repo");
+    await fs.mkdir(path.join(repoRoot, "dist", "plugin-sdk"), { recursive: true });
+    await fs.writeFile(path.join(repoRoot, "dist", "index.js"), "");
+    await fs.writeFile(path.join(repoRoot, "dist", "plugin-sdk", "qa-lab.js"), "");
+    for (const key of ["TMPDIR", "TMP", "TEMP"]) {
+      vi.stubEnv(key, root);
+    }
+    for (const key of [
+      "HOME",
+      "OPENCLAW_HOME",
+      "OPENCLAW_STATE_DIR",
+      "OPENCLAW_CONFIG_PATH",
+      "OPENCLAW_OAUTH_DIR",
+      "XDG_CONFIG_HOME",
+      "XDG_DATA_HOME",
+      "XDG_CACHE_HOME",
+    ]) {
+      vi.stubEnv(key, path.join(root, "home"));
+    }
+    const cleaned: string[] = [];
+    let providerUrl: string | undefined;
+    const written: Array<{ status: string; details?: string }> = [];
+    vi.doMock(qaApiModuleId, () => ({
+      createQaBusState: () => ({}),
+      createQaChannelTransport: () => ({}),
+      startQaBusServer: async () => ({
+        baseUrl: "http://127.0.0.1:1",
+        stop: async () => {
+          cleaned.push("bus");
+          throw new Error("bus cleanup failed");
+        },
+      }),
+      createQaGatewayChild: () => ({
+        start: async (params: { providerBaseUrl: string }) => {
+          providerUrl = params.providerBaseUrl;
+          const response = await fetch(`${providerUrl}/models`);
+          expect(response.status).toBe(200);
+          await response.arrayBuffer();
+          throw new Error("compaction startup failed");
+        },
+        stop: async () => {
+          cleaned.push("gateway");
+          return { process: "never-spawned", errors: [new Error("gateway cleanup failed")] };
+        },
+      }),
+    }));
+    vi.doMock("../e2e/qa-lab/runtime/script-evidence.js", () => ({
+      createQaScriptEvidenceWriter: () => ({
+        appendLog: () => {},
+        write: async (result: { status: string; details?: string }) => {
+          written.push(result);
+        },
+      }),
+    }));
+    const exited = createDeferred<number | string | null | undefined>();
+    vi.spyOn(process, "exit").mockImplementation((code) => {
+      exited.resolve(code);
+      return undefined as never;
+    });
+    const argv = process.argv;
+    process.argv = [
+      process.execPath,
+      path.resolve("test/e2e/qa-lab/runtime/gateway-compaction-abort.ts"),
+      "--isolated-child",
+      "--repo-root",
+      repoRoot,
+      "--artifact-base",
+      ".artifacts/cleanup-proof",
+    ];
+    try {
+      await import("../e2e/qa-lab/runtime/gateway-compaction-abort.js");
+      expect(await exited.promise).toBe(1);
+      expect(cleaned).toEqual(["gateway", "bus"]);
+      expect(providerUrl).toBeDefined();
+      await expect(fetch(`${providerUrl}/models`)).rejects.toThrow();
+      expect(written).toHaveLength(1);
+      expect(written[0]?.status).toBe("fail");
+      for (const message of [
+        "compaction startup failed",
+        "gateway cleanup failed",
+        "bus cleanup failed",
+      ]) {
+        expect(written[0]?.details).toContain(message);
+      }
+      await expect(fs.stat(path.join(root, "gateway-stopped"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+    } finally {
+      process.argv = argv;
+    }
+  });
+
   it.each(["diagnostic", "rejection"])(
     "stops the WebChat bus after startup fails and owner cleanup reports a %s",
     async (mode) => {


### PR DESCRIPTION
## What Problem This Solves

Three QA fixture lifetime defects made failure evidence unreliable: the worker-generation proof could remove its temporary workspace while its server and other owners were still shutting down; compaction cleanup could replace the original failure with a cleanup-only message; and an MCP gate watcher could leave a deadline allocated when `fs.watch` threw synchronously.

These were found during maintainer-requested release verification and reproduced against main at `8249fd61a9183a14063278741093645f8f3b238f`. This PR isolates seven test/test-support files from the separate prepared-runtime/build-owner investigation.

## Why This Change Was Made

Keep cleanup responsibility at the fixture owner. Worker-generation cleanup now joins every stop before removing its namespace, retains the namespace when shutdown fails or is unconfirmed, and includes primary plus aggregate cleanup details in the existing bounded/redacted evidence path. Compaction records both its primary failure and subsequent cleanup failures while still attempting all owners.

The MCP gate waiter moves into the existing test-support module and allocates its unchanged deadline only after constructing the watcher. Nearby promise/error handling is made explicit so the same seven paths pass type-aware lint without weakening product assertions.

The regressions run actual script footers with a real temporary Git workspace, loopback HTTP/provider servers, an upgraded socket holding server close, real filesystem removal and real `fs.watch` failure. Existing injection seams supply Gateway/startup/cleanup faults; no new production test seam is introduced. Increasing timeouts or checking only final temporary-directory absence would miss the ownership bugs.

## User Impact

Internal QA reliability and diagnostics only. No product runtime, public SDK, config, storage, dependencies, release artifacts or operator defaults change. No changelog edit. Production LOC: **+0/-0**. Tests/test support: **+431/-69** (net +362); this comprises +327 regression-test lines and net +35 fixture/support lines, including the waiter move. Existing E2E product assertions remain intact.

## Evidence

Local environment: Node 24.20.0, pnpm 12.1.0, Vitest 4.1.11, macOS arm64. Node watcher construction and HTTP/server-close contracts were inspected directly in the installed runtime source.

- Before the owner fixes, the two complete regression files produced **13 passes / 5 intended failures**: three premature namespace-removal cases, one lost-primary-error case and one abandoned watcher deadline.
- Fixed owner/error suites: **63 passes** across four files; evidence-writer sibling: **13 passes**. Total fixed proof: **76 unique cases**, not a count inflated by the failing-before run.
- Exact seven-path type-aware lint: 18 diagnostics before → zero after. Root test types, formatting, selected guards, the complete seven-path changed gate and `git diff --check` passed.
- Fresh managed Codex review of the actual seven-file diff and owner context: scoped-clean P0, no actionable findings. The reviewer did not run tests; the executions above were independent local proof.

```bash
node scripts/run-vitest.mjs test/helpers/qa-gateway-cleanup.test.ts test/e2e/qa-lab/runtime/gateway-node-mcp.test-support.test.ts src/infra/errors.test.ts packages/normalization-core/src/error-coercion.test.ts --maxWorkers=16
```

```bash
node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/script-evidence.test.ts --maxWorkers=16
```

```bash
node scripts/check-changed.mjs -- test/e2e/qa-lab/plugins/discord-show-widget-contextual-presenter.e2e.test.ts test/e2e/qa-lab/runtime/gateway-compaction-abort.ts test/e2e/qa-lab/runtime/gateway-mcp-app-grant-revalidation.e2e.test.ts test/e2e/qa-lab/runtime/gateway-node-mcp.test-support.test.ts test/e2e/qa-lab/runtime/gateway-node-mcp.test-support.ts test/e2e/qa-lab/runtime/worker-inference-generation-reload.ts test/helpers/qa-gateway-cleanup.test.ts
```

Proof limits: these are actual-script/server/filesystem boundary controls with synthetic faults, not full Gateway generation/compaction, Discord, Linux, packaged or native-provider acceptance. The separate build-owner/fs-safe race and previously unlocalized staging-removal timeout remain unresolved by this PR. No timeout increase, skip, retry or environment mask was added. Exact-head CI and native landing gates remain required.
