### PR TITLE
fix(cli): preserve triage diagnostics when the Gateway is offline

### DIFF
--- a/docs/cli/triage.md
+++ b/docs/cli/triage.md
@@ -14,7 +14,7 @@ Run read-only Doctor checks, collect the existing sanitized diagnostics archive,
 openclaw triage
 ```
 
-The prompt includes the OpenClaw version, platform, Node.js version, prioritized Doctor findings with repair hints, and the diagnostics archive path. The archive contains sanitized config, Gateway status and health snapshots, operational log summaries, and available stability diagnostics. If the Gateway is unreachable, triage still writes the prompt and explains why the archive is unavailable.
+The prompt includes the OpenClaw version, platform, Node.js version, prioritized Doctor findings with repair hints, and the diagnostics archive path. The archive contains sanitized config, best-effort Gateway status and health snapshots, operational log summaries, and available stability diagnostics. If the Gateway is unreachable, triage still writes the archive with available local diagnostics and records snapshot failures inside it. If the export itself fails, triage still writes the prompt and explains why the archive is unavailable.
 
 Secrets, tokens, raw chat payloads, and raw logs are excluded. Paths inside the prompt are shown relative to `~` or `$OPENCLAW_STATE_DIR`; the saved prompt path, archive path, and printed handoff commands retain the real absolute paths needed by your shell. Doctor checks remain advisory and do not apply repairs.
 
@@ -26,21 +26,23 @@ Choosing Claude Code or Codex starts its interactive session directly with the g
 
 On Windows, agents installed only as `.cmd` or `.bat` command shims appear in the manual handoff commands instead of the direct-launch picker.
 
-Non-interactive sessions and the print-only choice provide these manual handoff commands instead:
+Non-interactive sessions and the print-only choice provide these POSIX shell handoff commands instead:
 
 ```bash
 claude "$(cat '<prompt-path>')"
