### PR TITLE
fix(channels): treat restart drain as ingress idle

### DIFF
--- a/src/channels/message/ingress-monitor.restart-drain.test.ts
+++ b/src/channels/message/ingress-monitor.restart-drain.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import * as gatewayWorkAdmission from "../../process/gateway-work-admission.js";
 import {
+  beginGatewayRestartSignalAdmission,
   markGatewayRestartDraining,
   resetGatewayWorkAdmission,
 } from "../../process/gateway-work-admission.js";
@@ -122,6 +123,31 @@ describe("channel ingress monitor restart drain idle", () => {
       ]);
       expect(result).toBe("idle");
       expect(prune).toHaveBeenCalledTimes(pruneCallsAfterIdle);
+      await monitor.stop();
+    });
+  });
+
+  it("keeps waitForIdle pending through a rolled-back restart signal fence", async () => {
+    await withQueue(async (queue) => {
+      const monitor = createMonitor(queue);
+      monitor.start();
+      await monitor.waitForIdle();
+
+      const lease = beginGatewayRestartSignalAdmission();
+      expect(lease).not.toBeNull();
+      monitor.requestDrain();
+
+      const idle = monitor.waitForIdle();
+      const beforeRollback = await Promise.race([
+        idle.then(() => "idle" as const),
+        new Promise<"pending">((resolve) => {
+          setTimeout(() => resolve("pending"), 80);
+        }),
+      ]);
+      expect(beforeRollback).toBe("pending");
+
+      expect(lease?.rollback()).toBe(true);
+      await expect(idle).resolves.toBeUndefined();
       await monitor.stop();
     });
   });

