### PR TITLE
fix(agents): retain terminal timeout during delayed restart recovery

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -920,6 +920,13 @@ describe("failover-error", () => {
       expect(resolveFailoverReasonFromError(new Error(missingToolResultMessage))).toBeNull();
     });
 
+    it("classifies a generic unrecognized error as unknown", () => {
+      const error = new Error("bad request");
+      expect(
+        resolveModelFallbackError(error, { provider: "openai", model: "gpt-4.1-mini" }),
+      ).toEqual({ kind: "unknown", error });
+    });
+
     it("returns false for plain timeouts and provider errors", () => {
       const timeoutErr = Object.assign(new Error("operation timed out"), { name: "TimeoutError" });
       expect(isNonProviderRuntimeCoordinationError(timeoutErr)).toBe(false);

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery-helpers.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery-helpers.ts
@@ -81,3 +81,59 @@ export function assertRestartRecoverySnapshotCurrent(params: {
     throw new Error("subagent restart recovery session snapshot changed before dispatch");
   }
 }
+
+type ShippedRestartTimeoutSnapshot = {
+  execution: SubagentRunRecord["execution"];
+  endedReason: SubagentRunRecord["endedReason"];
+  terminalOwner: SubagentRunRecord["terminalOwner"];
+};
+
+export function captureShippedRestartTimeout(
+  entry: SubagentRunRecord,
+): ShippedRestartTimeoutSnapshot | undefined {
+  if (
+    entry.execution.outcome?.status !== "timeout" ||
+    typeof entry.execution.endedAt !== "number"
+  ) {
+    return undefined;
+  }
+  return {
+    execution: entry.execution,
+    endedReason: entry.endedReason,
+    terminalOwner: entry.terminalOwner,
+  };
+}
+
+export function reclassifyShippedRestartTimeout(entry: SubagentRunRecord): void {
+  if (
+    entry.execution.outcome?.status !== "timeout" ||
+    typeof entry.execution.endedAt !== "number"
+  ) {
+    return;
+  }
+  const interruptedAt = entry.execution.endedAt;
+  entry.execution = {
+    ...entry.execution,
+    status: "interrupted",
+    interruptedAt,
+    interruptionReason: "gateway-restart",
+    endedAt: undefined,
+    outcome: undefined,
+  };
+  entry.endedReason = undefined;
+  entry.terminalOwner = undefined;
+}
+
+// Resume reclassifies a shipped timeout as live interrupted so the session
+// can be wedged. Restore that timeout when resume is blocked.
+export function restoreShippedRestartTimeout(
+  entry: SubagentRunRecord,
+  snapshot: ShippedRestartTimeoutSnapshot | undefined,
+): void {
+  if (!snapshot) {
+    return;
+  }
+  entry.execution = snapshot.execution;
+  entry.endedReason = snapshot.endedReason;
+  entry.terminalOwner = snapshot.terminalOwner;
+}

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery.test.ts
@@ -930,4 +930,37 @@ describe("subagent registry restart recovery", () => {
       },
     });
   });
+
+  it("keeps a shipped timeout row terminal when recovery is blocked", async () => {
+    mocks.entries[childSessionKey]!.subagentRecovery = {
+      automaticAttempts: 2,
+      lastAttemptAt: Date.now(),
+      lastRunId: "prior-run",
+    };
+    const endedAt = Date.now() - 1_000;
+    const entry = run({
+      endedReason: "subagent-error",
+      execution: {
+        status: "terminal",
+        endedAt,
+        outcome: { status: "timeout" },
+      },
+    });
+
+    await expect(recover(entry)).resolves.toEqual({ status: "handled" });
+    expect(dispatchAgent).not.toHaveBeenCalled();
+    expect(entry.execution).toMatchObject({
+      status: "terminal",
+      endedAt,
+      outcome: { status: "timeout" },
+    });
+    expect(entry.endedReason).toBe("subagent-error");
+    expect(mocks.entries[childSessionKey]).toMatchObject({
+      abortedLastRun: false,
+      subagentRecovery: {
+        automaticAttempts: 2,
+        wedgedAt: expect.any(Number),
+      },
+    });
+  });
 });

