### PR TITLE
perf(heartbeat): reduce queue and diagnostic snapshot scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Heartbeat and diagnostics:** reduce repeated wake-queue and broadcast-outcome scans, and copy diagnostic snapshot rings in one pass while preserving scheduling barriers, retry precedence, and publication order.
 - **Subagent completion:** recognize visible final answers delivered to internal and nested parent sessions, preventing false delivery failures while preserving external channel delivery checks.
 - Codex/Linux: wait for a live app-server process to expose its startup command line within the existing inspection deadline, preserving process identity checks and preventing intermittent startup failures.
 - **Cloud session lifecycle:** prevent archive, delete, and restart recovery from deadlocking behind an earlier worker move, keep work admission closed through cleanup, and preserve the same successor for concurrent recovery requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Heartbeat and diagnostics:** reduce repeated wake-queue and broadcast-outcome scans, and copy diagnostic snapshot rings in one pass while preserving scheduling barriers, retry precedence, and publication order.
 - **Subagent completion:** recognize visible final answers delivered to internal and nested parent sessions, preventing false delivery failures while preserving external channel delivery checks.
 - Codex/Linux: wait for a live app-server process to expose its startup command line within the existing inspection deadline, preserving process identity checks and preventing intermittent startup failures.
 - **Cloud session lifecycle:** prevent archive, delete, and restart recovery from deadlocking behind an earlier worker move, keep work admission closed through cleanup, and preserve the same successor for concurrent recovery requests.

