### PR TITLE
fix(codex): avoid import timeouts in large native homes

### DIFF
--- a/docs/plugins/codex-supervision.md
+++ b/docs/plugins/codex-supervision.md
@@ -481,6 +481,16 @@ Gateway-local stored and idle rows offer **Continue as branch** instead of
 unsafe exact-thread takeover. A row that already has a supervised Chat offers
 **Open Chat**.
 
+**Session eligibility could not be verified:** for filesystem-backed local
+sources, transcript, Continue, Archive, and terminal actions verify the selected
+thread directly, check non-archived native index membership, and validate its
+rollout metadata in the selected Codex home. These checks share one request
+budget and do not scan the full catalog. Missing, unreadable, inconsistent, or
+OpenClaw-managed metadata is not accepted. Refresh the catalog, verify the session
+in its native Codex home, and retry. This error does not prove that the thread
+does not exist. Ordinary discovery keeps its existing behavior; remote sources
+continue to use native catalog verification.
+
 **Archive is disabled:** archive is available for stored/activity-unknown and
 idle Gateway-local rows after no-other-runner confirmation. Active, error,
 offline, paired-node, pending-branch, and known exact-binding-owner rows remain

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -154,9 +154,10 @@ export default definePluginEntry({
       }));
     const lazyManagedThreadStateStore: Pick<
       PluginStateSyncKeyedStore<StoredCodexManagedThread>,
