### PR TITLE
fix(outbound): a delivery mirrored into another session is silently dropped

### DIFF
--- a/src/config/sessions/transcript-write-context.test.ts
+++ b/src/config/sessions/transcript-write-context.test.ts
@@ -12,6 +12,7 @@ import {
   type SessionTranscriptRuntimeTarget,
 } from "./session-accessor.js";
 import {
+  getOwnedSessionTranscriptWriterFence,
   SessionTranscriptWriterClaimReboundError,
   withOwnedSessionTranscriptWrites,
 } from "./transcript-write-context.js";
@@ -133,4 +134,74 @@ describe("owned transcript commit boundary", () => {
       });
     },
   );
+});
+
+describe("owned transcript writer fence scope", () => {
+  const runningTarget = {
+    agentId: "main",
+    sessionKey: "agent:main:running",
+    storePath: "/state/agents/main/openclaw-agent.sqlite",
+    expectedLifecycleRevision: "rev-3",
+    expectedWriterRunId: "run-running",
+  };
+
+  async function withRunningWriter(run: () => void): Promise<void> {
+    await withOwnedSessionTranscriptWrites(
+      {
+        sessionKey: runningTarget.sessionKey,
+        sessionTarget: runningTarget,
+        withTranscriptWrite: async (operation) => await operation(),
+      },
+      async () => run(),
+    );
+  }
+
+  it("inherits the fence for a caller that names the running session by key alone", async () => {
+    await withRunningWriter(() => {
+      expect(
+        getOwnedSessionTranscriptWriterFence({ sessionKey: runningTarget.sessionKey }),
+      ).toEqual({
+        expectedLifecycleRevision: "rev-3",
+        expectedWriterRunId: "run-running",
+      });
+    });
+  });
+
+  it("withholds the fence from a caller naming another session by key alone", async () => {
+    await withRunningWriter(() => {
+      // A key-only caller cannot form a target, so before this scoping it was refused by
+      // the target comparison and fell back to the ambient claim - a claim about a
+      // different session entirely.
+      expect(
+        getOwnedSessionTranscriptWriterFence({ sessionKey: "agent:main:elsewhere" }),
+      ).toBeUndefined();
+    });
+  });
+
+  it("still compares targets when the caller can express one", async () => {
+    await withRunningWriter(() => {
+      expect(getOwnedSessionTranscriptWriterFence({ sessionTarget: runningTarget })).toEqual({
+        expectedLifecycleRevision: "rev-3",
+        expectedWriterRunId: "run-running",
+      });
+      expect(
+        getOwnedSessionTranscriptWriterFence({
+          sessionTarget: {
+            ...runningTarget,
+            storePath: "/state/agents/other/openclaw-agent.sqlite",
+          },
+        }),
+      ).toBeUndefined();
+    });
+  });
+
+  it("keeps the unscoped lookup reading the ambient claim", async () => {
+    await withRunningWriter(() => {
+      expect(getOwnedSessionTranscriptWriterFence()).toEqual({
+        expectedLifecycleRevision: "rev-3",
+        expectedWriterRunId: "run-running",
+      });
+    });
+    expect(getOwnedSessionTranscriptWriterFence()).toBeUndefined();
+  });
 });

