### PR TITLE
refactor(agents): avoid unnecessary failure classification

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1864,7 +1864,7 @@ src/agents/embedded-agent-utils.ts	3
 src/agents/exec-auto-reviewer.ts	1
 src/agents/exec-defaults.ts	2
 src/agents/execution-auth-binding.ts	1
-src/agents/failover-error.ts	15
+src/agents/failover-error.ts	12
 src/agents/failover/retry-evidence.ts	1
 src/agents/failover/signal-details.ts	1
 src/agents/fallback-skip-cache.ts	1

--- a/qa/scenarios/channels/provider-http-503-visible-failure.yaml
+++ b/qa/scenarios/channels/provider-http-503-visible-failure.yaml
@@ -84,8 +84,8 @@ flow:
               timeoutMs:
                 expr: liveTurnTimeoutMs(env, 180000)
         - assert:
-            expr: "!outbound.deleted && outbound.conversation.id === config.conversationId && outbound.conversation.kind === 'channel' && outbound.isError === true && outbound.text === config.expectedReply"
-            message: expected one classified provider failure on the original conversation
+            expr: "!outbound.deleted && outbound.accountId === env.transport.accountId && outbound.conversation.id === config.conversationId && outbound.conversation.kind === 'channel' && outbound.isError === true && outbound.text === config.expectedReply"
+            message: expected one classified provider failure on the original account and conversation
         - call: sleep
           args:
             - expr: liveTurnTimeoutMs(env, 8000)

--- a/src/agents/command/lifecycle.ts
+++ b/src/agents/command/lifecycle.ts
@@ -5,7 +5,7 @@ import { normalizeAgentRunTerminalDeliverySnapshot } from "../agent-run-terminal
 import type { AgentRunTerminalOutcome } from "../agent-run-terminal-outcome.js";
 import { normalizeAgentRunTerminalReceipt } from "../agent-run-terminal-receipt.js";
 import type { EmbeddedAgentRunEntryTerminal } from "../embedded-agent-runner/run-entry.js";
