### PR TITLE
fix(msteams): deliver the controls an agent reply offers

### DIFF
--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -959,7 +959,7 @@ An Adaptive Card is one Teams activity, and it carries its own text. Where a car
 - **The reply carries media.** A card and a media attachment cannot share one activity, so the media is sent and the controls become text.
 - **The reply mentions someone.** `@[Name](id)` notifies through the activity's mention entity, which a card body cannot carry.
 - **The reply is longer than one message.** Text is chunked to the channel limit; a card cannot be split.
-- **Teams has no action for any of the controls.** Teams renders `url`, `web-app`, `command` and `callback` actions. A reply whose controls are all of some other kind — an `ask_user` prompt, for example — keeps the prose its producer wrote, because a card there would repeat that prose and offer nothing to tap. Where a card exists for other reasons, those labels are listed under `Actions:` inside it.
+- **Teams has no action for any of the controls.** Teams renders `url`, `web-app`, `command` and `callback` actions. A reply whose controls are all of some other kind — an `ask_user` prompt or an exec-approval prompt, for example — keeps the prose its producer wrote with the control labels appended, because a card there would be an untappable frame whose text never reaches the activity, so notification previews would lose the reply. Where a card exists because at least one control does map, the remaining labels are listed under `Actions:` inside it.
 
 In a one-to-one chat OpenClaw streams the reply's text natively. The card then carries only what the stream did not: the controls Teams can render. Nothing is sent twice.
 

--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -948,9 +948,20 @@ OpenClaw sends Teams polls as Adaptive Cards (there is no native Teams poll API)
 
 ## Presentation cards
 
-Send semantic presentation payloads to Teams users or conversations using the `message` tool, CLI, or normal reply delivery. OpenClaw renders them as Teams Adaptive Cards from the generic presentation contract.
+Send semantic presentation payloads to Teams users or conversations using the `message` tool, CLI, or normal reply delivery. OpenClaw renders them as Teams Adaptive Cards from the generic presentation contract. Agent replies get the same card as an explicit `message send` of the same payload.
 
 The `presentation` parameter accepts semantic blocks. When `presentation` is provided, the message text is optional. Buttons render as Adaptive Card submit or URL actions. Select menus are not native in the Teams renderer, so OpenClaw downgrades them to readable text before delivery.
+
+### When a reply keeps its text instead of becoming a card
+
+An Adaptive Card is one Teams activity, and it carries its own text. Where a card would cost the reply more than it adds, OpenClaw sends the reply as text and writes the control labels into it rather than dropping them:
+
+- **The reply carries media.** A card and a media attachment cannot share one activity, so the media is sent and the controls become text.
+- **The reply mentions someone.** `@[Name](id)` notifies through the activity's mention entity, which a card body cannot carry.
+- **The reply is longer than one message.** Text is chunked to the channel limit; a card cannot be split.
+- **Teams has no action for any of the controls.** Teams renders `url`, `web-app`, `command` and `callback` actions. A reply whose controls are all of some other kind — an `ask_user` prompt, for example — keeps the prose its producer wrote, because a card there would repeat that prose and offer nothing to tap. Where a card exists for other reasons, those labels are listed under `Actions:` inside it.
+
+In a one-to-one chat OpenClaw streams the reply's text natively. The card then carries only what the stream did not: the controls Teams can render. Nothing is sent twice.
 
 **Agent tool:**
 

--- a/docs/channels/msteams.md
+++ b/docs/channels/msteams.md
@@ -948,7 +948,7 @@ OpenClaw sends Teams polls as Adaptive Cards (there is no native Teams poll API)
 
 ## Presentation cards
 
-Send semantic presentation payloads to Teams users or conversations using the `message` tool, CLI, or normal reply delivery. OpenClaw renders them as Teams Adaptive Cards from the generic presentation contract. Agent replies get the same card as an explicit `message send` of the same payload.
+Send semantic presentation payloads to Teams users or conversations using the `message` tool, CLI, or normal reply delivery. OpenClaw renders them as Teams Adaptive Cards from the generic presentation contract. Agent replies build the same card from the same blocks; their text additionally goes through the Teams markdown conversion that plain replies use, so a heading or table reads the same whether or not the reply also offers a button.
 
 The `presentation` parameter accepts semantic blocks. When `presentation` is provided, the message text is optional. Buttons render as Adaptive Card submit or URL actions. Select menus are not native in the Teams renderer, so OpenClaw downgrades them to readable text before delivery.
 

