### PR TITLE
fix(voice-call): preserve current settings during legacy migration

### DIFF
--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -348,12 +348,12 @@ That stages grounded durable candidates into the short-term dreaming store while
     | Runtime and channel tuning knobs retired in 2026.7                                               | removed (built-in production defaults apply)                               |
 
     <Note>
-      The `plugins.entries.voice-call.config.*` rows above are normalized by
-      the Voice Call plugin itself on every config load, not by `openclaw
-      doctor`. The plugin also logs a startup warning pointing at `openclaw
-      doctor --fix`, but doctor does not currently rewrite
-      `openclaw.json` for these keys; the plugin's own normalization is what
-      applies the change at runtime.
+      The Voice Call plugin supplies the migration for its legacy config keys.
+      `openclaw doctor --fix` invokes it and persists the canonical shape in
+      `openclaw.json`; runtime config parsing accepts only current keys.
+      Existing canonical settings win over legacy values, including streaming
+      provider credentials, models, and timing. Doctor reports retained
+      destinations instead of claiming those legacy values were moved.
     </Note>
 
     Account-default guidance for multi-account channels:

--- a/docs/plugins/voice-call.md
+++ b/docs/plugins/voice-call.md
@@ -220,10 +220,11 @@ that Region. See
 
   </Accordion>
   <Accordion title="Legacy config migrations">
-    Config parsing normalizes these legacy keys automatically and logs a
-    warning naming the replacement path; the shim is removed in a future
-    release (`2026.6.0`), so run `openclaw doctor --fix` to rewrite committed
-    config to the canonical shape:
+    Run `openclaw doctor --fix` to rewrite these legacy keys to the canonical
+    shape. The Voice Call plugin owns the migration; runtime config parsing
+    accepts only the current keys. When both old and current settings exist,
+    Doctor keeps the current setting, removes the legacy key, and reports which
+    destination it retained. Legacy values fill only missing current fields:
 
     - `provider: "log"` → `provider: "mock"`
     - `twilio.from` → `fromNumber`

--- a/extensions/voice-call/package.json
+++ b/extensions/voice-call/package.json
@@ -28,6 +28,7 @@
     "extensions": [
       "./index.ts"
     ],
