### PR TITLE
fix(ci): fetch pinned Kova archive with retries

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -75,6 +75,7 @@ env:
   OCM_VERSION: v0.2.33
   OCM_LINUX_X64_SHA256: 06b0e46791e750eb044e4a898b6643ad5e7b20224fe0c64f160e35a42f08d00a
   KOVA_REPOSITORY: openclaw/Kova
+  KOVA_ARCHIVE_SHA256: 8cb2f4dd90e1bd5a5615d5d14f7766136057c4c5e66d399b5efb4d59a50dee7e
   KOVA_CANONICAL_CONFIG_REF: 81919463ef9620722373c813192c688573f2b533
   KOVA_LEGACY_LIST_CONFIG_REF: 81919463ef9620722373c813192c688573f2b533
   KOVA_TRUSTED_LIVE_REF: 81919463ef9620722373c813192c688573f2b533
@@ -419,12 +420,24 @@ jobs:
           tar -xzf "$ocm_archive" -C "${RUNNER_TEMP}/ocm-install"
           install -m 0755 "${RUNNER_TEMP}/ocm-install/ocm" "$HOME/.local/bin/ocm"
 
-          python3 -I -S "$CI_GIT_OWNER" --git 0 init -b main "$KOVA_SRC"
-          python3 -I -S "$CI_GIT_OWNER" --git 0 -C "$KOVA_SRC" remote add origin "https://github.com/${KOVA_REPOSITORY}.git"
-          # The complete worktree is consumed next; do not defer its blobs to a
-          # second unauthenticated promisor fetch during checkout.
-          python3 -I -S "$CI_GIT_OWNER" --git 0 -C "$KOVA_SRC" fetch --depth 1 origin "$KOVA_REF"
-          python3 -I -S "$CI_GIT_OWNER" --git 0 -C "$KOVA_SRC" checkout --detach FETCH_HEAD
+          if [[ "$KOVA_REF" == "$KOVA_TRUSTED_LIVE_REF" ]]; then
+            kova_archive="${RUNNER_TEMP}/kova-${KOVA_REF}.tar.gz"
+            mkdir -p "$KOVA_SRC"
+            curl -fsSL --proto '=https' --tlsv1.2 \
+              --max-time 180 \
+              --retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused \
+              -o "$kova_archive" \
+              "https://codeload.github.com/${KOVA_REPOSITORY}/tar.gz/${KOVA_REF}"
+            echo "${KOVA_ARCHIVE_SHA256}  ${kova_archive}" | sha256sum -c -
+            tar -xzf "$kova_archive" --strip-components=1 -C "$KOVA_SRC"
+          else
+            python3 -I -S "$CI_GIT_OWNER" --git 0 init -b main "$KOVA_SRC"
+            python3 -I -S "$CI_GIT_OWNER" --git 0 -C "$KOVA_SRC" remote add origin "https://github.com/${KOVA_REPOSITORY}.git"
+            # The complete worktree is consumed next; do not defer its blobs to a
+            # second unauthenticated promisor fetch during checkout.
+            python3 -I -S "$CI_GIT_OWNER" --git 0 -C "$KOVA_SRC" fetch --depth 1 origin "$KOVA_REF"
+            python3 -I -S "$CI_GIT_OWNER" --git 0 -C "$KOVA_SRC" checkout --detach FETCH_HEAD
+          fi
           npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund
           node - "$KOVA_SRC" <<'NODE'
           const fs = require("node:fs");

--- a/test/scripts/ci-git-owner-auth.test.ts
+++ b/test/scripts/ci-git-owner-auth.test.ts
@@ -89,7 +89,7 @@ it.skipIf(process.platform === "win32").each([
 );
 
 it.skipIf(process.platform === "win32")(
-  "Kova checkout is complete after its initial public fetch closes",
+  "custom Kova checkout is complete after its initial public fetch closes",
   async () => {
     const report = await runAuthFixture(
       "kova",

--- a/test/scripts/fixtures/ci-checkout-auth.py
+++ b/test/scripts/fixtures/ci-checkout-auth.py
@@ -173,7 +173,8 @@ node() { :; }
                 "RUNNER_TEMP": str(root), "KOVA_HOME": str(home / "kova"),
                 "GITHUB_ENV": str(root / "environment"), "GITHUB_PATH": str(root / "path"),
                 "OCM_VERSION": "fixture", "OCM_LINUX_X64_SHA256": "fixture",
-                "KOVA_REPOSITORY": "fixture/kova", "KOVA_REF": revision})
+                "KOVA_REPOSITORY": "fixture/kova", "KOVA_REF": revision,
+                "KOVA_TRUSTED_LIVE_REF": "trusted-fixture-ref"})
             complete = result.returncode == 0 and (workspace / "payload.txt").read_text() == (source / "payload.txt").read_text()
             local_config = (workspace / ".git/config").read_text()
             assert token not in result.stdout + result.stderr + local_config

