### PR TITLE
fix(matrix): bound monitor waitForIdle on hung joins

### DIFF
--- a/extensions/matrix/src/matrix/monitor/task-runner.test.ts
+++ b/extensions/matrix/src/matrix/monitor/task-runner.test.ts
@@ -1,0 +1,103 @@
+// Matrix tests cover monitor task-runner idle drain behavior.
+import type { RuntimeLogger } from "openclaw/plugin-sdk/plugin-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createMatrixMonitorTaskRunner } from "./task-runner.js";
+
+function deferredTask() {
+  let resolve: (() => void) | undefined;
+  const promise = new Promise<void>((res) => {
+    resolve = res;
+  });
+  if (!resolve) {
+    throw new Error("Expected deferred task resolver to be initialized");
+  }
+  return { promise, resolve };
+}
+
+const WAIT_FOR_IDLE_TIMEOUT_MS = 30_000;
+
+function createHarness() {
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } satisfies RuntimeLogger;
+  const logVerboseMessage = vi.fn();
+  const runner = createMatrixMonitorTaskRunner({
+    logger,
+    logVerboseMessage,
+  });
+  return { logger, logVerboseMessage, runner };
+}
+
+describe("createMatrixMonitorTaskRunner waitForIdle", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("resolves immediately when no tasks are in flight", async () => {
+    const { logger, logVerboseMessage, runner } = createHarness();
+
+    await expect(runner.waitForIdle()).resolves.toBeUndefined();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logVerboseMessage).not.toHaveBeenCalled();
+  });
+
+  it("returns when no in-flight task settles within the idle window", async () => {
+    vi.useFakeTimers();
+    const { logger, logVerboseMessage, runner } = createHarness();
+    void runner.runDetachedTask("join", () => new Promise(() => {}));
+
+    const idle = runner.waitForIdle();
+    await vi.advanceTimersByTimeAsync(WAIT_FOR_IDLE_TIMEOUT_MS);
+    await expect(idle).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      "matrix waitForIdle timed out",
+      expect.objectContaining({ idleTimeoutMs: WAIT_FOR_IDLE_TIMEOUT_MS, remaining: 1 }),
+    );
+    expect(logVerboseMessage).toHaveBeenCalledWith(
+      expect.stringContaining(`${WAIT_FOR_IDLE_TIMEOUT_MS}ms`),
+    );
+  });
+
+  it("waits for a task that settles before the idle timeout", async () => {
+    const { logger, logVerboseMessage, runner } = createHarness();
+    const pending = deferredTask();
+    let settled = false;
+    void runner.runDetachedTask("room", async () => {
+      await pending.promise;
+      settled = true;
+    });
+
+    const idle = runner.waitForIdle();
+    expect(settled).toBe(false);
+    pending.resolve();
+    await expect(idle).resolves.toBeUndefined();
+    expect(settled).toBe(true);
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logVerboseMessage).not.toHaveBeenCalled();
+  });
+
+  it("resets the idle timer when a task settles and another is added", async () => {
+    vi.useFakeTimers();
+    const { logger, logVerboseMessage, runner } = createHarness();
+    const first = deferredTask();
+    const second = deferredTask();
+    void runner.runDetachedTask("first", () => first.promise);
+
+    const idle = runner.waitForIdle();
+    await vi.advanceTimersByTimeAsync(WAIT_FOR_IDLE_TIMEOUT_MS - 5_000);
+    first.resolve();
+    void runner.runDetachedTask("second", () => second.promise);
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(WAIT_FOR_IDLE_TIMEOUT_MS - 5_000);
+    expect(logger.warn).not.toHaveBeenCalled();
+
+    second.resolve();
+    await expect(idle).resolves.toBeUndefined();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logVerboseMessage).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/matrix/src/matrix/monitor/task-runner.ts
+++ b/extensions/matrix/src/matrix/monitor/task-runner.ts
@@ -3,9 +3,29 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import type { RuntimeLogger } from "openclaw/plugin-sdk/plugin-runtime";
 
 const monitorTaskSignal = new AsyncLocalStorage<AbortSignal>();
+const DEFAULT_WAIT_FOR_IDLE_TIMEOUT_MS = 30_000;
 
 export function getMatrixMonitorTaskSignal(): AbortSignal | undefined {
   return monitorTaskSignal.getStore();
+}
+
+function createIdleTimeoutPromise(timeoutMs: number): {
+  promise: Promise<"timeout">;
+  clear: () => void;
+} {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const promise = new Promise<"timeout">((resolve) => {
+    timeoutId = setTimeout(() => resolve("timeout"), timeoutMs);
+    timeoutId.unref?.();
+  });
+  return {
+    promise,
+    clear: () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    },
+  };
 }
 
 export function createMatrixMonitorTaskRunner(params: {
@@ -40,8 +60,32 @@ export function createMatrixMonitorTaskRunner(params: {
   };
 
   const waitForIdle = async (): Promise<void> => {
+    // Must not block gateway stop on a hung homeserver join or inbound turn.
+    // Idle window, not wall-clock: keep waiting while tasks settle; return if none complete.
     while (inFlight.size > 0) {
-      await Promise.allSettled(Array.from(inFlight.keys()));
+      const snapshot = Array.from(inFlight.keys());
+      const timeout = createIdleTimeoutPromise(DEFAULT_WAIT_FOR_IDLE_TIMEOUT_MS);
+      const outcome = await Promise.race<"timeout" | "settled">([
+        timeout.promise,
+        ...snapshot.map((task) =>
+          task.then(
+            () => "settled" as const,
+            () => "settled" as const,
+          ),
+        ),
+      ]);
+      timeout.clear();
+      if (outcome === "timeout") {
+        const remaining = inFlight.size;
+        params.logVerboseMessage(
+          `matrix: waitForIdle made no progress within ${DEFAULT_WAIT_FOR_IDLE_TIMEOUT_MS}ms; continuing retirement with ${remaining} task(s) still in flight`,
+        );
+        params.logger.warn("matrix waitForIdle timed out", {
+          idleTimeoutMs: DEFAULT_WAIT_FOR_IDLE_TIMEOUT_MS,
+          remaining,
+        });
+        return;
+      }
     }
   };
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Matrix monitor retirement waits forever on in-flight room or join tasks. `waitForIdle` looped `Promise.allSettled` until `inFlight` was empty. A hung homeserver join then blocks Gateway stop and client lease release.

## Why This Change Was Made

Give Matrix `waitForIdle` the same idle-window pattern core already uses for pending tool drains: keep waiting while tasks settle, and return after 30 seconds with no progress. The 30-second window is a private constant. There is no constructor timeout parameter. Leftover tasks are logged and left running. `close()` already refuses new detached work. No new config. Plugin code does not import core `src/`.

## User Impact

Stopping the Gateway or releasing a Matrix client lease no longer hangs on a join or room handler that never finishes.

## Evidence

Live `pnpm exec tsx` against production `createMatrixMonitorTaskRunner`. A detached `join` task never settles.

Before (origin/main): `waitForIdle` does not resolve within 200ms.

```console
$ pnpm exec tsx proof-f056-before.mts
{"outcome":"timeout"}
```

After (this branch): waitForIdle returns and logs the leftover task. The capture below used a 30ms window to observe the same timeout path; production now always uses the private 30-second constant.

```console
$ pnpm exec tsx proof-f056.mts
{"verbose":"matrix: waitForIdle made no progress within 30ms; continuing retirement with 1 task(s) still in flight"}
{"warn":["matrix waitForIdle timed out",{"idleTimeoutMs":30,"remaining":1}]}
{"resolved":true,"elapsedMs":31}
```

## Real behavior proof

Behavior addressed: Matrix monitor retirement returns after an idle window instead of waiting forever on a hung join.
Real environment tested: macOS Darwin, Node v26.7.0, worktree /tmp/oc-f056-matrix-idle on current origin/main, invoked with pnpm exec tsx against extensions/matrix/src/matrix/monitor/task-runner.ts.
Exact steps or command run after this patch: pnpm exec tsx proof-f056.mts
Evidence after fix: terminal output copied below.

```console
$ pnpm exec tsx proof-f056.mts
{"verbose":"matrix: waitForIdle made no progress within 30ms; continuing retirement with 1 task(s) still in flight"}
{"warn":["matrix waitForIdle timed out",{"idleTimeoutMs":30,"remaining":1}]}
{"resolved":true,"elapsedMs":31}
```

Observed result after fix: waitForIdle resolves in 31ms, warns with remaining: 1, and does not wait on the never-settling join.
What was not tested: Live Matrix homeserver join through a running Gateway.

## Summary

Same family as core pending-tool idle drain (30s). Sibling F043 is [#132395](https://github.com/openclaw/openclaw/pull/132395).
No CHANGELOG (repo auto-generates).

