### PR TITLE
fix(update): retain pnpm owner across launcher respawn

### DIFF
--- a/openclaw.mjs
+++ b/openclaw.mjs
@@ -277,7 +277,8 @@ const respawnWithPackagedCompileCacheIfNeeded = () => {
   };
   return runRespawnedChild(
     process.execPath,
-    [...process.execArgv, fileURLToPath(import.meta.url), ...process.argv.slice(2)],
+    // pnpm's lexical hash link owns the install; its realpath is only shared package content.
+    [...process.execArgv, process.argv[1], ...process.argv.slice(2)],
     env,
   );
 };

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -4103,6 +4103,22 @@ describe("update-cli", () => {
     expect(packageInstallCommandCall()).toBeUndefined();
   });
 
+  it("does not clean handoffs before rejecting an unknown package owner", async () => {
+    mockPackageInstallStatus(createCaseDir("openclaw-unknown-owner"));
+    resolveGlobalManager.mockRejectedValueOnce(
+      new Error(
+        "Update refused: package manager owner is unknown; no changes were made. Run this OpenClaw install through its active npm, pnpm, or Bun global shim, or reinstall it with that package manager, then retry.",
+      ),
+    );
+
+    await expect(updateCommand({ yes: true, restart: false })).rejects.toThrow(
+      "Update refused: package manager owner is unknown; no changes were made. Run this OpenClaw install through its active npm, pnpm, or Bun global shim, or reinstall it with that package manager, then retry.",
+    );
+
+    expect(cleanupStaleManagedServiceUpdateHandoffs).not.toHaveBeenCalled();
+    expect(packageInstallCommandCall()).toBeUndefined();
+  });
+
   it("reports an incompatible package target during dry-run", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-schema-dry-run"));
     vi.mocked(fetchNpmPackageTargetStatus).mockResolvedValue(

--- a/src/cli/update-cli/shared.command-runner.test.ts
+++ b/src/cli/update-cli/shared.command-runner.test.ts
@@ -8,6 +8,7 @@ import {
   createGlobalCommandRunner,
   ensureGitCheckout,
   parseTimeoutMsOrExit,
+  resolveGlobalManager,
   resolveUpdateRoot,
   runUpdateStep,
 } from "./shared.js";
@@ -162,6 +163,23 @@ describe("update CLI shared helpers", () => {
       });
     },
   );
+
+  it("refuses a package root without a proven manager owner", async () => {
+    runCommandWithTimeout.mockResolvedValue({
+      ...successfulCommandResult,
+      code: 1,
+      stderr: "not owned",
+    });
+
+    await expect(
+      resolveGlobalManager({
+        root: "/shared/store/openclaw",
+        installKind: "package",
+        timeoutMs: 1_000,
+      }),
+    ).rejects.toThrow("Update refused: package manager owner is unknown; no changes were made.");
+    expect(runCommandWithTimeout).toHaveBeenCalledTimes(2);
+  });
 
   it("publishes a successful fresh clone only after the clone completes", async () => {
     await withTestDir({ prefix: "openclaw-update-clone-success-" }, async (base) => {

--- a/src/cli/update-cli/shared.command-runner.test.ts
+++ b/src/cli/update-cli/shared.command-runner.test.ts
@@ -177,7 +177,9 @@ describe("update CLI shared helpers", () => {
         installKind: "package",
         timeoutMs: 1_000,
       }),
-    ).rejects.toThrow("Update refused: package manager owner is unknown; no changes were made.");
+    ).rejects.toThrow(
+      "Update refused: package manager owner is unknown; no changes were made. Run this OpenClaw install through its active npm, pnpm, or Bun global shim, or reinstall it with that package manager, then retry.",
+    );
     expect(runCommandWithTimeout).toHaveBeenCalledTimes(2);
   });
 

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -376,7 +376,9 @@ export async function resolveGlobalManager(params: {
       params.timeoutMs,
     );
     if (!detected) {
-      throw new Error("Update refused: package manager owner is unknown; no changes were made.");
+      throw new Error(
+        "Update refused: package manager owner is unknown; no changes were made. Run this OpenClaw install through its active npm, pnpm, or Bun global shim, or reinstall it with that package manager, then retry.",
+      );
     }
     return detected;
   }

--- a/src/cli/update-cli/shared.ts
+++ b/src/cli/update-cli/shared.ts
@@ -375,9 +375,10 @@ export async function resolveGlobalManager(params: {
       params.root,
       params.timeoutMs,
     );
-    if (detected) {
-      return detected;
+    if (!detected) {
+      throw new Error("Update refused: package manager owner is unknown; no changes were made.");
     }
+    return detected;
   }
 
   const byPresence = await detectGlobalInstallManagerByPresence(runCommand, params.timeoutMs);

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -205,9 +205,6 @@ async function updateCommandInternal(
       await disableCurrentOpenClawUpdateLaunchdJob().catch(() => undefined);
       throw err;
     }
-
-    // Cleanup deletes handoff directories, so previews and rejected invocations must never run it.
-    await cleanupStaleManagedServiceUpdateHandoffs().catch(() => undefined);
   }
   const updateStepTimeoutMs = timeoutMs ?? DEFAULT_UPDATE_STEP_TIMEOUT_MS;
 
