### PR TITLE
test: tighten the default truncation boundary

### DIFF
--- a/packages/agent-core/src/harness/utils/truncate.test.ts
+++ b/packages/agent-core/src/harness/utils/truncate.test.ts
@@ -32,32 +32,22 @@ describe("truncate utilities", () => {
       expect(result.text).toBe("this is a ... [truncated]");
     });
 
-    it("uses GREP_MAX_LINE_LENGTH as the default limit", () => {
-      const result = truncateLine("x");
-      expect(result.wasTruncated).toBe(false);
-      expect(result.text).toBe("x");
+    it("keeps 500 characters and truncates longer lines by default", () => {
+      const line = "x".repeat(500);
+      expect(truncateLine(line)).toEqual({ text: line, wasTruncated: false });
+      expect(truncateLine(`${line}y`)).toEqual({
+        text: `${line}... [truncated]`,
+        wasTruncated: true,
+      });
     });
 
     it("does not split a surrogate pair at the cut point", () => {
       // Emoji at boundary: "AB" + 🤖(surrogate pair) + "CD" — cut at 3 splits the emoji.
       expect(truncateLine("AB🤖CD", 3).text).toBe("AB... [truncated]");
-      // Three emoji, cut in the middle of the second emoji.
+      // Three emoji, cut in the middle of the third emoji.
       expect(truncateLine("🤖🤖🤖", 5).text).toBe("🤖🤖... [truncated]");
       // CJK Extension B (surrogate pair) at boundary stays intact.
       expect(truncateLine("AB𠮷CD", 5).text).toBe("AB𠮷C... [truncated]");
-    });
-
-    it("never produces unpaired surrogates in output", () => {
-      const results = [
-        truncateLine("AB🤖CD", 3).text,
-        truncateLine("🤖🤖🤖", 5).text,
-        truncateLine("AB𠮷CD", 5).text,
-      ];
-      for (const text of results) {
-        expect(text).not.toMatch(
-          /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/,
-        );
-      }
     });
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The line-truncation suite repeats three exact surrogate-boundary inputs in a weaker regex-only test. Its default-limit test checks only a one-character input, so it would pass with almost any default, including an unbounded one.

## Why This Change Was Made

Keep the three exact Unicode input/output assertions and remove their repeated regex check. Rewrite the existing default case to verify that 500 characters remain unchanged and a distinct 501st character is truncated, including the exact suffix and truncation flag. Correct the adjacent comment identifying the third emoji's cut point.

The 500-character default is advertised by the grep tool and used when rendering its matched lines. The test uses a literal boundary rather than importing the implementation constant.

## User Impact

Production unchanged. Tests: +8/-18 (net -10), eight cases become seven. Explicit limits, UTF-8 byte handling, newline accounting, and all three original surrogate regression assertions remain. No API, default, timeout, fixture or runner changes.

## Evidence

Read the complete truncation owner, real grep caller, package exports, session-tool facade, sibling UTF-16 helper and existing tests. Verified the original surrogate fix against its raw parent; the exact regression assertions remain intact. The shared UTF-16 helper has different limit/suffix semantics and is intentionally unchanged.

The full owner suite passes before (8 cases) and after (7 cases) through `node scripts/run-vitest.mjs packages/agent-core/src/harness/utils/truncate.test.ts`. Targeted formatting and diff checks pass. Independent Codex review found no actionable finding in its selected scope. All 19 required changed-file checks pass, including core test typechecks, scoped lint, plugin boundaries, the dead-export scan and assertion-safety guards.

## Real grep boundary proof and review disposition

Executed the existing `createGrepTool` with normal local filesystem operations and installed ripgrep against two temporary synthetic files: 500 `x` characters, and the same prefix plus a distinct 501st `y`. No mocks, injected operations, installs, or limit overrides. Node v26.5.0 on macOS; ripgrep 15.2.0. The process exited 0 in 1.112s and the fixture was removed.

The recorded invocation, shown with `node` in place of its resolved local executable, was `node --import ./scripts/tsx.mjs /tmp/openclaw-package-truncate-preland-40f/real-grep-proof/probe.mjs /tmp/openclaw-package-truncate-preland-40f/real-grep-proof/manifest-c76.json`. `OPENCLAW_TESTBOX` was unset for the child. The probe called `createGrepTool(tempDir).execute(id, { pattern: "x", path: filename })` and checked the complete returned objects.

Proof ran at c76feea6f7882e1a182be03d7afc726a24e1ea2c. The truncation owner blob 2b8174087616b74a1479d04ff7284ad42e661462 and facade are identical to reviewed PR head d116f71828ec0fc8e33aa6dec78fd5f52c177ce6. Current grep differs only in terminal-component rendering; its entire execute body is byte-identical to the PR head (SHA256 36c529bd5ba6dacbed3d7c01faeba2bd413c1ef00e99ee0882a06a20e13262d2). All 27 qualified context entries match captured 40f → c76; all 14 runtime source pins matched before/after.

These are the complete synthetic result records from the actual run:

```jsonl
{"event":"result","inputCharacters":500,"params":{"pattern":"x","path":"boundary-500.txt"},"fixtureSha256":"8fd45c9cb8f53330c161ffaa51a9ccfdc03b7f706384d41e578a5f671cb2e8a9","result":{"content":[{"type":"text","text":"boundary-500.txt:1: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}]}}
{"event":"result","inputCharacters":501,"params":{"pattern":"x","path":"boundary-501.txt"},"fixtureSha256":"2d0ed4d70068e2b5c1bede7e4cbc1d4e7974f16567d97fc99520b6b6c2d23a64","result":{"content":[{"type":"text","text":"boundary-501.txt:1: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx... [truncated]\n\n[Some lines truncated to 500 chars. Use read tool to see full lines]"}],"details":{"linesTruncated":true}}}
```

The 500-character result has no truncation details. The 501-character result has the exact suffix and recovery notice plus `linesTruncated:true`. Both complete-object assertions passed. Raw stdout, empty stderr, source manifest, command/exit receipt and cleanup receipt were personally inspected; the output contains only synthetic fixture names/content and public source/runtime facts.

The latest full Claw review and the entire current two-comment array were read. The omitted-comment concern is resolved. The requested real grep boundary evidence is now supplied above. This remains a test-only change with production 0; no production repair was required. Exact-head CI 33395997430 attempt 2 is SUCCESS, including lint 99595560324 and CI gate 99597083826.
