### PR TITLE
fix(memory): preserve vector worker stderr

### DIFF
--- a/extensions/memory-core/src/memory/fixtures/manager-search-knn-child.fixture.mjs
+++ b/extensions/memory-core/src/memory/fixtures/manager-search-knn-child.fixture.mjs
@@ -16,9 +16,14 @@ process.stdin.once("end", () => {
     process.stdout.write(Buffer.alloc(2 * 1024 * 1024 + 1024, 120));
     return;
   }
+  if (input.databasePath === "fixture:oversized-stderr") {
+    process.stderr.write(Buffer.alloc(64 * 1024 + 1024, 120));
+    return;
+  }
   if (input.databasePath === "fixture:early-exit") {
-    process.stderr.write("fixture KNN failure\n");
-    process.exit(7);
+    // Flush pipe output before exiting so the test cannot lose its own diagnostic.
+    process.stderr.write("fixture KNN failure\n", () => process.exit(7));
+    return;
   }
   process.stderr.write("ready\n");
   const deadline = performance.now() + Math.max(0, Number(input.request?.limit ?? 0));

--- a/extensions/memory-core/src/memory/fixtures/manager-search-knn-child.fixture.mjs
+++ b/extensions/memory-core/src/memory/fixtures/manager-search-knn-child.fixture.mjs
@@ -17,6 +17,7 @@ process.stdin.once("end", () => {
     return;
   }
   if (input.databasePath === "fixture:early-exit") {
+    process.stderr.write("fixture KNN failure\n");
     process.exit(7);
   }
   process.stderr.write("ready\n");

--- a/extensions/memory-core/src/memory/manager-search-knn-subprocess.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn-subprocess.test.ts
@@ -306,6 +306,15 @@ describe("memory vector KNN subprocess boundary", () => {
     ).rejects.toThrow(
       "exited before returning a result (code 7, signal none): fixture KNN failure",
     );
+    await expect(
+      runVectorKnnInSubprocess({
+        databasePath: "fixture:oversized-stderr",
+        request: request(1),
+      }),
+    ).rejects.toMatchObject({
+      code: "protocol",
+      message: "memory vector KNN child stderr exceeded its limit",
+    });
   });
 
   it("fails vector recall closed when the subprocess is unavailable", async () => {

--- a/extensions/memory-core/src/memory/manager-search-knn-subprocess.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn-subprocess.test.ts
@@ -303,7 +303,9 @@ describe("memory vector KNN subprocess boundary", () => {
         databasePath: "fixture:early-exit",
         request: request(1),
       }),
-    ).rejects.toThrow("exited before returning a result");
+    ).rejects.toThrow(
+      "exited before returning a result (code 7, signal none): fixture KNN failure",
+    );
   });
 
   it("fails vector recall closed when the subprocess is unavailable", async () => {

--- a/extensions/memory-core/src/memory/manager-search-knn-subprocess.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn-subprocess.ts
@@ -193,6 +193,7 @@ export async function runVectorKnnInSubprocess(
   }
   return await new Promise<VectorKnnResponse>((resolve, reject) => {
     const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
     let stdoutBytes = 0;
     let stderrBytes = 0;
     let closed = false;
@@ -277,7 +278,9 @@ export async function runVectorKnnInSubprocess(
           "protocol",
         );
         requestTermination(failure);
+        return;
       }
+      stderrChunks.push(chunk);
     });
     child.stdin.on("error", (error: NodeJS.ErrnoException) => {
       if (!terminationReason && error.code !== "EPIPE") {
@@ -298,9 +301,10 @@ export async function runVectorKnnInSubprocess(
           return;
         }
         if (code !== 0 || signal) {
+          const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
           reject(
             new VectorKnnSubprocessError(
-              `memory vector KNN child exited before returning a result (code ${code}, signal ${signal ?? "none"})`,
+              `memory vector KNN child exited before returning a result (code ${code}, signal ${signal ?? "none"})${stderr ? `: ${stderr}` : ""}`,
               "failed",
             ),
           );


### PR DESCRIPTION
## What Problem This Solves

When a file-backed vector-search worker exits before returning its JSON result, the parent discards the worker's bounded stderr and reports only its exit code and signal. That hides the native SQLite failure that explains missing vector results.

## Why This Change Was Made

Keep stderr within the existing 64 KiB limit and append it to the existing early-exit error at the subprocess owner. Oversized output, cancellation, child cleanup, and structured-result handling retain their existing behavior. The normal memory-search caller passes this error through the canonical redacting formatter before logging it.

The existing real-child fixture now waits for its stderr write to finish before exiting, so POSIX pipe buffering cannot lose the test's diagnostic. Its failure test also checks that oversized stderr still produces the existing protocol-limit error.

## User Impact

Memory-search diagnostics include the worker's failure detail when native code terminates before a JSON result. Successful search results and configuration are unchanged. This adds no database schema or persisted metadata.

## Evidence

Independent maintainer proof used trusted main `c0f1cbfddb909541b7ad88920d8ae0e59fff89b7` plus an independently authored equivalent repair. The three changed-file baselines and ten inspected caller/child/runtime/error/SQLite dependency files match this PR's corresponding source. The final candidate's changed-file hashes match the tested equivalent.

- Before the production edit, the strengthened canonical subprocess test failed because the parent omitted `fixture KNN failure`.
- After the repair, all seven tests in `manager-search-knn-subprocess.test.ts` passed through the repository runner. Coverage includes the stderr limit, malformed/oversized stdout, cancellation/reaping/admission cleanup, real SQLite/WAL visibility, source filtering, bounded snippets, and unavailable subprocess behavior.
- The same real file-backed failure probe failed before and passed after on macOS with Node 24.20.0. It uses the production parent and production child, opens a temporary SQLite file read-only, and loads a synthetic native extension that writes a marker before `_exit(86)`. The database bytes remain unchanged in both runs; no embedding service, credentials, Gateway, or operator data is used.
- Scoped canonical changed checks passed, including both extension typecheck lanes, lint/formatting, repository guards, and five plugin doctor-contract tests.
- Fresh independent review of the complete candidate found no P0 issues.

Observed production-parent diagnostics:

```text
before: memory vector KNN child exited before returning a result (code 86, signal none)
after:  memory vector KNN child exited before returning a result (code 86, signal none): vector-proof: native SQLite worker terminated before result
```

The contributor separately supplied Linux Node 26.8.1 production-parent/child file-backed proof at tree `90effc3495f7a944f57a774f991253cfc98e6ac0`, preserving the same native failure marker after the original repair.

The old exact-head lint job 99517593209 in run 33399732864 was interrupted by runner shutdown, with its check step cancelled and no lint diagnostic. Final-head [CI](https://github.com/openclaw/openclaw/actions/runs/33455349016) and [Workflow Sanity](https://github.com/openclaw/openclaw/actions/runs/33455348949) passed at `86752e6b5c759611061a1da930ef2e7135538aec`.

Production grows by four net lines to retain and render the already bounded diagnostic at its owner. Test and fixture changes add seventeen net lines. Moving this handling to the search caller would lose the worker-stream fact; a new collector abstraction would add more code to the same bounded flow.

Thanks @klabir.
