### PR TITLE
fix: prevent Doctor from rolling back migratable config

### DIFF
--- a/src/commands/doctor-config-preflight.test.ts
+++ b/src/commands/doctor-config-preflight.test.ts
@@ -534,8 +534,9 @@ describe("runDoctorConfigPreflight", () => {
     },
   );
 
-  it("migrates a readable active config before considering last-known-good", async () => {
+  it("migrates readable active config after preserving its state locators", async () => {
     await withTempHome(async (home) => {
+      const storePath = path.join(home, "custom-cron", "jobs.json");
       const configPath = await writeOpenClawConfig(home, {
         gateway: { mode: "local", port: 19091 },
       });
@@ -545,6 +546,7 @@ describe("runDoctorConfigPreflight", () => {
         `${JSON.stringify(
           {
             gateway: { mode: "local", port: 19092 },
+            cron: { store: storePath },
             session: { idleMinutes: 45 },
             channels: {
               discord: {
@@ -560,7 +562,7 @@ describe("runDoctorConfigPreflight", () => {
 
       const repaired = await withEnvOverride({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
         runDoctorConfigPreflight({
-          migrateState: false,
+          migrateState: true,
           migrateLegacyConfig: false,
           repairPrefixedConfig: true,
           invalidConfigNote: false,
@@ -574,6 +576,7 @@ describe("runDoctorConfigPreflight", () => {
         "channels.discord.guilds.100.channels.general.enabled",
         true,
       );
+      expect(readConfigMachineState("cron.store")).toBe(storePath);
       const migratedRaw = await fs.readFile(configPath, "utf-8");
       const entries = await fs.readdir(path.dirname(configPath));
       expect(entries.filter((entry) => entry.startsWith("openclaw.json.clobbered."))).toEqual([]);

--- a/src/commands/doctor-config-preflight.test.ts
+++ b/src/commands/doctor-config-preflight.test.ts
@@ -486,12 +486,14 @@ describe("runDoctorConfigPreflight", () => {
       });
       expect(inspectOnly.snapshot.valid).toBe(false);
 
-      const repaired = await runDoctorConfigPreflight({
-        migrateState: false,
-        migrateLegacyConfig: false,
-        repairPrefixedConfig: true,
-        invalidConfigNote: false,
-      });
+      const repaired = await withEnvOverride({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
+        runDoctorConfigPreflight({
+          migrateState: false,
+          migrateLegacyConfig: false,
+          repairPrefixedConfig: true,
+          invalidConfigNote: false,
+        }),
+      );
 
       expect(repaired.snapshot.valid).toBe(true);
       expect(repaired.snapshot.config.gateway?.mode).toBe("local");
@@ -531,6 +533,63 @@ describe("runDoctorConfigPreflight", () => {
       });
     },
   );
+
+  it("migrates a readable active config before considering last-known-good", async () => {
+    await withTempHome(async (home) => {
+      const configPath = await writeOpenClawConfig(home, {
+        gateway: { mode: "local", port: 19091 },
+      });
+      await promoteConfigSnapshotToLastKnownGood(await readConfigFileSnapshot());
+      await fs.writeFile(
+        configPath,
+        `${JSON.stringify(
+          {
+            gateway: { mode: "local", port: 19092 },
+            session: { idleMinutes: 45 },
+            channels: {
+              discord: {
+                guilds: { "100": { channels: { general: { allow: true } } } },
+              },
+            },
+          },
+          null,
+          2,
+        )}\n`,
+        "utf-8",
+      );
+
+      const repaired = await withEnvOverride({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
+        runDoctorConfigPreflight({
+          migrateState: false,
+          migrateLegacyConfig: false,
+          repairPrefixedConfig: true,
+          invalidConfigNote: false,
+        }),
+      );
+
+      expect(repaired.snapshot.valid).toBe(true);
+      expect(repaired.snapshot.config.gateway?.port).toBe(19092);
+      expect(repaired.snapshot.config).toHaveProperty("session.reset.idleMinutes", 45);
+      expect(repaired.snapshot.config).toHaveProperty(
+        "channels.discord.guilds.100.channels.general.enabled",
+        true,
+      );
+      const migratedRaw = await fs.readFile(configPath, "utf-8");
+      const entries = await fs.readdir(path.dirname(configPath));
+      expect(entries.filter((entry) => entry.startsWith("openclaw.json.clobbered."))).toEqual([]);
+
+      const converged = await withEnvOverride({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
+        runDoctorConfigPreflight({
+          migrateState: false,
+          migrateLegacyConfig: false,
+          repairPrefixedConfig: true,
+          invalidConfigNote: false,
+        }),
+      );
+      expect(converged.snapshot.valid).toBe(true);
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(migratedRaw);
+    });
+  });
 
   it("preserves the active config when last-known-good cannot converge", async () => {
     await withTempHome(async (home) => {
@@ -643,16 +702,40 @@ describe("runDoctorConfigPreflight", () => {
         "utf-8",
       );
 
-      const repaired = await runDoctorConfigPreflight({
-        migrateState: false,
-        migrateLegacyConfig: false,
-        repairPrefixedConfig: true,
-        invalidConfigNote: false,
-      });
+      const repaired = await withEnvOverride({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
+        runDoctorConfigPreflight({
+          migrateState: false,
+          migrateLegacyConfig: false,
+          repairPrefixedConfig: true,
+          invalidConfigNote: false,
+        }),
+      );
 
       expect(repaired.snapshot.valid).toBe(true);
       expect(repaired.snapshot.config.gateway?.port).toBe(19091);
       await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(lastGoodRaw);
+      const entries = await fs.readdir(path.dirname(configPath));
+      const clobbered = entries.filter((entry) => entry.startsWith("openclaw.json.clobbered."));
+      expect(clobbered).toHaveLength(1);
+      await expect(
+        fs.readFile(path.join(path.dirname(configPath), clobbered[0]!), "utf-8"),
+      ).resolves.toContain('"port": 19092');
+
+      const converged = await withEnvOverride({ OPENCLAW_UPDATE_IN_PROGRESS: "1" }, () =>
+        runDoctorConfigPreflight({
+          migrateState: false,
+          migrateLegacyConfig: false,
+          repairPrefixedConfig: true,
+          invalidConfigNote: false,
+        }),
+      );
+      expect(converged.snapshot.valid).toBe(true);
+      await expect(fs.readFile(configPath, "utf-8")).resolves.toBe(lastGoodRaw);
+      expect(
+        (await fs.readdir(path.dirname(configPath))).filter((entry) =>
+          entry.startsWith("openclaw.json.clobbered."),
+        ),
+      ).toEqual(clobbered);
     });
   });
 });

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -324,10 +324,11 @@ export async function runDoctorConfigPreflight(
     }
 
     let snapshot = configSnapshotRead.snapshot;
+    let activeConfigRepair: ReturnType<typeof planAutomaticConfigRepair> = null;
     if (options.repairPrefixedConfig === true && snapshot.exists && !snapshot.valid) {
       // Migrate readable active bytes before rollback; otherwise one retired key can discard
       // newer valid settings that the canonical Doctor migration would preserve.
-      const activeConfigRepair =
+      activeConfigRepair =
         typeof snapshot.raw === "string" && parseConfigJson5(snapshot.raw).ok
           ? runWithPluginMetadataSnapshot(
               { config: snapshot.sourceConfig ?? snapshot.config ?? {} },
@@ -335,21 +336,15 @@ export async function runDoctorConfigPreflight(
             )
           : null;
       let configRepaired = false;
-      if (activeConfigRepair) {
-        await commitAutomaticConfigRepair(activeConfigRepair, snapshot);
-        note(
-          `Migrated legacy config keys in the active openclaw.json:\n${activeConfigRepair.changes.map((entry) => `- ${entry}`).join("\n")}`,
-          "Doctor changes",
-        );
-        configRepaired = true;
-      } else if (await recoverConfigFromJsonRootSuffix(snapshot)) {
+      if (!activeConfigRepair && (await recoverConfigFromJsonRootSuffix(snapshot))) {
         note(
           "Removed non-JSON prefix from openclaw.json; original saved as .clobbered.*.",
           "Config",
         );
         configRepaired = true;
       } else if (
-        await recoverConfigFromLastKnownGood({ snapshot, reason: "doctor-invalid-config" })
+        !activeConfigRepair &&
+        (await recoverConfigFromLastKnownGood({ snapshot, reason: "doctor-invalid-config" }))
       ) {
         note(
           "Restored openclaw.json from last-known-good; original saved as .clobbered.*.",
@@ -377,6 +372,7 @@ export async function runDoctorConfigPreflight(
       invalidConfigNote &&
       snapshot.exists &&
       !snapshot.valid &&
+      !activeConfigRepair &&
       snapshot.legacyIssues.length === 0
     ) {
       note(invalidConfigNote, "Config");
@@ -394,14 +390,15 @@ export async function runDoctorConfigPreflight(
     }
 
     let baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};
-    const automaticStartupRepair =
-      gatewayStartupCheckpointRequired &&
+    const automaticConfigRepair =
+      activeConfigRepair ??
+      (gatewayStartupCheckpointRequired &&
       !snapshot.valid &&
       !shouldSkipPluginValidationForDoctorConfigPreflight()
         ? runWithPluginMetadataSnapshot({ config: baseConfig }, () =>
             planAutomaticConfigRepair(snapshot),
           )
-        : null;
+        : null);
     const stateMigrationInput = resolveStateMigrationConfigInput({ snapshot, baseConfig });
     if (migrationCheckpoint) {
       migrationCheckpointIdentity = resolveMigrationCheckpointIdentity({
@@ -447,7 +444,7 @@ export async function runDoctorConfigPreflight(
           ),
         );
       }
-      if (gatewayStartupCheckpointRequired && (snapshot.valid || automaticStartupRepair)) {
+      if (gatewayStartupCheckpointRequired && (snapshot.valid || automaticConfigRepair)) {
         if (!startupMigrationLease) {
           throw new Error("Startup plugin host-link repair requires the startup migration lease.");
         }
@@ -600,15 +597,14 @@ export async function runDoctorConfigPreflight(
       );
     }
     // State migrations must consume retired locators before the config write removes them.
-    // Keep them on disk on failure or interruption so the next startup can retry safely.
+    // Explicit Doctor repair commits after that attempt; startup still requires clean migration.
     if (
-      automaticStartupRepair &&
-      migrationCheckpoint &&
+      automaticConfigRepair &&
       stateMigrationsAllowed &&
       freshConfigGuardAllowed &&
-      startupMigrationWarnings.length === 0
+      (activeConfigRepair || startupMigrationWarnings.length === 0)
     ) {
-      if (!startupMigrationLease) {
+      if (gatewayStartupCheckpointRequired && !startupMigrationLease) {
         throw new Error("Automatic startup config repair requires the startup migration lease.");
       }
       // No snapshot argument: the guard re-reads the config from disk, so an external
@@ -621,14 +617,14 @@ export async function runDoctorConfigPreflight(
       if (!configRepairAllowed) {
         throwStartupMigrationGuardRejected();
       }
-      startupMigrationLease.heartbeat();
-      await measurePreflightStep("startup-config-repair", () =>
-        runWithPluginMetadataSnapshot({ config: automaticStartupRepair.config }, () =>
-          commitAutomaticConfigRepair(automaticStartupRepair, snapshot),
+      startupMigrationLease?.heartbeat();
+      await measurePreflightStep("automatic-config-repair", () =>
+        runWithPluginMetadataSnapshot({ config: automaticConfigRepair.config }, () =>
+          commitAutomaticConfigRepair(automaticConfigRepair, snapshot),
         ),
       );
       note(
-        `Migrated legacy config keys at startup:\n${automaticStartupRepair.changes.map((entry) => `- ${entry}`).join("\n")}`,
+        `Migrated legacy config keys${activeConfigRepair ? " in the active openclaw.json" : " at startup"}:\n${automaticConfigRepair.changes.map((entry) => `- ${entry}`).join("\n")}`,
         "Doctor changes",
       );
       configSnapshotRead = await readConfigSnapshotForPreflight(false);
@@ -642,7 +638,9 @@ export async function runDoctorConfigPreflight(
       ) {
         throwStartupMigrationGuardRejected();
       }
-      refreshMigrationCheckpoint(migrationCheckpoint, configSnapshotRead);
+      if (migrationCheckpoint) {
+        refreshMigrationCheckpoint(migrationCheckpoint, configSnapshotRead);
+      }
     }
     if (
       migrationCheckpoint &&

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -44,8 +44,8 @@ import {
 } from "./doctor-startup-migration-refusal.js";
 import type { CronCodexRuntimePolicyTarget } from "./doctor/cron/store-migration.js";
 import {
-  commitStartupConfigRepair,
-  planStartupConfigRepair,
+  commitAutomaticConfigRepair,
+  planAutomaticConfigRepair,
 } from "./doctor/shared/automatic-startup-config-repair.js";
 import { resolveStateMigrationConfigInput } from "./doctor/shared/legacy-config-state-migration-input.js";
 import { createDoctorPluginMetadataSnapshotScope } from "./doctor/shared/plugin-metadata-snapshot-scope.js";
@@ -325,13 +325,29 @@ export async function runDoctorConfigPreflight(
 
     let snapshot = configSnapshotRead.snapshot;
     if (options.repairPrefixedConfig === true && snapshot.exists && !snapshot.valid) {
-      if (await recoverConfigFromJsonRootSuffix(snapshot)) {
+      // Migrate readable active bytes before rollback; otherwise one retired key can discard
+      // newer valid settings that the canonical Doctor migration would preserve.
+      const activeConfigRepair =
+        typeof snapshot.raw === "string" && parseConfigJson5(snapshot.raw).ok
+          ? runWithPluginMetadataSnapshot(
+              { config: snapshot.sourceConfig ?? snapshot.config ?? {} },
+              () => planAutomaticConfigRepair(snapshot),
+            )
+          : null;
+      let configRepaired = false;
+      if (activeConfigRepair) {
+        await commitAutomaticConfigRepair(activeConfigRepair, snapshot);
+        note(
+          `Migrated legacy config keys in the active openclaw.json:\n${activeConfigRepair.changes.map((entry) => `- ${entry}`).join("\n")}`,
+          "Doctor changes",
+        );
+        configRepaired = true;
+      } else if (await recoverConfigFromJsonRootSuffix(snapshot)) {
         note(
           "Removed non-JSON prefix from openclaw.json; original saved as .clobbered.*.",
           "Config",
         );
-        configSnapshotRead = await readConfigSnapshotForPreflight(false);
-        snapshot = configSnapshotRead.snapshot;
+        configRepaired = true;
       } else if (
         await recoverConfigFromLastKnownGood({ snapshot, reason: "doctor-invalid-config" })
       ) {
@@ -339,6 +355,9 @@ export async function runDoctorConfigPreflight(
           "Restored openclaw.json from last-known-good; original saved as .clobbered.*.",
           "Config",
         );
+        configRepaired = true;
+      }
+      if (configRepaired) {
         configSnapshotRead = await readConfigSnapshotForPreflight(false);
         snapshot = configSnapshotRead.snapshot;
       }
@@ -380,7 +399,7 @@ export async function runDoctorConfigPreflight(
       !snapshot.valid &&
       !shouldSkipPluginValidationForDoctorConfigPreflight()
         ? runWithPluginMetadataSnapshot({ config: baseConfig }, () =>
-            planStartupConfigRepair(snapshot),
+            planAutomaticConfigRepair(snapshot),
           )
         : null;
     const stateMigrationInput = resolveStateMigrationConfigInput({ snapshot, baseConfig });
@@ -605,7 +624,7 @@ export async function runDoctorConfigPreflight(
       startupMigrationLease.heartbeat();
       await measurePreflightStep("startup-config-repair", () =>
         runWithPluginMetadataSnapshot({ config: automaticStartupRepair.config }, () =>
-          commitStartupConfigRepair(automaticStartupRepair, snapshot),
+          commitAutomaticConfigRepair(automaticStartupRepair, snapshot),
         ),
       );
       note(

--- a/src/commands/doctor/shared/automatic-startup-config-repair.test.ts
+++ b/src/commands/doctor/shared/automatic-startup-config-repair.test.ts
@@ -8,7 +8,7 @@ import { validateConfigObjectWithPlugins } from "../../../config/validation.js";
 import { VERSION } from "../../../version.js";
 import {
   isStartupConfigRepairResult,
-  planStartupConfigRepair,
+  planAutomaticConfigRepair,
   resolveStartupConfigSnapshot,
 } from "./automatic-startup-config-repair.js";
 
@@ -41,11 +41,11 @@ describe("automatic startup config repair", () => {
       issuePaths: ["session.idleMinutes"],
     });
 
-    const plan = planStartupConfigRepair(snapshot);
+    const plan = planAutomaticConfigRepair(snapshot);
 
     expect(plan?.config.session).toEqual({ reset: { mode: "idle", idleMinutes: 45 } });
     expect(validateConfigObjectWithPlugins(plan?.config).ok).toBe(true);
-    expect(planStartupConfigRepair(snapshot)?.config).toEqual(plan?.config);
+    expect(planAutomaticConfigRepair(snapshot)?.config).toEqual(plan?.config);
     expect(snapshot.sourceConfig.session).toEqual({ idleMinutes: 45 });
   });
 
@@ -65,7 +65,7 @@ describe("automatic startup config repair", () => {
       issuePaths: ["meta", "agents.defaults.heartbeat"],
     });
 
-    const plan = planStartupConfigRepair(snapshot);
+    const plan = planAutomaticConfigRepair(snapshot);
 
     expect(plan?.config).toEqual({
       meta: { lastTouchedVersion: "2026.7.1-2" },
@@ -200,6 +200,6 @@ describe("automatic startup config repair", () => {
       includedPaths,
     });
 
-    expect(planStartupConfigRepair(snapshot)).toBeNull();
+    expect(planAutomaticConfigRepair(snapshot)).toBeNull();
   });
 });

--- a/src/commands/doctor/shared/automatic-startup-config-repair.ts
+++ b/src/commands/doctor/shared/automatic-startup-config-repair.ts
@@ -15,13 +15,13 @@ import {
 import { applyLegacyDoctorMigrations } from "./legacy-config-compat.js";
 import { findDoctorLegacyConfigIssues } from "./legacy-config-issues.js";
 
-type StartupConfigRepairPlan = {
+type AutomaticConfigRepairPlan = {
   config: OpenClawConfig;
   snapshot: ConfigFileSnapshot;
   changes: string[];
 };
 
-function admitStartupConfigRepairSnapshot(snapshot: ConfigFileSnapshot): boolean {
+function admitAutomaticConfigRepairSnapshot(snapshot: ConfigFileSnapshot): boolean {
   return (
     !snapshot.valid &&
     snapshot.exists &&
@@ -31,11 +31,11 @@ function admitStartupConfigRepairSnapshot(snapshot: ConfigFileSnapshot): boolean
   );
 }
 
-function buildStartupConfigRepairPlan(
+function buildAutomaticConfigRepairPlan(
   snapshot: ConfigFileSnapshot,
   config: OpenClawConfig,
   changes: string[],
-): StartupConfigRepairPlan {
+): AutomaticConfigRepairPlan {
   return {
     config,
     changes,
@@ -52,11 +52,11 @@ function buildStartupConfigRepairPlan(
   };
 }
 
-/** Admits only complete, deterministic single-file legacy migrations for startup. */
-export function planStartupConfigRepair(
+/** Admits only complete, deterministic single-file legacy migrations. */
+export function planAutomaticConfigRepair(
   snapshot: ConfigFileSnapshot,
-): StartupConfigRepairPlan | null {
-  if (!admitStartupConfigRepairSnapshot(snapshot)) {
+): AutomaticConfigRepairPlan | null {
+  if (!admitAutomaticConfigRepairSnapshot(snapshot)) {
     return null;
   }
 
@@ -73,7 +73,7 @@ export function planStartupConfigRepair(
     return null;
   }
 
-  return buildStartupConfigRepairPlan(snapshot, config, changes);
+  return buildAutomaticConfigRepairPlan(snapshot, config, changes);
 }
 
 /**
@@ -85,8 +85,8 @@ export function planStartupConfigRepair(
  */
 function planStartupConfigRepairPreview(
   snapshot: ConfigFileSnapshot,
-): StartupConfigRepairPlan | null {
-  if (!admitStartupConfigRepairSnapshot(snapshot)) {
+): AutomaticConfigRepairPlan | null {
+  if (!admitAutomaticConfigRepairSnapshot(snapshot)) {
     return null;
   }
 
@@ -104,7 +104,7 @@ function planStartupConfigRepairPreview(
     return null;
   }
 
-  return buildStartupConfigRepairPlan(snapshot, config, changes);
+  return buildAutomaticConfigRepairPlan(snapshot, config, changes);
 }
 
 /**
@@ -120,7 +120,7 @@ export function resolveStartupConfigSnapshot(snapshot: ConfigFileSnapshot) {
     return snapshot;
   }
   try {
-    return planStartupConfigRepair(snapshot)?.snapshot;
+    return planAutomaticConfigRepair(snapshot)?.snapshot;
   } catch {
     return planStartupConfigRepairPreview(snapshot)?.snapshot;
   }
@@ -131,7 +131,7 @@ export function isStartupConfigRepairResult(
   before: ConfigFileSnapshot,
   after: ConfigFileSnapshot,
 ): boolean {
-  const plan = planStartupConfigRepair(before);
+  const plan = planAutomaticConfigRepair(before);
   const expected = plan
     ? stampConfigWriteMetadata(
         applyUnsetPathsForWrite(plan.config, resolveManagedUnsetPathsForWrite(undefined)),
@@ -148,15 +148,15 @@ export function isStartupConfigRepairResult(
   );
 }
 
-/** Commits a planned repair against the exact snapshot admitted under the startup lease. */
-export async function commitStartupConfigRepair(
-  plan: StartupConfigRepairPlan,
+/** Commits a planned repair against the exact snapshot admitted by its caller. */
+export async function commitAutomaticConfigRepair(
+  plan: AutomaticConfigRepairPlan,
   snapshot: ConfigFileSnapshot,
 ): Promise<void> {
   await replaceConfigFile({
     nextConfig: plan.config,
     snapshot,
-    afterWrite: { mode: "none", reason: "startup migration" },
+    afterWrite: { mode: "none", reason: "automatic migration" },
     writeOptions: {
       auditOrigin: "doctor",
       skipOutputLogs: true,


### PR DESCRIPTION
Closes #90551

## What Problem This Solves

Fixes an issue where `openclaw update` could replace a newer readable configuration with stale last-known-good data when Doctor could have migrated the active file safely.

## Why This Change Was Made

Doctor now sends a readable active candidate through the existing canonical migration planner and complete validation boundary before whole-file recovery. It keeps the migrated active file only when the complete candidate validates, while prefix repair and last-known-good remain the fallback paths.

This adds no config surface, compatibility reader, or migration registry.

## User Impact

Operators keep newer valid settings when a retired key can be migrated. Unrecoverable configurations still restore last-known-good and preserve the rejected active bytes as `.clobbered.*`.

## Evidence

- Red on current main `9b4c3d5f1b216884872452a7c780b13320298b5d`: Doctor restored last-known-good port `19091` over newer active port `19092`; the discarded active file remained in `.clobbered.*`.
- Green on `d17a989f60e576836aa052c0158ed34c747d0242`: 40 focused Doctor config and state-migration tests pass.
- Coverage includes the core `session.idleMinutes` migration, the Discord channel `allow` migration, a newer active sentinel, custom `cron.store` state-locator preservation, fallback, `.clobbered.*` preservation, and second-run convergence.
- Formatting, targeted lint, max-lines, assertion-safety, test-temp, and diff checks pass.
- Exact source-CLI green was not run because Doctor attempts to build missing Control UI assets in a source checkout, while this host explicitly forbids local builds. Exact-head CI owns build and TypeScript checks.

Production LOC: +57/-40 (net +17). Tests: +103/-17. The production growth adds the active-candidate preservation boundary; the shared planner rename is net zero.