-      "entries" | "registerIfAbsent"
+      "entries" | "lookup" | "registerIfAbsent"
     > = {
       entries: () => openManagedThreadStateStore().entries(),
+      lookup: (key) => openManagedThreadStateStore().lookup(key),
       registerIfAbsent: (key, value) => openManagedThreadStateStore().registerIfAbsent(key, value),
     };
     const bindingStore = createLazyCodexAppServerBindingStore(
@@ -165,6 +166,7 @@ export default definePluginEntry({
     );
     registerCodexCliMetadata(api);
     const sessionCatalogControlFactory = createCodexSessionCatalogControl({
+      managedThreads: bindingStore.managedThreads,
       config: api.config as OpenClawConfig,
       getPluginConfig: resolveCurrentPluginConfig,
       getRuntimeConfig: resolveCurrentConfig,

--- a/extensions/codex/src/app-server/managed-thread-store.test.ts
+++ b/extensions/codex/src/app-server/managed-thread-store.test.ts
@@ -13,7 +13,7 @@ function createStateStore() {
   const values = new Map<string, StoredCodexManagedThread>();
   const state: Pick<
     PluginStateSyncKeyedStore<StoredCodexManagedThread>,
-    "entries" | "registerIfAbsent"
+    "entries" | "lookup" | "registerIfAbsent"
   > = {
     registerIfAbsent(key, value) {
       if (values.has(key)) {
@@ -22,6 +22,7 @@ function createStateStore() {
       values.set(key, value);
       return true;
     },
+    lookup: (key) => values.get(key),
     entries: () => [...values].map(([key, value]) => ({ key, value, createdAt: 0 })),
   };
   return { state, values };
@@ -36,6 +37,9 @@ describe("Codex managed thread store", () => {
     await store.mark({ sourceHomeId, threadId: "thread-1", rolloutPath: "/rollout.jsonl" });
     await store.mark({ sourceHomeId, threadId: "thread-1", rolloutPath: "/new-path.jsonl" });
 
+    await expect(store.has(sourceHomeId, "thread-1")).resolves.toBe(true);
+    await expect(store.has("other-home", "thread-1")).resolves.toBe(false);
+    await expect(store.has(sourceHomeId, "missing-thread")).resolves.toBe(false);
     expect(values.size).toBe(1);
     expect([...values.values()][0]).toMatchObject({
       kind: "managed-thread",

--- a/extensions/codex/src/app-server/managed-thread-store.ts
+++ b/extensions/codex/src/app-server/managed-thread-store.ts
@@ -17,6 +17,7 @@ const managedThreadSchema = z.object({
 export type StoredCodexManagedThread = z.infer<typeof managedThreadSchema>;
 
 export type CodexManagedThreadStore = {
+  has(sourceHomeId: string, threadId: string): Promise<boolean>;
   mark(params: { sourceHomeId: string; threadId: string; rolloutPath?: string }): Promise<boolean>;
   snapshot(): Promise<ReadonlyMap<string, ReadonlySet<string>>>;
 };
@@ -52,9 +53,22 @@ function managedThreadStoreKey(sourceHomeId: string, threadId: string): string {
 
 /** Durable ownership index for Codex threads created by OpenClaw. */
 export function createCodexManagedThreadStore(
-  state: Pick<PluginStateSyncKeyedStore<StoredCodexManagedThread>, "entries" | "registerIfAbsent">,
+  state: Pick<
+    PluginStateSyncKeyedStore<StoredCodexManagedThread>,
+    "entries" | "lookup" | "registerIfAbsent"
+  >,
 ): CodexManagedThreadStore {
   return {
+    async has(sourceHomeId, threadId) {
+      const parsed = managedThreadSchema.safeParse(
+        state.lookup(managedThreadStoreKey(sourceHomeId, threadId)),
+      );
+      return (
+        parsed.success &&
+        parsed.data.sourceHomeId === sourceHomeId &&
+        parsed.data.threadId === threadId
+      );
+    },
     async mark(params) {
       try {
         const value = managedThreadSchema.parse({

--- a/extensions/codex/src/app-server/session-binding-store.ts
+++ b/extensions/codex/src/app-server/session-binding-store.ts
@@ -22,7 +22,7 @@ export function createLazyCodexAppServerBindingStore(
   >,
   managedThreadState?: Pick<
     PluginStateSyncKeyedStore<StoredCodexManagedThread>,
-    "entries" | "registerIfAbsent"
+    "entries" | "lookup" | "registerIfAbsent"
   >,
 ): CodexAppServerBindingStore {
   let resolved: Promise<CodexAppServerBindingStore> | undefined;

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -2615,7 +2615,11 @@ describe("Codex plugin binding recovery", () => {
     const mark = vi.fn(async () => undefined);
     const stateStore = createCodexTestBindingStateStore();
     const bindingStore = Object.assign(createCodexAppServerBindingStore(stateStore), {
-      managedThreads: { mark, snapshot: vi.fn(async () => new Map()) },
+      managedThreads: {
+        has: vi.fn(async () => false),
+        mark,
+        snapshot: vi.fn(async () => new Map()),
+      },
     });
     const request = vi.fn(async (method: string) => {
       if (method === "thread/start") {
@@ -2665,7 +2669,13 @@ describe("Codex plugin binding recovery", () => {
     const mark = vi.fn(async () => undefined);
     const bindingStore = Object.assign(
       createCodexAppServerBindingStore(createCodexTestBindingStateStore()),
-      { managedThreads: { mark, snapshot: vi.fn(async () => new Map()) } },
+      {
+        managedThreads: {
+          has: vi.fn(async () => false),
+          mark,
+          snapshot: vi.fn(async () => new Map()),
+        },
+      },
     );
     const request = vi.fn(async (method: string) => {
       if (method === "thread/start") {
@@ -2709,6 +2719,7 @@ describe("Codex plugin binding recovery", () => {
     const stateStore = createCodexTestBindingStateStore();
     const bindingStore = Object.assign(createCodexAppServerBindingStore(stateStore), {
       managedThreads: {
+        has: vi.fn(async () => false),
         mark: vi.fn(async () => {
           throw new Error("managed ownership unavailable");
         }),

--- a/extensions/codex/src/session-catalog-adoption.test.ts
+++ b/extensions/codex/src/session-catalog-adoption.test.ts
@@ -3,6 +3,12 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   commandRpcMocks,
+  pinnedConnectionMocks,
+  createCodexSessionCatalogControlFactory,
+  fs,
+  os,
+  path,
+  tempDirs,
   transcriptMirrorMocks,
   CODEX_APP_SERVER_THREADS_LIST_COMMAND,
   listCodexSessionCatalog,
@@ -225,6 +231,69 @@ describe("Codex supervision catalog", () => {
 });
 
 describe("Codex supervision actions", () => {
+  it("imports an exact local source when broad native listing times out", async () => {
+    const home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "codex-exact-import-")));
+    tempDirs.push(home);
+    const sessionsRoot = path.join(home, "sessions");
+    await fs.mkdir(sessionsRoot);
+    const rollout = path.join(sessionsRoot, "source.jsonl");
+    await fs.writeFile(
+      rollout,
+      `${JSON.stringify({
+        type: "session_meta",
+        payload: {
+          id: "thread-source",
+          source: "cli",
+          originator: "codex_cli_rs",
+        },
+      })}\n`,
+    );
+    const sourceThread = idleThread({
+      id: "thread-source",
+      source: "cli",
+      path: rollout,
+      turns: [],
+    });
+    let indexed = false;
+    pinnedConnectionMocks.request.mockImplementation(async ({ method, requestParams }) => {
+      if (method === "thread/read") {
+        indexed = true;
+        return { thread: sourceThread };
+      }
+      if (method === "thread/list" && requestParams.useStateDbOnly === true) {
+        return { data: indexed ? [sourceThread] : [] };
+      }
+      throw new Error("thread/list timed out");
+    });
+    const factory = createCodexSessionCatalogControlFactory({
+      getPluginConfig: () => ({}),
+      getRuntimeConfig: () => config,
+      env: { CODEX_HOME: home },
+    });
+    const source = factory.homesForAgent("main")[0]!;
+    const { runtime, createSessionEntry } = createRuntime();
+    const { api } = createGatewayApi(runtime);
+    await expect(
+      continueLocalCodexSession({
+        api,
+        bindingStore: createCodexTestBindingStore(),
+        config,
+        control: factory.forRequest("main", source),
+        threadId: sourceThread.id,
+        sourceHomeId: source.sourceHomeId,
+      }),
+    ).resolves.toMatchObject({ disposition: "forked" });
+    expect(createSessionEntry).toHaveBeenCalledOnce();
+    expect(transcriptMirrorMocks.importCodexThreadHistoryToTranscript).toHaveBeenCalledWith(
+      expect.objectContaining({ thread: sourceThread }),
+    );
+    expect(pinnedConnectionMocks.request.mock.calls.map(([request]) => request.method)).toEqual([
+      "thread/read",
+      "thread/list",
+      "thread/read",
+    ]);
+  });
+
   it("lists and adopts a local session under the retained compatibility owner", async () => {
     const runtimeConfig = compatibilityOwnerConfig();
     const { runtime, createSessionEntry } = createRuntime();

--- a/extensions/codex/src/session-catalog-adoption.ts
+++ b/extensions/codex/src/session-catalog-adoption.ts
@@ -31,7 +31,6 @@ import {
   MAX_SESSION_ID_LENGTH,
   requireBoundThread,
 } from "./session-catalog-parsing.js";
-import { requireCatalogEligibleThread } from "./session-catalog-terminal.js";
 import type { CodexSessionCatalogControl } from "./session-catalog-types.js";
 import {
   codexLastTerminalTurnId,
@@ -452,7 +451,7 @@ type ContinueLocalCodexSessionParams = {
 async function continueLocalCodexSessionInner(
   params: ContinueLocalCodexSessionParams,
 ): Promise<{ sessionKey: string; disposition: CodexSessionDisposition }> {
-  await requireCatalogEligibleThread(params.control, params.threadId);
+  await params.control.requireEligibleThread(params.threadId);
   const existing = await findAdoptedSessionEntry({ ...params, runtime: params.api.runtime });
   if (existing) {
     const boundThreadId = requireBoundThread(existing);

--- a/extensions/codex/src/session-catalog-archive.test.ts
+++ b/extensions/codex/src/session-catalog-archive.test.ts
@@ -10,7 +10,6 @@ import {
   config,
   compatibilityOwnerConfig,
   idleThread,
-  createControl,
   createEligibleControl,
   createRuntime,
   archiveTestSession,
@@ -23,128 +22,7 @@ import {
 } from "./session-catalog.test-helpers.js";
 
 describe("Codex supervision actions", () => {
-  it("walks the canonical non-archived catalog before continuing a known thread", async () => {
-    const { runtime } = createRuntime();
-    const { api } = createGatewayApi(runtime);
-    const listPage = vi.fn(async (params: { cursor?: string }) =>
-      params.cursor
-        ? {
-            sessions: [
-              {
-                threadId: "thread-1",
-                status: "idle",
-                source: "vscode",
-                archived: false as const,
-              },
-            ],
-          }
-        : {
-            sessions: [
-              {
-                threadId: "other-thread",
-                status: "idle",
-                source: "cli",
-                archived: false as const,
-              },
-            ],
-            nextCursor: "page-2",
-          },
-    );
-    const control = createControl({ listPage });
-
-    await expect(
-      continueLocalCodexSession({
-        api,
-        bindingStore: createCodexTestBindingStore(),
-        config,
-        control,
-        threadId: "thread-1",
-      }),
-    ).resolves.toMatchObject({ disposition: "forked" });
-    expect(listPage).toHaveBeenNthCalledWith(1, { limit: 100 });
-    expect(listPage).toHaveBeenNthCalledWith(2, {
-      cursor: "page-2",
-      limit: 100,
-    });
-  });
-
-  it("rejects archived interactive thread ids that are absent from the canonical catalog", async () => {
-    const { runtime, createSessionEntry } = createRuntime();
-    const { api } = createGatewayApi(runtime);
-    const control = createControl({
-      listPage: vi.fn(async () => ({ sessions: [] })),
-      readThread: vi.fn(async () => idleThread({ source: "cli" })),
-    });
-
-    await expect(
-      continueLocalCodexSession({
-        api,
-        bindingStore: createCodexTestBindingStore(),
-        config,
-        control,
-        threadId: "thread-1",
-      }),
-    ).rejects.toThrow("not a non-archived interactive Codex session");
-    await expect(archiveTestSession({ control })).rejects.toThrow(
-      "not a non-archived interactive Codex session",
-    );
-    expect(control.readThread).not.toHaveBeenCalled();
-    expect(createSessionEntry).not.toHaveBeenCalled();
-    expect(control.archiveThread).not.toHaveBeenCalled();
-  });
-
-  it("rejects internal App Server thread ids even if a control returns them", async () => {
-    const { runtime } = createRuntime();
-    const { api } = createGatewayApi(runtime);
-    const control = createControl({
-      listPage: vi.fn(async () => ({
-        sessions: [
-          {
-            threadId: "thread-1",
-            status: "idle",
-            source: "appServer",
-            archived: false,
-          },
-        ],
-      })),
-    });
-
-    await expect(
-      continueLocalCodexSession({
-        api,
-        bindingStore: createCodexTestBindingStore(),
-        config,
-        control,
-        threadId: "thread-1",
-      }),
-    ).rejects.toThrow("not a non-archived interactive Codex session");
-    await expect(archiveTestSession({ control })).rejects.toThrow(
-      "not a non-archived interactive Codex session",
-    );
-    expect(control.readThread).not.toHaveBeenCalled();
-  });
-
-  it("fails closed when canonical catalog cursors cycle", async () => {
-    const { runtime } = createRuntime();
-    const { api } = createGatewayApi(runtime);
-    const control = createControl({
-      listPage: vi.fn(async () => ({ sessions: [], nextCursor: "cycle" })),
-    });
-
-    await expect(
-      continueLocalCodexSession({
-        api,
-        bindingStore: createCodexTestBindingStore(),
-        config,
-        control,
-        threadId: "thread-1",
-      }),
-    ).rejects.toThrow("eligibility could not be verified");
-    expect(control.listPage).toHaveBeenCalledTimes(2);
-    expect(control.readThread).not.toHaveBeenCalled();
-  });
-
-  it("rechecks status and rejects active local sessions before either mutation", async () => {
+  it("rechecks status after eligibility and rejects active local sessions before either mutation", async () => {
     const { runtime, createSessionEntry } = createRuntime();
     const { api } = createGatewayApi(runtime);
     const bindingStore = createCodexTestBindingStore();
@@ -170,6 +48,7 @@ describe("Codex supervision actions", () => {
     expect(control.archiveThread).not.toHaveBeenCalled();
     expect(control.readThread).toHaveBeenNthCalledWith(1, "thread-1", true);
     expect(control.readThread).toHaveBeenNthCalledWith(2, "thread-1", false);
+    expect(control.requireEligibleThread).toHaveBeenCalledWith("thread-1");
   });
 
   it("archives an idle local thread only after the fresh status read", async () => {
@@ -180,7 +59,7 @@ describe("Codex supervision actions", () => {
     await expect(archiveTestSession({ control })).resolves.toEqual({
       archived: true,
     });
-    expect(control.readThread).toHaveBeenCalledWith("thread-1", false);
+    expect(control.requireEligibleThread).toHaveBeenCalledWith("thread-1");
     expect(control.archiveThread).toHaveBeenCalledWith("thread-1");
     expect(readThread.mock.invocationCallOrder[0]).toBeLessThan(
       archiveThread.mock.invocationCallOrder[0] ?? Number.POSITIVE_INFINITY,
@@ -300,7 +179,7 @@ describe("Codex supervision actions", () => {
     await expect(archiveTestSession({ bindingStore, control })).rejects.toThrow(
       "attached to an OpenClaw session",
     );
-    expect(control.readThread).toHaveBeenCalledWith("thread-1", false);
+    expect(control.requireEligibleThread).toHaveBeenCalledWith("thread-1");
     expect(control.archiveThread).not.toHaveBeenCalled();
   });
 
@@ -446,17 +325,6 @@ describe("Codex supervision actions", () => {
     expect(control.archiveThread).not.toHaveBeenCalled();
   });
 
-  it("rejects an archive when the fresh read returns a different thread", async () => {
-    const control = createEligibleControl({
-      readThread: vi.fn(async () => idleThread({ id: "different-thread" })),
-    });
-
-    await expect(archiveTestSession({ control })).rejects.toThrow(
-      "returned a different thread than requested",
-    );
-    expect(control.archiveThread).not.toHaveBeenCalled();
-  });
-
   it("archives a not-loaded local thread after explicit runner confirmation", async () => {
     const control = createEligibleControl({
       readThread: vi.fn(async () => idleThread({ status: { type: "notLoaded" } })),
@@ -557,7 +425,7 @@ describe("Codex supervision actions", () => {
         clientScopes: ["operator.admin"],
       }),
     ).rejects.toThrow("paired node does not permit Codex session continuation");
-    expect(control.readThread).toHaveBeenCalledOnce();
+    expect(control.requireEligibleThread).toHaveBeenCalledOnce();
     expect(control.archiveThread).toHaveBeenCalledOnce();
     expect(createSessionEntry).not.toHaveBeenCalled();
   });

--- a/extensions/codex/src/session-catalog-archive.ts
+++ b/extensions/codex/src/session-catalog-archive.ts
@@ -10,7 +10,6 @@ import { assertCodexArchiveDescendantsUnowned } from "./app-server/thread-archiv
 import { isAdoptionSessionKeyForThread, requireIdleThread } from "./session-catalog-adoption.js";
 import { runSessionActionExclusive } from "./session-catalog-node-adoption.js";
 import { CatalogParamsError, CODEX_LOCAL_SESSION_HOST_ID } from "./session-catalog-parsing.js";
-import { requireCatalogEligibleThread } from "./session-catalog-terminal.js";
 import type { CodexSessionCatalogControl } from "./session-catalog-types.js";
 
 async function assertNoPendingSupervisionBranch(params: {
@@ -82,8 +81,9 @@ export async function archiveLocalCodexSession(params: {
     async () => {
       return await params.bindingStore.withThreadArchiveFence(async () => {
         const run = async (control: CodexSessionCatalogControl) => {
-          await requireCatalogEligibleThread(control, params.threadId);
           await assertNoPendingSupervisionBranch(params);
+          await control.requireEligibleThread(params.threadId);
+          // Eligibility reads metadata before checking membership; activity can change meanwhile.
           const thread = await control.readThread(params.threadId, false);
           if (thread.id !== params.threadId) {
             throw new Error("Codex app-server returned a different thread than requested");

--- a/extensions/codex/src/session-catalog-control.ts
+++ b/extensions/codex/src/session-catalog-control.ts
@@ -7,6 +7,7 @@ import {
   resolveCodexSupervisionAppServerRuntimeOptions,
   type CodexAppServerStartOptions,
 } from "./app-server/config.js";
+import type { CodexManagedThreadStore } from "./app-server/managed-thread-store.js";
 import { buildCodexAppServerConnectionFingerprint } from "./app-server/plugin-app-cache-key.js";
 import { assertCodexThreadForkParams } from "./app-server/protocol-validators.js";
 import type {
@@ -25,15 +26,23 @@ import {
   getLeasedSharedCodexAppServerClient,
   releaseLeasedSharedCodexAppServerClient,
 } from "./app-server/shared-client.js";
+import { withTimeout } from "./app-server/timeout.js";
 import { codexControlRequest } from "./command-rpc.js";
 import { createCodexCatalogHomeResolver, type CodexCatalogHome } from "./session-catalog-homes.js";
 import {
   MAX_TITLE_SEARCH_CATALOG_PAGES,
+  MAX_ACTION_CATALOG_PAGES,
+  CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT,
+  CatalogParamsError,
+  isInteractiveThreadSource,
   normalizeLimit,
   readControlCursor,
   toCatalogSession,
 } from "./session-catalog-parsing.js";
-import { isOpenClawManagedCodexThread } from "./session-catalog-provenance.js";
+import {
+  isOpenClawManagedCodexThread,
+  readCodexSessionMeta,
+} from "./session-catalog-provenance.js";
 import type {
   CodexSessionCatalogControl,
   CodexSessionCatalogControlFactory,
@@ -78,7 +87,7 @@ type CodexSessionCatalogRequestSnapshot = {
   listThreads(params: CodexThreadListParams, timeoutMs: number): Promise<CodexThreadListResponse>;
   listThreadTurns(params: CodexThreadTurnsListParams): Promise<CodexThreadTurnsListResponse>;
   forkThread(params: CodexThreadForkParams): Promise<CodexThreadForkResponse>;
-  readThread(threadId: string, includeTurns: boolean): Promise<CodexThread>;
+  readThread(threadId: string, includeTurns: boolean, timeoutMs?: number): Promise<CodexThread>;
   archiveThread(threadId: string): Promise<void>;
 };
 
@@ -106,8 +115,9 @@ function createCodexCatalogRequestSnapshot(
     listThreadTurns: (params) => request(CODEX_CONTROL_METHODS.listThreadTurns, params),
     forkThread: (params) =>
       request(CODEX_CONTROL_METHODS.forkThread, assertCodexThreadForkParams(params)),
-    readThread: async (threadId, includeTurns) =>
-      (await request(CODEX_CONTROL_METHODS.readThread, { threadId, includeTurns })).thread,
+    readThread: async (threadId, includeTurns, timeoutMs) =>
+      (await request(CODEX_CONTROL_METHODS.readThread, { threadId, includeTurns }, timeoutMs))
+        .thread,
     archiveThread: async (threadId) => {
       await request(CODEX_CONTROL_METHODS.archiveThread, { threadId });
     },
@@ -119,6 +129,8 @@ function createCodexSessionCatalogControlFromRequests(params: {
   connectionFingerprint?: string;
   createRequestSnapshot: () => CodexSessionCatalogRequestSnapshot;
   localSessionsRoot?: string;
+  sourceHomeId?: string;
+  managedThreads?: CodexManagedThreadStore;
   now: () => number;
   withPinnedConnection: CodexSessionCatalogControl["withPinnedConnection"];
 }): CodexSessionCatalogControl {
@@ -128,6 +140,99 @@ function createCodexSessionCatalogControlFromRequests(params: {
       ? { connectionFingerprint: params.connectionFingerprint }
       : {}),
     withPinnedConnection: params.withPinnedConnection,
+    async requireEligibleThread(threadId) {
+      const requests = params.createRequestSnapshot();
+      const deadline = params.now() + requests.requestTimeoutMs;
+      const unverified = () =>
+        new CatalogParamsError(
+          "Codex session eligibility could not be verified. Refresh the catalog and verify the session in its native Codex home before retrying.",
+        );
+      const remaining = () => {
+        const timeoutMs = Math.ceil(deadline - params.now());
+        if (timeoutMs <= 0) {
+          throw unverified();
+        }
+        return timeoutMs;
+      };
+      const verify = async () => {
+        if (
+          params.sourceHomeId &&
+          (await params.managedThreads?.has(params.sourceHomeId, threadId))
+        ) {
+          throw unverified();
+        }
+        // Local exact reads seed missing native index rows before DB-only membership checks.
+        // Remote/pathless stores retain native scan-and-repair membership: no local rollout authority.
+        const root = params.localSessionsRoot;
+        const thread = root ? await requests.readThread(threadId, false, remaining()) : undefined;
+        if (
+          root &&
+          (!thread || thread.id !== threadId || !isInteractiveThreadSource(thread.source))
+        ) {
+          throw unverified();
+        }
+        let cursor: string | undefined;
+        const seenCursors = new Set<string>();
+        for (let pageIndex = 0; pageIndex < MAX_ACTION_CATALOG_PAGES; pageIndex += 1) {
+          const page = await requests.listThreads(
+            {
+              archived: false,
+              limit: CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT,
+              modelProviders: [],
+              sortKey: root ? "recency_at" : "updated_at",
+              sortDirection: "desc",
+              ...(root
+                ? { useStateDbOnly: true, ...(thread?.cwd ? { cwd: thread.cwd } : {}) }
+                : {}),
+              ...(cursor ? { cursor } : {}),
+            },
+            remaining(),
+          );
+          remaining();
+          const candidate = page.data.find((value) => value.id === threadId);
+          if (candidate) {
+            if (!isInteractiveThreadSource(candidate.source)) {
+              throw unverified();
+            }
+            if (root && thread) {
+              const rolloutPath = thread.path;
+              // Codex may retain the plain path after compressing the selected immutable rollout.
+              if (
+                !rolloutPath ||
+                !candidate.path ||
+                rolloutPath.replace(/\.zst$/u, "") !== candidate.path.replace(/\.zst$/u, "")
+              ) {
+                throw unverified();
+              }
+              const metadata = await readCodexSessionMeta(root, rolloutPath, threadId);
+              remaining();
+              if (
+                !metadata ||
+                !isInteractiveThreadSource(metadata.source) ||
+                metadata.originator === "openclaw"
+              ) {
+                throw unverified();
+              }
+              return thread;
+            }
+            return candidate;
+          }
+          const nextCursor = readControlCursor(page.nextCursor, "next response");
+          if (!nextCursor || seenCursors.has(nextCursor)) {
+            throw unverified();
+          }
+          seenCursors.add(nextCursor);
+          cursor = nextCursor;
+        }
+        throw unverified();
+      };
+      return await withTimeout(
+        verify(),
+        requests.requestTimeoutMs,
+        "Codex session eligibility could not be verified",
+        unverified,
+      );
+    },
     async listPage(pageParams) {
       const limit = normalizeLimit(pageParams.limit, "limit");
       // App Server search also matches transcript previews. Scan native pages
@@ -230,6 +335,7 @@ export function createCodexSessionCatalogControl(params: {
   getPluginConfig: () => unknown;
   getRuntimeConfig: () => OpenClawConfig | undefined;
   now?: () => number;
+  managedThreads?: CodexManagedThreadStore;
 }): CodexSessionCatalogControlFactory {
   const now = params.now ?? Date.now;
   const getPluginConfig = () => params.getPluginConfig();
@@ -340,6 +446,8 @@ export function createCodexSessionCatalogControl(params: {
             connectionFingerprint: buildCodexAppServerConnectionFingerprint(runtime, agentDir),
             createRequestSnapshot: () => requests,
             ...(source?.localSessionsRoot ? { localSessionsRoot: source.localSessionsRoot } : {}),
+            sourceHomeId: source?.sourceHomeId,
+            managedThreads: params.managedThreads,
             now,
             withPinnedConnection: async (nestedRun) => await nestedRun(pinnedControl),
           });
@@ -356,6 +464,8 @@ export function createCodexSessionCatalogControl(params: {
     });
     return {
       ...control,
+      requireEligibleThread: (threadId) =>
+        withPinnedConnection((pinned) => pinned.requireEligibleThread(threadId)),
       async listPage(pageParams: CodexSessionCatalogPageParams) {
         const runtimeConfig = params.getRuntimeConfig();
         if (!runtimeConfig) {
@@ -368,7 +478,7 @@ export function createCodexSessionCatalogControl(params: {
         }
         const key = codexCatalogPageCacheKey(pageParams, agentId, source);
         const cached = cache.get(key);
-        if (pageParams.forceRefresh !== true && cached) {
+        if (cached) {
           cache.delete(key);
           cache.set(key, cached);
           if (cached.expiresAt > now()) {
@@ -409,8 +519,8 @@ export function createCodexSessionCatalogControl(params: {
           }
         };
         // Expiry starts one background refresh. Passive callers keep the last settled page while
-        // the next poll publishes success or retries failure; a forced caller still sees failure.
-        if (pageParams.forceRefresh !== true && staleValue) {
+        // the next poll publishes success or retries failure.
+        if (staleValue) {
           void page.then(settle, restore);
           return staleValue;
         }

--- a/extensions/codex/src/session-catalog-listing-cache.test.ts
+++ b/extensions/codex/src/session-catalog-listing-cache.test.ts
@@ -6,7 +6,6 @@ import {
   config,
   idleThread,
   resolveDefaultAgentDir,
-  requireCatalogEligibleThread,
   type OpenClawConfig,
 } from "./session-catalog.test-helpers.js";
 
@@ -128,126 +127,6 @@ describe("Codex supervision catalog", () => {
     });
     await expect(control.listPage({ limit: 25 })).resolves.toMatchObject({
       sessions: [expect.objectContaining({ threadId: "thread-recovered" })],
-    });
-    expect(commandRpcMocks.codexControlRequest).toHaveBeenCalledTimes(2);
-  });
-
-  it("propagates a forced refresh failure while preserving the stale retry state", async () => {
-    let now = 1_000;
-    commandRpcMocks.codexControlRequest.mockResolvedValue({
-      data: [idleThread({ id: "thread-stale", source: "cli" })],
-    });
-    const control = createCodexSessionCatalogControl({
-      getPluginConfig: () => ({ supervision: { enabled: true } }),
-      getRuntimeConfig: () => config,
-      now: () => now,
-    });
-    await control.listPage({ limit: 25 });
-
-    commandRpcMocks.codexControlRequest.mockRejectedValueOnce(new Error("forced refresh failed"));
-    await expect(control.listPage({ limit: 25, forceRefresh: true })).rejects.toThrow(
-      "forced refresh failed",
-    );
-
-    commandRpcMocks.codexControlRequest.mockResolvedValue({
-      data: [idleThread({ id: "thread-recovered", source: "cli" })],
-    });
-    now += 1;
-    await expect(control.listPage({ limit: 25 })).resolves.toMatchObject({
-      sessions: [expect.objectContaining({ threadId: "thread-stale" })],
-    });
-    await vi.waitFor(async () => {
-      await expect(control.listPage({ limit: 25 })).resolves.toMatchObject({
-        sessions: [expect.objectContaining({ threadId: "thread-recovered" })],
-      });
-    });
-    expect(commandRpcMocks.codexControlRequest).toHaveBeenCalledTimes(3);
-  });
-
-  it("serves stale data to a passive waiter overlapping a failed forced refresh", async () => {
-    commandRpcMocks.codexControlRequest.mockResolvedValue({
-      data: [idleThread({ id: "thread-stale", source: "cli" })],
-    });
-    const control = createCodexSessionCatalogControl({
-      getPluginConfig: () => ({ supervision: { enabled: true } }),
-      getRuntimeConfig: () => config,
-    });
-    const stale = await control.listPage({ limit: 25 });
-    let rejectRefresh!: (error: Error) => void;
-    commandRpcMocks.codexControlRequest.mockImplementationOnce(
-      async () =>
-        await new Promise((_resolve, reject) => {
-          rejectRefresh = reject;
-        }),
-    );
-
-    const forced = control.listPage({ limit: 25, forceRefresh: true });
-    await vi.waitFor(() => expect(commandRpcMocks.codexControlRequest).toHaveBeenCalledTimes(2));
-    const passive = control.listPage({ limit: 25 });
-    const forcedResult = expect(forced).rejects.toThrow("forced refresh failed");
-    rejectRefresh(new Error("forced refresh failed"));
-
-    await forcedResult;
-    await expect(passive).resolves.toEqual(stale);
-  });
-
-  it("does not expose a pending cold fill as stale after a forced refresh overtakes it", async () => {
-    let resolveCold!: (value: unknown) => void;
-    let resolveForced!: (value: unknown) => void;
-    commandRpcMocks.codexControlRequest
-      .mockReturnValueOnce(
-        new Promise((resolve) => {
-          resolveCold = resolve;
-        }),
-      )
-      .mockReturnValueOnce(
-        new Promise((resolve) => {
-          resolveForced = resolve;
-        }),
-      );
-    const control = createCodexSessionCatalogControl({
-      getPluginConfig: () => ({ supervision: { enabled: true } }),
-      getRuntimeConfig: () => config,
-    });
-
-    const cold = control.listPage({ limit: 25 });
-    const forced = control.listPage({ limit: 25, forceRefresh: true });
-    const passive = control.listPage({ limit: 25 });
-    resolveForced({ data: [idleThread({ id: "thread-forced", source: "cli" })] });
-
-    await expect(Promise.all([forced, passive])).resolves.toEqual([
-      expect.objectContaining({
-        sessions: [expect.objectContaining({ threadId: "thread-forced" })],
-      }),
-      expect.objectContaining({
-        sessions: [expect.objectContaining({ threadId: "thread-forced" })],
-      }),
-    ]);
-
-    resolveCold({ data: [idleThread({ id: "thread-cold", source: "cli" })] });
-    await expect(cold).resolves.toMatchObject({
-      sessions: [expect.objectContaining({ threadId: "thread-cold" })],
-    });
-    await expect(control.listPage({ limit: 25 })).resolves.toMatchObject({
-      sessions: [expect.objectContaining({ threadId: "thread-forced" })],
-    });
-    expect(commandRpcMocks.codexControlRequest).toHaveBeenCalledTimes(2);
-  });
-
-  it("force-refreshes after a cached specific-thread miss", async () => {
-    let includeThread = false;
-    commandRpcMocks.codexControlRequest.mockImplementation(async () => ({
-      data: includeThread ? [idleThread({ id: "thread-new", source: "cli" })] : [],
-    }));
-    const control = createCodexSessionCatalogControl({
-      getPluginConfig: () => ({ supervision: { enabled: true } }),
-      getRuntimeConfig: () => config,
-    });
-    await control.listPage({ limit: 100 });
-    includeThread = true;
-
-    await expect(requireCatalogEligibleThread(control, "thread-new")).resolves.toMatchObject({
-      threadId: "thread-new",
     });
     expect(commandRpcMocks.codexControlRequest).toHaveBeenCalledTimes(2);
   });

--- a/extensions/codex/src/session-catalog-listing.test.ts
+++ b/extensions/codex/src/session-catalog-listing.test.ts
@@ -528,7 +528,7 @@ describe("Codex supervision catalog", () => {
       async () => new Map<string, ReadonlySet<string>>([["home-a", new Set(["thread-managed"])]]),
     );
     const bindingStore = Object.assign(createCodexTestBindingStore(), {
-      managedThreads: { mark: vi.fn(), snapshot },
+      managedThreads: { has: vi.fn(async () => false), mark: vi.fn(), snapshot },
     });
     const listPage = vi.fn(async (params?: { cursor?: string; limit?: number }) =>
       params?.cursor === "next"
@@ -612,6 +612,7 @@ describe("Codex supervision catalog", () => {
     const mark = vi.fn(async () => true);
     const bindingStore = Object.assign(createCodexTestBindingStore(), {
       managedThreads: {
+        has: vi.fn(async () => false),
         mark,
         snapshot: vi.fn(async () => new Map<string, ReadonlySet<string>>()),
       },

--- a/extensions/codex/src/session-catalog-listing.ts
+++ b/extensions/codex/src/session-catalog-listing.ts
@@ -47,7 +47,6 @@ import {
 import {
   codexNodeTerminalCapability,
   createCodexTerminalNodeHostCommand,
-  requireCatalogEligibleThread,
   type CodexTerminalConfigSources,
 } from "./session-catalog-terminal.js";
 import type {
@@ -377,7 +376,7 @@ export function createCodexSessionCatalogNodeHostCommands(
         const request = bindRequest(paramsJSON);
         const action = readNodeTranscriptParams(request.params);
         try {
-          await requireCatalogEligibleThread(request.control, action.threadId);
+          await request.control.requireEligibleThread(action.threadId);
           const page = parseTranscriptPage(
             await request.control.listTurnPage({
               threadId: action.threadId,
@@ -451,7 +450,7 @@ export async function readCodexSessionTranscript(params: {
   source?: CodexCatalogHome;
 }): Promise<CodexSessionTranscriptPage> {
   if (params.source || params.hostId === CODEX_LOCAL_SESSION_HOST_ID) {
-    await requireCatalogEligibleThread(params.control, params.threadId);
+    await params.control.requireEligibleThread(params.threadId);
     const listParams = {
       threadId: params.threadId,
       limit: params.limit,

--- a/extensions/codex/src/session-catalog-node-continue.test.ts
+++ b/extensions/codex/src/session-catalog-node-continue.test.ts
@@ -12,6 +12,7 @@ import {
   readCodexSessionTranscript,
   registerCodexSessionCatalog,
   config,
+  idleThread,
   compatibilityOwnerConfig,
   createControl,
   createEligibleControl,
@@ -487,6 +488,14 @@ describe("Codex supervision actions", () => {
     vi.spyOn(Date, "now").mockImplementation(() => now);
     const executable = path.join(binDir, process.platform === "win32" ? "codex.cmd" : "codex");
     const control = createEligibleControl({
+      requireEligibleThread: vi.fn(async () =>
+        idleThread({
+          id: threadId,
+          status: { type: "active" },
+          source: "cli",
+          cwd: "/workspace/local",
+        }),
+      ),
       listPage: vi.fn(async () => ({
         sessions: [
           { threadId, status: "active", source: "cli", cwd: "/workspace/local", archived: false },

--- a/extensions/codex/src/session-catalog-node-listing.test.ts
+++ b/extensions/codex/src/session-catalog-node-listing.test.ts
@@ -10,6 +10,7 @@ import {
   registerCodexSessionCatalog,
   createCodexSessionCatalogNodeHostCommands,
   config,
+  idleThread,
   createControl,
   createEligibleControl,
   createRuntime,
@@ -46,6 +47,7 @@ describe("Codex supervision catalog", () => {
     const control = createControl({ listPage });
     const bindingStore = Object.assign(createCodexTestBindingStore(), {
       managedThreads: {
+        has: vi.fn(async () => false),
         mark: vi.fn(async () => undefined),
         snapshot: vi.fn(
           async () => new Map<string, ReadonlySet<string>>([["home-main", new Set(["managed"])]]),
@@ -577,17 +579,9 @@ describe("Codex supervision catalog", () => {
     } as OpenClawConfig;
     const command = createCodexSessionCatalogNodeHostCommands(
       createEligibleControl({
-        listPage: vi.fn(async () => ({
-          sessions: [
-            {
-              threadId,
-              status: "idle",
-              source: "atlas",
-              cwd: "/node/catalog/cwd",
-              archived: false,
-            },
-          ],
-        })),
+        requireEligibleThread: vi.fn(async () =>
+          idleThread({ id: threadId, source: { custom: "atlas" }, cwd: "/node/catalog/cwd" }),
+        ),
       }),
       {
         getPluginConfig: () => ({ appServer: { homeScope: "agent" } }),

--- a/extensions/codex/src/session-catalog-provenance.test.ts
+++ b/extensions/codex/src/session-catalog-provenance.test.ts
@@ -2,9 +2,25 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { zstdCompressSync } from "node:zlib";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CodexThread } from "./app-server/protocol.js";
 import { isOpenClawManagedCodexThread } from "./session-catalog-provenance.js";
+import {
+  config,
+  idleThread,
+  commandRpcMocks,
+  pinnedConnectionMocks,
+  createCodexSessionCatalogControlFactory as createCodexSessionCatalogControl,
+  createRuntime,
+  createGatewayApi,
+  registerCodexSessionCatalog,
+  createCodexTestBindingStore,
+  createCodexSessionCatalogNodeHostCommands,
+  CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND,
+  CODEX_TERMINAL_RESUME_COMMAND,
+  nodeHostMocks,
+  withEnvAsync,
+} from "./session-catalog.test-helpers.js";
 
 const temporaryDirectories: string[] = [];
 
@@ -148,5 +164,424 @@ describe("Codex catalog provenance", () => {
     await expect(
       isOpenClawManagedCodexThread({ id: "missing-path" } as CodexThread, path.dirname(native)),
     ).resolves.toBe(false);
+  });
+});
+
+// Filesystem cases use the production budget; clock-driven cases select their own deadline.
+async function localEligibilityFixture(now = () => 0, requestTimeoutMs?: number) {
+  const home = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "codex-eligibility-")));
+  temporaryDirectories.push(home);
+  const root = path.join(home, "sessions");
+  await fs.mkdir(root);
+  const rollout = path.join(root, "source.jsonl");
+  const metadata = {
+    id: "12345678-1234-1234-1234-123456789abc",
+    source: "cli",
+    originator: "codex_cli_rs",
+  };
+  const writeMetadata = (payload: Record<string, unknown>) =>
+    fs.writeFile(rollout, `${JSON.stringify({ type: "session_meta", payload })}\n`);
+  await writeMetadata(metadata);
+  const thread = idleThread({ id: metadata.id, source: "cli", path: rollout });
+  const managedThreads = {
+    has: vi.fn(async (_sourceHomeId: string, _threadId: string) => false),
+    mark: vi.fn(async () => true),
+    snapshot: vi.fn(async () => new Map()),
+  };
+  const factory = createCodexSessionCatalogControl({
+    env: { CODEX_HOME: home },
+    getPluginConfig: () => ({ appServer: { requestTimeoutMs } }),
+    getRuntimeConfig: () => config,
+    now,
+    managedThreads,
+  });
+  const source = factory.homesForAgent("main")[0]!;
+  const control = factory.forRequest("main", source);
+  pinnedConnectionMocks.request.mockImplementation(async ({ method }) =>
+    method === "thread/read" ? { thread } : { data: [thread] },
+  );
+  return {
+    home,
+    root,
+    rollout,
+    metadata,
+    writeMetadata,
+    thread,
+    managedThreads,
+    factory,
+    source,
+    control,
+  };
+}
+
+describe("Codex exact local eligibility", () => {
+  it.each(["cli", "vscode", { custom: "atlas" }, { custom: "chatgpt" }] as const)(
+    "verifies interactive source %j using one selected rollout",
+    async (source) => {
+      const f = await localEligibilityFixture();
+      f.thread.source = source;
+      await f.writeMetadata({ ...f.metadata, source });
+      await expect(f.control.requireEligibleThread(f.thread.id)).resolves.toBe(f.thread);
+      expect(
+        pinnedConnectionMocks.request.mock.calls.map(([r]) => [r.method, r.requestParams]),
+      ).toEqual([
+        ["thread/read", { threadId: f.thread.id, includeTurns: false }],
+        [
+          "thread/list",
+          {
+            archived: false,
+            cwd: f.thread.cwd,
+            limit: 100,
+            modelProviders: [],
+            sortKey: "recency_at",
+            sortDirection: "desc",
+            useStateDbOnly: true,
+          },
+        ],
+      ]);
+      expect(commandRpcMocks.codexControlRequest).not.toHaveBeenCalled();
+      expect(f.managedThreads.snapshot).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    "archived",
+    "missing",
+    "noninteractive",
+    "stale source",
+    "wrong metadata",
+    "wrong read",
+    "different rollout",
+    "outside",
+    "symlink",
+    "hardlink",
+    "malformed",
+    "unreadable",
+    "oversized",
+    "managed",
+    "managed provenance",
+  ])("rejects %s evidence without broad listing", async (kind) => {
+    const f = await localEligibilityFixture();
+    const listed = { ...f.thread };
+    if (kind === "archived") {
+      const archived = path.join(f.home, "archived_sessions");
+      await fs.mkdir(archived);
+      await fs.rename(f.rollout, path.join(archived, "source.jsonl"));
+      f.thread.path = path.join(archived, "source.jsonl");
+      listed.path = f.thread.path;
+    } else if (kind === "missing") {
+      await fs.rm(f.rollout);
+    } else if (kind === "noninteractive") {
+      f.thread.source = "exec";
+    } else if (kind === "stale source") {
+      await f.writeMetadata({ ...f.metadata, source: "exec" });
+    } else if (kind === "wrong metadata") {
+      await f.writeMetadata({ ...f.metadata, id: "other-thread" });
+    } else if (kind === "wrong read") {
+      f.thread.id = "other-thread";
+    } else if (kind === "different rollout") {
+      listed.path = path.join(f.root, "previous.jsonl");
+    } else if (kind === "outside") {
+      f.thread.path = path.join(f.home, "source.jsonl");
+      listed.path = f.thread.path;
+      await fs.rename(f.rollout, f.thread.path);
+    } else if (kind === "symlink" || kind === "hardlink") {
+      const target = path.join(f.home, "source.jsonl");
+      await fs.rename(f.rollout, target);
+      if (kind === "symlink") {
+        await fs.symlink(target, f.rollout);
+      } else {
+        await fs.link(target, f.rollout);
+      }
+    } else if (kind === "malformed") {
+      await fs.writeFile(f.rollout, "not metadata\n");
+    } else if (kind === "unreadable") {
+      await fs.rm(f.rollout);
+      await fs.mkdir(f.rollout);
+    } else if (kind === "oversized") {
+      await f.writeMetadata({ ...f.metadata, instructions: "x".repeat(1024 * 1024) });
+    } else if (kind === "managed") {
+      f.managedThreads.has.mockResolvedValue(true);
+    } else {
+      await f.writeMetadata({ ...f.metadata, originator: "openclaw" });
+    }
+    pinnedConnectionMocks.request.mockImplementation(async ({ method, requestParams }) => {
+      if (method === "thread/read") {
+        return { thread: f.thread };
+      }
+      if (method === "thread/list" && requestParams.useStateDbOnly === true) {
+        return { data: [listed] };
+      }
+      throw new Error("broad listing must not run");
+    });
+    await expect(f.control.requireEligibleThread(f.metadata.id)).rejects.toThrow(
+      "eligibility could not be verified",
+    );
+    expect(
+      pinnedConnectionMocks.request.mock.calls.every(
+        ([r]) => r.method !== "thread/list" || r.requestParams.useStateDbOnly === true,
+      ),
+    ).toBe(true);
+  });
+
+  it.each(["absent", "repeated", "oversized", "page cap"])(
+    "rejects %s native membership",
+    async (kind) => {
+      const f = await localEligibilityFixture();
+      let page = 0;
+      pinnedConnectionMocks.request.mockImplementation(async ({ method }) => {
+        if (method === "thread/read") {
+          return { thread: f.thread };
+        }
+        page += 1;
+        return {
+          data: [],
+          nextCursor:
+            kind === "absent"
+              ? null
+              : kind === "repeated"
+                ? "cycle"
+                : kind === "oversized"
+                  ? "x".repeat(4097)
+                  : `page-${page}`,
+        };
+      });
+      await expect(f.control.requireEligibleThread(f.thread.id)).rejects.toThrow(
+        kind === "oversized"
+          ? "invalid Codex session catalog"
+          : "eligibility could not be verified",
+      );
+      expect(page).toBe(kind === "page cap" ? 100 : kind === "repeated" ? 2 : 1);
+    },
+  );
+
+  it.each([false, true])(
+    "accepts native compressed path representation (read compressed: %s)",
+    async (readCompressed) => {
+      const f = await localEligibilityFixture();
+      await fs.writeFile(`${f.rollout}.zst`, zstdCompressSync(await fs.readFile(f.rollout)));
+      await fs.rm(f.rollout);
+      f.thread.path = readCompressed ? `${f.rollout}.zst` : f.rollout;
+      pinnedConnectionMocks.request.mockImplementation(async ({ method }) =>
+        method === "thread/read"
+          ? { thread: f.thread }
+          : { data: [{ ...f.thread, path: readCompressed ? f.rollout : `${f.rollout}.zst` }] },
+      );
+      await expect(f.control.requireEligibleThread(f.thread.id)).resolves.toBe(f.thread);
+    },
+  );
+
+  it("follows opaque recency cursors beyond the first same-timestamp page without narrowing providers", async () => {
+    const f = await localEligibilityFixture();
+    const cursor = "native-opaque-timestamp-and-id";
+    pinnedConnectionMocks.request.mockImplementation(async ({ method, requestParams }) => {
+      if (method === "thread/read") {
+        return { thread: { ...f.thread, modelProvider: "rollout-provider" } };
+      }
+      return requestParams.cursor === cursor
+        ? { data: [{ ...f.thread, modelProvider: "indexed-provider", recencyAt: 42 }] }
+        : {
+            data: Array.from({ length: 100 }, (_, i) => ({
+              ...f.thread,
+              id: `other-${i}`,
+              recencyAt: 42,
+            })),
+            nextCursor: cursor,
+          };
+    });
+    await expect(f.control.requireEligibleThread(f.thread.id)).resolves.toMatchObject({
+      id: f.thread.id,
+    });
+    expect(pinnedConnectionMocks.request.mock.calls.slice(1).map(([r]) => r.requestParams)).toEqual(
+      [
+        expect.objectContaining({ sortKey: "recency_at", modelProviders: [] }),
+        expect.objectContaining({ cursor, sortKey: "recency_at", modelProviders: [] }),
+      ],
+    );
+  });
+
+  it("uses one deadline across the exact read and all membership pages", async () => {
+    let now = 0;
+    const f = await localEligibilityFixture(() => now, 1_000);
+    pinnedConnectionMocks.request.mockImplementation(async ({ method }) => {
+      now += 400;
+      return method === "thread/read"
+        ? { thread: f.thread }
+        : { data: [], nextCursor: `page-${now}` };
+    });
+    await expect(f.control.requireEligibleThread(f.thread.id)).rejects.toThrow(
+      "eligibility could not be verified",
+    );
+    expect(pinnedConnectionMocks.request.mock.calls.map(([r]) => r.timeoutMs)).toEqual([
+      1_000, 600, 200,
+    ]);
+  });
+
+  it("bounds stalled ownership lookup and prevents native reads after its deadline", async () => {
+    const f = await localEligibilityFixture(() => Date.now(), 1_000);
+    let release!: (managed: boolean) => void;
+    f.managedThreads.has.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          release = resolve;
+        }),
+    );
+    vi.useFakeTimers();
+    try {
+      const result = expect(f.control.requireEligibleThread(f.thread.id)).rejects.toThrow(
+        "eligibility could not be verified",
+      );
+      await vi.advanceTimersByTimeAsync(1_000);
+      await result;
+      release(false);
+      await vi.advanceTimersByTimeAsync(0);
+      expect(pinnedConnectionMocks.request).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(["transcript", "archive", "terminal", "node transcript", "node terminal"])(
+    "uses exact eligibility for %s at the real catalog boundary",
+    async (action) => {
+      const f = await localEligibilityFixture();
+      // Terminal viewing remains available while the source is active.
+      if (action.includes("terminal")) {
+        f.thread.status = { type: "active" };
+      }
+      const reply = ({
+        method,
+        requestParams,
+      }: {
+        method: string;
+        requestParams: Record<string, unknown>;
+      }) => {
+        if (method === "thread/read") {
+          return { thread: f.thread };
+        }
+        if (method === "thread/list" && requestParams.ancestorThreadId) {
+          return { data: [] };
+        }
+        if (method === "thread/list" && requestParams.useStateDbOnly === true) {
+          return { data: [f.thread] };
+        }
+        if (method === "thread/turns/list") {
+          return { data: [] };
+        }
+        if (method === "thread/archive") {
+          return {};
+        }
+        throw new Error("broad listing must not run");
+      };
+      pinnedConnectionMocks.request.mockImplementation(reply);
+      commandRpcMocks.codexControlRequest.mockImplementation(
+        async (_config, method, requestParams) => reply({ method, requestParams }),
+      );
+      const bindingStore = createCodexTestBindingStore();
+      const { runtime } = createRuntime();
+      const { api, getProvider } = createGatewayApi(runtime);
+      const sources = { getPluginConfig: () => ({}), getRuntimeConfig: () => config };
+      registerCodexSessionCatalog({ api, bindingStore, control: f.factory, ...sources });
+      const provider = getProvider()!;
+      const request = {
+        hostId: f.source.hostId,
+        sourceHomeId: f.source.sourceHomeId,
+        threadId: f.thread.id,
+      };
+      const binary = path.join(f.home, process.platform === "win32" ? "codex.exe" : "codex");
+      await fs.writeFile(binary, "synthetic executable; never launched", { mode: 0o755 });
+      await withEnvAsync({ PATH: f.home }, async () => {
+        if (action === "transcript") {
+          await expect(provider.read(request)).resolves.toMatchObject({
+            threadId: f.thread.id,
+            items: [],
+          });
+        } else if (action === "archive") {
+          await expect(
+            provider.archive!({ ...request, confirmNoOtherRunner: true }),
+          ).resolves.toEqual({ ok: true });
+        } else if (action === "terminal") {
+          await expect(provider.openTerminal!(request)).resolves.toMatchObject({
+            kind: "local",
+            cwd: f.thread.cwd,
+            argv: [binary, "resume", f.thread.id],
+          });
+        } else {
+          const commandId =
+            action === "node transcript"
+              ? CODEX_APP_SERVER_THREAD_TURNS_LIST_COMMAND
+              : CODEX_TERMINAL_RESUME_COMMAND;
+          const command = createCodexSessionCatalogNodeHostCommands(
+            f.factory,
+            sources,
+            bindingStore,
+          ).find((c) => c.command === commandId)!;
+          const io = {
+            signal: new AbortController().signal,
+            emitChunk: async () => {},
+            onInput: () => {},
+          };
+          await command.handle(
+            JSON.stringify({
+              agentId: "main",
+              threadId: f.thread.id,
+              ...(action === "node terminal" ? { cols: 80, rows: 24 } : {}),
+            }),
+            io,
+          );
+          if (action === "node terminal") {
+            expect(nodeHostMocks.runNodePtyCommand).toHaveBeenCalledWith(
+              expect.objectContaining({ args: ["resume", f.thread.id], cwd: f.thread.cwd }),
+              io,
+            );
+          }
+        }
+      });
+      expect(pinnedConnectionMocks.request.mock.calls[0]?.[0]).toMatchObject({
+        method: "thread/read",
+        requestParams: { threadId: f.thread.id, includeTurns: false },
+      });
+      expect(
+        pinnedConnectionMocks.request.mock.calls.filter(([r]) => r.method === "thread/read"),
+      ).toHaveLength(action === "archive" ? 2 : 1);
+    },
+  );
+
+  it("does not promote cached negative provenance or cross-home ownership into eligibility", async () => {
+    const f = await localEligibilityFixture();
+    commandRpcMocks.codexControlRequest.mockResolvedValue({ data: [f.thread] });
+    await f.control.listPage({});
+    await fs.rm(f.rollout);
+    await expect(f.control.requireEligibleThread(f.thread.id)).rejects.toThrow(
+      "eligibility could not be verified",
+    );
+    await f.writeMetadata(f.metadata);
+    f.managedThreads.has.mockImplementation(
+      async (sourceHomeId) => sourceHomeId !== f.source.sourceHomeId,
+    );
+    await expect(f.control.requireEligibleThread(f.thread.id)).resolves.toBe(f.thread);
+    expect(f.managedThreads.has).toHaveBeenLastCalledWith(f.source.sourceHomeId, f.thread.id);
+    const other = f.factory.forRequest("main", { ...f.source, sourceHomeId: "other-home" });
+    await expect(other.requireEligibleThread(f.thread.id)).rejects.toThrow(
+      "eligibility could not be verified",
+    );
+  });
+
+  it("selects native scan-and-repair verification upfront for a remote pathless source", async () => {
+    const f = await localEligibilityFixture();
+    const { localSessionsRoot: _root, ...remoteSource } = f.source;
+    f.thread.path = null;
+    const remote = f.factory.forRequest("main", remoteSource);
+    await expect(remote.requireEligibleThread(f.thread.id)).resolves.toBe(f.thread);
+    expect(pinnedConnectionMocks.request.mock.calls.map(([r]) => r.method)).toEqual([
+      "thread/list",
+    ]);
+    expect(pinnedConnectionMocks.request.mock.calls[0]?.[0].requestParams).toEqual({
+      archived: false,
+      limit: 100,
+      modelProviders: [],
+      sortKey: "updated_at",
+      sortDirection: "desc",
+    });
   });
 });

--- a/extensions/codex/src/session-catalog-terminal.ts
+++ b/extensions/codex/src/session-catalog-terminal.ts
@@ -81,56 +81,6 @@ export function codexNodeTerminalCapability(node: {
     : {};
 }
 
-export async function requireCatalogEligibleThread(
-  control: CodexSessionCatalogControl,
-  threadId: string,
-): Promise<CodexSessionCatalogSession> {
-  // Mutating actions use a fresh pinned control and authoritative thread/read. Passive positive hits
-  // may use the cadence-safe page memo; only a miss must bypass it before rejecting a new thread.
-  const cached = await findCatalogEligibleThread(control, threadId, false);
-  if (cached) {
-    return cached;
-  }
-  const refreshed = await findCatalogEligibleThread(control, threadId, true);
-  if (refreshed) {
-    return refreshed;
-  }
-  throw new CatalogParamsError("Codex session is not a non-archived interactive Codex session");
-}
-
-async function findCatalogEligibleThread(
-  control: CodexSessionCatalogControl,
-  threadId: string,
-  forceRefresh: boolean,
-): Promise<CodexSessionCatalogSession | undefined> {
-  let cursor: string | undefined;
-  const seenCursors = new Set<string>();
-  for (let pageIndex = 0; pageIndex < MAX_ACTION_CATALOG_PAGES; pageIndex += 1) {
-    const page = await control.listPage({
-      limit: CODEX_SESSION_CATALOG_MAX_PAGE_LIMIT,
-      ...(cursor ? { cursor } : {}),
-      ...(forceRefresh ? { forceRefresh: true } : {}),
-    });
-    const candidate = page.sessions.find((session) => session.threadId === threadId);
-    if (candidate) {
-      if (isInteractiveThreadSource(candidate.source)) {
-        return candidate;
-      }
-      throw new CatalogParamsError("Codex session is not a non-archived interactive Codex session");
-    }
-    const nextCursor = page.nextCursor?.trim();
-    if (!nextCursor) {
-      return undefined;
-    }
-    if (seenCursors.has(nextCursor)) {
-      throw new CatalogParamsError("Codex session eligibility could not be verified");
-    }
-    seenCursors.add(nextCursor);
-    cursor = nextCursor;
-  }
-  throw new CatalogParamsError("Codex session eligibility could not be verified");
-}
-
 export function createCodexTerminalNodeHostCommand(
   bindRequest: (paramsJSON?: string | null) => {
     agentId: string;
@@ -166,7 +116,7 @@ export function createCodexTerminalNodeHostCommand(
         }
         return value;
       });
-      const record = await requireCatalogEligibleThread(request.control, resume.threadId);
+      const record = await request.control.requireEligibleThread(resume.threadId);
       const resolution = resolveNodeHostExecutable("codex", {
         env: process.env,
         pathEnv: process.env.PATH ?? process.env.Path ?? "",
@@ -180,7 +130,7 @@ export function createCodexTerminalNodeHostCommand(
           {
             file: resolution.executable,
             args: ["resume", resume.threadId],
-            cwd: record.cwd,
+            ...(record.cwd ? { cwd: record.cwd } : {}),
             env: {
               CODEX_HOME: resolveCodexCatalogTerminalHome({
                 ...configSources,
@@ -252,7 +202,7 @@ export async function openCodexCatalogTerminal(
     params.hostId === CODEX_LOCAL_SESSION_HOST_ID ||
     params.hostId.startsWith(`${CODEX_LOCAL_SESSION_HOST_ID}:`)
   ) {
-    const record = await requireCatalogEligibleThread(params.control, params.threadId);
+    const record = await params.control.requireEligibleThread(params.threadId);
     const resolution = resolveLocalCodexTerminalResolution();
     // A managed app-server may exist without a local CLI. Fail closed so
     // terminal resume never targets a different machine or missing binary.

--- a/extensions/codex/src/session-catalog-types.ts
+++ b/extensions/codex/src/session-catalog-types.ts
@@ -57,8 +57,6 @@ export type CodexSessionCatalogPageParams = {
   limit?: number;
   searchTerm?: string;
   cwd?: string;
-  /** Bypasses the brief list memo after a specific thread lookup misses. */
-  forceRefresh?: boolean;
 };
 
 export type CodexSessionCatalogControl = {
@@ -66,6 +64,7 @@ export type CodexSessionCatalogControl = {
   connectionFingerprint?: string;
   withPinnedConnection<T>(run: (control: CodexSessionCatalogControl) => Promise<T>): Promise<T>;
   listPage(params: CodexSessionCatalogPageParams): Promise<CodexSessionCatalogPage>;
+  requireEligibleThread(threadId: string): Promise<CodexThread>;
   listDescendantPage(params: CodexThreadListParams): Promise<CodexThreadListResponse>;
   listTurnPage(params: CodexThreadTurnsListParams): Promise<CodexThreadTurnsListResponse>;
   forkThread(params: CodexThreadForkParams): Promise<CodexThreadForkResponse>;

--- a/extensions/codex/src/session-catalog.test-helpers.ts
+++ b/extensions/codex/src/session-catalog.test-helpers.ts
@@ -42,7 +42,6 @@ import { listPairedNode } from "./session-catalog-node-continue.js";
 import { catalogError, parseCatalogPage } from "./session-catalog-parsing.js";
 import {
   CODEX_TERMINAL_RESUME_COMMAND,
-  requireCatalogEligibleThread,
   type CodexTerminalConfigSources,
 } from "./session-catalog-terminal.js";
 import type {
@@ -318,6 +317,7 @@ export function createControl(overrides: Partial<CodexSessionCatalogControl> = {
   const control = {
     connectionFingerprint: "catalog-connection",
     withPinnedConnection,
+    requireEligibleThread: vi.fn(async (threadId: string) => idleThread({ id: threadId })),
     listPage: vi.fn(async () => ({ sessions: [] })),
     listDescendantPage: vi.fn(async () => ({ data: [] })),
     listTurnPage: vi.fn(async () => ({ data: [] })),
@@ -594,7 +594,6 @@ export {
   catalogError,
   parseCatalogPage,
   CODEX_TERMINAL_RESUME_COMMAND,
-  requireCatalogEligibleThread,
   CODEX_LOCAL_SESSION_HOST_ID,
   createCodexSessionCatalogControlFactory,
   createCodexSessionCatalogNodeInvokePolicies,

--- a/test/plugins/codex-session-catalog-naming.test.ts
+++ b/test/plugins/codex-session-catalog-naming.test.ts
@@ -1,5 +1,6 @@
 import { once } from "node:events";
 import fs from "node:fs/promises";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { rawDataToString } from "@openclaw/gateway-client/websocket-data";
 import { expect, it } from "vitest";
@@ -81,8 +82,12 @@ it("adopts duplicate native titles without claiming labels or replacing local na
           "",
           ` ${"界".repeat(499)}${"🦞".repeat(300)} `,
         ];
+        // WebSocket supervision selects the agent's native home, not process CODEX_HOME.
+        const sessionsRoot = path.join(state.agentDir(), "codex-home", "sessions");
+        await fs.mkdir(sessionsRoot, { recursive: true });
         const threads = titles.map((name, index) => ({
           id: `01980000-0000-7000-8000-${String(index + 1).padStart(12, "0")}`,
+          path: path.join(sessionsRoot, `rollout-${index}.jsonl`),
           name,
           cwd: state.workspaceDir,
           projectId: null,
@@ -106,6 +111,26 @@ it("adopts duplicate native titles without claiming labels or replacing local na
             },
           ],
         }));
+        for (const thread of threads) {
+          const timestamp = new Date(thread.createdAt * 1000).toISOString();
+          await fs.writeFile(
+            thread.path,
+            `${JSON.stringify({
+              timestamp,
+              type: "session_meta",
+              payload: {
+                session_id: thread.id,
+                id: thread.id,
+                timestamp,
+                cwd: thread.cwd,
+                source: thread.source,
+                originator: "codex_cli_rs",
+                cli_version: "0.151.0",
+                model_provider: thread.modelProvider,
+              },
+            })}\n`,
+          );
+        }
         server.on("connection", (socket) => {
           socket.on("message", (data) => {
             const request = JSON.parse(rawDataToString(data)) as {


### PR DESCRIPTION
Closes #133929 — known native Codex sessions can time out before import in large homes.

<details>
<summary>Additional instructions</summary>

This is an upstream branch that maintainers can push to.

</details>

## What Problem This Solves

Fixes an issue where users importing a known native Codex session would hit a `thread/list` timeout before import when their native home contained many rollouts. Exact native transcript and terminal actions shared the same unnecessary dependency on full catalog discovery.

This is the separate follow-up found while validating [paginated native fork support](https://github.com/openclaw/openclaw/pull/132908), not a change to that merged PR.

## Why This Change Was Made

The source-pinned catalog control now owns exact eligibility: read the selected thread, check non-archived DB-only membership with bounded opaque pagination, and freshly validate the matching interactive, non-OpenClaw rollout under that source's active sessions root. Neither a metadata read nor an index row is sufficient alone; the composition preserves managed-thread exclusion and action-specific lifecycle checks without increasing timeouts or changing ordinary discovery.

## User Impact

Known filesystem-backed local sessions can be imported and read without enumerating unrelated rollouts. Local TypeScript/headless-node transcript and terminal consumers share the same owner; Archive still performs a separate fresh activity read before its existing ownership/descendant checks. Unverifiable metadata fails explicitly rather than being treated as proof of a native session.

Ordinary discovery and remote/pathless native membership verification retain their existing behavior. Gateway-to-node catalog enumeration and the native Swift implementation are unchanged. This does not make initial catalog discovery instantaneous or add a cross-process writer lease. No new configuration, environment variable, dependency, protocol, or database schema is introduced.

## Evidence

A real isolated Gateway and official Codex 0.151.0 used the same synthetic 10,000-rollout home before and after: one disposable native paginated thread with two completed turns, plus 9,999 synthetic noninteractive headers. Native metadata/history initialization used Codex's own APIs; no manual SQLite repairs, copied credentials, operator Gateway changes, or inference were needed for the import proof.

| Observed operation | Before | After |
| --- | --- | --- |
| Gateway Continue action | `thread/list` timeout at 62,860 ms | Success in 568 ms |
| Exact native transcript RPC | `thread/list` timeout at 60,014 ms | Success in 39 ms |
| Imported Chat | Unavailable | Both native turns visible; `/status` answered |

These are single-run operation timings, not whole-process benchmarks. The after CLI process took 72.7 seconds because the source launcher rebuilt the dirty checkout first. A cold native preview still took 40.9 seconds overall waiting on unchanged discovery before its 39 ms exact read. The imported Chat opened in 546 ms. The source rollout's SHA-256 remained unchanged.

Before, actual native-preview failure:

![Before: known native source cannot load because thread/list times out](https://github.com/user-attachments/assets/ca5e2b60-d4bc-489d-9169-247e27719768)

After, imported history and a real non-inference status reply:

![After: both imported native turns and the OpenClaw status reply](https://github.com/user-attachments/assets/b808a6da-e273-49fc-8832-98dafe5ce573)

The production-repair recording at `00d75bc3ae818c8d7d5aa478a7f944d808a11aed` uses a fresh OpenClaw state directory and captures the UI-driven import itself, navigation into the new Chat, and `/status`. The subsequent CI-repair commit changes tests only. After 14.7 seconds of ordinary catalog discovery, the measured exact read took 36 ms, Continue took 211 ms, and navigation completed in 258 ms; the original two turns remained visible. Every recorded frame was inspected for synthetic-only content, and the source rollout remained unchanged.

https://github.com/user-attachments/assets/854a36ef-b813-4361-aec2-3ee1aa2ccae6

Regression proof captured the actual pre-fix import rejection (`thread/list timed out`) and then passed. The catalog/CLI/upstream-activity/managed-store sweep passed 187 tests across 13 suites; four focused native ownership-bookkeeping tests also passed. Coverage includes read-before-index ordering, stale source metadata, archived/missing/unsafe/managed rollouts, source-home isolation, compressed-path equivalence, selected-path disagreement, opaque pagination, repeated cursors, one total eligibility deadline, local consumers, and unchanged remote membership strategy. A strengthened existing mutation test also caught—and now prevents—reusing pre-membership activity status for Archive.

```bash
node scripts/run-vitest.mjs extensions/codex/src/session-catalog*.test.ts extensions/codex/src/session-upstream*.test.ts extensions/codex/src/session-cli.test.ts extensions/codex/src/app-server/managed-thread-store.test.ts
```

```bash
node scripts/run-vitest.mjs extensions/codex/src/app-server/thread-lifecycle.test.ts -t 'records ownership before committing|keys remote ownership|starts a durable thread when catalog ownership bookkeeping fails'
```

Build/check proof: the baseline full build, `node scripts/check-changed.mjs`, and the clean rebased candidate's `pnpm build:ci-artifacts` passed. The candidate emitted no ineffective-dynamic-import warnings. The initial rebase onto `620fb72e02466b32e494aa887e3750cdea91ef9b` kept the repair unchanged. A later necessary rebase onto `3ee32fb9c10dcf9d5713c0c4891e55227f5b1f0d` retained the independently landed provider-fixture fix from [Matrix monitor cleanup and CI repair](https://github.com/openclaw/openclaw/pull/134033), dropping our duplicate change. The production repair remains unchanged by range-diff. Fresh isolated Codex autoreview returned no actionable findings at its configured P0 scope. Two intermediate doctor-guard attempts collided with `dist` writers (the explicit build, then the CLI's automatic rebuild); the same five doctor tests passed once serialized. Nullable/native-shape type errors and test-style lint findings were repaired rather than suppressed.

The first CI run exposed a native naming fixture that supplied neither rollout paths nor files; this PR now materializes matching metadata in the selected agent-local native home without weakening the guard or naming assertions. Its separate global-prompt timeout came from a preexisting provider handle missing `modelId`; the canonical fix landed on `main` during validation and is retained rather than duplicated here. The lint job was canceled mid-step without a lint diagnostic. Seventeen additional focused tests and canonical core/test-root gates passed; after conflict resolution, both complete affected test files passed again, followed by a clean build and fresh full-candidate review. The new exact-head CI run reruns the canceled lane as well.

Dependency contract inspected directly at Codex `rust-v0.151.0` (`78c290807ce710180111df227df3b7a4fe845452`): [list/read processor](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/app-server/src/request_processors/thread_processor.rs#L2480-L2600), [local listing owner](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/thread-store/src/local/list_threads.rs), and [rollout reconciliation](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/rollout/src/recorder.rs#L474-L743). Required read/list fields, missing-index read repair, and the recency ID tiebreaker were also checked directly in `rust-v0.149.0`, the supported minimum. An official, integrity-verified 0.149.0 binary passed the unindexed/read/index composition plus unreadable, archived, unarchived, and missing-rollout probes; [the maintainer proof comment](https://github.com/openclaw/openclaw/pull/134073#issuecomment-5478149267) records outcomes and the explicit strict-metadata compatibility decision. Gateway/UI and paginated large-home proof used 0.151.0.

The old terminal-owned scan and force-refresh-on-miss path are deleted. Production is net +73 lines after consolidating ownership and removing duplicate scans; the remaining growth implements the bounded membership/provenance proof and exact existing-store lookup that native `thread/read` cannot provide alone. Tests/support are net +294 lines, counted separately. [Operator troubleshooting](https://docs.openclaw.ai/plugins/codex-supervision#troubleshooting) documents explicit verification failures and the unchanged discovery scope.
