### PR TITLE
perf(ci): balance release verification work and trim runtime builds

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -1057,15 +1057,20 @@ jobs:
             command: pnpm test:e2e:gateway --shard=4/4
           - name: UI 1/4
             command: pnpm test:ui:e2e --shard=1/4
+            build_command: pnpm build:ci-artifacts
           - name: UI 2/4
             command: pnpm test:ui:e2e --shard=2/4
+            build_command: pnpm build:ci-artifacts
           - name: UI 3/4
             command: pnpm test:ui:e2e --shard=3/4
+            build_command: pnpm build:ci-artifacts
           - name: UI 4/4
             command: pnpm test:ui:e2e --shard=4/4
+            build_command: pnpm build:ci-artifacts
           - name: Agent plugin Gateway
             command: pnpm test:e2e:agent-plugin-gateway
             target_script: test:e2e:agent-plugin-gateway
+            build_command: pnpm build:ci-artifacts
     env:
       OPENCLAW_BUILD_PRIVATE_QA: "1"
       OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
@@ -1088,7 +1093,8 @@ jobs:
       - name: Build dist for repo E2E
         env:
           NODE_OPTIONS: --max-old-space-size=8192
-        run: pnpm build
+        # Gateway shards pack and type-check packages; runtime-only suites keep SDK checks without global declarations.
+        run: ${{ matrix.build_command || 'pnpm build' }}
 
       - name: Install Playwright Chromium
         run: pnpm --dir ui exec playwright install --with-deps chromium
@@ -1542,6 +1548,7 @@ jobs:
           bash .release-harness/scripts/ci-docker-pull-retry.sh "${OPENCLAW_DOCKER_E2E_FUNCTIONAL_IMAGE}"
 
       - name: Validate Docker E2E credentials
+        id: validate_credentials
         if: contains(matrix.profiles, inputs.release_test_profile)
         shell: bash
         env:
@@ -1581,7 +1588,8 @@ jobs:
           fi
 
       - name: Run Docker E2E chunk
-        if: contains(matrix.profiles, inputs.release_test_profile)
+        # Missing live credentials still fail this job, but must not suppress non-live diagnostics.
+        if: ${{ !cancelled() && contains(matrix.profiles, inputs.release_test_profile) && (success() || steps.validate_credentials.outcome == 'failure') }}
         shell: bash
         run: |
           set -euo pipefail
@@ -1928,6 +1936,7 @@ jobs:
           bash .release-harness/scripts/ci-docker-pull-retry.sh "${OPENCLAW_DOCKER_E2E_FUNCTIONAL_IMAGE}"
 
       - name: Validate Docker E2E credentials
+        id: validate_credentials
         shell: bash
         env:
           CREDENTIALS: ${{ steps.plan.outputs.credentials }}
@@ -1966,6 +1975,7 @@ jobs:
           fi
 
       - name: Run targeted Docker E2E lanes
+        if: ${{ !cancelled() && (success() || steps.validate_credentials.outcome == 'failure') }}
         shell: bash
         env:
           ARTIFACT_SUFFIX: ${{ steps.plan.outputs.artifact_suffix }}

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -875,8 +875,12 @@ A lane heavier than its effective cap can still start from an empty pool, then r
 Repository E2E runs as nine independent jobs: four native Gateway shards, four
 duration-weighted Control UI shards, and the standalone agent-plugin Gateway
 test. At most six run concurrently, and a failure does not cancel the remaining
-jobs. Every job checks out the same selected source and prepares its own full
-private-QA build, Chromium, and sandbox image. Gateway shards retain the existing
+jobs. Every job checks out the same selected source and prepares its own
+private-QA build, Chromium, and sandbox image. Gateway shards use the full build
+because they include packed-package type checks. UI and agent-plugin jobs use
+the existing CI artifact build, retaining runtime code, private QA entries,
+Control UI assets, and canonical SDK declarations/checks without generating
+unneeded package-wide declarations. Gateway shards retain the existing
 four fresh-process boundaries and two-worker limit; UI shards retain serial
 files within each process. No tests are filtered out, and the existing
 90-minute job deadline is unchanged. Local `pnpm test:e2e` remains sequential.
