### PR TITLE
feat(scripts): materialize the scripts/pr trust anchor for mismatched worktrees

### DIFF
--- a/scripts/pr
+++ b/scripts/pr
@@ -61,7 +61,20 @@ pr_wrapper_components=(
   scripts/watch-pr-ci.mts
   .github/workflows/pr-crabbox-gate-publisher.yml
 )
-if common_git_dir=$(git -C "$script_parent_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null); then
+# Anchor-exec handoff: this process was exec'd from wrapper bytes materialized
+# out of refs/remotes/origin/main by the selection logic below in a previous
+# wrapper. The env var conveys repository addressing only — code trust came
+# from the parent's per-blob verification of the materialized copy, the same
+# verify-then-exec contract as the canonical-checkout substitution. Skip
+# re-selection: the running bytes ARE the anchor, and the temp copy has no git
+# context of its own to select against.
+if [ -n "${OPENCLAW_PR_ANCHOR_REPO_ROOT:-}" ]; then
+  if ! git -C "$OPENCLAW_PR_ANCHOR_REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "OPENCLAW_PR_ANCHOR_REPO_ROOT is not a git work tree: $OPENCLAW_PR_ANCHOR_REPO_ROOT" >&2
+    exit 1
+  fi
+  canonical_repo_root="$OPENCLAW_PR_ANCHOR_REPO_ROOT"
+elif common_git_dir=$(git -C "$script_parent_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null); then
   canonical_repo_root="$(dirname "$common_git_dir")"
   canonical_self="$canonical_repo_root/scripts/$(basename "${BASH_SOURCE[0]}")"
   if [ "$script_self" != "$canonical_self" ] && [ -x "$canonical_self" ]; then
@@ -119,6 +132,53 @@ if common_git_dir=$(git -C "$script_parent_dir" rev-parse --path-format=absolute
           [ "$canonical_wrapper_clean" = "1" ]; then
           echo "scripts/pr wrapper in this worktree differs from origin/main; running the canonical checkout's wrapper (matches the origin/main trust anchor): $canonical_repo_root" >&2
           exec "$canonical_self" "$@"
+        fi
+        # Neither this worktree nor the canonical checkout matches the fetched
+        # origin/main anchor. Materialize the anchor wrapper bytes directly
+        # from refs/remotes/origin/main and exec that copy: trust flows from
+        # the fetched ref itself, so a queued PR stops paying a rebase + CI lap
+        # for unrelated wrapper drift on main. Requires the anchor entrypoint
+        # to understand the handoff; older anchors fall through to the refusal.
+        # Archive emits paths relative to its cwd, so run it (and the
+        # verification listing) from the worktree toplevel to keep component
+        # paths intact in the materialized tree.
+        anchor_git_root=$(git -C "$script_parent_dir" rev-parse --show-toplevel 2>/dev/null || true)
+        if [ -n "$anchor_wrapper_revision" ] && [ -n "$anchor_git_root" ] &&
+          anchor_exec_dir=$(mktemp -d "${TMPDIR:-/tmp}/openclaw-pr-anchor.XXXXXX" 2>/dev/null); then
+          anchor_extraction_valid=0
+          if git -C "$anchor_git_root" archive refs/remotes/origin/main -- \
+            "${pr_wrapper_components[@]}" 2>/dev/null |
+            tar -x -C "$anchor_exec_dir" 2>/dev/null; then
+            anchor_extraction_valid=1
+            anchor_verified_entries=0
+            # Verify every extracted file byte-matches its anchor blob so an
+            # archive/extract fault can never smuggle different code past the
+            # trust boundary. The temp dir is 0700 and exec'd immediately —
+            # the same TOCTOU class as the canonical-substitution exec above.
+            while IFS=$'\t' read -r anchor_meta anchor_path; do
+              anchor_blob="${anchor_meta##* }"
+              extracted_blob=$(git -C "$anchor_git_root" hash-object -- \
+                "$anchor_exec_dir/$anchor_path" 2>/dev/null || true)
+              if [ -z "$extracted_blob" ] || [ "$extracted_blob" != "$anchor_blob" ]; then
+                anchor_extraction_valid=0
+                break
+              fi
+              anchor_verified_entries=$((anchor_verified_entries + 1))
+            done < <(git -C "$anchor_git_root" ls-tree -r --full-tree refs/remotes/origin/main -- "${pr_wrapper_components[@]}")
+            # An empty listing means the anchor read failed; never exec unverified bytes.
+            if [ "$anchor_verified_entries" = "0" ]; then
+              anchor_extraction_valid=0
+            fi
+          fi
+          if [ "$anchor_extraction_valid" = "1" ] &&
+            grep -q "OPENCLAW_PR_ANCHOR_REPO_ROOT" "$anchor_exec_dir/scripts/pr" 2>/dev/null; then
+            # Not cleaned by trap: exec replaces this shell, and bash re-reads
+            # the script file during execution, so the copy must outlive the
+            # whole supervised run. OS tmp reaping owns the ~200 KiB dir.
+            echo "scripts/pr wrapper in this worktree differs from origin/main; running wrapper code materialized from the refs/remotes/origin/main trust anchor at revision $(git -C "$script_parent_dir" rev-parse --short refs/remotes/origin/main)." >&2
+            OPENCLAW_PR_ANCHOR_REPO_ROOT="$canonical_repo_root" exec "$anchor_exec_dir/scripts/pr" "$@"
+          fi
+          rm -rf "$anchor_exec_dir"
         fi
         # HEAD blobs are authoritative here: the uncommitted-wrapper guard above
         # already exited for any staged or unstaged edit to these paths, so

--- a/scripts/pr-lib/worktree.sh
+++ b/scripts/pr-lib/worktree.sh
@@ -7,6 +7,13 @@ repo_root() {
   # the same from main checkout or any linked worktree.
   local base_dir
   local common_git_dir
+  # Anchor-exec handoff (see scripts/pr): the wrapper runs from materialized
+  # temp-dir bytes with no git context of its own; the handoff env carries the
+  # repository the run addresses.
+  if [ -n "${OPENCLAW_PR_ANCHOR_REPO_ROOT:-}" ]; then
+    (cd "$OPENCLAW_PR_ANCHOR_REPO_ROOT" && pwd)
+    return
+  fi
   base_dir="${script_parent_dir:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 
   if common_git_dir=$(git -C "$base_dir" rev-parse --path-format=absolute --git-common-dir 2>/dev/null); then

--- a/src/agents/embedded-agent-helpers/provider-runtime-failure.test.ts
+++ b/src/agents/embedded-agent-helpers/provider-runtime-failure.test.ts
@@ -1,4 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+// Classification fixtures here exercise message/status tables. Provider-attributed
+// structured signals otherwise cross the plugin-consult gate and cold-materialize
+// the full bundled provider runtime, timing the unit test out under CI load
+// (src/agents/CLAUDE.md: no full-runtime cold loads for table coverage).
+vi.mock("../../plugins/provider-hook-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../plugins/provider-hook-runtime.js")>();
+  return {
+    ...actual,
+    resolveProviderHookPlugin: () => undefined,
+    resolveProviderPluginsForHooks: () => [],
+  };
+});
+
 import {
   classifyFailoverReason,
   isFailoverErrorMessage,

--- a/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
+++ b/src/agents/embedded-agent-runner/run/payloads.errors.test.ts
@@ -1,7 +1,20 @@
 // Error payload tests ensure embedded runs convert provider/tool failures into
 // concise user-facing replies without leaking raw provider bodies or secrets.
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+// Classification fixtures here exercise message/status tables. Provider-attributed
+// structured signals otherwise cross the plugin-consult gate and cold-materialize
+// the full bundled provider runtime, timing the unit test out under CI load
+// (src/agents/CLAUDE.md: no full-runtime cold loads for table coverage).
+vi.mock("../../../plugins/provider-hook-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../plugins/provider-hook-runtime.js")>();
+  return {
+    ...actual,
+    resolveProviderHookPlugin: () => undefined,
+    resolveProviderPluginsForHooks: () => [],
+  };
+});
+
 import { getReplyPayloadMetadata } from "../../../auto-reply/reply-payload.js";
 import { formatBillingErrorMessage } from "../../embedded-agent-helpers.js";
 import { makeAssistantMessageFixture } from "../../test-helpers/assistant-message-fixtures.js";

--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -2,8 +2,22 @@
  * Regression coverage for provider/model failover classification.
  * Exercises raw error coercion, remediation hints, timeout/auth/billing/rate-limit cases.
  */
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createAgentRunStaleLifecycleError } from "../infra/agent-lifecycle-error.js";
+
+// Classification here is message/status table behavior. Provider-attributed
+// structured signals (e.g. moonshot + 429) otherwise cross the plugin-consult
+// gate and cold-materialize the full bundled provider runtime, which times the
+// unit test out under CI load (src/agents/CLAUDE.md: no full-runtime cold
+// loads for table coverage). No bundled hook classifies these fixtures anyway.
+vi.mock("../plugins/provider-hook-runtime.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../plugins/provider-hook-runtime.js")>();
+  return {
+    ...actual,
+    resolveProviderHookPlugin: () => undefined,
+    resolveProviderPluginsForHooks: () => [],
+  };
+});
 import {
   buildFailoverRemediationHint,
   buildProviderReauthCommand,

--- a/src/agents/openrouter-error-classification.integration.test.ts
+++ b/src/agents/openrouter-error-classification.integration.test.ts
@@ -2,8 +2,18 @@ import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { AssistantMessage, Context, Model } from "@openclaw/ai";
 import { streamOpenAICompletions } from "@openclaw/ai/internal/openai";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
+import { resolveProviderHookPlugin } from "../plugins/provider-hook-runtime.js";
 import { classifyAssistantFailoverReason } from "./embedded-agent-helpers/assistant-message-failures.js";
+
+// This integration suite deliberately exercises the real bundled OpenRouter
+// failover hooks, and the first hook materialization compiles the plugin
+// sources in this worker (import-bound; src/agents/CLAUDE.md). Warm it once
+// under an explicit hook budget so the per-test 120s timeout measures
+// classification behavior, not cold compile under CI load.
+beforeAll(() => {
+  resolveProviderHookPlugin({ provider: "openrouter" });
+}, 300_000);
 import { formatAssistantErrorText } from "./embedded-agent-helpers/error-text.js";
 import { resolveFailoverStatus, resolveModelFallbackError } from "./failover-error.js";
 

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -456,6 +456,97 @@ describe("scripts/pr wrappers", () => {
     }
   });
 
