### PR TITLE
test(infra): simplify HTTP response assertions

### DIFF
--- a/src/infra/http-body.response.test.ts
+++ b/src/infra/http-body.response.test.ts
@@ -73,37 +73,6 @@ async function expectIdleTimeout(
   }
 }
 
-async function expectReadResponseTextSnippetCase(params: {
-  response: Response;
-  options: Parameters<typeof readResponseTextSnippet>[1];
-  expected: string;
-}) {
-  await expect(readResponseTextSnippet(params.response, params.options)).resolves.toBe(
-    params.expected,
-  );
-}
-
-async function expectReadResponseWithLimitSuccessCase(params: {
-  response: Response;
-  maxBytes: number;
-  expected: Buffer;
-  options?: Parameters<typeof readResponseWithLimit>[2];
-}) {
-  const buf = await readResponseWithLimit(params.response, params.maxBytes, params.options);
-  expect(buf).toEqual(params.expected);
-}
-
-async function expectReadResponseWithLimitFailureCase(params: {
-  response: Response;
-  maxBytes: number;
-  options?: Parameters<typeof readResponseWithLimit>[2];
-  expectedError: RegExp | string;
-}) {
-  await expect(
-    readResponseWithLimit(params.response, params.maxBytes, params.options),
-  ).rejects.toThrow(params.expectedError);
-}
-
 describe("cancelUnreadResponseBody", () => {
   it("cancels unread bodies and ignores cancellation failures", async () => {
     const cancel = vi.fn(() => {
@@ -211,13 +180,13 @@ describe("readResponseWithLimit", () => {
     },
   );
 
+  it("reads all chunks within the limit", async () => {
+    const response = new Response(makeStream([new Uint8Array([1, 2]), new Uint8Array([3, 4])]));
+
+    await expect(readResponseWithLimit(response, 100)).resolves.toEqual(Buffer.from([1, 2, 3, 4]));
+  });
+
   it.each([
-    {
-      name: "reads all chunks within the limit",
-      response: new Response(makeStream([new Uint8Array([1, 2]), new Uint8Array([3, 4])])),
-      maxBytes: 100,
-      expected: Buffer.from([1, 2, 3, 4]),
-    },
     {
       name: "throws when total exceeds maxBytes",
       response: new Response(makeStream([new Uint8Array([1, 2, 3]), new Uint8Array([4, 5, 6])])),
@@ -234,28 +203,16 @@ describe("readResponseWithLimit", () => {
       },
       expectedError: "custom: 10 > 5",
     },
-  ] as const)("$name", async ({ response, maxBytes, options, expected, expectedError }) => {
-    if (expected !== undefined) {
-      await expectReadResponseWithLimitSuccessCase({ response, maxBytes, options, expected });
-      return;
-    }
-
-    await expectReadResponseWithLimitFailureCase({
-      response,
-      maxBytes,
-      options,
-      expectedError,
-    });
+  ] as const)("$name", async ({ response, maxBytes, options, expectedError }) => {
+    await expect(readResponseWithLimit(response, maxBytes, options)).rejects.toThrow(expectedError);
   });
 
   it.each([Number.NaN, Number.POSITIVE_INFINITY, -1])(
     "rejects invalid maxBytes before reading: %s",
     async (maxBytes) => {
-      await expectReadResponseWithLimitFailureCase({
-        response: new Response(makeStream([new Uint8Array([1, 2, 3])])),
-        maxBytes,
-        expectedError: /maxBytes must be a non-negative finite number/,
-      });
+      await expect(
+        readResponseWithLimit(new Response(makeStream([new Uint8Array([1, 2, 3])])), maxBytes),
+      ).rejects.toThrow(/maxBytes must be a non-negative finite number/);
     },
   );
 
@@ -306,12 +263,7 @@ describe("readResponseWithLimit", () => {
     }
   });
 
-  it.each([
-    {
-      name: "does not time out while chunks keep arriving",
-      expected: Buffer.from([1, 2]),
-    },
-  ] as const)("$name", async ({ expected }) => {
+  it("does not time out while chunks keep arriving", async () => {
     vi.useFakeTimers();
     try {
       const body = makeStream([new Uint8Array([1]), new Uint8Array([2])], 10);
@@ -319,7 +271,7 @@ describe("readResponseWithLimit", () => {
       const readPromise = readResponseWithLimit(res, 100, { chunkTimeoutMs: 500 });
       await vi.advanceTimersByTimeAsync(25);
       const buf = await readPromise;
-      expect(buf).toEqual(expected);
+      expect(buf).toEqual(Buffer.from([1, 2]));
     } finally {
       vi.useRealTimers();
     }
@@ -529,7 +481,7 @@ describe("readResponseTextSnippet", () => {
       expected: "ab…",
     },
   ] as const)("$name", async ({ response, options, expected }) => {
-    await expectReadResponseTextSnippetCase({ response, options, expected });
+    await expect(readResponseTextSnippet(response, options)).resolves.toBe(expected);
   });
 
   it("rejects invalid maxBytes before reading text snippets", async () => {
@@ -552,19 +504,10 @@ describe("readResponseTextSnippet", () => {
     expect(cancel).toHaveBeenCalledTimes(1);
   });
 
-  it.each([
-    {
-      name: "applies the idle timeout while reading snippets",
-      createReadPromise: () => {
-        const res = new Response(makeStallingStream([new Uint8Array([65, 66])]));
-        return readResponseTextSnippet(res, { maxBytes: 64, chunkTimeoutMs: 50 });
-      },
-    },
-  ] as const)(
-    "$name",
-    async ({ createReadPromise }) => {
-      await expectIdleTimeout(createReadPromise);
-    },
-    5_000,
-  );
+  it("applies the idle timeout while reading snippets", async () => {
+    await expectIdleTimeout(() => {
+      const res = new Response(makeStallingStream([new Uint8Array([65, 66])]));
+      return readResponseTextSnippet(res, { maxBytes: 64, chunkTimeoutMs: 50 });
+    });
+  }, 5_000);
 });


### PR DESCRIPTION
## What Problem This Solves

HTTP response tests hide individual assertions behind three single-assertion wrappers and two one-row parameter tables. A mixed success/error table also branches on optional fixture fields.

## Why This Change Was Made

Assert directly against the real response readers, give the success case its own test, and keep the error matrix uniform. Convert one-row tables into ordinary tests without changing their explicit deadlines.

## User Impact

No runtime change. All 31 behavior cases and 58 effective assertions remain, including native response clones, cancellation, byte limits, Unicode truncation, stalled streams and idle timeout cleanup. Production +0/-0; tests +20/-77.

## Evidence

- All 31 focused tests pass. This change improves readability and removes duplicate scaffolding; it makes no elapsed-time performance claim.
- Complete response reader, timeout owner, caller and test source inspected. Stream fixtures and cleanup remain unchanged.
- Full changed-file gate, formatting, diff check and structured Codex autoreview pass.

Recorded after-change local run started at `2026-08-31T12:44:14.141Z`.

```text
node scripts/run-vitest.mjs src/infra/http-body.response.test.ts
```

Native reporter summary (selected fields):

```json
{"numPassedTests":31,"numFailedTests":0,"numPendingTests":0,"success":true}
```

The native report includes the direct success/error assertions and the retained clone, cancellation, Unicode, and timeout cases.

Native `assertionResults` excerpt (selected records and fields, copied without changing case names or results):

```json
[
  {"fullName":"cancelUnreadResponseBody does not wait for a retained response clone to finish cancellation","status":"passed"},
  {"fullName":"readResponseWithLimit settles deadline reads before a retained response clone is released","status":"passed"},
  {"fullName":"readResponseWithLimit reads all chunks within the limit","status":"passed"},
  {"fullName":"readResponseWithLimit 'throws when total exceeds maxBytes'","status":"passed"},
  {"fullName":"readResponseWithLimit passes the idle-timeout error to stream cancellation","status":"passed"},
  {"fullName":"readResponseWithLimit clears the overall timeout after a successful read","status":"passed"},
  {"fullName":"readResponseTextSnippet 'drops partial UTF-8 characters when s…'","status":"passed"},
  {"fullName":"readResponseTextSnippet applies the idle timeout while reading snippets","status":"passed"}
]
```

Wrapper output excerpt; its elapsed time includes startup:

```text
[test] starting test/vitest/vitest.infra.config.ts
[test] passed 1 Vitest shard in 4.24s
```