@@ -894,9 +898,11 @@ The reusable live/E2E workflow asks `scripts/test-docker-all.mjs --plan-json` wh
 Release Docker coverage runs smaller chunked jobs with `OPENCLAW_SKIP_DOCKER_BUILD=1` so each chunk verifies and loads only the artifact-backed image kind it needs (or pulls it under explicit `existing-only` reuse) and executes multiple lanes through the same weighted scheduler:
 
 - `OPENCLAW_DOCKER_ALL_PROFILE=release-path`
-- `OPENCLAW_DOCKER_ALL_CHUNK=core | package-update-openai | package-update-anthropic | package-update-core | plugins-runtime-plugins | plugins-runtime-services | plugins-runtime-install-a..h | openwebui`
+- `OPENCLAW_DOCKER_ALL_CHUNK=core | package-update-openai | package-update-core | plugins-runtime-plugins | plugins-runtime-services | plugins-runtime-install-a..h | openwebui`
 
-Current release Docker chunks are `core`, `package-update-openai`, `package-update-anthropic`, `package-update-core`, `plugins-runtime-plugins`, `plugins-runtime-services`, `plugins-runtime-install-a` through `plugins-runtime-install-h`, and `openwebui`. `package-update-openai` includes the live Codex plugin package lane, which installs the candidate OpenClaw package, installs the Codex plugin from `codex_plugin_spec` or a same-ref tarball with explicit Codex CLI install approval, runs Codex CLI preflight and same-session agent turns, then runs a zero-retry medium-thinking turn that sends progress, reads randomized workspace inputs, writes their exact artifact, and sends completion. `plugins-runtime-core`, `plugins-runtime`, and `plugins-integrations` remain aggregate plugin/runtime aliases. The `install-e2e` lane alias remains the aggregate manual rerun alias for both provider installer lanes.
+Current release Docker chunks are `core`, `package-update-openai`, `package-update-core`, `plugins-runtime-plugins`, `plugins-runtime-services`, `plugins-runtime-install-a` through `plugins-runtime-install-h`, and `openwebui`. `package-update-openai` includes the live Codex plugin package lane, which installs the candidate OpenClaw package, installs the Codex plugin from `codex_plugin_spec` or a same-ref tarball with explicit Codex CLI install approval, runs Codex CLI preflight and same-session agent turns, then runs a zero-retry medium-thinking turn that sends progress, reads randomized workspace inputs, writes their exact artifact, and sends completion. `plugins-runtime-core`, `plugins-runtime`, and `plugins-integrations` remain aggregate plugin/runtime aliases. The `install-e2e` lane alias remains the aggregate manual rerun alias for both provider installer lanes.
+
+The `package-update-openai` row also runs root-managed VPS upgrade and authenticated update restart proof, balancing the existing package jobs without raising scheduler limits. Credential preflight failures remain blocking while the following diagnostic pool drains non-live lanes; earlier setup failures and cancellation still prevent execution.
 
 OpenWebUI runs as a standalone `openwebui` chunk on a dedicated large-disk Blacksmith runner whenever stable or full release-path coverage requests it, even when the reusable workflow routes supported jobs to GitHub-hosted runners. Keeping the external image pull separate prevents the large image from competing with the shared package and plugin images in `plugins-runtime-services`; legacy aggregate plugin/runtime chunks still include OpenWebUI for compatible manual reruns. Bundled-channel update lanes retry once for transient npm network failures.
 

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -518,7 +518,7 @@ Release Docker coverage includes:
 - full install smoke with the slow Bun global install smoke enabled
 - root Dockerfile smoke image preparation/reuse by target SHA, with QR, root/gateway, and installer/Bun smoke jobs running as separate install-smoke shards
 - repository E2E lanes
-- release-path Docker chunks: `core`, `package-update-openai`, `package-update-anthropic`, `package-update-core`, `plugins-runtime-plugins`, `plugins-runtime-services`, `plugins-runtime-install-a` through `plugins-runtime-install-h`, and `openwebui`
+- release-path Docker chunks: `core`, `package-update-openai`, `package-update-core`, `plugins-runtime-plugins`, `plugins-runtime-services`, `plugins-runtime-install-a` through `plugins-runtime-install-h`, and `openwebui`
 - OpenWebUI coverage on a dedicated large-disk runner when requested
 - split bundled plugin install/uninstall lanes `bundled-plugin-install-uninstall-0` through `bundled-plugin-install-uninstall-23`
 - live/E2E provider suites and Docker live model coverage when release checks include live suites

