### PR TITLE
test: remove redundant fixture and helper probes

### DIFF
--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -835,12 +835,6 @@ describe("openclaw test instance", () => {
     expect(logs).not.toContain("old stderr");
   });
 
-  it("treats signaled gateway children as exited", () => {
-    expect(testing.hasChildExited({ exitCode: null, signalCode: "SIGTERM" })).toBe(true);
-    expect(testing.hasChildExited({ exitCode: 0, signalCode: null })).toBe(true);
-    expect(testing.hasChildExited({ exitCode: null, signalCode: null })).toBe(false);
-  });
-
   it("fails startup waits immediately after signaled gateway exits", async () => {
     await expect(
       testing.waitForGatewayReady(

--- a/test/helpers/openclaw-test-instance.ts
+++ b/test/helpers/openclaw-test-instance.ts
@@ -726,7 +726,6 @@ export const testing = {
   appendLogChunk,
   createBoundedStringLog,
   formatLogs,
-  hasChildExited,
   isGatewayMigrationConvergenceRefusal,
   signalOpenClawTestProcess,
   stopGatewayProcess,

--- a/test/helpers/provider-http.test.ts
+++ b/test/helpers/provider-http.test.ts
@@ -1,15 +1,7 @@
-import { describe, expect, it, vi } from "vitest";
-import {
-  oversizedJsonResponse,
-  requireFirstPostJsonRecordRequest,
-  streamedJsonResponse,
-} from "./provider-http.js";
+import { describe, expect, it } from "vitest";
+import { oversizedJsonResponse } from "./provider-http.js";
 
 describe("provider HTTP fixtures", () => {
-  it("builds streamed JSON responses", async () => {
-    await expect(streamedJsonResponse({ ok: true }).json()).resolves.toEqual({ ok: true });
-  });
-
   it("tracks bounded oversized response reads and cancellation", async () => {
     const fixture = oversizedJsonResponse({ chunkCount: 2, chunkSize: 4 });
     const reader = fixture.response.body?.getReader();
@@ -18,14 +10,5 @@ describe("provider HTTP fixtures", () => {
 
     expect(fixture.getReadCount()).toBe(1);
     expect(fixture.wasCanceled()).toBe(true);
-  });
-
-  it("requires the first request to be a record", () => {
-    const mock = vi.fn();
-    mock({ url: "https://example.test" });
-
-    expect(requireFirstPostJsonRecordRequest(mock, "request")).toEqual({
-      url: "https://example.test",
-    });
   });
 });

--- a/test/scripts/check-file-utils.test.ts
+++ b/test/scripts/check-file-utils.test.ts
@@ -20,14 +20,6 @@ vi.mock("node:child_process", async (importOriginal) => {
 
 const { createTempDir } = createScriptTestHarness();
 
-describe("scripts/check-file-utils isCodeFile", () => {
-  it("accepts source files and skips declarations", () => {
-    expect(isCodeFile("example.ts")).toBe(true);
-    expect(isCodeFile("example.mjs")).toBe(true);
-    expect(isCodeFile("example.d.ts")).toBe(false);
-  });
-});
-
 describe("scripts/check-file-utils collectFilesSync", () => {
   it("collects matching files while skipping common generated dirs", () => {
     const rootDir = createTempDir("openclaw-check-file-utils-");
@@ -78,14 +70,14 @@ describe("scripts/check-file-utils listRepoFilesSync", () => {
     execFileSyncMock.mockReset();
   });
 
-  it("bounds git ls-files with a timeout and kill signal", () => {
-    execFileSyncMock.mockReturnValue("src/keep.ts\nsrc/skip.d.ts\n");
+  it("filters tracked source files and bounds the git lookup", () => {
+    execFileSyncMock.mockReturnValue("src/keep.ts\nsrc/keep.mjs\nsrc/skip.d.ts\n");
 
     expect(
       listRepoFilesSync("/fake/repo", {
         includeFile: (filePath) => isCodeFile(filePath),
       }),
-    ).toEqual(["src/keep.ts"]);
+    ).toEqual(["src/keep.mjs", "src/keep.ts"]);
     expect(execFileSyncMock).toHaveBeenCalledWith(
       "git",
       expect.arrayContaining(["-C", "/fake/repo", "ls-files", "--"]),

--- a/test/scripts/test-device-pair-telegram.test.ts
+++ b/test/scripts/test-device-pair-telegram.test.ts
@@ -1,18 +1,11 @@
 // Test Device Pair Telegram tests cover the dev Telegram pairing smoke helper.
-import { pathToFileURL } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import {
   parseDevicePairTelegramArgs,
   runDevicePairTelegram,
 } from "../../scripts/dev/test-device-pair-telegram.ts";
 
-const scriptUrl = pathToFileURL("scripts/dev/test-device-pair-telegram.ts").href;
-
 describe("scripts/dev/test-device-pair-telegram.ts", () => {
-  it("loads without resolving the Telegram runtime sidecar", async () => {
-    await expect(import(`${scriptUrl}?case=load-${Date.now()}`)).resolves.toBeDefined();
-  });
-
   it("parses help without requiring Telegram config", () => {
     expect(parseDevicePairTelegramArgs(["--help"])).toEqual({
       accountId: undefined,


### PR DESCRIPTION
## What Problem This Solves

Several tests repeat fixture or helper results without adding coverage beyond retained consumer tests. One private child-exit predicate is also exposed only for such a test.

## Why This Change Was Made

Remove provider-fixture smoke replays and a redundant Telegram helper namespace import. Preserve the file filter's unique .mjs input in the existing tracked-file consumer test. Drop the child-exit testing property and direct boolean test while keeping readiness, signal, real child stop/restart, and acquisition-cleanup coverage.

## User Impact

Runtime and tooling behavior are unchanged. Provider request/output assertions, exact stream read accounting, Telegram parser/runner outcomes, bounded Git discovery, and process lifecycle proof remain. Five fewer test executions; tests net -38 lines and test support -1 line.

## Evidence

The retained Together provider test uses both HTTP helpers to verify real request and output behavior. Static import already loads the Telegram helper before its remaining tests. The tracked-file test now exercises all three former predicate inputs. Child-exit callers retain direct readiness and real process outcomes for signal, code-zero, and still-running states.

Six focused files passed before and after: 61 → 56 cases, including the real fixture child-process lifecycle tests and Together request/output tests. The changed-file gate passed root-test typechecking, script lint, formatting and repository boundaries. Codex autoreview found no accepted actionable findings. Production/tooling +0/-0; tests +5/-43 (net -38); test support +0/-1.
