### PR TITLE
test(plugins): advance lifecycle lease contention virtually

### DIFF
--- a/src/plugins/plugin-lifecycle-lease.test.ts
+++ b/src/plugins/plugin-lifecycle-lease.test.ts
@@ -113,8 +113,8 @@ describe("plugin lifecycle lease", () => {
     ["an explicit database path across different state directories", true],
   ])("serializes lifecycle work sharing %s", async (_label, explicitPath) => {
     await withOpenClawTestState({ label: "plugin-lifecycle-lease" }, async (state) => {
-      const firstEntered = createDeferred<void>();
-      const releaseFirst = createDeferred<void>();
+      const firstEntered = createDeferred();
+      const releaseFirst = createDeferred();
       const events: string[] = [];
       const leaseOptions = (caller: string) => ({
         env: explicitPath ? { ...state.env, OPENCLAW_STATE_DIR: state.path(caller) } : state.env,

--- a/src/plugins/plugin-lifecycle-lease.test.ts
+++ b/src/plugins/plugin-lifecycle-lease.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import type { Readable } from "node:stream";
 import { pathToFileURL } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { readPersistedInstalledPluginIndex } from "./installed-plugin-index-store.js";
@@ -35,14 +35,6 @@ async function withLeaseChildren<T>(fn: (children: Set<LeaseChild>) => Promise<T
   } finally {
     await Promise.all(Array.from(children, terminateLeaseChild));
   }
-}
-
-function deferred(): { promise: Promise<void>; resolve: () => void } {
-  let resolve!: () => void;
-  const promise = new Promise<void>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
 }
 
 function runLeaseChild(
@@ -115,78 +107,46 @@ function runLeaseChild(
 }
 
 describe("plugin lifecycle lease", () => {
-  it("serializes lifecycle work sharing one state directory", async () => {
+  it.each([
+    ["one state directory", false],
+    ["an explicit database path across different state directories", true],
+  ])("serializes lifecycle work sharing %s", async (_label, explicitPath) => {
     await withOpenClawTestState({ label: "plugin-lifecycle-lease" }, async (state) => {
-      const firstEntered = deferred();
-      const releaseFirst = deferred();
+      const firstEntered = Promise.withResolvers<void>();
+      const releaseFirst = Promise.withResolvers<void>();
       const events: string[] = [];
+      const leaseOptions = (caller: string) => ({
+        env: explicitPath ? { ...state.env, OPENCLAW_STATE_DIR: state.path(caller) } : state.env,
+        ...(explicitPath ? { path: state.path("shared-plugin-lifecycle.sqlite") } : {}),
+        leaseMs: 1_000,
+        waitMs: 3_000,
+      });
 
-      const first = withPluginLifecycleLease(
-        { env: state.env, leaseMs: 1_000, waitMs: 3_000 },
-        async () => {
+      vi.useFakeTimers();
+      try {
+        const first = withPluginLifecycleLease(leaseOptions("state-a"), async () => {
           events.push("first-enter");
           firstEntered.resolve();
           await releaseFirst.promise;
           events.push("first-exit");
-        },
-      );
-      await firstEntered.promise;
-
-      const second = withPluginLifecycleLease(
-        { env: state.env, leaseMs: 1_000, waitMs: 3_000 },
-        async () => {
+        });
+        await firstEntered.promise;
+        const second = withPluginLifecycleLease(leaseOptions("state-b"), async () => {
           events.push("second-enter");
-        },
-      );
-      await new Promise((resolve) => {
-        setTimeout(resolve, 100);
-      });
-      expect(events).toEqual(["first-enter"]);
-
-      releaseFirst.resolve();
-      await Promise.all([first, second]);
-      expect(events).toEqual(["first-enter", "first-exit", "second-enter"]);
-    });
-  });
-
-  it("uses an explicit shared database path instead of each caller's default state", async () => {
-    await withOpenClawTestState({ label: "plugin-lifecycle-explicit-path" }, async (state) => {
-      const databasePath = state.path("shared-plugin-lifecycle.sqlite");
-      const firstEntered = deferred();
-      const releaseFirst = deferred();
-      const events: string[] = [];
-      const first = withPluginLifecycleLease(
-        {
-          env: { ...state.env, OPENCLAW_STATE_DIR: state.path("state-a") },
-          path: databasePath,
-          leaseMs: 1_000,
-          waitMs: 3_000,
-        },
-        async () => {
-          events.push("first-enter");
-          firstEntered.resolve();
-          await releaseFirst.promise;
-        },
-      );
-      await firstEntered.promise;
-      const second = withPluginLifecycleLease(
-        {
-          env: { ...state.env, OPENCLAW_STATE_DIR: state.path("state-b") },
-          path: databasePath,
-          leaseMs: 1_000,
-          waitMs: 3_000,
-        },
-        async () => {
-          events.push("second-enter");
-        },
-      );
-      await new Promise((resolve) => {
-        setTimeout(resolve, 100);
-      });
-      expect(events).toEqual(["first-enter"]);
-      releaseFirst.resolve();
-      await Promise.all([first, second]);
-      expect(events).toEqual(["first-enter", "second-enter"]);
+        });
+        try {
+          await vi.advanceTimersByTimeAsync(100);
+          expect(events).toEqual(["first-enter"]);
+        } finally {
+          releaseFirst.resolve();
+          // Drive the pending acquisition retry after the first owner releases.
+          await vi.advanceTimersByTimeAsync(250);
+          await Promise.all([first, second]);
+        }
+        expect(events).toEqual(["first-enter", "first-exit", "second-enter"]);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/src/plugins/plugin-lifecycle-lease.test.ts
+++ b/src/plugins/plugin-lifecycle-lease.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { Readable } from "node:stream";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { readPersistedInstalledPluginIndex } from "./installed-plugin-index-store.js";
@@ -112,8 +113,8 @@ describe("plugin lifecycle lease", () => {
     ["an explicit database path across different state directories", true],
   ])("serializes lifecycle work sharing %s", async (_label, explicitPath) => {
     await withOpenClawTestState({ label: "plugin-lifecycle-lease" }, async (state) => {
-      const firstEntered = Promise.withResolvers<void>();
-      const releaseFirst = Promise.withResolvers<void>();
+      const firstEntered = createDeferred<void>();
+      const releaseFirst = createDeferred<void>();
       const events: string[] = [];
       const leaseOptions = (caller: string) => ({
         env: explicitPath ? { ...state.env, OPENCLAW_STATE_DIR: state.path(caller) } : state.env,


### PR DESCRIPTION
## What Problem This Solves

Two plugin lifecycle lease tests repeat nearly identical fixtures and spend real time holding a lease and waiting for the contender's acquisition retry.

## Why This Change Was Made

Use one table for a shared state directory and an explicit shared database across different state directories. Advance the clock while the first operation stays gated, assert the contender is excluded, then release the owner and advance the bounded acquisition retry. Cleanup releases and drains both operations even if the exclusion assertion fails.

## User Impact

Faster tests with the same real SQLite lease owner. Subprocess serialization, cross-process install-record refresh, nested reuse, process-exit cleanup and exact ownership-loss tests remain intact.

## Evidence

- `node scripts/run-vitest.mjs src/plugins/plugin-lifecycle-lease.test.ts src/state/openclaw-state-lease.test.ts` — all eight tests pass.
- The two changed cases took 266/213 ms before and 123/72 ms after locally. Full plugin file: 3884 to 3555 ms; subprocess work remains dominant.
- Formatting, diff check, and fresh structured Codex autoreview pass. The first full check caught an ES library typing mismatch for direct Promise.withResolvers; the suite now uses the existing shared deferred helper and its focused rerun passes. All other changed-check gates passed; the final lint finding was the redundant default type argument on that helper, now removed and verified by rerunning the exact core lint gate.
- Production +0/-0; tests +34/-73 (net -39).
- Read lifecycle owner, shared SQLite lease implementation, both suites and the earlier process-handshake repair. No storage/schema or production behavior changes.