--- a/test/scripts/openclaw-performance-git-lifecycle.test.ts
+++ b/test/scripts/openclaw-performance-git-lifecycle.test.ts
@@ -1,5 +1,6 @@
 import { beforeAll, expect, it, vi } from "vitest";
 import { runCiGitStep } from "./ci-git-owner.test-support.js";
+import type { PerformanceFixtureOptions } from "./openclaw-performance-workflow.test-support.js";
 
 // Each case owns its checkout and process trees. Overlap their real timeout and
 // drain waits while keeping subprocess pressure bounded.
@@ -16,12 +17,13 @@ const steps = {
   target: ["resolve_target", "Resolve OpenClaw target ref"],
   record: ["source_performance", "Record source performance revision"],
   tested: ["kova", "Record tested revision"],
+  kova: ["kova", "Install OCM and Kova"],
   baseline: ["source_performance", "Fetch previous source performance baseline"],
   prepare: ["publish", "Prepare clawgrit report commit"],
   publish: ["publish", "Publish to clawgrit reports"],
 } as const;
 
-type PerformanceGitMode = keyof typeof steps;
+type PerformanceGitMode = Extract<PerformanceFixtureOptions["mode"], keyof typeof steps>;
 
 function performanceRun(
   mode: PerformanceGitMode,
@@ -105,6 +107,7 @@ const terminalCases = [
   ...["rev-parse"].map((operation) => ({ mode: "target" as const, operation })),
   { mode: "record" as const, operation: "rev-parse" },
   { mode: "tested" as const, operation: "rev-parse" },
+  ...["fetch", "checkout"].map((operation) => ({ mode: "kova" as const, operation })),
   ...["fetch", "ls-tree", "show", "sparse-checkout init", "sparse-checkout set", "checkout"].map(
     (operation) => ({ mode: "baseline" as const, operation }),
   ),

--- a/test/scripts/openclaw-performance-git-lifecycle.test.ts
+++ b/test/scripts/openclaw-performance-git-lifecycle.test.ts
@@ -1,6 +1,5 @@
 import { beforeAll, expect, it, vi } from "vitest";
 import { runCiGitStep } from "./ci-git-owner.test-support.js";
-import type { PerformanceFixtureOptions } from "./openclaw-performance-workflow.test-support.js";
 
 // Each case owns its checkout and process trees. Overlap their real timeout and
 // drain waits while keeping subprocess pressure bounded.
@@ -17,14 +16,15 @@ const steps = {
   target: ["resolve_target", "Resolve OpenClaw target ref"],
   record: ["source_performance", "Record source performance revision"],
   tested: ["kova", "Record tested revision"],
-  kova: ["kova", "Install OCM and Kova"],
   baseline: ["source_performance", "Fetch previous source performance baseline"],
   prepare: ["publish", "Prepare clawgrit report commit"],
   publish: ["publish", "Publish to clawgrit reports"],
 } as const;
 
+type PerformanceGitMode = keyof typeof steps;
+
 function performanceRun(
-  mode: PerformanceFixtureOptions["mode"],
+  mode: PerformanceGitMode,
   options: Partial<Parameters<typeof runCiGitStep>[0]> = {},
 ) {
   const [job, step] = steps[mode];
@@ -39,7 +39,7 @@ function performanceRun(
 // The previous semantic tests used short-lived stubs or replayed Git by hand.
 // These actual workflow bodies must drain real parent/child/grandchild writers
 // before every command, output, consumer and exit, while a sentinel stays alive.
-posixIt.each(Object.keys(steps) as PerformanceFixtureOptions["mode"][])(
+posixIt.each(Object.keys(steps) as PerformanceGitMode[])(
   "Performance %s drains Git trees before every continuation",
   async (mode) => {
     const report = await performanceRun(mode);
@@ -105,7 +105,6 @@ const terminalCases = [
   ...["rev-parse"].map((operation) => ({ mode: "target" as const, operation })),
   { mode: "record" as const, operation: "rev-parse" },
   { mode: "tested" as const, operation: "rev-parse" },
-  ...["fetch", "checkout"].map((operation) => ({ mode: "kova" as const, operation })),
   ...["fetch", "ls-tree", "show", "sparse-checkout init", "sparse-checkout set", "checkout"].map(
     (operation) => ({ mode: "baseline" as const, operation }),
   ),

--- a/test/scripts/openclaw-performance-git-lifecycle.test.ts
+++ b/test/scripts/openclaw-performance-git-lifecycle.test.ts
@@ -47,7 +47,9 @@ posixIt.each(Object.keys(steps) as PerformanceGitMode[])(
     const report = await performanceRun(mode);
     expect(report.code, report.output).toBe(0);
     expect(report.readyAttempts.length).toBeGreaterThan(0);
-    if (mode === "prepare") expect(report.githubOutput).toContain("ready=true\n");
+    if (mode === "prepare") {
+      expect(report.githubOutput).toContain("ready=true\n");
+    }
     if (mode === "publish") {
       expect(report.pushes).toHaveLength(1);
       expect(report.fetches).toHaveLength(0);
@@ -126,7 +128,7 @@ const terminalCases = [
 // Every injected lifecycle failure must stop at its command, before later policy actions.
 posixIt.each(
   terminalCases.flatMap((entry) =>
-    (["cleanup-failure", "cancel"] as const).map((code) => ({ ...entry, code })),
+    (["cleanup-failure", "cancel"] as const).map((code) => Object.assign({}, entry, { code })),
   ),
 )(
   "$mode $operation $code fences every later action",
@@ -236,7 +238,9 @@ posixIt.each([124, 125, 143, "hang"] as const)(
       const scope = JSON.parse(command.envProbe!);
       expect(scope.token).toBe(false);
       expect(scope.auth).toBe(command.args[0] === "push");
-      if (scope.auth) expect(scope).toMatchObject({ count: "2", hooks: "/dev/null", prompt: "0" });
+      if (scope.auth) {
+        expect(scope).toMatchObject({ count: "2", hooks: "/dev/null", prompt: "0" });
+      }
     }
     expect(JSON.stringify(report)).not.toContain("fixture-performance-token");
     expect(JSON.stringify(report)).not.toContain(

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -194,6 +194,7 @@ describe("OpenClaw performance workflow", () => {
     expect(installRun).toContain(
       "https://codeload.github.com/${KOVA_REPOSITORY}/tar.gz/${KOVA_REF}",
     );
+    expect(installRun).toContain('if [[ "$KOVA_REF" == "$KOVA_TRUSTED_LIVE_REF" ]]');
     expect(installRun).toContain(
       "--retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused",
     );
@@ -205,7 +206,7 @@ describe("OpenClaw performance workflow", () => {
     expect(
       installRun.indexOf('echo "${KOVA_ARCHIVE_SHA256}  ${kova_archive}" | sha256sum -c -'),
     ).toBeLessThan(installRun.indexOf('tar -xzf "$kova_archive" --strip-components=1'));
-    expect(installRun).not.toContain('-C "$KOVA_SRC" fetch');
+    expect(installRun).toContain('-C "$KOVA_SRC" fetch --depth 1 origin "$KOVA_REF"');
     expect(installRun).toContain(
       'npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund',
     );

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -197,7 +197,14 @@ describe("OpenClaw performance workflow", () => {
     expect(installRun).toContain(
       "--retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused",
     );
+    expect(readWorkflow().env?.KOVA_ARCHIVE_SHA256).toBe(
+      "8cb2f4dd90e1bd5a5615d5d14f7766136057c4c5e66d399b5efb4d59a50dee7e",
+    );
+    expect(installRun).toContain('echo "${KOVA_ARCHIVE_SHA256}  ${kova_archive}" | sha256sum -c -');
     expect(installRun).toContain('tar -xzf "$kova_archive" --strip-components=1');
+    expect(
+      installRun.indexOf('echo "${KOVA_ARCHIVE_SHA256}  ${kova_archive}" | sha256sum -c -'),
+    ).toBeLessThan(installRun.indexOf('tar -xzf "$kova_archive" --strip-components=1'));
     expect(installRun).not.toContain('-C "$KOVA_SRC" fetch');
     expect(installRun).toContain(
       'npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund',

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -192,6 +192,14 @@ describe("OpenClaw performance workflow", () => {
       "${{ needs.resolve_target.outputs.kova_ref_trusted_for_live }}",
     );
     expect(installRun).toContain(
+      "https://codeload.github.com/${KOVA_REPOSITORY}/tar.gz/${KOVA_REF}",
+    );
+    expect(installRun).toContain(
+      "--retry 8 --retry-max-time 180 --retry-all-errors --retry-connrefused",
+    );
+    expect(installRun).toContain('tar -xzf "$kova_archive" --strip-components=1');
+    expect(installRun).not.toContain('-C "$KOVA_SRC" fetch');
+    expect(installRun).toContain(
       'npm --prefix "$KOVA_SRC" ci --ignore-scripts --no-audit --no-fund',
     );
     expect(installRun).toContain('require.resolve("mock-ai-provider/package.json", {');


### PR DESCRIPTION
## Summary
- replace Kova’s single unauthenticated `git fetch` with a pinned GitHub codeload archive
- apply bounded curl transfer and retry limits already used for the OCM release asset
- keep the pinned SHA and strip the archive into the same Kova source directory

## Why
Extended-stable release validation repeatedly failed before benchmark execution because the public Kova repository fetch returned GitHub credential errors. The archive endpoint avoids Git credential handling and adds bounded transient-network retries.

## Validation
- `node scripts/run-vitest.mjs run test/scripts/openclaw-performance-workflow.test.ts` (39/39)
- actionlint portion of `pnpm check:workflows` passed; local zizmor setup is blocked by the host Python 3.9 environment requiring Python 3.10+
- `git diff --check`