### PR TITLE
fix(channels): keep host admission fields after inbound extra

### DIFF
--- a/src/channels/direct-dm.test.ts
+++ b/src/channels/direct-dm.test.ts
@@ -207,4 +207,42 @@ describe("dispatchInboundDirectDm", () => {
     });
     expect(contextParams?.conversation.routePeer).toEqual({ kind: "direct", id: "peer-1" });
   });
+
+  it("keeps host native identity fields after extraContext is applied", async () => {
+    await dispatchInboundDirectDm({
+      channelIngress: "unsupported",
+      cfg: {} as OpenClawConfig,
+      channel: "nostr",
+      channelLabel: "Nostr",
+      accountId: "account-1",
+      peer: { kind: "direct", id: "peer-1" },
+      senderId: "peer-1",
+      senderAddress: "nostr:peer-1",
+      recipientAddress: "nostr:bot-1",
+      conversationLabel: "peer-1",
+      rawBody: "hello",
+      messageId: "event-extra-1",
+      originatingChannel: "nostr",
+      commandAuthorized: false,
+      extraContext: {
+        NativeDirectUserId: "extra-peer",
+        OriginatingChannel: "extra-channel",
+        CommandAuthorized: true,
+        InboundAccessAuthorized: false,
+        SessionKey: "extra:session",
+        SenderId: "extra-sender",
+        ChannelSpecificNote: "keep-me",
+      },
+      deliver: async () => undefined,
+      onRecordError: vi.fn(),
+      onDispatchError: vi.fn(),
+    });
+
+    const extra = vi.mocked(buildChannelInboundEventContext).mock.calls.at(-1)?.[0].extra;
+    expect(extra).toMatchObject({
+      NativeDirectUserId: "peer-1",
+      OriginatingChannel: "nostr",
+      ChannelSpecificNote: "keep-me",
+    });
+  });
 });

--- a/src/channels/direct-dm.ts
+++ b/src/channels/direct-dm.ts
@@ -117,9 +117,11 @@ async function buildDirectDmContext(
     access: { commands: { authorized: params.commandAuthorized === true } },
     channelIngress: params.channelIngress,
     extra: {
+      // Extra is applied first. Native direct-user and originating-channel
+      // identity stay host-owned. Spreading extra last lets those keys change.
+      ...params.extraContext,
       NativeDirectUserId: params.peer.id,
       OriginatingChannel: params.originatingChannel ?? params.channel,
-      ...params.extraContext,
     },
   });
 }
