### PR TITLE
test: restore native OS module after tool-manager cases

### DIFF
--- a/src/agents/utils/tools-manager.test.ts
+++ b/src/agents/utils/tools-manager.test.ts
@@ -52,6 +52,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.doUnmock("node:os");
   vi.clearAllMocks();
   vi.resetModules();
   vi.unstubAllEnvs();


### PR DESCRIPTION
## What problem does this solve?

The Windows ZIP case in `src/agents/utils/tools-manager.test.ts` registers a `node:os` mock but leaves it registered for the rest of the file. `vi.resetModules()` clears evaluated modules, not the mock registry. An original-order probe on macOS observed `win32/x64` after all 12 cases had finished.

## Why this change?

Add `vi.doUnmock("node:os")` first in the existing `afterEach`, so subsequent imports use the native OS module even when the Windows case throws. Keep the module reset because the tool manager captures its fixture bin directory at import time.

The normal runner already resets module mocks between files. This fixes the case-owned fixture cleanup without changing that runner or the file-wide network/archive/spawn/lock mocks.

## User impact

Test isolation only; production behavior is unchanged. All 12 cases, their order and 40 existing assertion sites remain, including real temporary-file and stream coverage. Production: +0/-0; tests: +1/-0. No timeout, retry, concurrency or sharding changes. No performance improvement or native Windows support is claimed.

## Evidence

- Six sequential phases used the normal `node scripts/run-vitest.mjs src/agents/utils/tools-manager.test.ts` route. Uninstrumented original and candidate each passed all 12 cases.
- The original external postcondition probe passed those 12 cases but failed in `afterAll`: the OS module still reported `win32` on the `darwin/arm64` host. The candidate passed the cases and postcondition, including native OS function identity checks.
- An intentional throw after the Windows case's original assertions left the original with both that case failure and the OS postcondition failure. The candidate had only the intentional failure; all six later cases still executed and passed. These controls were expected nonzero runs.
- Final composed validation included all 71 tools-manager/find/grep cases passing. The wider run finished with 262 passed and five existing daemon platform skips, 267 registered cases total.
- Full changed checks passed. Independent source/runtime evidence reviews found no actionable issue; the scoped Codex P0 review was clean.

## Review follow-up

The installed Vitest 4.1.11 implementation and types were inspected directly: `doUnmock` queues registry removal, pending mock actions resolve before the next module fetch, and unmocking invalidates the cached mocked exports. `resetModules` alone does not clear that registry. This closes the dependency-inspection gap noted by ClawSweeper and agrees with the original/candidate failure probes above. No dependency change is needed.

A fresh composed run on landed main `22dcf4cffbfc` also passed all 71 original tools-manager/find/grep cases plus seven path-resolution cases, with one existing Windows-only path case skipped on macOS (79 registered). This follows direct inspection of main’s separate literal-`@` path correction; the test cleanup preserves it. No native Windows or new full changed-gate result is inferred.
