### PR TITLE
fix(ui): release evicted chat transcript payloads

### DIFF
--- a/src/gateway/server-methods/sessions-mutations.perf.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.perf.test.ts
@@ -1,4 +1,3 @@
-import { performance } from "node:perf_hooks";
 import { afterEach, expect, test, vi } from "vitest";
 import { trackSqliteStatementExecutions } from "../../../test/helpers/sqlite-statement-execution-counter.js";
 import {
@@ -275,17 +274,12 @@ test("sessions.patchMany archives 30 human sessions without transcript hydration
         },
       } as unknown as GatewayRequestContext;
 
-      const startedAt = performance.now();
       await sessionMutationHandlers["sessions.patchMany"]!({
         params: { targets, patch: { archived: true } },
         respond,
         context,
         client: humanClient(),
       } as never);
-      const elapsedMs = performance.now() - startedAt;
-      console.info(`[perf] sessions.patchMany archive-30 ${elapsedMs.toFixed(2)}ms`);
-      expect(elapsedMs).toBeLessThan(1_000);
-
       expect(respond).toHaveBeenCalledWith(
         true,
         {
@@ -293,6 +287,7 @@ test("sessions.patchMany archives 30 human sessions without transcript hydration
         },
         undefined,
       );
+      // Guard batch cost with operation counts, independent of shared-runner contention.
       expect(statements.counts["whole-store-projection"]).toBe(0);
       expect(statements.counts["transcript-full-hydration"]).toBe(0);
       // Archive attribution stays in the session-store batch; transcripts are untouched.

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -1,6 +1,8 @@
-import { expectDefined } from "@openclaw/normalization-core";
 // @vitest-environment node
 // Control UI tests cover build chat items behavior.
+import { setImmediate } from "node:timers/promises";
+import { queryObjects } from "node:v8";
+import { expectDefined } from "@openclaw/normalization-core";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
 import { markInboundContextLabel } from "../../../../src/auto-reply/reply/inbound-context-marker.js";
@@ -4513,6 +4515,34 @@ describe("buildCachedChatItems", () => {
 });
 
 describe("tool expansion state", () => {
+  it("releases a closed pane's messages while retaining its disclosure choices", async () => {
+    resetChatThreadState();
+    class TranscriptMessage {
+      role = "assistant";
+      content = [{ type: "toolcall", id: "released-call", name: "read" }];
+    }
+    const paneId = "released-pane";
+    const sessionKey = "released-session";
+    const populatePane = () => {
+      const items = buildCachedChatItems(
+        createProps({ paneId, sessionKey, messages: [new TranscriptMessage()] }),
+      );
+      syncToolCardExpansionState(sessionKey, items, true);
+    };
+    try {
+      populatePane();
+      expect(queryObjects(TranscriptMessage)).toBe(1);
+
+      resetChatThreadState(paneId);
+      await setImmediate();
+
+      expect(queryObjects(TranscriptMessage)).toBe(0);
+      expect([...getExpandedToolCards(sessionKey).values()]).toEqual([true]);
+    } finally {
+      resetChatThreadState();
+    }
+  });
+
   it("skips the tool-card walk when the item array identity is unchanged", () => {
     resetChatThreadState();
     const group: MessageGroup = {

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -52,9 +52,11 @@ const expandedAssistantMessagesBySession = new Map<
 >();
 const initializedToolCardsBySession = new Map<string, Set<string>>();
 const lastAutoExpandPrefBySession = new Map<string, boolean>();
+// This memo only skips repeated work. Keeping its transcript strongly would
+// retain message payloads after the owning pane and message cache release them.
 const lastToolCardItemsBySession = new Map<
   string,
-  { items: readonly (ChatItem | MessageGroup)[]; isFilteredProjection: boolean }
+  { items: WeakRef<readonly RenderChatItem[]>; isFilteredProjection: boolean }
 >();
 
 export function resetChatThreadState(paneId?: string): void {
@@ -452,7 +454,7 @@ export function syncToolCardExpansionState(
   const previousProjection = getSessionCacheValue(lastToolCardItemsBySession, sessionKey);
   const previousAutoExpand = getSessionCacheValue(lastAutoExpandPrefBySession, sessionKey) ?? false;
   if (
-    previousProjection?.items === items &&
+    previousProjection?.items.deref() === items &&
     previousProjection.isFilteredProjection === isFilteredProjection &&
     previousAutoExpand === autoExpandToolCalls
   ) {
@@ -501,6 +503,9 @@ export function syncToolCardExpansionState(
       }
     }
   }
-  setSessionCacheValue(lastToolCardItemsBySession, sessionKey, { items, isFilteredProjection });
+  setSessionCacheValue(lastToolCardItemsBySession, sessionKey, {
+    items: new WeakRef(items),
+    isFilteredProjection,
+  });
   setSessionCacheValue(lastAutoExpandPrefBySession, sessionKey, autoExpandToolCalls);
 }

--- a/ui/src/pages/chat/session-snapshot-store.test.ts
+++ b/ui/src/pages/chat/session-snapshot-store.test.ts
@@ -1,8 +1,11 @@
 /* @vitest-environment jsdom */
 
+import { setImmediate } from "node:timers/promises";
+import { queryObjects } from "node:v8";
 import { IDBFactory, IDBObjectStore } from "fake-indexeddb";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createStorageMock } from "../../test-helpers/storage.ts";
+import { MAX_CACHED_CHAT_SESSIONS } from "./session-cache.ts";
 import {
   appendChatMessageToCache,
   cacheChatSessionSnapshot,
@@ -39,7 +42,7 @@ function transactionDone(transaction: IDBTransaction): Promise<void> {
   });
 }
 
-async function putRawRecord(record: unknown): Promise<void> {
+async function putRawRecord(record: unknown, metadata?: unknown): Promise<void> {
   const request = indexedDB.open(CHAT_SNAPSHOT_DB_NAME);
   const database = await new Promise<IDBDatabase>((resolve, reject) => {
     request.addEventListener("success", () => resolve(request.result));
@@ -53,11 +56,13 @@ async function putRawRecord(record: unknown): Promise<void> {
   );
   const completed = transactionDone(transaction);
   transaction.objectStore(CHAT_SNAPSHOT_STORE_NAME).put(record);
-  transaction.objectStore(CHAT_SNAPSHOT_METADATA_STORE_NAME).put({
-    savedAt: Date.now(),
-    sessionKey: (record as { sessionKey: string }).sessionKey,
-    weight: 0,
-  });
+  transaction.objectStore(CHAT_SNAPSHOT_METADATA_STORE_NAME).put(
+    metadata ?? {
+      savedAt: Date.now(),
+      sessionKey: (record as { sessionKey: string }).sessionKey,
+      weight: 0,
+    },
+  );
   await completed;
   database.close();
 }
@@ -233,7 +238,7 @@ describe("persistent chat session snapshots", () => {
     expect(await new SessionSnapshotStore().read(sessionKey)).toBeNull();
   });
 
-  it("does not write a snapshot back after pure hydration", async () => {
+  it("suppresses unchanged writes only for the latest hydration", async () => {
     let now = 1;
     vi.spyOn(Date, "now").mockImplementation(() => now);
     const sessionKey = "agent:main:hydrate-only";
@@ -246,8 +251,9 @@ describe("persistent chat session snapshots", () => {
     const memoryCache: ChatMessageCache = new Map();
     const reader = new SessionSnapshotStore(memoryCache);
     observeChatCache(memoryCache, reader);
+    const previousHydration = await reader.read(sessionKey);
     const hydrated = await reader.read(sessionKey);
-    if (!hydrated) {
+    if (!previousHydration || !hydrated) {
       throw new Error("expected hydrated snapshot");
     }
     cacheChatSessionSnapshot(
@@ -259,6 +265,48 @@ describe("persistent chat session snapshots", () => {
     await reader.flush();
 
     expect((await readRawRecord(sessionKey))?.savedAt).toBe(1);
+    reader.write(sessionKey, previousHydration);
+    await reader.flush();
+    expect((await readRawRecord(sessionKey))?.savedAt).toBe(2);
+  });
+
+  it("releases hydrated snapshots after the message cache evicts them", async () => {
+    const sessionKey = "agent:main:evicted-hydration";
+    const memoryCache: ChatMessageCache = new Map();
+    const store = new SessionSnapshotStore(memoryCache);
+    observeChatCache(memoryCache, store);
+    store.write(sessionKey, snapshot("persisted"));
+    await store.flush();
+
+    const evicted = await (async () => {
+      const hydrated = await store.read(sessionKey);
+      if (!hydrated) {
+        throw new Error("expected hydrated snapshot");
+      }
+      cacheChatSessionSnapshot(
+        memoryCache,
+        { assistantAgentId: "main", agentsList: null, hello: null },
+        { sessionKey },
+        hydrated,
+      );
+      return new WeakRef(hydrated);
+    })();
+    for (let index = 0; index < MAX_CACHED_CHAT_SESSIONS; index += 1) {
+      cacheChatSessionSnapshot(
+        memoryCache,
+        { assistantAgentId: "main", agentsList: null, hello: null },
+        { sessionKey: `agent:main:newer-${index}` },
+        snapshot(index),
+      );
+    }
+    await store.flush();
+    expect(memoryCache.has(sessionKey)).toBe(false);
+    // Weak references keep their target alive for the current job. Move to the
+    // next turn before the V8 heap census forces a complete collection.
+    await setImmediate();
+    queryObjects(SessionSnapshotStore);
+    expect(evicted.deref()).toBeUndefined();
+    expect(store.readSavedAt("agent:main:newer-0")).not.toBeNull();
   });
 
   it("evicts the oldest sessions by count and total serialized weight", async () => {
@@ -285,7 +333,7 @@ describe("persistent chat session snapshots", () => {
     expect(await weightReader.read("agent:main:weight-2")).not.toBeNull();
   });
 
-  it("resets the whole database when the savedAt seed finds a malformed record", async () => {
+  it("seeds timestamps without hydrating unrelated snapshots", async () => {
     const writer = new SessionSnapshotStore();
     writer.write("agent:main:valid", snapshot("valid"));
     await writer.flush();
@@ -295,6 +343,28 @@ describe("persistent chat session snapshots", () => {
       savedAt: Date.now(),
       snapshot: { messages: "not-an-array" },
     });
+
+    const reader = new SessionSnapshotStore();
+    await reader.loadSavedAtIndex();
+    expect(reader.readSavedAt("agent:main:valid")).not.toBeNull();
+    expect(reader.readSavedAt("agent:main:corrupt")).not.toBeNull();
+    expect(await reader.read("agent:main:corrupt")).toBeNull();
+    expect(await reader.read("agent:main:valid")).toBeNull();
+  });
+
+  it("resets the whole database when the savedAt seed finds malformed metadata", async () => {
+    const writer = new SessionSnapshotStore();
+    writer.write("agent:main:valid", snapshot("valid"));
+    await writer.flush();
+    await putRawRecord(
+      {
+        sessionKey: "agent:main:corrupt",
+        sessionId: "session-1",
+        savedAt: Date.now(),
+        snapshot: snapshot("corrupt metadata"),
+      },
+      { sessionKey: "agent:main:corrupt", savedAt: "invalid", weight: 0 },
+    );
 
     const reader = new SessionSnapshotStore();
     await reader.loadSavedAtIndex();

--- a/ui/src/pages/chat/session-snapshot-store.ts
+++ b/ui/src/pages/chat/session-snapshot-store.ts
@@ -167,24 +167,26 @@ async function readSnapshotRecord(sessionKey: string): Promise<SessionSnapshotRe
   }
 }
 
-async function readSnapshotRecords(): Promise<SessionSnapshotRecord[] | null> {
+async function readSnapshotMetadata(): Promise<SessionSnapshotMetadata[] | null> {
   const database = await openSessionSnapshotDatabase();
   if (!database) {
     return [];
   }
   try {
-    const transaction = database.transaction(CHAT_SNAPSHOT_STORE_NAME, "readonly");
-    const values = await requestResult(transaction.objectStore(CHAT_SNAPSHOT_STORE_NAME).getAll());
+    const transaction = database.transaction(CHAT_SNAPSHOT_METADATA_STORE_NAME, "readonly");
+    const values = await requestResult(
+      transaction.objectStore(CHAT_SNAPSHOT_METADATA_STORE_NAME).getAll(),
+    );
     await transactionDone(transaction);
-    const records: SessionSnapshotRecord[] = [];
+    const records: SessionSnapshotMetadata[] = [];
     for (const value of values) {
-      const record = parseSnapshotRecord(value);
-      if (!record) {
-        debugSnapshotStore("resetting cache after record shape mismatch");
+      const record = metadataSchema.safeParse(value);
+      if (!record.success) {
+        debugSnapshotStore("resetting cache after metadata shape mismatch");
         await resetSessionSnapshotDatabase(database);
         return null;
       }
-      records.push(record);
+      records.push(record.data);
     }
     return records;
   } catch (error) {
@@ -277,7 +279,9 @@ async function writeSnapshotRecords(
 export class SessionSnapshotStore implements ChatCacheObserver {
   private connected = false;
   private readonly pending = new Map<string, PendingSessionState>();
-  private readonly hydratedSnapshots = new Map<string, ChatSessionSnapshot>();
+  // Hydration identity suppresses unchanged writes; the bounded message cache
+  // owns transcript retention, so eviction must leave no second strong owner.
+  private readonly hydratedSnapshots = new Map<string, WeakRef<ChatSessionSnapshot>>();
   private readonly revisions = new Map<string, number>();
   // Cross-tab writes may leave this index stale until reload; the 30s prefetch
   // cooldown bounds the resulting redundant fetches without per-row IDB reads.
@@ -313,7 +317,7 @@ export class SessionSnapshotStore implements ChatCacheObserver {
     ) {
       return null;
     }
-    setSessionCacheValue(this.hydratedSnapshots, sessionKey, record.snapshot);
+    setSessionCacheValue(this.hydratedSnapshots, sessionKey, new WeakRef(record.snapshot));
     return record.snapshot;
   }
 
@@ -328,7 +332,7 @@ export class SessionSnapshotStore implements ChatCacheObserver {
 
   write(sessionKey: string, snapshot: ChatSessionSnapshot): void {
     this.revisions.set(sessionKey, (this.revisions.get(sessionKey) ?? 0) + 1);
-    if (getSessionCacheValue(this.hydratedSnapshots, sessionKey) === snapshot) {
+    if (getSessionCacheValue(this.hydratedSnapshots, sessionKey)?.deref() === snapshot) {
       return;
     }
     this.hydratedSnapshots.delete(sessionKey);
@@ -424,7 +428,7 @@ export class SessionSnapshotStore implements ChatCacheObserver {
   private async seedSavedAtIndex(): Promise<void> {
     const generation = snapshotStoreGeneration;
     const revisions = new Map(this.revisions);
-    const records = await readSnapshotRecords();
+    const records = await readSnapshotMetadata();
     if (generation !== snapshotStoreGeneration) {
       return;
     }


### PR DESCRIPTION
Closes #133939.

## What Problem This Solves

Fixes an issue where users who revisit saved chats or switch panes keep obsolete transcript payloads alive after the visible pane and bounded message cache release them. Startup prefetch also read every persisted transcript just to retrieve cache timestamps.

## Why This Change Was Made

Hydration and tool-card memoization now retain only weak identity references. The bounded message cache remains the transcript owner; the existing latest-hydration and disclosure-state behavior stays intact. Timestamp seeding reads the existing IndexedDB metadata store, while actual hydration still validates transcript records. No schema, cache-budget, configuration, or public API changes.

## User Impact

Long-lived Control UI sessions release obsolete chat histories and avoid loading full saved histories for timestamp-only prefetch decisions. Chat content, pagination, tool disclosure choices, and saved history remain unchanged. Both strong-reference paths are present in stable v2026.8.1.

## Evidence

- Real isolated Gateway plus Chromium: browser and CLI chat completed; 12 baseline and six post-fix cycles through Home, Automations, and Plugins completed with no page errors.
- In-browser snapshot-owner probe on the built app: 20 released hydrated histories remained reachable after full GC before the fix, retaining 12,803,988 additional heap bytes for the synthetic payloads. After the repair, all 20 were collected. The after sample includes unrelated page boot allocation and is not presented as an exact whole-browser heap reduction.
- Both snapshot-eviction and pane-teardown GC regression tests fail before the respective fixes and pass afterward. The latest-only hydration test also preserves the behavior for an older hydration returned before a newer one.
- 274 tests passed across `session-snapshot-store.test.ts`, `session-message-cache.test.ts`, `session-prefetch.test.ts`, `chat-pane-snapshot-hydration.test.ts`, and `chat-thread.test.ts` using `node scripts/run-vitest.mjs`.
- Scoped changed checks for snapshot files, full UI typecheck, targeted lint, formatting, and `git diff --check` passed. `node scripts/ui.js build` and the full `scripts/build-all.mts` build passed. Fresh independent Codex autoreview was clean at its default P0 threshold.
- Production LOC: +24/-15 (net +9), mostly the ownership comments and formatting of weak-reference values/metadata reads. Tests: +111/-16 (net +95). No new dependency or production export.

CI exposed a separate archive-test flake: archiving 30 sessions took 1,001.94 ms against a fixed 1,000 ms cutoff, while the unchanged test took 55.22 ms locally. The test now guards cost through its existing one-transaction, zero-transcript-hydration, zero-whole-store-read, and one-cron-scan assertions, preserving every outcome and attribution check. All four focused mutation tests pass; the test-only change also passed fresh independent Codex autoreview. No production timeout or performance contract changed.

The repeatable Gateway scenarios used a local deterministic model endpoint, not an external live provider. They also completed 50 reconnects, 30 sessions plus deletion, 50 status/history cycles, and eight concurrent tool turns with 552 successful history probes and 50 successful session mutations. Those are supporting real-Gateway flow checks, not substitutes for the focused memory regressions.
