### PR TITLE
fix(volcengine): reject invalid UTF-8 in TTS responses

### DIFF
--- a/extensions/volcengine/tts.test.ts
+++ b/extensions/volcengine/tts.test.ts
@@ -58,6 +58,24 @@ function makeOversizedStreamResponse(): Response {
   );
 }
 
+// Builds a JSON-shaped success body that is otherwise well-formed but carries
+// a raw 0xFF byte (invalid UTF-8) inside the message field. A non-fatal UTF-8
+// decoder would silently substitute U+FFFD and let JSON.parse succeed.
+function makeInvalidUtf8Response(code: number): Response {
+  const coding = Buffer.from(`{"code":${code},"message":"bad`);
+  const invalidByte = Buffer.from([0xff]);
+  const suffix = Buffer.from('","data":"dm9pY2UtaW52YWxpZC1iYXNlNjQ="}');
+  const body = Buffer.concat([coding, invalidByte, suffix]);
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(body));
+        controller.close();
+      },
+    }),
+  );
+}
+
 describe("Volcengine speech provider", () => {
   const provider = buildVolcengineSpeechProvider();
 
@@ -273,6 +291,43 @@ describe("volcengineTTS", () => {
     });
 
     expect(audio.toString()).toBe("audio-1audio-2");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects Seed Speech responses with invalid UTF-8 in the body", async () => {
+    const release = vi.fn();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: makeInvalidUtf8Response(0),
+      release,
+    });
+
+    await expect(
+      volcengineTTS({ text: "hello", apiKey: "secret-api-key", timeoutMs: 1000 }),
+    ).rejects.toThrow(Error);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects invalid UTF-8 in otherwise well-formed legacy TTS JSON instead of accepting replacement characters", async () => {
+    const release = vi.fn();
+    fetchWithSsrFGuardMock.mockResolvedValue({
+      response: makeInvalidUtf8Response(3000),
+      release,
+    });
+
+    let error: unknown;
+    try {
+      await volcengineTTS({
+        text: "hello",
+        appId: "app-id",
+        token: "secret-token",
+        timeoutMs: 1000,
+      });
+    } catch (err) {
+      error = err;
+    }
+
+    expect(error).toBeInstanceOf(Error);
+    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
     expect(release).toHaveBeenCalledTimes(1);
   });
 

--- a/extensions/volcengine/tts.test.ts
+++ b/extensions/volcengine/tts.test.ts
@@ -58,24 +58,6 @@ function makeOversizedStreamResponse(): Response {
   );
 }
 
