### PR TITLE
refactor(agents): consolidate session text component reuse

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1991,14 +1991,11 @@ src/agents/sessions/session-manager-persistence.ts	2
 src/agents/sessions/session-manager.ts	2
 src/agents/sessions/settings-manager.ts	11
 src/agents/sessions/steering-message-identity.ts	2
-src/agents/sessions/tools/bash.ts	3
+src/agents/sessions/tools/bash.ts	2
 src/agents/sessions/tools/edit.ts	14
-src/agents/sessions/tools/find.ts	2
-src/agents/sessions/tools/grep.ts	4
-src/agents/sessions/tools/ls.ts	2
-src/agents/sessions/tools/read.ts	2
+src/agents/sessions/tools/grep.ts	2
 src/agents/sessions/tools/tool-definition-wrapper.ts	1
-src/agents/sessions/tools/write.ts	4
+src/agents/sessions/tools/write.ts	3
 src/agents/shell-snapshot.ts	1
 src/agents/spawn-plan.ts	1
 src/agents/subagents/announce/subagent-announce-completion-delivery.ts	2

--- a/src/agents/sessions/tools/bash.ts
+++ b/src/agents/sessions/tools/bash.ts
@@ -25,7 +25,7 @@ import {
 import type { ToolDefinition, ToolRenderResultOptions } from "../extensions/types.js";
 import type { BashOperations } from "./bash-operations.js";
 import { OutputAccumulator } from "./output-accumulator.js";
-import { getTextOutput, invalidArgText, str } from "./render-utils.js";
+import { getTextOutput, invalidArgText, reuseTextComponent, str } from "./render-utils.js";
 import { formatFullOutputFooter, type BashToolDetails } from "./tool-contracts.js";
 import { wrapToolDefinition } from "./tool-definition-wrapper.js";
 import { DEFAULT_MAX_BYTES, DEFAULT_MAX_LINES, formatSize } from "./truncate.js";
@@ -493,9 +493,7 @@ export function createBashToolDefinition(
         state.startedAt = Date.now();
         state.endedAt = undefined;
       }
-      const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
-      text.setText(formatBashCall(args));
-      return text;
+      return reuseTextComponent(context.lastComponent, formatBashCall(args));
     },
     renderResult(result, optionsLocal, themeLocal, context) {
       void themeLocal;

--- a/src/agents/sessions/tools/find.ts
+++ b/src/agents/sessions/tools/find.ts
@@ -1,7 +1,6 @@
 import { existsSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
-import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { releaseChildProcessOutputAfterExit } from "../../../process/child-process.js";
 import { spawnCommand } from "../../../process/exec.js";
@@ -20,6 +19,7 @@ import {
   appendSessionToolTruncationWarning,
   formatSessionToolOutput,
   invalidArgText,
+  reuseTextComponent,
   shortenPath,
   str,
 } from "./render-utils.js";
@@ -383,14 +383,11 @@ export function createFindToolDefinition(
       });
     },
     renderCall(args, theme, context) {
-      const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
-      text.setText(formatFindCall(args, theme));
-      return text;
+      return reuseTextComponent(context.lastComponent, formatFindCall(args, theme));
     },
     renderResult(result, optionsLocal, theme, context) {
-      const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
-      text.setText(formatFindResult(result, optionsLocal, theme, context.showImages));
-      return text;
+      const content = formatFindResult(result, optionsLocal, theme, context.showImages);
+      return reuseTextComponent(context.lastComponent, content);
     },
   };
 }

--- a/src/agents/sessions/tools/grep.ts
+++ b/src/agents/sessions/tools/grep.ts
@@ -6,7 +6,6 @@
 import { statSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
-import { Text } from "@earendil-works/pi-tui";
 import { resolveNonNegativeIntegerOption } from "@openclaw/normalization-core/number-coercion";
 import { Type } from "typebox";
 import { releaseChildProcessOutputAfterExit } from "../../../process/child-process.js";
@@ -21,6 +20,7 @@ import {
   appendSessionToolTruncationWarning,
   formatSessionToolOutput,
   invalidArgText,
+  reuseTextComponent,
   shortenPath,
   str,
 } from "./render-utils.js";
@@ -459,14 +459,11 @@ export function createGrepToolDefinition(
       });
     },
     renderCall(args, theme, context) {
-      const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
-      text.setText(formatGrepCall(args, theme));
-      return text;
+      return reuseTextComponent(context.lastComponent, formatGrepCall(args, theme));
     },
     renderResult(result, optionsLocal, theme, context) {
-      const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
-      text.setText(formatGrepResult(result, optionsLocal, theme, context.showImages));
-      return text;
+      const content = formatGrepResult(result, optionsLocal, theme, context.showImages);
+      return reuseTextComponent(context.lastComponent, content);
     },
   };
 }

