### PR TITLE
fix(doctor): report state blocked by config errors

### DIFF
--- a/src/cli/doctor-output.process.test.ts
+++ b/src/cli/doctor-output.process.test.ts
@@ -8,7 +8,152 @@ import { spawnNodeEvalSync } from "../test-utils/node-process.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+function runDoctorFix(params: { root: string; configPath: string; loaderPath: string }) {
+  const entryPath = fileURLToPath(new URL("../entry.ts", import.meta.url));
+  return spawnSync(
+    process.execPath,
+    [
+      "--import",
+      "tsx",
+      "--import",
+      params.loaderPath,
+      entryPath,
+      "doctor",
+      "--fix",
+      "--non-interactive",
+      "--no-workspace-suggestions",
+      "--no-color",
+    ],
+    {
+      cwd: path.resolve("."),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        HOME: params.root,
+        USERPROFILE: params.root,
+        NODE_DISABLE_COMPILE_CACHE: "1",
+        NODE_ENV: undefined,
+        OPENCLAW_CONFIG_PATH: params.configPath,
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        OPENCLAW_HIDE_BANNER: "1",
+        OPENCLAW_HOME: undefined,
+        OPENCLAW_NO_RESPAWN: "1",
+        OPENCLAW_SKIP_CHANNELS: "1",
+        OPENCLAW_STATE_DIR: path.join(params.root, "state"),
+        OPENCLAW_TEST_FAST: "1",
+        VITEST: undefined,
+        VITEST_POOL_ID: undefined,
+        VITEST_WORKER_ID: undefined,
+      },
+      maxBuffer: 4 * 1024 * 1024,
+      timeout: 60_000,
+    },
+  );
+}
+
 describe("Doctor report process output", () => {
+  it("reports deferred Doctor-only state after config refusal, then converges", () => {
+    const root = tempDirs.make("openclaw-doctor-deferred-state-");
+    const stateDir = path.join(root, "state");
+    const workspaceDir = path.join(root, "workspace");
+    const configPath = path.join(root, "openclaw.json");
+    const workspaceSource = path.join(workspaceDir, "openclaw-workspace-state.json");
+    const tuiSource = path.join(stateDir, "tui", "last-session.json");
+    const loaderPath = path.join(root, "doctor-test-loader.mjs");
+    fs.mkdirSync(path.dirname(tuiSource), { recursive: true });
+    fs.mkdirSync(workspaceDir, { recursive: true });
+    fs.writeFileSync(
+      loaderPath,
+      `import { registerHooks } from "node:module";
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.endsWith("/doctor-ui.js")) {
+      return {
+        shortCircuit: true,
+        url: "data:text/javascript," + encodeURIComponent(
+          [
+            "export async function detectUiProtocolFreshnessIssues() { return []; }",
+            "export function uiProtocolFreshnessIssueToHealthFinding() { return {}; }",
+            "export function uiProtocolFreshnessIssueToRepairEffects() { return []; }",
+            "export async function maybeRepairUiProtocolFreshness() {}",
+          ].join("\\n"),
+        ),
+      };
+    }
+    return nextResolve(specifier, context);
+  },
+});
+`,
+    );
+    const invalidConfig = {
+      gatway: { port: 12345 },
+      gateway: {
+        mode: "remote",
+        remote: { url: "ws://127.0.0.1:1", token: "fixture-token" },
+      },
+      agents: { defaults: { workspace: workspaceDir, heartbeat: { every: 5 } } },
+    };
+    fs.writeFileSync(configPath, `${JSON.stringify(invalidConfig, null, 2)}\n`);
+    fs.writeFileSync(
+      workspaceSource,
+      `${JSON.stringify({ version: 1, setupCompletedAt: "2026-08-01T00:00:00.000Z" })}\n`,
+    );
+    fs.writeFileSync(
+      tuiSource,
+      `${JSON.stringify({ global: { sessionKey: "agent:main:main", updatedAt: 1 } })}\n`,
+    );
+    const configBefore = fs.readFileSync(configPath);
+    const workspaceBefore = fs.readFileSync(workspaceSource);
+    const tuiBefore = fs.readFileSync(tuiSource);
+
+    const refused = runDoctorFix({ root, configPath, loaderPath });
+    const refusedOutput = `${refused.stderr}\n${refused.stdout}`;
+
+    expect(refused.error, refusedOutput).toBeUndefined();
+    expect(refused.signal, refusedOutput).toBeNull();
+    expect(refused.status, refusedOutput).toBe(1);
+    expect(refusedOutput.match(/Legacy state deferred/g) ?? [], refusedOutput).toHaveLength(1);
+    expect(refusedOutput).toContain("Workspace setup and attestations");
+    expect(refusedOutput).toContain("TUI last-session pointers");
+    expect(refusedOutput).toContain("No listed legacy source was removed.");
+    expect(refusedOutput).toContain('rerun "openclaw doctor --fix"');
+    expect(fs.readFileSync(configPath)).toEqual(configBefore);
+    expect(fs.readFileSync(workspaceSource)).toEqual(workspaceBefore);
+    expect(fs.readFileSync(tuiSource)).toEqual(tuiBefore);
+    expect(fs.readdirSync(workspaceDir)).toEqual(["openclaw-workspace-state.json"]);
+    expect(fs.readdirSync(path.dirname(tuiSource))).toEqual(["last-session.json"]);
+
+    fs.writeFileSync(
+      configPath,
+      `${JSON.stringify(
+        {
+          ...invalidConfig,
+          agents: {
+            defaults: { workspace: workspaceDir, heartbeat: { every: "30m" } },
+          },
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    const repaired = runDoctorFix({ root, configPath, loaderPath });
+    const repairedOutput = `${repaired.stderr}\n${repaired.stdout}`;
+    expect(repaired.error, repairedOutput).toBeUndefined();
+    expect(repaired.signal, repairedOutput).toBeNull();
+    expect(repaired.status, repairedOutput).toBe(0);
+    expect(fs.existsSync(workspaceSource)).toBe(false);
+    expect(fs.existsSync(tuiSource)).toBe(false);
+    expect(JSON.parse(fs.readFileSync(configPath, "utf8"))).not.toHaveProperty("gatway");
+
+    const clean = runDoctorFix({ root, configPath, loaderPath });
+    const cleanOutput = `${clean.stderr}\n${clean.stdout}`;
+    expect(clean.error, cleanOutput).toBeUndefined();
+    expect(clean.signal, cleanOutput).toBeNull();
+    expect(clean.status, cleanOutput).toBe(0);
+    expect(cleanOutput).not.toContain("Legacy state deferred");
+    expect(cleanOutput).not.toContain("Legacy state detected");
+  }, 180_000);
+
   it("omits backup tips for Git-backed nested agent workspaces", () => {
     const root = tempDirs.make("openclaw-doctor-workspace-git-");
     const repoRoot = path.join(root, "repo");

--- a/src/cli/doctor-output.process.test.ts
+++ b/src/cli/doctor-output.process.test.ts
@@ -59,6 +59,7 @@ describe("Doctor report process output", () => {
     const configPath = path.join(root, "openclaw.json");
     const workspaceSource = path.join(workspaceDir, "openclaw-workspace-state.json");
     const tuiSource = path.join(stateDir, "tui", "last-session.json");
+    const agentSource = path.join(stateDir, "agent", "auth.json");
     const loaderPath = path.join(root, "doctor-test-loader.mjs");
     fs.mkdirSync(path.dirname(tuiSource), { recursive: true });
     fs.mkdirSync(workspaceDir, { recursive: true });
@@ -91,7 +92,14 @@ registerHooks({
         mode: "remote",
         remote: { url: "ws://127.0.0.1:1", token: "fixture-token" },
       },
-      agents: { defaults: { workspace: workspaceDir, heartbeat: { every: 5 } } },
+      agents: {
+        ownership: "explicit",
+        defaults: { heartbeat: { every: 5 } },
+        entries: {
+          primary: { workspace: workspaceDir },
+          secondary: {},
+        },
+      },
     };
     fs.writeFileSync(configPath, `${JSON.stringify(invalidConfig, null, 2)}\n`);
     fs.writeFileSync(
@@ -102,9 +110,12 @@ registerHooks({
       tuiSource,
       `${JSON.stringify({ global: { sessionKey: "agent:main:main", updatedAt: 1 } })}\n`,
     );
+    fs.mkdirSync(path.dirname(agentSource), { recursive: true });
+    fs.writeFileSync(agentSource, "{}\n");
     const configBefore = fs.readFileSync(configPath);
     const workspaceBefore = fs.readFileSync(workspaceSource);
     const tuiBefore = fs.readFileSync(tuiSource);
+    const agentBefore = fs.readFileSync(agentSource);
 
     const refused = runDoctorFix({ root, configPath, loaderPath });
     const refusedOutput = `${refused.stderr}\n${refused.stdout}`;
@@ -115,11 +126,15 @@ registerHooks({
     expect(refusedOutput.match(/Legacy state deferred/g) ?? [], refusedOutput).toHaveLength(1);
     expect(refusedOutput).toContain("Workspace setup and attestations");
     expect(refusedOutput).toContain("TUI last-session pointers");
+    expect(refusedOutput).toContain(
+      "Deferred legacy agent/session migration: select an agent owner",
+    );
     expect(refusedOutput).toContain("No listed legacy source was removed.");
     expect(refusedOutput).toContain('rerun "openclaw doctor --fix"');
     expect(fs.readFileSync(configPath)).toEqual(configBefore);
     expect(fs.readFileSync(workspaceSource)).toEqual(workspaceBefore);
     expect(fs.readFileSync(tuiSource)).toEqual(tuiBefore);
+    expect(fs.readFileSync(agentSource)).toEqual(agentBefore);
     expect(fs.readdirSync(workspaceDir)).toEqual(["openclaw-workspace-state.json"]);
     expect(fs.readdirSync(path.dirname(tuiSource))).toEqual(["last-session.json"]);
 
@@ -129,7 +144,11 @@ registerHooks({
         {
           ...invalidConfig,
           agents: {
-            defaults: { workspace: workspaceDir, heartbeat: { every: "30m" } },
+            ...invalidConfig.agents,
+            defaults: {
+              heartbeat: { every: "30m" },
+              systemAgent: { agentId: "primary" },
+            },
           },
         },
         null,
@@ -143,6 +162,10 @@ registerHooks({
     expect(repaired.status, repairedOutput).toBe(0);
     expect(fs.existsSync(workspaceSource)).toBe(false);
     expect(fs.existsSync(tuiSource)).toBe(false);
+    expect(fs.existsSync(agentSource)).toBe(false);
+    expect(fs.existsSync(path.join(stateDir, "agents", "primary", "agent", "auth.json"))).toBe(
+      true,
+    );
     expect(JSON.parse(fs.readFileSync(configPath, "utf8"))).not.toHaveProperty("gatway");
 
     const clean = runDoctorFix({ root, configPath, loaderPath });

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1136,14 +1136,14 @@ describe("doctor health contributions", () => {
       options: { nonInteractive: true, repair: true },
       env: {},
     });
-    const pendingOwners = [
-      "- Workspace setup and attestations: legacy files → shared SQLite state",
-      "- TUI last-session pointers: legacy JSON file → shared SQLite state",
-      ...Array.from({ length: 20 }, (_, index) => `- Test owner ${index + 1}: legacy state`),
+    const pendingWarnings = [
+      "Deferred legacy agent/session migration: select an agent owner",
+      "Second pending owner needs operator input",
+      ...Array.from({ length: 20 }, (_, index) => `Test owner ${index + 1} is blocked`),
     ];
     mocks.detectLegacyStateMigrations.mockResolvedValue({
-      preview: pendingOwners,
-      warnings: [],
+      preview: [],
+      warnings: pendingWarnings,
       notices: [],
     });
     mocks.replaceConfigFile.mockRejectedValueOnce(
@@ -1194,9 +1194,9 @@ describe("doctor health contributions", () => {
       ([, title]) => title === "Legacy state deferred",
     );
     expect(deferredPanels).toHaveLength(1);
-    expect(deferredPanels[0]?.[0]).toContain(pendingOwners[0]);
-    expect(deferredPanels[0]?.[0]).toContain(pendingOwners[1]);
-    expect(deferredPanels[0]?.[0]).toContain("2 additional pending owners were omitted");
+    expect(deferredPanels[0]?.[0]).toContain(pendingWarnings[0]);
+    expect(deferredPanels[0]?.[0]).toContain(pendingWarnings[1]);
+    expect(deferredPanels[0]?.[0]).toContain("2 additional pending entries were omitted");
     expect(deferredPanels[0]?.[0]).toContain("No listed legacy source was removed.");
     expect(deferredPanels[0]?.[0]).toContain('rerun "openclaw doctor --fix"');
     expect(mocks.runLegacyStateMigrations).not.toHaveBeenCalled();
@@ -1289,7 +1289,13 @@ describe("doctor health contributions", () => {
       cfgForPersistence: structuredClone(cfg),
       configResult: { cfg, shouldWriteConfig: true },
       shouldRepair: true,
+      options: { repair: true },
       env: {},
+    });
+    mocks.detectLegacyStateMigrations.mockResolvedValue({
+      preview: ["- Workspace setup and attestations: legacy files → shared SQLite state"],
+      warnings: [],
+      notices: [],
     });
     mocks.replaceConfigFile.mockRejectedValueOnce(
       Object.assign(
@@ -1318,6 +1324,15 @@ describe("doctor health contributions", () => {
       expect.stringContaining("preserving any retained legacy owner"),
       "Doctor warnings",
     );
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining("Resolve the Gateway or cron-store condition above"),
+      "Legacy state deferred",
+    );
+    expect(mocks.note).not.toHaveBeenCalledWith(
+      expect.stringContaining("Fix the config errors above"),
+      "Legacy state deferred",
+    );
+    expect(mocks.runLegacyStateMigrations).not.toHaveBeenCalled();
   });
 
   it("skips read-scope gateway probes when gateway health only proved reachability", async () => {

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1133,7 +1133,18 @@ describe("doctor health contributions", () => {
       },
       sourceConfigValid: false,
       shouldRepair: true,
+      options: { nonInteractive: true, repair: true },
       env: {},
+    });
+    const pendingOwners = [
+      "- Workspace setup and attestations: legacy files → shared SQLite state",
+      "- TUI last-session pointers: legacy JSON file → shared SQLite state",
+      ...Array.from({ length: 20 }, (_, index) => `- Test owner ${index + 1}: legacy state`),
+    ];
+    mocks.detectLegacyStateMigrations.mockResolvedValue({
+      preview: pendingOwners,
+      warnings: [],
+      notices: [],
     });
     mocks.replaceConfigFile.mockRejectedValueOnce(
       Object.assign(
@@ -1179,6 +1190,16 @@ describe("doctor health contributions", () => {
       expect.stringContaining("agents.defaults.heartbeat.every"),
       "Doctor warnings",
     );
+    const deferredPanels = mocks.note.mock.calls.filter(
+      ([, title]) => title === "Legacy state deferred",
+    );
+    expect(deferredPanels).toHaveLength(1);
+    expect(deferredPanels[0]?.[0]).toContain(pendingOwners[0]);
+    expect(deferredPanels[0]?.[0]).toContain(pendingOwners[1]);
+    expect(deferredPanels[0]?.[0]).toContain("2 additional pending owners were omitted");
+    expect(deferredPanels[0]?.[0]).toContain("No listed legacy source was removed.");
+    expect(deferredPanels[0]?.[0]).toContain('rerun "openclaw doctor --fix"');
+    expect(mocks.runLegacyStateMigrations).not.toHaveBeenCalled();
 
     // A later write pass must not retry the identical candidate or duplicate the warning.
     mocks.note.mockClear();

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -31,7 +31,7 @@ const loadDoctorCoreChecksModule = async () => await import("./doctor-core-check
 const loadNoteModule = async () => await import("../../packages/terminal-core/src/note.js");
 const loadOnboardHelpersModule = async () => await import("../commands/onboard-helpers.js");
 const loadSecretTypesModule = async () => await import("../config/types.secrets.js");
-const MAX_DEFERRED_LEGACY_STATE_OWNERS = 20;
+const MAX_DEFERRED_LEGACY_STATE_DETAILS = 20;
 
 async function reportDeferredLegacyState(ctx: DoctorHealthFlowContext): Promise<void> {
   if (ctx.options.repair !== true && ctx.options.yes !== true) {
@@ -47,23 +47,29 @@ async function reportDeferredLegacyState(ctx: DoctorHealthFlowContext): Promise<
     ...(ctx.env ? { env: ctx.env } : {}),
     legacySessionSurfaces: prepareLegacySessionSurfaces({ config: ctx.cfg }),
   });
-  if (legacyState.preview.length === 0) {
+  const pendingDetails = [
+    ...legacyState.warnings.map((warning) => (warning.startsWith("- ") ? warning : `- ${warning}`)),
+    ...legacyState.preview,
+  ];
+  if (pendingDetails.length === 0) {
     return;
   }
   const { note } = await loadNoteModule();
-  const displayedOwners = legacyState.preview.slice(0, MAX_DEFERRED_LEGACY_STATE_OWNERS);
-  const omittedOwnerCount = legacyState.preview.length - displayedOwners.length;
+  const displayedDetails = pendingDetails.slice(0, MAX_DEFERRED_LEGACY_STATE_DETAILS);
+  const omittedDetailCount = pendingDetails.length - displayedDetails.length;
+  const remediation =
+    ctx.configWriteRefusal === "validation"
+      ? 'Fix the config errors above, then rerun "openclaw doctor --fix".'
+      : 'Resolve the Gateway or cron-store condition above, then rerun "openclaw doctor --fix".';
   note(
     [
-      "Pending owners:",
-      ...displayedOwners,
-      ...(omittedOwnerCount > 0
-        ? [
-            `${omittedOwnerCount} additional pending ${omittedOwnerCount === 1 ? "owner was" : "owners were"} omitted from this bounded report.`,
-          ]
+      "Pending owners and blockers:",
+      ...displayedDetails,
+      ...(omittedDetailCount > 0
+        ? [`${omittedDetailCount} additional pending entries were omitted from this report.`]
         : []),
       "No listed legacy source was removed.",
-      'Fix the config errors above, then rerun "openclaw doctor --fix".',
+      remediation,
     ].join("\n"),
     "Legacy state deferred",
   );

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -31,6 +31,43 @@ const loadDoctorCoreChecksModule = async () => await import("./doctor-core-check
 const loadNoteModule = async () => await import("../../packages/terminal-core/src/note.js");
 const loadOnboardHelpersModule = async () => await import("../commands/onboard-helpers.js");
 const loadSecretTypesModule = async () => await import("../config/types.secrets.js");
+const MAX_DEFERRED_LEGACY_STATE_OWNERS = 20;
+
+async function reportDeferredLegacyState(ctx: DoctorHealthFlowContext): Promise<void> {
+  if (ctx.options.repair !== true && ctx.options.yes !== true) {
+    return;
+  }
+  const [{ detectLegacyStateMigrations }, { prepareLegacySessionSurfaces }] = await Promise.all([
+    import("../infra/state-migrations.doctor.js"),
+    import("../plugins/legacy-session-surfaces.js"),
+  ]);
+  const legacyState = await detectLegacyStateMigrations({
+    cfg: ctx.cfg,
+    doctorOnlyStateMigrations: true,
+    ...(ctx.env ? { env: ctx.env } : {}),
+    legacySessionSurfaces: prepareLegacySessionSurfaces({ config: ctx.cfg }),
+  });
+  if (legacyState.preview.length === 0) {
+    return;
+  }
+  const { note } = await loadNoteModule();
+  const displayedOwners = legacyState.preview.slice(0, MAX_DEFERRED_LEGACY_STATE_OWNERS);
+  const omittedOwnerCount = legacyState.preview.length - displayedOwners.length;
+  note(
+    [
+      "Pending owners:",
+      ...displayedOwners,
+      ...(omittedOwnerCount > 0
+        ? [
+            `${omittedOwnerCount} additional pending ${omittedOwnerCount === 1 ? "owner was" : "owners were"} omitted from this bounded report.`,
+          ]
+        : []),
+      "No listed legacy source was removed.",
+      'Fix the config errors above, then rerun "openclaw doctor --fix".',
+    ].join("\n"),
+    "Legacy state deferred",
+  );
+}
 
 async function runGatewayConfigHealth(ctx: DoctorHealthFlowContext): Promise<void> {
   const { formatCliCommand } = await loadCommandFormatModule();
@@ -507,13 +544,17 @@ async function runDoctorHealthContributionList(
   const runWithPluginMetadataSnapshot = ctx.runWithPluginMetadataSnapshot;
   for (const contribution of contributions) {
     try {
-      if (!runWithPluginMetadataSnapshot) {
+      const run = async () => {
         await contribution.run(ctx);
+        if (ctx.configWriteRefusal) {
+          await reportDeferredLegacyState(ctx);
+        }
+      };
+      if (!runWithPluginMetadataSnapshot) {
+        await run();
       } else {
         const workspaceDir = resolveDoctorWorkspaceDir(ctx.cfg, ctx.env);
-        await runWithPluginMetadataSnapshot({ config: ctx.cfg, workspaceDir }, () =>
-          contribution.run(ctx),
-        );
+        await runWithPluginMetadataSnapshot({ config: ctx.cfg, workspaceDir }, run);
       }
       if (ctx.configWriteRefusal) {
         // Later repairs consume the candidate. Stop before they persist state


### PR DESCRIPTION
Closes #134036

## What Problem This Solves

Fixes an issue where `openclaw doctor --fix` could refuse an invalid config write and exit before reporting Doctor-only legacy state that still needed repair.

## Why This Change Was Made

After a config write refusal, Doctor reruns its canonical legacy-state detector read-only and prints one bounded deferred-work panel. The panel includes actionable detector warnings and selects recovery text for validation or cron-owner refusal. The existing mutation order and nonzero refusal exit stay unchanged.

This does not adopt the issue's broad TTY claim. Current main proves only that the config refusal stopped the later Doctor-only state report.

## User Impact

Operators now see the exact pending legacy-state owners, confirmation that the listed sources remain in place, and instructions to fix the config and rerun Doctor.

## Evidence

- Red on `a5490b1a5006ba05970050618200e0d14df87155`: a non-TTY repair with a validation-blocked config exited `1` without any legacy-state report; workspace and TUI sources stayed byte-identical.
- Green on `99f34a51927a7a0cb9261a778c5ae56c6db4d762`: the same command exited `1` with one `Legacy state deferred` panel naming both owners and an unresolved explicit multi-agent owner; no source or config byte changed.
- Rerun: after fixing only the invalid config value, Doctor exited `0`, applied the existing config-key repair, and migrated both legacy sources through their canonical owners.
- Convergence: the next identical run exited `0` with no legacy-state panel.
- Tests: 145 focused Doctor tests, 5 source-CLI process tests, 57 workspace/TUI/exec-approval owner tests, and the explicit Doctor session-migration test passed. Cron-owner refusal keeps its Gateway/cron-specific recovery action.
- Static checks: focused Oxfmt, type-aware Oxlint, max-lines ratchet, assertion-safety ratchet, conflict-marker check, and `git diff --check` passed.
- Production delta: `+51/-4`; test delta: `+204/-0`. The production growth adds the read-only refusal report, warning coverage, refusal-specific recovery, and its hard output cap.
