### PR TITLE
refactor(sessions): share session entry admission

### DIFF
--- a/src/agents/sessions/session-file-parser.test.ts
+++ b/src/agents/sessions/session-file-parser.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { isSessionFileEntry } from "./session-file-parser.js";
+
+describe("isSessionFileEntry", () => {
+  it.each([
+    ["an arbitrary non-message entry", { type: "plugin_metadata" }],
+    ["a message with a current role", { type: "message", message: { role: "user" } }],
+    ["a message with a future role", { type: "message", message: { role: "future_role" } }],
+  ])("accepts %s", (_label, value) => {
+    expect(isSessionFileEntry(value)).toBe(true);
+  });
+
+  it.each([
+    ["null", null],
+    ["an array", []],
+    ["a non-record value", "message"],
+    ["a missing type", {}],
+    ["a non-string type", { type: 1 }],
+    ["a message without message data", { type: "message" }],
+    ["a message with null data", { type: "message", message: null }],
+    ["a message with array data", { type: "message", message: [] }],
+    ["a message without a role", { type: "message", message: {} }],
+    ["a message with a non-string role", { type: "message", message: { role: 1 } }],
+  ])("rejects %s", (_label, value) => {
+    expect(isSessionFileEntry(value)).toBe(false);
+  });
+});

--- a/src/agents/sessions/session-file-parser.ts
+++ b/src/agents/sessions/session-file-parser.ts
@@ -6,7 +6,7 @@ type SessionFileParseWarning = {
   row: number;
 };
 
-function isSessionFileEntry(value: unknown): value is FileEntry {
+export function isSessionFileEntry(value: unknown): value is FileEntry {
   if (!isRecord(value) || typeof value.type !== "string") {
     return false;
   }

--- a/src/auto-reply/reply/commands-export-session.ts
+++ b/src/auto-reply/reply/commands-export-session.ts
@@ -3,9 +3,9 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { hasNonEmptyString } from "@openclaw/normalization-core/string-coerce";
 import { readAcpSessionMetaForEntry } from "../../acp/runtime/session-meta.js";
+import { isSessionFileEntry } from "../../agents/sessions/session-file-parser.js";
 import {
   migrateSessionEntries,
   type FileEntry as SessionFileEntry,
@@ -200,17 +200,6 @@ async function generateHtml(sessionData: SessionData): Promise<string> {
       ),
     template,
   );
-}
-
-function isSessionFileEntry(value: unknown): value is SessionFileEntry {
-  if (!isRecord(value) || typeof value.type !== "string") {
-    return false;
-  }
-  if (value.type !== "message") {
-    return true;
-  }
-  const message = value.message;
-  return isRecord(message) && typeof message.role === "string";
 }
 
 function filterSessionEntriesWithWarnings(events: unknown[]): {

--- a/src/trajectory/export.ts
+++ b/src/trajectory/export.ts
@@ -5,7 +5,10 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sanitizeDiagnosticPayload } from "../agents/payload-redaction.js";
 import type { AgentMessage } from "../agents/runtime/index.js";
-import { parseSessionFileEntriesWithWarnings } from "../agents/sessions/session-file-parser.js";
+import {
+  isSessionFileEntry,
+  parseSessionFileEntriesWithWarnings,
+} from "../agents/sessions/session-file-parser.js";
 import type { FileEntry, SessionEntry, SessionHeader } from "../agents/sessions/session-manager.js";
 import { resolveStateDir } from "../config/paths.js";
 import { parseSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
@@ -107,17 +110,6 @@ function normalizeCompleteSessionTarget(
 
 function isFiniteNumber(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value);
-}
-
-function isSessionFileEntry(value: unknown): value is FileEntry {
-  if (!isRecord(value) || typeof value.type !== "string") {
-    return false;
-  }
-  if (value.type !== "message") {
-    return true;
-  }
-  const message = value.message;
-  return isRecord(message) && typeof message.role === "string";
 }
 
 function formatSessionParseWarnings(


### PR DESCRIPTION
## What Problem This Solves

Session transcript parsing, session export, and trajectory export independently owned the same permissive session-entry admission policy. Keeping three copies made it possible for malformed-row handling and future entry compatibility to drift between consumers.

## Why This Change Was Made

The existing session-file parser now exports the private `isSessionFileEntry` predicate, and both export consumers use that canonical owner. The contract is unchanged: entries require a record with a string `type`; any non-`message` string type is accepted; messages additionally require a record `message` with a string `role`.

This deliberately does not validate role enums, content, headers, ids, or storage shape. Consumer-specific warnings, transcript-tree handling, and output mapping remain separate.

Provenance: https://github.com/openclaw/openclaw/pull/98236 reintroduced the two consumer-local predicates while transcript loading moved to SQLite.

Overlap refresh covered:

- https://github.com/openclaw/openclaw/pull/130877
- https://github.com/openclaw/openclaw/pull/113810
- https://github.com/openclaw/openclaw/pull/124953
- https://github.com/openclaw/openclaw/pull/119267

Those PRs touch adjacent trajectory files but not this predicate or its admission contract.

## User Impact

No user-visible or storage behavior changes. Session entry admission now has one internal owner, reducing future drift across export paths.

Production LOC: +6/-25 (net -19)  
Tests: +27/-0

## Evidence

- `node scripts/run-vitest.mjs src/agents/sessions/session-file-parser.test.ts src/auto-reply/reply/commands-export-session.test.ts src/trajectory/export.test.ts` - 96 passed.
- `node scripts/check-changed.mjs --dry-run -- src/agents/sessions/session-file-parser.ts src/agents/sessions/session-file-parser.test.ts src/auto-reply/reply/commands-export-session.ts src/trajectory/export.ts` - expected `core, coreTests` plan.
- `pnpm check:changed` - passed.
- `git diff --check` - passed.
- Pinned Codex Sol/high autoreview - clean, confidence 0.99.
- No SQLite schema, persistence, public barrel, Plugin SDK, configuration, or protocol change.
