### PR TITLE
ci: resolve OpenGrep base before fetching history

### DIFF
--- a/.github/workflows/opengrep-precise.yml
+++ b/.github/workflows/opengrep-precise.yml
@@ -49,10 +49,19 @@ jobs:
           persist-credentials: false
           submodules: false
 
+      - name: Resolve PR scan base
+        id: scan-base
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          # Resolve the scan's merge parent before fetching a stale event-payload base.
+          base="$(node scripts/lib/merge-head-diff-base.mjs --base "$BASE_SHA" --head HEAD --prefer-first-parent)"
+          echo "sha=$base" >> "$GITHUB_OUTPUT"
+
       - name: Ensure PR base commit
         uses: ./.github/actions/ensure-base-commit
         with:
-          base-sha: ${{ github.event.pull_request.base.sha }}
+          base-sha: ${{ steps.scan-base.outputs.sha }}
           fetch-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Install opengrep
@@ -81,8 +90,7 @@ jobs:
 
       - name: Run opengrep on PR diff
         env:
-          OPENCLAW_OPENGREP_BASE_REF: ${{ github.event.pull_request.base.sha }}...HEAD
-          OPENCLAW_OPENGREP_MERGE_HEAD_FIRST_PARENT: "1"
+          OPENCLAW_OPENGREP_BASE_REF: ${{ steps.scan-base.outputs.sha }}...HEAD
         # Findings from precise rules block this workflow. Pull requests scan
         # changed first-party source paths only so findings stay attributable to
         # the PR diff. Test/fixture/QA path exclusions live in `.semgrepignore`

--- a/test/scripts/run-opengrep.test.ts
+++ b/test/scripts/run-opengrep.test.ts
@@ -1,6 +1,7 @@
 // Run Opengrep tests cover run opengrep script behavior.
 import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import { devNull } from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
@@ -45,6 +46,84 @@ function installOpengrepStub(repo: string): { argsPath: string; binDir: string }
   );
   fs.chmodSync(path.join(binDir, "opengrep"), 0o755);
   return { argsPath, binDir };
