### PR TITLE
test: simplify plugin slot selection oracles

### DIFF
--- a/src/plugins/slots.test.ts
+++ b/src/plugins/slots.test.ts
@@ -1,7 +1,6 @@
 /** Tests plugin slot normalization and exclusive slot selection behavior. */
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
-import type { PluginKind } from "./plugin-kind.types.js";
 import {
   applyExclusiveSlotSelection,
   hasKind,
@@ -41,52 +40,6 @@ describe("applyExclusiveSlotSelection", () => {
     },
   });
 
-  const runMemorySelection = (config: OpenClawConfig, selectedId = "memory") =>
-    applyExclusiveSlotSelection({
-      config,
-      selectedId,
-      selectedKind: "memory",
-      registry: {
-        plugins: [
-          { id: "memory-core", kind: "memory" },
-          { id: "memory", kind: "memory" },
-        ],
-      },
-    });
-
-  function expectMemorySelectionState(
-    result: ReturnType<typeof applyExclusiveSlotSelection>,
-    params: {
-      changed: boolean;
-      selectedId?: string;
-      disabledCompetingPlugin?: boolean;
-    },
-  ) {
-    expect(result.changed).toBe(params.changed);
-    if (params.selectedId) {
-      expect(result.config.plugins?.slots?.memory).toBe(params.selectedId);
-    }
-    if (params.disabledCompetingPlugin != null) {
-      expect(result.config.plugins?.entries?.["memory-core"]?.enabled).toBe(
-        params.disabledCompetingPlugin,
-      );
-    }
-  }
-
-  function expectSelectionWarnings(
-    warnings: string[],
-    params: {
-      expected: readonly string[];
-    },
-  ) {
-    expect(warnings).toEqual([...params.expected]);
-  }
-
-  function expectUnchangedSelection(result: ReturnType<typeof applyExclusiveSlotSelection>) {
-    expect(result.changed).toBe(false);
-    expect(result.warnings).toHaveLength(0);
-  }
-
   it("keeps the default memory selection implicit", () => {
     const config: OpenClawConfig = {
       plugins: { entries: { "memory-core": { enabled: true } } },
@@ -99,7 +52,8 @@ describe("applyExclusiveSlotSelection", () => {
       registry: { plugins: [{ id: "memory-core", kind: "memory" }] },
     });
 
-    expectUnchangedSelection(result);
+    expect(result.changed).toBe(false);
+    expect(result.warnings).toHaveLength(0);
     expect(result.config).toBe(config);
   });
 
@@ -128,55 +82,6 @@ describe("applyExclusiveSlotSelection", () => {
     expect(result.config.plugins?.entries?.memory?.enabled).toBe(false);
   });
 
-  function buildSelectionRegistry(
-    plugins: ReadonlyArray<{ id: string; kind?: PluginKind | PluginKind[] }>,
-  ) {
-    return {
-      plugins: [...plugins],
-    };
-  }
-
-  function expectUnchangedSelectionCase(params: {
-    config: OpenClawConfig;
-    selectedId: string;
-    selectedKind?: PluginKind | PluginKind[];
-    registry?: { plugins: ReadonlyArray<{ id: string; kind?: PluginKind | PluginKind[] }> };
-  }) {
-    const result = applyExclusiveSlotSelection({
-      config: params.config,
-      selectedId: params.selectedId,
-      ...(params.selectedKind ? { selectedKind: params.selectedKind } : {}),
-      ...(params.registry
-        ? {
-            registry: buildSelectionRegistry(params.registry.plugins),
-          }
-        : {}),
-    });
-
-    expectUnchangedSelection(result);
-    expect(result.config).toBe(params.config);
-  }
-
-  function expectChangedSelectionCase(params: {
-    config: OpenClawConfig;
-    selectedId?: string;
-    expectedDisabled?: boolean;
-    warningChecks: {
-      expected: readonly string[];
-    };
-  }) {
-    const result = runMemorySelection(params.config, params.selectedId);
-
-    expectMemorySelectionState(result, {
-      changed: true,
-      selectedId: params.selectedId ?? "memory",
-      ...(params.expectedDisabled != null
-        ? { disabledCompetingPlugin: params.expectedDisabled }
-        : {}),
-    });
-    expectSelectionWarnings(result.warnings, params.warningChecks);
-  }
-
   it.each([
     {
       name: "selects the slot and disables other entries for the same kind",
@@ -185,22 +90,18 @@ describe("applyExclusiveSlotSelection", () => {
         entries: { "memory-core": { enabled: true } },
       }),
       expectedDisabled: false,
-      warningChecks: {
-        expected: [
-          'Exclusive slot "memory" switched from "memory-core" to "memory".',
-          'Disabled other "memory" slot plugins: memory-core.',
-        ],
-      },
+      expectedWarnings: [
+        'Exclusive slot "memory" switched from "memory-core" to "memory".',
+        'Disabled other "memory" slot plugins: memory-core.',
+      ],
     },
     {
       name: "warns when the slot falls back to a default",
       config: createMemoryConfig(),
-      warningChecks: {
-        expected: [
-          'Exclusive slot "memory" switched from "memory-core" to "memory".',
-          'Disabled other "memory" slot plugins: memory-core.',
-        ],
-      },
+      expectedWarnings: [
+        'Exclusive slot "memory" switched from "memory-core" to "memory".',
+        'Disabled other "memory" slot plugins: memory-core.',
+      ],
     },
     {
       name: "keeps disabled competing plugins disabled without adding disable warnings",
@@ -210,16 +111,27 @@ describe("applyExclusiveSlotSelection", () => {
         },
       }),
       expectedDisabled: false,
-      warningChecks: {
-        expected: ['Exclusive slot "memory" switched from "memory-core" to "memory".'],
-      },
+      expectedWarnings: ['Exclusive slot "memory" switched from "memory-core" to "memory".'],
     },
-  ] as const)("$name", ({ config, expectedDisabled, warningChecks }) => {
-    expectChangedSelectionCase({
+  ] as const)("$name", ({ config, expectedDisabled, expectedWarnings }) => {
+    const result = applyExclusiveSlotSelection({
       config,
-      ...(expectedDisabled != null ? { expectedDisabled } : {}),
-      warningChecks,
+      selectedId: "memory",
+      selectedKind: "memory",
+      registry: {
+        plugins: [
+          { id: "memory-core", kind: "memory" },
+          { id: "memory", kind: "memory" },
+        ],
+      },
     });
+
+    expect(result.changed).toBe(true);
+    expect(result.config.plugins?.slots?.memory).toBe("memory");
+    if (expectedDisabled != null) {
+      expect(result.config.plugins?.entries?.["memory-core"]?.enabled).toBe(expectedDisabled);
+    }
+    expect(result.warnings).toEqual(expectedWarnings);
   });
 
   it.each([
@@ -238,12 +150,16 @@ describe("applyExclusiveSlotSelection", () => {
       selectedId: "custom",
     },
   ] as const)("$name", ({ config, selectedId, selectedKind, registry }) => {
-    expectUnchangedSelectionCase({
+    const result = applyExclusiveSlotSelection({
       config,
       selectedId,
       ...(selectedKind ? { selectedKind } : {}),
-      ...(registry ? { registry: buildSelectionRegistry(registry.plugins) } : {}),
+      ...(registry ? { registry: { plugins: [...registry.plugins] } } : {}),
     });
+
+    expect(result.changed).toBe(false);
+    expect(result.warnings).toHaveLength(0);
+    expect(result.config).toBe(config);
   });
 
   it("applies slot selection for each kind in a multi-kind array", () => {
@@ -260,11 +176,13 @@ describe("applyExclusiveSlotSelection", () => {
       config,
       selectedId: "dual-plugin",
       selectedKind: ["memory", "context-engine"],
-      registry: buildSelectionRegistry([
-        { id: "memory-core", kind: "memory" },
-        { id: "legacy", kind: "context-engine" },
-        { id: "dual-plugin", kind: ["memory", "context-engine"] },
-      ]),
+      registry: {
+        plugins: [
+          { id: "memory-core", kind: "memory" },
+          { id: "legacy", kind: "context-engine" },
+          { id: "dual-plugin", kind: ["memory", "context-engine"] },
+        ],
+      },
     });
     expect(result.changed).toBe(true);
     expect(result.config.plugins?.slots?.memory).toBe("dual-plugin");
@@ -286,10 +204,12 @@ describe("applyExclusiveSlotSelection", () => {
       config,
       selectedId: "new-memory",
       selectedKind: "memory",
-      registry: buildSelectionRegistry([
-        { id: "dual-plugin", kind: ["memory", "context-engine"] },
-        { id: "new-memory", kind: "memory" },
-      ]),
+      registry: {
+        plugins: [
+          { id: "dual-plugin", kind: ["memory", "context-engine"] },
+          { id: "new-memory", kind: "memory" },
+        ],
+      },
     });
     expect(result.changed).toBe(true);
     expect(result.config.plugins?.slots?.memory).toBe("new-memory");
@@ -311,10 +231,12 @@ describe("applyExclusiveSlotSelection", () => {
       config,
       selectedId: "new-memory",
       selectedKind: "memory",
-      registry: buildSelectionRegistry([
-        { id: "legacy", kind: ["memory", "context-engine"] },
-        { id: "new-memory", kind: "memory" },
-      ]),
+      registry: {
+        plugins: [
+          { id: "legacy", kind: ["memory", "context-engine"] },
+          { id: "new-memory", kind: "memory" },
+        ],
+      },
     });
     expect(result.changed).toBe(true);
     expect(result.config.plugins?.slots?.memory).toBe("new-memory");


### PR DESCRIPTION
## What Problem This Solves

Plugin slot-selection tests route inputs and assertions through seven small forwarding helpers. Their unused options and repeated copying hide which configuration, warnings and identity each case protects.

## Why This Change Was Made

Call the real slot-selection owner directly and keep the assertions beside each case. Retain the useful config builder and all existing tables. Preserve unchanged-config identity, exact ordered warning arrays, optional competing-plugin checks, implicit defaults, explicit override removal, and dual-kind ownership exemptions.

This changes no plugin selection policy, configuration, runtime behavior, persistence or dependency. No new mock, fixture, sharding, concurrency, routing, deadline or retry setting.

## Evidence

- Before and after: `node scripts/run-vitest.mjs src/plugins/slots.test.ts src/plugins/status.runtime-inspection.test.ts src/plugins/registry.dual-kind-memory-gate.test.ts` passes all 29 owner/sibling cases. Expanded names and per-file ordering are identical.
- Independent source comparison preserves 21 slot cases, 48 assertions and 24 calls to the actual exported owners. All warning literals/order and reference-identity assertions remain.
- Root read the complete changed test and slot owner, selection and uninstall/update callers, runtime-inspection/dual-kind siblings, the actual default-selection repair history and installed Vitest equality contract.
- Codex autoreview is clean at its configured P0 threshold; separate author-independent owner/caller/dependency review has no actionable finding.
- `CI=1 pnpm check:changed --base 273d1f017c0feb70f563b14eac0869b35d99bb3e -- src/plugins/slots.test.ts` passes the full changed gate, including core test types and lint.

Production LOC: unchanged. Tests: +53/-131, 78 fewer lines. This is removal of unnecessary test indirection, not a measured execution-time improvement.

Current-main composition: the unchanged candidate was exercised with the other pending fixture cleanups on `a5269bb31b875abc29ad55b0811183d1f0afb19f`. All 189 cases across the five normal project invocations passed, including this change’s 29-case owner/sibling group. Original full case names and per-file order remain unchanged. Fresh Codex review of the composed test-only diff is clean at its configured P0 threshold. The separate original/final proofs above remain the evidence for this individual change.

Final combined changed gate on `a5269bb31b875abc29ad55b0811183d1f0afb19f` also passed, including core and plugin test types, lint, boundary guards and dead-export checks. The seven reviewed file afterimages were unchanged after the 189-case run, review and gate.
