### PR TITLE
refactor(media): simplify image helper tests

### DIFF
--- a/src/media/image-ops.helpers.test.ts
+++ b/src/media/image-ops.helpers.test.ts
@@ -1,31 +1,20 @@
-// Image operation helper tests cover dimension and format utility behavior.
 import { describe, expect, it } from "vitest";
 import { buildImageResizeSideGrid, IMAGE_REDUCE_QUALITY_STEPS } from "./image-ops.js";
 
 describe("buildImageResizeSideGrid", () => {
-  function expectImageResizeSideGridCase(width: number, height: number, expected: number[]) {
-    expect(buildImageResizeSideGrid(width, height)).toEqual(expected);
-  }
-
   it.each([
-    { width: 1200, height: 900, expected: [1200, 1000, 900, 800] },
-    { width: 0, height: 0, expected: [] },
-  ] as const)("builds resize side grid for %ix%i", ({ width, height, expected }) => {
-    expectImageResizeSideGridCase(width, height, [...expected]);
-  });
+    { maxSide: 1200, sideStart: 900, expected: [1200, 1000, 900, 800] },
+    { maxSide: 0, sideStart: 0, expected: [] },
+  ] as const)(
+    "builds resize grid for maxSide=$maxSide and sideStart=$sideStart",
+    ({ maxSide, sideStart, expected }) => {
+      expect(buildImageResizeSideGrid(maxSide, sideStart)).toEqual(expected);
+    },
+  );
 });
 
 describe("IMAGE_REDUCE_QUALITY_STEPS", () => {
-  function expectQualityLadderCase(expectedQualityLadder: number[]) {
-    expect([...IMAGE_REDUCE_QUALITY_STEPS]).toEqual(expectedQualityLadder);
-  }
-
-  it.each([
-    {
-      name: "keeps expected quality ladder",
-      expectedQualityLadder: [85, 75, 65, 55, 45, 35],
-    },
-  ] as const)("$name", ({ expectedQualityLadder }) => {
-    expectQualityLadderCase([...expectedQualityLadder]);
+  it("keeps expected quality ladder", () => {
+    expect(IMAGE_REDUCE_QUALITY_STEPS).toEqual([85, 75, 65, 55, 45, 35]);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The image-helper tests wrap individual equality assertions in one-use helpers and put a single quality-ladder case through a table. The resize table also calls its inputs width and height even though the owner takes a maximum side and starting side.

## Why This Change Was Made

Use direct equality assertions, retain both resize inputs and the exact ordered quality ladder, and name table fields after the actual function parameters. Remove the generic header and unnecessary array copies. These helpers remain reachable through the media SDK and real image/screenshot consumers, so their behavior coverage stays.

## User Impact

Production and SDK exports are unchanged. All three test executions and asserted values remain; test LOC +10/-21 (net -11).

## Evidence

The focused helper suite passed all three cases before and after. Direct inspection of the owner, image/screenshot callers, SDK exports and installed Vitest equality/title formatting confirms the same assertions now use simpler plumbing. The full changed gate and Codex review passed. The original runner printed both resize cases as `NaNxNaN`; the revised names show each actual input pair.

Exact-head CI [33367283629](https://github.com/openclaw/openclaw/actions/runs/33367283629) passed. The latest completed ClawSweeper review has no actionable findings; its remaining normal-maintainer step is covered by this review and native landing. All ten inspected owner, caller, SDK and sibling-test files match captured main `0b84655e8ba6`, and the reviewed one-file patch is unchanged.
