### PR TITLE
test(ui): classify workspace icon fetch failures

### DIFF
--- a/src/shared/pid-alive.ts
+++ b/src/shared/pid-alive.ts
@@ -1,7 +1,7 @@
 // PID liveness helpers check whether process ids still refer to active processes.
 import childProcess from "node:child_process";
 import fsSync from "node:fs";
-import { readWindowsProcessStartTimeSync } from "../infra/windows-process-start.js";
+import { readWindowsProcessStartTimeSync } from "../infra/windows-process-start.ts";
 
 const PROCESS_START_TIMEOUT_MS = 1000;
 // Cron reads its own identity on every tick. Cache only a successful Windows

--- a/ui/src/pages/chat/components/chat-pane-header.test-support.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test-support.ts
@@ -63,3 +63,25 @@ export function mountChatPaneHeader(
   render(html`${renderChatPaneHeader(props)}`, container);
   return { container, props };
 }
+
+export function describeFetchCalls(calls: readonly (readonly unknown[])[]): string {
+  const requests = calls.map(([input]) => {
+    if (typeof input !== "string") {
+      return "non-string";
+    }
+    if (input === "/__openclaw__/workspace-icon/agent%3Amain%3Aone") {
+      return "workspace-one";
+    }
+    if (input === "/__openclaw__/workspace-icon/agent%3Amain%3Arecovering") {
+      return "workspace-recovering";
+    }
+    if (input.startsWith("/__openclaw__/workspace-icon/")) {
+      return "other-workspace";
+    }
+    if (input.startsWith("data:image/svg+xml,")) {
+      return "svg-data";
+    }
+    return "other-string";
+  });
+  return `fetch request categories: ${JSON.stringify(requests)}`;
+}

--- a/ui/src/pages/chat/components/chat-pane-header.test.ts
+++ b/ui/src/pages/chat/components/chat-pane-header.test.ts
@@ -19,6 +19,7 @@ import type { ChatPageHost } from "../chat-state-host.ts";
 import { createBackgroundTasksProps } from "./chat-background-tasks.ts";
 import {
   chatPaneHeaderSessionRow as row,
+  describeFetchCalls,
   mountChatPaneHeader,
   type ChatPaneHeaderProps,
 } from "./chat-pane-header.test-support.ts";
@@ -854,7 +855,7 @@ describe("chat pane workspace chip icon", () => {
     expect(element).not.toBeNull();
     expect(container.querySelector(".workspace-icon")).toBeNull();
     expect(container.querySelector(".chat-pane__workspace-chip svg")).not.toBeNull();
-    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(fetchSpy, describeFetchCalls(fetchSpy.mock.calls)).not.toHaveBeenCalled();
     fetchSpy.mockRestore();
   });
 
@@ -868,7 +869,7 @@ describe("chat pane workspace chip icon", () => {
       authReady: true,
     });
     await Promise.resolve();
-    expect(fetchSpy).toHaveBeenCalledWith(
+    expect(fetchSpy, describeFetchCalls(fetchSpy.mock.calls)).toHaveBeenCalledWith(
       "/__openclaw__/workspace-icon/agent%3Amain%3Aone",
       expect.objectContaining({ headers: { Authorization: "Bearer token" } }),
     );
@@ -900,7 +901,7 @@ describe("chat pane workspace chip icon", () => {
         authReady: true,
       });
       await Promise.resolve();
-      expect(fetchSpy).toHaveBeenCalledOnce();
+      expect(fetchSpy, describeFetchCalls(fetchSpy.mock.calls)).toHaveBeenCalledOnce();
       expect(container.querySelector(".workspace-icon")).toBeNull();
       expect(container.querySelector(".chat-pane__workspace-chip svg")).not.toBeNull();
 
@@ -908,7 +909,7 @@ describe("chat pane workspace chip icon", () => {
       await Promise.resolve();
       await element?.updateComplete;
 
-      expect(fetchSpy).toHaveBeenCalledTimes(2);
+      expect(fetchSpy, describeFetchCalls(fetchSpy.mock.calls)).toHaveBeenCalledTimes(2);
       expect(container.querySelector("openclaw-workspace-icon")).toBe(element);
       expect(container.querySelector<HTMLImageElement>(".workspace-icon")?.src).toBe(
         "blob:recovered-workspace-icon",
@@ -942,7 +943,7 @@ describe("chat pane workspace chip icon", () => {
     await element?.updateComplete;
     await Promise.resolve();
 
-    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(fetchSpy, describeFetchCalls(fetchSpy.mock.calls)).toHaveBeenCalledTimes(1);
     render(
       html`${renderChatPaneHeader({
         ...mounted.props,
@@ -950,7 +951,9 @@ describe("chat pane workspace chip icon", () => {
       })}`,
       mounted.container,
     );
-    await vi.waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() =>
+      expect(fetchSpy, describeFetchCalls(fetchSpy.mock.calls)).toHaveBeenCalledTimes(2),
+    );
     fetchSpy.mockRestore();
   });
 
@@ -974,7 +977,7 @@ describe("chat pane workspace chip icon", () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(fetchSpy, describeFetchCalls(fetchSpy.mock.calls)).toHaveBeenCalledTimes(2);
     expect(fetchSpy.mock.calls[1]?.[1]).toMatchObject({
       headers: { Authorization: "Bearer session-password" },
     });


### PR DESCRIPTION
## What Problem This Solves

The shared Control UI shard intermittently reports too many fetch calls in workspace-icon tests. The bare count does not identify whether the extra calls came from the intended route, another workspace, SVG icons, or another input. That missing context makes the original Linux-only failure difficult to diagnose.

## Why This Change Was Made

Add fixed request-category labels to the existing assertion messages. Do not print URLs, headers, credentials, bodies, or raw request objects. All mocks, waits, expected counts and credential assertions stay unchanged. The helper belongs in existing test support and preserves the header's file-size scheduling position.

This is test-only investigation support: tests/test-support +32/-7, net +25; production net zero. It changes no UI behavior and is not counted as a performance improvement.

## Validation and Scope Decision

The original 269-file/two-worker UI group passes locally on macOS/Node 26 (259 files and 3,605 tests passed; 10 files and 53 tests skipped). The complete changed-file checks and independent managed review pass. These local results do not establish Linux parity or explain the intermittent failure. Exact-head CI33373754652 at4fdc05e27ab814487306dc70c0830f204614199f is green, including the previously failing UI, cron and tooling jobs. The final snapshot records142successful checks and46skipped; cancelled ancillary dispatch/label jobs and neutral CodeQL are not failed required checks.

The process-import repair originally investigated here independently landed in #133903, commit 2911761ab94fa9e5d989ba6b04d09f761a3f3ab3. It is not a unique change or a performance claim for this PR. In response to ClawSweeper's scope decision and Rank-up move, retain this PR as focused UI diagnostic support: two earlier Linux runs reproduced the excess counts, while the unchanged assertions now pass. The failure remains an unresolved named follow-up, and retaining bounded request categories gives a future recurrence useful context without changing the outcome.

The separate cron timeout also remains an unresolved follow-up: its complete local owner file passes 71 tests, and the subsequent hosted job passes. No timeout, retry, mock, expectation, or failure gate was weakened.
