### PR TITLE
perf(workers): reuse validated hashes during workspace activation

### DIFF
--- a/src/gateway/worker-environments/workspace-actual-manifest.ts
+++ b/src/gateway/worker-environments/workspace-actual-manifest.ts
@@ -58,7 +58,7 @@ export async function readWorkspaceFileSnapshotWithLimit(
     constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK,
   );
   try {
-    const { memo: hashMemo, metrics } = activeWorkspaceHashContext() ?? {};
+    const { memo: hashMemo, metrics, owner = "gateway" } = activeWorkspaceHashContext() ?? {};
     const before = await handle.stat({ bigint: true });
     const realPath = await resolveOpenedFileRealPathForHandle(handle, expectedPath);
     if (!before.isFile() || (root && !isPathInside(root, realPath))) {
@@ -67,7 +67,7 @@ export async function readWorkspaceFileSnapshotWithLimit(
     if (before.size > BigInt(maxBytes)) {
       return { type: "unsupported" };
     }
-    const identity = workspaceStatIdentity("gateway", before);
+    const identity = workspaceStatIdentity(owner, before);
     let sha256 = hashMemo?.get(identity);
     let size = Number(before.size);
     if (sha256) {
@@ -97,7 +97,7 @@ export async function readWorkspaceFileSnapshotWithLimit(
       }
     }
     const after = await handle.stat({ bigint: true });
-    if (after.size !== BigInt(size) || workspaceStatIdentity("gateway", after) !== identity) {
+    if (after.size !== BigInt(size) || workspaceStatIdentity(owner, after) !== identity) {
       throw new Error("Gateway workspace file changed while it was being read");
     }
     hashMemo?.set(identity, sha256);

--- a/src/gateway/worker-environments/workspace-hash-memo.test.ts
+++ b/src/gateway/worker-environments/workspace-hash-memo.test.ts
@@ -11,6 +11,7 @@ import {
   recordRemoteWorkspaceHashMetrics,
   serializeRemoteWorkspaceHashMemo,
   withWorkspaceHashMemo,
+  withWorkerWorkspaceHashMemo,
   type WorkspaceHashMemo,
 } from "./workspace-hash-memo.js";
 import { MAX_RECONCILIATION_ENTRIES, type WorkerWorkspaceManifest } from "./workspace-manifest.js";
@@ -191,6 +192,11 @@ describe("workspace hash memo", () => {
     );
     expect(envelopeBytes).toBeLessThan(MAX_WORKSPACE_HASH_MEMO_BYTES);
     expect(MAX_WORKSPACE_HASH_MEMO_BYTES - envelopeBytes).toBeGreaterThan(3 * 1024 * 1024);
+    const smallFile = "worker:0:0:1:0:0";
+    memo.set(smallFile, "c".repeat(64));
+    const bounded = JSON.parse(serializeRemoteWorkspaceHashMemo(memo)) as [string, string][];
+    expect(bounded).toHaveLength(MAX_RECONCILIATION_ENTRIES);
+    expect(bounded.some(([identity]) => identity === smallFile)).toBe(false);
   });
 
   it("reuses hashes only for matching stat identities in one remote reconcile", async () => {
@@ -218,6 +224,13 @@ describe("workspace hash memo", () => {
 
     const first = await capture([]);
     expect(first.metrics).toMatchObject({ contentHashCount: 1, memoHitCount: 0 });
+    const nodeMemo: WorkspaceHashMemo = new Map();
+    await withWorkerWorkspaceHashMemo(nodeMemo, () =>
+      readActualWorkspaceManifest({ root: workspace, baseCommit: null }),
+    );
+    const nodeValidated = await capture([...nodeMemo]);
+    expect(nodeValidated.manifestRef).toBe(first.manifestRef);
+    expect(nodeValidated.metrics).toMatchObject({ contentHashCount: 0, memoHitCount: 1 });
     const unchanged = await capture(first.memo);
     expect(unchanged.manifestRef).toBe(first.manifestRef);
     expect(unchanged.metrics).toMatchObject({ contentHashCount: 0, memoHitCount: 1 });
@@ -238,6 +251,17 @@ describe("workspace hash memo", () => {
     const nextReconcile = await capture([]);
     expect(nextReconcile.manifestRef).toBe(replaced.manifestRef);
     expect(nextReconcile.metrics).toMatchObject({ contentHashCount: 1, memoHitCount: 0 });
+
+    await fs.chmod(target, 0o755);
+    const executable = await capture(replaced.memo);
+    if (process.platform !== "win32") {
+      expect(executable.manifestRef).not.toBe(replaced.manifestRef);
+    }
+    await fs.unlink(target);
+    await fs.symlink("other.txt", target);
+    const symlink = await capture(executable.memo);
+    expect(symlink.manifestRef).not.toBe(executable.manifestRef);
+    expect(symlink.metrics).toMatchObject({ contentHashCount: 0, memoHitCount: 0 });
   });
 
   it("bounds the remote memo to the largest files and reports truncation", async () => {

--- a/src/gateway/worker-environments/workspace-hash-memo.ts
+++ b/src/gateway/worker-environments/workspace-hash-memo.ts
@@ -80,6 +80,7 @@ export function replaceWorkerWorkspaceHashMemoEntries(
 type WorkspaceHashContext = {
   memo: WorkspaceHashMemo;
   metrics?: WorkspaceHashMetrics;
+  owner: "gateway" | "worker";
 };
 
 const workspaceHashContext = new AsyncLocalStorage<WorkspaceHashContext>();
@@ -116,7 +117,18 @@ export async function withWorkspaceHashMemo<T>(
   if (active?.memo === memo && active.metrics === inheritedMetrics) {
     return await operation();
   }
-  return await workspaceHashContext.run({ memo, metrics: inheritedMetrics }, operation);
+  return await workspaceHashContext.run(
+    { memo, metrics: inheritedMetrics, owner: active?.owner ?? "gateway" },
+    operation,
+  );
+}
+
+/** Shares hashes validated on the node with its final manifest capture. */
+export async function withWorkerWorkspaceHashMemo<T>(
+  memo: WorkspaceHashMemo,
+  operation: () => Promise<T>,
+): Promise<T> {
+  return await workspaceHashContext.run({ memo, owner: "worker" }, operation);
 }
 
 export async function withWorkspaceHashContext<T>(operation: () => Promise<T>): Promise<T> {
@@ -151,16 +163,41 @@ export function takeWorkspaceHashMemo(
   return memo;
 }
 
-export function serializeRemoteWorkspaceHashMemo(memo: WorkspaceHashMemo): string {
-  const serialized = JSON.stringify(
-    [...memo]
-      .filter(([identity]) => identity.startsWith("worker:"))
-      .toSorted(([left], [right]) => left.localeCompare(right)),
-  );
-  if (Buffer.byteLength(serialized) > MAX_WORKSPACE_HASH_MEMO_BYTES) {
-    throw new Error("Workspace hash memo exceeds its byte limit");
+/** Self-contained for the node script; preserve the largest hashes within both wire limits. */
+export function selectWorkerWorkspaceHashMemoEntries(
+  memo: ReadonlyMap<string, string>,
+  maxEntries: number,
+  maxBytes: number,
+): Array<[string, string]> {
+  const compareIdentity = ([left]: [string, string], [right]: [string, string]) =>
+    left < right ? -1 : left > right ? 1 : 0;
+  const candidates = [...memo]
+    .filter(([identity]) => identity.startsWith("worker:"))
+    .map((entry) => ({ entry, size: Number(entry[0].split(":")[3]) }))
+    .toSorted((left, right) => right.size - left.size || compareIdentity(left.entry, right.entry));
+  const selected: Array<[string, string]> = [];
+  let bytes = 2;
+  for (const { entry } of candidates) {
+    if (selected.length === maxEntries) {
+      break;
+    }
+    const entryBytes = Buffer.byteLength(JSON.stringify(entry)) + (selected.length > 0 ? 1 : 0);
+    if (bytes + entryBytes <= maxBytes) {
+      selected.push(entry);
+      bytes += entryBytes;
+    }
   }
-  return serialized;
+  return selected.toSorted(compareIdentity);
+}
+
+export function serializeRemoteWorkspaceHashMemo(memo: WorkspaceHashMemo): string {
+  return JSON.stringify(
+    selectWorkerWorkspaceHashMemoEntries(
+      memo,
+      MAX_RECONCILIATION_ENTRIES,
+      MAX_WORKSPACE_HASH_MEMO_BYTES,
+    ),
+  );
 }
 
 export function recordRemoteWorkspaceHashMetrics(

--- a/src/gateway/worker-environments/workspace-sync-scripts.ts
+++ b/src/gateway/worker-environments/workspace-sync-scripts.ts
@@ -1,5 +1,9 @@
 import { STAGED_INPUT_GIT_PATHSPEC } from "../../media/staged-inputs.js";
-import { MAX_WORKSPACE_HASH_MEMO_BYTES, workspaceStatIdentity } from "./workspace-hash-memo.js";
+import {
+  MAX_WORKSPACE_HASH_MEMO_BYTES,
+  selectWorkerWorkspaceHashMemoEntries,
+  workspaceStatIdentity,
+} from "./workspace-hash-memo.js";
 import {
   MAX_WORKSPACE_GIT_CANDIDATES,
   MAX_WORKSPACE_INVENTORY_ENTRIES,
@@ -74,8 +78,9 @@ const fs = require("node:fs");
 const path = require("node:path");
 ${WORKSPACE_PATH_EXCLUSIONS_JS}
 const workspaceStatIdentity = ${workspaceStatIdentity.toString()};
+const selectWorkerWorkspaceHashMemoEntries = ${selectWorkerWorkspaceHashMemoEntries.toString()};
 const MAX_RECONCILIATION_ENTRIES = ${MAX_RECONCILIATION_ENTRIES};
-const MAX_HASH_MEMO_BYTES = ${MAX_WORKSPACE_HASH_MEMO_BYTES};
+const MAX_WORKSPACE_HASH_MEMO_BYTES = ${MAX_WORKSPACE_HASH_MEMO_BYTES};
 const root = fs.realpathSync(process.argv[1]);
 ${WORKSPACE_STAGED_INPUT_OWNERSHIP_JS}
 const requestedBaseCommit = process.argv[2] || null;
@@ -105,13 +110,10 @@ const startedAt = performance.now();
 function fail(message) {
   throw new Error(message);
 }
-function compareHashMemoIdentity(left, right) {
-  return left < right ? -1 : left > right ? 1 : 0;
-}
 function readHashMemo() {
   if (!memoMode) return new Map();
   const raw = fs.readFileSync(0, "utf8");
-  if (Buffer.byteLength(raw) > MAX_HASH_MEMO_BYTES) {
+  if (Buffer.byteLength(raw) > MAX_WORKSPACE_HASH_MEMO_BYTES) {
     fail("workspace hash memo exceeds its byte limit");
   }
   let entries;
@@ -384,7 +386,7 @@ async function hashFiles(entries) {
       entry.mode = Number(after.mode & 0o777n);
       entry.size = Number(after.size);
       entry.sha256 = sha256;
-      usedHashMemo.set(identity, { sha256, size: Number(after.size) });
+      usedHashMemo.set(identity, sha256);
     } finally {
       await handle.close();
     }
@@ -485,16 +487,9 @@ async function main() {
   const digest = publishManifest(manifestRoot, manifest);
   const manifestRef = "sha256:" + digest;
   if (memoMode) {
-    // Largest files preserve the most expensive hashes. Identity tie-breaking and
-    // final ordering keep the bounded cache deterministic across captures.
-    const memo = [...usedHashMemo]
-      .sort(
-        (left, right) =>
-          right[1].size - left[1].size || compareHashMemoIdentity(left[0], right[0]),
-      )
-      .slice(0, MAX_RECONCILIATION_ENTRIES)
-      .map(([identity, value]) => [identity, value.sha256])
-      .sort((left, right) => compareHashMemoIdentity(left[0], right[0]));
+    const memo = selectWorkerWorkspaceHashMemoEntries(
+      usedHashMemo, MAX_RECONCILIATION_ENTRIES, MAX_WORKSPACE_HASH_MEMO_BYTES,
+    );
     metrics.memoTruncatedCount = usedHashMemo.size - memo.length;
     const measured = { ...metrics, totalDurationMs: performance.now() - startedAt };
     process.stdout.write(JSON.stringify({

--- a/src/node-host/node-worker-transfer-client.git.test.ts
+++ b/src/node-host/node-worker-transfer-client.git.test.ts
@@ -114,16 +114,25 @@ describe("node worker Git transfers", () => {
       description: "reuses Git-base tracked files without requesting unavailable blobs",
       changed: false,
       replaceSymlinkAncestor: false,
+      lateWrite: false,
     },
     {
       description: "downloads changed and nested files without restoring deleted Git-base paths",
       changed: true,
       replaceSymlinkAncestor: false,
+      lateWrite: false,
     },
     {
       description: "replaces a Git-base symlink ancestor without changing files outside staging",
       changed: false,
       replaceSymlinkAncestor: true,
+      lateWrite: false,
+    },
+    {
+      description: "preserves the prior workspace when a matched base file changes before capture",
+      changed: true,
+      replaceSymlinkAncestor: false,
+      lateWrite: true,
     },
   ];
   it.each([
@@ -135,11 +144,12 @@ describe("node worker Git transfers", () => {
       description: "handles a prepared project cache " + seedState,
       changed: false,
       replaceSymlinkAncestor: false,
+      lateWrite: false,
       seedState,
     })),
   ])(
     "$description (prepared project: $seedState)",
-    async ({ changed, replaceSymlinkAncestor, seedState }) => {
+    async ({ changed, replaceSymlinkAncestor, lateWrite, seedState }) => {
       transferDebug.mockClear();
       const root = tempDirs.make("node-worker-transfer-git-");
       const source = path.join(root, "source");
@@ -187,7 +197,7 @@ describe("node worker Git transfers", () => {
           }
         }
       }
-      if (invalidSeed) {
+      if (invalidSeed || lateWrite) {
         await fs.mkdir(workspaceDir);
         await fs.writeFile(path.join(workspaceDir, "previous.txt"), "preserve prior workspace\n");
       }
@@ -250,6 +260,16 @@ describe("node worker Git transfers", () => {
             requestedBlobs.push(sha256);
             const file = filesByHash.get(sha256);
             if (file) {
+              if (lateWrite && sha256 === tracked.sha256) {
+                const staging = (await fs.readdir(root)).find((name) =>
+                  name.startsWith(".workspace.workspace-transfer-"),
+                );
+                expect(staging).toBeDefined();
+                const script = path.join(root, staging!, "script.sh");
+                const original = await fs.stat(script);
+                await fs.writeFile(script, "#!/bin/sh\nexit 1\n");
+                await fs.utimes(script, original.atime, original.mtime);
+              }
               const body = await fs.readFile(file);
               res.writeHead(200, { "content-length": String(body.byteLength) });
               res.end(body);
@@ -270,6 +290,7 @@ describe("node worker Git transfers", () => {
           environmentId: "environment-git",
           workspaceDir,
           manifestHome: root,
+          hashMemo: new Map(),
           transfer: {
             direction: "download",
             token: "test-token",
@@ -280,6 +301,17 @@ describe("node worker Git transfers", () => {
         if (invalidSeed) {
           await expect(transfer).rejects.toThrow("prepared project seed is invalid");
           expect(requestedPacks).toBe(0);
+          expect(await fs.readFile(path.join(workspaceDir, "previous.txt"), "utf8")).toBe(
+            "preserve prior workspace\n",
+          );
+          return;
+        }
+        if (lateWrite) {
+          await expect(transfer).rejects.toMatchObject({
+            cause: expect.objectContaining({
+              message: expect.stringContaining("materialized a different manifest"),
+            }),
+          });
           expect(await fs.readFile(path.join(workspaceDir, "previous.txt"), "utf8")).toBe(
             "preserve prior workspace\n",
           );
@@ -309,6 +341,15 @@ describe("node worker Git transfers", () => {
           changed ? "script.sh" : "tracked.txt",
         );
         expect(requestedBlobs).toEqual([...filesByHash.keys()]);
+        expect(transferDebug).toHaveBeenCalledWith(
+          "node worker manifest capture completed",
+          expect.objectContaining({
+            contentHashCount: downloadablePaths.size,
+            memoHitCount:
+              snapshot.manifest.entries.filter((entry) => entry.type === "file").length -
+              downloadablePaths.size,
+          }),
+        );
         await expect(git(workspaceDir, ["rev-parse", "HEAD"])).resolves.toBe(commit);
         if (changed) {
           await expect(fs.access(path.join(workspaceDir, "deleted.txt"))).rejects.toMatchObject({

--- a/src/node-host/node-worker-transfer-client.ts
+++ b/src/node-host/node-worker-transfer-client.ts
@@ -6,7 +6,11 @@ import type { ClientRequest, IncomingMessage } from "node:http";
 import path from "node:path";
 import type { CloudflareAccessCredentials } from "../../packages/gateway-client/src/cloudflare-access.js";
 import { boundedWorkerError } from "../gateway/worker-environments/worker-error.js";
-import type { WorkspaceHashMemo } from "../gateway/worker-environments/workspace-hash-memo.js";
+import {
+  replaceWorkerWorkspaceHashMemoEntries,
+  withWorkerWorkspaceHashMemo,
+  type WorkspaceHashMemo,
+} from "../gateway/worker-environments/workspace-hash-memo.js";
 import {
   MAX_WORKSPACE_MANIFEST_BYTES,
   MAX_WORKSPACE_INVENTORY_TOTAL_BYTES,
@@ -385,55 +389,58 @@ async function downloadWorkspace(params: {
       }
     }
     const blobApplyStartedAt = performance.now();
+    const stagingHashMemo: WorkspaceHashMemo = new Map();
     for (const directory of manifest.directories ?? []) {
       await fsp.mkdir(workspacePath(staging, directory), {
         recursive: true,
         mode: 0o700,
       });
     }
-    for (const entry of manifest.entries) {
-      const destination = workspacePath(staging, entry.path);
-      const materializedEntry =
-        process.platform === "win32" && entry.type === "file" && entry.mode === 0o755
-          ? { ...entry, mode: 0o644 }
-          : entry;
-      if (manifest.baseCommit && (await absoluteEntryMatches(destination, materializedEntry))) {
-        continue;
+    await withWorkerWorkspaceHashMemo(stagingHashMemo, async () => {
+      for (const entry of manifest.entries) {
+        const destination = workspacePath(staging, entry.path);
+        const materializedEntry =
+          process.platform === "win32" && entry.type === "file" && entry.mode === 0o755
+            ? { ...entry, mode: 0o644 }
+            : entry;
+        if (manifest.baseCommit && (await absoluteEntryMatches(destination, materializedEntry))) {
+          continue;
+        }
+        await fsp.mkdir(path.dirname(destination), {
+          recursive: true,
+          mode: 0o700,
+        });
+        await fsp.rm(destination, { recursive: true, force: true });
+        if (entry.type === "symlink") {
+          await fsp.symlink(entry.target, destination);
+          continue;
+        }
+        await downloadFile({
+          request: {
+            gatewayUrl: params.gatewayUrl,
+            tlsFingerprint: params.tlsFingerprint,
+            cloudflareAccess: params.cloudflareAccess,
+            routePath: nodeWorkspaceTransferBlobPath(params.environmentId, entry.sha256),
+            method: "GET",
+            token: params.transfer.token,
+            signal: params.signal,
+          },
+          destination,
+          expectedBytes: entry.size,
+          expectedSha256: entry.sha256,
+        });
+        await fsp.chmod(destination, entry.mode);
       }
-      await fsp.mkdir(path.dirname(destination), {
-        recursive: true,
-        mode: 0o700,
-      });
-      await fsp.rm(destination, { recursive: true, force: true });
-      if (entry.type === "symlink") {
-        await fsp.symlink(entry.target, destination);
-        continue;
-      }
-      await downloadFile({
-        request: {
-          gatewayUrl: params.gatewayUrl,
-          tlsFingerprint: params.tlsFingerprint,
-          cloudflareAccess: params.cloudflareAccess,
-          routePath: nodeWorkspaceTransferBlobPath(params.environmentId, entry.sha256),
-          method: "GET",
-          token: params.transfer.token,
-          signal: params.signal,
-        },
-        destination,
-        expectedBytes: entry.size,
-        expectedSha256: entry.sha256,
-      });
-      await fsp.chmod(destination, entry.mode);
-    }
+    });
     const blobApplyMs = performance.now() - blobApplyStartedAt;
-    // Staging identities are fresh, so this capture re-hashes; its memo output
-    // survives the rename into workspaceDir and seeds the next upload capture.
+    // Reuse only hashes validated on this staging filesystem. Capture still checks
+    // the complete tree and current handle identities before the atomic replacement.
     const observed = await captureManifest({
       workspaceDir: staging,
       manifestHome: params.manifestHome,
       baseCommit: manifest.baseCommit,
       referenceManifestRef: params.transfer.manifestRef,
-      ...(params.hashMemo === undefined ? {} : { hashMemo: params.hashMemo }),
+      hashMemo: stagingHashMemo,
       signal: params.signal,
     });
     if (observed !== params.transfer.manifestRef) {
@@ -468,6 +475,9 @@ async function downloadWorkspace(params: {
       }
     } else {
       await replaceWorkspace(params.workspaceDir, staging);
+    }
+    if (params.hashMemo) {
+      replaceWorkerWorkspaceHashMemoEntries(params.hashMemo, [...stagingHashMemo]);
     }
     transferLog.debug("node worker workspace transfer completed", {
       environmentId: params.environmentId,

--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -14,7 +14,10 @@ import { buildCachedChatItems } from "../chat-thread.ts";
 import { agentEvent, createHost } from "../tool-stream.test-helpers.ts";
 import { handleAgentEvent } from "../tool-stream.ts";
 import { renderChatNotice } from "./chat-divider.ts";
-import { getChatMediaRenderVersion } from "./chat-message-media.ts";
+import {
+  getChatMediaRenderVersion,
+  releaseChatMediaResourceSubscriber,
+} from "./chat-message-media.ts";
 import {
   dismissConfirmedActionPopovers,
   renderActivityGroup,
@@ -26,6 +29,7 @@ import { renderTurnRecapRow } from "./chat-working-indicator.ts";
 import "./chat-sidebar.ts";
 
 const localStorageValues = new Map<string, string>();
+const mediaSubscribers = new Set<() => void>();
 const renderMarkdownHtml = markdown.toSanitizedMarkdownHtml;
 const markdownRenderMock = vi.fn(
   (value: string, _options?: { codeBlockChrome?: "copy" | "none"; fileLinks?: boolean }) => value,
@@ -214,6 +218,9 @@ function renderTestMessageGroup(
   group: MessageGroup,
   opts: Partial<RenderMessageGroupOptions> = {},
 ) {
+  if (opts.onRequestUpdate) {
+    mediaSubscribers.add(opts.onRequestUpdate);
+  }
   return renderMessageGroup(group, {
     showReasoning: true,
     showToolCalls: true,
@@ -656,6 +663,11 @@ function mediaTicketPayload(mediaTicket: string, ttlMs = 5 * 60 * 1000) {
 }
 
 afterEach(() => {
+  // These detached render fixtures own the callbacks a live chat pane normally releases.
+  for (const subscriber of mediaSubscribers) {
+    releaseChatMediaResourceSubscriber(subscriber);
+  }
+  mediaSubscribers.clear();
   markdownRenderMock.mockClear();
   document.querySelectorAll("[data-confirmed-action-fixture]").forEach((element) => {
     dismissConfirmedActionPopovers(element);


### PR DESCRIPTION
## What Problem This Solves

Initial node workspace synchronization reads unchanged Git-base files twice: once to decide whether an overlay download is needed, then again to verify the final workspace manifest. This repeats disk reads and hashing even when a project snapshot already supplies the Git objects.

## What Changed

The first integrity check used the shared file reader's Gateway-owned hash context; the node's final manifest capture accepts worker-owned hashes. A fresh worker-owned memo now belongs to staging-file comparisons and carries those validated hashes into final capture. The full tree scan, open-handle before/after identity checks, mode and symlink handling, expected-manifest comparison and atomic workspace replacement remain. The generation receives the bounded memo only after successful replacement; failed staging preserves the prior workspace and memo.

One shared selector applies the existing largest-file retention policy, deterministic identity ordering, 25,000-entry limit and 8 MiB serialized limit to both capture input and output. It parses file size once per candidate. Gateway sibling paths retain Gateway-owned identities. The memo stays in memory with unchanged serialized memo/manifest formats; no configuration, persistence, dependency, cloud API or transport-protocol change is included.

The chat-media fixture also releases each detached subscriber through the actual callback owner, fixing leaked retry work across tests. Existing assertions and deadlines remain. Main now owns the Gateway recovery fixture and timer corrections in #134207; superseded local repairs were removed during integration. Upstream header restoration and the compiled Anthropic startup smoke remain intact.

Production is **+108/-66 (net +42)** across four modules. Hash regressions are **+67/-2**; ancillary tests are **+13/-1**. Growth supplies explicit hash ownership and staging lifetime while removing the separate remote selection policy; much of the transfer-loop diff is indentation around that scoped operation.

## Validation

- Actual readers and manifest script reproduced **1,114,112 content bytes** read for base matching and the same bytes read again during original final capture. The candidate returns the identical manifest with **zero second-pass content hashes and two memo hits**. These are byte/operation counts, not wall-clock or end-to-end cloud measurements.
- The pre-fix Git-transfer suite has **7 expected failures, 3 passes and 1 Windows-only skip**. The candidate transfer/Git/memo suites pass **19 tests with 1 Windows-only skip**. Prepared-seed and downloaded-pack late writes reject the changed staged manifest and preserve the previous workspace; download/upload reuse, changed/deleted files, links, executable modes and memo limits remain covered. The parse-once selector refinement passes six cases.
- An unminified build of the actual manifest owner emits a working standalone capture script: one initial hash, then zero hashes and one memo hit with an identical manifest. This is not a full application build.
- The media fixture followed by header cases fails before cleanup across the real five-second retry boundary and passes afterward. Five relevant suites pass 332 cases; the final uninstrumented header suite passes 50. The final patch adds no diagnostic delay, retry, broader mock or weaker assertion.
- All selected static gates passed on the prior candidate. The refreshed branch preserves every hash/UI file byte-for-byte and uses the canonical upstream recovery fixtures without modification. Both retained commits are patch-identical; only the superseded local fixture repairs were dropped.
- Independent source review and scoped Codex reviews found no actionable findings; the service reviews were scoped to P0. Normal commit hooks pass.

[CI for the previous reviewed head `bb30718f`](https://github.com/openclaw/openclaw/actions/runs/33407572835) passed, including both Windows lanes and types. An earlier compiled Anthropic Windows case passed in 8.312s with one native loader hit and zero source transforms. [Windows case evidence](https://github.com/openclaw/openclaw/actions/runs/33404797672/job/99530153501).

The current head `98a8eccc34951c884bf1145c2403cbfa6157a6dc` is rebased onto `ace8a13` with fresh whole-candidate scoped review and normal hooks passing. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33415829551) passed, including the required gate, both Windows lanes and core test types. The bounded CLI watcher timed out while its aggregate run state lagged; the actual completed check records establish this result. No full Gateway/application build or new cloud-session speedup is claimed for this patch.

Latest ClawSweeper review of this exact head found no actionable defects; its remaining maintainer-handling item is covered by this maintainer review and landing. Its stored-schema classification is a heuristic false positive: this patch changes only the in-memory memo owner and shared selection logic, with no SQLite schema or serialized memo/manifest format change.
