### PR TITLE
fix(node): fence cancelled worker bundle installation

### DIFF
--- a/src/node-host/node-worker-bundle-installer.test.ts
+++ b/src/node-host/node-worker-bundle-installer.test.ts
@@ -22,6 +22,7 @@ describe("node worker bundle installer", () => {
   });
 
   afterEach(async () => {
+    vi.restoreAllMocks();
     await new Promise<void>((resolve) => {
       if (!server) {
         resolve();
@@ -115,6 +116,132 @@ describe("node worker bundle installer", () => {
     }
     return { gatewayUrl: `ws://127.0.0.1:${address.port}`, requests };
   }
+
+  it("does not publish a bundle when cancellation arrives during receipt staging", async () => {
+    const fixture = await bundleFixture();
+    const served = await serve(fixture.archive, fixture.input.archive.token);
+    const installer = new NodeWorkerBundleInstaller({ root });
+    const controller = new AbortController();
+    const open = fs.open.bind(fs);
+    vi.spyOn(fs, "open").mockImplementation(async (...args) => {
+      const handle = await open(...args);
+      if (String(args[0]).endsWith("bootstrap-receipt.json") && args[1] === "wx") {
+        controller.abort(new Error("installer cancelled"));
+      }
+      return handle;
+    });
+
+    await expect(
+      installer.ensure({
+        input: fixture.input,
+        gatewayUrl: served.gatewayUrl,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("installer cancelled");
+    expect(served.requests).toHaveBeenCalledOnce();
+    await expect(
+      fs.readdir(path.join(root, fixture.input.gatewayNamespace, "bundles")),
+    ).resolves.toEqual([]);
+  });
+
+  it("restores the prior destination when cancelled between publication renames", async () => {
+    const fixture = await bundleFixture();
+    const served = await serve(fixture.archive, fixture.input.archive.token);
+    const installer = new NodeWorkerBundleInstaller({ root });
+    const bundlesRoot = path.join(root, fixture.input.gatewayNamespace, "bundles");
+    const destination = path.join(bundlesRoot, fixture.input.build.bundleHash);
+    await fs.mkdir(destination, { recursive: true });
+    await fs.writeFile(path.join(destination, "prior-install"), "preserved");
+    const controller = new AbortController();
+    const rename = fs.rename.bind(fs);
+    vi.spyOn(fs, "rename").mockImplementation(async (...args) => {
+      await rename(...args);
+      if (args[0] === destination && String(args[1]).includes(".previous-")) {
+        controller.abort(new Error("publication cancelled"));
+      }
+    });
+
+    await expect(
+      installer.ensure({
+        input: fixture.input,
+        gatewayUrl: served.gatewayUrl,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("publication cancelled");
+
+    await expect(fs.readdir(bundlesRoot)).resolves.toEqual([fixture.input.build.bundleHash]);
+    await expect(fs.readdir(destination)).resolves.toEqual(["prior-install"]);
+    await expect(fs.readFile(path.join(destination, "prior-install"), "utf8")).resolves.toBe(
+      "preserved",
+    );
+  });
+
+  it("does not renew retention when cancelled while validating an installed bundle", async () => {
+    const fixture = await bundleFixture();
+    const served = await serve(fixture.archive, fixture.input.archive.token);
+    const installer = new NodeWorkerBundleInstaller({ root });
+    await installer.ensure({ input: fixture.input, gatewayUrl: served.gatewayUrl });
+    const controller = new AbortController();
+    const stat = fs.stat.bind(fs);
+    vi.spyOn(fs, "stat").mockImplementation(async (...args) => {
+      const result = await stat(...args);
+      if (String(args[0]).endsWith("worker.mjs")) {
+        controller.abort(new Error("cached install cancelled"));
+      }
+      return result;
+    });
+
+    await expect(
+      installer.ensure({
+        input: fixture.input,
+        gatewayUrl: served.gatewayUrl,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("cached install cancelled");
+
+    expect(served.requests).toHaveBeenCalledOnce();
+    await expect(
+      installer.retain({
+        gatewayNamespace: fixture.input.gatewayNamespace,
+        bundleHashes: [fixture.input.build.bundleHash],
+      }),
+    ).resolves.toEqual({ deleted: 0, hasMore: false, generation: 1 });
+  });
+
+  it("rejects cancellation during final cleanup without renewing retention or removing published bytes", async () => {
+    const fixture = await bundleFixture();
+    const served = await serve(fixture.archive, fixture.input.archive.token);
+    const installer = new NodeWorkerBundleInstaller({ root });
+    const controller = new AbortController();
+    const rm = fs.rm.bind(fs);
+    vi.spyOn(fs, "rm").mockImplementation(async (...args) => {
+      await rm(...args);
+      if (path.basename(String(args[0])).startsWith(".staging-")) {
+        controller.abort(new Error("install cleanup cancelled"));
+      }
+    });
+
+    await expect(
+      installer.ensure({
+        input: fixture.input,
+        gatewayUrl: served.gatewayUrl,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow("install cleanup cancelled");
+
+    await expect(
+      installer.inspect({
+        gatewayNamespace: fixture.input.gatewayNamespace,
+        bundleHash: fixture.input.build.bundleHash,
+      }),
+    ).resolves.toEqual({ bundleHash: fixture.input.build.bundleHash, status: "installed" });
+    await expect(
+      installer.retain({
+        gatewayNamespace: fixture.input.gatewayNamespace,
+        bundleHashes: [fixture.input.build.bundleHash],
+      }),
+    ).resolves.toEqual({ deleted: 0, hasMore: false, generation: 0 });
+  });
 
   it("atomically installs, reuses, and cleans prior-hash crash staging", async () => {
     const prewarmMarker = path.join(root, "worker-prewarmed");

--- a/src/node-host/node-worker-bundle-installer.ts
+++ b/src/node-host/node-worker-bundle-installer.ts
@@ -170,9 +170,14 @@ async function removeStaleInstallStaging(bundlesRoot: string): Promise<void> {
   );
 }
 
-async function publishBundle(destination: string, staging: string): Promise<void> {
+async function publishBundle(
+  destination: string,
+  staging: string,
+  signal?: AbortSignal,
+): Promise<void> {
   const prior = `${destination}.previous-${process.pid}-${randomUUID()}`;
   let movedPrior = false;
+  signal?.throwIfAborted();
   try {
     await fsp.rename(destination, prior);
     movedPrior = true;
@@ -182,6 +187,8 @@ async function publishBundle(destination: string, staging: string): Promise<void
     }
   }
   try {
+    // Cancellation after moving the old install must restore it through the same rollback path.
+    signal?.throwIfAborted();
     await fsp.rename(staging, destination);
   } catch (error) {
     if (movedPrior) {
@@ -257,54 +264,57 @@ export class NodeWorkerBundleInstaller {
         params.signal?.throwIfAborted();
         const bundlesRoot = path.join(this.#root, input.gatewayNamespace, "bundles");
         const destination = path.join(bundlesRoot, input.build.bundleHash);
-        if (await validateInstalledBundle(destination, input.build)) {
-          if (input.bundlePrewarm) {
-            await this.#prewarmBundle(destination, params.signal);
-          }
-          this.#markPendingRetention(input.gatewayNamespace, input.build.bundleHash);
-          return structuredClone(input.build);
-        }
-        await fsp.mkdir(bundlesRoot, { recursive: true, mode: 0o700 });
-        await removeStaleInstallStaging(bundlesRoot);
-        const operationRoot = await fsp.mkdtemp(
-          path.join(bundlesRoot, `.staging-${input.build.bundleHash}-`),
-        );
-        try {
-          const archivePath = path.join(operationRoot, "bundle.tgz");
-          const staging = path.join(operationRoot, "root");
-          await downloadBundle({
-            gatewayUrl: params.gatewayUrl,
-            gatewayTlsFingerprint: params.gatewayTlsFingerprint,
-            gatewayCloudflareAccess: params.gatewayCloudflareAccess,
-            input,
-            destination: archivePath,
-            signal: params.signal,
-          });
-          await extractWorkerBundleArchive({
-            tarballPath: archivePath,
-            destination: staging,
-            expectedBundleHash: input.build.bundleHash,
-            limits: DEFAULT_WORKER_BUNDLE_ARCHIVE_LIMITS,
-          });
-          const receipt = await fsp.open(path.join(staging, INSTALL_RECEIPT), "wx", 0o600);
+        const installed = await validateInstalledBundle(destination, input.build);
+        params.signal?.throwIfAborted();
+        if (!installed) {
+          await fsp.mkdir(bundlesRoot, { recursive: true, mode: 0o700 });
+          await removeStaleInstallStaging(bundlesRoot);
+          const operationRoot = await fsp.mkdtemp(
+            path.join(bundlesRoot, `.staging-${input.build.bundleHash}-`),
+          );
           try {
-            await receipt.writeFile(`${JSON.stringify(input.build)}\n`);
-            await receipt.sync();
+            const archivePath = path.join(operationRoot, "bundle.tgz");
+            const staging = path.join(operationRoot, "root");
+            params.signal?.throwIfAborted();
+            await downloadBundle({
+              gatewayUrl: params.gatewayUrl,
+              gatewayTlsFingerprint: params.gatewayTlsFingerprint,
+              gatewayCloudflareAccess: params.gatewayCloudflareAccess,
+              input,
+              destination: archivePath,
+              signal: params.signal,
+            });
+            params.signal?.throwIfAborted();
+            await extractWorkerBundleArchive({
+              tarballPath: archivePath,
+              destination: staging,
+              expectedBundleHash: input.build.bundleHash,
+              limits: DEFAULT_WORKER_BUNDLE_ARCHIVE_LIMITS,
+            });
+            params.signal?.throwIfAborted();
+            const receipt = await fsp.open(path.join(staging, INSTALL_RECEIPT), "wx", 0o600);
+            try {
+              params.signal?.throwIfAborted();
+              await receipt.writeFile(`${JSON.stringify(input.build)}\n`);
+              await receipt.sync();
+            } finally {
+              await receipt.close();
+            }
+            await publishBundle(destination, staging, params.signal);
+            if (!(await validateInstalledBundle(destination, input.build))) {
+              throw new Error("published worker bundle failed validation");
+            }
           } finally {
-            await receipt.close();
+            await fsp.rm(operationRoot, { recursive: true, force: true });
           }
-          await publishBundle(destination, staging);
-          if (!(await validateInstalledBundle(destination, input.build))) {
-            throw new Error("published worker bundle failed validation");
-          }
-          if (input.bundlePrewarm) {
-            await this.#prewarmBundle(destination, params.signal);
-          }
-          this.#markPendingRetention(input.gatewayNamespace, input.build.bundleHash);
-          return structuredClone(input.build);
-        } finally {
-          await fsp.rm(operationRoot, { recursive: true, force: true });
         }
+        params.signal?.throwIfAborted();
+        if (input.bundlePrewarm) {
+          await this.#prewarmBundle(destination, params.signal);
+        }
+        params.signal?.throwIfAborted();
+        this.#markPendingRetention(input.gatewayNamespace, input.build.bundleHash);
+        return structuredClone(input.build);
       } catch (error) {
         if (error instanceof NodeWorkerBundleInstallError) {
           throw error;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where cancelling a cloud worker startup could still publish its worker bundle or report a successful installation after cancellation. Reusing an installed bundle could also renew its pending retention after the invocation was cancelled.

## Why This Change Was Made

The installer checked cancellation before entering the operation and during prewarming, but filesystem work could finish after cancellation and continue into publication or success. Fresh and cached installs now share one completion path that checks cancellation before prewarming, retention updates, and returning the build receipt; publication also restores the previous directory if cancellation arrives between its two renames.

## User Impact

Cancelled installs report failure without claiming successful preparation or extending retention. Cancellation before publication leaves no new installed bundle; late cancellation preserves an already published, validated bundle for subsequent use. The existing archive verification, authenticated transfer, namespace serialization, and receipt format are unchanged.

## Evidence

On an isolated Linux Testbox at base `01eb7d52384ab3af432d4286c8f0eb7723aa1f01`, all four new regressions failed against the original installer because the cancelled operation resolved successfully. With the fix, the full installer suite passed: **16 tests**, including existing integrity, retention, platform-mode, and prewarm cancellation coverage.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/node-host/node-worker-bundle-installer.test.ts
```

The regressions use real temporary archives, loopback HTTP, and filesystem operations, with narrow fault injection at receipt staging, publication rename, cached validation, and final cleanup. This is deterministic installer-boundary proof, not an authenticated end-to-end cloud cancellation run. Independent source review and Codex autoreview found no actionable findings.

Production changes are +55/-45 lines (net +10); tests are +127 lines. Consolidating duplicate completion paths offsets the cancellation fences required at asynchronous ownership boundaries.

Exact-head [hosted CI](https://github.com/openclaw/openclaw/actions/runs/33373679052) passed for `8252addaa9c0059426ed589256f9c31d00e2daf0`, including build, lint, production/test types, static guards, Linux/Windows tests, and `openclaw/ci-gate`. Fresh pre-landing Codex autoreview also found no actionable findings. Native preparation and merge remain pending.