--- a/src/infra/heartbeat-runner-scheduler.ts
+++ b/src/infra/heartbeat-runner-scheduler.ts
@@ -358,29 +358,35 @@ export function startHeartbeatRunner(opts: {
     const agentOutcomes = await Promise.all(
       Array.from(state.agents.values(), (agent) => runOneAgent(agent.agentId, agent)),
     );
-    const firstRetryableSkip = agentOutcomes.find(
-      (outcome) => outcome.retryableSkip,
-    )?.retryableSkip;
-    if (firstRetryableSkip) {
-      // At least one agent's runtime was busy. The wake layer schedules a
-      // retry; on retry, agents that already advanced their schedule will
-      // defer via cooldown, so only the still-busy agent actually re-runs.
-      return firstRetryableSkip;
+    let ran = false;
+    let firstResult: HeartbeatRunResult | undefined;
+    let firstGuardSkip: Extract<HeartbeatRunResult, { status: "skipped" }> | undefined;
+    for (const outcome of agentOutcomes) {
+      if (outcome.retryableSkip) {
+        // Busy agents own the retry. Successful siblings already advanced their
+        // cooldown, so the retry does not replay their completed work.
+        return outcome.retryableSkip;
+      }
+      ran ||= outcome.ran;
+      firstResult ??= outcome.result;
+      const result = outcome.result;
+      if (
+        !ran &&
+        result?.status === "skipped" &&
+        result.retryAtMs !== undefined &&
+        (!firstGuardSkip || result.retryAtMs < (firstGuardSkip.retryAtMs ?? Infinity))
+      ) {
+        // Keep the original result identity and first agent on equal deadlines;
+        // wake-layer retention consumes the exact guard reason and retry time.
+        firstGuardSkip = result;
+      }
     }
-
-    if (agentOutcomes.some((outcome) => outcome.ran)) {
+    if (ran) {
       return { status: "ran", durationMs: Date.now() - startedAt };
     }
-    // Preserve per-agent guard results: wake-layer retry/retention keys off
-    // their reason, and the earliest guard deadline owns the next attempt.
-    const firstGuardSkip = agentOutcomes
-      .map((outcome) => outcome.result)
-      .filter((result) => result?.status === "skipped")
-      .filter((result) => result.retryAtMs !== undefined)
-      .toSorted((left, right) => (left.retryAtMs ?? Infinity) - (right.retryAtMs ?? Infinity))[0];
     return (
       firstGuardSkip ??
-      agentOutcomes.find((outcome) => outcome.result)?.result ?? {
+      firstResult ?? {
         status: "skipped",
         reason: isInterval ? "not-due" : "disabled",
       }

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -214,6 +214,17 @@ function mergePendingWakeReasons(
   return merged;
 }
 
+function* pendingTargetsBeforeGlobal(globalWakeGroup: PendingWakeGroup) {
+  // Selection only updates/deletes the current target, with no callbacks or
+  // awaits. Keep target insertion order without materializing the whole queue.
+  for (const entry of pendingWakes) {
+    if (entry[0] !== GLOBAL_HEARTBEAT_WAKE_TARGET_KEY) {
+      yield entry;
+    }
+  }
+  yield [GLOBAL_HEARTBEAT_WAKE_TARGET_KEY, globalWakeGroup] as const;
+}
+
 function takePendingWakeBatch(maxGroups: number, now = performance.now()): ReadyWakeGroup[] {
   if (maxGroups <= 0) {
     return [];
@@ -246,10 +257,9 @@ function takePendingWakeBatch(maxGroups: number, now = performance.now()): Ready
   const readyGroups: Array<{ targetKey: string; group: PendingWakeGroup }> = [];
   const pendingEntries = globalBarrierReady
     ? flushPendingCoalescing
-      ? [...pendingWakes.entries()].toSorted(
-          ([leftTarget], [rightTarget]) =>
-            Number(leftTarget === GLOBAL_HEARTBEAT_WAKE_TARGET_KEY) -
-            Number(rightTarget === GLOBAL_HEARTBEAT_WAKE_TARGET_KEY),
+      ? pendingTargetsBeforeGlobal(
+          // SAFETY: Readiness rejects an absent global group.
+          globalWakeGroup as PendingWakeGroup,
         )
       : [[GLOBAL_HEARTBEAT_WAKE_TARGET_KEY, globalWakeGroup as PendingWakeGroup] as const]
     : pendingWakes.entries();
@@ -624,7 +634,6 @@ function schedulePendingWakes(readyDelayMs: number) {
       ? pendingGlobalImmediateWake.immediateBarrierSequence
       : undefined;
   let earliestNotBeforeMs = Number.POSITIVE_INFINITY;
-  let hasReadyWake = false;
   for (const [targetKey, group] of pendingWakes) {
     if (activeWakeTargets.has(targetKey)) {
       continue;
@@ -660,15 +669,13 @@ function schedulePendingWakes(readyDelayMs: number) {
       }
       const nextReadyAtMs = Math.max(pending.readyAtMs ?? 0, pending.notBeforeMs ?? 0);
       if (nextReadyAtMs <= now) {
-        hasReadyWake = true;
-      } else {
-        earliestNotBeforeMs = Math.min(earliestNotBeforeMs, nextReadyAtMs);
+        schedule(readyDelayMs);
+        return;
       }
+      earliestNotBeforeMs = Math.min(earliestNotBeforeMs, nextReadyAtMs);
     }
   }
-  if (hasReadyWake) {
-    schedule(readyDelayMs);
-  } else if (Number.isFinite(earliestNotBeforeMs)) {
+  if (Number.isFinite(earliestNotBeforeMs)) {
     schedule(earliestNotBeforeMs - now);
   }
 }

--- a/src/logging/diagnostic-stability.ts
+++ b/src/logging/diagnostic-stability.ts
@@ -683,18 +683,16 @@ export function recordDiagnosticExporterHealth(
 
 function listRecords(): DiagnosticStabilityEventRecord[] {
   const state = getDiagnosticStabilityState();
-  if (state.count === 0) {
-    return [];
+  const records: DiagnosticStabilityEventRecord[] = [];
+  const start = state.count < state.capacity ? 0 : state.nextIndex;
+  // Capture the ordered view before query normalization or summary getters can re-enter.
+  for (let offset = 0; offset < state.count; offset += 1) {
+    const record = state.records[(start + offset) % state.capacity];
+    if (record !== undefined) {
+      records.push(record);
+    }
   }
-  if (state.count < state.capacity) {
-    return state.records
-      .slice(0, state.count)
-      .filter((record): record is DiagnosticStabilityEventRecord => record !== undefined);
-  }
-  return [
-    ...state.records.slice(state.nextIndex),
-    ...state.records.slice(0, state.nextIndex),
-  ].filter((record): record is DiagnosticStabilityEventRecord => record !== undefined);
+  return records;
 }
 
 function listExporterRecords(): DiagnosticStabilityEventRecord[] {


### PR DESCRIPTION
## What Problem This Solves

Heartbeat dispatch repeatedly copies and scans queues whose ordering and readiness are already known. Broadcast completion also walks the same result array several times. Stability snapshots take separate partial/full ring paths and allocate intermediate arrays before applying their existing query and summary logic.

## Why This Change Was Made

Keep those decisions at their current owners. The wake selector iterates targeted work in insertion order before the global barrier, and readiness scanning stops once the scheduling decision is known. The scheduler folds completed outcomes once, preserving first busy precedence, successful siblings, earliest guard deadlines and first-on-tie result identity. The diagnostic recorder makes one publication-ordered copy before query normalization or getters can re-enter.

This removes queue materialization/sorting, repeated outcome maps/filters/sorting, and the partial/full ring copy branches. There is no new cache, configuration, timer policy, API, persistence or concurrency limit. Production +51/-40, net+11, with no test growth or changelog edit. The growth is explicit iterator/reduction state plus the required readiness-cast invariant; the snapshot change removes two lines. No readiness-helper type contract or assertion-baseline change is retained.

## Measurement and Tradeoffs

These are bounded whole-owner measurements, not provider or end-to-end turn latency. Heartbeat measurements retain all 59 workloads, eight fresh processes, 5,192 samples and both variant orders. Nine-target queues improve by roughly 3–15%; 64-target queue results generally improve more, with the global-last reverse control slightly slower. A one-target no-global wake costs another 0.37/0.51 microseconds. Quiet and guarded broadcasts with 1–16 agents improve; ordinary successful one/four-agent controls include small regressions, which remain in the results.

The recorder comparison retains all 68 workloads and 4,896 samples across four ablations. The selected ordered copy makes the complete 1,000-record/default-limit owner 1.186/1.176 times faster (about 4.8/4.6 microseconds saved), and CLI-limit reads 1.162/1.160 times faster. Snapshot-plus-JSON and several small/control cases are slower. The separate complete-page optimization was rejected; no combined or overall speedup is claimed.

## Preservation Evidence

Historical complete-owner proofs compare 7,788 heartbeat outcomes and 924 recorder cases, including queue barriers, busy/retry/cooldown precedence, real transcript-write context, wrap/reset, publication order, shallow aliases, getter re-entry and exporter lifecycle. The current baseline passes all 158 tests in ten canonical suites. The refreshed candidate passes 192 tests in 11 suites and a fresh full build (168.08 seconds). Full changed-file checks passed in 236.26 seconds before the source-identical rebase; independent full-owner and scoped managed reviews found no actionable source defects.

Real built-Gateway proof completed four OpenAI heartbeat turns with exact nonce payloads and run/session terminal outcomes, operator.read scope rejection, one-shot task-plugin behavior and target-before-broadcast ordering. The candidate's six strict main-thread V8 coverage counts are 3/1/1/2/4/4, including the non-global generator yield and new scheduler reduction. Two diagnostic snapshot calls execute the ordered-copy loop 153 times for 40 and 113 records, with no drops and publication order preserved. The original comparator confirms the same projected outcomes as the baseline. All observed processes/groups are absent, the port is closed and private task state is removed.

The live scenarios are explicitly distinguished: the first candidate used default coalescing and passed all four turn outcomes, but its harness failed because the target became ready just before the global wake and never reached the non-global generator yield. That failed receipt remains. The successful separate scenario adds only public SDK `coalesceMs: 0` to the unscoped immediate wake to exercise the global flush of the pending default-coalesced target. It is not an identical-input timing comparison. Provider HTTP retries, native Codex, channel delivery, full-ring/alias/reentry behavior and global latency are not claimed by the live smoke; broader owner cases remain covered separately.

The latest ClawSweeper runtime review found no correctness defect. Its release-owned changelog finding and Rank-up move are addressed by removing this normal PR's changelog entry; release context stays here. The first full hosted CI run also timed out in the unchanged `error-text.test.ts` transport-fragment case; its original log is retained and the provider-discovery path is being investigated separately. No timeout, retry, or test assertion has been relaxed.

Exact-head CI for `59d65e9e51660d46a4ca2895ed4378e0ed31c357` is green ([run 33379221126](https://github.com/openclaw/openclaw/actions/runs/33379221126)). The latest review’s remaining Rank-up move, completing CI, is satisfied; native preparation also passed without changing the reviewed head. The prior formatter timeout remains an unconfirmed follow-up, not a claimed repair.
