### PR TITLE
refactor(agents): share trailing empty-line trimming

### DIFF
--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -43,7 +43,14 @@ import {
   readToolInputSchema,
   readToolOutputSchema,
 } from "./read-tool-contract.js";
-import { getTextOutput, invalidArgText, replaceTabs, shortenPath, str } from "./render-utils.js";
+import {
+  getTextOutput,
+  invalidArgText,
+  replaceTabs,
+  shortenPath,
+  str,
+  trimTrailingEmptyLines,
+} from "./render-utils.js";
 import type { ReadToolDetails } from "./tool-contracts.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "./truncate.js";
@@ -180,14 +187,6 @@ function formatReadCall(args: ReadRenderArgs | undefined, theme: Theme): string 
   const pathDisplay =
     path === null ? invalidArg : path ? theme.fg("accent", path) : theme.fg("toolOutput", "...");
   return `${theme.fg("toolTitle", theme.bold("read"))} ${pathDisplay}${formatReadLineRange(args, theme)}`;
-}
-
-function trimTrailingEmptyLines(lines: string[]): string[] {
-  let end = lines.length;
-  while (end > 0 && lines[end - 1] === "") {
-    end--;
-  }
-  return lines.slice(0, end);
 }
 
 function getOpenClawDocsClassification(

--- a/src/agents/sessions/tools/render-utils.test.ts
+++ b/src/agents/sessions/tools/render-utils.test.ts
@@ -2,7 +2,11 @@ import fs from "node:fs";
 import * as os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
-import { appendSessionToolTruncationWarning, shortenPath } from "./render-utils.js";
+import {
+  appendSessionToolTruncationWarning,
+  shortenPath,
+  trimTrailingEmptyLines,
+} from "./render-utils.js";
 
 const theme = {
   fg: (color: string, text: string) => `<${color}>${text}</${color}>`,
@@ -23,6 +27,38 @@ describe("appendSessionToolTruncationWarning", () => {
     ).toBe(
       "output\n<warning>[Truncated: 5 matches limit, 1.0KB limit, some lines truncated]</warning>",
     );
+  });
+});
+
+describe("trimTrailingEmptyLines", () => {
+  it.each([
+    {
+      name: "removes multiple trailing empty lines",
+      lines: ["first", "second", "", ""],
+      expected: ["first", "second"],
+    },
+    { name: "removes all-empty input", lines: ["", ""], expected: [] },
+    {
+      name: "keeps leading and interior empty lines",
+      lines: ["", "first", "", "second", ""],
+      expected: ["", "first", "", "second"],
+    },
+    {
+      name: "keeps whitespace-only trailing lines",
+      lines: ["first", " ", "\t"],
+      expected: ["first", " ", "\t"],
+    },
+  ])("$name", ({ lines, expected }) => {
+    expect(trimTrailingEmptyLines(lines)).toEqual(expected);
+  });
+
+  it("does not mutate the caller-owned lines", () => {
+    const lines = ["first", "", ""];
+    const original = [...lines];
+
+    trimTrailingEmptyLines(lines);
+
+    expect(lines).toEqual(original);
   });
 });
 

--- a/src/agents/sessions/tools/render-utils.ts
+++ b/src/agents/sessions/tools/render-utils.ts
@@ -41,6 +41,10 @@ export function normalizeDisplayText(text: string): string {
   return text.replace(/\r/g, "");
 }
 
+export function trimTrailingEmptyLines(lines: readonly string[]): string[] {
+  return lines.slice(0, lines.findLastIndex((line) => line !== "") + 1);
+}
+
 /** Extracts text output and image placeholders from a tool result. */
 export function getTextOutput(
   result:

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -32,6 +32,7 @@ import {
   replaceTabs,
   shortenPath,
   str,
+  trimTrailingEmptyLines,
 } from "./render-utils.js";
 import type { WriteToolDetails } from "./tool-contracts.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
@@ -246,14 +247,6 @@ function updateWriteHighlightCacheIncremental(
   }
   refreshWriteHighlightPrefix(cache);
   return cache;
-}
-
-function trimTrailingEmptyLines(lines: string[]): string[] {
-  let end = lines.length;
-  while (end > 0 && lines[end - 1] === "") {
-    end--;
-  }
-  return lines.slice(0, end);
 }
 
 function formatWriteCall(


### PR DESCRIPTION
## What Problem This Solves

The session read and write renderers carried separate copies of the same trailing-empty-line policy. Keeping that display invariant in two places made future rendering changes easy to apply inconsistently.

## Why This Change Was Made

This maintainer-requested refactor moves the exact existing behavior into the private session rendering owner and reuses it from both callers. It removes only terminal empty-string entries, preserves leading/interior empty lines and whitespace-only lines, and never mutates caller-owned arrays.

The current-path copies first coexisted in #85341. Its parent already contained the read-side behavior in the previous runtime path, so this does not claim that PR introduced both behaviors from scratch.

## User Impact

No user-visible behavior change. Read and write tool output retain their existing blank-line rendering while sharing one canonical implementation.

## Evidence

- `node scripts/run-vitest.mjs src/agents/sessions/tools/render-utils.test.ts src/agents/sessions/tools/read.test.ts src/agents/sessions/tools/write.test.ts`
  - 83 passed, 1 platform-specific skip
- `node scripts/check-changed.mjs --dry-run -- src/agents/sessions/tools/render-utils.ts src/agents/sessions/tools/render-utils.test.ts src/agents/sessions/tools/read.ts src/agents/sessions/tools/write.ts`
  - lanes: `core`, `coreTests`
- `pnpm check:changed`
  - passed
- `git diff --check`
  - passed
- Autoreview: `gpt-5.6-sol`, high reasoning, scoped clean at 0.99
- Production LOC: +13/-17 (net -4)
- Tests: +37/-1

The helper contract covers multiple trailing empty strings, all-empty input, leading/interior empties, whitespace-only retention, and caller input non-mutation. This is behavior-preserving consolidation, not a claimed pre-fix behavioral regression.
