### PR TITLE
feat(clickclack): claim setup-code URLs in the channel wizard

### DIFF
--- a/docs/channels/clickclack.md
+++ b/docs/channels/clickclack.md
@@ -55,9 +55,19 @@ For guided setup, run:
 openclaw onboard
 ```
 
-Select ClickClack, then enter the server URL, bot token, and workspace when
-prompted. Guided setup checks the server, token, and workspace after saving; a
-failed check does not discard the configuration.
+or `openclaw channels add --channel clickclack`.
+
+Select ClickClack. The first prompt is the **setup URL** from ClickClack
+(**Workspace settings → Integrations → OpenClaw → Setup code**), for example
+`https://clickclack.example.com/#XXXX-XXXX-XXXX`. OpenClaw claims that
+one-time code, writes token / server URL / workspace, and skips the later
+credential prompts. Leave the setup URL **blank** to use the manual path
+instead: bot token (or env), server URL, then workspace.
+
+Guided setup checks the server, token, and workspace after saving; a failed
+check does not discard the configuration. Android and other `wizard.start`
+clients use this same flow — the Gateway claims the code; the client never
+stores the bot token.
 
 ### Alternative: manual token
 

--- a/extensions/clickclack/src/setup-core.ts
+++ b/extensions/clickclack/src/setup-core.ts
@@ -339,6 +339,24 @@ const clickClackSetupAdapter: ChannelSetupAdapter = {
   },
 };
 
