### PR TITLE
fix(workspace): verify migration readiness before accepting work

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -244,6 +244,8 @@ This includes retired MCP OAuth files under `<state-dir>/mcp-oauth/*.json`. Stop
 
 After explicit repair (`--fix`, `--repair`, or `--yes`), Doctor verifies runtime schema readiness for existing configured, default-layout, and registered databases before reporting completion, including stores whose migration failed before registration. A blocked required migration exits nonzero; stop the Gateway and other OpenClaw processes, then rerun repair. Unrelated advisory warnings, including archived transcript repair failures, do not make a ready database fail this check. Missing databases are not created by the readiness check.
 
+Doctor also checks every configured agent workspace and active sandbox workspace for retired setup state and interrupted migration claims. Repair exits nonzero while any of these files still block agent turns, even if their data already reached SQLite. Gateway startup checks the same workspace readiness before starting channels. Keep the retained files in place and rerun `openclaw doctor --fix` to finish verified cleanup; neither check imports or deletes legacy state.
+
 ## Shared state SQLite compaction
 
 See [Database schemas](/reference/database-schemas) for schema versioning, integrity checks, and downgrade recovery.

--- a/src/agents/workspace-legacy-state.test.ts
+++ b/src/agents/workspace-legacy-state.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
   assertNoUnmigratedWorkspaceState,
+  assertWorkspaceStateMigrationReady,
   LEGACY_WORKSPACE_ATTESTATION_HEADER,
   prepareLegacyWorkspaceStateReset,
   removeLegacyWorkspaceStateForReset,
@@ -145,6 +146,33 @@ describe("legacy workspace reset cleanup", () => {
     expect(() => assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir })).toThrow(
       /run openclaw doctor --fix/u,
     );
