### PR TITLE
test(scripts): share Android catalogs and strengthen scanner assertions

### DIFF
--- a/test/scripts/android-app-i18n.test.ts
+++ b/test/scripts/android-app-i18n.test.ts
@@ -11,7 +11,7 @@ import {
   selectDeterministicTranslation,
   selectGeneratedTranslation,
 } from "../../scripts/android-app-i18n.ts";
-import { NATIVE_I18N_LOCALES } from "../../scripts/native-app-i18n.ts";
+import { NATIVE_I18N_LOCALES } from "../../scripts/native-i18n-locales.ts";
 
 describe("Android app i18n resources", () => {
   it("keeps generated resources, runtime coverage, and every locale aligned", async () => {
@@ -46,7 +46,7 @@ describe("Android app i18n resources", () => {
     ]);
   });
 
-  it("builds complete Wear resources for every native locale", async () => {
+  it("builds complete Wear and third-party resources for every native locale", async () => {
     const catalog = await buildAndroidAppI18nCatalog();
     const wearResources = [...catalog.resources].filter(
       ([filePath]) =>
@@ -90,11 +90,8 @@ describe("Android app i18n resources", () => {
         'name="show_new_messages" tools:ignore="MissingTranslation,Typos,TypographyDashes,TypographyEllipsis"',
       );
     }
-  });
 
-  it("builds complete third-party flavor resources for every native locale", async () => {
-    const catalog = await buildAndroidAppI18nCatalog();
-    const base = await readFile(
+    const thirdPartyBase = await readFile(
       "apps/android/app/src/thirdParty/res/values/accessibility_strings.xml",
       "utf8",
     );
@@ -104,7 +101,7 @@ describe("Android app i18n resources", () => {
         filePath.endsWith("/accessibility_strings.xml"),
     );
 
-    expect(base).toContain('tools:ignore="MissingTranslation"');
+    expect(thirdPartyBase).toContain('tools:ignore="MissingTranslation"');
     expect(resources).toHaveLength(NATIVE_I18N_LOCALES.length);
     for (const [, content] of resources) {
       expect(content).toContain('name="accessibility_service_label"');
@@ -295,12 +292,6 @@ describe("Android app i18n resources", () => {
       expect.objectContaining({ source: "Second sentence." }),
       expect.objectContaining({ source: "Ready" }),
     ]);
-    expect(
-      findUnlocalizedAndroidUiLiterals(
-        source,
-        "apps/android/app/src/main/java/ai/openclaw/app/ui/Example.kt",
-      ).map((finding) => finding.source),
-    ).not.toEqual(expect.arrayContaining(["Connected", "Waiting"]));
   });
 
   it("maps typed model fields across generic types and named argument omissions", () => {
@@ -399,26 +390,14 @@ describe("Android app i18n resources", () => {
       "apps/android/app/src/main/java/ai/openclaw/app/ui/Example.kt",
     ).map((finding) => finding.source);
 
-    expect(findings).toEqual(
-      expect.arrayContaining([
-        "Open Chat",
-        "Start a conversation",
-        "Gateway",
-        "Connect before chat, voice, and live status.",
-        "Online",
-        "All systems nominal",
-      ]),
-    );
-    expect(findings).not.toEqual(
-      expect.arrayContaining([
-        "chat",
-        "voice",
-        "Start Voice",
-        "Talk with OpenClaw",
-        "Offline",
-        "gateway",
-      ]),
-    );
+    expect(findings).toEqual([
+      "Open Chat",
+      "Start a conversation",
+      "Gateway",
+      "Connect before chat, voice, and live status.",
+      "Online",
+      "All systems nominal",
+    ]);
   });
 
   it("requires exact String fields and scans multiline helper expressions", () => {
@@ -444,8 +423,7 @@ describe("Android app i18n resources", () => {
       "apps/android/app/src/main/java/ai/openclaw/app/ui/Example.kt",
     ).map((finding) => finding.source);
 
-    expect(findings).toEqual(expect.arrayContaining(["Failure", "Fallback"]));
-    expect(findings).not.toEqual(expect.arrayContaining(["resource_key", "Ready"]));
+    expect(findings).toEqual(["Failure", "Fallback"]);
   });
 
   it("ignores preview fixtures", () => {


### PR DESCRIPTION
## What Problem This Solves

Wear and third-party resource tests rebuild the same Android localization catalog. Scanner tests also repeat an identical scan and use negative subset assertions that can miss individual unexpected findings.

## Why This Change Was Made

Build one catalog for both resource families while retaining every per-locale assertion, and import locales from their small owning module. Remove the duplicate scan and require exact finding arrays for the two affected scanner cases.

## User Impact

No application, translation or generator change. One catalog build and one duplicate scan are removed. Twenty-seven tests become 26 by combining the two complete resource scenarios. Production +0/-0; tests +13/-35.

## Evidence

- All 26 tests pass with the real catalog and scanner. Local suite time decreased from 875.1 ms to 736.1 ms; this is not a CI-wide benchmark.
- A controlled fault removed the scanner's exact-String type boundary, incorrectly treating StringResource as String. The old assertion passed; the new assertion failed on the extra resource_key finding. The mutation was removed before the full passing run.
- Full changed-file gate, formatting, diff check and structured Codex autoreview pass.

Fault-probe terminal excerpt:

```text
FAIL requires exact String fields and scans multiline helper expressions
AssertionError: expected [ 'resource_key', 'Failure', …(1) ] to deeply equal [ 'Failure', 'Fallback' ]
```

Passing command and selected native JSON result after restoring the scanner:

```text
node scripts/run-vitest.mjs test/scripts/android-app-i18n.test.ts
```

```json
{"numPassedTests":26,"numFailedTests":0,"numPendingTests":0,"success":true}
```
