### PR TITLE
test: simplify Microsoft speech fixtures

### DIFF
--- a/extensions/microsoft/speech-provider.test.ts
+++ b/extensions/microsoft/speech-provider.test.ts
@@ -272,87 +272,60 @@ describe("buildMicrosoftSpeechProvider", () => {
     vi.restoreAllMocks();
   });
 
-  it("switches to a Chinese voice for CJK text when no explicit voice override is set", async () => {
-    const provider = buildMicrosoftSpeechProvider();
-    const edgeSpy = vi.spyOn(ttsModule, "edgeTTS").mockImplementation(async ({ outputPath }) => {
-      writeFileSync(outputPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
-    });
-
-    await provider.synthesize({
-      text: "你好，这是一个测试 hello",
-      cfg: TEST_CFG,
-      providerConfig: {
-        enabled: true,
-        voice: "en-US-MichelleNeural",
-        lang: "en-US",
-        outputFormat: "audio-24khz-48kbitrate-mono-mp3",
-        outputFormatConfigured: true,
-        saveSubtitles: false,
-      },
-      providerOverrides: {},
-      timeoutMs: 1000,
-      target: "audio-file",
-    });
-
-    expect(edgeSpy).toHaveBeenCalledOnce();
-    const edgeCall = requireFirstEdgeTtsCall(edgeSpy);
-    expect(edgeCall.text).toBe("你好，这是一个测试 hello");
-    expect(path.basename(edgeCall.outputPath)).toBe("speech.mp3");
-    expect(edgeCall.timeoutMs).toBe(1000);
-    expect(edgeCall.config).toEqual({
-      enabled: true,
-      voice: "zh-CN-XiaoxiaoNeural",
-      lang: "zh-CN",
-      outputFormat: "audio-24khz-48kbitrate-mono-mp3",
-      outputFormatConfigured: true,
-      pitch: undefined,
-      rate: undefined,
-      volume: undefined,
-      saveSubtitles: false,
-      proxy: undefined,
-      timeoutMs: undefined,
-    });
-  });
-
-  it("preserves an explicitly configured English voice for CJK text", async () => {
-    const provider = buildMicrosoftSpeechProvider();
-    const edgeSpy = vi.spyOn(ttsModule, "edgeTTS").mockImplementation(async ({ outputPath }) => {
-      writeFileSync(outputPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
-    });
-
-    await provider.synthesize({
-      text: "你好，这是一个测试 hello",
-      cfg: TEST_CFG,
-      providerConfig: {
-        enabled: true,
-        voice: "en-US-AvaNeural",
-        lang: "en-US",
-        outputFormat: "audio-24khz-48kbitrate-mono-mp3",
-        outputFormatConfigured: true,
-        saveSubtitles: false,
-      },
-      providerOverrides: {},
-      timeoutMs: 1000,
-      target: "audio-file",
-    });
-
-    expect(edgeSpy).toHaveBeenCalledOnce();
-    const edgeCall = requireFirstEdgeTtsCall(edgeSpy);
-    expect(edgeCall.text).toBe("你好，这是一个测试 hello");
-    expect(path.basename(edgeCall.outputPath)).toBe("speech.mp3");
-    expect(edgeCall.timeoutMs).toBe(1000);
-    expect(edgeCall.config).toEqual({
-      enabled: true,
+  for (const { name, voice, expectedVoice, expectedLang } of [
+    {
+      name: "switches to a Chinese voice for CJK text when no explicit voice override is set",
+      voice: "en-US-MichelleNeural",
+      expectedVoice: "zh-CN-XiaoxiaoNeural",
+      expectedLang: "zh-CN",
+    },
+    {
+      name: "preserves an explicitly configured English voice for CJK text",
       voice: "en-US-AvaNeural",
-      lang: "en-US",
-      outputFormat: "audio-24khz-48kbitrate-mono-mp3",
-      outputFormatConfigured: true,
-      pitch: undefined,
-      rate: undefined,
-      volume: undefined,
-      saveSubtitles: false,
-      proxy: undefined,
-      timeoutMs: undefined,
+      expectedVoice: "en-US-AvaNeural",
+      expectedLang: "en-US",
+    },
+  ]) {
+    it(name, async () => {
+      const provider = buildMicrosoftSpeechProvider();
+      const edgeSpy = vi.spyOn(ttsModule, "edgeTTS").mockImplementation(async ({ outputPath }) => {
+        writeFileSync(outputPath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+      });
+
+      await provider.synthesize({
+        text: "你好，这是一个测试 hello",
+        cfg: TEST_CFG,
+        providerConfig: {
+          enabled: true,
+          voice,
+          lang: "en-US",
+          outputFormat: "audio-24khz-48kbitrate-mono-mp3",
+          outputFormatConfigured: true,
+          saveSubtitles: false,
+        },
+        providerOverrides: {},
+        timeoutMs: 1000,
+        target: "audio-file",
+      });
+
+      expect(edgeSpy).toHaveBeenCalledOnce();
+      const edgeCall = requireFirstEdgeTtsCall(edgeSpy);
+      expect(edgeCall.text).toBe("你好，这是一个测试 hello");
+      expect(path.basename(edgeCall.outputPath)).toBe("speech.mp3");
+      expect(edgeCall.timeoutMs).toBe(1000);
+      expect(edgeCall.config).toEqual({
+        enabled: true,
+        voice: expectedVoice,
+        lang: expectedLang,
+        outputFormat: "audio-24khz-48kbitrate-mono-mp3",
+        outputFormatConfigured: true,
+        pitch: undefined,
+        rate: undefined,
+        volume: undefined,
+        saveSubtitles: false,
+        proxy: undefined,
+        timeoutMs: undefined,
+      });
     });
-  });
+  }
 });

--- a/extensions/microsoft/tts.test.ts
+++ b/extensions/microsoft/tts.test.ts
@@ -2,7 +2,7 @@
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 let edgeTTS: typeof import("./tts.js").edgeTTS;
 
@@ -19,9 +19,15 @@ const baseEdgeConfig = {
 
 describe("edgeTTS empty audio validation", () => {
   let tempDir: string | undefined;
+  let outputPath: string;
 
   beforeAll(async () => {
     ({ edgeTTS } = await import("./tts.js"));
+  });
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(path.join(tmpdir(), "tts-test-"));
+    outputPath = path.join(tempDir, "voice.mp3");
   });
 
   afterEach(() => {
@@ -31,30 +37,30 @@ describe("edgeTTS empty audio validation", () => {
     }
   });
 
+  function synthesize(tts: ReturnType<typeof createEdgeTTSClient>, text = "Hello") {
+    return edgeTTS(
+      {
+        text,
+        outputPath,
+        config: baseEdgeConfig,
+        timeoutMs: 10000,
+      },
+      tts,
+    );
+  }
+
   it("rejects blank text before calling Edge TTS", async () => {
-    tempDir = mkdtempSync(path.join(tmpdir(), "tts-test-"));
-    const outputPath = path.join(tempDir, "voice.mp3");
     const ttsPromise = vi.fn(async (_text: string, filePath: string) => {
       writeFileSync(filePath, Buffer.from([0xff]));
     });
 
-    await expect(
-      edgeTTS(
-        {
-          text: " \n\t ",
-          outputPath,
-          config: baseEdgeConfig,
-          timeoutMs: 10000,
-        },
-        createEdgeTTSClient(ttsPromise),
-      ),
-    ).rejects.toThrow("Microsoft TTS text cannot be empty");
+    await expect(synthesize(createEdgeTTSClient(ttsPromise), " \n\t ")).rejects.toThrow(
+      "Microsoft TTS text cannot be empty",
+    );
     expect(ttsPromise).not.toHaveBeenCalled();
   });
 
   it("throws after one retry when the output file stays empty", async () => {
-    tempDir = mkdtempSync(path.join(tmpdir(), "tts-test-"));
-    const outputPath = path.join(tempDir, "voice.mp3");
     const calls: string[] = [];
 
     const tts = createEdgeTTSClient(async (text: string, filePath: string) => {
@@ -62,23 +68,11 @@ describe("edgeTTS empty audio validation", () => {
       writeFileSync(filePath, "");
     });
 
-    await expect(
-      edgeTTS(
-        {
-          text: "Hello",
-          outputPath,
-          config: baseEdgeConfig,
-          timeoutMs: 10000,
-        },
-        tts,
-      ),
-    ).rejects.toThrow("Edge TTS produced empty audio file after retry");
+    await expect(synthesize(tts)).rejects.toThrow("Edge TTS produced empty audio file after retry");
     expect(calls).toEqual(["Hello", "Hello"]);
   });
 
   it("succeeds when the output file has content", async () => {
-    tempDir = mkdtempSync(path.join(tmpdir(), "tts-test-"));
-    const outputPath = path.join(tempDir, "voice.mp3");
     let stagedPath = "";
 
     const tts = createEdgeTTSClient(async (_text: string, filePath: string) => {
@@ -86,17 +80,7 @@ describe("edgeTTS empty audio validation", () => {
       writeFileSync(filePath, Buffer.from([0xff, 0xfb, 0x90, 0x00]));
     });
 
-    await expect(
-      edgeTTS(
-        {
-          text: "Hello",
-          outputPath,
-          config: baseEdgeConfig,
-          timeoutMs: 10000,
-        },
-        tts,
-      ),
-    ).resolves.toBeUndefined();
+    await expect(synthesize(tts)).resolves.toBeUndefined();
     expect(stagedPath).not.toBe(outputPath);
     expect(path.basename(stagedPath)).toContain(path.basename(outputPath));
     expect(path.basename(stagedPath)).toMatch(/\.part$/);
@@ -105,8 +89,6 @@ describe("edgeTTS empty audio validation", () => {
   });
 
   it("retries once when the first output file is empty", async () => {
-    tempDir = mkdtempSync(path.join(tmpdir(), "tts-test-"));
-    const outputPath = path.join(tempDir, "voice.mp3");
     const calls: string[] = [];
 
     const tts = createEdgeTTSClient(async (text: string, filePath: string) => {
@@ -114,23 +96,11 @@ describe("edgeTTS empty audio validation", () => {
       writeFileSync(filePath, calls.length === 1 ? "" : Buffer.from([0xff, 0xfb, 0x90, 0x00]));
     });
 
-    await expect(
-      edgeTTS(
-        {
-          text: "Hello",
-          outputPath,
-          config: baseEdgeConfig,
-          timeoutMs: 10000,
-        },
-        tts,
-      ),
-    ).resolves.toBeUndefined();
+    await expect(synthesize(tts)).resolves.toBeUndefined();
     expect(calls).toEqual(["Hello", "Hello"]);
   });
 
   it("retries once when Edge TTS resolves without creating an output file", async () => {
-    tempDir = mkdtempSync(path.join(tmpdir(), "tts-test-"));
-    const outputPath = path.join(tempDir, "voice.mp3");
     const calls: string[] = [];
 
     const tts = createEdgeTTSClient(async (text: string, filePath: string) => {
@@ -140,23 +110,11 @@ describe("edgeTTS empty audio validation", () => {
       }
     });
 
-    await expect(
-      edgeTTS(
-        {
-          text: "Hello",
-          outputPath,
-          config: baseEdgeConfig,
-          timeoutMs: 10000,
-        },
-        tts,
-      ),
-    ).resolves.toBeUndefined();
+    await expect(synthesize(tts)).resolves.toBeUndefined();
     expect(calls).toEqual(["Hello", "Hello"]);
   });
 
   it("does not retry provider errors", async () => {
-    tempDir = mkdtempSync(path.join(tmpdir(), "tts-test-"));
-    const outputPath = path.join(tempDir, "voice.mp3");
     const calls: string[] = [];
 
     const tts = createEdgeTTSClient(async (text: string) => {
@@ -164,17 +122,7 @@ describe("edgeTTS empty audio validation", () => {
       throw new Error("upstream timeout");
     });
 
-    await expect(
-      edgeTTS(
-        {
-          text: "Hello",
-          outputPath,
-          config: baseEdgeConfig,
-          timeoutMs: 10000,
-        },
-        tts,
-      ),
-    ).rejects.toThrow("upstream timeout");
+    await expect(synthesize(tts)).rejects.toThrow("upstream timeout");
     expect(calls).toEqual(["Hello"]);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Microsoft speech tests repeat the same synthesis request and temporary-file setup across cases. The two CJK voice cases also duplicate their setup and assertions, making their differing voice-selection expectations harder to compare.

## Why This Change Was Made

Create a fresh output directory in `beforeEach`, keep its existing `afterEach` cleanup, and share the common synthesis request through a local helper. Register the two CJK cases from explicit voice/language rows while retaining their exact names and assertions. Each case still owns its client, spies, files, and provider; real file staging and publication remain exercised.

## User Impact

No user-visible behavior changes. This removes 79 test lines (+81/-160) with zero production changes. All 15 cases remain, including blank text, empty/no-write retries, provider-error propagation, CJK overrides, and voice discovery. Mocks, deadlines, isolation, concurrency, and sharding are unchanged. No execution-speed improvement or live Microsoft-provider result is claimed.

## Evidence

- Individual proof: all 15 cases passed before, after, and with shuffled execution; exact names and normal per-file order were preserved.
- Combined proof with four separate test cleanups and their siblings: 267 cases registered, 262 passed, and five existing Linux-only daemon cases skipped on macOS. All 15 Microsoft cases passed in that run. This is additional composition proof, not 267 Microsoft tests.
- The full changed-file gate completed successfully. Independent source review found no actionable issue; the combined Codex P0 review reported no findings.
- Hosted CI for this PR is pending.
