### PR TITLE
test(ui): remove duplicate catalog display assertions

### DIFF
--- a/ui/src/lib/chat/model-ref.test.ts
+++ b/ui/src/lib/chat/model-ref.test.ts
@@ -1,6 +1,5 @@
 // @vitest-environment node
 // Control UI tests cover chat model ref behavior.
-import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import {
   createAmbiguousModelCatalog,
@@ -24,16 +23,6 @@ const catalog = createModelCatalog(OPENAI_GPT5_MINI_MODEL, {
 });
 
 describe("chat-model-ref helpers", () => {
-  it("builds provider-qualified options with catalog labels", () => {
-    const lookup = buildCatalogDisplayLookup(catalog);
-    expect(
-      buildChatModelOptionFromLookup(expectDefined(catalog[0], "first model fixture"), lookup),
-    ).toEqual({
-      value: "openai/gpt-5-mini",
-      label: "GPT-5 Mini",
-    });
-  });
-
   it("preserves provider-native nested ids and prefers aliases", () => {
     const nested = {
       id: "moonshotai/kimi-k2.5",
@@ -84,30 +73,6 @@ describe("chat-model-ref helpers", () => {
       expect(formatCatalogChatModelDisplayFromLookup(`anthropic/${id}`, lookup)).toBe(expected);
     },
   );
-
-  it("disambiguates duplicate names by provider and model id", () => {
-    const duplicateProviders = createModelCatalog(
-      { id: "claude-sonnet", name: "Claude Sonnet", provider: "anthropic" },
-      { id: "claude-sonnet", name: "Claude Sonnet", provider: "openrouter" },
-    );
-    const duplicateModels = createModelCatalog(
-      { id: "claude-sonnet", name: "Claude Sonnet", provider: "anthropic" },
-      { id: "claude-sonnet-thinking", name: "Claude Sonnet", provider: "anthropic" },
-    );
-
-    expect(
-      buildChatModelOptionFromLookup(
-        expectDefined(duplicateProviders[0], "first duplicate-provider fixture"),
-        buildCatalogDisplayLookup(duplicateProviders),
-      ).label,
-    ).toBe("Claude Sonnet · anthropic");
-    expect(
-      formatCatalogChatModelDisplayFromLookup(
-        "anthropic/claude-sonnet-thinking",
-        buildCatalogDisplayLookup(duplicateModels),
-      ),
-    ).toBe("Claude Sonnet · claude-sonnet-thinking · anthropic");
-  });
 
   it("normalizes raw overrides when the catalog match is unique", () => {
     expect(normalizeChatModelOverrideValue("gpt-5-mini", catalog)).toBe("openai/gpt-5-mini");


### PR DESCRIPTION
## What Problem This Solves

Two chat model-reference tests repeat catalog label assertions already covered through the picker-state owner. The helper checks inspect one option or label, while the retained tests verify complete options, selected values, and default labels.

## Why This Change Was Made

Remove the basic label and duplicate-name helper replays, along with their unused test import. Keep the real picker-state cases that exercise the same lookup for ordinary names, collisions across providers, and collisions within one provider.

## User Impact

No UI or model-routing behavior changes. Provider qualification, aliases, auth availability, persisted overrides, session provenance, fast-mode, Agents metadata, and rendered alias-flow tests remain.

## Evidence

Both suites call the real shared display owner without mocks. The collision fixtures have equivalent name/provider topology; model-version text does not select a different branch. Tests -35 lines, two fewer executions; production and test support unchanged.

The three focused owner/sibling suites passed before and after: 102 → 100 tests. Codex autoreview found no accepted actionable findings. The required changed-file gate passed, including i18n verification, full dead-export scans, core-test typechecking, formatting and lint. The existing browser alias-flow tests were inspected and remain; no browser execution is claimed for this test-only deletion.
