### PR TITLE
test(utils): add conversation-target test coverage

### DIFF
--- a/src/utils/conversation-target.test.ts
+++ b/src/utils/conversation-target.test.ts
@@ -1,0 +1,88 @@
+// Tests for conversation target parameter normalization.
+import { describe, expect, it } from "vitest";
+import { normalizeConversationTargetParams } from "./conversation-target.js";
+
+describe("normalizeConversationTargetParams", () => {
+  it("returns empty object for empty params", () => {
+    const result = normalizeConversationTargetParams({});
+    expect(result).toEqual({});
+  });
+
+  it("normalizes channel string", () => {
+    const result = normalizeConversationTargetParams({ channel: "telegram" });
+    expect(result.channel).toBe("telegram");
+  });
+
+  it("trims channel whitespace", () => {
+    const result = normalizeConversationTargetParams({ channel: "  telegram  " });
+    expect(result.channel).toBe("telegram");
+  });
+
+  it("normalizes numeric conversationId to string", () => {
+    const result = normalizeConversationTargetParams({ conversationId: 123 });
+    expect(result.conversationId).toBe("123");
+  });
+
+  it("normalizes large numeric conversationId to string", () => {
+    const result = normalizeConversationTargetParams({ conversationId: 9007199254740991 });
+    expect(result.conversationId).toBe("9007199254740991");
+  });
+
+  it("truncates decimal conversationId", () => {
+    const result = normalizeConversationTargetParams({ conversationId: 123.7 });
+    expect(result.conversationId).toBe("123");
+  });
+
+  it("normalizes string conversationId", () => {
+    const result = normalizeConversationTargetParams({ conversationId: "thread-abc" });
+    expect(result.conversationId).toBe("thread-abc");
+  });
+
+  it("trims string conversationId whitespace", () => {
+    const result = normalizeConversationTargetParams({ conversationId: "  thread-abc  " });
+    expect(result.conversationId).toBe("thread-abc");
+  });
+
+  it("returns undefined for undefined conversationId", () => {
+    const result = normalizeConversationTargetParams({});
+    expect(result.conversationId).toBeUndefined();
+  });
+
+  it("returns undefined for null conversationId", () => {
+    const result = normalizeConversationTargetParams({ conversationId: null as never });
+    expect(result.conversationId).toBeUndefined();
+  });
+
+  it("normalizes numeric parentConversationId", () => {
+    const result = normalizeConversationTargetParams({ parentConversationId: 456 });
+    expect(result.parentConversationId).toBe("456");
+  });
+
+  it("normalizes all fields together", () => {
+    const result = normalizeConversationTargetParams({
+      channel: "discord",
+      conversationId: 789,
+      parentConversationId: 101112,
+    });
+    expect(result).toEqual({
+      channel: "discord",
+      conversationId: "789",
+      parentConversationId: "101112",
+    });
+  });
+
+  it("handles Infinity conversationId by truncating", () => {
+    const result = normalizeConversationTargetParams({ conversationId: Infinity });
+    expect(result.conversationId).toBeUndefined();
+  });
+
+  it("handles NaN conversationId", () => {
+    const result = normalizeConversationTargetParams({ conversationId: NaN });
+    expect(result.conversationId).toBeUndefined();
+  });
+
+  it("handles object conversationId", () => {
+    const result = normalizeConversationTargetParams({ conversationId: {} as never });
+    expect(result.conversationId).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Add test coverage for the conversation-target utility. Tests parameter extraction for multi-channel dispatch, default fallback behavior, and edge cases for malformed or missing routing parameters.

## What Problem This Solves

The `normalizeConversationTargetParams` helper lacked unit tests. This PR adds coverage for channel string normalization, numeric/string conversationId coercion, parentConversationId handling, and edge cases (Infinity, NaN, objects, null, undefined).

## Evidence

### Real Behavior Proof

**Revised head:** `ee54cbd5ab81c0b6794b1d0a0f525b979bcf3aec`

**Environment:** Ubuntu 22.04, Node v24.14.1, Vitest v4.1.11

**Command run:**
```bash
git checkout test-conversation-target
pnpm install
pnpm test src/utils/conversation-target.test.ts
```

**Terminal output:**
```
$ pnpm test src/utils/conversation-target.test.ts

 RUN  v4.1.11 /tmp/openclaw

 ✓ src/utils/conversation-target.test.ts (15 tests) 6ms

 Test Files  1 passed (1)
      Tests  15 passed (15)
   Duration  159ms
```

**Observed result:** All 15 test assertions pass.

**What was not tested:**
- Windows-specific behavior
- Interactive PTY mode
- Node.js versions < 20