--- a/src/agents/sessions/tools/ls.ts
+++ b/src/agents/sessions/tools/ls.ts
@@ -5,7 +5,6 @@
  */
 import { existsSync, readdirSync, statSync } from "node:fs";
 import nodePath from "node:path";
-import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { toErrorObject } from "../../../infra/errors.js";
 import type { AgentTool } from "../../runtime/index.js";
@@ -16,6 +15,7 @@ import {
   appendSessionToolTruncationWarning,
   formatSessionToolOutput,
   invalidArgText,
+  reuseTextComponent,
   shortenPath,
   str,
 } from "./render-utils.js";
@@ -225,14 +225,11 @@ export function createLsToolDefinition(
       }
     },
     renderCall(args, theme, context) {
-      const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
-      text.setText(formatLsCall(args, theme));
-      return text;
+      return reuseTextComponent(context.lastComponent, formatLsCall(args, theme));
     },
     renderResult(result, optionsLocal, theme, context) {
-      const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
-      text.setText(formatLsResult(result, optionsLocal, theme, context.showImages));
-      return text;
+      const content = formatLsResult(result, optionsLocal, theme, context.showImages);
+      return reuseTextComponent(context.lastComponent, content);
     },
   };
 }

--- a/src/agents/sessions/tools/read.ts
+++ b/src/agents/sessions/tools/read.ts
@@ -1,7 +1,6 @@
 import { constants } from "node:fs";
 import { access as fsAccess, readdir as fsReaddir, stat as fsStat } from "node:fs/promises";
 import { basename, dirname, isAbsolute, relative, resolve as resolvePath, sep } from "node:path";
-import { Text } from "@earendil-works/pi-tui";
 import { hasErrnoCode, toErrorObject } from "../../../infra/errors.js";
 import { readRegularFile } from "../../../infra/regular-file.js";
 import { decodeWindowsTextFileBuffer } from "../../../infra/windows-encoding.js";
@@ -52,6 +51,7 @@ import {
   getTextOutput,
   invalidArgText,
   replaceTabs,
+  reuseTextComponent,
   shortenPath,
   str,
   trimTrailingEmptyLines,
@@ -623,31 +623,25 @@ export function createReadToolDefinition(
       });
     },
     renderCall(args, theme, context) {
-      const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
       const classification = !context.expanded
         ? getCompactReadClassification(args, context.cwd)
         : undefined;
-      text.setText(
-        classification
-          ? formatCompactReadCall(classification, args, theme)
-          : formatReadCall(args, theme),
-      );
-      return text;
+      const content = classification
+        ? formatCompactReadCall(classification, args, theme)
+        : formatReadCall(args, theme);
+      return reuseTextComponent(context.lastComponent, content);
     },
     renderResult(result, optionsLocal, theme, context) {
-      const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
-      text.setText(
-        formatReadResult(
-          context.args,
-          result,
-          optionsLocal,
-          theme,
-          context.showImages,
-          context.cwd,
-          context.isError,
-        ),
+      const content = formatReadResult(
+        context.args,
+        result,
+        optionsLocal,
+        theme,
+        context.showImages,
+        context.cwd,
+        context.isError,
       );
-      return text;
+      return reuseTextComponent(context.lastComponent, content);
     },
   };
 }

--- a/src/agents/sessions/tools/render-utils.test.ts
+++ b/src/agents/sessions/tools/render-utils.test.ts
@@ -1,9 +1,11 @@
 import fs from "node:fs";
 import * as os from "node:os";
 import path from "node:path";
+import { Text } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
 import {
   appendSessionToolTruncationWarning,
+  reuseTextComponent,
   shortenPath,
   trimTrailingEmptyLines,
 } from "./render-utils.js";
@@ -59,6 +61,25 @@ describe("trimTrailingEmptyLines", () => {
     trimTrailingEmptyLines(lines);
 
     expect(lines).toEqual(original);
+  });
+});
+
+describe("reuseTextComponent", () => {
+  it("creates a zero-padding Text component when no prior component exists", () => {
+    const component = reuseTextComponent(undefined, "hello");
+
+    expect(component).toBeInstanceOf(Text);
+    expect(component.render(5)).toEqual(["hello"]);
+  });
+
+  it("reuses the prior Text component and invalidates its rendered content", () => {
+    const component = new Text("before", 0, 0);
+    expect(component.render(6)).toEqual(["before"]);
+
+    const reused = reuseTextComponent(component, "after!");
+
+    expect(reused).toBe(component);
+    expect(reused.render(6)).toEqual(["after!"]);
   });
 });
 