-// Builds a JSON-shaped success body that is otherwise well-formed but carries
-// a raw 0xFF byte (invalid UTF-8) inside the message field. A non-fatal UTF-8
-// decoder would silently substitute U+FFFD and let JSON.parse succeed.
-function makeInvalidUtf8Response(code: number): Response {
-  const coding = Buffer.from(`{"code":${code},"message":"bad`);
-  const invalidByte = Buffer.from([0xff]);
-  const suffix = Buffer.from('","data":"dm9pY2UtaW52YWxpZC1iYXNlNjQ="}');
-  const body = Buffer.concat([coding, invalidByte, suffix]);
-  return new Response(
-    new ReadableStream<Uint8Array>({
-      start(controller) {
-        controller.enqueue(new Uint8Array(body));
-        controller.close();
-      },
-    }),
-  );
-}
-
 describe("Volcengine speech provider", () => {
   const provider = buildVolcengineSpeechProvider();
 
@@ -294,66 +276,53 @@ describe("volcengineTTS", () => {
     expect(release).toHaveBeenCalledTimes(1);
   });
 
-  it("rejects Seed Speech responses with invalid UTF-8 in the body", async () => {
-    const release = vi.fn();
-    fetchWithSsrFGuardMock.mockResolvedValue({
-      response: makeInvalidUtf8Response(0),
-      release,
-    });
-
-    await expect(
-      volcengineTTS({ text: "hello", apiKey: "secret-api-key", timeoutMs: 1000 }),
-    ).rejects.toThrow(Error);
-    expect(release).toHaveBeenCalledTimes(1);
-  });
-
-  it("rejects invalid UTF-8 in otherwise well-formed legacy TTS JSON instead of accepting replacement characters", async () => {
-    const release = vi.fn();
-    fetchWithSsrFGuardMock.mockResolvedValue({
-      response: makeInvalidUtf8Response(3000),
-      release,
-    });
-
-    let error: unknown;
-    try {
-      await volcengineTTS({
-        text: "hello",
-        appId: "app-id",
-        token: "secret-token",
-        timeoutMs: 1000,
-      });
-    } catch (err) {
-      error = err;
-    }
-
-    expect(error).toBeInstanceOf(Error);
-    expect(fetchWithSsrFGuardMock).toHaveBeenCalledTimes(1);
-    expect(release).toHaveBeenCalledTimes(1);
-  });
-
   it.each([
     {
       name: "Seed Speech",
-      response: { code: 0, data: "%%%not-base64!!" },
+      response: JSON.stringify({ code: 0, data: "%%%not-base64!!" }),
       params: { text: "hello", apiKey: "secret-api-key", timeoutMs: 1000 },
       error: "BytePlus Seed Speech TTS returned malformed base64 audio data",
     },
     {
       name: "legacy",
-      response: { code: 3000, data: "%%%not-base64!!" },
+      response: JSON.stringify({ code: 3000, data: "%%%not-base64!!" }),
       params: { text: "hello", appId: "app-id", token: "secret-token", timeoutMs: 1000 },
       error: "Volcengine TTS returned malformed base64 audio data",
     },
-  ])("rejects malformed base64 in $name responses", async ({ response, params, error }) => {
-    const release = vi.fn();
-    fetchWithSsrFGuardMock.mockResolvedValue({
-      response: new Response(JSON.stringify(response)),
-      release,
-    });
+    ...[
+      {
+        name: "Seed Speech",
+        code: 0,
+        params: { text: "hello", apiKey: "test-key", timeoutMs: 1000 },
+      },
+      {
+        name: "legacy",
+        code: 3000,
+        params: { text: "hello", appId: "app", token: "test-token", timeoutMs: 1000 },
+      },
+    ].map(({ name, code, params }) => ({
+      name: `${name} UTF-8`,
+      response: Buffer.concat([
+        Buffer.from(`{"code":${code},"message":"bad`),
+        Buffer.from([0xff]),
+        Buffer.from(`","data":"${Buffer.from("audio").toString("base64")}"}`),
+      ]),
+      params,
+      error: TypeError,
+    })),
+  ])(
+    "rejects malformed $name responses and releases the request",
+    async ({ response, params, error }) => {
+      const release = vi.fn();
+      fetchWithSsrFGuardMock.mockResolvedValue({
+        response: new Response(response),
+        release,
+      });
 
-    await expect(volcengineTTS(params)).rejects.toThrow(error);
-    expect(release).toHaveBeenCalledTimes(1);
-  });
+      await expect(volcengineTTS(params)).rejects.toThrow(error);
+      expect(release).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("reports Seed Speech provider errors without exposing credentials", async () => {
     const release = vi.fn();

--- a/extensions/volcengine/tts.ts
+++ b/extensions/volcengine/tts.ts
@@ -161,7 +161,7 @@ async function seedSpeechTTS(params: VolcengineTTSParams & { apiKey: string }): 
   });
 
   try {
-    const responseText = new TextDecoder().decode(
+    const responseText = new TextDecoder("utf-8", { fatal: true }).decode(
       await readResponseWithLimit(response, VOLCENGINE_TTS_RESPONSE_MAX_BYTES, {
         onOverflow: ({ maxBytes }) =>
           new Error(`BytePlus Seed Speech TTS response exceeds ${maxBytes} bytes`),
@@ -253,7 +253,7 @@ async function legacyVolcengineTTS(
   });
 
   try {
-    const responseText = new TextDecoder().decode(
+    const responseText = new TextDecoder("utf-8", { fatal: true }).decode(
       await readResponseWithLimit(response, VOLCENGINE_TTS_RESPONSE_MAX_BYTES, {
         onOverflow: ({ maxBytes }) =>
           new Error(`Volcengine TTS response exceeds ${maxBytes} bytes`),


### PR DESCRIPTION
## What Problem This Solves

Reject malformed UTF-8 before parsing Seed Speech or legacy Volcengine TTS responses. Both readers previously replaced invalid bytes silently, so a corrupted JSON message containing valid base64 audio could still return audio. The fix enables fatal UTF-8 decoding at the existing two byte-reader boundaries; production LOC is unchanged.

## Why This Change Was Made

The existing malformed-response table now exercises invalid byte responses as well as malformed base64. Both new cases fail before the fix by resolving audio; all19 tests pass afterward. All changed-file gates pass and independent P0 review is clean. Thanks @ZengWen-DT for the original repair.

## User Impact

Corrupted provider response bytes now fail visibly; valid Unicode audio and streamed frames still work.

## Evidence

Actual guarded HTTP proof exercises the public speech-provider synthesis path, both API routes, the unmodified SSRF guard and Undici transport, bounded response reader, JSON/frame parsing and audio return. A synthetic server runs in an ephemeral Linux network namespace with no external route. Seven cases cover valid Unicode, invalid UTF-8, malformed base64 and Seed data frames. Before, both corrupted responses returned audio. After, both reject with the decoder error; valid audio and existing errors are unchanged. Every TCP connection closes before the next case and final cleanup leaves none open. This is a real transport test against a synthetic service, not a call to Volcengine's external service.

A fresh seven-case run used the current bounded reader and verified10 source hashes against the candidate’s virtual integration with main e6ae941d8b2 (tree74663ac3dc3bbaacb0bdc1d653b07a81429fd1be). Both task-owned Testbox leases stopped successfully. Final publication will bind the committed head to candidate tree1e774219eb2e915a9f9a5adf4f8fd4f449baf281 and attach exact-head CI. No configuration, dependency or response-size limit changes.

<details>
<summary>Captured behavior verdict</summary>

```json
{"passed":true,"sourceSha256":"161425cc1ee49766eb991884b177f18ef0c7673e134e678a9de1e1554ce4157a","node":"v24.19.0","serverClosed":true,"remainingConnections":0,"cases":[{"route":"seed","mode":"valid","acceptedAudio":true,"releasedConnections":true},{"route":"seed","mode":"invalid","acceptedAudio":false,"errorCode":"ERR_ENCODING_INVALID_ENCODED_DATA","releasedConnections":true},{"route":"seed","mode":"base64","acceptedAudio":false,"releasedConnections":true},{"route":"seed","mode":"frames","acceptedAudio":true,"releasedConnections":true},{"route":"legacy","mode":"valid","acceptedAudio":true,"releasedConnections":true},{"route":"legacy","mode":"invalid","acceptedAudio":false,"errorCode":"ERR_ENCODING_INVALID_ENCODED_DATA","releasedConnections":true},{"route":"legacy","mode":"base64","acceptedAudio":false,"releasedConnections":true}]}
```
</details>


Reviewed and pushed head: `82b75a22b096a16bd786641761ace8e87f593100`. Required exact-head CI must pass before landing.
