### PR TITLE
test(ai): avoid runtime barrel in environment key tests

### DIFF
--- a/packages/ai/src/env-api-keys.test.ts
+++ b/packages/ai/src/env-api-keys.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { captureEnv, withEnvAsync } from "../test-utils/env.js";
+import { captureEnv, withEnvAsync } from "../../../src/test-utils/env.js";
 
 const envKeys = [
   "ANTHROPIC_API_KEY",
@@ -37,7 +37,7 @@ afterEach(async () => {
 describe("getEnvApiKey", () => {
   it("returns no env auth in browser contexts without process", async () => {
     vi.resetModules();
-    const { findEnvKeys, getEnvApiKey } = await import("@openclaw/ai/internal/runtime");
+    const { findEnvKeys, getEnvApiKey } = await import("./env-api-keys.js");
     vi.stubGlobal("process", undefined);
 
     expect(findEnvKeys("openai")).toBeUndefined();
@@ -59,7 +59,7 @@ describe("getEnvApiKey", () => {
       },
       async () => {
         vi.resetModules();
-        const { getEnvApiKey } = await import("@openclaw/ai/internal/runtime");
+        const { getEnvApiKey } = await import("./env-api-keys.js");
 
         expect(getEnvApiKey("google-vertex")).toBe("<authenticated>");
       },
@@ -75,7 +75,7 @@ describe("getEnvApiKey", () => {
       },
       async () => {
         vi.resetModules();
-        const { findEnvKeys, getEnvApiKey } = await import("@openclaw/ai/internal/runtime");
+        const { findEnvKeys, getEnvApiKey } = await import("./env-api-keys.js");
 
         expect(findEnvKeys("moonshot")).toEqual(["MOONSHOT_API_KEY", "KIMI_API_KEY"]);
         expect(getEnvApiKey("moonshot")).toBe("moonshot-key");
@@ -90,7 +90,7 @@ describe("getEnvApiKey", () => {
   it("falls back to alternate canonical Kimi env vars", async () => {
     await withEnvAsync({ KIMICODE_API_KEY: "kimicode-key" }, async () => {
       vi.resetModules();
-      const { findEnvKeys, getEnvApiKey } = await import("@openclaw/ai/internal/runtime");
+      const { findEnvKeys, getEnvApiKey } = await import("./env-api-keys.js");
 
       expect(findEnvKeys("kimi")).toEqual(["KIMICODE_API_KEY"]);
       expect(getEnvApiKey("kimi")).toBe("kimicode-key");
@@ -106,7 +106,7 @@ describe("getEnvApiKey", () => {
 
     await withEnvAsync(env, async () => {
       vi.resetModules();
-      const { findEnvKeys, getEnvApiKey } = await import("@openclaw/ai/internal/runtime");
+      const { findEnvKeys, getEnvApiKey } = await import("./env-api-keys.js");
 
       expect(findEnvKeys("anthropic")).toEqual(["ANTHROPIC_API_KEY"]);
       expect(getEnvApiKey("anthropic")).toBe("test-anthropic-key");
@@ -128,7 +128,7 @@ describe("getEnvApiKey", () => {
       },
       async () => {
         vi.resetModules();
-        const { getEnvApiKey } = await import("@openclaw/ai/internal/runtime");
+        const { getEnvApiKey } = await import("./env-api-keys.js");
 
         expect(getEnvApiKey("amazon-bedrock")).toBeUndefined();
       },
@@ -138,7 +138,7 @@ describe("getEnvApiKey", () => {
   it("keeps non-blank AWS profile authentication available", async () => {
     await withEnvAsync({ AWS_PROFILE: "  production  " }, async () => {
       vi.resetModules();
-      const { getEnvApiKey } = await import("@openclaw/ai/internal/runtime");
+      const { getEnvApiKey } = await import("./env-api-keys.js");
 
       expect(getEnvApiKey("amazon-bedrock")).toBe("<authenticated>");
     });
@@ -157,7 +157,7 @@ describe("getEnvApiKey", () => {
 
     await withEnvAsync(env, async () => {
       vi.resetModules();
-      const { getEnvApiKey } = await import("@openclaw/ai/internal/runtime");
+      const { getEnvApiKey } = await import("./env-api-keys.js");
 
       expect(getEnvApiKey("google-vertex")).toBeUndefined();
     });
@@ -175,7 +175,7 @@ describe("getEnvApiKey", () => {
       },
       async () => {
         vi.resetModules();
-        const { getEnvApiKey } = await import("@openclaw/ai/internal/runtime");
+        const { getEnvApiKey } = await import("./env-api-keys.js");
 
         expect(getEnvApiKey("google-vertex")).toBeUndefined();
         await writeFile(credentialsPath, "{}", "utf-8");
@@ -197,7 +197,7 @@ describe("getEnvApiKey", () => {
 
     await withEnvAsync(env, async () => {
       vi.resetModules();
-      const { getEnvApiKey } = await import("@openclaw/ai/internal/runtime");
+      const { getEnvApiKey } = await import("./env-api-keys.js");
 
       expect(getEnvApiKey("google-vertex")).toBe("<authenticated>");
     });


### PR DESCRIPTION
## What Problem This Solves

Environment-key regressions loaded the full AI runtime barrel for each fresh module instance, adding unrelated provider and transport initialization to a leaf helper suite. This is the first change in a maintainer-requested test performance and cleanup batch.

## Why This Change Was Made

Move the ten existing cases beside their AI package owner and import that owner directly. Keep all module resets: positive Vertex ADC detection is cached, and the first synchronous lookup must still exercise fresh initialization. The browser-bundle contract remains independently covered.

## User Impact

Faster contributor feedback with unchanged runtime behavior and assertions. The package test remains selected by the existing unit-support lane.

## Evidence

- Before: `node scripts/run-vitest.mjs src/llm/env-api-keys.test.ts --reporter=json --outputFile=/tmp/env-before.json` — 10 passed; test-file body time 386 ms.
- After: `node scripts/run-vitest.mjs packages/ai/src/env-api-keys.test.ts packages/ai/src/env-api-keys.browser-bundle.test.ts --reporter=json --outputFile=/tmp/env-after.json` — 11 passed; relocated suite 39 ms, browser contract 35 ms. These are focused local Node 24 timings, not full CI wall-time estimates.
- Fresh structured Codex review: no accepted/actionable findings. Formatting and `git diff --check` pass.
- `node scripts/check-changed.mjs -- src/llm/env-api-keys.test.ts packages/ai/src/env-api-keys.test.ts` is running; hosted CI will validate the exact PR head before landing.
- Production LOC: +0/-0. Test LOC excluding the move: +11/-11. No test-only production seam or new dependency.
