### PR TITLE
fix(gateway): release cached transcript backing storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3334,11 +3334,15 @@ jobs:
                   lint_args=(--only=scripts --threads=1)
                 fi
                 export GOMAXPROCS=2
+                # Match local Go GC policy; thread limits alone leave the
+                # extension semantic graph too large for a 16GB runner.
+                export GOGC=30 GOMEMLIMIT=3GiB
               elif [ "$(nproc)" -lt 8 ]; then
                 # Fork PRs build each semantic Program once. Bound both oxlint
                 # and its Go helper within the 4-core/16GB hosted runner.
                 lint_args=(--threads=1)
                 export GOMAXPROCS=2
+                export GOGC=30 GOMEMLIMIT=3GiB
               fi
               if [[ ! -f scripts/run-oxlint-shards.mts ]]; then
                 # The candidate's older shard runner owns all three source

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -490,6 +490,9 @@ ratchet-down when cleanup lowers the real count.
 
 ## Local equivalents
 
+Hosted extension lint also uses the local Go garbage-collection policy;
+limiting worker threads alone does not bound the helper's heap.
+
 Oxlint keeps `eslint/no-redeclare` enabled for JavaScript. For `.ts`, `.tsx`,
 `.mts`, and `.cts`, `tsgo` owns declaration validity, including intentional
 type/value pairs with the same public name. `eslint/no-var` remains enabled

