### PR TITLE
fix(doctor): stop warning for nested Git workspaces

### DIFF
--- a/src/cli/doctor-output.process.test.ts
+++ b/src/cli/doctor-output.process.test.ts
@@ -1,4 +1,7 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { spawnNodeEvalSync } from "../test-utils/node-process.js";
@@ -6,6 +9,85 @@ import { spawnNodeEvalSync } from "../test-utils/node-process.js";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("Doctor report process output", () => {
+  it("omits backup tips for Git-backed nested agent workspaces", () => {
+    const root = tempDirs.make("openclaw-doctor-workspace-git-");
+    const repoRoot = path.join(root, "repo");
+    const nestedWorkspace = path.join(
+      repoRoot,
+      ...Array.from({ length: 12 }, (_, index) => `workspace-level-${index}`),
+    );
+    const linkedWorkspace = path.join(root, "linked-workspace");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(root, "openclaw.json");
+    fs.mkdirSync(path.join(repoRoot, ".git"), { recursive: true });
+    fs.mkdirSync(nestedWorkspace, { recursive: true });
+    fs.mkdirSync(stateDir);
+    fs.symlinkSync(
+      nestedWorkspace,
+      linkedWorkspace,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({
+        agents: {
+          ownership: "explicit",
+          entries: {
+            direct: { workspace: nestedWorkspace },
+            linked: { workspace: linkedWorkspace },
+          },
+        },
+      }),
+    );
+
+    const entryPath = fileURLToPath(new URL("../entry.ts", import.meta.url));
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        entryPath,
+        "doctor",
+        "--lint",
+        "--only",
+        "core/doctor/workspace-suggestions",
+        "--severity-min",
+        "info",
+        "--json",
+        "--no-color",
+      ],
+      {
+        cwd: path.resolve("."),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HOME: root,
+          USERPROFILE: root,
+          NODE_DISABLE_COMPILE_CACHE: "1",
+          NODE_ENV: undefined,
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_HIDE_BANNER: "1",
+          OPENCLAW_HOME: root,
+          OPENCLAW_NO_RESPAWN: "1",
+          OPENCLAW_STATE_DIR: stateDir,
+          VITEST: undefined,
+          VITEST_POOL_ID: undefined,
+          VITEST_WORKER_ID: undefined,
+        },
+        maxBuffer: 4 * 1024 * 1024,
+        timeout: 60_000,
+      },
+    );
+
+    expect(result.error).toBeUndefined();
+    expect(result.signal).toBeNull();
+    expect(result.status, result.stderr).toBe(1);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).not.toContain("back up the agent workspace");
+    expect(result.stdout).toContain('"target":"direct"');
+    expect(result.stdout).toContain('"target":"linked"');
+  });
+
   it.each([
     { name: "advisory JSON", args: ["--json"], exitCode: 0 },
     { name: "lint JSON", args: ["--lint", "--json"], exitCode: 1 },

--- a/src/commands/doctor-state-integrity.test.ts
+++ b/src/commands/doctor-state-integrity.test.ts
@@ -11,8 +11,10 @@ import {
 import { writeConfigMachineState } from "../state/config-machine-state.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withTestDir } from "../test-helpers/temp-dir.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import {
+  collectWorkspaceBackupTip,
   detectStateIntegrityHealthIssues,
   noteStateIntegrity as noteStateIntegrityRaw,
   stateIntegrityIssueToHealthFinding,
@@ -30,6 +32,42 @@ import {
   withMainAgentRoster,
   writeSessionStore,
 } from "./doctor-state-integrity.test-support.js";
+
+const WORKSPACE_BACKUP_TIP =
+  "- Tip: back up the agent workspace in a private git repo; keep ~/.openclaw out of git (credentials, sessions). Details: /concepts/agent-workspace#git-backup-recommended";
+
+describe("workspace backup tip", () => {
+  it("recognizes direct, deeply nested, and symlinked Git workspaces without duplicate tips", async () => {
+    await withTestDir({ prefix: "openclaw-doctor-workspace-git-" }, async (tempDir) => {
+      const repoRoot = path.join(tempDir, "repo");
+      const nestedWorkspace = path.join(repoRoot, "agents", "direct");
+      const deeplyNestedWorkspace = path.join(
+        repoRoot,
+        ...Array.from({ length: 12 }, (_, index) => `workspace-level-${index}`),
+      );
+      const linkedWorkspace = path.join(tempDir, "linked-workspace");
+      const outsideWorkspace = path.parse(tempDir).root;
+      const missingWorkspace = path.join(tempDir, "missing");
+      fs.mkdirSync(path.join(repoRoot, ".git"), { recursive: true });
+      fs.mkdirSync(nestedWorkspace, { recursive: true });
+      fs.mkdirSync(deeplyNestedWorkspace, { recursive: true });
+      fs.symlinkSync(
+        nestedWorkspace,
+        linkedWorkspace,
+        process.platform === "win32" ? "junction" : "dir",
+      );
+
+      expect(collectWorkspaceBackupTip(repoRoot)).toBeNull();
+      expect(
+        [nestedWorkspace, deeplyNestedWorkspace, linkedWorkspace]
+          .map((workspaceDir) => collectWorkspaceBackupTip(workspaceDir))
+          .filter((tip) => tip !== null),
+      ).toEqual([]);
+      expect(collectWorkspaceBackupTip(outsideWorkspace)).toBe(WORKSPACE_BACKUP_TIP);
+      expect(collectWorkspaceBackupTip(missingWorkspace)).toBeNull();
+    });
+  });
+});
 
 vi.mock("../channels/plugins/bundled-ids.js", () => ({
   listBundledChannelIds: () => ["matrix", "whatsapp"],

--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -51,6 +51,7 @@ import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HealthFinding, HealthRepairEffect } from "../flows/health-checks.js";
 import { safeRealpathSync } from "../infra/boundary-path.js";
+import { findGitRoot } from "../infra/git-root.js";
 import { resolveRequiredHomeDir } from "../infra/home-dir.js";
 import {
   loadLegacySessionStore,
@@ -1658,8 +1659,8 @@ export function collectWorkspaceBackupTip(workspaceDir: string): string | null {
   if (!existsDir(workspaceDir)) {
     return null;
   }
-  const gitMarker = path.join(workspaceDir, ".git");
-  if (fs.existsSync(gitMarker)) {
+  const resolvedWorkspaceDir = safeRealpathSync(workspaceDir);
+  if (!resolvedWorkspaceDir || findGitRoot(resolvedWorkspaceDir)) {
     return null;
   }
   return "- Tip: back up the agent workspace in a private git repo; keep ~/.openclaw out of git (credentials, sessions). Details: /concepts/agent-workspace#git-backup-recommended";

--- a/src/infra/git-root.ts
+++ b/src/infra/git-root.ts
@@ -2,16 +2,13 @@
 import fs from "node:fs";
 import path from "node:path";
 
-const DEFAULT_GIT_DISCOVERY_MAX_DEPTH = 12;
-
 function walkUpFrom<T>(
   startDir: string,
   opts: { maxDepth?: number },
   resolveAtDir: (dir: string) => T | null | undefined,
 ): T | null {
   let current = path.resolve(startDir);
-  const maxDepth = opts.maxDepth ?? DEFAULT_GIT_DISCOVERY_MAX_DEPTH;
-  for (let i = 0; i < maxDepth; i += 1) {
+  for (let i = 0; opts.maxDepth === undefined || i < opts.maxDepth; i += 1) {
     const resolved = resolveAtDir(current);
     if (resolved !== null && resolved !== undefined) {
       return resolved;


### PR DESCRIPTION
Closes #133923

## What Problem This Solves

Fixes an issue where Doctor told multi-agent operators to back up workspaces that were already nested inside a Git repository. The same false advice appeared when an agent workspace used a symlink to that nested directory.

## Why This Change Was Made

Doctor now resolves the workspace symlink and uses the existing in-process Git-root discovery helper. The helper now searches to the filesystem root by default, so it recognizes repository roots, deeply nested workspaces, and linked workspaces without spawning Git or adding configuration.

The regression test also keeps the existing behavior for an outside workspace and a missing workspace. Agent-scoped memory guidance remains unchanged.

## User Impact

`openclaw doctor` no longer repeats Git-backup advice for workspaces that are already covered by a parent repository.

## Evidence

- Current-main red at `65bb866a548a9499b893db3fb15818c358593490`: `openclaw doctor --lint --only core/doctor/workspace-suggestions --severity-min info --json` returned one false backup finding for a nested workspace and one for its symlink.
- Exact-head green at `9b4090930694b7fefc3f99be9d95af338084f755`: the same Doctor command returned zero backup findings while preserving both agent-scoped memory findings.
- Regression test: direct root, 12-level nested workspace, symlinked nested workspace, outside workspace, missing workspace, and the two-agent duplicate case.
- Focused tests: 20 passed.
- Sibling Doctor flow tests: 129 passed.
- Real Doctor CLI process tests: 4 passed.
- Production LOC: +4/-6 (net -2). Tests: +120/-0.
