### PR TITLE
refactor(core): share UTF-16 ellipsis truncation

### DIFF
--- a/src/agents/subagents/spawn/acp-spawn-parent-stream.ts
+++ b/src/agents/subagents/spawn/acp-spawn-parent-stream.ts
@@ -2,11 +2,7 @@
 import { asFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord as asObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import {
-  sliceUtf16Safe,
-  truncateUtf16Safe,
-  truncateWithMarker,
-} from "@openclaw/normalization-core/utf16-slice";
+import { sliceUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   isAcpTagVisible,
   resolveAcpProjectionSettings,
@@ -29,6 +25,7 @@ import { createSubsystemLogger } from "../../../logging/subsystem.js";
 import { resolveNormalizedAccountEntry } from "../../../routing/account-lookup.js";
 import { normalizeAccountId } from "../../../routing/session-key.js";
 import { normalizeAssistantPhase } from "../../../shared/chat-message-content.js";
+import { truncateUtf16WithEllipsis as truncate } from "../../../shared/text-truncate.js";
 import { recordTaskRunProgressByRunId } from "../../../tasks/detached-task-runtime.js";
 import type { DeliveryContext } from "../../../utils/delivery-context.types.js";
 import {
@@ -54,16 +51,6 @@ type AcpParentProgressStreamingConfig = StreamingCompatEntry & {
 
 function compactWhitespace(value: string): string {
   return value.replace(/\s+/g, " ").trim();
-}
-
-function truncate(value: string, maxChars: number): string {
-  if (value.length <= maxChars) {
-    return value;
-  }
-  if (maxChars <= 1) {
-    return truncateUtf16Safe(value, maxChars);
-  }
-  return truncateWithMarker(value, maxChars, { marker: "…", reserve: 1, trimEnd: false });
 }
 
 function normalizeStringArray(value: unknown): string[] {

--- a/src/auto-reply/reply/acp-projector.ts
+++ b/src/auto-reply/reply/acp-projector.ts
@@ -4,13 +4,14 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
-import { truncateUtf16Safe, truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { resolveAcpToolTerminalOutcome } from "../../acp/tool-status.js";
 import { EmbeddedBlockChunker } from "../../agents/embedded-agent-block-chunker.js";
 import { createVerifiedConversationContextStreamFilter } from "../../agents/embedded-agent-helpers/sanitize-user-facing-text.js";
 import { formatToolSummary, resolveToolDisplay } from "../../agents/tool-display.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { prefixSystemMessage } from "../../infra/system-message.js";
+import { truncateUtf16WithEllipsis as truncateText } from "../../shared/text-truncate.js";
 import type { ReplyPayload } from "../types.js";
 import {
   type AcpHiddenBoundarySeparator,
@@ -46,16 +47,6 @@ type BufferedToolDelivery = {
   payload: ReplyPayload;
   meta?: AcpProjectedDeliveryMeta;
 };
-
-function truncateText(input: string, maxChars: number): string {
-  if (input.length <= maxChars) {
-    return input;
-  }
-  if (maxChars <= 1) {
-    return truncateUtf16Safe(input, maxChars);
-  }
-  return truncateWithMarker(input, maxChars, { marker: "…", reserve: 1, trimEnd: false });
-}
 
 function hashText(text: string): string {
   return text.trim();

--- a/src/commands/flows.ts
+++ b/src/commands/flows.ts
@@ -1,7 +1,6 @@
 /** CLI commands for listing, inspecting, and cancelling TaskFlow records. */
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
-import { truncateUtf16Safe, truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { formatCliCommand } from "../cli/command-format.js";
@@ -10,6 +9,7 @@ import { formatCliJsonFailure } from "../cli/failure-output.js";
 import { getRuntimeConfig } from "../config/config.js";
 import { info } from "../globals.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import { truncateUtf16WithEllipsis as truncate } from "../shared/text-truncate.js";
 import { listTasksForFlowId } from "../tasks/runtime-internal.js";
 import { cancelFlowById, getFlowTaskSummary } from "../tasks/task-executor.js";
 import {
@@ -37,16 +37,6 @@ const CTRL_PAD = 20;
 
 function formatFlowLookupMiss(lookup: string): string {
   return `TaskFlow not found: ${sanitizeTerminalText(lookup)}. Run ${formatCliCommand("openclaw tasks flow list")} to see recent flow ids.`;
-}
-
-function truncate(value: string, maxChars: number) {
-  if (value.length <= maxChars) {
-    return value;
-  }
-  if (maxChars <= 1) {
-    return truncateUtf16Safe(value, maxChars);
-  }
-  return truncateWithMarker(value, maxChars, { marker: "…", reserve: 1, trimEnd: false });
 }
 
 function safeFlowDisplayText(value: string | undefined, maxChars?: number): string {

--- a/src/shared/text-truncate.test.ts
+++ b/src/shared/text-truncate.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { truncateUtf16WithEllipsis } from "./text-truncate.js";
+
+describe("truncateUtf16WithEllipsis", () => {
+  it.each([
+    { name: "keeps text at the boundary", value: "abcd", maxLength: 4, expected: "abcd" },
+    { name: "adds an ellipsis", value: "abcdef", maxLength: 4, expected: "abc…" },
+    { name: "returns empty for a negative limit", value: "abc", maxLength: -1, expected: "" },
+    { name: "returns empty for a zero limit", value: "abc", maxLength: 0, expected: "" },
+    { name: "keeps one safe code unit", value: "abc", maxLength: 1, expected: "a" },
+    {
+      name: "drops a leading surrogate pair at limit one",
+      value: "😀a",
+      maxLength: 1,
+      expected: "",
+    },
+    { name: "avoids a dangling surrogate at limit two", value: "😀a", maxLength: 2, expected: "…" },
+    {
+      name: "avoids a dangling surrogate at larger limits",
+      value: "a😀bc",
+      maxLength: 3,
+      expected: "a…",
+    },
+    {
+      name: "preserves whitespace before the marker",
+      value: "ab  cd",
+      maxLength: 5,
+      expected: "ab  …",
+    },
+  ])("$name", ({ value, maxLength, expected }) => {
+    expect(truncateUtf16WithEllipsis(value, maxLength)).toBe(expected);
+  });
+});

--- a/src/shared/text-truncate.ts
+++ b/src/shared/text-truncate.ts
@@ -1,0 +1,11 @@
+import { truncateUtf16Safe, truncateWithMarker } from "@openclaw/normalization-core/utf16-slice";
+
+export function truncateUtf16WithEllipsis(value: string, maxLength: number): string {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  if (maxLength <= 1) {
+    return truncateUtf16Safe(value, maxLength);
+  }
+  return truncateWithMarker(value, maxLength, { marker: "…", reserve: 1, trimEnd: false });
+}


### PR DESCRIPTION
## What Problem This Solves

Three internal rendering paths independently owned the same UTF-16-safe ellipsis truncation policy. The copies were behaviorally identical but could drift as agent relay, ACP projection, and TaskFlow output evolve.

## Why This Change Was Made

This moves the exact shared policy into one private core helper and routes all three existing callers through it. The helper preserves UTF-16 length comparison, safe handling for limits at or below one, one-code-unit U+2026 reservation for larger limits, whitespace, and surrogate boundaries.

Intentionally excluded helpers keep their distinct contracts:

- `src/commands/tasks.ts` emits an ellipsis at limit one.
- `src/agents/bash-process-references.ts` uses the ASCII marker `...`.
- `src/shared/subagents-format.ts` trims whitespace and uses partial ASCII markers.
- No normalization-core, Plugin SDK, or barrel export was added.

The three implementations converged to this behavior in https://github.com/openclaw/openclaw/pull/120350.

## User Impact

No user-visible behavior change. The same output is now governed by one internal implementation.

## Evidence

- Focused Vitest: 95 tests passed across the shared helper, ACP parent relay, ACP projector, and TaskFlow command suites.
- Test audit: the new table protects the independently meaningful small-limit, U+2026, whitespace, and surrogate-boundary contract used by three production callers; existing integration tests do not cover all of those cases.
- `pnpm check:changed`: passed, including core/test typechecks, lint, dead-export scanning, schema guards, and runtime import-cycle validation.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `git diff --check`: passed.
- Pinned Sol/high autoreview: clean, 0.99.
- Production LOC: +16/-37, net -21. Tests: +33/-0.
- The prior overlap audit covered 2,220 open pull requests. Execution-time refresh rechecked https://github.com/openclaw/openclaw/pull/119585, https://github.com/openclaw/openclaw/pull/119589, and https://github.com/openclaw/openclaw/pull/129388; their current patches touch imports or unrelated branches, not the consolidated helper bodies.
