### PR TITLE
refactor(plugins): share LLM completion error construction

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3561,8 +3561,8 @@ src/plugins/runtime/channel-runtime-contexts.ts	1
 src/plugins/runtime/index.ts	1
 src/plugins/runtime/runtime-agent.ts	1
 src/plugins/runtime/runtime-channel.ts	1
-src/plugins/runtime/runtime-llm-isolated.ts	4
-src/plugins/runtime/runtime-llm.runtime.ts	5
+src/plugins/runtime/runtime-llm-isolated.ts	3
+src/plugins/runtime/runtime-llm.runtime.ts	4
 src/plugins/runtime/runtime-plugin-boundary.ts	2
 src/plugins/runtime/runtime-taskflow.ts	1
 src/plugins/runtime/runtime-web-channel-plugin.ts	3

--- a/src/plugins/runtime/runtime-llm-error.test.ts
+++ b/src/plugins/runtime/runtime-llm-error.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import { createLlmCompleteError } from "./runtime-llm-error.js";
+
+describe("createLlmCompleteError", () => {
+  it("creates a plain Error with the stable completion error fields and cause", () => {
+    const cause = new Error("provider failed");
+    const error = createLlmCompleteError("LLM_COMPLETION_FAILED", "Completion failed.", cause);
+
+    expect(Object.getPrototypeOf(error)).toBe(Error.prototype);
+    expect(error).toMatchObject({
+      name: "LlmCompleteError",
+      code: "LLM_COMPLETION_FAILED",
+      message: "Completion failed.",
+      cause,
+    });
+    expect(error.cause).toBe(cause);
+  });
+
+  it("omits the cause property when no cause is supplied", () => {
+    const error = createLlmCompleteError("LLM_COMPLETION_ABORTED", "Completion aborted.");
+
+    expect(Object.hasOwn(error, "cause")).toBe(false);
+  });
+});

--- a/src/plugins/runtime/runtime-llm-error.ts
+++ b/src/plugins/runtime/runtime-llm-error.ts
@@ -1,0 +1,12 @@
+import type { LlmCompleteErrorCode } from "./types-core.js";
+
+export function createLlmCompleteError(
+  code: LlmCompleteErrorCode,
+  message: string,
+  cause?: unknown,
+): Error & { code: LlmCompleteErrorCode } {
+  return Object.assign(new Error(message, cause === undefined ? undefined : { cause }), {
+    name: "LlmCompleteError",
+    code,
+  });
+}

--- a/src/plugins/runtime/runtime-llm-isolated.ts
+++ b/src/plugins/runtime/runtime-llm-isolated.ts
@@ -5,26 +5,10 @@ import { buildConfiguredModelCatalog } from "../../agents/model-selection-shared
 import { resolveEffectiveAgentRuntime } from "../../agents/thinking-runtime.js";
 import { resolveThinkingProfile } from "../../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type {
-  LlmCompleteErrorCode,
-  LlmCompleteParams,
-  LlmIsolatedAgentRuntimeCompleteParams,
-} from "./types-core.js";
+import { createLlmCompleteError as completionError } from "./runtime-llm-error.js";
+import type { LlmCompleteParams, LlmIsolatedAgentRuntimeCompleteParams } from "./types-core.js";
 
 const MAX_TIMER_DELAY_MS = 2_147_483_647;
-
-function completionError(
-  code: LlmCompleteErrorCode,
-  message: string,
-  cause?: unknown,
-): Error & { code: LlmCompleteErrorCode } {
-  const error = new Error(message, cause === undefined ? undefined : { cause }) as Error & {
-    code: LlmCompleteErrorCode;
-  };
-  error.name = "LlmCompleteError";
-  error.code = code;
-  return error;
-}
 
 function requireIsolatedUserPrompt(params: LlmCompleteParams): string {
   if (

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -24,6 +24,7 @@ import {
 } from "../../utils/usage-format.js";
 import { normalizePluginsConfig } from "../config-state.js";
 import { getPluginRuntimeGatewayRequestScope } from "./gateway-request-scope.js";
+import { createLlmCompleteError as completionError } from "./runtime-llm-error.js";
 import {
   assertSupportedExecutionMode,
   isIsolatedAgentRuntimeRequest,
@@ -31,7 +32,6 @@ import {
 } from "./runtime-llm-isolated.js";
 import type {
   LlmCompleteCaller,
-  LlmCompleteErrorCode,
   LlmCompleteParams,
   LlmCompleteResult,
   LlmCompleteUsage,
@@ -100,19 +100,6 @@ function normalizeCaller(
     ...(normalizeOptionalString(source.id) ? { id: source.id!.trim() } : {}),
     ...(normalizeOptionalString(source.name) ? { name: source.name!.trim() } : {}),
   };
-}
-
-function completionError(
-  code: LlmCompleteErrorCode,
-  message: string,
-  cause?: unknown,
-): Error & { code: LlmCompleteErrorCode } {
-  const error = new Error(message, cause === undefined ? undefined : { cause }) as Error & {
-    code: LlmCompleteErrorCode;
-  };
-  error.name = "LlmCompleteError";
-  error.code = code;
-  return error;
 }
 
 function resolveTrustedCaller(authority?: RuntimeLlmAuthority): LlmCompleteCaller {


### PR DESCRIPTION
## What Problem This Solves

Direct and isolated plugin LLM completion paths independently owned the same error construction policy. Keeping the error identity and optional-cause semantics duplicated made future drift possible across two halves of the same runtime boundary.

## Why This Change Was Made

This moves LLM completion error construction into one internal runtime leaf and routes both consumers through it. The helper remains private to the plugin runtime: there is no barrel or public Plugin SDK export.

The exact behavior is preserved:

- plain `Error` prototype
- `name` set to `LlmCompleteError`
- stable completion error `code` and message
- supplied cause identity retained
- no own `cause` property when cause is omitted

Open overlap was refreshed before implementation. https://github.com/openclaw/openclaw/pull/80967 and https://github.com/openclaw/openclaw/pull/111901 touch the broad runtime file but not this constructor. https://github.com/openclaw/openclaw/pull/111175 changes the neighboring usage import block only; no constructor-body conflict exists.

## User Impact

No user-visible or provider behavior change. Direct and isolated plugin completions now share one internal error identity owner.

## Evidence

- Focused runtime/plugin tests: 100 passed across the new helper contract, direct runtime, isolated runtime, diagnostics, and `llm-task`
- `pnpm test:contracts:plugins`: 1,111 passed
- `pnpm check:changed`: passed
- `pnpm check:import-cycles`: 0 runtime value cycles
- `git diff --check`: passed
- Pinned Sol/high autoreview: clean, 0.99
- Production LOC: +15/-32, net -17
- Test LOC: +24/-0
- Ratchet tooling LOC: +2/-2
