### PR TITLE
test: consolidate link-understanding runner cases

### DIFF
--- a/src/link-understanding/runner.test.ts
+++ b/src/link-understanding/runner.test.ts
@@ -212,35 +212,37 @@ describe("runLinkUnderstanding", () => {
     expect(runCommandWithTimeout).not.toHaveBeenCalled();
   });
 
-  it("skips links rejected by the guarded fetch DNS policy", async () => {
-    mocks.fetchWithSsrFGuard.mockRejectedValueOnce(
-      new Error("Blocked: resolves to private/internal/special-use IP address"),
-    );
+  it.each([
+    [
+      "skips links rejected by the guarded fetch DNS policy",
+      "http://169.254.169.254.nip.io/latest/meta-data/",
+      "Blocked: resolves to private/internal/special-use IP address",
+    ],
+    [
+      "skips links rejected by the guarded fetch redirect policy",
+      "https://public.example/redirect-to-metadata",
+      "redirect target resolves to private network",
+    ],
+  ])("%s", async (_name, url, errorMessage) => {
+    mocks.fetchWithSsrFGuard.mockRejectedValueOnce(new Error(errorMessage));
 
     const result = await runLinkUnderstanding({
       cfg: cfg({ type: "cli", command: "summarize" }),
-      ctx: ctx("see http://169.254.169.254.nip.io/latest/meta-data/"),
+      ctx: ctx(`see ${url}`),
     });
 
     expect(result.outputs).toEqual([]);
     expect(runCommandWithTimeout).not.toHaveBeenCalled();
   });
 
-  it("skips links rejected by the guarded fetch redirect policy", async () => {
-    mocks.fetchWithSsrFGuard.mockRejectedValueOnce(
-      new Error("redirect target resolves to private network"),
-    );
-
-    const result = await runLinkUnderstanding({
-      cfg: cfg({ type: "cli", command: "summarize" }),
-      ctx: ctx("see https://public.example/redirect-to-metadata"),
-    });
-
-    expect(result.outputs).toEqual([]);
-    expect(runCommandWithTimeout).not.toHaveBeenCalled();
-  });
-
-  it("uses the global link-tools timeout for fetches when configured", async () => {
+  it.each([
+    [
+      "uses the global link-tools timeout for fetches when configured",
+      { timeoutSeconds: 15 },
+      15000,
+    ],
+    ["falls back to the largest model timeout for fetches when no global timeout is set", {}, 9000],
+  ] as const)("%s", async (_name, timeoutConfig, timeoutMs) => {
     mockGuardedFetch("page body", "https://example.com/final");
     mockCommand("summarized page");
 
@@ -249,7 +251,7 @@ describe("runLinkUnderstanding", () => {
         tools: {
           links: {
             enabled: true,
-            timeoutSeconds: 15,
+            ...timeoutConfig,
             models: [
               { type: "cli", command: "summarize-fast", timeoutSeconds: 1 },
               { type: "cli", command: "summarize-slow", timeoutSeconds: 9 },
@@ -262,34 +264,7 @@ describe("runLinkUnderstanding", () => {
 
     expect(fetchWithSsrFGuard).toHaveBeenCalledWith(
       expect.objectContaining({
-        timeoutMs: 15000,
-        url: "https://example.com/page",
-      }),
-    );
-  });
-
-  it("falls back to the largest model timeout for fetches when no global timeout is set", async () => {
-    mockGuardedFetch("page body", "https://example.com/final");
-    mockCommand("summarized page");
-
-    await runLinkUnderstanding({
-      cfg: {
-        tools: {
-          links: {
-            enabled: true,
-            models: [
-              { type: "cli", command: "summarize-fast", timeoutSeconds: 1 },
-              { type: "cli", command: "summarize-slow", timeoutSeconds: 9 },
-            ],
-          },
-        },
-      } as OpenClawConfig,
-      ctx: ctx("see https://example.com/page"),
-    });
-
-    expect(fetchWithSsrFGuard).toHaveBeenCalledWith(
-      expect.objectContaining({
-        timeoutMs: 9000,
+        timeoutMs,
         url: "https://example.com/page",
       }),
     );


### PR DESCRIPTION
## What Problem This Solves

Link-understanding tests duplicate the setup and assertions for two guarded-fetch rejection cases and two fetch-timeout selection cases. The repetition obscures which inputs distinguish each regression.

## Why This Change Was Made

Use two local tables with the original test titles, URLs, error messages, and assertions. The timeout rows retain an explicitly configured 15-second global timeout versus an absent global option, with the same 1-second and 9-second model entries. Every row still creates fresh config and mock results and calls the real runner.

## User Impact

No user-visible behavior changes. This removes 25 test lines (+24/-49) with zero production changes. All 12 runner cases remain. The real unfinished-response transport test still verifies body cancellation before release, socket closure, and server teardown. Mocks, deadlines, isolation, concurrency, and sharding are unchanged; no execution-speed improvement is claimed.

## Evidence

- Individual scope: all 24 runner, detector, and transport cases passed before the change and after the final formatted candidate; the same 24 passed with shuffle seed `133876`. Exact names, statuses, and normal per-file order were preserved.
- The final ordinary after-run also included four separate test cleanups and siblings: 267 cases registered, 262 passed, and five existing Linux-only daemon cases skipped on macOS. All 24 link cases passed. This combined result is separate from the shuffled run.
- The full changed-file gate completed successfully. Independent source review found no actionable issue; the combined Codex P0 review reported no findings.
- Guard-rejection rows retain their existing mocks; the unchanged transport sibling supplies real local HTTP cancellation coverage, not live external-service proof.

## Hosted CI follow-up

The first exact-head run [33373127173](https://github.com/openclaw/openclaw/actions/runs/33373127173/job/99428739249) failed an unchanged Control UI workspace-icon assertion: expected two fetches, observed four. That job does not execute the Link runner test. The complete failed log and source comparison were retained; no timeout, assertion, or mock was weakened.

The original 269-file UI group passed locally with the same two-worker setting (3,605 passed, 53 unchanged skips). Temporary request logging observed exactly two requests to the intended recovery route, so that local result does not reproduce or repair the Linux failure. The original fixture bytes were restored after the diagnostic.

The mechanical refresh adopts main's [#133942](https://github.com/openclaw/openclaw/pull/133942), which adds request-category assertion messages while preserving counts and timing. It is diagnostic support, not a claimed fix; the intermittent UI failure remains a named follow-up. The Link patch and reviewed test afterimage remain byte-identical. All 24 focused cases passed again on refreshed head `6318f5cc136ab9f97db4e30910747d4884de77cd`. The refreshed exact-head [CI run 33376708173](https://github.com/openclaw/openclaw/actions/runs/33376708173) completed successfully. The completed ClawSweeper review on that head and the retained prior review were read in full; no unresolved earlier rank-up move remains.
