### PR TITLE
fix: compact and retry llama.cpp context overflows

### DIFF
--- a/packages/ai/src/utils/overflow.ts
+++ b/packages/ai/src/utils/overflow.ts
@@ -26,7 +26,7 @@ export function isConfiguredContextSizeOverflowError(errorMessage: string): bool
  * - Groq: "Please reduce the length of the messages or completion"
  * - OpenRouter: "This endpoint's maximum context length is X tokens. However, you requested about Y tokens"
  * - Together AI: "The input (X tokens) is longer than the model's context length (Y tokens)."
- * - llama.cpp: "the request exceeds the available context size, try increasing it"
+ * - llama.cpp: "request exceeds the available context size" or "Context size has been exceeded."
  * - LM Studio: "tokens to keep from the initial prompt is greater than the context length"
  * - GitHub Copilot: "prompt token count of X exceeds the limit of Y"
  * - MiniMax: "invalid params, context window exceeds limit"
@@ -55,7 +55,7 @@ const ASSISTANT_OVERFLOW_PATTERNS = [
   /exceeds (?:the )?maximum allowed input length of [\d,]+ tokens?/i, // OpenRouter/Poolside
   /input \(\d+ tokens\) is longer than the model'?s context length \(\d+ tokens\)/i, // Together AI
   /exceeds the limit of \d+/i, // GitHub Copilot
-  /exceeds the available context size/i, // llama.cpp server
+  /(?:exceeds the available context size|context size has been exceeded)/i, // llama.cpp server
   /greater than the context length/i, // LM Studio
   /context window exceeds limit/i, // MiniMax
   /exceeded model token limit/i, // Kimi For Coding
@@ -77,7 +77,7 @@ const FAILOVER_EXPLICIT_OVERFLOW_PATTERNS = [
   CONFIGURED_CONTEXT_SIZE_OVERFLOW_RE, // DS4 server
   /invalid_argument[\s\S]*maximum number of tokens/i, // Google/Vertex
   /request exceeds the maximum size/i, // Anthropic
-  /context length exceeded/i,
+  /(?:context length exceeded|context size has been exceeded)/i,
   /maximum context length/i,
   /prompt is too long/i,
   /prompt too long/i,
@@ -183,7 +183,7 @@ function resolveContextInputTokens(message: AssistantMessage): number | undefine
  * - Mistral: "Prompt contains X tokens ... too large for model with Y maximum context length"
  * - OpenRouter (all backends): "maximum context length is X tokens"
  * - Together AI: "The input (X tokens) is longer than the model's context length (Y tokens)."
- * - llama.cpp: "exceeds the available context size"
+ * - llama.cpp: "exceeds the available context size" or "Context size has been exceeded."
  * - LM Studio: "greater than the context length"
  * - Kimi For Coding: "exceeded model token limit: X (requested: Y)"
  * - z.ai: "tokens in request more than max tokens allowed" or "Prompt exceeds max length"

--- a/src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-context-recovery.test.ts
@@ -243,10 +243,10 @@ describe("recoverEmbeddedRunOverflow", () => {
     mocks.warn.mockReset();
   });
 
-  it("uses the canonical assistant classifier when the text heuristic misses", async () => {
+  it("compacts and retries current llama.cpp overflow reported by the assistant", async () => {
     const assistantOverflowCandidate = makeAssistantMessage({
       stopReason: "error",
-      errorMessage: "400 Your input exceeds the context window of this model",
+      errorMessage: "Context size has been exceeded.",
     });
     const result = await recoverEmbeddedRunOverflow(
       makeInput({ promptError: null, assistantOverflowCandidate }),

--- a/src/agents/failover/failover-classification.overflow.cases.ts
+++ b/src/agents/failover/failover-classification.overflow.cases.ts
@@ -132,6 +132,7 @@ export const overflowCases = [
           "prompt (8500 tokens) exceeds the available context size (8192 tokens), try increasing it",
       },
     ],
+    ["patterns-context-llamacpp-size-exceeded", { message: "Context size has been exceeded." }],
     [
       "patterns-context-ds4",
       {

--- a/src/agents/failover/failover-retry.expected.test-support.ts
+++ b/src/agents/failover/failover-retry.expected.test-support.ts
@@ -52,6 +52,7 @@ export const failoverRetryExpectations = {
   "patterns-context-llamacpp-available": false,
   "patterns-context-llamacpp-no-the": false,
   "patterns-context-llamacpp-prompt": false,
+  "patterns-context-llamacpp-size-exceeded": false,
   "patterns-context-ds4": false,
   "structured-context-raw-invalid-request": false,
   "structured-context-typed-invalid-request": false,

--- a/test/gateway-openai-compaction-replay.e2e.test.ts
+++ b/test/gateway-openai-compaction-replay.e2e.test.ts
@@ -18,8 +18,10 @@ const COMPACTION_ID = "cmp_gateway_replay";
 const COMPACTION_DATA = "opaque-gateway-compaction";
 
 type CapturedRequest = {
-  body: { input?: unknown[] };
+  body: { input?: unknown[]; instructions?: unknown };
 };
+
+type MockModelScenario = "compaction-replay" | "llama-overflow-recovery";
 
 type MockModelServer = {
   baseUrl: string;
@@ -42,7 +44,7 @@ describe("Gateway OpenAI Responses compaction replay", () => {
     "replays persisted provider state on the next embedded turn",
     { timeout: TEST_TIMEOUT_MS },
     async () => {
-      const modelServer = await startMockModelServer();
+      const modelServer = await startMockModelServer("compaction-replay");
       modelServers.push(modelServer);
       const instance = await createOpenClawTestInstance({
         name: "gateway-openai-compaction-replay",
@@ -133,6 +135,63 @@ describe("Gateway OpenAI Responses compaction replay", () => {
       }
     },
   );
+
+  it(
+    "compacts and retries current llama.cpp overflow through Gateway",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const modelServer = await startMockModelServer("llama-overflow-recovery");
+      modelServers.push(modelServer);
+      const instance = await createOpenClawTestInstance({
+        name: "gateway-llama-overflow-recovery",
+        config: createTestConfig(modelServer.baseUrl),
+        env: {
+          OPENCLAW_DEBUG_MODEL_TRANSPORT: "1",
+          OPENCLAW_SKIP_PROVIDERS: undefined,
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+        },
+      });
+      instances.push(instance);
+      await instance.startGateway();
+
+      const client = await connectGatewayClient({
+        url: instance.url,
+        token: instance.gatewayToken,
+        role: "operator",
+        scopes: ["operator.admin", "operator.read", "operator.write"],
+      });
+      try {
+        await runAgentTurn(client, "seed transcript");
+        let proofError: unknown;
+        try {
+          await runAgentTurn(client, "trigger llama overflow recovery");
+        } catch (error) {
+          proofError = error;
+        }
+
+        expect(modelServer.requests).toHaveLength(4);
+        expect(JSON.stringify(modelServer.requests[1]?.body)).toContain(
+          "trigger llama overflow recovery",
+        );
+        expect(JSON.stringify(modelServer.requests[2]?.body)).toContain("seed transcript");
+        expect(JSON.stringify(modelServer.requests[3]?.body)).toContain(
+          "trigger llama overflow recovery",
+        );
+
+        const logs = instance.logs();
+        expect(logs).toContain("[context-overflow-diag]");
+        expect(logs).toContain("source=assistantError");
+        expect(logs).toContain("Context size has been exceeded.");
+        expect(logs).toContain("context overflow detected");
+        expect(logs).toContain("attempting auto-compaction");
+        expect(logs).toContain("auto-compaction succeeded");
+        expect(logs).toContain("retrying prompt");
+        expect(proofError).toBeUndefined();
+      } finally {
+        await disconnectGatewayClient(client);
+      }
+    },
+  );
 });
 
 function createTestConfig(baseUrl: string): OpenClawConfig {
@@ -145,6 +204,12 @@ function createTestConfig(baseUrl: string): OpenClawConfig {
         models: { [MODEL_REF]: { agentRuntime: { id: "openclaw" } } },
         skipBootstrap: true,
         skills: [],
+        compaction: {
+          mode: "default",
+          keepRecentTokens: 1,
+          recentTurnsPreserve: 0,
+          memoryFlush: { enabled: false },
+        },
       },
     },
     tools: { profile: "minimal" },
@@ -202,10 +267,10 @@ function expectCompactionReplay(input: unknown[]): void {
   });
 }
 
-async function startMockModelServer(): Promise<MockModelServer> {
+async function startMockModelServer(scenario: MockModelScenario): Promise<MockModelServer> {
   const requests: CapturedRequest[] = [];
   const server = createServer((request, response) => {
-    void handleRequest(request, response, requests).catch((error: unknown) => {
+    void handleRequest(request, response, requests, scenario).catch((error: unknown) => {
       response.writeHead(500, { "content-type": "application/json" });
       response.end(JSON.stringify({ error: { message: String(error) } }));
     });
@@ -234,6 +299,7 @@ async function handleRequest(
   request: IncomingMessage,
   response: ServerResponse,
   requests: CapturedRequest[],
+  scenario: MockModelScenario,
 ): Promise<void> {
   const url = new URL(request.url ?? "/", "http://127.0.0.1");
   if (request.method === "GET" && url.pathname === "/v1/models") {
@@ -251,10 +317,18 @@ async function handleRequest(
   }
   const body = JSON.parse(Buffer.concat(chunks).toString("utf8")) as CapturedRequest["body"];
   requests.push({ body });
-  writeModelResponse(response, requests.length);
+  writeModelResponse(response, requests.length, scenario);
 }
 
-function writeModelResponse(response: ServerResponse, sequence: number): void {
+function writeModelResponse(
+  response: ServerResponse,
+  sequence: number,
+  scenario: MockModelScenario,
+): void {
+  if (scenario === "llama-overflow-recovery") {
+    writeOverflowRecoveryResponse(response, sequence);
+    return;
+  }
   if (sequence === 1) {
     const compaction = {
       type: "compaction",
@@ -277,7 +351,25 @@ function writeModelResponse(response: ServerResponse, sequence: number): void {
     ]);
     return;
   }
-  const text = `gateway replay response ${sequence}`;
+  writeTextModelResponse(response, sequence, `gateway replay response ${sequence}`);
+}
+
+function writeOverflowRecoveryResponse(response: ServerResponse, sequence: number): void {
+  if (sequence === 2) {
+    response.writeHead(400, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: { message: "Context size has been exceeded." } }));
+    return;
+  }
+  const text =
+    sequence === 1
+      ? "seed response"
+      : sequence === 3
+        ? "seed transcript summary"
+        : "llama retry ok";
+  writeTextModelResponse(response, sequence, text);
+}
+
+function writeTextModelResponse(response: ServerResponse, sequence: number, text: string): void {
   const message = {
     type: "message",
     id: `msg_gateway_replay_${sequence}`,


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
Use a parenthesized scope only when it adds clarity:
fix(auth): login redirect loops when session cookie is expired

Types: feat, fix, improve, refactor, docs, chore.
For fixes, describe the user-visible symptom and trigger:
fix: task list fails to load when user has no environments
Avoid implementation details such as:
fix: add null check to task query
-->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

Closes #133860

## What Problem This Solves

Fixes an issue where users running llama.cpp-backed models could receive `Context size has been exceeded.` without OpenClaw compacting and retrying the request.

## Why This Change Was Made

The canonical context-overflow matcher now recognizes llama.cpp's current wording in both assistant recovery and strict failover classification while retaining the existing llama.cpp wording. The compaction algorithm, provider routing, and retry limits are unchanged.

## User Impact

Oversized llama.cpp conversations now use the existing automatic compaction-and-retry flow instead of surfacing the provider failure to the user.

## Evidence

- **Pre-fix Gateway reproduction:** an isolated Gateway and OpenAI Responses-compatible test provider returned HTTP 400 with `Context size has been exceeded.`. The seed and failed request were the only two provider calls; the expected compaction-summary and retried request were absent (`expected length 4, received 2`).
- **Post-fix Gateway behavior:** `pnpm test test/gateway-openai-compaction-replay.e2e.test.ts` passed both tests. The issue-specific turn produced four provider calls (seed, overflow, summary, retry), completed successfully, and logged overflow detection, successful auto-compaction, and prompt retry.
- **Shared consumer coverage:** focused owner, embedded recovery, provider-runtime, session-compaction, and strict failover corpus tests passed across 4 Vitest shards: 17 + 32 + 46 + 617 tests.
- **Cross-layer retry contract:** the assistant retry-decision contract and strict failover corpus passed 631 + 617 tests; llama.cpp context overflow remains explicitly non-retryable in the ordinary assistant retry path because compaction recovery owns it.
- **Changed gate:** `pnpm check:changed` passed the required core, core-test, root-test, formatting, type, lint, and repository guard lanes.
- **Compatibility:** the existing llama.cpp `exceeds the available context size` wording remains covered, and the original compaction replay E2E still passes.
