### PR TITLE
fix(talk): honor configured owners for default sessions

### DIFF
--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -83,6 +83,26 @@ the call and shows an error. Choose an available **Microphone input**, restore
 permission if needed, and start Talk again. An unexpected GPT-Live connection
 loss also ends the call with an error; automatic reconnection is not supported.
 
+## Session ownership
+
+`talk.client.create` and realtime `talk.session.create` resolve their session before
+loading profile context or starting a provider. An agent-prefixed `sessionKey`
+selects that agent. Otherwise, Talk uses `talk.agentId`, then the configured system
+agent or an unambiguous default agent. Without an owner in a multi-agent Gateway,
+set `talk.agentId` or send an agent-prefixed key.
+
+Omitting `sessionKey` selects the same owned main session as a bare `main` key;
+both enforce sharing, incognito, and operator-role restrictions. Main aliases
+honor `session.mainKey` and `session.scope`. A shared fixed store retains its
+recorded owner for unqualified keys, and conflicting explicit ownership is rejected
+even when a main alias becomes `global`. If routing or access changes during
+startup, creation fails rather than switching sessions; retry the request.
+
+Keep the original `sessionKey` for client transcript, tool-call, and close requests.
+`talk.client.close` requires both that exact key and the returned `voiceSessionId`;
+an equivalent storage alias is not a replacement. Transcription-only sessions
+without a key remain sessionless and do not select a default chat.
+
 ## Behavior (macOS)
 
 - Always-on overlay while Talk mode is enabled.

--- a/docs/nodes/talk.md
+++ b/docs/nodes/talk.md
@@ -93,10 +93,16 @@ set `talk.agentId` or send an agent-prefixed key.
 
 Omitting `sessionKey` selects the same owned main session as a bare `main` key;
 both enforce sharing, incognito, and operator-role restrictions. Main aliases
-honor `session.mainKey` and `session.scope`. A shared fixed store retains its
-recorded owner for unqualified keys, and conflicting explicit ownership is rejected
+honor `session.scope`; the [main session](/concepts/main-session) suffix is fixed at
+`main`, and custom `session.mainKey` values are ignored. A shared fixed store retains
+its recorded owner for unqualified keys, and conflicting explicit ownership is rejected
 even when a main alias becomes `global`. If routing or access changes during
 startup, creation fails rather than switching sessions; retry the request.
+
+Gateway-owned provider consultations and steering retain the prepared agent,
+canonical session key, and store. Agent replies stay in the same session as voice
+transcripts, including under global scope, while the original key continues to
+identify the voice call.
 
 Keep the original `sessionKey` for client transcript, tool-call, and close requests.
 `talk.client.close` requires both that exact key and the returned `voiceSessionId`;

--- a/src/agents/cli-runner/execute.supervisor-capture.test.ts
+++ b/src/agents/cli-runner/execute.supervisor-capture.test.ts
@@ -17,6 +17,9 @@ import {
   type TrustedToolExecutionEvent,
 } from "../../infra/diagnostic-events.js";
 import type { CliBackendParseJsonlEvent } from "../../plugins/cli-backend.types.js";
