### PR TITLE
fix(ci): let OpenGrep prepare stale-base PR checkouts

### DIFF
--- a/.github/workflows/opengrep-precise.yml
+++ b/.github/workflows/opengrep-precise.yml
@@ -49,10 +49,20 @@ jobs:
           persist-credentials: false
           submodules: false
 
+      - name: Resolve PR diff base
+        id: diff_base
+        env:
+          EVENT_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        # The merge ref may have newer main than the event payload. Resolve the
+        # scanner's actual base before asking the shallow checkout for history.
+        run: |
+          base_sha="$(node scripts/lib/merge-head-diff-base.mjs --base "$EVENT_BASE_SHA" --head HEAD --prefer-first-parent)"
+          echo "sha=$base_sha" >> "$GITHUB_OUTPUT"
+
       - name: Ensure PR base commit
         uses: ./.github/actions/ensure-base-commit
         with:
-          base-sha: ${{ github.event.pull_request.base.sha }}
+          base-sha: ${{ steps.diff_base.outputs.sha }}
           fetch-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Install opengrep
@@ -81,8 +91,7 @@ jobs:
 
       - name: Run opengrep on PR diff
         env:
-          OPENCLAW_OPENGREP_BASE_REF: ${{ github.event.pull_request.base.sha }}...HEAD
-          OPENCLAW_OPENGREP_MERGE_HEAD_FIRST_PARENT: "1"
+          OPENCLAW_OPENGREP_BASE_REF: ${{ steps.diff_base.outputs.sha }}...HEAD
         # Findings from precise rules block this workflow. Pull requests scan
         # changed first-party source paths only so findings stay attributable to
         # the PR diff. Test/fixture/QA path exclusions live in `.semgrepignore`

--- a/test/scripts/run-opengrep.test.ts
+++ b/test/scripts/run-opengrep.test.ts
@@ -2,6 +2,7 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { createScriptTestHarness } from "./test-helpers.js";
@@ -212,8 +213,8 @@ describe("run-opengrep.sh", () => {
     },
   );
 
