### PR TITLE
perf(gateway): batch bounded operator request starts

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2990,7 +2990,6 @@ src/gateway/server/ws-connection.ts	3
 src/gateway/server/ws-connection/authenticated-request-dispatch.ts	1
 src/gateway/server/ws-connection/connect-device-metadata.ts	1
 src/gateway/server/ws-connection/connect-node-session.ts	1
-src/gateway/server/ws-connection/connect-session.ts	1
 src/gateway/server/ws-connection/message-handler.ts	10
 src/gateway/server/ws-connection/worker-connection.ts	2
 src/gateway/session-compaction-checkpoints.ts	7

--- a/docs/gateway/protocol.md
+++ b/docs/gateway/protocol.md
@@ -62,6 +62,11 @@ request never establishes trace context for later frames. Use a separate
 the WebSocket itself as one trace.
 
 Response errors use `{ code, message, details?, retryable?, retryAfterMs? }`.
+Authenticated operator requests share a bounded queue for starting RPC handlers.
+When waiting capacity is exhausted, the Gateway returns retryable `UNAVAILABLE`
+before the method runs; retry within the request's budget. Started requests
+complete concurrently, so responses can arrive out of order.
+
 Clients should branch on `code` and `details.code`; `message` remains human-readable
 and can change except where a compatibility note says otherwise. Method-level
 authorization failures use top-level `code: "FORBIDDEN"` with structured

--- a/src/gateway/server/ws-connection.test-helpers.ts
+++ b/src/gateway/server/ws-connection.test-helpers.ts
@@ -6,6 +6,7 @@ import { expect, vi } from "vitest";
 import type { WebSocketServer } from "ws";
 import type { ResolvedGatewayAuth } from "../auth.js";
 import { prepareGatewayIngressAttribution } from "../ingress-attribution.js";
+import { MAX_PREAUTH_PAYLOAD_BYTES } from "../server-constants.js";
 import type { attachGatewayWsConnectionHandler } from "./ws-connection.js";
 
 type AttachGatewayWsConnectionParams = Parameters<typeof attachGatewayWsConnectionHandler>[0];