-codex exec - < '<prompt-path>'
+codex exec --skip-git-repo-check - < '<prompt-path>'
 openclaw triage --run
 ```
 
 JSON output also includes `detectedAgents`, listing the external agents found on `PATH`. JSON output and non-interactive sessions never start an agent.
 
+The Codex command works outside a Git checkout; it does not change Codex sandbox or approval settings.
+
 ## Output and exit codes
 
 The prompt is written to `logs/support/` inside the state directory with owner-only permissions, alongside the diagnostics archive when one was produced. Both paths are printed, and `--json` returns them plus finding counts by severity.
 
-A launched agent inherits the current environment, so it inspects the same installation the prompt describes, including a custom `OPENCLAW_STATE_DIR`. Triage exits with the launched agent's exit code. If the agent cannot be started, triage prints its manual command and exits non-zero. Selecting the embedded agent when no model is configured reports the missing model and exits non-zero without starting a turn.
+A launched external agent inherits the current environment, including a custom `OPENCLAW_STATE_DIR`. Triage exits with the launched agent's exit code. If the agent cannot be started, triage prints its manual command and exits non-zero. A failed embedded inference check exits non-zero whether selected from the picker or requested with `--run`; the saved prompt and manual handoff commands remain available. `--run` without an interactive terminal also exits non-zero.
 
 ## Options
 

--- a/src/commands/triage.test.ts
+++ b/src/commands/triage.test.ts
@@ -2,6 +2,7 @@
 import { EventEmitter } from "node:events";
 import fs from "node:fs/promises";
 import path from "node:path";
+import JSZip from "jszip";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { HealthFinding } from "../flows/health-checks.js";
@@ -239,7 +240,7 @@ describe("triageCommand", () => {
       detectedAgents: [],
       suggestedCommands: [
         `claude "$(cat '${promptPath}')"`,
-        `codex exec - < '${promptPath}'`,
+        `codex exec --skip-git-repo-check - < '${promptPath}'`,
         "openclaw triage --run",
       ],
     });
@@ -263,9 +264,10 @@ describe("triageCommand", () => {
     expect(mocks.verifySetupInference).not.toHaveBeenCalled();
   });
 
-  it("degrades to a sanitized prompt when the Gateway cannot provide diagnostics", async () => {
+  it("degrades to a sanitized prompt when the diagnostics export fails", async () => {
     const secret = "sk-abcdefghijklmnopqrstuvwxyz123456";
-    mocks.callGatewayFromCliWithTransport.mockRejectedValue(
+    mocks.callGatewayFromCliWithTransport.mockResolvedValue({ ok: true });
+    mocks.writeDiagnosticSupportExport.mockRejectedValue(
       new Error(
         `Gateway unreachable: Config: ${stateDir}/openclaw.json; Authorization: Bearer ${secret}`,
       ),
@@ -287,7 +289,62 @@ describe("triageCommand", () => {
     expect(prompt).toContain("Diagnostics export unavailable: Gateway unreachable");
     expect(prompt).toContain("Config: $OPENCLAW_STATE_DIR/openclaw.json");
     expect(prompt).not.toContain(stateDir);
-    expect(mocks.writeDiagnosticSupportExport).not.toHaveBeenCalled();
+  });
+
+  it("preserves local diagnostics and redacted snapshot failures while the Gateway is offline", async () => {
+    const { writeDiagnosticSupportExport } = await vi.importActual<
+      typeof import("../logging/diagnostic-support-export.js")
+    >("../logging/diagnostic-support-export.js");
+    const secret = "sk-test-triage-offline-secret-1234567890";
+    const configPath = path.join(stateDir, "openclaw.json");
+    await fs.writeFile(configPath, JSON.stringify({ gateway: { auth: { token: secret } } }));
+    mocks.callGatewayFromCliWithTransport.mockRejectedValue(new Error(`Offline token=${secret}`));
+    mocks.gatherDaemonStatus.mockRejectedValue(new Error("Status unavailable"));
+    mocks.writeDiagnosticSupportExport.mockImplementation((options) =>
+      writeDiagnosticSupportExport({
+        ...options,
+        stateDir,
+        env: { HOME: stateDir, OPENCLAW_CONFIG_PATH: configPath },
+        readLogTail: async () => ({
+          file: path.join(stateDir, "gateway.log"),
+          cursor: 0,
+          size: 0,
+          lines: [],
+          truncated: false,
+          reset: false,
+        }),
+      }),
+    );
+    const runtime = createRuntime();
+
+    await triageCommand(runtime, { json: true });
+
+    const report = runtime.writeJson.mock.calls[0]?.[0] as {
+      promptPath: string;
+      bundlePath: string;
+      bundleError: string | null;
+    };
+    expect(report.bundleError).toBeNull();
+    expect(report.bundlePath).toEqual(expect.any(String));
+    const zip = await JSZip.loadAsync(await fs.readFile(report.bundlePath));
+    const diagnostics = JSON.parse(await zip.file("diagnostics.json")!.async("string"));
+    expect(diagnostics.config).toMatchObject({ exists: true, parseOk: true });
+    expect(diagnostics.health).toMatchObject({ status: "failed" });
+    expect(diagnostics.status).toMatchObject({ status: "failed" });
+    const entries = await Promise.all(
+      Object.values(zip.files)
+        .filter((entry) => !entry.dir)
+        .map((entry) => entry.async("string")),
+    );
+    expect(entries.join("\n")).not.toContain(secret);
+    expect(entries.join("\n")).not.toContain(stateDir);
+    expect(await fs.readFile(report.promptPath, "utf8")).toContain("Sanitized ZIP:");
+    if (process.platform !== "win32") {
+      for (const file of [report.promptPath, report.bundlePath]) {
+        expect((await fs.stat(file)).mode & 0o777).toBe(0o600);
+      }
+      expect((await fs.stat(path.dirname(report.promptPath))).mode & 0o777).toBe(0o700);
+    }
   });
 
   it("reuses the sanitized support exporter with Gateway status and health snapshots", async () => {
@@ -327,23 +384,32 @@ describe("triageCommand", () => {
     });
   });
 
-  it("refuses embedded execution when the live inference probe fails", async () => {
-    mocks.verifySetupInference.mockResolvedValue({
-      ok: false,
-      status: "auth",
-      error: "The configured model is unavailable",
-    });
-    const runtime = createRuntime();
+  it.each([true, false])(
+    "refuses embedded execution when inference fails (run=%s)",
+    async (run) => {
+      mocks.readConfigFileSnapshot.mockResolvedValue({
+        exists: true,
+        valid: true,
+        config: { agents: { defaults: { model: "openai/gpt-5.6-luna" } } },
+      });
+      mocks.select.mockResolvedValue({ kind: "embedded" });
+      mocks.verifySetupInference.mockResolvedValue({
+        ok: false,
+        status: "auth",
+        error: "The configured model is unavailable",
+      });
+      const runtime = createRuntime();
 
-    await withInteractiveTerminal(async () => {
-      await expect(triageCommand(runtime, { noExport: true, run: true })).rejects.toThrow(
-        "Run `openclaw onboard` or use a suggested handoff command.",
-      );
-    });
+      await withInteractiveTerminal(async () => {
+        await expect(triageCommand(runtime, { noExport: true, run })).rejects.toThrow(
+          "Run `openclaw onboard` or use a suggested handoff command.",
+        );
+      });
 
-    expect(mocks.verifySetupInference).toHaveBeenCalledWith({ runtime, timeoutMs: 15_000 });
-    expect(mocks.agentExecCommand).not.toHaveBeenCalled();
-  });
+      expect(mocks.verifySetupInference).toHaveBeenCalledWith({ runtime, timeoutMs: 15_000 });
+      expect(mocks.agentExecCommand).not.toHaveBeenCalled();
+    },
+  );
 
   it("passes the saved prompt to one embedded agent turn after a healthy live probe", async () => {
     mocks.verifySetupInference.mockResolvedValue({

--- a/src/commands/triage.ts
+++ b/src/commands/triage.ts
@@ -35,16 +35,17 @@ async function collectTriageBundle(skipExport: boolean): Promise<TriageBundle> {
   }
   try {
     const rpc = { timeout: "3000", json: true };
-    const health = await callGatewayFromCliWithTransport("health", rpc, undefined, {
-      defaultTimeoutMs: 3000,
-      sharedStateMode: "read-only",
-    });
     const [{ writeDiagnosticSupportExport }, { gatherDaemonStatus }] = await Promise.all([
       import("../logging/diagnostic-support-export.js"),
       import("../cli/daemon-cli/status.gather.js"),
     ]);
     const result = await writeDiagnosticSupportExport({
-      readHealthSnapshot: async () => health,
+      // The exporter records failed snapshots while preserving local diagnostics.
+      readHealthSnapshot: async () =>
+        await callGatewayFromCliWithTransport("health", rpc, undefined, {
+          defaultTimeoutMs: 3000,
+          sharedStateMode: "read-only",
+        }),
       readStatusSnapshot: async () =>
         await gatherDaemonStatus({ rpc, probe: true, requireRpc: false, deep: false }),
     });
@@ -91,7 +92,7 @@ export async function triageCommand(
   const quotedPath = quoteShellArgument(promptPath);
   const suggestedCommands = [
     `claude "$(cat ${quotedPath})"`,
-    `codex exec - < ${quotedPath}`,
+    `codex exec --skip-git-repo-check - < ${quotedPath}`,
     "openclaw triage --run",
   ];
   const findingCounts: Record<HealthFindingSeverity, number> = {
@@ -205,12 +206,9 @@ export async function triageCommand(
   const inference = await verifySetupInference({ runtime, timeoutMs: 15_000 });
   if (!inference.ok) {
     const reason = redactSupportString(scrubDoctorErrorMessage(inference.error), redaction);
-    const message = `Embedded agent unavailable: ${reason}. Run \`openclaw onboard\` or use a suggested handoff command.`;
-    if (options.run === true) {
-      throw new Error(message);
-    }
-    runtime.log(message);
-    return;
+    throw new Error(
+      `Embedded agent unavailable: ${reason}. Run \`openclaw onboard\` or use a suggested handoff command.`,
+    );
   }
   const { agentExecCommand } = await import("./agent-exec.js");
   const result = await agentExecCommand(undefined, { messageFile: promptPath }, runtime);


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/128598 (broader recovery-agent proposal; this PR fixes the existing read-only triage/handoff flow, not the full proposal).

