### PR TITLE
test(media): mock QR runtime at loader boundary

### DIFF
--- a/src/media/qr-image.test.ts
+++ b/src/media/qr-image.test.ts
@@ -1,4 +1,3 @@
-// QR image tests cover QR image generation and file output.
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -13,16 +12,9 @@ const { MOCK_PNG_BASE64, MOCK_PNG_BUFFER, toBuffer } = vi.hoisted(() => {
   };
 });
 
-vi.mock("qrcode", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("qrcode")>();
-  return {
-    ...actual,
-    default: {
-      ...(actual.default ?? actual),
-      toBuffer,
-    },
-  };
-});
+vi.mock("./qr-runtime.ts", () => ({
+  loadQrCodeRuntime: async () => ({ toBuffer }),
+}));
 
 let renderQrPngBase64: typeof import("./qr-image.ts").renderQrPngBase64;
 let renderQrPngDataUrl: typeof import("./qr-image.ts").renderQrPngDataUrl;
@@ -120,6 +112,6 @@ describe("renderQrPngBase64", () => {
 });
 
 afterAll(() => {
-  vi.doUnmock("qrcode");
+  vi.doUnmock("./qr-runtime.ts");
   vi.resetModules();
 });

--- a/src/media/qr-terminal.test.ts
+++ b/src/media/qr-terminal.test.ts
@@ -1,4 +1,3 @@
-// QR terminal tests cover text normalization and terminal render calls.
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const { create, toString } = vi.hoisted(() => ({
@@ -11,17 +10,9 @@ const { create, toString } = vi.hoisted(() => ({
   toString: vi.fn(async () => "ASCII-QR"),
 }));
 
-vi.mock("qrcode", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("qrcode")>();
-  return {
-    ...actual,
-    default: {
-      ...(actual.default ?? actual),
-      create,
-      toString,
-    },
-  };
-});
+vi.mock("./qr-runtime.ts", () => ({
+  loadQrCodeRuntime: async () => ({ create, toString }),
+}));
 
 let renderQrTerminal: typeof import("./qr-terminal.ts").renderQrTerminal;
 
@@ -53,6 +44,6 @@ describe("renderQrTerminal", () => {
 });
 
 afterAll(() => {
-  vi.doUnmock("qrcode");
+  vi.doUnmock("./qr-runtime.ts");
   vi.resetModules();
 });


### PR DESCRIPTION
## What Problem This Solves

QR wrapper tests imported and spread the real qrcode package inside mocks. That initializes unrelated renderers even though the tests replace the only methods they exercise.

## Why This Change Was Made

Mock the existing QR runtime loader directly. Keep module-cache isolation from the earlier cross-file leak repair, and retain the separate real terminal rendering and decoding suite.

## User Impact

Faster focused tests and smaller fixtures; runtime behavior is unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/media/qr-image.test.ts src/media/qr-terminal.test.ts src/media/qr-terminal.render.test.ts` passes all 18 cases together.
- Observed image/terminal wrapper file durations: 97/71 ms before, 69/51 ms after. The real rendering suite also passes. These are local focused measurements.
- Formatting, diff check, and fresh structured Codex autoreview pass. Full changed checks are running before landing.
- Production +0/-0; tests +8/-25 (net -17). Read both wrappers, runtime loader, lazy promise helper, dependency entry points and cross-file isolation history.
