### PR TITLE
fix(settings): preserve concurrent first saves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,8 +71,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Session settings:** restore merging of concurrent first writes after a startup optimization regressed lock ordering, preserving both global and project settings without adding filesystem side effects to missing-settings reads. Thanks @MrSwagatRathod, @obviyus, and @yetval for the original fix.
 - Provider error handling: reuse prepared or already loaded provider hooks instead of cold-loading plugins during error classification, avoiding long stalls in failure reporting and model fallback.
+- **Session settings:** restore merging of concurrent first writes after a startup optimization regressed lock ordering, preserving both global and project settings without adding filesystem side effects to missing-settings reads. Thanks @MrSwagatRathod, @obviyus, and @yetval for the original fix.
 - **Subagent completion:** recognize visible final answers delivered to internal and nested parent sessions, preventing false delivery failures while preserving external channel delivery checks.
 - Codex/Linux: wait for a live app-server process to expose its startup command line within the existing inspection deadline, preserving process identity checks and preventing intermittent startup failures.
 - **Cloud session lifecycle:** prevent archive, delete, and restart recovery from deadlocking behind an earlier worker move, keep work admission closed through cleanup, and preserve the same successor for concurrent recovery requests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Session settings:** restore merging of concurrent first writes after a startup optimization regressed lock ordering, preserving both global and project settings without adding filesystem side effects to missing-settings reads. Thanks @MrSwagatRathod, @obviyus, and @yetval for the original fix.
 - Provider error handling: reuse prepared or already loaded provider hooks instead of cold-loading plugins during error classification, avoiding long stalls in failure reporting and model fallback.
 - **Subagent completion:** recognize visible final answers delivered to internal and nested parent sessions, preventing false delivery failures while preserving external channel delivery checks.
 - Codex/Linux: wait for a live app-server process to expose its startup command line within the existing inspection deadline, preserving process identity checks and preventing intermittent startup failures.

