### PR TITLE
test(discord): consolidate successful request signal coverage

### DIFF
--- a/extensions/discord/src/proxy-request-client.test.ts
+++ b/extensions/discord/src/proxy-request-client.test.ts
@@ -30,12 +30,14 @@ describe("createDiscordRequestClient", () => {
     vi.useRealTimers();
   });
 
-  it("preserves the REST client's abort signal for proxied fetch calls", async () => {
+  it("preserves a live REST abort signal through successful proxied fetches", async () => {
+    let receivedSignal: AbortSignal | undefined;
     const fetchSpy = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
       if (!(init?.signal instanceof AbortSignal)) {
         throw new Error("Expected proxied fetch init to include an AbortSignal");
       }
       expect(init.signal.aborted).toBe(false);
+      receivedSignal = init.signal;
       return createJsonResponse([]);
     });
 
@@ -46,6 +48,7 @@ describe("createDiscordRequestClient", () => {
 
     await client.get("/channels/123/messages");
     expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(receivedSignal?.aborted).toBe(false);
   });
 
   it("lets the REST client abort hanging proxied requests after its timeout", async () => {
@@ -104,27 +107,6 @@ describe("createDiscordRequestClient", () => {
 
     await expectAbortError(request);
     expect(abortable.receivedSignal?.aborted).toBe(true);
-  });
-
-  it("provides the REST client's timeout signal even without a caller signal", async () => {
-    let receivedSignal: AbortSignal | undefined;
-
-    const fetchSpy = vi.fn(async (_input: string | URL | Request, init?: RequestInit) => {
-      receivedSignal = init?.signal ?? undefined;
-      return createJsonResponse({});
-    });
-
-    const client = createDiscordRequestClient("Bot test-token", {
-      fetch: fetchSpy as never,
-      queueRequests: false,
-    });
-
-    await client.get("/channels/123/messages");
-
-    if (!receivedSignal) {
-      throw new Error("Expected proxied fetch to receive the REST timeout signal");
-    }
-    expect(receivedSignal.aborted).toBe(false);
   });
 
   it("exports a reasonable timeout constant", () => {


### PR DESCRIPTION
## What Problem This Solves

Two Discord proxy tests create the same successful no-caller-signal request, then inspect the REST-owned signal at different times.

## Why This Change Was Made

Use one request to retain both observations: the signal is valid and live during fetch, and remains live after successful completion. Keep the exact fetch count and remove the redundant request setup.

## User Impact

One fewer test execution. Actual request timeout, abortAllRequests, caller cancellation, and shared timeout-bound tests remain. Production unchanged; tests +4/-22 (net -18).

## Evidence

The proxy owner passes the fetch function to the internal RequestClient, which owns its per-request controller and cleanup. Both former fixtures used identical options and route. The preserved assertions cover both observation times; response parsing has separate owner tests.

The two complete proxy/client test files pass before (11 tests) and after (10 tests). Targeted formatting and diff checks pass. Independent Codex review is scoped-clean at its configured P0 threshold. The required changed-file gate passes plugin boundaries, extension-test types, formatting and scoped lint.
