### PR TITLE
fix(anthropic): preserve native auth with stored API keys

### DIFF
--- a/extensions/anthropic/cli-backend.ts
+++ b/extensions/anthropic/cli-backend.ts
@@ -232,6 +232,7 @@ export function buildAnthropicCliBackend(
     resolveModelId: ({ modelId, contextWindow }) =>
       resolveClaudeCliContextWindowModelId(modelId, contextWindow),
     authEpochMode: "profile-only",
+    autoSelectAuthProfile: false,
     prepareExecution: (context) => {
       const prepare = () => {
         const credentialContext = context as typeof context & {

--- a/extensions/anthropic/cli-shared.test.ts
+++ b/extensions/anthropic/cli-shared.test.ts
@@ -875,6 +875,7 @@ describe("normalizeClaudeBackendConfig", () => {
   it("leaves claude cli subscription-managed, restricts setting sources, and clears inherited env overrides", () => {
     const backend = buildAnthropicCliBackend();
 
+    expect(backend.autoSelectAuthProfile).toBe(false);
     expect(backend.config.env).toBeUndefined();
     expect(backend.config.liveSession).toBe("claude-stdio");
     expect(backend.config.output).toBe("jsonl");

--- a/src/agents/cli-execution-auth.test.ts
+++ b/src/agents/cli-execution-auth.test.ts
@@ -72,6 +72,40 @@ describe("resolveCliExecutionAuthProfileId", () => {
     ).toBe(authProfileId);
   });
 
+  it("forwards only automatic Claude profiles owned by Claude CLI", () => {
+    mocks.profiles["anthropic:default"] = {
+      type: "api_key",
+      provider: "anthropic",
+      key: "test-anthropic-key",
+    };
+    mocks.order.push("anthropic:default");
+
+    expect(
+      resolveCliExecutionAuthProfileId({
+        cliExecutionProvider: "claude-cli",
+        authProfileProvider: "anthropic",
+        config: {},
+        agentDir: "/tmp/unused-agent",
+      }),
+    ).toBeUndefined();
+
+    mocks.profiles["claude-cli:work"] = {
+      type: "api_key",
+      provider: "claude-cli",
+      key: "test-claude-key",
+    };
+    mocks.order.push("claude-cli:work");
+
+    expect(
+      resolveCliExecutionAuthProfileId({
+        cliExecutionProvider: "claude-cli",
+        authProfileProvider: "anthropic",
+        config: {},
+        agentDir: "/tmp/unused-agent",
+      }),
+    ).toBe("claude-cli:work");
+  });
+
   it("rejects an explicitly selected profile from another provider", () => {
     mocks.profiles["openai:work"] = {
       type: "api_key",

--- a/src/agents/cli-execution-auth.ts
+++ b/src/agents/cli-execution-auth.ts
@@ -87,9 +87,13 @@ export function resolveCliExecutionAuthProfileId(params: {
     cfg: params.config,
     store,
     provider: params.cliExecutionProvider,
-  })[0];
+  }).find(
+    (profileId) =>
+      store.profiles[profileId]?.provider === params.cliExecutionProvider &&
+      !nativeAuthProfileIds?.includes(profileId),
+  );
   if (cliProfileId) {
-    return nativeAuthProfileIds?.includes(cliProfileId) ? undefined : cliProfileId;
+    return cliProfileId;
   }
 
   if (

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -1256,6 +1256,7 @@ describe("prepareCliRunContext", () => {
 
     setCliBackendForPrepareTest({
       prepareExecution,
+      authEpochMode: "profile-only",
       autoSelectAuthProfile: testCase.autoSelectAuthProfile,
     });
     const context = await fixture.prepare({

--- a/src/agents/cli-runner/prepare.ts
+++ b/src/agents/cli-runner/prepare.ts
@@ -624,8 +624,8 @@ export async function prepareCliRunContext(
     authStore = loadScopedAuthStore({ profileId: effectiveAuthProfileId });
     authCredential = authStore.profiles[effectiveAuthProfileId];
   } else if (
-    backendResolved.authEpochMode === "profile-only" ||
-    (backendResolved.prepareExecution && backendResolved.autoSelectAuthProfile !== false)
+    backendResolved.autoSelectAuthProfile !== false &&
+    (backendResolved.authEpochMode === "profile-only" || backendResolved.prepareExecution)
   ) {
     authStore = loadScopedAuthStore();
     effectiveAuthProfileId =


### PR DESCRIPTION
Closes #134004

## What Problem This Solves

Fixes an issue where users who upgraded to 2026.8.1 could get a deterministic 401 on every Claude CLI-backed turn when a stored Anthropic API-key profile existed beside a healthy native Claude login.

## Why This Change Was Made

Automatic Claude CLI forwarding now selects only a non-retired profile whose stored owner is exactly `claude-cli`. Otherwise it passes no profile and lets Claude use its native login. Claude also opts out of the generic profile fallback during backend preparation, so that later stage cannot undo the execution-auth decision.

Explicit profile selections still fail closed. The separate Google API-key to Gemini CLI bridge is unchanged. Shared-auth relocation and auth status reporting remain out of scope.

## User Impact

Claude CLI-backed agent turns keep using the healthy native Claude login when an unrelated Anthropic credential remains in the store.

## Evidence

- Released 2026.8.1 red: direct `claude -p` returned `healthy-native-auth`, but the same isolated state made `openclaw agent --local --model anthropic/claude-opus-5` fail after 179530 ms with `401 API key is invalid`.
- Exact-head green: the same state and stored Anthropic profile returned `exact-head-green` through the real CLI entry in 3654 ms.
- Owner boundary: `node scripts/run-vitest.mjs src/agents/cli-execution-auth.test.ts` — 9 passed.
- Prepared backend: `node scripts/run-vitest.mjs src/agents/cli-runner/prepare.test.ts` — 121 passed.
- Anthropic backend: `node scripts/run-vitest.mjs extensions/anthropic/cli-shared.test.ts` — 50 passed.
- Format, core lint, extension lint, conflict-marker ratchet, max-lines ratchet, assertion-safety ratchet, and `git diff --check` passed.
- Local TypeScript typecheck and build were not run per host policy; CI owns them.

Production LOC: +9/-4 (net +5) | Tests: +36/-0

Provenance: PR #112458 introduced owner-blind automatic Claude profile forwarding. PRs #129052 and #130225 later moved native login ownership to Claude and filtered only the retired profile ID, exposing the alias-compatible stored-owner case in 2026.8.1.
