### PR TITLE
perf: shrink cloud bootstrap archives and memory use

### DIFF
--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -207,7 +207,7 @@ Each enrollment receives short-lived download authority scoped to that live prov
 
 Native dependencies are installed by npm for the cloud machine's operating system and CPU; the archive does not copy the build host's native `node_modules`. Registry access is still required, and this is not an offline dependency bundle. Bootstrap does not select a global OpenClaw installation merely because its version matches.
 
-The Gateway reuses its prepared archive for subsequent enrollments with the same execution mode. Nodes keep successful installs under `~/.openclaw-worker/node-runtimes/<sha256>`, so a warm image can reuse the exact artifact. A different digest selects a different installation even when the version is unchanged. After enrollment, OpenClaw `worker-turn` receives its separate content-addressed worker bundle through the authenticated node channel; Codex `remote-exec` starts the managed exec-server directly. Existing placement checks, node-command allowlists, and invocation approval still govern execution.
+The Gateway reuses its prepared archive for subsequent enrollments with the same execution mode. Nodes keep successful installs under `~/.openclaw-worker/node-runtimes/<sha256>`, so a warm image can reuse the exact artifact. A different digest selects a different installation even when the version is unchanged. The runtime archive omits the worker deploy artifacts: nodes receive the content-addressed worker bundle separately through the authenticated node channel after enrollment. OpenClaw `worker-turn` uses that bundle; Codex `remote-exec` starts the managed exec-server directly. Existing placement checks, node-command allowlists, and invocation approval still govern execution.
 
 ### Build a complete custom node package
 

--- a/src/gateway/worker-environments/node-bootstrap-artifact.test.ts
+++ b/src/gateway/worker-environments/node-bootstrap-artifact.test.ts
@@ -55,6 +55,8 @@ async function fixture(mode: "source" | "package" | "external-plugin" = "source"
     'import { answer } from "./extensions/remote-runtime/index.js"; import { name } from "@fixture/ai"; console.log(`${name}:${answer}`);',
   );
   await write(packageRoot, "dist/shared.js", 'export const answer = "cloud-ready";');
+  await write(packageRoot, "dist/worker/worker.mjs", 'console.log("separate-worker-bundle");');
+  await write(packageRoot, "dist/worker/workspace-rsync-receiver.mjs", "export {};");
   await write(packageRoot, "dist/build-info.json", { version, buildId });
   await write(packageRoot, "dist/extensions/remote-runtime/package.json", pluginPackage);
   await write(packageRoot, "dist/extensions/remote-runtime/openclaw.plugin.json", {
@@ -161,6 +163,7 @@ describe("node bootstrap distribution", () => {
           /(?:\.env|private\.ts|host-native|\.map|\.buildstamp)$/u.test(entry),
         ),
       ).toBe(false);
+      expect(entries.some((entry) => entry.startsWith("package/dist/worker/"))).toBe(false);
       if (process.platform !== "win32") {
         expect(modes.get("package/openclaw.mjs")).toBe(0o755 & ~process.umask());
         expect(modes.get("package/dist/shared.js")).toBe(0o644 & ~process.umask());

--- a/src/gateway/worker-environments/node-bootstrap-artifact.ts
+++ b/src/gateway/worker-environments/node-bootstrap-artifact.ts
@@ -274,7 +274,13 @@ async function prepareNodeBootstrapArtifact(
     .map(({ id }) => `dist/extensions/${id}/`);
   const files = (
     await collectPackageDistInventory(packageRoot, { packageManifest: packageJson })
-  ).filter((relative) => !externalPluginPrefixes.some((prefix) => relative.startsWith(prefix)));
+  ).filter(
+    // Nodes install the Gateway's worker bundle separately through authenticated transfer.
+    // Carrying its deploy artifacts here duplicates staging, validation, and download work.
+    (relative) =>
+      !relative.startsWith("dist/worker/") &&
+      !externalPluginPrefixes.some((prefix) => relative.startsWith(prefix)),
+  );
   if (!files.includes("dist/entry.js") && !files.includes("dist/entry.mjs")) {
     throw new Error(
       "Cloud bootstrap is missing its built CLI entry; run pnpm build and restart the Gateway",


### PR DESCRIPTION
Related: #133725

## What Problem This Solves

The first cloud session after a Gateway restart spends unnecessary time and memory preparing a runtime archive, then downloads a duplicate worker payload to the node.

## Why This Change Was Made

Exclude the standalone worker deploy directory from node bootstrap composition. The Gateway already prepares and transfers that content-addressed bundle separately, and the node launches workers only from the authenticated per-Gateway bundle installation. The complete npm package and SSH/npm worker installation keep their deploy artifacts. Import closure, archive integrity, exact dependency pins, lifecycle cleanup, and snapshot selection are unchanged.

## User Impact

Cloud runtime preparation and transfer handle fewer bytes for both OpenClaw and Codex execution modes. This affects first preparation of a runtime; cached archive reuse remains unchanged. The separate worker-bundle transfer still occurs during node provisioning.

## Evidence

- The archive regression failed on the original producer for source, packaged, and external-plugin installations; all three pass with the change and execute the resulting runtime.
- 39 focused tests passed across runtime archive preparation, standalone bundle production, and authenticated node bundle installation.
- The real producer ran against the same built package on Node 26.8.1. The compressed archive fell from 58,155,406 to 46,454,479 bytes (20.1%); peak RSS fell from 2.004 to 0.506 GiB (74.8%); user CPU fell from 20.183 to 13.899 seconds (31.1%). Total CPU fell from 28.972 to 27.318 seconds. Wall times were 26.571 and 30.293 seconds with uncontrolled disk caching, so this is not an end-to-end wall-time improvement claim.
- Full manifest comparison: only the two standalone worker assets were removed and the installation inventory updated; all other 10,349 files retained identical bytes and modes. Warm archive reuse returned the same object in 0.011 ms, and staging/provider cleanup passed.
- Live local paired-node proof passed with the exact reduced archive: normal npm installation with lifecycle scripts enabled; installed runtime and inventory contain no worker deploy assets; a real Gateway and installed CLI paired through a join code; sessions.dispatch reached active; authenticated standalone bundle download returned HTTP 200; its receipt matched the installed bundle; a real worker turn returned the synthetic expected marker. Model responses were synthetic. Session reclaim, device removal, process shutdown, and private-state cleanup passed. This does not claim another Machine0 snapshot benchmark.
- Codex autoreview completed scoped-clean at P0; independent owner/caller review found no actionable defects. The full changed-file check passed, including production/test typechecks, formatting, lint, and policy guards. The full build of aeb13df63bcd6a5d356f2ca689bf932dce08532e passed in 8m 0.1s. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/33361012363).

Production change: +7/-1 lines (net +6) to separate the existing artifact owners; tests +3 lines, plus the cloud-worker documentation update. No configuration, persistence, protocol, or dependency changes.

Follow-up identified during profiling: the shared architecture-import preflight can miss optional require calls, escaped import.meta properties, and imports following certain regex literals. The package closure validator uses the full parser and is unaffected. This PR does not change import parsing.

Latest ClawSweeper review: no actionable code findings or Rank-up moves. Its pending CI concern is resolved by the green exact-head run above. This PR is being handled under the maintainer’s explicit request to implement, live-test, and land the performance improvement; native merge gates still apply.
