### PR TITLE
test(scripts): batch distribution import fixtures

### DIFF
--- a/test/scripts/check-package-dist-imports.test.ts
+++ b/test/scripts/check-package-dist-imports.test.ts
@@ -47,32 +47,27 @@ describe("check-package-dist-imports", () => {
     expect(result.stdout).toContain("OpenClaw package dist import closure passed.");
   });
 
-  it.each([
-    {
-      name: "named imports",
-      source: 'import { value } from "./missing.js";\n',
-    },
-    {
-      name: "multiline named imports",
-      source: 'import {\n  value,\n} from "./missing.js";\n',
-    },
-    {
-      name: "named re-exports",
-      source: 'export { value } from "./missing.js";\n',
-    },
-    {
-      name: "multiline named re-exports",
-      source: 'export {\n  value,\n} from "./missing.js";\n',
-    },
-  ])("rejects missing chunks in $name", ({ source }) => {
+  it("rejects missing chunks across ESM import, re-export, and CommonJS forms", () => {
     const root = makeTempDir(tempDirs, "openclaw-package-dist-imports-");
     mkdirSync(join(root, "dist"), { recursive: true });
-    writeFileSync(join(root, "dist", "index.js"), source, "utf8");
+    const sources = {
+      "named-import.js": 'import { value } from "./missing.js";\n',
+      "multiline-import.js": 'import {\n  value,\n} from "./missing.js";\n',
+      "named-export.js": 'export { value } from "./missing.js";\n',
+      "multiline-export.js": 'export {\n  value,\n} from "./missing.js";\n',
+      "index.cjs": 'module.exports = require("./chunk.cjs");\n',
+    };
+    for (const [file, source] of Object.entries(sources)) {
+      writeFileSync(join(root, "dist", file), source, "utf8");
+    }
 
     const result = spawnSync("node", [CHECK_SCRIPT, root], { encoding: "utf8" });
 
     expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("dist/index.js imports missing dist/missing.js");
+    for (const file of Object.keys(sources)) {
+      const target = file.endsWith(".cjs") ? "chunk.cjs" : "missing.js";
+      expect(result.stderr).toContain(`dist/${file} imports missing dist/${target}`);
+    }
   });
 
   it("ignores import-like text inside multiline template literals", () => {
@@ -90,17 +85,23 @@ describe("check-package-dist-imports", () => {
     expect(result.stdout).toContain("OpenClaw package dist import closure passed.");
   });
 
-  it.each([
-    "../../openclaw.mjs",
-    "../../scripts/run-node.mjs",
-    "../../dist/entry.js",
-    "../../dist/entry.mjs",
-  ])("ignores import.meta.url probes outside packaged dist (%s)", (specifier) => {
+  it("ignores import.meta.url probes outside packaged dist", () => {
     const root = makeTempDir(tempDirs, "openclaw-package-dist-imports-");
     mkdirSync(join(root, "dist"), { recursive: true });
+    const probes = [
+      "../../openclaw.mjs",
+      "../../scripts/run-node.mjs",
+      "../../dist/entry.js",
+      "../../dist/entry.mjs",
+    ];
     writeFileSync(
       join(root, "dist", "index.js"),
-      `const candidate = new URL(${JSON.stringify(specifier)}, import.meta.url);\n`,
+      probes
+        .map(
+          (specifier, index) =>
+            `const candidate${index} = new URL(${JSON.stringify(specifier)}, import.meta.url);`,
+        )
+        .join("\n"),
       "utf8",
     );
 
@@ -108,20 +109,5 @@ describe("check-package-dist-imports", () => {
 
     expect(result.status, result.stderr).toBe(0);
     expect(result.stdout).toContain("OpenClaw package dist import closure passed.");
-  });
-
-  it("rejects missing CommonJS require chunks", () => {
-    const root = makeTempDir(tempDirs, "openclaw-package-dist-imports-");
-    mkdirSync(join(root, "dist"), { recursive: true });
-    writeFileSync(
-      join(root, "dist", "index.cjs"),
-      'module.exports = require("./chunk.cjs");\n',
-      "utf8",
-    );
-
-    const result = spawnSync("node", [CHECK_SCRIPT, root], { encoding: "utf8" });
-
-    expect(result.status).not.toBe(0);
-    expect(result.stderr).toContain("dist/index.cjs imports missing dist/chunk.cjs");
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The distribution import guard tests start a new Node process and temporary package for each equivalent import syntax or external URL probe.

## Why This Change Was Made

Put all five failing ESM/CommonJS forms in one package and require an individual diagnostic for every importer. Put the four ignored URL probes in one successful scan. This also proves that scanning reports every bad edge instead of stopping at the first file. Help, argument validation, a minimal package, and template-literal exclusions remain separate.

## User Impact

No runtime change. Seven fewer Node processes and temporary package roots per suite. Local timing is noisy: the first pair was 1.50/1.60 seconds, while a consecutive remeasurement was 4.57/2.83 seconds before/after; these are test-body measurements, not a CI-wide speed claim.

## Evidence

- All six consolidated tests pass, retaining the thirteen original cases and every import/probe input.
- `node scripts/check-changed.mjs -- test/scripts/check-package-dist-imports.test.ts`: passes.
- CLI, scanner owner, tarball caller, and temp-fixture helpers inspected; formatting, diff check, and structured Codex autoreview pass.
- Production unchanged; tests +28/-42, net -14 lines.
