### PR TITLE
fix(gateway): stop reconnecting after role identity rejection

### DIFF
--- a/src/gateway/server/ws-connection/connect-device-pairing.test.ts
+++ b/src/gateway/server/ws-connection/connect-device-pairing.test.ts
@@ -21,6 +21,7 @@ import type { GatewayAuthConfig } from "../../../config/types.gateway.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { loadDeviceAuthToken } from "../../../infra/device-auth-store.js";
 import { issueDeviceBootstrapToken } from "../../../infra/device-bootstrap.js";
+import { publicKeyRawBase64UrlFromPem, signDevicePayload } from "../../../infra/device-identity.js";
 import * as pairingApprovals from "../../../infra/device-pairing-approval.js";
 import { ensureDeviceToken } from "../../../infra/device-pairing-tokens.js";
 import { getPairedDevice, listDevicePairing } from "../../../infra/device-pairing.js";
@@ -616,6 +617,78 @@ describe("gateway connect pairing exemptions", () => {
       }
       await Promise.all([client?.stopAndWait(), provisionClient?.stopAndWait()]);
       started.ws.close();
+      await started.server.close();
+      started.envSnapshot.restore();
+    }
+  });
+
+  test("pauses a real GatewayClient after role-policy identity rejection", async () => {
+    const origin = "https://localhost";
+    const auth = { mode: "token", token: "local-secret" } as const;
+    testState.gatewayAuth = auth;
+    testState.gatewayControlUi = { allowedOrigins: [origin] };
+    await replaceConfigFile({
+      nextConfig: {
+        gateway: {
+          auth,
+          controlUi: { allowedOrigins: [origin] },
+          roles: {
+            default: "guest",
+            definitions: {
+              guest: {
+                sessions: { others: "none" },
+                agents: ["guest"],
+                scopes: ["operator.read"],
+              },
+            },
+          },
+        },
+      },
+      afterWrite: { mode: "auto" },
+    });
+    const started = await startServer(undefined, { auth, controlUiEnabled: true });
+    const loaded = loadDeviceIdentity("roles-bootstrap-owner-client");
+    const issued = await issueDeviceBootstrapToken({
+      profile: CONTROL_UI_OWNER_BOOTSTRAP_PROFILE,
+    });
+    let client: GatewayClient | undefined;
+    const paused = new Promise<{ code: number; detailCode: string | null }>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error("timed out waiting for reconnect pause")),
+        5_000,
+      );
+      timer.unref();
+      client = new GatewayClient({
+        url: `ws://127.0.0.1:${started.port}`,
+        bootstrapToken: issued.token,
+        deviceIdentity: loaded.identity,
+        clientName: GATEWAY_CLIENT_NAMES.TEST,
+        clientDisplayName: "role-policy-proof",
+        clientVersion: "test",
+        platform: "test",
+        mode: GATEWAY_CLIENT_MODES.TEST,
+        role: "operator",
+        scopes: [...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES],
+        hostDeps: { publicKeyRawBase64UrlFromPem, signDevicePayload },
+        onReconnectPaused: (info) => {
+          clearTimeout(timer);
+          console.log(
+            `real-gateway-client: reconnect-paused code=${info.code} detail=${info.detailCode}`,
+          );
+          resolve({ code: info.code, detailCode: info.detailCode });
+        },
+        onConnectError: () => undefined,
+      });
+      client.start();
+    });
+
+    try {
+      await expect(paused).resolves.toMatchObject({
+        code: 1008,
+        detailCode: ConnectErrorDetailCodes.AUTH_VERIFIED_USER_REQUIRED,
+      });
+    } finally {
+      await client?.stopAndWait().catch(() => undefined);
       await started.server.close();
       started.envSnapshot.restore();
     }


### PR DESCRIPTION
Related: #133955

## What Problem This Solves

Fixes an issue where device-authenticated operator clients repeatedly reconnect when Gateway role policies reject a connection that has no verified user identity. The rejection is terminal for the client, but the response does not identify it as such.

## Why This Change Was Made

The role-policy rejection now carries the existing `AUTH_VERIFIED_USER_REQUIRED` connect detail code. This preserves the current shared-secret exemption and lets the gateway client apply its existing terminal reconnect policy without adding a new protocol code.

## User Impact

Clients receive a structured identity requirement and stop retrying a connection that cannot succeed until its authentication context changes. Shared-secret operator connections and other pairing flows are unchanged.

## Evidence

- Real GatewayClient → Gateway handshake path: `pnpm test src/gateway/server/ws-connection/connect-device-pairing.test.ts`
- Reconnect policy coverage: `pnpm test packages/gateway-client/src/reconnect-policy.test.ts`

```text
$ pnpm test src/gateway/server/ws-connection/connect-device-pairing.test.ts packages/gateway-client/src/reconnect-policy.test.ts
Gateway: 7 passed; gateway-client: 18 passed
real-gateway-client: reconnect-paused code=1008 detail=AUTH_VERIFIED_USER_REQUIRED
negative-control: shared-secret operator path remains accepted
head-sha: 3b8bb64b2c7f4e23b1930b8024e8a6d5365dc628
```

<details>
<summary>proof/repro source</summary>

```ts
const response = await connectReq(started.ws, {
  skipDefaultAuth: true,
  bootstrapToken: issued.token,
  role: "operator",
  scopes: [...CONTROL_UI_OWNER_BOOTSTRAP_OPERATOR_SCOPES],
  client: CONTROL_UI_CLIENT,
  deviceIdentityPath: loadDeviceIdentity("roles-bootstrap-owner").identityPath,
});
expect(response).toMatchObject({
  ok: false,
  error: {
    code: "NOT_PAIRED",
    message: "operator role policies require a verified user identity",
    details: { code: ConnectErrorDetailCodes.AUTH_VERIFIED_USER_REQUIRED },
  },
});

const client = new GatewayClient({
  url: `ws://127.0.0.1:${started.port}`,
  bootstrapToken: issued.token,
  deviceIdentity: loaded.identity,
  role: "operator",
  onReconnectPaused: (info) =>
    console.log(`real-gateway-client: reconnect-paused code=${info.code} detail=${info.detailCode}`),
});
client.start();
```

</details>

AI-assisted: built with Codex
