### PR TITLE
test: consolidate Slack thread-root predicate cases

### DIFF
--- a/extensions/slack/src/monitor/message-handler/prepare-thread-context-root.test.ts
+++ b/extensions/slack/src/monitor/message-handler/prepare-thread-context-root.test.ts
@@ -19,49 +19,14 @@ type SlackThreadRootCandidate = {
 describe("isSlackThreadAuthorCurrentBot", () => {
   const identity = { botUserId: "U_BOT", botId: "B1" };
 
-  it("matches the configured bot user id", () => {
-    expect(
-      isSlackThreadAuthorCurrentBot({
-        identity,
-        author: { userId: "U_BOT" },
-      }),
-    ).toBe(true);
-  });
-
-  it("matches the configured bot id", () => {
-    expect(
-      isSlackThreadAuthorCurrentBot({
-        identity,
-        author: { botId: "B1" },
-      }),
-    ).toBe(true);
-  });
-
-  it("does not match a different bot id", () => {
-    expect(
-      isSlackThreadAuthorCurrentBot({
-        identity,
-        author: { botId: "B2" },
-      }),
-    ).toBe(false);
-  });
-
-  it("does not match a regular user", () => {
-    expect(
-      isSlackThreadAuthorCurrentBot({
-        identity,
-        author: { userId: "U1" },
-      }),
-    ).toBe(false);
-  });
-
-  it("returns false when identity has no bot ids", () => {
-    expect(
-      isSlackThreadAuthorCurrentBot({
-        identity: {},
-        author: { userId: "U_BOT", botId: "B1" },
-      }),
-    ).toBe(false);
+  it.each([
+    ["matches the configured bot user id", identity, { userId: "U_BOT" }, true],
+    ["matches the configured bot id", identity, { botId: "B1" }, true],
+    ["does not match a different bot id", identity, { botId: "B2" }, false],
+    ["does not match a regular user", identity, { userId: "U1" }, false],
+    ["returns false when identity has no bot ids", {}, { userId: "U_BOT", botId: "B1" }, false],
+  ] as const)("%s", (_name, botIdentity, author, expected) => {
+    expect(isSlackThreadAuthorCurrentBot({ identity: botIdentity, author })).toBe(expected);
   });
 });
 
@@ -156,44 +121,29 @@ describe("applySlackThreadHistoryFilterPolicy", () => {
 });
 
 describe("shouldIncludeBotThreadStarterContext", () => {
-  it("includes when starter is bot, session is new, and starter has text", () => {
-    expect(
-      shouldIncludeBotThreadStarterContext({
-        starterIsCurrentBot: true,
-        isNewThreadSession: true,
-        hasStarterText: true,
-      }),
-    ).toBe(true);
-  });
-
-  it("does not include when starter is not the current bot", () => {
-    expect(
-      shouldIncludeBotThreadStarterContext({
-        starterIsCurrentBot: false,
-        isNewThreadSession: true,
-        hasStarterText: true,
-      }),
-    ).toBe(false);
-  });
-
-  it("does not include when session is not new", () => {
-    expect(
-      shouldIncludeBotThreadStarterContext({
-        starterIsCurrentBot: true,
-        isNewThreadSession: false,
-        hasStarterText: true,
-      }),
-    ).toBe(false);
-  });
-
-  it("does not include when starter has no text", () => {
-    expect(
-      shouldIncludeBotThreadStarterContext({
-        starterIsCurrentBot: true,
-        isNewThreadSession: true,
-        hasStarterText: false,
-      }),
-    ).toBe(false);
+  it.each([
+    [
+      "includes when starter is bot, session is new, and starter has text",
+      { starterIsCurrentBot: true, isNewThreadSession: true, hasStarterText: true },
+      true,
+    ],
+    [
+      "does not include when starter is not the current bot",
+      { starterIsCurrentBot: false, isNewThreadSession: true, hasStarterText: true },
+      false,
+    ],
+    [
+      "does not include when session is not new",
+      { starterIsCurrentBot: true, isNewThreadSession: false, hasStarterText: true },
+      false,
+    ],
+    [
+      "does not include when starter has no text",
+      { starterIsCurrentBot: true, isNewThreadSession: true, hasStarterText: false },
+      false,
+    ],
+  ] as const)("%s", (_name, params, expected) => {
+    expect(shouldIncludeBotThreadStarterContext(params)).toBe(expected);
   });
 });
 


### PR DESCRIPTION
## What Problem This Solves

The Slack thread-root tests repeat the same predicate call and assertion for five author-identity inputs and four starter-inclusion inputs. The repeated shells make the two decision matrices harder to compare without adding another behavior.

## Why This Change Was Made

Use two focused tables, preserving each original name, input and boolean oracle. The three inclusion booleans remain named fields in an object. More complex history filtering, omission counts, root reference identity and UTF-16 label tests remain byte-for-byte unchanged.

No production, Slack API, configuration, dependency, mock, lifecycle, deadline, sharding, concurrency or routing change. The real predicate owners still execute once per original case.

## Evidence

- Normal before/after wrapper runs pass all 49 cases: 26 thread-root cases and 23 caller-level thread-context cases. Full emitted names, ordering and statuses match exactly.
- Independent source comparison preserves all 30 root-test assertions, including exact history order, omission counts, root identity, and the surrogate-boundary regression.
- Root read the full changed suite, predicate owner, thread-context caller, integration sibling, fixture helpers, thread-history producer and canonical UTF-16 helper. The actual-parent MPIM reconstruction repair was inspected and its tests remain unchanged.
- Direct installed Vitest formatter inspection confirms the `%s` tuple form uses only the literal title; the observed before/after reports also verify the complete titles.
- Codex autoreview at the configured P0 threshold and a separate independent owner/caller/dependency review are clean. The full changed gate passed, including extension test types and lint.

Production LOC: unchanged. Tests: +31/-81, 50 fewer lines. This is a focused test readability/LOC cleanup; no execution-time or stability improvement is claimed.

Current-main composition: the unchanged candidate was exercised with the other pending fixture cleanups on `a5269bb31b875abc29ad55b0811183d1f0afb19f`. All 189 cases across the five normal project invocations passed, including this change’s 49-case owner/sibling group. Original full case names and per-file order remain unchanged. Fresh Codex review of the composed test-only diff is clean at its configured P0 threshold. The separate original/final proofs above remain the evidence for this individual change.

Final combined changed gate on `a5269bb31b875abc29ad55b0811183d1f0afb19f` also passed, including core and plugin test types, lint, boundary guards and dead-export checks. The seven reviewed file afterimages were unchanged after the 189-case run, review and gate.
