### PR TITLE
fix(config): preserve owners across legacy roster imports and store changes

### DIFF
--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -63,14 +63,15 @@ Within a batch, a submitted list keeps its order across subsequent keyed edits,
 including when agent IDs are numeric strings. Existing roster-deletion and
 `$include` ownership protections still apply.
 
-When a legacy roster expands a single-agent installation, writes retire its
-`default` marker and preserve the existing agent's responsibilities with explicit
-owners. An explicitly authored `ownership: "explicit"` cannot be combined with a
-legacy `default: true` marker.
+When a legacy roster expands a single-agent installation in the root config file,
+writes retire its `default` marker and preserve the existing agent's responsibilities
+with explicit owners. An explicitly authored `ownership: "explicit"` cannot be
+combined with a legacy `default: true` marker.
 
-Changing `session.store` clears a copied `agents.defaults.sessionStore.agentId`
-because that owner belongs to the previous store. To assign the destination
-store's owner, set that owner path explicitly in the same batch.
+For root-file writes, changing `session.store` clears a copied
+`agents.defaults.sessionStore.agentId` because that owner belongs to the previous
+store. To assign the destination store's owner, set that owner path explicitly in
+the same batch.
 
 ### `config get`
 

--- a/docs/cli/config.md
+++ b/docs/cli/config.md
@@ -63,6 +63,15 @@ Within a batch, a submitted list keeps its order across subsequent keyed edits,
 including when agent IDs are numeric strings. Existing roster-deletion and
 `$include` ownership protections still apply.
 
+When a legacy roster expands a single-agent installation, writes retire its
+`default` marker and preserve the existing agent's responsibilities with explicit
+owners. An explicitly authored `ownership: "explicit"` cannot be combined with a
+legacy `default: true` marker.
+
+Changing `session.store` clears a copied `agents.defaults.sessionStore.agentId`
+because that owner belongs to the previous store. To assign the destination
+store's owner, set that owner path explicitly in the same batch.
+
 ### `config get`
 
 Reads a value from the redacted config snapshot (secrets never print). `--json` prints the same redacted value as JSON; otherwise strings/numbers/booleans print bare and objects/arrays print as formatted JSON.

