### PR TITLE
refactor: consolidate package inventory exclusions

### DIFF
--- a/src/infra/package-dist-inventory.test.ts
+++ b/src/infra/package-dist-inventory.test.ts
@@ -303,14 +303,14 @@ describe("package dist inventory", () => {
     );
   });
 
-  it("keeps publishable externalized bundled plugin dist trees out of the inventory", async () => {
+  it.each(["index.js", ""])("omits externalized plugin entry %j", async (entry) => {
     await withTestDir({ prefix: "openclaw-dist-inventory-externalized-" }, async (packageRoot) => {
       const externalizedRuntime = path.join(
         packageRoot,
         "dist",
         "extensions",
         "external-chat",
-        "index.js",
+        entry,
       );
       const bundledRuntime = path.join(
         packageRoot,

--- a/src/infra/package-dist-inventory.ts
+++ b/src/infra/package-dist-inventory.ts
@@ -84,15 +84,10 @@ const OMITTED_DIST_SUBTREE_PATTERNS = [
   new RegExp(`^dist/plugin-sdk/extensions/${LEGACY_QA_CHANNEL_DIR}(?:/|$)`, "u"),
   new RegExp(`^dist/plugin-sdk/extensions/${LEGACY_QA_LAB_DIR}(?:/|$)`, "u"),
 ] as const;
-type ExternalizedBundledExtensionIds = ReadonlySet<string>;
 type PackageDistExclusionRules = {
   files: ReadonlySet<string>;
   prefixes: readonly string[];
   patterns: readonly RegExp[];
-};
-type PackageDistInventoryRules = {
-  externalizedExtensionIds: ExternalizedBundledExtensionIds;
-  exclusions: PackageDistExclusionRules;
 };
 
 function normalizeRelativePath(value: string): string {
@@ -141,23 +136,16 @@ function compilePackageFilesExclusionPattern(pattern: string): RegExp {
   return new RegExp(source, "u");
 }
 
-function collectPackageDistInventoryRules(rootPackageJson: unknown): PackageDistInventoryRules {
+function collectPackageDistExclusionRules(rootPackageJson: unknown): PackageDistExclusionRules {
   if (!rootPackageJson || typeof rootPackageJson !== "object") {
-    return {
-      externalizedExtensionIds: new Set(),
-      exclusions: { files: new Set(), prefixes: [], patterns: [] },
-    };
+    return { files: new Set(), prefixes: [], patterns: [] };
   }
   const files = (rootPackageJson as { files?: unknown }).files;
   if (!Array.isArray(files)) {
-    return {
-      externalizedExtensionIds: new Set(),
-      exclusions: { files: new Set(), prefixes: [], patterns: [] },
-    };
+    return { files: new Set(), prefixes: [], patterns: [] };
   }
-  const externalizedExtensionIds = new Set<string>();
   const excludedFiles = new Set<string>();
-  const excludedPrefixes: string[] = [];
+  const excludedPrefixes = new Set<string>();
   const excludedPatterns: RegExp[] = [];
   for (const entry of files) {
     if (typeof entry !== "string") {
@@ -166,14 +154,16 @@ function collectPackageDistInventoryRules(rootPackageJson: unknown): PackageDist
     const normalized = normalizeRelativePath(entry);
     const match = /^!dist\/extensions\/([^/]+)\/\*\*$/u.exec(normalized);
     if (match?.[1]) {
-      externalizedExtensionIds.add(match[1]);
+      // Preserve literal root and descendant exclusion alongside package-file glob rules.
+      excludedFiles.add(`dist/extensions/${match[1]}`);
+      excludedPrefixes.add(`dist/extensions/${match[1]}/`);
     }
     if (!normalized.startsWith("!dist/")) {
       continue;
     }
     const excludedPath = normalized.slice(1);
     if (excludedPath.endsWith("/**") && !excludedPath.slice(0, -3).includes("*")) {
-      excludedPrefixes.push(excludedPath.slice(0, -2));
+      excludedPrefixes.add(excludedPath.slice(0, -2));
     } else if (excludedPath.includes("*")) {
       excludedPatterns.push(compilePackageFilesExclusionPattern(excludedPath));
     } else {
@@ -181,30 +171,10 @@ function collectPackageDistInventoryRules(rootPackageJson: unknown): PackageDist
     }
   }
   return {
-    externalizedExtensionIds,
-    exclusions: {
-      files: excludedFiles,
-      prefixes: excludedPrefixes.toSorted((left, right) => left.localeCompare(right)),
-      patterns: excludedPatterns,
-    },
+    files: excludedFiles,
+    prefixes: [...excludedPrefixes].toSorted((left, right) => left.localeCompare(right)),
+    patterns: excludedPatterns,
   };
-}
-
-function isExternalizedBundledExtensionDistPath(
-  relativePath: string,
-  externalizedExtensionIds: ExternalizedBundledExtensionIds,
-): boolean {
-  if (externalizedExtensionIds.size === 0) {
-    return false;
-  }
-  const parts = normalizeRelativePath(relativePath).split("/");
-  return (
-    parts.length >= 3 &&
-    parts[0] === "dist" &&
-    parts[1] === "extensions" &&
-    Boolean(parts[2]) &&
-    externalizedExtensionIds.has(parts[2] ?? "")
-  );
 }
 
 function isOmittedPluginSdkTestPath(relativePath: string): boolean {
@@ -216,11 +186,11 @@ function isOmittedPluginSdkTestPath(relativePath: string): boolean {
   );
 }
 
-async function collectPackageDistInventoryRulesForRoot(
+async function collectPackageDistExclusionRulesForRoot(
   packageRoot: string,
-): Promise<PackageDistInventoryRules> {
+): Promise<PackageDistExclusionRules> {
   const packageJsonPath = path.join(packageRoot, "package.json");
-  return collectPackageDistInventoryRules(await readJsonIfExists<unknown>(packageJsonPath));
+  return collectPackageDistExclusionRules(await readJsonIfExists<unknown>(packageJsonPath));
 }
 
 function isPackageFilesExcludedDistPath(
@@ -234,14 +204,11 @@ function isPackageFilesExcludedDistPath(
   );
 }
 
-function isPackagedDistPath(relativePath: string, rules: PackageDistInventoryRules): boolean {
+function isPackagedDistPath(relativePath: string, rules: PackageDistExclusionRules): boolean {
   if (!relativePath.startsWith("dist/")) {
     return false;
   }
-  if (isExternalizedBundledExtensionDistPath(relativePath, rules.externalizedExtensionIds)) {
-    return false;
-  }
-  if (isPackageFilesExcludedDistPath(relativePath, rules.exclusions)) {
+  if (isPackageFilesExcludedDistPath(relativePath, rules)) {
     return false;
   }
   if (isLegacyPluginDependencyDirPath(relativePath)) {
@@ -278,12 +245,11 @@ function isPackagedDistPath(relativePath: string, rules: PackageDistInventoryRul
   return true;
 }
 
-function isOmittedDistSubtree(relativePath: string, rules: PackageDistInventoryRules): boolean {
+function isOmittedDistSubtree(relativePath: string, rules: PackageDistExclusionRules): boolean {
   return (
-    isExternalizedBundledExtensionDistPath(relativePath, rules.externalizedExtensionIds) ||
     // npm directory exclusions can select the root itself or its trailing-slash subtree.
-    isPackageFilesExcludedDistPath(relativePath, rules.exclusions) ||
-    isPackageFilesExcludedDistPath(`${relativePath}/`, rules.exclusions) ||
+    isPackageFilesExcludedDistPath(relativePath, rules) ||
+    isPackageFilesExcludedDistPath(`${relativePath}/`, rules) ||
     isLegacyPluginDependencyDirPath(relativePath) ||
     isOmittedPluginSdkTestPath(relativePath) ||
     OMITTED_DIST_SUBTREE_PATTERNS.some((pattern) => pattern.test(relativePath))
@@ -293,7 +259,7 @@ function isOmittedDistSubtree(relativePath: string, rules: PackageDistInventoryR
 async function collectRelativeFiles(
   rootDir: string,
   baseDir: string,
-  rules: PackageDistInventoryRules,
+  rules: PackageDistExclusionRules,
   fsLimit: LimitFunction,
   onDirectory?: (directoryPath: string) => Promise<void>,
 ): Promise<string[]> {
@@ -345,8 +311,8 @@ export async function collectPackageDistInventory(
 ): Promise<string[]> {
   const rules =
     options.packageManifest === undefined
-      ? await collectPackageDistInventoryRulesForRoot(packageRoot)
-      : collectPackageDistInventoryRules(options.packageManifest);
+      ? await collectPackageDistExclusionRulesForRoot(packageRoot)
+      : collectPackageDistExclusionRules(options.packageManifest);
   const fsLimit = pLimit(PACKAGE_DIST_INVENTORY_SCAN_CONCURRENCY);
   return await collectRelativeFiles(
     path.join(packageRoot, "dist"),
@@ -357,7 +323,10 @@ export async function collectPackageDistInventory(
   );
 }
 
-async function readPackageDistInventoryOptional(packageRoot: string): Promise<string[] | null> {
+/** Reads an existing package dist inventory, returning null when the inventory is absent. */
+export async function readPackageDistInventoryIfPresent(
+  packageRoot: string,
+): Promise<string[] | null> {
   const inventoryPath = path.join(packageRoot, PACKAGE_DIST_INVENTORY_RELATIVE_PATH);
   const parsed = await readJsonIfExists<unknown>(inventoryPath);
   if (parsed === null) {
@@ -367,11 +336,4 @@ async function readPackageDistInventoryOptional(packageRoot: string): Promise<st
     throw new Error(`Invalid package dist inventory at ${PACKAGE_DIST_INVENTORY_RELATIVE_PATH}`);
   }
   return sortUniqueStrings(parsed.map(normalizeRelativePath));
-}
-
-/** Reads an existing package dist inventory, returning null when the inventory is absent. */
-export async function readPackageDistInventoryIfPresent(
-  packageRoot: string,
-): Promise<string[] | null> {
-  return await readPackageDistInventoryOptional(packageRoot);
 }


### PR DESCRIPTION
## What Problem This Solves

Package inventory construction maintained two exclusion paths for externalized plugins. Keeping file inclusion and directory pruning aligned required duplicating the same policy.

## Why This Change Was Made

Represent each externalized plugin's literal root and descendants in the existing exclusion rules, so file filtering and subtree pruning share the canonical predicate. Keep general glob matching unchanged. The exported optional inventory reader now owns its existing validation body directly, removing a private forwarding wrapper.

## User Impact

No intended behavior change. Package contents and inventory validation keep their existing contracts. Production: +26/−64 (net −38); tests: +2/−2 (net 0); whole change: −38 lines. No configuration, dependency, storage or schema change.

## Original evidence on `8ac255cd`

- Baseline and candidate each passed the same 102 cases across inventory, global update, bootstrap artifact and real inventory-writer suites. Case identities, multiplicity and within-file order match.
- The existing table now covers a literal excluded root file alongside descendants, with all inventory assertions retained.
- All 29 normal selected checks and the full 14-stage default build passed.
- Separate precommit and exact-commit Codex reviews completed with no P0 findings.

These are filesystem/process/archive-fixture tests and static build-output checks, not a full built-package install/update, live Gateway/provider or cross-platform proof. That original source base was `79c921d0`; the refreshed-head evidence is below. No performance claim is made.

## Failure-justified refresh on `d3ea6f44`

The original [CI run 33374536741](https://github.com/openclaw/openclaw/actions/runs/33374536741) remains failed: the formatter's Anthropic context-window case exceeded its existing 120-second test timeout. The retained log and original local proof have not been relabeled. This is not a measured attribution of that timeout to one particular cause.

The branch is now composed onto fixed canonical parent `afd1a36d5d6d3c155e6f0f7a4a3e3221a9f9fef6`. The production afterimage and −38-line cleanup are unchanged; the test retains upstream `PACKAGE_LIFECYCLE_PENDING_RELATIVE_PATH` behavior plus only this PR's original table edits. Canonical loaded-hook discovery repair #133970 and the separate provider-hook fixture changes from #133913 remain upstream-owned; this PR introduces no provider fix, mock, timeout change or duplicate repair credit.

Fresh local proof on `d3ea6f444fea523311599f2dffe430d931b20294`, using Node 24.19.0 and pnpm 12.1.0:

- All 123 cases across the original four Package suites, followed in the command by lifecycle and pnpm-guard siblings, passed.
- The separate complete formatter suite passed all 95 cases; the previously failing quoted Anthropic context-window case completed in 3 ms.
- All 29 normally selected changed checks passed against fixed parent `afd1a36d`.
- The normal default build completed all 14 stages with its existing cache behavior.
- One separate exact-commit Codex review completed on `d3ea6f44`, scoped-clean at P0 with no findings. It was a static review, not another runtime proof; original precommit and exact-`8ac` reviews remain historical.

Exact commands, run separately without assertion or budget changes:

```sh
node scripts/run-vitest.mjs run src/infra/package-dist-inventory.test.ts src/infra/update-global.test.ts src/gateway/worker-environments/node-bootstrap-artifact.test.ts test/scripts/write-package-dist-inventory.test.ts src/infra/package-lifecycle.test.ts src/infra/package-update-steps.pnpm11-guard.test.ts --maxWorkers=2 --reporter=verbose
node scripts/run-vitest.mjs run src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts --maxWorkers=2 --reporter=verbose
node scripts/check-changed.mjs --base afd1a36d5d6d3c155e6f0f7a4a3e3221a9f9fef6 -- src/infra/package-dist-inventory.ts src/infra/package-dist-inventory.test.ts
corepack pnpm run build
```

The retained output-classifier refusal remains failed: a canonical transient worker manifest had already been disposed, so independent historical compiled-output equality cannot be established. Subsequent source-backed producer attribution and actual source/index/config/process checks are separate evidence, not a transform-equivalence claim. The build's retained current output hashes and cache/live pairs likewise do not prove historical deleted-output equivalence.

These remain filesystem/process/archive-fixture and compiled-output checks, not a full built-package install/update, live Gateway/provider or cross-platform proof. The formatter and full-build results above are historical exact-`d3ea6f44` evidence, not execution against a later `main`.

## Exact-head CI and native review

[CI run 33393416073](https://github.com/openclaw/openclaw/actions/runs/33393416073) completed successfully on exact head `d3ea6f444fea523311599f2dffe430d931b20294`, including the required `openclaw/ci-gate`. The first local watcher reached its deadline while that run was queued; a successor watcher attached to the same run and observed completion. No CI rerun, cancellation or replacement run was requested.

The latest Claw review, updated at 2026-08-31 12:53 UTC for `d3ea6f44`, reports no findings and contains no Rank-up moves section. Normal native review initialization, main/PR checkout guards, artifact initialization and artifact validation completed. The validated recommendation is `READY FOR /prepare-pr`; mandatory hosted-gate prepare and normal merge remain pending.

A read-only prospective composition against fixed `2278fbc9df879d52efbb6a0b81f7798a9f7c16c1` verified all 35,763 tree entries with only the two reviewed Package afterimages and matching base preimages. The 32 scoped owner/context files and 31 native tooling files, plus the shared record helper, are unchanged from that point to observed `ba04388ce466730d73027189670d5d99860dfdda`. The earlier package manifest change was only the additional Windows CI test token; it is not Windows runtime proof. This is scoped source composition, not whole-new-main behavior or actual-parent verification. Current main and live review/rules must be checked again before merge; actual-parent tree, ancestry and cleanup verification remain post-merge work.
