### PR TITLE
test(scripts): set ratchet fixture identity per Git invocation

### DIFF
--- a/test/scripts/check-assertion-safety-ratchet.test.ts
+++ b/test/scripts/check-assertion-safety-ratchet.test.ts
@@ -40,7 +40,11 @@ function git(cwd: string, args: string[]) {
   for (const key of nestedGitEnvKeys) {
     delete env[key];
   }
-  execFileSync("git", args, { cwd, env, stdio: "ignore" });
+  execFileSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=Test", ...args], {
+    cwd,
+    env,
+    stdio: "ignore",
+  });
 }
 
 afterEach(() => {
@@ -102,13 +106,7 @@ describe("check-assertion-safety-ratchet", () => {
     const sourcePath = path.join(root, "src/example.ts");
     fs.writeFileSync(baselinePath, "src/example.ts\t1\n");
     fs.writeFileSync(sourcePath, "export const first = value as string;\n");
-    for (const args of [
-      ["init"],
-      ["config", "user.email", "test@example.com"],
-      ["config", "user.name", "Test"],
-      ["add", "."],
-      ["commit", "-m", "base"],
-    ]) {
+    for (const args of [["init"], ["add", "."], ["commit", "-m", "base"]]) {
       git(root, args);
     }
 
@@ -167,8 +165,6 @@ describe("check-assertion-safety-ratchet", () => {
     );
     for (const args of [
       ["init"],
-      ["config", "user.email", "test@example.com"],
-      ["config", "user.name", "Test"],
       ["add", "."],
       ["commit", "-m", "base with stale assertion baseline"],
     ]) {
@@ -195,14 +191,7 @@ describe("check-assertion-safety-ratchet", () => {
     );
     fs.writeFileSync(path.join(root, "src/a.ts"), "export const a = value as string;\n");
     fs.writeFileSync(path.join(root, "src/b.ts"), "export const b = value as string;\n");
-    for (const args of [
-      ["init"],
-      ["config", "user.email", "test@example.com"],
-      ["config", "user.name", "Test"],
-      ["add", "."],
-      ["commit", "-m", "base"],
-      ["branch", "release"],
-    ]) {
+    for (const args of [["init"], ["add", "."], ["commit", "-m", "base"], ["branch", "release"]]) {
       git(root, args);
     }
 

--- a/test/scripts/check-max-lines-ratchet.test.ts
+++ b/test/scripts/check-max-lines-ratchet.test.ts
@@ -42,17 +42,15 @@ function git(cwd: string, args: string[]): void {
   for (const key of nestedGitEnvKeys) {
     delete env[key];
   }
-  execFileSync("git", args, { cwd, env, stdio: "ignore" });
+  execFileSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=Test", ...args], {
+    cwd,
+    env,
+    stdio: "ignore",
+  });
 }
 
 function commitFixture(root: string, message = "base"): void {
-  for (const args of [
-    ["init"],
-    ["config", "user.email", "test@example.com"],
-    ["config", "user.name", "Test"],
-    ["add", "."],
-    ["commit", "-m", message],
-  ]) {
+  for (const args of [["init"], ["add", "."], ["commit", "-m", message]]) {
     git(root, args);
   }
 }


### PR DESCRIPTION
## What Problem This Solves

The max-lines and assertion-safety ratchet fixtures launch two extra Git commands per committed repository solely to persist the same test identity. Twelve committed fixtures repeat that setup.

## Why This Change Was Made

Supply the same identity through command-scoped git -c options in each existing Git helper. This removes 24 setup-only Git processes while retaining all thirteen independent repositories, including the index-only filename fixture. Actual commits, refs, merge bases, renames and index reads remain.

## User Impact

No runtime change. All seventeen changed-suite cases retain suppression and debt rules, AST/SAFETY parsing, moving and disconnected bases, staged versus working-tree content, unusual filenames and baseline pruning. Production +0/-0; tests +13/-26.

## Evidence

- All 34 tests pass across both ratchets and the shared shrink-ratchet suite.
- Changed-suite test-body time decreased locally from 2183.6 ms to 1929.8 ms. This is a local observation, not a CI-wide benchmark.
- Git's installed manual documents command-scoped configuration; the shared ratchet suite already uses this identity mechanism. Source, owner and relevant history inspected.
- Full changed-file gate, formatting, diff check and structured Codex autoreview pass.

Recorded after-change local run started at `2026-08-31T12:47:39.158Z`.

```text
node scripts/run-vitest.mjs test/scripts/check-max-lines-ratchet.test.ts test/scripts/check-assertion-safety-ratchet.test.ts test/scripts/shrink-ratchet.test.ts
```

Native reporter summary (selected fields):

```json
{"numPassedTests":34,"numFailedTests":0,"numPendingTests":0,"success":true}
```

These passing cases create and inspect real Git repositories, including committed histories, moving bases, renames, and the index-only filename fixture. The shared snapshot suite ran in the same invocation.

Native `assertionResults` excerpt (selected records and fields, copied without changing case names or results):

```json
[
  {"fullName":"check-assertion-safety-ratchet blocks new debt, accepts SAFETY comments, and prunes reduced counts","status":"passed"},
  {"fullName":"check-assertion-safety-ratchet compares an explicit moving base at the branch fork","status":"passed"},
  {"fullName":"check-max-lines-ratchet transfers grandfathered debt across a verified rename","status":"passed"},
  {"fullName":"check-max-lines-ratchet falls back to main when no merge base is available","status":"passed"},
  {"fullName":"check-max-lines-ratchet checks staged content instead of unstaged worktree edits","status":"passed"},
  {"fullName":"check-max-lines-ratchet keeps staged filenames NUL-framed","status":"passed"},
  {"fullName":"shrink-ratchet loads worktree, index, and reference snapshots","status":"passed"}
]
```

Wrapper output excerpt; its elapsed time includes startup:

```text
[test] starting test/vitest/vitest.tooling.config.ts
[test] passed 1 Vitest shard in 6.31s
```