--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts
@@ -139,7 +139,7 @@ describe("buildAttemptSystemPrompt", () => {
         effectiveCwd: workspaceDir,
         effectiveTools: [],
         effectiveWorkspace: workspaceDir,
-        getProviderRuntimeHandle: () => ({ provider: "openai" }),
+        getProviderRuntimeHandle: () => ({ provider: "openai", modelId: "gpt-5.5" }),
         isRawModelRun: true,
         markStage: vi.fn(),
         modelToolsEnabled: false,

--- a/src/agents/sessions/settings-storage.test.ts
+++ b/src/agents/sessions/settings-storage.test.ts
@@ -92,6 +92,7 @@ describe("FileSettingsStorage", () => {
           ),
         );
         const originalExists = fs.existsSync;
+        const originalLstat = fs.lstatSync;
         let committedDuringRead = false;
         try {
           await Promise.race([
@@ -104,9 +105,8 @@ describe("FileSettingsStorage", () => {
           expect(existsSync(`${settingsPath}.lock`)).toBe(true);
           // Return the real observation, but let the independently locked writer
           // commit before the next probe. File-first probing then returns stale defaults.
-          vi.spyOn(fs, "existsSync").mockImplementation((filePath) => {
-            const observed = originalExists(filePath);
-            if (!committedDuringRead && (filePath === settingsPath || filePath === settingsDir)) {
+          const commitDuringObservation = () => {
+            if (!committedDuringRead) {
               committedDuringRead = true;
               fs.writeFileSync(continuePath, "continue");
               const deadline = Date.now() + 5_000;
@@ -117,6 +117,19 @@ describe("FileSettingsStorage", () => {
                 }
                 Atomics.wait(pause, 0, 0, 2);
               }
+            }
+          };
+          vi.spyOn(fs, "existsSync").mockImplementation((filePath) => {
+            const observed = originalExists(filePath);
+            if (filePath === settingsPath) {
+              commitDuringObservation();
+            }
+            return observed;
+          });
+          vi.spyOn(fs, "lstatSync").mockImplementation((...args) => {
+            const observed = originalLstat(...args);
+            if (args[0] === `${settingsPath}.lock`) {
+              commitDuringObservation();
             }
             return observed;
           });
@@ -180,14 +193,92 @@ describe("FileSettingsStorage", () => {
     expect(existsSync(settingsPath)).toBe(false);
   });
 
-  it("creates a missing directory when the callback writes", () => {
-    const root = fixtures.createTempDir("openclaw-settings-write-");
-    const settingsDir = join(root, "agent");
-    const settingsPath = join(settingsDir, "settings.json");
-    const storage = new FileSettingsStorage(settingsDir, settingsDir);
-
-    storage.withLock("global", () => JSON.stringify({ theme: "dark" }));
-
-    expect(JSON.parse(readFileSync(settingsPath, "utf8"))).toEqual({ theme: "dark" });
-  });
+  it.each(["global", "project"] as const)(
+    "preserves independent concurrent first writes to %s settings",
+    (scope) =>
+      fixtures.run(async () => {
+        const root = fixtures.createTempDir("openclaw-settings-concurrent-create-");
+        const agentDir = join(root, "agent");
+        const settingsDir = scope === "global" ? agentDir : join(root, ".openclaw");
+        const settingsPath = join(settingsDir, "settings.json");
+        const firstEntered = join(root, "first-entered");
+        const contenderReady = join(root, "contender-ready");
+        const abort = new AbortController();
+        const writers: ReturnType<typeof runNodeScript>[] = [];
+        const startWriter = (field: string) => {
+          const writer = fixtures.track(
+            runNodeScript(
+              [
+                "--import",
+                new URL("../../../scripts/tsx.mjs", import.meta.url).href,
+                "--input-type=module",
+                "--eval",
+                String.raw`
+                  import { existsSync, writeFileSync } from "node:fs";
+                  const [moduleUrl, root, agentDir, scope, settingsPath, firstEntered, contenderReady, field] = process.argv.slice(1);
+                  const { FileSettingsStorage } = await import(moduleUrl);
+                  if (field === "theme" && existsSync(settingsPath + ".lock")) {
+                    writeFileSync(contenderReady, "waiting for lock");
+                  }
+                  new FileSettingsStorage(root, agentDir).withLock(scope, (current) => {
+                    if (field === "defaultModel") {
+                      writeFileSync(firstEntered, "ready");
+                      const deadline = Date.now() + 5_000;
+                      const pause = new Int32Array(new SharedArrayBuffer(4));
+                      while (!existsSync(contenderReady)) {
+                        if (Date.now() >= deadline) throw new Error("contender did not reach settings");
+                        Atomics.wait(pause, 0, 0, 2);
+                      }
+                    } else {
+                      writeFileSync(contenderReady, "entered callback");
+                    }
+                    return JSON.stringify({
+                      ...(current ? JSON.parse(current) : {}),
+                      [field]: field === "theme" ? "dark" : "mock-model",
+                    });
+                  });
+                `,
+                new URL("./settings-storage.ts", import.meta.url).href,
+                root,
+                agentDir,
+                scope,
+                settingsPath,
+                firstEntered,
+                contenderReady,
+                field,
+              ],
+              process.env,
+              10_000,
+              { signal: abort.signal, requireProcessTreeExit: true },
+            ),
+          );
+          writers.push(writer);
+          return writer;
+        };
+        try {
+          expect(existsSync(settingsDir)).toBe(false);
+          const first = startWriter("defaultModel");
+          await Promise.race([
+            waitForFile(firstEntered, 10_000),
+            first.then((result) => {
+              throw new Error(`first writer exited before contention: ${result.stderr}`);
+            }),
+          ]);
+          // Let the contender either observe the lock or enter the broken unlocked callback.
+          void startWriter("theme");
+          for (const result of await Promise.all(writers)) {
+            expect(result, result.stderr).toMatchObject({ error: undefined, status: 0 });
+          }
+          expect(JSON.parse(readFileSync(settingsPath, "utf8"))).toEqual({
+            defaultModel: "mock-model",
+            theme: "dark",
+          });
+          expect(existsSync(`${settingsPath}.lock`)).toBe(false);
+        } finally {
+          abort.abort();
+          await Promise.all(writers);
+        }
+      }),
+    20_000,
+  );
 });

--- a/src/agents/sessions/settings-storage.ts
+++ b/src/agents/sessions/settings-storage.ts
@@ -1,5 +1,5 @@
-import { existsSync, lstatSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
-import { dirname, join } from "node:path";
+import { existsSync, lstatSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { acquireFileLockSyncWithRetry } from "../../infra/file-lock-sync.js";
 import type { Transport } from "../../llm/types.js";
 import { CONFIG_DIR_NAME } from "../config.js";
@@ -159,27 +159,17 @@ export class FileSettingsStorage implements SettingsStorage {
 
   withLock(scope: SettingsScope, fn: (current: string | undefined) => string | undefined): void {
     const path = this.paths[scope];
-    const dir = dirname(path);
-
-    let release: (() => void) | undefined;
+    // The canonical lock creates its parent before acquisition. First writers must
+    // read and derive their updates only after that shared ownership is established.
+    const release = acquireFileLockSyncWithRetry(path);
     try {
-      const directoryExists = existsSync(dir);
-      if (directoryExists) {
-        release = acquireFileLockSyncWithRetry(path);
-      }
-      // Missing-directory reads stay side-effect free. Concurrent external first creators
-      // remain unsupported because they can derive writes before a lock path exists.
       const current = existsSync(path) ? readFileSync(path, "utf-8") : undefined;
       const next = fn(current);
       if (next !== undefined) {
-        if (!directoryExists) {
-          mkdirSync(dir, { recursive: true });
-          release = acquireFileLockSyncWithRetry(path);
-        }
         writeFileSync(path, next, "utf-8");
       }
     } finally {
-      release?.();
+      release();
     }
   }
 }


### PR DESCRIPTION
Related: #124471, #133413

## What Problem This Solves

Fixes an issue where users saving different settings from concurrent OpenClaw processes could silently lose one setting when its directory did not exist yet. Both processes reported success, but the last writer replaced the other's update.

## Why This Change Was Made

Acquire the existing canonical lock before reading settings or invoking the merge callback. The lock implementation already creates its parent directory, so this removes the separate delayed-lock path. Missing-settings reads retain their existing side-effect-free path. No schema, configuration, dependency, or public API changes.

Provenance: the first-write ordering shipped in 2026.8.1 via #124471 and was regressed by #133413 (`bec70700e08a09d5719e0acede249d4bcaefcfbf`), verified against its raw parent diff. This restores that contract while preserving main's later read-side improvements.

## User Impact

Independent global and project settings survive concurrent initial saves. Existing lock ownership, stale-lock handling, and read behavior remain intact.

## Evidence

- Before the fix, two real Node processes both exited successfully but lost the theme update in both scopes; both regression cases failed.
- After the fix, all 16 storage/manager tests pass, including read races, lock namespaces, nested merges, and first-write concurrency.
- Separate real-file proof using three simultaneous SettingsManager processes per scope preserved all six updates.
- Production LOC: +6/-16. Tests: +104/-13. The read-race fixture now releases its writer at the actual lock/file observation instead of depending on a redundant directory probe.
- Full `check:changed` passed, including production/test types, lint, and structural guards.
- Codex autoreview: scoped-clean at the configured P0 threshold. The pinned fs-safe 0.5.6 implementation was inspected directly.

Original contributor credit is retained in the changelog and commit trailers.

## Review Follow-through

ClawSweeper's lock-contract concern is resolved by direct inspection of the installed, pinned `@openclaw/fs-safe@0.5.6` source: `dist/file-lock-sync.js:83–90` creates and canonicalizes the parent directory, and `acquireFileLockSync` calls that owner at line 129 before exclusive lock acquisition. Both first-write scope regressions and the separate six-update SettingsManager proof passed against that exact dependency. No dependency upgrade is part of this change.

The direct no-op callback compatibility finding is also intentionally skipped after checking the stable contract: [published 2026.8.1 FileSettingsStorage.withLock](https://github.com/openclaw/openclaw/blob/ea806575e6450e4d1efdfc72c19f04be982a1b9b/src/agents/sessions/settings-storage.ts#L160) explicitly creates the missing directory before locking, reading, or invoking the callback, including callbacks that return `undefined`. The class was already exported through the agent-sessions SDK in that tag. This repair restores that shipped behavior; the side-effect-free direct callback branch was introduced by the later, unreleased regression in #133413. Read-only callers retain the canonical `readSettingsScope` absence path, which remains side-effect-free and tested. Running a callback once outside the lock to discover whether it writes would recreate stale input or require duplicate callback execution.

The suggestion to remove the changelog bullet is intentionally skipped: this is maintainer-authorized release repair work with explicitly requested comprehensive release notes, rather than an ordinary contributor PR. The single user-facing bullet records the restored shipped contract and preserves original contributor credit.

## CI Repairs

The initial exact-head CI found an unrelated global-session prompt fixture timeout and a workspace-icon test that counted unrelated header SVG fetches. The prompt fixture now includes the model identity supplied by real prepared attempt handles, preserving both sandbox-policy assertions. Its first case failed locally at 138.7 seconds before correction and passed in 199 ms afterward; all 25 prompt/setup tests pass without a timeout increase. Latest main already repaired workspace-icon fetch isolation in #133904 (`ca8064f2625`), using the shared `mockWorkspaceIconFetch` helper. The redundant copied UI patch was dropped during rebase; this PR retains main’s canonical UI tests unchanged. No production prompt or UI behavior changes are included. The initial lint job was canceled by runner shutdown with no lint diagnostic; it is not reported as a code failure or a pass.

The interrupted parent lint check passed on a single exact-job retry against unchanged source. A later docs-only relocation of the same settings note resolves a concurrent changelog insertion; text and contributor credit are unchanged. The new commit requires fresh CI independently of that parent result.
