### PR TITLE
test: share daemon inspection fixture cleanup

### DIFF
--- a/src/daemon/inspect.test.ts
+++ b/src/daemon/inspect.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   detectMarkerLineWithGateway,
   findExtraGatewayServices,
@@ -16,6 +17,9 @@ const { execSchtasksMock } = vi.hoisted(() => ({
 vi.mock("./schtasks-exec.js", () => ({
   execSchtasks: (...args: unknown[]) => execSchtasksMock(...args),
 }));
+
+// File-scope cleanup cannot prevent the nested platform-restoration hooks from running.
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 // Real content from the openclaw-gateway.service unit file (the canonical gateway unit).
 const GATEWAY_SERVICE_CONTENTS = `\
@@ -231,109 +235,88 @@ describe("renderGatewayServiceCleanupHints", () => {
 describe("findExtraGatewayServices (linux / scanSystemdDir) — real filesystem", () => {
   // These tests write real .service files to a temp dir and call findExtraGatewayServices
   // with that dir as HOME. No platform mocking or fs mocking needed.
-  // Only runs on Linux/macOS where the linux branch of findExtraGatewayServices is active.
   const isLinux = process.platform === "linux";
 
   it.skipIf(!isLinux)("does not report openclaw-test.service as a gateway service", async () => {
-    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+    const tmpHome = tempDirs.make("openclaw-test-", os.tmpdir());
     const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
-    try {
-      await fs.mkdir(systemdDir, { recursive: true });
-      await fs.writeFile(path.join(systemdDir, "openclaw-test.service"), TEST_SERVICE_CONTENTS);
-      const result = await findExtraGatewayServices({ HOME: tmpHome });
-      expect(result).toStrictEqual([]);
-    } finally {
-      await fs.rm(tmpHome, { recursive: true, force: true });
-    }
+    await fs.mkdir(systemdDir, { recursive: true });
+    await fs.writeFile(path.join(systemdDir, "openclaw-test.service"), TEST_SERVICE_CONTENTS);
+    const result = await findExtraGatewayServices({ HOME: tmpHome });
+    expect(result).toStrictEqual([]);
   });
 
   it.skipIf(!isLinux)(
     "does not report the canonical openclaw-gateway.service as an extra service",
     async () => {
-      const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+      const tmpHome = tempDirs.make("openclaw-test-", os.tmpdir());
       const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
-      try {
-        await fs.mkdir(systemdDir, { recursive: true });
-        await fs.writeFile(
-          path.join(systemdDir, "openclaw-gateway.service"),
-          GATEWAY_SERVICE_CONTENTS,
-        );
-        const result = await findExtraGatewayServices({ HOME: tmpHome });
-        expect(result).toStrictEqual([]);
-      } finally {
-        await fs.rm(tmpHome, { recursive: true, force: true });
-      }
+      await fs.mkdir(systemdDir, { recursive: true });
+      await fs.writeFile(
+        path.join(systemdDir, "openclaw-gateway.service"),
+        GATEWAY_SERVICE_CONTENTS,
+      );
+      const result = await findExtraGatewayServices({ HOME: tmpHome });
+      expect(result).toStrictEqual([]);
     },
   );
 
   it.skipIf(!isLinux)(
     "reports a legacy clawdbot-gateway service as an extra gateway service",
     async () => {
-      const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+      const tmpHome = tempDirs.make("openclaw-test-", os.tmpdir());
       const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
       const unitPath = path.join(systemdDir, "clawdbot-gateway.service");
-      try {
-        await fs.mkdir(systemdDir, { recursive: true });
-        await fs.writeFile(unitPath, CLAWDBOT_GATEWAY_CONTENTS);
-        const result = await findExtraGatewayServices({ HOME: tmpHome });
-        expect(result).toEqual([
-          {
-            platform: "linux",
-            label: "clawdbot-gateway.service",
-            detail: `unit: ${unitPath}`,
-            scope: "user",
-            marker: "clawdbot",
-            legacy: true,
-          },
-        ]);
-      } finally {
-        await fs.rm(tmpHome, { recursive: true, force: true });
-      }
+      await fs.mkdir(systemdDir, { recursive: true });
+      await fs.writeFile(unitPath, CLAWDBOT_GATEWAY_CONTENTS);
+      const result = await findExtraGatewayServices({ HOME: tmpHome });
+      expect(result).toEqual([
+        {
+          platform: "linux",
+          label: "clawdbot-gateway.service",
+          detail: `unit: ${unitPath}`,
+          scope: "user",
+          marker: "clawdbot",
+          legacy: true,
+        },
+      ]);
     },
   );
 
   it.skipIf(!isLinux)(
     "does not report companion units that only depend on the gateway",
     async () => {
-      const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+      const tmpHome = tempDirs.make("openclaw-test-", os.tmpdir());
       const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
-      try {
-        await fs.mkdir(systemdDir, { recursive: true });
-        await fs.writeFile(
-          path.join(systemdDir, "openclaw-companion.service"),
-          COMPANION_SERVICE_CONTENTS,
-        );
-        const result = await findExtraGatewayServices({ HOME: tmpHome });
-        expect(result).toStrictEqual([]);
-      } finally {
-        await fs.rm(tmpHome, { recursive: true, force: true });
-      }
+      await fs.mkdir(systemdDir, { recursive: true });
+      await fs.writeFile(
+        path.join(systemdDir, "openclaw-companion.service"),
+        COMPANION_SERVICE_CONTENTS,
+      );
+      const result = await findExtraGatewayServices({ HOME: tmpHome });
+      expect(result).toStrictEqual([]);
     },
   );
 
   it.skipIf(!isLinux)(
     "reports custom-named gateway units that execute openclaw gateway",
     async () => {
-      const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+      const tmpHome = tempDirs.make("openclaw-test-", os.tmpdir());
       const systemdDir = path.join(tmpHome, ".config", "systemd", "user");
       const unitPath = path.join(systemdDir, "custom-openclaw.service");
-      try {
-        await fs.mkdir(systemdDir, { recursive: true });
-        await fs.writeFile(unitPath, CUSTOM_OPENCLAW_GATEWAY_CONTENTS);
-        const result = await findExtraGatewayServices({ HOME: tmpHome });
-        expect(result).toEqual([
-          {
-            platform: "linux",
-            label: "custom-openclaw.service",
-            detail: `unit: ${unitPath}`,
-            scope: "user",
-            marker: "openclaw",
-            legacy: false,
-          },
-        ]);
-      } finally {
-        await fs.rm(tmpHome, { recursive: true, force: true });
-      }
+      await fs.mkdir(systemdDir, { recursive: true });
+      await fs.writeFile(unitPath, CUSTOM_OPENCLAW_GATEWAY_CONTENTS);
+      const result = await findExtraGatewayServices({ HOME: tmpHome });
+      expect(result).toEqual([
+        {
+          platform: "linux",
+          label: "custom-openclaw.service",
+          detail: `unit: ${unitPath}`,
+          scope: "user",
+          marker: "openclaw",
+          legacy: false,
+        },
+      ]);
     },
   );
 });
@@ -356,99 +339,83 @@ describe("findExtraGatewayServices (darwin / scanLaunchdDir) — real filesystem
   });
 
   it("does not report LaunchAgent companions that only mention the gateway label", async () => {
-    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+    const tmpHome = tempDirs.make("openclaw-test-", os.tmpdir());
     const launchdDir = path.join(tmpHome, "Library", "LaunchAgents");
-    try {
-      await fs.mkdir(launchdDir, { recursive: true });
-      await fs.writeFile(
-        path.join(launchdDir, "com.example.companion.plist"),
-        `<?xml version="1.0" encoding="UTF-8"?>
+    await fs.mkdir(launchdDir, { recursive: true });
+    await fs.writeFile(
+      path.join(launchdDir, "com.example.companion.plist"),
+      `<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0"><dict>
 <key>Label</key><string>com.example.companion</string>
 <key>KeepAlive</key><dict><key>OtherJobEnabled</key><dict><key>ai.openclaw.gateway</key><true/></dict></dict>
 <key>ProgramArguments</key><array><string>/usr/local/bin/openclaw-helper</string><string>sync</string></array>
 </dict></plist>`,
-      );
-      const result = await findExtraGatewayServices({ HOME: tmpHome });
-      expect(result).toStrictEqual([]);
-    } finally {
-      await fs.rm(tmpHome, { recursive: true, force: true });
-    }
+    );
+    const result = await findExtraGatewayServices({ HOME: tmpHome });
+    expect(result).toStrictEqual([]);
   });
 
   it("does not report LaunchAgent companions that only pass gateway-named options", async () => {
-    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+    const tmpHome = tempDirs.make("openclaw-test-", os.tmpdir());
     const launchdDir = path.join(tmpHome, "Library", "LaunchAgents");
-    try {
-      await fs.mkdir(launchdDir, { recursive: true });
-      await fs.writeFile(
-        path.join(launchdDir, "com.example.companion-options.plist"),
-        `<?xml version="1.0" encoding="UTF-8"?>
+    await fs.mkdir(launchdDir, { recursive: true });
+    await fs.writeFile(
+      path.join(launchdDir, "com.example.companion-options.plist"),
+      `<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0"><dict>
 <key>Label</key><string>com.example.companion-options</string>
 <key>ProgramArguments</key><array><string>/usr/local/bin/openclaw-helper</string><string>--gateway-url</string><string>http://127.0.0.1:18789</string><string>sync</string></array>
 </dict></plist>`,
-      );
-      const result = await findExtraGatewayServices({ HOME: tmpHome });
-      expect(result).toStrictEqual([]);
-    } finally {
-      await fs.rm(tmpHome, { recursive: true, force: true });
-    }
+    );
+    const result = await findExtraGatewayServices({ HOME: tmpHome });
+    expect(result).toStrictEqual([]);
   });
 
   it("does not report non-gateway LaunchAgents that mention clawdbot in environment values", async () => {
-    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+    const tmpHome = tempDirs.make("openclaw-test-", os.tmpdir());
     const launchdDir = path.join(tmpHome, "Library", "LaunchAgents");
-    try {
-      await fs.mkdir(launchdDir, { recursive: true });
-      await fs.writeFile(
-        path.join(launchdDir, "com.github.facebook.watchman.plist"),
-        `<?xml version="1.0" encoding="UTF-8"?>
+    await fs.mkdir(launchdDir, { recursive: true });
+    await fs.writeFile(
+      path.join(launchdDir, "com.github.facebook.watchman.plist"),
+      `<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0"><dict>
 <key>Label</key><string>com.github.facebook.watchman</string>
 <key>EnvironmentVariables</key><dict><key>PATH</key><string>/Users/test/Projects/clawdbot2/node_modules/.bin:/opt/homebrew/bin</string></dict>
 <key>ProgramArguments</key><array><string>/opt/homebrew/bin/watchman</string><string>--foreground</string></array>
 </dict></plist>`,
-      );
-      const result = await findExtraGatewayServices({ HOME: tmpHome });
-      expect(result).toStrictEqual([]);
-    } finally {
-      await fs.rm(tmpHome, { recursive: true, force: true });
-    }
+    );
+    const result = await findExtraGatewayServices({ HOME: tmpHome });
+    expect(result).toStrictEqual([]);
   });
 
   it("reports custom LaunchAgents that execute openclaw gateway", async () => {
-    const tmpHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-test-"));
+    const tmpHome = tempDirs.make("openclaw-test-", os.tmpdir());
     const launchdDir = path.join(tmpHome, "Library", "LaunchAgents");
     const plistPath = path.join(launchdDir, "com.example.openclaw-gateway.plist");
-    try {
-      await fs.mkdir(launchdDir, { recursive: true });
-      await fs.writeFile(
-        plistPath,
-        `<?xml version="1.0" encoding="UTF-8"?>
+    await fs.mkdir(launchdDir, { recursive: true });
+    await fs.writeFile(
+      plistPath,
+      `<?xml version="1.0" encoding="UTF-8"?>
 <plist version="1.0"><dict>
 <key>Label</key><string>com.example.openclaw-gateway</string>
 <key>ProgramArguments</key><array><string>/usr/local/bin/openclaw</string><string>gateway</string><string>--port</string><string>18888</string></array>
 </dict></plist>`,
-      );
-      const result = await findExtraGatewayServices({ HOME: tmpHome });
-      expect(result).toEqual([
-        {
-          platform: "darwin",
-          label: "com.example.openclaw-gateway",
-          detail: `plist: ${plistPath}`,
-          scope: "user",
-          marker: "openclaw",
-          legacy: false,
-        },
-      ]);
-      expect(renderGatewayServiceCleanupHints(result)).toEqual([
-        "launchctl bootout gui/$UID/com.example.openclaw-gateway",
-        `rm ${plistPath}`,
-      ]);
-    } finally {
-      await fs.rm(tmpHome, { recursive: true, force: true });
-    }
+    );
+    const result = await findExtraGatewayServices({ HOME: tmpHome });
+    expect(result).toEqual([
+      {
+        platform: "darwin",
+        label: "com.example.openclaw-gateway",
+        detail: `plist: ${plistPath}`,
+        scope: "user",
+        marker: "openclaw",
+        legacy: false,
+      },
+    ]);
+    expect(renderGatewayServiceCleanupHints(result)).toEqual([
+      "launchctl bootout gui/$UID/com.example.openclaw-gateway",
+      `rm ${plistPath}`,
+    ]);
   });
 });
 


### PR DESCRIPTION
## What Problem

Nine real-filesystem daemon inspection cases repeat temporary-HOME creation and try/finally removal. Each needs its own directory, but the cleanup ownership is already provided by the shared test helper.

## Why

Use the existing file-scoped `useAutoCleanupTempDirTracker(afterEach)` and keep a fresh HOME for every case. Passing `os.tmpdir()` explicitly preserves the original path spelling. File-scoped cleanup runs after the nested platform-restoration hooks, so a removal error cannot prevent restoration.

The literal service/plist documents, awaited writes, real scanner calls, assertions and platform hooks remain intact. The shared helper is unchanged; its established bounded filesystem-removal retries are reused, without adding test retries.

## User Impact

Test-only cleanup; no daemon behavior change or claimed speedup/stability improvement. No mock broadening or changes to deadlines, Linux skips, selection, sharding or concurrency.

Production/shared-helper LOC: +0/-0. Tests: +98/-131, net −33 lines.

## Evidence

```sh
node scripts/run-vitest.mjs src/daemon/inspect.test.ts src/daemon/systemd-unit.test.ts src/daemon/launchd-plist.test.ts test/helpers/temp-dir.test.ts
```

Before and after on macOS: 66 registered cases, 61 passed and the same five Linux-only cases skipped. Per-file names, order and statuses match. The inspect file itself retains 28 passes and five skips; parser/helper siblings provide the other 33 passes.

The same candidate was included in a composed regression run of 267 cases: 262 passed and those same five skipped. The full changed gate passed for that composition. Independent source/runtime reviews found no actionable candidate-specific issue; scoped autoreview completed without actionable P0 findings.

Exact-head [Linux CI](https://github.com/openclaw/openclaw/actions/runs/33372268511/job/99426014363) now passed all **33 inspect cases**, including all five systemd cases skipped locally, with zero skips or failures and child exit 0. The individual verbose results match both retained macOS case inventories. The tested merge checkout contains the exact reviewed PR afterimage. This completes the Linux requirement in the ClawSweeper review; no native service or measured speedup is claimed.