-  it("scans PR files instead of main-only files when the payload base is stale", () => {
-    const repo = createTempDir("openclaw-run-opengrep-merge-");
+  it("prepares and scans a shallow PR merge without fetching a stale payload base", () => {
+    let repo = createTempDir("openclaw-run-opengrep-merge-");
     git(repo, "init", "-q", "--initial-branch=main");
     git(repo, "config", "user.email", "test@example.com");
     git(repo, "config", "user.name", "Test User");
@@ -234,8 +235,72 @@ describe("run-opengrep.sh", () => {
     writeFile(path.join(repo, "src/main-only.ts"), "export const mainOnly = true;\n");
     git(repo, "add", ".");
     git(repo, "commit", "-qm", "main only");
+    const mergeBase = git(repo, "rev-parse", "HEAD");
     git(repo, "merge", "--no-ff", "feature", "-m", "synthetic merge");
 
+    const checkout = createTempDir("openclaw-run-opengrep-shallow-");
+    git(checkout, "clone", "--quiet", "--depth=2", pathToFileURL(repo).href, ".");
+    repo = checkout;
+    git(repo, "remote", "remove", "origin");
+    expect(spawnSync("git", ["cat-file", "-e", staleBase], { cwd: repo }).status).not.toBe(0);
+
+    const workflow = parse(fs.readFileSync(".github/workflows/opengrep-precise.yml", "utf8"));
+    const outputPath = path.join(repo, "github-output");
+    const expressions: Record<string, string> = {
+      "github.event.pull_request.base.sha": staleBase,
+      "github.event.pull_request.base.ref": "main",
+    };
+    const expand = (value: string) =>
+      value.replace(/\$\{\{ ([\w.-]+) \}\}/gu, (_match, key: string) => {
+        const expanded = expressions[key];
+        if (expanded === undefined) {
+          throw new Error(`Unexpected workflow expression: ${key}`);
+        }
+        return expanded;
+      });
+    for (const step of workflow.jobs.scan.steps) {
+      if (step.name === "Checkout") {
+        continue;
+      }
+      if (step.name === "Install opengrep") {
+        break;
+      }
+      let runnable = step;
+      if (step.uses) {
+        const actionPath = path.resolve(step.uses);
+        expressions["github.action_path"] = actionPath;
+        for (const [key, value] of Object.entries(step.with)) {
+          expressions[`inputs.${key}`] = expand(String(value));
+        }
+        runnable = parse(fs.readFileSync(path.join(actionPath, "action.yml"), "utf8")).runs
+          .steps[0];
+      }
+      const prepared = spawnSync("bash", ["-euo", "pipefail", "-c", runnable.run], {
+        cwd: repo,
+        env: {
+          ...process.env,
+          RUNNER_OS: process.platform === "win32" ? "Windows" : process.platform,
+          GITHUB_OUTPUT: outputPath,
+          ...Object.fromEntries(
+            Object.entries(runnable.env ?? {}).map(([key, value]) => [key, expand(String(value))]),
+          ),
+        },
+        encoding: "utf8",
+      });
+      expect(prepared.status, `${prepared.stdout}${prepared.stderr}`).toBe(0);
+      if (step.id) {
+        for (const line of fs.readFileSync(outputPath, "utf8").trim().split("\n")) {
+          const separator = line.indexOf("=");
+          expressions[`steps.${step.id}.outputs.${line.slice(0, separator)}`] = line.slice(
+            separator + 1,
+          );
+        }
+      }
+    }
+    const scan = workflow.jobs.scan.steps.find(
+      (step: { name: string }) => step.name === "Run opengrep on PR diff",
+    );
+    expect(expand(scan.env.OPENCLAW_OPENGREP_BASE_REF)).toBe(`${mergeBase}...HEAD`);
     const { argsPath, binDir } = installOpengrepStub(repo);
 
     execFileSync("bash", ["scripts/run-opengrep.sh", "--changed"], {
@@ -243,8 +308,9 @@ describe("run-opengrep.sh", () => {
       env: {
         ...process.env,
         PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
-        OPENCLAW_OPENGREP_BASE_REF: `${staleBase}...HEAD`,
-        OPENCLAW_OPENGREP_MERGE_HEAD_FIRST_PARENT: "1",
+        ...Object.fromEntries(
+          Object.entries(scan.env).map(([key, value]) => [key, expand(String(value))]),
+        ),
       },
       encoding: "utf8",
     });


### PR DESCRIPTION
Related: #134014

## What Problem This Solves

Fixes an issue where maintainers updating a PR would see OpenGrep fail before scanning when its shallow merge checkout did not contain the older base SHA from the event payload. The workflow attempted an unnecessary fetch after checkout had removed its credentials; run [33381249161](https://github.com/openclaw/openclaw/actions/runs/33381249161) failed there and consequently produced no SARIF report.

## Why This Change Was Made

OpenGrep already selects the synthetic merge's first parent as its scan base. The workflow now resolves that base with the existing shared helper before ensuring history, and passes the same captured SHA to both preparation and scanning. The depth-two checkout already contains that parent. Non-merge inputs retain the existing helper and ensure-base behavior.

This keeps checkout credentials unpersisted and leaves fetch ownership, scan scope, finding failures and SARIF enforcement intact. No token injection, larger fetch, retry, or scan bypass is introduced. GitHub documents the [PR merge checkout contract](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#pull_request); the pinned checkout action [removes authentication when persistence is disabled](https://github.com/actions/checkout/blob/3d3c42e5aac5ba805825da76410c181273ba90b1/src/git-source-provider.ts#L291-L299).

## User Impact

PR scans can prepare their actual comparison base even when the event base is stale and further fetching is unavailable. OpenClaw runtime behavior is unchanged.

## Evidence

- Extended the existing stale-base real-Git regression to clone the synthetic merge with depth two, prove the event base is absent, remove remote access, execute the workflow's preparation steps and run the scanner path. It failed before the workflow repair; afterward preparation succeeds and scanning includes the PR file while excluding main-only changes.
- `node scripts/run-vitest.mjs test/scripts/run-opengrep.test.ts test/scripts/merge-head-diff-base.test.ts`: all 13 tests passed, including invalid discovery, empty SARIF, malformed reports, and preserved suppression evidence. The final focused shallow-checkout case also passed after a fixture type correction.
- The initial changed gate caught a fixture callback typed as possibly undefined. The callback now explicitly checks the captured value; the failed gate is retained in local evidence.

- `node scripts/check-changed.mjs -- .github/workflows/opengrep-precise.yml test/scripts/run-opengrep.test.ts`, `pnpm check:workflows`, formatting and `git diff --check`: passed. Fresh Codex Autoreview on the final diff: scoped-clean at P0, no accepted findings.

- Live [OpenGrep run 33383224020](https://github.com/openclaw/openclaw/actions/runs/33383224020) passed at `0432f9a659277fdb3a0001227855ab1708f7e771`, including base preparation, scanning, Code Scanning upload and raw SARIF artifact upload.

Production/tooling LOC: +12/-3 (net +9); tests: +70/-4. The extra workflow step moves existing base selection ahead of history preparation and shares its result with the scanner; it adds no second diff-base policy.

