### PR TITLE
fix(talk): browser agent consults rejected as draining after the creating request completes

### DIFF
--- a/src/gateway/talk-client-gateway-control.agent-consult.test.ts
+++ b/src/gateway/talk-client-gateway-control.agent-consult.test.ts
@@ -2,6 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginRuntime } from "../plugins/runtime/types.js";
 import {
+  isGatewaySubordinateWorkAdmissionClosed,
+  resetGatewayWorkAdmission,
+  tryBeginGatewayRootWorkAdmission,
+} from "../process/gateway-work-admission.js";
+import {
   authorizeClientVoiceConfirmation,
   checkClientVoiceToolConfirmationPolicy,
   deactivateClientVoiceConfirmationSession,
@@ -100,6 +105,36 @@ describe("Talk client agent consult admission", () => {
   });
 
   afterEach(() => resetClientVoiceConfirmationStateForTest());
+
+  beforeEach(resetGatewayWorkAdmission);
+  afterEach(resetGatewayWorkAdmission);
+
+  it("runs consults outside the released initiating gateway request admission", async () => {
+    // Regression (issue #134081): the consult runner outlives the talk.client.create
+    // request that created it. A later voice turn must not see the released request
+    // root admission as a closed subordinate boundary.
+    let consultSawClosedContext: boolean | undefined;
+    mocks.consultRealtimeVoiceAgent.mockImplementationOnce(async (params: ConsultParams) => {
+      consultSawClosedContext = isGatewaySubordinateWorkAdmissionClosed();
+      params.onRunStarted?.({ runId: "run-talk", sessionId: "session-talk", timeoutMs: 1 });
+      await params.agentRuntime.runEmbeddedAgent(coreParams);
+      return { text: "done" };
+    });
+    const rootAdmission = tryBeginGatewayRootWorkAdmission();
+    expect(rootAdmission).not.toBeNull();
+    const runner = createRunner();
+    // Keep the deferred invocation in the request's async chain, then release the
+    // originating root like the completed talk.client.create handler does.
+    const invoke = deferred<void>();
+    const consult = rootAdmission!.run(async () =>
+      invoke.promise.then(() => runner.runPrompt({ prompt: "check" })),
+    );
+    rootAdmission!.release();
+    invoke.resolve();
+
+    await expect(consult).resolves.toEqual({ text: "done" });
+    expect(consultSawClosedContext).toBe(false);
+  });
 
   it("runs through a Talk-owned gateway admission and closes it after success", async () => {
     await expect(createRunner().runPrompt({ prompt: "check" })).resolves.toEqual({ text: "done" });

--- a/src/gateway/talk-client-gateway-control.ts
+++ b/src/gateway/talk-client-gateway-control.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import { normalizeTalkSection } from "../config/talk.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
+import { runOutsideGatewayRootWorkAdmission } from "../process/gateway-work-admission.js";
 import { BoundedSerialQueue } from "../shared/bounded-serial-queue.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { consultRealtimeVoiceAgent } from "../talk/agent-consult-runtime.js";
@@ -252,85 +253,89 @@ export function createTalkClientAgentConsultRunner(params: {
 }) {
   const authority = params.authority ?? resolveTalkAgentConsultAuthority(undefined);
   let agentRuntime: ReturnType<typeof createPluginRuntime>["agent"] | undefined;
-  const runArgs = async (args: unknown, signal?: AbortSignal) => {
-    const parsedArgs = parseRealtimeVoiceAgentConsultArgs(args);
-    const voiceSessionId = params.getVoiceSessionId();
-    if (!voiceSessionId) {
-      throw new Error("Realtime browser voice session is not ready for agent consult");
-    }
-    // Relays own admission before their lazy record registration. Browser callbacks
-    // must validate the durable call before accepting a new run.
-    if (!params.registerRun) {
-      assertClientVoiceSessionOpen({
+  const runArgs = async (args: unknown, signal?: AbortSignal) =>
+    // The runner outlives the talk.client.create request that created it. Each consult
+    // must start outside the initiating gateway root admission; a released inherited
+    // root would make session work admission reject every later voice turn as draining.
+    await runOutsideGatewayRootWorkAdmission(async () => {
+      const parsedArgs = parseRealtimeVoiceAgentConsultArgs(args);
+      const voiceSessionId = params.getVoiceSessionId();
+      if (!voiceSessionId) {
+        throw new Error("Realtime browser voice session is not ready for agent consult");
+      }
+      // Relays own admission before their lazy record registration. Browser callbacks
+      // must validate the durable call before accepting a new run.
+      if (!params.registerRun) {
+        assertClientVoiceSessionOpen({
+          agentId: params.agentId,
+          sessionKey: params.sessionKey,
+          voiceSessionId,
+        });
+      }
+      const confirmationGrant = parsedArgs.confirmationId
+        ? authorizeClientVoiceConfirmation({
+            agentId: params.agentId,
+            voiceSessionId,
+            confirmationId: parsedArgs.confirmationId,
+          })
+        : undefined;
+      agentRuntime ??= createTalkClientAgentRuntime({
+        config: params.config,
+        agentId: params.agentId,
+        ...(params.ownerConnId ? { rawSourceRef: params.ownerConnId } : {}),
+      });
+      const talkConfig = normalizeTalkSection(params.config.talk);
+      return await consultRealtimeVoiceAgent({
+        cfg: params.config,
+        agentRuntime,
+        logger: params.context.logGateway,
         agentId: params.agentId,
         sessionKey: params.sessionKey,
-        voiceSessionId,
-      });
-    }
-    const confirmationGrant = parsedArgs.confirmationId
-      ? authorizeClientVoiceConfirmation({
-          agentId: params.agentId,
-          voiceSessionId,
-          confirmationId: parsedArgs.confirmationId,
-        })
-      : undefined;
-    agentRuntime ??= createTalkClientAgentRuntime({
-      config: params.config,
-      agentId: params.agentId,
-      ...(params.ownerConnId ? { rawSourceRef: params.ownerConnId } : {}),
-    });
-    const talkConfig = normalizeTalkSection(params.config.talk);
-    return await consultRealtimeVoiceAgent({
-      cfg: params.config,
-      agentRuntime,
-      logger: params.context.logGateway,
-      agentId: params.agentId,
-      sessionKey: params.sessionKey,
-      messageProvider: "webchat",
-      lane: "talk",
-      runIdPrefix: params.runIdPrefix ?? "talk-realtime-consult",
-      args: parsedArgs,
-      transcript: params.initialItems,
-      surface: params.surface ?? "a browser Talk session",
-      userLabel: "User",
-      questionSourceLabel: "user",
-      thinkLevel: talkConfig?.consultThinkingLevel,
-      fastMode: talkConfig?.consultFastMode,
-      ...authority,
-      abortSignal: signal,
-      onRunStarted: ({ runId, sessionId, timeoutMs }) => {
-        if (params.registerRun) {
-          params.registerRun({ runId });
-        } else {
-          registerClientVoiceConsultRun({
-            agentId: params.agentId,
-            sessionKey: params.sessionKey,
-            voiceSessionId,
+        messageProvider: "webchat",
+        lane: "talk",
+        runIdPrefix: params.runIdPrefix ?? "talk-realtime-consult",
+        args: parsedArgs,
+        transcript: params.initialItems,
+        surface: params.surface ?? "a browser Talk session",
+        userLabel: "User",
+        questionSourceLabel: "user",
+        thinkLevel: talkConfig?.consultThinkingLevel,
+        fastMode: talkConfig?.consultFastMode,
+        ...authority,
+        abortSignal: signal,
+        onRunStarted: ({ runId, sessionId, timeoutMs }) => {
+          if (params.registerRun) {
+            params.registerRun({ runId });
+          } else {
+            registerClientVoiceConsultRun({
+              agentId: params.agentId,
+              sessionKey: params.sessionKey,
+              voiceSessionId,
+              runId,
+              config: params.config,
+            });
+          }
+          if (confirmationGrant) {
+            bindAuthorizedClientVoiceConfirmation({ grant: confirmationGrant, runId });
+          }
+          if (!params.ownerConnId) {
+            return undefined;
+          }
+          const registration = registerChatAbortController({
+            chatAbortControllers: params.context.chatAbortControllers,
             runId,
-            config: params.config,
+            sessionId,
+            sessionKey: params.sessionKey,
+            agentId: params.agentId,
+            timeoutMs,
+            ownerConnId: params.ownerConnId,
+            controlUiVisible: false,
+            kind: "chat-send",
           });
-        }
-        if (confirmationGrant) {
-          bindAuthorizedClientVoiceConfirmation({ grant: confirmationGrant, runId });
-        }
-        if (!params.ownerConnId) {
-          return undefined;
-        }
-        const registration = registerChatAbortController({
-          chatAbortControllers: params.context.chatAbortControllers,
-          runId,
-          sessionId,
-          sessionKey: params.sessionKey,
-          agentId: params.agentId,
-          timeoutMs,
-          ownerConnId: params.ownerConnId,
-          controlUiVisible: false,
-          kind: "chat-send",
-        });
-        return { abortSignal: registration.controller.signal, cleanup: registration.cleanup };
-      },
+          return { abortSignal: registration.controller.signal, cleanup: registration.cleanup };
+        },
+      });
     });
-  };
   return {
     runArgs,
     runPrompt: async ({ prompt, signal }: { prompt: string; signal?: AbortSignal }) =>


### PR DESCRIPTION
Closes #134081

## What Problem This Solves

Fixes an issue where Browser Talk users in realtime mode with `brain: "agent-consult"` would get every spoken agent request rejected with `Gateway is draining; new tasks are not accepted` once the `talk.client.create` request that started the session had completed, even though the gateway stayed healthy (`/readyz` green, no restart or drain active). Voice mode fell into a user-visible retry loop and could not perform any agent/tool-backed work until the session/process was restarted.

## Why This Change Was Made

The realtime consult runner is created inside the `talk.client.create` gateway request, which runs in a root work admission tracked via `AsyncLocalStorage`. The runner's callbacks intentionally outlive that request, but they kept executing inside the request's admission context; once the initiating root was released, `beginSessionWorkAdmission` saw the inherited root as retired and threw `GatewayDrainingError` for every later consult. The fix detaches each consultation with `runOutsideGatewayRootWorkAdmission(...)` so consults start with a process-lifetime boundary and are only gated by the real process-wide fences (restart drain/signal, host suspension), which remain enforced. This covers both the gateway-control tool-call path and the direct client-owned consult path, since both funnel through the same runner. Non-goals: other consult surfaces (e.g. meeting-bot) are unchanged.

## User Impact

Browser Talk voice sessions with `agent-consult` now keep working across many spoken turns after the session-creating request completes, instead of entering a permanent draining retry loop. No behavior change while the gateway is genuinely draining or suspended.

## Evidence

### Real behavior trace (terminal trace through production code, no mocks except the LLM leaf)

A focused harness (`issue-134081-live-trace.mts`, available on request / in the evidence directory) drives the **real production modules** in-process, replaying the exact user scenario:

1. `talk.client.create` gateway request begins a real root work admission (`tryBeginGatewayRootWorkAdmission`)
2. the real long-lived consult runner (`createTalkClientAgentConsultRunner`) is created inside that request
3. the request completes and its root admission is released while the process-global fence stays open
4. a later spoken turn invokes the retained `agent-consult` callback (kept in the request's async chain, like the provider does)

Everything on the path is production code — real admission machinery, real consult runner, real `beginSessionWorkAdmission` guard. Only the embedded-agent execution leaf is stubbed, because a real agent run requires LLM provider credentials (external-service boundary).

Real environment tested: In-process gateway runtime trace on Linux (Node v26.7.0) against OpenClaw main, exercising the real `gateway-work-admission`, the real long-lived Browser Talk consult runner, and the real `beginSessionWorkAdmission` guard; no external LLM credentials or browser session involved.
Exact steps or commands run after this patch: `node --import ./scripts/tsx.mjs issue-134081-live-trace.mts runner` and `node --import ./scripts/tsx.mjs issue-134081-live-trace.mts full` — each replays: root admission begins for `talk.client.create` -> consult runner created inside the request -> request completes and its root is released while the process-global fence stays open -> a later spoken turn invokes the retained consult callback.

Evidence before fix:

**BEFORE — unpatched runner from `main` (`dd30aa4^`), same sequence (exit 2):**

```text
[trace] 3. talk.client.create completed; request root admission released
[trace]    process-global gateway fence still open (readyz-equivalent) -> {"isGatewayWorkAdmissionClosed":false}
[trace] 4. later spoken turn invokes the retained agent-consult callback
[trace] 5. consult REJECTED by session work admission: GatewayDrainingError: Gateway is draining; new tasks are not accepted
[trace] RESULT: FAIL — reproduced issue #134081 (released root leaks into later consult)
```

This is the exact rejection the reporter logged (`OpenAI GPT-Live delegation consult failed: Gateway is draining; new tasks are not accepted`) while readiness stayed healthy.

Evidence after fix: same released-root scenario with this patch applied — the later spoken consult now clears session work admission and proceeds into real agent execution:

**AFTER — this PR's runner, same sequence:**

```text
[trace] 4. later spoken turn invokes the retained agent-consult callback
[trace] 5. consult PASSED admission; stopped later at the external model boundary: RunWorkspaceRosterRequiredError: No agents configured; run workspace resolution requires an explicit roster.
[trace] RESULT: PASS — drain rejection gone; consult reached agent execution
```

The consult now clears session work admission and proceeds into real agent execution; it stops only at the model/workspace boundary, which is expected in a credential-free harness (and is far past the admission gate that previously rejected it).

**AFTER — full consult pipeline to a completed spoken answer**, same released-root scenario:

```text
[trace] 4a. admission context inside the retained callback -> {"isGatewaySubordinateWorkAdmissionClosed":false}
[trace] 5. real consult pipeline completed; speakable answer returned -> You have three items today: standup at 9:30, design review at 14:00, and wrap-up at 17:00.
[trace] RESULT: PASS — later spoken consult succeeded end-to-end after request completion
```

The same harness run **without** the PR's detachment boundary (`--legacy`, pre-fix semantics) shows the callback seeing `isGatewaySubordinateWorkAdmissionClosed: true` and rejecting with `GatewayDrainingError` — confirming the boundary is exactly what restores the later turn.


Observed result after fix: The later spoken consult passed session work admission (no `GatewayDrainingError`) and proceeded into real agent execution; the full consult pipeline completed and returned a speakable answer after the session-creating request had already returned.
What was not tested: A live OpenAI realtime WebRTC voice session with real microphone/speaker and provider credentials (external-service boundary); the unchanged meeting-bot consult surface.

### Focused regression test

`src/gateway/talk-client-gateway-control.agent-consult.test.ts` adds the released-root sequence as a permanent guard:

- **RED (unpatched):** the consult observes `isGatewaySubordinateWorkAdmissionClosed() === true` — the retained released-root context — and the test fails.
- **GREEN (patched):** the consult observes `false` and completes normally.

### Validation (Node v26.7.0)

```text
src/gateway/talk-client-gateway-control.agent-consult.test.ts      9 passed
src/gateway/talk-client-gateway-control.test.ts (+ import-failure) 9 passed
src/gateway/server-methods/talk-client.test.ts                    13 passed
pnpm tsgo:core                                                     0 errors
oxlint on touched files                                            0 findings
oxfmt on touched files                                             clean
```