@@ -65,6 +66,7 @@ export function createGatewayWsTestSocket(
   } = {},
 ): GatewayWsTestSocket {
   const socket = Object.assign(new EventEmitter(), {
+    _receiver: { _maxPayload: MAX_PREAUTH_PAYLOAD_BYTES, _allowSynchronousEvents: false },
     _socket: {
       remoteAddress: "127.0.0.1",
       remotePort: 1234,

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.server.test.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.server.test.ts
@@ -1,5 +1,10 @@
+import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocket } from "ws";
+import {
+  GATEWAY_CLIENT_IDS,
+  GATEWAY_CLIENT_MODES,
+} from "../../../../packages/gateway-protocol/src/client-info.js";
 import { createOperationalRunInstanceRef } from "../../../agents/admitted-run-context.js";
 import {
   createDiagnosticTraceContext,
@@ -8,6 +13,10 @@ import {
   type DiagnosticTraceContext,
 } from "../../../infra/diagnostic-trace-context.js";
 import { createEmptyPluginRegistry } from "../../../plugins/registry-empty.js";
+import {
+  getActiveGatewayRootWorkCount,
+  tryBeginGatewayRootWorkAdmission,
+} from "../../../process/gateway-work-admission.js";
 import { createDeferredCore, type Deferred } from "../../../shared/deferred.js";
 import type { AgentRuntimeIdentity } from "../../agent-runtime-identity-token.js";
 import {
@@ -85,6 +94,17 @@ async function dispatchInFreshMessageScope(
       client,
     ),
   );
+}
+
+async function warmDispatcher(
+  harness: ReturnType<typeof createDispatchTestHarness>,
+  client: GatewayWsClient,
+): Promise<void> {
+  await harness.dispatcher.dispatch(
+    { type: "req", id: "warmup", method: "test.trace", params: {} },
+    client,
+  );
+  await harness.awaitResponseFrame("warmup");
 }
 
 async function openAuthenticatedTraceSocket(params: {
@@ -226,6 +246,128 @@ describe("authenticated WebSocket request trace dispatch", () => {
     expect(close).toHaveBeenCalledWith(4001, "agent runtime authority closed");
   });
 
+  it.each([
+    { change: "shared-auth", closeReason: "gateway auth changed" },
+    { change: "invalidated", closeReason: "client invalidated: device-token-revoked" },
+    { change: "runtime", closeReason: "agent runtime authority closed" },
+  ] as const)("revalidates $change authority after waiting to start", async (testCase) => {
+    let generation = "current";
+    let runtimeActive = true;
+    let pendingStarted = false;
+    const client = createClient();
+    if (testCase.change === "shared-auth") {
+      client.usesSharedGatewayAuth = true;
+      client.sharedGatewaySessionGeneration = generation;
+    }
+    if (testCase.change === "runtime") {
+      client.internal = { agentRuntimeIdentity: createTestAgentRuntimeIdentity("pending-start") };
+    }
+    const harness = createDispatchTestHarness({
+      getRequiredSharedGatewaySessionGeneration: () => generation,
+      buildRequestContext: () => ({ validateAgentRuntimeApprovalAuthority: () => runtimeActive }),
+      extraHandlers: {
+        "test.trace": ({ req, respond }) => {
+          pendingStarted ||= req.id === "pending";
+          respond(true, { completed: req.id });
+        },
+      },
+    });
+    const closed = createDeferredCore();
+    harness.close.mockImplementation(() => closed.resolve());
+    await warmDispatcher(harness, client);
+    await harness.dispatcher.dispatch(
+      { type: "req", id: "pending", method: "test.trace", params: {} },
+      client,
+    );
+    expect(pendingStarted).toBe(false);
+    if (testCase.change === "shared-auth") {
+      generation = "rotated";
+    } else if (testCase.change === "invalidated") {
+      client.invalidated = true;
+      client.invalidatedReason = "device-token-revoked";
+    } else {
+      runtimeActive = false;
+    }
+    // Baseline failures also finish: an unauthorized handler response is a verdict,
+    // not a reason to wait forever for the missing authority-close notification.
+    await Promise.race([closed.promise, harness.awaitResponseFrame("pending")]);
+    expect(pendingStarted).toBe(false);
+    expect(harness.close).toHaveBeenCalledWith(4001, testCase.closeReason);
+    expect(harness.send).not.toHaveBeenCalledWith(
+      expect.objectContaining({ id: "pending", ok: true }),
+    );
+  });
+
+  it.each([
+    {
+      label: "ordinary UI node invocation",
+      method: "node.invoke",
+      id: GATEWAY_CLIENT_IDS.CONTROL_UI,
+      mode: GATEWAY_CLIENT_MODES.UI,
+      cancel: false,
+    },
+    {
+      label: "CLI node invocation",
+      method: "node.invoke",
+      id: GATEWAY_CLIENT_IDS.CLI,
+      mode: GATEWAY_CLIENT_MODES.CLI,
+      cancel: true,
+    },
+    {
+      label: "session companion ask",
+      method: "sessions.companion.ask",
+      id: GATEWAY_CLIENT_IDS.CONTROL_UI,
+      mode: GATEWAY_CLIENT_MODES.UI,
+      cancel: true,
+    },
+  ])("preserves pending $label disconnect policy", async (testCase) => {
+    const socket = new EventEmitter();
+    let disconnected = false;
+    let pendingStarted = false;
+    let pendingSignal: AbortSignal | undefined;
+    const handler: NonNullable<GatewayWsMessageHandlerParams["extraHandlers"][string]> = ({
+      req,
+      respond,
+      signal,
+    }) => {
+      if (req.id === "pending") {
+        pendingStarted = true;
+        pendingSignal = signal;
+      }
+      respond(true, { completed: req.id });
+    };
+    const client = createOperatorWsClient({ socket, clientInfo: testCase });
+    const harness = createDispatchTestHarness({
+      isClosed: () => disconnected,
+      extraHandlers: { "test.trace": handler, [testCase.method]: handler },
+    });
+    await warmDispatcher(harness, client);
+    await harness.dispatcher.dispatch(
+      { type: "req", id: "pending", method: testCase.method, params: {} },
+      client,
+    );
+    expect(pendingStarted).toBe(false);
+    disconnected = true;
+    socket.emit("close", 1000, Buffer.alloc(0));
+
+    // A later live request proves start scheduling progressed past the cancelled
+    // request without importing or mocking the scheduling implementation.
+    const probe = createDispatcher(handler);
+    await probe.dispatcher.dispatch(
+      { type: "req", id: "probe", method: "test.trace", params: {} },
+      createClient(),
+    );
+    expect(await probe.awaitResponseFrame("probe")).toMatchObject({ ok: true });
+    expect(pendingStarted).toBe(!testCase.cancel);
+    if (!testCase.cancel) {
+      expect(await harness.awaitResponseFrame("pending")).toMatchObject({ ok: true });
+      expect(pendingSignal).toBeUndefined();
+    } else {
+      expect(harness.send).not.toHaveBeenCalledWith(expect.objectContaining({ id: "pending" }));
+    }
+    expect(socket.listenerCount("close")).toBe(0);
+  });
+
   it("keeps handler failure logging and responses inside the request trace", async () => {
     let loggedContext: DiagnosticTraceContext | undefined;
     let responseContext: DiagnosticTraceContext | undefined;
@@ -306,13 +448,25 @@ describe("authenticated WebSocket request trace dispatch", () => {
     });
     const client = createClient();
 
-    await Promise.all([
-      dispatchInFreshMessageScope(dispatcher, client, "first", TRACEPARENTS.first),
-      dispatchInFreshMessageScope(dispatcher, client, "second", TRACEPARENTS.second),
-    ]);
-    await bothObserved.promise;
-    requestBarrier.resolve();
-    await bothCompleted.promise;
+    const parent = tryBeginGatewayRootWorkAdmission();
+    if (!parent) {
+      throw new Error("expected open parent work admission");
+    }
+    try {
+      await parent.run(() =>
+        Promise.all([
+          dispatchInFreshMessageScope(dispatcher, client, "first", TRACEPARENTS.first),
+          dispatchInFreshMessageScope(dispatcher, client, "second", TRACEPARENTS.second),
+        ]),
+      );
+      await bothObserved.promise;
+      // The pending starts retain their traces but cannot borrow the parent root.
+      expect(getActiveGatewayRootWorkCount()).toBe(3);
+    } finally {
+      requestBarrier.resolve();
+      parent.release();
+      await bothCompleted.promise;
+    }
 
     expect(observed.get("first")?.before?.traceId).toBe("11111111111111111111111111111111");
     expect(observed.get("second")?.before?.traceId).toBe("22222222222222222222222222222222");

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.test-support.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.test-support.ts
@@ -46,6 +46,8 @@ export function createDispatchTestHarness(
     connId?: string;
     extraHandlers?: GatewayWsMessageHandlerParams["extraHandlers"];
     buildRequestContext?: () => unknown;
+    isClosed?: () => boolean;
+    getRequiredSharedGatewaySessionGeneration?: () => string | undefined;
   } = {},
 ) {
   const sentResponses: GatewayTestResponseFrame[] = [];
@@ -77,7 +79,8 @@ export function createDispatchTestHarness(
       buildRequestContext: () => (options.buildRequestContext?.() ?? {}) as never,
       send: sendForDispatcher,
       close,
-      isClosed: () => false,
+      isClosed: options.isClosed ?? (() => false),
+      getRequiredSharedGatewaySessionGeneration: options.getRequiredSharedGatewaySessionGeneration,
       setCloseCause,
       logGateway,
     } as unknown as GatewayWsMessageHandlerParams,
@@ -95,5 +98,15 @@ export function createDispatchTestHarness(
     responseWaiters.push({ id, deferred });
     return deferred.promise;
   };
-  return { awaitResponseFrame, close, dispatcher, logGateway, send, setCloseCause };
+  return {
+    awaitResponseFrame,
+    close,
+    dispatcher: {
+      dispatch: (frame: unknown, client: GatewayWsClient) =>
+        dispatcher.dispatch(frame, client, Buffer.byteLength(JSON.stringify(frame))),
+    },
+    logGateway,
+    send,
+    setCloseCause,
+  };
 }

--- a/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
+++ b/src/gateway/server/ws-connection/authenticated-request-dispatch.ts
@@ -14,11 +14,13 @@ import {
   parseDiagnosticTraceparent,
   runWithDiagnosticTraceContext,
 } from "../../../infra/diagnostic-trace-context.js";
+import { runOutsideGatewayRootWorkAdmission } from "../../../process/gateway-work-admission.js";
 import { createLazyPromise } from "../../../shared/lazy-runtime.js";
 import { classifyGatewayStaleInstall } from "../../stale-install.js";
 import { formatForLog, logWs } from "../../ws-log.js";
 import type { GatewayWsClient } from "../ws-types.js";
 import type { GatewayWsMessageHandlerParams } from "./message-handler-types.js";
+import { scheduleGatewayRequestStart } from "./request-start.js";
 import { isUnauthorizedRoleError, UnauthorizedFloodGuard } from "./unauthorized-flood-guard.js";
 
 const loadGatewayServerMethods = createLazyPromise(
@@ -64,7 +66,11 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
     return true;
   };
 
-  const dispatch = async (parsed: unknown, client: GatewayWsClient): Promise<void> => {
+  const dispatch = async (
+    parsed: unknown,
+    client: GatewayWsClient,
+    frameBytes: number,
+  ): Promise<void> => {
     // After handshake, accept only req frames
     if (!validateRequestFrame(parsed)) {
       send({
@@ -90,22 +96,25 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
         return;
       }
     }
-    if (closeInvalidatedClient(client, req.method)) {
-      return;
-    }
-    if (client.usesSharedGatewayAuth) {
-      const requiredSharedGatewaySessionGeneration = getRequiredSharedGatewaySessionGeneration?.();
-      if (
-        requiredSharedGatewaySessionGeneration !== undefined &&
-        client.sharedGatewaySessionGeneration !== requiredSharedGatewaySessionGeneration
-      ) {
-        setCloseCause("gateway-auth-rotated", {
-          authGenerationStale: true,
-          method: req.method,
-        });
-        close(4001, "gateway auth changed");
-        return;
+    const hasCurrentClientAuthority = () => {
+      if (closeInvalidatedClient(client, req.method)) {
+        return false;
       }
+      const requiredGeneration = client.usesSharedGatewayAuth
+        ? getRequiredSharedGatewaySessionGeneration?.()
+        : undefined;
+      if (
+        requiredGeneration !== undefined &&
+        client.sharedGatewaySessionGeneration !== requiredGeneration
+      ) {
+        setCloseCause("gateway-auth-rotated", { authGenerationStale: true, method: req.method });
+        close(4001, "gateway auth changed");
+        return false;
+      }
+      return true;
+    };
+    if (!hasCurrentClientAuthority()) {
+      return;
     }
     const respond = (
       ok: boolean,
@@ -163,20 +172,7 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
 
     const context = buildRequestContext();
     const agentRuntimeIdentity = client.internal?.agentRuntimeIdentity;
-    if (
-      agentRuntimeIdentity &&
-      context.validateAgentRuntimeApprovalAuthority?.(agentRuntimeIdentity) !== true
-    ) {
-      respond(
-        false,
-        undefined,
-        errorShape(ErrorCodes.INVALID_REQUEST, "agent runtime authority is no longer active"),
-      );
-      setCloseCause("agent-runtime-authority-closed", { method: req.method });
-      close(4001, "agent runtime authority closed");
-      return;
-    }
-    const respondWithAuthority: typeof respond = (ok, payload, error, meta) => {
+    const hasCurrentRuntimeAuthority = () => {
       if (
         agentRuntimeIdentity &&
         context.validateAgentRuntimeApprovalAuthority?.(agentRuntimeIdentity) !== true
@@ -188,9 +184,17 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
         );
         setCloseCause("agent-runtime-authority-closed", { method: req.method });
         close(4001, "agent runtime authority closed");
-        return;
+        return false;
       }
-      respond(ok, payload, error, meta);
+      return true;
+    };
+    if (!hasCurrentRuntimeAuthority()) {
+      return;
+    }
+    const respondWithAuthority: typeof respond = (ok, payload, error, meta) => {
+      if (hasCurrentRuntimeAuthority()) {
+        respond(ok, payload, error, meta);
+      }
     };
 
     const executeRequest = async () => {
@@ -208,16 +212,43 @@ export function createGatewayAuthenticatedRequestDispatcher(params: {
       }
       try {
         const { handleGatewayRequest } = await loadGatewayServerMethods();
-        await handleGatewayRequest({
-          req,
-          respond: respondWithAuthority,
-          client,
-          isWebchatConnect: params.isWebchatConnect,
-          extraHandlers,
-          methodRegistry: getMethodRegistry?.(),
-          context,
-          ...(requestController ? { signal: requestController.signal } : {}),
-        });
+        // Node completion traffic retains its native yielding and existing close-drain
+        // deadline. Operator requests share bounded starts without serializing completion.
+        if (client.connect.role === "operator") {
+          const start = scheduleGatewayRequestStart(frameBytes);
+          if (!start) {
+            respondWithAuthority(
+              false,
+              undefined,
+              errorShape(ErrorCodes.UNAVAILABLE, "gateway request start capacity exceeded", {
+                retryable: true,
+              }),
+            );
+            return;
+          }
+          await start;
+        }
+        // Waiting never grants authority. Ordinary requests may outlive their socket;
+        // only request-owned cancellation and current authority fence their start.
+        if (
+          requestController?.signal.aborted ||
+          !hasCurrentClientAuthority() ||
+          !hasCurrentRuntimeAuthority()
+        ) {
+          return;
+        }
+        await runOutsideGatewayRootWorkAdmission(() =>
+          handleGatewayRequest({
+            req,
+            respond: respondWithAuthority,
+            client,
+            isWebchatConnect: params.isWebchatConnect,
+            extraHandlers,
+            methodRegistry: getMethodRegistry?.(),
+            context,
+            ...(requestController ? { signal: requestController.signal } : {}),
+          }),
+        );
       } catch (err) {
         // Failure diagnostics and responses belong to the same request trace as the handler.
         logGateway.error(`request handler failed: ${formatForLog(err)}`);

--- a/src/gateway/server/ws-connection/connect-session.ts
+++ b/src/gateway/server/ws-connection/connect-session.ts
@@ -1,7 +1,6 @@
 // Gateway WebSocket connect finalization attaches node/session state and sends hello-ok.
 import os from "node:os";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import type { WebSocket } from "ws";
 import {
   GATEWAY_CLIENT_IDS,
   GATEWAY_CLIENT_MODES,
@@ -51,7 +50,7 @@ import {
   setClientPluginNodeCapability,
   type PluginNodeCapabilitySurface,
 } from "../../plugin-node-capability.js";
-import { MAX_PAYLOAD_BYTES, WEBSOCKET_OPEN_READY_STATE } from "../../server-constants.js";
+import { WEBSOCKET_OPEN_READY_STATE } from "../../server-constants.js";
 import { formatForLog, logWs } from "../../ws-log.js";
 import { truncateCloseReason } from "../close-reason.js";
 import { broadcastPresenceSnapshot } from "../presence-events.js";
@@ -64,6 +63,7 @@ import type {
   DeviceAuthorizedGatewayConnect,
   GatewayConnectPhaseContext,
 } from "./message-handler-types.js";
+import { prepareGatewayReceiverHandoff } from "./request-start.js";
 
 /** Match production release versions (YYYY.M.PATCH or YYYY.M.PATCH-beta.N). */
 const RELEASED_VERSION_RE = /^\d{4}\.\d+\.\d+/;
@@ -76,13 +76,6 @@ type AuthenticatedNodePairingAdmission = {
 
 function isReleasedVersion(version: string): boolean {
   return RELEASED_VERSION_RE.test(version);
-}
-
-function setSocketMaxPayload(socket: WebSocket, maxPayload: number): void {
-  const receiver = (socket as { _receiver?: { _maxPayload?: number } })["_receiver"];
-  if (receiver) {
-    receiver["_maxPayload"] = maxPayload;
-  }
 }
 
 export async function attachAuthenticatedGatewayConnect(
@@ -481,7 +474,6 @@ export async function attachAuthenticatedGatewayConnect(
       expiresAtMs: entry.expiresAtMs,
     });
   }
-  setSocketMaxPayload(socket, MAX_PAYLOAD_BYTES);
 
   // Version mismatch: kick the local node host so the OS supervisor restarts it.
   // Only applies when the connecting node is the same-install local node (verified by
@@ -551,6 +543,15 @@ export async function attachAuthenticatedGatewayConnect(
     close(4001, "gateway auth changed");
     return;
   }
+  const handoffReceiver = prepareGatewayReceiverHandoff(socket, role);
+  if (!handoffReceiver) {
+    const message = "unsupported Gateway WebSocket receiver";
+    markHandshakeFailure("unsupported-websocket-receiver", {});
+    sendHandshakeErrorResponse(ErrorCodes.UNAVAILABLE, message);
+    await releasePendingNodePairingCleanup();
+    close(1011, message);
+    return;
+  }
   if (!setClient(nextClient)) {
     await releasePendingNodePairingCleanup();
     setCloseCause("connect-aborted-before-register", {
@@ -559,6 +560,9 @@ export async function attachAuthenticatedGatewayConnect(
     });
     return;
   }
+  // Only registered operators use bounded router starts. Node lifecycle traffic,
+  // workers and preauth retain native yielding and their existing queue/drain rules.
+  handoffReceiver();
   setHandshakeState("connected");
   advanceHandshakePhase("session_attached");
   logWs("in", "connect", {

--- a/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.post-connect-health.test.ts
@@ -29,6 +29,7 @@ import type { HealthSummary } from "../../health/types.js";
 import type { GatewayAttributedIngress } from "../../ingress-attribution.js";
 import { getGatewayLocalUserIngress } from "../../local-user-ingress.js";
 import { getOperatorApprovalRuntimeToken } from "../../operator-approval-runtime-token.js";
+import { MAX_PREAUTH_PAYLOAD_BYTES } from "../../server-constants.js";
 import { handleGatewayRequest } from "../../server-methods.js";
 import { resolveGatewayCronCreatorAuthorityAdmission } from "../../server-methods/cron-creator-authority-admission.js";
 import type { GatewayRequestContext } from "../../server-methods/types.js";
@@ -289,7 +290,7 @@ function attachGatewayHarness(options: {
   let onMessage: ((data: string) => void) | undefined;
   const socket = {
     readyState: 1,
-    _receiver: {},
+    _receiver: { _maxPayload: MAX_PREAUTH_PAYLOAD_BYTES, _allowSynchronousEvents: false },
     send: socketSend,
     on: vi.fn((event: string, handler: (data: string) => void) => {
       if (event === "message") {

--- a/src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts
+++ b/src/gateway/server/ws-connection/message-handler.suspension-admission.test.ts
@@ -9,6 +9,7 @@ import {
   resetGatewayWorkAdmission,
   tryBeginGatewaySuspendAdmission,
 } from "../../../process/gateway-work-admission.js";
+import { MAX_PREAUTH_PAYLOAD_BYTES } from "../../server-constants.js";
 import type { GatewayRequestContext } from "../../server-methods/types.js";
 import { GatewayNodeLifecycleDispatchTracker } from "./node-lifecycle-dispatch.js";
 
@@ -68,7 +69,7 @@ function attachHarness(params: { deferSocketSend?: boolean; startupPending?: boo
     callback?.();
   });
   const socket = {
-    _receiver: {},
+    _receiver: { _maxPayload: MAX_PREAUTH_PAYLOAD_BYTES, _allowSynchronousEvents: false },
     send: socketSend,
     on: vi.fn((event: string, handler: (data: string) => void) => {
       if (event === "message") {

--- a/src/gateway/server/ws-connection/message-handler.ts
+++ b/src/gateway/server/ws-connection/message-handler.ts
@@ -380,7 +380,7 @@ export function attachGatewayWsMessageHandler(params: GatewayWsMessageHandlerPar
         await attachAuthenticatedGatewayConnect(phaseContext, deviceAuthorized);
         return;
       }
-      await authenticatedRequestDispatcher.dispatch(parsed, client);
+      await authenticatedRequestDispatcher.dispatch(parsed, client, rawDataByteLength(data));
     } catch (err) {
       await releasePendingNodePairingCleanup();
       logGateway.error(`parse/handle error: ${String(err)}`);

--- a/src/gateway/server/ws-connection/request-start.server.test.ts
+++ b/src/gateway/server/ws-connection/request-start.server.test.ts
@@ -1,0 +1,428 @@
+import { on, once } from "node:events";
+import type { IncomingMessage } from "node:http";
+import { performance } from "node:perf_hooks";
+import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WebSocket, WebSocketServer } from "ws";
+import { createEmptyPluginRegistry } from "../../../plugins/registry-empty.js";
+import { createDeferredCore } from "../../../shared/deferred.js";
+import {
+  connectOk,
+  connectReq,
+  getGatewayTestPort,
+  installGatewayTestHooks,
+  onceMessage,
+  startTestGatewayServer,
+  trackConnectChallengeNonce,
+} from "../../test-helpers.js";
+import {
+  resetTestPluginRegistry,
+  setTestPluginRegistry,
+} from "../../test-helpers.plugin-registry.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+async function openOperatorSocket(port: number, token: string): Promise<WebSocket> {
+  const socket = new WebSocket(`ws://127.0.0.1:${port}`);
+  trackConnectChallengeNonce(socket);
+  await once(socket, "open");
+  try {
+    await connectOk(socket, { token });
+    return socket;
+  } catch (error) {
+    socket.terminate();
+    throw error;
+  }
+}
+
+async function sendTraceRequest(socket: WebSocket, id: string): Promise<{ ok: boolean }> {
+  const response = onceMessage<{ type: "res"; id: string; ok: boolean }>(
+    socket,
+    (value) => value.type === "res" && value.id === id,
+  );
+  socket.send(JSON.stringify({ type: "req", id, method: "test.trace", params: {} }));
+  return await response;
+}
+
+function captureGatewayConnection(port: number) {
+  let connection: { socket: WebSocket; stream: IncomingMessage["socket"] } | undefined;
+  const emitter: {
+    emit: (this: WebSocketServer, event: string | symbol, ...args: unknown[]) => boolean;
+  } = WebSocketServer.prototype;
+  const originalEmit = emitter.emit;
+  const observer = vi.spyOn(WebSocketServer.prototype, "emit").mockImplementation(function (
+    this: WebSocketServer,
+    event: string | symbol,
+    ...args: unknown[]
+  ) {
+    if (event === "connection") {
+      const [socket, request] = args as [WebSocket, IncomingMessage];
+      if (request.socket.localPort === port) {
+        connection = { socket, stream: request.socket };
+      }
+    }
+    return originalEmit.call(this, event, ...args);
+  });
+  return {
+    get: () => {
+      if (!connection) {
+        throw new Error("expected the real gateway connection for the test port");
+      }
+      return connection;
+    },
+    restore: () => observer.mockRestore(),
+  };
+}
+
+function maskedFrame(opcode: 0x81 | 0x88 | 0x89 | 0x8a, text: string): Buffer {
+  const payload = Buffer.from(text);
+  if (payload.length >= 126) {
+    throw new Error("fixture requires a short masked WebSocket frame");
+  }
+  const mask = Buffer.from([1, 2, 3, 4]);
+  for (let index = 0; index < payload.length; index++) {
+    payload[index] = payload[index]! ^ mask[index % mask.length]!;
+  }
+  return Buffer.concat([Buffer.from([opcode, 0x80 | payload.length]), mask, payload]);
+}
+
+function injectReceiveChunk(stream: IncomingMessage["socket"], frames: Buffer[]) {
+  // Exercise the installed receiver through one actual upgraded stream chunk,
+  // independent of how TCP splits writes; never set private receiver policy here.
+  stream.pause();
+  stream.unshift(Buffer.concat(frames));
+  stream.resume();
+}
+
+describe("authenticated operator request starts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("starts a coalesced authenticated operator burst before an immediate while completions overlap", async () => {
+    const ids = Array.from({ length: 33 }, (_, index) => `burst-${index}`);
+    const starts: string[] = [];
+    const completed: string[] = [];
+    const held = createDeferredCore();
+    const observedAtYield = createDeferredCore<string[]>();
+    let sentinel: ReturnType<typeof setImmediate> | undefined;
+    const registry = createEmptyPluginRegistry();
+    registry.gatewayHandlers["test.trace"] = async ({ req, respond }) => {
+      if (req.id === "warmup") {
+        respond(true);
+        return;
+      }
+      starts.push(req.id);
+      if (starts.length === 1) {
+        sentinel = setImmediate(() => observedAtYield.resolve([...starts]));
+      }
+      if (req.id !== ids.at(-1)) {
+        await held.promise;
+      }
+      completed.push(req.id);
+      respond(true);
+    };
+    setTestPluginRegistry(registry);
+    const token = "gateway-operator-start-fairness-test-token";
+    const port = await getGatewayTestPort();
+    const capture = captureGatewayConnection(port);
+    let server: Awaited<ReturnType<typeof startTestGatewayServer>> | undefined;
+    let ws: WebSocket | undefined;
+    let restoreClock: (() => void) | undefined;
+    let allResponses: Promise<unknown> | undefined;
+    try {
+      server = await startTestGatewayServer(port, {
+        auth: { mode: "token", token },
+        bind: "loopback",
+        controlUiEnabled: false,
+      });
+      ws = await openOperatorSocket(port, token);
+      await expect(sendTraceRequest(ws, "warmup")).resolves.toMatchObject({ ok: true });
+      const { stream } = capture.get();
+      // This case isolates cheap-start batching. Other owner cases advance the
+      // work clock to prove the elapsed-work fairness boundary independently.
+      const now = performance.now();
+      const clock = vi.spyOn(performance, "now").mockReturnValue(now);
+      restoreClock = () => clock.mockRestore();
+      const responsesById = new Map<string, boolean>();
+      allResponses = onceMessage(ws, (value) => {
+        if (value.type === "res" && typeof value.id === "string" && ids.includes(value.id)) {
+          responsesById.set(value.id, value.ok === true);
+        }
+        return responsesById.size === ids.length;
+      });
+      // Cleanup below still awaits this promise; attach a rejection observer now
+      // so a fixture failure cannot produce an unrelated unhandled rejection.
+      void allResponses.catch(() => {});
+      const markerResponse = onceMessage(
+        ws,
+        (value) => value.type === "res" && value.id === ids.at(-1),
+      );
+      injectReceiveChunk(
+        stream,
+        ids.map((id) =>
+          maskedFrame(
+            0x81,
+            JSON.stringify({
+              type: "req",
+              id,
+              method: "test.trace",
+              params: {},
+            }),
+          ),
+        ),
+      );
+
+      await expect(markerResponse).resolves.toMatchObject({ ok: true });
+      expect(starts).toEqual(ids);
+      expect(completed).toEqual([ids.at(-1)]);
+      expect(await observedAtYield.promise).toEqual(ids);
+      held.resolve();
+      await allResponses;
+      expect(responsesById).toEqual(new Map(ids.map((id) => [id, true])));
+    } finally {
+      held.resolve();
+      await allResponses?.catch(() => {});
+      clearImmediate(sentinel);
+      restoreClock?.();
+      ws?.terminate();
+      try {
+        await server?.close();
+      } finally {
+        capture.restore();
+        resetTestPluginRegistry();
+      }
+    }
+  });
+
+  it("delivers operator control frames while ordinary request completions overlap", async () => {
+    const held = createDeferredCore();
+    let completed = false;
+    const registry = createEmptyPluginRegistry();
+    registry.gatewayHandlers["test.trace"] = async ({ req, respond }) => {
+      if (req.id === "held") {
+        await held.promise;
+        completed = true;
+      }
+      respond(true);
+    };
+    setTestPluginRegistry(registry);
+    const token = "gateway-operator-control-test-token";
+    const port = await getGatewayTestPort();
+    const server = await startTestGatewayServer(port, {
+      auth: { mode: "token", token },
+      bind: "loopback",
+      controlUiEnabled: false,
+    });
+    const capture = captureGatewayConnection(port);
+    let ws: WebSocket | undefined;
+    try {
+      ws = await openOperatorSocket(port, token);
+      await sendTraceRequest(ws, "warmup");
+      const { socket, stream } = capture.get();
+      const signal = AbortSignal.timeout(2_000);
+      const peerPongs = on(ws, "pong", { signal });
+      const serverPongs = on(socket, "pong", { signal });
+      const response = onceMessage(ws, (value) => value.type === "res" && value.id === "held");
+      void response.catch(() => {});
+      try {
+        const marker = onceMessage(ws, (value) => value.type === "res" && value.id === "marker");
+        injectReceiveChunk(stream, [
+          maskedFrame(0x89, "first"),
+          maskedFrame(0x81, JSON.stringify({ type: "req", id: "held", method: "test.trace" })),
+          maskedFrame(0x8a, "client-pong"),
+          maskedFrame(0x89, "second"),
+          maskedFrame(0x81, JSON.stringify({ type: "req", id: "marker", method: "test.trace" })),
+        ]);
+        expect((await peerPongs.next()).value?.[0].toString()).toBe("first");
+        expect((await peerPongs.next()).value?.[0].toString()).toBe("second");
+        expect((await serverPongs.next()).value?.[0].toString()).toBe("client-pong");
+        await expect(marker).resolves.toMatchObject({ ok: true });
+        expect(completed).toBe(false);
+        socket.ping("keepalive");
+        expect((await serverPongs.next()).value?.[0].toString()).toBe("keepalive");
+        held.resolve();
+        await expect(response).resolves.toMatchObject({ ok: true });
+      } finally {
+        held.resolve();
+        await response.catch(() => {});
+        await peerPongs.return?.();
+        await serverPongs.return?.();
+      }
+    } finally {
+      held.resolve();
+      ws?.terminate();
+      try {
+        await server.close();
+      } finally {
+        capture.restore();
+        resetTestPluginRegistry();
+      }
+    }
+  });
+
+  it("completes an ordinary operator request after a coalesced native close", async () => {
+    const held = createDeferredCore();
+    const completed = createDeferredCore();
+    const registry = createEmptyPluginRegistry();
+    registry.gatewayHandlers["test.trace"] = async ({ req, respond }) => {
+      if (req.id === "held") {
+        await held.promise;
+        completed.resolve();
+      }
+      respond(true);
+    };
+    setTestPluginRegistry(registry);
+    const token = "gateway-operator-close-test-token";
+    const port = await getGatewayTestPort();
+    const server = await startTestGatewayServer(port, {
+      auth: { mode: "token", token },
+      bind: "loopback",
+      controlUiEnabled: false,
+    });
+    const capture = captureGatewayConnection(port);
+    let ws: WebSocket | undefined;
+    try {
+      ws = await openOperatorSocket(port, token);
+      await sendTraceRequest(ws, "warmup");
+      const { socket, stream } = capture.get();
+      const signal = AbortSignal.timeout(2_000);
+      const closed = Promise.all([
+        once(socket, "close", { signal }),
+        once(ws, "close", { signal }),
+      ]);
+      const responses: unknown[] = [];
+      ws.on("message", (data) => {
+        const frame = JSON.parse(rawDataToString(data));
+        if (frame.type === "res" && frame.id === "held") {
+          responses.push(frame);
+        }
+      });
+      injectReceiveChunk(stream, [
+        maskedFrame(0x81, JSON.stringify({ type: "req", id: "held", method: "test.trace" })),
+        maskedFrame(0x88, ""),
+      ]);
+      await closed;
+      expect(socket.readyState).toBe(WebSocket.CLOSED);
+      held.resolve();
+      await completed.promise;
+      expect(responses).toEqual([]);
+    } finally {
+      held.resolve();
+      ws?.terminate();
+      try {
+        await server.close();
+      } finally {
+        capture.restore();
+        resetTestPluginRegistry();
+      }
+    }
+  });
+
+  it.each(["preauth", "node"] as const)(
+    "retains native control-frame yielding for %s sockets",
+    async (role) => {
+      const token = "gateway-native-control-fairness-test-token";
+      const port = await getGatewayTestPort();
+      const capture = captureGatewayConnection(port);
+      let server: Awaited<ReturnType<typeof startTestGatewayServer>> | undefined;
+      let ws: WebSocket | undefined;
+      let sentinel: ReturnType<typeof setImmediate> | undefined;
+      let removePingObserver: (() => void) | undefined;
+      try {
+        server = await startTestGatewayServer(port, {
+          auth: { mode: "token", token },
+          bind: "loopback",
+          controlUiEnabled: false,
+        });
+        ws = new WebSocket(`ws://127.0.0.1:${port}`);
+        trackConnectChallengeNonce(ws);
+        await once(ws, "open");
+        if (role === "node") {
+          await connectOk(ws, {
+            token,
+            role: "node",
+            prePairDevice: true,
+            client: { id: "node-host", version: "dev", platform: "test", mode: "node" },
+            scopes: [],
+            caps: [],
+            commands: [],
+          });
+        }
+        const { socket, stream } = capture.get();
+        const events: string[] = [];
+        const recordPing = (data: Buffer) => {
+          const value = data.toString();
+          events.push(value);
+          if (value === "first") {
+            sentinel = setImmediate(() => events.push("yield"));
+          }
+        };
+        socket.on("ping", recordPing);
+        removePingObserver = () => socket.off("ping", recordPing);
+        const pings = on(socket, "ping", { signal: AbortSignal.timeout(2_000) });
+        try {
+          injectReceiveChunk(stream, [maskedFrame(0x89, "first"), maskedFrame(0x89, "second")]);
+          await pings.next();
+          await pings.next();
+          expect(events).toEqual(["first", "yield", "second"]);
+        } finally {
+          await pings.return?.();
+        }
+      } finally {
+        clearImmediate(sentinel);
+        removePingObserver?.();
+        ws?.terminate();
+        try {
+          await server?.close();
+        } finally {
+          capture.restore();
+          resetTestPluginRegistry();
+        }
+      }
+    },
+  );
+
+  it("rejects an operator handshake visibly when the receiver handoff field is not writable", async () => {
+    const token = "gateway-receiver-contract-test-token";
+    const port = await getGatewayTestPort();
+    const capture = captureGatewayConnection(port);
+    let server: Awaited<ReturnType<typeof startTestGatewayServer>> | undefined;
+    let ws: WebSocket | undefined;
+    try {
+      server = await startTestGatewayServer(port, {
+        auth: { mode: "token", token },
+        bind: "loopback",
+        controlUiEnabled: false,
+      });
+      ws = new WebSocket(`ws://127.0.0.1:${port}`);
+      trackConnectChallengeNonce(ws);
+      await once(ws, "open");
+      const { socket } = capture.get();
+      const receiver = (socket as WebSocket & { _receiver: object })["_receiver"];
+      const descriptor = Object.getOwnPropertyDescriptor(receiver, "_allowSynchronousEvents");
+      expect(descriptor).toMatchObject({ value: false, writable: true });
+      // Fault injection is confined to this dependency-drift case. The burst
+      // regression above exercises the source handoff without private mutation.
+      Object.defineProperty(receiver, "_allowSynchronousEvents", {
+        ...descriptor,
+        writable: false,
+      });
+      const closed = once(ws, "close");
+      void closed.catch(() => {});
+      await expect(connectReq(ws, { token })).resolves.toMatchObject({
+        ok: false,
+        error: { code: "UNAVAILABLE", message: "unsupported Gateway WebSocket receiver" },
+      });
+      expect((await closed)[0]).toBe(1011);
+    } finally {
+      ws?.terminate();
+      try {
+        await server?.close();
+      } finally {
+        capture.restore();
+        resetTestPluginRegistry();
+      }
+    }
+  });
+});

--- a/src/gateway/server/ws-connection/request-start.test.ts
+++ b/src/gateway/server/ws-connection/request-start.test.ts
@@ -1,0 +1,111 @@
+import { performance } from "node:perf_hooks";
+import { setImmediate as nextTurn } from "node:timers/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { scheduleGatewayRequestStart } from "./request-start.js";
+
+const permissions: Promise<void>[] = [];
+function requestStart(bytes = 1): Promise<void> {
+  const permission = scheduleGatewayRequestStart(bytes);
+  if (!permission) {
+    throw new Error("expected start capacity");
+  }
+  permissions.push(permission);
+  return permission;
+}
+
+afterEach(async () => {
+  await Promise.all(permissions.splice(0));
+  vi.restoreAllMocks();
+});
+
+describe("Gateway request start fairness", () => {
+  it("releases cheap starts in FIFO order without waiting for their work to finish", async () => {
+    vi.spyOn(performance, "now").mockReturnValue(0);
+    const starts: number[] = [];
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const first = requestStart().then(async () => {
+      starts.push(0);
+      await held;
+    });
+    const rest = Array.from({ length: 32 }, (_, index) =>
+      requestStart().then(() => {
+        starts.push(index + 1);
+      }),
+    );
+    try {
+      await Promise.all(rest);
+      expect(starts).toEqual(Array.from({ length: 33 }, (_, index) => index));
+    } finally {
+      release();
+      await first;
+    }
+  });
+
+  it.each([false, true])(
+    "yields after actual caller work (ready continuation: %s)",
+    async (continuation) => {
+      let workClock = 0;
+      vi.spyOn(performance, "now").mockImplementation(() => workClock);
+      const events: string[] = [];
+      let sentinel: Promise<void> | undefined;
+      const first = requestStart().then(async () => {
+        if (continuation) {
+          await Promise.resolve();
+        }
+        events.push("first");
+        workClock += 20;
+        sentinel = nextTurn().then(() => {
+          events.push("yield");
+        });
+      });
+      const second = requestStart().then(() => {
+        events.push("second");
+      });
+      await Promise.all([first, second]);
+      await sentinel;
+      expect(events).toEqual(["first", "yield", "second"]);
+    },
+  );
+
+  it("bounds zero-cost starts per turn even when elapsed work stays zero", async () => {
+    vi.spyOn(performance, "now").mockReturnValue(0);
+    const starts: number[] = [];
+    let seenAtYield: number | undefined;
+    let sentinel: Promise<void> | undefined;
+    const callers = Array.from({ length: 65 }, (_, index) =>
+      requestStart().then(() => {
+        starts.push(index);
+        if (index === 0) {
+          sentinel = nextTurn().then(() => {
+            seenAtYield = starts.length;
+          });
+        }
+      }),
+    );
+    await Promise.all(callers);
+    await sentinel;
+    expect(seenAtYield).toBe(64);
+    expect(starts).toEqual(Array.from({ length: 65 }, (_, index) => index));
+  });
+
+  it("rejects count overflow without starting it inline and releases waiting capacity", async () => {
+    vi.spyOn(performance, "now").mockReturnValue(0);
+    const accepted = Array.from({ length: 257 }, () => requestStart());
+    expect(scheduleGatewayRequestStart(1)).toBeNull();
+    await Promise.all(accepted);
+    await expect(requestStart()).resolves.toBeUndefined();
+  });
+
+  it("accounts the original serialized bytes independently of frame count", async () => {
+    vi.spyOn(performance, "now").mockReturnValue(0);
+    const first = requestStart(25 * 1024 * 1024);
+    const second = requestStart(25 * 1024 * 1024);
+    const third = requestStart(25 * 1024 * 1024);
+    expect(scheduleGatewayRequestStart(1)).toBeNull();
+    await Promise.all([first, second, third]);
+    await expect(requestStart(25 * 1024 * 1024)).resolves.toBeUndefined();
+  });
+});

--- a/src/gateway/server/ws-connection/request-start.ts
+++ b/src/gateway/server/ws-connection/request-start.ts
@@ -1,0 +1,70 @@
+import { performance } from "node:perf_hooks";
+import { setImmediate as nextTurn } from "node:timers/promises";
+import type { WebSocket } from "ws";
+import { runOutsideGatewayRootWorkAdmission } from "../../../process/gateway-work-admission.js";
+import { BoundedSerialQueue } from "../../../shared/bounded-serial-queue.js";
+import type { GatewayRole } from "../../role-policy.js";
+import { MAX_PAYLOAD_BYTES } from "../../server-constants.js";
+
+type GatewayReceiver = { _maxPayload?: number; _allowSynchronousEvents?: boolean };
+
+export function prepareGatewayReceiverHandoff(
+  socket: WebSocket,
+  role: GatewayRole,
+): (() => void) | null {
+  // SAFETY: ws owns these private per-frame fields; validate each before the handoff.
+  const receiver = (socket as WebSocket & { _receiver?: GatewayReceiver })["_receiver"];
+  if (
+    !receiver ||
+    typeof receiver["_maxPayload"] !== "number" ||
+    Object.getOwnPropertyDescriptor(receiver, "_maxPayload")?.writable !== true ||
+    (role === "operator" &&
+      (typeof receiver["_allowSynchronousEvents"] !== "boolean" ||
+        Object.getOwnPropertyDescriptor(receiver, "_allowSynchronousEvents")?.writable !== true))
+  ) {
+    return null;
+  }
+  return () => {
+    receiver["_maxPayload"] = MAX_PAYLOAD_BYTES;
+    if (role === "operator") {
+      receiver["_allowSynchronousEvents"] = true;
+    }
+  };
+}
+
+// One active scheduling task is separate from these waiting budgets. Each task
+// grants start permission only; it never owns the RPC or waits for its completion.
+const requestStarts = new BoundedSerialQueue({
+  maxPendingCount: 256,
+  maxPendingWeight: 50 * 1024 * 1024,
+});
+const MAX_STARTS_PER_TURN = 64;
+const START_WORK_BUDGET_MS = 12;
+let turnStartedAt = 0;
+let turnStarts = 0;
+
+/** Grants operator router-start permission, or null when its waiting budget is exhausted. */
+export function scheduleGatewayRequestStart(frameBytes: number): Promise<void> | null {
+  return runOutsideGatewayRootWorkAdmission(() => {
+    const wasIdle = requestStarts.isIdle;
+    const admission = requestStarts.enqueue(
+      async () => {
+        // Observe ready caller work before granting another start, without awaiting
+        // an unresolved request or capturing that caller's root admission.
+        await new Promise<void>(queueMicrotask);
+        if (
+          wasIdle ||
+          turnStarts >= MAX_STARTS_PER_TURN ||
+          performance.now() - turnStartedAt >= START_WORK_BUDGET_MS
+        ) {
+          await nextTurn();
+          turnStartedAt = performance.now();
+          turnStarts = 0;
+        }
+        turnStarts++;
+      },
+      { weight: frameBytes, sealOnOverflow: false },
+    );
+    return admission.accepted ? admission.completion : null;
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the Control UI and Gateway control requests can wait several seconds during concurrent agent turns, despite the individual requests succeeding. This follows #133683 and #133782. In the retained browser-inclusive reproduction, most of the worst request's latency occurred before its server receive callback.

## Why This Change Was Made

The WebSocket receiver was yielding once for every authenticated operator message. Coalesced requests therefore competed across many event-loop turns with synchronous agent/session preparation. After successful operator registration, let the receiver deliver the available frames and put cooperative scheduling at the router-start owner instead. Reuse the existing bounded serial queue to grant start permission; do not hold its task until the RPC finishes.

The queue yields on idle entry, after 64 starts, or after observing 12ms of ready caller work. These are cooperative scheduling budgets, not CPU preemption or a maximum event-loop delay. Its waiting budget is 256 tasks and 50MiB of original serialized frame weights; the active permission task is separate. This does not cap active RPCs, heap use, or callers waiting for lazy router loading or earlier credential mutations. Overflow returns retryable `UNAVAILABLE` before that request's method runs, and later admission resumes after capacity drains.

Pre-authentication, node lifecycle/result traffic, and dedicated workers retain native receiver yielding and their existing admission/drain owners. The receiver handoff validates the installed dependency fields before registration. Deferred starts recheck current client/shared-auth/runtime authority and selective cancellation. Credential mutation ordering remains connection-owned. Ordinary UI/SDK work can survive a disconnect; companion asks and CLI node invocation retain cancellation. Each router dispatch owns its root admission and diagnostic trace.

No dependency patch, configuration option, timeout increase, protocol version, SQLite schema, or persistent-store concurrency change. The old unvalidated receiver-payload helper is removed. Production delta is **+105 lines**; tests/support **+710**, docs **+5**, assertion baseline **−1**. The added production code owns bounded start scheduling, dependency handoff validation and authority rechecks; the existing generic queue is reused rather than duplicated.

## User Impact

Control requests can start promptly without waiting for unrelated long RPCs to finish. Responses may still complete out of order. The protocol documentation describes the typed overload response. This does not promise zero event-loop occupancy or establish a memory leak.

## Evidence

The integrated candidate at `b8bba37e5b778a10df5ab2bb8306c11ac414a85c` includes preparation #133782. Fresh source-performance and Control UI builds passed; source/build snapshots matched before and after each run. Focused owner and sibling suites passed **16 files / 225 tests**. Two Codex autoreviews completed with no accepted findings at their requested P0 scope; subsequent mechanical test cleanup was checked directly and by the final suites. The complete 13-file `check-changed` gate passed on that source, including core and test types, full core/scripts lint, formatting and all guards. The landed preparation commit was then integrated with an identical scheduler patch at `7bf8082d385230efb7ca1f7d2be2aa0fde4c847a`; main contributes four disjoint assertion-baseline cleanups. Fresh exact-source build/profile and exact-head hosted CI results will be appended as they complete.

| Isolated 32-turn proof | List max | History max / p99 | Control UI HTTP max | Readiness max |
| --- | ---: | ---: | ---: | ---: |
| Three standard runs, aggregate | 898ms | 1944 / 1542ms | 983ms | 880ms |
| Built UI + CPU profile, requests observer | 804ms | 926 / 888ms | 777ms | 436ms |
| Built UI + CPU profile, append observer | 942ms | 1982 / 1726ms | 902ms | 394ms |

All valid runs passed the unchanged **2000ms** control/handshake budgets with zero operation failure counters and zero plugin metadata rescans. Browser proof includes visible session updates, streamed assistant output and post-load recovery; the append run returned two eligible healthy samples within 4.01 seconds. Event-loop utilization still reaches 1 and readiness still reports degradation during load. History's worst append-observer request has only 18ms budget headroom. This is a measured improvement with remaining synchronous work, not a claim that every event-loop stall is eliminated.

The profile runs completed 640/645 history operations and each recorded 32 successful model-fetch starts. The harness's separate whole mock-provider log counts differ (34/67) and are not generation counts; raw provider logs were not retained, so the difference is not assigned to a specific cause. Request counts and source generations differ from older profiles. No throughput or percentage speedup is inferred from those unequal totals. The requests-mode recording is supplemental; append mode matches the earlier observer policy.

An initial profiler-controller attempt failed before launching a Gateway because it lacked the repository TSX preload. Its failed artifacts are retained and excluded from performance conclusions; both valid profiles used the unchanged controller with the required preload.

The retained native reproduction injects 33 masked operator frames as one receive chunk into a real upgraded socket, with the work clock held constant to isolate cheap-start batching: the parent starts only two before the first event-loop sentinel, while the candidate starts the whole burst. Separate owner tests advance the work clock to check yielding, and the isolated live measurements use the real clock. The final request completes while 32 deliberately held requests remain unresolved. Native control-frame, close/disconnect, pre-auth/node pacing, receiver-contract drift, authority invalidation, credential mutation chains, root-admission isolation, and queue count/byte recovery are covered.

Earlier failing baseline/preparation measurements and an incomplete browser recording remain retained. All runs use synthetic isolated HOME/state and owned loopback ports; no production or operator Gateway is involved. No latency, timeout, CSS or test assertion threshold was increased.


Final exact-source integration at `7bf8082d385230efb7ca1f7d2be2aa0fde4c847a` passed fresh source/Control UI builds and the same append-mode 32-turn browser/CPU workload: list **394ms**, history **593ms** (p99 **507ms**), HTTP **399ms**, readiness **270ms**, handshake **105ms**, with zero operation failures and zero metadata rescans. All 1,019 benchmark request identities joined across the original five markers, 580 history operations completed, and 133 browser sends retained 128 observed responses plus five explicitly incomplete requests at closure. Two healthy recovery observations completed within 3.01 seconds. All 39,463 pinned source/build/dependency files matched before and after the run; all three synthetic UI captures were inspected.

The first integrated profile is retained as invalid even though its benchmark budgets passed: two old-document requests lacked Playwright sender events during full navigation. Installed Playwright source clears its socket event map at new-document commit; the UI's visibility listeners can still produce final requests while that document hides. The recorder now stops the existing UI Gateway owner and observes the first navigation's actual socket close before navigating, just as it already did before final browser disposal. Strict validation requires both closures and still rejects unknown IDs; no missing record is inferred from socket identity. Offline positive/negative checks cover this ordering and the unchanged five benchmark markers. The corrected run changes that observer lifecycle, so its lower latency is not attributed solely to the product patch or used as a matched speedup ratio.


Exact-head [CI33364484661](https://github.com/openclaw/openclaw/actions/runs/33364484661) passed at `7bf8082d385230efb7ca1f7d2be2aa0fde4c847a`.