-import { describeFailoverError } from "../failover-error.js";
+import { getFailoverErrorCode } from "../failover/error.js";
 import { renderFailoverCodeUserCopy } from "../failover/user-copy.js";
 import {
   AGENT_RUN_SUPERSEDED_STOP_REASON,
@@ -18,7 +18,7 @@ import type { AgentAttemptResult } from "./runtime-loaders.js";
 const log = createSubsystemLogger("agents/agent-command");
 
 const formatLifecycleError = (error: unknown): string =>
-  renderFailoverCodeUserCopy(describeFailoverError(error).code) ?? formatErrorMessage(error);
+  renderFailoverCodeUserCopy(getFailoverErrorCode(error)) ?? formatErrorMessage(error);
 
 function resolveTerminalLogLevel(
   outcome: AgentRunTerminalOutcome,

--- a/src/agents/embedded-agent-runner/run/auth-controller.ts
+++ b/src/agents/embedded-agent-runner/run/auth-controller.ts
@@ -20,12 +20,9 @@ import {
   isFailoverErrorMessage,
   type FailoverReason,
 } from "../../embedded-agent-helpers.js";
-import {
-  describeFailoverError,
-  FailoverError,
-  resolveFailoverStatus,
-} from "../../failover-error.js";
+import { FailoverError, resolveFailoverStatus } from "../../failover-error.js";
 import { shouldUseTransientCooldownProbeSlot } from "../../failover-policy.js";
+import { getFailoverErrorCode } from "../../failover/error.js";
 import { renderAuthProfileFailoverCopy } from "../../failover/user-copy.js";
 import {
   getApiKeyForModelCore,
@@ -502,7 +499,7 @@ export function createEmbeddedRunAuthController(params: {
         model: modelId,
         authMode,
         status: resolveFailoverStatus(reason),
-        code: failoverParams.error ? describeFailoverError(failoverParams.error).code : undefined,
+        code: failoverParams.error ? getFailoverErrorCode(failoverParams.error) : undefined,
         authProfileFailure: { allInCooldown: failoverParams.allInCooldown },
         cause: failoverParams.error,
       });

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -20,6 +20,7 @@ import {
   getErrorMessage,
   isFailoverError,
   isTimeoutError,
+  readDirectErrorCode,
   readDirectErrorMessage,
   type CliTimeoutContext,
 } from "./failover/error.js";
@@ -172,32 +173,6 @@ function readDirectStatusCode(err: unknown): number | undefined {
 
 function getStatusCode(err: unknown): number | undefined {
   return findErrorProperty(err, readDirectStatusCode);
-}
-
-function readDirectErrorCode(err: unknown): string | undefined {
-  if (!err || typeof err !== "object") {
-    return undefined;
-  }
-  const directCode = (err as { code?: unknown }).code;
-  if (typeof directCode === "string") {
-    const trimmed = directCode.trim();
-    return trimmed ? trimmed : undefined;
-  }
-  const detailCode = (err as { detail?: { code?: unknown } }).detail?.code;
-  if (typeof detailCode === "string") {
-    const trimmed = detailCode.trim();
-    return trimmed ? trimmed : undefined;
-  }
-  const status = (err as { status?: unknown }).status;
-  if (typeof status !== "string" || /^\d+$/.test(status)) {
-    return undefined;
-  }
-  const trimmed = status.trim();
-  return trimmed ? trimmed : undefined;
-}
-
-function getErrorCode(err: unknown): string | undefined {
-  return findErrorProperty(err, readDirectErrorCode);
 }
 
 function isStableProviderErrorType(value: string): boolean {
@@ -397,7 +372,7 @@ function normalizeErrorSignal(err: unknown, providerHint?: string): FailoverSign
   const message = getErrorMessage(err);
   return {
     status: getStatusCode(err),
-    code: getErrorCode(err),
+    code: findErrorProperty(err, readDirectErrorCode),
     errorType: getErrorType(err),
     message: message || undefined,
     provider: getProvider(err) ?? providerHint,

--- a/src/agents/failover/error.ts
+++ b/src/agents/failover/error.ts
@@ -126,6 +126,36 @@ export function findErrorProperty<T>(
   );
 }
 
+export function readDirectErrorCode(err: unknown): string | undefined {
+  if (!err || typeof err !== "object") {
+    return undefined;
+  }
+  // SAFETY: The object guard permits probing code; its value remains unknown.
+  const directCode = (err as { code?: unknown }).code;
+  if (typeof directCode === "string") {
+    const trimmed = directCode.trim();
+    return trimmed ? trimmed : undefined;
+  }
+  // SAFETY: Optional chaining handles absent details; only string codes are accepted.
+  const detailCode = (err as { detail?: { code?: unknown } }).detail?.code;
+  if (typeof detailCode === "string") {
+    const trimmed = detailCode.trim();
+    return trimmed ? trimmed : undefined;
+  }
+  // SAFETY: The object guard permits probing status; its type is checked below.
+  const status = (err as { status?: unknown }).status;
+  if (typeof status !== "string" || /^\d+$/.test(status)) {
+    return undefined;
+  }
+  const trimmed = status.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function getFailoverErrorCode(err: unknown): string | undefined {
+  // A typed failure owns its code, including absence; only raw errors search causes.
+  return isFailoverError(err) ? err.code : findErrorProperty(err, readDirectErrorCode);
+}
+
 export function readDirectErrorMessage(err: unknown): string | undefined {
   if (err instanceof Error) {
     return err.message || undefined;

--- a/src/agents/session-model-auto-revert.ts
+++ b/src/agents/session-model-auto-revert.ts
@@ -166,6 +166,10 @@ export function createAgentPatchedSessionModelRunGuard(params: {
   let failure: { error?: unknown; reason?: FailoverReason } = {};
   let reconciled = false;
   const captureFailure = (error: unknown, reason?: string) => {
+    // Only the patch captured when this guard was created can be reconciled.
+    if (markerTs === undefined) {
+      return false;
+    }
     const classifiedReason = reason
       ? (reason as FailoverReason)
       : resolveFailoverReasonFromError(error);

--- a/src/agents/tools/sessions-tool.test.ts
+++ b/src/agents/tools/sessions-tool.test.ts
@@ -16,6 +16,7 @@ import { GatewayClientRequestError } from "../../gateway/client.js";
 import { isAgentSessionModelPatchOrigin } from "../../gateway/session-model-patch-origin.js";
 import { beginSessionWorkAdmission } from "../../sessions/session-lifecycle-admission.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
+import * as failoverErrors from "../failover-error.js";
 import { createAgentPatchedSessionModelRunGuard } from "../session-model-auto-revert.js";
 import { withGatewayToolCallerIdentity } from "./gateway-caller-context.js";
 import type { AgentToolGatewayRequestCaller } from "./in-process-gateway.js";
@@ -606,28 +607,26 @@ describe("sessions tool", () => {
         session: { store: storePath },
         agents: { defaults: { model: { primary: "openai/good" } } },
       };
-      await upsertSessionEntryCore(
-        { agentId: "main", sessionKey, storePath },
-        {
-          sessionId: "session-main",
-          updatedAt: 1,
-          model: "good",
-          modelProvider: "openai",
-          modelOverride: "good",
-          providerOverride: "openai",
-          modelOverrideSource: "auto",
-          modelOverrideFallbackOriginProvider: "openai",
-          modelOverrideFallbackOriginModel: "primary",
-          authProfileOverride: "good-profile",
-          authProfileOverrideSource: "user",
-          thinkingLevel: "high",
-        },
-      );
+      const sessionScope = { agentId: "main", sessionKey, storePath };
+      await upsertSessionEntryCore(sessionScope, {
+        sessionId: "session-main",
+        updatedAt: 1,
+        model: "good",
+        modelProvider: "openai",
+        modelOverride: "good",
+        providerOverride: "openai",
+        modelOverrideSource: "auto",
+        modelOverrideFallbackOriginProvider: "openai",
+        modelOverrideFallbackOriginModel: "primary",
+        authProfileOverride: "good-profile",
+        authProfileOverrideSource: "user",
+        thinkingLevel: "high",
+      });
       const callGateway = vi.fn(
         async (request: { method: string; params: Record<string, unknown> }) => {
           expect(request.method).toBe("sessions.patch");
           expect(isAgentSessionModelPatchOrigin()).toBe(true);
-          await patchSessionEntryCore({ agentId: "main", sessionKey, storePath }, () => ({
+          await patchSessionEntryCore(sessionScope, () => ({
             label: request.params.label as string,
             model: "bad",
             modelProvider: "broken",
@@ -662,12 +661,9 @@ describe("sessions tool", () => {
         config: cfg,
         callGateway: callGateway as never,
       });
-      const currentRunGuard = createAgentPatchedSessionModelRunGuard({
-        cfg,
-        agentId: "main",
-        sessionKey,
-        storePath,
-      });
+      const guardParams = { cfg, ...sessionScope };
+      const currentRunGuard = createAgentPatchedSessionModelRunGuard(guardParams);
+      const failedCurrentRunGuard = createAgentPatchedSessionModelRunGuard(guardParams);
 
       await tool.execute("patch-model", {
         action: "patch",
@@ -683,7 +679,7 @@ describe("sessions tool", () => {
           model: "broken/bad",
         },
       });
-      expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).toMatchObject({
+      expect(loadSessionEntry(sessionScope)).toMatchObject({
         label: "Research",
         modelFallback: {
           prevModel: "good",
@@ -697,18 +693,36 @@ describe("sessions tool", () => {
         },
       });
       await currentRunGuard.finish(true);
-      expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).toHaveProperty(
-        "modelFallback",
-      );
+      expect(loadSessionEntry(sessionScope)).toHaveProperty("modelFallback");
 
-      const runGuard = createAgentPatchedSessionModelRunGuard({
-        cfg,
-        agentId: "main",
-        sessionKey,
-        storePath,
-      });
-      await runGuard.fail({ status: 404, message: "No endpoints found for broken/bad." });
-      expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).toMatchObject({
+      const failure = { status: 404, message: "No endpoints found for broken/bad." };
+      const entryBeforeFailure = loadSessionEntry(sessionScope);
+      const transcriptScope = { ...sessionScope, sessionId: "session-main" };
+      const transcriptBeforeFailure = await loadTranscriptEvents(transcriptScope);
+      const classifyFailure = vi
+        .spyOn(failoverErrors, "resolveFailoverReasonFromError")
+        .mockImplementation(() => {
+          throw new Error("An unarmed model-patch guard must not classify failures");
+        });
+      try {
+        expect(failedCurrentRunGuard.captureFallbackFailure([])).toBeUndefined();
+        expect(failedCurrentRunGuard.captureFailure(failure)).toBe(false);
+        expect(
+          failedCurrentRunGuard.captureFallbackFailure([
+            { error: failure.message, reason: "model_not_found" },
+          ]),
+        ).toBe(false);
+        await failedCurrentRunGuard.fail(failure);
+        expect(classifyFailure).not.toHaveBeenCalled();
+      } finally {
+        classifyFailure.mockRestore();
+      }
+      expect(loadSessionEntry(sessionScope)).toEqual(entryBeforeFailure);
+      expect(await loadTranscriptEvents(transcriptScope)).toEqual(transcriptBeforeFailure);
+
+      const runGuard = createAgentPatchedSessionModelRunGuard(guardParams);
+      await runGuard.fail(failure);
+      expect(loadSessionEntry(sessionScope)).toMatchObject({
         model: "good",
         modelProvider: "openai",
         modelOverrideSource: "auto",
@@ -717,15 +731,8 @@ describe("sessions tool", () => {
         authProfileOverride: "good-profile",
         thinkingLevel: "high",
       });
-      expect(loadSessionEntry({ agentId: "main", sessionKey, storePath })).not.toHaveProperty(
-        "modelFallback",
-      );
-      const events = await loadTranscriptEvents({
-        agentId: "main",
-        sessionId: "session-main",
-        sessionKey,
-        storePath,
-      });
+      expect(loadSessionEntry(sessionScope)).not.toHaveProperty("modelFallback");
+      const events = await loadTranscriptEvents(transcriptScope);
       expect(events).toContainEqual(
         expect.objectContaining({
           message: expect.objectContaining({

--- a/src/auto-reply/reply/agent-lifecycle-terminal.test.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { FailoverError } from "../../agents/failover-error.js";
 import { renderFailoverCodeUserCopy } from "../../agents/failover/user-copy.js";
+import * as providerFailover from "../../plugins/provider-failover.js";
 import { createAgentLifecycleTerminalBackstop } from "./agent-lifecycle-terminal.js";
 
 const { emitAgentEvent } = vi.hoisted(() => ({ emitAgentEvent: vi.fn() }));
@@ -8,29 +9,48 @@ const { emitAgentEvent } = vi.hoisted(() => ({ emitAgentEvent: vi.fn() }));
 vi.mock("../../infra/agent-events.js", () => ({ emitAgentEvent }));
 
 describe("createAgentLifecycleTerminalBackstop", () => {
-  it("publishes bounded selected-profile recovery from typed failures", () => {
-    const profileId = "openai:private-profile";
-    const rawCause = `Codex app-server auth profile "${profileId}" was not found`;
-    const terminal = createAgentLifecycleTerminalBackstop({
-      runId: "missing-selected-profile",
-      sessionKey: "agent:main:test",
-      getLifecycleGeneration: () => "test-generation",
-      resolveTerminationFields: () => ({}),
-    });
+  it.each(["typed", "raw"] as const)(
+    "publishes bounded selected-profile recovery from %s failures without discovering providers",
+    (kind) => {
+      const classifyProvider = vi
+        .spyOn(providerFailover, "classifyProviderFailoverSignalWithPlugin")
+        .mockImplementation(() => {
+          throw new Error("Terminal presentation must not discover providers");
+        });
+      emitAgentEvent.mockClear();
+      try {
+        const profileId = "openai:private-profile";
+        const rawCause = `Codex app-server auth profile "${profileId}" was not found`;
+        const terminal = createAgentLifecycleTerminalBackstop({
+          runId: "missing-selected-profile",
+          sessionKey: "agent:main:test",
+          getLifecycleGeneration: () => "test-generation",
+          resolveTerminationFields: () => ({}),
+        });
 
-    terminal.emit(
-      "error",
-      new FailoverError(rawCause, {
-        reason: "auth",
-        code: "selected_auth_profile_unavailable",
-        profileId,
-        cause: new Error(rawCause),
-      }),
-    );
+        const error =
+          kind === "typed"
+            ? new FailoverError(rawCause, {
+                reason: "auth",
+                code: "selected_auth_profile_unavailable",
+                profileId,
+                cause: new Error(rawCause),
+              })
+            : Object.assign(new Error(rawCause), {
+                code: "selected_auth_profile_unavailable",
+              });
+        terminal.emit("error", error);
 
-    const event = emitAgentEvent.mock.calls[0]?.[0];
-    expect(event.data.error).toBe(renderFailoverCodeUserCopy("selected_auth_profile_unavailable"));
-    expect(JSON.stringify(event)).not.toContain(profileId);
-    expect(JSON.stringify(event)).not.toContain(rawCause);
-  });
+        const event = emitAgentEvent.mock.calls[0]?.[0];
+        expect(event.data.error).toBe(
+          renderFailoverCodeUserCopy("selected_auth_profile_unavailable"),
+        );
+        expect(JSON.stringify(event)).not.toContain(profileId);
+        expect(JSON.stringify(event)).not.toContain(rawCause);
+        expect(classifyProvider).not.toHaveBeenCalled();
+      } finally {
+        classifyProvider.mockRestore();
+      }
+    },
+  );
 });

--- a/src/auto-reply/reply/agent-lifecycle-terminal.ts
+++ b/src/auto-reply/reply/agent-lifecycle-terminal.ts
@@ -1,5 +1,5 @@
 import { readStringValue } from "@openclaw/normalization-core/string-coerce";
-import { describeFailoverError } from "../../agents/failover-error.js";
+import { getFailoverErrorCode } from "../../agents/failover/error.js";
 import { renderFailoverCodeUserCopy } from "../../agents/failover/user-copy.js";
 import { AGENT_RUN_RESTART_ABORT_STOP_REASON } from "../../agents/run-termination.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
@@ -102,7 +102,7 @@ export function createAgentLifecycleTerminalBackstop(params: {
       data.stopReason = AGENT_RUN_RESTART_ABORT_STOP_REASON;
     } else if (phase === "error") {
       data.error =
-        renderFailoverCodeUserCopy(describeFailoverError(resultOrError).code) ??
+        renderFailoverCodeUserCopy(getFailoverErrorCode(resultOrError)) ??
         formatErrorMessage(resultOrError);
       Object.assign(data, terminationFields);
     } else {


### PR DESCRIPTION
## What Problem This Solves

Removes unnecessary provider classification from error-code presentation and from failed turns whose rollback guard never captured a model patch. These consumers need an existing code or an inactive guard result, not provider policy.

## Why This Change Was Made

Error-code consumers now read the existing code fact directly. The shared reader preserves typed failures' own code, including absence, and the existing raw error/cause traversal; reason classification and provider policy keep their existing path. A model-patch guard now declines failure classification unless it captured a patch when it was created, matching the reconciliation owner's existing eligibility check.

This removes three full-description calls used only for `.code`, moves the raw code reader to the existing pure error module, and prevents inactive guards from consulting provider policy. It does not change OAuth classification, fallback selection, retry rules, or rollback behavior for an armed guard.

## User Impact

Agent failures avoid unrelated provider-hook calls where only an error code is needed or no model patch can be reconciled. Operator error text, privacy filtering, and active model-patch rollback remain covered by their existing behavior assertions.

## Evidence

- The terminal regression failed before the code-reader change when a raw selected-profile error consulted provider classification, then passed for both typed and raw errors with bounded operator copy and no private profile or cause leakage.
- The existing real-store model-patch case failed before the guard change when an unarmed failed guard consulted classification. After the change it preserves the session entry and transcript, while the same test still proves that a subsequently armed guard rolls back the captured patch.
- All 119 focused pure-reader owner/sibling cases passed. The complete 33-case sessions suite passed before and after; its case inventory is unchanged.
- The original 34-case authentication/state execution pair passed in its original order before and after. The repeated model-switch case fell from 77,051 ms to 31 ms; the combined process peak RSS fell from about 4.08 GB to 2.55 GB in this local comparison. These are historical measurements on base b3552e8, before the separate loaded-provider fix #133970 landed; they are not an incremental performance claim against current main.
- On the earlier 4bf8432 composition, all 69 cases covering the original pair, terminal privacy behavior, and real-store session ownership passed; the repeated model-switch case took 28 ms. The complete build passed. Managed Codex review found no actionable P0 defect; root inspection also checked error traversal, provider-policy ordering, real session-store ownership, callers, siblings, and the upstream Codex protocol boundary.
- Direct upstream source inspection: Codex commit `3b67b03a3f6b`, `codex-rs/app-server-protocol/src/protocol/v2/account.rs:62` and `codex-rs/app-server/src/request_processors/account_processor.rs:99`. OpenClaw’s selected-profile error is produced before the login RPC (`extensions/codex/src/app-server/auth-bridge.ts:789`); no upstream protocol behavior is changed.
- The complete final changed-file gate passed. The first composed run stopped at the session test’s 1000-line limit; reusing its session/transcript address objects brought it to 995 effective lines with all 15 assertions and three independent guards retained. The complete 33-case suite passed again.

The execution fixtures above use the real in-process failure flow and isolated session stores with synthetic model failures. The Gateway proof below additionally exercises actual channel dispatch and tool execution against loopback mock-provider HTTP; it is not an authenticated upstream-provider run. The full final changed-file gate passed, including all core/UI/plugin/script/test typechecks, lint, dead-export and import-cycle checks. Fresh review of the complete ten-file change found no actionable P0 defect. Exact-head CI [33384692553](https://github.com/openclaw/openclaw/actions/runs/33384692553) passed at `9a0e41c65b8e780750f4104de3e994c0bc9da8b3`. Fresh managed pre-land review and native artifact validation also passed; all 34 recorded current-main source contexts match the qualified composition.

Current main includes #133970, which prevents cold provider discovery during classification, and #133979, which handles accepted-turn failures at the outer channel dispatcher. On main 4feff037, the unchanged 34-case auth/state pair passed in 19.80 seconds (repeated switch 32 ms); with this candidate it passed in 18.88 seconds (25 ms). Both runs retained the bare typed OAuth fixture. These local timings establish composition and change the historical attribution; they do not establish a statistically meaningful incremental speedup.

The composed candidate also passes all 292 focused owner and sibling cases, including loaded/scoped/generation provider precedence, structured signals, real session-store rollback, admission cleanup, and current terminal-delivery recovery. A fresh private-QA build passed. The existing `provider-http-503-visible-failure` scenario passed through qa-channel, the QA bus and a real Gateway child: one exact sanitized error reply, one planned read and three post-tool HTTP 503 requests, with no tool replay. The scenario ran once (`retryCount: 0`) and retained all deadlines and provider policy.

The canonical expected-error waiter had lost the old helper’s account filter. A synthetic foreign-account reply satisfied its unchanged assertion; adding the expected transport account makes that input fail while the correct account passes. The same real Gateway scenario then passed again with that account assertion. This is a two-line assertion/message correction in the existing scenario, with no new case or waiter API.

Production +43/-37 (net +6): the moved reader adds three required assertion-safety comments and the guard adds its explicit ownership check. Executable production growth is three lines. Tests +95/-68 (net +27), QA scenario +2/-2 (net 0), with the existing model-patch case extended and terminal behavior parameterized; assertion-safety baseline decreases by three casts at the old owner. No configuration, persistent schema, SDK export, or external protocol changes.
