### PR TITLE
test(tooling): inspect formatter failure once

### DIFF
--- a/test/scripts/format-generated-module.test.ts
+++ b/test/scripts/format-generated-module.test.ts
@@ -69,28 +69,7 @@ describe("formatGeneratedModule", () => {
       code: "ETIMEDOUT",
     });
 
-    expect(() =>
-      formatGeneratedModule(
-        "export const value=1;",
-        {
-          errorLabel: "test module",
-          outputPath: "generated.ts",
-          repoRoot,
-        },
-        {
-          spawnSync: () => ({
-            error: timeoutError,
-            signal: "SIGTERM",
-            status: null,
-            stderr: `DO_NOT_DUMP_OLD_STDERR${"x".repeat(20 * 1024)}\nrecent stderr tail`,
-            stdout: `DO_NOT_DUMP_OLD_STDOUT${"x".repeat(20 * 1024)}\nrecent stdout tail`,
-          }),
-        },
-      ),
-    ).toThrow(
-      /formatter timed out after 30000ms[\s\S]*recent stderr tail[\s\S]*recent stdout tail/u,
-    );
-
+    let message = "";
     try {
       formatGeneratedModule(
         "export const value=1;",
@@ -110,10 +89,13 @@ describe("formatGeneratedModule", () => {
         },
       );
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      expect(message).not.toContain("DO_NOT_DUMP_OLD_STDERR");
-      expect(message).not.toContain("DO_NOT_DUMP_OLD_STDOUT");
+      message = error instanceof Error ? error.message : String(error);
     }
+    expect(message).toMatch(
+      /formatter timed out after 30000ms[\s\S]*recent stderr tail[\s\S]*recent stdout tail/u,
+    );
+    expect(message).not.toContain("DO_NOT_DUMP_OLD_STDERR");
+    expect(message).not.toContain("DO_NOT_DUMP_OLD_STDOUT");
   });
 
   it("keeps truncated formatter diagnostics UTF-8 safe", () => {


### PR DESCRIPTION
## What Problem This Solves

The formatter timeout regression invoked the same failing operation twice to inspect two properties of one diagnostic. Each invocation created, wrote, and removed another temporary file, and duplicated the fixture setup.

## Why This Change Was Made

Capture the failure once, then assert the timeout message, recent output tails, and exclusion of old output against that same diagnostic. The positive message assertion also fails if the formatter unexpectedly returns.

## User Impact

Simpler tests with unchanged formatter behavior and diagnostic coverage. This is a cleanup of repeated work, not a claimed material wall-time improvement.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/format-generated-module.test.ts test/scripts/format-docs.test.ts` passes, retaining bounded execution and UTF-8 diagnostics coverage.
- Fresh structured Codex review, formatting and `git diff --check` pass. Changed checks are running before landing.
- Production +0/-0; tests +7/-25. One redundant formatter invocation and temporary-file lifecycle removed.
- Full formatter owner and tests read; no production seams added.
