### PR TITLE
fix(codex): preserve conversations across app-server restarts

### DIFF
--- a/extensions/codex/src/app-server/thread-lifecycle-io.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-io.ts
@@ -63,6 +63,9 @@ type ResumeThreadContext = CodexThreadRequestContext & {
   binding: CodexAppServerThreadBinding;
   clearCurrentBinding: (operation: string) => Promise<void>;
   prebuiltPluginThreadConfig?: CodexPluginThreadConfig;
+  buildLoadedPluginThreadConfig?: (
+    binding: CodexAppServerThreadBinding,
+  ) => Promise<CodexPluginThreadConfig | undefined>;
   prebuiltFinalConfigPatch?: {
     configPatch?: JsonObject;
     nativeHookRelayGeneration?: string;
@@ -136,6 +139,7 @@ export async function resumeExistingCodexThread(
   } = context;
   let resumeReservation: { release: () => void } | undefined;
   let resumeResponseAccepted = false;
+  let checkingLoadedPluginThreadConfig = false;
   const abandonClient =
     params.abandonClient ?? (() => closeCodexStartupClientBestEffort(params.client));
   try {
@@ -151,10 +155,17 @@ export async function resumeExistingCodexThread(
         configPatch: params.finalConfigPatch,
         nativeHookRelayGeneration: params.nativeHookRelayGeneration,
       };
-    // Codex rebuilds effective config on thread/resume, so replay the app
-    // allowlist persisted at thread/start or plugin tools disappear after one turn.
+    // A cold thread has no scoped inventory yet. Build its complete config before
+    // resume (including scheduled tool ceilings), then admit the loaded thread below.
+    const pluginThreadConfig =
+      context.prebuiltPluginThreadConfig ??
+      (params.pluginThreadConfig?.requiresCurrentPolicyCheck
+        ? await lifecycleTiming.measure("plugin-config-build", () =>
+            params.pluginThreadConfig?.build(),
+          )
+        : undefined);
     const pluginAppsConfigPatch =
-      context.prebuiltPluginThreadConfig?.configPatch ??
+      pluginThreadConfig?.configPatch ??
       (params.pluginThreadConfig?.enabled && resumeBinding.pluginAppPolicyContext
         ? buildCodexPluginAppsConfigPatchFromPolicyContext(resumeBinding.pluginAppPolicyContext)
         : undefined);
@@ -212,14 +223,26 @@ export async function resumeExistingCodexThread(
     resumeResponseAccepted = true;
     assertCodexThreadAcceptsDirectInput(response.thread);
     context.assertResumeConfiguration?.();
-    if (resumeBinding.pendingResumeConfiguration) {
-      await attestCodexPluginThreadApps({
-        client: params.client,
-        threadId: response.thread.id,
-        appIds: context.prebuiltPluginThreadConfig?.provisionalAppIds ?? [],
-        signal: params.signal,
-      });
+    // Current-policy denial must release this subscription and stop, not retry
+    // as a fresh thread. A confirmed config change still follows normal rotation.
+    checkingLoadedPluginThreadConfig = true;
+    const loadedPluginThreadConfig = await context.buildLoadedPluginThreadConfig?.(resumeBinding);
+    if (
+      loadedPluginThreadConfig &&
+      loadedPluginThreadConfig.fingerprint !==
+        (pluginThreadConfig?.fingerprint ?? resumeBinding.pluginAppsFingerprint)
+    ) {
+      checkingLoadedPluginThreadConfig = false;
+      throw new Error("Codex thread app policy changed; a fresh thread configuration is required");
     }
+    await attestCodexPluginThreadApps({
+      client: params.client,
+      threadId: response.thread.id,
+      appIds:
+        loadedPluginThreadConfig?.provisionalAppIds ?? pluginThreadConfig?.provisionalAppIds ?? [],
+      signal: params.signal,
+    });
+    checkingLoadedPluginThreadConfig = false;
     if (
       ringZeroActive ||
       isMessageOnlyCodexSourceReply(params.params) ||
@@ -278,13 +301,11 @@ export async function resumeExistingCodexThread(
         resumeBinding.connectionScope === "supervision"
           ? buildCodexAppServerConnectionFingerprint(params.appServer, params.params.agentDir)
           : params.appServerRuntimeFingerprint,
-      pluginAppsFingerprint:
-        context.prebuiltPluginThreadConfig?.fingerprint ?? resumeBinding.pluginAppsFingerprint,
+      pluginAppsFingerprint: pluginThreadConfig?.fingerprint ?? resumeBinding.pluginAppsFingerprint,
       pluginAppsInputFingerprint:
-        context.prebuiltPluginThreadConfig?.inputFingerprint ??
-        resumeBinding.pluginAppsInputFingerprint,
+        pluginThreadConfig?.inputFingerprint ?? resumeBinding.pluginAppsInputFingerprint,
       pluginAppPolicyContext:
-        context.prebuiltPluginThreadConfig?.policyContext ?? resumeBinding.pluginAppPolicyContext,
+        pluginThreadConfig?.policyContext ?? resumeBinding.pluginAppPolicyContext,
       contextEngine: contextEngineBinding,
       environmentSelectionFingerprint,
     } satisfies Partial<Omit<CodexAppServerThreadBinding, "threadId">>;
@@ -389,6 +410,7 @@ export async function resumeExistingCodexThread(
       }
     }
     if (
+      checkingLoadedPluginThreadConfig ||
       resumeBinding.pendingResumeConfiguration ||
       error instanceof CodexThreadDirectInputError ||
       params.signal?.aborted

--- a/extensions/codex/src/app-server/thread-lifecycle-run.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-run.ts
@@ -47,7 +47,6 @@ import type {
   CodexStartOrResumeThreadParams,
 } from "./thread-lifecycle-types.js";
 import {
-  releaseCodexConsumedLiveThread,
   releaseCodexRetainedLiveThread,
   throwIfCodexThreadLifecycleAborted,
   tryReuseCodexLiveThread,
@@ -368,7 +367,6 @@ export async function startOrResumeThread(
       binding = undefined;
     }
     const requestContext = resolveRequestContext();
-    const { startModelSelection, startModelProvider } = requestContext;
     // Capability read failures use managed search for this turn but must not
     // create a binding that later looks like a confirmed provider-policy change.
     let preserveExistingBinding =
@@ -378,6 +376,38 @@ export async function startOrResumeThread(
         !binding?.threadId);
     let rotatedContextEngineBinding = false;
     let prebuiltPluginThreadConfig: CodexPluginThreadConfig | undefined;
+    // Scoped inventory requires a loaded native thread. The warm/resume owner
+    // calls this only after acquiring that exact subscription, before admission.
+    const buildLoadedPluginThreadConfig = async (
+      current: CodexAppServerThreadBinding,
+    ): Promise<CodexPluginThreadConfig | undefined> => {
+      if (
+        !params.pluginThreadConfig?.requiresCurrentPolicyCheck &&
+        !shouldRecheckRecoverablePluginBinding({
+          binding: current,
+          pluginThreadConfig: params.pluginThreadConfig,
+        })
+      ) {
+        return undefined;
+      }
+      try {
+        prebuiltPluginThreadConfig = await lifecycleTiming.measure("plugin-config-recovery", () =>
+          params.pluginThreadConfig?.build({ threadId: current.threadId }),
+        );
+      } catch (error) {
+        throwIfAborted();
+        if (params.pluginThreadConfig?.requiresCurrentPolicyCheck) {
+          throw error;
+        }
+        embeddedAgentLog.warn("codex app-server plugin app config recovery check failed", {
+          error,
+          threadId: current.threadId,
+        });
+        return undefined;
+      }
+      throwIfAborted();
+      return prebuiltPluginThreadConfig;
+    };
     const webSearchBindingChanged =
       binding?.threadId &&
       binding.webSearchThreadConfigFingerprint !== webSearchThreadConfigFingerprint;
@@ -544,38 +574,13 @@ export async function startOrResumeThread(
       binding = undefined;
     }
     if (binding?.threadId) {
-      let pluginBindingStale = isCodexPluginThreadBindingStale({
+      const pluginBindingStale = isCodexPluginThreadBindingStale({
         codexPluginsEnabled: params.pluginThreadConfig?.enabled ?? false,
         bindingFingerprint: binding.pluginAppsFingerprint,
         bindingInputFingerprint: binding.pluginAppsInputFingerprint,
         currentInputFingerprint: params.pluginThreadConfig?.inputFingerprint,
         hasBindingPolicyContext: Boolean(binding.pluginAppPolicyContext),
       });
-      if (
-        !pluginBindingStale &&
-        (params.pluginThreadConfig?.requiresCurrentPolicyCheck ||
-          shouldRecheckRecoverablePluginBinding({
-            binding,
-            pluginThreadConfig: params.pluginThreadConfig,
-          }))
-      ) {
-        try {
-          const bindingThreadId = binding.threadId;
-          prebuiltPluginThreadConfig = await lifecycleTiming.measure("plugin-config-recovery", () =>
-            params.pluginThreadConfig?.build({ threadId: bindingThreadId }),
-          );
-          pluginBindingStale =
-            prebuiltPluginThreadConfig?.fingerprint !== binding.pluginAppsFingerprint;
-        } catch (error) {
-          if (params.pluginThreadConfig?.requiresCurrentPolicyCheck) {
-            throw error;
-          }
-          embeddedAgentLog.warn("codex app-server plugin app config recovery check failed", {
-            error,
-            threadId: binding.threadId,
-          });
-        }
-      }
       if (pluginBindingStale) {
         embeddedAgentLog.debug(
           "codex app-server plugin app config changed; starting a new thread",
@@ -637,7 +642,12 @@ export async function startOrResumeThread(
           await clearCurrentBinding("rotating a stale thread binding");
         }
       } else if (incognito) {
-        if (binding.clientId && binding.clientId === clientId) {
+        if (
+          binding.clientId &&
+          binding.clientId === clientId &&
+          ((await buildLoadedPluginThreadConfig(binding))?.fingerprint ??
+            binding.pluginAppsFingerprint) === binding.pluginAppsFingerprint
+        ) {
           // Ephemeral threads have no cold-resume source; reuse only the live client that started it.
           params.buildFinalConfigPatch?.({ action: "resume", binding });
           throwIfAborted();
@@ -655,50 +665,38 @@ export async function startOrResumeThread(
         binding = undefined;
       } else {
         const warmReuse = await tryReuseCodexLiveThread({
+          ...requestContext,
           params,
           binding,
-          bindingIdentity,
           clientId,
-          dynamicToolsFingerprint,
-          environmentSelectionFingerprint,
-          hostSystemAgentActive,
-          lifecycleTiming,
-          nativeSkillIsolation,
-          releaseConsumedThread: (threadId, cause) =>
-            releaseCodexConsumedLiveThread({
-              client: params.client,
-              abandonClient: params.abandonClient,
-              lifecycleTiming,
-              threadId,
-              cause,
-            }),
-          ringZeroActive,
-          restrictedToolSurfaceInheritedMcpServerNames,
-          startModelProvider,
-          startModelSelection,
-          throwIfAborted,
-          userMcpServersConfigPatch,
+          buildLoadedPluginThreadConfig,
         });
-        if (warmReuse.binding) {
+        if (warmReuse.kind === "ready") {
           return warmReuse.binding;
         }
-        // Native adoption must be checked before releasing any retained owner;
-        // a passive refusal neither acquires nor authorizes dropping a subscription.
-        if (binding.preserveNativeModel === true) {
-          await assertAdoptedCodexThreadResumeAllowed(params, binding.threadId, requestContext);
-        }
-        // Codex cold-resumes a changed idle thread after its last subscriber
-        // leaves; resume_running_thread shuts down the old cached session.
-        await releaseRetainedThread(binding.threadId);
-        const resumed = await resumeExistingCodexThread(params, {
-          ...requestContext,
-          binding,
-          clearCurrentBinding,
-          prebuiltFinalConfigPatch: warmReuse.prebuiltFinalConfigPatch,
-          prebuiltPluginThreadConfig,
-        });
-        if (resumed) {
-          return resumed;
+        if (warmReuse.kind === "rotate") {
+          throwIfAborted();
+          await clearCurrentBinding("rotating a stale plugin app binding");
+        } else {
+          // Native adoption must be checked before releasing any retained owner;
+          // a passive refusal neither acquires nor authorizes dropping a subscription.
+          if (binding.preserveNativeModel === true) {
+            await assertAdoptedCodexThreadResumeAllowed(params, binding.threadId, requestContext);
+          }
+          // Codex cold-resumes a changed idle thread after its last subscriber
+          // leaves; resume_running_thread shuts down the old cached session.
+          await releaseRetainedThread(binding.threadId);
+          const resumed = await resumeExistingCodexThread(params, {
+            ...requestContext,
+            binding,
+            clearCurrentBinding,
+            prebuiltFinalConfigPatch: warmReuse.prebuiltFinalConfigPatch,
+            prebuiltPluginThreadConfig,
+            buildLoadedPluginThreadConfig,
+          });
+          if (resumed) {
+            return resumed;
+          }
         }
       }
     }

--- a/extensions/codex/src/app-server/thread-lifecycle-warm.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle-warm.ts
@@ -7,27 +7,27 @@ import {
 } from "./attempt-client-cleanup.js";
 import {
   consumeCodexAppServerLiveThread,
+  isCodexAppServerClientRuntimeLive,
   releaseCodexAppServerLiveThread,
 } from "./client-runtime.js";
 import type { CodexAppServerClient } from "./client.js";
 import { applyCodexNativeSkillIsolation } from "./native-skill-isolation.js";
+import { attestCodexPluginThreadApps } from "./plugin-thread-attestation.js";
 import {
   buildCodexPluginAppsConfigPatchFromPolicyContext,
   mergeCodexThreadConfigs,
+  type CodexPluginThreadConfig,
 } from "./plugin-thread-config.js";
 import type { JsonObject } from "./protocol.js";
-import type {
-  CodexAppServerBindingIdentity,
-  CodexAppServerThreadBinding,
-} from "./session-binding.js";
+import type { CodexAppServerThreadBinding } from "./session-binding.js";
 import { fingerprintCodexThreadConfig } from "./thread-fingerprints.js";
 import { CodexThreadBindingConflictError } from "./thread-lifecycle-errors.js";
 import type { CodexThreadLifecycleTimingTracker } from "./thread-lifecycle-timing.js";
 import type {
   CodexAppServerThreadLifecycleBinding,
   CodexStartOrResumeThreadParams,
+  CodexThreadRequestContext,
 } from "./thread-lifecycle-types.js";
-import type { resolveCodexAppServerThreadModelSelection } from "./thread-model-selection.js";
 import { buildThreadResumeParams } from "./thread-requests.js";
 
 type CodexWarmThreadFinalConfigPatch = {
@@ -35,29 +35,19 @@ type CodexWarmThreadFinalConfigPatch = {
   nativeHookRelayGeneration?: string;
 };
 
-type CodexWarmThreadReuseParams = {
+type CodexWarmThreadReuseParams = CodexThreadRequestContext & {
   params: CodexStartOrResumeThreadParams;
   binding: CodexAppServerThreadBinding;
-  bindingIdentity: CodexAppServerBindingIdentity;
   clientId?: string;
-  dynamicToolsFingerprint: string;
-  environmentSelectionFingerprint?: string;
-  hostSystemAgentActive: boolean;
-  lifecycleTiming: CodexThreadLifecycleTimingTracker;
-  nativeSkillIsolation?: Parameters<typeof applyCodexNativeSkillIsolation>[1];
-  releaseConsumedThread: (threadId: string, cause?: unknown) => Promise<void>;
-  ringZeroActive: boolean;
-  restrictedToolSurfaceInheritedMcpServerNames: string[];
-  startModelProvider?: string;
-  startModelSelection: ReturnType<typeof resolveCodexAppServerThreadModelSelection>;
-  throwIfAborted: () => void;
-  userMcpServersConfigPatch?: JsonObject;
+  buildLoadedPluginThreadConfig: (
+    binding: CodexAppServerThreadBinding,
+  ) => Promise<CodexPluginThreadConfig | undefined>;
 };
 
-type CodexWarmThreadReuseResult = {
-  binding?: CodexAppServerThreadLifecycleBinding;
-  prebuiltFinalConfigPatch?: CodexWarmThreadFinalConfigPatch;
-};
+type CodexWarmThreadReuseResult =
+  | { kind: "ready"; binding: CodexAppServerThreadLifecycleBinding }
+  | { kind: "rotate" }
+  | { kind: "resume"; prebuiltFinalConfigPatch?: CodexWarmThreadFinalConfigPatch };
 
 type CodexLiveThreadReleaseParams = {
   client: CodexAppServerClient;
@@ -146,7 +136,6 @@ export async function tryReuseCodexLiveThread(
     hostSystemAgentActive,
     lifecycleTiming,
     nativeSkillIsolation,
-    releaseConsumedThread,
     ringZeroActive,
     restrictedToolSurfaceInheritedMcpServerNames,
     startModelProvider,
@@ -162,84 +151,96 @@ export async function tryReuseCodexLiveThread(
     binding.connectionScope === "supervision" ||
     ringZeroActive
   ) {
-    return {};
+    return { kind: "resume" };
   }
 
-  // Engine identity, projection epoch, and policy were checked by the owner
-  // before this call; compatible bootstrap threads must keep their session.
-
-  const prebuiltFinalConfigPatch = params.buildFinalConfigPatch?.({
-    action: "resume",
-    binding,
-  }) ?? {
-    configPatch: params.finalConfigPatch,
-    nativeHookRelayGeneration: params.nativeHookRelayGeneration,
-  };
-  const pluginAppsConfigPatch =
-    params.pluginThreadConfig?.enabled && binding.pluginAppPolicyContext
-      ? buildCodexPluginAppsConfigPatchFromPolicyContext(binding.pluginAppPolicyContext)
-      : undefined;
-  const resumeAuthProfileId = params.params.authProfileId ?? binding.authProfileId;
-  const resumeConfig = mergeCodexThreadConfigs(
-    params.config,
-    userMcpServersConfigPatch,
-    pluginAppsConfigPatch,
-    prebuiltFinalConfigPatch.configPatch,
-  );
-  const resumeParams = lifecycleTiming.measureSync("warm-thread-resume-params", () =>
-    buildThreadResumeParams(params.params, {
-      threadId: binding.threadId,
-      cwd: params.cwd,
-      authProfileId: resumeAuthProfileId,
-      model: startModelSelection.model,
-      modelProvider: startModelProvider,
-      preserveNativeModel: false,
-      appServer: params.appServer,
-      dynamicTools: params.dynamicTools,
-      developerInstructions: params.developerInstructions,
-      config: applyCodexNativeSkillIsolation(resumeConfig, nativeSkillIsolation),
-      nativeCodeModeEnabled: params.nativeCodeModeEnabled,
-      nativeProviderWebSearchSupport: params.nativeProviderWebSearchSupport,
-      nativeCodeModeOnlyEnabled: params.nativeCodeModeOnlyEnabled,
-      webSearchAllowed: params.webSearchAllowed,
-      hostSystemAgentActive,
-      restrictedToolSurfaceInheritedMcpServerNames,
-      shellEnvironment: params.shellEnvironment,
-      disableLoginShell: params.disableLoginShell,
-    }),
-  );
-  const liveThreadConfigFingerprint = fingerprintCodexThreadConfig(
-    {
-      ...resumeParams,
-      // Keep the actual loaded provider separate from caller-selected
-      // overrides so account or provider changes always invalidate reuse.
-      model: binding.model ?? resumeParams.model ?? null,
-      requestedModel: resumeParams.model ?? null,
-      modelProvider: binding.modelProvider ?? resumeParams.modelProvider ?? null,
-      requestedModelProvider: resumeParams.modelProvider ?? binding.modelProvider ?? null,
-    },
-    resumeAuthProfileId,
-    dynamicToolsFingerprint,
-  );
-  const retainedThread = await consumeCodexAppServerLiveThread(
-    params.client,
-    binding.threadId,
-    liveThreadConfigFingerprint,
-  );
+  const retainedThread = await consumeCodexAppServerLiveThread(params.client, binding.threadId);
   if (!retainedThread) {
-    const incompatibleOwnership = await consumeCodexAppServerLiveThread(
-      params.client,
-      binding.threadId,
-    );
-    if (incompatibleOwnership) {
-      // Codex ignores resume overrides while any subscription remains. Manual
-      // external adoption has no verified fingerprint, so release before resume.
-      await incompatibleOwnership.release(binding.threadId);
-    }
-    return { prebuiltFinalConfigPatch };
+    return { kind: "resume" };
   }
-
+  const assertCurrentClient = () => {
+    throwIfAborted();
+    // Startup attaches router abort after this lifecycle call. A closed client's
+    // inventory failure must not be treated as revocation of the durable binding.
+    if (!isCodexAppServerClientRuntimeLive(params.client)) {
+      throw params.client.getCloseError() ?? new Error("codex app-server client is closed");
+    }
+  };
+  let ownershipTransferred = false;
   try {
+    const pluginThreadConfig = await options.buildLoadedPluginThreadConfig(binding);
+    assertCurrentClient();
+    if (pluginThreadConfig && pluginThreadConfig.fingerprint !== binding.pluginAppsFingerprint) {
+      return { kind: "rotate" };
+    }
+    // Engine identity, projection epoch, and policy were checked by the owner
+    // before this call; compatible bootstrap threads must keep their session.
+
+    const prebuiltFinalConfigPatch = params.buildFinalConfigPatch?.({
+      action: "resume",
+      binding,
+    }) ?? {
+      configPatch: params.finalConfigPatch,
+      nativeHookRelayGeneration: params.nativeHookRelayGeneration,
+    };
+    const pluginAppsConfigPatch =
+      pluginThreadConfig?.configPatch ??
+      (params.pluginThreadConfig?.enabled && binding.pluginAppPolicyContext
+        ? buildCodexPluginAppsConfigPatchFromPolicyContext(binding.pluginAppPolicyContext)
+        : undefined);
+    const resumeAuthProfileId = params.params.authProfileId ?? binding.authProfileId;
+    const resumeConfig = mergeCodexThreadConfigs(
+      params.config,
+      userMcpServersConfigPatch,
+      pluginAppsConfigPatch,
+      prebuiltFinalConfigPatch.configPatch,
+    );
+    const resumeParams = lifecycleTiming.measureSync("warm-thread-resume-params", () =>
+      buildThreadResumeParams(params.params, {
+        threadId: binding.threadId,
+        cwd: params.cwd,
+        authProfileId: resumeAuthProfileId,
+        model: startModelSelection.model,
+        modelProvider: startModelProvider,
+        preserveNativeModel: false,
+        appServer: params.appServer,
+        dynamicTools: params.dynamicTools,
+        developerInstructions: params.developerInstructions,
+        config: applyCodexNativeSkillIsolation(resumeConfig, nativeSkillIsolation),
+        nativeCodeModeEnabled: params.nativeCodeModeEnabled,
+        nativeProviderWebSearchSupport: params.nativeProviderWebSearchSupport,
+        nativeCodeModeOnlyEnabled: params.nativeCodeModeOnlyEnabled,
+        webSearchAllowed: params.webSearchAllowed,
+        hostSystemAgentActive,
+        restrictedToolSurfaceInheritedMcpServerNames,
+        shellEnvironment: params.shellEnvironment,
+        disableLoginShell: params.disableLoginShell,
+      }),
+    );
+    const liveThreadConfigFingerprint = fingerprintCodexThreadConfig(
+      {
+        ...resumeParams,
+        // Keep the actual loaded provider separate from caller-selected
+        // overrides so account or provider changes always invalidate reuse.
+        model: binding.model ?? resumeParams.model ?? null,
+        requestedModel: resumeParams.model ?? null,
+        modelProvider: binding.modelProvider ?? resumeParams.modelProvider ?? null,
+        requestedModelProvider: resumeParams.modelProvider ?? binding.modelProvider ?? null,
+      },
+      resumeAuthProfileId,
+      dynamicToolsFingerprint,
+    );
+    if (retainedThread.configFingerprint !== liveThreadConfigFingerprint) {
+      // Loaded Codex threads ignore overrides; release the claimed subscription before resume.
+      return { kind: "resume", prebuiltFinalConfigPatch };
+    }
+    await attestCodexPluginThreadApps({
+      client: params.client,
+      threadId: binding.threadId,
+      appIds: pluginThreadConfig?.provisionalAppIds ?? [],
+      signal: params.signal,
+    });
+    assertCurrentClient();
     const nativeHookRelayGeneration =
       prebuiltFinalConfigPatch.nativeHookRelayGeneration ?? binding.nativeHookRelayGeneration;
     const model = startModelSelection.model;
@@ -247,23 +248,27 @@ export async function tryReuseCodexLiveThread(
     // have replaced the persisted binding since it was first read. Model and
     // cwd are sticky turn settings, so future turns and /btw need current facts.
     const committed = await lifecycleTiming.measure("warm-thread-write-binding", () =>
-      params.bindingStore.mutate(bindingIdentity, {
-        kind: "patch",
-        threadId: binding.threadId,
-        // Environment selection is sticky turn/start state, like cwd/model;
-        // recording its new value must not recreate the approval-bearing thread.
-        patch: {
-          cwd: params.cwd,
-          model,
-          nativeHookRelayGeneration,
-          environmentSelectionFingerprint,
+      params.bindingStore.mutate(
+        bindingIdentity,
+        {
+          kind: "patch",
+          threadId: binding.threadId,
+          // Environment selection is sticky turn/start state, like cwd/model;
+          // recording its new value must not recreate the approval-bearing thread.
+          patch: {
+            cwd: params.cwd,
+            model,
+            nativeHookRelayGeneration,
+            environmentSelectionFingerprint,
+          },
         },
-      }),
+        assertCurrentClient,
+      ),
     );
     if (!committed) {
       throw new CodexThreadBindingConflictError(binding.threadId, "committing a reused thread");
     }
-    throwIfAborted();
+    assertCurrentClient();
     lifecycleTiming.mark("thread-ready");
     lifecycleTiming.logSummary({
       runId: params.params.runId,
@@ -272,7 +277,9 @@ export async function tryReuseCodexLiveThread(
       threadId: binding.threadId,
       action: "resumed",
     });
+    ownershipTransferred = true;
     return {
+      kind: "ready",
       binding: {
         ...binding,
         cwd: params.cwd,
@@ -286,10 +293,23 @@ export async function tryReuseCodexLiveThread(
           : {}),
         lifecycle: { action: "resumed" },
       },
-      prebuiltFinalConfigPatch,
     };
-  } catch (error) {
-    await releaseConsumedThread(binding.threadId, error);
-    throw error;
+  } finally {
+    if (!ownershipTransferred) {
+      try {
+        // Keep the claim's generation fence across policy awaits and binding conflicts.
+        await retainedThread.release(binding.threadId);
+      } catch (error) {
+        await abandonCodexLiveThreadRelease(
+          {
+            client: params.client,
+            abandonClient: params.abandonClient,
+            lifecycleTiming,
+            threadId: binding.threadId,
+          },
+          error,
+        );
+      }
+    }
   }
 }

--- a/extensions/codex/src/app-server/thread-lifecycle.app-inventory.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.app-inventory.test.ts
@@ -1,0 +1,544 @@
+import path from "node:path";
+import type { EmbeddedRunAttemptParamsV2 as EmbeddedRunAttemptParams } from "openclaw/plugin-sdk/agent-harness-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CodexAppInventoryCache } from "./app-inventory-cache.js";
+import { codexAppInventoryResponse } from "./app-inventory.test-helpers.js";
+import {
+  ensureCodexAppServerClientRuntime,
+  releaseCodexAppServerLiveThread,
+  retainCodexAppServerLiveThread,
+} from "./client-runtime.js";
+import { CodexAppServerRpcError } from "./client.js";
+import {
+  createFakeCodexAppServerClient,
+  threadStartResult,
+} from "./codex-app-server.test-fixtures.js";
+import { resolveCodexPluginsPolicy } from "./config.js";
+import {
+  appInfo,
+  appSummary,
+  pluginDetail,
+  pluginInstalled,
+  pluginSummary,
+} from "./plugin-inventory.test-helpers.js";
+import { CodexPluginMetadataCache } from "./plugin-metadata-cache.js";
+import { createCodexPluginThreadConfigStartupProvider } from "./plugin-thread-config-deadline.js";
+import { buildCodexPluginThreadConfigInputFingerprint } from "./plugin-thread-config.js";
+import { isJsonObject, type JsonObject } from "./protocol.js";
+import { buildScheduledCodexAppAuthorityInputFingerprint } from "./scheduled-app-authority.js";
+import { createCodexAppServerBindingStore, sessionBindingIdentity } from "./session-binding.js";
+import { createCodexTestBindingStateStore } from "./session-binding.test-helpers.js";
+import { createCodexTestModel, useAutoCleanupTempDirTracker } from "./test-support.js";
+import { startOrResumeThread as startOrResumeThreadImpl } from "./thread-lifecycle.js";
+import {
+  createAppServerOptions,
+  createParams,
+  resetThreadLifecycleTestFixtures,
+} from "./thread-lifecycle.test-fixtures.js";
+
+describe("Codex app inventory across physical process restart", () => {
+  const appId = "calendar-app";
+  const pluginName = "calendar";
+  const pluginConfig = {
+    codexPlugins: {
+      enabled: true,
+      plugins: {
+        calendar: {
+          marketplaceName: "openai-curated",
+          pluginName,
+          enabled: true,
+          allow_destructive_actions: false,
+        },
+      },
+    },
+  };
+  const authority: NonNullable<EmbeddedRunAttemptParams["scheduledRuntimeAuthority"]> = {
+    version: 1,
+    runtimeId: "codex",
+    namespace: "codex.apps",
+    payload: {
+      version: 1,
+      auth: { profileId: "openai:fixture", accountId: "fixture-account" },
+      apps: [
+        {
+          id: appId,
+          allowDestructiveActions: false,
+          allowOpenWorld: true,
+          destructiveApprovalMode: "deny",
+          tools: { list: "prompt" },
+        },
+      ],
+    },
+  };
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  let tempDir = "";
+  const processes: Array<ReturnType<typeof createFakeCodexAppServerClient>> = [];
+
+  beforeEach(() => {
+    tempDir = tempDirs.make("openclaw-cold-app-inventory-");
+  });
+  afterEach(() => {
+    for (const process of processes.splice(0)) {
+      process.close();
+    }
+    resetThreadLifecycleTestFixtures();
+    vi.restoreAllMocks();
+  });
+
+  async function fixture(scheduled: boolean) {
+    const workspaceDir = path.join(tempDir, "workspace");
+    const agentDir = path.join(tempDir, "agent");
+    const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir, {});
+    params.agentDir = agentDir;
+    params.disableTools = false;
+    params.provider = "openai";
+    params.model = {
+      ...createCodexTestModel("openai"),
+      id: "gpt-5.6-luna",
+      name: "gpt-5.6-luna",
+    };
+    params.modelId = params.model.id;
+    params.scheduledRuntimeAuthority = scheduled ? authority : undefined;
+    const appServer = {
+      ...createAppServerOptions(),
+      connectionClass: "local-loopback" as const,
+      remoteAppsSubstrate: "preconfigured" as const,
+    };
+    appServer.start = {
+      ...appServer.start,
+      env: { HOME: path.join(tempDir, "home"), CODEX_HOME: path.join(tempDir, "codex-home") },
+    };
+    const state = createCodexTestBindingStateStore();
+    let bindingStore = createCodexAppServerBindingStore(state);
+    const identity = sessionBindingIdentity({
+      sessionId: params.sessionId,
+      sessionKey: params.sessionKey,
+    });
+    const durableThreads = new Map<string, JsonObject>();
+    let sequence = 0;
+    let processSequence = 0;
+    let accountRevoked = false;
+    const calls: Array<{ processId: string; method: string; params: JsonObject; loaded: boolean }> =
+      [];
+    const currentConfig: JsonObject = {
+      apps: {
+        _default: { enabled: false },
+        [appId]: { enabled: true, tools: { list: { approval_mode: "auto" } } },
+      },
+    };
+
+    function createProcess() {
+      const processId = `process-${++processSequence}`;
+      const loadedThreads = new Map<string, JsonObject>();
+      const threadToolRevocations = new Set<string>();
+      const disabledThreadApps = new Set<string>();
+      const abort = new AbortController();
+      const faults: { beforeInventory?: () => Promise<void>; unsubscribe?: Error } = {};
+      let closeError: Error | undefined;
+      const appCache = new CodexAppInventoryCache();
+      const metadataCache = new CodexPluginMetadataCache();
+      const assertOpen = () => {
+        if (closeError) {
+          throw closeError;
+        }
+      };
+      const fake = createFakeCodexAppServerClient(async (method, raw) => {
+        assertOpen();
+        const requestParams = isJsonObject(raw) ? raw : {};
+        const threadId =
+          typeof requestParams.threadId === "string" ? requestParams.threadId : undefined;
+        calls.push({
+          processId,
+          method,
+          params: requestParams,
+          loaded: Boolean(threadId && loadedThreads.has(threadId)),
+        });
+        if (
+          ["app/installed", "app/read", "mcpServerStatus/list"].includes(method) &&
+          threadId &&
+          !loadedThreads.has(threadId)
+        ) {
+          throw new CodexAppServerRpcError(
+            { code: -32600, message: `thread not found: ${threadId}` },
+            method,
+          );
+        }
+        if (method === "skills/list") {
+          return { data: [], errors: [] };
+        }
+        if (method === "config/read") {
+          return { config: currentConfig, layers: [] };
+        }
+        if (method === "plugin/installed") {
+          return pluginInstalled([pluginSummary(pluginName, { installed: true, enabled: true })]);
+        }
+        if (method === "plugin/read") {
+          return pluginDetail(pluginName, [appSummary(appId)]);
+        }
+        if (method === "app/installed" || method === "app/read") {
+          if (threadId) {
+            await faults.beforeInventory?.();
+          }
+          assertOpen();
+          const effective = threadId ? loadedThreads.get(threadId) : currentConfig;
+          const apps = isJsonObject(effective?.apps) ? effective.apps : {};
+          const app = isJsonObject(apps[appId]) ? apps[appId] : {};
+          const row = {
+            ...appInfo(appId, !accountRevoked),
+            isEnabled: app.enabled === true && !(threadId && disabledThreadApps.has(threadId)),
+          };
+          if (method === "app/installed") {
+            return codexAppInventoryResponse(
+              method,
+              [row],
+              {
+                forceRefresh: requestParams.forceRefresh === true,
+              },
+              { callableByAppId: { [appId]: !accountRevoked && row.isEnabled } },
+            );
+          }
+          return codexAppInventoryResponse(method, [row], {
+            appIds: Array.isArray(requestParams.appIds)
+              ? requestParams.appIds.filter((value): value is string => typeof value === "string")
+              : [],
+            includeTools: requestParams.includeTools === true,
+          });
+        }
+        if (method === "mcpServerStatus/list") {
+          return {
+            data: [
+              {
+                name: "codex_apps",
+                tools:
+                  accountRevoked || (threadId && threadToolRevocations.has(threadId))
+                    ? {}
+                    : { list: { _meta: { connector_id: appId } } },
+              },
+            ],
+            nextCursor: null,
+          };
+        }
+        if (method === "thread/start") {
+          const id = `00000000-0000-4000-8000-${String(++sequence).padStart(12, "0")}`;
+          const config = isJsonObject(requestParams.config) ? requestParams.config : {};
+          durableThreads.set(id, config);
+          loadedThreads.set(id, config);
+          return { ...threadStartResult(id, workspaceDir), model: params.modelId };
+        }
+        if (method === "thread/resume" && threadId) {
+          if (!durableThreads.has(threadId)) {
+            throw new CodexAppServerRpcError(
+              { code: -32600, message: `thread not found: ${threadId}` },
+              method,
+            );
+          }
+          // Loaded threads ignore config overrides; cold resume rebuilds effective config.
+          if (!loadedThreads.has(threadId)) {
+            const config = isJsonObject(requestParams.config)
+              ? requestParams.config
+              : durableThreads.get(threadId)!;
+            loadedThreads.set(threadId, config);
+            durableThreads.set(threadId, config);
+          }
+          return { ...threadStartResult(threadId, workspaceDir), model: params.modelId };
+        }
+        if (method === "thread/unsubscribe" && threadId) {
+          if (faults.unsubscribe) {
+            throw faults.unsubscribe;
+          }
+          loadedThreads.delete(threadId);
+          return { status: "unsubscribed" };
+        }
+        if (method === "thread/delete" && threadId) {
+          loadedThreads.delete(threadId);
+          durableThreads.delete(threadId);
+          return {};
+        }
+        throw new Error(`unexpected fixture RPC: ${method}`);
+      });
+      vi.spyOn(fake.client, "getInstanceId").mockReturnValue(processId);
+      fake.client.addCloseHandler((client) => {
+        closeError = client.getCloseError() ?? new Error("codex app-server client is closed");
+      });
+      ensureCodexAppServerClientRuntime(fake.client, { agentDir });
+      processes.push(fake);
+      const abandonClient = vi.fn(async () => fake.close());
+      const appCacheKey = "same-account-home-version";
+      const inputFingerprint = buildScheduledCodexAppAuthorityInputFingerprint(
+        buildCodexPluginThreadConfigInputFingerprint({ pluginConfig, appCacheKey }),
+        params.scheduledRuntimeAuthority,
+      );
+      const provider = () =>
+        createCodexPluginThreadConfigStartupProvider({
+          inputFingerprint,
+          enabledPluginConfigKeys: [pluginName],
+          policy: resolveCodexPluginsPolicy(pluginConfig),
+          requestTimeoutMs: appServer.requestTimeoutMs,
+          signal: abort.signal,
+          pluginConfig,
+          client: fake.client,
+          configCwd: workspaceDir,
+          appCache,
+          appCacheKey,
+          metadataCache,
+          scheduledRuntimeAuthority: params.scheduledRuntimeAuthority,
+        });
+      return {
+        ...fake,
+        loadedThreads,
+        threadToolRevocations,
+        disabledThreadApps,
+        abort,
+        faults,
+        abandonClient,
+        run: () =>
+          startOrResumeThreadImpl({
+            client: fake.client,
+            abandonClient,
+            signal: abort.signal,
+            params,
+            cwd: workspaceDir,
+            dynamicTools: [],
+            appServer,
+            bindingStore,
+            userMcpServersEnabled: false,
+            nativeCodeModeEnabled: true,
+            hostSystemAgentActive: false,
+            pluginThreadConfig: provider(),
+          }),
+      };
+    }
+    return {
+      calls,
+      createProcess,
+      readBinding: () => bindingStore.read(identity),
+      replaceBinding: async (threadId: string) => {
+        const current = await bindingStore.read(identity);
+        if (!current) {
+          throw new Error("fixture binding missing");
+        }
+        expect(
+          await bindingStore.mutate(identity, {
+            kind: "replace-thread",
+            expectedThreadId: current.threadId,
+            binding: { ...current, threadId },
+          }),
+        ).toBe(true);
+      },
+      restartStore: () => {
+        bindingStore = createCodexAppServerBindingStore(state);
+      },
+      revokeAccount: () => {
+        accountRevoked = true;
+      },
+    };
+  }
+
+  async function continuation(scheduled: boolean, lifecycle: string) {
+    const f = await fixture(scheduled);
+    const firstProcess = f.createProcess();
+    const first = await firstProcess.run();
+    expect(first.pluginAppPolicyContext?.apps[appId]).toBeDefined();
+    expect(firstProcess.loadedThreads.has(first.threadId)).toBe(true);
+    if (lifecycle !== "cold") {
+      expect(
+        await retainCodexAppServerLiveThread(
+          firstProcess.client,
+          first.threadId,
+          undefined,
+          first.liveThreadConfigFingerprint,
+        ),
+      ).toBe(true);
+      if (lifecycle === "unloaded-same-process") {
+        expect(await releaseCodexAppServerLiveThread(firstProcess.client, first.threadId)).toBe(
+          true,
+        );
+        expect(firstProcess.loadedThreads.has(first.threadId)).toBe(false);
+      }
+    } else {
+      firstProcess.close();
+      f.restartStore();
+    }
+    const process = lifecycle === "cold" ? f.createProcess() : firstProcess;
+    return { ...f, first, process };
+  }
+
+  it.each([
+    { lifecycle: "cold", scheduled: false },
+    { lifecycle: "warm", scheduled: false },
+    { lifecycle: "unloaded-same-process", scheduled: false },
+    { lifecycle: "cold", scheduled: true },
+    { lifecycle: "warm", scheduled: true },
+    { lifecycle: "unloaded-same-process", scheduled: true },
+  ])(
+    "preserves approved apps on $lifecycle continuation, scheduled=$scheduled",
+    async ({ lifecycle, scheduled }) => {
+      const f = await continuation(scheduled, lifecycle);
+      const { first, process } = f;
+      const boundary = f.calls.length;
+      const second = await process.run();
+      expect(second.threadId).toBe(first.threadId);
+      if (lifecycle === "warm") {
+        expect(f.calls.slice(boundary).some((call) => call.method === "thread/resume")).toBe(false);
+      }
+      if (scheduled) {
+        expect(process.loadedThreads.get(second.threadId)).toMatchObject({
+          apps: { [appId]: { tools: { list: { approval_mode: "prompt" } } } },
+        });
+      }
+      expect((await f.readBinding())?.pluginAppPolicyContext?.apps[appId]).toMatchObject({
+        allowDestructiveActions: false,
+      });
+      const scopedReads = f.calls
+        .slice(boundary)
+        .filter(
+          (call) =>
+            ["app/installed", "app/read", "mcpServerStatus/list"].includes(call.method) &&
+            call.params.threadId,
+        );
+      expect(scopedReads.length).toBeGreaterThan(0);
+      expect(scopedReads.every((call) => call.loaded)).toBe(true);
+      expect(
+        scopedReads.some(
+          (call) => call.method === "app/installed" && call.params.threadId === second.threadId,
+        ),
+      ).toBe(true);
+      if (scheduled) {
+        expect(
+          scopedReads.some(
+            (call) =>
+              call.method === "mcpServerStatus/list" && call.params.threadId === second.threadId,
+          ),
+        ).toBe(true);
+      }
+    },
+  );
+
+  it("keeps revoked account apps unavailable after a cold process restart", async () => {
+    const f = await continuation(false, "cold");
+    f.revokeAccount();
+    const boundary = f.calls.length;
+    const second = await f.process.run();
+    expect(second.pluginAppPolicyContext?.apps).not.toHaveProperty(appId);
+    expect((await f.readBinding())?.pluginAppPolicyContext?.apps).not.toHaveProperty(appId);
+    const reads = f.calls
+      .slice(boundary)
+      .filter((call) => ["app/installed", "app/read"].includes(call.method));
+    expect(reads.length).toBeGreaterThan(0);
+    expect(reads.some((call) => call.params.threadId && call.loaded)).toBe(true);
+    expect(reads.every((call) => !call.params.threadId || call.loaded)).toBe(true);
+  });
+
+  it("rejects a scheduled continuation whose account app was revoked", async () => {
+    const f = await continuation(true, "cold");
+    f.revokeAccount();
+    await expect(f.process.run()).rejects.toThrow("Scheduled Codex apps are unavailable");
+  });
+
+  it("checks scheduled tools on the loaded thread even when account-wide tools remain available", async () => {
+    const f = await continuation(true, "warm");
+    const { process, first } = f;
+    process.threadToolRevocations.add(first.threadId);
+    const boundary = f.calls.length;
+    await expect(process.run()).rejects.toThrow("Scheduled Codex apps are unavailable");
+    const calls = f.calls.slice(boundary);
+    expect(
+      calls.some(
+        (call) =>
+          call.method === "mcpServerStatus/list" &&
+          call.params.threadId === first.threadId &&
+          call.loaded,
+      ),
+    ).toBe(true);
+    expect(
+      calls.filter((call) => call.method === "thread/start" || call.method === "thread/resume"),
+    ).toEqual([]);
+  });
+
+  it.each([
+    { lifecycle: "cold", fault: "abort" },
+    { lifecycle: "warm", fault: "abort" },
+    { lifecycle: "cold", fault: "replacement" },
+    { lifecycle: "warm", fault: "replacement" },
+  ])("fences $fault during $lifecycle loaded-thread admission", async ({ lifecycle, fault }) => {
+    const f = await continuation(false, lifecycle);
+    const previousBinding = await f.readBinding();
+    const entered = createDeferred<void>();
+    const release = createDeferred<void>();
+    const replacementId = "00000000-0000-4000-8000-000000000099";
+    f.process.faults.beforeInventory = async () => {
+      f.process.faults.beforeInventory = undefined;
+      entered.resolve();
+      await release.promise;
+      if (fault === "replacement") {
+        await f.replaceBinding(replacementId);
+      }
+    };
+    const boundary = f.calls.length;
+    const pending = f.process.run();
+    const rejected = expect(pending).rejects.toThrow(
+      fault === "abort" ? "admission cancelled" : "Codex thread binding changed",
+    );
+    await entered.promise;
+    if (fault === "abort") {
+      f.process.abort.abort(new Error("admission cancelled"));
+    }
+    release.resolve();
+    await rejected;
+    expect(await f.readBinding()).toEqual(
+      fault === "abort" ? previousBinding : { ...previousBinding, threadId: replacementId },
+    );
+    expect(f.process.loadedThreads.has(f.first.threadId)).toBe(false);
+    expect(f.calls.slice(boundary).some((call) => call.method === "thread/start")).toBe(false);
+  });
+
+  it.each(["cold", "warm"])(
+    "attests provisional apps on the %s loaded thread",
+    async (lifecycle) => {
+      const f = await continuation(false, lifecycle);
+      const previousBinding = await f.readBinding();
+      f.process.disabledThreadApps.add(f.first.threadId);
+      const boundary = f.calls.length;
+      await expect(f.process.run()).rejects.toThrow("did not expose admitted apps");
+      expect(await f.readBinding()).toEqual(previousBinding);
+      expect(f.process.loadedThreads.has(f.first.threadId)).toBe(false);
+      expect(f.calls.slice(boundary).some((call) => call.method === "thread/start")).toBe(false);
+    },
+  );
+
+  it.each(["cold", "warm"])(
+    "preserves the durable binding when the %s client closes during inventory",
+    async (lifecycle) => {
+      const f = await continuation(false, lifecycle);
+      const previousBinding = await f.readBinding();
+      f.process.faults.beforeInventory = async () => {
+        f.process.faults.beforeInventory = undefined;
+        f.process.close(new Error("codex app-server client is closed"));
+      };
+      const boundary = f.process.request.mock.calls.length;
+      await expect(f.process.run()).rejects.toThrow();
+      expect(await f.readBinding()).toEqual(previousBinding);
+      expect(
+        f.process.request.mock.calls.slice(boundary).some(([method]) => method === "thread/start"),
+      ).toBe(false);
+    },
+  );
+
+  it.each(["cold", "warm"])(
+    "retires the %s client when denied admission cannot unsubscribe",
+    async (lifecycle) => {
+      const f = await continuation(true, lifecycle);
+      const previousBinding = await f.readBinding();
+      f.process.threadToolRevocations.add(f.first.threadId);
+      f.process.faults.unsubscribe = new Error("unsubscribe unavailable");
+      const boundary = f.calls.length;
+      await expect(f.process.run()).rejects.toMatchObject({
+        name: "CodexAppServerUnsafeSubscriptionError",
+      });
+      expect(f.process.abandonClient).toHaveBeenCalledOnce();
+      expect(await f.readBinding()).toEqual(previousBinding);
+      expect(f.calls.slice(boundary).some((call) => call.method === "thread/start")).toBe(false);
+    },
+  );
+});

--- a/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.binding.test.ts
@@ -13,7 +13,13 @@ import {
 import { CodexAppServerClient, CodexAppServerRpcError } from "./client.js";
 import { createFakeCodexAppServerClient } from "./codex-app-server.test-fixtures.js";
 import { acquireCodexNativeConfigFence } from "./native-config-fence.js";
-import type { CodexDynamicToolFunctionSpec, JsonValue, RpcRequest } from "./protocol.js";
+import type { PluginAppPolicyContext } from "./plugin-thread-config.js";
+import type {
+  CodexDynamicToolFunctionSpec,
+  JsonObject,
+  JsonValue,
+  RpcRequest,
+} from "./protocol.js";
 import {
   createParams as createRunAttemptParams,
   setupRunAttemptTestHooks,
@@ -1380,6 +1386,7 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(conflictBindingStore.mutate).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ kind: "patch", threadId: "thread-warm-conflict" }),
+      expect.any(Function),
     );
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/start",
@@ -4428,7 +4435,61 @@ describe("Codex app-server thread lifecycle bindings", () => {
     });
   });
 
-  it("starts a new plugin app thread when full binding revalidation removes an app", async () => {
+  it.each<{
+    name: string;
+    previousFingerprint: string;
+    previousPolicyContext: PluginAppPolicyContext;
+    configPatch: JsonObject;
+    fingerprint: string;
+    policyContext: PluginAppPolicyContext;
+    enabledPluginConfigKeys: string[];
+  }>([
+    {
+      name: "full binding revalidation removes an app",
+      previousFingerprint: "plugin-apps-config-1",
+      previousPolicyContext: createPluginAppPolicyContext(),
+      configPatch: {
+        apps: {
+          _default: { enabled: false, destructive_enabled: false, open_world_enabled: false },
+        },
+      },
+      fingerprint: "plugin-apps-empty",
+      policyContext: { fingerprint: "plugin-policy-empty", apps: {}, pluginAppIds: {} },
+      enabledPluginConfigKeys: ["google-calendar"],
+    },
+    {
+      name: "app inventory recovers for an empty binding",
+      previousFingerprint: "plugin-apps-empty",
+      previousPolicyContext: { fingerprint: "plugin-policy-empty", apps: {}, pluginAppIds: {} },
+      configPatch: createPluginAppConfigPatch(),
+      fingerprint: "plugin-apps-config-1",
+      policyContext: createPluginAppPolicyContext(),
+      enabledPluginConfigKeys: [],
+    },
+    {
+      name: "another plugin recovers for a partial binding",
+      previousFingerprint: "plugin-apps-partial",
+      previousPolicyContext: createPluginAppPolicyContext(),
+      configPatch: createTwoPluginAppConfigPatch(),
+      fingerprint: "plugin-apps-config-2",
+      policyContext: createTwoPluginAppPolicyContext(),
+      enabledPluginConfigKeys: ["google-calendar", "gmail"],
+    },
+    {
+      name: "another app from the same plugin recovers for a partial binding",
+      previousFingerprint: "plugin-apps-partial",
+      previousPolicyContext: {
+        ...createPluginAppPolicyContext(),
+        pluginAppIds: {
+          "google-calendar": ["google-calendar-app", "google-calendar-secondary-app"],
+        },
+      },
+      configPatch: createTwoCalendarAppConfigPatch(),
+      fingerprint: "plugin-apps-config-calendar-2",
+      policyContext: createTwoCalendarAppPolicyContext(),
+      enabledPluginConfigKeys: ["google-calendar"],
+    },
+  ])("rotates the loaded plugin app thread when $name", async (scenario) => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
     await writeCodexAppServerBinding(sessionFile, {
@@ -4437,33 +4498,29 @@ describe("Codex app-server thread lifecycle bindings", () => {
       model: "gpt-5.4-codex",
       modelProvider: "openai",
       dynamicToolsFingerprint: "[]",
-      pluginAppsFingerprint: "plugin-apps-config-1",
+      pluginAppsFingerprint: scenario.previousFingerprint,
       pluginAppsInputFingerprint: "plugin-apps-input-1",
-      pluginAppPolicyContext: createPluginAppPolicyContext(),
+      pluginAppPolicyContext: scenario.previousPolicyContext,
     });
     const params = createParams(sessionFile, workspaceDir);
-    const appServer = createThreadLifecycleAppServerOptions();
-    const request = vi.fn(async (method: string) => {
+    const request = vi.fn(async (method: string, _requestParams?: unknown) => {
       if (method === "thread/start") {
-        return threadStartResult("thread-revalidated");
+        return threadStartResult("thread-recovered");
+      }
+      if (method === "thread/resume") {
+        return threadStartResult("thread-existing");
+      }
+      if (method === "thread/unsubscribe") {
+        return { status: "unsubscribed" };
       }
       throw new Error(`unexpected method: ${method}`);
     });
-    const emptyPolicyContext = { fingerprint: "plugin-policy-empty", apps: {}, pluginAppIds: {} };
     const buildPluginThreadConfig = vi.fn(async () => ({
       enabled: true,
-      configPatch: {
-        apps: {
-          _default: {
-            enabled: false,
-            destructive_enabled: false,
-            open_world_enabled: false,
-          },
-        },
-      },
-      fingerprint: "plugin-apps-empty",
+      configPatch: scenario.configPatch,
+      fingerprint: scenario.fingerprint,
       inputFingerprint: "plugin-apps-input-1",
-      policyContext: emptyPolicyContext,
+      policyContext: scenario.policyContext,
       diagnostics: [],
     }));
 
@@ -4472,32 +4529,31 @@ describe("Codex app-server thread lifecycle bindings", () => {
       params,
       cwd: workspaceDir,
       dynamicTools: [],
-      appServer,
+      appServer: createThreadLifecycleAppServerOptions(),
       pluginThreadConfig: {
         enabled: true,
         inputFingerprint: "plugin-apps-input-1",
-        enabledPluginConfigKeys: ["google-calendar"],
+        enabledPluginConfigKeys: scenario.enabledPluginConfigKeys,
         build: buildPluginThreadConfig,
       },
     });
 
     expect(buildPluginThreadConfig).toHaveBeenCalledTimes(1);
-    const requestCalls = request.mock.calls as unknown as Array<[string, { config?: unknown }]>;
-    expect(requestCalls.map(([method]) => method)).toEqual(["thread/start"]);
-    expect(requestCalls[0]?.[1].config).toEqual({
-      ...DEFAULT_CODEX_RUNTIME_THREAD_CONFIG,
-      apps: {
-        _default: {
-          enabled: false,
-          destructive_enabled: false,
-          open_world_enabled: false,
-        },
-      },
+    expect(request.mock.calls.map(([method]) => method)).toEqual([
+      "thread/resume",
+      "thread/unsubscribe",
+      "thread/start",
+    ]);
+    expect(request.mock.calls.at(-1)?.[1]).toEqual(
+      expect.objectContaining({
+        config: { ...DEFAULT_CODEX_RUNTIME_THREAD_CONFIG, ...scenario.configPatch },
+      }),
+    );
+    expect(await readCodexAppServerBinding(sessionFile)).toMatchObject({
+      threadId: "thread-recovered",
+      pluginAppsFingerprint: scenario.fingerprint,
+      pluginAppPolicyContext: scenario.policyContext,
     });
-    const binding = await readCodexAppServerBinding(sessionFile);
-    expect(binding?.threadId).toBe("thread-revalidated");
-    expect(binding?.pluginAppsFingerprint).toBe("plugin-apps-empty");
-    expect(binding?.pluginAppPolicyContext).toEqual(emptyPolicyContext);
   });
 
   it("keeps the existing plugin app binding when revalidation fails", async () => {
@@ -4549,63 +4605,6 @@ describe("Codex app-server thread lifecycle bindings", () => {
     expect(binding?.threadId).toBe("thread-existing");
     expect(binding?.pluginAppsFingerprint).toBe("plugin-apps-config-1");
     expect(binding?.pluginAppsInputFingerprint).toBe("plugin-apps-input-1");
-    expect(binding?.pluginAppPolicyContext).toEqual(pluginAppPolicyContext);
-  });
-
-  it("rebuilds an empty plugin app binding after app inventory recovers", async () => {
-    const sessionFile = path.join(tempDir, "session.jsonl");
-    const workspaceDir = path.join(tempDir, "workspace");
-    await writeCodexAppServerBinding(sessionFile, {
-      threadId: "thread-existing",
-      cwd: workspaceDir,
-      model: "gpt-5.4-codex",
-      modelProvider: "openai",
-      dynamicToolsFingerprint: "[]",
-      pluginAppsFingerprint: "plugin-apps-empty",
-      pluginAppsInputFingerprint: "plugin-apps-input-1",
-      pluginAppPolicyContext: { fingerprint: "plugin-policy-empty", apps: {}, pluginAppIds: {} },
-    });
-    const params = createParams(sessionFile, workspaceDir);
-    const appServer = createThreadLifecycleAppServerOptions();
-    const request = vi.fn(async (method: string) => {
-      if (method === "thread/start") {
-        return threadStartResult("thread-recovered");
-      }
-      throw new Error(`unexpected method: ${method}`);
-    });
-    const pluginAppPolicyContext = createPluginAppPolicyContext();
-    const buildPluginThreadConfig = vi.fn(async () => ({
-      enabled: true,
-      configPatch: createPluginAppConfigPatch(),
-      fingerprint: "plugin-apps-config-1",
-      inputFingerprint: "plugin-apps-input-1",
-      policyContext: pluginAppPolicyContext,
-      diagnostics: [],
-    }));
-
-    await startOrResumeThread({
-      client: { request } as never,
-      params,
-      cwd: workspaceDir,
-      dynamicTools: [],
-      appServer,
-      pluginThreadConfig: {
-        enabled: true,
-        inputFingerprint: "plugin-apps-input-1",
-        build: buildPluginThreadConfig,
-      },
-    });
-
-    expect(buildPluginThreadConfig).toHaveBeenCalledTimes(1);
-    const requestCalls = request.mock.calls as unknown as Array<[string, { config?: unknown }]>;
-    expect(requestCalls.map(([method]) => method)).toEqual(["thread/start"]);
-    expect(requestCalls[0]?.[1].config).toEqual({
-      ...createPluginAppConfigPatch(),
-      ...DEFAULT_CODEX_RUNTIME_THREAD_CONFIG,
-    });
-    const binding = await readCodexAppServerBinding(sessionFile);
-    expect(binding?.threadId).toBe("thread-recovered");
-    expect(binding?.pluginAppsFingerprint).toBe("plugin-apps-config-1");
     expect(binding?.pluginAppPolicyContext).toEqual(pluginAppPolicyContext);
   });
 
@@ -4674,127 +4673,6 @@ describe("Codex app-server thread lifecycle bindings", () => {
         },
       },
     });
-  });
-
-  it("rebuilds a partial plugin app binding after another plugin recovers", async () => {
-    const sessionFile = path.join(tempDir, "session.jsonl");
-    const workspaceDir = path.join(tempDir, "workspace");
-    await writeCodexAppServerBinding(sessionFile, {
-      threadId: "thread-existing",
-      cwd: workspaceDir,
-      model: "gpt-5.4-codex",
-      modelProvider: "openai",
-      dynamicToolsFingerprint: "[]",
-      pluginAppsFingerprint: "plugin-apps-partial",
-      pluginAppsInputFingerprint: "plugin-apps-input-1",
-      pluginAppPolicyContext: createPluginAppPolicyContext(),
-    });
-    const params = createParams(sessionFile, workspaceDir);
-    const appServer = createThreadLifecycleAppServerOptions();
-    const request = vi.fn(async (method: string) => {
-      if (method === "thread/start") {
-        return threadStartResult("thread-recovered");
-      }
-      throw new Error(`unexpected method: ${method}`);
-    });
-    const recoveredPolicyContext = createTwoPluginAppPolicyContext();
-    const buildPluginThreadConfig = vi.fn(async () => ({
-      enabled: true,
-      configPatch: createTwoPluginAppConfigPatch(),
-      fingerprint: "plugin-apps-config-2",
-      inputFingerprint: "plugin-apps-input-1",
-      policyContext: recoveredPolicyContext,
-      diagnostics: [],
-    }));
-
-    await startOrResumeThread({
-      client: { request } as never,
-      params,
-      cwd: workspaceDir,
-      dynamicTools: [],
-      appServer,
-      pluginThreadConfig: {
-        enabled: true,
-        inputFingerprint: "plugin-apps-input-1",
-        enabledPluginConfigKeys: ["google-calendar", "gmail"],
-        build: buildPluginThreadConfig,
-      },
-    });
-
-    expect(buildPluginThreadConfig).toHaveBeenCalledTimes(1);
-    const requestCalls = request.mock.calls as unknown as Array<[string, { config?: unknown }]>;
-    expect(requestCalls.map(([method]) => method)).toEqual(["thread/start"]);
-    expect(requestCalls[0]?.[1].config).toEqual({
-      ...createTwoPluginAppConfigPatch(),
-      ...DEFAULT_CODEX_RUNTIME_THREAD_CONFIG,
-    });
-    const binding = await readCodexAppServerBinding(sessionFile);
-    expect(binding?.threadId).toBe("thread-recovered");
-    expect(binding?.pluginAppsFingerprint).toBe("plugin-apps-config-2");
-    expect(binding?.pluginAppPolicyContext).toEqual(recoveredPolicyContext);
-  });
-
-  it("rebuilds a partial plugin app binding after another app from the same plugin recovers", async () => {
-    const sessionFile = path.join(tempDir, "session.jsonl");
-    const workspaceDir = path.join(tempDir, "workspace");
-    await writeCodexAppServerBinding(sessionFile, {
-      threadId: "thread-existing",
-      cwd: workspaceDir,
-      model: "gpt-5.4-codex",
-      modelProvider: "openai",
-      dynamicToolsFingerprint: "[]",
-      pluginAppsFingerprint: "plugin-apps-partial",
-      pluginAppsInputFingerprint: "plugin-apps-input-1",
-      pluginAppPolicyContext: {
-        ...createPluginAppPolicyContext(),
-        pluginAppIds: {
-          "google-calendar": ["google-calendar-app", "google-calendar-secondary-app"],
-        },
-      },
-    });
-    const params = createParams(sessionFile, workspaceDir);
-    const appServer = createThreadLifecycleAppServerOptions();
-    const request = vi.fn(async (method: string) => {
-      if (method === "thread/start") {
-        return threadStartResult("thread-recovered");
-      }
-      throw new Error(`unexpected method: ${method}`);
-    });
-    const recoveredPolicyContext = createTwoCalendarAppPolicyContext();
-    const buildPluginThreadConfig = vi.fn(async () => ({
-      enabled: true,
-      configPatch: createTwoCalendarAppConfigPatch(),
-      fingerprint: "plugin-apps-config-calendar-2",
-      inputFingerprint: "plugin-apps-input-1",
-      policyContext: recoveredPolicyContext,
-      diagnostics: [],
-    }));
-
-    await startOrResumeThread({
-      client: { request } as never,
-      params,
-      cwd: workspaceDir,
-      dynamicTools: [],
-      appServer,
-      pluginThreadConfig: {
-        enabled: true,
-        inputFingerprint: "plugin-apps-input-1",
-        enabledPluginConfigKeys: ["google-calendar"],
-        build: buildPluginThreadConfig,
-      },
-    });
-
-    expect(buildPluginThreadConfig).toHaveBeenCalledTimes(1);
-    const requestCalls = request.mock.calls as unknown as Array<[string, { config?: unknown }]>;
-    expect(requestCalls.map(([method]) => method)).toEqual(["thread/start"]);
-    expect(requestCalls[0]?.[1].config).toEqual({
-      ...createTwoCalendarAppConfigPatch(),
-      ...DEFAULT_CODEX_RUNTIME_THREAD_CONFIG,
-    });
-    const binding = await readCodexAppServerBinding(sessionFile);
-    expect(binding?.threadId).toBe("thread-recovered");
-    expect(binding?.pluginAppsFingerprint).toBe("plugin-apps-config-calendar-2");
-    expect(binding?.pluginAppPolicyContext).toEqual(recoveredPolicyContext);
   });
 
   it("starts a new configured thread for legacy bindings missing plugin app metadata", async () => {

--- a/extensions/codex/src/app-server/thread-lifecycle.test.ts
+++ b/extensions/codex/src/app-server/thread-lifecycle.test.ts
@@ -2796,46 +2796,6 @@ describe("Codex plugin binding recovery", () => {
     expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start", "thread/resume"]);
   });
 
-  it("rechecks scheduled current policy against the exact existing thread", async () => {
-    const sessionFile = path.join(tempDir, "session-current-policy.jsonl");
-    const workspaceDir = path.join(tempDir, "workspace-current-policy");
-    const params = createThreadLifecycleParams(sessionFile, workspaceDir);
-    const request = vi.fn(async (method: string) => {
-      if (method === "thread/start" || method === "thread/resume") {
-        return threadStartResult("thread-current-policy");
-      }
-      throw new Error(`unexpected method: ${method}`);
-    });
-    const build = vi.fn(async (_options?: { threadId?: string }) => ({
-      enabled: true,
-      configPatch: { apps: { _default: { enabled: false } } },
-      fingerprint: "plugin-config-current-policy",
-      inputFingerprint: "plugin-input-current-policy",
-      policyContext: { fingerprint: "plugin-policy-current", apps: {}, pluginAppIds: {} },
-      diagnostics: [],
-    }));
-    const common = {
-      client: { request } as never,
-      params,
-      cwd: workspaceDir,
-      dynamicTools: [],
-      appServer: createThreadLifecycleAppServerOptions(),
-      pluginThreadConfig: {
-        enabled: true,
-        requiresCurrentPolicyCheck: true,
-        inputFingerprint: "plugin-input-current-policy",
-        build,
-      },
-    };
-
-    await startOrResumeThread(common);
-    await startOrResumeThread(common);
-
-    expect(build).toHaveBeenNthCalledWith(1);
-    expect(build).toHaveBeenNthCalledWith(2, { threadId: "thread-current-policy" });
-    expect(request.mock.calls.map(([method]) => method)).toEqual(["thread/start", "thread/resume"]);
-  });
-
   it("rebuilds once when a settled negative binding still enables the plugin", async () => {
     const sessionFile = path.join(tempDir, "session.jsonl");
     const workspaceDir = path.join(tempDir, "workspace");
@@ -2843,6 +2803,9 @@ describe("Codex plugin binding recovery", () => {
     const request = vi.fn(async (method: string) => {
       if (method === "thread/start" || method === "thread/resume") {
         return threadStartResult("thread-settled-transition");
+      }
+      if (method === "thread/unsubscribe") {
+        return { status: "unsubscribed" };
       }
       throw new Error(`unexpected method: ${method}`);
     });
@@ -2907,6 +2870,8 @@ describe("Codex plugin binding recovery", () => {
     expect(build).toHaveBeenCalledTimes(2);
     expect(request.mock.calls.map(([method]) => method)).toEqual([
       "thread/start",
+      "thread/resume",
+      "thread/unsubscribe",
       "thread/start",
       "thread/resume",
     ]);
@@ -3014,6 +2979,7 @@ describe("Codex plugin binding recovery", () => {
       "thread/start",
       "app/installed",
       "thread/resume",
+      "app/installed",
     ]);
     expect(threadStarts).toHaveLength(3);
     expect(threadStarts[1]?.config).toMatchObject({


### PR DESCRIPTION
Related: #133985

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where users continuing a Codex conversation after an app-server restart could lose their existing thread or encounter `thread not found` while checking available apps. Scheduled continuations could fail before applying their captured app permissions. A related interruption race could discard a valid saved binding when a warm client closed during the inventory check.

This addresses the thread-scoped inventory failure reported in #133985. The separate `deps.refreshOpenAICodexToken is not a function` error remains unexplained; this PR does not resolve or close the entire issue.

## Why This Change Was Made

A persisted thread ID does not establish that the thread is loaded in the current Codex process. The lifecycle previously queried scoped inventory before claiming a retained thread or resuming a cold one. The repair moves that check into the lifecycle owner: claim or load the exact thread, then validate its current app policy and attestation before committing or returning the binding. Scheduled cold resumes first construct the complete config, including per-tool approval limits, and then validate the loaded thread.

Warm reuse now has one generation-bound claim and one cleanup owner, replacing duplicate consumption and downstream release handling. Existing client-liveness checks also fence the new asynchronous admission boundary. Abort, replacement, policy denial, and cleanup failure retain their existing ownership protections; there are no new configuration options, defaults, storage formats, schemas, or retries.

**Provenance:** unknown. The failure is reproduced and the violated dependency contract is verified, but no introducing commit or author has been established. Current upstream Codex source was inspected at `d58d0e5841e0de08e251673db2d5af8cf3a1ad51`: [scoped app configuration requires a loaded thread](https://github.com/openai/codex/blob/d58d0e5841e0de08e251673db2d5af8cf3a1ad51/codex-rs/app-server/src/request_processors/apps_processor.rs#L331-L366), called by `apps_processor/installed.rs:50`. Related MCP status and per-tool policy owners were also checked.

**Size:** production +235/-195, net **+40**; tests +642/-254, net **+388**. Reusing the existing request context and consolidating claim/release paths absorbs much of the repair. The remaining production growth implements the required distinction between planning config, loading the thread, and admitting its exact policy, plus the observed client-close race. Replacing scoped checks with account-wide inventory would miss thread-specific revocation and is not an equivalent repair.

## User Impact

Compatible conversations retain their existing thread after an app-server restart. Warm continuations avoid unnecessary resume calls. Scheduled continuations preserve captured tool-approval limits, revoked or unattested apps remain unavailable, and an interrupted inventory check does not erase a valid binding.

## Evidence

- Failure-first lifecycle tests reproduced cold and unloaded-thread failures. The original nine-case baseline had six failures; one overly specific revocation assertion was corrected and independently failed again on unchanged production. A separate close-during-inventory regression reproduced warm binding deletion while the cold control passed.
- Final frozen run: **523/523 tests passed across ten files**, comprising **19 focused regressions and 504 existing owner/sibling cases**. Coverage includes ordinary and scheduled continuation, exact-thread revocation, per-tool approval ceilings, provisional-app attestation, abort, binding replacement/CAS, physical close, and unsafe cleanup. The focused file is `extensions/codex/src/app-server/thread-lifecycle.app-inventory.test.ts` and runs with `node scripts/run-vitest.mjs`.
- Changed-gate structural, contract, dead-export, and production type checks passed. Test typing and fixture lint failures were corrected; exact test typecheck, formatting, and changed-file lint replays passed. Fresh isolated Codex autoreview was scoped-clean at its requested P0 threshold. Source hashes remained unchanged through final tests and review.
- **Real managed Codex 0.151.0 runtime: 2/2 temporary probe cases passed.** Process one persisted a thread with injected synthetic history. In a fresh process, scoped `app/installed` first rejected with `-32600`; the actual lifecycle then resumed the same thread before successful scoped inventory. Warm reuse performed neither `thread/start` nor `thread/resume`. All three child processes were joined and gone after cleanup, and production source hashes stayed unchanged. Native binary SHA-256: `98491713ffb196061003ee148636e743997cc31d76144ba7c53462269896891d`.

The native probe used isolated, unauthenticated state with empty app inventory, actual Codex thread persistence, and the canonical binding owner backed by a test map. It requested no model turn and recorded zero requests to its configured model HTTP endpoint; this does not claim complete outbound-network isolation. Account apps, OAuth refresh, and scheduled permissions were not authenticated-live-tested. Native unsubscribe retained the idle thread, so same-process unloaded behavior is covered by the regression fixture, not claimed as native proof. The first probe launch failed an isolation path-canonicalization guard before starting clients; the canonicalized launcher passed without changing the test or guard. The temporary probe was removed after completion.

## Release Note

- Codex: preserve conversations and scheduled app permissions across app-server restarts, and keep saved bindings intact when an inventory check is interrupted. Thanks @climbingNight for reporting the inventory failure.


## Executed native policy follow-through


Passed on OpenClaw `142b6f568c3cb505d87bb786b5d9825788a970d5` with the real managed Codex app-server `0.151.0`. One integration sequence passed (20.66 seconds total; 3.79 seconds in the test). The real OpenClaw attempt, prepared-profile auth handoff, config builder, thread lifecycle, scheduled authority capture/intersection, native model turn and built-in app MCP handler remained in the path.

**This uses synthetic ChatGPT-mode fixture auth and loopback Responses/app MCP services.** It does not use paid model inference, real account credentials, real remote app revocation, the real scheduler database, or production SQLite bindings. The canonical binding owner runs over its existing test map. It does not prove OAuth refresh or resolve the separate refresh TypeError reported in #133985.

| Scenario | Physical process | Thread | New model requests | Endpoint effect count after scenario | Result |
|---|---:|---:|---:|---:|---|
| Ordinary allowed | 1 | 1 | 3 | 1 | Real model-dispatched app call returned its endpoint result |
| Ordinary after physical restart | 2 | 1 | 2 | 2 | Same native thread resumed; real app call succeeded |
| Captured scheduled authority allowed | 2 | 2 | 2 | 3 | Normal scheduled policy established its own binding; real app call succeeded |
| Scheduled after physical restart | 3 | 2 | 2 | 4 | Same scheduled thread resumed, then scoped inventory/attestation; real app call succeeded |
| Scheduled after local app disable, warm | 3 | 2 | 0 | 4 | Refused before turn/model/tool call; binding preserved |
| Scheduled after local app disable, cold | 4 | — | 0 | 4 | Refused before turn/model/tool call; binding preserved |

The backend stayed available for both denied attempts; its counter increments on every `tools/call` before checking the requested tool. Only the disposable native app policy changed, through `config/value/write` for `apps.policy-fixture.enabled=false`. The captured scheduled authority was unchanged. Denial therefore represents the actual admission outcome, not a disabled endpoint or a synthetic “deny” response. Direct `mcpServer/tool/call` RPC was forbidden by the fixture.

Ordinary settled account-app reuse intentionally does not always re-read inventory. The mandatory loaded-thread check is shown separately on the captured scheduled restart. The transition into scheduled authority legitimately starts a new thread because its policy input changes; the subsequent physical restart preserves that scheduled thread.

Selected settled native events (IDs are scenario-local ordinals; no native thread/account identifiers):

| Sequence | Scenario | Process | RPC | Thread | Outcome |
|---:|---|---:|---|---:|---|
| 6 | allowed-first | 1 | app/installed | — | resolved {"enabled":true,"callable":true} |
| 9 | allowed-first | 1 | app/installed | — | resolved {"enabled":true,"callable":true} |
| 18 | allowed-first | 1 | thread/start | — | resolved |
| 21 | allowed-first | 1 | app/installed | 1 | resolved {"enabled":true,"callable":true} |
| 23 | allowed-first | 1 | turn/start | 1 | resolved |
| 42 | allowed-after-cold-restart | 2 | app/installed | — | resolved {"enabled":true,"callable":true} |
| 46 | allowed-after-cold-restart | 2 | thread/resume | 1 | resolved |
| 49 | allowed-after-cold-restart | 2 | turn/start | 1 | resolved |
| 64 | capture-scheduled-authority | 2 | app/installed | 1 | resolved {"enabled":true,"callable":true} |
| 91 | scheduled-allowed | 2 | thread/start | — | resolved |
| 94 | scheduled-allowed | 2 | app/installed | 2 | resolved {"enabled":true,"callable":true} |
| 97 | scheduled-allowed | 2 | turn/start | 2 | resolved |
| 114 | scheduled-allowed-after-cold-restart | 3 | app/installed | — | resolved {"enabled":true,"callable":true} |
| 131 | scheduled-allowed-after-cold-restart | 3 | thread/resume | 2 | resolved |
| 135 | scheduled-allowed-after-cold-restart | 3 | app/installed | 2 | resolved {"enabled":true,"callable":true} |
| 153 | scheduled-allowed-after-cold-restart | 3 | app/installed | 2 | resolved {"enabled":true,"callable":true} |
| 155 | scheduled-allowed-after-cold-restart | 3 | turn/start | 2 | resolved |
| 168 | local-app-revocation | 3 | config/value/write | — | resolved |
| 190 | scheduled-revoked-cold | 4 | app/installed | — | resolved {"enabled":false,"callable":false} |

Native SHA-256: `98491713ffb196061003ee148636e743997cc31d76144ba7c53462269896891d`. Temporary proof SHA-256: `bfdd586bd257afb7b16c733a3f7ae5442d9927252431f3ac9c74cb90a1ddd593`. All four native processes were closed, joined, and checked absent. The loopback HTTP server and MCP transports closed. All three production owner hashes and the temporary test hash were unchanged during the successful run; the detailed JSON receipt includes these hashes and the complete allowlisted event trace.

Prior fixture failures are preserved: (1) pre-client missing Vitest XDG directory, corrected by creating only expected children after immediate-parent canonical containment checks; (2) an overbroad ordinary settled-account inventory assertion, corrected by retaining the ordinary positive control and adding the required scheduled restart; (3) final diagnostics rejected native OAuth-discovery probes as unexpected despite all behavior checks passing. Exact observed ancillary and OAuth-discovery paths now remain HTTP 404 and are recorded separately. No successful OAuth response, production change, policy guard relaxation, timeout increase, or broad success stub was introduced.

The 404 ancillary paths cover native model/plugin catalog probes, settings, analytics, and OAuth metadata discovery. Unknown paths still fail. Native source downgrades built-in app MCP auth for an untrusted loopback host and may query OAuth support during status inventory; absence of discovered authorization metadata means unsupported OAuth, not a granted credential.

Dependency contracts personally inspected in the literal sibling checkout:

- [Loaded-thread requirement for scoped app config](https://github.com/openai/codex/blob/d58d0e5841e0de08e251673db2d5af8cf3a1ad51/codex-rs/app-server/src/request_processors/apps_processor.rs#L331-L366).
- [Installed inventory owner](https://github.com/openai/codex/blob/d58d0e5841e0de08e251673db2d5af8cf3a1ad51/codex-rs/app-server/src/request_processors/apps_processor/installed.rs#L49-L171).
- [Native model app policy before tool dispatch](https://github.com/openai/codex/blob/d58d0e5841e0de08e251673db2d5af8cf3a1ad51/codex-rs/core/src/mcp_tool_call.rs#L177-L231).
- [Upstream native app fixture with temporary config and synthetic auth](https://github.com/openai/codex/blob/d58d0e5841e0de08e251673db2d5af8cf3a1ad51/codex-rs/app-server/tests/suite/v2/app_installed.rs#L212-L242).
- [Loopback auth gating](https://github.com/openai/codex/blob/d58d0e5841e0de08e251673db2d5af8cf3a1ad51/codex-rs/codex-mcp/src/mcp/mod.rs#L339-L403) and [OAuth metadata discovery handling](https://github.com/openai/codex/blob/d58d0e5841e0de08e251673db2d5af8cf3a1ad51/codex-rs/rmcp-client/src/auth_status.rs#L267-L282).

The local source inspection was against the fetched immutable OSS commit above; the independent executable proof identifies the actual managed binary by version and SHA-256, without claiming an unavailable local release-tag match.


<details>
<summary>Executed native policy receipt (complete allowlisted event trace)</summary>

```json
{"openclawHead":"142b6f568c3cb505d87bb786b5d9825788a970d5","passed":true,"commandExit":0,"vitestTests":{"passed":1,"failed":0,"durationSeconds":20.66},"sourceUnchanged":true,"sourceHashes":{"thread-lifecycle-run.ts":"1a5a8a9e9336ba8afb952132dbac0a3399fb173540ed3dfd27017df72e4c64c7","thread-lifecycle-io.ts":"fe377102858707c203ff81f236da213ae222f2cb42f402959a6622c39cc885c8","thread-lifecycle-warm.ts":"e8c2d487b1111f03ae214f0637af53ac3d540b12b5a899a8de3486da5d996d98","thread-lifecycle.app-policy.real-binary.live.test.ts":"bfdd586bd257afb7b16c733a3f7ae5442d9927252431f3ac9c74cb90a1ddd593"},"nativeBinaries":[{"process":1,"version":"0.151.0","nativeSha256":"98491713ffb196061003ee148636e743997cc31d76144ba7c53462269896891d"},{"process":2,"version":"0.151.0","nativeSha256":"98491713ffb196061003ee148636e743997cc31d76144ba7c53462269896891d"},{"process":3,"version":"0.151.0","nativeSha256":"98491713ffb196061003ee148636e743997cc31d76144ba7c53462269896891d"},{"process":4,"version":"0.151.0","nativeSha256":"98491713ffb196061003ee148636e743997cc31d76144ba7c53462269896891d"}],"scenarios":[{"phase":"allowed-first","nativeProcesses":[1],"threadOrdinals":[1],"turnsStarted":1,"modelRequests":3,"endpointEffects":[1],"policyDenialBeforeTurnAsserted":false},{"phase":"allowed-after-cold-restart","nativeProcesses":[2],"threadOrdinals":[1],"turnsStarted":1,"modelRequests":2,"endpointEffects":[2],"policyDenialBeforeTurnAsserted":false},{"phase":"capture-scheduled-authority","nativeProcesses":[2],"threadOrdinals":[1],"turnsStarted":0,"modelRequests":0,"endpointEffects":[],"policyDenialBeforeTurnAsserted":false},{"phase":"scheduled-allowed","nativeProcesses":[2],"threadOrdinals":[1,2],"turnsStarted":1,"modelRequests":2,"endpointEffects":[3],"policyDenialBeforeTurnAsserted":false},{"phase":"scheduled-allowed-after-cold-restart","nativeProcesses":[3],"threadOrdinals":[2],"turnsStarted":1,"modelRequests":2,"endpointEffects":[4],"policyDenialBeforeTurnAsserted":false},{"phase":"local-app-revocation","nativeProcesses":[3],"threadOrdinals":[],"turnsStarted":0,"modelRequests":0,"endpointEffects":[],"policyDenialBeforeTurnAsserted":false},{"phase":"scheduled-revoked-warm","nativeProcesses":[3],"threadOrdinals":[2],"turnsStarted":0,"modelRequests":0,"endpointEffects":[],"policyDenialBeforeTurnAsserted":true},{"phase":"scheduled-revoked-cold","nativeProcesses":[4],"threadOrdinals":[],"turnsStarted":0,"modelRequests":0,"endpointEffects":[],"policyDenialBeforeTurnAsserted":true}],"assertions":{"ordinaryRestartPreservedThread":true,"scheduledRestartPreservedThread":true,"scheduledScopedInventoryAfterResume":true,"revokedWarmPreservedBinding":true,"revokedColdPreservedBinding":true,"directMcpToolCallRpcForbidden":true},"counters":{"effects":4,"modelRequests":9},"unexpectedFixtureRoutes":[],"traceOverflow":false,"cleanup":[{"process":1,"joined":true,"gone":true},{"process":2,"joined":true,"gone":true},{"process":3,"joined":true,"gone":true},{"process":4,"joined":true,"gone":true}],"limits":{"realAccountCredentials":false,"accountPermissionsModified":false,"syntheticChatgptAuth":true,"realNativeBinary":true,"realOpenClawAttempt":true,"syntheticModelResponses":true,"realProviderInference":false,"actualSchedulerStore":false,"bindingBackend":"canonical-owner-test-map","remoteAccountRevocation":false,"oauthRefresh":false,"completeOutboundIsolation":false},"events":[{"sequence":1,"phase":"allowed-first","surface":"ancillary","method":"GET:/plugins/featured","response":404},{"sequence":2,"phase":"allowed-first","surface":"ancillary","method":"GET:/ps/plugins/suggested/codex","response":404},{"sequence":3,"phase":"allowed-first","surface":"ancillary","method":"GET:/ps/plugins/installed","response":404},{"sequence":4,"phase":"allowed-first","surface":"native","process":1,"method":"app/installed","thread":null,"event":"sent"},{"sequence":5,"phase":"allowed-first","surface":"mcp","method":"tools/list"},{"sequence":6,"phase":"allowed-first","surface":"native","process":1,"method":"app/installed","thread":null,"event":"resolved","fixtureApp":{"enabled":true,"callable":true}},{"sequence":7,"phase":"allowed-first","surface":"native","process":1,"method":"app/installed","thread":null,"event":"sent"},{"sequence":8,"phase":"allowed-first","surface":"mcp","method":"tools/list"},{"sequence":9,"phase":"allowed-first","surface":"native","process":1,"method":"app/installed","thread":null,"event":"resolved","fixtureApp":{"enabled":true,"callable":true}},{"sequence":10,"phase":"allowed-first","surface":"native","process":1,"method":"app/read","thread":null,"event":"sent"},{"sequence":11,"phase":"allowed-first","surface":"metadata","method":"apps/batch","fixtureRequested":true},{"sequence":12,"phase":"allowed-first","surface":"native","process":1,"method":"app/read","thread":null,"event":"resolved"},{"sequence":13,"phase":"allowed-first","surface":"native","process":1,"method":"config/read","thread":null,"event":"sent"},{"sequence":14,"phase":"allowed-first","surface":"native","process":1,"method":"config/read","thread":null,"event":"resolved"},{"sequence":15,"phase":"allowed-first","surface":"native","process":1,"method":"thread/start","thread":null,"event":"sent"},{"sequence":16,"phase":"allowed-first","surface":"ancillary","method":"GET:/v1/models","response":404},{"sequence":17,"phase":"allowed-first","surface":"mcp","method":"tools/list"},{"sequence":18,"phase":"allowed-first","surface":"native","process":1,"method":"thread/start","thread":null,"event":"resolved"},{"sequence":19,"phase":"allowed-first","surface":"native","process":1,"method":"app/installed","thread":1,"event":"sent"},{"sequence":20,"phase":"allowed-first","surface":"ancillary","method":"POST:/codex/analytics-events/events","response":404},{"sequence":21,"phase":"allowed-first","surface":"native","process":1,"method":"app/installed","thread":1,"event":"resolved","fixtureApp":{"enabled":true,"callable":true}},{"sequence":22,"phase":"allowed-first","surface":"native","process":1,"method":"turn/start","thread":1,"event":"sent"},{"sequence":23,"phase":"allowed-first","surface":"native","process":1,"method":"turn/start","thread":1,"event":"resolved"},{"sequence":24,"phase":"allowed-first","surface":"ancillary","method":"GET:/ps/plugins/suggested/codex","response":404},{"sequence":25,"phase":"allowed-first","surface":"ancillary","method":"GET:/api/codex/settings/user","response":404},{"sequence":26,"phase":"allowed-first","surface":"ancillary","method":"GET:/ps/plugins/suggested/codex","response":404},{"sequence":27,"phase":"allowed-first","surface":"model","method":"responses","step":1,"fixtureNamespaceObserved":false},{"sequence":28,"phase":"allowed-first","surface":"ancillary","method":"GET:/ps/plugins/suggested/codex","response":404},{"sequence":29,"phase":"allowed-first","surface":"model","method":"responses","step":2,"fixtureNamespaceObserved":true},{"sequence":30,"phase":"allowed-first","surface":"mcp","method":"tools/call","fixtureTool":true,"effects":1},{"sequence":31,"phase":"allowed-first","surface":"ancillary","method":"POST:/codex/analytics-events/events","response":404},{"sequence":32,"phase":"allowed-first","surface":"ancillary","method":"GET:/ps/plugins/suggested/codex","response":404},{"sequence":33,"phase":"allowed-first","surface":"model","method":"responses","step":3,"fixtureNamespaceObserved":true},{"sequence":34,"phase":"allowed-first","surface":"model","method":"tool-result-observed","fixtureEffectObserved":true},{"sequence":35,"phase":"allowed-first","surface":"ancillary","method":"POST:/codex/analytics-events/events","response":404},{"sequence":36,"phase":"allowed-first","surface":"ancillary","method":"POST:/codex/analytics-events/events","response":404},{"sequence":37,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"GET:/plugins/featured","response":404},{"sequence":38,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"GET:/ps/plugins/suggested/codex","response":404},{"sequence":39,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"GET:/ps/plugins/installed","response":404},{"sequence":40,"phase":"allowed-after-cold-restart","surface":"native","process":2,"method":"app/installed","thread":null,"event":"sent"},{"sequence":41,"phase":"allowed-after-cold-restart","surface":"mcp","method":"tools/list"},{"sequence":42,"phase":"allowed-after-cold-restart","surface":"native","process":2,"method":"app/installed","thread":null,"event":"resolved","fixtureApp":{"enabled":true,"callable":true}},{"sequence":43,"phase":"allowed-after-cold-restart","surface":"native","process":2,"method":"thread/resume","thread":1,"event":"sent"},{"sequence":44,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"GET:/v1/models","response":404},{"sequence":45,"phase":"allowed-after-cold-restart","surface":"mcp","method":"tools/list"},{"sequence":46,"phase":"allowed-after-cold-restart","surface":"native","process":2,"method":"thread/resume","thread":1,"event":"resolved"},{"sequence":47,"phase":"allowed-after-cold-restart","surface":"native","process":2,"method":"turn/start","thread":1,"event":"sent"},{"sequence":48,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"POST:/codex/analytics-events/events","response":404},{"sequence":49,"phase":"allowed-after-cold-restart","surface":"native","process":2,"method":"turn/start","thread":1,"event":"resolved"},{"sequence":50,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"GET:/v1/models","response":404},{"sequence":51,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"GET:/ps/plugins/suggested/codex","response":404},{"sequence":52,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"GET:/api/codex/settings/user","response":404},{"sequence":53,"phase":"allowed-after-cold-restart","surface":"model","method":"responses","step":1,"fixtureNamespaceObserved":true},{"sequence":54,"phase":"allowed-after-cold-restart","surface":"mcp","method":"tools/call","fixtureTool":true,"effects":2},{"sequence":55,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"POST:/codex/analytics-events/events","response":404},{"sequence":56,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"GET:/ps/plugins/suggested/codex","response":404},{"sequence":57,"phase":"allowed-after-cold-restart","surface":"model","method":"responses","step":2,"fixtureNamespaceObserved":true},{"sequence":58,"phase":"allowed-after-cold-restart","surface":"model","method":"tool-result-observed","fixtureEffectObserved":true},{"sequence":59,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"POST:/codex/analytics-events/events","response":404},{"sequence":60,"phase":"capture-scheduled-authority","surface":"native","process":2,"method":"app/installed","thread":1,"event":"sent"},{"sequence":61,"phase":"capture-scheduled-authority","surface":"native","process":2,"method":"config/read","thread":null,"event":"sent"},{"sequence":62,"phase":"capture-scheduled-authority","surface":"native","process":2,"method":"mcpServerStatus/list","thread":1,"event":"sent"},{"sequence":63,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"POST:/codex/analytics-events/events","response":404},{"sequence":64,"phase":"capture-scheduled-authority","surface":"native","process":2,"method":"app/installed","thread":1,"event":"resolved","fixtureApp":{"enabled":true,"callable":true}},{"sequence":65,"phase":"capture-scheduled-authority","surface":"native","process":2,"method":"config/read","thread":null,"event":"resolved"},{"sequence":66,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"GET:/.well-known/oauth-protected-resource/api/codex/ps/mcp","response":404},{"sequence":67,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"GET:/api/codex/ps/mcp/.well-known/oauth-protected-resource","response":404},{"sequence":68,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"GET:/.well-known/oauth-protected-resource","response":404},{"sequence":69,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"GET:/.well-known/oauth-authorization-server/api/codex/ps/mcp","response":404},{"sequence":70,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"GET:/.well-known/openid-configuration/api/codex/ps/mcp","response":404},{"sequence":71,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"GET:/api/codex/ps/mcp/.well-known/openid-configuration","response":404},{"sequence":72,"phase":"allowed-after-cold-restart","surface":"ancillary","method":"GET:/.well-known/oauth-authorization-server","response":404},{"sequence":73,"phase":"capture-scheduled-authority","surface":"native","process":2,"method":"mcpServerStatus/list","thread":1,"event":"resolved"},{"sequence":74,"phase":"scheduled-allowed","surface":"native","process":2,"method":"thread/unsubscribe","thread":1,"event":"sent"},{"sequence":75,"phase":"scheduled-allowed","surface":"native","process":2,"method":"thread/unsubscribe","thread":1,"event":"resolved"},{"sequence":76,"phase":"scheduled-allowed","surface":"native","process":2,"method":"config/read","thread":null,"event":"sent"},{"sequence":77,"phase":"scheduled-allowed","surface":"native","process":2,"method":"config/read","thread":null,"event":"resolved"},{"sequence":78,"phase":"scheduled-allowed","surface":"native","process":2,"method":"config/read","thread":null,"event":"sent"},{"sequence":79,"phase":"scheduled-allowed","surface":"native","process":2,"method":"mcpServerStatus/list","thread":null,"event":"sent"},{"sequence":80,"phase":"scheduled-allowed","surface":"native","process":2,"method":"config/read","thread":null,"event":"resolved"},{"sequence":81,"phase":"scheduled-allowed","surface":"ancillary","method":"GET:/.well-known/oauth-protected-resource/api/codex/ps/mcp","response":404},{"sequence":82,"phase":"scheduled-allowed","surface":"ancillary","method":"GET:/api/codex/ps/mcp/.well-known/oauth-protected-resource","response":404},{"sequence":83,"phase":"scheduled-allowed","surface":"ancillary","method":"GET:/.well-known/oauth-protected-resource","response":404},{"sequence":84,"phase":"scheduled-allowed","surface":"ancillary","method":"GET:/.well-known/oauth-authorization-server/api/codex/ps/mcp","response":404},{"sequence":85,"phase":"scheduled-allowed","surface":"ancillary","method":"GET:/.well-known/openid-configuration/api/codex/ps/mcp","response":404},{"sequence":86,"phase":"scheduled-allowed","surface":"ancillary","method":"GET:/api/codex/ps/mcp/.well-known/openid-configuration","response":404},{"sequence":87,"phase":"scheduled-allowed","surface":"ancillary","method":"GET:/.well-known/oauth-authorization-server","response":404},{"sequence":88,"phase":"scheduled-allowed","surface":"native","process":2,"method":"mcpServerStatus/list","thread":null,"event":"resolved"},{"sequence":89,"phase":"scheduled-allowed","surface":"native","process":2,"method":"thread/start","thread":null,"event":"sent"},{"sequence":90,"phase":"scheduled-allowed","surface":"ancillary","method":"GET:/v1/models","response":404},{"sequence":91,"phase":"scheduled-allowed","surface":"native","process":2,"method":"thread/start","thread":null,"event":"resolved"},{"sequence":92,"phase":"scheduled-allowed","surface":"native","process":2,"method":"app/installed","thread":2,"event":"sent"},{"sequence":93,"phase":"scheduled-allowed","surface":"ancillary","method":"POST:/codex/analytics-events/events","response":404},{"sequence":94,"phase":"scheduled-allowed","surface":"native","process":2,"method":"app/installed","thread":2,"event":"resolved","fixtureApp":{"enabled":true,"callable":true}},{"sequence":95,"phase":"scheduled-allowed","surface":"native","process":2,"method":"turn/start","thread":2,"event":"sent"},{"sequence":96,"phase":"scheduled-allowed","surface":"mcp","method":"tools/list"},{"sequence":97,"phase":"scheduled-allowed","surface":"native","process":2,"method":"turn/start","thread":2,"event":"resolved"},{"sequence":98,"phase":"scheduled-allowed","surface":"ancillary","method":"GET:/ps/plugins/suggested/codex","response":404},{"sequence":99,"phase":"scheduled-allowed","surface":"ancillary","method":"GET:/api/codex/settings/user","response":404},{"sequence":100,"phase":"scheduled-allowed","surface":"ancillary","method":"GET:/ps/plugins/suggested/codex","response":404},{"sequence":101,"phase":"scheduled-allowed","surface":"model","method":"responses","step":1,"fixtureNamespaceObserved":true},{"sequence":102,"phase":"scheduled-allowed","surface":"mcp","method":"tools/call","fixtureTool":true,"effects":3},{"sequence":103,"phase":"scheduled-allowed","surface":"ancillary","method":"POST:/codex/analytics-events/events","response":404},{"sequence":104,"phase":"scheduled-allowed","surface":"ancillary","method":"GET:/ps/plugins/suggested/codex","response":404},{"sequence":105,"phase":"scheduled-allowed","surface":"model","method":"responses","step":2,"fixtureNamespaceObserved":true},{"sequence":106,"phase":"scheduled-allowed","surface":"model","method":"tool-result-observed","fixtureEffectObserved":true},{"sequence":107,"phase":"scheduled-allowed","surface":"ancillary","method":"POST:/codex/analytics-events/events","response":404},{"sequence":108,"phase":"scheduled-allowed","surface":"ancillary","method":"POST:/codex/analytics-events/events","response":404},{"sequence":109,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/plugins/featured","response":404},{"sequence":110,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/ps/plugins/installed","response":404},{"sequence":111,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/ps/plugins/suggested/codex","response":404},{"sequence":112,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"app/installed","thread":null,"event":"sent"},{"sequence":113,"phase":"scheduled-allowed-after-cold-restart","surface":"mcp","method":"tools/list"},{"sequence":114,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"app/installed","thread":null,"event":"resolved","fixtureApp":{"enabled":true,"callable":true}},{"sequence":115,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"config/read","thread":null,"event":"sent"},{"sequence":116,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"config/read","thread":null,"event":"resolved"},{"sequence":117,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"config/read","thread":null,"event":"sent"},{"sequence":118,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"mcpServerStatus/list","thread":null,"event":"sent"},{"sequence":119,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"config/read","thread":null,"event":"resolved"},{"sequence":120,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/.well-known/oauth-protected-resource/api/codex/ps/mcp","response":404},{"sequence":121,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/api/codex/ps/mcp/.well-known/oauth-protected-resource","response":404},{"sequence":122,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/.well-known/oauth-protected-resource","response":404},{"sequence":123,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/.well-known/oauth-authorization-server/api/codex/ps/mcp","response":404},{"sequence":124,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/.well-known/openid-configuration/api/codex/ps/mcp","response":404},{"sequence":125,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/api/codex/ps/mcp/.well-known/openid-configuration","response":404},{"sequence":126,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/.well-known/oauth-authorization-server","response":404},{"sequence":127,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"mcpServerStatus/list","thread":null,"event":"resolved"},{"sequence":128,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"thread/resume","thread":2,"event":"sent"},{"sequence":129,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/v1/models","response":404},{"sequence":130,"phase":"scheduled-allowed-after-cold-restart","surface":"mcp","method":"tools/list"},{"sequence":131,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"thread/resume","thread":2,"event":"resolved"},{"sequence":132,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"app/installed","thread":2,"event":"sent"},{"sequence":133,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"POST:/codex/analytics-events/events","response":404},{"sequence":134,"phase":"scheduled-allowed-after-cold-restart","surface":"mcp","method":"tools/list"},{"sequence":135,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"app/installed","thread":2,"event":"resolved","fixtureApp":{"enabled":true,"callable":true}},{"sequence":136,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"app/read","thread":2,"event":"sent"},{"sequence":137,"phase":"scheduled-allowed-after-cold-restart","surface":"metadata","method":"apps/batch","fixtureRequested":true},{"sequence":138,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"app/read","thread":2,"event":"resolved"},{"sequence":139,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"config/read","thread":null,"event":"sent"},{"sequence":140,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"config/read","thread":null,"event":"resolved"},{"sequence":141,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"config/read","thread":null,"event":"sent"},{"sequence":142,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"mcpServerStatus/list","thread":2,"event":"sent"},{"sequence":143,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"config/read","thread":null,"event":"resolved"},{"sequence":144,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/.well-known/oauth-protected-resource/api/codex/ps/mcp","response":404},{"sequence":145,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/api/codex/ps/mcp/.well-known/oauth-protected-resource","response":404},{"sequence":146,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/.well-known/oauth-protected-resource","response":404},{"sequence":147,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/.well-known/oauth-authorization-server/api/codex/ps/mcp","response":404},{"sequence":148,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/.well-known/openid-configuration/api/codex/ps/mcp","response":404},{"sequence":149,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/api/codex/ps/mcp/.well-known/openid-configuration","response":404},{"sequence":150,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/.well-known/oauth-authorization-server","response":404},{"sequence":151,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"mcpServerStatus/list","thread":2,"event":"resolved"},{"sequence":152,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"app/installed","thread":2,"event":"sent"},{"sequence":153,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"app/installed","thread":2,"event":"resolved","fixtureApp":{"enabled":true,"callable":true}},{"sequence":154,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"turn/start","thread":2,"event":"sent"},{"sequence":155,"phase":"scheduled-allowed-after-cold-restart","surface":"native","process":3,"method":"turn/start","thread":2,"event":"resolved"},{"sequence":156,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/v1/models","response":404},{"sequence":157,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/ps/plugins/suggested/codex","response":404},{"sequence":158,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/api/codex/settings/user","response":404},{"sequence":159,"phase":"scheduled-allowed-after-cold-restart","surface":"model","method":"responses","step":1,"fixtureNamespaceObserved":true},{"sequence":160,"phase":"scheduled-allowed-after-cold-restart","surface":"mcp","method":"tools/call","fixtureTool":true,"effects":4},{"sequence":161,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"POST:/codex/analytics-events/events","response":404},{"sequence":162,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"GET:/ps/plugins/suggested/codex","response":404},{"sequence":163,"phase":"scheduled-allowed-after-cold-restart","surface":"model","method":"responses","step":2,"fixtureNamespaceObserved":true},{"sequence":164,"phase":"scheduled-allowed-after-cold-restart","surface":"model","method":"tool-result-observed","fixtureEffectObserved":true},{"sequence":165,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"POST:/codex/analytics-events/events","response":404},{"sequence":166,"phase":"local-app-revocation","surface":"native","process":3,"method":"config/value/write","thread":null,"event":"sent"},{"sequence":167,"phase":"scheduled-allowed-after-cold-restart","surface":"ancillary","method":"POST:/codex/analytics-events/events","response":404},{"sequence":168,"phase":"local-app-revocation","surface":"native","process":3,"method":"config/value/write","thread":null,"event":"resolved"},{"sequence":169,"phase":"scheduled-revoked-warm","surface":"native","process":3,"method":"config/read","thread":null,"event":"sent"},{"sequence":170,"phase":"scheduled-revoked-warm","surface":"native","process":3,"method":"config/read","thread":null,"event":"resolved"},{"sequence":171,"phase":"scheduled-revoked-warm","surface":"native","process":3,"method":"config/read","thread":null,"event":"sent"},{"sequence":172,"phase":"scheduled-revoked-warm","surface":"native","process":3,"method":"mcpServerStatus/list","thread":2,"event":"sent"},{"sequence":173,"phase":"scheduled-revoked-warm","surface":"native","process":3,"method":"config/read","thread":null,"event":"resolved"},{"sequence":174,"phase":"scheduled-revoked-warm","surface":"ancillary","method":"GET:/.well-known/oauth-protected-resource/api/codex/ps/mcp","response":404},{"sequence":175,"phase":"scheduled-revoked-warm","surface":"ancillary","method":"GET:/api/codex/ps/mcp/.well-known/oauth-protected-resource","response":404},{"sequence":176,"phase":"scheduled-revoked-warm","surface":"ancillary","method":"GET:/.well-known/oauth-protected-resource","response":404},{"sequence":177,"phase":"scheduled-revoked-warm","surface":"ancillary","method":"GET:/.well-known/oauth-authorization-server/api/codex/ps/mcp","response":404},{"sequence":178,"phase":"scheduled-revoked-warm","surface":"ancillary","method":"GET:/.well-known/openid-configuration/api/codex/ps/mcp","response":404},{"sequence":179,"phase":"scheduled-revoked-warm","surface":"ancillary","method":"GET:/api/codex/ps/mcp/.well-known/openid-configuration","response":404},{"sequence":180,"phase":"scheduled-revoked-warm","surface":"ancillary","method":"GET:/.well-known/oauth-authorization-server","response":404},{"sequence":181,"phase":"scheduled-revoked-warm","surface":"native","process":3,"method":"mcpServerStatus/list","thread":2,"event":"resolved"},{"sequence":182,"phase":"scheduled-revoked-warm","surface":"native","process":3,"method":"thread/unsubscribe","thread":2,"event":"sent"},{"sequence":183,"phase":"scheduled-revoked-warm","surface":"native","process":3,"method":"thread/unsubscribe","thread":2,"event":"resolved"},{"sequence":184,"phase":"scheduled-revoked-warm","surface":"assertion","result":"scheduled-policy-denied-before-turn","effects":4},{"sequence":185,"phase":"scheduled-revoked-cold","surface":"ancillary","method":"GET:/plugins/featured","response":404},{"sequence":186,"phase":"scheduled-revoked-cold","surface":"ancillary","method":"GET:/ps/plugins/suggested/codex","response":404},{"sequence":187,"phase":"scheduled-revoked-cold","surface":"ancillary","method":"GET:/ps/plugins/installed","response":404},{"sequence":188,"phase":"scheduled-revoked-cold","surface":"native","process":4,"method":"app/installed","thread":null,"event":"sent"},{"sequence":189,"phase":"scheduled-revoked-cold","surface":"mcp","method":"tools/list"},{"sequence":190,"phase":"scheduled-revoked-cold","surface":"native","process":4,"method":"app/installed","thread":null,"event":"resolved","fixtureApp":{"enabled":false,"callable":false}},{"sequence":191,"phase":"scheduled-revoked-cold","surface":"native","process":4,"method":"config/read","thread":null,"event":"sent"},{"sequence":192,"phase":"scheduled-revoked-cold","surface":"native","process":4,"method":"config/read","thread":null,"event":"resolved"},{"sequence":193,"phase":"scheduled-revoked-cold","surface":"native","process":4,"method":"config/read","thread":null,"event":"sent"},{"sequence":194,"phase":"scheduled-revoked-cold","surface":"native","process":4,"method":"mcpServerStatus/list","thread":null,"event":"sent"},{"sequence":195,"phase":"scheduled-revoked-cold","surface":"native","process":4,"method":"config/read","thread":null,"event":"resolved"},{"sequence":196,"phase":"scheduled-revoked-cold","surface":"ancillary","method":"GET:/.well-known/oauth-protected-resource/api/codex/ps/mcp","response":404},{"sequence":197,"phase":"scheduled-revoked-cold","surface":"ancillary","method":"GET:/api/codex/ps/mcp/.well-known/oauth-protected-resource","response":404},{"sequence":198,"phase":"scheduled-revoked-cold","surface":"ancillary","method":"GET:/.well-known/oauth-protected-resource","response":404},{"sequence":199,"phase":"scheduled-revoked-cold","surface":"ancillary","method":"GET:/.well-known/oauth-authorization-server/api/codex/ps/mcp","response":404},{"sequence":200,"phase":"scheduled-revoked-cold","surface":"ancillary","method":"GET:/.well-known/openid-configuration/api/codex/ps/mcp","response":404},{"sequence":201,"phase":"scheduled-revoked-cold","surface":"ancillary","method":"GET:/api/codex/ps/mcp/.well-known/openid-configuration","response":404},{"sequence":202,"phase":"scheduled-revoked-cold","surface":"ancillary","method":"GET:/.well-known/oauth-authorization-server","response":404},{"sequence":203,"phase":"scheduled-revoked-cold","surface":"native","process":4,"method":"mcpServerStatus/list","thread":null,"event":"resolved"},{"sequence":204,"phase":"scheduled-revoked-cold","surface":"assertion","result":"scheduled-policy-denied-before-turn","effects":4}]}
```

</details>

Latest ClawSweeper disposition: direct upstream contract inspection is complete and linked above; the final-effect gap is covered by the actual native allowed/disabled-app sequence. The optional real-account variant is intentionally not claimed: the isolated synthetic account-mode proof exercises the same admission owner without changing any real account permissions. The original empty-inventory probe remains separately scoped. Exact-head CI run [33391704687](https://github.com/openclaw/openclaw/actions/runs/33391704687) passed.
