### PR TITLE
test(gateway): exercise authorized exec suppression

### DIFF
--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -215,6 +215,8 @@ const sendDurableMessageBatchMock = runtimeMocks.sendDurableMessageBatch;
 
 beforeEach(() => {
   resetGatewayWorkAdmission();
+  enqueueSystemEventMock.mockReset().mockReturnValue(true);
+  requestHeartbeatMock.mockClear();
 });
 
 afterEach(() => {
@@ -301,17 +303,13 @@ function buildExecCtx() {
   return buildCtx({ authorizeNodeSystemRunEvent: () => true });
 }
 
-function makeNodeClient(connId: string, nodeId: string, sent: string[] = []): GatewayWsClient {
+function makeNodeClient(connId: string, nodeId: string): GatewayWsClient {
   return {
     connId,
     usesSharedGatewayAuth: false,
     socket: {
       readyState: WebSocket.OPEN,
-      send(frame: unknown) {
-        if (typeof frame === "string") {
-          sent.push(frame);
-        }
-      },
+      send: () => {},
     } as unknown as GatewayWsClient["socket"],
     connect: {
       minProtocol: PROTOCOL_VERSION,
@@ -374,9 +372,6 @@ function presenceConnection(deviceId: string, generation = `${deviceId}-generati
 
 describe("node exec events", () => {
   beforeEach(() => {
-    enqueueSystemEventMock.mockClear();
-    enqueueSystemEventMock.mockReturnValue(true);
-    requestHeartbeatMock.mockClear();
     registerApnsRegistrationVi.mockClear();
     loadOrCreateProcessDeviceIdentityMock.mockClear();
     normalizeChannelIdVi.mockClear();
@@ -435,90 +430,104 @@ describe("node exec events", () => {
     expect(requestHeartbeatMock).not.toHaveBeenCalled();
   });
 
-  it("keeps a node run authorized from exec.started through exec.finished", async () => {
-    const registry = new NodeRegistry();
-    const frames: string[] = [];
-    registry.register(makeNodeClient("conn-1", "node-1", frames), {
-      pairingIdentity: "identity-a",
-    });
-    const invoke = registry.invoke({
-      nodeId: "node-1",
-      command: "system.run",
-      params: { runId: "run-seq", sessionKey: "agent:main:main" },
-      timeoutMs: 1_000,
-    });
-    const invokeSettled = invoke.catch(() => {});
-    const ctx = buildCtx({
-      authorizeNodeSystemRunEvent: (params) => registry.authorizeSystemRunEvent(params),
-    });
-
-    await handleNodeEvent(
-      ctx,
-      "node-1",
-      {
-        event: "exec.started",
-        payloadJSON: JSON.stringify({
-          sessionKey: "agent:main:main",
-          runId: "run-seq",
-          command: "printf ok",
-        }),
-      },
-      { connId: "conn-1" },
-    );
-    await handleNodeEvent(
-      ctx,
-      "node-1",
-      {
+  it.each([false, true])(
+    "preserves exec authorization and terminal consumption with suppressNotifyOnExit=%s",
+    async (suppressNotifyOnExit) => {
+      const registry = new NodeRegistry();
+      const connection = { connId: "conn-1" };
+      const runId = `run-seq-suppress-${suppressNotifyOnExit}`;
+      const sessionKey = "agent:main:main";
+      const eventRouting = { sessionKey, contextKey: `exec:${runId}` };
+      const startedPayload = { runId, sessionKey, command: "printf ok" };
+      const finishedPayload = {
+        ...startedPayload,
+        exitCode: 0,
+        timedOut: false,
+        output: "done",
+        suppressNotifyOnExit,
+      };
+      const finishedEvent = {
         event: "exec.finished",
-        payloadJSON: JSON.stringify({
-          sessionKey: "agent:main:main",
-          runId: "run-seq",
-          command: "printf ok",
-          exitCode: 0,
-          timedOut: false,
-          output: "done",
-        }),
-      },
-      { connId: "conn-1" },
-    );
-
-    expect(enqueueSystemEventMock).toHaveBeenNthCalledWith(
-      1,
-      "Exec started (node=node-1 id=run-seq): printf ok",
-      {
-        sessionKey: "agent:main:main",
-        contextKey: "exec:run-seq",
-      },
-    );
-    expect(enqueueSystemEventMock).toHaveBeenNthCalledWith(
-      2,
-      "Exec finished (node=node-1 id=run-seq, code 0)\ndone",
-      {
-        sessionKey: "agent:main:main",
-        contextKey: "exec:run-seq",
-      },
-    );
-    expect(requestHeartbeatMock).toHaveBeenNthCalledWith(
-      1,
-      execEventHeartbeatOptions("agent:main:main"),
-    );
-    expect(requestHeartbeatMock).toHaveBeenNthCalledWith(
-      2,
-      execEventHeartbeatOptions("agent:main:main"),
-    );
-    expect(
-      registry.authorizeSystemRunEvent({
+        payloadJSON: JSON.stringify(finishedPayload),
+      };
+      const unmatchedEvent = {
+        ok: true,
+        event: "exec.finished",
+        handled: false,
+        reason: "unmatched_exec_event",
+      };
+      const ctx = buildCtx({
+        authorizeNodeSystemRunEvent: (params) => registry.authorizeSystemRunEvent(params),
+      });
+      registry.register(makeNodeClient(connection.connId, "node-1"), {
+        pairingIdentity: "identity-a",
+      });
+      const invoke = registry.invoke({
         nodeId: "node-1",
-        connId: "conn-1",
-        runId: "run-seq",
-        sessionKey: "agent:main:main",
-        terminal: false,
-      }),
-    ).toBe(false);
+        command: "system.run",
+        params: { runId, sessionKey },
+        timeoutMs: 0,
+      });
+      try {
+        await expect(
+          handleNodeEvent(ctx, "node-1", finishedEvent, { connId: "wrong-conn" }),
+        ).resolves.toEqual(unmatchedEvent);
+        await expect(
+          handleNodeEvent(
+            ctx,
+            "node-1",
+            { event: "exec.started", payloadJSON: JSON.stringify(startedPayload) },
+            connection,
+          ),
+        ).resolves.toBeUndefined();
 
-    registry.unregister("conn-1");
-    await invokeSettled;
-  });
+        expect(enqueueSystemEventMock).toHaveBeenCalledTimes(1);
+        expect(enqueueSystemEventMock).toHaveBeenNthCalledWith(
+          1,
+          `Exec started (node=node-1 id=${runId}): printf ok`,
+          eventRouting,
+        );
+        expect(requestHeartbeatMock).toHaveBeenCalledTimes(1);
+        expect(requestHeartbeatMock).toHaveBeenNthCalledWith(
+          1,
+          execEventHeartbeatOptions(sessionKey),
+        );
+
+        await expect(
+          handleNodeEvent(ctx, "node-1", finishedEvent, connection),
+        ).resolves.toBeUndefined();
+        if (!suppressNotifyOnExit) {
+          expect(enqueueSystemEventMock).toHaveBeenNthCalledWith(
+            2,
+            `Exec finished (node=node-1 id=${runId}, code 0)\ndone`,
+            eventRouting,
+          );
+          expect(requestHeartbeatMock).toHaveBeenNthCalledWith(
+            2,
+            execEventHeartbeatOptions(sessionKey),
+          );
+        }
+        // Remove suppression on replay so filtering cannot hide unconsumed authorization.
+        await expect(
+          handleNodeEvent(
+            ctx,
+            "node-1",
+            {
+              event: "exec.finished",
+              payloadJSON: JSON.stringify({ ...finishedPayload, suppressNotifyOnExit: false }),
+            },
+            connection,
+          ),
+        ).resolves.toEqual(unmatchedEvent);
+        const notificationCount = suppressNotifyOnExit ? 1 : 2;
+        expect(enqueueSystemEventMock).toHaveBeenCalledTimes(notificationCount);
+        expect(requestHeartbeatMock).toHaveBeenCalledTimes(notificationCount);
+      } finally {
+        registry.unregister(connection.connId);
+        await invoke;
+      }
+    },
+  );
 
   it("enqueues exec.finished events with output", async () => {
     const ctx = buildExecCtx();
@@ -1466,13 +1475,10 @@ describe("voice transcript events", () => {
 
 describe("notifications changed events", () => {
   beforeEach(() => {
-    enqueueSystemEventMock.mockClear();
-    requestHeartbeatMock.mockClear();
     loadSessionEntryMock.mockClear();
     normalizeChannelIdVi.mockClear();
     normalizeChannelIdVi.mockImplementation((channel?: string | null) => channel ?? null);
     loadSessionEntryMock.mockImplementation((sessionKey: string) => buildSessionLookup(sessionKey));
-    enqueueSystemEventMock.mockReturnValue(true);
   });
 
   it("enqueues notifications.changed posted events", async () => {
@@ -1647,7 +1653,6 @@ describe("notifications changed events", () => {
   });
 
   it("does not wake heartbeat when notifications.changed event is deduped", async () => {
-    enqueueSystemEventMock.mockReset();
     enqueueSystemEventMock.mockReturnValueOnce(true).mockReturnValueOnce(false);
     const ctx = buildCtx();
     const payload = JSON.stringify({
@@ -1669,23 +1674,6 @@ describe("notifications changed events", () => {
 
     expect(enqueueSystemEventMock).toHaveBeenCalledTimes(2);
     expect(requestHeartbeatMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("suppresses exec notifyOnExit events when payload opts out", async () => {
-    const ctx = buildCtx();
-    await handleNodeEvent(ctx, "node-n7", {
-      event: "exec.finished",
-      payloadJSON: JSON.stringify({
-        sessionKey: "agent:main:main",
-        runId: "approval-1",
-        exitCode: 0,
-        output: "ok",
-        suppressNotifyOnExit: true,
-      }),
-    });
-
-    expect(enqueueSystemEventMock).not.toHaveBeenCalled();
-    expect(requestHeartbeatMock).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a false-positive regression test for node exec notification suppression. The test named `suppresses exec notifyOnExit events when payload opts out` passed even after the suppression guard was removed: its default-deny context rejected the completion before notification filtering ran.

This is a maintainer-requested test-audit repair, not a production authorization change or a workaround for existing red CI.

## Why This Change Was Made

Consolidate the misplaced test into the existing real-`NodeRegistry` lifecycle test. Both payload suppression settings now cover a dispatched `system.run`, rejected wrong-connection completion, authorized start/completion, and an unsuppressed replay that must return `unmatched_exec_event`. Nonempty completion output and the unsuppressed case keep other quiet paths from masking the suppression assertion.

Removing the old test exposed an existing order dependency: its setup hook happened to clear notification calls left by the preceding dedupe test. Reset the shared notification mocks before every test and remove duplicated resets and unused frame capture. Registry cleanup runs in `finally`, including when a regression assertion fails.

The runtime invariant is documented in [Node exec lifecycle events](https://docs.openclaw.ai/gateway/protocol#node-exec-lifecycle-events): terminal authorization is consumed before notification filtering. Merely changing the old fixture to allow all exec events would not protect that boundary.

## User Impact

No runtime, configuration, protocol, or authorization changes. Maintainers get regression-sensitive coverage for payload suppression without weakening production auth or retaining a test-order dependency.

Production LOC: +0/-0. Tests and test support: +100/-112 (net -12).

## Evidence

- Before repair, temporarily deleting only the `suppressNotifyOnExit` guard left the old named test green: 1 passed, 72 skipped.
- The revised real-registry cases detect all three mutations: deleting the suppression guard (unexpected completion notification), moving suppression before authorization (wrong-connection event no longer explicitly rejected), and no longer marking `exec.finished` terminal (replay no longer rejected). Each failed at its intended assertion; all temporary production mutations were restored exactly.
- Removing the old test initially exposed two presence-test failures caused by calls from the preceding notification dedupe test. The complete original file order passes after the shared-mock lifetime repair.
- `node scripts/run-vitest.mjs src/gateway/server-node-events.test.ts src/gateway/node-registry.test.ts --reporter=dot` — 224 passed, including a final run after restoring all mutation experiments.
- `node scripts/check-changed.mjs -- src/gateway/server-node-events.test.ts` — passed, including core test typechecking, targeted lint, formatting, and repository guards.
- `git diff --check` — passed.
- Isolated Codex autoreview of the final test-only diff, supplied with complete handler, registry/lifecycle, ingress, and both test files — scoped-clean with no findings at the configured P0 priority.

No live Gateway or UI proof is claimed or required for this test-only change. No production file remains modified.