+/** Wizard text steps skip prepareAccountConfigInput; claim the setup URL here instead. */
+export async function applyClickClackWizardSetupCode(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  code: string;
+}): Promise<OpenClawConfig> {
+  const prepared = await clickClackSetupAdapter.prepareAccountConfigInput!({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    input: { code: params.code },
+  } as Parameters<NonNullable<ChannelSetupAdapter["prepareAccountConfigInput"]>>[0]);
+  return clickClackSetupAdapter.applyAccountConfig({
+    cfg: params.cfg,
+    accountId: params.accountId,
+    input: prepared,
+  });
+}
+
 export const clickClackSetupContract = defineChannelSetupContract({
   fields: {
     code: {

--- a/extensions/clickclack/src/setup-surface.test.ts
+++ b/extensions/clickclack/src/setup-surface.test.ts
@@ -16,6 +16,7 @@ const mocks = vi.hoisted(() => ({
   me: vi.fn(),
   resolveWorkspaceId: vi.fn(),
   workspaces: vi.fn(),
+  claimClickClackSetupCode: vi.fn(),
 }));
 
 vi.mock("./http-client.js", () => ({
@@ -30,6 +31,10 @@ vi.mock("./http-client.js", () => ({
 
 vi.mock("./resolve.js", () => ({
   resolveWorkspaceId: mocks.resolveWorkspaceId,
+}));
+vi.mock("./setup-claim.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./setup-claim.js")>()),
+  claimClickClackSetupCode: mocks.claimClickClackSetupCode,
 }));
 
 import { clickClackSetupPlugin } from "./channel.setup.js";
@@ -60,6 +65,7 @@ describe("ClickClack setup wizard", () => {
     mocks.me.mockReset();
     mocks.resolveWorkspaceId.mockReset();
     mocks.workspaces.mockReset();
+    mocks.claimClickClackSetupCode.mockReset();
     mocks.me.mockResolvedValue({ id: "usr_bot", handle: "openclaw" });
     mocks.resolveWorkspaceId.mockResolvedValue("wsp_default");
     mocks.workspaces.mockResolvedValue([
@@ -162,6 +168,53 @@ describe("ClickClack setup wizard", () => {
     ).toBe(false);
   });
 
+  it("asks for a setup-code URL before token entry and allows skipping to manual token", () => {
+    expect(clickClackSetupWizard.stepOrder).toBe("text-first");
+    const codeInput = clickClackSetupWizard.textInputs?.[0];
+    expect(codeInput?.inputKey).toBe("code");
+    expect(codeInput?.sensitive).toBe(true);
+    expect(codeInput?.required).toBe(false);
+    expect(typeof codeInput?.applySet).toBe("function");
+    expect(
+      codeInput?.shouldPrompt?.({
+        cfg: {},
+        accountId: "default",
+        credentialValues: {},
+      }),
+    ).toBe(true);
+    expect(
+      codeInput?.shouldPrompt?.({
+        cfg: configuredAccount,
+        accountId: "default",
+        credentialValues: {},
+      }),
+    ).toBe(false);
+    expect(
+      codeInput?.validate?.({
+        value: "",
+        cfg: {},
+        accountId: "default",
+        credentialValues: {},
+      }),
+    ).toBeUndefined();
+    expect(
+      codeInput?.validate?.({
+        value: "ABCD-EFGH-IJKL",
+        cfg: {},
+        accountId: "default",
+        credentialValues: {},
+      }),
+    ).toEqual(expect.any(String));
+    expect(
+      codeInput?.validate?.({
+        value: "https://clickclack.example/#ABCD-EFGH-IJKL",
+        cfg: {},
+        accountId: "default",
+        credentialValues: {},
+      }),
+    ).toBeUndefined();
+  });
+
   it("switches the default account to env auth before URL and workspace prompts", async () => {
     const credential = tokenCredential();
     const next = await credential.applyUseEnv?.({
@@ -188,7 +241,7 @@ describe("ClickClack setup wizard", () => {
 
   it("saves URL, token, and workspace through the guided flow", async () => {
     const queued = createQueuedWizardPrompter({
-      textValues: ["ccb_guided", "https://clickclack.example/", "default"],
+      textValues: ["", "ccb_guided", "https://clickclack.example/", "default"],
     });
 
     const result = await runSetupWizardConfigure({
@@ -206,6 +259,47 @@ describe("ClickClack setup wizard", () => {
     });
     expect(mocks.me).toHaveBeenCalledTimes(1);
     expect(mocks.resolveWorkspaceId).toHaveBeenCalledTimes(1);
+  });
+
+  it("claims a setup-code URL and skips token, server URL, and workspace prompts", async () => {
+    mocks.claimClickClackSetupCode.mockResolvedValue({
+      token: "ccb_claimed",
+      bot: { id: "usr_bot", handle: "openclaw", display_name: "OpenClaw" },
+      workspace: {
+        id: "wsp_1",
+        route_id: "clickclack",
+        slug: "default",
+        name: "ClickClack",
+      },
+      defaults: {
+        defaultTo: "channel:general",
+        allowFrom: ["*"],
+        agentActivity: true,
+      },
+    });
+    const queued = createQueuedWizardPrompter({
+      textValues: ["https://clickclack.example/#abcd-efgh-jkmn"],
+    });
+
+    const result = await runSetupWizardConfigure({
+      configure: createPluginSetupWizardConfigure(clickClackSetupPlugin),
+      cfg: {} as CoreConfig,
+      prompter: queued.prompter,
+      options: { secretInputMode: "plaintext" as const },
+    });
+
+    expect(result.cfg.channels?.clickclack).toMatchObject({
+      enabled: true,
+      token: "ccb_claimed",
+      baseUrl: "https://clickclack.example",
+      workspace: "wsp_1",
+      defaultTo: "channel:general",
+    });
+    expect(mocks.claimClickClackSetupCode).toHaveBeenCalledWith({
+      claimUrl: "https://clickclack.example/api/bot-setup-codes/claim",
+      code: "ABCDEFGHJKMN",
+    });
+    expect(queued.text).toHaveBeenCalledTimes(1);
   });
 
   it("reports the resolved bot and workspace after live validation", async () => {

--- a/extensions/clickclack/src/setup-surface.ts
+++ b/extensions/clickclack/src/setup-surface.ts
@@ -14,6 +14,7 @@ import { listClickClackAccountIds, resolveClickClackAccount } from "./accounts.j
 import {
   applyClickClackCredentialConfig,
   applyClickClackSetupConfigPatch,
+  applyClickClackWizardSetupCode,
   normalizeClickClackBaseUrl,
 } from "./setup-core.js";
 import { checkClickClackSetupConnection } from "./setup-verify.js";
@@ -33,6 +34,18 @@ function isClickClackSetupConfigured(account: ResolvedClickClackAccount): boolea
     account.baseUrl &&
     account.workspace &&
     (account.token || hasConfiguredClickClackCredential(account)),
+  );
+}
+
+function shouldPromptUnconfiguredClickClack(params: {
+  cfg: CoreConfig | Record<string, unknown>;
+  accountId: string;
+}): boolean {
+  return !isClickClackSetupConfigured(
+    resolveClickClackAccount({
+      cfg: params.cfg as CoreConfig,
+      accountId: params.accountId,
+    }),
   );
 }
 
@@ -58,9 +71,10 @@ export const clickClackSetupWizard: ChannelSetupWizard = {
       ),
   }),
   introNote: {
-    title: t("wizard.clickclack.botTokenTitle"),
+    title: t("wizard.clickclack.setupCodeTitle"),
     lines: [
-      t("wizard.clickclack.helpCreateToken"),
+      t("wizard.clickclack.helpCreateSetupCode"),
+      t("wizard.clickclack.setupCodeLeaveBlank"),
       t("wizard.channels.docs", {
         link: formatDocsLink("/channels/clickclack", "clickclack"),
       }),
@@ -73,6 +87,7 @@ export const clickClackSetupWizard: ChannelSetupWizard = {
         }),
       ),
   },
+  stepOrder: "text-first",
   credentials: [
     defineTokenCredential({
       inputKey: "token",
@@ -85,6 +100,8 @@ export const clickClackSetupWizard: ChannelSetupWizard = {
       keepPrompt: t("wizard.clickclack.botTokenKeep"),
       inputPrompt: t("wizard.clickclack.botTokenInput"),
       allowEnv: ({ accountId }) => accountId === DEFAULT_ACCOUNT_ID,
+      shouldPrompt: ({ cfg, accountId }) =>
+        shouldPromptUnconfiguredClickClack({ cfg: cfg as CoreConfig, accountId }),
       resolveAccount: ({ cfg, accountId }) =>
         resolveClickClackAccount({ cfg: cfg as CoreConfig, accountId }),
       hasConfiguredValue: hasConfiguredClickClackCredential,
@@ -102,6 +119,39 @@ export const clickClackSetupWizard: ChannelSetupWizard = {
     }),
   ],
   textInputs: [
+    {
+      inputKey: "code",
+      message: t("wizard.clickclack.setupCodeInput"),
+      placeholder: t("wizard.clickclack.setupCodePlaceholder"),
+      sensitive: true,
+      required: false,
+      helpTitle: t("wizard.clickclack.setupCodeTitle"),
+      helpLines: [
+        t("wizard.clickclack.helpCreateSetupCode"),
+        t("wizard.clickclack.setupCodeLeaveBlank"),
+      ],
+      shouldPrompt: ({ cfg, accountId }) =>
+        shouldPromptUnconfiguredClickClack({ cfg: cfg as CoreConfig, accountId }),
+      validate: ({ value }) => {
+        if (!value.trim()) {
+          return undefined;
+        }
+        if (!/^https?:\/\//iu.test(value.trim()) || !value.includes("#")) {
+          return t("wizard.clickclack.setupCodeUrlRequired");
+        }
+        return undefined;
+      },
+      applySet: async ({ cfg, accountId, value }) => {
+        if (!value.trim()) {
+          return cfg;
+        }
+        return await applyClickClackWizardSetupCode({
+          cfg,
+          accountId,
+          code: value,
+        });
+      },
+    },
     baseUrlTextInput({
       inputKey: "baseUrl",
       configKey: "baseUrl",
@@ -110,6 +160,8 @@ export const clickClackSetupWizard: ChannelSetupWizard = {
         resolveClickClackAccount({ cfg: cfg as CoreConfig, accountId }),
       currentValue: (account) => account.baseUrl || undefined,
       includeInitialValue: true,
+      shouldPrompt: ({ cfg, accountId }) =>
+        shouldPromptUnconfiguredClickClack({ cfg: cfg as CoreConfig, accountId }),
       validate: (value) =>
         normalizeClickClackBaseUrl(value)
           ? undefined
@@ -131,6 +183,8 @@ export const clickClackSetupWizard: ChannelSetupWizard = {
         resolveClickClackAccount({ cfg: cfg as CoreConfig, accountId }).workspace || undefined,
       initialValue: ({ cfg, accountId }) =>
         resolveClickClackAccount({ cfg: cfg as CoreConfig, accountId }).workspace || undefined,
+      shouldPrompt: ({ cfg, accountId }) =>
+        shouldPromptUnconfiguredClickClack({ cfg: cfg as CoreConfig, accountId }),
       validate: ({ value }) => (value.trim() ? undefined : "Required"),
       normalizeValue: ({ value }) => value.trim(),
       applySet: async ({ cfg, accountId, value }) =>

--- a/src/wizard/i18n/locales/en.ts
+++ b/src/wizard/i18n/locales/en.ts
@@ -753,6 +753,14 @@ export const en = {
       envPrompt: "CLICKCLACK_BOT_TOKEN detected. Use env var?",
       helpCreateToken:
         "In ClickClack: Workspace settings → Integrations → OpenClaw → create bot → copy token",
+      helpCreateSetupCode:
+        "In ClickClack: Workspace settings → Integrations → OpenClaw → Setup code (recommended) → copy the setup URL",
+      setupCodeInput: "ClickClack setup URL",
+      setupCodePlaceholder: "https://clickclack.example/#XXXX-XXXX-XXXX",
+      setupCodeTitle: "ClickClack setup code",
+      setupCodeLeaveBlank: "Leave blank to enter a bot token, server URL, and workspace instead.",
+      setupCodeUrlRequired:
+        "Paste the full ClickClack setup URL (https://…/#CODE). Bare codes need a server URL.",
       invalidToken:
         "ClickClack rejected the bot token (401). Copy a current token and rerun setup.",
       validationWarningTitle: "ClickClack connection check",

--- a/src/wizard/i18n/locales/zh-CN.ts
+++ b/src/wizard/i18n/locales/zh-CN.ts
@@ -731,6 +731,13 @@ export const zh_CN = {
       envPrompt: "检测到 CLICKCLACK_BOT_TOKEN。使用环境变量？",
       helpCreateToken:
         "在 ClickClack 中：工作区设置 → Integrations → OpenClaw → 创建 bot → 复制 token",
+      helpCreateSetupCode:
+        "在 ClickClack 中：工作区设置 → Integrations → OpenClaw → Setup code（推荐）→ 复制设置 URL",
+      setupCodeInput: "ClickClack 设置 URL",
+      setupCodePlaceholder: "https://clickclack.example/#XXXX-XXXX-XXXX",
+      setupCodeTitle: "ClickClack 设置码",
+      setupCodeLeaveBlank: "留空则改为输入 bot token、服务器 URL 和工作区。",
+      setupCodeUrlRequired: "请粘贴完整的 ClickClack 设置 URL（https://…/#CODE）。单独的码需要服务器 URL。",
       invalidToken: "ClickClack 拒绝了 bot token（401）。复制当前 token 后重新运行设置。",
       validationWarningTitle: "ClickClack 连接检查",
       workspaceHelp: "可使用 wsp_… ID、工作区 slug 或显示名称。",

--- a/src/wizard/i18n/locales/zh-TW.ts
+++ b/src/wizard/i18n/locales/zh-TW.ts
@@ -732,6 +732,13 @@ export const zh_TW = {
       envPrompt: "偵測到 CLICKCLACK_BOT_TOKEN。使用環境變數？",
       helpCreateToken:
         "在 ClickClack 中：工作區設定 → Integrations → OpenClaw → 建立 bot → 複製 token",
+      helpCreateSetupCode:
+        "在 ClickClack 中：工作區設定 → Integrations → OpenClaw → Setup code（建議）→ 複製設定 URL",
+      setupCodeInput: "ClickClack 設定 URL",
+      setupCodePlaceholder: "https://clickclack.example/#XXXX-XXXX-XXXX",
+      setupCodeTitle: "ClickClack 設定碼",
+      setupCodeLeaveBlank: "留空則改為輸入 bot token、伺服器 URL 和工作區。",
+      setupCodeUrlRequired: "請貼上完整的 ClickClack 設定 URL（https://…/#CODE）。單獨的碼需要伺服器 URL。",
       invalidToken: "ClickClack 拒絕了 bot token（401）。複製目前 token 後重新執行設定。",
       validationWarningTitle: "ClickClack 連線檢查",
       workspaceHelp: "可使用 wsp_… ID、工作區 slug 或顯示名稱。",


### PR DESCRIPTION
Related: TaskZilla Android contract https://git.aiprocurement.club/TaskZilla/taskzilla-web/issues/41

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators (including Android Connect ClickClack) who paste a ClickClack **setup URL** into the generic channel wizard would still be prompted for bot token, server URL, and workspace, because wizard **text** steps never called `prepareAccountConfigInput`. The one-time setup code was never claimed. The CLI `--code` path already claims; guided `wizard.start` / `openclaw onboard` / `openclaw channels add --channel clickclack` did not.

The phone never stores the bot token. If the Gateway does not claim the URL, Connect ClickClack cannot finish bind.

## Why This Change Was Made

ClickClack's guided wizard now runs **text-first**. The first optional prompt is the setup URL. A non-empty URL is claimed through the existing setup owner (`applyClickClackWizardSetupCode` → `prepareAccountConfigInput` + `applyAccountConfig`). After a successful claim, token / URL / workspace `shouldPrompt` is false so those steps are skipped. Leaving the URL blank keeps the previous manual token path.

Non-goals: no new claim client, no Android-specific Gateway RPC, no TaskZilla product code in this repo. Android is a `wizard.start` client of this same flow (Forgejo issue above).

## User Impact

Operators who run guided ClickClack setup can paste `https://clickclack.example/#CODE` once. OpenClaw claims it, saves the account, and does not re-ask for token, server URL, or workspace. Blank entry still means manual token (or env), server URL, then workspace. Docs now match that order (`docs/channels/clickclack.md`).

No change for `openclaw channels add clickclack --code …` (already claimed). Existing configured accounts are not re-prompted.

## Evidence

**Unit (this head, mock claim — not a live ClickClack run):**

`extensions/clickclack/src/setup-surface.test.ts`

- asks for a setup-code URL before token entry and allows skipping to manual token
- claims a setup-code URL and skips token, server URL, and workspace prompts
- existing guided token path still works with a leading blank setup-URL answer

Those cases replace the network claim with a Vitest mock. They prove wizard ordering and skip logic, not a real `/api/bot-setup-codes/claim` round-trip.

**Docs:** guided setup in `docs/channels/clickclack.md` now documents setup-URL-first and blank → manual fallback (addresses ClawSweeper P3).

**Still needed before merge (honest):** redacted terminal from a real claim (`openclaw channels add --channel clickclack` paste URL) and a blank-fallback run. I do not have that live output on this laptop against a disposable ClickClack. @clawsweeper re-review after this docs + template update; real-service proof remains contributor-owned.
