### PR TITLE
fix(gateway): require protocol evidence for readiness

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2557,7 +2557,7 @@ src/commands/doctor/shared/stale-oauth-profile-shadows.ts	1
 src/commands/doctor/shared/stale-plugin-repair-preservation.ts	1
 src/commands/doctor/shared/stale-subagent-allowlist.ts	2
 src/commands/export-trajectory.ts	1
-src/commands/gateway-health-auth-diagnostic.ts	2
+src/commands/gateway-health-auth-diagnostic.ts	1
 src/commands/gateway-presence.ts	1
 src/commands/gateway-status/helpers.ts	11
 src/commands/message-format.ts	20

--- a/docs/cli/dashboard.md
+++ b/docs/cli/dashboard.md
@@ -30,6 +30,10 @@ The OpenClaw CLI and the background Gateway service are separate. A service-inst
 prompt refers to the background service for the selected profile; it does not mean the
 CLI is missing. The dashboard needs a running Gateway, which can also run in a terminal.
 
+If the configured port is busy but its Gateway handshake cannot be verified, the dashboard
+reports the failed probe and does not offer to start another service. Run
+`openclaw gateway status --deep` to inspect the listener and repair its connection.
+
 A newer database schema warning means this build cannot read the existing state. Use a
 compatible build with that state. To start fresh, point `OPENCLAW_STATE_DIR` at a separate
 directory. Installing the background service does not resolve a database version mismatch. See

--- a/packages/gateway-client/src/client.ts
+++ b/packages/gateway-client/src/client.ts
@@ -205,6 +205,7 @@ export type GatewayClientCloseInfo = {
 };
 
 export { GatewayClientRequestError } from "./request-error.js";
