### PR TITLE
test(scripts): call package consent parser directly

### DIFF
--- a/test/scripts/package-compat.test.ts
+++ b/test/scripts/package-compat.test.ts
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { fixtureCapabilityConsentArgs } from "../../scripts/e2e/lib/package-compat.mjs";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -252,19 +253,13 @@ run_plugins_clawhub_scenario
   );
 
   it.each([
-    ["  --accept-capabilities  Accept\n", consent],
-    ["  \u001b[32m--accept-capabilities\u001b[0m  Accept\n", consent],
-    ["  --accept-capabilities-extra  Other\n", ""],
-    ["See --accept-capabilities in newer releases\n", ""],
-    ["  --force  Confirm\n", ""],
+    ["  --accept-capabilities  Accept\n", [consent]],
+    ["  \u001b[32m--accept-capabilities\u001b[0m  Accept\n", [consent]],
+    ["  --accept-capabilities-extra  Other\n", []],
+    ["See --accept-capabilities in newer releases\n", []],
+    ["  --force  Confirm\n", []],
   ])("reads only an advertised option from help %j", (help, expected) => {
-    const result = spawnSync(
-      process.execPath,
-      ["scripts/e2e/lib/package-compat.mjs", "fixture-consent"],
-      { encoding: "utf8", input: help },
-    );
-    expect(result.status).toBe(0);
-    expect(result.stdout.trim()).toBe(expected);
+    expect(fixtureCapabilityConsentArgs(help)).toEqual(expected);
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

Five help-text parser cases each start Node even though the production parser is already exported and the suite separately exercises real shell and CLI integration.

## Why This Change Was Made

Call fixtureCapabilityConsentArgs directly for the five literal fixtures, keeping exact argument-array expectations for advertised options, ANSI-colored help, longer option names, prose-only mentions and unrelated help. No test seam or production export is added.

## User Impact

No consent-policy or runtime change. All 23 cases remain, including fifteen shell integration cases and three legacy-version CLI cases. Five fewer Node processes are launched. Production +0/-0; tests +7/-12.

## Evidence

- All 23 tests pass together, including real help failures/timeouts, literal argv, both plugin sweeps, mutation failures and executable replacement.
- Local complete-suite time was 14.26 seconds before and 15.76 seconds after; process-count reduction is deterministic, but this pair does not demonstrate a wall-time speedup.
- Full changed-file gate, formatting, diff check and structured Codex autoreview pass. Parser, direct-run guard, shell consent owner and sweep callers inspected.

Recorded after-change local run started at `2026-08-31T12:49:22.726Z`.

```text
node scripts/run-vitest.mjs test/scripts/package-compat.test.ts
```

Native reporter summary (selected fields):

```json
{"numPassedTests":23,"numFailedTests":0,"numPendingTests":0,"success":true}
```

The same recorded run includes the five direct parser rows and the retained shell/CLI paths: both support states, literal arguments, real help timeouts, mutation status, and executable replacement.

Native `assertionResults` excerpt (selected records and fields, copied without changing case names or results):

```json
[
  {"fullName":"package fixture consent compatibility runs the plugin sweep with selective consent (supported=true)","status":"passed"},
  {"fullName":"package fixture consent compatibility runs the plugin sweep with selective consent (supported=false)","status":"passed"},
  {"fullName":"package fixture consent compatibility probes each command and preserves literal argv","status":"passed"},
  {"fullName":"package fixture consent compatibility reads only an advertised option from help \"  --accept-capabilities  Accept\\n\"","status":"passed"},
  {"fullName":"package fixture consent compatibility reads only an advertised option from help \"  \\u001b[32m--accept-capabilities\\u001b[0m  Accept\\n\"","status":"passed"},
  {"fullName":"package fixture consent compatibility reads only an advertised option from help \"  --accept-capabilities-extra  Other\\n\"","status":"passed"},
  {"fullName":"package fixture consent compatibility reads only an advertised option from help \"See --accept-capabilities in newer releases\\n\"","status":"passed"},
  {"fullName":"package fixture consent compatibility reads only an advertised option from help \"  --force  Confirm\\n\"","status":"passed"},
  {"fullName":"package fixture consent compatibility plugins logger fails before mutation on help timeout","status":"passed"},
  {"fullName":"package fixture consent compatibility kitchen-sink logger fails before mutation on help timeout","status":"passed"},
  {"fullName":"package fixture consent compatibility returns the mutation exit status","status":"passed"},
  {"fullName":"package fixture consent compatibility reprobes a replacement at the same executable path and version","status":"passed"}
]
```

Wrapper output excerpt; its elapsed time includes startup:

```text
[test] starting test/vitest/vitest.tooling.config.ts
[test] passed 1 Vitest shard in 20.09s
```
