### PR TITLE
refactor(infra): share Git commit prefix matching

### DIFF
--- a/src/infra/git-commit.test.ts
+++ b/src/infra/git-commit.test.ts
@@ -6,8 +6,29 @@ import process from "node:process";
 import { pathToFileURL } from "node:url";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
+import { gitCommitPrefixesMatch } from "./git-commit.js";
 
 const tempDirs = createTrackedTempDirs();
+
+describe("git commit prefix matching", () => {
+  const fullCommit = "abcdef0123456789abcdef0123456789abcdef01";
+  const unrelatedCommit = "1234567890abcdef1234567890abcdef12345678";
+  const sharedPrefixCommit = "abcdef0fedcba9876543210fedcba9876543210f";
+
+  it.each([
+    ["exact equality", fullCommit, fullCommit, true],
+    ["short left prefix", "abcdef0", fullCommit, true],
+    ["short right prefix", fullCommit, "abcdef0", true],
+    ["whitespace and case normalization", "  ABCDEF0  ", fullCommit, true],
+    ["unrelated commits", fullCommit, unrelatedCommit, false],
+    ["distinct full commits sharing seven characters", fullCommit, sharedPrefixCommit, false],
+    ["short left operand", "abcdef", fullCommit, false],
+    ["short right operand", fullCommit, "abcdef", false],
+    ["whitespace-only operand", "   ", fullCommit, false],
+  ])("%s", (_name, left, right, expected) => {
+    expect(gitCommitPrefixesMatch(left, right)).toBe(expected);
+  });
+});
 
 async function makeTempDir(label: string): Promise<string> {
   return await tempDirs.make(`openclaw-${label}-`);

--- a/src/infra/git-commit.ts
+++ b/src/infra/git-commit.ts
@@ -26,6 +26,16 @@ const formatCommit = (value?: string | null) => {
   return normalizeLowercaseStringOrEmpty(match[0].slice(0, 7));
 };
 
+export function gitCommitPrefixesMatch(left: string, right: string): boolean {
+  const normalizedLeft = normalizeLowercaseStringOrEmpty(left);
+  const normalizedRight = normalizeLowercaseStringOrEmpty(right);
+  return (
+    normalizedLeft.length >= 7 &&
+    normalizedRight.length >= 7 &&
+    (normalizedLeft.startsWith(normalizedRight) || normalizedRight.startsWith(normalizedLeft))
+  );
+}
+
 const cachedGitCommitBySearchDir = new Map<string, string | null>();
 const GIT_COMMIT_CACHE_LIMIT = 256;
 declare const WORKER_DEPLOY_BUILD: boolean;

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -10,6 +10,7 @@ import {
 } from "../state/openclaw-state-db.js";
 import { resolveRuntimeServiceCommit, resolveRuntimeServiceVersion } from "../version.js";
 import { formatErrorMessage } from "./errors.js";
+import { gitCommitPrefixesMatch } from "./git-commit.js";
 import { resolveOpenClawPackageRoot } from "./openclaw-root.js";
 import {
   deleteRestartSentinelRowSync,
@@ -82,17 +83,6 @@ async function rewriteRestartSentinel(
   );
 }
 
-function commitsMatch(expected: string, actual: string): boolean {
-  const normalizedExpected = expected.trim().toLowerCase();
-  const normalizedActual = actual.trim().toLowerCase();
-  return (
-    normalizedExpected.length >= 7 &&
-    normalizedActual.length >= 7 &&
-    (normalizedExpected.startsWith(normalizedActual) ||
-      normalizedActual.startsWith(normalizedExpected))
-  );
-}
-
 export async function finalizeUpdateRestartSentinelRunningVersion(
   version = resolveRuntimeServiceVersion(process.env),
   env: NodeJS.ProcessEnv = process.env,
@@ -144,12 +134,15 @@ export async function finalizeUpdateRestartSentinelRunningVersion(
       const expectedSha = typeof after.sha === "string" ? after.sha.trim() : "";
       const actualSha = commit?.trim() ?? "";
       const verifiesGitRevision =
-        stats.mode !== "git" || (expectedSha.length > 0 && commitsMatch(expectedSha, actualSha));
+        stats.mode !== "git" ||
+        (expectedSha.length > 0 && gitCommitPrefixesMatch(expectedSha, actualSha));
       const verifiesInstallRoot =
         expectedRoot !== null && actualRoot !== null && expectedRoot === actualRoot;
       const changedInstall =
         stats.mode !== "git" ||
-        (beforeSha.length > 0 && expectedSha.length > 0 && !commitsMatch(beforeSha, expectedSha));
+        (beforeSha.length > 0 &&
+          expectedSha.length > 0 &&
+          !gitCommitPrefixesMatch(beforeSha, expectedSha));
       if (payload.status === "ok" && expectedRoot && !verifiesInstallRoot) {
         payload.status = "error";
         stats.reason = actualRoot ? "restart-root-mismatch" : "restart-root-unavailable";

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -27,6 +27,7 @@ import {
   EXTERNAL_SUPERVISOR_UPDATE_REQUIRED_REASON,
   isGatewayExternallySupervised,
 } from "./gateway-supervision.js";
+import { gitCommitPrefixesMatch } from "./git-commit.js";
 import { resolveOpenClawPackageRoot } from "./openclaw-root.js";
 import { readVerifiedGitUpdateReceipt, type VerifiedGitUpdateReceipt } from "./restart-sentinel.js";
 import {
@@ -553,16 +554,6 @@ export function initializeGatewayUpdateStatus(): ReturnType<typeof resolveStartu
 
 type GitScheduleStatus = NonNullable<NonNullable<UpdateScheduleState["install"]>["git"]>;
 
-function gitCommitsMatch(left: string, right: string): boolean {
-  const normalizedLeft = left.trim().toLowerCase();
-  const normalizedRight = right.trim().toLowerCase();
-  return (
-    normalizedLeft.length >= 7 &&
-    normalizedRight.length >= 7 &&
-    (normalizedLeft.startsWith(normalizedRight) || normalizedRight.startsWith(normalizedLeft))
-  );
-}
-
 function resolveGitInstalledAtMs(
   git: NonNullable<UpdateCheckResult["git"]>,
   installReceipt: VerifiedGitUpdateReceipt | null,
@@ -572,7 +563,7 @@ function resolveGitInstalledAtMs(
     root !== null &&
     updateInstallRootsMatch(root, installReceipt.root) &&
     git.sha &&
-    gitCommitsMatch(installReceipt.sha, git.sha)
+    gitCommitPrefixesMatch(installReceipt.sha, git.sha)
     ? installReceipt.installedAtMs
     : undefined;
 }


### PR DESCRIPTION
## What Problem This Solves

Restart verification and startup install-receipt attribution independently owned the same Git commit identity policy. Keeping that operational rule in two places made future drift capable of rejecting a valid restart or attributing an installation receipt to the wrong revision.

## Why This Change Was Made

This moves commit-prefix comparison into the internal Git commit metadata owner and routes both lifecycle consumers through it. Semantics are unchanged: values are trimmed and lowercased, both must contain at least seven characters, and either value may be the longer prefix-compatible commit identity.

The UI copy remains separate because it belongs to a different runtime boundary. This consolidation follows the policy introduced in https://github.com/openclaw/openclaw/pull/120769.

## User Impact

No user-visible behavior changes. Restart verification and install-time attribution now share one internal policy, reducing the risk of operational drift.

## Evidence

- `node scripts/run-vitest.mjs src/infra/git-commit.test.ts src/infra/restart-sentinel.test.ts src/infra/update-startup.test.ts`: 152 passed
- `node scripts/check-changed.mjs --dry-run -- src/infra/git-commit.ts src/infra/git-commit.test.ts src/infra/restart-sentinel.ts src/infra/update-startup.ts`: core and core-test lanes selected
- `pnpm check:changed`: passed
- `pnpm check:import-cycles`: 0 runtime value cycles
- `git diff --check`: passed
- Pinned Sol/high autoreview: clean, 0.99
- Production LOC: +18/-24, net -6
- Test LOC: +21/-0
