### PR TITLE
fix(cli): resolve agent ownership only where setup needs it

### DIFF
--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -44,7 +44,7 @@ Options: `--workspace <dir>`, `--model <id>`, `--agent-dir <dir>`, `--bind <chan
 - The automation flags `--workspace`, `--model`, `--agent-dir`, `--bind`, and `--non-interactive` select the non-interactive path. Non-interactive mode requires both an agent name and `--workspace`.
 - `--json` alone keeps the guided wizard interactive. Prompts and status are written to stderr, and stdout contains one JSON summary after setup completes.
 - `main` is an ordinary agent id. Recreating it after another agent owns the installation can require `openclaw doctor --fix` to repair legacy session or shared-auth ownership first.
-- Interactive mode seeds auth by copying only portable static credentials (`api_key` and static `token` profiles) unless a credential opts out with `copyToAgents: false`; OAuth refresh-token profiles are not copied unless a provider opts in with `copyToAgents: true`. Without a copy, OAuth stays available through the shared auth base. If the configured default agent has its own local OAuth profile, sign in separately for the new agent.
+- Interactive mode offers optional auth copying. When the fleet has no default agent, choose a source agent or **Skip copying auth profiles** (the default). Selecting a source still requires confirmation before copying. Only portable static credentials (`api_key` and static `token` profiles) are copied unless a credential opts out with `copyToAgents: false`; OAuth refresh-token profiles are not copied unless a provider opts in with `copyToAgents: true`. Without a copy, OAuth stays available through the shared auth base. If the source agent has its own local OAuth profile, sign in separately for the new agent.
 
 ### `agents bindings`
 

--- a/docs/cli/configure.md
+++ b/docs/cli/configure.md
@@ -30,6 +30,8 @@ openclaw configure --section gateway --section daemon
 
 Selecting `gateway`, `daemon`, or `health` (or running the full wizard with no `--section`) prompts where the Gateway runs and updates `gateway.mode`. Section filters that skip all three go straight to the requested setup with no gateway-mode prompt. Picking remote gateway mode writes the remote config and exits immediately; it does not run local-only steps like plugin installs.
 
+Gateway, daemon, health, and web settings do not require an agent owner. Workspace, model, plugin, skill, and channel setup use the configured System Agent in an explicit fleet; if none is configured, the wizard asks which existing agent to use. That selection applies to the remaining agent-scoped sections without changing the System Agent setting. Channel setup uses the selected workspace for plugin discovery; removing channel configuration does not require an agent selection.
+
 <Note>
 `openclaw configure` requires an interactive terminal (both stdin and stdout must be TTYs). Without one it prints the equivalent non-interactive `openclaw config get|set|patch|validate` commands and exits with an error instead of partially running.
 </Note>

--- a/packages/ai/src/transports/openai-responses-websocket-client.test.ts
+++ b/packages/ai/src/transports/openai-responses-websocket-client.test.ts
@@ -6,7 +6,13 @@ import {
 } from "@openclaw/llm-core";
 import { WebSocketError } from "openai/resources/responses/internal-base.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createPluginMetadataSnapshot,
+  makeRegistry,
+} from "../../../../src/config/plugin-auto-enable.test-helpers.js";
 import { isRetryableAssistantError } from "../../../../src/llm/utils/retry.js";
+import { createEmptyPluginRegistry } from "../../../../src/plugins/registry-empty.js";
+import { withPluginRuntimeGenerationScope } from "../../../../src/plugins/runtime/generation-scope.js";
 import { configureAiTransportHost, getAiTransportHost } from "../host.js";
 import { cleanupSessionResources } from "../session-resources.js";
 import {
@@ -811,8 +817,10 @@ describe("native OpenAI Responses WebSocket client integration", () => {
     );
 
     const terminalFacts = {
+      provider: "openai",
       stopReason: "error",
       errorMessage: "server_error: 503 temporary provider response",
+      errorCode: "server_error",
       responseId: "resp_failed",
       responseModel: "gpt-5.6-luna-2026-08-01",
       usage: {
@@ -828,8 +836,39 @@ describe("native OpenAI Responses WebSocket client integration", () => {
     expect(sse).toMatchObject(terminalFacts);
     expect(websocket.usage.cost.total).toBeCloseTo(0.000401, 10);
     expect(sse.usage.cost.total).toBeCloseTo(0.000401, 10);
-    expect(isRetryableAssistantError(websocket)).toBe(true);
-    expect(isRetryableAssistantError(sse)).toBe(true);
+    const classifyFailoverReason = vi.fn(() => undefined);
+    const pluginRegistry = createEmptyPluginRegistry();
+    pluginRegistry.providers.push({
+      pluginId: "openai",
+      source: "test",
+      provider: { id: "openai", label: "OpenAI fixture", auth: [], classifyFailoverReason },
+    });
+    // Agent runs prepare a provider owner before retry classification. Keep that boundary
+    // here so the transport fixture exercises core retry policy without plugin discovery.
+    withPluginRuntimeGenerationScope(
+      {
+        config: {},
+        metadataSnapshot: createPluginMetadataSnapshot({
+          manifestRegistry: makeRegistry([{ id: "openai", channels: [], providers: ["openai"] }]),
+        }),
+        pluginRegistry,
+      },
+      () => {
+        expect(isRetryableAssistantError(websocket)).toBe(true);
+        expect(isRetryableAssistantError(sse)).toBe(true);
+      },
+    );
+    const expectedProviderSignal = {
+      provider: "openai",
+      code: "server_error",
+      errorMessage: terminalFacts.errorMessage,
+      errorType: undefined,
+      status: undefined,
+    };
+    expect(classifyFailoverReason.mock.calls).toEqual([
+      [expectedProviderSignal],
+      [expectedProviderSignal],
+    ]);
 
     const next = await run(
       { messages: [userMessage("next", 3)], tools: [] },

--- a/src/channels/plugins/setup-wizard-types.ts
+++ b/src/channels/plugins/setup-wizard-types.ts
@@ -302,6 +302,8 @@ export type ChannelSetupWizard = {
 
 /** Runtime options for selecting and configuring one or more channels. */
 export type SetupChannelsOptions = {
+  /** Workspace already selected by the caller, used for trusted plugin discovery. */
+  workspaceDir?: string;
   allowDisable?: boolean;
   allowIMessageInstall?: boolean;
   allowSignalInstall?: boolean;

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -385,11 +385,7 @@ describe("agents add command", () => {
   });
 
   it("rejects an unrepresentable positional name before targeting an existing agent", async () => {
-    readConfigFileSnapshotMock.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: { agents: { entries: { main: {} } } },
-      sourceConfig: { agents: { entries: { main: {} } } },
-    });
+    setConfigSnapshot({ agents: { entries: { main: {} } } });
     const prompter = {
       intro: vi.fn(),
       text: vi.fn(),
@@ -485,11 +481,7 @@ describe("agents add command", () => {
   );
 
   it("uses the explicit agent target and skips catalog validation", async () => {
-    readConfigFileSnapshotMock.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: { agents: { list: [{ id: "main", default: true }] } },
-      sourceConfig: { agents: { list: [{ id: "main", default: true }] } },
-    });
+    setConfigSnapshot({ agents: { list: [{ id: "main", default: true }] } });
     const prompter = {
       intro: vi.fn(),
       text: vi.fn().mockResolvedValueOnce("Jon").mockResolvedValueOnce("/tmp/openclaw-jon"),
@@ -527,11 +519,7 @@ describe("agents add command", () => {
   it("keeps guided JSON stdout isolated while wizard logs and UI use stderr", async () => {
     const config = { agents: { entries: { work: { id: "work" } } } };
     setConfigSnapshot(config);
-    const wizard = createQueuedWizardPrompter({
-      textValues: ["/tmp/workspace-work"],
-      confirmValues: [true, false],
-    });
-    wizardMocks.createClackPrompter.mockReturnValue(wizard.prompter);
+    useExistingAgentWizard();
     onboardChannelsMocks.setupChannels.mockImplementationOnce(
       async (nextConfig, wizardRuntime, _prompter, options) => {
         wizardRuntime.log("channel log");
@@ -569,11 +557,7 @@ describe("agents add command", () => {
   });
 
   it("surfaces the canonical main gate before guided auth or workspace side effects", async () => {
-    readConfigFileSnapshotMock.mockResolvedValue({
-      ...baseConfigSnapshot,
-      config: { agents: { entries: { robby: { id: "robby" } } } },
-      sourceConfig: { agents: { entries: { robby: { id: "robby" } } } },
-    });
+    setConfigSnapshot({ agents: { entries: { robby: { id: "robby" } } } });
     const prompter = {
       intro: vi.fn(),
       text: vi.fn(),
@@ -644,6 +628,47 @@ describe("agents add command", () => {
     },
   );
 
+  it.each([
+    { source: "__skip__", copy: false, systemAgent: undefined },
+    { source: "ops", copy: true, systemAgent: { agentId: "main" } },
+    { source: "ops", copy: false, systemAgent: undefined },
+  ])("adds to an explicit fleet with optional auth copy: %j", async (testCase) => {
+    await withAgentsAddStateRoot("openclaw-agents-add-explicit-", async (root) => {
+      const workspaceDir = path.join(root, "workspace-work");
+      const sourceAgentDir = await seedAgentAuthStore(root, "ops", {
+        version: AUTH_STORE_VERSION,
+        profiles: {
+          "openai:portable": { type: "api_key", provider: "openai", key: "fixture-only-key" },
+        },
+      });
+      setConfigSnapshot({
+        agents: {
+          ownership: "explicit",
+          defaults: { systemAgent: testCase.systemAgent },
+          entries: { main: {}, ops: { agentDir: sourceAgentDir } },
+        },
+      });
+      const wizard = createQueuedWizardPrompter({
+        textValues: ["work", workspaceDir],
+        selectValues: [testCase.source],
+        confirmValues: testCase.source === "__skip__" ? [false] : [testCase.copy, false],
+      });
+      wizardMocks.createClackPrompter.mockReturnValue(wizard.prompter);
+
+      await agentsAddCommand({}, runtime);
+
+      expect(wizard.outro).toHaveBeenCalledWith('Agent "work" ready.');
+      const copied = loadPersistedAuthProfileStore(path.join(root, "agents", "work", "agent"));
+      expect(copied?.profiles["openai:portable"] !== undefined).toBe(testCase.copy);
+      expect(onboardChannelsMocks.setupChannels).toHaveBeenCalledWith(
+        expect.any(Object),
+        runtime,
+        wizard.prompter,
+        expect.objectContaining({ workspaceDir, deferStatusUntilSelection: true }),
+      );
+    });
+  });
+
   it("fails before config mutation when the source auth store is unreadable", async () => {
     await withAgentsAddStateRoot("openclaw-agents-add-auth-unreadable-", async (root) => {
       const sourceAgentDir = path.join(root, "agents", "main", "agent");
@@ -654,26 +679,15 @@ describe("agents add command", () => {
         "CREATE VIEW auth_profile_store AS SELECT 'primary' AS store_key, '{}' AS store_json;",
       );
       database.close();
-      readConfigFileSnapshotMock.mockResolvedValue({
-        ...baseConfigSnapshot,
-        config: { agents: { list: [{ id: "main", default: true }] } },
-        sourceConfig: { agents: { list: [{ id: "main", default: true }] } },
-      });
-      const prompter = {
-        intro: vi.fn(),
-        text: vi.fn().mockResolvedValueOnce("work").mockResolvedValueOnce(workspaceDir),
-        confirm: vi.fn().mockResolvedValue(false),
-        note: vi.fn(),
-        outro: vi.fn(),
-      };
-      wizardMocks.createClackPrompter.mockReturnValue(prompter);
+      setConfigSnapshot({ agents: { list: [{ id: "main", default: true }] } });
+      const wizard = useFreshAgentWizard({ workspaceDir });
 
       await expect(agentsAddCommand({}, runtime)).rejects.toThrow(
         /auth profile store .* is unreadable; run .*doctor --fix/i,
       );
 
       expect(writeConfigFileMock).not.toHaveBeenCalled();
-      expect(prompter.outro).not.toHaveBeenCalled();
+      expect(wizard.outro).not.toHaveBeenCalled();
     });
   });
 
@@ -993,11 +1007,7 @@ describe("agents add command", () => {
 
   describe("non-interactive config mutation", () => {
     it("creates with explicit non-interactive inputs without a usable terminal", async () => {
-      readConfigFileSnapshotMock.mockResolvedValue({
-        ...baseConfigSnapshot,
-        config: { agents: { list: [{ id: "main", default: true }] } },
-        sourceConfig: { agents: { list: [{ id: "main", default: true }] } },
-      });
+      setConfigSnapshot({ agents: { list: [{ id: "main", default: true }] } });
       terminalMocks.isTerminalInteractive.mockReturnValue(false);
 
       await agentsAddCommand(
@@ -1039,11 +1049,7 @@ describe("agents add command", () => {
         message: 'Invalid binding "telegram:". Account id is empty.',
       },
     ])("reports $name through the root failure owner", async (testCase) => {
-      readConfigFileSnapshotMock.mockResolvedValue({
-        ...baseConfigSnapshot,
-        config: { agents: { list: [{ id: "main", default: true }] } },
-        sourceConfig: { agents: { list: [{ id: "main", default: true }] } },
-      });
+      setConfigSnapshot({ agents: { list: [{ id: "main", default: true }] } });
       createAgentMock.mockResolvedValueOnce(testCase.result);
 
       await expect(

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -12,7 +12,7 @@ import {
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
-  resolveDefaultAgentId,
+  tryResolveLegacyCompatibilityAgentId,
 } from "../agents/agent-scope.js";
 import {
   buildPortableAuthProfileStoreForAgentCopy,
@@ -290,9 +290,21 @@ export async function agentsAddCommand(
     let stagedAuthOrder: AuthProfileStore["order"];
     let reportPortableAuthCopy: (() => Promise<void>) | undefined;
 
-    const defaultAgentId = resolveDefaultAgentId(cfg);
-    if (defaultAgentId !== agentId) {
-      const sourceAgentDir = resolveAgentDir(cfg, defaultAgentId);
+    const copySourceAgentId =
+      tryResolveLegacyCompatibilityAgentId(cfg) ??
+      (await prompter.select({
+        message: "Copy auth profiles from another agent?",
+        initialValue: "__skip__",
+        options: [
+          { value: "__skip__", label: "Skip copying auth profiles" },
+          ...listAgentEntries(cfg)
+            .map((agent) => normalizeAgentId(agent.id))
+            .filter((id) => id !== agentId)
+            .map((id) => ({ value: id, label: id })),
+        ],
+      }));
+    if (copySourceAgentId !== "__skip__" && copySourceAgentId !== agentId) {
+      const sourceAgentDir = resolveAgentDir(cfg, copySourceAgentId);
       const sourceAuthPath = resolveAuthProfileDatabasePath(sourceAgentDir);
       const destAuthPath = resolveAuthProfileDatabasePath(agentDir);
       const sharedMainAgentPath = resolveAuthProfileDatabasePath(resolveSharedMainAuthAgentDir());
@@ -321,7 +333,7 @@ export async function agentsAddCommand(
           Object.keys(destStore?.profiles ?? {}).length === 0
         ) {
           const shouldCopy = await prompter.confirm({
-            message: `Copy portable auth profiles from "${defaultAgentId}"?`,
+            message: `Copy portable auth profiles from "${copySourceAgentId}"?`,
             initialValue: false,
           });
           if (shouldCopy) {
@@ -329,7 +341,7 @@ export async function agentsAddCommand(
             const copiedOAuthProfileIds = copiedProfileIds.filter(
               (profileId) => sourceStore.profiles[profileId]?.type === "oauth",
             );
-            const sourceAgentId = defaultAgentId;
+            const sourceAgentId = copySourceAgentId;
             const sourceInheritedMain = sourceIsInheritedMain;
             const destinationAgentDir = agentDir;
             for (const [profileId, credential] of Object.entries(portable.store.profiles)) {
@@ -355,7 +367,7 @@ export async function agentsAddCommand(
             };
           }
         } else if (skippedOAuthProfiles) {
-          const sourceAgentId = defaultAgentId;
+          const sourceAgentId = copySourceAgentId;
           const sourceInheritedMain = sourceIsInheritedMain;
           reportPortableAuthCopy = async () => {
             await prompter.note(
@@ -423,6 +435,8 @@ export async function agentsAddCommand(
     let selection: ChannelChoice[] = [];
     const channelAccountIds: Partial<Record<ChannelChoice, string>> = {};
     nextConfig = await setupChannels(nextConfig, wizardRuntime, prompter, {
+      workspaceDir,
+      deferStatusUntilSelection: true,
       allowIMessageInstall: true,
       allowSignalInstall: true,
       onSelection: (value) => {

--- a/src/commands/configure.wizard.default-agent.test.ts
+++ b/src/commands/configure.wizard.default-agent.test.ts
@@ -102,6 +102,8 @@ const runtime = {
 describe("runConfigureWizard default-agent ownership", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.select.mockReset();
+    mocks.text.mockReset();
     const baseConfig = {
       agents: {
         defaults: { workspace: "/tmp/global-workspace" },
@@ -234,6 +236,67 @@ describe("runConfigureWizard default-agent ownership", () => {
       runtime,
       expect.objectContaining({ agentId: "main" }),
     );
+  });
+
+  it("selects one explicit owner for workspace, plugins, skills, and channel setup", async () => {
+    const config: OpenClawConfig = {
+      agents: {
+        ownership: "explicit",
+        entries: {
+          alpha: { workspace: "/tmp/alpha-workspace" },
+          beta: { workspace: "/tmp/beta-workspace" },
+        },
+      },
+    };
+    mocks.state.snapshot = {
+      exists: true,
+      valid: true,
+      hash: "config-hash",
+      config,
+      sourceConfig: config,
+      issues: [],
+    };
+    mocks.select.mockResolvedValueOnce("beta").mockResolvedValueOnce("configure");
+    mocks.text.mockResolvedValueOnce("/tmp/new-beta-workspace");
+
+    await runConfigureWizard(
+      { command: "configure", sections: ["workspace", "plugins", "skills", "channels"] },
+      runtime,
+    );
+
+    const committed = mocks.commitConfig.mock.calls[0]?.[0].nextConfig as OpenClawConfig;
+    expect(committed.agents).toEqual({
+      ownership: "explicit",
+      entries: {
+        alpha: { workspace: "/tmp/alpha-workspace" },
+        beta: { workspace: "/tmp/new-beta-workspace" },
+      },
+    });
+    expect(mocks.ensureWorkspaceAndSessions).toHaveBeenCalledWith(
+      "/tmp/new-beta-workspace",
+      runtime,
+      expect.objectContaining({ agentId: "beta" }),
+    );
+    expect(mocks.setupPluginConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: "/tmp/new-beta-workspace" }),
+    );
+    expect(mocks.setupSkills).toHaveBeenCalledWith(
+      expect.any(Object),
+      "/tmp/new-beta-workspace",
+      runtime,
+      expect.any(Object),
+    );
+    expect(mocks.setupChannels).toHaveBeenCalledWith(
+      expect.any(Object),
+      runtime,
+      expect.any(Object),
+      expect.objectContaining({ workspaceDir: "/tmp/new-beta-workspace" }),
+    );
+    expect(
+      mocks.select.mock.calls.filter(
+        ([params]) => params.message === "Which agent do you want to configure?",
+      ),
+    ).toHaveLength(1);
   });
 
   it("preserves the legacy default owner when system-agent ownership is not explicit", async () => {
@@ -384,6 +447,29 @@ describe("runConfigureWizard default-agent ownership", () => {
     expect(hook).toHaveBeenCalledOnce();
     expect(mocks.commitConfig.mock.invocationCallOrder[0]!).toBeLessThan(
       hook.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("can remove channel configuration without selecting an agent", async () => {
+    const config: OpenClawConfig = {
+      agents: { ownership: "explicit", entries: { alpha: {}, beta: {} } },
+    };
+    mocks.state.snapshot = {
+      exists: true,
+      valid: true,
+      hash: "config-hash",
+      config,
+      sourceConfig: config,
+      issues: [],
+    };
+    mocks.select.mockResolvedValueOnce("remove");
+
+    await runConfigureWizard({ command: "configure", sections: ["channels"] }, runtime);
+
+    expect(mocks.setupChannels).not.toHaveBeenCalled();
+    expect(mocks.select).toHaveBeenCalledOnce();
+    expect(mocks.commitConfig).toHaveBeenCalledWith(
+      expect.objectContaining({ nextConfig: config }),
     );
   });
 });

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -57,6 +57,34 @@ describe("runConfigureWizard", () => {
     setupWizardTestDefaults();
   });
 
+  it.each(["gateway", "daemon", "health", "web"] as const)(
+    "configures %s without requiring an agent owner",
+    async (section) => {
+      const config: OpenClawConfig = {
+        agents: { ownership: "explicit", entries: { alpha: {}, beta: {} } },
+        gateway: { mode: "local" },
+      };
+      setupBaseWizardState(config);
+      queueWizardPrompts({ select: section === "web" ? [] : ["local"], confirm: [false, false] });
+
+      await runConfigureWizard({ command: "configure", sections: [section] }, createRuntime());
+
+      expect(mocks.promptAuthConfig).not.toHaveBeenCalled();
+      expect(mocks.clackSelect).not.toHaveBeenCalledWith(
+        expect.objectContaining({ message: "Which agent do you want to configure?" }),
+      );
+      if (section === "gateway") {
+        expect(mocks.promptGatewayConfig).toHaveBeenCalledOnce();
+      } else if (section === "daemon") {
+        expect(mocks.maybeInstallDaemon).toHaveBeenCalledOnce();
+      } else if (section === "health") {
+        expect(mocks.healthCommand).toHaveBeenCalledOnce();
+      } else {
+        expect(getWebSearch(requireWriteConfig()).enabled).toBe(false);
+      }
+    },
+  );
+
   it("persists provider-owned web search config changes returned by setupSearch", async () => {
     setupBaseWizardState();
     mocks.setupSearch.mockImplementation(async (cfg: OpenClawConfig) => {

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -3,6 +3,11 @@ import fsPromises from "node:fs/promises";
 import nodePath from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { note } from "../../packages/terminal-core/src/note.js";
+import {
+  listAgentIds,
+  tryResolveAmbientOwnerAgentId,
+  tryResolveLegacyCompatibilityAgentId,
+} from "../agents/agent-scope-config.js";
 import { describeCodexNativeWebSearch } from "../agents/codex-native-web-search.shared.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { formatPortRangeHint } from "../cli/error-format.js";
@@ -47,7 +52,6 @@ import { healthCommandNonExiting } from "./health.js";
 import {
   ensureOnboardingAgentWorkspace,
   resolveOnboardingAgentTarget,
-  resolveSystemAgentOnboardingTarget,
 } from "./onboard-agent-target.js";
 import { setupChannels } from "./onboard-channels.js";
 import {
@@ -606,13 +610,29 @@ export async function runConfigureWizard(
         },
       };
     }
-    // Configure keeps legacy default-owner semantics; only explicit fleets opt into
-    // the System Agent target used unconditionally by setup and recovery callers.
-    const resolveSetupTarget = () =>
-      nextConfig.agents?.ownership === "explicit"
-        ? resolveSystemAgentOnboardingTarget(nextConfig)
-        : resolveOnboardingAgentTarget(inheritLegacyDefaultAgentId(baseConfig, nextConfig));
-    let workspaceDir = resolveSetupTarget().workspaceDir;
+    let setupAgentId: string | undefined;
+    const resolveSetupTarget = async () => {
+      // Only agent-scoped steps choose an owner; keep that choice across sections.
+      if (nextConfig.agents?.ownership !== "explicit") {
+        inheritLegacyDefaultAgentId(baseConfig, nextConfig);
+      }
+      setupAgentId ??=
+        nextConfig.agents?.ownership === "explicit"
+          ? tryResolveAmbientOwnerAgentId(nextConfig)
+          : tryResolveLegacyCompatibilityAgentId(nextConfig);
+      const agentIds = listAgentIds(nextConfig);
+      if (!setupAgentId && agentIds.length > 1) {
+        setupAgentId = guardCancel(
+          await select({
+            message: "Which agent do you want to configure?",
+            options: agentIds.map((id) => ({ value: id, label: id })),
+          }),
+          runtime,
+          1,
+        );
+      }
+      return resolveOnboardingAgentTarget(nextConfig, setupAgentId);
+    };
     let gatewayPort = resolveGatewayPort(baseConfig);
     let didPersistConfig = false;
     let daemonSetupOutcome: DaemonSetupOutcome | undefined;
@@ -642,15 +662,16 @@ export async function runConfigureWizard(
     };
 
     const configureWorkspace = async () => {
+      const target = await resolveSetupTarget();
       const workspaceInput = guardCancel(
         await text({
           message: "Workspace directory",
-          initialValue: workspaceDir,
+          initialValue: target.workspaceDir,
         }),
         runtime,
         1,
       );
-      workspaceDir = resolveUserPath(
+      const workspaceDir = resolveUserPath(
         normalizeOptionalString(workspaceInput ?? "") || DEFAULT_WORKSPACE,
       );
       if (!snapshot.exists) {
@@ -679,7 +700,6 @@ export async function runConfigureWizard(
           );
         }
       }
-      const target = resolveSetupTarget();
       const authoredEntryKey = Object.keys(nextConfig.agents?.entries ?? {}).find(
         (key) => normalizeAgentId(key) === target.agentId,
       );
@@ -711,10 +731,7 @@ export async function runConfigureWizard(
                 },
               },
             };
-    };
-
-    const provisionWorkspace = async () => {
-      await ensureOnboardingAgentWorkspace(resolveSetupTarget(), runtime, {
+      await ensureOnboardingAgentWorkspace(await resolveSetupTarget(), runtime, {
         skipBootstrap: Boolean(nextConfig.agents?.defaults?.skipBootstrap),
         skipOptionalBootstrapFiles: nextConfig.agents?.defaults?.skipOptionalBootstrapFiles,
       });
@@ -723,7 +740,9 @@ export async function runConfigureWizard(
     const configureChannelsSection = async () => {
       const channelMode = await promptChannelMode(runtime);
       if (channelMode === "configure") {
+        const target = await resolveSetupTarget();
         nextConfig = await setupChannels(nextConfig, runtime, prompter, {
+          workspaceDir: target.workspaceDir,
           allowDisable: true,
           allowIMessageInstall: true,
           allowSignalInstall: true,
@@ -752,12 +771,14 @@ export async function runConfigureWizard(
 
     let didConfigureGateway = false;
     const sectionActions = {
-      workspace: async () => {
-        await configureWorkspace();
-        await provisionWorkspace();
-      },
+      workspace: configureWorkspace,
       model: async () => {
-        nextConfig = await promptAuthConfig(nextConfig, runtime, prompter, resolveSetupTarget());
+        nextConfig = await promptAuthConfig(
+          nextConfig,
+          runtime,
+          prompter,
+          await resolveSetupTarget(),
+        );
       },
       web: async () => {
         nextConfig = await promptWebToolsConfig(nextConfig, runtime, prompter);
@@ -774,13 +795,13 @@ export async function runConfigureWizard(
         nextConfig = await configurePluginConfig({
           config: nextConfig,
           prompter,
-          workspaceDir: resolveSetupTarget().workspaceDir,
+          workspaceDir: (await resolveSetupTarget()).workspaceDir,
         });
       },
       skills: async () => {
         nextConfig = await setupSkills(
           nextConfig,
-          resolveSetupTarget().workspaceDir,
+          (await resolveSetupTarget()).workspaceDir,
           runtime,
           prompter,
         );

--- a/src/flows/channel-setup.status.test.ts
+++ b/src/flows/channel-setup.status.test.ts
@@ -110,6 +110,24 @@ describe("resolveChannelSetupSelectionContributions", () => {
     isChannelConfigured.mockReturnValue(false);
   });
 
+  it("uses the caller-selected workspace for explicit-fleet status and selection notes", async () => {
+    const params = {
+      cfg: { agents: { ownership: "explicit" as const, entries: { alpha: {}, beta: {} } } },
+      workspaceDir: "/tmp/beta-workspace",
+      accountOverrides: {},
+      installedPlugins: [],
+      selection: [],
+    };
+
+    await collectChannelStatus(params);
+    resolveChannelSelectionNoteLines(params);
+
+    expect(resolveChannelSetupEntries).toHaveBeenCalledTimes(2);
+    for (const [request] of resolveChannelSetupEntries.mock.calls) {
+      expect(request.workspaceDir).toBe(params.workspaceDir);
+    }
+  });
+
   it("uses the configured system agent workspace for explicit multi-agent setup", async () => {
     const cfg = {
       agents: {

--- a/src/flows/channel-setup.status.ts
+++ b/src/flows/channel-setup.status.ts
@@ -352,13 +352,14 @@ export function findBundledSourceForCatalogChannel(params: {
 
 export async function collectChannelStatus(params: {
   cfg: OpenClawConfig;
+  workspaceDir?: string;
   options?: SetupChannelsOptions;
   accountOverrides: Partial<Record<ChannelChoice, string>>;
   installedPlugins?: ChannelSetupPlugin[];
   resolveAdapter?: (channel: ChannelChoice) => ChannelSetupWizardAdapter | undefined;
 }): Promise<ChannelStatusSummary> {
   const installedPlugins = params.installedPlugins ?? listChannelSetupPlugins();
-  const workspaceDir = resolveChannelSetupWorkspaceDir(params.cfg);
+  const workspaceDir = params.workspaceDir ?? resolveChannelSetupWorkspaceDir(params.cfg);
   const { installedCatalogEntries, installableCatalogEntries } = resolveChannelSetupEntries({
     cfg: params.cfg,
     installedPlugins,
@@ -543,13 +544,14 @@ export function resolveQuickstartDefault(
 
 export function resolveChannelSelectionNoteLines(params: {
   cfg: OpenClawConfig;
+  workspaceDir?: string;
   installedPlugins: ChannelSetupPlugin[];
   selection: ChannelChoice[];
 }): string[] {
   const { entries } = resolveChannelSetupEntries({
     cfg: params.cfg,
     installedPlugins: params.installedPlugins,
-    workspaceDir: resolveChannelSetupWorkspaceDir(params.cfg),
+    workspaceDir: params.workspaceDir ?? resolveChannelSetupWorkspaceDir(params.cfg),
   });
   const selectionNotes = new Map<string, string>();
   for (const entry of entries) {

--- a/src/flows/channel-setup.test.ts
+++ b/src/flows/channel-setup.test.ts
@@ -336,6 +336,21 @@ describe("setupChannels workspace shadow exclusion", () => {
     expect(resolveChannelSetupWorkspaceDir).toHaveBeenCalledWith(cfg);
   });
 
+  it("does not load or probe channels when optional deferred setup is declined", async () => {
+    const cfg = { agents: { ownership: "explicit" as const, entries: { alpha: {}, beta: {} } } };
+
+    const result = await runChannelSetup(
+      cfg,
+      { confirm: vi.fn(async () => false) },
+      { workspaceDir: "/tmp/beta-workspace", deferStatusUntilSelection: true },
+    );
+
+    expect(result).toBe(cfg);
+    expect(collectChannelStatus).not.toHaveBeenCalled();
+    expect(listTrustedChannelPluginCatalogEntries).not.toHaveBeenCalled();
+    expect(loadChannelSetupPluginRegistrySnapshotForChannel).not.toHaveBeenCalled();
+  });
+
   it("keeps trusted workspace overrides eligible during preload", async () => {
     listTrustedChannelPluginCatalogEntries.mockReturnValue([
       { id: "external-chat", pluginId: "trusted-external-chat-shadow", origin: "workspace" },

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -146,7 +146,9 @@ export async function setupChannels(
     ...options?.accountIds,
   };
   const scopedPluginsById = new Map<ChannelChoice, ChannelSetupPlugin>();
-  const resolveWorkspaceDir = () => resolveChannelSetupWorkspaceDir(next);
+  let preparedWorkspaceDir = options?.workspaceDir;
+  const resolveWorkspaceDir = () =>
+    (preparedWorkspaceDir ??= resolveChannelSetupWorkspaceDir(next));
   const rememberScopedPlugin = (plugin: ChannelSetupPlugin) => {
     const channel = plugin.id;
     scopedPluginsById.set(channel, plugin);
@@ -265,6 +267,7 @@ export async function setupChannels(
     ? { statusByChannel: new Map<ChannelChoice, ChannelSetupStatus>(), statusLines: [] }
     : await collectChannelStatus({
         cfg: next,
+        workspaceDir: resolveWorkspaceDir(),
         options,
         accountOverrides,
         installedPlugins: listVisibleInstalledPlugins(),
@@ -1027,6 +1030,7 @@ export async function setupChannels(
 
   const selectedLines = resolveChannelSelectionNoteLines({
     cfg: next,
+    workspaceDir: resolveWorkspaceDir(),
     installedPlugins: listVisibleInstalledPlugins(),
     selection,
   });


### PR DESCRIPTION
## What Problem This Solves

An explicit multi-agent installation could fail with `AGENT_SELECTION_REQUIRED` when running `agents add` or configuring Gateway, health, or web settings. The guided add command required a default agent for optional credential copying, and configure resolved a workspace before it knew which section needed one. Channel setup also discarded the selected agent workspace and resolved an ambient owner again.

Closes #133959.

Related: #128637 (multi-agent compatibility issues; this change addresses guided setup ownership, not exec reviewer ownership).

## Why This Change Was Made

Resolve an agent when a step actually needs one. Preserve configured System Agent and legacy owner semantics, prompt for an existing agent when an explicit fleet has no ambient owner, and retain that selection across setup sections. Pass the selected workspace through channel discovery, status, and selection notes. Optional auth copying offers a source or Skip and retains explicit copy confirmation and existing credential portability restrictions. Optional channel setup defers discovery until the operator accepts it.

## User Impact

Gateway, daemon, health, and web settings work without a global agent owner. Agent-scoped setup can target an existing agent without changing the System Agent configuration. Adding an agent works in explicit fleets with and without a System Agent, and selecting Skip copies no credentials. Removing channel configuration remains independent of agent workspace ownership.

Release-note context: fix multi-agent guided setup failing on unnecessary default-agent resolution; thanks to @msipes for reporting upgrade recovery friction.

## Evidence

Real built CLI, driven through a PTY with isolated synthetic HOME/state/config and no credentials:

| Scenario | Before | After |
| --- | --- | --- |
| `configure --section web`, explicit two-agent fleet, no System Agent | Owner error, exit 1 | Both web prompts complete; exit 0 |
| `configure --section workspace`, same fleet | Owner error, exit 1 | Select beta, provision beta workspace; exit 0 |
| `agents add gamma`, same fleet | Owner error after workspace prompt, exit 1 | Skip auth copying, decline model and channel setup, gamma ready; exit 0 |
| `agents add gamma`, System Agent alpha configured | Owner error after workspace prompt, exit 1 | Same flow completes, alpha retained as System Agent; exit 0 |

The new owner regressions failed on pre-fix source. Focused tests cover all global configure sections, retained legacy/System Agent ownership, one selected owner across workspace/plugins/skills/channels, owner-free channel removal, prepared workspace propagation into discovery/status/notes, and declined optional channel setup without plugin loading. Agent-add tests exercise real isolated SQLite auth storage for Skip, explicit copy, declined copy, portability, rollback, and config publication.

- 167 unique tests across eight focused files pass. After the final cleanup, the agent-add and channel flow suites were rerun: 97 tests pass.
- `pnpm build` passes, including SDK declarations, external plugin artifacts, Control UI, and bootstrap checks. The exact final runtime was refreshed with the existing `qaRuntime` build profile, which also passes.
- `check:changed` planned gates pass across the initial run and focused reruns: formatting, architectural guards, all core/plugin production and test type lanes, changed-core lint, and full plugin lint. Initial max-lines and no-shadow findings were fixed by reusing existing test helpers and renaming the cached local; affected types/tests/lint were rerun.
- Diff formatting, `git diff --check`, and independent Codex autoreview pass; autoreview returned no actionable findings at its configured P0-only scope.

Production delta: +43 lines; tests +192; docs +2. Growth implements explicit interactive owner/source selection and carries the selected workspace across the channel setup boundary. The eager workspace lookup and separate provisioning wrapper are removed; existing test fixture helpers replace 35 duplicated setup lines. No new config, environment, database schema, or protocol options; the setup options type gains an optional prepared workspace field.

Live proof deliberately declines provider and channel setup. Real credentials and outbound channel delivery are outside this CLI-owner change; channel discovery/status ownership is covered by focused tests.

CI follow-up: both initial hosted attempts hit the existing WebSocket/SSE terminal test's 120-second timeout. Linux phase tracing showed both transports completing within 3 ms, followed by 79.5 seconds of cold provider discovery during retry classification. The fixture now supplies the existing prepared provider generation, with a real registered classifier callback returning no policy override. The original transport and real core retry assertions remain, and exact provider/error-code/hook signals are asserted. Full-file proof passes 19/19 on Linux (terminal case 12 ms) and macOS; changed gates including typecheck/lint and fresh isolated autoreview pass. This follow-up changes tests only (+41/-2), with no timeout changes. Linux proof: https://github.com/openclaw/openclaw/actions/runs/33378374717. Both commits remain patch-identical after rebase onto `9b4c3d5f1b216884872452a7c780b13320298b5d`.
