### PR TITLE
fix(msteams): deliver the controls an agent reply offers

### DIFF
--- a/extensions/msteams/src/messenger.presentation.test.ts
+++ b/extensions/msteams/src/messenger.presentation.test.ts
@@ -1,0 +1,196 @@
+// Msteams tests cover delivering a reply's portable presentation.
+import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { StoredConversationReference } from "./conversation-store.js";
+import { renderReplyPayloadsToMessages, sendMSTeamsMessages } from "./messenger.js";
+import { setMSTeamsRuntime } from "./runtime.js";
+import type { MSTeamsApp } from "./sdk.js";
+
+const chunkMarkdownText = (text: string, limit: number) => {
+  if (!text) {
+    return [];
+  }
+  if (limit <= 0 || text.length <= limit) {
+    return [text];
+  }
+  const chunks: string[] = [];
+  for (let index = 0; index < text.length; index += limit) {
+    chunks.push(text.slice(index, index + limit));
+  }
+  return chunks;
+};
+
+const runtimeStub = {
+  config: { loadConfig: () => ({}) },
+  channel: {
+    text: {
+      chunkMarkdownText,
+      chunkMarkdownTextWithMode: chunkMarkdownText,
+      resolveMarkdownTableMode: () => "code",
+      convertMarkdownTables: (text: string) => text,
+    },
+  },
+} as unknown as PluginRuntime;
+
+const conversationRef: StoredConversationReference = {
+  activityId: "activity123",
+  user: { id: "user123", name: "User" },
+  agent: { id: "bot123", name: "Bot" },
+  conversation: { id: "19:abc@thread.tacv2" },
+  channelId: "msteams",
+  serviceUrl: "https://smba.trafficmanager.net/amer/",
+};
+
+const approvalButtons = {
+  type: "buttons" as const,
+  buttons: [
+    { label: "Approve", action: { type: "callback" as const, value: "approve" } },
+    { label: "Deny", action: { type: "callback" as const, value: "deny" } },
+  ],
+};
+
+function render(payload: Parameters<typeof renderReplyPayloadsToMessages>[0][number]) {
+  return renderReplyPayloadsToMessages([payload], { textChunkLimit: 4000, tableMode: "code" });
+}
+
+/** Sends one rendered message and returns the activity handed to the Bot Framework SDK. */
+async function captureActivity(
+  message: Parameters<typeof sendMSTeamsMessages>[0]["messages"][number],
+): Promise<Record<string, unknown>> {
+  let captured: Record<string, unknown> | undefined;
+  const app = {
+    client: { request: vi.fn() },
+    tokenManager: {
+      getBotToken: async () => ({ toString: () => "bot-token" }),
+      getGraphToken: async () => ({ toString: () => "graph-token" }),
+    },
+    send: async (_conversationId: string, activity: unknown) => {
+      captured = activity as Record<string, unknown>;
+      return { id: "captured" };
+    },
+    activitySender: {
+      send: async (activity: unknown) => {
+        captured = activity as Record<string, unknown>;
+        return { id: "captured" };
+      },
+    },
+    reply: async (_conversationId: string, _messageId: string, activity: unknown) => {
+      captured = activity as Record<string, unknown>;
+      return { id: "captured" };
+    },
+    api: {
+      serviceUrl: "https://smba.trafficmanager.net/amer",
+      conversations: {
+        activities: () => ({
+          create: async (activity: unknown) => {
+            captured = activity as Record<string, unknown>;
+            return { id: "captured" };
+          },
+          update: async () => ({ id: "updated" }),
+          delete: async () => {},
+        }),
+      },
+    },
+  } as unknown as MSTeamsApp;
+  await sendMSTeamsMessages({
+    replyStyle: "top-level",
+    app,
+    appId: "app123",
+    conversationRef,
+    messages: [message],
+  });
+  if (!captured) {
+    throw new Error("expected a Teams activity to be sent");
+  }
+  return captured;
+}
+
+describe("msteams reply presentation", () => {
+  beforeEach(() => {
+    setMSTeamsRuntime(runtimeStub);
+  });
+
+  it("delivers the controls a reply offers as a card", () => {
+    const messages = render({
+      text: "Deploy to production?",
+      presentation: {
+        blocks: [{ type: "text", text: "Deploy to production?" }, approvalButtons],
+      },
+    });
+
+    expect(messages).toHaveLength(1);
+    const card = messages[0]?.card as
+      | { actions?: Array<{ title?: string }>; body?: Array<{ text?: string }> }
+      | undefined;
+    expect(card?.actions?.map((action) => action.title)).toEqual(["Approve", "Deny"]);
+    expect(card?.body?.some((block) => block.text === "Deploy to production?")).toBe(true);
+  });
+
+  it("still reaches Teams when the controls are the whole reply", () => {
+    // Without a card this payload has neither text nor media, so nothing was sent.
+    const messages = render({ presentation: { blocks: [approvalButtons] } });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.card).toBeDefined();
+  });
+
+  it("states the controls in prose when the reply also carries media", () => {
+    // A Teams activity carries a card or an attachment, never both.
+    const messages = render({
+      text: "Here it is",
+      mediaUrl: "https://example.com/a.png",
+      presentation: { blocks: [approvalButtons] },
+    });
+
+    expect(messages.some((message) => message.card)).toBe(false);
+    expect(messages[0]?.text).toContain("Approve");
+    expect(messages.some((message) => message.mediaUrl === "https://example.com/a.png")).toBe(true);
+  });
+
+  it("keeps authored prose when the presentation only restates it", () => {
+    // `/status` ships its own plain rendering plus a table Teams cannot render natively.
+    const authored = "Status: ok\n\n| agent | state |\n| --- | --- |\n| main | idle |";
+    const messages = renderReplyPayloadsToMessages(
+      [
+        {
+          text: authored,
+          presentationTextMode: "fallback",
+          presentation: {
+            blocks: [
+              {
+                type: "table",
+                caption: "Agents",
+                headers: ["agent", "state"],
+                rows: [["main", "idle"]],
+              },
+            ],
+          },
+        },
+      ],
+      { textChunkLimit: 4000, tableMode: "off" },
+    );
+
+    expect(messages.some((message) => message.card)).toBe(false);
+    expect(messages[0]?.text).toBe(authored);
+  });
+
+  it("puts the controls on the wire as an adaptive-card attachment", async () => {
+    // Whole send path: render -> buildActivity -> sendMSTeamsMessages.
+    const [message] = render({
+      text: "Deploy to production?",
+      presentation: { blocks: [approvalButtons] },
+    });
+    const activity = await captureActivity(message!);
+
+    const attachments = activity.attachments as Array<{
+      contentType?: string;
+      content?: { actions?: Array<{ title?: string }> };
+    }>;
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]?.contentType).toBe("application/vnd.microsoft.card.adaptive");
+    expect(attachments[0]?.content?.actions?.map((action) => action.title)).toEqual([
+      "Approve",
+      "Deny",
+    ]);
+  });
+});

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -30,6 +30,7 @@ import {
 import { extractFilename, extractMessageId, getMimeType, isLocalPath } from "./media-helpers.js";
 import { parseMentions } from "./mentions.js";
 import { setPendingUploadActivityId } from "./pending-uploads.js";
+import { resolveMSTeamsReplyPresentation } from "./presentation.js";
 import { withRevokedProxyFallback } from "./revoked-context.js";
 import { getMSTeamsRuntime } from "./runtime.js";
 import { sendMSTeamsActivityWithReference } from "./sdk-proactive.js";
@@ -85,6 +86,8 @@ type MSTeamsReplyRenderOptions = {
 export type MSTeamsRenderedMessage = {
   text?: string;
   mediaUrl?: string;
+  /** Adaptive Card carrying a reply's portable presentation. */
+  card?: Record<string, unknown>;
 };
 
 type MSTeamsSendRetryOptions = {
@@ -229,8 +232,14 @@ export function renderReplyPayloadsToMessages(
     });
 
   for (const payload of replies) {
+    const presentation = resolveMSTeamsReplyPresentation(payload);
+    if (presentation?.kind === "card") {
+      // The card is the whole message: its body already carries the reply's text.
+      out.push({ card: presentation.card });
+      continue;
+    }
     const reply = resolveSendableOutboundReplyParts(payload, {
-      text: formatMSTeamsMarkdown(payload.text ?? "", tableMode),
+      text: formatMSTeamsMarkdown(presentation?.text ?? payload.text ?? "", tableMode),
     });
 
     if (!reply.hasContent) {
@@ -286,6 +295,14 @@ async function buildActivity(
   activity.channelData = {
     feedbackLoopEnabled: options?.feedbackLoopEnabled ?? false,
   };
+
+  if (msg.card) {
+    activity.entities = [AI_GENERATED_ENTITY];
+    activity.attachments = [
+      { contentType: "application/vnd.microsoft.card.adaptive", content: msg.card },
+    ];
+    return activity;
+  }
 
   if (msg.text) {
     // Parse mentions from text (format: @[Name](id))
@@ -409,7 +426,7 @@ export async function sendMSTeamsMessages(params: {
   serviceUrlBoundary?: MSTeamsSdkCloudOptions;
 }): Promise<string[]> {
   const messages = params.messages.filter(
-    (m) => (m.text && m.text.trim().length > 0) || m.mediaUrl,
+    (m) => (m.text && m.text.trim().length > 0) || m.mediaUrl || m.card,
   );
   if (messages.length === 0) {
     return [];

--- a/extensions/msteams/src/presentation.ts
+++ b/extensions/msteams/src/presentation.ts
@@ -1,9 +1,14 @@
 // Msteams plugin module implements presentation behavior.
 import {
   adaptMessagePresentationForChannel,
+  normalizeMessagePresentation,
+  renderMessagePresentationFallbackText,
   resolveMessagePresentationButtonAction,
   type MessagePresentation,
+  type MessagePresentationBlock,
 } from "openclaw/plugin-sdk/interactive-runtime";
+import { resolveOutboundMediaUrls } from "openclaw/plugin-sdk/reply-payload";
+import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { ChannelOutboundAdapter } from "../runtime-api.js";
 
@@ -103,5 +108,63 @@ export function buildMSTeamsPresentationCard(params: {
     version: "1.4",
     body,
     ...(actions.length ? { actions } : {}),
+  };
+}
+
+/** How a reply's presentation reaches Teams once the channel has resolved it. */
+export type MSTeamsReplyPresentation =
+  | { kind: "card"; card: Record<string, unknown> }
+  | { kind: "text"; text: string };
+
+const countMSTeamsPresentationDataBlocks = (blocks: readonly MessagePresentationBlock[]): number =>
+  blocks.filter((block) => block.type === "table" || block.type === "chart").length;
+
+/**
+ * Resolve a reply's portable presentation for the monitor's own send path.
+ *
+ * Core runs the presentation renderer inside the outbound send pipeline only, so a
+ * reply the monitor delivers itself reaches Teams with its presentation still
+ * portable — and loses it. Resolving it here puts both Teams delivery paths on the
+ * one card builder, and mirrors `renderPresentationForDelivery`, which owns the same
+ * decision for the outbound path.
+ */
+export function resolveMSTeamsReplyPresentation(
+  payload: ReplyPayload,
+): MSTeamsReplyPresentation | undefined {
+  const presentation = normalizeMessagePresentation(payload.presentation);
+  if (!presentation) {
+    return undefined;
+  }
+  const usesFallbackText = payload.presentationTextMode === "fallback";
+  const adapted = adaptMessagePresentationForChannel({
+    presentation,
+    capabilities: MSTEAMS_PRESENTATION_CAPABILITIES,
+  });
+  // Only a presentation whose structured blocks all degraded to text says nothing its
+  // producer's own fallback prose already says; that prose then stays verbatim.
+  const degradedToTextOnly =
+    !presentation.blocks.some((block) => block.type === "buttons" || block.type === "select") &&
+    countMSTeamsPresentationDataBlocks(presentation.blocks) > 0 &&
+    countMSTeamsPresentationDataBlocks(adapted.blocks) === 0;
+  if (usesFallbackText && payload.text?.trim() && degradedToTextOnly) {
+    return { kind: "text", text: payload.text };
+  }
+  // A Teams activity carries a card or an attachment, never both, so a reply that also
+  // carries media keeps its media and states the controls in prose instead.
+  if (resolveOutboundMediaUrls(payload).length === 0) {
+    return {
+      kind: "card",
+      // The card renders the authored prose itself; passing it again would repeat it.
+      card: buildMSTeamsPresentationCard({
+        presentation,
+        text: usesFallbackText ? undefined : payload.text,
+      }),
+    };
+  }
+  return {
+    kind: "text",
+    text: usesFallbackText
+      ? (payload.text ?? renderMessagePresentationFallbackText({ presentation }))
+      : renderMessagePresentationFallbackText({ text: payload.text, presentation }),
   };
 }


### PR DESCRIPTION
Closes #133295

## What Problem This Solves

Every button an agent reply offers is dropped before it reaches Microsoft Teams. Teams declares that it supports these controls and renders them as an Adaptive Card when a message is sent through the outbound pipeline, but ordinary agent replies do not go through that pipeline — the monitor delivers them itself, and that path never runs the renderer. The user gets the reply as plain text with the controls silently missing, and nothing reports the loss.

A reply whose only content is those controls is worse: it produces no Teams activity at all. The reply renderer treats a payload with no text and no media as empty and skips it, so the dispatcher reports no visible result and the user sees nothing whatsoever.

Both outcomes are invisible in testing, because `message send` with a presentation does produce a Teams Adaptive Card today — the split only shows up on the reply path that answers an inbound turn.

## Why This Change Was Made

The reply path now resolves a reply's presentation before delivering it, using the same `preparePayload` seam the LINE fix for this pattern used, and the resolved card travels through the renderer into the Teams activity as an adaptive-card attachment. Three things had to line up for the card to arrive: the rendered-message type could not carry a card at all, the renderer skipped a card-only reply as empty, and the send loop filtered it out a second time before the activity was built.

Rather than add a third place that renders a Teams presentation, this pulls the renderer that was inlined in the outbound adapter into a named function that both delivery paths now share, so a reply and a `message send` of the same payload produce the same card by construction. That makes the outbound adapter smaller, not larger.

Boundaries. A reply carrying media keeps its media and degrades the controls to text instead of dropping them, because a card and a media attachment cannot share one Teams activity — this mirrors what core's own renderer does when a channel cannot carry controls natively. Fallback text, which is core's prose rendering of the same controls, is replaced by the card rather than repeated inside it. A reply with no presentation is returned untouched, and the text and media paths are unchanged. This is separate from encoding typed approval actions into Teams' native callback envelope (#104521); Teams already builds the card, it was simply never built on this path.

## User Impact

Buttons an agent offers in Teams now actually appear in Teams, on the reply path that answers a message rather than only when a message is sent explicitly. A reply that is nothing but controls now produces a message instead of silence. Replies without controls are unaffected.

## Evidence

Behavior addressed: agent replies on the Teams monitor path lose every button they offer, and a controls-only reply produces no Teams activity.

Real environment tested: the real `prepareMSTeamsReplyPayload`, `renderReplyPayloadsToMessages` and `sendMSTeamsMessages` build the activity; only the Bot Framework transport is a stub that records the activity instead of posting it. No Teams tenant was involved — see the limitations below. Node v24.18.0 on Windows 11.

Exact steps or command run after this patch: render two replies — one with text plus a button, one with only a button — through the reply path and capture the Teams activities that would be sent.

Evidence after fix:

```
$ node --import ./scripts/tsx.mjs ./msteams-reply-presentation-proof.mts
mode: prepared (this branch)
text+controls reply -> 1 Teams activity(ies)
  controls delivered: Open run
controls-only reply -> 1 Teams activity(ies)
  controls delivered: Approve
PASS: a reply's buttons reach Teams on the monitor reply path
PASS: a controls-only reply produces a Teams activity
```

Observed result after fix: both replies produce exactly one activity, and each activity carries an `application/vnd.microsoft.card.adaptive` attachment whose actions are the buttons the reply offered.

Before evidence: the same script with `messenger.ts`, `presentation.ts` and `outbound.ts` reverted to `origin/main`, and `--unprepared` so the renderer receives the payload exactly as the reply path hands it over on main:

```
$ node --import ./scripts/tsx.mjs ./msteams-reply-presentation-proof.mts --unprepared
mode: unprepared (origin/main reply path)
text+controls reply -> 1 Teams activity(ies)
  controls delivered: (none)
controls-only reply -> 0 Teams activity(ies)
  controls delivered: (none)
FAIL: the reply's buttons were dropped before the activity was built
FAIL: a controls-only reply produced no Teams activity
```

Both reported outcomes reproduce exactly: the controls vanish from the first reply, and the second produces no activity at all.

Additional review: each of the three parts has its own failing test without the fix. Reverting only `reply-dispatcher.ts` leaves all 49 pre-existing dispatcher tests green and fails only the new one, with `expected undefined to deeply equal [ { type: 'Action.Submit', …(2) } ]` — that seam had no regression test before. Reverting only `messenger.ts` fails the render cases in `presentation.reply.test.ts`. And the send loop's filter was found by the new activity test failing with `expected Teams activity to be sent`, which is the "produces no activity" symptom reproduced one layer lower.

The shared renderer is verified equivalent by the pre-existing `outbound.test.ts` case that compares the whole Adaptive Card and then feeds it to `sendPayload`; it passes unchanged after the extraction.

Checks run on the exact head: the full `msteams` extension suite — 100 files, 1555 tests, 1 skipped, all passing; `tsgo -p tsconfig.extensions.json` and `tsgo -p test/tsconfig/tsconfig.extensions.test.json`, both with no diagnostics (the test lane caught a bad `tableMode` fixture value on an earlier run, fixed by giving the fixture a real value under `satisfies` rather than casting); `lint:extensions`, which also caught this change pushing `messenger.test.ts` past the 1000-line budget — resolved by extracting the shared app double and activity-capture helper into `messenger.test-helpers.ts` rather than suppressing the rule; `oxfmt --check` on all touched files; `check:assertion-safety --base origin/main` and `check:max-lines-ratchet --base origin/main`, both OK.

What was not tested: no Microsoft Teams tenant, Bot Framework registration or real Adaptive Card render was involved. The activity is built by the product code and captured at the transport boundary, so the card's structure and the attachment envelope are real, but how Teams itself renders that card was not observed.

Proof limitations or environment constraints: single-host Windows run. The `selects: false` capability means select blocks are degraded by the shared adaptation step before the card is built; that degradation is core's and is unchanged here, so this change only covers the controls Teams already claims to support.
