### PR TITLE
docs: identify v2026.8.1 release notes link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ﻿# Changelog
 
 Docs: https://docs.openclaw.ai
-Latest release notes: https://docs.openclaw.ai/releases/2026.8.1
+2026.8.1 release notes: https://docs.openclaw.ai/releases/2026.8.1
 
 ## Unreleased
 


### PR DESCRIPTION
## What Problem This Solves

The changelog's top release-notes link is labeled generically even though it points specifically to the 2026.8.1 release notes.

## Why This Change Was Made

Changes the top-level label from `Latest release notes` to `2026.8.1 release notes`.

## User Impact

Readers can immediately see which changelog release the linked notes describe.

## Evidence

- `git diff --check` passes.
- The release-notes URL returns HTTP 200.
- The diff changes one Markdown label.

AI-assisted: yes.
