### PR TITLE
test(searxng): remove an unused normalization test exposure

### DIFF
--- a/extensions/searxng/src/searxng-client.ts
+++ b/extensions/searxng/src/searxng-client.ts
@@ -1,4 +1,3 @@
-// Searxng plugin module implements searxng client behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   DEFAULT_CACHE_TTL_MINUTES,
@@ -329,7 +328,6 @@ export async function runSearxngSearch(params: {
 
 export const testing = {
   buildSearxngSearchUrl,
-  normalizeSearxngResult,
   parseSearxngResponseText,
   shouldRetryEmptyCategorySearchWithGeneral,
   validateSearxngBaseUrl,


### PR DESCRIPTION
## What Problem This Solves

SearXNG exposes a result-normalization helper through its private test object even though no test or caller consumes that property. The meaningful normalization checks already exercise the parser that owns the behavior.

## Why This Change Was Made

Remove the unused property while retaining the normalizer and its parser call. Also remove the adjacent generic module header. The public provider factory, search implementation and consumed test helpers stay intact.

## User Impact

No user-visible behavior change. This removes an unused test surface without deleting any test case, fixture or assertion. Runtime behavior delta: zero; test-only exposure: -1 line; comment: -1 line; tests: unchanged.

## Evidence

All three complete SearXNG suites passed before and after: 29 cases each. They retain malformed-row, image-result, count-limit and invalid-JSON checks, plus real loopback HTTP, cache-TTL and aborted-socket coverage. Repository-wide references and public entrypoints were inspected; no consumer or public contract uses the removed property.

The complete changed-file gate passed, and Codex review returned no actionable findings in its selected scope. Exact-head hosted CI run 33373519810 passed. The latest completed ClawSweeper review was read in full: its requested hosted-CI completion and latest-comment check are both satisfied, with no remaining actionable finding. The normal native workflow will recheck current-main owner coverage before landing.
