### PR TITLE
fix(resources): preserve source scope for Windows path casing

### DIFF
--- a/src/agents/sessions/prompt-templates.test.ts
+++ b/src/agents/sessions/prompt-templates.test.ts
@@ -3,6 +3,7 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { withMockedWindowsPlatform } from "../../test-utils/vitest-spies.js";
 import { loadPromptTemplates } from "./prompt-templates.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -45,5 +46,24 @@ describe("loadPromptTemplates", () => {
       description: "----",
       content,
     });
+  });
+
+  it("keeps case-variant Windows user prompt paths in user scope", async () => {
+    const root = tempDirs.make("openclaw-prompt-templates-");
+    const promptDir = join(root, "agent", "prompts");
+    await mkdir(promptDir, { recursive: true });
+    await writeFile(join(promptDir, "user.md"), "User prompt\n", "utf-8");
+
+    expect(
+      withMockedWindowsPlatform(
+        () =>
+          loadPromptTemplates({
+            cwd: root,
+            agentDir: join(root, "AGENT"),
+            promptPaths: [promptDir],
+            includeDefaults: false,
+          })[0]?.sourceInfo.scope,
+      ),
+    ).toBe("user");
   });
 });

--- a/src/agents/sessions/prompt-templates.ts
+++ b/src/agents/sessions/prompt-templates.ts
@@ -1,5 +1,5 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { basename, dirname, isAbsolute, join, resolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import {
   parseCommandArgs,
@@ -10,6 +10,7 @@ import {
  *
  * Reads markdown prompt templates from user, project, and package sources with frontmatter metadata.
  */
+import { isPathInside } from "../../infra/path-guards.js";
 import { expandTildePath } from "../../shared/tilde-path.js";
 import { CONFIG_DIR_NAME } from "../config.js";
 import { parsePromptFrontmatter } from "../utils/frontmatter.js";
@@ -138,24 +139,15 @@ export function loadPromptTemplates(options: LoadPromptTemplatesOptions): Prompt
   const globalPromptsDir = options.agentDir ? join(options.agentDir, "prompts") : resolvedAgentDir;
   const projectPromptsDir = resolve(resolvedCwd, CONFIG_DIR_NAME, "prompts");
 
-  const isUnderPath = (target: string, root: string): boolean => {
-    const normalizedRoot = resolve(root);
-    if (target === normalizedRoot) {
-      return true;
-    }
-    const prefix = normalizedRoot.endsWith(sep) ? normalizedRoot : `${normalizedRoot}${sep}`;
-    return target.startsWith(prefix);
-  };
-
   const getSourceInfo = (resolvedPath: string): SourceInfo => {
-    if (isUnderPath(resolvedPath, globalPromptsDir)) {
+    if (isPathInside(globalPromptsDir, resolvedPath)) {
       return createSyntheticSourceInfo(resolvedPath, {
         source: "local",
         scope: "user",
         baseDir: globalPromptsDir,
       });
     }
-    if (isUnderPath(resolvedPath, projectPromptsDir)) {
+    if (isPathInside(projectPromptsDir, resolvedPath)) {
       return createSyntheticSourceInfo(resolvedPath, {
         source: "local",
         scope: "project",

--- a/src/agents/sessions/resource-loader.test.ts
+++ b/src/agents/sessions/resource-loader.test.ts
@@ -3,10 +3,12 @@ import { mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { withMockedWindowsPlatform } from "../../test-utils/vitest-spies.js";
 import { clearExtensionCache } from "./extensions/loader.js";
 import { DefaultPackageManager } from "./package-manager.js";
 import { DefaultResourceLoader } from "./resource-loader.js";
 import { SettingsManager } from "./settings-manager.js";
+import type { SourceScope } from "./source-info.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -34,6 +36,10 @@ export default function extension(api) {
   });
 }
 `;
+}
+
+function sourceMetadata(path: string, source: string, scope: SourceScope) {
+  return { path, source, scope, origin: "package" as const, baseDir: path };
 }
 
 afterEach(() => {
@@ -149,5 +155,38 @@ describe("DefaultResourceLoader", () => {
     } finally {
       consoleError.mockRestore();
     }
+  });
+
+  it("inherits Windows source metadata across case-variant resource roots", async () => {
+    const root = tempDirs.make("openclaw-resource-loader-scope-");
+    const variantAgentDir = join(root, "AGENT");
+    const variantPackageDir = join(root, "PACKAGE-SOURCE");
+    const defaultSkillDir = join(root, "agent", "skills", "default");
+    await mkdir(defaultSkillDir, { recursive: true });
+
+    withMockedWindowsPlatform(() => {
+      const loader = new DefaultResourceLoader({
+        cwd: root,
+        agentDir: variantAgentDir,
+      });
+      const cases = [
+        loader["getDefaultSourceInfoForPath"](defaultSkillDir),
+        loader["findSourceInfoForPath"](
+          join(root, "package-source", "extra", "SKILL.md"),
+          new Map([[variantPackageDir, sourceMetadata(variantPackageDir, "extension", "project")]]),
+        ),
+        loader["findSourceInfoForPath"](
+          join(root, "package-source", "package", "SKILL.md"),
+          undefined,
+          new Map([[variantPackageDir, sourceMetadata(variantPackageDir, "package", "user")]]),
+        ),
+      ];
+
+      expect(cases).toMatchObject([
+        { source: "local", scope: "user", baseDir: join(variantAgentDir, "skills") },
+        { source: "extension", scope: "project", baseDir: variantPackageDir },
+        { source: "package", scope: "user", baseDir: variantPackageDir },
+      ]);
+    });
   });
 });

--- a/src/agents/sessions/resource-loader.ts
+++ b/src/agents/sessions/resource-loader.ts
@@ -5,8 +5,9 @@
  */
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve, sep } from "node:path";
+import { join, resolve } from "node:path";
 import chalk from "chalk";
+import { isPathInside } from "../../infra/path-guards.js";
 import type { Skill } from "../../skills/loading/session.js";
 import { loadSkills } from "../../skills/loading/session.js";
 import { CONFIG_DIR_NAME } from "../config.js";
@@ -674,10 +675,7 @@ export class DefaultResourceLoader implements ResourceLoader {
     if (extraSourceInfos) {
       for (const [sourcePath, sourceInfo] of extraSourceInfos.entries()) {
         const normalizedSourcePath = resolve(sourcePath);
-        if (
-          normalizedResourcePath === normalizedSourcePath ||
-          normalizedResourcePath.startsWith(`${normalizedSourcePath}${sep}`)
-        ) {
+        if (isPathInside(normalizedSourcePath, normalizedResourcePath)) {
           return { ...sourceInfo, path: resourcePath };
         }
       }
@@ -691,10 +689,7 @@ export class DefaultResourceLoader implements ResourceLoader {
 
       for (const [sourcePath, metadata] of metadataByPath.entries()) {
         const normalizedSourcePath = resolve(sourcePath);
-        if (
-          normalizedResourcePath === normalizedSourcePath ||
-          normalizedResourcePath.startsWith(`${normalizedSourcePath}${sep}`)
-        ) {
+        if (isPathInside(normalizedSourcePath, normalizedResourcePath)) {
           return createSourceInfo(resourcePath, metadata);
         }
       }
@@ -728,7 +723,7 @@ export class DefaultResourceLoader implements ResourceLoader {
     ];
 
     for (const root of agentRoots) {
-      if (this.isUnderPath(normalizedPath, root)) {
+      if (isPathInside(root, normalizedPath)) {
         return {
           path: filePath,
           source: "local",
@@ -740,7 +735,7 @@ export class DefaultResourceLoader implements ResourceLoader {
     }
 
     for (const root of projectRoots) {
-      if (this.isUnderPath(normalizedPath, root)) {
+      if (isPathInside(root, normalizedPath)) {
         return {
           path: filePath,
           source: "local",
@@ -993,15 +988,6 @@ export class DefaultResourceLoader implements ResourceLoader {
     }
 
     return undefined;
-  }
-
-  private isUnderPath(target: string, root: string): boolean {
-    const normalizedRoot = resolve(root);
-    if (target === normalizedRoot) {
-      return true;
-    }
-    const prefix = normalizedRoot.endsWith(sep) ? normalizedRoot : `${normalizedRoot}${sep}`;
-    return target.startsWith(prefix);
   }
 
   private detectExtensionConflicts(

--- a/src/skills/loading/session.test.ts
+++ b/src/skills/loading/session.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { withMockedWindowsPlatform } from "../../test-utils/vitest-spies.js";
 import { parseSkillFrontmatter, resolveSkillManifestMetadata } from "./frontmatter.js";
 import { loadSkills } from "./session.js";
 
@@ -125,5 +126,26 @@ description: Valid sibling
         message: expect.stringContaining("invalid frontmatter: BAD_INDENT"),
       }),
     ]);
+  });
+
+  it("keeps case-variant Windows project skill paths in project scope", async () => {
+    const root = tempDirs.make("openclaw-skill-scan-");
+    const projectDir = path.join(root, "project");
+    const skillDir = path.join(projectDir, ".openclaw", "skills", "project-skill");
+    const skillFile = path.join(skillDir, "SKILL.md");
+    await fs.mkdir(skillDir, { recursive: true });
+    await fs.writeFile(skillFile, "---\nname: project-skill\ndescription: Project skill.\n---\n");
+
+    expect(
+      withMockedWindowsPlatform(
+        () =>
+          loadSkills({
+            cwd: path.join(root, "PROJECT"),
+            agentDir: path.join(root, "agent"),
+            skillPaths: [skillFile],
+            includeDefaults: false,
+          }).skills[0]?.source,
+      ),
+    ).toBe("project");
   });
 });

--- a/src/skills/loading/session.ts
+++ b/src/skills/loading/session.ts
@@ -1,9 +1,10 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { basename, dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { CONFIG_DIR_NAME, getAgentDir } from "../../agents/config.js";
 import type { ResourceDiagnostic } from "../../agents/sessions/diagnostics.js";
 import { createSyntheticSourceInfo, type SourceInfo } from "../../agents/sessions/source-info.js";
 import { canonicalizePath } from "../../agents/utils/paths.js";
+import { isPathInside } from "../../infra/path-guards.js";
 import {
   addIgnoreRules,
   normalizeNativePathSeparators,
@@ -349,21 +350,12 @@ export function loadSkills(options: LoadSkillsOptions): LoadSkillsResult {
   const userSkillsDir = join(resolvedAgentDir, "skills");
   const projectSkillsDir = resolve(cwd, CONFIG_DIR_NAME, "skills");
 
-  const isUnderPath = (target: string, root: string): boolean => {
-    const normalizedRoot = resolve(root);
-    if (target === normalizedRoot) {
-      return true;
-    }
-    const prefix = normalizedRoot.endsWith(sep) ? normalizedRoot : `${normalizedRoot}${sep}`;
-    return target.startsWith(prefix);
-  };
-
   const getSource = (resolvedPath: string): "user" | "project" | "path" => {
     if (!includeDefaults) {
-      if (isUnderPath(resolvedPath, userSkillsDir)) {
+      if (isPathInside(userSkillsDir, resolvedPath)) {
         return "user";
       }
-      if (isUnderPath(resolvedPath, projectSkillsDir)) {
+      if (isPathInside(projectSkillsDir, resolvedPath)) {
         return "project";
       }
     }


### PR DESCRIPTION
## Summary

- preserve prompt-template, skill, and resource source metadata when Windows path casing differs
- replace eight bespoke lexical containment checks with the canonical `isPathInside(root, target)` guard
- remove three duplicate helpers and their unused `sep` imports

## Problem

The resources loaded successfully, but caller-local case-sensitive prefix checks could misclassify their source metadata on Windows. Case-variant user roots became temporary/path sources, project skills became path sources, and nested extra-source or package metadata inheritance fell back to local temporary metadata.

## Fix

Use the existing `src/infra/path-guards.ts` contract at all eight source-scope decisions. This preserves root equality, POSIX behavior, cross-drive rejection, mixed-separator handling, Windows case-insensitive comparison, and lexical-only semantics.

No authorization, loading, realpath, symlink, configuration, persistence, or migration behavior changes. `src/infra/path-guards.ts` itself is unchanged.

## Proof

Pre-fix caller-level regressions failed as expected:

- prompt templates: expected `scope: "user"`, received `"temporary"`
- skills session loader: expected `source: "project"`, received `"path"`
- resource loader table: default-root, nested extra-source, and nested package-metadata cases all fell back to temporary/local metadata

Post-fix:

```text
node scripts/run-vitest.mjs src/agents/sessions/prompt-templates.test.ts src/agents/sessions/resource-loader.test.ts src/skills/loading/session.test.ts src/infra/path-guards.test.ts
3 shards, 42 tests passed

pnpm check:changed
passed

pnpm check:import-cycles
0 runtime value cycles

git diff --check
passed
```

Pinned Sol/high autoreview: scoped clean, no accepted/actionable findings.

Native Windows attempt:

- An Azure Crabbox lease reached a native Windows host.
- GitHub-backed [`hydrate-windows-daemon` run 33382475310](https://github.com/openclaw/openclaw/actions/runs/33382475310) stayed queued because its ephemeral self-hosted runner disappeared before pickup.
- The raw host rejected the focused command before project execution because `node` and `corepack` were absent.
- The workflow was canceled and the lease released. No native test result is claimed.

Fallback evidence is the portable mocked-Windows red-green suite above plus direct inspection of `@openclaw/fs-safe@0.5.6`, whose `isPathInside` implementation selects `path.win32`, normalizes case and mixed separators, rejects cross-drive relative paths, preserves equality, and performs no filesystem resolution.

## Scope

- production: `+14/-44` (net `-30`)
- tests: `+81/-0`
- no changelog entry: internal bug fix with no new user-facing surface

## Provenance

- https://github.com/openclaw/openclaw/pull/85341
- https://github.com/openclaw/openclaw/pull/124870
