### PR TITLE
fix(ui): preserve mocked browser proof across reruns

### DIFF
--- a/.agents/skills/control-ui-e2e/SKILL.md
+++ b/.agents/skills/control-ui-e2e/SKILL.md
@@ -41,7 +41,10 @@ When running mocked Control UI/dashboard validation for a user-facing feature, p
 - After or alongside the focused E2E test, run the mocked Control UI app when available, for example `pnpm dev:ui:mock -- --port <port>`.
 - Drive Chromium with Playwright against the local mock URL and capture a video plus screenshots for each meaningful state: initial view, interaction input, result state, and final/paginated/selected state.
 - Use `browser.newContext({ recordVideo: { dir, size }, viewport })`, `page.screenshot({ path })`, and close the context before reporting the video path.
-- Put artifacts under `.artifacts/control-ui-e2e/<short-feature-name>/` or another clearly named local temp directory, and report the absolute paths in the final answer.
+- Allocate retained proof with `createControlUiE2eArtifactDir(scope, parentDir?)` from `ui/src/test-helpers/control-ui-e2e-artifacts.ts`. Each call atomically creates a fresh directory and logs its actual path. An explicit parent wins, then the trimmed existing `OPENCLAW_UI_E2E_ARTIFACT_DIR`, then the repository's `.artifacts/control-ui-e2e` parent. Existing custom output controls select parents; do not add or rewrite env vars to enable capture.
+- Allocate during the test/scenario or `beforeEach`, once per attempt; standalone scripts allocate once per invocation. Pass the owner explicitly to shared capture helpers. Keep the original gates, feature/stage names, viewports, waits, and recording options. Use distinct filenames for distinct stages and keep screenshots, reports, and video together.
+- Retain successful and failed evidence. Report actual allocated paths, including relocated filename overrides. Manually delete only exact owned directories after review; never clear shared parents before a replay. Disposable build/media fixtures and owned temporary raw video may keep their cleanup. New synthetic captures do not recover overwritten evidence.
+- Timeout diagnostics use fresh children beneath their existing diagnostic parent. Mantis retains every capture attempt under an invocation-owned directory and refuses to overwrite reports. Real-Gateway suites, `chat-outbox-*`, and `chat-attachment-read-lifecycle` remain separate owners; coordinate before claiming replay-safe retention there.
 - Treat recording as validation, not only demo capture. If the recorder fails or shows surprising behavior, stop, fix the behavior, add or update a regression test, then rerecord.
 - If visual proof is blocked, state the exact blocker and still report the textual E2E evidence.
 
@@ -74,4 +77,4 @@ When recording an already-running mocked Control UI URL, use a temporary Playwri
 - Open the mock URL, interact through stable `data-*` selectors or user-facing role selectors, and wait on asserted states instead of relying on fixed sleeps.
 - Assert both visible UI state and mocked Gateway traffic for request-driven flows. For example, verify the expected count/row is visible and that `sessions.list` was called with the expected `search`, `offset`, and `limit`.
 - Use short sleeps only after assertions to make the captured video readable.
-- Store the generated video under `.artifacts/control-ui-e2e/<feature>/`; do not commit it.
+- Store the generated video in the invocation's fresh allocated directory; do not commit it or remove older captures.

--- a/.github/workflows/mantis-web-ui-chat-proof.yml
+++ b/.github/workflows/mantis-web-ui-chat-proof.yml
@@ -113,15 +113,27 @@ jobs:
     runs-on: blacksmith-8vcpu-ubuntu-2404
     timeout-minutes: 60
     outputs:
-      artifact_name: ${{ steps.run_mantis.outputs.artifact_name }}
-      output_dir: ${{ steps.run_mantis.outputs.output_dir }}
-      proof_status: ${{ steps.run_mantis.outputs.proof_status }}
+      artifact_name: ${{ steps.prepare_evidence.outputs.artifact_name }}
+      output_dir: ${{ steps.prepare_evidence.outputs.output_dir }}
+      proof_status: ${{ steps.build_evidence.outputs.proof_status }}
     steps:
       - name: Checkout harness ref
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 0
+
+      - name: Allocate invocation evidence directory
+        id: prepare_evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          output_parent="${GITHUB_WORKSPACE}/.artifacts/qa-e2e/mantis/web-ui-chat-proof"
+          mkdir -p "$output_parent"
+          root="$(mktemp -d "$output_parent/run.XXXXXX")"
+          echo "Retained Mantis invocation evidence: $root"
+          echo "artifact_name=mantis-web-ui-chat-proof-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
+          echo "output_dir=${root}" >> "$GITHUB_OUTPUT"
 
       - name: Prepare Git owner
         uses: openclaw/openclaw/.github/actions/git-owner@dd4528b6393e7d00063067a080ca7241b48ce475
@@ -140,71 +152,68 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          worktree_root=".artifacts/qa-e2e/mantis/web-ui-chat-proof-worktrees"
-          mkdir -p "$worktree_root"
-          python3 -I -S "$CI_GIT_OWNER" --checkout-git 0 worktree add --detach "$worktree_root/candidate" "$CANDIDATE_SHA"
-          pnpm --dir "$worktree_root/candidate" install --frozen-lockfile --prefer-offline
+          root="${{ steps.prepare_evidence.outputs.output_dir }}"
+          {
+            worktree_root=".artifacts/qa-e2e/mantis/web-ui-chat-proof-worktrees"
+            mkdir -p "$worktree_root"
+            python3 -I -S "$CI_GIT_OWNER" --checkout-git 0 worktree add --detach "$worktree_root/candidate" "$CANDIDATE_SHA"
+            pnpm --dir "$worktree_root/candidate" install --frozen-lockfile --prefer-offline
+          } 2>&1 | tee "$root/setup.log"
 
       - name: Run web UI chat proof
         id: run_mantis
-        env:
-          CANDIDATE_REF: ${{ needs.resolve_request.outputs.candidate_ref }}
-          CANDIDATE_SHA: ${{ needs.validate_candidate.outputs.candidate_revision }}
         shell: bash
         run: |
           set -euo pipefail
-
-          artifact_name="mantis-web-ui-chat-proof-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          root="${{ steps.prepare_evidence.outputs.output_dir }}"
           candidate_repo="$(pwd)/.artifacts/qa-e2e/mantis/web-ui-chat-proof-worktrees/candidate"
-          output_rel=".artifacts/qa-e2e/mantis/web-ui-chat-proof"
-          root="$candidate_repo/$output_rel"
-          mkdir -p "$root"
-          echo "artifact_name=${artifact_name}" >> "$GITHUB_OUTPUT"
-          echo "output_dir=${root}" >> "$GITHUB_OUTPUT"
+          {
+            install -D -m 0644 \
+              "${GITHUB_WORKSPACE}/ui/src/e2e/mantis-chat-proof.e2e.test.ts" \
+              "$candidate_repo/ui/src/e2e/mantis-chat-proof.e2e.test.ts"
+            install -D -m 0644 \
+              "${GITHUB_WORKSPACE}/ui/src/test-helpers/control-ui-e2e.ts" \
+              "$candidate_repo/ui/src/test-helpers/control-ui-e2e.ts"
+            install -D -m 0644 \
+              "${GITHUB_WORKSPACE}/ui/src/test-helpers/control-ui-e2e-artifacts.ts" \
+              "$candidate_repo/ui/src/test-helpers/control-ui-e2e-artifacts.ts"
 
-          install -D -m 0644 \
-            "${GITHUB_WORKSPACE}/ui/src/e2e/mantis-chat-proof.e2e.test.ts" \
-            "$candidate_repo/ui/src/e2e/mantis-chat-proof.e2e.test.ts"
-          install -D -m 0644 \
-            "${GITHUB_WORKSPACE}/ui/src/test-helpers/control-ui-e2e.ts" \
-            "$candidate_repo/ui/src/test-helpers/control-ui-e2e.ts"
+            cd "$candidate_repo"
+            node --import tsx scripts/ensure-playwright-chromium.mts
+            OPENCLAW_MANTIS_WEB_UI_CHAT_OUTPUT_DIR="$root" \
+              OPENCLAW_UI_E2E_ARTIFACT_DIR="$root" \
+              node scripts/run-vitest.mjs run \
+                --config test/vitest/vitest.ui-e2e.config.ts \
+                --configLoader runner \
+                ui/src/e2e/mantis-chat-proof.e2e.test.ts
+          } 2>&1 | tee "$root/vitest.log"
 
-          cd "$candidate_repo"
-          node --import tsx scripts/ensure-playwright-chromium.mts
-
-          set +e
-          OPENCLAW_MANTIS_WEB_UI_CHAT_OUTPUT_DIR="$root" \
-            node scripts/run-vitest.mjs run \
-              --config test/vitest/vitest.ui-e2e.config.ts \
-              --configLoader runner \
-              ui/src/e2e/mantis-chat-proof.e2e.test.ts \
-            2>&1 | tee "$root/vitest.log"
-          vitest_exit="${PIPESTATUS[0]}"
-          set -e
-
-          proof_status="pass"
-          if [[ "$vitest_exit" -ne 0 ]]; then
-            proof_status="fail"
-          fi
-          echo "proof_status=${proof_status}" >> "$GITHUB_OUTPUT"
-
+      - name: Build invocation evidence report
+        id: build_evidence
+        if: ${{ always() && steps.prepare_evidence.outputs.output_dir != '' }}
+        env:
+          CANDIDATE_REF: ${{ needs.resolve_request.outputs.candidate_ref }}
+          CANDIDATE_SHA: ${{ needs.validate_candidate.outputs.candidate_revision }}
+          PROOF_STATUS: ${{ steps.run_mantis.outcome == 'success' && 'pass' || 'fail' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.prepare_evidence.outputs.output_dir }}"
+          echo "proof_status=${PROOF_STATUS}" >> "$GITHUB_OUTPUT"
           node "${GITHUB_WORKSPACE}/scripts/mantis/build-web-ui-chat-evidence.mjs" \
             --output-dir "$root" \
             --candidate-ref "$CANDIDATE_REF" \
             --candidate-sha "$CANDIDATE_SHA" \
-            --status "$proof_status"
+            --status "$PROOF_STATUS"
 
           cat "$root/mantis-report.md" >> "$GITHUB_STEP_SUMMARY"
-          if [[ "$vitest_exit" -ne 0 ]]; then
-            exit "$vitest_exit"
-          fi
 
       - name: Upload Mantis web UI chat artifacts
-        if: ${{ always() && steps.run_mantis.outputs.output_dir != '' }}
+        if: ${{ always() && steps.prepare_evidence.outputs.output_dir != '' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: ${{ steps.run_mantis.outputs.artifact_name }}
-          path: ${{ steps.run_mantis.outputs.output_dir }}
+          name: ${{ steps.prepare_evidence.outputs.artifact_name }}
+          path: ${{ steps.prepare_evidence.outputs.output_dir }}
           retention-days: 14
           if-no-files-found: error
 

--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -330,6 +330,40 @@ not sweep old directories or infer ownership from names, ages, or PIDs.
 - Base Vitest config defaults to `pool: "threads"` and `isolate: false`, with the shared non-isolated runner enabled across repo configs.
 - `pnpm test:channels` runs `vitest.channels.config.ts`.
 
+### Retained mocked Control UI proof
+
+Ordinary mocked browser screenshots, recordings, and reports use fresh directories
+for each test attempt or standalone capture invocation. The Node-only
+`createControlUiE2eArtifactDir(scope, parentDir?)` helper in
+`ui/src/test-helpers/control-ui-e2e-artifacts.ts` prints the actual allocated path.
+An explicit parent wins; otherwise it uses the trimmed existing
+`OPENCLAW_UI_E2E_ARTIFACT_DIR`, then the repository's `.artifacts/control-ui-e2e`
+parent. Existing feature-specific directory controls and script output arguments
+select parents, with unique children beneath them. Explicit screenshot filename
+controls preserve the basename and print the relocated path.
+
+Keep capture gates independent from allocation: `OPENCLAW_CAPTURE_UI_PROOF`,
+`OPENCLAW_UI_E2E_RECORD`, and output-presence gates retain their existing meanings.
+Allocate during scenario execution or `beforeEach`, and pass the same owner to
+shared capture helpers so screenshots, reports, and video stay together. Distinguish
+stage names within an attempt. Close the browser context before finalizing video.
+
+Successful and failed evidence is retained. Cleanup is manual: remove only exact
+directories that you own and have finished reviewing. Never recursively delete
+the shared parent before a replay. Disposable build/media fixtures and temporary
+raw video have their own cleanup. New captures cannot recover overwritten evidence;
+do not describe a replay as recovery of lost files.
+
+Timeout diagnostics allocate fresh children beneath the existing
+`OPENCLAW_UI_E2E_DIAGNOSTIC_DIR` or default timeout directory, keeping each PNG and
+JSON report together. Mantis allocates an invocation directory for setup logs,
+capture attempts, and its report; the builder preserves each attempt's relative
+paths and refuses to overwrite an existing report.
+
+Separate output owners remain: real-Gateway suites, `chat-outbox-*`, and
+`chat-attachment-read-lifecycle`. Do not assume those owners have the ordinary
+mocked proof retention guarantee.
+
 ## Gateway and E2E
 
 - Gateway tests are included in the untargeted `pnpm test` full suite; run them alone with `pnpm test:gateway`.

--- a/scripts/capture-composer-mic-hover-proof.mts
+++ b/scripts/capture-composer-mic-hover-proof.mts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
-// Captures composer mic-hover proof shots: idle vs hovered talk control, plus
-// the mic button's x position in both states (the hover-shift regression).
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium } from "playwright";
+// Captures composer mic-hover proof shots: idle vs hovered talk control, plus
+// the mic button's x position in both states (the hover-shift regression).
+import { createControlUiE2eArtifactDir } from "../ui/src/test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -21,7 +21,8 @@ function readOption(name: string): string | undefined {
   return index >= 0 ? process.argv[index + 1] : undefined;
 }
 
-const outputDir = path.resolve(
+const outputDir = createControlUiE2eArtifactDir(
+  "composer-mic-hover-proof",
   readOption("output-dir") ?? ".artifacts/control-ui-e2e/composer-mic-hover-proof",
 );
 const label = readOption("label") ?? "after";
@@ -30,7 +31,6 @@ if (!canRunPlaywrightChromium(executablePath)) {
   throw new Error(`Playwright Chromium is unavailable at ${executablePath}`);
 }
 
-await mkdir(outputDir, { recursive: true });
 const server = await startControlUiE2eServer(undefined, { source: true });
 const browser = await chromium.launch({ executablePath });
 const context = await browser.newContext({

--- a/scripts/capture-injected-turn-notice-proof.mts
+++ b/scripts/capture-injected-turn-notice-proof.mts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
+import path from "node:path";
+import { chromium } from "playwright";
 // Captures webchat proof that a CLI harness-injected user turn renders as a
 // collapsed system notice while the operator's own message keeps its bubble.
 // Usage: node --import tsx scripts/capture-injected-turn-notice-proof.mts [--mode after|before]
-import { mkdir } from "node:fs/promises";
-import path from "node:path";
-import { chromium } from "playwright";
+import { createControlUiE2eArtifactDir } from "../ui/src/test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -26,7 +26,8 @@ const mode = readOption("mode") ?? "after";
 if (mode !== "after" && mode !== "before") {
   throw new Error(`Expected --mode after|before, received ${mode}`);
 }
-const outputDir = path.resolve(
+const outputDir = createControlUiE2eArtifactDir(
+  "injected-turn-notice-proof",
   readOption("output-dir") ?? ".artifacts/control-ui-e2e/injected-turn-notice-proof",
 );
 
@@ -78,7 +79,6 @@ if (!canRunPlaywrightChromium(executablePath)) {
   throw new Error(`Playwright Chromium is unavailable at ${executablePath}`);
 }
 
-await mkdir(outputDir, { recursive: true });
 const server = await startControlUiE2eServer(undefined, { source: true });
 const browser = await chromium.launch({ executablePath });
 try {

--- a/scripts/capture-model-picker-proof.mts
+++ b/scripts/capture-model-picker-proof.mts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
+import path from "node:path";
+import { chromium } from "playwright";
 // Captures chat model-picker proof shots: the open picker inheriting the agent
 // default, the same picker with a session override, and the picker after a
 // failed catalog refresh. Also reports the x offset between the provider
 // heading label and the model row name (the row-alignment change).
-import { mkdir } from "node:fs/promises";
-import path from "node:path";
-import { chromium } from "playwright";
+import { createControlUiE2eArtifactDir } from "../ui/src/test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -23,7 +23,8 @@ function readOption(name: string): string | undefined {
   return index >= 0 ? process.argv[index + 1] : undefined;
 }
 
-const outputDir = path.resolve(
+const outputDir = createControlUiE2eArtifactDir(
+  "model-picker-proof",
   readOption("output-dir") ?? ".artifacts/control-ui-e2e/model-picker-proof",
 );
 const label = readOption("label") ?? "after";
@@ -46,7 +47,6 @@ const models = [
   { id: "claude-opus-4-6", name: "Claude Opus 4.6", provider: "anthropic", contextWindow: 200_000 },
 ];
 
-await mkdir(outputDir, { recursive: true });
 const server = await startControlUiE2eServer(undefined, { source: true });
 const browser = await chromium.launch({ executablePath });
 const context = await browser.newContext({

--- a/scripts/capture-session-toolbar-proof.mts
+++ b/scripts/capture-session-toolbar-proof.mts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Page } from "playwright";
+import { createControlUiE2eArtifactDir } from "../ui/src/test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -112,7 +112,8 @@ const ungroupedSessions = [
 ];
 
 const mode = readMode();
-const outputDir = path.resolve(
+const outputDir = createControlUiE2eArtifactDir(
+  "session-toolbar-proof",
   readOption("output-dir") ?? ".artifacts/control-ui-e2e/session-toolbar-proof",
 );
 const executablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
@@ -120,7 +121,6 @@ if (!canRunPlaywrightChromium(executablePath)) {
   throw new Error(`Playwright Chromium is unavailable at ${executablePath}`);
 }
 
-await mkdir(outputDir, { recursive: true });
 const server = await startControlUiE2eServer(undefined, { source: true });
 const browser = await chromium.launch({ executablePath });
 const captured: string[] = [];

--- a/scripts/capture-where-chip-auto-proof.mts
+++ b/scripts/capture-where-chip-auto-proof.mts
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 // Captures placement, inventory, and context-meter proof in both themes.
 import assert from "node:assert/strict";
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium } from "playwright";
+import { createControlUiE2eArtifactDir } from "../ui/src/test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -12,9 +12,11 @@ import {
 } from "../ui/src/test-helpers/control-ui-e2e.ts";
 
 const captureLabel = process.argv[2] ?? "after";
-const outputDir = path.resolve(process.argv[3] ?? "/tmp/node-slot-pips-proof");
+const outputDir = createControlUiE2eArtifactDir(
+  "node-slot-pips-proof",
+  process.argv[3] ?? "/tmp/node-slot-pips-proof",
+);
 const remoteExec = process.argv[4] === "remote-exec";
-await mkdir(outputDir, { recursive: true });
 const executablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
 if (!canRunPlaywrightChromium(executablePath)) {
   throw new Error(`Playwright Chromium unavailable at ${executablePath}`);

--- a/scripts/capture-workboard-ui-proof.mts
+++ b/scripts/capture-workboard-ui-proof.mts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium } from "playwright";
+import { createControlUiE2eArtifactDir } from "../ui/src/test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   resolvePlaywrightChromiumExecutablePath,
@@ -22,13 +22,15 @@ function readOption(name: string): string | undefined {
 }
 
 const baseUrl = new URL(readOption("base-url") ?? DEFAULT_BASE_URL);
-const outputDir = path.resolve(readOption("output-dir") ?? DEFAULT_OUTPUT_DIR);
+const outputDir = createControlUiE2eArtifactDir(
+  "workboard-proof",
+  readOption("output-dir") ?? DEFAULT_OUTPUT_DIR,
+);
 const executablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
 if (!canRunPlaywrightChromium(executablePath)) {
   throw new Error(`Playwright Chromium is unavailable at ${executablePath}`);
 }
 
-await mkdir(outputDir, { recursive: true });
 const browser = await chromium.launch({ executablePath });
 const context = await browser.newContext({
   colorScheme: "light",

--- a/scripts/mantis/build-web-ui-chat-evidence.mjs
+++ b/scripts/mantis/build-web-ui-chat-evidence.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Builds a Mantis evidence manifest from Control UI web chat proof artifacts.
-import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -35,26 +35,27 @@ function normalizeStatus(value) {
   throw new Error(`Unsupported web UI chat proof status: ${value}`);
 }
 
-function artifactEntry({ inline = false, kind, label, path: artifactPath, required, targetPath }) {
+function artifactEntry({ inline = false, kind, label, path: artifactPath, required }) {
   return {
     kind,
     lane: "candidate",
     label,
     path: artifactPath,
-    targetPath,
+    targetPath: artifactPath,
     required,
     ...(inline ? { alt: label, inline: true, width: 900 } : {}),
   };
 }
 
-export function buildWebUiChatEvidenceManifest({ candidateRef, candidateSha, status }) {
+function buildWebUiChatEvidenceManifest({ candidateRef, candidateSha, status, captures }) {
   const passed = status === "pass";
   return {
     schemaVersion: 2,
     id: "web-ui-chat-proof",
     title: "Mantis Web UI Chat Proof",
-    summary:
-      "Mantis ran the OpenClaw Control UI chat proof against the candidate ref, sent a message through the mocked Gateway, rendered the final reply in the browser, and captured browser artifacts for review.",
+    summary: passed
+      ? "Mantis ran the OpenClaw Control UI chat proof against the candidate ref, sent a message through the mocked Gateway, rendered the final reply in the browser, and captured browser artifacts for review."
+      : "Mantis could not complete the Control UI chat proof. Retained attempt artifacts and logs describe the failure.",
     scenario: "web-ui-chat-proof",
     comparison: {
       candidate: {
@@ -69,34 +70,38 @@ export function buildWebUiChatEvidenceManifest({ candidateRef, candidateSha, sta
       pass: passed,
     },
     artifacts: [
-      artifactEntry({
-        inline: true,
-        kind: "desktopScreenshot",
-        label: "Control UI web chat proof",
-        path: "web-ui-chat.png",
-        required: passed,
-        targetPath: "web-ui-chat.png",
-      }),
-      artifactEntry({
-        kind: "fullVideo",
-        label: "Control UI web chat recording",
-        path: "web-ui-chat.webm",
-        required: false,
-        targetPath: "web-ui-chat.webm",
-      }),
-      artifactEntry({
-        kind: "metadata",
-        label: "Control UI web chat proof metadata",
-        path: "web-ui-chat-proof.json",
-        required: passed,
-        targetPath: "web-ui-chat-proof.json",
-      }),
+      ...captures.flatMap(({ directory, complete }) => [
+        artifactEntry({
+          inline: true,
+          kind: "desktopScreenshot",
+          label: `Control UI web chat proof (${directory})`,
+          path: `${directory}/web-ui-chat.png`,
+          required: passed && complete,
+        }),
+        artifactEntry({
+          kind: "fullVideo",
+          label: `Control UI web chat recording (${directory})`,
+          path: `${directory}/web-ui-chat.webm`,
+          required: false,
+        }),
+        artifactEntry({
+          kind: "metadata",
+          label: `Control UI web chat proof metadata (${directory})`,
+          path: `${directory}/web-ui-chat-proof.json`,
+          required: passed && complete,
+        }),
+      ]),
       artifactEntry({
         kind: "metadata",
         label: "Control UI web chat Vitest log",
         path: "vitest.log",
         required: false,
-        targetPath: "vitest.log",
+      }),
+      artifactEntry({
+        kind: "metadata",
+        label: "Control UI web chat setup log",
+        path: "setup.log",
+        required: false,
       }),
       {
         kind: "report",
@@ -109,7 +114,7 @@ export function buildWebUiChatEvidenceManifest({ candidateRef, candidateSha, sta
   };
 }
 
-function renderReport({ candidateRef, candidateSha, outputDir, status }) {
+function renderReport({ candidateRef, candidateSha, outputDir, status, artifacts }) {
   const artifactStatus = (artifactPath) =>
     existsSync(path.join(outputDir, artifactPath)) ? "present" : "missing";
   return [
@@ -121,14 +126,16 @@ function renderReport({ candidateRef, candidateSha, outputDir, status }) {
     "",
     "## Scenario",
     "",
-    "OpenClaw Control UI chat was loaded in a browser with the mocked Gateway harness. The proof sends a chat message through the GUI, verifies the `chat.send` request, emits a final Gateway reply, and waits for the reply to render in the web chat thread.",
+    "The scenario loads OpenClaw Control UI chat in a browser with the mocked Gateway harness, sends a chat message through the GUI, verifies the `chat.send` request, emits a final Gateway reply, and waits for the reply to render in the web chat thread.",
     "",
     "## Artifacts",
     "",
-    `- Screenshot: \`web-ui-chat.png\` (${artifactStatus("web-ui-chat.png")})`,
-    `- Recording: \`web-ui-chat.webm\` (${artifactStatus("web-ui-chat.webm")})`,
-    `- Proof metadata: \`web-ui-chat-proof.json\` (${artifactStatus("web-ui-chat-proof.json")})`,
-    `- Vitest log: \`vitest.log\` (${artifactStatus("vitest.log")})`,
+    ...artifacts
+      .filter((artifact) => artifact.kind !== "report")
+      .map(
+        (artifact) =>
+          `- ${artifact.label}: \`${artifact.path}\` (${artifactStatus(artifact.path)})`,
+      ),
     "",
   ].join("\n");
 }
@@ -143,13 +150,35 @@ export function writeWebUiChatEvidence(rawArgs = process.argv.slice(2)) {
   }
   const outputDir = path.resolve(args.output_dir);
   mkdirSync(outputDir, { recursive: true });
+  const reportPath = path.join(outputDir, "mantis-report.md");
+  const manifestPath = path.join(outputDir, "mantis-evidence.json");
+  if (existsSync(reportPath) || existsSync(manifestPath)) {
+    throw new Error("Evidence already exists in --output-dir; use a fresh invocation directory.");
+  }
   const status = normalizeStatus(args.status);
+  // The workflow owns this fresh invocation root. Keep every attempt, including
+  // incomplete retries; never pick a newest capture from a shared history root.
+  const captures = readdirSync(outputDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory() && entry.name.startsWith("mantis-chat-proof-"))
+    .map((entry) => entry.name)
+    .toSorted()
+    .map((directory) => ({
+      directory,
+      complete: ["web-ui-chat.png", "web-ui-chat-proof.json"].every((file) =>
+        existsSync(path.join(outputDir, directory, file)),
+      ),
+    }));
+  if (status === "pass" && !captures.some((capture) => capture.complete)) {
+    throw new Error(
+      "Passing proof requires a captured screenshot and proof metadata in --output-dir.",
+    );
+  }
   const manifest = buildWebUiChatEvidenceManifest({
     candidateRef: args.candidate_ref,
     candidateSha: args.candidate_sha,
     status,
+    captures,
   });
-  const reportPath = path.join(outputDir, "mantis-report.md");
   writeFileSync(
     reportPath,
     renderReport({
@@ -157,11 +186,14 @@ export function writeWebUiChatEvidence(rawArgs = process.argv.slice(2)) {
       candidateSha: args.candidate_sha,
       outputDir,
       status,
+      artifacts: manifest.artifacts,
     }),
-    "utf8",
+    { encoding: "utf8", flag: "wx" },
   );
-  const manifestPath = path.join(outputDir, "mantis-evidence.json");
-  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, "utf8");
+  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+  });
   return { manifest, manifestPath, reportPath };
 }
 

--- a/test/scripts/ci-git-owner.test-support.ts
+++ b/test/scripts/ci-git-owner.test-support.ts
@@ -115,6 +115,7 @@ export async function runCiGitStep(options: {
   policy?: string;
   inlinePolicy?: boolean;
   step?: string;
+  stepOutputs?: Record<string, Record<string, string>>;
   env?: Record<string, string>;
   fetchResults: FetchResult[];
   cloneResults?: FetchResult[];
@@ -409,6 +410,11 @@ def main():`,
         }),
       );
       let run = renderGitTestClock(step.run, clock);
+      for (const [stepId, outputs] of Object.entries(options.stepOutputs ?? {})) {
+        for (const [name, value] of Object.entries(outputs)) {
+          run = run.replaceAll(`\${{ steps.${stepId}.outputs.${name} }}`, value);
+        }
+      }
       if (externalOwner) {
         const prepare = parse(readFileSync(".github/actions/git-owner/action.yml", "utf8")) as {
           runs: { steps: { run?: string }[] };

--- a/test/scripts/ci-linux-git.test.ts
+++ b/test/scripts/ci-linux-git.test.ts
@@ -934,6 +934,12 @@ posixIt.each([
       },
       fetchResults: [],
       worktreeResults: failure ? ["cleanup-failure"] : lanes.map(() => 0),
+      // The runner hands off the earlier allocation's output; keep setup logs
+      // inside this fixture's fresh invocation directory.
+      stepOutputs:
+        workflow === "web-ui-chat-proof"
+          ? { prepare_evidence: { output_dir: "${RUNNER_TEMP}" } }
+          : undefined,
       realClock: true,
       realDrain: false,
       poisonPython: true,

--- a/test/scripts/mantis-web-ui-chat-evidence.test.ts
+++ b/test/scripts/mantis-web-ui-chat-evidence.test.ts
@@ -1,12 +1,13 @@
-// Mantis web UI chat evidence tests cover manifest generation.
+// Mantis web UI chat evidence tests cover retained capture-to-publisher identity.
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { writeWebUiChatEvidence } from "../../scripts/mantis/build-web-ui-chat-evidence.mjs";
 import {
-  buildWebUiChatEvidenceManifest,
-  writeWebUiChatEvidence,
-} from "../../scripts/mantis/build-web-ui-chat-evidence.mjs";
+  loadEvidenceManifest,
+  renderEvidenceComment,
+} from "../../scripts/mantis/publish-pr-evidence.mjs";
 
 function withTempDir<T>(fn: (dir: string) => T): T {
   const dir = mkdtempSync(path.join(tmpdir(), "openclaw-mantis-web-ui-chat-"));
@@ -17,89 +18,149 @@ function withTempDir<T>(fn: (dir: string) => T): T {
   }
 }
 
+function captureAttempt(parent: string, marker: string, complete = true): string {
+  const directory = mkdtempSync(path.join(parent, "mantis-chat-proof-"));
+  writeFileSync(path.join(directory, "web-ui-chat.png"), `${marker} screenshot`);
+  writeFileSync(path.join(directory, "web-ui-chat.webm"), `${marker} video`);
+  if (complete) {
+    const metadata = JSON.stringify({ status: "pass" });
+    writeFileSync(path.join(directory, "web-ui-chat-proof.json"), metadata);
+  }
+  return directory;
+}
+
 describe("build-web-ui-chat-evidence", () => {
-  it("marks a passing Control UI chat proof as publishable visible Mantis evidence", () => {
-    const manifest = buildWebUiChatEvidenceManifest({
-      candidateRef: "HEAD",
-      candidateSha: "1234567890abcdef1234567890abcdef12345678",
-      status: "pass",
-    });
-
-    expect(manifest).toMatchObject({
-      id: "web-ui-chat-proof",
-      scenario: "web-ui-chat-proof",
-      schemaVersion: 2,
-      comparison: {
-        candidate: {
-          expectationMet: true,
-          fixed: true,
-          ref: "HEAD",
-          sha: "1234567890abcdef1234567890abcdef12345678",
-          status: "pass",
-        },
-        pass: true,
-      },
-    });
-    expect(manifest.artifacts).toContainEqual(
-      expect.objectContaining({
-        inline: true,
-        kind: "desktopScreenshot",
-        path: "web-ui-chat.png",
-        required: true,
-      }),
-    );
-  });
-
-  it("writes a failing manifest without requiring a missing screenshot", () => {
+  it("publishes every attempt at its exact retained path without mixing invocation roots", () => {
     withTempDir((dir) => {
+      const priorRoot = mkdtempSync(path.join(dir, "run-"));
+      const priorCapture = captureAttempt(priorRoot, "prior");
+      const prior = writeWebUiChatEvidence(["--output-dir", priorRoot, "--status", "pass"]);
+      const priorReport = readFileSync(prior.reportPath, "utf8");
+      const priorManifest = readFileSync(prior.manifestPath, "utf8");
+
+      const root = mkdtempSync(path.join(dir, "run-"));
+      const incomplete = captureAttempt(root, "incomplete", false);
+      const complete = captureAttempt(root, "complete");
+      writeFileSync(path.join(root, "vitest.log"), "current invocation log");
       const result = writeWebUiChatEvidence([
         "--output-dir",
-        dir,
+        root,
+        "--candidate-ref",
+        "main",
         "--candidate-sha",
-        "abcdef",
+        "1234567890abcdef1234567890abcdef12345678",
         "--status",
-        "fail",
+        "pass",
       ]);
-
-      expect(existsSync(result.manifestPath)).toBe(true);
-      expect(existsSync(result.reportPath)).toBe(true);
-      const manifest = JSON.parse(readFileSync(result.manifestPath, "utf8"));
-      expect(manifest.comparison.pass).toBe(false);
-      expect(manifest.comparison.candidate.expectationMet).toBe(false);
-      expect(
-        manifest.artifacts.find(
-          (artifact: { path: string }) => artifact.path === "web-ui-chat.png",
-        ),
-      ).toMatchObject({
-        required: false,
+      const manifest = loadEvidenceManifest(result.manifestPath);
+      expect(manifest).toMatchObject({
+        id: "web-ui-chat-proof",
+        scenario: "web-ui-chat-proof",
+        schemaVersion: 2,
+        comparison: {
+          candidate: { expectationMet: true, fixed: true, ref: "main", status: "pass" },
+          pass: true,
+        },
       });
+      const screenshots = manifest.artifacts.filter(
+        (artifact) => artifact.kind === "desktopScreenshot",
+      );
+      expect(screenshots.map((artifact) => artifact.source).sort()).toEqual(
+        [incomplete, complete].map((directory) => path.join(directory, "web-ui-chat.png")).sort(),
+      );
+      const comment = renderEvidenceComment({
+        manifest,
+        marker: "<!-- synthetic-mantis-proof -->",
+        rawBase: "https://artifacts.example.test/current",
+      });
+      for (const [directory, marker] of [
+        [incomplete, "incomplete"],
+        [complete, "complete"],
+      ] as const) {
+        const relative = path.basename(directory);
+        for (const [file, content] of [
+          ["web-ui-chat.png", "screenshot"],
+          ["web-ui-chat.webm", "video"],
+        ]) {
+          const artifact = manifest.artifacts.find((entry) => entry.path === `${relative}/${file}`);
+          expect(artifact?.targetPath).toBe(`${relative}/${file}`);
+          expect(readFileSync(artifact!.source, "utf8")).toBe(`${marker} ${content}`);
+          expect(comment).toContain(`https://artifacts.example.test/current/${relative}/${file}`);
+          expect(readFileSync(result.reportPath, "utf8")).toContain(`${relative}/${file}`);
+        }
+      }
+      expect(readFileSync(prior.reportPath, "utf8")).toBe(priorReport);
+      expect(readFileSync(prior.manifestPath, "utf8")).toBe(priorManifest);
+      expect(readFileSync(path.join(priorCapture, "web-ui-chat.png"), "utf8")).toBe(
+        "prior screenshot",
+      );
+      expect(readFileSync(result.reportPath, "utf8")).not.toContain(path.basename(priorCapture));
+    });
+  });
+
+  it("retains setup failures before a capture exists as publishable failure evidence", () => {
+    withTempDir((dir) => {
+      writeFileSync(path.join(dir, "setup.log"), "candidate installation failed");
+      const result = writeWebUiChatEvidence(["--output-dir", dir, "--status", "fail"]);
+      const manifest = loadEvidenceManifest(result.manifestPath);
+      expect(manifest.comparison).toMatchObject({
+        candidate: { expectationMet: false, status: "fail" },
+        pass: false,
+      });
+      expect(manifest.artifacts.map((artifact) => artifact.targetPath)).toEqual([
+        "setup.log",
+        "mantis-report.md",
+        "mantis-evidence.json",
+      ]);
+      expect(manifest.summary).toContain("could not complete");
+      expect(readFileSync(result.reportPath, "utf8")).toContain("`setup.log` (present)");
+    });
+  });
+
+  it("keeps a failed process verdict even when an attempt completed its captures", () => {
+    withTempDir((dir) => {
+      captureAttempt(dir, "completed before process failure");
+      const result = writeWebUiChatEvidence(["--output-dir", dir, "--status", "fail"]);
+      expect(loadEvidenceManifest(result.manifestPath).comparison.pass).toBe(false);
       expect(readFileSync(result.reportPath, "utf8")).toContain("Status: fail");
     });
   });
 
-  it("uses the explicit pass status and includes report output", () => {
-    withTempDir((dir) => {
-      writeFileSync(path.join(dir, "web-ui-chat.png"), "png");
-      writeFileSync(
-        path.join(dir, "web-ui-chat-proof.json"),
-        `${JSON.stringify({ status: "pass" })}\n`,
-      );
-
-      const result = writeWebUiChatEvidence([
-        "--output-dir",
-        dir,
-        "--candidate-ref",
-        "main",
-        "--status",
-        "pass",
-      ]);
-
-      expect(result.manifest.comparison).toMatchObject({
-        candidate: { fixed: true, ref: "main", status: "pass" },
-        pass: true,
+  it.each(["absent", "old flat files", "split attempts"])(
+    "rejects a passing verdict with %s instead of using unrelated proof",
+    (kind) => {
+      withTempDir((dir) => {
+        const metadata = JSON.stringify({ status: "pass" });
+        if (kind === "old flat files") {
+          writeFileSync(path.join(dir, "web-ui-chat.png"), "old screenshot");
+          writeFileSync(path.join(dir, "web-ui-chat-proof.json"), metadata);
+        } else if (kind === "split attempts") {
+          captureAttempt(dir, "screenshot only", false);
+          const metadataOnly = mkdtempSync(path.join(dir, "mantis-chat-proof-"));
+          writeFileSync(path.join(metadataOnly, "web-ui-chat-proof.json"), metadata);
+        }
+        expect(() => writeWebUiChatEvidence(["--output-dir", dir, "--status", "pass"])).toThrow(
+          "Passing proof requires a captured screenshot and proof metadata",
+        );
+        expect(existsSync(path.join(dir, "mantis-evidence.json"))).toBe(false);
       });
-      expect(readFileSync(result.reportPath, "utf8")).toContain(
-        "Screenshot: `web-ui-chat.png` (present)",
+    },
+  );
+
+  it("refuses to rewrite reports when the builder is replayed against the same invocation", () => {
+    withTempDir((dir) => {
+      captureAttempt(dir, "original");
+      const original = writeWebUiChatEvidence(["--output-dir", dir, "--status", "pass"]);
+      const report = readFileSync(original.reportPath, "utf8");
+      const manifest = readFileSync(original.manifestPath, "utf8");
+      const retry = captureAttempt(dir, "retained retry", false);
+      expect(() => writeWebUiChatEvidence(["--output-dir", dir, "--status", "fail"])).toThrow(
+        "use a fresh invocation directory",
+      );
+      expect(readFileSync(original.reportPath, "utf8")).toBe(report);
+      expect(readFileSync(original.manifestPath, "utf8")).toBe(manifest);
+      expect(readFileSync(path.join(retry, "web-ui-chat.png"), "utf8")).toBe(
+        "retained retry screenshot",
       );
     });
   });

--- a/test/scripts/mantis-web-ui-chat-proof-workflow.test.ts
+++ b/test/scripts/mantis-web-ui-chat-proof-workflow.test.ts
@@ -7,6 +7,9 @@ const WORKFLOW = ".github/workflows/mantis-web-ui-chat-proof.yml";
 const SHARED_RESOLVE_WORKFLOW = ".github/workflows/mantis-resolve-request.yml";
 
 type WorkflowStep = {
+  id?: string;
+  if?: string;
+  env?: Record<string, string>;
   name?: string;
   run?: string;
   uses?: string;
@@ -14,6 +17,7 @@ type WorkflowStep = {
 };
 
 type WorkflowJob = {
+  outputs?: Record<string, string>;
   permissions?: Record<string, string>;
   steps?: WorkflowStep[];
 };
@@ -89,6 +93,37 @@ describe("Mantis Web UI chat proof workflow", () => {
     expect(job.steps?.some((step) => step.name === "Setup Node environment")).toBe(false);
     expect(publish?.run).toContain("node scripts/mantis/publish-pr-evidence.mjs");
     expect(publish?.run).not.toContain("--import tsx");
+  });
+
+  it("retains one invocation root through capture, failure reporting, and artifact upload", () => {
+    const job = workflowJob("run_web_ui_chat");
+    const allocate = job.steps?.find((step) => step.id === "prepare_evidence");
+    const capture = job.steps?.find((step) => step.id === "run_mantis");
+    const report = job.steps?.find((step) => step.id === "build_evidence");
+    const upload = job.steps?.find((step) => step.name === "Upload Mantis web UI chat artifacts");
+    const rootOutput = "${{ steps.prepare_evidence.outputs.output_dir }}";
+
+    expect(allocate?.run).toContain('mktemp -d "$output_parent/run.XXXXXX"');
+    expect(capture?.run).toContain(`root="${rootOutput}"`);
+    expect(capture?.run).toContain('OPENCLAW_MANTIS_WEB_UI_CHAT_OUTPUT_DIR="$root"');
+    expect(capture?.run).toContain('OPENCLAW_UI_E2E_ARTIFACT_DIR="$root"');
+    // Older candidates need the allocator imported by both overlaid harness files.
+    expect(capture?.run).toContain(
+      '"${GITHUB_WORKSPACE}/ui/src/test-helpers/control-ui-e2e-artifacts.ts"',
+    );
+    expect(capture?.run).toContain(
+      '"$candidate_repo/ui/src/test-helpers/control-ui-e2e-artifacts.ts"',
+    );
+    expect(report?.if).toContain("always()");
+    expect(report?.run).toContain(`root="${rootOutput}"`);
+    expect(report?.run).toContain('--output-dir "$root"');
+    expect(report?.env?.PROOF_STATUS).toBe(
+      "${{ steps.run_mantis.outcome == 'success' && 'pass' || 'fail' }}",
+    );
+    expect(upload?.if).toContain("always()");
+    expect(upload?.with?.path).toBe(rootOutput);
+    expect(job.outputs?.output_dir).toBe(rootOutput);
+    expect(upload?.with?.name).toBe(job.outputs?.artifact_name);
   });
 
   it("only treats explicit candidate assignments as PR head overrides", () => {

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -6457,10 +6457,16 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
 
     for (const [workflowPath, jobName, count] of cases) {
       const job = workflowJob(workflowPath, jobName);
+      const initialSteps = [
+        "Checkout harness ref",
+        ...(jobName === "run_web_ui_chat" ? ["Allocate invocation evidence directory"] : []),
+        "Prepare Git owner",
+        "Setup Node environment",
+      ];
       expect(
-        job.steps?.slice(0, 3).map(({ name }) => name),
+        job.steps?.slice(0, initialSteps.length).map(({ name }) => name),
         workflowPath,
-      ).toEqual(["Checkout harness ref", "Prepare Git owner", "Setup Node environment"]);
+      ).toEqual(initialSteps);
       expect(job.steps?.filter(({ name }) => name === "Prepare Git owner")).toEqual([
         {
           name: "Prepare Git owner",

--- a/ui/src/e2e/activity-answer-candidates.e2e.test.ts
+++ b/ui/src/e2e/activity-answer-candidates.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI E2E tests cover Codex final-answer candidate Activity rendering.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -14,18 +14,17 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "codex-answer-candidates",
-);
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("codex-answer-candidates");
+  }
+});
 
 async function screenshot(page: Page, name: string) {
   if (!captureUiProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,
@@ -35,9 +34,6 @@ async function screenshot(page: Page, name: string) {
 
 suite.define(() => {
   it("shows superseded and authoritative selected answers only in Activity", async () => {
-    if (captureUiProof) {
-      await mkdir(proofDir, { recursive: true });
-    }
     await suite.withPage(
       {
         locale: "en-US",

--- a/ui/src/e2e/activity-run-inspector.e2e.test.ts
+++ b/ui/src/e2e/activity-run-inspector.e2e.test.ts
@@ -1,8 +1,9 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import type { AuditRunInspectResult } from "../../../packages/gateway-protocol/src/schema/audit-run.js";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -21,7 +22,12 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.resolve(".artifacts/control-ui-e2e/activity-run-inspector-r6");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("activity-run-inspector-r6");
+  }
+});
 
 let browser: Browser;
 let server: ControlUiE2eServer;
@@ -91,7 +97,6 @@ async function screenshot(page: Page, name: string) {
   if (!captureUiProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,

--- a/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
+++ b/ui/src/e2e/activity-session-feed.capture.e2e.test.ts
@@ -1,6 +1,6 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiBundledGatewayUrl,
   controlUiSessionUrl,
@@ -15,7 +15,10 @@ const suite = createControlUiE2eSuite({
   startServerBeforeBrowser: true,
 });
 
-const outputDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/session-activity-feed");
+let outputDir: string;
+beforeEach(() => {
+  outputDir = createControlUiE2eArtifactDir("session-activity-feed");
+});
 const proofPhase = process.env.OPENCLAW_MENU_THEME_PROOF_PHASE;
 
 suite.define(() => {
@@ -295,7 +298,6 @@ suite.define(() => {
         const onlineToggle = page.getByRole("button", { name: "Online", exact: true });
         await expect.poll(() => onlineToggle.getAttribute("aria-expanded")).toBe("true");
         await expect.poll(() => page.locator(".sidebar-online__person").count()).toBe(4);
-        await mkdir(outputDir, { recursive: true });
         await page.locator(".sidebar").screenshot({
           animations: "disabled",
           path: path.join(outputDir, "01-sidebar-online-default-open-light.png"),

--- a/ui/src/e2e/activity-summaries.e2e.test.ts
+++ b/ui/src/e2e/activity-summaries.e2e.test.ts
@@ -1,6 +1,7 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -11,7 +12,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.resolve(".artifacts/control-ui-e2e/control-ui-activity-summaries");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("control-ui-activity-summaries");
+  }
+});
 
 suite.define(() => {
   it("updates one visible tool summary from running to completed output", async () => {

--- a/ui/src/e2e/agent-channel-runtime-status.e2e.test.ts
+++ b/ui/src/e2e/agent-channel-runtime-status.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI E2E tests cover Agents channel runtime-status precedence.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -14,13 +14,17 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "channel-runtime-status");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("channel-runtime-status");
+  }
+});
 
 async function screenshot(page: Page) {
   if (!captureUiProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,

--- a/ui/src/e2e/agent-config-save.e2e.test.ts
+++ b/ui/src/e2e/agent-config-save.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI E2E proves per-agent config writes use the canonical keyed shape.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -13,7 +13,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "agent-config-save");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("agent-config-save");
+  }
+});
 
 const requireRecord = createRequireRecord("record", "expected-object-value");
 
@@ -52,7 +57,6 @@ suite.define(() => {
         const reload = agentsPage.getByRole("button", { name: "Reload Config" });
         await reload.waitFor();
         if (captureUiProof) {
-          await mkdir(proofDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
@@ -194,7 +198,6 @@ suite.define(() => {
         await page.getByRole("alert").filter({ hasText: "mock validation failure" }).waitFor();
 
         if (captureUiProof) {
-          await mkdir(proofDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,

--- a/ui/src/e2e/agent-github-device-authorization.e2e.test.ts
+++ b/ui/src/e2e/agent-github-device-authorization.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI E2E proves the complete Agents -> Tools GitHub authorization presentation.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -13,18 +13,17 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "agent-github-device-authorization",
-);
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("agent-github-device-authorization");
+  }
+});
 
 async function capture(page: Page, name: string) {
   if (!captureUiProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,

--- a/ui/src/e2e/agent-model-fallback-ownership.e2e.test.ts
+++ b/ui/src/e2e/agent-model-fallback-ownership.e2e.test.ts
@@ -1,7 +1,7 @@
 // Real browser proof that agent model fallbacks follow the Gateway's ownership contract.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -15,7 +15,12 @@ const primaryModel = "openai/gpt-5.4";
 const inheritedFallback = "anthropic/claude-sonnet-4-6";
 const writerWorkspace = "/tmp/agents/writer";
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.resolve(".artifacts/control-ui-e2e/agent-context-ownership");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("agent-context-ownership");
+  }
+});
 
 suite.define(() => {
   it.each([
@@ -120,7 +125,6 @@ suite.define(() => {
           .toBe("/settings/agents/writer/overview");
 
         if (captureUiProof && model && !("primary" in Object(model))) {
-          await mkdir(proofDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,

--- a/ui/src/e2e/agent-page-scope.e2e.test.ts
+++ b/ui/src/e2e/agent-page-scope.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI E2E tests cover chip-selected page scope and the all-agents escape.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway, type MockGatewayControls } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -14,7 +14,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "agent-page-scope");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("agent-page-scope");
+  }
+});
 
 function requestParams(request: { params?: unknown }): Record<string, unknown> {
   return request.params && typeof request.params === "object"
@@ -38,7 +43,6 @@ async function screenshot(page: Page, name: string) {
   if (!captureUiProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,
@@ -205,9 +209,6 @@ suite.define(() => {
   });
 
   it("keeps a refreshed canonical roster while chat startup remains delayed", async () => {
-    if (captureUiProof) {
-      await mkdir(proofDir, { recursive: true });
-    }
     await suite.withPage(
       {
         locale: "en-US",

--- a/ui/src/e2e/agent-select-avatar-timeout.e2e.test.ts
+++ b/ui/src/e2e/agent-select-avatar-timeout.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI tests cover bounded authenticated agent-picker avatar fetches.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -14,18 +14,17 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "agent-select-avatar-timeout",
-);
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("agent-select-avatar-timeout");
+  }
+});
 
 async function screenshot(page: Page, name: string) {
   if (!captureUiProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,

--- a/ui/src/e2e/agent-selection-persistence.e2e.test.ts
+++ b/ui/src/e2e/agent-selection-persistence.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiBundledGatewayUrl,
   controlUiBundledSettingsStorageKey,
@@ -20,12 +20,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "agent-selection-persistence",
-);
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("agent-selection-persistence");
+  }
+});
 
 const agentsList = {
   agents: [
@@ -78,7 +78,6 @@ async function screenshot(page: Page, name: string) {
   if (!captureUiProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.waitForTimeout(600);
   await page.screenshot({
     animations: "disabled",
@@ -139,9 +138,6 @@ async function openPage(
 
 suite.define(() => {
   it("restores the selected agent when a fresh shell reopens the canonical global session", async () => {
-    if (captureUiProof) {
-      await mkdir(proofDir, { recursive: true });
-    }
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",

--- a/ui/src/e2e/app-chrome-interaction.e2e.test.ts
+++ b/ui/src/e2e/app-chrome-interaction.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI tests cover the canonical scrollbar profile and native-style text selection.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   installMockGateway,
   waitForControlUiSettingsTakeover,
@@ -17,12 +17,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "app-chrome-interaction",
-);
+let uiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    uiProofArtifactDir = createControlUiE2eArtifactDir("app-chrome-interaction");
+  }
+});
 
 async function dragAcross(page: Page, locator: Locator): Promise<string> {
   await locator.scrollIntoViewIfNeeded();
@@ -52,7 +52,6 @@ async function captureUiProof(page: Page, fileName: string) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(uiProofArtifactDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     path: path.join(uiProofArtifactDir, fileName),
@@ -61,9 +60,6 @@ async function captureUiProof(page: Page, fileName: string) {
 
 suite.define(() => {
   it("keeps canonical scrollbars without horizontal model-picker overflow and preserves selection", async () => {
-    if (captureUiProofEnabled) {
-      await mkdir(uiProofArtifactDir, { recursive: true });
-    }
     await suite.withPage(
       {
         locale: "en-US",
@@ -258,9 +254,6 @@ suite.define(() => {
   });
 
   it("resolves the scrollbar thumb from theme tokens and captures dark/light proof", async () => {
-    if (captureUiProofEnabled) {
-      await mkdir(uiProofArtifactDir, { recursive: true });
-    }
     const thumbColorByScheme: Record<"dark" | "light", string> = { dark: "", light: "" };
     for (const colorScheme of ["dark", "light"] as const) {
       await suite.withPage(

--- a/ui/src/e2e/appearance-settings-defaults.e2e.test.ts
+++ b/ui/src/e2e/appearance-settings-defaults.e2e.test.ts
@@ -1,9 +1,9 @@
 // Control UI tests cover Appearance override provenance and restoring product defaults.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import { importCustomThemeFromUrl } from "../pages/config/custom-theme-import.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiBundledGatewayUrl,
   controlUiBundledSettingsStorageKey,
@@ -24,12 +24,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "appearance-settings-defaults",
-);
+let uiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    uiProofArtifactDir = createControlUiE2eArtifactDir("appearance-settings-defaults");
+  }
+});
 function settingsStorageKey(): string {
   return controlUiBundledSettingsStorageKey(suite.server.baseUrl);
 }
@@ -169,7 +169,6 @@ async function captureViewport(page: Page, filename: string): Promise<void> {
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(uiProofArtifactDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     path: path.join(uiProofArtifactDir, filename),

--- a/ui/src/e2e/approval-flow.e2e.test.ts
+++ b/ui/src/e2e/approval-flow.e2e.test.ts
@@ -1,9 +1,9 @@
 // Control UI E2E tests cover approval queue behavior through the Gateway WebSocket.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import type { Page } from "playwright";
-import { afterEach, expect, it } from "vitest";
+import { afterEach, beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -15,7 +15,12 @@ const suite = createControlUiE2eSuite({
 let page: Page | undefined;
 const activeSessionKey = "agent:main:main";
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "approval-flow");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("approval-flow");
+  }
+});
 
 function approval(id: string, command: string, createdAtMs: number, sessionKey = activeSessionKey) {
   return {
@@ -95,9 +100,6 @@ suite.define(() => {
   });
 
   it("keeps approvals passive until the Inbox opens the full queue", async () => {
-    if (captureUiProof) {
-      await mkdir(proofDir, { recursive: true });
-    }
     const context = await suite.browser.newContext({
       viewport: { height: 800, width: 1200 },
       ...(captureUiProof
@@ -144,9 +146,6 @@ suite.define(() => {
   });
 
   it("keeps no-auth inline and Inbox approvals readable while blocking decisions", async () => {
-    if (captureUiProof) {
-      await mkdir(proofDir, { recursive: true });
-    }
     const context = await suite.browser.newContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;

--- a/ui/src/e2e/approval-page.e2e.test.ts
+++ b/ui/src/e2e/approval-page.e2e.test.ts
@@ -1,11 +1,12 @@
-import { copyFile, mkdir, rm } from "node:fs/promises";
+import { copyFile, rm } from "node:fs/promises";
 import path from "node:path";
 import type { Browser, BrowserContext, Page, Video } from "playwright";
-import { afterEach, expect, it } from "vitest";
+import { afterEach, beforeEach, expect, it } from "vitest";
 import type {
   AllowedApprovalSnapshot,
   PendingApprovalSnapshot,
 } from "../../../packages/gateway-protocol/src/index.js";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiE2eWaitTimeoutMs,
   installMockGateway,
@@ -21,9 +22,8 @@ const suite = createControlUiE2eSuite({
 
 const APPROVAL_ID = "Approval:Mobile/東京 100% 🦞";
 const APPROVAL_NOW_MS = Date.UTC(2026, 6, 10, 18, 0, 0);
-const ARTIFACT_DIR = path.resolve(".artifacts/control-ui-e2e/approval-page");
+let ARTIFACT_DIR: string;
 const CAPTURE_UI_PROOF = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const MOBILE_RAW_VIDEO_DIR = path.join(ARTIFACT_DIR, "mobile-raw");
 const MOBILE_VIEWPORT = { height: 844, width: 390 } as const;
 const DESKTOP_VIEWPORT = { height: 800, width: 1200 } as const;
 
@@ -36,7 +36,6 @@ type ApprovalSurface = {
 };
 
 const openContexts = new Set<BrowserContext>();
-const rawVideoDirs = new Set<string>();
 
 function approvalPath(basePath: string): string {
   return `${basePath}/approve/${encodeURIComponent(APPROVAL_ID)}`;
@@ -116,13 +115,10 @@ async function createSurface(params: {
   recordVideo?: boolean;
   viewport: { height: number; width: number };
 }): Promise<ApprovalSurface> {
-  const rawVideoDir = params.recordVideo && CAPTURE_UI_PROOF ? MOBILE_RAW_VIDEO_DIR : undefined;
-  if (rawVideoDir) {
-    await mkdir(ARTIFACT_DIR, { recursive: true });
-    await rm(rawVideoDir, { force: true, recursive: true });
-    await mkdir(rawVideoDir, { recursive: true });
-    rawVideoDirs.add(rawVideoDir);
-  }
+  const rawVideoDir =
+    params.recordVideo && CAPTURE_UI_PROOF
+      ? createControlUiE2eArtifactDir("mobile-raw", ARTIFACT_DIR)
+      : undefined;
   const context = await requireBrowser().newContext({
     colorScheme: "dark",
     hasTouch: params.viewport.width <= MOBILE_VIEWPORT.width,
@@ -158,7 +154,7 @@ async function closeRecordedSurface(surface: ApprovalSurface, targetName: string
   }
   const rawVideoPath = await video.path();
   await copyFile(rawVideoPath, path.join(ARTIFACT_DIR, targetName));
-  rawVideoDirs.delete(surface.rawVideoDir);
+  // Remove raw footage only after the retained named copy succeeds.
   await rm(surface.rawVideoDir, { force: true, recursive: true });
 }
 
@@ -209,7 +205,6 @@ async function captureProof(page: Page, name: string): Promise<void> {
   if (!CAPTURE_UI_PROOF) {
     return;
   }
-  await mkdir(ARTIFACT_DIR, { recursive: true });
   await waitForStableApprovalPaint(page);
   await page.screenshot({ path: path.join(ARTIFACT_DIR, name) });
 }
@@ -218,7 +213,6 @@ async function captureDocumentProof(page: Page, name: string): Promise<void> {
   if (!CAPTURE_UI_PROOF) {
     return;
   }
-  await mkdir(ARTIFACT_DIR, { recursive: true });
   await page.evaluate(async () => {
     await document.fonts.ready;
     await new Promise<void>((resolve) => {
@@ -287,13 +281,14 @@ async function expectMobilePendingLayout(page: Page): Promise<void> {
 }
 
 suite.define(() => {
+  beforeEach(() => {
+    if (CAPTURE_UI_PROOF) {
+      ARTIFACT_DIR = createControlUiE2eArtifactDir("approval-page");
+    }
+  });
   afterEach(async () => {
     await Promise.all([...openContexts].map((context) => context.close().catch(() => {})));
     openContexts.clear();
-    await Promise.all(
-      [...rawVideoDirs].map((rawVideoDir) => rm(rawVideoDir, { force: true, recursive: true })),
-    );
-    rawVideoDirs.clear();
   });
 
   it("keeps one canonical winner across conflicting surfaces and terminal reload", async () => {

--- a/ui/src/e2e/avatar-initial-emoji.e2e.test.ts
+++ b/ui/src/e2e/avatar-initial-emoji.e2e.test.ts
@@ -1,9 +1,9 @@
 // Control UI E2E: grapheme-aware avatar initials remain intact across every
 // live agent-avatar fallback surface.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -15,7 +15,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "avatar-initial-emoji");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("avatar-initial-emoji");
+  }
+});
 
 const emojiAgent = { id: "emoji", identity: { name: "🚀Rocket" }, name: "🚀Rocket" };
 const asciiAgent = { id: "main", identity: { name: "Main" }, name: "Main" };
@@ -43,7 +48,6 @@ async function screenshot(page: Page, name: string) {
   if (!captureUiProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,

--- a/ui/src/e2e/board-a2ui.e2e.test.ts
+++ b/ui/src/e2e/board-a2ui.e2e.test.ts
@@ -9,6 +9,7 @@ import { buildWidgetDocument } from "../../../src/canvas/wrap.js";
 import { buildBoardWidgetSandboxPath } from "../../../src/gateway/board-sandbox.js";
 import { createSandboxHostHttpServer } from "../../../src/gateway/mcp-app-sandbox-http.js";
 import { getGatewayE2ePortBlock } from "../../../src/gateway/test-helpers.e2e.js";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   controlUiBundledSettingsStorageKey,
@@ -266,8 +267,7 @@ describeControlUiE2e("Control UI dashboard A2UI", () => {
       expect(scrollbar.ratio).toBeLessThan(0.2);
       if (scrollbarProofLabel) {
         const screenshotPath = path.resolve(
-          process.cwd(),
-          ".artifacts/control-ui-e2e/widget-scrollbar",
+          createControlUiE2eArtifactDir("widget-scrollbar"),
           `${scrollbarProofLabel}-${colorScheme}.png`,
         );
         await mkdir(path.dirname(screenshotPath), { recursive: true });

--- a/ui/src/e2e/board-split-transcript.e2e.test.ts
+++ b/ui/src/e2e/board-split-transcript.e2e.test.ts
@@ -1,10 +1,10 @@
 // Regression: the chat transcript must repaint after a dashboard -> split face
 // switch re-stamps it into the sidebar region (issue: virtualizer stayed
 // detached until an unrelated re-render, painting a blank pane).
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   controlUiBundledSettingsStorageKey,
@@ -21,7 +21,12 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const sessionKey = "agent:main:board-split-transcript";
-const proofDir = path.resolve(".artifacts/control-ui-e2e/dashboard-side-chat-tabs");
+let proofDir: string;
+beforeEach(() => {
+  if (process.env.OPENCLAW_UI_E2E_RECORD === "1") {
+    proofDir = createControlUiE2eArtifactDir("dashboard-side-chat-tabs");
+  }
+});
 
 let browser: Browser;
 let controlUi: ControlUiE2eServer;
@@ -270,9 +275,6 @@ describeControlUiE2e("Board split transcript restore", () => {
 
   it("transitions between Dashboard and Split with the whole side panel", async () => {
     const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
-    if (recordProof) {
-      await mkdir(proofDir, { recursive: true });
-    }
     const context = await browser.newContext({
       viewport: { width: 1400, height: 900 },
       ...(recordProof
@@ -380,9 +382,6 @@ describeControlUiE2e("Board split transcript restore", () => {
 
   it("activates Side chat from a split dashboard panel", async () => {
     const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
-    if (recordProof) {
-      await mkdir(proofDir, { recursive: true });
-    }
     const context = await browser.newContext({
       viewport: { width: 1400, height: 900 },
       ...(recordProof
@@ -445,9 +444,6 @@ describeControlUiE2e("Board split transcript restore", () => {
 
   it("does not offer Discussion when the gateway has no discussion provider", async () => {
     const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
-    if (recordProof) {
-      await mkdir(proofDir, { recursive: true });
-    }
     const context = await browser.newContext({
       viewport: { width: 1400, height: 900 },
       ...(recordProof

--- a/ui/src/e2e/browser-dictation-status.e2e.test.ts
+++ b/ui/src/e2e/browser-dictation-status.e2e.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 // Control UI E2E tests cover visible browser dictation state through a real composer.
 import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
@@ -69,7 +70,11 @@ suite.define(() => {
       const committedDraft = cancel ? "ship it" : expected;
       expect(await textarea.inputValue()).toBe(committedDraft);
       expect(await gateway.getRequests("chat.send")).toHaveLength(0);
-      await captureComposerProof(page, `dictation-${name.replaceAll(" ", "-")}-committed.png`);
+      await captureComposerProof(
+        suite,
+        page,
+        `dictation-${name.replaceAll(" ", "-")}-committed.png`,
+      );
       expect(await textarea.inputValue()).toBe(committedDraft);
     });
   });
@@ -132,7 +137,7 @@ suite.define(() => {
       await expect
         .poll(() => textarea.inputValue())
         .toBe("keep this draft discard this speech too");
-      await captureComposerProof(page, "dictation-new-session-recognized-preview.png");
+      await captureComposerProof(suite, page, "dictation-new-session-recognized-preview.png");
       await page.keyboard.press("Escape");
       await expect.poll(() => textarea.inputValue()).toBe("keep this draft");
       await gateway.waitForRequest("talk.session.close");
@@ -140,7 +145,7 @@ suite.define(() => {
         true,
       );
       expect(await gateway.getRequests("sessions.create")).toHaveLength(0);
-      await captureComposerProof(page, "dictation-new-session-cancelled.png");
+      await captureComposerProof(suite, page, "dictation-new-session-cancelled.png");
     });
   });
 
@@ -173,10 +178,10 @@ suite.define(() => {
 
       await expect.poll(() => toggle.getAttribute("aria-checked")).toBe("false");
       await expect.poll(() => picker.getAttribute("open")).not.toBeNull();
-      await captureComposerProof(page, "microphone-picker-hold-toggle.png");
+      await captureComposerProof(suite, page, "microphone-picker-hold-toggle.png");
       await page.screenshot({
         animations: "disabled",
-        path: ".artifacts/control-ui-e2e/voice-controls/microphone-picker-hold-toggle-full.png",
+        path: path.join(suite.artifactDir, "voice-controls/microphone-picker-hold-toggle-full.png"),
       });
     });
   });
@@ -204,10 +209,13 @@ suite.define(() => {
       await expect
         .poll(() => unavailable.getByRole("button", { name: "Configure" }).count())
         .toBe(2);
-      await captureComposerProof(page, "microphone-picker-capability-gating.png");
+      await captureComposerProof(suite, page, "microphone-picker-capability-gating.png");
       await page.screenshot({
         animations: "disabled",
-        path: ".artifacts/control-ui-e2e/voice-controls/microphone-picker-capability-gating-full.png",
+        path: path.join(
+          suite.artifactDir,
+          "voice-controls/microphone-picker-capability-gating-full.png",
+        ),
       });
     });
   });
@@ -252,10 +260,10 @@ suite.define(() => {
         expect(await composer.locator(".agent-chat__dictation-elapsed").count()).toBe(0);
         await expect.poll(() => stop.isVisible()).toBe(true);
         await expect.poll(() => send.isVisible()).toBe(true);
-        await captureComposerProof(page, "dictation-status-actions.png");
+        await captureComposerProof(suite, page, "dictation-status-actions.png");
         await page.screenshot({
           animations: "disabled",
-          path: ".artifacts/control-ui-e2e/voice-controls/dictation-latched-after-release.png",
+          path: path.join(suite.artifactDir, "voice-controls/dictation-latched-after-release.png"),
         });
         const composerBox = await composer.boundingBox();
         expect(composerBox).not.toBeNull();

--- a/ui/src/e2e/browser-screenshot-body-cancel.e2e.test.ts
+++ b/ui/src/e2e/browser-screenshot-body-cancel.e2e.test.ts
@@ -1,6 +1,7 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { openChatSidePanelType } from "./chat-side-panel.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -12,10 +13,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.resolve(
-  process.cwd(),
-  ".artifacts/control-ui-e2e/browser-screenshot-body-cancel",
-);
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    proofDir = createControlUiE2eArtifactDir("browser-screenshot-body-cancel");
+  }
+});
 
 suite.define(() => {
   it("keeps the status error visible and cancels the unread media body", async () => {
@@ -175,7 +178,6 @@ suite.define(() => {
         });
 
         if (captureUiProofEnabled) {
-          await mkdir(proofDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             path: path.join(proofDir, "failed-screenshot.png"),

--- a/ui/src/e2e/browser-talk-microphone-lifetime.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-microphone-lifetime.e2e.test.ts
@@ -56,7 +56,7 @@ suite.define(() => {
         )
         .toBe(true);
       expect(await gateway.getRequests("talk.client.create")).toHaveLength(0);
-      await captureMicrophoneLossProof(page, "prepared-input-pending.png");
+      await captureMicrophoneLossProof(suite, page, "prepared-input-pending.png");
       const guidance = page.locator('.agent-chat__talk-status[role="status"]');
       await expect
         .poll(() => guidance.allTextContents())
@@ -76,7 +76,7 @@ suite.define(() => {
         .toBe(1);
       await expect.poll(() => guidance.count()).toBe(0);
       expect(await gateway.getRequests("talk.client.create")).toHaveLength(1);
-      await captureMicrophoneLossProof(page, "prepared-input-ready.png");
+      await captureMicrophoneLossProof(suite, page, "prepared-input-ready.png");
       await page.getByRole("button", { name: "Stop voice input" }).click();
     });
   });
@@ -120,10 +120,10 @@ suite.define(() => {
           )
           .toMatchObject({ status: "listening" });
       } catch (error) {
-        await captureMicrophoneLossProof(page, "microphone-loss-setup-failure.png");
+        await captureMicrophoneLossProof(suite, page, "microphone-loss-setup-failure.png");
         throw error;
       }
-      await captureMicrophoneLossProof(page, "microphone-loss-before-listening.png");
+      await captureMicrophoneLossProof(suite, page, "microphone-loss-before-listening.png");
 
       await page.evaluate(() => {
         (
@@ -150,7 +150,7 @@ suite.define(() => {
           }),
         )
         .toEqual({ tracksStopped: 1, peerClosed: true, trackState: "ended", audioElements: 0 });
-      await captureMicrophoneLossProof(page, "microphone-loss-after-error.png");
+      await captureMicrophoneLossProof(suite, page, "microphone-loss-after-error.png");
       await gateway.waitForRequest("talk.client.close");
       await page.getByRole("button", { name: "Dismiss voice input error" }).click();
       console.info(

--- a/ui/src/e2e/browser-talk-ordering.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-ordering.e2e.test.ts
@@ -1,6 +1,6 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import {
   dispatchOpenAiTalkEvent,
@@ -18,8 +18,7 @@ const suite = createControlUiE2eSuite({
 
 suite.define(() => {
   it("renders and saves overlapping replies beside their delayed user transcripts", async () => {
-    const artifactDir = path.join(process.cwd(), ".artifacts/control-ui-e2e/transcript-ordering");
-    await mkdir(artifactDir, { recursive: true });
+    const artifactDir = createControlUiE2eArtifactDir("transcript-ordering");
     await suite.withPage(
       {
         permissions: ["microphone"],

--- a/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-start-stop.e2e.test.ts
@@ -258,7 +258,7 @@ suite.define(() => {
           Number(await page.locator(".agent-chat__voice-activity").getAttribute("data-level")),
         )
         .toBeGreaterThan(0);
-      await captureComposerProof(page, "01-voice-live-listening.png");
+      await captureComposerProof(suite, page, "01-voice-live-listening.png");
 
       // Enter-sends while voice is active; the deferred chat.send keeps the
       // run abortable so both stop controls render side by side.
@@ -296,16 +296,16 @@ suite.define(() => {
       ).toBe(false);
       expect(await stopVoice.locator(".agent-chat__voice-activity").count()).toBe(1);
       expect(await page.locator(".chat-send-btn--stop").count()).toBe(1);
-      await captureComposerProof(page, "02-voice-plus-run-stop.png");
+      await captureComposerProof(suite, page, "02-voice-plus-run-stop.png");
 
       await page.emulateMedia({ colorScheme: "dark" });
       await expect
         .poll(() => page.evaluate(() => document.documentElement.dataset.themeMode))
         .toBe("dark");
-      await captureComposerProof(page, "03-voice-plus-run-stop-dark.png");
+      await captureComposerProof(suite, page, "03-voice-plus-run-stop-dark.png");
 
       await stopVoice.hover();
-      await captureComposerProof(page, "04-voice-live-hover-stop-glyph.png");
+      await captureComposerProof(suite, page, "04-voice-live-hover-stop-glyph.png");
 
       // Stopping voice must leave the run (and its stop control) untouched.
       await stopVoice.click();
@@ -333,7 +333,7 @@ suite.define(() => {
 
       await page.setViewportSize({ width: 1366, height: 900 });
       await page.goto(`${suite.server.baseUrl}chat`);
-      await captureVideoTalkProof(page, "01-before-video-talk.png");
+      await captureVideoTalkProof(suite, page, "01-before-video-talk.png");
 
       await page.getByRole("button", { name: "Start voice input" }).click();
       const request = await gateway.waitForRequest("talk.client.create");
@@ -382,7 +382,7 @@ suite.define(() => {
         item_id: "unintelligible-input",
         error: { message: "The audio could not be transcribed." },
       });
-      await captureMicrophoneLossProof(page, "input-transcription-error.png");
+      await captureMicrophoneLossProof(suite, page, "input-transcription-error.png");
       const transcriptionError = page.getByRole("alert").filter({
         hasText: "The audio could not be transcribed.",
       });
@@ -409,7 +409,7 @@ suite.define(() => {
       console.info(
         `[video-talk-e2e] preview=live,width:${dimensions.width},height:${dimensions.height}`,
       );
-      await captureVideoTalkProof(page, "02-live-camera-preview.png");
+      await captureVideoTalkProof(suite, page, "02-live-camera-preview.png");
 
       await dispatchOpenAiTalkEvent(page, {
         type: "response.done",
@@ -476,7 +476,7 @@ suite.define(() => {
       );
       expect(trackStates).toHaveLength(2);
       expect(trackStates?.every((state) => state === "ended")).toBe(true);
-      await captureVideoTalkProof(page, "04-after-video-talk-stop.png");
+      await captureVideoTalkProof(suite, page, "04-after-video-talk-stop.png");
       console.info("[video-talk-e2e] stop=preview-removed,tracks:ended+ended");
     });
   });
@@ -604,7 +604,7 @@ suite.define(() => {
         "talk.catalog",
         "talk.client.create",
       ]);
-      await captureVideoTalkProof(page, "05-gemini-live-camera-preview.png");
+      await captureVideoTalkProof(suite, page, "05-gemini-live-camera-preview.png");
       console.info(
         "[video-talk-e2e] gemini=realtimeInput.video+functionResponse,gateway_frame_requests:0",
       );
@@ -673,7 +673,7 @@ suite.define(() => {
       await expect
         .poll(() => page.getByRole("button", { name: "Turn camera on" }).isVisible())
         .toBe(true);
-      await captureVideoTalkProof(page, "03-camera-permission-blocked.png");
+      await captureVideoTalkProof(suite, page, "03-camera-permission-blocked.png");
       console.info("[video-talk-e2e] camera_denial=actionable,no-audio-fallback");
     });
   });
@@ -834,7 +834,7 @@ suite.define(() => {
       await expect
         .poll(() => gateway.getRequests("talk.session.close").then((requests) => requests.length))
         .toBe(1);
-      await captureComposerProof(page, "relay-input-backpressure-error.png");
+      await captureComposerProof(suite, page, "relay-input-backpressure-error.png");
     });
   });
 

--- a/ui/src/e2e/browser-talk-start-stop.fixtures.ts
+++ b/ui/src/e2e/browser-talk-start-stop.fixtures.ts
@@ -1,4 +1,3 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 
@@ -419,32 +418,44 @@ export async function installOversizedWebRtcSdpFixture(page: Page) {
   });
 }
 
-export async function captureComposerProof(page: Page, fileName: string) {
-  const artifactDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "voice-controls");
-  await mkdir(artifactDir, { recursive: true });
+export async function captureComposerProof(
+  owner: { readonly artifactDir: string },
+  page: Page,
+  fileName: string,
+) {
+  const artifactDir = path.join(owner.artifactDir, "voice-controls");
   await page
     .locator(".agent-chat__composer-shell")
     .screenshot({ path: path.join(artifactDir, fileName) });
 }
 
-export async function captureMicrophoneLossProof(page: Page, fileName: string) {
-  const artifactDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "voice-controls");
-  await mkdir(artifactDir, { recursive: true });
+export async function captureMicrophoneLossProof(
+  owner: { readonly artifactDir: string },
+  page: Page,
+  fileName: string,
+) {
+  const artifactDir = path.join(owner.artifactDir, "voice-controls");
   // The error floats above the composer bounds; retain the real chat context.
   await page.screenshot({ path: path.join(artifactDir, fileName), fullPage: true });
 }
 
-export async function captureVideoTalkProof(page: Page, fileName: string) {
-  const artifactDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "video-talk");
-  await mkdir(artifactDir, { recursive: true });
+export async function captureVideoTalkProof(
+  owner: { readonly artifactDir: string },
+  page: Page,
+  fileName: string,
+) {
+  const artifactDir = path.join(owner.artifactDir, "video-talk");
   await page
     .locator(".agent-chat__composer-shell")
     .screenshot({ path: path.join(artifactDir, fileName) });
 }
 
-export async function captureWebRtcSdpAlertProof(page: Page, fileName: string) {
-  const artifactDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "webrtc-sdp");
-  await mkdir(artifactDir, { recursive: true });
+export async function captureWebRtcSdpAlertProof(
+  owner: { readonly artifactDir: string },
+  page: Page,
+  fileName: string,
+) {
+  const artifactDir = path.join(owner.artifactDir, "webrtc-sdp");
   await page
     .locator('.agent-chat__talk-status[role="alert"]')
     .screenshot({ path: path.join(artifactDir, fileName) });

--- a/ui/src/e2e/browser-talk-start-stop.webrtc-sdp.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-start-stop.webrtc-sdp.e2e.test.ts
@@ -57,7 +57,7 @@ suite.define(() => {
 
       const alert = page.locator('.agent-chat__talk-status[role="alert"]');
       await expect.poll(() => alert.textContent()).toContain("Realtime WebRTC setup failed (502)");
-      await captureWebRtcSdpAlertProof(page, "01-http-failure-alert.png");
+      await captureWebRtcSdpAlertProof(suite, page, "01-http-failure-alert.png");
       await expect
         .poll(() =>
           page.evaluate(
@@ -109,7 +109,7 @@ suite.define(() => {
       await expect
         .poll(() => alert.textContent())
         .toContain("Realtime WebRTC SDP answer: text response exceeds 262144 bytes");
-      await captureWebRtcSdpAlertProof(page, "02-oversized-answer-alert.png");
+      await captureWebRtcSdpAlertProof(suite, page, "02-oversized-answer-alert.png");
       await expect
         .poll(() =>
           page.evaluate(

--- a/ui/src/e2e/browser-talk-webkit-error.e2e.test.ts
+++ b/ui/src/e2e/browser-talk-webkit-error.e2e.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 // Control UI E2E coverage for legacy WebKit media errors.
 import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
@@ -37,9 +38,13 @@ suite.define(() => {
         .toBe("The selected microphone is unavailable. Choose another input or System default.");
       expect(await gateway.getRequests("talk.client.create")).toHaveLength(0);
       expect(await gateway.getRequests("talk.session.close")).toHaveLength(0);
-      await captureComposerProof(page, "webkit-selected-microphone-unavailable-composer.png");
+      await captureComposerProof(
+        suite,
+        page,
+        "webkit-selected-microphone-unavailable-composer.png",
+      );
       await page.getByRole("alert").screenshot({
-        path: ".artifacts/control-ui-e2e/voice-controls/webkit-selected-microphone-alert.png",
+        path: path.join(suite.artifactDir, "voice-controls/webkit-selected-microphone-alert.png"),
       });
     });
   });

--- a/ui/src/e2e/build-info-unicode.e2e.test.ts
+++ b/ui/src/e2e/build-info-unicode.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI tests keep build identity readable at UTF-16 truncation boundaries.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway, startControlUiE2eServer } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -25,12 +25,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "build-info-unicode",
-);
+let uiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    uiProofArtifactDir = createControlUiE2eArtifactDir("build-info-unicode");
+  }
+});
 
 const RAW_BRANCH = `${"a".repeat(12)}😀${"b".repeat(85)}😀suffix`;
 const NORMALIZED_BRANCH = `${"a".repeat(12)}😀${"b".repeat(85)}`;
@@ -128,7 +128,6 @@ suite.define(() => {
           });
 
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await identityCard.screenshot({
             animations: "disabled",
             path: path.join(uiProofArtifactDir, "00-footer-custom-build-identity.png"),

--- a/ui/src/e2e/channel-wizard-option-contrast.e2e.test.ts
+++ b/ui/src/e2e/channel-wizard-option-contrast.e2e.test.ts
@@ -1,6 +1,7 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -12,12 +13,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const proofVariant = process.env.OPENCLAW_PICKER_PROOF_VARIANT;
-const proofDirectory = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "channel-wizard-option-contrast",
-);
+let proofDirectory: string;
+beforeEach(() => {
+  if (proofVariant) {
+    proofDirectory = createControlUiE2eArtifactDir("channel-wizard-option-contrast");
+  }
+});
 
 suite.define(() => {
   it("keeps option subtext legible and keyboard focus visible in forced colors", async () => {
@@ -101,7 +102,6 @@ suite.define(() => {
         });
 
         if (proofVariant) {
-          await mkdir(proofDirectory, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,

--- a/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
+++ b/ui/src/e2e/channels-whatsapp-logout.e2e.test.ts
@@ -1,7 +1,7 @@
 // Control UI tests cover WhatsApp logout feedback against a mocked Gateway.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway, waitForConfirmModal } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -14,24 +14,21 @@ const suite = createControlUiE2eSuite({
 const QR_DATA_URL =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9WlY9Z8AAAAASUVORK5CYII=";
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "channels-save-failure",
-);
-const wizardUiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "channel-wizard-continue-spinner",
-);
+let uiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    uiProofArtifactDir = createControlUiE2eArtifactDir("channels-save-failure");
+  }
+});
+let wizardUiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    wizardUiProofArtifactDir = createControlUiE2eArtifactDir("channel-wizard-continue-spinner");
+  }
+});
 
 suite.define(() => {
   it("shows rejected channel configuration saves in the open editor without losing the draft", async () => {
-    if (captureUiProofEnabled) {
-      await mkdir(uiProofArtifactDir, { recursive: true });
-    }
     await suite.withPage(
       {
         locale: "en-US",
@@ -185,7 +182,6 @@ suite.define(() => {
         });
 
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
@@ -272,7 +268,6 @@ suite.define(() => {
         await firstConfirm.getByRole("button", { name: "Cancel" }).focus();
         await page.keyboard.press("Escape");
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
@@ -377,9 +372,6 @@ suite.define(() => {
   });
 
   it("preserves standard channel details and the complete Telegram setup wizard", async () => {
-    if (captureUiProofEnabled) {
-      await mkdir(wizardUiProofArtifactDir, { recursive: true });
-    }
     await suite.withPage({ locale: "en-US", serviceWorkers: "block" }, async ({ page }) => {
       const channelEntries = [
         ["discord", "Discord"],

--- a/ui/src/e2e/chat-active-cursor-replay.e2e.test.ts
+++ b/ui/src/e2e/chat-active-cursor-replay.e2e.test.ts
@@ -1,6 +1,6 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   chatSessionListResponse,
   createChatFlowE2eSuite,
@@ -14,10 +14,10 @@ const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
   it("restores active commentary when an evicted session revalidates from its cursor", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-    if (artifactDir) {
-      await mkdir(artifactDir, { recursive: true });
-    }
+    const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("chat-active-cursor-replay", artifactRoot)
+      : undefined;
     const context = await suite.newBrowserContext({
       locale: "en-US",
       ...(artifactDir

--- a/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Page } from "playwright/test";
-import { it } from "vitest";
+import { beforeEach, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   installMockGateway,
   type MockGatewayControls,
@@ -16,7 +16,12 @@ const suite = createControlUiE2eSuite({
     `Playwright Chromium is required for active-turn recovery proof at ${executablePath}`,
 });
 
-const proofDir = path.resolve(".artifacts/control-ui-e2e/active-turn-recovery");
+let proofDir: string;
+beforeEach(() => {
+  if (captureProof) {
+    proofDir = createControlUiE2eArtifactDir("active-turn-recovery");
+  }
+});
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 type ActiveRunSnapshotOptions = {
   events?: unknown[];
@@ -30,7 +35,6 @@ async function capture(page: Page, name: string): Promise<void> {
   if (!captureProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.screenshot({ path: path.join(proofDir, `${name}.png`), fullPage: true });
 }
 

--- a/ui/src/e2e/chat-agent-run-transcript.e2e.test.ts
+++ b/ui/src/e2e/chat-agent-run-transcript.e2e.test.ts
@@ -1,6 +1,6 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -84,9 +84,11 @@ suite.define(() => {
 
     expect(rowKeys[0]).toMatch(/^agent-run:/u);
     expect(rowKeys).toEqual([rowKeys[0], rowKeys[0], rowKeys[0]]);
-    const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactRoot = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("chat-agent-run-transcript", artifactRoot)
+      : undefined;
     if (artifactDir) {
-      await fs.mkdir(artifactDir, { recursive: true });
       await page.locator(".chat-thread-inner").screenshot({
         path: path.join(artifactDir, "restart-recovery-run-frame.png"),
       });
@@ -249,9 +251,11 @@ suite.define(() => {
       await page.goto(`${suite.server.baseUrl}chat`);
       const transcript = page.locator(".chat-thread-inner");
       await transcript.getByText("Caption ready for the second run.", { exact: true }).waitFor();
-      const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactRoot = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = artifactRoot
+        ? createControlUiE2eArtifactDir("chat-agent-run-transcript", artifactRoot)
+        : undefined;
       if (artifactDir) {
-        await fs.mkdir(artifactDir, { recursive: true });
         const firstNarration = transcript.getByText(
           "I’ll create the launch card and check the existing style first.",
           { exact: true },
@@ -445,9 +449,11 @@ suite.define(() => {
     });
     expect(overlappingRows).toEqual([]);
 
-    const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactRoot = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("chat-agent-run-transcript", artifactRoot)
+      : undefined;
     if (artifactDir) {
-      await fs.mkdir(artifactDir, { recursive: true });
       await page.screenshot({
         path: path.join(artifactDir, "cross-session-run-isolation.png"),
         fullPage: true,

--- a/ui/src/e2e/chat-attachment-announcement.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-announcement.e2e.test.ts
@@ -1,12 +1,18 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({ name: "Attachment failure announcements" });
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts/control-ui-e2e/attachment-announcement");
+let proofDir: string;
+beforeEach(() => {
+  if (captureProof) {
+    proofDir = createControlUiE2eArtifactDir("attachment-announcement");
+  }
+});
 
 suite.define(() => {
   it.each(["ordinary", "completed"])(
@@ -39,7 +45,6 @@ suite.define(() => {
           expect(await announcement.getAttribute("aria-atomic")).toBe("true");
           expect(await announcement.textContent()).toBe("");
           if (captureProof) {
-            await mkdir(proofDir, { recursive: true });
             await page.screenshot({ path: path.join(proofDir, `${flow}-initial.png`) });
           }
 

--- a/ui/src/e2e/chat-attributed-identity.e2e.test.ts
+++ b/ui/src/e2e/chat-attributed-identity.e2e.test.ts
@@ -1,8 +1,8 @@
-// Control UI E2E tests cover attributed chat identity placement.
-import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, type Locator, type Page } from "playwright/test";
-import { it } from "vitest";
+import { beforeEach, it } from "vitest";
+// Control UI E2E tests cover attributed chat identity placement.
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -11,16 +11,19 @@ const suite = createControlUiE2eSuite({
   startServerBeforeBrowser: true,
 });
 
-function resolveArtifactDir(): string | undefined {
-  return process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim() || undefined;
-}
+let proofArtifactDir: string | undefined;
+beforeEach(() => {
+  const parent = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+  proofArtifactDir = parent
+    ? createControlUiE2eArtifactDir("chat-attributed-identity", parent)
+    : undefined;
+});
 
 async function captureProof(page: Page, name: string) {
-  const artifactDir = resolveArtifactDir();
+  const artifactDir = proofArtifactDir;
   if (!artifactDir) {
     return;
   }
-  await fs.mkdir(artifactDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     path: path.join(artifactDir, name),
@@ -66,10 +69,7 @@ function expectStableNamePosition(
 
 suite.define(() => {
   it("uses one avatar placement and keeps shared-thread authors readable", async () => {
-    const artifactDir = resolveArtifactDir();
-    if (artifactDir) {
-      await fs.mkdir(artifactDir, { recursive: true });
-    }
+    const artifactDir = proofArtifactDir;
     const context = await suite.browser.newContext({
       viewport: { height: 760, width: 1180 },
       ...(artifactDir
@@ -446,10 +446,10 @@ suite.define(() => {
   });
 
   it("keeps an attributed failed send in the transcript with one-line retry metadata", async () => {
-    const artifactDir = process.env.OPENCLAW_BUBBLE_DELIVERY_ARTIFACT_DIR?.trim();
-    if (artifactDir) {
-      await fs.mkdir(artifactDir, { recursive: true });
-    }
+    const artifactRoot = process.env.OPENCLAW_BUBBLE_DELIVERY_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("bubble-delivery", artifactRoot)
+      : undefined;
     const context = await suite.browser.newContext({ viewport: { height: 760, width: 1180 } });
     const page = await context.newPage();
     const sender = {
@@ -554,10 +554,7 @@ suite.define(() => {
   });
 
   it("keeps missing local-viewer avatar initials through a live rerender", async () => {
-    const artifactDir = resolveArtifactDir();
-    if (artifactDir) {
-      await fs.mkdir(artifactDir, { recursive: true });
-    }
+    const artifactDir = proofArtifactDir;
     const context = await suite.browser.newContext({
       viewport: { height: 760, width: 1180 },
       ...(artifactDir

--- a/ui/src/e2e/chat-code-block-fences.e2e.test.ts
+++ b/ui/src/e2e/chat-code-block-fences.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -17,7 +17,12 @@ const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM 
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofStage = process.env.OPENCLAW_CODE_FENCE_PROOF_STAGE ?? "after";
-const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/chat-code-block-fences");
+let artifactDir: string;
+beforeEach(() => {
+  if (captureProof) {
+    artifactDir = createControlUiE2eArtifactDir("chat-code-block-fences");
+  }
+});
 
 function fencedJson(lineCount: number): string {
   const values = Array.from({ length: lineCount - 2 }, (_, index) => `  ${index},`);
@@ -61,9 +66,6 @@ describeControlUiE2e("Control UI fenced code blocks", () => {
   beforeAll(async () => {
     if (!chromiumAvailable) {
       throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    if (captureProof) {
-      await mkdir(artifactDir, { recursive: true });
     }
     server = await startControlUiE2eServer(undefined, { source: true });
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });

--- a/ui/src/e2e/chat-composer-accessory-focus.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-accessory-focus.e2e.test.ts
@@ -1,6 +1,6 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -70,9 +70,11 @@ suite.define(() => {
         await outside.focus();
         await trigger.click();
         expect(await outside.evaluate((element) => document.activeElement === element)).toBe(true);
-        const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+        const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+        const artifactDir = artifactRoot
+          ? createControlUiE2eArtifactDir("chat-composer-accessory-focus", artifactRoot)
+          : undefined;
         if (artifactDir && triggerSelector.startsWith(".context-usage")) {
-          await fs.mkdir(artifactDir, { recursive: true });
           const composerBox = await composer.boundingBox();
           const popoverBox = await composer.locator(".context-usage__popover").boundingBox();
           if (!composerBox || !popoverBox) {

--- a/ui/src/e2e/chat-composer-capability-menu-height.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu-height.e2e.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -141,13 +142,15 @@ suite.define(() => {
       await dropdown.locator('[value="open-skills"]').click();
       await expect.poll(() => dropdown.getAttribute("data-view")).toBe("skills");
 
-      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = artifactDirParent
+        ? createControlUiE2eArtifactDir("chat-composer-capability-menu-height", artifactDirParent)
+        : undefined;
       const captureStage = process.env.OPENCLAW_UI_E2E_CAPTURE_STAGE?.trim();
       const capture = async (view: string, theme: "dark" | "light") => {
         if (!artifactDir || !captureStage) {
           return;
         }
-        await fs.mkdir(artifactDir, { recursive: true });
         await page.evaluate((mode) => {
           document.documentElement.dataset.themeMode = mode;
         }, theme);

--- a/ui/src/e2e/chat-composer-catalog.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-catalog.e2e.test.ts
@@ -1,5 +1,6 @@
 // Control UI E2E tests cover chat composer catalog discovery.
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiSessionUrl,
   installMockGateway,
@@ -238,7 +239,10 @@ suite.define(() => {
       await expect.poll(() => composer.locator("textarea").isDisabled()).toBe(true);
       expect(await gateway.getRequests("chat.send")).toHaveLength(0);
 
-      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = artifactRoot
+        ? createControlUiE2eArtifactDir("chat-composer-catalog", artifactRoot)
+        : undefined;
       if (artifactDir) {
         await composer.screenshot({
           animations: "disabled",
@@ -467,7 +471,10 @@ suite.define(() => {
       await expect
         .poll(() => composer.locator("[data-chat-model-catalog-state]").textContent())
         .toContain("No models available");
-      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = artifactRoot
+        ? createControlUiE2eArtifactDir("chat-composer-catalog", artifactRoot)
+        : undefined;
       if (artifactDir) {
         await page.screenshot({
           animations: "disabled",
@@ -546,7 +553,10 @@ suite.define(() => {
       await expect
         .poll(() => composer.locator('[data-chat-model-option="openai/gpt-5.6-luna"]').isVisible())
         .toBe(true);
-      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = artifactRoot
+        ? createControlUiE2eArtifactDir("chat-composer-catalog", artifactRoot)
+        : undefined;
       if (artifactDir) {
         await page.screenshot({
           animations: "disabled",
@@ -606,7 +616,10 @@ suite.define(() => {
           .poll(() => textarea.evaluate((node) => node.matches(":placeholder-shown")))
           .toBe(true);
         await expect.poll(() => textarea.getAttribute("placeholder")).toContain("Message");
-        const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+        const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+        const artifactDir = artifactRoot
+          ? createControlUiE2eArtifactDir("chat-composer-catalog", artifactRoot)
+          : undefined;
         if (artifactDir) {
           await page.locator(".agent-chat__composer-shell").screenshot({
             animations: "disabled",

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -1,5 +1,6 @@
 // Control UI E2E tests cover the redesigned chat composer.
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -25,7 +26,10 @@ suite.define(() => {
   ] as const)(
     "keeps $reason model availability honest in the composer and picker",
     async ({ reason, blocked, message }) => {
-      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = artifactRoot
+        ? createControlUiE2eArtifactDir("chat-composer-redesign", artifactRoot)
+        : undefined;
       await suite.withPage(
         {
           viewport: { width: 1280, height: 900 },
@@ -189,7 +193,10 @@ suite.define(() => {
   });
 
   it("keeps the model in the bottom bar, session settings in the header, and holds send beside the microphone in every input state", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("chat-composer-redesign", artifactRoot)
+      : undefined;
     const pageOptions = {
       viewport: { width: 1920, height: 1080 },
       ...(artifactDir

--- a/ui/src/e2e/chat-continue-in-terminal.e2e.test.ts
+++ b/ui/src/e2e/chat-continue-in-terminal.e2e.test.ts
@@ -1,8 +1,8 @@
-import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { decodeResumeHandoff } from "../../../src/shared/resume-handoff.js";
 import type { ChatPaneElement } from "../pages/chat/route-draft-focus-handoff.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiSessionPath,
   controlUiSessionUrl,
@@ -18,7 +18,6 @@ const suite = createControlUiE2eSuite({
     `Playwright Chromium is not installed at ${executablePath}. Run \`pnpm --dir ui exec playwright install chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
 });
 
-const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/header-session-menu");
 const basePath = new URL("/nested/$&;=()+,![]{}'`/%25PATH%25", "http://localhost").pathname;
 const agentId = "runner";
 const sessionKey = `agent:${agentId}:main-'"$&;|<>^()%![]{}\\\`-%PATH%`;
@@ -67,8 +66,7 @@ const compactManagementActions = sharedManagementActions.filter(
 
 suite.define(() => {
   it("shows, copies, and retires a credential-free exact continuation command", async () => {
-    await rm(artifactDir, { recursive: true, force: true });
-    await mkdir(artifactDir, { recursive: true });
+    const artifactDir = createControlUiE2eArtifactDir("header-session-menu");
     await suite.withPage(
       {
         locale: "en-US",
@@ -164,7 +162,7 @@ suite.define(() => {
   });
 
   it("keeps the canonical session actions reachable in the mobile header menu", async () => {
-    await mkdir(artifactDir, { recursive: true });
+    const artifactDir = createControlUiE2eArtifactDir("header-session-menu");
     await suite.withPage(
       {
         locale: "en-US",

--- a/ui/src/e2e/chat-file-links.e2e.test.ts
+++ b/ui/src/e2e/chat-file-links.e2e.test.ts
@@ -2,7 +2,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   controlUiE2eWaitTimeoutMs,
@@ -17,14 +18,16 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/chat-file-links");
+let artifactDir: string;
+beforeEach(() => {
+  artifactDir = createControlUiE2eArtifactDir("chat-file-links");
+});
 
 let browser: Browser;
 let server: ControlUiE2eServer;
 
 describeControlUiE2e("Control UI chat file links", () => {
   beforeAll(async () => {
-    fs.mkdirSync(artifactDir, { recursive: true });
     server = await startControlUiE2eServer();
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
   });

--- a/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
@@ -1,6 +1,6 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { waitForControlUiGatewayReconnecting } from "../test-helpers/control-ui-e2e-readiness.ts";
 import {
   chatSessionListResponse,
@@ -187,8 +187,7 @@ suite.define(() => {
       });
       const startupIndicator = page.locator('.chat-working-indicator[role="status"]');
       if (process.env.OPENCLAW_CAPTURE_UI_PROOF === "1") {
-        const startupProofDir = path.resolve(".artifacts/control-ui-e2e/duplicate-session-naming");
-        await mkdir(startupProofDir, { recursive: true });
+        const startupProofDir = path.join(suite.artifactDir, "duplicate-session-naming");
         await page.screenshot({ path: path.join(startupProofDir, "steer.png"), fullPage: true });
       }
       await expect.poll(() => startupIndicator.textContent()).not.toContain("Naming worktree…");
@@ -483,9 +482,11 @@ suite.define(() => {
             )
             .toEqual([initialText, beforeText, steerText, afterText]);
         } finally {
-          const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+          const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+          const artifactDir = artifactDirParent
+            ? createControlUiE2eArtifactDir("chat-flow.active-run-follow-ups", artifactDirParent)
+            : undefined;
           if (artifactDir) {
-            await mkdir(artifactDir, { recursive: true });
             await page.screenshot({
               fullPage: true,
               path: path.join(artifactDir, `steer-history-${historyOrder}-live-event.png`),
@@ -544,9 +545,11 @@ suite.define(() => {
         state: "delta",
       });
     const capture = async (name: string) => {
-      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = artifactDirParent
+        ? createControlUiE2eArtifactDir("chat-flow.active-run-follow-ups", artifactDirParent)
+        : undefined;
       if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
         await page.screenshot({
           fullPage: true,
           path: path.join(artifactDir, `steer-split-commentary-${name}.png`),

--- a/ui/src/e2e/chat-flow.clipboard.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.clipboard.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
@@ -99,10 +99,10 @@ suite.define(() => {
   it.each(["tool-diff", "selection", "agent-id"] as const)(
     "reports clipboard failure from the %s action",
     async (surface) => {
-      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-      if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
-      }
+      const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = artifactDirParent
+        ? createControlUiE2eArtifactDir("chat-flow.clipboard", artifactDirParent)
+        : undefined;
       const context = await suite.newBrowserContext({
         colorScheme: "light",
         locale: "en-US",
@@ -399,9 +399,11 @@ suite.define(() => {
         });
         expect(await gateway.getRequests("chat.send")).toHaveLength(0);
 
-        const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+        const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+        const artifactDir = artifactDirParent
+          ? createControlUiE2eArtifactDir("chat-flow.clipboard", artifactDirParent)
+          : undefined;
         if (artifactDir) {
-          await mkdir(artifactDir, { recursive: true });
           await page.screenshot({
             fullPage: true,
             path: path.join(artifactDir, `clipboard-${action}-failure.png`),
@@ -454,9 +456,11 @@ suite.define(() => {
       });
       expect(await gateway.getRequests("chat.send")).toHaveLength(0);
 
-      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = artifactDirParent
+        ? createControlUiE2eArtifactDir("chat-flow.clipboard", artifactDirParent)
+        : undefined;
       if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
         await page.screenshot({
           fullPage: true,
           path: path.join(artifactDir, "clipboard-assistant-code-failure.png"),

--- a/ui/src/e2e/chat-flow.dynamic-catalog.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.dynamic-catalog.e2e.test.ts
@@ -1,6 +1,6 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   createChatFlowE2eSuite,
   controlUiSessionUrl,
@@ -8,16 +8,16 @@ import {
 } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
-const dynamicCatalogProofDir =
-  process.env.OPENCLAW_CAPTURE_UI_PROOF === "1"
-    ? path.join(process.cwd(), ".artifacts", "control-ui-e2e", "dynamic-catalog-convergence")
-    : null;
+let dynamicCatalogProofDir: string | null;
+beforeEach(() => {
+  dynamicCatalogProofDir =
+    process.env.OPENCLAW_CAPTURE_UI_PROOF === "1"
+      ? createControlUiE2eArtifactDir("dynamic-catalog-convergence")
+      : null;
+});
 
 suite.define(() => {
   it("converges Chat reasoning and context metadata after dynamic catalog discovery", async () => {
-    if (dynamicCatalogProofDir) {
-      await mkdir(dynamicCatalogProofDir, { recursive: true });
-    }
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",

--- a/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-issuance.e2e.test.ts
@@ -1,4 +1,3 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
@@ -7,11 +6,12 @@ import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-sup
 const suite = createChatFlowE2eSuite();
 
 async function captureHistoryIssuanceProof(page: Page, name: string): Promise<void> {
-  const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+  const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim()
+    ? suite.artifactDir
+    : undefined;
   if (!artifactDir) {
     return;
   }
-  await mkdir(artifactDir, { recursive: true });
   await page.screenshot({ fullPage: true, path: path.join(artifactDir, `${name}.png`) });
 }
 

--- a/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.history-recovery.e2e.test.ts
@@ -1,8 +1,8 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import type { ApplicationContext } from "../app/context.ts";
 import type { ChatQueueItem } from "../lib/chat/chat-types.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   chatSessionListResponse,
   controlUiSessionUrl,
@@ -134,10 +134,10 @@ suite.define(() => {
   });
 
   it("restores reasoning and tool activity after navigating away from a session", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-    if (artifactDir) {
-      await mkdir(artifactDir, { recursive: true });
-    }
+    const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactDirParent
+      ? createControlUiE2eArtifactDir("chat-flow.history-recovery", artifactDirParent)
+      : undefined;
     const context = await suite.newBrowserContext({
       locale: "en-US",
       ...(artifactDir
@@ -425,7 +425,10 @@ suite.define(() => {
   });
 
   it("keeps evicted paginated history stable when returning to a session", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactDirParent
+      ? createControlUiE2eArtifactDir("chat-flow.history-recovery", artifactDirParent)
+      : undefined;
     const context = await suite.newBrowserContext({
       locale: "en-US",
       ...(artifactDir
@@ -695,7 +698,10 @@ suite.define(() => {
   });
 
   it("stores new input while offline and sends it after reconnect", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactDirParent
+      ? createControlUiE2eArtifactDir("chat-flow.history-recovery", artifactDirParent)
+      : undefined;
     const context = await suite.newBrowserContext({
       locale: "en-US",
       ...(artifactDir

--- a/ui/src/e2e/chat-flow.local-media-dollar-home.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.local-media-dollar-home.e2e.test.ts
@@ -1,14 +1,17 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { createPlaybackMediaFixture } from "../../../test/fixtures/media-playback.js";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
   it("allows tilde local media previews when the preview root home contains a literal $ pattern", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactDirParent
+      ? createControlUiE2eArtifactDir("chat-flow.local-media-dollar-home", artifactDirParent)
+      : undefined;
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -92,7 +95,6 @@ suite.define(() => {
         .toBeGreaterThanOrEqual(1);
       expect(await page.getByText("Outside allowed folders").count()).toBe(0);
       if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
         await page.screenshot({
           fullPage: true,
           path: path.join(artifactDir, "local-media-dollar-home-allowed.png"),

--- a/ui/src/e2e/chat-flow.media-files.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.media-files.e2e.test.ts
@@ -1,7 +1,8 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { afterEach, expect, it } from "vitest";
 import { createPlaybackMediaFixture } from "../../../test/fixtures/media-playback.js";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.ts";
 import {
   buildLocalWebchatAudioMessage,
   captureUiProofEnabled,
@@ -10,12 +11,12 @@ import {
   expectDefined,
   installMockGateway,
   installPlainHttpClipboardCapture,
-  managedImageCacheProofDir,
   waitForChatScrollIdle,
 } from "./chat-flow.test-support.ts";
 import { openChatSidePanelType } from "./chat-side-panel.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
+const mediaTempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 suite.define(() => {
   it("exposes an assistant document download with its Unicode filename and ticketed URL", async () => {
@@ -89,13 +90,17 @@ suite.define(() => {
     },
     {
       kind: "audio",
-      source: `FILE:${path.join(managedImageCacheProofDir, "bootstrap-structured-audio.mp3")}`,
+      source: "bootstrap-structured-audio.mp3",
       ticket: "ticket-bootstrap-structured-audio",
       structured: true,
     },
   ] as const)(
     "renders local assistant $kind through server metadata before preview roots load",
-    async ({ kind, source, ticket, ...options }) => {
+    async ({ kind, source: fixtureSource, ticket, ...options }) => {
+      const source =
+        "structured" in options
+          ? `FILE:${path.join(mediaTempDirs.make("control-ui-audio-"), fixtureSource)}`
+          : fixtureSource;
       const context = await suite.newBrowserContext({
         locale: "en-US",
         serviceWorkers: "block",
@@ -200,12 +205,10 @@ suite.define(() => {
             .toBe(180);
         }
 
-        const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-        if (artifactDir) {
-          await mkdir(artifactDir, { recursive: true });
+        if (process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim()) {
           await page.screenshot({
             fullPage: true,
-            path: path.join(artifactDir, `bootstrap-local-${kind}-${ticket}.png`),
+            path: path.join(suite.artifactDir, `bootstrap-local-${kind}-${ticket}.png`),
           });
         }
         if (process.env.OPENCLAW_BEHAVIOR_PROOF === "1") {
@@ -286,12 +289,10 @@ suite.define(() => {
         expect(await page.locator(".chat-assistant-attachment-card audio").count()).toBe(0);
         expect(await page.locator(".chat-assistant-attachment-card__download").count()).toBe(0);
 
-        const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-        if (artifactDir) {
-          await mkdir(artifactDir, { recursive: true });
+        if (process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim()) {
           await page.screenshot({
             fullPage: true,
-            path: path.join(artifactDir, `bootstrap-blocked-${code}.png`),
+            path: path.join(suite.artifactDir, `bootstrap-blocked-${code}.png`),
           });
         }
         if (process.env.OPENCLAW_BEHAVIOR_PROOF === "1") {
@@ -432,7 +433,9 @@ suite.define(() => {
       viewport: { height: 900, width: 1280 },
     });
     const page = await context.newPage();
-    const proofDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const proofDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim()
+      ? suite.artifactDir
+      : undefined;
     const managedAttachmentSource = (artifactId: string) =>
       `/api/chat/media/outgoing/agent%3Amain%3Amain/${artifactId.slice("artifact_managed_media_".length)}/full`;
     const attachments = [
@@ -548,7 +551,6 @@ suite.define(() => {
       expect(await page.getByText("Checking...", { exact: true }).count()).toBe(0);
       expect(((await page.locator("body").textContent()) ?? "").includes("MEDIA:")).toBe(false);
       if (proofDir) {
-        await mkdir(proofDir, { recursive: true });
         await page.screenshot({ path: path.join(proofDir, "media-batch-skeletons.png") });
       }
 
@@ -602,7 +604,9 @@ suite.define(() => {
   ] as const)(
     "renders a $name image through the ticketed media route",
     async ({ source, workspaceDir, screenshotName }) => {
-      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim()
+        ? suite.artifactDir
+        : undefined;
       const context = await suite.newBrowserContext({
         locale: "en-US",
         serviceWorkers: "block",
@@ -670,7 +674,6 @@ suite.define(() => {
           )
           .toBe(1);
         if (artifactDir) {
-          await mkdir(artifactDir, { recursive: true });
           await page.screenshot({
             fullPage: true,
             path: `${artifactDir}/${screenshotName}.png`,
@@ -889,7 +892,7 @@ suite.define(() => {
         revokedBlobUrls: finalProof.revoked.length,
       };
       if (captureUiProofEnabled) {
-        await mkdir(managedImageCacheProofDir, { recursive: true });
+        const managedImageCacheProofDir = path.join(suite.artifactDir, "managed-image-cache");
         await page.evaluate((summary) => {
           const panel = document.createElement("pre");
           panel.setAttribute("data-managed-image-cache-proof", "true");

--- a/ui/src/e2e/chat-flow.messaging.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.messaging.e2e.test.ts
@@ -1,10 +1,8 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import {
   captureUiProofEnabled,
-  channelStopProofDir,
   chatSessionListResponse,
   controlUiSessionUrl,
   createChatFlowE2eSuite,
@@ -872,7 +870,7 @@ suite.define(() => {
       await expect.poll(() => page.getByRole("listbox").count()).toBe(0);
       expect(await composer.inputValue()).toBe("");
       if (captureUiProofEnabled) {
-        await mkdir(channelStopProofDir, { recursive: true });
+        const channelStopProofDir = path.join(suite.artifactDir, "channel-stop");
         await page.screenshot({
           path: path.join(channelStopProofDir, "stopped.png"),
           fullPage: true,

--- a/ui/src/e2e/chat-flow.model-picker-refresh.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.model-picker-refresh.e2e.test.ts
@@ -11,14 +11,16 @@ import {
 const suite = createChatFlowE2eSuite();
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "model-picker-refresh");
 
 async function screenshot(page: Page, name: string) {
   if (!captureUiProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
-  await page.screenshot({ animations: "disabled", path: path.join(proofDir, name) });
+  await mkdir(path.join(suite.artifactDir, "model-picker-refresh"), { recursive: true });
+  await page.screenshot({
+    animations: "disabled",
+    path: path.join(path.join(suite.artifactDir, "model-picker-refresh"), name),
+  });
 }
 
 suite.define(() => {
@@ -28,7 +30,12 @@ suite.define(() => {
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       ...(captureUiProof
-        ? { recordVideo: { dir: proofDir, size: { height: 900, width: 1280 } } }
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "model-picker-refresh"),
+              size: { height: 900, width: 1280 },
+            },
+          }
         : {}),
     });
     const page = await context.newPage();

--- a/ui/src/e2e/chat-flow.model-switch-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.model-switch-reasoning.e2e.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   chatSessionListResponse,
   createChatFlowE2eSuite,
@@ -119,7 +120,10 @@ suite.define(() => {
       });
       await expect.poll(() => page.getByText(/not supported for/u).count()).toBe(0);
 
-      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = artifactDirParent
+        ? createControlUiE2eArtifactDir("chat-flow.model-switch-reasoning", artifactDirParent)
+        : undefined;
       if (artifactDir) {
         await page.screenshot({
           path: `${artifactDir}/model-thinking-sync.png`,

--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -1,5 +1,6 @@
 import { expect, it } from "vitest";
 import { t } from "../i18n/lib/translate.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   chatSessionListResponse,
   createChatFlowE2eSuite,
@@ -484,7 +485,10 @@ suite.define(() => {
         },
       ]);
 
-      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = artifactDirParent
+        ? createControlUiE2eArtifactDir("chat-flow.models-reasoning", artifactDirParent)
+        : undefined;
       if (artifactDir) {
         await menu.screenshot({
           animations: "disabled",
@@ -682,7 +686,10 @@ suite.define(() => {
   });
 
   it("shows one canonical default model with matching inherited reasoning", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactDirParent
+      ? createControlUiE2eArtifactDir("chat-flow.models-reasoning", artifactDirParent)
+      : undefined;
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",

--- a/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.navigation-presentation.e2e.test.ts
@@ -946,7 +946,7 @@ suite.define(() => {
       expect(await link.getAttribute("aria-current")).toBe("page");
       expect(await link.getAttribute("aria-describedby")).toBeNull();
       expect(await link.ariaSnapshot()).toContain(`link "${readableTitle}"`);
-      await captureSessionAccessibilityProof(page, "after-derived-title");
+      await captureSessionAccessibilityProof(suite, page, "after-derived-title");
 
       const listCountBeforePatch = (await gateway.getRequests("sessions.list")).length;
       await row.hover();
@@ -966,7 +966,7 @@ suite.define(() => {
       await expect.poll(() => label.textContent()).toBe(readableTitle);
       expect(await link.getAttribute("aria-current")).toBe("page");
       expect(await link.ariaSnapshot()).toContain(`link "${readableTitle}"`);
-      await captureSessionAccessibilityProof(page, "after-patch-refresh");
+      await captureSessionAccessibilityProof(suite, page, "after-patch-refresh");
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/e2e/chat-flow.pending-settings.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.pending-settings.e2e.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { expect, it } from "vitest";
 import {
   captureUiProofEnabled,
@@ -104,7 +105,7 @@ suite.define(() => {
   it("dispatches after its settings refresh while a later roster refresh is still pending", async () => {
     const context = await suite.newBrowserContext({
       ...(captureUiProofEnabled
-        ? { recordVideo: { dir: ".artifacts/send-settings-wait/video" } }
+        ? { recordVideo: { dir: path.join(suite.artifactDir, "send-settings-wait", "video") } }
         : {}),
       locale: "en-US",
       serviceWorkers: "block",
@@ -158,7 +159,9 @@ suite.define(() => {
         .getByText("Settings applied and message delivered.")
         .waitFor();
       if (captureUiProofEnabled) {
-        await page.screenshot({ path: ".artifacts/send-settings-wait/browser-after.png" });
+        await page.screenshot({
+          path: path.join(suite.artifactDir, "send-settings-wait", "browser-after.png"),
+        });
       }
       await gateway.resolveDeferred("sessions.list");
     } finally {

--- a/ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.queue-edit.e2e.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   createChatFlowE2eSuite,
   expectRequestCountStable,
@@ -160,7 +161,10 @@ suite.define(() => {
   });
 
   it("keeps edit, remove, and reorder outcomes exact through reconnect", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactDirParent
+      ? createControlUiE2eArtifactDir("chat-flow.queue-edit", artifactDirParent)
+      : undefined;
     const context = await suite.newBrowserContext({
       locale: "en-US",
       ...(artifactDir

--- a/ui/src/e2e/chat-flow.queue-reorder.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.queue-reorder.e2e.test.ts
@@ -10,12 +10,6 @@ import {
 const suite = createChatFlowE2eSuite();
 
 const QUEUED = ["review the migration", "then update the docs", "finally run the smoke"] as const;
-const failureReloadProofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "queue-reorder-failure-reload",
-);
 
 suite.define(() => {
   it("reorders offline queued messages from the keyboard-focused handle", async () => {
@@ -65,7 +59,9 @@ suite.define(() => {
 
   it("keeps the queue order consistent through a reload after a mid-reorder storage failure", async () => {
     if (captureUiProofEnabled) {
-      await mkdir(failureReloadProofDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "queue-reorder-failure-reload"), {
+        recursive: true,
+      });
     }
     const context = await suite.newBrowserContext({
       locale: "en-US",
@@ -102,7 +98,9 @@ suite.define(() => {
       const queueText = () => page.locator(".chat-queue__item .chat-queue__text").allTextContents();
       expect(await queueText()).toEqual([...QUEUED]);
       if (captureUiProofEnabled) {
-        await page.screenshot({ path: `${failureReloadProofDir}/01-queued-before-failure.png` });
+        await page.screenshot({
+          path: `${path.join(suite.artifactDir, "queue-reorder-failure-reload")}/01-queued-before-failure.png`,
+        });
       }
 
       // Break durable storage for the rest of this page's lifetime, then attempt
@@ -126,7 +124,7 @@ suite.define(() => {
       expect(await queueText()).toEqual([...QUEUED]);
       if (captureUiProofEnabled) {
         await page.screenshot({
-          path: `${failureReloadProofDir}/02-order-unchanged-after-failure.png`,
+          path: `${path.join(suite.artifactDir, "queue-reorder-failure-reload")}/02-order-unchanged-after-failure.png`,
         });
       }
 
@@ -173,7 +171,7 @@ suite.define(() => {
       expect(await queueText()).toEqual([...QUEUED]);
       if (captureUiProofEnabled) {
         await page.screenshot({
-          path: `${failureReloadProofDir}/03-consistent-order-after-reload.png`,
+          path: `${path.join(suite.artifactDir, "queue-reorder-failure-reload")}/03-consistent-order-after-reload.png`,
         });
       }
     } finally {

--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -14,36 +14,23 @@ import {
 } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
-const terminalMetadataProofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "remote-session-sidebar-metadata",
-);
-const sessionSecondRowProofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "session-status-second-row-implementation",
-);
-const subtitleStabilityProofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "sidebar-subtitle-stability",
-);
 
 suite.define(() => {
   it("keeps a running subtitle and row height stable when its session is opened", async () => {
     if (captureUiProofEnabled) {
-      await mkdir(subtitleStabilityProofDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "sidebar-subtitle-stability"), { recursive: true });
     }
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       ...(captureUiProofEnabled
-        ? { recordVideo: { dir: subtitleStabilityProofDir, size: { height: 900, width: 1280 } } }
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "sidebar-subtitle-stability"),
+              size: { height: 900, width: 1280 },
+            },
+          }
         : {}),
     });
     const page = await context.newPage();
@@ -100,7 +87,10 @@ suite.define(() => {
       if (captureUiProofEnabled) {
         await page.waitForTimeout(800);
         await secondRow.screenshot({
-          path: path.join(subtitleStabilityProofDir, "01-running-before-open.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "sidebar-subtitle-stability"),
+            "01-running-before-open.png",
+          ),
         });
       }
 
@@ -116,14 +106,20 @@ suite.define(() => {
       if (captureUiProofEnabled) {
         await page.waitForTimeout(800);
         await secondRow.screenshot({
-          path: path.join(subtitleStabilityProofDir, "02-running-after-open.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "sidebar-subtitle-stability"),
+            "02-running-after-open.png",
+          ),
         });
       }
     } finally {
       await suite.closeBrowserContext(context);
       if (proofVideo) {
         await proofVideo.saveAs(
-          path.join(subtitleStabilityProofDir, "sidebar-subtitle-stability.webm"),
+          path.join(
+            path.join(suite.artifactDir, "sidebar-subtitle-stability"),
+            "sidebar-subtitle-stability.webm",
+          ),
         );
       }
     }
@@ -131,14 +127,21 @@ suite.define(() => {
 
   it("replaces an intermediate running subtitle with the unread final digest", async () => {
     if (captureUiProofEnabled) {
-      await mkdir(terminalMetadataProofDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "remote-session-sidebar-metadata"), {
+        recursive: true,
+      });
     }
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       ...(captureUiProofEnabled
-        ? { recordVideo: { dir: terminalMetadataProofDir, size: { height: 900, width: 1280 } } }
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "remote-session-sidebar-metadata"),
+              size: { height: 900, width: 1280 },
+            },
+          }
         : {}),
     });
     const page = await context.newPage();
@@ -198,7 +201,10 @@ suite.define(() => {
       if (captureUiProofEnabled) {
         await page.screenshot({
           fullPage: true,
-          path: path.join(terminalMetadataProofDir, "01-running-subtitle.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "remote-session-sidebar-metadata"),
+            "01-running-subtitle.png",
+          ),
         });
       }
       await gateway.setMethodResponse("sessions.list", completed);
@@ -223,7 +229,10 @@ suite.define(() => {
       if (captureUiProofEnabled) {
         await page.screenshot({
           fullPage: true,
-          path: path.join(terminalMetadataProofDir, "02-final-reply-subtitle.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "remote-session-sidebar-metadata"),
+            "02-final-reply-subtitle.png",
+          ),
         });
       }
       const listRequests = await gateway.getRequests("sessions.list");
@@ -328,14 +337,21 @@ suite.define(() => {
 
   it("keeps session titles on the first line and collapses rows that have no second line", async () => {
     if (captureUiProofEnabled) {
-      await mkdir(sessionSecondRowProofDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "session-status-second-row-implementation"), {
+        recursive: true,
+      });
     }
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       ...(captureUiProofEnabled
-        ? { recordVideo: { dir: sessionSecondRowProofDir, size: { height: 900, width: 1280 } } }
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "session-status-second-row-implementation"),
+              size: { height: 900, width: 1280 },
+            },
+          }
         : {}),
     });
     const page = await context.newPage();
@@ -407,7 +423,10 @@ suite.define(() => {
       expect(await busyRow.getAttribute("class")).toContain("sidebar-recent-session--single-line");
       if (captureUiProofEnabled) {
         await page.locator(".shell-nav").screenshot({
-          path: path.join(sessionSecondRowProofDir, "00-default-hidden-preview.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "session-status-second-row-implementation"),
+            "00-default-hidden-preview.png",
+          ),
         });
       }
       await page.locator(".sidebar-session-toolbar .sidebar-session-sort").click();
@@ -442,7 +461,10 @@ suite.define(() => {
         if (captureUiProofEnabled) {
           await page.locator(".shell-nav").screenshot({
             animations: "disabled",
-            path: path.join(sessionSecondRowProofDir, `indicators-${colorScheme}.png`),
+            path: path.join(
+              path.join(suite.artifactDir, "session-status-second-row-implementation"),
+              `indicators-${colorScheme}.png`,
+            ),
           });
         }
       }
@@ -462,11 +484,17 @@ suite.define(() => {
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
-            path: path.join(sessionSecondRowProofDir, `01-second-row-endcap-${sidebarWidth}.png`),
+            path: path.join(
+              path.join(suite.artifactDir, "session-status-second-row-implementation"),
+              `01-second-row-endcap-${sidebarWidth}.png`,
+            ),
           });
           await shellNav.screenshot({
             animations: "disabled",
-            path: path.join(sessionSecondRowProofDir, `01-sidebar-${sidebarWidth}.png`),
+            path: path.join(
+              path.join(suite.artifactDir, "session-status-second-row-implementation"),
+              `01-sidebar-${sidebarWidth}.png`,
+            ),
           });
         }
         badgeSizes.push(
@@ -586,7 +614,10 @@ suite.define(() => {
       if (captureUiProofEnabled) {
         await shellNav.screenshot({
           animations: "disabled",
-          path: path.join(sessionSecondRowProofDir, "03-unread-hover.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "session-status-second-row-implementation"),
+            "03-unread-hover.png",
+          ),
         });
       }
       await unreadDot.waitFor({ state: "hidden" });
@@ -624,7 +655,10 @@ suite.define(() => {
       if (captureUiProofEnabled) {
         await page.screenshot({
           fullPage: true,
-          path: path.join(sessionSecondRowProofDir, "02-hover-actions.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "session-status-second-row-implementation"),
+            "02-hover-actions.png",
+          ),
         });
       }
       await plainRow.waitFor();

--- a/ui/src/e2e/chat-flow.streaming.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.streaming.e2e.test.ts
@@ -1,8 +1,8 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import type { ChatHost } from "../pages/chat/chat-send-contract.ts";
 import { CHAT_TRANSCRIPT_END_THRESHOLD_PX } from "../pages/chat/scroll.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   chatThreadDistanceFromBottom,
   createChatFlowE2eSuite,
@@ -22,7 +22,10 @@ suite.define(() => {
     { label: "desktop hover", mobile: false, viewport: { height: 900, width: 1280 } },
     { label: "mobile tap", mobile: true, viewport: { height: 844, width: 390 } },
   ])("shows turn metadata only after completion on $label", async ({ mobile, viewport }) => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactDirParent
+      ? createControlUiE2eArtifactDir("chat-flow.streaming", artifactDirParent)
+      : undefined;
     const context = await suite.newBrowserContext({
       hasTouch: mobile,
       isMobile: mobile,
@@ -55,7 +58,6 @@ suite.define(() => {
             : { opacity: "1", pointerEvents: "auto" },
         );
       if (artifactDir && !mobile) {
-        await mkdir(artifactDir, { recursive: true });
         await page.screenshot({
           fullPage: true,
           path: path.join(artifactDir, "before-user-follow-up-actions-visible.png"),
@@ -152,7 +154,10 @@ suite.define(() => {
   });
 
   it("keeps a bottom-anchored transcript pinned while the composer grows", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactDirParent
+      ? createControlUiE2eArtifactDir("chat-flow.streaming", artifactDirParent)
+      : undefined;
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -194,7 +199,6 @@ suite.define(() => {
         ).toBeLessThanOrEqual(CHAT_TRANSCRIPT_END_THRESHOLD_PX);
       }
       if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
         await page.screenshot({
           fullPage: true,
           path: path.join(artifactDir, "composer-resize-pinned.png"),
@@ -354,7 +358,10 @@ suite.define(() => {
   ])(
     "keeps streamed text visible when a chat error terminates the turn on $label",
     async ({ label, viewport }) => {
-      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDirParent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = artifactDirParent
+        ? createControlUiE2eArtifactDir("chat-flow.streaming", artifactDirParent)
+        : undefined;
       const context = await suite.newBrowserContext({
         locale: "en-US",
         serviceWorkers: "block",
@@ -434,7 +441,6 @@ suite.define(() => {
           await page.locator(".chat-thread-inner").getByText(partialText, { exact: true }).count(),
         ).toBe(1);
         if (artifactDir) {
-          await mkdir(artifactDir, { recursive: true });
           await page.screenshot({ path: path.join(artifactDir, `terminal-partial-${label}.png`) });
         }
         const alert = page.locator(".chat-error");

--- a/ui/src/e2e/chat-flow.test-support.ts
+++ b/ui/src/e2e/chat-flow.test-support.ts
@@ -23,25 +23,7 @@ export {
   pauseVirtualClock,
 };
 
-export const managedImageCacheProofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "managed-image-cache",
-);
-export const channelStopProofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "channel-stop",
-);
 export const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const sessionAccessibilityProofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "session-accessibility",
-);
 
 export function createChatFlowE2eSuite() {
   return createControlUiE2eSuite({
@@ -178,11 +160,15 @@ export async function scrollChatThreadToTop(page: Page): Promise<void> {
   });
 }
 
-export async function captureSessionAccessibilityProof(page: Page, name: string): Promise<void> {
+export async function captureSessionAccessibilityProof(
+  owner: { readonly artifactDir: string },
+  page: Page,
+  name: string,
+): Promise<void> {
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(sessionAccessibilityProofDir, { recursive: true });
+  const sessionAccessibilityProofDir = path.join(owner.artifactDir, "session-accessibility");
   const sidebar = page.locator("openclaw-app-sidebar");
   await page.screenshot({
     fullPage: true,

--- a/ui/src/e2e/chat-goal-elapsed.e2e.test.ts
+++ b/ui/src/e2e/chat-goal-elapsed.e2e.test.ts
@@ -1,19 +1,21 @@
 // Real-browser proof of frozen goal timing on the chat composer.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createControlUiE2eSuite({ name: "Control UI goal elapsed time" });
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const artifactDir = path.resolve(".artifacts/control-ui-e2e/goal-elapsed");
+let artifactDir: string;
+beforeEach(() => {
+  if (captureProof) {
+    artifactDir = createControlUiE2eArtifactDir("goal-elapsed");
+  }
+});
 
 suite.define(() => {
   it("shows a paused goal's frozen duration before and after opening details and reloading", async () => {
-    if (captureProof) {
-      await mkdir(artifactDir, { recursive: true });
-    }
     await suite.withPage(
       {
         colorScheme: "light",

--- a/ui/src/e2e/chat-guardian-review.e2e.test.ts
+++ b/ui/src/e2e/chat-guardian-review.e2e.test.ts
@@ -1,6 +1,6 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { requireRecord, requireString } from "./chat-flow.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -10,14 +10,16 @@ const suite = createControlUiE2eSuite({
   trackBrowserContexts: true,
 });
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts/control-ui-e2e/codex-guardian-review");
+let proofDir: string;
+beforeEach(() => {
+  if (captureProof) {
+    proofDir = createControlUiE2eArtifactDir("codex-guardian-review");
+  }
+});
 const viewport = { height: 900, width: 1280 };
 
 suite.define(() => {
   it("shows and settles a strict Guardian review in the active chat", async () => {
-    if (captureProof) {
-      await mkdir(proofDir, { recursive: true });
-    }
     await suite.withPage(
       {
         locale: "en-US",

--- a/ui/src/e2e/chat-header-axis.e2e.test.ts
+++ b/ui/src/e2e/chat-header-axis.e2e.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import {
@@ -248,15 +248,10 @@ suite.define(() => {
       await icon.waitFor();
       await icon.locator("svg").waitFor();
       await icon.evaluate((element) => element.setAttribute("data-recovery-host", "mounted"));
-      const proofDir = path.join(
-        process.cwd(),
-        ".artifacts",
-        "control-ui-e2e",
-        "workspace-icon-recovery",
-      );
       if (captureUiProofEnabled) {
-        await mkdir(proofDir, { recursive: true });
-        await page.screenshot({ path: path.join(proofDir, "fallback.png") });
+        await page.screenshot({
+          path: path.join(suite.artifactDir, "workspace-icon-recovery", "fallback.png"),
+        });
       }
 
       await icon.locator(".workspace-icon").waitFor({ timeout: 10_000 });
@@ -264,7 +259,9 @@ suite.define(() => {
       expect(requests).toBe(2);
       expect(await icon.getAttribute("data-recovery-host")).toBe("mounted");
       if (captureUiProofEnabled) {
-        await page.screenshot({ path: path.join(proofDir, "recovered.png") });
+        await page.screenshot({
+          path: path.join(suite.artifactDir, "workspace-icon-recovery", "recovered.png"),
+        });
       }
     } finally {
       await suite.closeBrowserContext(context);

--- a/ui/src/e2e/chat-header-owner-presence.capture.e2e.test.ts
+++ b/ui/src/e2e/chat-header-owner-presence.capture.e2e.test.ts
@@ -1,6 +1,6 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -9,15 +9,14 @@ const suite = createControlUiE2eSuite({
   startServerBeforeBrowser: true,
 });
 
-const outputDir = path.resolve(
-  process.cwd(),
-  process.env.OPENCLAW_CHAT_HEADER_CAPTURE_OUTPUT_DIR ??
-    ".artifacts/control-ui-e2e/chat-header-owner-presence",
-);
 suite.define(() => {
   it.each(["chat", "dashboard"] as const)(
     "deduplicates participants watching the %s",
     async (face) => {
+      const outputDir = createControlUiE2eArtifactDir(
+        "chat-header-owner-presence",
+        process.env.OPENCLAW_CHAT_HEADER_CAPTURE_OUTPUT_DIR,
+      );
       await suite.withPage(
         {
           locale: "en-US",
@@ -138,7 +137,6 @@ suite.define(() => {
           if (!clip) {
             throw new Error("Chat header did not expose a screenshot bounding box");
           }
-          await mkdir(outputDir, { recursive: true });
           await page.screenshot({ animations: "disabled", clip, path: screenshotPath });
           process.stdout.write(`Chat header screenshot: ${screenshotPath}\n`);
 

--- a/ui/src/e2e/chat-header-session-outcomes.e2e.test.ts
+++ b/ui/src/e2e/chat-header-session-outcomes.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { beforeAll, expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   chatSessionListResponse,
   controlUiSessionPath,
@@ -12,12 +12,12 @@ import {
 
 const suite = createChatFlowE2eSuite();
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "header-outcomes-followup",
-);
+let proofDir: string;
+beforeEach(() => {
+  if (captureProof) {
+    proofDir = createControlUiE2eArtifactDir("header-outcomes-followup");
+  }
+});
 
 async function capture(page: Page, name: string): Promise<void> {
   if (captureProof) {
@@ -97,12 +97,6 @@ async function startPlacementReclaim(
 }
 
 suite.define(() => {
-  beforeAll(async () => {
-    if (captureProof) {
-      await mkdir(proofDir, { recursive: true });
-    }
-  });
-
   it("does not resurrect a reveal failure after navigating away", async () => {
     const context = await suite.newBrowserContext(proofContextOptions());
     const page = await context.newPage();

--- a/ui/src/e2e/chat-heartbeat-activity-rollup.e2e.test.ts
+++ b/ui/src/e2e/chat-heartbeat-activity-rollup.e2e.test.ts
@@ -1,7 +1,15 @@
 // Control UI E2E covers pooling reply-less wake activity (heartbeats) into one rollup row.
-import fs from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+
+let artifactDir: string | undefined;
+beforeEach(() => {
+  const parent = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+  artifactDir = parent
+    ? createControlUiE2eArtifactDir("chat-heartbeat-activity-rollup", parent)
+    : undefined;
+});
 import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { waitForChatScrollIdle } from "./chat-flow.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -12,11 +20,9 @@ const suite = createControlUiE2eSuite({
 });
 
 async function captureProof(page: import("playwright").Page, name: string) {
-  const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
   if (!artifactDir) {
     return;
   }
-  await fs.mkdir(artifactDir, { recursive: true });
   await page.screenshot({ path: path.join(artifactDir, `${name}.png`), fullPage: true });
 }
 

--- a/ui/src/e2e/chat-history-stale-geometry.e2e.test.ts
+++ b/ui/src/e2e/chat-history-stale-geometry.e2e.test.ts
@@ -1,10 +1,10 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import {
   CHAT_SNAPSHOT_DB_NAME,
   CHAT_SNAPSHOT_STORE_NAME,
 } from "../pages/chat/session-snapshot-database.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   createChatFlowE2eSuite,
   installMockGateway,
@@ -27,10 +27,10 @@ function historyMessage(seq: number, text: string) {
 
 suite.define(() => {
   it("discards stale transcript geometry before restored history bootstrap", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-    if (artifactDir) {
-      await fs.mkdir(artifactDir, { recursive: true });
-    }
+    const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("chat-history-stale-geometry", artifactRoot)
+      : undefined;
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",

--- a/ui/src/e2e/chat-image-lightbox.e2e.test.ts
+++ b/ui/src/e2e/chat-image-lightbox.e2e.test.ts
@@ -1,8 +1,9 @@
-import { mkdir, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { finishElementAnimations } from "../test-helpers/animations.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -17,7 +18,12 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "image-lightbox");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    proofDir = createControlUiE2eArtifactDir("image-lightbox");
+  }
+});
 
 let server: ControlUiE2eServer;
 let browser: Browser;
@@ -57,9 +63,6 @@ describeControlUiE2e("Control UI image lightbox", () => {
     const banner = await readFile(path.join(process.cwd(), "docs/assets/openclaw-banner-dark.png"));
     const bannerBase64 = banner.toString("base64");
     const dataUrl = `data:image/png;base64,${bannerBase64}`;
-    if (captureUiProofEnabled) {
-      await mkdir(proofDir, { recursive: true });
-    }
     const context = await newContext({
       locale: "en-US",
       recordVideo: captureUiProofEnabled

--- a/ui/src/e2e/chat-large-paste-99213.e2e.test.ts
+++ b/ui/src/e2e/chat-large-paste-99213.e2e.test.ts
@@ -1,10 +1,11 @@
 // Control UI regression proof for #99213: paste a large screenshot-like PNG through the
 // real chat composer and verify chat.send receives it without overflowing base64 handling.
-import { copyFile, mkdir, rm, writeFile } from "node:fs/promises";
+import { copyFile, rm, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   controlUiE2eWaitTimeoutMs,
@@ -18,7 +19,6 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/chat-large-paste-99213");
 const viewport = { height: 900, width: 1280 };
 
 let server: ControlUiE2eServer;
@@ -113,11 +113,8 @@ function toBase64(bytes: Uint8Array): string {
   return Buffer.from(bytes).toString("base64");
 }
 
-async function newRecordedPage(label: string): Promise<RecordedPage> {
-  await mkdir(artifactDir, { recursive: true });
-  const rawVideoDir = path.join(artifactDir, `${label}-raw`);
-  await rm(rawVideoDir, { force: true, recursive: true });
-  await mkdir(rawVideoDir, { recursive: true });
+async function newRecordedPage(artifactDir: string, label: string): Promise<RecordedPage> {
+  const rawVideoDir = createControlUiE2eArtifactDir(`${label}-raw`, artifactDir);
   const browser = await chromium.launch({ executablePath: chromiumExecutablePath });
   let context: BrowserContext | undefined;
   let page: Page | undefined;
@@ -139,12 +136,15 @@ async function newRecordedPage(label: string): Promise<RecordedPage> {
     await page?.close().catch(() => {});
     await context?.close().catch(() => {});
     await browser.close().catch(() => {});
-    await rm(rawVideoDir, { force: true, recursive: true });
     throw error;
   }
 }
 
-async function closeRecordedPage(recorded: RecordedPage, label: string): Promise<string[]> {
+async function closeRecordedPage(
+  recorded: RecordedPage,
+  artifactDir: string,
+  label: string,
+): Promise<string[]> {
   const video = recorded.page.video();
   const videos: string[] = [];
   try {
@@ -154,10 +154,11 @@ async function closeRecordedPage(recorded: RecordedPage, label: string): Promise
       const videoPath = path.join(artifactDir, `${label}.webm`);
       await copyFile(rawVideoPath, videoPath);
       videos.push(videoPath);
+      // Failed finalization leaves the raw recording available for inspection.
+      await rm(recorded.rawVideoDir, { force: true, recursive: true });
     }
   } finally {
     await recorded.browser.close().catch(() => {});
-    await rm(recorded.rawVideoDir, { force: true, recursive: true });
   }
   return videos;
 }
@@ -177,13 +178,12 @@ describeControlUiE2e("Control UI #99213 large screenshot paste proof", () => {
   });
 
   it("sends a roughly 2 MB PNG without overlapping transcript rows", async () => {
-    await rm(artifactDir, { force: true, recursive: true });
-    await mkdir(artifactDir, { recursive: true });
+    const artifactDir = createControlUiE2eArtifactDir("chat-large-paste-99213");
     const pngBytes = createLargePngBytes(1_901_669);
     const imageBase64 = toBase64(pngBytes);
     const dataUrl = `data:image/png;base64,${imageBase64}`;
     const prompt = "proof: large Control UI clipboard image";
-    const recorded = await newRecordedPage("large-paste");
+    const recorded = await newRecordedPage(artifactDir, "large-paste");
     const screenshots: string[] = [];
     let videos: string[];
 
@@ -270,7 +270,7 @@ describeControlUiE2e("Control UI #99213 large screenshot paste proof", () => {
       await recorded.page.screenshot({ fullPage: true, path: sentScreenshot });
       screenshots.push(sentScreenshot);
     } finally {
-      videos = await closeRecordedPage(recorded, "large-paste");
+      videos = await closeRecordedPage(recorded, artifactDir, "large-paste");
     }
 
     const summary = {

--- a/ui/src/e2e/chat-live-final-order.e2e.test.ts
+++ b/ui/src/e2e/chat-live-final-order.e2e.test.ts
@@ -1,6 +1,6 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   createChatFlowE2eSuite,
   installMockGateway,
@@ -11,10 +11,10 @@ const suite = createChatFlowE2eSuite();
 
 suite.define(() => {
   it("keeps multiple live replies after their delayed prompt before history catches up", async () => {
-    const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
-    if (artifactDir) {
-      await mkdir(artifactDir, { recursive: true });
-    }
+    const artifactRoot = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("chat-live-final-order", artifactRoot)
+      : undefined;
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -233,9 +233,11 @@ suite.define(() => {
         )
         .toBe(true);
 
-      const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactRoot = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = artifactRoot
+        ? createControlUiE2eArtifactDir("chat-live-final-order", artifactRoot)
+        : undefined;
       if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
         await page.screenshot({
           path: path.join(artifactDir, "live-final-transcript-order.png"),
           fullPage: true,

--- a/ui/src/e2e/chat-markdown-table-interactions.e2e.test.ts
+++ b/ui/src/e2e/chat-markdown-table-interactions.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -15,10 +15,12 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const artifactDir = path.resolve(
-  process.cwd(),
-  ".artifacts/control-ui-e2e/chat-markdown-table-interactions",
-);
+let artifactDir: string;
+beforeEach(() => {
+  if (captureProof) {
+    artifactDir = createControlUiE2eArtifactDir("chat-markdown-table-interactions");
+  }
+});
 
 const wideTable = `| Service | Owner | Region | Status | Version | Deploy | Incidents | Notes |
 | --- | --- | --- | --- | --- | --- | --- | --- |
@@ -31,9 +33,6 @@ describeControlUiE2e("Control UI Markdown table interactions", () => {
   beforeAll(async () => {
     if (!chromiumAvailable) {
       throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    if (captureProof) {
-      await mkdir(artifactDir, { recursive: true });
     }
     server = await startControlUiE2eServer(undefined, { source: true });
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });

--- a/ui/src/e2e/chat-message-actions.e2e.test.ts
+++ b/ui/src/e2e/chat-message-actions.e2e.test.ts
@@ -1,8 +1,8 @@
 // Real-browser proof for inline and context-menu chat message actions.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type Locator, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -16,7 +16,12 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/chat-message-actions");
+let artifactDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    artifactDir = createControlUiE2eArtifactDir("chat-message-actions");
+  }
+});
 
 // Neutral filler line repeated to push the fixture past the transport
 // preview limit without embedding stale implementation narrative; the
@@ -153,9 +158,6 @@ describeControlUiE2e("Control UI chat message actions", () => {
   beforeAll(async () => {
     if (!chromiumAvailable) {
       throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    if (captureUiProof) {
-      await mkdir(artifactDir, { recursive: true });
     }
     server = await startControlUiE2eServer();
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });

--- a/ui/src/e2e/chat-model-controls.e2e.test.ts
+++ b/ui/src/e2e/chat-model-controls.e2e.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -129,7 +130,10 @@ suite.define(() => {
           await expect
             .poll(() => model.evaluate((node) => node === document.activeElement))
             .toBe(true);
-          const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+          const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+          const artifactDir = artifactRoot
+            ? createControlUiE2eArtifactDir("chat-model-controls", artifactRoot)
+            : undefined;
           if (artifactDir && [320, 393, 560, 1280].includes(width)) {
             await page.screenshot({
               path: `${artifactDir}/${route}-model-effort-${width}.png`,
@@ -209,7 +213,10 @@ suite.define(() => {
               ),
             )
             .toBe(true);
-          const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+          const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+          const artifactDir = artifactRoot
+            ? createControlUiE2eArtifactDir("chat-model-controls", artifactRoot)
+            : undefined;
           if (artifactDir) {
             await page.screenshot({
               path: `${artifactDir}/chat-model-effort-split.png`,
@@ -309,7 +316,10 @@ suite.define(() => {
         await expect
           .poll(() => effort.evaluate((node) => node === document.activeElement))
           .toBe(true);
-        const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+        const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+        const artifactDir = artifactRoot
+          ? createControlUiE2eArtifactDir("chat-model-controls", artifactRoot)
+          : undefined;
         if (artifactDir) {
           await page.screenshot({
             path: `${artifactDir}/chat-speed-only-320.png`,

--- a/ui/src/e2e/chat-only-model.e2e.test.ts
+++ b/ui/src/e2e/chat-only-model.e2e.test.ts
@@ -1,14 +1,17 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 const sessionKey = "agent:main:main";
-const proofDir =
-  process.env.OPENCLAW_CAPTURE_UI_PROOF === "1"
-    ? path.join(process.cwd(), ".artifacts", "control-ui-e2e", "chat-only-model")
-    : null;
+let proofDir: string | null;
+beforeEach(() => {
+  proofDir =
+    process.env.OPENCLAW_CAPTURE_UI_PROOF === "1"
+      ? createControlUiE2eArtifactDir("chat-only-model")
+      : null;
+});
 
 const models = [
   {
@@ -59,9 +62,6 @@ function sessionsList(model: string, modelProvider: string) {
 
 suite.define(() => {
   it("explains chat-only models and keeps model switching as the recovery path", async () => {
-    if (proofDir) {
-      await mkdir(proofDir, { recursive: true });
-    }
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",

--- a/ui/src/e2e/chat-panel-reflow.e2e.test.ts
+++ b/ui/src/e2e/chat-panel-reflow.e2e.test.ts
@@ -1,6 +1,6 @@
-import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import {
   activateChatHeaderPanelAction,
@@ -14,7 +14,6 @@ const suite = createControlUiE2eSuite({
   unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
 });
 
-const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/chat-panel-reflow");
 const chatSessionKey = "agent:main:main";
 
 const longReply =
@@ -65,8 +64,7 @@ async function expectMessagesNotToOverlap(page: import("playwright").Page): Prom
 
 suite.define(() => {
   it("keeps transcript rows separate across background-task, file, and diff panel toggles", async () => {
-    await rm(artifactDir, { force: true, recursive: true });
-    await mkdir(artifactDir, { recursive: true });
+    const artifactDir = createControlUiE2eArtifactDir("chat-panel-reflow");
     await suite.withPage(
       {
         locale: "en-US",

--- a/ui/src/e2e/chat-pull-requests.e2e.test.ts
+++ b/ui/src/e2e/chat-pull-requests.e2e.test.ts
@@ -1,10 +1,10 @@
 // Control UI tests cover session pull request chips above the chat composer.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gateway/control-ui-contract.js";
 import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   controlUiSessionUrl,
@@ -20,18 +20,18 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const publicationProofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "github-publication",
-);
-const stackingProofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "pr-chip-stacking",
-);
+let publicationProofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    publicationProofDir = createControlUiE2eArtifactDir("github-publication");
+  }
+});
+let stackingProofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    stackingProofDir = createControlUiE2eArtifactDir("pr-chip-stacking");
+  }
+});
 
 let server: ControlUiE2eServer;
 // Browser contexts preserve test isolation; keep one process warm for this file.
@@ -317,7 +317,6 @@ describeControlUiE2e("session pull request chips", () => {
 
       await overlapLastTranscriptRowWithPullRequestChip(page);
       if (captureUiProof) {
-        await mkdir(stackingProofDir, { recursive: true });
         await page.screenshot({
           animations: "disabled",
           path: path.join(stackingProofDir, `${label}.png`),
@@ -391,9 +390,6 @@ describeControlUiE2e("session pull request chips", () => {
   });
 
   it("publishes through the Gateway and renders the terminal pull request URL", async () => {
-    if (captureUiProof) {
-      await mkdir(publicationProofDir, { recursive: true });
-    }
     const context = await browser.newContext({
       colorScheme: "light",
       locale: "en-US",
@@ -672,7 +668,6 @@ describeControlUiE2e("session pull request chips", () => {
       )
       .toBe("https://github.com/openclaw/openclaw/pull/new/openclaw/rejected-publication");
     if (captureUiProof) {
-      await mkdir(publicationProofDir, { recursive: true });
       await page.screenshot({
         animations: "disabled",
         fullPage: true,
@@ -815,7 +810,6 @@ describeControlUiE2e("session pull request chips", () => {
       .toContain("Start a live agent turn");
     expect(await gateway.getRequests("sessions.github.publish")).toHaveLength(0);
     if (captureUiProof) {
-      await mkdir(publicationProofDir, { recursive: true });
       await page.screenshot({
         animations: "disabled",
         fullPage: true,

--- a/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
+++ b/ui/src/e2e/chat-quota-pill-93041.e2e.test.ts
@@ -1,9 +1,9 @@
 // Real-browser proof + regression for #93041: provider usage from models.authStatus remains
 // available in the desktop composer's context popover. Screenshots go to the ignored artifacts tree.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiE2eWaitTimeoutMs,
   controlUiSessionUrl,
@@ -17,14 +17,10 @@ const suite = createControlUiE2eSuite({
 });
 
 const baseTime = 1_700_000_000_000;
-const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/chat-quota-pill-93041");
+let artifactDir: string;
 const captureOwnershipProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const ownershipProofPhase = process.env.OPENCLAW_UI_PROOF_PHASE?.trim() || "candidate";
-const ownershipProofDir = path.resolve(
-  process.cwd(),
-  ".artifacts/ui-visual-proof/agent-quota-ownership",
-  ownershipProofPhase,
-);
+let ownershipProofDir: string;
 
 const authStatusWithUsage = {
   ts: baseTime,
@@ -333,6 +329,12 @@ async function openVisibleQuotaPopover(page: Page) {
 }
 
 suite.define(() => {
+  beforeEach(() => {
+    artifactDir = createControlUiE2eArtifactDir("chat-quota-pill-93041");
+    if (captureOwnershipProof) {
+      ownershipProofDir = path.join(artifactDir, "agent-quota-ownership", ownershipProofPhase);
+    }
+  });
   it("shows high context pressure without a compact action", async () => {
     const fixture = await openChat(authStatusWithUsage, {
       "sessions.list": highPressureSessions,
@@ -462,9 +464,6 @@ suite.define(() => {
   });
 
   it("binds delayed auth and quota presentation to the selected global agent", async () => {
-    if (captureOwnershipProof) {
-      await mkdir(ownershipProofDir, { recursive: true });
-    }
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -737,7 +736,7 @@ suite.define(() => {
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
-          path: path.join(ownershipProofDir, "03-work-settled.png"),
+          path: path.join(ownershipProofDir, "04-work-quota-popover.png"),
         });
       }
     } finally {

--- a/ui/src/e2e/chat-rail-columns.e2e.test.ts
+++ b/ui/src/e2e/chat-rail-columns.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiBundledSettingsStorageKey,
   controlUiSessionUrl,
@@ -17,8 +17,22 @@ const suite = createControlUiE2eSuite({
 });
 
 const sessionKey = "agent:main:rail-tabs";
-const proofDir = process.env.OPENCLAW_UI_RAIL_PROOF_DIR?.trim();
-const videoDir = process.env.OPENCLAW_UI_RAIL_VIDEO_DIR?.trim();
+const proofDirParent = process.env.OPENCLAW_UI_RAIL_PROOF_DIR?.trim();
+let proofDir: string | undefined;
+beforeEach(() => {
+  proofDir = proofDirParent
+    ? createControlUiE2eArtifactDir("chat-rail-columns", proofDirParent)
+    : undefined;
+});
+const videoDirParent = process.env.OPENCLAW_UI_RAIL_VIDEO_DIR?.trim();
+let videoDir: string | undefined;
+beforeEach(() => {
+  videoDir = videoDirParent
+    ? proofDir && proofDirParent && path.resolve(videoDirParent) === path.resolve(proofDirParent)
+      ? proofDir
+      : createControlUiE2eArtifactDir("chat-rail-columns", videoDirParent)
+    : undefined;
+});
 
 const historyMessages = Array.from({ length: 10 }, (_, index) => ({
   id: `rail-tabs-${index}`,
@@ -276,7 +290,6 @@ async function captureRichPanel(page: Page, name: string) {
   if (!proofDir) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   const clip = await page.evaluate(() => {
     const elements = [
       document.querySelector<HTMLElement>(".chat-pane__header"),

--- a/ui/src/e2e/chat-reply-preview-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-reply-preview-recovery.e2e.test.ts
@@ -1,6 +1,7 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   createChatFlowE2eSuite,
   expectRequestCountStable,
@@ -31,10 +32,10 @@ suite.define(() => {
   ])(
     "settles a $name without repeatedly loading the reply preview",
     async ({ artifact, response }) => {
-      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-      if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
-      }
+      const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = artifactRoot
+        ? createControlUiE2eArtifactDir("chat-reply-preview-recovery", artifactRoot)
+        : undefined;
       const context = await suite.newBrowserContext({
         locale: "en-US",
         ...(artifactDir

--- a/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/chat-run-lifecycle.e2e.test.ts
@@ -1,5 +1,4 @@
 // Control UI E2E tests cover chat run lifecycle behavior through the Gateway WebSocket.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { afterEach, expect, it } from "vitest";
@@ -232,8 +231,7 @@ suite.define(() => {
     expect(await currentPage.locator(".chat-reading-indicator").count()).toBe(0);
     expect(await assistantGroup.getByText("Working…", { exact: true }).count()).toBe(1);
 
-    const artifactDir = path.resolve(".artifacts/control-ui-e2e/chat-single-turn-status");
-    await mkdir(artifactDir, { recursive: true });
+    const artifactDir = path.join(suite.artifactDir, "chat-single-turn-status");
     await currentPage.screenshot({
       path: path.join(artifactDir, "continuing-reply.png"),
       fullPage: true,
@@ -275,11 +273,11 @@ suite.define(() => {
   });
 
   it("restores only the unpersisted assistant response after reconnecting", async () => {
-    const artifactDir = path.resolve(".artifacts/control-ui-e2e/chat-inflight-reconnect");
+    const artifactDir =
+      process.env.OPENCLAW_CAPTURE_UI_PROOF === "1"
+        ? path.join(suite.artifactDir, "chat-inflight-reconnect")
+        : "";
     const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-    if (captureProof) {
-      await mkdir(artifactDir, { recursive: true });
-    }
     const context = await suite.newBrowserContext({
       viewport: { height: 800, width: 1200 },
       ...(captureProof
@@ -586,11 +584,11 @@ suite.define(() => {
   });
 
   it("renders a safe self-abort diagnostic without leaving stale composer status", async () => {
-    const artifactDir = path.resolve(".artifacts/control-ui-e2e/chat-abort-diagnostic");
+    const artifactDir =
+      process.env.OPENCLAW_CAPTURE_UI_PROOF === "1"
+        ? path.join(suite.artifactDir, "chat-abort-diagnostic")
+        : "";
     const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-    if (captureProof) {
-      await mkdir(artifactDir, { recursive: true });
-    }
     const context = await suite.newBrowserContext({ viewport: { height: 800, width: 1200 } });
     const currentPage = await context.newPage();
     page = currentPage;

--- a/ui/src/e2e/chat-session-companion-clear.e2e.test.ts
+++ b/ui/src/e2e/chat-session-companion-clear.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiSessionUrl,
   installMockGateway,
@@ -16,7 +16,13 @@ const suite = createControlUiE2eSuite({
   startServerBeforeBrowser: true,
 });
 
-const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+let artifactDir: string | undefined;
+beforeEach(() => {
+  artifactDir = artifactRoot
+    ? createControlUiE2eArtifactDir("chat-session-companion-clear", artifactRoot)
+    : undefined;
+});
 const answer = "Keep this companion answer visible until the reset succeeds.";
 const initiatingSessionKey = "agent:main:companion-clear";
 const nextSessionKey = "agent:main:companion-next";
@@ -30,9 +36,6 @@ type CompanionSurface = {
 };
 
 async function withCompanion(run: (surface: CompanionSurface) => Promise<void>): Promise<void> {
-  if (artifactDir) {
-    await mkdir(artifactDir, { recursive: true });
-  }
   await suite.withPage(
     {
       locale: "en-US",

--- a/ui/src/e2e/chat-session-diff.e2e.test.ts
+++ b/ui/src/e2e/chat-session-diff.e2e.test.ts
@@ -1,10 +1,10 @@
 // Control UI tests cover the session diff panel (sessions.diff RPC).
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { CONTROL_UI_SESSION_PULL_REQUESTS_CHANGED_EVENT } from "../../../src/gateway/control-ui-contract.js";
 import { SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD } from "../lib/session-pull-requests.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   controlUiBundledSettingsStorageKey,
@@ -25,7 +25,12 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/diff-highlighting");
+let artifactDir: string;
+beforeEach(() => {
+  if (captureProof) {
+    artifactDir = createControlUiE2eArtifactDir("diff-highlighting");
+  }
+});
 
 let server: ControlUiE2eServer;
 // Browser contexts preserve test isolation; keep one process warm for this file.
@@ -607,7 +612,6 @@ describeControlUiE2e("session diff panel", () => {
         ),
     ).toBe(true);
     if (captureProof) {
-      await mkdir(artifactDir, { recursive: true });
       await panelSurface.screenshot({ path: path.join(artifactDir, "unified-light.png") });
     }
 

--- a/ui/src/e2e/chat-session-discussion-toggle.e2e.test.ts
+++ b/ui/src/e2e/chat-session-discussion-toggle.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   controlUiSessionUrl,
@@ -17,12 +17,12 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "session-discussion-toggle",
-);
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("session-discussion-toggle");
+  }
+});
 
 let server: ControlUiE2eServer;
 let browser: Browser;
@@ -41,9 +41,6 @@ describeControlUiE2e("session discussion toggle", () => {
     }
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     server = await startControlUiE2eServer();
-    if (captureUiProof) {
-      await mkdir(proofDir, { recursive: true });
-    }
   });
 
   afterEach(closeOpenContexts);

--- a/ui/src/e2e/chat-side-panel-clearance.e2e.test.ts
+++ b/ui/src/e2e/chat-side-panel-clearance.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiBundledSettingsStorageKey,
   installMockGateway,
@@ -19,7 +19,13 @@ const suite = createControlUiE2eSuite({
 });
 
 const sessionKey = "agent:main:side-panel-clearance";
-const proofDir = process.env.OPENCLAW_UI_RAIL_PROOF_DIR?.trim();
+const proofDirParent = process.env.OPENCLAW_UI_RAIL_PROOF_DIR?.trim();
+let proofDir: string | undefined;
+beforeEach(() => {
+  proofDir = proofDirParent
+    ? createControlUiE2eArtifactDir("chat-side-panel-clearance", proofDirParent)
+    : undefined;
+});
 const limitedScopes = ["operator.read", "operator.write"];
 const historyMessages = [
   {
@@ -196,7 +202,6 @@ async function capturePanel(page: Page, name: string): Promise<void> {
   if (!proofDir) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.screenshot({ fullPage: true, path: path.join(proofDir, `${name}.png`) });
 }
 

--- a/ui/src/e2e/chat-skill-references.e2e.test.ts
+++ b/ui/src/e2e/chat-skill-references.e2e.test.ts
@@ -1,6 +1,7 @@
 // Control UI E2E tests cover composable skill references in the chat composer.
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -10,7 +11,10 @@ const suite = createControlUiE2eSuite({
 
 suite.define(() => {
   it("references multiple skills inside a normal prompt and sends their raw names", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("chat-skill-references", artifactRoot)
+      : undefined;
     await suite.withPage(
       {
         viewport: { width: 1280, height: 900 },

--- a/ui/src/e2e/chat-slash-command-ranking.e2e.test.ts
+++ b/ui/src/e2e/chat-slash-command-ranking.e2e.test.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { text } from "node:stream/consumers";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -13,7 +14,10 @@ suite.define(() => {
   it.each(["/export-session", "/export"])(
     "shows an empty export result and retains staged attachments for %s",
     async (command) => {
-      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = artifactRoot
+        ? createControlUiE2eArtifactDir("chat-slash-command-ranking", artifactRoot)
+        : undefined;
       await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
         const gateway = await installMockGateway(page, { historyMessages: [] });
         const downloads: string[] = [];
@@ -99,7 +103,10 @@ suite.define(() => {
   });
 
   it("keeps visible search results and keyboard selection in relevance order", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("chat-slash-command-ranking", artifactRoot)
+      : undefined;
     await suite.withPage(
       {
         viewport: { width: 1280, height: 900 },

--- a/ui/src/e2e/chat-startup-progress.e2e.test.ts
+++ b/ui/src/e2e/chat-startup-progress.e2e.test.ts
@@ -1,17 +1,19 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
-const proofDir = path.resolve(".artifacts/control-ui-e2e/duplicate-session-naming");
+let proofDir: string;
+beforeEach(() => {
+  if (capture) {
+    proofDir = createControlUiE2eArtifactDir("duplicate-session-naming");
+  }
+});
 const capture = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 
 suite.define(() => {
   it("preserves tool and approval activity received before the send ACK", async () => {
-    if (capture) {
-      await mkdir(proofDir, { recursive: true });
-    }
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -76,9 +78,6 @@ suite.define(() => {
   });
 
   it("retains current startup progress through delayed history", async () => {
-    if (capture) {
-      await mkdir(proofDir, { recursive: true });
-    }
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",

--- a/ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts
+++ b/ui/src/e2e/chat-stream-runtime-budgets.e2e.test.ts
@@ -1,6 +1,7 @@
-import { appendFile, mkdir } from "node:fs/promises";
+import { appendFile } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   createChatFlowE2eSuite,
   installMockGateway,
@@ -92,18 +93,15 @@ type ScopedWindow = Window & {
   };
 };
 
-const metricsArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "stream-runtime-budgets",
-);
+let metricsArtifactDir: string;
+beforeEach(() => {
+  metricsArtifactDir = createControlUiE2eArtifactDir("stream-runtime-budgets");
+});
 
 async function recordBudgetMetrics(
   testName: string,
   metrics: Record<string, number>,
 ): Promise<void> {
-  await mkdir(metricsArtifactDir, { recursive: true });
   await appendFile(
     path.join(metricsArtifactDir, "metrics.jsonl"),
     `${JSON.stringify({ testName, metrics, recordedAt: new Date().toISOString() })}\n`,

--- a/ui/src/e2e/chat-thinking-arguments.e2e.test.ts
+++ b/ui/src/e2e/chat-thinking-arguments.e2e.test.ts
@@ -1,7 +1,7 @@
 // Control UI E2E proves model-aware /think completion in the rendered composer.
-import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -136,9 +136,11 @@ suite.define(() => {
           thinkingLevel: "ultra",
         });
 
-        const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+        const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+        const artifactDir = artifactRoot
+          ? createControlUiE2eArtifactDir("chat-thinking-arguments", artifactRoot)
+          : undefined;
         if (artifactDir) {
-          await fs.mkdir(artifactDir, { recursive: true });
           await page.screenshot({
             path: path.join(artifactDir, `think-arguments-${viewport.name}.png`),
             fullPage: true,

--- a/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
+++ b/ui/src/e2e/chat-tool-turn-outcome.e2e.test.ts
@@ -1,7 +1,15 @@
 // Control UI E2E tests cover autonomous tool-turn outcome rendering.
-import fs from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+
+let artifactDir: string | undefined;
+beforeEach(() => {
+  const parent = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+  artifactDir = parent
+    ? createControlUiE2eArtifactDir("chat-tool-turn-outcome", parent)
+    : undefined;
+});
 import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -21,11 +29,9 @@ function failedTool(timestamp: number) {
 }
 
 async function captureToolActivityProof(page: import("playwright").Page, name: string) {
-  const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
   if (!artifactDir) {
     return;
   }
-  await fs.mkdir(artifactDir, { recursive: true });
   await page.screenshot({ path: path.join(artifactDir, `${name}.png`), fullPage: true });
 }
 
@@ -34,12 +40,10 @@ async function captureFactrowProof(
   activity: import("playwright").Locator,
   theme: "dark" | "light",
 ) {
-  const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
   if (!artifactDir) {
     return;
   }
   const state = process.env.OPENCLAW_FACTROW_PROOF_STATE?.trim() || "after";
-  await fs.mkdir(artifactDir, { recursive: true });
   await page.locator(".chat-main").screenshot({
     path: path.join(artifactDir, `factrow-${state}-${theme}-context.png`),
   });
@@ -67,10 +71,6 @@ suite.define(() => {
   ])(
     "keeps narrated tool details in one contained hierarchy ($name)",
     async ({ colorScheme, height, name, width }) => {
-      const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
-      if (artifactDir) {
-        await fs.mkdir(artifactDir, { recursive: true });
-      }
       const context = await suite.browser.newContext({
         colorScheme,
         locale: "en-US",
@@ -274,10 +274,6 @@ suite.define(() => {
   });
 
   it("pairs a canonical parallel batch and renders per-file patch sections", async () => {
-    const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
-    if (artifactDir) {
-      await fs.mkdir(artifactDir, { recursive: true });
-    }
     const context = await suite.browser.newContext({
       locale: "en-US",
       viewport: { height: 900, width: 1200 },
@@ -780,10 +776,6 @@ suite.define(() => {
       riskLevel,
       userAuthorization,
     }) => {
-      const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
-      if (artifactDir) {
-        await fs.mkdir(artifactDir, { recursive: true });
-      }
       const context = await suite.browser.newContext({
         colorScheme: "dark",
         locale: "en-US",

--- a/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
+++ b/ui/src/e2e/chat-transcript-disclosure-anchor.e2e.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiBundledSettingsStorageKey,
   controlUiSessionUrl,
@@ -130,12 +131,14 @@ suite.define(() => {
   ] as const)(
     "remeasures recovered assistant text after interrupted scrolling ($reducedMotion, $interruption, $recoveryPosition)",
     async ({ reducedMotion, interruption, recoveryPosition }) => {
-      const artifactDir = path.resolve(
-        process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR ??
-          ".artifacts/control-ui-e2e/virtual-sizing/after",
+      const artifactDir = path.join(
+        createControlUiE2eArtifactDir(
+          "virtual-sizing",
+          process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR,
+        ),
+        "after",
         `${reducedMotion}-${interruption}-${recoveryPosition}`,
       );
-      await fs.mkdir(artifactDir, { recursive: true });
       await suite.withPage(
         {
           reducedMotion,
@@ -596,7 +599,10 @@ suite.define(() => {
   });
 
   it("keeps completed-work and tool disclosures anchored on every expand and collapse frame", async () => {
-    const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDirParent = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactDirParent
+      ? createControlUiE2eArtifactDir("chat-transcript-disclosure-anchor", artifactDirParent)
+      : undefined;
     const context = await suite.browser.newContext({
       reducedMotion: "reduce",
       viewport: { height: 800, width: 1400 },
@@ -773,7 +779,6 @@ suite.define(() => {
     traces.workMiddleCollapse = await toggleDisclosureWithFrameTrace(page, middleWorkSummary);
 
     if (artifactDir) {
-      await fs.mkdir(artifactDir, { recursive: true });
       await fs.writeFile(
         path.join(artifactDir, "disclosure-geometry.json"),
         `${JSON.stringify(traces, null, 2)}\n`,
@@ -796,7 +801,10 @@ suite.define(() => {
   });
 
   it("keeps raw tool details anchored at the end and middle of a long transcript", async () => {
-    const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDirParent = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactDirParent
+      ? createControlUiE2eArtifactDir("chat-transcript-disclosure-anchor", artifactDirParent)
+      : undefined;
     const context = await suite.browser.newContext({
       reducedMotion: "reduce",
       viewport: { height: 600, width: 900 },
@@ -896,7 +904,6 @@ suite.define(() => {
     traces.rawDetailsMiddleExpand = await toggleDisclosureWithFrameTrace(page, rawDetailsToggle);
 
     if (artifactDir) {
-      await fs.mkdir(artifactDir, { recursive: true });
       await fs.writeFile(
         path.join(artifactDir, "raw-details-geometry.json"),
         `${JSON.stringify(traces, null, 2)}\n`,

--- a/ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts
+++ b/ui/src/e2e/chat-user-bubble-disclosure.e2e.test.ts
@@ -1,4 +1,3 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import {
@@ -34,15 +33,10 @@ suite.define(() => {
       await page.goto(`${suite.server.baseUrl}chat`);
       const bubble = page.locator(".chat-group.user .chat-bubble");
       await bubble.waitFor({ state: "visible", timeout: 10_000 });
-      const proofDir = path.join(
-        process.cwd(),
-        ".artifacts",
-        "control-ui-e2e",
-        "user-bubble-clamp",
-      );
       if (captureUiProofEnabled) {
-        await mkdir(proofDir, { recursive: true });
-        await bubble.screenshot({ path: path.join(proofDir, "short-message.png") });
+        await bubble.screenshot({
+          path: path.join(suite.artifactDir, "user-bubble-clamp", "short-message.png"),
+        });
       }
 
       expect(await bubble.getByRole("button", { name: "Show more" }).count()).toBe(0);
@@ -88,15 +82,10 @@ suite.define(() => {
       expect(await content.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(
         true,
       );
-      const proofDir = path.join(
-        process.cwd(),
-        ".artifacts",
-        "control-ui-e2e",
-        "user-bubble-clamp",
-      );
       if (captureUiProofEnabled) {
-        await mkdir(proofDir, { recursive: true });
-        await bubble.screenshot({ path: path.join(proofDir, "long-message-collapsed.png") });
+        await bubble.screenshot({
+          path: path.join(suite.artifactDir, "user-bubble-clamp", "long-message-collapsed.png"),
+        });
       }
 
       await toggle.click();

--- a/ui/src/e2e/chat-worked-for-visualization.e2e.test.ts
+++ b/ui/src/e2e/chat-worked-for-visualization.e2e.test.ts
@@ -1,7 +1,15 @@
 // Control UI E2E covers completed-work expansion and persistent visual outcomes.
-import fs from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+
+let artifactDir: string | undefined;
+beforeEach(() => {
+  const parent = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+  artifactDir = parent
+    ? createControlUiE2eArtifactDir("chat-worked-for-visualization", parent)
+    : undefined;
+});
 import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { waitForChatScrollIdle } from "./chat-flow.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -19,11 +27,9 @@ const suite = createControlUiE2eSuite({
 });
 
 async function captureProof(page: import("playwright").Page, name: string) {
-  const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
   if (!artifactDir) {
     return;
   }
-  await fs.mkdir(artifactDir, { recursive: true });
   await page.screenshot({ path: path.join(artifactDir, `${name}.png`), fullPage: true });
 }
 

--- a/ui/src/e2e/child-session-load-errors.e2e.test.ts
+++ b/ui/src/e2e/child-session-load-errors.e2e.test.ts
@@ -84,7 +84,7 @@ suite.define(() => {
             request.params.spawnedBy === parentKey,
         ).length;
       expect(await childRequestCount()).toBe(1);
-      await captureUiProof(page, "child-session-load-error.png");
+      await captureUiProof(suite, page, "child-session-load-error.png");
 
       for (let revision = 1; revision <= 3; revision += 1) {
         const listRequests = (await gateway.getRequests("sessions.list")).length;
@@ -124,7 +124,7 @@ suite.define(() => {
       await page.getByText("Recovered child", { exact: true }).waitFor();
       expect(await childRequestCount()).toBe(2);
       expect(await alert.count()).toBe(0);
-      await captureUiProof(page, "child-session-load-recovered.png");
+      await captureUiProof(suite, page, "child-session-load-recovered.png");
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/claude-sessions.e2e.test.ts
+++ b/ui/src/e2e/claude-sessions.e2e.test.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 import {
@@ -218,9 +218,11 @@ suite.define(() => {
             toggleFocused: true,
           });
 
-        const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+        const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+        const artifactDir = artifactRoot
+          ? createControlUiE2eArtifactDir("claude-sessions", artifactRoot)
+          : undefined;
         if (artifactDir) {
-          await fs.mkdir(artifactDir, { recursive: true });
           await header.screenshot({
             animations: "disabled",
             path: path.join(artifactDir, "catalog-header-pointer-away.png"),
@@ -315,9 +317,11 @@ suite.define(() => {
         chevronOpacity: "0.75",
       });
 
-      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = artifactRoot
+        ? createControlUiE2eArtifactDir("claude-sessions", artifactRoot)
+        : undefined;
       if (artifactDir) {
-        await fs.mkdir(artifactDir, { recursive: true });
         await page.screenshot({
           path: path.join(artifactDir, "native-session-host-groups.png"),
           fullPage: true,
@@ -369,9 +373,11 @@ suite.define(() => {
       await connecting.waitFor();
       expect(await page.locator(".tabstrip-tab.is-connecting").count()).toBe(1);
 
-      const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+      const artifactDir = artifactRoot
+        ? createControlUiE2eArtifactDir("claude-sessions", artifactRoot)
+        : undefined;
       if (artifactDir) {
-        await fs.mkdir(artifactDir, { recursive: true });
         await page.screenshot({ path: path.join(artifactDir, "claude-terminal-connecting.png") });
       }
 
@@ -614,7 +620,10 @@ suite.define(() => {
     await expect
       .poll(() => page.getByText("This session is on a paired device and is view-only.").count())
       .toBe(1);
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("claude-sessions", artifactRoot)
+      : undefined;
     const expectCenteredLayout = async (screenshotName: string) => {
       const [workbenchBox, threadBox, composerBox] = await Promise.all([
         catalogPane.locator(".chat-workbench").boundingBox(),
@@ -632,7 +641,6 @@ suite.define(() => {
         Math.abs(composerBox!.x + composerBox!.width / 2 - workbenchCenter),
       ).toBeLessThanOrEqual(1);
       if (artifactDir) {
-        await fs.mkdir(artifactDir, { recursive: true });
         await page.screenshot({
           path: path.join(artifactDir, screenshotName),
           fullPage: true,
@@ -660,10 +668,10 @@ suite.define(() => {
   });
 
   it("auto-pages an underfilled native transcript until it becomes scrollable", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-    if (artifactDir) {
-      await fs.mkdir(artifactDir, { recursive: true });
-    }
+    const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("claude-sessions", artifactRoot)
+      : undefined;
     const viewport = { width: 1280, height: 900 };
     const context = await suite.newBrowserContext({
       locale: "en-US",
@@ -815,7 +823,10 @@ suite.define(() => {
 
   it("shows loaded native history before fetching and revealing an earlier page", async () => {
     const page = await suite.browser.newPage({ viewport: { width: 1280, height: 800 } });
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("claude-sessions", artifactRoot)
+      : undefined;
     const historyMessage = (seq: number, prefix: string) => ({
       __openclaw: { seq },
       content: [
@@ -896,7 +907,6 @@ suite.define(() => {
     });
     await showEarlier.waitFor();
     if (artifactDir) {
-      await fs.mkdir(artifactDir, { recursive: true });
       await page.screenshot({
         path: path.join(artifactDir, "00-native-history-available.png"),
         fullPage: true,

--- a/ui/src/e2e/cloud-session-disk-space.e2e.test.ts
+++ b/ui/src/e2e/cloud-session-disk-space.e2e.test.ts
@@ -1,8 +1,9 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import type { SessionPlacementDiskSpace } from "../../../packages/gateway-protocol/src/schema/session-placement.js";
 import type { GatewaySessionRow, SessionsListResult } from "../api/types.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiSessionUrl,
   installMockGateway,
@@ -12,9 +13,12 @@ import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts"
 
 const sessionKey = "agent:main:disk-monitor";
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const artifactDir = path.resolve(
-  process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim() || ".artifacts/control-ui-e2e/cloud-disk",
-);
+let artifactDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    artifactDir = createControlUiE2eArtifactDir("cloud-disk");
+  }
+});
 const viewport = { height: 900, width: 1280 };
 const gibibyte = 1024 ** 3;
 const mebibyte = 1024 ** 2;

--- a/ui/src/e2e/cloud-workspace-conflict.e2e.test.ts
+++ b/ui/src/e2e/cloud-workspace-conflict.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI browser proof covers the cloud-workspace conflict recovery lifecycle.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   controlUiSessionUrl,
@@ -16,7 +16,13 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-const proofDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+let proofDir: string | undefined;
+beforeEach(() => {
+  proofDir = artifactRoot
+    ? createControlUiE2eArtifactDir("cloud-workspace-conflict", artifactRoot)
+    : undefined;
+});
 const sessionKey = "agent:main:conflict-proof";
 const workerFailureDiagnostic = [
   "Worker provider rejected profile: node enrollment setup failed with exit code 1: provider reported lease destroyed",
@@ -135,9 +141,6 @@ describeControlUiE2e("Control UI cloud workspace conflict recovery", () => {
   beforeAll(async () => {
     if (!chromiumAvailable) {
       throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    if (proofDir) {
-      await mkdir(proofDir, { recursive: true });
     }
     server = await startControlUiE2eServer();
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -1,8 +1,8 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import type { SessionsCatalogHostEvent } from "../../../packages/gateway-protocol/src/index.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { controlUiSessionPath, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite, tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -15,12 +15,12 @@ const suite = createControlUiE2eSuite({
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const catalogGroupingStorageKey = "openclaw:sidebar:sessions:catalog-grouping";
 const collapsedSessionSectionsStorageKey = "openclaw:sidebar:sessions:collapsed-sections";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "native-session-discovery",
-);
+let uiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    uiProofArtifactDir = createControlUiE2eArtifactDir("native-session-discovery");
+  }
+});
 
 async function expandCodingSection(page: Page, required = false) {
   const toggle = page.locator('[data-session-section="work"] .sidebar-session-group-toggle');
@@ -231,7 +231,6 @@ suite.define(() => {
       expect(groupGap).toBeGreaterThan(0);
       expect(Math.round(catalogBox!.y - (liveRowsBox!.y + liveRowsBox!.height))).toBe(groupGap);
       if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
         await sessionGroups.screenshot({
           animations: "disabled",
           path: path.join(uiProofArtifactDir, "06-coding-catalog-spacing.png"),
@@ -290,7 +289,6 @@ suite.define(() => {
       await page.getByText("Progressive node result", { exact: true }).waitFor();
       expect((await gateway.getRequests("sessions.catalog.list")).length).toBe(1);
       if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
@@ -585,7 +583,6 @@ suite.define(() => {
         await page.evaluate((key) => localStorage.getItem(key), catalogGroupingStorageKey),
       ).toBe("none");
       if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
         await section.screenshot({
           animations: "disabled",
           path: path.join(uiProofArtifactDir, "04-flat-session-hosts.png"),
@@ -659,7 +656,6 @@ suite.define(() => {
       ).not.toContain("catalog-project:codex:gateway:local:project:/Users/dev/openclaw");
 
       if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
         await section.screenshot({
           animations: "disabled",
           path: path.join(uiProofArtifactDir, "03-content-bearing-session-hosts.png"),
@@ -789,7 +785,6 @@ suite.define(() => {
       expect(await page.locator('[data-session-catalog-host="node:registry"]').count()).toBe(0);
 
       if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
         await page.screenshot({
           animations: "disabled",
           fullPage: true,

--- a/ui/src/e2e/config-controls-visual.e2e.test.ts
+++ b/ui/src/e2e/config-controls-visual.e2e.test.ts
@@ -1,9 +1,9 @@
 // Control UI tests cover shared Settings control styling through the mocked Gateway.
 import { Buffer } from "node:buffer";
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -15,12 +15,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "settings-controls",
-);
+let uiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    uiProofArtifactDir = createControlUiE2eArtifactDir("settings-controls");
+  }
+});
 
 async function resolvedBackground(page: Page, value: string): Promise<string> {
   return page.evaluate((background) => {
@@ -95,7 +95,6 @@ async function captureBrowserSettingProof(
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(uiProofArtifactDir, { recursive: true });
   await section.screenshot({
     animations: "disabled",
     path: path.join(uiProofArtifactDir, `${name}-desktop.png`),
@@ -165,7 +164,6 @@ suite.define(() => {
           expect(await selected.getAttribute("aria-checked")).toBe("true");
           expect(await unselected.getAttribute("aria-checked")).toBe("false");
           if (captureUiProofEnabled) {
-            await mkdir(uiProofArtifactDir, { recursive: true });
             await selected
               .locator(
                 "xpath=ancestor::div[contains(concat(' ', normalize-space(@class), ' '), ' settings-row ')][1]",
@@ -257,7 +255,6 @@ suite.define(() => {
         ).toBe(await resolvedBackground(page, "var(--accent)"));
 
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await page.locator(".content-header").screenshot({
             animations: "disabled",
             path: path.join(uiProofArtifactDir, "01-settings-view.png"),
@@ -306,9 +303,6 @@ suite.define(() => {
 
   for (const host of ["browser", "app"] as const) {
     it(`routes links to the Control UI browser in a ${host}-hosted UI`, async () => {
-      if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
-      }
       await suite.withPage(
         {
           colorScheme: "dark",

--- a/ui/src/e2e/config-form-defaults.e2e.test.ts
+++ b/ui/src/e2e/config-form-defaults.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI tests cover schema defaults and restoring inherited config values.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway, type MockGatewayRequest } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -14,12 +14,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "config-form-defaults",
-);
+let uiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    uiProofArtifactDir = createControlUiE2eArtifactDir("config-form-defaults");
+  }
+});
 
 function requestRaw(request: MockGatewayRequest): Record<string, unknown> {
   const params = request.params;
@@ -157,7 +157,6 @@ suite.define(() => {
         await expect.poll(() => tagsBlock.textContent()).toContain('Default: ["stable","default"]');
 
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await panel.screenshot({
             animations: "disabled",
             path: path.join(uiProofArtifactDir, "01-explicit-overrides.png"),

--- a/ui/src/e2e/config-form-guidance.e2e.test.ts
+++ b/ui/src/e2e/config-form-guidance.e2e.test.ts
@@ -1,7 +1,7 @@
 // Control UI tests cover form support for transform-backed config fields.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -13,12 +13,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "config-form-guidance",
-);
+let uiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    uiProofArtifactDir = createControlUiE2eArtifactDir("config-form-guidance");
+  }
+});
 
 function notificationStatusConfigMocks() {
   const config = { ui: { prefs: { theme: "claw" } } };
@@ -122,7 +122,6 @@ suite.define(() => {
           .toBe(0);
 
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
@@ -211,7 +210,6 @@ suite.define(() => {
           .toBe(0);
 
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
@@ -288,7 +286,6 @@ suite.define(() => {
           .toContain("Ready");
 
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,

--- a/ui/src/e2e/config-form-integrity.e2e.test.ts
+++ b/ui/src/e2e/config-form-integrity.e2e.test.ts
@@ -1,8 +1,9 @@
 // Control UI tests cover schema-backed form constraints, draft recovery, and accessible names.
-import { mkdir, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Locator } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -15,13 +16,15 @@ const suite = createControlUiE2eSuite({
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofVariant = process.env.OPENCLAW_UI_PROOF_VARIANT ?? "after";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "config-form-integrity",
-  proofVariant,
-);
+let uiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    uiProofArtifactDir = path.join(
+      createControlUiE2eArtifactDir("config-form-integrity"),
+      proofVariant,
+    );
+  }
+});
 
 function configFormIntegrityMocks() {
   const config = {
@@ -195,7 +198,6 @@ suite.define(() => {
           expect((await mode.locator("option:checked").textContent())?.trim()).toBe(label);
         }
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
@@ -233,7 +235,6 @@ suite.define(() => {
         await metadataEditor.blur();
 
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await page.locator("#config-section-panel").screenshot({
             animations: "disabled",
             path: path.join(uiProofArtifactDir, "01-invalid-json-draft.png"),
@@ -395,7 +396,6 @@ suite.define(() => {
         expect(rejection.message).toContain(".3.name");
 
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,

--- a/ui/src/e2e/config-open-file-feedback.e2e.test.ts
+++ b/ui/src/e2e/config-open-file-feedback.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -11,7 +11,6 @@ const suite = createControlUiE2eSuite({
 });
 const configPath = "/tmp/openclaw-config-open-feedback/openclaw.json";
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofPath = path.resolve(".artifacts/control-ui-e2e/config-open-file-feedback/after.png");
 
 async function installClipboardProof(page: Page): Promise<void> {
   await page.addInitScript(() => {
@@ -91,7 +90,10 @@ suite.define(() => {
 
       await expectOpenFailure(page, "No desktop opener is available.");
       if (captureProof) {
-        await mkdir(path.dirname(proofPath), { recursive: true });
+        const proofPath = path.join(
+          createControlUiE2eArtifactDir("config-open-file-feedback"),
+          "after.png",
+        );
         await page.screenshot({ animations: "disabled", fullPage: true, path: proofPath });
       }
     });

--- a/ui/src/e2e/config-safe-write.e2e.test.ts
+++ b/ui/src/e2e/config-safe-write.e2e.test.ts
@@ -1,8 +1,9 @@
 // Control UI browser proof covers the config snapshot and guarded-write lifecycle.
-import { mkdir, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway, type MockGatewayRequest } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -14,12 +15,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "config-safe-write",
-);
+let uiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    uiProofArtifactDir = createControlUiE2eArtifactDir("config-safe-write");
+  }
+});
 
 function configResponse(config: Record<string, unknown>, hash: string, appliedConfigHash = hash) {
   return {
@@ -130,7 +131,6 @@ async function capture(page: Page, name: string): Promise<void> {
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(uiProofArtifactDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,
@@ -757,7 +757,6 @@ suite.define(() => {
         expect(typeof submitted.tools.elevated.allowFrom.discord[0]).toBe("string");
 
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await writeFile(
             path.join(uiProofArtifactDir, "09-id-config-set-payload.json"),
             `${JSON.stringify({ before: initialConfig, submitted }, null, 2)}\n`,

--- a/ui/src/e2e/control-ui-credentials.e2e.test.ts
+++ b/ui/src/e2e/control-ui-credentials.e2e.test.ts
@@ -1,10 +1,11 @@
 // Control UI tests cover browser credential submission and visible recovery.
-import { mkdir, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   controlUiE2eWaitTimeoutMs,
@@ -20,11 +21,10 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-const artifactDir = path.resolve(
-  process.cwd(),
-  process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim() ||
-    ".artifacts/control-ui-e2e/control-ui-credentials",
-);
+let artifactDir: string;
+beforeEach(() => {
+  artifactDir = createControlUiE2eArtifactDir("control-ui-credentials");
+});
 const viewport = { height: 900, width: 1280 };
 
 let browser: Browser;
@@ -43,7 +43,6 @@ async function createCredentialPage(): Promise<{
   gateway: MockGatewayControls;
   page: Page;
 }> {
-  await mkdir(artifactDir, { recursive: true });
   const context = await browser.newContext({
     locale: "en-US",
     recordVideo: { dir: artifactDir, size: viewport },

--- a/ui/src/e2e/control-ui-e2e-suite.test-support.ts
+++ b/ui/src/e2e/control-ui-e2e-suite.test-support.ts
@@ -1,5 +1,6 @@
 import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, inject } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, inject } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiE2eWaitTimeoutMs,
   startControlUiE2eServer,
@@ -27,6 +28,7 @@ type ControlUiE2ePage = {
 };
 
 type ControlUiE2eSuite = {
+  readonly artifactDir: string;
   readonly browser: Browser;
   readonly server: ControlUiE2eServer;
   closeBrowserContext: (context: BrowserContext) => Promise<void>;
@@ -96,6 +98,7 @@ export function createControlUiE2eSuite(options: ControlUiE2eSuiteOptions): Cont
   const openBrowserContexts = new Set<BrowserContext>();
   let browser: Browser | undefined;
   let server: ControlUiE2eServer | undefined;
+  let artifactDir: string | undefined;
 
   const closeBrowserContext = async (context: BrowserContext): Promise<void> => {
     openBrowserContexts.delete(context);
@@ -118,6 +121,11 @@ export function createControlUiE2eSuite(options: ControlUiE2eSuiteOptions): Cont
   };
 
   return {
+    get artifactDir() {
+      return (artifactDir ??= createControlUiE2eArtifactDir(
+        options.name.toLowerCase().replaceAll(/[^a-z0-9_-]+/gu, "-"),
+      ));
+    },
     get browser() {
       if (!browser) {
         throw new Error("Control UI E2E browser accessed before suite setup");
@@ -133,6 +141,10 @@ export function createControlUiE2eSuite(options: ControlUiE2eSuiteOptions): Cont
     closeBrowserContext,
     define(defineTests) {
       describeControlUiE2e(options.name, () => {
+        // Each retry/repeat owns new proof, but disabled capture never reads the lazy directory.
+        beforeEach(() => {
+          artifactDir = undefined;
+        });
         beforeAll(async () => {
           if (!chromiumAvailable && options.unavailableMessage) {
             throw new Error(options.unavailableMessage(chromiumExecutablePath));

--- a/ui/src/e2e/control-ui-retained-assets.e2e.test.ts
+++ b/ui/src/e2e/control-ui-retained-assets.e2e.test.ts
@@ -17,12 +17,12 @@ import {
   type ControlUiRootState,
 } from "../../../src/gateway/control-ui.ts";
 import { withEnvAsync } from "../../../src/test-utils/env.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { resolvePlaywrightChromiumExecutablePath } from "../test-helpers/control-ui-e2e.ts";
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const useWebKit = process.env.OPENCLAW_CONTROL_UI_E2E_BROWSER === "webkit";
 const browserName = useWebKit ? "webkit" : "chromium";
-const artifactDir = path.resolve(`.artifacts/control-ui-e2e/retained-assets-${browserName}`);
 const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
 
 async function writeBuild(root: string, files: Readonly<Record<string, string>>): Promise<void> {
@@ -116,6 +116,9 @@ async function startGatewayAssetServer(root: Extract<ControlUiRootState, { kind:
 }
 
 it("keeps an old document's unvisited lazy module available across builds", async () => {
+  const artifactDir = captureUiProof
+    ? createControlUiE2eArtifactDir(`retained-assets-${browserName}`)
+    : "";
   const fixture = await mkdtemp(path.join(os.tmpdir(), "openclaw-retained-assets-e2e-"));
   const buildA = path.join(fixture, "build-a");
   const buildB = path.join(fixture, "build-b");
@@ -123,9 +126,6 @@ it("keeps an old document's unvisited lazy module available across builds", asyn
   let browser: Browser | undefined;
   let server: Awaited<ReturnType<typeof startGatewayAssetServer>> | undefined;
   try {
-    if (captureUiProof) {
-      await mkdir(artifactDir, { recursive: true });
-    }
     await writeOldDocumentBuild(buildA);
     await writeReplacementBuild(buildB);
 

--- a/ui/src/e2e/control-ui-shell-routing.e2e.test.ts
+++ b/ui/src/e2e/control-ui-shell-routing.e2e.test.ts
@@ -1,9 +1,10 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import path from "node:path";
 import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -16,7 +17,10 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-const artifactDir = path.resolve(".artifacts/control-ui-e2e/control-ui-shell-routing");
+let artifactDir: string;
+beforeEach(() => {
+  artifactDir = createControlUiE2eArtifactDir("control-ui-shell-routing");
+});
 const basePath = "/control";
 const forwardedHeaderBlocklist = new Set([
   "connection",
@@ -121,7 +125,6 @@ describeControlUiE2e("Control UI shell routing E2E", () => {
     if (!chromiumAvailable) {
       throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
     }
-    await mkdir(artifactDir, { recursive: true });
     server = await startControlUiE2eServer(undefined, { source: true });
     proxy = await startBasePathProxy(server.baseUrl);
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });

--- a/ui/src/e2e/cron-run-suppression.e2e.test.ts
+++ b/ui/src/e2e/cron-run-suppression.e2e.test.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import type { CronJob, CronRunLogEntry } from "../api/types.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -118,9 +118,11 @@ suite.define(() => {
           expect(await suppressed.textContent()).not.toContain(
             "Synthetic delivery target unavailable.",
           );
-          const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR;
+          const artifactRoot = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR;
+          const artifactDir = artifactRoot
+            ? createControlUiE2eArtifactDir("cron-run-suppression", artifactRoot)
+            : undefined;
           if (artifactDir) {
-            await fs.mkdir(artifactDir, { recursive: true });
             // Only the synthetic suppressed row is captured, never the error row.
             await suppressed.screenshot({
               path: path.join(artifactDir, `${scope}-suppressed.png`),

--- a/ui/src/e2e/cron-trigger-authoring.e2e.test.ts
+++ b/ui/src/e2e/cron-trigger-authoring.e2e.test.ts
@@ -1,9 +1,9 @@
 // Real-Chromium coverage keeps automation condition authoring aligned with Gateway contracts.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import type { ApplicationContext } from "../app/context.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -13,7 +13,13 @@ const suite = createControlUiE2eSuite({
   unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
 });
 
-const proofDirectory = process.env.OPENCLAW_TRIGGER_UI_PROOF_DIR;
+const proofDirectoryParent = process.env.OPENCLAW_TRIGGER_UI_PROOF_DIR;
+let proofDirectory: string | undefined;
+beforeEach(() => {
+  proofDirectory = proofDirectoryParent
+    ? createControlUiE2eArtifactDir("cron-trigger-authoring", proofDirectoryParent)
+    : undefined;
+});
 const proofStage = process.env.OPENCLAW_TRIGGER_UI_PROOF_STAGE ?? "after";
 type CronTriggerTestApp = HTMLElement & { runtime?: { context: ApplicationContext } };
 
@@ -68,7 +74,6 @@ async function captureProof(page: Page, name: string) {
   if (!proofDirectory) {
     return;
   }
-  await mkdir(proofDirectory, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     path: path.join(proofDirectory, `${proofStage}-${name}.png`),

--- a/ui/src/e2e/curated-settings-defaults.e2e.test.ts
+++ b/ui/src/e2e/curated-settings-defaults.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI tests cover inherited defaults across curated settings pages.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway, type MockGatewayRequest } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -14,12 +14,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "curated-settings-defaults",
-);
+let uiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    uiProofArtifactDir = createControlUiE2eArtifactDir("curated-settings-defaults");
+  }
+});
 
 function configResponse(config: Record<string, unknown>, hash: string) {
   return {
@@ -110,7 +110,6 @@ suite.define(() => {
         await expect.poll(() => codeModeRow.textContent()).toContain("Default: Disabled");
 
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await codeModeRow.screenshot({
             animations: "disabled",
             path: path.join(uiProofArtifactDir, "01-labs-explicit-override.png"),

--- a/ui/src/e2e/custodian-channel-onboarding.e2e.test.ts
+++ b/ui/src/e2e/custodian-channel-onboarding.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI tests cover the first-run model-to-channel onboarding handoff.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -16,12 +16,10 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-const artifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "custodian-channel-onboarding",
-);
+let artifactDir: string;
+beforeEach(() => {
+  artifactDir = createControlUiE2eArtifactDir("custodian-channel-onboarding");
+});
 
 let browser: Browser;
 let server: ControlUiE2eServer;
@@ -57,7 +55,6 @@ describeControlUiE2e("Control UI Custodian channel onboarding mocked Gateway E2E
     if (!chromiumAvailable) {
       throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
     }
-    await mkdir(artifactDir, { recursive: true });
     server = await startControlUiE2eServer();
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
   });

--- a/ui/src/e2e/custodian-event-nudge.e2e.test.ts
+++ b/ui/src/e2e/custodian-event-nudge.e2e.test.ts
@@ -1,9 +1,9 @@
 // Control UI tests cover event-reactive custodian presence against a mocked Gateway.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import { GATEWAY_SERVER_CAPS } from "../../../packages/gateway-protocol/src/index.js";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -14,12 +14,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "custodian-event-nudge",
-);
+let uiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    uiProofArtifactDir = createControlUiE2eArtifactDir("custodian-event-nudge");
+  }
+});
 
 async function settleUi(page: Page): Promise<void> {
   await page.evaluate(
@@ -68,9 +68,6 @@ suite.define(() => {
   });
 
   it("shows one consequential nudge and sends its canonical message", async () => {
-    if (captureUiProofEnabled) {
-      await mkdir(uiProofArtifactDir, { recursive: true });
-    }
     await suite.withPage(
       {
         colorScheme: "dark",
@@ -167,9 +164,6 @@ suite.define(() => {
   });
 
   it("keeps a blocking startup error next to the composer", async () => {
-    if (captureUiProofEnabled) {
-      await mkdir(uiProofArtifactDir, { recursive: true });
-    }
     await suite.withPage(
       {
         colorScheme: "dark",
@@ -320,9 +314,6 @@ suite.define(() => {
   });
 
   it("renders rich wizard controls and sends typed answers", async () => {
-    if (captureUiProofEnabled) {
-      await mkdir(uiProofArtifactDir, { recursive: true });
-    }
     await suite.withPage(
       {
         colorScheme: "dark",

--- a/ui/src/e2e/custodian-panel-toggle.e2e.test.ts
+++ b/ui/src/e2e/custodian-panel-toggle.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI tests cover the global Ask OpenClaw panel toggle and persisted session identity.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -15,12 +15,10 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-const artifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "custodian-panel-toggle",
-);
+let artifactDir: string;
+beforeEach(() => {
+  artifactDir = createControlUiE2eArtifactDir("custodian-panel-toggle");
+});
 
 const CUSTODIAN_SESSION_STORAGE_KEY = "openclaw.custodian.session.v1";
 const MOCK_SESSION_ID = "e2e-custodian-panel";
@@ -52,7 +50,6 @@ describeControlUiE2e("Control UI Ask OpenClaw panel toggle mocked Gateway E2E", 
     if (!chromiumAvailable) {
       throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
     }
-    await mkdir(artifactDir, { recursive: true });
     server = await startControlUiE2eServer();
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
   });

--- a/ui/src/e2e/dashboard-final-reply-recovery.e2e.test.ts
+++ b/ui/src/e2e/dashboard-final-reply-recovery.e2e.test.ts
@@ -10,7 +10,6 @@ const suite = createControlUiE2eSuite({
 });
 
 const sessionKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
-const proofDir = path.resolve(".artifacts/control-ui-e2e/dashboard-final-reply-recovery");
 
 function dashboardPath(): string {
   return controlUiSessionPath(sessionKey).replace(/^\/chat\//u, "/dashboard/");
@@ -20,13 +19,20 @@ suite.define(() => {
   it("projects a distinct durable reply after interim text and a message-less terminal", async () => {
     const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
     if (recordProof) {
-      await mkdir(proofDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "dashboard-final-reply-recovery"), {
+        recursive: true,
+      });
     }
     const context = await suite.browser.newContext({
       locale: "en-US",
       viewport: { height: 900, width: 1280 },
       ...(recordProof
-        ? { recordVideo: { dir: proofDir, size: { height: 900, width: 1280 } } }
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "dashboard-final-reply-recovery"),
+              size: { height: 900, width: 1280 },
+            },
+          }
         : {}),
     });
     const page = await context.newPage();
@@ -176,14 +182,22 @@ suite.define(() => {
       if (recordProof) {
         await page.screenshot({
           fullPage: true,
-          path: path.join(proofDir, "dashboard-final-reply-recovered.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "dashboard-final-reply-recovery"),
+            "dashboard-final-reply-recovered.png",
+          ),
         });
       }
     } finally {
       const video = page.video();
       await context.close();
       if (recordProof && video) {
-        await video.saveAs(path.join(proofDir, "dashboard-final-reply-recovered.webm"));
+        await video.saveAs(
+          path.join(
+            path.join(suite.artifactDir, "dashboard-final-reply-recovery"),
+            "dashboard-final-reply-recovered.webm",
+          ),
+        );
       }
     }
   });

--- a/ui/src/e2e/dashboard-session-retention.e2e.test.ts
+++ b/ui/src/e2e/dashboard-session-retention.e2e.test.ts
@@ -11,7 +11,6 @@ const suite = createControlUiE2eSuite({
 
 const alphaKey = "agent:main:dashboard-alpha";
 const betaKey = "agent:main:dashboard-beta";
-const proofDir = path.resolve(".artifacts/control-ui-e2e/dashboard-session-retention");
 
 function dashboardPath(key: string): string {
   return controlUiSessionPath(key).replace(/^\/chat\//u, "/dashboard/");
@@ -33,12 +32,17 @@ suite.define(() => {
   it("shows a warmed dashboard immediately while its refresh is pending", async () => {
     const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
     if (recordProof) {
-      await mkdir(proofDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "dashboard-session-retention"), { recursive: true });
     }
     const context = await suite.browser.newContext({
       viewport: { height: 900, width: 1280 },
       ...(recordProof
-        ? { recordVideo: { dir: proofDir, size: { height: 900, width: 1280 } } }
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "dashboard-session-retention"),
+              size: { height: 900, width: 1280 },
+            },
+          }
         : {}),
     });
     const page = await context.newPage();
@@ -85,7 +89,12 @@ suite.define(() => {
         Reflect.set(globalThis, "__retainedDashboardTab", tab);
       });
       if (recordProof) {
-        await page.screenshot({ path: path.join(proofDir, "01-alpha-warmed.png") });
+        await page.screenshot({
+          path: path.join(
+            path.join(suite.artifactDir, "dashboard-session-retention"),
+            "01-alpha-warmed.png",
+          ),
+        });
       }
 
       const sessionLink = (key: string) =>
@@ -106,7 +115,12 @@ suite.define(() => {
       await expect.poll(() => dashboardActive(alphaKey)).toBe(false);
       await expect.poll(() => dashboardActive(betaKey)).toBe(true);
       if (recordProof) {
-        await page.screenshot({ path: path.join(proofDir, "02-beta-selected.png") });
+        await page.screenshot({
+          path: path.join(
+            path.join(suite.artifactDir, "dashboard-session-retention"),
+            "02-beta-selected.png",
+          ),
+        });
       }
 
       await gateway.deferNext("board.get", { sessionKey: alphaKey });
@@ -118,13 +132,23 @@ suite.define(() => {
       await expect.poll(() => dashboardActive(alphaKey)).toBe(true);
       await expect.poll(() => dashboardActive(betaKey)).toBe(false);
       if (recordProof) {
-        await page.screenshot({ path: path.join(proofDir, "03-alpha-retained.png") });
+        await page.screenshot({
+          path: path.join(
+            path.join(suite.artifactDir, "dashboard-session-retention"),
+            "03-alpha-retained.png",
+          ),
+        });
       }
     } finally {
       const video = page.video();
       await context.close();
       if (recordProof && video) {
-        await video.saveAs(path.join(proofDir, "dashboard-session-retention.webm"));
+        await video.saveAs(
+          path.join(
+            path.join(suite.artifactDir, "dashboard-session-retention"),
+            "dashboard-session-retention.webm",
+          ),
+        );
       }
     }
   });

--- a/ui/src/e2e/dashboards-list-demand.e2e.test.ts
+++ b/ui/src/e2e/dashboards-list-demand.e2e.test.ts
@@ -1,9 +1,9 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
 // Control UI E2E proves dashboard tabs do not multiply server-owned session-list demand.
 import { SIDEBAR_SESSION_ROSTER_LIMIT } from "../../../src/shared/session-list-limits.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   installMockGateway,
   waitForControlUiRoute,
@@ -61,8 +61,7 @@ async function requestCounts(gateways: MockGatewayControls[]) {
 
 suite.define(() => {
   it("shows failed dashboard refreshes beside retained rows and retries the same query", async () => {
-    const artifactDir = path.resolve(".artifacts/control-ui-e2e/dashboard-refresh-errors");
-    await mkdir(artifactDir, { recursive: true });
+    const artifactDir = createControlUiE2eArtifactDir("dashboard-refresh-errors");
     const context = await suite.browser.newContext({ viewport: { height: 900, width: 1440 } });
     const page = await context.newPage();
     try {

--- a/ui/src/e2e/debug-diagnostics.e2e.test.ts
+++ b/ui/src/e2e/debug-diagnostics.e2e.test.ts
@@ -1,6 +1,7 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -11,7 +12,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.resolve(".artifacts/control-ui-e2e/control-ui-debug-diagnostics");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("control-ui-debug-diagnostics");
+  }
+});
 
 suite.define(() => {
   it("renders status, health, heartbeat, and model snapshots from the Gateway", async () => {

--- a/ui/src/e2e/desktop-document-mode.e2e.test.ts
+++ b/ui/src/e2e/desktop-document-mode.e2e.test.ts
@@ -1,6 +1,6 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
 import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { chatSessionListResponse } from "./chat-flow.test-support.ts";
@@ -17,7 +17,10 @@ const suite = createControlUiE2eSuite({
     `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`.`,
 });
 
-const artifactDirectory = path.resolve(".artifacts/mobile-desktop");
+let artifactDirectory: string;
+beforeEach(() => {
+  artifactDirectory = createControlUiE2eArtifactDir("mobile-desktop");
+});
 const gatewayEnvironment = {
   id: "gateway",
   type: "local",
@@ -221,7 +224,6 @@ suite.define(() => {
         expect(await popout.getAttribute("href")).toBe(
           `/focus/desktop/session/${encodeURIComponent(sessionKey)}`,
         );
-        await mkdir(artifactDirectory, { recursive: true });
         await page.screenshot({
           path: path.join(artifactDirectory, `chat-session-${initialState}-connected.png`),
         });
@@ -262,7 +264,6 @@ suite.define(() => {
         await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth),
       ).toBe(true);
 
-      await mkdir(artifactDirectory, { recursive: true });
       await page.screenshot({
         path: path.join(artifactDirectory, "picker-390x844.png"),
         fullPage: false,
@@ -368,7 +369,6 @@ suite.define(() => {
         source: scenario.source,
         control: false,
       });
-      await mkdir(artifactDirectory, { recursive: true });
       await page.screenshot({
         path: path.join(
           artifactDirectory,
@@ -425,7 +425,6 @@ suite.define(() => {
         .waitFor();
       await panel.getByText("Desktop sources", { exact: true }).waitFor();
       expect(await gateway.getRequests("desktop.observe")).toHaveLength(0);
-      await mkdir(artifactDirectory, { recursive: true });
       await page.screenshot({
         path: path.join(artifactDirectory, "unknown-session-picker-390x844.png"),
         fullPage: false,
@@ -554,7 +553,6 @@ suite.define(() => {
       });
       await expect.poll(() => panel.getAttribute("data-last-keyboard-text")).toBe("m");
 
-      await mkdir(artifactDirectory, { recursive: true });
       await page.screenshot({
         path: path.join(artifactDirectory, "connected-toolbar-390x844.png"),
         fullPage: false,

--- a/ui/src/e2e/desktop-panel-fullscreen.e2e.test.ts
+++ b/ui/src/e2e/desktop-panel-fullscreen.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -19,7 +19,12 @@ const suite = createControlUiE2eSuite({
 });
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofStage = process.env.OPENCLAW_DESKTOP_FULLSCREEN_PROOF_STAGE ?? "after";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "desktop-fullscreen");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("desktop-fullscreen");
+  }
+});
 
 function sessionsList() {
   return {
@@ -82,7 +87,6 @@ async function captureDesktopProof(page: Page, panel: import("playwright").Locat
   if (!captureUiProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     path: path.join(proofDir, `${proofStage}-${name}-context.png`),

--- a/ui/src/e2e/device-scope-upgrade.e2e.test.ts
+++ b/ui/src/e2e/device-scope-upgrade.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -15,7 +15,13 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-const proofDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+let proofDir: string | undefined;
+beforeEach(() => {
+  proofDir = artifactRoot
+    ? createControlUiE2eArtifactDir("device-scope-upgrade", artifactRoot)
+    : undefined;
+});
 
 const LIMITED_SCOPES = ["operator.read", "operator.write"];
 const FULL_SCOPES = [
@@ -57,7 +63,6 @@ async function captureProof(page: Page, name: string): Promise<void> {
   if (!proofDir) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.screenshot({ fullPage: true, path: path.join(proofDir, name) });
 }
 

--- a/ui/src/e2e/device-token-reconnect.e2e.test.ts
+++ b/ui/src/e2e/device-token-reconnect.e2e.test.ts
@@ -1,10 +1,10 @@
 // Control UI tests cover browser-native device-token isolation and reuse.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { gatewayCredentialScope, gatewayOriginScope } from "@openclaw/gateway-client/browser";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -17,7 +17,13 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-const proofDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+let proofDir: string | undefined;
+beforeEach(() => {
+  proofDir = artifactRoot
+    ? createControlUiE2eArtifactDir("device-token-reconnect", artifactRoot)
+    : undefined;
+});
 
 let browser: Browser;
 let server: ControlUiE2eServer;
@@ -112,7 +118,6 @@ async function captureProof(page: Page, name: string): Promise<void> {
   if (!proofDir) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.screenshot({ fullPage: true, path: path.join(proofDir, name) });
 }
 

--- a/ui/src/e2e/external-session-catalogs.e2e.test.ts
+++ b/ui/src/e2e/external-session-catalogs.e2e.test.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import type { ApplicationContext } from "../app/context.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway, waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -103,9 +103,11 @@ suite.define(() => {
             .locator(".chat-group.user")
             .filter({ hasText: "The imported author's question." });
           await message.waitFor();
-          const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+          const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+          const artifactDir = artifactRoot
+            ? createControlUiE2eArtifactDir("external-session-catalogs", artifactRoot)
+            : undefined;
           if (artifactDir && catalogId === "beam") {
-            await fs.mkdir(artifactDir, { recursive: true });
             await page.screenshot({ path: path.join(artifactDir, `beam-author-${viewer}.png`) });
           }
           expect(await message.locator(".chat-sender-name").textContent()).toBe("User");
@@ -433,8 +435,7 @@ suite.define(() => {
   );
 
   it("keeps old Beam links working and opens pretty shares under a non-main default agent", async () => {
-    const artifactDir = path.resolve(".artifacts/control-ui-e2e/beam-named-share-url");
-    await fs.mkdir(artifactDir, { recursive: true });
+    const artifactDir = createControlUiE2eArtifactDir("beam-named-share-url");
     const context = await suite.newBrowserContext({
       recordVideo: { dir: artifactDir, size: { width: 1280, height: 720 } },
       viewport: { width: 1280, height: 720 },
@@ -714,9 +715,11 @@ suite.define(() => {
     );
     expect(await gateway.getRequests("sessions.catalog.read")).toHaveLength(2);
 
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("external-session-catalogs", artifactRoot)
+      : undefined;
     if (artifactDir) {
-      await fs.mkdir(artifactDir, { recursive: true });
       await page.screenshot({
         path: path.join(artifactDir, "external-session-catalogs.png"),
         fullPage: true,

--- a/ui/src/e2e/github-link-hovercard.e2e.test.ts
+++ b/ui/src/e2e/github-link-hovercard.e2e.test.ts
@@ -1,8 +1,14 @@
 // Control UI tests cover GitHub link hover card behavior.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+
+let artifactDir: string | undefined;
+beforeEach(() => {
+  const parent = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+  artifactDir = parent ? createControlUiE2eArtifactDir("github-link-hovercard", parent) : undefined;
+});
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -40,11 +46,9 @@ async function expectText(locator: Locator, text: string): Promise<void> {
 }
 
 async function captureArtifact(page: Page, name: string): Promise<void> {
-  const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
   if (!artifactDir) {
     return;
   }
-  await mkdir(artifactDir, { recursive: true });
   await page.screenshot({ path: path.join(artifactDir, `${name}.png`) });
 }
 
@@ -277,9 +281,7 @@ describeControlUiE2e("GitHub link hover cards", () => {
     await page.goto(`${server.baseUrl}chat`);
 
     const message = page.locator(".chat-text").filter({ hasText: "Review" });
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
     if (artifactDir) {
-      await mkdir(artifactDir, { recursive: true });
       await message.screenshot({ path: path.join(artifactDir, "github-references-light.png") });
       await page.emulateMedia({ colorScheme: "dark" });
       await expect.poll(() => page.locator("html").getAttribute("data-theme-mode")).toBe("dark");

--- a/ui/src/e2e/home-attention.e2e.test.ts
+++ b/ui/src/e2e/home-attention.e2e.test.ts
@@ -1,8 +1,8 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { QuestionRecord } from "@openclaw/gateway-protocol";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import type { GatewaySessionRow, SessionsListResult } from "../api/types.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiSessionUrl,
   installMockGateway,
@@ -21,13 +21,12 @@ const suite = createControlUiE2eSuite({
 const mainSessionKey = "agent:main:main";
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofVariant = process.env.OPENCLAW_HOME_ATTENTION_PROOF_VARIANT || "candidate";
-const proofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "home-attention",
-  proofVariant,
-);
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = path.join(createControlUiE2eArtifactDir("home-attention"), proofVariant);
+  }
+});
 
 function sessionsList(row: GatewaySessionRow): SessionsListResult {
   return {
@@ -90,9 +89,6 @@ async function captureState(
 
 suite.define(() => {
   it("projects question, failure, and agent-declared attention onto Home", async () => {
-    if (captureUiProof) {
-      await mkdir(proofDir, { recursive: true });
-    }
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",

--- a/ui/src/e2e/identity-activity-links.e2e.test.ts
+++ b/ui/src/e2e/identity-activity-links.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
 import {
   captureUiProofEnabled,
@@ -11,18 +11,17 @@ import {
   installMockGateway,
 } from "./chat-flow.test-support.ts";
 
-const proofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "identity-activity-links",
-);
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    proofDir = createControlUiE2eArtifactDir("identity-activity-links");
+  }
+});
 
 async function captureProof(page: Page, fileName: string): Promise<void> {
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,

--- a/ui/src/e2e/inference-setup-gate.e2e.test.ts
+++ b/ui/src/e2e/inference-setup-gate.e2e.test.ts
@@ -1,19 +1,23 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   createNewSessionPageE2eSuite,
   installMockGateway,
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "inference-setup-gate");
+let proofDir: string;
+beforeEach(() => {
+  if (process.env.OPENCLAW_CAPTURE_UI_PROOF === "1") {
+    proofDir = createControlUiE2eArtifactDir("inference-setup-gate");
+  }
+});
 
 async function captureProof(page: import("playwright").Page, fileName: string) {
   if (process.env.OPENCLAW_CAPTURE_UI_PROOF !== "1") {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,

--- a/ui/src/e2e/initial-connect-splash.e2e.test.ts
+++ b/ui/src/e2e/initial-connect-splash.e2e.test.ts
@@ -1,10 +1,10 @@
 // Control UI tests cover the initial-connect splash shown instead of the
 // login gate while the Gateway resolves its first connection attempt.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   controlUiE2eWaitTimeoutMs,
@@ -18,7 +18,13 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+let artifactDir: string | undefined;
+beforeEach(() => {
+  artifactDir = artifactRoot
+    ? createControlUiE2eArtifactDir("initial-connect-splash", artifactRoot)
+    : undefined;
+});
 const viewport = { height: 900, width: 1280 };
 
 let browser: Browser;
@@ -26,9 +32,6 @@ let server: ControlUiE2eServer;
 const openContexts = new Set<BrowserContext>();
 
 async function createPage(): Promise<Page> {
-  if (artifactDir) {
-    await mkdir(artifactDir, { recursive: true });
-  }
   const context = await browser.newContext({
     viewport,
     ...(artifactDir ? { recordVideo: { dir: artifactDir, size: viewport } } : {}),

--- a/ui/src/e2e/lazy-custom-element-recovery.e2e.test.ts
+++ b/ui/src/e2e/lazy-custom-element-recovery.e2e.test.ts
@@ -1,11 +1,11 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import {
   buildControlUiFocusPath,
   type ControlUiFocusBuildTarget,
 } from "@openclaw/session-url-contract";
 import type { Page, Route, Video } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
 import {
   defaultControlUiFeatureMethods,
@@ -17,9 +17,20 @@ import {
 } from "./control-ui-e2e-suite.test-support.ts";
 import { installNativeWebChrome } from "./native-nav.test-support.ts";
 
-const artifactDir = path.resolve(".artifacts/control-ui-e2e/lazy-custom-element-recovery");
+let artifactDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    artifactDir = createControlUiE2eArtifactDir("lazy-custom-element-recovery");
+  }
+});
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const railProofDir = process.env.OPENCLAW_UI_RAIL_PROOF_DIR?.trim();
+const railProofDirParent = process.env.OPENCLAW_UI_RAIL_PROOF_DIR?.trim();
+let railProofDir: string | undefined;
+beforeEach(() => {
+  railProofDir = railProofDirParent
+    ? createControlUiE2eArtifactDir("lazy-custom-element-recovery", railProofDirParent)
+    : undefined;
+});
 const nativeTitlebarChunk = /\/assets\/macos-titlebar-controls\.runtime-[^/?]+\.js(?:\?.*)?$/u;
 const viewport = { height: 900, width: 1280 };
 const sessionKey = "agent:main:dashboard:12345678-90ab-cdef-1234-567890abcdef";
@@ -193,7 +204,6 @@ suite.define(() => {
           const error = await expectRealChunkFailure(page, "command palette");
           await expect.poll(failure.headCount).toBe(1);
           if (captureUiProof) {
-            await mkdir(artifactDir, { recursive: true });
             await page.screenshot({ path: path.join(artifactDir, "dismissed-retry-before.png") });
           }
 
@@ -274,9 +284,6 @@ suite.define(() => {
   }
 
   it("restores the command-palette action after a real stale-chunk reload", async () => {
-    if (captureUiProof) {
-      await mkdir(artifactDir, { recursive: true });
-    }
     const context = await suite.newBrowserContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -365,7 +372,6 @@ suite.define(() => {
             .poll(() => page.locator(".shell").getAttribute("class"))
             .toContain("shell--nav-collapsed");
           if (railProofDir) {
-            await mkdir(railProofDir, { recursive: true });
             await page.screenshot({ path: path.join(railProofDir, "native-titlebar-loading.png") });
           }
 
@@ -437,7 +443,6 @@ suite.define(() => {
         await expect.poll(failure.headCount).toBe(1);
         expect(failure.chunkRequestCount()).toBe(1);
         if (railProofDir) {
-          await mkdir(railProofDir, { recursive: true });
           await page.screenshot({
             path: path.join(railProofDir, `${testCase.proofName}-failed.png`),
           });

--- a/ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts
+++ b/ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts
@@ -1,10 +1,10 @@
 // Measures the lobster dismiss menu's internal overflow in the real sidebar
 // footer context, with classic (space-taking) scrollbars forced on so the
 // Linux run matches what a macOS "Always show scrollbars" operator sees.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContextOptions, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -25,10 +25,7 @@ type BrowserLobsterPet = HTMLElement & {
   updateComplete: Promise<unknown>;
 };
 
-const artifactDir = path.resolve(
-  process.cwd(),
-  ".artifacts/control-ui-e2e/lobster-dismiss-menu-overflow",
-);
+let artifactDir: string;
 
 /** Shared setup for a fresh page: mock gateway, load, and park the clock so
  *  the pet's own timers don't fire mid-assertion. Reused across the default
@@ -48,7 +45,6 @@ async function withDismissMenuPage(
 ) {
   await suite.withPage({ viewport: { width: 1280, height: 900 }, ...options }, async ({ page }) => {
     await loadControlUiPage(page);
-    await mkdir(artifactDir, { recursive: true });
     await run(page);
   });
 }
@@ -171,6 +167,9 @@ async function useOversizedDismissLabels(currentPage: Page) {
 }
 
 suite.define(() => {
+  beforeEach(() => {
+    artifactDir = createControlUiE2eArtifactDir("lobster-dismiss-menu-overflow");
+  });
   it("does not scroll its two dismissal items in the real sidebar footer", () =>
     withDismissMenuPage({}, async (page) => {
       await mountPetInRealFooter(page, 42);

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -1,9 +1,9 @@
 // Control UI tests cover the responsive disconnected login gate.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -13,7 +13,10 @@ const suite = createControlUiE2eSuite({
   unavailableMessage: (executablePath) =>
     `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
 });
-const RECOVERY_ARTIFACT_DIR = path.resolve(".artifacts/control-ui-e2e/zombie-reload");
+let RECOVERY_ARTIFACT_DIR: string;
+beforeEach(() => {
+  RECOVERY_ARTIFACT_DIR = createControlUiE2eArtifactDir("zombie-reload");
+});
 
 async function renderLoginGate(page: Page): Promise<void> {
   const response = await page.goto(suite.server.baseUrl);
@@ -154,7 +157,6 @@ suite.define(() => {
       await page.getByRole("button", { name: /Server updated/u }).waitFor({ timeout: 10_000 });
       expect(await page.locator("openclaw-login-gate").count()).toBe(0);
       expect(await page.locator("openclaw-router-outlet").getAttribute("inert")).not.toBeNull();
-      await mkdir(RECOVERY_ARTIFACT_DIR, { recursive: true });
       await page.screenshot({
         path: path.join(RECOVERY_ARTIFACT_DIR, "01-reload-required.png"),
         fullPage: true,
@@ -292,7 +294,6 @@ suite.define(() => {
       expect((bounds.headerTop ?? 0) - (bounds.noticeBottom ?? 0)).toBeCloseTo(44, 3);
       expect(bounds.noticeLeft).toBe(bounds.navRight);
       expect(bounds.noticeRight).toBe(bounds.mainRight);
-      await mkdir(RECOVERY_ARTIFACT_DIR, { recursive: true });
       await page.screenshot({
         path: path.join(RECOVERY_ARTIFACT_DIR, "02-reconnecting-actions-blocked.png"),
         fullPage: true,

--- a/ui/src/e2e/logs-autofollow.e2e.test.ts
+++ b/ui/src/e2e/logs-autofollow.e2e.test.ts
@@ -1,6 +1,7 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -12,7 +13,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.resolve(".artifacts/control-ui-e2e/control-ui-live-log-tail");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("control-ui-live-log-tail");
+  }
+});
 
 const logLines = Array.from({ length: 200 }, (_value, index) =>
   JSON.stringify({

--- a/ui/src/e2e/logs-layout.e2e.test.ts
+++ b/ui/src/e2e/logs-layout.e2e.test.ts
@@ -1,6 +1,7 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiBundledSettingsStorageKey,
   installMockGateway,
@@ -13,7 +14,13 @@ const suite = createControlUiE2eSuite({
   unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
 });
 
-const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+let artifactDir: string | undefined;
+beforeEach(() => {
+  artifactDir = artifactRoot
+    ? createControlUiE2eArtifactDir("logs-layout", artifactRoot)
+    : undefined;
+});
 const proofLabel = process.env.OPENCLAW_UI_E2E_PROOF_LABEL?.trim() || "logs-layout";
 const viewport = { height: 584, width: 863 };
 

--- a/ui/src/e2e/managed-image-actions.e2e.test.ts
+++ b/ui/src/e2e/managed-image-actions.e2e.test.ts
@@ -1,6 +1,7 @@
-import { mkdir, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   captureUiProofEnabled,
   createChatFlowE2eSuite,
@@ -9,7 +10,12 @@ import {
 
 const suite = createChatFlowE2eSuite();
 const controlUiBasePath = "/rosita";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "managed-image-actions");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    proofDir = createControlUiE2eArtifactDir("managed-image-actions");
+  }
+});
 
 suite.define(() => {
   it("previews, downloads, and opens a ticketed generated image", async () => {
@@ -84,7 +90,6 @@ suite.define(() => {
         .toBe(1280);
       expect(requestedVariants).toEqual(["thumbnail"]);
       if (captureUiProofEnabled) {
-        await mkdir(proofDir, { recursive: true });
         await page.screenshot({
           fullPage: true,
           path: path.join(proofDir, "ticketed-generated-image-subpath.png"),

--- a/ui/src/e2e/managed-media-base-path.e2e.test.ts
+++ b/ui/src/e2e/managed-media-base-path.e2e.test.ts
@@ -1,7 +1,8 @@
-import { mkdir, readFile } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { chromium } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   installMockGateway,
   resolvePlaywrightChromiumExecutablePath,
@@ -9,16 +10,19 @@ import {
   type ControlUiE2eServer,
 } from "../test-helpers/control-ui-e2e.ts";
 
-const proofDir = process.env.OPENCLAW_MEDIA_PROOF_DIR?.trim() || null;
+const proofDirParent = process.env.OPENCLAW_MEDIA_PROOF_DIR?.trim() || null;
+let proofDir: string | undefined;
+beforeEach(() => {
+  proofDir = proofDirParent
+    ? createControlUiE2eArtifactDir("managed-media-base-path", proofDirParent)
+    : undefined;
+});
 
 let server: ControlUiE2eServer;
 
 describe("Control UI managed media under a UI base path", () => {
   beforeAll(async () => {
     server = await startControlUiE2eServer();
-    if (proofDir) {
-      await mkdir(proofDir, { recursive: true });
-    }
   });
 
   afterAll(async () => {

--- a/ui/src/e2e/mantis-chat-proof.e2e.test.ts
+++ b/ui/src/e2e/mantis-chat-proof.e2e.test.ts
@@ -3,6 +3,7 @@ import { copyFile, mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -17,10 +18,6 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeMantisWebUiChat =
   chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-const artifactDir = path.resolve(
-  process.env.OPENCLAW_MANTIS_WEB_UI_CHAT_OUTPUT_DIR ??
-    path.join(process.cwd(), ".artifacts", "qa-e2e", "mantis", "web-ui-chat-proof"),
-);
 
 let server: ControlUiE2eServer;
 const contextBrowsers = new WeakMap<BrowserContext, Browser>();
@@ -51,7 +48,6 @@ describeMantisWebUiChat("Mantis Control UI web chat proof", () => {
         `Playwright Chromium is not installed or cannot start at ${chromiumExecutablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, set PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH to a compatible browser, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
       );
     }
-    await mkdir(artifactDir, { recursive: true });
     server = await startControlUiE2eServer();
   });
 
@@ -60,6 +56,10 @@ describeMantisWebUiChat("Mantis Control UI web chat proof", () => {
   });
 
   it("sends a chat message and captures visible browser proof", async () => {
+    const artifactDir = createControlUiE2eArtifactDir(
+      "mantis-chat-proof",
+      process.env.OPENCLAW_MANTIS_WEB_UI_CHAT_OUTPUT_DIR?.trim() || undefined,
+    );
     const rawVideoDir = path.join(artifactDir, "raw-video");
     await mkdir(rawVideoDir, { recursive: true });
     const context = await newBrowserContext({

--- a/ui/src/e2e/memory-settings-defaults.e2e.test.ts
+++ b/ui/src/e2e/memory-settings-defaults.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI tests cover Memory default provenance and clearing optional overrides.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway, type MockGatewayRequest } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -14,12 +14,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "memory-settings-defaults",
-);
+let uiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    uiProofArtifactDir = createControlUiE2eArtifactDir("memory-settings-defaults");
+  }
+});
 
 const memoryPlugins = [
   {
@@ -64,7 +64,6 @@ async function captureProof(page: Page, name: string, locator?: Locator) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(uiProofArtifactDir, { recursive: true });
   await locator?.scrollIntoViewIfNeeded();
   await page.screenshot({
     animations: "disabled",

--- a/ui/src/e2e/memory-settings-engine.e2e.test.ts
+++ b/ui/src/e2e/memory-settings-engine.e2e.test.ts
@@ -1,7 +1,7 @@
 // Control UI tests cover memory engine ordering and serialized config writes.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -13,12 +13,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "memory-settings-engine",
-);
+let uiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    uiProofArtifactDir = createControlUiE2eArtifactDir("memory-settings-engine");
+  }
+});
 
 function configResponse(engineId: string, hash: string) {
   const config = { plugins: { slots: { memory: engineId } } };
@@ -94,7 +94,6 @@ suite.define(() => {
         const pendingOffSave = await gateway.waitForRequest("config.set");
         expect(pendingOffSave.params).toMatchObject({ baseHash: "memory-hash-1" });
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await page
             .locator(".settings-page > .settings-section")
             .first()
@@ -124,7 +123,6 @@ suite.define(() => {
           .toBe(0);
 
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await page
             .locator(".settings-page > .settings-section")
             .first()
@@ -213,7 +211,6 @@ suite.define(() => {
         expect(pageErrors).toEqual([]);
 
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await page.locator("openclaw-memory-settings").screenshot({
             animations: "disabled",
             path: path.join(uiProofArtifactDir, "03-addon-committed-refresh-warning.png"),
@@ -262,7 +259,6 @@ suite.define(() => {
           .toBe("true");
 
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await page
             .locator(".settings-page > .settings-section")
             .first()

--- a/ui/src/e2e/mobile-chat-session-menu.e2e.test.ts
+++ b/ui/src/e2e/mobile-chat-session-menu.e2e.test.ts
@@ -85,7 +85,7 @@ suite.define(() => {
           .locator('wa-dropdown-item[value="delete"] .session-menu__text')
           .evaluate((element) => getComputedStyle(element).color);
         expect(deleteIconColor).toBe(deleteLabelColor);
-        await captureUiProof(page, `mobile-more-followup-after-${colorScheme}.png`);
+        await captureUiProof(suite, page, `mobile-more-followup-after-${colorScheme}.png`);
 
         await expect
           .poll(() => page.getByRole("button", { name: "Session sharing" }).count())
@@ -107,7 +107,7 @@ suite.define(() => {
             publish.evaluate((element) => Math.round(element.getBoundingClientRect().height)),
           )
           .toBe(34);
-        await captureUiProof(page, `mobile-more-sharing-followup-after-${colorScheme}.png`);
+        await captureUiProof(suite, page, `mobile-more-sharing-followup-after-${colorScheme}.png`);
       } finally {
         await context.close();
       }

--- a/ui/src/e2e/mobile-inbox-sheet.e2e.test.ts
+++ b/ui/src/e2e/mobile-inbox-sheet.e2e.test.ts
@@ -1,10 +1,16 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+let artifactDir: string | undefined;
+beforeEach(() => {
+  artifactDir = artifactRoot
+    ? createControlUiE2eArtifactDir("mobile-inbox-sheet", artifactRoot)
+    : undefined;
+});
 const viewport = { width: 390, height: 844 };
 const suite = createControlUiE2eSuite({
   name: "Control UI mobile Inbox sheet",
@@ -103,7 +109,6 @@ suite.define(() => {
       results.push(result);
 
       if (artifactDir) {
-        await mkdir(artifactDir, { recursive: true });
         const previousStyle = await page.addStyleTag({
           content: `
             .shell--mobile-nav .sidebar-issues-panel { background: var(--bg-elevated); }

--- a/ui/src/e2e/mobile-pairing.e2e.test.ts
+++ b/ui/src/e2e/mobile-pairing.e2e.test.ts
@@ -1,10 +1,10 @@
 // Control UI tests cover mobile pairing setup through the mocked Gateway.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "@openclaw/gateway-client/browser";
 import type { Page } from "playwright";
 import qrcode from "qrcode";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { requireRecord, requireString } from "./chat-flow.test-support.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -19,18 +19,17 @@ const suite = createControlUiE2eSuite({
 // Visual proof rides the behavioral scenario so every captured state is one the
 // assertions above it already proved, at whatever SHA the lane ran.
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "mobile-pairing",
-);
+let uiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    uiProofArtifactDir = createControlUiE2eArtifactDir("mobile-pairing");
+  }
+});
 
 async function captureUiProof(page: Page, fileName: string) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(uiProofArtifactDir, { recursive: true });
   await page.screenshot({ animations: "disabled", path: path.join(uiProofArtifactDir, fileName) });
 }
 

--- a/ui/src/e2e/mobile-sidebar-session-menu.e2e.test.ts
+++ b/ui/src/e2e/mobile-sidebar-session-menu.e2e.test.ts
@@ -52,7 +52,7 @@ suite.define(() => {
 
       const menu = page.getByRole("menu", { name: "Actions for Mobile sidebar menu" });
       await menu.waitFor({ state: "visible" });
-      await captureUiProof(page, "mobile-sidebar-session-menu-after-root.png");
+      await captureUiProof(suite, page, "mobile-sidebar-session-menu-after-root.png");
 
       expect(await page.locator("openclaw-session-menu [slot='submenu']").count()).toBe(0);
       await page.getByRole("menuitem", { name: "Move to group" }).click();
@@ -84,7 +84,7 @@ suite.define(() => {
       }
       expect(backBox.y).toBeGreaterThanOrEqual(menuBox.y);
       expect(backBox.y + backBox.height).toBeLessThanOrEqual(menuBox.y + menuBox.height);
-      await captureUiProof(page, "mobile-sidebar-session-menu-after-group-drilldown.png");
+      await captureUiProof(suite, page, "mobile-sidebar-session-menu-after-group-drilldown.png");
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/model-alias-display.e2e.test.ts
+++ b/ui/src/e2e/model-alias-display.e2e.test.ts
@@ -1,6 +1,6 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
@@ -26,15 +26,15 @@ const models = [
   },
 ];
 
-const proofDir =
-  process.env.OPENCLAW_CAPTURE_UI_PROOF === "1"
-    ? path.join(process.cwd(), ".artifacts", "control-ui-e2e", "model-alias-display")
-    : null;
+let proofDir: string | null;
+beforeEach(() => {
+  proofDir =
+    process.env.OPENCLAW_CAPTURE_UI_PROOF === "1"
+      ? createControlUiE2eArtifactDir("model-alias-display")
+      : null;
+});
 
 async function createProofContext() {
-  if (proofDir) {
-    await mkdir(proofDir, { recursive: true });
-  }
   return suite.newBrowserContext({
     locale: "en-US",
     serviceWorkers: "block",

--- a/ui/src/e2e/model-provider-usage-outcomes.e2e.test.ts
+++ b/ui/src/e2e/model-provider-usage-outcomes.e2e.test.ts
@@ -13,7 +13,6 @@ const suite = createControlUiE2eSuite({
 });
 const now = Date.now();
 const recordVisuals = process.env.OPENCLAW_UI_E2E_RECORD === "1";
-const artifactDir = path.resolve(".artifacts/control-ui-e2e/model-providers");
 const unavailableMessage =
   "Provider usage is unavailable; the last request failed. Refresh to retry.";
 
@@ -61,11 +60,14 @@ suite.define(() => {
           .poll(() => page.locator(".settings-page").textContent())
           .toContain(unavailableMessage);
         if (recordVisuals) {
-          await mkdir(artifactDir, { recursive: true });
+          await mkdir(path.join(suite.artifactDir, "model-providers"), { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
-            path: path.join(artifactDir, "provider-usage-request-failed.png"),
+            path: path.join(
+              path.join(suite.artifactDir, "model-providers"),
+              "provider-usage-request-failed.png",
+            ),
           });
         }
       },
@@ -105,10 +107,13 @@ suite.define(() => {
           .poll(() => page.locator(".settings-page").textContent())
           .not.toContain(unavailableMessage);
         if (recordVisuals) {
-          await mkdir(artifactDir, { recursive: true });
+          await mkdir(path.join(suite.artifactDir, "model-providers"), { recursive: true });
           await card.screenshot({
             animations: "disabled",
-            path: path.join(artifactDir, "provider-usage-provider-error.png"),
+            path: path.join(
+              path.join(suite.artifactDir, "model-providers"),
+              "provider-usage-provider-error.png",
+            ),
           });
         }
       },
@@ -167,13 +172,16 @@ suite.define(() => {
           .toBeGreaterThan(0);
 
         if (recordVisuals) {
-          await mkdir(artifactDir, { recursive: true });
+          await mkdir(path.join(suite.artifactDir, "model-providers"), { recursive: true });
           const phase =
             (await page.locator(".provider-usage-error").count()) === 0 ? "before" : "after";
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
-            path: path.join(artifactDir, `model-catalog-request-failure-${phase}.png`),
+            path: path.join(
+              path.join(suite.artifactDir, "model-providers"),
+              `model-catalog-request-failure-${phase}.png`,
+            ),
           });
         }
 
@@ -208,7 +216,10 @@ suite.define(() => {
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
-            path: path.join(artifactDir, "model-catalog-request-recovered.png"),
+            path: path.join(
+              path.join(suite.artifactDir, "model-providers"),
+              "model-catalog-request-recovered.png",
+            ),
           });
         }
       },
@@ -277,9 +288,12 @@ suite.define(() => {
         await expect.poll(async () => openaiCard.textContent()).toContain("Credentials for Main");
         await openaiCard.getByRole("button", { name: "Replace key" }).click();
         if (recordVisuals) {
-          await mkdir(artifactDir, { recursive: true });
+          await mkdir(path.join(suite.artifactDir, "model-providers"), { recursive: true });
           await page.screenshot({
-            path: path.join(artifactDir, "provider-credential-scope-before.png"),
+            path: path.join(
+              path.join(suite.artifactDir, "model-providers"),
+              "provider-credential-scope-before.png",
+            ),
             fullPage: true,
           });
         }
@@ -293,7 +307,10 @@ suite.define(() => {
         expect(await gateway.getRequests("config.patch")).toHaveLength(0);
         if (recordVisuals) {
           await page.screenshot({
-            path: path.join(artifactDir, "provider-credential-scope-inline-cleared.png"),
+            path: path.join(
+              path.join(suite.artifactDir, "model-providers"),
+              "provider-credential-scope-inline-cleared.png",
+            ),
             fullPage: true,
           });
         }
@@ -312,7 +329,10 @@ suite.define(() => {
         expect(await gateway.getRequests("config.patch")).toHaveLength(0);
         if (recordVisuals) {
           await page.screenshot({
-            path: path.join(artifactDir, "provider-credential-scope-after.png"),
+            path: path.join(
+              path.join(suite.artifactDir, "model-providers"),
+              "provider-credential-scope-after.png",
+            ),
             fullPage: true,
           });
         }

--- a/ui/src/e2e/model-providers-progressive.e2e.test.ts
+++ b/ui/src/e2e/model-providers-progressive.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -15,9 +15,15 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const recordVisuals = process.env.OPENCLAW_UI_E2E_RECORD === "1";
-const artifactDir = path.resolve(
-  process.env.OPENCLAW_UI_E2E_PROOF_DIR ?? ".artifacts/control-ui-e2e/model-providers-progressive",
-);
+let artifactDir: string;
+beforeEach(() => {
+  if (recordVisuals) {
+    artifactDir = createControlUiE2eArtifactDir(
+      "model-providers-progressive",
+      process.env.OPENCLAW_UI_E2E_PROOF_DIR,
+    );
+  }
+});
 
 describeControlUiE2e("Control UI progressive Model Providers loading", () => {
   let browser: Browser;
@@ -29,9 +35,6 @@ describeControlUiE2e("Control UI progressive Model Providers loading", () => {
     }
     server = await startControlUiE2eServer();
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    if (recordVisuals) {
-      await mkdir(artifactDir, { recursive: true });
-    }
   });
 
   afterAll(async () => {

--- a/ui/src/e2e/model-providers.e2e.test.ts
+++ b/ui/src/e2e/model-providers.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI tests cover the Models settings page against a mocked Gateway.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type Locator } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -19,9 +19,16 @@ const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? descri
 
 const NOW = Date.now();
 const recordVisuals = process.env.OPENCLAW_UI_E2E_RECORD === "1";
-const artifactDir = path.resolve(".artifacts/control-ui-e2e/model-providers");
-const utilityHelpArtifactDir = path.resolve(".artifacts/control-ui-e2e/utility-model-help");
-const readinessArtifactDir = path.resolve(".artifacts/control-ui-e2e/models-provider-readiness");
+let artifactDir: string;
+let utilityHelpArtifactDir: string;
+let readinessArtifactDir: string;
+beforeEach(() => {
+  if (recordVisuals) {
+    artifactDir = createControlUiE2eArtifactDir("model-providers");
+    utilityHelpArtifactDir = path.join(artifactDir, "utility-model-help");
+    readinessArtifactDir = path.join(artifactDir, "models-provider-readiness");
+  }
+});
 const redactedConfigValue = "[redacted]";
 const openaiInputValue = ["e2e", "test", "key"].join("-");
 const googleInputValue = ["e2e", "google", "key"].join("-");
@@ -61,11 +68,6 @@ describeControlUiE2e("Control UI Models mocked Gateway E2E", () => {
     }
     server = await startControlUiE2eServer();
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
-    if (recordVisuals) {
-      await mkdir(artifactDir, { recursive: true });
-      await mkdir(utilityHelpArtifactDir, { recursive: true });
-      await mkdir(readinessArtifactDir, { recursive: true });
-    }
   });
 
   afterAll(async () => {

--- a/ui/src/e2e/model-setup-activation-feedback.e2e.test.ts
+++ b/ui/src/e2e/model-setup-activation-feedback.e2e.test.ts
@@ -1,10 +1,10 @@
 // Real browser flow with a mocked Gateway; no Ollama server or model is used.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import type { Locator } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import type { ApplicationRuntime } from "../app/bootstrap.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   defaultControlUiFeatureMethods,
   installMockGateway,
@@ -15,7 +15,13 @@ const suite = createControlUiE2eSuite({
   name: "Model Setup activation feedback mocked Gateway E2E",
   startServerBeforeBrowser: true,
 });
-const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+let artifactDir: string | undefined;
+beforeEach(() => {
+  artifactDir = artifactRoot
+    ? createControlUiE2eArtifactDir("model-setup-activation-feedback", artifactRoot)
+    : undefined;
+});
 
 async function viewportIntersection(target: Locator): Promise<number> {
   return target.evaluate(
@@ -124,7 +130,6 @@ suite.define(() => {
         await connectionOwner.dispose();
         expect(pageErrors).toEqual([]);
         if (artifactDir) {
-          await mkdir(artifactDir, { recursive: true });
           await page.screenshot({ path: path.join(artifactDir, "setup-back-to-chat.png") });
         }
       },
@@ -204,7 +209,6 @@ suite.define(() => {
             ),
           ).toBe(false);
           if (artifactDir) {
-            await mkdir(artifactDir, { recursive: true });
             await page.screenshot({
               path: path.join(artifactDir, `${entry}-viewport-pending.png`),
             });
@@ -340,7 +344,6 @@ suite.define(() => {
           await progress.waitFor();
           expect.soft(await viewportIntersection(progress)).toBeGreaterThan(0.99);
           if (artifactDir) {
-            await mkdir(artifactDir, { recursive: true });
             await page.screenshot({ path: path.join(artifactDir, `${outcome}-pending.png`) });
           }
           expect.soft(await progress.count()).toBe(1);

--- a/ui/src/e2e/model-setup-cancel.e2e.test.ts
+++ b/ui/src/e2e/model-setup-cancel.e2e.test.ts
@@ -1,7 +1,7 @@
 // Real routing and browser storage; Gateway/provider sign-in is mocked.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -9,7 +9,13 @@ const suite = createControlUiE2eSuite({
   name: "Control UI first-run wizard cancellation ownership",
   startServerBeforeBrowser: true,
 });
-const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+let artifactDir: string | undefined;
+beforeEach(() => {
+  artifactDir = artifactRoot
+    ? createControlUiE2eArtifactDir("model-setup-cancel", artifactRoot)
+    : undefined;
+});
 const receiptKey = "openclaw.modelSetup.pendingActivation.v1";
 const detection = {
   candidates: [],
@@ -72,7 +78,6 @@ suite.define(() => {
             await gateway.resolveDeferred("wizard.cancel");
           }
           if (artifactDir) {
-            await mkdir(artifactDir, { recursive: true });
             await page.screenshot({
               path: path.join(artifactDir, `cancel-${acknowledgement.replaceAll(" ", "-")}.png`),
               animations: "disabled",

--- a/ui/src/e2e/model-setup-llamacpp.e2e.test.ts
+++ b/ui/src/e2e/model-setup-llamacpp.e2e.test.ts
@@ -1,7 +1,7 @@
 // Control UI tests cover llama.cpp setup against a mocked Gateway.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -11,7 +11,13 @@ const suite = createControlUiE2eSuite({
   unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
 });
 
-const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+let artifactDir: string | undefined;
+beforeEach(() => {
+  artifactDir = artifactRoot
+    ? createControlUiE2eArtifactDir("model-setup-llamacpp", artifactRoot)
+    : undefined;
+});
 const prepareOptions = [
   {
     id: "ollama",
@@ -139,7 +145,6 @@ suite.define(() => {
         await expect.poll(() => llamaCppRow.textContent()).not.toContain("RAM");
 
         if (artifactDir) {
-          await mkdir(artifactDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,

--- a/ui/src/e2e/model-setup-lmstudio.e2e.test.ts
+++ b/ui/src/e2e/model-setup-lmstudio.e2e.test.ts
@@ -1,7 +1,7 @@
 // Control UI tests cover LM Studio setup against a mocked Gateway.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -11,7 +11,13 @@ const suite = createControlUiE2eSuite({
   unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
 });
 
-const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+let artifactDir: string | undefined;
+beforeEach(() => {
+  artifactDir = artifactRoot
+    ? createControlUiE2eArtifactDir("model-setup-lmstudio", artifactRoot)
+    : undefined;
+});
 const prepareOptions = [
   {
     id: "lmstudio",
@@ -125,7 +131,6 @@ suite.define(() => {
           .toBe(1);
 
         if (artifactDir) {
-          await mkdir(artifactDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,

--- a/ui/src/e2e/model-setup-reconnect.e2e.test.ts
+++ b/ui/src/e2e/model-setup-reconnect.e2e.test.ts
@@ -1,9 +1,9 @@
 // Browser proof that model setup reloads after a same-client Gateway reconnect.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { Compile } from "typebox/compile";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import { ConnectParamsSchema } from "../../../packages/gateway-protocol/src/schema.js";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -14,12 +14,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const artifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "model-setup-reconnect",
-);
+let artifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    artifactDir = createControlUiE2eArtifactDir("model-setup-reconnect");
+  }
+});
 
 const validateConnect = Compile(ConnectParamsSchema);
 function connectParams(value: unknown) {
@@ -147,7 +147,6 @@ suite.define(() => {
           expect(new URL(destination.url()).pathname).toBe("/settings/model-setup");
           expect(await reconnectedGateway.getRequests("openclaw.chat")).toHaveLength(0);
           if (captureUiProofEnabled) {
-            await mkdir(artifactDir, { recursive: true });
             await destination.screenshot({
               animations: "disabled",
               path: path.join(artifactDir, `manual-first-run-${restart}-pending.png`),
@@ -177,7 +176,6 @@ suite.define(() => {
           expect(welcomeRequest.params).toMatchObject({ welcomeVariant: "onboarding" });
           if (captureUiProofEnabled) {
             await destination.locator(".custodian__header--minimal").waitFor();
-            await mkdir(artifactDir, { recursive: true });
             await destination.screenshot({
               animations: "disabled",
               path: path.join(artifactDir, `manual-first-run-${restart}-fixed.png`),
@@ -335,7 +333,6 @@ suite.define(() => {
         expect(pageErrors).toEqual([]);
 
         if (captureUiProofEnabled) {
-          await mkdir(artifactDir, { recursive: true });
           await page.locator("openclaw-model-setup-page").screenshot({
             animations: "disabled",
             path: path.join(artifactDir, "00-reconnected-model-visible.png"),

--- a/ui/src/e2e/model-setup-recovery.e2e.test.ts
+++ b/ui/src/e2e/model-setup-recovery.e2e.test.ts
@@ -1,7 +1,7 @@
 // Control UI tests cover local-provider recovery against a mocked Gateway.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -11,7 +11,13 @@ const suite = createControlUiE2eSuite({
   unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
 });
 
-const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+let artifactDir: string | undefined;
+beforeEach(() => {
+  artifactDir = artifactRoot
+    ? createControlUiE2eArtifactDir("model-setup-recovery", artifactRoot)
+    : undefined;
+});
 
 suite.define(() => {
   it("shows a failed LM Studio connection with its detected endpoint", async () => {
@@ -99,7 +105,6 @@ suite.define(() => {
           .toBe(0);
 
         if (artifactDir) {
-          await mkdir(artifactDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,

--- a/ui/src/e2e/model-setup.e2e.test.ts
+++ b/ui/src/e2e/model-setup.e2e.test.ts
@@ -1,7 +1,7 @@
 // Control UI tests cover guided model setup against a mocked Gateway.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -11,7 +11,13 @@ const suite = createControlUiE2eSuite({
   unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
 });
 
-const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+let artifactDir: string | undefined;
+beforeEach(() => {
+  artifactDir = artifactRoot
+    ? createControlUiE2eArtifactDir("model-setup", artifactRoot)
+    : undefined;
+});
 const localPrepareOptions = [
   {
     id: "ollama",
@@ -239,7 +245,6 @@ suite.define(() => {
         await page.getByText("ABCD-1234").waitFor();
         await page.getByText("Working…").waitFor();
         if (artifactDir) {
-          await mkdir(artifactDir, { recursive: true });
           await page.screenshot({
             path: path.join(artifactDir, "model-setup-refresh-pending.png"),
           });
@@ -431,7 +436,6 @@ suite.define(() => {
         expect(start.params).toMatchObject({ authChoice: "ollama" });
 
         if (artifactDir) {
-          await mkdir(artifactDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
@@ -459,7 +463,6 @@ suite.define(() => {
           .waitFor();
 
         if (artifactDir) {
-          await mkdir(artifactDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
@@ -666,7 +669,6 @@ suite.define(() => {
           .toBe(1);
 
         if (artifactDir) {
-          await mkdir(artifactDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
@@ -885,7 +887,6 @@ suite.define(() => {
           .toBe(0);
         await expect.poll(() => page.locator('[data-candidate-kind="claude-cli"]').count()).toBe(1);
         if (artifactDir) {
-          await mkdir(artifactDir, { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,

--- a/ui/src/e2e/mount-recovery.e2e.test.ts
+++ b/ui/src/e2e/mount-recovery.e2e.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway, startControlUiE2eServer } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -12,7 +13,7 @@ const suite = createControlUiE2eSuite({
 
 suite.define(() => {
   it("reloads a fresh document after the initial app module is unavailable", async () => {
-    const artifactDir = path.resolve(".artifacts/control-ui-e2e/mount-recovery");
+    const artifactDir = createControlUiE2eArtifactDir("mount-recovery");
     await suite.withPage(
       {
         locale: "en-US",

--- a/ui/src/e2e/native-link-routing.e2e.test.ts
+++ b/ui/src/e2e/native-link-routing.e2e.test.ts
@@ -1,8 +1,8 @@
 // Real-browser proof for native-host link routing and the bridge-free browser path.
-import fs from "node:fs";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -15,7 +15,10 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/native-link-routing");
+let artifactDir: string;
+beforeEach(() => {
+  artifactDir = createControlUiE2eArtifactDir("native-link-routing");
+});
 
 let server: ControlUiE2eServer;
 // Browser contexts preserve test isolation; keep one process warm for this file.
@@ -43,7 +46,6 @@ describeControlUiE2e("native link routing", () => {
     if (!chromiumAvailable) {
       throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
     }
-    fs.mkdirSync(artifactDir, { recursive: true });
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     try {
       server = await startControlUiE2eServer();

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -1,10 +1,10 @@
 // Shipped apps stamp `openclaw-native-nav`; current apps advertise web chrome
 // at document start and stamp `openclaw-native-web-chrome` at document end.
 // Plain browsers keep their normal in-page controls.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext, Page } from "playwright";
-import { afterEach, expect, it } from "vitest";
+import { beforeEach, afterEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   installMockGateway,
   type ControlUiMockGatewayScenario,
@@ -25,8 +25,17 @@ const suite = createControlUiE2eSuite({
   startServerBeforeBrowser: true,
   unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
 });
-const TOAST_PROOF_DIR = path.resolve(".artifacts/control-ui-e2e/toast-layering");
-const railProofDir = process.env.OPENCLAW_UI_RAIL_PROOF_DIR?.trim();
+let TOAST_PROOF_DIR: string;
+beforeEach(() => {
+  TOAST_PROOF_DIR = createControlUiE2eArtifactDir("toast-layering");
+});
+const railProofDirParent = process.env.OPENCLAW_UI_RAIL_PROOF_DIR?.trim();
+let railProofDir: string | undefined;
+beforeEach(() => {
+  railProofDir = railProofDirParent
+    ? createControlUiE2eArtifactDir("native-nav-sidebar-toggle", railProofDirParent)
+    : undefined;
+});
 const limitedScopes = ["operator.read", "operator.write"];
 const UPDATE_AVAILABLE = {
   channel: "stable",
@@ -471,7 +480,6 @@ suite.define(() => {
       expect(centerline).toBeCloseTo(centerlines[0]!, 1);
     }
     if (railProofDir) {
-      await mkdir(railProofDir, { recursive: true });
       await page.screenshot({
         animations: "disabled",
         path: path.join(railProofDir, "native-web-top-left-controls.png"),
@@ -577,7 +585,6 @@ suite.define(() => {
       await panelControls.nth(index).click({ trial: true });
     }
     if (railProofDir) {
-      await mkdir(railProofDir, { recursive: true });
       await page.screenshot({
         fullPage: true,
         path: path.join(

--- a/ui/src/e2e/native-session-sidebar.e2e.test.ts
+++ b/ui/src/e2e/native-session-sidebar.e2e.test.ts
@@ -1,6 +1,6 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -12,12 +12,12 @@ const suite = createControlUiE2eSuite({
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const collapsedSessionSectionsStorageKey = "openclaw:sidebar:sessions:collapsed-sections";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "native-session-discovery",
-);
+let uiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    uiProofArtifactDir = createControlUiE2eArtifactDir("native-session-discovery");
+  }
+});
 
 suite.define(() => {
   it("hides empty native hosts and the empty Coding section", async () => {
@@ -101,7 +101,6 @@ suite.define(() => {
       await section.getByText("Shared gateway session", { exact: true }).waitFor();
       await section.getByText("Remote-only session", { exact: true }).waitFor();
       if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
         await sessionGroups.screenshot({
           animations: "disabled",
           path: path.join(uiProofArtifactDir, "08-after-deduplicated-session-hosts.png"),

--- a/ui/src/e2e/new-session-page.agent-identity.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.agent-identity.e2e.test.ts
@@ -12,12 +12,6 @@ const suite = createNewSessionPageE2eSuite();
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const proofStage = process.env.OPENCLAW_AGENT_IDENTITY_PROOF_STAGE ?? "after";
 const captureBefore = proofStage === "before";
-const proofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "new-session-agent-identity",
-);
 
 const agentsList = {
   agents: [
@@ -87,11 +81,16 @@ async function capture(page: Page, name: string) {
   if (!captureProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
+  await mkdir(path.join(suite.artifactDir, "new-session-agent-identity", proofStage), {
+    recursive: true,
+  });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,
-    path: path.join(proofDir, `${proofStage}-${name}`),
+    path: path.join(
+      path.join(suite.artifactDir, "new-session-agent-identity", proofStage),
+      `${proofStage}-${name}`,
+    ),
   });
 }
 
@@ -99,10 +98,15 @@ async function captureElement(locator: Locator, name: string) {
   if (!captureProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
+  await mkdir(path.join(suite.artifactDir, "new-session-agent-identity", proofStage), {
+    recursive: true,
+  });
   await locator.screenshot({
     animations: "disabled",
-    path: path.join(proofDir, `${proofStage}-${name}`),
+    path: path.join(
+      path.join(suite.artifactDir, "new-session-agent-identity", proofStage),
+      `${proofStage}-${name}`,
+    ),
   });
 }
 

--- a/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.catalog-reconnect.e2e.test.ts
@@ -18,12 +18,6 @@ import {
 
 const suite = createNewSessionPageE2eSuite();
 const captureCliAgentsProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const cliAgentsProofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "cli-agents-picker",
-);
 
 function requestHasParam(request: { params?: unknown }, key: string, value: unknown): boolean {
   return Boolean(
@@ -119,14 +113,19 @@ suite.define(() => {
 
   it("routes a Labs-enabled CLI agent picker row through catalog-target mode", async () => {
     if (captureCliAgentsProof) {
-      await mkdir(cliAgentsProofDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "cli-agents-picker"), { recursive: true });
     }
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       ...(captureCliAgentsProof
-        ? { recordVideo: { dir: cliAgentsProofDir, size: { height: 900, width: 1280 } } }
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "cli-agents-picker"),
+              size: { height: 900, width: 1280 },
+            },
+          }
         : {}),
     });
     const page = await context.newPage();
@@ -183,7 +182,7 @@ suite.define(() => {
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
-          path: path.join(cliAgentsProofDir, "picker-group.png"),
+          path: path.join(path.join(suite.artifactDir, "cli-agents-picker"), "picker-group.png"),
         });
       }
 
@@ -202,7 +201,7 @@ suite.define(() => {
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
-          path: path.join(cliAgentsProofDir, "catalog-target.png"),
+          path: path.join(path.join(suite.artifactDir, "cli-agents-picker"), "catalog-target.png"),
         });
       }
     } finally {
@@ -271,14 +270,19 @@ suite.define(() => {
 
   it("creates a worktree, starts the catalog session, and opens its terminal", async () => {
     if (captureCliAgentsProof) {
-      await mkdir(cliAgentsProofDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "cli-agents-picker"), { recursive: true });
     }
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       ...(captureCliAgentsProof
-        ? { recordVideo: { dir: cliAgentsProofDir, size: { height: 900, width: 1280 } } }
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "cli-agents-picker"),
+              size: { height: 900, width: 1280 },
+            },
+          }
         : {}),
     });
     const page = await context.newPage();
@@ -393,7 +397,7 @@ suite.define(() => {
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
-          path: path.join(cliAgentsProofDir, "terminal-split.png"),
+          path: path.join(path.join(suite.artifactDir, "cli-agents-picker"), "terminal-split.png"),
         });
       }
 

--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -26,12 +26,6 @@ import {
 const suite = createNewSessionPageE2eSuite();
 const SESSION_PLACEMENT_STARTUP_RUNTIME_REQUEST =
   /\/assets\/session-placement-startup\.runtime-[^/?]+\.js(?:\?.*)?$/;
-const cloudProfileRefreshProofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "cloud-profile-refresh-retention",
-);
 
 suite.define(() => {
   it("dispatches an optionless cloud profile without a machine override", async () => {
@@ -87,7 +81,7 @@ suite.define(() => {
         .toBe(false);
       expect(await place.getByText("Machine", { exact: true }).count()).toBe(0);
       expect(await place.locator('[data-value^="machine:"]').count()).toBe(0);
-      await captureUiProof(page, "optionless-cloud-profile.png");
+      await captureUiProof(suite, page, "optionless-cloud-profile.png");
       await page.keyboard.press("Escape");
 
       await page.locator(".new-session-page__message").fill("Use the configured machine size");
@@ -99,14 +93,21 @@ suite.define(() => {
 
   it("dispatches a cloud target before sending its first turn and shows placement", async () => {
     if (captureUiProofEnabled) {
-      await mkdir(cloudProfileRefreshProofDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "cloud-profile-refresh-retention"), {
+        recursive: true,
+      });
     }
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       ...(captureUiProofEnabled
-        ? { recordVideo: { dir: cloudProfileRefreshProofDir, size: { height: 900, width: 1280 } } }
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "cloud-profile-refresh-retention"),
+              size: { height: 900, width: 1280 },
+            },
+          }
         : {}),
     });
     const page = await context.newPage();
@@ -273,7 +274,7 @@ suite.define(() => {
       await expect.poll(() => effortSelect.getAttribute("data-chat-thinking-value")).toBe("off");
       await thinkingSlider.press("End");
       await expect.poll(() => effortSelect.getAttribute("data-chat-thinking-value")).toBe("high");
-      await captureUiProof(page, "01-cloud-thinking-level.png");
+      await captureUiProof(suite, page, "01-cloud-thinking-level.png");
       await effortSelect.click();
       await expect
         .poll(() => effortSelect.evaluate((element) => element.closest("details")?.open ?? false))
@@ -328,7 +329,7 @@ suite.define(() => {
       await pollLocatorText(project.locator(".new-session-page__menu-note").last()).toContain(
         "Syncs OpenClaw to the selected runner",
       );
-      await captureUiProof(page, "01-cloud-worker-target.png");
+      await captureUiProof(suite, page, "01-cloud-worker-target.png");
       await page.keyboard.press("Escape");
 
       const message = "fix the cloud-only failure";
@@ -362,7 +363,10 @@ suite.define(() => {
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
-          path: path.join(cloudProfileRefreshProofDir, "01-before-refresh.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "cloud-profile-refresh-retention"),
+            "01-before-refresh.png",
+          ),
         });
         await page.keyboard.press("Escape");
       }
@@ -383,7 +387,10 @@ suite.define(() => {
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
-          path: path.join(cloudProfileRefreshProofDir, "02-refresh-pending.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "cloud-profile-refresh-retention"),
+            "02-refresh-pending.png",
+          ),
         });
       }
       await gateway.rejectDeferred("environments.list", {
@@ -415,7 +422,10 @@ suite.define(() => {
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
-          path: path.join(cloudProfileRefreshProofDir, "03-after-retry-exhaustion.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "cloud-profile-refresh-retention"),
+            "03-after-retry-exhaustion.png",
+          ),
         });
       }
       await page.keyboard.press("Escape");
@@ -437,6 +447,7 @@ suite.define(() => {
       expect(create.params).not.toHaveProperty("cwd");
       await expect.poll(() => runtimeRequested).toBe(true);
       const startupStatus = await expectPendingSessionPlacementStartupBeforeRuntime(
+        suite,
         page,
         gateway,
         sessionKey,
@@ -453,7 +464,10 @@ suite.define(() => {
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
-          path: path.join(cloudProfileRefreshProofDir, "04-session-dispatch.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "cloud-profile-refresh-retention"),
+            "04-session-dispatch.png",
+          ),
         });
       }
       const describeRequestsAfterNavigation = (await gateway.getRequests("sessions.describe"))
@@ -623,7 +637,7 @@ suite.define(() => {
         .locator("openclaw-session-menu")
         .getByRole("menuitem", { name: "Stop cloud worker…" });
       await stopWorker.waitFor();
-      await captureUiProof(page, "02-active-cloud-worker-stop.png");
+      await captureUiProof(suite, page, "02-active-cloud-worker-stop.png");
       expect(await localSessionRow.locator(".session-row-badge--cloud").count()).toBe(0);
       expect(await cloudPlacementBadge.locator("circle").count()).toBe(1);
       expect(await cloudPlacementBadge.locator("rect").count()).toBe(0);

--- a/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
@@ -16,10 +16,6 @@ import {
 
 const suite = createNewSessionPageE2eSuite();
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.resolve(
-  process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim() || ".artifacts/control-ui-e2e",
-  "cloud-session-recovery",
-);
 
 suite.define(() => {
   it("retries an ambiguous cloud create with the same session key and machine class", async () => {
@@ -274,7 +270,14 @@ suite.define(() => {
         locale: "en-US",
         serviceWorkers: "block",
         viewport,
-        ...(captureUiProof ? { recordVideo: { dir: proofDir, size: viewport } } : {}),
+        ...(captureUiProof
+          ? {
+              recordVideo: {
+                dir: path.join(suite.artifactDir, "cloud-session-recovery"),
+                size: viewport,
+              },
+            }
+          : {}),
       });
       const page = await context.newPage();
       const message = "restart this interrupted cloud task";
@@ -353,9 +356,12 @@ suite.define(() => {
         await expect.poll(() => composer.isDisabled()).toBe(true);
         await expect.poll(() => start.isDisabled()).toBe(true);
         if (captureUiProof) {
-          await mkdir(proofDir, { recursive: true });
+          await mkdir(path.join(suite.artifactDir, "cloud-session-recovery"), { recursive: true });
           await page.screenshot({
-            path: path.join(proofDir, "01-interrupted.png"),
+            path: path.join(
+              path.join(suite.artifactDir, "cloud-session-recovery"),
+              "01-interrupted.png",
+            ),
             fullPage: true,
           });
         }
@@ -369,7 +375,13 @@ suite.define(() => {
         await expect.poll(() => start.isEnabled()).toBe(true);
         expect(await readRecovery()).toBeNull();
         if (captureUiProof) {
-          await page.screenshot({ path: path.join(proofDir, "02-recovered.png"), fullPage: true });
+          await page.screenshot({
+            path: path.join(
+              path.join(suite.artifactDir, "cloud-session-recovery"),
+              "02-recovered.png",
+            ),
+            fullPage: true,
+          });
         }
 
         const previousCreateCount = (await gateway.getRequests("sessions.create")).length;

--- a/ui/src/e2e/new-session-page.connect-machine.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.connect-machine.e2e.test.ts
@@ -9,22 +9,16 @@ import {
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
-const proofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "connect-machine",
-);
 
 async function captureProof(page: import("playwright").Page, fileName: string) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(proofArtifactDir, { recursive: true });
+  await mkdir(path.join(suite.artifactDir, "connect-machine"), { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,
-    path: path.join(proofArtifactDir, fileName),
+    path: path.join(path.join(suite.artifactDir, "connect-machine"), fileName),
   });
 }
 
@@ -37,7 +31,7 @@ suite.define(() => {
       ...(captureUiProofEnabled
         ? {
             recordVideo: {
-              dir: proofArtifactDir,
+              dir: path.join(suite.artifactDir, "connect-machine"),
               size: { height: 900, width: 1280 },
             },
           }

--- a/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.device-dispatch.e2e.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { gatewayOriginScope } from "@openclaw/gateway-client/browser";
 import { expect, it } from "vitest";
 import { CLOUD_PROFILE_RETRY_DELAYS_MS } from "../pages/new-session/cloud-profile-discovery.ts";
@@ -163,7 +164,7 @@ suite.define(() => {
         locale: "en-US",
         serviceWorkers: "block",
         ...(process.env.OPENCLAW_CAPTURE_UI_PROOF === "1"
-          ? { recordVideo: { dir: ".artifacts/control-ui-e2e/device-runtime-gating" } }
+          ? { recordVideo: { dir: path.join(suite.artifactDir, "device-runtime-gating") } }
           : {}),
       });
       const page = await context.newPage();
@@ -226,7 +227,11 @@ suite.define(() => {
         expect(await gateway.getRequests("environments.list")).toHaveLength(
           requestsBeforeRefresh + 1,
         );
-        await captureDeviceRuntimeUiProof(page, `failed-topology-${value.replace(":", "-")}.png`);
+        await captureDeviceRuntimeUiProof(
+          suite,
+          page,
+          `failed-topology-${value.replace(":", "-")}.png`,
+        );
         expect(await start.isDisabled()).toBe(true);
         expect(await selectedDevice.isDisabled()).toBe(true);
         expect(await automaticDevice.isDisabled()).toBe(true);
@@ -534,7 +539,7 @@ suite.define(() => {
       await where.click();
       await page.locator('[data-value="device:paired-runner"]').click();
       await expect.poll(() => where.getAttribute("data-device-id")).toBe("paired-runner");
-      await captureDeviceRuntimeUiProof(page, "01-main-agent-paired-node-selected.png");
+      await captureDeviceRuntimeUiProof(suite, page, "01-main-agent-paired-node-selected.png");
 
       const agentPicker = page.locator(".new-session-page__select--agent openclaw-agent-select");
       await agentPicker.locator(".agent-select__trigger").click();
@@ -546,7 +551,11 @@ suite.define(() => {
       await expect
         .poll(() => where.locator(".new-session-page__trigger-label").textContent())
         .toBe("Local");
-      await captureDeviceRuntimeUiProof(page, "02-research-agent-local-destination-restored.png");
+      await captureDeviceRuntimeUiProof(
+        suite,
+        page,
+        "02-research-agent-local-destination-restored.png",
+      );
 
       const message = "run this agent locally";
       await page.locator(".new-session-page__message").fill(message);

--- a/ui/src/e2e/new-session-page.draft-handoff.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.draft-handoff.e2e.test.ts
@@ -46,7 +46,7 @@ suite.define(() => {
         .locator(".agent-chat__photo-input")
         .setInputFiles(path.join(process.cwd(), "ui/public/favicon-32.png"));
       await pageA.getByRole("button", { name: `Open image ${staleFileName}` }).waitFor();
-      await captureUiProof(pageA, "new-session-draft-before-navigation.png");
+      await captureUiProof(suite, pageA, "new-session-draft-before-navigation.png");
 
       await existingSession.click();
       await pageA.waitForURL((url) => url.pathname === controlUiSessionPath(sessionKey));
@@ -82,7 +82,7 @@ suite.define(() => {
       await expect(
         pageA.getByRole("button", { name: `Open image ${staleFileName}` }).count(),
       ).resolves.toBe(0);
-      await captureUiProof(pageA, "new-session-draft-restored.png");
+      await captureUiProof(suite, pageA, "new-session-draft-restored.png");
       await pageA.close();
 
       const freshPage = await context.newPage();

--- a/ui/src/e2e/new-session-page.environment-metadata.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.environment-metadata.e2e.test.ts
@@ -113,7 +113,7 @@ suite.define(() => {
       expect(await device.isDisabled()).toBe(true);
       expect(await device.textContent()).toContain("No worker slots are available");
       expect(await restrictedDevice.isEnabled()).toBe(true);
-      await captureDeviceRuntimeUiProof(page, "01-embedded-device-capacity-gated.png");
+      await captureDeviceRuntimeUiProof(suite, page, "01-embedded-device-capacity-gated.png");
       await page.keyboard.press("Escape");
 
       await modelSelect.click();
@@ -124,6 +124,7 @@ suite.define(() => {
       await expect.poll(() => restrictedDevice.isDisabled()).toBe(true);
       await expect.poll(() => tooltipTitleText(restrictedDevice)).toMatch(/enable|approv/i);
       await captureDeviceRuntimeUiProof(
+        suite,
         page,
         "02-codex-zero-slot-enabled-denied-command-disabled.png",
       );
@@ -140,7 +141,7 @@ suite.define(() => {
       await expect
         .poll(() => tooltipTitleText(device))
         .toBe("This runtime does not support paired devices");
-      await captureDeviceRuntimeUiProof(page, "03-cloud-only-device-disabled.png");
+      await captureDeviceRuntimeUiProof(suite, page, "03-cloud-only-device-disabled.png");
       await page.keyboard.press("Escape");
 
       await modelSelect.click();
@@ -239,7 +240,7 @@ suite.define(() => {
       const place = page.locator("wa-popover.new-session-page__where-popover");
       const row = (id: string) => place.locator(`[data-value="device:${id}"]`);
       await row("alpha-device").waitFor();
-      await captureEnvironmentMetadataUiProof(page);
+      await captureEnvironmentMetadataUiProof(suite, page);
 
       expect(await row("alpha-device").isEnabled()).toBe(true);
       await expect

--- a/ui/src/e2e/new-session-page.github-projects.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.github-projects.e2e.test.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { mkdir, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import {
@@ -12,8 +12,6 @@ import {
   installMockGateway,
   navigateInApp,
   pollLocatorText,
-  prepareProjectUiProof,
-  projectProofArtifactDir,
   waitForCommittedChatRoute,
 } from "./new-session-page.test-support.ts";
 
@@ -34,14 +32,16 @@ const remoteSearchResult = {
 
 suite.define(() => {
   it("offers a worktree for a GitHub result before its checkout exists", async () => {
-    await prepareProjectUiProof();
     await suite.withPage(
       {
         locale: "en-US",
         serviceWorkers: "block",
         ...(captureUiProofEnabled
           ? {
-              recordVideo: { dir: projectProofArtifactDir, size: { height: 900, width: 1280 } },
+              recordVideo: {
+                dir: path.join(suite.artifactDir, "project-registry"),
+                size: { height: 900, width: 1280 },
+              },
               viewport: { height: 900, width: 1280 },
             }
           : {}),
@@ -73,7 +73,7 @@ suite.define(() => {
           .fill("openclaw");
         await projects.getByRole("button", { name: /openclaw\/openclaw/u }).click();
 
-        await captureProjectUiProof(page, "github-worktree-direct.png");
+        await captureProjectUiProof(suite, page, "github-worktree-direct.png");
         const detail = page.locator("#new-session-detail-trigger");
         await expect.poll(() => detail.isVisible()).toBe(true);
         await pollLocatorText(detail).toContain("Runs directly");
@@ -85,7 +85,7 @@ suite.define(() => {
         expect(await baseRef.getAttribute("placeholder")).toBe("Base branch");
         expect(await baseRef.inputValue()).toBe("");
         expect(await branches.locator("datalist option").count()).toBe(0);
-        await captureProjectUiProof(page, "github-worktree-selected.png");
+        await captureProjectUiProof(suite, page, "github-worktree-selected.png");
         await page.locator(".new-session-page__message").fill("inspect the worktree");
         await page.getByRole("button", { name: "Start session" }).click();
 
@@ -117,27 +117,17 @@ suite.define(() => {
       worktree: true,
     },
   ])("keeps GitHub selection inert and $name", async ({ failure, worktree }) => {
-    await prepareProjectUiProof();
-    const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-    const artifactDir = artifactRoot
-      ? path.join(artifactRoot, worktree ? "worktree" : "project", failure ? "failed" : "prepared")
+    // Both capture gates share this attempt's screenshots, custody report, and video.
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim()
+      ? path.join(suite.artifactDir, "project-registry")
       : undefined;
-    if (artifactDir) {
-      await mkdir(artifactDir, { recursive: true });
-    }
     const context = await suite.browser.newContext({
-      ...(artifactDir
-        ? {
-            recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } },
-            viewport: { height: 900, width: 1280 },
-          }
-        : {}),
       locale: "en-US",
       serviceWorkers: "block",
-      ...(captureUiProofEnabled
+      ...(captureUiProofEnabled || artifactDir
         ? {
             recordVideo: {
-              dir: projectProofArtifactDir,
+              dir: path.join(suite.artifactDir, "project-registry"),
               size: { height: 900, width: 1280 },
             },
             viewport: { height: 900, width: 1280 },
@@ -403,6 +393,7 @@ suite.define(() => {
       expect(await working.locator(".chat-reading-indicator").count()).toBe(1);
       expect(await gateway.getRequests("chat.send")).toHaveLength(0);
       await captureProjectUiProof(
+        suite,
         page,
         worktree ? "worktree-preparing.png" : "project-cloning.png",
       );
@@ -424,7 +415,7 @@ suite.define(() => {
           await pollLocatorText(working).toContain(label);
           expect(await page.locator(".chat-group.user").count()).toBe(1);
         }
-        await captureProjectUiProof(page, "worktree-running-setup.png");
+        await captureProjectUiProof(suite, page, "worktree-running-setup.png");
       }
 
       if (!failure) {
@@ -493,6 +484,7 @@ suite.define(() => {
       const composer = page.locator(".agent-chat__composer-combobox textarea");
       await expect.poll(() => composer.isEnabled()).toBe(true);
       await captureProjectUiProof(
+        suite,
         page,
         worktree ? "worktree-setup-failed.png" : "project-cloning-failed.png",
       );

--- a/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
@@ -10,18 +10,6 @@ import {
 
 const suite = createNewSessionPageE2eSuite();
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const catalogRetryProofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "new-session-catalog-retry",
-);
-const skeletonGapProofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "new-session-skeleton-gap",
-);
 
 function catalogDiscoveryRequests(
   requests: Array<{ params?: unknown }>,
@@ -38,7 +26,7 @@ function catalogDiscoveryRequests(
 suite.define(() => {
   it("keeps composer actions fixed while model metadata loads", async () => {
     if (captureUiProof) {
-      await mkdir(skeletonGapProofDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "new-session-skeleton-gap"), { recursive: true });
     }
     const context = await suite.browser.newContext({
       locale: "en-US",
@@ -79,7 +67,7 @@ suite.define(() => {
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
-          path: path.join(skeletonGapProofDir, "after.png"),
+          path: path.join(path.join(suite.artifactDir, "new-session-skeleton-gap"), "after.png"),
         });
       }
 
@@ -290,14 +278,19 @@ suite.define(() => {
 
   it("recovers a failed CLI-agent catalog without reloading model metadata for its retry", async () => {
     if (captureUiProof) {
-      await mkdir(catalogRetryProofDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "new-session-catalog-retry"), { recursive: true });
     }
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       ...(captureUiProof
-        ? { recordVideo: { dir: catalogRetryProofDir, size: { height: 900, width: 1280 } } }
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "new-session-catalog-retry"),
+              size: { height: 900, width: 1280 },
+            },
+          }
         : {}),
     });
     const page = await context.newPage();
@@ -372,7 +365,10 @@ suite.define(() => {
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
-          path: path.join(catalogRetryProofDir, "01-cli-agents-retry.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "new-session-catalog-retry"),
+            "01-cli-agents-retry.png",
+          ),
         });
       }
 
@@ -422,7 +418,10 @@ suite.define(() => {
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
-          path: path.join(catalogRetryProofDir, "02-cli-agents-recovered.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "new-session-catalog-retry"),
+            "02-cli-agents-recovered.png",
+          ),
         });
       }
     } finally {

--- a/ui/src/e2e/new-session-page.places.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.places.e2e.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { expect, it } from "vitest";
 import {
   PICKED,
@@ -9,18 +10,13 @@ import {
   createNewSessionPageE2eSuite,
   createdSessionListResult,
   installMockGateway,
-  newSessionComposerProofArtifactDir,
   pollLocatorText,
-  prepareNewSessionComposerUiProof,
-  prepareProjectUiProof,
-  projectProofArtifactDir,
 } from "./new-session-page.test-support.ts";
 
 const suite = createNewSessionPageE2eSuite();
 
 suite.define(() => {
   it("keeps the pre-submit draft on the composer and creates exactly one session", async () => {
-    await prepareNewSessionComposerUiProof();
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -28,7 +24,7 @@ suite.define(() => {
       ...(captureUiProofEnabled
         ? {
             recordVideo: {
-              dir: newSessionComposerProofArtifactDir,
+              dir: path.join(suite.artifactDir, "new-session-slash-menu"),
               size: { height: 900, width: 1280 },
             },
           }
@@ -65,7 +61,7 @@ suite.define(() => {
       const slashMenu = page.locator("#chat-new-session-slash-menu-listbox");
       await pollLocatorText(slashMenu).toContain("/status");
       expect(await slashMenu.textContent()).not.toContain("/clear");
-      await captureNewSessionComposerUiProof(page, "slash-menu-open.png");
+      await captureNewSessionComposerUiProof(suite, page, "slash-menu-open.png");
       if (captureUiProofEnabled) {
         await page.waitForTimeout(750);
       }
@@ -110,7 +106,6 @@ suite.define(() => {
   });
 
   it("drafts a session with a browsed folder and creates it on first message", async () => {
-    await prepareProjectUiProof();
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -118,7 +113,7 @@ suite.define(() => {
       ...(captureUiProofEnabled
         ? {
             recordVideo: {
-              dir: projectProofArtifactDir,
+              dir: path.join(suite.artifactDir, "project-registry"),
               size: { height: 900, width: 1280 },
             },
           }
@@ -289,7 +284,7 @@ suite.define(() => {
       expect(triggersBox?.width).toBeCloseTo(composerBox?.width ?? 0, 0);
       expect(composerBox?.width).toBeCloseTo(48 * 16, 0);
       expect(await page.locator(".new-session-page__message").getAttribute("rows")).toBe("1");
-      await captureProjectUiProof(page, "new-session-control-layout.png");
+      await captureProjectUiProof(suite, page, "new-session-control-layout.png");
 
       await page.setViewportSize({ width: 393, height: 852 });
       const mobileModelSettings = page.locator(
@@ -328,7 +323,7 @@ suite.define(() => {
       expect(mobileModelSettingsBox.x + mobileModelSettingsBox.width).toBeLessThanOrEqual(
         mobileFooterBox.x + mobileFooterBox.width,
       );
-      await captureProjectUiProof(page, "mobile-new-session-idle.png");
+      await captureProjectUiProof(suite, page, "mobile-new-session-idle.png");
       await mobilePermission.click();
       await page.locator('[data-chat-permission-option="workspace"]').click();
       await expect
@@ -338,11 +333,11 @@ suite.define(() => {
       await expect
         .poll(() => page.locator(".chat-controls__permission-option").first().isVisible())
         .toBe(true);
-      await captureProjectUiProof(page, "mobile-new-session-permissions-open.png");
+      await captureProjectUiProof(suite, page, "mobile-new-session-permissions-open.png");
       await page.keyboard.press("Escape");
       await mobileModelSettings.click();
       await expect.poll(() => page.locator(".chat-controls__model-menu").isVisible()).toBe(true);
-      await captureProjectUiProof(page, "mobile-new-session-model-open.png");
+      await captureProjectUiProof(suite, page, "mobile-new-session-model-open.png");
       expect(
         await page
           .locator(".chat-controls__model-menu")
@@ -352,14 +347,14 @@ suite.define(() => {
       await page.keyboard.press("Escape");
       await page.locator('[data-chat-thinking-select="true"]').click();
       await expect.poll(() => page.locator(".chat-controls__effort-menu").isVisible()).toBe(true);
-      await captureProjectUiProof(page, "mobile-new-session-effort-open.png");
+      await captureProjectUiProof(suite, page, "mobile-new-session-effort-open.png");
       await page.keyboard.press("Escape");
       await page.setViewportSize({ width: 1280, height: 900 });
 
       const agentPicker = page.locator(".new-session-page__select--agent openclaw-agent-select");
       await agentPicker.locator(".agent-select__trigger").click();
       await pollLocatorText(agentPicker.locator(".agent-select__menu-title")).toBe("Agents");
-      await captureProjectUiProof(page, "new-session-agent-menu-label.png");
+      await captureProjectUiProof(suite, page, "new-session-agent-menu-label.png");
       await page.keyboard.press("Escape");
 
       const whereSelect = page.locator("wa-popover.new-session-page__where-popover");
@@ -368,7 +363,7 @@ suite.define(() => {
       await pollLocatorText(whereSelect.locator(".new-session-page__menu-title").first()).toBe(
         "Environments",
       );
-      await captureProjectUiProof(page, "new-session-environment-menu-label.png");
+      await captureProjectUiProof(suite, page, "new-session-environment-menu-label.png");
       await page.keyboard.press("Escape");
 
       const projectSelect = page.locator("wa-popover.new-session-page__project-popover");
@@ -384,7 +379,7 @@ suite.define(() => {
       await pollLocatorText(projectSelect.locator(".new-session-page__menu-title").first()).toBe(
         "Projects",
       );
-      await captureProjectUiProof(page, "new-session-project-menu-label.png");
+      await captureProjectUiProof(suite, page, "new-session-project-menu-label.png");
       await projectSelect.getByRole("button", { name: "Browse folders" }).click();
       await page.locator(".new-session-page__browser-entry", { hasText: "packages" }).click();
       await expect
@@ -408,7 +403,7 @@ suite.define(() => {
       await pollLocatorText(detailSelect.locator(".new-session-page__menu-title").first()).toBe(
         "Branches",
       );
-      await captureProjectUiProof(page, "new-session-branch-menu-label.png");
+      await captureProjectUiProof(suite, page, "new-session-branch-menu-label.png");
       const worktreeItem = detailSelect.getByRole("button", { name: "Worktree" });
       await expect.poll(() => worktreeItem.getAttribute("aria-pressed")).toBe("false");
       expect(await worktreeItem.isEnabled()).toBe(true);
@@ -455,14 +450,13 @@ suite.define(() => {
   });
 
   it("selects a registered project and submits its id at write scope", async () => {
-    await prepareProjectUiProof();
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
       ...(captureUiProofEnabled
         ? {
             recordVideo: {
-              dir: projectProofArtifactDir,
+              dir: path.join(suite.artifactDir, "project-registry"),
               size: { height: 900, width: 1280 },
             },
             viewport: { height: 900, width: 1280 },
@@ -533,7 +527,7 @@ suite.define(() => {
         .locator("wa-popover.new-session-page__detail-popover")
         .getByRole("button", { name: "Worktree" })
         .click();
-      await captureProjectUiProof(page, "project-selected.png");
+      await captureProjectUiProof(suite, page, "project-selected.png");
       await page.keyboard.press("Escape");
       await page.locator(".new-session-page__message").fill("inspect the project");
       await page.getByRole("button", { name: "Start session" }).click();

--- a/ui/src/e2e/new-session-page.projects-places.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.projects-places.e2e.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { expect, it } from "vitest";
 import { tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 import {
@@ -8,8 +9,6 @@ import {
   createNewSessionPageE2eSuite,
   installMockGateway,
   pollLocatorText,
-  prepareProjectUiProof,
-  projectProofArtifactDir,
   replaceGatewayClient,
 } from "./new-session-page.test-support.ts";
 
@@ -21,7 +20,6 @@ const gatewayEnvironment = {
 };
 suite.define(() => {
   it("registers a Git checkout from Browse and selects the refreshed project", async () => {
-    await prepareProjectUiProof();
     const context = await suite.browser.newContext({ locale: "en-US", serviceWorkers: "block" });
     const page = await context.newPage();
     const repoRoot = "/recorded/openclaw";
@@ -81,7 +79,7 @@ suite.define(() => {
       await pathInput.press("Enter");
       const register = place.getByRole("button", { name: "Register as project" });
       await register.waitFor();
-      await captureProjectUiProof(page, "project-register-action.png");
+      await captureProjectUiProof(suite, page, "project-register-action.png");
       await register.click();
 
       const request = await gateway.waitForRequest("projects.register");
@@ -151,11 +149,12 @@ suite.define(() => {
   it.each(["recovery scope", "system info"] as const)(
     "updates Gateway place labels after late %s",
     async (late) => {
-      await prepareProjectUiProof();
       const context = await suite.browser.newContext({
         locale: "en-US",
         serviceWorkers: "block",
-        ...(captureUiProofEnabled ? { recordVideo: { dir: projectProofArtifactDir } } : {}),
+        ...(captureUiProofEnabled
+          ? { recordVideo: { dir: path.join(suite.artifactDir, "project-registry") } }
+          : {}),
       });
       const page = await context.newPage();
       if (late === "recovery scope") {
@@ -220,7 +219,7 @@ suite.define(() => {
           await expect.poll(() => tooltipTitleText(local)).toBe("Gateway · QA-Gateway");
         }
         await expect.poll(() => pathInput.getAttribute("placeholder")).toBe("Gateway · QA-Gateway");
-        await captureProjectUiProof(page, `gateway-name-${late.replaceAll(" ", "-")}.png`);
+        await captureProjectUiProof(suite, page, `gateway-name-${late.replaceAll(" ", "-")}.png`);
 
         await page.keyboard.press("Escape");
         await replaceGatewayClient(page);
@@ -229,7 +228,11 @@ suite.define(() => {
         await expect.poll(() => tooltipTitleText(local)).toBe("Gateway · QA-Gateway");
       } finally {
         try {
-          await captureProjectUiProof(page, `gateway-name-${late.replaceAll(" ", "-")}-final.png`);
+          await captureProjectUiProof(
+            suite,
+            page,
+            `gateway-name-${late.replaceAll(" ", "-")}-final.png`,
+          );
         } finally {
           await context.close();
         }

--- a/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
@@ -16,7 +16,6 @@ import {
   installMockGateway,
   pastePng,
   pollLocatorText,
-  reconnectProofArtifactDir,
   waitForCommittedNewSessionDraft,
 } from "./new-session-page.test-support.ts";
 
@@ -37,10 +36,9 @@ async function withNewSessionPage(run: (page: Page) => Promise<void>): Promise<v
 
 suite.define(() => {
   it("restores a prompt and image in a fresh page, then clears them after creation", async () => {
-    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-    if (artifactDir) {
-      await mkdir(artifactDir, { recursive: true });
-    }
+    const artifactDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim()
+      ? suite.artifactDir
+      : undefined;
     const context = await suite.browser.newContext({
       locale: "en-US",
       ...(artifactDir
@@ -89,7 +87,7 @@ suite.define(() => {
         .poll(() => restoredMessage.inputValue())
         .toBe("restore this prompt after restart and incognito");
       await expect.poll(() => restoredPage.locator(".chat-attachment-thumb").count()).toBe(1);
-      await captureUiProof(restoredPage, "new-session-restart-draft-restored.png");
+      await captureUiProof(suite, restoredPage, "new-session-restart-draft-restored.png");
       if (artifactDir) {
         await restoredPage.screenshot({
           path: path.join(artifactDir, "new-session-restart-draft-restored.png"),
@@ -121,7 +119,7 @@ suite.define(() => {
         .poll(() => clearedPage.locator(".new-session-page__message").inputValue())
         .toBe("");
       await expect.poll(() => clearedPage.locator(".chat-attachment-thumb").count()).toBe(0);
-      await captureUiProof(clearedPage, "new-session-restart-draft-cleared.png");
+      await captureUiProof(suite, clearedPage, "new-session-restart-draft-cleared.png");
       if (artifactDir) {
         await clearedPage.screenshot({
           path: path.join(artifactDir, "new-session-restart-draft-cleared.png"),
@@ -186,7 +184,7 @@ suite.define(() => {
       const composerThumbInset = Number.parseFloat(tenLines.webkitThumbInset);
       expect(composerScrollbar).toBe(12);
       expect(composerScrollbar - composerThumbInset * 2).toBe(6);
-      await captureUiProof(page, "new-session-composer-ten-lines.png");
+      await captureUiProof(suite, page, "new-session-composer-ten-lines.png");
 
       const longPrompt = Array.from({ length: 14 }, (_, index) => `line ${index + 1}`).join("\n");
       await message.fill(longPrompt);
@@ -210,7 +208,7 @@ suite.define(() => {
       ]) {
         expect(Math.abs((after?.y ?? 0) - (before?.y ?? 0))).toBeLessThanOrEqual(2);
       }
-      await captureUiProof(page, "new-session-composer-capped-scrollbar.png");
+      await captureUiProof(suite, page, "new-session-composer-capped-scrollbar.png");
       const start = page.getByRole("button", { name: "Start session" });
       await expect(start.isVisible()).resolves.toBe(true);
       await expect(start.isEnabled()).resolves.toBe(true);
@@ -239,7 +237,7 @@ suite.define(() => {
       await pastePng(message);
 
       await page.getByRole("img", { name: "pixel.png" }).waitFor();
-      await captureUiProof(page, "mobile-composer-new-session-attachment.png");
+      await captureUiProof(suite, page, "mobile-composer-new-session-attachment.png");
       await page.getByRole("button", { name: "Start session" }).click();
 
       const create = await gateway.waitForRequest("sessions.create");
@@ -275,14 +273,14 @@ suite.define(() => {
       const previewButton = page.getByRole("button", { name: "Open image favicon-32.png" });
       await preview.waitFor({ state: "visible" });
       await expect.poll(() => preview.getAttribute("src")).toMatch(/^data:image\/png;base64,/u);
-      await captureUiProof(page, "new-session-picked-image-preview.png");
+      await captureUiProof(suite, page, "new-session-picked-image-preview.png");
       await previewButton.click();
       const lightbox = page.locator("openclaw-image-lightbox");
       const dialog = page.getByRole("dialog", { name: "Image preview: favicon-32.png" });
       await dialog.waitFor({ state: "visible" });
       await expect(lightbox.getAttribute("title")).resolves.toBeNull();
       await page.getByAltText("favicon-32.png").last().waitFor({ state: "visible" });
-      await captureUiProof(page, "new-session-picked-image-lightbox.png");
+      await captureUiProof(suite, page, "new-session-picked-image-lightbox.png");
       await page.keyboard.press("Escape");
       await lightbox.waitFor({ state: "detached" });
       await previewButton.press("Enter");
@@ -290,7 +288,7 @@ suite.define(() => {
       await page.keyboard.press("Escape");
       await page.getByRole("button", { name: "Remove attachment" }).click();
       await expect.poll(() => attachment.count()).toBe(0);
-      await captureUiProof(page, "new-session-picked-image-removed.png");
+      await captureUiProof(suite, page, "new-session-picked-image-removed.png");
     });
   });
 
@@ -312,7 +310,7 @@ suite.define(() => {
       await previewButton.click();
       await page.getByRole("dialog", { name: "Image preview: untrusted.svg" }).waitFor();
       await expect(page.getByRole("link", { name: "Open in new tab" }).count()).resolves.toBe(0);
-      await captureUiProof(page, "new-session-svg-lightbox.png");
+      await captureUiProof(suite, page, "new-session-svg-lightbox.png");
     });
   });
 
@@ -426,9 +424,12 @@ suite.define(() => {
         )
         .toBe("connected");
       if (captureUiProofEnabled) {
-        await mkdir(reconnectProofArtifactDir, { recursive: true });
+        await mkdir(path.join(suite.artifactDir, "initial-prompt-reconnect"), { recursive: true });
         await page.screenshot({
-          path: path.join(reconnectProofArtifactDir, "reconnected-session.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "initial-prompt-reconnect"),
+            "reconnected-session.png",
+          ),
           fullPage: true,
         });
       }

--- a/ui/src/e2e/new-session-page.test-support.ts
+++ b/ui/src/e2e/new-session-page.test-support.ts
@@ -1,4 +1,3 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { errors, type Locator, type Page } from "playwright";
 import { expect } from "vitest";
@@ -43,53 +42,7 @@ const LOCATOR_TEXT_READ_TIMEOUT_MS = 500;
 const LOCATOR_TEXT_POLL_TIMEOUT_MS = 10_000;
 
 export const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "cloud-worker-session",
-);
-export const reconnectProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "initial-prompt-reconnect",
-);
-export const projectProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "project-registry",
-);
-export const newSessionComposerProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "new-session-slash-menu",
-);
-const environmentMetadataProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "environment-metadata",
-);
-const deviceRuntimeProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "device-runtime-gating",
-);
 
-export async function prepareProjectUiProof() {
-  if (captureUiProofEnabled) {
-    await prepareUiProof(projectProofArtifactDir);
-  }
-}
-export async function prepareNewSessionComposerUiProof() {
-  if (captureUiProofEnabled) {
-    await prepareUiProof(newSessionComposerProofArtifactDir);
-  }
-}
 export const ONE_PIXEL_PNG_B64 =
   "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=";
 export const SESSION_LIST_DEFAULTS = {
@@ -146,6 +99,7 @@ export function createdSessionListResult(sessionKey: string) {
 }
 
 export async function expectPendingSessionPlacementStartupBeforeRuntime(
+  owner: { readonly artifactDir: string },
   page: Page,
   gateway: MockGatewayControls,
   sessionKey: string,
@@ -163,52 +117,70 @@ export async function expectPendingSessionPlacementStartupBeforeRuntime(
     .toBe(true);
   expect(await gateway.getRequests("sessions.dispatch")).toHaveLength(0);
   expect(await gateway.getRequests("sessions.send")).toHaveLength(0);
-  await captureUiProof(page, "02-cloud-startup-chunk-pending.png");
+  await captureUiProof(owner, page, "02-cloud-startup-chunk-pending.png");
   return startupStatus;
 }
 
-export async function captureUiProof(page: Page, fileName: string) {
+export async function captureUiProof(
+  owner: { readonly artifactDir: string },
+  page: Page,
+  fileName: string,
+) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await captureProof(page, uiProofArtifactDir, fileName);
+  await captureProof(page, path.join(owner.artifactDir, "cloud-worker-session"), fileName);
 }
 
-export async function captureProjectUiProof(page: Page, fileName: string) {
+export async function captureProjectUiProof(
+  owner: { readonly artifactDir: string },
+  page: Page,
+  fileName: string,
+) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await captureProof(page, projectProofArtifactDir, fileName);
+  await captureProof(page, path.join(owner.artifactDir, "project-registry"), fileName);
 }
 
-export async function captureNewSessionComposerUiProof(page: Page, fileName: string) {
+export async function captureNewSessionComposerUiProof(
+  owner: { readonly artifactDir: string },
+  page: Page,
+  fileName: string,
+) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await captureProof(page, newSessionComposerProofArtifactDir, fileName);
+  await captureProof(page, path.join(owner.artifactDir, "new-session-slash-menu"), fileName);
 }
 
-export async function captureEnvironmentMetadataUiProof(page: Page) {
+export async function captureEnvironmentMetadataUiProof(
+  owner: { readonly artifactDir: string },
+  page: Page,
+) {
   const proofName = process.env.OPENCLAW_ENVIRONMENT_METADATA_PROOF;
   if (proofName !== "before" && proofName !== "after") {
     return;
   }
-  await captureProof(page, environmentMetadataProofArtifactDir, `${proofName}.png`);
+  await captureProof(
+    page,
+    path.join(owner.artifactDir, "environment-metadata"),
+    `${proofName}.png`,
+  );
 }
 
-export async function captureDeviceRuntimeUiProof(page: Page, fileName: string) {
+export async function captureDeviceRuntimeUiProof(
+  owner: { readonly artifactDir: string },
+  page: Page,
+  fileName: string,
+) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await captureProof(page, deviceRuntimeProofArtifactDir, fileName);
-}
-
-async function prepareUiProof(artifactDir: string) {
-  await mkdir(artifactDir, { recursive: true });
+  await captureProof(page, path.join(owner.artifactDir, "device-runtime-gating"), fileName);
 }
 
 async function captureProof(page: Page, artifactDir: string, fileName: string) {
-  await prepareUiProof(artifactDir);
   await page.screenshot({
     animations: "disabled",
     fullPage: true,

--- a/ui/src/e2e/new-session-page.transition.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.transition.e2e.test.ts
@@ -12,15 +12,17 @@ import {
 const suite = createNewSessionPageE2eSuite();
 const SESSION_KEY = "agent:main:transition-proof-0f403cb8-3920-4cf1-8eb7-79f2f00ce488";
 const RUN_ID = "transition-proof-run";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "new-session-transition");
 const captureProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 
 async function captureProof(page: import("playwright").Page, fileName: string) {
   if (!captureProofEnabled) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
-  await page.screenshot({ fullPage: true, path: path.join(proofDir, fileName) });
+  await mkdir(path.join(suite.artifactDir, "new-session-transition"), { recursive: true });
+  await page.screenshot({
+    fullPage: true,
+    path: path.join(path.join(suite.artifactDir, "new-session-transition"), fileName),
+  });
 }
 
 suite.define(() => {

--- a/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.workspace-memory.e2e.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { gatewayOriginScope } from "@openclaw/gateway-client/browser";
 import type { BrowserContextOptions, Page } from "playwright";
 import { expect, it } from "vitest";
@@ -15,7 +16,6 @@ import {
   installMockGateway,
   navigateInApp,
   pollLocatorText,
-  projectProofArtifactDir,
   waitForCommittedChatRoute,
   waitForCommittedNewSessionDraft,
 } from "./new-session-page.test-support.ts";
@@ -501,7 +501,7 @@ suite.define(() => {
         .poll(() => modelSelect.getAttribute("data-chat-select-value"))
         .toBe("anthropic/claude-sonnet-4-6");
       await expect.poll(() => effortSelect.getAttribute("data-chat-thinking-value")).toBe("high");
-      await captureUiProof(page, "new-session-preferences-restored.png");
+      await captureUiProof(suite, page, "new-session-preferences-restored.png");
 
       const branchRequests = await gateway.getRequests("worktrees.branches");
       expect(branchRequests.at(-1)?.params).toMatchObject({ repoRoot: PICKED });
@@ -538,7 +538,7 @@ suite.define(() => {
       ...(captureUiProofEnabled
         ? {
             recordVideo: {
-              dir: projectProofArtifactDir,
+              dir: path.join(suite.artifactDir, "project-registry"),
               size: { height: 900, width: 1280 },
             },
             viewport: { height: 900, width: 1280 },
@@ -595,7 +595,7 @@ suite.define(() => {
       const recentFolder = page.locator(`[data-value="recent:${WORKSPACE}/scratch"]`);
       await project.waitFor();
       await recentFolder.waitFor();
-      await captureProjectUiProof(page, "identity-project-recents-after.png");
+      await captureProjectUiProof(suite, page, "identity-project-recents-after.png");
       await project.click();
       await page.locator(".new-session-page__message").fill("continue registered work");
       await page.getByRole("button", { name: "Start session" }).click();
@@ -616,7 +616,7 @@ suite.define(() => {
         ...(captureUiProofEnabled
           ? {
               recordVideo: {
-                dir: projectProofArtifactDir,
+                dir: path.join(suite.artifactDir, "project-registry"),
                 size: { height: 900, width: 1280 },
               },
             }
@@ -699,7 +699,7 @@ suite.define(() => {
         const detailTrigger = page.locator("#new-session-detail-trigger");
         await pollLocatorText(trigger.locator(".new-session-page__trigger-label")).toBe("packages");
         await expect.poll(() => detailTrigger.getAttribute("data-worktree")).toBe("true");
-        await captureProjectUiProof(page, "identity-preferences-migrated.png");
+        await captureProjectUiProof(suite, page, "identity-preferences-migrated.png");
 
         await navigateInApp(page, "chat");
         await waitForCommittedChatRoute(page);

--- a/ui/src/e2e/operator-admin.e2e.test.ts
+++ b/ui/src/e2e/operator-admin.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI E2E coverage for operator-facing Skills, Nodes, and exec approvals administration.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   installMockGateway,
   type MockGatewayControls,
@@ -17,7 +17,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "operator-admin");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("operator-admin");
+  }
+});
 const viewport = { height: 960, width: 1440 };
 
 const agentRoster = [
@@ -116,9 +121,6 @@ async function waitForRequest(
 }
 
 async function createContext(): Promise<BrowserContext> {
-  if (captureUiProof) {
-    await mkdir(proofDir, { recursive: true });
-  }
   return suite.browser.newContext({
     locale: "en-US",
     serviceWorkers: "block",

--- a/ui/src/e2e/people-activity-card.e2e.test.ts
+++ b/ui/src/e2e/people-activity-card.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { defaultControlUiFeatureMethods } from "../test-helpers/control-ui-e2e.ts";
 import {
   captureUiProofEnabled,
@@ -14,7 +14,12 @@ import {
 const suite = createChatFlowE2eSuite();
 const selected = "agent:main:card-selected";
 const watched = "agent:main:card-viewing";
-const proofDirectory = path.resolve(".artifacts/control-ui-e2e/presence-namespaces");
+let proofDirectory: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    proofDirectory = createControlUiE2eArtifactDir("presence-namespaces");
+  }
+});
 const recentLabel = "Review the complete cross-platform launch readiness checklist before release";
 const updatedRecentLabel = `${recentLabel} with every regional owner`;
 const focusUpdatedRecentLabel = `${updatedRecentLabel} and final approval`;
@@ -104,7 +109,6 @@ async function capturePeopleCard(page: Page, filename: string) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(proofDirectory, { recursive: true });
   await page.screenshot({
     path: path.join(proofDirectory, filename),
     fullPage: true,
@@ -390,7 +394,6 @@ suite.define(() => {
         });
         await profileButton.waitFor({ state: "visible" });
         if (captureUiProofEnabled) {
-          await mkdir(proofDirectory, { recursive: true });
           await page.screenshot({
             path: path.join(proofDirectory, "initial.png"),
             animations: "disabled",

--- a/ui/src/e2e/plugin-bundled-view-recovery.e2e.test.ts
+++ b/ui/src/e2e/plugin-bundled-view-recovery.e2e.test.ts
@@ -1,12 +1,15 @@
 // Source-blind browser proof for bundled plugin lazy-view recovery.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Route } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const artifactDir = path.resolve(".artifacts/control-ui-e2e/plugin-bundled-view-recovery");
+let artifactDir: string;
+beforeEach(() => {
+  artifactDir = createControlUiE2eArtifactDir("plugin-bundled-view-recovery");
+});
 const bundledChunk = /\/assets\/logbook-view-[^/]+\.js(?:\?.*)?$/;
 
 const suite = createControlUiE2eSuite({
@@ -17,7 +20,6 @@ const suite = createControlUiE2eSuite({
 
 suite.define(() => {
   it("stops automatic reloads after one failed recovery and keeps manual Reload", async () => {
-    await mkdir(artifactDir, { recursive: true });
     await suite.withPage(
       {
         locale: "en-US",

--- a/ui/src/e2e/plugins-config-mutation.e2e.test.ts
+++ b/ui/src/e2e/plugins-config-mutation.e2e.test.ts
@@ -1,7 +1,7 @@
 // Control UI tests cover plugin mutations serialized behind pending config drafts.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway, waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -13,12 +13,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "plugins-config-mutation",
-);
+let uiProofArtifactDir: string;
+beforeEach(() => {
+  if (captureUiProofEnabled) {
+    uiProofArtifactDir = createControlUiE2eArtifactDir("plugins-config-mutation");
+  }
+});
 
 function configResponse(fallback: string | undefined, workboardEnabled: boolean, hash: string) {
   const config = {
@@ -113,7 +113,6 @@ suite.define(() => {
         const workboardRow = page.locator('[data-plugin-id="workboard"]');
         await workboardRow.waitFor();
         if (captureUiProofEnabled) {
-          await mkdir(uiProofArtifactDir, { recursive: true });
           await workboardRow.screenshot({
             animations: "disabled",
             path: path.join(uiProofArtifactDir, "00-before-enable.png"),

--- a/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
+++ b/ui/src/e2e/plugins-hub-navigation.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway, waitForControlUiRoute } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -12,7 +12,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "plugins-hub-shell");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("plugins-hub-shell");
+  }
+});
 
 const methodResponses = {
   "agents.list": {
@@ -85,9 +90,6 @@ type ControlGeometry = {
 };
 
 async function createContext(viewport: { height: number; width: number }): Promise<BrowserContext> {
-  if (captureUiProof) {
-    await mkdir(proofDir, { recursive: true });
-  }
   return suite.browser.newContext({
     locale: "en-US",
     serviceWorkers: "block",

--- a/ui/src/e2e/profile-page.e2e.test.ts
+++ b/ui/src/e2e/profile-page.e2e.test.ts
@@ -1,13 +1,13 @@
 // Control UI tests cover the settings profile page against a mocked Gateway.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, type Page } from "playwright/test";
-import { it } from "vitest";
+import { beforeEach, it } from "vitest";
 import { GIT_COAUTHOR_PREFERENCE_KEY } from "../../../packages/gateway-protocol/src/index.ts";
 import {
   buildControlUiCspHeader,
   computeInlineScriptHashes,
 } from "../../../src/gateway/control-ui-csp.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -19,7 +19,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "profile-identity");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("profile-identity");
+  }
+});
 const basePath = "/wilfred";
 const profilePath = `${basePath}/settings/profile`;
 
@@ -27,7 +32,6 @@ async function screenshot(page: Page, name: string) {
   if (!captureUiProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.locator("#settings-profile-identity").screenshot({
     animations: "disabled",
     path: path.join(proofDir, name),
@@ -102,9 +106,6 @@ suite.define(() => {
   });
 
   it("shows sign-in verification separately from explicit Git co-author credit", async () => {
-    if (captureUiProof) {
-      await mkdir(proofDir, { recursive: true });
-    }
     await suite.withPage(
       {
         ...(captureUiProof
@@ -270,7 +271,6 @@ suite.define(() => {
           ]),
         );
         if (captureUiProof) {
-          await mkdir(proofDir, { recursive: true });
           await page.locator(".profile-hero").screenshot({
             animations: "disabled",
             path: path.join(proofDir, "06-authenticated-assistant-avatar.png"),
@@ -281,9 +281,6 @@ suite.define(() => {
   });
 
   it("shares one authenticated avatar between the sidebar and profile preview", async () => {
-    if (captureUiProof) {
-      await mkdir(proofDir, { recursive: true });
-    }
     await suite.withPage(
       {
         ...(captureUiProof
@@ -649,7 +646,7 @@ suite.define(() => {
         await expect(chooser).toHaveAccessibleName("Choose image");
         await chooser.focus();
         await expect(chooser).toBeFocused();
-        await screenshot(page, "11-avatar-keyboard-focus.png");
+        await screenshot(page, `11-avatar-keyboard-focus-${revision}.png`);
         const [fileChooser] = await Promise.all([
           page.waitForEvent("filechooser"),
           chooser.press("Enter"),
@@ -665,7 +662,7 @@ suite.define(() => {
         await expect
           .poll(async () => (await gateway.getRequests("users.setAvatar")).length)
           .toBe(requestCountBefore + 1);
-        await screenshot(page, "12-avatar-action-disabled.png");
+        await screenshot(page, `12-avatar-action-disabled-${revision}.png`);
         await expect(chooser).toBeDisabled();
         await expect
           .poll(() => chooser.evaluate((element) => getComputedStyle(element).opacity))

--- a/ui/src/e2e/question-flow.e2e.test.ts
+++ b/ui/src/e2e/question-flow.e2e.test.ts
@@ -1,11 +1,11 @@
 // Control UI E2E tests cover composer-replacing Gateway questions through the mocked WebSocket.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Question, QuestionResolveResult } from "@openclaw/gateway-protocol";
 import type { BrowserContext, Page } from "playwright";
-import { afterEach, expect, it } from "vitest";
+import { beforeEach, afterEach, expect, it } from "vitest";
 import type { SessionsListResult } from "../api/types.ts";
 import { CHAT_TRANSCRIPT_END_THRESHOLD_PX } from "../pages/chat/scroll.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiSessionUrl,
   installMockGateway,
@@ -22,7 +22,12 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "question-flow");
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("question-flow");
+  }
+});
 const mainSessionKey = "agent:main:main";
 const questionSessionKey = "agent:main:question-proof";
 
@@ -70,7 +75,6 @@ async function screenshot(page: Page, name: string) {
   if (!captureUiProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,

--- a/ui/src/e2e/resize-handles.e2e.test.ts
+++ b/ui/src/e2e/resize-handles.e2e.test.ts
@@ -1,4 +1,3 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
@@ -72,8 +71,7 @@ async function captureResizeState(page: Page, name: string) {
   if (process.env.OPENCLAW_CAPTURE_UI_PROOF !== "1") {
     return;
   }
-  const output = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "resize-handles");
-  await mkdir(output, { recursive: true });
+  const output = path.join(suite.artifactDir, "resize-handles");
   await page.screenshot({
     animations: "disabled",
     path: path.join(output, `${name}.png`),

--- a/ui/src/e2e/service-worker-update.e2e.test.ts
+++ b/ui/src/e2e/service-worker-update.e2e.test.ts
@@ -1,10 +1,11 @@
 import { createHash } from "node:crypto";
-import { mkdir, mkdtemp, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, readdir, rename, rm, writeFile } from "node:fs/promises";
 import { createServer as createHttpServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   buildProductionControlUiE2e,
   canRunPlaywrightChromium,
@@ -17,7 +18,12 @@ import {
 } from "../test-helpers/control-ui-e2e.ts";
 
 const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.executablePath());
-const artifactDir = path.resolve(".artifacts/control-ui-e2e/service-worker-update");
+let artifactDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    artifactDir = createControlUiE2eArtifactDir("service-worker-update");
+  }
+});
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 
 const buildA = "service-worker-build-a";
@@ -274,9 +280,6 @@ describe("Control UI service-worker production update E2E", () => {
   });
 
   it("refreshes a same-version build on reconnect before restoring an owned terminal", async () => {
-    if (captureUiProof) {
-      await mkdir(artifactDir, { recursive: true });
-    }
     const context = await browser.newContext({
       locale: "en-US",
       serviceWorkers: "allow",

--- a/ui/src/e2e/session-color.e2e.test.ts
+++ b/ui/src/e2e/session-color.e2e.test.ts
@@ -1,6 +1,6 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { createControlUiSessionRow as sessionRow } from "../test-helpers/control-ui-session-fixtures.ts";
 import {
   controlUiSessionUrl,
@@ -142,8 +142,10 @@ suite.define(() => {
   it("sets and clears session colors through desktop and compact menus", async () => {
     const key = "agent:main:color-proof";
     const now = Date.now();
-    const proofDir = "/tmp/session-color-web-proof";
     const capture = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+    const proofDir = capture
+      ? createControlUiE2eArtifactDir("session-color-web-proof", "/tmp/session-color-web-proof")
+      : "";
     const context = await suite.browser.newContext({
       locale: "en-US",
       colorScheme: "dark",
@@ -207,7 +209,6 @@ suite.define(() => {
     });
     const shot = async (name: string) => {
       if (capture) {
-        await mkdir(proofDir, { recursive: true });
         await page.screenshot({
           path: path.join(proofDir, name),
           animations: "disabled",

--- a/ui/src/e2e/session-dashboard.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.e2e.test.ts
@@ -18,20 +18,6 @@ const suite = createControlUiE2eSuite({
   startServerBeforeBrowser: true,
 });
 
-const cardboardProofDir = path.resolve(
-  process.cwd(),
-  ".artifacts/control-ui-e2e/workboard-cardboard",
-);
-const workboardPinProofDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/workboard-pin");
-const workboardPinFailureProofDir = path.resolve(
-  process.cwd(),
-  ".artifacts/control-ui-e2e/workboard-pin-failure",
-);
-const pluginWidgetsProofDir = path.resolve(
-  process.cwd(),
-  ".artifacts/control-ui-e2e/workboard-plugin-widgets",
-);
-
 const sessionKey = "agent:main:dashboard";
 const boardSnapshot = {
   sessionKey,
@@ -268,7 +254,7 @@ suite.define(() => {
   it("pins Canvas HTML, follows board commands, and persists dock resizing", async () => {
     const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
     if (recordProof) {
-      await mkdir(workboardPinProofDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "workboard-pin"), { recursive: true });
     }
     const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
     const page = await context.newPage();
@@ -362,7 +348,7 @@ suite.define(() => {
         .poll(() => widgetActions.evaluate((element) => getComputedStyle(element).opacity))
         .toBe("1");
       await previewBubble.screenshot({
-        path: path.join(workboardPinProofDir, "01-pin-hover.png"),
+        path: path.join(path.join(suite.artifactDir, "workboard-pin"), "01-pin-hover.png"),
       });
     }
     await preview.getByRole("button", { name: "Pin to dashboard" }).click();
@@ -377,7 +363,9 @@ suite.define(() => {
       .poll(() => preview.getByRole("button", { name: "Pinned" }).isDisabled())
       .toBe(true);
     if (recordProof) {
-      await previewBubble.screenshot({ path: path.join(workboardPinProofDir, "02-pinned.png") });
+      await previewBubble.screenshot({
+        path: path.join(path.join(suite.artifactDir, "workboard-pin"), "02-pinned.png"),
+      });
     }
     await gateway.setMethodResponse("board.get", resizablePinnedBoardSnapshot);
 
@@ -418,14 +406,14 @@ suite.define(() => {
   it("shows a bounded visible outcome when a Canvas dashboard pin fails", async () => {
     const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
     if (recordProof) {
-      await mkdir(workboardPinFailureProofDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "workboard-pin-failure"), { recursive: true });
     }
     const context = await suite.browser.newContext({
       viewport: { height: 900, width: 1280 },
       ...(recordProof
         ? {
             recordVideo: {
-              dir: workboardPinFailureProofDir,
+              dir: path.join(suite.artifactDir, "workboard-pin-failure"),
               size: { height: 900, width: 1280 },
             },
           }
@@ -495,7 +483,9 @@ suite.define(() => {
     expect(await hint.textContent()).toContain("Could not pin to dashboard. Try again.");
     expect(await page.getByText("internal path detail", { exact: false }).count()).toBe(0);
     if (recordProof) {
-      await page.screenshot({ path: path.join(workboardPinFailureProofDir, "pin-failed.png") });
+      await page.screenshot({
+        path: path.join(path.join(suite.artifactDir, "workboard-pin-failure"), "pin-failed.png"),
+      });
     }
     await context.close();
   });
@@ -572,12 +562,17 @@ suite.define(() => {
   it("renders and updates active Workboard plugin widgets", async () => {
     const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
     if (recordProof) {
-      await mkdir(pluginWidgetsProofDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "workboard-plugin-widgets"), { recursive: true });
     }
     const context = await suite.browser.newContext({
       viewport: { height: 900, width: 1280 },
       ...(recordProof
-        ? { recordVideo: { dir: pluginWidgetsProofDir, size: { height: 900, width: 1280 } } }
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "workboard-plugin-widgets"),
+              size: { height: 900, width: 1280 },
+            },
+          }
         : {}),
     });
     const page = await context.newPage();
@@ -641,7 +636,10 @@ suite.define(() => {
       );
       if (recordProof) {
         await page.screenshot({
-          path: path.join(pluginWidgetsProofDir, "01-plugin-widgets-ready.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "workboard-plugin-widgets"),
+            "01-plugin-widgets-ready.png",
+          ),
         });
       }
 
@@ -728,14 +726,22 @@ suite.define(() => {
         .toBe("2 Running");
       if (recordProof) {
         await page.screenshot({
-          path: path.join(pluginWidgetsProofDir, "02-plugin-widgets-running.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "workboard-plugin-widgets"),
+            "02-plugin-widgets-running.png",
+          ),
         });
       }
     } finally {
       const video = page.video();
       await context.close();
       if (recordProof && video) {
-        await video.saveAs(path.join(pluginWidgetsProofDir, "workboard-plugin-widgets.webm"));
+        await video.saveAs(
+          path.join(
+            path.join(suite.artifactDir, "workboard-plugin-widgets"),
+            "workboard-plugin-widgets.webm",
+          ),
+        );
       }
     }
   });
@@ -797,12 +803,17 @@ suite.define(() => {
   it("links a dispatched Workboard card and its live session dashboard in both directions", async () => {
     const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
     if (recordProof) {
-      await mkdir(cardboardProofDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "workboard-cardboard"), { recursive: true });
     }
     const context = await suite.browser.newContext({
       viewport: { height: 900, width: 1280 },
       ...(recordProof
-        ? { recordVideo: { dir: cardboardProofDir, size: { height: 900, width: 1280 } } }
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "workboard-cardboard"),
+              size: { height: 900, width: 1280 },
+            },
+          }
         : {}),
     });
     const page = await context.newPage();
@@ -847,7 +858,12 @@ suite.define(() => {
       await expect.poll(() => chip.textContent()).toContain("Running");
       expect(await chip.getAttribute("href")).toBe("/workboard?board=platform");
       if (recordProof) {
-        await page.screenshot({ path: path.join(cardboardProofDir, "01-dashboard-card-chip.png") });
+        await page.screenshot({
+          path: path.join(
+            path.join(suite.artifactDir, "workboard-cardboard"),
+            "01-dashboard-card-chip.png",
+          ),
+        });
       }
 
       const completedCard = { ...card, status: "done", updatedAt: 3 };
@@ -898,7 +914,10 @@ suite.define(() => {
       await cardDashboard.locator("openclaw-board-view").waitFor();
       if (recordProof) {
         await page.screenshot({
-          path: path.join(cardboardProofDir, "02-workboard-card-dashboard.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "workboard-cardboard"),
+            "02-workboard-card-dashboard.png",
+          ),
         });
       }
 
@@ -916,7 +935,12 @@ suite.define(() => {
       const video = page.video();
       await context.close();
       if (recordProof && video) {
-        await video.saveAs(path.join(cardboardProofDir, "workboard-cardboard.webm"));
+        await video.saveAs(
+          path.join(
+            path.join(suite.artifactDir, "workboard-cardboard"),
+            "workboard-cardboard.webm",
+          ),
+        );
       }
     }
   });

--- a/ui/src/e2e/session-dashboard.grant-failure.e2e.test.ts
+++ b/ui/src/e2e/session-dashboard.grant-failure.e2e.test.ts
@@ -13,18 +13,22 @@ const suite = createControlUiE2eSuite({
   startServerBeforeBrowser: true,
 });
 const sessionKey = "agent:main:dashboard-grant-failure";
-const proofDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/workboard-grant-failure");
 
 suite.define(() => {
   it("keeps a network-capability decision retryable and toasts when Allow fails", async () => {
     const recordProof = process.env.OPENCLAW_UI_E2E_RECORD === "1";
     if (recordProof) {
-      await mkdir(proofDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "workboard-grant-failure"), { recursive: true });
     }
     const context = await suite.browser.newContext({
       viewport: { height: 900, width: 1280 },
       ...(recordProof
-        ? { recordVideo: { dir: proofDir, size: { height: 900, width: 1280 } } }
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "workboard-grant-failure"),
+              size: { height: 900, width: 1280 },
+            },
+          }
         : {}),
     });
     const page = await context.newPage();
@@ -97,13 +101,23 @@ suite.define(() => {
       await pending.waitFor();
       await page.locator('[data-test-id="board-widget-action-error"]').waitFor();
       if (recordProof) {
-        await page.screenshot({ path: path.join(proofDir, "grant-failed.png") });
+        await page.screenshot({
+          path: path.join(
+            path.join(suite.artifactDir, "workboard-grant-failure"),
+            "grant-failed.png",
+          ),
+        });
       }
     } finally {
       const video = page.video();
       await context.close();
       if (recordProof && video) {
-        await video.saveAs(path.join(proofDir, "workboard-grant-failure.webm"));
+        await video.saveAs(
+          path.join(
+            path.join(suite.artifactDir, "workboard-grant-failure"),
+            "workboard-grant-failure.webm",
+          ),
+        );
       }
     }
   });

--- a/ui/src/e2e/session-link-not-found.e2e.test.ts
+++ b/ui/src/e2e/session-link-not-found.e2e.test.ts
@@ -52,7 +52,7 @@ suite.define(() => {
         expect(await page.locator(".agent-chat__input textarea").count()).toBe(0);
         expect(await page.locator("openclaw-toast-host .app-toast").count()).toBe(0);
         expect(await gateway.getRequests("sessions.resolve")).toHaveLength(1);
-        await captureUiProof(page, "session-link-not-found-after.png");
+        await captureUiProof(suite, page, "session-link-not-found-after.png");
 
         await currentSession.click();
         await expect.poll(() => new URL(page.url()).pathname).toBe("/chat/main");

--- a/ui/src/e2e/session-management.account-label.e2e.test.ts
+++ b/ui/src/e2e/session-management.account-label.e2e.test.ts
@@ -54,7 +54,7 @@ suite.define(() => {
       await expect
         .poll(() => trimmedTextContents(cardsRow.locator(".sidebar-recent-session__name")))
         .toEqual(["Alice · cards"]);
-      await captureUiProof(page, "telegram-account-session-labels.png");
+      await captureUiProof(suite, page, "telegram-account-session-labels.png");
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/session-management.archive.e2e.test.ts
+++ b/ui/src/e2e/session-management.archive.e2e.test.ts
@@ -12,7 +12,6 @@ import {
   installMockGateway,
   requireRecord,
   sessionsListResponse,
-  uiProofArtifactDir,
   waitForConfirmModal,
   waitForPatch,
 } from "./session-management.test-support.ts";
@@ -22,7 +21,7 @@ const suite = createSessionManagementE2eSuite();
 async function confirmDelete(page: import("playwright").Page, proofName?: string) {
   const dialog = await waitForConfirmModal(page);
   if (proofName) {
-    await captureUiProof(page, proofName);
+    await captureUiProof(suite, page, proofName);
   }
   await dialog.getByRole("button", { name: "Delete", exact: true }).click();
 }
@@ -33,7 +32,7 @@ suite.define(() => {
       locale: "en-US",
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
-      ...(captureUiProofEnabled ? { recordVideo: { dir: uiProofArtifactDir } } : {}),
+      ...(captureUiProofEnabled ? { recordVideo: { dir: suite.artifactDir } } : {}),
     });
     const page = await context.newPage();
     const main = sessionRow("agent:main:main", "Main", 1);
@@ -54,7 +53,7 @@ suite.define(() => {
       const notice = pane.locator(".agent-chat__disabled-banner");
       await row.waitFor({ state: "visible" });
       await pane.getByText("Work completed.", { exact: true }).waitFor();
-      await captureUiProof(page, "agent-archive-before.png");
+      await captureUiProof(suite, page, "agent-archive-before.png");
 
       // The agent's deferred self-archive reaches clients as a committed patch,
       // without running the sidebar menu's optimistic mutation path.
@@ -67,12 +66,12 @@ suite.define(() => {
         reason: "patch",
       });
       await notice.waitFor({ state: "visible" });
-      await captureUiProof(page, "agent-archive-received.png");
+      await captureUiProof(suite, page, "agent-archive-received.png");
       await row.waitFor({ state: "detached", timeout: 10_000 });
       expect(new URL(page.url()).pathname).toBe(controlUiSessionPath(target.key));
       await pane.getByText("Work completed.", { exact: true }).waitFor();
       expect(await gateway.getRequests("sessions.patch")).toEqual([]);
-      await captureUiProof(page, "agent-archive-after.png");
+      await captureUiProof(suite, page, "agent-archive-after.png");
 
       await page.getByRole("button", { name: "Filter & sort" }).click();
       await page
@@ -136,7 +135,7 @@ suite.define(() => {
       const sidebar = page.locator("openclaw-app-sidebar");
       const archivedRow = sidebar.locator(`[data-session-key="${archived.key}"]`);
       await archivedRow.waitFor({ state: "visible" });
-      await captureUiProof(page, "filtered-roster-forced-refresh-before.png");
+      await captureUiProof(suite, page, "filtered-roster-forced-refresh-before.png");
 
       const archivedRequests = async () =>
         (await gateway.getRequests("sessions.list")).filter(
@@ -163,7 +162,7 @@ suite.define(() => {
 
       await expect.poll(archivedRequests).toHaveLength(initialRequests + 2);
       await archivedRow.waitFor({ state: "detached" });
-      await captureUiProof(page, "filtered-roster-forced-refresh-after.png");
+      await captureUiProof(suite, page, "filtered-roster-forced-refresh-after.png");
     } finally {
       await context.close();
     }
@@ -346,7 +345,7 @@ suite.define(() => {
     const context = await suite.browser.newContext({
       locale: "en-US",
       recordVideo: captureUiProofEnabled
-        ? { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } }
+        ? { dir: suite.artifactDir, size: { height: 900, width: 1280 } }
         : undefined,
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
@@ -375,7 +374,7 @@ suite.define(() => {
       const row = page.locator(`[data-session-key="${sessionKey}"]`);
       await row.waitFor({ state: "visible", timeout: 10_000 });
       await page.getByText("Research thread content").waitFor({ state: "visible" });
-      await captureUiProof(page, "archive-current-thread-before.png");
+      await captureUiProof(suite, page, "archive-current-thread-before.png");
       await row.hover();
       await row.getByRole("button", { name: "Open session menu" }).click();
       await activateSelfRemovingControl(page.getByRole("menuitem", { name: "Archive session" }));
@@ -384,17 +383,17 @@ suite.define(() => {
       await expect.poll(() => row.count()).toBe(0);
       expect(new URL(page.url()).pathname).toBe(controlUiSessionPath(sessionKey));
       await page.getByText("Research thread content").waitFor({ state: "visible" });
-      await captureUiProof(page, "archive-current-thread-pending.png");
+      await captureUiProof(suite, page, "archive-current-thread-pending.png");
 
       await gateway.resolveDeferred("sessions.patch");
       await expect.poll(() => row.count()).toBe(0);
       expect(new URL(page.url()).pathname).toBe(controlUiSessionPath(sessionKey));
       await page.getByText("Research thread content").waitFor({ state: "visible" });
-      await captureUiProof(page, "archive-current-thread-complete.png");
+      await captureUiProof(suite, page, "archive-current-thread-complete.png");
     } finally {
       await context.close();
       if (proofVideo) {
-        await proofVideo.saveAs(path.join(uiProofArtifactDir, "archive-current-thread.webm"));
+        await proofVideo.saveAs(path.join(suite.artifactDir, "archive-current-thread.webm"));
       }
     }
   });
@@ -452,7 +451,7 @@ suite.define(() => {
       expect(
         await batchMenu.getByRole("menuitem", { name: `Delete ${batchKeys.length}…` }).isDisabled(),
       ).toBe(true);
-      await captureUiProof(page, "sidebar-multi-select-archive-menu.png");
+      await captureUiProof(suite, page, "sidebar-multi-select-archive-menu.png");
       await page.keyboard.press("A");
 
       const patchMany = await gateway.waitForRequest("sessions.patchMany");
@@ -478,7 +477,7 @@ suite.define(() => {
       await expect
         .poll(() => page.locator(".app-toast").textContent())
         .toContain("Archived 3 sessions");
-      await captureUiProof(page, "sidebar-multi-select-archive-settled.png");
+      await captureUiProof(suite, page, "sidebar-multi-select-archive-settled.png");
       await page.waitForTimeout(500);
       expect((await gateway.getRequests("sessions.list")).length).toBe(listCountBeforeBatch + 1);
     } finally {
@@ -767,7 +766,7 @@ suite.define(() => {
       await expect.poll(() => progressCard.count()).toBe(0);
       const archiveEvent = activePane.locator(".chat-notice", { hasText: "Archived by Mira" });
       await archiveEvent.waitFor({ state: "visible", timeout: 10_000 });
-      await captureUiProof(page, "archive-attribution-notice-after.png");
+      await captureUiProof(suite, page, "archive-attribution-notice-after.png");
       await expect
         .poll(() => activePane.locator(".chat-bubble", { hasText: "Archived by Mira" }).count())
         .toBe(0);
@@ -986,7 +985,7 @@ suite.define(() => {
       const settledRequestCount = (await gateway.getRequests("sessions.list")).length;
       await expectRequestCountStable(gateway, "sessions.list", settledRequestCount);
       expect(routeErrors).toEqual([]);
-      await captureUiProof(page, "deleted-active-session-fallback.png");
+      await captureUiProof(suite, page, "deleted-active-session-fallback.png");
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/session-management.archived-actions.e2e.test.ts
+++ b/ui/src/e2e/session-management.archived-actions.e2e.test.ts
@@ -12,7 +12,6 @@ import {
   installMockGateway,
   requireRecord,
   sessionsListResponse,
-  uiProofArtifactDir,
   waitForPatch,
 } from "./session-management.test-support.ts";
 
@@ -26,9 +25,7 @@ suite.define(() => {
     it(`keeps archived transcript actions inert on ${viewport.label}`, async () => {
       const context = await suite.browser.newContext({
         locale: "en-US",
-        recordVideo: captureUiProofEnabled
-          ? { dir: uiProofArtifactDir, size: viewport }
-          : undefined,
+        recordVideo: captureUiProofEnabled ? { dir: suite.artifactDir, size: viewport } : undefined,
         serviceWorkers: "block",
         viewport,
       });
@@ -192,7 +189,7 @@ suite.define(() => {
               ),
           ).toBe(true);
         }
-        await captureUiProof(page, `archived-actions-${viewport.label}.png`);
+        await captureUiProof(suite, page, `archived-actions-${viewport.label}.png`);
         expect(
           await page.evaluate(() => {
             const portal = document.querySelector<HTMLElement>(".chat-reply-context-menu");
@@ -231,7 +228,7 @@ suite.define(() => {
         await context.close();
         if (proofVideo) {
           await proofVideo.saveAs(
-            path.join(uiProofArtifactDir, `archived-actions-${viewport.label}.webm`),
+            path.join(suite.artifactDir, `archived-actions-${viewport.label}.webm`),
           );
         }
       }

--- a/ui/src/e2e/session-management.copy-session-id.e2e.test.ts
+++ b/ui/src/e2e/session-management.copy-session-id.e2e.test.ts
@@ -54,7 +54,7 @@ suite.define(() => {
       await openSessionMenuSubmenu(page, "Copy");
       const copyItem = menuHost.getByRole("menuitem", { name: "Session ID", exact: true });
       await expect.poll(() => copyItem.count()).toBe(1);
-      await captureUiProof(page, "copy-session-id-menu.png");
+      await captureUiProof(suite, page, "copy-session-id-menu.png");
 
       await activateSelfRemovingControl(copyItem);
 

--- a/ui/src/e2e/session-management.created-sort.e2e.test.ts
+++ b/ui/src/e2e/session-management.created-sort.e2e.test.ts
@@ -8,7 +8,6 @@ import {
   controlUiSessionUrl,
   installMockGateway,
   sessionsListResponse,
-  uiProofArtifactDir,
 } from "./session-management.test-support.ts";
 
 const suite = createSessionManagementE2eSuite();
@@ -37,7 +36,7 @@ suite.define(() => {
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       recordVideo: captureUiProofEnabled
-        ? { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } }
+        ? { dir: suite.artifactDir, size: { height: 900, width: 1280 } }
         : undefined,
     });
     const page = await context.newPage();
@@ -55,7 +54,7 @@ suite.define(() => {
       await expect.poll(() => rows.count(), { timeout: 10_000 }).toBe(10);
       const retainedSessionKey = olderRows[5]!.key;
       await rows.nth(5).evaluate((row) => Reflect.set(row, "__retainedSessionRow", true));
-      await captureUiProof(page, "sidebar-created-sort-before-refresh.png");
+      await captureUiProof(suite, page, "sidebar-created-sort-before-refresh.png");
       const initialListCount = (await gateway.getRequests("sessions.list")).length;
 
       await gateway.setMethodResponse(
@@ -84,7 +83,7 @@ suite.define(() => {
           .locator(`.sidebar-recent-session[data-session-key="${retainedSessionKey}"]`)
           .evaluate((row) => Reflect.get(row, "__retainedSessionRow")),
       ).toBe(true);
-      await captureUiProof(page, "sidebar-created-sort-after-refresh.png");
+      await captureUiProof(suite, page, "sidebar-created-sort-after-refresh.png");
 
       expect(await rows.count()).toBe(11);
       expect(
@@ -96,7 +95,7 @@ suite.define(() => {
       await context.close();
       if (proofVideo) {
         await proofVideo.saveAs(
-          path.join(uiProofArtifactDir, "sidebar-created-sort-external-session.webm"),
+          path.join(suite.artifactDir, "sidebar-created-sort-external-session.webm"),
         );
       }
     }

--- a/ui/src/e2e/session-management.delete.e2e.test.ts
+++ b/ui/src/e2e/session-management.delete.e2e.test.ts
@@ -10,7 +10,6 @@ import {
   createSessionManagementE2eSuite,
   installMockGateway,
   sessionsListResponse,
-  uiProofArtifactDir,
   waitForConfirmModal,
 } from "./session-management.test-support.ts";
 
@@ -278,7 +277,7 @@ suite.define(() => {
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       recordVideo: captureUiProofEnabled
-        ? { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } }
+        ? { dir: suite.artifactDir, size: { height: 900, width: 1280 } }
         : undefined,
     });
     const page = await context.newPage();
@@ -299,7 +298,7 @@ suite.define(() => {
       await page.getByRole("checkbox", { name: `Select session: ${key}` }).check();
       await page.locator(".data-table-bulk-bar").getByRole("button", { name: "Delete" }).click();
       const confirmModal = await waitForConfirmModal(page);
-      await captureUiProof(page, "sessions-bulk-delete-original-confirm.png");
+      await captureUiProof(suite, page, "sessions-bulk-delete-original-confirm.png");
 
       await gateway.setMethodResponse("sessions.list", sessionsListResponse([replacement]));
       await gateway.emitGatewayEvent("sessions.changed", {
@@ -323,13 +322,11 @@ suite.define(() => {
         .poll(() => page.locator(".sessions-error[role=alert]").textContent())
         .toContain("changed before deletion. Retry.");
       await replacementLabel.waitFor();
-      await captureUiProof(page, "sessions-bulk-delete-replacement-protected.png");
+      await captureUiProof(suite, page, "sessions-bulk-delete-replacement-protected.png");
     } finally {
       await context.close();
       if (proofVideo) {
-        await proofVideo.saveAs(
-          path.join(uiProofArtifactDir, "sessions-bulk-delete-replaced.webm"),
-        );
+        await proofVideo.saveAs(path.join(suite.artifactDir, "sessions-bulk-delete-replaced.webm"));
       }
     }
   });
@@ -341,7 +338,7 @@ suite.define(() => {
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       recordVideo: captureUiProofEnabled
-        ? { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } }
+        ? { dir: suite.artifactDir, size: { height: 900, width: 1280 } }
         : undefined,
     });
     const page = await context.newPage();
@@ -376,7 +373,7 @@ suite.define(() => {
         .click();
 
       const confirmModal = await waitForConfirmModal(page);
-      await captureUiProof(page, "sidebar-delete-session-confirm.png");
+      await captureUiProof(suite, page, "sidebar-delete-session-confirm.png");
       await gateway.deferNext("sessions.delete");
       await confirmModal.getByRole("button", { name: "Delete", exact: true }).evaluate((button) => {
         if (!(button instanceof HTMLButtonElement)) {
@@ -401,13 +398,13 @@ suite.define(() => {
         .toContain("changed before deletion. Retry.");
       expect(await visibleError.textContent()).not.toContain("GatewayRequestError");
       await row.waitFor({ state: "visible" });
-      await captureUiProof(page, "sidebar-delete-session-replaced-error.png");
+      await captureUiProof(suite, page, "sidebar-delete-session-replaced-error.png");
       expect(nativeDialogs).toEqual([]);
     } finally {
       await context.close();
       if (proofVideo) {
         await proofVideo.saveAs(
-          path.join(uiProofArtifactDir, "sidebar-delete-session-replaced.webm"),
+          path.join(suite.artifactDir, "sidebar-delete-session-replaced.webm"),
         );
       }
     }
@@ -420,7 +417,7 @@ suite.define(() => {
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       recordVideo: captureUiProofEnabled
-        ? { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } }
+        ? { dir: suite.artifactDir, size: { height: 900, width: 1280 } }
         : undefined,
     });
     const page = await context.newPage();
@@ -468,14 +465,14 @@ suite.define(() => {
         .poll(() => worktreeModal.textContent())
         .toContain("OpenClaw could not create a safety snapshot");
       await expect.poll(() => worktreeModal.textContent()).toContain("Remove?");
-      await captureUiProof(page, "sidebar-delete-preserved-snapshot-failed.png");
+      await captureUiProof(suite, page, "sidebar-delete-preserved-snapshot-failed.png");
       await worktreeModal.getByRole("button", { name: "Cancel", exact: true }).click();
       expect(await gateway.getRequests("worktrees.remove")).toHaveLength(0);
     } finally {
       await context.close();
       if (proofVideo) {
         await proofVideo.saveAs(
-          path.join(uiProofArtifactDir, "sidebar-delete-preserved-snapshot-failed.webm"),
+          path.join(suite.artifactDir, "sidebar-delete-preserved-snapshot-failed.webm"),
         );
       }
     }

--- a/ui/src/e2e/session-management.draft-indicator.e2e.test.ts
+++ b/ui/src/e2e/session-management.draft-indicator.e2e.test.ts
@@ -49,7 +49,7 @@ suite.define(() => {
       await homeRow.waitFor({ state: "visible", timeout: 10_000 });
       await secondRow.waitFor({ state: "visible" });
       await composer.waitFor({ state: "visible" });
-      await captureUiProof(page, "draft-indicator-before.png");
+      await captureUiProof(suite, page, "draft-indicator-before.png");
 
       await composer.fill("Keep this unsent");
       const activity = homeRow.getByRole("img", { name: "Active run" });
@@ -62,7 +62,7 @@ suite.define(() => {
         throw new Error("expected activity and draft icon bounds");
       }
       expect(draftBox.x).toBeGreaterThanOrEqual(activityBox.x + activityBox.width);
-      await captureUiProof(page, "draft-indicator-active.png");
+      await captureUiProof(suite, page, "draft-indicator-active.png");
 
       await secondRow.getByRole("link").click();
       await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(secondKey));

--- a/ui/src/e2e/session-management.filtered-errors.e2e.test.ts
+++ b/ui/src/e2e/session-management.filtered-errors.e2e.test.ts
@@ -61,7 +61,7 @@ suite.define(() => {
           .poll(() => alert.textContent())
           .toContain("Session list temporarily unavailable");
         if (statusFilter === "Archived") {
-          await captureUiProof(page, "filtered-session-error-recovery-before.png");
+          await captureUiProof(suite, page, "filtered-session-error-recovery-before.png");
         }
 
         await gateway.setMethodResponse("sessions.list", healthy);
@@ -69,7 +69,7 @@ suite.define(() => {
         await expect.poll(() => alert.count()).toBe(0);
         await page.getByText("Archived planning", { exact: true }).first().waitFor();
         if (statusFilter === "Archived") {
-          await captureUiProof(page, "filtered-session-error-recovery-after.png");
+          await captureUiProof(suite, page, "filtered-session-error-recovery-after.png");
         }
 
         await gateway.setMethodResponse("sessions.list", failure);

--- a/ui/src/e2e/session-management.group-defaults.e2e.test.ts
+++ b/ui/src/e2e/session-management.group-defaults.e2e.test.ts
@@ -109,7 +109,7 @@ suite.define(() => {
             };
           })
           .toEqual({ horizontal: true, vertical: true });
-        await captureUiProof(page, `group-defaults-folder-picker-${viewport.name}.png`);
+        await captureUiProof(suite, page, `group-defaults-folder-picker-${viewport.name}.png`);
       }
       await folderPicker.getByRole("button", { name: "Use this folder" }).click();
       await page.setViewportSize({ height: 900, width: 1280 });
@@ -221,7 +221,11 @@ suite.define(() => {
         await expect
           .poll(() => environment.getAttribute("data-session-group-environment"))
           .not.toBe("checking");
-        await captureUiProof(page, `group-defaults-${groupCwd ? "folder" : "workspace"}.png`);
+        await captureUiProof(
+          suite,
+          page,
+          `group-defaults-${groupCwd ? "folder" : "workspace"}.png`,
+        );
         await expect.poll(() => environment.textContent()).toContain("Couldn't verify Git");
         const save = dialog.getByRole("button", { name: "Save" });
         await expect.poll(() => save.isDisabled()).toBe(true);

--- a/ui/src/e2e/session-management.group-identity.e2e.test.ts
+++ b/ui/src/e2e/session-management.group-identity.e2e.test.ts
@@ -14,7 +14,6 @@ import {
 } from "./session-management.test-support.ts";
 
 const suite = createSessionManagementE2eSuite();
-const proofDir = path.join(process.cwd(), ".artifacts/control-ui-e2e/group-identity-20260827");
 
 suite.define(() => {
   it.each(["sessions", "sidebar", "selection", "header"] as const)(
@@ -25,7 +24,9 @@ suite.define(() => {
         locale: "en-US",
         serviceWorkers: "block",
         viewport,
-        recordVideo: captureUiProofEnabled ? { dir: proofDir, size: viewport } : undefined,
+        recordVideo: captureUiProofEnabled
+          ? { dir: path.join(suite.artifactDir, "group-identity-20260827"), size: viewport }
+          : undefined,
       });
       const page = await context.newPage();
       const video = page.video();
@@ -50,9 +51,12 @@ suite.define(() => {
       });
       const capture = async (stage: string) => {
         if (captureUiProofEnabled) {
-          await mkdir(proofDir, { recursive: true });
+          await mkdir(path.join(suite.artifactDir, "group-identity-20260827"), { recursive: true });
           await page.screenshot({
-            path: path.join(proofDir, `${surface}-${stage}.png`),
+            path: path.join(
+              path.join(suite.artifactDir, "group-identity-20260827"),
+              `${surface}-${stage}.png`,
+            ),
             animations: "disabled",
             fullPage: true,
           });
@@ -181,7 +185,9 @@ suite.define(() => {
       } finally {
         await suite.closeBrowserContext(context);
         if (video) {
-          await video.saveAs(path.join(proofDir, `${surface}.webm`));
+          await video.saveAs(
+            path.join(path.join(suite.artifactDir, "group-identity-20260827"), `${surface}.webm`),
+          );
         }
       }
     },

--- a/ui/src/e2e/session-management.group-return.e2e.test.ts
+++ b/ui/src/e2e/session-management.group-return.e2e.test.ts
@@ -75,9 +75,9 @@ suite.define(() => {
         state: "visible",
       });
       await setThemeMode(page, "light");
-      await captureUiProof(page, "sidebar-done-return-before-light.png");
+      await captureUiProof(suite, page, "sidebar-done-return-before-light.png");
       await setThemeMode(page, "dark");
-      await captureUiProof(page, "sidebar-done-return-before-dark.png");
+      await captureUiProof(suite, page, "sidebar-done-return-before-dark.png");
 
       await setThemeMode(page, "light");
       await page.reload();
@@ -99,9 +99,9 @@ suite.define(() => {
       await groups.locator('[data-session-key="agent:main:done-group"]').waitFor({
         state: "visible",
       });
-      await captureUiProof(page, "sidebar-done-return-after-light.png");
+      await captureUiProof(suite, page, "sidebar-done-return-after-light.png");
       await setThemeMode(page, "dark");
-      await captureUiProof(page, "sidebar-done-return-after-dark.png");
+      await captureUiProof(suite, page, "sidebar-done-return-after-dark.png");
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/session-management.groups.e2e.test.ts
+++ b/ui/src/e2e/session-management.groups.e2e.test.ts
@@ -16,7 +16,6 @@ import {
   requireRecord,
   sessionsListResponse,
   submitInputDialog,
-  uiProofArtifactDir,
   waitForPatch,
 } from "./session-management.test-support.ts";
 
@@ -116,7 +115,7 @@ suite.define(() => {
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       recordVideo: captureUiProofEnabled
-        ? { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } }
+        ? { dir: suite.artifactDir, size: { height: 900, width: 1280 } }
         : undefined,
     });
     const page = await context.newPage();
@@ -144,7 +143,7 @@ suite.define(() => {
       const name = dialog.getByRole("textbox", { name: "Rename session" });
       await name.waitFor({ state: "visible" });
       await expect.poll(() => name.inputValue()).toBe("Original name");
-      await captureUiProof(page, "sidebar-session-rename-dialog.png");
+      await captureUiProof(suite, page, "sidebar-session-rename-dialog.png");
       await name.fill("Renamed session");
       await dialog.getByRole("button", { name: "Save" }).click();
 
@@ -157,11 +156,11 @@ suite.define(() => {
         label: "Renamed session",
       });
       await expect.poll(() => row.textContent()).toContain("Renamed session");
-      await captureUiProof(page, "sidebar-session-renamed.png");
+      await captureUiProof(suite, page, "sidebar-session-renamed.png");
     } finally {
       await context.close();
       if (proofVideo) {
-        await proofVideo.saveAs(path.join(uiProofArtifactDir, "sidebar-session-rename.webm"));
+        await proofVideo.saveAs(path.join(suite.artifactDir, "sidebar-session-rename.webm"));
       }
     }
   });
@@ -272,7 +271,7 @@ suite.define(() => {
       await expect.poll(() => actionOpacity(sidebarReleasePin)).toBe("0");
       await sidebarResearch.hover();
       await expect.poll(() => actionOpacity(sidebarResearchPin)).toBe("1");
-      await captureUiProof(page, "sidebar-sessions.png");
+      await captureUiProof(suite, page, "sidebar-sessions.png");
 
       await sidebarRows.filter({ hasText: "Release planning" }).hover();
       await expect.poll(() => actionOpacity(sidebarReleasePin)).toBe("1");
@@ -359,7 +358,7 @@ suite.define(() => {
         agentId: "main",
         query: "view-only handshake",
       });
-      await captureUiProof(page, "command-palette-session-search.png");
+      await captureUiProof(suite, page, "command-palette-session-search.png");
       await paletteOption.click();
       await expect
         .poll(() => new URL(page.url()).pathname)
@@ -535,7 +534,7 @@ suite.define(() => {
       const researchGroup = groups.filter({ hasText: "Research" });
       await researchGroup.waitFor({ state: "visible", timeout: 10_000 });
       await expect.poll(() => researchGroup.locator(".sidebar-recent-session").count()).toBe(2);
-      await captureUiProof(page, "sidebar-session-groups.png");
+      await captureUiProof(suite, page, "sidebar-session-groups.png");
 
       // Rename group: the gateway renames the catalog entry and repoints every
       // member session server-side (sessions.groups.rename), no per-member patches.
@@ -545,7 +544,7 @@ suite.define(() => {
       await researchGroup.locator(".sidebar-recent-sessions__head").hover();
       await groupMenuButton.click();
       await page.getByRole("menuitem", { name: "Rename group…" }).waitFor({ state: "visible" });
-      await captureUiProof(page, "sidebar-group-menu.png");
+      await captureUiProof(suite, page, "sidebar-group-menu.png");
       await activateSelfRemovingControl(page.getByRole("menuitem", { name: "Rename group…" }));
       // The rename runs in the owned dialog, prefilled with the name it is
       // changing; a native prompt here would be a regression.
@@ -554,7 +553,7 @@ suite.define(() => {
       await expect
         .poll(() => page.locator("openclaw-modal-dialog input").inputValue())
         .toBe("Research");
-      await captureUiProof(page, "sidebar-group-rename-dialog.png");
+      await captureUiProof(suite, page, "sidebar-group-rename-dialog.png");
       await submitInputDialog(page, "Projects");
       const renameRequest = await gateway.waitForRequest("sessions.groups.rename");
       expect(requireRecord(renameRequest.params)).toMatchObject({
@@ -590,7 +589,7 @@ suite.define(() => {
       await expect
         .poll(() => deleteConfirm.textContent())
         .toContain("The group is removed. Its sessions move back to the session list.");
-      await captureUiProof(page, "sidebar-group-delete-confirm.png");
+      await captureUiProof(suite, page, "sidebar-group-delete-confirm.png");
       await deleteConfirm.getByRole("button", { name: "Delete", exact: true }).click();
       const deleteRequest = await gateway.waitForRequest("sessions.groups.delete");
       expect(requireRecord(deleteRequest.params)).toMatchObject({ name: "Projects" });
@@ -623,7 +622,7 @@ suite.define(() => {
       await filterAndSortButton.click();
       await expect.poll(() => showAutomationSessions.getAttribute("aria-checked")).toBe("true");
       await page.getByRole("menuitemradio", { name: "None" }).waitFor({ state: "visible" });
-      await captureUiProof(page, "sidebar-groupby-sort-menu.png");
+      await captureUiProof(suite, page, "sidebar-groupby-sort-menu.png");
       const groupingCheck = page
         .getByRole("menuitemradio", { name: "Custom groups" })
         .locator(".session-menu__check");
@@ -649,7 +648,7 @@ suite.define(() => {
       await filterAndSortButton.click();
       await expect.poll(() => filterAndSortButton.getAttribute("aria-expanded")).toBe("false");
       await expect.poll(() => page.getByRole("menuitemradio", { name: "None" }).count()).toBe(0);
-      await captureUiProof(page, "sidebar-groupby-sort-menu-closed.png");
+      await captureUiProof(suite, page, "sidebar-groupby-sort-menu-closed.png");
 
       await filterAndSortButton.click();
       await activateSelfRemovingControl(page.getByRole("menuitemradio", { name: "None" }));
@@ -783,7 +782,7 @@ suite.define(() => {
       await page.getByRole("button", { name: "Show more" }).click();
       await expect.poll(() => sidebarRows.count()).toBe(13);
       await expect.poll(() => page.getByText("All sessions", { exact: true }).count()).toBe(0);
-      await captureUiProof(page, "sidebar-all-sessions.png");
+      await captureUiProof(suite, page, "sidebar-all-sessions.png");
 
       // New groups are created from a session's menu (Move to group → New group…),
       // which files that session into the new group.
@@ -821,7 +820,7 @@ suite.define(() => {
       await expect
         .poll(() => gamma.locator(".sidebar-recent-session").count(), { timeout: 10_000 })
         .toBe(2);
-      await captureUiProof(page, "sidebar-session-dropped-into-group.png");
+      await captureUiProof(suite, page, "sidebar-session-dropped-into-group.png");
 
       const ungrouped = page.locator('[data-session-section="ungrouped"]');
       const ungroupedHead = ungrouped.locator(":scope > .sidebar-recent-sessions__head");
@@ -844,7 +843,7 @@ suite.define(() => {
       const alphaToggle = alpha.getByRole("button", { name: "Alpha", exact: true });
       await alphaToggle.click();
       await expect.poll(() => alpha.locator(".sidebar-recent-session").count()).toBe(0);
-      await captureUiProof(page, "sidebar-session-group-collapsed.png");
+      await captureUiProof(suite, page, "sidebar-session-group-collapsed.png");
       await alphaToggle.click();
       await expect.poll(() => alpha.locator(".sidebar-recent-session").count()).toBe(1);
       await alphaToggle.click();
@@ -864,7 +863,7 @@ suite.define(() => {
       await expect
         .poll(customGroupOrder)
         .toEqual(["category:Gamma", "category:Alpha", "category:Beta"]);
-      await captureUiProof(page, "sidebar-session-groups-reordered.png");
+      await captureUiProof(suite, page, "sidebar-session-groups-reordered.png");
 
       await page.reload();
       await expect
@@ -1007,7 +1006,7 @@ suite.define(() => {
         firstEmptyGroup.evaluate((element) => element.getBoundingClientRect().height);
       await expect.poll(groupHeight).toBeGreaterThan(0);
       const expandedHeight = await groupHeight();
-      await captureUiProof(page, "sidebar-empty-cross-agent-groups.png");
+      await captureUiProof(suite, page, "sidebar-empty-cross-agent-groups.png");
 
       const toggle = firstEmptyGroup.locator(".sidebar-session-group-toggle");
       await toggle.click();

--- a/ui/src/e2e/session-management.new-group.e2e.test.ts
+++ b/ui/src/e2e/session-management.new-group.e2e.test.ts
@@ -61,7 +61,7 @@ suite.define(() => {
       await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:move-me"));
       const field = await openNewGroupDialog();
       const create = page.getByRole("button", { name: "Create group" });
-      await captureUiProof(page, "new-group-dialog-dark.png");
+      await captureUiProof(suite, page, "new-group-dialog-dark.png");
 
       // Opening the dialog writes nothing, hands focus to the field, and holds
       // the create action closed until a non-blank name exists.
@@ -74,7 +74,7 @@ suite.define(() => {
       expect(await create.isDisabled()).toBe(true);
 
       await page.emulateMedia({ colorScheme: "light" });
-      await captureUiProof(page, "new-group-dialog-light.png");
+      await captureUiProof(suite, page, "new-group-dialog-light.png");
       await page.emulateMedia({ colorScheme: "dark" });
 
       // Compact viewports keep the whole dialog on screen.
@@ -84,7 +84,7 @@ suite.define(() => {
       expect(bounds).not.toBeNull();
       expect(bounds!.x).toBeGreaterThanOrEqual(0);
       expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(420);
-      await captureUiProof(page, "new-group-dialog-compact.png");
+      await captureUiProof(suite, page, "new-group-dialog-compact.png");
       await page.setViewportSize({ height: 900, width: 1280 });
 
       // Escape leaves the session untouched.
@@ -111,7 +111,7 @@ suite.define(() => {
       );
       expect(categoryPatches).toHaveLength(1);
       expect(nativeDialogs).toEqual([]);
-      await captureUiProof(page, "new-group-created.png");
+      await captureUiProof(suite, page, "new-group-created.png");
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/session-management.optimistic-pin.e2e.test.ts
+++ b/ui/src/e2e/session-management.optimistic-pin.e2e.test.ts
@@ -10,7 +10,6 @@ import {
   installMockGateway,
   sessionsListResponse,
   trimmedTextContents,
-  uiProofArtifactDir,
 } from "./session-management.test-support.ts";
 
 const suite = createSessionManagementE2eSuite();
@@ -41,7 +40,7 @@ suite.define(() => {
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       recordVideo: captureUiProofEnabled
-        ? { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } }
+        ? { dir: suite.artifactDir, size: { height: 900, width: 1280 } }
         : undefined,
     });
     const page = await context.newPage();
@@ -59,7 +58,7 @@ suite.define(() => {
       const row = threads.locator(`.sidebar-recent-session[data-session-key="${candidateKey}"]`);
       await expect.poll(() => row.count()).toBe(1);
       await expect.poll(() => zoneEntry.count()).toBe(0);
-      await captureUiProof(page, "optimistic-pin-01-before-click.png");
+      await captureUiProof(suite, page, "optimistic-pin-01-before-click.png");
 
       await gateway.deferNext("sessions.patch");
       await row.hover();
@@ -70,7 +69,7 @@ suite.define(() => {
       await expect.poll(() => zoneEntry.count()).toBe(1);
       await expect.poll(() => row.count()).toBe(0);
       expect(await gateway.getRequests("sessions.list")).toHaveLength(1);
-      await captureUiProof(page, "optimistic-pin-02-pinned-while-in-flight.png");
+      await captureUiProof(suite, page, "optimistic-pin-02-pinned-while-in-flight.png");
 
       await gateway.setMethodResponse("sessions.list", pinnedList());
       await gateway.resolveDeferred("sessions.patch", { ok: true, key: candidateKey, path: "" });
@@ -79,11 +78,11 @@ suite.define(() => {
       await expect.poll(() => zoneEntry.count()).toBe(1);
       await expect.poll(() => row.count()).toBe(0);
       expect(await page.locator("[data-sidebar-session-error]").count()).toBe(0);
-      await captureUiProof(page, "optimistic-pin-03-confirmed-after-refresh.png");
+      await captureUiProof(suite, page, "optimistic-pin-03-confirmed-after-refresh.png");
     } finally {
       await context.close();
       if (proofVideo) {
-        await proofVideo.saveAs(path.join(uiProofArtifactDir, "optimistic-pin-button.webm"));
+        await proofVideo.saveAs(path.join(suite.artifactDir, "optimistic-pin-button.webm"));
       }
     }
   });
@@ -117,7 +116,7 @@ suite.define(() => {
 
       await expect.poll(() => zoneEntry.count()).toBe(0);
       await expect.poll(() => row.count()).toBe(1);
-      await captureUiProof(page, "optimistic-pin-04-unpinned-while-in-flight.png");
+      await captureUiProof(suite, page, "optimistic-pin-04-unpinned-while-in-flight.png");
 
       await gateway.rejectDeferred("sessions.patch", { message: "pin storage unavailable" });
 
@@ -126,7 +125,7 @@ suite.define(() => {
       await expect
         .poll(() => trimmedTextContents(page.locator("[data-sidebar-session-error]")))
         .toEqual([expect.stringContaining("pin storage unavailable")]);
-      await captureUiProof(page, "optimistic-pin-05-rolled-back-with-error.png");
+      await captureUiProof(suite, page, "optimistic-pin-05-rolled-back-with-error.png");
     } finally {
       await context.close();
     }
@@ -177,7 +176,7 @@ suite.define(() => {
       await expect.poll(() => gateway.getRequests("sessions.list")).toHaveLength(3);
       await expect.poll(() => row.count()).toBe(1);
       expect(await zoneEntry.count()).toBe(0);
-      await captureUiProof(page, "optimistic-pin-06-newest-intent-wins.png");
+      await captureUiProof(suite, page, "optimistic-pin-06-newest-intent-wins.png");
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/session-management.queue.e2e.test.ts
+++ b/ui/src/e2e/session-management.queue.e2e.test.ts
@@ -8,7 +8,6 @@ import {
   createSessionManagementE2eSuite,
   installMockGateway,
   sessionsListResponse,
-  uiProofArtifactDir,
 } from "./session-management.test-support.ts";
 
 const suite = createSessionManagementE2eSuite();
@@ -26,7 +25,7 @@ suite.define(() => {
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       recordVideo: captureUiProofEnabled
-        ? { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } }
+        ? { dir: suite.artifactDir, size: { height: 900, width: 1280 } }
         : undefined,
     });
     const page = await context.newPage();
@@ -62,7 +61,7 @@ suite.define(() => {
       expect(
         await spinner.evaluate((element) => getComputedStyle(element).animationPlayState),
       ).toBe(playState);
-      await captureUiProof(page, `${status}-session-ring.png`);
+      await captureUiProof(suite, page, `${status}-session-ring.png`);
 
       const listRequests = (await gateway.getRequests("sessions.list")).length;
       await gateway.setMethodResponse(
@@ -94,11 +93,11 @@ suite.define(() => {
       expect(
         await spinner.evaluate((element) => getComputedStyle(element).animationPlayState),
       ).toBe("running");
-      await captureUiProof(page, `${status}-session-running.png`);
+      await captureUiProof(suite, page, `${status}-session-running.png`);
     } finally {
       await context.close();
       if (proofVideo) {
-        await proofVideo.saveAs(path.join(uiProofArtifactDir, `${status}-session-ring.webm`));
+        await proofVideo.saveAs(path.join(suite.artifactDir, `${status}-session-ring.webm`));
       }
     }
   });

--- a/ui/src/e2e/session-management.rename-identity.e2e.test.ts
+++ b/ui/src/e2e/session-management.rename-identity.e2e.test.ts
@@ -13,7 +13,6 @@ import {
 } from "./session-management.test-support.ts";
 
 const suite = createSessionManagementE2eSuite();
-const proofDir = path.join(process.cwd(), ".artifacts/control-ui-e2e/session-identity-20260827");
 
 suite.define(() => {
   it.each(["sessions", "sidebar", "header"] as const)(
@@ -24,7 +23,9 @@ suite.define(() => {
         locale: "en-US",
         serviceWorkers: "block",
         viewport,
-        recordVideo: captureUiProofEnabled ? { dir: proofDir, size: viewport } : undefined,
+        recordVideo: captureUiProofEnabled
+          ? { dir: path.join(suite.artifactDir, "session-identity-20260827"), size: viewport }
+          : undefined,
       });
       const page = await context.newPage();
       const video = page.video();
@@ -47,9 +48,14 @@ suite.define(() => {
       });
       const capture = async (stage: string) => {
         if (captureUiProofEnabled) {
-          await mkdir(proofDir, { recursive: true });
+          await mkdir(path.join(suite.artifactDir, "session-identity-20260827"), {
+            recursive: true,
+          });
           await page.screenshot({
-            path: path.join(proofDir, `${surface}-${stage}.png`),
+            path: path.join(
+              path.join(suite.artifactDir, "session-identity-20260827"),
+              `${surface}-${stage}.png`,
+            ),
             animations: "disabled",
             fullPage: true,
           });
@@ -139,7 +145,9 @@ suite.define(() => {
       } finally {
         await context.close();
         if (video) {
-          await video.saveAs(path.join(proofDir, `${surface}.webm`));
+          await video.saveAs(
+            path.join(path.join(suite.artifactDir, "session-identity-20260827"), `${surface}.webm`),
+          );
         }
       }
     },

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -18,7 +18,6 @@ import {
   requireRecord,
   sessionsListResponse,
   trimmedTextContents,
-  uiProofArtifactDir,
   waitForPatch,
 } from "./session-management.test-support.ts";
 
@@ -103,7 +102,7 @@ suite.define(() => {
       await expect
         .poll(() => parent.locator(".session-run-spinner").getAttribute("aria-label"))
         .toBe("Active run");
-      await captureUiProof(page, "child-sessions-collapsed.png");
+      await captureUiProof(suite, page, "child-sessions-collapsed.png");
 
       await parent.getByRole("button", { name: "Show 4 child sessions for Plan release" }).click();
       await page.getByText("Research sources", { exact: true }).waitFor({ state: "visible" });
@@ -139,8 +138,8 @@ suite.define(() => {
         expect(await child.locator("openclaw-elapsed-time").count()).toBe(0);
         expect((await child.locator(".session-row-trail").textContent())?.trim()).toBeTruthy();
       }
-      await captureUiProof(page, "child-sessions-expanded.png");
-      await captureUiProof(page, "child-sessions-run-state-precedence.png");
+      await captureUiProof(suite, page, "child-sessions-expanded.png");
+      await captureUiProof(suite, page, "child-sessions-run-state-precedence.png");
 
       const completedChild = childRows.nth(1);
       const childMenuButton = completedChild.getByRole("button", {
@@ -162,7 +161,7 @@ suite.define(() => {
       await page.getByRole("menuitem", { name: "Delete…" }).waitFor();
       expect(await page.getByRole("menuitem", { name: "Pin session" }).count()).toBe(0);
       expect(await page.getByRole("menuitem", { name: "Move to group" }).count()).toBe(0);
-      await captureUiProof(page, "child-session-menu.png");
+      await captureUiProof(suite, page, "child-session-menu.png");
       await page.keyboard.press("Escape");
       await childMenu.waitFor({ state: "detached" });
 
@@ -467,7 +466,7 @@ suite.define(() => {
           .locator(`.sidebar-recent-session[data-session-key="${otherKey}"]`)
           .waitFor({ state: "visible" });
       }
-      await captureUiProof(page, "sidebar-sessions-during-reconnect.png");
+      await captureUiProof(suite, page, "sidebar-sessions-during-reconnect.png");
 
       await expect
         .poll(() => gateway.getSocketCount(), { timeout: 15_000 })
@@ -479,7 +478,7 @@ suite.define(() => {
       await retryConnection.waitFor({ state: "visible", timeout: 10_000 });
       await retryConnection.click();
       await expect.poll(() => pinnedEntry.count()).toBe(1);
-      await captureUiProof(page, "sidebar-sessions-during-client-replacement.png");
+      await captureUiProof(suite, page, "sidebar-sessions-during-client-replacement.png");
 
       await gateway.deferNext("sessions.list", { includeLastMessage: true });
       await gateway.setOnline(true);
@@ -597,7 +596,7 @@ suite.define(() => {
       expect(await gateway.getRequests("sessions.subscribe")).toHaveLength(
         initialObserverCount + 1,
       );
-      await captureUiProof(page, "sidebar-selected-session-route-reconnect.png");
+      await captureUiProof(suite, page, "sidebar-selected-session-route-reconnect.png");
     } finally {
       await context.close();
     }
@@ -674,7 +673,7 @@ suite.define(() => {
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       recordVideo: captureUiProofEnabled
-        ? { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } }
+        ? { dir: suite.artifactDir, size: { height: 900, width: 1280 } }
         : undefined,
     });
     const page = await context.newPage();
@@ -715,7 +714,7 @@ suite.define(() => {
       await expect
         .poll(() => trimmedTextContents(pinnedEntry.locator(".sidebar-recent-session__name")))
         .toEqual(["Already pinned"]);
-      await captureUiProof(page, "sidebar-session-before-pinned-drop.png");
+      await captureUiProof(suite, page, "sidebar-session-before-pinned-drop.png");
       const pinnedBox = await pinnedEntry.boundingBox();
       if (!pinnedBox) {
         throw new Error("expected the pinned row to be laid out");
@@ -752,11 +751,11 @@ suite.define(() => {
       await pinnedCandidate.click({ button: "right" });
       await page.getByRole("menuitem", { name: "Unpin session" }).waitFor();
       expect(await page.getByRole("menuitem", { name: "Reset pinned items" }).count()).toBe(0);
-      await captureUiProof(page, "sidebar-session-dropped-into-pinned.png");
+      await captureUiProof(suite, page, "sidebar-session-dropped-into-pinned.png");
     } finally {
       await context.close();
       if (proofVideo) {
-        await proofVideo.saveAs(path.join(uiProofArtifactDir, "sidebar-session-pinned-drop.webm"));
+        await proofVideo.saveAs(path.join(suite.artifactDir, "sidebar-session-pinned-drop.webm"));
       }
     }
   });
@@ -911,7 +910,7 @@ suite.define(() => {
       await expect
         .poll(() => page.locator(".sidebar-recent-session").count(), { timeout: 15_000 })
         .toBe(rows.length);
-      await captureUiProof(page, "short-window-session-sections.png");
+      await captureUiProof(suite, page, "short-window-session-sections.png");
 
       // Sections must stack below each other, not paint over the rows above.
       const overlaps = await page.evaluate(() => {

--- a/ui/src/e2e/session-management.test-support.ts
+++ b/ui/src/e2e/session-management.test-support.ts
@@ -1,4 +1,3 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import type { Locator, Page } from "playwright";
@@ -18,12 +17,6 @@ export { controlUiSessionPath, controlUiSessionUrl, installMockGateway, waitForC
 
 export const collapsedSessionSectionsStorageKey = "openclaw:sidebar:sessions:collapsed-sections";
 export const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-export const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "thread-management",
-);
 
 export function createSessionManagementE2eSuite(source = false) {
   return createControlUiE2eSuite({
@@ -173,16 +166,19 @@ export async function submitInputDialog(page: Page, value: string): Promise<void
   await field.waitFor({ state: "detached" });
 }
 
-export async function captureUiProof(page: Page, fileName: string) {
+export async function captureUiProof(
+  owner: { readonly artifactDir: string },
+  page: Page,
+  fileName: string,
+) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(uiProofArtifactDir, { recursive: true });
   // Dialogs and menus fade in, so an undisabled capture can land mid-transition
   // and prove nothing about the state it was taken for.
   await page.screenshot({
     animations: "disabled",
     fullPage: true,
-    path: path.join(uiProofArtifactDir, fileName),
+    path: path.join(owner.artifactDir, fileName),
   });
 }

--- a/ui/src/e2e/session-management.trailing-state.e2e.test.ts
+++ b/ui/src/e2e/session-management.trailing-state.e2e.test.ts
@@ -51,7 +51,7 @@ suite.define(() => {
       const pin = row.getByRole("button", { name: "Unpin session" });
       const menu = row.getByRole("button", { name: "Open session menu" });
       await expect.poll(() => actionOpacity(pin)).toBe("1");
-      await captureUiProof(page, "sidebar-session-actions-centered.png");
+      await captureUiProof(suite, page, "sidebar-session-actions-centered.png");
 
       const [rowBounds, subtitleBounds, pinBounds, menuBounds] = await Promise.all([
         row.boundingBox(),
@@ -79,7 +79,7 @@ suite.define(() => {
           return title && details ? title.y + title.height - details.y : Number.POSITIVE_INFINITY;
         })
         .toBeLessThanOrEqual(0.5);
-      await captureUiProof(page, "sidebar-session-text-scale-140.png");
+      await captureUiProof(suite, page, "sidebar-session-text-scale-140.png");
     } finally {
       await context.close();
     }
@@ -352,9 +352,9 @@ suite.define(() => {
       const pullRequestIcon = pullRequestRow.locator("[data-pull-request-state='merged']");
       const unreadDot = pullRequestRow.locator(".session-unread-dot");
       const trailingState = pullRequestRow.locator(".session-row-state");
-      await captureUiProof(page, "sidebar-pr-before-hover.png");
+      await captureUiProof(suite, page, "sidebar-pr-before-hover.png");
       await pullRequestRow.hover();
-      await captureUiProof(page, "sidebar-pr-hover.png");
+      await captureUiProof(suite, page, "sidebar-pr-hover.png");
       await pullRequestIcon.waitFor({ state: "hidden" });
       await unreadDot.waitFor({ state: "hidden" });
       await trailingState.waitFor({ state: "hidden" });

--- a/ui/src/e2e/session-management.unread.e2e.test.ts
+++ b/ui/src/e2e/session-management.unread.e2e.test.ts
@@ -12,7 +12,6 @@ import {
   installMockGateway,
   requireRecord,
   sessionsListResponse,
-  uiProofArtifactDir,
   waitForPatch,
 } from "./session-management.test-support.ts";
 
@@ -28,7 +27,7 @@ suite.define(() => {
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       recordVideo: captureUiProofEnabled
-        ? { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } }
+        ? { dir: suite.artifactDir, size: { height: 900, width: 1280 } }
         : undefined,
     });
     const page = await context.newPage();
@@ -51,7 +50,7 @@ suite.define(() => {
       const otherRow = page.locator(`[data-session-key="${otherKey}"]`);
       await activeRow.waitFor({ state: "visible", timeout: 10_000 });
       await otherRow.waitFor({ state: "visible" });
-      await captureUiProof(page, "manual-unread-before.png");
+      await captureUiProof(suite, page, "manual-unread-before.png");
 
       await activeRow.click({ button: "right" });
       await page.getByRole("menuitem", { name: "Mark as unread" }).click();
@@ -63,7 +62,7 @@ suite.define(() => {
 
       await activeRow.locator(".session-unread-dot").waitFor();
       await expectRequestCountStable(gateway, "sessions.patch", 1);
-      await captureUiProof(page, "manual-unread-marked.png");
+      await captureUiProof(suite, page, "manual-unread-marked.png");
 
       const marker = 1_800_000_000_001;
       await gateway.emitGatewayEvent("sessions.changed", {
@@ -80,7 +79,7 @@ suite.define(() => {
       });
       await activeRow.locator(".session-run-spinner").waitFor();
       await expectRequestCountStable(gateway, "sessions.patch", 1);
-      await captureUiProof(page, "manual-unread-running.png");
+      await captureUiProof(suite, page, "manual-unread-running.png");
 
       await gateway.emitGatewayEvent("sessions.changed", {
         reason: "run",
@@ -96,7 +95,7 @@ suite.define(() => {
       });
       await activeRow.locator(".session-unread-dot").waitFor();
       await expectRequestCountStable(gateway, "sessions.patch", 1);
-      await captureUiProof(page, "manual-unread-complete.png");
+      await captureUiProof(suite, page, "manual-unread-complete.png");
 
       await otherRow.getByRole("link").click();
       await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(otherKey));
@@ -113,11 +112,11 @@ suite.define(() => {
         unread: false,
       });
       expect(requireRecord(acknowledge.params)).not.toHaveProperty("readIntent");
-      await captureUiProof(page, "manual-unread-reopened.png");
+      await captureUiProof(suite, page, "manual-unread-reopened.png");
     } finally {
       await context.close();
       if (proofVideo) {
-        await proofVideo.saveAs(path.join(uiProofArtifactDir, "manual-unread-running.webm"));
+        await proofVideo.saveAs(path.join(suite.artifactDir, "manual-unread-running.webm"));
       }
     }
   });

--- a/ui/src/e2e/session-manager-history.e2e.test.ts
+++ b/ui/src/e2e/session-manager-history.e2e.test.ts
@@ -19,19 +19,16 @@ const suite = createControlUiE2eSuite({
     `Playwright Chromium is not installed or cannot start at ${executablePath}.`,
 });
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const artifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "session-manager-history",
-);
 
 async function captureUiProof(page: Page, fileName: string) {
   if (!captureProof) {
     return;
   }
-  await mkdir(artifactDir, { recursive: true });
-  await page.screenshot({ fullPage: true, path: path.join(artifactDir, fileName) });
+  await mkdir(path.join(suite.artifactDir, "session-manager-history"), { recursive: true });
+  await page.screenshot({
+    fullPage: true,
+    path: path.join(path.join(suite.artifactDir, "session-manager-history"), fileName),
+  });
 }
 
 suite.define(() => {

--- a/ui/src/e2e/session-owner-assignment.e2e.test.ts
+++ b/ui/src/e2e/session-owner-assignment.e2e.test.ts
@@ -1,8 +1,8 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect as expectBrowser } from "playwright/test";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiBundledGatewayUrl,
   controlUiSessionUrl,
@@ -17,7 +17,12 @@ const suite = createControlUiE2eSuite({
 });
 const sessionKey = "agent:main:owner-outcome";
 const proofPhase = process.env.OPENCLAW_OWNER_ASSIGNMENT_PROOF_PHASE;
-const proofDir = path.resolve(".artifacts/control-ui-e2e/session-owner-assignment");
+let proofDir: string;
+beforeEach(() => {
+  if (proofPhase) {
+    proofDir = createControlUiE2eArtifactDir("session-owner-assignment");
+  }
+});
 
 function sessionsListResponse() {
   return {
@@ -80,7 +85,6 @@ async function captureProof(page: Page, surface: string): Promise<void> {
   if (!proofPhase) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,

--- a/ui/src/e2e/session-owner-first.e2e.test.ts
+++ b/ui/src/e2e/session-owner-first.e2e.test.ts
@@ -8,7 +8,6 @@ import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts"
 
 const suite = createControlUiE2eSuite({ name: "Control UI owner-first session roster" });
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "session-owner-stack");
 
 function sessionRoster(ownerId: string, key: string, label: string, updatedAt: number) {
   const owner = {
@@ -45,10 +44,10 @@ async function captureSidebar(page: Page, fileName: string) {
   if (!captureProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
+  await mkdir(path.join(suite.artifactDir, "session-owner-stack"), { recursive: true });
   await page.locator(".sidebar-sessions").screenshot({
     animations: "disabled",
-    path: path.join(proofDir, fileName),
+    path: path.join(path.join(suite.artifactDir, "session-owner-stack"), fileName),
   });
 }
 

--- a/ui/src/e2e/session-owner-warm-refresh.e2e.test.ts
+++ b/ui/src/e2e/session-owner-warm-refresh.e2e.test.ts
@@ -9,7 +9,6 @@ import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts"
 
 const suite = createControlUiE2eSuite({ name: "Control UI warm owner-first refresh" });
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "session-owner-warm");
 
 function sessionRow(ownerId: string, key: string, label: string, updatedAt: number) {
   const owner = {
@@ -42,10 +41,10 @@ async function captureSidebar(page: Page, fileName: string) {
   if (!captureProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
+  await mkdir(path.join(suite.artifactDir, "session-owner-warm"), { recursive: true });
   await page.locator(".sidebar-sessions").screenshot({
     animations: "disabled",
-    path: path.join(proofDir, fileName),
+    path: path.join(path.join(suite.artifactDir, "session-owner-warm"), fileName),
   });
 }
 
@@ -54,7 +53,12 @@ suite.define(() => {
     const context = await suite.browser.newContext({
       viewport: { height: 800, width: 1200 },
       ...(captureProof
-        ? { recordVideo: { dir: proofDir, size: { height: 800, width: 1200 } } }
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "session-owner-warm"),
+              size: { height: 800, width: 1200 },
+            },
+          }
         : {}),
     });
     const page = await context.newPage();

--- a/ui/src/e2e/session-ownership-visuals.test-support.ts
+++ b/ui/src/e2e/session-ownership-visuals.test-support.ts
@@ -1,21 +1,8 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext, Locator, Page } from "playwright";
 import { expect } from "vitest";
 
 export const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-export const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "drafts-ux",
-);
-export const sessionOwnerProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "session-owner-stack",
-);
 
 type AvatarFixture = {
   id: string;
@@ -66,38 +53,47 @@ export async function avatarLabelCenterDelta(row: Locator) {
   });
 }
 
-export async function captureUiProof(page: Page, fileName: string) {
+export async function captureUiProof(
+  owner: { readonly artifactDir: string },
+  page: Page,
+  fileName: string,
+) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(uiProofArtifactDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,
-    path: path.join(uiProofArtifactDir, fileName),
+    path: path.join(owner.artifactDir, "drafts-ux", fileName),
   });
 }
 
-export async function captureSessionOwnerProof(page: Page, fileName: string) {
+export async function captureSessionOwnerProof(
+  owner: { readonly artifactDir: string },
+  page: Page,
+  fileName: string,
+) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(sessionOwnerProofArtifactDir, { recursive: true });
   await page.locator(".sidebar-sessions").screenshot({
     animations: "disabled",
-    path: path.join(sessionOwnerProofArtifactDir, fileName),
+    path: path.join(owner.artifactDir, "session-owner-stack", fileName),
   });
 }
 
-export async function captureSessionOwnerPageProof(page: Page, fileName: string) {
+export async function captureSessionOwnerPageProof(
+  owner: { readonly artifactDir: string },
+  page: Page,
+  fileName: string,
+) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(sessionOwnerProofArtifactDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,
-    path: path.join(sessionOwnerProofArtifactDir, fileName),
+    path: path.join(owner.artifactDir, "session-owner-stack", fileName),
   });
 }
 

--- a/ui/src/e2e/session-ownership.e2e.test.ts
+++ b/ui/src/e2e/session-ownership.e2e.test.ts
@@ -1,4 +1,4 @@
-import { mkdir } from "node:fs/promises";
+import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect as expectBrowser } from "playwright/test";
 import { afterEach, expect, it } from "vitest";
@@ -13,8 +13,6 @@ import {
   captureUiProofEnabled,
   openSidebarSortMenu,
   routeAvatarFixtures,
-  sessionOwnerProofArtifactDir,
-  uiProofArtifactDir,
 } from "./session-ownership-visuals.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -253,30 +251,27 @@ suite.define(() => {
           .session-owner-stack__front { width: 20px; height: 20px; }
         `,
       });
-      await captureSessionOwnerProof(currentPage, "00-before-light.png");
+      await captureSessionOwnerProof(suite, currentPage, "00-before-light.png");
       await currentPage.evaluate(() =>
         document.documentElement.setAttribute("data-theme-mode", "dark"),
       );
-      await captureSessionOwnerProof(currentPage, "01-before-dark.png");
+      await captureSessionOwnerProof(suite, currentPage, "01-before-dark.png");
       await legacyStyles.evaluate((style) => style.parentNode?.removeChild(style));
-      await captureSessionOwnerProof(currentPage, "02-after-dark.png");
+      await captureSessionOwnerProof(suite, currentPage, "02-after-dark.png");
       await currentPage.evaluate(() =>
         document.documentElement.setAttribute("data-theme-mode", "light"),
       );
-      await captureSessionOwnerProof(currentPage, "03-after-light.png");
+      await captureSessionOwnerProof(suite, currentPage, "03-after-light.png");
     }
   });
 
   it("derives People controls and owner filtering from current session owners", async () => {
-    if (captureUiProofEnabled) {
-      await mkdir(sessionOwnerProofArtifactDir, { recursive: true });
-    }
     const context = await suite.browser.newContext({
       viewport: { height: 800, width: 1200 },
       ...(captureUiProofEnabled
         ? {
             recordVideo: {
-              dir: sessionOwnerProofArtifactDir,
+              dir: path.join(suite.artifactDir, "session-owner-stack"),
               size: { height: 800, width: 1200 },
             },
           }
@@ -312,7 +307,7 @@ suite.define(() => {
     await expect.poll(() => currentPage.locator("openclaw-session-owner-chip").count()).toBe(3);
 
     const ownerMenu = await openSidebarSortMenu(currentPage);
-    await captureUiProof(currentPage, "00-people-controls-from-session-owners.png");
+    await captureUiProof(suite, currentPage, "00-people-controls-from-session-owners.png");
     await expectBrowser(ownerMenu.locator('[value="grouping:person"]')).toBeVisible();
     await expectBrowser(ownerMenu.locator('[value="sort:people"]')).toBeVisible();
     const ownerRows = ownerMenu.locator('wa-dropdown-item[value^="owner:"]:not([value="owner:"])');
@@ -321,7 +316,7 @@ suite.define(() => {
     await expectBrowser(ownerRows.first()).toContainText("Patrick (You)");
     await expectBrowser(ownerRows.locator("openclaw-session-owner-chip img")).toHaveCount(3);
     const firstOwnerCenterDelta = await avatarLabelCenterDelta(ownerRows.first());
-    await captureUiProof(currentPage, "00-people-sort-available.png");
+    await captureUiProof(suite, currentPage, "00-people-sort-available.png");
     expect(firstOwnerCenterDelta).toBeLessThanOrEqual(0.5);
     await selectMenuValue(ownerMenu, "grouping:person");
     await expectBrowser(
@@ -345,7 +340,7 @@ suite.define(() => {
       "aria-checked",
       "true",
     );
-    await captureUiProof(currentPage, "01-people-sort-selected.png");
+    await captureUiProof(suite, currentPage, "01-people-sort-selected.png");
     const expectOwnerFilter = async (after: number) => {
       // The chat title survives a sidebar refresh; wait for the filtered row itself.
       await expectBrowser(
@@ -373,7 +368,7 @@ suite.define(() => {
     await peopleMenu.locator('[value="owner:profile-ada"]').waitFor();
     await selectMenuValue(peopleMenu, "owner:profile-ada");
     await expectOwnerFilter(beforeSelection);
-    await captureSessionOwnerProof(currentPage, "04-owner-filter-selected.png");
+    await captureSessionOwnerProof(suite, currentPage, "04-owner-filter-selected.png");
 
     const initialConnections = (await gateway.getRequests("connect")).length;
     const beforeReconnect = (await gateway.getRequests("sessions.list")).length;
@@ -396,19 +391,20 @@ suite.define(() => {
       "aria-checked",
       "true",
     );
-    await captureSessionOwnerPageProof(currentPage, "05-owner-filter-restored-after-reload.png");
+    await captureSessionOwnerPageProof(
+      suite,
+      currentPage,
+      "05-owner-filter-restored-after-reload.png",
+    );
   });
 
   it("keeps unrelated active sessions out of the involving-me filter", async () => {
-    if (captureUiProofEnabled) {
-      await mkdir(sessionOwnerProofArtifactDir, { recursive: true });
-    }
     const context = await suite.browser.newContext({
       viewport: { height: 800, width: 1200 },
       ...(captureUiProofEnabled
         ? {
             recordVideo: {
-              dir: sessionOwnerProofArtifactDir,
+              dir: path.join(suite.artifactDir, "session-owner-stack"),
               size: { height: 800, width: 1200 },
             },
           }
@@ -445,7 +441,7 @@ suite.define(() => {
         ),
       )
       .toBe(true);
-    await captureSessionOwnerProof(currentPage, "02-involving-me-before-active-event.png");
+    await captureSessionOwnerProof(suite, currentPage, "02-involving-me-before-active-event.png");
 
     await gateway.emitGatewayEvent("session.message", {
       sessionKey: "agent:main:bob",
@@ -469,7 +465,7 @@ suite.define(() => {
       "aria-checked",
       "true",
     );
-    await captureSessionOwnerProof(currentPage, "03-involving-me-after-active-event.png");
+    await captureSessionOwnerProof(suite, currentPage, "03-involving-me-after-active-event.png");
   });
 
   it("renders zero ownership chrome for a single owner", async () => {
@@ -488,7 +484,7 @@ suite.define(() => {
     await currentPage.locator('[data-session-key="agent:main:ada"] a').click();
     await currentPage.getByText("Ready.", { exact: true }).waitFor();
     const ownerMenu = await openSidebarSortMenu(currentPage);
-    await captureUiProof(currentPage, "00-people-sort-hidden.png");
+    await captureUiProof(suite, currentPage, "00-people-sort-hidden.png");
     expect(
       await ownerMenu.locator(".sidebar-session-sort-menu__title", { hasText: "People" }).count(),
     ).toBe(0);
@@ -535,13 +531,15 @@ suite.define(() => {
   });
 
   it("keeps own drafts subtle and fades admin-visible drafts from other people", async () => {
-    if (captureUiProofEnabled) {
-      await mkdir(uiProofArtifactDir, { recursive: true });
-    }
     const context = await suite.browser.newContext({
       viewport: { height: 800, width: 1200 },
       ...(captureUiProofEnabled
-        ? { recordVideo: { dir: uiProofArtifactDir, size: { height: 800, width: 1200 } } }
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "drafts-ux"),
+              size: { height: 800, width: 1200 },
+            },
+          }
         : {}),
     });
     const currentPage = await context.newPage();
@@ -564,21 +562,23 @@ suite.define(() => {
       .poll(() => otherDraft.getAttribute("class"))
       .toContain("session-row-host--draft-other");
     expect(await currentPage.locator(".session-row-draft-indicator").count()).toBe(2);
-    await captureUiProof(currentPage, "01-sidebar-draft-treatment.png");
+    await captureUiProof(suite, currentPage, "01-sidebar-draft-treatment.png");
     await currentPage.evaluate(() =>
       document.documentElement.setAttribute("data-theme-mode", "dark"),
     );
-    await captureUiProof(currentPage, "01-sidebar-draft-treatment-dark.png");
+    await captureUiProof(suite, currentPage, "01-sidebar-draft-treatment-dark.png");
   });
 
   it("creates a draft atomically from the multi-person new-session flow", async () => {
-    if (captureUiProofEnabled) {
-      await mkdir(uiProofArtifactDir, { recursive: true });
-    }
     const context = await suite.browser.newContext({
       viewport: { height: 800, width: 1200 },
       ...(captureUiProofEnabled
-        ? { recordVideo: { dir: uiProofArtifactDir, size: { height: 800, width: 1200 } } }
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "drafts-ux"),
+              size: { height: 800, width: 1200 },
+            },
+          }
         : {}),
     });
     const currentPage = await context.newPage();
@@ -598,11 +598,11 @@ suite.define(() => {
     const draftToggle = currentPage.getByRole("switch", { name: "Draft", exact: true });
     await currentPage.locator(".new-session-page__composer .agent-chat__composer-footer").hover();
     await draftToggle.waitFor();
-    await captureUiProof(currentPage, "02-create-draft-available.png");
+    await captureUiProof(suite, currentPage, "02-create-draft-available.png");
     await draftToggle.check();
     await expectBrowser(draftToggle).toBeChecked();
     await currentPage.locator(".new-session-page__message").fill("work privately first");
-    await captureUiProof(currentPage, "03-create-draft-selected.png");
+    await captureUiProof(suite, currentPage, "03-create-draft-selected.png");
     await currentPage.getByRole("button", { name: "Start session" }).click();
 
     const create = await gateway.waitForRequest("sessions.create");
@@ -614,13 +614,15 @@ suite.define(() => {
   });
 
   it("publishes a draft through the header sharing menu", async () => {
-    if (captureUiProofEnabled) {
-      await mkdir(uiProofArtifactDir, { recursive: true });
-    }
     const context = await suite.browser.newContext({
       viewport: { height: 800, width: 1200 },
       ...(captureUiProofEnabled
-        ? { recordVideo: { dir: uiProofArtifactDir, size: { height: 800, width: 1200 } } }
+        ? {
+            recordVideo: {
+              dir: path.join(suite.artifactDir, "drafts-ux"),
+              size: { height: 800, width: 1200 },
+            },
+          }
         : {}),
     });
     const currentPage = await context.newPage();
@@ -665,7 +667,7 @@ suite.define(() => {
     await currentPage.getByLabel("Session sharing").click();
     const publish = currentPage.getByText("Publish draft", { exact: true });
     await publish.waitFor();
-    await captureUiProof(currentPage, "04-publish-draft-action.png");
+    await captureUiProof(suite, currentPage, "04-publish-draft-action.png");
     await publish.click();
 
     const request = await gateway.waitForRequest("session.visibility.set");

--- a/ui/src/e2e/session-person-grouping-presence.e2e.test.ts
+++ b/ui/src/e2e/session-person-grouping-presence.e2e.test.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import type { Locator } from "playwright";
 import { expect as expectBrowser } from "playwright/test";
 import { it } from "vitest";
@@ -8,7 +9,6 @@ import {
   captureUiProofEnabled,
   openSidebarSortMenu,
   routeAvatarFixtures,
-  sessionOwnerProofArtifactDir,
 } from "./session-ownership-visuals.test-support.ts";
 
 const suite = createControlUiE2eSuite({
@@ -75,7 +75,7 @@ suite.define(() => {
       ...(captureUiProofEnabled
         ? {
             recordVideo: {
-              dir: sessionOwnerProofArtifactDir,
+              dir: path.join(suite.artifactDir, "session-owner-stack"),
               size: { height: 800, width: 1200 },
             },
           }
@@ -138,7 +138,7 @@ suite.define(() => {
         adaSection.locator(".session-owner-chip:not(.session-owner-chip--away)"),
       ).toHaveCount(1);
       await expectBrowser(bobSection.locator('[data-viewer-id="profile-morgan"]')).toHaveCount(1);
-      await captureSessionOwnerProof(page, "person-grouping-live-presence.png");
+      await captureSessionOwnerProof(suite, page, "person-grouping-live-presence.png");
       await expectBrowser(bobSection.locator("openclaw-session-owner-chip")).toHaveCount(0);
     } finally {
       await context.close();

--- a/ui/src/e2e/session-placement.move.e2e.test.ts
+++ b/ui/src/e2e/session-placement.move.e2e.test.ts
@@ -1,7 +1,6 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { beforeAll, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import {
   chatSessionListResponse,
   createChatFlowE2eSuite,
@@ -13,25 +12,21 @@ import { tooltipTitleText } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "session-placement-move");
 const runnerOfflineProofName = process.env.OPENCLAW_RUNNER_OFFLINE_SCREENSHOT;
-const runnerOfflineProofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "runner-offline",
-);
 
 async function capture(page: Page, name: string): Promise<void> {
   if (captureProof) {
-    await page.screenshot({ path: path.join(proofDir, name) });
+    await page.screenshot({
+      path: path.join(suite.artifactDir, "session-placement-move", name),
+    });
   }
 }
 
 async function captureRunnerOffline(page: Page): Promise<void> {
   if (runnerOfflineProofName) {
-    await mkdir(runnerOfflineProofDir, { recursive: true });
-    await page.screenshot({ path: path.join(runnerOfflineProofDir, runnerOfflineProofName) });
+    await page.screenshot({
+      path: path.join(suite.artifactDir, "runner-offline", runnerOfflineProofName),
+    });
   }
 }
 
@@ -40,7 +35,14 @@ function contextOptions() {
     locale: "en-US",
     serviceWorkers: "block" as const,
     viewport: { height: 900, width: 1280 },
-    ...(captureProof ? { recordVideo: { dir: proofDir, size: { height: 900, width: 1280 } } } : {}),
+    ...(captureProof
+      ? {
+          recordVideo: {
+            dir: path.join(suite.artifactDir, "session-placement-move"),
+            size: { height: 900, width: 1280 },
+          },
+        }
+      : {}),
   };
 }
 
@@ -73,12 +75,6 @@ function activeSession(placementMove?: {
 }
 
 suite.define(() => {
-  beforeAll(async () => {
-    if (captureProof) {
-      await mkdir(proofDir, { recursive: true });
-    }
-  });
-
   it("shows authoritative device targets to writers and moves through the exact-source RPC", async () => {
     const context = await suite.newBrowserContext(contextOptions());
     const page = await context.newPage();

--- a/ui/src/e2e/session-progress-hovercard.e2e.test.ts
+++ b/ui/src/e2e/session-progress-hovercard.e2e.test.ts
@@ -14,22 +14,15 @@ import {
   pauseVirtualClock,
 } from "./chat-flow.test-support.ts";
 
-const proofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "session-progress-hovercard",
-);
-
 async function captureProof(page: Page, fileName: string): Promise<void> {
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
+  await mkdir(path.join(suite.artifactDir, "session-progress-hovercard"), { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,
-    path: path.join(proofDir, fileName),
+    path: path.join(path.join(suite.artifactDir, "session-progress-hovercard"), fileName),
   });
 }
 

--- a/ui/src/e2e/session-progress-live-placement.e2e.test.ts
+++ b/ui/src/e2e/session-progress-live-placement.e2e.test.ts
@@ -16,22 +16,15 @@ import {
 } from "./chat-flow.test-support.ts";
 import { openChatSidePanelType } from "./chat-side-panel.test-support.ts";
 
-const proofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "session-progress-live-placement",
-);
-
 async function captureProof(page: Page, fileName: string): Promise<void> {
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
+  await mkdir(path.join(suite.artifactDir, "session-progress-live-placement"), { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,
-    path: path.join(proofDir, fileName),
+    path: path.join(path.join(suite.artifactDir, "session-progress-live-placement"), fileName),
   });
 }
 

--- a/ui/src/e2e/session-progress-widget.e2e.test.ts
+++ b/ui/src/e2e/session-progress-widget.e2e.test.ts
@@ -1,6 +1,6 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiBundledSettingsStorageKey,
   controlUiSessionUrl,
@@ -13,7 +13,10 @@ const suite = createControlUiE2eSuite({
   startServerBeforeBrowser: true,
 });
 const sessionKey = "agent:main:progress-dashboard";
-const proofDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/session-progress-widget");
+let proofDir: string;
+beforeEach(() => {
+  proofDir = createControlUiE2eArtifactDir("session-progress-widget");
+});
 
 suite.define(() => {
   it("renders the live session progress card through an advertised dashboard kind", async () => {
@@ -89,7 +92,6 @@ suite.define(() => {
         .toContain("1/3");
       await expect.poll(() => gateway.getRequests("progressCard.get")).toHaveLength(1);
 
-      await mkdir(proofDir, { recursive: true });
       await page.screenshot({
         animations: "disabled",
         fullPage: true,

--- a/ui/src/e2e/session-suggestions.e2e.test.ts
+++ b/ui/src/e2e/session-suggestions.e2e.test.ts
@@ -1,8 +1,8 @@
-// Control UI E2E tests cover suggestion queue and solo-dormancy behavior.
-import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, type Page } from "playwright/test";
-import { it } from "vitest";
+import { beforeEach, it } from "vitest";
+// Control UI E2E tests cover suggestion queue and solo-dormancy behavior.
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -13,15 +13,16 @@ const suite = createControlUiE2eSuite({
 
 const sessionKey = "agent:main:main";
 
-function artifactDir(): string | undefined {
-  return process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim() || undefined;
-}
+let proofArtifactDir: string | undefined;
+beforeEach(() => {
+  const parent = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+  proofArtifactDir = parent
+    ? createControlUiE2eArtifactDir("session-suggestions", parent)
+    : undefined;
+});
 
 async function contextAndPage() {
-  const output = artifactDir();
-  if (output) {
-    await fs.mkdir(output, { recursive: true });
-  }
+  const output = proofArtifactDir;
   const context = await suite.browser.newContext({
     viewport: { height: 760, width: 1180 },
     ...(output ? { recordVideo: { dir: output, size: { height: 760, width: 1180 } } } : {}),
@@ -30,7 +31,7 @@ async function contextAndPage() {
 }
 
 async function screenshot(page: Page, name: string) {
-  const output = artifactDir();
+  const output = proofArtifactDir;
   if (output) {
     await page.screenshot({ animations: "disabled", path: path.join(output, name) });
   }
@@ -241,7 +242,7 @@ suite.define(() => {
       visible = visible ? `${visible} ${word}` : word;
       await ownerTyping(visible);
       await expect(previewBubble).toHaveText(visible);
-      if (artifactDir()) {
+      if (proofArtifactDir) {
         // Readability pacing for the recorded artifact only; assertions above
         // already proved each chunk rendered.
         await page.waitForTimeout(160);

--- a/ui/src/e2e/session-transcript-search.e2e.test.ts
+++ b/ui/src/e2e/session-transcript-search.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI E2E tests transcript search through the advertised Gateway method.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
-import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   controlUiSessionPath,
@@ -17,12 +17,12 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const artifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "session-transcript-search",
-);
+let artifactDir: string;
+beforeEach(() => {
+  if (captureProof) {
+    artifactDir = createControlUiE2eArtifactDir("session-transcript-search");
+  }
+});
 
 // Browser contexts preserve test isolation; keep one process warm for this file.
 let browser: Browser;
@@ -65,9 +65,6 @@ async function resolveDeferredAndDrain(
 
 describeControlUiE2e("Control UI session transcript search", () => {
   beforeAll(async () => {
-    if (captureProof) {
-      await mkdir(artifactDir, { recursive: true });
-    }
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
     try {
       server = await startControlUiE2eServer();

--- a/ui/src/e2e/settings-layout.e2e.test.ts
+++ b/ui/src/e2e/settings-layout.e2e.test.ts
@@ -13,13 +13,6 @@ const suite = createControlUiE2eSuite({
 });
 
 const proofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "settings-layout-audit",
-  "after",
-);
 
 const introRoutes = [
   "appearance",
@@ -402,11 +395,14 @@ suite.define(() => {
       await expect.poll(() => advanced.getAttribute("open")).toBeNull();
       await expect.poll(() => advancedSummary.textContent()).toContain("Advanced settings");
       if (proofEnabled) {
-        await mkdir(proofDir, { recursive: true });
+        await mkdir(path.join(suite.artifactDir, "settings-layout-audit"), { recursive: true });
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
-          path: path.join(proofDir, "communications-messages.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "settings-layout-audit"),
+            "communications-messages.png",
+          ),
         });
       }
 
@@ -417,7 +413,10 @@ suite.define(() => {
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
-          path: path.join(proofDir, "communications-advanced-expanded.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "settings-layout-audit"),
+            "communications-advanced-expanded.png",
+          ),
         });
       }
 
@@ -431,7 +430,10 @@ suite.define(() => {
         await page.screenshot({
           animations: "disabled",
           fullPage: true,
-          path: path.join(proofDir, "communications-voice.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "settings-layout-audit"),
+            "communications-voice.png",
+          ),
         });
       }
 
@@ -475,7 +477,7 @@ suite.define(() => {
 
     try {
       if (proofEnabled) {
-        await mkdir(proofDir, { recursive: true });
+        await mkdir(path.join(suite.artifactDir, "settings-layout-audit"), { recursive: true });
       }
 
       let auditedPairCount = 0;
@@ -526,7 +528,10 @@ suite.define(() => {
             await page.screenshot({
               animations: "disabled",
               fullPage: true,
-              path: path.join(proofDir, `${route}.png`),
+              path: path.join(
+                path.join(suite.artifactDir, "settings-layout-audit"),
+                `${route}.png`,
+              ),
             });
           }
         }
@@ -652,7 +657,10 @@ suite.define(() => {
           if (proofEnabled && viewport.width === 1440) {
             await section.screenshot({
               animations: "disabled",
-              path: path.join(proofDir, `action-${sectionCase.route}.png`),
+              path: path.join(
+                path.join(suite.artifactDir, "settings-layout-audit"),
+                `action-${sectionCase.route}.png`,
+              ),
             });
           }
         }

--- a/ui/src/e2e/sidebar-account-footer.e2e.test.ts
+++ b/ui/src/e2e/sidebar-account-footer.e2e.test.ts
@@ -49,7 +49,12 @@ async function assertIdentityMenuContract(sidebar: Locator, menu: Locator) {
   ).toBe(false);
 }
 
-async function runAccountFooterProof(page: Page, sidebar: Locator, branch: "feature" | "main") {
+async function runAccountFooterProof(
+  suite: ReturnType<typeof createSidebarFooterProofSuite>,
+  page: Page,
+  sidebar: Locator,
+  branch: "feature" | "main",
+) {
   const footer = sidebar.locator(".sidebar-footer-bar");
   const identity = sidebar.locator(".sidebar-identity-card");
   await assertSingleAccountTarget(page, sidebar);
@@ -57,9 +62,13 @@ async function runAccountFooterProof(page: Page, sidebar: Locator, branch: "feat
   for (const theme of ["light", "dark"] as const) {
     await setSidebarProofTheme(page, theme);
     await page.mouse.move(0, 0);
-    await captureUnionProof(page, "sidebar-account-footer", `${branch}-${theme}-footer.png`, [
-      footer,
-    ]);
+    await captureUnionProof(
+      suite,
+      page,
+      "sidebar-account-footer",
+      `${branch}-${theme}-footer.png`,
+      [footer],
+    );
 
     await identity.focus();
     await page.keyboard.press("Enter");
@@ -86,17 +95,22 @@ async function runAccountFooterProof(page: Page, sidebar: Locator, branch: "feat
     await page.clock.runFor(600);
     await expect.poll(() => buildTooltip.getAttribute("open")).not.toBeNull();
     await page.clock.resume();
-    await captureUnionProof(page, "build-chip-hover-intent", `${branch}-${theme}-intent-open.png`, [
-      footer,
-      menuSurface,
-      buildTooltipCard,
-    ]);
+    await captureUnionProof(
+      suite,
+      page,
+      "build-chip-hover-intent",
+      `${branch}-${theme}-intent-open.png`,
+      [footer, menuSurface, buildTooltipCard],
+    );
     await page.mouse.move(0, 0);
     await buildTooltipCard.waitFor({ state: "hidden" });
-    await captureUnionProof(page, "sidebar-account-footer", `${branch}-${theme}-menu-default.png`, [
-      footer,
-      menuSurface,
-    ]);
+    await captureUnionProof(
+      suite,
+      page,
+      "sidebar-account-footer",
+      `${branch}-${theme}-menu-default.png`,
+      [footer, menuSurface],
+    );
 
     const settings = menu.locator('wa-dropdown-item[value="command:settings"]');
     const settingsShortcut = settings.locator(".session-menu__shortcut");
@@ -112,6 +126,7 @@ async function runAccountFooterProof(page: Page, sidebar: Locator, branch: "feat
       .poll(() => settings.evaluate((element) => getComputedStyle(element).backgroundColor))
       .not.toBe(settingsRestBackground);
     await captureUnionProof(
+      suite,
       page,
       "sidebar-account-footer",
       `${branch}-${theme}-menu-settings-hover.png`,
@@ -121,6 +136,7 @@ async function runAccountFooterProof(page: Page, sidebar: Locator, branch: "feat
     const usage = menu.locator('wa-dropdown-item[value="command:usage"]');
     await usage.focus();
     await captureUnionProof(
+      suite,
       page,
       "sidebar-account-footer",
       `${branch}-${theme}-menu-usage-focus.png`,
@@ -137,6 +153,7 @@ async function runAccountFooterProof(page: Page, sidebar: Locator, branch: "feat
     const submenu = help.locator('[part="submenu"]');
     await submenu.waitFor({ state: "visible" });
     await captureUnionProof(
+      suite,
       page,
       "sidebar-account-footer",
       `${branch}-${theme}-menu-help-submenu.png`,
@@ -179,7 +196,9 @@ suite.define(() => {
       expect(await offline.textContent()).toContain("Offline");
       expect(await offline.textContent()).toContain("Reconnecting…");
       await expect.poll(() => page.title()).toContain("(Disconnected)");
-      await captureUnionProof(page, "sidebar-account-footer", "feature-dark-offline.png", [footer]);
+      await captureUnionProof(suite, page, "sidebar-account-footer", "feature-dark-offline.png", [
+        footer,
+      ]);
 
       const socketCount = await gateway.getSocketCount();
       await offline.click();
@@ -199,9 +218,13 @@ suite.define(() => {
       const restarting = footer.locator(".sidebar-footer-bar__status--restarting");
       await restarting.waitFor({ state: "visible" });
       expect(await restarting.textContent()).toBe("Restarting…");
-      await captureUnionProof(page, "sidebar-account-footer", "feature-dark-restarting.png", [
-        footer,
-      ]);
+      await captureUnionProof(
+        suite,
+        page,
+        "sidebar-account-footer",
+        "feature-dark-restarting.png",
+        [footer],
+      );
     } finally {
       await suite.closeBrowserContext(opened.context);
     }
@@ -210,7 +233,7 @@ suite.define(() => {
   it("keeps the feature account target, identity menu, and visual states coherent", async () => {
     const opened = await openSidebarFooterProofPage(suite);
     try {
-      await runAccountFooterProof(opened.page, opened.sidebar, "feature");
+      await runAccountFooterProof(suite, opened.page, opened.sidebar, "feature");
     } finally {
       await suite.closeBrowserContext(opened.context);
     }

--- a/ui/src/e2e/sidebar-attention-scope.e2e.test-support.ts
+++ b/ui/src/e2e/sidebar-attention-scope.e2e.test-support.ts
@@ -1,4 +1,3 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Browser, Page } from "playwright";
 import { expect } from "vitest";
@@ -50,9 +49,6 @@ async function setDarkTheme(page: Page) {
 }
 
 export async function runSidebarAttentionScopeFlow(params: SidebarAttentionScopeFlowOptions) {
-  if (params.captureProof) {
-    await mkdir(params.artifactDir, { recursive: true });
-  }
   const context = await params.browser.newContext({
     locale: "en-US",
     recordVideo: params.captureProof

--- a/ui/src/e2e/sidebar-attention-scope.e2e.test.ts
+++ b/ui/src/e2e/sidebar-attention-scope.e2e.test.ts
@@ -12,7 +12,9 @@ const suite = createControlUiE2eSuite({
 suite.define(() => {
   it("scopes automation attention and bulk dismissal across agents", async () => {
     await runSidebarAttentionScopeFlow({
-      artifactDir: path.join(process.cwd(), ".artifacts", "control-ui-e2e", "inbox-agent-scope"),
+      get artifactDir() {
+        return path.join(suite.artifactDir, "inbox-agent-scope");
+      },
       baseUrl: suite.server.baseUrl,
       browser: suite.browser,
       captureProof: false,

--- a/ui/src/e2e/sidebar-customization.e2e.test.ts
+++ b/ui/src/e2e/sidebar-customization.e2e.test.ts
@@ -21,12 +21,6 @@ const suite = createControlUiE2eSuite({
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 const hiddenSessionCatalogsStorageKey = "openclaw:sidebar:sessions:hidden-catalogs";
-const uiProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "sidebar-customization",
-);
 
 async function trimmedTextContents(locator: Locator): Promise<string[]> {
   return (await locator.allTextContents()).map((text) => text.trim());
@@ -69,11 +63,11 @@ async function captureUiProof(page: Page, fileName: string) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(uiProofArtifactDir, { recursive: true });
+  await mkdir(path.join(suite.artifactDir, "sidebar-customization"), { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,
-    path: path.join(uiProofArtifactDir, fileName),
+    path: path.join(path.join(suite.artifactDir, "sidebar-customization"), fileName),
   });
 }
 
@@ -81,10 +75,10 @@ async function captureSettingsSidebarProof(sidebar: Locator, fileName: string) {
   if (!captureUiProofEnabled) {
     return;
   }
-  await mkdir(uiProofArtifactDir, { recursive: true });
+  await mkdir(path.join(suite.artifactDir, "sidebar-customization"), { recursive: true });
   await sidebar.screenshot({
     animations: "disabled",
-    path: path.join(uiProofArtifactDir, fileName),
+    path: path.join(path.join(suite.artifactDir, "sidebar-customization"), fileName),
   });
 }
 
@@ -161,17 +155,23 @@ suite.define(() => {
       expect(await recovery.getByText("claude", { exact: true }).count()).toBe(0);
 
       if (captureUiProofEnabled) {
-        await mkdir(uiProofArtifactDir, { recursive: true });
+        await mkdir(path.join(suite.artifactDir, "sidebar-customization"), { recursive: true });
         await recovery.scrollIntoViewIfNeeded();
         for (const theme of ["light", "dark"] as const) {
           await setThemeMode(page, theme);
           await page.screenshot({
             animations: "disabled",
-            path: path.join(uiProofArtifactDir, `after-${theme}-context.png`),
+            path: path.join(
+              path.join(suite.artifactDir, "sidebar-customization"),
+              `after-${theme}-context.png`,
+            ),
           });
           await recovery.screenshot({
             animations: "disabled",
-            path: path.join(uiProofArtifactDir, `after-${theme}-rows.png`),
+            path: path.join(
+              path.join(suite.artifactDir, "sidebar-customization"),
+              `after-${theme}-rows.png`,
+            ),
           });
         }
       }
@@ -188,12 +188,15 @@ suite.define(() => {
 
   it("pins routes, restores defaults, and persists navigation state across reloads", async () => {
     if (captureUiProofEnabled) {
-      await mkdir(uiProofArtifactDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "sidebar-customization"), { recursive: true });
     }
     const context = await suite.browser.newContext({
       locale: "en-US",
       recordVideo: captureUiProofEnabled
-        ? { dir: path.join(uiProofArtifactDir, "video"), size: { height: 900, width: 1300 } }
+        ? {
+            dir: path.join(path.join(suite.artifactDir, "sidebar-customization"), "video"),
+            size: { height: 900, width: 1300 },
+          }
         : undefined,
       serviceWorkers: "block",
       viewport: { height: 900, width: 1440 },
@@ -436,7 +439,10 @@ suite.define(() => {
         .toContain("No matching settings.");
       if (captureUiProofEnabled) {
         await writeFile(
-          path.join(uiProofArtifactDir, "settings-search-accessibility.yml"),
+          path.join(
+            path.join(suite.artifactDir, "sidebar-customization"),
+            "settings-search-accessibility.yml",
+          ),
           await settingsSidebar.ariaSnapshot(),
           "utf8",
         );
@@ -672,7 +678,12 @@ suite.define(() => {
     } finally {
       await context.close();
       if (video) {
-        await video.saveAs(path.join(uiProofArtifactDir, "settings-search-flow.webm"));
+        await video.saveAs(
+          path.join(
+            path.join(suite.artifactDir, "sidebar-customization"),
+            "settings-search-flow.webm",
+          ),
+        );
       }
     }
   });

--- a/ui/src/e2e/sidebar-customization.test-support.ts
+++ b/ui/src/e2e/sidebar-customization.test-support.ts
@@ -1,15 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
-
-const sidebarProofArtifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "sidebar-customization",
-);
 
 export function createSidebarCustomizationSuite(name: string) {
   return createControlUiE2eSuite({
@@ -20,29 +12,32 @@ export function createSidebarCustomizationSuite(name: string) {
   });
 }
 
-export async function captureSidebarUiProof(page: Page, fileName: string): Promise<void> {
+export async function captureSidebarUiProof(
+  owner: { readonly artifactDir: string },
+  page: Page,
+  fileName: string,
+): Promise<void> {
   if (process.env.OPENCLAW_CAPTURE_UI_PROOF !== "1") {
     return;
   }
-  await mkdir(sidebarProofArtifactDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,
-    path: path.join(sidebarProofArtifactDir, fileName),
+    path: path.join(owner.artifactDir, fileName),
   });
 }
 
 export async function captureSettingsSidebarUiProof(
+  owner: { readonly artifactDir: string },
   sidebar: Locator,
   fileName: string,
 ): Promise<void> {
   if (process.env.OPENCLAW_CAPTURE_UI_PROOF !== "1") {
     return;
   }
-  await mkdir(sidebarProofArtifactDir, { recursive: true });
   await sidebar.screenshot({
     animations: "disabled",
-    path: path.join(sidebarProofArtifactDir, fileName),
+    path: path.join(owner.artifactDir, fileName),
   });
 }
 

--- a/ui/src/e2e/sidebar-dev-branch.e2e.test.ts
+++ b/ui/src/e2e/sidebar-dev-branch.e2e.test.ts
@@ -1,9 +1,9 @@
 // Control UI sidebar footer flags non-release gateways: a source-checkout
 // gateway off main reports its branch via bootstrap config and the footer
 // renders it in the danger color; release gateways omit it entirely.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -58,8 +58,7 @@ suite.define(() => {
         expect(colors.danger).not.toBe("");
         expect(colors.badge).toBe(colors.danger);
 
-        const artifactDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "dev-branch");
-        await mkdir(artifactDir, { recursive: true });
+        const artifactDir = createControlUiE2eArtifactDir("dev-branch");
         await page
           .locator(".sidebar-shell__footer")
           .screenshot({ path: path.join(artifactDir, "footer-dev-branch.png") });

--- a/ui/src/e2e/sidebar-footer-proof.test-support.ts
+++ b/ui/src/e2e/sidebar-footer-proof.test-support.ts
@@ -1,12 +1,9 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Locator, Page } from "playwright";
 import { expect } from "vitest";
 import type { ControlUiBuildInfo } from "../build-info.ts";
 import { installMockGateway, startControlUiE2eServer } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
-
-const proofArtifactRoot = path.join(process.cwd(), ".artifacts", "control-ui-e2e");
 
 const SIDEBAR_PROOF_USER = {
   self: true,
@@ -57,6 +54,7 @@ export async function setSidebarProofTheme(page: Page, mode: "dark" | "light") {
 }
 
 export async function captureUnionProof(
+  owner: { readonly artifactDir: string },
   page: Page,
   directory: string,
   fileName: string,
@@ -95,8 +93,7 @@ export async function captureUnionProof(
     viewport.height,
     Math.max(...boxes.map((box) => box.y + box.height)) + margin,
   );
-  const artifactDir = path.join(proofArtifactRoot, directory);
-  await mkdir(artifactDir, { recursive: true });
+  const artifactDir = path.join(owner.artifactDir, directory);
   await page.screenshot({
     clip: { x, y, width: right - x, height: bottom - y },
     path: path.join(artifactDir, fileName),

--- a/ui/src/e2e/sidebar-interactions.e2e.test.ts
+++ b/ui/src/e2e/sidebar-interactions.e2e.test.ts
@@ -84,7 +84,7 @@ suite.define(() => {
       const draft = "Keep this unsent conversation draft";
       await composer.fill(draft);
       const originalUrl = page.url();
-      await captureSidebarUiProof(page, "new-session-links-source.png");
+      await captureSidebarUiProof(suite, page, "new-session-links-source.png");
 
       const actions: Array<{ selector: string; section?: string; params: Record<string, string> }> =
         [
@@ -149,7 +149,7 @@ suite.define(() => {
           expect(await composer.inputValue()).toBe(draft);
           expect(await sessionCreates(page)).toEqual([]);
           if ("group" in action.params) {
-            await captureSidebarUiProof(popup, "new-session-links-group-tab.png");
+            await captureSidebarUiProof(suite, popup, "new-session-links-group-tab.png");
           }
         } finally {
           await popup.close();
@@ -229,7 +229,7 @@ suite.define(() => {
         duration: "0.6s",
         name: "chat-composer-prefill-attention",
       });
-      await captureSidebarUiProof(page, "capabilities-composer-focus.png");
+      await captureSidebarUiProof(suite, page, "capabilities-composer-focus.png");
       await expect
         .poll(() => input.getAttribute("class"))
         .not.toContain("agent-chat__input--prefill-attention");
@@ -247,7 +247,7 @@ suite.define(() => {
     try {
       expect(cueStyle.name).toBe("none");
       expect(cueStyle.boxShadow).not.toBe("none");
-      await captureSidebarUiProof(page, "capabilities-composer-reduced-motion.png");
+      await captureSidebarUiProof(suite, page, "capabilities-composer-reduced-motion.png");
       await expect
         .poll(() => input.getAttribute("class"))
         .not.toContain("agent-chat__input--prefill-attention");
@@ -496,7 +496,7 @@ suite.define(() => {
       await expect
         .poll(() => researchSwitch.evaluate((element) => element === document.activeElement))
         .toBe(true);
-      await captureSidebarUiProof(page, "agent-menu-without-new-session-rows.png");
+      await captureSidebarUiProof(suite, page, "agent-menu-without-new-session-rows.png");
       await page.keyboard.press("Enter");
       await expect
         .poll(() => new URL(page.url()).pathname)
@@ -552,7 +552,7 @@ suite.define(() => {
       await expect
         .poll(() => image.evaluate((element: HTMLImageElement) => element.naturalWidth))
         .toBe(1);
-      await captureSidebarUiProof(page, "workspace-agent-avatar.png");
+      await captureSidebarUiProof(suite, page, "workspace-agent-avatar.png");
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/e2e/sidebar-per-tab-visibility.capture.e2e.test.ts
+++ b/ui/src/e2e/sidebar-per-tab-visibility.capture.e2e.test.ts
@@ -87,7 +87,7 @@ suite.define(() => {
       // The general chat surface is the app's main view; collapsing it here
       // would be a default-path regression, so this is the guard for it.
       await expect.poll(() => sidebar.isVisible()).toBe(true);
-      await captureUiProof(page, "per-tab-01-chat-root-sidebar-visible.png");
+      await captureUiProof(suite, page, "per-tab-01-chat-root-sidebar-visible.png");
     } finally {
       await context.close();
     }
@@ -142,12 +142,12 @@ suite.define(() => {
       expect(new URL(page.url()).searchParams.has(SIDEBAR_SESSION_NAV_COLLAPSE_QUERY.name)).toBe(
         false,
       );
-      await captureUiProof(page, "per-tab-02-session-tab-collapsed.png");
+      await captureUiProof(suite, page, "per-tab-02-session-tab-collapsed.png");
 
       await page.keyboard.press("Meta+B");
       await sidebar.waitFor({ state: "visible", timeout: 10_000 });
       await expect.poll(() => sidebar.isVisible()).toBe(true);
-      await captureUiProof(page, "per-tab-03-session-tab-after-cmd-b.png");
+      await captureUiProof(suite, page, "per-tab-03-session-tab-after-cmd-b.png");
 
       await page.reload();
       await composer.waitFor({ state: "visible", timeout: 10_000 });
@@ -194,7 +194,7 @@ suite.define(() => {
         hostId: "gateway:local",
         threadId: "thread-sidebar-collapse",
       });
-      await captureUiProof(catalogTab, "per-tab-04-catalog-session-tab-collapsed.png");
+      await captureUiProof(suite, catalogTab, "per-tab-04-catalog-session-tab-collapsed.png");
     } finally {
       await context.close();
     }

--- a/ui/src/e2e/sidebar-roster-completeness.capture.e2e.test.ts
+++ b/ui/src/e2e/sidebar-roster-completeness.capture.e2e.test.ts
@@ -118,6 +118,7 @@ suite.define(() => {
       // Captured before the row assertion so a pre-fix run still produces its
       // own proof image instead of dying at the assertion with nothing to show.
       await captureUiProof(
+        suite,
         page,
         `roster-completeness-${process.env.OPENCLAW_ROSTER_PROOF ?? "after"}.png`,
       );

--- a/ui/src/e2e/sidebar-selection-overflow.e2e.test.ts
+++ b/ui/src/e2e/sidebar-selection-overflow.e2e.test.ts
@@ -12,13 +12,13 @@ const suite = createControlUiE2eSuite({
   },
 });
 
-const artifactDir = path.resolve(".artifacts/control-ui-e2e/sidebar-selection-overflow");
-
 suite.define(() => {
   it("keeps the active session pill clear of a classic scrollbar", async () => {
     const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
     if (captureProof) {
-      await fs.mkdir(artifactDir, { recursive: true });
+      await fs.mkdir(path.join(suite.artifactDir, "sidebar-selection-overflow"), {
+        recursive: true,
+      });
     }
     const context = await suite.newBrowserContext({
       viewport: { height: 500, width: 1280 },
@@ -72,7 +72,10 @@ suite.define(() => {
 
       if (captureProof) {
         await page.screenshot({
-          path: path.join(artifactDir, "active-session-pill.png"),
+          path: path.join(
+            path.join(suite.artifactDir, "sidebar-selection-overflow"),
+            "active-session-pill.png",
+          ),
           fullPage: true,
         });
       }

--- a/ui/src/e2e/sidebar-session-stability.e2e.test.ts
+++ b/ui/src/e2e/sidebar-session-stability.e2e.test.ts
@@ -9,7 +9,6 @@ import {
   createSessionManagementE2eSuite,
   installMockGateway,
   sessionsListResponse,
-  uiProofArtifactDir,
 } from "./session-management.test-support.ts";
 
 const suite = createSessionManagementE2eSuite();
@@ -50,7 +49,7 @@ suite.define(() => {
       serviceWorkers: "block",
       viewport: { height: 900, width: 1280 },
       recordVideo: captureUiProofEnabled
-        ? { dir: uiProofArtifactDir, size: { height: 900, width: 1280 } }
+        ? { dir: suite.artifactDir, size: { height: 900, width: 1280 } }
         : undefined,
     });
     const page = await context.newPage();
@@ -72,7 +71,7 @@ suite.define(() => {
       const childToggle = page.locator(`[data-child-session-toggle="${parentKey}"]`);
       await expect.poll(visibleKeys, { timeout: 10_000 }).toEqual(expectedVisibleKeys);
       await expect.poll(() => childToggle.getAttribute("aria-expanded")).toBe("true");
-      await captureUiProof(page, "sidebar-session-stability-running.png");
+      await captureUiProof(suite, page, "sidebar-session-stability-running.png");
 
       await gateway.emitGatewayEvent("agent", {
         data: { name: "bash" },
@@ -123,11 +122,11 @@ suite.define(() => {
         .toBe(controlUiSessionPath(nextSessionKey));
       await expect.poll(() => childToggle.getAttribute("aria-expanded")).toBe("true");
       await expect.poll(visibleKeys).toEqual(expectedVisibleKeys);
-      await captureUiProof(page, "sidebar-session-stability-completed.png");
+      await captureUiProof(suite, page, "sidebar-session-stability-completed.png");
     } finally {
       await context.close();
       if (proofVideo) {
-        await proofVideo.saveAs(path.join(uiProofArtifactDir, "sidebar-session-stability.webm"));
+        await proofVideo.saveAs(path.join(suite.artifactDir, "sidebar-session-stability.webm"));
       }
     }
   });

--- a/ui/src/e2e/sidebar-settings.e2e.test.ts
+++ b/ui/src/e2e/sidebar-settings.e2e.test.ts
@@ -211,6 +211,7 @@ suite.define(() => {
         )
         .toBe(webChrome);
       await captureSettingsSidebarUiProof(
+        suite,
         settingsSidebar,
         `settings-search-alignment-${mode.replaceAll(" ", "-")}.png`,
       );
@@ -251,6 +252,7 @@ suite.define(() => {
         )
         .toBe("1");
       await captureSettingsSidebarUiProof(
+        suite,
         settingsSidebar,
         `settings-search-scrolled-${mode.replaceAll(" ", "-")}.png`,
       );

--- a/ui/src/e2e/sidebar-transient-surfaces.e2e.test.ts
+++ b/ui/src/e2e/sidebar-transient-surfaces.e2e.test.ts
@@ -15,7 +15,6 @@ const suite = createSidebarCustomizationSuite(
   "Control UI transient surface tokens mocked Gateway E2E",
 );
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.resolve(".artifacts/control-ui-e2e/transient-surfaces");
 
 const themes = [
   { colorScheme: "light", resolvedTheme: "light", theme: "claw" },
@@ -86,11 +85,14 @@ suite.define(() => {
         await menuSurface.waitFor({ state: "visible" });
         const menuTokens = await surfaceTokens(menuSurface);
         if (captureProof && theme === "claw") {
-          await mkdir(proofDir, { recursive: true });
+          await mkdir(path.join(suite.artifactDir, "transient-surfaces"), { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
-            path: path.join(proofDir, `session-menu-${colorScheme}.png`),
+            path: path.join(
+              path.join(suite.artifactDir, "transient-surfaces"),
+              `session-menu-${colorScheme}.png`,
+            ),
           });
         }
 
@@ -104,7 +106,10 @@ suite.define(() => {
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
-            path: path.join(proofDir, `settings-listbox-${colorScheme}.png`),
+            path: path.join(
+              path.join(suite.artifactDir, "transient-surfaces"),
+              `settings-listbox-${colorScheme}.png`,
+            ),
           });
         }
 

--- a/ui/src/e2e/skill-workshop-applied-diff.e2e.test.ts
+++ b/ui/src/e2e/skill-workshop-applied-diff.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser, type Page } from "playwright";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -16,7 +16,7 @@ const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/applied-revision-diff");
+let artifactDir: string;
 
 let browser: Browser;
 let server: ControlUiE2eServer;
@@ -72,13 +72,14 @@ async function screenshot(page: Page, fileName: string): Promise<void> {
 }
 
 describeControlUiE2e("Skill Workshop applied revision diff mocked Gateway E2E", () => {
+  beforeEach(() => {
+    if (captureUiProofEnabled) {
+      artifactDir = createControlUiE2eArtifactDir("applied-revision-diff");
+    }
+  });
   beforeAll(async () => {
     if (!chromiumAvailable) {
       throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
-    }
-    if (captureUiProofEnabled) {
-      await rm(artifactDir, { force: true, recursive: true });
-      await mkdir(artifactDir, { recursive: true });
     }
     server = await startControlUiE2eServer();
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });

--- a/ui/src/e2e/skill-workshop-revision-integrity.e2e.test.ts
+++ b/ui/src/e2e/skill-workshop-revision-integrity.e2e.test.ts
@@ -1,7 +1,8 @@
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext, Page } from "playwright";
-import { beforeAll, expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   defaultControlUiFeatureMethods,
   installMockGateway,
@@ -16,12 +17,7 @@ const suite = createControlUiE2eSuite({
   unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
 });
 
-const artifactDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "skill-workshop-revision-integrity",
-);
+let artifactDir: string;
 const viewport = { height: 900, width: 1280 };
 const PROPOSAL_ID = "revision-integrity-proposal";
 const SKILL_KEY = "revision-integrity";
@@ -174,9 +170,8 @@ async function closeProofContext(params: { context: BrowserContext }): Promise<v
 }
 
 suite.define(() => {
-  beforeAll(async () => {
-    await rm(artifactDir, { force: true, recursive: true });
-    await mkdir(artifactDir, { recursive: true });
+  beforeEach(() => {
+    artifactDir = createControlUiE2eArtifactDir("skill-workshop-revision-integrity");
   });
 
   it.each([

--- a/ui/src/e2e/skill-workshop-self-learning.e2e.test.ts
+++ b/ui/src/e2e/skill-workshop-self-learning.e2e.test.ts
@@ -1,8 +1,8 @@
 // Control UI tests prove self-learning config conflict recovery through the mocked Gateway.
-import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import { chromium, type Browser } from "playwright";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   canRunPlaywrightChromium,
   installMockGateway,
@@ -16,10 +16,6 @@ const chromiumExecutablePath = resolvePlaywrightChromiumExecutablePath(chromium.
 const chromiumAvailable = canRunPlaywrightChromium(chromiumExecutablePath);
 const allowMissingChromium = process.env.OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM === "1";
 const describeControlUiE2e = chromiumAvailable || !allowMissingChromium ? describe : describe.skip;
-const artifactDir = path.resolve(
-  process.cwd(),
-  ".artifacts/control-ui-e2e/self-learning-config-retry",
-);
 
 let browser: Browser;
 let server: ControlUiE2eServer;
@@ -73,8 +69,6 @@ describeControlUiE2e("Skill Workshop self-learning config recovery mocked Gatewa
     if (!chromiumAvailable) {
       throw new Error(`Playwright Chromium is unavailable at ${chromiumExecutablePath}`);
     }
-    await rm(artifactDir, { force: true, recursive: true });
-    await mkdir(artifactDir, { recursive: true });
     server = await startControlUiE2eServer();
     browser = await chromium.launch({ executablePath: chromiumExecutablePath });
   });
@@ -85,6 +79,7 @@ describeControlUiE2e("Skill Workshop self-learning config recovery mocked Gatewa
   });
 
   it("enables self-learning after refreshing and replaying a stale-hash patch", async () => {
+    const artifactDir = createControlUiE2eArtifactDir("self-learning-config-retry");
     const context = await browser.newContext({
       locale: "en-US",
       recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } },

--- a/ui/src/e2e/terminal-embedded.e2e.test.ts
+++ b/ui/src/e2e/terminal-embedded.e2e.test.ts
@@ -1,4 +1,6 @@
+import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   defaultControlUiFeatureMethods,
   installMockGateway,
@@ -12,8 +14,9 @@ const suite = createControlUiE2eSuite({
     `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`, or set OPENCLAW_UI_E2E_ALLOW_MISSING_CHROMIUM=1 only when intentionally skipping this lane.`,
 });
 
-const deadSessionScreenshotPath = process.env.OPENCLAW_TERMINAL_DEAD_SESSION_SCREENSHOT?.trim();
-const deadSessionVideoDir = process.env.OPENCLAW_TERMINAL_DEAD_SESSION_VIDEO_DIR?.trim();
+const requestedDeadSessionScreenshotPath =
+  process.env.OPENCLAW_TERMINAL_DEAD_SESSION_SCREENSHOT?.trim();
+const requestedDeadSessionVideoDir = process.env.OPENCLAW_TERMINAL_DEAD_SESSION_VIDEO_DIR?.trim();
 
 suite.define(() => {
   it("returns from an unavailable focused terminal", async () => {
@@ -333,6 +336,27 @@ suite.define(() => {
   });
 
   it("restores a persisted session with no gateway PTY as exited", async () => {
+    const screenshotDir = requestedDeadSessionScreenshotPath
+      ? createControlUiE2eArtifactDir(
+          "terminal-dead-session",
+          path.dirname(requestedDeadSessionScreenshotPath),
+        )
+      : undefined;
+    const deadSessionScreenshotPath =
+      screenshotDir && requestedDeadSessionScreenshotPath
+        ? path.join(screenshotDir, path.basename(requestedDeadSessionScreenshotPath))
+        : undefined;
+    const deadSessionVideoDir = requestedDeadSessionVideoDir
+      ? screenshotDir &&
+        requestedDeadSessionScreenshotPath &&
+        path.resolve(requestedDeadSessionVideoDir) ===
+          path.resolve(path.dirname(requestedDeadSessionScreenshotPath))
+        ? screenshotDir
+        : createControlUiE2eArtifactDir("terminal-dead-session", requestedDeadSessionVideoDir)
+      : undefined;
+    if (deadSessionScreenshotPath) {
+      console.info(`[control-ui-e2e] screenshot: ${deadSessionScreenshotPath}`);
+    }
     await suite.withPage(
       {
         serviceWorkers: "block",

--- a/ui/src/e2e/terminal-panel-layout.e2e.test.ts
+++ b/ui/src/e2e/terminal-panel-layout.e2e.test.ts
@@ -1,7 +1,7 @@
-import fs from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   waitForControlUiGatewayReady,
   waitForControlUiTerminalReady,
@@ -16,13 +16,18 @@ const suite = createControlUiE2eSuite({
     `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`.`,
 });
 
-const screenshotDir = process.env.OPENCLAW_TERMINAL_LAYOUT_SCREENSHOT_DIR?.trim();
+const screenshotDirParent = process.env.OPENCLAW_TERMINAL_LAYOUT_SCREENSHOT_DIR?.trim();
+let screenshotDir: string | undefined;
+beforeEach(() => {
+  screenshotDir = screenshotDirParent
+    ? createControlUiE2eArtifactDir("terminal-panel-layout", screenshotDirParent)
+    : undefined;
+});
 
 async function captureLayout(page: Page, theme: string, state: string): Promise<void> {
   if (!screenshotDir) {
     return;
   }
-  await fs.mkdir(screenshotDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     caret: "hide",

--- a/ui/src/e2e/terminal-repaint.e2e.test.ts
+++ b/ui/src/e2e/terminal-repaint.e2e.test.ts
@@ -2,7 +2,8 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { Locator } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   waitForControlUiGatewayReady,
   waitForControlUiTerminalReady,
@@ -17,7 +18,19 @@ const suite = createControlUiE2eSuite({
     `Playwright Chromium is not installed or cannot start at ${executablePath}. Run \`pnpm --dir ui exec playwright install --with-deps chromium\`.`,
 });
 
-const screenshotPath = process.env.OPENCLAW_TERMINAL_REPAINT_SCREENSHOT?.trim();
+const requestedScreenshotPath = process.env.OPENCLAW_TERMINAL_REPAINT_SCREENSHOT?.trim();
+let screenshotPath: string | undefined;
+beforeEach(() => {
+  screenshotPath = requestedScreenshotPath
+    ? path.join(
+        createControlUiE2eArtifactDir("terminal-repaint", path.dirname(requestedScreenshotPath)),
+        path.basename(requestedScreenshotPath),
+      )
+    : undefined;
+  if (screenshotPath) {
+    console.info(`[control-ui-e2e] screenshot: ${screenshotPath}`);
+  }
+});
 
 async function terminalCanvasDigest(canvas: Locator): Promise<string> {
   const png = await canvas.screenshot({ animations: "disabled", caret: "hide" });

--- a/ui/src/e2e/terminal-upload.e2e.test.ts
+++ b/ui/src/e2e/terminal-upload.e2e.test.ts
@@ -1,4 +1,6 @@
+import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -10,13 +12,41 @@ const suite = createControlUiE2eSuite({
 });
 
 const expectUploadSurface = process.env.OPENCLAW_TERMINAL_UPLOAD_EXPECT_PRESENT !== "0";
-const screenshotPath = process.env.OPENCLAW_TERMINAL_UPLOAD_SCREENSHOT?.trim();
-const progressScreenshotPath = process.env.OPENCLAW_TERMINAL_UPLOAD_PROGRESS_SCREENSHOT?.trim();
-const errorScreenshotPath = process.env.OPENCLAW_TERMINAL_UPLOAD_ERROR_SCREENSHOT?.trim();
-const videoDir = process.env.OPENCLAW_TERMINAL_UPLOAD_VIDEO_DIR?.trim();
+const requestedScreenshotPath = process.env.OPENCLAW_TERMINAL_UPLOAD_SCREENSHOT?.trim();
+const requestedProgressScreenshotPath =
+  process.env.OPENCLAW_TERMINAL_UPLOAD_PROGRESS_SCREENSHOT?.trim();
+const requestedErrorScreenshotPath = process.env.OPENCLAW_TERMINAL_UPLOAD_ERROR_SCREENSHOT?.trim();
+const requestedVideoDir = process.env.OPENCLAW_TERMINAL_UPLOAD_VIDEO_DIR?.trim();
 
 suite.define(() => {
   it("uploads picked and dropped files, then pastes staged paths without Enter", async () => {
+    // Independent requested parents stay independent; captures under one parent share this attempt.
+    const directories = new Map<string, string>();
+    const directoryFor = (parent: string) => {
+      const resolved = path.resolve(parent);
+      let directory = directories.get(resolved);
+      if (!directory) {
+        directory = createControlUiE2eArtifactDir("terminal-upload", resolved);
+        directories.set(resolved, directory);
+      }
+      return directory;
+    };
+    const screenshotFor = (requested: string | undefined, stage: string) => {
+      if (!requested) {
+        return undefined;
+      }
+      const output = path.join(
+        directoryFor(path.dirname(requested)),
+        stage,
+        path.basename(requested),
+      );
+      console.info(`[control-ui-e2e] screenshot: ${output}`);
+      return output;
+    };
+    const screenshotPath = screenshotFor(requestedScreenshotPath, "initial");
+    const progressScreenshotPath = screenshotFor(requestedProgressScreenshotPath, "progress");
+    const errorScreenshotPath = screenshotFor(requestedErrorScreenshotPath, "error");
+    const videoDir = requestedVideoDir ? directoryFor(requestedVideoDir) : undefined;
     await suite.withPage(
       {
         serviceWorkers: "block",

--- a/ui/src/e2e/theme-muted-contrast.e2e.test.ts
+++ b/ui/src/e2e/theme-muted-contrast.e2e.test.ts
@@ -6,10 +6,6 @@ import { controlUiBundledGatewayUrl, installMockGateway } from "../test-helpers/
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDirectory = path.resolve(
-  process.cwd(),
-  ".artifacts/control-ui-e2e/theme-muted-contrast",
-);
 
 const themeCases = [
   { family: "claw", mode: "dark", resolved: "dark" },
@@ -386,15 +382,18 @@ suite.define(() => {
         expect(await selected.getAttribute("value")).toBe(selectedValue);
 
         if (captureUiProof) {
-          await mkdir(proofDirectory, { recursive: true });
+          await mkdir(path.join(suite.artifactDir, "theme-muted-contrast"), { recursive: true });
           const proofName = accent ? `${resolved}-${accent.slice(1)}` : resolved;
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
-            path: path.join(proofDirectory, `${proofName}.png`),
+            path: path.join(
+              path.join(suite.artifactDir, "theme-muted-contrast"),
+              `${proofName}.png`,
+            ),
           });
           await writeFile(
-            path.join(proofDirectory, `${proofName}.json`),
+            path.join(path.join(suite.artifactDir, "theme-muted-contrast"), `${proofName}.json`),
             `${JSON.stringify(
               {
                 accent,
@@ -497,14 +496,20 @@ suite.define(() => {
         expect(rendered.bodyWidth).toBeLessThanOrEqual(rendered.viewportWidth);
 
         if (captureUiProof) {
-          await mkdir(proofDirectory, { recursive: true });
+          await mkdir(path.join(suite.artifactDir, "theme-muted-contrast"), { recursive: true });
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
-            path: path.join(proofDirectory, "skill-workshop-today-mobile.png"),
+            path: path.join(
+              path.join(suite.artifactDir, "theme-muted-contrast"),
+              "skill-workshop-today-mobile.png",
+            ),
           });
           await writeFile(
-            path.join(proofDirectory, "skill-workshop-today-mobile.json"),
+            path.join(
+              path.join(suite.artifactDir, "theme-muted-contrast"),
+              "skill-workshop-today-mobile.json",
+            ),
             `${JSON.stringify(rendered, null, 2)}\n`,
           );
         }

--- a/ui/src/e2e/theme-typography.e2e.test.ts
+++ b/ui/src/e2e/theme-typography.e2e.test.ts
@@ -24,7 +24,6 @@ import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts"
  */
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDirectory = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/theme-typography");
 
 const suite = createControlUiE2eSuite({
   name: "Control UI theme typography",
@@ -114,9 +113,11 @@ async function captureTypography(
   name: string,
 ) {
   if (captureUiProof) {
-    await mkdir(proofDirectory, { recursive: true });
+    await mkdir(path.join(suite.artifactDir, "theme-typography"), { recursive: true });
     await page.evaluate(() => document.fonts.ready);
-    await page.screenshot({ path: path.join(proofDirectory, `${name}.png`) });
+    await page.screenshot({
+      path: path.join(path.join(suite.artifactDir, "theme-typography"), `${name}.png`),
+    });
   }
 }
 
@@ -315,8 +316,13 @@ suite.define(() => {
     );
 
     if (captureUiProof) {
-      await mkdir(proofDirectory, { recursive: true });
-      await page.screenshot({ path: path.join(proofDirectory, "phosphor-settings-shortcut.png") });
+      await mkdir(path.join(suite.artifactDir, "theme-typography"), { recursive: true });
+      await page.screenshot({
+        path: path.join(
+          path.join(suite.artifactDir, "theme-typography"),
+          "phosphor-settings-shortcut.png",
+        ),
+      });
     }
 
     const modelShortcutFont = await page.evaluate(() => {

--- a/ui/src/e2e/tool-titles.e2e.test.ts
+++ b/ui/src/e2e/tool-titles.e2e.test.ts
@@ -1,9 +1,10 @@
 import { createHash } from "node:crypto";
-import { mkdir, writeFile } from "node:fs/promises";
+import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
 import { fnv1aUtf16 } from "../lib/fnv1a.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { controlUiBundledSettingsStorageKey } from "../test-helpers/control-ui-e2e.ts";
 import {
   chatSessionListResponse,
@@ -139,10 +140,10 @@ async function setToolTitleProofCue(page: Page, text: string): Promise<void> {
 
 suite.define(() => {
   it("bounds a 240-row title burst and preserves overflow fallbacks", async () => {
-    const artifactDir =
-      process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim() ||
-      path.join(process.cwd(), ".artifacts", "ui-visual-proof", "tool-title-bounds", "executable");
-    await mkdir(artifactDir, { recursive: true });
+    const artifactDir = createControlUiE2eArtifactDir(
+      "tool-title-bounds-executable",
+      process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim() || undefined,
+    );
     const context = await suite.newBrowserContext({
       locale: "en-US",
       recordVideo: { dir: artifactDir, size: { height: 900, width: 1440 } },
@@ -269,10 +270,10 @@ suite.define(() => {
   });
 
   it("resumes title generation after transcript pruning removes the cursor", async () => {
-    const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
-    if (artifactDir) {
-      await mkdir(artifactDir, { recursive: true });
-    }
+    const artifactRoot = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("tool-title-bounds", artifactRoot)
+      : undefined;
     const context = await suite.newBrowserContext({
       locale: "en-US",
       ...(artifactDir
@@ -546,7 +547,10 @@ suite.define(() => {
   });
 
   it("invalidates a rendered title when the gateway client is replaced", async () => {
-    const artifactDir = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactRoot = process.env.OPENCLAW_CONTROL_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("tool-title-bounds", artifactRoot)
+      : undefined;
     const context = await suite.newBrowserContext({
       locale: "en-US",
       ...(artifactDir

--- a/ui/src/e2e/update-coalesced.e2e.test.ts
+++ b/ui/src/e2e/update-coalesced.e2e.test.ts
@@ -40,7 +40,9 @@ async function captureUpdateProof(
 
 suite.define(() => {
   it("explains a disabled update to a read-only mobile operator", async () => {
-    const artifactDir = path.resolve(".artifacts/control-ui-e2e/update-read-only-mobile");
+    const artifactDir = captureUiProofEnabled
+      ? path.join(suite.artifactDir, "update-read-only-mobile")
+      : "";
     await suite.withPage(
       {
         colorScheme: "dark",
@@ -99,7 +101,9 @@ suite.define(() => {
   });
 
   it("shows package update failure status after the Update click", async () => {
-    const artifactDir = path.resolve(".artifacts/control-ui-e2e/update-package-status");
+    const artifactDir = captureUiProofEnabled
+      ? path.join(suite.artifactDir, "update-package-status")
+      : "";
     await suite.withPage(
       {
         locale: "en-US",
@@ -160,7 +164,9 @@ suite.define(() => {
   });
 
   it("shows coalesced restart feedback after the Update click", async () => {
-    const artifactDir = path.resolve(".artifacts/control-ui-e2e/update-coalesced");
+    const artifactDir = captureUiProofEnabled
+      ? path.join(suite.artifactDir, "update-coalesced")
+      : "";
     await suite.withPage(
       {
         locale: "en-US",
@@ -237,9 +243,9 @@ suite.define(() => {
   ])(
     "settles the managed update $name",
     async ({ artifactName, expectedStatusRequests, expectedText, responseFirst }) => {
-      const artifactDir = path.resolve(
-        `.artifacts/control-ui-e2e/update-managed-handoff-${artifactName}`,
-      );
+      const artifactDir = captureUiProofEnabled
+        ? path.join(suite.artifactDir, `update-managed-handoff-${artifactName}`)
+        : "";
       await suite.withPage(
         {
           locale: "en-US",
@@ -313,7 +319,9 @@ suite.define(() => {
   );
 
   it("shows and routes the update target from live Mac app ownership", async () => {
-    const artifactDir = path.resolve(".artifacts/control-ui-e2e/update-ownership");
+    const artifactDir = captureUiProofEnabled
+      ? path.join(suite.artifactDir, "update-ownership")
+      : "";
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",

--- a/ui/src/e2e/update-confirmation.e2e.test.ts
+++ b/ui/src/e2e/update-confirmation.e2e.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import type { Locator, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -20,7 +21,10 @@ const UPDATE_RUN_RESPONSE = {
   restart: null,
   result: { after: { version: "2.0.0" }, status: "ok" },
 } as const;
-const PROOF_DIR = path.resolve(".artifacts/control-ui-e2e/update-confirmation");
+let PROOF_DIR: string;
+beforeEach(() => {
+  PROOF_DIR = createControlUiE2eArtifactDir("update-confirmation");
+});
 
 /** The dialog element lives in a shadow root; its visible copy is slotted light DOM. */
 function confirmationCopy(page: Page) {

--- a/ui/src/e2e/update-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/update-lifecycle.e2e.test.ts
@@ -4,6 +4,7 @@
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -62,7 +63,7 @@ suite.define(() => {
   it.each(["light", "dark"] as const)(
     "narrates a dev-channel update through to its recorded success (%s)",
     async (colorScheme) => {
-      const artifactDir = path.resolve(`.artifacts/control-ui-e2e/update-lifecycle-${colorScheme}`);
+      const artifactDir = createControlUiE2eArtifactDir(`update-lifecycle-${colorScheme}`);
       await suite.withPage(
         {
           colorScheme,
@@ -149,9 +150,7 @@ suite.define(() => {
   it.each(["light", "dark"] as const)(
     "names the recorded cause when the install fails (%s)",
     async (colorScheme) => {
-      const artifactDir = path.resolve(
-        `.artifacts/control-ui-e2e/update-failure-cause-${colorScheme}`,
-      );
+      const artifactDir = createControlUiE2eArtifactDir(`update-failure-cause-${colorScheme}`);
       await suite.withPage(
         {
           colorScheme,

--- a/ui/src/e2e/updates-settings.e2e.test.ts
+++ b/ui/src/e2e/updates-settings.e2e.test.ts
@@ -13,12 +13,11 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.join(process.cwd(), ".artifacts", "control-ui-e2e", "updates-settings");
 
 suite.define(() => {
   it("renders live campaign status without requesting config.schema", async () => {
     if (captureProof) {
-      await mkdir(proofDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "updates-settings"), { recursive: true });
     }
     await suite.withPage(
       {
@@ -27,7 +26,12 @@ suite.define(() => {
         serviceWorkers: "block",
         viewport: { height: 900, width: 1280 },
         ...(captureProof
-          ? { recordVideo: { dir: proofDir, size: { height: 900, width: 1280 } } }
+          ? {
+              recordVideo: {
+                dir: path.join(suite.artifactDir, "updates-settings"),
+                size: { height: 900, width: 1280 },
+              },
+            }
           : {}),
       },
       async ({ page }) => {
@@ -91,7 +95,10 @@ suite.define(() => {
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
-            path: path.join(proofDir, "01-updates-countdown.png"),
+            path: path.join(
+              path.join(suite.artifactDir, "updates-settings"),
+              "01-updates-countdown.png",
+            ),
           });
         }
 
@@ -151,7 +158,10 @@ suite.define(() => {
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
-            path: path.join(proofDir, "02-updates-read-only.png"),
+            path: path.join(
+              path.join(suite.artifactDir, "updates-settings"),
+              "02-updates-read-only.png",
+            ),
           });
         }
       },

--- a/ui/src/e2e/usage-cost-analysis.e2e.test.ts
+++ b/ui/src/e2e/usage-cost-analysis.e2e.test.ts
@@ -12,8 +12,6 @@ const suite = createControlUiE2eSuite({
 });
 
 const recordVisuals = process.env.OPENCLAW_UI_E2E_RECORD === "1";
-const providerUsageArtifactDir = path.resolve(".artifacts/control-ui-e2e/provider-usage-outcomes");
-const usageFilterArtifactDir = path.resolve(".artifacts/control-ui-e2e/usage-filter-repair");
 
 const totals = {
   input: 1_200_000,
@@ -156,8 +154,7 @@ suite.define(() => {
             .getByRole("button", { name: "Visible C", exact: true })
             .click({ modifiers: ["Shift"] });
           if (recordVisuals) {
-            const artifactDir = path.resolve(".artifacts/control-ui-e2e/usage-range-selection");
-            await mkdir(artifactDir, { recursive: true });
+            const artifactDir = path.join(suite.artifactDir, "usage-range-selection");
             await card.screenshot({ path: path.join(artifactDir, `${scenario}.png`) });
           }
           await expect
@@ -210,10 +207,13 @@ suite.define(() => {
           .poll(() => page.locator(".usage-page").textContent())
           .toContain("Provider usage is unavailable; the last request failed. Refresh to retry.");
         if (recordVisuals) {
-          await mkdir(providerUsageArtifactDir, { recursive: true });
+          await mkdir(path.join(suite.artifactDir, "provider-usage-outcomes"), { recursive: true });
           await page.locator(".usage-page").screenshot({
             animations: "disabled",
-            path: path.join(providerUsageArtifactDir, "usage-status-request-failed.png"),
+            path: path.join(
+              path.join(suite.artifactDir, "provider-usage-outcomes"),
+              "usage-status-request-failed.png",
+            ),
           });
         }
       },
@@ -246,10 +246,13 @@ suite.define(() => {
             "Provider usage is unavailable; the last request failed. Refresh to retry.",
           );
         if (recordVisuals) {
-          await mkdir(providerUsageArtifactDir, { recursive: true });
+          await mkdir(path.join(suite.artifactDir, "provider-usage-outcomes"), { recursive: true });
           await page.locator(".usage-page").screenshot({
             animations: "disabled",
-            path: path.join(providerUsageArtifactDir, "usage-status-empty.png"),
+            path: path.join(
+              path.join(suite.artifactDir, "provider-usage-outcomes"),
+              "usage-status-empty.png",
+            ),
           });
         }
       },
@@ -374,7 +377,7 @@ suite.define(() => {
     }));
     const empty = emptyUsageResponses();
     if (recordVisuals) {
-      await mkdir(usageFilterArtifactDir, { recursive: true });
+      await mkdir(path.join(suite.artifactDir, "usage-filter-repair"), { recursive: true });
     }
 
     await suite.withPage(
@@ -383,7 +386,12 @@ suite.define(() => {
         serviceWorkers: "block",
         viewport: { height: 1_000, width: 1_440 },
         ...(recordVisuals
-          ? { recordVideo: { dir: usageFilterArtifactDir, size: { height: 1_000, width: 1_440 } } }
+          ? {
+              recordVideo: {
+                dir: path.join(suite.artifactDir, "usage-filter-repair"),
+                size: { height: 1_000, width: 1_440 },
+              },
+            }
           : {}),
       },
       async ({ page }) => {
@@ -418,7 +426,10 @@ suite.define(() => {
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
-            path: path.join(usageFilterArtifactDir, "01-provider-alternatives.png"),
+            path: path.join(
+              path.join(suite.artifactDir, "usage-filter-repair"),
+              "01-provider-alternatives.png",
+            ),
           });
         }
 
@@ -430,7 +441,10 @@ suite.define(() => {
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
-            path: path.join(usageFilterArtifactDir, "02-quoted-session-label.png"),
+            path: path.join(
+              path.join(suite.artifactDir, "usage-filter-repair"),
+              "02-quoted-session-label.png",
+            ),
           });
         }
       },
@@ -756,13 +770,7 @@ suite.define(() => {
         await expect.poll(() => topProviders.textContent()).not.toContain("openai");
 
         if (process.env.OPENCLAW_CAPTURE_UI_PROOF === "1") {
-          const artifactDir = path.join(
-            process.cwd(),
-            ".artifacts",
-            "control-ui-e2e",
-            "provider-plans",
-          );
-          await mkdir(artifactDir, { recursive: true });
+          const artifactDir = path.join(suite.artifactDir, "provider-plans");
           await page.locator(".usage-page").screenshot({
             path: path.join(artifactDir, "after.png"),
           });

--- a/ui/src/e2e/usage-reconnect.e2e.test.ts
+++ b/ui/src/e2e/usage-reconnect.e2e.test.ts
@@ -1,9 +1,9 @@
 // Control UI tests cover proxy-style same-client reconnects through the real browser lifecycle.
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { BrowserContext, Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
 import type { CostUsageSummary } from "../api/types.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
 import { installMockGateway, type MockGatewayControls } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
@@ -18,7 +18,13 @@ const suite = createControlUiE2eSuite({
 // Mirrors the module-private default usage TTL asserted by this flow.
 const USAGE_PAYLOAD_TTL_MS = 5 * 60_000;
 
-const proofDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+let proofDir: string | undefined;
+beforeEach(() => {
+  proofDir = artifactRoot
+    ? createControlUiE2eArtifactDir("usage-reconnect", artifactRoot)
+    : undefined;
+});
 
 const totals = {
   input: 100,
@@ -107,9 +113,6 @@ function sessionsUsage(
 }
 
 async function createContext(): Promise<BrowserContext> {
-  if (proofDir) {
-    await mkdir(proofDir, { recursive: true });
-  }
   return suite.browser.newContext({
     locale: "en-US",
     serviceWorkers: "block",

--- a/ui/src/e2e/usage-session-unicode.e2e.test.ts
+++ b/ui/src/e2e/usage-session-unicode.e2e.test.ts
@@ -1,7 +1,7 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
-import { expect, it } from "vitest";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -12,7 +12,13 @@ const suite = createControlUiE2eSuite({
     `Playwright Chromium is not available at ${executablePath}`,
 });
 
-const proofDir = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+let proofDir: string | undefined;
+beforeEach(() => {
+  proofDir = artifactRoot
+    ? createControlUiE2eArtifactDir("usage-session-unicode", artifactRoot)
+    : undefined;
+});
 
 const usageTotals = {
   input: 100,
@@ -100,7 +106,6 @@ async function captureProof(page: Page, name: string): Promise<void> {
   if (!proofDir) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.locator(".usage-page").screenshot({ path: path.join(proofDir, name) });
 }
 

--- a/ui/src/test-helpers/control-ui-e2e-artifacts.node.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e-artifacts.node.test.ts
@@ -1,0 +1,124 @@
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { Worker } from "node:worker_threads";
+import { afterEach, expect, it, vi } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.ts";
+import { createControlUiE2eArtifactDir } from "./control-ui-e2e-artifacts.ts";
+
+const tempDirs: string[] = [];
+const artifactNames = ["state.png", "proof.webm", "report.json"];
+// Vite rewrites asset-style new URL expressions under the ordinary UI test runner.
+const sourceDir = path.dirname(fileURLToPath(import.meta.url));
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+  cleanupTempDirs(tempDirs);
+});
+
+it("retains old proof and repeated scenario outputs with identical filenames", () => {
+  const parent = makeTempDir(tempDirs, "control-ui-proof-");
+  const previous = path.join(parent, "same-scenario");
+  mkdirSync(previous);
+  for (const name of artifactNames) {
+    writeFileSync(path.join(previous, name), `old:${name}`);
+  }
+  const outputs = Array.from({ length: 3 }, (_, attempt) => {
+    const directory = createControlUiE2eArtifactDir("same-scenario", parent);
+    for (const name of artifactNames) {
+      writeFileSync(path.join(directory, name), `${attempt}:${name}`);
+    }
+    return directory;
+  });
+  for (const name of artifactNames) {
+    expect(readFileSync(path.join(previous, name), "utf8")).toBe(`old:${name}`);
+    for (const [attempt, directory] of outputs.entries()) {
+      expect(readFileSync(path.join(directory, name), "utf8")).toBe(`${attempt}:${name}`);
+    }
+  }
+  expect(new Set(outputs).size).toBe(3);
+});
+
+it("allocates independently in concurrent workers sharing the same parent and scope", async () => {
+  const parent = makeTempDir(tempDirs, "control-ui-proof-workers-");
+  const previous = path.join(parent, "same-scenario");
+  mkdirSync(previous);
+  for (const name of artifactNames) {
+    writeFileSync(path.join(previous, name), `old:${name}`);
+  }
+  const moduleUrl = pathToFileURL(path.join(sourceDir, "control-ui-e2e-artifacts.ts")).href;
+  const outputs = await Promise.all(
+    ["first", "second"].map(
+      (contents) =>
+        new Promise<string>((resolve, reject) => {
+          const worker = new Worker(
+            `const { parentPort, workerData } = require("node:worker_threads");
+             const { writeFileSync } = require("node:fs");
+             const path = require("node:path");
+             import(workerData.moduleUrl).then(({ createControlUiE2eArtifactDir }) => {
+               const directory = createControlUiE2eArtifactDir("same-scenario", workerData.parent);
+               for (const name of workerData.names) {
+                 writeFileSync(path.join(directory, name), workerData.contents);
+               }
+               parentPort.postMessage(directory);
+             });`,
+            { eval: true, workerData: { moduleUrl, parent, contents, names: artifactNames } },
+          );
+          let directory: string;
+          worker.once("message", (value: string) => {
+            directory = value;
+          });
+          worker.once("error", reject);
+          worker.once("exit", (code) => {
+            if (code === 0) {
+              resolve(directory);
+            } else {
+              reject(new Error(`Capture worker exited with ${code}`));
+            }
+          });
+        }),
+    ),
+  );
+  expect(new Set(outputs).size).toBe(2);
+  for (const name of artifactNames) {
+    expect(readFileSync(path.join(previous, name), "utf8")).toBe(`old:${name}`);
+  }
+  for (const [index, directory] of outputs.entries()) {
+    for (const name of artifactNames) {
+      expect(readFileSync(path.join(directory, name), "utf8")).toBe(["first", "second"][index]);
+    }
+  }
+});
+
+it("keeps explicit parents authoritative and trims the existing configured root", () => {
+  const explicit = makeTempDir(tempDirs, "control-ui-proof-explicit-");
+  const configured = makeTempDir(tempDirs, "control-ui-proof-configured-");
+  vi.stubEnv("OPENCLAW_UI_E2E_ARTIFACT_DIR", `  ${configured}  `);
+  expect(path.dirname(createControlUiE2eArtifactDir("configured"))).toBe(configured);
+  expect(path.dirname(createControlUiE2eArtifactDir("explicit", explicit))).toBe(explicit);
+});
+
+it.each([undefined, "", "   "])(
+  "uses the repository parent for an unset or blank root (%s)",
+  (root) => {
+    vi.stubEnv("OPENCLAW_UI_E2E_ARTIFACT_DIR", root);
+    const directory = createControlUiE2eArtifactDir("allocator-regression");
+    // Only this exclusive child is disposable; the repository evidence parent is not ours.
+    tempDirs.push(directory);
+    expect(path.dirname(directory)).toBe(
+      path.resolve(sourceDir, "../../../.artifacts/control-ui-e2e"),
+    );
+  },
+);
+
+it("does not enable optional capture when allocating an always-on scenario", () => {
+  const parent = makeTempDir(tempDirs, "control-ui-proof-disabled-");
+  vi.stubEnv("OPENCLAW_UI_E2E_ARTIFACT_DIR", undefined);
+  vi.stubEnv("OPENCLAW_CAPTURE_UI_PROOF", "0");
+  expect(readdirSync(parent)).toEqual([]);
+  const directory = createControlUiE2eArtifactDir("always-on", parent);
+  expect(readdirSync(parent)).toEqual([path.basename(directory)]);
+  expect(process.env.OPENCLAW_CAPTURE_UI_PROOF).toBe("0");
+  expect(process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR).toBeUndefined();
+});

--- a/ui/src/test-helpers/control-ui-e2e-artifacts.ts
+++ b/ui/src/test-helpers/control-ui-e2e-artifacts.ts
@@ -1,0 +1,21 @@
+import { mkdirSync, mkdtempSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Resolve as a Node path so Vite asset-URL rewriting cannot change the evidence root.
+const defaultArtifactRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../../../.artifacts/control-ui-e2e",
+);
+
+/** Allocate retained proof only when its caller actually captures a scenario. */
+export function createControlUiE2eArtifactDir(scope: string, parentDir?: string): string {
+  const parent = path.resolve(
+    parentDir ?? (process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim() || defaultArtifactRoot),
+  );
+  mkdirSync(parent, { recursive: true });
+  // Exclusive directory ownership protects fixed capture names across retries and processes.
+  const directory = mkdtempSync(path.join(parent, `${scope}-`));
+  console.info(`[control-ui-e2e] retained proof: ${directory}`);
+  return directory;
+}

--- a/ui/src/test-helpers/control-ui-e2e.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.test.ts
@@ -1,11 +1,88 @@
 // Control UI tests cover control ui e2e behavior.
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import type { Page } from "playwright";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.ts";
+import { captureSidebarUiProof } from "../e2e/sidebar-customization.test-support.ts";
+import { createControlUiE2eArtifactDir } from "./control-ui-e2e-artifacts.ts";
 import {
+  captureControlUiE2eFailureDiagnostics,
   resolvePlaywrightChromiumExecutablePath,
   systemChromiumExecutableCandidates,
   waitForControlUiRoute,
 } from "./control-ui-e2e.ts";
+
+describe("shared proof capture", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("keeps each failure screenshot and report in its own retained directory", async () => {
+    const parent = tempDirs.make("control-ui-failure-proof-");
+    vi.stubEnv("OPENCLAW_UI_E2E_DIAGNOSTIC_DIR", parent);
+    writeFileSync(path.join(parent, "prior.png"), "prior-proof");
+    // SAFETY: this fixture implements the Page boundary used by failure diagnostics.
+    const page = {
+      evaluate: async () => ({ marker: "failed-page" }),
+      isClosed: () => false,
+      url: () => "http://127.0.0.1/chat",
+      screenshot: async (options: { path: string }) => {
+        writeFileSync(options.path, "failure-proof");
+        return Buffer.from("failure-proof");
+      },
+    } as unknown as Page;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      await captureControlUiE2eFailureDiagnostics(page, {
+        error: new Error("Synthetic request timeout"),
+        label: "chat.send",
+      });
+    }
+    const directories = readdirSync(parent, { withFileTypes: true }).filter((entry) =>
+      entry.isDirectory(),
+    );
+    expect(directories).toHaveLength(2);
+    for (const directory of directories) {
+      const root = path.join(parent, directory.name);
+      const files = readdirSync(root);
+      expect(files).toHaveLength(2);
+      const reportFile = files.find((file) => file.endsWith(".json"));
+      expect(reportFile).toBeDefined();
+      const report = JSON.parse(readFileSync(path.join(root, reportFile!), "utf8"));
+      expect(report).toMatchObject({ label: "chat.send", captureErrors: [] });
+      expect(files).toContain(report.screenshot);
+      expect(readFileSync(path.join(root, report.screenshot), "utf8")).toBe("failure-proof");
+    }
+    expect(readFileSync(path.join(parent, "prior.png"), "utf8")).toBe("prior-proof");
+  });
+
+  it("keeps shared capture disabled until its gate is enabled and uses the supplied owner", async () => {
+    const parent = tempDirs.make("control-ui-proof-capture-");
+    vi.stubEnv("OPENCLAW_UI_E2E_ARTIFACT_DIR", parent);
+    vi.stubEnv("OPENCLAW_CAPTURE_UI_PROOF", "0");
+    let directory: string | undefined;
+    const owner = {
+      get artifactDir() {
+        return (directory ??= createControlUiE2eArtifactDir("sidebar", parent));
+      },
+    };
+    const screenshot = vi.fn(async (options: { path: string }) => {
+      // A broken caller must fail before it can write outside this test's owned directory.
+      expect(options.path).toBe(path.join(owner.artifactDir, "state.png"));
+      writeFileSync(options.path, "sidebar-proof");
+      return Buffer.from("sidebar-proof");
+    });
+    // SAFETY: this fixture implements only the screenshot method used by the capture helper.
+    const page = { screenshot } as unknown as Page;
+
+    await captureSidebarUiProof(owner, page, "state.png");
+    expect(readdirSync(parent)).toEqual([]);
+    expect(screenshot).not.toHaveBeenCalled();
+
+    vi.stubEnv("OPENCLAW_CAPTURE_UI_PROOF", "1");
+    await captureSidebarUiProof(owner, page, "state.png");
+    expect(readFileSync(path.join(owner.artifactDir, "state.png"), "utf8")).toBe("sidebar-proof");
+  });
+});
 
 describe("resolvePlaywrightChromiumExecutablePath", () => {
   it("uses a runnable system Chromium when the cached Playwright executable cannot start", () => {

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -1,6 +1,6 @@
 // Control UI test helper supports control ui e2e setup.
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { createServer as createNetServer } from "node:net";
 import path from "node:path";
@@ -15,6 +15,7 @@ import type { ModelCatalogEntry, UpdateAvailable, UpdateScheduleState } from "..
 import type { AuthenticatedUser } from "../app/user-profile.ts";
 import { normalizeControlUiBuildInfo } from "../build-info-normalizers.ts";
 import type { ControlUiBuildInfo } from "../build-info.ts";
+import { createControlUiE2eArtifactDir } from "./control-ui-e2e-artifacts.ts";
 import {
   createControlUiSessionFixtures,
   type ControlUiSessionFixture,
@@ -436,7 +437,6 @@ let sharedControlUiE2eServerBaseUrl: string | null = null;
 const CONTROL_UI_E2E_DIAGNOSTIC_RING_LIMIT = 200;
 const controlUiE2ePageDiagnostics = new WeakMap<Page, ControlUiE2eDiagnosticEvent[]>();
 const controlUiE2eUnhandledRejectionPages = new WeakSet<Page>();
-let controlUiE2eDiagnosticSequence = 0;
 
 type ControlUiE2eDiagnosticEvent = {
   at: string;
@@ -2859,12 +2859,12 @@ async function captureControlUiE2eFailureDiagnosticsUnsafe(
   },
 ): Promise<void> {
   const configuredDir = process.env.OPENCLAW_UI_E2E_DIAGNOSTIC_DIR?.trim();
-  const artifactDir = path.resolve(
+  const artifactDir = createControlUiE2eArtifactDir(
+    "failure",
     configuredDir || path.join(resolveRepoRoot(), ".artifacts", "control-ui-e2e-timeouts", "local"),
   );
-  mkdirSync(artifactDir, { recursive: true });
   const safeMethod = label.replaceAll(/[^a-zA-Z0-9_.-]+/gu, "-");
-  const captureId = `${new Date().toISOString().replaceAll(/[:.]/gu, "-")}-${String(++controlUiE2eDiagnosticSequence).padStart(2, "0")}-${safeMethod}`;
+  const captureId = `${new Date().toISOString().replaceAll(/[:.]/gu, "-")}-${safeMethod}`;
   const screenshotName = `${captureId}.png`;
   const screenshotPath = path.join(artifactDir, screenshotName);
   const reportPath = path.join(artifactDir, `${captureId}.json`);


### PR DESCRIPTION
Related: #133628 — the offline-draft/canceled-queue-edit repair, during whose CI replay the capture-loss incident was observed. This is a separate test/proof-tooling repair; it does not modify the outbox repair.

## What Problem This Solves

Resolves a problem where developers replaying mocked Control UI browser suites could silently overwrite previously retained screenshots, recordings, and reports. Several fixtures used fixed filenames in shared directories, and some cleared the shared directory before capturing.

The reported incident lost ten older PNGs from the quota-popover and lobster-dismiss-menu proof directories. Their previous bytes were not preserved. This PR does not recreate those images or claim recovery; reproduction and validation used new, isolated synthetic evidence only.

## Why This Change Was Made

A single Node-only `createControlUiE2eArtifactDir(scope, parentDir?)` allocator uses atomic filesystem directory allocation. Each scenario/test attempt or standalone invocation owns a fresh child directory. The shared suite exposes a lazy attempt-owned directory, and shared capture helpers receive that owner explicitly rather than owning a fixed global path.

Existing artifact-directory controls select parents; existing capture/record gates retain their meanings. Screenshots, reports, raw recordings, and named video copies stay with their owner. Shared-parent cleanup is removed, distinct stages have distinct names, and failed video finalization retains its raw recording. Timeout diagnostics use the same allocator beneath their existing diagnostic parent. Mantis's capture producer, candidate-overlay closure, report builder, and workflow invocation root move together so published relative artifact paths remain coherent; rebuilding a sealed report is refused.

No dependency, operator environment/configuration option, product runtime behavior, or SQLite surface is added. The broad file count is capture-path/lifecycle wiring across existing fixtures, not a UI feature rewrite.

## User Impact

Maintainers can replay the migrated mocked browser proofs without replacing earlier evidence. Actual output directories are logged, and explicit screenshot overrides preserve their basenames while reporting their run-owned locations. Successful and failed proof is retained until the operator removes the exact directories they own; old shared parents are never swept.

There is no end-user bot/UI behavior change. Outbox-owned files and evidence remain untouched. Real-Gateway and mixed mock/real output owners remain separate follow-up work, as do the explicitly excluded outbox capture owners. Ownership and cleanup guidance is updated in `docs/reference/test.md` and the Control UI E2E skill.

## Evidence

- Before the fix, two runs of the reported suites passed all 12 tests while overwriting all 12 newly generated PNG paths; every hash changed. A backup was taken before replay, and this experiment never used the lost original captures.
- Allocator regression: 7 tests cover seeded prior evidence, repeated allocations, concurrent workers sharing a parent/scope, explicit/configured/default parent precedence, and unchanged capture enablement. Replacing exclusive allocation with a fixed directory makes both collision regressions fail for the intended reason.
- Shared capture/diagnostic boundary: 6 tests pass. The diagnostic regression fails against the exact pre-fix helper because captures have no distinct owned directories, then passes against the repair.
- Both reported suites pass twice with default output controls. A broader 9-file / 35-test browser selection passes twice with capture enabled, covering quota, lobster menus, large paste, native-link routing, shared session captures, parameterized recovery/fallback cases, initial-connect captures, and Mantis. Another 46 focused browser tests pass across media fixtures, terminal filename overrides, independent rail roots, recording gates, profile stages, session placement, and typed capture owners.
- Final integrity verification checked **342 retained capture files** against their sealed hashes: **0 changed or missing**. The standalone microphone-hover capture command was replayed; its first four images remained unchanged while the next run produced four new paths.
- Mantis's 22 producer/consumer/workflow tests pass. Three actual mocked-browser Mantis attempts also pass through the report builder and publisher's local manifest/comment rendering with distinct paths, all nine original capture files unchanged, and report rebuild correctly refused. Nothing was uploaded or publicly posted during this local proof.
- AST comparison across all 241 edited E2E suites found **6,896 existing assertions unchanged**. Browser assertions, fixtures, viewports, waits, and capture gates are preserved; disposable managed-audio inputs use the existing temporary-directory tracker separately from retained proof.
- Fresh pre-commit Codex autoreview: two complete bundle chunks, scoped-clean at the P0 threshold, no findings. Exact-head hosted CI and the native landing guards remain required before merge.

After rebasing onto current main, the GitHub-project conflict preserves upstream workspace/media-custody assertions and both existing capture gates. A later import-only splash conflict preserves upstream painting fix `4253fe3ab28`. Post-rebase proof adds 24 helper/consumer tests, 14 browser tests across five merged files, 20 GitHub-project tests across all four output modes, and 21 splash tests across default/capture/replay, followed by a passing scoped typecheck/lint run. The splash replay retains its first 17 files and emits 17 new files; all 20 new PNGs were inspected. All **450 pre-existing files** in the original evidence roots remain hash-preserved.

The first hosted run ([33370586381](https://github.com/openclaw/openclaw/actions/runs/33370586381)) exposed two Mantis fixture contracts and a plain-Node source-import closure gap. Three test/support files preserve exact Mantis step ordering and model the preceding workflow output. Upstream `e45ba01a955` independently landed the identical scoped TypeScript importer repair, so the final rebase keeps that upstream file unchanged. All 16 focused regressions pass, the selected changed-check passes, and fresh isolated Codex reviews of both the repair and resolved rebase are scoped-clean at P0.

Representative local commands (all executed):

```bash
node scripts/run-vitest.mjs run --config vitest.node.config.ts --root ui --configLoader runner src/test-helpers/control-ui-e2e-artifacts.node.test.ts
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui.config.ts --configLoader runner ui/src/test-helpers/control-ui-e2e.test.ts
```

```bash
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-quota-pill-93041.e2e.test.ts ui/src/e2e/lobster-pet-dismiss-menu-overflow.e2e.test.ts
```

```bash
node scripts/run-vitest.mjs test/scripts/mantis-web-ui-chat-evidence.test.ts test/scripts/mantis-web-ui-chat-proof-workflow.test.ts test/scripts/mantis-publish-pr-evidence.test.ts
```

```bash
node scripts/check-changed.mjs
```

The combined changed-check run passed all guards, four typecheck lanes, core lint, and every changed UI-style batch. Its last scripts-lint stage found one `sort`/`toSorted` style issue; that line was corrected, then the complete scripts-lint lane, scripts typecheck, all 22 Mantis tests, formatting, and `git diff --check` passed. The full aggregate was not rerun after that lint-only correction. Earlier integration checks caught and removed a stale native-link setup call and premature session-placement allocation, and replaced two nullable capture locals with the canonical suite owner; the relevant browser flows were rerun successfully.

Source accounting after rebase and CI repair:

| Surface | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Product runtime | 0 | 0 | 0 |
| Test support | 144 | 156 | -12 |
| Tests | 2701 | 1858 | +843 |
| Capture/report tooling | 98 | 62 | +36 |
| Workflow | 58 | 49 | +9 |
| Docs/skill guidance | 39 | 2 | +37 |

Tooling/workflow growth carries the existing Mantis consumer across attempt-owned paths and preserves setup/failure evidence; it is not a new persistence or configuration system. Shared test-support ownership is net-negative.

Historical proof-quality limitation: some earlier initial-connect splash captures were blank or partially painted despite passing DOM assertions. Those files remain unchanged. Upstream `4253fe3ab28` has since repaired capture readiness; its compositor assertion and settled capture waits are preserved and pass in the current rebase. Real-Gateway retention remains separate follow-up work. No product visual change is being asserted, and no generated media is committed.

## Current landing state

Rebased without conflicts onto `0e0b89663f945324a9a9698a58ff8019fe78da8a`, containing the canonical provider-error repairs #133970 (`afd1a36d5d6`) and #134029 (`6100a68ec04`). Both capture PR commits remain patch-identical, with zero product-runtime delta. The prepared-provider and loaded-hook repairs remain upstream-owned; #133747 is separate fixture-readiness work.

On candidate `f710b4c0c1253824fbdafae7bdf3cf775c901ee6`, the unchanged complete authentication file passes 23/23 (previously failing first case 3.052s) and the complete formatter file passes 95/95 (previously failing case 2ms), using their existing test inventory, order, and deadlines without profiling. The updated real Anthropic fresh-process test and four source/compiled scoped/prepared hook combinations pass. Another 113 provider-owner/runtime tests pass.

Fresh capture checks pass: 7 allocator, 6 shared/diagnostic, 22 Mantis consumer/workflow, 5 Mantis fixture, and 21 splash browser tests across default/capture/replay. Each retained splash run produces 17 files; replay leaves the first 17 unchanged. All 450 sealed files in the original evidence roots remain byte-preserved. Fresh isolated Codex autoreview of the complete rebased PR is scoped-clean at P0 in two chunks.

The prior failed run [33374699182](https://github.com/openclaw/openclaw/actions/runs/33374699182) tested the old head and is retained as historical evidence. The [provider-owner diagnosis](https://github.com/openclaw/openclaw/pull/133918#issuecomment-5476659169) is addressed by the upstream repairs above. The previous header failure did not reproduce in focused tests or the original 270-file partition on macOS/Linux; no header repair is claimed and that successful partition was not repeated. [Earlier Linux proof](https://github.com/openclaw/openclaw/actions/runs/33375665410) remains preserved, with its lease stopped.

[Exact-head CI run 33403201859, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33403201859) completed successfully: 119 successful jobs, 12 skips, zero failures. The three formerly failing Linux shards and Windows test shard 1 are green. The Windows log confirms the real Anthropic preparation case passed in 8.557s with one native load and zero source transforms; its source/compiled hook sibling passed in 22.966s. The single native watcher finished GREEN with zero pending checks.

Selected changed checks pass, fresh native review artifacts validate as `READY FOR /prepare-pr`, and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 133918` completed successfully on the same exact head, using hosted CI. Native preparation skipped publication because the remote branch already matched; it did not rebase. The latest ClawSweeper entry is its acknowledgement, with no substantive findings or Rank-up moves available. All 20 fresh splash PNGs were inspected and show the expected synthetic states. This PR is prepared for the lead’s final inspection; no merge has been attempted and explicit merge clearance remains required.
