### PR TITLE
test: restore inherited logging environment

### DIFF
--- a/src/logging/level-filter.test.ts
+++ b/src/logging/level-filter.test.ts
@@ -1,5 +1,6 @@
 // Level filter tests cover logger filtering by configured log level.
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { captureEnv } from "../test-utils/env.js";
 
 const { readLoggingConfigMock } = vi.hoisted(() => ({
   readLoggingConfigMock: vi.fn<() => { level: "silent" } | { consoleLevel: "silent" } | undefined>(
@@ -12,6 +13,7 @@ vi.mock("./config.js", () => ({
   readLoggingConfig: readLoggingConfigMock,
 }));
 
+let envSnapshot: ReturnType<typeof captureEnv> | undefined;
 let logging: typeof import("../logging.js");
 
 beforeAll(async () => {
@@ -19,6 +21,11 @@ beforeAll(async () => {
 });
 
 beforeEach(() => {
+  envSnapshot = captureEnv([
+    "OPENCLAW_TEST_FILE_LOG",
+    "OPENCLAW_TEST_CONSOLE",
+    "OPENCLAW_LOG_LEVEL",
+  ]);
   delete process.env.OPENCLAW_TEST_FILE_LOG;
   delete process.env.OPENCLAW_TEST_CONSOLE;
   delete process.env.OPENCLAW_LOG_LEVEL;
@@ -28,9 +35,8 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  delete process.env.OPENCLAW_TEST_FILE_LOG;
-  delete process.env.OPENCLAW_TEST_CONSOLE;
-  delete process.env.OPENCLAW_LOG_LEVEL;
+  envSnapshot?.restore();
+  envSnapshot = undefined;
   logging.resetLogger();
   logging.setLoggerOverride(null);
   vi.restoreAllMocks();
@@ -102,55 +108,43 @@ function firstMockArg(mock: { mock: { calls: readonly unknown[][] } }): Record<s
 }
 
 describe("isFileLogLevelEnabled", () => {
-  it("returns false for all levels when configured as silent", () => {
-    logging.setLoggerOverride({ level: "silent" });
-    expect(logging.isFileLogLevelEnabled("fatal")).toBe(false);
-    expect(logging.isFileLogLevelEnabled("error")).toBe(false);
-    expect(logging.isFileLogLevelEnabled("warn")).toBe(false);
-    expect(logging.isFileLogLevelEnabled("info")).toBe(false);
-    expect(logging.isFileLogLevelEnabled("debug")).toBe(false);
-    expect(logging.isFileLogLevelEnabled("trace")).toBe(false);
-  });
-
-  it("passes only fatal when configured as fatal", () => {
-    logging.setLoggerOverride({ level: "fatal" });
-    expect(logging.isFileLogLevelEnabled("fatal")).toBe(true);
-    expect(logging.isFileLogLevelEnabled("error")).toBe(false);
-    expect(logging.isFileLogLevelEnabled("warn")).toBe(false);
-    expect(logging.isFileLogLevelEnabled("info")).toBe(false);
-    expect(logging.isFileLogLevelEnabled("debug")).toBe(false);
-    expect(logging.isFileLogLevelEnabled("trace")).toBe(false);
-  });
-
-  it("passes fatal and error when configured as error", () => {
-    logging.setLoggerOverride({ level: "error" });
-    expect(logging.isFileLogLevelEnabled("fatal")).toBe(true);
-    expect(logging.isFileLogLevelEnabled("error")).toBe(true);
-    expect(logging.isFileLogLevelEnabled("warn")).toBe(false);
-    expect(logging.isFileLogLevelEnabled("info")).toBe(false);
-    expect(logging.isFileLogLevelEnabled("debug")).toBe(false);
-    expect(logging.isFileLogLevelEnabled("trace")).toBe(false);
-  });
-
-  it("passes fatal, error, warn, info when configured as info", () => {
-    logging.setLoggerOverride({ level: "info" });
-    expect(logging.isFileLogLevelEnabled("fatal")).toBe(true);
-    expect(logging.isFileLogLevelEnabled("error")).toBe(true);
-    expect(logging.isFileLogLevelEnabled("warn")).toBe(true);
-    expect(logging.isFileLogLevelEnabled("info")).toBe(true);
-    expect(logging.isFileLogLevelEnabled("debug")).toBe(false);
-    expect(logging.isFileLogLevelEnabled("trace")).toBe(false);
-  });
-
-  it("passes all levels when configured as trace", () => {
-    logging.setLoggerOverride({ level: "trace" });
-    expect(logging.isFileLogLevelEnabled("fatal")).toBe(true);
-    expect(logging.isFileLogLevelEnabled("error")).toBe(true);
-    expect(logging.isFileLogLevelEnabled("warn")).toBe(true);
-    expect(logging.isFileLogLevelEnabled("info")).toBe(true);
-    expect(logging.isFileLogLevelEnabled("debug")).toBe(true);
-    expect(logging.isFileLogLevelEnabled("trace")).toBe(true);
-  });
+  for (const { name, level, expected } of [
+    {
+      name: "returns false for all levels when configured as silent",
+      level: "silent",
+      expected: [false, false, false, false, false, false],
+    },
+    {
+      name: "passes only fatal when configured as fatal",
+      level: "fatal",
+      expected: [true, false, false, false, false, false],
+    },
+    {
+      name: "passes fatal and error when configured as error",
+      level: "error",
+      expected: [true, true, false, false, false, false],
+    },
+    {
+      name: "passes fatal, error, warn, info when configured as info",
+      level: "info",
+      expected: [true, true, true, true, false, false],
+    },
+    {
+      name: "passes all levels when configured as trace",
+      level: "trace",
+      expected: [true, true, true, true, true, true],
+    },
+  ] as const) {
+    it(name, () => {
+      logging.setLoggerOverride({ level });
+      expect(logging.isFileLogLevelEnabled("fatal")).toBe(expected[0]);
+      expect(logging.isFileLogLevelEnabled("error")).toBe(expected[1]);
+      expect(logging.isFileLogLevelEnabled("warn")).toBe(expected[2]);
+      expect(logging.isFileLogLevelEnabled("info")).toBe(expected[3]);
+      expect(logging.isFileLogLevelEnabled("debug")).toBe(expected[4]);
+      expect(logging.isFileLogLevelEnabled("trace")).toBe(expected[5]);
+    });
+  }
 
   it("never treats silent as an emittable file level", () => {
     logging.setLoggerOverride({ level: "info" });


### PR DESCRIPTION
## What Problem This Solves

The logging threshold fixture deletes three environment keys before and after each test. Clearing them during a test is intentional, but teardown also erases values inherited from the enclosing runner. Vitest cannot restore these raw mutations through its tracked environment-stub registry.

## Why This Change Was Made

Capture exactly the three existing keys before clearing them, and restore their previous values first in the existing teardown, using the same `captureEnv` helper as sibling logging tests. Keep logger resets and mock cleanup in their original order.

Consolidate the five repeated threshold bodies into literal rows, registering each with ordinary `it(name, callback)` so the full original names remain visible. The initial object-table prototype exposed Vitest's quoted/truncated title formatting; this version avoids that formatting without changing runner configuration. All 15 cases and 49 assertions remain, including all 30 threshold expectations, cache-generation counts, silent-level behavior and child/Pino inheritance.

No production, logging policy, new environment variable, dependency, sharding, concurrency, deadline or retry change.

## Evidence

The temporary full-order probe runs every original case with synthetic inherited file/console/log-level values. Original: all 15 cases pass, but the final environment postcondition fails because all three keys are absent. Corrected candidate: all 15 cases and the postcondition pass, preserving the exact nonempty and empty values. Actual emitted case names and ordering match the original. The probe restores its own enclosing environment in `finally` and was removed after both commands exited.

Root directly inspected the logger/console/subsystem owners, reset and configuration boundaries, sibling fixtures, environment helper, actual Vitest stub/name/hook contracts and tslog child behavior. The fix belongs to the fixture that mutates the keys; no broad runner reset is needed.

Normal before/after runs pass all 61 owner/sibling cases, with identical names and per-file ordering. The full changed gate, including core test typecheck and lint, passes. Codex autoreview is clean at its configured P0 threshold, and a separate independent final review closes the naming finding with no remaining actionable issue. No execution-time improvement or observed cross-file CI failure is claimed.

Production LOC: unchanged. Tests: +46/-52, six fewer lines.

Provenance: the console test key's deletion was added in `2456c7745991c5698ca3e536221b6927e3a51881`, verified against its actual parent; the other raw deletions predate that change and their original introduction is unknown. The existing cache-generation regressions from that change are preserved.

Follow-up: the unchanged six-file baseline also emitted an unexpected subsystem file-append warning. A separate fixture drain repair now has failing-before/passing-after proof and is being published independently; this PR does not change the transport or claim to repair it.

Current-main composition: the unchanged candidate was exercised with the other pending fixture cleanups on `a5269bb31b875abc29ad55b0811183d1f0afb19f`. All 189 cases across the five normal project invocations passed, including this change’s 70-case owner/sibling group. Original full case names and per-file order remain unchanged. Fresh Codex review of the composed test-only diff is clean at its configured P0 threshold. The separate original/final proofs above remain the evidence for this individual change.

Final combined changed gate on `a5269bb31b875abc29ad55b0811183d1f0afb19f` also passed, including core and plugin test types, lint, boundary guards and dead-export checks. The seven reviewed file afterimages were unchanged after the 189-case run, review and gate.