## What Problem This Solves

Fixes an issue where operators running `openclaw triage` with an unreachable Gateway received no diagnostics archive, even when local config and logs were available. Two handoff failures also made recovery confusing: selecting an unavailable embedded agent returned exit 0, and the printed Codex command failed outside a Git checkout.

## Why This Change Was Made

Let the existing support exporter collect health itself, so its per-snapshot failure handling preserves local evidence instead of an eager health preflight aborting the entire export. Both embedded-selection paths now use the same redacted failure outcome. The printed Codex command includes its documented `--skip-git-repo-check` flag without changing sandbox or approval settings.

The diagnostics exporter, Doctor checks, agent runner, redaction, and prompt-byte budget remain the canonical owners; no new config, environment variables, dependencies, storage, or fallback implementation. Production LOC: +10/-12 (net -2). Tests: +85/-19 (net +66). Docs: +6/-4.

Provenance: the affected triage paths were added in https://github.com/openclaw/openclaw/pull/128756 (sanitized agent debugging handoffs), commit `091f23ff490829f102b97b0a77867c74e99fe2bb`. Raw-parent comparison verified that patch; the affected modules are unchanged in the local `v2026.8.1` stable tag.

## User Impact

An offline or misconfigured installation still gets a private, sanitized ZIP with available local evidence and recorded failed Gateway snapshots. A genuine exporter failure still yields a prompt explaining the missing archive, and `--no-export` still skips it. An unavailable embedded model now fails visibly with a nonzero exit regardless of whether selected in the picker or through `--run`. Manual Codex handoff works from an ordinary non-repository directory.

