### PR TITLE
test: drain subsystem log writes before cleanup

### DIFF
--- a/src/logging/subsystem.test.ts
+++ b/src/logging/subsystem.test.ts
@@ -35,7 +35,9 @@ beforeAll(async () => {
   await logPathTracker.setup();
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // Settle owned file writes before resetting logging state or removing the suite directory.
+  await testApi.flushFileLogQueueForTests();
   setConsoleSubsystemFilter(null);
   setLoggerOverride(null);
   loggingState.rawConsole = null;


### PR DESCRIPTION
## What Problem This Solves

The subsystem suite resets logging state and removes its temporary directory without waiting for the real asynchronous file transport. The final two cache-generation cases enqueue six records but never read or drain them. Normal runs passed while reporting dropped log records.

A retained original-order diagnostic proves the race: directory cleanup starts, then the queued `after reset` append starts with its parent already absent and rejects with `ENOENT`. Later appends observed after the diagnostic's cleanup drain are recorded separately, not presented as uninstrumented timing evidence.

## Why This Change Was Made

Await the existing file-queue drain at the start of this fixture's `afterEach`, before resetting its logging state. This follows the existing file-transport test owner's teardown pattern and settles each case's writes while its temporary paths still exist. No production transport, shared runner, timeout, retry, warning suppression, sharding or concurrency change.

The last two producing cases were added in #126147; its actual parent-to-child patch was inspected. This is a missing fixture cleanup barrier, not a claim that the production transport was introduced by that PR.

## Evidence

- The normal original-order six-file run passes all 61 case bodies while the diagnostic records the missing-parent append and actual `ENOENT`.
- A before-deletion readback fails on the original fixture with `ENOENT`; all 61 original cases still pass, but the suite and command fail at teardown.
- With the fixture drain, the same readback passes: all four files contain the six expected final-case records before deletion, all ten suite appends have settled successfully, and no append remains in flight.
- The final patch without diagnostic instrumentation passes all 70 cases, including the nine file-transport tests. All 61 original full names, order and statuses match; no subsystem append warning occurs.
- The diagnostic copies and raw outputs are retained outside the repository. No permanent instrumentation is needed for this two-line fixture cleanup; the existing cases and external failing/passing teardown check exercise the real owner.

Production LOC: unchanged. Tests: +3/-1, net +2 for an awaited cleanup barrier and its ordering comment. No execution-time improvement is claimed; this fixes an observed fixture lifetime race.

Full changed gate passed, including core test types and lint. Codex review is clean at its configured P0 threshold; separate independent source, dependency and retained-runtime review found no actionable defect.

Current-main composition: the unchanged candidate was exercised with the other pending fixture cleanups on `a5269bb31b875abc29ad55b0811183d1f0afb19f`. All 189 cases across the five normal project invocations passed, including this change’s 70-case owner/sibling group. Original full case names and per-file order remain unchanged. Fresh Codex review of the composed test-only diff is clean at its configured P0 threshold. The separate original/final proofs above remain the evidence for this individual change.

Final combined changed gate on `a5269bb31b875abc29ad55b0811183d1f0afb19f` also passed, including core and plugin test types, lint, boundary guards and dead-export checks. The seven reviewed file afterimages were unchanged after the 189-case run, review and gate.
