### PR TITLE
fix(backup): prune nested workspaces from the state asset when inclusion is disabled

### DIFF
--- a/src/commands/backup-resource-inventory.ts
+++ b/src/commands/backup-resource-inventory.ts
@@ -101,6 +101,8 @@ export async function createBackupResourceInventory(params: {
   configPath: string;
   oauthDir: string;
   workspaceDirs: readonly string[];
+  /** Workspace roots requested out of scope; they prune from broader assets instead of becoming assets. */
+  excludedWorkspaceDirs?: readonly string[];
   agentRoots: readonly BackupAgentRoot[];
   pluginResources: readonly ResolvedPluginBackupResource[];
   pluginRoots: readonly string[];
@@ -180,10 +182,15 @@ export async function createBackupResourceInventory(params: {
       }),
   );
   const protectedPaths = Object.freeze([...protectedPathSet].toSorted());
+  // Out-of-scope workspace roots prune with the same subtree semantics as
+  // regenerable roots so a broad state asset cannot swallow a nested workspace,
+  // but they are not regenerable: keep them out of regenerableRoots so the
+  // manifest never records a workspace as a disposable resource.
   const excludedPaths = Object.freeze(
-    uniqueRegenerableRoots
-      .map((resource) => resource.sourcePath)
-      .toSorted((left, right) => right.length - left.length || left.localeCompare(right)),
+    [
+      ...uniqueRegenerableRoots.map((resource) => resource.sourcePath),
+      ...(params.excludedWorkspaceDirs ?? []).map((workspaceDir) => path.resolve(workspaceDir)),
+    ].toSorted((left, right) => right.length - left.length || left.localeCompare(right)),
   );
 
   const isIncluded = (sourcePath: string): boolean => {

--- a/src/commands/backup-shared.ts
+++ b/src/commands/backup-shared.ts
@@ -173,6 +173,7 @@ async function resolveBackupPlanFromPaths(params: {
   configPath: string;
   oauthDir: string;
   workspaceDirs?: string[];
+  workspaceExclusions?: readonly string[];
   agentRoots?: readonly BackupAgentRoot[];
   pluginInventory?: ActivatedPluginBackupInventory;
   unresolvedOwnership?: boolean;
@@ -194,6 +195,16 @@ async function resolveBackupPlanFromPaths(params: {
   const configInsideState = params.configInsideState ?? false;
   const oauthInsideState = params.oauthInsideState ?? false;
   const canonicalStateDir = await canonicalizePathForContainment(stateDir);
+  // A workspace root that contains the state directory would prune the whole
+  // state asset; that layout leaves includeWorkspace=false without a meaningful
+  // scope, so keep state backup intact and drop such an exclusion instead.
+  const workspaceExclusions = (
+    await Promise.all(
+      (params.workspaceExclusions ?? []).map((workspaceDir) =>
+        canonicalizePathForContainment(workspaceDir),
+      ),
+    )
+  ).filter((workspaceDir) => !isPathWithin(canonicalStateDir, workspaceDir));
   const inventory = await createBackupResourceInventory({
     stateDir: canonicalStateDir,
     configPath: await canonicalizePathForContainment(configPath),
@@ -201,6 +212,7 @@ async function resolveBackupPlanFromPaths(params: {
     workspaceDirs: await Promise.all(
       workspaceDirs.map((workspaceDir) => canonicalizePathForContainment(workspaceDir)),
     ),
+    excludedWorkspaceDirs: workspaceExclusions,
     agentRoots,
     pluginResources: params.pluginInventory?.resources ?? [],
     pluginRoots: params.pluginInventory?.pluginRoots ?? [],
@@ -555,20 +567,24 @@ export async function resolveBackupPlanFromDisk(
   const agentRoots = unresolvedOwnership
     ? []
     : await resolveBackupAgentRoots(discoverySnapshot.config);
-  const workspaceDirs = includeWorkspace ? cleanupPlan.workspaceDirs : [];
+  const workspaceDirs = cleanupPlan.workspaceDirs;
+  // Plugin resources follow the requested scope: an excluded workspace is not
+  // an include anchor for workspace-scoped plugin resources.
+  const workspaceIncludes = includeWorkspace ? workspaceDirs : [];
   const pluginInventory = unresolvedOwnership
     ? undefined
     : resolveActivatedPluginBackupInventory({
         config: discoverySnapshot.config,
         env: process.env,
         stateDir,
-        workspaceDirs,
+        workspaceDirs: workspaceIncludes,
       });
   return await resolveBackupPlanFromPaths({
     stateDir,
     configPath,
     oauthDir,
-    workspaceDirs,
+    workspaceDirs: workspaceIncludes,
+    workspaceExclusions: includeWorkspace ? [] : workspaceDirs,
     agentRoots,
     pluginInventory,
     unresolvedOwnership,

--- a/src/commands/backup.test-support.ts
+++ b/src/commands/backup.test-support.ts
@@ -14,6 +14,7 @@ type ResolveBackupPlanFromPathsParams = {
   configPath: string;
   oauthDir: string;
   workspaceDirs?: string[];
+  workspaceExclusions?: readonly string[];
   includeWorkspace?: boolean;
   onlyConfig?: boolean;
   configInsideState?: boolean;

--- a/src/commands/backup.test.ts
+++ b/src/commands/backup.test.ts
@@ -202,6 +202,63 @@ describe("backup commands", () => {
     expectWorkspaceCoveredByState(plan);
   });
 
+  it("prunes a workspace nested inside the state asset when workspace inclusion is disabled", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const oauthDir = path.join(stateDir, "credentials");
+    const workspaceDir = path.join(stateDir, "workspace");
+    await fs.writeFile(configPath, JSON.stringify({}), "utf8");
+    await fs.mkdir(oauthDir, { recursive: true });
+    await fs.writeFile(path.join(oauthDir, "oauth.json"), "{}", "utf8");
+    await fs.mkdir(workspaceDir, { recursive: true });
+    await fs.writeFile(path.join(workspaceDir, "SOUL.md"), "# soul\n", "utf8");
+
+    const plan = await resolveBackupPlanFromPaths({
+      stateDir,
+      configPath,
+      oauthDir,
+      workspaceDirs: [workspaceDir],
+      workspaceExclusions: [workspaceDir],
+      includeWorkspace: false,
+      configInsideState: true,
+      oauthInsideState: true,
+      nowMs: 123,
+    });
+    expect(plan.workspaceDirs).toStrictEqual([]);
+    expect(plan.included.map((asset) => asset.kind)).toStrictEqual(["state"]);
+    // The archive filter asks the inventory for every entry under the state
+    // asset, so the exclusion must hold at inventory level, not just in assets.
+    expect(plan.inventory.isIncluded(path.join(workspaceDir, "SOUL.md"))).toBe(false);
+    expect(plan.inventory.isIncluded(workspaceDir)).toBe(false);
+    expect(plan.inventory.isIncluded(configPath)).toBe(true);
+    expect(plan.inventory.isTraversable(path.join(stateDir, "agents"))).toBe(true);
+  });
+
+  it("keeps the state asset intact when a configured workspace contains the state directory", async () => {
+    const stateDir = path.join(tempHome.home, ".openclaw");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const oauthDir = path.join(stateDir, "credentials");
+    await fs.writeFile(configPath, JSON.stringify({}), "utf8");
+    await fs.mkdir(oauthDir, { recursive: true });
+    await fs.writeFile(path.join(oauthDir, "oauth.json"), "{}", "utf8");
+
+    const plan = await resolveBackupPlanFromPaths({
+      stateDir,
+      configPath,
+      oauthDir,
+      // A workspace that contains the state directory leaves
+      // includeWorkspace=false without a meaningful scope; excluding it would
+      // prune the entire state asset.
+      workspaceExclusions: [tempHome.home],
+      includeWorkspace: false,
+      configInsideState: true,
+      oauthInsideState: true,
+      nowMs: 123,
+    });
+    expect(plan.included.map((asset) => asset.kind)).toStrictEqual(["state"]);
+    expect(plan.inventory.isIncluded(path.join(stateDir, "agents", "state.txt"))).toBe(true);
+  });
+
   it("orders coverage checks by canonical path so symlinked workspaces do not duplicate state", async () => {
     if (process.platform === "win32") {
       return;


### PR DESCRIPTION
## What Problem This Solves

Fixes #133900: `includeWorkspace: false` still archives the complete workspace when the workspace lives under the state directory (`~/.openclaw/workspace`). The manifest records `workspaceDirs: []` and lists no workspace asset, but the archive payload contains every workspace file — the reporter measured a 9.4 GB intermediate archive with workspace inclusion disabled.

## Why This Change Was Made

`resolveBackupPlanFromPaths` drops configured workspace roots from the include list when `includeWorkspace` is false, but the broad `state` asset (the whole state directory) still covers them: the archive traversal filter consults the resource inventory, and the inventory never learned those roots are out of scope. The fix passes the configured roots to the inventory as pruning exclusions, so the state asset's traversal cuts the nested workspace subtree exactly where the archive filter already decides inclusion.

The inventory reuses its existing subtree-exclusion semantics (regenerable roots): nested workspace paths fail `isIncluded`/`isTraversable`, while the protected-path override rule keeps config, credentials, agent roots, and plugin resources inside an excluded workspace intact. Workspace exclusions deliberately stay out of `regenerableRoots` so the manifest never records a workspace as a disposable resource.

## User Impact

- `openclaw backup` with workspace inclusion disabled now produces an archive matching the requested scope: nested workspace files are excluded and the archive size drops accordingly.
- Explicitly protected content (config, credentials, agent roots, plugin includes) keeps its existing protection even inside an excluded workspace.
- A workspace root that contains the state directory is skipped as an exclusion instead of pruning the entire state asset — that layout leaves the option without a meaningful scope, and the operator keeps a valid state backup.

## Evidence

- Regression test `prunes a workspace nested inside the state asset when workspace inclusion is disabled` (`src/commands/backup.test.ts`) asserts the inventory-level decision the archive filter consumes: `isIncluded(workspace file)` = false, `isIncluded(workspace root)` = false, `isIncluded(configPath)` = true, workspace absent from `plan.workspaceDirs` and from included assets.
- Pre-fix reproduction: reverting only the two production files and running that test fails with `expected true to be false` (the workspace file was archive-eligible). Rerun with the fix: green.
- Scope guard regression test `keeps the state asset intact when a configured workspace contains the state directory` asserts the state asset survives a workspace-exclusion that would contain it.
- `src/commands/backup.test.ts` 20/20 green; sibling surfaces `backup-shared.test.ts`, `backup.create-verify.test.ts`, `backup-restore.test.ts`, `backup.atomic.test.ts` 30/30 green; `pnpm tsgo:core` clean; `oxlint` clean on touched files.
- Local full-build gap: the E2E-lane build needs a ~4.7 GB peak heap and this machine has ~4.6 GB available, so the local build OOM-protected and was not forced. The touched boundary is covered by the plan/inventory tests above; exact-head CI runs the full suite including the E2E lane.

## Production LOC delta

Production +29/−6 (exclusion channel through `resolveBackupPlanFromPaths` → inventory params, the state-containing-root guard, and the inventory merge into `excludedPaths`; roughly half is invariant comments). Tests +57. The growth is the scope-enforcement capability itself plus the guard that prevents trading this bug for a silently empty state backup; no narrower equivalent shape was found — dropping workspaces from the include list (current behavior) is precisely the bug.


### Update (head 57b1c6adf45): test-facade type sync + real-CLI archive proof

- **Deterministic test-type failure fixed**: `ResolveBackupPlanFromPathsParams` in `src/commands/backup.test-support.ts` now declares `workspaceExclusions?: readonly string[]`, matching the production parameter the new assertions pass. `check-test-types` failure (`TS2353` at `src/commands/backup.test.ts:221`/`:252`) resolved; full `pnpm tsgo:test` lane (core + extensions + root shards) green on this head.

**Real CLI archive proof** (built dist, isolated `OPENCLAW_STATE_DIR`, fixture: state dir with `openclaw.json` pointing `agents.defaults.workspace` at a workspace nested inside the state directory, marker files in state/credentials/workspace; command `openclaw backup create --no-include-workspace --output <tmp>`):

Pre-fix behavior (stale dist without the exclusion channel — same production shape as reported):
```
…/.openclaw/workspaces/main/nested-secret.txt   <- present in archive
…/.openclaw/workspaces/main/SOUL.md             <- present in archive
```

After-fix behavior (this head):
```
$ tar -tf <archive> | grep -c "workspaces/main/SOUL.md|workspaces/main/nested-secret.txt"
0
```
- Nested workspace **files**: 0 entries in the archive (`workspaces`/`workspaces/main` empty directory scaffolding remains, consistent with inventory-level subtree pruning).
- Protected content retained inside the excluded scope: `agents/main/agent/state.txt`, `credentials/oauth.json`, `openclaw.json` all present (1 each).
- CLI plan output: `Included 1 path: state: …/.openclaw` / `Skipped 1 path: agent: … (covered by …)`.