+  // Parks the canonical checkout on a diverging branch so neither the linked
+  // worktree nor canonical matches the fetched origin/main anchor — the shape
+  // that previously refused and forced a rebase.
+  function parkCanonicalOffAnchor(fixture: ReturnType<typeof makeMismatchedWrapperRepo>) {
+    fixture.git(fixture.canonical, ["checkout", "-b", "parked"]);
+    writeFileSync(
+      join(fixture.canonical, "scripts", "pr-lib", "gates.sh"),
+      'ci_dispatch() { echo "parked canonical executed"; }\n',
+    );
+    fixture.git(fixture.canonical, ["add", "scripts/pr-lib/gates.sh"]);
+    fixture.git(fixture.canonical, ["commit", "-m", "test: parked canonical wrapper"]);
+  }
+
+  it("materializes the origin/main anchor wrapper when canonical is parked elsewhere", () => {
+    const fixture = makeMismatchedWrapperRepo();
+    try {
+      parkCanonicalOffAnchor(fixture);
+      const result = spawnSync(join(fixture.linked, "scripts", "pr"), ["ci-dispatch", "123"], {
+        cwd: fixture.linked,
+        encoding: "utf8",
+        env: fixture.env,
+      });
+      expect(result.status, `${result.stderr}\n${result.stdout}`).toBe(0);
+      // The anchor (pushed main) marker proves materialized anchor code ran,
+      // not the linked worktree's wrapper and not the parked canonical one.
+      expect(result.stdout).toContain("canonical wrapper executed");
+      expect(result.stdout).not.toContain("local wrapper executed");
+      expect(result.stdout).not.toContain("parked canonical executed");
+      expect(result.stderr).toContain(
+        "running wrapper code materialized from the refs/remotes/origin/main trust anchor",
+      );
+      expect(result.stderr).not.toContain("Refusing to silently substitute");
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("routes a mismatched landing subcommand through the materialized anchor", () => {
+    const fixture = makeMismatchedWrapperRepo();
+    try {
+      parkCanonicalOffAnchor(fixture);
+      const result = spawnSync(join(fixture.linked, "scripts", "pr"), ["prepare-run", "123"], {
+        cwd: fixture.linked,
+        encoding: "utf8",
+        env: fixture.env,
+      });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain(
+        "running wrapper code materialized from the refs/remotes/origin/main trust anchor",
+      );
+      // The stubbed gh reports a non-main base: reaching this gate proves the
+      // materialized anchor wrapper ran the landing subcommand.
+      expect(result.stderr).toContain(
+        "scripts/pr prepare and merge commands only support PRs targeting main; PR #123 targets not-main.",
+      );
+      expect(result.stderr).not.toContain("Refusing to silently substitute");
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  it("keeps the refusal when the anchor wrapper predates the handoff contract", () => {
+    const fixture = makeMismatchedWrapperRepo();
+    try {
+      // Rewrite origin/main's scripts/pr to an entrypoint without the
+      // OPENCLAW_PR_ANCHOR_REPO_ROOT handoff, as pre-fix anchors are.
+      fixture.git(fixture.canonical, ["checkout", "main"]);
+      const legacy = readScript(join(fixture.canonical, "scripts", "pr")).replaceAll(
+        "OPENCLAW_PR_ANCHOR_REPO_ROOT",
+        "OPENCLAW_PR_LEGACY_UNSUPPORTED",
+      );
+      writeFileSync(join(fixture.canonical, "scripts", "pr"), legacy);
+      fixture.git(fixture.canonical, ["add", "scripts/pr"]);
+      fixture.git(fixture.canonical, ["commit", "-m", "test: legacy anchor wrapper"]);
+      fixture.git(fixture.canonical, ["push", "origin", "main"]);
+      fixture.git(fixture.linked, ["fetch", "origin", "main"]);
+      parkCanonicalOffAnchor(fixture);
+      const result = spawnSync(join(fixture.linked, "scripts", "pr"), ["ci-dispatch", "123"], {
+        cwd: fixture.linked,
+        encoding: "utf8",
+        env: fixture.env,
+      });
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain("Refusing to silently substitute");
+      expect(result.stdout).not.toContain("canonical wrapper executed");
+      expect(result.stdout).not.toContain("local wrapper executed");
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   it("keeps merge wrapper modes delegated to the main PR helper", () => {
     const script = readScript("scripts/pr-merge");
 


### PR DESCRIPTION
## What Problem This Solves

`scripts/pr` landing subcommands refuse to run when the invoking worktree's wrapper components differ from `refs/remotes/origin/main` and the canonical checkout cannot substitute (parked on another branch, or dirty). On high-velocity days this turns every unrelated wrapper change on main into a forced rebase **plus a full exact-head CI lap** for every queued PR — green CI gets discarded because 12 lines moved in a file the PR never touches. Tonight's cleanup pass paid that tax three times; the operator called it out directly.

## Why This Change Was Made

The trust boundary only cares that the **executed wrapper bytes** come from the fetched origin/main anchor — not what base the invoking checkout sits on. So the mismatch branch now materializes the anchor directly instead of refusing:

1. Extract all `pr_wrapper_components` from `refs/remotes/origin/main` via `git archive` into a fresh 0700 temp dir (run from the worktree toplevel so component paths stay intact).
2. Verify **every extracted file byte-matches its anchor blob** (`ls-tree -r --full-tree` × `hash-object`), failing closed on an empty listing — an archive/extract fault can never smuggle different code past the boundary. Same verify-then-exec TOCTOU class as the existing canonical-substitution `exec`.
3. `exec` the materialized `scripts/pr` with `OPENCLAW_PR_ANCHOR_REPO_ROOT` carrying the repository the run addresses. The env var conveys **addressing only, never authority**: the child validates it is a git work tree and skips re-selection because its running bytes *are* the anchor. `repo_root()` in `pr-lib/worktree.sh` honors the same handoff (the temp copy has no git context of its own).
4. A materialized anchor that predates the handoff contract (no `OPENCLAW_PR_ANCHOR_REPO_ROOT` in its entrypoint) falls through to today's refusal — the feature self-gates until this lands, and old wrappers on existing branches simply keep refusing as they always did.

The announcement is loud (same convention as canonical substitution), `--dev-wrapper` semantics are unchanged, and the temp dir deliberately outlives the run (bash re-reads the script file during execution; `merge-run`/`gc` can delete linked worktrees mid-run — the existing comment at the selection block documents that hazard).

## User Impact

Maintainer/agent workflow only: queued PRs stop paying a rebase + CI lap for unrelated wrapper drift on main. The refusal remains for anything that cannot be verified against the anchor.

## Evidence

- Three new cases in `test/scripts/pr-wrappers.test.ts` using the existing bare-origin fixture: (a) mismatched worktree + canonical parked on a diverging branch → materialized anchor executes (anchor marker output, not local, not parked); (b) a landing subcommand (`prepare-run`) routes through the materialized anchor to the stubbed gh base-gate; (c) an anchor whose entrypoint lacks the handoff keeps the historical refusal. Full suite: 23/23 passing.
- `test/scripts/pr-operation-lock.test.ts` green (the `repo_root()` change is on its path).
- Live scratch-fixture proof during development caught two real bugs the tests now pin: `git archive` pathspec/cwd stripping (`scripts/pr` extracted as `pr`) and `repo_root()` resolving to `/tmp` inside the materialized child (lock acquisition against a non-repo).
- `node scripts/check-changed.mjs` fully green; Codex autoreview scoped-clean.

## Ride-along CI repair

PR CI exposed a pre-existing red gate reproducible on pristine `origin/main`: three agents unit-test files (`failover-error`, `provider-runtime-failure`, `payloads.errors`) time out at 120s whenever provider-attributed structured fixtures (e.g. moonshot + 429) cross the classifier's plugin-consult gate and cold-materialize the full bundled provider runtime — load-dependent, so it slips through some runs and kills others. Per repo policy (fix the red gate in the landing PR, never land past it), this PR adds a narrow `provider-hook-runtime` mock (`importOriginal` + two resolver overrides, every binding preserved) to those three files: table coverage is exactly what they protect, and no bundled hook classifies their fixtures. 131/131 tests pass locally in <1s of test time each; pre-fix the timeout reproduces deterministically under load.
