### PR TITLE
test(release): assert current wizard admission contract

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
@@ -746,6 +746,36 @@ fi
 
 CURRENT_PHASE=target-wizard
 echo "Exercising current target Gateway wizard RPC lifecycle"
+# The current setup owner exposes an admission code; the pinned source package only exposes prose.
+assert_target_setup_admission_busy() {
+  local output="$1"
+  local error_output="$2"
+  local label="$3"
+  if node -e '
+    const fs = require("node:fs");
+    try {
+      const payload = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+      process.exit(
+        payload?.ok === false &&
+          payload?.error?.type === "gateway_request_error" &&
+          payload.error.code === "UNAVAILABLE" &&
+          payload.error.details?.code === "SETUP_ADMISSION_BUSY" &&
+          payload.error.retryable === true
+          ? 0
+          : 1,
+      );
+    } catch {
+      process.exit(1);
+    }
+  ' "$output"; then
+    return 0
+  fi
+  echo "$label failed without a retryable SETUP_ADMISSION_BUSY result" >&2
+  openclaw_e2e_print_log "$output" >&2
+  openclaw_e2e_print_log "$error_output" >&2
+  exit 1
+}
+
 wait_for_target_wizard_start() {
   local output="$1"
   local error_output="$2"
@@ -777,8 +807,7 @@ wait_for_target_wizard_start() {
       printf '%s\t%s\n' "$session_id" "$polls"
       return 0
     fi
-    assert_gateway_call_error_message \
-      "$output" "$error_output" "wizard already running" "$label"
+    assert_target_setup_admission_busy "$output" "$error_output" "$label"
     sleep 0.2
   done
   echo "timed out waiting for $label" >&2
@@ -865,10 +894,9 @@ if gateway_call wizard.start '{"mode":"local"}' \
   echo "target wizard.start unexpectedly allowed an overlapping setup session" >&2
   exit 1
 fi
-assert_gateway_call_error_message \
+assert_target_setup_admission_busy \
   "$TARGET_WIZARD_DUPLICATE_JSON" \
   "$TARGET_WIZARD_DUPLICATE_ERR" \
-  "wizard already running" \
   "target overlapping wizard.start"
 
 gateway_call wizard.cancel "$target_active_session_params" \

--- a/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
+++ b/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
@@ -134,9 +134,6 @@ describe("update.run package self-upgrade producer", () => {
       'gateway_call wizard.next "$target_active_next_params" \\\n  "$TARGET_WIZARD_NEXT_JSON" "$TARGET_WIZARD_NEXT_ERR"',
     );
     expect(script).toContain(
-      '"$TARGET_WIZARD_DUPLICATE_JSON" \\\n  "$TARGET_WIZARD_DUPLICATE_ERR" \\\n  "wizard already running"',
-    );
-    expect(script).toContain(
       'gateway_call wizard.cancel "$target_active_session_params" \\\n  "$TARGET_WIZARD_CANCEL_JSON" "$TARGET_WIZARD_CANCEL_ERR"',
     );
     expect(script).toContain("wait_for_target_wizard_start()");

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -4611,6 +4611,109 @@ exit ${exitCode}
   );
 
   it.each([
+    ["target overlap", "busy", 0],
+    ["target settlement", "busy", 0],
+    ["target overlap", "legacy", 1],
+    ["target settlement", "other-detail", 1],
+    ["target overlap", "not-retryable", 1],
+    ["target overlap", "wrong-type", 1],
+    ["target overlap", "success", 1],
+    ["source overlap", "legacy", 0],
+    ["source overlap", "legacy-stderr", 0],
+  ] as const)(
+    "checks self-upgrade %s against its package contract: %s",
+    (phase, fixture, exitCode) => {
+      const workDir = tempDirs.make("openclaw-self-upgrade-wizard-");
+      const source = readFileSync(
+        "scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh",
+        "utf8",
+      );
+      const assertions = source.slice(
+        source.indexOf("assert_gateway_call_error_message() {"),
+        source.indexOf("\ngateway_call channels.status"),
+      );
+      const targetStart = source.indexOf("CURRENT_PHASE=target-wizard");
+      const waitStart = source.indexOf("wait_for_target_wizard_start() {", targetStart);
+      const waitEnd = source.indexOf("\n}\n", waitStart) + 3;
+      const overlapStart = source.indexOf(
+        "if gateway_call wizard.start",
+        phase === "source overlap" ? 0 : waitEnd,
+      );
+      const overlapEnd = source.indexOf("\ngateway_call wizard.cancel", overlapStart);
+      const invocation =
+        phase === "target settlement"
+          ? 'wait_for_target_wizard_start "$OUTPUT" "$ERROR_OUTPUT" "target settlement"'
+          : source.slice(overlapStart, overlapEnd);
+      const error = fixture.startsWith("legacy")
+        ? { type: "gateway_request_error", code: "UNAVAILABLE", message: "wizard already running" }
+        : {
+            type: fixture === "wrong-type" ? "transport_error" : "gateway_request_error",
+            code: "UNAVAILABLE",
+            message: "Setup admission is busy.",
+            details: {
+              code: fixture === "other-detail" ? "OTHER_FAILURE" : "SETUP_ADMISSION_BUSY",
+            },
+            retryable: fixture !== "not-retryable",
+          };
+      writeFileSync(
+        join(workDir, "response.json"),
+        JSON.stringify({ ok: fixture === "success", error }),
+      );
+      writeFileSync(join(workDir, "calls"), "");
+      const result = spawnSync(
+        "bash",
+        [
+          "-c",
+          `set -euo pipefail
+${assertions}
+${source.slice(targetStart, waitEnd)}
+openclaw_e2e_print_log() { cat "$1"; }
+gateway_call() {
+  printf '%s\\n' "$1" >>"$PROBE_CALLS"
+  : >"$4"
+  if [ "$(wc -l <"$PROBE_CALLS")" -eq 1 ]; then
+    if [ "$PROBE_FIXTURE" = legacy-stderr ]; then
+      : >"$3"
+      printf 'wizard already running\\n' >"$4"
+    else
+      cat "$PROBE_RESPONSE" >"$3"
+    fi
+    [ "$PROBE_FIXTURE" = success ]
+  else
+    printf '{"sessionId":"replacement","done":false,"status":"running","step":{"id":"ready"}}\\n' >"$3"
+  fi
+}
+${invocation}
+`,
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            PROBE_CALLS: join(workDir, "calls"),
+            PROBE_RESPONSE: join(workDir, "response.json"),
+            PROBE_FIXTURE: fixture,
+            OUTPUT: join(workDir, "output.json"),
+            ERROR_OUTPUT: join(workDir, "error.txt"),
+            TARGET_WIZARD_DUPLICATE_JSON: join(workDir, "output.json"),
+            TARGET_WIZARD_DUPLICATE_ERR: join(workDir, "error.txt"),
+            WIZARD_DUPLICATE_JSON: join(workDir, "output.json"),
+            WIZARD_DUPLICATE_ERR: join(workDir, "error.txt"),
+          },
+        },
+      );
+      expect(result.status, result.stdout + result.stderr).toBe(exitCode);
+      const expectedCalls = phase === "target settlement" && exitCode === 0 ? 2 : 1;
+      expect(readFileSync(join(workDir, "calls"), "utf8").trim().split("\n")).toEqual(
+        Array(expectedCalls).fill("wizard.start"),
+      );
+      if (phase === "target settlement" && exitCode === 0) {
+        expect(result.stdout).toMatch(/replacement\t2\s*$/u);
+      }
+    },
+  );
+
+  it.each([
     ["direct failure", 42, false],
     ["substitution failure", 42, false],
     ["assertion after success", 43, false],


### PR DESCRIPTION
## Why

The full release verification's package self-upgrade lane failed after a successful upgrade because it expected the old wizard-busy prose from the current target. Current Gateway setup admission deliberately returns a retryable `UNAVAILABLE` error with `details.code: SETUP_ADMISSION_BUSY`.

Use one strict structured-envelope assertion for both target overlap rejection and cancellation settlement. Keep the historical JSON/stderr prose contract only for the pinned 2026.4.26 source package. Generic errors, wrong detail codes, non-retryable errors, and unexpected success still fail the test. No timeout, retry budget, runtime, configuration, schema, or permission change.

## Proof

- Three intended regression failures before the fix; all nine executable wizard-contract cases and six existing launcher/diagnostics cases pass with it.
- [Native package proof](https://github.com/openclaw/openclaw/actions/runs/33375370680): authenticated published 2026.4.26 → published 2026.8.1 `update.run` passed in 275.151s, including supervised service restart, both wizard lifecycles, target admission/cancellation settlement, Gateway health/readiness/status, plugin install-state survival, and QA polling after restart.
- This proves the published-package upgrade, not an arbitrary new main artifact. Separate baseline setup repair #133802 is already landed and is not duplicated here. The complete release run remains a separate gate.
- Bash syntax and formatting pass. Managed Codex review of the complete three-file PR is scoped-clean at P0–P2 with no actionable findings. All 14 checks in the actual three-path changed-files gate passed, including root test types and scripts lint. All three native source hashes match published head `7e3690030357ddb4596d5b9ad047a46aed1dc535`.
- Hosted CI exposed one additional obsolete source-text assertion demanding the target's legacy error wording. Reproduced 1 failed/7 passed before deleting only that three-line assertion; both complete affected test files now pass all **279 tests**, with no name filters or removed test cases. The new executable shell cases retain stronger behavior coverage. The real package proof remains valid because its executable bytes are unchanged.
- [Final native proof](https://github.com/openclaw/openclaw/actions/runs/33380976968) is complete and the Testbox is closed. Required exact-head GitHub CI remains the final merge gate.

Runtime production delta: 0. Release test tooling: +28 net lines for the shared current-target assertion; tests: +100 net lines (+103 executable regression lines, −3 obsolete text-assertion lines). This is an internal test repair, so no changelog entry.
