### PR TITLE
test: share broad tooling routing assertions

### DIFF
--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -2024,8 +2024,11 @@ describe("scripts/test-projects changed-target routing", () => {
     ]);
   });
 
-  it("chunks the broad shell helper tooling shard after isolated targets", () => {
-    const plans = buildVitestRunPlans(["test/scripts"], process.cwd());
+  it.each([
+    ["chunks the broad shell helper tooling shard after isolated targets", "test/scripts"],
+    ["chunks broad shell helper globs after isolated targets", "test/scripts/*.test.ts"],
+  ])("%s", (_title, target) => {
+    const plans = buildVitestRunPlans([target], process.cwd());
     expect(plans.slice(0, 4)).toEqual([
       expect.objectContaining({
         config: "test/vitest/vitest.unit-fast.config.ts",
@@ -2212,70 +2215,6 @@ describe("scripts/test-projects changed-target routing", () => {
     expect(() => buildVitestRunPlans(["--watch", "src/cli"])).toThrow(
       "watch mode with mixed test suites is not supported",
     );
-  });
-
-  it("chunks broad shell helper globs after isolated targets", () => {
-    const plans = buildVitestRunPlans(["test/scripts/*.test.ts"], process.cwd());
-    expect(plans.slice(0, 4)).toEqual([
-      expect.objectContaining({
-        config: "test/vitest/vitest.unit-fast.config.ts",
-        includePatterns: expect.arrayContaining(["test/scripts/arg-utils.test.ts"]),
-        watchMode: false,
-      }),
-      {
-        config: "test/vitest/vitest.unit-fast-isolated.config.ts",
-        forwardedArgs: [],
-        includePatterns: [
-          "test/scripts/android-version.test.ts",
-          "test/scripts/ios-release-plan.test.ts",
-        ],
-        watchMode: false,
-      },
-      {
-        config: "test/vitest/vitest.tooling-docker.config.ts",
-        forwardedArgs: [],
-        includePatterns: ["test/scripts/docker-build-helper.test.ts"],
-        watchMode: false,
-      },
-      {
-        config: "test/vitest/vitest.tooling-isolated.config.ts",
-        forwardedArgs: [],
-        includePatterns: [
-          "test/scripts/check-extension-package-tsc-boundary.test.ts",
-          "test/scripts/check-plugin-sdk-wildcard-reexports.test.ts",
-          "test/scripts/control-ui-i18n.test.ts",
-          "test/scripts/openclaw-e2e-instance.test.ts",
-          "test/scripts/test-projects-build-admission.test.ts",
-          "test/scripts/vitest-fork-shutdown.test.ts",
-        ],
-        watchMode: false,
-      },
-    ]);
-    const e2ePlans = plans.filter((plan) => plan.config === "test/vitest/vitest.e2e.config.ts");
-    const toolingPlans = plans
-      .slice(4)
-      .filter((plan) => plan.config === "test/vitest/vitest.tooling.config.ts");
-    const toolingTargets = toolingPlans.flatMap((plan) => plan.includePatterns ?? []);
-
-    expect(toolingPlans.length).toBeGreaterThan(1);
-    expect(toolingPlans.every((plan) => (plan.includePatterns?.length ?? 0) <= 60)).toBe(true);
-    expect(toolingTargets).toContain("test/scripts/run-opengrep.test.ts");
-    expect(toolingTargets).not.toContain("test/scripts/docker-build-helper.test.ts");
-    expect(toolingTargets).not.toContain("test/scripts/openclaw-e2e-instance.test.ts");
-    expect(new Set(toolingTargets).size).toBe(toolingTargets.length);
-    expect(e2ePlans).toEqual([
-      {
-        config: "test/vitest/vitest.e2e.config.ts",
-        forwardedArgs: [
-          "test/scripts/doctor-config-preflight-plugin-index.built-cli.e2e.test.ts",
-          "test/scripts/mcp-channels-seed.built-cli.e2e.test.ts",
-          "test/scripts/sqlite-sessions-transcripts-flip-proof.built-cli.e2e.test.ts",
-          "test/scripts/sqlite-sessions-transcripts-flip-proof.e2e.test.ts",
-        ],
-        includePatterns: null,
-        watchMode: false,
-      },
-    ]);
   });
 
   it("keeps broad shell helper watch targets in one tooling shard", () => {


### PR DESCRIPTION
## What Problem This Solves

The test-project planner’s broad-directory and flat-glob cases duplicate the same 60-line assertion body. Keeping two copies makes routing expectations easier to update inconsistently.

## Why This Change Was Made

Use one two-row table with both original case names and inputs: `test/scripts` and `test/scripts/*.test.ts`. Each case still calls the real planner once and runs all eight original assertions. Exact owner-plan order, tooling chunk bounds, required inclusions/exclusions, uniqueness and the E2E forwarding plan remain unchanged. The separate routing suite is retained in full.

The glob case now runs immediately after the directory case, moving across five unchanged planning/watch cases. The suite’s existing hook and all configuration, fixtures and expected literals are unchanged.

## User Impact

No user-facing or runtime behavior change. Tests have 61 fewer lines (+5/-66); production LOC is unchanged. This is a maintenance cleanup, not a measured execution-time improvement. No test selection, sharding, concurrency, deadline, retry or mock change.

## Evidence

- Normal repository-wrapper runs before and after pass all 450 cases: 367 in `test-projects.test.ts` and 83 in `test-projects-routing.test.ts`.
- Full case names and statuses are preserved. Moving the glob case from zero-based index 176 to 171 accounts for the entire owning-file ordering difference; the routing file’s order is unchanged.
- A shuffled repeat with seed 73 passes the same 450-case inventory. Verbose output confirms different execution order in both files.
- Independent source and runtime-artifact reviews confirm both inputs, two planner calls and all 16 assertions remain. Complete planner/CLI owners, routing and admission siblings, config/classification owners and the installed Vitest registration/title formatter were inspected.
- Codex autoreview completed with no actionable findings at its configured P0 threshold.

The full changed gate passed on Blacksmith Testbox, including test-root typechecking and script lint. The one-shot lease stopped successfully and its temporary checkout was removed. Exact-head [CI run 33373158583](https://github.com/openclaw/openclaw/actions/runs/33373158583) subsequently completed successfully. Fresh compositions at afd1 and landed main 22dcf4cffbfc both passed all 450 cases with identical per-file names, order and statuses. The latter preserves the canonical build-stamp ownership mapping from #133974. These focused runs are separate from the earlier full changed gate.
