### PR TITLE
test(whatsapp): exercise real outbound target policy

### DIFF
--- a/extensions/whatsapp/src/resolve-outbound-target.test.ts
+++ b/extensions/whatsapp/src/resolve-outbound-target.test.ts
@@ -1,289 +1,75 @@
-// Whatsapp tests cover resolve outbound target plugin behavior.
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import * as normalize from "./normalize-target.js";
-
-vi.mock("./normalize-target.js");
-vi.mock("openclaw/plugin-sdk/channel-feedback", () => ({
-  missingTargetError: (platform: string, format: string) => new Error(`${platform}: ${format}`),
-}));
-
-let resolveWhatsAppOutboundTarget: typeof import("./resolve-outbound-target.js").resolveWhatsAppOutboundTarget;
+import { describe, expect, it } from "vitest";
+import { resolveWhatsAppOutboundTarget } from "./resolve-outbound-target.js";
 
 type ResolveParams = Parameters<typeof resolveWhatsAppOutboundTarget>[0];
+
 const PRIMARY_TARGET = "+11234567890";
 const SECONDARY_TARGET = "+19876543210";
 
-function expectResolutionError(params: ResolveParams) {
-  const result = resolveWhatsAppOutboundTarget(params);
-  expect(result.ok).toBe(false);
-  if (result.ok) {
-    throw new Error("expected resolution to fail");
-  }
-  expect(result.error.message).toContain("WhatsApp");
-}
-
-function expectResolutionErrorMessage(params: ResolveParams, expectedMessage: string) {
-  const result = resolveWhatsAppOutboundTarget(params);
-  expect(result.ok).toBe(false);
-  if (result.ok) {
-    throw new Error("expected resolution to fail");
-  }
-  expect(result.error.message).toBe(expectedMessage);
-}
-
-function expectResolutionOk(params: ResolveParams, expectedTarget: string) {
-  const result = resolveWhatsAppOutboundTarget(params);
-  expect(result).toEqual({ ok: true, to: expectedTarget });
-}
-
-function mockNormalizedDirectMessage(...values: Array<string | null>) {
-  const normalizeMock = vi.mocked(normalize.normalizeWhatsAppTarget);
-  for (const value of values) {
-    normalizeMock.mockReturnValueOnce(value);
-  }
-  vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
-}
-
-function expectAllowedForTarget(params: {
-  allowFrom: ResolveParams["allowFrom"];
-  mode: ResolveParams["mode"];
-  to?: string;
-}) {
-  const to = params.to ?? PRIMARY_TARGET;
-  expectResolutionOk(
-    {
-      to,
-      allowFrom: params.allowFrom,
-      mode: params.mode,
-    },
-    to,
-  );
-}
-
-function expectDeniedForTarget(params: {
-  allowFrom: ResolveParams["allowFrom"];
-  mode: ResolveParams["mode"];
-  to?: string;
-}) {
-  expectResolutionError({
-    to: params.to ?? PRIMARY_TARGET,
-    allowFrom: params.allowFrom,
-    mode: params.mode,
-  });
-}
-
 describe("resolveWhatsAppOutboundTarget", () => {
-  beforeEach(async () => {
-    vi.resetModules();
-    vi.resetAllMocks();
-    ({ resolveWhatsAppOutboundTarget } = await import("./resolve-outbound-target.js"));
-  });
-
-  describe("empty/missing to parameter", () => {
-    it.each([
-      ["null", null],
-      ["undefined", undefined],
-      ["empty string", ""],
-      ["whitespace only", "   "],
-    ])("returns error when to is %s", (_label, to) => {
-      expectResolutionError({ to, allowFrom: undefined, mode: undefined });
+  it.each([null, undefined, "", "   ", "invalid"])("rejects missing or invalid target %j", (to) => {
+    expect(resolveWhatsAppOutboundTarget({ to, allowFrom: undefined, mode: undefined })).toEqual({
+      ok: false,
+      error: expect.objectContaining({
+        message: "Delivering to WhatsApp requires target <E.164|group JID|newsletter JID>",
+      }),
     });
   });
 
-  describe("normalization failures", () => {
-    it("returns error when normalizeWhatsAppTarget returns null/undefined", () => {
-      vi.mocked(normalize.normalizeWhatsAppTarget).mockReturnValueOnce(null);
-      expectResolutionError({
-        to: "+1234567890",
+  it.each([
+    ["120363123456789@g.us", "implicit"],
+    ["120363999888777@g.us", "heartbeat"],
+    ["120363123456789@newsletter", "implicit"],
+  ])("does not apply DM allowFrom to %s in %s mode", (to, mode) => {
+    expect(resolveWhatsAppOutboundTarget({ to, allowFrom: [SECONDARY_TARGET], mode })).toEqual({
+      ok: true,
+      to,
+    });
+  });
+
+  it.each<[string, ResolveParams["allowFrom"], ResolveParams["mode"]]>([
+    ["wildcard", ["*"], "implicit"],
+    ["empty allowFrom", [], "implicit"],
+    ["matching target", [PRIMARY_TARGET], "implicit"],
+    ["numeric target", [11234567890, SECONDARY_TARGET], "implicit"],
+    ["invalid entry beside matching target", ["invalid", PRIMARY_TARGET], "implicit"],
+    ["whitespace in allowFrom", [`  ${PRIMARY_TARGET}  `], undefined],
+    ["no policy in null mode", undefined, null],
+    ["no policy in unspecified mode", undefined, undefined],
+    ["matching target in heartbeat mode", [PRIMARY_TARGET], "heartbeat"],
+    ["matching target in custom mode", [PRIMARY_TARGET], "broadcast"],
+  ])("allows %s", (_label, allowFrom, mode) => {
+    expect(resolveWhatsAppOutboundTarget({ to: PRIMARY_TARGET, allowFrom, mode })).toEqual({
+      ok: true,
+      to: PRIMARY_TARGET,
+    });
+  });
+
+  it.each(["implicit", "heartbeat", "broadcast"])(
+    "denies an unlisted target in %s mode with its normalized address",
+    (mode) => {
+      expect(
+        resolveWhatsAppOutboundTarget({
+          to: "  +1 (123) 456-7890  ",
+          allowFrom: [SECONDARY_TARGET],
+          mode,
+        }),
+      ).toEqual({
+        ok: false,
+        error: expect.objectContaining({
+          message: `Target "${PRIMARY_TARGET}" is not listed in the configured WhatsApp allowFrom policy.`,
+        }),
+      });
+    },
+  );
+
+  it("trims the resolved target", () => {
+    expect(
+      resolveWhatsAppOutboundTarget({
+        to: `  ${PRIMARY_TARGET}  `,
         allowFrom: undefined,
         mode: undefined,
-      });
-    });
-  });
-
-  describe("group JID handling", () => {
-    it("returns success for valid group JID regardless of mode", () => {
-      vi.mocked(normalize.normalizeWhatsAppTarget).mockReturnValueOnce("120363123456789@g.us");
-      vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(true);
-
-      expectResolutionOk(
-        {
-          to: "120363123456789@g.us",
-          allowFrom: undefined,
-          mode: "implicit",
-        },
-        "120363123456789@g.us",
-      );
-    });
-
-    it("returns success for group JID in heartbeat mode", () => {
-      vi.mocked(normalize.normalizeWhatsAppTarget).mockReturnValueOnce("120363999888777@g.us");
-      vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(true);
-
-      expectResolutionOk(
-        {
-          to: "120363999888777@g.us",
-          allowFrom: undefined,
-          mode: "heartbeat",
-        },
-        "120363999888777@g.us",
-      );
-    });
-  });
-
-  describe("newsletter JID handling", () => {
-    it("returns success for valid newsletter JID without applying DM allowFrom", () => {
-      vi.mocked(normalize.normalizeWhatsAppTarget).mockReturnValueOnce(
-        "120363123456789@newsletter",
-      );
-      vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
-      vi.mocked(normalize.isWhatsAppNewsletterJid).mockReturnValueOnce(true);
-
-      expectResolutionOk(
-        {
-          to: "120363123456789@newsletter",
-          allowFrom: [SECONDARY_TARGET],
-          mode: "implicit",
-        },
-        "120363123456789@newsletter",
-      );
-      expect(vi.mocked(normalize.normalizeWhatsAppTarget)).toHaveBeenCalledOnce();
-      expect(vi.mocked(normalize.normalizeWhatsAppTarget)).toHaveBeenCalledWith(
-        "120363123456789@newsletter",
-      );
-    });
-  });
-
-  describe("implicit/heartbeat mode with allowList", () => {
-    it("allows message when wildcard is present", () => {
-      mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
-      expectAllowedForTarget({ allowFrom: ["*"], mode: "implicit" });
-    });
-
-    it("allows message when allowList is empty", () => {
-      mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
-      expectAllowedForTarget({ allowFrom: [], mode: "implicit" });
-    });
-
-    it("allows message when target is in allowList", () => {
-      mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
-      expectAllowedForTarget({ allowFrom: [PRIMARY_TARGET], mode: "implicit" });
-    });
-
-    it("denies message when target is not in allowList", () => {
-      mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET);
-      expectResolutionErrorMessage(
-        {
-          to: PRIMARY_TARGET,
-          allowFrom: [SECONDARY_TARGET],
-          mode: "implicit",
-        },
-        `Target "${PRIMARY_TARGET}" is not listed in the configured WhatsApp allowFrom policy.`,
-      );
-    });
-
-    it("uses the normalized target in the allowFrom error message", () => {
-      vi.mocked(normalize.normalizeWhatsAppTarget)
-        .mockReturnValueOnce(PRIMARY_TARGET)
-        .mockReturnValueOnce(SECONDARY_TARGET);
-      vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
-
-      expectResolutionErrorMessage(
-        {
-          to: "(123) 456-7890",
-          allowFrom: [SECONDARY_TARGET],
-          mode: "implicit",
-        },
-        `Target "${PRIMARY_TARGET}" is not listed in the configured WhatsApp allowFrom policy.`,
-      );
-    });
-
-    it("handles mixed numeric and string allowList entries", () => {
-      vi.mocked(normalize.normalizeWhatsAppTarget)
-        .mockReturnValueOnce("+11234567890")
-        .mockReturnValueOnce("+11234567890")
-        .mockReturnValueOnce("+11234567890");
-      vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
-
-      expectAllowedForTarget({
-        allowFrom: [1234567890, PRIMARY_TARGET],
-        mode: "implicit",
-      });
-    });
-
-    it("filters out invalid normalized entries from allowList", () => {
-      vi.mocked(normalize.normalizeWhatsAppTarget)
-        .mockReturnValueOnce("+11234567890")
-        .mockReturnValueOnce(null)
-        .mockReturnValueOnce("+11234567890");
-      vi.mocked(normalize.isWhatsAppGroupJid).mockReturnValueOnce(false);
-
-      expectAllowedForTarget({
-        allowFrom: ["invalid", PRIMARY_TARGET],
-        mode: "implicit",
-      });
-    });
-  });
-
-  describe("heartbeat mode", () => {
-    it("allows message when target is in allowList in heartbeat mode", () => {
-      mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
-      expectAllowedForTarget({ allowFrom: [PRIMARY_TARGET], mode: "heartbeat" });
-    });
-
-    it("denies message when target is not in allowList in heartbeat mode", () => {
-      mockNormalizedDirectMessage(PRIMARY_TARGET, SECONDARY_TARGET);
-      expectDeniedForTarget({ allowFrom: [SECONDARY_TARGET], mode: "heartbeat" });
-    });
-  });
-
-  describe("explicit/custom modes", () => {
-    it("allows message in null mode when allowList is not set", () => {
-      mockNormalizedDirectMessage(PRIMARY_TARGET);
-      expectAllowedForTarget({ allowFrom: undefined, mode: null });
-    });
-
-    it("allows message in undefined mode when allowList is not set", () => {
-      mockNormalizedDirectMessage(PRIMARY_TARGET);
-      expectAllowedForTarget({ allowFrom: undefined, mode: undefined });
-    });
-
-    it("enforces allowList in custom mode string", () => {
-      mockNormalizedDirectMessage(SECONDARY_TARGET, PRIMARY_TARGET);
-      expectDeniedForTarget({ allowFrom: [SECONDARY_TARGET], mode: "broadcast" });
-    });
-
-    it("allows message in custom mode string when target is in allowList", () => {
-      mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
-      expectAllowedForTarget({ allowFrom: [PRIMARY_TARGET], mode: "broadcast" });
-    });
-  });
-
-  describe("whitespace handling", () => {
-    it("trims whitespace from to parameter", () => {
-      mockNormalizedDirectMessage(PRIMARY_TARGET);
-
-      expectResolutionOk(
-        {
-          to: `  ${PRIMARY_TARGET}  `,
-          allowFrom: undefined,
-          mode: undefined,
-        },
-        PRIMARY_TARGET,
-      );
-      expect(vi.mocked(normalize.normalizeWhatsAppTarget)).toHaveBeenCalledWith(PRIMARY_TARGET);
-    });
-
-    it("trims whitespace from allowList entries", () => {
-      mockNormalizedDirectMessage(PRIMARY_TARGET, PRIMARY_TARGET);
-
-      resolveWhatsAppOutboundTarget({
-        to: PRIMARY_TARGET,
-        allowFrom: [`  ${PRIMARY_TARGET}  `],
-        mode: undefined,
-      });
-
-      expect(vi.mocked(normalize.normalizeWhatsAppTarget)).toHaveBeenCalledWith(PRIMARY_TARGET);
-    });
+      }),
+    ).toEqual({ ok: true, to: PRIMARY_TARGET });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

WhatsApp target-policy tests script a mocked normalizer and reload a stateless resolver before every case, obscuring the actual input-to-policy contract.

## Why This Change Was Made

Use real target inputs and exact resolution/error outcomes with a static import. Preserve missing/invalid targets, group and newsletter exemptions, wildcard and empty policies, implicit/heartbeat/custom-mode enforcement, formatted-address diagnostics, and trimming. The numeric allowlist row now succeeds only if the numeric entry itself matches, strengthening the old mocked case.

## User Impact

No runtime behavior change. The target-policy test body took 61 ms before and 20 ms after locally. Tests are smaller and exercise actual normalization with policy rather than hand-scripted normalization results.

## Evidence

- Four focused suites pass, 70 tests: target policy, normalization, action authorization, and channel outbound behavior.
- `node scripts/check-changed.mjs -- extensions/whatsapp/src/resolve-outbound-target.test.ts`: changed-file validation.
- Formatting, diff check, owner/caller/sibling review, and structured Codex autoreview.
- Production unchanged. Tests +53/-267 lines, net -214. No mocks or per-case module reloads remain in the changed suite.
