### PR TITLE
fix(doctor): preserve files created during session restore

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -462,9 +462,16 @@ it writes the local support report and prints a prefilled issue URL.
 
 `restore` remains the lower-level undo operation. It uses manifest
 `sourcePath -> archivePath` records, moves archived artifacts back only when the
-original path is missing, reports conflicts when both paths exist, and leaves
-the SQLite database in place. When several manifests recorded the same original
-path, restore plans all candidates before moving any of them. Identical archives
+original path is missing, reports conflicts for independently existing originals,
+and leaves the SQLite database in place. Publication is exclusive: a file or
+symbolic link created during verification is not replaced. Restore moves the
+original without copying its contents, and fails without consuming the archive
+if the filesystem cannot publish it safely. Recorded interrupted publications
+can be retried, including with older manifests or after the replacement SQLite
+database has been removed. If restore recreates a missing sessions directory,
+retries repeat its parent-directory durability check before consuming the archive.
+When several manifests recorded the same original path, restore plans all
+candidates before moving any of them. Identical archives
 are safe duplicates, and one nonempty legacy `sessions.json` may supersede empty
 copies created by older writers. Distinct nonempty indexes, distinct transcript
 archives, invalid archives, and archives missing without a recorded prior

--- a/src/commands/doctor-session-sqlite-artifact.ts
+++ b/src/commands/doctor-session-sqlite-artifact.ts
@@ -146,6 +146,7 @@ export async function moveMigrationArtifact(
   sourcePath: string,
   targetPath: string,
   expected: MigrationArtifactIdentity,
+  onPublished?: () => undefined,
 ): Promise<void> {
   if (!fs.lstatSync(targetPath, { bigint: true, throwIfNoEntry: false })) {
     if (!sameMigrationArtifact(readMigrationArtifactIdentity(sourcePath), expected)) {
@@ -159,8 +160,19 @@ export async function moveMigrationArtifact(
       onSyncFailure: "preserve",
     });
     requireDirectorySync(published.directorySync, "Recovery artifact publication");
+  } else {
+    // A preserved link may have outlived a failed directory sync. Make its name durable
+    // before an interrupted move can remove the original name.
+    requireDirectorySync(
+      await syncDirectory(path.dirname(targetPath)),
+      "Recovery artifact publication",
+    );
   }
   assertMigrationArtifactPublication(sourcePath, targetPath, expected);
+  if (onPublished) {
+    onPublished();
+    assertMigrationArtifactPublication(sourcePath, targetPath, expected);
+  }
   fs.unlinkSync(sourcePath);
   requireDirectorySync(await syncDirectory(path.dirname(sourcePath)), "Recovery artifact source");
   if (!sameMigrationArtifact(readMigrationArtifactIdentity(targetPath), expected)) {
@@ -169,7 +181,7 @@ export async function moveMigrationArtifact(
 }
 
 /** Only the recorded exact two-name inode can finish or undo an interrupted publication. */
-export function assertMigrationArtifactPublication(
+function assertMigrationArtifactPublication(
   sourcePath: string,
   targetPath: string,
   expected: MigrationArtifactIdentity,

--- a/src/commands/doctor-session-sqlite-migration-run.ts
+++ b/src/commands/doctor-session-sqlite-migration-run.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { z } from "zod";
 import { resolveStateDir } from "../config/paths.js";
+import { requireDirectorySync, syncDirectorySync } from "../infra/directory-durability.js";
 import * as replaceFile from "../infra/replace-file.js";
 import { VERSION } from "../version.js";
 import {
@@ -239,8 +240,13 @@ export function writeSessionSqliteMigrationManifest(
     tempPrefix: path.basename(activeRun.manifestPath),
     copyFallbackOnPermissionError: false,
     syncTempFile: true,
-    syncParentDir: true,
   });
+  // Atomic replacement only offers best-effort parent sync. Recovery receipts must be
+  // durable before their recorded original can be published, consumed, or retired.
+  requireDirectorySync(
+    syncDirectorySync(path.dirname(activeRun.manifestPath)),
+    "Session SQLite migration manifest",
+  );
 }
 
 export function updateMigrationManifestTarget(

--- a/src/commands/doctor-session-sqlite-recover-report.ts
+++ b/src/commands/doctor-session-sqlite-recover-report.ts
@@ -72,7 +72,7 @@ export async function recoverDoctorSessionSqliteTargets(params: {
       ),
     ]);
   }
-  const restore = restoreSessionSqliteMigrationRun({
+  const restore = await restoreSessionSqliteMigrationRun({
     env: params.env,
     manifestPath: failedRun.manifestPath,
     trustedTargets,

--- a/src/commands/doctor-session-sqlite-restore-report.ts
+++ b/src/commands/doctor-session-sqlite-restore-report.ts
@@ -19,7 +19,7 @@ export async function restoreDoctorSessionSqliteTargets(params: {
     ...target,
     sqlitePath: resolveTargetSqlitePath(target),
   }));
-  const restore = restoreSessionSqliteMigrationRuns({
+  const restore = await restoreSessionSqliteMigrationRuns({
     env: params.env,
     trustedTargets,
   });

--- a/src/commands/doctor-session-sqlite-restore.ts
+++ b/src/commands/doctor-session-sqlite-restore.ts
@@ -8,11 +8,9 @@ import { readFileDescriptorBoundedSync } from "../infra/boundary-file-read.js";
 import { requireDirectorySync, syncDirectorySync } from "../infra/directory-durability.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
-import { inspectOpenClawAgentDatabaseOwner } from "../state/openclaw-agent-db.js";
 import {
-  assertMigrationArtifactPublication,
+  moveMigrationArtifact,
   readMigrationArtifactIdentity,
-  sameMigrationArtifact,
   statMigrationPath,
 } from "./doctor-session-sqlite-artifact.js";
 import {
@@ -35,16 +33,16 @@ import type { DoctorSessionSqliteRestoreReport } from "./doctor-session-sqlite-t
 import { assertDoctorSqliteMaintenancePathsNotAliased } from "./doctor-sqlite-maintenance-lock.js";
 const RESTORE_ARCHIVE_HASH_CHUNK_BYTES = 64 * 1024;
 
-export function restoreSessionSqliteMigrationRuns(params: {
+export async function restoreSessionSqliteMigrationRuns(params: {
   env: NodeJS.ProcessEnv;
   trustedTargets: readonly SessionSqliteMigrationTargetInput[];
-}): DoctorSessionSqliteRestoreReport {
+}): Promise<DoctorSessionSqliteRestoreReport> {
   const restoreReport: DoctorSessionSqliteRestoreReport = emptyRestoreReport();
   const contexts = loadRestoreManifestContexts(
     listSessionSqliteMigrationManifestPaths(params.env).toReversed(),
     params.trustedTargets,
   );
-  reconcileRestorePublications(contexts, params.env);
+  await reconcileRestorePublications(contexts, params.env);
   const restorePlan = createRestorePlan(contexts);
   for (const { manifest, manifestPath, targets } of contexts) {
     const manifestRestoreReport: DoctorSessionSqliteRestoreReport = {
@@ -52,7 +50,7 @@ export function restoreSessionSqliteMigrationRuns(params: {
       manifestPaths: [manifestPath],
     };
     restoreReport.manifestPaths.push(manifestPath);
-    restoreSessionSqliteMigrationManifest(
+    await restoreSessionSqliteMigrationManifest(
       manifest,
       manifestPath,
       targets,
@@ -68,12 +66,12 @@ export function restoreSessionSqliteMigrationRuns(params: {
 }
 
 /** Undo only recorded, still-linked publication intermediates before a fresh import or restore. */
-export function reconcileSessionSqliteMigrationPublications(params: {
+export async function reconcileSessionSqliteMigrationPublications(params: {
   env: NodeJS.ProcessEnv;
   trustedTargets: readonly SessionSqliteMigrationTargetInput[];
   sourcePath?: string;
-}): void {
-  reconcileRestorePublications(
+}): Promise<void> {
+  await reconcileRestorePublications(
     loadRestoreManifestContexts(
       listSessionSqliteMigrationManifestPaths(params.env),
       params.trustedTargets,
@@ -83,11 +81,11 @@ export function reconcileSessionSqliteMigrationPublications(params: {
   );
 }
 
-function reconcileRestorePublications(
+async function reconcileRestorePublications(
   contexts: readonly RestoreManifestContext[],
   env: NodeJS.ProcessEnv,
   sourcePath?: string,
-): void {
+): Promise<void> {
   const stateDir = path.dirname(
     canonicalMigrationFilePath(path.join(resolveStateDir(env), "anchor")),
   );
@@ -130,56 +128,46 @@ function reconcileRestorePublications(
           [context.manifestPath, ...resolveSqliteDatabaseFilePaths(target.sqlitePath)],
           [stateDir],
         );
-        const owner = inspectOpenClawAgentDatabaseOwner(target.sqlitePath);
-        if (owner.status !== "owned" || owner.agentId !== target.agentId) {
-          throw new Error("Cannot reconcile publication without the current destination owner");
-        }
-        assertMigrationArtifactPublication(
-          move.sourcePath,
+        // The exact recorded original stays at its source; reconciliation never needs
+        // the replacement SQLite database to exist or opens it for ownership inspection.
+        await moveMigrationArtifact(
           move.archivePath,
-          move.artifact.identity,
-        );
-        // The original already exists at its source. Record that restoration before removing the
-        // archive name, so a crash cannot turn a consumed original into unexplained missing history.
-        const consumed = collectRecordedConsumedArchives(context.manifest);
-        consumed.add(move.archivePath);
-        context.manifest.restore = {
-          attemptedAt: new Date().toISOString(),
-          consumedArchives: [...consumed].toSorted(),
-          conflicts: [],
-          restoredFiles: [
-            ...new Set([...(context.manifest.restore?.restoredFiles ?? []), move.sourcePath]),
-          ],
-          skippedFiles: [],
-          status: "restored",
-        };
-        writeSessionSqliteMigrationManifest(context);
-        requireDirectorySync(
-          syncDirectorySync(path.dirname(context.manifestPath)),
-          "Recovery restoration receipt",
-        );
-        assertSafeSessionSqliteMigrationMove(move, target);
-        assertMigrationArtifactPublication(
           move.sourcePath,
-          move.archivePath,
           move.artifact.identity,
+          () => {
+            assertSafeSessionSqliteMigrationMove(move, target);
+            recordRestoredMigrationMove(context.manifest, context.manifestPath, move);
+          },
         );
-        fs.unlinkSync(move.archivePath);
-        requireDirectorySync(
-          syncDirectorySync(path.dirname(move.archivePath)),
-          "Recovery publication reconciliation",
-        );
-        if (
-          !sameMigrationArtifact(
-            readMigrationArtifactIdentity(move.sourcePath),
-            move.artifact.identity,
-          )
-        ) {
-          throw new Error("Restored publication source changed");
-        }
       }
     }
   }
+}
+
+function recordRestoredMigrationMove(
+  manifest: SessionSqliteMigrationManifest,
+  manifestPath: string,
+  move: SessionSqliteMigrationMove,
+): void {
+  // Sessions and archives are siblings. Retry their parent sync even when a previous
+  // attempt created the sessions directory, before consuming its original archive.
+  requireDirectorySync(
+    syncDirectorySync(path.dirname(path.dirname(move.sourcePath))),
+    "Restored session directory",
+  );
+  // Commit consumption before unlinking the archive, so an interrupted restore cannot
+  // make a settled generation look like unexplained missing history.
+  const consumed = collectRecordedConsumedArchives(manifest);
+  consumed.add(move.archivePath);
+  manifest.restore = {
+    attemptedAt: new Date().toISOString(),
+    consumedArchives: [...consumed].toSorted(),
+    conflicts: [],
+    restoredFiles: [...new Set([...(manifest.restore?.restoredFiles ?? []), move.sourcePath])],
+    skippedFiles: [],
+    status: "restored",
+  };
+  writeSessionSqliteMigrationManifest({ manifest, manifestPath });
 }
 
 type RestoreManifestContext = {
@@ -536,11 +524,11 @@ function inspectRestoreArchive(move: SessionSqliteMigrationMove): RestoreArchive
   }
 }
 
-export function restoreSessionSqliteMigrationRun(params: {
+export async function restoreSessionSqliteMigrationRun(params: {
   env?: NodeJS.ProcessEnv;
   manifestPath: string;
   trustedTargets: readonly SessionSqliteMigrationTargetInput[];
-}): DoctorSessionSqliteRestoreReport {
+}): Promise<DoctorSessionSqliteRestoreReport> {
   const restoreReport: DoctorSessionSqliteRestoreReport = {
     ...emptyRestoreReport(),
     manifestPaths: [params.manifestPath],
@@ -563,11 +551,11 @@ export function restoreSessionSqliteMigrationRun(params: {
     });
     return restoreReport;
   }
-  reconcileRestorePublications(
+  await reconcileRestorePublications(
     [{ manifest, manifestPath: params.manifestPath, targets: targetManifests }],
     params.env ?? process.env,
   );
-  restoreSessionSqliteMigrationManifest(
+  await restoreSessionSqliteMigrationManifest(
     manifest,
     params.manifestPath,
     targetManifests,
@@ -593,25 +581,26 @@ function emptyRestoreReport(): DoctorSessionSqliteRestoreReport {
   };
 }
 
-function restoreSessionSqliteMigrationManifest(
+async function restoreSessionSqliteMigrationManifest(
   manifest: SessionSqliteMigrationManifest,
   manifestPath: string,
   targets: readonly SessionSqliteMigrationTargetManifest[],
   restoreReport: DoctorSessionSqliteRestoreReport,
   restorePlan: ReadonlyMap<string, RestoreMovePlan>,
-): void {
-  const consumedArchives = collectRecordedConsumedArchives(manifest);
+): Promise<void> {
   for (const target of targets) {
     for (const move of uniqueRestoreMoves(target)) {
-      restoreMigrationMove({
-        consumedArchives,
+      await restoreMigrationMove({
+        manifest,
         manifestPath,
+        target,
         move,
         restorePlan,
         restoreReport,
       });
     }
   }
+  const consumedArchives = collectRecordedConsumedArchives(manifest);
   manifest.restore = {
     attemptedAt: new Date().toISOString(),
     ...(consumedArchives.size > 0 ? { consumedArchives: [...consumedArchives].toSorted() } : {}),
@@ -622,97 +611,99 @@ function restoreSessionSqliteMigrationManifest(
   };
 }
 
-function restoreMigrationMove(params: {
-  consumedArchives: Set<string>;
+async function restoreMigrationMove(params: {
+  manifest: SessionSqliteMigrationManifest;
   manifestPath: string;
+  target: SessionSqliteMigrationTargetManifest;
   move: SessionSqliteMigrationMove;
   restorePlan: ReadonlyMap<string, RestoreMovePlan>;
   restoreReport: DoctorSessionSqliteRestoreReport;
-}): void {
-  const { consumedArchives, manifestPath, move, restorePlan, restoreReport } = params;
-  const planned = restorePlan.get(restoreMovePlanKey(manifestPath, move)) ?? {
-    action: "standard",
-  };
-  if (planned.action === "conflict") {
+}): Promise<void> {
+  const { manifest, manifestPath, target, move, restorePlan, restoreReport } = params;
+  const recordConflict = (reason: string) => {
     restoreReport.conflicts.push({
       archivePath: move.archivePath,
-      reason: planned.reason,
+      reason,
       sourcePath: move.sourcePath,
     });
+  };
+  const planned = restorePlan.get(restoreMovePlanKey(manifestPath, move)) ?? { action: "standard" };
+  if (planned.action === "conflict") {
+    recordConflict(planned.reason);
     return;
   }
   if (planned.action === "skip-consumed" || planned.action === "skip-superseded") {
     restoreReport.skippedFiles.push(move.sourcePath);
     return;
   }
-  const sourceExists = fs.existsSync(move.sourcePath);
-  const archiveExists = fs.existsSync(move.archivePath);
-  if (!sourceExists && archiveExists) {
-    if (planned.action === "restore") {
-      const inspection = inspectRestoreArchive(move);
-      if (
-        inspection.state !== "available" ||
-        inspection.snapshot.digest !== planned.snapshot.digest ||
-        inspection.snapshot.size !== planned.snapshot.size ||
-        inspection.snapshot.legacyEntryCount !== planned.snapshot.legacyEntryCount
-      ) {
-        restoreReport.conflicts.push({
-          archivePath: move.archivePath,
-          reason: "archive changed after restore planning; refusing restore",
-          sourcePath: move.sourcePath,
-        });
-        return;
-      }
+  const sourceExists = statMigrationPath(move.sourcePath) !== undefined;
+  const archiveExists = statMigrationPath(move.archivePath) !== undefined;
+  if (sourceExists || !archiveExists) {
+    if (sourceExists && !archiveExists) {
+      restoreReport.skippedFiles.push(move.sourcePath);
+    } else {
+      recordConflict(
+        sourceExists
+          ? "source and archive both exist; refusing to overwrite source"
+          : "source and archive are both missing",
+      );
     }
+    return;
+  }
+  try {
     if (!isRegularFileWithoutFollowingSymlinks(move.archivePath)) {
-      restoreReport.conflicts.push({
-        archivePath: move.archivePath,
-        reason: "archive is not a regular file; refusing restore",
-        sourcePath: move.sourcePath,
-      });
-      return;
+      throw new Error("archive is not a regular file; refusing restore");
     }
-    const sourceDir = path.dirname(move.sourcePath);
-    const archiveDir = path.dirname(move.archivePath);
-    if (hasSymbolicLinkInDirectoryPath(sourceDir) || hasSymbolicLinkInDirectoryPath(archiveDir)) {
-      restoreReport.conflicts.push({
-        archivePath: move.archivePath,
-        reason: "source or archive parent is a symbolic link; refusing restore",
-        sourcePath: move.sourcePath,
-      });
-      return;
+    assertRestoreDirectories(move);
+    fs.mkdirSync(path.dirname(move.sourcePath), { recursive: true, mode: 0o700 });
+    assertRestoreDirectories(move);
+    const identity = move.artifact?.identity ?? readMigrationArtifactIdentity(move.archivePath);
+    // Publication rechecks these exact bytes; matching the plan also preserves its index count.
+    if (
+      planned.action === "restore" &&
+      (identity.sha256 !== planned.snapshot.digest || identity.size !== planned.snapshot.size)
+    ) {
+      throw new Error("archive changed after restore planning; refusing restore");
     }
-    fs.mkdirSync(sourceDir, { recursive: true, mode: 0o700 });
-    if (hasSymbolicLinkInDirectoryPath(sourceDir) || hasSymbolicLinkInDirectoryPath(archiveDir)) {
-      restoreReport.conflicts.push({
-        archivePath: move.archivePath,
-        reason: "source or archive parent is a symbolic link; refusing restore",
-        sourcePath: move.sourcePath,
-      });
-      return;
+    if (!move.artifact) {
+      // Historical manifests need an identity before the first link so a crash is retryable.
+      // This proves the original's identity, not its import; cleanup must keep it protected.
+      move.artifact = {
+        identity,
+        classification: "protected",
+        reason: "historical-restore-original",
+        dependencies:
+          move.kind === "legacy-store"
+            ? uniqueRestoreMoves(target)
+                .filter((item) => item.kind === "transcript")
+                .map((item) => item.sourcePath)
+            : [],
+        disposal: { state: "retained" },
+      };
+      for (const recorded of [...target.plannedMoves, ...target.completedMoves]) {
+        if (migrationMoveKey(recorded) === migrationMoveKey(move)) {
+          recorded.artifact = move.artifact;
+        }
+      }
+      writeSessionSqliteMigrationManifest({ manifest, manifestPath });
     }
-    fs.renameSync(move.archivePath, move.sourcePath);
-    consumedArchives.add(move.archivePath);
-    restoreReport.restoredFiles.push(move.sourcePath);
-    return;
-  }
-  if (sourceExists && !archiveExists) {
-    restoreReport.skippedFiles.push(move.sourcePath);
-    return;
-  }
-  if (sourceExists && archiveExists) {
-    restoreReport.conflicts.push({
-      archivePath: move.archivePath,
-      reason: "source and archive both exist; refusing to overwrite source",
-      sourcePath: move.sourcePath,
+    await moveMigrationArtifact(move.archivePath, move.sourcePath, move.artifact.identity, () => {
+      assertRestoreDirectories(move);
+      recordRestoredMigrationMove(manifest, manifestPath, move);
     });
-    return;
+    restoreReport.restoredFiles.push(move.sourcePath);
+  } catch (error) {
+    recordConflict(error instanceof Error ? error.message : String(error));
   }
-  restoreReport.conflicts.push({
-    archivePath: move.archivePath,
-    reason: "source and archive are both missing",
-    sourcePath: move.sourcePath,
-  });
+}
+
+function assertRestoreDirectories(move: SessionSqliteMigrationMove): void {
+  if (
+    hasSymbolicLinkInDirectoryPath(path.dirname(move.sourcePath)) ||
+    hasSymbolicLinkInDirectoryPath(path.dirname(move.archivePath))
+  ) {
+    throw new Error("source or archive parent is a symbolic link; refusing restore");
+  }
 }
 
 function resolveRestoreStatus(
@@ -726,9 +717,6 @@ function resolveRestoreStatus(
   }
   if (report.restoredFiles.length > 0) {
     return "restored";
-  }
-  if (report.skippedFiles.length > 0) {
-    return "noop";
   }
   return "noop";
 }

--- a/src/commands/doctor-session-sqlite-retirement.ts
+++ b/src/commands/doctor-session-sqlite-retirement.ts
@@ -33,17 +33,6 @@ import {
 } from "./doctor-session-sqlite-verification.js";
 import { withDoctorSqliteMaintenanceLock } from "./doctor-sqlite-maintenance-lock.js";
 
-async function persistRetirementManifest(run: ActiveSessionSqliteMigrationRun): Promise<void> {
-  writeSessionSqliteMigrationManifest(run);
-  // Atomic replacement fsyncs the file but only best-effort syncs its parent.
-  // Require the shared commit policy: unsupported Windows directory sync is accepted;
-  // real I/O failures and unsupported sync elsewhere still prevent retirement.
-  requireDirectorySync(
-    await syncDirectory(path.dirname(run.manifestPath)),
-    "Recovery retirement manifest",
-  );
-}
-
 function assertRecoveryOriginal(archivePath: string, artifact: MigrationArtifact): void {
   const currentPath = statMigrationPath(archivePath)
     ? archivePath
@@ -240,7 +229,7 @@ export async function retireSessionSqliteRecovery(params: {
       }
       // Every referencing manifest is durable before the first artifact in this selection moves.
       for (const run of runs) {
-        await persistRetirementManifest(run);
+        writeSessionSqliteMigrationManifest(run);
       }
       let activeItem: (typeof selected)[number] | undefined;
       const claims = selected.map((item) => {
@@ -281,7 +270,7 @@ export async function retireSessionSqliteRecovery(params: {
         }
         // All claims, including their unlink intents, must survive a crash before disposal starts.
         for (const run of runs) {
-          await persistRetirementManifest(run);
+          writeSessionSqliteMigrationManifest(run);
         }
         for (const { item, artifact, disposal, present } of claims) {
           activeItem = item;
@@ -333,7 +322,7 @@ export async function retireSessionSqliteRecovery(params: {
             }
           }
           for (const run of new Set(refs.map((ref) => ref.run))) {
-            await persistRetirementManifest(run);
+            writeSessionSqliteMigrationManifest(run);
           }
         }
       } catch (error) {

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -1,5 +1,7 @@
 // Doctor session SQLite tests exercise real temp stores and per-agent SQLite files.
+import { execFileSync } from "node:child_process";
 import fs from "node:fs";
+import fsPromises from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
@@ -52,7 +54,7 @@ import { inspectSessionSqliteRecovery } from "./doctor-session-sqlite-recovery-i
 import { restoreSessionSqliteMigrationRun } from "./doctor-session-sqlite-restore.js";
 import { retireSessionSqliteRecovery } from "./doctor-session-sqlite-retirement.js";
 import { createDoctorSessionSqliteTargetReport } from "./doctor-session-sqlite-types.js";
-import { runDoctorSessionSqlite } from "./doctor-session-sqlite.js";
+import { runDoctorSessionSqlite, type DoctorSessionSqliteReport } from "./doctor-session-sqlite.js";
 import { withDoctorSqliteMaintenanceLock } from "./doctor-sqlite-maintenance-lock.js";
 import { doctorCommand } from "./doctor.js";
 
@@ -988,27 +990,23 @@ describe("runDoctorSessionSqlite", () => {
   it.each(["intent", "intent-sync", "claim", "unlink", "unlink-later", "receipt"])(
     "resumes retirement after a %s failure without overclaiming removed bytes",
     async (phase) => {
-      const { store, archivePath } = await createVerifiedRecoveryStore();
+      const { store, imported, archivePath } = await createVerifiedRecoveryStore();
+      const manifestDir = path.dirname(
+        requireMigrationManifestPath(imported.migrationRun?.manifestPath),
+      );
       const original = fs.readFileSync(archivePath);
       let injected = false;
       let claimUnlinks = 0;
       const write = replaceFile.replaceFileAtomicSync;
       const unlink = fs.unlinkSync;
-      const sync = directoryDurability.syncDirectory;
-      const syncSpy = vi
-        .spyOn(directoryDurability, "syncDirectory")
-        .mockImplementation(async (directory, options) => {
-          if (
-            !injected &&
-            phase === "intent-sync" &&
-            typeof directory === "string" &&
-            path.basename(directory) === "session-sqlite-migration-runs"
-          ) {
-            injected = true;
-            throw new Error("injected intent-sync");
-          }
-          return sync(directory, options);
-        });
+      const fsync = fs.fsyncSync;
+      const syncSpy = vi.spyOn(fs, "fsyncSync").mockImplementation((fd) => {
+        if (!injected && phase === "intent-sync" && isDirectoryDescriptor(fd, manifestDir)) {
+          injected = true;
+          throw new Error("injected intent-sync");
+        }
+        fsync(fd);
+      });
       const writeSpy = vi
         .spyOn(replaceFile, "replaceFileAtomicSync")
         .mockImplementation((options) => {
@@ -1087,28 +1085,25 @@ describe("runDoctorSessionSqlite", () => {
       const manifestPath = requireMigrationManifestPath(imported.migrationRun?.manifestPath);
       const original = fs.readFileSync(archivePath);
       const preview = inspectSessionSqliteRecovery({ cfg: {}, env: store.env });
-      const sync = directoryDurability.syncDirectory;
+      const fsync = fs.fsyncSync;
+      const failureCode =
+        syncFailure === "EIO" ? "EIO" : platform === "win32" ? "EPERM" : "ENOTSUP";
       const platformSpy = vi.spyOn(process, "platform", "get").mockReturnValue(platform);
-      const syncSpy = vi
-        .spyOn(directoryDurability, "syncDirectory")
-        .mockImplementation(async (directory, options) => {
-          if (directory !== path.dirname(manifestPath)) {
-            return sync(directory, options);
-          }
-          // Assert the persisted intent at the commit boundary, before any original moves.
-          const manifest = readMigrationManifest(manifestPath);
-          if (fs.existsSync(archivePath)) {
-            expect(
-              manifest.targets[0]?.completedMoves.find((move) => move.archivePath === archivePath)
-                ?.artifact?.disposal.state,
-            ).toBe("pending-disposal");
-            expect(fs.readFileSync(archivePath)).toEqual(original);
-          }
-          if (syncFailure === "EIO") {
-            throw Object.assign(new Error("injected manifest EIO"), { code: "EIO" });
-          }
-          return { status: "unsupported", code: platform === "win32" ? "EPERM" : "ENOTSUP" };
-        });
+      const syncSpy = vi.spyOn(fs, "fsyncSync").mockImplementation((fd) => {
+        if (!isDirectoryDescriptor(fd, path.dirname(manifestPath))) {
+          return fsync(fd);
+        }
+        // Assert the persisted intent at the commit boundary, before any original moves.
+        const manifest = readMigrationManifest(manifestPath);
+        if (fs.existsSync(archivePath)) {
+          expect(
+            manifest.targets[0]?.completedMoves.find((move) => move.archivePath === archivePath)
+              ?.artifact?.disposal.state,
+          ).toBe("pending-disposal");
+          expect(fs.readFileSync(archivePath)).toEqual(original);
+        }
+        throw Object.assign(new Error(`injected manifest ${failureCode}`), { code: failureCode });
+      });
       try {
         const cleanup = retireSessionSqliteRecovery({
           env: store.env,
@@ -1130,9 +1125,7 @@ describe("runDoctorSessionSqlite", () => {
             )?.artifact?.disposal.state,
           ).toBe("disposed");
         } else {
-          await expect(cleanup).rejects.toThrow(
-            syncFailure === "EIO" ? "injected manifest EIO" : "crash-durable",
-          );
+          await expect(cleanup).rejects.toThrow(`injected manifest ${failureCode}`);
           expect(fs.readFileSync(archivePath)).toEqual(original);
         }
       } finally {
@@ -1310,28 +1303,25 @@ describe("runDoctorSessionSqlite", () => {
       }
       expect(fs.statSync(databasePath, { bigint: true }).ino).toBe(before.ino);
     };
-    const sync = directoryDurability.syncDirectory;
-    const spy = vi
-      .spyOn(directoryDurability, "syncDirectory")
-      .mockImplementation(async (dir, opts) => {
-        const result = await sync(dir, opts);
-        if (!injected && phase !== "confirmation") {
-          const moves = readMigrationManifest(manifestPath).targets[0]!.completedMoves;
-          const atUnlink = moves.some(
-            (move) =>
-              move.artifact?.disposal.state === "pending-disposal" &&
-              move.artifact.disposal.phase === "unlink-pending",
-          );
-          if (
-            (phase === "publication" &&
-              dir === path.dirname(target.completedMoves[0]!.archivePath)) ||
-            (phase === "unlink-intent" && dir === path.dirname(manifestPath) && atUnlink)
-          ) {
-            mutate();
-          }
-        }
-        return result;
-      });
+    const mutateAfterSync = (directory: string) => {
+      if (injected || phase === "confirmation") {
+        return;
+      }
+      const moves = readMigrationManifest(manifestPath).targets[0]!.completedMoves;
+      const atUnlink = moves.some(
+        (move) =>
+          move.artifact?.disposal.state === "pending-disposal" &&
+          move.artifact.disposal.phase === "unlink-pending",
+      );
+      if (
+        (phase === "publication" &&
+          directory === path.dirname(target.completedMoves[0]!.archivePath)) ||
+        (phase === "unlink-intent" && directory === path.dirname(manifestPath) && atUnlink)
+      ) {
+        mutate();
+      }
+    };
+    const restoreSync = observeRecoveryDirectorySync(path.dirname(manifestPath), mutateAfterSync);
     try {
       const cleanup = retireSessionSqliteRecovery({
         env: store.env,
@@ -1365,7 +1355,7 @@ describe("runDoctorSessionSqlite", () => {
         expect(fs.readFileSync(retainedPath)).toEqual(originals[index]);
       }
     } finally {
-      spy.mockRestore();
+      restoreSync();
       writer?.close();
     }
   });
@@ -1405,39 +1395,35 @@ describe("runDoctorSessionSqlite", () => {
         target.completedMoves.map((move) => [move.archivePath, fs.readFileSync(move.archivePath)]),
       );
       let injected = false;
-      const sync = directoryDurability.syncDirectory;
-      const spy = vi
-        .spyOn(directoryDurability, "syncDirectory")
-        .mockImplementation(async (dir, opts) => {
-          const result = await sync(dir, opts);
-          const moves = readMigrationManifest(manifestPath).targets[0]!.completedMoves;
-          const atUnlink = moves.some(
-            (move) =>
-              move.artifact?.disposal.state === "pending-disposal" &&
-              move.artifact.disposal.phase === "unlink-pending",
+      const mutateAfterSync = (directory: string) => {
+        const moves = readMigrationManifest(manifestPath).targets[0]!.completedMoves;
+        const atUnlink = moves.some(
+          (move) =>
+            move.artifact?.disposal.state === "pending-disposal" &&
+            move.artifact.disposal.phase === "unlink-pending",
+        );
+        if (
+          !injected &&
+          ((phase === "intent-sync" && directory === path.dirname(manifestPath) && !atUnlink) ||
+            (phase === "publication" && directory === path.dirname(changed.archivePath)) ||
+            (phase === "unlink-intent" && directory === path.dirname(manifestPath) && atUnlink))
+        ) {
+          injected = true;
+          const move = expectDefined(
+            moves.find((mappedMove) => mappedMove.archivePath === changed.archivePath),
+            "changed transcript receipt",
           );
-          if (
-            !injected &&
-            ((phase === "intent-sync" && dir === path.dirname(manifestPath) && !atUnlink) ||
-              (phase === "publication" && dir === path.dirname(changed.archivePath)) ||
-              (phase === "unlink-intent" && dir === path.dirname(manifestPath) && atUnlink))
-          ) {
-            injected = true;
-            const move = expectDefined(
-              moves.find((mappedMove) => mappedMove.archivePath === changed.archivePath),
-              "changed transcript receipt",
-            );
-            const disposal = move.artifact!.disposal;
-            const file = fs.existsSync(move.archivePath)
-              ? move.archivePath
-              : disposal.state === "pending-disposal"
-                ? disposal.claimPath
-                : move.archivePath;
-            fs.appendFileSync(file, "unique late history\n");
-            originals.set(move.archivePath, fs.readFileSync(file));
-          }
-          return result;
-        });
+          const disposal = move.artifact!.disposal;
+          const file = fs.existsSync(move.archivePath)
+            ? move.archivePath
+            : disposal.state === "pending-disposal"
+              ? disposal.claimPath
+              : move.archivePath;
+          fs.appendFileSync(file, "unique late history\n");
+          originals.set(move.archivePath, fs.readFileSync(file));
+        }
+      };
+      const restoreSync = observeRecoveryDirectorySync(path.dirname(manifestPath), mutateAfterSync);
       const invoke = () =>
         retireSessionSqliteRecovery({
           env: store.env,
@@ -1451,7 +1437,7 @@ describe("runDoctorSessionSqlite", () => {
         expect(result.status).toBe("blocked");
         expect(result.totals.removedFiles).toBe(0);
       } finally {
-        spy.mockRestore();
+        restoreSync();
       }
       expect((await invoke()).totals.removedFiles).toBe(0);
       for (const move of readMigrationManifest(manifestPath).targets[0]!.completedMoves) {
@@ -3355,7 +3341,17 @@ describe("runDoctorSessionSqlite", () => {
   });
 
   it("streams duplicate large transcript archives while selecting an identical restore", async () => {
-    const store = createLegacyStore();
+    const transcriptLines = [
+      JSON.stringify({ type: "session", id: "session-1", version: 3 }),
+      JSON.stringify({
+        type: "message",
+        id: "large",
+        parentId: null,
+        message: { role: "user", content: "x".repeat(4 * 1024 * 1024) },
+      }),
+    ];
+    const largeTranscript = `${transcriptLines.join("\n")}\n`;
+    const store = createLegacyStore({ transcriptLines });
     const importReport = await runDoctorSessionSqlite({
       env: store.env,
       mode: "import",
@@ -3368,22 +3364,24 @@ describe("runDoctorSessionSqlite", () => {
       firstTarget.plannedMoves.find((move) => move.kind === "transcript"),
       "transcript archive move",
     );
-    const largeTranscript = `${JSON.stringify({
-      payload: "x".repeat(4 * 1024 * 1024),
-      type: "event",
-    })}\n`;
-    fs.writeFileSync(transcriptMove.archivePath, largeTranscript, { mode: 0o600 });
-
     const secondArchivePath = `${transcriptMove.archivePath}.duplicate`;
     fs.copyFileSync(transcriptMove.archivePath, secondArchivePath);
+    const duplicateMove = {
+      ...transcriptMove,
+      archivePath: secondArchivePath,
+      artifact: {
+        ...expectDefined(transcriptMove.artifact, "original transcript identity"),
+        identity: migrationArtifact.readMigrationArtifactIdentity(secondArchivePath),
+      },
+    };
     const duplicateManifest = structuredClone(firstManifest);
     duplicateManifest.runId = `${firstManifest.runId}-duplicate`;
     duplicateManifest.startedAt = new Date(Date.parse(firstManifest.startedAt) + 1).toISOString();
     duplicateManifest.targets = [
       {
         ...firstTarget,
-        completedMoves: [{ ...transcriptMove, archivePath: secondArchivePath }],
-        plannedMoves: [{ ...transcriptMove, archivePath: secondArchivePath }],
+        completedMoves: [duplicateMove],
+        plannedMoves: [duplicateMove],
       },
     ];
     const duplicateManifestPath = path.join(
@@ -3647,7 +3645,7 @@ describe("runDoctorSessionSqlite", () => {
     );
   });
 
-  it("rejects malformed restore manifests without throwing", () => {
+  it("rejects malformed restore manifests without throwing", async () => {
     const store = createLegacyStore();
     const manifestPath = path.join(store.tempDir, "malformed-manifest.json");
     fs.writeFileSync(
@@ -3660,7 +3658,7 @@ describe("runDoctorSessionSqlite", () => {
       { mode: 0o600 },
     );
 
-    const restore = restoreSessionSqliteMigrationRun({
+    const restore = await restoreSessionSqliteMigrationRun({
       manifestPath,
       trustedTargets: [trustedMigrationTarget(store)],
     });
@@ -3703,7 +3701,7 @@ describe("runDoctorSessionSqlite", () => {
     target.completedMoves = [unsafeMove];
     fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
 
-    const restore = restoreSessionSqliteMigrationRun({
+    const restore = await restoreSessionSqliteMigrationRun({
       manifestPath,
       trustedTargets: [trustedMigrationTarget(store)],
     });
@@ -3775,7 +3773,7 @@ describe("runDoctorSessionSqlite", () => {
     target.completedMoves = [rewrittenMove];
     fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
 
-    const restore = restoreSessionSqliteMigrationRun({
+    const restore = await restoreSessionSqliteMigrationRun({
       manifestPath,
       trustedTargets: [trustedMigrationTarget(store)],
     });
@@ -3857,7 +3855,7 @@ describe("runDoctorSessionSqlite", () => {
       target.completedMoves = [traversalMove];
       fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
 
-      const restore = restoreSessionSqliteMigrationRun({
+      const restore = await restoreSessionSqliteMigrationRun({
         manifestPath,
         trustedTargets: [trustedMigrationTarget(store)],
       });
@@ -3906,7 +3904,7 @@ describe("runDoctorSessionSqlite", () => {
       }
       fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`, { mode: 0o600 });
 
-      const restore = restoreSessionSqliteMigrationRun({
+      const restore = await restoreSessionSqliteMigrationRun({
         manifestPath,
         trustedTargets: [trustedMigrationTarget(store)],
       });
@@ -3989,7 +3987,7 @@ describe("runDoctorSessionSqlite", () => {
       fs.renameSync(agentDir, relocatedAgentDir);
       fs.symlinkSync(relocatedAgentDir, agentDir);
 
-      const restore = restoreSessionSqliteMigrationRun({
+      const restore = await restoreSessionSqliteMigrationRun({
         manifestPath,
         trustedTargets: [trustedMigrationTarget(store)],
       });
@@ -4033,7 +4031,7 @@ describe("runDoctorSessionSqlite", () => {
       fs.renameSync(agentDir, relocatedAgentDir);
       fs.symlinkSync(relocatedAgentDir, agentDir);
 
-      const restore = restoreSessionSqliteMigrationRun({
+      const restore = await restoreSessionSqliteMigrationRun({
         manifestPath,
         trustedTargets: [trustedMigrationTarget(store)],
       });
@@ -4076,7 +4074,7 @@ describe("runDoctorSessionSqlite", () => {
       fs.renameSync(store.sessionDir, relocatedSessionDir);
       fs.symlinkSync(relocatedSessionDir, store.sessionDir);
 
-      const restore = restoreSessionSqliteMigrationRun({
+      const restore = await restoreSessionSqliteMigrationRun({
         manifestPath,
         trustedTargets: [trustedMigrationTarget(store)],
       });
@@ -4120,7 +4118,7 @@ describe("runDoctorSessionSqlite", () => {
       fs.renameSync(archiveDir, relocatedArchiveDir);
       fs.symlinkSync(relocatedArchiveDir, archiveDir);
 
-      const restore = restoreSessionSqliteMigrationRun({
+      const restore = await restoreSessionSqliteMigrationRun({
         manifestPath,
         trustedTargets: [trustedMigrationTarget(store)],
       });
@@ -4162,7 +4160,7 @@ describe("runDoctorSessionSqlite", () => {
     fs.rmSync(move.archivePath);
     fs.symlinkSync(outsidePath, move.archivePath);
 
-    const restore = restoreSessionSqliteMigrationRun({
+    const restore = await restoreSessionSqliteMigrationRun({
       manifestPath,
       trustedTargets: [trustedMigrationTarget(store)],
     });
@@ -4252,6 +4250,540 @@ describe("runDoctorSessionSqlite", () => {
     });
     expect(fs.readFileSync(store.transcriptPath, "utf-8")).toBe('{"type":"event","id":"new"}\n');
   });
+
+  it.each(
+    (
+      [
+        { version: 1, destination: "file" },
+        { version: 2, destination: "file" },
+        { version: 1, destination: "dangling-symlink" },
+        { version: 2, destination: "dangling-symlink" },
+      ] as const
+    ).filter(({ destination }) => destination === "file" || process.platform !== "win32"),
+  )(
+    "preserves a late-created $destination during historical v$version restore without SQLite",
+    async ({ version, destination }) => {
+      const { store, manifestPath, manifest, archivePath } = createHistoricalRestoreStore(version);
+      const original = fs.readFileSync(archivePath);
+      const sourcePath = expectDefined(
+        manifest.targets
+          .flatMap((target) => target.plannedMoves)
+          .find((move) => move.archivePath === archivePath),
+        "transcript restore move",
+      ).sourcePath;
+      const competitorPath = path.join(store.tempDir, "competing-writer.jsonl");
+      const competitorContent = "history written by a separate process\n";
+      if (destination === "file") {
+        fs.writeFileSync(competitorPath, competitorContent, { mode: 0o600 });
+      }
+      let competitorIdentity: fs.BigIntStats | undefined;
+      const insertCompetitor = (from: fs.PathLike, to: fs.PathLike) => {
+        if (competitorIdentity || String(from) !== archivePath || String(to) !== sourcePath) {
+          return;
+        }
+        // Insert after every pathname guard, then forward the real publication syscall.
+        execFileSync(
+          process.execPath,
+          [
+            "-e",
+            `const fs = require("node:fs");
+             const [kind, candidate, target] = process.argv.slice(1);
+             if (kind === "file") fs.copyFileSync(candidate, target, fs.constants.COPYFILE_EXCL);
+             else fs.symlinkSync(candidate, target);`,
+            destination,
+            competitorPath,
+            sourcePath,
+          ],
+          { timeout: 10_000 },
+        );
+        competitorIdentity = fs.lstatSync(sourcePath, { bigint: true });
+      };
+      const rename = fs.renameSync;
+      const link = fsPromises.link;
+      const renameSpy = vi.spyOn(fs, "renameSync").mockImplementation((from, to) => {
+        insertCompetitor(from, to);
+        return rename(from, to);
+      });
+      const linkSpy = vi.spyOn(fsPromises, "link").mockImplementation(async (from, to) => {
+        insertCompetitor(from, to);
+        return link(from, to);
+      });
+      let result: Awaited<ReturnType<typeof runPublicSessionSqlite>>;
+      try {
+        result = await runPublicSessionSqlite(store, "restore");
+      } finally {
+        renameSpy.mockRestore();
+        linkSpy.mockRestore();
+      }
+      const created = expectDefined(competitorIdentity, "separate writer ran at publication");
+      const retained = fs.lstatSync(sourcePath, { bigint: true });
+      expect(retained.ino).toBe(created.ino);
+      expect(retained.dev).toBe(created.dev);
+      if (destination === "file") {
+        expect(fs.readFileSync(sourcePath, "utf8")).toBe(competitorContent);
+      } else {
+        expect(retained.isSymbolicLink()).toBe(true);
+        expect(fs.readlinkSync(sourcePath)).toBe(competitorPath);
+        expect(fs.existsSync(competitorPath)).toBe(false);
+      }
+      expect(fs.readFileSync(archivePath)).toEqual(original);
+      expect(result.exitCode).toBe(1);
+      const restored = readMigrationManifest(manifestPath).restore;
+      expect(restored?.conflicts).toEqual(
+        expect.arrayContaining([expect.objectContaining({ archivePath, sourcePath })]),
+      );
+      expect(restored?.consumedArchives ?? []).not.toContain(archivePath);
+      expect(restored?.restoredFiles ?? []).not.toContain(sourcePath);
+      for (const target of manifest.targets) {
+        expect(fs.existsSync(target.sqlitePath)).toBe(false);
+      }
+    },
+  );
+
+  it.each(
+    ([1, 2] as const).flatMap((version) =>
+      (["transcript", "legacy-store"] as const).map((kind) => ({ version, kind })),
+    ),
+  )(
+    "rejects a changed historical v$version $kind before adopting restore metadata",
+    async ({ version, kind }) => {
+      const { store, manifestPath, manifest } = createHistoricalRestoreStore(version);
+      const target = expectDefined(manifest.targets[0], "historical restore target");
+      const move = expectDefined(
+        target.plannedMoves.find((candidate) => candidate.kind === kind),
+        "selected historical archive",
+      );
+      const original = fs.readFileSync(move.archivePath, "utf8");
+      const changed = original.replace('"session-1"', '"session-2"');
+      expect(changed).not.toBe(original);
+      expect(Buffer.byteLength(changed)).toBe(Buffer.byteLength(original));
+      const identity = fs.statSync(move.archivePath, { bigint: true });
+      const duplicate = { ...move, archivePath: `${move.archivePath}.duplicate` };
+      fs.copyFileSync(move.archivePath, duplicate.archivePath);
+      target.plannedMoves.push(duplicate);
+      target.completedMoves.push({ ...duplicate });
+      fs.writeFileSync(manifestPath, `${JSON.stringify(manifest)}\n`, { mode: 0o600 });
+
+      const close = fs.closeSync;
+      let injected = false;
+      const closeSpy = vi.spyOn(fs, "closeSync").mockImplementation((fd) => {
+        const opened = fs.fstatSync(fd, { bigint: true });
+        close(fd);
+        if (!injected && opened.dev === identity.dev && opened.ino === identity.ino) {
+          // Change real bytes after the planner closes its verified descriptor, before adoption.
+          injected = true;
+          fs.writeFileSync(move.archivePath, changed);
+        }
+      });
+      let result: Awaited<ReturnType<typeof runPublicSessionSqlite>>;
+      try {
+        result = await runPublicSessionSqlite(store, "restore");
+      } finally {
+        closeSpy.mockRestore();
+      }
+      expect(injected).toBe(true);
+      expect(result.exitCode).toBe(1);
+      expect(result.report.targets[0]?.restore?.conflicts).toEqual([
+        {
+          archivePath: move.archivePath,
+          sourcePath: move.sourcePath,
+          reason: "archive changed after restore planning; refusing restore",
+        },
+      ]);
+      expect(fs.existsSync(move.sourcePath)).toBe(false);
+      expect(fs.readFileSync(move.archivePath, "utf8")).toBe(changed);
+      expect(fs.statSync(move.archivePath, { bigint: true }).ino).toBe(identity.ino);
+      expect(fs.readFileSync(duplicate.archivePath, "utf8")).toBe(original);
+      const recorded = readMigrationManifest(manifestPath);
+      expect(recorded.restore?.consumedArchives ?? []).not.toContain(move.archivePath);
+      expect(recorded.restore?.restoredFiles ?? []).not.toContain(move.sourcePath);
+      const recordedTarget = expectDefined(recorded.targets[0], "recorded historical target");
+      for (const moves of [recordedTarget.plannedMoves, recordedTarget.completedMoves]) {
+        const recordedMove = expectDefined(
+          moves.find((item) => item.archivePath === move.archivePath),
+          "recorded historical original",
+        );
+        expect(recordedMove.artifact).toBeUndefined();
+      }
+      expect(fs.existsSync(target.sqlitePath)).toBe(false);
+    },
+  );
+
+  it.each(
+    ([1, 2] as const).flatMap((version) =>
+      (["restore", "recover"] as const).map((retryMode) => ({ version, retryMode })),
+    ),
+  )(
+    "retries historical v$version restored-directory edge sync through $retryMode",
+    async ({ version, retryMode }) => {
+      const { store, manifestPath, manifest } = createHistoricalRestoreStore(version);
+      const target = expectDefined(manifest.targets[0], "historical restore target");
+      const originals = target.plannedMoves.map((move) => ({
+        ...move,
+        bytes: fs.readFileSync(move.archivePath),
+        identity: fs.statSync(move.archivePath, { bigint: true }),
+      }));
+      if (retryMode === "recover") {
+        manifest.failedAt = manifest.startedAt;
+        fs.writeFileSync(manifestPath, `${JSON.stringify(manifest)}\n`, { mode: 0o600 });
+      }
+      fs.rmdirSync(store.sessionDir);
+      const sourceParent = path.dirname(store.sessionDir);
+      const assertOriginalsRetained = () => {
+        expect(readMigrationManifest(manifestPath).restore?.consumedArchives ?? []).toEqual([]);
+        for (const original of originals) {
+          expect(fs.readFileSync(original.archivePath)).toEqual(original.bytes);
+          expect(fs.statSync(original.archivePath, { bigint: true }).ino).toBe(
+            original.identity.ino,
+          );
+          if (fs.existsSync(original.sourcePath)) {
+            expect(fs.readFileSync(original.sourcePath)).toEqual(original.bytes);
+            expect(fs.statSync(original.sourcePath, { bigint: true }).ino).toBe(
+              original.identity.ino,
+            );
+          }
+        }
+        for (const file of resolveSqliteDatabaseFilePaths(target.sqlitePath)) {
+          expect(fs.existsSync(file)).toBe(false);
+        }
+      };
+      const fsync = fs.fsyncSync;
+      let edgeSyncAttempted = false;
+      const syncSpy = vi.spyOn(fs, "fsyncSync").mockImplementation((fd) => {
+        if (isDirectoryDescriptor(fd, sourceParent)) {
+          edgeSyncAttempted = true;
+          throw Object.assign(new Error("injected restored-directory edge sync"), { code: "EIO" });
+        }
+        fsync(fd);
+      });
+      try {
+        const first = await runPublicSessionSqlite(store, "restore");
+        expect(edgeSyncAttempted).toBe(true);
+        expect(first.exitCode).toBe(1);
+        expect(first.report.targets[0]?.restore?.conflicts).toEqual(
+          expect.arrayContaining(
+            originals.map(({ archivePath, sourcePath }) =>
+              expect.objectContaining({ archivePath, sourcePath }),
+            ),
+          ),
+        );
+        expect(fs.statSync(store.sessionDir).isDirectory()).toBe(true);
+        assertOriginalsRetained();
+
+        edgeSyncAttempted = false;
+        await expect(runPublicSessionSqlite(store, retryMode)).rejects.toThrow(
+          "injected restored-directory edge sync",
+        );
+        expect(edgeSyncAttempted).toBe(true);
+        assertOriginalsRetained();
+      } finally {
+        syncSpy.mockRestore();
+      }
+      const resumed = await runPublicSessionSqlite(store, retryMode);
+      expect(resumed.report.targets[0]?.restore?.conflicts).toEqual([]);
+      const consumed = readMigrationManifest(manifestPath).restore?.consumedArchives;
+      expect(consumed).toHaveLength(originals.length);
+      expect(consumed).toEqual(expect.arrayContaining(originals.map((move) => move.archivePath)));
+      for (const original of originals) {
+        expect(fs.readFileSync(original.sourcePath)).toEqual(original.bytes);
+        expect(fs.statSync(original.sourcePath, { bigint: true }).ino).toBe(original.identity.ino);
+        expect(fs.existsSync(original.archivePath)).toBe(false);
+      }
+      for (const file of resolveSqliteDatabaseFilePaths(target.sqlitePath)) {
+        expect(fs.existsSync(file)).toBe(false);
+      }
+    },
+  );
+
+  it.each(
+    ([1, 2] as const).flatMap((version) =>
+      (
+        [
+          { phase: "metadata-write", retryMode: "restore" },
+          { phase: "metadata-sync", retryMode: "restore" },
+          { phase: "target-sync", retryMode: "recover" },
+          { phase: "receipt-write", retryMode: "restore" },
+          { phase: "receipt-sync", retryMode: "recover" },
+          { phase: "archive-unlink", retryMode: "restore" },
+          { phase: "archive-sync", retryMode: "recover" },
+        ] as const
+      ).map(({ phase, retryMode }) => ({ version, phase, retryMode })),
+    ),
+  )(
+    "resumes historical v$version index restore after $phase through $retryMode",
+    async ({ version, phase, retryMode }) => {
+      const { store, manifestPath, manifest } = createHistoricalRestoreStore(version);
+      const target = expectDefined(manifest.targets[0], "historical restore target");
+      const index = expectDefined(
+        target.plannedMoves.find((move) => move.kind === "legacy-store"),
+        "historical index original",
+      );
+      const originals = target.plannedMoves.map((move) => ({
+        ...move,
+        bytes: fs.readFileSync(move.archivePath),
+        identity: fs.statSync(move.archivePath, { bigint: true }),
+      }));
+      const indexOriginal = expectDefined(
+        originals.find((item) => item.kind === "legacy-store"),
+        "historical index bytes",
+      );
+      if (retryMode === "recover") {
+        manifest.failedAt = manifest.startedAt;
+        fs.writeFileSync(manifestPath, `${JSON.stringify(manifest)}\n`, { mode: 0o600 });
+      }
+      const manifestDir = path.dirname(manifestPath);
+      const sourceDir = path.dirname(index.sourcePath);
+      const archiveDir = path.dirname(index.archivePath);
+      let injected = false;
+      let replay = false;
+      let failReplaySync = false;
+      let replaySynced = false;
+      let replayUnlinked = false;
+      const hasReceipt = (candidate: SessionSqliteMigrationManifest) =>
+        candidate.restore?.consumedArchives?.includes(index.archivePath) === true;
+      const failManifestPhase = (
+        candidate: SessionSqliteMigrationManifest,
+        boundary: "write" | "sync",
+      ) => {
+        const recorded = candidate.targets
+          .flatMap((item) => item.plannedMoves)
+          .find((move) => move.archivePath === index.archivePath);
+        const expectedPhase = hasReceipt(candidate)
+          ? `receipt-${boundary}`
+          : `metadata-${boundary}`;
+        if (!injected && recorded?.artifact && phase === expectedPhase) {
+          injected = true;
+          throw new Error(`injected ${phase}`);
+        }
+      };
+      const write = replaceFile.replaceFileAtomicSync;
+      const writeSpy = vi
+        .spyOn(replaceFile, "replaceFileAtomicSync")
+        .mockImplementation((options) => {
+          if (options.filePath === manifestPath) {
+            failManifestPhase(
+              JSON.parse(String(options.content)) as SessionSqliteMigrationManifest,
+              "write",
+            );
+          }
+          return write(options);
+        });
+      const fsync = fs.fsyncSync;
+      const fsyncSpy = vi.spyOn(fs, "fsyncSync").mockImplementation((fd) => {
+        if (isDirectoryDescriptor(fd, manifestDir)) {
+          failManifestPhase(readMigrationManifest(manifestPath), "sync");
+        }
+        fsync(fd);
+      });
+      const open = fsPromises.open;
+      const restoreHandleSpies: Array<() => void> = [];
+      const openSpy = vi.spyOn(fsPromises, "open").mockImplementation(async (...args) => {
+        const handle = await open(...args);
+        if (phase === "target-sync" && String(args[0]) === sourceDir) {
+          const sync = handle.sync.bind(handle);
+          const handleSpy = vi.spyOn(handle, "sync").mockImplementation(async () => {
+            if (!injected && fs.existsSync(index.sourcePath) && fs.existsSync(index.archivePath)) {
+              injected = true;
+              throw Object.assign(new Error("injected target-sync"), { code: "EIO" });
+            }
+            return sync();
+          });
+          restoreHandleSpies.push(() => handleSpy.mockRestore());
+        }
+        return handle;
+      });
+      const sync = directoryDurability.syncDirectory;
+      const syncSpy = vi
+        .spyOn(directoryDurability, "syncDirectory")
+        .mockImplementation(async (directory, options) => {
+          const syncingPath = typeof directory === "string" ? directory : directory.path;
+          if (replay && syncingPath === sourceDir) {
+            if (failReplaySync) {
+              throw new Error("injected replay target-sync");
+            }
+            const result = await sync(directory, options);
+            replaySynced = true;
+            return result;
+          }
+          if (
+            !injected &&
+            phase === "archive-sync" &&
+            syncingPath === archiveDir &&
+            !fs.existsSync(index.archivePath)
+          ) {
+            injected = true;
+            throw new Error("injected archive-sync");
+          }
+          return sync(directory, options);
+        });
+      const unlink = fs.unlinkSync;
+      const unlinkSpy = vi.spyOn(fs, "unlinkSync").mockImplementation((file) => {
+        if (String(file) === index.archivePath) {
+          if (!injected && phase === "archive-unlink") {
+            injected = true;
+            throw new Error("injected archive-unlink");
+          }
+          if (replay) {
+            expect(replaySynced).toBe(true);
+            replayUnlinked = true;
+          }
+        }
+        return unlink(file);
+      });
+      const copySpy = vi.spyOn(fs, "copyFileSync");
+      const asyncCopySpy = vi.spyOn(fsPromises, "copyFile");
+      try {
+        const failed = await runPublicSessionSqlite(store, "restore");
+        expect(injected).toBe(true);
+        expect(failed.exitCode).toBe(1);
+        expect(failed.report.targets[0]?.restore?.conflicts).toEqual(
+          expect.arrayContaining([expect.objectContaining({ archivePath: index.archivePath })]),
+        );
+        const interrupted = readMigrationManifest(manifestPath);
+        const consumedBeforeRetry = interrupted.restore?.consumedArchives ?? [];
+        if (phase === "metadata-write" || phase === "metadata-sync") {
+          expect(fs.existsSync(index.sourcePath)).toBe(false);
+        } else {
+          expect(fs.readFileSync(index.sourcePath)).toEqual(indexOriginal.bytes);
+        }
+        if (phase !== "archive-sync") {
+          expect(fs.readFileSync(index.archivePath)).toEqual(indexOriginal.bytes);
+        }
+        if (phase === "archive-unlink" || phase === "archive-sync") {
+          expect(consumedBeforeRetry).toContain(index.archivePath);
+        }
+        replay = fs.existsSync(index.sourcePath) && fs.existsSync(index.archivePath);
+        if (phase === "target-sync") {
+          failReplaySync = true;
+          await expect(runPublicSessionSqlite(store, retryMode)).rejects.toThrow(
+            "injected replay target-sync",
+          );
+          expect(fs.statSync(index.sourcePath).nlink).toBe(2);
+          expect(fs.statSync(index.archivePath).ino).toBe(fs.statSync(index.sourcePath).ino);
+          expect(replayUnlinked).toBe(false);
+          failReplaySync = false;
+        }
+        const resumed = await runPublicSessionSqlite(store, retryMode);
+        expect(resumed.report.targets[0]?.restore?.conflicts).toEqual([]);
+        if (replay) {
+          expect(replaySynced).toBe(true);
+          expect(replayUnlinked).toBe(true);
+        }
+        replay = false;
+        const settled = readMigrationManifest(manifestPath);
+        expect(settled.manifestVersion).toBe(version);
+        expect(settled.restore?.consumedArchives).toEqual(
+          expect.arrayContaining(consumedBeforeRetry),
+        );
+        expect(settled.restore?.consumedArchives).toEqual(
+          expect.arrayContaining(originals.map((item) => item.archivePath)),
+        );
+        for (const original of originals) {
+          expect(fs.readFileSync(original.sourcePath)).toEqual(original.bytes);
+          expect(fs.statSync(original.sourcePath, { bigint: true }).ino).toBe(
+            original.identity.ino,
+          );
+          expect(fs.existsSync(original.archivePath)).toBe(false);
+        }
+        for (const file of resolveSqliteDatabaseFilePaths(target.sqlitePath)) {
+          expect(fs.existsSync(file)).toBe(false);
+        }
+        expect(copySpy).not.toHaveBeenCalled();
+        expect(asyncCopySpy).not.toHaveBeenCalled();
+        expect((await runPublicSessionSqlite(store, "import")).report.totals.issues).toBe(0);
+        expect(
+          (await runPublicSessionSqlite(store, "restore")).report.targets[0]?.restore?.conflicts,
+        ).toEqual([]);
+        expect(readMigrationManifest(manifestPath).restore?.consumedArchives).toEqual(
+          expect.arrayContaining(originals.map((item) => item.archivePath)),
+        );
+      } finally {
+        writeSpy.mockRestore();
+        fsyncSpy.mockRestore();
+        openSpy.mockRestore();
+        syncSpy.mockRestore();
+        unlinkSpy.mockRestore();
+        copySpy.mockRestore();
+        asyncCopySpy.mockRestore();
+        for (const restoreSpy of restoreHandleSpies) {
+          restoreSpy();
+        }
+      }
+    },
+  );
+
+  it.each([1, 2] as const)(
+    "protects historical v%s restore metadata and its retained transcript dependency from cleanup",
+    async (version) => {
+      const { store, manifestPath, manifest, archivePath } = createHistoricalRestoreStore(version);
+      const target = expectDefined(manifest.targets[0], "historical cleanup target");
+      const index = expectDefined(
+        target.plannedMoves.find((move) => move.kind === "legacy-store"),
+        "historical index",
+      );
+      const indexIdentity = migrationArtifact.readMigrationArtifactIdentity(index.archivePath);
+      const indexBytes = fs.readFileSync(index.archivePath);
+      const transcriptBytes = fs.readFileSync(archivePath);
+      fs.writeFileSync(store.transcriptPath, "new source history\n", { mode: 0o600 });
+      const link = fsPromises.link;
+      const linkSpy = vi.spyOn(fsPromises, "link").mockImplementation(async (from, to) => {
+        if (String(from) === index.archivePath && String(to) === index.sourcePath) {
+          throw Object.assign(new Error("injected unsupported hard link"), { code: "EXDEV" });
+        }
+        return link(from, to);
+      });
+      const copySpy = vi.spyOn(fs, "copyFileSync");
+      const asyncCopySpy = vi.spyOn(fsPromises, "copyFile");
+      try {
+        const failed = await runPublicSessionSqlite(store, "restore");
+        expect(failed.exitCode).toBe(1);
+        expect(failed.report.targets[0]?.restore?.conflicts).toEqual(
+          expect.arrayContaining([expect.objectContaining({ archivePath: index.archivePath })]),
+        );
+        expect(copySpy).not.toHaveBeenCalled();
+        expect(asyncCopySpy).not.toHaveBeenCalled();
+      } finally {
+        linkSpy.mockRestore();
+        copySpy.mockRestore();
+        asyncCopySpy.mockRestore();
+      }
+      const recorded = readMigrationManifest(manifestPath);
+      expect(recorded.manifestVersion).toBe(version);
+      const indexMoves = [
+        ...recorded.targets[0]!.plannedMoves,
+        ...recorded.targets[0]!.completedMoves,
+      ].filter((move) => move.archivePath === index.archivePath);
+      expect(indexMoves).toHaveLength(2);
+      for (const move of indexMoves) {
+        expect(move.artifact).toMatchObject({
+          classification: "protected",
+          disposal: { state: "retained" },
+          identity: indexIdentity,
+          dependencies: [canonicalTestPath(store.transcriptPath)],
+        });
+      }
+      const preview = inspectSessionSqliteRecovery({ cfg: {}, env: store.env });
+      expect(preview.artifacts.find((item) => item.path === index.archivePath)?.outcome).toBe(
+        "protected",
+      );
+      expect(preview.artifacts.find((item) => item.path === archivePath)).toMatchObject({
+        outcome: "protected",
+        reason: "retained-recovery-dependency",
+      });
+      const cleanup = await retireSessionSqliteRecovery({
+        env: store.env,
+        preview,
+        readConfig: async () => ({}),
+        confirm: async () => true,
+      });
+      expect(cleanup.totals.removedFiles).toBe(0);
+      expect(fs.readFileSync(index.archivePath)).toEqual(indexBytes);
+      expect(fs.readFileSync(archivePath)).toEqual(transcriptBytes);
+      expect(fs.readFileSync(store.transcriptPath, "utf8")).toBe("new source history\n");
+      expect(fs.existsSync(index.sourcePath)).toBe(false);
+      expect(fs.existsSync(target.sqlitePath)).toBe(false);
+    },
+  );
 
   it("recovers the latest failed migration run and prepares a sanitized GitHub issue", async () => {
     const store = createLegacyStore({ agentDirName: "token=supersecret" });
@@ -5598,24 +6130,130 @@ function createCanonicalCacheIndexDrift(sqlitePath: string): void {
   }
 }
 
-async function createVerifiedRecoveryStore(transcriptLines?: string[]) {
-  const store = createLegacyStore({
-    transcriptLines: transcriptLines ?? [
-      JSON.stringify({
-        type: "session",
-        id: "session-1",
-        version: 3,
-        timestamp: "2026-08-30T00:00:00Z",
-        cwd: "/fixture",
-      }),
-      JSON.stringify({
-        type: "message",
-        id: "one",
-        parentId: null,
-        message: { role: "user", content: "preserved history" },
-      }),
-    ],
+const RECOVERY_TRANSCRIPT_LINES = [
+  JSON.stringify({
+    type: "session",
+    id: "session-1",
+    version: 3,
+    timestamp: "2026-08-30T00:00:00Z",
+    cwd: "/fixture",
+  }),
+  JSON.stringify({
+    type: "message",
+    id: "one",
+    parentId: null,
+    message: { role: "user", content: "preserved history" },
+  }),
+];
+
+function createHistoricalRestoreStore(version: 1 | 2) {
+  const store = createLegacyStore({ transcriptLines: RECOVERY_TRANSCRIPT_LINES });
+  const archiveDir = path.join(path.dirname(store.sessionDir), "session-sqlite-import-archive");
+  const runsDir = path.join(store.stateDir, "session-sqlite-migration-runs");
+  fs.mkdirSync(archiveDir, { recursive: true, mode: 0o700 });
+  fs.mkdirSync(runsDir, { recursive: true, mode: 0o700 });
+  // Model the historical on-disk contract directly; the current importer is not fixture setup.
+  const moves = (
+    [
+      ["transcript", store.transcriptPath],
+      ["trajectory", store.trajectoryPath],
+      ["unreferenced-jsonl", store.unreferencedJsonlPath],
+      ["legacy-store", store.storePath],
+    ] as const
+  ).map(([kind, sourcePath]) => {
+    const archivePath = path.join(archiveDir, `${kind}.${path.basename(sourcePath)}.imported-1`);
+    fs.renameSync(sourcePath, archivePath);
+    return { kind, sourcePath, archivePath };
   });
+  const manifest: SessionSqliteMigrationManifest = {
+    manifestVersion: version,
+    openClawVersion: "test",
+    runId: `historical-v${version}`,
+    startedAt: "2026-08-30T00:00:00.000Z",
+    completedAt: "2026-08-30T00:00:01.000Z",
+    targets: [
+      {
+        ...trustedMigrationTarget(store),
+        plannedMoves: moves,
+        completedMoves: structuredClone(moves),
+        issues: [],
+        validationBeforeArchive: "passed",
+      },
+    ],
+  };
+  const manifestPath = path.join(runsDir, `${manifest.runId}.json`);
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest)}\n`, { mode: 0o600 });
+  const archivePath = expectDefined(
+    moves.find((move) => move.kind === "transcript"),
+    "historical transcript archive",
+  ).archivePath;
+  return { store, manifestPath, manifest, archivePath };
+}
+
+async function runPublicSessionSqlite(store: TestStore, mode: "import" | "restore" | "recover") {
+  let exitCode: number | undefined;
+  const runtime = {
+    log: vi.fn(),
+    error: vi.fn(),
+    exit: vi.fn((code: number): never => {
+      exitCode = code;
+      throw new ExitError(code);
+    }),
+  };
+  try {
+    await doctorCommand(runtime, {
+      sessionSqlite: mode,
+      sessionSqliteStore: store.storePath,
+      json: true,
+    });
+  } catch (error) {
+    if (!(error instanceof ExitError)) {
+      throw error;
+    }
+  }
+  const output = expectDefined(runtime.log.mock.calls.at(-1)?.[0], "Doctor JSON report");
+  return {
+    exitCode: expectDefined(exitCode, "Doctor exit code"),
+    report: JSON.parse(String(output)) as DoctorSessionSqliteReport,
+  };
+}
+
+function observeRecoveryDirectorySync(
+  manifestDir: string,
+  onSynced: (directory: string) => void,
+): () => void {
+  const sync = directoryDurability.syncDirectory;
+  const asyncSpy = vi
+    .spyOn(directoryDurability, "syncDirectory")
+    .mockImplementation(async (directory, options) => {
+      const result = await sync(directory, options);
+      onSynced(typeof directory === "string" ? directory : directory.path);
+      return result;
+    });
+  const fsync = fs.fsyncSync;
+  const syncSpy = vi.spyOn(fs, "fsyncSync").mockImplementation((fd) => {
+    fsync(fd);
+    if (isDirectoryDescriptor(fd, manifestDir)) {
+      onSynced(manifestDir);
+    }
+  });
+  return () => {
+    asyncSpy.mockRestore();
+    syncSpy.mockRestore();
+  };
+}
+
+function isDirectoryDescriptor(fd: number, directory: string): boolean {
+  const opened = fs.fstatSync(fd);
+  if (!opened.isDirectory()) {
+    return false;
+  }
+  const expected = fs.statSync(directory);
+  return opened.dev === expected.dev && opened.ino === expected.ino;
+}
+
+async function createVerifiedRecoveryStore(transcriptLines = RECOVERY_TRANSCRIPT_LINES) {
+  const store = createLegacyStore({ transcriptLines });
   const imported = await runDoctorSessionSqlite({
     env: store.env,
     mode: "import",

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -143,7 +143,7 @@ export async function runDoctorSessionSqlite(
     });
   }
   if (options.mode === "import") {
-    reconcileSessionSqliteMigrationPublications({
+    await reconcileSessionSqliteMigrationPublications({
       env,
       trustedTargets: targets.map(createMigrationTargetInput),
     });
@@ -191,10 +191,10 @@ export async function runDoctorSessionSqlite(
 }
 
 /** Called only under the public maintenance lock, before its strict alias recheck. */
-export function reconcileDoctorSessionSqlitePublication(
+export async function reconcileDoctorSessionSqlitePublication(
   options: DoctorSessionSqliteOptions,
   sourcePath: string,
-): void {
+): Promise<void> {
   const env = options.env ?? process.env;
   const cfg = resolveDoctorSessionSqliteConfig(options);
   const targets = resolveDoctorSessionSqliteTargets({ ...options, cfg, env });
@@ -203,7 +203,7 @@ export function reconcileDoctorSessionSqlitePublication(
     resolveDoctorSessionSqliteMaintenancePaths(targets),
     resolveDoctorSessionSqliteMaintenanceRoots(targets, env),
   );
-  reconcileSessionSqliteMigrationPublications({
+  await reconcileSessionSqliteMigrationPublications({
     env,
     sourcePath,
     trustedTargets: targets.map(createMigrationTargetInput),

--- a/src/commands/doctor-sqlite-maintenance-lock.ts
+++ b/src/commands/doctor-sqlite-maintenance-lock.ts
@@ -48,12 +48,12 @@ export class DoctorSqliteMaintenanceLockUnavailableError extends Error {
   }
 }
 
-function assertMaintenancePathsOwnedByStateDir(
+async function assertMaintenancePathsOwnedByStateDir(
   env: NodeJS.ProcessEnv,
   operation: string,
   protectedPaths: readonly string[],
-  reconcileHardlink?: (filePath: string) => void,
-): void {
+  reconcileHardlink?: (filePath: string) => Promise<void>,
+): Promise<void> {
   if (protectedPaths.length === 0) {
     return;
   }
@@ -78,12 +78,19 @@ function assertMaintenancePathsOwnedByStateDir(
       );
     }
   }
-  assertDoctorSqliteMaintenancePathsNotAliased(
-    operation,
-    protectedPaths,
-    [stateDir],
-    reconcileHardlink,
-  );
+  if (reconcileHardlink) {
+    for (const protectedPath of new Set(
+      protectedPaths.map((candidate) => path.resolve(candidate)),
+    )) {
+      const stat = inspectMaintenancePath(operation, protectedPath, [stateDir]);
+      if (stat?.isFile() && stat.nlink > 1) {
+        await reconcileHardlink(protectedPath);
+      }
+    }
+  }
+  // Reconciliation can await durable publication. Recheck every path afterward under the
+  // same state lock; repairing a recorded alias never permits maintenance of other aliases.
+  assertDoctorSqliteMaintenancePathsNotAliased(operation, protectedPaths, [stateDir]);
 }
 
 /** Reject file aliases that destructive SQLite maintenance would mutate in place. */
@@ -91,38 +98,39 @@ export function assertDoctorSqliteMaintenancePathsNotAliased(
   operation: string,
   protectedPaths: readonly string[],
   ownershipRoots: readonly string[] = [],
-  reconcileHardlink?: (filePath: string) => void,
 ): void {
   const resolvedRoots = ownershipRoots.map((candidate) => path.resolve(candidate));
   for (const protectedPath of new Set(protectedPaths.map((candidate) => path.resolve(candidate)))) {
-    assertPathComponentsNotSymbolicLinks(operation, protectedPath, resolvedRoots);
-    let stat: fs.Stats;
-    try {
-      stat = fs.lstatSync(protectedPath);
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
-        continue;
-      }
-      throw error;
-    }
-    if (stat.isSymbolicLink()) {
-      throw new Error(
-        `Cannot run ${operation} for a symbolic-link path: ${protectedPath}. Replace the symbolic link with an owned regular file and retry.`,
-      );
-    }
-    if (stat.isFile() && stat.nlink > 1 && reconcileHardlink) {
-      // Owner reconciliation may remove only its recorded publication alias. Every path still
-      // passes the ordinary guard afterward; this is not permission to maintain aliased files.
-      reconcileHardlink(protectedPath);
-      assertPathComponentsNotSymbolicLinks(operation, protectedPath, resolvedRoots);
-      stat = fs.lstatSync(protectedPath);
-    }
-    if (stat.isSymbolicLink() || (stat.isFile() && stat.nlink > 1)) {
+    const stat = inspectMaintenancePath(operation, protectedPath, resolvedRoots);
+    if (stat?.isFile() && stat.nlink > 1) {
       throw new Error(
         `Cannot run ${operation} for a hard-linked path: ${protectedPath}. Remove the additional hard link and retry.`,
       );
     }
   }
+}
+
+function inspectMaintenancePath(
+  operation: string,
+  protectedPath: string,
+  ownershipRoots: readonly string[],
+): fs.Stats | undefined {
+  assertPathComponentsNotSymbolicLinks(operation, protectedPath, ownershipRoots);
+  let stat: fs.Stats;
+  try {
+    stat = fs.lstatSync(protectedPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return undefined;
+    }
+    throw error;
+  }
+  if (stat.isSymbolicLink()) {
+    throw new Error(
+      `Cannot run ${operation} for a symbolic-link path: ${protectedPath}. Replace the symbolic link with an owned regular file and retry.`,
+    );
+  }
+  return stat;
 }
 
 function assertPathComponentsNotSymbolicLinks(
@@ -165,7 +173,7 @@ export async function withDoctorSqliteMaintenanceLock<T>(
     env?: NodeJS.ProcessEnv;
     operation: string;
     protectedPaths?: readonly string[];
-    reconcileHardlink?: (filePath: string) => void;
+    reconcileHardlink?: (filePath: string) => Promise<void>;
     run: (authority: DoctorSqliteMaintenanceAuthority) => Promise<T> | T;
   },
   deps: DoctorSqliteMaintenanceLockDeps = {},
@@ -195,7 +203,7 @@ export async function withDoctorSqliteMaintenanceLock<T>(
 
   let active = true;
   try {
-    assertMaintenancePathsOwnedByStateDir(
+    await assertMaintenancePathsOwnedByStateDir(
       env,
       params.operation,
       params.protectedPaths ?? [],

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -76,6 +76,8 @@ export async function doctorCommand(runtime?: RuntimeEnv, options?: DoctorOption
       ...(options.sessionSqliteAllAgents ? { allAgents: true } : {}),
     };
     const runSessionSqlite = async () => await runDoctorSessionSqlite(sessionSqliteOptions);
+    const reconcileHardlink = (filePath: string) =>
+      reconcileDoctorSessionSqlitePublication(sessionSqliteOptions, filePath);
     const report = isDestructiveDoctorSessionSqliteMode(sessionSqliteMode)
       ? await withDoctorSqliteMaintenanceLock({
           env: process.env,
@@ -83,12 +85,7 @@ export async function doctorCommand(runtime?: RuntimeEnv, options?: DoctorOption
           ...(options.sessionSqliteStore
             ? { protectedPaths: resolveExplicitSessionSqliteMaintenancePaths(options) }
             : {}),
-          ...(sessionSqliteMode === "import" || sessionSqliteMode === "restore"
-            ? {
-                reconcileHardlink: (filePath: string) =>
-                  reconcileDoctorSessionSqlitePublication(sessionSqliteOptions, filePath),
-              }
-            : {}),
+          ...(sessionSqliteMode !== "compact" ? { reconcileHardlink } : {}),
           run: runSessionSqlite,
         })
       : await runSessionSqlite();


### PR DESCRIPTION
## What Problem This Solves

Doctor could overwrite a file independently copied into a restore destination while it was verifying an archive, then report success and record the archive as consumed. The same race replaced a dangling destination symlink. The maintenance lock excludes cooperating Doctor/Gateway processes, not independent filesystem operations. Installed stable `2026.8.1` reproduced all eight historical-manifest/index/transcript collision cases before the repair.

This is now a **Doctor-only** follow-up to [PR #133864 — retained migration recovery cleanup](https://github.com/openclaw/openclaw/pull/133864), merged as [78d2d914db75](https://github.com/openclaw/openclaw/commit/78d2d914db75e310bb7dfc4ca2d680c137ce9aa4). That dependency, its separately repaired local recovery-path projection, and the provider diagnostics repair already on main are not replayed in this PR.

## Why This Change Was Made

Ordinary restore and interrupted-publication reconciliation use the canonical `moveMigrationArtifact` owner. Its fs-safe `link-required` publication creates the destination exclusively and never copies raw history. The owner verifies identity and content, records a durable consumption receipt through a synchronous callback, and only then removes the archive. Preserved publications synchronize their target directory again on retry. The manifest writer owns strict directory synchronization; retirement's duplicate persistence wrapper is removed.

Historical v1/v2 manifests receive already-supported **protected**, retained identity metadata before publication without changing their versions or granting cleanup eligibility. Filesystem reconciliation no longer requires the replacement SQLite database; destructive cleanup retains its separate current-database ownership/content verifier. Reconciliation remains under the maintenance lock, followed by a synchronous recheck of protected paths. Recreated sessions directories repeat their parent durability check before consumption, including when a failed attempt already created the directory.

Simplification removes the selected duplicate archive's redundant full read/hash and index parse while retaining fresh publication-time content verification. Historical fixtures construct their original manifests directly rather than importing SQLite only to delete it. A second destination-existence check cannot reserve a pathname; a full-file copy adds unnecessary raw-history I/O. Neither is retained as an alternative publication path.

## User Impact

Independently created files and symlinks remain untouched, archived originals remain available, and Doctor reports a conflict with exit `1` instead of false success. Interrupted restores can be retried without copying history, including v1/v2 manifests and missing replacement databases. Duplicate selection, cumulative consumed-generation receipts, restore/reimport behavior, and cleanup protection remain covered.

There are **no SQLite schema, manifest-version, configuration, dependency-version, or CLI-flag changes** in this main-bound delta. No operator-owned Gateway or state was accessed or changed. Documentation: [Doctor](https://docs.openclaw.ai/cli/doctor).

## Evidence

Current candidate: [adbb0831f663](https://github.com/openclaw/openclaw/commit/adbb0831f663fa14dcdcfc07b173f6bb2402544b), based on main `ace8a13f19ccc2805b3d458026de3ab4bbbd8878`. The production build and **248 focused tests across four files** passed. The first changed gate exposed six inherited Gateway fixture type errors; [PR #134207 — Gateway fixture lint/types repair](https://github.com/openclaw/openclaw/pull/134207) had already fixed them upstream. This candidate incorporates that main checkpoint with every changed Doctor file byte-identical to the reviewed and tested integration. The full changed gate subsequently **passed** on this head. [Exact-head CI — run 33412665798](https://github.com/openclaw/openclaw/actions/runs/33412665798) completed **successfully**, and the fresh installed proof below passed.

Production **+199/−199 (net zero)**, tests **+771/−133**, docs **+10/−3**, across **11 files**. No provider source, worker harness, schema, lockfile, baseline, suppression, or test-only production seam is added.

Focused local verification uses the repository runners with isolated HOME/state:

```bash
pnpm build
```

```bash
node scripts/run-vitest.mjs src/commands/doctor-session-sqlite.test.ts src/commands/doctor-sqlite-maintenance-lock.test.ts src/commands/doctor.test.ts src/infra/fs-safe-import-boundary.test.ts
```

```bash
node scripts/check-changed.mjs -- docs/cli/doctor.md src/commands/doctor-session-sqlite-artifact.ts src/commands/doctor-session-sqlite-migration-run.ts src/commands/doctor-session-sqlite-recover-report.ts src/commands/doctor-session-sqlite-restore-report.ts src/commands/doctor-session-sqlite-restore.ts src/commands/doctor-session-sqlite-retirement.ts src/commands/doctor-session-sqlite.test.ts src/commands/doctor-session-sqlite.ts src/commands/doctor-sqlite-maintenance-lock.ts src/commands/doctor.ts
```

Fresh independent Codex autoreview of the complete main-bound Doctor delta completed **scoped-clean at P0**, with caller and dependency-contract evidence. Source regressions demonstrated the overwrite and interrupted-durability failures before repair; retained coverage exercises late file/symlink creation, metadata/publication/receipt/unlink failures, missing replacement databases, historical generations, and repeated parent-directory synchronization failure through public Doctor restore/recover entry points.

### Installed CLI proof

The previous installed candidate [7a79631e353f](https://github.com/openclaw/openclaw/commit/7a79631e353f8bc04cb6172063921a4b9b530e8f) passed **17 candidate cases**, while stable `2026.8.1` produced all **12 expected baseline outcomes**, including eight overwrite/false-success reproductions. That proof used Blacksmith Testbox `tbx_01m1c02kbtpx6hp8zynqh931vj`, [run 33397114446 — installed restore proof](https://github.com/openclaw/openclaw/actions/runs/33397114446); the owned lease was stopped and verified completed. All changed Doctor runtime/test files in this integration are byte-identical to that candidate, but this is prior-head evidence, not a claim of new-head execution.

**Fresh installed proof on the final main-bound commit passed all 17 candidate cases and all 12 expected stable outcomes.** Blacksmith Testbox `tbx_01m1c9k17jwb3sj127zdk8q8dj`, [run 33412972034 — main-bound installed restore proof](https://github.com/openclaw/openclaw/actions/runs/33412972034), used Node 24.19.0 and source-pinned pnpm 12.1.0. The lease was stopped in `finally`, with stop/status exit `0` and terminal `completed` verified.

Local and remote HEAD matched `adbb0831f663fa14dcdcfc07b173f6bb2402544b`. All 31,434 selected runtime/package/doc source inputs matched SHA-256 `2e128b9739d3d6569e0c0ab00489f1ec2f367d9dc28eef92cee379a981bd1bb5` before and after off-path packaging. Candidate tarball SHA-256: `800793401bc0861a63284de1c155e3b02bf5dda26dda9e41df703829353161c8` (62,503,758 bytes). Evidence archive SHA-256: `1153de101ab04d22f68da531618342001279308923355641ae17d9c2a033e446`.

The 39 scenario CLI invocations proved:

- v1/v2 ordinary and missing-directory restore;
- v1/v2 transcript/index × competing regular-file/dangling-symlink publication;
- four real restore process kills followed by fresh retries with the replacement database absent;
- a real interrupted import from an old-machine path, readable retry manifest, cleanup retention, byte-exact original-inode restore, and complete reimport/cleanup of exactly two originals.

All scenarios use synthetic files and isolated homes/state, neutral working directories, and explicit environment allowlists. Installed interruption proof uses external process observation and termination, not substituted syscalls or fabricated receipts/locks. It is not physical power-cut testing. Standalone artifact hosting is unavailable because the configured broker has no upload backend; inspected evidence and drivers are retained locally, with compact results and source/package identities recorded on the PR.

### Dependency contract and review follow-through

The lead personally inspected installed fs-safe `0.5.6` source/types: `publish-file.js:189–364` (especially the `link-required` no-copy branch and preserved sync failures) and `directory-durability.js:104–117,162–199,230–299` (strict synchronization and existing-directory retry behavior). The hard-link publisher leaves source removal to its caller. No dependency patch or version change is involved.

The current-head ClawSweeper review at 16:20 UTC reports **no actionable findings**. Its rank-up moves request exact-head CI and direct fs-safe contract confirmation: both are now satisfied, including a fresh personal read of the installed 0.5.6 implementation before landing. The earlier provider-policy slice was completely removed; canonical main remains verbatim. The former SQLite-table warning described the old stacked dependency diff: this 11-file delta contains no persisted-table change. Historical v1/v2 and current import/restore/cleanup flows have installed compatibility proof.

Native review setup exposed a separate wrapper-materialization omission already tracked by [PR #134196 — trusted PR helper closure](https://github.com/openclaw/openclaw/pull/134196). Using the unchanged wrapper from a clean main-pinned checkout resolved setup without bypassing any guard or changing this PR.

> **Close-study reminder:** inspect publication → durable consumption receipt → archive removal, historical manifest protection, and filesystem-only restore versus SQLite-verified cleanup ownership before landing. No auto-merge has been enabled.
