### PR TITLE
test(plugins): simplify provider fixtures

### DIFF
--- a/extensions/exa/src/exa-web-search-provider.test.ts
+++ b/extensions/exa/src/exa-web-search-provider.test.ts
@@ -1,8 +1,7 @@
-// Exa tests cover exa web search provider plugin behavior.
 import { describe, expect, it, vi } from "vitest";
-import { testing } from "../test-api.js";
 import { createExaWebSearchProvider as createContractExaWebSearchProvider } from "../web-search-contract-api.js";
 import { createExaWebSearchProvider } from "./exa-web-search-provider.js";
+import { testing } from "./exa-web-search-provider.runtime.js";
 
 function cancelTrackedResponse(
   text: string,

--- a/extensions/exa/test-api.ts
+++ b/extensions/exa/test-api.ts
@@ -1,2 +1,0 @@
-// Exa API module exposes the plugin public contract.
-export { testing } from "./src/exa-web-search-provider.runtime.js";

--- a/extensions/minimax/src/minimax-web-search-provider.test.ts
+++ b/extensions/minimax/src/minimax-web-search-provider.test.ts
@@ -1,7 +1,7 @@
-// Minimax tests cover minimax web search provider plugin behavior.
+import { captureEnv } from "openclaw/plugin-sdk/test-env";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { minimaxWebSearchTesting } from "../test-api.js";
 import { createMiniMaxWebSearchProvider } from "./minimax-web-search-provider.js";
+import { testing as minimaxWebSearchTesting } from "./minimax-web-search-provider.runtime.js";
 
 const {
   MINIMAX_SEARCH_ENDPOINT_GLOBAL,
@@ -11,20 +11,14 @@ const {
   resolveMiniMaxRegion,
 } = minimaxWebSearchTesting;
 
-function restoreEnvValue(key: string, value: string | undefined) {
-  if (value === undefined) {
-    delete process.env[key];
-  } else {
-    process.env[key] = value;
-  }
-}
-
 describe("minimax web search provider", () => {
-  const originalApiHost = process.env.MINIMAX_API_HOST;
-  const originalCodePlanKey = process.env.MINIMAX_CODE_PLAN_KEY;
-  const originalCodingApiKey = process.env.MINIMAX_CODING_API_KEY;
-  const originalOauthToken = process.env.MINIMAX_OAUTH_TOKEN;
-  const originalApiKey = process.env.MINIMAX_API_KEY;
+  const envSnapshot = captureEnv([
+    "MINIMAX_API_HOST",
+    "MINIMAX_CODE_PLAN_KEY",
+    "MINIMAX_CODING_API_KEY",
+    "MINIMAX_OAUTH_TOKEN",
+    "MINIMAX_API_KEY",
+  ]);
 
   beforeEach(() => {
     delete process.env.MINIMAX_API_HOST;
@@ -35,11 +29,7 @@ describe("minimax web search provider", () => {
   });
 
   afterEach(() => {
-    restoreEnvValue("MINIMAX_API_HOST", originalApiHost);
-    restoreEnvValue("MINIMAX_CODE_PLAN_KEY", originalCodePlanKey);
-    restoreEnvValue("MINIMAX_CODING_API_KEY", originalCodingApiKey);
-    restoreEnvValue("MINIMAX_OAUTH_TOKEN", originalOauthToken);
-    restoreEnvValue("MINIMAX_API_KEY", originalApiKey);
+    envSnapshot.restore();
   });
 
   it.each([0, 1])(

--- a/extensions/minimax/test-api.ts
+++ b/extensions/minimax/test-api.ts
@@ -1,2 +1,0 @@
-// MiniMax test API exposes the web-search fixture.
-export { testing as minimaxWebSearchTesting } from "./src/minimax-web-search-provider.runtime.js";

--- a/extensions/moonshot/src/kimi-web-search-provider.test.ts
+++ b/extensions/moonshot/src/kimi-web-search-provider.test.ts
@@ -1,9 +1,8 @@
-// Moonshot tests cover kimi web search provider plugin behavior.
 import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-onboard";
 import { withEnv, withEnvAsync } from "openclaw/plugin-sdk/test-env";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { testing } from "../test-api.js";
 import { createKimiWebSearchProvider } from "./kimi-web-search-provider.js";
+import { testing } from "./kimi-web-search-provider.runtime.js";
 
 const kimiApiKeyEnv = ["KIMI_API", "KEY"].join("_");
 

--- a/extensions/moonshot/test-api.ts
+++ b/extensions/moonshot/test-api.ts
@@ -1,2 +1,0 @@
-// Moonshot test API exposes the web-search fixture.
-export { testing } from "./src/kimi-web-search-provider.runtime.js";


### PR DESCRIPTION
## What Problem This Solves

Exa, MiniMax and Moonshot each retain a two-line test facade used by a single test inside the same plugin. MiniMax also duplicates the shared environment snapshot helper.

## Why This Change Was Made

Import the same runtime testing bindings directly and delete the three forwarding files. Use the existing SDK test helper to capture MiniMax's five environment keys at the same describe-time boundary, preserving the existing per-test deletion and restoration. Remove the three generic test-file headers.

These are private fixture paths with no public package export or cross-plugin consumer. Runtime entrypoints, provider policy and the existing public contract tests remain unchanged.

## User Impact

Less test scaffolding to maintain, with all behavioral cases and assertions retained. Production changes: 0. Test/support changes: +12/-30, net -18 lines across six files, including three deleted files.

## Evidence

All 80 focused cases pass before and after: 24 Exa, 22 MiniMax, 21 Moonshot, three test-API consumption checks and ten environment-helper cases. Per-file case names and order are identical. Cancellation, credential/region precedence, cache behavior, grounding and response-validation coverage remain intact.

A temporary observer of the actual MiniMax suite also passes before and after. It changes synthetic keys after collection and verifies all 22 beforeEach deletion cycles and 22 afterEach restorations, including absent, empty and whitespace-containing values. The observer adds no committed tests.

The initial changed gate caught import ordering; the repository formatter corrected it, and focused tests plus the hook observer passed again on the final diff. The complete changed gate then passed, including five doctor contract cases, plugin boundaries, dead exports, production/test types, lint, persistence/media/sidecar guards and runtime import cycles. Fresh managed Codex review is scoped-clean.

## CI refresh

CI 33391211876 timed out in an inherited global sandbox-policy prompt fixture that omitted modelId. This refresh incorporates the existing correction from #134033 while preserving the six reviewed cleanup afterimages. The exact operation responsible for the old 120-second timeout remains unobserved; no timeout or assertion was weakened.

All 178 retained provider/helper/consumer and prompt-owner cases pass in a combined local run with the separate Brave cleanup. The complete changed-file gate and fresh Codex review pass on the same frozen eight-file composition. This PR retains only its own six-file diff, and its refreshed exact-head CI must complete independently before landing.
