### PR TITLE
docs: clarify Swarm progress across chat clients

### DIFF
--- a/docs/tools/swarm.md
+++ b/docs/tools/swarm.md
@@ -312,10 +312,20 @@ is rejected with the relevant config key in the error.
 
 Keep the parent session open in Chat while a swarm is active. The Control UI and
 native Android, iOS, and macOS chat surfaces show a compact Swarm progress widget
-between the transcript and composer, rendering each active collector group as one
-dot per child with queued, running, done, or failed state. Accessible labels identify
-each child and status; the Control UI also exposes them as dot tooltips. The widget
-disappears after every group child reaches a terminal state.
+between the transcript and composer.
+
+In the Control UI, each active collector group appears as a card with a completion
+count and phase progress segments. Hover over a card or focus it with the keyboard
+to reveal a list of child names, status icons, and run durations.
+
+Native Android, iOS, and macOS chat surfaces show phase-grouped grids of child
+status markers, capped at 256 markers per phase with an overflow count for additional
+children. Accessible labels identify each child and its queued, running, done, or
+failed status.
+
+All clients present killed and timed-out children as failed. Each group leaves the
+widget when none of its children are queued or running, and the widget disappears
+when no active groups remain.
 
 The session sidebar keeps the normal parent/child tree. Expand the parent row to
 inspect a collector child or open its transcript without losing the swarm hierarchy.


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where readers of [Observe a Swarm](https://docs.openclaw.ai/tools/swarm#observe-a-swarm) were told to expect child dots and tooltips in the Control UI, although it displays completion cards and phase progress segments. The shared description also obscured the native clients' marker limit and when individual groups disappear.

## Why This Change Was Made

Describe the existing clients separately: Control UI cards reveal child names, status icons, and run durations on hover or keyboard focus; Android, iOS, and macOS use phase-grouped status grids capped at 256 markers per phase, with overflow counts and accessible child name/status labels. Clarify that killed and timed-out children appear as failed, and each group leaves when it has no queued or running children.

This is a prose correction only. No UI or runtime behavior changes; sidebar, retention, Stop, and all other paragraphs are unchanged. Production LOC: +0/-0; test LOC: +0/-0; docs LOC: +14/-4 (net +10).

## User Impact

Readers can recognize the Swarm widget in their client, discover Control UI child details, and understand why completed groups leave the widget.

## Evidence

- Source checked against current main `1b223b37a0fc172a07a5a72e92309c7f4c92804a`: `ui/src/pages/chat/components/chat-swarm-progress.ts`, its hover/focus rules in `ui/src/styles/chat/layout.css`, Android `ChatSwarmProgressView.kt` and `chat/ChatSwarmProgress.kt`, and shared Swift `OpenClawChatUI/Swarm.swift` used by iOS/macOS. The Swarm renderer, focused test files, and relevant CSS rules are unchanged from the reviewed proof.
- `pnpm docs:list` — passed.
- `node scripts/check-docs-mdx.mjs docs/tools/swarm.md` — passed, one file.
- `git diff --check` — passed. Byte comparison against main confirms everything outside the progress-widget prose is unchanged; the complete PR diff contains only `docs/tools/swarm.md`.
- Prior reviewed focused proof: `node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-swarm-progress.test.ts ui/src/pages/chat/components/chat-swarm-progress.browser.test.ts` — 10 tests passed across two files, exit 0.
- Prior reviewed browser proof: existing `scripts/control-ui-mock-dev.ts --fixture swarm --port 5198` fixture in real headless Chromium showed the `mock-turn` card, `2 of 5`, one phase segment, and child list hidden initially and visible after hover and actual keyboard Tab. This is mocked Control UI rendering evidence, not a real Gateway run. Native apps were source-checked, not launched. No screenshot assets or agent transcripts are committed.
- Docs-only autoreview exemption applies. No production, test, configuration, schema, or dependency surface changes.
