### PR TITLE
fix(agents): expire poll vote echo at TTL

### DIFF
--- a/src/agents/tools/message-tool-execution.ts
+++ b/src/agents/tools/message-tool-execution.ts
@@ -492,7 +492,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
         sourceReplySinkDeliveryMode === "message_tool_only" &&
         (action === "send" || action === "reply")
       ) {
-        if (Date.now() - recentPollVote.recordedAt > POLL_VOTE_ECHO_TTL_MS) {
+        if (Date.now() - recentPollVote.recordedAt >= POLL_VOTE_ECHO_TTL_MS) {
           recentPollVoteBySession.delete(pollEchoSessionKey);
         } else if (pollVoteEchoRoute === recentPollVote.route) {
           const vote = recentPollVote;

--- a/src/agents/tools/message-tool-execution.ts
+++ b/src/agents/tools/message-tool-execution.ts
@@ -703,7 +703,7 @@ export function createMessageTool(options?: MessageToolOptions): AnyAgentTool {
           // sends a follow-up text can't leak a record forever in a long-lived
           // gateway; the map stays bounded to sessions that voted within the TTL.
           for (const [key, entry] of recentPollVoteBySession) {
-            if (recordedAt - entry.recordedAt > POLL_VOTE_ECHO_TTL_MS) {
+            if (recordedAt - entry.recordedAt >= POLL_VOTE_ECHO_TTL_MS) {
               recentPollVoteBySession.delete(key);
             }
           }

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -1015,26 +1015,32 @@ describe("poll vote echo guard", () => {
     expect(result.details).toMatchObject({ status: "suppressed", reason: "poll_vote_echo" });
   });
 
-  it("allows a same-route echo at the exact TTL boundary", async () => {
-    vi.useFakeTimers();
+  it.each([
+    { elapsedMs: 29_999, suppressed: true },
+    { elapsedMs: 30_000, suppressed: false },
+    { elapsedMs: 30_001, suppressed: false },
+  ])("expires the same-route vote after $elapsedMs ms", async ({ elapsedMs, suppressed }) => {
+    const now = vi.spyOn(Date, "now").mockReturnValue(100_000);
     try {
-      vi.setSystemTime(100_000);
-      const sessionKey = "agent:test:imessage:direct:ttl-boundary";
+      const sessionKey = `agent:test:imessage:direct:ttl-${elapsedMs}`;
       const voteTool = createPollVoteTool("Black", sessionKey);
       await castBlueVote(voteTool);
 
-      await vi.advanceTimersByTimeAsync(30_000);
+      now.mockReturnValue(100_000 + elapsedMs);
       const nextRunTool = createPollVoteTool("Black", sessionKey);
       const result = await nextRunTool.execute("send", {
         action: "send",
         channel: "imessage",
         message: "🦞 Black.",
       });
-
-      expect(result.details).not.toMatchObject({ status: "suppressed" });
-      expect(mocks.runMessageAction).toHaveBeenCalledTimes(2);
+      if (suppressed) {
+        expect(result.details).toMatchObject({ status: "suppressed", reason: "poll_vote_echo" });
+      } else {
+        expect(result.details).not.toMatchObject({ status: "suppressed" });
+      }
+      expect(mocks.runMessageAction).toHaveBeenCalledTimes(suppressed ? 1 : 2);
     } finally {
-      vi.useRealTimers();
+      now.mockRestore();
     }
   });
 

--- a/src/agents/tools/message-tool.test.ts
+++ b/src/agents/tools/message-tool.test.ts
@@ -1015,6 +1015,29 @@ describe("poll vote echo guard", () => {
     expect(result.details).toMatchObject({ status: "suppressed", reason: "poll_vote_echo" });
   });
 
+  it("allows a same-route echo at the exact TTL boundary", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(100_000);
+      const sessionKey = "agent:test:imessage:direct:ttl-boundary";
+      const voteTool = createPollVoteTool("Black", sessionKey);
+      await castBlueVote(voteTool);
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      const nextRunTool = createPollVoteTool("Black", sessionKey);
+      const result = await nextRunTool.execute("send", {
+        action: "send",
+        channel: "imessage",
+        message: "🦞 Black.",
+      });
+
+      expect(result.details).not.toMatchObject({ status: "suppressed" });
+      expect(mocks.runMessageAction).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not suppress a later-run echo from a different conversation", async () => {
     const voteTool = createPollVoteTool("Black", "agent:test:imessage:direct:convo-a");
     await castBlueVote(voteTool);


### PR DESCRIPTION
## What Problem This Solves

A same-route poll-vote follow-up at exactly 30 seconds could still be suppressed even though the echo guard had reached its expiry boundary.

## Why This Change Was Made

Use inclusive expiry in both the pre-dispatch lookup and the write-time pruning loop. Preserve the existing session/agent/route/account scope, one-shot consumption, and text matching. Production remains net zero; no configuration, persistence, or channel API changes.

## User Impact

An echo at 29,999 ms stays suppressed. At 30,000 ms and afterward, the follow-up reaches outbound delivery.

## Evidence

Independently authored tests first ran against unchanged trusted main `37db48c3e93cef9330bad6de67fd7d77183e05da`: the 30,000 ms case failed because the result was suppressed, while 29,999 ms and 30,001 ms controls passed. The equivalent two-comparator repair passes all ten existing and authored poll-guard cases, covering fresh tool instances across turns, conversation/route/account isolation, emoji identity, and one-shot consumption. Only `Date.now` is controlled in the boundary regression; unrelated timers retain normal behavior.

The retained inspectable harness below proves the changed delivery boundary through the real `createMessageTool` and default `runMessageAction`, a loopback WebSocket mock Gateway, the production server-side action runner, and an HTTP synthetic channel API. The vote is handled through the channel's local action path, and follow-up sends use its Gateway execution path. Each follow-up uses a fresh tool and turn capability for the same session and route. The same unchanged harness records baseline suppression at exactly 30,000 ms and repaired delivery at 30,000 and 30,001 ms, while retaining suppression at 29,999 ms. Both socket servers are closed and the isolated state is removed in `finally`.

This is actual mock-Gateway/channel transport proof. It does not start the complete production Gateway, use a model, or deliver an external iMessage; the action runner and tool results are not mocked. The original temporary direct-adapter trace is superseded by this retained harness and its explicit transport observations, addressing the latest ClawSweeper proof request.

Node 24.20.0: the baseline regression command took 27.50 seconds; the repaired ten-case poll group took 26.86 seconds. The initial harness calibration failed before actions because the synthetic plugin lacked its required outbound surface; the retained harness includes that surface and then reproduced the intended baseline failure. No production workaround, deadline change, or assertion weakening was made. Production +2/-2 (net0), tests +29/-0. Thanks @qingminglong; contributor ancestry is preserved.

The incoming branch's CI failed in checkout authentication before tests began. Final published-head CI and native landing validation remain pending; runtime results above come from the independently authored equivalent on trusted main.

Changed-scope validation passed formatting, core and core-test typechecks, targeted lint, and the required repository guards. The temporary gate checkout initially lacked the UI workspace dependency link and resolved an older root pako without declarations; linking the existing pinned UI installation corrected that checkout layout, with no dependency or source change.

<details>
<summary>Inspectable synthetic proof harness</summary>

Run from the reviewed, dependency-complete checkout with Node 24:

```sh
node --import ./scripts/tsx.mjs /path/to/probe.mts "$PWD"
```

```typescript
// Retained synthetic proof: real tool + outbound runner, loopback WebSocket mock
// Gateway, production server-side action runner, and an HTTP mock channel API.
import assert from "node:assert/strict";
import { createHash } from "node:crypto";
import { readFile } from "node:fs/promises";
import { createServer } from "node:http";
import { createRequire } from "node:module";
import path from "node:path";
import { performance } from "node:perf_hooks";
import { pathToFileURL } from "node:url";
const repo = process.argv[2];
if (!repo) throw new Error("usage: tools-poll-gateway-probe.mts <trusted-checkout>");
const load = (file: string) => import(pathToFileURL(path.join(repo, file)).href);
const { WebSocketServer } = createRequire(path.join(repo, "package.json"))("ws");
const [{ createOpenClawTestState }, registry, fixtures, configRuntime, capabilities, gatewayFrames] =
  await Promise.all([
    load("src/test-utils/openclaw-test-state.ts"), load("src/plugins/runtime.ts"),
    load("src/test-utils/channel-plugins.ts"), load("src/config/runtime-snapshot.ts"),
    load("src/gateway/message-action-turn-capability.ts"), load("src/gateway/minimal-gateway.test-helpers.ts"),
  ]);
const state = await createOpenClawTestState({ prefix: "poll-ttl-proof-", layout: "home" });
const originalNow = Date.now;
const started = performance.now();
const channelRecords: Array<Record<string, unknown>> = [];
const gatewayRecords: Array<Record<string, unknown>> = [];
const minted: string[] = [];
const results: Array<Record<string, unknown>> = [];
let clock = 100_000;
const channel = "ttl-proof";
const target = "user:synthetic-recipient";
const token = "synthetic-loopback-proof-token";
let runMessageAction: any;
let config: any;
const http = createServer(async (req, res) => {
  if (req.method !== "POST" || req.url !== "/channel") { res.writeHead(404).end(); return; }
  try {
    let body = "";
    for await (const chunk of req) body += chunk.toString();
    const record = JSON.parse(body);
    channelRecords.push(record);
    res.setHeader("content-type", "application/json");
    res.end(JSON.stringify({
      ok: true, messageId: `synthetic-${channelRecords.length}`,
      ...(record.action === "poll-vote" ? { pollVotedOption: "Black" } : {}),
    }));
  } catch (error) { res.writeHead(500).end(String(error)); }
});
const wss = new WebSocketServer({ server: http });
wss.on("connection", (ws: any) => {
  gatewayFrames.sendMinimalGatewayConnectChallenge(ws);
  ws.on("message", async (raw: any) => {
    const request = gatewayFrames.parseMinimalGatewayRequestFrame(raw);
    try {
      if (request.method === "connect") {
        assert.equal(request.params.auth.token, token);
        gatewayFrames.sendMinimalGatewayResponse(ws, request.id,
          gatewayFrames.buildMinimalGatewayHelloOkPayload({ methods: ["message.action"] }));
        return;
      }
      assert.equal(request.method, "message.action");
      const envelope = request.params;
      gatewayRecords.push({ action: envelope.action, channel: envelope.channel, params: envelope.params });
      // The mock Gateway owns this synthetic channel and delegates to the actual
      // outbound action runner. No network operation or tool result is mocked.
      const result = await runMessageAction({
        cfg: config, action: envelope.action,
        params: { ...envelope.params, channel: envelope.channel },
        defaultAccountId: envelope.accountId,
        conversationReadOrigin: "direct-operator",
      });
      gatewayFrames.sendMinimalGatewayResponse(ws, request.id, result.payload);
    } catch (error) {
      ws.send(JSON.stringify({ type: "res", id: request.id, ok: false,
        error: { code: "UNAVAILABLE", message: String(error) } }));
    }
  });
});
try {
  await new Promise<void>((resolve) => http.listen(0, "127.0.0.1", resolve));
  const address = http.address();
  assert(address && typeof address !== "string");
  const url = `ws://127.0.0.1:${address.port}`;
  const channelApi = `http://127.0.0.1:${address.port}/channel`;
  config = { gateway: { port: address.port, auth: { mode: "token", token } },
    channels: { [channel]: { enabled: true } }, agents: { entries: { main: { default: true } } } };
  configRuntime.setRuntimeConfigSnapshot(config, config);
  const plugin = {
    ...fixtures.createChannelTestPluginBase({ id: channel,
      config: { listAccountIds: () => ["default"], resolveAccount: () => ({ enabled: true }) } }),
    outbound: { deliveryMode: "gateway" },
    messaging: { normalizeTarget: (value: string) => value, targetResolver: { looksLikeId: () => true } },
    actions: {
      describeMessageTool: () => ({ actions: ["send", "poll-vote"] }),
      resolveExecutionMode: ({ action }: { action: string }) => action === "send" ? "gateway" : "local",
      handleAction: async ({ action, params, accountId }: any) => {
        const response = await fetch(channelApi, { method: "POST", headers: { "content-type": "application/json" },
          body: JSON.stringify({ action, target: params.to ?? params.target, accountId,
            message: params.message, pollId: params.pollId }) });
        assert.equal(response.status, 200);
        const details = await response.json();
        return { content: [{ type: "text", text: JSON.stringify(details) }], details };
      },
    },
  };
  registry.setActivePluginRegistry(fixtures.createTestRegistry([
    { pluginId: channel, plugin, source: "test", origin: "config" },
  ]));
  const { createMessageTool } = await load("src/agents/tools/message-tool-execution.ts");
  ({ runMessageAction } = await load("src/infra/outbound/message-action-runner.ts"));
  Date.now = () => clock;
  for (const elapsedMs of [29_999, 30_000, 30_001]) {
    clock = 100_000;
    const sessionKey = `agent:main:${channel}:direct:ttl-${elapsedMs}`;
    const toolForRun = (runId: string) => {
      const capability = capabilities.mintMessageActionTurnCapability({
        agentId: "main", runId, sessionKey, requesterAccountId: "default", expiresWithRun: true,
        toolContext: { currentChannelProvider: channel, currentChannelId: target, currentChatType: "direct" },
      });
      minted.push(capability);
      return createMessageTool({ config, agentId: "main", runId, agentSessionKey: sessionKey,
        agentAccountId: "default", currentChannelProvider: channel, currentChannelId: target,
        sourceReplyDeliveryMode: "message_tool_only", messageActionTurnCapability: capability,
        getScopedChannelsCommandSecretTargets: () => ({ targetIds: new Set<string>() }),
        resolveCommandSecretRefsViaGateway: async ({ config: cfg }: any) => ({ resolvedConfig: cfg, diagnostics: [] }),
      });
    };
    const from = channelRecords.length;
    await toolForRun(`vote-${elapsedMs}`).execute(`vote-${elapsedMs}`, {
      action: "poll-vote", channel, target, pollId: "synthetic-poll", pollOptionIndex: 2,
      gatewayUrl: url, gatewayToken: token,
    });
    capabilities.revokeMessageActionTurnCapability(minted.pop());
    clock += elapsedMs;
    const result = await toolForRun(`followup-${elapsedMs}`).execute(`send-${elapsedMs}`, {
      action: "send", channel, target, message: "🦞 Black.", gatewayUrl: url, gatewayToken: token,
    });
    capabilities.revokeMessageActionTurnCapability(minted.pop());
    const records = channelRecords.slice(from);
    const suppressed = result.details?.status === "suppressed";
    results.push({ elapsedMs, suppressed, channelRecords: records,
      expected: elapsedMs < 30_000 ? "suppressed" : "delivered" });
  }
  const passed = results.every((result) => result.suppressed === (Number(result.elapsedMs) < 30_000) &&
    (result.channelRecords as unknown[]).length === (Number(result.elapsedMs) < 30_000 ? 1 : 2));
  console.log(JSON.stringify({ passed, sourceSha256: createHash("sha256").update(await readFile(
    path.join(repo, "src/agents/tools/message-tool-execution.ts"))).digest("hex"),
    node: process.version, transport: "loopback WebSocket mock Gateway + HTTP synthetic channel API",
    realGatewayServer: false, mockActionRunner: false, externalDelivery: false,
    results, gatewayRecords, wallMs: performance.now() - started, rssBytes: process.memoryUsage().rss }, null, 2));
  if (!passed) process.exitCode = 1;
} finally {
  Date.now = originalNow;
  for (const capability of minted) capabilities.revokeMessageActionTurnCapability(capability);
  await gatewayFrames.closeMinimalGatewayServer(wss);
  await new Promise<void>((resolve) => http.close(() => resolve()));
  registry.resetPluginRuntimeStateForTest();
  configRuntime.clearRuntimeConfigSnapshot();
  await state.cleanup();
}
```

</details>

<details>
<summary>Before proof result</summary>

```json
{
  "passed": false,
  "sourceSha256": "76dbcc332bb46fb2cf24944beeeaa7a1a349ad98a39d8ffb995095328df5a2fd",
  "node": "v24.20.0",
  "transport": "loopback WebSocket mock Gateway + HTTP synthetic channel API",
  "realGatewayServer": false,
  "mockActionRunner": false,
  "externalDelivery": false,
  "results": [
    {
      "elapsedMs": 29999,
      "suppressed": true,
      "channelRecords": [
        {
          "action": "poll-vote",
          "target": "user:synthetic-recipient",
          "accountId": "default",
          "pollId": "synthetic-poll"
        }
      ],
      "expected": "suppressed"
    },
    {
      "elapsedMs": 30000,
      "suppressed": true,
      "channelRecords": [
        {
          "action": "poll-vote",
          "target": "user:synthetic-recipient",
          "accountId": "default",
          "pollId": "synthetic-poll"
        }
      ],
      "expected": "delivered"
    },
    {
      "elapsedMs": 30001,
      "suppressed": false,
      "channelRecords": [
        {
          "action": "poll-vote",
          "target": "user:synthetic-recipient",
          "accountId": "default",
          "pollId": "synthetic-poll"
        },
        {
          "action": "send",
          "target": "user:synthetic-recipient",
          "accountId": "default",
          "message": "🦞 Black."
        }
      ],
      "expected": "delivered"
    }
  ],
  "gatewayRecords": [
    {
      "action": "send",
      "channel": "ttl-proof",
      "params": {
        "action": "send",
        "channel": "ttl-proof",
        "target": "user:synthetic-recipient",
        "message": "🦞 Black.",
        "idempotencyKey": "followup-30001:message-tool:-LdJxFPey48gLnmhZfEyOkpm:send-30001",
        "bestEffort": true,
        "to": "user:synthetic-recipient",
        "accountId": "default",
        "__sessionKey": "agent:main:main",
        "__agentId": "main"
      }
    }
  ],
  "wallMs": 3374.4456249999994,
  "rssBytes": 759595008
}
```

</details>

<details>
<summary>After proof result</summary>

```json
{
  "passed": true,
  "sourceSha256": "f518a930ee6f785f032648a4ee14a62ddd38220e025e2f3a4df4a3215ad6a58a",
  "node": "v24.20.0",
  "transport": "loopback WebSocket mock Gateway + HTTP synthetic channel API",
  "realGatewayServer": false,
  "mockActionRunner": false,
  "externalDelivery": false,
  "results": [
    {
      "elapsedMs": 29999,
      "suppressed": true,
      "channelRecords": [
        {
          "action": "poll-vote",
          "target": "user:synthetic-recipient",
          "accountId": "default",
          "pollId": "synthetic-poll"
        }
      ],
      "expected": "suppressed"
    },
    {
      "elapsedMs": 30000,
      "suppressed": false,
      "channelRecords": [
        {
          "action": "poll-vote",
          "target": "user:synthetic-recipient",
          "accountId": "default",
          "pollId": "synthetic-poll"
        },
        {
          "action": "send",
          "target": "user:synthetic-recipient",
          "accountId": "default",
          "message": "🦞 Black."
        }
      ],
      "expected": "delivered"
    },
    {
      "elapsedMs": 30001,
      "suppressed": false,
      "channelRecords": [
        {
          "action": "poll-vote",
          "target": "user:synthetic-recipient",
          "accountId": "default",
          "pollId": "synthetic-poll"
        },
        {
          "action": "send",
          "target": "user:synthetic-recipient",
          "accountId": "default",
          "message": "🦞 Black."
        }
      ],
      "expected": "delivered"
    }
  ],
  "gatewayRecords": [
    {
      "action": "send",
      "channel": "ttl-proof",
      "params": {
        "action": "send",
        "channel": "ttl-proof",
        "target": "user:synthetic-recipient",
        "message": "🦞 Black.",
        "idempotencyKey": "followup-30000:message-tool:-LdJxFPey48gLnmhZfEyOkpm:send-30000",
        "bestEffort": true,
        "to": "user:synthetic-recipient",
        "accountId": "default",
        "__sessionKey": "agent:main:main",
        "__agentId": "main"
      }
    },
    {
      "action": "send",
      "channel": "ttl-proof",
      "params": {
        "action": "send",
        "channel": "ttl-proof",
        "target": "user:synthetic-recipient",
        "message": "🦞 Black.",
        "idempotencyKey": "followup-30001:message-tool:-LdJxFPey48gLnmhZfEyOkpm:send-30001",
        "bestEffort": true,
        "to": "user:synthetic-recipient",
        "accountId": "default",
        "__sessionKey": "agent:main:main",
        "__agentId": "main"
      }
    }
  ],
  "wallMs": 3949.3650829999997,
  "rssBytes": 760463360
}
```

</details>
