### PR TITLE
fix(reply): report failures after a turn is accepted

### DIFF
--- a/docs/concepts/messages.md
+++ b/docs/concepts/messages.md
@@ -116,6 +116,8 @@ Details: [Command queue](/concepts/queue) and [Steering queue](/concepts/queue-s
 
 Channel plugins may preserve ordering, debounce input, and apply transport backpressure before a message enters the session queue. They should not impose a separate timeout around the agent turn itself. Once a message is routed to a session, the session, tool, and runtime lifecycle govern long-running work so all channels report and recover from slow turns consistently.
 
+Once a turn is durably accepted, an unexpected failure before its answer produces a compact error reply in direct chats and explicitly addressed conversations where automatic replies are enabled. Progress acknowledgments do not replace that final outcome. The turn remains failed and is not replayed as a new inbound message; delivery policies and replies already sent through the message tool still apply.
+
 ## Streaming, chunking, and batching
 
 Block streaming sends partial replies as the model produces text blocks; chunking respects channel text limits and avoids splitting fenced code.

--- a/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.dynamic-tools.test.ts
@@ -98,6 +98,7 @@ describe("runCodexAppServerAttempt dynamic tools", () => {
         path.join(tempDir, "session.jsonl"),
         path.join(tempDir, "workspace"),
       );
+      params.runtimePlan = createCodexRuntimePlanFixture();
       params.timeoutMs = waitMs + 120_000;
       setCodexTestModelSupportsTools(params, true);
       const closeHostCapabilities = await bindProductionHarnessHostCapabilitiesForTest(params);

--- a/qa/scenarios/channels/provider-http-503-visible-failure.yaml
+++ b/qa/scenarios/channels/provider-http-503-visible-failure.yaml
@@ -35,6 +35,7 @@ scenario:
     - extensions/qa-lab/src/providers/mock-openai/server.ts
   execution:
     kind: flow
+    retryCount: 0
     channel: qa-channel
     summary: Run one channel turn whose mock provider returns HTTP 503 after a tool result, then verify one sanitized reply and no tool replay.
     config:
@@ -73,14 +74,18 @@ flow:
             senderName: Alice
             text:
               expr: config.prompt
-        - call: waitForOutboundMessage
+        - call: state.waitFor
           saveAs: outbound
           args:
-            - ref: state
-            - lambda:
-                params: [candidate]
-                expr: "candidate.conversation.id === config.conversationId && candidate.conversation.kind === 'channel' && String(candidate.text ?? '') === config.expectedReply"
-            - expr: liveTurnTimeoutMs(env, 180000)
+            - kind: message-text
+              direction: outbound
+              textIncludes:
+                ref: config.expectedReply
+              timeoutMs:
+                expr: liveTurnTimeoutMs(env, 180000)
+        - assert:
+            expr: "!outbound.deleted && outbound.conversation.id === config.conversationId && outbound.conversation.kind === 'channel' && outbound.isError === true && outbound.text === config.expectedReply"
+            message: expected one classified provider failure on the original conversation
         - call: sleep
           args:
             - expr: liveTurnTimeoutMs(env, 8000)

--- a/src/auto-reply/reply/dispatch-from-config.execute.ts
+++ b/src/auto-reply/reply/dispatch-from-config.execute.ts
@@ -2,6 +2,7 @@ import {
   hasOutboundReplyContent,
   isFastModeAutoProgressPayload,
 } from "openclaw/plugin-sdk/reply-payload";
+import { GENERIC_EXTERNAL_RUN_FAILURE_TEXT } from "../../agents/failover/user-copy.js";
 import { isAskUserPromptPending } from "../../agents/tools/ask-user-tool.js";
 import { normalizeAgentPlanSteps } from "../../channels/streaming.js";
 import { logVerbose } from "../../globals.js";
@@ -599,16 +600,24 @@ export async function executeDispatch(state: PrepareDispatchExecutionReadyState)
       );
     }
     const failedAgentRun = getAgentRunTerminalOutcome() === "failed";
