### PR TITLE
fix(install): repair set-npm-prefix rc line and surface silent finalization failures

### DIFF
--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -1225,7 +1225,7 @@ fix_npm_prefix_if_needed() {
   mkdir -p "$target"
   "$(npm_bin)" config set prefix "$target"
 
-  local path_line="export PATH=\\\"${target}/bin:\\$PATH\\\""
+  local path_line="export PATH=\"${target}/bin:\$PATH\""
   for rc in "${HOME}/.bashrc" "${HOME}/.zshrc"; do
     if [[ -f "$rc" ]] && ! grep -q ".npm-global" "$rc"; then
       echo "$path_line" >> "$rc"
@@ -1400,7 +1400,9 @@ install_openclaw() {
   )
   local resolved_requested="$requested"
   if [[ -n "${REQUIRED_COMPATIBLE_VERSION:-}" ]]; then
-    resolved_requested="$(resolve_npm_openclaw_version "$requested")"
+    # || true: a failed npm view must reach the explicit fail below instead
+    # of dying silently through set -e with no error event.
+    resolved_requested="$(resolve_npm_openclaw_version "$requested" || true)"
     if [[ -z "$resolved_requested" ]]; then
       fail "Could not resolve OpenClaw ${requested} before compatibility checking."
     fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3654,17 +3654,29 @@ verify_installation() {
 
 retire_npm_owner_after_git_install() {
     local wrapper="$HOME/.local/bin/openclaw" npm_cmd="" npm_root="" npm_bin="" package_root="" package_name=""
-    npm_cmd="$(npm_command_path npm)" || return 1
+    if ! npm_cmd="$(npm_command_path npm)"; then
+        ui_error "Could not retire the previous npm install: npm not found on PATH"
+        return 1
+    fi
     npm_root="$("$npm_cmd" root -g 2>/dev/null | awk 'NF { value = $0 } END { print value }')" || true
     package_root="${npm_root%/}/openclaw"
     [[ -n "$npm_root" && -f "$package_root/package.json" ]] || return 0
     package_name="$(node -e 'const p=require(process.argv[1]); process.stdout.write(String(p.name || ""))' "$package_root/package.json" 2>/dev/null || true)"
-    [[ "$package_name" == "openclaw" ]] || return 1
+    if [[ "$package_name" != "openclaw" ]]; then
+        ui_error "Could not retire the previous npm install: ${package_root} contains package '${package_name:-unknown}', not openclaw"
+        return 1
+    fi
     npm_bin="$(npm_global_bin_dir "$npm_cmd" || true)"
     if [[ "${npm_bin%/}/openclaw" == "$wrapper" ]]; then
-        rm -rf "$package_root" || return 1
+        if ! rm -rf "$package_root"; then
+            ui_error "Could not retire the previous npm install: failed to remove ${package_root}"
+            return 1
+        fi
     else
-        "$npm_cmd" uninstall -g openclaw >/dev/null 2>&1 || return 1
+        if ! "$npm_cmd" uninstall -g openclaw >/dev/null 2>&1; then
+            ui_error "Could not retire the previous npm install: npm uninstall -g openclaw failed"
+            return 1
+        fi
     fi
     ui_success "Previous npm install retired"
 }
@@ -3680,10 +3692,13 @@ is_installer_git_wrapper() {
 
 prepare_git_wrapper_backup_for_npm() {
     local npm_cmd="" npm_root="" npm_bin="" target="" launcher=""
-    npm_cmd="$(npm_command_path npm)" || return 1
+    # Without a resolvable npm there is nothing to back up; let the npm
+    # install step report the missing npm with its own remediation text
+    # instead of silently exiting here (Arch splits node and npm packages).
+    npm_cmd="$(npm_command_path npm)" || return 0
     npm_root="$("$npm_cmd" root -g 2>/dev/null || true)"
     npm_bin="$(npm_global_bin_dir "$npm_cmd" || true)"
-    [[ -n "$npm_root" && -n "$npm_bin" ]] || return 1
+    [[ -n "$npm_root" && -n "$npm_bin" ]] || return 0
     target="${npm_bin%/}/openclaw"
     is_installer_git_wrapper "$target" || return 0
     launcher="${npm_root%/}/openclaw/openclaw.mjs"
@@ -3693,7 +3708,10 @@ prepare_git_wrapper_backup_for_npm() {
 retire_git_wrapper_after_npm_install() {
     local wrapper="$HOME/.local/bin/openclaw"
     is_installer_git_wrapper "$wrapper" || return 0
-    rm -f "$wrapper" || return 1
+    if ! rm -f "$wrapper"; then
+        ui_error "Could not retire the previous git wrapper: failed to remove ${wrapper}"
+        return 1
+    fi
     ui_success "Previous git wrapper retired"
 }
 


### PR DESCRIPTION
## Summary
A full audit of the three hosted installers (run from openclaw.ai against the synced copies, verified against this repo's `scripts/` sources) found several verified defects. This PR fixes the three highest-confidence shell ones; the remaining findings are listed below for follow-up.

### Fixed here
1. **`install-cli.sh --set-npm-prefix` corrupted shell rc files (P1).** The PATH line was over-escaped: `\\\"` collapsed to a literal `\"` and `\\$PATH` expanded at install time, so `.bashrc`/`.zshrc` received a line wrapped in literal backslash-quotes containing a frozen snapshot of the install-time PATH. The npm-global bin dir was never actually resolvable from it, and the user's PATH was frozen to install-time values. `install.sh` already used the correct form; this backports it.
2. **`install.sh` could exit 1 with zero output (P1).** The finalization helpers (`retire_npm_owner_after_git_install`, `retire_git_wrapper_after_npm_install`) had silent fatal paths; each now prints an actionable error. `prepare_git_wrapper_backup_for_npm` no longer hard-fails when npm is missing (Arch installs node without npm): there is nothing to back up, and the npm install step already reports missing npm with remediation — previously that case died silently before any message.
3. **`install-cli.sh --compatible-with` with an unresolvable `--version` died silently.** The failed `npm view` killed the script through `set -e` before the intended `fail` (and its JSON error event) could run; the resolution failure now reaches the explicit error path.

### Verification
- `pnpm vitest run test/scripts/install-cli.test.ts test/scripts/install-sh.test.ts` — 270/270 pass with these changes.
- `bash -n` and `shellcheck -S warning` clean on both scripts.
- Reproduced the rc-line corruption before/after: old form writes `export PATH=\"/home/u/.npm-global/bin:\<frozen 1KB PATH snapshot>\"`, new form writes `export PATH="/home/u/.npm-global/bin:$PATH"`.
- Downstream openclaw.ai Docker lanes (root, non-root, git, cli-git, e2e, 4-distro matrix) all pass against the current installers.

### Proposed changelog entry (not included: add on merge)
> **Installer diagnostics:** stop `install-cli.sh --set-npm-prefix` from writing an over-escaped PATH line with a frozen install-time PATH snapshot into shell rc files, surface the previously silent npm retirement/backup failures in `install.sh` with actionable errors (including the Arch node-without-npm case), and report an explicit error when `--compatible-with` cannot resolve the requested version instead of exiting silently.

### Audit findings NOT fixed here (follow-ups, roughly by priority)
- **install.ps1 (P1):** on Windows PowerShell 5.1, `$ErrorActionPreference = "Stop"` + stderr redirection (`2>&1` / `2>$null`) can abort mid-install on the first npm stderr warning; several call sites are unguarded (e.g. `npm config get min-release-age`), and the npm-failure diagnostics path itself can be killed by npm's own `npm error` output.
- **install.ps1 (P1):** when winget/choco/scoop is detected but fails (non-admin, lagging package), `Install-Node` aborts instead of falling through to the elevation-free portable Node path; the winget failure message advises a rerun that deterministically fails again.
- **install.sh / install.ps1 (P2):** both force `--min-release-age=0` (install.sh's user-configured branch assigns the same value, making it dead code), silently defeating a user's supply-chain cooldown; decide whether that override is intentional and log it either way.
- **install.sh (P2):** gum UI never activates under `curl | bash` (stdin-pipe check runs before the controlling-TTY check), so the rich UI only appears for file-based runs; shell `GIT_DIR` variable can collide with an exported git `GIT_DIR` env var; `exec openclaw onboard` skips the temp-file cleanup trap; `--dry-run` downloads gum before the dry-run gate; `--version latest` for the git method silently degrades to moving `main` when the registry is unreachable (and `resolve_git_openclaw_ref` uses bare `npm` from PATH instead of the managed `$(npm_bin)` that install-cli.sh uses).
- **install-cli.sh (P2):** `--json` NDJSON stdout gets polluted by npm/pnpm child output; several `set -e` death paths emit no JSON error event; sudo/git prompts can still block a TTY-attached non-interactive run (`sudo -n` / `GIT_TERMINAL_PROMPT=0` are unset); managed-Node upgrade removes the old runtime before the new one is extracted; non-Alpine musl distros get the glibc tarball with a misleading remediation.
- **install.ps1 (P2):** no `SecurityProtocol` TLS floor for PS 5.1; no checksums for portable Node/MinGit; missing `-UseBasicParsing` on the MinGit download; user PATH rewrite flattens `REG_EXPAND_SZ`; non-ASCII profile paths break the git-method `.cmd` wrapper (OEM codepage); `Ensure-OpenClawOnPath` failure exits 0.
