### PR TITLE
perf(imessage): prepare code marker offset shifts once

### DIFF
--- a/extensions/imessage/src/markdown-format.test.ts
+++ b/extensions/imessage/src/markdown-format.test.ts
@@ -62,6 +62,17 @@ describe("extractMarkdownFormatRuns", () => {
         { start: 19, length: 4, styles: ["strikethrough"] },
       ],
     });
+    expect(
+      extractMarkdownFormatRuns(
+        "😀\ud800 **bold `a😀` mid 😀\udfff `b` tail** then _italics `c😀` end \ud800_.",
+      ),
+    ).toEqual({
+      text: "😀\ud800 bold `a😀` mid 😀\udfff `b` tail then italics `c😀` end \ud800.",
+      ranges: [
+        { start: 4, length: 27, styles: ["bold"] },
+        { start: 37, length: 19, styles: ["italic"] },
+      ],
+    });
   });
 
   it("keeps literal markers that CommonMark does not treat as emphasis", () => {

--- a/extensions/imessage/src/markdown-format.ts
+++ b/extensions/imessage/src/markdown-format.ts
@@ -49,49 +49,46 @@ function codeDelimiter(content: string): string {
   return "`".repeat(longestRun + 1);
 }
 
-type TextEdit = { start: number; end: number; text: string };
-
-function applyTextEdits(text: string, edits: TextEdit[]) {
-  const ordered = edits.toSorted((left, right) => left.start - right.start);
-  let rendered = "";
-  let cursor = 0;
-  for (const edit of ordered) {
-    rendered += text.slice(cursor, edit.start) + edit.text;
-    cursor = edit.end;
-  }
-  rendered += text.slice(cursor);
-  return {
-    text: rendered,
-    mapOffset: (offset: number) =>
-      offset +
-      ordered.reduce(
-        (delta, edit) =>
-          delta + (edit.end <= offset ? edit.text.length - edit.end + edit.start : 0),
-        0,
-      ),
-  };
-}
-
 function restoreCodeMarkers(
   text: string,
   ranges: Array<{ start: number; length: number; styles: IMessageFormatStyle[] }>,
   codeRanges: Array<{ start: number; length: number }>,
 ): { text: string; ranges: IMessageFormatRange[] } {
+  let rendered = "";
+  let cursor = 0;
+  // The code-only renderer merges and sorts these non-overlapping ranges.
+  // Record each cumulative UTF-16 shift at the existing end-inclusive boundary.
   const edits = codeRanges.map((range) => {
     const end = range.start + range.length;
     const content = text.slice(range.start, end);
     const marker = codeDelimiter(content);
     const padding = content.startsWith("`") || content.endsWith("`") ? " " : "";
-    return { start: range.start, end, text: `${marker}${padding}${content}${padding}${marker}` };
+    rendered +=
+      text.slice(cursor, range.start) + `${marker}${padding}${content}${padding}${marker}`;
+    cursor = end;
+    return { end, shift: rendered.length - end };
   });
-  const edited = applyTextEdits(text, edits);
+  rendered += text.slice(cursor);
+  const mapOffset = (offset: number) => {
+    let low = 0;
+    let high = edits.length;
+    while (low < high) {
+      const middle = low + Math.floor((high - low) / 2);
+      const edit = edits[middle];
+      if (edit && edit.end <= offset) {
+        low = middle + 1;
+      } else {
+        high = middle;
+      }
+    }
+    return offset + (edits[low - 1]?.shift ?? 0);
+  };
   return {
-    text: edited.text,
-    ranges: ranges.map((range) => ({
-      ...range,
-      start: edited.mapOffset(range.start),
-      length: edited.mapOffset(range.start + range.length) - edited.mapOffset(range.start),
-    })),
+    text: rendered,
+    ranges: ranges.map((range) => {
+      const start = mapOffset(range.start);
+      return { ...range, start, length: mapOffset(range.start + range.length) - start };
+    }),
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Restoring inline code markers in iMessage text sorts already ordered edits and scans the complete edit list again for every styled endpoint. Mixed code/style messages repeat that work as both counts grow.

## Why This Change Was Made

The code-only attributed renderer already returns sorted, merged, non-overlapping UTF-16 ranges. Record each cumulative insertion shift while building the final text, then find the applicable shift with an end-inclusive upper-bound lookup. The private generic edit wrapper, redundant sort and repeated reductions are removed. The existing code delimiter and second rendering pass remain unchanged.

## User Impact

The exact text, native style ranges, endpoint rules, order and fresh result arrays are preserved, including code inside outer styles, emoji and lone surrogates. No configuration, protocol, SDK, dependency, native transport or delivery-policy change is introduced. This is one measured formatter mechanism; the rejected no-code admission experiment is excluded.

Production is +28/-31 (net -3). The existing UTF-16 test gains 11 lines for a literal combined code/style/emoji/lone-surrogate assertion. That preservation assertion passes on both baseline and candidate; it is not represented as a bug-fix RED test.

## Evidence

The historical complete four-variant comparison retains 86 workloads and 6,192 samples across eight fresh processes in forward/reverse order. The selected offset-only formatter reduces elapsed time by 8.46/8.72% on a 544-character mixed message, 28.15/26.02% on a 2,176-character message, and 8.02/9.42% on the outer-style case. Costs remain visible: nested endpoints add 0.33/0.60 microseconds (4.10/7.51%), link fallback adds 2.58/1.15%, and table/plain controls are retained. Full injected-wire send results are mixed, so this does not claim whole-send, native Messages or network latency improvement.

Complete owner proof passes 5,604 differential comparisons, 104 identity controls and 36 producer controls through formatter, sanitizer and injected-wire send. Current baseline formatter bytes exactly match the captured baseline; the formatted candidate AST matches the measured offset-only composition. Historical capture, compilation and execution heads remain distinct. A direct emitted-text correspondence attempt differed only in a formatter-inserted line break; the structural AST check passes and both outputs are retained.

All 494 tests across eight affected/sibling suites pass before and after. The complete changed-file checks pass (190.68 seconds), including plugin boundary, types, lint and zero dead exports. The fresh full build passes (209.96 seconds). Independent owner review and managed review found no actionable issue; managed review is scoped-clean, 0.98, not a full-repository verdict.

Actual isolated built Gateway and built iMessage plugin verification passes before and after through the documented `channels.imessage.cliPath` stdio contract. Four fixed ordinary/code/Unicode/repeated-style payloads have exactly matching text, complete typed ranges and wire hashes; a read-only client is rejected by normal scope enforcement. The strict task transport accepts exactly four sends and observes watch unsubscribe, with no unexpected frame. Positive V8 owner coverage and CPU profiles are retained. Every recorded Gateway, client and ten fixture PIDs is absent, both groups are gone, the port is closed and task state is removed.

This proves actual Gateway routing, plugin sanitization, formatter output, stdio serialization and receipts. It does not exercise Apple's rendering, a real Messages account/database, the real imsg executable or an external recipient; the task uses only synthetic data and a strict transport fixture. No provider call is made. An initial authorization-path error failed before launching any product process and is preserved; it was repaired without changing product code or the fixed payload oracle. The source client loader rebind changes only the current tsconfig's unrelated pricing alias, retaining the earlier baseline binding.

## Review follow-through

The latest ClawSweeper review at this head has no correctness or security finding. Its sole Rank-up move asks to inspect an omitted bot comment. The maintainer fetched the full current comment list: the other ClawSweeper comment is only the initial acknowledgment, with no outstanding move. Independent maintainer review and exact-head hosted checks are complete.
