### PR TITLE
perf(browser): avoid redundant snapshot traversal allocations

### DIFF
--- a/extensions/browser/src/browser/cdp.ts
+++ b/extensions/browser/src/browser/cdp.ts
@@ -407,8 +407,7 @@ export function formatAriaSnapshot(nodes: RawAXNode[], limit: number): AriaSnaps
     }
     const { id, depth } = popped;
     const n = byId.get(id);
-    // Every id pushed onto the stack came from `children.filter(c => byId.has(c))`,
-    // so byId.get(id) is always defined here. Dead defensive guard.
+    // Child admission below only pushes ids present in this map.
     /* c8 ignore next 3 */
     if (!n) {
       continue;
@@ -428,13 +427,10 @@ export function formatAriaSnapshot(nodes: RawAXNode[], limit: number): AriaSnaps
       depth,
     });
 
-    const children = (n.childIds ?? []).filter((c) => byId.has(c));
+    const children = n.childIds ?? [];
     for (let i = children.length - 1; i >= 0; i--) {
       const child = children[i];
-      // `children` is a string[] from an array filter over RawAXNode.childIds,
-      // so `child` is always a defined string here. Dead defensive guard.
-      /* c8 ignore next 3 */
-      if (child) {
+      if (child && byId.has(child)) {
         stack.push({ id: child, depth: depth + 1 });
       }
     }
@@ -550,8 +546,10 @@ function buildRoleTree(nodes: RawAXNode[]): { tree: RoleTreeNode[]; roots: numbe
     if (!current) {
       break;
     }
-    expectDefined(tree[current.index], "CDP traversal node index").depth = current.depth;
-    for (const child of (tree[current.index]?.children ?? []).toReversed()) {
+    const node = expectDefined(tree[current.index], "CDP traversal node index");
+    node.depth = current.depth;
+    for (let i = node.children.length - 1; i >= 0; i--) {
+      const child = expectDefined(node.children[i], "CDP traversal child index");
       stack.push({ index: child, depth: current.depth + 1 });
     }
   }
@@ -733,11 +731,12 @@ async function resolveLinkUrls(
   sessionId?: string,
 ): Promise<Map<number, string>> {
   const out = new Map<number, string>();
+  const linkRefs = Object.values(refs).filter(
+    (ref): ref is CdpRoleRef & { backendDOMNodeId: number } =>
+      ref.role === "link" && Boolean(ref.backendDOMNodeId),
+  );
   await Promise.all(
-    Object.values(refs).map(async (ref) => {
-      if (ref.role !== "link" || !ref.backendDOMNodeId) {
-        return;
-      }
+    linkRefs.map(async (ref) => {
       const resolved = (await send(
         "DOM.resolveNode",
         { backendNodeId: ref.backendDOMNodeId },
@@ -771,11 +770,12 @@ async function resolveIframeFrameIds(
   sessionId?: string,
 ): Promise<Map<number, string>> {
   const out = new Map<number, string>();
+  const iframeNodes = tree.filter(
+    (node): node is RoleTreeNode & { backendDOMNodeId: number } =>
+      node.role.toLowerCase() === "iframe" && Boolean(node.backendDOMNodeId),
+  );
   await Promise.all(
-    tree.map(async (node) => {
-      if (node.role.toLowerCase() !== "iframe" || !node.backendDOMNodeId) {
-        return;
-      }
+    iframeNodes.map(async (node) => {
       const described = (await send(
         "DOM.describeNode",
         { backendNodeId: node.backendDOMNodeId, depth: 1 },


### PR DESCRIPTION
## What Problem This Solves

CDP snapshot preparation creates asynchronous work for unrelated nodes and copies child arrays just to push an existing traversal stack. Both costs grow with page structure even when those nodes need no link or iframe lookup.

## Why This Change Was Made

Filter eligible link/iframe records before creating async callbacks, and push children directly in the same reverse order. These are **two** local preparation mechanisms in one owner, **+17/-17 production lines (net 0)**. The rejected static-NodeList proposal is not included.

CDP request counts/concurrency, output order/depth, limits, duplicate refs, URLs, frame metadata, publication copies and document-identity checks remain unchanged. No new cache, dependency, public API, config, transport policy, test seam or helper is added. Default Playwright AI snapshots and Chrome MCP remain unchanged where they do not call the shared ARIA formatter.

## User Impact

Role and raw accessibility snapshots do less local preparation while returning the same actionable refs and hierarchy. The measured native browser path is mixed; this is not a claim of lower overall browser, Gateway, network or model-turn latency, startup time or memory use.

## Evidence

The selected complete-owner composition passed **488** before/after Node comparisons and **49** same-DOM native scenarios, including empty/singleton trees, missing/duplicate/shared IDs, ordering, error responses, frame metadata/recursion, mutation/freshness, and ref publication around document changes. The declared 64-row noneligible case creates **173 versus 43 promises**; this is an operation witness, not a memory estimate. Dependency fixtures remain explicit for transport/acquisition/authority, and are supplemented by the real baseline below.

Eight fresh serial before/selected measurement children retain **70 workloads and 2,520 samples**, with all **280 medians** reconciled. The original adaptive warmups/per-child calibration and nine rounds remain; no fixed-iteration or significance claim is made. F/R identifies the two fresh-process variant orders.

| Measured owner workload | Elapsed reduction F / R |
| --- | ---: |
| ARIA wide, 8 rows | 19.8% / 20.7% |
| ARIA deep, 8 rows | 35.0% / 37.9% |
| Complete role, 32 ordinary rows, no URLs | 9.2% / 11.7% |
| Complete role, 32 mixed rows, URLs | 5.7% / 6.9% |
| Complete role, 32 missing-backend links | 8.0% / 11.2% |

These Node role rows use the complete owner with a synthetic transport. Native CDP results do **not** establish a consistent full-path gain: 100 cursors cost +381.50/-191.42 µs (+2.40/-1.12%), and 1,000 cost -3,807.42/+8,291.08 µs (-2.57/+5.57%). Empty/all-eligible/frame controls remain; unchanged PW/MCP controls also vary. Every mixed/slower row is retained below, without a V8/JIT/GC explanation or a traffic-weighted overall claim. Native measurement cleanup used the reviewed bounded kill fallback; no graceful-exit claim is made for those runs.

The unchanged **319ed built baseline** passed all **17 ordered CLI commands** through authenticated Gateway `browser.request` and task-owned signed Chrome 152. It covers exact link/no-link output, iframe metadata, both traversal results, a seven-node prefix, stable refs and second-then-first duplicate activation. Six full snapshot responses are retained; other command bodies retain hashes and bound-driver assertions. Across-run comparison is the entire semantic record, not all raw transport JSON or JavaScript alias identity. Both task Chrome children and all CLI/Gateway groups stopped, both ports closed and task state was removed. The saved baseline also passed **240 canonical tests across seven suites**.

The current candidate passes **299 tests across 11 canonical suites**, full changed checks (144.44 seconds), and scoped managed review (clean, 0.95), with exact byte correspondence to the measured selected owner. The first local check stopped when concurrent native PR-checkout work changed the dependency-resolution namespace; its failed receipt is retained. The full rerun passed with checkout mutations serialized. The fresh ordinary build passes (168.07 seconds). The unchanged native candidate flow also passes all 17 commands, and the unchanged comparator confirms exact equality of the complete semantic records against the preserved 319ed baseline. All 21 recorded PIDs and 18 process groups are absent, both task ports refuse connections, and task HOME is removed. Native stop and Gateway exit 0 are observed. Six full snapshot responses and all command hashes remain retained; no whole-response cross-run identity or performance claim is inferred. The proof uses no operator browser profile, external page, real key or model. Child-document traversal, Chrome MCP transport, screenshots, CPU coverage and startup-intermittency repair are outside its scope; retained connection-refused/abort observations are not deleted.

<details>
<summary>All mixed or slower selected controls</summary>

Positive deltas are slower. PW/MCP rows are unchanged-code controls.

| Workload | F delta µs (%) | R delta µs (%) |
| --- | ---: | ---: |
| aria-empty | +0.00019 (+0.46%) | -0.00280 (-6.45%) |
| role-links-0-urls-true | +0.01615 (+0.95%) | +0.00970 (+0.57%) |
| frames-8-rows-32-urls-true | -4.16275 (-3.25%) | +0.88278 (+0.70%) |
| native-pw-100 | +112.00000 (+3.02%) | +65.79100 (+1.73%) |
| native-pw-1000 | -177.91700 (-1.18%) | +1143.62500 (+7.77%) |
| native-mcp-0 | +5.72656 (+2.18%) | -1.63281 (-0.62%) |
| native-mcp-100 | +36.46875 (+2.92%) | -104.00025 (-7.48%) |
| native-mcp-1000 | -475.38525 (-25.31%) | +328.13550 (+22.03%) |
| native-cdp-0 | +29.96900 (+2.25%) | -61.07275 (-4.50%) |
| native-cdp-16 | +0.41700 (+0.01%) | -133.66600 (-2.92%) |
| native-cdp-100 | +381.49900 (+2.40%) | -191.41700 (-1.12%) |
| native-cdp-1000 | -3807.41700 (-2.57%) | +8291.08400 (+5.57%) |

</details>

Current candidate is `a106bf6b829` on main base `3fd6fcd6796`. Upstream package-lifecycle entry changes are recorded separately; the fixed native proof launches `dist/entry.js`, so it does not claim package-update recovery coverage.

The final browser proof binds current 202 source files, 730 installed/native leaves, 7 complete package trees, 6 unchanged helpers, signed Google Chrome 152 and all 12,250 built files. The extra 7 source pins explicitly cover upstream entry/package-lifecycle drift; they do not expand the behavior claim.

Independent post-run audit confirms all saved snapshots, the complete semantic comparison, observer records, physical cleanup and current source/build pins. Both ClawSweeper Rank-up moves are complete; exact-head CI is green.
