### PR TITLE
fix(doctor): allow legacy exec approvals migration before security checks

### DIFF
--- a/src/commands/doctor-security.ts
+++ b/src/commands/doctor-security.ts
@@ -11,9 +11,11 @@ import { resolveGatewayAuth } from "../gateway/auth.js";
 import { isLoopbackHost, resolveGatewayBindHost } from "../gateway/net.js";
 import { resolveExecPolicyScopeSnapshot } from "../infra/exec-approvals-effective.js";
 import { countObsoleteGeneratedExecApprovals } from "../infra/exec-approvals-generated-migration.js";
+import { ExecApprovalsMigrationRequiredError } from "../infra/exec-approvals-migration-gate.js";
 import {
   loadExecApprovalsReadOnly,
   resolveExecApprovalsDisplayPath,
+  type ExecApprovalsFile,
   type ExecAsk,
   type ExecMode,
   type ExecSecurity,
@@ -92,9 +94,11 @@ function execAskRank(value: ExecAsk): number {
   throw new Error("Unsupported exec ask value");
 }
 
-function collectExecPolicyConflictWarnings(cfg: OpenClawConfig): SecurityAuditFinding[] {
+function collectExecPolicyConflictWarnings(
+  cfg: OpenClawConfig,
+  approvals: ExecApprovalsFile,
+): SecurityAuditFinding[] {
   const findings: SecurityAuditFinding[] = [];
-  const approvals = loadExecApprovalsReadOnly();
   const defaultRequestedSecuritySource = "OpenClaw default (full)";
   const defaultRequestedAskSource = "OpenClaw default (off)";
 
@@ -194,9 +198,12 @@ function collectExecPolicyConflictWarnings(cfg: OpenClawConfig): SecurityAuditFi
   return findings;
 }
 
-function collectDurableExecApprovalWarnings(cfg: OpenClawConfig): SecurityAuditFinding[] {
+function collectDurableExecApprovalWarnings(
+  cfg: OpenClawConfig,
+  approvals: ExecApprovalsFile,
+): SecurityAuditFinding[] {
   void cfg;
-  const count = countObsoleteGeneratedExecApprovals(loadExecApprovalsReadOnly());
+  const count = countObsoleteGeneratedExecApprovals(approvals);
   if (count === 0) {
     return [];
   }
@@ -303,10 +310,32 @@ export async function collectSecurityWarnings(
   }
 
   findings.push(...collectImplicitHeartbeatDirectPolicyWarnings(cfg));
-  findings.push(...collectExecPolicyConflictWarnings(cfg));
+  let approvals: ExecApprovalsFile | undefined;
+  try {
+    approvals = loadExecApprovalsReadOnly();
+  } catch (error) {
+    if (!(error instanceof ExecApprovalsMigrationRequiredError)) {
+      throw error;
+    }
+    // Doctor owns this migration later in the same repair flow. Security
+    // diagnostics must not invoke the runtime gate first and make
+    // `doctor --fix` abort with an instruction to run itself.
+    findings.push({
+      checkId: "doctor.exec_approvals_migration_pending",
+      severity: "warn",
+      title: "Exec approvals migration pending",
+      detail: error.message,
+      remediation: "Continue this Doctor repair to migrate the retired approvals store.",
+    });
+  }
+  if (approvals) {
+    findings.push(...collectExecPolicyConflictWarnings(cfg, approvals));
+  }
   findings.push(...collectExecFilesystemPolicyWarnings(cfg));
   findings.push(...collectPlaintextConfigSecretWarnings(cfg));
-  findings.push(...collectDurableExecApprovalWarnings(cfg));
+  if (approvals) {
+    findings.push(...collectDurableExecApprovalWarnings(cfg, approvals));
+  }
 
   // Network exposure needs auth proof before doctor can treat non-loopback bind as intentional.
   const tailscaleMode = cfg.gateway?.tailscale?.mode ?? "off";

--- a/src/commands/doctor/repair-sequencing.ts
+++ b/src/commands/doctor/repair-sequencing.ts
@@ -5,7 +5,6 @@ import {
   applyPluginAutoEnable,
   materializePluginAutoEnableCandidates,
 } from "../../config/plugin-auto-enable.js";
-import { repairObsoleteGeneratedExecApprovals } from "../../infra/exec-approvals-generated-migration.js";
 import type { PluginCapabilityConsentHandler } from "../../plugins/capability-consent.js";
 import type { PluginMetadataSnapshotScopeRunner } from "../../plugins/current-plugin-metadata-snapshot.js";
 import {
@@ -111,13 +110,6 @@ export async function runDoctorRepairSequence(params: {
     }
     return params.runWithPluginMetadataSnapshot(resolveCurrentPluginMetadataScope(), run);
   };
-
-  const removedExecApprovals = repairObsoleteGeneratedExecApprovals();
-  if (removedExecApprovals > 0) {
-    changeNotes.push(
-      `Exec approvals updated: removed ${removedExecApprovals} older generated ${removedExecApprovals === 1 ? "approval" : "approvals"} that were not tied to a working directory. Manual allowlist rules were not changed. Rerun affected workflows and choose "Always allow here" when prompted.`,
-    );
-  }
 
   const applyMutation = (mutation: {
     config: DoctorConfigMutationState["candidate"];

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -284,36 +284,58 @@ async function runLegacyStateHealth(ctx: DoctorHealthFlowContext): Promise<void>
   if (legacyState.notices.length > 0) {
     note(legacyState.notices.join("\n"), "Doctor notices");
   }
-  if (legacyState.preview.length === 0) {
+  if (legacyState.preview.length > 0) {
+    note(legacyState.preview.join("\n"), "Legacy state detected");
+    const migrate =
+      ctx.options.nonInteractive === true
+        ? true
+        : await ctx.prompter.confirm({
+            message: "Migrate detected legacy state now?",
+            initialValue: true,
+          });
+    if (!migrate) {
+      return;
+    }
+    const migrated = await runLegacyStateMigrations({
+      detected: legacyState,
+      config: ctx.cfg,
+      ...(doctorOnlyStateMigrations ? { doctorOnlyStateMigrations: true } : {}),
+      recoverCorruptTargetStore: ctx.options.repair === true || ctx.options.yes === true,
+      legacySessionSurfaces,
+    });
+    if (migrated.changes.length > 0) {
+      note(migrated.changes.join("\n"), "Doctor changes");
+    }
+    const notices = migrated.notices ?? [];
+    if (notices.length > 0) {
+      note(notices.join("\n"), "Doctor notices");
+    }
+    if (migrated.warnings.length > 0) {
+      note(migrated.warnings.join("\n"), "Doctor warnings");
+    }
+  }
+  if (!doctorOnlyStateMigrations) {
     return;
   }
-  note(legacyState.preview.join("\n"), "Legacy state detected");
-  const migrate =
-    ctx.options.nonInteractive === true
-      ? true
-      : await ctx.prompter.confirm({
-          message: "Migrate detected legacy state now?",
-          initialValue: true,
-        });
-  if (!migrate) {
-    return;
+  const { repairObsoleteGeneratedExecApprovals } =
+    await import("../infra/exec-approvals-generated-migration.js");
+  const { ExecApprovalsMigrationRequiredError } =
+    await import("../infra/exec-approvals-migration-gate.js");
+  let removedExecApprovals: number;
+  try {
+    // The legacy-state owner must import retired JSON before this gated SQLite update.
+    removedExecApprovals = repairObsoleteGeneratedExecApprovals();
+  } catch (error) {
+    if (error instanceof ExecApprovalsMigrationRequiredError) {
+      return;
+    }
+    throw error;
   }
-  const migrated = await runLegacyStateMigrations({
-    detected: legacyState,
-    config: ctx.cfg,
-    ...(doctorOnlyStateMigrations ? { doctorOnlyStateMigrations: true } : {}),
-    recoverCorruptTargetStore: ctx.options.repair === true || ctx.options.yes === true,
-    legacySessionSurfaces,
-  });
-  if (migrated.changes.length > 0) {
-    note(migrated.changes.join("\n"), "Doctor changes");
-  }
-  const notices = migrated.notices ?? [];
-  if (notices.length > 0) {
-    note(notices.join("\n"), "Doctor notices");
-  }
-  if (migrated.warnings.length > 0) {
-    note(migrated.warnings.join("\n"), "Doctor warnings");
+  if (removedExecApprovals > 0) {
+    note(
+      `Exec approvals updated: removed ${removedExecApprovals} older generated ${removedExecApprovals === 1 ? "approval" : "approvals"} that were not tied to a working directory. Manual allowlist rules were not changed. Rerun affected workflows and choose "Always allow here" when prompted.`,
+      "Doctor changes",
+    );
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes #133813 -- 2026.8.1 upgrade crash-loops the Gateway; doctor --fix is blocked by ExecApprovalsMigrationRequiredError.

- **Root cause:** self-deadlocking Doctor ordering. collectSecurityWarnings() -> countObsoleteGeneratedExecApprovals() -> loadExecApprovalsReadOnly() throws ExecApprovalsMigrationRequiredError before runLegacyStateMigrations() is reached. Security check runs before legacy migration, so doctor --fix never reaches the migration that would unblock it.
- **Fix:**
  - src/commands/doctor-security.ts: collectSecurityWarnings now loads ExecApprovalsFile leniently (try/catch, ExecApprovalsMigrationRequiredError -> pending-migration finding with guidance, not throw); collectDurableExecApprovalWarnings takes approvals param.
  - src/commands/doctor/repair-sequencing.ts: remove early repairObsoleteGeneratedExecApprovals() (8 lines), defer to post-migration.
  - src/flows/doctor-health-contributions.ts: reorder health flow -- legacy state migration runs before repair, with doctorOnlyStateMigrations guard.

## Evidence

- Repro repro-133813.mjs / validate-133813.mjs / tmp-sec-test.mjs: collectSecurityWarnings with legacy file now returns doctor.exec_approvals_migration_pending finding instead of throw; post-migration repairObsolete succeeds.
  - vitest: doctor-security.test.ts + repair-sequencing.test.ts + doctor-health-contributions.test.ts 141s pass; state-migrations.exec-approvals + exec-approvals-generated-migration + exec-approvals-store 155s pass; process-repro-133813.mjs preflight -> legacy pending -> migration -> success.
  - Mirrors focused repair PR #133773 intent.

Closes #133813