--- a/src/commands/doctor-session-sqlite.memory.test.ts
+++ b/src/commands/doctor-session-sqlite.memory.test.ts
@@ -23,6 +23,10 @@ beforeAll(async () => {
     bundle: true,
     entryPoints: [fileURLToPath(sqliteImportMemorySupportUrl)],
     format: "esm",
+    // Keep generated source overhead out of the transcript-data heap budget;
+    // preserve function/class names used by runtime dispatch and diagnostics.
+    minify: true,
+    keepNames: true,
     outfile: childPath,
     packages: "external",
     platform: "node",

--- a/src/config/types.telegram.ts
+++ b/src/config/types.telegram.ts
@@ -13,6 +13,7 @@ import type {
   CommonChannelMessagingConfig,
 } from "./types.channel-messaging-common.js";
 import type { ProviderCommandsConfig } from "./types.messages.js";
+import type { SecretInput } from "./types.secrets.js";
 import type { GroupToolPolicyBySenderConfig, GroupToolPolicyConfig } from "./types.tools.js";
 
 export type TelegramActionConfig = {
@@ -88,7 +89,7 @@ export type TelegramAccountConfig = CommonChannelMessagingConfig<
     commands?: ProviderCommandsConfig;
     /** Custom commands to register in Telegram's command menu (merged with native). */
     customCommands?: TelegramCustomCommand[];
-    botToken?: string;
+    botToken?: SecretInput;
     /** Path to a regular file containing the bot token; symlinks are rejected. */
     tokenFile?: string;
     groups?: Record<string, TelegramGroupConfig>;

--- a/src/gateway/session-transcript-title-reader.retention.test.ts
+++ b/src/gateway/session-transcript-title-reader.retention.test.ts
@@ -1,0 +1,93 @@
+import { spawnSync } from "node:child_process";
+import { expect, test } from "vitest";
+
+test.each(["scalar", "batch"])(
+  "releases transcript payloads after caching %s title fields",
+  (mode) => {
+    const moduleUrl = (relative: string) => new URL(relative, import.meta.url).href;
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--expose-gc",
+        "--import",
+        "tsx",
+        "--input-type=module",
+        "--eval",
+        `
+          import path from "node:path";
+          import { setImmediate as yieldTurn } from "node:timers/promises";
+          import { persistSessionTranscriptTurn, upsertSessionEntryCore } from ${JSON.stringify(moduleUrl("../config/sessions/session-accessor.ts"))};
+          import { readSessionTitleFieldsFromTranscript, readSessionTitleFieldsFromTranscriptBatch } from ${JSON.stringify(moduleUrl("./session-transcript-title-reader.ts"))};
+          import { deriveSessionTitle } from ${JSON.stringify(moduleUrl("./session-utils-core.ts"))};
+          import { withOpenClawTestState } from ${JSON.stringify(moduleUrl("../test-utils/openclaw-test-state.ts"))};
+
+          async function heapUsed() {
+            await yieldTurn();
+            for (let index = 0; index < 3; index++) globalThis.gc();
+            return process.memoryUsage().heapUsed;
+          }
+
+          await withOpenClawTestState({ label: "title-cache-retention" }, async (state) => {
+            const storePath = path.join(state.sessionsDir("main"), "sessions.json");
+            const scopes = [];
+            for (let index = 0; index < 128; index++) {
+              const sessionId = "preview-" + index;
+              const sessionKey = "agent:main:dashboard:" + sessionId;
+              const scope = { agentId: "main", sessionId, sessionKey, storePath };
+              await upsertSessionEntryCore(scope, { sessionId, updatedAt: 1, displayName: "Named session" });
+              await persistSessionTranscriptTurn(scope, {
+                messages: [
+                  { message: { role: "user", content: index + ": " + "abcdefg ".repeat(32 * 1024) } },
+                  { message: { role: "assistant", content: "Short reply." } },
+                ],
+                touchSessionEntry: false,
+              });
+              scopes.push(scope);
+            }
+            const before = await heapUsed();
+            const listRows = () => {
+              const fields = ${JSON.stringify(mode)} === "scalar"
+                ? scopes.map((scope) => readSessionTitleFieldsFromTranscript(scope))
+                : readSessionTitleFieldsFromTranscriptBatch(scopes);
+              return fields.map((field, index) => ({
+                derivedTitle: deriveSessionTitle({ sessionId: scopes[index].sessionId, updatedAt: 1, displayName: "Named session" }, field.firstUserMessage),
+                lastMessagePreview: field.lastMessagePreview,
+              }));
+            };
+            // Named sessions do not consume the cached first-user preview. Serializing
+            // that unused field here would flatten its slices and hide the retention.
+            const rows = listRows();
+            JSON.stringify(rows);
+            const retainedBytes = (await heapUsed()) - before;
+            const unicodeScope = { ...scopes[0], sessionId: "unicode-preview", sessionKey: "agent:main:unicode-preview" };
+            await persistSessionTranscriptTurn(unicodeScope, {
+              messages: [{ message: { role: "user", content: String.fromCharCode(0xd800) + " visible text" } }],
+              touchSessionEntry: false,
+            });
+            const unicodePreview = readSessionTitleFieldsFromTranscript(unicodeScope).firstUserMessage;
+            process.stdout.write(JSON.stringify({ retainedBytes, rows, unicodePreview }));
+          });
+        `,
+      ],
+      { cwd: process.cwd(), encoding: "utf8", timeout: 20_000 },
+    );
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    const output = JSON.parse(result.stdout) as {
+      retainedBytes: number;
+      rows: { derivedTitle: string; lastMessagePreview: string }[];
+      unicodePreview: string;
+    };
+    expect(output.rows).toEqual(
+      Array.from({ length: 128 }, () => ({
+        derivedTitle: "Named session",
+        lastMessagePreview: "Short reply.",
+      })),
+    );
+    expect(output.unicodePreview).toBe("\ud800 visible text");
+    // The source prompts total 32 MiB; allow allocator/JIT noise while rejecting
+    // caches that retain those payloads behind their 240-character previews.
+    expect(output.retainedBytes).toBeLessThan(8 * 1024 * 1024);
+  },
+  30_000,
+);

--- a/src/gateway/session-transcript-title-reader.ts
+++ b/src/gateway/session-transcript-title-reader.ts
@@ -110,6 +110,12 @@ function findLastMessageText(
   return text;
 }
 
+function copySessionTitleText(text: string | null): string | null {
+  // V8 slices can pin whole transcript payloads behind a short cached preview.
+  // Copy UTF-16 code units so ownership changes without altering lone surrogates.
+  return text === null ? null : Buffer.from(text, "utf16le").toString("utf16le");
+}
+
 function hydrateSqliteTitleFields(
   target: ResolvedTranscriptReadTarget,
   opts?: { includeInterSession?: boolean },
@@ -169,7 +175,10 @@ function hydrateSqliteTitleFields(
         opts?.includeInterSession === true,
       );
     }
-    const fields = { firstUserMessage: firstText, lastMessagePreview: lastText };
+    const fields = {
+      firstUserMessage: copySessionTitleText(firstText),
+      lastMessagePreview: copySessionTitleText(lastText),
+    };
     const fieldsByVariant = current ? cached.fields : {};
     fieldsByVariant[variant] = fields;
     // Retain only the watermark and bounded strings, never the probe's transcript payloads.

--- a/ui/src/e2e/chat-composer-focus.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-focus.e2e.test.ts
@@ -209,7 +209,7 @@ suite.define(() => {
     });
   });
 
