### PR TITLE
perf(gateway): reuse owned history snapshots

### DIFF
--- a/src/gateway/server-methods/chat-history-handler.test.ts
+++ b/src/gateway/server-methods/chat-history-handler.test.ts
@@ -5,6 +5,7 @@ import {
   appendTranscriptMessage,
   bindSessionPendingInputSources,
   stageSessionPendingInput,
+  updateSessionEntry,
   upsertSessionEntryCore,
 } from "../../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -123,6 +124,95 @@ describe("chat history consumption receipts", () => {
       expect.objectContaining({ code: "INVALID_REQUEST" }),
     );
   });
+});
+
+describe("chat history exact-entry snapshots", () => {
+  it.each(["chat.history", "chat.startup"] as const)(
+    "%s projects fresh owned session state without another preparation copy",
+    async (method) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const now = Date.now();
+        const scope = {
+          agentId: "main",
+          sessionKey: "agent:main:history-owned",
+          sessionId: "history-owned",
+        };
+        const childScope = { agentId: "main", sessionKey: "agent:main:subagent:history-child" };
+        const toolOverrides = { mcpToolsDeny: { synthetic: ["blocked"] } };
+        await upsertSessionEntryCore(scope, {
+          sessionId: scope.sessionId,
+          updatedAt: now,
+          thinkingLevel: "high",
+          toolOverrides,
+        });
+        await upsertSessionEntryCore(childScope, {
+          sessionId: "history-child",
+          updatedAt: now,
+          parentSessionKey: scope.sessionKey,
+          spawnedBy: scope.sessionKey,
+          status: "running",
+        });
+        const context = createDirectChatContext();
+        const handler = expectDefined(chatHistoryHandlers[method], "history handler");
+        const call = async () => {
+          const respond = vi.fn();
+          const cloneSpy = vi.spyOn(globalThis, "structuredClone");
+          try {
+            const pending = handler({
+              params: { sessionKey: scope.sessionKey },
+              context,
+              req: { type: "req", id: "owned-history", method },
+              client: null,
+              isWebchatConnect: () => false,
+              respond,
+            });
+            // Count synchronous history preparation before optional startup icon work resumes.
+            const preparationCopies = cloneSpy.mock.calls.filter(
+              ([value]) => asOptionalRecord(value)?.sessionId === scope.sessionId,
+            ).length;
+            await pending;
+            const [ok, payload, error] = expectDefined(respond.mock.calls[0], "history response");
+            expect(error).toBeUndefined();
+            expect(ok).toBe(true);
+            expect(preparationCopies).toBe(0);
+            return expectDefined(asOptionalRecord(payload), "history payload");
+          } finally {
+            cloneSpy.mockRestore();
+          }
+        };
+
+        const first = await call();
+        expect(first).toMatchObject({ thinkingLevel: "high", toolOverrides });
+        expect(first.sessionInfo).toMatchObject({ childSessions: [childScope.sessionKey] });
+        const responseTools = expectDefined(
+          asOptionalRecord(first.toolOverrides),
+          "tool overrides",
+        );
+        const deniedByServer = expectDefined(
+          asOptionalRecord(responseTools.mcpToolsDeny),
+          "denied tools by server",
+        );
+        const deniedTools = deniedByServer.synthetic;
+        if (!Array.isArray(deniedTools)) {
+          throw new Error("expected nested denied tool array");
+        }
+        deniedTools.push("response-only");
+        expect(toolOverrides.mcpToolsDeny.synthetic).toEqual(["blocked"]);
+        expect((await call()).toolOverrides).toEqual(toolOverrides);
+
+        await updateSessionEntry(scope, () => ({ thinkingLevel: "low", updatedAt: now + 1 }));
+        await updateSessionEntry(childScope, () => ({
+          parentSessionKey: "agent:main:other-parent",
+          spawnedBy: "agent:main:other-parent",
+          updatedAt: now + 1,
+        }));
+        const fresh = await call();
+        expect(fresh).toMatchObject({ thinkingLevel: "low", toolOverrides });
+        expect(asOptionalRecord(fresh.sessionInfo)?.childSessions).toBeUndefined();
+        expect(first.thinkingLevel).toBe("high");
+      });
+    },
+  );
 });
 
 describe("chat metadata ownership", () => {

--- a/src/gateway/server-methods/chat-history-handler.ts
+++ b/src/gateway/server-methods/chat-history-handler.ts
@@ -234,13 +234,13 @@ async function handleChatHistoryRequest({
     respond(false, undefined, requestedAgent.error);
     return;
   }
-  const requestedAgentId = requestedAgent.agentId;
-  const sessionLoadOptions = requestedAgentId ? { agentId: requestedAgentId } : undefined;
   const { cfg, storePath, store, entry, canonicalKey } = measureDiagnosticsTimelineSpanSync(
     `gateway.${method}.session_entry`,
     () =>
       loadGatewaySessionEntryReadOnly(sessionKey, {
-        ...sessionLoadOptions,
+        agentId: requestedAgent.agentId,
+        // Exact reads own their nested JSON; history only projects that snapshot.
+        clone: false,
         includeStoreChildEntries: true,
       }),
     {

--- a/src/gateway/server-methods/chat.directive-tags.test.ts
+++ b/src/gateway/server-methods/chat.directive-tags.test.ts
@@ -3203,7 +3203,7 @@ describe("chat directive tag stripping for non-streaming final payloads", () => 
 
     expect(mockState.loadSessionEntryCalls).toContainEqual({
       rawKey: "agent:work:main",
-      opts: { agentId: "work", includeStoreChildEntries: true },
+      opts: { agentId: "work", clone: false, includeStoreChildEntries: true },
     });
   });
 

--- a/src/gateway/session-utils-core.ts
+++ b/src/gateway/session-utils-core.ts
@@ -336,8 +336,8 @@ export function getSingleRowChildSessionCandidates(params: {
   }
   const childSessionCandidatesByParentKey = buildStoreChildSessionCandidateIndex(params.store);
   rememberSingleRowChildSessionCandidateCacheEntry(params.storePath, {
-    // Exact read-only lookups rebuild a sparse record but borrow stable entry objects
-    // from the SQLite snapshot. Compare those identities so the derived index survives.
+    // Full-store snapshots can retain entry identities between short-list projections.
+    // Exact reads own fresh JSON and do not use this cache.
     entriesByKey: new Map(Object.entries(params.store)),
     childSessionCandidatesByParentKey,
   });
@@ -415,7 +415,7 @@ export function isCurrentSessionChildOwner(params: {
   );
 }
 
-/** Prepare only selected parents; a supplied candidate map retains exact-row cache ownership. */
+/** Prepare only selected parents; a supplied candidate map belongs to the full-store caller. */
 export function buildStoreChildSessionIndex(params: {
   store: Record<string, SessionEntry>;
   keys: readonly string[];

--- a/src/gateway/session-utils-projection.ts
+++ b/src/gateway/session-utils-projection.ts
@@ -16,7 +16,6 @@ import type {
 } from "./session-utils-contracts.js";
 import {
   buildStoreChildSessionIndex,
-  getSingleRowChildSessionCandidates,
   resolveEstimatedSessionCostUsd,
   resolvePositiveNumber,
   resolveRuntimeChildSessionKeys,
@@ -39,7 +38,6 @@ export function buildSessionListRowMetadataContext(params: {
 
 export function buildSingleRowStoreChildSessionsByKey(params: {
   store: Record<string, SessionEntry>;
-  storePath: string;
   key: string;
   now: number;
 }): Map<string, string[]> {
@@ -47,10 +45,6 @@ export function buildSingleRowStoreChildSessionsByKey(params: {
     store: params.store,
     keys: [params.key],
     now: params.now,
-    candidates: getSingleRowChildSessionCandidates({
-      storePath: params.storePath,
-      store: params.store,
-    }),
     requireCurrentController: true,
   });
 }

--- a/src/gateway/session-utils-search.ts
+++ b/src/gateway/session-utils-search.ts
@@ -171,7 +171,6 @@ function loadGatewaySessionSnapshot(
     return { row: null };
   }
   const storeChildSessionsByKey = buildSingleRowStoreChildSessionsByKey({
-    storePath,
     store,
     key: canonicalKey,
     now,
@@ -223,7 +222,6 @@ export function buildGatewaySessionInfo(params: {
 }): GatewaySessionRow {
   const now = params.now ?? Date.now();
   const storeChildSessionsByKey = buildSingleRowStoreChildSessionsByKey({
-    storePath: params.storePath,
     store: params.store,
     key: params.key,
     now,

--- a/src/gateway/session-utils.single-row-cache.test.ts
+++ b/src/gateway/session-utils.single-row-cache.test.ts
@@ -1,5 +1,5 @@
 /**
- * Tests single-row session cache behavior in gateway session utilities.
+ * Tests fresh child state in exact session-row Gateway projections.
  */
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
@@ -69,7 +69,12 @@ const subagentRegistryReadMock = vi.hoisted(() => {
 
 vi.mock("../agents/subagents/registry/subagent-registry-read.js", () => subagentRegistryReadMock);
 
-import { listSessionsFromStoreAsync, loadGatewaySessionRow } from "./session-utils.js";
+import {
+  buildGatewaySessionInfo,
+  listSessionsFromStoreAsync,
+  loadGatewaySessionEntryReadOnly,
+  loadGatewaySessionRow,
+} from "./session-utils.js";
 
 const MAIN_AGENT_ID = "main";
 const TEST_MODEL = "openai/gpt-5.4";
@@ -198,7 +203,7 @@ function expectChildMovedToNewParent(fixture: MovingChildFixture, now: number): 
   expect(subagentRegistryReadMock.buildSubagentSessionListReadIndex).not.toHaveBeenCalled();
 }
 
-describe("single gateway session row child-session cache", () => {
+describe("single gateway session row child projections", () => {
   afterEach(() => {
     resetConfigRuntimeState();
     resetPluginRuntimeStateForTest();
@@ -206,7 +211,7 @@ describe("single gateway session row child-session cache", () => {
     vi.clearAllMocks();
   });
 
-  test("shares the child-session index across repeated single-row loads for the same store", async () => {
+  test("keeps direct children visible with at most one candidate scan per exact snapshot", async () => {
     await withSingleRowCacheStore(
       "openclaw-single-row-cache-",
       "/tmp/openclaw-single-row-cache",
@@ -236,12 +241,28 @@ describe("single gateway session row child-session cache", () => {
         expect(rowA?.childSessions).toEqual(["agent:main:subagent:child-a"]);
         expect(rowB?.childSessions).toEqual(["agent:main:subagent:child-b"]);
         expect(rowAAfterWindow?.childSessions).toEqual(["agent:main:subagent:child-a"]);
+        for (let index = 0; index < 2; index += 1) {
+          const loaded = loadGatewaySessionEntryReadOnly("agent:main:subagent:parent-a", {
+            clone: false,
+            includeStoreChildEntries: true,
+          });
+          const entriesSpy = vi.spyOn(Object, "entries");
+          try {
+            const row = buildGatewaySessionInfo({ ...loaded, key: loaded.canonicalKey, now });
+            expect(row.childSessions).toEqual(["agent:main:subagent:child-a"]);
+            expect(
+              entriesSpy.mock.calls.filter(([value]) => value === loaded.store).length,
+            ).toBeLessThanOrEqual(1);
+          } finally {
+            entriesSpy.mockRestore();
+          }
+        }
         expect(subagentRegistryReadMock.buildSubagentSessionListReadIndex).not.toHaveBeenCalled();
       },
     );
   });
 
-  test("refreshes subagent registry state while reusing store child candidates", async () => {
+  test("refreshes subagent registry control on each projection", async () => {
     await withSingleRowCacheStore(
       "openclaw-single-row-cache-fresh-registry-",
       "/tmp/openclaw-single-row-cache-fresh-registry",
@@ -267,7 +288,7 @@ describe("single gateway session row child-session cache", () => {
     );
   });
 
-  test("keeps independent navigation lineage while cached runtime control moves", async () => {
+  test("keeps independent navigation lineage while runtime control moves", async () => {
     await withSingleRowCacheStore(
       "openclaw-single-row-cache-navigation-owner-",
       "/tmp/openclaw-single-row-cache-navigation-owner",
@@ -334,7 +355,7 @@ describe("single gateway session row child-session cache", () => {
     );
   });
 
-  test("rebuilds store child candidates after same-object session store writes", async () => {
+  test("refreshes store child candidates after session writes", async () => {
     await withSingleRowCacheStore(
       "openclaw-single-row-cache-write-version-",
       "/tmp/openclaw-single-row-cache-write-version",

--- a/src/gateway/session-utils.subagent.test.ts
+++ b/src/gateway/session-utils.subagent.test.ts
@@ -250,7 +250,6 @@ describe("session list subagent metadata", () => {
     expect(
       buildSingleRowStoreChildSessionsByKey({
         store,
-        storePath: "/tmp/sessions.json",
         key: navigationParentKey,
         now,
       }).get(navigationParentKey),

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -36,17 +36,14 @@ import { registerSessionAutomationSource } from "./session-automation-index.js";
 import { buildGatewaySessionEventFields } from "./session-event-payload.js";
 import { projectSessionActor } from "./session-identity-projection.js";
 import { resolveSessionStoreAgentId, resolveSessionStoreKey } from "./session-store-key.js";
-import { deriveSessionTitle } from "./session-utils-core.js";
+import { deriveSessionTitle, getSingleRowChildSessionCandidates } from "./session-utils-core.js";
 import { listSessionsFromStoreAsync } from "./session-utils-list.js";
 import {
   getSessionDefaults,
   projectSessionPatchResult,
   resolveGatewayModelSupportsImages,
 } from "./session-utils-model.js";
-import {
-  buildSessionListRowMetadataContext,
-  buildSingleRowStoreChildSessionsByKey,
-} from "./session-utils-projection.js";
+import { buildSessionListRowMetadataContext } from "./session-utils-projection.js";
 import { buildGatewaySessionRow as buildGatewaySessionRowOwner } from "./session-utils-row.js";
 import {
   resolveGatewaySessionStoreTarget,
@@ -3339,7 +3336,7 @@ describe("gateway session utils", () => {
     }
   });
 
-  test("single-row child candidates reuse stable entry identities across sparse stores", () => {
+  test("short-list child candidates reuse stable full-store entry identities", () => {
     const parentKey = "agent:main:main";
     let spawnedByReads = 0;
     const parent = { sessionId: "parent", updatedAt: 1 } as SessionEntry;
@@ -3353,17 +3350,13 @@ describe("gateway session utils", () => {
     } as SessionEntry;
     const storePath = "/tmp/openclaw-single-row-child-cache";
 
-    const first = buildSingleRowStoreChildSessionsByKey({
+    const first = getSingleRowChildSessionCandidates({
       store: { [parentKey]: parent, "agent:main:child": child },
       storePath,
-      key: parentKey,
-      now: Date.now(),
     });
-    const second = buildSingleRowStoreChildSessionsByKey({
+    const second = getSingleRowChildSessionCandidates({
       store: { [parentKey]: parent, "agent:main:child": child },
       storePath,
-      key: parentKey,
-      now: Date.now(),
     });
 
     expect(first.get(parentKey)).toEqual(["agent:main:child"]);

--- a/src/shared/pid-alive.ts
+++ b/src/shared/pid-alive.ts
@@ -1,7 +1,7 @@
-// PID liveness helpers check whether process ids still refer to active processes.
+// Native Node callers load this source closure without a TypeScript import resolver.
 import childProcess from "node:child_process";
 import fsSync from "node:fs";
-import { readWindowsProcessStartTimeSync } from "../infra/windows-process-start.js";
+import { readWindowsProcessStartTimeSync } from "../infra/windows-process-start.ts";
 
 const PROCESS_START_TIMEOUT_MS = 1000;
 // Cron reads its own identity on every tick. Cache only a successful Windows


### PR DESCRIPTION
## What Problem This Solves

History/startup preparation copied an exact session row after the SQLite accessor had already parsed its owned nested JSON. Child projection then sent fresh sparse rows through an identity cache that could not reuse them, repeating enumeration and retaining a useless entry. This follow-up to #133873 removes that repeated work; it does not attribute every saturation tail to these two costs.

## Why This Change Was Made

History/startup uses the existing `clone: false` read option and projects the accessor-owned snapshot directly. Exact-row child projection calls the canonical selected-parent builder, preserving current-controller and navigation-lineage rules. The ineffective cache calls and unused `storePath` argument are deleted. Default loader cloning and the legitimate short-list/full-store cache remain; its stable-identity test now exercises the actual owner.

Production, including the native-import CI correction: **+8/−16 (net −8)** across five files. Tests/support: **+124/−21 (net +103)** across five files. No new API, dependency, configuration, schema, SQL projection, index, concurrency, recovery or persistence semantics.

## User Impact

Each history/startup read avoids one redundant selected-row deep copy. Exact-row child preparation scans its sparse snapshot once instead of three times. Nested response data remains independent of persisted data and later requests; subsequent session and child-owner updates stay visible. Cursor/display freshness, archived history, authorization and missing-store behavior retain their existing owners.

## Evidence

Before editing production code, the real SQLite owner tests failed exactly three work-budget assertions: one extra selected-entry copy in each history/startup path and three exact-snapshot scans against a budget of at most one. Ten sibling cases passed; there was no setup/import failure.

After the refactor, **10 files / 569 tests pass**, covering those budgets, nested response mutation, fresh parent/child updates, default cloning, canonical/Doctor and non-provisioning paths, runtime controller versus navigation lineage, profile-scoped metadata generations, lifecycle broadcasts and global-alias routing. The full nine-file `check-changed` gate passed. Codex autoreview found no accepted findings at its requested P0 scope. All nine reviewed/tested afterimages were preserved through rebase and the subsequent native-import correction.

The exact accessor and selected-parent builder already supply the ownership contract; another cache or library would add unnecessary state. Raw parent/patch history verifies the earlier clone/cache paths and later lower-layer clone removal without assigning the whole latency incident to those commits.

### Isolated runtime proof

All runs use synthetic HOME/state, owned loopback ports, and unchanged **2,000 ms control/handshake budgets**: 32 turns, 48 seeded sessions, 128 updates across four clients, three history clients with five-request bursts, six subscribers, a visible observer, 100 ms cadence and 1,000 ms mock stream delay. No production or operator Gateway was stressed.

| Maximum latency | Three standard runs at `c24845ad` | Real UI + CPU at `c24845ad` | Final real UI + CPU at `d5774f84` |
| --- | ---: | ---: | ---: |
| `sessions.list` | 399.6 ms | 705.1 ms | 329.8 ms |
| History | 448.3 ms | 826.4 ms | 501.5 ms |
| Control UI HTTP | 504.4 ms | 667.4 ms | 390.3 ms |
| Readiness | 296.1 ms | 224.3 ms | 215.5 ms |
| Fresh handshake | 108.9 ms | 107.5 ms | 100.2 ms |

Every budget passed; every operation failure counter and metadata rescan count was zero. The standard runs completed 1,640 history operations and 384 updates; the two additional profiles completed 580 and 560 history operations. Each head was freshly built with its Control UI, with 39,489 source/build/dependency pins unchanged afterward. All 7,681 non-UI built JavaScript files are byte-identical between these two heads; the three earlier standard runs remain attributed to their actual `c24845ad51824148d556c42bf5cadd67e3c9ca52` head.

The final `d5774f8424c9035b17bb75753170c149e19a9f29` profile retained all 993 strict benchmark joins and 121/121 observed browser responses, with zero incomplete requests. Both actual browser sockets closed before their observers were replaced. The real page displayed live session updates and the complete synthetic reply; all three full screenshots were inspected. The header still read Working, so this is not an idle-UI assertion. Two distinct eligible healthy readiness snapshots were observed within **4.01 s** after load under the unchanged recovery guard. Owned processes, loopback listeners and temporary browser/HOME directories were verified absent afterward.

The final CPU profile retains all 12,324 samples, with approximately ±7.09 ms load-boundary clock uncertainty. The removed history-copy and ineffective cache paths no longer appear in samples; source and regression proof establish their removal. Event-loop utilization still reaches 1 during load. SQLite transaction ancestry remains about 22% of weighted sample intervals and history about 10%; these overlap and include preemption, not exact CPU service times. These results establish the observed budgets and reduced work, not a universal latency bound, exact speedup ratio or absence of memory leaks. Failed and invalid historical measurements remain retained.

### Exact-head CI and review disposition

Initial CI [33366336245](https://github.com/openclaw/openclaw/actions/runs/33366336245) failed six cancellation/report cases across three tooling shards. Every failure had the same primary `ERR_MODULE_NOT_FOUND` for `windows-process-start.js`; missing fixture reports were secondary. Raw-parent inspection verified an inherited native-source import regression in [97bc908](https://github.com/openclaw/openclaw/commit/97bc908f8850872b960c36dfb58752f6c3a3b653). This was not a Gateway latency failure or a timing flake, and the failed head was not blindly rerun.

The correction uses the real `.ts` dependency path from `pid-alive.ts`, preserving its plain Node source-entry contract. The Windows reader, process identity checks, cancellation, teardown and timing limits are unchanged. A direct native import and the original POSIX timeout-drain case fail before and pass after; 29 existing PID/Windows-reader tests also pass. No duplicate fixture, loader, retry or skipped test was added. A fresh scoped Codex review and the full changed-file gate pass.

Updated exact-head CI [33368352529](https://github.com/openclaw/openclaw/actions/runs/33368352529) completed successfully, including the original Linux cancellation cases and Windows checks. The fresh ClawSweeper review of `d5774f84` found no code or security findings; its sole Rank-up move was successful exact-head CI, now satisfied. Independent audit also reproduced the final profile validator and verified raw artifacts, source/build identity and cleanup. Native prepare and merge use these completed checks.
