### PR TITLE
test: consolidate IRC socket fixture lifetimes

### DIFF
--- a/extensions/irc/src/client.test.ts
+++ b/extensions/irc/src/client.test.ts
@@ -1,7 +1,7 @@
 // Irc tests cover client plugin behavior.
-import net from "node:net";
 import { describe, expect, it } from "vitest";
 import { connectIrcClient } from "./client.js";
+import { onIrcTestLine, startIrcTestServer } from "./irc-server.test-support.js";
 
 type LoopbackIrcServer = {
   port: number;
@@ -21,62 +21,24 @@ async function startLoopbackIrcServer(options?: {
   rejectInitialNick?: boolean;
 }): Promise<LoopbackIrcServer> {
   const lines: string[] = [];
-  const sockets = new Set<net.Socket>();
-  const server = net.createServer((socket) => {
-    sockets.add(socket);
-    socket.setEncoding("utf8");
-    let buffer = "";
+  const server = await startIrcTestServer((socket) => {
     let awaitingFallbackNick = false;
-    socket.on("data", (chunk: string) => {
-      buffer += chunk;
-      let idx = buffer.indexOf("\n");
-      while (idx !== -1) {
-        const line = buffer.slice(0, idx).replace(/\r$/, "");
-        buffer = buffer.slice(idx + 1);
-        idx = buffer.indexOf("\n");
-        lines.push(line);
-        if (line.startsWith("USER ")) {
-          if (options?.rejectInitialNick) {
-            awaitingFallbackNick = true;
-            socket.write(":server 433 * bot :Nickname in use\r\n");
-          } else {
-            socket.write(":server 001 bot :welcome\r\n");
-          }
-        } else if (awaitingFallbackNick && line.startsWith("NICK ")) {
-          awaitingFallbackNick = false;
-          socket.write(`:server 001 ${line.slice("NICK ".length)} :welcome\r\n`);
+    onIrcTestLine(socket, (line) => {
+      lines.push(line);
+      if (line.startsWith("USER ")) {
+        if (options?.rejectInitialNick) {
+          awaitingFallbackNick = true;
+          socket.write(":server 433 * bot :Nickname in use\r\n");
+        } else {
+          socket.write(":server 001 bot :welcome\r\n");
         }
+      } else if (awaitingFallbackNick && line.startsWith("NICK ")) {
+        awaitingFallbackNick = false;
+        socket.write(`:server 001 ${line.slice("NICK ".length)} :welcome\r\n`);
       }
     });
-    socket.on("close", () => {
-      sockets.delete(socket);
-    });
   });
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address();
-  if (!address || typeof address === "string") {
-    throw new Error("expected loopback IRC server to bind a TCP port");
-  }
-  return {
-    port: address.port,
-    lines,
-    close: async () => {
-      for (const socket of sockets) {
-        socket.destroy();
-      }
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      });
-    },
-  };
+  return { ...server, lines };
 }
 
 async function connectAndCollectRegistration(params: {
@@ -85,44 +47,46 @@ async function connectAndCollectRegistration(params: {
 }): Promise<{ lines: string[]; errors: Error[] }> {
   const server = await startLoopbackIrcServer();
   const errors: Error[] = [];
-  const client = await connectIrcClient({
-    host: "127.0.0.1",
-    port: server.port,
-    tls: false,
-    nick: "bot",
-    username: "bot",
-    realname: "OpenClaw Bot",
-    nickserv: params.nickserv,
-    onError: (error) => errors.push(error),
-  });
+  let client: Awaited<ReturnType<typeof connectIrcClient>> | undefined;
   try {
+    client = await connectIrcClient({
+      host: "127.0.0.1",
+      port: server.port,
+      tls: false,
+      nick: "bot",
+      username: "bot",
+      realname: "OpenClaw Bot",
+      nickserv: params.nickserv,
+      onError: (error) => errors.push(error),
+    });
     await waitForIrcCondition(
       () => params.done(server.lines, errors),
       "expected IRC registration outcome",
     );
     return { lines: [...server.lines], errors };
   } finally {
-    client.close();
+    client?.close();
     await server.close();
   }
 }
 
 async function connectAfterNickCollision(nick: string): Promise<string> {
   const server = await startLoopbackIrcServer({ rejectInitialNick: true });
-  const client = await connectIrcClient({
-    host: "127.0.0.1",
-    port: server.port,
-    tls: false,
-    nick,
-    username: "bot",
-    realname: "OpenClaw Bot",
-  });
+  let client: Awaited<ReturnType<typeof connectIrcClient>> | undefined;
   try {
+    client = await connectIrcClient({
+      host: "127.0.0.1",
+      port: server.port,
+      tls: false,
+      nick,
+      username: "bot",
+      realname: "OpenClaw Bot",
+    });
     const nickLines = server.lines.filter((line) => line.startsWith("NICK "));
     expect(nickLines).toHaveLength(2);
     return nickLines[1]!.slice("NICK ".length);
   } finally {
-    client.close();
+    client?.close();
     await server.close();
   }
 }
@@ -144,48 +108,22 @@ async function waitForIrcCondition(
 }
 
 async function startHangingIrcServer(): Promise<HangingIrcServer> {
-  const sockets = new Set<net.Socket>();
   let acceptedCount = 0;
   let closedCount = 0;
-  const server = net.createServer((socket) => {
+  const server = await startIrcTestServer((socket) => {
     acceptedCount += 1;
-    sockets.add(socket);
-    socket.setEncoding("utf8");
     socket.on("data", () => {});
     socket.on("close", () => {
-      sockets.delete(socket);
       closedCount += 1;
     });
   });
-  await new Promise<void>((resolve) => {
-    server.listen(0, "127.0.0.1", resolve);
-  });
-  const address = server.address();
-  if (!address || typeof address === "string") {
-    throw new Error("expected loopback IRC server to bind a TCP port");
-  }
   return {
-    port: address.port,
+    ...server,
     get acceptedCount() {
       return acceptedCount;
     },
     get closedCount() {
       return closedCount;
-    },
-    openSocketCount: () => sockets.size,
-    close: async () => {
-      for (const socket of sockets) {
-        socket.destroy();
-      }
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      });
     },
   };
 }

--- a/extensions/irc/src/irc-server.test-support.ts
+++ b/extensions/irc/src/irc-server.test-support.ts
@@ -1,0 +1,63 @@
+import net from "node:net";
+
+type IrcTestServer = {
+  port: number;
+  openSocketCount(): number;
+  close(): Promise<void>;
+};
+
+export async function startIrcTestServer(
+  onConnection: (socket: net.Socket) => void,
+): Promise<IrcTestServer> {
+  const sockets = new Set<net.Socket>();
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.setEncoding("utf8");
+    socket.on("close", () => sockets.delete(socket));
+    onConnection(socket);
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected loopback IRC server to bind a TCP port");
+  }
+  return {
+    port: address.port,
+    openSocketCount: () => sockets.size,
+    close: async () => {
+      // Server.close waits for accepted peers; destroy them before awaiting listener shutdown.
+      for (const socket of sockets) {
+        socket.destroy();
+      }
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+    },
+  };
+}
+
+export function onIrcTestLine(socket: net.Socket, onLine: (line: string) => void): void {
+  let buffer = "";
+  socket.on("data", (chunk: string) => {
+    buffer += chunk;
+    let idx = buffer.indexOf("\n");
+    while (idx !== -1) {
+      const line = buffer.slice(0, idx).replace(/\r$/, "");
+      buffer = buffer.slice(idx + 1);
+      idx = buffer.indexOf("\n");
+      onLine(line);
+    }
+  });
+}

--- a/extensions/irc/src/monitor.test.ts
+++ b/extensions/irc/src/monitor.test.ts
@@ -9,6 +9,7 @@ import {
 } from "openclaw/plugin-sdk/channel-ingress-test-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { createIrcIngressMonitor } from "./irc-ingress.js";
+import { onIrcTestLine, startIrcTestServer } from "./irc-server.test-support.js";
 import { monitorIrcProvider } from "./monitor.js";
 import { setIrcRuntime } from "./runtime.js";
 import type { CoreConfig, IrcInboundMessage } from "./types.js";
@@ -86,70 +87,28 @@ async function waitForIrcAsyncCondition(
 
 async function startDisconnectingIrcServer(): Promise<DisconnectingIrcServer> {
   const lines: string[] = [];
-  const sockets = new Set<net.Socket>();
   let connectionCount = 0;
-
-  const server = net.createServer((socket) => {
+  const server = await startIrcTestServer((socket) => {
     const connectionNumber = ++connectionCount;
-    sockets.add(socket);
-    socket.setEncoding("utf8");
-    let buffer = "";
-    socket.on("data", (chunk: string) => {
-      buffer += chunk;
-      let idx = buffer.indexOf("\n");
-      while (idx !== -1) {
-        const line = buffer.slice(0, idx).replace(/\r$/, "");
-        buffer = buffer.slice(idx + 1);
-        idx = buffer.indexOf("\n");
-        lines.push(line);
-        if (line.startsWith("USER ")) {
-          if (connectionNumber === 2) {
-            socket.destroy();
-          } else {
-            socket.write(":server 001 bot :welcome\r\n");
-          }
-          if (connectionNumber === 1) {
-            setTimeout(() => socket.destroy(), 10);
-          }
+    onIrcTestLine(socket, (line) => {
+      lines.push(line);
+      if (line.startsWith("USER ")) {
+        if (connectionNumber === 2) {
+          socket.destroy();
+        } else {
+          socket.write(":server 001 bot :welcome\r\n");
+        }
+        if (connectionNumber === 1) {
+          setTimeout(() => socket.destroy(), 10);
         }
       }
     });
-    socket.on("close", () => {
-      sockets.delete(socket);
-    });
   });
-
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      server.off("error", reject);
-      resolve();
-    });
-  });
-  const address = server.address();
-  if (!address || typeof address === "string") {
-    throw new Error("expected loopback IRC server to bind a TCP port");
-  }
-
   return {
-    port: address.port,
+    ...server,
     lines,
     get connectionCount() {
       return connectionCount;
-    },
-    close: async () => {
-      for (const socket of sockets) {
-        socket.destroy();
-      }
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      });
     },
   };
 }
@@ -160,126 +119,51 @@ async function startInboundIrcServer(
   colonlessBody = false,
   senderNick = "alice",
 ): Promise<InboundIrcServer> {
-  const sockets = new Set<net.Socket>();
-  const server = net.createServer((socket) => {
-    sockets.add(socket);
-    socket.setEncoding("utf8");
-    let buffer = "";
-    socket.on("data", (chunk: string) => {
-      buffer += chunk;
-      let idx = buffer.indexOf("\n");
-      while (idx !== -1) {
-        const line = buffer.slice(0, idx).replace(/\r$/, "");
-        buffer = buffer.slice(idx + 1);
-        idx = buffer.indexOf("\n");
-        if (line.startsWith("USER ")) {
-          socket.write(`:server 001 ${welcomeNick} :welcome\r\n`);
-          if (target) {
-            setTimeout(() => {
-              const bodySeparator = colonlessBody ? " " : " :";
-              socket.write(
-                `:${senderNick}!ident@example.org PRIVMSG ${target}${bodySeparator}hello\r\n`,
-              );
-            }, 20);
-          }
+  return await startIrcTestServer((socket) => {
+    onIrcTestLine(socket, (line) => {
+      if (line.startsWith("USER ")) {
+        socket.write(`:server 001 ${welcomeNick} :welcome\r\n`);
+        if (target) {
+          setTimeout(() => {
+            const bodySeparator = colonlessBody ? " " : " :";
+            socket.write(
+              `:${senderNick}!ident@example.org PRIVMSG ${target}${bodySeparator}hello\r\n`,
+            );
+          }, 20);
         }
       }
     });
-    socket.on("close", () => sockets.delete(socket));
   });
-
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      server.off("error", reject);
-      resolve();
-    });
-  });
-  const address = server.address();
-  if (!address || typeof address === "string") {
-    throw new Error("expected loopback IRC server to bind a TCP port");
-  }
-  return {
-    port: address.port,
-    close: async () => {
-      for (const socket of sockets) {
-        socket.destroy();
-      }
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      });
-    },
-  };
 }
 
 async function startReconnectingReplyIrcServer(): Promise<ReconnectingReplyIrcServer> {
+  // Retain closed sockets in order so reconnect assertions keep their original connection index.
   const sockets: net.Socket[] = [];
   const linesByConnection: string[][] = [];
-  const server = net.createServer((socket) => {
+  const server = await startIrcTestServer((socket) => {
     const connectionIndex = sockets.length;
     sockets.push(socket);
     linesByConnection[connectionIndex] = [];
-    socket.setEncoding("utf8");
-    let buffer = "";
-    socket.on("data", (chunk: string) => {
-      buffer += chunk;
-      let idx = buffer.indexOf("\n");
-      while (idx !== -1) {
-        const line = buffer.slice(0, idx).replace(/\r$/, "");
-        buffer = buffer.slice(idx + 1);
-        idx = buffer.indexOf("\n");
-        linesByConnection[connectionIndex]?.push(line);
-        if (line.startsWith("USER ")) {
-          const nick = connectionIndex === 0 ? "receipt-bot" : "reconnected-bot";
-          socket.write(`:server 001 ${nick} :welcome\r\n`);
-          if (connectionIndex === 0) {
-            setTimeout(() => {
-              socket.write(":alice!ident@example.org PRIVMSG receipt-bot :hello\r\n");
-            }, 20);
-          }
+    onIrcTestLine(socket, (line) => {
+      linesByConnection[connectionIndex]?.push(line);
+      if (line.startsWith("USER ")) {
+        const nick = connectionIndex === 0 ? "receipt-bot" : "reconnected-bot";
+        socket.write(`:server 001 ${nick} :welcome\r\n`);
+        if (connectionIndex === 0) {
+          setTimeout(() => {
+            socket.write(":alice!ident@example.org PRIVMSG receipt-bot :hello\r\n");
+          }, 20);
         }
       }
     });
   });
-
-  await new Promise<void>((resolve, reject) => {
-    server.once("error", reject);
-    server.listen(0, "127.0.0.1", () => {
-      server.off("error", reject);
-      resolve();
-    });
-  });
-  const address = server.address();
-  if (!address || typeof address === "string") {
-    throw new Error("expected loopback IRC server to bind a TCP port");
-  }
   return {
-    port: address.port,
+    ...server,
     linesByConnection,
     get connectionCount() {
       return sockets.length;
     },
     disconnectFirst: () => sockets[0]?.destroy(),
-    close: async () => {
-      for (const socket of sockets) {
-        socket.destroy();
-      }
-      await new Promise<void>((resolve, reject) => {
-        server.close((error) => {
-          if (error) {
-            reject(error);
-            return;
-          }
-          resolve();
-        });
-      });
-    },
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

IRC client and monitor tests independently implement five real TCP server lifetimes and four copies of line framing. Two client fixtures also connect before entering their existing cleanup scope: if real registration rejects, the client closes its own socket but the test leaves its server listening.

## Why This Change Was Made

Share the TCP listener, accepted-socket ownership and line framing in one test-only helper. Keep each scenario's replies, counters, reconnect timing, polling, SQLite setup and assertions in its current test. Move both fixture connection awaits inside their existing `try/finally`, so the fixture always closes its listener even when no client is returned.

The shared helper keeps a live socket set for cleanup. The reconnect scenario separately retains its original append-only connection history, so historical socket indexing and real reconnect assertions remain intact. No production, dependency, sharding, concurrency, routing or deadline change.

## Evidence

- Normal before/after client, monitor, ingress, probe and surrogate suites pass all 41 cases, with identical expanded names and per-file order. The consolidated fixtures also passed all 41 with shuffled order before the rejection repair; the final ordinary run includes that repair.
- A temporary real TCP diagnostic sends `464` instead of the attempted welcome. In the collision path it preserves the actual `433`, fallback `NICK`, then `464` exchange. Both original fixture wrappers fail the closed-listener assertion; the exact repaired wrapper bodies using the actual shared helper pass both cases. The diagnostic verifies the production rejection, native listener close event, null bound address and accepted socket closure. Its fallback cleanup also closes all resources after the deliberately failing original assertions.
- The diagnostic is external proof, not an added permanent test harness or a production-client leak claim. Existing production-client readiness-timeout, socket-close, reconnect and protocol assertions remain.
- Root inspection covered complete client/monitor/ingress owners and callers, existing tests, actual Node socket/server close implementation and installed timeout implementation. A neighboring HTTP helper cannot own these real TCP fixtures.
- Codex autoreview at the configured P0 threshold is clean. The full changed gate, including extension test typecheck and lint, passes; a separate full author-independent review of the amended owner/fixture/probe paths has no actionable finding.

Production LOC: unchanged. Tests and support: +137/-252, 115 fewer lines, including the rejection cleanup repair. No timing percentage is claimed.

Provenance: the connect-before-cleanup ordering is present in the retained pre-change fixture. Its original introduction is unknown; inspected later lifecycle/security changes do not establish introduction. The observed defect belongs to the test fixture's listener lifetime, not production IRC connection ownership.

Current-main composition: the unchanged candidate was exercised with the other pending fixture cleanups on `a5269bb31b875abc29ad55b0811183d1f0afb19f`. All 189 cases across the five normal project invocations passed, including this change’s 41-case owner/sibling group. Original full case names and per-file order remain unchanged. Fresh Codex review of the composed test-only diff is clean at its configured P0 threshold. The separate original/final proofs above remain the evidence for this individual change.

Final combined changed gate on `a5269bb31b875abc29ad55b0811183d1f0afb19f` also passed, including core and plugin test types, lint, boundary guards and dead-export checks. The seven reviewed file afterimages were unchanged after the 189-case run, review and gate.