+import { getPluginModuleLoaderStats } from "../../plugins/plugin-module-loader-cache.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import type { getProcessSupervisor } from "../../process/supervisor/index.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { createTestUserTurnTranscriptTarget } from "../../sessions/user-turn-transcript.test-support.js";
@@ -151,6 +154,20 @@ beforeEach(() => {
   resetAgentEventsForTest();
   resetDiagnosticEventsForTest();
   supervisorSpawnMock.mockReset();
+  // These contexts bypass preparation, which normally loads the provider owner.
+  // Unknown CLI errors must not materialize bundled plugins inside this fixture.
+  const registry = createEmptyPluginRegistry();
+  registry.providers.push({
+    pluginId: "fixture-cli-provider",
+    provider: {
+      id: "fixture-cli-provider",
+      label: "Fixture CLI provider",
+      hookAliases: ["claude-cli", "codex-cli", "google-gemini-cli"],
+      auth: [],
+    },
+    source: "test",
+  });
+  setActivePluginRegistry(registry);
 });
 
 describe("executePreparedCliRun supervisor output capture", () => {
@@ -1581,6 +1598,7 @@ describe("executePreparedCliRun supervisor output capture", () => {
   });
 
   it("finishes parsed CLI tools when the process exits before a tool result", async () => {
+    const pluginLoaderCalls = getPluginModuleLoaderStats().calls;
     const toolEvents: TrustedToolExecutionEvent[] = [];
     const stop = onTrustedToolExecutionEvent((event) => toolEvents.push(event));
     const toolStart = `${JSON.stringify({
@@ -1633,6 +1651,10 @@ describe("executePreparedCliRun supervisor output capture", () => {
         errorCategory: "cli_tool_incomplete",
       },
     ]);
+    expect(
+      getPluginModuleLoaderStats().calls,
+      "prepared CLI execution must not materialize provider plugins",
+    ).toBe(pluginLoaderCalls);
   });
 
   it("cancels an outstanding parsed CLI tool when the enclosing run is aborted", async () => {

--- a/src/auto-reply/reply/reply-run-registry.control-owner.test.ts
+++ b/src/auto-reply/reply/reply-run-registry.control-owner.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { replyRunRegistry } from "./reply-run-registry.js";
+import { resolveActiveReplyRunOwnerForSignal } from "./reply-run-registry.state.js";
+
+const sessionKey = "agent:main:voice-control";
+
+afterEach(() => replyRunRegistry.get(sessionKey)?.complete());
+
+describe("reply run control ownership", () => {
+  it.each(["key", "sessionId"] as const)(
+    "fences retained controls after its %s changes",
+    (field) => {
+      const controller = new AbortController();
+      const operation = replyRunRegistry.begin({
+        sessionKey,
+        sessionId: "original-session",
+        resetTriggered: false,
+        upstreamAbortSignal: controller.signal,
+      });
+      try {
+        const owner = resolveActiveReplyRunOwnerForSignal(controller.signal);
+        if (field === "key") {
+          operation.updateSessionKey("agent:main:voice-control-rekeyed");
+        } else {
+          operation.updateSessionId("replacement-session");
+        }
+        expect(owner?.abort()).toBe(false);
+        expect(operation.abortSignal.aborted).toBe(false);
+      } finally {
+        operation.complete();
+      }
+    },
+  );
+
+  it("controls a queued reply only through its admitted upstream signal", () => {
+    const controller = new AbortController();
+    const operation = replyRunRegistry.begin({
+      sessionKey,
+      sessionId: "queued-session",
+      resetTriggered: false,
+      upstreamAbortSignal: controller.signal,
+    });
+    expect(resolveActiveReplyRunOwnerForSignal(new AbortController().signal)).toBeUndefined();
+    const owner = resolveActiveReplyRunOwnerForSignal(controller.signal);
+    expect(owner?.sessionId).toBe("queued-session");
+    expect(owner?.abort()).toBe(true);
+    expect(operation.abortSignal.aborted).toBe(true);
+    expect(resolveActiveReplyRunOwnerForSignal(controller.signal)).toBeUndefined();
+  });
+
+  it("fences retained controls after same-session replacement", () => {
+    const controller = new AbortController();
+    const operation = replyRunRegistry.begin({
+      sessionKey,
+      sessionId: "same-session",
+      resetTriggered: false,
+      upstreamAbortSignal: controller.signal,
+    });
+    const owner = resolveActiveReplyRunOwnerForSignal(controller.signal);
+    operation.complete();
+    const successor = replyRunRegistry.begin({
+      sessionKey,
+      sessionId: "same-session",
+      resetTriggered: false,
+      upstreamAbortSignal: new AbortController().signal,
+    });
+    expect(resolveActiveReplyRunOwnerForSignal(controller.signal)).toBeUndefined();
+    expect(owner?.abort()).toBe(false);
+    expect(successor.abortSignal.aborted).toBe(false);
+  });
+});

--- a/src/auto-reply/reply/reply-run-registry.state.ts
+++ b/src/auto-reply/reply/reply-run-registry.state.ts
@@ -190,6 +190,32 @@ export function isReplyRunAbortableForSignal(signal: AbortSignal): boolean {
   return operation ? isReplyOperationAbortable(operation) : true;
 }
 
+/** Resolve only the live operation admitted with this exact upstream signal. */
+export function resolveActiveReplyRunOwnerForSignal(
+  signal: AbortSignal,
+): { sessionId: string; sessionKey: string; abort: () => boolean } | undefined {
+  const operation = operationsByUpstreamAbortSignal.get(signal);
+  if (!operation) {
+    return undefined;
+  }
+  const { key: sessionKey, sessionId } = operation;
+  const isCurrent = () =>
+    !signal.aborted &&
+    !operation.result &&
+    operation.key === sessionKey &&
+    operation.sessionId === sessionId &&
+    replyRunState.activeRunsByKey.get(sessionKey) === operation;
+  if (!isCurrent()) {
+    return undefined;
+  }
+  return {
+    sessionId,
+    sessionKey,
+    // A retained selector must never cancel the operation that replaced this owner.
+    abort: () => isCurrent() && operation.abortByUser(),
+  };
+}
+
 /** Keep terminal state registered until the operation owner exits via complete(). */
 export function retainReplyOperationUntilComplete(operation: ReplyOperation): void {
   retainStateUntilCompleteOperations.add(operation);

--- a/src/commands/doctor/shared/default-agent-role-materialization.test.ts
+++ b/src/commands/doctor/shared/default-agent-role-materialization.test.ts
@@ -10,7 +10,7 @@ import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { resolveCronJobEffectiveAgentId } from "../../../cron/agent-id.js";
 import { resolveHeartbeatAgents } from "../../../infra/heartbeat-runner.js";
 import { resolveAgentRoute } from "../../../routing/resolve-route.js";
-import { resolveTalkSessionAgentId, resolveTalkTargetAgentId } from "../../../talk/agent-target.js";
+import { resolveTalkSessionAgentId } from "../../../talk/agent-target.js";
 
 function materializeDefaultAgentRoles(cfg: OpenClawConfig) {
   if (listAgentEntries(cfg).length < 2) {
@@ -50,7 +50,7 @@ function snapshotSurfaces(cfg: OpenClawConfig): SurfaceSnapshot {
         throw error;
       }
     })(),
-    voice: resolveTalkTargetAgentId(cfg),
+    voice: resolveTalkSessionAgentId(cfg),
     cron: resolveCronJobEffectiveAgentId({}, defaultAgentId),
     cli: defaultAgentId,
   };

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -398,8 +398,14 @@ export type GatewayRequestOptions = {
 
 /** Commit-time guard captured by the pre-dispatch session participation check. */
 export type SessionMutationAuthorization = {
+  talkSessionTarget?: import("../talk-session-target.js").PreparedTalkSessionTarget;
   assertCurrent: () => void;
-  assertTargetCurrent: (target: { sessionKey: string; agentId?: string }) => void;
+  assertTargetCurrent: (target: {
+    sessionKey: string;
+    agentId?: string;
+    /** Internal ensure result: may materialize a previously id-less Talk target, never replace it. */
+    ensuredSessionId?: string;
+  }) => void;
 };
 
 /** Normalized method invocation options passed to registered handlers. */

--- a/src/gateway/server-methods/shared-types.ts
+++ b/src/gateway/server-methods/shared-types.ts
@@ -398,7 +398,7 @@ export type GatewayRequestOptions = {
 
 /** Commit-time guard captured by the pre-dispatch session participation check. */
 export type SessionMutationAuthorization = {
-  talkSessionTarget?: import("../talk-session-target.js").PreparedTalkSessionTarget;
+  talkSessionTarget?: import("../talk-session-target.types.js").PreparedTalkSessionTarget;
   assertCurrent: () => void;
   assertTargetCurrent: (target: {
     sessionKey: string;

--- a/src/gateway/server-methods/talk-client-create.ts
+++ b/src/gateway/server-methods/talk-client-create.ts
@@ -236,8 +236,7 @@ export const createTalkClient: GatewayRequestHandler = async ({
       const consultRunner = createTalkClientAgentConsultRunner({
         config: runtimeConfig,
         context,
-        agentId,
-        sessionKey,
+        sessionTarget: target,
         ...(ownerConnId ? { ownerConnId } : {}),
         authority: resolveTalkAgentConsultAuthority(client?.connect?.scopes),
         getVoiceSessionId: () => activeVoiceSessionId,
@@ -247,7 +246,7 @@ export const createTalkClient: GatewayRequestHandler = async ({
         ? createTalkClientGatewayControlOwner({
             voiceSessionId: activeVoiceSessionId!,
             providerId: resolution.provider.id,
-            sessionKey,
+            sessionTarget: target,
             connId: ownerConnId!,
             context,
             assertConnectionOpen: () => {

--- a/src/gateway/server-methods/talk-client-create.ts
+++ b/src/gateway/server-methods/talk-client-create.ts
@@ -9,11 +9,9 @@ import {
   validateTalkClientCreateParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { AgentSelectionRequiredError, resolveAgentWorkspaceDir } from "../../agents/agent-scope.js";
-import { buildAgentMainSessionKey } from "../../routing/session-key.js";
 import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL } from "../../talk/agent-consult-tool.js";
 import { REALTIME_VOICE_AGENT_CONTROL_TOOL } from "../../talk/agent-run-control-shared.js";
-import { resolveTalkSessionAgentId } from "../../talk/agent-target.js";
 import {
   appendClientVoiceTranscript,
   closeClientVoiceSession,
@@ -32,10 +30,8 @@ import {
   resolveConfiguredRealtimeVoiceProvider,
   resolveRealtimeVoiceProviderCapabilities,
 } from "../../talk/provider-resolver.js";
-import {
-  authorizeGatewaySessionCreation,
-  resolveSandboxedSessionCreation,
-} from "../operator-role-policy.js";
+import { resolveSandboxedSessionCreation } from "../operator-role-policy.js";
+import { SessionMutationAuthorizationChangedError } from "../session-sharing.js";
 import { readSessionPreviewItemsFromTranscript } from "../session-transcript-readers.js";
 import {
   boundTalkClientRealtimeInitialItems,
@@ -43,7 +39,9 @@ import {
   createTalkClientGatewayControlOwner,
   resolveTalkAgentConsultAuthority,
 } from "../talk-client-gateway-control.js";
+import { requirePreparedTalkSessionTarget } from "../talk-session-target.js";
 import { formatForLog } from "../ws-log.js";
+import { resolveOperatorSessionCreation } from "./session-creation-provenance.js";
 import {
   forgetLegacyVoiceBinding,
   rememberLegacyVoiceBinding,
@@ -74,11 +72,14 @@ export const createTalkClient: GatewayRequestHandler = async ({
   respond,
   context,
   client,
+  sessionMutationAuthorization,
+  sessionMutationCommitGuard,
 }) => {
   if (!assertValidParams(params, validateTalkClientCreateParams, "talk.client.create", respond)) {
     return;
   }
   try {
+    sessionMutationAuthorization?.assertCurrent();
     const runtimeConfig = context.getRuntimeConfig();
     const realtimeConfig = buildTalkRealtimeConfig(runtimeConfig, params.provider, params.model);
     const mode = normalizeOptionalLowercaseString(params.mode) ?? realtimeConfig.mode ?? "realtime";
@@ -134,14 +135,18 @@ export const createTalkClient: GatewayRequestHandler = async ({
       requested: params,
       defaults: realtimeConfig,
     });
-    const requestedAgentId = resolveTalkSessionAgentId(runtimeConfig, params.sessionKey);
+    const target = requirePreparedTalkSessionTarget(
+      sessionMutationAuthorization?.talkSessionTarget,
+    );
+    const { agentId, sessionKey } = target;
+    const sessionTarget = { agentId, sessionKey: target.canonicalKey, storePath: target.storePath };
     assertSecretOwnerAvailable("capability", "talk:realtime");
     const resolution = resolveConfiguredRealtimeVoiceProvider({
       configuredProviderId: realtimeConfig.provider,
       providerConfigs: realtimeConfig.providers,
       ...(launchOptions.model ? { providerConfigOverrides: { model: launchOptions.model } } : {}),
       cfg: runtimeConfig,
-      agentId: requestedAgentId,
+      agentId,
       defaultModel: realtimeConfig.model,
       surface: "browser-session",
     });
@@ -149,7 +154,7 @@ export const createTalkClient: GatewayRequestHandler = async ({
       provider: resolution.provider,
       providerConfig: resolution.providerConfig,
       cfg: runtimeConfig,
-      agentId: requestedAgentId,
+      agentId,
       model: launchOptions.model,
       surface: "browser-session",
     });
@@ -169,36 +174,22 @@ export const createTalkClient: GatewayRequestHandler = async ({
       );
       return;
     }
-    const realtimeContext = await resolveTalkRealtimeProviderInstructions({
+    const providerInstructions = await resolveTalkRealtimeProviderInstructions({
       config: runtimeConfig,
-      agentId: requestedAgentId,
+      agentId,
       configuredInstructions: realtimeConfig.instructions,
-      sessionKey: params.sessionKey,
-      // Legacy creates can drift to another agent's session at toolCall time, so
-      // the default agent's profile must not leak into the provider session.
-      requireSessionKeyForProfile: true,
+      sessionKey: target.canonicalKey,
       warn: (message) => context.logGateway.warn(`talk realtime context: ${message}`),
     });
-    const { agentId, requestedSessionKey } = realtimeContext;
-    const sessionKey = requestedSessionKey ?? buildAgentMainSessionKey({ agentId });
-    const creationError = authorizeGatewaySessionCreation({
-      cfg: runtimeConfig,
-      client,
-      agentId,
-    });
-    if (creationError) {
-      respond(false, undefined, creationError);
-      return;
-    }
+    sessionMutationAuthorization?.assertCurrent();
     if (resolution.provider.createBrowserSession && transport !== "gateway-relay") {
-      const agentSessionId = resolveClientVoiceAgentSessionId({ agentId, sessionKey });
+      const agentSessionId = resolveClientVoiceAgentSessionId(sessionTarget);
       const initialItems = agentSessionId
         ? boundTalkClientRealtimeInitialItems(
             readSessionPreviewItemsFromTranscript(
               {
-                agentId,
+                ...sessionTarget,
                 sessionId: agentSessionId,
-                sessionKey,
               },
               REALTIME_VOICE_CONTEXT_MAX_ITEMS,
               REALTIME_VOICE_CONTEXT_MAX_ITEM_CHARS,
@@ -221,8 +212,8 @@ export const createTalkClient: GatewayRequestHandler = async ({
       }
       const instructions =
         providerCapabilities?.handlesAgentConsult === true
-          ? normalizeOptionalString(realtimeContext.instructions)
-          : buildRealtimeInstructions(realtimeContext.instructions);
+          ? normalizeOptionalString(providerInstructions)
+          : buildRealtimeInstructions(providerInstructions);
       const requestedVoiceSessionId = normalizeOptionalString(params.voiceSessionId);
       const ownsProvider =
         wantsGatewayControl || providerCapabilities?.handlesAgentConsult === true;
@@ -272,6 +263,7 @@ export const createTalkClient: GatewayRequestHandler = async ({
               appendClientVoiceTranscript({
                 agentId,
                 sessionKey,
+                sessionTarget,
                 voiceSessionId: activeVoiceSessionId!,
                 entryId,
                 role,
@@ -313,9 +305,15 @@ export const createTalkClient: GatewayRequestHandler = async ({
         ...(tools.length > 0 ? { tools } : {}),
         ...launchOptions,
       };
+      const assertCommitAllowed = () => {
+        sessionMutationCommitGuard?.();
+        sessionMutationAuthorization?.assertCurrent();
+        gatewayControlOwner?.assertOpen();
+      };
       let session: Awaited<ReturnType<typeof resolution.provider.createBrowserSession>> | undefined;
       let delivered = false;
       try {
+        assertCommitAllowed();
         session = await resolution.provider.createBrowserSession(browserSessionRequest);
         const createdSession = session;
         await gatewayControlOwner?.adoptProvider(() =>
@@ -325,7 +323,7 @@ export const createTalkClient: GatewayRequestHandler = async ({
             session: createdSession,
           }),
         );
-        gatewayControlOwner?.assertOpen();
+        assertCommitAllowed();
         // Client-owned voice records are minted only for client-owned transports;
         // relay sessions are created via talk.session.create and keyed by relaySessionId.
         // Widening this guard would hand relay calls a mismatched voiceSessionId.
@@ -344,13 +342,16 @@ export const createTalkClient: GatewayRequestHandler = async ({
           // Defer persistent session creation until the provider has returned a
           // usable client transport. The write boundary rechecks the credential
           // deadline so queued storage work cannot leave a phantom chat.
-          await ensureClientVoiceAgentSessionEntry({
-            agentId,
-            sessionKey,
-            creation: resolveSandboxedSessionCreation(client, runtimeConfig),
+          const ensuredSessionId = await ensureClientVoiceAgentSessionEntry({
+            ...sessionTarget,
+            creation:
+              resolveSandboxedSessionCreation(client, runtimeConfig) ??
+              resolveOperatorSessionCreation(client),
             deadlineAt: sessionEntryDeadlineAt,
-            ...(gatewayControlOwner ? { assertCommitAllowed: gatewayControlOwner.assertOpen } : {}),
+            assertCommitAllowed,
           });
+          sessionMutationCommitGuard?.();
+          sessionMutationAuthorization?.assertTargetCurrent({ ...sessionTarget, ensuredSessionId });
           gatewayControlOwner?.assertOpen();
           // Recovering 6h-abandoned calls (and retrying their digests) is not on the
           // start path; running it inline would delay use of time-sensitive provider
@@ -429,6 +430,10 @@ export const createTalkClient: GatewayRequestHandler = async ({
       `Realtime provider "${resolution.provider.id}" does not support client-owned realtime sessions`,
     );
   } catch (err) {
+    if (err instanceof SessionMutationAuthorizationChangedError) {
+      respond(false, undefined, err.error);
+      return;
+    }
     respond(
       false,
       undefined,

--- a/src/gateway/server-methods/talk-client-run-ownership.ts
+++ b/src/gateway/server-methods/talk-client-run-ownership.ts
@@ -1,7 +1,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { isAgentEventLifecycleGenerationCurrent } from "../../infra/agent-events.js";
 import type { controlRealtimeVoiceAgentRun } from "../../talk/agent-run-control.js";
-import type { PreparedTalkSessionTarget } from "../talk-session-target.js";
+import type { PreparedTalkSessionTarget } from "../talk-session-target.types.js";
 import type { GatewayRequestContext } from "./types.js";
 
 export function resolveOwnedActiveTalkRunTarget(params: {

--- a/src/gateway/server-methods/talk-client-run-ownership.ts
+++ b/src/gateway/server-methods/talk-client-run-ownership.ts
@@ -1,20 +1,47 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import type { GatewayRequestHandlers } from "./types.js";
+import { isAgentEventLifecycleGenerationCurrent } from "../../infra/agent-events.js";
+import type { controlRealtimeVoiceAgentRun } from "../../talk/agent-run-control.js";
+import type { PreparedTalkSessionTarget } from "../talk-session-target.js";
+import type { GatewayRequestContext } from "./types.js";
 
-export function hasOwnedActiveTalkClientRun(params: {
-  context: Parameters<GatewayRequestHandlers[string]>[0]["context"];
+export function resolveOwnedActiveTalkRunTarget(params: {
+  context: Pick<GatewayRequestContext, "chatAbortControllers">;
   clientConnId?: string;
-  sessionKey: string;
-}): boolean {
+  sessionTarget: PreparedTalkSessionTarget;
+  assertCurrent?: () => void;
+}): NonNullable<Parameters<typeof controlRealtimeVoiceAgentRun>[0]["runTarget"]> | null {
   const connId = normalizeOptionalString(params.clientConnId);
-  const sessionKey = params.sessionKey.trim();
-  if (!connId || !sessionKey) {
-    return false;
+  if (!connId) {
+    return null;
   }
-  for (const entry of params.context.chatAbortControllers.values()) {
-    if (entry.sessionKey === sessionKey && entry.ownerConnId === connId && entry.kind !== "agent") {
-      return true;
+  const { agentId, sessionKey, canonicalKey } = params.sessionTarget;
+  for (const [runId, entry] of params.context.chatAbortControllers) {
+    const generation = entry.lifecycleGeneration;
+    if (!generation) {
+      continue;
+    }
+    const signal = entry.controller.signal;
+    // Backing identity can materialize after admission; compare the live owner's
+    // session ID with this same registration's current value, not an early snapshot.
+    const isCurrent = (resolvedSessionId?: string) => {
+      params.assertCurrent?.();
+      return (
+        params.context.chatAbortControllers.get(runId) === entry &&
+        entry.agentId === agentId &&
+        (entry.sessionKey === sessionKey || entry.sessionKey === canonicalKey) &&
+        entry.ownerConnId === connId &&
+        entry.kind !== "agent" &&
+        entry.registrationCleanupRequested !== true &&
+        (resolvedSessionId === undefined || entry.sessionId === resolvedSessionId) &&
+        entry.controller.signal === signal &&
+        !signal.aborted &&
+        entry.lifecycleGeneration === generation &&
+        isAgentEventLifecycleGenerationCurrent(generation)
+      );
+    };
+    if (isCurrent()) {
+      return { runId, signal, isCurrent };
     }
   }
-  return false;
+  return null;
 }

--- a/src/gateway/server-methods/talk-client.test.ts
+++ b/src/gateway/server-methods/talk-client.test.ts
@@ -21,10 +21,13 @@ import {
 } from "../../talk/client-voice-session.js";
 import { clientVoiceSessionTesting } from "../../talk/client-voice-session.test-support.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
+import { resolveSessionMutationAuthorization } from "../session-sharing.js";
 import { closeTalkClientGatewayControlSession } from "../talk-client-gateway-control.js";
 import { cleanupTalkConnection } from "../talk-session-registry.js";
+import { createTalkClient } from "./talk-client-create.js";
 import { readLegacyVoiceBinding } from "./talk-client-legacy-voice-bindings.js";
 import { talkClientHandlers } from "./talk-client.js";
+import type { GatewayRequestHandlerOptions } from "./types.js";
 
 const voiceMocks = vi.hoisted(() => ({
   resolveConfiguredRealtimeVoiceProvider: vi.fn(),
@@ -103,6 +106,20 @@ function configureDelegatedBrowserProvider(
       broadcastToConnIds: vi.fn(),
     },
   };
+}
+
+async function invokeCreate(options: GatewayRequestHandlerOptions) {
+  const admission = resolveSessionMutationAuthorization({
+    method: "talk.client.create",
+    requestParams: options.params,
+    context: options.context,
+    client: options.client,
+  });
+  if (admission.error) {
+    options.respond(false, undefined, admission.error);
+    return;
+  }
+  await createTalkClient({ ...options, sessionMutationAuthorization: admission.authorization });
 }
 
 async function invokeTranscript(params: Record<string, unknown>) {
@@ -291,7 +308,7 @@ describe("talk.client.transcript", () => {
         .mockResolvedValue({ text: "Late task started" })
         .mockReturnValueOnce(acceptedResult);
       const respond = vi.fn();
-      await talkClientHandlers["talk.client.create"]?.({
+      await invokeCreate({
         params: { sessionKey, provider: "openai", model: "gpt-live-test" },
         respond,
         context,
@@ -351,7 +368,7 @@ describe("talk.client.transcript", () => {
       configureDelegatedBrowserProvider(createBrowserSession);
     const pendingSessionKey = "agent:main:pending-voice";
     const respond = vi.fn();
-    const starting = talkClientHandlers["talk.client.create"]!({
+    const starting = invokeCreate({
       params: { sessionKey: pendingSessionKey, provider: "openai", model: "gpt-live-test" },
       respond,
       context,
@@ -381,7 +398,7 @@ describe("talk.client.transcript", () => {
     const createBrowserSession = vi.fn(async (_request: BrowserRequest) => browserSession);
     const { client, clients, context } = configureDelegatedBrowserProvider(createBrowserSession);
     const respond = vi.fn();
-    const starting = talkClientHandlers["talk.client.create"]!({
+    const starting = invokeCreate({
       params: { sessionKey, provider: "openai", model: "gpt-live-test" },
       respond,
       context,

--- a/src/gateway/server-methods/talk-client.ts
+++ b/src/gateway/server-methods/talk-client.ts
@@ -41,6 +41,7 @@ import {
   ensureTalkRealtimeRelayVoiceSession,
   flushTalkRealtimeRelayVoiceWrites,
 } from "../talk-realtime-relay.js";
+import { prepareTalkSessionTarget } from "../talk-session-target.js";
 import { formatForLog } from "../ws-log.js";
 import { createTalkClient } from "./talk-client-create.js";
 import {
@@ -193,7 +194,7 @@ export const talkClientHandlers: GatewayRequestHandlers = {
       undefined,
     );
   },
-  "talk.client.transcript": async ({ params, respond, context }) => {
+  "talk.client.transcript": async ({ params, respond, context, sessionMutationAuthorization }) => {
     if (
       !assertValidParams(
         params,
@@ -206,9 +207,14 @@ export const talkClientHandlers: GatewayRequestHandlers = {
     }
     try {
       const config = context.getRuntimeConfig();
+      const target =
+        sessionMutationAuthorization?.talkSessionTarget ??
+        prepareTalkSessionTarget(config, params.sessionKey);
+      sessionMutationAuthorization?.assertCurrent();
       await appendClientVoiceTranscript({
-        agentId: resolveTalkSessionAgentId(config, params.sessionKey),
-        sessionKey: params.sessionKey,
+        agentId: target.agentId,
+        sessionKey: target.sessionKey,
+        sessionTarget: { sessionKey: target.canonicalKey, storePath: target.storePath },
         voiceSessionId: params.voiceSessionId,
         entryId: params.entryId,
         role: params.role,
@@ -221,7 +227,13 @@ export const talkClientHandlers: GatewayRequestHandlers = {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, formatForLog(err)));
     }
   },
-  "talk.client.close": async ({ params, respond, context, client }) => {
+  "talk.client.close": async ({
+    params,
+    respond,
+    context,
+    client,
+    sessionMutationAuthorization,
+  }) => {
     if (!assertValidParams(params, validateTalkClientCloseParams, "talk.client.close", respond)) {
       return;
     }
@@ -237,7 +249,10 @@ export const talkClientHandlers: GatewayRequestHandlers = {
         return;
       }
       const config = context.getRuntimeConfig();
-      const agentId = resolveTalkSessionAgentId(config, params.sessionKey);
+      const { agentId } =
+        sessionMutationAuthorization?.talkSessionTarget ??
+        prepareTalkSessionTarget(config, params.sessionKey);
+      sessionMutationAuthorization?.assertCurrent();
       const origin = resolveClientVoiceSessionOrigin({
         agentId,
         sessionKey: params.sessionKey,

--- a/src/gateway/server-methods/talk-client.ts
+++ b/src/gateway/server-methods/talk-client.ts
@@ -35,6 +35,7 @@ import {
   authorizeGatewaySessionCreation,
   resolveSandboxedSessionCreation,
 } from "../operator-role-policy.js";
+import { SessionMutationAuthorizationChangedError } from "../session-mutation-authorization-error.js";
 import { startTalkRealtimeAgentConsult } from "../talk-agent-consult.js";
 import { closeTalkClientGatewayControlSession } from "../talk-client-gateway-control.js";
 import {
@@ -49,7 +50,7 @@ import {
   readLegacyVoiceBinding,
   rememberLegacyVoiceBinding,
 } from "./talk-client-legacy-voice-bindings.js";
-import { hasOwnedActiveTalkClientRun } from "./talk-client-run-ownership.js";
+import { resolveOwnedActiveTalkRunTarget } from "./talk-client-run-ownership.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams } from "./validation.js";
 
@@ -121,8 +122,6 @@ export const talkClientHandlers: GatewayRequestHandlers = {
         rememberLegacyVoiceBinding({ connId, sessionKey: params.sessionKey, voiceSessionId });
       }
       if (relaySessionId && connId) {
-        // Initialize the canonical session row BEFORE binding: the bind drains the
-        // relay's buffered finals into transcript appends, which fail without it.
         await ensureClientVoiceAgentSessionEntry({
           agentId,
           sessionKey: params.sessionKey,
@@ -276,35 +275,49 @@ export const talkClientHandlers: GatewayRequestHandlers = {
       respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, formatForLog(err)));
     }
   },
-  "talk.client.steer": async ({ params, respond, client, context }) => {
+  "talk.client.steer": async ({
+    params,
+    respond,
+    client,
+    context,
+    sessionMutationAuthorization,
+  }) => {
     if (!assertValidParams(params, validateTalkClientSteerParams, "talk.client.steer", respond)) {
       return;
     }
-    if (
-      !hasOwnedActiveTalkClientRun({
+    try {
+      const target =
+        sessionMutationAuthorization?.talkSessionTarget ??
+        prepareTalkSessionTarget(context.getRuntimeConfig(), params.sessionKey);
+      const runTarget = resolveOwnedActiveTalkRunTarget({
         context,
         clientConnId: client?.connId,
-        sessionKey: params.sessionKey,
-      })
-    ) {
-      respond(
-        false,
-        undefined,
-        errorShape(
-          ErrorCodes.INVALID_REQUEST,
-          "talk.client.steer requires an active browser-owned Talk run",
-        ),
-      );
-      return;
-    }
-    try {
+        sessionTarget: target,
+        assertCurrent: sessionMutationAuthorization?.assertCurrent,
+      });
+      if (runTarget === null) {
+        respond(
+          false,
+          undefined,
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            "talk.client.steer requires an active browser-owned Talk run",
+          ),
+        );
+        return;
+      }
       const result = await controlRealtimeVoiceAgentRun({
-        sessionKey: params.sessionKey,
+        sessionKey: target.canonicalKey,
+        runTarget,
         text: params.text,
         mode: params.mode,
       });
       respond(true, result, undefined);
     } catch (err) {
+      if (err instanceof SessionMutationAuthorizationChangedError) {
+        respond(false, undefined, err.error);
+        return;
+      }
       respond(
         false,
         undefined,

--- a/src/gateway/server-methods/talk-native-consult-target.test.ts
+++ b/src/gateway/server-methods/talk-native-consult-target.test.ts
@@ -1,0 +1,694 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RunEmbeddedAgentParams } from "../../agents/embedded-agent-runner/run/params.js";
+import {
+  clearActiveEmbeddedRun,
+  setActiveEmbeddedRun,
+} from "../../agents/embedded-agent-runner/runs.js";
+import { testing as embeddedRunTesting } from "../../agents/embedded-agent-runner/runs.test-support.js";
+import { replyRunRegistry } from "../../auto-reply/reply/reply-run-registry.js";
+import {
+  listSessionEntriesReadOnly,
+  loadSessionEntry,
+  replaceSessionEntry,
+  replaceSessionEntrySync,
+} from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import type { RealtimeVoiceProviderPlugin } from "../../plugins/types.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { ensureProfileForEmail } from "../../state/user-profiles.js";
+import { controlRealtimeVoiceAgentRun } from "../../talk/agent-run-control.js";
+import { clientVoiceSessionTesting } from "../../talk/client-voice-session.test-support.js";
+import type { InternalRealtimeVoiceProviderCapabilities } from "../../talk/provider-internal.js";
+import type {
+  RealtimeVoiceAgentConsultRunner,
+  RealtimeVoiceGatewayControl,
+  RealtimeVoiceProviderCapabilities,
+} from "../../talk/provider-types.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { registerChatAbortController } from "../chat-abort.js";
+import { handleGatewayRequest } from "../server-methods.js";
+import { resolveSessionMutationAuthorization } from "../session-sharing.js";
+import { sharingPolicyClient } from "../session-sharing.test-utils.js";
+import { closeTalkClientGatewayControlSession } from "../talk-client-gateway-control.js";
+import { drainingRelaySessions } from "../talk-realtime-relay-state.js";
+import {
+  cleanupTalkConnection,
+  getUnifiedTalkSession,
+  rememberUnifiedTalkSession,
+} from "../talk-session-registry.js";
+import { prepareTalkSessionTarget } from "../talk-session-target.js";
+import { resolveOwnedActiveTalkRunTarget } from "./talk-client-run-ownership.js";
+import { talkClientHandlers } from "./talk-client.js";
+import { talkSessionHandlers } from "./talk-session.js";
+import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
+
+const mocks = vi.hoisted(() => ({
+  capabilities: {
+    transports: ["webrtc", "gateway-relay"],
+    inputAudioFormats: [{ encoding: "pcm16", sampleRateHz: 24000, channels: 1 }],
+    outputAudioFormats: [{ encoding: "pcm16", sampleRateHz: 24000, channels: 1 }],
+    supportsToolCalls: false,
+  } satisfies RealtimeVoiceProviderCapabilities,
+  resolveProvider: vi.fn(),
+  runEmbeddedAgent: vi.fn(async (_params: RunEmbeddedAgentParams) => ({
+    payloads: [{ text: "Synthetic consult answer" }],
+    meta: { durationMs: 0 },
+  })),
+}));
+
+vi.mock("../../agents/embedded-agent.js", () => ({ runEmbeddedAgent: mocks.runEmbeddedAgent }));
+vi.mock("../../agents/realtime-bootstrap-context.js", () => ({
+  resolveRealtimeBootstrapContextInstructions: async () => undefined,
+}));
+vi.mock("../../talk/provider-resolver.js", () => ({
+  resolveConfiguredRealtimeVoiceProvider: mocks.resolveProvider,
+  resolveRealtimeVoiceProviderCapabilities: (): InternalRealtimeVoiceProviderCapabilities => ({
+    ...mocks.capabilities,
+    supportsGatewayControl: true,
+    handlesAgentConsult: true,
+  }),
+}));
+vi.mock("../../talk/provider-registry.js", () => ({ listRealtimeVoiceProviders: () => [] }));
+
+let state: OpenClawTestState;
+let config: OpenClawConfig;
+let client: ReturnType<typeof sharingPolicyClient> & { connId: string };
+let callback: RealtimeVoiceAgentConsultRunner | undefined;
+let browserVoiceSessionId: string | undefined;
+let browserControl: RealtimeVoiceGatewayControl | undefined;
+const submitProviderResult = vi.fn();
+const context = {
+  getRuntimeConfig: () => config,
+  getClientConnIds: () => new Set([client.connId]),
+  chatAbortControllers: new Map(),
+  broadcastToConnIds: vi.fn(),
+  logGateway: { warn: vi.fn() },
+} as unknown as GatewayRequestContext;
+
+async function dispatch(
+  method: string,
+  params: Record<string, unknown>,
+  handlers: GatewayRequestHandlers = {},
+) {
+  const respond = vi.fn();
+  await handleGatewayRequest({
+    req: { type: "req", id: "native-consult", method, params },
+    client,
+    context,
+    isWebchatConnect: () => false,
+    respond,
+    extraHandlers: { ...talkClientHandlers, ...talkSessionHandlers, ...handlers },
+  });
+  return respond;
+}
+
+beforeEach(async () => {
+  state = await createOpenClawTestState({ label: "talk-native-consult" });
+  config = {
+    agents: {
+      ownership: "explicit",
+      entries: { primary: {}, voice: { workspace: state.workspaceDir } },
+    },
+    talk: { agentId: "voice" },
+  };
+  client = {
+    ...sharingPolicyClient({ user: ensureProfileForEmail("native-listener@example.test").id }),
+    connId: "native-consult-client",
+  };
+  callback = undefined;
+  browserVoiceSessionId = undefined;
+  browserControl = undefined;
+  vi.clearAllMocks();
+  mocks.runEmbeddedAgent.mockReset().mockResolvedValue({
+    payloads: [{ text: "Synthetic consult answer" }],
+    meta: { durationMs: 0 },
+  });
+  context.chatAbortControllers.clear();
+  setActivePluginRegistry(createEmptyPluginRegistry());
+  const provider: RealtimeVoiceProviderPlugin = {
+    id: "synthetic-voice",
+    label: "Synthetic voice",
+    capabilities: mocks.capabilities,
+    isConfigured: () => true,
+    createBrowserSession: async (request) => {
+      callback = request.runAgentConsult;
+      browserControl = request.gatewayControl;
+      browserControl?.bindBridge({
+        connect: async () => undefined,
+        sendAudio: () => undefined,
+        setMediaTimestamp: () => undefined,
+        handleBargeIn: () => undefined,
+        submitToolResult: submitProviderResult,
+        acknowledgeMark: () => undefined,
+        close: () => undefined,
+        isConnected: () => true,
+      });
+      return {
+        provider: "synthetic-voice",
+        transport: "webrtc",
+        clientSecret: "synthetic-offer",
+        offerUrl: "/test/offer",
+      };
+    },
+    createBridge: (request) => {
+      callback = request.runAgentConsult;
+      return {
+        connect: async () => undefined,
+        sendAudio: () => undefined,
+        setMediaTimestamp: () => undefined,
+        handleBargeIn: () => undefined,
+        submitToolResult: () => undefined,
+        acknowledgeMark: () => undefined,
+        close: () => undefined,
+        isConnected: () => true,
+      };
+    },
+  };
+  Object.defineProperty(provider, Symbol.for("openclaw.internal.realtime-voice-provider.v1"), {
+    value: { isBrowserSessionConfigured: () => true, cancelBrowserSession: async () => undefined },
+  });
+  mocks.resolveProvider.mockReturnValue({ provider, providerConfig: {} });
+});
+
+afterEach(async () => {
+  try {
+    if (browserVoiceSessionId) {
+      await closeTalkClientGatewayControlSession({
+        voiceSessionId: browserVoiceSessionId,
+        sessionKey: "main",
+        connId: client.connId,
+      });
+    }
+    cleanupTalkConnection(client.connId, context.logGateway);
+    await Promise.all(
+      [...drainingRelaySessions].map((session) => session.voiceSessionClose ?? Promise.resolve()),
+    );
+  } finally {
+    clientVoiceSessionTesting.reset();
+    embeddedRunTesting.resetActiveEmbeddedRuns();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    await state.cleanup();
+  }
+});
+
+async function createRelayCall() {
+  const respond = await dispatch("talk.session.create", {
+    sessionKey: "main",
+    mode: "realtime",
+    transport: "gateway-relay",
+    brain: "agent-consult",
+  });
+  expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+  const sessionId = (respond.mock.calls[0]![1] as { sessionId: string }).sessionId;
+  const record = getUnifiedTalkSession(sessionId);
+  if (record.kind !== "realtime-relay") {
+    throw new Error("Expected realtime relay");
+  }
+  return { sessionId, target: record.sessionTarget };
+}
+
+it.each([undefined, "main"])(
+  "retains the opaque relay owner when Talk defaults change (key=%s)",
+  async (sessionKey) => {
+    config.session = { scope: "global" };
+    const { sessionId } = await createRelayCall();
+    await replaceSessionEntry(
+      { agentId: "primary", sessionKey: "global" },
+      {
+        sessionId: "private-primary",
+        updatedAt: 1,
+        visibility: "draft",
+        createdActor: { type: "human", source: "profile", id: "another-person" },
+      },
+    );
+    config = { ...config, talk: { agentId: "primary" } };
+    expect(
+      await dispatch("talk.session.steer", {
+        sessionId,
+        ...(sessionKey ? { sessionKey } : {}),
+        text: "status",
+        mode: "status",
+      }),
+    ).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ mode: "status", sessionKey: "global" }),
+      undefined,
+    );
+  },
+);
+
+it.each([undefined, "main"])(
+  "enforces the retained relay's sharing policy (key=%s)",
+  async (sessionKey) => {
+    await replaceSessionEntry(
+      { agentId: "voice", sessionKey: "agent:voice:main" },
+      {
+        sessionId: "shared-before-call",
+        updatedAt: 1,
+        visibility: "shared",
+        createdActor: { type: "human", source: "profile", id: "another-person" },
+      },
+    );
+    const { sessionId, target } = await createRelayCall();
+    const scope = {
+      agentId: target.agentId,
+      sessionKey: target.canonicalKey,
+      storePath: target.storePath,
+    };
+    await replaceSessionEntry(scope, {
+      ...loadSessionEntry(scope)!,
+      visibility: "read-only",
+    });
+    expect(
+      await dispatch("talk.session.steer", {
+        sessionId,
+        ...(sessionKey ? { sessionKey } : {}),
+        text: "status",
+        mode: "status",
+      }),
+    ).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        details: expect.objectContaining({ code: "SESSION_PARTICIPATION_REQUIRED" }),
+      }),
+    );
+  },
+);
+
+it("rejects retained relay mapping changes even when the physical store is unchanged", async () => {
+  const { sessionId } = await createRelayCall();
+  config = { ...config, session: { mainKey: "home" } };
+  expect(
+    await dispatch("talk.session.steer", { sessionId, text: "status", mode: "status" }),
+  ).toHaveBeenCalledWith(
+    false,
+    undefined,
+    expect.objectContaining({
+      code: "INVALID_REQUEST",
+      message: expect.stringContaining("non-canonical persisted row"),
+    }),
+  );
+});
+
+it("fences an opaque relay record replaced after authorization", async () => {
+  const { sessionId } = await createRelayCall();
+  const entered = createDeferredCore();
+  const release = createDeferredCore();
+  const pending = dispatch(
+    "talk.session.steer",
+    { sessionId, text: "status", mode: "status" },
+    {
+      "talk.session.steer": async (request) => {
+        entered.resolve();
+        await release.promise;
+        await talkSessionHandlers["talk.session.steer"]!(request);
+      },
+    },
+  );
+  await entered.promise;
+  rememberUnifiedTalkSession(sessionId, { ...getUnifiedTalkSession(sessionId) });
+  release.resolve();
+  expect(await pending).toHaveBeenCalledWith(
+    false,
+    undefined,
+    expect.objectContaining({
+      details: expect.objectContaining({ code: "SESSION_MUTATION_AUTHORIZATION_CHANGED" }),
+    }),
+  );
+});
+
+it("rechecks RPC sharing authorization after the control runtime import", async () => {
+  config.session = { scope: "global" };
+  const target = prepareTalkSessionTarget(config, "main");
+  const scope = { agentId: "voice", sessionKey: "global", storePath: target.storePath };
+  await replaceSessionEntry(scope, {
+    sessionId: "acl-session",
+    updatedAt: 1,
+    visibility: "shared",
+  });
+  const registration = registerChatAbortController({
+    chatAbortControllers: context.chatAbortControllers,
+    runId: "acl-run",
+    sessionId: "acl-session",
+    sessionKey: "global",
+    agentId: "voice",
+    ownerConnId: client.connId,
+    timeoutMs: 60_000,
+    kind: "chat-send",
+  });
+  const abort = vi.fn();
+  setActiveEmbeddedRun(
+    "acl-session",
+    {
+      runId: "acl-run",
+      queueMessage: async () => undefined,
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort,
+    },
+    "global",
+  );
+  const authorization = resolveSessionMutationAuthorization({
+    client,
+    method: "talk.client.steer",
+    requestParams: { sessionKey: "main" },
+    context,
+  });
+  expect(authorization.error).toBeNull();
+  const runTarget = resolveOwnedActiveTalkRunTarget({
+    context,
+    clientConnId: client.connId,
+    sessionTarget: target,
+    assertCurrent: authorization.authorization!.assertCurrent,
+  });
+  const pending = controlRealtimeVoiceAgentRun({
+    sessionKey: "global",
+    runTarget,
+    text: "cancel",
+    mode: "cancel",
+  });
+  replaceSessionEntrySync(scope, {
+    sessionId: "acl-session",
+    updatedAt: 2,
+    visibility: "read-only",
+    createdActor: { type: "human", source: "profile", id: "another-person" },
+  });
+  try {
+    await expect(pending).rejects.toMatchObject({
+      error: expect.objectContaining({
+        details: expect.objectContaining({ code: "SESSION_PARTICIPATION_REQUIRED" }),
+      }),
+    });
+    expect(abort).not.toHaveBeenCalled();
+  } finally {
+    registration.cleanup();
+  }
+});
+
+it.each([
+  "removed",
+  "replaced",
+  "agent",
+  "key",
+  "connection",
+  "signal",
+  "generation",
+  "cleanup",
+] as const)("fences %s Gateway registration while exact control loads", async (change) => {
+  config.session = { scope: "global" };
+  const target = prepareTalkSessionTarget(config, "main");
+  const runId = "captured-run";
+  const registration = registerChatAbortController({
+    chatAbortControllers: context.chatAbortControllers,
+    runId,
+    sessionId: "captured-session",
+    sessionKey: "global",
+    agentId: "voice",
+    ownerConnId: client.connId,
+    timeoutMs: 60_000,
+    kind: "chat-send",
+  });
+  const abort = vi.fn();
+  setActiveEmbeddedRun(
+    "captured-session",
+    {
+      runId,
+      queueMessage: async () => undefined,
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort,
+    },
+    "global",
+  );
+  const runTarget = resolveOwnedActiveTalkRunTarget({
+    context,
+    clientConnId: client.connId,
+    sessionTarget: target,
+  });
+  expect(runTarget?.isCurrent()).toBe(true);
+  const control = controlRealtimeVoiceAgentRun({
+    sessionKey: "global",
+    runTarget,
+    text: "cancel",
+    mode: "cancel",
+  });
+  const entry = context.chatAbortControllers.get(runId)!;
+  if (change === "removed") {
+    context.chatAbortControllers.delete(runId);
+  } else if (change === "replaced") {
+    context.chatAbortControllers.set(runId, { ...entry });
+  } else if (change === "agent") {
+    entry.agentId = "primary";
+  } else if (change === "key") {
+    entry.sessionKey = "agent:voice:another";
+  } else if (change === "connection") {
+    entry.ownerConnId = "another-client";
+  } else if (change === "generation") {
+    entry.lifecycleGeneration = "retired";
+  } else if (change === "cleanup") {
+    entry.registrationCleanupRequested = true;
+  } else {
+    entry.controller = new AbortController();
+  }
+  try {
+    expect(await control).toMatchObject({ ok: false, active: false, reason: "no_active_run" });
+    expect(abort).not.toHaveBeenCalled();
+  } finally {
+    registration.cleanup();
+  }
+});
+
+it("preserves status and cancellation for an owned queued chat.send reply", async () => {
+  config.session = { scope: "global" };
+  const respond = await dispatch("talk.client.create", {
+    sessionKey: "main",
+    mode: "realtime",
+    transport: "webrtc",
+    brain: "agent-consult",
+    capabilities: ["gateway-control-v1"],
+  });
+  expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+  browserVoiceSessionId = (respond.mock.calls[0]![1] as { voiceSessionId: string }).voiceSessionId;
+  const sessionId = loadSessionEntry({ agentId: "voice", sessionKey: "global" })!.sessionId;
+  const registration = registerChatAbortController({
+    chatAbortControllers: context.chatAbortControllers,
+    runId: "queued-talk",
+    sessionId,
+    sessionKey: "global",
+    agentId: "voice",
+    ownerConnId: client.connId,
+    timeoutMs: 60_000,
+    kind: "chat-send",
+  });
+  const operation = replyRunRegistry.begin({
+    sessionKey: "global",
+    sessionId,
+    resetTriggered: false,
+    upstreamAbortSignal: registration.controller.signal,
+  });
+  const runTarget = resolveOwnedActiveTalkRunTarget({
+    context,
+    clientConnId: client.connId,
+    sessionTarget: prepareTalkSessionTarget(config, "main"),
+  });
+  const resolvedSessionId = "materialized-reply-session";
+  context.chatAbortControllers.get("queued-talk")!.sessionId = resolvedSessionId;
+  operation.updateSessionId(resolvedSessionId);
+  try {
+    expect(
+      await controlRealtimeVoiceAgentRun({
+        sessionKey: "global",
+        runTarget,
+        text: "status",
+        mode: "status",
+      }),
+    ).toMatchObject({ active: true, sessionId: resolvedSessionId });
+    expect(
+      await dispatch("talk.client.steer", { sessionKey: "main", text: "status", mode: "status" }),
+    ).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ active: true, sessionId: resolvedSessionId }),
+      undefined,
+    );
+    expect(
+      await dispatch("talk.client.steer", { sessionKey: "main", text: "cancel", mode: "cancel" }),
+    ).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ ok: true, aborted: true, sessionId: resolvedSessionId }),
+      undefined,
+    );
+    expect(operation.abortSignal.aborted).toBe(true);
+    expect(mocks.runEmbeddedAgent).not.toHaveBeenCalled();
+  } finally {
+    operation.complete();
+    registration.cleanup();
+  }
+});
+
+describe.each(["browser", "relay"] as const)("native %s Talk consultation", (transport) => {
+  it.each([
+    { name: "custom main", scope: "per-sender" as const, canonicalKey: "agent:voice:home" },
+    { name: "global", scope: "global" as const, canonicalKey: "global" },
+  ])("uses the created $name session in the provider callback", async ({ scope, canonicalKey }) => {
+    config.session = { mainKey: "home", scope };
+    const target = prepareTalkSessionTarget(config, "main");
+    const method = transport === "browser" ? "talk.client.create" : "talk.session.create";
+    const respond = await dispatch(method, {
+      sessionKey: "main",
+      mode: "realtime",
+      transport: transport === "browser" ? "webrtc" : "gateway-relay",
+      brain: "agent-consult",
+      ...(transport === "browser" ? { capabilities: ["gateway-control-v1"] } : {}),
+    });
+    expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+    const result = respond.mock.calls[0]?.[1] as { voiceSessionId?: string; sessionId?: string };
+    browserVoiceSessionId = result.voiceSessionId;
+    const storage = { agentId: "voice", sessionKey: canonicalKey, storePath: target.storePath };
+    const created = loadSessionEntry(storage);
+    expect(created?.sessionId).toBeTruthy();
+    expect(callback).toBeTypeOf("function");
+    await expect(callback!({ prompt: "Continue this conversation" })).resolves.toEqual({
+      text: "Synthetic consult answer",
+    });
+    expect(mocks.runEmbeddedAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "voice",
+        sessionKey: canonicalKey,
+        sessionId: created!.sessionId,
+        sessionTarget: { ...storage, sessionId: created!.sessionId },
+      }),
+    );
+    expect(
+      listSessionEntriesReadOnly({ agentId: "voice", storePath: target.storePath }).map(
+        (entry) => entry.sessionKey,
+      ),
+    ).toEqual([canonicalKey]);
+    expect(
+      clientVoiceSessionTesting.readRecord("voice", result.voiceSessionId ?? result.sessionId!)
+        ?.sessionKey,
+    ).toBe("main");
+  });
+});
+
+describe.each(["browser-rpc", "browser-provider", "relay"] as const)(
+  "native %s exact control",
+  (surface) => {
+    it.each(["foreign global", "replaced run", "reused run ID"] as const)(
+      "never cancels the %s owner",
+      async (replacement) => {
+        config.session = { scope: "global" };
+        const started = createDeferredCore<RunEmbeddedAgentParams>();
+        const finish = createDeferredCore();
+        const abortOwned = vi.fn(() => finish.resolve());
+        const abortOther = vi.fn();
+        mocks.runEmbeddedAgent.mockImplementationOnce(async (params) => {
+          const handle = {
+            runId: params.runId,
+            queueMessage: async () => undefined,
+            isStreaming: () => true,
+            isCompacting: () => false,
+            abort: abortOwned,
+          };
+          setActiveEmbeddedRun(params.sessionId, handle, params.sessionKey);
+          started.resolve(params);
+          try {
+            await finish.promise;
+            return { payloads: [{ text: "Synthetic consult answer" }], meta: { durationMs: 0 } };
+          } finally {
+            clearActiveEmbeddedRun(params.sessionId, handle, params.sessionKey);
+          }
+        });
+        const browser = surface !== "relay";
+        const respond = await dispatch(browser ? "talk.client.create" : "talk.session.create", {
+          sessionKey: "main",
+          mode: "realtime",
+          brain: "agent-consult",
+          transport: browser ? "webrtc" : "gateway-relay",
+          ...(browser ? { capabilities: ["gateway-control-v1"] } : {}),
+        });
+        expect(respond).toHaveBeenCalledWith(true, expect.any(Object), undefined);
+        const result = respond.mock.calls[0]![1] as { voiceSessionId?: string; sessionId?: string };
+        browserVoiceSessionId = result.voiceSessionId;
+        const consult = callback!({ prompt: "Keep working" });
+        try {
+          const active = await Promise.race([
+            started.promise,
+            consult.then(() => {
+              throw new Error("consult ended before model dispatch");
+            }),
+          ]);
+          expect(context.chatAbortControllers.get(active.runId)).toMatchObject({
+            agentId: "voice",
+            sessionKey: "global",
+            sessionId: active.sessionId,
+          });
+          setActiveEmbeddedRun(
+            replacement === "replaced run" ? active.sessionId : "other-agent-session",
+            {
+              runId: replacement === "reused run ID" ? active.runId : "other-run",
+              queueMessage: async () => undefined,
+              isStreaming: () => true,
+              isCompacting: () => false,
+              abort: abortOther,
+            },
+            "global",
+          );
+          expect(
+            await dispatch("talk.client.steer", {
+              sessionKey: "agent:primary:main",
+              text: "cancel",
+              mode: "cancel",
+            }),
+          ).toHaveBeenCalledWith(
+            false,
+            undefined,
+            expect.objectContaining({ code: "INVALID_REQUEST" }),
+          );
+          if (surface === "browser-provider") {
+            browserControl!.onToolCall?.({
+              callId: "control",
+              itemId: "control",
+              name: "openclaw_agent_control",
+              args: { text: "cancel", mode: "cancel" },
+            });
+            await vi.waitFor(() =>
+              expect(submitProviderResult).toHaveBeenCalledWith(
+                "control",
+                expect.objectContaining({ ok: replacement === "foreign global", mode: "cancel" }),
+              ),
+            );
+          } else {
+            const control = await dispatch(browser ? "talk.client.steer" : "talk.session.steer", {
+              ...(browser ? {} : { sessionId: result.sessionId }),
+              sessionKey: "main",
+              text: "cancel",
+              mode: "cancel",
+            });
+            expect(control).toHaveBeenCalledWith(
+              true,
+              expect.objectContaining({ ok: replacement === "foreign global", mode: "cancel" }),
+              undefined,
+            );
+          }
+          expect(abortOwned).toHaveBeenCalledTimes(replacement === "foreign global" ? 1 : 0);
+          expect(abortOther).not.toHaveBeenCalled();
+          expect(
+            clientVoiceSessionTesting.readRecord(
+              "voice",
+              result.voiceSessionId ?? result.sessionId!,
+            )?.sessionKey,
+          ).toBe("main");
+        } finally {
+          finish.resolve();
+          await consult;
+        }
+      },
+    );
+  },
+);

--- a/src/gateway/server-methods/talk-session.ts
+++ b/src/gateway/server-methods/talk-session.ts
@@ -328,6 +328,7 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           kind: "realtime-relay",
           connId,
           relaySessionId: session.relaySessionId,
+          sessionTarget: target,
         });
         return respondOk(respond, {
           ...session,
@@ -491,7 +492,7 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
       respondUnavailable(respond, err);
     }
   },
-  "talk.session.steer": async ({ params, respond, client }) => {
+  "talk.session.steer": async ({ params, respond, client, sessionMutationAuthorization }) => {
     if (!assertValidParams(params, validateTalkSessionSteerParams, "talk.session.steer", respond)) {
       return;
     }
@@ -499,12 +500,24 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
       const session = getUnifiedTalkSession(params.sessionId);
       if (session.kind === "realtime-relay") {
         const connId = requireUnifiedTalkSessionConn(session, client?.connId);
+        const assertCurrent = () => {
+          sessionMutationAuthorization?.assertCurrent();
+          if (
+            getUnifiedTalkSession(params.sessionId) !== session ||
+            (sessionMutationAuthorization?.talkSessionTarget &&
+              sessionMutationAuthorization.talkSessionTarget !== session.sessionTarget)
+          ) {
+            throw new Error("Talk session changed while steering the agent run");
+          }
+        };
+        assertCurrent();
         const result = await steerTalkRealtimeRelayAgentRun({
           relaySessionId: session.relaySessionId,
           connId,
           sessionKey: normalizeOptionalString(params.sessionKey),
           text: params.text,
           mode: normalizeOptionalString(params.mode),
+          assertCurrent,
         });
         respondOk(respond, result);
         return;

--- a/src/gateway/server-methods/talk-session.ts
+++ b/src/gateway/server-methods/talk-session.ts
@@ -13,20 +13,15 @@ import {
   validateTalkSessionSubmitToolResultParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { AgentSelectionRequiredError } from "../../agents/agent-scope.js";
-import { buildAgentMainSessionKey, parseAgentSessionKey } from "../../routing/session-key.js";
 import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL } from "../../talk/agent-consult-tool.js";
 import { REALTIME_VOICE_AGENT_CONTROL_TOOL } from "../../talk/agent-run-control-shared.js";
 import { controlRealtimeVoiceAgentRun } from "../../talk/agent-run-control.js";
-import { resolveTalkSessionAgentId } from "../../talk/agent-target.js";
 import { ensureClientVoiceAgentSessionEntry } from "../../talk/client-voice-session.js";
 import { resolveConfiguredRealtimeVoiceProvider } from "../../talk/provider-resolver.js";
-import {
-  authorizeGatewaySessionCreation,
-  resolveSandboxedSessionCreation,
-} from "../operator-role-policy.js";
+import { resolveSandboxedSessionCreation } from "../operator-role-policy.js";
 import { ADMIN_SCOPE } from "../operator-scopes.js";
-import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
+import { SessionMutationAuthorizationChangedError } from "../session-sharing.js";
 import { resolveSessionKeyFromResolveParams } from "../sessions-resolve.js";
 import { resolveTalkAgentConsultAuthority } from "../talk-client-gateway-control.js";
 import { createTalkHandoff, getTalkHandoff, revokeTalkHandoff } from "../talk-handoff.js";
@@ -44,12 +39,14 @@ import {
   rememberUnifiedTalkSession,
   requireUnifiedTalkSessionConn,
 } from "../talk-session-registry.js";
+import { requirePreparedTalkSessionTarget } from "../talk-session-target.js";
 import {
   createTalkTranscriptionRelaySession,
   sendTalkTranscriptionRelayAudio,
   stopTalkTranscriptionRelaySession,
 } from "../talk-transcription-relay.js";
 import { formatForLog } from "../ws-log.js";
+import { resolveOperatorSessionCreation } from "./session-creation-provenance.js";
 import { acknowledgeTalkSessionMark } from "./talk-session-mark.js";
 import {
   broadcastTalkRoomEvents,
@@ -105,6 +102,10 @@ function respondInvalidRequest(respond: RespondFn, message: string) {
 }
 
 function respondUnavailable(respond: RespondFn, err: unknown) {
+  if (err instanceof SessionMutationAuthorizationChangedError) {
+    respond(false, undefined, err.error);
+    return;
+  }
   const message = formatForLog(err);
   if (err instanceof AgentSelectionRequiredError) {
     respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, message));
@@ -131,7 +132,14 @@ function respondOk(respond: RespondFn, payload: unknown = { ok: true }) {
 
 /** RPC handlers for gateway-managed Talk sessions and room lifecycle. */
 export const talkSessionHandlers: GatewayRequestHandlers = {
-  "talk.session.create": async ({ params, respond, context, client }) => {
+  "talk.session.create": async ({
+    params,
+    respond,
+    context,
+    client,
+    sessionMutationAuthorization,
+    sessionMutationCommitGuard,
+  }) => {
     if (
       !assertValidParams(params, validateTalkSessionCreateParams, "talk.session.create", respond)
     ) {
@@ -150,6 +158,7 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
       return;
     }
     try {
+      sessionMutationAuthorization?.assertCurrent();
       if (transport === "managed-room") {
         if (brain === "direct-tools" && !canUseTalkDirectTools(client)) {
           respondInvalidRequest(
@@ -168,23 +177,16 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           return;
         }
         const runtimeConfig = context.getRuntimeConfig();
-        const bareTalkAgentId =
-          requestedSessionKey && !parseAgentSessionKey(requestedSessionKey)
-            ? resolveTalkSessionAgentId(runtimeConfig, requestedSessionKey)
-            : undefined;
-        const requestedOwner = requestedSessionKey
-          ? resolveRequestedSessionAgentId(runtimeConfig, requestedSessionKey, bareTalkAgentId)
+        const target = requestedSessionKey
+          ? requirePreparedTalkSessionTarget(sessionMutationAuthorization?.talkSessionTarget)
           : undefined;
-        if (requestedOwner && !requestedOwner.ok) {
-          respond(false, undefined, requestedOwner.error);
-          return;
-        }
+        sessionMutationAuthorization?.assertCurrent();
         const resolvedSession = await resolveSessionKeyFromResolveParams({
           cfg: runtimeConfig,
           client,
           p: {
-            key: requestedSessionKey,
-            ...(requestedOwner?.agentId ? { agentId: requestedOwner.agentId } : {}),
+            key: target?.canonicalKey,
+            ...(target ? { agentId: target.agentId } : {}),
             ...(spawnedBy ? { spawnedBy } : {}),
             includeGlobal: true,
             includeUnknown: true,
@@ -198,6 +200,8 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           respondInvalidRequest(respond, `No session found: ${params.sessionKey}`);
           return;
         }
+        sessionMutationCommitGuard?.();
+        sessionMutationAuthorization?.assertCurrent();
         const handoff = createTalkHandoff({
           sessionKey: resolvedSession.key,
           provider: normalizeOptionalString(params.provider),
@@ -253,22 +257,15 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           requested: params,
           defaults: realtimeConfig,
         });
-        const requestedSessionKey = normalizeOptionalString(params.sessionKey);
-        const bareTalkAgentId =
-          requestedSessionKey && !parseAgentSessionKey(requestedSessionKey)
-            ? resolveTalkSessionAgentId(runtimeConfig, requestedSessionKey)
-            : undefined;
-        const requestedOwner = requestedSessionKey
-          ? resolveRequestedSessionAgentId(runtimeConfig, requestedSessionKey, bareTalkAgentId)
-          : undefined;
-        if (requestedOwner && !requestedOwner.ok) {
-          respond(false, undefined, requestedOwner.error);
-          return;
-        }
-        const agentId =
-          requestedOwner?.agentId ??
-          bareTalkAgentId ??
-          resolveTalkSessionAgentId(runtimeConfig, requestedSessionKey);
+        const target = requirePreparedTalkSessionTarget(
+          sessionMutationAuthorization?.talkSessionTarget,
+        );
+        const { agentId } = target;
+        const assertCommitAllowed = () => {
+          sessionMutationCommitGuard?.();
+          sessionMutationAuthorization?.assertCurrent();
+        };
+        assertCommitAllowed();
         assertSecretOwnerAvailable("capability", "talk:realtime");
         const resolution = resolveConfiguredRealtimeVoiceProvider({
           configuredProviderId: realtimeConfig.provider,
@@ -289,30 +286,28 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           // GPT-Live delegates natively; forced transcript consults are a GA-model mode.
           return respondInvalidRequest(respond, relayLaunch.error);
         }
-        const realtimeContext = await resolveTalkRealtimeProviderInstructions({
+        const providerInstructions = await resolveTalkRealtimeProviderInstructions({
           config: runtimeConfig,
           agentId,
           configuredInstructions: realtimeConfig.instructions,
-          sessionKey: params.sessionKey,
-          requireSessionKeyForProfile: true,
+          sessionKey: target.canonicalKey,
           warn: (message) => context.logGateway.warn(`talk realtime context: ${message}`),
         });
-        const sessionKey =
-          realtimeContext.requestedSessionKey ??
-          buildAgentMainSessionKey({ agentId: realtimeContext.agentId });
-        const creationError = authorizeGatewaySessionCreation({
-          cfg: runtimeConfig,
-          client,
-          agentId: realtimeContext.agentId,
+        assertCommitAllowed();
+        const ensuredSessionId = await ensureClientVoiceAgentSessionEntry({
+          agentId,
+          sessionKey: target.canonicalKey,
+          storePath: target.storePath,
+          creation:
+            resolveSandboxedSessionCreation(client, runtimeConfig) ??
+            resolveOperatorSessionCreation(client),
+          assertCommitAllowed,
         });
-        if (creationError) {
-          respond(false, undefined, creationError);
-          return;
-        }
-        await ensureClientVoiceAgentSessionEntry({
-          agentId: realtimeContext.agentId,
-          sessionKey,
-          creation: resolveSandboxedSessionCreation(client, runtimeConfig),
+        sessionMutationCommitGuard?.();
+        sessionMutationAuthorization?.assertTargetCurrent({
+          agentId,
+          sessionKey: target.canonicalKey,
+          ensuredSessionId,
         });
         const session = createTalkRealtimeRelaySession({
           context,
@@ -321,10 +316,10 @@ export const talkSessionHandlers: GatewayRequestHandlers = {
           consultAuthority: resolveTalkAgentConsultAuthority(client?.connect?.scopes),
           provider: resolution.provider,
           providerConfig: relayLaunch.providerConfig,
-          instructions: buildRealtimeInstructions(realtimeContext.instructions),
+          instructions: buildRealtimeInstructions(providerInstructions),
           tools: [REALTIME_VOICE_AGENT_CONSULT_TOOL, REALTIME_VOICE_AGENT_CONTROL_TOOL],
           model: launchOptions.model,
-          sessionKey,
+          sessionTarget: target,
           voice: launchOptions.voice,
           language: normalizeOptionalLowercaseString(params.language),
           forceAgentConsultOnFinalTranscript: relayLaunch.forceAgentConsultOnFinalTranscript,

--- a/src/gateway/server-methods/talk-shared.ts
+++ b/src/gateway/server-methods/talk-shared.ts
@@ -17,7 +17,6 @@ import {
 import type { RealtimeTranscriptionProviderConfig } from "../../realtime-transcription/provider-types.js";
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME } from "../../talk/agent-consult-tool.js";
 import { REALTIME_VOICE_AGENT_CONTROL_TOOL_NAME } from "../../talk/agent-run-control-shared.js";
-import { resolveTalkSessionAgentId, resolveTalkTargetAgentId } from "../../talk/agent-target.js";
 import { resolveInternalRealtimeVoiceGatewayRelayLaunchError } from "../../talk/provider-internal.js";
 import { listRealtimeVoiceProviders } from "../../talk/provider-registry.js";
 import type {
@@ -64,38 +63,15 @@ export function normalizeTalkSessionBrain(params: { mode: TalkMode; brain?: stri
 
 export async function resolveTalkRealtimeProviderInstructions(params: {
   config: OpenClawConfig;
-  agentId?: string;
+  agentId: string;
   configuredInstructions?: string;
-  sessionKey?: unknown;
-  /** Relay sessions bind their agent lazily; injecting a guessed profile would mix agents. */
-  requireSessionKeyForProfile?: boolean;
+  sessionKey: string;
   warn: (message: string) => void;
-}): Promise<{ agentId: string; instructions: string; requestedSessionKey?: string }> {
-  const requestedSessionKey = normalizeOptionalString(params.sessionKey);
-  const defaultAgentId = resolveTalkTargetAgentId(params.config);
-  // Older clients can prefetch without a key. Client-owned creates bind to the
-  // default agent immediately, so its workspace profile stays consistent there.
-  const agentId =
-    params.agentId ??
-    (requestedSessionKey
-      ? resolveTalkSessionAgentId(params.config, requestedSessionKey)
-      : defaultAgentId);
-  const bootstrapContext =
-    params.requireSessionKeyForProfile && !requestedSessionKey
-      ? undefined
-      : await resolveRealtimeBootstrapContextInstructions({
-          agentId,
-          config: params.config,
-          sessionKey: requestedSessionKey,
-          warn: params.warn,
-        });
-  return {
-    agentId,
-    instructions: [params.configuredInstructions, bootstrapContext]
-      .filter((entry): entry is string => Boolean(entry?.trim()))
-      .join("\n\n"),
-    ...(requestedSessionKey ? { requestedSessionKey } : {}),
-  };
+}): Promise<string> {
+  const bootstrapContext = await resolveRealtimeBootstrapContextInstructions(params);
+  return [params.configuredInstructions, bootstrapContext]
+    .filter((entry): entry is string => Boolean(entry?.trim()))
+    .join("\n\n");
 }
 
 export function canUseTalkDirectTools(client: { connect?: { scopes?: string[] } } | null): boolean {

--- a/src/gateway/server-methods/talk-target.test.ts
+++ b/src/gateway/server-methods/talk-target.test.ts
@@ -1,0 +1,660 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  loadSessionEntry,
+  readSessionTranscriptMessageEvents,
+  replaceSessionEntry,
+} from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { setActivePluginRegistry } from "../../plugins/runtime.js";
+import type { RealtimeVoiceProviderPlugin } from "../../plugins/types.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { ensureProfileForEmail } from "../../state/user-profiles.js";
+import * as clientVoiceSession from "../../talk/client-voice-session.js";
+import { clientVoiceSessionTesting } from "../../talk/client-voice-session.test-support.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import { handleGatewayRequest } from "../server-methods.js";
+import { sharingPolicyClient } from "../session-sharing.test-utils.js";
+import { closeTalkClientGatewayControlSession } from "../talk-client-gateway-control.js";
+import { cleanupTalkConnection } from "../talk-session-registry.js";
+import { createTalkClient } from "./talk-client-create.js";
+import { talkClientHandlers } from "./talk-client.js";
+import { talkSessionHandlers } from "./talk-session.js";
+import type { GatewayRequestContext, GatewayRequestHandlers } from "./types.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveConfiguredRealtimeVoiceProvider: vi.fn(),
+  bootstrap: vi.fn(async () => undefined),
+  createRelay: vi.fn(() => ({
+    relaySessionId: "test-relay",
+    provider: "test-voice",
+    transport: "gateway-relay",
+  })),
+  createTranscription: vi.fn(() => ({ transcriptionSessionId: "test-dictation" })),
+  transcriptionProviders: vi.fn(() => []),
+}));
+
+vi.mock("../../talk/provider-resolver.js", () => ({
+  resolveConfiguredRealtimeVoiceProvider: mocks.resolveConfiguredRealtimeVoiceProvider,
+  resolveRealtimeVoiceProviderCapabilities: ({
+    provider,
+  }: {
+    provider: RealtimeVoiceProviderPlugin;
+  }) => provider.capabilities,
+}));
+vi.mock("../../talk/provider-registry.js", () => ({ listRealtimeVoiceProviders: () => [] }));
+vi.mock("../../agents/realtime-bootstrap-context.js", () => ({
+  resolveRealtimeBootstrapContextInstructions: mocks.bootstrap,
+}));
+vi.mock("../talk-realtime-relay.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../talk-realtime-relay.js")>()),
+  createTalkRealtimeRelaySession: mocks.createRelay,
+}));
+vi.mock("../talk-transcription-relay.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../talk-transcription-relay.js")>()),
+  createTalkTranscriptionRelaySession: mocks.createTranscription,
+}));
+vi.mock("../../realtime-transcription/provider-registry.js", () => ({
+  listRealtimeTranscriptionProviders: mocks.transcriptionProviders,
+  getRealtimeTranscriptionProvider: () => undefined,
+}));
+
+const createParams = {
+  mode: "realtime",
+  transport: "webrtc",
+  brain: "agent-consult",
+  silenceDurationMs: 400,
+  capabilities: ["gateway-control-v1"],
+};
+
+const browserSession = {
+  provider: "test-voice",
+  transport: "webrtc" as const,
+  clientSecret: "synthetic-offer-token",
+  offerUrl: "/test/voice/offer",
+};
+
+let state: OpenClawTestState;
+let config: OpenClawConfig;
+let client: ReturnType<typeof sharingPolicyClient> & { connId: string };
+const createBrowserSession = vi.fn<
+  NonNullable<RealtimeVoiceProviderPlugin["createBrowserSession"]>
+>(async () => browserSession);
+const createdCalls: Array<{ sessionKey: string; voiceSessionId: string }> = [];
+const cancelBrowserSession = vi.fn(async () => undefined);
+const context = {
+  getRuntimeConfig: () => config,
+  getClientConnIds: () => new Set([client.connId]),
+  chatAbortControllers: new Map(),
+  logGateway: { warn: vi.fn() },
+  broadcastToConnIds: vi.fn(),
+} as unknown as GatewayRequestContext;
+
+async function dispatch(
+  method: string,
+  params: Record<string, unknown>,
+  handlers: GatewayRequestHandlers = {},
+) {
+  const respond = vi.fn();
+  await handleGatewayRequest({
+    req: { type: "req", id: "talk-request", method, params },
+    client,
+    context,
+    isWebchatConnect: () => false,
+    respond,
+    extraHandlers: { ...talkClientHandlers, ...talkSessionHandlers, ...handlers },
+  });
+  if (method === "talk.client.create" && respond.mock.calls[0]?.[0] === true) {
+    const { voiceSessionId } = respond.mock.calls[0][1] as { voiceSessionId: string };
+    const record = ["voice", "primary"]
+      .map((agentId) => clientVoiceSessionTesting.readRecord(agentId, voiceSessionId))
+      .find(Boolean);
+    if (record) {
+      createdCalls.push({ sessionKey: record.sessionKey, voiceSessionId });
+    }
+  }
+  return respond;
+}
+
+beforeEach(async () => {
+  state = await createOpenClawTestState({ label: "talk-target" });
+  client = {
+    ...sharingPolicyClient({ user: ensureProfileForEmail("listener@example.test").id }),
+    connId: "talk-target-test",
+  };
+  config = {
+    agents: { ownership: "explicit", entries: { primary: {}, voice: {} } },
+    talk: { agentId: "voice" },
+  };
+  vi.clearAllMocks();
+  createdCalls.length = 0;
+  createBrowserSession.mockReset().mockResolvedValue(browserSession);
+  mocks.bootstrap.mockReset().mockResolvedValue(undefined);
+  setActivePluginRegistry(createEmptyPluginRegistry());
+  const provider = {
+    id: "test-voice",
+    capabilities: { supportsGatewayControl: true, supportsToolCalls: true },
+    createBrowserSession,
+  };
+  Object.defineProperty(provider, Symbol.for("openclaw.internal.realtime-voice-provider.v1"), {
+    value: { isBrowserSessionConfigured: () => true, cancelBrowserSession },
+  });
+  mocks.resolveConfiguredRealtimeVoiceProvider.mockReturnValue({ provider, providerConfig: {} });
+});
+
+afterEach(async () => {
+  try {
+    for (const call of createdCalls) {
+      await closeTalkClientGatewayControlSession({ ...call, connId: client.connId });
+    }
+    cleanupTalkConnection(client.connId, context.logGateway);
+  } finally {
+    vi.restoreAllMocks();
+    clientVoiceSessionTesting.reset();
+    setActivePluginRegistry(createEmptyPluginRegistry());
+    await state.cleanup();
+  }
+});
+
+describe("Talk target preparation through Gateway authorization", () => {
+  it.each(["main", undefined])("uses the configured Talk owner for %s", async (sessionKey) => {
+    const respond = await dispatch("talk.client.create", {
+      ...createParams,
+      ...(sessionKey ? { sessionKey } : {}),
+    });
+    expect(respond).toHaveBeenCalledWith(true, expect.objectContaining(browserSession), undefined);
+    expect(createBrowserSession).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "voice" }),
+    );
+    expect(
+      loadSessionEntry({ agentId: "voice", sessionKey: "agent:voice:main" })?.sessionId,
+    ).toBeTruthy();
+  });
+
+  it.each<{ name: string; agents: NonNullable<OpenClawConfig["agents"]> }>([
+    { name: "sole agent", agents: { entries: { voice: {} }, ownership: "explicit" as const } },
+    {
+      name: "system agent",
+      agents: {
+        entries: { primary: {}, voice: {} },
+        ownership: "explicit" as const,
+        defaults: { systemAgent: { agentId: "voice" } },
+      },
+    },
+    { name: "legacy default", agents: { entries: { primary: {}, voice: { default: true } } } },
+  ])("uses a valid $name default without talk.agentId", async ({ agents }) => {
+    config = { agents };
+    const respond = await dispatch("talk.client.create", createParams);
+    expect(respond).toHaveBeenCalledWith(true, expect.objectContaining(browserSession), undefined);
+    expect(createBrowserSession).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "voice" }),
+    );
+  });
+
+  it.each([
+    { agentId: "voice", withoutOwner: true, name: "missing ambient owner" },
+    { agentId: "primary", withoutOwner: false, name: "different Talk owner" },
+  ])("honors the explicitly selected session with a $name", async ({ agentId, withoutOwner }) => {
+    if (withoutOwner) {
+      delete config.talk;
+    }
+    const sessionKey = `agent:${agentId}:selected`;
+    const respond = await dispatch("talk.client.create", { ...createParams, sessionKey });
+    expect(respond).toHaveBeenCalledWith(true, expect.objectContaining(browserSession), undefined);
+    expect(mocks.bootstrap).toHaveBeenCalledWith(expect.objectContaining({ agentId, sessionKey }));
+  });
+
+  it("rejects ambiguous default ownership before loading profile or provider state", async () => {
+    delete config.talk;
+    const respond = await dispatch("talk.client.create", createParams);
+    expect(respond).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({
+        code: "INVALID_REQUEST",
+        message: expect.stringContaining("explicit owner"),
+      }),
+    );
+    expect(mocks.bootstrap).not.toHaveBeenCalled();
+    expect(createBrowserSession).not.toHaveBeenCalled();
+  });
+
+  it.each(["read-only", "draft", "incognito"] as const)(
+    "applies %s restrictions to bare and omitted create targets",
+    async (restriction) => {
+      await replaceSessionEntry(
+        { agentId: "voice", sessionKey: "agent:voice:main" },
+        {
+          sessionId: "private-session",
+          updatedAt: 1,
+          createdActor: { type: "human", source: "profile", id: "another-person" },
+          ...(restriction === "incognito" ? { incognito: true } : { visibility: restriction }),
+        },
+      );
+      for (const method of ["talk.client.create", "talk.session.create"]) {
+        for (const sessionKey of ["main", undefined]) {
+          const respond = await dispatch(method, {
+            mode: "realtime",
+            brain: "agent-consult",
+            transport: method === "talk.client.create" ? "webrtc" : "gateway-relay",
+            ...(sessionKey ? { sessionKey } : {}),
+          });
+          expect(respond).toHaveBeenCalledWith(
+            false,
+            undefined,
+            expect.objectContaining({ code: "INVALID_REQUEST" }),
+          );
+        }
+      }
+      expect(createBrowserSession).not.toHaveBeenCalled();
+      expect(mocks.createRelay).not.toHaveBeenCalled();
+      expect(mocks.bootstrap).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { name: "custom main", sessionKey: "main", mainKey: "home", canonicalKey: "agent:voice:home" },
+    { name: "omitted custom main", mainKey: "home", canonicalKey: "agent:voice:home" },
+    { name: "global alias", sessionKey: "main", global: true, canonicalKey: "global" },
+    {
+      name: "global explicit owner",
+      sessionKey: "agent:voice:main",
+      global: true,
+      canonicalKey: "global",
+    },
+    { name: "omitted global", global: true, canonicalKey: "global" },
+    {
+      name: "fixed-store owner",
+      sessionKey: "main",
+      fixed: true,
+      canonicalKey: "agent:primary:main",
+    },
+    { name: "omitted fixed-store owner", fixed: true, canonicalKey: "agent:primary:main" },
+    {
+      name: "global fixed-store owner",
+      sessionKey: "main",
+      fixed: true,
+      global: true,
+      canonicalKey: "global",
+    },
+    {
+      name: "explicit global fixed-store owner",
+      sessionKey: "agent:primary:main",
+      fixed: true,
+      global: true,
+      canonicalKey: "global",
+    },
+  ])(
+    "shares one canonical storage target for $name while retaining the exact voice key",
+    async (entry) => {
+      const agentId = entry.fixed ? "primary" : "voice";
+      config.session = {
+        ...(entry.mainKey ? { mainKey: entry.mainKey } : {}),
+        ...(entry.global ? { scope: "global" } : {}),
+        ...(entry.fixed ? { store: state.statePath("shared", "sessions.sqlite") } : {}),
+      };
+      if (entry.fixed) {
+        config.agents!.defaults = { sessionStore: { agentId } };
+      }
+      const params = Object.freeze({
+        ...createParams,
+        ...(entry.sessionKey ? { sessionKey: entry.sessionKey } : {}),
+      });
+      const respond = await dispatch("talk.client.create", params);
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining(browserSession),
+        undefined,
+      );
+      const { voiceSessionId } = respond.mock.calls[0]![1] as { voiceSessionId: string };
+      const voiceKey = entry.sessionKey ?? `agent:${agentId}:${entry.mainKey ?? "main"}`;
+      expect(clientVoiceSessionTesting.readRecord(agentId, voiceSessionId)?.sessionKey).toBe(
+        voiceKey,
+      );
+      const scope = {
+        agentId,
+        sessionKey: entry.canonicalKey,
+        ...(entry.fixed ? { storePath: config.session.store } : {}),
+      };
+      const stored = loadSessionEntry(scope);
+      expect(stored?.sessionId).toBeTruthy();
+      expect(mocks.bootstrap).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId, sessionKey: entry.canonicalKey }),
+      );
+      expect(
+        await dispatch("talk.client.transcript", {
+          sessionKey: voiceKey,
+          voiceSessionId,
+          entryId: "utterance",
+          role: "user",
+          text: "Synthetic speech",
+        }),
+      ).toHaveBeenCalledWith(true, { ok: true }, undefined);
+      expect(
+        readSessionTranscriptMessageEvents({ ...scope, sessionId: stored!.sessionId }),
+      ).toHaveLength(1);
+      if (voiceKey !== entry.canonicalKey) {
+        expect(
+          await dispatch("talk.client.close", { sessionKey: entry.canonicalKey, voiceSessionId }),
+        ).toHaveBeenCalledWith(
+          false,
+          undefined,
+          expect.objectContaining({ code: "INVALID_REQUEST" }),
+        );
+      }
+      expect(
+        await dispatch("talk.client.close", { sessionKey: voiceKey, voiceSessionId }),
+      ).toHaveBeenCalledWith(true, { ok: true }, undefined);
+    },
+  );
+
+  it.each([
+    { name: "missing key", params: { voiceSessionId: "relay-call" } },
+    { name: "missing voice id", params: { sessionKey: "main" } },
+    { name: "relay origin", params: { sessionKey: "main", voiceSessionId: "relay-call" } },
+  ])("rejects a client close with $name without changing the voice record", async ({ params }) => {
+    clientVoiceSession.createOrResumeClientVoiceSession({
+      agentId: "voice",
+      sessionKey: "main",
+      voiceSessionId: "relay-call",
+      origin: "relay",
+    });
+    expect(await dispatch("talk.client.close", params)).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "INVALID_REQUEST" }),
+    );
+    expect(clientVoiceSessionTesting.readRecord("voice", "relay-call")?.status).toBe("open");
+  });
+
+  it.each(["primary", "retired"])(
+    "rejects a global key conflicting with fixed-store owner %s",
+    async (owner) => {
+      config.session = { scope: "global", store: state.statePath("shared", "sessions.sqlite") };
+      config.agents!.defaults = { sessionStore: { agentId: owner } };
+      const respond = await dispatch("talk.client.create", {
+        ...createParams,
+        sessionKey: "agent:voice:main",
+      });
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({ code: "INVALID_REQUEST" }),
+      );
+      expect(createBrowserSession).not.toHaveBeenCalled();
+      expect(mocks.bootstrap).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    "owner",
+    "removed-agent",
+    "main-key",
+    "global-main-key",
+    "scope",
+    "store",
+    "sharing",
+    "incognito",
+  ] as const)(
+    "rejects %s changes during provider creation without writing a different target",
+    async (change) => {
+      const gate = createDeferredCore<typeof browserSession>();
+      const started = createDeferredCore();
+      createBrowserSession.mockImplementationOnce(async () => {
+        started.resolve();
+        return await gate.promise;
+      });
+      if (change === "global-main-key") {
+        config.session = { scope: "global" };
+      }
+      const pending = dispatch("talk.client.create", {
+        ...createParams,
+        ...(change === "global-main-key" ? {} : { sessionKey: "main" }),
+      });
+      await started.promise;
+      if (change === "removed-agent") {
+        config = { ...config, agents: { ownership: "explicit", entries: { primary: {} } } };
+      } else if (change === "global-main-key") {
+        config = { ...config, session: { scope: "global", mainKey: "changed" } };
+      } else if (change === "owner") {
+        config = { ...config, talk: { agentId: "primary" } };
+      } else if (change === "main-key") {
+        config = { ...config, session: { mainKey: "changed" } };
+      } else if (change === "scope") {
+        config = { ...config, session: { scope: "global" } };
+      } else if (change === "store") {
+        config = { ...config, session: { store: state.statePath("changed", "sessions.sqlite") } };
+      } else {
+        await replaceSessionEntry(
+          { agentId: "voice", sessionKey: "agent:voice:main" },
+          {
+            sessionId: "concurrent-session",
+            updatedAt: 1,
+            ...(change === "incognito"
+              ? { incognito: true }
+              : { visibility: "read-only" as const }),
+          },
+        );
+      }
+      gate.resolve(browserSession);
+      const respond = await pending;
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({ code: "INVALID_REQUEST" }),
+      );
+      expect(cancelBrowserSession).toHaveBeenCalledOnce();
+      expect(
+        loadSessionEntry({ agentId: "primary", sessionKey: "agent:primary:main" }),
+      ).toBeUndefined();
+      expect(
+        loadSessionEntry({ agentId: "voice", sessionKey: "agent:voice:changed" }),
+      ).toBeUndefined();
+      if (change !== "sharing" && change !== "incognito") {
+        expect(
+          loadSessionEntry({ agentId: "voice", sessionKey: "agent:voice:main" }),
+        ).toBeUndefined();
+      }
+    },
+  );
+
+  it.each(["agent", "hidden", "sandbox"] as const)(
+    "enforces the %s role boundary on an omitted target",
+    async (restriction) => {
+      config.gateway = {
+        roles: {
+          default: "limited",
+          definitions: {
+            limited: {
+              agents: restriction === "agent" ? ["primary"] : "*",
+              sessions: { others: restriction === "hidden" ? "none" : "write" },
+              scopes: ["operator.read", "operator.write"],
+              ...(restriction === "sandbox" ? { sandbox: "required" } : {}),
+            },
+          },
+        },
+      };
+      if (restriction !== "agent") {
+        await replaceSessionEntry(
+          { agentId: "voice", sessionKey: "agent:voice:main" },
+          {
+            sessionId: "host-session",
+            updatedAt: 1,
+            visibility: "shared",
+            createdActor: { type: "human", source: "profile", id: "another-person" },
+          },
+        );
+      }
+      const respond = await dispatch("talk.client.create", createParams);
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({
+          code: restriction === "hidden" ? "INVALID_REQUEST" : "FORBIDDEN",
+        }),
+      );
+      expect(createBrowserSession).not.toHaveBeenCalled();
+      expect(mocks.bootstrap).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not retarget between router authorization and lazy handler dispatch", async () => {
+    const gate = createDeferredCore();
+    const started = createDeferredCore();
+    const pending = dispatch("talk.client.create", createParams, {
+      "talk.client.create": async (request) => {
+        started.resolve();
+        await gate.promise;
+        return createTalkClient(request);
+      },
+    });
+    await started.promise;
+    config = { ...config, talk: { agentId: "primary" } };
+    gate.resolve();
+    expect(await pending).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "INVALID_REQUEST" }),
+    );
+    expect(mocks.bootstrap).not.toHaveBeenCalled();
+    expect(createBrowserSession).not.toHaveBeenCalled();
+  });
+
+  it.each(["main", undefined])(
+    "passes the authorized %s target into relay creation",
+    async (sessionKey) => {
+      config.session = { scope: "global" };
+      const respond = await dispatch("talk.session.create", {
+        mode: "realtime",
+        transport: "gateway-relay",
+        brain: "agent-consult",
+        ...(sessionKey ? { sessionKey } : {}),
+      });
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ sessionId: "test-relay" }),
+        undefined,
+      );
+      expect(mocks.createRelay).toHaveBeenCalledWith(
+        expect.objectContaining({
+          sessionTarget: expect.objectContaining({
+            agentId: "voice",
+            canonicalKey: "global",
+            sessionKey: sessionKey ?? "agent:voice:main",
+          }),
+        }),
+      );
+      expect(loadSessionEntry({ agentId: "voice", sessionKey: "global" })?.sessionId).toBeTruthy();
+    },
+  );
+
+  it("keeps keyless transcription independent of Talk agent selection", async () => {
+    delete config.talk;
+    mocks.transcriptionProviders.mockReturnValue([
+      { id: "test-transcription", isConfigured: () => true },
+    ] as never);
+    const respond = await dispatch("talk.session.create", {
+      mode: "transcription",
+      transport: "gateway-relay",
+      brain: "none",
+    });
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ sessionId: "test-dictation" }),
+      undefined,
+    );
+    expect(mocks.bootstrap).not.toHaveBeenCalled();
+    expect(createBrowserSession).not.toHaveBeenCalled();
+    expect(loadSessionEntry({ agentId: "voice", sessionKey: "agent:voice:main" })).toBeUndefined();
+  });
+
+  it.each(["owner", "sharing", "incognito", "replacement"] as const)(
+    "rechecks %s after the guarded ensure settles and before publishing the call",
+    async (change) => {
+      if (change === "sharing") {
+        await replaceSessionEntry(
+          { agentId: "voice", sessionKey: "agent:voice:main" },
+          {
+            sessionId: "existing-shared-session",
+            updatedAt: 1,
+            visibility: "shared",
+            createdActor: { type: "human", source: "profile", id: "another-person" },
+          },
+        );
+      }
+      const ensure = clientVoiceSession.ensureClientVoiceAgentSessionEntry;
+      vi.spyOn(clientVoiceSession, "ensureClientVoiceAgentSessionEntry").mockImplementationOnce(
+        async (params) => {
+          const sessionId = await ensure(params);
+          if (change === "owner") {
+            config = { ...config, talk: { agentId: "primary" } };
+          } else {
+            await replaceSessionEntry(params, {
+              sessionId: change === "replacement" ? "replacement-session" : sessionId,
+              updatedAt: 2,
+              createdActor: { type: "human", source: "profile", id: "another-person" },
+              ...(change === "incognito" ? { incognito: true } : { visibility: "read-only" }),
+            });
+          }
+          return sessionId;
+        },
+      );
+      const respond = await dispatch("talk.client.create", {
+        ...createParams,
+        voiceSessionId: "provisional",
+      });
+      expect(respond).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({ code: "INVALID_REQUEST" }),
+      );
+      expect(clientVoiceSessionTesting.readRecord("voice", "provisional")).toBeUndefined();
+      expect(cancelBrowserSession).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("retains the identified creator when a restricted role creates its first Talk session", async () => {
+    config.gateway = {
+      roles: {
+        default: "personal",
+        definitions: {
+          personal: {
+            agents: ["voice"],
+            sessions: { others: "none" },
+            scopes: ["operator.read", "operator.write"],
+          },
+        },
+      },
+    };
+    expect(await dispatch("talk.client.create", createParams)).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining(browserSession),
+      undefined,
+    );
+    expect(
+      loadSessionEntry({ agentId: "voice", sessionKey: "agent:voice:main" })?.createdActor,
+    ).toEqual({ type: "human", source: "profile", id: client.authenticatedUserProfile?.profileId });
+  });
+
+  it("rejects a default-owner change while profile preparation is awaited", async () => {
+    const gate = createDeferredCore<undefined>();
+    const started = createDeferredCore();
+    mocks.bootstrap.mockImplementationOnce(async () => {
+      started.resolve();
+      return await gate.promise;
+    });
+    const pending = dispatch("talk.client.create", createParams);
+    await started.promise;
+    config = { ...config, talk: { agentId: "primary" } };
+    gate.resolve(undefined);
+    expect(await pending).toHaveBeenCalledWith(
+      false,
+      undefined,
+      expect.objectContaining({ code: "INVALID_REQUEST" }),
+    );
+    expect(createBrowserSession).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -8,6 +8,7 @@ import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import { normalizeResolvedSecretInputString } from "../../config/types.secrets.js";
+import { getAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
 import { ensureProfileForEmail } from "../../state/user-profiles.js";
 import {
@@ -2125,6 +2126,7 @@ describe("talk.session unified handlers", () => {
       sessionKey: "agent:main:main",
       text: "use the safer plan",
       mode: "steer",
+      assertCurrent: expect.any(Function),
     });
     expectRespondOk(steerRespond, {
       ok: true,
@@ -3069,6 +3071,7 @@ describe("talk.client.toolCall handler", () => {
 describe("talk.client.steer handler", () => {
   const createSteerContext = (ownerConnId = "conn-1") =>
     ({
+      getRuntimeConfig: () => ({}),
       chatAbortControllers: new Map([
         [
           "run-voice-1",
@@ -3076,6 +3079,8 @@ describe("talk.client.steer handler", () => {
             controller: new AbortController(),
             sessionId: "session-active",
             sessionKey: "agent:main:main",
+            agentId: "main",
+            lifecycleGeneration: getAgentEventLifecycleGeneration(),
             startedAtMs: 1,
             expiresAtMs: Date.now() + 60_000,
             ownerConnId,
@@ -3116,6 +3121,7 @@ describe("talk.client.steer handler", () => {
 
     expect(mocks.controlRealtimeVoiceAgentRun).toHaveBeenCalledWith({
       sessionKey: "agent:main:main",
+      runTarget: expect.objectContaining({ runId: "run-voice-1" }),
       text: "use the safer plan",
       mode: "steer",
     });
@@ -3305,7 +3311,8 @@ describe("talk.client.create handler", () => {
         cfg: expect.any(Object),
         agentRuntime: mocks.agentRuntime,
         agentId: "main",
-        sessionKey: "main",
+        sessionKey: "agent:main:main",
+        storePath: expect.any(String),
         args: { question: "Check the repository" },
         transcript: [
           { role: "user", text: `2:${"🙂".repeat(799)}` },
@@ -3607,7 +3614,7 @@ describe("talk.client.create handler", () => {
     });
     expect(chatAbortControllers.get("talk-realtime-consult:gpt-live")).toMatchObject({
       sessionId: "session-main",
-      sessionKey: "main",
+      sessionKey: "agent:main:main",
       agentId: "main",
       ownerConnId: "conn-1",
       controlUiVisible: false,
@@ -3633,7 +3640,8 @@ describe("talk.client.create handler", () => {
       context,
     });
     expect(mocks.controlRealtimeVoiceAgentRun).toHaveBeenCalledWith({
-      sessionKey: "main",
+      sessionKey: "agent:main:main",
+      runTarget: expect.objectContaining({ runId: "talk-realtime-consult:gpt-live" }),
       text: "Use the safer plan",
       mode: "steer",
     });

--- a/src/gateway/server-methods/talk.test.ts
+++ b/src/gateway/server-methods/talk.test.ts
@@ -17,8 +17,10 @@ import {
 import { resetClientVoiceConfirmationStateForTest } from "../../talk/client-voice-confirmation.test-support.js";
 import { REALTIME_VOICE_DESCRIBE_VIEW_TOOL_NAME } from "../../talk/describe-view-tool.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { resolveSessionMutationAuthorization } from "../session-sharing.js";
 import { buildTalkRealtimeConfig } from "./talk-shared.js";
 import { talkHandlers } from "./talk.js";
+import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
 const mocks = vi.hoisted(() => ({
   getRuntimeConfig: vi.fn<() => OpenClawConfig>(),
@@ -267,7 +269,7 @@ function createTalkConfig(apiKey: unknown): OpenClawConfig {
 
 type TalkHandlerCallOptions = {
   params: Record<string, unknown>;
-  respond: ReturnType<typeof vi.fn>;
+  respond: RespondFn;
   context: unknown;
   client?: unknown;
   id?: string;
@@ -277,6 +279,19 @@ async function callTalkHandler(
   method: keyof typeof talkHandlers,
   { params, respond, context, client = { connId: "conn-1" }, id = "1" }: TalkHandlerCallOptions,
 ) {
+  const admission =
+    method === "talk.client.create" || method === "talk.session.create"
+      ? resolveSessionMutationAuthorization({
+          client: client as GatewayClient,
+          context: context as GatewayRequestContext,
+          method,
+          requestParams: params,
+        })
+      : undefined;
+  if (admission?.error) {
+    respond(false, undefined, admission.error);
+    return;
+  }
   await expectDefined(
     talkHandlers[method],
     `talkHandlers["${method}"] test invariant`,
@@ -285,8 +300,17 @@ async function callTalkHandler(
     params: params as never,
     client: client as never,
     isWebchatConnect: () => false,
-    respond: respond as never,
+    respond,
     context: context as never,
+    // Row creation is mocked here; talk-target.test covers the real post-ensure fence.
+    ...(admission?.authorization
+      ? {
+          sessionMutationAuthorization: {
+            ...admission.authorization,
+            assertTargetCurrent: vi.fn(),
+          },
+        }
+      : {}),
   });
 }
 
@@ -1925,10 +1949,14 @@ describe("talk.session unified handlers", () => {
       defaultModel: "gpt-realtime-default",
       surface: "gateway-relay",
     });
-    expect(mocks.ensureClientVoiceAgentSessionEntry).toHaveBeenCalledWith({
-      agentId: "main",
-      sessionKey: "agent:main:main",
-    });
+    expect(mocks.ensureClientVoiceAgentSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        storePath: expect.any(String),
+        assertCommitAllowed: expect.any(Function),
+      }),
+    );
     const relayCreateInput = mockCallArg(mocks.createTalkRealtimeRelaySession) as Record<
       string,
       unknown
@@ -2173,10 +2201,14 @@ describe("talk.session unified handlers", () => {
     expect(mocks.resolveConfiguredRealtimeVoiceProvider).toHaveBeenCalledWith(
       expect.objectContaining({ agentId: "research" }),
     );
-    expect(mocks.ensureClientVoiceAgentSessionEntry).toHaveBeenCalledWith({
-      agentId: "research",
-      sessionKey: "incident-42",
-    });
+    expect(mocks.ensureClientVoiceAgentSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "research",
+        sessionKey: "agent:research:incident-42",
+        storePath: expect.any(String),
+        assertCommitAllowed: expect.any(Function),
+      }),
+    );
     expectRespondOk(respond, { relaySessionId: "relay-talk-owner" });
   });
 
@@ -2241,6 +2273,7 @@ describe("talk.session unified handlers", () => {
       context: {
         getRuntimeConfig: () =>
           ({
+            agents: { entries: { "voice-agent": {} } },
             talk: {
               realtime: {
                 provider: "openai",
@@ -2258,13 +2291,22 @@ describe("talk.session unified handlers", () => {
         provider,
         providerConfig: { model: "gpt-live-1-codex" },
         model: "gpt-live-1-codex",
-        sessionKey: "agent:voice-agent:main",
+        sessionTarget: expect.objectContaining({
+          agentId: "voice-agent",
+          sessionKey: "agent:voice-agent:main",
+          canonicalKey: "agent:voice-agent:main",
+          storePath: expect.any(String),
+        }),
       }),
     );
-    expect(mocks.ensureClientVoiceAgentSessionEntry).toHaveBeenCalledWith({
-      agentId: "voice-agent",
-      sessionKey: "agent:voice-agent:main",
-    });
+    expect(mocks.ensureClientVoiceAgentSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "voice-agent",
+        sessionKey: "agent:voice-agent:main",
+        storePath: expect.any(String),
+        assertCommitAllowed: expect.any(Function),
+      }),
+    );
     expectRespondOk(respond, { relaySessionId: "relay-effective-model" });
   });
 
@@ -2531,6 +2573,7 @@ describe("talk.session unified handlers", () => {
 
   it("passes managed-room spawnedBy visibility scope to session resolution", async () => {
     const createRespond = vi.fn();
+    const config: OpenClawConfig = { agents: { entries: { worker: {} } } };
     await callTalkHandler("talk.session.create", {
       params: {
         mode: "stt-tts",
@@ -2541,7 +2584,7 @@ describe("talk.session unified handlers", () => {
       client: { connId: "conn-1", connect: { scopes: ["operator.write"] } },
       respond: createRespond,
       context: {
-        getRuntimeConfig: () => ({}) as OpenClawConfig,
+        getRuntimeConfig: () => config,
       },
     });
 
@@ -2550,7 +2593,7 @@ describe("talk.session unified handlers", () => {
       brain: "agent-consult",
     });
     expect(mocks.resolveSessionKeyFromResolveParams).toHaveBeenCalledWith({
-      cfg: {},
+      cfg: config,
       client: { connId: "conn-1", connect: { scopes: ["operator.write"] } },
       p: {
         key: "agent:worker:subagent:child",
@@ -2600,7 +2643,7 @@ describe("talk.session unified handlers", () => {
       client: { connId: "conn-1", connect: { scopes: ["operator.write"] } },
       respond: createRespond,
       context: {
-        getRuntimeConfig: () => ({}) as OpenClawConfig,
+        getRuntimeConfig: () => ({ agents: { entries: { worker: {} } } }),
       },
     });
 
@@ -3277,15 +3320,20 @@ describe("talk.client.create handler", () => {
     expect(createInput).not.toHaveProperty("provider");
     expect(createInput).not.toHaveProperty("providers");
     expect(createInput).not.toHaveProperty("transport");
-    expect(mocks.ensureClientVoiceAgentSessionEntry).toHaveBeenCalledWith({
-      agentId: "main",
-      sessionKey: "main",
-    });
+    expect(mocks.ensureClientVoiceAgentSessionEntry).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "main",
+        sessionKey: "agent:main:main",
+        storePath: expect.any(String),
+        assertCommitAllowed: expect.any(Function),
+      }),
+    );
     expect(mocks.readSessionPreviewItemsFromTranscript).toHaveBeenCalledWith(
       {
         agentId: "main",
         sessionId: "session-main",
-        sessionKey: "main",
+        sessionKey: "agent:main:main",
+        storePath: expect.any(String),
       },
       16,
       800,

--- a/src/gateway/session-sharing-policy.ts
+++ b/src/gateway/session-sharing-policy.ts
@@ -1,0 +1,335 @@
+import {
+  ErrorCodes,
+  errorShape,
+  type ErrorShape,
+  type SessionSharingRole,
+  type SessionVisibility,
+} from "../../packages/gateway-protocol/src/index.js";
+import { isSessionMember, type SessionEntry } from "../config/sessions.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isIncognitoSessionKey } from "../routing/session-key.js";
+import {
+  authorizeGatewaySessionCreation,
+  operatorSessionCap,
+  resolveGatewayOperatorRoleActor,
+  resolveOperatorRolePolicy,
+} from "./operator-role-policy.js";
+import {
+  authenticatedProfileUnavailableError,
+  gatewayClientSessionCreator,
+  isGatewayClientProfilePending,
+} from "./server-methods/gateway-client-identity.js";
+import type { GatewayClient } from "./server-methods/types.js";
+import { prepareSessionCreatorProfile } from "./session-creator.js";
+import type {
+  GatewaySessionStoreCache,
+  GatewaySessionStoreDiscoveryCache,
+} from "./session-utils-store-lookup.js";
+import {
+  resolveCanonicalSessionStoreMatchFromStoreKeys,
+  resolveGatewaySessionStoreTargetWithStore,
+} from "./session-utils.js";
+
+export type SessionSharingTarget = {
+  agentId: string;
+  canonicalKey: string;
+  entry: SessionEntry;
+  storeKey: string;
+  storeKeys: string[];
+  storePath: string;
+};
+
+export function resolveSessionVisibility(
+  entry: Pick<SessionEntry, "visibility">,
+): SessionVisibility {
+  return entry.visibility ?? "shared";
+}
+
+export function isGatewayAdmin(client: Pick<GatewayClient, "connect"> | null): boolean {
+  // Internal/plugin-runtime runs reach authorization with a client that has no
+  // connect handshake; treat a connect-less client as a non-admin, never a crash.
+  return client?.connect?.scopes?.includes("operator.admin") === true;
+}
+
+export function allowedSessionVisibilities(cfg: OpenClawConfig): SessionVisibility[] {
+  const policy = cfg.session?.sharing;
+  return [
+    "shared",
+    ...(policy?.readOnly === false ? [] : (["read-only"] as const)),
+    ...(policy?.suggest === false ? [] : (["suggest"] as const)),
+    ...(policy?.drafts === false ? [] : (["draft"] as const)),
+  ];
+}
+
+export function isSessionVisibilityAllowed(
+  cfg: OpenClawConfig,
+  visibility: SessionVisibility,
+): boolean {
+  return allowedSessionVisibilities(cfg).includes(visibility);
+}
+
+export function resolveSessionSharingTarget(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  agentId?: string;
+  projection?: "full" | "list";
+  storeCache?: GatewaySessionStoreCache;
+  targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
+}): SessionSharingTarget | null {
+  const target = resolveGatewaySessionStoreTargetWithStore({
+    cfg: params.cfg,
+    key: params.sessionKey,
+    agentId: params.agentId,
+    clone: false,
+    ...(params.projection ? { projection: params.projection } : {}),
+    ...(params.storeCache ? { storeCache: params.storeCache } : {}),
+    ...(params.targetDiscoveryCache ? { targetDiscoveryCache: params.targetDiscoveryCache } : {}),
+  });
+  const match = resolveCanonicalSessionStoreMatchFromStoreKeys(target.store, target.storeKeys);
+  return match
+    ? {
+        agentId: target.agentId,
+        canonicalKey: target.canonicalKey,
+        entry: match.entry,
+        storeKey: match.key,
+        storeKeys: target.storeKeys,
+        storePath: target.storePath,
+      }
+    : null;
+}
+
+export type SessionSharingRoleParams = {
+  cfg?: OpenClawConfig;
+  client: GatewayClient | null;
+  target: SessionSharingTarget;
+  includeMembership?: boolean;
+  isMember?: boolean;
+};
+
+export function sharingIdentity(
+  client: GatewayClient | null,
+  actor: ReturnType<typeof resolveGatewayOperatorRoleActor>,
+) {
+  const operator = actor?.kind === "operator" ? { id: actor.profileId } : undefined;
+  return gatewayClientSessionCreator(client) ?? operator;
+}
+
+export function resolveSessionSharingRole(
+  params: SessionSharingRoleParams,
+  preparedCap?: { value: ReturnType<typeof operatorSessionCap> },
+  isCreator?: ReturnType<typeof prepareSessionCreatorProfile>,
+): SessionSharingRole {
+  if (isGatewayAdmin(params.client)) {
+    return "admin";
+  }
+  const operatorActor = resolveGatewayOperatorRoleActor(params.client);
+  const identity = sharingIdentity(params.client, operatorActor);
+  // Shared-secret/no-auth solo deployments have no durable person identity.
+  if (!identity) {
+    return params.client?.authenticatedGitHubIdentitySync ||
+      (params.cfg?.gateway?.roles && operatorActor?.kind !== "system")
+      ? "viewer"
+      : "owner";
+  }
+  const creatorMatches = isCreator ?? prepareSessionCreatorProfile(identity.id);
+  if (creatorMatches(params.target.entry.createdActor)) {
+    return "owner";
+  }
+  const sessionCap = preparedCap
+    ? preparedCap.value
+    : params.cfg && operatorSessionCap(params.client, params.cfg);
+  if (
+    sessionCap === "write" &&
+    resolveSessionVisibility(params.target.entry) !== "draft" &&
+    params.target.entry.incognito !== true &&
+    !isIncognitoSessionKey(params.target.canonicalKey)
+  ) {
+    return "member";
+  }
+  if (sessionCap === "none") {
+    return "viewer";
+  }
+  const member =
+    params.isMember ??
+    (params.includeMembership !== false &&
+      isSessionMember(
+        {
+          agentId: params.target.agentId,
+          sessionKey: params.target.storeKey,
+          storePath: params.target.storePath,
+        },
+        identity.id,
+      ));
+  return member ? "member" : "viewer";
+}
+
+export function canManageSessionSharing(role: SessionSharingRole): boolean {
+  return role === "admin" || role === "owner";
+}
+
+export function hiddenSessionNotFound(sessionKey: string, incognito = false): ErrorShape {
+  const label = incognito ? "Incognito session" : "Session";
+  return errorShape(ErrorCodes.INVALID_REQUEST, `${label} "${sessionKey}" was not found.`);
+}
+
+function isIncognitoSessionTarget(params: {
+  sessionKey: string;
+  target: Pick<SessionSharingTarget, "canonicalKey" | "entry"> | null;
+}): boolean {
+  return params.target
+    ? params.target.entry.incognito === true || isIncognitoSessionKey(params.target.canonicalKey)
+    : isIncognitoSessionKey(params.sessionKey);
+}
+
+export function isResolvedIncognitoSession(params: {
+  cfg: OpenClawConfig;
+  sessionKey: string;
+  agentId?: string;
+}): boolean {
+  return isIncognitoSessionTarget({
+    sessionKey: params.sessionKey,
+    target: resolveSessionSharingTarget(params),
+  });
+}
+
+export function authorizeIncognitoSessionTarget(params: {
+  client: GatewayClient | null;
+  sessionKey: string;
+  target: SessionSharingTarget | null;
+}): ErrorShape | null {
+  if (!isIncognitoSessionTarget(params)) {
+    return null;
+  }
+  if (isGatewayAdmin(params.client)) {
+    return null;
+  }
+  if (isGatewayClientProfilePending(params.client)) {
+    return authenticatedProfileUnavailableError();
+  }
+  const identity = gatewayClientSessionCreator(params.client);
+  if (!identity) {
+    return null;
+  }
+  return hiddenSessionNotFound(params.sessionKey, true);
+}
+
+export function canAccessIncognitoSession(params: {
+  cfg: OpenClawConfig;
+  client: GatewayClient | null;
+  sessionKey: string;
+  agentId?: string;
+}): boolean {
+  if (isGatewayAdmin(params.client)) {
+    return true;
+  }
+  return (
+    authorizeIncognitoSessionTarget({
+      client: params.client,
+      sessionKey: params.sessionKey,
+      target: resolveSessionSharingTarget(params),
+    }) === null
+  );
+}
+
+export function authorizeResolvedSessionMutation(params: {
+  cfg: OpenClawConfig;
+  client: GatewayClient | null;
+  sessionKey: string;
+  agentId?: string;
+}): ErrorShape | null {
+  if (isGatewayAdmin(params.client) && !params.cfg.gateway?.roles) {
+    return null;
+  }
+  if (isGatewayClientProfilePending(params.client)) {
+    return authenticatedProfileUnavailableError();
+  }
+  const target = resolveSessionSharingTarget(params);
+  if (target) {
+    const agentError = authorizeSessionAgentRun({
+      cfg: params.cfg,
+      client: params.client,
+      target,
+    });
+    if (agentError) {
+      return agentError;
+    }
+  }
+  if (isGatewayAdmin(params.client)) {
+    return null;
+  }
+  const incognitoError = authorizeIncognitoSessionTarget({
+    client: params.client,
+    sessionKey: params.sessionKey,
+    target,
+  });
+  if (incognitoError) {
+    return incognitoError;
+  }
+  if (!target) {
+    return null;
+  }
+  return authorizeSessionSharingTarget({ cfg: params.cfg, client: params.client, target });
+}
+
+export function authorizeSessionAgentRun(params: {
+  cfg: OpenClawConfig;
+  client: GatewayClient | null;
+  target: SessionSharingTarget;
+}): ErrorShape | null {
+  const agentError = authorizeGatewaySessionCreation({
+    cfg: params.cfg,
+    client: params.client,
+    agentId: params.target.agentId,
+  });
+  if (agentError) {
+    return agentError;
+  }
+  if (
+    params.cfg.gateway?.roles &&
+    params.target.entry.sandbox !== "required" &&
+    resolveOperatorRolePolicy(params.client, params.cfg)?.sandbox === "required"
+  ) {
+    return errorShape(
+      ErrorCodes.FORBIDDEN,
+      `Your operator role requires a sandboxed session; create a new session instead of running in "${params.target.canonicalKey}".`,
+    );
+  }
+  return null;
+}
+
+export function authorizeSessionSharingTarget(params: {
+  cfg?: OpenClawConfig;
+  client: GatewayClient | null;
+  target: SessionSharingTarget;
+}): ErrorShape | null {
+  const visibility = resolveSessionVisibility(params.target.entry);
+  const sessionCap = params.cfg && operatorSessionCap(params.client, params.cfg);
+  const role = resolveSessionSharingRole(params, { value: sessionCap });
+  if (sessionCap === "none" && role !== "owner" && role !== "admin") {
+    return hiddenSessionNotFound(params.target.canonicalKey);
+  }
+  const capped = sessionCap === "view" || sessionCap === "suggest";
+  // Draft membership is inactive, while an explicit role caps even shared visibility.
+  const canMutate =
+    visibility === "draft"
+      ? canManageSessionSharing(role)
+      : role !== "viewer" || (visibility === "shared" && !capped);
+  return canMutate
+    ? null
+    : errorShape(ErrorCodes.INVALID_REQUEST, `session is ${visibility} for this connection`, {
+        details: {
+          code: "SESSION_PARTICIPATION_REQUIRED",
+          sessionKey: params.target.canonicalKey,
+          visibility,
+        },
+      });
+}
+
+export function authorizeSessionSharing(
+  params: Parameters<typeof resolveSessionSharingTarget>[0] & { client: GatewayClient | null },
+): ErrorShape | null {
+  const target = resolveSessionSharingTarget(params);
+  return (
+    target && authorizeSessionSharingTarget({ cfg: params.cfg, client: params.client, target })
+  );
+}

--- a/src/gateway/session-sharing-target-input.ts
+++ b/src/gateway/session-sharing-target-input.ts
@@ -11,6 +11,7 @@ import {
 } from "./session-groups.js";
 import type { SessionMutationTarget } from "./session-mutation-authorization-error.js";
 import { canonicalizeSessionKeyForAgent } from "./session-store-key.js";
+import { resolveUnifiedTalkSessionTarget } from "./talk-session-registry.js";
 
 export type { SessionMutationTarget } from "./session-mutation-authorization-error.js";
 
@@ -279,29 +280,39 @@ function resolveApprovalSessionTarget(
 export function resolveTalkSessionTargetInput(
   method: string,
   params: unknown,
-): { sessionKey?: string } | undefined {
-  // Only these handlers consume the prepared target. Consult/steer have separate run ownership.
+  connId?: string,
+):
+  | { kind: "request"; sessionKey?: string }
+  | ({ kind: "relay" } & NonNullable<ReturnType<typeof resolveUnifiedTalkSessionTarget>>)
+  | undefined {
+  if (method === "talk.session.steer") {
+    const sessionId = readSessionSharingStringParam(params, "sessionId");
+    const retained = sessionId ? resolveUnifiedTalkSessionTarget(sessionId, connId) : undefined;
+    return retained ? { kind: "relay", ...retained } : undefined;
+  }
+  // Only these handlers consume the prepared target; legacy tool calls route through chat.send.
   if (
     method !== "talk.client.create" &&
     method !== "talk.session.create" &&
     method !== "talk.client.transcript" &&
-    method !== "talk.client.close"
+    method !== "talk.client.close" &&
+    method !== "talk.client.steer"
   ) {
     return undefined;
   }
   const sessionKey = readSessionSharingStringParam(params, "sessionKey");
   if (sessionKey) {
-    return { sessionKey };
+    return { kind: "request", sessionKey };
   }
   if (method === "talk.client.create") {
-    return {};
+    return { kind: "request" };
   }
   if (
     method === "talk.session.create" &&
     (readSessionSharingStringParam(params, "mode") ?? "realtime") === "realtime" &&
     readSessionSharingStringParam(params, "transport") !== "managed-room"
   ) {
-    return {};
+    return { kind: "request" };
   }
   return undefined;
 }

--- a/src/gateway/session-sharing-target-input.ts
+++ b/src/gateway/session-sharing-target-input.ts
@@ -275,6 +275,37 @@ function resolveApprovalSessionTarget(
     : undefined;
 }
 
+/** Realtime creates authorize their effective default; transcription stays sessionless. */
+export function resolveTalkSessionTargetInput(
+  method: string,
+  params: unknown,
+): { sessionKey?: string } | undefined {
+  // Only these handlers consume the prepared target. Consult/steer have separate run ownership.
+  if (
+    method !== "talk.client.create" &&
+    method !== "talk.session.create" &&
+    method !== "talk.client.transcript" &&
+    method !== "talk.client.close"
+  ) {
+    return undefined;
+  }
+  const sessionKey = readSessionSharingStringParam(params, "sessionKey");
+  if (sessionKey) {
+    return { sessionKey };
+  }
+  if (method === "talk.client.create") {
+    return {};
+  }
+  if (
+    method === "talk.session.create" &&
+    (readSessionSharingStringParam(params, "mode") ?? "realtime") === "realtime" &&
+    readSessionSharingStringParam(params, "transport") !== "managed-room"
+  ) {
+    return {};
+  }
+  return undefined;
+}
+
 export function resolveSessionMutationTargets(params: {
   method: string;
   requestParams: unknown;

--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -54,7 +54,11 @@ import type {
   GatewaySessionStoreCache,
   GatewaySessionStoreDiscoveryCache,
 } from "./session-utils-store-lookup.js";
-import { prepareTalkSessionTarget, type PreparedTalkSessionTarget } from "./talk-session-target.js";
+import {
+  prepareTalkSessionTarget,
+  assertTalkSessionStorageTarget,
+  type PreparedTalkSessionTarget,
+} from "./talk-session-target.js";
 
 type AuthorizedSessionMutationTarget = SessionMutationTarget & {
   resolved: Omit<SessionSharingTarget, "entry" | "storeKeys"> | null;
@@ -156,10 +160,20 @@ export function resolveSessionMutationAuthorization(params: {
       throw error;
     }
   };
-  const talkInput = resolveTalkSessionTargetInput(params.method, params.requestParams);
+  let talkInput: ReturnType<typeof resolveTalkSessionTargetInput>;
   let talkSessionTarget: PreparedTalkSessionTarget | undefined;
   try {
-    talkSessionTarget = talkInput && prepareTalkSessionTarget(getCfg(), talkInput.sessionKey);
+    talkInput = resolveTalkSessionTargetInput(
+      params.method,
+      params.requestParams,
+      params.client?.connId,
+    );
+    if (talkInput?.kind === "relay") {
+      assertTalkSessionStorageTarget(getCfg(), talkInput.target);
+      talkSessionTarget = talkInput.target;
+    } else {
+      talkSessionTarget = talkInput && prepareTalkSessionTarget(getCfg(), talkInput.sessionKey);
+    }
   } catch (error) {
     return {
       error: errorShape(
@@ -301,7 +315,15 @@ export function resolveSessionMutationAuthorization(params: {
         }
         let current: PreparedTalkSessionTarget;
         try {
-          current = prepareTalkSessionTarget(cfg, talkInput.sessionKey);
+          if (talkInput.kind === "relay") {
+            if (!talkInput.isCurrent()) {
+              throw targetChanged(talkSessionTarget.sessionKey);
+            }
+            assertTalkSessionStorageTarget(cfg, talkSessionTarget);
+            current = talkSessionTarget;
+          } else {
+            current = prepareTalkSessionTarget(cfg, talkInput.sessionKey);
+          }
         } catch {
           throw targetChanged(talkSessionTarget.sessionKey);
         }

--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -54,11 +54,8 @@ import type {
   GatewaySessionStoreCache,
   GatewaySessionStoreDiscoveryCache,
 } from "./session-utils-store-lookup.js";
-import {
-  prepareTalkSessionTarget,
-  assertTalkSessionStorageTarget,
-  type PreparedTalkSessionTarget,
-} from "./talk-session-target.js";
+import { prepareTalkSessionTarget, assertTalkSessionStorageTarget } from "./talk-session-target.js";
+import type { PreparedTalkSessionTarget } from "./talk-session-target.types.js";
 
 type AuthorizedSessionMutationTarget = SessionMutationTarget & {
   resolved: Omit<SessionSharingTarget, "entry" | "storeKeys"> | null;

--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -3,18 +3,15 @@ import {
   ErrorCodes,
   errorShape,
   type ErrorShape,
-  type SessionSharingRole,
-  type SessionVisibility,
 } from "../../packages/gateway-protocol/src/index.js";
 import { AgentSelectionRequiredError } from "../agents/agent-scope.js";
-import { isSessionMember, type SessionEntry } from "../config/sessions.js";
+import type { SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isIncognitoSessionKey } from "../routing/session-key.js";
 import {
   authorizeGatewaySessionCreation,
   operatorSessionCap,
   resolveGatewayOperatorRoleActor,
-  resolveOperatorRolePolicy,
 } from "./operator-role-policy.js";
 import {
   authenticatedProfileUnavailableError,
@@ -29,6 +26,20 @@ import type {
 import type { GatewayWsClient } from "./server/ws-types.js";
 import { isSessionCreatorProfile, prepareSessionCreatorProfile } from "./session-creator.js";
 import { SessionMutationAuthorizationChangedError } from "./session-mutation-authorization-error.js";
+import {
+  authorizeIncognitoSessionTarget,
+  authorizeSessionAgentRun,
+  authorizeSessionSharingTarget,
+  canManageSessionSharing,
+  hiddenSessionNotFound,
+  isGatewayAdmin,
+  resolveSessionSharingRole,
+  resolveSessionSharingTarget,
+  resolveSessionVisibility,
+  sharingIdentity,
+  type SessionSharingRoleParams,
+  type SessionSharingTarget,
+} from "./session-sharing-policy.js";
 import { loadCachedSessionSharingSnapshot } from "./session-sharing-snapshot-cache.js";
 import {
   isRequiredSessionTargetMethod,
@@ -36,25 +47,14 @@ import {
   resolveDirectIncognitoTargets,
   resolveDirectSessionTargets,
   resolveSessionMutationTargets,
+  resolveTalkSessionTargetInput,
   type SessionMutationTarget,
 } from "./session-sharing-target-input.js";
 import type {
   GatewaySessionStoreCache,
   GatewaySessionStoreDiscoveryCache,
 } from "./session-utils-store-lookup.js";
-import {
-  resolveCanonicalSessionStoreMatchFromStoreKeys,
-  resolveGatewaySessionStoreTargetWithStore,
-} from "./session-utils.js";
-
-type SessionSharingTarget = {
-  agentId: string;
-  canonicalKey: string;
-  entry: SessionEntry;
-  storeKey: string;
-  storeKeys: string[];
-  storePath: string;
-};
+import { prepareTalkSessionTarget, type PreparedTalkSessionTarget } from "./talk-session-target.js";
 
 type AuthorizedSessionMutationTarget = SessionMutationTarget & {
   resolved: Omit<SessionSharingTarget, "entry" | "storeKeys"> | null;
@@ -84,300 +84,21 @@ const VISIBILITY_AUTHORIZED_METHODS = new Set(["sessions.assignOwner"]);
 export { SessionMutationAuthorizationChangedError } from "./session-mutation-authorization-error.js";
 export { invalidateSessionSharingSnapshot } from "./session-sharing-snapshot-cache.js";
 
-export function resolveSessionVisibility(
-  entry: Pick<SessionEntry, "visibility">,
-): SessionVisibility {
-  return entry.visibility ?? "shared";
-}
-
-export function isGatewayAdmin(client: Pick<GatewayClient, "connect"> | null): boolean {
-  // Internal/plugin-runtime runs reach authorization with a client that has no
-  // connect handshake; treat a connect-less client as a non-admin, never a crash.
-  return client?.connect?.scopes?.includes("operator.admin") === true;
-}
-
-export function allowedSessionVisibilities(cfg: OpenClawConfig): SessionVisibility[] {
-  const policy = cfg.session?.sharing;
-  return [
-    "shared",
-    ...(policy?.readOnly === false ? [] : (["read-only"] as const)),
-    ...(policy?.suggest === false ? [] : (["suggest"] as const)),
-    ...(policy?.drafts === false ? [] : (["draft"] as const)),
-  ];
-}
-
-export function isSessionVisibilityAllowed(
-  cfg: OpenClawConfig,
-  visibility: SessionVisibility,
-): boolean {
-  return allowedSessionVisibilities(cfg).includes(visibility);
-}
-
-export function resolveSessionSharingTarget(params: {
-  cfg: OpenClawConfig;
-  sessionKey: string;
-  agentId?: string;
-  projection?: "full" | "list";
-  storeCache?: GatewaySessionStoreCache;
-  targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
-}): SessionSharingTarget | null {
-  const target = resolveGatewaySessionStoreTargetWithStore({
-    cfg: params.cfg,
-    key: params.sessionKey,
-    agentId: params.agentId,
-    clone: false,
-    ...(params.projection ? { projection: params.projection } : {}),
-    ...(params.storeCache ? { storeCache: params.storeCache } : {}),
-    ...(params.targetDiscoveryCache ? { targetDiscoveryCache: params.targetDiscoveryCache } : {}),
-  });
-  const match = resolveCanonicalSessionStoreMatchFromStoreKeys(target.store, target.storeKeys);
-  return match
-    ? {
-        agentId: target.agentId,
-        canonicalKey: target.canonicalKey,
-        entry: match.entry,
-        storeKey: match.key,
-        storeKeys: target.storeKeys,
-        storePath: target.storePath,
-      }
-    : null;
-}
-
-type SessionSharingRoleParams = {
-  cfg?: OpenClawConfig;
-  client: GatewayClient | null;
-  target: SessionSharingTarget;
-  includeMembership?: boolean;
-  isMember?: boolean;
-};
-
-function sharingIdentity(
-  client: GatewayClient | null,
-  actor: ReturnType<typeof resolveGatewayOperatorRoleActor>,
-) {
-  const operator = actor?.kind === "operator" ? { id: actor.profileId } : undefined;
-  return gatewayClientSessionCreator(client) ?? operator;
-}
-
-export function resolveSessionSharingRole(
-  params: SessionSharingRoleParams,
-  preparedCap?: { value: ReturnType<typeof operatorSessionCap> },
-  isCreator?: ReturnType<typeof prepareSessionCreatorProfile>,
-): SessionSharingRole {
-  if (isGatewayAdmin(params.client)) {
-    return "admin";
-  }
-  const operatorActor = resolveGatewayOperatorRoleActor(params.client);
-  const identity = sharingIdentity(params.client, operatorActor);
-  // Shared-secret/no-auth solo deployments have no durable person identity.
-  if (!identity) {
-    return params.client?.authenticatedGitHubIdentitySync ||
-      (params.cfg?.gateway?.roles && operatorActor?.kind !== "system")
-      ? "viewer"
-      : "owner";
-  }
-  const creatorMatches = isCreator ?? prepareSessionCreatorProfile(identity.id);
-  if (creatorMatches(params.target.entry.createdActor)) {
-    return "owner";
-  }
-  const sessionCap = preparedCap
-    ? preparedCap.value
-    : params.cfg && operatorSessionCap(params.client, params.cfg);
-  if (
-    sessionCap === "write" &&
-    resolveSessionVisibility(params.target.entry) !== "draft" &&
-    params.target.entry.incognito !== true &&
-    !isIncognitoSessionKey(params.target.canonicalKey)
-  ) {
-    return "member";
-  }
-  if (sessionCap === "none") {
-    return "viewer";
-  }
-  const member =
-    params.isMember ??
-    (params.includeMembership !== false &&
-      isSessionMember(
-        {
-          agentId: params.target.agentId,
-          sessionKey: params.target.storeKey,
-          storePath: params.target.storePath,
-        },
-        identity.id,
-      ));
-  return member ? "member" : "viewer";
-}
-
-export function canManageSessionSharing(role: SessionSharingRole): boolean {
-  return role === "admin" || role === "owner";
-}
-
-function hiddenSessionNotFound(sessionKey: string, incognito = false): ErrorShape {
-  const label = incognito ? "Incognito session" : "Session";
-  return errorShape(ErrorCodes.INVALID_REQUEST, `${label} "${sessionKey}" was not found.`);
-}
-
-function isIncognitoSessionTarget(params: {
-  sessionKey: string;
-  target: Pick<SessionSharingTarget, "canonicalKey" | "entry"> | null;
-}): boolean {
-  return params.target
-    ? params.target.entry.incognito === true || isIncognitoSessionKey(params.target.canonicalKey)
-    : isIncognitoSessionKey(params.sessionKey);
-}
-
-export function isResolvedIncognitoSession(params: {
-  cfg: OpenClawConfig;
-  sessionKey: string;
-  agentId?: string;
-}): boolean {
-  return isIncognitoSessionTarget({
-    sessionKey: params.sessionKey,
-    target: resolveSessionSharingTarget(params),
-  });
-}
-
-export function authorizeIncognitoSessionTarget(params: {
-  client: GatewayClient | null;
-  sessionKey: string;
-  target: SessionSharingTarget | null;
-}): ErrorShape | null {
-  if (!isIncognitoSessionTarget(params)) {
-    return null;
-  }
-  if (isGatewayAdmin(params.client)) {
-    return null;
-  }
-  if (isGatewayClientProfilePending(params.client)) {
-    return authenticatedProfileUnavailableError();
-  }
-  const identity = gatewayClientSessionCreator(params.client);
-  if (!identity) {
-    return null;
-  }
-  return hiddenSessionNotFound(params.sessionKey, true);
-}
-
-export function canAccessIncognitoSession(params: {
-  cfg: OpenClawConfig;
-  client: GatewayClient | null;
-  sessionKey: string;
-  agentId?: string;
-}): boolean {
-  if (isGatewayAdmin(params.client)) {
-    return true;
-  }
-  return (
-    authorizeIncognitoSessionTarget({
-      client: params.client,
-      sessionKey: params.sessionKey,
-      target: resolveSessionSharingTarget(params),
-    }) === null
-  );
-}
-
-export function authorizeResolvedSessionMutation(params: {
-  cfg: OpenClawConfig;
-  client: GatewayClient | null;
-  sessionKey: string;
-  agentId?: string;
-}): ErrorShape | null {
-  if (isGatewayAdmin(params.client) && !params.cfg.gateway?.roles) {
-    return null;
-  }
-  if (isGatewayClientProfilePending(params.client)) {
-    return authenticatedProfileUnavailableError();
-  }
-  const target = resolveSessionSharingTarget(params);
-  if (target) {
-    const agentError = authorizeSessionAgentRun({
-      cfg: params.cfg,
-      client: params.client,
-      target,
-    });
-    if (agentError) {
-      return agentError;
-    }
-  }
-  if (isGatewayAdmin(params.client)) {
-    return null;
-  }
-  const incognitoError = authorizeIncognitoSessionTarget({
-    client: params.client,
-    sessionKey: params.sessionKey,
-    target,
-  });
-  if (incognitoError) {
-    return incognitoError;
-  }
-  if (!target) {
-    return null;
-  }
-  return authorizeSessionSharingTarget({ cfg: params.cfg, client: params.client, target });
-}
-
-function authorizeSessionAgentRun(params: {
-  cfg: OpenClawConfig;
-  client: GatewayClient | null;
-  target: SessionSharingTarget;
-}): ErrorShape | null {
-  const agentError = authorizeGatewaySessionCreation({
-    cfg: params.cfg,
-    client: params.client,
-    agentId: params.target.agentId,
-  });
-  if (agentError) {
-    return agentError;
-  }
-  if (
-    params.cfg.gateway?.roles &&
-    params.target.entry.sandbox !== "required" &&
-    resolveOperatorRolePolicy(params.client, params.cfg)?.sandbox === "required"
-  ) {
-    return errorShape(
-      ErrorCodes.FORBIDDEN,
-      `Your operator role requires a sandboxed session; create a new session instead of running in "${params.target.canonicalKey}".`,
-    );
-  }
-  return null;
-}
-
-export function authorizeSessionSharingTarget(params: {
-  cfg?: OpenClawConfig;
-  client: GatewayClient | null;
-  target: SessionSharingTarget;
-}): ErrorShape | null {
-  const visibility = resolveSessionVisibility(params.target.entry);
-  const sessionCap = params.cfg && operatorSessionCap(params.client, params.cfg);
-  const role = resolveSessionSharingRole(params, { value: sessionCap });
-  if (sessionCap === "none" && role !== "owner" && role !== "admin") {
-    return hiddenSessionNotFound(params.target.canonicalKey);
-  }
-  const capped = sessionCap === "view" || sessionCap === "suggest";
-  // Draft membership is inactive, while an explicit role caps even shared visibility.
-  const canMutate =
-    visibility === "draft"
-      ? canManageSessionSharing(role)
-      : role !== "viewer" || (visibility === "shared" && !capped);
-  return canMutate
-    ? null
-    : errorShape(ErrorCodes.INVALID_REQUEST, `session is ${visibility} for this connection`, {
-        details: {
-          code: "SESSION_PARTICIPATION_REQUIRED",
-          sessionKey: params.target.canonicalKey,
-          visibility,
-        },
-      });
-}
-
-export function authorizeSessionSharing(
-  params: Parameters<typeof resolveSessionSharingTarget>[0] & { client: GatewayClient | null },
-): ErrorShape | null {
-  const target = resolveSessionSharingTarget(params);
-  return (
-    target && authorizeSessionSharingTarget({ cfg: params.cfg, client: params.client, target })
-  );
-}
+export {
+  allowedSessionVisibilities,
+  authorizeIncognitoSessionTarget,
+  authorizeResolvedSessionMutation,
+  authorizeSessionSharing,
+  authorizeSessionSharingTarget,
+  canAccessIncognitoSession,
+  canManageSessionSharing,
+  isGatewayAdmin,
+  isResolvedIncognitoSession,
+  isSessionVisibilityAllowed,
+  resolveSessionSharingRole,
+  resolveSessionSharingTarget,
+  resolveSessionVisibility,
+} from "./session-sharing-policy.js";
 
 export function resolveSessionMutationAuthorization(params: {
   client: GatewayClient | null;
@@ -435,7 +156,23 @@ export function resolveSessionMutationAuthorization(params: {
       throw error;
     }
   };
-  const directTargets = resolveDirectSessionTargets(params.method, params.requestParams);
+  const talkInput = resolveTalkSessionTargetInput(params.method, params.requestParams);
+  let talkSessionTarget: PreparedTalkSessionTarget | undefined;
+  try {
+    talkSessionTarget = talkInput && prepareTalkSessionTarget(getCfg(), talkInput.sessionKey);
+  } catch (error) {
+    return {
+      error: errorShape(
+        ErrorCodes.INVALID_REQUEST,
+        String(error instanceof Error ? error.message : error),
+      ),
+    };
+  }
+  const talkTargets = talkSessionTarget
+    ? [{ sessionKey: talkSessionTarget.canonicalKey, agentId: talkSessionTarget.agentId }]
+    : undefined;
+  const directTargets =
+    talkTargets ?? resolveDirectSessionTargets(params.method, params.requestParams);
   const hidesForeignSessions =
     directTargets.length > 0 &&
     gatewayClientSessionCreator(params.client) &&
@@ -443,7 +180,8 @@ export function resolveSessionMutationAuthorization(params: {
   // Incognito and role-hidden direct reads share the same non-disclosing access boundary.
   const protectedTargets = hidesForeignSessions
     ? directTargets
-    : resolveDirectIncognitoTargets(params.method, params.requestParams);
+    : (talkTargets?.filter((target) => isIncognitoSessionKey(target.sessionKey)) ??
+      resolveDirectIncognitoTargets(params.method, params.requestParams));
   for (const targetRef of protectedTargets) {
     const resolved = resolveAuthorizedTarget(targetRef);
     if ("error" in resolved) {
@@ -469,12 +207,14 @@ export function resolveSessionMutationAuthorization(params: {
       return { error: hiddenSessionNotFound(targetRef.sessionKey) };
     }
   }
-  const targetRefs = resolveSessionMutationTargets({
-    method: params.method,
-    requestParams: params.requestParams,
-    context: params.context,
-    getCfg,
-  });
+  const targetRefs =
+    talkTargets ??
+    resolveSessionMutationTargets({
+      method: params.method,
+      requestParams: params.requestParams,
+      context: params.context,
+      getCfg,
+    });
   if (!targetRefs) {
     if (isRequiredSessionTargetMethod(params.method)) {
       return {
@@ -484,6 +224,16 @@ export function resolveSessionMutationAuthorization(params: {
       };
     }
     return { error: null };
+  }
+  if (talkSessionTarget && authorizesAgentRun) {
+    const error = authorizeGatewaySessionCreation({
+      cfg: getCfg(),
+      client: params.client,
+      agentId: talkSessionTarget.agentId,
+    });
+    if (error) {
+      return { error };
+    }
   }
   const authorizedTargets: AuthorizedSessionMutationTarget[] = [];
   for (const targetRef of targetRefs) {
@@ -531,11 +281,51 @@ export function resolveSessionMutationAuthorization(params: {
   return {
     error: null,
     authorization: (() => {
+      const targetChanged = (sessionKey: string) =>
+        new SessionMutationAuthorizationChangedError(
+          errorShape(
+            ErrorCodes.INVALID_REQUEST,
+            `session changed before ${params.method}; retry the request`,
+            {
+              details: {
+                code: "SESSION_MUTATION_AUTHORIZATION_CHANGED",
+                method: params.method,
+                sessionKey,
+              },
+            },
+          ),
+        );
+      const assertTalkTargetCurrent = (cfg: OpenClawConfig) => {
+        if (!talkInput || !talkSessionTarget) {
+          return;
+        }
+        let current: PreparedTalkSessionTarget;
+        try {
+          current = prepareTalkSessionTarget(cfg, talkInput.sessionKey);
+        } catch {
+          throw targetChanged(talkSessionTarget.sessionKey);
+        }
+        if (
+          current.agentId !== talkSessionTarget.agentId ||
+          current.sessionKey !== talkSessionTarget.sessionKey ||
+          current.canonicalKey !== talkSessionTarget.canonicalKey ||
+          current.storePath !== talkSessionTarget.storePath
+        ) {
+          throw targetChanged(talkSessionTarget.sessionKey);
+        }
+        const error =
+          authorizesAgentRun &&
+          authorizeGatewaySessionCreation({ cfg, client: params.client, agentId: current.agentId });
+        if (error) {
+          throw new SessionMutationAuthorizationChangedError(error);
+        }
+      };
       const assertTargetCurrent = (
         targetRef: SessionMutationTarget,
         expected: AuthorizedSessionMutationTarget | undefined,
         currentCfg: OpenClawConfig,
         currentLookupCaches?: ReturnType<typeof createLookupCaches>,
+        ensuredSessionId?: string,
       ) => {
         const current = resolveSessionSharingTarget({
           cfg: currentCfg,
@@ -543,30 +333,35 @@ export function resolveSessionMutationAuthorization(params: {
           agentId: targetRef.agentId,
           ...currentLookupCaches,
         });
+        // The guarded ensure may mint this row/id. Its result permits only that
+        // materialization, never a replacement of an already admitted session.
+        const ensuredTarget =
+          talkSessionTarget &&
+          authorizesAgentRun &&
+          expected?.sessionId === null &&
+          ensuredSessionId
+            ? {
+                agentId: talkSessionTarget.agentId,
+                canonicalKey: talkSessionTarget.canonicalKey,
+                storeKey: talkSessionTarget.canonicalKey,
+                storePath: talkSessionTarget.storePath,
+              }
+            : undefined;
+        const expectedResolved = expected?.resolved ?? ensuredTarget;
+        const expectedSessionId = expected?.sessionId ?? (ensuredTarget ? ensuredSessionId : null);
         const sameResolvedTarget =
           expected !== undefined &&
           (current === null
-            ? expected.resolved === null
-            : expected.resolved !== null &&
-              current.agentId === expected.resolved.agentId &&
-              current.canonicalKey === expected.resolved.canonicalKey &&
-              current.storeKey === expected.resolved.storeKey &&
-              current.storePath === expected.resolved.storePath &&
-              (current.entry.sessionId?.trim() || null) === expected.sessionId);
+            ? expected.resolved === null && !ensuredSessionId
+            : expectedResolved !== undefined &&
+              expectedResolved !== null &&
+              current.agentId === expectedResolved.agentId &&
+              current.canonicalKey === expectedResolved.canonicalKey &&
+              current.storeKey === expectedResolved.storeKey &&
+              current.storePath === expectedResolved.storePath &&
+              (current.entry.sessionId?.trim() || null) === expectedSessionId);
         if (!sameResolvedTarget) {
-          throw new SessionMutationAuthorizationChangedError(
-            errorShape(
-              ErrorCodes.INVALID_REQUEST,
-              `session changed before ${params.method}; retry the request`,
-              {
-                details: {
-                  code: "SESSION_MUTATION_AUTHORIZATION_CHANGED",
-                  method: params.method,
-                  sessionKey: targetRef.sessionKey,
-                },
-              },
-            ),
-          );
+          throw targetChanged(targetRef.sessionKey);
         }
         if (!current) {
           return;
@@ -594,14 +389,16 @@ export function resolveSessionMutationAuthorization(params: {
         }
       };
       return {
+        ...(talkSessionTarget ? { talkSessionTarget } : {}),
         assertCurrent: () => {
           const currentCfg = params.context.getRuntimeConfig();
+          assertTalkTargetCurrent(currentCfg);
           const currentLookupCaches = createLookupCaches();
           for (const authorized of authorizedTargets) {
             assertTargetCurrent(authorized, authorized, currentCfg, currentLookupCaches);
           }
         },
-        assertTargetCurrent: (targetRef: SessionMutationTarget) => {
+        assertTargetCurrent: (targetRef: SessionMutationTarget & { ensuredSessionId?: string }) => {
           // Batch outcomes preserve caller identities, but authorization owns normalized targets.
           // Resolve the same normalized identity so padded aliases cannot escape the snapshot fence.
           const sessionKey = normalizeOptionalString(targetRef.sessionKey);
@@ -610,7 +407,15 @@ export function resolveSessionMutationAuthorization(params: {
           const expected = authorizedTargets.find(
             (target) => target.sessionKey === sessionKey && target.agentId === agentId,
           );
-          assertTargetCurrent(normalizedTarget, expected, params.context.getRuntimeConfig());
+          const currentCfg = params.context.getRuntimeConfig();
+          assertTalkTargetCurrent(currentCfg);
+          assertTargetCurrent(
+            normalizedTarget,
+            expected,
+            currentCfg,
+            undefined,
+            targetRef.ensuredSessionId,
+          );
         },
       };
     })(),

--- a/src/gateway/talk-client-gateway-control.agent-consult.test.ts
+++ b/src/gateway/talk-client-gateway-control.agent-consult.test.ts
@@ -71,8 +71,12 @@ function createRunner(
   return createTalkClientAgentConsultRunner({
     config,
     context: { chatAbortControllers: new Map(), logGateway: { warn: vi.fn() } } as never,
-    agentId: "researcher",
-    sessionKey: "agent:researcher:talk",
+    sessionTarget: {
+      agentId: "researcher",
+      sessionKey: "agent:researcher:talk",
+      canonicalKey: "agent:researcher:talk",
+      storePath: "/tmp/sessions",
+    },
     authority,
     getVoiceSessionId: () => "voice-session",
     initialItems: [],

--- a/src/gateway/talk-client-gateway-control.agent-import-failure.test.ts
+++ b/src/gateway/talk-client-gateway-control.agent-import-failure.test.ts
@@ -43,8 +43,12 @@ it("does not create Talk admission when lazy core loading fails", async () => {
   const runner = createTalkClientAgentConsultRunner({
     config: {} as OpenClawConfig,
     context: { chatAbortControllers: new Map(), logGateway: { warn: vi.fn() } } as never,
-    agentId: "main",
-    sessionKey: "agent:main:talk",
+    sessionTarget: {
+      agentId: "main",
+      sessionKey: "agent:main:talk",
+      canonicalKey: "agent:main:talk",
+      storePath: "/tmp/sessions",
+    },
     getVoiceSessionId: () => "voice-session",
     initialItems: [],
     registerRun: vi.fn(),

--- a/src/gateway/talk-client-gateway-control.test.ts
+++ b/src/gateway/talk-client-gateway-control.test.ts
@@ -6,6 +6,13 @@ import {
 } from "./talk-client-gateway-control.js";
 import { cleanupTalkConnection } from "./talk-session-registry.js";
 
+const sessionTarget = {
+  agentId: "main",
+  sessionKey: "agent:main:main",
+  canonicalKey: "agent:main:main",
+  storePath: "/tmp/sessions",
+};
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((done) => {
@@ -20,6 +27,7 @@ function controlContext(
 ) {
   return {
     logGateway: { warn },
+    chatAbortControllers: new Map(),
     broadcastToConnIds: vi.fn((_name: string, payload: { talkEvent?: unknown }) => {
       if (payload.talkEvent) {
         onTalkEvent?.(payload.talkEvent as { type: string; payload: unknown });
@@ -39,7 +47,7 @@ describe("Talk client Gateway control owner", () => {
       const owner = createTalkClientGatewayControlOwner({
         voiceSessionId: `voice-${status}`,
         providerId: "openai",
-        sessionKey: "agent:main:main",
+        sessionTarget,
         connId: "conn-gateway",
         context: controlContext(warn, (event) => talkEvents.push(event)),
         runAgentConsult: vi.fn(async () => ({ text: "done" })),
@@ -107,7 +115,7 @@ describe("Talk client Gateway control owner", () => {
     } satisfies RealtimeVoiceBridge;
     const owner = createTalkClientGatewayControlOwner({
       voiceSessionId: "voice-gateway",
-      sessionKey: "agent:main:main",
+      sessionTarget,
       connId: "conn-gateway",
       context: controlContext(),
       runAgentConsult,
@@ -141,7 +149,7 @@ describe("Talk client Gateway control owner", () => {
 
     const closeParams = {
       voiceSessionId: "voice-gateway",
-      sessionKey: "agent:main:main",
+      sessionKey: sessionTarget.sessionKey,
       connId: "conn-gateway",
     };
     await expect(
@@ -166,7 +174,7 @@ describe("Talk client Gateway control owner", () => {
     const runAgentConsult = vi.fn(async () => ({ text: "unexpected" }));
     const owner = createTalkClientGatewayControlOwner({
       voiceSessionId: "voice-control",
-      sessionKey: "agent:main:main",
+      sessionTarget,
       connId: "conn-control",
       context: controlContext(),
       runAgentConsult,
@@ -203,7 +211,7 @@ describe("Talk client Gateway control owner", () => {
           : text === "status"
             ? ("status" as const)
             : ("steer" as const),
-      sessionKey: "agent:main:main",
+      sessionKey: sessionTarget.canonicalKey,
       active: true,
       ...(text === "cancel" ? { aborted: true } : { queued: text !== "status" }),
       message: `${text} accepted`,
@@ -240,7 +248,7 @@ describe("Talk client Gateway control owner", () => {
     } satisfies RealtimeVoiceBridge;
     const owner = createTalkClientGatewayControlOwner({
       voiceSessionId: "voice-spoken-control",
-      sessionKey: "agent:main:main",
+      sessionTarget,
       connId: "conn-spoken-control",
       context: controlContext(),
       runAgentConsult,
@@ -289,7 +297,7 @@ describe("Talk client Gateway control owner", () => {
     const closeLogicalSession = vi.fn(async () => undefined);
     const owner = createTalkClientGatewayControlOwner({
       voiceSessionId: "voice-disconnect",
-      sessionKey: "agent:main:main",
+      sessionTarget,
       connId: "conn-disconnect",
       context: controlContext(),
       runAgentConsult: vi.fn(async () => ({ text: "done" })),
@@ -310,7 +318,7 @@ describe("Talk client Gateway control owner", () => {
     const closeLogicalSession = vi.fn(async () => undefined);
     const owner = createTalkClientGatewayControlOwner({
       voiceSessionId: "voice-close-error",
-      sessionKey: "agent:main:main",
+      sessionTarget,
       connId: "conn-close-error",
       context: controlContext(),
       runAgentConsult: vi.fn(async () => ({ text: "done" })),
@@ -340,7 +348,7 @@ describe("Talk client Gateway control owner", () => {
     const closeLogicalSession = vi.fn(async () => undefined);
     const common = {
       voiceSessionId: "voice-replacement",
-      sessionKey: "agent:main:main",
+      sessionTarget,
       connId: "conn-replacement",
       context: controlContext(),
       runAgentConsult,

--- a/src/gateway/talk-client-gateway-control.ts
+++ b/src/gateway/talk-client-gateway-control.ts
@@ -44,7 +44,7 @@ import type { GatewayRequestContext } from "./server-methods/shared-types.js";
 import { resolveOwnedActiveTalkRunTarget } from "./server-methods/talk-client-run-ownership.js";
 import { formatError } from "./server-utils.js";
 import { registerTalkConnectionCleanup } from "./talk-session-registry.js";
-import type { PreparedTalkSessionTarget } from "./talk-session-target.js";
+import type { PreparedTalkSessionTarget } from "./talk-session-target.types.js";
 
 type GatewayControlOwner = {
   adoptProvider: (closeProvider: () => Promise<void>) => Promise<void>;

--- a/src/gateway/talk-client-gateway-control.ts
+++ b/src/gateway/talk-client-gateway-control.ts
@@ -41,8 +41,10 @@ import type { TalkEvent } from "../talk/talk-events.js";
 import { registerChatAbortController } from "./chat-abort.js";
 import { ADMIN_SCOPE, WRITE_SCOPE } from "./operator-scopes.js";
 import type { GatewayRequestContext } from "./server-methods/shared-types.js";
+import { resolveOwnedActiveTalkRunTarget } from "./server-methods/talk-client-run-ownership.js";
 import { formatError } from "./server-utils.js";
 import { registerTalkConnectionCleanup } from "./talk-session-registry.js";
+import type { PreparedTalkSessionTarget } from "./talk-session-target.js";
 
 type GatewayControlOwner = {
   adoptProvider: (closeProvider: () => Promise<void>) => Promise<void>;
@@ -56,7 +58,7 @@ type GatewayControlOwner = {
   connId: string;
   control: RealtimeVoiceGatewayControl;
   runAgentConsult: RealtimeVoiceAgentConsultRunner;
-  sessionKey: string;
+  sessionTarget: PreparedTalkSessionTarget;
   voiceSessionId: string;
 };
 
@@ -240,8 +242,7 @@ export function boundTalkClientRealtimeInitialItems(
 export function createTalkClientAgentConsultRunner(params: {
   config: OpenClawConfig;
   context: Pick<GatewayRequestContext, "chatAbortControllers" | "logGateway">;
-  agentId: string;
-  sessionKey: string;
+  sessionTarget: PreparedTalkSessionTarget;
   ownerConnId?: string;
   authority?: TalkAgentConsultAuthority;
   getVoiceSessionId: () => string | undefined;
@@ -250,6 +251,7 @@ export function createTalkClientAgentConsultRunner(params: {
   surface?: string;
   registerRun?: (params: { runId: string }) => void;
 }) {
+  const { agentId, sessionKey, canonicalKey, storePath } = params.sessionTarget;
   const authority = params.authority ?? resolveTalkAgentConsultAuthority(undefined);
   let agentRuntime: ReturnType<typeof createPluginRuntime>["agent"] | undefined;
   const runArgs = async (args: unknown, signal?: AbortSignal) => {
@@ -261,22 +263,18 @@ export function createTalkClientAgentConsultRunner(params: {
     // Relays own admission before their lazy record registration. Browser callbacks
     // must validate the durable call before accepting a new run.
     if (!params.registerRun) {
-      assertClientVoiceSessionOpen({
-        agentId: params.agentId,
-        sessionKey: params.sessionKey,
-        voiceSessionId,
-      });
+      assertClientVoiceSessionOpen({ agentId, sessionKey, voiceSessionId });
     }
     const confirmationGrant = parsedArgs.confirmationId
       ? authorizeClientVoiceConfirmation({
-          agentId: params.agentId,
+          agentId,
           voiceSessionId,
           confirmationId: parsedArgs.confirmationId,
         })
       : undefined;
     agentRuntime ??= createTalkClientAgentRuntime({
       config: params.config,
-      agentId: params.agentId,
+      agentId,
       ...(params.ownerConnId ? { rawSourceRef: params.ownerConnId } : {}),
     });
     const talkConfig = normalizeTalkSection(params.config.talk);
@@ -284,8 +282,9 @@ export function createTalkClientAgentConsultRunner(params: {
       cfg: params.config,
       agentRuntime,
       logger: params.context.logGateway,
-      agentId: params.agentId,
-      sessionKey: params.sessionKey,
+      agentId,
+      sessionKey: canonicalKey,
+      storePath,
       messageProvider: "webchat",
       lane: "talk",
       runIdPrefix: params.runIdPrefix ?? "talk-realtime-consult",
@@ -303,8 +302,8 @@ export function createTalkClientAgentConsultRunner(params: {
           params.registerRun({ runId });
         } else {
           registerClientVoiceConsultRun({
-            agentId: params.agentId,
-            sessionKey: params.sessionKey,
+            agentId,
+            sessionKey,
             voiceSessionId,
             runId,
             config: params.config,
@@ -320,8 +319,8 @@ export function createTalkClientAgentConsultRunner(params: {
           chatAbortControllers: params.context.chatAbortControllers,
           runId,
           sessionId,
-          sessionKey: params.sessionKey,
-          agentId: params.agentId,
+          sessionKey: canonicalKey,
+          agentId,
           timeoutMs,
           ownerConnId: params.ownerConnId,
           controlUiVisible: false,
@@ -341,9 +340,12 @@ export function createTalkClientAgentConsultRunner(params: {
 export function createTalkClientGatewayControlOwner(params: {
   voiceSessionId: string;
   providerId?: string;
-  sessionKey: string;
+  sessionTarget: PreparedTalkSessionTarget;
   connId: string;
-  context: Pick<GatewayRequestContext, "broadcastToConnIds" | "logGateway">;
+  context: Pick<
+    GatewayRequestContext,
+    "broadcastToConnIds" | "logGateway" | "chatAbortControllers"
+  >;
   assertConnectionOpen?: () => void;
   runAgentConsult: (args: unknown, signal: AbortSignal) => Promise<{ text: string }>;
   appendTranscript: (entry: {
@@ -353,11 +355,7 @@ export function createTalkClientGatewayControlOwner(params: {
   }) => Promise<void>;
   flushTranscript: () => Promise<void>;
   closeLogicalSession: () => Promise<void>;
-  controlAgentRun?: (params: {
-    sessionKey: string;
-    text: string;
-    mode?: unknown;
-  }) => Promise<RealtimeVoiceAgentControlResult>;
+  controlAgentRun?: typeof controlRealtimeVoiceAgentRun;
 }): GatewayControlOwner {
   let bridge: RealtimeVoiceBridge | undefined;
   let closeProvider: (() => Promise<void>) | undefined;
@@ -405,8 +403,20 @@ export function createTalkClientGatewayControlOwner(params: {
 
   const applyControl = async (args: unknown) => {
     const parsed = parseRealtimeVoiceAgentControlToolArgs(args);
+    const runTarget = resolveOwnedActiveTalkRunTarget({
+      context: params.context,
+      clientConnId: params.connId,
+      sessionTarget: params.sessionTarget,
+      assertCurrent: () => {
+        owner.assertOpen();
+        if (owners.get(params.voiceSessionId) !== owner) {
+          throw new Error("Realtime voice session is not active");
+        }
+      },
+    });
     const result = await (params.controlAgentRun ?? controlRealtimeVoiceAgentRun)({
-      sessionKey: params.sessionKey,
+      sessionKey: params.sessionTarget.canonicalKey,
+      runTarget,
       text: parsed.text,
       mode: parsed.mode,
     });
@@ -521,7 +531,7 @@ export function createTalkClientGatewayControlOwner(params: {
 
   const owner: GatewayControlOwner = {
     connId: params.connId,
-    sessionKey: params.sessionKey,
+    sessionTarget: params.sessionTarget,
     voiceSessionId: params.voiceSessionId,
     assertOpen: () => {
       signal.throwIfAborted();
@@ -686,7 +696,8 @@ export async function closeTalkClientGatewayControlSession(params: {
     return false;
   }
   const owned = matching.filter(
-    (owner) => owner.sessionKey === params.sessionKey.trim() && owner.connId === params.connId,
+    (owner) =>
+      owner.sessionTarget.sessionKey === params.sessionKey.trim() && owner.connId === params.connId,
   );
   if (owned.length === 0) {
     throw new Error("Gateway-controlled voice session is not owned by this client");

--- a/src/gateway/talk-realtime-relay-operations.ts
+++ b/src/gateway/talk-realtime-relay-operations.ts
@@ -12,6 +12,7 @@ import type {
 } from "../talk/provider-types.js";
 import type { TalkEvent } from "../talk/talk-session-controller.js";
 import { abortChatRunById } from "./chat-abort.js";
+import { resolveOwnedActiveTalkRunTarget } from "./server-methods/talk-client-run-ownership.js";
 import { formatError } from "./server-utils.js";
 import {
   submitForcedTalkRealtimeRelayToolResult,
@@ -463,15 +464,28 @@ export async function steerTalkRealtimeRelayAgentRun(params: {
   sessionKey?: string;
   text: string;
   mode?: string;
+  assertCurrent?: () => void;
 }): Promise<RealtimeVoiceAgentControlResult> {
   const session = getRelaySession(params.relaySessionId, params.connId);
-  const { sessionKey } = session.sessionTarget;
+  const { sessionKey, canonicalKey } = session.sessionTarget;
   const requestedSessionKey = params.sessionKey?.trim();
   if (requestedSessionKey && requestedSessionKey !== sessionKey) {
     throw new Error("Realtime relay steering session key does not match the relay session");
   }
+  const runTarget = resolveOwnedActiveTalkRunTarget({
+    context: session.context,
+    clientConnId: session.connId,
+    sessionTarget: session.sessionTarget,
+    assertCurrent: () => {
+      params.assertCurrent?.();
+      if (relaySessions.get(session.id) !== session) {
+        throw new Error("Realtime relay session closed while steering the agent run");
+      }
+    },
+  });
   const result = await controlRealtimeVoiceAgentRun({
-    sessionKey,
+    sessionKey: canonicalKey,
+    runTarget,
     text: params.text,
     mode: params.mode,
     recentEvents: session.harness.talk.recentEvents,

--- a/src/gateway/talk-realtime-relay-operations.ts
+++ b/src/gateway/talk-realtime-relay-operations.ts
@@ -38,13 +38,7 @@ import {
   resolveRelayProviderToolCallId,
   type RelaySession,
 } from "./talk-realtime-relay-state.js";
-import {
-  bindRelaySessionKey,
-  closeRelayVoiceSession,
-  enqueueRelayVoiceTranscript,
-  ensureRelayVoiceSession,
-  resolveRelayAgentId,
-} from "./talk-realtime-relay-voice.js";
+import { closeRelayVoiceSession, ensureRelayVoiceSession } from "./talk-realtime-relay-voice.js";
 import { decodeTalkRelayAudioBase64 } from "./talk-relay-audio-base64.js";
 import {
   closeExpiredTalkRelaySessions,
@@ -62,13 +56,11 @@ export function ensureTalkRealtimeRelayVoiceSession(params: {
   sessionKey: string;
 }): void {
   const session = getRelaySession(params.relaySessionId, params.connId);
-  bindRelaySessionKey(session, params.sessionKey);
+  if (session.sessionTarget.sessionKey !== params.sessionKey.trim()) {
+    throw new Error("Realtime relay session belongs to another agent session");
+  }
   if (!ensureRelayVoiceSession(session)) {
     throw new Error("Realtime relay voice session could not be created");
-  }
-  const buffered = session.pendingVoiceTranscripts.splice(0);
-  for (const entry of buffered) {
-    enqueueRelayVoiceTranscript(session, entry.role, entry.text);
   }
 }
 
@@ -385,9 +377,6 @@ export function registerTalkRealtimeRelayAgentRun(params: {
   if (callId && !session.toolCalls.tryAdmit([callId])) {
     throw new Error("Realtime relay tool-call session limit exceeded");
   }
-  if (!session.sessionKey) {
-    bindRelaySessionKey(session, params.sessionKey);
-  }
   session.activeAgentRuns.set(params.runId, params.sessionKey);
   if (callId) {
     session.activeAgentToolCalls.set(callId, params.runId);
@@ -395,13 +384,10 @@ export function registerTalkRealtimeRelayAgentRun(params: {
   if (!ensureRelayVoiceSession(session)) {
     throw new Error("Realtime relay voice session could not be created for agent consult");
   }
-  const voiceSessionKey = session.sessionKey;
-  if (!voiceSessionKey) {
-    throw new Error("Realtime relay voice session has no pinned session key");
-  }
+  const { agentId, sessionKey } = session.sessionTarget;
   registerClientVoiceConsultRun({
-    agentId: resolveRelayAgentId(session, voiceSessionKey),
-    sessionKey: voiceSessionKey,
+    agentId,
+    sessionKey,
     voiceSessionId: session.id,
     runId: params.runId,
   });
@@ -479,10 +465,7 @@ export async function steerTalkRealtimeRelayAgentRun(params: {
   mode?: string;
 }): Promise<RealtimeVoiceAgentControlResult> {
   const session = getRelaySession(params.relaySessionId, params.connId);
-  const sessionKey = session.sessionKey;
-  if (!sessionKey) {
-    throw new Error("Realtime relay steering requires a session key");
-  }
+  const { sessionKey } = session.sessionTarget;
   const requestedSessionKey = params.sessionKey?.trim();
   if (requestedSessionKey && requestedSessionKey !== sessionKey) {
     throw new Error("Realtime relay steering session key does not match the relay session");

--- a/src/gateway/talk-realtime-relay-session-create.ts
+++ b/src/gateway/talk-realtime-relay-session-create.ts
@@ -125,12 +125,11 @@ export function createTalkRealtimeRelaySession(
       }
     },
   );
-  const { agentId: relayAgentId, sessionKey: relaySessionKey } = params.sessionTarget;
+  const { agentId: relayAgentId, canonicalKey } = params.sessionTarget;
   const consultRunner = createTalkClientAgentConsultRunner({
     config: params.cfg ?? params.context.getRuntimeConfig(),
     context: params.context,
-    agentId: relayAgentId,
-    sessionKey: relaySessionKey,
+    sessionTarget: params.sessionTarget,
     ownerConnId: params.connId,
     authority: params.consultAuthority,
     getVoiceSessionId: () => relaySessionId,
@@ -141,7 +140,7 @@ export function createTalkRealtimeRelaySession(
       registerTalkRealtimeRelayAgentRun({
         relaySessionId,
         connId: params.connId,
-        sessionKey: relaySessionKey,
+        sessionKey: canonicalKey,
         runId,
       }),
   });

--- a/src/gateway/talk-realtime-relay-session-create.ts
+++ b/src/gateway/talk-realtime-relay-session-create.ts
@@ -3,7 +3,6 @@ import { resolveExpiresAtMsFromDurationMs } from "@openclaw/normalization-core/n
 import { formatErrorMessage } from "../infra/errors.js";
 import { REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME } from "../talk/agent-consult-tool.js";
 import { buildRealtimeVoiceAgentCancelProviderResult } from "../talk/agent-run-control-shared.js";
-import { resolveTalkSessionAgentId } from "../talk/agent-target.js";
 import {
   REALTIME_VOICE_AUDIO_FORMAT_PCM16_24KHZ,
   type RealtimeVoiceCloseReason,
@@ -126,42 +125,29 @@ export function createTalkRealtimeRelaySession(
       }
     },
   );
-  const relaySessionKey = params.sessionKey?.trim();
-  const relayAgentId = relaySessionKey
-    ? resolveTalkSessionAgentId(params.cfg ?? params.context.getRuntimeConfig(), relaySessionKey)
-    : undefined;
-  const consultRunner = relaySessionKey
-    ? createTalkClientAgentConsultRunner({
-        config: params.cfg ?? params.context.getRuntimeConfig(),
-        context: params.context,
-        agentId:
-          relayAgentId ??
-          resolveTalkSessionAgentId(
-            params.cfg ?? params.context.getRuntimeConfig(),
-            relaySessionKey,
-          ),
+  const { agentId: relayAgentId, sessionKey: relaySessionKey } = params.sessionTarget;
+  const consultRunner = createTalkClientAgentConsultRunner({
+    config: params.cfg ?? params.context.getRuntimeConfig(),
+    context: params.context,
+    agentId: relayAgentId,
+    sessionKey: relaySessionKey,
+    ownerConnId: params.connId,
+    authority: params.consultAuthority,
+    getVoiceSessionId: () => relaySessionId,
+    initialItems: [],
+    runIdPrefix: "talk-realtime-relay-consult",
+    surface: "a gateway-relay Talk session",
+    registerRun: ({ runId }) =>
+      registerTalkRealtimeRelayAgentRun({
+        relaySessionId,
+        connId: params.connId,
         sessionKey: relaySessionKey,
-        ownerConnId: params.connId,
-        authority: params.consultAuthority,
-        getVoiceSessionId: () => relaySessionId,
-        initialItems: [],
-        runIdPrefix: "talk-realtime-relay-consult",
-        surface: "a gateway-relay Talk session",
-        registerRun: ({ runId }) =>
-          registerTalkRealtimeRelayAgentRun({
-            relaySessionId,
-            connId: params.connId,
-            sessionKey: relaySessionKey,
-            runId,
-          }),
-      })
-    : undefined;
+        runId,
+      }),
+  });
   const runAgentConsult = async ({ prompt, signal }: { prompt: string; signal?: AbortSignal }) => {
     if (!getActiveRelay()) {
       throw new Error("Realtime gateway-relay session is closed");
-    }
-    if (!consultRunner) {
-      throw new Error("Realtime gateway-relay agent consult requires a pinned session key");
     }
     return await consultRunner.runPrompt({ prompt, signal });
   };
@@ -571,7 +557,6 @@ export function createTalkRealtimeRelaySession(
     }
     throw new Error(`Realtime provider closed during session creation: ${earlyTerminal.reason}`);
   }
-  const initialSessionKey = params.sessionKey?.trim() || undefined;
   const failSession = (message: string) => {
     const active = relaySessions.get(relaySessionId);
     if (!active || sessionFailureRequested) {
@@ -598,15 +583,7 @@ export function createTalkRealtimeRelaySession(
     bridge,
     harness,
     outputOwnership,
-    sessionKey: initialSessionKey,
-    ...(initialSessionKey
-      ? {
-          agentId: resolveTalkSessionAgentId(
-            params.cfg ?? params.context.getRuntimeConfig(),
-            initialSessionKey,
-          ),
-        }
-      : {}),
+    sessionTarget: params.sessionTarget,
     expiresAtMs,
     cleanupTimer: setTimeout(() => {
       const active = relaySessions.get(relaySessionId);
@@ -635,7 +612,6 @@ export function createTalkRealtimeRelaySession(
     voiceTranscriptSeq: 0,
     voiceTranscriptQueue: VOICE_TRANSCRIPT_QUEUE_POLICY.createQueue(),
     failSession,
-    pendingVoiceTranscripts: [],
   };
   relayRef.current = relay;
   relay.cleanupTimer.unref?.();

--- a/src/gateway/talk-realtime-relay-state.ts
+++ b/src/gateway/talk-realtime-relay-state.ts
@@ -17,7 +17,7 @@ import type { TalkEvent } from "../talk/talk-session-controller.js";
 import type { GatewayRequestContext } from "./server-methods/shared-types.js";
 import type { TalkAgentConsultAuthority } from "./talk-client-gateway-control.js";
 import type { RelayToolCallLedger } from "./talk-realtime-relay-tool-call-ledger.js";
-import type { PreparedTalkSessionTarget } from "./talk-session-target.js";
+import type { PreparedTalkSessionTarget } from "./talk-session-target.types.js";
 
 export const RELAY_SESSION_TTL_MS = 30 * 60 * 1000;
 export const MAX_AUDIO_BASE64_BYTES = 512 * 1024;

--- a/src/gateway/talk-realtime-relay-state.ts
+++ b/src/gateway/talk-realtime-relay-state.ts
@@ -17,6 +17,7 @@ import type { TalkEvent } from "../talk/talk-session-controller.js";
 import type { GatewayRequestContext } from "./server-methods/shared-types.js";
 import type { TalkAgentConsultAuthority } from "./talk-client-gateway-control.js";
 import type { RelayToolCallLedger } from "./talk-realtime-relay-tool-call-ledger.js";
+import type { PreparedTalkSessionTarget } from "./talk-session-target.js";
 
 export const RELAY_SESSION_TTL_MS = 30 * 60 * 1000;
 export const MAX_AUDIO_BASE64_BYTES = 512 * 1024;
@@ -186,8 +187,7 @@ export type RelaySession = {
   bridge: RealtimeVoiceBridgeSession;
   harness: RealtimeVoiceSessionHarness;
   outputOwnership: TalkRealtimeRelayOutputOwnership;
-  sessionKey?: string;
-  agentId?: string;
+  sessionTarget: PreparedTalkSessionTarget;
   expiresAtMs: number;
   cleanupTimer: ReturnType<typeof setTimeout>;
   activeAgentRuns: Map<string, string>;
@@ -212,7 +212,6 @@ export type RelaySession = {
   voiceTranscriptQueue: BoundedSerialQueue;
   voiceSessionClose?: Promise<void>;
   failSession: (message: string) => void;
-  pendingVoiceTranscripts: Array<{ role: "user" | "assistant"; text: string }>;
 };
 
 export type CreateTalkRealtimeRelaySessionParams = {
@@ -225,7 +224,7 @@ export type CreateTalkRealtimeRelaySessionParams = {
   instructions: string;
   tools: RealtimeVoiceTool[];
   model?: string;
-  sessionKey?: string;
+  sessionTarget: PreparedTalkSessionTarget;
   voice?: string;
   language?: string;
   forceAgentConsultOnFinalTranscript?: boolean;

--- a/src/gateway/talk-realtime-relay-voice.test.ts
+++ b/src/gateway/talk-realtime-relay-voice.test.ts
@@ -31,8 +31,12 @@ function createRelaySession(): {
   });
   const session = {
     id: "relay-voice-bounded",
-    sessionKey: "agent:main:main",
-    agentId: "main",
+    sessionTarget: {
+      agentId: "main",
+      sessionKey: "main",
+      canonicalKey: "agent:main:work",
+      storePath: "/tmp/relay-voice-sessions.sqlite",
+    },
     provider: "openai",
     context: {
       getRuntimeConfig: () => ({}),
@@ -42,7 +46,6 @@ function createRelaySession(): {
     voiceTranscriptSeq: 0,
     voiceTranscriptQueue: VOICE_TRANSCRIPT_QUEUE_POLICY.createQueue(),
     failSession,
-    pendingVoiceTranscripts: [],
   } as unknown as RelaySession;
   return { session, failSession };
 }
@@ -83,7 +86,16 @@ describe("realtime relay voice transcript persistence", () => {
     }
 
     expect(accepted).toBe(41);
-    expect(voiceSessionMocks.appendRelayVoiceTranscript).toHaveBeenCalledOnce();
+    expect(voiceSessionMocks.appendRelayVoiceTranscript).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        agentId: "main",
+        sessionKey: "main",
+        sessionTarget: {
+          sessionKey: "agent:main:work",
+          storePath: "/tmp/relay-voice-sessions.sqlite",
+        },
+      }),
+    );
     expect(failSession).toHaveBeenCalledOnce();
     const close = session.voiceSessionClose;
     expect(close).toBeDefined();
@@ -129,25 +141,5 @@ describe("realtime relay voice transcript persistence", () => {
     } finally {
       vi.useRealTimers();
     }
-  });
-
-  it("normalizes the bounded pre-bind transcript buffer", () => {
-    const { session } = createRelaySession();
-    session.sessionKey = undefined;
-    session.agentId = undefined;
-
-    for (let index = 0; index < 100; index += 1) {
-      expect(enqueueRelayVoiceTranscript(session, "user", " \t\n ")).toBe(true);
-    }
-    expect(session.pendingVoiceTranscripts).toHaveLength(0);
-
-    for (let index = 0; index < 100; index += 1) {
-      expect(enqueueRelayVoiceTranscript(session, "user", `  ${"x".repeat(9_000)}  `)).toBe(true);
-    }
-
-    expect(session.pendingVoiceTranscripts).toHaveLength(40);
-    expect(session.pendingVoiceTranscripts.every((entry) => entry.text.length === 8_000)).toBe(
-      true,
-    );
   });
 });

--- a/src/gateway/talk-realtime-relay-voice.ts
+++ b/src/gateway/talk-realtime-relay-voice.ts
@@ -1,5 +1,4 @@
 import { formatErrorMessage } from "../infra/errors.js";
-import { resolveTalkSessionAgentId } from "../talk/agent-target.js";
 import {
   appendRelayVoiceTranscript,
   closeRelayVoiceSessionRecord,
@@ -17,44 +16,15 @@ function logRelayVoiceFailure(session: RelaySession, message: string, error: unk
   session.context.logGateway?.warn(`${message}: ${formatErrorMessage(error)}`);
 }
 
-function resolveRelayAgentIdFromCurrentConfig(session: RelaySession, sessionKey: string): string {
-  const config = session.voiceConfig ?? session.context.getRuntimeConfig();
-  return resolveTalkSessionAgentId(config, sessionKey);
-}
-
-export function bindRelaySessionKey(session: RelaySession, sessionKey: string): void {
-  const normalizedSessionKey = sessionKey.trim();
-  if (!normalizedSessionKey) {
-    throw new Error("Realtime relay session key must be non-empty");
-  }
-  if (session.sessionKey && session.sessionKey !== normalizedSessionKey) {
-    throw new Error("Realtime relay session belongs to another agent session");
-  }
-  if (!session.sessionKey) {
-    session.sessionKey = normalizedSessionKey;
-    session.agentId = resolveRelayAgentIdFromCurrentConfig(session, normalizedSessionKey);
-  }
-}
-
-export function resolveRelayAgentId(session: RelaySession, sessionKey: string): string {
-  bindRelaySessionKey(session, sessionKey);
-  if (!session.agentId) {
-    throw new Error("Realtime relay session has no pinned agent owner");
-  }
-  return session.agentId;
-}
-
 export function ensureRelayVoiceSession(session: RelaySession): boolean {
   if (session.voiceSessionCreated) {
     return true;
   }
-  if (!session.sessionKey) {
-    return false;
-  }
+  const { agentId, sessionKey } = session.sessionTarget;
   try {
     createOrResumeClientVoiceSession({
-      agentId: resolveRelayAgentId(session, session.sessionKey),
-      sessionKey: session.sessionKey,
+      agentId,
+      sessionKey,
       provider: session.provider,
       origin: "relay",
       voiceSessionId: session.id,
@@ -76,22 +46,12 @@ export function enqueueRelayVoiceTranscript(
   if (!normalizedText) {
     return true;
   }
-  if (!session.sessionKey) {
-    // Lazy-bound relays hear audio before talk.client.toolCall supplies the session
-    // key; buffer bounded finals so the call's opening turns survive the binding.
-    // Never-binding callers accept best-effort loss: they had no persistence before.
-    session.pendingVoiceTranscripts.push({ role, text: normalizedText });
-    if (session.pendingVoiceTranscripts.length > VOICE_TRANSCRIPT_QUEUE_POLICY.maxPendingCount) {
-      session.pendingVoiceTranscripts.shift();
-    }
-    return true;
-  }
   if (!ensureRelayVoiceSession(session)) {
     return true;
   }
   const transcriptSeq = session.voiceTranscriptSeq + 1;
   const entryId = String(transcriptSeq);
-  const sessionKey = session.sessionKey;
+  const { agentId, sessionKey, canonicalKey, storePath } = session.sessionTarget;
   const admission = session.voiceTranscriptQueue.enqueue(
     async () => {
       let lastError: unknown;
@@ -103,8 +63,9 @@ export function enqueueRelayVoiceTranscript(
         }
         try {
           await appendRelayVoiceTranscript({
-            agentId: resolveRelayAgentId(session, sessionKey),
+            agentId,
             sessionKey,
+            sessionTarget: { sessionKey: canonicalKey, storePath },
             voiceSessionId: session.id,
             entryId,
             role,
@@ -138,17 +99,17 @@ export function closeRelayVoiceSession(session: RelaySession): Promise<void> {
     return session.voiceSessionClose;
   }
   session.voiceTranscriptQueue.seal();
-  if (!session.sessionKey || !ensureRelayVoiceSession(session)) {
+  if (!ensureRelayVoiceSession(session)) {
     session.voiceSessionClose = Promise.resolve();
     return session.voiceSessionClose;
   }
-  const sessionKey = session.sessionKey;
+  const { agentId, sessionKey } = session.sessionTarget;
   session.voiceSessionClose = session.voiceTranscriptQueue
     .flush()
     .then(async () => {
       const config = session.voiceConfig ?? session.context.getRuntimeConfig();
       await closeRelayVoiceSessionRecord({
-        agentId: resolveRelayAgentId(session, sessionKey),
+        agentId,
         sessionKey,
         voiceSessionId: session.id,
         config,

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -14,6 +14,7 @@ import {
   replaceSessionEntry,
 } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.js";
+import { getAgentEventLifecycleGeneration } from "../infra/agent-events.js";
 import type { RealtimeVoiceProviderPlugin } from "../plugins/types.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
@@ -35,6 +36,7 @@ import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../test-utils/openclaw-test-state.js";
+import { registerChatAbortController, type ChatAbortControllerEntry } from "./chat-abort.js";
 import { createChatRunState } from "./server-chat-state.js";
 import { drainingRelaySessions, relaySessions } from "./talk-realtime-relay-state.js";
 import { MAX_RELAY_TOOL_CALL_IDENTITIES } from "./talk-realtime-relay-tool-call-ledger.js";
@@ -81,6 +83,10 @@ function createTalkRealtimeRelaySession(
   const cfg = params.cfg ?? { agents: { entries: { main: { default: true } } } };
   const session = createTalkRealtimeRelaySessionRaw({
     ...request,
+    context: {
+      ...request.context,
+      chatAbortControllers: request.context.chatAbortControllers ?? new Map(),
+    },
     cfg,
     sessionTarget: prepareTalkSessionTarget(cfg, sessionKey ?? "agent:main:main"),
   });
@@ -93,6 +99,21 @@ function stopTalkRealtimeRelaySession(
 ): void {
   stopTalkRealtimeRelaySessionRaw(params);
   activeRelaySessions.delete(params.relaySessionId);
+}
+
+function createOwnedTalkRunControllers() {
+  const chatAbortControllers = new Map<string, ChatAbortControllerEntry>();
+  registerChatAbortController({
+    chatAbortControllers,
+    runId: "run-1",
+    sessionId: "embedded-session-1",
+    sessionKey: "agent:main:main",
+    agentId: "main",
+    ownerConnId: "conn-1",
+    timeoutMs: 60_000,
+    kind: "chat-send",
+  });
+  return chatAbortControllers;
 }
 
 function ensureActiveRelayTurnId(relaySessionId: string): string {
@@ -1142,6 +1163,9 @@ describe("talk realtime gateway relay", () => {
             controller: abortController,
             sessionId: "run-1",
             sessionKey: "main",
+            agentId: "main",
+            ownerConnId: "conn-1",
+            lifecycleGeneration: getAgentEventLifecycleGeneration(),
             startedAtMs: 1,
             expiresAtMs: Date.now() + 60_000,
           },
@@ -4102,14 +4126,15 @@ describe("talk realtime gateway relay", () => {
     async ({ supportsSuppression, expectedOptions, expectedSuppress }) => {
       const abortEmbeddedRun = vi.fn();
       setActiveEmbeddedRun(
-        "embedded-session-1",
+        "run-1",
         {
+          runId: "run-1",
           queueMessage: vi.fn(async () => undefined),
           isStreaming: () => true,
           isCompacting: () => false,
           abort: abortEmbeddedRun,
         },
-        "main",
+        "agent:main:main",
       );
       const bridge = makeRelayTransport({
         supportsToolResultSuppression: supportsSuppression,
@@ -4172,14 +4197,15 @@ describe("talk realtime gateway relay", () => {
 
   it("finalizes accepted cancel calls independently when another provider result rejects", async () => {
     setActiveEmbeddedRun(
-      "embedded-session-1",
+      "run-1",
       {
+        runId: "run-1",
         queueMessage: vi.fn(async () => undefined),
         isStreaming: () => true,
         isCompacting: () => false,
         abort: vi.fn(),
       },
-      "main",
+      "agent:main:main",
     );
     const submitToolResult = vi
       .fn<RealtimeVoiceBridge["submitToolResult"]>()
@@ -4240,14 +4266,15 @@ describe("talk realtime gateway relay", () => {
 
   it("does not broadcast steering progress after the relay closes during provider acceptance", async () => {
     setActiveEmbeddedRun(
-      "embedded-session-1",
+      "run-1",
       {
+        runId: "run-1",
         queueMessage: vi.fn(async () => undefined),
         isStreaming: () => true,
         isCompacting: () => false,
         abort: vi.fn(),
       },
-      "main",
+      "agent:main:main",
     );
     const accepted = createDeferred();
     const submitToolResult = vi.fn(() => accepted.promise);
@@ -4286,12 +4313,13 @@ describe("talk realtime gateway relay", () => {
     setActiveEmbeddedRun(
       "embedded-session-1",
       {
+        runId: "run-1",
         queueMessage: vi.fn(async () => undefined),
         isStreaming: () => true,
         isCompacting: () => false,
         abort: abortEmbeddedRun,
       },
-      "main",
+      "agent:main:main",
     );
 
     let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
@@ -4314,7 +4342,7 @@ describe("talk realtime gateway relay", () => {
       broadcastToConnIds: (event: string, payload: unknown, connIds: ReadonlySet<string>) => {
         events.push({ event, payload, connIds: [...connIds] });
       },
-      chatAbortControllers: new Map(),
+      chatAbortControllers: createOwnedTalkRunControllers(),
     } as never;
 
     const session = createTalkRealtimeRelaySession({
@@ -4516,12 +4544,13 @@ describe("talk realtime gateway relay", () => {
     setActiveEmbeddedRun(
       "embedded-session-1",
       {
+        runId: "run-1",
         queueMessage: vi.fn(async () => undefined),
         isStreaming: () => true,
         isCompacting: () => false,
         abort: vi.fn(),
       },
-      "main",
+      "agent:main:main",
     );
 
     let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
@@ -4553,7 +4582,7 @@ describe("talk realtime gateway relay", () => {
         broadcastToConnIds: (event: string, payload: unknown, connIds: ReadonlySet<string>) => {
           events.push({ event, payload, connIds: [...connIds] });
         },
-        chatAbortControllers: new Map(),
+        chatAbortControllers: createOwnedTalkRunControllers(),
       } as never,
       connId: "conn-1",
       provider,
@@ -4759,6 +4788,9 @@ describe("talk realtime gateway relay", () => {
             controller: abortController,
             sessionId: "run-1",
             sessionKey: "main",
+            agentId: "main",
+            ownerConnId: "conn-1",
+            lifecycleGeneration: getAgentEventLifecycleGeneration(),
             startedAtMs: 1,
             expiresAtMs: Date.now() + 60_000,
           },

--- a/src/gateway/talk-realtime-relay.test.ts
+++ b/src/gateway/talk-realtime-relay.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 /**
  * Tests talk realtime relay event forwarding and connection cleanup.
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { setActiveEmbeddedRun } from "../agents/embedded-agent-runner/runs.js";
@@ -24,12 +24,17 @@ import {
   noteClientVoiceConfirmationUtterance,
 } from "../talk/client-voice-confirmation.js";
 import { resetClientVoiceConfirmationStateForTest } from "../talk/client-voice-confirmation.test-support.js";
+import { ensureClientVoiceAgentSessionEntry } from "../talk/client-voice-session.js";
 import { clientVoiceSessionTesting } from "../talk/client-voice-session.test-support.js";
 import type {
   RealtimeVoiceBridge,
   RealtimeVoiceBridgeCreateRequest,
 } from "../talk/provider-types.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
 import { createChatRunState } from "./server-chat-state.js";
 import { drainingRelaySessions, relaySessions } from "./talk-realtime-relay-state.js";
 import { MAX_RELAY_TOOL_CALL_IDENTITIES } from "./talk-realtime-relay-tool-call-ledger.js";
@@ -46,6 +51,7 @@ import {
   submitTalkRealtimeRelayToolResult,
 } from "./talk-realtime-relay.js";
 import { cleanupTalkConnection } from "./talk-session-registry.js";
+import { prepareTalkSessionTarget } from "./talk-session-target.js";
 
 const activeRelaySessions = new Map<string, string>();
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -67,11 +73,16 @@ function makeRelayTransport<Overrides extends Partial<RealtimeVoiceBridge> = Rec
 }
 
 function createTalkRealtimeRelaySession(
-  params: Parameters<typeof createTalkRealtimeRelaySessionRaw>[0],
+  params: Omit<Parameters<typeof createTalkRealtimeRelaySessionRaw>[0], "sessionTarget"> & {
+    sessionKey?: string;
+  },
 ): ReturnType<typeof createTalkRealtimeRelaySessionRaw> {
+  const { sessionKey, ...request } = params;
+  const cfg = params.cfg ?? { agents: { entries: { main: { default: true } } } };
   const session = createTalkRealtimeRelaySessionRaw({
-    cfg: { agents: { entries: { main: { default: true } } } },
-    ...params,
+    ...request,
+    cfg,
+    sessionTarget: prepareTalkSessionTarget(cfg, sessionKey ?? "agent:main:main"),
   });
   activeRelaySessions.set(session.relaySessionId, params.connId);
   return session;
@@ -96,6 +107,18 @@ function ensureActiveRelayTurnId(relaySessionId: string): string {
 }
 
 describe("talk realtime gateway relay", () => {
+  let testState: OpenClawTestState | undefined;
+
+  beforeEach(async () => {
+    testState = await createOpenClawTestState({
+      label: "talk-realtime-relay",
+      scenario: "minimal",
+    });
+    // The RPC owner creates this row before starting a relay. Explicit missing-key
+    // tests keep their own target and isolated state instead of inheriting this row.
+    await ensureClientVoiceAgentSessionEntry({ agentId: "main", sessionKey: "agent:main:main" });
+  });
+
   it.each([
     [
       { status: "failed" as const, responseId: "response-1", message: "provider failed" },
@@ -204,25 +227,31 @@ describe("talk realtime gateway relay", () => {
   });
 
   afterEach(async () => {
-    for (const [relaySessionId, connId] of activeRelaySessions) {
-      try {
-        stopTalkRealtimeRelaySessionRaw({ relaySessionId, connId });
-      } catch (error) {
-        if (
-          !(error instanceof Error) ||
-          !error.message.includes("Unknown realtime relay session")
-        ) {
-          throw error;
+    try {
+      for (const [relaySessionId, connId] of activeRelaySessions) {
+        try {
+          stopTalkRealtimeRelaySessionRaw({ relaySessionId, connId });
+        } catch (error) {
+          if (
+            !(error instanceof Error) ||
+            !error.message.includes("Unknown realtime relay session")
+          ) {
+            throw error;
+          }
         }
       }
+      await Promise.all(
+        [...drainingRelaySessions].map((session) => session.voiceSessionClose ?? Promise.resolve()),
+      );
+    } finally {
+      activeRelaySessions.clear();
+      vi.useRealTimers();
+      clientVoiceSessionTesting.reset();
+      resetClientVoiceConfirmationStateForTest();
+      embeddedRunTesting.resetActiveEmbeddedRuns();
+      await testState?.cleanup();
+      testState = undefined;
     }
-    activeRelaySessions.clear();
-    await Promise.all(
-      [...drainingRelaySessions].map((session) => session.voiceSessionClose ?? Promise.resolve()),
-    );
-    vi.useRealTimers();
-    resetClientVoiceConfirmationStateForTest();
-    embeddedRunTesting.resetActiveEmbeddedRuns();
   });
 
   function createIdleRelayProvider(): RealtimeVoiceProviderPlugin {
@@ -542,80 +571,110 @@ describe("talk realtime gateway relay", () => {
     },
   );
 
-  it("appends finalized relay transcripts to the canonical agent session", async () => {
-    const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
-    const tempDir = await fs.realpath(
-      await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-relay-voice-")),
-    );
-    setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
-    let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
-    try {
-      await replaceSessionEntry(
-        { agentId: "main", sessionKey: "agent:main:main" },
-        { sessionId: "relay-voice-session", updatedAt: Date.now() },
+  it.each([
+    {
+      sessionKey: "agent:main:main",
+      canonicalKey: "agent:main:main",
+      mainKey: "main",
+      scope: "per-sender" as const,
+    },
+    {
+      sessionKey: "main",
+      canonicalKey: "agent:main:work",
+      mainKey: "work",
+      scope: "per-sender" as const,
+    },
+    {
+      sessionKey: "agent:main:main",
+      canonicalKey: "global",
+      mainKey: "main",
+      scope: "global" as const,
+    },
+  ])(
+    "appends relay transcripts from $sessionKey to $canonicalKey",
+    async ({ sessionKey, canonicalKey, mainKey, scope }) => {
+      const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+      const tempDir = await fs.realpath(
+        await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-relay-voice-")),
       );
-      const provider = createIdleRelayProvider();
-      provider.createBridge = (request) => {
-        bridgeRequest = request;
-        return createIdleRelayProvider().createBridge?.(request) as RealtimeVoiceBridge;
-      };
-      const session = createTalkRealtimeRelaySession({
-        context: {
-          broadcastToConnIds: vi.fn(),
-          chatAbortControllers: new Map(),
-          getRuntimeConfig: () => ({}),
-          logGateway: { warn: vi.fn() },
-        } as never,
-        connId: "conn-voice",
-        cfg: {},
-        provider,
-        providerConfig: {},
-        instructions: "brief",
-        tools: [],
-        sessionKey: "agent:main:main",
-      });
-      bridgeRequest?.onTranscript?.("user", "relay hello", true);
-      bridgeRequest?.onTranscript?.("assistant", "relay response", true);
-      await flushTalkRealtimeRelayVoiceWrites({
-        relaySessionId: session.relaySessionId,
-        connId: "conn-voice",
-      });
+      setTestEnvValue("OPENCLAW_STATE_DIR", tempDir);
+      const storePath = path.join(tempDir, "configured", "sessions.sqlite");
+      const cfg: OpenClawConfig = { session: { store: storePath, mainKey, scope } };
+      let bridgeRequest: RealtimeVoiceBridgeCreateRequest | undefined;
+      try {
+        await replaceSessionEntry(
+          { agentId: "main", sessionKey: canonicalKey, storePath },
+          { sessionId: "relay-voice-session", updatedAt: Date.now() },
+        );
+        const provider = createIdleRelayProvider();
+        provider.createBridge = (request) => {
+          bridgeRequest = request;
+          return createIdleRelayProvider().createBridge?.(request) as RealtimeVoiceBridge;
+        };
+        const session = createTalkRealtimeRelaySession({
+          context: {
+            broadcastToConnIds: vi.fn(),
+            chatAbortControllers: new Map(),
+            getRuntimeConfig: () => ({}),
+            logGateway: { warn: vi.fn() },
+          } as never,
+          connId: "conn-voice",
+          cfg,
+          provider,
+          providerConfig: {},
+          instructions: "brief",
+          tools: [],
+          sessionKey,
+        });
+        bridgeRequest?.onTranscript?.("user", "relay hello", true);
+        bridgeRequest?.onTranscript?.("assistant", "relay response", true);
+        await flushTalkRealtimeRelayVoiceWrites({
+          relaySessionId: session.relaySessionId,
+          connId: "conn-voice",
+        });
 
-      const events = readSessionTranscriptMessageEvents({
-        agentId: "main",
-        sessionId: "relay-voice-session",
-      });
-      expect(events).toHaveLength(2);
-      expect(events[0]?.event).toMatchObject({
-        id: `voice:${session.relaySessionId}:1`,
-        message: { role: "user", content: [{ type: "text", text: "relay hello" }] },
-      });
-      expect(events[1]?.event).toMatchObject({
-        id: `voice:${session.relaySessionId}:2`,
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "relay response" }],
-          api: "realtime",
-          provider: "relay-test",
-          model: "realtime-voice",
-        },
-      });
-      stopTalkRealtimeRelaySession({
-        relaySessionId: session.relaySessionId,
-        connId: "conn-voice",
-      });
-      await vi.waitFor(() =>
-        expect(clientVoiceSessionTesting.readRecord("main", session.relaySessionId)?.status).toBe(
-          "closed",
-        ),
-      );
-    } finally {
-      closeOpenClawAgentDatabasesForTest();
-      closeOpenClawStateDatabaseForTest();
-      envSnapshot.restore();
-      await fs.rm(tempDir, { recursive: true, force: true });
-    }
-  });
+        const events = readSessionTranscriptMessageEvents({
+          agentId: "main",
+          sessionId: "relay-voice-session",
+          storePath,
+        });
+        expect(clientVoiceSessionTesting.readRecord("main", session.relaySessionId)).toMatchObject({
+          agentId: "main",
+          sessionKey,
+          origin: "relay",
+        });
+        expect(events).toHaveLength(2);
+        expect(events[0]?.event).toMatchObject({
+          id: `voice:${session.relaySessionId}:1`,
+          message: { role: "user", content: [{ type: "text", text: "relay hello" }] },
+        });
+        expect(events[1]?.event).toMatchObject({
+          id: `voice:${session.relaySessionId}:2`,
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "relay response" }],
+            api: "realtime",
+            provider: "relay-test",
+            model: "realtime-voice",
+          },
+        });
+        stopTalkRealtimeRelaySession({
+          relaySessionId: session.relaySessionId,
+          connId: "conn-voice",
+        });
+        await vi.waitFor(() =>
+          expect(clientVoiceSessionTesting.readRecord("main", session.relaySessionId)?.status).toBe(
+            "closed",
+          ),
+        );
+      } finally {
+        closeOpenClawAgentDatabasesForTest();
+        closeOpenClawStateDatabaseForTest();
+        envSnapshot.restore();
+        await fs.rm(tempDir, { recursive: true, force: true });
+      }
+    },
+  );
 
   it("emits one terminal error and close when transcript persistence overflows", async () => {
     const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
@@ -822,7 +881,7 @@ describe("talk realtime gateway relay", () => {
         providerConfig: {},
         instructions: "brief",
         tools: [],
-        sessionKey: "main",
+        sessionTarget: prepareTalkSessionTarget(runtimeConfig, "main"),
       });
       activeRelaySessions.set(session.relaySessionId, "conn-owner-pin");
       runtimeConfig = {
@@ -873,7 +932,10 @@ describe("talk realtime gateway relay", () => {
         providerConfig: {},
         instructions: "brief",
         tools: [],
-        sessionKey: " agent:main:main ",
+        sessionTarget: prepareTalkSessionTarget(
+          { agents: { entries: { main: {}, ops: { default: true } } } },
+          " agent:main:main ",
+        ),
       });
       activeRelaySessions.set(session.relaySessionId, "conn-trimmed-owner");
 
@@ -1096,6 +1158,7 @@ describe("talk realtime gateway relay", () => {
       providerConfig: {},
       instructions: "brief",
       tools: [],
+      sessionKey: "main",
     });
     ensureActiveRelayTurnId(session.relaySessionId);
 
@@ -4251,6 +4314,7 @@ describe("talk realtime gateway relay", () => {
       broadcastToConnIds: (event: string, payload: unknown, connIds: ReadonlySet<string>) => {
         events.push({ event, payload, connIds: [...connIds] });
       },
+      chatAbortControllers: new Map(),
     } as never;
 
     const session = createTalkRealtimeRelaySession({
@@ -4260,6 +4324,7 @@ describe("talk realtime gateway relay", () => {
       providerConfig: {},
       instructions: "be brief",
       tools: [],
+      sessionKey: "main",
       forceAgentConsultOnFinalTranscript: true,
     });
     await Promise.resolve();
@@ -4488,12 +4553,14 @@ describe("talk realtime gateway relay", () => {
         broadcastToConnIds: (event: string, payload: unknown, connIds: ReadonlySet<string>) => {
           events.push({ event, payload, connIds: [...connIds] });
         },
+        chatAbortControllers: new Map(),
       } as never,
       connId: "conn-1",
       provider,
       providerConfig: {},
       instructions: "be brief",
       tools: [],
+      sessionKey: "main",
       forceAgentConsultOnFinalTranscript: true,
     });
     await Promise.resolve();

--- a/src/gateway/talk-relay-audio-base64.test.ts
+++ b/src/gateway/talk-relay-audio-base64.test.ts
@@ -3,12 +3,14 @@ import type {
   RealtimeTranscriptionProviderPlugin,
   RealtimeVoiceProviderPlugin,
 } from "../plugins/types.js";
+import { drainingRelaySessions } from "./talk-realtime-relay-state.js";
 import {
   createTalkRealtimeRelaySession,
   sendTalkRealtimeRelayAudio,
   stopTalkRealtimeRelaySession,
 } from "./talk-realtime-relay.js";
 import { decodeTalkRelayAudioBase64 } from "./talk-relay-audio-base64.js";
+import { prepareTalkSessionTarget } from "./talk-session-target.js";
 import {
   createTalkTranscriptionRelaySession,
   sendTalkTranscriptionRelayAudio,
@@ -64,7 +66,7 @@ function transcriptionProvider(
 }
 
 describe("Talk relay audio base64", () => {
-  afterEach(() => {
+  afterEach(async () => {
     for (const [relaySessionId, connId] of realtime) {
       stopTalkRealtimeRelaySession({ relaySessionId, connId });
     }
@@ -73,6 +75,9 @@ describe("Talk relay audio base64", () => {
     }
     realtime.clear();
     transcription.clear();
+    await Promise.all(
+      [...drainingRelaySessions].map((session) => session.voiceSessionClose ?? Promise.resolve()),
+    );
   });
 
   it.each([
@@ -98,6 +103,7 @@ describe("Talk relay audio base64", () => {
       providerConfig: {},
       instructions: "brief",
       tools: [],
+      sessionTarget: prepareTalkSessionTarget({}, "agent:main:main"),
     });
     realtime.set(session.relaySessionId, "conn");
     await Promise.resolve();
@@ -123,6 +129,7 @@ describe("Talk relay audio base64", () => {
       providerConfig: {},
       instructions: "brief",
       tools: [],
+      sessionTarget: prepareTalkSessionTarget({}, "agent:main:main"),
     });
     realtime.set(session.relaySessionId, "conn");
     await Promise.resolve();

--- a/src/gateway/talk-session-registry.ts
+++ b/src/gateway/talk-session-registry.ts
@@ -4,7 +4,7 @@
  */
 import { resolveGlobalMap } from "../shared/global-singleton.js";
 import { formatError } from "./server-utils.js";
-import type { PreparedTalkSessionTarget } from "./talk-session-target.js";
+import type { PreparedTalkSessionTarget } from "./talk-session-target.types.js";
 
 type TalkConnectionCleanupKind = "browser-control" | "realtime-relay" | "transcription-relay";
 

--- a/src/gateway/talk-session-registry.ts
+++ b/src/gateway/talk-session-registry.ts
@@ -4,6 +4,7 @@
  */
 import { resolveGlobalMap } from "../shared/global-singleton.js";
 import { formatError } from "./server-utils.js";
+import type { PreparedTalkSessionTarget } from "./talk-session-target.js";
 
 type TalkConnectionCleanupKind = "browser-control" | "realtime-relay" | "transcription-relay";
 
@@ -12,6 +13,7 @@ type UnifiedTalkSessionRecord =
       kind: "realtime-relay";
       connId: string;
       relaySessionId: string;
+      sessionTarget: PreparedTalkSessionTarget;
     }
   | {
       kind: "transcription-relay";
@@ -86,6 +88,23 @@ export function getUnifiedTalkSession(sessionId: string): UnifiedTalkSessionReco
     throw new Error("Unknown Talk session");
   }
   return session;
+}
+
+/** Retains the realtime relay's admitted target without reinterpreting current defaults. */
+export function resolveUnifiedTalkSessionTarget(sessionId: string, connId: string | undefined) {
+  const session = unifiedTalkSessions.get(sessionId);
+  if (session?.kind !== "realtime-relay") {
+    return undefined;
+  }
+  requireUnifiedTalkSessionConn(session, connId);
+  const target = session.sessionTarget;
+  return {
+    target,
+    isCurrent: () =>
+      unifiedTalkSessions.get(sessionId) === session &&
+      session.connId === connId &&
+      session.sessionTarget === target,
+  };
 }
 
 /** Removes a Talk session id after the concrete backend closes. */

--- a/src/gateway/talk-session-target.ts
+++ b/src/gateway/talk-session-target.ts
@@ -29,12 +29,37 @@ export function prepareTalkSessionTarget(
   requestedSessionKey?: string,
 ): PreparedTalkSessionTarget {
   const requestedKey = normalizeOptionalString(requestedSessionKey);
-  const owner = resolveConfiguredAgentId(
-    cfg,
-    resolveTalkSessionAgentId(cfg, requestedKey ?? "main"),
-  );
+  const owner = resolveTalkSessionAgentId(cfg, requestedKey ?? "main");
   const sessionKey = requestedKey ?? resolveAgentMainSessionKey({ cfg, agentId: owner });
-  const requestedAgentId = resolveSessionStoreAgentId(cfg, sessionKey, owner);
+  const { agentId, canonicalKey, storePath } = resolveTalkSessionStorageTarget(
+    cfg,
+    sessionKey,
+    owner,
+  );
+  return Object.freeze({ agentId, sessionKey, canonicalKey, storePath });
+}
+
+/** Revalidate a retained owner without consulting the current ambient Talk default. */
+export function assertTalkSessionStorageTarget(
+  cfg: OpenClawConfig,
+  target: PreparedTalkSessionTarget,
+): void {
+  const current = resolveTalkSessionStorageTarget(cfg, target.canonicalKey, target.agentId);
+  if (
+    current.agentId !== target.agentId ||
+    current.canonicalKey !== target.canonicalKey ||
+    current.storePath !== target.storePath
+  ) {
+    throw new Error("Talk session storage target changed; retry the request");
+  }
+}
+
+function resolveTalkSessionStorageTarget(cfg: OpenClawConfig, sessionKey: string, owner: string) {
+  const requestedAgentId = resolveSessionStoreAgentId(
+    cfg,
+    sessionKey,
+    resolveConfiguredAgentId(cfg, owner),
+  );
   const canonicalKey = resolveSessionStoreKey({ cfg, sessionKey, storeAgentId: requestedAgentId });
   // A scoped main alias may become global. Validate the fixed-store owner again,
   // rather than dropping the explicit owner when the canonical key loses its prefix.
@@ -46,5 +71,5 @@ export function prepareTalkSessionTarget(
     readOnly: true,
     exactRead: true,
   });
-  return Object.freeze({ agentId, sessionKey, canonicalKey, storePath: target.storePath });
+  return { agentId, canonicalKey, storePath: target.storePath };
 }

--- a/src/gateway/talk-session-target.ts
+++ b/src/gateway/talk-session-target.ts
@@ -1,0 +1,50 @@
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { resolveConfiguredAgentId } from "../agents/agent-scope-config.js";
+import { resolveAgentMainSessionKey } from "../config/sessions/main-session.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveTalkSessionAgentId } from "../talk/agent-target.js";
+import { resolveSessionStoreAgentId, resolveSessionStoreKey } from "./session-store-key.js";
+import { resolveGatewaySessionStoreTargetWithStore } from "./session-utils-store-lookup.js";
+
+export type PreparedTalkSessionTarget = Readonly<{
+  agentId: string;
+  /** Voice records and close/resume retain the client's exact key, not its storage alias. */
+  sessionKey: string;
+  canonicalKey: string;
+  storePath: string;
+}>;
+
+export function requirePreparedTalkSessionTarget(
+  target: PreparedTalkSessionTarget | undefined,
+): PreparedTalkSessionTarget {
+  if (!target) {
+    throw new Error("Talk session target was not prepared by the Gateway");
+  }
+  return target;
+}
+
+/** Resolve Talk ownership before aliases collapse, then retain the exact storage target. */
+export function prepareTalkSessionTarget(
+  cfg: OpenClawConfig,
+  requestedSessionKey?: string,
+): PreparedTalkSessionTarget {
+  const requestedKey = normalizeOptionalString(requestedSessionKey);
+  const owner = resolveConfiguredAgentId(
+    cfg,
+    resolveTalkSessionAgentId(cfg, requestedKey ?? "main"),
+  );
+  const sessionKey = requestedKey ?? resolveAgentMainSessionKey({ cfg, agentId: owner });
+  const requestedAgentId = resolveSessionStoreAgentId(cfg, sessionKey, owner);
+  const canonicalKey = resolveSessionStoreKey({ cfg, sessionKey, storeAgentId: requestedAgentId });
+  // A scoped main alias may become global. Validate the fixed-store owner again,
+  // rather than dropping the explicit owner when the canonical key loses its prefix.
+  const agentId = resolveSessionStoreAgentId(cfg, canonicalKey, requestedAgentId);
+  const target = resolveGatewaySessionStoreTargetWithStore({
+    cfg,
+    key: canonicalKey,
+    agentId,
+    readOnly: true,
+    exactRead: true,
+  });
+  return Object.freeze({ agentId, sessionKey, canonicalKey, storePath: target.storePath });
+}

--- a/src/gateway/talk-session-target.ts
+++ b/src/gateway/talk-session-target.ts
@@ -5,14 +5,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveTalkSessionAgentId } from "../talk/agent-target.js";
 import { resolveSessionStoreAgentId, resolveSessionStoreKey } from "./session-store-key.js";
 import { resolveGatewaySessionStoreTargetWithStore } from "./session-utils-store-lookup.js";
-
-export type PreparedTalkSessionTarget = Readonly<{
-  agentId: string;
-  /** Voice records and close/resume retain the client's exact key, not its storage alias. */
-  sessionKey: string;
-  canonicalKey: string;
-  storePath: string;
-}>;
+import type { PreparedTalkSessionTarget } from "./talk-session-target.types.js";
 
 export function requirePreparedTalkSessionTarget(
   target: PreparedTalkSessionTarget | undefined,

--- a/src/gateway/talk-session-target.types.ts
+++ b/src/gateway/talk-session-target.types.ts
@@ -1,0 +1,8 @@
+// Keep shared Talk identity independent of the storage runtime used to prepare it.
+export type PreparedTalkSessionTarget = Readonly<{
+  agentId: string;
+  /** Voice records and close/resume retain the client's exact key, not its storage alias. */
+  sessionKey: string;
+  canonicalKey: string;
+  storePath: string;
+}>;

--- a/src/talk/agent-consult-runtime.storage.test.ts
+++ b/src/talk/agent-consult-runtime.storage.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createRuntimeAgent } from "../plugins/runtime/runtime-agent.js";
+import { MODEL_SELECTION_LOCKED_MESSAGE } from "../sessions/model-overrides.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { normalizeSessionDeliveryState } from "../utils/delivery-context.shared.js";
+import { consultRealtimeVoiceAgent } from "./agent-consult-runtime.js";
+
+let state: OpenClawTestState;
+beforeEach(async () => {
+  state = await createOpenClawTestState({ label: "voice-consult-store" });
+});
+afterEach(async () => {
+  await state.cleanup();
+});
+
+describe("voice consult concrete store ownership", () => {
+  it.each([
+    { parentAgentId: "main", locked: false },
+    { parentAgentId: "other", locked: false },
+    { parentAgentId: "main", locked: true },
+  ])(
+    "keeps parent $parentAgentId policy and routing in its configured store (locked=$locked)",
+    async ({ parentAgentId, locked }) => {
+      const cfg: OpenClawConfig = {
+        agents: {
+          entries: { main: { workspace: state.workspaceDir }, other: {} },
+          ownership: "explicit",
+        },
+      };
+      const runEmbeddedAgent = vi.fn(async () => ({
+        payloads: [{ text: "Checked" }],
+        meta: { durationMs: 0 },
+      }));
+      const agentRuntime = { ...createRuntimeAgent(), runEmbeddedAgent };
+      const spawnedBy = `agent:${parentAgentId}:parent`;
+      const parentStore = agentRuntime.session.resolveStorePath(cfg.session?.store, {
+        agentId: parentAgentId,
+      });
+      const createdActor = {
+        type: "human" as const,
+        source: "profile" as const,
+        id: "parent-creator",
+      };
+      await replaceSessionEntry(
+        { agentId: parentAgentId, sessionKey: spawnedBy, storePath: parentStore },
+        {
+          sessionId: "parent-session",
+          updatedAt: 1,
+          createdVia: "operator",
+          createdActor,
+          sandbox: "required",
+          modelSelectionLocked: locked,
+          delivery: normalizeSessionDeliveryState({
+            context: { channel: "discord", to: "channel:synthetic", accountId: "test-account" },
+          }),
+        },
+      );
+      const sessionKey = "agent:main:voice-child";
+      const storePath = state.statePath("consult", "sessions.sqlite");
+      const consult = consultRealtimeVoiceAgent({
+        cfg,
+        agentRuntime,
+        logger: { warn: vi.fn() },
+        agentId: "main",
+        sessionKey,
+        storePath,
+        spawnedBy,
+        contextMode: "isolated",
+        messageProvider: "webchat",
+        lane: "talk",
+        runIdPrefix: "test-consult",
+        args: { question: "Check this" },
+        transcript: [],
+        surface: "test voice",
+        userLabel: "User",
+      });
+      if (locked) {
+        await expect(consult).rejects.toThrow(MODEL_SELECTION_LOCKED_MESSAGE);
+        expect(runEmbeddedAgent).not.toHaveBeenCalled();
+        expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).toBeUndefined();
+        return;
+      }
+      await expect(consult).resolves.toEqual({ text: "Checked" });
+      expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).toMatchObject({
+        sandbox: "required",
+        createdActor,
+        spawnedBy,
+      });
+      expect(runEmbeddedAgent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          messageProvider: "discord",
+          messageTo: "channel:synthetic",
+          agentAccountId: "test-account",
+          sessionTarget: expect.objectContaining({ agentId: "main", sessionKey, storePath }),
+        }),
+      );
+    },
+  );
+});

--- a/src/talk/agent-consult-runtime.ts
+++ b/src/talk/agent-consult-runtime.ts
@@ -63,7 +63,7 @@ export function assertRealtimeVoiceAgentConsultModelSelectionUnlocked(params: {
   spawnedBy?: string | null;
   storePath?: string;
 }): void {
-  const candidates = new Map<string, { sessionKey: string; storePath: string }>();
+  const candidates = new Map<string, { agentId: string; sessionKey: string; storePath: string }>();
   const remember = (sessionKey: string, fallbackAgentId: string, storePath?: string) => {
     const candidateAgentId = parseAgentSessionKey(sessionKey)?.agentId ?? fallbackAgentId;
     const candidateStorePath =
@@ -72,6 +72,7 @@ export function assertRealtimeVoiceAgentConsultModelSelectionUnlocked(params: {
         agentId: candidateAgentId,
       });
     candidates.set(`${candidateStorePath}\u0000${sessionKey}`, {
+      agentId: candidateAgentId,
       sessionKey,
       storePath: candidateStorePath,
     });
@@ -88,8 +89,9 @@ export function assertRealtimeVoiceAgentConsultModelSelectionUnlocked(params: {
     }
   }
 
-  for (const { sessionKey, storePath } of candidates.values()) {
+  for (const { agentId, sessionKey, storePath } of candidates.values()) {
     const entry = params.agentRuntime.session.getSessionEntry({
+      agentId,
       storePath,
       sessionKey,
       readConsistency: "latest",
@@ -129,7 +131,9 @@ function resolveDeliverySessionFields(context?: DeliveryContext): Partial<Sessio
 }
 
 function resolveRealtimeVoiceAgentDeliveryContext(params: {
+  cfg: OpenClawConfig;
   agentRuntime: RealtimeVoiceAgentConsultRuntime;
+  agentId: string;
   storePath: string;
   sessionKey: string;
   spawnedBy?: string | null;
@@ -138,18 +142,25 @@ function resolveRealtimeVoiceAgentDeliveryContext(params: {
   try {
     // Prefer the live requester session, then its base thread, then the voice consult session.
     // This preserves channel/account/thread routing when a voice bridge delegates back to agent.
-    const candidates: string[] = [];
+    const candidates: Array<{ sessionKey: string; storePath?: string }> = [];
     if (requesterSessionKey) {
       const { baseSessionKey } = parseSessionThreadInfoFast(requesterSessionKey);
-      candidates.push(
-        ...[requesterSessionKey, baseSessionKey].filter((key): key is string => Boolean(key)),
-      );
+      for (const key of [requesterSessionKey, baseSessionKey]) {
+        if (key) {
+          candidates.push({ sessionKey: key });
+        }
+      }
     }
-    candidates.push(params.sessionKey);
-    for (const key of candidates) {
+    candidates.push({ sessionKey: params.sessionKey, storePath: params.storePath });
+    for (const candidate of candidates) {
+      const agentId = parseAgentSessionKey(candidate.sessionKey)?.agentId ?? params.agentId;
+      const storePath =
+        candidate.storePath ??
+        params.agentRuntime.session.resolveStorePath(params.cfg.session?.store, { agentId });
       const entry = params.agentRuntime.session.getSessionEntry({
-        storePath: params.storePath,
-        sessionKey: key,
+        agentId,
+        storePath,
+        sessionKey: candidate.sessionKey,
       });
       const context = deliveryContextFromSession(entry);
       if (hasRoutableDeliveryContext(context)) {
@@ -179,12 +190,10 @@ async function resolveRealtimeVoiceAgentConsultSessionEntry(params: {
   const requesterAgentId = parseAgentSessionKey(requesterSessionKey)?.agentId;
   const requesterEntry = requesterSessionKey
     ? params.agentRuntime.session.getSessionEntry({
-        storePath:
-          requesterAgentId && requesterAgentId !== params.agentId
-            ? params.agentRuntime.session.resolveStorePath(params.cfg.session?.store, {
-                agentId: requesterAgentId,
-              })
-            : params.storePath,
+        agentId: requesterAgentId ?? params.agentId,
+        storePath: params.agentRuntime.session.resolveStorePath(params.cfg.session?.store, {
+          agentId: requesterAgentId ?? params.agentId,
+        }),
         sessionKey: requesterSessionKey,
         readConsistency: "latest",
       })
@@ -235,6 +244,7 @@ async function resolveRealtimeVoiceAgentConsultSessionEntry(params: {
   }
 
   patched ??= await params.agentRuntime.session.patchSessionEntry({
+    agentId: params.agentId,
     storePath: params.storePath,
     sessionKey: params.sessionKey,
     fallbackEntry: {
@@ -271,6 +281,8 @@ export async function consultRealtimeVoiceAgent(params: {
   agentRuntime: RealtimeVoiceAgentConsultRuntime;
   logger: Pick<RuntimeLogger, "warn">;
   sessionKey: string;
+  /** Prepared concrete store; omitted callers retain their configured store selection. */
+  storePath?: string;
   messageProvider: string;
   lane: string;
   runIdPrefix: string;
@@ -316,10 +328,13 @@ export async function consultRealtimeVoiceAgent(params: {
     });
   const agentDir = params.agentRuntime.resolveAgentDir(params.cfg, agentId);
   const workspaceDir = params.agentRuntime.resolveAgentWorkspaceDir(params.cfg, agentId);
-  const storePath = params.agentRuntime.session.resolveStorePath(params.cfg.session?.store, {
-    agentId,
-  });
+  const storePath =
+    params.storePath ??
+    params.agentRuntime.session.resolveStorePath(params.cfg.session?.store, {
+      agentId,
+    });
   const initialSessionEntry = params.agentRuntime.session.getSessionEntry({
+    agentId,
     storePath,
     sessionKey: params.sessionKey,
     readConsistency: "latest",
@@ -343,6 +358,7 @@ export async function consultRealtimeVoiceAgent(params: {
       ),
     assertAllowed: () => {
       const currentEntry = params.agentRuntime.session.getSessionEntry({
+        agentId,
         storePath,
         sessionKey: params.sessionKey,
         readConsistency: "latest",
@@ -374,7 +390,9 @@ export async function consultRealtimeVoiceAgent(params: {
       // The consult session stores normal session metadata so subsequent voice turns can keep
       // routing and, in fork mode, recover useful conversation context from the requester.
       const resolvedDeliveryContext = resolveRealtimeVoiceAgentDeliveryContext({
+        cfg: params.cfg,
         agentRuntime: params.agentRuntime,
+        agentId,
         storePath,
         sessionKey: params.sessionKey,
         spawnedBy: params.spawnedBy,

--- a/src/talk/agent-run-control.runtime.ts
+++ b/src/talk/agent-run-control.runtime.ts
@@ -1,0 +1,17 @@
+import { resolveActiveEmbeddedRunSessionId } from "../agents/embedded-agent-runner/active-run-projections.js";
+import {
+  abortEmbeddedAgentRun,
+  queueEmbeddedAgentMessageWithOutcomeAsync,
+  resolveActiveEmbeddedRunOwnerByRunId,
+} from "../agents/embedded-agent-runner/runs.js";
+import { resolveActiveReplyRunOwnerForSignal } from "../auto-reply/reply/reply-run-registry.state.js";
+import { getDiagnosticSessionActivitySnapshot } from "../logging/diagnostic-run-activity.js";
+
+export const realtimeVoiceControlRuntime = {
+  abortEmbeddedAgentRun,
+  queueEmbeddedAgentMessageWithOutcomeAsync,
+  resolveActiveEmbeddedRunOwnerByRunId,
+  resolveActiveEmbeddedRunSessionId,
+  resolveActiveReplyRunOwnerForSignal,
+  getDiagnosticSessionActivitySnapshot,
+};

--- a/src/talk/agent-run-control.test.ts
+++ b/src/talk/agent-run-control.test.ts
@@ -126,6 +126,62 @@ describe("classifyRealtimeVoiceAgentControlText", () => {
 });
 
 describe("controlRealtimeVoiceAgentRun", () => {
+  it.each([null, "stale-run"])(
+    "never falls back from exact selector %s to a shared global key",
+    async (runId) => {
+      const deps = createDeps({
+        activeSessionId: "another-agent-session",
+        activity: { hasActiveEmbeddedRun: true },
+      });
+      const runTarget = runId
+        ? { runId, signal: new AbortController().signal, isCurrent: () => true }
+        : null;
+      for (const mode of ["status", "cancel", "steer"] as const) {
+        const result = await controlRealtimeVoiceAgentRun(
+          { sessionKey: "global", runTarget, text: mode, mode },
+          deps,
+        );
+        expect(result.active).toBe(false);
+      }
+      expect(deps.resolveActiveEmbeddedRunSessionId).not.toHaveBeenCalled();
+      expect(deps.getDiagnosticSessionActivitySnapshot).not.toHaveBeenCalled();
+      expect(deps.abortEmbeddedAgentRun).not.toHaveBeenCalled();
+      expect(deps.queueEmbeddedAgentMessageWithOutcomeAsync).not.toHaveBeenCalled();
+    },
+  );
+
+  it("controls the exact live owner and queries only its session diagnostics", async () => {
+    const deps = createDeps({ activeSessionId: "another-agent-session" });
+    const abort = vi.fn(() => true);
+    const resolveActiveEmbeddedRunOwnerByRunId = vi.fn(() => ({
+      runId: "owned-run",
+      sessionId: "owned-session",
+      sessionKey: "global",
+      abort,
+    }));
+    const result = await controlRealtimeVoiceAgentRun(
+      {
+        sessionKey: "global",
+        runTarget: {
+          runId: "owned-run",
+          signal: new AbortController().signal,
+          isCurrent: () => true,
+        },
+        text: "cancel",
+        mode: "cancel",
+      },
+      { ...deps, resolveActiveEmbeddedRunOwnerByRunId },
+    );
+    expect(result).toMatchObject({ ok: true, sessionId: "owned-session", aborted: true });
+    expect(resolveActiveEmbeddedRunOwnerByRunId).toHaveBeenCalledExactlyOnceWith("owned-run");
+    expect(abort).toHaveBeenCalledOnce();
+    expect(deps.getDiagnosticSessionActivitySnapshot).toHaveBeenCalledExactlyOnceWith({
+      sessionId: "owned-session",
+    });
+    expect(deps.resolveActiveEmbeddedRunSessionId).not.toHaveBeenCalled();
+    expect(deps.abortEmbeddedAgentRun).not.toHaveBeenCalled();
+  });
+
   it("queues steering into the active embedded run", async () => {
     const deps = createDeps({ activeSessionId: "session-active" });
 

--- a/src/talk/agent-run-control.ts
+++ b/src/talk/agent-run-control.ts
@@ -4,8 +4,10 @@
  * The shared module owns classification and message contracts; this adapter
  * binds those contracts to embedded-run abort, status, and steering primitives.
  */
-import type { EmbeddedAgentQueueMessageOutcome } from "../agents/embedded-agent-runner/runs.js";
-import { getDiagnosticSessionActivitySnapshot } from "../logging/diagnostic-run-activity.js";
+import type {
+  ActiveEmbeddedRunOwner,
+  EmbeddedAgentQueueMessageOutcome,
+} from "../agents/embedded-agent-runner/runs.js";
 import {
   buildRealtimeVoiceAgentCancelProviderResult,
   buildRealtimeVoiceAgentFollowupSteeringText,
@@ -51,12 +53,22 @@ type RealtimeVoiceAgentControlDeps = {
     sessionKey?: string;
   }) => RealtimeVoiceAgentRunActivity;
   resolveActiveEmbeddedRunSessionId: (sessionKey: string) => string | undefined;
+  resolveActiveEmbeddedRunOwnerByRunId?: (runId: string) => ActiveEmbeddedRunOwner | undefined;
+  resolveActiveReplyRunOwnerForSignal?: (
+    signal: AbortSignal,
+  ) => Pick<ActiveEmbeddedRunOwner, "sessionId" | "sessionKey" | "abort"> | undefined;
 };
 
 /** Apply a spoken status, cancel, steer, or follow-up request to an active run. */
 export async function controlRealtimeVoiceAgentRun(
   params: {
     sessionKey: string;
+    /** Exact admitted owner; null forbids lookup, omission retains legacy session-key control. */
+    runTarget?: {
+      runId: string;
+      signal: AbortSignal;
+      isCurrent: (sessionId?: string) => boolean;
+    } | null;
     text: string;
     mode?: unknown;
     recentEvents?: readonly TalkEvent[];
@@ -64,18 +76,35 @@ export async function controlRealtimeVoiceAgentRun(
   providedDeps?: RealtimeVoiceAgentControlDeps,
 ): Promise<RealtimeVoiceAgentControlResult> {
   // Provider registration consumes the shared policy without starting the agent runtime.
-  const deps = providedDeps ?? {
-    ...(await import("../agents/embedded-agent-runner/runs.js")),
-    ...(await import("../agents/embedded-agent-runner/active-run-projections.js")),
-    getDiagnosticSessionActivitySnapshot,
-  };
+  const deps =
+    providedDeps ?? (await import("./agent-run-control.runtime.js")).realtimeVoiceControlRuntime;
   const sessionKey = params.sessionKey.trim();
   const text = params.text.trim();
   const intent = resolveRealtimeVoiceAgentControlIntent({ text, mode: params.mode });
   const mode = intent.mode;
-  const sessionId = deps.resolveActiveEmbeddedRunSessionId(sessionKey);
-  const activity = deps.getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey });
-  const active = Boolean(sessionId || activity.activeWorkKind || activity.hasActiveEmbeddedRun);
+  const target = params.runTarget;
+  const candidate =
+    target && !target.signal.aborted && target.isCurrent()
+      ? (deps.resolveActiveEmbeddedRunOwnerByRunId?.(target.runId) ??
+        deps.resolveActiveReplyRunOwnerForSignal?.(target.signal))
+      : undefined;
+  const exactOwner =
+    candidate?.sessionKey === sessionKey && target?.isCurrent(candidate.sessionId)
+      ? candidate
+      : undefined;
+  const sessionId =
+    target === undefined
+      ? deps.resolveActiveEmbeddedRunSessionId(sessionKey)
+      : exactOwner?.sessionId;
+  // Global keys are shared across agents. Exact selectors never consult another
+  // session's key-only diagnostics, including when their live owner disappeared.
+  const activity =
+    target === undefined
+      ? deps.getDiagnosticSessionActivitySnapshot({ sessionId, sessionKey })
+      : sessionId
+        ? deps.getDiagnosticSessionActivitySnapshot({ sessionId })
+        : undefined;
+  const active = Boolean(sessionId || activity?.activeWorkKind || activity?.hasActiveEmbeddedRun);
 
   // Status is read-only and can answer from diagnostic activity even when the
   // active embedded run id has already disappeared.
@@ -114,7 +143,8 @@ export async function controlRealtimeVoiceAgentRun(
         suppress: false,
       };
     }
-    const aborted = deps.abortEmbeddedAgentRun(sessionId);
+    const aborted =
+      target === undefined ? deps.abortEmbeddedAgentRun(sessionId) : exactOwner?.abort() === true;
     const message = aborted
       ? "Cancelled the active OpenClaw run."
       : "OpenClaw could not cancel the active run.";

--- a/src/talk/agent-target.ts
+++ b/src/talk/agent-target.ts
@@ -4,14 +4,6 @@ import { resolvePersistedSessionStoreOwnerForKey } from "../config/sessions/sess
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
 
-/** Resolves the configured owner for Talk work that has no agent-scoped session key. */
-export function resolveTalkTargetAgentId(config: OpenClawConfig): string {
-  return resolveAmbientOwnerAgentId(config, config.talk?.agentId, {
-    surface: "Talk relay ownership",
-    hint: "Set talk.agentId to the agent that owns unscoped Talk sessions.",
-  });
-}
-
 /** Agent-scoped keys own their Talk session; legacy/unscoped aliases use the Talk target. */
 export function resolveTalkSessionAgentId(
   config: OpenClawConfig,
@@ -23,6 +15,9 @@ export function resolveTalkSessionAgentId(
     return normalizeAgentId(scopedAgentId);
   }
   return resolvePersistedSessionStoreOwnerForKey(config, normalizedSessionKey).kind === "none"
-    ? resolveTalkTargetAgentId(config)
+    ? resolveAmbientOwnerAgentId(config, config.talk?.agentId, {
+        surface: "Talk session ownership",
+        hint: "Set talk.agentId to the agent that owns unscoped Talk sessions.",
+      })
     : resolveSessionAgentId({ config, sessionKey: normalizedSessionKey });
 }

--- a/src/talk/client-voice-session.startup.test.ts
+++ b/src/talk/client-voice-session.startup.test.ts
@@ -3,11 +3,25 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
-import { loadSessionEntry, patchSessionEntryCore } from "../config/sessions/session-accessor.js";
+import {
+  loadSessionEntry,
+  patchSessionEntryCore,
+  readSessionTranscriptMessageEvents,
+  replaceSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { captureEnv, setTestEnvValue } from "../test-utils/env.js";
-import { ensureClientVoiceAgentSessionEntry } from "./client-voice-session.js";
+import { resetClientVoiceConfirmationStateForTest } from "./client-voice-confirmation.test-support.js";
+import {
+  appendClientVoiceTranscript,
+  appendRelayVoiceTranscript,
+  closeClientVoiceSession,
+  createOrResumeClientVoiceSession,
+  ensureClientVoiceAgentSessionEntry,
+  resolveClientVoiceAgentSessionId,
+} from "./client-voice-session.js";
+import { clientVoiceSessionTesting } from "./client-voice-session.test-support.js";
 
 describe("client voice session startup", () => {
   const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
@@ -21,10 +35,139 @@ describe("client voice session startup", () => {
   });
 
   afterEach(async () => {
+    clientVoiceSessionTesting.reset();
+    resetClientVoiceConfirmationStateForTest();
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
     envSnapshot.restore();
     await fs.rm(tempDir, { recursive: true, force: true });
+  });
+
+  it.each([false, true])("stamps Talk creation once (required=%s)", async (required) => {
+    const target = { agentId: "main", sessionKey: "agent:main:talk:new" };
+    const actor = required
+      ? { type: "human" as const, source: "profile" as const, id: "profile-required" }
+      : { type: "human" as const, source: "unknown" as const };
+    const creation = required ? { actor, sandbox: "required" as const } : undefined;
+    const sessionId = await ensureClientVoiceAgentSessionEntry({ ...target, creation });
+
+    const original = loadSessionEntry(target);
+    expect(original).toMatchObject({
+      sessionId,
+      createdVia: "talk",
+      createdActor: actor,
+      createdAt: expect.any(Number),
+      ...(required ? { sandbox: "required" } : {}),
+    });
+
+    await ensureClientVoiceAgentSessionEntry({
+      ...target,
+      creation: {
+        actor: { type: "human", source: "profile", id: "another-profile" },
+        sandbox: "required",
+      },
+    });
+    expect(loadSessionEntry(target)).toEqual(original);
+  });
+
+  it("reads an existing agent session without creating a missing row", async () => {
+    const existingKey = "agent:main:talk:existing";
+    await replaceSessionEntry(
+      { agentId: "main", sessionKey: existingKey },
+      { sessionId: "session-existing", updatedAt: 1 },
+    );
+
+    expect(resolveClientVoiceAgentSessionId({ agentId: "main", sessionKey: existingKey })).toBe(
+      "session-existing",
+    );
+    expect(
+      resolveClientVoiceAgentSessionId({
+        agentId: "main",
+        sessionKey: "agent:main:talk:missing",
+      }),
+    ).toBeUndefined();
+    expect(
+      loadSessionEntry({ agentId: "main", sessionKey: "agent:main:talk:missing" }),
+    ).toBeUndefined();
+  });
+
+  it.each([
+    { origin: "client" as const, canonicalKey: "agent:main:work" },
+    { origin: "relay" as const, canonicalKey: "global" },
+  ])(
+    "writes $origin transcripts to $canonicalKey without changing voice identity",
+    async ({ origin, canonicalKey }) => {
+      const sessionTarget = {
+        sessionKey: canonicalKey,
+        storePath: path.join(tempDir, "configured", "sessions.sqlite"),
+      };
+      const storage = { agentId: "main", ...sessionTarget };
+      const sessionId = await ensureClientVoiceAgentSessionEntry(storage);
+      expect(resolveClientVoiceAgentSessionId(storage)).toBe(sessionId);
+      const voiceTarget = { agentId: "main", sessionKey: "main" };
+      const voiceSessionId = createOrResumeClientVoiceSession({ ...voiceTarget, origin });
+      const append = origin === "client" ? appendClientVoiceTranscript : appendRelayVoiceTranscript;
+      await append({
+        ...voiceTarget,
+        sessionTarget,
+        voiceSessionId,
+        entryId: "canonical-transcript",
+        role: "user",
+        text: "Stored in the prepared session",
+      });
+      expect(readSessionTranscriptMessageEvents({ ...storage, sessionId })).toEqual([
+        expect.objectContaining({
+          event: expect.objectContaining({
+            message: expect.objectContaining({
+              content: [{ type: "text", text: "Stored in the prepared session" }],
+            }),
+          }),
+        }),
+      ]);
+      expect(clientVoiceSessionTesting.readRecord("main", voiceSessionId)).toMatchObject({
+        sessionKey: "main",
+        origin,
+      });
+      await expect(
+        closeClientVoiceSession({
+          agentId: "main",
+          sessionKey: canonicalKey,
+          voiceSessionId,
+          config: {},
+        }),
+      ).rejects.toThrow("does not belong");
+      await closeClientVoiceSession({ ...voiceTarget, voiceSessionId, config: {} });
+      await closeClientVoiceSession({ ...voiceTarget, voiceSessionId, config: {} });
+      expect(clientVoiceSessionTesting.readRecord("main", voiceSessionId)?.status).toBe("closed");
+    },
+  );
+
+  it("does not create an agent session after a browser-session deadline", async () => {
+    const sessionKey = "agent:main:talk:expired";
+
+    await expect(
+      ensureClientVoiceAgentSessionEntry({
+        agentId: "main",
+        sessionKey,
+        deadlineAt: Date.now() - 1,
+      }),
+    ).rejects.toThrow("Realtime browser session expired during startup");
+    expect(loadSessionEntry({ agentId: "main", sessionKey })).toBeUndefined();
+  });
+
+  it("repairs an incomplete existing row without claiming its creation actor", async () => {
+    const sessionKey = "agent:main:talk:incomplete";
+    await replaceSessionEntry(
+      { agentId: "main", sessionKey },
+      { sessionId: "", updatedAt: 1, createdVia: "internal", createdAt: 1 },
+    );
+
+    await ensureClientVoiceAgentSessionEntry({ agentId: "main", sessionKey });
+
+    const repaired = loadSessionEntry({ agentId: "main", sessionKey });
+    expect(repaired?.sessionId).toBeTruthy();
+    expect(repaired).toMatchObject({ createdVia: "internal", createdAt: 1 });
+    expect(repaired?.createdActor).toBeUndefined();
   });
 
   it("does not create a chat when browser startup closes while its write is queued", async () => {

--- a/src/talk/client-voice-session.test.ts
+++ b/src/talk/client-voice-session.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
-import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
+import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import {
   emitTrustedDiagnosticEvent,
   waitForDiagnosticEventsDrained,
@@ -28,10 +28,8 @@ import {
   closeRelayVoiceSessionRecord,
   closeStaleClientVoiceSessions,
   createOrResumeClientVoiceSession,
-  ensureClientVoiceAgentSessionEntry,
   isClientVoiceSessionConfirmable,
   registerClientVoiceConsultRun,
-  resolveClientVoiceAgentSessionId,
   resolveClientVoiceRunBinding,
   resolveOpenClientVoiceSessionId,
 } from "./client-voice-session.js";
@@ -183,82 +181,6 @@ describe("client voice session", () => {
     ).toThrow("already closed");
   });
 
-  it.each([false, true])("stamps Talk creation once (required=%s)", async (required) => {
-    const target = { agentId: "main", sessionKey: "agent:main:talk:new" };
-    const actor = required
-      ? { type: "human" as const, source: "profile" as const, id: "profile-required" }
-      : { type: "human" as const, source: "unknown" as const };
-    const creation = required ? { actor, sandbox: "required" as const } : undefined;
-    const sessionId = await ensureClientVoiceAgentSessionEntry({ ...target, creation });
-
-    const original = loadSessionEntry(target);
-    expect(original).toMatchObject({
-      sessionId,
-      createdVia: "talk",
-      createdActor: actor,
-      createdAt: expect.any(Number),
-      ...(required ? { sandbox: "required" } : {}),
-    });
-
-    await ensureClientVoiceAgentSessionEntry({
-      ...target,
-      creation: {
-        actor: { type: "human", source: "profile", id: "another-profile" },
-        sandbox: "required",
-      },
-    });
-    expect(loadSessionEntry(target)).toEqual(original);
-  });
-
-  it("reads an existing agent session without creating a missing row", async () => {
-    const existingKey = "agent:main:talk:existing";
-    await replaceSessionEntry(
-      { agentId: "main", sessionKey: existingKey },
-      { sessionId: "session-existing", updatedAt: 1 },
-    );
-
-    expect(resolveClientVoiceAgentSessionId({ agentId: "main", sessionKey: existingKey })).toBe(
-      "session-existing",
-    );
-    expect(
-      resolveClientVoiceAgentSessionId({
-        agentId: "main",
-        sessionKey: "agent:main:talk:missing",
-      }),
-    ).toBeUndefined();
-    expect(
-      loadSessionEntry({ agentId: "main", sessionKey: "agent:main:talk:missing" }),
-    ).toBeUndefined();
-  });
-
-  it("does not create an agent session after a browser-session deadline", async () => {
-    const sessionKey = "agent:main:talk:expired";
-
-    await expect(
-      ensureClientVoiceAgentSessionEntry({
-        agentId: "main",
-        sessionKey,
-        deadlineAt: Date.now() - 1,
-      }),
-    ).rejects.toThrow("Realtime browser session expired during startup");
-    expect(loadSessionEntry({ agentId: "main", sessionKey })).toBeUndefined();
-  });
-
-  it("repairs an incomplete existing row without claiming its creation actor", async () => {
-    const sessionKey = "agent:main:talk:incomplete";
-    await replaceSessionEntry(
-      { agentId: "main", sessionKey },
-      { sessionId: "", updatedAt: 1, createdVia: "internal", createdAt: 1 },
-    );
-
-    await ensureClientVoiceAgentSessionEntry({ agentId: "main", sessionKey });
-
-    const repaired = loadSessionEntry({ agentId: "main", sessionKey });
-    expect(repaired?.sessionId).toBeTruthy();
-    expect(repaired).toMatchObject({ createdVia: "internal", createdAt: 1 });
-    expect(repaired?.createdActor).toBeUndefined();
-  });
-
   it("marks confirmability by declared capability, relay origin, or observed transcript", () => {
     const capable = createOrResumeClientVoiceSession({
       agentId: "main",
@@ -356,6 +278,7 @@ describe("client voice session", () => {
     const append = appendClientVoiceTranscript({
       agentId: "main",
       sessionKey: "agent:main:main",
+      sessionTarget: { sessionKey: "agent:main:main" },
       voiceSessionId,
       entryId: "final",
       role: "assistant",
@@ -432,6 +355,7 @@ describe("client voice session", () => {
     const append = appendClientVoiceTranscript({
       agentId: "main",
       sessionKey: "agent:main:main",
+      sessionTarget: { sessionKey: "agent:main:main" },
       voiceSessionId,
       entryId: "failed",
       role: "user",
@@ -475,6 +399,7 @@ describe("client voice session", () => {
     const append = appendClientVoiceTranscript({
       agentId: "main",
       sessionKey: "agent:main:main",
+      sessionTarget: { sessionKey: "agent:main:main" },
       voiceSessionId,
       entryId: "retryable",
       role: "user",
@@ -507,6 +432,7 @@ describe("client voice session", () => {
     await appendClientVoiceTranscript({
       agentId: "main",
       sessionKey: "agent:main:main",
+      sessionTarget: { sessionKey: "agent:main:main" },
       voiceSessionId,
       entryId: "retryable",
       role: "user",
@@ -543,6 +469,7 @@ describe("client voice session", () => {
       appendRelayVoiceTranscript({
         agentId: "main",
         sessionKey: "agent:main:main",
+        sessionTarget: { sessionKey: "agent:main:main" },
         voiceSessionId,
         entryId: "relay-entry-1",
         role: "user",
@@ -589,6 +516,7 @@ describe("client voice session", () => {
       appendClientVoiceTranscript({
         agentId: "main",
         sessionKey: "agent:main:main",
+        sessionTarget: { sessionKey: "agent:main:main" },
         voiceSessionId,
         entryId: String(index + 1),
         role: index % 2 === 0 ? "user" : "assistant",
@@ -628,6 +556,7 @@ describe("client voice session", () => {
       appendClientVoiceTranscript({
         agentId: "main",
         sessionKey: "agent:main:main",
+        sessionTarget: { sessionKey: "agent:main:main" },
         voiceSessionId,
         entryId: "after-overflow",
         role: "user",
@@ -670,6 +599,7 @@ describe("client voice session", () => {
         appendClientVoiceTranscript({
           agentId: "main",
           sessionKey: "agent:main:main",
+          sessionTarget: { sessionKey: "agent:main:main" },
           voiceSessionId,
           entryId: String(index + 1),
           role: "user",
@@ -682,6 +612,7 @@ describe("client voice session", () => {
     await appendClientVoiceTranscript({
       agentId: "main",
       sessionKey: "agent:main:main",
+      sessionTarget: { sessionKey: "agent:main:main" },
       voiceSessionId,
       entryId: "real",
       role: "user",
@@ -709,6 +640,7 @@ describe("client voice session", () => {
       appendClientVoiceTranscript({
         agentId: "main",
         sessionKey: "agent:main:main",
+        sessionTarget: { sessionKey: "agent:main:main" },
         voiceSessionId,
         entryId: "1",
         role: "user",
@@ -719,6 +651,7 @@ describe("client voice session", () => {
       appendClientVoiceTranscript({
         agentId: "main",
         sessionKey: "agent:main:main",
+        sessionTarget: { sessionKey: "agent:main:main" },
         voiceSessionId,
         entryId: "2",
         role: "assistant",
@@ -750,6 +683,7 @@ describe("client voice session", () => {
         appendClientVoiceTranscript({
           agentId: "main",
           sessionKey: "agent:main:main",
+          sessionTarget: { sessionKey: "agent:main:main" },
           voiceSessionId,
           entryId,
           role: "user",
@@ -764,6 +698,7 @@ describe("client voice session", () => {
     await appendClientVoiceTranscript({
       agentId: "main",
       sessionKey: "agent:main:main",
+      sessionTarget: { sessionKey: "agent:main:main" },
       voiceSessionId,
       entryId: "later",
       role: "assistant",
@@ -772,6 +707,7 @@ describe("client voice session", () => {
     await appendClientVoiceTranscript({
       agentId: "main",
       sessionKey: "agent:main:main",
+      sessionTarget: { sessionKey: "agent:main:main" },
       voiceSessionId,
       entryId: "1",
       role: "user",
@@ -789,6 +725,7 @@ describe("client voice session", () => {
     await appendClientVoiceTranscript({
       agentId: "main",
       sessionKey: "agent:main:main",
+      sessionTarget: { sessionKey: "agent:main:main" },
       voiceSessionId,
       entryId: "2",
       role: "user",
@@ -820,6 +757,7 @@ describe("client voice session", () => {
         appendClientVoiceTranscript({
           agentId: "main",
           sessionKey: "agent:main:main",
+          sessionTarget: { sessionKey: "agent:main:main" },
           voiceSessionId,
           entryId: String(index),
           role: "user",
@@ -831,6 +769,7 @@ describe("client voice session", () => {
       appendClientVoiceTranscript({
         agentId: "main",
         sessionKey: "agent:main:main",
+        sessionTarget: { sessionKey: "agent:main:main" },
         voiceSessionId,
         entryId: "beyond-bound",
         role: "user",
@@ -852,6 +791,7 @@ describe("client voice session", () => {
     await appendClientVoiceTranscript({
       agentId: "main",
       sessionKey: "agent:main:main",
+      sessionTarget: { sessionKey: "agent:main:main" },
       voiceSessionId,
       entryId: "0",
       role: "user",
@@ -864,6 +804,7 @@ describe("client voice session", () => {
       appendClientVoiceTranscript({
         agentId: "main",
         sessionKey: "agent:main:main",
+        sessionTarget: { sessionKey: "agent:main:main" },
         voiceSessionId,
         entryId: "replacement",
         role: "user",
@@ -903,6 +844,7 @@ describe("client voice session", () => {
     const first = appendClientVoiceTranscript({
       agentId: "main",
       sessionKey: "agent:main:first",
+      sessionTarget: { sessionKey: "agent:main:first" },
       voiceSessionId: firstVoiceSessionId,
       entryId: "1",
       role: "user",
@@ -914,6 +856,7 @@ describe("client voice session", () => {
     const second = appendClientVoiceTranscript({
       agentId: "main",
       sessionKey: "agent:main:second",
+      sessionTarget: { sessionKey: "agent:main:second" },
       voiceSessionId: secondVoiceSessionId,
       entryId: "1",
       role: "user",

--- a/src/talk/client-voice-session.ts
+++ b/src/talk/client-voice-session.ts
@@ -229,6 +229,7 @@ export function createOrResumeClientVoiceSession(params: {
 export function resolveClientVoiceAgentSessionId(params: {
   agentId: string;
   sessionKey: string;
+  storePath?: string;
 }): string | undefined {
   return loadSessionEntryReadOnly(params)?.sessionId?.trim() || undefined;
 }
@@ -237,6 +238,7 @@ export function resolveClientVoiceAgentSessionId(params: {
 export async function ensureClientVoiceAgentSessionEntry(params: {
   agentId: string;
   sessionKey: string;
+  storePath?: string;
   deadlineAt?: number;
   assertCommitAllowed?: () => void;
   creation?: Pick<Parameters<typeof buildSessionCreationStamp>[0], "actor" | "sandbox">;
@@ -444,6 +446,7 @@ function transcriptFailureKey(entryId: string): string {
 function appendVoiceTranscript(params: {
   agentId: string;
   sessionKey: string;
+  sessionTarget: { sessionKey: string; storePath?: string };
   voiceSessionId: string;
   origin: "client" | "relay";
   entryId: string;
@@ -479,10 +482,10 @@ function appendVoiceTranscript(params: {
       ) {
         throw new Error("voice transcript persistence has too many unresolved entries");
       }
-      const sessionEntry = loadSessionEntryReadOnly({
-        agentId: normalized.agentId,
-        sessionKey: normalized.sessionKey,
-      });
+      // Voice ownership keeps the original key; transcript storage uses the target
+      // prepared before main/global aliases lose their selected agent identity.
+      const sessionTarget = { ...normalized.sessionTarget, agentId: normalized.agentId };
+      const sessionEntry = loadSessionEntryReadOnly(sessionTarget);
       if (!sessionEntry?.sessionId) {
         throw new Error(`agent session not found (${normalized.sessionKey})`);
       }
@@ -506,11 +509,7 @@ function appendVoiceTranscript(params: {
         { agentId: normalized.agentId },
       );
       await appendTranscriptMessage(
-        {
-          agentId: normalized.agentId,
-          sessionId: sessionEntry.sessionId,
-          sessionKey: normalized.sessionKey,
-        },
+        { ...sessionTarget, sessionId: sessionEntry.sessionId },
         {
           ...(normalized.config ? { config: normalized.config } : {}),
           eventId: `voice:${normalized.voiceSessionId}:${normalized.entryId}`,


### PR DESCRIPTION
Related: #126730 — bare-key Talk consult ownership.
Related: #126732 — the separate durable voice-session/consult continuity repair; this PR does not supersede or close that work.

## What Problem This Solves

Fixes an issue where users starting Talk with `sessionKey: "main"` would receive an explicit-owner error on a multi-agent Gateway even when `talk.agentId` was configured. Omitting the optional key took a different path: the handler inferred a default session only after router authorization, so existing-session sharing, incognito, and operator restrictions were not checked against that effective target.

The supplied deployed reproduction was on `83b61257d6e328d904e7ed0c99ee50b661bbfe6d`; the affected Talk target/admission logic remains present on current main.

## Why This Change Was Made

The Gateway now prepares one frozen Talk target before authorization and passes that exact target into both realtime create handlers. The raw voice key remains the close/resume identity, while an explicit agent, canonical session key, and concrete store path own authorization and persistence. Owner checks run before and after main aliases collapse to `global`, so fixed-store conflicts are rejected instead of losing ownership.

Creation revalidates routing and access after asynchronous startup work, inside the SQLite commit boundary, and before publishing the provider session. An internal ensure-result permits only the operation's own previously id-less row to materialize; it cannot replace an already admitted session identity. New sessions retain their authenticated creator, including callers whose roles hide other people's sessions.

This removes handler-side target inference, duplicate relay owner lookups, and the unreachable relay late-binding/transcript-buffer path. Existing sharing predicates move to a policy module to keep the request-authorization owner within the existing file-size limit. No configuration option, protocol field, SQLite schema, or durable voice-record format is added.

The same prepared target now reaches native browser/relay consultation callbacks and run controls. Voice records and confirmation bindings retain the raw key; storage, embedded execution, and control use the canonical agent/key/store. This addresses the late review finding: fixing creation alone had split global-scope transcripts from their consultations. Raw-config fixtures also exposed custom-name separation, but a real Gateway intentionally ignores custom `session.mainKey` values; those fixtures are not a supported-config claim. Exact controls validate the live Gateway registration, connection, agent, lifecycle generation, controller signal, cleanup state, and current backing session ID; a stale or foreign owner never falls back to a shared global-key lookup. Queued reply operations retain their existing signal-bound ownership, including legitimate session-ID materialization. Keyed and keyless relay steering authorize the retained opaque-session target, not a newly selected Talk default.

The public consultation helper adds an optional concrete store override while preserving configured-store defaults for existing callers. Parent/requester policy, model-lock, and delivery reads retain their own configured agent/store. Durable continuity across separate requests/restarts, the legacy client-wire handoff, and provider/broker capability behavior remain separate work. Keyless transcription remains sessionless. No cross-store entry-fork support is added or claimed.

Production: +1078/-705 lines (net +373, including the behavior-preserving policy-module move and dependency-free prepared-target type). The growth implements the previously missing prepared-target/current-access boundary, retained relay authorization, and exact live control ownership using existing registries; obsolete inference/binding paths are deleted rather than retained as fallbacks. Replacing raw keys everywhere would break voice identity, while key-only global control would cross agent ownership. Tests/test support: +2131/-251 (net +1880), including the 22-line CLI fixture repair described below. Docs: +26. No baseline, schema, wire, dependency, or configuration expansion.

## User Impact

- Bare `main` and omitted realtime-create keys honor the configured Talk owner and valid default ownership.
- Explicit selected-agent keys do not require an ambient Talk owner.
- Main aliases, global sessions, and shared fixed stores retain the correct owner and storage target. Native browser/relay consultations use the same conversation as voice transcripts. The main suffix remains fixed at `main`; custom `session.mainKey` values remain ignored.
- Status, steering, and cancellation select the current connection-owned run; a shared global key or stale registration cannot select a different agent's work.
- Restricted sessions cannot bypass their access checks by omitting the key, and routing/access changes during startup fail visibly rather than redirecting the call.
- Client close still requires the original voice key and voice-session ID; relay-origin calls cannot be closed through the client-close RPC.

The [Talk documentation](https://docs.openclaw.ai/nodes/talk) source now explains these ownership and lifecycle rules. No operator migration or configuration change is required.

## Evidence

The pre-fix synthetic router reproduction observed the exact bare-`main` `INVALID_REQUEST`; omitted read-only, draft, and incognito targets reached provider creation. The repaired tests exercise the real Gateway router and SQLite access boundaries, with only provider transport/bootstrap behavior synthesized.

Passed local validation:

- 306 tests in the Talk/sharing regression group, including current-default ownership, explicit selection, global/fixed-store routing, shared/incognito/operator restrictions, delayed provider/bootstrap/dispatch work, post-ensure publication fences, raw-key identity, and relay lifecycle behavior.
- Subsequent focused runs: 46 router/close cases, 14 default-owner migration cases, and 34 voice-storage/startup/teardown cases after test-only organization/cleanup changes.
- Final consultation/control group: 408 tests across 19 files, covering both native callback transports, custom-main/global session identity, retained relay authorization, exact-owner and cleanup fences, queued reply ownership, voice confirmation, requester storage/policy, and meeting/voice-call siblings. The four callback identity regressions and four wrong-backing-ID/cleanup regressions each failed before their respective repairs. Queued-reply coverage manually links real Gateway and ReplyOperation owners; it is not full `chat.send` E2E.
- Complete changed-check plan covered: formatting across all 40 paths, core and core-test types, five targeted lint batches, dead exports, schema/legacy-store guards, and zero runtime import cycles. The final aggregate initially stopped on incomplete synthetic provider types; the fixture was corrected at its public/host capability boundary without casts or API widening. Core-test types, 29 affected native tests, formatting, lint, and all eight remaining guards then passed in the explicit resumed lane. Earlier aggregate failures are retained, not relabeled as successful runs. SDK surface check separately passed.
- Full build: passed; zero `INEFFECTIVE_DYNAMIC_IMPORT` warnings.
- Independent Codex autoreview: clean at the configured P0 threshold; refreshed before publication, with another clean scoped review of the test-only CI repair.
- [Synthetic real-Gateway RPC proof](https://github.com/openclaw/openclaw/pull/133958#issuecomment-5475946884): 7/7 create/close cases across normal, global, and fixed-store targets, including bare/omitted keys and explicit other-agent selection. Real plugin loading and SQLite observations; zero model requests; all owned Gateway processes and temporary fixtures cleaned up.
- [Native consultation proof](https://github.com/openclaw/openclaw/pull/133958#issuecomment-5478162766): 4/4 browser/relay callbacks across normalized default and global scope, using real embedded execution with exactly four local mock-model requests. Voice and agent transcripts and status used one canonical session ID; foreign owners, wrong close identities, and retained callbacks were rejected. All owned processes/roots were cleaned up. Commit `43d4674dcde7ec60da6d4293a206915306c33886` has the exact tested tree. The sealed runtime was reused only after verifying the complete final delta was test/doc-only; the original build identity and failed custom-main-premise attempt remain preserved, with no fresh package/docs-build claim.

The final type-only follow-up, `8c8c0109f2b8d598ad6dbcdbb32fda7cec673c80`, fixes the CI static-import cycle by moving the prepared target type into a dependency-free leaf (net −2 production lines). Full architecture checks, core/core-test types, 209 owner tests, formatting/lint, a fresh isolated build, erased-JavaScript comparison, and fresh P0-scoped review pass. It does not change the real-Gateway-tested runtime logic. The latest managed-room regression claim was refuted by directly inspected pre-PR source plus a six-case current-router probe; existing role permissions remain unchanged. [Detailed review and CI disposition](https://github.com/openclaw/openclaw/pull/133958#issuecomment-5478589945).

[Exact-head CI run 33395028462](https://github.com/openclaw/openclaw/actions/runs/33395028462), attempt 2, completed successfully for the final head. Its merge snapshot includes main's canonical prepared-model fixture fix. Only the interrupted lint job and its dependent gate were retried, with diagnostics and no source/workflow changes. The required gate is green with no failed or pending checks. Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 133958` passed and retained the exact reviewed head without rebasing.

Hosted CI first exposed an unrelated incomplete prepared-runtime fixture in `execute.supervisor-capture.test.ts`: classifying synthetic stderr `failed` synchronously loaded the real Anthropic plugin instead of using a prepared provider. A local stack capture confirmed that exact path. The test-only repair registers its synthetic provider through the real registry APIs and asserts zero plugin-loader calls, retaining the real executor/classifier and all tool-finalization assertions. No timeout, environment, retry, or assertion was weakened. The new assertion failed before the fixture repair (one plugin load); afterward the file passed 59/59 and the original 118-file CI selection passed 2734 tests with 12 existing macOS GNU-shell skips. The individual regression case measured 333254 ms before and 2 ms after on the same Node 26 executable; whole-file wall time was 516.49 s versus 64.43 s and RSS 2.32 GB versus 1.68 GB, with import/cache variation included in those whole-process measurements.

Exact local commands:

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_TEST_PROJECTS_PARALLEL=2 node scripts/run-vitest.mjs src/gateway/server-methods/talk-target.test.ts src/gateway/server-methods/talk-client.test.ts src/gateway/server-methods/talk.test.ts src/gateway/talk-realtime-relay.test.ts src/gateway/talk-realtime-relay-voice.test.ts src/gateway/talk-relay-audio-base64.test.ts src/gateway/session-sharing.test.ts src/gateway/session-sharing.sandbox.test.ts src/gateway/session-sharing-store-cache.test.ts src/gateway/session-sharing.creator-namespace.test.ts src/gateway/session-sharing-groups.test.ts src/talk/client-voice-session.test.ts src/talk/agent-target.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_TEST_PROJECTS_PARALLEL=2 node scripts/run-vitest.mjs src/gateway/server-methods/talk-target.test.ts src/commands/doctor/shared/default-agent-role-materialization.test.ts
```

```bash
OPENCLAW_VITEST_MAX_WORKERS=2 OPENCLAW_TEST_PROJECTS_PARALLEL=2 node scripts/run-vitest.mjs src/talk/client-voice-session.test.ts src/talk/client-voice-session.startup.test.ts src/gateway/talk-relay-audio-base64.test.ts
```

```bash
node scripts/check-changed.mjs
```

```bash
pnpm build
```

Proof boundary: this task explicitly required synthetic, isolated testing and prohibited live operator Gateway/config/state/restart or credential work. No live audio, SDP exchange, authenticated provider, or device proof is claimed. Provider APIs and credential selection are unchanged. No operator instance was touched.