--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -398,16 +398,22 @@ artifact when package or Docker-facing stages need it.
 The Docker release-path stage runs these chunks when `live_suite_filter` is
 empty:
 
-| Chunk                                                           | Coverage                                                                                                                                     |
-| --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
-| `core`                                                          | Core Docker release-path smoke lanes.                                                                                                        |
-| `package-update-openai`                                         | OpenAI package install/update behavior, Codex on-demand install, Codex plugin live progress follow-through, and Chat Completions tool calls. |
-| `package-update-anthropic`                                      | Anthropic package install and update behavior.                                                                                               |
-| `package-update-core`                                           | Provider-neutral package and update behavior.                                                                                                |
-| `plugins-runtime-plugins`                                       | Plugin runtime lanes that exercise plugin behavior.                                                                                          |
-| `plugins-runtime-services`                                      | Service-backed and live plugin runtime lanes.                                                                                                |
-| `plugins-runtime-install-a` through `plugins-runtime-install-h` | Plugin install/runtime batches split for parallel release validation.                                                                        |
-| `openwebui`                                                     | OpenWebUI compatibility smoke isolated on a dedicated large-disk runner when requested.                                                      |
+| Chunk                                                           | Coverage                                                                                                                                    |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `core`                                                          | Core Docker release-path smoke lanes.                                                                                                       |
+| `package-update-openai`                                         | OpenAI package and tool-call proof, Codex on-demand install and live progress, root-managed VPS upgrades, and authenticated update restart. |
+| `package-update-core`                                           | Provider-neutral package and update behavior.                                                                                               |
+| `plugins-runtime-plugins`                                       | Plugin runtime lanes that exercise plugin behavior.                                                                                         |
+| `plugins-runtime-services`                                      | Service-backed and live plugin runtime lanes.                                                                                               |
+| `plugins-runtime-install-a` through `plugins-runtime-install-h` | Plugin install/runtime batches split for parallel release validation.                                                                       |
+| `openwebui`                                                     | OpenWebUI compatibility smoke isolated on a dedicated large-disk runner when requested.                                                     |
+
+The two package/update rows share the same coverage across every release profile.
+Root-managed VPS upgrade and authenticated restart checks run in the shorter
+OpenAI row to balance the workload without adding jobs or raising resource caps.
+Missing required credentials still fail the job; the diagnostic pool continues
+so independent non-live checks also report their results. Setup failures and
+cancellation do not start that pool.
 
 Expanded published-upgrade survivor and update-migration coverage runs in
 baseline-specific groups of at most three scenarios, with up to 32 targeted