+  });
+
+  it("rechecks every workspace at lifecycle boundaries after runtime cached absence", async () => {
+    const context = setup();
+    const workspaceDirs = [context.workspaceDir, path.join(context.homeDir, "secondary")];
+    for (const workspaceDir of workspaceDirs) {
+      await fs.mkdir(workspaceDir, { recursive: true });
+      assertNoUnmigratedWorkspaceState({ workspaceDir });
+      await fs.writeFile(path.join(workspaceDir, "openclaw-workspace-state.json"), '{"version":1}');
+    }
+    expect(() =>
+      assertWorkspaceStateMigrationReady({
+        workspaceDirs,
+        env: context.env,
+        homedir: context.homedir,
+      }),
+    ).toThrow(`${workspaceDirs.join(", ")}; run openclaw doctor --fix`);
+    for (const workspaceDir of workspaceDirs) {
+      await fs.unlink(path.join(workspaceDir, "openclaw-workspace-state.json"));
+    }
+    expect(() =>
+      assertWorkspaceStateMigrationReady({
+        workspaceDirs,
+        env: context.env,
+        homedir: context.homedir,
+      }),
+    ).not.toThrow();
   });
 
   it("checks canonical legacy markers when configuration uses a symlink alias", async () => {

--- a/src/agents/workspace-legacy-state.ts
+++ b/src/agents/workspace-legacy-state.ts
@@ -3,6 +3,7 @@
 import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { formatCliCommand } from "../cli/command-format.js";
 import { resolveLegacyStateDirs, resolveStateDir } from "../config/paths.js";
 import { root } from "../infra/fs-safe.js";
 import { resolveUserPath } from "../utils.js";
@@ -152,6 +153,38 @@ function siblingPathIsOwnedMarker(filePath: string): boolean {
   }
 }
 
+function hasUnmigratedWorkspaceSources(sources: LegacyWorkspaceSourcePaths): boolean {
+  return (
+    sources.setupStatePaths.some(pathOrClaimExists) ||
+    sources.stateDirAttestationPaths.some(pathOrClaimExists) ||
+    sources.siblingAttestationPaths.some(
+      (sourcePath) =>
+        siblingPathIsOwnedMarker(`${sourcePath}${WORKSPACE_DOCTOR_CLAIM_SUFFIX}`) ||
+        siblingPathIsOwnedMarker(sourcePath),
+    )
+  );
+}
+
+function workspaceMigrationError(workspaceDirs: string[], env?: NodeJS.ProcessEnv): Error {
+  return new Error(
+    `Legacy workspace setup state requires migration for ${workspaceDirs.join(", ")}; run ${formatCliCommand("openclaw doctor --fix", env)}.`,
+  );
+}
+
+/** Recheck lifecycle readiness without reusing a running turn's verified-absence cache. */
+export function assertWorkspaceStateMigrationReady(params: {
+  workspaceDirs: readonly string[];
+  env?: NodeJS.ProcessEnv;
+  homedir?: () => string;
+}): void {
+  const blocked = params.workspaceDirs.filter((workspaceDir) =>
+    hasUnmigratedWorkspaceSources(resolveLegacyWorkspaceSourcePaths(workspaceDir, params)),
+  );
+  if (blocked.length > 0) {
+    throw workspaceMigrationError(blocked, params.env);
+  }
+}
+
 /** Fail closed on unmigrated owned state without reading it as runtime data. */
 export function assertNoUnmigratedWorkspaceState(params: { workspaceDir: string }): void {
   const identity = resolveWorkspaceStateIdentity(params.workspaceDir);
@@ -165,18 +198,8 @@ export function assertNoUnmigratedWorkspaceState(params: { workspaceDir: string 
   if (checkedWorkspaceSourceSets.has(sourceSetKey)) {
     return;
   }
-  const hasLegacy =
-    sources.setupStatePaths.some(pathOrClaimExists) ||
-    sources.stateDirAttestationPaths.some(pathOrClaimExists) ||
-    sources.siblingAttestationPaths.some(
-      (sourcePath) =>
-        siblingPathIsOwnedMarker(`${sourcePath}${WORKSPACE_DOCTOR_CLAIM_SUFFIX}`) ||
-        siblingPathIsOwnedMarker(sourcePath),
-    );
-  if (hasLegacy) {
-    throw new Error(
-      `Legacy workspace setup state requires migration for ${identity.workspacePath}; run openclaw doctor --fix.`,
-    );
+  if (hasUnmigratedWorkspaceSources(sources)) {
+    throw workspaceMigrationError([identity.workspacePath]);
   }
   checkedWorkspaceSourceSets.add(sourceSetKey);
 }

--- a/src/agents/workspace-state-dirs.ts
+++ b/src/agents/workspace-state-dirs.ts
@@ -1,25 +1,26 @@
+import os from "node:os";
 import path from "node:path";
-import {
-  listAgentIds,
-  resolveAgentConfig,
-  resolveAgentWorkspaceDir,
-} from "../agents/agent-scope.js";
-import { resolveSandboxConfigForAgent } from "../agents/sandbox/config.js";
-import { resolveSandboxRuntimeStatus } from "../agents/sandbox/runtime-status.js";
-import { resolveSandboxWorkspaceLayoutPaths } from "../agents/sandbox/shared.js";
+import { resolveStateDir } from "../config/paths.js";
 import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import { listSessionEntryKeysReadOnly } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveUserPath } from "../infra/home-dir.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
-import { resolveUserPath } from "./home-dir.js";
+import { listAgentIds, resolveAgentConfig, resolveAgentWorkspaceDir } from "./agent-scope.js";
+import { resolveSandboxConfigForAgent } from "./sandbox/config.js";
+import { resolveSandboxRuntimeStatus } from "./sandbox/runtime-status.js";
+import { resolveSandboxWorkspaceLayoutPaths } from "./sandbox/shared.js";
+import { listAgentWorkspaceDirs } from "./workspace-dirs.js";
+import { assertWorkspaceStateMigrationReady } from "./workspace-legacy-state.js";
 
-export function listSandboxWorkspaceDirs(params: {
+/** Select configured workspaces and active sandbox copies for migration and readiness. */
+export function listWorkspaceStateDirs(params: {
   cfg: OpenClawConfig;
   env: NodeJS.ProcessEnv;
   homedir: () => string;
   stateDir: string;
 }): string[] {
-  const dirs = new Set<string>();
+  const dirs = new Set(listAgentWorkspaceDirs(params.cfg, params.env));
 
   for (const agentId of listAgentIds(params.cfg)) {
     const sandbox = resolveSandboxConfigForAgent(params.cfg, agentId);
@@ -79,4 +80,20 @@ export function listSandboxWorkspaceDirs(params: {
   }
 
   return [...dirs];
+}
+
+/** Refuse completion before channels accept work that a workspace cannot execute. */
+export function assertConfiguredWorkspaceStateReady(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+}): void {
+  const env = params.env ?? process.env;
+  const homedir = os.homedir;
+  const workspaceDirs = listWorkspaceStateDirs({
+    cfg: params.cfg,
+    env,
+    homedir,
+    stateDir: resolveStateDir(env, homedir),
+  });
+  assertWorkspaceStateMigrationReady({ workspaceDirs, env, homedir });
 }

--- a/src/flows/doctor-health.test.ts
+++ b/src/flows/doctor-health.test.ts
@@ -1,9 +1,15 @@
 import fs from "node:fs";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { assertNoUnmigratedWorkspaceState } from "../agents/workspace-legacy-state.js";
+import { readWorkspaceStateSnapshot } from "../agents/workspace-state-store.js";
 import { runCommandWithRuntime } from "../cli/cli-utils.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { migrateLegacyMediaPersistence } from "../infra/state-migrations.media-persistence.js";
+import {
+  detectLegacyWorkspaceState,
+  migrateLegacyWorkspaceState,
+} from "../infra/state-migrations.workspace-setup.js";
 import {
   claimOpenClawAgentDatabaseLease,
   releaseOpenClawAgentDatabaseLease,
@@ -278,6 +284,91 @@ describe("runDoctorHealthFlow", () => {
       expect(fs.readFileSync(archive, "utf8")).toBe("invalid JSON\n");
     });
   });
+
+  it.each(["configured", "sandbox"] as const)(
+    "refuses incomplete %s workspace cleanup with current SQLite schemas, then completes on retry",
+    async (kind) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+        const workspaceDir = state.statePath("secondary-workspace");
+        const cfg: OpenClawConfig = {
+          agents: {
+            ownership: "explicit",
+            entries: {
+              primary: { workspace: state.workspaceDir },
+              secondary:
+                kind === "configured"
+                  ? { workspace: workspaceDir }
+                  : {
+                      workspace: state.path("secondary-host-workspace"),
+                      sandbox: {
+                        mode: "all",
+                        scope: "shared",
+                        workspaceRoot: workspaceDir,
+                        workspaceAccess: "none",
+                      },
+                    },
+            },
+          },
+        };
+        mocks.config.mockReturnValue(cfg);
+        const sourcePath = await state.writeJson(
+          "secondary-workspace/openclaw-workspace-state.json",
+          {
+            version: 1,
+            setupCompletedAt: "2026-07-15T00:00:00.000Z",
+          },
+        );
+        openOpenClawStateDatabase({ env: state.env });
+        let failCleanup = true;
+        mocks.runContributions.mockImplementation(async (ctx) => {
+          const result = await migrateLegacyWorkspaceState({
+            stateDir: state.stateDir,
+            env: state.env,
+            detected: detectLegacyWorkspaceState({
+              cfg: ctx.cfg,
+              stateDir: state.stateDir,
+              env: state.env,
+              homedir: () => state.home,
+              doctorOnlyStateMigrations: true,
+            }),
+            ...(failCleanup
+              ? {
+                  removeSource: () => {
+                    throw new Error("simulated unlink failure");
+                  },
+                }
+              : {}),
+          });
+          ctx.runtime.log(result.warnings.join("\n"));
+        });
+        const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+        await runCommandWithRuntime(runtime, () =>
+          runDoctorHealthFlow(runtime, { repair: true, nonInteractive: true }),
+        );
+        expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("legacy cleanup failed"));
+        expect(readWorkspaceStateSnapshot(workspaceDir).setup.setupCompletedAt).toBe(
+          "2026-07-15T00:00:00.000Z",
+        );
+        expect(fs.existsSync(`${sourcePath}.doctor-importing`)).toBe(true);
+        expect(() => assertNoUnmigratedWorkspaceState({ workspaceDir })).toThrow(
+          /requires migration/,
+        );
+        expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(1);
+        expect(runtime.error).toHaveBeenCalledWith(
+          expect.stringMatching(/workspace.*requires migration/),
+        );
+        expect(mocks.outro).not.toHaveBeenCalledWith("Doctor complete.");
+
+        failCleanup = false;
+        runtime.exit.mockClear();
+        await runDoctorHealthFlow(runtime, { repair: true, nonInteractive: true });
+        expect(mocks.outro).toHaveBeenCalledWith("Doctor complete.");
+        expect(runtime.exit).not.toHaveBeenCalled();
+        expect(fs.existsSync(`${sourcePath}.doctor-importing`)).toBe(false);
+        expect(() => assertNoUnmigratedWorkspaceState({ workspaceDir })).not.toThrow();
+      });
+    },
+  );
 
   it.each(["missing-state", "missing-agent", "current"])(
     "accepts %s databases without creating or repairing them",

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -148,6 +148,9 @@ export async function runDoctorHealthFlow(runtime?: RuntimeEnv, options: DoctorO
         env: process.env,
       }),
     });
