### PR TITLE
test(scripts): share approved package patch fixtures

### DIFF
--- a/test/scripts/check-package-patches.test.ts
+++ b/test/scripts/check-package-patches.test.ts
@@ -53,13 +53,14 @@ afterEach(() => {
 });
 
 describe("check-package-patches", () => {
-  it.each([
-    ["baileys@7.0.0-rc12", "patches/baileys@7.0.0-rc12.patch"],
-    ["baileys@7.0.0-rc13", "patches/baileys@7.0.0-rc13.patch"],
-    ["@vitest/runner@4.1.11", "patches/@vitest__runner@4.1.11.patch"],
-    ["vitest@4.1.11", "patches/vitest@4.1.11.patch"],
-    ["matrix-js-sdk@42.2.0", "patches/matrix-js-sdk@42.2.0.patch"],
-  ])("allows approved pnpm patch %s", (specifier, patchPath) => {
+  it("allows approved pnpm patches together", () => {
+    const approvedPatches = [
+      ["baileys@7.0.0-rc12", "patches/baileys@7.0.0-rc12.patch"],
+      ["baileys@7.0.0-rc13", "patches/baileys@7.0.0-rc13.patch"],
+      ["@vitest/runner@4.1.11", "patches/@vitest__runner@4.1.11.patch"],
+      ["vitest@4.1.11", "patches/vitest@4.1.11.patch"],
+      ["matrix-js-sdk@42.2.0", "patches/matrix-js-sdk@42.2.0.patch"],
+    ] as const;
     const dir = makeRepo();
     mkdirSync(path.join(dir, "patches"), { recursive: true });
     writeFileSync(
@@ -67,7 +68,7 @@ describe("check-package-patches", () => {
       `packages:
   - .
 patchedDependencies:
-  "${specifier}": "${patchPath}"
+${approvedPatches.map(([specifier, patchPath]) => `  "${specifier}": "${patchPath}"`).join("\n")}
 `,
       "utf8",
     );
@@ -75,11 +76,13 @@ patchedDependencies:
       path.join(dir, "pnpm-lock.yaml"),
       `lockfileVersion: '9.0'
 patchedDependencies:
-  "${specifier}": a9aea1790d2c65b1ae543c77faca4119bbfb91ee3b6ca6c38d1cad4f5702ada2
+${approvedPatches.map(([specifier]) => `  "${specifier}": a9aea1790d2c65b1ae543c77faca4119bbfb91ee3b6ca6c38d1cad4f5702ada2`).join("\n")}
 `,
       "utf8",
     );
-    writeFileSync(path.join(dir, patchPath), "diff\n", "utf8");
+    for (const [, patchPath] of approvedPatches) {
+      writeFileSync(path.join(dir, patchPath), "diff\n", "utf8");
+    }
     git(dir, ["add", "pnpm-workspace.yaml", "pnpm-lock.yaml", "patches"]);
 
     expect(collectPackagePatchViolations(dir)).toEqual([]);


### PR DESCRIPTION
## What Problem This Solves

The package-patch guard tests create five independent Git repositories to verify five approved declarations, repeating identical repository setup and scans.

## Why This Change Was Made

Put the five approved declarations and tracked patch files in one fixture. The guard already scans every workspace/lockfile entry and tracked patch, so the same independent allowlist expectations remain covered while twenty Git child processes disappear. Keep every unapproved selector/path, deleted tracked file, package-local declaration, and multi-document lockfile case.

## User Impact

No runtime behavior change. The focused test file took 1,118 ms before and 998 ms after in local runs; the structural saving is four fixture repositories and twenty Git launches.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/check-package-patches.test.ts`: all eight consolidated cases pass.
- `node scripts/check-changed.mjs -- test/scripts/check-package-patches.test.ts`: passes, including root test typecheck and script guards/lint.
- Formatting, diff check, independent owner review, and structured Codex autoreview pass with no accepted findings.
- Production: unchanged. Tests: +13/-10 lines. The fixture expectations remain hardcoded independently of the production allowlist.
