### PR TITLE
fix(cli): reject blank native hook relay --timeout instead of silent default

### DIFF
--- a/src/cli/native-hook-relay-cli.ts
+++ b/src/cli/native-hook-relay-cli.ts
@@ -104,7 +104,7 @@ export async function runNativeHookRelayCli(
   const event = readRequiredOption(opts.event, "event");
   let timeoutMs: number;
   try {
-    timeoutMs = parseTimeoutMsWithFallback(opts.timeout, 5_000);
+    timeoutMs = parseTimeoutMsWithFallback(opts.timeout, 5_000, { invalidType: "error" });
   } catch (error) {
     writeText(stderr, formatRelayCliError("invalid native hook timeout", error));
     return 1;


### PR DESCRIPTION
## What Problem This Solves

Running `openclaw hooks relay --timeout ""` (an internal harness command) silently fell back to the 5000 ms default instead of rejecting the blank value. This fix makes the blank input error out with the same "invalid native hook timeout" message already used for other malformed values.

- Problem: `runNativeHookRelayCli` called `parseTimeoutMsWithFallback(opts.timeout, 5_000)` without the `{ invalidType: "error" }` option. When Commander parses `--timeout ""` it produces an empty string that overrides the registered default, and `parseTimeoutMsWithFallback` treats a blank string as "absent" and returns the fallback — so the explicit (but empty) input is silently replaced by 5000 ms with exit code 0. The argv parser path (`parseNativeHookRelayCliOptions`) already rejects empty values via `if (!value) throw`, but the Commander action path (`hooks-cli.ts`) passes `opts` directly to `runNativeHookRelayCli`, bypassing that guard.
- Solution: Pass `{ invalidType: "error" }` as the third argument so blank/whitespace-only values throw `Invalid --timeout`. The existing `try/catch` already catches this and writes `invalid native hook timeout` to stderr with exit code 1 — no new error handling needed.
- What changed: `src/cli/native-hook-relay-cli.ts` — one line, added the options argument.
- What did NOT change: behavior for `undefined`/omitted `--timeout` (still uses the 5000 ms default), valid positive-integer values (still parsed normally), and the argv parser path (already guarded).

## Why This Change Was Made

This completes the sweep started in #133781 (channels capabilities, merged 2026-08-31). The argv parser path (`parseNativeHookRelayCliOptions`) already rejects empty values, but the Commander action path bypassed that guard. With this and #134040 (gateway probe), every `parseTimeoutMsWithFallback` caller now rejects blank input.

This is the same fix already applied to `channels capabilities` (#133781), `nodes` CLI (615f6eac62), `usage-cost --days` (#127978), and the sibling `gateway probe` command. The `hooks relay` command was another holdout that omitted the `invalidType: "error"` option. Passing the option the shared helper already accepts is the minimal, consistent fix.

- Best fix: yes — the shared helper (`parseTimeoutMsWithFallback`) already supports the `invalidType: "error"` option and the existing `try/catch` already handles the thrown error gracefully. This just aligns `hooks relay` with the other commands.
- Alternative: validate `opts.timeout` inline before calling the helper — rejected as it duplicates logic the helper already encapsulates and the `try/catch` already covers.
- Risk: very low. Only blank/whitespace input changes behavior (from silent default to error with exit 1). Omitted and valid values are unaffected. The command is `hidden: true` (internal harness use), so user-facing surface is minimal, but consistency with sibling commands still matters.

## User Impact

This is an internal harness command (`hidden: true`), so direct user impact is limited. However, internal tooling and test harnesses that pass `--timeout "$VAR"` where `$VAR` is empty will now get a clear error instead of a silently wrong timeout budget that could cause flaky or misleading test results.

## Evidence

Live command verification using `node --import tsx` importing the shared helper, simulating the exact call `runNativeHookRelayCli` makes (including the `try/catch` that returns exit 1):

```text
$ node --import tsx -e '
import { parseTimeoutMsWithFallback } from "./src/cli/parse-timeout.ts";
console.log("=== AFTER FIX (with invalidType:error, 走 runNativeHookRelayCli try/catch) ===");
for (const [label, val] of [["\"\"", ""], ["\"   \"", "   "], ["undefined", undefined], ["\"5000\"", "5000"]]) {
  try {
    const r = parseTimeoutMsWithFallback(val, 5_000, { invalidType: "error" });
    console.log("timeout=" + label + " →", r);
  } catch (e) {
    console.log("timeout=" + label + " → threw (catch→exit 1):", e.message);
  }
}
console.log();
console.log("=== BEFORE FIX (no invalidType, old behavior) ===");
console.log("timeout=\"\" →", parseTimeoutMsWithFallback("", 5_000), "(silently used default, bug)");
'

=== AFTER FIX (with invalidType:error, 走 runNativeHookRelayCli try/catch) ===
timeout="" → threw (catch→exit 1): Invalid --timeout. Use a positive millisecond value, e.g. --timeout 30000.
timeout="   " → threw (catch→exit 1): Invalid --timeout. Use a positive millisecond value, e.g. --timeout 30000.
timeout=undefined → 5000
timeout="5000" → 5000

=== BEFORE FIX (no invalidType, old behavior) ===
timeout="" → 5000 (silently used default, bug)
```

Behavior matrix:

```text
input form        => pre-fix result           => post-fix result
""  (blank)       => 5000 (silent default)    => throws → catch → exit 1
"   " (whitespace)=> 5000 (silent default)    => throws → catch → exit 1
undefined/omitted => 5000 (default)           => 5000 (default, unchanged)
"5000" (valid)    => 5000 (parsed)            => 5000 (parsed, unchanged)
```

Commander behavior confirmed — `--timeout ""` produces an empty string that overrides the registered default on the `hooks relay` command:

```text
$ node -e '
const { Command } = require("commander");
const program = new Command();
program.command("relay", { hidden: true })
  .requiredOption("--provider <provider>", "")
  .requiredOption("--relay-id <id>", "")
  .requiredOption("--event <event>", "")
  .option("--timeout <ms>", "", "5000")
  .action((opts) => { console.log("timeout:", JSON.stringify(opts.timeout)); });
program.parse(["node", "test", "relay", "--provider", "p", "--relay-id", "r", "--event", "e", "--timeout", ""]);
'
timeout: ""
```

## AI Assistance

This PR was authored with AI assistance (Codex CLI, `local-code-analysis` skill). The AI identified the missing `invalidType: "error"` option by grepping all `parseTimeoutMsWithFallback` call sites after seeing the pattern fixed in #133781, verified the bug by reading the helper source, the argv parser guard, and the Commander action path, and confirmed the fix with real `node` commands. The existing `try/catch` was confirmed to already handle the thrown error. The author has read and understands every line of the diff.