--- a/src/config/sessions/transcript-write-context.ts
+++ b/src/config/sessions/transcript-write-context.ts
@@ -90,6 +90,30 @@ function contextMatches(params: {
   return Boolean(contextSessionKey && sessionKey && contextSessionKey === sessionKey);
 }
 
+/**
+ * Ownership test for a writer fence, which is the one gate a caller can reach holding
+ * nothing but a session key. A delivery mirror knows the session it writes into but not
+ * that session's store path, so it cannot form a target; `contextMatches` would refuse
+ * it for not being target-shaped and leave it unable to tell "the running session" from
+ * "some other session". Compare keys in that case, and defer to the target comparison
+ * whenever the caller can express one.
+ */
+function ownsRequestedSession(params: {
+  context: OwnedSessionTranscriptWriteContext;
+  sessionFile?: string;
+  sessionKey?: string;
+  sessionTarget?: SessionTranscriptWriteTarget;
+}): boolean {
+  if (params.sessionTarget || params.sessionFile) {
+    return contextMatches(params);
+  }
+  const contextSessionKey = (
+    params.context.sessionTarget?.sessionKey ?? params.context.sessionKey
+  )?.trim();
+  const sessionKey = params.sessionKey?.trim();
+  return Boolean(contextSessionKey && sessionKey && contextSessionKey === sessionKey);
+}
+
 /** Runs transcript writes with the admitted run's teardown and writer-fence context. */
 export async function withOwnedSessionTranscriptWrites<T>(
   context: OwnedSessionTranscriptWriteContext,
@@ -110,7 +134,13 @@ export function bindOwnedSessionTranscriptWrites<TArgs extends unknown[], TResul
   return (...args) => ownedTranscriptWriteContext.run(context, () => run(...args));
 }
 
-/** Returns the matching admitted-run fence for a durable write boundary. */
+/**
+ * Returns the matching admitted-run fence for a durable write boundary.
+ *
+ * Every write boundary must name the session it writes into, or it inherits a claim
+ * about whichever session happens to be running. Omitting the scope asks for the
+ * ambient claim itself and is only for diagnostics that observe the running writer.
+ */
 export function getOwnedSessionTranscriptWriterFence(
   params: {
     sessionFile?: string;
@@ -119,7 +149,10 @@ export function getOwnedSessionTranscriptWriterFence(
   } = {},
 ): SessionTranscriptWriterFence | undefined {
   const context = ownedTranscriptWriteContext.getStore();
-  if (!context || (Object.keys(params).length > 0 && !contextMatches({ context, ...params }))) {
+  if (
+    !context ||
+    (Object.keys(params).length > 0 && !ownsRequestedSession({ context, ...params }))
+  ) {
     return undefined;
   }
   const initial = context.initialWriter;

--- a/src/gateway/internal-source-reply-persistence.ts
+++ b/src/gateway/internal-source-reply-persistence.ts
@@ -54,7 +54,7 @@ async function completePersistedInternalSourceReply(params: {
   scope.sessionKey = resolveSessionEntrySelection(scope).normalizedKey;
   const expected = {
     expectedSessionId: params.expectedSessionId,
-    ...getOwnedSessionTranscriptWriterFence(),
+    ...getOwnedSessionTranscriptWriterFence({ sessionKey: scope.sessionKey }),
   };
   const found = await findTranscriptEvent(scope, (event) => {
     const message = readTranscriptEventMessage(event);
@@ -171,7 +171,9 @@ export async function persistInternalSourceReply(params: {
         ...(params.payload.text ? [{ type: "text", text: params.payload.text }] : []),
         ...mediaBlocks,
       ];
-      const writerFence = getOwnedSessionTranscriptWriterFence();
+      const writerFence = getOwnedSessionTranscriptWriterFence({
+        sessionKey: params.sessionKey,
+      });
       const appended = await appendAssistantMessageToSessionTranscript({
         agentId: params.agentId,
         sessionKey: params.sessionKey,

--- a/src/infra/outbound/deliver-transcript.ts
+++ b/src/infra/outbound/deliver-transcript.ts
@@ -40,7 +40,9 @@ export async function mirrorDeliveredPayloads(params: {
   // Keep mirror failures non-fatal so callers do not retry an already-sent payload.
   try {
     const { appendAssistantMessageToSessionTranscript } = await loadTranscriptRuntime();
-    const writerFence = getOwnedSessionTranscriptWriterFence();
+    // Fence against the session this mirror lands in, not whichever run is delivering:
+    // a cross-session delivery would otherwise carry the sending run's writer claim.
+    const writerFence = getOwnedSessionTranscriptWriterFence({ sessionKey: mirror.sessionKey });
     const mirrorResult = await appendAssistantMessageToSessionTranscript({
       agentId: mirror.agentId,
       sessionKey: mirror.sessionKey,

--- a/src/infra/outbound/deliver-transcript.writer-fence.test.ts
+++ b/src/infra/outbound/deliver-transcript.writer-fence.test.ts
@@ -1,0 +1,105 @@
+// Mirror fence tests cover which session's writer claim a delivery mirror carries.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withOwnedSessionTranscriptWrites } from "../../config/sessions/transcript-write-context.js";
+import type { DeliverOutboundPayloadsCoreParams } from "./deliver-contracts.js";
+import { mirrorDeliveredPayloads } from "./deliver-transcript.js";
+import type { NormalizedOutboundPayload } from "./payloads.js";
+
+const mocks = vi.hoisted(() => ({
+  // Typed with the append params so the recorded call is inspectable without a cast.
+  appendAssistantMessageToSessionTranscript: vi.fn(
+    async (_params: Record<string, unknown>) => ({ ok: true }) as const,
+  ),
+}));
+
+vi.mock("../../config/sessions/transcript.runtime.js", async () => {
+  const actual = await vi.importActual<
+    typeof import("../../config/sessions/transcript.runtime.js")
+  >("../../config/sessions/transcript.runtime.js");
+  return {
+    ...actual,
+    appendAssistantMessageToSessionTranscript: mocks.appendAssistantMessageToSessionTranscript,
+  };
+});
+
+const RUNNING_SESSION_KEY = "agent:wolf:discord:channel:1497965766035640391";
+const OTHER_SESSION_KEY = "agent:arthur:discord:channel:1538510183024689305";
+
+function payload(text: string): NormalizedOutboundPayload {
+  return { text, mediaUrls: [] };
+}
+
+async function mirrorInto(sessionKey: string): Promise<void> {
+  await mirrorDeliveredPayloads({
+    delivery: {
+      cfg: {},
+      mirror: { agentId: "wolf", sessionKey },
+    } as unknown as DeliverOutboundPayloadsCoreParams,
+    payloads: [payload("delivered to the user")],
+    channel: "discord",
+    to: "1497965766035640391",
+  });
+}
+
+/** Runs a mirror inside a run that owns `RUNNING_SESSION_KEY`, the way a live delivery does. */
+async function withRunningSession(run: () => Promise<void>): Promise<void> {
+  await withOwnedSessionTranscriptWrites(
+    {
+      sessionKey: RUNNING_SESSION_KEY,
+      sessionTarget: {
+        agentId: "wolf",
+        sessionKey: RUNNING_SESSION_KEY,
+        storePath: "/state/agents/wolf/openclaw-agent.sqlite",
+        expectedLifecycleRevision: "rev-7",
+        expectedWriterRunId: "run-running",
+      },
+      withTranscriptWrite: async (operation) => await operation(),
+    },
+    run,
+  );
+}
+
+function appendedArgs() {
+  return mocks.appendAssistantMessageToSessionTranscript.mock.calls[0]?.[0];
+}
+
+describe("outbound delivery mirror writer fence", () => {
+  beforeEach(() => {
+    mocks.appendAssistantMessageToSessionTranscript.mockClear();
+    mocks.appendAssistantMessageToSessionTranscript.mockResolvedValue({ ok: true } as const);
+  });
+
+  it("carries the running run's fence when it mirrors into that run's own session", async () => {
+    await withRunningSession(async () => {
+      await mirrorInto(RUNNING_SESSION_KEY);
+    });
+
+    expect(appendedArgs()).toMatchObject({
+      sessionKey: RUNNING_SESSION_KEY,
+      expectedWriterRunId: "run-running",
+      expectedLifecycleRevision: "rev-7",
+    });
+  });
+
+  it("withholds that fence when it mirrors into a different session", async () => {
+    await withRunningSession(async () => {
+      await mirrorInto(OTHER_SESSION_KEY);
+    });
+
+    const args = appendedArgs();
+    expect(args).toMatchObject({ sessionKey: OTHER_SESSION_KEY });
+    // A claim about the delivering session is not a claim about this one. Passing it made
+    // the transcript guards refuse the append as "session rebound", and the refusal is
+    // warn-only after a successful channel send, so the mirror was lost for good.
+    expect(args).not.toHaveProperty("expectedWriterRunId");
+    expect(args).not.toHaveProperty("expectedLifecycleRevision");
+  });
+
+  it("mirrors unfenced when no run owns a transcript write", async () => {
+    await mirrorInto(RUNNING_SESSION_KEY);
+
+    const args = appendedArgs();
+    expect(args).toMatchObject({ sessionKey: RUNNING_SESSION_KEY });
+    expect(args).not.toHaveProperty("expectedWriterRunId");
+  });
+});

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -446,7 +446,9 @@ export async function executeSendAction(params: {
             params.mediaUrls ??
             (params.mediaUrl ? [params.mediaUrl] : undefined);
           try {
-            const writerFence = getOwnedSessionTranscriptWriterFence();
+            const writerFence = getOwnedSessionTranscriptWriterFence({
+              sessionKey: params.ctx.mirror.sessionKey,
+            });
             const mirrorResult = await appendAssistantMessageToSessionTranscript({
               agentId: params.ctx.mirror.agentId,
               sessionKey: params.ctx.mirror.sessionKey,

--- a/src/infra/outbound/source-reply-mirror.ts
+++ b/src/infra/outbound/source-reply-mirror.ts
@@ -594,7 +594,7 @@ export async function mirrorDeliveredSourceReplyToTranscript(
     return false;
   }
   const sourceTurnId = resolveCurrentSourceTurnId(params.toolContext);
-  const writerFence = getOwnedSessionTranscriptWriterFence();
+  const writerFence = getOwnedSessionTranscriptWriterFence({ sessionKey: params.sessionKey });
   const result = await appendAssistantMessageToSessionTranscript({
     agentId: params.agentId,
     sessionKey: params.sessionKey,


### PR DESCRIPTION
Closes #132766

## What Problem This Solves

A message the user has already received can be missing from the transcript of the session it was delivered into. When a run in one session delivers an outbound payload addressed to another session, the mirror that records it in the receiving session's transcript is refused, the refusal is logged at `warn` after the channel send has already succeeded, and it is never retried. The user sees the message; the receiving session never learns it happened, and every later turn in that session answers from a history that is missing it.

Nothing surfaces this. There is no error, no retry, and no counter — the reporter of #132766 found it only by auditing mirror counts against their gateway journal, where it had been happening for four days across five session keys and three agents, on one channel for 8 of 8 deliveries.

The same drop sits on five delivery paths, not one: the generic outbound mirror, the plugin-handled send mirror, the source-reply mirror, and both of the gateway's internal source-reply persistence points.

## Why This Change Was Made

Each of those paths asked for the current writer claim without saying which session it was about to write into, so it inherited whichever run happened to be executing. When that run belonged to a different session, the transcript guards correctly refused a claim that did not describe the target — which is why the symptom is a `session rebound` refusal rather than a corrupted write.

Every one of the five now names the session it writes into. Naming it is only half the repair: the ownership test compares full targets, and a delivery mirror holds a session key but not that session's store path, so a key-only request could not be answered at all and would have been refused even when the run did own the session. The fence lookup now has its own ownership test that compares session keys when the caller cannot form a target and defers to the existing target comparison whenever it can. The shared `contextMatches` used by the initial-writer inheritance and the commit assertion is untouched, so those two paths keep their exact semantics.

Boundaries. A same-session mirror still inherits the run's fence — the guard is scoped, not removed. The unscoped lookup still returns the ambient claim and is kept for the one caller that legitimately asks "which run is writing right now" rather than "may I write into this session". The issue's secondary ask — making the four `session rebound` emit sites distinguishable in the log — is not addressed here; it is a change to a shared refusal string on a much hotter path and stands on its own.

## User Impact

A message delivered into another session is now recorded in that session's transcript instead of being silently dropped, so the receiving session answers from the history the user actually sees. Sessions that were quietly desynchronised stop drifting further apart. Nothing changes for a delivery into the running session's own transcript, and nothing changes about when a channel send succeeds or fails.

## Evidence

Behavior addressed: an outbound payload mirrored into a session other than the delivering run's own is refused as `session rebound`, logged at `warn` after a successful send, and lost permanently.

Real environment tested: a real temporary state directory with the real SQLite session store, the real exported `mirrorDeliveredPayloads`, and the real `appendAssistantMessageToSessionTranscript` guards that issue the refusal. Only the channel send is absent; the defect is entirely in the mirror that runs after it. Node v24.18.0 on Windows 11.

Exact steps or command run after this patch: create two real sessions in one store, give the delivering session an active writer run the way a live turn does, leave the receiving session unowned (the ordinary state of a session that is not mid-turn), then mirror one payload into each from inside the delivering run's transcript-write context.

Evidence after fix:

```
$ node --import ./scripts/tsx.mjs ./outbound-mirror-writer-fence-proof.mts
store: ...\.openclaw\agents\main\sessions\sessions.json
cross-session mirror  agent:main:discord:channel:receiving: 0 -> 2 transcript event(s)
same-session mirror   agent:main:discord:channel:delivering: 0 -> 2 transcript event(s)
PASS: the mirror into the other session landed in its transcript
PASS: the mirror into the delivering run's own session still lands
```

Observed result after fix: the cross-session mirror lands, and the same-session mirror is unchanged — the fence is scoped, not dropped. No `warn` line is emitted.

Before evidence: the identical script against the same commit with `src/config/sessions/transcript-write-context.ts` and `src/infra/outbound/deliver-transcript.ts` reverted to `origin/main`:

```
[outbound/deliver] failed to mirror outbound delivery into session transcript; channel send already succeeded: session rebound for sessionKey: agent:main:discord:channel:receiving
store: ...\.openclaw\agents\main\sessions\sessions.json
cross-session mirror  agent:main:discord:channel:receiving: 0 -> 0 transcript event(s)
same-session mirror   agent:main:discord:channel:delivering: 0 -> 2 transcript event(s)
FAIL: the mirror into the other session was dropped (session rebound)
PASS: the mirror into the delivering run's own session still lands
```

That `warn` line is the reporter's production line, verbatim down to the format. The same-session control passes on both sides, so the difference is the cross-session case alone.

Additional review: the unit tests fail without the fix. Reverting only `src/infra/outbound/deliver-transcript.ts` to `origin/main` and rerunning `src/infra/outbound/deliver-transcript.writer-fence.test.ts` fails with `expected { agentId: 'wolf', …(8) } to not have property "expectedWriterRunId"` / `Received "run-running"` — the delivering run's claim, on a mirror into another session. Restoring the fix returns 3/3. `src/config/sessions/transcript-write-context.test.ts` adds four cases that pin both halves and the unchanged target path, and its ten pre-existing cases still pass (14/14).

Checks run on the exact head: `tsgo -p tsconfig.core.json` with no diagnostics; the sharded core test-type lane, which caught a `TS2493` in the new test file on its first run — fixed by giving the mock its parameter type rather than adding a cast, which also let an existing assertion be deleted; `lint:core`; `oxfmt --check` on all seven touched files; `check:assertion-safety --base origin/main` and `check:max-lines-ratchet --base origin/main`, both OK; `check:import-cycles`, 0 cycles.

What was not tested: no live gateway drove a real cross-session announce or handoff; the proof drives the same exported mirror entry point directly. The channel send itself is not exercised, which is deliberate — the send already succeeds in the reported failure.

Proof limitations or environment constraints: this host has three suites that fail before this change and fail identically with `src/config/sessions/transcript-write-context.ts`, `src/gateway/internal-source-reply-persistence.ts`, `src/infra/outbound/deliver-transcript.ts`, `src/infra/outbound/outbound-send-service.ts` and `src/infra/outbound/source-reply-mirror.ts` reverted to `origin/main`, so they are pre-existing here and not caused by this change: `src/plugin-sdk/session-transcript-runtime.test.ts` (21 failures, all `EPERM ... syscall: 'rm'` while removing a temp directory in `afterEach`; identical 21 failed / 3 passed on both sides), `src/config/sessions/transcript.test.ts` (suite-level `EPERM` in the same cleanup shape, so all 65 tests are skipped and none actually runs), and one 120s timeout in `src/agents/tools/sessions.test.ts` (`sessions_send gating > keeps an exact-incarnation send synchronous to its scoped lifecycle grant`, 120074ms on this branch versus 120064ms on reverted source). Everything else in the touched and neighbouring set passes.