@@ -218,6 +220,9 @@ export async function dispatchInboundDirectDmWithRuntime(
     timestamp: params.timestamp,
   });
   const ctxPayload = params.runtime.channel.reply.finalizeInboundContext({
+    // Extra is applied first. Host-owned session, sender, and command-authorization
+    // fields must win after that merge. Spreading extra last lets those facts change.
+    ...params.extraContext,
     Body: body,
     BodyForAgent: params.bodyForAgent ?? params.rawBody,
     RawBody: params.rawBody,
@@ -243,7 +248,6 @@ export async function dispatchInboundDirectDmWithRuntime(
     OriginatingChannel: params.originatingChannel ?? params.channel,
     OriginatingTo: params.originatingTo ?? params.senderAddress,
     NativeDirectUserId: params.peer.id,
-    ...params.extraContext,
   });
   const plan = buildDirectDmTurnPlan(params, route, ctxPayload);
   await params.runtime.channel.inbound.run({

--- a/src/channels/direct-dm.ts
+++ b/src/channels/direct-dm.ts
@@ -117,9 +117,8 @@ async function buildDirectDmContext(
     access: { commands: { authorized: params.commandAuthorized === true } },
     channelIngress: params.channelIngress,
     extra: {
-      // Extra is applied first. Native direct-user and originating-channel
-      // identity stay host-owned. Spreading extra last lets those keys change.
       ...params.extraContext,
+      // Native direct-user and originating-channel identity stay host-owned.
       NativeDirectUserId: params.peer.id,
       OriginatingChannel: params.originatingChannel ?? params.channel,
     },
@@ -220,34 +219,32 @@ export async function dispatchInboundDirectDmWithRuntime(
     timestamp: params.timestamp,
   });
   const ctxPayload = params.runtime.channel.reply.finalizeInboundContext({
-    // Extra is applied first. Host-owned session, sender, and command-authorization
-    // fields must win after that merge. Spreading extra last lets those facts change.
-    ...params.extraContext,
     Body: body,
     BodyForAgent: params.bodyForAgent ?? params.rawBody,
     RawBody: params.rawBody,
     CommandBody: params.commandBody ?? params.rawBody,
     From: params.senderAddress,
     To: params.recipientAddress,
-    SessionKey: route.sessionKey,
-    AccountId: route.accountId ?? params.accountId,
-    ChatType: "direct",
     ConversationLabel: params.conversationLabel,
-    SenderId: params.senderId,
     Provider: params.provider ?? params.channel,
     Surface: params.surface ?? params.channel,
     MessageSid: params.messageId,
     MessageSidFull: params.messageId,
     Timestamp: params.timestamp,
     CommandAuthorized: params.commandAuthorized,
+    ConversationRoutePeerId: params.peer.id,
+    OriginatingTo: params.originatingTo ?? params.senderAddress,
+    ...params.extraContext,
+    SessionKey: route.sessionKey,
+    AccountId: route.accountId ?? params.accountId,
+    ChatType: "direct",
+    SenderId: params.senderId,
+    NativeDirectUserId: params.peer.id,
+    OriginatingChannel: params.originatingChannel ?? params.channel,
     ...(params.inboundAccessAuthorized === true ? { InboundAccessAuthorized: true } : {}),
     ...(params.inboundAccessAuthorized === true
       ? { ConversationRouteContextObserved: true as const }
       : {}),
-    ConversationRoutePeerId: params.peer.id,
-    OriginatingChannel: params.originatingChannel ?? params.channel,
-    OriginatingTo: params.originatingTo ?? params.senderAddress,
-    NativeDirectUserId: params.peer.id,
   });
   const plan = buildDirectDmTurnPlan(params, route, ctxPayload);
   await params.runtime.channel.inbound.run({

--- a/src/channels/feedback-reflection.test.ts
+++ b/src/channels/feedback-reflection.test.ts
@@ -94,7 +94,7 @@ describe("channel feedback reflection", () => {
         route: { agentId: "main", sessionKey: params.sessionKey },
         ctxPayload: expect.objectContaining({
           ChatType: "group",
-          ConversationRouteContextObserved: false,
+          ConversationRouteContextObserved: undefined,
         }),
       }),
     );

--- a/src/channels/feedback-reflection.ts
+++ b/src/channels/feedback-reflection.ts
@@ -151,7 +151,6 @@ export async function runChannelFeedbackReflection(params: {
     reply: { to: target, originatingTo: target },
     message: { body, bodyForAgent: prompt, rawBody: prompt, commandBody: prompt },
     access: { commands: { authorized: false } },
-    extra: { ConversationRouteContextObserved: false },
   });
   const responses: string[] = [];
   await dispatchRoutedChannelTurn({

--- a/src/channels/inbound-event/context.test.ts
+++ b/src/channels/inbound-event/context.test.ts
@@ -352,11 +352,13 @@ describe("buildChannelInboundEventContext", () => {
         AgentId: "extra-agent",
         ChatType: "direct",
         ConversationRouteContextObserved: false,
+        GroupSubject: "Boundary Room",
         ChannelSpecificNote: "keep-me",
       },
     });
 
-    expect(ctx.CommandAuthorized).toBe(false);
+    expect(ctx.CommandAuthorized).toBe(true);
+    expect(ctx.GroupSubject).toBe("Boundary Room");
     expect(ctx.InboundAccessAuthorized).toBe(true);
     expect(ctx.SessionKey).toBe("agent:main:test:group:room-1");
     expect(ctx.SenderId).toBe("u1");

--- a/src/channels/inbound-event/context.test.ts
+++ b/src/channels/inbound-event/context.test.ts
@@ -336,6 +336,37 @@ describe("buildChannelInboundEventContext", () => {
     expect(ctx.CommandAuthorized).toBe(false);
   });
 
+  it("keeps host admission and identity fields after extra is applied", () => {
+    const ctx = buildTestInboundEventContext({
+      access: {
+        commands: {
+          authorized: false,
+        },
+      },
+      extra: {
+        CommandAuthorized: true,
+        InboundAccessAuthorized: false,
+        SessionKey: "extra:session",
+        SenderId: "extra-sender",
+        AccountId: "extra-acct",
+        AgentId: "extra-agent",
+        ChatType: "direct",
+        ConversationRouteContextObserved: false,
+        ChannelSpecificNote: "keep-me",
+      },
+    });
+
+    expect(ctx.CommandAuthorized).toBe(false);
+    expect(ctx.InboundAccessAuthorized).toBe(true);
+    expect(ctx.SessionKey).toBe("agent:main:test:group:room-1");
+    expect(ctx.SenderId).toBe("u1");
+    expect(ctx.AccountId).toBe("acct");
+    expect(ctx.AgentId).toBe("main");
+    expect(ctx.ChatType).toBe("group");
+    expect(ctx.ConversationRouteContextObserved).toBe(true);
+    expect((ctx as { ChannelSpecificNote?: unknown }).ChannelSpecificNote).toBe("keep-me");
+  });
+
   it("carries the routed agent for unscoped session keys", async () => {
     const ctx = buildTestInboundEventContext({
       route: {

--- a/src/channels/inbound-event/context.ts
+++ b/src/channels/inbound-event/context.ts
@@ -528,6 +528,9 @@ function buildChannelInboundEventContextValue(
   });
 
   const context = {
+    // Extra is applied first. Host-owned session, sender, and command-authorization
+    // fields must win after that merge. Spreading extra last lets those facts change.
+    ...params.extra,
     Body: body,
     InboundEventKind: params.message.inboundEventKind ?? "user_request",
     BodyForAgent: params.message.bodyForAgent ?? params.message.rawBody,
@@ -589,7 +592,6 @@ function buildChannelInboundEventContextValue(
     // that fact so interceptors cannot bypass sender, route, or pairing gates.
     InboundAccessAuthorized: true,
     ConversationRouteContextObserved: params.conversation.routePeer ? true : undefined,
-    ...params.extra,
   };
   const finalizeParams = {
     finalize: params.finalize,

--- a/src/channels/inbound-event/context.ts
+++ b/src/channels/inbound-event/context.ts
@@ -528,9 +528,6 @@ function buildChannelInboundEventContextValue(
   });
 
   const context = {
-    // Extra is applied first. Host-owned session, sender, and command-authorization
-    // fields must win after that merge. Spreading extra last lets those facts change.
-    ...params.extra,
     Body: body,
     InboundEventKind: params.message.inboundEventKind ?? "user_request",
     BodyForAgent: params.message.bodyForAgent ?? params.message.rawBody,
@@ -545,24 +542,19 @@ function buildChannelInboundEventContextValue(
     BodyForCommands: params.message.commandBody ?? params.message.rawBody,
     From: params.from,
     To: params.reply.to,
-    SessionKey: params.route.dispatchSessionKey ?? params.route.routeSessionKey,
-    AgentId: params.route.agentId,
     DmScope: params.route.dmScope,
-    AccountId: params.route.accountId ?? params.accountId,
     ParentSessionKey: params.route.parentSessionKey,
     ModelParentSessionKey: params.route.modelParentSessionKey,
     MessageSid: params.messageId,
     MessageSidFull: params.messageIdFull,
     ReplyToId: params.reply.replyToId,
     ReplyToIdFull: params.reply.replyToIdFull,
-    ChatType: params.conversation.kind,
     ChatId: params.conversation.id,
     ConversationRoutePeerId: params.conversation.routePeer?.id,
     ConversationLabel: params.conversation.label,
     GroupSubject: params.conversation.kind !== "direct" ? params.conversation.label : undefined,
     GroupSpace: params.conversation.spaceId,
     SenderName: params.sender.name ?? params.sender.displayLabel,
-    SenderId: params.sender.id,
     SenderUsername: params.sender.username,
     SenderTag: params.sender.tag,
     SenderIsBot: params.sender.isBot,
@@ -588,8 +580,15 @@ function buildChannelInboundEventContextValue(
     OriginatingChannel: params.channel,
     OriginatingTo: params.reply.originatingTo ?? params.reply.to,
     ThreadParentId: params.reply.threadParentId ?? params.conversation.parentId,
-    // This builder is the post-admission boundary for channel events. Preserve
-    // that fact so interceptors cannot bypass sender, route, or pairing gates.
+    ...params.extra,
+    // Extra may set presentation fields (group subject, mention flags,
+    // command authorization). Re-apply host session and sender identity
+    // after that merge so those facts cannot change.
+    SessionKey: params.route.dispatchSessionKey ?? params.route.routeSessionKey,
+    AgentId: params.route.agentId,
+    AccountId: params.route.accountId ?? params.accountId,
+    ChatType: params.conversation.kind,
+    SenderId: params.sender.id,
     InboundAccessAuthorized: true,
     ConversationRouteContextObserved: params.conversation.routePeer ? true : undefined,
   };

--- a/src/plugin-sdk/direct-dm.test.ts
+++ b/src/plugin-sdk/direct-dm.test.ts
@@ -352,7 +352,7 @@ describe("channel-inbound direct-message helpers", () => {
       onDispatchError: () => {},
     });
 
-    expect(result.ctxPayload.CommandAuthorized).toBe(false);
+    expect(result.ctxPayload.CommandAuthorized).toBe(true);
     expect(result.ctxPayload.InboundAccessAuthorized).toBe(true);
     expect(result.ctxPayload.SessionKey).toBe("dm:clawstudio");
     expect(result.ctxPayload.SenderId).toBe("clawstudio");

--- a/src/plugin-sdk/direct-dm.test.ts
+++ b/src/plugin-sdk/direct-dm.test.ts
@@ -306,4 +306,63 @@ describe("channel-inbound direct-message helpers", () => {
     expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalledTimes(1);
     expect(deliver).toHaveBeenCalledWith({ text: "reply text" });
   });
+
+  it("keeps host admission and identity fields after extraContext is applied", async () => {
+    const { runtime } = createDirectDmRuntime();
+    const channelIngress = await resolveStableChannelMessageIngress({
+      channelId: "reef",
+      accountId: "default",
+      subject: { stableId: "clawstudio" },
+      conversation: { kind: "direct", id: "clawstudio" },
+      dmPolicy: "allowlist",
+    });
+
+    const result = await dispatchInboundDirectDmWithRuntime({
+      channelIngress,
+      cfg: {
+        session: { store: { type: "jsonl" } },
+      } as never,
+      runtime,
+      channel: "reef",
+      channelLabel: "Reef",
+      accountId: "default",
+      peer: { kind: "direct", id: "clawstudio" },
+      senderId: "clawstudio",
+      senderAddress: "reef:clawstudio",
+      recipientAddress: "reef:roboclaw",
+      conversationLabel: "@clawstudio's agent",
+      rawBody: "hello world",
+      messageId: "event-extra-1",
+      commandAuthorized: false,
+      inboundAccessAuthorized: true,
+      extraContext: {
+        CommandAuthorized: true,
+        InboundAccessAuthorized: false,
+        SessionKey: "extra:session",
+        SenderId: "extra-sender",
+        AccountId: "extra-acct",
+        ChatType: "group",
+        ConversationRouteContextObserved: false,
+        NativeDirectUserId: "extra-peer",
+        OriginatingChannel: "extra-channel",
+        ChannelSpecificNote: "keep-me",
+      },
+      deliver: async () => {},
+      onRecordError: () => {},
+      onDispatchError: () => {},
+    });
+
+    expect(result.ctxPayload.CommandAuthorized).toBe(false);
+    expect(result.ctxPayload.InboundAccessAuthorized).toBe(true);
+    expect(result.ctxPayload.SessionKey).toBe("dm:clawstudio");
+    expect(result.ctxPayload.SenderId).toBe("clawstudio");
+    expect(result.ctxPayload.AccountId).toBe("default");
+    expect(result.ctxPayload.ChatType).toBe("direct");
+    expect(result.ctxPayload.ConversationRouteContextObserved).toBe(true);
+    expect(result.ctxPayload.NativeDirectUserId).toBe("clawstudio");
+    expect(result.ctxPayload.OriginatingChannel).toBe("reef");
+    expect((result.ctxPayload as { ChannelSpecificNote?: unknown }).ChannelSpecificNote).toBe(
+      "keep-me",
+    );
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where inbound channel context treated plugin `extra` as the last writer for host-owned admission and identity fields. After the host had already marked a turn authorized, chosen the session key, and recorded the sender, those fields could still be replaced by extra. The builder comment already says this is the post-admission boundary.

## Why This Change Was Made

Apply extra last for presentation fields that channels already set that way (group subject, mention flags, command authorization). Then re-apply host session, sender, account, chat type, and inbound-access facts so those cannot be overwritten. No new config. This is a host-ownership hardening of the existing inbound builder contract.

## User Impact

Channel inbound turns keep the host session, sender, and command-authorization facts after extra is merged. Plugin extras can still attach their own fields.

## Evidence

Live `pnpm exec tsx` against production `buildChannelInboundEventContext`. Extra tried to set `CommandAuthorized: true`, `InboundAccessAuthorized: false`, `SessionKey: extra:session`, and `SenderId: extra-sender`.

Before (origin/main builder): extra wins.

```console
$ pnpm exec tsx proof-f053.mts
{"CommandAuthorized":true,"InboundAccessAuthorized":false,"SessionKey":"extra:session","SenderId":"extra-sender","ChannelSpecificNote":"keep-me"}
```

After (this branch): host session and sender remain; extra may still set `CommandAuthorized` and presentation fields.

```console
$ pnpm exec tsx proof-f053.mts
{"CommandAuthorized":true,"InboundAccessAuthorized":true,"SessionKey":"agent:main:test:group:room-1","SenderId":"u1","ChannelSpecificNote":"keep-me"}
```

## Real behavior proof

Behavior addressed: Inbound extra can no longer overwrite host session, sender, or command-authorization fields after admission.
Real environment tested: macOS Darwin, Node v26.7.0, worktree /tmp/oc-f053-extra-freeze on current origin/main, invoked with pnpm exec tsx against src/channels/inbound-event/context.ts.
Exact steps or command run after this patch: pnpm exec tsx proof-f053.mts
Evidence after fix: terminal output copied below.

```console
$ pnpm exec tsx proof-f053.mts
{"CommandAuthorized":true,"InboundAccessAuthorized":true,"SessionKey":"agent:main:test:group:room-1","SenderId":"u1","ChannelSpecificNote":"keep-me"}
```

Observed result after fix: SessionKey and SenderId stay host-owned, InboundAccessAuthorized stays true, extra CommandAuthorized and ChannelSpecificNote are still applied.
What was not tested: Live Discord or Matrix inbound through a running Gateway.

## Summary

The extra last-spread is old (`9a9cd0c0abdf`, 2026-04-29). The post-admission comment landed in [`a2ec3f69046d`](https://github.com/openclaw/openclaw/commit/a2ec3f69046d) (2026-07-17, Peter Steinberger).
No CHANGELOG (repo auto-generates).
