### PR TITLE
ci: typecheck graphs that consume changed tests

### DIFF
--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -35,8 +35,10 @@ import { resolveLocalCheckEnv } from "./lib/local-check-runtime.mts";
 import { runManagedCommand } from "./lib/managed-child-process.mts";
 import { listGeneratedExtensionAssetSources } from "./lib/static-extension-assets.mts";
 import { createSparseTsgoSkipEnv } from "./lib/tsgo-sparse-guard.mts";
+import type { createChangedCoreTestCheck } from "./run-tsgo-core-test-shards.mts";
 
 type ChangedCheckCommand = {
+  coreTestCheck?: "checkBoundary" | "checkTypes";
   name: string;
   args: string[];
   bin?: string;
@@ -683,8 +685,22 @@ export function createChangedCheckPlan(
 
   // Typechecking alone accepts extension imports; the graph guard also covers
   // shared test/tooling dependencies that core tests can pull into their graph.
+  const changedTestPaths = result.paths.filter(
+    (file) => getChangedPathFacts(file).surface !== "docs",
+  );
+  const narrowCoreTests =
+    !runAll &&
+    !lanes.core &&
+    !lanes.ui &&
+    !lanes.tooling &&
+    !lanes.liveDockerTooling &&
+    changedTestPaths.length > 0 &&
+    changedTestPaths.every((file) => /^(?:src|ui|packages)\/.+\.test\.tsx?$/u.test(file));
   if (runAll || lanes.core || lanes.coreTests || lanes.ui || lanes.tooling) {
     add("core tsgo graph boundary", ["lint:tmp:tsgo-core-boundary"]);
+    if (narrowCoreTests) {
+      commands.at(-1)!.coreTestCheck = "checkBoundary";
+    }
   }
 
   if (runAll || lanes.scripts || result.paths.includes("scripts/check-script-erasability.mjs")) {
@@ -733,6 +749,9 @@ export function createChangedCheckPlan(
   }
   if (lanes.coreTests) {
     addTypecheck("typecheck core tests", ["tsgo:core:test"]);
+    if (narrowCoreTests) {
+      commands.at(-1)!.coreTestCheck = "checkTypes";
+    }
   }
   if (lanes.ui) {
     addTypecheck("typecheck UI", ["tsgo:ui"]);
@@ -1001,9 +1020,15 @@ async function runChangedCheck(result: ChangedLaneResult, options: ChangedCheckR
     return 0;
   }
 
+  const coreTestCheck = plan.commands.some((command) => command.coreTestCheck)
+    ? (await import("./run-tsgo-core-test-shards.mts")).createChangedCoreTestCheck(
+        result.paths.filter((file) => getChangedPathFacts(file).surface !== "docs"),
+        createSparseTsgoSkipEnv(childEnv),
+      )
+    : undefined;
   const timings: ChangedCheckTiming[] = [];
   for (const command of plan.commands) {
-    const status = await runPlanCommand(command, timings);
+    const status = await runPlanCommand(command, timings, coreTestCheck);
     if (status !== 0) {
       printSummary(timings, options);
       return status;
@@ -1042,7 +1067,18 @@ async function runPnpm(command: ChangedCheckCommand, timings: ChangedCheckTiming
   return await runCommand(createPnpmManagedCommand(command), timings);
 }
 
-async function runPlanCommand(command: ChangedCheckCommand, timings: ChangedCheckTiming[]) {
+async function runPlanCommand(
+  command: ChangedCheckCommand,
+  timings: ChangedCheckTiming[],
+  coreTestCheck?: ReturnType<typeof createChangedCoreTestCheck>,
+) {
+  if (command.coreTestCheck && coreTestCheck) {
+    return await runCommand(
+      createPnpmManagedCommand(command),
+      timings,
+      coreTestCheck[command.coreTestCheck],
+    );
+  }
   if (command.bin) {
     return await runCommand({ ...command, bin: command.bin }, timings);
   }
@@ -1117,16 +1153,19 @@ export function cleanupCorepackPnpmShimDir() {
 async function runCommand(
   command: ChangedCheckCommand & { bin: string },
   timings: ChangedCheckTiming[],
+  run?: () => Promise<number>,
 ) {
   const startedAt = performance.now();
   console.error(`\n[check:changed] ${command.name}`);
   let status = 1;
   try {
-    status = await runManagedCommand({
-      bin: command.bin,
-      args: command.args,
-      env: command.env ?? resolveLocalCheckEnv(),
-    });
+    status = run
+      ? await run()
+      : await runManagedCommand({
+          bin: command.bin,
+          args: command.args,
+          env: command.env ?? resolveLocalCheckEnv(),
+        });
   } catch (error) {
     console.error(error);
   }

--- a/scripts/check-tsgo-core-boundary.mts
+++ b/scripts/check-tsgo-core-boundary.mts
@@ -1,27 +1,21 @@
 #!/usr/bin/env node
 
 // Enforces core tsgo project boundaries and sparse-checkout safety.
-import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import { resolveRepoToolBinPath } from "./lib/local-check-runtime.mts";
-import { createManagedCommandInvocation } from "./lib/managed-child-process.mts";
+import { runManagedCommand, signalExitCode } from "./lib/managed-child-process.mts";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import {
   findTsgoCoreTestShardViolations,
   TSGO_CORE_TEST_MAX_ROOTS,
+  TSGO_CORE_GRAPHS,
   TSGO_CORE_TEST_SHARDS,
 } from "./lib/tsgo-core-test-shards.mts";
 const repoRoot = resolveRepoRoot(import.meta.url);
 const tsgoPath = resolveRepoToolBinPath("tsgo", { cwd: repoRoot });
 const canonicalCoreTestConfig = "test/tsconfig/tsconfig.core.test.json";
 
-const coreGraphs = [
-  { name: "core", config: "tsconfig.core.json" },
-  { name: "ui", config: "tsconfig.ui.json" },
-  ...TSGO_CORE_TEST_SHARDS.map((shard) => ({
-    name: `core-test-${shard.name}`,
-    config: shard.config,
-  })),
-];
 function normalizeFilePath(filePath: string) {
   const normalized = filePath.trim().replaceAll("\\", "/");
   const normalizedRoot = repoRoot.replaceAll("\\", "/");
@@ -31,117 +25,171 @@ function normalizeFilePath(filePath: string) {
   return normalized;
 }
 
-function listGraphFiles(graph: (typeof coreGraphs)[number]) {
-  const tsgo = createManagedCommandInvocation({
-    args: ["-p", graph.config, "--pretty", "false", "--listFilesOnly"],
-    bin: tsgoPath,
-  });
-  const result = spawnSync(tsgo.command, tsgo.args, {
-    cwd: repoRoot,
-    encoding: "utf8",
-    maxBuffer: 256 * 1024 * 1024,
-    shell: tsgo.shell,
-    windowsVerbatimArguments: tsgo.windowsVerbatimArguments,
-  });
-  if (result.error) {
-    throw result.error;
+export class CoreTsgoBoundaryInterruptedError extends Error {
+  readonly exitCode: number;
+
+  constructor(signal: NodeJS.Signals) {
+    super(`Core tsgo graph boundary interrupted by ${signal}`);
+    this.exitCode = signalExitCode(signal);
   }
-  if ((result.status ?? 1) !== 0) {
-    const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
-    throw new Error(`${graph.name} file listing failed with exit code ${result.status}\n${output}`);
-  }
-  return (result.stdout ?? "").split(/\r?\n/u).map(normalizeFilePath).filter(Boolean);
 }
 
-function readGraphConfig(config: string): {
+async function runTsgoQuery(config: string, query: string, label: string): Promise<string> {
+  const outputs: Buffer[][] = [[], []];
+  const overflow = new AbortController();
+  let outputBytes = 0;
+  let receivedSignal: NodeJS.Signals | undefined;
+  let code: number;
+  try {
+    code = await runManagedCommand({
+      bin: tsgoPath,
+      args: ["-p", config, "--pretty", "false", query],
+      cwd: repoRoot,
+      stdio: ["ignore", "pipe", "pipe"],
+      signal: overflow.signal,
+      requireProcessTreeExit: process.platform !== "win32",
+      onSignal(signal) {
+        receivedSignal = signal;
+      },
+      onReady(child) {
+        for (const [index, stream] of [child.stdout!, child.stderr!].entries()) {
+          stream.on("data", (chunk: Buffer) => {
+            if (overflow.signal.aborted) {
+              return;
+            }
+            outputBytes += chunk.byteLength;
+            // Inventory must be complete; preserve spawnSync's bound and fail rather than truncate.
+            if (outputBytes > 256 * 1024 * 1024) {
+              overflow.abort();
+              return;
+            }
+            outputs[index]!.push(chunk);
+          });
+        }
+      },
+    });
+  } catch (error) {
+    if (overflow.signal.aborted) {
+      throw new Error(`${label} output exceeded 256 MiB`, { cause: error });
+    }
+    throw error;
+  }
+  if (receivedSignal) {
+    throw new CoreTsgoBoundaryInterruptedError(receivedSignal);
+  }
+  const [stdout, stderr] = outputs.map((chunks) => Buffer.concat(chunks).toString("utf8"));
+  if (code !== 0) {
+    throw new Error(
+      `${label} failed with exit code ${code}\n${[stdout, stderr].filter(Boolean).join("\n")}`,
+    );
+  }
+  return stdout!;
+}
+
+async function readGraphConfig(config: string): Promise<{
   compilerOptions?: { tsBuildInfoFile?: string };
   files?: string[];
-} {
-  const tsgo = createManagedCommandInvocation({
-    args: ["-p", config, "--pretty", "false", "--showConfig"],
-    bin: tsgoPath,
-  });
-  const result = spawnSync(tsgo.command, tsgo.args, {
-    cwd: repoRoot,
-    encoding: "utf8",
-    maxBuffer: 256 * 1024 * 1024,
-    shell: tsgo.shell,
-    windowsVerbatimArguments: tsgo.windowsVerbatimArguments,
-  });
-  if (result.error) {
-    throw result.error;
-  }
-  if ((result.status ?? 1) !== 0) {
-    const output = [result.stdout, result.stderr].filter(Boolean).join("\n");
-    throw new Error(`${config} config expansion failed with exit code ${result.status}\n${output}`);
-  }
-  return JSON.parse(result.stdout ?? "") as {
+}> {
+  return JSON.parse(await runTsgoQuery(config, "--showConfig", `${config} config expansion`)) as {
     compilerOptions?: { tsBuildInfoFile?: string };
     files?: string[];
   };
 }
 
-const testRootPattern = /\.test\.(?:ts|tsx)$/u;
-const canonicalRoots = (readGraphConfig(canonicalCoreTestConfig).files ?? [])
-  .map(normalizeFilePath)
-  .filter((file) => testRootPattern.test(file));
-const shardConfigs = TSGO_CORE_TEST_SHARDS.map((shard) => ({
-  name: shard.name,
-  config: shard.config,
-  expanded: readGraphConfig(shard.config),
-}));
-const shardViolations = findTsgoCoreTestShardViolations({
-  canonicalRoots,
-  shards: shardConfigs.map((shard) => ({
-    name: shard.name,
-    roots: (shard.expanded.files ?? [])
+export type CoreTsgoGraph = {
+  name: string;
+  config: string;
+  roots: readonly string[];
+  files: readonly string[];
+};
+
+/** Validates all boundaries and returns this invocation's compiler-resolved inputs. */
+export async function checkCoreTsgoGraphBoundary(): Promise<CoreTsgoGraph[]> {
+  const testRootPattern = /\.test\.(?:ts|tsx)$/u;
+  const canonicalRoots = ((await readGraphConfig(canonicalCoreTestConfig)).files ?? [])
+    .map(normalizeFilePath)
+    .filter((file) => testRootPattern.test(file));
+  const shardConfigs = [];
+  for (const shard of TSGO_CORE_TEST_SHARDS) {
+    shardConfigs.push({ ...shard, expanded: await readGraphConfig(shard.config) });
+  }
+  const shardViolations = findTsgoCoreTestShardViolations({
+    canonicalRoots,
+    shards: shardConfigs.map((shard) => ({
+      name: shard.name,
+      roots: (shard.expanded.files ?? [])
+        .map(normalizeFilePath)
+        .filter((file) => testRootPattern.test(file)),
+    })),
+  });
+
+  const buildInfoOwners = new Map<string, string[]>();
+  for (const shard of shardConfigs) {
+    const buildInfo = shard.expanded.compilerOptions?.tsBuildInfoFile;
+    if (!buildInfo) {
+      shardViolations.push(`${shard.name}: missing compilerOptions.tsBuildInfoFile`);
+      continue;
+    }
+    const owners = buildInfoOwners.get(buildInfo) ?? [];
+    owners.push(shard.name);
+    buildInfoOwners.set(buildInfo, owners);
+  }
+  for (const [buildInfo, owners] of buildInfoOwners) {
+    if (owners.length > 1) {
+      shardViolations.push(`shared tsBuildInfoFile (${owners.join(", ")}): ${buildInfo}`);
+    }
+  }
+
+  if (shardViolations.length > 0) {
+    console.error(
+      `Core test shards must cover every canonical test root exactly once and stay at or below ${TSGO_CORE_TEST_MAX_ROOTS} roots:`,
+    );
+    for (const violation of shardViolations) {
+      console.error(`- ${violation}`);
+    }
+    throw new Error("Core test graph ownership validation failed");
+  }
+
+  const violations: string[] = [];
+  const graphs: CoreTsgoGraph[] = [];
+  for (const graph of TSGO_CORE_GRAPHS) {
+    const files = (
+      await runTsgoQuery(graph.config, "--listFilesOnly", `${graph.name} file listing`)
+    )
+      .split(/\r?\n/u)
       .map(normalizeFilePath)
-      .filter((file) => testRootPattern.test(file)),
-  })),
-});
+      .filter(Boolean);
+    graphs.push({
+      ...graph,
+      files,
+      roots: (shardConfigs.find((shard) => shard.config === graph.config)?.expanded.files ?? [])
+        .map((file) => normalizeFilePath(path.resolve(repoRoot, path.dirname(graph.config), file)))
+        .filter((file) => testRootPattern.test(file)),
+    });
+    const extensionFiles = files.filter((file) => file.startsWith("extensions/"));
+    for (const file of extensionFiles) {
+      violations.push(`${graph.name}: ${file}`);
+    }
+  }
 
-const buildInfoOwners = new Map<string, string[]>();
-for (const shard of shardConfigs) {
-  const buildInfo = shard.expanded.compilerOptions?.tsBuildInfoFile;
-  if (!buildInfo) {
-    shardViolations.push(`${shard.name}: missing compilerOptions.tsBuildInfoFile`);
-    continue;
+  if (violations.length > 0) {
+    console.error("Core tsgo graphs must not include bundled extension files:");
+    for (const violation of violations) {
+      console.error(`- ${violation}`);
+    }
+    console.error(
+      "Move extension-owned behavior behind plugin SDK contracts, public artifacts, or extension-local tests.",
+    );
+    throw new Error("Core tsgo graphs include bundled extension files");
   }
-  const owners = buildInfoOwners.get(buildInfo) ?? [];
-  owners.push(shard.name);
-  buildInfoOwners.set(buildInfo, owners);
-}
-for (const [buildInfo, owners] of buildInfoOwners) {
-  if (owners.length > 1) {
-    shardViolations.push(`shared tsBuildInfoFile (${owners.join(", ")}): ${buildInfo}`);
-  }
-}
-
-if (shardViolations.length > 0) {
-  console.error(
-    `Core test shards must cover every canonical test root exactly once and stay at or below ${TSGO_CORE_TEST_MAX_ROOTS} roots:`,
-  );
-  for (const violation of shardViolations) {
-    console.error(`- ${violation}`);
-  }
-  process.exit(1);
+  return graphs;
 }
 
-const violations: string[] = [];
-for (const graph of coreGraphs) {
-  const extensionFiles = listGraphFiles(graph).filter((file) => file.startsWith("extensions/"));
-  for (const file of extensionFiles) {
-    violations.push(`${graph.name}: ${file}`);
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
+  try {
+    await checkCoreTsgoGraphBoundary();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = error instanceof CoreTsgoBoundaryInterruptedError ? error.exitCode : 1;
   }
-}
-
-if (violations.length > 0) {
-  console.error("Core tsgo graphs must not include bundled extension files:");
-  for (const violation of violations) {
-    console.error(`- ${violation}`);
-  }
-  console.error(
-    "Move extension-owned behavior behind plugin SDK contracts, public artifacts, or extension-local tests.",
-  );
-  process.exit(1);
 }

--- a/scripts/lib/tsgo-core-test-shards.mts
+++ b/scripts/lib/tsgo-core-test-shards.mts
@@ -60,6 +60,15 @@ export const TSGO_CORE_TEST_SHARDS = [
   },
 ] as const;
 
+export const TSGO_CORE_GRAPHS = [
+  { name: "core", config: "tsconfig.core.json" },
+  { name: "ui", config: "tsconfig.ui.json" },
+  ...TSGO_CORE_TEST_SHARDS.map((shard) => ({
+    name: `core-test-${shard.name}`,
+    config: shard.config,
+  })),
+];
+
 export type TsgoCoreTestShard = (typeof TSGO_CORE_TEST_SHARDS)[number];
 
 export const TSGO_TARGETED_TEST_SHARED_SHARDS = [
@@ -142,4 +151,37 @@ export function findTsgoCoreTestShardViolations(params: {
   }
 
   return violations;
+}
+
+/** Select every consuming graph, not just the file's declared root partition. */
+export function selectChangedTsgoCoreTestShards(
+  paths: readonly string[],
+  graphs: readonly { config: string; roots: readonly string[]; files: readonly string[] }[],
+): readonly { name: string; config: string }[] | undefined {
+  if (
+    paths.length === 0 ||
+    paths.some((file) => !/^(?:src|ui|packages)\/.+\.test\.tsx?$/u.test(file))
+  ) {
+    return undefined;
+  }
+  const testConfigs = new Set<string>(TSGO_CORE_TEST_SHARDS.map((shard) => shard.config));
+  const testGraphs = graphs.filter((graph) => testConfigs.has(graph.config));
+  if (
+    graphs.length !== TSGO_CORE_GRAPHS.length ||
+    TSGO_CORE_GRAPHS.some(
+      (expected) => graphs.filter((graph) => graph.config === expected.config).length !== 1,
+    ) ||
+    paths.some((file) => testGraphs.filter((graph) => graph.roots.includes(file)).length !== 1) ||
+    paths.some((file) => !testGraphs.some((graph) => graph.files.includes(file))) ||
+    graphs.some(
+      (graph) => !testConfigs.has(graph.config) && paths.some((file) => graph.files.includes(file)),
+    )
+  ) {
+    return undefined;
+  }
+  return TSGO_CORE_TEST_SHARDS.filter((shard) =>
+    testGraphs.some(
+      (graph) => graph.config === shard.config && paths.some((file) => graph.files.includes(file)),
+    ),
+  );
 }

--- a/scripts/run-tsgo-core-test-shards.mts
+++ b/scripts/run-tsgo-core-test-shards.mts
@@ -3,6 +3,8 @@
 // Run bounded test graphs in fresh processes so one shard's checker heap cannot
 // accumulate while the next shard loads.
 import path from "node:path";
+import type { CoreTsgoGraph } from "./check-tsgo-core-boundary.mts";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import {
   distArtifactEntryArgs,
   withDistArtifactOwnership,
@@ -12,45 +14,13 @@ import { runManagedCommand } from "./lib/managed-child-process.mts";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
 import {
   selectTsgoCoreTestShards,
+  selectChangedTsgoCoreTestShards,
+  TSGO_CORE_TEST_SHARDS,
   selectTsgoCoreTestStripe,
 } from "./lib/tsgo-core-test-shards.mts";
 
 const repoRoot = resolveRepoRoot(import.meta.url);
-// CI stripes split the serial shard sequence across parallel jobs; the
-// stripe union is exactly the full shard list, so coverage is unchanged.
-const stripeFlagIndex = process.argv.indexOf("--stripe");
-let shards;
-if (stripeFlagIndex >= 0) {
-  const stripeSpec = process.argv[stripeFlagIndex + 1] ?? "";
-  shards = selectTsgoCoreTestStripe(stripeSpec);
-  if (!shards) {
-    console.error(`Invalid core test stripe (expected i/n): ${stripeSpec}`);
-    process.exit(1);
-  }
-} else {
-  const requestedGroup = process.argv[2];
-  shards = selectTsgoCoreTestShards(requestedGroup);
-  if (!shards) {
-    console.error(`Unknown core test shard group: ${requestedGroup}`);
-    process.exit(1);
-  }
-}
-// Each graph is a serial single-project build, so tsgo gains little past four
-// cores; CI stripe jobs opt into overlapping fresh child processes to use the
-// idle cores. Local runs stay serial to keep the heap-bounded default.
-const concurrencyFlagIndex = process.argv.indexOf("--concurrency");
-let concurrency = 1;
-if (concurrencyFlagIndex >= 0) {
-  const rawConcurrency = process.argv[concurrencyFlagIndex + 1] ?? "";
-  concurrency = Number(rawConcurrency);
-  if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 4) {
-    console.error(`Invalid shard concurrency (expected 1-4): ${rawConcurrency}`);
-    process.exit(1);
-  }
-}
-const env = resolveLocalCheckEnv(process.env);
-
-function runShard(config: string): Promise<number> {
+function runShard(config: string, env: NodeJS.ProcessEnv): Promise<number> {
   return runManagedCommand({
     bin: process.execPath,
     args: distArtifactEntryArgs(path.join(repoRoot, "scripts/run-tsgo.mts"), [
@@ -65,35 +35,110 @@ function runShard(config: string): Promise<number> {
   });
 }
 
-// The batch owns outputs once; its existing compiler concurrency stays intact
-// without children waiting to reacquire their parent's lock.
-await withDistArtifactOwnership(repoRoot, async () => {
-  const queue = [...shards];
-  let failureCode = 0;
-  const workers = Array.from({ length: Math.min(concurrency, queue.length) }, async () => {
-    for (;;) {
-      const shard = queue.shift();
-      // Stop draining after the first failure so the exit stays prompt.
-      if (!shard || failureCode !== 0) {
-        return;
+/** Runs selected canonical graphs under the same output and child-process owner. */
+async function runTsgoCoreTestShards(
+  shards: readonly { name: string; config: string }[],
+  options: { concurrency?: number; env?: NodeJS.ProcessEnv } = {},
+): Promise<number> {
+  const concurrency = options.concurrency ?? 1;
+  const env = resolveLocalCheckEnv(options.env ?? process.env);
+  // The batch owns outputs once; its existing compiler concurrency stays intact
+  // without children waiting to reacquire their parent's lock.
+  return await withDistArtifactOwnership(repoRoot, async () => {
+    const queue = [...shards];
+    let failureCode = 0;
+    const workers = Array.from({ length: Math.min(concurrency, queue.length) }, async () => {
+      for (;;) {
+        const shard = queue.shift();
+        // Stop draining after the first failure so the exit stays prompt.
+        if (!shard || failureCode !== 0) {
+          return;
+        }
+        const code = await runShard(shard.config, env).catch((error: unknown) => {
+          failureCode = 1;
+          throw error;
+        });
+        if (code !== 0 && failureCode === 0) {
+          failureCode = code;
+        }
       }
-      const code = await runShard(shard.config).catch((error: unknown) => {
-        failureCode = 1;
-        throw error;
-      });
-      if (code !== 0 && failureCode === 0) {
-        failureCode = code;
-      }
+    });
+    const results = await Promise.allSettled(workers);
+    const failures = results.flatMap((result) =>
+      result.status === "rejected" ? [result.reason] : [],
+    );
+    if (failures.length > 0) {
+      throw new AggregateError(failures, "tsgo core test shards failed");
     }
+    return failureCode;
   });
-  const results = await Promise.allSettled(workers);
-  const failures = results.flatMap((result) =>
-    result.status === "rejected" ? [result.reason] : [],
-  );
-  if (failures.length > 0) {
-    throw new AggregateError(failures, "tsgo core test shards failed");
+}
+
+/** Owns one changed-check execution; plans never retain compiler inventories. */
+export function createChangedCoreTestCheck(paths: readonly string[], env: NodeJS.ProcessEnv) {
+  let graphs: CoreTsgoGraph[] | undefined;
+  return {
+    async checkBoundary(): Promise<number> {
+      graphs = undefined;
+      const { checkCoreTsgoGraphBoundary, CoreTsgoBoundaryInterruptedError } =
+        await import("./check-tsgo-core-boundary.mts");
+      try {
+        graphs = await checkCoreTsgoGraphBoundary();
+        return 0;
+      } catch (error) {
+        if (error instanceof CoreTsgoBoundaryInterruptedError) {
+          console.error(error.message);
+          return error.exitCode;
+        }
+        throw error;
+      }
+    },
+    async checkTypes(): Promise<number> {
+      const inspected = graphs;
+      graphs = undefined;
+      const shards = inspected && selectChangedTsgoCoreTestShards(paths, inspected);
+      const selected = shards ?? TSGO_CORE_TEST_SHARDS;
+      console.error(
+        `[check:changed] core test graphs: ${selected.map((shard) => shard.name).join(", ")}`,
+      );
+      return await runTsgoCoreTestShards(selected, { env });
+    },
+  };
+}
+
+if (isDirectRunUrl(process.argv[1], import.meta.url)) {
+  // CI stripes split the serial shard sequence across parallel jobs; the
+  // stripe union is exactly the full shard list, so coverage is unchanged.
+  const stripeFlagIndex = process.argv.indexOf("--stripe");
+  let shards;
+  if (stripeFlagIndex >= 0) {
+    const stripeSpec = process.argv[stripeFlagIndex + 1] ?? "";
+    shards = selectTsgoCoreTestStripe(stripeSpec);
+    if (!shards) {
+      console.error(`Invalid core test stripe (expected i/n): ${stripeSpec}`);
+      process.exit(1);
+    }
+  } else {
+    const requestedGroup = process.argv[2];
+    shards = selectTsgoCoreTestShards(requestedGroup);
+    if (!shards) {
+      console.error(`Unknown core test shard group: ${requestedGroup}`);
+      process.exit(1);
+    }
   }
-  if (failureCode !== 0) {
-    process.exitCode = failureCode;
+  // Each graph is a serial single-project build, so tsgo gains little past four
+  // cores; CI stripe jobs opt into overlapping fresh child processes to use the
+  // idle cores. Local runs stay serial to keep the heap-bounded default.
+  const concurrencyFlagIndex = process.argv.indexOf("--concurrency");
+  let concurrency = 1;
+  if (concurrencyFlagIndex >= 0) {
+    const rawConcurrency = process.argv[concurrencyFlagIndex + 1] ?? "";
+    concurrency = Number(rawConcurrency);
+    if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > 4) {
+      console.error(`Invalid shard concurrency (expected 1-4): ${rawConcurrency}`);
+      process.exit(1);
+    }
   }
-});
+
+  process.exitCode = await runTsgoCoreTestShards(shards, { concurrency });
+}

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -1275,6 +1275,16 @@ describe("scripts/changed-lanes", () => {
 
   it.each([
     {
+      name: "selects compiler-owned graphs for core test leaf changes",
+      path: "src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts",
+      expected: {
+        lanes: { coreTests: true },
+        includes: ["tsgo:core:test"],
+        excludes: ["tsgo:core"],
+        coreTestChecks: ["checkBoundary", "checkTypes"],
+      },
+    },
+    {
       name: "routes core test-only changes to core test lanes only",
       path: "packages/normalization-core/src/string-normalization.test-support.ts",
       expected: {
@@ -1303,9 +1313,13 @@ describe("scripts/changed-lanes", () => {
     },
   ])("$name", ({ path: changedPath, expected }) => {
     const result = detectChangedLanes([changedPath]);
-    const commands = createChangedCheckPlan(result).commands.map((command) => command.args[0]);
+    const plan = createChangedCheckPlan(result);
+    const commands = plan.commands.map((command) => command.args[0]);
 
     expectLanes(result.lanes, expected.lanes);
+    expect(plan.commands.flatMap((command) => command.coreTestCheck ?? [])).toEqual(
+      "coreTestChecks" in expected ? expected.coreTestChecks : [],
+    );
     for (const command of expected.includes) {
       expect(commands).toContain(command);
     }
@@ -2277,11 +2291,11 @@ describe("scripts/changed-lanes", () => {
         platform: "linux",
         swiftlintAvailable,
       });
-      const commands = plan.commands.map((command) => command.args[0]);
+      const commands = new Set(plan.commands.map((command) => command.args[0]));
 
-      expect(commands.includes("android:lint")).toBe(androidLint);
-      expect(commands.includes("lint:apps")).toBe(swiftlintAvailable);
-      expect(commands.includes("test:macos:ci")).toBe(macosCi);
+      expect(commands.has("android:lint")).toBe(androidLint);
+      expect(commands.has("lint:apps")).toBe(swiftlintAvailable);
+      expect(commands.has("test:macos:ci")).toBe(macosCi);
       expect(
         plan.commands.some(
           (command) => command.name === "lint apps (swiftlint unavailable on this host)",

--- a/test/scripts/tsgo-core-test-shards.test.ts
+++ b/test/scripts/tsgo-core-test-shards.test.ts
@@ -1,11 +1,18 @@
 import fs from "node:fs";
-import { describe, expect, it } from "vitest";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   findTsgoCoreTestShardViolations,
+  selectChangedTsgoCoreTestShards,
+  TSGO_CORE_GRAPHS,
   selectTsgoCoreTestShards,
   selectTsgoCoreTestStripe,
   TSGO_CORE_TEST_SHARDS,
 } from "../../scripts/lib/tsgo-core-test-shards.mts";
+import { createFixtureLifetime } from "../helpers/fixture-lifetime.js";
+import { isProcessAlive, waitForPidFile } from "../helpers/process-wait.js";
+import { runNodeScript } from "../helpers/run-node-script.js";
 
 describe("tsgo core test shards", () => {
   it("stripes partition the full shard list exactly once", () => {
@@ -91,3 +98,233 @@ describe("tsgo core test shards", () => {
     expect(packageJson.scripts["tsgo:all"]).not.toContain("run-tsgo.mjs -b");
   });
 });
+
+describe("changed core test graph selection", () => {
+  const leaf = "src/agents/nested/leaf.test.ts";
+  const inventory = () =>
+    TSGO_CORE_GRAPHS.map((graph) => ({
+      ...graph,
+      roots: graph.name === "core-test-agents-other" ? [leaf] : [],
+      files: graph.name === "core-test-agents-other" ? [leaf] : [],
+    }));
+
+  it("includes a consuming graph even when another graph owns the test root", () => {
+    const graphs = inventory();
+    graphs.find((graph) => graph.name === "core-test-agents-tools")!.files.push(leaf);
+    expect(selectChangedTsgoCoreTestShards([leaf], graphs)?.map((shard) => shard.name)).toEqual([
+      "agents-other",
+      "agents-tools",
+    ]);
+  });
+
+  it.for([
+    [],
+    ["src/owner.ts"],
+    ["test/tsconfig/tsconfig.core.test.json"],
+    ["src/shared.test-support.ts"],
+    ["src/missing.test.ts"],
+    [leaf, "package.json"],
+  ])("retains full checks for unsupported changed paths %j", (paths) => {
+    expect(selectChangedTsgoCoreTestShards(paths, inventory())).toBeUndefined();
+  });
+
+  it.each(["incomplete", "duplicate", "deleted", "production", "ambiguous"])(
+    "retains full checks for %s ownership",
+    (failure) => {
+      const graphs = inventory();
+      if (failure === "incomplete") {
+        graphs.shift();
+      }
+      if (failure === "duplicate") {
+        graphs.push(graphs[0]!);
+      }
+      if (failure === "deleted") {
+        graphs.forEach((graph) => {
+          graph.files = [];
+        });
+      }
+      if (failure === "production") {
+        graphs[0]!.files.push(leaf);
+      }
+      if (failure === "ambiguous") {
+        graphs.find((graph) => graph.name === "core-test-agents-tools")!.roots.push(leaf);
+      }
+      expect(selectChangedTsgoCoreTestShards([leaf], graphs)).toBeUndefined();
+    },
+  );
+});
+
+// The compiler owns dependency reachability; test root partitions alone cannot prove it.
+const lifetime = createFixtureLifetime();
+afterEach(() => lifetime.cleanup());
+
+it.runIf(process.platform !== "win32")(
+  "checks a real type error in the non-root importing graph without repeating enumeration",
+  ({ signal }) =>
+    lifetime.run(async () => {
+      const sourceRoot = process.cwd();
+      const root = fs.realpathSync(lifetime.createTempDir("openclaw-changed-types-"));
+      const write = (name: string, content: string) => {
+        const file = path.join(root, name);
+        fs.mkdirSync(path.dirname(file), { recursive: true });
+        fs.writeFileSync(file, content);
+        return file;
+      };
+      write("package.json", '{"type":"module"}');
+      write("pnpm-workspace.yaml", "packages: []\n");
+      for (const name of [
+        "check-tsgo-core-boundary.mts",
+        "run-tsgo-core-test-shards.mts",
+        "run-tsgo.mts",
+      ]) {
+        write(`scripts/${name}`, fs.readFileSync(path.join(sourceRoot, "scripts", name), "utf8"));
+      }
+      fs.symlinkSync(path.join(sourceRoot, "scripts/lib"), path.join(root, "scripts/lib"), "dir");
+      const leaf = "src/agents/nested/leaf.test.ts";
+      const consumer = "src/agents/tools/consumer.test.ts";
+      write(leaf, "export type Value = number;\n");
+      write(consumer, "export {};\n");
+      write("src/empty.ts", "export {};\n");
+      const configs = [
+        ...TSGO_CORE_GRAPHS,
+        { name: "canonical", config: "test/tsconfig/tsconfig.core.test.json" },
+      ];
+      for (const { name, config } of configs) {
+        const files =
+          name === "canonical"
+            ? [leaf, consumer]
+            : name === "core-test-agents-other"
+              ? [leaf]
+              : name === "core-test-agents-tools"
+                ? [consumer]
+                : ["src/empty.ts"];
+        write(
+          config,
+          JSON.stringify({
+            compilerOptions: {
+              noEmit: true,
+              strict: true,
+              types: [],
+              module: "nodenext",
+              target: "es2022",
+              incremental: true,
+              tsBuildInfoFile: path.join(root, `.artifacts/${name}.tsbuildinfo`),
+            },
+            files: files.map((file) => path.join(root, file)),
+          }),
+        );
+      }
+      const compiler = write(
+        "node_modules/.bin/tsgo",
+        `#!/usr/bin/env node
+const fs=require('node:fs'),path=require('node:path'),{spawnSync}=require('node:child_process');
+const args=process.argv.slice(2);
+fs.appendFileSync(path.join(process.cwd(),'compiler-events.jsonl'),JSON.stringify(args)+'\\n');
+const result=spawnSync(process.execPath,[${JSON.stringify(path.join(sourceRoot, "node_modules/@typescript/native-preview/bin/tsgo"))},...args],{stdio:'inherit'});
+process.exit(result.status??1);
+`,
+      );
+      fs.chmodSync(compiler, 0o755);
+      const driver = write(
+        "check.mts",
+        `
+import {createChangedCoreTestCheck} from './scripts/run-tsgo-core-test-shards.mts';
+const check=createChangedCoreTestCheck([${JSON.stringify(leaf)}],process.env);
+const boundary=await check.checkBoundary();
+process.exitCode=boundary || await check.checkTypes();
+`,
+      );
+      const check = async () => {
+        write("compiler-events.jsonl", "");
+        const result = await lifetime.track(
+          runNodeScript(
+            ["--import", pathToFileURL(path.join(sourceRoot, "scripts/tsx.mjs")).href, driver],
+            { ...process.env, OPENCLAW_LOCAL_CHECK: "0" },
+            undefined,
+            { cwd: root, signal, requireProcessTreeExit: true },
+          ),
+        );
+        const calls = fs
+          .readFileSync(path.join(root, "compiler-events.jsonl"), "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line) as string[]);
+        expect(calls.filter((args) => args.includes("--listFilesOnly"))).toHaveLength(
+          TSGO_CORE_GRAPHS.length,
+        );
+        const builds = calls
+          .filter((args) => args.includes("-b"))
+          .map((args) => args[args.indexOf("-b") + 1]);
+        return { result, builds };
+      };
+      const initial = await check();
+      expect(initial.result.status, initial.result.stderr).toBe(0);
+      expect(initial.builds).toEqual(["test/tsconfig/tsconfig.core.test.agents-other.json"]);
+      write(
+        consumer,
+        "import type {Value} from '../nested/leaf.test.js';\nconst value: Value = 1;\n",
+      );
+      const validConsumer = await check();
+      expect(validConsumer.result.status, validConsumer.result.stderr).toBe(0);
+      expect(validConsumer.builds).toEqual([
+        "test/tsconfig/tsconfig.core.test.agents-other.json",
+        "test/tsconfig/tsconfig.core.test.agents-tools.json",
+      ]);
+      write(leaf, "export type Value = string;\n");
+      const brokenConsumer = await check();
+      expect(brokenConsumer.result.status).not.toBe(0);
+      expect(brokenConsumer.builds).toEqual(validConsumer.builds);
+      expect(brokenConsumer.result.stdout + brokenConsumer.result.stderr).toContain(
+        "consumer.test.ts(2,7): error TS2322",
+      );
+      // Target only the boundary owner PID; its managed compiler must forward and join its group.
+      write(
+        "node_modules/.bin/tsgo",
+        `#!/usr/bin/env node
+const fs=require('node:fs'),{spawn}=require('node:child_process');
+const child=spawn(process.execPath,['-e',"process.on('SIGTERM',()=>process.exit(0)); process.send('ready'); setInterval(()=>{},1000);"],{stdio:['ignore','ignore','ignore','ipc']});
+let terminating=false;
+const finish=()=>{if(terminating && (child.exitCode!==null || child.signalCode!==null)){fs.writeFileSync('compiler.joined','joined');process.exit(0);}};
+child.once('exit',finish);
+process.on('SIGTERM',()=>{terminating=true;fs.writeFileSync('compiler.signal','SIGTERM');finish();});
+child.once('message',()=>{child.disconnect();fs.writeFileSync('compiler.pid',String(process.pid));fs.writeFileSync('descendant.pid',String(child.pid));});
+setInterval(()=>{},1000);
+`,
+      );
+      let ownerPid: number | undefined;
+      const cancel = new AbortController();
+      const running = lifetime.track(
+        runNodeScript(
+          ["--import", pathToFileURL(path.join(sourceRoot, "scripts/tsx.mjs")).href, driver],
+          { ...process.env, OPENCLAW_LOCAL_CHECK: "0" },
+          undefined,
+          {
+            cwd: root,
+            signal: AbortSignal.any([signal, cancel.signal]),
+            requireProcessTreeExit: true,
+            onReady(child) {
+              ownerPid = child.pid;
+            },
+          },
+        ),
+      );
+      try {
+        const compilerPid = await waitForPidFile(path.join(root, "compiler.pid"), 5_000);
+        const descendantPid = await waitForPidFile(path.join(root, "descendant.pid"), 5_000);
+        expect(ownerPid).toBeDefined();
+        process.kill(ownerPid!, "SIGTERM");
+        const canceled = await running;
+        expect(canceled.error).toBeUndefined();
+        expect(canceled.status).toBe(143);
+        expect(canceled.stderr).toContain("interrupted by SIGTERM");
+        expect(fs.readFileSync(path.join(root, "compiler.signal"), "utf8")).toBe("SIGTERM");
+        expect(fs.readFileSync(path.join(root, "compiler.joined"), "utf8")).toBe("joined");
+        expect(isProcessAlive(compilerPid)).toBe(false);
+        expect(isProcessAlive(descendantPid)).toBe(false);
+        expect(() => process.kill(-compilerPid, 0)).toThrow();
+      } finally {
+        cancel.abort();
+        await running;
+      }
+    }),
+);


### PR DESCRIPTION
## What Problem This Solves

A one-test repair can spend most of its changed-files gate compiling all 16 core test graphs. This slows the edit, prove, and land cycle during release verification even when only one graph consumes the changed file.

## Why This Change Was Made

Keep the existing complete compiler boundary check over all 18 production and test graphs, and reuse its resolved file inventory within the same check execution. For a pure existing test-leaf change, compile every test graph that consumes the file, including graphs that import it indirectly. Consume that inventory once; plans retain no compiler state.

Mixed production/tooling changes, removed or unknown roots, incomplete inventories, and tests consumed by production graphs retain the full test compilation. The existing runner still owns output locks and fresh child processes. Compiler inventory queries also run through the existing managed process owner, with bounded output capture and signal forwarding; cancellation returns only after the compiler tree is joined. Direct CLI groups, full CI stripes, serial defaults, resource limits, timeouts, and assertions are unchanged. No new cache, configuration, environment option, or dependency.

## User Impact

Maintainers can verify isolated test repairs without recompiling unrelated graphs. This is internal verification tooling; product runtime behavior and the coverage of full release CI do not change.

## Evidence

The pre-change reproduction selected all 16 graphs for one test leaf. Regression coverage executes the real changed-check plan, compiler boundary, and shard runner: a leaf selects its owner; adding an importing test selects that graph too; an incompatible exported type then produces TS2322 in the non-root consumer. All 18 boundary enumerations remain required.

The earlier native six-file gate and 219 sibling tests passed, but independent review then found that in-process synchronous inventory queries could leave compiler descendants alive after PID-targeted cancellation. That failure was reproduced before repair. Both query collectors now share one asynchronous managed command path: interrupted checks retain exit 143 after joining; ordinary compiler failures retain diagnostics; output overflow fails and joins rather than truncating the inventory.

The corrected source passed all 219 canonical tooling tests locally and on native Linux. On an actual four-CPU runner with Node 24.19, the complete six-path changed-files gate passed in 190.49 seconds, and standalone PID cancellation preserved exit 143 with both compiler and descendant stopped. The final test-only exit-listener ordering cleanup then passed its changed-test gate in 73.90 seconds and all 219 cases in 13.67 seconds on the same lease. All production hashes were unchanged; final source hashes match this PR. [Native proof](https://github.com/openclaw/openclaw/actions/runs/33392122887).

A fresh private copy with all workspace dependencies and no inherited compiler artifacts completed the same one-test gate in 250.20 seconds (4m10s), versus the retained earlier four-CPU baseline of 851.06 seconds (14m11s). Test compilation was 52.90 seconds versus 676.33 seconds, while all 18 boundary graphs were checked. This is an observed 70.6% reduction in that gate, about ten minutes; different hosts, source bases, and cache histories prevent a controlled A/B or total-release speedup claim. No memory reduction is claimed.

Managed Codex review of the final six-file diff found no actionable P0-P2 findings. Exact-head CI remains required before landing.

Product runtime delta: 0. Tooling: +174 net lines, including factoring the existing boundary/runner into their shared execution owner and replacing duplicate synchronous collectors with bounded managed capture. Tests: +251 net lines, including real cross-graph compiler and cancellation coverage. Existing full-run paths remain in the same owner rather than being duplicated. Managed review and exact-head CI are required before landing.

Named follow-up: existing documentation and a CI comment contain stale test-graph counts; this change does not alter the number of graphs or CI stripes.
