### PR TITLE
test(tooling): assert benchmark arguments at worker launch

### DIFF
--- a/scripts/bench-task-registry-sqlite.ts
+++ b/scripts/bench-task-registry-sqlite.ts
@@ -87,12 +87,6 @@ type WorkerLaunchRuntime = {
   spawnWorker?: BenchmarkWorkerSpawner;
 };
 
-type BenchmarkRuntime = {
-  runWorker?: typeof runWorker;
-  writeProgress?: (line: string) => void;
-  now?: () => number;
-};
-
 function usage(): string {
   return `OpenClaw durable task registry churn benchmark
 
@@ -330,23 +324,6 @@ function parseWorkerProcessResult(
   });
 }
 
-function buildWorkerArgs(options: Options, size: number, stateDir: string): string[] {
-  return [
-    "--expose-gc",
-    "--import",
-    "tsx",
-    "scripts/bench-task-registry-sqlite-worker.ts",
-    "--size",
-    String(size),
-    "--cycles",
-    String(options.cycles),
-    "--warmup",
-    String(options.warmup),
-    "--state-dir",
-    stateDir,
-  ];
-}
-
 function runWorker(
   options: Options,
   size: number,
@@ -355,7 +332,20 @@ function runWorker(
   const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-task-registry-bench-"));
   try {
     return runBenchmarkWorker({
-      args: buildWorkerArgs(options, size, stateDir),
+      args: [
+        "--expose-gc",
+        "--import",
+        "tsx",
+        "scripts/bench-task-registry-sqlite-worker.ts",
+        "--size",
+        String(size),
+        "--cycles",
+        String(options.cycles),
+        "--warmup",
+        String(options.warmup),
+        "--state-dir",
+        stateDir,
+      ],
       label: `size ${size}`,
       sentinel: WORKER_RESULT_SENTINEL,
       spawnWorker: runtime.spawnWorker,
@@ -441,14 +431,11 @@ function aggregateWorkerResults(options: Options, workers: WorkerResult[]) {
   };
 }
 
-function benchmark(options: Options, runtime: BenchmarkRuntime = {}) {
-  const run = runtime.runWorker ?? runWorker;
+function benchmark(options: Options) {
   const workers = runBenchmarkJobs(options.sizes, {
     prefix: "bench-task-registry-sqlite",
     describe: (size) => `size=${size}`,
-    run: (size) => run(options, size),
-    now: runtime.now,
-    writeProgress: runtime.writeProgress,
+    run: (size) => runWorker(options, size),
   });
   return aggregateWorkerResults(options, workers);
 }
@@ -473,12 +460,9 @@ async function main(argv = process.argv.slice(2)): Promise<void> {
 
 export const testing = {
   aggregateWorkerResults,
-  benchmark,
-  buildWorkerArgs,
   parseOptions,
   parseWorkerProcessResult,
   runWorker,
-  summarizeTimings: summarizeBenchmarkTimings,
 };
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {

--- a/test/scripts/bench-task-registry-sqlite.test.ts
+++ b/test/scripts/bench-task-registry-sqlite.test.ts
@@ -1,6 +1,5 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import {
@@ -148,36 +147,31 @@ describe("durable task registry churn benchmark", () => {
     expect(() => testing.parseOptions(["--wat"])).toThrow("Unknown argument: --wat");
   });
 
-  it("always launches a fresh expose-gc worker for one size", () => {
+  it("launches an expose-gc worker and removes its state directory after a timeout", () => {
     const options = testing.parseOptions(["--sizes", "8", "--cycles", "2", "--warmup", "1"]);
-    const stateDir = path.join(os.tmpdir(), "benchmark-state");
-    expect(testing.buildWorkerArgs(options, 8, stateDir)).toEqual([
-      "--expose-gc",
-      "--import",
-      "tsx",
-      "scripts/bench-task-registry-sqlite-worker.ts",
-      "--size",
-      "8",
-      "--cycles",
-      "2",
-      "--warmup",
-      "1",
-      "--state-dir",
-      stateDir,
-    ]);
-  });
-
-  it("removes the parent-owned worker state directory after a timeout", () => {
-    const options = testing.parseOptions(["--sizes", "2", "--cycles", "1", "--warmup", "0"]);
     let stateDir: string | undefined;
     expect(() =>
-      testing.runWorker(options, 2, {
+      testing.runWorker(options, 8, {
         spawnWorker: (_command, args) => {
           const stateDirIndex = args.indexOf("--state-dir");
           stateDir = args[stateDirIndex + 1];
           if (!stateDir) {
             throw new Error("missing worker state directory");
           }
+          expect(args).toEqual([
+            "--expose-gc",
+            "--import",
+            "tsx",
+            "scripts/bench-task-registry-sqlite-worker.ts",
+            "--size",
+            "8",
+            "--cycles",
+            "2",
+            "--warmup",
+            "1",
+            "--state-dir",
+            stateDir,
+          ]);
           fs.writeFileSync(path.join(stateDir, "openclaw.sqlite"), "timeout fixture");
           return {
             status: null,


### PR DESCRIPTION
## What Problem This Solves

The task-registry benchmark tests its worker argument array separately from the existing test that observes a worker launch and timeout cleanup. It also exposes unused benchmark injection and testing hooks.

## Why This Change Was Made

Check the same non-default arguments at the actual spawn boundary in the timeout test, retaining its state-directory cleanup assertion and the real worker smoke. Inline the one-use argument builder and remove unused exports and injection hooks. The shared benchmark harness remains responsible for clock and progress defaults; its sibling's actively used injection tests stay.

## User Impact

The benchmark CLI, workload, report, SQLite lifecycle, timeouts and progress defaults are unchanged. Tooling: +16/-32 (net -16); tests: +16/-22 (net -6). Runtime production is unchanged. Seven benchmark cases become six without losing the launch or cleanup assertions.

## Evidence

Read the full benchmark, worker, shared harness, callers, sibling implementation and tests. The real subprocess case retains `--expose-gc`, durable registration, terminal transitions and teardown checks; result-integrity cases remain.

On main `10564e2f`, the current composed run passed 126 cases before and 125 after, including this patch and the separate catalog import cleanup in #134205. The benchmark's seven cases become six; all 118 catalog cases and the SDK cleanup case remain unchanged. The full 18 changed-file checks passed, including script/root-test types, lint, formatting and repository boundaries. Earlier 34-case auth/state proof remains attributed to composed head `5d2e193b`; it is not a new performance comparison.

## CI Refresh

CI 33431057289 failed in an unchanged SDK CLI test that expected the entire shared `RUNNER_TEMP` parent to be empty. Its cancellation, deadline and Git cleanup assertions had passed. This refresh incorporates canonical #134422, which verifies removal of the CLI's actual temporary root while preserving unrelated sibling files. That SDK case now passes in both composed runs; the benchmark afterimages are unchanged and no duplicate SDK fix is included.

The base also retains the previously adopted provider-classification repairs #133970/#134008 and hosted lint policy #133988. Those changes do not establish the cause of the older cold-auth durations or runner shutdown. Fresh exact-head hosted CI is required before landing.

Fresh managed Codex review of the complete composed diff is scoped-clean at the configured P0 threshold. Manual owner, coverage and source-composition review is recorded separately.