-  it("uses a visible neutral focus treatment in dark and light themes", async () => {
+  it("changes neutral focus styling in dark and light themes", async () => {
     await suite.withPage({ viewport: { width: 1440, height: 900 } }, async ({ page }) => {
       const gateway = await installMockGateway(page);
       await page.goto(`${suite.server.baseUrl}chat`);
@@ -220,21 +220,23 @@ suite.define(() => {
       await composer.waitFor({ state: "visible" });
 
       for (const theme of ["dark", "light"] as const) {
-        await page.evaluate((nextTheme) => {
-          document.documentElement.dataset.theme = "claw";
-          document.documentElement.dataset.themeMode = nextTheme;
-        }, theme);
+        await page.emulateMedia({ colorScheme: theme });
+        await expect
+          .poll(() => page.evaluate(() => document.documentElement.dataset.themeMode))
+          .toBe(theme);
         await textarea.evaluate((element) => element.blur());
-        await page.waitForTimeout(150);
-        const unfocused = await composer.evaluate((element) => {
+        const unfocused = await composer.evaluate(async (element) => {
+          await Promise.all(element.getAnimations().map((animation) => animation.finished));
           const style = getComputedStyle(element);
-          return { borderColor: style.borderColor, boxShadow: style.boxShadow };
+          const { width, height } = element.getBoundingClientRect();
+          return { borderColor: style.borderColor, boxShadow: style.boxShadow, width, height };
         });
 
         await textarea.focus();
-        await page.waitForTimeout(150);
-        const focused = await composer.evaluate((element) => {
+        const focused = await composer.evaluate(async (element) => {
+          await Promise.all(element.getAnimations().map((animation) => animation.finished));
           const style = getComputedStyle(element);
+          const { width, height } = element.getBoundingClientRect();
           const parseRgb = (color: string): [number, number, number] => {
             const values = color
               .match(/[\d.]+/g)
@@ -247,31 +249,13 @@ suite.define(() => {
               color.startsWith("color(srgb") ? values.map((value) => value * 255) : values
             ) as [number, number, number];
           };
-          const luminance = (color: string): number => {
-            const linearize = (channel: number) => {
-              const normalized = channel / 255;
-              return normalized <= 0.04045
-                ? normalized / 12.92
-                : ((normalized + 0.055) / 1.055) ** 2.4;
-            };
-            const channels = parseRgb(color);
-            return (
-              0.2126 * linearize(channels[0]) +
-              0.7152 * linearize(channels[1]) +
-              0.0722 * linearize(channels[2])
-            );
-          };
-          const borderLuminance = luminance(style.borderColor);
-          const surfaceLuminance = luminance(style.backgroundColor);
           const borderChannels = parseRgb(style.borderColor);
-          const contrast =
-            (Math.max(borderLuminance, surfaceLuminance) + 0.05) /
-            (Math.min(borderLuminance, surfaceLuminance) + 0.05);
 
           return {
             borderColor: style.borderColor,
             boxShadow: style.boxShadow,
-            contrast,
+            width,
+            height,
             neutralChannelSpread: Math.max(...borderChannels) - Math.min(...borderChannels),
           };
         });
@@ -281,7 +265,7 @@ suite.define(() => {
           unfocused.boxShadow,
         ]);
         expect(focused.neutralChannelSpread).toBeLessThanOrEqual(24);
-        expect(focused.contrast).toBeGreaterThanOrEqual(3);
+        expect([focused.width, focused.height]).toEqual([unfocused.width, unfocused.height]);
       }
     });
   });


### PR DESCRIPTION
Closes #133941.

## What Problem This Solves

Listing named sessions with long first messages retained whole prompt allocations through short cached title fields. The strings were bounded, but V8 slices could still reference the complete source storage. The defect is present in stable v2026.8.1; its original introducing commit is not established.

## Why This Change Was Made

The shared scalar/batch title-cache hydration owner now copies both bounded UTF-16 fields before retaining them. This releases source allocations while preserving every code unit, including lone surrogates, and the existing watermark, capacity and display behavior.

Validation also exposed excessive memory in type-aware plugin lint. Pinned tsgolint discovers ancestor projects independently of the CLI's named config. Tests excluded from package build configs fell into the repository-wide program, loading 35,548 source files. Main now owns the canonical plugin-level project and executable regression through #134216, so this PR removes its duplicate project/test/docs changes. The two constrained CI commands inherit the existing local Go GC policy. Main's small-host chunking remains intact.

The browser theme test now waits for real CSS transitions and system-theme changes. Its obsolete opaque contrast calculation predated the intentional translucent composer redesign in #124301; the replacement checks changed neutral paint and stable geometry. Main owns the dropdown lifecycle synchronization from #134014. Telegram's bot-token TypeScript declaration also matches the SecretInput contract already supported by its schema, resolver and docs; main owns the accompanying recovery-fixture corrections from #134207.

## User Impact

Session-list previews retain less unnecessary prompt data. There are no new operator options, runtime defaults, schemas, persistence semantics, dependencies, timeouts or fallback paths. The CI GC controls change as described above. The bot-token declaration accepts an existing supported input shape.

## Evidence

| Matched workload | Before | After |
| --- | ---: | ---: |
| Title-cache retained heap: 128 SQLite-backed named sessions, 256 KiB first prompts | 33,582,616 bytes | 58,656 bytes |
| RSS increase in the same cache probe | 35,373,056 bytes | 344,064 bytes |
| Profiled plugin lint peak RSS on macOS | 19,865,108,480 bytes | 9,232,711,680 bytes |

The 99.8% heap reduction is specific to the title-cache probe. It serializes only displayed fields; serializing an unused preview would flatten the V8 slice and conceal the bug. Scalar and batch regressions fail before the copy, and all 36 title/projection cases pass, including lone-surrogate preservation.

Lint preserves all 8,684 targets, 123 package owners and 39 unmatched JavaScript files. Exactly 3,995 targets move from the root to the plugin project; its largest program falls to about 23,900 source files. The [pinned Oxlint bridge](https://github.com/oxc-project/oxc/blob/oxlint_v1.79.0/crates/oxc_linter/src/tsgolint.rs#L346-L399), [project discovery](https://github.com/oxc-project/tsgolint/blob/v7.0.2001/cmd/tsgolint/headless.go#L242-L311) and [program construction](https://github.com/oxc-project/tsgolint/blob/v7.0.2001/internal/linter/linter.go#L94-L168) were inspected directly. More GC work costs CPU: 78.85 seconds versus 43.61 seconds. The Go target is soft. These local measurements cover the unsplit workload; hosted runner shutdowns alone do not establish OOM.

An isolated real Gateway served the built UI and CLI against a deterministic local provider: chat, 50 reconnects, 30 short sessions and deletion, 64 long-prompt sessions, repeated polling, and eight concurrent tool turns with four history clients and four subscribers. The repaired run completed 699 history probes and 50 mutations without errors. HTTP-401 failure and post-cooldown recovery produced visible outcomes and terminal events correlated to the exact browser request. A final rebuilt CLI listed 68 sessions with titles/previews, and the UI completed its unique reply. These are functional and workload-specific memory proofs, not an external-model benchmark or a whole-Gateway reduction percentage. Screenshots and raw traces remain local.

## Validation and Landing

The initial runtime composition passed 82 focused cases and a full build. The lint investigation passed 202 configuration/workflow cases with two existing skips, a regression that fails before the project-owner fix, and the full changed-file gate. The final six-file composition on main ce8ea4a28ef passes nine Gateway/retention cases, all 14 canonical lint-contract cases, a fresh UI build and nine built-browser composer/agent-identity cases. No product UI behavior or accessibility contrast certification is claimed.

The complete patch previously passed [CI run 33401520877](https://github.com/openclaw/openclaw/actions/runs/33401520877), including a targeted lint retry on an actual 4-CPU, 16 GiB hosted worker. That is capacity proof without a Linux peak-RSS measurement. The rebased composition passed its formerly failing Gateway type/lint checks. The six-file memory composition and the subsequent four-line fixture correction both have clean independent Codex reviews at the default P0 scope.

The final candidate `696ea30e61d6c316885e7260b163216afb7705ce` passed [CI run 33417488596](https://github.com/openclaw/openclaw/actions/runs/33417488596): 225 successful checks, no failed or unfinished checks. The exact-head ClawSweeper review has no source/security finding; its final-CI rank-up requirement is satisfied. The preceding run passed final lint, browser shard 13 and real-Gateway browser proof, but its deep migration fixture exhausted the 256 MiB child heap. The fixture recently gained the full public Doctor dependency graph through #133864. Local phase traces found about 174 MB already used before import and about 266 MB at projection replay startup. The existing fixture fix from #134252 compacts generated code with [esbuild's name-preserving minification](https://esbuild.github.io/api/#keep-names), leaving all source paths, datasets, 256 MiB limits, timeouts, byte hashes, projections and repeat-import checks intact. All three cases pass locally and in the final Linux job 99571978385; a deliberate eager-payload-retention mutation still aborts with heap exhaustion under the compact bundle. This is a test-fixture repair, not an additional production-memory claim.

An earlier run had one Vault malformed-response subprocess failure. All 28 Vault cases passed locally unchanged; its assertion omitted stdout, so that hosted cause remains unproven. The final composition's plugin lane passed unchanged. No runtime guard, timeout increase or assertion weakening was applied.

Delta against inspected main: production +12/-2 (net +10: bounded title ownership +9, existing token type contract +1); tests +112/-31 (net +81); internal workflow +4; docs +3. Root changelog is release-owned; this body supplies release-note context.

## Related Work and Follow-ups

UI transcript retention landed separately in #133965. Concurrent #133970/#134008 own the cold failure-path repair; provisional duplicate code was removed, and historical cold-path savings are not attributed to this PR.

Named follow-ups: session-lineage cache lifecycle, archive-index payload budgeting, Matrix crypto installer's undefined error variable after a network reset, background continuation cleanup during competing work, Web Awesome's early-navigation reset during opening, and the separate webhook-secret type/runtime boundary. Vault's test also needs better subprocess diagnostics and consistent fixture-environment ownership before any future intermittent failure can be attributed. These observations do not establish additional memory defects in this repair.


## Landed Verification

Merged as [4cef1ee1f262](https://github.com/openclaw/openclaw/commit/4cef1ee1f262147e21e1d5da26dc2876cd8cacd6); issue #133941 is closed. Native prepare and merge completed on the reviewed source head. The merged commit then passed the complete [main CI run 33420068148](https://github.com/openclaw/openclaw/actions/runs/33420068148), including lint, the real-Gateway browser lane, both Windows lanes, and the Linux migration-memory shard.

The actual squash changes six files, +127/-33: production +12/-2, tests +108/-31, workflow +4, docs +3. The identical four-line migration fixture correction had already landed in #134252, so it adds no duplicate lines in this squash. The reviewed title-cache, token declaration, and browser-test bytes are unchanged in the merge.