+export { isGatewayProtocolResponseError } from "./protocol-request.js";
 
 export class GatewayClientRequestTimeoutError extends GatewayProtocolRequestTimeoutError {
   constructor(params: { method: string; timeoutMs: number; requestSent: boolean }) {

--- a/packages/gateway-client/src/protocol-client.request.test.ts
+++ b/packages/gateway-client/src/protocol-client.request.test.ts
@@ -8,6 +8,7 @@ import {
   type GatewayProtocolRequestTiming,
   type GatewayProtocolSocketHandlers,
 } from "./protocol-client.js";
+import { isGatewayProtocolResponseError } from "./protocol-request.js";
 import { MAX_SAFE_TIMEOUT_DELAY_MS } from "./timeouts.js";
 
 type RequestFrame = {
@@ -138,6 +139,7 @@ describe("GatewayProtocolClient requests", () => {
         ]);
         for (const [index, error] of errors.entries()) {
           expect(error).toBeInstanceOf(GatewayProtocolRequestError);
+          expect(isGatewayProtocolResponseError(error)).toBe(true);
           expect(error).toMatchObject({
             ...fields,
             gatewayCode: fields.code,

--- a/packages/gateway-client/src/protocol-request.ts
+++ b/packages/gateway-client/src/protocol-request.ts
@@ -1,5 +1,14 @@
 import type { ErrorShape } from "@openclaw/gateway-protocol";
 
+const gatewayResponseErrors = new WeakSet<Error>();
+
+/** Distinguishes correlated Gateway responses from locally constructed transport errors. */
+export function isGatewayProtocolResponseError(
+  error: unknown,
+): error is GatewayProtocolRequestError {
+  return error instanceof Error && gatewayResponseErrors.has(error);
+}
+
 export type GatewayProtocolRequestOptions = {
   timeoutMs?: number | null;
   expectFinal?: boolean;
@@ -32,6 +41,7 @@ export function retainGatewayResponsePayload(
   error: GatewayProtocolRequestError,
   payload: unknown,
 ): void {
+  gatewayResponseErrors.add(error);
   Object.defineProperty(error, "responsePayload", {
     value: payload,
     enumerable: false,

--- a/src/agents/tools/image-tool.test.ts
+++ b/src/agents/tools/image-tool.test.ts
@@ -15,6 +15,7 @@ import type {
   ImagesDescriptionRequest,
   MediaUnderstandingProvider,
 } from "../../plugin-sdk/media-understanding.js";
+import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { withFetchPreconnect } from "../../test-utils/fetch-mock.js";
 import {
@@ -2762,7 +2763,7 @@ describe("image tool MiniMax VLM routing", () => {
     vi.stubEnv("MINIMAX_API_KEY", "minimax-test");
     const cfg = createMinimaxImageConfig();
     const tool = createRequiredImageTool({ config: cfg, agentDir });
-    return { fetch: fetchMock, tool };
+    return { fetch: fetchMock, tool, cfg, agentDir };
   }
 
   it("accepts path for single-image requests and calls minimaxUnderstandImage", async () => {
@@ -2887,14 +2888,39 @@ describe("image tool MiniMax VLM routing", () => {
   });
 
   it("surfaces MiniMax API errors from /v1/coding_plan/vlm", async () => {
-    const { tool } = await createMinimaxVlmFixture({ status_code: 1004, status_msg: "bad key" });
+    const { tool, cfg, agentDir } = await createMinimaxVlmFixture({
+      status_code: 1004,
+      status_msg: "bad key",
+    });
+    const generation = createModelGenerationFixture({
+      agentDir,
+      workspaceDir: state.workspaceDir,
+      config: cfg,
+      label: "minimax-vlm",
+      provider: "minimax",
+      requestProvider: "minimax",
+    });
+    const classifyFailoverReason = vi.fn(() => undefined);
+    expectDefined(
+      generation.pluginRegistry.providers[0],
+      "MiniMax provider registration",
+    ).provider.classifyFailoverReason = classifyFailoverReason;
 
+    // Embedded tools inherit this registry scope before provider error classification.
     await expect(
-      tool.execute("t1", {
-        prompt: "Describe the image.",
-        path: `data:image/png;base64,${ONE_PIXEL_PNG_B64}`,
-      }),
+      withPluginRuntimeGenerationScope(generation.preparedModelRuntime, () =>
+        tool.execute("t1", {
+          prompt: "Describe the image.",
+          path: `data:image/png;base64,${ONE_PIXEL_PNG_B64}`,
+        }),
+      ),
     ).rejects.toThrow(/MiniMax VLM API error/i);
+    expect(classifyFailoverReason).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: "minimax",
+        errorMessage: "MiniMax VLM API error (1004): bad key.",
+      }),
+    );
   });
 });
 

--- a/src/cli/daemon-cli/probe.reachability.test.ts
+++ b/src/cli/daemon-cli/probe.reachability.test.ts
@@ -1,0 +1,180 @@
+import { once } from "node:events";
+import { afterEach, assert, describe, expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
+import { ensureGatewayReadyForOperation } from "../../commands/gateway-readiness.js";
+import {
+  buildMinimalGatewayHelloOkPayload,
+  closeMinimalGatewayServer,
+  parseMinimalGatewayRequestFrame,
+  sendMinimalGatewayConnectChallenge,
+  sendMinimalGatewayResponse,
+  startMinimalRealGateway,
+} from "../../gateway/minimal-gateway.test-helpers.js";
+import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { probeGatewayStatus } from "./probe.js";
+import type { DaemonStatus } from "./status.gather.js";
+
+const cleanups: Array<() => Promise<void>> = [];
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0).toReversed()) {
+    await cleanup();
+  }
+});
+
+async function checkDashboardReadiness(url: string, rpc: NonNullable<DaemonStatus["rpc"]>) {
+  const port = Number(new URL(url).port);
+  const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+  const confirm = vi.fn();
+  const startGateway = vi.fn();
+  const installGateway = vi.fn();
+  const result = await ensureGatewayReadyForOperation({
+    runtime,
+    operation: "open the dashboard",
+    readyWhenReachable: true,
+    interactive: true,
+    deps: {
+      confirm,
+      startGateway,
+      installGateway,
+      gatherStatus: async () => ({
+        service: {
+          label: "synthetic stopped service",
+          loaded: false,
+          loadState: { status: "not-loaded" },
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          command: null,
+          runtime: { status: "stopped" },
+        },
+        port: { port, status: "busy", listeners: [], hints: [] },
+        rpc: { ...rpc, url },
+        extraServices: [],
+      }),
+    },
+  });
+  expect(confirm).not.toHaveBeenCalled();
+  expect(startGateway).not.toHaveBeenCalled();
+  expect(installGateway).not.toHaveBeenCalled();
+  return { result, output: runtime.log.mock.calls.flat().join("\n") };
+}
+
+describe("Gateway reachability over real sockets", () => {
+  it.each(["terminate", "policy-close", "silent", "upgrade-rejected"] as const)(
+    "does not start a second service or accept a %s listener",
+    async (mode) => {
+      const state = await createOpenClawTestState();
+      cleanups.push(() => state.cleanup());
+      const wss = new WebSocketServer({
+        host: "127.0.0.1",
+        port: 0,
+        ...(mode === "upgrade-rejected" ? { verifyClient: () => false } : {}),
+      });
+      cleanups.push(() => closeMinimalGatewayServer(wss));
+      wss.on("connection", (ws) => {
+        if (mode === "terminate") {
+          ws.terminate();
+        } else if (mode === "policy-close") {
+          ws.close(1008, "pairing required");
+        }
+      });
+      await once(wss, "listening");
+      const address = wss.address();
+      if (typeof address === "string" || !address) {
+        throw new Error("missing test listener address");
+      }
+      const url = `ws://127.0.0.1:${address.port}`;
+      const rpc = await probeGatewayStatus({ url, config: {}, timeoutMs: 400, json: true });
+      assert(!rpc.ok);
+      expect(rpc.gatewayReached).toBeUndefined();
+      if (mode === "terminate") {
+        expect(rpc.error).toContain("gateway closed (1006)");
+      }
+      const { result, output } = await checkDashboardReadiness(url, rpc);
+      expect(result).toMatchObject({ ready: false, recoverable: false });
+      expect(output).toContain("Gateway probe failed:");
+      expect(output).not.toContain("Gateway is not running");
+      expect(output).not.toContain("gateway start");
+    },
+  );
+
+  it("preserves the accepted handshake when a subsequent status RPC fails", async () => {
+    const state = await createOpenClawTestState();
+    cleanups.push(() => state.cleanup());
+    const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+    cleanups.push(() => closeMinimalGatewayServer(wss));
+    wss.on("connection", (ws) => {
+      sendMinimalGatewayConnectChallenge(ws);
+      ws.on("message", (data) => {
+        const frame = parseMinimalGatewayRequestFrame(data);
+        if (frame.method === "connect") {
+          sendMinimalGatewayResponse(
+            ws,
+            frame.id!,
+            buildMinimalGatewayHelloOkPayload({
+              methods: ["status"],
+              auth: { role: "operator", scopes: ["operator.read"] },
+            }),
+          );
+        } else {
+          ws.send(
+            JSON.stringify({
+              type: "res",
+              id: frame.id,
+              ok: false,
+              error: { code: "UNAVAILABLE", message: "synthetic status failure" },
+            }),
+          );
+        }
+      });
+    });
+    await once(wss, "listening");
+    const address = wss.address();
+    if (typeof address === "string" || !address) {
+      throw new Error("missing test listener address");
+    }
+    const url = `ws://127.0.0.1:${address.port}`;
+    const rpc = await probeGatewayStatus({
+      url,
+      token: "synthetic-token",
+      config: {},
+      timeoutMs: 2_000,
+      json: true,
+      requireRpc: true,
+    });
+    expect(rpc).toMatchObject({
+      ok: false,
+      gatewayReached: true,
+      error: "synthetic status failure",
+      capability: "read_only",
+      server: { version: "test", connId: "conn-test" },
+    });
+    expect((await checkDashboardReadiness(url, rpc)).result.ready).toBe(true);
+  });
+
+  it("accepts a real Gateway auth rejection as reachable without starting another service", async () => {
+    const gateway = await startMinimalRealGateway();
+    cleanups.push(() => gateway.close());
+    const rejected = await probeGatewayStatus({
+      url: gateway.url,
+      token: "synthetic-wrong-token",
+      config: {},
+      timeoutMs: 5_000,
+      json: true,
+    });
+    expect(rejected).toMatchObject({
+      ok: false,
+      gatewayReached: true,
+      connectFailure: { kind: "auth-rejected" },
+    });
+    expect((await checkDashboardReadiness(gateway.url, rejected)).result.ready).toBe(true);
+    const accepted = await probeGatewayStatus({
+      url: gateway.url,
+      token: gateway.token,
+      config: {},
+      timeoutMs: 5_000,
+      json: true,
+    });
+    expect(accepted.ok).toBe(true);
+    expect((await checkDashboardReadiness(gateway.url, accepted)).result.ready).toBe(true);
+  });
+});

--- a/src/cli/daemon-cli/probe.test.ts
+++ b/src/cli/daemon-cli/probe.test.ts
@@ -1,5 +1,5 @@
 // Daemon probe tests cover gateway probe command behavior and output.
-import { describe, expect, it, vi } from "vitest";
+import { assert, describe, expect, it, vi } from "vitest";
 import { gatewayProbeResultSawGateway } from "../../commands/gateway-health-auth-diagnostic.js";
 import { probeGatewayStatus } from "./probe.js";
 import type { DaemonStatus } from "./status.gather.js";
@@ -47,6 +47,7 @@ describe("probeGatewayStatus", () => {
       error,
       close: { code: 1008, reason: "pairing required" },
       auth: pairingPendingAuth,
+      gatewayReached: true,
     });
   }
 
@@ -55,6 +56,7 @@ describe("probeGatewayStatus", () => {
       ok: false,
       kind: "connect",
       capability: "pairing_pending",
+      gatewayReached: true,
       auth: pairingPendingAuth,
       connectFailure: { kind: "pairing-required" },
       error: "gateway closed (1008): pairing required",
@@ -114,6 +116,7 @@ describe("probeGatewayStatus", () => {
         secret: "do-not-print",
       },
       auth: pairingPendingAuth,
+      gatewayReached: true,
     });
 
     const result = await probeGatewayStatus({
@@ -122,7 +125,7 @@ describe("probeGatewayStatus", () => {
       json: true,
     });
 
-    expect(result.ok).toBe(false);
+    assert(!result.ok);
     if (result.ok) {
       throw new Error("expected failed gateway probe");
     }
@@ -139,7 +142,7 @@ describe("probeGatewayStatus", () => {
     expect(json).not.toContain("scope-upgrade");
   });
 
-  it("classifies a legacy pairing close when the probe error is generic", async () => {
+  it("classifies a legacy pairing close without treating its prose as Gateway evidence", async () => {
     probeGatewayMock.mockResolvedValueOnce({
       ok: false,
       error: "connect failed",
@@ -152,35 +155,37 @@ describe("probeGatewayStatus", () => {
       json: true,
     });
 
-    expect(result.ok).toBe(false);
+    assert(!result.ok);
     if (result.ok) {
       throw new Error("expected failed gateway probe");
     }
     expect(result.error).toBe("connect failed");
     expect(result.connectFailure).toEqual({ kind: "pairing-required" });
-    expect(gatewayProbeResultSawGateway(result)).toBe(true);
-  });
-
-  it("does not classify an unvalidated transport close as a reachable gateway", async () => {
-    probeGatewayMock.mockResolvedValueOnce({
-      ok: false,
-      error: "connect ECONNREFUSED 127.0.0.1:19191",
-      close: { code: 1006, reason: "" },
-    });
-
-    const result = await probeGatewayStatus({
-      url: "ws://127.0.0.1:19191",
-      timeoutMs: 5_000,
-      json: true,
-    });
-
-    expect(result.ok).toBe(false);
-    if (result.ok) {
-      throw new Error("expected failed gateway probe");
-    }
-    expect(result.connectFailure).toEqual({ kind: "unreachable" });
     expect(gatewayProbeResultSawGateway(result)).toBe(false);
   });
+
+  it.each(["connect ECONNREFUSED 127.0.0.1:19191", "gateway closed (1006): ", null])(
+    "does not treat an unvalidated transport close with error %s as a Gateway response",
+    async (error) => {
+      probeGatewayMock.mockResolvedValueOnce({
+        ok: false,
+        error,
+        close: { code: 1006, reason: "" },
+      });
+
+      const result = await probeGatewayStatus({
+        url: "ws://127.0.0.1:19191",
+        timeoutMs: 5_000,
+        json: true,
+      });
+
+      assert(!result.ok);
+      if (result.ok) {
+        throw new Error("expected failed gateway probe");
+      }
+      expect(gatewayProbeResultSawGateway(result)).toBe(false);
+    },
+  );
 
   it("projects authentication rate limits as reachable temporary lockouts", async () => {
     probeGatewayMock.mockResolvedValueOnce({
@@ -196,6 +201,7 @@ describe("probeGatewayStatus", () => {
         recommendedNextStep: "wait_then_retry",
         retryAfterMs: 60_000,
       },
+      gatewayReached: true,
     });
 
     const result = await probeGatewayStatus({
@@ -204,7 +210,7 @@ describe("probeGatewayStatus", () => {
       json: true,
     });
 
-    expect(result.ok).toBe(false);
+    assert(!result.ok);
     if (result.ok) {
       throw new Error("expected failed gateway probe");
     }
@@ -234,7 +240,7 @@ describe("probeGatewayStatus", () => {
       json: true,
     });
 
-    expect(result.ok).toBe(false);
+    assert(!result.ok);
     if (result.ok) {
       throw new Error("expected failed gateway probe");
     }
@@ -557,7 +563,7 @@ describe("probeGatewayStatus", () => {
       timeoutMs: 5_000,
     });
 
-    expect(result.ok).toBe(false);
+    assert(!result.ok);
     expect(result.kind).toBe("connect");
     expect(result.error).toBe("scope upgrade pending approval (requestId: req-123)");
   });
@@ -576,7 +582,7 @@ describe("probeGatewayStatus", () => {
       timeoutMs: 5_000,
     });
 
-    expect(result.ok).toBe(false);
+    assert(!result.ok);
     expect(result.error).not.toContain("secret");
     expect(result.error).not.toContain("abc123");
     expect(result.error).toContain("ws://***:***@gw.example.com:18789?token=***");
@@ -594,7 +600,7 @@ describe("probeGatewayStatus", () => {
       timeoutMs: 5_000,
     });
 
-    expect(result.ok).toBe(false);
+    assert(!result.ok);
     expect(result.error).not.toContain("secret");
     expect(result.error).toContain("ws://***:***@gw.example.com:18789");
   });

--- a/src/cli/daemon-cli/probe.ts
+++ b/src/cli/daemon-cli/probe.ts
@@ -1,5 +1,6 @@
 // Gateway status probe helper used by `gateway status` service diagnostics.
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
+import { isGatewayProtocolResponseError } from "../../../packages/gateway-client/src/protocol-request.js";
 import {
   classifyGatewayConnectFailure,
   ConnectErrorDetailCodes,
@@ -65,6 +66,9 @@ export async function probeGatewayStatus(opts: {
   configPath?: string;
 }) {
   const kind = (opts.requireRpc ? "read" : "connect") satisfies GatewayStatusProbeKind;
+  let auth: GatewayProbeAuthSummary | undefined;
+  let server: GatewayProbeServerSummary | undefined;
+  let gatewayReached = false;
   try {
     const result = await withProgress(
       {
@@ -82,8 +86,6 @@ export async function probeGatewayStatus(opts: {
           }
           const { resolveProbeAuthSummary } = await loadProbeGatewayModule();
           const { callGateway } = await import("../../gateway/call.js");
-          let auth: GatewayProbeAuthSummary | undefined;
-          let server: GatewayProbeServerSummary | undefined;
           await callGateway({
             url: opts.url,
             localPortOverride: opts.localPortOverride,
@@ -97,6 +99,7 @@ export async function probeGatewayStatus(opts: {
             sharedStateMode: "read-only",
             ...(opts.configPath ? { configPath: opts.configPath } : {}),
             onHelloOk: (hello) => {
+              gatewayReached = true;
               auth = resolveProbeAuthSummary({
                 role: hello.auth.role,
                 scopes: hello.auth.scopes,
@@ -124,8 +127,8 @@ export async function probeGatewayStatus(opts: {
         });
       },
     );
-    const auth = result.auth;
-    const server = result.server;
+    auth = result.auth;
+    server = result.server;
     const serverSummary = server ? { server } : {};
     const version = server?.version ?? null;
     if (result.ok) {
@@ -147,6 +150,7 @@ export async function probeGatewayStatus(opts: {
     return {
       ok: false,
       kind,
+      ...(result.gatewayReached ? { gatewayReached: true as const } : {}),
       capability: auth?.capability,
       auth,
       ...serverSummary,
@@ -165,7 +169,15 @@ export async function probeGatewayStatus(opts: {
     return {
       ok: false,
       kind,
-      connectFailure: projectGatewayConnectFailure({ message: error }),
+      ...(gatewayReached || isGatewayProtocolResponseError(err)
+        ? { gatewayReached: true as const }
+        : {}),
+      ...(auth ? { auth, capability: auth.capability } : {}),
+      ...(server ? { server, ...(server.version != null ? { version: server.version } : {}) } : {}),
+      connectFailure: projectGatewayConnectFailure({
+        message: error,
+        ...(isGatewayProtocolResponseError(err) ? { details: err.details } : {}),
+      }),
       error,
     } as const;
   }

--- a/src/cli/daemon-cli/restart-health-external.test.ts
+++ b/src/cli/daemon-cli/restart-health-external.test.ts
@@ -113,6 +113,7 @@ describe("restart health", () => {
       });
       probeGateway.mockResolvedValue({
         ok: false,
+        gatewayReached: true,
         close: { code: 1008, reason: "device identity required" },
       });
       const previousLockIdentity = mockGatewayLockReplacement({ pid: 4300 });

--- a/src/cli/daemon-cli/restart-health-probe.test.ts
+++ b/src/cli/daemon-cli/restart-health-probe.test.ts
@@ -173,6 +173,7 @@ describe("restart health", () => {
       close: null,
       connectLatencyMs: 12,
       error: "missing scope: operator.read",
+      gatewayReached: true,
       auth: { capability: "connected_no_operator_scope" },
       server: { version: "2026.4.24", connId: "new" },
     });

--- a/src/cli/daemon-cli/restart-health-probe.ts
+++ b/src/cli/daemon-cli/restart-health-probe.ts
@@ -174,13 +174,14 @@ export async function confirmGatewayReachable(params: {
     });
     const reachedGateway =
       probe.ok ||
-      looksLikeAuthClose(probe.close?.code, probe.close?.reason) ||
-      (params.allowDeviceIdentityRequired === true &&
-        probe.close?.code === 1008 &&
-        normalizeLowercaseStringOrEmpty(probe.close.reason) === "device identity required") ||
-      (probe.connectLatencyMs != null &&
-        probe.server?.version != null &&
-        probe.auth.capability === "connected_no_operator_scope");
+      (probe.gatewayReached === true &&
+        (looksLikeAuthClose(probe.close?.code, probe.close?.reason) ||
+          (params.allowDeviceIdentityRequired === true &&
+            probe.close?.code === 1008 &&
+            normalizeLowercaseStringOrEmpty(probe.close.reason) === "device identity required") ||
+          (probe.connectLatencyMs != null &&
+            probe.server?.version != null &&
+            probe.auth.capability === "connected_no_operator_scope")));
     return {
       reachable: reachedGateway,
       gatewayVersion: probe.server?.version ?? null,

--- a/src/cli/daemon-cli/restart-health.test.ts
+++ b/src/cli/daemon-cli/restart-health.test.ts
@@ -161,10 +161,11 @@ describe("restart health", () => {
     "unauthorized: gateway password mismatch (set gateway.remote.password to match gateway.auth.password)",
     "unauthorized: device token rejected (pair/repair this device, or provide gateway token)",
   ])(
-    "treats local policy-close probe reason %s as healthy gateway reachability",
+    "treats a correlated Gateway rejection with reason %s as healthy gateway reachability",
     async (reason) => {
       const snapshot = await inspectAmbiguousOwnershipWithProbe({
         ok: false,
+        gatewayReached: true,
         error: reason,
         close: { code: 1008, reason },
       });
@@ -177,6 +178,8 @@ describe("restart health", () => {
   it.each([
     "",
     "repair required",
+    "pairing required",
+    "auth required",
     "device identity required",
     "connect challenge missing nonce",
     "device signature invalid",

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -312,6 +312,7 @@ export type DaemonStatus = {
   lastError?: string;
   rpc?: {
     ok: boolean;
+    gatewayReached?: true;
     kind?: "connect" | "read";
     capability?: string;
     auth?: {

--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -1,6 +1,7 @@
 // Doctor gateway health tests cover gateway probe failures, auth requirements, and repair messages.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayClientRequestError } from "../../packages/gateway-client/src/index.js";
+import { retainGatewayResponsePayload } from "../../packages/gateway-client/src/protocol-request.js";
 import type { OpenClawConfig } from "../config/config.js";
 import {
   GATEWAY_HEALTH_CREDENTIALS_REQUIRED_MESSAGE,
@@ -339,6 +340,7 @@ describe("checkGatewayHealth", () => {
       ok: false,
       kind: "connect",
       error: TEST_AUTH_CLOSE_ERROR,
+      gatewayReached: true,
     });
     const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
 
@@ -370,6 +372,7 @@ describe("checkGatewayHealth", () => {
       kind: "connect",
       error: "connect failed",
       connectFailure: { kind: "rate-limited", detailCode: "AUTH_RATE_LIMITED" },
+      gatewayReached: true,
     });
     const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
 
@@ -403,6 +406,7 @@ describe("checkGatewayHealth", () => {
       retryable: true,
       retryAfterMs: 60_000,
     });
+    retainGatewayResponsePayload(error, undefined);
     callGateway.mockRejectedValueOnce(error);
     const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
 
@@ -427,6 +431,7 @@ describe("checkGatewayHealth", () => {
       ok: false,
       kind: "connect",
       error: TEST_AUTH_CLOSE_ERROR,
+      gatewayReached: true,
     });
     const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
 

--- a/src/commands/gateway-health-auth-diagnostic.ts
+++ b/src/commands/gateway-health-auth-diagnostic.ts
@@ -1,4 +1,5 @@
 /** Gateway health auth diagnostic helpers for reachable-but-unauthenticated probes. */
+import { isGatewayProtocolResponseError } from "../../packages/gateway-client/src/protocol-request.js";
 import {
   classifyGatewayConnectFailure,
   ConnectErrorDetailCodes,
@@ -30,12 +31,12 @@ export function gatewayProbeResultWasRateLimited(
 
 /** Detects a structured or legacy rate-limit connect error before close projection. */
 export function gatewayConnectErrorWasRateLimited(error: unknown): boolean {
-  if (!(error instanceof Error)) {
+  if (!isGatewayProtocolResponseError(error)) {
     return false;
   }
   return (
     classifyGatewayConnectFailure({
-      details: (error as Error & { details?: unknown }).details,
+      details: error.details,
       message: error.message,
     }).kind === "rate-limited"
   );
@@ -45,21 +46,7 @@ export function gatewayConnectErrorWasRateLimited(error: unknown): boolean {
  * Detects when a daemon probe reached the gateway even if read-scope auth failed.
  */
 export function gatewayProbeResultSawGateway(status: GatewayProbeReachabilityEvidence): boolean {
-  if (status.ok) {
-    return true;
-  }
-  const auth = status.auth;
-  if (auth?.capability && auth.capability !== "unknown") {
-    return true;
-  }
-  if (auth?.role || (auth?.scopes?.length ?? 0) > 0) {
-    return true;
-  }
-  const server = status.server;
-  if (server?.version || server?.connId) {
-    return true;
-  }
-  return gatewayProbeFailureKind(status) !== "unreachable";
+  return status.ok || status.gatewayReached === true;
 }
 
 /**

--- a/src/commands/gateway-readiness.test.ts
+++ b/src/commands/gateway-readiness.test.ts
@@ -80,6 +80,35 @@ describe("ensureGatewayReadyForOperation", () => {
     expect(runtime.log).not.toHaveBeenCalled();
   });
 
+  it.each(["timeout", "gateway closed (1006): "])(
+    "does not start over a busy listener after an inconclusive %s probe",
+    async (error) => {
+      const status = createStatus({
+        port: { port: 18789, status: "busy", listeners: [], hints: [] },
+        rpc: { ok: false, error },
+      });
+      const confirm = vi.fn().mockResolvedValue(false);
+      const installGateway = vi.fn();
+      const startGateway = vi.fn();
+      const result = await ensureGatewayReadyForOperation({
+        runtime,
+        operation: "open the dashboard",
+        readyWhenReachable: true,
+        interactive: true,
+        deps: { gatherStatus: async () => status, confirm, installGateway, startGateway },
+      });
+
+      expect(result).toMatchObject({ ready: false, recoverable: false });
+      expect(confirm).not.toHaveBeenCalled();
+      expect(installGateway).not.toHaveBeenCalled();
+      expect(startGateway).not.toHaveBeenCalled();
+      const output = runtime.log.mock.calls.flat().join("\n");
+      expect(output).toContain("Gateway probe failed:");
+      expect(output).not.toContain("Gateway is not running");
+      expect(output).not.toContain("gateway start");
+    },
+  );
+
   it("prints diagnosis and skips recovery when an interactive user declines", async () => {
     const gatherStatus = vi.fn().mockResolvedValue(createStatus());
     const confirm = vi.fn().mockResolvedValue(false);
@@ -264,6 +293,7 @@ describe("ensureGatewayReadyForOperation", () => {
       rpc: {
         ok: false,
         error: "gateway closed (1008): auth failed",
+        gatewayReached: true,
         url: "ws://127.0.0.1:49876",
       },
     });
@@ -296,6 +326,7 @@ describe("ensureGatewayReadyForOperation", () => {
       rpc: {
         ok: false,
         error: "device identity required",
+        gatewayReached: true,
         url: "ws://127.0.0.1:18789",
       },
     });
@@ -328,6 +359,7 @@ describe("ensureGatewayReadyForOperation", () => {
       rpc: {
         ok: false,
         error: "connect failed",
+        gatewayReached: true,
         connectFailure: { kind: "pairing-required", detailCode: "PAIRING_REQUIRED" },
         url: "ws://127.0.0.1:18789",
       },
@@ -361,6 +393,7 @@ describe("ensureGatewayReadyForOperation", () => {
         ok: false,
         error: "connect failed",
         connectFailure: { kind: "rate-limited", detailCode: "AUTH_RATE_LIMITED" },
+        gatewayReached: true,
         url: "ws://127.0.0.1:18789",
       },
     });

--- a/src/commands/gateway-readiness.ts
+++ b/src/commands/gateway-readiness.ts
@@ -79,31 +79,14 @@ function activeProbePortStatus(status: DaemonStatus): DaemonStatus["port"] {
   return status.port;
 }
 
-function gatewayIsRunning(status: DaemonStatus): boolean {
-  return status.rpc?.ok === true;
-}
-
-function gatewayProbeSawGateway(status: DaemonStatus): boolean {
-  return Boolean(status.rpc && gatewayProbeResultSawGateway(status.rpc));
-}
-
-function gatewayLooksReachable(status: DaemonStatus): boolean {
-  if (gatewayIsRunning(status)) {
-    return true;
-  }
-  const port = activeProbePortStatus(status);
-  if (port?.status !== "busy") {
-    return false;
-  }
+function gatewayIsReady(status: DaemonStatus, options: { readyWhenReachable?: boolean }): boolean {
   // A busy port alone is not enough: pair it with probe evidence so another
   // local service on the same port cannot satisfy gateway readiness.
-  return gatewayProbeSawGateway(status);
-}
-
-function gatewayIsReady(status: DaemonStatus, options: { readyWhenReachable?: boolean }): boolean {
   return (
-    gatewayIsRunning(status) ||
-    (options.readyWhenReachable === true && gatewayLooksReachable(status))
+    status.rpc?.ok === true ||
+    (options.readyWhenReachable === true &&
+      activeProbePortStatus(status)?.status === "busy" &&
+      Boolean(status.rpc && gatewayProbeResultSawGateway(status.rpc)))
   );
 }
 
@@ -112,6 +95,9 @@ function gatewayLooksStopped(status: DaemonStatus): boolean {
     return false;
   }
   const port = activeProbePortStatus(status);
+  if (port?.status === "busy" || (status.rpc && gatewayProbeResultSawGateway(status.rpc))) {
+    return false;
+  }
   if (port?.status === "free") {
     return true;
   }
@@ -143,11 +129,11 @@ function readinessFailureReason(status: DaemonStatus): string {
 function printGatewayNotReadyHints(
   runtime: RuntimeEnv,
   reason: string,
-  nativeServiceCanRecover = true,
+  canStartService = true,
 ): void {
   runtime.log(reason);
   runtime.log("Run `openclaw gateway status --deep` for details.");
-  if (!nativeServiceCanRecover) {
+  if (!canStartService) {
     runtime.log(
       "Use the owning environment or supervisor to start or repair the selected Gateway.",
     );
@@ -225,7 +211,7 @@ export async function ensureGatewayReadyForOperation(
   const reason = readinessFailureReason(initialStatus);
   const nativeServiceCanRecover = nativeServiceTargetsGateway(initialStatus);
   if (!gatewayLooksStopped(initialStatus) || !nativeServiceCanRecover) {
-    printGatewayNotReadyHints(options.runtime, reason, nativeServiceCanRecover);
+    printGatewayNotReadyHints(options.runtime, reason, false);
     return { ready: false, status: initialStatus, reason, recoverable: false };
   }
 
@@ -265,15 +251,13 @@ export async function ensureGatewayReadyForOperation(
   }
 
   const recoveredReason = readinessFailureReason(recoveredStatus);
-  printGatewayNotReadyHints(
-    options.runtime,
-    recoveredReason,
-    nativeServiceTargetsGateway(recoveredStatus),
-  );
+  const recoverable =
+    gatewayLooksStopped(recoveredStatus) && nativeServiceTargetsGateway(recoveredStatus);
+  printGatewayNotReadyHints(options.runtime, recoveredReason, recoverable);
   return {
     ready: false,
     status: recoveredStatus,
     reason: recoveredReason,
-    recoverable: true,
+    recoverable,
   };
 }

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -674,6 +674,7 @@ describe("gateway-status command", () => {
       ok: false,
       url: "ws://127.0.0.1:18789",
       connectLatencyMs: 51,
+      gatewayReached: true,
       error: "missing scope: operator.read",
       close: null,
       auth: {

--- a/src/commands/gateway-status/helpers.test.ts
+++ b/src/commands/gateway-status/helpers.test.ts
@@ -237,6 +237,7 @@ describe("probe reachability classification", () => {
       ok: false,
       url: "ws://127.0.0.1:18789",
       connectLatencyMs: 51,
+      gatewayReached: true as const,
       error: "missing scope: operator.read",
       close: null,
       auth: {
@@ -262,6 +263,7 @@ describe("probe reachability classification", () => {
       ok: false,
       url: "ws://127.0.0.1:18789",
       connectLatencyMs: 51,
+      gatewayReached: true as const,
       error: "permission denied",
       missingScopeErrorDetails: {
         code: "MISSING_SCOPE" as const,
@@ -288,6 +290,7 @@ describe("probe reachability classification", () => {
       ok: false,
       url: "ws://127.0.0.1:18789",
       connectLatencyMs: 43,
+      gatewayReached: true as const,
       error: "unknown method: status",
       close: null,
       auth: {

--- a/src/commands/gateway-status/helpers.ts
+++ b/src/commands/gateway-status/helpers.ts
@@ -288,7 +288,7 @@ export function renderTargetHeader(target: GatewayStatusTarget, rich: boolean) {
 
 /** Returns true when auth succeeded enough to connect but lacks the read scope. */
 export function isScopeLimitedProbeFailure(probe: GatewayProbeResult): boolean {
-  if (probe.ok || probe.connectLatencyMs == null) {
+  if (probe.ok || !probe.gatewayReached) {
     return false;
   }
   if (probe.missingScopeErrorDetails) {
@@ -299,12 +299,12 @@ export function isScopeLimitedProbeFailure(probe: GatewayProbeResult): boolean {
 
 /** Returns true when the gateway connection was established but a later probe failed. */
 export function isPostConnectProbeFailure(probe: GatewayProbeResult): boolean {
-  return !probe.ok && probe.connectLatencyMs != null;
+  return !probe.ok && probe.gatewayReached === true;
 }
 
 /** Returns true when the probe established any gateway connection. */
 export function isProbeReachable(probe: GatewayProbeResult): boolean {
-  return probe.ok || probe.connectLatencyMs != null;
+  return probe.ok || probe.gatewayReached === true;
 }
 
 function getGatewayProbeCapability(probe: GatewayProbeResult): GatewayProbeCapability {
@@ -380,7 +380,7 @@ export function renderProbeSummaryLine(probe: GatewayProbeResult, rich: boolean)
   }
 
   const detail = probe.error ? ` - ${probe.error}` : "";
-  if (probe.connectLatencyMs != null) {
+  if (probe.gatewayReached && probe.connectLatencyMs != null) {
     const latency =
       typeof probe.connectLatencyMs === "number" ? `${probe.connectLatencyMs}ms` : "unknown";
     const readStatus = isScopeLimitedProbeFailure(probe)

--- a/src/commands/gateway-status/output.test.ts
+++ b/src/commands/gateway-status/output.test.ts
@@ -49,6 +49,7 @@ function createProbe(
   params: {
     ok: boolean;
     connectLatencyMs: number | null;
+    gatewayReached?: true;
     error?: string | null;
   },
 ): GatewayProbeResult {
@@ -56,6 +57,7 @@ function createProbe(
     ok: params.ok,
     url: "ws://127.0.0.1:18789",
     connectLatencyMs: params.connectLatencyMs,
+    gatewayReached: params.gatewayReached,
     error: params.error ?? null,
     close: null,
     auth: {
@@ -357,6 +359,7 @@ describe("gateway status output", () => {
           "reachable-read",
           createProbe("read_only", {
             ok: false,
+            gatewayReached: true,
             connectLatencyMs: 20,
             error: "missing scope: operator.read",
           }),
@@ -386,6 +389,7 @@ describe("gateway status output", () => {
           "detail-timeout",
           createProbe("read_only", {
             ok: false,
+            gatewayReached: true,
             connectLatencyMs: 40,
             error: "timeout",
           }),

--- a/src/commands/health.test.ts
+++ b/src/commands/health.test.ts
@@ -1,6 +1,7 @@
 // Health command tests cover gateway health probes, JSON output, and status formatting.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayClientRequestError } from "../../packages/gateway-client/src/index.js";
+import { retainGatewayResponsePayload } from "../../packages/gateway-client/src/protocol-request.js";
 import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import { ExitError } from "../runtime.js";
@@ -634,6 +635,7 @@ describe("healthCommand", () => {
         ok: false,
         kind: "connect",
         error: TEST_AUTH_CLOSE_ERROR,
+        gatewayReached: true,
       });
 
       await healthCommand({ json, timeoutMs: 5000, config: {} }, runtime as never);
@@ -680,6 +682,7 @@ describe("healthCommand", () => {
         retryable: true,
         retryAfterMs: 60_000,
       });
+      retainGatewayResponsePayload(error, undefined);
       callGatewayMock.mockRejectedValueOnce(error);
 
       await healthCommand({ json, timeoutMs: 5000, config: {} }, runtime as never);
@@ -714,6 +717,7 @@ describe("healthCommand", () => {
         kind: "connect",
         error: "connect failed",
         connectFailure: { kind: "rate-limited", detailCode: "AUTH_RATE_LIMITED" },
+        gatewayReached: true,
       });
 
       await healthCommand({ json, timeoutMs: 5000, config: {} }, runtime as never);
@@ -733,6 +737,20 @@ describe("healthCommand", () => {
       expect(output).not.toContain("devices rotate");
     },
   );
+
+  it("does not report reachable from a locally constructed rate-limit error", async () => {
+    const error = new GatewayClientRequestError({
+      code: "INVALID_REQUEST",
+      message: "unauthorized: too many failed authentication attempts (retry later)",
+      details: { code: "AUTH_RATE_LIMITED" },
+    });
+    callGatewayMock.mockRejectedValueOnce(error);
+
+    await expect(healthCommand({ config: {} }, runtime as never)).rejects.toBe(error);
+
+    expect(runtime.log).not.toHaveBeenCalled();
+    expect(probeGatewayStatusMock).not.toHaveBeenCalled();
+  });
 
   it("keeps credential failures machine-readable when the gateway is unreachable", async () => {
     const error = new Error("gateway health requires credentials");
@@ -789,6 +807,7 @@ describe("healthCommand", () => {
       ok: false,
       kind: "connect",
       error: TEST_AUTH_CLOSE_ERROR,
+      gatewayReached: true,
     });
 
     await healthCommand(
@@ -830,6 +849,7 @@ describe("healthCommand", () => {
       ok: false,
       kind: "connect",
       error: TEST_AUTH_CLOSE_ERROR,
+      gatewayReached: true,
     });
 
     await expect(

--- a/src/commands/onboard-helpers.remote-probe.test.ts
+++ b/src/commands/onboard-helpers.remote-probe.test.ts
@@ -162,6 +162,7 @@ describe("probeGatewayReachable", () => {
       .mockResolvedValueOnce({
         ok: true,
         server: { version: "2026.7.2", connId: "conn-configured" },
+        gatewayReached: true,
         configSnapshot: {
           valid: true,
           config: { agents: { list: [{ id: "work", default: true, model: "openai/gpt-5.5" }] } },
@@ -170,6 +171,7 @@ describe("probeGatewayReachable", () => {
       .mockResolvedValueOnce({
         ok: true,
         server: { version: "2026.7.2", connId: "conn-missing" },
+        gatewayReached: true,
         configSnapshot: { valid: true, config: { gateway: { mode: "local" } } },
       });
 
@@ -199,6 +201,7 @@ describe("probeGatewayReachable", () => {
       error: "config.get: unauthorized",
       auth: { role: null, scopes: [], capability: "unknown" },
       server: { version: "2026.7.2", connId: "conn-1" },
+      gatewayReached: true,
     });
 
     await expect(probeGatewayConfiguredModel({ url: "ws://127.0.0.1:18789" })).resolves.toEqual({
@@ -213,6 +216,7 @@ describe("probeGatewayReachable", () => {
       connectLatencyMs: 42,
       error: "device pairing required",
       connectErrorDetails: { code: ConnectErrorDetailCodes.PAIRING_REQUIRED },
+      gatewayReached: true,
       auth: { role: null, scopes: [], capability: "pairing_pending" },
       server: { version: null, connId: null },
     });
@@ -279,6 +283,7 @@ describe("probeGatewayReachable", () => {
       error: "missing scope: operator.read",
       auth: { role: "operator", scopes: [], capability: "connected_no_operator_scope" },
       server: { version: "2026.7.2", connId: "conn-1" },
+      gatewayReached: true,
     });
 
     await expect(probeGatewayConfiguredModel({ url: "ws://127.0.0.1:18789" })).resolves.toEqual({
@@ -293,6 +298,7 @@ describe("probeGatewayReachable", () => {
       connectLatencyMs: 42,
       auth: { role: "operator", scopes: ["operator.read"], capability: "read_only" },
       server: { version: "2026.7.2", connId: "conn-1" },
+      gatewayReached: true,
       configSnapshot: { valid: false },
     });
 

--- a/src/commands/onboard-helpers.ts
+++ b/src/commands/onboard-helpers.ts
@@ -6,10 +6,6 @@ import { cancel, isCancel } from "@clack/prompts";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import {
-  ConnectErrorDetailCodes,
-  readConnectErrorDetailCode,
-} from "../../packages/gateway-protocol/src/connect-error-details.js";
 import { stylePromptTitle } from "../../packages/terminal-core/src/prompt-style.js";
 import { resolveAgentEffectiveModelPrimary, resolveDefaultAgentId } from "../agents/agent-scope.js";
 import { DEFAULT_AGENT_WORKSPACE_DIR, ensureAgentWorkspace } from "../agents/workspace.js";
@@ -360,21 +356,6 @@ export type GatewayConfiguredModelProbeResult =
   | { kind: "reachable-unverified"; detail?: string }
   | { kind: "unreachable"; detail?: string };
 
-const RECOGNIZED_GATEWAY_CONNECT_ERROR_CODES: ReadonlySet<string> = new Set(
-  Object.values(ConnectErrorDetailCodes),
-);
-
-function didProbeReachGateway(probe: GatewayProbeResult): boolean {
-  const connectErrorCode = readConnectErrorDetailCode(probe.connectErrorDetails);
-  const recognizedConnectError =
-    connectErrorCode !== null && RECOGNIZED_GATEWAY_CONNECT_ERROR_CODES.has(connectErrorCode);
-  const serverVersion = probe.server?.version?.trim();
-  const serverConnectionId = probe.server?.connId?.trim();
-  // Opening a WebSocket proves only that something is listening. A Gateway is
-  // established by a hello-ok server identity or its typed connect rejection.
-  return recognizedConnectError || Boolean(serverVersion && serverConnectionId);
-}
-
 /** Reads only Gateway config and classifies whether its default agent has inference. */
 export async function probeGatewayConfiguredModel(
   params: OnboardingGatewayProbeParams,
@@ -386,7 +367,7 @@ export async function probeGatewayConfiguredModel(
     return { kind: "unreachable", detail: summarizeError(err) };
   }
   const detail = probe.error ?? undefined;
-  if (!didProbeReachGateway(probe)) {
+  if (!probe.gatewayReached) {
     return { kind: "unreachable", ...(detail ? { detail } : {}) };
   }
   if (!probe.ok) {

--- a/src/commands/status.scan.shared.test.ts
+++ b/src/commands/status.scan.shared.test.ts
@@ -234,6 +234,7 @@ describe("resolveGatewayProbeSnapshot", () => {
       ok: false,
       url: "ws://127.0.0.1:18789",
       connectLatencyMs: 51,
+      gatewayReached: true,
       error: "missing scope: operator.read",
       close: null,
       auth: {

--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -1,6 +1,7 @@
 // Doctor runtime check tests cover runtime-backed doctor checks.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayClientRequestError } from "../../packages/gateway-client/src/index.js";
+import { retainGatewayResponsePayload } from "../../packages/gateway-client/src/protocol-request.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { GATEWAY_HEALTH_RATE_LIMITED_MESSAGE } from "../commands/gateway-health-auth-diagnostic.js";
 import { GatewaySecretRefUnavailableError } from "../gateway/credentials.js";
@@ -708,6 +709,9 @@ describe("doctor gateway runtime checks", () => {
       message: "Gateway status could not be inspected: connect ECONNREFUSED 127.0.0.1:5829",
     },
   ])("reports $label from exactly one sanitized status attempt", async (entry) => {
+    if (entry.error instanceof GatewayClientRequestError) {
+      retainGatewayResponsePayload(entry.error, undefined);
+    }
     mocks.callGateway.mockRejectedValueOnce(entry.error);
     mocks.isGatewayCredentialsRequiredError.mockReturnValueOnce(entry.credentialsRequired);
 

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -36,6 +36,7 @@ import { VERSION } from "../version.js";
 export {
   GatewayClientRequestError,
   isGatewayConnectAssemblyError,
+  isGatewayProtocolResponseError,
 } from "../../packages/gateway-client/src/index.js";
 export type {
   GatewayClientCloseInfo,

--- a/src/gateway/probe.test.ts
+++ b/src/gateway/probe.test.ts
@@ -1,6 +1,11 @@
 // Gateway probe tests cover bootstrap auth, pairing prompts, startup retries,
 // event-loop readiness checks, and close/error reporting.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isGatewayProtocolResponseError,
+  retainGatewayResponsePayload,
+} from "../../packages/gateway-client/src/protocol-request.js";
+import { GatewayClientRequestError as MockGatewayClientRequestError } from "../../packages/gateway-client/src/request-error.js";
 
 const gatewayClientState = vi.hoisted(() => ({
   options: null as Record<string, unknown> | null,
@@ -63,20 +68,6 @@ const eventLoopReadyState = vi.hoisted(() => ({
   },
 }));
 
-class MockGatewayClientRequestError extends Error {
-  readonly code: string;
-  readonly gatewayCode: string;
-  readonly details?: unknown;
-
-  constructor(error: { code?: string; message?: string; details?: unknown }) {
-    super(error.message ?? "gateway request failed");
-    this.name = "GatewayClientRequestError";
-    this.code = error.code ?? "UNAVAILABLE";
-    this.gatewayCode = this.code;
-    this.details = error.details;
-  }
-}
-
 class MockGatewayClient {
   private readonly opts: Record<string, unknown>;
 
@@ -121,12 +112,12 @@ class MockGatewayClient {
         if (gatewayClientState.startMode === "connect-error-close") {
           const onConnectError = this.opts.onConnectError;
           if (typeof onConnectError === "function") {
-            onConnectError(
-              new MockGatewayClientRequestError({
-                message: gatewayClientState.connectError,
-                details: gatewayClientState.connectErrorDetails,
-              }),
-            );
+            const error = new MockGatewayClientRequestError({
+              message: gatewayClientState.connectError,
+              details: gatewayClientState.connectErrorDetails,
+            });
+            retainGatewayResponsePayload(error, undefined);
+            onConnectError(error);
           }
           this.emitClose();
           return;
@@ -171,6 +162,7 @@ class MockGatewayClient {
 vi.mock("./client.js", () => ({
   GatewayClient: MockGatewayClient,
   GatewayClientRequestError: MockGatewayClientRequestError,
+  isGatewayProtocolResponseError,
 }));
 
 vi.mock("../infra/device-identity.js", () => ({
@@ -238,8 +230,10 @@ function nextProbeUrl(label: string): string {
 
 function setDeviceRequiredProbeMode(): void {
   deviceIdentityState.cachedToken = null;
-  gatewayClientState.startMode = "close";
+  gatewayClientState.startMode = "connect-error-close";
   gatewayClientState.close = { code: 1008, reason: "device identity required" };
+  gatewayClientState.connectError = "gateway closed (1008): device identity required";
+  gatewayClientState.connectErrorDetails = null;
 }
 
 function lastGatewayClientOptions(): Record<string, unknown> | null {
@@ -798,6 +792,7 @@ describe("probeGateway", () => {
     });
     expect(gatewayClientState.startCalls).toBe(startCalls);
     expect(lastGatewayClientOptions()).toBeNull();
+    expect(result.gatewayReached).toBeUndefined();
   });
 
   it("does not cache other policy-close reasons", async () => {

--- a/src/gateway/probe.ts
+++ b/src/gateway/probe.ts
@@ -20,7 +20,11 @@ import { formatErrorMessage } from "../infra/errors.js";
 import type { SystemPresence } from "../infra/system-presence.js";
 import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
 import { startGatewayClientWhenEventLoopReady } from "./client-start-readiness.js";
-import { GatewayClient, GatewayClientRequestError } from "./client.js";
+import {
+  GatewayClient,
+  GatewayClientRequestError,
+  isGatewayProtocolResponseError,
+} from "./client.js";
 import {
   gatewayEdgeAuthValueForTarget,
   normalizeEdgeAuthHeadersConfig,
@@ -63,6 +67,8 @@ export type GatewayProbeServerSummary = {
 
 export type GatewayProbeResult = {
   ok: boolean;
+  /** Set only after a Gateway hello or a correlated protocol response. */
+  gatewayReached?: true;
   url: string;
   connectLatencyMs: number | null;
   error: string | null;
@@ -184,6 +190,7 @@ function makeDeviceRequiredShortCircuitResult(url: string): GatewayProbeResult {
     url,
     connectLatencyMs: null,
     error: formatProbeCloseError(close),
+    // This cached diagnostic does not prove the current listener still speaks Gateway.
     close,
     auth: emptyProbeAuth(),
     server: emptyProbeServer(),
@@ -274,6 +281,7 @@ export async function probeGateway(opts: {
   let connectLatencyMs: number | null = null;
   let connectError: string | null = null;
   let connectErrorDetails: unknown = null;
+  let gatewayReached = false;
   let close: GatewayProbeClose | null = null;
   let auth = emptyProbeAuth();
   let server = emptyProbeServer();
@@ -369,7 +377,11 @@ export async function probeGateway(opts: {
         }
         if (result.ok) {
           clearDeviceRequiredProbeFailures(cacheKey);
-        } else if (cacheEligible && isDeviceIdentityRequiredClose(result.close)) {
+        } else if (
+          cacheEligible &&
+          result.gatewayReached &&
+          isDeviceIdentityRequiredClose(result.close)
+        ) {
           noteDeviceRequiredProbeFailure(cacheKey, Date.now());
         }
         const { connectErrorDetails: resultConnectErrorDetails, ...rest } = result;
@@ -394,6 +406,7 @@ export async function probeGateway(opts: {
     }) => {
       settle({
         ok: params.ok,
+        ...(gatewayReached ? { gatewayReached: true as const } : {}),
         connectLatencyMs,
         error: params.error,
         ...(params.missingScopeErrorDetails
@@ -443,9 +456,11 @@ export async function probeGateway(opts: {
       onConnectError: (err) => {
         connectError = formatErrorMessage(err);
         connectErrorDetails = err instanceof GatewayClientRequestError ? err.details : null;
+        gatewayReached ||= isGatewayProtocolResponseError(err);
       },
       onClose: (code, reason, info) => {
         close = { code, reason };
+        gatewayReached ||= isGatewayProtocolResponseError(info?.connectError);
         if (connectLatencyMs == null) {
           // Preserve the transport boundary: request-level handshake failures
           // still prove the listener was reachable once the socket opened.
@@ -463,6 +478,7 @@ export async function probeGateway(opts: {
         }
       },
       onHelloOk: (hello) => {
+        gatewayReached = true;
         void (async () => {
           connectLatencyMs = Date.now() - startedAt;
           authMetadataPresent = typeof hello?.auth === "object" && hello.auth !== null;


### PR DESCRIPTION
Closes #133953

## What Problem This Solves

Fixes an issue where users opening the dashboard could be told to start another Gateway when the configured port was already occupied and the connection probe timed out. A raw WebSocket close formatted as `gateway closed (1006):` could instead make the same unverified listener appear ready.

## Why This Change Was Made

The client now records whether it received a correlated Gateway protocol response, and the probe carries that evidence through daemon status. Dashboard readiness, health diagnostics, onboarding, and restart checks consume the recorded fact rather than reconstructing it from close text, transport latency, or projected auth fields. An accepted handshake remains recorded even when the subsequent status RPC fails. Cached rejections remain diagnostic-only and cannot establish fresh reachability. Occupied ports remain unavailable for service recovery until their listener is diagnosed.

## User Impact

An inconclusive probe over a busy port reports the connection failure and points to `openclaw gateway status --deep`, without offering to start another service. Real Gateway auth/pairing rejections still establish reachability and keep their actionable diagnostics. No config, environment, database schema, or wire-protocol version changes.

## Evidence

- The two new dashboard regression cases fail against baseline `006527dce2cd5b7ede8859c7bd4a95d05b133393`: the timeout case reports `recoverable:true`, and the raw `1006` case reports `ready:true`.
- Real local WebSocket tests cover abrupt termination, bare pairing-looking close text, a silent opened socket, HTTP upgrade rejection, and a successful hello followed by a failed status RPC.
- An isolated real Gateway on an ephemeral loopback port verifies auth rejection and successful connection, with synthetic state and credentials. No operator service or state is used.
- Focused owner and sibling suites: 367 distinct tests across 17 files passed; 49 probe/readiness tests were rerun after the final consolidation.
- Independent isolated Codex review: no findings at the P0 threshold.
- Production LOC: 80 added / 86 removed (net -6); tests: 315 added / 50 removed (net +265); documentation: +4. The assertion-safety baseline shrinks by one removed cast.
- Full production build passed, including runtime bundles, SDK export validation, and the Control UI.
- Built `dashboard --json` proof against fresh synthetic listeners passed: raw `1006` and silent listeners return explicit probe failures; a correlated auth rejection advances to the document check.
- `check:changed` passed for all changed TypeScript and documentation paths, including full core/test typechecks, the assertion baseline ratchet, lint, and storage/import/auth guards. The mechanical assertion-baseline count file was validated by its owning guard.
- The full core lint pass found one test cleanup-style issue; the corrected file and the complete changed-file lint pass both passed.

CI follow-up: the existing MiniMax image-error fixture omitted the prepared provider generation used by embedded tool execution. Its actual error classifier cold-loaded plugins and timed out at 120 seconds in hosted CI. The fixture now enters the existing generation scope with a registered test provider; the real classifier callback is asserted and returns no override, preserving core fallback policy and the original image/error assertions. The matching Linux case fell from 65,920 ms to 17 ms, with all 105 tests passing. Local full-file tests, typecheck, lint, formatting, and fresh isolated autoreview passed. Production code is unchanged by this follow-up; test delta is +33/-7. Linux proof: https://github.com/openclaw/openclaw/actions/runs/33378374717.

The initial CI run also failed an extension/script lint job without an actionable diagnostic and the existing Doctor config/state shard. All three previously failing jobs pass on the exact refreshed head in CI run 33378867087; the Doctor fixture investigation is tracked alongside the migration repair. The rebase onto `9b4c3d5f1b216884872452a7c780b13320298b5d` preserves both patches unchanged.
