### PR TITLE
fix(ui): prevent blank splash proof captures

### DIFF
--- a/ui/src/e2e/initial-connect-splash.e2e.test.ts
+++ b/ui/src/e2e/initial-connect-splash.e2e.test.ts
@@ -2,7 +2,7 @@
 // login gate while the Gateway resolves its first connection attempt.
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
-import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { chromium, type Browser, type BrowserContext, type Locator, type Page } from "playwright";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { ConnectErrorDetailCodes } from "../../../packages/gateway-protocol/src/connect-error-details.js";
 import {
@@ -39,11 +39,38 @@ async function createPage(): Promise<Page> {
   return page;
 }
 
-async function captureProof(page: Page, name: string): Promise<void> {
-  if (!artifactDir) {
-    return;
+async function waitForSettledSurface(page: Page): Promise<void> {
+  // Playwright visibility ignores opacity. Let entrance/resize motion finish;
+  // do not fast-forward animations or wait for perpetual descendant motion.
+  const surface = page.locator(".connect-splash, .shell");
+  await expect
+    .poll(() =>
+      surface.evaluate(
+        (element) =>
+          getComputedStyle(element).opacity === "1" &&
+          element
+            .getAnimations()
+            .filter((animation) => Number.isFinite(animation.effect?.getComputedTiming().endTime))
+            .every((animation) => animation.playState === "finished"),
+      ),
+    )
+    .toBe(true);
+}
+
+async function takeProofScreenshot(page: Page, name: string, content: Locator[]): Promise<Buffer> {
+  // Lazy hosts can have boxes before their definitions or children have loaded.
+  await Promise.all(content.map((locator) => locator.waitFor()));
+  await waitForSettledSurface(page);
+  return page.screenshot({
+    fullPage: true,
+    ...(artifactDir ? { path: path.join(artifactDir, `${name}.png`) } : {}),
+  });
+}
+
+async function captureProof(page: Page, name: string, content: Locator[]): Promise<void> {
+  if (artifactDir) {
+    await takeProofScreenshot(page, name, content);
   }
-  await page.screenshot({ fullPage: true, path: path.join(artifactDir, `${name}.png`) });
 }
 
 async function traceLoginGateMounts(page: Page): Promise<() => Promise<boolean>> {
@@ -122,13 +149,39 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     expect(await page.getByText("Loading panel", { exact: true }).count()).toBe(0);
     expect(await page.locator("openclaw-app-sidebar").count()).toBe(0);
     expect(await page.locator("openclaw-login-gate").count()).toBe(0);
-    await captureProof(page, "01-centered-connecting-mascot");
+    // Inspect the compositor output, not the mascot's already-painted backing canvas.
+    // This regression runs in memory even when optional artifact retention is off.
+    const proof = await takeProofScreenshot(page, "01-centered-connecting-mascot", [
+      mascot.locator("canvas"),
+    ]);
+    const painted = await page.evaluate(
+      async ({ png, bounds }) => {
+        const image = new Image();
+        image.src = `data:image/png;base64,${png}`;
+        await image.decode();
+        const crop = document.createElement("canvas");
+        crop.width = bounds.width;
+        crop.height = bounds.height;
+        const context = crop.getContext("2d")!;
+        context.drawImage(image, -bounds.x, -bounds.y);
+        const pixels = context.getImageData(0, 0, crop.width, crop.height).data;
+        // Reject a flat (or effectively invisible) crop without fixing the pose or palette.
+        return pixels.some(
+          (value, index) => index % 4 !== 3 && Math.abs(value - pixels[index % 4]!) > 10,
+        );
+      },
+      { png: proof.toString("base64"), bounds: mascotBounds! },
+    );
+    expect(painted, "connecting proof must contain the centered mascot").toBe(true);
 
     await gateway.resolveDeferred("connect");
     await page.locator("openclaw-app-shell").waitFor();
     expect(await page.locator(".connect-splash").count()).toBe(0);
     expect(await loginGateMounted()).toBe(false);
-    await captureProof(page, "02-connected-content");
+    await captureProof(page, "02-connected-content", [
+      page.locator(".sidebar-brand"),
+      page.locator(".agent-chat__composer-combobox textarea"),
+    ]);
   });
 
   it("centers the animated mascot until the chat route finishes loading", async () => {
@@ -183,12 +236,15 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
             ((loadingBounds?.y ?? 0) + (loadingBounds?.height ?? 0) / 2),
         ),
       ).toBeLessThanOrEqual(1);
-      await captureProof(page, "03-centered-pending-chat-mascot");
+      await captureProof(page, "03-centered-pending-chat-mascot", [mascot.locator("canvas")]);
 
       releaseChatModule();
       await page.locator("openclaw-chat-page").waitFor();
       expect(await loadingState.count()).toBe(0);
-      await captureProof(page, "04-loaded-chat-content");
+      await captureProof(page, "04-loaded-chat-content", [
+        page.locator(".sidebar-brand"),
+        page.locator(".agent-chat__composer-combobox textarea"),
+      ]);
     } finally {
       releaseChatModule();
     }
@@ -204,7 +260,9 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     await page.locator(".connect-splash").waitFor();
     expect(await page.locator("openclaw-login-gate").count()).toBe(0);
     expect(await loginGateMounted()).toBe(false);
-    await captureProof(page, "05-credentialless-connecting-mascot");
+    await captureProof(page, "05-credentialless-connecting-mascot", [
+      page.locator(".connect-splash openclaw-mascot canvas"),
+    ]);
 
     await gateway.resolveDeferred("connect");
     await page.locator("openclaw-app-shell").waitFor();
@@ -259,6 +317,8 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     expect(await loadingSections.locator(".model-setup__loading-row").count()).toBe(5);
     expect(await loadingSections.locator("button, input, wa-dropdown").count()).toBe(0);
     await page.evaluate(() => document.fonts.ready);
+    // Compare section layouts at rest, not the shell's translated entrance frame.
+    await waitForSettledSurface(page);
     const sectionTitles = [
       "Found on this Gateway",
       "Run a model locally",
@@ -274,7 +334,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     );
     expect(await page.locator(".connect-splash").count()).toBe(0);
     expect([...requestedWorkspaceModules]).toEqual([]);
-    await captureProof(page, "06-first-run-routed-before-detection");
+    await captureProof(page, "06-first-run-routed-before-detection", [loadingSections]);
     await page.setViewportSize({ height: 844, width: 390 });
     await expect
       .poll(() =>
@@ -283,7 +343,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
         ),
       )
       .toBe(true);
