### PR TITLE
fix(macos): avoid release packaging failures and slow notes

### DIFF
--- a/scripts/changelog-to-html.sh
+++ b/scripts/changelog-to-html.sh
@@ -42,17 +42,18 @@ extract_version_section() {
 }
 
 markdown_to_html() {
-  local text=$1
-  text=$(echo "$text" | sed 's/^##### \(.*\)$/<h5>\1<\/h5>/')
-  text=$(echo "$text" | sed 's/^#### \(.*\)$/<h4>\1<\/h4>/')
-  text=$(echo "$text" | sed 's/^### \(.*\)$/<h3>\1<\/h3>/')
-  text=$(echo "$text" | sed 's/^## \(.*\)$/<h2>\1<\/h2>/')
-  text=$(echo "$text" | sed 's/^- \*\*\([^*]*\)\*\*\(.*\)$/<li><strong>\1<\/strong>\2<\/li>/')
-  text=$(echo "$text" | sed 's/^- \([^*].*\)$/<li>\1<\/li>/')
-  text=$(echo "$text" | sed 's/\*\*\([^*]*\)\*\*/<strong>\1<\/strong>/g')
-  text=$(echo "$text" | sed 's/`\([^`]*\)`/<code>\1<\/code>/g')
-  text=$(echo "$text" | sed 's/\[\([^]]*\)\](\([^)]*\))/<a href="\2">\1<\/a>/g')
-  echo "$text"
+  # Keep substitution order and literal HTML unchanged, but process the whole
+  # section once instead of spawning nine sed processes for every changelog line.
+  sed \
+    -e 's/^##### \(.*\)$/<h5>\1<\/h5>/' \
+    -e 's/^#### \(.*\)$/<h4>\1<\/h4>/' \
+    -e 's/^### \(.*\)$/<h3>\1<\/h3>/' \
+    -e 's/^## \(.*\)$/<h2>\1<\/h2>/' \
+    -e 's/^- \*\*\([^*]*\)\*\*\(.*\)$/<li><strong>\1<\/strong>\2<\/li>/' \
+    -e 's/^- \([^*].*\)$/<li>\1<\/li>/' \
+    -e 's/\*\*\([^*]*\)\*\*/<strong>\1<\/strong>/g' \
+    -e 's/`\([^`]*\)`/<code>\1<\/code>/g' \
+    -e 's/\[\([^]]*\)\](\([^)]*\))/<a href="\2">\1<\/a>/g'
 }
 
 version_content=$(extract_version_section "$VERSION" "$CHANGELOG_FILE")
@@ -65,27 +66,29 @@ fi
 
 echo "<h2>OpenClaw $VERSION</h2>"
 
-in_list=false
-while IFS= read -r line; do
-  if [[ "$line" =~ ^- ]]; then
-    if [[ "$in_list" == false ]]; then
-      echo "<ul>"
-      in_list=true
+{
+  in_list=false
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^- ]]; then
+      if [[ "$in_list" == false ]]; then
+        echo "<ul>"
+        in_list=true
+      fi
+      printf '%s\n' "$line"
+    else
+      if [[ "$in_list" == true ]]; then
+        echo "</ul>"
+        in_list=false
+      fi
+      if [[ -n "$line" ]]; then
+        printf '%s\n' "$line"
+      fi
     fi
-    markdown_to_html "$line"
-  else
-    if [[ "$in_list" == true ]]; then
-      echo "</ul>"
-      in_list=false
-    fi
-    if [[ -n "$line" ]]; then
-      markdown_to_html "$line"
-    fi
-  fi
-done <<< "$version_content"
+  done <<< "$version_content"
 
-if [[ "$in_list" == true ]]; then
-  echo "</ul>"
-fi
+  if [[ "$in_list" == true ]]; then
+    echo "</ul>"
+  fi
+} | markdown_to_html
 
 echo "<p><a href=\"https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md\">View full changelog</a></p>"