+    const { assertConfiguredWorkspaceStateReady } =
+      await import("../agents/workspace-state-dirs.js");
+    assertConfiguredWorkspaceStateReady({ cfg: ctx.cfg });
   }
   if (ctx.postInstallDoctorResult) {
     const {

--- a/src/gateway/server-startup-plugins.test.ts
+++ b/src/gateway/server-startup-plugins.test.ts
@@ -127,6 +127,10 @@ vi.mock("../agents/agent-scope.js", () => ({
   tryResolveSystemAgentWorkspaceDir: () => "/workspace",
 }));
 
+vi.mock("../agents/workspace-state-dirs.js", () => ({
+  assertConfiguredWorkspaceStateReady: () => {},
+}));
+
 vi.mock("../agents/subagents/registry/subagent-registry.js", () => ({
   initSubagentRegistry: () => initSubagentRegistry(),
 }));

--- a/src/gateway/server-startup-plugins.ts
+++ b/src/gateway/server-startup-plugins.ts
@@ -53,6 +53,8 @@ export async function runGatewayStartupMaintenance(params: {
   minimalTestGateway: boolean;
   log: GatewayPluginBootstrapLog;
 }): Promise<void> {
+  const { assertConfiguredWorkspaceStateReady } = await import("../agents/workspace-state-dirs.js");
+  assertConfiguredWorkspaceStateReady({ cfg: params.cfgAtStart });
   const startupMaintenanceConfig = resolveGatewayStartupMaintenanceConfig({
     cfgAtStart: params.cfgAtStart,
     startupRuntimeConfig: params.startupRuntimeConfig,

--- a/src/gateway/server-startup-workspace-readiness.test.ts
+++ b/src/gateway/server-startup-workspace-readiness.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { writeConfigFile, type OpenClawConfig } from "../config/config.js";
+import {
+  detectLegacyWorkspaceState,
+  migrateLegacyWorkspaceState,
+} from "../infra/state-migrations.workspace-setup.js";
+import {
+  getGatewayTestPort,
+  installGatewayTestHooks,
+  startTestGatewayServer,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+describe("Gateway workspace migration readiness", () => {
+  let server: Awaited<ReturnType<typeof startTestGatewayServer>> | undefined;
+  afterEach(async () => {
+    await server?.close();
+    server = undefined;
+  });
+
+  it("refuses startup for a secondary workspace until Doctor removes its legacy state", async () => {
+    const stateDir = process.env.OPENCLAW_STATE_DIR!;
+    const workspaceDir = path.join(stateDir, "workspace-secondary");
+    const cfg: OpenClawConfig = {
+      gateway: { mode: "local", bind: "loopback", auth: { mode: "none" } },
+      agents: {
+        ownership: "explicit",
+        entries: {
+          main: { workspace: path.join(stateDir, "workspace-main") },
+          secondary: { workspace: workspaceDir },
+        },
+      },
+    };
+    await writeConfigFile(cfg);
+    await fs.mkdir(workspaceDir, { recursive: true });
+    const sourcePath = path.join(workspaceDir, "openclaw-workspace-state.json");
+    await fs.writeFile(
+      sourcePath,
+      JSON.stringify({ version: 1, setupCompletedAt: "2026-07-15T00:00:00.000Z" }),
+    );
+    const port = await getGatewayTestPort();
+
+    await expect(startTestGatewayServer(port, { auth: { mode: "none" } })).rejects.toThrow(
+      "Legacy workspace setup state requires migration",
+    );
+    await expect(fetch(`http://127.0.0.1:${port}/readyz`)).rejects.toThrow();
+    await expect(fs.stat(sourcePath)).resolves.toBeDefined();
+
+    const migration = await migrateLegacyWorkspaceState({
+      stateDir,
+      detected: detectLegacyWorkspaceState({
+        cfg,
+        stateDir,
+        homedir: os.homedir,
+        doctorOnlyStateMigrations: true,
+      }),
+    });
+    expect(migration.warnings).toEqual([]);
+    server = await startTestGatewayServer(port, { auth: { mode: "none" } });
+    const ready = await fetch(`http://127.0.0.1:${port}/readyz`);
+    expect(ready.status).toBe(200);
+    await expect(fs.stat(sourcePath)).rejects.toHaveProperty("code", "ENOENT");
+  });
+});

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -5,7 +5,6 @@ import os from "node:os";
 import path from "node:path";
 import { TextDecoder } from "node:util";
 import { root, type Root } from "@openclaw/fs-safe";
-import { listAgentWorkspaceDirs } from "../agents/workspace-dirs.js";
 import {
   LEGACY_WORKSPACE_ATTESTATION_DIRNAME,
   LEGACY_WORKSPACE_ATTESTATION_HEADER,
@@ -14,6 +13,7 @@ import {
   WORKSPACE_DOCTOR_CLAIM_SUFFIX,
   resolveLegacyWorkspaceSourcePaths,
 } from "../agents/workspace-legacy-state.js";
+import { listWorkspaceStateDirs } from "../agents/workspace-state-dirs.js";
 import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
 import { resolveLegacyStateDirs } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -31,7 +31,6 @@ import {
   readReceipt,
   type MigrationReceipt,
 } from "./state-migrations.workspace-setup-receipts.js";
-import { listSandboxWorkspaceDirs } from "./state-migrations.workspace-setup-sandbox.js";
 import {
   canonicalCoversParsedSource,
   importAndRecordReceipt,
@@ -332,11 +331,7 @@ export function detectLegacyWorkspaceState(params: {
     }
   };
 
-  for (const workspaceDir of listAgentWorkspaceDirs(params.cfg)) {
-    addLegacyWorkspaceSources({ workspaceDir, env, homedir, add });
-  }
-
-  for (const workspaceDir of listSandboxWorkspaceDirs({
+  for (const workspaceDir of listWorkspaceStateDirs({
     cfg: params.cfg,
     env,
     homedir,


### PR DESCRIPTION
Closes #133951

## What Problem This Solves

Fixes an issue where users upgrading and running `openclaw doctor --fix` could receive a successful repair result while leftover workspace migration files still prevented their agents from answering. Gateway startup could likewise report readiness and connect channels before the first turn encountered the same blocker.

## Why This Change Was Made

Doctor completion and Gateway startup now use the workspace owner's existing presence check across every configured agent workspace and active sandbox workspace. Both refuse readiness while a retired setup file, attestation, or interrupted migration claim still blocks a turn, including when the canonical rows already exist in a current-schema SQLite database.

The existing sandbox target resolver is shared with Doctor migration instead of duplicating its selection rules. Migration and verified cleanup remain Doctor-owned; readiness never imports, removes, or overwrites legacy state. Lifecycle checks inspect current files independently of the per-turn verified-absence cache, and unrelated archived-transcript warnings remain advisory.

## User Impact

An incomplete workspace repair produces a nonzero Doctor result and names the affected workspace directories. The Gateway refuses startup before channels accept work until Doctor finishes the migration. Retained sources and receipts remain available for safe retry, and the repair command respects the selected CLI profile.

No configuration option, database schema, protocol version, or migration storage semantics change. Startup refusal happens earlier for state that already prevented the affected agents from executing turns.

## Evidence

- Before the fix, two Doctor boundary regressions reproduced successful exit despite imported SQLite state and a retained `.doctor-importing` claim: one secondary configured workspace and one sandbox workspace. Both failed at the expected nonzero-exit assertion.
- After the fix, the Doctor suite passes both regressions plus existing schema failures, missing-database checks, and archived-transcript advisory behavior.
- A real isolated Gateway test verifies startup refusal and an unreachable `/readyz` with legacy state on a secondary workspace, then runs the real workspace migrator and verifies successful startup with `/readyz` returning HTTP 200.
- An independent process with isolated HOME/state and real migration locks confirms that interrupted cleanup preserves the source claim, both lifecycle and per-turn readiness refuse it, and retry cleanup makes both ready.

Focused verification passed 103 tests across seven suites: Doctor completion (11), Gateway startup wiring (30), actual isolated Gateway readiness (1), workspace runtime guard (10), workspace migration (29), sandbox selection (18), and recreated legacy sources (4). The initial Gateway fixture needed correction to preserve its seeded agent roster; the corrected real-startup run passed. No production change was needed for that fixture correction.

Independent isolated Codex autoreview returned `scoped-clean` at the configured P0 threshold, with no accepted, filtered, or rejected findings. `pnpm build` passed, including runtime packaging, CLI bootstrap, plugin SDK exports, and Control UI bundle checks. `OPENCLAW_VITEST_MAX_WORKERS=4 node scripts/check-changed.mjs` passed, including core and test typechecks, lint, all unused-export scans, database-first storage guards, and zero runtime import cycles. `git diff --check` passed.

Production delta: +40 lines after accounting for the moved sandbox resolver; tests +191 lines; docs +2 lines. The production growth establishes the shared lifecycle readiness boundary and preserves the separate per-turn cache while deleting duplicated workspace selection.

CI integration: the patch is unchanged after rebasing onto `4feff037baaf786d967fbbb6335ad6b97835cbd6` as `151f57949cc30989da0870235e45a074a33ea288`. Earlier CI attempts timed out in the unchanged assistant formatter; current main includes the independently landed loaded-provider error-handling repair #133970. The refreshed exact-head CI run33380835939 passed. Doctor maintenance #134031 is stacked on this readiness boundary and verifies that incomplete cleanup prevents restart.
