### PR TITLE
ci: balance expensive tooling lifecycle tests

### DIFF
--- a/scripts/lib/ci-node-test-plan.mts
+++ b/scripts/lib/ci-node-test-plan.mts
@@ -647,6 +647,11 @@ const STRIPE_FILE_SECONDS_HINTS = new Map<string, number>([
   // PR run 33360253877: keep the process proofs apart instead of pricing each
   // at 3s. Git-owner's serial baseline remains a conservative packing weight.
   ["test/scripts/ci-git-owner.test.ts", 367],
+  // Successful hosted run 33388762505: these serial lifecycle suites cost
+  // 305s/204s/159s, but the 3s default packed all three into one tooling stripe.
+  ["test/scripts/openclaw-performance-git-lifecycle.test.ts", 305],
+  ["test/scripts/ci-linux-git.test.ts", 204],
+  ["test/scripts/pr-merge-outcome.test.ts", 159],
   ["test/scripts/ci-workflow-guards.test.ts", 12],
   ["test/scripts/crabbox-wrapper.test.ts", 19],
   ["test/scripts/find-reusable-release-validation.test.ts", 8],

--- a/test/scripts/ci-node-test-plan.test.ts
+++ b/test/scripts/ci-node-test-plan.test.ts
@@ -1013,6 +1013,9 @@ describe("scripts/lib/ci-node-test-plan.mts", () => {
       "test/scripts/managed-child-process.test.ts",
       "test/scripts/vitest-worker-artifacts.test.ts",
       "test/scripts/vitest-worker-artifacts.transforms.test.ts",
+      "test/scripts/openclaw-performance-git-lifecycle.test.ts",
+      "test/scripts/ci-linux-git.test.ts",
+      "test/scripts/pr-merge-outcome.test.ts",
     ];
     const processProofStripes = processProofFiles.map(
       (file) => stripes.find((stripe) => stripe.includePatterns?.includes(file))?.shardName,


### PR DESCRIPTION
Three Git lifecycle test files took 304.77, 203.43 and 158.34 seconds but the CI planner priced each at three seconds and placed them together. Add their rounded observed costs to the existing advisory table, so the existing balancing algorithm separates them. Extend the existing partition assertion; no new scheduler, runner, concurrency, retry, timeout, configuration or test exclusion.

The canonical plans preserve all 523 tooling files exactly once in seven stripes, with unchanged compact job counts and runtime prebuild rows. Runtime production delta is zero; CI tooling adds five lines to its existing owner and the regression assertion adds three.

All seven rebalanced tooling groups passed in [hosted CI](https://github.com/openclaw/openclaw/actions/runs/33392163065). The observed slowest group fell from 1,098.17 seconds to 655.38 seconds (40.3%), using the same begin/end log markers. Queue/setup time is excluded; different bases and hosts prevent a controlled causal or whole-release speedup claim. The actual run reported 522 files passed, one skipped, 12,349 tests passed and 476 existing skips. No skip policy changes. [Original bottleneck](https://github.com/openclaw/openclaw/actions/runs/33388762505/job/99478660923).

The new separation assertion fails before the change. [Native Linux proof](https://github.com/openclaw/openclaw/actions/runs/33392137613) passed all 179 planner/timing/changed-planner tests and the complete two-path changed gate in 218.79 seconds. Independent Codex reviews found no actionable P0–P2 findings. The refreshed complete planner file passes all 39 tests, including the upstream runtime-preparation expectation. The scheduling implementation is unchanged from the reviewed and natively tested version.

Earlier CI attempts encountered two extension-lint runner shutdowns, then inherited Gateway fixture lint/type errors on the refreshed base. Those fixture errors were independently fixed by #134207. This branch now uses that canonical repair on base ace8a13f19ccc2805b3d458026de3ab4bbbd8878 and drops our redundant test cleanup; it contains only the original two-file speedup. Exact-head required CI remains the landing gate. No full-release pass is claimed.
