### PR TITLE
improve: load Control UI history with less blocking

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2814,7 +2814,7 @@ src/gateway/chat-display-projection.canvas.ts	14
 src/gateway/chat-display-projection.core.ts	6
 src/gateway/chat-display-projection.helpers.ts	10
 src/gateway/chat-display-projection.history.ts	1
-src/gateway/chat-display-projection.sanitize.ts	16
+src/gateway/chat-display-projection.sanitize.ts	15
 src/gateway/chat-sanitize.ts	3
 src/gateway/chat-tool-titles.ts	2
 src/gateway/cli-session-history.claude-activity.ts	1
@@ -3968,7 +3968,7 @@ ui/src/lib/board/widgets/workboard-widget.ts	2
 ui/src/lib/channels/index.ts	3
 ui/src/lib/chat/heartbeat-display.ts	4
 ui/src/lib/chat/message-extract.ts	7
-ui/src/lib/chat/message-normalizer.ts	3
+ui/src/lib/chat/message-normalizer.ts	2
 ui/src/lib/chat/outbox-store-codec.ts	1
 ui/src/lib/chat/outbox-store.ts	1
 ui/src/lib/chat/tool-call-patch.ts	1

--- a/src/chat/sender-identity.ts
+++ b/src/chat/sender-identity.ts
@@ -12,6 +12,8 @@ export type TranscriptSenderIdentity = Extract<
 /** Transcript attribution uses the closed product vocabulary, never raw-id inference. */
 export function readTranscriptSenderIdentity(value: unknown): TranscriptSenderIdentity | undefined {
   if (
+    typeof value !== "object" ||
+    value === null ||
     !Value.Check(SessionParticipantIdentitySchema, value) ||
     (value.type !== "profile" && value.type !== "remote" && value.type !== "observation") ||
     Object.values(value).some((part) => part !== null && (!part.trim() || part.length > 512))

--- a/src/gateway/chat-display-projection.sanitize.ts
+++ b/src/gateway/chat-display-projection.sanitize.ts
@@ -570,36 +570,38 @@ export function sanitizeChatHistoryMessage(
       truncated ||= res.truncated;
     }
   } else if (Array.isArray(entry.content)) {
-    const updated = entry.content.map((block) => {
-      const sanitized = sanitizeChatHistoryContentBlock(block, {
+    const content = entry.content;
+    let updated: unknown[] | undefined;
+    for (let index = 0; index < content.length; index++) {
+      const sanitized = sanitizeChatHistoryContentBlock(content[index], {
         preserveExactToolPayload,
         maxChars,
       });
+      const contentBlock = stripAssistantControlTokens ? readRecord(sanitized.block) : undefined;
       if (
-        !stripAssistantControlTokens ||
-        !sanitized.block ||
-        typeof sanitized.block !== "object" ||
-        Array.isArray(sanitized.block)
+        contentBlock &&
+        isAssistantTextContentType(contentBlock.type) &&
+        typeof contentBlock.text === "string"
       ) {
-        return sanitized;
+        const text = stripAssistantMediaDirectivesForDisplay(
+          stripSuppressedControlReplyToken(contentBlock.text),
+          managedMedia.urls,
+        );
+        if (text !== contentBlock.text) {
+          sanitized.block = { ...contentBlock, text };
+          sanitized.changed = true;
+        }
       }
-      const contentBlock = sanitized.block as { type?: unknown; text?: unknown };
-      if (!isAssistantTextContentType(contentBlock.type) || typeof contentBlock.text !== "string") {
-        return sanitized;
+      if (sanitized.changed) {
+        updated ??= content.slice();
+        updated[index] = sanitized.block;
       }
-      const text = stripAssistantMediaDirectivesForDisplay(
-        stripSuppressedControlReplyToken(contentBlock.text),
-        managedMedia.urls,
-      );
-      return text === contentBlock.text
-        ? sanitized
-        : { block: { ...contentBlock, text }, changed: true, truncated: sanitized.truncated };
-    });
-    if (updated.some((item) => item.changed)) {
-      entry.content = updated.map((item) => item.block);
+      truncated ||= sanitized.truncated;
+    }
+    if (updated) {
+      entry.content = updated;
       changed = true;
     }
-    truncated ||= updated.some((item) => item.truncated);
     if (entry.role === "assistant" && Array.isArray(entry.content)) {
       const mixedToolContent = projectAssistantMixedToolContent(entry.content, maxChars);
       if (mixedToolContent) {

--- a/ui/src/components/markdown-code-blocks.ts
+++ b/ui/src/components/markdown-code-blocks.ts
@@ -157,8 +157,10 @@ const codeBlockResizeObserver =
   typeof ResizeObserver === "undefined"
     ? null
     : new ResizeObserver((entries) => {
-        for (const entry of entries) {
-          const wrapper = entry.target.closest<HTMLElement>(".code-block-wrapper");
+        const wrappers = new Set(
+          entries.map(({ target }) => target.closest<HTMLElement>(".code-block-wrapper")),
+        );
+        for (const wrapper of wrappers) {
           if (wrapper) {
             updateCodeBlockWidthOverflow(wrapper);
           }
@@ -204,7 +206,10 @@ function scanMarkdownCodeBlocks(root: ParentNode): void {
     }
     observeCodeBlockNode(viewport);
     observeCodeBlockNode(code);
-    updateCodeBlockWidthOverflow(wrapper);
+    // The observer owns initial geometry too, after the browser lays out new blocks.
+    if (!codeBlockResizeObserver) {
+      updateCodeBlockWidthOverflow(wrapper);
+    }
   }
 }
 

--- a/ui/src/e2e/chat-code-block-fences.e2e.test.ts
+++ b/ui/src/e2e/chat-code-block-fences.e2e.test.ts
@@ -31,7 +31,7 @@ function fencedProse(language: "text" | "md" | "markdown"): string {
 
 const shortFence = `\`\`\`json
 {
-  "status": "ok",
+  "status": "${"ready-for-staging-".repeat(4)}",
   "items": [
     "alpha"
   ]
@@ -133,7 +133,7 @@ describeControlUiE2e("Control UI fenced code blocks", () => {
   });
 
   it.each(["dark", "light"] as const)(
-    "previews long fences, reveals them, and wraps overflowing lines in %s mode",
+    "keeps code controls correct through disclosure, resize, and virtual remount in %s mode",
     async (theme) => {
       const context = await browser.newContext({
         colorScheme: theme,
@@ -147,47 +147,53 @@ describeControlUiE2e("Control UI fenced code blocks", () => {
       const page = await context.newPage();
       await installMockGateway(page, {
         historyMessages: [
+          ...Array.from({ length: 40 }, (_, index) => ({
+            role: index % 2 === 0 ? "user" : "assistant",
+            content: [{ type: "text", text: `Earlier diagnostic turn ${index}` }],
+            timestamp: Date.now() - 40 + index,
+            __openclaw: { id: `earlier-diagnostic-${index}`, seq: index + 1 },
+          })),
           {
             role: "user",
             content: [{ type: "text", text: "Show the full diagnostic payload." }],
             timestamp: Date.now(),
-            __openclaw: { id: "user-fence-long", seq: 1 },
+            __openclaw: { id: "user-fence-long", seq: 41 },
           },
           {
             role: "assistant",
             content: [{ type: "text", text: fencedJson(41) }],
             timestamp: Date.now() + 1,
-            __openclaw: { id: "assistant-fence-long", seq: 2 },
+            __openclaw: { id: "assistant-fence-long", seq: 42 },
           },
           {
             role: "user",
             content: [{ type: "text", text: "Return the deployment receipt." }],
             timestamp: Date.now() + 2,
-            __openclaw: { id: "user-fence-short", seq: 3 },
+            __openclaw: { id: "user-fence-short", seq: 43 },
           },
           {
             role: "assistant",
             content: [{ type: "text", text: shortFence }],
             timestamp: Date.now() + 3,
-            __openclaw: { id: "assistant-fence-short", seq: 4 },
+            __openclaw: { id: "assistant-fence-short", seq: 44 },
           },
           {
             role: "user",
             content: [{ type: "text", text: "Show the launch command." }],
             timestamp: Date.now() + 4,
-            __openclaw: { id: "user-fence-wide", seq: 5 },
+            __openclaw: { id: "user-fence-wide", seq: 45 },
           },
           {
             role: "assistant",
             content: [{ type: "text", text: wideFence }],
             timestamp: Date.now() + 5,
-            __openclaw: { id: "assistant-fence-wide", seq: 6 },
+            __openclaw: { id: "assistant-fence-wide", seq: 46 },
           },
           ...(["text", "md", "markdown"] as const).map((language, index) => ({
             role: "assistant",
             content: [{ type: "text", text: fencedProse(language) }],
             timestamp: Date.now() + 6 + index,
-            __openclaw: { id: `assistant-fence-${language}`, seq: 7 + index },
+            __openclaw: { id: `assistant-fence-${language}`, seq: 47 + index },
           })),
         ],
       });
@@ -257,6 +263,31 @@ describeControlUiE2e("Control UI fenced code blocks", () => {
             () => document.documentElement.scrollWidth <= document.documentElement.clientWidth,
           ),
         ).toBe(true);
+
+        // Resize must update existing code controls without another chat message.
+        const shortWrapper = shortBubble.locator(".code-block-wrapper");
+        const shortWrap = shortWrapper.locator(".code-block-wrap");
+        await shortBubble.scrollIntoViewIfNeeded();
+        expect(await shortWrap.isVisible()).toBe(false);
+        await page.setViewportSize({ width: 560, height: 900 });
+        await shortBubble.scrollIntoViewIfNeeded();
+        await expect.poll(() => shortWrap.isVisible()).toBe(true);
+        await page.setViewportSize({ width: 1440, height: 900 });
+        await shortBubble.scrollIntoViewIfNeeded();
+        await expect.poll(() => shortWrap.isVisible()).toBe(false);
+
+        // Virtualization must initialize replacement DOM in an otherwise quiet transcript.
+        const thread = page.locator(".chat-thread");
+        // Focused rows stay mounted offscreen; move focus out of the wrap control first.
+        await page.locator(".agent-chat__composer-combobox textarea").click();
+        await thread.hover();
+        await page.mouse.wheel(0, -100_000);
+        await expect.poll(() => thread.evaluate((element) => element.scrollTop)).toBe(0);
+        await expect.poll(() => wideBubble.count()).toBe(0);
+        await page.mouse.wheel(0, 100_000);
+        await wideBubble.waitFor({ state: "visible" });
+        await expect.poll(() => wideWrapper.locator(".code-block-wrap").isVisible()).toBe(true);
+        expect(await shortWrapper.locator(".code-block-wrap").isVisible()).toBe(false);
       } finally {
         await context.close();
       }

--- a/ui/src/lib/chat/message-normalizer.sender-session.test.ts
+++ b/ui/src/lib/chat/message-normalizer.sender-session.test.ts
@@ -34,6 +34,20 @@ describe("message-normalizer senderSession", () => {
     },
   );
 
+  it("trims forwarded source fields and drops unrelated session metadata", () => {
+    expect(
+      normalizeMessage({
+        role: "assistant",
+        content: "Forwarded report",
+        senderSession: {
+          sessionKey: " agent:source:main ",
+          agentId: " source\t",
+          extra: "discarded",
+        },
+      }).senderSession,
+    ).toStrictEqual({ sessionKey: "agent:source:main", agentId: "source" });
+  });
+
   it("keeps a valid source agent when its source-session key is malformed", () => {
     expect(
       normalizeMessage({

--- a/ui/src/lib/chat/message-normalizer.test.ts
+++ b/ui/src/lib/chat/message-normalizer.test.ts
@@ -520,6 +520,68 @@ describe("message-normalizer", () => {
       ]);
     });
 
+    it.each(["audioAsVoice", "replyToCurrent"])(
+      "ignores the entire delivery record when %s has an invalid flag",
+      (field) => {
+        for (const value of [false, null, 0, "true"]) {
+          const result = normalizeMessage({
+            role: "assistant",
+            content: "The answer remains visible.",
+            openclawDelivery: {
+              audioAsVoice: true,
+              replyToCurrent: true,
+              replyToId: "target",
+              [field]: value,
+            },
+          });
+          expect(result.content).toEqual([{ type: "text", text: "The answer remains visible." }]);
+          expect(result).not.toHaveProperty("audioAsVoice");
+          expect(result).not.toHaveProperty("replyTarget");
+        }
+      },
+    );
+
+    it.each([Number.NaN, Infinity, -Infinity])(
+      "omits non-finite canvas and media dimensions: %s",
+      (value) => {
+        const result = normalizeMessage({
+          role: "assistant",
+          content: [
+            {
+              type: "canvas",
+              preview: {
+                kind: "canvas",
+                render: "url",
+                url: "/canvas/one",
+                preferredHeight: value,
+              },
+            },
+            {
+              type: "video",
+              url: "/media/clip",
+              sizeBytes: value,
+              durationMs: value,
+              width: value,
+              height: value,
+            },
+          ],
+        });
+        expect(result.content).toEqual([
+          {
+            type: "canvas",
+            preview: {
+              kind: "canvas",
+              surface: "assistant_message",
+              render: "url",
+              url: "/canvas/one",
+            },
+            rawText: null,
+          },
+          { type: "attachment", attachment: { kind: "video", url: "/media/clip", label: "Video" } },
+        ]);
+      },
+    );
+
     it("marks media-only audio attachments as voice notes from delivery facts", () => {
       const result = normalizeMessage({
         role: "assistant",

--- a/ui/src/lib/chat/message-normalizer.ts
+++ b/ui/src/lib/chat/message-normalizer.ts
@@ -3,7 +3,9 @@
  */
 
 import { mediaKindFromMime } from "@openclaw/media-core/constants";
-import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
+import { asOptionalRecord, readStringField } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { z } from "zod";
 import { stripInboundMetadata } from "../../../../src/auto-reply/reply/strip-inbound-meta.js";
 import {
@@ -31,29 +33,6 @@ const OPAQUE_ID_LABEL_SUFFIX_RE =
 
 const optionalMessageStringSchema = z.string().optional().catch(undefined);
 const optionalMessageNumberSchema = z.number().optional().catch(undefined);
-const rawMcpAppSchema = z
-  .looseObject({
-    viewId: optionalMessageStringSchema,
-    serverName: optionalMessageStringSchema,
-    toolName: optionalMessageStringSchema,
-    uiResourceUri: optionalMessageStringSchema,
-    toolCallId: optionalMessageStringSchema,
-    originSessionKey: optionalMessageStringSchema,
-  })
-  .optional()
-  .catch(undefined);
-const rawCanvasPreviewSchema = z
-  .looseObject({
-    title: optionalMessageStringSchema,
-    preferredHeight: optionalMessageNumberSchema,
-    url: optionalMessageStringSchema,
-    viewId: optionalMessageStringSchema,
-    className: optionalMessageStringSchema,
-    style: optionalMessageStringSchema,
-    mcpApp: rawMcpAppSchema,
-  })
-  .optional()
-  .catch(undefined);
 const rawAttachmentSchema = z
   .looseObject({
     code: optionalMessageStringSchema,
@@ -69,85 +48,39 @@ const rawAttachmentSchema = z
   })
   .optional()
   .catch(undefined);
-const rawAudioSourceSchema = z
-  .looseObject({
-    media_type: optionalMessageStringSchema,
-    data: optionalMessageStringSchema,
-    url: optionalMessageStringSchema,
-  })
-  .optional()
-  .catch(undefined);
-const rawContentBlockSchema = z.looseObject({
-  text: optionalMessageStringSchema,
-  source: rawAudioSourceSchema,
-  attachment: rawAttachmentSchema,
-  preview: rawCanvasPreviewSchema,
-  rawText: optionalMessageStringSchema,
-  label: optionalMessageStringSchema,
-  fileName: optionalMessageStringSchema,
-  mimeType: optionalMessageStringSchema,
-  artifactId: optionalMessageStringSchema,
-  url: optionalMessageStringSchema,
-  sizeBytes: optionalMessageNumberSchema,
-  durationMs: optionalMessageNumberSchema,
-  width: optionalMessageNumberSchema,
-  height: optionalMessageNumberSchema,
-});
-const rawContentBlocksSchema = z
-  .array(z.union([rawContentBlockSchema, z.unknown().transform(() => null)]))
-  .transform((items) =>
-    items.filter((item): item is z.infer<typeof rawContentBlockSchema> => item !== null),
-  );
-const rawOpenClawMetadataSchema = z
-  .looseObject({
-    replyToId: optionalMessageStringSchema,
-    replyToPreview: z
-      .object({
-        text: optionalMessageStringSchema,
-        senderLabel: optionalMessageStringSchema,
-      })
-      .optional()
-      .catch(undefined),
-  })
-  .optional()
-  .catch(undefined);
-const rawOpenClawDeliverySchema = z
-  .object({
-    audioAsVoice: z.literal(true).optional(),
-    replyToCurrent: z.literal(true).optional(),
-    replyToId: optionalMessageStringSchema,
-  })
-  .optional()
-  .catch(undefined);
-const rawMessageSchema = z
-  .looseObject({
-    role: optionalMessageStringSchema,
-    content: z.union([z.string(), rawContentBlocksSchema]).optional().catch(undefined),
-    text: optionalMessageStringSchema,
-    timestamp: optionalMessageNumberSchema,
-    id: optionalMessageStringSchema,
-    senderLabel: optionalMessageStringSchema,
-    senderSession: z
-      .object({
-        sessionKey: optionalMessageStringSchema.transform((value) => value?.trim() || undefined),
-        agentId: optionalMessageStringSchema.transform((value) => value?.trim() || undefined),
-      })
-      .refine((value) => Boolean(value.sessionKey || value.agentId))
-      .optional()
-      .catch(undefined),
-    toolCallId: optionalMessageStringSchema,
-    tool_call_id: optionalMessageStringSchema,
-    toolUseId: optionalMessageStringSchema,
-    tool_use_id: optionalMessageStringSchema,
-    toolName: optionalMessageStringSchema,
-    tool_name: optionalMessageStringSchema,
-    __openclaw: rawOpenClawMetadataSchema,
-    openclawDelivery: rawOpenClawDeliverySchema,
-  })
-  .catch({});
+type CanvasPreview = Extract<MessageContentItem, { type: "canvas" }>["preview"];
+type MessageDelivery = { audioAsVoice?: true; replyToCurrent?: true; replyToId?: string };
 
-type RawContentBlock = z.infer<typeof rawContentBlockSchema>;
-type RawCanvasPreview = z.infer<typeof rawCanvasPreviewSchema>;
+function readMessageDelivery(value: unknown): MessageDelivery | undefined {
+  const delivery = asOptionalRecord(value);
+  if (
+    !delivery ||
+    (delivery.audioAsVoice !== undefined && delivery.audioAsVoice !== true) ||
+    (delivery.replyToCurrent !== undefined && delivery.replyToCurrent !== true)
+  ) {
+    return undefined;
+  }
+  return {
+    audioAsVoice: delivery.audioAsVoice,
+    replyToCurrent: delivery.replyToCurrent,
+    replyToId: readStringField(delivery, "replyToId"),
+  };
+}
+
+function readSenderSession(value: unknown): NormalizedMessage["senderSession"] {
+  const source = asOptionalRecord(value);
+  if (!source) {
+    return undefined;
+  }
+  const sessionKey = normalizeOptionalString(source.sessionKey);
+  const agentId = normalizeOptionalString(source.agentId);
+  return sessionKey || agentId
+    ? {
+        ...("sessionKey" in source ? { sessionKey } : {}),
+        ...("agentId" in source ? { agentId } : {}),
+      }
+    : undefined;
+}
 
 export function normalizeRoleForGrouping(role: string): string {
   const lower = role.toLowerCase();
@@ -181,66 +114,47 @@ export function isStandaloneToolMessageForDisplay(message: unknown): boolean {
   );
 }
 
-function isTextContentBlock(
-  item: RawContentBlock,
-  role: string,
-): item is RawContentBlock & { text: string } {
-  return (
-    item.text !== undefined &&
-    (item.type === "text" ||
-      (role === "user" && item.type === "input_text") ||
-      (role === "assistant" && (item.type === "input_text" || item.type === "output_text")))
-  );
-}
-
-function coerceCanvasPreview(
-  preview: RawCanvasPreview,
-):
-  | Extract<NonNullable<NormalizedMessage["content"][number]>, { type: "canvas" }>["preview"]
-  | null {
-  if (!preview) {
+function coerceCanvasPreview(preview: Record<string, unknown>): CanvasPreview | null {
+  if (preview.kind !== "canvas" || preview.surface === "tool_card" || preview.render !== "url") {
     return null;
   }
-  if (preview.kind !== "canvas" || preview.surface === "tool_card") {
-    return null;
+  const result: CanvasPreview = { kind: "canvas", surface: "assistant_message", render: "url" };
+  for (const key of ["title", "url", "viewId", "className", "style"] as const) {
+    const value = readStringField(preview, key);
+    if (value !== undefined) {
+      result[key] = value;
+    }
   }
-  const render = preview.render === "url" ? "url" : null;
-  if (!render) {
-    return null;
+  const preferredHeight = asFiniteNumber(preview.preferredHeight);
+  if (preferredHeight !== undefined) {
+    result.preferredHeight = preferredHeight;
   }
-  const mcpApp = preview.mcpApp;
-  const boardWidgetName = isCanvasBoardWidgetName(preview.boardWidgetName)
-    ? preview.boardWidgetName
-    : undefined;
-  return {
-    kind: "canvas",
-    surface: "assistant_message",
-    render,
-    ...(preview.title !== undefined ? { title: preview.title } : {}),
-    ...(preview.preferredHeight !== undefined ? { preferredHeight: preview.preferredHeight } : {}),
-    ...(preview.url !== undefined ? { url: preview.url } : {}),
-    ...(preview.viewId !== undefined ? { viewId: preview.viewId } : {}),
-    ...(preview.className !== undefined ? { className: preview.className } : {}),
-    ...(preview.style !== undefined ? { style: preview.style } : {}),
-    ...(preview.sandbox === "strict" || preview.sandbox === "scripts"
-      ? { sandbox: preview.sandbox }
-      : {}),
-    ...(boardWidgetName ? { boardWidgetName } : {}),
-    ...(mcpApp?.viewId?.trim()
-      ? {
-          mcpApp: {
-            viewId: mcpApp.viewId,
-            ...(mcpApp.serverName !== undefined ? { serverName: mcpApp.serverName } : {}),
-            ...(mcpApp.toolName !== undefined ? { toolName: mcpApp.toolName } : {}),
-            ...(mcpApp.uiResourceUri !== undefined ? { uiResourceUri: mcpApp.uiResourceUri } : {}),
-            ...(mcpApp.toolCallId !== undefined ? { toolCallId: mcpApp.toolCallId } : {}),
-            ...(mcpApp.originSessionKey !== undefined
-              ? { originSessionKey: mcpApp.originSessionKey }
-              : {}),
-          },
-        }
-      : {}),
-  };
+  const sandbox = preview.sandbox;
+  if (sandbox === "strict" || sandbox === "scripts") {
+    result.sandbox = sandbox;
+  }
+  const boardWidgetName = preview.boardWidgetName;
+  if (isCanvasBoardWidgetName(boardWidgetName)) {
+    result.boardWidgetName = boardWidgetName;
+  }
+  const mcpApp = asOptionalRecord(preview.mcpApp);
+  const viewId = readStringField(mcpApp, "viewId");
+  if (viewId?.trim()) {
+    result.mcpApp = { viewId };
+    for (const key of [
+      "serverName",
+      "toolName",
+      "uiResourceUri",
+      "toolCallId",
+      "originSessionKey",
+    ] as const) {
+      const value = readStringField(mcpApp, key);
+      if (value !== undefined) {
+        result.mcpApp[key] = value;
+      }
+    }
+  }
+  return result;
 }
 
 const MIME_BY_EXT: Record<string, string> = {
@@ -302,20 +216,21 @@ function inferAttachmentKind(url: string): {
 }
 
 function coerceAudioContentBlock(
-  item: RawContentBlock,
+  item: Record<string, unknown>,
 ): Extract<MessageContentItem, { type: "attachment" }> | null {
   if (item.type !== "audio") {
     return null;
   }
-  const source = item.source;
+  const source = asOptionalRecord(item.source);
   if (!source) {
     return null;
   }
-  const mediaType = source.media_type?.trim().toLowerCase().startsWith("audio/")
-    ? source.media_type.trim()
-    : "audio/mpeg";
-  if (source.type === "base64" && source.data !== undefined) {
-    const data = source.data.trim();
+  const rawMediaType = readStringField(source, "media_type")?.trim();
+  const mediaType = rawMediaType?.toLowerCase().startsWith("audio/") ? rawMediaType : "audio/mpeg";
+  const type = source.type;
+  const rawData = readStringField(source, "data");
+  if (type === "base64" && rawData !== undefined) {
+    const data = rawData.trim();
     if (!data) {
       return null;
     }
@@ -325,14 +240,15 @@ function coerceAudioContentBlock(
       attachment: {
         url,
         kind: "audio",
-        label: item.label?.trim() || "Audio",
+        label: readStringField(item, "label")?.trim() || "Audio",
         mimeType: mediaType,
         ...(item.isVoiceNote === true ? { isVoiceNote: true } : {}),
       },
     };
   }
-  if (source.type === "url" && source.url !== undefined) {
-    const url = source.url.trim();
+  const rawUrl = readStringField(source, "url");
+  if (type === "url" && rawUrl !== undefined) {
+    const url = rawUrl.trim();
     if (!url) {
       return null;
     }
@@ -341,7 +257,7 @@ function coerceAudioContentBlock(
       attachment: {
         url,
         kind: "audio",
-        label: item.label?.trim() || "Audio",
+        label: readStringField(item, "label")?.trim() || "Audio",
         mimeType: mediaType,
         ...(item.isVoiceNote === true ? { isVoiceNote: true } : {}),
       },
@@ -351,42 +267,42 @@ function coerceAudioContentBlock(
 }
 
 function coerceManagedMediaContentBlock(
-  item: RawContentBlock,
+  item: Record<string, unknown>,
 ): Extract<MessageContentItem, { type: "attachment" }> | null {
-  if ((item.type !== "audio" && item.type !== "video") || item.url === undefined) {
-    return null;
-  }
-  const url = item.url.trim();
-  if (!url) {
-    return null;
-  }
   const kind = item.type;
-  const fallbackLabel = kind === "audio" ? "Audio" : "Video";
-  const label = item.fileName?.trim() || item.label?.trim() || fallbackLabel;
-  return {
-    type: "attachment",
-    attachment: {
-      url,
-      kind,
-      label,
-      ...(item.mimeType !== undefined ? { mimeType: item.mimeType } : {}),
-      ...(item.artifactId !== undefined ? { artifactId: item.artifactId } : {}),
-      ...(kind === "audio" && item.isVoiceNote === true ? { isVoiceNote: true } : {}),
-      ...(item.playback === "native" || item.playback === "transcode"
-        ? { playback: item.playback }
-        : {}),
-      ...(item.sizeBytes !== undefined && item.sizeBytes >= 0 ? { sizeBytes: item.sizeBytes } : {}),
-      ...(item.durationMs !== undefined && item.durationMs >= 0
-        ? { durationMs: item.durationMs }
-        : {}),
-      ...(kind === "video" && item.width !== undefined && item.width > 0
-        ? { width: item.width }
-        : {}),
-      ...(kind === "video" && item.height !== undefined && item.height > 0
-        ? { height: item.height }
-        : {}),
-    },
+  const url = readStringField(item, "url")?.trim();
+  if ((kind !== "audio" && kind !== "video") || !url) {
+    return null;
+  }
+  const attachment: Extract<MessageContentItem, { type: "attachment" }>["attachment"] = {
+    url,
+    kind,
+    label:
+      readStringField(item, "fileName")?.trim() ||
+      readStringField(item, "label")?.trim() ||
+      (kind === "audio" ? "Audio" : "Video"),
   };
+  for (const key of ["mimeType", "artifactId"] as const) {
+    const value = readStringField(item, key);
+    if (value !== undefined) {
+      attachment[key] = value;
+    }
+  }
+  if (kind === "audio" && item.isVoiceNote === true) {
+    attachment.isVoiceNote = true;
+  }
+  const playback = item.playback;
+  if (playback === "native" || playback === "transcode") {
+    attachment.playback = playback;
+  }
+  for (const key of ["sizeBytes", "durationMs", "width", "height"] as const) {
+    const value = asFiniteNumber(item[key]);
+    const dimension = key === "width" || key === "height";
+    if (value !== undefined && (dimension ? kind === "video" && value > 0 : value >= 0)) {
+      attachment[key] = value;
+    }
+  }
+  return { type: "attachment", attachment };
 }
 
 function mergeAdjacentTextItems(items: MessageContentItem[]): MessageContentItem[] {
@@ -419,7 +335,7 @@ function stripMessageDisplayMetadata(items: MessageContentItem[]): MessageConten
 
 function expandTextContent(
   text: string,
-  delivery: z.infer<typeof rawOpenClawDeliverySchema>,
+  delivery: MessageDelivery | undefined,
 ): {
   content: MessageContentItem[];
   audioAsVoice: boolean;
@@ -500,31 +416,32 @@ function expandTextContent(
  * Normalize a raw message object into a consistent structure.
  */
 export function normalizeMessage(message: unknown): NormalizedMessage {
-  const m = rawMessageSchema.parse(message);
-  let role = m.role ?? "unknown";
+  const m = asOptionalRecord(message) ?? {};
+  let role = readStringField(m, "role") ?? "unknown";
 
   // Detect tool messages by common gateway shapes.
   // Some tool events come through as assistant role with tool_* items in the content array.
   const hasToolId =
-    m.toolCallId !== undefined ||
-    m.tool_call_id !== undefined ||
-    m.toolUseId !== undefined ||
-    m.tool_use_id !== undefined;
+    typeof m.toolCallId === "string" ||
+    typeof m.tool_call_id === "string" ||
+    typeof m.toolUseId === "string" ||
+    typeof m.tool_use_id === "string";
 
   const contentRaw = m.content;
   const contentItems = Array.isArray(contentRaw) ? contentRaw : null;
   const hasToolContent =
-    contentItems?.some(
-      (item) => isToolResultContentType(item.type) || isToolCallContentType(item.type),
-    ) ?? false;
+    contentItems?.some((value) => {
+      const type = asOptionalRecord(value)?.type;
+      return isToolResultContentType(type) || isToolCallContentType(type);
+    }) ?? false;
 
-  const hasToolName = m.toolName !== undefined || m.tool_name !== undefined;
+  const hasToolName = typeof m.toolName === "string" || typeof m.tool_name === "string";
 
   if (hasToolId || hasToolContent || hasToolName) {
     role = "toolResult";
   }
   const isAssistantMessage = role === "assistant";
-  const delivery = isAssistantMessage ? m.openclawDelivery : undefined;
+  const delivery = isAssistantMessage ? readMessageDelivery(m.openclawDelivery) : undefined;
 
   // Extract content
   let content: MessageContentItem[] = [];
@@ -541,7 +458,13 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
       content = [{ type: "text", text: m.content }];
     }
   } else if (contentItems) {
-    content = contentItems.flatMap((item) => {
+    content = contentItems.flatMap((value) => {
+      const item = asOptionalRecord(value);
+      if (!item) {
+        return [];
+      }
+      const type = item.type;
+      const text = readStringField(item, "text");
       if (isAssistantMessage) {
         const managedMediaAttachment = coerceManagedMediaContentBlock(item);
         if (managedMediaAttachment) {
@@ -551,15 +474,20 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
         if (audioAttachment) {
           return [audioAttachment];
         }
-      } else if (item.type === "audio") {
+      } else if (type === "audio") {
         return [];
       }
-      const attachmentContent = normalizeAttachmentContentBlock(item);
-      if (attachmentContent) {
-        return attachmentContent;
+      if (type === "attachment" || type === "attachment_error") {
+        return (
+          normalizeAttachmentContentBlock({
+            type,
+            attachment: rawAttachmentSchema.parse(item.attachment),
+          }) ?? []
+        );
       }
-      if (item.type === "canvas" && item.preview) {
-        const preview = coerceCanvasPreview(item.preview);
+      const rawPreview = type === "canvas" ? asOptionalRecord(item.preview) : undefined;
+      if (rawPreview) {
+        const preview = coerceCanvasPreview(rawPreview);
         if (!preview) {
           return [];
         }
@@ -567,13 +495,18 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
           {
             type: "canvas" as const,
             preview,
-            rawText: item.rawText ?? null,
+            rawText: readStringField(item, "rawText") ?? null,
           },
         ];
       }
-      if (isTextContentBlock(item, role)) {
+      if (
+        text !== undefined &&
+        (type === "text" ||
+          (role === "user" && type === "input_text") ||
+          (role === "assistant" && (type === "input_text" || type === "output_text")))
+      ) {
         if (isAssistantMessage) {
-          const expanded = expandTextContent(item.text, delivery);
+          const expanded = expandTextContent(text, delivery);
           audioAsVoice = audioAsVoice || expanded.audioAsVoice;
           if (expanded.replyTarget?.kind === "id") {
             replyTarget = expanded.replyTarget;
@@ -585,7 +518,7 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
         return [
           {
             type: "text" as const,
-            text: item.text,
+            text,
             name: undefined,
             args: undefined,
           },
@@ -594,17 +527,17 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
       return [
         {
           type:
-            (item.type as Extract<
+            (type as Extract<
               MessageContentItem,
               { type: "text" | "tool_call" | "tool_result" }
             >["type"]) || "text",
-          text: item.text as string | undefined,
+          text,
           name: item.name as string | undefined,
           args: resolveToolBlockArgs(item),
         },
       ];
     });
-  } else if (m.text !== undefined) {
+  } else if (typeof m.text === "string") {
     if (isAssistantMessage) {
       const expanded = expandTextContent(m.text, delivery);
       content = expanded.content;
@@ -615,16 +548,16 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
     }
   }
 
-  const timestamp = m.timestamp ?? Date.now();
-  const id = m.id;
-  const openClawMeta = m["__openclaw"];
-  const structuredReplyToId = openClawMeta?.replyToId?.trim() ?? "";
+  const timestamp = asFiniteNumber(m.timestamp) ?? Date.now();
+  const id = readStringField(m, "id");
+  const openClawMeta = asOptionalRecord(m["__openclaw"]);
+  const structuredReplyToId = readStringField(openClawMeta, "replyToId")?.trim() ?? "";
   if (structuredReplyToId) {
     replyTarget = { kind: "id", id: structuredReplyToId };
   }
-  const replyPreviewRecord = openClawMeta?.replyToPreview;
-  const replyPreviewText = replyPreviewRecord?.text?.trim() ?? "";
-  const replyPreviewSender = replyPreviewRecord?.senderLabel?.trim() ?? "";
+  const replyPreviewRecord = asOptionalRecord(openClawMeta?.replyToPreview);
+  const replyPreviewText = readStringField(replyPreviewRecord, "text")?.trim() ?? "";
+  const replyPreviewSender = readStringField(replyPreviewRecord, "senderLabel")?.trim() ?? "";
   const identity = readTranscriptSenderIdentity(openClawMeta?.senderIdentity);
   const metaSender = normalizeSenderIdentity({
     identity,
@@ -634,13 +567,14 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
     profileAvatarUrl:
       identity?.type === "profile" ? openClawMeta?.senderProfileAvatarUrl : undefined,
   });
-  const rawLabel = m.senderLabel?.trim() ?? "";
+  const rawLabel = readStringField(m, "senderLabel")?.trim() ?? "";
   const senderLabel = rawLabel
     ? rawLabel.replace(OPAQUE_ID_LABEL_SUFFIX_RE, "").trim()
     : formatSenderLabel(metaSender);
   const sender = metaSender ?? (senderLabel ? { name: senderLabel } : null);
 
   content = stripMessageDisplayMetadata(content);
+  const senderSession = readSenderSession(m.senderSession);
 
   return {
     role,
@@ -648,7 +582,7 @@ export function normalizeMessage(message: unknown): NormalizedMessage {
     timestamp,
     id,
     senderLabel,
-    ...(m.senderSession ? { senderSession: m.senderSession } : {}),
+    ...(senderSession ? { senderSession } : {}),
     ...(sender ? { sender } : {}),
     ...(audioAsVoice ? { audioAsVoice: true } : {}),
     ...(replyPreviewText


### PR DESCRIPTION
## What Problem This Solves

Long Control UI histories spend unnecessary time preparing messages and measuring code blocks, making initial loads and older-page prepends less responsive.

Related: #133798.

## Why This Change Was Made

Normalize fields where their content variant consumes them, instead of parsing and copying every optional media/canvas field for ordinary text. Keep attachment validation in its branch, finite-number checks, whole-record delivery validation, sender attribution, tool classification, and mutable-input behavior.

The existing ResizeObserver owns initial code-block sizing and deduplicates notifications for the same wrapper. Gateway projection skips schema work for absent sender identities and copies content arrays only when the sanitizer records a change. This removes repeated work at its owners without adding another cache or scheduler.

## User Impact

History loads and prepends become faster at the existing 800-message initial and 1,000-message older-page limits. Message content, sender labels, media, code controls, virtualized rows, and scroll anchoring retain their behavior.

## Evidence

Paired production-bundle Chromium 144 runs on one clean Linux Testbox, with synthetic Gateway responses, a 1280×800 viewport, and five fresh contexts per cell. Initial sizes rotate; the full matrix contains 100 samples. Browser latency excludes Gateway execution and network latency.

| Measurement | Before median | After median | Reduction |
| --- | ---: | ---: | ---: |
| Initial 800 paint, normal CPU | 233.3 ms | 198.3 ms | 15.0% |
| Prepend 1,000 paint, normal CPU | 212.7 ms | 132.5 ms | 37.7% |
| Initial 800 long tasks, 4× CPU | 1,119 ms | 712 ms | 36.4% |
| Prepend 1,000 long tasks, 4× CPU | 1,123 ms | 607 ms | 45.9% |

The long-task rows use a separate 30-sample focused run that releases the response in a new task after observation starts. Original-source and candidate-source hashes were verified explicitly; the original harness's long-task filter omitted the response-triggering task. Compare within each paired run: scheduling boundaries and between-run variation differ. Normal-CPU scrolling is essentially unchanged, and these synthetic medians do not establish statistical significance.

Mapped 4× CPU profiles attribute normalization inclusive samples of 185.2→50.9 ms for initial 800 and 390.3→88.4 ms for prepend 1,000. Initial code-block overflow measurement's 59.8 ms self hotspot no longer appears in the candidate profile. These are sampled CPU captures, not per-frame latency. Prepend anchor drift remains 1.875 px, and rendered rows remain bounded at seven initially, 15 after prepend, and 13 while scrolling.

Node inspector runs cover seven real isolated SQLite fixtures of 3,000 messages, five warmups and 30 rotated rounds across four page sizes/positions. All 28 complete output pages (22,400 messages) match after normalizing only each database-specific transcript source identity. Server medians are mixed/small; no general server-wide latency gain is claimed.

- 122 focused UI tests and 84 focused Gateway tests passed; four real-Chromium lifecycle cases cover streaming, dark/light resize, virtual eviction/remount, and focused-row retention.
- 3,311 normalization fixtures plus an in-place mutation check, 3,062 sender identity cases, and 14,760 sanitizer/full-projection differential comparisons passed. The sanitizer corpus passed again after the final equivalent record-guard cleanup.
- Fresh independent Codex autoreview of the final eight-file candidate is scoped-clean at the configured P0 threshold. [ClawSweeper reviewed the same head](https://github.com/openclaw/openclaw/pull/133870#issuecomment-5474657998) with no correctness/security findings or requested mechanical changes; its remaining step is normal maintainer landing after exact-head CI.
- Production build and clean-dependency core/UI type checks passed. Changed-file source/style lint, assertion safety, unused exports, storage/media/sidecar, import-cycle, auth/webhook, and other completed changed guards passed.
- The local aggregate check stops at six logger-type errors in unchanged `src/logging/logger.ts` with the shared dependency install. Clean-dependency core/UI type checks passed; the shared install was left intact. [Exact-head hosted CI passed](https://github.com/openclaw/openclaw/actions/runs/33364246472), including UI, browser E2E, real-Gateway E2E, and core shards, without retries.

[Prepared Testbox run](https://github.com/openclaw/openclaw/actions/runs/33361078318). The task-owned lease is stopped and verified completed. Performance captures precede only an equivalent Gateway record-guard simplification and a test literal style fix; the browser production code is unchanged.

Production: +203/-260, net **−57 lines**. Tests: +116/-9, net **+107**. Two assertion-baseline allowances shrink. No dependency, config, storage/schema, default-limit, or protocol change. The root changelog is release-owned.

Further measured candidates are recorded for separate work: saved-reader restoration renders, carrying prepared transcript projection facts through the build owner, and separating semantic projection from late text bounding while preserving TTS/forwarding ordering.

### Before and after

The inspected synthetic initial-800 captures are byte-identical to each other and to this already-published asset. The appearance is preserved; the timing/profile results above demonstrate the improvement.

Before:

![Initial 800 before optimization](https://github.com/user-attachments/assets/3be2ff4b-9f8a-4526-a225-f1a570429e23)

After:

![Initial 800 after optimization](https://github.com/user-attachments/assets/3be2ff4b-9f8a-4526-a225-f1a570429e23)
