### PR TITLE
fix(ci): bind agent prompt fixture model

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-system-prompt.test.ts
@@ -139,7 +139,7 @@ describe("buildAttemptSystemPrompt", () => {
         effectiveCwd: workspaceDir,
         effectiveTools: [],
         effectiveWorkspace: workspaceDir,
-        getProviderRuntimeHandle: () => ({ provider: "openai" }),
+        getProviderRuntimeHandle: () => ({ provider: "openai", modelId: "gpt-5.5" }),
         isRawModelRun: true,
         markStage: vi.fn(),
         modelToolsEnabled: false,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the embedded-agent CI shard repeatedly timed out while testing global-session sandbox reporting.

## Why This Change Was Made

The test supplied a provider-only runtime handle even though the prompt context selected `gpt-5.5`. That mismatch correctly triggered cold provider discovery, making the first parameter row load the real plugin graph. The fixture now carries the already-selected model, matching the production prepared-handle contract and the sibling fixture in this test file.

Production LOC: +0/-0
Tests: +1/-1

## User Impact

No user-visible behavior changes. The regression test still checks both sandbox ownership cases without accidentally benchmarking cold plugin discovery.

## Evidence

- Reproduced before the change: first fresh row took approximately 98-132 seconds; direct prompt preparation took 83.6 seconds and approximately 1.27 GB RSS.
- Exact CI failures:
  - https://github.com/openclaw/openclaw/actions/runs/33388110342/job/99475804677
  - https://github.com/openclaw/openclaw/actions/runs/33388450093/job/99477067487
- Fresh-process rows after the change: 137 ms and 128 ms.
- Focused file: 12/12 passed.
- Owning `agents-embedded-agent-run` shard: 1,467/1,467 passed in 51.46 seconds.
- `git diff --check`: passed.
- `check-changed` reached an unrelated sparse-checkout missing UI file during the dead-export scan after the relevant checks passed.
