### PR TITLE
fix(infra): make SSH tunnel stop await process reaping and join concurrent callers

### DIFF
--- a/src/infra/ssh-tunnel.test.ts
+++ b/src/infra/ssh-tunnel.test.ts
@@ -212,6 +212,49 @@ describe("startSshPortForward", () => {
     await tunnel.stop();
   });
 
+  it.each(["term", "kill"] as const)(
+    "keeps every stop caller pending until the child exits after %s",
+    async (exitAfter) => {
+      spawnFakeSshListening();
+      const tunnel = await startSshPortForward({
+        target: "me@example.com:2222",
+        localPortPreferred: await getFreePort(),
+        remotePort: 18789,
+        timeoutMs: 1000,
+      });
+      const child = mocks.spawn.mock.results[0]?.value as EventEmitter & {
+        killed: boolean;
+        kill: (signal?: string) => boolean;
+      };
+      const signals: string[] = [];
+      child.kill = (signal = "SIGTERM") => {
+        child.killed = true;
+        signals.push(signal);
+        return true;
+      };
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const settled: number[] = [];
+      const waits = [
+        tunnel.stop().then(() => settled.push(1)),
+        tunnel.stop().then(() => settled.push(2)),
+      ];
+      try {
+        await vi.advanceTimersByTimeAsync(exitAfter === "kill" ? 1500 : 0);
+        expect(signals).toEqual(exitAfter === "kill" ? ["SIGTERM", "SIGKILL"] : ["SIGTERM"]);
+        expect(settled).toEqual([]);
+        child.emit("exit", null, exitAfter === "kill" ? "SIGKILL" : "SIGTERM");
+        await Promise.all(waits);
+        expect(settled).toHaveLength(2);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        child.emit("exit", null, "SIGTERM");
+        child.emit("close", null, "SIGTERM");
+        await Promise.all(waits);
+        vi.useRealTimers();
+      }
+    },
+  );
+
   it("rejects with the spawn error when ssh binary is missing", async () => {
     vi.useFakeTimers();
     const spawnError = new Error("ENOENT: no such file or directory, spawn /usr/bin/ssh");

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -207,23 +207,83 @@ export async function startSshPortForward(opts: {
     stderr.push(...lines);
   });
 
+  // Memoize teardown so concurrent callers join the same process-reaping
+  // fence. `child.killed` only means a signal was dispatched, not that the
+  // process is reaped — so parked concurrent callers must still await
+  // `close`/`exit`, not return early. Track TERM/KILL escalation
+  // exactly once and resolve only after the child settles.
+  let teardownPromise: Promise<void> | undefined;
+  let termSent = false;
+  let killSent = false;
+  let childExited = false;
+  // Mark reaped once so already-exited idempotence is observable without
+  // racing the `exit` handler that the teardown installs.
+  child.once("exit", () => {
+    childExited = true;
+  });
+  child.once("close", () => {
+    childExited = true;
+  });
   const stop = async () => {
-    if (child.killed || !child.kill("SIGTERM")) {
+    if (teardownPromise) {
+      return teardownPromise;
+    }
+    // Already reaped — idempotent fast path without dispatching signals.
+    if (childExited || child.exitCode !== null || child.signalCode !== null) {
       return;
     }
-    await new Promise<void>((resolve) => {
-      const t = setTimeout(() => {
+    teardownPromise = new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        clearTimeout(killTimer);
+        resolve();
+      };
+      const onExit = () => {
+        finish();
+      };
+      child.once("exit", onExit);
+      child.once("close", onExit);
+      child.once("error", onExit);
+      const killTimer = setTimeout(() => {
+        if (killSent) {
+          return;
+        }
+        killSent = true;
         try {
           child.kill("SIGKILL");
-        } finally {
-          resolve();
+        } catch {
+          // Process may have already exited; treat as settled via exit/close.
         }
+        // Do not resolve here — await the child's exit/close so delayed
+        // post-SIGKILL settlement is still observed before resolving.
       }, 1500);
-      child.once("exit", () => {
-        clearTimeout(t);
-        resolve();
-      });
+      // Unref the grace timer so it does not keep the process alive in tests.
+      // SAFETY: NodeJS.Timeout unref is optional across platforms; guarded by optional chain
+      const maybeTimer = killTimer as unknown as { unref?: () => void };
+      maybeTimer.unref?.();
+
+      if (!termSent) {
+        termSent = true;
+        try {
+          const sent = child.kill("SIGTERM");
+          if (!sent) {
+            // Child already exited synchronously — let the exit/close handler settle.
+          }
+        } catch {
+          // Child already exited — settle via the exit/close handler.
+        }
+      }
+      // If the child was already reaped before we installed handlers, settle
+      // immediately so we do not wait for an event that will never fire.
+      if (child.exitCode !== null || child.signalCode !== null || childExited) {
+        finish();
+      }
     });
+    return teardownPromise;
   };
 
   try {

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -207,84 +207,22 @@ export async function startSshPortForward(opts: {
     stderr.push(...lines);
   });
 
-  // Memoize teardown so concurrent callers join the same process-reaping
-  // fence. `child.killed` only means a signal was dispatched, not that the
-  // process is reaped — so parked concurrent callers must still await
-  // `close`/`exit`, not return early. Track TERM/KILL escalation
-  // exactly once and resolve only after the child settles.
-  let teardownPromise: Promise<void> | undefined;
-  let termSent = false;
-  let killSent = false;
-  let childExited = false;
-  // Mark reaped once so already-exited idempotence is observable without
-  // racing the `exit` handler that the teardown installs.
-  child.once("exit", () => {
-    childExited = true;
+  const exited = new Promise<void>((resolve) => {
+    child.once("exit", () => resolve());
+    child.once("close", () => resolve());
   });
-  child.once("close", () => {
-    childExited = true;
-  });
-  const stop = async () => {
-    if (teardownPromise) {
-      return teardownPromise;
-    }
-    // Already reaped — idempotent fast path without dispatching signals.
-    if (childExited || child.exitCode !== null || child.signalCode !== null) {
-      return;
-    }
-    teardownPromise = new Promise<void>((resolve) => {
-      let settled = false;
-      const finish = () => {
-        if (settled) {
-          return;
-        }
-        settled = true;
-        clearTimeout(killTimer);
-        resolve();
-      };
-      const onExit = () => {
-        finish();
-      };
-      child.once("exit", onExit);
-      child.once("close", onExit);
-      child.once("error", onExit);
-      const killTimer = setTimeout(() => {
-        if (killSent) {
-          return;
-        }
-        killSent = true;
-        try {
-          child.kill("SIGKILL");
-        } catch {
-          // Process may have already exited; treat as settled via exit/close.
-        }
-        // Do not resolve here — await the child's exit/close so delayed
-        // post-SIGKILL settlement is still observed before resolving.
-      }, 1500);
-      // Unref the grace timer so it does not keep the process alive in tests.
-      // SAFETY: NodeJS.Timeout unref is optional across platforms; guarded by optional chain
-      const maybeTimer = killTimer as unknown as { unref?: () => void };
-      maybeTimer.unref?.();
-
-      if (!termSent) {
-        termSent = true;
-        try {
-          const sent = child.kill("SIGTERM");
-          if (!sent) {
-            // Child already exited synchronously — let the exit/close handler settle.
-          }
-        } catch {
-          // Child already exited — settle via the exit/close handler.
-        }
+  let stopping: Promise<void> | undefined;
+  const stop = () =>
+    (stopping ??= (async () => {
+      // Sending a signal is not exit; every caller must await the same child lifetime.
+      const timer = setTimeout(() => child.kill("SIGKILL"), 1500);
+      try {
+        child.kill("SIGTERM");
+        await exited;
+      } finally {
+        clearTimeout(timer);
       }
-      // If the child was already reaped before we installed handlers, settle
-      // immediately so we do not wait for an event that will never fire.
-      if (child.exitCode !== null || child.signalCode !== null || childExited) {
-        finish();
-      }
-    });
-    return teardownPromise;
-  };
+    })());
 
   try {
     await Promise.race([


### PR DESCRIPTION
## What Problem This Solves

Concurrent tunnel stop calls can return after a signal was sent while the SSH child still runs. Retain one exit/close promise from spawn and one memoized stop operation, send TERM then escalate after 1500 ms, and resolve every caller only after observed child termination. Remove the killed-flag shortcut and the timeout resolver.

## Why This Change Was Made

Signal delivery does not prove process termination. The SSH tunnel owns the child lifetime and must make every concurrent stop caller wait for the same exit or close event.

## User Impact

Callers can safely release or replace a tunnel after stop returns; the prior SSH child has terminated.

## Evidence

Real Linux sshd and system ssh forwarded a synthetic payload. With the child paused, baseline stop caller two returned early and the first joined while the child was still alive. The exact restored production source kept both pending, then joined with the child gone and port closed. Baseline 2 regression failures/12 controls became 14 passing tests. Core/infra test types, scoped lint, format and diff checks passed. Testbox exit0 and own-resource cleanup are recorded; lease was stopped. The external runner portal sync warning was an artifact-sync timeout after successful proof.

Production: +16/−18, net -2. Tests: +43. No changelog change.

The replacement has no error-as-exit handler or undefined-versus-null terminal-state check, eliminating both contributor blockers. Existing ENOENT close and stderr-error controls remain green. The real SSH proof covers the requested after-fix trace.

Observed synthetic proof:

```json
{"label":"baseline","sourceSha256":"8d97e1172ee69c8dcc7ce54af3f6fd86fc2e51286a12e04f65761b0889c1a677","forwardedPayload":"synthetic-forwarded-payload","beforeExit":{"firstDone":false,"secondDone":true,"childAlive":true,"listenerOpen":true},"atJoin":{"elapsedMs":1502,"childAlive":true,"listenerOpen":false},"final":{"childAlive":false,"listenerOpen":false}}
{"label":"fixed","sourceSha256":"5bcaddbb0dbdeabb83b0b743836360e62fbb47350e16ab6d2e9be16c73e3bfef","forwardedPayload":"synthetic-forwarded-payload","beforeExit":{"firstDone":false,"secondDone":false,"childAlive":true,"listenerOpen":true},"atJoin":{"elapsedMs":1502,"childAlive":false,"listenerOpen":false},"final":{"childAlive":false,"listenerOpen":false}}
{"status":"pass","baselineHead":"f74dde80b6c951124d9f8c7038d8391945296e79","candidateSha256":"5bcaddbb0dbdeabb83b0b743836360e62fbb47350e16ab6d2e9be16c73e3bfef","assertion":"baseline reproduced early concurrent completion; fixed callers joined child exit and port closure"}
{"cleanup":"own SSH daemon, children, ports, keys, namespace, and worktrees removed"}
```

Thanks @aniruddhaadak80 for the original repair.
