### PR TITLE
test(build): import stamp writers from their shared owner

### DIFF
--- a/scripts/build-stamp.mts
+++ b/scripts/build-stamp.mts
@@ -1,11 +1,8 @@
 #!/usr/bin/env node
 
-// Writes the local build stamp and re-exports build metadata helpers.
 import process from "node:process";
 import { pathToFileURL } from "node:url";
 import { writeBuildStamp } from "./lib/local-build-metadata.mts";
-
-export { BUILD_STAMP_FILE, resolveGitHead, writeBuildStamp } from "./lib/local-build-metadata.mts";
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   try {

--- a/scripts/runtime-postbuild-stamp.mts
+++ b/scripts/runtime-postbuild-stamp.mts
@@ -4,11 +4,6 @@ import process from "node:process";
 import { pathToFileURL } from "node:url";
 import { writeRuntimePostBuildStamp } from "./lib/local-build-metadata.mts";
 
-export {
-  RUNTIME_POSTBUILD_STAMP_FILE,
-  writeRuntimePostBuildStamp,
-} from "./lib/local-build-metadata.mts";
-
 if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
   try {
     writeRuntimePostBuildStamp();

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -2193,6 +2193,7 @@ const EXACT_TOOLING_TARGETS = new Map<string, string[]>([
       "src/channels/plugins/contracts/channel-import-guardrails.test.ts",
     ],
   ],
+  ["scripts/build-stamp.mts", ["src/infra/build-stamp.test.ts"]],
   ["scripts/run-vitest.mjs", ["run-vitest", "test-projects", "vitest-local-scheduling"]],
   ["scripts/run-vitest.mts", ["run-vitest", "test-projects", "vitest-local-scheduling"]],
   ["scripts/run-oxlint-shards.mts", ["run-oxlint"]],

--- a/src/infra/build-stamp.test.ts
+++ b/src/infra/build-stamp.test.ts
@@ -1,8 +1,7 @@
-// Tests build stamp file parsing and fallback behavior.
 import fs from "node:fs/promises";
 import { describe, expect, it } from "vitest";
-import { writeBuildStamp } from "../../scripts/build-stamp.mts";
 import { BUILD_STAMP_FILE } from "../../scripts/lib/local-build-metadata-paths.mts";
+import { writeBuildStamp } from "../../scripts/lib/local-build-metadata.mts";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 
 describe("build-stamp script", () => {

--- a/test/scripts/runtime-postbuild-stamp.test.ts
+++ b/test/scripts/runtime-postbuild-stamp.test.ts
@@ -1,9 +1,8 @@
-// Runtime Postbuild Stamp tests cover runtime postbuild stamp script behavior.
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { RUNTIME_POSTBUILD_STAMP_FILE } from "../../scripts/lib/local-build-metadata-paths.mts";
-import { writeRuntimePostBuildStamp } from "../../scripts/runtime-postbuild-stamp.mts";
+import { writeRuntimePostBuildStamp } from "../../scripts/lib/local-build-metadata.mts";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 describe("runtime-postbuild-stamp script", () => {


### PR DESCRIPTION
## What Problem This Solves

Build-stamp tests import their writers through CLI entrypoints, keeping unused re-exports on those commands. The changed-file runner also relied on that incidental test import to select the build-stamp regression test.

## Why This Change Was Made

Import both writers directly from their shared metadata owner and remove the CLI re-exports and inaccurate test headers. Record the build-stamp CLI’s existing regression-test owner in the selector’s exact map, since that test lives outside its conventional tooling directories. The runtime-postbuild sibling keeps its existing conventional route.

## User Impact

The CLI entry guards, execution, error handling and artifact writers stay unchanged. Both filesystem tests retain every assertion and fixture, and changed-file execution retains its narrow regression target. Tooling +1/-8 (net -7); tests +2/-4 (net -2); product runtime unchanged.

## Evidence

Both complete writer tests passed before and after (2 → 2). Both real CLI entrypoints also passed before and after in a temporary working directory, writing the expected timestamp fields, Git-head absence and trailing newlines. The canonical writer and packaging-path contracts were inspected.

The first hosted run, [33373379861](https://github.com/openclaw/openclaw/actions/runs/33373379861), caught the lost selector edge: the existing build-stamp routing assertion expected `src/infra/build-stamp.test.ts` but received the broad tooling config. The repair preserves that assertion and adds the missing exact owner. It does not restore a test facade, introduce a fake import, or broaden discovery.

On the refreshed main composition, the unchanged routing regression reproduced the same failure before the map repair. After the repair, all 367 selector cases and both writer cases passed (369 total). Direct selector checks preserve the exact build-stamp target, the conventional runtime-postbuild target and all nine shared-metadata targets. Fresh Codex review found no actionable findings in its configured scope. The full changed-file gate also passed. Exact refreshed head `97bb4b125e5d` passed [CI33379626153](https://github.com/openclaw/openclaw/actions/runs/33379626153), including the CI gate.

The review’s generic stored-data warning does not describe a changed data contract here: stamp writer implementation and serialized artifact formats are unchanged; no vector/embedding metadata or SQLite store is modified.