+}
+
+type OpengrepWorkflowStep = {
+  name: string;
+  id?: string;
+  run?: string;
+  uses?: string;
+  env?: Record<string, string>;
+  with?: Record<string, string>;
+};
+
+function runChangedPathsWorkflow(repo: string, base: string, env: NodeJS.ProcessEnv) {
+  const workflow = parse(fs.readFileSync(".github/workflows/opengrep-precise.yml", "utf8"));
+  const steps: OpengrepWorkflowStep[] = workflow.jobs.scan.steps;
+  const values = new Map([
+    ["github.event.pull_request.base.sha", base],
+    ["github.event.pull_request.base.ref", "main"],
+  ]);
+  const output = path.join(repo, "step-output.txt");
+  const interpolate = (value: string) =>
+    value.replace(/\$\{\{\s*(.*?)\s*\}\}/gu, (_match, expression: string) => {
+      const resolved = values.get(expression);
+      if (resolved === undefined) {
+        throw new Error(`Unbound workflow expression: ${expression}`);
+      }
+      return resolved;
+    });
+  const renderEnv = (bindings: Record<string, string> = {}) =>
+    Object.fromEntries(Object.entries(bindings).map(([key, value]) => [key, interpolate(value)]));
+  const run = (step: OpengrepWorkflowStep) => {
+    let command = step.run;
+    let commandEnv = renderEnv(step.env);
+    if (step.uses) {
+      const actionPath = path.join(repo, step.uses);
+      values.set("github.action_path", actionPath);
+      for (const [key, value] of Object.entries(step.with ?? {})) {
+        values.set(`inputs.${key}`, interpolate(value));
+      }
+      const action = parse(fs.readFileSync(path.join(actionPath, "action.yml"), "utf8"));
+      const actionStep: OpengrepWorkflowStep = action.runs.steps[0];
+      command = actionStep.run;
+      commandEnv = { ...commandEnv, ...renderEnv(actionStep.env) };
+    }
+    if (!command) {
+      throw new Error(`Workflow step has no executable command: ${step.name}`);
+    }
+    fs.writeFileSync(output, "");
+    const result = spawnSync("bash", ["-euo", "pipefail", "-c", interpolate(command)], {
+      cwd: repo,
+      env: { ...env, ...commandEnv, GITHUB_OUTPUT: output },
+      encoding: "utf8",
+    });
+    if (step.id) {
+      for (const line of fs.readFileSync(output, "utf8").trim().split("\n")) {
+        const separator = line.indexOf("=");
+        if (separator >= 0) {
+          values.set(
+            `steps.${step.id}.outputs.${line.slice(0, separator)}`,
+            line.slice(separator + 1),
+          );
+        }
+      }
+    }
+    return result;
+  };
+  const ensureIndex = steps.findIndex((step) => step.name === "Ensure PR base commit");
+  expect(ensureIndex).toBeGreaterThan(0);
+  for (const step of steps.slice(1, ensureIndex + 1)) {
+    const result = run(step);
+    if (result.status !== 0) {
+      return result;
+    }
+  }
+  const scan = steps.find((step) => step.name === "Run opengrep on PR diff");
+  if (!scan) {
+    throw new Error("Workflow has no scan step");
+  }
+  return run(scan);
 }
 
 describe("run-opengrep.sh", () => {
@@ -212,47 +291,90 @@ describe("run-opengrep.sh", () => {
     },
   );
 
-  it("scans PR files instead of main-only files when the payload base is stale", () => {
-    const repo = createTempDir("openclaw-run-opengrep-merge-");
-    git(repo, "init", "-q", "--initial-branch=main");
-    git(repo, "config", "user.email", "test@example.com");
-    git(repo, "config", "user.name", "Test User");
+  it.each([
+    { shape: "merge", branch: "main", depth: 2, passes: true },
+    { shape: "linear", branch: "feature", depth: 2, passes: true },
+    { shape: "merge without parents", branch: "main", depth: 1, passes: false },
+    { shape: "linear without base", branch: "feature", depth: 1, passes: false },
+  ])(
+    "prepares and scans a shallow $shape checkout without unrelated base fetches",
+    ({ branch, depth, passes }) => {
+      const source = createTempDir("openclaw-opengrep-source-");
+      git(source, "init", "-q", "--initial-branch=main");
+      git(source, "config", "user.email", "test@example.com");
+      git(source, "config", "user.name", "Test User");
+      copyRunOpengrepFiles(source);
+      for (const name of ["ensure-base-commit", "git-owner"]) {
+        fs.cpSync(`.github/actions/${name}`, path.join(source, ".github/actions", name), {
+          recursive: true,
+        });
+      }
+      writeFile(path.join(source, "security/opengrep/precise.yml"), "rules: []\n");
+      git(source, "add", ".");
+      git(source, "commit", "-qm", "base");
+      const staleBase = git(source, "rev-parse", "HEAD");
+      git(source, "switch", "-q", "-c", "feature");
+      writeFile(path.join(source, "src/pr.ts"), "export const pr = true;\n");
+      git(source, "add", ".");
+      git(source, "commit", "-qm", "feature");
+      git(source, "switch", "-q", "main");
+      writeFile(path.join(source, "src/main-only.ts"), "export const mainOnly = true;\n");
+      git(source, "add", ".");
+      git(source, "commit", "-qm", "main only");
+      git(source, "merge", "--no-ff", "feature", "-m", "synthetic merge");
 
-    copyRunOpengrepFiles(repo);
-    writeFile(path.join(repo, "security/opengrep/precise.yml"), "rules: []\n");
-    writeFile(path.join(repo, "README.md"), "base\n");
-    git(repo, "add", ".");
-    git(repo, "commit", "-qm", "base");
-    const staleBase = git(repo, "rev-parse", "HEAD");
-
-    git(repo, "switch", "-q", "-c", "feature");
-    writeFile(path.join(repo, "src/pr.ts"), "export const pr = true;\n");
-    git(repo, "add", ".");
-    git(repo, "commit", "-qm", "feature");
-
-    git(repo, "switch", "-q", "main");
-    writeFile(path.join(repo, "src/main-only.ts"), "export const mainOnly = true;\n");
-    git(repo, "add", ".");
-    git(repo, "commit", "-qm", "main only");
-    git(repo, "merge", "--no-ff", "feature", "-m", "synthetic merge");
-
-    const { argsPath, binDir } = installOpengrepStub(repo);
-
-    execFileSync("bash", ["scripts/run-opengrep.sh", "--changed"], {
-      cwd: repo,
-      env: {
+      const repo = createTempDir("openclaw-opengrep-shallow-");
+      git(
+        source,
+        "clone",
+        "--quiet",
+        "--no-local",
+        `--depth=${depth}`,
+        "--branch",
+        branch,
+        source,
+        repo,
+      );
+      expect(git(repo, "rev-parse", "--is-shallow-repository")).toBe("true");
+      const hasPayloadBase =
+        spawnSync("git", ["cat-file", "-e", `${staleBase}^{commit}`], { cwd: repo }).status === 0;
+      expect(hasPayloadBase).toBe(branch === "feature" && depth === 2);
+      const { argsPath, binDir } = installOpengrepStub(repo);
+      const trace = path.join(createTempDir("openclaw-opengrep-trace-"), "git.jsonl");
+      const result = runChangedPathsWorkflow(repo, staleBase, {
         ...process.env,
         PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
-        OPENCLAW_OPENGREP_BASE_REF: `${staleBase}...HEAD`,
-        OPENCLAW_OPENGREP_MERGE_HEAD_FIRST_PARENT: "1",
-      },
-      encoding: "utf8",
-    });
-
-    const args = fs.readFileSync(argsPath, "utf8");
-    expect(args).toContain("src/pr.ts");
-    expect(args).not.toContain("src/main-only.ts");
-  });
+        RUNNER_OS:
+          process.platform === "win32"
+            ? "Windows"
+            : process.platform === "darwin"
+              ? "macOS"
+              : "Linux",
+        GIT_CONFIG_GLOBAL: devNull,
+        GIT_CONFIG_NOSYSTEM: "1",
+        GIT_ALLOW_PROTOCOL: "",
+        GIT_TRACE2_EVENT: trace,
+      });
+      const fetches = fs
+        .readFileSync(trace, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line))
+        .filter((event) => event.event === "cmd_name" && event.name === "fetch");
+      if (!passes) {
+        expect(result.status, result.stderr).not.toBe(0);
+        expect(result.stdout).toContain("Base commit still unavailable");
+        expect(fetches).toHaveLength(5);
+        expect(fs.existsSync(argsPath)).toBe(false);
+        return;
+      }
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(fetches).toEqual([]);
+      const args = fs.readFileSync(argsPath, "utf8");
+      expect(args).toContain("src/pr.ts");
+      expect(args).not.toContain("src/main-only.ts");
+    },
+  );
 });
 
 describe("OpenGrep GitHub SARIF uploads", () => {


### PR DESCRIPTION
## Summary

OpenGrep PR setup could fail before scanning when main advanced after the pull-request event. The depth-two merge checkout contains its actual main parent, but setup tried to fetch the older event-base commit first. The scanner already selected the actual merge parent, so that network prerequisite was unnecessary.

Resolve the base once through the existing shared merge-parent helper and pass the same SHA to history preparation and scanning. Ordinary non-merge and unavailable-history paths retain their existing fail-closed behavior. Credentials, permissions, scan rules, exclusions, runner routing, timeouts and retry counts are unchanged.

## Validation

The regression executes the actual workflow shell and composite history action against real shallow Git repositories, with network protocols disabled. The old workflow reproduced one intended failure. On exact published head `d7efeac8232b2c7c44ad6834359f43de373fe444`, native Linux proof passed all 13 scanner cases and all 3 shared-resolver cases through their respective canonical tooling and unit-fast owners. Successful merge and linear cases make no fetches and scan only PR files. Missing-parent and missing-base cases still fail before scanning.

Focused lint, typecheck, formatting and actionlint passed. The complete two-path native changed-files gate passed all 14 checks in 122.91 seconds; source hashes stayed unchanged and its lease is closed. [Native proof](https://github.com/openclaw/openclaw/actions/runs/33384028506). Managed Codex review of both changed files found no actionable P0–P2 defects.

The observed pre-scan failure is run 33382146518, job 99456705806. Its single retry passed without code changes; this patch removes the unnecessary network dependency rather than claiming to repair the underlying authentication challenge.

Runtime production delta: 0. CI tooling: +8 net lines. Tests: +122 net lines, replacing the full-history scanner-only fixture with workflow-boundary coverage. No new production test seam.

## Limits and follow-up

This is a CI setup repair, with no user-facing product change. The [exact-head OpenGrep run](https://github.com/openclaw/openclaw/actions/runs/33383950297) passed base resolution, history preparation, the real scan, SARIF preparation, Code Scanning upload, and artifact upload. The retained job log confirms its intentional workflow-change smoke path, `scripts/run-opengrep.sh`: two applicable rules ran on one file with zero findings. This addresses the ClawSweeper rank-up request for integrated scan proof; the focused tests separately exercise fail-closed history cases. Separate named documentation follow-up: docs/ci.md describes standalone OpenGrep as hosted, while the current workflow can select Blacksmith; this PR does not change that routing.