--- a/scripts/lib/docker-e2e-scenarios.mts
+++ b/scripts/lib/docker-e2e-scenarios.mts
@@ -877,6 +877,8 @@ const releasePathPackageUpdateOpenAiLanes = [
   scheduledLane("live-codex-npm-plugin"),
   scheduledLane("codex-on-demand", { timeoutMs: 30 * 60 * 1000 }),
   scheduledLane("release-typed-onboarding"),
+  // Use the shorter package row without changing npm weights or upgrade coverage.
+  ...scheduledLaneList("root-managed-vps-upgrade", "update-restart-auth"),
 ];
 
 const releasePathPackageUpdateCoreLanes = scheduledLaneList(
@@ -888,8 +890,6 @@ const releasePathPackageUpdateCoreLanes = scheduledLaneList(
   "skill-install",
   "upgrade-survivor",
   "published-upgrade-survivor",
-  "root-managed-vps-upgrade",
-  "update-restart-auth",
   "update-run-package-self-upgrade",
 );
 

--- a/scripts/plan-release-workflow-matrix.mjs
+++ b/scripts/plan-release-workflow-matrix.mjs
@@ -10,7 +10,7 @@ const DOCKER_E2E_CHUNKS = [
   },
   {
     chunk_id: "package-update-openai",
-    label: "package/update OpenAI",
+    label: "package/update OpenAI and recovery",
     timeout_minutes: 45,
     profiles: "beta minimum stable full",
   },

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4585,6 +4585,22 @@ server.listen(0, "127.0.0.1", () => {
     expect(repoE2eSteps.find((step) => step.name === "Checkout selected ref")?.with?.ref).toBe(
       "${{ needs.validate_selected_ref.outputs.selected_sha }}",
     );
+    const build = repoE2eSteps.find((step) => step.name === "Build dist for repo E2E");
+    for (const row of repoE2eRows) {
+      const command = build?.run?.startsWith("${{")
+        ? evaluateWorkflowExpression(build.run, {
+            eventName: "workflow_dispatch",
+            repository: "openclaw/openclaw",
+            runAttempt: 1,
+            matrix: row,
+          })
+        : build?.run;
+      // Gateway shards include packed-package type consumers; UI and the
+      // standalone agent-plugin proof need runtime and canonical SDK artifacts.
+      expect(command, row.name).toBe(
+        row.command.startsWith("pnpm test:e2e:gateway ") ? "pnpm build" : "pnpm build:ci-artifacts",
+      );
+    }
     const sandboxSetupIndex = repoE2eSteps.findIndex(
       (step) => step.name === "Build sandbox image" && step.run === "scripts/sandbox-setup.sh",
     );

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -571,6 +571,8 @@ describe("scripts/lib/docker-e2e-plan", () => {
       "live-codex-npm-plugin",
       "codex-on-demand",
       "release-typed-onboarding",
+      "root-managed-vps-upgrade",
+      "update-restart-auth",
     ]);
     expect(
       packageInstallOpenAi.lanes
@@ -585,6 +587,34 @@ describe("scripts/lib/docker-e2e-plan", () => {
         resources: ["docker", "npm", "service"],
         stateScenario: "empty",
         timeoutMs: 1_200_000,
+        weight: 3,
+      },
+    ]);
+    expect(packageInstallOpenAi.lanes.slice(-2).map(summarizeLane)).toEqual([
+      {
+        command: trustedUpgradeSurvivorCommand(
+          "OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE=1 OPENCLAW_UPGRADE_SURVIVOR_ROOT_MANAGED_VPS=1",
+          'export OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC="${OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC:-openclaw@latest}"; export OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT="${OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT:-1500s}"',
+        ),
+        imageKind: "bare",
+        live: false,
+        name: "root-managed-vps-upgrade",
+        resources: ["docker", "npm"],
+        stateScenario: "upgrade-survivor",
+        timeoutMs: 1_500_000,
+        weight: 3,
+      },
+      {
+        command: trustedUpgradeSurvivorCommand(
+          "OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE=1 OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE=auto-auth",
+          'export OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC="${OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC:-openclaw@latest}"; export OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT="${OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT:-1500s}"',
+        ),
+        imageKind: "bare",
+        live: false,
+        name: "update-restart-auth",
+        resources: ["docker", "npm"],
+        stateScenario: "upgrade-survivor",
+        timeoutMs: 1_500_000,
         weight: 3,
       },
     ]);
@@ -665,32 +695,6 @@ describe("scripts/lib/docker-e2e-plan", () => {
         imageKind: "bare",
         live: false,
         name: "published-upgrade-survivor",
-        resources: ["docker", "npm"],
-        stateScenario: "upgrade-survivor",
-        timeoutMs: 1_500_000,
-        weight: 3,
-      },
-      {
-        command: trustedUpgradeSurvivorCommand(
-          "OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE=1 OPENCLAW_UPGRADE_SURVIVOR_ROOT_MANAGED_VPS=1",
-          'export OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC="${OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC:-openclaw@latest}"; export OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT="${OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT:-1500s}"',
-        ),
-        imageKind: "bare",
-        live: false,
-        name: "root-managed-vps-upgrade",
-        resources: ["docker", "npm"],
-        stateScenario: "upgrade-survivor",
-        timeoutMs: 1_500_000,
-        weight: 3,
-      },
-      {
-        command: trustedUpgradeSurvivorCommand(
-          "OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE=1 OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE=auto-auth",
-          'export OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC="${OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC:-openclaw@latest}"; export OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT="${OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT:-1500s}"',
-        ),
-        imageKind: "bare",
-        live: false,
-        name: "update-restart-auth",
         resources: ["docker", "npm"],
         stateScenario: "upgrade-survivor",
         timeoutMs: 1_500_000,
@@ -853,6 +857,8 @@ describe("scripts/lib/docker-e2e-plan", () => {
       "live-codex-npm-plugin",
       "codex-on-demand",
       "release-typed-onboarding",
+      "root-managed-vps-upgrade",
+      "update-restart-auth",
       "npm-onboard-channel-agent",
       "npm-onboard-discord-channel-agent",
       "npm-onboard-slack-channel-agent",
@@ -861,8 +867,6 @@ describe("scripts/lib/docker-e2e-plan", () => {
       "skill-install",
       "upgrade-survivor",
       "published-upgrade-survivor",
-      "root-managed-vps-upgrade",
-      "update-restart-auth",
       "update-run-package-self-upgrade",
     ]);
     expect(pluginsRuntime.lanes.map((lane) => lane.name)).toEqual([

--- a/test/scripts/release-workflow-matrix-plan.test.ts
+++ b/test/scripts/release-workflow-matrix-plan.test.ts
@@ -2,6 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, readdirSync, symlinkSync } from "node:fs";
 import path from "node:path";
+import { runInNewContext } from "node:vm";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
@@ -24,7 +25,9 @@ const PROFILE_GATED_STATIC_MATRIX_ALLOWLIST = [
 ];
 
 type WorkflowStep = {
+  "continue-on-error"?: boolean;
   env?: Record<string, string>;
+  id?: string;
   if?: string;
   name?: string;
   run?: string;
@@ -166,6 +169,97 @@ function staticProfileMatrixJobs() {
 }
 
 describe("scripts/plan-release-workflow-matrix.mjs", () => {
+  it.each([
+    ["validate_docker_e2e", "Run Docker E2E chunk"],
+    ["validate_docker_lanes", "Run targeted Docker E2E lanes"],
+  ])("drains diagnostics after credential failure in %s", (jobName, runStepName) => {
+    const job = requiredJob(workflow(), jobName);
+    const credentials = expectDefined(
+      job.steps.find((step) => step.name === "Validate Docker E2E credentials"),
+      "credential validation step",
+    );
+    const run = expectDefined(
+      job.steps.find((step) => step.name === runStepName),
+      "Docker execution step",
+    );
+    // Credential validation must be reached only after every setup/binding step
+    // succeeds; nothing fallible may intervene before diagnostic continuation.
+    expect(job.steps.indexOf(run)).toBe(job.steps.indexOf(credentials) + 1);
+    expect(credentials["continue-on-error"]).not.toBe(true);
+    expect(credentials.if ?? "").not.toMatch(/\b(?:always|cancelled|failure|success)\s*\(/u);
+
+    const preflight = expectDefined(credentials.run, "credential validation command");
+    for (const key of [undefined, "synthetic-openai-key"]) {
+      const result = spawnSync("bash", ["--noprofile", "--norc", "-c", preflight], {
+        encoding: "utf8",
+        env: {
+          PATH: process.env.PATH,
+          CREDENTIALS: "openai",
+          ...(key ? { OPENAI_API_KEY: key } : {}),
+        },
+      });
+      expect(result.status, result.stderr).toBe(key ? 0 : 1);
+      if (!key) {
+        expect(result.stderr).toContain("Missing credential for OpenAI");
+      }
+      expect(result.stdout + result.stderr).not.toContain("synthetic-openai-key");
+    }
+
+    for (const state of [
+      { label: "success", success: true, cancelled: false, outcome: "success", selected: true },
+      {
+        label: "credential failure",
+        success: false,
+        cancelled: false,
+        outcome: "failure",
+        selected: true,
+      },
+      {
+        label: "setup failure",
+        success: false,
+        cancelled: false,
+        outcome: "skipped",
+        selected: true,
+      },
+      { label: "cancelled", success: false, cancelled: true, outcome: "failure", selected: true },
+      {
+        label: "unselected profile",
+        success: true,
+        cancelled: false,
+        outcome: "skipped",
+        selected: false,
+      },
+    ]) {
+      const evaluate = (step: WorkflowStep) => {
+        const expression = (step.if ?? "success()").replace(/^\$\{\{\s*([\s\S]*?)\s*\}\}$/u, "$1");
+        // GitHub implicitly adds success() unless a status function is present.
+        const implicitSuccess = /\b(?:always|cancelled|failure|success)\s*\(/u.test(expression)
+          ? true
+          : state.success;
+        return (
+          implicitSuccess &&
+          runInNewContext(expression, {
+            always: () => true,
+            cancelled: () => state.cancelled,
+            failure: () => !state.success && !state.cancelled,
+            success: () => state.success,
+            contains: (value: string, item: string) => value.includes(item),
+            inputs: { release_test_profile: "full" },
+            matrix: { profiles: state.selected ? "stable full" : "beta" },
+            steps: { [credentials.id ?? ""]: { outcome: state.outcome } },
+          })
+        );
+      };
+      const profileSelected = jobName === "validate_docker_lanes" || state.selected;
+      expect(evaluate(credentials), `${state.label}: preflight`).toBe(
+        state.success && profileSelected,
+      );
+      expect(evaluate(run), `${state.label}: diagnostics`).toBe(
+        !state.cancelled && profileSelected && (state.success || state.outcome === "failure"),
+      );
+    }
+  });
+
   it("builds provider owners used by every direct and Gateway Docker live lane", () => {
     const definition = workflow();
     const outputDir = tempDirs.make("openclaw-live-image-selection-");


### PR DESCRIPTION
## What Problem This Solves

Full release verification leaves useful runner capacity idle while long jobs finish. In the last passing full run, the package/update rows took 38m07 and 6m03; the nine repository E2E jobs also spent a combined 65m29 in build steps before running tests. These are observed job timings, not a controlled before/after benchmark.

## Why This Change Was Made

Rebalance the two existing package rows by moving the unchanged root-managed VPS upgrade and authenticated update-restart lanes into the shorter OpenAI row. Keep all lane commands, artifact/registry binding, profiles, resource weights, retries and deadlines. Required credential preflight still fails the job, but its immediately following diagnostic pool now runs after that failure so independent non-live checks are not suppressed. Earlier setup failure and cancellation do not start the pool; existing advisory policy remains unchanged.

Use the existing CI artifact build for the four UI shards and standalone agent-plugin Gateway job. It retains private QA runtime code, UI assets and canonical SDK declarations/checks. The four Gateway shards keep the full build: their packed-package consumers validate published TypeScript declarations. No new build profile, artifact producer, cache, runner, job, parallelism increase or test omission is introduced. Remove obsolete Anthropic package-row documentation.

## User Impact

Maintainers should spend less time waiting for release verification, with the same coverage and failure policy. The nine repository E2E rows, six-job cap, local test entrypoints and release/package builds remain unchanged. No installed-product behavior changes.

## Evidence

- Baseline regressions reproduced the two credential-failure diagnostic skips, the old row placement, and UI jobs selecting the unnecessarily full build.
- Canonical before/after plans preserve every effective lane definition, uniqueness and aggregate coverage across 36 plans (four release profiles, three live modes and three package selectors).
- Broad Docker scheduler/harness proof passed 141 tests; its only failure was the aggregate-order fixture, subsequently updated. Final focused planner, workflow and build-owner proof passed 160 tests (191 unrelated tests excluded by the explicit filter).
- Actionlint and targeted formatting passed. Independent Codex review found no actionable P0–P2 defects. The local changed-file gate passed 13 checks, then stopped on missing `shiki`/`tslog` declaration files in the shared dependency installation; those packages and consumers are untouched. Exact-head CI passed: 129 checks passed, including `openclaw/ci-gate`; 36 checks were intentionally skipped. Clean hosted type/lint gates passed despite the incomplete local shared dependency installation.

- [Same-host Linux comparison](https://github.com/openclaw/openclaw/actions/runs/33363934214), exact head `68bca5e4e2391f5abea0915e17b9e3ef15a3a038`, Node 24.19.0, four observed CPUs: cold full build **297.514s** versus CI artifact build **83.406s**, a **72.0% reduction** (214.108s). Both arms used fresh output/build/compile caches, the same dependencies and Chromium, and a fixed build timestamp. This is one sequential pair; filesystem/page-cache carryover remains.
- Both build modes passed private-QA CLI help, the unchanged real agent-plugin Gateway flow, and six real-Gateway/auth plus production service-worker UI checks with zero skips. Build stamps remained unchanged after the consumers, ruling out silent rebuilds. Seven required runtime/provenance files were byte-identical; canonical SDK export checks passed in both arms. Native command exited 0; its owned Testbox lease is stopped.

Runtime production delta: 0. CI/tooling delta: +10 net lines, needed to select the existing build mode and preserve diagnostic execution after a hard credential failure; no scheduler/runtime abstraction added. Tests: +114 net lines; docs: +12. No measured full-workflow speedup is claimed yet. A fresh full verification will run after the final trusted Tooling commit is on main.
