### PR TITLE
docs: correct SQLite downgrade restore guidance

### DIFF
--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -85,23 +85,27 @@ transaction, so a superseded run cannot write to the transcript.
 
 ### Downgrading After The SQLite Flip
 
-Restore archived legacy transcript artifacts before running an older
-file-backed OpenClaw version:
+Stop the Gateway and back up its state. Using the current SQLite-capable OpenClaw
+version, restore archived legacy session stores and transcript artifacts before
+starting an older file-backed version:
 
 ```bash
 openclaw doctor --session-sqlite restore --session-sqlite-all-agents
 ```
 
-The migration leaves legacy `sessions.json` files in place for support and
-rollback, but hot transcript JSONL files that were imported into SQLite are
-renamed into `session-sqlite-import-archive/`. Older file-backed runtimes follow
-the `sessionFile` paths in `sessions.json`, so they need those artifacts restored
-before startup. Restore uses migration manifests, moves only recorded archived
-artifacts whose original paths are missing, and leaves the SQLite database in
-place for forward recovery.
+The migration archives imported hot transcript JSONL files and verified, fully
+covered legacy `sessions.json` stores in `session-sqlite-import-archive/`.
+Legacy stores with incomplete coverage or blocking migration issues remain in
+place. Older file-backed runtimes need both `sessions.json` and the artifacts
+referenced by its `sessionFile` paths at their original locations before startup.
 
-Sessions created after the SQLite flip are SQLite-only and will not appear to an
-older file-backed runtime. If you re-upgrade after a downgrade, run the Doctor
+Restore uses migration manifests, moves only recorded archived artifacts whose
+original paths are missing, reports conflicts rather than overwriting existing
+files, and leaves the SQLite database in place for forward recovery.
+
+Restore does not export changes made only in SQLite after migration. Sessions
+created after the SQLite flip are SQLite-only and will not appear to an older
+file-backed runtime. If you re-upgrade after a downgrade, run the Doctor
 inspection and validation sequence again so OpenClaw can verify restored legacy
 artifacts before importing.
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators preparing to downgrade to a file-backed OpenClaw version would be told that migration leaves legacy `sessions.json` files in place, even though verified, fully covered row stores are archived. The contradiction is in [Downgrading After The SQLite Flip](https://docs.openclaw.ai/reference/session-management-compaction#downgrading-after-the-sqlite-flip).

## Why This Change Was Made

Align the reference with the existing Doctor migration and manifest-driven restore owners, and with the [Doctor migration documentation](https://docs.openclaw.ai/cli/doctor#session-sqlite-migration). This is a documentation-only correction: no migration, storage, configuration, or runtime semantics change.

## User Impact

The downgrade guidance now explains that both the legacy row store and its transcript artifacts must be available at their original locations. It distinguishes verified, fully covered imports from incomplete or blocked imports, tells operators to stop the Gateway and back up state before restoring with the SQLite-capable version, and preserves the no-overwrite and SQLite-retention safeguards. It also makes clear that restore recovers archived files rather than exporting changes written only to SQLite after migration.

## Evidence

Source audit covered the complete import, manifest/restore, target-discovery, maintenance-lock, and startup owners, plus the relevant existing tests. The affected docs and inspected migration/restore owners and tests were unchanged between the working base and public main at `b1ab4dff06730d048209beae21d73a9aeb990bb3`.

- [`archiveImportedLegacySessionStores` and `archiveLegacySessionStore`](https://github.com/openclaw/openclaw/blob/b1ab4dff06730d048209beae21d73a9aeb990bb3/src/commands/doctor-session-sqlite.ts#L899-L967) archive fully covered row stores only when the participating reports have no blocking issues.
- [Manifest-driven restore](https://github.com/openclaw/openclaw/blob/b1ab4dff06730d048209beae21d73a9aeb990bb3/src/commands/doctor-session-sqlite-migration-run.ts#L873-L964) restores recorded archives only to missing original paths and reports conflicts instead of overwriting existing files.
- [Existing startup regression](https://github.com/openclaw/openclaw/blob/b1ab4dff06730d048209beae21d73a9aeb990bb3/src/gateway/session-startup-migration.test.ts#L117-L148) expects one archived legacy row store before subsequent startup succeeds. Existing import/restore tests also cover manifest-recorded `sessions.json`, partial shared-store imports, duplicate-index selection, and restore conflicts. These tests were inspected, not rerun for this docs-only change.

Local validation passed:

```text
pnpm docs:list
./node_modules/.bin/oxfmt --check docs/reference/session-management-compaction.md
node scripts/check-docs-mdx.mjs docs/reference/session-management-compaction.md
git diff --check
```

Formatting and MDX checks each selected exactly one file. Production LOC: +0/-0; tests: +0/-0; docs: +15/-11. No live Gateway or operator-state operations were performed. No browser proof or runtime test changes are needed for this prose-only correction. The separate channel-routing documentation work is excluded.
