### PR TITLE
test(parallel): assert user agent at the request boundary

### DIFF
--- a/extensions/parallel/src/parallel-search-normalize.ts
+++ b/extensions/parallel/src/parallel-search-normalize.ts
@@ -38,11 +38,6 @@ const PARALLEL_MAX_SEARCH_QUERIES = 5;
 const PARALLEL_SESSION_ID_MAX_LENGTH = 1000;
 const PARALLEL_CLIENT_MODEL_MAX_LENGTH = 100;
 
-const normalizeParallelSessionId: (
-  value: string | undefined,
-  maxLength: number,
-) => string | undefined = normalizeBoundedOptionalString;
-
 type ParallelSearchResult = {
   title?: unknown;
   url?: unknown;
@@ -84,7 +79,10 @@ function normalizeParallelSearchRequest(
     objective,
     searchQueries,
     count: resolveParallelSearchCount(args, configuredCount),
-    sessionId: normalizeParallelSessionId(readStringParam(args, "session_id"), sessionIdMaxLength),
+    sessionId: normalizeBoundedOptionalString(
+      readStringParam(args, "session_id"),
+      sessionIdMaxLength,
+    ),
     clientModel: normalizeParallelClientModel(readStringParam(args, "client_model")),
   };
 }

--- a/extensions/parallel/src/parallel-web-search-provider.runtime.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.runtime.ts
@@ -221,5 +221,4 @@ export const testing = {
   resolveParallelSearchCount,
   resolveParallelSearchEndpoint,
   PARALLEL_SEARCH_RESPONSE_LIMIT_BYTES,
-  USER_AGENT,
 } as const;

--- a/extensions/parallel/src/parallel-web-search-provider.test.ts
+++ b/extensions/parallel/src/parallel-web-search-provider.test.ts
@@ -350,9 +350,6 @@ describe("parallel web search provider", () => {
       docs: "https://docs.openclaw.ai/tools/parallel-search",
     });
   });
-  it("identifies the plugin via a versioned User-Agent header", () => {
-    expect(testing.USER_AGENT).toMatch(/^openclaw-parallel\/\d+\.\d+\.\d+/);
-  });
   it("treats objective as optional and omits it from the request when absent", async () => {
     enqueueJson();
     const result = await paidTool().execute({ search_queries: ["openclaw"] });
@@ -460,7 +457,7 @@ describe("parallel web search provider", () => {
     });
     const headers = (call.init.headers ?? {}) as Record<string, string>;
     expect(headers["x-api-key"]).toBe("par-secret");
-    expect(headers["User-Agent"]).toMatch(/^openclaw-parallel\//);
+    expect(headers["User-Agent"]).toMatch(/^openclaw-parallel\/\d+\.\d+\.\d+/);
     expect(result).toMatchObject({
       provider: "parallel",
       searchId: "search_test",


### PR DESCRIPTION
## What Problem This Solves

Parallel exposes its private User-Agent constant for a standalone assertion even though an existing provider test already inspects that outgoing header. Its session normalizer also retains a one-use typed alias with no distinct behavior.

## Why This Change Was Made

Move the exact version regex into the existing paid-request header assertion and delete the standalone constant test and testing exposure. Call the already-imported canonical string normalizer directly with identical input and limit, removing the private alias.

## User Impact

One fewer redundant test execution. Request normalization, limits, authentication, paid/free transport, cache grouping, cancellation, and public plugin/SDK surfaces remain unchanged.

## Evidence

The retained header assertion checks the same version pattern at the actual request boundary. Shared normalization tests and actual paid/free session cases remain; the normalizer call invokes exactly the same function with the same arguments. Production +4/-7 (net -3); tests +1/-4 (net -3).

The complete Parallel suite and canonical string-normalizer tests pass before and after: 68 → 67 cases on the reviewed base. The required changed gate passes plugin contract tests, boundary reports, dead exports, extension production/test types, lint, database/media/sidecar guards and import-cycle checks. Independent Codex review is scoped-clean.
