### PR TITLE
fix(ui): deduplicate initial image prompt during worktree preparation

### DIFF
--- a/ui/src/app/session-placement-startup.runtime.ts
+++ b/ui/src/app/session-placement-startup.runtime.ts
@@ -157,7 +157,6 @@ export default function createApplicationPlacementStartupRuntime(
       attachments: entry.attachments,
       createdAt: entry.createdAt,
       runId: result.messageId,
-      sequence: result.messageSeq,
     });
     if (message) {
       params.initialUserMessage.prepare({

--- a/ui/src/app/session-placement-startup.test.ts
+++ b/ui/src/app/session-placement-startup.test.ts
@@ -421,9 +421,20 @@ describe("application session placement startup", () => {
       pendingRunId: "message-stable",
       message: {
         role: "user",
-        __openclaw: { idempotencyKey: "message-stable:user", seq: 7 },
+        __openclaw: { idempotencyKey: "message-stable:user" },
       },
     });
+    {
+      const stored = initialUserMessage.read(input.recovery.sessionKey, client)?.message as
+        | {
+            __openclaw?: Record<string, unknown>;
+          }
+        | undefined;
+      // eslint-disable-next-line no-underscore-dangle -- test inspects internal __openclaw field
+      expect((stored as { __openclaw?: Record<string, unknown> })?.__openclaw).not.toHaveProperty(
+        "seq",
+      );
+    }
     expect(sessions.refresh).not.toHaveBeenCalled();
     startup.dispose();
   });

--- a/ui/src/pages/chat/chat-pending-inputs.ts
+++ b/ui/src/pages/chat/chat-pending-inputs.ts
@@ -145,13 +145,13 @@ export function applyChatPendingInputs(
     const projection = getChatSessionProjection(state, state.chatMessages, scope);
     // Custody replaces only this pane's provisional user copy, never a canonical
     // message or active assistant state that happens to share the run correlation.
+    // Retirement is by submission identity (pendingRunId) to avoid transient
+    // duplicate during worktree preparation when a speculative seq was stamped.
     const entries = projection.entries.filter(
       (entry) =>
         !(
           entry.pending &&
           entry.identity?.role === "user" &&
-          entry.identity.id === null &&
-          entry.identity.sequence === null &&
           acceptedRunIds.has(entry.pendingRunId ?? "")
         ),
     );

--- a/ui/src/pages/new-session/draft-submission-flow.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.ts
@@ -633,7 +633,7 @@ export class DraftSubmissionFlow {
           result.key,
           { text: message, attachments, createdAt: submittedAt, ...(sender ? { sender } : {}) },
           submissionClient,
-          { runId: result.initialRun.runId, messageSeq: result.initialRun.messageSeq },
+          { runId: result.initialRun.runId },
         );
       }
       await this.draftPersistence.clearSubmittedDraft();


### PR DESCRIPTION
## What Problem This Solves

Fixes #133719 -- Initial image prompt appears twice during worktree preparation (P2, diamond lobster, impact:session-state impact:ux-friction).

- **Root cause:** Gateway sessions.create/sessions.send predicts messageSeq as transcript position; Control UI prepareInitialUserMessageHandoff writes it as __openclaw.seq, making isLocallyOptimisticSessionMessage() false. chat-pending-inputs.ts custody retirement requires id===null && sequence===null, so empty-history + pendingInputs coexists -- two user groups rendered. history-merge also blocked by seq mismatch.
- **Fix:**
  - ui/src/pages/new-session/draft-submission-flow.ts:636 -> { runId } (drop messageSeq)
  - ui/src/app/session-placement-startup.runtime.ts:160 drop sequence: result.messageSeq
  - ui/src/pages/chat/chat-pending-inputs.ts:148-156 retirement filter -> pending && role===user && acceptedRunIds.has(pendingRunId) (by submission identity, not id/sequence null)
  - ui/src/app/session-placement-startup.test.ts expect seq-free handoff

## Evidence

- Repro reproduce-133719.mjs: seq=1 -> combined=2 (BUG) vs seq=undefined -> combined=1 (FIX); same text different runId stays independent.
  - vitest ui: initial-turn-handoff 2 pass, history-merge 26 pass, chat-pending-inputs 18 pass, draft-submission-flow 29 pass, session-placement-startup 35 pass; chat-thread 10 fails are locale zh-CN pre-existing (stash一致).

Closes #133719
