### PR TITLE
test: await bounded concurrency task starts directly

### DIFF
--- a/src/utils/run-with-concurrency.test.ts
+++ b/src/utils/run-with-concurrency.test.ts
@@ -1,53 +1,45 @@
 // Concurrency runner tests cover bounded parallel task execution.
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { runTasksWithConcurrency } from "./run-with-concurrency.js";
-
-function createDeferred() {
-  let resolve = () => {};
-  const promise = new Promise<void>((resolvePromise) => {
-    resolve = resolvePromise;
-  });
-  return { promise, resolve };
-}
 
 describe("runTasksWithConcurrency", () => {
   it("preserves task order with bounded worker count", async () => {
     let running = 0;
     let peak = 0;
-    const resolvers: Array<(() => void) | undefined> = [];
-    const tasks = [0, 1, 2, 3].map((index) => async (): Promise<number> => {
-      running += 1;
-      peak = Math.max(peak, running);
-      await new Promise<void>((resolve) => {
-        resolvers[index] = resolve;
-      });
-      running -= 1;
-      return index + 1;
-    });
+    function createTask(index: number) {
+      const started = createDeferred();
+      const release = createDeferred();
+      return {
+        started: started.promise,
+        release: release.resolve,
+        run: async () => {
+          running += 1;
+          peak = Math.max(peak, running);
+          started.resolve();
+          await release.promise;
+          running -= 1;
+          return index + 1;
+        },
+      };
+    }
+    const first = createTask(0);
+    const second = createTask(1);
+    const third = createTask(2);
+    const fourth = createTask(3);
+    const tasks = [first, second, third, fourth].map((task) => task.run);
 
     const resultPromise = runTasksWithConcurrency({ tasks, limit: 2 });
-    const takeResolver = async (index: number): Promise<() => void> => {
-      await vi.waitFor(() => {
-        expect(resolvers[index]).toBeTypeOf("function");
-      });
-      const resolver = resolvers[index];
-      if (!resolver) {
-        throw new Error(`expected task ${index} to be running`);
-      }
-      return resolver;
-    };
+    await Promise.all([first.started, second.started]);
 
-    const resolveFirst = await takeResolver(0);
-    const resolveSecond = await takeResolver(1);
+    second.release();
+    await third.started;
 
-    resolveSecond();
-    const resolveThird = await takeResolver(2);
+    first.release();
+    await fourth.started;
 
-    resolveFirst();
-    const resolveFourth = await takeResolver(3);
-
-    resolveThird();
-    resolveFourth();
+    third.release();
+    fourth.release();
 
     const result = await resultPromise;
     expect(result.hasError).toBe(false);


### PR DESCRIPTION
## What Problem This Solves

The bounded-concurrency test polls for task starts even though it owns every task and release gate. Three eventual observations add about 150 ms of polling delay to a small suite.

## Why This Change Was Made

Signal task admission directly from each task body, then release tasks in the same deliberately different completion order. Reuse the shared deferred helper instead of a local copy. The real p-limit scheduler, concurrency bound, ordered results, failure handling, and early-rejection cases remain intact, including the drain turn required by the negative scheduling assertion.

## User Impact

No runtime behavior change. The five-test file took 159 ms before and 5 ms after in local runs. Successful synchronization now follows task starts without a polling cadence.

## Evidence

- `node scripts/run-vitest.mjs src/utils/run-with-concurrency.test.ts`: five cases pass.
- `node scripts/check-changed.mjs -- src/utils/run-with-concurrency.test.ts`: changed-file guard/type/lint validation.
- Formatting, diff checks, owner/caller/sibling and installed p-limit source review completed; structured Codex autoreview reports no accepted findings.
- Production unchanged. Tests +29/-37 lines, net -8.