--- a/scripts/create-dmg.sh
+++ b/scripts/create-dmg.sh
@@ -162,15 +162,13 @@ mkdir -p "$DMG_SOURCE" "$MOUNT_POINT"
 cp -R "$APP_PATH" "$DMG_SOURCE/"
 ln -s /Applications "$DMG_SOURCE/Applications"
 
-APP_SIZE_MB=$(du -sm "$APP_PATH" | awk '{print $1}')
-DMG_SIZE_MB=$((APP_SIZE_MB + 80))
-
+# Let -srcfolder account for filesystem overhead; du plus fixed slack can
+# underallocate bundles containing many small runtime files.
 hdiutil create \
   -volname "$DMG_VOLUME_NAME" \
   -srcfolder "$DMG_SOURCE" \
   -ov \
   -format UDRW \
-  -size "${DMG_SIZE_MB}m" \
   "$DMG_RW_PATH"
 
 hdiutil attach "$DMG_RW_PATH" -mountpoint "$MOUNT_POINT" -nobrowse

--- a/scripts/package-mac-dist.sh
+++ b/scripts/package-mac-dist.sh
@@ -243,12 +243,10 @@ if [[ "$SKIP_DSYM" != "1" ]]; then
   DSYM_PATHS=()
   MISSING_DSYM_ARCHS=()
   for arch in "${DSYM_ARCHS[@]}"; do
-    if [[ ! -d "$BUILD_ROOT/$arch" ]]; then
-      MISSING_DSYM_ARCHS+=("$arch")
-      continue
-    fi
-    DSYM_FOR_ARCH="$(find "$BUILD_ROOT/$arch" -type d -path "*/$BUILD_CONFIG/$PRODUCT.dSYM" -print -quit)"
-    if [[ -n "$DSYM_FOR_ARCH" ]]; then
+    # Use the same SwiftPM output link as package-mac-app.sh; Xcode builds
+    # place products under out/Products/Release rather than a lowercase directory.
+    DSYM_FOR_ARCH="$BUILD_ROOT/$arch/$BUILD_CONFIG/$PRODUCT.dSYM"
+    if [[ -d "$DSYM_FOR_ARCH" ]]; then
       DSYM_PATHS+=("$DSYM_FOR_ARCH")
     else
       MISSING_DSYM_ARCHS+=("$arch")