@@ -614,6 +611,9 @@ async function updateCommandInternal(
 
   // Preload execution and recovery before the package swap can remove these chunks.
   const { executeMutableUpdate, finishUpdate } = await import("./update-execution.runtime.js");
+
+  // Cleanup deletes handoff directories, so previews and rejected invocations must never run it.
+  await cleanupStaleManagedServiceUpdateHandoffs().catch(() => undefined);
 
   // Startup migrations belong to the freshly installed Doctor. Admit shared-state
   // mutation only after every pre-install refusal has passed.

--- a/src/infra/update-global.pnpm11-discovery.test.ts
+++ b/src/infra/update-global.pnpm11-discovery.test.ts
@@ -190,12 +190,18 @@ describe("pnpm 11 global install discovery", () => {
         fs.symlink(activeInstallRoot, path.join(globalRoot, "hash-active"), "dir"),
       ]);
       const runCommand: CommandRunner = async (argv) => {
+        if (argv.join(" ") === "npm root -g") {
+          return { stdout: "", stderr: "", code: 1 };
+        }
         if (argv.join(" ") === "pnpm root -g") {
           return { stdout: `${globalRoot}\n`, stderr: "", code: 0 };
         }
         throw new Error(`unexpected command: ${argv.join(" ")}`);
       };
 
+      await expect(
+        detectGlobalInstallManagerForRoot(runCommand, sharedPackageRoot, 1000),
+      ).resolves.toBeNull();
       await expect(
         resolveGlobalInstallTarget({
           manager: "pnpm",

--- a/test/openclaw-launcher.e2e.test.ts
+++ b/test/openclaw-launcher.e2e.test.ts
@@ -1037,6 +1037,33 @@ describe("openclaw launcher", () => {
     },
   );
 
+  it.runIf(process.platform !== "win32")(
+    "preserves a packaged pnpm project path through compile-cache respawn",
+    async () => {
+      const fixtureRoot = await makeLauncherFixture(fixtureRoots);
+      await fs.writeFile(path.join(fixtureRoot, "package.json"), '{"version":"2026.8.1"}\n');
+      await fs.writeFile(
+        path.join(fixtureRoot, "dist", "entry.js"),
+        'process.stdout.write(process.argv[1] ?? "");\n',
+        "utf8",
+      );
+      const globalRoot = makeTempDir(fixtureRoots, "openclaw-pnpm-global-");
+      const packageRoot = path.join(globalRoot, "v11", "active", "node_modules", "openclaw");
+      await fs.mkdir(path.dirname(packageRoot), { recursive: true });
+      await fs.symlink(fixtureRoot, packageRoot, "dir");
+      const launcher = path.join(packageRoot, "openclaw.mjs");
+
+      const result = spawnSync(process.execPath, [launcher], {
+        cwd: globalRoot,
+        env: launcherEnv({ NODE_COMPILE_CACHE: path.join(globalRoot, ".node-compile-cache") }),
+        encoding: "utf8",
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toBe(launcher);
+    },
+  );
+
   it("keeps compile cache enabled for packaged launchers when NODE_COMPILE_CACHE is configured", async () => {
     const fixtureRoot = await makeLauncherFixture(fixtureRoots);
     await addCompileCacheProbe(fixtureRoot);


### PR DESCRIPTION
## Summary

- Preserve the lexical package entry through the packaged compile-cache respawn.
- Refuse package updates when no package manager owns the active package root.
- Keep pnpm ownership tied to one active global project, never its shared-store realpath.

## Problem

`openclaw update --dry-run` could classify a pnpm 11 global install as npm after the launcher respawned through the shared-store package path. A real update could then create a second npm install while the pnpm-owned Gateway stayed on the old package.

## Root cause

The packaged compile-cache respawn replaced the pnpm-generated hash-link entry in `process.argv[1]` with `import.meta.url`. The latter resolves to shared package content and has no global-project ownership identity. Manager detection then fell through to npm.

## Fix

The launcher passes the lexical entry to its child. Existing pnpm owner discovery then resolves the exact active project, carries its prepared install target through dry-run and mutation, and rejects grouped, multiple, orphaned, or mismatched owners. Package roots with no proven owner now stop before stale-handoff cleanup, with recovery guidance, instead of falling back to npm.

## Proof

- Red: a real isolated pnpm 11.25.0 global install of `openclaw@2026.8.1` reported `mode: npm` when compile-cache respawn was active.
- Green: the same non-mutating dry-run on the repaired launcher reported `mode: pnpm` and the active hash-linked project root.
- The green trace contains only pnpm probes and no npm command.
- The complete pnpm global-project tree was unchanged after dry-run.
- Focused launcher, owner-discovery, target-carry, ambiguity-refusal, and no-cleanup tests pass: 87 passed, one platform skip.

## Size

- Production: +10/-6, net +4 lines for lexical ownership preservation, fail-closed package detection, and pre-mutation cleanup ordering.
- Tests: +69 lines at the launcher, command, and package-owner boundaries.

Fixes #134037
