### PR TITLE
perf(security): prepare external content scans once

### DIFF
--- a/extensions/browser/chrome-extension/bootstrap-diagnostics.test-support.ts
+++ b/extensions/browser/chrome-extension/bootstrap-diagnostics.test-support.ts
@@ -1,4 +1,4 @@
-import type { Page } from "playwright-core";
+import type { BrowserContext, Page } from "playwright-core";
 import { z } from "zod";
 import type { ExtensionRelayBridge } from "../src/browser/extension-relay/relay-bridge.js";
 
@@ -6,6 +6,18 @@ const METHODS = [
   "Target.attachedToTarget",
   "Target.detachedFromTarget",
   "Target.attachToTarget",
+  "Target.setAutoAttach",
+  "Page.enable",
+  "Page.getFrameTree",
+  "Page.setLifecycleEventsEnabled",
+  "Page.addScriptToEvaluateOnNewDocument",
+  "Page.createIsolatedWorld",
+  "Runtime.enable",
+  "Runtime.addBinding",
+  "Runtime.runIfWaitingForDebugger",
+  "Runtime.executionContextCreated",
+  "Network.enable",
+  "Log.enable",
   "Page.navigate",
   "Page.frameNavigated",
   "Page.frameDetached",
@@ -25,6 +37,7 @@ const METHODS = [
   "Network.loadingFailed",
 ] as const;
 const id = z.string().max(200).optional();
+const frameFields = z.object({ id, loaderId: id, url: z.string().optional() });
 const fields = z.object({
   sessionId: id,
   targetId: id,
@@ -33,8 +46,10 @@ const fields = z.object({
   frameId: id,
   loaderId: id,
   name: z.string().optional(),
-  frame: z.object({ id, loaderId: id }).optional(),
-  targetInfo: z.object({ targetId: id }).optional(),
+  frame: frameFields.optional(),
+  frameTree: z.object({ frame: frameFields }).optional(),
+  targetInfo: z.object({ targetId: id, url: z.string().optional() }).optional(),
+  context: z.object({ auxData: z.object({ frameId: id }).optional() }).optional(),
 });
 const envelope = z.object({
   id: z.number().int().optional(),
@@ -77,6 +92,9 @@ export function createBootstrapDiagnostic() {
   let remaining = 256;
   let dropped = 0;
   let active = false;
+  let inventoryUrl: string | undefined;
+  let contextBindingName: string | undefined;
+  let contextClient = 0;
   let nextClient = 0;
   let nextCommand = 0;
   let flushes = 0;
@@ -105,7 +123,7 @@ export function createBootstrapDiagnostic() {
     return next;
   };
   const observe = (client: number, outgoing: boolean, raw: string) => {
-    if (!active) {
+    if (!active && contextBindingName === undefined) {
       return;
     }
     // Reserve the final records for action outcome and teardown, even on event floods.
@@ -119,6 +137,19 @@ export function createBootstrapDiagnostic() {
         return;
       }
       const msg = parsed.data;
+      if (
+        !outgoing &&
+        msg.method === "Runtime.addBinding" &&
+        contextBindingName !== undefined &&
+        msg.params?.name === contextBindingName
+      ) {
+        contextClient = client;
+        contextBindingName = undefined;
+        append({ phase: "inventory.client", client });
+      }
+      if (!active) {
+        return;
+      }
       const key = `${client}:${msg.id}`;
       const command = outgoing ? pending.get(key) : undefined;
       if (outgoing) {
@@ -136,6 +167,7 @@ export function createBootstrapDiagnostic() {
       append({
         phase: !outgoing ? "cdp.command" : command ? "cdp.result" : "cdp.event",
         client,
+        retainedContext: client === contextClient,
         method,
         command: commandId,
         session: ordinal("session", msg.sessionId ?? data?.sessionId),
@@ -143,8 +175,21 @@ export function createBootstrapDiagnostic() {
         target: ordinal("target", data?.targetId ?? data?.targetInfo?.targetId),
         request: ordinal(method.startsWith("Fetch.") ? "fetch" : "network", data?.requestId),
         network: ordinal("network", data?.networkId),
-        frame: ordinal("frame", data?.frameId ?? data?.frame?.id),
-        loader: ordinal("loader", data?.loaderId ?? data?.frame?.loaderId),
+        frame: ordinal(
+          "frame",
+          data?.frameId ??
+            data?.frame?.id ??
+            data?.frameTree?.frame.id ??
+            data?.context?.auxData?.frameId,
+        ),
+        loader: ordinal(
+          "loader",
+          data?.loaderId ?? data?.frame?.loaderId ?? data?.frameTree?.frame.loaderId,
+        ),
+        matchesInventoryUrl:
+          inventoryUrl !== undefined &&
+          (data?.targetInfo?.url ?? data?.frame?.url ?? data?.frameTree?.frame.url) ===
+            inventoryUrl,
         load: data?.name === "load",
         domContentLoaded: data?.name === "DOMContentLoaded",
         error: msg.error !== undefined || Boolean(msg.result?.errorText),
@@ -156,7 +201,11 @@ export function createBootstrapDiagnostic() {
   const mark = (phase: Phase, value: boolean | number) => append({ phase, value });
   return {
     mark,
-    arm(selected: string, unrelated: string) {
+    identifyContextBinding(name: string) {
+      // Correlate the retained context through its existing command, without a new CDP request.
+      contextBindingName = name;
+    },
+    arm(selected: string, unrelated?: string) {
       active = true;
       append({
         phase: "armed",
@@ -192,6 +241,31 @@ export function createBootstrapDiagnostic() {
       };
       restores.push(() => {
         bridge.attachCdpClientSocket = original;
+      });
+    },
+    inventory(
+      context: BrowserContext,
+      bridge: Pick<ExtensionRelayBridge, "devtoolsTargetDescriptors" | "extensionConnected">,
+      expectedUrl: string,
+    ) {
+      inventoryUrl = expectedUrl;
+      const browser = context.browser();
+      const pages = context.pages();
+      const tabs = bridge.devtoolsTargetDescriptors();
+      append({
+        phase: "inventory.state",
+        contextClient,
+        extensionConnected: bridge.extensionConnected,
+        browserPresent: browser !== null,
+        browserConnected: browser?.isConnected() ?? false,
+        contextClosed: context.isClosed(),
+        pages: pages.length,
+        pageMatches: pages.filter((page) => page.url() === expectedUrl).length,
+        tabs: tabs.length,
+        tabMatches: tabs.filter((tab) => tab.url === expectedUrl).length,
+        unresolvedMatches: tabs.filter(
+          (tab) => tab.url === expectedUrl && tab.id === `tab-${tab.tabId}`,
+        ).length,
       });
     },
     watchPage(page: Page, expectedUrl: string) {

--- a/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
+++ b/extensions/browser/chrome-extension/bootstrap.chromium.test.ts
@@ -519,6 +519,7 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
           const bindingSession = await relayPlaywrightContext.newCDPSession(relayPage);
           const observerSession = await relayPlaywrightContext.newCDPSession(relayPage);
           const bindingName = "__openclawRelayBindingProof";
+          diagnostic.identifyContextBinding(bindingName);
           const bindingPayloads: string[] = [];
           const observerPayloads: string[] = [];
           observerSession.on("Runtime.bindingCalled", (event) => {
@@ -591,12 +592,20 @@ describe.runIf(runE2E)("Chrome native bootstrap Chromium E2E", () => {
           "[browser-extension-e2e] same-browser transport-reconnect labeled-ref screenshot passed\n",
         );
 
-        const distractingPage = await context.newPage();
         const distractingUrl = `data:text/html,${encodeURIComponent("<title>Unrelated tab</title>")}`;
-        await distractingPage.goto(distractingUrl);
-        await expect
-          .poll(() => relayPlaywrightContext.pages().some((page) => page.url() === distractingUrl))
-          .toBe(true);
+        diagnostic.arm(reconnectedTarget);
+        diagnostic.inventory(relayPlaywrightContext, relay.bridge, distractingUrl);
+        const distractingPage = await context.newPage();
+        try {
+          await distractingPage.goto(distractingUrl);
+          await expect
+            .poll(() =>
+              relayPlaywrightContext.pages().some((page) => page.url() === distractingUrl),
+            )
+            .toBe(true);
+        } finally {
+          diagnostic.inventory(relayPlaywrightContext, relay.bridge, distractingUrl);
+        }
         const liveTabsResponse = await dispatcher.dispatch({
           method: "GET",
           path: "/tabs",

--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts
@@ -139,7 +139,7 @@ describe("buildAttemptSystemPrompt", () => {
         effectiveCwd: workspaceDir,
         effectiveTools: [],
         effectiveWorkspace: workspaceDir,
-        getProviderRuntimeHandle: () => ({ provider: "openai" }),
+        getProviderRuntimeHandle: () => ({ provider: "openai", modelId: "gpt-5.5" }),
         isRawModelRun: true,
         markStage: vi.fn(),
         modelToolsEnabled: false,

--- a/src/security/external-content.ts
+++ b/src/security/external-content.ts
@@ -1,6 +1,7 @@
 // Wraps external content with source tags and random boundary tokens.
 import { randomBytes } from "node:crypto";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { escapeRegExp } from "../shared/regexp.js";
 export {
   resolveHookExternalContentSource,
   type HookExternalContentSource,
@@ -141,11 +142,14 @@ const LLM_SPECIAL_TOKEN_LITERALS = [
   "<end_of_turn>",
 ] as const;
 
-const LLM_SPECIAL_TOKEN_PATTERNS = [
-  // Many Hugging Face chat templates reserve token spellings in this form. Exact known
-  // literals above handle the common cases; this catches future reserved-token variants.
-  /<\|reserved_special_token_\d+\|>/g,
-] as const;
+// Token spellings do not overlap, and the replacement cannot create another token.
+// Keep the existing literal set and reserved numeric family in one native scan.
+const LLM_SPECIAL_TOKEN_PATTERN = new RegExp(
+  [...LLM_SPECIAL_TOKEN_LITERALS.map(escapeRegExp), /<\|reserved_special_token_\d+\|>/.source].join(
+    "|",
+  ),
+  "g",
+);
 
 const FULLWIDTH_ASCII_OFFSET = 0xfee0;
 
@@ -210,14 +214,16 @@ function isMarkerIgnorableChar(char: string): boolean {
 
 type FoldedMarkerMatch = {
   folded: string;
-  originalStartByFoldedIndex: number[];
-  originalEndByFoldedIndex: number[];
+  // ASCII folding is identity; all other retained code units need only their source start.
+  originalStartByFoldedIndex?: number[];
 };
 
 function foldMarkerTextWithIndexMap(input: string): FoldedMarkerMatch {
+  if (!/[\u0080-\u{10FFFF}]/u.test(input)) {
+    return { folded: input };
+  }
   let folded = "";
   const originalStartByFoldedIndex: number[] = [];
-  const originalEndByFoldedIndex: number[] = [];
 
   for (let index = 0; index < input.length; index += 1) {
     const char = input.charAt(index);
@@ -227,15 +233,13 @@ function foldMarkerTextWithIndexMap(input: string): FoldedMarkerMatch {
     const foldedChar = foldMarkerChar(char);
     folded += foldedChar;
     originalStartByFoldedIndex.push(index);
-    originalEndByFoldedIndex.push(index + 1);
   }
 
-  return { folded, originalStartByFoldedIndex, originalEndByFoldedIndex };
+  return { folded, originalStartByFoldedIndex };
 }
 
 function replaceMarkers(content: string): string {
-  const { folded, originalStartByFoldedIndex, originalEndByFoldedIndex } =
-    foldMarkerTextWithIndexMap(content);
+  const { folded, originalStartByFoldedIndex } = foldMarkerTextWithIndexMap(content);
   // Intentionally catch whitespace-delimited spoof variants (space, tab, newline) in addition
   // to the legacy underscore form because LLMs may still parse them as trusted boundary markers.
   if (!/external[\s_]+untrusted[\s_]+content/i.test(folded)) {
@@ -264,11 +268,8 @@ function replaceMarkers(content: string): string {
       const foldedStart = match.index;
       const foldedEnd = match.index + match[0].length;
       replacements.push({
-        start: originalStartByFoldedIndex[foldedStart] ?? foldedStart,
-        end:
-          originalEndByFoldedIndex[foldedEnd - 1] ??
-          originalStartByFoldedIndex[foldedEnd] ??
-          foldedEnd,
+        start: originalStartByFoldedIndex?.[foldedStart] ?? foldedStart,
+        end: (originalStartByFoldedIndex?.[foldedEnd - 1] ?? foldedEnd - 1) + 1,
         value: pattern.value,
       });
     }
@@ -294,14 +295,7 @@ function replaceMarkers(content: string): string {
 }
 
 export function sanitizeModelSpecialTokens(content: string): string {
-  let output = content;
-  for (const literal of LLM_SPECIAL_TOKEN_LITERALS) {
-    output = output.split(literal).join(SPECIAL_TOKEN_REPLACEMENT);
-  }
-  for (const pattern of LLM_SPECIAL_TOKEN_PATTERNS) {
-    output = output.replace(pattern, SPECIAL_TOKEN_REPLACEMENT);
-  }
-  return output;
+  return content.replace(LLM_SPECIAL_TOKEN_PATTERN, SPECIAL_TOKEN_REPLACEMENT);
 }
 
 /** Bound sanitized external prose while preserving its exact retained source prefix. */
@@ -319,7 +313,10 @@ export function truncateSanitizedExternalContent(
         /<<<\s*(?:END[\s_]+)?EXTERNAL[\s_]+UNTRUSTED[\s_]+CONTENT((?:\s+id=\\*"[^"]*")?\s*>>>)?/giu;
       for (const match of folded.folded.matchAll(markers)) {
         if (!match[1]) {
-          retained = retained.slice(0, folded.originalStartByFoldedIndex[match.index]);
+          retained = retained.slice(
+            0,
+            folded.originalStartByFoldedIndex?.[match.index] ?? match.index,
+          );
           break;
         }
       }


### PR DESCRIPTION
## What Problem This Solves

External-content sanitization builds two character-position maps even when ASCII folding changes nothing, then scans the same response separately for every reserved model-token spelling. Web fetch pays these preparation costs before returning its bounded, wrapped result.

## Why This Change Was Made

Keep the existing sanitizer as the single owner. ASCII input now retains its original string without a position map; Unicode input needs only source-start positions to recover the same endpoints. The existing token literals and reserved numeric family share one escaped regular expression. Token spellings do not overlap, and the replacement cannot create another recognized token.

These are two measured mechanisms. No marker recognition, warning, random boundary, truncation cap, decoding, request, SSRF, cache, fallback or provider policy changes. No dependency, configuration, schema or public API is added. The formatted production diff is +23/-26, net -3. A separate CI follow-up adds +96/-13 test/support lines (net +83), explained below; it adds no performance count. The selected measured source differs from this final source only by two formatting wraps.

## Evidence and Limits

Historical complete-owner differential proof retains 211,224 sanitizer and 8,523 reader/fetch comparisons, with 65,536 separate Unicode predicate checks. Eight fresh timing processes retain all 84 workloads, 6,048 measured samples and both variant orders. Complete plain-text 64 KiB tool preparation takes 87.2/87.4% less elapsed time; 750 KiB takes 89.8/90.3% less. Token-heavy HTML improves by 13.1/12.5%, and hostile-marker clipping by 51.2/52.6%.

Costs remain visible. Combined CJK 1,024-character/no-warning input adds 1.85/3.50 microseconds (6.45/12.81%). The default-byte-cap row is -4.65/+2.11% against the baseline and +1.67/+12.92% against the map-only variant. A non-ASCII-last 64 KiB case costs 13.93/13.59% against map-only. All direct and incremental mixed/slower controls are retained. These are bounded local owner measurements, not network, model-turn, total Gateway, memory or engine-cause claims.

The integrated source passes all 339 tests across 14 canonical owner/sibling files, including hostile content, clipping, headers, visibility, SSRF, signal handling, provider fallback, web search and session-memory transcript sanitization. Managed review is scoped-clean (0.84) with a limited diff bundle; complete changed-file gates also pass (256.41 seconds). Independent full-source review found no actionable defect and identified two additional existing sibling suites; both pass without test changes.

The preserved real built baseline completed four public synthetic HTTPS web_fetch calls through authenticated Gateway tools.invoke, plus a read-scope denial. All eleven strict main-thread V8 owner points were positive, including ASCII/Unicode folding, token sanitizing, visible truncation and one complete spill. Processes and groups stopped, the port closed and private task state was removed. The fresh candidate build at 5898 passes (167.69 seconds). The unchanged real Gateway candidate also passes all four public HTTPS calls and the read-scope denial. The unchanged comparator confirms equality of the complete normalized response details and spill text/counts against the preserved baseline. All eleven exact innermost main-thread V8 coverage points are positive, including 13 ASCII bypasses, 235 Unicode mapping iterations, 13 token replacements and one complete 1,899-byte spill. Both process leaders and groups are gone, the task port is closed, and the private fixture is removed.

Historical source/build labels remain explicit. Upstream source and entry-point drift is reviewed separately before preparing the new candidate binding. The live slice does not prove HTML extraction, provider/search fallback, default 750 KiB transport behavior, cache behavior or end-to-end latency. Listed security-owner involvement is recorded; GitHub review requirements remain in force.

Current head: `a298f8c68a5c27be3bbfc2732d9f75cfc1438532`. Production is byte-identical to the built/live-tested 5898 head; the new commit changes only the test fixtures and diagnostics below. The first exact-head CI run 33386285938 finished with three failures: the sandbox-report fixture timed out, Chromium's retained-context tab assertion failed, and the Windows fresh Anthropic-hook subprocess timed out. These failures and the original logs are retained; none was a sanitizer assertion failure. The new-head [hosted CI run 33391104671](https://github.com/openclaw/openclaw/actions/runs/33391104671) passed on its first attempt at this exact commit, completing at 13:28 UTC. All 14 UI shards, including the formerly failing browser shard, and the build passed. The required openclaw/ci-gate passed. Two non-required results remain qualified: a cancelled label check and neutral CodeQL analysis warning that 15 main configurations were not analyzed in this PR; this is not a claim of complete code-scanning coverage.

The sandbox-report fixture omitted the model ID from its prepared provider handle, which caused real model-scoped discovery instead of using the intended resolved-empty owner. Supplying the fixture's existing model ID preserves its sandbox assertions and production's model-matching guard. Its existing tests and real setup/provider siblings pass: 110 tests across three files. The browser follow-up identifies the retained connection through its existing binding command and records bounded, redacted bootstrap replies and inventory immediately around the same assertion. No CDP request, domain, permission, retry, timeout or assertion is changed; all three existing diagnostic helper tests pass. Full changed-file gates pass in 227.26 seconds, managed review is scoped-clean (0.88), and independent complete diagnostic/fixture source review is clean.

Full local Chromium execution did not occur: the exact canonical macOS Chrome for Testing binary failed signing verification and this host has no signing identity; Testbox also lacked its native client. The exact-head Linux browser shard passed. The original cause remains unconfirmed; this is a non-reproduction with improved diagnostics, not a claimed browser root-cause fix. The diagnostic envelope guard remains 65,536 UTF-16 code units, not a byte-limit claim.

The unchanged Anthropic fresh-process test passes locally in 47.218 seconds; one CPU-profiled run passes in 48.918 seconds with the same deadline and assertions. The retained profile observes the actual fixture/loader path: roughly 45.24 seconds inclusive in loading versus 1.5 milliseconds in registration. Inclusive totals overlap; Jiti, filesystem and transform costs dominate sampled self time. This is not a reproduced Windows failure, a new performance gain, or whole-Gateway latency proof. Named follow-up: reduce the broad provider-auth source-import graph through a coherent auth/registration refactor. No unsupported registration option, mock, timeout extension or weaker test was added.

Independent retained-artifact audit of the production live proof passes: all four normalized results, complete spill, eleven innermost V8 ranges, source/build/dependency/helper inputs, and every recorded process/group/port/fixture cleanup were checked.

The ClawSweeper review at 12:26 UTC found no source defect. Its requested Gateway evidence and exact-head security/browser checks are now supplied and green. The Playwright declaration missing from its isolated review checkout is installed in the canonical checkout, where full changed-file checks passed. The complete comment and Rank-up moves were read. The authorizing maintainer’s security-owner team membership was reverified active/maintainer at 13:32 UTC; the standing request authorizes this behavior-preserving refactor and landing. Live main rules require the CI gate and show no separate pull-request approval rule. No security policy or GitHub-enforced requirement is bypassed.