--- a/test/scripts/changelog-to-html.test.ts
+++ b/test/scripts/changelog-to-html.test.ts
@@ -1,0 +1,101 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+const roots: string[] = [];
+const footer =
+  '<p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>';
+
+function render(section: string, version = "2026.8.2") {
+  const root = mkdtempSync(path.join(tmpdir(), "openclaw-changelog-html-"));
+  roots.push(root);
+  const file = path.join(root, "CHANGELOG.md");
+  writeFileSync(file, section);
+  return spawnSync("bash", ["scripts/changelog-to-html.sh", version, file], {
+    encoding: "utf8",
+    timeout: 10_000,
+    maxBuffer: 4 * 1024 * 1024,
+  });
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+describe("changelog release HTML", () => {
+  it("preserves markup ordering, literal HTML, links, backslashes and list boundaries", () => {
+    const result = render(
+      [
+        "# Changelog",
+        "## 2026.8.2 (Unreleased)",
+        "",
+        "### Highlights",
+        "- **Fast** & reliable `path\\file`",
+        "- [Guide](https://example.com?a=1&b=2) and **bold**",
+        "",
+        "#### Details",
+        "<p>Existing &amp; HTML</p>",
+        "##### More",
+        "- Plain <tag>",
+        "## 2026.8.1",
+        "- Old release",
+      ].join("\n"),
+    );
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe(
+      [
+        "<h2>OpenClaw 2026.8.2</h2>",
+        "<h3>Highlights</h3>",
+        "<ul>",
+        "<li><strong>Fast</strong> & reliable <code>path\\file</code></li>",
+        '<li><a href="https://example.com?a=1&b=2">Guide</a> and <strong>bold</strong></li>',
+        "</ul>",
+        "<h4>Details</h4>",
+        "<p>Existing &amp; HTML</p>",
+        "<h5>More</h5>",
+        "<ul>",
+        "<li>Plain <tag></li>",
+        "</ul>",
+        footer,
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("renders a release-sized appendix within the command budget without losing entries", () => {
+    const entries = Array.from(
+      { length: 2_000 },
+      (_, index) =>
+        `- **Fix ${index}**: preserve \`bytes\` & [credit](https://example.com/${index})`,
+    );
+    const result = render(`## 2026.8.2\n\n### Contributions\n${entries.join("\n")}\n`);
+    expect(result.error).toBeUndefined();
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe(
+      [
+        "<h2>OpenClaw 2026.8.2</h2>",
+        "<h3>Contributions</h3>",
+        "<ul>",
+        ...entries.map(
+          (_, index) =>
+            `<li><strong>Fix ${index}</strong>: preserve <code>bytes</code> & <a href="https://example.com/${index}">credit</a></li>`,
+        ),
+        "</ul>",
+        footer,
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("keeps the missing-version fallback", () => {
+    const result = render("## 2026.8.1\n- Previous release\n");
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe(
+      `<h2>OpenClaw 2026.8.2</h2>\n<p>Latest OpenClaw update.</p>\n${footer}\n`,
+    );
+  });
+});

--- a/test/scripts/create-dmg.test.ts
+++ b/test/scripts/create-dmg.test.ts
@@ -282,6 +282,11 @@ describe.runIf(process.platform === "darwin")("create-dmg ownership boundaries",
     const log = readFileSync(tools.hdiutilLog, "utf8");
     expectPrivateDmgMount(log);
     expect(log).toContain("convert ");
+    // hdiutil sizes -srcfolder images with filesystem overhead; an explicit
+    // byte estimate underallocates bundles containing many small files.
+    const create = log.split("\n").find((line) => line.startsWith("create "));
+    expect(create).toContain("-srcfolder ");
+    expect(create).not.toMatch(/\s-(?:size|megabytes|sectors)\s/);
     expect(log).toContain("final.dmg");
     expect(log).toContain(`${outputDir}${path.sep}.openclaw-dmg.`);
     expect(log).not.toContain(sibling);

--- a/test/scripts/package-mac-dist.test.ts
+++ b/test/scripts/package-mac-dist.test.ts
@@ -1,12 +1,99 @@
 // Package Mac Dist tests cover package mac dist script behavior.
 import { spawnSync } from "node:child_process";
-import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 
 const tempDirs: string[] = [];
 const scriptPath = "scripts/package-mac-dist.sh";
+
+function makeDistributionFixture(layout: "native" | "xcode", missingArch?: string) {
+  const root = mkdtempSync(path.join(tmpdir(), "openclaw-dist-symbols-"));
+  tempDirs.push(root);
+  const scripts = path.join(root, "scripts");
+  const tools = path.join(root, "tools");
+  mkdirSync(path.join(scripts, "lib"), { recursive: true });
+  mkdirSync(tools);
+  for (const file of ["package-mac-dist.sh", "lib/plistbuddy.sh", "lib/swift-toolchain.sh"]) {
+    copyFileSync(path.join("scripts", file), path.join(scripts, file));
+  }
+  const executable = (file: string, body: string) => {
+    writeFileSync(file, `#!/usr/bin/env bash\nset -euo pipefail\n${body}\n`, { mode: 0o755 });
+  };
+  executable(path.join(scripts, "package-mac-app.sh"), "exit 0");
+  executable(path.join(tools, "swift"), "echo 'Apple Swift version 6.3'");
+  executable(path.join(tools, "xcrun"), "echo 'Xcode 26.4'");
+  executable(path.join(tools, "node"), "echo 2608000290");
+  const contents = path.join(root, "dist", "OpenClaw.app", "Contents");
+  mkdirSync(contents, { recursive: true });
+  writeFileSync(
+    path.join(contents, "Info.plist"),
+    `<plist version="1.0"><dict>
+<key>CFBundleShortVersionString</key><string>2026.8.2</string>
+<key>CFBundleVersion</key><string>2608000290</string>
+<key>CFBundleIdentifier</key><string>ai.openclaw.mac</string>
+<key>SUFeedURL</key><string>https://example.com/appcast.xml</string>
+</dict></plist>`,
+  );
+  const source = path.join(root, "main.c");
+  writeFileSync(source, "int main(void) { return 0; }\n");
+  const expectedUUIDs: string[] = [];
+  for (const arch of ["arm64", "x86_64"]) {
+    const build = path.join(root, "apps", "macos", ".build", arch);
+    const products = path.join(
+      build,
+      layout === "xcode" ? "out/Products/Release" : `${arch}-apple-macosx/release`,
+    );
+    mkdirSync(products, { recursive: true });
+    symlinkSync(path.relative(build, products), path.join(build, "release"));
+    if (arch === missingArch) {
+      continue;
+    }
+    const binary = path.join(products, "OpenClaw");
+    const symbols = `${binary}.dSYM`;
+    for (const args of [
+      ["clang", "-arch", arch, "-g", source, "-o", binary],
+      ["dsymutil", binary, "-o", symbols],
+    ]) {
+      const result = spawnSync("xcrun", args, { encoding: "utf8" });
+      expect(result.status, result.stderr).toBe(0);
+    }
+    const uuid = spawnSync("xcrun", ["dwarfdump", "--uuid", binary], { encoding: "utf8" });
+    expect(uuid.status, uuid.stderr).toBe(0);
+    expectedUUIDs.push(uuid.stdout.trim().split(" ").slice(0, 3).join(" "));
+  }
+  return {
+    root,
+    expectedUUIDs,
+    run: () =>
+      spawnSync("bash", [path.join(scripts, "package-mac-dist.sh")], {
+        cwd: root,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${tools}:/usr/bin:/bin`,
+          APP_VERSION: "2026.8.2",
+          APP_BUILD: "2608000290",
+          BUILD_CONFIG: "release",
+          BUILD_ARCHS: "all",
+          SKIP_NOTARIZE: "1",
+          SKIP_DMG: "1",
+          SKIP_DSYM: "0",
+        },
+      }),
+  };
+}
 
 function makePlist(): string {
   const dir = mkdtempSync(path.join(tmpdir(), "openclaw-dist-plist-"));
@@ -404,7 +491,6 @@ describe("package-mac-dist plist validation", () => {
     const dsymBlock = script.slice(script.indexOf('if [[ "$SKIP_DSYM" != "1" ]]'));
 
     expect(dsymBlock).toContain('for arch in "${DSYM_ARCHS[@]}"');
-    expect(dsymBlock).toContain('if [[ ! -d "$BUILD_ROOT/$arch" ]]; then');
     expect(dsymBlock).toContain('MISSING_DSYM_ARCHS+=("$arch")');
     expect(dsymBlock).toContain("Error: dSYM not found for architecture(s):");
     expect(dsymBlock).not.toContain('find "$BUILD_ROOT/arm64"');
@@ -441,4 +527,41 @@ describe("package-mac-dist plist validation", () => {
       expect(result.stderr).toContain("Does Not Exist");
     },
   );
+});
+
+describe.runIf(process.platform === "darwin")("package-mac-dist symbol archives", () => {
+  it.each(["native", "xcode"] as const)(
+    "archives matching universal symbols from the %s build output",
+    (layout) => {
+      const fixture = makeDistributionFixture(layout);
+      const result = fixture.run();
+      expect(result.status, result.stderr).toBe(0);
+      const archive = path.join(fixture.root, "dist", "OpenClaw-2026.8.2.dSYM.zip");
+      const extracted = path.join(fixture.root, "extracted");
+      const unpack = spawnSync("ditto", ["-x", "-k", archive, extracted], { encoding: "utf8" });
+      expect(unpack.status, unpack.stderr).toBe(0);
+      const uuid = spawnSync(
+        "xcrun",
+        ["dwarfdump", "--uuid", path.join(extracted, "OpenClaw.dSYM")],
+        { encoding: "utf8" },
+      );
+      expect(uuid.status, uuid.stderr).toBe(0);
+      expect(
+        uuid.stdout
+          .trim()
+          .split("\n")
+          .map((line) => line.split(" ").slice(0, 3).join(" "))
+          .sort(),
+      ).toEqual(fixture.expectedUUIDs.sort());
+      expect(existsSync(path.join(fixture.root, "dist", "OpenClaw.dSYM"))).toBe(false);
+    },
+  );
+
+  it("refuses a universal archive when one architecture has no symbols", () => {
+    const fixture = makeDistributionFixture("xcode", "x86_64");
+    const result = fixture.run();
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("dSYM not found for architecture(s): x86_64");
+    expect(existsSync(path.join(fixture.root, "dist", "OpenClaw-2026.8.2.dSYM.zip"))).toBe(false);
+  });
 });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where maintainers preparing large macOS releases could fail to create the disk image despite ample free space, miss debug symbols produced by current Xcode builds, and spend minutes rendering the contribution appendix. All three problems were observed while shipping 2026.8.1.

## Why This Change Was Made

The distribution scripts now let `hdiutil -srcfolder` account for filesystem overhead and read debug symbols through the same SwiftPM architecture/configuration output link as the app executable. Changelog rendering applies the existing substitutions once to the complete section, preserving their order and output. Production/tooling LOC: **+40/-41 (net -1)**.

This removes the fixed image-size estimate, recursive symbol search, and per-line subprocess loop. App signing, notarization, missing-architecture rejection, universal symbol merging, HTML markup, and promotion boundaries remain unchanged. No new dependencies or configuration are introduced.

## User Impact

Maintainers can prepare complete universal Mac release packages without the manual image-sizing and symbol-path recovery used for 2026.8.1. Large release notes render promptly. Published 2026.8.1 application, package, tag, and feed bytes are untouched; this PR only repairs preparation tooling on `main`.

## Evidence

- Before the production edits: four regression failures, with 28 other focused checks passing. After the fixes: **32/32 focused tests passed** across the DMG, distribution, and changelog command tests.
- Real tiny arm64 and x86_64 Mach-O binaries and dSYMs exercise both native SwiftPM and Xcode output layouts through the full distribution entrypoint. The extracted universal archive retains both original UUIDs, and a missing architecture still fails.
- The complete published 2026.8.1 notes, including **17,468 bullets**, rendered in **0.481 seconds** and matched the retained canonical HTML byte-for-byte: **1,077,539 bytes**, SHA256 `dbc899272c4c24b89e2f1671a7bce7f17008273ba3cbf6dfd657a06ed776fb5a`.
- The retained native DMG failure allocated 2708 MiB when 2814 MiB was required. The same source-folder sizing recovery produced the signed, notarized, publicly verified 2026.8.1 image. The local `hdiutil` manual explicitly documents filesystem padding for `-srcfolder` and that `-size` overrides it.
- Autoreview completed scoped-clean at its default P0 threshold with no findings. Shell syntax, focused formatting, and diff whitespace checks passed.
- The broader changed-file gate passed its guards, test-root typecheck and script lint, but recorded seven subprocess timeouts in unchanged native-artifact security fixtures during severe local host load (1-minute load average 173 on 32 CPUs). The release owner stopped that already-failed run; its result is **failed and incomplete**, not passed. Hosted CI provides independent exact-head verification. Fresh full native release preparation follows main integration; no published app was rebuilt for this PR.