+    "setupEntry": "./setup-api.ts",
     "install": {
       "npmSpec": "@openclaw/voice-call",
       "defaultChoice": "npm",

--- a/extensions/voice-call/src/config-migration.test.ts
+++ b/extensions/voice-call/src/config-migration.test.ts
@@ -1,8 +1,17 @@
 // Voice Call tests cover setup-time config migration behavior.
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { migrateVoiceCallLegacyConfigInput } from "./config-migration.js";
+import { VoiceCallConfigSchema } from "./config.js";
 
 describe("voice-call config migration", () => {
+  it("declares the setup entry needed to migrate installed packages", () => {
+    const packageJson: unknown = JSON.parse(
+      readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+    );
+    expect(packageJson).toMatchObject({ openclaw: { setupEntry: "./setup-api.ts" } });
+  });
+
   it("maps deprecated provider and twilio.from fields into canonical config", () => {
     const migration = migrateVoiceCallLegacyConfigInput({
       value: {
@@ -18,46 +27,108 @@ describe("voice-call config migration", () => {
     expect(migration.config.fromNumber).toBe("+15550001234");
   });
 
-  it("moves legacy streaming OpenAI fields into streaming.providers.openai", () => {
-    const migration = migrateVoiceCallLegacyConfigInput({
-      value: {
+  it.each([
+    { label: "legacy-only", current: undefined },
+    {
+      label: "all canonical fields",
+      current: {
+        apiKey: "synthetic-current-key",
+        model: "synthetic-current-model",
+        silenceDurationMs: 900,
+        vadThreshold: 0.8,
+        keep: { setting: "current" },
+      },
+    },
+    {
+      label: "partial canonical fields and a SecretRef",
+      current: {
+        apiKey: { source: "env", provider: "default", id: "SYNTHETIC_VOICE_KEY" },
+        vadThreshold: 0,
+        keep: "current",
+      },
+    },
+    {
+      label: "explicit empty and zero canonical fields",
+      current: { apiKey: "", model: "", silenceDurationMs: 0, vadThreshold: 0 },
+    },
+  ] satisfies Array<{ label: string; current: Record<string, unknown> | undefined }>)(
+    "fills only missing streaming provider fields with $label",
+    ({ current }) => {
+      const value = {
         streaming: {
           enabled: true,
           sttProvider: "openai",
-          openaiApiKey: "test",
-          sttModel: "gpt-4o-transcribe",
+          openaiApiKey: "synthetic-legacy-key",
+          sttModel: "synthetic-legacy-model",
           silenceDurationMs: 700,
           vadThreshold: 0.4,
+          providers: { openai: current, other: { keep: "other-provider" } },
         },
+      };
+      const before = structuredClone(value);
+      const migration = migrateVoiceCallLegacyConfigInput({ value });
+
+      expect(migration.config.streaming).toEqual({
+        enabled: true,
+        provider: "openai",
+        providers: {
+          other: { keep: "other-provider" },
+          openai: {
+            apiKey: "synthetic-legacy-key",
+            model: "synthetic-legacy-model",
+            silenceDurationMs: 700,
+            vadThreshold: 0.4,
+            ...current,
+          },
+        },
+      });
+      const prefix = "plugins.entries.voice-call.config.streaming";
+      expect(migration.changes).toEqual([
+        `Moved ${prefix}.sttProvider → ${prefix}.provider.`,
+        ...(
+          [
+            ["openaiApiKey", "apiKey"],
+            ["sttModel", "model"],
+            ["silenceDurationMs", "silenceDurationMs"],
+            ["vadThreshold", "vadThreshold"],
+          ] as const
+        ).map(([legacy, canonical]) => {
+          const target = `${prefix}.providers.openai.${canonical}`;
+          return current?.[canonical] !== undefined
+            ? `Removed ${prefix}.${legacy} (kept ${target}).`
+            : `Moved ${prefix}.${legacy} → ${target}.`;
+        }),
+      ]);
+      expect(value).toEqual(before);
+      expect(VoiceCallConfigSchema.safeParse(migration.config).success).toBe(true);
+      expect(migrateVoiceCallLegacyConfigInput({ value: migration.config })).toEqual({
+        config: migration.config,
+        changes: [],
+      });
+    },
+  );
+
+  it("reports removal of legacy selectors while retaining canonical settings", () => {
+    const migration = migrateVoiceCallLegacyConfigInput({
+      value: {
+        fromNumber: "+15550005678",
+        twilio: { from: "+15550001234", accountSid: "synthetic-account" },
+        streaming: { provider: "other", sttProvider: "openai" },
       },
+      configPathPrefix: "voice-config",
     });
 
-    const streaming = migration.config.streaming as
-      | {
-          enabled?: boolean;
-          provider?: string;
-          providers?: {
-            openai?: {
-              apiKey?: string;
-              model?: string;
-              silenceDurationMs?: number;
-              vadThreshold?: number;
-            };
-          };
-          openaiApiKey?: unknown;
-          sttModel?: unknown;
-        }
-      | undefined;
-    expect(streaming?.enabled).toBe(true);
-    expect(streaming?.provider).toBe("openai");
-    expect(streaming?.providers?.openai).toEqual({
-      apiKey: "test",
-      model: "gpt-4o-transcribe",
-      silenceDurationMs: 700,
-      vadThreshold: 0.4,
+    expect(migration.config).toMatchObject({
+      fromNumber: "+15550005678",
+      twilio: { accountSid: "synthetic-account" },
+      streaming: { provider: "other" },
     });
-    expect(streaming?.openaiApiKey).toBeUndefined();
-    expect(streaming?.sttModel).toBeUndefined();
+    expect(migration.config.twilio).not.toHaveProperty("from");
+    expect(migration.config.streaming).not.toHaveProperty("sttProvider");
+    expect(migration.changes).toEqual([
+      "Removed voice-config.twilio.from (kept voice-config.fromNumber).",
+      "Removed voice-config.streaming.sttProvider (kept voice-config.streaming.provider).",
+    ]);
   });
 
   it("removes legacy realtime agentContext system prompt toggle", () => {

--- a/extensions/voice-call/src/config-migration.ts
+++ b/extensions/voice-call/src/config-migration.ts
@@ -5,27 +5,6 @@ import {
   readStringField,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 
-/** Merge legacy provider-specific values into the canonical providers map. */
-function mergeProviderConfig(
-  providersValue: unknown,
-  providerId: string,
-  compatValues: Record<string, unknown>,
-): Record<string, unknown> | undefined {
-  if (Object.keys(compatValues).length === 0) {
-    return asOptionalRecord(providersValue);
-  }
-
-  const providers = asOptionalRecord(providersValue) ?? {};
-  const existing = asOptionalRecord(providers[providerId]) ?? {};
-  return {
-    ...providers,
-    [providerId]: {
-      ...existing,
-      ...compatValues,
-    },
-  };
-}
-
 /** Migrate legacy voice-call config input to the current canonical shape. */
 export function migrateVoiceCallLegacyConfigInput(params: {
   value: unknown;
@@ -40,56 +19,78 @@ export function migrateVoiceCallLegacyConfigInput(params: {
   const twilio = asOptionalRecord(raw.twilio);
   const streaming = asOptionalRecord(raw.streaming);
   const configPathPrefix = params.configPathPrefix ?? "plugins.entries.voice-call.config";
+  const changes: string[] = [];
 
-  const legacyStreamingOpenAICompat: Record<string, unknown> = {};
-  const streamingOpenAIApiKey = readStringField(streaming, "openaiApiKey");
-  if (streamingOpenAIApiKey) {
-    legacyStreamingOpenAICompat.apiKey = streamingOpenAIApiKey;
+  if (raw.provider === "log") {
+    changes.push(`Moved ${configPathPrefix}.provider "log" → "mock".`);
   }
-  const streamingSttModel = readStringField(streaming, "sttModel");
-  if (streamingSttModel) {
-    legacyStreamingOpenAICompat.model = streamingSttModel;
+  if (typeof twilio?.from === "string") {
+    const source = `${configPathPrefix}.twilio.from`;
+    const target = `${configPathPrefix}.fromNumber`;
+    changes.push(
+      raw.fromNumber != null
+        ? `Removed ${source} (kept ${target}).`
+        : `Moved ${source} → ${target}.`,
+    );
   }
-  const streamingSilenceDurationMs = asFiniteNumber(streaming?.silenceDurationMs);
-  if (streamingSilenceDurationMs !== undefined) {
-    legacyStreamingOpenAICompat.silenceDurationMs = streamingSilenceDurationMs;
-  }
-  const streamingVadThreshold = asFiniteNumber(streaming?.vadThreshold);
-  if (streamingVadThreshold !== undefined) {
-    legacyStreamingOpenAICompat.vadThreshold = streamingVadThreshold;
-  }
+
   const streamingProvider = readStringField(streaming, "provider");
   const legacyStreamingProvider = readStringField(streaming, "sttProvider");
-
   const normalizedStreaming: Record<string, unknown> | undefined = streaming
-    ? {
-        ...streaming,
-        provider: streamingProvider ?? legacyStreamingProvider,
-        providers: mergeProviderConfig(streaming.providers, "openai", legacyStreamingOpenAICompat),
-      }
+    ? { ...streaming, provider: streamingProvider ?? legacyStreamingProvider }
     : undefined;
 
   if (normalizedStreaming) {
     delete normalizedStreaming.sttProvider;
-    delete normalizedStreaming.openaiApiKey;
-    delete normalizedStreaming.sttModel;
-    delete normalizedStreaming.silenceDurationMs;
-    delete normalizedStreaming.vadThreshold;
+    if (legacyStreamingProvider !== undefined) {
+      const source = `${configPathPrefix}.streaming.sttProvider`;
+      const target = `${configPathPrefix}.streaming.provider`;
+      changes.push(
+        streamingProvider !== undefined
+          ? `Removed ${source} (kept ${target}).`
+          : `Moved ${source} → ${target}.`,
+      );
+    }
+
+    for (const [legacyKey, canonicalKey, value] of [
+      ["openaiApiKey", "apiKey", readStringField(streaming, "openaiApiKey")],
+      ["sttModel", "model", readStringField(streaming, "sttModel")],
+      ["silenceDurationMs", "silenceDurationMs", asFiniteNumber(streaming?.silenceDurationMs)],
+      ["vadThreshold", "vadThreshold", asFiniteNumber(streaming?.vadThreshold)],
+    ] as const) {
+      if (!Object.hasOwn(normalizedStreaming, legacyKey)) {
+        continue;
+      }
+      delete normalizedStreaming[legacyKey];
+      const source = `${configPathPrefix}.streaming.${legacyKey}`;
+      if (value === undefined || value === "") {
+        changes.push(`Removed invalid ${source}.`);
+        continue;
+      }
+      const providers = asOptionalRecord(normalizedStreaming.providers);
+      const existing = asOptionalRecord(providers?.openai);
+      const target = `${configPathPrefix}.streaming.providers.openai.${canonicalKey}`;
+      // Transitional configs can retain stale credentials and tuning. Canonical
+      // fields are authoritative, including SecretRefs, empty strings, and zero.
+      if (existing?.[canonicalKey] !== undefined) {
+        changes.push(`Removed ${source} (kept ${target}).`);
+        continue;
+      }
+      normalizedStreaming.providers = {
+        ...providers,
+        openai: { ...existing, [canonicalKey]: value },
+      };
+      changes.push(`Moved ${source} → ${target}.`);
+    }
   }
 
-  const normalizedTwilio = twilio
-    ? {
-        ...twilio,
-      }
-    : undefined;
+  const normalizedTwilio = twilio ? { ...twilio } : undefined;
   if (normalizedTwilio) {
     delete normalizedTwilio.from;
   }
 
   const normalizedRealtimeAgentContext = realtimeAgentContext
-    ? {
-        ...realtimeAgentContext,
-      }
+    ? { ...realtimeAgentContext }
     : undefined;
   if (normalizedRealtimeAgentContext) {
     delete normalizedRealtimeAgentContext.includeSystemPrompt;
@@ -111,42 +112,6 @@ export function migrateVoiceCallLegacyConfigInput(params: {
     realtime: normalizedRealtime,
   };
 
-  const changes: string[] = [];
-  if (raw.provider === "log") {
-    changes.push(`Moved ${configPathPrefix}.provider "log" → "mock".`);
-  }
-  if (typeof twilio?.from === "string" && typeof raw.fromNumber !== "string") {
-    changes.push(`Moved ${configPathPrefix}.twilio.from → ${configPathPrefix}.fromNumber.`);
-  }
-  if (typeof streaming?.sttProvider === "string") {
-    changes.push(
-      `Moved ${configPathPrefix}.streaming.sttProvider → ${configPathPrefix}.streaming.provider.`,
-    );
-  }
-  if (typeof streaming?.openaiApiKey === "string") {
-    changes.push(
-      `Moved ${configPathPrefix}.streaming.openaiApiKey → ${configPathPrefix}.streaming.providers.openai.apiKey.`,
-    );
-  }
-  if (typeof streaming?.sttModel === "string") {
-    changes.push(
-      `Moved ${configPathPrefix}.streaming.sttModel → ${configPathPrefix}.streaming.providers.openai.model.`,
-    );
-  }
-  if (asFiniteNumber(streaming?.silenceDurationMs) !== undefined) {
-    changes.push(
-      `Moved ${configPathPrefix}.streaming.silenceDurationMs → ${configPathPrefix}.streaming.providers.openai.silenceDurationMs.`,
-    );
-  } else if (typeof streaming?.silenceDurationMs === "number") {
-    changes.push(`Removed invalid ${configPathPrefix}.streaming.silenceDurationMs.`);
-  }
-  if (asFiniteNumber(streaming?.vadThreshold) !== undefined) {
-    changes.push(
-      `Moved ${configPathPrefix}.streaming.vadThreshold → ${configPathPrefix}.streaming.providers.openai.vadThreshold.`,
-    );
-  } else if (typeof streaming?.vadThreshold === "number") {
-    changes.push(`Removed invalid ${configPathPrefix}.streaming.vadThreshold.`);
-  }
   if (realtimeAgentContext && Object.hasOwn(realtimeAgentContext, "includeSystemPrompt")) {
     changes.push(`Removed ${configPathPrefix}.realtime.agentContext.includeSystemPrompt.`);
   }

--- a/src/plugins/setup-registry.migrations.test.ts
+++ b/src/plugins/setup-registry.migrations.test.ts
@@ -15,6 +15,49 @@ function runMigration(config: OpenClawConfig) {
 }
 
 describe("bundled setup config migrations", () => {
+  test("preserves Voice Call canonical settings and converges through the bundled registry", () => {
+    const current = {
+      apiKey: { source: "env", provider: "default", id: "SYNTHETIC_VOICE_KEY" },
+      model: "synthetic-current-model",
+      silenceDurationMs: 900,
+      vadThreshold: 0,
+      keep: "current",
+    };
+    const config = {
+      plugins: {
+        entries: {
+          "voice-call": {
+            enabled: false,
+            config: {
+              responseSystemPrompt: "synthetic-preserved-instructions",
+              streaming: {
+                openaiApiKey: "synthetic-legacy-key",
+                sttModel: "synthetic-legacy-model",
+                silenceDurationMs: 700,
+                vadThreshold: 0.4,
+                providers: { openai: current },
+              },
+            },
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const before = structuredClone(config);
+    const result = runMigration(config);
+
+    expect(result.config.plugins?.entries?.["voice-call"]).toEqual({
+      enabled: false,
+      config: expect.objectContaining({
+        responseSystemPrompt: "synthetic-preserved-instructions",
+        streaming: { provider: undefined, providers: { openai: current } },
+      }),
+    });
+    expect(result.changes).toHaveLength(4);
+    expect(result.changes.every((change) => change.includes("(kept "))).toBe(true);
+    expect(config).toEqual(before);
+    expect(runMigration(result.config)).toEqual({ config: result.config, changes: [] });
+  });
+
   test("repairs Tencent TokenHub model defaults", () => {
     const result = runMigration({
       agents: {


### PR DESCRIPTION
Closes #127596

## What Problem This Solves

Fixes an issue where users running Doctor on a Voice Call configuration containing both legacy streaming keys and current provider settings could have their current credential, model, VAD threshold, or silence duration replaced by stale legacy values. The migration also reported those conflicts as ordinary successful moves.

Package-level reproduction found a connected problem: the published Voice Call package contains its migration module but does not declare its setup entry. On OpenClaw 2026.8.1, the actual installed-plugin Doctor flow therefore quarantines the transitional configuration instead of running that migration. The previous configuration remains in Doctor's backup; this is not a claim of irreversible data loss.

## Why This Change Was Made

Keep the repair in the owning Voice Call plugin. The migration now fills only missing canonical provider fields, removes deprecated inputs, and reports whether it moved a value or retained the existing destination. The existing package setup-entry contract makes that migration discoverable after packaging. Core migration policy and runtime parsing remain unchanged; no runtime compatibility reader, new operator setting, dependency change, or schema change is added.

The old merge helper and duplicated reporting branches are removed. Production changes are +56/-90 lines (net -34); tests are +144/-30 (net +114), with a net +1 documentation line. The retained public contract is migration of the legacy Voice Call configuration into its current shape; explicit canonical settings are authoritative, including SecretRefs, empty strings, and zero.

## User Impact

Doctor preserves current Voice Call settings and credentials when legacy keys coexist, still migrates legacy-only fields, and gives truthful diagnostics without printing credential values. Repeated runs converge on the same canonical plugin configuration. Documentation now correctly identifies Doctor as the migration and persistence owner rather than promising runtime normalization.

This does not place voice calls, change provider behavior, or recover settings that were already replaced by a prior run. No package release or version bump is part of this PR.

## Evidence

- Preserved regression proof: the original canonical-collision owner and setup-registry cases failed before the repair. The package-entry regression separately failed because `openclaw.setupEntry` was absent, then passed with the declaration.
- The final six-file candidate passed 68 focused tests across the Voice Call migration/config suites and the setup-registry migration suite (two Vitest shards; 33.01 seconds). No source edits were made during those runs.
- Fresh managed P0–P2 review of the complete six-file candidate returned no findings. A separate read-only, approval-never, ephemeral Codex source review also passed on exact commit `d9a32afc439f312b42d66a8067fbd0b1085270e0` with no P0/P1/P2 findings. These source reviews do not substitute for runtime or CI evidence.
- Published baseline: OpenClaw 2026.8.1, commit `ea806575e6450e4d1efdfc72c19f04be982a1b9b`, with the published `@openclaw/voice-call@2026.8.1` artifact. A real supported plugin install into a synthetic HOME/state passed the canonical dry-run smoke before Doctor; adding legacy keys and running Doctor twice quarantined the plugin configuration and left the dry-run smoke unavailable. The stable core was installed with scripts disabled, so it is a CLI baseline, not install-lifecycle proof.
- Canonical external-plugin build/pack passed on `d9a32afc439f312b42d66a8067fbd0b1085270e0` using `OPENCLAW_PLUGIN_NPM_PACK_OUTPUT_DIR="<artifact-dir>" bash scripts/plugin-npm-publish.sh --pack extensions/voice-call`. The tarball SHA-256 is `0309f092169eaf40443174dbff6f426a200f18a477df2bb29e4e54b87b62ee76`. Both setup entries name `./dist/setup-api.js`; runtime dependencies are bundled and lockfiles are absent. This is a local test artifact, not a published package.
- Actual installed-artifact matrix passed in four separate synthetic HOME/state directories: full canonical collisions (including API/URL/header/option fields), partial canonical fields with a SecretRef, legacy-only fields, and explicit empty/zero canonical values. Each used the supported `openclaw plugins install "npm-pack:<tarball>" --force --accept-capabilities` flow, then fresh-process `doctor --fix --non-interactive --no-workspace-suggestions` twice, `config validate --json`, and `voicecall smoke --json` without `--yes` or a call target. All eight migration Doctor calls, all four validations, and all four post-migration dry-run smokes exited zero; no real calls were placed. Canonical baseline Doctor ran before legacy injection so unrelated first-run setup could not distort the comparison.
- All four scenarios preserved current settings, unrelated provider config, instructions, and plugin inventory; second-pass config was unchanged. Every moved/retained receipt matched the actual decision, and diagnostics omitted synthetic credential values. Readback verified all 21 installed runtime files byte-for-byte against the candidate tarball in every managed plugin root, with matching recorded npm integrity.
- Independent artifact replay passed the collision scenario, then the partial-config scenario hit the harness's 300-second outer deadline during candidate installation, before Doctor. That attempt is retained. Source inspection found that the CLI owns multiple npm stages with separate deadlines and can start npm in distinct process groups; the original single-deadline/group-only harness did not model those contracts. A separately reviewed supervisor retains the original scenario assertions, applies source-derived stage bounds, and requires identity-checked descendant cleanup plus pipe EOF. The retained collision fixture was independently re-read without rerunning the CLI: its active plugin index, raw manifest, all 21 runtime files, all ten rich canonical provider fields, four kept-field receipts, and no-call smoke receipt still match the candidate and expected result. The remaining partial, legacy-only, and empty/zero scenarios now also pass independently on the same commit and tarball. This is one retained earlier collision execution plus three new executions, not one uninterrupted successful four-case batch; the earlier batch's later timeout remains recorded. The three new executions covered 27 real CLI calls, 63 runtime-file byte comparisons, matching active plugin registry and package metadata, independently checked persisted settings and truthful receipts, repeated-Doctor convergence, credential-free diagnostics, and successful no-call smoke. All cleanup and EOF checks passed with no matching fixture processes remaining; the longest command was 34.203 seconds, so every command also finished within the original 300-second ceiling. Process sampling can omit short completed npm stages; its observed stage counts are not a complete event history. Neither the successful replay nor the harness repair establishes the cause of the earlier install latency.
- All applicable local checks passed on the unchanged candidate. The production export scan passed in 163.70 seconds and the script export scan in 114.98 seconds, both with zero findings. After an earlier parallel attempt and a low-priority serial full-tree attempt hit the original 600-second deadline, the exact full-tree scan passed at ordinary priority in 120.8 seconds with zero findings and about 2.54 GiB sampled aggregate RSS. No heap, deadline, scope, or assertion changes were made; the failed attempts remain recorded.
- With all three exact export scans verified, the repository's documented already-verified dead-code skip was used for the six-file `check-changed` continuation. That actual continuation exited zero, including formatting, npm-lock validation, five Doctor contract tests, core/plugin test typechecks, core/plugin lint, metadata and architecture guards, and zero runtime import cycles. The source worktree stayed clean.
- Exact-head CI is green on `d9a32afc439f312b42d66a8067fbd0b1085270e0`. The [dependency guard](https://github.com/openclaw/openclaw/actions/runs/33379168383) initially failed with a GitHub repository-content HTTP 429; exactly one failed-job retry passed as attempt 2. [Primary CI](https://github.com/openclaw/openclaw/actions/runs/33379168625) attempt 1 stopped before the build when its base-commit fetches could not obtain the required commit. The proof upload then had no files, and the aggregate gate reported the build job failure. The log does not establish the underlying fetch-latency cause. Exactly one failed-job retry passed as primary attempt 2 on the unchanged head. The canonical exact-head watcher completed successfully with a green rollup and no pending checks. No guard, permission, token, timeout, or product-source change was made to bypass either failure.
- The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/134018#issuecomment-5476707806) covers this exact head and identifies no code defect. Its packaged-upgrade validation request is covered by the owner and independent installed-artifact evidence above. Native review initialization, exact-main/PR guards, and artifact validation passed on the reviewed head. Validation emitted `review artifacts validated`, `READY FOR /prepare-pr`, and zero findings; both nonempty identity-bound review artifacts were preserved byte-for-byte. The local `/tmp` path alias initially skipped the artifact CLI entry and produced empty templates despite exit zero; this was detected by content checks, and the physical-path native invocation passed without source changes or a gate override. Native prepare/merge remain required. No release, real telephony, or core install-lifecycle proof is claimed.

Issue scope and closure: #127596 reports the bundled migration overwriting four canonical credential/model/VAD/timing fields and misreporting the result. Independent review of the full original issue bound its affected build `41acededbc5751d6c6eafa0716c73326459451b4` to repair base `ee036be7796396868bfa4851210e66c17bb2a25c`: the migration source is byte-identical (SHA-256 `59988081b540863a98b21e3541a6ebbc20f10fd545fd5620bd206c5871133af4`), and the setup entry is unchanged through the candidate. The preserved old-code owner and real bundled-registry regressions reproduce those exact conflicts; the final 68-test run repairs them. Those red logs do not embed a per-run HEAD, so the separate freeze/patch checkpoints must not be presented as a stronger per-run source identity. The published-package negative control is a distinct discovery failure—Doctor quarantined the legacy config because setup metadata was missing, with the backup retained—not a claimed installed overwrite reproduction. The candidate's real installed Doctor flow preserves those same four canonical fields, fills only missing targets, removes legacy keys with truthful receipts, and converges, independently challenged through the retained-one-plus-new-three artifact evidence above. The closing reference covers that narrow prospective migration defect after verified landing, not restoration of previously overwritten values, real phone-call/transcription behavior, unrelated upgrade failures, or another plugin.

Provenance: the overwrite implementation and missing setup-entry metadata are present in the published Voice Call 2026.8.1 artifact. Exact introducing-commit attribution is not established. Source inspection covered the owning migration, setup registration, discovery/registry, Doctor caller, strict runtime schema, packaging transforms, and canonical-precedence sibling migrations.
