### PR TITLE
test(scripts): share retry fixture counters

### DIFF
--- a/test/scripts/ci-live-command-retry.test.ts
+++ b/test/scripts/ci-live-command-retry.test.ts
@@ -1,4 +1,3 @@
-// CI live command retry tests cover transient provider failure classification.
 import { spawnSync } from "node:child_process";
 import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -16,7 +15,21 @@ function writeCommand(
   tempDirs.push(dir);
   const commandPath = path.join(dir, "command.sh");
   const counterPath = path.join(dir, "attempts.txt");
-  writeFileSync(commandPath, ["#!/bin/bash", "set -euo pipefail", ...lines, ""].join("\n"));
+  writeFileSync(
+    commandPath,
+    [
+      "#!/bin/bash",
+      "set -euo pipefail",
+      "attempts=0",
+      'if [[ -f "$OPENCLAW_RETRY_TEST_COUNTER" ]]; then',
+      '  attempts="$(<"$OPENCLAW_RETRY_TEST_COUNTER")"',
+      "fi",
+      'attempts="$((attempts + 1))"',
+      'printf "%s" "$attempts" > "$OPENCLAW_RETRY_TEST_COUNTER"',
+      ...lines,
+      "",
+    ].join("\n"),
+  );
   chmodSync(commandPath, 0o755);
   return { commandPath, counterPath };
 }
@@ -48,9 +61,6 @@ afterEach(() => {
 describe("scripts/ci-live-command-retry.sh", () => {
   it("retries a provider-internal RPC timeout", () => {
     const { commandPath, counterPath } = writeCommand("openclaw-ci-live-rpc-timeout-", [
-      'attempts="$(cat "$OPENCLAW_RETRY_TEST_COUNTER" 2>/dev/null || printf 0)"',
-      'attempts="$((attempts + 1))"',
-      'printf "%s" "$attempts" > "$OPENCLAW_RETRY_TEST_COUNTER"',
       'if [[ "$attempts" -eq 1 ]]; then',
       '  echo "MiniMax image generation API error (1000): rpc timeout: timeout=1m0s" >&2',
       "  exit 42",
@@ -72,9 +82,6 @@ describe("scripts/ci-live-command-retry.sh", () => {
     ["live terminal timeout", "Error: terminal timeout after 300000ms"],
   ])("retries a transient %s", (_label, message) => {
     const { commandPath, counterPath } = writeCommand("openclaw-ci-live-transient-", [
-      'attempts="$(cat "$OPENCLAW_RETRY_TEST_COUNTER" 2>/dev/null || printf 0)"',
-      'attempts="$((attempts + 1))"',
-      'printf "%s" "$attempts" > "$OPENCLAW_RETRY_TEST_COUNTER"',
       'if [[ "$attempts" -eq 1 ]]; then',
       `  echo ${JSON.stringify(message)} >&2`,
       "  exit 42",
@@ -90,9 +97,6 @@ describe("scripts/ci-live-command-retry.sh", () => {
 
   it("does not retry a MiniMax authentication failure", () => {
     const { commandPath, counterPath } = writeCommand("openclaw-ci-live-auth-failure-", [
-      'attempts="$(cat "$OPENCLAW_RETRY_TEST_COUNTER" 2>/dev/null || printf 0)"',
-      'attempts="$((attempts + 1))"',
-      'printf "%s" "$attempts" > "$OPENCLAW_RETRY_TEST_COUNTER"',
       'echo "MiniMax image generation API error (1004): authentication failed" >&2',
       "exit 42",
     ]);


### PR DESCRIPTION
## What Problem This Solves

Retry-command fixtures copy the same attempt-counter setup and start an external cat process for each attempt, including missing counter files.

## Why This Change Was Made

Own counter initialization, increment and persistence in the existing fixture writer. Use Bash's documented file-read substitution after checking whether the file exists, and remove the duplicated setup and obvious file header.

## User Impact

No retry classification or runtime change. All five cases still execute the real Bash wrapper and preserve exact retries, exit status and authentication-failure behavior. Nine external cat launches are removed. Production +0/-0; tests +15/-11.

## Evidence

```text
node scripts/run-vitest.mjs test/scripts/ci-live-command-retry.test.ts
```

```json
{"numPassedTests":5,"numFailedTests":0,"numPendingTests":0,"success":true}
```

The full changed-file gate, formatting, diff check and structured Codex autoreview pass. The installed Bash manual confirms the file-read substitution contract. Local test-body times were 162.6 ms before and 165.6 ms after; this pair supports no elapsed-time speedup claim.

Recorded after-change local run started at `2026-08-31T12:59:18.489Z`.

The recorded cases execute generated temporary commands through the actual Bash wrapper. The [retained assertions](https://github.com/openclaw/openclaw/blob/f4cd564146e2c323ddce5ac640a6dfec25b81543/test/scripts/ci-live-command-retry.test.ts#L72) check counter bytes `2`, status `0`, and a retry message for transient failures; authentication failure checks counter bytes `1`, status `42`, and no retry message.

Native `assertionResults` excerpt (selected records and fields, copied without changing case names or results):

```json
[
  {"fullName":"scripts/ci-live-command-retry.sh retries a provider-internal RPC timeout","status":"passed"},
  {"fullName":"scripts/ci-live-command-retry.sh retries a transient provider HTTP 500","status":"passed"},
  {"fullName":"scripts/ci-live-command-retry.sh retries a transient live test timeout","status":"passed"},
  {"fullName":"scripts/ci-live-command-retry.sh retries a transient live terminal timeout","status":"passed"},
  {"fullName":"scripts/ci-live-command-retry.sh does not retry a MiniMax authentication failure","status":"passed"}
]
```

Wrapper output excerpt; its elapsed time includes startup:

```text
[test] starting test/vitest/vitest.tooling.config.ts
[test] passed 1 Vitest shard in 4.43s
```

A diagnostic run on Node `v24.19.0` at head `f4cd564146e2c323ddce5ac640a6dfec25b81543` added temporary logging immediately after each existing child process completed. The generated Bash commands, retry wrapper, inputs, limits, and assertions were unchanged. The same five tests passed with verbose and JSON reporters; the original test bytes were then restored and the tracked/staged diffs were empty.

The following records contain the observed failed-attempt output, wrapper retry message, final exit status, and persisted counter bytes. Only the diagnostic marker prefix is omitted:

```json
[
  {"status":0,"stdout":"MiniMax image generation API error (1000): rpc timeout: timeout=1m0s\n","stderr":"Live command failed with a retryable provider/network error; retrying (1/2)...\n","counterBytes":"2"},
  {"status":0,"stdout":"xAI image edit failed (HTTP 500): Please try again later\n","stderr":"Live command failed with a retryable provider/network error; retrying (1/2)...\n","counterBytes":"2"},
  {"status":0,"stdout":"Error: Test timed out in 45000ms.\n","stderr":"Live command failed with a retryable provider/network error; retrying (1/2)...\n","counterBytes":"2"},
  {"status":0,"stdout":"Error: terminal timeout after 300000ms\n","stderr":"Live command failed with a retryable provider/network error; retrying (1/2)...\n","counterBytes":"2"},
  {"status":42,"stdout":"MiniMax image generation API error (1004): authentication failed\n","stderr":"","counterBytes":"1"}
]
```

Diagnostic native summary:

```json
{"numPassedTests":5,"numFailedTests":0,"numPendingTests":0,"success":true}
```