## Evidence

- Before production edits, the focused suite had three intended failures: missing offline archive, picker-selected inference failure returning success, and the missing Codex non-Git flag. After repair all 22 triage tests pass.
- 407 tests passed across seven owner/sibling files, covering triage, Doctor lint, maintenance argument parsing, support export, daemon status, agent execution, and setup inference:
  ```bash
  OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/commands/triage.test.ts src/commands/doctor-lint.test.ts src/cli/program/register.maintenance.test.ts src/logging/diagnostic-support-export.test.ts src/cli/daemon-cli/status.gather.test.ts src/commands/agent-exec.test.ts src/system-agent/setup-inference.test.ts
  ```
- `pnpm build` passed for both baseline and candidate; no `INEFFECTIVE_DYNAMIC_IMPORT` warning. `node scripts/check-changed.mjs -- src/commands/triage.ts src/commands/triage.test.ts docs/cli/triage.md` and `git diff --check` passed.
- Real dist-backed `pnpm --silent openclaw triage --json` runs used synthetic isolated home/config/state, unique profiles, and free nondefault ports. Before: offline, empty, and malformed-config cases had `bundlePath: null`. After: all three produced ZIPs containing local config/log entries and a failed health snapshot, with `bundleError: null`. Config bytes were unchanged; prompt/ZIP permissions were 0600 and support-directory permissions 0700. Prompt and archive scans excluded the synthetic secret/private payload and absolute state paths. Parent independently reopened and checked these artifacts.
- Real `--json --no-export` and quoted-path runs passed. Four inert external-command tests proved POSIX argument/stdin delivery, including apostrophes, spaces, `$`, and `&`; these are executable-boundary tests, not provider-inference claims.
- Real CLI PTY: selecting a synthetic unavailable embedded model exited 0 before and 1 after. A guarded fake external Codex executable received the exact prompt and its exit 17 propagated. No real fixing agent or operator Gateway was used.
- Direct upstream Codex source inspection: `codex-rs/exec/src/cli.rs:28,75`, `codex-rs/exec/src/lib.rs:795-802`, and `codex-rs/tui/src/cli.rs:13` at `86b1123ff6b5d089a146be4e603a324cf454223a` verify the non-Git flag, stdin prompt, and interactive argv contracts.
- Independent Codex autoreview: scoped-clean at its default P0 scope, with no accepted/actionable findings.

Validation notes: early PTY harness attempts had terminal geometry/process-exit/PATH issues and were discarded, not counted as product proof. Source-launcher rebuilds and a stale lock from an interrupted owned build also required recovery before the successful final runs. No healthy live Gateway/provider inference or native Windows validation is claimed; those surfaces are unchanged, and owner/sibling tests cover the existing healthy callbacks.

Named follow-ups from this testing: client TLS inspection currently auto-generates missing certificates through the shared server TLS loader; embedded `agent exec` temporary state loses the original installation context referenced by `$OPENCLAW_STATE_DIR`; native Windows handoff commands still need shell-specific generation. The first two are recorded as separate owner-boundary follow-up tasks. This PR does not claim to solve them or to implement the broader auto-heal proposal.

Docs: https://docs.openclaw.ai/cli/triage