-    await captureProof(page, "06b-first-run-routed-before-detection-mobile");
+    await captureProof(page, "06b-first-run-routed-before-detection-mobile", [loadingSections]);
     await page.setViewportSize(viewport);
 
     await gateway.resolveDeferred("openclaw.setup.detect", {
@@ -317,12 +377,9 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     });
     await loading.waitFor({ state: "detached" });
     await page.getByRole("heading", { name: "Connect a verified AI model" }).waitFor();
-    await page.evaluate(
-      () =>
-        new Promise<void>((resolve) => {
-          requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-        }),
-    );
+    // Restoring desktop starts a grid-row transition after the responsive Lit update.
+    await page.locator(".shell:not(.shell--mobile-nav)").waitFor();
+    await waitForSettledSurface(page);
     const readySectionTops = await Promise.all(
       sectionTitles.map(
         async (name) => (await page.getByRole("heading", { name }).boundingBox())!.y,
@@ -332,7 +389,8 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
       Math.max(...readySectionTops.map((top, index) => Math.abs(top - loadingSectionTops[index]!))),
     ).toBeLessThanOrEqual(13);
     expect([...requestedWorkspaceModules]).toEqual([]);
-    await captureProof(page, "07-first-run-model-setup-ready");
+    const setupHeading = page.getByRole("heading", { name: "Connect a verified AI model" });
+    await captureProof(page, "07-first-run-model-setup-ready", [setupHeading]);
     await page.setViewportSize({ height: 844, width: 390 });
     await expect
       .poll(() =>
@@ -341,7 +399,7 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
         ),
       )
       .toBe(true);
