### PR TITLE
test(logging): exercise canonical owners without duplicate checks

### DIFF
--- a/src/logging/console-timestamp.test.ts
+++ b/src/logging/console-timestamp.test.ts
@@ -61,19 +61,4 @@ describe("formatConsoleTimestamp", () => {
     const now = new Date();
     expect(formatConsoleTimestamp("json")).toBe(formatExpectedLocalIsoWithOffset(now));
   });
-
-  it("timestamp contains the correct local date components", () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-17T18:01:02.345Z"));
-
-    const before = new Date();
-    const result = formatConsoleTimestamp("compact");
-    const after = new Date();
-    // The date portion should match the local date
-    const datePart = result.slice(0, 10);
-    const beforeDate = `${before.getFullYear()}-${String(before.getMonth() + 1).padStart(2, "0")}-${String(before.getDate()).padStart(2, "0")}`;
-    const afterDate = `${after.getFullYear()}-${String(after.getMonth() + 1).padStart(2, "0")}-${String(after.getDate()).padStart(2, "0")}`;
-    // Allow for date boundary crossing during test
-    expect([beforeDate, afterDate]).toContain(datePart);
-  });
 });

--- a/src/logging/console.ts
+++ b/src/logging/console.ts
@@ -141,13 +141,7 @@ const SUPPRESSED_CONSOLE_PREFIXES = [
 const NODE_PROCESS_WARNING_PREFIX = `(${process.release.name}:${process.pid}) `;
 
 function shouldSuppressConsoleMessage(message: string): boolean {
-  if (SUPPRESSED_CONSOLE_PREFIXES.some((prefix) => message.startsWith(prefix))) {
-    return true;
-  }
-  if (isVerbose()) {
-    return false;
-  }
-  return false;
+  return SUPPRESSED_CONSOLE_PREFIXES.some((prefix) => message.startsWith(prefix));
 }
 
 function isEpipeError(err: unknown): boolean {

--- a/src/logging/logger-redaction-behavior.test.ts
+++ b/src/logging/logger-redaction-behavior.test.ts
@@ -8,7 +8,7 @@ import {
   runWithDiagnosticTraceContext,
 } from "../infra/diagnostic-trace-context.js";
 import { getChildLogger, getLogger, resetLogger, setLoggerOverride } from "../logging.js";
-import { withEnv } from "../test-utils/env.js";
+import { withEnv, withEnvAsync } from "../test-utils/env.js";
 import { createSuiteLogPathTracker } from "./log-test-helpers.js";
 import { testApi as loggerTest } from "./logger.test-support.js";
 import { createDiagnosticLogRecordCapture } from "./test-helpers/diagnostic-log-capture.js";
@@ -162,13 +162,15 @@ describe("file log redaction", () => {
     expect(content).toContain("configured log path works");
   });
 
-  it("expands leading tilde in logging.file", () => {
+  it("expands leading tilde in logging.file", async () => {
     const home = path.join(path.dirname(logPathTracker.nextPath()), "home");
+    const logPath = path.join(home, "custom-openclaw.log");
 
-    withEnv({ HOME: home }, () => {
-      expect(loggerTest.resolveActiveLogFile("~/custom-openclaw.log")).toBe(
-        path.join(home, "custom-openclaw.log"),
-      );
+    await withEnvAsync({ HOME: home, OPENCLAW_HOME: undefined }, async () => {
+      setLoggerOverride({ level: "info", file: "~/custom-openclaw.log" });
+      getLogger().info("tilde log path works");
+
+      expect(await readLogFile(logPath)).toContain("tilde log path works");
     });
   });
 

--- a/src/logging/logger.test-support.ts
+++ b/src/logging/logger.test-support.ts
@@ -1,5 +1,3 @@
-import { expandHomePrefix } from "../infra/home-dir.js";
-import { isLegacyRollingLogFilePath, resolveRollingLogFilePathForDate } from "./log-file-path.js";
 import { fileLogTransport } from "./logger-file-transport.js";
 import { defaultLoggerHostnameResolver, loggerHostnameState } from "./logger-hostname-state.js";
 
@@ -7,12 +5,6 @@ export const testApi = {
   drainFileLogQueueSyncForTests: fileLogTransport.drainSync,
   flushFileLogQueueForTests: fileLogTransport.flush,
   resetFileLogTransportForTests: fileLogTransport.resetForTests,
-  resolveActiveLogFile(file: string): string {
-    const expandedFile = expandHomePrefix(file);
-    return isLegacyRollingLogFilePath(expandedFile)
-      ? resolveRollingLogFilePathForDate(expandedFile, new Date())
-      : expandedFile;
-  },
   setFileLogAppenderForTests: fileLogTransport.setAppenderForTests,
   setFileLogQueueMaxRecordsForTests: fileLogTransport.setMaxQueuedRecordsForTests,
   setHostnameResolverForTests(resolver?: () => string): void {


### PR DESCRIPTION
## What Problem This Solves

One logging test checks a copied path resolver in test support rather than the logger's real resolver. The console timestamp suite also repeats the date portion of an existing full timestamp assertion for the same frozen instant.

## Why This Change Was Made

Keep the tilde-path contract and test it through a real logger write to the independently expected temporary-home path. Await the existing file queue and inspect the output before restoring the scoped environment. Delete the now-unused copied resolver and its imports. Keep the complete compact timestamp assertion and remove its weaker date-only subset. Also simplify the nearby console suppression predicate: the verbose and default branches both returned false, so return the unchanged sensitive-prefix check directly.

## User Impact

Logging behavior is unchanged. The logger's actual home-expansion wiring gains direct output coverage; no test-only production export or new helper is added. Other style, timezone, config, redaction, trace, hostname, UTF-16, output-routing and lifecycle assertions remain. One redundant execution is removed.

## Evidence

The old tilde test could remain green if home expansion disappeared from the real logger: it invoked a separate implementation. Raw-parent history confirms that this copy arose when logging test controls were isolated from production exports. The replacement exercises the normal logger and file transport while preserving that isolation. Existing asynchronous environment scope, queue flush and suite cleanup own all fixture lifetime.

The removed date-only case uses the same frozen instant and style as the retained full timestamp assertion. That survivor independently builds all date, time and offset fields using native Date getters. Original introduction before the available shallow history is unknown.

The complete four-file selection passes before (54 tests) and after (53 tests), including the real tilde-path write/read. Targeted formatting and diff checks pass. Production +1/-7 (net -6), test files +8/-21 (net -13), test support +0/-8. The final selection also passes all 53 tests after the console predicate simplification, including sensitive-session suppression in verbose mode. The final four-file changed gate passes core and core-test types, full dead-export scans, formatting, lint, repository boundaries and runtime import-cycle guards. Independent Codex review is scoped-clean at its configured P0 threshold.

The console cleanup preserves the exact prefix list and both output callers. The verbose getter is pure, and its meaningful uses in console settings remain. No suppression or redaction test is removed.
