### PR TITLE
test(scripts): assert each dated TODO exclusion

### DIFF
--- a/test/scripts/dated-todo-scan.test.ts
+++ b/test/scripts/dated-todo-scan.test.ts
@@ -125,18 +125,19 @@ describe("dated-todo-scan", () => {
         }),
       ]),
     );
-    expect(candidates.map((candidate) => candidate.file)).not.toEqual(
-      expect.arrayContaining([
-        "CHANGELOG.md",
-        "docs/.generated/noise.md",
-        "locales/en.json",
-        "src/history.ts",
-        "src/no-date.ts",
-        "src/too-far.ts",
-        "src/untracked.ts",
-        "test/fixtures/noise.ts",
-      ]),
-    );
+    const candidateFiles = candidates.map((candidate) => candidate.file);
+    for (const excludedFile of [
+      "CHANGELOG.md",
+      "docs/.generated/noise.md",
+      "locales/en.json",
+      "src/history.ts",
+      "src/no-date.ts",
+      "src/too-far.ts",
+      "src/untracked.ts",
+      "test/fixtures/noise.ts",
+    ]) {
+      expect(candidateFiles).not.toContain(excludedFile);
+    }
     expect(candidates.filter((candidate) => candidate.source === "compat-registry")).toHaveLength(
       1,
     );


### PR DESCRIPTION
## What Problem This Solves

The dated-TODO scanner test negates a subset containing eight excluded files. That assertion passes when any one is absent, even if other excluded files leak into the report.

## Why This Change Was Made

Assert each excluded filename is absent independently, preserving all positive candidate, compatibility-registry and report assertions.

## User Impact

No scanner or workflow change. This repairs a test oracle; no performance claim. Production +0/-0; tests +13/-12.

## Evidence

A temporary fault removed CHANGELOG.md from the actual scanner exclusion set. The original test passed; the corrected test failed:

```text
AssertionError: expected [ 'CHANGELOG.md', …(11) ] to not include 'CHANGELOG.md'
```

The scanner was restored and the complete test passed:

```text
node scripts/run-vitest.mjs test/scripts/dated-todo-scan.test.ts
```

```json
{"numPassedTests":1,"numFailedTests":0,"numPendingTests":0,"success":true}
```

Full changed-file gate, formatting, diff check and structured Codex autoreview pass. Complete scanner, test and scheduled-workflow caller inspected.