-    await captureProof(page, "07b-first-run-model-setup-ready-mobile");
+    await captureProof(page, "07b-first-run-model-setup-ready-mobile", [setupHeading]);
   });
 
   it("falls back to the login gate when stored credentials are rejected", async () => {
@@ -384,7 +442,9 @@ describeControlUiE2e("Control UI initial connect splash E2E", () => {
     await expect
       .poll(async () => await splash.evaluate((element) => getComputedStyle(element).opacity))
       .toBe("1");
-    await captureProof(page, "06-gateway-starting-progress");
+    await captureProof(page, "06-gateway-starting-progress", [
+      splash.locator("openclaw-mascot canvas"),
+    ]);
 
     await expect
       .poll(async () => (await gateway.getRequests("connect")).length)


### PR DESCRIPTION
Related: #133918 — run-owned retention for mocked Control UI proof. This repair fixes capture readiness independently and leaves artifact destinations and retention ownership unchanged.

## What Problem This Solves

Resolves a problem where developers retaining Control UI initial-connect proof could receive a blank `01-centered-connecting-mascot.png`, a partial-shell `02-connected-content.png`, and recordings that never showed the named mascot state even though the existing browser assertions passed. The same suite could also compare Model Setup section positions while its desktop layout was still transitioning after a mobile capture.

## Why This Change Was Made

The capture boundary now waits for actual rendered descendants, full owner opacity, and natural completion of finite owner-local animations. The splash deliberately delays its fade to avoid flashing during fast handshakes; its backing canvas can already be painted while the parent remains transparent, and shell host visibility does not mean lazy sidebar/chat content has loaded. Sleeps or disabling animations would mask those distinctions rather than prove the named state.

The first screenshot also has an in-memory pixel regression that decodes the captured PNG, not the mascot's backing canvas. Model Setup geometry waits for the committed desktop class and completed grid-row transition instead of assuming two animation frames are enough. All seven cases and existing assertions remain, including the 1 px centering and 13 px layout limits. No timeouts, viewport settings, screenshot options, production animation behavior, or dependencies change.

Production LOC: +0/-0. Tests and test support: +81/-21 (net +60), in one existing E2E file.

## User Impact

Developers get meaningful screenshots and recordings of the named splash and loaded-chat states. Optional PNG/video retention stays opt-in; the first screenshot's regression runs in memory when retention is disabled. There is no production UI or Gateway behavior change.

## Evidence

Real Chromium against the source-mode Control UI and mocked Gateway, using only fresh run-owned synthetic evidence:

- The original capture ordering reproduced the blank mascot and partial shell. Instrumentation found 7,321 painted backing-canvas pixels while splash opacity remained zero through the screenshot; sidebar/chat definitions were absent at the shell-only capture boundary.
- The new screenshot-pixel assertion failed against the original ordering: `connecting proof must contain the centered mascot: expected false to be true`.
- All seven cases passed with retained artifacts and with retention disabled. A second successful recorded run confirmed all seven again. Ten named PNGs and the corresponding recording frames were inspected.
- The original Model Setup comparison failed at 18.578125 px while the shell still reserved a 10.46875 px animated top row. Waiting for that transition yields the stable approximately 8.11 px difference, within the unchanged 13 px limit.
- All 21 router/mascot sibling tests passed. The complete changed-scope gate passed, including formatting, guards, all three dead-export scans, core test typechecks, UI i18n validation, and targeted lint.
- One additional repetition failed before app startup because Chromium reported `net::ERR_NETWORK_CHANGED` for 63 module requests. No capture code was reached; the unchanged full-suite rerun passed. No retry or timeout workaround was added.

Focused recorded command (allocate a fresh output directory for every invocation):

```bash
OPENCLAW_UI_E2E_ARTIFACT_DIR="$(mktemp -d "$PWD/.artifacts/splash-proof.XXXXXX")" node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/initial-connect-splash.e2e.test.ts --reporter=verbose
```

Without retained artifacts:

```bash
env -u OPENCLAW_UI_E2E_ARTIFACT_DIR node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/initial-connect-splash.e2e.test.ts --reporter=verbose
```

Sibling coverage:

```bash
node scripts/run-vitest.mjs ui/src/app/router-outlet-controller.test.ts ui/src/app/router-outlet.test.ts ui/src/components/mascot-animator.test.ts
```

Changed-scope validation:

```bash
node scripts/check-changed.mjs -- ui/src/e2e/initial-connect-splash.e2e.test.ts
```

Attached before/after PNGs and the repaired flow recording were inspected for the asserted states and incidental data. They contain synthetic browser content only; no operator Gateway or live provider credentials were used. Older captures were preserved, and no unrelated repair files were changed.

![Before: connecting capture is blank despite a painted mascot canvas](https://github.com/user-attachments/assets/3373cf16-e8c7-4913-9dbf-53cd5a346eae)

![Before: connected capture contains only partial shell chrome](https://github.com/user-attachments/assets/b48d63ce-6578-4fbb-b2d4-b0198f524512)

![After: the naturally faded-in centered connecting mascot](https://github.com/user-attachments/assets/6df9a697-e583-4513-9e08-3ede4c48cf1a)

![After: rendered sidebar and connected chat content](https://github.com/user-attachments/assets/e6241dd6-d1bd-4d1f-874e-59f3622ffb8d)

https://github.com/user-attachments/assets/b03c3d85-4fa8-4188-adbc-543800a34903