+    const adopted = state.turnAdoptionState?.adopted === true;
     if (
       params.replyOptions?.isHeartbeat === true ||
-      (!failedAgentRun && !didDeliverVisiblePartialReply) ||
+      (!failedAgentRun && !didDeliverVisiblePartialReply && !adopted) ||
       isDispatchOperationAborted()
     ) {
       throw error;
     }
     failDispatchReplyOperation(error, "failed");
     if (!didDeliverVisiblePartialReply) {
-      return undefined;
+      // Adoption retires ingress replay before the model starts. A progress ACK
+      // cannot settle a later failure; use normal final delivery and its policy.
+      return adopted &&
+        state.noVisibleReplyFallbackDirected &&
+        !state.suppressDelivery &&
+        !state.getObservedReplyDelivery()
+        ? { text: GENERIC_EXTERNAL_RUN_FAILURE_TEXT, isError: true }
+        : undefined;
     }
     return buildTerminalAgentRunFailureReplyPayload({
       visibleReplyDelivered: true,

--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -370,7 +370,12 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   const agentRunTerminalOutcome = state.getAgentRunTerminalOutcome();
   state.commitInboundDedupeIfClaimed();
   const messageInjectionAborted = state.replyOperationRunState.messageInjectionAborted === true;
-  const dispatchOutcome = queueCapRejected || messageInjectionAborted ? "skipped" : "completed";
+  const dispatchOutcome =
+    agentRunTerminalOutcome === "failed"
+      ? "error"
+      : queueCapRejected || messageInjectionAborted
+        ? "skipped"
+        : "completed";
   const dispatchReason = queueCapRejected
     ? "queue-cap"
     : messageInjectionAborted
@@ -385,7 +390,13 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
     dispatchReason ? { reason: dispatchReason } : undefined,
   );
   state.recordProcessed(dispatchOutcome, dispatchReason ? { reason: dispatchReason } : undefined);
-  state.markIdle(queueCapRejected ? "message_queue_cap_rejected" : "message_completed");
+  state.markIdle(
+    dispatchOutcome === "error"
+      ? "message_error"
+      : queueCapRejected
+        ? "message_queue_cap_rejected"
+        : "message_completed",
+  );
   state.completeDispatchReplyOperation();
   const result = state.attachSourceReplyDeliveryMode({
     queuedFinal,

--- a/src/auto-reply/reply/dispatch-from-config.lifecycle.ts
+++ b/src/auto-reply/reply/dispatch-from-config.lifecycle.ts
@@ -682,7 +682,7 @@ export function createDispatchReplyOperationCoordinator(params: {
   };
 
   const failDispatchReplyOperation = (error: unknown, terminalOutcome?: "failed") => {
-    if (terminalOutcome === "failed" && agentRunTerminalOutcome === "completed") {
+    if (terminalOutcome === "failed") {
       agentRunTerminalOutcome = "failed";
     }
     dispatchReplyOperation?.freezeAbort();

--- a/src/auto-reply/reply/dispatch-from-config.terminal-recovery.test.ts
+++ b/src/auto-reply/reply/dispatch-from-config.terminal-recovery.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { formatBillingErrorMessage } from "../../agents/failover/user-copy.js";
 import { readAgentRunTerminalOutcome } from "../../channels/turn/agent-run-terminal-outcome.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { withReplyDispatcher } from "../dispatch-dispatcher.js";
 import { setReplyPayloadMetadata } from "../reply-payload.js";
 import type { ReplyPayload } from "../types.js";
 import {
@@ -10,8 +11,11 @@ import {
   noAbortResult,
   resetPluginTtsAndThreadMocks,
   sessionStoreMocks,
+  ttsMocks,
 } from "./dispatch-from-config.shared.test-harness.js";
 import type { DispatchFromConfigParams } from "./dispatch-from-config.types.js";
+import { withDispatchProcessedOutcomeSink } from "./dispatch-processed-outcome.js";
+import { createReplyDispatcher } from "./reply-dispatcher.js";
 import { buildTestCtx } from "./test-ctx.js";
 
 let dispatchReplyFromConfig: typeof import("./dispatch-from-config.js").dispatchReplyFromConfig;
@@ -207,5 +211,171 @@ describe("dispatchReplyFromConfig terminal visible admission recovery", () => {
     });
     expect(readAgentRunTerminalOutcome(result)).toBe("failed");
     expect(dispatchParams.dispatcher.sendFinalReply).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { surface: "slack", origin: "slack", progress: false, chatType: "direct" },
+    { surface: "slack", origin: "slack", progress: true, chatType: "direct" },
+    { surface: "slack", origin: "slack", progress: true, chatType: "group" },
+    { surface: "slack", origin: "discord", progress: true, chatType: "direct" },
+  ])(
+    "settles an adopted failure on $surface → $origin ($chatType, progress=$progress)",
+    async ({ surface, origin, progress, chatType }) => {
+      sessionStoreMocks.currentEntry = { verboseLevel: "on" };
+      const resolverError = new Error("private synthetic failure detail");
+      const delivered: Array<{ kind: string; payload: ReplyPayload }> = [];
+      const dispatcher = createReplyDispatcher({
+        deliver: async (payload, { kind }) => {
+          delivered.push({ kind, payload });
+        },
+      });
+      mocks.routeReply.mockImplementation(async (raw) => {
+        const { payload, replyKind: kind } = raw as { payload: ReplyPayload; replyKind: string };
+        delivered.push({ kind, payload });
+        return { ok: true, delivered: true };
+      });
+      let operation: ReturnType<typeof createReplyOperation> | undefined;
+      const replyResolver: NonNullable<DispatchFromConfigParams["replyResolver"]> = async (
+        _ctx,
+        options,
+      ) => {
+        operation = options?.replyOperation;
+        await options?.turnAdoptionLifecycle?.onAdopted();
+        if (progress) {
+          await options?.onToolResult?.({
+            text: "Got it. I am checking now.",
+            isStatusNotice: true,
+          });
+          await dispatcher.waitForIdle();
+          expect(delivered.map(({ kind }) => kind)).toEqual(["tool"]);
+        }
+        throw resolverError;
+      };
+      const params = {
+        ...createVisibleDispatchParams(replyResolver),
+        dispatcher,
+        replyOptions: {
+          turnAdoptionLifecycle: { onAdopted: vi.fn(async () => {}) },
+        },
+      };
+      Object.assign(params.ctx, {
+        Provider: surface,
+        Surface: surface,
+        OriginatingChannel: origin,
+        ChatType: chatType,
+        WasMentioned: chatType === "group",
+      });
+      const { result, processedOutcome } = await withDispatchProcessedOutcomeSink(() =>
+        withReplyDispatcher({ dispatcher, run: () => dispatchReplyFromConfig(params) }),
+      );
+
+      expect(delivered.map(({ kind }) => kind)).toEqual(progress ? ["tool", "final"] : ["final"]);
+      expect(delivered.at(-1)?.payload).toMatchObject({
+        text: expect.stringContaining("Something went wrong"),
+        isError: true,
+      });
+      expect(JSON.stringify(delivered)).not.toContain(resolverError.message);
+      expect(operation?.result).toEqual({
+        kind: "failed",
+        code: "run_failed",
+        cause: resolverError,
+      });
+      expect(readAgentRunTerminalOutcome(result)).toBe("failed");
+      expect(processedOutcome?.outcome).toBe("error");
+      if (origin !== surface) {
+        expect(mocks.routeReply).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            channel: origin,
+            to: "user:1",
+            threadId: "501.000",
+            replyKind: "final",
+          }),
+        );
+      }
+    },
+  );
+
+  it.each(["before adoption", "adoption rejected"])(
+    "keeps %s failures retryable without a final notice",
+    async (failure) => {
+      const resolverError = new Error(failure);
+      const onAdopted = vi.fn(async () => {
+        throw resolverError;
+      });
+      const dispatcher = createReplyDispatcher({ deliver: vi.fn(async () => {}) });
+      const replyResolver = vi.fn<NonNullable<DispatchFromConfigParams["replyResolver"]>>(
+        async (_ctx, options) => {
+          if (failure === "adoption rejected") {
+            await options?.turnAdoptionLifecycle?.onAdopted();
+          }
+          throw resolverError;
+        },
+      );
+      const params = {
+        ...createVisibleDispatchParams(replyResolver),
+        dispatcher,
+        replyOptions: { turnAdoptionLifecycle: { onAdopted } },
+      };
+      params.ctx.MessageSid = "retryable-failure";
+      await expect(
+        withReplyDispatcher({ dispatcher, run: () => dispatchReplyFromConfig(params) }),
+      ).rejects.toBe(resolverError);
+      expect(dispatcher.getQueuedCounts()).toEqual({ tool: 0, block: 0, final: 0 });
+      replyResolver.mockResolvedValueOnce({ text: "retry succeeded" });
+      await dispatchReplyFromConfig({ ...params, dispatcher: createDispatcher() });
+      expect(replyResolver).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it.each(["message_tool_only", "send-denied", "observed-delivery", "ambient"])(
+    "does not add an adopted failure notice for %s",
+    async (policy) => {
+      const params = createVisibleDispatchParams(async (_ctx, options) => {
+        await options?.turnAdoptionLifecycle?.onAdopted();
+        if (policy === "observed-delivery") {
+          await options?.onObservedReplyDelivery?.();
+        }
+        throw new Error("adopted failure");
+      });
+      params.ctx.MessageSid = "adopted-suppressed-failure";
+      if (policy === "send-denied") {
+        sessionStoreMocks.currentEntry = { sendPolicy: "deny" };
+      }
+      if (policy === "ambient") {
+        params.ctx.ChatType = "group";
+        params.ctx.WasMentioned = false;
+      }
+      const result = await dispatchReplyFromConfig({
+        ...params,
+        replyOptions: {
+          ...(policy === "message_tool_only"
+            ? { sourceReplyDeliveryMode: "message_tool_only" as const }
+            : {}),
+          turnAdoptionLifecycle: { onAdopted: vi.fn(async () => {}) },
+        },
+      });
+      expect(readAgentRunTerminalOutcome(result)).toBe("failed");
+      expect(params.dispatcher.sendFinalReply).not.toHaveBeenCalled();
+    },
+  );
+
+  it("retains adopted dedupe when failure-notice preparation also fails", async () => {
+    const resolverError = new Error("accepted turn failed");
+    const deliveryError = new Error("final preparation failed");
+    const replyResolver = vi.fn<NonNullable<DispatchFromConfigParams["replyResolver"]>>(
+      async (_ctx, options) => {
+        await options?.turnAdoptionLifecycle?.onAdopted();
+        throw resolverError;
+      },
+    );
+    const params = {
+      ...createVisibleDispatchParams(replyResolver),
+      replyOptions: { turnAdoptionLifecycle: { onAdopted: vi.fn(async () => {}) } },
+    };
+    params.ctx.MessageSid = "adopted-final-failure";
+    ttsMocks.maybeApplyTtsToPayload.mockRejectedValueOnce(deliveryError);
+    await expect(dispatchReplyFromConfig(params)).rejects.toBe(deliveryError);
+    await dispatchReplyFromConfig({ ...params, dispatcher: createDispatcher() });
+    expect(replyResolver).toHaveBeenCalledOnce();
   });
 });

--- a/src/auto-reply/reply/dispatch-from-config.ts
+++ b/src/auto-reply/reply/dispatch-from-config.ts
@@ -121,7 +121,7 @@ async function dispatchReplyFromConfigInner(
         return finishReplyOperationAbortedDispatch();
       }
       if (inboundDedupeClaim.status === "claimed") {
-        if (errorState.inboundDedupeReplayUnsafe) {
+        if (errorState.turnAdoptionState?.adopted || errorState.inboundDedupeReplayUnsafe) {
           commitInboundDedupe(inboundDedupeClaim.key);
         } else {
           releaseInboundDedupe(inboundDedupeClaim.key);

--- a/src/gateway/server.chat-adopted-failure.test.ts
+++ b/src/gateway/server.chat-adopted-failure.test.ts
@@ -1,0 +1,96 @@
+import path from "node:path";
+import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
+import { afterAll, afterEach, beforeAll, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { clearConfigCache } from "../config/config.js";
+import {
+  connectOk,
+  createGatewaySuiteHarness,
+  gatewayReplyMock,
+  installGatewayTestHooks,
+  onceMessage,
+  prepareGatewayReplyRuntimeForTest,
+  rpcReq,
+  testState,
+  writeSessionStore,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+const temporaryDirectories = useAutoCleanupTempDirTracker(afterEach);
+let gateway: Awaited<ReturnType<typeof createGatewaySuiteHarness>>;
+
+beforeAll(async () => {
+  gateway = await createGatewaySuiteHarness();
+});
+afterAll(async () => {
+  await gateway.close();
+});
+afterEach(() => {
+  gatewayReplyMock.mockReset();
+  testState.sessionStorePath = undefined;
+  clearConfigCache();
+});
+
+it("reports an adopted pre-model failure as one visible failure over the Gateway WebSocket", async () => {
+  testState.sessionStorePath = path.join(
+    temporaryDirectories.make("openclaw-adopted-failure-"),
+    "sessions.json",
+  );
+  await writeSessionStore({
+    entries: { main: { sessionId: "adopted-failure-session", updatedAt: Date.now() } },
+  });
+  const socket = await gateway.openWs();
+  const runId = "adopted-before-model-failure";
+  const terminalStates: string[] = [];
+  socket.on("message", (raw) => {
+    const frame = JSON.parse(rawDataToString(raw)) as {
+      event?: string;
+      payload?: { runId?: string; state?: string };
+    };
+    const state = frame.payload?.state;
+    if (
+      frame.event === "chat" &&
+      frame.payload?.runId === runId &&
+      state &&
+      ["error", "final", "aborted"].includes(state)
+    ) {
+      terminalStates.push(state);
+    }
+  });
+  const originalError = new Error("private synthetic dispatch failure detail");
+  gatewayReplyMock.mockImplementationOnce(async (_ctx, options) => {
+    await options?.turnAdoptionLifecycle?.onAdopted();
+    throw originalError;
+  });
+  try {
+    await connectOk(socket);
+    await prepareGatewayReplyRuntimeForTest({ force: true });
+    const terminal = onceMessage(
+      socket,
+      (frame) =>
+        frame.type === "event" &&
+        frame.event === "chat" &&
+        frame.payload?.runId === runId &&
+        frame.payload?.state === "error",
+    );
+    void terminal.catch(() => undefined);
+    const request = {
+      sessionKey: "main",
+      message: "Please answer this message.",
+      idempotencyKey: runId,
+    };
+    const accepted = await rpcReq(socket, "chat.send", request);
+    expect(accepted.ok).toBe(true);
+    expect(accepted.payload).toMatchObject({ runId, status: "started" });
+    const failed = await terminal;
+    expect(JSON.stringify(failed)).toContain("Something went wrong");
+    expect(JSON.stringify(failed)).not.toContain(originalError.message);
+    const replay = await rpcReq(socket, "chat.send", request);
+    expect(replay.ok).toBe(false);
+    expect(replay.payload).toMatchObject({ runId, status: "error" });
+    expect(gatewayReplyMock).toHaveBeenCalledOnce();
+    expect(terminalStates).toEqual(["error"]);
+  } finally {
+    socket.close();
+  }
+});


### PR DESCRIPTION
Closes #133960

## What Problem This Solves

Fixes an issue where users could receive a progress acknowledgment and then no answer when a durably accepted turn failed before the model produced output. The same gap could leave a turn with no visible response at all.

## Why This Change Was Made

The shared dispatch failure handler recovered an existing model failure or visible partial reply, but did not recognize durable adoption as ownership of a terminal outcome. Extend that existing handler to return a sanitized error through normal final delivery, preserve the original failed operation and failed dispatch outcome, and retain inbound deduplication if preparing the failure reply also fails.

Source reply suppression, directed conversation policy, routing, and replies already sent through the message tool still apply. Failures before adoption remain eligible for ingress retry. No channel-specific catch-and-send path, configuration option, protocol change, or persistent-store change is added.

The reported Slack `.catch` exception has not been traced to an exact producer; this PR repairs an independently reproduced terminal-outcome gap.

## User Impact

A durably accepted direct or explicitly addressed turn can now end with one compact error reply after an unexpected pre-answer failure. Progress acknowledgments do not replace that outcome. The turn remains failed, and a repeated inbound event does not start the same adopted work again.

## Evidence

The exact regression file was run against the four unchanged owner modules from `006527dce2cd5b7ede8859c7bd4a95d05b133393`, then against this candidate. The original code fails 9 of 16 tests; the candidate passes all 16. All four adopted-turn cases fail before the fix: no output, Slack direct progress acknowledgment, mentioned-group progress acknowledgment, and Slack-to-Discord routing. Each progress case asserts that the acknowledgment was actually delivered before injecting the error.

A real ephemeral Gateway WebSocket test accepts `chat.send`, injects the adopted pre-model failure at the resolver boundary, observes exactly one sanitized error terminal event, and verifies that replay returns the cached failure without another resolver invocation. The focused existing reply dispatch, delivery, lifecycle, and delivery-ledger suites pass 322 tests; with the owner and WebSocket regressions, 339 tests pass. Coverage includes pre-adoption retry, rejected adoption, source suppression, message-tool delivery, ambient groups, failure-reply preparation failure, and uncertain transport acceptance.

`OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build` passed. Core typecheck, all core-test typecheck shards, changed-file guards, formatting, and focused lint passed. The first lint run caught an unused test import; it was removed and lint rerun successfully. Independent Codex autoreview was scoped-clean at the requested P0 threshold.

The real mock-provider + qa-channel + ephemeral Gateway sibling flow also passed. It verifies exactly one classified, sanitized provider-error reply after a tool call and no tool replay. This is sibling delivery proof; the targeted owner/WebSocket regressions exercise the newly repaired catch.

The pre-existing expected-error QA scenario used success-only waiters that reject all error replies. It now waits through the existing bus message waiter, explicitly asserts the error classification, original conversation, and exact text, retains the single-reply/tool-once/redaction assertions, and disables scenario-level retries so an entire scenario cannot be replayed during exactly-once proof.

Actual verdict excerpt from `.artifacts/qa-e2e/reply-failures-provider-final/qa-suite-summary.json`:

```json
{
  "scenarios": [
    {
      "name": "Provider HTTP 503 remains visible after tool execution",
      "status": "pass",
      "steps": [
        {
          "name": "surfaces one sanitized failure without replaying the tool",
          "status": "pass",
          "details": "reply=1; plannedReads=1; postTool503=3"
        }
      ]
    }
  ],
  "counts": {
    "total": 1,
    "passed": 1,
    "failed": 0,
    "skipped": 0
  }
}
```

Reproduce the packaged mock-channel proof after the private QA build:

```sh
OPENCLAW_ENABLE_PRIVATE_QA_CLI=1 OPENCLAW_DISABLE_BUNDLED_PLUGINS=0 \
  node openclaw.mjs qa suite --provider-mode mock-openai \
  --scenario provider-http-503-visible-failure --channel-driver qa-channel \
  --concurrency 1 --output-dir .artifacts/qa-e2e/reply-failures-provider-final
```

The native Slack progress module flow and group policy are unsupported by Crabline Slack. The supported Slack DM smoke was attempted twice, but Crabline failed before message injection while publishing provider-readiness artifacts: `Private directory must not have a macOS extended ACL. OpenClaw Crabline artifact rollback cleanup also failed.` The stack identifies `@openclaw/crabline` private-directory validation and artifact generation; no Slack success is claimed, no live Slack service was contacted, and no directory ACL was changed. This is a separate dependency/harness follow-up.

Production delta: +26/-6, net +20. Tests/test scenarios: net +272; docs: +2. The production growth extends the existing failure owner to adopted turns and preserves their failed audit/idle outcome; it introduces no alternate sender, new store, or configuration surface. Existing partial-reply recovery remains the same canonical path.

CI initially hit the same 120-second timeout twice in the existing Codex credential-wait test. A Linux Testbox phase probe located 71.2 seconds in provider tool normalization before `turn/start`; the simulated human wait and completion finished normally. The test omitted the existing prepared runtime-plan fixture used by its sibling tests. One test-only assignment now supplies that fixture, preserving every timeout, host-tool, and terminal assertion. The entire file passes 13/13 on Linux (default case 375 ms) and macOS; a fresh isolated autoreview is clean. The repair was rebased onto `51432b2d46a36c26d573c13a9b604984dee27820` with both commits patch-identical.
