### PR TITLE
fix(pr): avoid drain delays from detached Git maintenance

### DIFF
--- a/scripts/pr-lib/process-group-runner.mjs
+++ b/scripts/pr-lib/process-group-runner.mjs
@@ -196,11 +196,23 @@ for (const signal of FORWARDED_SIGNALS) {
   process.on(signal, handler);
 }
 
+// Git maintenance must join before leader completion, not daemonize with fd 3.
+// Append to Git's inherited -c transport so nested tools share this lifetime
+// without changing repository config or discarding the caller's other settings.
+const gitConfigParameters = [
+  process.env.GIT_CONFIG_PARAMETERS,
+  "'maintenance.autoDetach=false'",
+  "'gc.autoDetach=false'",
+]
+  .filter(Boolean)
+  .join(" ");
+
 const child = spawn(script, args, {
   cwd: invocationCwd,
   detached: true,
   env: {
     ...process.env,
+    GIT_CONFIG_PARAMETERS: gitConfigParameters,
     OPENCLAW_PR_DEDICATED_PROCESS_GROUP: "1",
     OPENCLAW_PR_LOCK_NOTIFY_FD: "3",
     OPENCLAW_PR_LOCK_SUPERVISOR_PID: String(process.pid),

--- a/test/scripts/pr-git-maintenance.test.ts
+++ b/test/scripts/pr-git-maintenance.test.ts
@@ -1,0 +1,196 @@
+import { execFileSync, spawn, spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const runner = join(process.cwd(), "scripts/pr-lib/process-group-runner.mjs");
+const lockScript = join(process.cwd(), "scripts/pr-lib/operation-lock.sh");
+const lockRef = "refs/openclaw/pr-operation-locks/42";
+const describePosix = process.platform === "win32" ? describe.skip : describe;
+
+function shellQuote(value: string) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+function createMaintenanceFixture(command: string, exitCode: number) {
+  const root = realpathSync(tempDirs.make("openclaw-pr-git-maintenance-"));
+  const home = join(root, "home");
+  const repo = join(root, "repo");
+  mkdirSync(home);
+  mkdirSync(repo);
+  const env = {
+    PATH: process.env.PATH,
+    HOME: home,
+    XDG_CONFIG_HOME: join(home, ".config"),
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_TERMINAL_PROMPT: "0",
+    GIT_CONFIG_COUNT: "1",
+    GIT_CONFIG_KEY_0: "test.fromCount",
+    GIT_CONFIG_VALUE_0: "preserved count value",
+    GIT_CONFIG_PARAMETERS:
+      "'maintenance.autoDetach=true' 'gc.autoDetach=true' 'test.fromParameters=value with spaces=kept'",
+  };
+  const git = (args: string[], input?: string) =>
+    execFileSync("git", args, { cwd: repo, env, input, encoding: "utf8" }).trim();
+  git(["init", "-q", "-b", "main"]);
+  git(["config", "user.name", "OpenClaw Test"]);
+  git(["config", "user.email", "test@example.invalid"]);
+  git(["config", "commit.gpgSign", "false"]);
+  writeFileSync(join(repo, "base.txt"), "synthetic maintenance fixture\n");
+  git(["add", "base.txt"]);
+  git(["commit", "-qm", "base"]);
+  git(["remote", "add", "origin", repo]);
+  git(["fetch", "-q", "origin", "main"]);
+
+  // Force real auto-GC with two tiny packs; old unreachable objects exercise
+  // the documented recentObjectsHook after maintenance's daemonization point.
+  for (let index = 0; index < 2; index++) {
+    const oid = git(["hash-object", "-w", "--stdin"], `unreachable fixture ${index}\n`);
+    const packed = git(["pack-objects", join(repo, ".git/objects/pack/pack")], `${oid}\n`);
+    for (const extension of ["pack", "idx"]) {
+      utimesSync(join(repo, `.git/objects/pack/pack-${packed}.${extension}`), 1, 1);
+    }
+    utimesSync(join(repo, ".git/objects", oid.slice(0, 2), oid.slice(2)), 1, 1);
+  }
+  git(["config", "maintenance.strategy", "gc"]);
+  git(["config", "gc.auto", "1"]);
+  git(["config", "gc.autoPackLimit", "1"]);
+
+  const ready = join(root, "maintenance-ready.json");
+  const release = join(root, "release-maintenance");
+  const completed = join(root, "maintenance-completed");
+  const hook = join(root, "recent-objects.mjs");
+  writeFileSync(
+    hook,
+    [
+      'import { execFileSync } from "node:child_process";',
+      'import { existsSync, fstatSync, renameSync, writeFileSync } from "node:fs";',
+      `const ready = ${JSON.stringify(ready)};`,
+      `const release = ${JSON.stringify(release)};`,
+      "if (!existsSync(ready)) {",
+      '  const pgid = Number(execFileSync("ps", ["-o", "pgid=", "-p", String(process.pid)], { encoding: "utf8" }).trim());',
+      "  const notifierOpen = fstatSync(3).isSocket() || fstatSync(3).isFIFO();",
+      '  writeFileSync(ready + ".pending", JSON.stringify({ pgid, notifierOpen }));',
+      '  renameSync(ready + ".pending", ready);',
+      "  const deadline = Date.now() + 10_000;",
+      "  while (!existsSync(release)) {",
+      '    if (Date.now() >= deadline) throw new Error("maintenance gate was not released");',
+      "    await new Promise(resolve => setTimeout(resolve, 10));",
+      "  }",
+      `  writeFileSync(${JSON.stringify(completed)}, "complete\\n");`,
+      "}",
+    ].join("\n"),
+  );
+  git(["config", "gc.recentObjectsHook", `${shellQuote(process.execPath)} ${shellQuote(hook)}`]);
+
+  const script = join(root, "operation.sh");
+  writeFileSync(
+    script,
+    [
+      "#!/usr/bin/env bash",
+      "set -euo pipefail",
+      `source ${shellQuote(lockScript)}`,
+      `repo_root() { printf '%s\\n' ${shellQuote(repo)}; }`,
+      "acquire_pr_operation_lock 42",
+      "begin_pr_operation_validation_phase",
+      "mark_pr_operation_side_effects_started",
+      'test "$(git config --get test.fromCount)" = "preserved count value"',
+      'test "$(git config --get test.fromParameters)" = "value with spaces=kept"',
+      command,
+      `test -f ${shellQuote(completed)}`,
+      `exit ${exitCode}`,
+    ].join("\n"),
+  );
+  chmodSync(script, 0o755);
+  return { repo, env, git, script, ready, release, completed };
+}
+
+describePosix("scripts/pr Git maintenance ownership", () => {
+  it.each([
+    { command: "git fetch origin main", exitCode: 0 },
+    { command: "git gc --auto", exitCode: 0 },
+    { command: "git fetch origin main", exitCode: 7 },
+  ])(
+    "joins $command before operation completion (exit $exitCode)",
+    async ({ command, exitCode }) => {
+      const fixture = createMaintenanceFixture(command, exitCode);
+      const child = spawn(process.execPath, [runner, fixture.repo, fixture.script], {
+        cwd: fixture.repo,
+        env: fixture.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stderr = "";
+      child.stdout.resume();
+      child.stderr.setEncoding("utf8");
+      child.stderr.on("data", (chunk: string) => {
+        stderr += chunk;
+      });
+      const closed = new Promise<number | null>((resolve) => {
+        child.once("close", resolve);
+      });
+      let ownerOid = "";
+      try {
+        await vi.waitFor(() => expect(existsSync(fixture.ready), stderr).toBe(true), {
+          timeout: 5000,
+        });
+        ownerOid = fixture.git(["rev-parse", lockRef]);
+        const owner = fixture.git(["cat-file", "blob", ownerOid]);
+        const pgid = Number(/^pgid=(\d+)$/m.exec(owner)?.[1]);
+        const hookState = JSON.parse(readFileSync(fixture.ready, "utf8")) as {
+          pgid: number;
+          notifierOpen: boolean;
+        };
+        expect(hookState.notifierOpen).toBe(true);
+        expect(hookState.pgid).toBe(pgid);
+        expect(child.exitCode).toBeNull();
+        expect(existsSync(fixture.completed)).toBe(false);
+        // A second operation cannot acquire the exact PR while maintenance is held.
+        const probe = spawn(
+          "bash",
+          [
+            "-c",
+            `source ${shellQuote(lockScript)}; repo_root() { printf '%s\\n' ${shellQuote(fixture.repo)}; }; try_acquire_pr_operation_lock 42`,
+          ],
+          { cwd: fixture.repo, env: fixture.env, detached: true, stdio: "ignore" },
+        );
+        const probeCode = await new Promise<number | null>((resolve) => {
+          probe.once("close", resolve);
+        });
+        expect(probeCode).toBe(1);
+        expect(fixture.git(["rev-parse", lockRef])).toBe(ownerOid);
+      } finally {
+        // The gate belongs to this fixture. Let Git finish and join it; no PID-based cleanup.
+        writeFileSync(fixture.release, "release\n");
+        await closed;
+      }
+      expect(child.exitCode, stderr).toBe(exitCode);
+      expect(existsSync(fixture.completed)).toBe(true);
+      expect(stderr).not.toContain("drain deadline");
+      expect(stderr).not.toContain("process group remained active");
+      if (exitCode === 0) {
+        expect(
+          spawnSync("git", ["show-ref", "--verify", "--quiet", lockRef], {
+            cwd: fixture.repo,
+            env: fixture.env,
+          }).status,
+        ).toBe(1);
+      } else {
+        expect(fixture.git(["rev-parse", lockRef])).toBe(ownerOid);
+        expect(stderr).toContain(`reason: child exited with code ${exitCode}`);
+      }
+      expect(fixture.git(["config", "--bool", "maintenance.autoDetach"])).toBe("true");
+      expect(fixture.git(["config", "--bool", "gc.autoDetach"])).toBe("true");
+    },
+  );
+});


### PR DESCRIPTION
Closes #133825 — successful PR operations wait for detached Git maintenance.
Related: #124583 — escaped notifier drain failures; #124614 — warned release after leader completion.

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer branch and remains editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where maintainers running native `scripts/pr review-checkout-main` or `review-artifacts-init` would see success, then wait until the drain deadline and receive an escaped-notification-pipe warning when automatic Git maintenance outlived the operation shell.

Real Git maintenance can fork, enter another process group, and retain notification FD 3. This repair addresses that producer; it does not change the supervisor's criteria for completion or lock release.

## Why This Change Was Made

The operation launcher appends `maintenance.autoDetach=false` and `gc.autoDetach=false` to the child-scoped Git command configuration, preserving inherited settings and reaching nested Git helpers. Both keys are necessary for current maintenance and older/direct automatic-GC paths.

Git maintenance remains enabled and joined in the foreground. No notifier FD is closed, no timeout is changed, and no completion marker, process-group check, exact-owner CAS, sticky-failure rule, or recovery guard is weakened. Shared repository configuration is not modified.

Appending to Git's own quoted `-c` transport also preserves precedence over inherited command parameters; appending only `GIT_CONFIG_COUNT` entries would not override an inherited `maintenance.autoDetach=true`. A shell-only Git function would not cover non-shell descendants.

Production/tooling LOC: **+12/-0 (net +12)** for the missing child-lifetime policy. Tests: **+196/-0**. No existing guard or path is removed; there is no redundant owner path to delete without changing the established safety contract.

## User Impact

Successful PR operations no longer incur a post-success drain wait caused by their own automatic Git maintenance. Maintenance now finishes before the operation reports completion, so its real work remains part of the operation's duration rather than continuing after success. Interruptions and failures still retain their exact operation lock when required.

No bot, provider, channel, UI, configuration-schema, or persistent application-store behavior changes. This is separate from the unrelated completion-hardening PR #133717, during whose landing the symptom was observed.

## Evidence

AI-assisted maintainer repair, with direct source/dependency inspection and real task-owned native process proof; no credentials, environment files, captures, or transcripts are attached.

On main snapshot `c2d1c256665119d7f441a4fe90cf3c29149983fd`, with Apple Git 2.54.0 and system Bash 3.2.57, disposable local repositories used real automatic maintenance and the documented `gc.recentObjectsHook` as a release gate. Git itself was not mocked; only the GitHub network boundary was stubbed.

| Native operation | Before: delay after success | After: delay after success |
| --- | ---: | ---: |
| `review-checkout-main` | 5,460 ms, escaped-pipe warning | 227 ms, no warning |
| `review-artifacts-init` | 5,891 ms, escaped-pipe warning | 31 ms, no warning |

Before the repair, maintenance had a different PGID and retained FD 3; the operation returned before maintenance was released. After the repair, maintenance shared the operation group, retained FD 3, and kept the operation locked until the task-owned gate was released. A real SIGTERM test returned 143 and retained the exact lock. Historical PIDs were not queried or signaled, and fixture cleanup required ownership/liveness verification.

The three new regressions failed on the pre-fix code specifically because the maintenance PGID differed from the operation owner. They cover real fetch-triggered maintenance, direct automatic GC, failure after joined maintenance, exclusion of a second operation, and preservation of inherited Git settings. All three pass after the repair.

Synchronized focused/sibling proof on `d8c9ff9325a904ccfd081c9360fb2f868253a571`: **203 passed, one Linux-only skip** across the five suites below. Changed formatting, type, lint, and guard gates passed using the repository-pinned pnpm 12.1.0. The synchronized commit is patch-identical to the original reviewed repair; fresh scoped Codex P0 autoreview of that exact commit is clean.

```bash
node scripts/run-vitest.mjs test/scripts/pr-git-maintenance.test.ts test/scripts/pr-operation-lock.test.ts test/scripts/pr-wrappers.test.ts test/scripts/pr-worktree-containment.test.ts test/scripts/pr-review-artifact-validation.test.ts
```

```bash
node scripts/check-changed.mjs -- scripts/pr-lib/process-group-runner.mjs test/scripts/pr-git-maintenance.test.ts
```

[Exact-head GitHub Actions CI run 33362177506](https://github.com/openclaw/openclaw/actions/runs/33362177506) completed successfully on attempt 1. [Maintainer follow-through](https://github.com/openclaw/openclaw/pull/133832#issuecomment-5474447254) addresses ClawSweeper's Git-source access limitation and its Rank-up move with direct source inspection and exact-head/native proof. No code/security findings or remaining proof gaps.

Dependency contracts checked directly: [Git daemonization](https://github.com/git/git/blob/v2.54.0/setup.c#L2158-L2180), [automatic-maintenance selection](https://github.com/git/git/blob/v2.54.0/run-command.c#L1944-L1976), [configuration precedence](https://github.com/git/git/blob/v2.54.0/config.c#L711-L777), and [joined recent-object hooks](https://github.com/git/git/blob/v2.54.0/reachable.c#L128-L191).
