### PR TITLE
fix: keep stable-upgrade validation compatible with older installs

### DIFF
--- a/extensions/discord/src/config-schema.test.ts
+++ b/extensions/discord/src/config-schema.test.ts
@@ -1,5 +1,8 @@
 // Discord tests cover config schema plugin behavior.
+import { validateJsonSchemaValue } from "openclaw/plugin-sdk/json-schema-runtime";
 import { describe, expect, it } from "vitest";
+import { resolveUpgradeSurvivorConfigStepsForBaseline } from "../../../scripts/e2e/lib/upgrade-survivor/config-recipe.mts";
+import { DiscordChannelConfigSchema } from "../channel-config-api.js";
 import { DiscordConfigSchema } from "../config-api.js";
 
 function expectValidDiscordConfig(config: unknown) {
@@ -21,6 +24,41 @@ function expectInvalidDiscordConfig(config: unknown) {
 }
 
 describe("discord config schema", () => {
+  it.each([
+    ["2026.3.13", true],
+    ["2026.7.1-2", true],
+    ["2026.7.2-beta.3", true],
+    ["2026.7.2-beta.4", false],
+    ["2026.8.1-beta.1", false],
+    ["2026.8.1-beta.2", false],
+    ["2026.8.1", false],
+    [null, false],
+  ] as const)("preserves supported Discord DM input for baseline %s", (version, legacy) => {
+    const step = resolveUpgradeSurvivorConfigStepsForBaseline("base", version).find(
+      (entry) => entry.id === "channels-discord",
+    );
+    expect(step).toBeDefined();
+    const discord = JSON.parse(step?.argv[3] ?? "{}");
+    if (legacy) {
+      expect(discord.dm).toEqual({ policy: "allowlist", allowFrom: ["111111111111111111"] });
+      expect(discord.dmPolicy).toBeUndefined();
+      expect(discord.allowFrom).toBeUndefined();
+    } else {
+      expect(discord.dm).toBeUndefined();
+      expect(discord.dmPolicy).toBe("allowlist");
+      expect(discord.allowFrom).toEqual(["111111111111111111"]);
+    }
+    // The public schema is the config-set boundary; runtime Zod preprocessing
+    // would silently normalize the legacy specimen and miss a bad baseline cutoff.
+    expect(
+      validateJsonSchemaValue({
+        schema: DiscordChannelConfigSchema.schema,
+        cacheKey: "upgrade-survivor-discord-config",
+        value: discord,
+      }).ok,
+    ).toBe(!legacy);
+  });
+
   it('rejects dmPolicy="open" without allowFrom "*"', () => {
     const issues = expectInvalidDiscordConfig({
       dmPolicy: "open",

--- a/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
+++ b/scripts/e2e/lib/upgrade-survivor/config-recipe.mts
@@ -4,7 +4,7 @@ import { spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { parseReleaseVersion } from "../../../lib/release-version.mjs";
+import { compareReleaseVersions, parseReleaseVersion } from "../../../lib/release-version.mjs";
 import { buildCmdExeCommandLine, resolveWindowsCmdExePath } from "../../../windows-cmd-helpers.mjs";
 
 const args = process.argv.slice(2);
@@ -289,59 +289,82 @@ function adaptStepForBaseline(
     }
     return null;
   }
-  const legacyBaseline = isReleaseBefore(baselineVersion, "2026.4.0");
-  const modernBaseline = baselineVersion && !isReleaseBefore(baselineVersion, "2026.8.1");
-  if (legacyBaseline && (step.id === "plugins-feishu" || step.id === "channels-feishu")) {
+  if (step.id === "agents") {
+    const agentsJson = step.argv[3];
+    if (agentsJson === undefined) {
+      throw new Error(`config recipe step ${step.id} is missing its JSON value`);
+    }
+    const agents = JSON.parse(agentsJson);
+    // Explicit ownership was introduced in beta.2; beta.1 requires a
+    // legacy default marker, so this boundary must compare prereleases too.
+    if (compareReleaseVersions(baselineVersion ?? "", "2026.8.1-beta.2") === -1) {
+      agents.list = Object.entries<Record<string, unknown>>(agents.entries).map(([id, entry]) => {
+        entry.id = id;
+        if (id === "main") {
+          entry.default = true;
+        }
+        return entry;
+      });
+      delete agents.entries;
+      delete agents.ownership;
+    }
+    if (isReleaseBefore(baselineVersion, "2026.4.0")) {
+      delete agents.defaults?.skills;
+      for (const agent of agents.list) {
+        delete agent.thinkingDefault;
+        delete agent.fastModeDefault;
+        delete agent.skills;
+      }
+      summary.skippedIntents.push("agent-modern-preferences");
+    }
+    return {
+      ...step,
+      argv: [...step.argv.slice(0, 3), JSON.stringify(agents), ...step.argv.slice(4)],
+    };
+  }
+  if (
+    step.id === "channels-discord" &&
+    compareReleaseVersions(baselineVersion ?? "", "2026.7.2-beta.4") === -1
+  ) {
+    const discordJson = step.argv[3];
+    if (discordJson === undefined) {
+      throw new Error(`config recipe step ${step.id} is missing its JSON value`);
+    }
+    // beta.4 retired nested DM policy. Older baselines retain the shipped
+    // specimen so candidate Doctor must migrate it without changing access.
+    const { dmPolicy, allowFrom, ...discord } = JSON.parse(discordJson);
+    discord.dm = { policy: dmPolicy, allowFrom };
+    return {
+      ...step,
+      argv: [...step.argv.slice(0, 3), JSON.stringify(discord), ...step.argv.slice(4)],
+    };
+  }
+  if (!isReleaseBefore(baselineVersion, "2026.4.0")) {
+    return step;
+  }
+  if (step.id === "plugins-feishu" || step.id === "channels-feishu") {
     if (!summary.skippedIntents.includes("feishu-channel")) {
       summary.skippedIntents.push("feishu-channel");
     }
     return null;
   }
-  if (
-    !(step.id === "agents" && (legacyBaseline || modernBaseline)) &&
-    !(step.id === "channels-discord" && modernBaseline) &&
-    !(step.intent === "plugins" && legacyBaseline)
-  ) {
-    return step;
-  }
-  const configJson = step.argv[3];
-  if (configJson === undefined) {
-    throw new Error(`config recipe step ${step.id} is missing its JSON value`);
-  }
-  const config = JSON.parse(configJson);
-  if (step.id === "agents") {
-    // Modern config writes stamp explicit ownership when adding a second agent.
-    // Older baselines need their default marker for ownership migration on upgrade.
-    for (const agent of config.list ?? []) {
-      if (modernBaseline) {
-        delete agent.default;
-      }
-      if (legacyBaseline) {
-        delete agent.thinkingDefault;
-        delete agent.fastModeDefault;
-        delete agent.skills;
-      }
+  if (step.intent === "plugins") {
+    const pluginsJson = step.argv[3];
+    if (pluginsJson === undefined) {
+      throw new Error(`config recipe step ${step.id} is missing its JSON value`);
     }
-    if (legacyBaseline) {
-      delete config.defaults?.skills;
-      summary.skippedIntents.push("agent-modern-preferences");
-    }
-  } else if (step.id === "channels-discord") {
-    // Keep retired DM fields as migration specimens only for older baselines.
-    config.dmPolicy = config.dm.policy;
-    config.allowFrom = config.dm.allowFrom;
-    delete config.dm;
-  } else {
-    config.allow = (config.allow ?? []).filter((id: unknown) => id !== "memory");
-    delete config.entries?.memory;
+    const plugins = JSON.parse(pluginsJson);
+    plugins.allow = (plugins.allow ?? []).filter((id: unknown) => id !== "memory");
+    delete plugins.entries?.memory;
     if (!summary.skippedIntents.includes("memory-plugin-allow")) {
       summary.skippedIntents.push("memory-plugin-allow");
     }
+    return {
+      ...step,
+      argv: [...step.argv.slice(0, 3), JSON.stringify(plugins), ...step.argv.slice(4)],
+    };
   }
-  return {
-    ...step,
-    argv: [...step.argv.slice(0, 3), JSON.stringify(config), ...step.argv.slice(4)],
-  };
+  return step;
 }
 
 export function resolveUpgradeSurvivorConfigStepsForBaseline(

--- a/scripts/e2e/lib/upgrade-survivor/config-recipe/agents.json
+++ b/scripts/e2e/lib/upgrade-survivor/config-recipe/agents.json
@@ -1,17 +1,15 @@
 {
+  "ownership": "explicit",
   "defaults": {
     "model": {
       "primary": "openai/gpt-5.5"
     },
-    "contextTokens": 64000,
     "heartbeat": {
       "every": "0m"
     }
   },
-  "list": [
-    {
-      "id": "main",
-      "default": true,
+  "entries": {
+    "main": {
       "name": "Main",
       "workspace": "~/workspace",
       "model": {
@@ -20,8 +18,7 @@
       "thinkingDefault": "low",
       "skills": ["memory"]
     },
-    {
-      "id": "ops",
+    "ops": {
       "name": "Ops",
       "workspace": "~/workspace/ops",
       "model": {
@@ -29,5 +26,5 @@
       },
       "fastModeDefault": true
     }
-  ]
+  }
 }

--- a/scripts/e2e/lib/upgrade-survivor/config-recipe/channels-discord.json
+++ b/scripts/e2e/lib/upgrade-survivor/config-recipe/channels-discord.json
@@ -5,10 +5,8 @@
     "provider": "default",
     "id": "DISCORD_BOT_TOKEN"
   },
-  "dm": {
-    "policy": "allowlist",
-    "allowFrom": ["111111111111111111"]
-  },
+  "dmPolicy": "allowlist",
+  "allowFrom": ["111111111111111111"],
   "groupPolicy": "allowlist",
   "guilds": {
     "222222222222222222": {

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -872,15 +872,8 @@ source scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
 export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG="$SYSTEMCTL_SHIM_LOG"
 export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE="$SYSTEMCTL_SHIM_PID_FILE"
 export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG="$SYSTEMCTL_SHIM_DAEMON_LOG"
-
-install_update_restart_service_unit() {
-  if ! openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD openclaw gateway install --force --json >"$BASELINE_SERVICE_INSTALL_JSON" 2>"$BASELINE_SERVICE_INSTALL_ERR"; then
-    echo "baseline gateway service install failed" >&2
-    openclaw_e2e_print_log "$BASELINE_SERVICE_INSTALL_ERR" >&2
-    openclaw_e2e_print_log "$BASELINE_SERVICE_INSTALL_JSON" >&2
-    return 1
-  fi
-}
+export OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_JSON="$BASELINE_SERVICE_INSTALL_JSON"
+export OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_ERR="$BASELINE_SERVICE_INSTALL_ERR"
 
 seed_update_restart_probe_device_auth() {
   node --input-type=module <<'NODE'
@@ -993,9 +986,14 @@ prepare_update_restart_probe() {
   echo "Preparing configured-auth gateway for automatic update restart."
   install_update_restart_systemctl_shim
   seed_update_restart_probe_device_auth
-  park_prepublish_authored_config
   local probe_status=0
-  start_gateway legacy-ready-log-ok || probe_status=$?
+  park_prepublish_authored_config || probe_status=$?
+  if [ "$probe_status" -eq 0 ]; then
+    write_update_restart_service_env || probe_status=$?
+  fi
+  if [ "$probe_status" -eq 0 ]; then
+    install_update_restart_probe_gateway 18789 "$COMMAND_TIMEOUT" legacy-ready-log-ok || probe_status=$?
+  fi
   if [ "$probe_status" -eq 0 ]; then
     assert_prepublish_fixture_idle || probe_status=$?
   fi
@@ -1008,8 +1006,6 @@ prepare_update_restart_probe() {
     return "$restore_status"
   fi
   assert_baseline_state
-  write_update_restart_service_env
-  install_update_restart_service_unit
 }
 
 assert_baseline_state() {
@@ -1283,10 +1279,7 @@ start_gateway() {
   start_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
   env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD openclaw gateway --port "$port" --bind loopback --allow-unconfigured >"$GATEWAY_LOG" 2>&1 &
   gateway_pid="$!"
-  if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
-    printf '%s\n' "$gateway_pid" >"$SYSTEMCTL_SHIM_PID_FILE"
-  fi
-  openclaw_e2e_wait_gateway_ready "$gateway_pid" "$GATEWAY_LOG" 360 "$port" "${1:-strict}"
+  openclaw_e2e_wait_gateway_ready "$gateway_pid" "$GATEWAY_LOG" 360 "$port" || return "$?"
   ready_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
   start_seconds=$(((ready_epoch - start_epoch + 999) / 1000))
   if [ "$start_seconds" -gt "$budget" ]; then

--- a/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
@@ -469,6 +469,35 @@ write_update_restart_service_auth_env() {
   printf 'GATEWAY_AUTH_TOKEN_REF=%s\n' "$GATEWAY_AUTH_TOKEN_REF" >"$OPENCLAW_STATE_DIR/gateway.systemd.env"
 }
 
+install_update_restart_probe_gateway() {
+  local port="$1" command_timeout="$2" readiness_mode="${3:-strict}"
+  local log_file="$OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG"
+  local install_json="$OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_JSON"
+  local install_err="$OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_ERR"
+  local start_epoch ready_epoch budget install_status=0
+  budget="$(openclaw_e2e_read_positive_int_env OPENCLAW_UPGRADE_SURVIVOR_START_BUDGET_SECONDS 90)"
+  start_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
+  : >"$log_file"
+  # Installation starts the generated unit. Only its manager may publish the PID;
+  # adopting a foreground CLI leaves historical respawn children outside that owner.
+  openclaw_e2e_maybe_timeout "$command_timeout" env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD openclaw gateway install --force --json >"$install_json" 2>"$install_err" || install_status=$?
+  if [ "$install_status" -ne 0 ]; then
+    echo "gateway service install failed" >&2
+    openclaw_e2e_print_log "$install_err" >&2
+    openclaw_e2e_print_log "$install_json" >&2
+    return "$install_status"
+  fi
+  gateway_pid="$(cat "$OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE")" || return "$?"
+  openclaw_e2e_wait_gateway_ready "$gateway_pid" "$log_file" 360 "$port" "$readiness_mode" || return "$?"
+  ready_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
+  start_seconds=$(((ready_epoch - start_epoch + 999) / 1000))
+  if [ "$start_seconds" -gt "$budget" ]; then
+    echo "gateway startup exceeded survivor budget: ${start_seconds}s > ${budget}s" >&2
+    openclaw_e2e_print_log "$log_file" >&2
+    return 1
+  fi
+}
+
 prepare_update_restart_probe_current_install() {
   local port="$1"
   local log_file="$2"
@@ -479,14 +508,12 @@ prepare_update_restart_probe_current_install() {
   local failure_stage=""
   local probe_status=0
   local restore_status=0
-  local start_epoch
-  local ready_epoch
 
   echo "Preparing candidate-auth gateway for automatic update restart."
   install_update_restart_systemctl_shim
   seed_update_restart_probe_device_auth
   # Service installation persists OPENCLAW_CONFIG_PATH, so isolate the canonical file in place.
-  # Reload stays off through service setup; restoring authored bytes cannot restart this probe.
+  # Keep reload off until the manager owns the installed service and its descendants.
   node "$parking_helper" \
     park-restart-probe "$OPENCLAW_CONFIG_PATH" "$authored_config" "$port" || probe_status=$?
   if [ "$probe_status" -ne 0 ]; then
@@ -517,36 +544,15 @@ prepare_update_restart_probe_current_install() {
     cat "$doctor_log" >&2 || true
   fi
   if [ "$probe_status" -eq 0 ]; then
-    start_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
-    env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD openclaw gateway --port "$port" --bind loopback --allow-unconfigured >"$log_file" 2>&1 &
-    gateway_pid="$!"
-    printf '%s\n' "$gateway_pid" >"$OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE"
-    openclaw_e2e_wait_gateway_ready "$gateway_pid" "$log_file" 360 "$port" || {
-      probe_status=$?
-      failure_stage="readiness"
-    }
-  fi
-  if [ "$probe_status" -eq 0 ]; then
-    ready_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
-    start_seconds=$(((ready_epoch - start_epoch + 999) / 1000))
     write_update_restart_service_auth_env || {
       probe_status=$?
       failure_stage="service-env"
     }
   fi
   if [ "$probe_status" -eq 0 ]; then
-    openclaw_e2e_maybe_timeout "$command_timeout" env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD openclaw gateway install --force --json >"$OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_JSON" 2>"$OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_ERR" || {
-      probe_status=$?
-      failure_stage="install"
-    }
+    install_update_restart_probe_gateway "$port" "$command_timeout" || probe_status=$?
   fi
-  if [ "$failure_stage" = "install" ]; then
-    echo "gateway service install failed" >&2
-    cat "$OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_ERR" >&2 || true
-    cat "$OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_JSON" >&2 || true
-  elif [ "$failure_stage" = "readiness" ]; then
-    echo "candidate restart probe gateway did not become ready" >&2
-  elif [ "$failure_stage" = "service-env" ]; then
+  if [ "$failure_stage" = "service-env" ]; then
     echo "failed to write candidate restart service environment" >&2
   fi
   node "$parking_helper" restore "$OPENCLAW_CONFIG_PATH" "$authored_config" || restore_status=$?

--- a/scripts/lib/openclaw-e2e-instance.sh
+++ b/scripts/lib/openclaw-e2e-instance.sh
@@ -421,6 +421,11 @@ openclaw_e2e_gateway_log_port_from_text() {
 openclaw_e2e_wait_gateway_ready() {
   local pid="$1" log="$2" attempts="${3:-300}" ready_port="${4:-}" readiness_mode="${5:-strict}" _ saw_ready_log=false
   local ready_scan_offset=0 ready_scan_carry="" ready_scan_carry_chars=256
+  local ready_log_pattern='\[gateway\] ready'
+  # Published baselines logged their listener before the modern ready marker existed.
+  if [ "$readiness_mode" = "legacy-ready-log-ok" ]; then
+    ready_log_pattern='\[gateway\] (ready|listening on)'
+  fi
   for _ in $(seq 1 "$attempts"); do
     ! kill -0 "$pid" >/dev/null 2>&1 && {
       echo "Gateway exited before becoming ready"
@@ -450,7 +455,7 @@ openclaw_e2e_wait_gateway_ready() {
           ready_scan_carry="$scan_text"
         fi
         local ready_log_lines
-        ready_log_lines="$(printf "%s" "$scan_text" | grep '\[gateway\] ready' || true)"
+        ready_log_lines="$(printf "%s" "$scan_text" | grep -E "$ready_log_pattern" || true)"
         if [ -n "$ready_log_lines" ]; then
           saw_ready_log=true
           [ -n "$ready_port" ] || ready_port="$(printf "%s" "$ready_log_lines" | openclaw_e2e_gateway_log_port_from_text)"
@@ -458,14 +463,21 @@ openclaw_e2e_wait_gateway_ready() {
       fi
     fi
     if [ "$saw_ready_log" = "true" ]; then
-      [ "$readiness_mode" = "legacy-ready-log-ok" ] && return 0
       [ -n "$ready_port" ] || ready_port="${OPENCLAW_E2E_GATEWAY_READY_PORT:-18789}"
-      openclaw_e2e_probe_http "http://127.0.0.1:${ready_port}/readyz" ok 400 && return 0
+      if [ "$readiness_mode" = "legacy-ready-log-ok" ]; then
+        openclaw_e2e_probe_tcp 127.0.0.1 "$ready_port" 400 && return 0
+      else
+        openclaw_e2e_probe_http "http://127.0.0.1:${ready_port}/readyz" ok 400 && return 0
+      fi
     fi
     sleep 0.25
   done
   if [ "$saw_ready_log" = "true" ]; then
-    echo "Gateway log reported ready, but /readyz probe never succeeded"
+    if [ "$readiness_mode" = "legacy-ready-log-ok" ]; then
+      echo "Gateway startup log was found, but TCP listener probe never succeeded"
+    else
+      echo "Gateway log reported ready, but /readyz probe never succeeded"
+    fi
   else
     echo "Gateway did not become ready"
   fi

--- a/scripts/lib/release-version.d.mts
+++ b/scripts/lib/release-version.d.mts
@@ -1,0 +1,25 @@
+type ParsedReleaseVersion = {
+  version: string;
+  baseVersion: string;
+  channel: "stable" | "alpha" | "beta";
+  year: number;
+  month: number;
+  patch: number;
+  alphaNumber?: number;
+  betaNumber?: number;
+  correctionNumber?: number;
+};
+
+type ReleaseTrain =
+  | "alpha"
+  | "beta"
+  | "stable"
+  | "extended-stable"
+  | "unsupported-extended-stable-correction";
+
+export function parseReleaseVersion(version: string): ParsedReleaseVersion | null;
+export function classifyReleaseTrain(parsedVersion: ParsedReleaseVersion): ReleaseTrain;
+export function collectReleaseVersionFloorErrors(
+  version: string | ParsedReleaseVersion | null,
+): string[];
+export function compareReleaseVersions(left: string, right: string): number | null;

--- a/scripts/windows-cmd-helpers.d.mts
+++ b/scripts/windows-cmd-helpers.d.mts
@@ -1,0 +1,5 @@
+export function resolvePathEnvKey(env: NodeJS.ProcessEnv): string;
+export function resolveWindowsSystem32Path(executableName: string, env?: NodeJS.ProcessEnv): string;
+export function resolveWindowsCmdExePath(env?: NodeJS.ProcessEnv): string;
+export function resolveWindowsPowerShellPath(env?: NodeJS.ProcessEnv): string;
+export function buildCmdExeCommandLine(command: string, args: readonly string[]): string;

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -17,6 +17,7 @@ import { dirname, join } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
+import { buildSystemdUnit } from "../../src/daemon/systemd-unit.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -2846,8 +2847,11 @@ docker_e2e_docker_run_cmd run demo
     expect(publishedRunner.lastIndexOf("assert_prepublish_fixture_idle")).toBeLessThan(
       publishedRunner.lastIndexOf("restore_prepublish_authored_config"),
     );
-    expect(publishedRunner.lastIndexOf("restore_prepublish_authored_config")).toBeLessThan(
-      publishedRunner.lastIndexOf("write_update_restart_service_env"),
+    expect(publishedRunner.lastIndexOf("write_update_restart_service_env")).toBeLessThan(
+      publishedRunner.lastIndexOf("install_update_restart_probe_gateway"),
+    );
+    expect(publishedRunner.lastIndexOf("install_update_restart_probe_gateway")).toBeLessThan(
+      publishedRunner.lastIndexOf("restore_prepublish_authored_config"),
     );
     for (const script of [runner, updateRestartAuth]) {
       expect(script).not.toContain("assert-no-requests");
@@ -3358,9 +3362,6 @@ fi
       'budget="$(openclaw_e2e_read_positive_int_env OPENCLAW_UPGRADE_SURVIVOR_STATUS_BUDGET_SECONDS 30)"',
     );
     expect(publishedRunner).toContain(
-      'openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" env -u OPENCLAW_GATEWAY_TOKEN',
-    );
-    expect(publishedRunner).toContain(
       'openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw --version',
     );
     expect(publishedRunner).toContain(
@@ -3383,10 +3384,6 @@ fi
       'openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw gateway status',
     );
     expect(publishedRunner).toContain('openclaw gateway --port "$port" --bind loopback');
-    expect(publishedRunner).toContain("start_gateway legacy-ready-log-ok");
-    expect(publishedRunner).toContain(
-      'openclaw_e2e_wait_gateway_ready "$gateway_pid" "$GATEWAY_LOG" 360 "$port" "${1:-strict}"',
-    );
 
     expect(updateRestartAuth).toContain(
       'command_timeout="${OPENCLAW_UPGRADE_SURVIVOR_COMMAND_TIMEOUT:-900s}"',
@@ -3394,10 +3391,193 @@ fi
     expect(updateRestartAuth).toContain(
       'openclaw_e2e_maybe_timeout "$command_timeout" env -u OPENCLAW_GATEWAY_TOKEN',
     );
-    expect(updateRestartAuth).toContain('openclaw gateway --port "$port" --bind loopback');
-    expect(updateRestartAuth).toContain(
-      'openclaw_e2e_wait_gateway_ready "$gateway_pid" "$log_file" 360 "$port"',
+  });
+
+  it.skipIf(process.platform !== "linux").each(["published", "current"])(
+    "starts the %s auth probe under the manager that owns its restart and stop",
+    async (lane) => {
+      const workDir = tempDirs.make("survivor-managed-probe-");
+      const artifacts = join(workDir, "artifacts");
+      const stateDir = join(workDir, "state");
+      mkdirSync(artifacts);
+      mkdirSync(stateDir);
+      const configPath = join(stateDir, "openclaw.json");
+      const authored = '{"gateway":{"mode":"local","port":18789},"channels":{"whatsapp":{}}}\n';
+      writeFileSync(configPath, authored);
+      const childPath = join(workDir, "listener.mjs");
+      const startsPath = join(workDir, "starts.jsonl");
+      const portPath = join(workDir, "port");
+      writeFileSync(
+        childPath,
+        `import fs from "node:fs";
+import http from "node:http";
+const identity = { pid: process.pid, managed: process.env.OPENCLAW_SYSTEMD_UNIT === "openclaw-gateway.service" };
+const server = http.createServer((_req, res) => res.end(JSON.stringify(identity)));
+const port = fs.existsSync(process.env.PORT_FILE) ? Number(fs.readFileSync(process.env.PORT_FILE, "utf8")) : 0;
+server.listen(port, "127.0.0.1", () => {
+  fs.writeFileSync(process.env.PORT_FILE, String(server.address().port));
+  fs.appendFileSync(process.env.STARTS_FILE, JSON.stringify(identity) + "\\n");
+  console.log("[gateway] ready on 127.0.0.1:" + server.address().port);
+});
+`,
+      );
+      const executable = join(workDir, "bin", "openclaw");
+      const stagedUnit = join(workDir, "staged.service");
+      writeFileSync(
+        stagedUnit,
+        buildSystemdUnit({
+          programArguments: [process.execPath, executable, "gateway"],
+          environment: { OPENCLAW_SYSTEMD_UNIT: "openclaw-gateway.service" },
+        }),
+      );
+      writeExecutables(join(workDir, "bin"), {
+        openclaw: `#!${process.execPath}
+const fs = require("node:fs"), path = require("node:path"), { spawn, spawnSync } = require("node:child_process");
+if (process.argv[2] === "doctor") process.exit(0);
+if (process.argv[3] === "install") {
+  const unit = path.join(process.env.HOME, ".config/systemd/user/openclaw-gateway.service");
+  fs.mkdirSync(path.dirname(unit), { recursive: true });
+  fs.copyFileSync(process.env.STAGED_UNIT, unit);
+  for (const args of [["daemon-reload"], ["enable", "openclaw-gateway.service"], ["restart", "openclaw-gateway.service"]]) {
+    const result = spawnSync("systemctl", ["--user", ...args], { stdio: "inherit" });
+    if (result.status !== 0) process.exit(result.status ?? 1);
+  }
+  process.exit(0);
+}
+const child = spawn(process.execPath, [process.env.LISTENER_SCRIPT], { stdio: "inherit" });
+child.once("exit", () => process.exit(0));
+// A wrapper exit must not strand the listening child outside its service owner.
+process.on("SIGTERM", () => {
+  if (!process.env.OPENCLAW_SYSTEMD_UNIT) process.exit(0);
+});
+`,
+      });
+      const env = {
+        ...process.env,
+        HOME: workDir,
+        PATH: `${join(workDir, "bin")}:${process.env.PATH}`,
+        npm_config_prefix: workDir,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_UPGRADE_SURVIVOR_BASELINE: "openclaw@2026.3.13",
+        OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE: "auto-auth",
+        OPENCLAW_UPGRADE_SURVIVOR_RUNTIME_ROOT: join(workDir, "runtime"),
+        OPENCLAW_UPGRADE_SURVIVOR_SUMMARY_JSON: join(artifacts, "summary.json"),
+        OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE: join(artifacts, "systemctl-shim.pid"),
+        OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_LOG: join(artifacts, "systemctl-shim.log"),
+        OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG: join(
+          artifacts,
+          "systemctl-shim-gateway.log",
+        ),
+        OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_JSON: join(artifacts, "install.json"),
+        OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_ERR: join(artifacts, "install.err"),
+        OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR: join(workDir, "registry"),
+        GATEWAY_AUTH_TOKEN_REF: "survivor-fixture-token",
+        STAGED_UNIT: stagedUnit,
+        LISTENER_SCRIPT: childPath,
+        STARTS_FILE: startsPath,
+        PORT_FILE: portPath,
+      };
+      const source = readFileSync(UPGRADE_SURVIVOR_RUN_SCRIPT, "utf8");
+      const setup =
+        lane === "published"
+          ? source.slice(0, source.indexOf("phase storage-preflight"))
+          : `source ${shellQuote(OPENCLAW_E2E_INSTANCE_HELPER_PATH)}\nsource ${shellQuote(UPGRADE_SURVIVOR_UPDATE_RESTART_AUTH_PATH)}`;
+      const script = `${setup}
+trap - EXIT ERR INT TERM
+seed_update_restart_probe_device_auth() { :; }
+assert_prepublish_fixture_idle() { :; }
+assert_baseline_state() { :; }
+# This fixture chooses an ephemeral port; retain the actual readiness implementation.
+eval "$(declare -f openclaw_e2e_wait_gateway_ready | sed '1s/openclaw_e2e_wait_gateway_ready/fixture_wait_gateway_ready/')"
+openclaw_e2e_wait_gateway_ready() {
+  for _ in {1..200}; do [ -s "$PORT_FILE" ] && break; sleep 0.01; done
+  fixture_wait_gateway_ready "$1" "$2" 20 "$(cat "$PORT_FILE")" "\${5:-strict}"
+}
+${lane === "published" ? "prepare_update_restart_probe" : 'prepare_update_restart_probe_current_install 18789 "$OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG"'}
+`;
+      const systemctlPath = join(
+        lane === "published" ? join(artifacts, "npm-prefix") : workDir,
+        "bin",
+        "systemctl",
+      );
+      const systemctl = (...args: string[]) =>
+        spawnSync(systemctlPath, ["--user", ...args], {
+          env,
+          encoding: "utf8",
+          timeout: 40_000,
+        });
+      const records = (): Array<{ pid: number; managed: boolean }> =>
+        existsSync(startsPath)
+          ? readFileSync(startsPath, "utf8")
+              .split("\n")
+              .slice(0, -1)
+              .filter(Boolean)
+              .map((line) => JSON.parse(line))
+          : [];
+      try {
+        const result = spawnSync("bash", ["-c", script], {
+          env,
+          encoding: "utf8",
+          timeout: 45_000,
+        });
+        expect(result.status, result.stdout + result.stderr).toBe(0);
+        expect(readFileSync(configPath, "utf8")).toBe(authored);
+        const url = `http://127.0.0.1:${readFileSync(portPath, "utf8")}/readyz`;
+        const initial = (await (
+          await fetch(url, { signal: AbortSignal.timeout(1_000) })
+        ).json()) as { pid: number; managed: boolean };
+        expect(initial.managed).toBe(true);
+        expect(systemctl("restart", "openclaw-gateway.service").status).toBe(0);
+        for (let attempt = 0; attempt < 200 && records().length < 2; attempt++) await delay(10);
+        expect(records()).toHaveLength(2);
+        const replacement = (await (
+          await fetch(url, { signal: AbortSignal.timeout(1_000) })
+        ).json()) as { pid: number; managed: boolean };
+        expect(replacement.managed).toBe(true);
+        expect(replacement.pid).not.toBe(initial.pid);
+        expect(isProcessRunning(initial.pid)).toBe(false);
+        expect(systemctl("stop", "openclaw-gateway.service").status).toBe(0);
+        await expect(fetch(url, { signal: AbortSignal.timeout(1_000) })).rejects.toThrow();
+      } finally {
+        systemctl("stop", "openclaw-gateway.service");
+        for (const { pid } of records()) {
+          try {
+            process.kill(pid, "SIGKILL");
+          } catch {}
+        }
+      }
+    },
+    60_000,
+  );
+
+  it("returns the gateway readiness failure when startup is called conditionally", () => {
+    const workDir = tempDirs.make("survivor-start-failure-");
+    writeExecutables(join(workDir, "bin"), { openclaw: "#!/bin/sh\nexit 17\n" });
+    const source = readFileSync(UPGRADE_SURVIVOR_RUN_SCRIPT, "utf8");
+    const start = source.slice(
+      source.indexOf("start_gateway() {"),
+      source.indexOf("\nensure_gateway_started()"),
     );
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        repoShell(workDir)`
+export PATH="$TMPDIR/bin:$PATH"
+source "$ROOT_DIR/${OPENCLAW_E2E_INSTANCE_HELPER_PATH}"
+GATEWAY_LOG="$TMPDIR/gateway.log"
+UPDATE_RESTART_MODE=manual
+${start}
+trap 'kill "$gateway_pid" 2>/dev/null || true; wait "$gateway_pid" 2>/dev/null || true' EXIT
+start_status=0
+start_gateway || start_status=$?
+exit "$start_status"
+`,
+      ],
+      { encoding: "utf8" },
+    );
+    expect(result.status, result.stdout + result.stderr).toBe(1);
   });
 
   it("scopes candidate device identity doctor markers to the doctor process", () => {
@@ -3488,6 +3668,8 @@ if [ "\${1:-}" = doctor ]; then
 fi
 if [ "\${1:-}" = gateway ] && [ "\${2:-}" = install ]; then
   [ "$FAILURE_STAGE" != install ] || exit 44
+  sleep 30 >/dev/null 2>&1 &
+  printf '%s\\n' "$!" >"$OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE"
   exit 0
 fi
 exec sleep 30
@@ -3502,12 +3684,14 @@ export OPENCLAW_STATE_DIR="$TMPDIR/state"
 export OPENCLAW_CONFIG_PATH="$OPENCLAW_STATE_DIR/openclaw.json"
 export OPENCLAW_UPGRADE_SURVIVOR_CONFIG_PARKING_HELPER="$ROOT_DIR/${UPGRADE_SURVIVOR_CONFIG_PARKING_PATH}"
 export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE="$TMPDIR/gateway.pid"
+export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG="$TMPDIR/service.log"
 export OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_JSON="$TMPDIR/install.json"
 export OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_ERR="$TMPDIR/install.err"
 export GATEWAY_AUTH_TOKEN_REF=upgrade-survivor-token
 mkdir -p "$OPENCLAW_STATE_DIR"
 authored_config='{"channels":{"discord":{"dm":{"policy":"allowlist","allowFrom":["123"]}}}}'
 printf '%s\n' "$authored_config" >"$OPENCLAW_CONFIG_PATH"
+source "$ROOT_DIR/${OPENCLAW_E2E_INSTANCE_HELPER_PATH}"
 source "$ROOT_DIR/${UPGRADE_SURVIVOR_UPDATE_RESTART_AUTH_PATH}"
 install_update_restart_systemctl_shim() { :; }
 seed_update_restart_probe_device_auth() { :; }
@@ -5156,6 +5340,7 @@ if (starts === 1) {
   it("bounds upgrade survivor failure log diagnostics", () => {
     const runner = readFileSync(UPGRADE_SURVIVOR_DOCKER_E2E_PATH, "utf8");
     const publishedRunner = readFileSync(UPGRADE_SURVIVOR_RUN_SCRIPT, "utf8");
+    const updateRestartAuth = readFileSync(UPGRADE_SURVIVOR_UPDATE_RESTART_AUTH_PATH, "utf8");
 
     expectTextToIncludeInOrder(runner, [
       "update_status=$?",
@@ -5225,8 +5410,8 @@ if (starts === 1) {
 
     expect(publishedRunner).toContain('openclaw_e2e_print_log "$BASELINE_INSTALL_LOG"');
     expect(publishedRunner).toContain('openclaw_e2e_print_log "$BASELINE_CONFIG_VALIDATE_LOG"');
-    expect(publishedRunner).toContain('openclaw_e2e_print_log "$BASELINE_SERVICE_INSTALL_ERR"');
-    expect(publishedRunner).toContain('openclaw_e2e_print_log "$BASELINE_SERVICE_INSTALL_JSON"');
+    expect(updateRestartAuth).toContain('openclaw_e2e_print_log "$install_err"');
+    expect(updateRestartAuth).toContain('openclaw_e2e_print_log "$install_json"');
     expect(publishedRunner).toContain('openclaw_e2e_print_log "$update_err"');
     expect(publishedRunner).toContain('openclaw_e2e_print_log "$update_json"');
     expect(publishedRunner).toContain('openclaw_e2e_print_log "$DOCTOR_LOG"');
@@ -5236,8 +5421,8 @@ if (starts === 1) {
     expect(publishedRunner).toContain('openclaw_e2e_print_log "$log_file"');
     expect(publishedRunner).not.toContain('cat "$BASELINE_INSTALL_LOG"');
     expect(publishedRunner).not.toContain('cat "$BASELINE_CONFIG_VALIDATE_LOG"');
-    expect(publishedRunner).not.toContain('cat "$BASELINE_SERVICE_INSTALL_ERR"');
-    expect(publishedRunner).not.toContain('cat "$BASELINE_SERVICE_INSTALL_JSON"');
+    expect(updateRestartAuth).not.toContain('cat "$install_err"');
+    expect(updateRestartAuth).not.toContain('cat "$install_json"');
     expect(publishedRunner).not.toContain('cat "$UPDATE_ERR"');
     expect(publishedRunner).not.toContain('cat "$UPDATE_JSON"');
     expect(publishedRunner).not.toContain('cat "$DOCTOR_LOG"');

--- a/test/scripts/openclaw-e2e-instance.test.ts
+++ b/test/scripts/openclaw-e2e-instance.test.ts
@@ -341,23 +341,62 @@ describe("scripts/lib/openclaw-e2e-instance.sh", () => {
     });
   });
 
-  it("allows explicit legacy ready-log mode without /readyz", () => {
+  it.each([
+    ["accepts the March listening marker", "listening on", true, "legacy-ready-log-ok", 0],
+    ["rejects a closed March listener", "listening on", false, "legacy-ready-log-ok", 1],
+    ["accepts a live legacy ready marker", "ready", true, "legacy-ready-log-ok", 0],
+    ["rejects a closed legacy ready listener", "ready", false, "legacy-ready-log-ok", 1],
+    ["rejects the March marker in strict mode", "listening on", true, "strict", 1],
+  ] as const)("%s", (_label, marker, listening, mode, expectedStatus) => {
     withTempDir("openclaw-e2e-readyz-legacy-", (tempDir) => {
       const logPath = path.join(tempDir, "gateway.log");
+      const portPath = path.join(tempDir, "port.txt");
+      const resultPath = path.join(tempDir, "readiness-status.txt");
+      const serverPath = path.join(tempDir, "gateway.cjs");
+      fs.writeFileSync(
+        serverPath,
+        [
+          "const fs = require('node:fs');",
+          "const http = require('node:http');",
+          "const [logPath, portPath, marker, listening, mode] = process.argv.slice(2);",
+          "const server = http.createServer((_request, response) => {",
+          // A working endpoint must not let strict mode accept the historical marker.
+          "  response.writeHead(mode === 'strict' ? 200 : 503);",
+          "  response.end('{}');",
+          "});",
+          "server.listen(0, '127.0.0.1', () => {",
+          "  const port = server.address().port;",
+          "  const publish = () => {",
+          "    fs.writeFileSync(logPath, `[gateway] ${marker} ws://127.0.0.1:${port} (PID ${process.pid})\\n`);",
+          "    fs.writeFileSync(portPath, String(port));",
+          "  };",
+          "  if (listening === 'true') publish(); else server.close(publish);",
+          "});",
+          "setInterval(() => {}, 1000);",
+          "process.on('SIGTERM', () => process.exit(0));",
+          "",
+        ].join("\n"),
+      );
       const result = runBashWithHelper(
         [
-          "openclaw_e2e_probe_http() { return 1; }",
-          "sleep 30 &",
+          `${shellQuote(process.execPath)} ${shellQuote(serverPath)} ${shellQuote(logPath)} ${shellQuote(portPath)} ${shellQuote(marker)} ${listening} ${shellQuote(mode)} &`,
           'gateway_pid="$!"',
-          "trap 'kill \"$gateway_pid\" >/dev/null 2>&1 || true' EXIT",
-          `printf '[gateway] ready\\n' >${shellQuote(logPath)}`,
-          `openclaw_e2e_wait_gateway_ready "$gateway_pid" ${shellQuote(logPath)} 2 23456 legacy-ready-log-ok`,
+          'trap \'kill "$gateway_pid" >/dev/null 2>&1 || true; wait "$gateway_pid" >/dev/null 2>&1 || true\' EXIT',
+          `for _ in $(seq 1 100); do [ -s ${shellQuote(portPath)} ] && break; sleep 0.02; done`,
+          `[ -s ${shellQuote(portPath)} ]`,
+          `port="$(cat ${shellQuote(portPath)})"`,
+          `if openclaw_e2e_wait_gateway_ready "$gateway_pid" ${shellQuote(logPath)} 2 "$port" ${shellQuote(mode)}; then`,
+          `  printf '0' >${shellQuote(resultPath)}`,
+          "else",
+          `  printf '%s' "$?" >${shellQuote(resultPath)}`,
+          "fi",
         ],
         {},
         5_000,
       );
 
       expectShellSuccess(result);
+      expect(fs.readFileSync(resultPath, "utf8")).toBe(String(expectedStatus));
     });
   });
 

--- a/test/scripts/upgrade-survivor-config-recipe.test.ts
+++ b/test/scripts/upgrade-survivor-config-recipe.test.ts
@@ -12,7 +12,6 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { DiscordChannelConfigSchema } from "../../extensions/discord/channel-config-api.js";
 import {
   CONFIG_COMMAND_MAX_BUFFER_BYTES,
   CONFIG_COMMAND_TIMEOUT_MS,
@@ -24,7 +23,6 @@ import {
   runUpgradeSurvivorOpenClawStep,
 } from "../../scripts/e2e/lib/upgrade-survivor/config-recipe.mts";
 import { AgentsSchema } from "../../src/config/zod-schema.agents.js";
-import { validateJsonSchemaValue } from "../../src/plugins/schema-validator.js";
 
 const RECIPE_PATH = "scripts/e2e/lib/upgrade-survivor/config-recipe.mts";
 const RUN_PATH = "scripts/e2e/lib/upgrade-survivor/run.sh";
@@ -200,40 +198,6 @@ describe("upgrade survivor config recipe command resolution", () => {
       expect(agents.entries.ops.fastModeDefault).toBe(true);
     },
   );
-
-  it.each([
-    ["2026.3.13", true],
-    ["2026.7.1-2", true],
-    ["2026.7.2-beta.3", true],
-    ["2026.7.2-beta.4", false],
-    ["2026.8.1-beta.1", false],
-    ["2026.8.1-beta.2", false],
-    ["2026.8.1", false],
-    [null, false],
-  ] as const)("preserves supported Discord DM input for baseline %s", (version, legacy) => {
-    const step = resolveUpgradeSurvivorConfigStepsForBaseline("base", version).find(
-      (entry) => entry.id === "channels-discord",
-    );
-    const discord = JSON.parse(step?.argv[3] ?? "{}");
-    if (legacy) {
-      expect(discord.dm).toEqual({ policy: "allowlist", allowFrom: ["111111111111111111"] });
-      expect(discord.dmPolicy).toBeUndefined();
-      expect(discord.allowFrom).toBeUndefined();
-    } else {
-      expect(discord.dm).toBeUndefined();
-      expect(discord.dmPolicy).toBe("allowlist");
-      expect(discord.allowFrom).toEqual(["111111111111111111"]);
-    }
-    // The public schema is the config-set boundary; runtime Zod preprocessing
-    // would silently normalize the legacy specimen and miss a bad baseline cutoff.
-    expect(
-      validateJsonSchemaValue({
-        schema: DiscordChannelConfigSchema.schema,
-        cacheKey: "upgrade-survivor-discord-config",
-        value: discord,
-      }).ok,
-    ).toBe(!legacy);
-  });
 
   it.each(["2026.3.13", "2026.4.1", "2026.8.1-beta.1"])(
     "preserves the legacy agent contract for baseline %s",

--- a/test/scripts/upgrade-survivor-config-recipe.test.ts
+++ b/test/scripts/upgrade-survivor-config-recipe.test.ts
@@ -12,6 +12,7 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
+import { DiscordChannelConfigSchema } from "../../extensions/discord/channel-config-api.js";
 import {
   CONFIG_COMMAND_MAX_BUFFER_BYTES,
   CONFIG_COMMAND_TIMEOUT_MS,
@@ -22,6 +23,8 @@ import {
   resolveUpgradeSurvivorOpenClawCommand,
   runUpgradeSurvivorOpenClawStep,
 } from "../../scripts/e2e/lib/upgrade-survivor/config-recipe.mts";
+import { AgentsSchema } from "../../src/config/zod-schema.agents.js";
+import { validateJsonSchemaValue } from "../../src/plugins/schema-validator.js";
 
 const RECIPE_PATH = "scripts/e2e/lib/upgrade-survivor/config-recipe.mts";
 const RUN_PATH = "scripts/e2e/lib/upgrade-survivor/run.sh";
@@ -182,6 +185,72 @@ describe("upgrade survivor config recipe command resolution", () => {
     expect(steps.find((step) => step.id === "channels-feishu")).toBeUndefined();
     expect(steps.at(-1)?.id).toBe("validate");
   });
+
+  it.each([null, "2026.8.1-beta.2", "2026.8.1"])(
+    "authors a schema-valid explicit agent roster for baseline %s",
+    (version) => {
+      const step = resolveUpgradeSurvivorConfigStepsForBaseline("base", version).find(
+        (step) => step.id === "agents",
+      );
+      const agents = JSON.parse(step?.argv[3] ?? "{}");
+      expect(AgentsSchema.safeParse(agents).success).toBe(true);
+      expect(agents.ownership).toBe("explicit");
+      expect(agents.defaults.heartbeat.every).toBe("0m");
+      expect(Object.keys(agents.entries)).toEqual(["main", "ops"]);
+      expect(agents.entries.ops.fastModeDefault).toBe(true);
+    },
+  );
+
+  it.each([
+    ["2026.3.13", true],
+    ["2026.7.1-2", true],
+    ["2026.7.2-beta.3", true],
+    ["2026.7.2-beta.4", false],
+    ["2026.8.1-beta.1", false],
+    ["2026.8.1-beta.2", false],
+    ["2026.8.1", false],
+    [null, false],
+  ] as const)("preserves supported Discord DM input for baseline %s", (version, legacy) => {
+    const step = resolveUpgradeSurvivorConfigStepsForBaseline("base", version).find(
+      (entry) => entry.id === "channels-discord",
+    );
+    const discord = JSON.parse(step?.argv[3] ?? "{}");
+    if (legacy) {
+      expect(discord.dm).toEqual({ policy: "allowlist", allowFrom: ["111111111111111111"] });
+      expect(discord.dmPolicy).toBeUndefined();
+      expect(discord.allowFrom).toBeUndefined();
+    } else {
+      expect(discord.dm).toBeUndefined();
+      expect(discord.dmPolicy).toBe("allowlist");
+      expect(discord.allowFrom).toEqual(["111111111111111111"]);
+    }
+    // The public schema is the config-set boundary; runtime Zod preprocessing
+    // would silently normalize the legacy specimen and miss a bad baseline cutoff.
+    expect(
+      validateJsonSchemaValue({
+        schema: DiscordChannelConfigSchema.schema,
+        cacheKey: "upgrade-survivor-discord-config",
+        value: discord,
+      }).ok,
+    ).toBe(!legacy);
+  });
+
+  it.each(["2026.3.13", "2026.4.1", "2026.8.1-beta.1"])(
+    "preserves the legacy agent contract for baseline %s",
+    (version) => {
+      const step = resolveUpgradeSurvivorConfigStepsForBaseline("base", version).find(
+        (step) => step.id === "agents",
+      );
+      const agents = JSON.parse(step?.argv[3] ?? "{}");
+      expect(agents.ownership).toBeUndefined();
+      expect(agents.entries).toBeUndefined();
+      expect(agents.list.map((agent: { id: string }) => agent.id)).toEqual(["main", "ops"]);
+      expect(agents.list.filter((agent: { default?: boolean }) => agent.default)).toEqual([
+        expect.objectContaining({ id: "main" }),
+      ]);
+      expect(agents.list[1].fastModeDefault).toBe(version === "2026.3.13" ? undefined : true);
+    },
+  );
 
   it("bounds baseline config commands and reports spawn errors", () => {
     const calls: unknown[] = [];


### PR DESCRIPTION
## What Problem This Solves

Stable-install upgrade tests could reject historical configurations before reaching the updater, miss a running March gateway, or leave the old gateway alive during authenticated restart.

## Why This Change Was Made

The survivor recipe authors canonical current inputs and adapts them to each published baseline. Agent ownership uses the exact `2026.8.1-beta.2` boundary; Discord retains the nested DM migration specimen before `2026.7.2-beta.4`. This keeps old upgrade coverage while allowing current and intervening beta installations to accept the recipe.

Legacy readiness recognizes the published listening marker and verifies a real TCP listener. Current readiness still requires its ready marker and endpoint. Both restart probes now use one shared installer and the service manager that owns their later restart and stop. The old setup adopted an unmanaged foreground CLI PID, bypassing descendant cleanup. Manual startup also propagates readiness failures when called conditionally. Startup budgets and supervisor drain policy are unchanged.

CI exposed a root test importing Discord's schema. The complete eight-case table now lives in Discord's existing schema suite and uses the public SDK validator. Colocated declaration companions describe the recipe's existing JavaScript dependencies for the stricter plugin test project; no typecheck settings or runtime exports change.

## User Impact

No product runtime change. Release validation reaches the real updater on older installations and reports service restart behavior reliably. Related #120703 addresses convergence retries; this change fixes fixture production and service ownership without copying its sidecar implementation.

## Evidence

On [isolated Crabbox/Testbox](https://github.com/openclaw/openclaw/actions/runs/33368034442), clean committed candidate `99170bd330a2f80dbc051f58e001b35ba75d3340` passed July volume migration, May configured-plugin repair and authenticated restart, current-install authenticated restart, and March explicit repair followed by authenticated restart. March's published updater invokes advisory Doctor without `--fix`; the documented explicit candidate repair was exercised separately. Its repaired service restart replaced the old supervisor and passed health, readiness, and status checks.

The July scenario preserved 9,600 sessions, 152,896 events, 4,400 cron jobs, and 512 plugin KV rows through automatic migration, history readback, and restart. Idempotent Doctor took 9 seconds. The earlier campaign also passed April obsolete dependency cleanup and July cron-authority migration. Final May and March reruns with historical Discord input passed in 260.957 and 227.815 seconds; their update-owned restart phases took 59 and 90 seconds.

All three managed-service regressions, both readiness regressions, and three historical Discord specimen regressions fail before their repairs and pass afterward. The full original harness proof totals 376 passing checks. After relocating the schema table, all 88 focused architecture/recipe/Discord cases pass. The final four-file correction passed its [full changed-file gate](https://github.com/openclaw/openclaw/actions/runs/33377348320) in 407.241 seconds, including plugin/script/root types, typed lint, formatting, Knip, and boundary guards. All proof leases are stopped.

The six executable tooling/recipe files on final head `7da9fba920626a198b2f64897c4b04792e3af3ab` remain byte-identical to the completed live proof. Main's per-agent volume seeding and baseline SDK-store discovery improvements are retained. Executable tooling: +132/-103 (net +29); the shared service setup itself removes one net line. Declaration companions add 30 type-only lines. Tests: +317/-22 (net +295), discounting the pure eight-case move. No product option, dependency, schema, or timeout is added. Fresh full-candidate autoreview is clear at its configured P0 threshold. ClawSweeper's consolidation concern is addressed by the single setup helper and the two distinct shipped version boundaries; exact-head CI remains required before native landing.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33381502187) completed successfully at `7da9fba920626a198b2f64897c4b04792e3af3ab`, including build artifacts, all selected test shards, and the required gate. This satisfies the remaining CI condition in ClawSweeper's latest review. The earlier Anthropic context-window timeout passed in 3 ms. Main also contains canonical #133970 and independent fixture changes from #133913, so this is combined-source validation, not a claim that this harness PR repairs provider error handling.