--- a/extensions/buzz/src/buzz-bus.socket.test.ts
+++ b/extensions/buzz/src/buzz-bus.socket.test.ts
@@ -325,6 +325,7 @@ it("recovers the Gateway account after silent presence without replaying pre-act
   const account = resolveBuzzAccount({ cfg });
   const abort = new AbortController();
   const states: string[] = [];
+  const firstReady = createDeferred<void>();
   const ctx = createStartAccountContext({
     account,
     cfg,
@@ -333,6 +334,9 @@ it("recovers the Gateway account after silent presence without replaying pre-act
       if (next.lifecycle) {
         states.push(next.lifecycle);
       }
+      if (next.lifecycle === "ready") {
+        firstReady.resolve();
+      }
       if (next.lifecycle === "recovering") {
         fixture.setPresenceMode("accept");
         fixture.sendMessage("during reconnect");
@@ -340,9 +344,14 @@ it("recovers the Gateway account after silent presence without replaying pre-act
     },
   });
   const lifecycle = startBuzzGatewayAccount(ctx);
-  void lifecycle.catch(() => {});
   try {
-    await vi.waitFor(() => expect(states).toContain("ready"));
+    await Promise.race([
+      firstReady.promise,
+      lifecycle.then(() => {
+        throw new Error("Buzz account stopped before becoming ready");
+      }),
+    ]);
+    expect(states).toContain("ready");
     fixture.sendMessage("before stall");
     await vi.waitFor(() => expect(handled).toContain("before stall"));
     await vi.waitFor(() => expect(fixture.authenticatedSessions()).toBe(2), { timeout: 8000 });

--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts
@@ -139,7 +139,7 @@ describe("buildAttemptSystemPrompt", () => {
         effectiveCwd: workspaceDir,
         effectiveTools: [],
         effectiveWorkspace: workspaceDir,
-        getProviderRuntimeHandle: () => ({ provider: "openai" }),
+        getProviderRuntimeHandle: () => ({ provider: "openai", modelId: "gpt-5.5" }),
         isRawModelRun: true,
         markStage: vi.fn(),
         modelToolsEnabled: false,

--- a/src/cli/config-cli.roster.integration.test.ts
+++ b/src/cli/config-cli.roster.integration.test.ts
@@ -3,6 +3,10 @@ import fs from "node:fs";
 import path from "node:path";
 import JSON5 from "json5";
 import { describe, expect, it, vi } from "vitest";
+import { resolveAgentWorkspaceDir } from "../agents/agent-scope-config.js";
+import { resolveLegacyInheritedAuthAgentId } from "../agents/legacy-inherited-auth-dir.js";
+import { readConfigFileSnapshot } from "../config/config.js";
+import { resolveSessionStoreCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { useConfigCliIntegrationHarness } from "./config-cli.integration.test-harness.js";
 
@@ -412,31 +416,204 @@ describe("config cli roster integration", () => {
     );
   });
 
-  it("previews the same ownership preparation used when adding a second agent", async () => {
+  it.each([
+    { mode: "canonical patch", ownerId: "main", input: "canonical" },
+    { mode: "legacy agents replacement", ownerId: "main", input: "agents" },
+    { mode: "legacy list set", ownerId: "keeper", input: "list" },
+    { mode: "legacy list patch", ownerId: "keeper", input: "patch" },
+    { mode: "batch changes retired default", ownerId: "keeper", input: "batch" },
+    { mode: "explicit fleet replacement", ownerId: "keeper", input: "agents", explicitFleet: true },
+    { mode: "changed fixed store", ownerId: "keeper", input: "store" },
+    {
+      mode: "canonical parent copy with a changed store",
+      ownerId: "keeper",
+      input: "canonical-store",
+    },
+    { mode: "narrow edit with a changed store", ownerId: "keeper", input: "narrow-store" },
+    { mode: "explicit destination store owner", ownerId: "keeper", input: "owned-store" },
+  ])("preserves ownership intent through $mode preview and write", async (scenario) => {
+    const { ownerId, input } = scenario;
+    const explicitFleet = scenario.explicitFleet === true;
+    const changedStore = input.endsWith("store");
     const prepareCronOwner = vi.spyOn(cronOwnerRefusal, "prepareCronOwnerWriteRefusal");
-    const raw = `${JSON.stringify({ agents: { entries: { main: { name: "original-main" } } } })}\n`;
     await withConfigFileHarness(
       "openclaw-config-cli-roster-owner-",
-      raw,
+      "{}",
       async ({ configPath, tempDir }) => {
+        const workspace = path.join(fs.realpathSync(tempDir), "existing-workspace");
+        const defaults = {
+          workspace,
+          ...(explicitFleet || changedStore ? { sessionStore: { agentId: ownerId } } : {}),
+          ...(explicitFleet
+            ? {
+                heartbeat: { agentId: ownerId },
+                systemAgent: { agentId: ownerId },
+                authInheritance: { agentId: ownerId },
+              }
+            : {}),
+        };
+        const ownerEntry = { name: "original-owner", ...(explicitFleet ? { workspace } : {}) };
+        const original = {
+          agents: {
+            defaults,
+            ...(explicitFleet ? { ownership: "explicit" } : {}),
+            entries: {
+              [ownerId]: ownerEntry,
+              ...(explicitFleet ? { work: { name: "new-worker" } } : {}),
+            },
+          },
+          session: { store: path.join(fs.realpathSync(tempDir), "sessions.sqlite") },
+          channels: { discord: { enabled: true, dmPolicy: "disabled", groupPolicy: "disabled" } },
+          ...(explicitFleet
+            ? {
+                talk: { agentId: ownerId },
+                bindings: [{ agentId: ownerId, match: { channel: "discord", accountId: "*" } }],
+              }
+            : {}),
+        };
+        const nextStore = changedStore
+          ? path.join(fs.realpathSync(tempDir), "destination.sqlite")
+          : original.session.store;
+        const raw = `${JSON.stringify(original)}\n`;
+        fs.writeFileSync(configPath, raw);
+        const list = [
+          { id: ownerId, ...ownerEntry, default: !explicitFleet && !changedStore },
+          {
+            id: "work",
+            name: "new-worker",
+            ...(explicitFleet || changedStore ? { default: true } : {}),
+          },
+        ];
         const patchFile = path.join(tempDir, "patch.json");
         fs.writeFileSync(
           patchFile,
-          JSON.stringify({ agents: { entries: { work: { name: "new-worker" } } } }),
+          JSON.stringify({
+            agents:
+              input === "canonical" ? { entries: { work: { name: "new-worker" } } } : { list },
+          }),
         );
-        const args = ["config", "patch", "--file", patchFile];
+        let args = ["config", "patch", "--file", patchFile];
+        if (input === "agents") {
+          args = ["config", "set", "agents", JSON.stringify({ defaults, list }), "--strict-json"];
+        } else if (input === "list") {
+          args = ["config", "set", "agents.list", JSON.stringify(list), "--strict-json"];
+        } else if (input === "batch" || changedStore) {
+          const operations = changedStore
+            ? [
+                ...(input === "narrow-store"
+                  ? [{ path: "agents.entries.work", value: { name: "new-worker" } }]
+                  : [
+                      {
+                        path: "agents",
+                        value:
+                          input === "store"
+                            ? { defaults, list }
+                            : {
+                                ownership: "explicit",
+                                defaults,
+                                entries: { [ownerId]: ownerEntry, work: { name: "new-worker" } },
+                              },
+                      },
+                    ]),
+                { path: "session.store", value: nextStore },
+                ...(input === "owned-store"
+                  ? [{ path: "agents.defaults.sessionStore.agentId", value: "work" }]
+                  : []),
+              ]
+            : [
+                { path: "agents.list", value: list },
+                { path: `agents.entries.${ownerId}.default`, value: false },
+                { path: "agents.entries.work.default", value: true },
+              ];
+          args = ["config", "set", "--batch-json", JSON.stringify(operations)];
+        }
         await runRegisteredConfigCommand([...args, "--dry-run"]);
         expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
         expect(prepareCronOwner).not.toHaveBeenCalled();
         await runRegisteredConfigCommand(args);
-        expect(prepareCronOwner).toHaveBeenCalledOnce();
+        expect(prepareCronOwner).toHaveBeenCalledTimes(explicitFleet ? 0 : 1);
         const after = JSON5.parse(fs.readFileSync(configPath, "utf8"));
         expect(after.agents).toMatchObject({
           ownership: "explicit",
-          entries: { main: { name: "original-main" }, work: { name: "new-worker" } },
-          defaults: { heartbeat: { agentId: "main" }, systemAgent: { agentId: "main" } },
+          defaults: {
+            heartbeat: { agentId: ownerId },
+            systemAgent: { agentId: ownerId },
+          },
         });
-        expect(after.agents.entries.main.workspace).toEqual(expect.any(String));
+        expect(after.agents.entries).toEqual({
+          [ownerId]: { name: "original-owner", workspace },
+          work: { name: "new-worker" },
+        });
+        expect(after.agents).not.toHaveProperty("list");
+        expect(after.talk.agentId).toBe(ownerId);
+        expect(after.bindings).toEqual([
+          { agentId: ownerId, match: { channel: "discord", accountId: "*" } },
+        ]);
+        const reloaded = await readConfigFileSnapshot();
+        expect(reloaded.valid).toBe(true);
+        expect(resolveAgentWorkspaceDir(reloaded.config, ownerId)).toBe(workspace);
+        expect(resolveAgentWorkspaceDir(reloaded.config, "work")).toBe(
+          path.join(workspace, "work"),
+        );
+        expect(resolveLegacyInheritedAuthAgentId(reloaded.config)).toBe(ownerId);
+        expect(after.session.store).toBe(nextStore);
+        if (changedStore && input !== "owned-store") {
+          expect(after.agents.defaults).not.toHaveProperty("sessionStore.agentId");
+        } else {
+          const expectedStoreOwner = input === "owned-store" ? "work" : ownerId;
+          expect(after.agents.defaults.sessionStore.agentId).toBe(expectedStoreOwner);
+          expect(resolveSessionStoreCompatibilityAgentId(reloaded.config)).toBe(expectedStoreOwner);
+        }
+        expect(registeredRuntimeErrors).toEqual([]);
+      },
+    );
+  });
+
+  it.each([
+    {
+      name: "duplicate default markers",
+      value: {
+        list: [
+          { id: "main", default: true },
+          { id: "work", default: true },
+        ],
+      },
+    },
+    {
+      name: "non-boolean default marker",
+      value: { list: [{ id: "main", default: "yes" }, { id: "work" }] },
+    },
+    {
+      name: "authored explicit ownership with a default marker",
+      value: { ownership: "explicit", list: [{ id: "main", default: true }, { id: "work" }] },
+    },
+    {
+      name: "inherited explicit ownership with a default marker",
+      sourceAgents: { ownership: "explicit", entries: { main: {}, work: {} } },
+      configPath: "agents.list",
+      value: [{ id: "main", default: true }, { id: "work" }],
+    },
+  ])("refuses $name without changing the config", async (scenario) => {
+    const raw = JSON.stringify({ agents: scenario.sourceAgents ?? { entries: { main: {} } } });
+    await withConfigFileHarness(
+      "openclaw-config-cli-roster-invalid-owner-",
+      raw,
+      async ({ configPath }) => {
+        const args = [
+          "config",
+          "set",
+          scenario.configPath ?? "agents",
+          JSON.stringify(scenario.value),
+          "--replace",
+          "--strict-json",
+        ];
+        for (const preview of [true, false]) {
+          await expect(
+            runRegisteredConfigCommand([...args, ...(preview ? ["--dry-run", "--json"] : [])]),
+          ).rejects.toMatchObject({ name: "ExitError", code: 1 });
+          expect(fs.readFileSync(configPath, "utf8")).toBe(raw);
+        }
+        expect(registeredRuntimeLogs.join("\n")).not.toContain("Updated");
       },
     );
   });

--- a/src/config/io.session-store-owner.ts
+++ b/src/config/io.session-store-owner.ts
@@ -14,7 +14,7 @@ export function prepareSessionStoreOwnershipForWrite(params: {
   env: NodeJS.ProcessEnv;
   explicitSetPaths?: readonly (readonly string[])[];
   explicitSetValueSource?: OpenClawConfig;
-}): { config: OpenClawConfig; sameFixedSessionStore: boolean } {
+}): { config: OpenClawConfig; sameFixedSessionStore: boolean; ownershipPaths: string[][] } {
   const sameFixedSessionStore = isSameFixedSessionStoreConfig(
     params.currentStore,
     params.targetConfig.session?.store,
@@ -37,9 +37,13 @@ export function prepareSessionStoreOwnershipForWrite(params: {
   // A compatibility owner belongs to one physical fixed store. Copied runtime config must not
   // carry it to another store; only an owner-specific authored path establishes the new owner.
   if (sameFixedSessionStore || !previousOwner || suppliesDestinationOwner) {
-    return { config: params.targetConfig, sameFixedSessionStore };
+    return { config: params.targetConfig, sameFixedSessionStore, ownershipPaths: [] };
   }
   const agents = structuredClone(params.targetConfig.agents ?? {});
   unsetConfigValueAtPath(agents as Record<string, unknown>, SESSION_STORE_OWNER_PATH.slice(1));
-  return { config: { ...params.targetConfig, agents }, sameFixedSessionStore };
+  return {
+    config: { ...params.targetConfig, agents },
+    sameFixedSessionStore,
+    ownershipPaths: [[...SESSION_STORE_OWNER_PATH]],
+  };
 }

--- a/src/config/io.write-topology.ts
+++ b/src/config/io.write-topology.ts
@@ -6,6 +6,7 @@ import { pinSurvivorWorkspaceForRosterCollapse } from "./agent-workspace-roster-
 import { getConfigValueAtPath, setConfigValueAtPath } from "./config-paths.js";
 import { prepareAuthInheritanceOwnerForWrite } from "./io.auth-inheritance-owner.js";
 import { assertAutomaticBindingsWriteAllowed } from "./io.ownership-write-guard.js";
+import { coerceConfig } from "./io.read-helpers.js";
 import { prepareSessionStoreOwnershipForWrite } from "./io.session-store-owner.js";
 import type {
   ConfigWriteOptions,
@@ -55,6 +56,12 @@ export function prepareConfigWriteTopology(
   const stampOwnership =
     (persistOwnership || keepOwnership) && nextConfig.agents?.ownership === undefined;
   if (stampOwnership) {
+    if (nextEntries.some((entry) => entry.default === true)) {
+      // This writer owns role transitions; retire only the submitted roster marker.
+      nextConfig = coerceConfig(
+        migratePersistedImplicitMainRoster(nextConfig, { materializeRoles: false }).config,
+      );
+    }
     nextConfig = {
       ...nextConfig,
       agents: { ...nextConfig.agents, ownership: "explicit" },
@@ -117,7 +124,8 @@ export function prepareConfigWriteTopology(
       : []),
     ...ownershipMaterialization.insertedPaths.concat(workspaceCollapse.insertedPaths),
     ...authInheritanceOwnership.insertedPaths, // Persisting explicit ownership must replace the authored legacy roster too.
-    ...(persistOwnership ? [["agents", "entries"]] : []), // Otherwise projection restores the retired default marker.
+    ...sessionStoreOwnership.ownershipPaths, // Parent writes must not restore a removed fixed-store owner.
+    ...(persistOwnership || stampOwnership ? [["agents", "entries"]] : []), // Otherwise projection restores the retired default marker.
     ...(stampOwnership ? [["agents", "ownership"]] : []),
   ];
 

--- a/src/config/legacy.roster.ts
+++ b/src/config/legacy.roster.ts
@@ -44,7 +44,7 @@ export function parseLegacyAgentRoster(
 
 export function migratePersistedImplicitMainRoster(
   raw: unknown,
-  options: { materializeWorkspace?: boolean } = {},
+  options: { materializeWorkspace?: boolean; materializeRoles?: boolean } = {},
 ): MigrationResult {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
     return { config: raw, changed: false, diagnostics: [] };
@@ -126,7 +126,7 @@ export function migratePersistedImplicitMainRoster(
   let insertedPaths: string[][] = [];
   const diagnostics = convertedLegacyList ? ["Moved agents.list to keyed agents.entries."] : [];
   let changed = convertedLegacyList;
-  if (legacyDefaultAgentId) {
+  if (legacyDefaultAgentId && options.materializeRoles !== false) {
     const materialized = materializeLegacyDefaultAgentRoles(
       nextRoot as OpenClawConfig,
       legacyDefaultAgentId,


### PR DESCRIPTION
Closes #133868
Closes #133889

## What Problem This Solves

Importing an older agent roster into a single-agent installation could fail when automatic explicit ownership conflicted with the submitted legacy default marker. A root-file config write that copied the agents parent while changing `session.store` could also restore the previous store's compatibility owner, even though an equivalent narrow edit cleared it.

## Why This Change Was Made

The shared root writer now retires the legacy marker through the existing roster migration before stamping ownership. It preserves the installation's prior responsibilities and materializes roles once. The store-owner helper also carries its removal decision into the existing persistence projection, so an explicitly copied parent cannot put the stale owner back.

Authored explicit ownership combined with a legacy marker remains invalid. Explicitly assigning the destination store owner still works. No public option, dependency, SQLite schema, or storage format is added.

The PR also corrects a Buzz test failure exposed by CI: real account startup was constrained by an accidental one-second readiness poll. The test now awaits the existing ready event and propagates lifecycle failure or premature completion. Its recovery/replay assertions, cleanup, and outer 15-second deadline are unchanged; Buzz production code is untouched.

A second CI correction completes the sandbox prompt fixture with the selected model ID, matching the existing production setup contract. The incomplete fixture was causing real provider discovery during a sandbox-policy assertion. The existing model-mismatch discovery contract and every sandbox/prompt assertion are preserved; no mock, timeout, or runtime change is added.

## User Impact

Root-file legacy roster imports can add agents without retargeting the existing workspace, heartbeat, system agent, Talk, channel binding, inherited auth, or unchanged fixed session store. Parent-copy store changes now agree with narrow edits. The config CLI documentation explains these contracts.

Included-file ownership is a separate, preexisting limitation described below; this PR does not claim to repair it.

## Evidence

The [isolated Crabbox/Testbox campaign](https://github.com/openclaw/openclaw/actions/runs/33363087712) reproduced seven failures before the config repair. All 47 real-parser cases and 29 migration/store sibling cases pass afterward. A full distribution build, full changed-file checks, and four separate built-CLI controls passed, including unchanged preview bytes and explicit destination-owner assignment.

A [clean committed-package run](https://github.com/openclaw/openclaw/actions/runs/33368034442) tested candidate `99170bd330a2f80dbc051f58e001b35ba75d3340`, with tarball SHA-256 `fff33d2dc27e12f657aeb1dc87252265f03a1e2c97726dba80a2bd67cd35e29f`. July volume migration, May configured-plugin repair and authenticated restart, current-install authenticated restart, and March explicit repair followed by authenticated restart passed. The July install preserved 9,600 sessions, 152,896 events, 4,400 cron jobs, and 512 plugin KV rows through migration, history readback, and restart; idempotent Doctor took 9 seconds. March's published updater only runs advisory Doctor, so its documented explicit repair is recorded separately from automatic update behavior. Harness repairs are in #134002.

The three production files and CLI regression fixture on final head `eb3c80c288ebea366d285f244b1bc4ececab8620` are byte-identical to that tested config repair; the documentation additionally clarifies its root-file scope. For the additional Buzz test correction, an [isolated delayed-start experiment](https://github.com/openclaw/openclaw/actions/runs/33378675494) held the membership reply for 1.25 seconds: the original poll failed; the corrected recovery test passed in 7.020 seconds. All 54 socket/lifecycle/cold-recovery cases and the full changed-file gate passed. The existing shared CI fixture repair is upstream in #124415 and excluded here.

The [cold sandbox-fixture comparison](https://github.com/openclaw/openclaw/actions/runs/33387310684) used the same pinned Linux clone and fresh Vitest processes. The first case took 76.056 seconds before the correction and 127 ms afterward. Full-file wall time fell from 97.075 to 13.131 seconds and peak RSS from 2,252,944 to 1,736,144 KiB; observed provider source loads fell from two to zero. All 12 cases passed in both local variants, so the hosted 120-second timeout was not reproduced locally; the cold discovery cost was. All 102 uninstrumented prompt/setup/provider cases and the full changed-file gate (713.923 seconds) passed. Temporary observations are absent from the committed fixture.

CI run 33384111548 attempt 1 had 99 checkout-only root failures. One exact-head retry passed checkout but exposed this prompt timeout and a separate lint runner shutdown without a lint diagnostic; every other selected job passed/skipped. The correction gets a fresh exact-head run before landing. The initially incorrect newer-main baseline in the isolated incremental gate was corrected to the PR's actual ancestor; both outcomes are retained, without weakening a check.

Production: +18/-6 (net +12). Tests: +198/-12. Docs: +10. The production growth reuses structural migration and carries an authoritative removal into projection; it adds no parallel writer or fallback. Fresh seven-file autoreview is clear at its configured P0 threshold. ClawSweeper found no actionable correctness or security issue; its remaining requirement is green exact-head CI before normal native landing.

Two named follow-ups remain. #133895 tracks an empty-roster preview that accepts a request the root writer rejects. **Included-store ownership planning** is confirmed by a separate [four-case real-parser audit](https://github.com/openclaw/openclaw/actions/runs/33380582437): both inline-config controls clear the old owner, while narrow and copied-parent edits through a top-level `session` include retain the root-file owner after changing stores. Both previews preserve file bytes. That unchanged include route bypasses this PR's topology/projection owner; repairing it requires shared root/include planning and coordinated persistence of the included section and derived root ownership. All six task-owned Testbox leases are stopped.
