### PR TITLE
fix(memory): stop legacy warnings for canonical database links

### DIFF
--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -1466,6 +1466,79 @@ describe("memory-core doctor dreaming migration", () => {
     await expect(fs.access(legacyPath)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it("ignores a legacy sidecar symlink to the populated canonical agent database", async () => {
+    const stateDir = path.join(rootDir, "state");
+    const legacyPath = path.join(stateDir, "memory", "main.sqlite");
+    const agentPath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    await createCanonicalMemoryIndex(agentPath, "canonical memory remains authoritative");
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.symlink(path.relative(path.dirname(legacyPath), agentPath), legacyPath);
+
+    const migration = legacyMemoryIndexMigration();
+    await expect(migration.detectLegacyState(migrationParams())).resolves.toBeNull();
+    await expect(migration.migrateLegacyState(migrationParams())).resolves.toEqual({
+      changes: [],
+      warnings: [],
+    });
+
+    expect((await fs.lstat(legacyPath)).isSymbolicLink()).toBe(true);
+    await expect(fs.realpath(legacyPath)).resolves.toBe(await fs.realpath(agentPath));
+    expect(readMemoryRows(agentPath).chunks).toEqual([
+      { id: "canonical-chunk", text: "canonical memory remains authoritative" },
+    ]);
+  });
+
+  it("keeps the warning for a legacy sidecar symlink to a different data-bearing database", async () => {
+    const stateDir = path.join(rootDir, "state");
+    const legacyPath = path.join(stateDir, "memory", "main.sqlite");
+    const unrelatedPath = path.join(rootDir, "unrelated.sqlite");
+    const db = new DatabaseSync(unrelatedPath);
+    try {
+      db.exec("CREATE TABLE unrelated (value TEXT)");
+      db.prepare("INSERT INTO unrelated (value) VALUES (?)").run("preserve me");
+    } finally {
+      db.close();
+    }
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.symlink(path.relative(path.dirname(legacyPath), unrelatedPath), legacyPath);
+
+    const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([
+      "Skipped Memory Core legacy memory index import for agent main because the sidecar schema is not a legacy memory index",
+    ]);
+    expect((await fs.lstat(legacyPath)).isSymbolicLink()).toBe(true);
+    await expect(fs.realpath(legacyPath)).resolves.toBe(await fs.realpath(unrelatedPath));
+    const preserved = new DatabaseSync(unrelatedPath, { readOnly: true });
+    try {
+      expect(preserved.prepare("SELECT value FROM unrelated").get()).toEqual({
+        value: "preserve me",
+      });
+    } finally {
+      preserved.close();
+    }
+  });
+
+  it("keeps a corrupt legacy sidecar with an import warning", async () => {
+    const stateDir = path.join(rootDir, "state");
+    const legacyPath = path.join(stateDir, "memory", "main.sqlite");
+    const corruptBytes = Buffer.from("not a sqlite database");
+    await fs.mkdir(path.dirname(legacyPath), { recursive: true });
+    await fs.writeFile(legacyPath, corruptBytes);
+
+    const result = await legacyMemoryIndexMigration().migrateLegacyState(migrationParams());
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings).toEqual([
+      expect.stringContaining(
+        "Skipped Memory Core legacy memory index import for agent main because legacy rows could not be imported:",
+      ),
+    ]);
+    await expect(fs.readFile(legacyPath)).resolves.toEqual(corruptBytes);
+    await expect(fs.access(`${legacyPath}.migrated`)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
   it("preserves the main sidecar when a companion stat fails with ELOOP", async () => {
     const stateDir = path.join(rootDir, "state");
     const legacyPath = path.join(stateDir, "memory", "main.sqlite");

--- a/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
+++ b/extensions/memory-core/src/migration/doctor-memory-sidecar.ts
@@ -134,6 +134,36 @@ function readMemorySearchFtsTokenizer(
   return raw === "unicode61" || raw === "trigram" ? raw : undefined;
 }
 
+async function isCanonicalAgentDatabaseSymlink(params: {
+  legacyPath: string;
+  agentDatabasePath: string;
+}): Promise<boolean> {
+  try {
+    if (!(await fs.lstat(params.legacyPath)).isSymbolicLink()) {
+      return false;
+    }
+    for (const suffix of LEGACY_MEMORY_SIDECAR_SUFFIXES.slice(1)) {
+      try {
+        await fs.lstat(`${params.legacyPath}${suffix}`);
+        return false;
+      } catch (err: unknown) {
+        if (!err || typeof err !== "object" || !("code" in err) || err.code !== "ENOENT") {
+          return false;
+        }
+      }
+    }
+    const [legacyTarget, canonicalTarget] = await Promise.all([
+      fs.realpath(params.legacyPath),
+      fs.realpath(params.agentDatabasePath),
+    ]);
+    return legacyTarget === canonicalTarget;
+  } catch {
+    // Only the exact compatibility alias is known non-legacy state. Any unresolved
+    // target remains visible so Doctor cannot hide data it failed to classify.
+    return false;
+  }
+}
+
 async function collectLegacyMemorySidecarSources(params: {
   config: unknown;
   env: NodeJS.ProcessEnv;
@@ -169,11 +199,23 @@ async function collectLegacyMemorySidecarSources(params: {
       return;
     }
     seen.add(key);
+    const agentDatabasePath = resolveOpenClawAgentSqlitePath({
+      agentId,
+      env: migrationEnv,
+    });
+    if (
+      await isCanonicalAgentDatabaseSymlink({
+        legacyPath: normalizedPath,
+        agentDatabasePath,
+      })
+    ) {
+      return;
+    }
     sources.push({
       agentId,
       legacyPath: normalizedPath,
       stateDir: params.stateDir,
-      agentDatabasePath: resolveOpenClawAgentSqlitePath({ agentId, env: migrationEnv }),
+      agentDatabasePath,
     });
   }
   for (const agentId of agentIds) {


### PR DESCRIPTION
Closes #133981

## What Problem This Solves

Fixes an issue where operators with `memory/<agent>.sqlite` compatibility links to the modern per-agent database received one false legacy-memory migration warning per agent during Doctor and startup checks.

## Why This Change Was Made

The Memory Core migration collector followed each symbolic link and classified the populated canonical database as a separate legacy sidecar. It now excludes only a proven link to the same agent's canonical database when no legacy companion files exist. Unknown, corrupt, different-target, and data-bearing legacy files keep the existing warning and preservation behavior.

The issue opener [corrected the reported file shape](https://github.com/openclaw/openclaw/issues/133981#issuecomment-5476148727): the apparent 54–60-byte size was the symbolic-link path length, and 9 of 10 per-agent paths linked to populated canonical databases.

## User Impact

Healthy modern multi-agent installations no longer show repeated false legacy-memory warnings. Existing compatibility links and canonical memory data remain unchanged.

## Evidence

- Current-main red at `cd0f6f487e1819b006b6c11968233ed76523754e`: isolated `openclaw doctor --non-interactive --yes` emitted one false schema warning for each of two agents whose legacy path linked to its populated canonical database.
- Exact candidate source green at `5f79c9ae83e3c92d036838243e8816aeb841683c`: [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/33391687950) reported 2 agents, 0 false previews, 0 false warnings, 2 links preserved, and 2 populated canonical rows preserved.
- `node scripts/run-vitest.mjs extensions/memory-core/doctor-contract-api.test.ts`: 63 passed.
- Focused alias, corrupt-file, data-bearing-file, empty-file, and unknown-companion cases: 7 passed.
- Targeted formatter, lint, and `git diff --check`: passed.
- Autoreview: clean; no accepted or actionable findings.
- Build, type checks, and full continuous integration are delegated to GitHub.
