### PR TITLE
test(shared): simplify text assertions

### DIFF
--- a/src/shared/subagents-format.test.ts
+++ b/src/shared/subagents-format.test.ts
@@ -1,4 +1,3 @@
-// Subagent format tests cover concise subagent status and duration formatting.
 import { describe, expect, it } from "vitest";
 import { formatTokenUsageDisplay, resolveTotalTokens, truncateLine } from "./subagents-format.js";
 
@@ -49,16 +48,6 @@ describe("shared/subagents-format", () => {
     expect(truncateLine("🤖🤖🤖", 5)).toBe("🤖...");
     // CJK Extension B (surrogate pair) at boundary: character stays intact.
     expect(truncateLine("AB𠮷CDEF", 7)).toBe("AB𠮷...");
-    // No broken surrogates in output.
-    for (const result of [
-      truncateLine("AB🤖CDEF", 6),
-      truncateLine("🤖🤖🤖", 5),
-      truncateLine("AB𠮷CDEF", 7),
-    ]) {
-      expect(result).not.toMatch(
-        /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
-      );
-    }
   });
 
   it("resolves token totals and io breakdowns from valid numeric fields only", () => {

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -1,4 +1,3 @@
-// Assistant visible text tests cover extracting user-visible assistant output.
 import { describe, expect, it } from "vitest";
 import {
   sanitizeAssistantFinalAnswerText,
@@ -436,13 +435,6 @@ describe("stripAssistantInternalScaffolding", () => {
       expectVisibleText(
         "prefix <tool_call><arg>secret</arg></tool_call> suffix",
         "prefix <tool_call><arg>secret</arg></tool_call> suffix",
-      );
-    });
-
-    it("preserves inline bare <function> XML examples in prose", () => {
-      expectVisibleText(
-        'Use <function name="read"><parameter name="path">/tmp</parameter></function> in docs.',
-        'Use <function name="read"><parameter name="path">/tmp</parameter></function> in docs.',
       );
     });
 

--- a/src/shared/text/join-segments.test.ts
+++ b/src/shared/text/join-segments.test.ts
@@ -1,14 +1,5 @@
-// Join segment tests cover stable text segment recombination.
 import { describe, expect, it } from "vitest";
 import { concatOptionalTextSegments, joinPresentTextSegments } from "./join-segments.js";
-
-function expectTextSegmentsCase<T>(actual: T, expected: T) {
-  expect(actual).toBe(expected);
-}
-
-function expectJoinedTextSegmentsCase<T>(params: { run: () => T; expected: T }) {
-  expectTextSegmentsCase(params.run(), params.expected);
-}
 
 describe("concatOptionalTextSegments", () => {
   it.each([
@@ -20,10 +11,7 @@ describe("concatOptionalTextSegments", () => {
     { params: { left: "" }, expected: "" },
     { params: { left: "A", right: "B", separator: " | " }, expected: "A | B" },
   ] as const)("concatenates optional segments %#", ({ params, expected }) => {
-    expectJoinedTextSegmentsCase({
-      run: () => concatOptionalTextSegments(params),
-      expected,
-    });
+    expect(concatOptionalTextSegments(params)).toBe(expected);
   });
 });
 
@@ -44,9 +32,6 @@ describe("joinPresentTextSegments", () => {
     },
     { segments: ["A", "  B  "], options: { separator: "|" }, expected: "A|  B  " },
   ] as const)("joins present segments %#", ({ segments, options, expected }) => {
-    expectJoinedTextSegmentsCase({
-      run: () => joinPresentTextSegments(segments, options),
-      expected,
-    });
+    expect(joinPresentTextSegments(segments, options)).toBe(expected);
   });
 });

--- a/src/shared/text/reasoning-tags.test.ts
+++ b/src/shared/text/reasoning-tags.test.ts
@@ -1,33 +1,7 @@
-// Reasoning tag tests cover parsing and stripping reasoning tag blocks.
 import { describe, expect, it } from "vitest";
 import { stripReasoningTagsFromText } from "./reasoning-tags.js";
 
 describe("stripReasoningTagsFromText", () => {
-  function expectStrippedCase(params: {
-    input: string | null;
-    expected: string | null;
-    opts?: Parameters<typeof stripReasoningTagsFromText>[1];
-  }) {
-    expect(stripReasoningTagsFromText(params.input as unknown as string, params.opts)).toBe(
-      params.expected,
-    );
-  }
-
-  function expectPreservedReasoningTagCodeExample(input: string) {
-    expect(stripReasoningTagsFromText(input)).toBe(input);
-  }
-
-  function expectReasoningCodeCase(params: { input: string; expected?: string }) {
-    if (params.expected === undefined) {
-      expectPreservedReasoningTagCodeExample(params.input);
-      return;
-    }
-    expectStrippedCase({
-      input: params.input,
-      expected: params.expected,
-    });
-  }
-
   describe("basic functionality", () => {
     it.each([
       {
@@ -91,8 +65,8 @@ describe("stripReasoningTagsFromText", () => {
         input: "<thinking>outer<internal>private reflection",
         expected: "",
       },
-    ] as const)("$name", (testCase) => {
-      expectStrippedCase(testCase);
+    ] as const)("$name", ({ input, expected }) => {
+      expect(stripReasoningTagsFromText(input)).toBe(expected);
     });
   });
 
@@ -141,7 +115,7 @@ describe("stripReasoningTagsFromText", () => {
         expected: "```\n<think>code</think>\n```\nvisible",
       },
     ] as const)("$name", ({ input, expected }) => {
-      expectReasoningCodeCase({ input, expected });
+      expect(stripReasoningTagsFromText(input)).toBe(expected ?? input);
     });
   });
 
@@ -179,8 +153,8 @@ describe("stripReasoningTagsFromText", () => {
         input: null as unknown as string,
         expected: null,
       },
-    ] as const)("handles malformed/null-ish input %j", (testCase) => {
-      expectStrippedCase(testCase);
+    ] as const)("handles malformed/null-ish input %j", ({ input, expected }) => {
+      expect(stripReasoningTagsFromText(input)).toBe(expected);
     });
 
     it.each([
@@ -208,8 +182,8 @@ describe("stripReasoningTagsFromText", () => {
         input: "Start `unclosed <think>hidden</think> end",
         expected: "Start `unclosed  end",
       },
-    ] as const)("handles fenced/inline code edge behavior: %j", (testCase) => {
-      expectStrippedCase(testCase);
+    ] as const)("handles fenced/inline code edge behavior: %j", ({ input, expected }) => {
+      expect(stripReasoningTagsFromText(input)).toBe(expected);
     });
 
     it.each([
@@ -261,8 +235,8 @@ describe("stripReasoningTagsFromText", () => {
         input: `A <final ${" ".repeat(10_000)}= > B`,
         expected: `A <final ${" ".repeat(10_000)}= > B`,
       },
-    ] as const)("handles nested/final tag behavior: %j", (testCase) => {
-      expectStrippedCase(testCase);
+    ] as const)("handles nested/final tag behavior: %j", ({ input, expected }) => {
+      expect(stripReasoningTagsFromText(input)).toBe(expected);
     });
 
     it.each([
@@ -282,8 +256,8 @@ describe("stripReasoningTagsFromText", () => {
         input: "A <ANTML:THINKING hidden='1'>secret</ANTML:THINKING> B",
         expected: "A  B",
       },
-    ] as const)("handles unicode/attributes/case-insensitive names: %j", (testCase) => {
-      expectStrippedCase(testCase);
+    ] as const)("handles unicode/attributes/case-insensitive names: %j", ({ input, expected }) => {
+      expect(stripReasoningTagsFromText(input)).toBe(expected);
     });
 
     it("handles long content and pathological backtick patterns efficiently", () => {
@@ -390,8 +364,8 @@ describe("stripReasoningTagsFromText", () => {
         expected: "",
         opts: { mode: "preserve" as const },
       },
-    ] as const)("$name", (testCase) => {
-      expectStrippedCase(testCase);
+    ] as const)("$name", ({ input, expected, opts }) => {
+      expect(stripReasoningTagsFromText(input, opts)).toBe(expected);
     });
   });
 
@@ -415,8 +389,8 @@ describe("stripReasoningTagsFromText", () => {
         expected: "result  ",
         opts: { trim: "start" as const },
       },
-    ] as const)("$name", (testCase) => {
-      expectStrippedCase(testCase);
+    ] as const)("$name", ({ input, expected, opts }) => {
+      expect(stripReasoningTagsFromText(input, opts)).toBe(expected);
     });
   });
 
@@ -424,7 +398,7 @@ describe("stripReasoningTagsFromText", () => {
     { input: "A <final>1</final> B", expected: "A 1 B" },
     { input: "C <final>2</final> D", expected: "C 2 D" },
     { input: "E <think>x</think> F", expected: "E  F" },
-  ] as const)("does not leak regex state across repeated calls: %j", (testCase) => {
-    expectStrippedCase(testCase);
+  ] as const)("does not leak regex state across repeated calls: %j", ({ input, expected }) => {
+    expect(stripReasoningTagsFromText(input)).toBe(expected);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Shared text tests contain assertion-forwarding helpers and repeated checks that add no distinct input or output coverage.

## Why This Change Was Made

Inline the join-segment and reasoning-tag assertions at their table callbacks. Keep every row, option, deliberate malformed-input fixture and repeated-call regression. Remove three surrogate regex checks whose identical calls are already protected by stronger exact string assertions, plus one prose-function case duplicated in the existing parameter/function example test. Remove the generic file headers.

The sanitizer's explicit regex-state tests remain. The deleted prose case has no separate setup or state contract: it uses the same profile, input and exact expected output as the retained case, and its XML parsing state is allocated per call.

## User Impact

No runtime, SDK, parser, privacy or delivery behavior changes. Production delta is zero; tests shrink by 60 lines across four files. Five forwarding helpers are removed, and every distinct input/output oracle remains.

## Evidence

All four files pass before the change (222 cases) and after it (221 cases). The retained case names and per-file execution order match exactly; only the identified duplicate prose case is removed. All 13 join-segment, six formatter and 74 reasoning-tag cases remain, alongside 128 sanitizer cases.

The complete required changed-file gate passes formatting, repository guards, dead-export scans, core-test types and lint. Independent Codex review is scoped-clean.