--- a/src/agents/subagents/registry/subagent-registry-restart-recovery.ts
+++ b/src/agents/subagents/registry/subagent-registry-restart-recovery.ts
@@ -16,9 +16,12 @@ import {
   assertRestartRecoverySnapshotCurrent,
   buildRestartRecoveryIdempotencyKey,
   buildRestartRecoveryResumeMessage,
+  captureShippedRestartTimeout,
   getRestartRecoveryReplayError,
   isRetiredSubagentExecution,
   isRestartRecoveryLifecycleCurrent,
+  reclassifyShippedRestartTimeout,
+  restoreShippedRestartTimeout,
 } from "./subagent-registry-restart-recovery-helpers.js";
 import { readSubagentRecoveryTranscriptMessage } from "./subagent-registry-restart-recovery-message.js";
 import {
@@ -219,24 +222,14 @@ export async function recoverInterruptedSubagentRow(
     if (typeof params.entry.execution.endedAt === "number" && !legacyRestartTimeout) {
       return { status: "ignored" };
     }
-    if (legacyRestartTimeout) {
-      const interruptedAt = params.entry.execution.endedAt;
-      params.entry.execution = {
-        ...params.entry.execution,
-        status: "interrupted",
-        interruptedAt,
-        interruptionReason: "gateway-restart",
-        endedAt: undefined,
-        outcome: undefined,
-      };
-      params.entry.endedReason = undefined;
-      params.entry.terminalOwner = undefined;
-    }
+    const timeoutSnapshot = captureShippedRestartTimeout(params.entry);
+    reclassifyShippedRestartTimeout(params.entry);
     // The abort marker records the interruption, not the age of useful work.
     // A long-running child must survive a brief planned Gateway update.
     const interruptedForMs =
       params.now - (params.entry.execution.interruptedAt ?? sessionEntry.updatedAt);
     if (interruptedForMs > MAX_INTERRUPTION_AGE_MS) {
+      restoreShippedRestartTimeout(params.entry, timeoutSnapshot);
       return {
         status: "terminal",
         error: `stale aborted subagent run not resumed (${Math.round(interruptedForMs / 1_000)}s interrupted, exceeds stale-run window)`,
@@ -301,6 +294,7 @@ export async function recoverInterruptedSubagentRow(
         childSessionKey,
         reason: blockedReason,
       });
+      restoreShippedRestartTimeout(params.entry, timeoutSnapshot);
       return { status: "handled" };
     }
     if (!params.gatewayRuntime) {


### PR DESCRIPTION
## What Problem This Solves

Proposes removing an obsolete terminal-timeout reclassification exception from delayed restart recovery. **NEEDS WORK: the claimed production timeout-loss path has not been established.** The earlier in-process reachability claim is superseded by the actual Gateway completion-boundary counterevidence below; this is not merge-ready.

## User Impact

No reproduced current Gateway regression is claimed. Ordinary terminal timeouts remain terminal on the tested baseline. This candidate must not be landed solely because its controlled helper tests fail on baseline and pass after the change.

## Why This Change Was Made

This preserves @SebTardif's timeout-preservation contribution and the subsequent narrower candidate for assessment. The candidate removes legacy reclassification rather than restoring a snapshot over a newer completion. Source and contributor ancestry remain unchanged while its need is reassessed.

## Evidence

- The in-process admission-gap fixture produced a baseline failure and 101 passing candidate tests, but supplied the deferred wait result. Actual Gateway/lifecycle experiments did not reproduce that composed late-terminal sequence: the first execution-settled restart event resolves the real pending wait and suppresses a second terminal publication. An observation-only wait timeout is not a terminal provider timeout. A combined restart/timeout event did not produce the required restart-abort marker.
- Independent baseline `8132c7cf75b34eb9db7be4d15a720340a5c226c9` and candidate `ccb8bda541717b84e2634a4194e20371ec0a27c9` Gateway builds passed stall, success, cancellation and restart controls. The stall became a watchdog terminal error, not a provider timeout; those plugin rows captured a zero run timeout. These controls are not baseline-fail/candidate-pass qualification.
- A separate real model-to-`sessions_spawn` control captured a five-second budget in the running row before timeout. Both refs reached terminal timeout, task `timed_out`, and session timeout. Physical Gateway replacement preserved the same run/generation, one child provider request and two actual recovery sweeps without redispatch. Heartbeat was disabled on every boot, using a local synthetic provider.
- The finite-budget control qualifies both versions, not the disputed admission gap. Its final baseline test/shard pass and raw outcomes are retained, but the original outer process exit receipt was lost and remains unknown. Both refs also retain a transcript writer-claim error despite final registry/task/session convergence. The internal watchdog may clamp to the run budget; the logs establish an embedded execution timeout, not independent external provider timeout behavior.
- Initial failed fixtures/checks remain recorded. The earlier controlled test's lint failure was repaired and the remaining planned checks passed individually; it is not represented as an initially green monolithic run.

**Disposition:** no supported baseline runtime failure currently justifies landing this candidate. Independent review and historical passing CI do not change that. The residual scheduling speculation is not a new mandatory gate or evidence of universal inertness. Keep the patch for a future actual-producer counterexample; no speculative eligibility widening or replacement persistence design is warranted.
