### PR TITLE
test(macos): remove duplicate shell smoke check

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/LowCoverageHelperTests.swift
@@ -58,12 +58,6 @@ struct LowCoverageHelperTests {
         #expect(!FileManager.default.fileExists(atPath: marker.path))
     }
 
-    @Test func `shell executor runs command`() async {
-        let result = await ShellExecutor.runDetailed(command: ["/bin/echo", "ok"], cwd: nil, env: nil, timeout: 2)
-        #expect(result.success == true)
-        #expect(result.stdout.contains("ok") || result.stderr.contains("ok"))
-    }
-
     @Test func `shell executor times out`() async {
         for _ in 0..<10 {
             let result = await ShellExecutor.runDetailed(


### PR DESCRIPTION
## What Problem This Solves

The macOS shell executor suite repeats a successful-command smoke check that accepts output on either stdout or stderr. It cannot detect swapped streams or exact argument/output errors already caught by stronger retained tests.

## Why This Change Was Made

Remove only `shell executor runs command`. Retain direct native `printf` execution with exact argv, stdout and exit status; distinct stdout/stderr draining with an explicit success assertion; real socket half-close completion; and all timeout, cancellation, descendant-cleanup and preflight checks.

## User Impact

No runtime behavior change. Production +0/-0; tests +0/-6, one redundant case removed. No retained assertion, fixture, timeout, dependency or runner policy changes. Exact test afterimage: `5e07b052fd194f98ee12685201dd7e435e6dd0aa`.

## Evidence

The execution owner, callers, siblings, retained tests and pinned subprocess contract were inspected. The original local changed gate passed all 13 checks with this deletion on `a7be8e5ec6ff9b4169eabe3bf37bb36396ac79ad`, including pinned Swift lint/format and 1,022 TypeScript tooling/lifecycle cases across seven routed projects. Earlier tool-version and native Node import/checkout-fixture failures were corrected by pinned tools and canonical #133903/#124415. Those local checks did not execute Swift.

The [original native job](https://github.com/openclaw/openclaw/actions/runs/33394471044/job/99498826931) failed: head `758cca4c991e02af65c7655abaf809f02f3e32f1`, actual merge `b428db6f272d63d444d52c38d713411f3215d7ba`, 11 issues followed by the 30-minute cancellation. These were two ManagedProcess timing failures, four Dashboard fixture/reconnect/window timeouts, two catalog-worker watchdogs, a BoundedCommand cleanup watchdog, socket-auth POSIX35 and half-close POSIX5. Their cause remains unknown. The release build and separate OpenClawKit pass were not native-app completion.

The unchanged deletion was refreshed onto canonical #134035 (`af345b0d4ea2615347e8ec1bab0c2d73167b03d7`), which bounds Swift Testing concurrency to `min(hw.logicalcpu, 12)`. Fresh scoped Codex review was clean. The refreshed normal changed gate passed all 13 checks in 701.741 seconds after correcting ambient SwiftLint 0.65.1 to the existing pinned SwiftLint 0.65.0 and SwiftFormat 0.62.1. No diagnostics, serial override, retry or timeout increase was added.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33412138456) and its [disposable macos-swift job](https://github.com/openclaw/openclaw/actions/runs/33412138456/job/99554600491) now pass on attempt 1 for `ecb8d532bd6ddd7f5587114f1b187b21efdbbb03`. Actual checkout and workflow SHA: `b3885489e17c58f528877f7fcc98c1e01b056283`. Toolchain: Xcode 26.6 / Apple Swift 6.3.3 / Testing Library 1902; logged parallelization width: 12. The complete default partition reports 1,899 tests in 197 suites: 1,896 pass events and three declared opt-in skips. All three XCTest layout cases pass, and the named AppState partition passes both tests. All 40 retained named tests across LowCoverage, ShellExecutorTimeout, socket auth and socket cancellation pass, including all parameterized cancellation variants. Every one of the 11 earlier issue cases now has a terminal pass with its assertions and deadlines unchanged.

The existing native response-loss transport proof and embedded Peekaboo handshake opt-ins remain skipped. The health-render case skips in the default partition and passes in its separate isolated render step. None of the 40 retained named tests or 11 earlier issue cases is skipped. This is real native execution on a disposable worker; no native app or test was launched on an operator Mac.

Source binding verifies all 919 non-directory entries under `apps/macos/`, `apps/shared/` and `apps/swabble/` against the actual CI merge and refreshed head. Captured main `fa0f9e786cc8b10f2929eddfd01d07bf422e47d0` matches after accounting for only the candidate deletion. The inherited #134014 checkout/CI-guard changes were read; the complete macos-swift job text, native launcher, test invocation, width, partitions and native source remain unchanged.

The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/134123#issuecomment-5478805177) found no patch defect; its before-merge and rank-up request was successful exact-head macos-swift completion. That request is now satisfied. This successful bounded-parallel run qualifies the deletion under current runner policy; it does not establish the original failure's cause or prove the earlier uncapped interleaving repaired.
