### PR TITLE
test(ui): consolidate duplicate owner coverage

### DIFF
--- a/ui/src/lib/chat/message-extract.test.ts
+++ b/ui/src/lib/chat/message-extract.test.ts
@@ -4,14 +4,6 @@ import { describe, expect, it } from "vitest";
 import { extractText, extractTextCached, extractThinkingCached } from "./message-extract.ts";
 
 describe("extractTextCached", () => {
-  it("matches extractText output", () => {
-    const message = {
-      role: "assistant",
-      content: [{ type: "text", text: "Hello there" }],
-    };
-    expect(extractTextCached(message)).toBe(extractText(message));
-  });
-
   it("returns consistent text output for repeated calls", () => {
     const message = {
       role: "user",
@@ -145,7 +137,6 @@ describe("nullish messages", () => {
     for (const message of [undefined, null]) {
       expect(extractText(message)).toBeNull();
       expect(extractTextCached(message)).toBeNull();
-      expect(extractText(message)).toBeNull();
       expect(extractThinkingCached(message)).toBeNull();
     }
   });

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -184,36 +184,6 @@ describe("stripThinkingTags", () => {
     expect(stripThinkingTags("<final\nHello")).toBe("<final\nHello");
     expect(stripThinkingTags("Hello</final>")).toBe("Hello");
   });
-
-  it("strips <relevant-memories> blocks", () => {
-    const input = [
-      "<relevant-memories>",
-      "The following memories may be relevant to this conversation:",
-      "- Internal memory note",
-      "</relevant-memories>",
-      "",
-      "User-visible answer",
-    ].join("\n");
-    expect(stripThinkingTags(input)).toBe("User-visible answer");
-  });
-
-  it("keeps relevant-memories tags in fenced code blocks", () => {
-    const input = [
-      "```xml",
-      "<relevant-memories>",
-      "sample",
-      "</relevant-memories>",
-      "```",
-      "",
-      "Visible text",
-    ].join("\n");
-    expect(stripThinkingTags(input)).toBe(input);
-  });
-
-  it("hides unfinished <relevant-memories> block tails", () => {
-    const input = ["Hello", "<relevant-memories>", "internal-only"].join("\n");
-    expect(stripThinkingTags(input)).toBe("Hello\n");
-  });
 });
 
 describe("formatUnknownText", () => {

--- a/ui/src/lib/toast.test.ts
+++ b/ui/src/lib/toast.test.ts
@@ -90,19 +90,6 @@ describe("shared toast", () => {
     expect(host.querySelector(".app-toast")).toBeNull();
   });
 
-  it("runs its action once and dismisses", async () => {
-    const host = await mountHost();
-    const onAction = vi.fn();
-    showToast({ message: "Archived", actionLabel: "Undo", onAction });
-    await host.updateComplete;
-
-    host.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
-    await host.updateComplete;
-
-    expect(onAction).toHaveBeenCalledOnce();
-    expect(host.querySelector(".app-toast")).toBeNull();
-  });
-
   it("preserves the dismissal reason when an exiting toast is replaced", async () => {
     vi.useFakeTimers();
     const host = await mountHost();
@@ -134,6 +121,7 @@ describe("shared toast", () => {
     await host.updateComplete;
     host.querySelector<HTMLButtonElement>(".app-toast__action")?.click();
     await host.updateComplete;
+    expect(host.querySelector(".app-toast")).toBeNull();
 
     showToast({ message: "Third", onDismiss: (reason) => reasons.push(reason) });
     await host.updateComplete;


### PR DESCRIPTION
## What Problem This Solves

UI tests repeat memory-scaffold inputs already checked at the canonical sanitizer, compare a cache miss with its own uncached implementation, and repeat a toast action scenario covered by the dismissal lifecycle case.

## Why This Change Was Made

Keep memory removal and literal-code assertions at their canonical owner and retain independent literal expectations through actual UI extraction. Remove the cache self-comparison and repeated nullish assertion. Move immediate toast disappearance into the existing lifecycle case, before any later toast could hide stale state; its exact event sequence still checks one callback and dismissal ordering.

## User Impact

Production, styles and test support are unchanged. Five redundant executions are removed; tests +1/-52 (net -51). Cache hits, role/phase selection, rendered/copy/reply privacy, reasoning, literal code, modal routing, timeout and annotation Undo ownership keep their independent coverage.

## Evidence

The removed memory fixtures are byte-identical to retained canonical cases. The deleted cache comparison had no independent oracle and did not hit the cache. Raw-parent history confirms the duplicated nullish assertion and the later toast lifecycle coverage. A real critical-notice caller retains the action-only variant without a dismissal callback; the annotation owner retains both callbacks and bounded payload lifetime.

The same six-file focused selection passed before (220 tests) and after (215 tests), including all 129 canonical sanitizer cases, the real toast lifecycle, annotation Undo ownership, and the real action-only critical-notice caller. The full changed gate and Codex review passed. No browser build or execution is claimed for this test-only consolidation.