--- a/src/agents/sessions/tools/render-utils.ts
+++ b/src/agents/sessions/tools/render-utils.ts
@@ -4,7 +4,13 @@
  * Normalizes paths/text/image fallbacks before tool results are styled or truncated.
  */
 import * as os from "node:os";
-import { getCapabilities, getImageDimensions, imageFallback } from "@earendil-works/pi-tui";
+import {
+  type Component,
+  getCapabilities,
+  getImageDimensions,
+  imageFallback,
+  Text,
+} from "@earendil-works/pi-tui";
 import { shortenPathWithHome } from "../../../infra/home-display.js";
 import { keyHint } from "../../modes/interactive/components/keybinding-hints.js";
 import type { Theme } from "../../modes/interactive/theme/theme.js";
@@ -45,6 +51,11 @@ export function trimTrailingEmptyLines(lines: readonly string[]): string[] {
   return lines.slice(0, lines.findLastIndex((line) => line !== "") + 1);
 }
 
+export function reuseTextComponent(lastComponent: Component | undefined, content: string): Text {
+  const text = (lastComponent as Text | undefined) ?? new Text("", 0, 0); // SAFETY: Render slots only reuse the component returned by this renderer.
+  text.setText(content);
+  return text;
+}
 /** Extracts text output and image placeholders from a tool result. */
 export function getTextOutput(
   result:

--- a/src/agents/sessions/tools/write.ts
+++ b/src/agents/sessions/tools/write.ts
@@ -30,6 +30,7 @@ import {
   invalidArgText,
   normalizeDisplayText,
   replaceTabs,
+  reuseTextComponent,
   shortenPath,
   str,
   trimTrailingEmptyLines,
@@ -620,9 +621,7 @@ export function createWriteToolDefinition(
         component.clear();
         return component;
       }
-      const text = (context.lastComponent as Text | undefined) ?? new Text("", 0, 0);
-      text.setText(output);
-      return text;
+      return reuseTextComponent(context.lastComponent, output);
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Ten session tool text renderers independently repeated the same component construction, identity reuse, and text-cache invalidation sequence.

## Why This Change Was Made

This consolidates that sequence in `reuseTextComponent`, preserving the existing unchecked render-slot cast while making the shared `Text` lifecycle explicit. The helper creates a zero-padding `Text` when absent, calls `setText` for every render, and returns the same component instance.

Installed `@earendil-works/pi-tui` source and types confirm the contract: `Text` implements `Component`, and `setText` clears the cached text, width, and rendered lines before the next render.

Renderer activation is explicitly out of scope. `wrapToolDefinition` currently drops these renderer hooks, so this PR does not claim a user-visible or live TUI behavior change.

## User Impact

No user-visible change. Bash, read, write-error, find, grep, and ls session text renderers retain their existing output and component identity semantics with one canonical implementation.

## Evidence

- Owner tests: `node scripts/run-vitest.mjs src/agents/sessions/tools/render-utils.test.ts` - 14 passed, 1 platform skip.
- New owner coverage proves zero-padding construction and same-instance replacement rendering after a prior cached render.
- `pnpm check:changed` - passed on the rebased diff.
- `pnpm test:changed` - first three partitions passed; the unit partition completed 10,807 passed and 17 skipped with one sparse-checkout fixture failure. Hydrating the tracked `custodian-skills/` directory made that exact unrelated spec pass.
- `git diff --check` - passed.
- Pinned `gpt-5.6-sol` high autoreview - scoped-clean, no actionable findings, overall correctness 0.99.
- Production LOC: +42/-49, net -7. Tests: +21. Tooling baseline: +3/-6.
- Assertion-safety baseline shrinks with the removed duplicate caller casts.
- Provenance commit: `bb46b79d3c1479f194a90afcf3dd69a1858a7898`.
- Overlap refresh: #133815 is merged; its render blocks remain compatible with this consolidation. The latest main advance was Matrix/QA work and did not touch this owner surface.
- Codex CLI contract check: `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870` are unrelated completion/config-normalization paths.
- No API, config, storage, security, protocol, changelog, Crabbox, PTY, or live-TUI change.
