### PR TITLE
refactor(cli): consolidate precomputed help caching

### DIFF
--- a/src/cli/root-help-metadata.test.ts
+++ b/src/cli/root-help-metadata.test.ts
@@ -1,0 +1,151 @@
+// Precomputed help preserves field selection, snapshots, and stdout semantics.
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+
+const { readMetadata, write } = vi.hoisted(() => ({
+  readMetadata: vi.fn(),
+  write: vi.fn<typeof process.stdout.write>(),
+}));
+vi.mock("./startup-metadata.js", () => ({ readCliStartupMetadata: readMetadata }));
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const metadata = {
+  rootHelpText: " root \n",
+  browserHelpText: " browser \n",
+  secretsHelpText: " secrets \n",
+  nodesHelpText: " nodes \n",
+  config: "not nested config",
+  subcommandHelpText: {
+    rootHelpText: "not flat root",
+    config: " config \n",
+    doctor: " doctor \n",
+    gateway: " gateway \n",
+    models: " models \n",
+    plugins: " plugins \n",
+    sessions: " sessions \n",
+    tasks: " tasks \n",
+  },
+};
+let help: typeof import("./root-help-metadata.js");
+
+beforeEach(async () => {
+  vi.resetModules();
+  readMetadata.mockReset().mockReturnValue(metadata);
+  write.mockReset().mockReturnValue(true);
+  vi.spyOn(process.stdout, "write").mockImplementation(write);
+  help = await import("./root-help-metadata.js");
+});
+afterEach(() => vi.restoreAllMocks());
+
+describe("precomputed help metadata output", () => {
+  it.each([
+    ["outputPrecomputedRootHelpText", " root \n"],
+    ["outputPrecomputedBrowserHelpText", " browser \n"],
+    ["outputPrecomputedSecretsHelpText", " secrets \n"],
+    ["outputPrecomputedNodesHelpText", " nodes \n"],
+  ] as const)("preserves %s bytes", (name, text) => {
+    expect(help[name]()).toBe(true);
+    expect(write.mock.calls).toEqual([[text]]);
+  });
+
+  it.each([
+    ["config", " config \n"],
+    ["doctor", " doctor \n"],
+    ["gateway", " gateway \n"],
+    ["models", " models \n"],
+    ["plugins", " plugins \n"],
+    ["sessions", " sessions \n"],
+    ["tasks", " tasks \n"],
+  ] as const)("preserves nested %s bytes", (name, text) => {
+    expect(help.outputPrecomputedSubcommandHelpText(name)).toBe(true);
+    expect(write.mock.calls).toEqual([[text]]);
+  });
+
+  it("keeps successful flat and nested field snapshots independent", () => {
+    expect(help.outputPrecomputedRootHelpText()).toBe(true);
+    expect(help.outputPrecomputedSubcommandHelpText("config")).toBe(true);
+    readMetadata.mockReturnValue(null);
+    expect(help.outputPrecomputedRootHelpText()).toBe(true);
+    expect(help.outputPrecomputedSubcommandHelpText("config")).toBe(true);
+    expect(write.mock.calls).toEqual([[" root \n"], [" config \n"], [" root \n"], [" config \n"]]);
+    expect(readMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([undefined, null, "", 17, {}])("rejects non-text fields (%j)", (value) => {
+    readMetadata.mockReturnValue({
+      rootHelpText: value,
+      subcommandHelpText: { config: value },
+    });
+    expect(help.outputPrecomputedRootHelpText()).toBe(false);
+    expect(help.outputPrecomputedSubcommandHelpText("config")).toBe(false);
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("keeps cached misses independent from a previously unread field", () => {
+    readMetadata.mockReturnValue(null);
+    expect(help.outputPrecomputedRootHelpText()).toBe(false);
+    expect(help.outputPrecomputedSubcommandHelpText("config")).toBe(false);
+    readMetadata.mockReturnValue(metadata);
+    expect(help.outputPrecomputedRootHelpText()).toBe(false);
+    expect(help.outputPrecomputedSubcommandHelpText("config")).toBe(false);
+    expect(write).not.toHaveBeenCalled();
+    expect(help.outputPrecomputedBrowserHelpText()).toBe(true);
+    expect(write.mock.calls).toEqual([[" browser \n"]]);
+    expect(readMetadata).toHaveBeenCalledTimes(3);
+  });
+
+  it.each([undefined, null, "config", 17])(
+    "rejects a non-object nested container (%j)",
+    (value) => {
+      readMetadata.mockReturnValue({ config: "not nested config", subcommandHelpText: value });
+      expect(help.outputPrecomputedSubcommandHelpText("config")).toBe(false);
+      expect(write).not.toHaveBeenCalled();
+    },
+  );
+
+  it("rejects unsupported names before metadata reads or output", () => {
+    for (const name of ["browser", "rootHelpText", "status"]) {
+      expect(help.outputPrecomputedSubcommandHelpText(name)).toBe(false);
+    }
+    expect(readMetadata).not.toHaveBeenCalled();
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it("retains a help miss when the real reader advances from null to parent metadata", async () => {
+    const parentDir = tempDirs.make("openclaw-help-metadata-");
+    const moduleDir = path.join(parentDir, "chunks");
+    fs.mkdirSync(moduleDir);
+    fs.writeFileSync(path.join(moduleDir, "cli-startup-metadata.json"), "null");
+    fs.writeFileSync(
+      path.join(parentDir, "cli-startup-metadata.json"),
+      JSON.stringify({ browserHelpText: " parent browser \n" }),
+    );
+    const moduleUrl = pathToFileURL(path.join(moduleDir, "root-help-metadata.js")).href;
+    const { readCliStartupMetadata } =
+      await vi.importActual<typeof import("./startup-metadata.js")>("./startup-metadata.js");
+    readMetadata.mockImplementation(() => readCliStartupMetadata(moduleUrl));
+
+    expect(help.outputPrecomputedBrowserHelpText()).toBe(false);
+    expect(readCliStartupMetadata(moduleUrl)).toEqual({ browserHelpText: " parent browser \n" });
+    expect(help.outputPrecomputedBrowserHelpText()).toBe(false);
+    expect(write).not.toHaveBeenCalled();
+    expect(readMetadata).toHaveBeenCalledOnce();
+  });
+
+  it("populates the cache before a failed write and treats backpressure as handled", () => {
+    const failure = new Error("stdout failed");
+    write
+      .mockImplementationOnce(() => {
+        throw failure;
+      })
+      .mockReturnValue(false);
+    expect(() => help.outputPrecomputedRootHelpText()).toThrow(failure);
+    readMetadata.mockReturnValue(null);
+    expect(help.outputPrecomputedRootHelpText()).toBe(true);
+    expect(write.mock.calls).toEqual([[" root \n"], [" root \n"]]);
+    expect(readMetadata).toHaveBeenCalledOnce();
+  });
+});

--- a/src/cli/root-help-metadata.ts
+++ b/src/cli/root-help-metadata.ts
@@ -10,114 +10,71 @@ export type PrecomputedSubcommandHelpName =
   | "sessions"
   | "tasks";
 
-let precomputedRootHelpText: string | null | undefined;
-let precomputedBrowserHelpText: string | null | undefined;
-let precomputedSecretsHelpText: string | null | undefined;
-let precomputedNodesHelpText: string | null | undefined;
-let precomputedSubcommandHelpText:
-  | Partial<Record<PrecomputedSubcommandHelpName, string | null>>
-  | undefined;
-
 type PrecomputedHelpTextKey =
   | "rootHelpText"
   | "browserHelpText"
   | "secretsHelpText"
-  | "nodesHelpText";
+  | "nodesHelpText"
+  | PrecomputedSubcommandHelpName;
 
-function loadPrecomputedHelpText(
-  key: PrecomputedHelpTextKey,
-  cache: string | null | undefined,
-  setCache: (value: string | null) => void,
-): string | null {
-  // Missing metadata is expected in source checkouts; fall back to live Commander help.
-  if (cache !== undefined) {
-    return cache;
+const precomputedHelpText = new Map<PrecomputedHelpTextKey, string | null>();
+
+function loadPrecomputedHelpText(key: PrecomputedHelpTextKey): string | null {
+  const cached = precomputedHelpText.get(key);
+  if (cached !== undefined) {
+    return cached;
   }
+  let helpText: string | null = null;
   try {
     const parsed = readCliStartupMetadata(import.meta.url);
-    if (parsed) {
-      const value = parsed[key];
-      if (typeof value === "string" && value.length > 0) {
-        setCache(value);
-        return value;
+    let value: unknown;
+    if (isPrecomputedSubcommandHelpName(key)) {
+      const subcommandHelpText = parsed?.subcommandHelpText;
+      if (isSubcommandHelpTextRecord(subcommandHelpText)) {
+        value = subcommandHelpText[key];
       }
+    } else if (parsed) {
+      value = parsed[key];
+    }
+    if (typeof value === "string" && value.length > 0) {
+      helpText = value;
     }
   } catch {
-    // Fall back to live help rendering.
+    // Missing metadata is expected in source checkouts; fall back to live Commander help.
   }
-  setCache(null);
-  return null;
+  // Entry can retry command help through run-main; keep a miss even if the
+  // metadata reader advances from a falsy direct record to the parent layout.
+  precomputedHelpText.set(key, helpText);
+  return helpText;
 }
 
-function outputPrecomputedHelpText(
-  key: PrecomputedHelpTextKey,
-  cache: string | null | undefined,
-  setCache: (value: string | null) => void,
-): boolean {
-  const helpText = loadPrecomputedHelpText(key, cache, setCache);
+function outputPrecomputedHelpText(key: PrecomputedHelpTextKey): boolean {
+  const helpText = loadPrecomputedHelpText(key);
   if (!helpText) {
     return false;
   }
   process.stdout.write(helpText);
   return true;
-}
-
-function loadPrecomputedSubcommandHelpText(commandName: string): string | null {
-  if (!isPrecomputedSubcommandHelpName(commandName)) {
-    return null;
-  }
-  const cache = precomputedSubcommandHelpText?.[commandName];
-  if (cache !== undefined) {
-    return cache;
-  }
-  try {
-    const parsed = readCliStartupMetadata(import.meta.url);
-    const subcommandHelpText = parsed?.subcommandHelpText;
-    if (isSubcommandHelpTextRecord(subcommandHelpText)) {
-      const value = subcommandHelpText[commandName];
-      if (typeof value === "string" && value.length > 0) {
-        setPrecomputedSubcommandHelpText(commandName, value);
-        return value;
-      }
-    }
-  } catch {
-    // Fall back to live help rendering.
-  }
-  setPrecomputedSubcommandHelpText(commandName, null);
-  return null;
 }
 
 export function outputPrecomputedRootHelpText(): boolean {
-  return outputPrecomputedHelpText("rootHelpText", precomputedRootHelpText, (value) => {
-    precomputedRootHelpText = value;
-  });
+  return outputPrecomputedHelpText("rootHelpText");
 }
 
 export function outputPrecomputedBrowserHelpText(): boolean {
-  return outputPrecomputedHelpText("browserHelpText", precomputedBrowserHelpText, (value) => {
-    precomputedBrowserHelpText = value;
-  });
+  return outputPrecomputedHelpText("browserHelpText");
 }
 
 export function outputPrecomputedSecretsHelpText(): boolean {
-  return outputPrecomputedHelpText("secretsHelpText", precomputedSecretsHelpText, (value) => {
-    precomputedSecretsHelpText = value;
-  });
+  return outputPrecomputedHelpText("secretsHelpText");
 }
 
 export function outputPrecomputedNodesHelpText(): boolean {
-  return outputPrecomputedHelpText("nodesHelpText", precomputedNodesHelpText, (value) => {
-    precomputedNodesHelpText = value;
-  });
+  return outputPrecomputedHelpText("nodesHelpText");
 }
 
 export function outputPrecomputedSubcommandHelpText(commandName: string): boolean {
-  const helpText = loadPrecomputedSubcommandHelpText(commandName);
-  if (!helpText) {
-    return false;
-  }
-  process.stdout.write(helpText);
-  return true;
+  return isPrecomputedSubcommandHelpName(commandName) && outputPrecomputedHelpText(commandName);
 }
 
 function isPrecomputedSubcommandHelpName(
@@ -138,14 +95,4 @@ function isSubcommandHelpTextRecord(
   value: unknown,
 ): value is Partial<Record<PrecomputedSubcommandHelpName, unknown>> {
   return typeof value === "object" && value !== null;
-}
-
-function setPrecomputedSubcommandHelpText(
-  commandName: PrecomputedSubcommandHelpName,
-  value: string | null,
-): void {
-  precomputedSubcommandHelpText = {
-    ...precomputedSubcommandHelpText,
-    [commandName]: value,
-  };
 }


### PR DESCRIPTION
## What Problem This Solves

Precomputed CLI help had separate scalar and nested caches with repeated loading and output paths. This internal refactor makes that behavior easier to maintain without changing the help users see.

## Why This Change Was Made

One typed Map and one loader/output flow now serve root help and the ten supported command-help surfaces. Each key still snapshots its first result independently, including a cached `null` miss, so a later help attempt cannot silently change the first result. Existing entry points, literal text bytes and stdout behavior are preserved.

## User Impact

No intended user-visible change, new setting or migration. Production shrinks by 53 lines; characterization tests add 151 lines, for a whole change of +98 lines.

## Evidence

- The same six-suite group passed all 68 cases before and after the production refactor, with no skips.
- The normal 29-stage changed gate and 14-stage build passed.
- Eleven profile-prefixed launcher commands passed before and after; all 22 complete stdout/stderr streams were byte-identical, with no normalization or tolerance.
- Precommit and exact-commit Codex reviews completed with no accepted findings. The two-file change was committed with normal signing and hooks.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33362672551) completed successfully at `39111293924e464735e402084c88ae6eca83d42a`.

CLI proof used this macOS source build, non-TTY output and isolated empty configuration. Packaged installations, arbitrary configuration, rich terminals and other platforms were not tested by that local comparison.

## Review Follow-through

The [completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/133841#issuecomment-5474462292) found no actionable correctness or security issue; its two before-merge items both requested exact-head CI, now successful. There was no separate Rank-up moves list.

The review's generated stored-data warning does not describe this change: `src/cli/root-help-metadata.ts` owns an in-memory Map, not persisted state or a vector store. Its unchanged `readCliStartupMetadata` callee reads generated build metadata; this refactor changes neither that artifact's format nor a database schema, migration or runtime persistence contract.
