### PR TITLE
fix(wizard): expire abandoned setup wizard sessions

### DIFF
--- a/src/gateway/server-methods/wizard.test.ts
+++ b/src/gateway/server-methods/wizard.test.ts
@@ -191,6 +191,166 @@ describe("hosted wizard runtime isolation", () => {
   );
 });
 
+// Matches openclaw.setup.auth.start (PROVIDER_AUTH_SESSION_TIMEOUT_MS).
+const WIZARD_START_IDLE_TTL_MS = 25 * 60 * 1000;
+
+describe("wizard.start idle TTL", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it.each([
+    { flow: "setup", params: { mode: "local" } },
+    { flow: "channels", params: { flow: "channels" } },
+  ] as const)(
+    "expires an abandoned $flow wizard so a later start is not busy",
+    async ({ params }) => {
+      vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+      const tracker = createWizardSessionTracker();
+      const waitOnPrompt = async (
+        _opts: unknown,
+        _runtime: RuntimeEnv,
+        prompter: WizardPrompter,
+      ) => {
+        await prompter.text({ message: "Name" });
+      };
+      const context = {
+        ...tracker,
+        wizardRunner: waitOnPrompt,
+        channelWizardRunner: waitOnPrompt,
+      };
+
+      try {
+        const startRespond = vi.fn();
+        await expectDefined(
+          wizardHandlers["wizard.start"],
+          "wizard.start test invariant",
+        )({
+          params,
+          respond: startRespond,
+          context,
+        } as never);
+        expect(startRespond.mock.calls[0]?.[1]).toMatchObject({ status: "running" });
+
+        const busyRespond = vi.fn();
+        await expectDefined(
+          wizardHandlers["wizard.start"],
+          "wizard.start test invariant",
+        )({
+          params,
+          respond: busyRespond,
+          context,
+        } as never);
+        expect(busyRespond).toHaveBeenCalledWith(
+          false,
+          undefined,
+          expect.objectContaining({
+            code: "UNAVAILABLE",
+            details: { code: "SETUP_ADMISSION_BUSY" },
+          }),
+        );
+
+        await vi.advanceTimersByTimeAsync(WIZARD_START_IDLE_TTL_MS);
+        const abandoned = expectDefined(
+          [...tracker.wizardSessions.values()][0],
+          "abandoned wizard session",
+        );
+        expect(abandoned.getStatus()).toBe("cancelled");
+        await whenAdmittedWizardSessionSettled(abandoned);
+
+        const replacementRespond = vi.fn();
+        await expectDefined(
+          wizardHandlers["wizard.start"],
+          "wizard.start test invariant",
+        )({
+          params,
+          respond: replacementRespond,
+          context,
+        } as never);
+        expect(replacementRespond.mock.calls[0]?.[1]).toMatchObject({ status: "running" });
+      } finally {
+        await cancelWizardSessions(tracker.wizardSessions);
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("refreshes the idle TTL when wizard.next answers a prompt", async () => {
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const tracker = createWizardSessionTracker();
+    const waitOnPrompts = async (
+      _opts: unknown,
+      _runtime: RuntimeEnv,
+      prompter: WizardPrompter,
+    ) => {
+      await prompter.text({ message: "Name" });
+      await prompter.text({ message: "Email" });
+    };
+    const context = {
+      ...tracker,
+      wizardRunner: waitOnPrompts,
+    };
+
+    try {
+      const startRespond = vi.fn();
+      await expectDefined(
+        wizardHandlers["wizard.start"],
+        "wizard.start test invariant",
+      )({
+        params: { mode: "local" },
+        respond: startRespond,
+        context,
+      } as never);
+      const started = startRespond.mock.calls[0]?.[1] as {
+        sessionId: string;
+        step?: { id: string };
+        status: string;
+      };
+      expect(started.status).toBe("running");
+
+      await vi.advanceTimersByTimeAsync(WIZARD_START_IDLE_TTL_MS - 60_000);
+      const answerRespond = vi.fn();
+      await expectDefined(
+        wizardHandlers["wizard.next"],
+        "wizard.next test invariant",
+      )({
+        params: {
+          sessionId: started.sessionId,
+          answer: { stepId: started.step?.id, value: "Ada" },
+        },
+        respond: answerRespond,
+        context,
+      } as never);
+      expect(answerRespond.mock.calls[0]?.[1]).toMatchObject({ status: "running" });
+
+      await vi.advanceTimersByTimeAsync(WIZARD_START_IDLE_TTL_MS - 60_000);
+      const stillAlive = expectDefined(
+        tracker.wizardSessions.get(started.sessionId),
+        "active wizard session",
+      );
+      expect(stillAlive.getStatus()).toBe("running");
+
+      await vi.advanceTimersByTimeAsync(WIZARD_START_IDLE_TTL_MS);
+      expect(stillAlive.getStatus()).toBe("cancelled");
+      await whenAdmittedWizardSessionSettled(stillAlive);
+
+      const replacementRespond = vi.fn();
+      await expectDefined(
+        wizardHandlers["wizard.start"],
+        "wizard.start test invariant",
+      )({
+        params: { mode: "local" },
+        respond: replacementRespond,
+        context,
+      } as never);
+      expect(replacementRespond.mock.calls[0]?.[1]).toMatchObject({ status: "running" });
+    } finally {
+      await cancelWizardSessions(tracker.wizardSessions);
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe("wizard setup ownership", () => {
   it("rejects classic setup while structured setup owns admission, then permits it", async () => {
     const structuredStarted = createDeferred();

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -80,6 +80,10 @@ function sanitizeWizardResultForClient<T extends { step?: WizardStep }>(result: 
   return result.step ? { ...result, step: sanitizeWizardStepForClient(result.step) } : result;
 }
 
+// Same idle budget as openclaw.setup.auth.start so a dropped Control UI
+// cannot pin SETUP_ADMISSION_BUSY until Gateway restart.
+const WIZARD_SESSION_TIMEOUT_MS = 25 * 60 * 1000;
+
 /** Resolves a live wizard session or sends the public not-found error. */
 function findWizardSessionOrRespond(params: {
   context: GatewayRequestContext;
@@ -111,33 +115,37 @@ export const wizardHandlers: GatewayRequestHandlers = {
     const flow = params.flow ?? "setup";
     const createSession = () =>
       flow === "channels"
-        ? new WizardSession((prompter, _signal, wizardSession) =>
-            runHostedWizard((runtime) =>
-              context.channelWizardRunner(
-                {
-                  channel: readStringValue(params.channel),
-                  onConfigured: (accounts) => wizardSession.setConfiguredAccounts(accounts),
-                  // Durable effects (plugin installs, config commit) must finish
-                  // even if the client cancels mid-write.
-                  beforePersistentEffect: async () => wizardSession.lockCancellation(),
-                },
-                runtime,
-                prompter,
+        ? new WizardSession(
+            (prompter, _signal, wizardSession) =>
+              runHostedWizard((runtime) =>
+                context.channelWizardRunner(
+                  {
+                    channel: readStringValue(params.channel),
+                    onConfigured: (accounts) => wizardSession.setConfiguredAccounts(accounts),
+                    // Durable effects (plugin installs, config commit) must finish
+                    // even if the client cancels mid-write.
+                    beforePersistentEffect: async () => wizardSession.lockCancellation(),
+                  },
+                  runtime,
+                  prompter,
+                ),
               ),
-            ),
+            { timeoutMs: WIZARD_SESSION_TIMEOUT_MS },
           )
-        : new WizardSession((prompter) =>
-            runHostedWizard((runtime) =>
-              context.wizardRunner(
-                {
-                  mode: params.mode,
-                  workspace: readStringValue(params.workspace),
-                  installDaemon: params.installDaemon,
-                },
-                runtime,
-                prompter,
+        : new WizardSession(
+            (prompter) =>
+              runHostedWizard((runtime) =>
+                context.wizardRunner(
+                  {
+                    mode: params.mode,
+                    workspace: readStringValue(params.workspace),
+                    installDaemon: params.installDaemon,
+                  },
+                  runtime,
+                  prompter,
+                ),
               ),
-            ),
+            { timeoutMs: WIZARD_SESSION_TIMEOUT_MS },
           );
     const session = await createAdmittedWizardSession(createSession, flow === "setup");
     if (!session) {

--- a/src/wizard/session.test.ts
+++ b/src/wizard/session.test.ts
@@ -466,6 +466,35 @@ describe("WizardSession", () => {
     }
   });
 
+  test("client answers refresh the idle TTL", async () => {
+    vi.useFakeTimers();
+    try {
+      const session = new WizardSession(
+        async (prompter) => {
+          await prompter.text({ message: "Name" });
+          await prompter.text({ message: "Email" });
+        },
+        { timeoutMs: 1_000 },
+      );
+
+      const first = await session.next();
+      expect(first.step?.type).toBe("text");
+      await vi.advanceTimersByTimeAsync(800);
+      expect(session.getStatus()).toBe("running");
+      await session.answer(first.step?.id ?? "", "Ada");
+
+      const second = await session.next();
+      expect(second.step?.type).toBe("text");
+      await vi.advanceTimersByTimeAsync(800);
+      expect(session.getStatus()).toBe("running");
+
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(session.getStatus()).toBe("cancelled");
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test.each(["return", "commit"])(
     "a cancelled runner stays cancelled on late %s",
     async (action) => {

--- a/src/wizard/session.ts
+++ b/src/wizard/session.ts
@@ -257,7 +257,8 @@ function createWizardSessionPrompter(session: WizardSession): WizardPrompter {
 
 export class WizardSession {
   private readonly abortController = new AbortController();
-  private readonly expiryTimer: ReturnType<typeof setTimeout> | undefined;
+  private expiryTimer: ReturnType<typeof setTimeout> | undefined;
+  private readonly idleTimeoutMs: number | undefined;
   private readonly runnerPromise: Promise<void>;
   private currentStep: WizardStep | null = null;
   private progressSteps: WizardStep[] = [];
@@ -294,14 +295,33 @@ export class WizardSession {
     options?: { timeoutMs?: number },
   ) {
     const prompter = createWizardSessionPrompter(this);
-    if (options?.timeoutMs !== undefined) {
-      this.expiryTimer = setTimeout(() => {
-        this.expiryPending = true;
-        this.cancel();
-      }, options.timeoutMs);
-      this.expiryTimer.unref?.();
-    }
+    this.idleTimeoutMs = options?.timeoutMs;
+    this.armIdleExpiry();
     this.runnerPromise = this.run(prompter);
+  }
+
+  // Idle TTL, not wall-clock from start: client next/answer keep a live
+  // hosted wizard alive. A one-shot constructor timer would cancel an
+  // active Control UI session after 25 minutes.
+  private armIdleExpiry() {
+    if (this.idleTimeoutMs === undefined || this.status !== "running") {
+      return;
+    }
+    if (this.expiryTimer) {
+      clearTimeout(this.expiryTimer);
+    }
+    this.expiryTimer = setTimeout(() => {
+      this.expiryPending = true;
+      this.cancel();
+    }, this.idleTimeoutMs);
+    this.expiryTimer.unref?.();
+  }
+
+  private clearIdleExpiry() {
+    if (this.expiryTimer) {
+      clearTimeout(this.expiryTimer);
+      this.expiryTimer = undefined;
+    }
   }
 
   async next(): Promise<WizardNextResult> {
@@ -310,6 +330,7 @@ export class WizardSession {
     if (this.status !== "running") {
       return this.terminalResult();
     }
+    this.armIdleExpiry();
     const progressStep = this.progressSteps.shift();
     if (progressStep) {
       this.rememberDeliveredProgressStep(progressStep.id);
@@ -383,10 +404,12 @@ export class WizardSession {
       // clients still acknowledge every rendered step, so accept that stale
       // acknowledgement while newer clients poll without an answer.
       if (this.deliveredProgressStepIds.delete(stepId)) {
+        this.armIdleExpiry();
         return undefined;
       }
       throw new Error("wizard: no pending step");
     }
+    this.armIdleExpiry();
     const normalizedValue = pending.text ? normalizeTextAnswer(value) : value;
     if (pending.text && normalizedValue === undefined) {
       return "wizard: text answer must be a scalar value";
@@ -410,6 +433,7 @@ export class WizardSession {
     ) {
       return false;
     }
+    this.clearIdleExpiry();
     this.status = "cancelled";
     this.error = "cancelled";
     this.abortController.abort(new WizardCancelledError());
@@ -554,9 +578,7 @@ export class WizardSession {
     } finally {
       this.settled = true;
       this.consumeExternalUrl();
-      if (this.expiryTimer) {
-        clearTimeout(this.expiryTimer);
-      }
+      this.clearIdleExpiry();
       // Browser completion can win while manual input is pending. Terminal
       // sessions must retire that prompt and reject retained answer handles.
       this.rejectPendingAnswers();


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators who start Control UI setup (`wizard.start`) and then close the browser or drop the WebSocket would leave the Gateway setup slot occupied. The next setup attempt then fails with `SETUP_ADMISSION_BUSY` until the Gateway process restarts.

Idle cancel also used to leave the abandoned session in the Gateway map forever, because the timer path never went through `wizard.cancel`.

## Why This Change Was Made

`WizardSession` already supports `timeoutMs`, and `openclaw.setup.auth.start` already uses a 25-minute session budget. `wizard.start` never passed a timeout, so an abandoned hosted wizard never cancelled.

This revision keeps that 25-minute budget on hosted `wizard.start` only as a sliding idle TTL (`renewIdleOnActivity: true`). Structured activation, provider auth, prepare, and `models.authLogin` keep their original one-shot deadlines.

When the idle timer cancels a session, start now schedules map cleanup after admission settles. The terminal result stays collectable for the same 5-minute uncollected window later starts already use. This change does not add a new config key. Cancellation stays locked after a durable channels write (`lockCancellation`), so an in-flight plugin install or config commit still finishes.

## User Impact

If Control UI setup sits with no `wizard.next` or answer for 25 minutes, the session cancels and a later `wizard.start` can run again without restarting the Gateway. Answering a prompt resets that 25-minute idle window. An expired session can still be collected with `wizard.status` for a few minutes, then the Gateway forgets it.

## Evidence

Live isolated Gateway on tip [`049ca3f2671`](https://github.com/openclaw/openclaw/commit/049ca3f267142195ee0bbb6ab67d2e0840ab61e9). Production `startGatewayServer` plus WebSocket `wizard.start` / `wizard.next` / `wizard.status`. Fresh `OPENCLAW_STATE_DIR`. The production idle constant is 25 minutes and the uncollected retention constant is 5 minutes; the probe remapped those exact values to 1500ms and 400ms so the RPC path could be observed without a 25-minute wait.

```console
$ pnpm exec tsx /tmp/proof-133848-gateway.mts
PLAN {"stateDir":".../oc-133848-proof-home-uBNb1A/.openclaw","port":56000,"idleTtlMs":1500000,"idleProbeMs":1500,"retentionMs":300000,"retentionProbeMs":400}
[gateway] ready
START {"status":"running","done":false,"stepType":"text","sessionIdPrefix":"08f510d3"}
BUSY {"code":"SETUP_ADMISSION_BUSY"}
RENEW {"status":"running","done":false,"stepType":"text"}
STILL_ALIVE_AFTER_ACTIVITY {"status":"running"}
EXPIRED_STATUS {"status":"cancelled","error":"cancelled"}
COLLECTED_GONE {"code":"WIZARD_NOT_FOUND"}
REPLACEMENT {"status":"running","done":false,"stepType":"text","sameSession":false}
UNATTENDED_EXPIRED {"status":"cancelled","error":"cancelled"}
AFTER_UNATTENDED_SETTLE {"status":"running","done":false,"stepType":"text"}
UNCOLLECTED_RETIRED {"code":"WIZARD_NOT_FOUND"}
ACCEPTED_AFTER_RETIRE {"status":"running","done":false,"stepType":"text"}
HEALTH {"ok":true}
DONE {"ok":true}
```

## Real behavior proof

- **Behavior or issue addressed:** Abandoned hosted setup and channels wizards expire after 25 minutes of inactivity instead of pinning SETUP_ADMISSION_BUSY until Gateway restart. Client next/answer refreshes that idle window only on hosted wizard.start. Other timeoutMs flows keep a fixed deadline. After idle cancel settles, an unattended session is retired from the Gateway map.
- **Real environment tested:** macOS Darwin, Node from the worktree /private/tmp/oc-133848-replay5, isolated OPENCLAW_STATE_DIR under /tmp, production startGatewayServer on loopback WebSocket.
- **Exact steps or command run after this patch:** pnpm exec tsx /tmp/proof-133848-gateway.mts
- **Evidence after fix:** terminal output copied below.

```console
START {"status":"running","done":false,"stepType":"text","sessionIdPrefix":"08f510d3"}
BUSY {"code":"SETUP_ADMISSION_BUSY"}
RENEW {"status":"running","done":false,"stepType":"text"}
STILL_ALIVE_AFTER_ACTIVITY {"status":"running"}
EXPIRED_STATUS {"status":"cancelled","error":"cancelled"}
COLLECTED_GONE {"code":"WIZARD_NOT_FOUND"}
REPLACEMENT {"status":"running","done":false,"stepType":"text","sameSession":false}
UNATTENDED_EXPIRED {"status":"cancelled","error":"cancelled"}
AFTER_UNATTENDED_SETTLE {"status":"running","done":false,"stepType":"text"}
UNCOLLECTED_RETIRED {"code":"WIZARD_NOT_FOUND"}
ACCEPTED_AFTER_RETIRE {"status":"running","done":false,"stepType":"text"}
HEALTH {"ok":true}
DONE {"ok":true}
```

- **Observed result after fix:** Live wizard.start occupied setup admission (second start returned SETUP_ADMISSION_BUSY). Answering a prompt kept the session running through most of the remapped idle window. After idle cancel, wizard.status returned cancelled, then the session was gone. A replacement start was accepted. An uncollected expired session was retired after the remapped retention window, and the next start was accepted.
- **What was not tested:** A full 25-minute wait against a Control UI browser disconnect on an operator Gateway. The probe remapped the production 25-minute and 5-minute constants instead of waiting those wall-clock durations.

## Summary

Sibling: `openclaw.setup.auth.start` already uses `PROVIDER_AUTH_SESSION_TIMEOUT_MS = 25 * 60 * 1000` in `src/gateway/server-methods/system-agent.ts`.
Hosted wizard constructors were added in [`e3c5821d982b`](https://github.com/openclaw/openclaw/commit/e3c5821d982b) (2026-07-13, Peter Steinberger) via [#106469](https://github.com/openclaw/openclaw/pull/106469). Admission wrapping landed in [#121415](https://github.com/openclaw/openclaw/pull/121415).
No CHANGELOG (repo auto-generates).
