### PR TITLE
fix: preserve speech and process output through nested tools

### DIFF
--- a/packages/agent-core/src/internal-hooks.ts
+++ b/packages/agent-core/src/internal-hooks.ts
@@ -145,15 +145,6 @@ export function attachInternalToolResultAcknowledgement<T extends object>(
   return value;
 }
 
-/** Carry private commit ownership through result transforms and message construction. */
-function copyInternalToolResultAcknowledgement<T extends object>(source: object, target: T): T {
-  const acknowledge = toolResultAcknowledgementByValue.get(source);
-  if (acknowledge) {
-    toolResultAcknowledgementByValue.set(target, acknowledge);
-  }
-  return target;
-}
-
 export function attachInternalToolResultProvenance<T extends object>(
   value: T,
   provenance: object,
@@ -166,8 +157,12 @@ export function getInternalToolResultProvenance(value: object): object | undefin
   return toolResultProvenanceByValue.get(value);
 }
 
+/** Carry private commit ownership through result transforms and message construction. */
 export function copyInternalToolResultState<T extends object>(source: object, target: T): T {
-  copyInternalToolResultAcknowledgement(source, target);
+  const acknowledge = toolResultAcknowledgementByValue.get(source);
+  if (acknowledge) {
+    toolResultAcknowledgementByValue.set(target, acknowledge);
+  }
   const provenance = toolResultProvenanceByValue.get(source);
   if (provenance) {
     toolResultProvenanceByValue.set(target, provenance);

--- a/src/agents/bash-tools.process.delivery.test.ts
+++ b/src/agents/bash-tools.process.delivery.test.ts
@@ -1,6 +1,13 @@
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, expect, test, vi } from "vitest";
 import { copyInternalToolResultState } from "../../packages/agent-core/src/internal-hooks.js";
 import { runWithAgentToolExecutionContext } from "../../packages/agent-core/src/tool-execution-context.js";
+import {
+  initializeGlobalHookRunner,
+  resetGlobalHookRunner,
+} from "../plugins/hook-runner-global.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import type { PluginHookBeforeMessageWriteEvent } from "../plugins/types.js";
 import {
   addSession,
   appendOutput,
@@ -10,12 +17,22 @@ import {
 import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
 import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
 import { createProcessTool } from "./bash-tools.process.js";
+import { createSubscribedCodeModeHarness } from "./code-mode.bridge.lifecycle.test-support.js";
+import { applyCodeModeCatalog } from "./code-mode.js";
+import {
+  resetCodeModeTestState,
+  resultDetails,
+  waitUntilCompleted,
+} from "./code-mode.test-support.js";
 import type { AgentMessage, AgentToolResult } from "./runtime/index.js";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 import { SessionManager } from "./sessions/index.js";
 import { makeAgentAssistantMessage } from "./test-helpers/agent-message-fixtures.js";
+import { snapshotToolSearchTargetTranscriptResult } from "./tool-search-transcript.js";
 
 afterEach(() => {
+  resetGlobalHookRunner();
+  resetCodeModeTestState();
   resetProcessRegistryForTests();
 });
 
@@ -96,13 +113,17 @@ test.each(["running", "completed"] as const)(
     const guard = installSessionToolResultGuard(manager);
 
     const droppedTurn = processTurn(`${status}-dropped`, sessionId);
-    const dropped = await poll(processTool, sessionId, droppedTurn.toolCall.id, droppedTurn);
+    const dropped = snapshotToolSearchTargetTranscriptResult(
+      await poll(processTool, sessionId, droppedTurn.toolCall.id, droppedTurn),
+    );
     expect(resultText(dropped)).toContain(`${status}-output`);
     manager.appendMessage(droppedTurn.assistantMessage);
     guard.flushPendingToolResults();
 
     const retryTurn = processTurn(`${status}-retry`, sessionId);
-    const retry = await poll(processTool, sessionId, retryTurn.toolCall.id, retryTurn);
+    const retry = snapshotToolSearchTargetTranscriptResult(
+      await poll(processTool, sessionId, retryTurn.toolCall.id, retryTurn),
+    );
     expect(resultText(retry)).toContain(`${status}-output`);
     manager.appendMessage(retryTurn.assistantMessage);
     persistResult(manager, retryTurn.toolCall.id, retry);
@@ -111,6 +132,107 @@ test.each(["running", "completed"] as const)(
     expect(resultText(observed)).not.toContain(`${status}-output`);
   },
 );
+
+test.each(["transformed", "blocked", "error"] as const)(
+  "preserves poll acknowledgement through %s nested activity persistence",
+  async (mode) => {
+    const session = createProcessSessionFixture({ id: "nested-poll", backgrounded: true });
+    addSession(session);
+    appendOutput(session, "stdout", "nested-output\n");
+    if (mode === "error") {
+      markExited(session, 1, null, "failed");
+    }
+    let writes = 0;
+    const registry = createEmptyPluginRegistry();
+    registry.typedHooks.push({
+      pluginId: "nested-poll-write",
+      hookName: "before_message_write",
+      source: "test",
+      handler: ({ message }: PluginHookBeforeMessageWriteEvent) => {
+        if (message.role !== "custom") {
+          return undefined;
+        }
+        writes += 1;
+        return mode === "blocked" && writes === 1 ? { block: true } : { message: { ...message } };
+      },
+    });
+    initializeGlobalHookRunner(registry);
+    const harness = createSubscribedCodeModeHarness({ name: "poll-persistence" });
+    applyCodeModeCatalog({ ...harness, tools: [...harness.tools, createProcessTool()] });
+    const execTool = expectDefined(harness.tools[0], "Code Mode exec tool");
+    const waitTool = expectDefined(harness.tools[1], "Code Mode wait tool");
+    const code = 'return await process({ action: "poll", sessionId: "nested-poll" });';
+    const pollThroughBridge = async (id: string) => {
+      const toolCall = { type: "toolCall" as const, id, name: execTool.name, arguments: { code } };
+      const assistantMessage = makeAgentAssistantMessage({
+        content: [toolCall],
+        stopReason: "toolUse",
+      });
+      return await runWithAgentToolExecutionContext({ assistantMessage, toolCall }, async () => {
+        const details = resultDetails(await execTool.execute(id, { code }));
+        return await waitUntilCompleted({ details, waitTool });
+      });
+    };
+    try {
+      expect(await pollThroughBridge("nested-first")).toMatchObject({ status: "completed" });
+      expect(harness.nestedToolActivities).toHaveLength(1);
+      expect(harness.nestedToolActivities[0]?.details.result.content).toContainEqual(
+        expect.objectContaining({ type: "text", text: expect.stringContaining("nested-output") }),
+      );
+      if (mode === "error") {
+        expect(harness.nestedToolActivities[0]?.details.isError).toBe(true);
+      }
+
+      expect(await pollThroughBridge("nested-next-turn")).toMatchObject({ status: "completed" });
+      expect(harness.nestedToolActivities).toHaveLength(2);
+      if (mode === "blocked") {
+        expect(harness.nestedToolActivities[1]?.details.result.content).toContainEqual(
+          expect.objectContaining({ type: "text", text: expect.stringContaining("nested-output") }),
+        );
+        expect(await pollThroughBridge("nested-after-retry")).toMatchObject({
+          status: "completed",
+        });
+      }
+      expect(harness.nestedToolActivities.at(-1)?.details.result.content).not.toContainEqual(
+        expect.objectContaining({ type: "text", text: expect.stringContaining("nested-output") }),
+      );
+      expect(writes).toBe(mode === "blocked" ? 3 : 2);
+      expect(
+        harness.sessionManager
+          .getEntries()
+          .filter((entry) => entry.type === "message" && entry.message.role === "custom"),
+      ).toHaveLength(2);
+    } finally {
+      harness.dispose();
+    }
+  },
+);
+
+test("a retained old snapshot cannot consume a successor poll delivery", async () => {
+  const session = createProcessSessionFixture({ id: "retained-poll", backgrounded: true });
+  addSession(session);
+  appendOutput(session, "stdout", "old-output\n");
+  const processTool = createProcessTool();
+  const firstTurn = processTurn("old-result", session.id);
+  const result = await poll(processTool, session.id, firstTurn.toolCall.id, firstTurn);
+  const retained = snapshotToolSearchTargetTranscriptResult(result);
+  const manager = SessionManager.inMemory();
+  installSessionToolResultGuard(manager);
+  manager.appendMessage(firstTurn.assistantMessage);
+  persistResult(manager, firstTurn.toolCall.id, result);
+
+  appendOutput(session, "stdout", "successor-output\n");
+  expect(resultText(await poll(processTool, session.id, "successor-dropped"))).toContain(
+    "successor-output",
+  );
+  const retainedTurn = processTurn("retained-old-result", session.id);
+  manager.appendMessage(retainedTurn.assistantMessage);
+  persistResult(manager, retainedTurn.toolCall.id, retained);
+
+  expect(resultText(await poll(processTool, session.id, "successor-retry"))).toContain(
+    "successor-output",
+  );
+});
 
 test.each(["initial", "retry"] as const)(
   "does not duplicate $phase output across parallel polls from one assistant turn",

--- a/src/agents/code-mode.bridge.lifecycle.test-support.ts
+++ b/src/agents/code-mode.bridge.lifecycle.test-support.ts
@@ -17,6 +17,7 @@ export function createSubscribedCodeModeHarness(params: {
   onToolResult?: EmbeddedRunAttemptParams["onToolResult"];
   onBlockReply?: EmbeddedRunAttemptParams["onBlockReply"];
   onPartialReply?: EmbeddedRunAttemptParams["onPartialReply"];
+  sourceReplyDeliveryMode?: EmbeddedRunAttemptParams["sourceReplyDeliveryMode"];
   timeoutMs?: number;
   observeToolTerminal?: EmbeddedRunAttemptParams["observeToolTerminal"];
   onToolStreamBoundary?: EmbeddedRunAttemptParams["onToolStreamBoundary"];
@@ -50,6 +51,7 @@ export function createSubscribedCodeModeHarness(params: {
       observeToolTerminal: params.observeToolTerminal,
       onToolStreamBoundary: params.onToolStreamBoundary,
       onPartialReply: params.onPartialReply,
+      sourceReplyDeliveryMode: params.sourceReplyDeliveryMode,
       blockReplyBreak: "message_end",
     } as never,
     activeSession: activeSession as never,

--- a/src/agents/code-mode.bridge.tts-delivery.test.ts
+++ b/src/agents/code-mode.bridge.tts-delivery.test.ts
@@ -1,0 +1,175 @@
+/** Nested TTS crosses real catalog acceptance and subscribed source delivery. */
+import { expectDefined } from "@openclaw/normalization-core";
+import { Type } from "typebox";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import type { ReplyPayload } from "../auto-reply/reply-payload.js";
+import { shouldDeliverDespiteSourceReplySuppression } from "../auto-reply/reply/dispatch-from-config.payloads.js";
+import * as ttsRuntime from "../tts/tts.js";
+import { createSubscribedCodeModeHarness } from "./code-mode.bridge.lifecycle.test-support.js";
+import { applyCodeModeCatalog } from "./code-mode.js";
+import { resetCodeModeTestState, runUntilCompleted } from "./code-mode.test-support.js";
+import { ToolSearchRuntime } from "./tool-search-runtime.js";
+import { resolveToolSearchConfig } from "./tool-search.js";
+import { jsonResult, type AnyAgentTool } from "./tools/common.js";
+import { createTtsTool } from "./tools/tts-tool.js";
+
+const audioPath = "/tmp/nested-tts-reply.mp3";
+const speechResult = {
+  success: true,
+  audioPath,
+  provider: "test",
+  voiceCompatible: false,
+};
+const suppressionState = {
+  ctx: {},
+  explicitCommandTurnCtx: false,
+  suppressAutomaticSourceDelivery: true,
+  sendPolicyDenied: false,
+};
+
+function createTtsHarness(name: string, target: AnyAgentTool = createTtsTool({ config: {} })) {
+  const delivered: ReplyPayload[] = [];
+  const harness = createSubscribedCodeModeHarness({
+    name,
+    sourceReplyDeliveryMode: "message_tool_only",
+    onBlockReply: (payload) => {
+      if (shouldDeliverDespiteSourceReplySuppression(payload, suppressionState)) {
+        delivered.push(payload);
+      }
+    },
+  });
+  applyCodeModeCatalog({ ...harness, tools: [...harness.tools, target] });
+  const runtime = new ToolSearchRuntime(harness, resolveToolSearchConfig(harness.config));
+  return { ...harness, runtime, delivered };
+}
+
+async function finishReply(harness: ReturnType<typeof createTtsHarness>, text = "") {
+  const message = {
+    role: "assistant",
+    content: text ? [{ type: "text", text }] : [],
+    stopReason: "stop",
+  };
+  harness.emit({ type: "message_start", message });
+  harness.emit({ type: "message_end", message });
+  harness.emit({ type: "agent_end", messages: [message], willRetry: false });
+  await harness.subscription.waitForPendingEvents();
+}
+
+describe("Code Mode nested TTS delivery", () => {
+  afterEach(() => {
+    resetCodeModeTestState();
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ["private", "Private final text must not be sent."],
+    ["empty", ""],
+  ])("delivers accepted speech with a %s final", async (name, finalText) => {
+    const synthesize = vi.spyOn(ttsRuntime, "textToSpeech").mockResolvedValue(speechResult);
+    const harness = createTtsHarness(name);
+    try {
+      const result = await runUntilCompleted({
+        execTool: expectDefined(harness.tools[0], "Code Mode exec tool"),
+        waitTool: expectDefined(harness.tools[1], "Code Mode wait tool"),
+        code: 'return await tts({ text: "Synthetic speech" });',
+      });
+      expect(result.status).toBe("completed");
+      expect(synthesize).toHaveBeenCalledOnce();
+      await finishReply(harness, finalText);
+
+      expect(harness.delivered).toEqual([
+        expect.objectContaining({ mediaUrl: audioPath, mediaUrls: [audioPath] }),
+      ]);
+      expect(harness.delivered[0]?.text).toBeUndefined();
+      expect(
+        shouldDeliverDespiteSourceReplySuppression(
+          expectDefined(harness.delivered[0], "delivered speech"),
+          { ...suppressionState, sendPolicyDenied: true },
+        ),
+      ).toBe(false);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it("does not authorize same-shaped unmarked media", async () => {
+    const target = createTtsTool({ config: {} });
+    target.execute = vi.fn(async () =>
+      jsonResult({ media: { mediaUrl: audioPath, trustedLocalMedia: true } }),
+    );
+    const harness = createTtsHarness("unmarked", target);
+    try {
+      await harness.runtime.call("tts", { text: "Synthetic speech" });
+      expect(target.execute).toHaveBeenCalledOnce();
+      await finishReply(harness, "Private final text.");
+      expect(harness.delivered).toEqual([]);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it("does not deliver synthesized speech rejected by output acceptance", async () => {
+    const synthesize = vi.spyOn(ttsRuntime, "textToSpeech").mockResolvedValue(speechResult);
+    const target = createTtsTool({ config: {} });
+    target.outputSchema = Type.Object({ accepted: Type.Boolean() });
+    const harness = createTtsHarness("rejected-output", target);
+    try {
+      await expect(harness.runtime.call("tts", { text: "Synthetic speech" })).rejects.toThrow(
+        "returned details that do not match its declared outputSchema",
+      );
+      expect(synthesize).toHaveBeenCalledOnce();
+      await finishReply(harness);
+      expect(harness.delivered).toEqual([]);
+      expect(harness.subscription.toolMetas).toEqual([
+        expect.objectContaining({ toolName: "tts", isError: true }),
+      ]);
+    } finally {
+      harness.dispose();
+    }
+  });
+
+  it("does not publish a raw speech result that completes after cancellation", async () => {
+    const started = createDeferred();
+    const releaseSpeech = createDeferred();
+    const acceptedLateResult = createDeferred();
+    vi.spyOn(ttsRuntime, "textToSpeech").mockImplementation(async () => {
+      started.resolve();
+      await releaseSpeech.promise;
+      return speechResult;
+    });
+    const harness = createTtsHarness("late-abort");
+    const lifecycle = vi.spyOn(harness.subscription, "runToolLifecycle");
+    const runtime = new ToolSearchRuntime(
+      {
+        ...harness,
+        executeTool: (params) =>
+          harness.executeTool({
+            ...params,
+            acceptResultBeforeProjection: async (result) => {
+              const accepted = await params.acceptResultBeforeProjection(result);
+              acceptedLateResult.resolve();
+              return accepted;
+            },
+          }),
+      },
+      resolveToolSearchConfig(harness.config),
+    );
+    try {
+      const call = runtime.call("tts", { text: "Synthetic speech" });
+      const rejected = expect(call).rejects.toMatchObject({ name: "AbortError" });
+      await started.promise;
+      harness.runAbortController.abort(new Error("cancel nested speech"));
+      await rejected;
+      // The outer abort race settles before nested terminal cleanup finishes.
+      await expect(lifecycle.mock.results[0]?.value).rejects.toMatchObject({ name: "AbortError" });
+      releaseSpeech.resolve();
+      await acceptedLateResult.promise;
+      await finishReply(harness);
+      expect(harness.delivered).toEqual([]);
+    } finally {
+      releaseSpeech.resolve();
+      harness.dispose();
+    }
+  });
+});

--- a/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-prepare.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 /**
  * Prepares stream subscription, tool execution, and the active run queue.
  */
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { isSilentReplyText, SILENT_REPLY_TOKEN } from "../../../auto-reply/tokens.js";
 import { runWithOwnedSessionTranscriptWrite } from "../../../config/sessions/transcript-write-context.js";
@@ -39,7 +40,10 @@ import {
   isAgentRunRestartAbortReason,
 } from "../../run-termination.js";
 import type { AgentMessage } from "../../runtime/index.js";
-import { getInternalToolExecutionPreparer } from "../../runtime/internal-hooks.js";
+import {
+  copyInternalToolResultState,
+  getInternalToolExecutionPreparer,
+} from "../../runtime/internal-hooks.js";
 import type { AgentSession } from "../../sessions/index.js";
 import { hashToolCall } from "../../tool-loop-detection.js";
 import { normalizeToolPolicyName } from "../../tool-policy.js";
@@ -395,20 +399,23 @@ export function prepareEmbeddedAttemptStream(input: {
           "hideFromChannelProgress" in toolParams.tool &&
           toolParams.tool.hideFromChannelProgress === true,
         onTerminal: async (terminal) => {
-          const activity = createNestedToolActivity({
-            runId: attempt.runId,
-            scopeId: activityScope,
-            afterEntryId,
-            startOrder,
-            parentToolCallId: toolParams.parentToolCallId,
-            toolCallId: toolParams.toolCallId,
-            toolName: toolParams.toolName,
-            input: terminal.executedArguments,
-            result: sanitizeToolResult(terminal.result),
-            isError: terminal.isError,
-            startedAt,
-            timestamp: Date.now(),
-          });
+          const message = {
+            ...createNestedToolActivity({
+              runId: attempt.runId,
+              scopeId: activityScope,
+              afterEntryId,
+              startOrder,
+              parentToolCallId: toolParams.parentToolCallId,
+              toolCallId: toolParams.toolCallId,
+              toolName: toolParams.toolName,
+              input: terminal.executedArguments,
+              result: sanitizeToolResult(terminal.result),
+              isError: terminal.isError,
+              startedAt,
+              timestamp: Date.now(),
+            }),
+            idempotencyKey: `${activityScope}:${toolParams.toolCallId}`,
+          };
           await runWithOwnedSessionTranscriptWrite(
             { sessionTarget: manager.getSessionTarget(), sessionKey: attempt.sessionKey },
             () => {
@@ -419,13 +426,12 @@ export function prepareEmbeddedAttemptStream(input: {
               ) {
                 return;
               }
-              const message = {
-                ...activity,
-                idempotencyKey: `${activityScope}:${toolParams.toolCallId}`,
-              };
+              if (isRecord(terminal.result)) {
+                copyInternalToolResultState(terminal.result, message);
+              }
               manager.appendMessage(message);
               const recorded = readNestedToolActivity(
-                redactTranscriptMessage(activity, attempt.config),
+                redactTranscriptMessage(message, attempt.config),
               );
               if (!recorded) {
                 throw new Error("Nested activity became invalid during transcript redaction");

--- a/src/agents/runtime/internal-hooks.ts
+++ b/src/agents/runtime/internal-hooks.ts
@@ -5,6 +5,7 @@ export {
   attachInternalToolResultAcknowledgement,
   attachInternalToolResultProvenance,
   copyInternalToolExecutionPreparer,
+  copyInternalToolResultState,
   getInternalToolResultProvenance,
   getInternalToolExecutionPreparer,
   setInternalBeforeToolBatch,

--- a/src/agents/session-tool-result-guard.ts
+++ b/src/agents/session-tool-result-guard.ts
@@ -980,6 +980,7 @@ export function installSessionToolResultGuard(
           callerInvalidatesCache || transformedMessage !== nextMessage || finalWrite.changed,
       },
       sourceAppend,
+      message,
     );
     if (sessionTarget) {
       const runId = resolveTerminalAssistantTranscriptRunId(persistedMessage, transcriptRunId);

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -12,7 +12,6 @@ import {
 import { runWithToolExecutionValidation } from "./agent-tools.execution-validation.js";
 import { getChannelAgentToolMeta } from "./channel-tool-metadata.js";
 import type { AgentToolResult } from "./runtime/index.js";
-import { transferToolEffectReceipt } from "./tool-effect-receipt.js";
 import { isAgentToolReplaySafe } from "./tool-replay-safety.js";
 import {
   isTrustedToolExecutionPreflightError,
@@ -624,8 +623,6 @@ export class ToolSearchRuntime {
         await assertCatalogOutputMatchesSchema(entry, candidate);
       }
       const snapshot = snapshotToolSearchTargetTranscriptResult(candidate);
-      // Projection changes object identity; move the private terminal receipt with it.
-      transferToolEffectReceipt(candidate, snapshot);
       await assertCatalogOutputMatchesSchema(entry, snapshot);
       return snapshot;
     };

--- a/src/agents/tool-search-transcript.ts
+++ b/src/agents/tool-search-transcript.ts
@@ -1,6 +1,8 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { transferMcpCodeModeGuestResult } from "./mcp-content.js";
 import type { AgentToolResult } from "./runtime/index.js";
+import { copyInternalToolResultState } from "./runtime/internal-hooks.js";
+import { transferToolEffectReceipt } from "./tool-effect-receipt.js";
 import { toToolSearchJsonSafe } from "./tool-search-json.js";
 
 function freezeJsonSnapshot(value: unknown): unknown {
@@ -28,8 +30,7 @@ export function snapshotToolSearchTargetTranscriptResult(
     snapshot.details =
       result.details === undefined ? undefined : toToolSearchJsonSafe(result.details);
   }
-  return transferMcpCodeModeGuestResult(
-    result,
-    freezeJsonSnapshot(snapshot) as AgentToolResult<unknown>,
-  );
+  const target = freezeJsonSnapshot(snapshot) as AgentToolResult<unknown>;
+  transferToolEffectReceipt(result, target);
+  return transferMcpCodeModeGuestResult(result, copyInternalToolResultState(result, target));
 }


### PR DESCRIPTION
Related: #133968, #133324

## What Problem This Solves

Speech requested through Code Mode or Tool Search could disappear after synthesis succeeded. Nested process polling could also replay output already attached to the conversation.

## Why This Change Was Made

The nested snapshot and activity-message projections dropped private delivery provenance and acknowledgement state. Both now use the existing canonical internal state copier; the existing durable append remains the only acknowledgement point. This removes duplicate effect-receipt copying and the single-use acknowledgement wrapper.

The writer revalidates its exact active attempt after awaited admission. Guest JSON cannot create private authority; blocked or failed persistence leaves process output replayable, while durably recorded nonzero-exit output is acknowledged. No configuration, dependency, protocol, schema, transcript format, or persistence policy changes.

Production: **+38/-37, net +1**. Tests/support: **+301/-2, net +299**. The remaining production line carries original result identity into the existing durable append after consolidating the duplicate paths. Exact first shipped introduction is unknown.

## Evidence

Current candidate: `f41ecd2c0cfad1841e12964d763b3a7420bdd60b`, mechanically rebased onto `e8ffa3557d724961b4b4b16f7ae0a10b4b4437f2`. The range-diff is identical and all nine repair files retain their prior bytes. This picks up main's existing bounded plugin lint batches (#134031), without adding a CI workaround here.

The failure-first reproductions cover private-state loss and real nested process persistence. On the refreshed candidate, all **24 selected owner/sibling regressions pass** (140 unrelated cases unselected), the canonical private-QA build passes, and fresh isolated Codex review is scoped-clean for **P0–P2**. The full changed-file gate passed on the byte-identical repair before this mechanical rebase.

The prior exact-head built Gateway matrix on `686475fbe2399f5bd289c6362722ca497e94dcaa` passed **8/8 cases, 164 checks**: Code Mode exec/wait and Tool Search code, each with allow/deny policy and empty/private final text. Allowed cases delivered one exact WAV; denied cases emitted no message or preview; private text did not leak; durable outer outcomes and actual nested lifecycle IDs matched. All Gateways stopped, and source plus the full dist manifest stayed unchanged.

The fresh eight-case matrix on this candidate finished **7/8 passing, 148/164 checks; overall EXIT 1**. All four allowed cases delivered exactly one WAV and completed; all three denied cases that reached the Gateway completed with no outbound message/audio or private-text leak. The sole failure was Code Mode deny/empty: installed-plugin CLI setup exceeded its unchanged 120-second deadline before any model, synthesis, tool or Gateway scenario ran. This is a recorded setup failure, not a passing denial test or a demonstrated delivery regression. A separate targeted rerun is recorded below. All eight cleanups confirmed the owned processes stopped without errors; the complete dist manifest and nine repair-file hashes were unchanged. The earlier complete matrix remains separate historical evidence for the identical repair bytes.

The previously unexecuted Code Mode deny/empty case was rerun alone on unchanged `f41ecd2`, using a separate fixture selection with the same canonical calls, assertions and deadlines. It passed **19/19 checks** (exit0,55.1 seconds): one nested synthesis, no outbound audio/message under the observed deny policy, and a completed durable outer turn. All nine source hashes and12,769 built entries remained unchanged; the Gateway and isolated state were cleaned up. The original **7/8 failed matrix is preserved** alongside this **separate1/1 pass**, not relabeled as one8/8 run.

The CLI build, Gateway, plugin registration, nested tools, dispatcher, persistence, media loader and QA channel are real. Model and speech HTTP are synthetic. This does not claim authenticated providers, external recipients, native Codex, microphone or browser-media proof. Unmarked, schema-rejected, cancelled and stale-owner result cases are owner regressions, not additional live-channel scenarios.

## Review and CI

The August31 16:43 UTC ClawSweeper review found no actionable patch defect. Both rank-up moves are now complete: the missing exact-head deny/empty case passed separately, and exact-head required CI is green. The generic delivery owner is covered above; no Telegram transport or encoding changes, and no separate Telegram playback claim.

Old-head CI run [33384146494](https://github.com/openclaw/openclaw/actions/runs/33384146494) failed after precise retries. Attempt 2 explicitly reported runner shutdown; attempts 3/4 showed cancellation without a lint/type diagnostic, OOM or identified cancellation owner. Those causes remain unknown. The rebase includes the existing low-memory lint batching improvement but does not prove memory caused the old failures. No deadline, required gate or runner policy was weakened. An earlier remote Testbox request failed before lease allocation with HTTP 429; no remote proof is claimed.

Named follow-up: a before-write hook can leave an in-memory recovery activity after blocking durable append. Acknowledgement remains withheld; no additional user-visible defect was established, and this repair does not change that retention policy.

Release note: preserve speech delivery and process-output acknowledgement through nested Code Mode and Tool Search results.

Fresh-head CI run [33413600515](https://github.com/openclaw/openclaw/actions/runs/33413600515) has a concrete failure in job 99559327368: `doctor-session-sqlite.memory.test.ts` exhausted the explicit 256 MiB child heap while importing one public transcript with 100,000 events. The same shard passed 383 other tests. This is a new diagnosed test failure; it is not attributed to the old lint cancellations or to this patch without owner-path proof. Three separate Linux Testbox runs on the exact CI merge tree, Node24.19.0 and unchanged256MiB heap have since passed: eight-event controls, original100,000-event controls with phase diagnostics, and the **unmodified canonical test file (batch,deep,public:3/3)** through its normal CI runner and commands-project setup. The public unmodified case completed in34.667 seconds. All leases are stopped. Diagnostic phase measurements show near-cap memory use during21plugin Doctor contract loads, but neither a reproduced OOM phase nor involvement of this repair is established. The original failed CI shard then passed on one diagnosed replay: attempt2 completed **success** at17:39:08 UTC on the unchanged candidate. The original OOM is still not causally attributed; the diagnostics are not a claimed source fix. No heap limit, assertion or required gate changed. Named follow-up: investigate the narrow memory margin during plugin Doctor contract loading if the failure recurs.