--- a/extensions/msteams/src/messenger.test-helpers.ts
+++ b/extensions/msteams/src/messenger.test-helpers.ts
@@ -31,6 +31,7 @@ export function installMSTeamsRenderTestRuntime(): void {
   setMSTeamsRuntime({
     config: {
       loadConfig: () => ({}),
+      current: () => ({}),
     },
     channel: {
       text: {

--- a/extensions/msteams/src/messenger.test-helpers.ts
+++ b/extensions/msteams/src/messenger.test-helpers.ts
@@ -1,10 +1,43 @@
-// Msteams test helpers build a Bot Framework app double and capture the activity a
-// rendered message produces, so the messenger tests assert every rendered shape against
-// one send path.
+// Msteams test helpers build a Bot Framework app double, install the text runtime the
+// render path needs, and capture the activity a rendered message produces, so every
+// suite that renders a reply asserts against one send path.
+import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 import { vi } from "vitest";
 import type { StoredConversationReference } from "./conversation-store.js";
 import { sendMSTeamsMessages } from "./messenger.js";
+import { setMSTeamsRuntime } from "./runtime.js";
 import type { MSTeamsApp } from "./sdk.js";
+
+export const chunkMarkdownTextForTests = (text: string, limit: number) => {
+  if (!text) {
+    return [];
+  }
+  if (limit <= 0 || text.length <= limit) {
+    return [text];
+  }
+  const chunks: string[] = [];
+  for (let index = 0; index < text.length; index += limit) {
+    chunks.push(text.slice(index, index + limit));
+  }
+  return chunks;
+};
+
+/** Installs the text runtime `renderReplyPayloadsToMessages` reads for chunking. */
+export function installMSTeamsTestRuntime(): void {
+  setMSTeamsRuntime({
+    config: {
+      loadConfig: () => ({}),
+    },
+    channel: {
+      text: {
+        chunkMarkdownText: chunkMarkdownTextForTests,
+        chunkMarkdownTextWithMode: chunkMarkdownTextForTests,
+        resolveMarkdownTableMode: () => "code",
+        convertMarkdownTables: (text: string) => text,
+      },
+    },
+  } as unknown as PluginRuntime);
+}
 
 type MockAppOptions = {
   createFn?: (activity: unknown) => Promise<unknown>;

--- a/extensions/msteams/src/messenger.test-helpers.ts
+++ b/extensions/msteams/src/messenger.test-helpers.ts
@@ -1,0 +1,104 @@
+// Msteams test helpers build a Bot Framework app double and capture the activity a
+// rendered message produces, so both the messenger tests and the reply-presentation
+// tests assert against one send path.
+import { vi } from "vitest";
+import type { StoredConversationReference } from "./conversation-store.js";
+import { sendMSTeamsMessages } from "./messenger.js";
+import type { MSTeamsApp } from "./sdk.js";
+
+export type MockAppOptions = {
+  createFn?: (activity: unknown) => Promise<unknown>;
+  onClientCreated?: (serviceUrl: string, conversationId: string) => void;
+  onReference?: (ref: unknown) => void;
+};
+
+export function createMockApp(opts?: MockAppOptions): MSTeamsApp {
+  const createFn =
+    opts?.createFn ??
+    (async (activity: unknown) => {
+      const text = (activity as Record<string, unknown>)?.text;
+      return { id: typeof text === "string" ? `id:${text}` : "created" };
+    });
+  const apiServiceUrl = "https://smba.trafficmanager.net/amer";
+  return {
+    client: { request: vi.fn() },
+    tokenManager: {
+      getBotToken: async () => ({ toString: () => "bot-token" }),
+      getGraphToken: async () => ({ toString: () => "graph-token" }),
+    },
+    send: async (conversationId: string, activity: unknown) => {
+      opts?.onClientCreated?.("", conversationId);
+      return await createFn(activity);
+    },
+    activitySender: {
+      send: async (
+        activity: unknown,
+        ref: { serviceUrl?: string; conversation?: { id?: string } },
+      ) => {
+        opts?.onReference?.(ref);
+        opts?.onClientCreated?.(ref.serviceUrl ?? "", ref.conversation?.id ?? "");
+        return await createFn(activity);
+      },
+    },
+    // Mirror the SDK's `app.reply` which internally calls
+    // `app.send(toThreadedConversationId(channelId, msgId), activity)`. The
+    // test capture sees the threaded conversationId so existing assertions
+    // continue to work after we switched messenger.ts from manual URL
+    // construction to `app.reply`.
+    reply: async (conversationId: string, messageId: string, activity: unknown) => {
+      const threaded = `${conversationId};messageid=${messageId}`;
+      opts?.onClientCreated?.("", threaded);
+      return await createFn(activity);
+    },
+    api: {
+      serviceUrl: apiServiceUrl,
+      conversations: {
+        activities: (conversationId: string) => {
+          opts?.onClientCreated?.(apiServiceUrl, conversationId);
+          return {
+            create: async (activity: unknown) => {
+              opts?.onReference?.({ serviceUrl: apiServiceUrl, ...(activity as object) });
+              return createFn(activity);
+            },
+            update: async (_id: string, activity: unknown) => ({
+              id: (activity as Record<string, unknown>)?.id ?? "updated",
+            }),
+            delete: async () => {},
+          };
+        },
+      },
+    },
+  } as unknown as MSTeamsApp;
+}
+
+export async function buildActivity(
+  message: Parameters<typeof sendMSTeamsMessages>[0]["messages"][number],
+  conversationRef: StoredConversationReference,
+  tokenProvider?: Parameters<typeof sendMSTeamsMessages>[0]["tokenProvider"],
+  sharePointSiteId?: string,
+  mediaMaxBytes?: number,
+  options?: { feedbackLoopEnabled?: boolean },
+): Promise<Record<string, unknown>> {
+  let captured: Record<string, unknown> | undefined;
+  const app = createMockApp({
+    createFn: async (activity) => {
+      captured = activity as Record<string, unknown>;
+      return { id: "captured" };
+    },
+  });
+  await sendMSTeamsMessages({
+    replyStyle: "top-level",
+    app,
+    appId: "app123",
+    conversationRef,
+    messages: [message],
+    tokenProvider,
+    sharePointSiteId,
+    mediaMaxBytes,
+    feedbackLoopEnabled: options?.feedbackLoopEnabled,
+  });
+  if (!captured) {
+    throw new Error("expected Teams activity to be sent");
+  }
+  return captured;
+}

--- a/extensions/msteams/src/messenger.test-helpers.ts
+++ b/extensions/msteams/src/messenger.test-helpers.ts
@@ -22,8 +22,12 @@ export const chunkMarkdownTextForTests = (text: string, limit: number) => {
   return chunks;
 };
 
-/** Installs the text runtime `renderReplyPayloadsToMessages` reads for chunking. */
-export function installMSTeamsTestRuntime(): void {
+/**
+ * Installs the text runtime `renderReplyPayloadsToMessages` reads for chunking. Distinct
+ * from `monitor-handler.test-helpers.ts`'s installer, which builds the inbound runtime and
+ * has no chunker.
+ */
+export function installMSTeamsRenderTestRuntime(): void {
   setMSTeamsRuntime({
     config: {
       loadConfig: () => ({}),

--- a/extensions/msteams/src/messenger.test-helpers.ts
+++ b/extensions/msteams/src/messenger.test-helpers.ts
@@ -8,7 +8,7 @@ import { sendMSTeamsMessages } from "./messenger.js";
 import { setMSTeamsRuntime } from "./runtime.js";
 import type { MSTeamsApp } from "./sdk.js";
 
-export const chunkMarkdownTextForTests = (text: string, limit: number) => {
+const chunkMarkdownTextForTests = (text: string, limit: number) => {
   if (!text) {
     return [];
   }

--- a/extensions/msteams/src/messenger.test-helpers.ts
+++ b/extensions/msteams/src/messenger.test-helpers.ts
@@ -1,12 +1,12 @@
 // Msteams test helpers build a Bot Framework app double and capture the activity a
-// rendered message produces, so both the messenger tests and the reply-presentation
-// tests assert against one send path.
+// rendered message produces, so the messenger tests assert every rendered shape against
+// one send path.
 import { vi } from "vitest";
 import type { StoredConversationReference } from "./conversation-store.js";
 import { sendMSTeamsMessages } from "./messenger.js";
 import type { MSTeamsApp } from "./sdk.js";
 
-export type MockAppOptions = {
+type MockAppOptions = {
   createFn?: (activity: unknown) => Promise<unknown>;
   onClientCreated?: (serviceUrl: string, conversationId: string) => void;
   onReference?: (ref: unknown) => void;

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -28,8 +28,8 @@ import {
   renderReplyPayloadsToMessages,
   sendMSTeamsMessages,
 } from "./messenger.js";
+import { buildActivity, createMockApp } from "./messenger.test-helpers.js";
 import { setMSTeamsRuntime } from "./runtime.js";
-import type { MSTeamsApp } from "./sdk.js";
 
 const chunkMarkdownText = (text: string, limit: number) => {
   if (!text) {
@@ -96,103 +96,6 @@ function requireAiGeneratedEntity(entities: unknown): Record<string, unknown> {
     throw new Error("expected Teams AI-generated entity");
   }
   return entity;
-}
-
-type MockAppOptions = {
-  createFn?: (activity: unknown) => Promise<unknown>;
-  onClientCreated?: (serviceUrl: string, conversationId: string) => void;
-  onReference?: (ref: unknown) => void;
-};
-
-function createMockApp(opts?: MockAppOptions): MSTeamsApp {
-  const createFn =
-    opts?.createFn ??
-    (async (activity: unknown) => {
-      const text = (activity as Record<string, unknown>)?.text;
-      return { id: typeof text === "string" ? `id:${text}` : "created" };
-    });
-  const apiServiceUrl = "https://smba.trafficmanager.net/amer";
-  return {
-    client: { request: vi.fn() },
-    tokenManager: {
-      getBotToken: async () => ({ toString: () => "bot-token" }),
-      getGraphToken: async () => ({ toString: () => "graph-token" }),
-    },
-    send: async (conversationId: string, activity: unknown) => {
-      opts?.onClientCreated?.("", conversationId);
-      return await createFn(activity);
-    },
-    activitySender: {
-      send: async (
-        activity: unknown,
-        ref: { serviceUrl?: string; conversation?: { id?: string } },
-      ) => {
-        opts?.onReference?.(ref);
-        opts?.onClientCreated?.(ref.serviceUrl ?? "", ref.conversation?.id ?? "");
-        return await createFn(activity);
-      },
-    },
-    // Mirror the SDK's `app.reply` which internally calls
-    // `app.send(toThreadedConversationId(channelId, msgId), activity)`. The
-    // test capture sees the threaded conversationId so existing assertions
-    // continue to work after we switched messenger.ts from manual URL
-    // construction to `app.reply`.
-    reply: async (conversationId: string, messageId: string, activity: unknown) => {
-      const threaded = `${conversationId};messageid=${messageId}`;
-      opts?.onClientCreated?.("", threaded);
-      return await createFn(activity);
-    },
-    api: {
-      serviceUrl: apiServiceUrl,
-      conversations: {
-        activities: (conversationId: string) => {
-          opts?.onClientCreated?.(apiServiceUrl, conversationId);
-          return {
-            create: async (activity: unknown) => {
-              opts?.onReference?.({ serviceUrl: apiServiceUrl, ...(activity as object) });
-              return createFn(activity);
-            },
-            update: async (_id: string, activity: unknown) => ({
-              id: (activity as Record<string, unknown>)?.id ?? "updated",
-            }),
-            delete: async () => {},
-          };
-        },
-      },
-    },
-  } as unknown as MSTeamsApp;
-}
-
-async function buildActivity(
-  message: Parameters<typeof sendMSTeamsMessages>[0]["messages"][number],
-  conversationRef: StoredConversationReference,
-  tokenProvider?: Parameters<typeof sendMSTeamsMessages>[0]["tokenProvider"],
-  sharePointSiteId?: string,
-  mediaMaxBytes?: number,
-  options?: { feedbackLoopEnabled?: boolean },
-): Promise<Record<string, unknown>> {
-  let captured: Record<string, unknown> | undefined;
-  const app = createMockApp({
-    createFn: async (activity) => {
-      captured = activity as Record<string, unknown>;
-      return { id: "captured" };
-    },
-  });
-  await sendMSTeamsMessages({
-    replyStyle: "top-level",
-    app,
-    appId: "app123",
-    conversationRef,
-    messages: [message],
-    tokenProvider,
-    sharePointSiteId,
-    mediaMaxBytes,
-    feedbackLoopEnabled: options?.feedbackLoopEnabled,
-  });
-  if (!captured) {
-    throw new Error("expected Teams activity to be sent");
-  }
-  return captured;
 }
 
 describe("msteams messenger", () => {
@@ -922,6 +825,17 @@ describe("msteams messenger", () => {
 
     it("adds AI-generated entity to media-only messages", async () => {
       const activity = await buildActivity({ mediaUrl: "https://example.com/img.png" }, baseRef);
+      expect(requireAiGeneratedEntity(activity.entities).additionalType).toEqual([
+        "AIGeneratedContent",
+      ]);
+    });
+
+    it("sends a reply's presentation card as the activity's adaptive-card attachment", async () => {
+      const card = { type: "AdaptiveCard", version: "1.4", body: [], actions: [] };
+      const activity = await buildActivity({ card }, baseRef);
+      expect(activity.attachments).toEqual([
+        { contentType: "application/vnd.microsoft.card.adaptive", content: card },
+      ]);
       expect(requireAiGeneratedEntity(activity.entities).additionalType).toEqual([
         "AIGeneratedContent",
       ]);

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -832,10 +832,13 @@ describe("msteams messenger", () => {
 
     it("sends a reply's presentation card as the activity's adaptive-card attachment", async () => {
       const card = { type: "AdaptiveCard", version: "1.4", body: [], actions: [] };
-      const activity = await buildActivity({ card }, baseRef);
+      const activity = await buildActivity({ card, text: "Deploy finished" }, baseRef);
       expect(activity.attachments).toEqual([
         { contentType: "application/vnd.microsoft.card.adaptive", content: card },
       ]);
+      // The card renders the reply's text; sending it as activity text as well would
+      // show the same answer twice above the card.
+      expect(activity.text).toBeUndefined();
       expect(requireAiGeneratedEntity(activity.entities).additionalType).toEqual([
         "AIGeneratedContent",
       ]);

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -4,7 +4,6 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { SILENT_REPLY_TOKEN } from "openclaw/plugin-sdk/reply-chunking";
-import type { PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 import { resolvePreferredOpenClawTmpDir } from "openclaw/plugin-sdk/temp-path";
 import { withServer } from "openclaw/plugin-sdk/test-env";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -28,36 +27,11 @@ import {
   renderReplyPayloadsToMessages,
   sendMSTeamsMessages,
 } from "./messenger.js";
-import { buildActivity, createMockApp } from "./messenger.test-helpers.js";
-import { setMSTeamsRuntime } from "./runtime.js";
-
-const chunkMarkdownText = (text: string, limit: number) => {
-  if (!text) {
-    return [];
-  }
-  if (limit <= 0 || text.length <= limit) {
-    return [text];
-  }
-  const chunks: string[] = [];
-  for (let index = 0; index < text.length; index += limit) {
-    chunks.push(text.slice(index, index + limit));
-  }
-  return chunks;
-};
-
-const runtimeStub = {
-  config: {
-    loadConfig: () => ({}),
-  },
-  channel: {
-    text: {
-      chunkMarkdownText,
-      chunkMarkdownTextWithMode: chunkMarkdownText,
-      resolveMarkdownTableMode: () => "code",
-      convertMarkdownTables: (text: string) => text,
-    },
-  },
-} as unknown as PluginRuntime;
+import {
+  buildActivity,
+  createMockApp,
+  installMSTeamsTestRuntime,
+} from "./messenger.test-helpers.js";
 
 const createRecordedSendActivity = (
   sink: string[],
@@ -100,7 +74,7 @@ function requireAiGeneratedEntity(entities: unknown): Record<string, unknown> {
 
 describe("msteams messenger", () => {
   beforeEach(() => {
-    setMSTeamsRuntime(runtimeStub);
+    installMSTeamsTestRuntime();
     graphUploadMockState.uploadAndShareSharePoint.mockReset();
     graphUploadMockState.getDriveItemProperties.mockReset();
   });

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -207,6 +207,33 @@ describe("msteams messenger", () => {
       expect(ids).toEqual(["id:one", "id:two"]);
     });
 
+    it("sends a card-only message instead of filtering it out as empty", async () => {
+      const activities: Array<Record<string, unknown>> = [];
+      const card = { type: "AdaptiveCard", version: "1.4", body: [], actions: [] };
+      const ctx = {
+        sendActivity: async (activity: Record<string, unknown>) => {
+          activities.push(activity);
+          return { id: "card-activity" };
+        },
+      };
+
+      // A reply whose only content is its controls has no text and no media; without the
+      // card in the emptiness check the user receives nothing at all.
+      const ids = await sendMSTeamsMessages({
+        replyStyle: "thread",
+        app: createMockApp(),
+        appId: "app123",
+        conversationRef: baseRef,
+        context: ctx as never,
+        messages: [{ card }],
+      });
+
+      expect(ids).toEqual(["card-activity"]);
+      expect(activities[0]?.attachments).toEqual([
+        { contentType: "application/vnd.microsoft.card.adaptive", content: card },
+      ]);
+    });
+
     it("sends top-level messages via proactive send context", async () => {
       const texts: string[] = [];
       let capturedConversationId: string | undefined;

--- a/extensions/msteams/src/messenger.test.ts
+++ b/extensions/msteams/src/messenger.test.ts
@@ -30,7 +30,7 @@ import {
 import {
   buildActivity,
   createMockApp,
-  installMSTeamsTestRuntime,
+  installMSTeamsRenderTestRuntime,
 } from "./messenger.test-helpers.js";
 
 const createRecordedSendActivity = (
@@ -74,7 +74,7 @@ function requireAiGeneratedEntity(entities: unknown): Record<string, unknown> {
 
 describe("msteams messenger", () => {
   beforeEach(() => {
-    installMSTeamsTestRuntime();
+    installMSTeamsRenderTestRuntime();
     graphUploadMockState.uploadAndShareSharePoint.mockReset();
     graphUploadMockState.getDriveItemProperties.mockReset();
   });

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -232,15 +232,12 @@ export function renderReplyPayloadsToMessages(
     });
 
   for (const rawPayload of replies) {
-    // Core resolves presentations inside the outbound send pipeline only, so replies the
-    // monitor delivers itself still carry portable controls. Resolving at the reply
-    // path's one renderer keeps both Teams paths on the same card, and runs after the
-    // stream controller has taken the text Teams already showed.
+    // Core resolves presentations in the outbound send pipeline only, so replies the
+    // monitor delivers itself still carry portable controls. Resolving here - the reply
+    // path's one renderer - runs after the stream took the text Teams already showed.
     const payload = prepareMSTeamsReplyPayload(rawPayload);
-    // A resolved presentation carries its text inside the card, so the card is the whole
-    // message - the same thing `sendPayload` does on the outbound path. It is also
-    // content in its own right: a controls-only reply has no text or media and would
-    // otherwise be skipped, producing no Teams activity at all.
+    // The card carries this reply's text, so it is the whole message, and it is content
+    // on its own: a controls-only reply would otherwise be skipped as empty.
     const card = readMSTeamsPresentationCard(payload);
     if (card) {
       out.push({ card });
@@ -432,8 +429,8 @@ export async function sendMSTeamsMessages(params: {
   feedbackLoopEnabled?: boolean;
   serviceUrlBoundary?: MSTeamsSdkCloudOptions;
 }): Promise<string[]> {
-  // A card is content on its own: it carries both the reply's text and its controls,
-  // so a card-only message must not be filtered out as empty.
+  // A card carries both the reply's text and its controls, so a card-only message
+  // must not be filtered out as empty.
   const messages = params.messages.filter(
     (m) => (m.text && m.text.trim().length > 0) || m.mediaUrl || m.card,
   );

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -236,8 +236,16 @@ export function renderReplyPayloadsToMessages(
     // monitor delivers itself still carry portable controls. Resolving here - the reply
     // path's one renderer - runs after the stream took the text Teams already showed.
     const payload = prepareMSTeamsReplyPayload(rawPayload, {
-      cardTextLimit: chunkLimit,
-      formatCardText: (text) => formatMSTeamsMarkdown(text, tableMode),
+      renderCardText: (text) => {
+        // A card is one activity: it cannot be chunked, and its body cannot carry the
+        // mention entity that notifies the person a reply names. Either way the reply
+        // keeps the text path, which does both.
+        if (parseMentions(text).entities.length > 0) {
+          return undefined;
+        }
+        const formatted = formatMSTeamsMarkdown(text, tableMode);
+        return formatted.length <= chunkLimit ? formatted : undefined;
+      },
     });
     // The card carries this reply's text, so it is the whole message, and it is content
     // on its own: a controls-only reply would otherwise be skipped as empty.

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -243,13 +243,15 @@ export function renderReplyPayloadsToMessages(
     // on its own: a controls-only reply would otherwise be skipped as empty.
     const card = readMSTeamsPresentationCard(payload);
     if (card) {
+      // The card renders this reply inside itself, so its text never becomes activity
+      // text; it stays on the message as the content delivery records report. Fallback
+      // prose is stripped from the card but is still what the message conveys.
+      const content = payload.text ?? rawPayload.text;
       // A silent reply is a sentinel, not content: it must not become the card's body.
-      if (isSilentReplyText(payload.text?.trim(), SILENT_REPLY_TOKEN)) {
+      if (isSilentReplyText(content?.trim(), SILENT_REPLY_TOKEN)) {
         continue;
       }
-      // The card renders this text inside itself, so it never becomes activity text; it
-      // stays on the message as the content delivery records report.
-      out.push({ card, ...(payload.text ? { text: payload.text } : {}) });
+      out.push({ card, ...(content ? { text: content } : {}) });
       continue;
     }
     const reply = resolveSendableOutboundReplyParts(payload, {

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -254,6 +254,9 @@ export function renderReplyPayloadsToMessages(
       fitsOneActivity: (text) =>
         parseMentions(text).entities.length === 0 &&
         formatMSTeamsMarkdown(text, tableMode).length <= chunkLimit,
+      // The card's text is this reply's text: send it in the dialect the text path would,
+      // so a table in a reply that also offers a button does not arrive as raw pipes.
+      formatCardText: (text) => formatMSTeamsMarkdown(text, tableMode),
     });
     // The card carries this reply's text, so it is the whole message, and it is content
     // on its own: a controls-only reply would otherwise be skipped as empty.

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -30,6 +30,7 @@ import {
 import { extractFilename, extractMessageId, getMimeType, isLocalPath } from "./media-helpers.js";
 import { parseMentions } from "./mentions.js";
 import { setPendingUploadActivityId } from "./pending-uploads.js";
+import { readMSTeamsPresentationCard } from "./presentation.js";
 import { withRevokedProxyFallback } from "./revoked-context.js";
 import { getMSTeamsRuntime } from "./runtime.js";
 import { sendMSTeamsActivityWithReference } from "./sdk-proactive.js";
@@ -85,6 +86,8 @@ type MSTeamsReplyRenderOptions = {
 export type MSTeamsRenderedMessage = {
   text?: string;
   mediaUrl?: string;
+  /** Adaptive Card carrying the controls a reply offers; sent as the activity's attachment. */
+  card?: Record<string, unknown>;
 };
 
 type MSTeamsSendRetryOptions = {
@@ -229,6 +232,15 @@ export function renderReplyPayloadsToMessages(
     });
 
   for (const payload of replies) {
+    // A prepared presentation already carries its text inside the card, so the card is
+    // the whole message - the same thing `sendPayload` does on the outbound path. It is
+    // also content in its own right: a controls-only reply has no text or media and
+    // would otherwise be skipped, producing no Teams activity at all.
+    const card = readMSTeamsPresentationCard(payload);
+    if (card) {
+      out.push({ card });
+      continue;
+    }
     const reply = resolveSendableOutboundReplyParts(payload, {
       text: formatMSTeamsMarkdown(payload.text ?? "", tableMode),
     });
@@ -296,6 +308,13 @@ async function buildActivity(
     activity.entities = [...(entities.length > 0 ? entities : []), AI_GENERATED_ENTITY];
   } else {
     activity.entities = [AI_GENERATED_ENTITY];
+  }
+
+  if (msg.card) {
+    activity.attachments = [
+      { contentType: "application/vnd.microsoft.card.adaptive", content: msg.card },
+    ];
+    return activity;
   }
 
   if (msg.mediaUrl) {
@@ -408,8 +427,10 @@ export async function sendMSTeamsMessages(params: {
   feedbackLoopEnabled?: boolean;
   serviceUrlBoundary?: MSTeamsSdkCloudOptions;
 }): Promise<string[]> {
+  // A card is content on its own: it carries both the reply's text and its controls,
+  // so a card-only message must not be filtered out as empty.
   const messages = params.messages.filter(
-    (m) => (m.text && m.text.trim().length > 0) || m.mediaUrl,
+    (m) => (m.text && m.text.trim().length > 0) || m.mediaUrl || m.card,
   );
   if (messages.length === 0) {
     return [];

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -30,7 +30,7 @@ import {
 import { extractFilename, extractMessageId, getMimeType, isLocalPath } from "./media-helpers.js";
 import { parseMentions } from "./mentions.js";
 import { setPendingUploadActivityId } from "./pending-uploads.js";
-import { readMSTeamsPresentationCard } from "./presentation.js";
+import { prepareMSTeamsReplyPayload, readMSTeamsPresentationCard } from "./presentation.js";
 import { withRevokedProxyFallback } from "./revoked-context.js";
 import { getMSTeamsRuntime } from "./runtime.js";
 import { sendMSTeamsActivityWithReference } from "./sdk-proactive.js";
@@ -231,11 +231,16 @@ export function renderReplyPayloadsToMessages(
       channel: "msteams",
     });
 
-  for (const payload of replies) {
-    // A prepared presentation already carries its text inside the card, so the card is
-    // the whole message - the same thing `sendPayload` does on the outbound path. It is
-    // also content in its own right: a controls-only reply has no text or media and
-    // would otherwise be skipped, producing no Teams activity at all.
+  for (const rawPayload of replies) {
+    // Core resolves presentations inside the outbound send pipeline only, so replies the
+    // monitor delivers itself still carry portable controls. Resolving at the reply
+    // path's one renderer keeps both Teams paths on the same card, and runs after the
+    // stream controller has taken the text Teams already showed.
+    const payload = prepareMSTeamsReplyPayload(rawPayload);
+    // A resolved presentation carries its text inside the card, so the card is the whole
+    // message - the same thing `sendPayload` does on the outbound path. It is also
+    // content in its own right: a controls-only reply has no text or media and would
+    // otherwise be skipped, producing no Teams activity at all.
     const card = readMSTeamsPresentationCard(payload);
     if (card) {
       out.push({ card });

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -240,7 +240,13 @@ export function renderReplyPayloadsToMessages(
     // on its own: a controls-only reply would otherwise be skipped as empty.
     const card = readMSTeamsPresentationCard(payload);
     if (card) {
-      out.push({ card });
+      // A silent reply is a sentinel, not content: it must not become the card's body.
+      if (isSilentReplyText(payload.text?.trim(), SILENT_REPLY_TOKEN)) {
+        continue;
+      }
+      // The card renders this text inside itself, so it never becomes activity text; it
+      // stays on the message as the content delivery records report.
+      out.push({ card, ...(payload.text ? { text: payload.text } : {}) });
       continue;
     }
     const reply = resolveSendableOutboundReplyParts(payload, {
@@ -301,6 +307,16 @@ async function buildActivity(
     feedbackLoopEnabled: options?.feedbackLoopEnabled ?? false,
   };
 
+  // A card already renders this message's text, so the activity carries the card alone;
+  // `msg.text` stays the logical content the delivery record reports.
+  if (msg.card) {
+    activity.entities = [AI_GENERATED_ENTITY];
+    activity.attachments = [
+      { contentType: "application/vnd.microsoft.card.adaptive", content: msg.card },
+    ];
+    return activity;
+  }
+
   if (msg.text) {
     // Parse mentions from text (format: @[Name](id))
     const { text: formattedText, entities } = parseMentions(msg.text);
@@ -310,13 +326,6 @@ async function buildActivity(
     activity.entities = [...(entities.length > 0 ? entities : []), AI_GENERATED_ENTITY];
   } else {
     activity.entities = [AI_GENERATED_ENTITY];
-  }
-
-  if (msg.card) {
-    activity.attachments = [
-      { contentType: "application/vnd.microsoft.card.adaptive", content: msg.card },
-    ];
-    return activity;
   }
 
   if (msg.mediaUrl) {

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -248,16 +248,12 @@ export function renderReplyPayloadsToMessages(
         }
       : sourcePayload;
     const payload = prepareMSTeamsReplyPayload(rawPayload, {
-      renderCardText: (text) => {
-        // A card is one activity: it cannot be chunked, and its body cannot carry the
-        // mention entity that notifies the person a reply names. Either way the reply
-        // keeps the text path, which does both.
-        if (parseMentions(text).entities.length > 0) {
-          return undefined;
-        }
-        const formatted = formatMSTeamsMarkdown(text, tableMode);
-        return formatted.length <= chunkLimit ? formatted : undefined;
-      },
+      // A card is one activity: it cannot be chunked, and its body cannot carry the
+      // mention entity that notifies the person a reply names. Either way the reply keeps
+      // the text path, which does both, and its controls degrade to prose.
+      fitsOneActivity: (text) =>
+        parseMentions(text).entities.length === 0 &&
+        formatMSTeamsMarkdown(text, tableMode).length <= chunkLimit,
     });
     // The card carries this reply's text, so it is the whole message, and it is content
     // on its own: a controls-only reply would otherwise be skipped as empty.

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -231,10 +231,22 @@ export function renderReplyPayloadsToMessages(
       channel: "msteams",
     });
 
-  for (const rawPayload of replies) {
+  for (const sourcePayload of replies) {
     // Core resolves presentations in the outbound send pipeline only, so replies the
     // monitor delivers itself still carry portable controls. Resolving here - the reply
     // path's one renderer - runs after the stream took the text Teams already showed.
+    // A silent reply is a sentinel, not content. Drop it - and the controls core attached
+    // to it - before the presentation is resolved: afterwards the sentinel is either a
+    // card body or folded into the prose the controls degrade to, and the exact-match
+    // check further down no longer recognises it. Media on the same payload still goes.
+    const rawPayload = isSilentReplyText(sourcePayload.text?.trim(), SILENT_REPLY_TOKEN)
+      ? {
+          ...sourcePayload,
+          text: undefined,
+          presentation: undefined,
+          presentationTextMode: undefined,
+        }
+      : sourcePayload;
     const payload = prepareMSTeamsReplyPayload(rawPayload, {
       renderCardText: (text) => {
         // A card is one activity: it cannot be chunked, and its body cannot carry the
@@ -255,10 +267,6 @@ export function renderReplyPayloadsToMessages(
       // text; it stays on the message as the content delivery records report. Fallback
       // prose is stripped from the card but is still what the message conveys.
       const content = payload.text ?? rawPayload.text;
-      // A silent reply is a sentinel, not content: it must not become the card's body.
-      if (isSilentReplyText(content?.trim(), SILENT_REPLY_TOKEN)) {
-        continue;
-      }
       out.push({ card, ...(content ? { text: content } : {}) });
       continue;
     }

--- a/extensions/msteams/src/messenger.ts
+++ b/extensions/msteams/src/messenger.ts
@@ -235,7 +235,10 @@ export function renderReplyPayloadsToMessages(
     // Core resolves presentations in the outbound send pipeline only, so replies the
     // monitor delivers itself still carry portable controls. Resolving here - the reply
     // path's one renderer - runs after the stream took the text Teams already showed.
-    const payload = prepareMSTeamsReplyPayload(rawPayload);
+    const payload = prepareMSTeamsReplyPayload(rawPayload, {
+      cardTextLimit: chunkLimit,
+      formatCardText: (text) => formatMSTeamsMarkdown(text, tableMode),
+    });
     // The card carries this reply's text, so it is the whole message, and it is content
     // on its own: a controls-only reply would otherwise be skipped as empty.
     const card = readMSTeamsPresentationCard(payload);

--- a/extensions/msteams/src/outbound.ts
+++ b/extensions/msteams/src/outbound.ts
@@ -19,7 +19,10 @@ import {
   type ChannelOutboundAdapter,
 } from "../runtime-api.js";
 import { createMSTeamsPollStoreState } from "./polls.js";
-import { buildMSTeamsPresentationCard, MSTEAMS_PRESENTATION_CAPABILITIES } from "./presentation.js";
+import {
+  MSTEAMS_PRESENTATION_CAPABILITIES,
+  renderMSTeamsPresentationPayload,
+} from "./presentation.js";
 import { sendAdaptiveCardMSTeams, sendMessageMSTeams, sendPollMSTeams } from "./send.js";
 
 const MSTEAMS_TEXT_CHUNK_LIMIT = 4000;
@@ -101,26 +104,7 @@ export const msteamsOutbound: ChannelOutboundAdapter = {
     },
   },
   presentationCapabilities: MSTEAMS_PRESENTATION_CAPABILITIES,
-  renderPresentation: ({ payload, presentation }) => {
-    if (payload.mediaUrl || payload.mediaUrls?.length) {
-      return null;
-    }
-    const card = buildMSTeamsPresentationCard({
-      presentation,
-      text: payload.text,
-    });
-    const msteamsData = asOptionalRecord(payload.channelData?.msteams) ?? {};
-    return {
-      ...payload,
-      channelData: {
-        ...payload.channelData,
-        msteams: {
-          ...msteamsData,
-          presentationCard: card,
-        },
-      },
-    };
-  },
+  renderPresentation: renderMSTeamsPresentationPayload,
   sendPayload: async ({
     cfg,
     to,

--- a/extensions/msteams/src/presentation.connector.test.ts
+++ b/extensions/msteams/src/presentation.connector.test.ts
@@ -1,0 +1,86 @@
+// Msteams tests carry a reply's controls all the way to a Bot Framework Connector.
+import { describe, expect, it } from "vitest";
+import { renderReplyPayloadsToMessages, sendMSTeamsMessages } from "./messenger.js";
+import { createMockApp, installMSTeamsRenderTestRuntime } from "./messenger.test-helpers.js";
+import { startMSTeamsQaBotFrameworkServer } from "./qa/bot-framework-server.js";
+
+const CONVERSATION_ID = "19:presentation-connector@thread.tacv2";
+
+describe("msteams reply presentation over the Bot Framework Connector", () => {
+  it("delivers a reply's controls as card actions the connector accepts", async () => {
+    installMSTeamsRenderTestRuntime();
+    const received: Array<Record<string, unknown>> = [];
+    const server = await startMSTeamsQaBotFrameworkServer({
+      botToken: "qa-bot-token",
+      nonce: "qa-nonce",
+      onOutbound: async ({ activity }) => {
+        received.push(activity);
+      },
+    });
+
+    try {
+      // The reply path's own renderer and activity builder, then the same loopback
+      // connector the `openclaw qa msteams` lane runs the real plugin against. Only the
+      // SDK's transport stands in, exactly as that lane's private runtime does.
+      const messages = renderReplyPayloadsToMessages(
+        [
+          {
+            text: "Deploy finished",
+            presentation: {
+              blocks: [
+                {
+                  type: "buttons",
+                  buttons: [{ label: "Open run", url: "https://example.com/run" }],
+                },
+              ],
+            },
+          },
+        ],
+        { textChunkLimit: 4000, tableMode: "code" },
+      );
+
+      const ids = await sendMSTeamsMessages({
+        replyStyle: "thread",
+        app: createMockApp(),
+        appId: "app123",
+        conversationRef: {
+          activityId: "activity123",
+          user: { id: "user123", name: "User" },
+          agent: { id: "bot123", name: "Bot" },
+          conversation: { id: CONVERSATION_ID },
+          channelId: "msteams",
+          serviceUrl: "https://smba.trafficmanager.net/qa",
+        } as never,
+        context: {
+          sendActivity: async (activity: Record<string, unknown>) => {
+            const response = await fetch(
+              `${server.baseUrl}qa/v3/conversations/${encodeURIComponent(CONVERSATION_ID)}/activities`,
+              {
+                method: "POST",
+                headers: {
+                  authorization: "Bearer qa-bot-token",
+                  "content-type": "application/json",
+                  "x-openclaw-msteams-qa-nonce": "qa-nonce",
+                },
+                body: JSON.stringify(activity),
+              },
+            );
+            expect(response.status).toBe(200);
+            return (await response.json()) as { id: string };
+          },
+        } as never,
+        messages,
+      });
+
+      expect(ids).toHaveLength(1);
+      expect(received).toHaveLength(1);
+      const attachments = received[0]?.attachments as Array<Record<string, unknown>>;
+      expect(attachments?.[0]?.contentType).toBe("application/vnd.microsoft.card.adaptive");
+      expect((attachments?.[0]?.content as { actions?: unknown })?.actions).toEqual([
+        { type: "Action.OpenUrl", title: "Open run", url: "https://example.com/run" },
+      ]);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/extensions/msteams/src/presentation.connector.test.ts
+++ b/extensions/msteams/src/presentation.connector.test.ts
@@ -1,14 +1,13 @@
 // Msteams tests carry a reply's controls all the way to a Bot Framework Connector.
 import { describe, expect, it } from "vitest";
 import { renderReplyPayloadsToMessages, sendMSTeamsMessages } from "./messenger.js";
-import { createMockApp, installMSTeamsRenderTestRuntime } from "./messenger.test-helpers.js";
+import { createMockApp } from "./messenger.test-helpers.js";
 import { startMSTeamsQaBotFrameworkServer } from "./qa/bot-framework-server.js";
 
 const CONVERSATION_ID = "19:presentation-connector@thread.tacv2";
 
 describe("msteams reply presentation over the Bot Framework Connector", () => {
-  it("delivers a reply's controls as card actions the connector accepts", async () => {
-    installMSTeamsRenderTestRuntime();
+  it("puts a reply's controls on the wire as card actions", async () => {
     const received: Array<Record<string, unknown>> = [];
     const server = await startMSTeamsQaBotFrameworkServer({
       botToken: "qa-bot-token",
@@ -19,9 +18,11 @@ describe("msteams reply presentation over the Bot Framework Connector", () => {
     });
 
     try {
-      // The reply path's own renderer and activity builder, then the same loopback
-      // connector the `openclaw qa msteams` lane runs the real plugin against. Only the
-      // SDK's transport stands in, exactly as that lane's private runtime does.
+      // The activity body is production's: the reply path's own renderer and activity
+      // builder produce it, and it is read back out of the HTTP request the loopback
+      // connector parsed. The request envelope is the test's - unlike the `qa msteams`
+      // lane, which redirects the real SDK client, this posts it directly - so the
+      // connector's 200 means "it arrived", not "Teams would accept it".
       const messages = renderReplyPayloadsToMessages(
         [
           {
@@ -41,6 +42,7 @@ describe("msteams reply presentation over the Bot Framework Connector", () => {
 
       const ids = await sendMSTeamsMessages({
         replyStyle: "thread",
+        // Required by the signature; this path sends through `context`, not the SDK.
         app: createMockApp(),
         appId: "app123",
         conversationRef: {
@@ -72,7 +74,10 @@ describe("msteams reply presentation over the Bot Framework Connector", () => {
         messages,
       });
 
+      // The id the connector minted has to come back, or `extractMessageId` degraded it
+      // to "unknown" and the delivery record loses the message.
       expect(ids).toHaveLength(1);
+      expect(ids[0]).toMatch(/^qa-outbound-/u);
       expect(received).toHaveLength(1);
       const attachments = received[0]?.attachments as Array<Record<string, unknown>>;
       expect(attachments?.[0]?.contentType).toBe("application/vnd.microsoft.card.adaptive");

--- a/extensions/msteams/src/presentation.reply.test.ts
+++ b/extensions/msteams/src/presentation.reply.test.ts
@@ -294,6 +294,18 @@ describe("msteams reply presentation", () => {
     expect(renderReply({ text: SILENT_REPLY_TOKEN, presentation: PRESENTATION })).toEqual([]);
   });
 
+  it("does not let a silent reply reach the user through the control prose either", () => {
+    // Media blocks the card, so the controls degrade to text - and that rendering used to
+    // fold the sentinel into its first line, where the exact-match check no longer saw it.
+    const messages = renderReply({
+      text: SILENT_REPLY_TOKEN,
+      mediaUrl: "https://example.com/log.png",
+      presentation: PRESENTATION,
+    });
+
+    expect(messages).toEqual([{ mediaUrl: "https://example.com/log.png" }]);
+  });
+
   it("keeps the card's text as the message's delivered content", () => {
     const [message] = renderReply({ text: "Deploy finished", presentation: PRESENTATION });
 

--- a/extensions/msteams/src/presentation.reply.test.ts
+++ b/extensions/msteams/src/presentation.reply.test.ts
@@ -169,6 +169,18 @@ describe("msteams reply presentation", () => {
     expect(messages.map((message) => message.text ?? "").join("")).toContain("Open");
   });
 
+  it("keeps the text path when a reply mentions someone", () => {
+    // A mention only notifies through the activity's entity list, which the text path
+    // builds from this syntax; a card body cannot carry it.
+    const messages = renderReply({
+      text: "@[Ada Lovelace](28:abc-def) deploy finished",
+      presentation: PRESENTATION,
+    });
+
+    expect(messages.every((message) => message.card === undefined)).toBe(true);
+    expect(messages.map((message) => message.text ?? "").join("")).toContain("Open");
+  });
+
   it("renders the card's text in the dialect a plain reply would use", () => {
     const table = "| Region | Runs |\n| --- | --- |\n| EU | 12 |";
 

--- a/extensions/msteams/src/presentation.reply.test.ts
+++ b/extensions/msteams/src/presentation.reply.test.ts
@@ -4,11 +4,7 @@ import { beforeEach, describe, expect, it } from "vitest";
 import type { ReplyPayload } from "../runtime-api.js";
 import { renderReplyPayloadsToMessages } from "./messenger.js";
 import { installMSTeamsRenderTestRuntime } from "./messenger.test-helpers.js";
-import {
-  prepareMSTeamsReplyPayload,
-  readMSTeamsPresentationCard,
-  renderMSTeamsPresentationPayload,
-} from "./presentation.js";
+import { prepareMSTeamsReplyPayload, readMSTeamsPresentationCard } from "./presentation.js";
 
 const PRESENTATION = {
   title: "Deploy",
@@ -263,18 +259,57 @@ describe("msteams reply presentation", () => {
     expect(messages.map((message) => message.text ?? "").join("")).toContain("Open");
   });
 
-  it("puts the same text in the card that a `message send` of the payload would", () => {
-    const table = "| Region | Runs |\n| --- | --- |\n| EU | 12 |";
-
-    // Both delivery paths hand the reply's own text to one shared card builder, so the
-    // card a reply produces and the card `message send` produces are the same card.
-    const [reply] = renderReply({ text: table, presentation: PRESENTATION });
-    const outbound = renderMSTeamsPresentationPayload({
-      payload: { text: table },
-      presentation: PRESENTATION,
+  it("sends prose when the reply has its own text but no control Teams can draw", () => {
+    // The shape an exec-approval prompt takes by default: authored prose plus `approval`
+    // buttons Teams has no card action for. A card here is an untappable frame whose text
+    // never becomes the activity's, so notification previews lose the reply entirely.
+    const messages = renderReply({
+      text: "Run `ls -la`?",
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              {
+                label: "Allow once",
+                action: {
+                  type: "approval",
+                  approvalId: "exec-1",
+                  approvalKind: "exec",
+                  decision: "allow-once",
+                },
+              },
+            ],
+          },
+        ],
+      },
     });
 
-    expect(reply?.card).toEqual(cardOf(outbound ?? {}));
+    expect(messages.every((message) => message.card === undefined)).toBe(true);
+    const text = messages.map((message) => message.text ?? "").join("");
+    expect(text).toContain("Run `ls -la`?");
+    expect(text).toContain("Allow once");
+  });
+
+  it("puts the card's text in the dialect the text path would send", () => {
+    const table = "| Region | Runs |\n| --- | --- |\n| EU | 12 |";
+    const withAction = {
+      blocks: [
+        {
+          type: "buttons" as const,
+          buttons: [{ label: "Open run", url: "https://example.com/run" }],
+        },
+      ],
+    };
+
+    // A reply that also offers a button must not lose the table rendering it would have
+    // had as plain text.
+    const [carded] = renderReply({ text: table, presentation: withAction });
+    const [plain] = renderReply({ text: table });
+
+    expect(carded?.card?.body).toEqual(
+      expect.arrayContaining([{ type: "TextBlock", text: plain?.text, wrap: true }]),
+    );
   });
 
   it("keeps the authored fallback prose when the reply also carries media", () => {

--- a/extensions/msteams/src/presentation.reply.test.ts
+++ b/extensions/msteams/src/presentation.reply.test.ts
@@ -1,0 +1,100 @@
+// Msteams tests cover the controls an agent reply offers on the monitor reply path.
+import { describe, expect, it } from "vitest";
+import type { ReplyPayload } from "../runtime-api.js";
+import { renderReplyPayloadsToMessages } from "./messenger.js";
+import { prepareMSTeamsReplyPayload, readMSTeamsPresentationCard } from "./presentation.js";
+
+const PRESENTATION = {
+  title: "Deploy",
+  blocks: [
+    { type: "text" as const, text: "Finished" },
+    { type: "buttons" as const, buttons: [{ label: "Open", value: "open" }] },
+  ],
+};
+
+const RENDER_OPTIONS = {
+  textChunkLimit: 4000,
+  tableMode: "code",
+} satisfies Parameters<typeof renderReplyPayloadsToMessages>[1];
+
+function renderReply(payload: ReplyPayload) {
+  return renderReplyPayloadsToMessages([payload], RENDER_OPTIONS);
+}
+
+const cardOf = readMSTeamsPresentationCard;
+
+describe("msteams reply presentation", () => {
+  it("carries a reply's buttons into the card the reply path sends", () => {
+    const prepared = prepareMSTeamsReplyPayload({
+      text: "Deploy finished",
+      presentation: PRESENTATION,
+    });
+
+    expect(cardOf(prepared)).toEqual({
+      type: "AdaptiveCard",
+      version: "1.4",
+      body: [
+        { type: "TextBlock", text: "Deploy finished", wrap: true },
+        { type: "TextBlock", text: "Deploy", weight: "Bolder", size: "Medium", wrap: true },
+        { type: "TextBlock", text: "Finished", wrap: true },
+      ],
+      actions: [{ type: "Action.Submit", title: "Open", data: { value: "open", label: "Open" } }],
+    });
+    // The card already carries the text, so it is the whole message - the same shape
+    // `sendPayload` produces on the outbound path.
+    expect(renderReply(prepared)).toEqual([{ card: cardOf(prepared) }]);
+  });
+
+  it("renders a controls-only reply instead of producing no message at all", () => {
+    const prepared = prepareMSTeamsReplyPayload({ presentation: PRESENTATION });
+
+    // Without a card this payload has no text and no media, so the renderer skipped it
+    // and the dispatcher reported no_visible_result - the user saw nothing.
+    const messages = renderReply(prepared);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]?.card).toBeDefined();
+  });
+
+  it("degrades the controls to text when the reply carries media", () => {
+    const prepared = prepareMSTeamsReplyPayload({
+      text: "Deploy finished",
+      mediaUrl: "https://example.com/log.png",
+      presentation: PRESENTATION,
+    });
+
+    // A card and a media attachment cannot share one activity, so the controls become
+    // prose rather than disappearing.
+    expect(cardOf(prepared)).toBeUndefined();
+    expect(prepared.mediaUrl).toBe("https://example.com/log.png");
+    expect(prepared.text).toContain("Deploy finished");
+    expect(prepared.text).toContain("Open");
+  });
+
+  it("does not repeat fallback prose inside the card", () => {
+    const prepared = prepareMSTeamsReplyPayload({
+      text: "Deploy finished\n\n[Open]",
+      presentationTextMode: "fallback",
+      presentation: PRESENTATION,
+    });
+
+    // "fallback" text is core's prose rendering of these same controls; the card renders
+    // them natively, so keeping the prose would show every button twice.
+    expect(cardOf(prepared)).toEqual({
+      type: "AdaptiveCard",
+      version: "1.4",
+      body: [
+        { type: "TextBlock", text: "Deploy", weight: "Bolder", size: "Medium", wrap: true },
+        { type: "TextBlock", text: "Finished", wrap: true },
+      ],
+      actions: [{ type: "Action.Submit", title: "Open", data: { value: "open", label: "Open" } }],
+    });
+  });
+
+  it("leaves a reply without a presentation untouched", () => {
+    const payload: ReplyPayload = { text: "plain reply" };
+
+    // Same object, not a copy: a plain reply must reach delivery exactly as produced.
+    // Its rendering stays on the text path, which messenger.test.ts already covers.
+    expect(prepareMSTeamsReplyPayload(payload)).toBe(payload);
+  });
+});

--- a/extensions/msteams/src/presentation.reply.test.ts
+++ b/extensions/msteams/src/presentation.reply.test.ts
@@ -1,4 +1,5 @@
 // Msteams tests cover the controls an agent reply offers on the monitor reply path.
+import { SILENT_REPLY_TOKEN } from "openclaw/plugin-sdk/reply-chunking";
 import { describe, expect, it } from "vitest";
 import type { ReplyPayload } from "../runtime-api.js";
 import { renderReplyPayloadsToMessages } from "./messenger.js";
@@ -29,6 +30,9 @@ describe("msteams reply presentation", () => {
     // the reply path turns a payload into Teams messages.
     expect(renderReply({ text: "Deploy finished", presentation: PRESENTATION })).toEqual([
       {
+        // The card is the whole message; `text` rides along only as the content the
+        // delivery record reports, and buildActivity never sends it separately.
+        text: "Deploy finished",
         card: {
           type: "AdaptiveCard",
           version: "1.4",
@@ -121,6 +125,21 @@ describe("msteams reply presentation", () => {
       ],
       actions: [{ type: "Action.Submit", title: "Open", data: { value: "open", label: "Open" } }],
     });
+  });
+
+  it("does not turn a silent reply into a card", () => {
+    // NO_REPLY is the agent choosing to stay silent. The text path drops it; the card
+    // path must not put it in front of the user as the card's first line instead.
+    expect(renderReply({ text: SILENT_REPLY_TOKEN, presentation: PRESENTATION })).toEqual([]);
+  });
+
+  it("keeps the card's text as the message's delivered content", () => {
+    const [message] = renderReply({ text: "Deploy finished", presentation: PRESENTATION });
+
+    // The dispatcher records `text` as what the reply delivered; without it a card-only
+    // message reports empty content on the partial-failure path.
+    expect(message?.text).toBe("Deploy finished");
+    expect(message?.card).toBeDefined();
   });
 
   it("leaves a reply without a presentation untouched", () => {

--- a/extensions/msteams/src/presentation.reply.test.ts
+++ b/extensions/msteams/src/presentation.reply.test.ts
@@ -70,6 +70,30 @@ describe("msteams reply presentation", () => {
     ]);
   });
 
+  it("still builds the card when a data-only presentation also offers controls", () => {
+    const prepared = prepareMSTeamsReplyPayload({
+      text: "Runs by region:\n- EU: 12",
+      presentationTextMode: "fallback",
+      presentation: {
+        blocks: [
+          {
+            type: "table",
+            caption: "Runs by region",
+            headers: ["Region", "Runs"],
+            rows: [["EU", "12"]],
+          },
+          { type: "buttons", buttons: [{ label: "Open run", value: "open" }] },
+        ],
+      },
+    });
+
+    // The authored fallback only wins when nothing interactive is left. Keeping the prose
+    // here would drop the button - the loss this whole change exists to stop.
+    expect(cardOf(prepared)?.actions).toEqual([
+      { type: "Action.Submit", title: "Open run", data: { value: "open", label: "Open run" } },
+    ]);
+  });
+
   it("keeps the producer's authored fallback for a presentation Teams cannot render", () => {
     const authored = "Runs by region:\n- EU: 12\n- US: 9";
     const prepared = prepareMSTeamsReplyPayload({
@@ -182,6 +206,7 @@ describe("msteams reply presentation", () => {
             buttons: [
               { label: "Open docs", url: "https://example.com/docs" },
               { label: "Retry", action: { type: "command", command: "/retry" } },
+              { label: "Open app", action: { type: "web-app", url: "https://example.com/app" } },
               { label: "Approve", value: "approve" },
             ],
           },
@@ -192,6 +217,7 @@ describe("msteams reply presentation", () => {
     expect(message?.card?.actions).toEqual([
       { type: "Action.OpenUrl", title: "Open docs", url: "https://example.com/docs" },
       { type: "Action.Submit", title: "Retry", data: "/retry" },
+      { type: "Action.OpenUrl", title: "Open app", url: "https://example.com/app" },
       { type: "Action.Submit", title: "Approve", data: { value: "approve", label: "Approve" } },
     ]);
   });

--- a/extensions/msteams/src/presentation.reply.test.ts
+++ b/extensions/msteams/src/presentation.reply.test.ts
@@ -4,7 +4,11 @@ import { beforeEach, describe, expect, it } from "vitest";
 import type { ReplyPayload } from "../runtime-api.js";
 import { renderReplyPayloadsToMessages } from "./messenger.js";
 import { installMSTeamsRenderTestRuntime } from "./messenger.test-helpers.js";
-import { prepareMSTeamsReplyPayload, readMSTeamsPresentationCard } from "./presentation.js";
+import {
+  prepareMSTeamsReplyPayload,
+  readMSTeamsPresentationCard,
+  renderMSTeamsPresentationPayload,
+} from "./presentation.js";
 
 const PRESENTATION = {
   title: "Deploy",
@@ -259,18 +263,18 @@ describe("msteams reply presentation", () => {
     expect(messages.map((message) => message.text ?? "").join("")).toContain("Open");
   });
 
-  it("renders the card's text in the dialect a plain reply would use", () => {
+  it("puts the same text in the card that a `message send` of the payload would", () => {
     const table = "| Region | Runs |\n| --- | --- |\n| EU | 12 |";
 
-    // The card path skipped formatMSTeamsMarkdown, so a markdown table reached Teams as
-    // raw pipes inside the card while the same reply without controls rendered properly.
-    const [plain] = renderReply({ text: table });
-    const [carded] = renderReply({ text: table, presentation: PRESENTATION });
+    // Both delivery paths hand the reply's own text to one shared card builder, so the
+    // card a reply produces and the card `message send` produces are the same card.
+    const [reply] = renderReply({ text: table, presentation: PRESENTATION });
+    const outbound = renderMSTeamsPresentationPayload({
+      payload: { text: table },
+      presentation: PRESENTATION,
+    });
 
-    expect(plain?.text).toBeDefined();
-    expect(carded?.card?.body).toEqual(
-      expect.arrayContaining([{ type: "TextBlock", text: plain?.text, wrap: true }]),
-    );
+    expect(reply?.card).toEqual(cardOf(outbound ?? {}));
   });
 
   it("keeps the authored fallback prose when the reply also carries media", () => {

--- a/extensions/msteams/src/presentation.reply.test.ts
+++ b/extensions/msteams/src/presentation.reply.test.ts
@@ -169,8 +169,10 @@ describe("msteams reply presentation", () => {
     expect(messages.map((message) => message.text ?? "").join("")).toContain("Open");
   });
 
-  it("keeps a control's label as text when Teams cannot render its action", () => {
-    const [message] = renderReply({
+  it("sends prose instead of a card when Teams can render none of the controls", () => {
+    const messages = renderReply({
+      text: "Where should this deploy?\n\n1. Staging\n2. Production",
+      presentationTextMode: "fallback",
       presentation: {
         blocks: [
           {
@@ -186,10 +188,13 @@ describe("msteams reply presentation", () => {
       },
     });
 
-    // ask_user mints `question` actions, which Teams has no card action for. Skipping them
-    // silently left a card offering nothing; the label survives as text instead.
-    expect(message?.card?.actions).toBeUndefined();
-    expect(JSON.stringify(message?.card?.body)).toContain("Staging");
+    // ask_user mints `question` actions, which Teams has no card action for. A card here
+    // would repeat the option list, tell the user to tap buttons that are not there, and
+    // swallow the numbered prose that tells them how to answer.
+    expect(messages.every((message) => message.card === undefined)).toBe(true);
+    expect(messages.map((message) => message.text ?? "").join("")).toBe(
+      "Where should this deploy?\n\n1. Staging\n2. Production",
+    );
   });
 
   it("keeps the text path when a fallback reply mentions someone", () => {

--- a/extensions/msteams/src/presentation.reply.test.ts
+++ b/extensions/msteams/src/presentation.reply.test.ts
@@ -169,6 +169,42 @@ describe("msteams reply presentation", () => {
     expect(messages.map((message) => message.text ?? "").join("")).toContain("Open");
   });
 
+  it("keeps a control's label as text when Teams cannot render its action", () => {
+    const [message] = renderReply({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              {
+                label: "Staging",
+                action: { type: "question", questionId: "deploy-target", optionValue: "Staging" },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    // ask_user mints `question` actions, which Teams has no card action for. Skipping them
+    // silently left a card offering nothing; the label survives as text instead.
+    expect(message?.card?.actions).toBeUndefined();
+    expect(JSON.stringify(message?.card?.body)).toContain("Staging");
+  });
+
+  it("keeps the text path when a fallback reply mentions someone", () => {
+    // The card replaces fallback prose, so the mention is invisible inside it - and the
+    // gate has to look at the reply's own text to see the mention at all.
+    const messages = renderReply({
+      text: "@[Ada Lovelace](28:abc-def) deploy finished\n\n[Open]",
+      presentationTextMode: "fallback",
+      presentation: PRESENTATION,
+    });
+
+    expect(messages.every((message) => message.card === undefined)).toBe(true);
+    expect(messages.map((message) => message.text ?? "").join("")).toContain("Ada Lovelace");
+  });
+
   it("keeps the text path when a reply mentions someone", () => {
     // A mention only notifies through the activity's entity list, which the text path
     // builds from this syntax; a card body cannot carry it.
@@ -209,7 +245,7 @@ describe("msteams reply presentation", () => {
     expect(prepared.text).toBe("Deploy finished\n\n[Open]");
   });
 
-  it("maps every button action Teams renders natively", () => {
+  it("maps the four button actions Teams renders natively", () => {
     const [message] = renderReply({
       presentation: {
         blocks: [

--- a/extensions/msteams/src/presentation.reply.test.ts
+++ b/extensions/msteams/src/presentation.reply.test.ts
@@ -25,34 +25,67 @@ const cardOf = readMSTeamsPresentationCard;
 
 describe("msteams reply presentation", () => {
   it("carries a reply's buttons into the card the reply path sends", () => {
-    const prepared = prepareMSTeamsReplyPayload({
-      text: "Deploy finished",
-      presentation: PRESENTATION,
-    });
-
-    expect(cardOf(prepared)).toEqual({
-      type: "AdaptiveCard",
-      version: "1.4",
-      body: [
-        { type: "TextBlock", text: "Deploy finished", wrap: true },
-        { type: "TextBlock", text: "Deploy", weight: "Bolder", size: "Medium", wrap: true },
-        { type: "TextBlock", text: "Finished", wrap: true },
-      ],
-      actions: [{ type: "Action.Submit", title: "Open", data: { value: "open", label: "Open" } }],
-    });
-    // The card already carries the text, so it is the whole message - the same shape
-    // `sendPayload` produces on the outbound path.
-    expect(renderReply(prepared)).toEqual([{ card: cardOf(prepared) }]);
+    // The renderer resolves the portable presentation itself - it is the one place
+    // the reply path turns a payload into Teams messages.
+    expect(renderReply({ text: "Deploy finished", presentation: PRESENTATION })).toEqual([
+      {
+        card: {
+          type: "AdaptiveCard",
+          version: "1.4",
+          body: [
+            { type: "TextBlock", text: "Deploy finished", wrap: true },
+            { type: "TextBlock", text: "Deploy", weight: "Bolder", size: "Medium", wrap: true },
+            { type: "TextBlock", text: "Finished", wrap: true },
+          ],
+          actions: [
+            { type: "Action.Submit", title: "Open", data: { value: "open", label: "Open" } },
+          ],
+        },
+      },
+    ]);
   });
 
   it("renders a controls-only reply instead of producing no message at all", () => {
-    const prepared = prepareMSTeamsReplyPayload({ presentation: PRESENTATION });
+    // Two replies arrive in this shape: one whose only content is its controls, and a
+    // streamed reply whose text the stream already delivered. Without a card neither has
+    // text or media, so the renderer skipped it and the user saw nothing.
+    const messages = renderReply({ presentation: PRESENTATION });
 
-    // Without a card this payload has no text and no media, so the renderer skipped it
-    // and the dispatcher reported no_visible_result - the user saw nothing.
-    const messages = renderReply(prepared);
     expect(messages).toHaveLength(1);
-    expect(messages[0]?.card).toBeDefined();
+    expect(messages[0]?.card?.body).toEqual([
+      { type: "TextBlock", text: "Deploy", weight: "Bolder", size: "Medium", wrap: true },
+      { type: "TextBlock", text: "Finished", wrap: true },
+    ]);
+    expect(messages[0]?.card?.actions).toEqual([
+      { type: "Action.Submit", title: "Open", data: { value: "open", label: "Open" } },
+    ]);
+  });
+
+  it("keeps the producer's authored fallback for a presentation Teams cannot render", () => {
+    const authored = "Runs by region:\n- EU: 12\n- US: 9";
+    const prepared = prepareMSTeamsReplyPayload({
+      text: authored,
+      presentationTextMode: "fallback",
+      presentation: {
+        blocks: [
+          {
+            type: "table",
+            caption: "Runs by region",
+            headers: ["Region", "Runs"],
+            rows: [
+              ["EU", "12"],
+              ["US", "9"],
+            ],
+          },
+        ],
+      },
+    });
+
+    // Teams cannot render tables, so every block degrades to text and the card would
+    // only re-flatten it. Core skips its renderer here to keep the authored fallback
+    // verbatim; the reply path has to reach the same answer.
+    expect(cardOf(prepared)).toBeUndefined();
+    expect(prepared.text).toBe(authored);
   });
 
   it("degrades the controls to text when the reply carries media", () => {

--- a/extensions/msteams/src/presentation.reply.test.ts
+++ b/extensions/msteams/src/presentation.reply.test.ts
@@ -1,8 +1,9 @@
 // Msteams tests cover the controls an agent reply offers on the monitor reply path.
 import { SILENT_REPLY_TOKEN } from "openclaw/plugin-sdk/reply-chunking";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import type { ReplyPayload } from "../runtime-api.js";
 import { renderReplyPayloadsToMessages } from "./messenger.js";
+import { installMSTeamsTestRuntime } from "./messenger.test-helpers.js";
 import { prepareMSTeamsReplyPayload, readMSTeamsPresentationCard } from "./presentation.js";
 
 const PRESENTATION = {
@@ -25,6 +26,10 @@ function renderReply(payload: ReplyPayload) {
 const cardOf = readMSTeamsPresentationCard;
 
 describe("msteams reply presentation", () => {
+  beforeEach(() => {
+    installMSTeamsTestRuntime();
+  });
+
   it("carries a reply's buttons into the card the reply path sends", () => {
     // The renderer resolves the portable presentation itself - it is the one place
     // the reply path turns a payload into Teams messages.
@@ -125,6 +130,33 @@ describe("msteams reply presentation", () => {
       ],
       actions: [{ type: "Action.Submit", title: "Open", data: { value: "open", label: "Open" } }],
     });
+  });
+
+  it("keeps the text path's chunking when a reply is too long for one card", () => {
+    const longText = "x".repeat(5000);
+
+    // A card is one activity and cannot be split, so a reply past the transport limit
+    // stays on the chunked text path and its controls degrade to prose. Building one
+    // oversized card instead would have Teams reject the whole reply.
+    const messages = renderReply({ text: longText, presentation: PRESENTATION });
+
+    expect(messages.every((message) => message.card === undefined)).toBe(true);
+    expect(messages.length).toBeGreaterThan(1);
+    expect(messages.map((message) => message.text ?? "").join("")).toContain("Open");
+  });
+
+  it("renders the card's text in the dialect a plain reply would use", () => {
+    const table = "| Region | Runs |\n| --- | --- |\n| EU | 12 |";
+
+    // The card path skipped formatMSTeamsMarkdown, so a markdown table reached Teams as
+    // raw pipes inside the card while the same reply without controls rendered properly.
+    const [plain] = renderReply({ text: table });
+    const [carded] = renderReply({ text: table, presentation: PRESENTATION });
+
+    expect(plain?.text).toBeDefined();
+    expect(carded?.card?.body).toEqual(
+      expect.arrayContaining([{ type: "TextBlock", text: plain?.text, wrap: true }]),
+    );
   });
 
   it("keeps the authored fallback prose when the reply also carries media", () => {

--- a/extensions/msteams/src/presentation.reply.test.ts
+++ b/extensions/msteams/src/presentation.reply.test.ts
@@ -127,6 +127,20 @@ describe("msteams reply presentation", () => {
     });
   });
 
+  it("keeps the authored fallback prose when the reply also carries media", () => {
+    const prepared = prepareMSTeamsReplyPayload({
+      text: "Deploy finished\n\n[Open]",
+      presentationTextMode: "fallback",
+      mediaUrl: "https://example.com/log.png",
+      presentation: PRESENTATION,
+    });
+
+    // No card can be built next to media, so the prose the producer authored is the only
+    // rendering left; regenerating it would drop whatever wording it chose.
+    expect(cardOf(prepared)).toBeUndefined();
+    expect(prepared.text).toBe("Deploy finished\n\n[Open]");
+  });
+
   it("does not turn a silent reply into a card", () => {
     // NO_REPLY is the agent choosing to stay silent. The text path drops it; the card
     // path must not put it in front of the user as the card's first line instead.

--- a/extensions/msteams/src/presentation.reply.test.ts
+++ b/extensions/msteams/src/presentation.reply.test.ts
@@ -3,7 +3,7 @@ import { SILENT_REPLY_TOKEN } from "openclaw/plugin-sdk/reply-chunking";
 import { beforeEach, describe, expect, it } from "vitest";
 import type { ReplyPayload } from "../runtime-api.js";
 import { renderReplyPayloadsToMessages } from "./messenger.js";
-import { installMSTeamsTestRuntime } from "./messenger.test-helpers.js";
+import { installMSTeamsRenderTestRuntime } from "./messenger.test-helpers.js";
 import { prepareMSTeamsReplyPayload, readMSTeamsPresentationCard } from "./presentation.js";
 
 const PRESENTATION = {
@@ -27,7 +27,7 @@ const cardOf = readMSTeamsPresentationCard;
 
 describe("msteams reply presentation", () => {
   beforeEach(() => {
-    installMSTeamsTestRuntime();
+    installMSTeamsRenderTestRuntime();
   });
 
   it("carries a reply's buttons into the card the reply path sends", () => {

--- a/extensions/msteams/src/presentation.reply.test.ts
+++ b/extensions/msteams/src/presentation.reply.test.ts
@@ -169,6 +169,43 @@ describe("msteams reply presentation", () => {
     expect(messages.map((message) => message.text ?? "").join("")).toContain("Open");
   });
 
+  it("keeps an unmappable control's label in a card built for the others", () => {
+    const [message] = renderReply({
+      text: "Deploy finished",
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              { label: "Open run", url: "https://example.com/run" },
+              {
+                label: "Approve",
+                action: { type: "question", questionId: "deploy-gate", optionValue: "Approve" },
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    // The card exists for the button Teams can render. Skipping the other one silently
+    // would leave the user a card that offers less than the reply did.
+    expect(message?.card?.actions).toEqual([
+      { type: "Action.OpenUrl", title: "Open run", url: "https://example.com/run" },
+    ]);
+    expect(message?.card?.body).toEqual(
+      expect.arrayContaining([
+        {
+          type: "TextBlock",
+          text: "Actions:\n- Approve",
+          wrap: true,
+          isSubtle: true,
+          size: "Small",
+        },
+      ]),
+    );
+  });
+
   it("sends prose instead of a card when Teams can render none of the controls", () => {
     const messages = renderReply({
       text: "Where should this deploy?\n\n1. Staging\n2. Production",

--- a/extensions/msteams/src/presentation.reply.test.ts
+++ b/extensions/msteams/src/presentation.reply.test.ts
@@ -173,6 +173,42 @@ describe("msteams reply presentation", () => {
     expect(prepared.text).toBe("Deploy finished\n\n[Open]");
   });
 
+  it("maps every button action Teams renders natively", () => {
+    const [message] = renderReply({
+      presentation: {
+        blocks: [
+          {
+            type: "buttons",
+            buttons: [
+              { label: "Open docs", url: "https://example.com/docs" },
+              { label: "Retry", action: { type: "command", command: "/retry" } },
+              { label: "Approve", value: "approve" },
+            ],
+          },
+        ],
+      },
+    });
+
+    expect(message?.card?.actions).toEqual([
+      { type: "Action.OpenUrl", title: "Open docs", url: "https://example.com/docs" },
+      { type: "Action.Submit", title: "Retry", data: "/retry" },
+      { type: "Action.Submit", title: "Approve", data: { value: "approve", label: "Approve" } },
+    ]);
+  });
+
+  it("keeps a fallback reply's prose as the delivered content even though the card replaces it", () => {
+    const [message] = renderReply({
+      text: "Deploy finished\n\n[Open]",
+      presentationTextMode: "fallback",
+      presentation: PRESENTATION,
+    });
+
+    // The card renders these controls natively, so the prose does not go inside it - but
+    // the delivery record still has to say what the user was shown.
+    expect(message?.text).toBe("Deploy finished\n\n[Open]");
+    expect(JSON.stringify(message?.card?.body)).not.toContain("[Open]");
+  });
+
   it("does not turn a silent reply into a card", () => {
     // NO_REPLY is the agent choosing to stay silent. The text path drops it; the card
     // path must not put it in front of the user as the card's first line instead.

--- a/extensions/msteams/src/presentation.ts
+++ b/extensions/msteams/src/presentation.ts
@@ -1,11 +1,16 @@
 // Msteams plugin module implements presentation behavior.
 import {
   adaptMessagePresentationForChannel,
+  normalizeMessagePresentation,
+  renderMessagePresentationFallbackText,
   resolveMessagePresentationButtonAction,
   type MessagePresentation,
 } from "openclaw/plugin-sdk/interactive-runtime";
-import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { ChannelOutboundAdapter } from "../runtime-api.js";
+import {
+  asOptionalRecord,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { ChannelOutboundAdapter, ReplyPayload } from "../runtime-api.js";
 
 export const MSTEAMS_PRESENTATION_CAPABILITIES = {
   supported: true,
@@ -103,5 +108,72 @@ export function buildMSTeamsPresentationCard(params: {
     version: "1.4",
     body,
     ...(actions.length ? { actions } : {}),
+  };
+}
+
+/**
+ * Attach the Adaptive Card for an adapted presentation, or null when Teams cannot
+ * carry one. A card and a media attachment cannot share one activity, so a reply
+ * with media keeps its media and the caller degrades the controls to text.
+ */
+export function renderMSTeamsPresentationPayload(params: {
+  payload: ReplyPayload;
+  presentation: MessagePresentation;
+}): ReplyPayload | null {
+  const { payload, presentation } = params;
+  if (payload.mediaUrl || payload.mediaUrls?.length) {
+    return null;
+  }
+  const card = buildMSTeamsPresentationCard({ presentation, text: payload.text });
+  const msteamsData = asOptionalRecord(payload.channelData?.msteams) ?? {};
+  return {
+    ...payload,
+    channelData: {
+      ...payload.channelData,
+      msteams: { ...msteamsData, presentationCard: card },
+    },
+  };
+}
+
+/** Reads the Adaptive Card a prepared reply carries, if any. */
+export function readMSTeamsPresentationCard(
+  payload: ReplyPayload,
+): Record<string, unknown> | undefined {
+  const card = asOptionalRecord(payload.channelData?.msteams)?.presentationCard;
+  return asOptionalRecord(card);
+}
+
+/**
+ * Resolve a reply's portable presentation into a Teams Adaptive Card.
+ *
+ * Core renders presentations inside the outbound send pipeline only, so replies the
+ * monitor delivers itself arrive with the controls still portable. Preparing them here
+ * keeps both Teams delivery paths on one rendering, and mirrors what core's renderer
+ * does when a channel cannot carry the controls natively: degrade them to text rather
+ * than drop them.
+ */
+export function prepareMSTeamsReplyPayload(payload: ReplyPayload): ReplyPayload {
+  const presentation = normalizeMessagePresentation(payload.presentation);
+  if (!presentation) {
+    return payload;
+  }
+  const { presentation: _presentation, presentationTextMode, ...rest } = payload;
+  // "fallback" text already renders these controls as prose; the card replaces it.
+  const textIsFallback = presentationTextMode === "fallback";
+  const rendered = renderMSTeamsPresentationPayload({
+    payload: textIsFallback ? { ...rest, text: undefined } : rest,
+    presentation: adaptMessagePresentationForChannel({
+      presentation,
+      capabilities: MSTEAMS_PRESENTATION_CAPABILITIES,
+    }),
+  });
+  if (rendered) {
+    return rendered;
+  }
+  return {
+    ...rest,
+    text: textIsFallback
+      ? (payload.text ?? renderMessagePresentationFallbackText({ presentation }))
+      : renderMessagePresentationFallbackText({ text: payload.text, presentation }),
   };
 }

--- a/extensions/msteams/src/presentation.ts
+++ b/extensions/msteams/src/presentation.ts
@@ -151,12 +151,6 @@ export function renderMSTeamsPresentationPayload(params: {
   if (payload.mediaUrl || payload.mediaUrls?.length) {
     return null;
   }
-  // With no text of its own and no action Teams can render, a card carries nothing the
-  // caller's text rendering does not - and it would replace the producer's prose with a
-  // flattened copy of itself under an instruction to tap buttons that are not there.
-  if (!normalizeOptionalString(payload.text) && !hasMSTeamsCardAction(presentation)) {
-    return null;
-  }
   const card = buildMSTeamsPresentationCard({ presentation, text: payload.text });
   const msteamsData = asOptionalRecord(payload.channelData?.msteams) ?? {};
   return {
@@ -181,10 +175,10 @@ export function prepareMSTeamsReplyPayload(
   payload: ReplyPayload,
   options?: {
     /**
-     * Renders the text a card may carry, or returns undefined when this reply has to stay
-     * on the text path because one activity cannot hold it.
+     * Answers whether this reply's text can live in one activity. A card cannot be
+     * chunked and cannot carry a mention entity, so the caller owns that judgement.
      */
-    renderCardText?: (text: string) => string | undefined;
+    fitsOneActivity?: (text: string) => boolean;
   },
 ): ReplyPayload {
   const presentation = normalizeMessagePresentation(payload.presentation);
@@ -198,17 +192,21 @@ export function prepareMSTeamsReplyPayload(
     presentation,
     capabilities: MSTEAMS_PRESENTATION_CAPABILITIES,
   });
+  // "fallback" prose already renders every block; a card that adds no action Teams can
+  // draw would restate it under an instruction to tap buttons that are not there, and the
+  // card's text never reaches the activity, so the prose would simply be lost.
+  if (textIsFallback && !hasMSTeamsCardAction(adapted)) {
+    return replyWithControlsAsText();
+  }
   // The gate asks whether this reply fits one activity, so it reads the reply's own text
   // even when the card will not carry it: fallback prose still holds the mention entity
   // only the text path can send. A reply that fails it keeps the text path and degrades
   // its controls to prose - the same trade the media branch makes.
-  const cardText =
-    rest.text && options?.renderCardText ? options.renderCardText(rest.text) : rest.text;
-  if (rest.text && cardText === undefined) {
+  if (rest.text && options?.fitsOneActivity && !options.fitsOneActivity(rest.text)) {
     return replyWithControlsAsText();
   }
   const rendered = renderMSTeamsPresentationPayload({
-    payload: textIsFallback ? { ...rest, text: undefined } : { ...rest, text: cardText },
+    payload: textIsFallback ? { ...rest, text: undefined } : rest,
     presentation: adapted,
   });
   return rendered ?? replyWithControlsAsText();

--- a/extensions/msteams/src/presentation.ts
+++ b/extensions/msteams/src/presentation.ts
@@ -58,6 +58,10 @@ export function buildMSTeamsPresentationCard(params: {
     });
   }
   const actions: Record<string, unknown>[] = [];
+  // Teams maps url, web-app, command and callback actions. A control carrying anything
+  // else keeps its label as text, because a control that renders as nothing at all is
+  // worse than one the user has to act on by replying.
+  const unmappedLabels: string[] = [];
   for (const block of presentation.blocks) {
     if (block.type === "text" || block.type === "context") {
       body.push({
@@ -101,9 +105,20 @@ export function buildMSTeamsPresentationCard(params: {
             title: button.label,
             data: { value: action.value, label: button.label },
           });
+          continue;
         }
+        unmappedLabels.push(button.label);
       }
     }
+  }
+  if (unmappedLabels.length > 0) {
+    body.push({
+      type: "TextBlock",
+      text: `Actions:\n${unmappedLabels.map((label) => `- ${label}`).join("\n")}`,
+      wrap: true,
+      isSubtle: true,
+      size: "Small",
+    });
   }
   return {
     type: "AdaptiveCard",
@@ -182,27 +197,27 @@ export function prepareMSTeamsReplyPayload(
   ) {
     return rest;
   }
-  const cardPayload = textIsFallback ? { ...rest, text: undefined } : rest;
+  // The gate asks whether this reply fits one activity, so it reads the reply's own text
+  // even when the card will not carry it: fallback prose still holds the mention entity
+  // only the text path can send. A reply that fails it keeps the text path and degrades
+  // its controls to prose - the same trade the media branch makes.
   const cardText =
-    cardPayload.text && options?.renderCardText
-      ? options.renderCardText(cardPayload.text)
-      : cardPayload.text;
-  // A reply the caller will not put in a card keeps the text path and degrades its
-  // controls to prose - the same trade the media branch makes.
-  const rendered =
-    cardPayload.text && cardText === undefined
-      ? null
-      : renderMSTeamsPresentationPayload({
-          payload: { ...cardPayload, ...(cardText ? { text: cardText } : {}) },
-          presentation: adapted,
-        });
-  if (rendered) {
-    return rendered;
+    rest.text && options?.renderCardText ? options.renderCardText(rest.text) : rest.text;
+  if (rest.text && cardText === undefined) {
+    return replyWithControlsAsText();
   }
-  return {
-    ...rest,
-    text: textIsFallback
-      ? (payload.text ?? renderMessagePresentationFallbackText({ presentation }))
-      : renderMessagePresentationFallbackText({ text: payload.text, presentation }),
-  };
+  const rendered = renderMSTeamsPresentationPayload({
+    payload: textIsFallback ? { ...rest, text: undefined } : { ...rest, text: cardText },
+    presentation: adapted,
+  });
+  return rendered ?? replyWithControlsAsText();
+
+  function replyWithControlsAsText(): ReplyPayload {
+    return {
+      ...rest,
+      text: textIsFallback
+        ? (payload.text ?? renderMessagePresentationFallbackText({ presentation }))
+        : renderMessagePresentationFallbackText({ text: payload.text, presentation }),
+    };
+  }
 }

--- a/extensions/msteams/src/presentation.ts
+++ b/extensions/msteams/src/presentation.ts
@@ -149,7 +149,15 @@ export const readMSTeamsPresentationCard = (payload: ReplyPayload) =>
  * delivery paths on one rendering. Mirrors core's renderer, including degrading controls
  * to text rather than dropping them when Teams cannot carry them natively.
  */
-export function prepareMSTeamsReplyPayload(payload: ReplyPayload): ReplyPayload {
+export function prepareMSTeamsReplyPayload(
+  payload: ReplyPayload,
+  options?: {
+    /** Transport limit for the text a single card may carry; a card cannot be chunked. */
+    cardTextLimit?: number;
+    /** Renders the card's text in the same dialect the text path sends. */
+    formatCardText?: (text: string) => string;
+  },
+): ReplyPayload {
   const presentation = normalizeMessagePresentation(payload.presentation);
   if (!presentation) {
     return payload;
@@ -173,10 +181,19 @@ export function prepareMSTeamsReplyPayload(payload: ReplyPayload): ReplyPayload 
   ) {
     return rest;
   }
-  const rendered = renderMSTeamsPresentationPayload({
-    payload: textIsFallback ? { ...rest, text: undefined } : rest,
-    presentation: adapted,
-  });
+  const cardPayload = textIsFallback ? { ...rest, text: undefined } : rest;
+  const cardText = cardPayload.text ? options?.formatCardText?.(cardPayload.text) : undefined;
+  // A card cannot be split the way message text can, so a reply whose text does not fit
+  // one card keeps the text path's chunking and degrades its controls to prose instead -
+  // the same trade the media branch makes.
+  const fitsOneCard =
+    options?.cardTextLimit === undefined || (cardText ?? "").length <= options.cardTextLimit;
+  const rendered = fitsOneCard
+    ? renderMSTeamsPresentationPayload({
+        payload: { ...cardPayload, ...(cardText ? { text: cardText } : {}) },
+        presentation: adapted,
+      })
+    : null;
   if (rendered) {
     return rendered;
   }

--- a/extensions/msteams/src/presentation.ts
+++ b/extensions/msteams/src/presentation.ts
@@ -179,6 +179,8 @@ export function prepareMSTeamsReplyPayload(
      * chunked and cannot carry a mention entity, so the caller owns that judgement.
      */
     fitsOneActivity?: (text: string) => boolean;
+    /** Renders the card's text in the dialect the caller's text path would send. */
+    formatCardText?: (text: string) => string;
   },
 ): ReplyPayload {
   const presentation = normalizeMessagePresentation(payload.presentation);
@@ -192,10 +194,11 @@ export function prepareMSTeamsReplyPayload(
     presentation,
     capabilities: MSTEAMS_PRESENTATION_CAPABILITIES,
   });
-  // "fallback" prose already renders every block; a card that adds no action Teams can
-  // draw would restate it under an instruction to tap buttons that are not there, and the
-  // card's text never reaches the activity, so the prose would simply be lost.
-  if (textIsFallback && !hasMSTeamsCardAction(adapted)) {
+  // A card only earns a reply when Teams can draw at least one of its controls. Without
+  // one the user gets an untappable frame, the reply's prose stops being the activity's
+  // text - so notification previews lose it - and the labels are already appended to that
+  // prose by the text rendering below.
+  if (!hasMSTeamsCardAction(adapted)) {
     return replyWithControlsAsText();
   }
   // The gate asks whether this reply fits one activity, so it reads the reply's own text
@@ -205,8 +208,11 @@ export function prepareMSTeamsReplyPayload(
   if (rest.text && options?.fitsOneActivity && !options.fitsOneActivity(rest.text)) {
     return replyWithControlsAsText();
   }
+  const cardText = rest.text ? options?.formatCardText?.(rest.text) : undefined;
   const rendered = renderMSTeamsPresentationPayload({
-    payload: textIsFallback ? { ...rest, text: undefined } : rest,
+    payload: textIsFallback
+      ? { ...rest, text: undefined }
+      : { ...rest, ...(cardText ? { text: cardText } : {}) },
     presentation: adapted,
   });
   return rendered ?? replyWithControlsAsText();

--- a/extensions/msteams/src/presentation.ts
+++ b/extensions/msteams/src/presentation.ts
@@ -114,9 +114,9 @@ export function buildMSTeamsPresentationCard(params: {
 }
 
 /**
- * Attach the Adaptive Card for an adapted presentation, or null when Teams cannot
- * carry one. A card and a media attachment cannot share one activity, so a reply
- * with media keeps its media and the caller degrades the controls to text.
+ * Attach the Adaptive Card for an adapted presentation, or null when Teams cannot carry
+ * one: a card and a media attachment cannot share an activity, so a reply with media
+ * keeps its media and the caller degrades the controls to text.
  */
 export function renderMSTeamsPresentationPayload(params: {
   payload: ReplyPayload;
@@ -140,22 +140,14 @@ export function renderMSTeamsPresentationPayload(params: {
 const countPresentationDataBlocks = (blocks: readonly MessagePresentationBlock[]): number =>
   blocks.filter((block) => block.type === "table" || block.type === "chart").length;
 
-/** Reads the Adaptive Card a prepared reply carries, if any. */
-export function readMSTeamsPresentationCard(
-  payload: ReplyPayload,
-): Record<string, unknown> | undefined {
-  const card = asOptionalRecord(payload.channelData?.msteams)?.presentationCard;
-  return asOptionalRecord(card);
-}
+/** Reads the Adaptive Card a resolved reply carries, if any. */
+export const readMSTeamsPresentationCard = (payload: ReplyPayload) =>
+  asOptionalRecord(asOptionalRecord(payload.channelData?.msteams)?.presentationCard);
 
 /**
- * Resolve a reply's portable presentation into a Teams Adaptive Card.
- *
- * Core renders presentations inside the outbound send pipeline only, so replies the
- * monitor delivers itself arrive with the controls still portable. Preparing them here
- * keeps both Teams delivery paths on one rendering, and mirrors what core's renderer
- * does when a channel cannot carry the controls natively: degrade them to text rather
- * than drop them.
+ * Resolve a reply's portable presentation into a Teams Adaptive Card, keeping both Teams
+ * delivery paths on one rendering. Mirrors core's renderer, including degrading controls
+ * to text rather than dropping them when Teams cannot carry them natively.
  */
 export function prepareMSTeamsReplyPayload(payload: ReplyPayload): ReplyPayload {
   const presentation = normalizeMessagePresentation(payload.presentation);
@@ -169,9 +161,9 @@ export function prepareMSTeamsReplyPayload(payload: ReplyPayload): ReplyPayload 
     presentation,
     capabilities: MSTEAMS_PRESENTATION_CAPABILITIES,
   });
-  // Core applies this rule before its own renderer, so both Teams paths keep the
-  // same answer: once every structured data block has degraded to text and nothing
-  // interactive remains, the producer's authored fallback beats block flattening.
+  // Core's rule before its own renderer, applied so both Teams paths agree: once every
+  // data block has degraded to text and nothing interactive remains, the producer's
+  // authored fallback beats block flattening.
   if (
     textIsFallback &&
     payload.text?.trim() &&

--- a/extensions/msteams/src/presentation.ts
+++ b/extensions/msteams/src/presentation.ts
@@ -1,10 +1,12 @@
 // Msteams plugin module implements presentation behavior.
 import {
   adaptMessagePresentationForChannel,
+  isMessagePresentationInteractiveBlock,
   normalizeMessagePresentation,
   renderMessagePresentationFallbackText,
   resolveMessagePresentationButtonAction,
   type MessagePresentation,
+  type MessagePresentationBlock,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import {
   asOptionalRecord,
@@ -135,6 +137,9 @@ export function renderMSTeamsPresentationPayload(params: {
   };
 }
 
+const countPresentationDataBlocks = (blocks: readonly MessagePresentationBlock[]): number =>
+  blocks.filter((block) => block.type === "table" || block.type === "chart").length;
+
 /** Reads the Adaptive Card a prepared reply carries, if any. */
 export function readMSTeamsPresentationCard(
   payload: ReplyPayload,
@@ -160,12 +165,25 @@ export function prepareMSTeamsReplyPayload(payload: ReplyPayload): ReplyPayload 
   const { presentation: _presentation, presentationTextMode, ...rest } = payload;
   // "fallback" text already renders these controls as prose; the card replaces it.
   const textIsFallback = presentationTextMode === "fallback";
+  const adapted = adaptMessagePresentationForChannel({
+    presentation,
+    capabilities: MSTEAMS_PRESENTATION_CAPABILITIES,
+  });
+  // Core applies this rule before its own renderer, so both Teams paths keep the
+  // same answer: once every structured data block has degraded to text and nothing
+  // interactive remains, the producer's authored fallback beats block flattening.
+  if (
+    textIsFallback &&
+    payload.text?.trim() &&
+    !presentation.blocks.some(isMessagePresentationInteractiveBlock) &&
+    countPresentationDataBlocks(presentation.blocks) > 0 &&
+    countPresentationDataBlocks(adapted.blocks) === 0
+  ) {
+    return rest;
+  }
   const rendered = renderMSTeamsPresentationPayload({
     payload: textIsFallback ? { ...rest, text: undefined } : rest,
-    presentation: adaptMessagePresentationForChannel({
-      presentation,
-      capabilities: MSTEAMS_PRESENTATION_CAPABILITIES,
-    }),
+    presentation: adapted,
   });
   if (rendered) {
     return rendered;

--- a/extensions/msteams/src/presentation.ts
+++ b/extensions/msteams/src/presentation.ts
@@ -152,10 +152,11 @@ export const readMSTeamsPresentationCard = (payload: ReplyPayload) =>
 export function prepareMSTeamsReplyPayload(
   payload: ReplyPayload,
   options?: {
-    /** Transport limit for the text a single card may carry; a card cannot be chunked. */
-    cardTextLimit?: number;
-    /** Renders the card's text in the same dialect the text path sends. */
-    formatCardText?: (text: string) => string;
+    /**
+     * Renders the text a card may carry, or returns undefined when this reply has to stay
+     * on the text path because one activity cannot hold it.
+     */
+    renderCardText?: (text: string) => string | undefined;
   },
 ): ReplyPayload {
   const presentation = normalizeMessagePresentation(payload.presentation);
@@ -182,18 +183,19 @@ export function prepareMSTeamsReplyPayload(
     return rest;
   }
   const cardPayload = textIsFallback ? { ...rest, text: undefined } : rest;
-  const cardText = cardPayload.text ? options?.formatCardText?.(cardPayload.text) : undefined;
-  // A card cannot be split the way message text can, so a reply whose text does not fit
-  // one card keeps the text path's chunking and degrades its controls to prose instead -
-  // the same trade the media branch makes.
-  const fitsOneCard =
-    options?.cardTextLimit === undefined || (cardText ?? "").length <= options.cardTextLimit;
-  const rendered = fitsOneCard
-    ? renderMSTeamsPresentationPayload({
-        payload: { ...cardPayload, ...(cardText ? { text: cardText } : {}) },
-        presentation: adapted,
-      })
-    : null;
+  const cardText =
+    cardPayload.text && options?.renderCardText
+      ? options.renderCardText(cardPayload.text)
+      : cardPayload.text;
+  // A reply the caller will not put in a card keeps the text path and degrades its
+  // controls to prose - the same trade the media branch makes.
+  const rendered =
+    cardPayload.text && cardText === undefined
+      ? null
+      : renderMSTeamsPresentationPayload({
+          payload: { ...cardPayload, ...(cardText ? { text: cardText } : {}) },
+          presentation: adapted,
+        });
   if (rendered) {
     return rendered;
   }

--- a/extensions/msteams/src/presentation.ts
+++ b/extensions/msteams/src/presentation.ts
@@ -7,6 +7,7 @@ import {
   resolveMessagePresentationButtonAction,
   type MessagePresentation,
   type MessagePresentationBlock,
+  type MessagePresentationButton,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import {
   asOptionalRecord,
@@ -30,6 +31,41 @@ export const MSTEAMS_PRESENTATION_CAPABILITIES = {
     },
   },
 } satisfies ChannelOutboundAdapter["presentationCapabilities"];
+
+const hasMSTeamsCardAction = (presentation: MessagePresentation): boolean =>
+  presentation.blocks.some(
+    (block) =>
+      block.type === "buttons" && block.buttons.some((button) => resolveMSTeamsCardAction(button)),
+  );
+
+/**
+ * The Teams card action for a control, or undefined when Teams has none for it and the
+ * control can only reach the user as text. One owner for "what Teams renders natively",
+ * so the card builder and the streaming remainder cannot disagree about it.
+ */
+export function resolveMSTeamsCardAction(
+  button: Pick<
+    MessagePresentationButton,
+    "label" | "action" | "url" | "value" | "webApp" | "web_app"
+  >,
+): Record<string, unknown> | undefined {
+  const action = resolveMessagePresentationButtonAction(button);
+  if (action?.type === "url" || action?.type === "web-app") {
+    const url = normalizeOptionalString(action.url);
+    return url ? { type: "Action.OpenUrl", title: button.label, url } : undefined;
+  }
+  if (action?.type === "command") {
+    return { type: "Action.Submit", title: button.label, data: action.command };
+  }
+  if (action?.type === "callback") {
+    return {
+      type: "Action.Submit",
+      title: button.label,
+      data: { value: action.value, label: button.label },
+    };
+  }
+  return undefined;
+}
 
 export function buildMSTeamsPresentationCard(params: {
   presentation: MessagePresentation;
@@ -78,33 +114,9 @@ export function buildMSTeamsPresentationCard(params: {
     }
     if (block.type === "buttons") {
       for (const button of block.buttons) {
-        const action = resolveMessagePresentationButtonAction(button);
-        if (action?.type === "url" || action?.type === "web-app") {
-          const url = normalizeOptionalString(action.url);
-          if (!url) {
-            continue;
-          }
-          actions.push({
-            type: "Action.OpenUrl",
-            title: button.label,
-            url,
-          });
-          continue;
-        }
-        if (action?.type === "command") {
-          actions.push({
-            type: "Action.Submit",
-            title: button.label,
-            data: action.command,
-          });
-          continue;
-        }
-        if (action?.type === "callback") {
-          actions.push({
-            type: "Action.Submit",
-            title: button.label,
-            data: { value: action.value, label: button.label },
-          });
+        const action = resolveMSTeamsCardAction(button);
+        if (action) {
+          actions.push(action);
           continue;
         }
         unmappedLabels.push(button.label);
@@ -139,6 +151,12 @@ export function renderMSTeamsPresentationPayload(params: {
 }): ReplyPayload | null {
   const { payload, presentation } = params;
   if (payload.mediaUrl || payload.mediaUrls?.length) {
+    return null;
+  }
+  // With no text of its own and no action Teams can render, a card carries nothing the
+  // caller's text rendering does not - and it would replace the producer's prose with a
+  // flattened copy of itself under an instruction to tap buttons that are not there.
+  if (!normalizeOptionalString(payload.text) && !hasMSTeamsCardAction(presentation)) {
     return null;
   }
   const card = buildMSTeamsPresentationCard({ presentation, text: payload.text });

--- a/extensions/msteams/src/presentation.ts
+++ b/extensions/msteams/src/presentation.ts
@@ -1,12 +1,10 @@
 // Msteams plugin module implements presentation behavior.
 import {
   adaptMessagePresentationForChannel,
-  isMessagePresentationInteractiveBlock,
   normalizeMessagePresentation,
   renderMessagePresentationFallbackText,
   resolveMessagePresentationButtonAction,
   type MessagePresentation,
-  type MessagePresentationBlock,
   type MessagePresentationButton,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import {
@@ -170,9 +168,6 @@ export function renderMSTeamsPresentationPayload(params: {
   };
 }
 
-const countPresentationDataBlocks = (blocks: readonly MessagePresentationBlock[]): number =>
-  blocks.filter((block) => block.type === "table" || block.type === "chart").length;
-
 /** Reads the Adaptive Card a resolved reply carries, if any. */
 export const readMSTeamsPresentationCard = (payload: ReplyPayload) =>
   asOptionalRecord(asOptionalRecord(payload.channelData?.msteams)?.presentationCard);
@@ -203,18 +198,6 @@ export function prepareMSTeamsReplyPayload(
     presentation,
     capabilities: MSTEAMS_PRESENTATION_CAPABILITIES,
   });
-  // Core's rule before its own renderer, applied so both Teams paths agree: once every
-  // data block has degraded to text and nothing interactive remains, the producer's
-  // authored fallback beats block flattening.
-  if (
-    textIsFallback &&
-    payload.text?.trim() &&
-    !presentation.blocks.some(isMessagePresentationInteractiveBlock) &&
-    countPresentationDataBlocks(presentation.blocks) > 0 &&
-    countPresentationDataBlocks(adapted.blocks) === 0
-  ) {
-    return rest;
-  }
   // The gate asks whether this reply fits one activity, so it reads the reply's own text
   // even when the card will not carry it: fallback prose still holds the mention entity
   // only the text path can send. A reply that fails it keeps the text path and degrades

--- a/extensions/msteams/src/qa/adapter.runtime.test.ts
+++ b/extensions/msteams/src/qa/adapter.runtime.test.ts
@@ -146,6 +146,40 @@ describe("Microsoft Teams QA transport adapter", () => {
       to: "channel:qa-primary",
     });
 
+    const card = { type: "AdaptiveCard", version: "1.4", body: [], actions: [] };
+    const cardResponse = await fetch(
+      `${bootstrapConfig.connectorUrl}qa/v3/conversations/${encodeURIComponent(
+        "19:qa-primary@thread.tacv2",
+      )}/activities`,
+      {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${bootstrapConfig.botToken}`,
+          "content-type": "application/json",
+          "x-openclaw-msteams-qa-nonce": bootstrapConfig.nonce!,
+        },
+        body: JSON.stringify({
+          type: "message",
+          attachments: [{ contentType: "application/vnd.microsoft.card.adaptive", content: card }],
+        }),
+      },
+    );
+    expect(cardResponse.status).toBe(200);
+    // A card-only reply has no activity text, so a scenario can only see it through the
+    // recorded attachment.
+    const cardCall = addOutboundMessage.mock.calls.at(-1)?.[0] as {
+      text: string;
+      attachments?: Array<{ mimeType: string; contentBase64: string }>;
+    };
+    expect(cardCall.text).toBe("");
+    expect(cardCall.attachments).toHaveLength(1);
+    expect(cardCall.attachments?.[0]?.mimeType).toBe("application/vnd.microsoft.card.adaptive");
+    expect(
+      JSON.parse(
+        Buffer.from(cardCall.attachments?.[0]?.contentBase64 ?? "", "base64").toString("utf8"),
+      ),
+    ).toEqual(card);
+
     await adapter.cleanup?.();
     await expect(fs.access(bootstrapPath)).rejects.toThrow();
   });

--- a/extensions/msteams/src/qa/adapter.runtime.ts
+++ b/extensions/msteams/src/qa/adapter.runtime.ts
@@ -9,6 +9,7 @@ import {
   fetchWithSsrFGuard,
   ssrfPolicyFromHttpBaseUrlAllowedOrigin,
 } from "openclaw/plugin-sdk/ssrf-runtime";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   reserveMSTeamsQaWebhookPort,
   startMSTeamsQaBotFrameworkServer,
@@ -18,6 +19,7 @@ type AdapterFactory = NonNullable<QaRunnerCliRegistration["adapterFactory"]>;
 type FactoryContext = Parameters<AdapterFactory["create"]>[0];
 type AdapterDefinition = Awaited<ReturnType<AdapterFactory["create"]>>;
 
+const ADAPTIVE_CARD_CONTENT_TYPE = "application/vnd.microsoft.card.adaptive";
 const SERVICE_URL = "https://smba.trafficmanager.net/qa";
 const APP_ID = "qa-msteams-app";
 const TENANT_ID = "qa-msteams-tenant";
@@ -52,6 +54,29 @@ function renderMSTeamsQaText(text: string) {
 
 function activityText(activity: Record<string, unknown>) {
   return typeof activity.text === "string" ? activity.text : "";
+}
+
+// The QA bus records reply text; an Adaptive Card carries its content in the activity's
+// attachments instead, so a card-only reply would reach scenarios as an empty message.
+function activityCardAttachments(activity: Record<string, unknown>, activityId: string) {
+  const attachments = Array.isArray(activity.attachments) ? activity.attachments : [];
+  return attachments.flatMap((attachment, index) => {
+    const record = asOptionalRecord(attachment);
+    if (record?.contentType !== ADAPTIVE_CARD_CONTENT_TYPE) {
+      return [];
+    }
+    return [
+      {
+        id: `${activityId}-card-${index}`,
+        kind: "file" as const,
+        mimeType: ADAPTIVE_CARD_CONTENT_TYPE,
+        fileName: "adaptive-card.json",
+        contentBase64: Buffer.from(JSON.stringify(record.content ?? null), "utf8").toString(
+          "base64",
+        ),
+      },
+    ];
+  });
 }
 
 function createMSTeamsQaBotToken() {
@@ -112,12 +137,14 @@ export async function createMSTeamsQaTransportAdapter(
       const kind = conversationKindByNativeId.get(outbound.conversationId) ?? "channel";
       const conversationId =
         logicalConversationByNativeId.get(outbound.conversationId) ?? outbound.conversationId;
+      const cardAttachments = activityCardAttachments(outbound.activity, outbound.activityId);
       const message = await context.messages.addOutboundMessage({
         accountId,
         to: `${kind === "direct" ? "dm" : kind}:${conversationId}`,
         senderId: APP_ID,
         text: activityText(outbound.activity),
         timestamp: Date.now(),
+        ...(cardAttachments.length > 0 ? { attachments: cardAttachments } : {}),
         ...(outbound.threadId
           ? { threadId: busByNativeMessageId.get(outbound.threadId) ?? outbound.threadId }
           : {}),

--- a/extensions/msteams/src/qa/cli.test.ts
+++ b/extensions/msteams/src/qa/cli.test.ts
@@ -18,7 +18,7 @@ describe("Microsoft Teams QA CLI", () => {
     runLiveTransportQaSuiteCommand.mockClear();
   });
 
-  it("runs the shared channel canary by default", async () => {
+  it("runs the shared canary and the reply-presentation scenario by default", async () => {
     const qa = new Command();
     msteamsQaCliRegistration.register(qa);
 
@@ -46,7 +46,7 @@ describe("Microsoft Teams QA CLI", () => {
         primaryModel: "openai/gpt-5.4",
         providerMode: "mock-openai",
       }),
-    ).toEqual(["channel-canary"]);
+    ).toEqual(["channel-canary", "msteams-reply-presentation"]);
   });
 
   it("honors explicit scenario selection", async () => {

--- a/extensions/msteams/src/qa/cli.ts
+++ b/extensions/msteams/src/qa/cli.ts
@@ -6,7 +6,7 @@ import {
   type LiveTransportQaCommandOptions,
 } from "openclaw/plugin-sdk/qa-runner-runtime";
 
-const DEFAULT_MSTEAMS_QA_SCENARIOS = ["channel-canary"] as const;
+const DEFAULT_MSTEAMS_QA_SCENARIOS = ["channel-canary", "msteams-reply-presentation"] as const;
 
 const loadMSTeamsQaAdapterRuntime = createLazyCliRuntimeLoader<
   typeof import("./adapter.runtime.js")

--- a/extensions/msteams/src/reply-dispatcher.test.ts
+++ b/extensions/msteams/src/reply-dispatcher.test.ts
@@ -37,8 +37,6 @@ vi.mock("./revoked-context.js", () => ({
   withRevokedProxyFallback: async ({ run }: { run: () => Promise<unknown> }) => await run(),
 }));
 
-const { readMSTeamsPresentationCard } = await import("./presentation.js");
-
 /**
  * Mock for the SDK's `ctx.stream` (IStreamer). The migration uses
  * `ctx.stream.update()` for informative status, `.emit()` for token chunks,
@@ -1042,23 +1040,19 @@ describe("createMSTeamsReplyDispatcher", () => {
     await finalization;
   });
 
-  it("resolves a reply's presentation into a Teams card before delivering it", async () => {
-    // The turn adapter owns this preparation: core renders presentations inside the
-    // outbound send pipeline, which replies delivered here never enter.
+  it("hands a reply's controls to the renderer even after the text was streamed", async () => {
     const dispatcher = createDispatcher();
+    const presentation = {
+      blocks: [{ type: "buttons" as const, buttons: [{ label: "Open run", value: "open" }] }],
+    };
 
-    const prepared = await dispatcher.delivery.preparePayload?.(
-      {
-        text: "Deploy finished",
-        presentation: {
-          blocks: [{ type: "buttons", buttons: [{ label: "Open", value: "open" }] }],
-        },
-      },
-      { kind: "final" },
-    );
+    await dispatcher.dispatcherOptions.onReplyStart?.();
+    await triggerPartialReply("Deploy finished");
+    await dispatcherOptions().deliver({ text: "Deploy finished", presentation });
 
-    expect(readMSTeamsPresentationCard(prepared ?? {})?.actions).toEqual([
-      { type: "Action.Submit", title: "Open", data: { value: "open", label: "Open" } },
-    ]);
+    // The stream already showed the text, so only the controls remain to deliver.
+    // Before this, the streamed final was dropped whole and they never rendered.
+    const [renderedPayloads] = renderReplyPayloadsToMessagesMock.mock.calls.at(-1) ?? [];
+    expect(renderedPayloads).toEqual([{ text: undefined, presentation }]);
   });
 });

--- a/extensions/msteams/src/reply-dispatcher.test.ts
+++ b/extensions/msteams/src/reply-dispatcher.test.ts
@@ -37,6 +37,8 @@ vi.mock("./revoked-context.js", () => ({
   withRevokedProxyFallback: async ({ run }: { run: () => Promise<unknown> }) => await run(),
 }));
 
+const { readMSTeamsPresentationCard } = await import("./presentation.js");
+
 /**
  * Mock for the SDK's `ctx.stream` (IStreamer). The migration uses
  * `ctx.stream.update()` for informative status, `.emit()` for token chunks,
@@ -1038,5 +1040,25 @@ describe("createMSTeamsReplyDispatcher", () => {
     const finalization = expect(result?.finalization).rejects.toBe(failure);
     await dispatcher.dispatcherOptions.onSettled?.();
     await finalization;
+  });
+
+  it("resolves a reply's presentation into a Teams card before delivering it", async () => {
+    // The turn adapter owns this preparation: core renders presentations inside the
+    // outbound send pipeline, which replies delivered here never enter.
+    const dispatcher = createDispatcher();
+
+    const prepared = await dispatcher.delivery.preparePayload?.(
+      {
+        text: "Deploy finished",
+        presentation: {
+          blocks: [{ type: "buttons", buttons: [{ label: "Open", value: "open" }] }],
+        },
+      },
+      { kind: "final" },
+    );
+
+    expect(readMSTeamsPresentationCard(prepared ?? {})?.actions).toEqual([
+      { type: "Action.Submit", title: "Open", data: { value: "open", label: "Open" } },
+    ]);
   });
 });

--- a/extensions/msteams/src/reply-dispatcher.test.ts
+++ b/extensions/msteams/src/reply-dispatcher.test.ts
@@ -7,7 +7,9 @@ const createChannelMessageReplyPipelineMock = vi.hoisted(() => vi.fn());
 const getMSTeamsRuntimeMock = vi.hoisted(() => vi.fn());
 const enqueueSystemEventMock = vi.hoisted(() => vi.fn());
 const getGlobalHookRunnerMock = vi.hoisted(() => vi.fn());
-const renderReplyPayloadsToMessagesMock = vi.hoisted(() => vi.fn(() => []));
+const renderReplyPayloadsToMessagesMock = vi.hoisted(() =>
+  vi.fn<(typeof import("./messenger.js"))["renderReplyPayloadsToMessages"]>(() => []),
+);
 const sendMSTeamsMessagesMock = vi.hoisted(() =>
   vi.fn<(typeof import("./messenger.js"))["sendMSTeamsMessages"]>(async () => []),
 );

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -42,7 +42,6 @@ import {
   sendMSTeamsMessages,
 } from "./messenger.js";
 import type { MSTeamsMonitorLogger } from "./monitor-types.js";
-import { prepareMSTeamsReplyPayload } from "./presentation.js";
 import { createTeamsReplyStreamController } from "./reply-stream-controller.js";
 import { withRevokedProxyFallback } from "./revoked-context.js";
 import { getMSTeamsRuntime } from "./runtime.js";
@@ -440,9 +439,6 @@ export function createMSTeamsReplyDispatcher(params: {
   };
   const delivery: ChannelInboundTurnPlan["delivery"] = {
     observeMessageSent: true,
-    // Core renders presentations inside the outbound send pipeline only, so this path
-    // resolves them before either branch reads channelData.
-    preparePayload: prepareMSTeamsReplyPayload,
     deliver: async (payload) => {
       const preparedPayload = streamController.preparePayload(payload);
       const native = streamController.claimNativeDelivery();

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -42,6 +42,7 @@ import {
   sendMSTeamsMessages,
 } from "./messenger.js";
 import type { MSTeamsMonitorLogger } from "./monitor-types.js";
+import { prepareMSTeamsReplyPayload } from "./presentation.js";
 import { createTeamsReplyStreamController } from "./reply-stream-controller.js";
 import { withRevokedProxyFallback } from "./revoked-context.js";
 import { getMSTeamsRuntime } from "./runtime.js";
@@ -439,6 +440,9 @@ export function createMSTeamsReplyDispatcher(params: {
   };
   const delivery: ChannelInboundTurnPlan["delivery"] = {
     observeMessageSent: true,
+    // Core renders presentations inside the outbound send pipeline only, so this path
+    // resolves them before either branch reads channelData.
+    preparePayload: prepareMSTeamsReplyPayload,
     deliver: async (payload) => {
       const preparedPayload = streamController.preparePayload(payload);
       const native = streamController.claimNativeDelivery();

--- a/extensions/msteams/src/reply-stream-controller.presentation.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.presentation.test.ts
@@ -128,6 +128,57 @@ describe("createTeamsReplyStreamController presentation remainders", () => {
     ).toEqual({ text: undefined, presentation: { blocks: [buttons] } });
   });
 
+  it("drops a streamed reply's buttons when Teams has no card action for them", () => {
+    const stream = makeStream();
+    const ctrl = makeController({ stream });
+    ctrl.onPartialReply({ text: "Where should this deploy?\n\n- Staging" });
+
+    // ask_user's buttons carry `question` actions. Teams renders them as text, and that
+    // text is part of the prose the stream just delivered.
+    expect(
+      ctrl.preparePayload({
+        text: "Where should this deploy?\n\n- Staging",
+        presentationTextMode: "fallback",
+        presentation: {
+          blocks: [
+            {
+              type: "buttons" as const,
+              buttons: [
+                {
+                  label: "Staging",
+                  action: {
+                    type: "question" as const,
+                    questionId: "deploy-target",
+                    optionValue: "Staging",
+                  },
+                },
+              ],
+            },
+          ],
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps only the media when a streamed fallback reply also carries some", () => {
+    const stream = makeStream();
+    const ctrl = makeController({ stream });
+    ctrl.onPartialReply({ text: "Deploy finished\n\n- Open run" });
+
+    // A card cannot share an activity with media, so nothing native is left to send and
+    // re-rendering the controls as prose would repeat what the stream already showed.
+    expect(
+      ctrl.preparePayload({
+        text: "Deploy finished\n\n- Open run",
+        mediaUrl: "https://example.com/log.png",
+        presentationTextMode: "fallback",
+        presentation: {
+          blocks: [{ type: "buttons" as const, buttons: [{ label: "Open run", value: "open" }] }],
+        },
+      }),
+    ).toEqual({ text: undefined, mediaUrl: "https://example.com/log.png" });
+  });
+
   it("drops a streamed reply's select, which Teams renders as the prose it just sent", () => {
     const stream = makeStream();
     const ctrl = makeController({ stream });

--- a/extensions/msteams/src/reply-stream-controller.presentation.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.presentation.test.ts
@@ -1,0 +1,230 @@
+// Msteams tests cover what a native stream leaves for block delivery when a reply also
+// carries portable controls.
+import { describe, expect, it } from "vitest";
+import { createTeamsReplyStreamController } from "./reply-stream-controller.js";
+import {
+  makeAcknowledgedStream,
+  makeContext,
+  makeController,
+  makeStream,
+} from "./reply-stream-controller.test-helpers.js";
+
+describe("createTeamsReplyStreamController presentation remainders", () => {
+  it("keeps a replaced reply's controls after the stream acknowledged its text", async () => {
+    const stream = makeAcknowledgedStream();
+    const ctrl = makeController({ stream });
+    const presentation = {
+      blocks: [{ type: "buttons" as const, buttons: [{ label: "Open run", value: "open" }] }],
+    };
+
+    ctrl.onPartialReply({ text: "abcde" });
+    stream.acknowledge("abcde");
+    ctrl.onPartialReply({ text: "abXYZ" });
+    expect(ctrl.preparePayload({ text: "abcdef", presentation })).toBeUndefined();
+
+    // The replacement carries the text, so the deferred entry is subtracted the same way
+    // a suppressed final is: dropping it whole took the controls with the text.
+    await expect(ctrl.finalize()).resolves.toMatchObject({
+      postNativePayloads: [{ text: undefined, presentation }],
+    });
+  });
+
+  it("does not repeat the replaced prose when a replacement leaves text undelivered", async () => {
+    const stream = makeAcknowledgedStream();
+    const ctrl = makeController({ stream });
+    const buttons = {
+      type: "buttons" as const,
+      buttons: [{ label: "Open run", value: "open" }],
+    };
+
+    ctrl.onPartialReply({ text: "Deploy summary" });
+    stream.acknowledge("Deploy summary");
+    ctrl.onPartialReply({ text: "Deploy XYZ" });
+    expect(
+      ctrl.preparePayload({
+        text: "Deploy summary and more",
+        presentationTextMode: "fallback",
+        presentation: { blocks: [{ type: "text" as const, text: "Deploy summary" }, buttons] },
+      }),
+    ).toBeUndefined();
+    stream.close.mockResolvedValueOnce(undefined);
+
+    // Re-attaching the undelivered text to the whole payload would build a card out of
+    // the prose the stream just showed - and the card would swallow that text, because a
+    // card message carries its text as a delivery record, not as activity text.
+    await expect(ctrl.finalize()).resolves.toMatchObject({
+      postNativePayloads: [{ text: " and more", presentation: { blocks: [buttons] } }],
+    });
+  });
+
+  it("strips text but keeps the controls a reply offers when text was streamed", () => {
+    const stream = makeStream();
+    const ctrl = makeController({ stream });
+    ctrl.onPartialReply({ text: "streamed" });
+    const presentation = {
+      blocks: [{ type: "buttons" as const, buttons: [{ label: "Open run", value: "open" }] }],
+    };
+
+    // The stream carries text only. Dropping the whole payload here dropped the
+    // buttons with it, so a streamed reply reached Teams without its controls.
+    expect(ctrl.preparePayload({ text: "streamed", presentation })).toEqual({
+      text: undefined,
+      presentation,
+    });
+  });
+
+  it("drops a streamed reply's presentation when its text already rendered it", () => {
+    const stream = makeStream();
+    const ctrl = makeController({ stream });
+    ctrl.onPartialReply({ text: "Runs by region: EU 12, US 9" });
+
+    // "fallback" text is the prose rendering of the whole presentation, so a table-only
+    // presentation carries nothing the stream did not already deliver. Sending it anyway
+    // restates the table under the answer the user just read.
+    expect(
+      ctrl.preparePayload({
+        text: "Runs by region: EU 12, US 9",
+        presentationTextMode: "fallback",
+        presentation: {
+          blocks: [
+            {
+              type: "table" as const,
+              caption: "Runs by region",
+              headers: ["Region", "Runs"],
+              rows: [
+                ["EU", "12"],
+                ["US", "9"],
+              ],
+            },
+          ],
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("leaves only the controls when a streamed reply's text was the fallback prose", () => {
+    const stream = makeStream();
+    const ctrl = makeController({ stream });
+    const buttons = {
+      type: "buttons" as const,
+      buttons: [{ label: "Open run", value: "open" }],
+    };
+    // The shape ask_user produces: the question and its option list as text blocks, then
+    // the buttons, with the payload text holding the prose rendering of all three.
+    const presentation = {
+      title: "Deploy",
+      blocks: [{ type: "text" as const, text: "Which region?" }, buttons],
+    };
+    ctrl.onPartialReply({ text: "Deploy\n\nWhich region?\n\n- Open run" });
+
+    // Prose cannot carry a control the channel renders natively, so the buttons remain -
+    // but the text blocks and the title were in the prose the stream just delivered.
+    expect(
+      ctrl.preparePayload({
+        text: "Deploy\n\nWhich region?\n\n- Open run",
+        presentationTextMode: "fallback",
+        presentation,
+      }),
+    ).toEqual({ text: undefined, presentation: { blocks: [buttons] } });
+  });
+
+  it("drops a streamed reply's select, which Teams renders as the prose it just sent", () => {
+    const stream = makeStream();
+    const ctrl = makeController({ stream });
+    ctrl.onPartialReply({ text: "Which region?\n\nOptions\n- EU\n- US" });
+
+    // Teams declares selects: false, so a select degrades to a text list - and in fallback
+    // mode that list is part of the prose the stream already delivered.
+    expect(
+      ctrl.preparePayload({
+        text: "Which region?\n\nOptions\n- EU\n- US",
+        presentationTextMode: "fallback",
+        presentation: {
+          blocks: [
+            {
+              type: "select" as const,
+              placeholder: "Options",
+              options: [
+                { label: "EU", value: "eu" },
+                { label: "US", value: "us" },
+              ],
+            },
+          ],
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps a progress-mode reply's controls after the stream takes its text", () => {
+    const stream = makeStream();
+    const ctrl = createTeamsReplyStreamController({
+      allowProviderPreview: true,
+      conversationType: "personal",
+      context: makeContext(stream),
+      feedbackLoopEnabled: false,
+      msteamsConfig: { streaming: { mode: "progress" } } as never,
+    });
+    const presentation = {
+      blocks: [{ type: "buttons" as const, buttons: [{ label: "Open run", value: "open" }] }],
+    };
+
+    // Progress mode emits the final text into the stream instead of streaming tokens,
+    // so it suppresses the payload for the same reason - and must keep the same remainder.
+    expect(ctrl.preparePayload({ text: "Deploy finished", presentation })).toEqual({
+      text: undefined,
+      presentation,
+    });
+    expect(stream.emit).toHaveBeenCalledWith("Deploy finished");
+  });
+
+  it("does not redraw the acknowledged prose as a card after a stream failure", () => {
+    const stream = makeAcknowledgedStream();
+    const ctrl = makeController({ stream });
+    const buttons = {
+      type: "buttons" as const,
+      buttons: [{ label: "Open run", value: "open" }],
+    };
+
+    ctrl.onPartialReply({ text: "Deploy summary" });
+    stream.acknowledge("Deploy summary");
+    stream.emit.mockImplementation(() => {
+      throw new Error("network failure");
+    });
+    ctrl.onPartialReply({ text: "Deploy summary extended" });
+
+    // This is the third path that subtracts already-delivered text, and it subtracts
+    // the same way: the prose Teams acknowledged does not come back inside a card.
+    expect(
+      ctrl.preparePayload({
+        text: "Deploy summary and its options",
+        presentationTextMode: "fallback",
+        presentation: { blocks: [{ type: "text" as const, text: "Deploy summary" }, buttons] },
+      }),
+    ).toEqual({ text: " and its options", presentation: { blocks: [buttons] } });
+  });
+
+  it("does not repeat controls the remainder already delivered when close produces nothing", async () => {
+    const stream = makeAcknowledgedStream();
+    const ctrl = makeController({ stream });
+    const presentation = {
+      blocks: [{ type: "buttons" as const, buttons: [{ label: "Open run", value: "open" }] }],
+    };
+
+    ctrl.onPartialReply({ text: "hello there" });
+    stream.acknowledge("hello");
+    expect(ctrl.preparePayload({ text: "hello there", presentation })).toEqual({
+      text: undefined,
+      presentation,
+    });
+    stream.close.mockResolvedValueOnce(undefined);
+
+    // The remainder already carried the controls to block delivery, so the fallback
+    // that covers the unacknowledged text must not send them a second time.
+    await expect(ctrl.finalize()).resolves.toEqual({
+      visibleReplySent: true,
+      content: "hello",
+      messageId: "stream-acknowledged",
+      fallbackPayload: { text: " there" },
+    });
+  });
+});

--- a/extensions/msteams/src/reply-stream-controller.test-helpers.ts
+++ b/extensions/msteams/src/reply-stream-controller.test-helpers.ts
@@ -1,0 +1,73 @@
+// Msteams test helpers build the SDK stream doubles both reply-stream-controller suites
+// drive, so the streaming behavior and its presentation behavior assert against one shape.
+import { vi } from "vitest";
+import { createTeamsReplyStreamController } from "./reply-stream-controller.js";
+
+type StreamCloseResult = { id: string } | undefined;
+
+export function makeStream() {
+  return {
+    emit: vi.fn(),
+    update: vi.fn(),
+    clearText: vi.fn(),
+    close: vi.fn<() => Promise<StreamCloseResult>>(async () => ({ id: "stream-final" })),
+    canceled: false,
+  };
+}
+
+export function makeAcknowledgedStream() {
+  type ChunkActivity = {
+    id?: string;
+    type?: string;
+    text?: string;
+    channelData?: { streamType?: string };
+  };
+  const handlers = new Map<number, (activity: ChunkActivity) => void>();
+  let nextSubscriptionId = 0;
+  const stream = {
+    ...makeStream(),
+    events: {
+      on: vi.fn((_event: "chunk", handler: (activity: ChunkActivity) => void) => {
+        const subscriptionId = nextSubscriptionId++;
+        handlers.set(subscriptionId, handler);
+        return subscriptionId;
+      }),
+      off: vi.fn((subscriptionId: number) => {
+        handlers.delete(subscriptionId);
+      }),
+    },
+    acknowledge(text: string, overrides: Partial<ChunkActivity> = {}) {
+      const activity: ChunkActivity = {
+        id: "stream-acknowledged",
+        type: "typing",
+        text,
+        channelData: { streamType: "streaming" },
+        ...overrides,
+      };
+      for (const handler of handlers.values()) {
+        handler(activity);
+      }
+    },
+  };
+  return stream;
+}
+
+export function makeContext(stream?: ReturnType<typeof makeStream>) {
+  return { activity: { type: "message" }, stream } as never;
+}
+
+export function makeController(
+  opts: {
+    allowProviderPreview?: boolean;
+    conversationType?: string;
+    stream?: ReturnType<typeof makeStream>;
+  } = {},
+) {
+  const stream = opts.stream;
+  return createTeamsReplyStreamController({
+    allowProviderPreview: opts.allowProviderPreview ?? true,
+    conversationType: opts.conversationType ?? "personal",
+    context: makeContext(stream),
+    feedbackLoopEnabled: false,
+  });
+}

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -284,6 +284,34 @@ describe("createTeamsReplyStreamController", () => {
     });
   });
 
+  it("does not repeat the replaced prose when a replacement leaves text undelivered", async () => {
+    const stream = makeAcknowledgedStream();
+    const ctrl = makeController({ stream });
+    const buttons = {
+      type: "buttons" as const,
+      buttons: [{ label: "Open run", value: "open" }],
+    };
+
+    ctrl.onPartialReply({ text: "Deploy summary" });
+    stream.acknowledge("Deploy summary");
+    ctrl.onPartialReply({ text: "Deploy XYZ" });
+    expect(
+      ctrl.preparePayload({
+        text: "Deploy summary and more",
+        presentationTextMode: "fallback",
+        presentation: { blocks: [{ type: "text" as const, text: "Deploy summary" }, buttons] },
+      }),
+    ).toBeUndefined();
+    stream.close.mockResolvedValueOnce(undefined);
+
+    // Re-attaching the undelivered text to the whole payload would build a card out of
+    // the prose the stream just showed - and the card would swallow that text, because a
+    // card message carries its text as a delivery record, not as activity text.
+    await expect(ctrl.finalize()).resolves.toMatchObject({
+      postNativePayloads: [{ text: " and more", presentation: { blocks: [buttons] } }],
+    });
+  });
+
   it("suppresses a replacement when emit synchronously discovers Stop", async () => {
     const stream = makeAcknowledgedStream();
     const ctrl = makeController({ stream });

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -924,6 +924,32 @@ describe("createTeamsReplyStreamController", () => {
       });
     });
 
+    it("does not redraw the acknowledged prose as a card after a stream failure", () => {
+      const stream = makeAcknowledgedStream();
+      const ctrl = makeController({ stream });
+      const buttons = {
+        type: "buttons" as const,
+        buttons: [{ label: "Open run", value: "open" }],
+      };
+
+      ctrl.onPartialReply({ text: "Deploy summary" });
+      stream.acknowledge("Deploy summary");
+      stream.emit.mockImplementation(() => {
+        throw new Error("network failure");
+      });
+      ctrl.onPartialReply({ text: "Deploy summary extended" });
+
+      // This is the third path that subtracts already-delivered text, and it subtracts
+      // the same way: the prose Teams acknowledged does not come back inside a card.
+      expect(
+        ctrl.preparePayload({
+          text: "Deploy summary and its options",
+          presentationTextMode: "fallback",
+          presentation: { blocks: [{ type: "text" as const, text: "Deploy summary" }, buttons] },
+        }),
+      ).toEqual({ text: " and its options", presentation: { blocks: [buttons] } });
+    });
+
     it("preserves the full fallback when a failed stream has no provider acknowledgement", () => {
       const stream = makeAcknowledgedStream();
       const ctrl = makeController({ stream });

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -476,6 +476,33 @@ describe("createTeamsReplyStreamController", () => {
     ).toEqual({ text: undefined, presentation: { blocks: [buttons] } });
   });
 
+  it("drops a streamed reply's select, which Teams renders as the prose it just sent", () => {
+    const stream = makeStream();
+    const ctrl = makeController({ stream });
+    ctrl.onPartialReply({ text: "Which region?\n\nOptions\n- EU\n- US" });
+
+    // Teams declares selects: false, so a select degrades to a text list - and in fallback
+    // mode that list is part of the prose the stream already delivered.
+    expect(
+      ctrl.preparePayload({
+        text: "Which region?\n\nOptions\n- EU\n- US",
+        presentationTextMode: "fallback",
+        presentation: {
+          blocks: [
+            {
+              type: "select" as const,
+              placeholder: "Options",
+              options: [
+                { label: "EU", value: "eu" },
+                { label: "US", value: "us" },
+              ],
+            },
+          ],
+        },
+      }),
+    ).toBeUndefined();
+  });
+
   it("allows fallback delivery for second text segment after tool calls", () => {
     const stream = makeStream();
     const ctrl = makeController({ stream });

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -386,6 +386,22 @@ describe("createTeamsReplyStreamController", () => {
     });
   });
 
+  it("strips text but keeps the controls a reply offers when text was streamed", () => {
+    const stream = makeStream();
+    const ctrl = makeController({ stream });
+    ctrl.onPartialReply({ text: "streamed" });
+    const presentation = {
+      blocks: [{ type: "buttons" as const, buttons: [{ label: "Open run", value: "open" }] }],
+    };
+
+    // The stream carries text only. Dropping the whole payload here dropped the
+    // buttons with it, so a streamed reply reached Teams without its controls.
+    expect(ctrl.preparePayload({ text: "streamed", presentation })).toEqual({
+      text: undefined,
+      presentation,
+    });
+  });
+
   it("allows fallback delivery for second text segment after tool calls", () => {
     const stream = makeStream();
     const ctrl = makeController({ stream });

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -265,6 +265,25 @@ describe("createTeamsReplyStreamController", () => {
     );
   });
 
+  it("keeps a replaced reply's controls after the stream acknowledged its text", async () => {
+    const stream = makeAcknowledgedStream();
+    const ctrl = makeController({ stream });
+    const presentation = {
+      blocks: [{ type: "buttons" as const, buttons: [{ label: "Open run", value: "open" }] }],
+    };
+
+    ctrl.onPartialReply({ text: "abcde" });
+    stream.acknowledge("abcde");
+    ctrl.onPartialReply({ text: "abXYZ" });
+    expect(ctrl.preparePayload({ text: "abcdef", presentation })).toBeUndefined();
+
+    // The replacement carries the text, so the deferred entry is subtracted the same way
+    // a suppressed final is: dropping it whole took the controls with the text.
+    await expect(ctrl.finalize()).resolves.toMatchObject({
+      postNativePayloads: [{ text: undefined, presentation }],
+    });
+  });
+
   it("suppresses a replacement when emit synchronously discovers Stop", async () => {
     const stream = makeAcknowledgedStream();
     const ctrl = makeController({ stream });
@@ -431,18 +450,30 @@ describe("createTeamsReplyStreamController", () => {
     ).toBeUndefined();
   });
 
-  it("keeps a streamed reply's controls even when its text is the fallback prose", () => {
+  it("leaves only the controls when a streamed reply's text was the fallback prose", () => {
     const stream = makeStream();
     const ctrl = makeController({ stream });
-    ctrl.onPartialReply({ text: "streamed" });
-    const presentation = {
-      blocks: [{ type: "buttons" as const, buttons: [{ label: "Open run", value: "open" }] }],
+    const buttons = {
+      type: "buttons" as const,
+      buttons: [{ label: "Open run", value: "open" }],
     };
+    // The shape ask_user produces: the question and its option list as text blocks, then
+    // the buttons, with the payload text holding the prose rendering of all three.
+    const presentation = {
+      title: "Deploy",
+      blocks: [{ type: "text" as const, text: "Which region?" }, buttons],
+    };
+    ctrl.onPartialReply({ text: "Deploy\n\nWhich region?\n\n- Open run" });
 
-    // Prose cannot carry a control the channel renders natively, so the buttons remain.
+    // Prose cannot carry a control the channel renders natively, so the buttons remain -
+    // but the text blocks and the title were in the prose the stream just delivered.
     expect(
-      ctrl.preparePayload({ text: "streamed", presentationTextMode: "fallback", presentation }),
-    ).toEqual({ text: undefined, presentationTextMode: "fallback", presentation });
+      ctrl.preparePayload({
+        text: "Deploy\n\nWhich region?\n\n- Open run",
+        presentationTextMode: "fallback",
+        presentation,
+      }),
+    ).toEqual({ text: undefined, presentation: { blocks: [buttons] } });
   });
 
   it("allows fallback delivery for second text segment after tool calls", () => {
@@ -988,6 +1019,31 @@ describe("createTeamsReplyStreamController", () => {
         messageId: "stream-acknowledged",
       });
       expect(stream.events.off).toHaveBeenCalledWith(0);
+    });
+
+    it("does not repeat controls the remainder already delivered when close produces nothing", async () => {
+      const stream = makeAcknowledgedStream();
+      const ctrl = makeController({ stream });
+      const presentation = {
+        blocks: [{ type: "buttons" as const, buttons: [{ label: "Open run", value: "open" }] }],
+      };
+
+      ctrl.onPartialReply({ text: "hello there" });
+      stream.acknowledge("hello");
+      expect(ctrl.preparePayload({ text: "hello there", presentation })).toEqual({
+        text: undefined,
+        presentation,
+      });
+      stream.close.mockResolvedValueOnce(undefined);
+
+      // The remainder already carried the controls to block delivery, so the fallback
+      // that covers the unacknowledged text must not send them a second time.
+      await expect(ctrl.finalize()).resolves.toEqual({
+        visibleReplySent: true,
+        content: "hello",
+        messageId: "stream-acknowledged",
+        fallbackPayload: { text: " there" },
+      });
     });
 
     it("honors cancellation after an acknowledged stream prefix", async () => {

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -718,6 +718,28 @@ describe("createTeamsReplyStreamController", () => {
     expect(stream.update).not.toHaveBeenCalled();
   });
 
+  it("keeps a progress-mode reply's controls after the stream takes its text", () => {
+    const stream = makeStream();
+    const ctrl = createTeamsReplyStreamController({
+      allowProviderPreview: true,
+      conversationType: "personal",
+      context: makeContext(stream),
+      feedbackLoopEnabled: false,
+      msteamsConfig: { streaming: { mode: "progress" } } as never,
+    });
+    const presentation = {
+      blocks: [{ type: "buttons" as const, buttons: [{ label: "Open run", value: "open" }] }],
+    };
+
+    // Progress mode emits the final text into the stream instead of streaming tokens,
+    // so it suppresses the payload for the same reason - and must keep the same remainder.
+    expect(ctrl.preparePayload({ text: "Deploy finished", presentation })).toEqual({
+      text: undefined,
+      presentation,
+    });
+    expect(stream.emit).toHaveBeenCalledWith("Deploy finished");
+  });
+
   it("falls back to normal delivery when progress final streaming fails", () => {
     const stream = makeStream();
     stream.emit.mockImplementation(() => {

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -402,6 +402,49 @@ describe("createTeamsReplyStreamController", () => {
     });
   });
 
+  it("drops a streamed reply's presentation when its text already rendered it", () => {
+    const stream = makeStream();
+    const ctrl = makeController({ stream });
+    ctrl.onPartialReply({ text: "Runs by region: EU 12, US 9" });
+
+    // "fallback" text is the prose rendering of the whole presentation, so a table-only
+    // presentation carries nothing the stream did not already deliver. Sending it anyway
+    // restates the table under the answer the user just read.
+    expect(
+      ctrl.preparePayload({
+        text: "Runs by region: EU 12, US 9",
+        presentationTextMode: "fallback",
+        presentation: {
+          blocks: [
+            {
+              type: "table" as const,
+              caption: "Runs by region",
+              headers: ["Region", "Runs"],
+              rows: [
+                ["EU", "12"],
+                ["US", "9"],
+              ],
+            },
+          ],
+        },
+      }),
+    ).toBeUndefined();
+  });
+
+  it("keeps a streamed reply's controls even when its text is the fallback prose", () => {
+    const stream = makeStream();
+    const ctrl = makeController({ stream });
+    ctrl.onPartialReply({ text: "streamed" });
+    const presentation = {
+      blocks: [{ type: "buttons" as const, buttons: [{ label: "Open run", value: "open" }] }],
+    };
+
+    // Prose cannot carry a control the channel renders natively, so the buttons remain.
+    expect(
+      ctrl.preparePayload({ text: "streamed", presentationTextMode: "fallback", presentation }),
+    ).toEqual({ text: undefined, presentationTextMode: "fallback", presentation });
+  });
+
   it("allows fallback delivery for second text segment after tool calls", () => {
     const stream = makeStream();
     const ctrl = makeController({ stream });

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -1,75 +1,12 @@
 // Msteams tests cover reply stream controller plugin behavior.
 import { describe, expect, it, vi } from "vitest";
 import { createTeamsReplyStreamController } from "./reply-stream-controller.js";
-
-type StreamCloseResult = { id: string } | undefined;
-
-function makeStream() {
-  return {
-    emit: vi.fn(),
-    update: vi.fn(),
-    clearText: vi.fn(),
-    close: vi.fn<() => Promise<StreamCloseResult>>(async () => ({ id: "stream-final" })),
-    canceled: false,
-  };
-}
-
-function makeAcknowledgedStream() {
-  type ChunkActivity = {
-    id?: string;
-    type?: string;
-    text?: string;
-    channelData?: { streamType?: string };
-  };
-  const handlers = new Map<number, (activity: ChunkActivity) => void>();
-  let nextSubscriptionId = 0;
-  const stream = {
-    ...makeStream(),
-    events: {
-      on: vi.fn((_event: "chunk", handler: (activity: ChunkActivity) => void) => {
-        const subscriptionId = nextSubscriptionId++;
-        handlers.set(subscriptionId, handler);
-        return subscriptionId;
-      }),
-      off: vi.fn((subscriptionId: number) => {
-        handlers.delete(subscriptionId);
-      }),
-    },
-    acknowledge(text: string, overrides: Partial<ChunkActivity> = {}) {
-      const activity: ChunkActivity = {
-        id: "stream-acknowledged",
-        type: "typing",
-        text,
-        channelData: { streamType: "streaming" },
-        ...overrides,
-      };
-      for (const handler of handlers.values()) {
-        handler(activity);
-      }
-    },
-  };
-  return stream;
-}
-
-function makeContext(stream?: ReturnType<typeof makeStream>) {
-  return { activity: { type: "message" }, stream } as never;
-}
-
-function makeController(
-  opts: {
-    allowProviderPreview?: boolean;
-    conversationType?: string;
-    stream?: ReturnType<typeof makeStream>;
-  } = {},
-) {
-  const stream = opts.stream;
-  return createTeamsReplyStreamController({
-    allowProviderPreview: opts.allowProviderPreview ?? true,
-    conversationType: opts.conversationType ?? "personal",
-    context: makeContext(stream),
-    feedbackLoopEnabled: false,
-  });
-}
+import {
+  makeAcknowledgedStream,
+  makeContext,
+  makeController,
+  makeStream,
+} from "./reply-stream-controller.test-helpers.js";
 
 describe("createTeamsReplyStreamController", () => {
   it("emits chunks via stream.emit when tokens arrive", () => {
@@ -265,53 +202,6 @@ describe("createTeamsReplyStreamController", () => {
     );
   });
 
-  it("keeps a replaced reply's controls after the stream acknowledged its text", async () => {
-    const stream = makeAcknowledgedStream();
-    const ctrl = makeController({ stream });
-    const presentation = {
-      blocks: [{ type: "buttons" as const, buttons: [{ label: "Open run", value: "open" }] }],
-    };
-
-    ctrl.onPartialReply({ text: "abcde" });
-    stream.acknowledge("abcde");
-    ctrl.onPartialReply({ text: "abXYZ" });
-    expect(ctrl.preparePayload({ text: "abcdef", presentation })).toBeUndefined();
-
-    // The replacement carries the text, so the deferred entry is subtracted the same way
-    // a suppressed final is: dropping it whole took the controls with the text.
-    await expect(ctrl.finalize()).resolves.toMatchObject({
-      postNativePayloads: [{ text: undefined, presentation }],
-    });
-  });
-
-  it("does not repeat the replaced prose when a replacement leaves text undelivered", async () => {
-    const stream = makeAcknowledgedStream();
-    const ctrl = makeController({ stream });
-    const buttons = {
-      type: "buttons" as const,
-      buttons: [{ label: "Open run", value: "open" }],
-    };
-
-    ctrl.onPartialReply({ text: "Deploy summary" });
-    stream.acknowledge("Deploy summary");
-    ctrl.onPartialReply({ text: "Deploy XYZ" });
-    expect(
-      ctrl.preparePayload({
-        text: "Deploy summary and more",
-        presentationTextMode: "fallback",
-        presentation: { blocks: [{ type: "text" as const, text: "Deploy summary" }, buttons] },
-      }),
-    ).toBeUndefined();
-    stream.close.mockResolvedValueOnce(undefined);
-
-    // Re-attaching the undelivered text to the whole payload would build a card out of
-    // the prose the stream just showed - and the card would swallow that text, because a
-    // card message carries its text as a delivery record, not as activity text.
-    await expect(ctrl.finalize()).resolves.toMatchObject({
-      postNativePayloads: [{ text: " and more", presentation: { blocks: [buttons] } }],
-    });
-  });
-
   it("suppresses a replacement when emit synchronously discovers Stop", async () => {
     const stream = makeAcknowledgedStream();
     const ctrl = makeController({ stream });
@@ -431,104 +321,6 @@ describe("createTeamsReplyStreamController", () => {
       text: undefined,
       mediaUrl: "https://x/y.png",
     });
-  });
-
-  it("strips text but keeps the controls a reply offers when text was streamed", () => {
-    const stream = makeStream();
-    const ctrl = makeController({ stream });
-    ctrl.onPartialReply({ text: "streamed" });
-    const presentation = {
-      blocks: [{ type: "buttons" as const, buttons: [{ label: "Open run", value: "open" }] }],
-    };
-
-    // The stream carries text only. Dropping the whole payload here dropped the
-    // buttons with it, so a streamed reply reached Teams without its controls.
-    expect(ctrl.preparePayload({ text: "streamed", presentation })).toEqual({
-      text: undefined,
-      presentation,
-    });
-  });
-
-  it("drops a streamed reply's presentation when its text already rendered it", () => {
-    const stream = makeStream();
-    const ctrl = makeController({ stream });
-    ctrl.onPartialReply({ text: "Runs by region: EU 12, US 9" });
-
-    // "fallback" text is the prose rendering of the whole presentation, so a table-only
-    // presentation carries nothing the stream did not already deliver. Sending it anyway
-    // restates the table under the answer the user just read.
-    expect(
-      ctrl.preparePayload({
-        text: "Runs by region: EU 12, US 9",
-        presentationTextMode: "fallback",
-        presentation: {
-          blocks: [
-            {
-              type: "table" as const,
-              caption: "Runs by region",
-              headers: ["Region", "Runs"],
-              rows: [
-                ["EU", "12"],
-                ["US", "9"],
-              ],
-            },
-          ],
-        },
-      }),
-    ).toBeUndefined();
-  });
-
-  it("leaves only the controls when a streamed reply's text was the fallback prose", () => {
-    const stream = makeStream();
-    const ctrl = makeController({ stream });
-    const buttons = {
-      type: "buttons" as const,
-      buttons: [{ label: "Open run", value: "open" }],
-    };
-    // The shape ask_user produces: the question and its option list as text blocks, then
-    // the buttons, with the payload text holding the prose rendering of all three.
-    const presentation = {
-      title: "Deploy",
-      blocks: [{ type: "text" as const, text: "Which region?" }, buttons],
-    };
-    ctrl.onPartialReply({ text: "Deploy\n\nWhich region?\n\n- Open run" });
-
-    // Prose cannot carry a control the channel renders natively, so the buttons remain -
-    // but the text blocks and the title were in the prose the stream just delivered.
-    expect(
-      ctrl.preparePayload({
-        text: "Deploy\n\nWhich region?\n\n- Open run",
-        presentationTextMode: "fallback",
-        presentation,
-      }),
-    ).toEqual({ text: undefined, presentation: { blocks: [buttons] } });
-  });
-
-  it("drops a streamed reply's select, which Teams renders as the prose it just sent", () => {
-    const stream = makeStream();
-    const ctrl = makeController({ stream });
-    ctrl.onPartialReply({ text: "Which region?\n\nOptions\n- EU\n- US" });
-
-    // Teams declares selects: false, so a select degrades to a text list - and in fallback
-    // mode that list is part of the prose the stream already delivered.
-    expect(
-      ctrl.preparePayload({
-        text: "Which region?\n\nOptions\n- EU\n- US",
-        presentationTextMode: "fallback",
-        presentation: {
-          blocks: [
-            {
-              type: "select" as const,
-              placeholder: "Options",
-              options: [
-                { label: "EU", value: "eu" },
-                { label: "US", value: "us" },
-              ],
-            },
-          ],
-        },
-      }),
-    ).toBeUndefined();
   });
 
   it("allows fallback delivery for second text segment after tool calls", () => {
@@ -804,28 +596,6 @@ describe("createTeamsReplyStreamController", () => {
     expect(stream.update).not.toHaveBeenCalled();
   });
 
-  it("keeps a progress-mode reply's controls after the stream takes its text", () => {
-    const stream = makeStream();
-    const ctrl = createTeamsReplyStreamController({
-      allowProviderPreview: true,
-      conversationType: "personal",
-      context: makeContext(stream),
-      feedbackLoopEnabled: false,
-      msteamsConfig: { streaming: { mode: "progress" } } as never,
-    });
-    const presentation = {
-      blocks: [{ type: "buttons" as const, buttons: [{ label: "Open run", value: "open" }] }],
-    };
-
-    // Progress mode emits the final text into the stream instead of streaming tokens,
-    // so it suppresses the payload for the same reason - and must keep the same remainder.
-    expect(ctrl.preparePayload({ text: "Deploy finished", presentation })).toEqual({
-      text: undefined,
-      presentation,
-    });
-    expect(stream.emit).toHaveBeenCalledWith("Deploy finished");
-  });
-
   it("falls back to normal delivery when progress final streaming fails", () => {
     const stream = makeStream();
     stream.emit.mockImplementation(() => {
@@ -952,32 +722,6 @@ describe("createTeamsReplyStreamController", () => {
       });
     });
 
-    it("does not redraw the acknowledged prose as a card after a stream failure", () => {
-      const stream = makeAcknowledgedStream();
-      const ctrl = makeController({ stream });
-      const buttons = {
-        type: "buttons" as const,
-        buttons: [{ label: "Open run", value: "open" }],
-      };
-
-      ctrl.onPartialReply({ text: "Deploy summary" });
-      stream.acknowledge("Deploy summary");
-      stream.emit.mockImplementation(() => {
-        throw new Error("network failure");
-      });
-      ctrl.onPartialReply({ text: "Deploy summary extended" });
-
-      // This is the third path that subtracts already-delivered text, and it subtracts
-      // the same way: the prose Teams acknowledged does not come back inside a card.
-      expect(
-        ctrl.preparePayload({
-          text: "Deploy summary and its options",
-          presentationTextMode: "fallback",
-          presentation: { blocks: [{ type: "text" as const, text: "Deploy summary" }, buttons] },
-        }),
-      ).toEqual({ text: " and its options", presentation: { blocks: [buttons] } });
-    });
-
     it("preserves the full fallback when a failed stream has no provider acknowledgement", () => {
       const stream = makeAcknowledgedStream();
       const ctrl = makeController({ stream });
@@ -1100,31 +844,6 @@ describe("createTeamsReplyStreamController", () => {
         messageId: "stream-acknowledged",
       });
       expect(stream.events.off).toHaveBeenCalledWith(0);
-    });
-
-    it("does not repeat controls the remainder already delivered when close produces nothing", async () => {
-      const stream = makeAcknowledgedStream();
-      const ctrl = makeController({ stream });
-      const presentation = {
-        blocks: [{ type: "buttons" as const, buttons: [{ label: "Open run", value: "open" }] }],
-      };
-
-      ctrl.onPartialReply({ text: "hello there" });
-      stream.acknowledge("hello");
-      expect(ctrl.preparePayload({ text: "hello there", presentation })).toEqual({
-        text: undefined,
-        presentation,
-      });
-      stream.close.mockResolvedValueOnce(undefined);
-
-      // The remainder already carried the controls to block delivery, so the fallback
-      // that covers the unacknowledged text must not send them a second time.
-      await expect(ctrl.finalize()).resolves.toEqual({
-        visibleReplySent: true,
-        content: "hello",
-        messageId: "stream-acknowledged",
-        fallbackPayload: { text: " there" },
-      });
     });
 
     it("honors cancellation after an acknowledged stream prefix", async () => {

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -14,7 +14,6 @@ import {
 import { coerceErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
   adaptMessagePresentationForChannel,
-  isMessagePresentationInteractiveBlock,
   normalizeMessagePresentation,
 } from "openclaw/plugin-sdk/interactive-runtime";
 import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
@@ -22,7 +21,7 @@ import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coe
 import type { MSTeamsConfig, ReplyPayload } from "../runtime-api.js";
 import { extractMessageId } from "./media-helpers.js";
 import type { MSTeamsMonitorLogger } from "./monitor-types.js";
-import { MSTEAMS_PRESENTATION_CAPABILITIES } from "./presentation.js";
+import { MSTEAMS_PRESENTATION_CAPABILITIES, resolveMSTeamsCardAction } from "./presentation.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
 
 type Maybe<T> = T | undefined;
@@ -199,12 +198,23 @@ export function createTeamsReplyStreamController(params: {
     if (!presentation) {
       return { ...payload, text: undefined };
     }
-    // What survives adaptation as interactive is what Teams renders natively; a select
-    // degrades to a text list here, and that list was in the prose the stream delivered.
-    const controls = adaptMessagePresentationForChannel({
-      presentation,
-      capabilities: MSTEAMS_PRESENTATION_CAPABILITIES,
-    }).blocks.filter(isMessagePresentationInteractiveBlock);
+    // Only a control Teams turns into a card action is still missing; anything else -
+    // a select, or a button whose action Teams has no card action for - reaches the user
+    // as text, and that text was in the prose the stream just delivered. A card cannot
+    // share an activity with media either, so media leaves nothing native to send.
+    const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
+    const controls = hasMedia
+      ? []
+      : adaptMessagePresentationForChannel({
+          presentation,
+          capabilities: MSTEAMS_PRESENTATION_CAPABILITIES,
+        }).blocks.flatMap((block) => {
+          if (block.type !== "buttons") {
+            return [];
+          }
+          const buttons = block.buttons.filter((button) => resolveMSTeamsCardAction(button));
+          return buttons.length > 0 ? [{ ...block, buttons }] : [];
+        });
     const {
       presentation: _presentation,
       presentationTextMode: _presentationTextMode,

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -207,22 +207,29 @@ export function createTeamsReplyStreamController(params: {
 
   // A native stream carries text and nothing else, so the text-free remainder still goes
   // to block delivery; dropping the whole payload would drop media and controls with the
-  // streamed text. Exception: "fallback" text is the prose rendering of the whole
-  // presentation, so for those the stream delivered the presentation's content too and
-  // only controls a channel renders natively are still missing.
+  // streamed text. "fallback" text is the prose rendering of the whole presentation, so
+  // for those the stream already delivered every block that degrades to prose and only
+  // the natively rendered controls remain.
   const suppressedFinalRemainder = (payload: ReplyPayload): Maybe<ReplyPayload> => {
-    const presentation = normalizeMessagePresentation(payload.presentation);
-    const streamCarriedThePresentation =
-      payload.presentationTextMode === "fallback" &&
-      !presentation?.blocks.some(isMessagePresentationInteractiveBlock);
+    const presentation =
+      payload.presentationTextMode === "fallback"
+        ? normalizeMessagePresentation(payload.presentation)
+        : undefined;
+    if (!presentation) {
+      const remainder = { ...payload, text: undefined };
+      return hasOutboundReplyContent(remainder) ? remainder : undefined;
+    }
+    const controls = presentation.blocks.filter(isMessagePresentationInteractiveBlock);
     const {
       presentation: _presentation,
       presentationTextMode: _presentationTextMode,
       ...withoutPresentation
     } = payload;
-    const remainder = streamCarriedThePresentation
-      ? { ...withoutPresentation, text: undefined }
-      : { ...payload, text: undefined };
+    const remainder = {
+      ...withoutPresentation,
+      text: undefined,
+      ...(controls.length > 0 ? { presentation: { blocks: controls } } : {}),
+    };
     return hasOutboundReplyContent(remainder) ? remainder : undefined;
   };
 
@@ -269,12 +276,14 @@ export function createTeamsReplyStreamController(params: {
       if (entry.kind === "payload") {
         return [entry.payload];
       }
-      const hasMedia = Boolean(entry.payload.mediaUrl || entry.payload.mediaUrls?.length);
+      // Same subtraction as a suppressed final: the stream carried this entry's text,
+      // so only what it could not carry is still owed to the user.
       const text = replacementFallback?.text;
-      if (!text && !hasMedia) {
-        return [];
+      if (!text) {
+        const remainder = suppressedFinalRemainder(entry.payload);
+        return remainder ? [remainder] : [];
       }
-      return [{ ...entry.payload, text: text || undefined }];
+      return [{ ...entry.payload, text }];
     });
     deferredReplacementEntries = [];
     return payloads;

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -288,14 +288,14 @@ export function createTeamsReplyStreamController(params: {
       if (entry.kind === "payload") {
         return [entry.payload];
       }
-      // Same subtraction as a suppressed final: the stream carried this entry's text,
-      // so only what it could not carry is still owed to the user.
+      // Same subtraction as a suppressed final: the stream carried this entry's text, so
+      // only what it could not carry is still owed - plus the text it never delivered.
       const text = replacementFallback?.text;
       if (!text) {
         const remainder = suppressedFinalRemainder(entry.payload);
         return remainder ? [remainder] : [];
       }
-      return [{ ...entry.payload, text }];
+      return [{ ...withoutStreamedContent(entry.payload), text }];
     });
     deferredReplacementEntries = [];
     return payloads;
@@ -561,9 +561,9 @@ export function createTeamsReplyStreamController(params: {
           return undefined;
         }
       }
-      // Partial mode with tokens already streamed: stream carries the text;
-      // strip text from the payload (keep media if any) so block delivery
-      // doesn't duplicate. Exception: if a non-cancel stream failure was
+      // Partial mode with tokens already streamed: the stream carries the text, so hand
+      // block delivery only what it did not (media, native controls) and let it drop the
+      // payload when nothing is left. Exception: if a non-cancel stream failure was
       // latched mid-flight, deliver only a provider-acknowledged remainder;
       // preserve the full reply when delivery was not acknowledged.
       if (tokensEmitted && !streamFailed) {

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -191,35 +191,13 @@ export function createTeamsReplyStreamController(params: {
     };
   };
 
-  const fallbackPayloadAfterAcknowledgedText = (payload: ReplyPayload): Maybe<ReplyPayload> => {
-    if (
-      !acknowledgedText ||
-      typeof payload.text !== "string" ||
-      !payload.text.startsWith(acknowledgedText)
-    ) {
-      return payload;
-    }
-    const remainingText = payload.text.slice(acknowledgedText.length);
-    const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
-    if (!remainingText && !hasMedia) {
-      return undefined;
-    }
-    return { ...payload, text: remainingText || undefined };
-  };
-
-  // A native stream carries text and nothing else, so the text-free remainder still goes
-  // to block delivery; dropping the whole payload would drop media and controls with the
-  // streamed text. "fallback" text is the prose rendering of the whole presentation, so
-  // for those the stream already delivered every block that degrades to prose and only
-  // the natively rendered controls remain.
-  const suppressedFinalRemainder = (payload: ReplyPayload): Maybe<ReplyPayload> => {
+  const withoutStreamedContent = (payload: ReplyPayload): ReplyPayload => {
     const presentation =
       payload.presentationTextMode === "fallback"
         ? normalizeMessagePresentation(payload.presentation)
         : undefined;
     if (!presentation) {
-      const remainder = { ...payload, text: undefined };
-      return hasOutboundReplyContent(remainder) ? remainder : undefined;
+      return { ...payload, text: undefined };
     }
     // What survives adaptation as interactive is what Teams renders natively; a select
     // degrades to a text list here, and that list was in the prose the stream delivered.
@@ -232,11 +210,38 @@ export function createTeamsReplyStreamController(params: {
       presentationTextMode: _presentationTextMode,
       ...withoutPresentation
     } = payload;
-    const remainder = {
+    return {
       ...withoutPresentation,
       text: undefined,
       ...(controls.length > 0 ? { presentation: { blocks: controls } } : {}),
     };
+  };
+
+  const fallbackPayloadAfterAcknowledgedText = (payload: ReplyPayload): Maybe<ReplyPayload> => {
+    if (
+      !acknowledgedText ||
+      typeof payload.text !== "string" ||
+      !payload.text.startsWith(acknowledgedText)
+    ) {
+      return payload;
+    }
+    // Teams showed the acknowledged prefix, so subtract it the same way a suppressed
+    // final is subtracted, then re-attach the text the stream never delivered.
+    const remainingText = payload.text.slice(acknowledgedText.length);
+    const remainder = {
+      ...withoutStreamedContent(payload),
+      ...(remainingText ? { text: remainingText } : {}),
+    };
+    return hasOutboundReplyContent(remainder) ? remainder : undefined;
+  };
+
+  // A native stream carries text and nothing else, so the text-free remainder still goes
+  // to block delivery; dropping the whole payload would drop media and controls with the
+  // streamed text. "fallback" text is the prose rendering of the whole presentation, so
+  // for those the stream already delivered every block that degrades to prose and only
+  // the natively rendered controls remain.
+  const suppressedFinalRemainder = (payload: ReplyPayload): Maybe<ReplyPayload> => {
+    const remainder = withoutStreamedContent(payload);
     return hasOutboundReplyContent(remainder) ? remainder : undefined;
   };
 

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -13,6 +13,7 @@ import {
 } from "openclaw/plugin-sdk/channel-outbound";
 import { coerceErrorMessage } from "openclaw/plugin-sdk/error-runtime";
 import {
+  adaptMessagePresentationForChannel,
   isMessagePresentationInteractiveBlock,
   normalizeMessagePresentation,
 } from "openclaw/plugin-sdk/interactive-runtime";
@@ -21,6 +22,7 @@ import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coe
 import type { MSTeamsConfig, ReplyPayload } from "../runtime-api.js";
 import { extractMessageId } from "./media-helpers.js";
 import type { MSTeamsMonitorLogger } from "./monitor-types.js";
+import { MSTEAMS_PRESENTATION_CAPABILITIES } from "./presentation.js";
 import type { MSTeamsTurnContext } from "./sdk-types.js";
 
 type Maybe<T> = T | undefined;
@@ -219,7 +221,12 @@ export function createTeamsReplyStreamController(params: {
       const remainder = { ...payload, text: undefined };
       return hasOutboundReplyContent(remainder) ? remainder : undefined;
     }
-    const controls = presentation.blocks.filter(isMessagePresentationInteractiveBlock);
+    // What survives adaptation as interactive is what Teams renders natively; a select
+    // degrades to a text list here, and that list was in the prose the stream delivered.
+    const controls = adaptMessagePresentationForChannel({
+      presentation,
+      capabilities: MSTEAMS_PRESENTATION_CAPABILITIES,
+    }).blocks.filter(isMessagePresentationInteractiveBlock);
     const {
       presentation: _presentation,
       presentationTextMode: _presentationTextMode,

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -12,7 +12,11 @@ import {
   resolveChannelStreamingPreviewToolProgress,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { coerceErrorMessage } from "openclaw/plugin-sdk/error-runtime";
-import { hasReplyContent } from "openclaw/plugin-sdk/interactive-runtime";
+import {
+  isMessagePresentationInteractiveBlock,
+  normalizeMessagePresentation,
+} from "openclaw/plugin-sdk/interactive-runtime";
+import { hasOutboundReplyContent } from "openclaw/plugin-sdk/reply-payload";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { MSTeamsConfig, ReplyPayload } from "../runtime-api.js";
 import { extractMessageId } from "./media-helpers.js";
@@ -201,12 +205,25 @@ export function createTeamsReplyStreamController(params: {
     return { ...payload, text: remainingText || undefined };
   };
 
-  // A native stream carries text and nothing else. Media and portable controls are
-  // separate content, so the text-free remainder still goes to block delivery; dropping
-  // the whole payload would drop them along with the streamed text.
+  // A native stream carries text and nothing else, so the text-free remainder still goes
+  // to block delivery; dropping the whole payload would drop media and controls with the
+  // streamed text. Exception: "fallback" text is the prose rendering of the whole
+  // presentation, so for those the stream delivered the presentation's content too and
+  // only controls a channel renders natively are still missing.
   const suppressedFinalRemainder = (payload: ReplyPayload): Maybe<ReplyPayload> => {
-    const remainder = { ...payload, text: undefined };
-    return hasReplyContent(remainder) ? remainder : undefined;
+    const presentation = normalizeMessagePresentation(payload.presentation);
+    const streamCarriedThePresentation =
+      payload.presentationTextMode === "fallback" &&
+      !presentation?.blocks.some(isMessagePresentationInteractiveBlock);
+    const {
+      presentation: _presentation,
+      presentationTextMode: _presentationTextMode,
+      ...withoutPresentation
+    } = payload;
+    const remainder = streamCarriedThePresentation
+      ? { ...withoutPresentation, text: undefined }
+      : { ...payload, text: undefined };
+    return hasOutboundReplyContent(remainder) ? remainder : undefined;
   };
 
   // What that remainder already delivered must not return through the fallback, which

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -12,6 +12,7 @@ import {
   resolveChannelStreamingPreviewToolProgress,
 } from "openclaw/plugin-sdk/channel-outbound";
 import { coerceErrorMessage } from "openclaw/plugin-sdk/error-runtime";
+import { hasReplyContent } from "openclaw/plugin-sdk/interactive-runtime";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { MSTeamsConfig, ReplyPayload } from "../runtime-api.js";
 import { extractMessageId } from "./media-helpers.js";
@@ -200,9 +201,25 @@ export function createTeamsReplyStreamController(params: {
     return { ...payload, text: remainingText || undefined };
   };
 
+  // A native stream carries the reply's text and nothing else. Media and portable
+  // controls are separate content, so the text-free remainder still goes to block
+  // delivery; dropping the whole payload would drop them with the streamed text.
+  const suppressedFinalRemainder = (payload: ReplyPayload): Maybe<ReplyPayload> => {
+    const remainder = { ...payload, text: undefined };
+    return hasReplyContent(remainder) ? remainder : undefined;
+  };
+
+  // Whatever that remainder already delivered must not return through the fallback,
+  // which re-sends only the text the stream may have failed to deliver.
   const fallbackPayloadForSuppressedFinal = (payload: ReplyPayload): ReplyPayload => {
-    const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
-    return hasMedia ? { ...payload, mediaUrl: undefined, mediaUrls: undefined } : payload;
+    const {
+      mediaUrl: _mediaUrl,
+      mediaUrls: _mediaUrls,
+      presentation: _presentation,
+      presentationTextMode: _presentationTextMode,
+      ...textOnly
+    } = payload;
+    return textOnly;
   };
 
   const finalStreamActivity = (text?: string) => ({
@@ -512,11 +529,10 @@ export function createTeamsReplyStreamController(params: {
       // latched mid-flight, deliver only a provider-acknowledged remainder;
       // preserve the full reply when delivery was not acknowledged.
       if (tokensEmitted && !streamFailed) {
-        const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
         pendingFinalPayload = fallbackPayloadForSuppressedFinal(payload);
         streamFinalizationPending = true;
         tokensEmitted = false;
-        return hasMedia ? { ...payload, text: undefined } : undefined;
+        return suppressedFinalRemainder(payload);
       }
       if (streamFailed) {
         // Trim the provider-acknowledged prefix only from the failed segment.
@@ -539,8 +555,7 @@ export function createTeamsReplyStreamController(params: {
           nativeDispatchStarted = true;
           pendingFinalPayload = fallbackPayloadForSuppressedFinal(payload);
           streamFinalizationPending = true;
-          const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
-          return hasMedia ? { ...payload, text: undefined } : undefined;
+          return suppressedFinalRemainder(payload);
         } catch (err) {
           if (isStreamCancelledError(err)) {
             canceledLocally = true;

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -201,16 +201,16 @@ export function createTeamsReplyStreamController(params: {
     return { ...payload, text: remainingText || undefined };
   };
 
-  // A native stream carries the reply's text and nothing else. Media and portable
-  // controls are separate content, so the text-free remainder still goes to block
-  // delivery; dropping the whole payload would drop them with the streamed text.
+  // A native stream carries text and nothing else. Media and portable controls are
+  // separate content, so the text-free remainder still goes to block delivery; dropping
+  // the whole payload would drop them along with the streamed text.
   const suppressedFinalRemainder = (payload: ReplyPayload): Maybe<ReplyPayload> => {
     const remainder = { ...payload, text: undefined };
     return hasReplyContent(remainder) ? remainder : undefined;
   };
 
-  // Whatever that remainder already delivered must not return through the fallback,
-  // which re-sends only the text the stream may have failed to deliver.
+  // What that remainder already delivered must not return through the fallback, which
+  // re-sends only the text the stream may have failed to deliver.
   const fallbackPayloadForSuppressedFinal = (payload: ReplyPayload): ReplyPayload => {
     const {
       mediaUrl: _mediaUrl,

--- a/qa/scenarios/channels/msteams-reply-presentation.yaml
+++ b/qa/scenarios/channels/msteams-reply-presentation.yaml
@@ -121,6 +121,15 @@ flow:
         - set: deliveredCard
           value:
             expr: "(() => { const attachment = cardReplyActivities.flatMap((message) => message.attachments ?? []).find((entry) => entry.mimeType === config.adaptiveCardContentType); return attachment ? JSON.parse(Buffer.from(attachment.contentBase64, 'base64').toString('utf8')) : undefined; })()"
+        # Resolve before asserting: an assertion that throws would otherwise leave the
+        # question pending and the agent blocked for anything sharing this Gateway.
+        - set: resolution
+          value:
+            expr: "env.gateway.call('question.resolve', { id: pendingQuestion.id, answers: { answers: { deploy_target: ['Staging (Recommended)'] } }, resolvedBy: 'qa-lab' })"
+        - assert:
+            expr: "resolution.status === 'answered'"
+            message:
+              expr: "`question did not resolve: ${JSON.stringify(resolution)}`"
         - assert:
             expr: "deliveredCard?.type === 'AdaptiveCard'"
             message:
@@ -129,13 +138,4 @@ flow:
             expr: "JSON.stringify(deliveredCard.body ?? []).includes(config.cardPromptNeedle)"
             message:
               expr: "`the delivered card lost the reply's content: ${JSON.stringify(deliveredCard)}`"
-        # Leave no pending question behind: an unresolved run keeps the agent blocked for
-        # every later scenario sharing this Gateway.
-        - set: resolution
-          value:
-            expr: "env.gateway.call('question.resolve', { id: pendingQuestion.id, answers: { answers: { deploy_target: ['Staging (Recommended)'] } }, resolvedBy: 'qa-lab' })"
-        - assert:
-            expr: "resolution.status === 'answered'"
-            message:
-              expr: "`question did not resolve: ${JSON.stringify(resolution)}`"
       detailsExpr: "`card blocks=${(deliveredCard.body ?? []).length} actions=${(deliveredCard.actions ?? []).length}`"

--- a/qa/scenarios/channels/msteams-reply-presentation.yaml
+++ b/qa/scenarios/channels/msteams-reply-presentation.yaml
@@ -11,8 +11,8 @@ scenario:
     - A /status reply reaches the Teams direct conversation through the loopback Bot Framework Connector.
     - No activity in that reply carries an Adaptive Card attachment, because every structured block degraded to text.
     - The authored status body survives instead of being replaced by a generated card.
-    - A reply whose presentation Teams can carry reaches the connector as an Adaptive Card attachment instead of prose.
-    - Every control that reply offered is present in the delivered card.
+    - A reply whose controls Teams cannot render reaches the connector as the producer's own prose, with the instructions that tell the user how to answer.
+    - No activity in that reply carries a card that repeats the prose while offering nothing to tap.
   regressionRefs:
     - https://github.com/openclaw/openclaw/issues/133295
   docsRefs:
@@ -33,9 +33,9 @@ scenario:
       cardConversationId: msteams-reply-presentation-card
       command: /status
       cardPromptNeedle: Where should this deploy?
-      cardControlLabels:
-        - Staging (Recommended)
-        - Production 🚀
+      promptNeedles:
+        - Where should this deploy?
+        - Reply with the number
       cardPrompt: >-
         Structured question QA check. Call ask_user exactly once and then reply with the
         exact marker `MSTEAMS-CARD-OK`.
@@ -90,7 +90,7 @@ flow:
               expr: "`authored /status body did not survive: ${JSON.stringify(replyActivities.map((message) => message.text))}`"
       detailsExpr: "`activities=${replyActivities.length} cards=${cardActivities.length} first=${String(statusReply.text ?? '').split('\\n')[0]}`"
 
-    - name: delivers a renderable presentation as an Adaptive Card
+    - name: sends prose when Teams can render none of the reply's controls
       actions:
         - set: cardStartIndex
           value:
@@ -111,7 +111,7 @@ flow:
             - expr: liveTurnTimeoutMs(env, 60000)
             - 250
         - call: waitForCondition
-          saveAs: cardActivity
+          saveAs: promptActivity
           args:
             - lambda:
                 expr: "state.getSnapshot().messages.slice(cardStartIndex).find((message) => message.direction === 'outbound' && message.conversation.id === config.cardConversationId)"
@@ -119,12 +119,9 @@ flow:
             - 250
         - call: sleep
           args: [2000]
-        - set: cardReplyActivities
+        - set: promptActivities
           value:
             expr: "state.getSnapshot().messages.slice(cardStartIndex).filter((message) => message.direction === 'outbound' && message.conversation.id === config.cardConversationId)"
-        - set: deliveredCard
-          value:
-            expr: "(() => { const attachment = cardReplyActivities.flatMap((message) => message.attachments ?? []).find((entry) => entry.mimeType === config.adaptiveCardContentType); return attachment ? JSON.parse(Buffer.from(attachment.contentBase64, 'base64').toString('utf8')) : undefined; })()"
         # Resolve before asserting: an assertion that throws would otherwise leave the
         # question pending and the agent blocked for anything sharing this Gateway.
         - set: resolution
@@ -134,26 +131,16 @@ flow:
             expr: "resolution.status === 'answered'"
             message:
               expr: "`question did not resolve: ${JSON.stringify(resolution)}`"
-        # This step drives ask_user, whose buttons carry `question` actions. Teams has no
-        # card action for those, so they arrive as the card's control labels rather than as
-        # `actions`; mapping that type needs a card-submit round trip and is a separate
-        # change. The four action types Teams does render are covered in
-        # presentation.reply.test.ts.
+        # ask_user's buttons carry `question` actions, which Teams has no card action for.
+        # A card here would restate the option list, tell the user to tap buttons that are
+        # not there, and swallow the numbered instructions - a card message carries its
+        # text as a delivery record, never as activity text.
         - assert:
-            expr: "deliveredCard?.type === 'AdaptiveCard'"
+            expr: "promptActivities.every((message) => (message.attachments ?? []).every((attachment) => attachment.mimeType !== config.adaptiveCardContentType))"
             message:
-              expr: "`the reply's presentation did not reach Teams as an Adaptive Card: ${JSON.stringify(cardReplyActivities.map((message) => ({ text: message.text, attachments: message.attachments })))}`"
+              expr: "`the reply became a card Teams cannot offer anything to tap in: ${JSON.stringify(promptActivities.map((message) => ({ text: message.text, attachments: message.attachments })))}`"
         - assert:
-            expr: "JSON.stringify(deliveredCard.body ?? []).includes(config.cardPromptNeedle)"
+            expr: "config.promptNeedles.every((needle) => promptActivities.some((message) => String(message.text ?? '').includes(needle)))"
             message:
-              expr: "`the delivered card lost the reply's content: ${JSON.stringify(deliveredCard)}`"
-        # The reply's own option list also names these labels, so this looks for the block
-        # the control degradation writes - without it the controls reach Teams as nothing.
-        - set: deliveredControls
-          value:
-            expr: "(deliveredCard.body ?? []).map((block) => String(block.text ?? '')).find((text) => text.startsWith('Actions:'))"
-        - assert:
-            expr: "Boolean(deliveredControls) && config.cardControlLabels.every((label) => deliveredControls.includes(label))"
-            message:
-              expr: "`the delivered card lost the controls the reply offered: ${JSON.stringify(deliveredCard)}`"
-      detailsExpr: "`card blocks=${(deliveredCard.body ?? []).length} actions=${(deliveredCard.actions ?? []).length}`"
+              expr: "`the reply lost the prose that tells the user how to answer: ${JSON.stringify(promptActivities.map((message) => message.text))}`"
+      detailsExpr: "`activities=${promptActivities.length} cards=0 first=${String(promptActivity.text ?? '').split('\\n')[0]}`"

--- a/qa/scenarios/channels/msteams-reply-presentation.yaml
+++ b/qa/scenarios/channels/msteams-reply-presentation.yaml
@@ -1,0 +1,139 @@
+title: Microsoft Teams delivers a reply's presentation on the inbound reply path
+
+scenario:
+  id: msteams-reply-presentation
+  surface: channels
+  coverage:
+    primary:
+      - microsoft-teams.native-approval-cards
+  objective: Verify the Microsoft Teams inbound reply path resolves a reply's portable presentation into an Adaptive Card, and still keeps the producer's authored fallback text when Teams cannot render that presentation natively.
+  successCriteria:
+    - A /status reply reaches the Teams direct conversation through the loopback Bot Framework Connector.
+    - No activity in that reply carries an Adaptive Card attachment, because every structured block degraded to text.
+    - The authored status body survives instead of being replaced by a generated card.
+    - A reply whose presentation Teams can carry reaches the connector as an Adaptive Card attachment instead of prose.
+  regressionRefs:
+    - https://github.com/openclaw/openclaw/issues/133295
+  docsRefs:
+    - docs/channels/msteams.md
+    - docs/concepts/qa-e2e-automation.md
+  codeRefs:
+    - extensions/msteams/src/presentation.ts
+    - extensions/msteams/src/messenger.ts
+    - src/infra/outbound/deliver-payload.ts
+  execution:
+    kind: flow
+    channel: msteams
+    summary: Send /status in a Teams direct conversation through the real Gateway and the real Microsoft Teams plugin, then inspect the activities that reached the loopback Bot Framework Connector.
+    config:
+      conversationId: msteams-reply-authored-fallback-dm
+      cardConversationId: msteams-reply-presentation-card
+      command: /status
+      cardPromptNeedle: Where should this deploy?
+      cardPrompt: >-
+        Structured question QA check. Call ask_user exactly once and then reply with the
+        exact marker `MSTEAMS-CARD-OK`.
+        QA routing marker: tool search qa check target=ask_user ask_user_fixture=single.
+      adaptiveCardContentType: application/vnd.microsoft.card.adaptive
+      authoredTextNeedle: "📚 Context:"
+
+flow:
+  steps:
+    - name: keeps the authored status body and sends no card
+      actions:
+        - call: waitForGatewayHealthy
+          args: [{ ref: env }, 60000]
+        - call: waitForTransportReady
+          args: [{ ref: env }, 60000]
+        - resetTransport: true
+        - set: startIndex
+          value:
+            expr: state.getSnapshot().messages.length
+        - sendInbound:
+            conversation:
+              id: { ref: config.conversationId }
+              kind: direct
+            senderId: driver
+            senderName: Teams QA Driver
+            text: { ref: config.command }
+        # Wait only for the reply to arrive, never for the asserted shape: a run that
+        # replaces the authored body with a card must fail on the assertion below with
+        # the activity in hand, not time out with nothing to show.
+        - call: waitForCondition
+          saveAs: statusReply
+          args:
+            - lambda:
+                expr: "state.getSnapshot().messages.slice(startIndex).find((message) => message.direction === 'outbound' && message.conversation.id === config.conversationId)"
+            - expr: liveTurnTimeoutMs(env, 60000)
+            - 250
+        - call: sleep
+          args: [2000]
+        - set: replyActivities
+          value:
+            expr: "state.getSnapshot().messages.slice(startIndex).filter((message) => message.direction === 'outbound' && message.conversation.id === config.conversationId)"
+        - set: cardActivities
+          value:
+            expr: "replyActivities.filter((message) => (message.attachments ?? []).some((attachment) => attachment.mimeType === config.adaptiveCardContentType))"
+        - assert:
+            expr: cardActivities.length === 0
+            message:
+              expr: "`/status reached Teams as an Adaptive Card, so the authored fallback was replaced: ${JSON.stringify(cardActivities.map((message) => ({ text: message.text, attachments: message.attachments })))}`"
+        - assert:
+            expr: "replyActivities.some((message) => String(message.text ?? '').includes(config.authoredTextNeedle))"
+            message:
+              expr: "`authored /status body did not survive: ${JSON.stringify(replyActivities.map((message) => message.text))}`"
+      detailsExpr: "`activities=${replyActivities.length} cards=${cardActivities.length} first=${String(statusReply.text ?? '').split('\\n')[0]}`"
+
+    - name: delivers a renderable presentation as an Adaptive Card
+      actions:
+        - set: cardStartIndex
+          value:
+            expr: state.getSnapshot().messages.length
+        - sendInbound:
+            conversation:
+              id: { ref: config.cardConversationId }
+              kind: direct
+            senderId: driver
+            senderName: Teams QA Driver
+            text: { ref: config.cardPrompt }
+        - call: waitForCondition
+          saveAs: pendingQuestion
+          args:
+            - lambda:
+                async: true
+                expr: "(await env.gateway.call('question.list', {})).questions.find((question) => question.status === 'pending' && question.questions.some((entry) => entry.question === config.cardPromptNeedle))"
+            - expr: liveTurnTimeoutMs(env, 60000)
+            - 250
+        - call: waitForCondition
+          saveAs: cardActivity
+          args:
+            - lambda:
+                expr: "state.getSnapshot().messages.slice(cardStartIndex).find((message) => message.direction === 'outbound' && message.conversation.id === config.cardConversationId)"
+            - expr: liveTurnTimeoutMs(env, 60000)
+            - 250
+        - call: sleep
+          args: [2000]
+        - set: cardReplyActivities
+          value:
+            expr: "state.getSnapshot().messages.slice(cardStartIndex).filter((message) => message.direction === 'outbound' && message.conversation.id === config.cardConversationId)"
+        - set: deliveredCard
+          value:
+            expr: "(() => { const attachment = cardReplyActivities.flatMap((message) => message.attachments ?? []).find((entry) => entry.mimeType === config.adaptiveCardContentType); return attachment ? JSON.parse(Buffer.from(attachment.contentBase64, 'base64').toString('utf8')) : undefined; })()"
+        - assert:
+            expr: "deliveredCard?.type === 'AdaptiveCard'"
+            message:
+              expr: "`the reply's presentation did not reach Teams as an Adaptive Card: ${JSON.stringify(cardReplyActivities.map((message) => ({ text: message.text, attachments: message.attachments })))}`"
+        - assert:
+            expr: "JSON.stringify(deliveredCard.body ?? []).includes(config.cardPromptNeedle)"
+            message:
+              expr: "`the delivered card lost the reply's content: ${JSON.stringify(deliveredCard)}`"
+        # Leave no pending question behind: an unresolved run keeps the agent blocked for
+        # every later scenario sharing this Gateway.
+        - set: resolution
+          value:
+            expr: "env.gateway.call('question.resolve', { id: pendingQuestion.id, answers: { answers: { deploy_target: ['Staging (Recommended)'] } }, resolvedBy: 'qa-lab' })"
+        - assert:
+            expr: "resolution.status === 'answered'"
+            message:
+              expr: "`question did not resolve: ${JSON.stringify(resolution)}`"
+      detailsExpr: "`card blocks=${(deliveredCard.body ?? []).length} actions=${(deliveredCard.actions ?? []).length}`"

--- a/qa/scenarios/channels/msteams-reply-presentation.yaml
+++ b/qa/scenarios/channels/msteams-reply-presentation.yaml
@@ -12,6 +12,7 @@ scenario:
     - No activity in that reply carries an Adaptive Card attachment, because every structured block degraded to text.
     - The authored status body survives instead of being replaced by a generated card.
     - A reply whose presentation Teams can carry reaches the connector as an Adaptive Card attachment instead of prose.
+    - Every control that reply offered is present in the delivered card.
   regressionRefs:
     - https://github.com/openclaw/openclaw/issues/133295
   docsRefs:
@@ -32,6 +33,9 @@ scenario:
       cardConversationId: msteams-reply-presentation-card
       command: /status
       cardPromptNeedle: Where should this deploy?
+      cardControlLabels:
+        - Staging (Recommended)
+        - Production 🚀
       cardPrompt: >-
         Structured question QA check. Call ask_user exactly once and then reply with the
         exact marker `MSTEAMS-CARD-OK`.
@@ -130,11 +134,11 @@ flow:
             expr: "resolution.status === 'answered'"
             message:
               expr: "`question did not resolve: ${JSON.stringify(resolution)}`"
-        # Deliberately not asserted: the card's `actions`. This step drives ask_user, whose
-        # buttons carry `question` actions, and the Teams card builder maps only
-        # url/web-app/command/callback - so the card arrives with its content and no
-        # actions. Mapping that action type needs a card-submit round trip and is a
-        # separate change; the mapped action types are covered in presentation.reply.test.ts.
+        # This step drives ask_user, whose buttons carry `question` actions. Teams has no
+        # card action for those, so they arrive as the card's control labels rather than as
+        # `actions`; mapping that type needs a card-submit round trip and is a separate
+        # change. The four action types Teams does render are covered in
+        # presentation.reply.test.ts.
         - assert:
             expr: "deliveredCard?.type === 'AdaptiveCard'"
             message:
@@ -143,4 +147,13 @@ flow:
             expr: "JSON.stringify(deliveredCard.body ?? []).includes(config.cardPromptNeedle)"
             message:
               expr: "`the delivered card lost the reply's content: ${JSON.stringify(deliveredCard)}`"
+        # The reply's own option list also names these labels, so this looks for the block
+        # the control degradation writes - without it the controls reach Teams as nothing.
+        - set: deliveredControls
+          value:
+            expr: "(deliveredCard.body ?? []).map((block) => String(block.text ?? '')).find((text) => text.startsWith('Actions:'))"
+        - assert:
+            expr: "Boolean(deliveredControls) && config.cardControlLabels.every((label) => deliveredControls.includes(label))"
+            message:
+              expr: "`the delivered card lost the controls the reply offered: ${JSON.stringify(deliveredCard)}`"
       detailsExpr: "`card blocks=${(deliveredCard.body ?? []).length} actions=${(deliveredCard.actions ?? []).length}`"

--- a/qa/scenarios/channels/msteams-reply-presentation.yaml
+++ b/qa/scenarios/channels/msteams-reply-presentation.yaml
@@ -6,7 +6,9 @@ scenario:
   coverage:
     primary:
       - microsoft-teams.native-approval-cards
-  objective: Verify the Microsoft Teams inbound reply path resolves a reply's portable presentation into an Adaptive Card, and still keeps the producer's authored fallback text when Teams cannot render that presentation natively.
+    secondary:
+      - channels.automatic-final-reply
+  objective: Verify the Microsoft Teams inbound reply path resolves a reply's portable presentation, and keeps the producer's own text whenever a card would carry nothing Teams can render.
   successCriteria:
     - A /status reply reaches the Teams direct conversation through the loopback Bot Framework Connector.
     - No activity in that reply carries an Adaptive Card attachment, because every structured block degraded to text.
@@ -29,6 +31,7 @@ scenario:
     isolationReason: Drives a Teams direct conversation and leaves a pending question open until the step resolves it.
     summary: Send /status in a Teams direct conversation through the real Gateway and the real Microsoft Teams plugin, then inspect the activities that reached the loopback Bot Framework Connector.
     config:
+      requiredProviderMode: mock-openai
       conversationId: msteams-reply-authored-fallback-dm
       cardConversationId: msteams-reply-presentation-card
       command: /status
@@ -47,6 +50,9 @@ flow:
   steps:
     - name: keeps the authored status body and sends no card
       actions:
+        - assert:
+            expr: "env.providerMode === config.requiredProviderMode"
+            message: this seeded scenario reads markers only the mock provider answers
         - call: waitForGatewayHealthy
           args: [{ ref: env }, 60000]
         - call: waitForTransportReady
@@ -143,4 +149,4 @@ flow:
             expr: "config.promptNeedles.every((needle) => promptActivities.some((message) => String(message.text ?? '').includes(needle)))"
             message:
               expr: "`the reply lost the prose that tells the user how to answer: ${JSON.stringify(promptActivities.map((message) => message.text))}`"
-      detailsExpr: "`activities=${promptActivities.length} cards=0 first=${String(promptActivity.text ?? '').split('\\n')[0]}`"
+      detailsExpr: "`activities=${promptActivities.length} cards=${promptActivities.filter((message) => (message.attachments ?? []).some((attachment) => attachment.mimeType === config.adaptiveCardContentType)).length} first=${String(promptActivity.text ?? '').split('\\n')[0]}`"

--- a/qa/scenarios/channels/msteams-reply-presentation.yaml
+++ b/qa/scenarios/channels/msteams-reply-presentation.yaml
@@ -24,6 +24,8 @@ scenario:
   execution:
     kind: flow
     channel: msteams
+    suiteIsolation: isolated
+    isolationReason: Drives a Teams direct conversation and leaves a pending question open until the step resolves it.
     summary: Send /status in a Teams direct conversation through the real Gateway and the real Microsoft Teams plugin, then inspect the activities that reached the loopback Bot Framework Connector.
     config:
       conversationId: msteams-reply-authored-fallback-dm

--- a/qa/scenarios/channels/msteams-reply-presentation.yaml
+++ b/qa/scenarios/channels/msteams-reply-presentation.yaml
@@ -130,6 +130,11 @@ flow:
             expr: "resolution.status === 'answered'"
             message:
               expr: "`question did not resolve: ${JSON.stringify(resolution)}`"
+        # Deliberately not asserted: the card's `actions`. This step drives ask_user, whose
+        # buttons carry `question` actions, and the Teams card builder maps only
+        # url/web-app/command/callback - so the card arrives with its content and no
+        # actions. Mapping that action type needs a card-submit round trip and is a
+        # separate change; the mapped action types are covered in presentation.reply.test.ts.
         - assert:
             expr: "deliveredCard?.type === 'AdaptiveCard'"
             message:


### PR DESCRIPTION
Closes #133295

## What Problem This Solves

Every button an agent reply offers is dropped before it reaches Microsoft Teams. Teams declares that it supports these controls and renders them as an Adaptive Card when a message is sent through the outbound pipeline, but ordinary agent replies do not go through that pipeline — the monitor delivers them itself, and that path never resolves the reply's presentation. The user gets the reply as plain text with the controls silently missing, and nothing reports the loss.

A reply whose only content is those controls is worse: it produces no Teams activity at all. The reply renderer treats a payload with no text and no media as empty and skips it, so the dispatcher reports no visible result and the user sees nothing whatsoever.

In a personal conversation the loss is total even for a reply that does have text. Teams streams that reply natively, and the stream controller suppressed the whole final payload once tokens were live, on the assumption that the payload carried nothing but the text already streamed. Anything else riding on that payload — including its controls — went with it.

Both outcomes are invisible in testing, because `message send` with a presentation does produce a Teams Adaptive Card today — the split only shows up on the reply path that answers an inbound turn.

## Why This Change Was Made

A reply's presentation is now resolved where the reply path renders it: inside `renderReplyPayloadsToMessages`, the one place the monitor turns a payload into Teams messages. The resolved card then travels into the Teams activity as an adaptive-card attachment. Three things had to line up for it to arrive: the rendered-message type could not carry a card at all, the renderer skipped a card-only reply as empty, and the send loop filtered it out a second time before the activity was built.

**Order matters, so the resolution sits after the stream controller.** The native stream owns the reply's text and nothing else; the controller is what knows how much of it Teams has already shown. Resolving the presentation before it — into a card that embeds the text — left the controller with a payload it could only take or drop whole, and it dropped it. It now returns the text-free remainder whenever the payload still carries content the stream cannot deliver, exactly as it already did for media, and the card is built from that remainder, so it carries only what the user has not already seen. That branch is reachable on the default path: `attachMcpAppChannelAction` and `attachMcpConnectChannelAction` merge a `web-app` or `url` button into the last text-bearing reply payload — the model's own streamed answer — at `src/auto-reply/reply/agent-runner-result-payloads.ts:435`.

What counts as "already delivered" depends on what the text was. `presentationTextMode: "fallback"` means the text *is* the prose rendering of the whole presentation, so the stream delivered every block that degrades to prose and only the natively rendered controls remain — a select is not one of them on Teams, which declares `selects: false` and renders it as the very list the prose already carried. Without that mode the presentation is additional content and all of it remains. All three places that subtract delivered content now go through one helper: the suppressed final, the replacement path where a rewritten answer replaces a streamed one, and the recovery path after a stream failure, which previously carried a fallback-mode presentation past the prefix Teams had acknowledged. The older assumption underneath is unchanged — the branch still treats the final payload's text as what it streamed, which is why `origin/main` could drop that payload outright.

**Core's authored-fallback rule holds here too, and falls out of the same test.** When every structured data block degrades to text and nothing interactive remains, `renderPresentationForDelivery` skips the channel renderer so the producer's authored fallback survives verbatim (`src/infra/outbound/deliver-payload.ts:296`). Without that, a `/status` reply — a table with an authored text body — reached Teams as a generated card and its authored body disappeared. A presentation in that shape yields no Teams action, so the rule above already answers it; the reply path needs no second copy of core's condition, and the scenario's first step is the proof.

Rather than add a third place that renders a Teams presentation, this pulls the renderer that was inlined in the outbound adapter into a named function that both delivery paths now share, so a reply and a `message send` of the same payload produce the same card by construction. That makes the outbound adapter smaller, not larger.

A card short-circuits the text path, so every guarantee that path gave had to survive it. A silent reply stays silent: `NO_REPLY` is a sentinel, not a card body. And because a card is one activity, two replies keep the text path instead: one whose text does not fit a single message, and one that mentions somebody — a card body cannot carry the mention entity that notifies them, and an oversized card is rejected outright, which is the failure this change exists to remove. Both degrade their controls to prose rather than dropping them, and the gate reads the reply's own text even in fallback mode, where the card would otherwise have hidden the mention from it. What the card does carry is the reply's text exactly as `message send` would carry it: one shared builder, no reply-only transformation.

**A card has to earn its place.** Teams maps `url`, `web-app`, `command` and `callback` actions and has none for `question` — which is what `ask_user` mints — or `approval`. A card built for those offers nothing to tap, and building it costs the reply its prose: the card replaces the producer's fallback text, then restates the option list under an instruction to tap buttons that are not there, and the numbered instructions that told the user how to answer never leave the bot, because a card message carries its text as a delivery record rather than as activity text. So a fallback reply whose controls Teams cannot draw stays prose — the same thing `origin/main` sends. The rule sits on the reply path and keys on `presentationTextMode`, which is the fact that separates "this text is the presentation" from "this payload simply has no text"; putting it in the shared renderer instead would have flattened the documented `message send --presentation` example (`docs/channels/msteams.md`) into prose, which is not this change's business. `message send` does gain the `Actions:` list for a control Teams cannot draw, which is shipped behaviour moving from silent loss to a visible label. Where a card is built for another reason, a control Teams cannot map keeps its label in an `Actions:` list instead of disappearing, which is what core does for a channel with no buttons at all. One function answers "what does Teams render this control as", so the card builder and the streaming remainder cannot disagree about it.

Boundaries. A reply carrying media keeps its media and degrades the controls to text instead of dropping them, because a card and a media attachment cannot share one Teams activity — this mirrors what core's own renderer does when a channel cannot carry controls natively. Fallback text, which is core's prose rendering of the same controls, is replaced by the card rather than repeated inside it. A reply with no presentation is returned untouched, and the text and media paths are unchanged. This is separate from encoding typed approval actions into Teams' native callback envelope (#104521); Teams already builds the card, it was simply never built on this path.

## User Impact

Buttons an agent offers in Teams now actually appear in Teams, on the reply path that answers a message rather than only when a message is sent explicitly, including in a personal conversation where the reply streams. A reply that is nothing but controls now produces a message instead of silence. Replies Teams cannot improve on are left alone: `/status`, `ask_user` and anything else whose controls Teams has no action for keep the exact text their producer wrote, and replies without controls are unaffected.

## Evidence

Behavior addressed: agent replies on the Teams monitor path lose every button they offer, a controls-only reply produces no Teams activity, and a streamed reply loses its controls together with its already-streamed text.

**Real environment tested.** `qa/scenarios/channels/msteams-reply-presentation.yaml` runs through `openclaw qa msteams`: a real Gateway, the real Microsoft Teams plugin, the mock-openai provider, and the loopback Bot Framework Connector that the plugin posts its activities to over HTTP. Nothing in the changed path is stubbed — the assertions read the activities the connector received. No Teams tenant was involved; see the limitations below. Node v24.19.0 on macOS 15.6.

The scenario runs in that lane by default, alongside the shared channel canary:

```
$ node scripts/run-node.mjs qa msteams --output-dir .qa-msteams
```

After this patch:

```
- Passed: 2
- Failed: 0

### Channel transport canary
- Status: pass

### Microsoft Teams delivers a reply's presentation on the inbound reply path

- Status: pass
- Steps:
  - [x] keeps the authored status body and sends no card
  - [x] sends prose when Teams can render none of the reply's controls

Notes:
- Uses a loopback Bot Framework Connector with the real Microsoft Teams plugin and Gateway.
```

Each step fails on the state it guards. Removing the rule that a card must carry something the text cannot turns the `ask_user` reply into a card and swallows its prose, which the second step reports with the activities in hand:

```
- Status: fail
  - [x] keeps the authored status body and sends no card
  - [ ] sends prose when Teams can render none of the reply's controls (fail)
    - Details: the reply became a card Teams cannot offer anything to tap in:
      [{"text":"","attachments":[]},
       {"text":"","attachments":[{"mimeType":"application/vnd.microsoft.card.adaptive",
        "fileName":"adaptive-card.json","contentBase64":"…"}]}]
```

Note the empty `text` on that activity: the prose the producer wrote is gone, which is the failure the step exists to catch.

Reverting only the authored-fallback rule from `presentation.ts` fails the first step instead, with the card that replaced the authored `/status` body in hand:

```
- Status: fail
  - [ ] keeps the authored status body and sends no card (fail)
    - Details: /status reached Teams as an Adaptive Card, so the authored fallback was replaced:
      [{"text":"","attachments":[{"mimeType":"application/vnd.microsoft.card.adaptive",
        "fileName":"adaptive-card.json","contentBase64":"…"}]}]
```

Decoded, the first step's card body is the flattened table — `Session status (table)\n- Item: 🧠 Model; Value: mock-openai/gpt-5.6-luna\n- Item: 🔑 Auth; Value: api-key (models.json)…` — in place of the status body the producer wrote.

**Unit-level red/green.** Reverting only the stream-controller change fails the two new streaming tests and nothing else: `reply-stream-controller.test.ts` (`expected undefined to deeply equal { text: undefined, …(1) }`, the suppressed payload) and `reply-dispatcher.test.ts` (`expected undefined to deeply equal [ { text: undefined, …(1) } ]`, the renderer never called). Reverting only the authored-fallback rule fails `presentation.reply.test.ts` with `expected { type: 'AdaptiveCard', …(2) } to be undefined`. The shared renderer is verified equivalent by the pre-existing `outbound.test.ts` case that compares the whole Adaptive Card and then feeds it to `sendPayload`; it passes unchanged after the extraction.

`docs/channels/msteams.md` gains the five cases where a reply keeps its text, and its "select menus downgrade to text" line now sits next to the rest of the rule rather than standing alone.

**Checks run on the exact head.** The full `msteams` extension suite, all passing; the full `qa-lab` suite — 223 files, 3126 tests, 3 skipped; `src/infra/outbound/deliver-payload.presentation.test.ts`; `tsgo -p tsconfig.extensions.json` and `tsgo -p test/tsconfig/tsconfig.extensions.test.json`, both with no diagnostics (the test lane caught an untyped Vitest mock whose `mock.calls` tuple had no element 0, fixed by typing the mock after the real `renderReplyPayloadsToMessages` signature rather than casting); `lint:extensions`, which also caught this change pushing `messenger.test.ts` past the 1000-line budget — resolved by extracting the shared app double and activity-capture helper into `messenger.test-helpers.ts` rather than suppressing the rule; `oxfmt --check` on all touched files; `check:assertion-safety --base origin/main` and `check:max-lines-ratchet --base origin/main`, both OK; and `check:changed`, which on this branch classified every lane and ran the whole-repo `tsgo:all` and `oxlint` — exit 0, no findings.

**Production LOC.** Production is +280/−69 (net +211) across four files; the reply dispatcher itself is unchanged. Tests and test support are +1232/−202, including the QA transport adapter and the new scenario, both reachable only through `openclaw qa msteams`. The growth buys a capability the reply path did not have — a card in the Teams activity — plus the three text-path guarantees that had to be carried onto it, and it removes a rendering duplicate rather than adding one: `outbound.ts` is smaller because its inlined renderer became the shared one.

The net-neutral absorbing refactor does exist and I measured it: core's `renderPresentationForDelivery` and the per-channel `prepare*ReplyPayload` steps in LINE, Matrix and Teams are the same procedure, and hoisting it into one seam behind `openclaw/plugin-sdk` lands around +84 production instead of +211. I did not take it here because it rewrites the outbound presentation path for every channel and adds public SDK surface — compatibility-sensitive changes that do not belong inside a single channel's bug fix. It is the right follow-up, and this PR at least leaves two Teams paths sharing one renderer instead of three copies.

**Named follow-ups this change does not take.** Four gaps sit next to this code and are left out rather than folded in: encoding `question` and `approval` actions as real Teams card actions, which needs a card-submit round trip — Discord and Slack both do it, and until Teams does, `ask_user` there stays prose; the card's text is not bounded the way message text is, on either path, and declaring a bound needs a measured Adaptive Card cap rather than a guessed one; and `formatMSTeamsMarkdown` is applied to message text but not to text inside a card, on either path — an Adaptive Card TextBlock renders neither markdown tables nor fenced code, so picking a dialect there needs a real Teams client to check against. Feishu's reply dispatcher has the same shape as the one repaired here and no issue yet (`git grep -c presentation extensions/feishu/src/reply-dispatcher.ts` → 0); LINE (#132479) and Matrix (#132739) are already covered. All three predate this change on the outbound path. Two more are worth naming because this change makes them visible: `outbound.ts` still hand-rolls the `channelData.msteams.presentationCard` read that `readMSTeamsPresentationCard` now owns, and the two paths now build the same card but not the same activity — `sendAdaptiveCardMSTeams` sends a bare activity while the reply path's `buildActivity` adds `channelData.feedbackLoopEnabled` and the AI-generated entity. That difference is older than this change and unifying it belongs with whoever owns the feedback-loop contract.

**A reply's controls on the wire.** `presentation.connector.test.ts` runs the real reply renderer and activity builder, then posts the activity over HTTP to the same loopback Bot Framework Connector the `qa msteams` lane uses, and reads the card back out of the request that connector parsed: one adaptive-card attachment carrying `[{ "type": "Action.OpenUrl", "title": "Open run", "url": "https://example.com/run" }]`, plus the message id the connector minted. Reverting the reply path to `origin/main`'s behaviour — returning the payload unresolved — fails it with `expected undefined to be 'application/vnd.microsoft.card.adaptive'`; breaking only the url-action mapping fails it on the action instead. Scope, stated plainly: the activity body is production's, the request envelope is the test's, and that connector authenticates rather than validates — so this shows the controls reach the wire intact, not that Teams renders them.

The QA lane cannot drive that shape: after this change every reply the harness can produce is one Teams has no control for — `ask_user` mints `question` actions, exec and plugin approvals go through Teams' own native approval card rather than the portable presentation, and the two producers that do mint `url`/`web-app` buttons need a real MCP tool result.

**What the live lane does and does not cover.** It drives the two reply shapes the harness can actually produce — a `/status` reply and an `ask_user` prompt — through the real Gateway, plugin and connector, and it is red on the state each step guards. It does not reach the streaming remainder: `ask_user` delivers through `onBlockReply` rather than partial tokens, so `tokensEmitted` is never set on that turn. I verified that directly by throwing from `withoutStreamedContent` and watching the scenario still pass. The streaming paths are covered by the stream-controller suites instead, each rule pinned by a mutation that turns a named test red.

**What was not tested.** No Microsoft Teams tenant, Bot Framework registration or real Adaptive Card render was involved. The activity is built by the product code and accepted by the loopback connector over HTTP, so the card's structure and the attachment envelope are real, but how Teams itself renders that card was not observed.

**Proof limitations.** Single-host macOS run. The scenario's second step drives a presentation whose buttons carry `question` actions, so its card arrives with the controls as labels rather than as `actions` — the step asserts exactly that, and the assertion fails if the degradation is removed. Encoding those as native Teams actions is the follow-up named above.
