### PR TITLE
test: simplify Gradium request fixtures

### DIFF
--- a/extensions/gradium/speech-provider.test.ts
+++ b/extensions/gradium/speech-provider.test.ts
@@ -23,52 +23,29 @@ describe("gradium speech provider", () => {
   });
 
   it("reports configured when GRADIUM_API_KEY is set", () => {
-    const original = process.env.GRADIUM_API_KEY;
-    try {
-      process.env.GRADIUM_API_KEY = "gsk_test";
-      expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 5_000 })).toBe(true);
-    } finally {
-      if (original === undefined) {
-        delete process.env.GRADIUM_API_KEY;
-      } else {
-        process.env.GRADIUM_API_KEY = original;
-      }
-    }
+    vi.stubEnv("GRADIUM_API_KEY", "gsk_test");
+    expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 5_000 })).toBe(true);
   });
 
   it("reports not configured when no key is available", () => {
-    const original = process.env.GRADIUM_API_KEY;
-    try {
-      delete process.env.GRADIUM_API_KEY;
-      expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 5_000 })).toBe(false);
-    } finally {
-      if (original !== undefined) {
-        process.env.GRADIUM_API_KEY = original;
-      }
-    }
+    vi.stubEnv("GRADIUM_API_KEY", undefined);
+    expect(provider.isConfigured({ providerConfig: {}, timeoutMs: 5_000 })).toBe(false);
   });
 
   it("reports not configured for an invalid baseUrl instead of throwing", () => {
-    const original = process.env.GRADIUM_API_KEY;
-    try {
-      delete process.env.GRADIUM_API_KEY;
-      expect(
-        provider.isConfigured({
-          providerConfig: { apiKey: String(true), baseUrl: "https://example.com" },
-          timeoutMs: 5_000,
-        }),
-      ).toBe(false);
-      expect(
-        provider.isConfigured({
-          providerConfig: { apiKey: String(true), baseUrl: "not-a-url" },
-          timeoutMs: 5_000,
-        }),
-      ).toBe(false);
-    } finally {
-      if (original !== undefined) {
-        process.env.GRADIUM_API_KEY = original;
-      }
-    }
+    vi.stubEnv("GRADIUM_API_KEY", undefined);
+    expect(
+      provider.isConfigured({
+        providerConfig: { apiKey: String(true), baseUrl: "https://example.com" },
+        timeoutMs: 5_000,
+      }),
+    ).toBe(false);
+    expect(
+      provider.isConfigured({
+        providerConfig: { apiKey: String(true), baseUrl: "not-a-url" },
+        timeoutMs: 5_000,
+      }),
+    ).toBe(false);
   });
 
   it("synthesizes audio via the Gradium TTS endpoint", async () => {
@@ -196,23 +173,16 @@ describe("gradium speech provider", () => {
   });
 
   it("throws when no API key is available", async () => {
-    const original = process.env.GRADIUM_API_KEY;
-    try {
-      delete process.env.GRADIUM_API_KEY;
-      await expect(
-        provider.synthesize({
-          text: "test",
-          cfg: {} as never,
-          providerConfig: {},
-          target: "audio-file",
-          timeoutMs: 5_000,
-        }),
-      ).rejects.toThrow("Gradium API key missing");
-    } finally {
-      if (original !== undefined) {
-        process.env.GRADIUM_API_KEY = original;
-      }
-    }
+    vi.stubEnv("GRADIUM_API_KEY", undefined);
+    await expect(
+      provider.synthesize({
+        text: "test",
+        cfg: {} as never,
+        providerConfig: {},
+        target: "audio-file",
+        timeoutMs: 5_000,
+      }),
+    ).rejects.toThrow("Gradium API key missing");
   });
 
   it("rejects a blank environment key before normal or telephony requests", async () => {

--- a/extensions/gradium/tts.test.ts
+++ b/extensions/gradium/tts.test.ts
@@ -144,65 +144,43 @@ describe("gradium tts diagnostics", () => {
     expect(result).toEqual(audioData);
   });
 
-  it("rejects HTTP base URLs before sending the API key", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(new Response(Buffer.from("audio"), { status: 200 }));
-    vi.stubGlobal("fetch", fetchMock);
+  for (const { name, baseUrl, expectedError } of [
+    {
+      name: "rejects HTTP base URLs before sending the API key",
+      baseUrl: "http://api.gradium.ai",
+      expectedError: "Gradium baseUrl must use https",
+    },
+    {
+      name: "rejects non-Gradium base URLs before sending the API key",
+      baseUrl: "https://example.com",
+      expectedError: "Gradium baseUrl must target api.gradium.ai",
+    },
+    {
+      name: "rejects hostname suffix lookalikes before sending the API key",
+      baseUrl: "https://api.gradium.ai.example.com",
+      expectedError: "Gradium baseUrl must target api.gradium.ai",
+    },
+  ]) {
+    it(name, async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValue(new Response(Buffer.from("audio"), { status: 200 }));
+      vi.stubGlobal("fetch", fetchMock);
 
-    await expect(
-      gradiumTTS({
-        text: "hello",
-        apiKey: "gsk_test123",
-        baseUrl: "http://api.gradium.ai",
-        voiceId: "YTpq7expH9539ERJ",
-        outputFormat: "wav",
-        timeoutMs: 5_000,
-      }),
-    ).rejects.toThrow("Gradium baseUrl must use https");
+      await expect(
+        gradiumTTS({
+          text: "hello",
+          apiKey: "gsk_test123",
+          baseUrl,
+          voiceId: "YTpq7expH9539ERJ",
+          outputFormat: "wav",
+          timeoutMs: 5_000,
+        }),
+      ).rejects.toThrow(expectedError);
 
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects non-Gradium base URLs before sending the API key", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(new Response(Buffer.from("audio"), { status: 200 }));
-    vi.stubGlobal("fetch", fetchMock);
-
-    await expect(
-      gradiumTTS({
-        text: "hello",
-        apiKey: "gsk_test123",
-        baseUrl: "https://example.com",
-        voiceId: "YTpq7expH9539ERJ",
-        outputFormat: "wav",
-        timeoutMs: 5_000,
-      }),
-    ).rejects.toThrow("Gradium baseUrl must target api.gradium.ai");
-
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects hostname suffix lookalikes before sending the API key", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(new Response(Buffer.from("audio"), { status: 200 }));
-    vi.stubGlobal("fetch", fetchMock);
-
-    await expect(
-      gradiumTTS({
-        text: "hello",
-        apiKey: "gsk_test123",
-        baseUrl: "https://api.gradium.ai.example.com",
-        voiceId: "YTpq7expH9539ERJ",
-        outputFormat: "wav",
-        timeoutMs: 5_000,
-      }),
-    ).rejects.toThrow("Gradium baseUrl must target api.gradium.ai");
-
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+  }
 
   it("caps streamed audio responses instead of buffering oversized TTS output", async () => {
     const streamed = createStreamingAudioResponse({


### PR DESCRIPTION
## What Problem This Solves

Gradium speech tests repeat four manual environment save/restore blocks even though the suite already owns environment teardown. Three URL-rejection cases also repeat the same request and rejection assertions.

## Why This Change Was Made

Use the existing Vitest environment-stub lifecycle for the four key overrides and ordinary named cases over literal URL rows. Each URL case still constructs fresh fetch state and exercises the real request owner. All original errors, no-fetch assertions, malformed-response cases and complete case names remain.

Production, HTTP behavior, dependency versions, deadlines, sharding and concurrency are unchanged. This is test fixture simplification, not a measured speed or reproduced-flake claim.

## Evidence

- Normal before/after runs preserve all 22 full case names and per-file ordering; the shuffled run also passes all 22.
- Six full-order environment probes cover original and candidate with synthetic nonempty, empty and absent inherited keys. All 60 case bodies and 60 post-case environment observations pass; each probe restores its enclosing environment. No intentional-failure-path proof is claimed.
- The same 22 cases pass on the refreshed current-main context. Relevant owner/test/source blobs are unchanged; the intervening lockfile change concerns only the Matrix SDK patch, not these dependencies.
- Root read the complete tests, speech/request/shared owners, normal and telephony callers, fixture lifecycle, API-key helper, actual repair history and installed Vitest environment and naming contracts. Separate independent source review is clean.
- Codex autoreview is clean at its configured P0 threshold. The full changed gate passes, including extension test types and lint.

Production LOC: unchanged. Tests: +64/-116, 52 fewer lines. The existing four malformed-success cases remain byte-for-byte unchanged.