--- a/src/channels/message/ingress-monitor.restart-drain.test.ts
+++ b/src/channels/message/ingress-monitor.restart-drain.test.ts
@@ -1,15 +1,26 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { afterEach, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import * as gatewayWorkAdmission from "../../process/gateway-work-admission.js";
 import {
   beginGatewayRestartSignalAdmission,
   markGatewayRestartDraining,
   resetGatewayWorkAdmission,
 } from "../../process/gateway-work-admission.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { createChannelIngressMonitor } from "./ingress-monitor.js";
+import {
+  createChannelIngressMonitor,
+  type ChannelIngressMonitorLifecycle,
+} from "./ingress-monitor.js";
 import { createChannelIngressQueue, type ChannelIngressQueue } from "./ingress-queue.js";
 
+type RestartDrainProof = {
+  restart: string;
+  committed: boolean;
+  idleMs: number;
+  finalActivity: boolean;
+  exitCode: number;
+};
 type RawEvent = { id: string; lane: string; text: string };
 type StoredEvent = { version: 1; rawEvent: string };
 
@@ -18,23 +29,21 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 afterEach(() => {
   resetGatewayWorkAdmission();
   closeOpenClawStateDatabaseForTest();
-  vi.restoreAllMocks();
 });
 
-async function withQueue<T>(
-  run: (queue: ChannelIngressQueue<StoredEvent>) => Promise<T>,
-): Promise<T> {
-  const stateDir = tempDirs.make("openclaw-ingress-monitor-restart-drain-");
-  try {
-    return await run(
-      createChannelIngressQueue<StoredEvent>({ channelId: "test", accountId: "a", stateDir }),
-    );
-  } finally {
-    closeOpenClawStateDatabaseForTest();
-  }
+async function withQueue(
+  run: (queue: ChannelIngressQueue<StoredEvent>) => Promise<void>,
+): Promise<void> {
+  const stateDir = tempDirs.make("openclaw-ingress-restart-lifecycle-");
+  await run(createChannelIngressQueue({ channelId: "test", accountId: "a", stateDir }));
 }
 
-function createMonitor(queue: ChannelIngressQueue<StoredEvent>) {
+function createMonitor(
+  queue: ChannelIngressQueue<StoredEvent>,
+  deliver: (raw: RawEvent, lifecycle: ChannelIngressMonitorLifecycle) => Promise<void>,
+  onActivityChange?: (active: boolean) => void,
+  runPumpTask?: (work: () => Promise<void>) => Promise<void>,
+) {
   return createChannelIngressMonitor<RawEvent, string, StoredEvent>({
     queue,
     inspect: (raw) => ({ eventId: raw.id, laneKey: `lane:${raw.lane}` }),
@@ -45,7 +54,7 @@ function createMonitor(queue: ChannelIngressQueue<StoredEvent>) {
       deserialize: (body) => JSON.parse(body) as RawEvent,
       createClaimError: (kind) => new Error(kind),
     },
-    deliver: vi.fn(),
+    deliver,
     pollIntervalMs: 60_000,
     retention: { pruneIntervalMs: 60_000 },
     drain: {
@@ -53,102 +62,178 @@ function createMonitor(queue: ChannelIngressQueue<StoredEvent>) {
       retryPolicy: { baseMs: 1_000, maxMs: 1_000 },
       resolveNonRetryableFailure: () => null,
     },
+    ...(onActivityChange ? { onActivityChange } : {}),
+    ...(runPumpTask ? { runPumpTask } : {}),
   });
 }
 
-describe("channel ingress monitor restart drain idle", () => {
-  it("resolves waitForIdle when restart drain leaves a queued request latched", async () => {
-    await withQueue(async (queue) => {
-      let markPruneStarted = () => {};
-      const pruneStarted = new Promise<void>((resolve) => {
-        markPruneStarted = resolve;
-      });
-      let releasePrune: (error?: Error) => void = () => {};
-      const pruneGate = new Promise<void>((resolve, reject) => {
-        releasePrune = (error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        };
-      });
-      const prune = queue.prune.bind(queue);
-      queue.prune = async (...args) => {
-        markPruneStarted();
-        await pruneGate;
-        return await prune(...args);
-      };
-      const isRestartDraining = vi
-        .spyOn(gatewayWorkAdmission, "isGatewayRestartDraining")
-        .mockReturnValue(false);
-      const monitor = createMonitor(queue);
-      monitor.start();
-      await pruneStarted;
-
-      monitor.requestDrain();
-      isRestartDraining.mockReturnValue(true);
-      markGatewayRestartDraining();
-      releasePrune(new Error("restart drain interrupted prune"));
-      await monitor.waitForPumpIdle();
-
-      const result = await Promise.race([
-        monitor.waitForIdle().then(() => "idle" as const),
-        new Promise<"timeout">((resolve) => {
-          setTimeout(() => resolve("timeout"), 200);
-        }),
-      ]);
-      expect(result).toBe("idle");
-      await monitor.stop();
+function runRestartDrainFixture(stateDir: string): Promise<RestartDrainProof> {
+  return new Promise((resolve, reject) => {
+    const fixture = fileURLToPath(
+      new URL("../../../test/fixtures/channel-ingress-gateway-restart.ts", import.meta.url),
+    );
+    const child = spawn(process.execPath, ["--import", "tsx", fixture, stateDir], {
+      cwd: process.cwd(),
+      env: { ...process.env, TMPDIR: stateDir },
+      stdio: ["ignore", "ignore", "pipe", "ipc"],
+    });
+    const childStderr = child.stderr;
+    if (!childStderr) {
+      child.kill();
+      reject(new Error("Gateway restart fixture stderr pipe was not created"));
+      return;
+    }
+    let proof: RestartDrainProof | undefined;
+    let failure: Error | undefined;
+    let stderr = "";
+    let idleTimer: ReturnType<typeof setTimeout> | undefined;
+    const startupTimer = setTimeout(() => {
+      failure = new Error("Gateway restart fixture did not commit drain within 30 seconds");
+      child.kill();
+    }, 30_000);
+    childStderr.setEncoding("utf8");
+    childStderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("message", (message: unknown) => {
+      if (!message || typeof message !== "object" || !("type" in message)) {
+        return;
+      }
+      if (message.type === "ingress-restart-drain-committed") {
+        clearTimeout(startupTimer);
+        idleTimer = setTimeout(() => {
+          failure = new Error("Ingress did not become idle within 3 seconds of restart drain");
+          child.kill();
+        }, 3_000);
+        return;
+      }
+      if (message.type === "ingress-restart-proof" && "proof" in message) {
+        proof = message.proof as RestartDrainProof;
+      }
+    });
+    child.on("error", (error) => {
+      failure = error;
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(startupTimer);
+      clearTimeout(idleTimer);
+      if (failure) {
+        reject(failure);
+        return;
+      }
+      if (code !== 0 || !proof) {
+        reject(
+          new Error(
+            `Gateway restart fixture failed: code=${String(code)} signal=${String(signal)} stderr=${stderr}`,
+          ),
+        );
+        return;
+      }
+      resolve(proof);
     });
   });
+}
 
-  it("does not start a pump when requestDrain sees restart drain", async () => {
-    await withQueue(async (queue) => {
-      const prune = vi.spyOn(queue, "prune");
-      const monitor = createMonitor(queue);
-      monitor.start();
-      await monitor.waitForIdle();
-      const pruneCallsAfterIdle = prune.mock.calls.length;
-
-      vi.spyOn(gatewayWorkAdmission, "isGatewayRestartDraining").mockReturnValue(true);
-      markGatewayRestartDraining();
-      monitor.requestDrain();
-
-      const result = await Promise.race([
-        monitor.waitForIdle().then(() => "idle" as const),
-        new Promise<"timeout">((resolve) => {
-          setTimeout(() => resolve("timeout"), 200);
-        }),
-      ]);
-      expect(result).toBe("idle");
-      expect(prune).toHaveBeenCalledTimes(pruneCallsAfterIdle);
-      await monitor.stop();
-    });
+it("reaches ingress idle after the Gateway commits restart drain", async () => {
+  const stateDir = tempDirs.make("openclaw-ingress-gateway-restart-");
+  const proof = await runRestartDrainFixture(stateDir);
+  expect(proof).toMatchObject({
+    restart: "emitted",
+    committed: true,
+    finalActivity: false,
+    exitCode: 0,
   });
+  expect(proof.idleMs).toBeLessThan(1_000);
+}, 40_000);
 
-  it("keeps waitForIdle pending through a rolled-back restart signal fence", async () => {
-    await withQueue(async (queue) => {
-      const monitor = createMonitor(queue);
+it("rearms queued ingress after a restart signal rolls back without an idle observer", async () => {
+  await withQueue(async (queue) => {
+    const deliver = vi.fn(async (_raw: RawEvent, lifecycle: ChannelIngressMonitorLifecycle) => {
+      await lifecycle.onAdopted();
+    });
+    const monitor = createMonitor(queue, deliver);
+    let signal: ReturnType<typeof beginGatewayRestartSignalAdmission> = null;
+    try {
       monitor.start();
       await monitor.waitForIdle();
+      signal = beginGatewayRestartSignalAdmission();
+      expect(signal).not.toBeNull();
+      await monitor.admit({ id: "event-signal-rollback", lane: "a", text: "deliver me" });
+      expect(deliver).not.toHaveBeenCalled();
 
-      const lease = beginGatewayRestartSignalAdmission();
-      expect(lease).not.toBeNull();
-      monitor.requestDrain();
-
-      const idle = monitor.waitForIdle();
-      const beforeRollback = await Promise.race([
-        idle.then(() => "idle" as const),
-        new Promise<"pending">((resolve) => {
-          setTimeout(() => resolve("pending"), 80);
-        }),
-      ]);
-      expect(beforeRollback).toBe("pending");
-
-      expect(lease?.rollback()).toBe(true);
-      await expect(idle).resolves.toBeUndefined();
+      expect(signal?.rollback()).toBe(true);
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledOnce());
+    } finally {
+      signal?.rollback();
       await monitor.stop();
+    }
+  });
+});
+
+it("clears activity when a restart signal commits to one-way drain", async () => {
+  await withQueue(async (queue) => {
+    const activity: boolean[] = [];
+    const monitor = createMonitor(
+      queue,
+      async () => {},
+      (active) => activity.push(active),
+    );
+    try {
+      monitor.start();
+      await monitor.waitForIdle();
+      activity.length = 0;
+
+      expect(beginGatewayRestartSignalAdmission()).not.toBeNull();
+      monitor.requestDrain();
+      expect(activity.at(-1)).toBe(true);
+
+      markGatewayRestartDraining();
+      await monitor.waitForIdle();
+      expect(activity.at(-1)).toBe(false);
+    } finally {
+      await monitor.stop();
+    }
+  });
+});
+
+it.each(["pause", "stop"] as const)(
+  "releases idle waiters when %s ends a restart fence wait",
+  async (action) => {
+    await withQueue(async (queue) => {
+      const monitor = createMonitor(queue, async () => {});
+      let signal: ReturnType<typeof beginGatewayRestartSignalAdmission> = null;
+      try {
+        monitor.start();
+        await monitor.waitForIdle();
+        signal = beginGatewayRestartSignalAdmission();
+        expect(signal).not.toBeNull();
+        monitor.requestDrain();
+        const idle = monitor.waitForIdle();
+
+        await monitor[action]();
+        await expect(idle).resolves.toBeUndefined();
+      } finally {
+        signal?.rollback();
+        await monitor.stop();
+      }
     });
+  },
+);
+
+it("propagates a rejected pump wrapper without spinning idle or stop waits", async () => {
+  await withQueue(async (queue) => {
+    const rejection = new Error("pump wrapper rejected");
+    const monitor = createMonitor(
+      queue,
+      async () => {},
+      undefined,
+      async () => {
+        throw rejection;
+      },
+    );
+    monitor.start();
+
+    await expect(monitor.waitForIdle()).rejects.toBe(rejection);
+    await expect(monitor.stop()).rejects.toBe(rejection);
   });
 });

--- a/src/channels/message/ingress-monitor.restart-drain.test.ts
+++ b/src/channels/message/ingress-monitor.restart-drain.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import * as gatewayWorkAdmission from "../../process/gateway-work-admission.js";
+import {
+  markGatewayRestartDraining,
+  resetGatewayWorkAdmission,
+} from "../../process/gateway-work-admission.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { createChannelIngressMonitor } from "./ingress-monitor.js";
+import { createChannelIngressQueue, type ChannelIngressQueue } from "./ingress-queue.js";
+
+type RawEvent = { id: string; lane: string; text: string };
+type StoredEvent = { version: 1; rawEvent: string };
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  resetGatewayWorkAdmission();
+  closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
+});
+
+async function withQueue<T>(
+  run: (queue: ChannelIngressQueue<StoredEvent>) => Promise<T>,
+): Promise<T> {
+  const stateDir = tempDirs.make("openclaw-ingress-monitor-restart-drain-");
+  try {
+    return await run(
+      createChannelIngressQueue<StoredEvent>({ channelId: "test", accountId: "a", stateDir }),
+    );
+  } finally {
+    closeOpenClawStateDatabaseForTest();
+  }
+}
+
+function createMonitor(queue: ChannelIngressQueue<StoredEvent>) {
+  return createChannelIngressMonitor<RawEvent, string, StoredEvent>({
+    queue,
+    inspect: (raw) => ({ eventId: raw.id, laneKey: `lane:${raw.lane}` }),
+    payload: {
+      storage: "raw-event",
+      version: 1,
+      serialize: (raw) => JSON.stringify(raw),
+      deserialize: (body) => JSON.parse(body) as RawEvent,
+      createClaimError: (kind) => new Error(kind),
+    },
+    deliver: vi.fn(),
+    pollIntervalMs: 60_000,
+    retention: { pruneIntervalMs: 60_000 },
+    drain: {
+      adoptionStallTimeoutMs: 5_000,
+      retryPolicy: { baseMs: 1_000, maxMs: 1_000 },
+      resolveNonRetryableFailure: () => null,
+    },
+  });
+}
+
+describe("channel ingress monitor restart drain idle", () => {
+  it("resolves waitForIdle when restart drain leaves a queued request latched", async () => {
+    await withQueue(async (queue) => {
+      let markPruneStarted = () => {};
+      const pruneStarted = new Promise<void>((resolve) => {
+        markPruneStarted = resolve;
+      });
+      let releasePrune: (error?: Error) => void = () => {};
+      const pruneGate = new Promise<void>((resolve, reject) => {
+        releasePrune = (error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        };
+      });
+      const prune = queue.prune.bind(queue);
+      queue.prune = async (...args) => {
+        markPruneStarted();
+        await pruneGate;
+        return await prune(...args);
+      };
+      const isRestartDraining = vi
+        .spyOn(gatewayWorkAdmission, "isGatewayRestartDraining")
+        .mockReturnValue(false);
+      const monitor = createMonitor(queue);
+      monitor.start();
+      await pruneStarted;
+
+      monitor.requestDrain();
+      isRestartDraining.mockReturnValue(true);
+      markGatewayRestartDraining();
+      releasePrune(new Error("restart drain interrupted prune"));
+      await monitor.waitForPumpIdle();
+
+      const result = await Promise.race([
+        monitor.waitForIdle().then(() => "idle" as const),
+        new Promise<"timeout">((resolve) => {
+          setTimeout(() => resolve("timeout"), 200);
+        }),
+      ]);
+      expect(result).toBe("idle");
+      await monitor.stop();
+    });
+  });
+
+  it("does not start a pump when requestDrain sees restart drain", async () => {
+    await withQueue(async (queue) => {
+      const prune = vi.spyOn(queue, "prune");
+      const monitor = createMonitor(queue);
+      monitor.start();
+      await monitor.waitForIdle();
+      const pruneCallsAfterIdle = prune.mock.calls.length;
+
+      vi.spyOn(gatewayWorkAdmission, "isGatewayRestartDraining").mockReturnValue(true);
+      markGatewayRestartDraining();
+      monitor.requestDrain();
+
+      const result = await Promise.race([
+        monitor.waitForIdle().then(() => "idle" as const),
+        new Promise<"timeout">((resolve) => {
+          setTimeout(() => resolve("timeout"), 200);
+        }),
+      ]);
+      expect(result).toBe("idle");
+      expect(prune).toHaveBeenCalledTimes(pruneCallsAfterIdle);
+      await monitor.stop();
+    });
+  });
+});

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -1,6 +1,10 @@
 /** Shared durable channel-ingress admission, pump, retention, and shutdown lifecycle. */
 import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
-import { isGatewayRestartDraining } from "../../process/gateway-work-admission.js";
+import {
+  isGatewayRestartDrainCommitted,
+  isGatewayRestartDraining,
+  waitForGatewayRestartFenceSettlement,
+} from "../../process/gateway-work-admission.js";
 import { sleep } from "../../utils/sleep.js";
 import {
   createChannelIngressDrain,
@@ -533,10 +537,17 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
   };
 
   const requestDrain = (): void => {
-    if (!running || isAborted() || isGatewayRestartDraining()) {
-      // Restart drain must not leave requested latched, or waitForIdle
-      // busy-spins on already-resolved awaits.
+    if (!running || isAborted() || isGatewayRestartDrainCommitted()) {
+      // One-way restart drain must not leave requested latched, or
+      // waitForIdle busy-spins on already-resolved awaits.
       requested = false;
+      publishActivity();
+      return;
+    }
+    if (isGatewayRestartDraining()) {
+      // Reversible signal fence: keep the drain request so waitForIdle
+      // stays pending until rollback reopens admission or drain commits.
+      requested = true;
       publishActivity();
       return;
     }
@@ -748,8 +759,18 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
         await waitForPumpIdle();
         await waitForActiveDeliveries();
         await drain?.waitForIdle();
-        if (!pumping && activeDeliveries.size === 0 && (!requested || isGatewayRestartDraining())) {
+        if (
+          !pumping &&
+          activeDeliveries.size === 0 &&
+          (!requested || isGatewayRestartDrainCommitted())
+        ) {
           return;
+        }
+        if (requested && isGatewayRestartDraining() && !isGatewayRestartDrainCommitted()) {
+          await waitForGatewayRestartFenceSettlement();
+          if (running && !isAborted() && requested && !isGatewayRestartDrainCommitted()) {
+            requestDrain();
+          }
         }
       }
     },

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -1,7 +1,7 @@
 /** Shared durable channel-ingress admission, pump, retention, and shutdown lifecycle. */
 import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
 import {
-  isGatewayRestartDrainCommitted,
+  getGatewayRestartDrainSignal,
   isGatewayRestartDraining,
   waitForGatewayRestartFenceSettlement,
 } from "../../process/gateway-work-admission.js";
@@ -183,6 +183,8 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
   let pumping: Promise<void> | undefined;
   let drainIdleWake: Promise<void> | undefined;
   let drainIdleWakeRequested = false;
+  let restartFenceWake: Promise<void> | undefined;
+  let releaseRestartFenceWake = () => {};
   let pollTimer: ReturnType<typeof setInterval> | undefined;
   let lastPrunedAt = 0;
   let admissionTail: Promise<void> = Promise.resolve();
@@ -258,27 +260,19 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
 
   const isAborted = () => drainAbortSignal.aborted;
 
-  const waitForActiveDeliveries = async (): Promise<void> => {
-    while (activeDeliveries.size > 0) {
-      await Promise.allSettled(activeDeliveries);
-    }
-  };
-
-  const waitForPumpIdle = async (): Promise<void> => {
+  const waitForPending = async (read: () => Iterable<Promise<unknown>>, reject = false) => {
     for (;;) {
-      const activePump = pumping;
-      if (!activePump) {
+      const pending = [...read()];
+      if (pending.length === 0) {
         return;
       }
-      await activePump;
+      await (reject ? Promise.all(pending) : Promise.allSettled(pending));
     }
   };
-
-  const waitForDeferredClaims = async (): Promise<void> => {
-    while (deferredClaims.size > 0) {
-      await Promise.allSettled(deferredClaims.values());
-    }
-  };
+  const waitForActiveDeliveries = () => waitForPending(() => activeDeliveries);
+  // A rejected pump wrapper remains caller-visible; delivery joins observe every outcome.
+  const waitForPumpIdle = () => waitForPending(() => (pumping ? [pumping] : []), true);
+  const waitForDeferredClaims = () => waitForPending(() => deferredClaims);
 
   const getDrain = (): ChannelIngressDrain => {
     drain ??= createChannelIngressDrain<TStoredPayload, TMetadata>({
@@ -536,18 +530,35 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
     }
   };
 
+  const scheduleRestartFenceWake = (): void => {
+    if (restartFenceWake) {
+      return;
+    }
+    const localWake = new Promise<void>((resolve) => {
+      releaseRestartFenceWake = resolve;
+    });
+    restartFenceWake = Promise.race([waitForGatewayRestartFenceSettlement(), localWake]).then(
+      () => {
+        restartFenceWake = undefined;
+        releaseRestartFenceWake = () => {};
+        requestDrain();
+      },
+    );
+  };
+  drainAbortSignal.addEventListener("abort", () => releaseRestartFenceWake(), { once: true });
+
   const requestDrain = (): void => {
-    if (!running || isAborted() || isGatewayRestartDrainCommitted()) {
-      // One-way restart drain must not leave requested latched, or
-      // waitForIdle busy-spins on already-resolved awaits.
+    if (!running || isAborted() || getGatewayRestartDrainSignal().aborted) {
+      // A stale request here makes waitForIdle busy-spin on resolved awaits.
       requested = false;
+      releaseRestartFenceWake();
       publishActivity();
       return;
     }
     if (isGatewayRestartDraining()) {
-      // Reversible signal fence: keep the drain request so waitForIdle
-      // stays pending until rollback reopens admission or drain commits.
+      // Keep the request pending until rollback reopens admission or drain commits.
       requested = true;
+      scheduleRestartFenceWake();
       publishActivity();
       return;
     }
@@ -568,6 +579,7 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
   const pause = async (): Promise<void> => {
     running = false;
     requested = false;
+    releaseRestartFenceWake();
     clearPollTimer();
     publishActivity();
     await waitForPumpIdle();
@@ -733,6 +745,7 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
         stopped = true;
         running = false;
         requested = false;
+        releaseRestartFenceWake();
         clearPollTimer();
         publishActivity();
         // Every transport callback accepted before stop keeps its durable-append guarantee.
@@ -759,18 +772,9 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
         await waitForPumpIdle();
         await waitForActiveDeliveries();
         await drain?.waitForIdle();
-        if (
-          !pumping &&
-          activeDeliveries.size === 0 &&
-          (!requested || isGatewayRestartDrainCommitted())
-        ) {
+        await restartFenceWake;
+        if (!pumping && activeDeliveries.size === 0 && !requested) {
           return;
-        }
-        if (requested && isGatewayRestartDraining() && !isGatewayRestartDrainCommitted()) {
-          await waitForGatewayRestartFenceSettlement();
-          if (running && !isAborted() && requested && !isGatewayRestartDrainCommitted()) {
-            requestDrain();
-          }
         }
       }
     },

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -534,6 +534,9 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
 
   const requestDrain = (): void => {
     if (!running || isAborted() || isGatewayRestartDraining()) {
+      // Restart drain must not leave requested latched, or waitForIdle
+      // busy-spins on already-resolved awaits.
+      requested = false;
       publishActivity();
       return;
     }
@@ -745,7 +748,7 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
         await waitForPumpIdle();
         await waitForActiveDeliveries();
         await drain?.waitForIdle();
-        if (!pumping && activeDeliveries.size === 0 && !requested) {
+        if (!pumping && activeDeliveries.size === 0 && (!requested || isGatewayRestartDraining())) {
           return;
         }
       }

--- a/src/process/gateway-work-admission.test.ts
+++ b/src/process/gateway-work-admission.test.ts
@@ -8,11 +8,8 @@ import {
   getActiveGatewayRootWorkCount,
   getGatewayRestartDrainSignal,
   getGatewaySuspendAdmissionPhase,
-  isGatewayRestartDrainCommitted,
   isGatewayRestartDrainError,
-  isGatewayRestartDraining,
   isGatewaySubordinateWorkAdmissionClosed,
-  waitForGatewayRestartFenceSettlement,
   isGatewayWorkAdmissionClosed,
   markGatewayRestartDraining,
   retainGatewayRootWorkAdmissionContinuation,
@@ -29,33 +26,6 @@ import { runWithGatewayRootWorkAdmissionForTest } from "./gateway-work-admission
 
 beforeEach(resetGatewayWorkAdmission);
 afterEach(resetGatewayWorkAdmission);
-
-it("treats the restart signal fence as draining but not committed", async () => {
-  expect(isGatewayRestartDraining()).toBe(false);
-  expect(isGatewayRestartDrainCommitted()).toBe(false);
-
-  const signal = beginGatewayRestartSignalAdmission();
-  expect(isGatewayRestartDraining()).toBe(true);
-  expect(isGatewayRestartDrainCommitted()).toBe(false);
-
-  const pending = waitForGatewayRestartFenceSettlement();
-  const raced = await Promise.race([
-    pending.then(() => "settled" as const),
-    new Promise<"pending">((resolve) => {
-      setTimeout(() => resolve("pending"), 20);
-    }),
-  ]);
-  expect(raced).toBe("pending");
-  expect(signal?.rollback()).toBe(true);
-  await expect(pending).resolves.toBeUndefined();
-  expect(isGatewayRestartDraining()).toBe(false);
-  expect(isGatewayRestartDrainCommitted()).toBe(false);
-
-  markGatewayRestartDraining();
-  expect(isGatewayRestartDraining()).toBe(true);
-  expect(isGatewayRestartDrainCommitted()).toBe(true);
-  await expect(waitForGatewayRestartFenceSettlement()).resolves.toBeUndefined();
-});
 
 it("classifies draining errors only while an authoritative restart signal or drain is active", () => {
   const error = new GatewayDrainingError();

--- a/src/process/gateway-work-admission.test.ts
+++ b/src/process/gateway-work-admission.test.ts
@@ -8,8 +8,11 @@ import {
   getActiveGatewayRootWorkCount,
   getGatewayRestartDrainSignal,
   getGatewaySuspendAdmissionPhase,
+  isGatewayRestartDrainCommitted,
   isGatewayRestartDrainError,
+  isGatewayRestartDraining,
   isGatewaySubordinateWorkAdmissionClosed,
+  waitForGatewayRestartFenceSettlement,
   isGatewayWorkAdmissionClosed,
   markGatewayRestartDraining,
   retainGatewayRootWorkAdmissionContinuation,
@@ -26,6 +29,33 @@ import { runWithGatewayRootWorkAdmissionForTest } from "./gateway-work-admission
 
 beforeEach(resetGatewayWorkAdmission);
 afterEach(resetGatewayWorkAdmission);
+
+it("treats the restart signal fence as draining but not committed", async () => {
+  expect(isGatewayRestartDraining()).toBe(false);
+  expect(isGatewayRestartDrainCommitted()).toBe(false);
+
+  const signal = beginGatewayRestartSignalAdmission();
+  expect(isGatewayRestartDraining()).toBe(true);
+  expect(isGatewayRestartDrainCommitted()).toBe(false);
+
+  const pending = waitForGatewayRestartFenceSettlement();
+  const raced = await Promise.race([
+    pending.then(() => "settled" as const),
+    new Promise<"pending">((resolve) => {
+      setTimeout(() => resolve("pending"), 20);
+    }),
+  ]);
+  expect(raced).toBe("pending");
+  expect(signal?.rollback()).toBe(true);
+  await expect(pending).resolves.toBeUndefined();
+  expect(isGatewayRestartDraining()).toBe(false);
+  expect(isGatewayRestartDrainCommitted()).toBe(false);
+
+  markGatewayRestartDraining();
+  expect(isGatewayRestartDraining()).toBe(true);
+  expect(isGatewayRestartDrainCommitted()).toBe(true);
+  await expect(waitForGatewayRestartFenceSettlement()).resolves.toBeUndefined();
+});
 
 it("classifies draining errors only while an authoritative restart signal or drain is active", () => {
   const error = new GatewayDrainingError();

--- a/src/process/gateway-work-admission.ts
+++ b/src/process/gateway-work-admission.ts
@@ -187,26 +187,15 @@ export function isGatewayRestartDraining(): boolean {
   );
 }
 
-/** True only after one-way restart drain. The reversible signal fence is excluded. */
-export function isGatewayRestartDrainCommitted(): boolean {
-  return GATEWAY_WORK_ADMISSION_STATE.restartDraining;
-}
-
 /** Resolves when one-way drain commits or the reversible signal fence clears. */
-export function waitForGatewayRestartFenceSettlement(): Promise<void> {
-  return new Promise((resolve) => {
-    const finish = () => {
-      if (
-        GATEWAY_WORK_ADMISSION_STATE.restartDraining ||
-        !GATEWAY_WORK_ADMISSION_STATE.restartSignalPending
-      ) {
-        resolve();
-        return;
-      }
-      GATEWAY_WORK_ADMISSION_STATE.suspendOpenWaiters.add(finish);
-    };
-    finish();
+export async function waitForGatewayRestartFenceSettlement(): Promise<void> {
+  if (!GATEWAY_WORK_ADMISSION_STATE.restartSignalPending) {
+    return;
+  }
+  await new Promise<void>((resolve) => {
+    GATEWAY_WORK_ADMISSION_STATE.suspendOpenWaiters.add(resolve);
   });
+  await waitForGatewayRestartFenceSettlement();
 }
 
 export function getGatewayRestartDrainSignal(): AbortSignal {

--- a/src/process/gateway-work-admission.ts
+++ b/src/process/gateway-work-admission.ts
@@ -187,6 +187,28 @@ export function isGatewayRestartDraining(): boolean {
   );
 }
 
+/** True only after one-way restart drain. The reversible signal fence is excluded. */
+export function isGatewayRestartDrainCommitted(): boolean {
+  return GATEWAY_WORK_ADMISSION_STATE.restartDraining;
+}
+
+/** Resolves when one-way drain commits or the reversible signal fence clears. */
+export function waitForGatewayRestartFenceSettlement(): Promise<void> {
+  return new Promise((resolve) => {
+    const finish = () => {
+      if (
+        GATEWAY_WORK_ADMISSION_STATE.restartDraining ||
+        !GATEWAY_WORK_ADMISSION_STATE.restartSignalPending
+      ) {
+        resolve();
+        return;
+      }
+      GATEWAY_WORK_ADMISSION_STATE.suspendOpenWaiters.add(finish);
+    };
+    finish();
+  });
+}
+
 export function getGatewayRestartDrainSignal(): AbortSignal {
   return GATEWAY_WORK_ADMISSION_STATE.restartDrainController.signal;
 }

--- a/test/fixtures/channel-ingress-gateway-restart.ts
+++ b/test/fixtures/channel-ingress-gateway-restart.ts
@@ -1,0 +1,158 @@
+import path from "node:path";
+import { createStandardRawEventIngressMonitor } from "openclaw/plugin-sdk/channel-ingress-runtime";
+import { createChannelIngressQueue } from "../../src/channels/message/ingress-queue.js";
+import { runGatewayLoop } from "../../src/cli/gateway-cli/run-loop.js";
+import type { GatewayServer } from "../../src/gateway/server-public.js";
+import {
+  requestGatewayRestartWithSignalAdmission,
+  resetGatewayRestartStateForInProcessRestart,
+} from "../../src/infra/restart.js";
+import {
+  getGatewayRestartDrainSignal,
+  resetGatewayWorkAdmission,
+} from "../../src/process/gateway-work-admission.js";
+import { closeOpenClawStateDatabaseForTest } from "../../src/state/openclaw-state-db.js";
+
+const stateDir = process.argv[2];
+if (!stateDir) {
+  throw new Error("state directory argument is required");
+}
+process.env.OPENCLAW_STATE_DIR = path.resolve(stateDir);
+process.env.OPENCLAW_NO_RESPAWN = "1";
+resetGatewayWorkAdmission();
+resetGatewayRestartStateForInProcessRestart();
+
+let releaseFirstClose = () => {};
+const firstCloseGate = new Promise<void>((resolve) => {
+  releaseFirstClose = resolve;
+});
+let markFirstStart = () => {};
+const firstStarted = new Promise<void>((resolve) => {
+  markFirstStart = resolve;
+});
+let markSecondStart = () => {};
+const secondStarted = new Promise<void>((resolve) => {
+  markSecondStart = resolve;
+});
+let markExited = (_code: number) => {};
+const exited = new Promise<number>((resolve) => {
+  markExited = resolve;
+});
+let startCount = 0;
+
+void runGatewayLoop({
+  ownsProcessLifecycle: false,
+  lockPort: 20_000 + (process.pid % 20_000),
+  runtime: {
+    log: () => {},
+    error: () => {},
+    exit: markExited,
+  },
+  start: async () => {
+    startCount += 1;
+    if (startCount === 1) {
+      markFirstStart();
+    } else {
+      markSecondStart();
+    }
+    const thisStart = startCount;
+    return {
+      startupSettled: Promise.resolve(),
+      getTailscaleIngressEndpoint: () => undefined,
+      close: async () => {
+        if (thisStart === 1) {
+          await firstCloseGate;
+        }
+      },
+    } satisfies GatewayServer;
+  },
+});
+
+await firstStarted;
+
+type RawEvent = { id: string; lane: string; text: string };
+type StoredEvent = { version: 1; rawEvent: string };
+const queue = createChannelIngressQueue<StoredEvent>({
+  channelId: "test",
+  accountId: "gateway-restart",
+  stateDir,
+});
+let releasePrune = (_error?: Error) => {};
+const pruneGate = new Promise<void>((resolve, reject) => {
+  releasePrune = (error) => (error ? reject(error) : resolve());
+});
+let markPruneStarted = () => {};
+const pruneStarted = new Promise<void>((resolve) => {
+  markPruneStarted = resolve;
+});
+const prune = queue.prune.bind(queue);
+queue.prune = async (...args) => {
+  markPruneStarted();
+  await pruneGate;
+  return await prune(...args);
+};
+const activity: boolean[] = [];
+const ingress = createStandardRawEventIngressMonitor<
+  RawEvent,
+  unknown,
+  { eventId: string; laneKey: string }
+>({
+  queue,
+  inspect: (raw: RawEvent) => ({ eventId: raw.id, laneKey: `lane:${raw.lane}` }),
+  payload: {
+    serialize: (raw) => JSON.stringify(raw),
+    deserialize: (body) => JSON.parse(body) as RawEvent,
+    createClaimError: (kind) => new Error(kind),
+  },
+  deliver: async () => {},
+  pollIntervalMs: 60_000,
+  drain: {
+    adoptionStallTimeoutMs: 5_000,
+    retryPolicy: { baseMs: 1_000, maxMs: 1_000 },
+    resolveNonRetryableFailure: () => null,
+  },
+  classifyAdmissionError: () => undefined,
+  onActivityChange: (active) => activity.push(active),
+});
+
+ingress.start();
+await pruneStarted;
+await ingress.receive({ id: "event-restart", lane: "a", text: "queued before restart" });
+const restart = requestGatewayRestartWithSignalAdmission("test", {
+  force: true,
+  reason: "test",
+});
+if (restart.status !== "emitted") {
+  throw new Error(`restart was not emitted: ${restart.status}`);
+}
+while (!getGatewayRestartDrainSignal().aborted) {
+  await new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+}
+process.send?.({ type: "ingress-restart-drain-committed" });
+
+releasePrune(new Error("restart drain interrupted prune"));
+const idleStartedAt = Date.now();
+await ingress.waitForIdle();
+const idleMs = Date.now() - idleStartedAt;
+const finalActivity = activity.at(-1);
+
+await ingress.stop();
+releaseFirstClose();
+await secondStarted;
+process.emit("SIGINT");
+const exitCode = await exited;
+closeOpenClawStateDatabaseForTest();
+
+process.send?.({
+  type: "ingress-restart-proof",
+  proof: {
+    restart: restart.status,
+    committed: true,
+    idleMs,
+    finalActivity,
+    exitCode,
+  },
+});
+process.exit(0);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Gateway restart could leave channel ingress waiting in a busy loop when a drain request was latched while the active pump stopped.

## Why This Change Was Made

The shared ingress monitor now owns one coalesced restart-fence wake. A reversible restart signal keeps queued work pending and rearms it after rollback, while committed drain, pause, stop, and abort clear the latch and let idle observers finish.

## User Impact

Gateway restart and channel shutdown can complete without an ingress idle loop starving timers. Queued channel work still resumes after a rejected or rolled-back restart signal.

## Evidence

- Current `main` at `cb75c1a820cdb521c3f6e38d1bf431c518442b43`: the production ingress queue and real Gateway restart loop committed drain, then failed to reach idle within the external 8-second bound.
- Exact head `c90d17152af3f58a87b4003d8c8535f82c0d73db`: the same sequence entered through the published `openclaw/plugin-sdk/channel-ingress-runtime` package subpath, reached idle, cleared activity, completed the in-process restart, and shut down cleanly.
- `node scripts/run-vitest.mjs src/channels/message/ingress-monitor.restart-drain.test.ts src/channels/message/ingress-monitor.test.ts src/process/gateway-work-admission.test.ts`: 62 tests passed, including rejected pump-wrapper propagation.
- Focused Oxlint, Oxfmt, max-lines, assertion-safety, conflict-marker, and `git diff --check` gates passed. Type checks remain delegated to pull-request CI under the repository host-safety rule.
