### PR TITLE
fix(gateway): sudo install no longer writes root state

### DIFF
--- a/src/cli/daemon-cli/install.test.ts
+++ b/src/cli/daemon-cli/install.test.ts
@@ -345,6 +345,28 @@ describe("runDaemonInstall", () => {
     expect(installDaemonServiceAndEmitMock).not.toHaveBeenCalled();
   });
 
+  it("blocks sudo-to-root systemd installs before persistent mutation", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    vi.spyOn(process, "geteuid").mockReturnValue(0);
+    process.env.HOME = "/root";
+    process.env.USER = "root";
+    process.env.LOGNAME = "root";
+    process.env.SUDO_USER = "operator";
+    delete process.env.XDG_RUNTIME_DIR;
+    delete process.env.DBUS_SESSION_BUS_ADDRESS;
+
+    await runDaemonInstall({ json: true });
+
+    expect(actionState.failed[0]?.message).toContain("Rerun the same command without sudo");
+    expect(actionState.failed[0]?.message).toContain("chmod go-w <path>");
+    expect(actionState.failed[0]?.message).toContain(
+      "https://docs.openclaw.ai/cli/gateway#install-identity",
+    );
+    expect(replaceConfigFileMock).not.toHaveBeenCalled();
+    expect(randomTokenMock).not.toHaveBeenCalled();
+    expect(installDaemonServiceAndEmitMock).not.toHaveBeenCalled();
+  });
+
   it("blocks inaccessible definitions before config reads or credential generation", async () => {
     service.readDefinitionMutationCapability.mockRejectedValueOnce(new Error("secret-canary"));
     await runDaemonInstall({ json: true, force: true });

--- a/src/cli/daemon-cli/install.ts
+++ b/src/cli/daemon-cli/install.ts
@@ -22,7 +22,10 @@ import {
   resolveManagedGatewayServiceCommand,
 } from "../../daemon/service-types.js";
 import { resolveGatewayService, type GatewayServiceCommandConfig } from "../../daemon/service.js";
-import { isNonFatalSystemdInstallProbeError } from "../../daemon/systemd.js";
+import {
+  hasSudoToRootSystemdUserManagerMismatch,
+  isNonFatalSystemdInstallProbeError,
+} from "../../daemon/systemd.js";
 import { resolveGatewayAuth } from "../../gateway/auth.js";
 import {
   defaultGatewayBindMode,
@@ -165,6 +168,17 @@ export async function runDaemonInstall(opts: DaemonInstallOptions) {
     assertGatewayServiceMutationAllowed("install or rewrite the gateway service");
   } catch (error) {
     fail(`Gateway install blocked: ${String(error)}`);
+    return;
+  }
+  if (process.platform === "linux" && hasSudoToRootSystemdUserManagerMismatch(process.env)) {
+    fail(
+      "Gateway install blocked: Refusing a sudo-to-root systemd user-service install because " +
+        "OpenClaw state and service files would belong to root while systemctl targets the " +
+        "invoking user's manager. Rerun the same command without sudo. If [unsafe-permissions] " +
+        "blocked the non-sudo command, repair the reported directory with `chmod go-w <path>` " +
+        "and retry; do not use sudo or --force to bypass it. " +
+        "See https://docs.openclaw.ai/cli/gateway#install-identity.",
+    );
     return;
   }
 

--- a/src/daemon/systemd-exec.ts
+++ b/src/daemon/systemd-exec.ts
@@ -211,6 +211,11 @@ function resolveSystemctlUserScope(env: GatewayServiceEnv): {
   };
 }
 
+/** True when root-owned paths would be paired with the sudo caller's user manager. */
+export function hasSudoToRootSystemdUserManagerMismatch(env: GatewayServiceEnv): boolean {
+  return resolveSystemctlUserScope(env).preferMachineScope;
+}
+
 /**
  * Resolves the account whose user manager owns the service operation.
  * Keep linger diagnostics on this identity so sudo never checks root while

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -97,6 +97,7 @@ import {
   findInstalledSystemdGatewayScope,
   findSystemdGatewayInstallation,
   formatDuelingScopesWarning,
+  hasSudoToRootSystemdUserManagerMismatch,
   installSystemdService,
   isNonFatalSystemdInstallProbeError,
   isSystemdServiceEnabled,
@@ -510,13 +511,9 @@ describe("systemd availability", () => {
       homedir: "/root",
     });
 
-    expect(
-      resolveSystemdUserServiceAccount({
-        SUDO_USER: "debian",
-        USER: "root",
-        LOGNAME: "root",
-      }),
-    ).toBe("debian");
+    const env = { SUDO_USER: "debian", USER: "root", LOGNAME: "root" };
+    expect(resolveSystemdUserServiceAccount(env)).toBe("debian");
+    expect(hasSudoToRootSystemdUserManagerMismatch(env)).toBe(true);
   });
 
   it("keeps root user scope when stale SUDO_USER is paired with root bus environment", async () => {
@@ -546,16 +543,16 @@ describe("systemd availability", () => {
       homedir: "/root",
     });
 
-    expect(
-      resolveSystemdUserServiceAccount({
-        HOME: "/root",
-        USER: "root",
-        LOGNAME: "root",
-        SUDO_USER: "debian",
-        XDG_RUNTIME_DIR: "/run/user/0",
-        DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/0/bus",
-      }),
-    ).toBe("root");
+    const env = {
+      HOME: "/root",
+      USER: "root",
+      LOGNAME: "root",
+      SUDO_USER: "debian",
+      XDG_RUNTIME_DIR: "/run/user/0",
+      DBUS_SESSION_BUS_ADDRESS: "unix:path=/run/user/0/bus",
+    };
+    expect(resolveSystemdUserServiceAccount(env)).toBe("root");
+    expect(hasSudoToRootSystemdUserManagerMismatch(env)).toBe(false);
   });
 
   it("does not let stale SUDO_USER override a sudo-u target user scope", async () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -1,6 +1,7 @@
 /** Linux systemd user service installer, parser, and lifecycle controls. */
 export {
   isNonFatalSystemdInstallProbeError,
+  hasSudoToRootSystemdUserManagerMismatch,
   isSystemdUnitActive,
   isSystemdUserServiceAvailable,
   resolveSystemdUserServiceAccount,


### PR DESCRIPTION
Closes #134000

## What Problem This Solves

Fixes an issue where operators who reran `openclaw gateway install` with `sudo` could write root-owned configuration, credentials, state, and a systemd unit before the install failed against the invoking user's systemd manager.

## Why This Change Was Made

The install preflight now reuses the systemd account resolver's existing sudo-to-root classification and refuses before persistent mutation. Genuine root user-manager installs and sudo-based lifecycle commands remain unchanged. The missing-unit uninstall path was already fixed and is not changed here.

## User Impact

Operators now get an actionable refusal that tells them to rerun without sudo and links to the documented `chmod go-w <path>` permissions repair.

## Evidence

- Baseline `43e9a3d81776741a1a9978cc8ee9772b432fdf7b`: an isolated real `sudo openclaw gateway install --json` wrote root-owned config, SQLite state, and a systemd unit, then failed because the invoking user's manager could not find that unit.
- Head `5907fff8a6d68a4b55228d90d8d5d5723001090c`: the same real command refused before any OpenClaw state or service path was created.
- Anti-cheat: changing the unique systemd unit name changed both the manager failure and the root-owned unit written on the baseline.
- Focused tests: `node scripts/run-vitest.mjs src/cli/daemon-cli/install.test.ts src/daemon/systemd.test.ts` — 239 passed.
- Focused lint and formatting passed for all five changed files.
- Autoreview: clean, no accepted or actionable findings.

### Redacted real Linux transcript

The proof used exact detached source checkouts and the invoking user's live systemd manager. A private mount namespace bound an empty retained directory over `/root`, so the real host root state was never touched.

Baseline `43e9a3d81776741a1a9978cc8ee9772b432fdf7b`:

```text
$ sudo openclaw gateway install --json
exit 1
Gateway install failed: systemctl enable failed: Unit openclaw-gateway-issue134000-red.service does not exist
warnings: gateway.mode persisted; gateway token generated and saved

$ find <isolated-root> -printf '<owner> <mode> <path>'
root 600 .openclaw/openclaw.json
root 600 .openclaw/state/openclaw.sqlite
root 644 .config/systemd/user/openclaw-gateway-issue134000-red.service

$ systemctl --user is-enabled openclaw-gateway-issue134000-red.service
not-found
```

Head `5907fff8a6d68a4b55228d90d8d5d5723001090c`:

```text
$ sudo openclaw gateway install --json
exit 1
Gateway install blocked: Refusing a sudo-to-root systemd user-service install ...
Rerun the same command without sudo ... chmod go-w <path> ...

$ find <isolated-root> -printf '<owner> <mode> <path>'
root 700 .
root 755 tmp
root 700 tmp/openclaw-0
# No .openclaw or .config path exists.
```

The proof host has no root user-manager bus, so a live genuine-root install would require unrelated host service provisioning. The existing systemd owner test proves the complete root user-manager environment remains classified as root, and all 239 focused install/systemd tests pass. This skips the optional live allowed-path rank-up without weakening the sudo red/green proof.

Production LOC: +21/-1 (net +20) for the identity safety boundary and operator guidance. Tests: +36/-17 (net +19).
