### PR TITLE
perf(queue): prepare snapshots and bounded diagnostic pruning

### DIFF
--- a/src/logging/diagnostic-session-state.ts
+++ b/src/logging/diagnostic-session-state.ts
@@ -58,27 +58,36 @@ export function pruneDiagnosticSessionStates(now = Date.now(), force = false): v
   }
   lastSessionPruneAt = now;
 
-  for (const [key, state] of diagnosticSessionStates.entries()) {
+  let trackOldest = diagnosticSessionStates.size === SESSION_STATE_MAX_ENTRIES + 1;
+  let oldest: [string, SessionState] | undefined;
+  for (const entry of diagnosticSessionStates.entries()) {
+    const [key, state] = entry;
     const ageMs = now - state.lastActivity;
     const isIdle = state.state === "idle";
     if (isIdle && state.queueDepth <= 0 && ageMs > SESSION_STATE_TTL_MS) {
       diagnosticSessionStates.delete(key);
+      trackOldest = false;
+    } else if (trackOldest && (!oldest || state.lastActivity < oldest[1].lastActivity)) {
+      oldest = entry;
     }
   }
 
   if (diagnosticSessionStates.size <= SESSION_STATE_MAX_ENTRIES) {
     return;
   }
-  const excess = diagnosticSessionStates.size - SESSION_STATE_MAX_ENTRIES;
+  // Insertions normally exceed the cap by one; equal ages keep Map order.
+  if (oldest) {
+    diagnosticSessionStates.delete(oldest[0]);
+    return;
+  }
   const ordered = Array.from(diagnosticSessionStates.entries()).toSorted(
     (a, b) => a[1].lastActivity - b[1].lastActivity,
   );
-  for (let i = 0; i < excess; i += 1) {
-    const key = ordered[i]?.[0];
-    if (!key) {
+  for (const [key] of ordered) {
+    diagnosticSessionStates.delete(key);
+    if (diagnosticSessionStates.size <= SESSION_STATE_MAX_ENTRIES) {
       break;
     }
-    diagnosticSessionStates.delete(key);
   }
 }
 

--- a/src/logging/diagnostic.test.ts
+++ b/src/logging/diagnostic.test.ts
@@ -210,16 +210,21 @@ describe("diagnostic session state pruning", () => {
     expect(diagnosticSessionStates.size).toBe(1);
   });
 
-  it("caps tracked session states to a bounded max", () => {
-    const now = Date.now();
-    for (let i = 0; i < 2001; i += 1) {
-      vi.setSystemTime(now + i);
-      getDiagnosticSessionState({ sessionKey: `session-${i}` }).queueDepth = 1;
-    }
+  it.each(["session-0", ""])(
+    "caps tracked session states when the oldest key is %j",
+    (oldestKey) => {
+      const now = Date.now();
+      for (let i = 0; i < 2001; i += 1) {
+        vi.setSystemTime(now + i);
+        getDiagnosticSessionState({
+          sessionKey: i === 0 ? oldestKey : `session-${i}`,
+        }).queueDepth = 1;
+      }
 
-    expect(diagnosticSessionStates.size).toBe(2000);
-    expect(diagnosticSessionStates.has("session-0")).toBe(false);
-  });
+      expect(diagnosticSessionStates.size).toBe(2000);
+      expect(diagnosticSessionStates.has(oldestKey)).toBe(false);
+    },
+  );
 
   it("reuses keyed session state when later looked up by sessionId", () => {
     const keyed = getDiagnosticSessionState({

--- a/src/process/command-queue.capacity-groups.ts
+++ b/src/process/command-queue.capacity-groups.ts
@@ -1,10 +1,10 @@
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
-import type { CommandLaneSnapshot } from "./command-queue.js";
 // Capacity groups: a shared, hard aggregate budget across several command
 // lanes, with per-member reservations. Split out of command-queue.ts to keep
 // that file within its size budget; the queue supplies its own `drainLane` so
 // this module never has to import the queue runtime.
 import { getQueueState, normalizeLane, peekLaneQueue } from "./command-queue.state.js";
+import type { CommandLaneBlockReason, CommandLaneSnapshot } from "./command-queue.types.js";
 import { CommandLane } from "./lanes.js";
 
 /** Drains a single lane. Supplied by command-queue.ts to avoid a cycle. */
@@ -12,9 +12,6 @@ type DrainLaneFn = (lane: string) => void;
 
 /** Internal bounded drain contract used by the group arbiter. */
 type BoundedDrainLaneFn = (lane: string, maxStarts?: number) => number | void;
-
-/** Why a lane cannot admit, from the narrowest cause outward. */
-export type CommandLaneBlockReason = "lane" | "group-budget" | "sibling-reservation" | null;
 
 /** Declares a group's shared budget and its members' hard reservations. */
 export type CommandLaneGroupSpec = {

--- a/src/process/command-queue.capacity-groups.ts
+++ b/src/process/command-queue.capacity-groups.ts
@@ -1,8 +1,9 @@
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import type { CommandLaneSnapshot } from "./command-queue.js";
 // Capacity groups: a shared, hard aggregate budget across several command
 // lanes, with per-member reservations. Split out of command-queue.ts to keep
 // that file within its size budget; the queue supplies its own `drainLane` so
-// this module never has to import back into it.
+// this module never has to import the queue runtime.
 import { getQueueState, normalizeLane, peekLaneQueue } from "./command-queue.state.js";
 import { CommandLane } from "./lanes.js";
 
@@ -109,7 +110,7 @@ export function getLaneGroup(lane: string): LaneGroupState | undefined {
  * Active task count for a group member WITHOUT creating the lane. Creating it
  * here would resurrect lanes that `retireIdleScopedCommandLane` just removed.
  */
-export function getMemberActiveCount(lane: string): number {
+function getMemberActiveCount(lane: string): number {
   return getQueueState().lanes.get(lane)?.activeTaskIds.size ?? 0;
 }
 
@@ -122,7 +123,7 @@ export function getMemberActiveCount(lane: string): number {
  * task id, so the next admission decision simply sees a smaller number. The
  * only remaining obligation is that those paths re-drain the group.
  */
-export function resolveLaneBlockReason(lane: string): CommandLaneBlockReason {
+function resolveLaneBlockReason(lane: string): CommandLaneBlockReason {
   const state = getQueueState().lanes.get(lane);
   if (state && state.activeTaskIds.size >= state.maxConcurrent) {
     return "lane";
@@ -161,6 +162,24 @@ function resolveGroupBlockReason(
   // The lane's own reservation is filled, so every unused reservation belongs
   // to a sibling and must remain unavailable for borrowing.
   return capacity.active + capacity.reserved < group.budget ? null : "sibling-reservation";
+}
+
+/** Fill a fresh snapshot from one synchronous group-capacity observation. */
+export function applyCommandLaneCapacity(snapshot: CommandLaneSnapshot): void {
+  const group = getLaneGroup(snapshot.lane);
+  const capacity = group ? readGroupCapacity(group) : undefined;
+  snapshot.blockedBy =
+    snapshot.activeCount >= snapshot.maxConcurrent
+      ? "lane"
+      : group && capacity
+        ? resolveGroupBlockReason(group, snapshot.lane, capacity)
+        : null;
+  if (group && capacity) {
+    snapshot.group = group.group;
+    snapshot.groupActive = capacity.active;
+    snapshot.groupBudget = group.budget;
+    snapshot.reservedForLane = group.reservations.get(snapshot.lane) ?? 0;
+  }
 }
 
 export function canAdmitInGroup(lane: string): boolean {

--- a/src/process/command-queue.state.ts
+++ b/src/process/command-queue.state.ts
@@ -82,7 +82,8 @@ function getPriorityRing(queue: LaneQueue, priority: QueuePriority): QueueRing {
 function appendQueueRing(ring: QueueRing, entry: QueueEntry): void {
   if (ring.length === ring.entries.length) {
     const nextCapacity = Math.max(INITIAL_QUEUE_RING_CAPACITY, ring.length * 2);
-    const nextEntries: Array<QueueEntry | undefined> = Array.from({ length: nextCapacity });
+    // oxlint-disable-next-line unicorn/no-new-array -- Reserve sparse capacity; head and length delimit occupied slots.
+    const nextEntries = new Array<QueueEntry | undefined>(nextCapacity);
     for (let index = 0; index < ring.length; index += 1) {
       nextEntries[index] = ring.entries[(ring.head + index) % ring.entries.length];
     }

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -8,16 +8,15 @@ import {
   logLaneEnqueue,
 } from "../logging/diagnostic-runtime.js";
 import {
+  applyCommandLaneCapacity,
   canAdmitInGroup,
   type CommandLaneBlockReason,
   type CommandLaneGroupSpec,
   drainGroupSiblings,
   getGroupRegistry,
   getLaneGroup,
-  getMemberActiveCount,
   installCommandLaneGroup,
   type LaneGroupState,
-  resolveLaneBlockReason,
   validateCommandLaneGroupSpec,
 } from "./command-queue.capacity-groups.js";
 import {
@@ -142,30 +141,6 @@ function isQuietProbeLane(lane: string): boolean {
 
 function getLaneDepth(state: LaneState): number {
   return state.queue.length + state.activeTaskIds.size;
-}
-
-function createCommandLaneSnapshot(state: LaneState): CommandLaneSnapshot {
-  const snapshot: CommandLaneSnapshot = {
-    lane: state.lane,
-    queuedCount: state.queue.length,
-    activeCount: state.activeTaskIds.size,
-    maxConcurrent: state.maxConcurrent,
-    draining: state.draining,
-    generation: state.generation,
-    blockedBy: resolveLaneBlockReason(state.lane),
-  };
-  const group = getLaneGroup(state.lane);
-  if (group) {
-    let groupActive = 0;
-    for (const member of group.members) {
-      groupActive += getMemberActiveCount(member);
-    }
-    snapshot.group = group.group;
-    snapshot.groupActive = groupActive;
-    snapshot.groupBudget = group.budget;
-    snapshot.reservedForLane = group.reservations.get(state.lane) ?? 0;
-  }
-  return snapshot;
 }
 
 function getLaneState(lane: string): LaneState {
@@ -619,33 +594,18 @@ export function getQueueSize(lane: string = CommandLane.Main) {
 export function getCommandLaneSnapshot(lane: string = CommandLane.Main): CommandLaneSnapshot {
   const resolved = normalizeLane(lane);
   const state = getQueueState().lanes.get(resolved);
-  if (!state) {
-    // The lane may not exist yet (first enqueue) or may have been retired while
-    // idle, but it can still be a configured group member — and a caller asking
-    // "can this lane start work?" needs the group answer, not a bare default.
-    const group = getLaneGroup(resolved);
-    const empty: CommandLaneSnapshot = {
-      lane: resolved,
-      queuedCount: 0,
-      activeCount: 0,
-      maxConcurrent: 1,
-      draining: false,
-      generation: 0,
-      blockedBy: resolveLaneBlockReason(resolved),
-    };
-    if (group) {
-      let groupActive = 0;
-      for (const member of group.members) {
-        groupActive += getMemberActiveCount(member);
-      }
-      empty.group = group.group;
-      empty.groupActive = groupActive;
-      empty.groupBudget = group.budget;
-      empty.reservedForLane = group.reservations.get(resolved) ?? 0;
-    }
-    return empty;
-  }
-  return createCommandLaneSnapshot(state);
+  const snapshot: CommandLaneSnapshot = {
+    lane: state?.lane ?? resolved,
+    queuedCount: state?.queue.length ?? 0,
+    activeCount: state?.activeTaskIds.size ?? 0,
+    maxConcurrent: state?.maxConcurrent ?? 1,
+    draining: state?.draining ?? false,
+    generation: state?.generation ?? 0,
+    blockedBy: null,
+  };
+  // Missing or retired lanes can still be group members; never recreate them to read capacity.
+  applyCommandLaneCapacity(snapshot);
+  return snapshot;
 }
 
 /** Per-lane work totals for every live lane; diagnostics composition lives in command-lane-diagnostics.ts. */

--- a/src/process/command-queue.ts
+++ b/src/process/command-queue.ts
@@ -10,7 +10,6 @@ import {
 import {
   applyCommandLaneCapacity,
   canAdmitInGroup,
-  type CommandLaneBlockReason,
   type CommandLaneGroupSpec,
   drainGroupSiblings,
   getGroupRegistry,
@@ -30,7 +29,7 @@ import {
   type QueueEntry,
   type QueuePriority,
 } from "./command-queue.state.js";
-import type { CommandQueueEnqueueOptions } from "./command-queue.types.js";
+import type { CommandLaneSnapshot, CommandQueueEnqueueOptions } from "./command-queue.types.js";
 import {
   GatewayDrainingError,
   isGatewaySubordinateWorkAdmissionClosed,
@@ -42,6 +41,7 @@ import {
 import { CommandLane } from "./lanes.js";
 export { GatewayDrainingError } from "./gateway-work-admission.js";
 export type { CommandLaneTaskMarker } from "./command-queue.state.js";
+export type { CommandLaneSnapshot } from "./command-queue.types.js";
 /**
  * Dedicated error type thrown when a queued command is rejected because
  * its lane was cleared.  Callers that fire-and-forget enqueued tasks can
@@ -96,34 +96,6 @@ export function isCommandLaneTaskTimeoutError(err: unknown, lane?: string): bool
   }
   return lane === undefined || err.message.includes(`Command lane "${lane}" task timed out`);
 }
-
-// Minimal in-process queue to serialize command executions.
-// Default lane ("main") preserves the existing behavior. Additional lanes allow
-// low-risk parallelism (e.g. cron jobs) without interleaving stdin / logs for
-// the main auto-reply workflow.
-
-export type CommandLaneSnapshot = {
-  lane: string;
-  queuedCount: number;
-  activeCount: number;
-  maxConcurrent: number;
-  draining: boolean;
-  generation: number;
-  /** Group this lane belongs to, if any. */
-  group?: string;
-  /** Sum of active tasks across every member of the group. Always derived. */
-  groupActive?: number;
-  /** Hard aggregate cap shared by the group's members. */
-  groupBudget?: number;
-  /** Slots within the budget this lane may always claim. */
-  reservedForLane?: number;
-  /**
-   * Why this lane cannot start more work right now, or null if it can.
-   * `lane` is the lane's own maxConcurrent; the other two are group-imposed and
-   * are invisible to a lane-local view — see `noteLaneWaitIfBusy`.
-   */
-  blockedBy?: CommandLaneBlockReason;
-};
 
 function isExpectedNonErrorLaneFailure(err: unknown): boolean {
   return err instanceof Error && err.name === "LiveSessionModelSwitchError";

--- a/src/process/command-queue.types.ts
+++ b/src/process/command-queue.types.ts
@@ -1,3 +1,29 @@
+/** Why a lane cannot admit, from the narrowest cause outward. */
+export type CommandLaneBlockReason = "lane" | "group-budget" | "sibling-reservation" | null;
+
+export type CommandLaneSnapshot = {
+  lane: string;
+  queuedCount: number;
+  activeCount: number;
+  maxConcurrent: number;
+  draining: boolean;
+  generation: number;
+  /** Group this lane belongs to, if any. */
+  group?: string;
+  /** Sum of active tasks across every member of the group. Always derived. */
+  groupActive?: number;
+  /** Hard aggregate cap shared by the group's members. */
+  groupBudget?: number;
+  /** Slots within the budget this lane may always claim. */
+  reservedForLane?: number;
+  /**
+   * Why this lane cannot start more work right now, or null if it can.
+   * `lane` is the lane's own maxConcurrent; the other two are group-imposed and
+   * are invisible to a lane-local view — see `noteLaneWaitIfBusy`.
+   */
+  blockedBy?: CommandLaneBlockReason;
+};
+
 /**
  * Public enqueue knobs shared by command-lane callers and narrower injection
  * points that should not import the full queue implementation.

--- a/test/scripts/lint-suppressions.test.ts
+++ b/test/scripts/lint-suppressions.test.ts
@@ -240,6 +240,8 @@ describe("production lint suppressions", () => {
         "src/plugins/runtime/runtime-plugin-boundary.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/runtime/types-channel.ts|typescript/no-unnecessary-type-parameters|1",
         "src/plugins/trusted-tool-policy.ts|typescript/no-unnecessary-type-parameters|1",
+        // The queue ring reserves sparse capacity and reads only its occupied slots.
+        "src/process/command-queue.state.ts|unicorn/no-new-array|1",
         // Raw PowerShell errors carry the -EncodedCommand argv; only the sanitized cause may escape.
         "src/secrets/private-plan-file.ts|preserve-caught-error|1",
         "src/state/config-machine-state.ts|typescript/no-unnecessary-type-parameters|2",


### PR DESCRIPTION
## What Problem This Solves

Queue diagnostics repeat capacity scans and build the same snapshot through separate paths. Queue growth also fills unused backing slots, and diagnostic state sorts all 2,001 entries whenever an ordinary insertion crosses its 2,000-entry cap. An accepted empty session key can stop the old cap loop from evicting anything.

## Why This Change Was Made

The private ring reserves capacity without populating unoccupied slots. A single snapshot builder carries one synchronous capacity observation from the group owner. The diagnostic-state owner tracks the oldest entry during its existing TTL scan for the usual one-entry overflow, while retaining the stable general sort for bulk overflow. Cap enforcement accepts empty keys just like the state producer does.

## User Impact

Queue order, priorities, reservations, concurrency limits, abort/reset behavior and fresh snapshot identity are preserved. Missing or retired lanes are never recreated for a read. Diagnostic state retains its existing cap, TTL, tie ordering and idle eligibility. There is no new configuration, protocol, persistence, SDK surface or dependency.

This is three measured mechanisms, plus an uncounted cap bug repair. The rejected membership-preparation experiment is excluded. Final production delta is 80 additions / 96 deletions (net -16); tests are 16 additions / 9 deletions (net +7). The shared declarations move unchanged into the existing dependency-free types module; the public snapshot export remains available. Two helpers used only inside the capacity owner are now private; no public SDK export is removed.

## Evidence

Historical isolated measurements use fresh processes in both forward and reverse order and retain all slower controls. Representative complete-owner observations, in microseconds:

| Operation | Before F/R | Candidate F/R |
| --- | --- | --- |
| Default diagnostic projection | 1.264 / 1.261 | 0.792 / 0.771 |
| Two-member admissible snapshot | 0.289 / 0.291 | 0.183 / 0.177 |
| One-entry ring cycle | 0.487 / 0.497 | 0.110 / 0.118 |
| 256-entry ring burst | 24.292 / 24.859 | 14.530 / 15.249 |
| Public diagnostic get/create at the cap | 46.649 / 46.038 | 12.777 / 13.239 |

The tradeoffs are explicit: a lane-capped snapshot with 128 members rises from 5.069/5.380 to 5.730/5.727 microseconds. Filling 16 diagnostic entries adds about 0.093/0.101 microseconds; filling 2,000 adds 9.2/11.5 microseconds. Bulk and TTL controls are mixed or slower, including the retained bulk sort. These observations do not establish whole-Gateway latency, workload prevalence, memory savings or a native model/runtime gain.

The selected queue measurements retain 6,336 samples from 72 workloads in 16 children. Pruning retains 1,606 samples from 25 workloads in six children; empty-key timings use a corrected semantic oracle, never the old growing oversized map. Complete owner proof covers queue state identity, publication, lifecycle settlement and boundary I/O, plus 922 prune scenarios / 1,804 comparisons. Historical source captures and execution heads remain separately identified.

The canonical cap test fails on the old empty-key path (2,001 entries instead of 2,000) and both parameterized cases pass with the repair. All 221 tests across 11 affected/sibling suites passed. Baseline and candidate full builds passed. The same actual isolated Gateway flow passed before and after: two real OpenAI turns returned exact nonce responses, the second turn visibly waited behind the first, and all static/dynamic queues drained. CPU profiles and V8 coverage record positive queue, snapshot and diagnostic-state owner calls; the new capacity projection ran 41 times. Both owned process groups, loopback port and private runtime fixture were independently confirmed gone. This live flow does not exercise the private 2,000-session cap, group reservations or ring growth above 16. The initial source-client bootstrap failure is retained and corrected by explicit source-loader configuration, without changing product dependencies or retrying model turns.

The final formatted composition passes 1,497 queue scenarios / 5,988 comparisons, the 72-workload check / 288 comparisons and 60 operation rows with zero execution-boundary I/O. The actual final pruner is present in the queue bundle; its standalone proof passes 922 scenarios / 1,804 comparisons, with 15 intentional differences caused by fixing empty-key eviction. The original child still fails exactly at 2,001 versus 2,000. All six owned proof groups were independently confirmed gone.

The first changed-file pass identified two newly unused exports, now made private. The second reached lint and required a local explanation for intentionally reserving sparse array capacity. Before the CI-only correction, the complete changed-file gate, another 221-test rerun, fresh full build and fresh real two-turn Gateway run passed on the exact runtime composition. Managed review of that diff is scoped-clean (0.90); complete source/caller and compiled-graph review were performed separately. There are no new dependencies, public settings, database migrations or protocol changes.

Exact-head CI then found a type-inclusive import cycle and the missing explicit inventory entry for the sparse-ring lint exception. The follow-up moves the unchanged snapshot/block-reason contracts into the existing leaf types module and records only that exact file/rule/count. It neither relaxes the cycle checker nor adds a generic lint exemption. All 225 tests across 12 suites pass after this correction; the full architecture gate passes (83.29 seconds), and the complete changed-file gate passes (257.04 seconds). TypeScript emits byte-identical JavaScript for all three affected production modules after comment removal. Independent source review and managed review (scoped-clean, 0.98) found no actionable issue. The earlier built Gateway observations remain bound to the pre-correction runtime composition; they are not relabelled as a new live run.
