### PR TITLE
fix(cron): preserve valid jobs during SQLite migration

### DIFF
--- a/src/commands/doctor/cron/index.test.ts
+++ b/src/commands/doctor/cron/index.test.ts
@@ -695,6 +695,50 @@ describe("maybeRepairLegacyCronStore", () => {
     expectNoteContaining("1 row was removed from the active cron store", "Cron");
   });
 
+  it("recovers a valid quarantined schedule only after Doctor confirmation", async () => {
+    const storePath = await makeTempStorePath();
+    vi.stubEnv("OPENCLAW_STATE_DIR", path.dirname(path.dirname(storePath)));
+    await writeCurrentCronStore(storePath, []);
+    saveCronQuarantinedJobs({
+      storePath,
+      nowMs: Date.parse("2026-08-30T18:50:02.000Z"),
+      entries: [
+        {
+          sourceIndex: 0,
+          reason: "invalid-schedule",
+          job: createCurrentCronJob({
+            id: "variant-cron",
+            schedule: { kind: " CRON ", expr: "0 9 * * *", tz: "UTC" },
+          }),
+          state: { nextRunAtMs: 123 },
+          updatedAtMs: 456,
+        },
+      ],
+    });
+    const cfg = createCronConfig(storePath);
+    const decline = makePrompter(false);
+
+    await maybeRepairLegacyCronStore({ cfg, options: {}, prompter: decline });
+
+    expect((await loadCronStore(storePath)).jobs).toEqual([]);
+    expect(loadCronQuarantinedJobs(storePath)).toHaveLength(1);
+    expect(decline.confirm).toHaveBeenCalledOnce();
+
+    const confirm = makePrompter(true);
+    await maybeRepairLegacyCronStore({ cfg, options: { repair: true }, prompter: confirm });
+
+    const persisted = (await loadCronStore(storePath)).jobs;
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]).toMatchObject({
+      id: "variant-cron",
+      enabled: true,
+      schedule: { kind: "cron", expr: "0 9 * * *", tz: "UTC" },
+      state: { nextRunAtMs: 123 },
+    });
+    expect(loadCronQuarantinedJobs(storePath)).toEqual([]);
+    expectNoteContaining("Recovered 1 quarantined automation", "Doctor changes");
+  });
+
   it("imports and archives standalone legacy quarantine files without losing recovery fields", async () => {
     const storePath = await makeTempStorePath();
     await writeCurrentCronStore(storePath, []);
@@ -2288,6 +2332,51 @@ describe("maybeRepairLegacyCronStore", () => {
     const delivery = requireRecord(persisted[0]?.delivery, "cron delivery");
     expect(delivery.mode).toBe("announce");
     expect(delivery.to).toBe("telegram:123");
+  });
+
+  it("keeps valid schedule enum variants active after SQLite migration", async () => {
+    const storePath = await makeTempStorePath();
+    await writeCronStore(storePath, [
+      createLegacyCronJob({
+        id: "legacy-cron-kind",
+        jobId: undefined,
+        enabled: true,
+        schedule: { kind: " CRON ", cron: "0 7 * * *", tz: "UTC" },
+      }),
+      createLegacyCronJob({
+        id: "legacy-every-kind",
+        jobId: undefined,
+        enabled: true,
+        schedule: { kind: "Every", everyMs: 60_000 },
+      }),
+      createLegacyCronJob({
+        id: "legacy-stream-kind",
+        jobId: undefined,
+        enabled: true,
+        schedule: { kind: " Stream ", command: ["node", "events.mjs"], mode: " LINE " },
+      }),
+    ]);
+
+    await maybeRepairLegacyCronStore({
+      cfg: createCronConfig(storePath),
+      options: { repair: true },
+      prompter: makePrompter(true),
+    });
+
+    const jobs = await readPersistedJobs(storePath);
+    expect(
+      jobs.map((job) => ({
+        id: job.id,
+        enabled: job.enabled,
+        kind: requireRecord(job.schedule, "cron schedule").kind,
+        mode: requireRecord(job.schedule, "cron schedule").mode,
+      })),
+    ).toEqual([
+      { id: "legacy-cron-kind", enabled: true, kind: "cron", mode: undefined },
+      { id: "legacy-every-kind", enabled: true, kind: "every", mode: undefined },
+      { id: "legacy-stream-kind", enabled: true, kind: "stream", mode: "line" },
+    ]);
+    expect(loadCronQuarantinedJobs(storePath)).toEqual([]);
   });
 
   it("quarantines invalid legacy rows before saving the repaired store", async () => {

--- a/src/commands/doctor/cron/index.ts
+++ b/src/commands/doctor/cron/index.ts
@@ -384,8 +384,12 @@ export async function maybeRepairLegacyCronStore(params: {
     legacyQuarantine,
     legacyImportCount,
     invalidConfigRows,
+    persistedQuarantine,
     rawJobs,
   } = state;
+  const revalidatableQuarantineCount = persistedQuarantine.filter(
+    (entry) => entry.reason === "invalid-schedule" && entry.job,
+  ).length;
   const sqliteStorePath = resolveOpenClawStateSqlitePath();
   try {
     const quarantine = loadCronQuarantinedJobs(storePath);
@@ -415,7 +419,8 @@ export async function maybeRepairLegacyCronStore(params: {
       !legacyStoreDetected &&
       !legacyRunLogDetected &&
       !legacyQuarantine &&
-      invalidConfigRows.length === 0
+      invalidConfigRows.length === 0 &&
+      revalidatableQuarantineCount === 0
     ) {
       return;
     }
@@ -434,9 +439,18 @@ export async function maybeRepairLegacyCronStore(params: {
         `- ${pluralize(invalidConfigRows.length, "malformed cron row")} will be quarantined in SQLite`,
       );
     }
+    if (revalidatableQuarantineCount > 0) {
+      previewLines.push(
+        `- ${pluralize(revalidatableQuarantineCount, "quarantined automation")} will be revalidated and restored only if current validation passes`,
+      );
+    }
+    const noteHeading =
+      legacyStoreDetected || legacyRunLogDetected || legacyQuarantine
+        ? `Legacy cron storage detected at ${shortenHomePath(storePath)}.`
+        : `Cron store issues detected at ${shortenHomePath(sqliteStorePath)}.`;
     note(
       [
-        `Legacy cron storage detected at ${shortenHomePath(storePath)}.`,
+        noteHeading,
         ...previewLines,
         `Repair with ${formatCliCommand("openclaw doctor --fix")} to finish the migration.`,
       ].join("\n"),
@@ -449,7 +463,13 @@ export async function maybeRepairLegacyCronStore(params: {
     if (!shouldRepair) {
       return;
     }
-    noteLegacyCronRepairResult(await applyLegacyCronStoreRepair({ cfg: params.cfg, state }));
+    noteLegacyCronRepairResult(
+      await applyLegacyCronStoreRepair({
+        cfg: params.cfg,
+        state,
+        recoverQuarantinedScheduleJobs: true,
+      }),
+    );
     return;
   }
   noteCronModelOverrides({ cfg: params.cfg, jobs: rawJobs });
@@ -607,6 +627,11 @@ export async function maybeRepairLegacyCronStore(params: {
       `- ${pluralize(invalidConfigRows.length, "malformed cron row")} will be quarantined in SQLite`,
     );
   }
+  if (revalidatableQuarantineCount > 0) {
+    previewLines.push(
+      `- ${pluralize(revalidatableQuarantineCount, "quarantined automation")} will be revalidated and restored only if current validation passes`,
+    );
+  }
   if (notifyCount > 0) {
     previewLines.push(
       `- ${pluralize(notifyCount, "job")} still uses legacy \`notify: true\` webhook fallback`,
@@ -643,6 +668,11 @@ export async function maybeRepairLegacyCronStore(params: {
   }
 
   noteLegacyCronRepairResult(
-    await applyLegacyCronStoreRepair({ cfg: params.cfg, state, normalized }),
+    await applyLegacyCronStoreRepair({
+      cfg: params.cfg,
+      state,
+      normalized,
+      recoverQuarantinedScheduleJobs: true,
+    }),
   );
 }

--- a/src/commands/doctor/cron/legacy-repair.test.ts
+++ b/src/commands/doctor/cron/legacy-repair.test.ts
@@ -1,14 +1,20 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, expect, it } from "vitest";
+import { afterEach, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
-import { saveCronStore } from "../../../cron/store.js";
-import { loadLegacyCronRepairState } from "./legacy-repair.js";
+import {
+  loadCronQuarantinedJobs,
+  loadCronStore,
+  saveCronQuarantinedJobs,
+  saveCronStore,
+} from "../../../cron/store.js";
+import { loadLegacyCronRepairState, repairLegacyCronStoreWithoutPrompt } from "./legacy-repair.js";
 
 let tempRoot: string | undefined;
 
 afterEach(async () => {
+  vi.unstubAllEnvs();
   if (tempRoot) {
     await fs.rm(tempRoot, { recursive: true, force: true });
     tempRoot = undefined;
@@ -79,3 +85,39 @@ it.each<{
     expect(state?.projectedOwnersByJobId.get("dynamic-default")).toEqual(expectedOwner);
   },
 );
+
+it("does not reactivate quarantined automations during startup repair", async () => {
+  tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-cron-startup-quarantine-"));
+  const storePath = path.join(tempRoot, "cron", "jobs.json");
+  vi.stubEnv("OPENCLAW_STATE_DIR", tempRoot);
+  await saveCronStore(storePath, { version: 1, jobs: [] });
+  saveCronQuarantinedJobs({
+    storePath,
+    nowMs: 123,
+    entries: [
+      {
+        sourceIndex: 0,
+        reason: "invalid-schedule",
+        job: {
+          id: "variant-cron",
+          name: "Variant cron",
+          enabled: true,
+          createdAtMs: 1,
+          updatedAtMs: 1,
+          schedule: { kind: " CRON ", expr: "0 9 * * *" },
+          sessionTarget: "main",
+          wakeMode: "now",
+          payload: { kind: "systemEvent", text: "tick" },
+          state: {},
+        },
+      },
+    ],
+  });
+  const cfg = { cron: { store: storePath } } as OpenClawConfig;
+
+  const result = await repairLegacyCronStoreWithoutPrompt({ cfg });
+
+  expect(result).toEqual({ changes: [], warnings: [] });
+  expect((await loadCronStore(storePath)).jobs).toEqual([]);
+  expect(loadCronQuarantinedJobs(storePath)).toHaveLength(1);
+});

--- a/src/commands/doctor/cron/legacy-repair.ts
+++ b/src/commands/doctor/cron/legacy-repair.ts
@@ -1,11 +1,15 @@
 // Doctor cron storage repair mechanics for legacy stores, run logs, payloads, and Codex refs.
-import { normalizeOptionalString } from "../../../../packages/normalization-core/src/string-coerce.js";
+import {
+  normalizeOptionalString,
+  normalizeOptionalStringifiedId,
+} from "../../../../packages/normalization-core/src/string-coerce.js";
 import { tryResolveAmbientOwnerAgentId } from "../../../agents/agent-scope-config.js";
 import { formatCliCommand } from "../../../cli/command-format.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import {
   loadCronJobsStoreWithConfigJobs,
   loadCronJobsStoreWithConfigJobsReadOnly,
+  loadCronQuarantinedJobs,
   resolveCronJobsStorePath,
   saveCronJobsStore,
   saveCronJobsStoreWithMetadata,
@@ -52,6 +56,7 @@ import {
   collectStoredCronCodexRuntimePolicyTargets,
   cronCodexRuntimePolicyTargetKey,
   normalizeStoredCronJobs,
+  recoverValidQuarantinedCronScheduleJobs,
   type CronCodexRuntimePolicyTarget,
 } from "./store-migration.js";
 
@@ -69,6 +74,7 @@ export type LegacyCronRepairState = {
   legacyMigrationAlreadyImported: boolean;
   legacyImportCount: number;
   invalidConfigRows: QuarantinedCronConfigJob[];
+  persistedQuarantine: CronQuarantinedJob[];
   projectedOwnersByJobId: ReadonlyMap<string, CronOwnerProjection>;
   rawJobs: Array<Record<string, unknown>>;
 };
@@ -130,6 +136,13 @@ export async function loadLegacyCronRepairState(params: {
   ) {
     return null;
   }
+  let persistedQuarantine: CronQuarantinedJob[];
+  try {
+    persistedQuarantine = loadCronQuarantinedJobs(storePath, params.env);
+  } catch (err) {
+    rethrowSqliteSchemaVersionError(err);
+    persistedQuarantine = [];
+  }
 
   const loaded = params.readOnly
     ? await loadCronJobsStoreWithConfigJobsReadOnly(storePath, params.env)
@@ -180,6 +193,7 @@ export async function loadLegacyCronRepairState(params: {
     legacyMigrationAlreadyImported,
     legacyImportCount,
     invalidConfigRows,
+    persistedQuarantine,
     projectedOwnersByJobId,
     rawJobs,
   };
@@ -191,11 +205,30 @@ export async function applyLegacyCronStoreRepair(params: {
   normalized?: ReturnType<typeof normalizeStoredCronJobs>;
   migrateCodexModelRefs?: boolean;
   blockedModelIdentities?: ReadonlySet<LegacyCodexModelIdentity>;
+  recoverQuarantinedScheduleJobs?: boolean;
 }): Promise<LegacyCronRepairResult> {
   assertCronStateSchemaSupported();
   const { state } = params;
   const changes: string[] = [];
   const warnings: string[] = [];
+  const quarantineEntriesToRevalidate =
+    params.recoverQuarantinedScheduleJobs === true
+      ? [...state.persistedQuarantine, ...(state.legacyQuarantine?.jobs ?? [])]
+      : [];
+  const persistedQuarantineEntrySet = new Set<QuarantinedCronConfigJob | CronQuarantinedJob>(
+    state.persistedQuarantine,
+  );
+  const quarantineRecovery = recoverValidQuarantinedCronScheduleJobs(
+    quarantineEntriesToRevalidate,
+    new Set(
+      state.rawJobs
+        .map((job) => normalizeOptionalStringifiedId(job.id))
+        .filter((id): id is string => id !== undefined),
+    ),
+  );
+  if (quarantineRecovery.recoveredJobs.length > 0) {
+    state.rawJobs.push(...quarantineRecovery.recoveredJobs);
+  }
   const runtimePolicyPlan =
     params.migrateCodexModelRefs === true
       ? planCronCodexRefRewriteAgainstPersistedConfig({
@@ -209,12 +242,13 @@ export async function applyLegacyCronStoreRepair(params: {
     (runtimePolicyPlan?.blockedTargets ?? []).map(cronCodexRuntimePolicyTargetKey),
   );
   const normalized =
-    params.normalized ??
-    normalizeStoredCronJobs(state.rawJobs, {
-      migrateCodexModelRefs: params.migrateCodexModelRefs,
-      shouldMigrateCodexRuntimePolicyTarget: (target) =>
-        !blockedRuntimePolicyTargets.has(cronCodexRuntimePolicyTargetKey(target)),
-    });
+    params.normalized && quarantineRecovery.recoveredJobs.length === 0
+      ? params.normalized
+      : normalizeStoredCronJobs(state.rawJobs, {
+          migrateCodexModelRefs: params.migrateCodexModelRefs,
+          shouldMigrateCodexRuntimePolicyTarget: (target) =>
+            !blockedRuntimePolicyTargets.has(cronCodexRuntimePolicyTargetKey(target)),
+        });
   warnings.push(
     ...normalized.unsupportedLegacyTriggerScriptJobs.map(
       (job) =>
@@ -236,7 +270,8 @@ export async function applyLegacyCronStoreRepair(params: {
     state.invalidConfigRows.length > 0 ||
     normalized.mutated ||
     notifyMigration.changed ||
-    dreamingMigration.changed;
+    dreamingMigration.changed ||
+    quarantineRecovery.recoveredJobs.length > 0;
   const changed =
     state.legacyStoreDetected ||
     state.legacyRunLogDetected ||
@@ -247,7 +282,11 @@ export async function applyLegacyCronStoreRepair(params: {
   }
 
   const quarantineEntries: (QuarantinedCronConfigJob | CronQuarantinedJob)[] = [
-    ...(state.legacyQuarantine?.jobs ?? []),
+    ...(params.recoverQuarantinedScheduleJobs === true
+      ? quarantineRecovery.retainedEntries.filter(
+          (entry) => !persistedQuarantineEntrySet.has(entry),
+        )
+      : (state.legacyQuarantine?.jobs ?? [])),
     ...state.invalidConfigRows,
     ...normalized.removedJobs.map((entry) => ({
       sourceIndex: entry.sourceIndex,
@@ -257,6 +296,9 @@ export async function applyLegacyCronStoreRepair(params: {
   ];
   const quarantine =
     quarantineEntries.length > 0 ? { entries: quarantineEntries, nowMs: Date.now() } : undefined;
+  const deleteQuarantineEntries = quarantineRecovery.recoveredEntries.filter((entry) =>
+    persistedQuarantineEntrySet.has(entry),
+  );
 
   if (storeChanged || quarantine) {
     try {
@@ -273,9 +315,13 @@ export async function applyLegacyCronStoreRepair(params: {
             store,
             (db) => acquireLegacyCronMigrationReceipt(db, migrationSource),
             quarantine,
+            deleteQuarantineEntries,
           );
         } else {
-          await saveCronJobsStore(state.storePath, store, quarantine ? { quarantine } : undefined);
+          await saveCronJobsStore(state.storePath, store, {
+            ...(quarantine ? { quarantine } : {}),
+            ...(deleteQuarantineEntries.length > 0 ? { deleteQuarantineEntries } : {}),
+          });
         }
       } else if (quarantine) {
         saveCronQuarantinedJobs({ storePath: state.storePath, ...quarantine });
@@ -290,6 +336,12 @@ export async function applyLegacyCronStoreRepair(params: {
         ],
       };
     }
+  }
+
+  if (quarantineRecovery.recoveredJobs.length > 0) {
+    changes.push(
+      `Recovered ${pluralize(quarantineRecovery.recoveredJobs.length, "quarantined automation")} after current schedule validation passed.`,
+    );
   }
 
   if (state.legacyQuarantine) {

--- a/src/commands/doctor/cron/repair-plan.ts
+++ b/src/commands/doctor/cron/repair-plan.ts
@@ -124,6 +124,11 @@ export function formatLegacyIssuePreview(issues: CronLegacyIssueCounts): string[
   if (issues.legacyScheduleCron) {
     lines.push(`- ${pluralize(issues.legacyScheduleCron, "job")} still uses \`schedule.cron\``);
   }
+  if (issues.legacyScheduleKind) {
+    lines.push(
+      `- ${pluralize(issues.legacyScheduleKind, "job")} stores a non-canonical schedule \`kind\` or stream \`mode\` that will be normalized`,
+    );
+  }
   if (issues.legacyPayloadKind) {
     lines.push(`- ${pluralize(issues.legacyPayloadKind, "job")} needs payload kind normalization`);
   }

--- a/src/commands/doctor/cron/store-migration.schedule-kind.test.ts
+++ b/src/commands/doctor/cron/store-migration.schedule-kind.test.ts
@@ -1,0 +1,106 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it } from "vitest";
+import type { QuarantinedCronConfigJob } from "../../../cron/store/types.js";
+import {
+  normalizeStoredCronJobs,
+  recoverValidQuarantinedCronScheduleJobs,
+} from "./store-migration.js";
+
+function makeJob(id: string, schedule: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id,
+    name: id,
+    enabled: true,
+    createdAtMs: 1_700_000_000_000,
+    updatedAtMs: 1_700_000_000_000,
+    sessionTarget: "main",
+    wakeMode: "next-heartbeat",
+    schedule,
+    payload: { kind: "systemEvent", text: "tick" },
+    state: {},
+  };
+}
+
+describe("legacy cron schedule enum migration", () => {
+  it.each([
+    ["at", { kind: " At ", at: "2026-08-31T10:00:00.000Z" }],
+    ["every", { kind: "Every", everyMs: 120_000 }],
+    ["cron", { kind: " CRON ", cron: "17 * * * *", tz: "UTC" }],
+    ["on-exit", { kind: " On-Exit ", command: "cleanup" }],
+    ["stream", { kind: " Stream ", command: ["node", "events.mjs"], mode: " LINE " }],
+  ])("keeps and canonicalizes a recognized %s schedule", (canonicalKind, schedule) => {
+    const jobs = [makeJob(`job-${canonicalKind}`, schedule)];
+
+    const result = normalizeStoredCronJobs(jobs);
+    const job = expectDefined(jobs[0], "job test invariant");
+
+    expect(result.removedJobs).toEqual([]);
+    expect(result.issues.invalidSchedule).toBeUndefined();
+    expect((job.schedule as Record<string, unknown>).kind).toBe(canonicalKind);
+    if (canonicalKind === "stream") {
+      expect((job.schedule as Record<string, unknown>).mode).toBe("line");
+    }
+  });
+
+  it("preserves an unknown kind in quarantine diagnostics", () => {
+    const jobs = [makeJob("unknown", { kind: " DAILY ", at: "09:00" })];
+
+    const result = normalizeStoredCronJobs(jobs);
+    const removed = expectDefined(result.removedJobs[0], "removed job test invariant");
+
+    expect(jobs).toEqual([]);
+    expect(removed.reason).toBe("invalid-schedule");
+    expect((removed.job.schedule as Record<string, unknown>).kind).toBe(" DAILY ");
+  });
+
+  it("does not report an issue for an already canonical kind", () => {
+    const jobs = [makeJob("canonical", { kind: "cron", expr: "0 7 * * *" })];
+
+    const result = normalizeStoredCronJobs(jobs);
+
+    expect(result.issues.legacyScheduleKind).toBeUndefined();
+    expect(result.removedJobs).toEqual([]);
+  });
+
+  it("recovers only currently valid schedule rows and preserves recovery state", () => {
+    const entries: QuarantinedCronConfigJob[] = [
+      {
+        sourceIndex: 0,
+        reason: "invalid-schedule",
+        job: makeJob("variant", { kind: " CRON ", expr: "0 7 * * *" }),
+        state: { nextRunAtMs: 123 },
+        updatedAtMs: 456,
+      },
+      {
+        sourceIndex: 1,
+        reason: "invalid-schedule",
+        job: makeJob("canonical", { kind: "every", everyMs: 60_000, anchorMs: 1 }),
+      },
+      {
+        sourceIndex: 2,
+        reason: "invalid-schedule",
+        job: makeJob("unknown", { kind: "daily", at: "09:00" }),
+      },
+      {
+        sourceIndex: 3,
+        reason: "invalid-schedule",
+        job: makeJob("existing", { kind: "cron", expr: "0 8 * * *" }),
+      },
+      {
+        sourceIndex: 4,
+        reason: "missing-payload",
+        job: makeJob("other-reason", { kind: "cron", expr: "0 9 * * *" }),
+      },
+    ];
+
+    const result = recoverValidQuarantinedCronScheduleJobs(entries, new Set(["existing"]));
+
+    expect(result.recoveredJobs.map((job) => job.id)).toEqual(["variant", "canonical"]);
+    expect(result.recoveredJobs[0]).toMatchObject({
+      schedule: { kind: "cron" },
+      state: { nextRunAtMs: 123 },
+      updatedAtMs: 456,
+    });
+    expect(result.retainedEntries.map((entry) => entry.sourceIndex)).toEqual([2, 3, 4]);
+  });
+});

--- a/src/commands/doctor/cron/store-migration.ts
+++ b/src/commands/doctor/cron/store-migration.ts
@@ -13,6 +13,7 @@ import { getInvalidPersistedCronJobReason } from "../../../cron/persisted-shape.
 import { coerceFiniteScheduleNumber } from "../../../cron/schedule-number.js";
 import { inferCronJobName } from "../../../cron/service/normalize.js";
 import { normalizeCronStaggerMs, resolveDefaultCronStaggerMs } from "../../../cron/stagger.js";
+import type { CronQuarantinedJob, QuarantinedCronConfigJob } from "../../../cron/store/types.js";
 import {
   isBlockedLegacyCodexModelRef,
   type LegacyCodexModelIdentity,
@@ -44,6 +45,7 @@ type CronStoreIssueKey =
   | "nonStringId"
   | "legacyScheduleString"
   | "legacyScheduleCron"
+  | "legacyScheduleKind"
   | "legacyPayloadKind"
   | "legacyPayloadCodexModel"
   | "legacyImageInspectionToolName"
@@ -437,6 +439,27 @@ export function normalizeStoredCronJobs(
     if (schedule && typeof schedule === "object" && !Array.isArray(schedule)) {
       const sched = schedule as Record<string, unknown>;
       const kind = normalizeOptionalLowercaseString(sched.kind) ?? "";
+      const canonicalKind =
+        kind === "at" ||
+        kind === "every" ||
+        kind === "cron" ||
+        kind === "on-exit" ||
+        kind === "stream"
+          ? kind
+          : undefined;
+      if (canonicalKind && sched.kind !== canonicalKind) {
+        sched.kind = canonicalKind;
+        mutated = true;
+        trackIssue("legacyScheduleKind");
+      }
+      if (canonicalKind === "stream") {
+        const streamMode = normalizeOptionalLowercaseString(sched.mode);
+        if ((streamMode === "line" || streamMode === "match") && sched.mode !== streamMode) {
+          sched.mode = streamMode;
+          mutated = true;
+          trackIssue("legacyScheduleKind");
+        }
+      }
       if (!kind && ("at" in sched || "atMs" in sched)) {
         sched.kind = "at";
         mutated = true;
@@ -654,4 +677,57 @@ export function normalizeStoredCronJobs(
     mutated,
     removedJobs,
   };
+}
+
+export type QuarantinedCronJobRecovery = {
+  recoveredJobs: Array<Record<string, unknown>>;
+  recoveredEntries: Array<QuarantinedCronConfigJob | CronQuarantinedJob>;
+  retainedEntries: Array<QuarantinedCronConfigJob | CronQuarantinedJob>;
+};
+
+function restoredCronJobId(job: Record<string, unknown>): string | undefined {
+  return normalizeOptionalStringifiedId(job.id) ?? normalizeOptionalStringifiedId(job.jobId);
+}
+
+/** Revalidate quarantined schedule rows for an explicit Doctor repair. */
+export function recoverValidQuarantinedCronScheduleJobs(
+  entries: ReadonlyArray<QuarantinedCronConfigJob | CronQuarantinedJob>,
+  activeJobIds: ReadonlySet<string>,
+): QuarantinedCronJobRecovery {
+  const recoveredJobs: Array<Record<string, unknown>> = [];
+  const recoveredEntries: Array<QuarantinedCronConfigJob | CronQuarantinedJob> = [];
+  const retainedEntries: Array<QuarantinedCronConfigJob | CronQuarantinedJob> = [];
+  const recoveredJobIds = new Set<string>();
+
+  for (const entry of entries) {
+    if (entry.reason !== "invalid-schedule" || !isRecord(entry.job)) {
+      retainedEntries.push(entry);
+      continue;
+    }
+    const candidate = structuredClone(entry.job);
+    const jobId = restoredCronJobId(candidate);
+    if (jobId && (activeJobIds.has(jobId) || recoveredJobIds.has(jobId))) {
+      retainedEntries.push(entry);
+      continue;
+    }
+    if (isRecord(entry.state)) {
+      candidate.state = structuredClone(entry.state);
+    }
+    if (typeof entry.updatedAtMs === "number" && Number.isFinite(entry.updatedAtMs)) {
+      candidate.updatedAtMs = entry.updatedAtMs;
+    }
+
+    const normalized = normalizeStoredCronJobs([candidate]);
+    if (normalized.jobs.length !== 1 || normalized.removedJobs.length !== 0) {
+      retainedEntries.push(entry);
+      continue;
+    }
+    recoveredJobs.push(candidate);
+    recoveredEntries.push(entry);
+    if (jobId) {
+      recoveredJobIds.add(jobId);
+    }
+  }
+
+  return { recoveredJobs, recoveredEntries, retainedEntries };
 }

--- a/src/cron/store.test.ts
+++ b/src/cron/store.test.ts
@@ -451,6 +451,36 @@ describe("cron store", () => {
     }
   });
 
+  it("rolls back quarantine deletion when the restored cron row cannot commit", async () => {
+    const { storePath } = await makeStorePath();
+    const store = makeStore("atomic-recovery-job", true);
+    await saveCronStore(storePath, store);
+    const entry = {
+      sourceIndex: 0,
+      reason: "invalid-schedule" as const,
+      job: { id: "atomic-recovery-job" },
+    };
+    saveCronQuarantinedJobs({ storePath, nowMs: 123, entries: [entry] });
+    const database = openOpenClawStateDatabase().db;
+    database.exec(
+      "CREATE TEMP TRIGGER fail_cron_recovery_update BEFORE UPDATE ON cron_jobs BEGIN SELECT RAISE(ABORT, 'cron recovery rejected'); END",
+    );
+    try {
+      await expect(
+        saveCronJobsStore(storePath, store, { deleteQuarantineEntries: [entry] }),
+      ).rejects.toThrow("cron recovery rejected");
+      expect(loadCronQuarantinedJobs(storePath)).toEqual([{ ...entry, quarantinedAtMs: 123 }]);
+      expect((await loadCronStore(storePath)).jobs.map((job) => job.id)).toEqual([
+        "atomic-recovery-job",
+      ]);
+    } finally {
+      database.exec("DROP TRIGGER fail_cron_recovery_update");
+    }
+
+    await saveCronJobsStore(storePath, store, { deleteQuarantineEntries: [entry] });
+    expect(loadCronQuarantinedJobs(storePath)).toEqual([]);
+  });
+
   it("runs post-commit hooks only after the cron write commits", async () => {
     const { storePath } = await makeStorePath();
     const store = makeStore("post-commit-hook", true);

--- a/src/cron/store.ts
+++ b/src/cron/store.ts
@@ -13,7 +13,10 @@ import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths
 import { resolveConfigDir } from "../utils.js";
 import { readCronStoreStatePath } from "./store/config-state.js";
 import { cronStoreKey } from "./store/key.js";
-import { saveCronQuarantinedJobs } from "./store/quarantine.js";
+import {
+  deleteCronQuarantinedJobsFromDatabase,
+  saveCronQuarantinedJobs,
+} from "./store/quarantine.js";
 import {
   assertCronStoreCanPersist,
   deleteStaleCronJobFamilyRows,
@@ -242,6 +245,7 @@ type SaveCronJobsStoreOptions = SaveCronStoreOptions & {
     entries: readonly (QuarantinedCronConfigJob | CronQuarantinedJob)[];
     nowMs: number;
   };
+  deleteQuarantineEntries?: readonly (QuarantinedCronConfigJob | CronQuarantinedJob)[];
 };
 
 type SaveCronJobsStoreInternalOptions = SaveCronJobsStoreOptions & {
@@ -261,7 +265,10 @@ export async function saveCronJobsStore(
 ): Promise<void> {
   const resolvedStorePath = path.resolve(storePath);
   const storeKey = cronStoreKey(resolvedStorePath);
-  const stateOnly = opts?.stateOnly === true && !opts.quarantine?.entries.length;
+  const stateOnly =
+    opts?.stateOnly === true &&
+    !opts.quarantine?.entries.length &&
+    !opts.deleteQuarantineEntries?.length;
   if (!stateOnly) {
     assertCronStoreCanPersist(store);
   }
@@ -273,6 +280,13 @@ export async function saveCronJobsStore(
         entries: opts.quarantine.entries,
         nowMs: opts.quarantine.nowMs,
         database,
+      });
+    }
+    if (opts?.deleteQuarantineEntries?.length) {
+      deleteCronQuarantinedJobsFromDatabase({
+        database: database.db,
+        storePath: resolvedStorePath,
+        entries: opts.deleteQuarantineEntries,
       });
     }
     // Hot-path timer updates mutate runtime columns only; malformed-row
@@ -298,6 +312,7 @@ export async function saveCronJobsStoreWithMetadata(
   store: CronStoreFile,
   acquireMetadata: (db: DatabaseSync) => boolean,
   quarantine?: SaveCronJobsStoreOptions["quarantine"],
+  deleteQuarantineEntries?: SaveCronJobsStoreOptions["deleteQuarantineEntries"],
 ): Promise<boolean> {
   const resolvedStorePath = path.resolve(storePath);
   const storeKey = cronStoreKey(resolvedStorePath);
@@ -312,6 +327,13 @@ export async function saveCronJobsStoreWithMetadata(
         entries: quarantine.entries,
         nowMs: quarantine.nowMs,
         database,
+      });
+    }
+    if (deleteQuarantineEntries?.length) {
+      deleteCronQuarantinedJobsFromDatabase({
+        database: database.db,
+        storePath: resolvedStorePath,
+        entries: deleteQuarantineEntries,
       });
     }
     const normalizedJobs = replaceCronRows(database.db, storeKey, store);

--- a/src/cron/store/quarantine.ts
+++ b/src/cron/store/quarantine.ts
@@ -1,5 +1,6 @@
 /** Durable malformed-cron recovery records stored in the shared SQLite database. */
 import { createHash } from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import { createSqliteAuditRecordStore } from "../../infra/sqlite-audit-record-store.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../../state/openclaw-state-db-readonly.js";
@@ -25,6 +26,27 @@ function cronQuarantineEntryKey(entry: QuarantinedCronConfigJob): string {
     scheduleIdentity: entry.scheduleIdentity ?? null,
   });
   return createHash("sha256").update(identity).digest("hex");
+}
+
+/** Deletes quarantine rows inside the caller-owned SQLite transaction. */
+export function deleteCronQuarantinedJobsFromDatabase(params: {
+  database: DatabaseSync;
+  storePath: string;
+  entries: readonly (QuarantinedCronConfigJob | CronQuarantinedJob)[];
+}): void {
+  if (params.entries.length === 0) {
+    return;
+  }
+  const scope = cronQuarantineScope(params.storePath);
+  for (const entry of params.entries) {
+    executeSqliteQuerySync(
+      params.database,
+      getNodeSqliteKysely<CronQuarantineDatabase>(params.database)
+        .deleteFrom("diagnostic_events")
+        .where("scope", "=", scope)
+        .where("event_key", "=", cronQuarantineEntryKey(entry)),
+    );
+  }
 }
 
 /** Reads quarantined cron rows without creating or migrating a state database. */


### PR DESCRIPTION
Fixes #133347.

Supersedes #133394 and #133415. This consolidates the useful parts of both approaches and credits their authors below.

## What Problem This Solves

Fixes an issue where Doctor's SQLite cron migration could quarantine valid automations when a recognized schedule kind, or stream mode, used different casing or surrounding whitespace. Re-running Doctor could not recover jobs already affected by that migration.

## Why This Change Was Made

Doctor now canonicalizes recognized schedule enums before strict validation. During an explicit Doctor repair, it also revalidates `invalid-schedule` quarantine rows and restores only jobs that pass current validation. Unknown schedule kinds remain quarantined, ordinary startup never reactivates quarantined jobs, and restoration plus quarantine deletion commit in one SQLite transaction.

## User Impact

Upgrades preserve valid cron, interval, exit, and stream automations across SQLite migration. Users already affected can run `openclaw doctor --fix`; valid jobs return with their enabled state and runtime state intact, while genuinely invalid jobs remain quarantined for review.

## Evidence

- Red reproduction on canonical base: recognized `cron`, `every`, and `stream` variants were removed alongside an unknown-kind control.
- Green source-blind upgrade proof: ordinary startup restored nothing; explicit Doctor restored exactly the three valid jobs in canonical form; the unknown control remained quarantined; a repeated repair restored nothing.
- Focused regression suite: 146 tests passed across Doctor migration, recovery, startup authority, and SQLite atomicity.
- Strict smoke builds passed on both canonical base and proposed code.
- Autoreview: scoped clean at blocking priority.

Thanks to @LiuwqGit for the normalization and recovery groundwork in #133394, and @zhangguiping-xydt for identifying the canonical normalization boundary in #133415.
