### PR TITLE
fix(ci): remove redundant Anthropic worker probe

### DIFF
--- a/test/scripts/vitest-worker-artifacts.test.ts
+++ b/test/scripts/vitest-worker-artifacts.test.ts
@@ -554,42 +554,6 @@ describe("fresh compiled subprocess invocation", () => {
     },
   );
 
-  it("uses the prepared Anthropic failover hook in a fresh process without global activation", (context) =>
-    fixtureLifetime.run(async () => {
-      const { node } = createFixtureCommands(context);
-      const probe = writeFixture(
-        fixtureDirectory(),
-        "anthropic-hook.mts",
-        `
-          import assert from 'node:assert/strict';
-          import {coerceToFailoverError} from ${JSON.stringify(pathToFileURL(path.join(root, "src/agents/failover-error.ts")).href)};
-          import {getActivePluginRegistry} from ${JSON.stringify(pathToFileURL(path.join(root, "src/plugins/runtime.ts")).href)};
-          import {loadPluginRegistryHandle} from ${JSON.stringify(pathToFileURL(path.join(root, "src/plugins/loader.ts")).href)};
-          import {withPluginRuntimeRegistryScope} from ${JSON.stringify(pathToFileURL(path.join(root, "src/plugins/runtime/gateway-request-scope.ts")).href)};
-          assert.equal(getActivePluginRegistry(), null);
-          const classify = () => coerceToFailoverError(
-            {code: 'API_ERROR', message: 'provider failure'}, {provider: 'anthropic'},
-          );
-          assert.equal(classify(), null, 'error handling must not discover a provider');
-          const registry = loadPluginRegistryHandle({
-            config: {plugins:{entries:{anthropic:{enabled:true}}}},
-            onlyPluginIds: ['anthropic'],
-          });
-          assert.ok(registry.providers.some(entry=>entry.provider.id==='anthropic'));
-          const result = withPluginRuntimeRegistryScope(registry,classify);
-          assert.equal(result?.reason, 'server_error');
-          assert.equal(result?.provider, 'anthropic');
-          assert.equal(getActivePluginRegistry(), null);
-        `,
-      );
-      const result = await node(resolveRuntimeWorkerArgv(pathToFileURL(probe)), root, {
-        ...process.env,
-        OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(root, "extensions"),
-        OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
-      });
-      expect(result.code, result.stderr + result.stdout).toBe(0);
-    }));
-
   it("preserves scoped and prepared provider hooks in source and compiled TUI payloads", (context) =>
     fixtureLifetime.run(async () => {
       const { node, prepareWorkers } = createFixtureCommands(context);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Windows `test-1` CI lane repeatedly timed out while a worker-artifact test cold-loaded the real bundled Anthropic plugin source.

## Why This Change Was Made

The test synchronously transformed the full Anthropic runtime graph through jiti, turning a worker-artifact contract check into an expensive plugin-loader benchmark. This removes that redundant composite probe; the Anthropic mapping, prepared provider handle, registry scoping, consumer routing, and fresh source/compiled subprocess contracts remain covered at their owning boundaries.

Production LOC: +0/-0
Tests: +0/-36

## User Impact

No user-visible behavior changes. Windows CI no longer spends its test timeout and more than a gigabyte of memory re-proving contracts already covered by focused owner tests.

## Evidence

- Reproduced before the change: 62.2 seconds and approximately 1.2 GB RSS for the removed probe.
- Exact CI failures:
  - https://github.com/openclaw/openclaw/actions/runs/33388110342/job/99475802765
  - https://github.com/openclaw/openclaw/actions/runs/33388450093/job/99477064707
- `node scripts/run-vitest.mjs test/scripts/vitest-worker-artifacts.test.ts`: 32/32 passed.
- Focused Anthropic/provider/runtime/failover owner suites: 169/169 passed.
- `git diff --check`: passed.
- `check-changed` reached unrelated sparse-checkout missing-file errors in Telegram, UI, Android, and QA paths after the relevant checks passed.
