### PR TITLE
fix(talk): keep later voice turns admitted after call setup

### DIFF
--- a/src/gateway/server-methods/talk-client.test.ts
+++ b/src/gateway/server-methods/talk-client.test.ts
@@ -1,12 +1,27 @@
+import { AsyncResource } from "node:async_hooks";
 import fs from "node:fs/promises";
+import { IncomingMessage, ServerResponse } from "node:http";
+import { Socket } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import {
   loadSessionEntry,
   readSessionTranscriptMessageEvents,
   replaceSessionEntry,
 } from "../../config/sessions/session-accessor.js";
+import { enqueueCommandInLane, resetCommandLane } from "../../process/command-queue.js";
+import {
+  beginGatewayRestartSignalAdmission,
+  GatewayDrainingError,
+  getActiveGatewayRootWorkCount,
+  isGatewayWorkAdmissionClosed,
+  markGatewayRestartDraining,
+  resetGatewayWorkAdmission,
+  tryBeginGatewaySuspendAdmission,
+} from "../../process/gateway-work-admission.js";
+import { getActiveSessionWorkAdmissionCount } from "../../sessions/session-lifecycle-admission.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import {
@@ -18,9 +33,11 @@ import {
   closeClientVoiceSession,
   createOrResumeClientVoiceSession,
   ensureClientVoiceAgentSessionEntry,
+  resolveClientVoiceRunBinding,
 } from "../../talk/client-voice-session.js";
 import { clientVoiceSessionTesting } from "../../talk/client-voice-session.test-support.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
+import { runWithGatewayHttpWorkAdmission } from "../server/http-work-admission.js";
 import { resolveSessionMutationAuthorization } from "../session-sharing.js";
 import { closeTalkClientGatewayControlSession } from "../talk-client-gateway-control.js";
 import { cleanupTalkConnection } from "../talk-session-registry.js";
@@ -32,6 +49,7 @@ import type { GatewayRequestHandlerOptions } from "./types.js";
 const voiceMocks = vi.hoisted(() => ({
   resolveConfiguredRealtimeVoiceProvider: vi.fn(),
   consultRealtimeVoiceAgent: vi.fn(),
+  runEmbeddedAgent: vi.fn<typeof import("../../agents/embedded-agent.js").runEmbeddedAgent>(),
 }));
 
 vi.mock("../../talk/provider-resolver.js", () => ({
@@ -49,8 +67,12 @@ vi.mock("../../talk/provider-registry.js", async (importOriginal) => ({
 vi.mock("../../talk/agent-consult-runtime.js", () => ({
   consultRealtimeVoiceAgent: voiceMocks.consultRealtimeVoiceAgent,
 }));
-vi.mock("../../plugins/runtime/index.js", () => ({
-  createPluginRuntime: () => ({ agent: {} }),
+vi.mock("../../plugins/runtime/index.js", async () => {
+  const { createRuntimeAgent } = await import("../../plugins/runtime/runtime-agent.js");
+  return { createPluginRuntime: () => ({ agent: createRuntimeAgent() }) };
+});
+vi.mock("../../agents/embedded-agent.js", () => ({
+  runEmbeddedAgent: voiceMocks.runEmbeddedAgent,
 }));
 vi.mock("../../agents/realtime-bootstrap-context.js", () => ({
   resolveRealtimeBootstrapContextInstructions: async () => undefined,
@@ -61,6 +83,7 @@ const sessionKey = "agent:main:main";
 const sessionId = "voice-transcript-session";
 let tempDir: string;
 let ownedVoiceSessionId: string | undefined;
+const offerResources: AsyncResource[] = [];
 type BrowserRequest = Parameters<
   NonNullable<import("../../plugins/types.js").RealtimeVoiceProviderPlugin["createBrowserSession"]>
 >[0];
@@ -94,7 +117,9 @@ function configureDelegatedBrowserProvider(
     client,
     clients,
     context: {
-      getRuntimeConfig: () => ({}),
+      getRuntimeConfig: () => ({
+        agents: { defaults: { workspace: path.join(tempDir, "workspace") } },
+      }),
       getClientConnIds: (filter?: (candidate: typeof client) => boolean) =>
         new Set(
           [...clients]
@@ -143,9 +168,65 @@ async function invokeClose(params: Record<string, unknown>) {
   return respond;
 }
 
+async function createBrowserConsult() {
+  const createBrowserSession = vi.fn(async (_request: BrowserRequest) => browserSession);
+  const fixture = configureDelegatedBrowserProvider(createBrowserSession);
+  const respond = vi.fn();
+  await invokeCreate({
+    params: { sessionKey, provider: "openai", model: "gpt-live-test" },
+    respond,
+    context: fixture.context,
+    client: fixture.client,
+  } as never);
+  expect(respond).toHaveBeenCalledWith(true, expect.objectContaining(browserSession), undefined);
+  const createdSession = respond.mock.calls[0]?.[1];
+  if (!createdSession) {
+    throw new Error("Expected a browser session response");
+  }
+  ownedVoiceSessionId = createdSession.voiceSessionId;
+  const consult = createBrowserSession.mock.calls[0]?.[0].runAgentConsult;
+  if (!consult) {
+    throw new Error("Expected a Gateway-owned browser consult callback");
+  }
+  return { ...fixture, consult };
+}
+
+async function completeOffer(run?: (resource: AsyncResource) => Promise<void>) {
+  const socket = new Socket();
+  const res = new ServerResponse(new IncomingMessage(socket));
+  let resource!: AsyncResource;
+  try {
+    await runWithGatewayHttpWorkAdmission(res, async () => {
+      // A socket captures its creator's async context; a retained plain closure does not.
+      resource = new AsyncResource("talk-sideband-test");
+      offerResources.push(resource);
+      await run?.(resource);
+      return true;
+    });
+    return resource;
+  } finally {
+    socket.destroy();
+  }
+}
+
+async function useRealConsultRuntime() {
+  const actual = await vi.importActual<typeof import("../../talk/agent-consult-runtime.js")>(
+    "../../talk/agent-consult-runtime.js",
+  );
+  voiceMocks.consultRealtimeVoiceAgent.mockImplementation(actual.consultRealtimeVoiceAgent);
+  voiceMocks.runEmbeddedAgent.mockImplementation(async (params) => {
+    params.abortSignal?.throwIfAborted();
+    return await enqueueCommandInLane("talk-admission-test", async () => ({
+      payloads: [{ text: "fixture status" }],
+      meta: { durationMs: 0 },
+    }));
+  });
+}
+
 describe("talk.client.transcript", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    resetGatewayWorkAdmission();
     ownedVoiceSessionId = undefined;
     tempDir = await fs.realpath(
       await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-talk-transcript-")),
@@ -158,6 +239,12 @@ describe("talk.client.transcript", () => {
   });
 
   afterEach(async () => {
+    const remainingRootWork = getActiveGatewayRootWorkCount();
+    resetGatewayWorkAdmission();
+    for (const resource of offerResources.splice(0)) {
+      resource.emitDestroy();
+    }
+    resetCommandLane("talk-admission-test");
     if (ownedVoiceSessionId) {
       await closeTalkClientGatewayControlSession({
         voiceSessionId: ownedVoiceSessionId,
@@ -173,7 +260,106 @@ describe("talk.client.transcript", () => {
     closeOpenClawStateDatabaseForTest();
     envSnapshot.restore();
     await fs.rm(tempDir, { recursive: true, force: true });
+    expect(remainingRootWork).toBe(0);
   });
+
+  it("admits a later sideband consult after its HTTP offer has released admission", async () => {
+    await useRealConsultRuntime();
+    const { consult } = await createBrowserConsult();
+    const resource = await completeOffer();
+    expect(getActiveGatewayRootWorkCount()).toBe(0);
+    expect(isGatewayWorkAdmissionClosed()).toBe(false);
+
+    await expect(
+      resource.runInAsyncScope(() => consult({ prompt: "Return the fixture status" })),
+    ).resolves.toEqual({ text: "fixture status" });
+    const [run] = voiceMocks.runEmbeddedAgent.mock.calls[0]!;
+    expect(resolveClientVoiceRunBinding(run.runId)).toMatchObject({
+      agentId: "main",
+      sessionKey,
+      voiceSessionId: ownedVoiceSessionId,
+    });
+    expect(getActiveSessionWorkAdmissionCount()).toBe(0);
+  });
+
+  it("keeps an accepted consult admitted through offer completion and suspension", async () => {
+    await useRealConsultRuntime();
+    const { consult } = await createBrowserConsult();
+    const beforeEnqueue = createDeferred();
+    const enqueue = voiceMocks.runEmbeddedAgent.getMockImplementation()!;
+    voiceMocks.runEmbeddedAgent.mockImplementationOnce(async (params) => {
+      expect(getActiveSessionWorkAdmissionCount()).toBe(1);
+      await beforeEnqueue.promise;
+      return await enqueue(params);
+    });
+    let work: Promise<{ text: string }> | undefined;
+    let suspension: ReturnType<typeof tryBeginGatewaySuspendAdmission> = null;
+    try {
+      await completeOffer(async (resource) => {
+        work = resource.runInAsyncScope(() => consult({ prompt: "Return the fixture status" }));
+        void work.catch(() => undefined);
+        await vi.waitFor(() => expect(voiceMocks.runEmbeddedAgent).toHaveBeenCalledOnce());
+      });
+      expect(getActiveSessionWorkAdmissionCount()).toBe(1);
+      suspension = tryBeginGatewaySuspendAdmission(() => {});
+      expect(suspension).not.toBeNull();
+      beforeEnqueue.resolve();
+      await expect(work).resolves.toEqual({ text: "fixture status" });
+      expect(getActiveSessionWorkAdmissionCount()).toBe(0);
+    } finally {
+      beforeEnqueue.resolve();
+      await work?.catch(() => undefined);
+      suspension?.rollback();
+    }
+  });
+
+  it.each(["suspend", "restart-signal", "restart-drain"] as const)(
+    "does not admit a new sideband consult during %s",
+    async (fence) => {
+      await useRealConsultRuntime();
+      const { consult } = await createBrowserConsult();
+      const resource = await completeOffer();
+      if (fence === "suspend") {
+        expect(tryBeginGatewaySuspendAdmission(() => {})).not.toBeNull();
+      } else if (fence === "restart-signal") {
+        expect(beginGatewayRestartSignalAdmission()).not.toBeNull();
+      } else {
+        markGatewayRestartDraining();
+      }
+      await expect(
+        resource.runInAsyncScope(() => consult({ prompt: "Must not start" })),
+      ).rejects.toThrow(GatewayDrainingError);
+      expect(voiceMocks.runEmbeddedAgent).not.toHaveBeenCalled();
+      expect(getActiveSessionWorkAdmissionCount()).toBe(0);
+    },
+  );
+
+  it.each(["close", "disconnect", "restart"] as const)(
+    "does not revive a stale sideband owner after %s",
+    async (ending) => {
+      await useRealConsultRuntime();
+      const { consult, client, clients, context } = await createBrowserConsult();
+      const resource = await completeOffer();
+      if (ending === "close") {
+        expect(
+          await invokeClose({ sessionKey, voiceSessionId: ownedVoiceSessionId }),
+        ).toHaveBeenCalledWith(true, { ok: true }, undefined);
+      } else {
+        if (ending === "restart") {
+          markGatewayRestartDraining();
+        }
+        clients.delete(client);
+        cleanupTalkConnection(client.connId, context.logGateway);
+        if (ending === "restart") {
+          resetGatewayWorkAdmission();
+        }
+      }
+      await expect(
+        resource.runInAsyncScope(() => consult({ prompt: "Must not start" })),
+      ).rejects.toThrow(/closed|disconnected/);
+      expect(voiceMocks.runEmbeddedAgent).not.toHaveBeenCalled();
+    },
+  );
 
   it("appends finalized messages once by event id", async () => {
     const voiceSessionId = createOrResumeClientVoiceSession({

--- a/src/gateway/talk-client-gateway-control.ts
+++ b/src/gateway/talk-client-gateway-control.ts
@@ -2,6 +2,11 @@ import { randomUUID } from "node:crypto";
 import { normalizeTalkSection } from "../config/talk.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createPluginRuntime } from "../plugins/runtime/index.js";
+import {
+  GatewayDrainingError,
+  runOutsideGatewayRootWorkAdmission,
+  tryBeginGatewayRootWorkAdmission,
+} from "../process/gateway-work-admission.js";
 import { BoundedSerialQueue } from "../shared/bounded-serial-queue.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
 import { consultRealtimeVoiceAgent } from "../talk/agent-consult-runtime.js";
@@ -272,63 +277,73 @@ export function createTalkClientAgentConsultRunner(params: {
           confirmationId: parsedArgs.confirmationId,
         })
       : undefined;
-    agentRuntime ??= createTalkClientAgentRuntime({
+    const runtime = (agentRuntime ??= createTalkClientAgentRuntime({
       config: params.config,
       agentId,
       ...(params.ownerConnId ? { rawSourceRef: params.ownerConnId } : {}),
-    });
+    }));
     const talkConfig = normalizeTalkSection(params.config.talk);
-    return await consultRealtimeVoiceAgent({
-      cfg: params.config,
-      agentRuntime,
-      logger: params.context.logGateway,
-      agentId,
-      sessionKey: canonicalKey,
-      storePath,
-      messageProvider: "webchat",
-      lane: "talk",
-      runIdPrefix: params.runIdPrefix ?? "talk-realtime-consult",
-      args: parsedArgs,
-      transcript: params.initialItems,
-      surface: params.surface ?? "a browser Talk session",
-      userLabel: "User",
-      questionSourceLabel: "user",
-      thinkLevel: talkConfig?.consultThinkingLevel,
-      fastMode: talkConfig?.consultFastMode,
-      ...authority,
-      abortSignal: signal,
-      onRunStarted: ({ runId, sessionId, timeoutMs }) => {
-        if (params.registerRun) {
-          params.registerRun({ runId });
-        } else {
-          registerClientVoiceConsultRun({
-            agentId,
-            sessionKey,
-            voiceSessionId,
-            runId,
-            config: params.config,
-          });
-        }
-        if (confirmationGrant) {
-          bindAuthorizedClientVoiceConfirmation({ grant: confirmationGrant, runId });
-        }
-        if (!params.ownerConnId) {
-          return undefined;
-        }
-        const registration = registerChatAbortController({
-          chatAbortControllers: params.context.chatAbortControllers,
-          runId,
-          sessionId,
-          sessionKey: canonicalKey,
+    // A voice turn outlives offer setup and must drain under its own root,
+    // while new turns still respect suspension and restart admission.
+    const admission = runOutsideGatewayRootWorkAdmission(tryBeginGatewayRootWorkAdmission);
+    if (!admission) {
+      throw new GatewayDrainingError();
+    }
+    return await admission
+      .run(() =>
+        consultRealtimeVoiceAgent({
+          cfg: params.config,
+          agentRuntime: runtime,
+          logger: params.context.logGateway,
           agentId,
-          timeoutMs,
-          ownerConnId: params.ownerConnId,
-          controlUiVisible: false,
-          kind: "chat-send",
-        });
-        return { abortSignal: registration.controller.signal, cleanup: registration.cleanup };
-      },
-    });
+          sessionKey: canonicalKey,
+          storePath,
+          messageProvider: "webchat",
+          lane: "talk",
+          runIdPrefix: params.runIdPrefix ?? "talk-realtime-consult",
+          args: parsedArgs,
+          transcript: params.initialItems,
+          surface: params.surface ?? "a browser Talk session",
+          userLabel: "User",
+          questionSourceLabel: "user",
+          thinkLevel: talkConfig?.consultThinkingLevel,
+          fastMode: talkConfig?.consultFastMode,
+          ...authority,
+          abortSignal: signal,
+          onRunStarted: ({ runId, sessionId, timeoutMs }) => {
+            if (params.registerRun) {
+              params.registerRun({ runId });
+            } else {
+              registerClientVoiceConsultRun({
+                agentId,
+                sessionKey,
+                voiceSessionId,
+                runId,
+                config: params.config,
+              });
+            }
+            if (confirmationGrant) {
+              bindAuthorizedClientVoiceConfirmation({ grant: confirmationGrant, runId });
+            }
+            if (!params.ownerConnId) {
+              return undefined;
+            }
+            const registration = registerChatAbortController({
+              chatAbortControllers: params.context.chatAbortControllers,
+              runId,
+              sessionId,
+              sessionKey: canonicalKey,
+              agentId,
+              timeoutMs,
+              ownerConnId: params.ownerConnId,
+              controlUiVisible: false,
+              kind: "chat-send",
+            });
+            return { abortSignal: registration.controller.signal, cleanup: registration.cleanup };
+          },
+        }),
+      )
+      .finally(admission.release);
   };
   return {
     runArgs,


### PR DESCRIPTION
## What Problem This Solves

Browser Talk could finish its WebRTC offer successfully and then reject later agent requests with “Gateway is draining” while the Gateway was healthy. A sideband socket created during the HTTP offer inherited that request's admission context, which was released when the offer handler returned. An already accepted consult could also lose subordinate command admission after the offer ended.

Fixes #134081. Thanks @mastertyko for the report.

Release note: keep Browser Talk agent requests working after call setup and preserve accepted turns during cooperative suspension.

## Why This Change Was Made

Each new Gateway-owned voice consult now acquires a fresh root through the existing admission owner, runs under that lease, and releases it when the consult settles. The HTTP offer no longer owns the turn's lifetime. The same shared runner covers browser GPT-Live, GA Gateway-controlled WebRTC, and direct relay consults. No provider protocol, authentication, configuration, or storage contract changes.

Provenance: the affected lifetime behavior is present in stable `v2026.8.1`; the exact original introduction is not established.

This adds 15 production lines to establish the missing per-turn ownership boundary. It retains exact voice-session and connection checks, spoken confirmation, caller tool authority, cancellation, and global restart/suspension fences. An idle voice connection does not retain a root indefinitely; accepted turns remain tracked while cooperative suspension drains them.

## User Impact

Later Talk requests can reach the configured agent after call setup completes. A consult already admitted before cooperative suspension can finish; new requests during suspension or restart still fail visibly. Closed, disconnected, and replaced voice owners remain fenced.

## Current candidate

Head `3170c74edb4b0a3dba9f27c6ab2e726a5fa7aa65` resolves a conflict with main's configured Talk-owner repair (#133958). It preserves the prepared agent, canonical session key and store for execution, the original key for voice identity, and wraps that canonical flow in the same fresh per-consult admission lease. The regression fixture now obtains its prepared target through the real create authorization helper.

Fresh independent P0–P2 review of this complete reconciled patch is scoped-clean. Exact-head hosted CI33414292743 passed all166 jobs, including the required gates. Refreshed local owner/target coverage passed **193 tests across five files**. The actual HTTP/WebSocket loopback replay also passed on this head (exit 0,21.94 seconds), using real create authorization with configured agent `voice`, requested session `main` and canonical `global` storage, without a preseeded session. It observed two successful later turns, visible suspension refusal, success after resume and stale-owner refusal. Each turn preserved the prepared target and returned roots/session leases to zero; all resources were released. Six source hashes match the clean committed head. This completes the current-head proof and rank-up request in the latest16:36 UTC ClawSweeper review. The earlier completed proof below applies to head `f156731090cf3482546bdd5dc858475f5e29713f`; it is retained as historical evidence and is not represented as a run of this new head. Exact-head required CI passed.

Production remains **net +15** (+67/-52); tests remain **net +186** (+189/-3). No added scope beyond preserving the upstream owner flow through the existing admission repair.

<details>
<summary>Current317 executed loopback receipt</summary>

```json
{
  "status": "passed",
  "failurePhase": null,
  "cleanupErrors": [],
  "sourceHashes": {
    "src/gateway/talk-client-gateway-control.ts": "f60d816e10389ed9d1f8b15646db0237b5446d27b97763d924633d824d2b0d2b",
    "src/gateway/server-methods/talk-client.test.ts": "9b046234f0dfa86dca5064b3d0563968d832b6e942e07c73a3c960e04f3b7d2e",
    "src/gateway/server-methods/talk-client-create.ts": "60fe145526f0ad53f373f67a0e900a8094c8d20f9045b7eadb3c8c70e96bba21",
    "src/gateway/session-sharing.ts": "3272fd0ac3ce8bc33754a2942df4a68772cfb0c420a39be8638e849b3277c2b2",
    "src/gateway/talk-session-target.ts": "ba4ee85d91ea6e4d6cc893cc80992e073cd26c309190fbbaede478aecc33cd2f",
    "src/talk/agent-consult-runtime.ts": "14e09be3e889e36e2cd9ccc8f69ca3d1bfa3b76863b8d96e3d456cd658159c24"
  },
  "realHttp": true,
  "realWebSocket": true,
  "actualBroker": true,
  "actualOwnerAndConsult": true,
  "configuredTalkOwner": "voice",
  "requestedSessionKey": "main",
  "canonicalSessionKey": "global",
  "preseededAgentSession": false,
  "externalProvider": false,
  "finalEmbeddedExecution": "fixture with real command queue",
  "completedHttpRequests": 2,
  "httpStatuses": [
    {
      "ordinal": 1,
      "status": 401
    },
    {
      "ordinal": 2,
      "status": 200
    }
  ],
  "websocketConnections": 1,
  "wireOrdinals": [
    {
      "ordinal": 1,
      "id": "turn-one",
      "characters": 23,
      "outcome": "fixture-answer",
      "canonicalTargetPreserved": true,
      "remainingRoots": 0,
      "remainingSessions": 0
    },
    {
      "ordinal": 2,
      "id": "turn-two",
      "characters": 23,
      "outcome": "fixture-answer",
      "canonicalTargetPreserved": true,
      "remainingRoots": 0,
      "remainingSessions": 0
    },
    {
      "ordinal": 3,
      "id": "turn-suspended",
      "characters": 80,
      "outcome": "provider-failure",
      "canonicalTargetPreserved": true,
      "remainingRoots": 0,
      "remainingSessions": 0
    },
    {
      "ordinal": 4,
      "id": "turn-resumed",
      "characters": 23,
      "outcome": "fixture-answer",
      "canonicalTargetPreserved": true,
      "remainingRoots": 0,
      "remainingSessions": 0
    }
  ],
  "successfulEmbeddedExecutions": 3,
  "remainingRoots": 0,
  "remainingSessions": 0,
  "resourcesReleased": true
}
```

Final model execution and external call creation remain synthetic; no authenticated provider, SDP/audio, microphone or full authenticated Gateway RPC claim.

</details>

## Earlier completed evidence

Two regression cases failed on the original source at the intended real boundaries: session admission for the later socket callback, and command admission for an accepted consult held until offer completion and suspension. Both now pass. The regression creates an actual Node AsyncResource inside the real HTTP admission scope; it does not mistake a retained plain closure for captured async context.

141 focused tests passed across the browser owner, Gateway control, relay lifecycle, and shared consult runtime. The final 21-case owner rerun also verifies zero outstanding roots before test cleanup resets state. The first changed-file gate caught a fixture-only optional-chain lint error; it was corrected, and the final type/lint gate passed. Core production checks passed on the unchanged production bytes.

A secretless loopback proof exercised real HTTP plugin dispatch and single-use offer authentication, a real WebSocket created during the offer, the actual OpenAI broker, and the real voice owner/consult/session admission. It observed HTTP 401/200, two successful later delegations, a visible suspension rejection, a successful turn after resume, and stale-owner rejection after close. PASS was recorded only after broker, socket/listener, database and task-state cleanup completed with zero roots or session admissions.

Proof limit: final embedded execution returned fixture text through the real command queue. This does not claim authenticated OpenAI service, SDP/media interoperability, microphone, or full authenticated Gateway RPC proof. No external credentials or operator Gateway were used.

Fresh independent Codex autoreview exited successfully: scoped-clean at the configured P0 priority, with no accepted/actionable findings. This was a static review of the final candidate and supporting owner source.

Production: +66/−51 (net +15, including indentation); tests: +189/−3 (net +186). The added ownership is necessary: detaching the stale offer context alone failed the accepted-turn/suspension checkpoint. No second admission implementation or long-lived connection lease is added.

<details>
<summary>Executed loopback trace and exact source binding</summary>

The following is the saved receipt from the completed after-fix run, not an expected result. Both source hashes match committed head `f156731090cf3482546bdd5dc858475f5e29713f`. The real broker returns the provider-failure text for the suspended request; the other three wire responses contain the fixture agent answer. The final stale callback rejection is asserted before the zero-admission/cleanup checks.

```text
voice-loopback-proof > delivers two actual sideband turns after offer completion, fences suspension, and closes the exact owner
Test Files  1 passed (1)
Tests       1 passed (1)
Duration    18.41s (tests 1.22s)
Exit        0
```

```json
{
  "status": "passed",
  "failurePhase": null,
  "cleanupErrors": [],
  "sourceHashes": {
    "src/gateway/talk-client-gateway-control.ts": "0f6668d875fcdd74c95e3d09093ee9e1d205f50c030a719dae182ebaa28deb54",
    "src/gateway/server-methods/talk-client.test.ts": "17cdb8470c447f53492fdc0d09e560478cb683eab41e50e3db71126cd8221fc3"
  },
  "realHttp": true,
  "realWebSocket": true,
  "actualBroker": true,
  "actualOwnerAndConsult": true,
  "externalProvider": false,
  "finalEmbeddedExecution": "fixture with real command queue",
  "completedHttpRequests": 2,
  "httpStatuses": [
    {
      "ordinal": 1,
      "status": 401
    },
    {
      "ordinal": 2,
      "status": 200
    }
  ],
  "websocketConnections": 1,
  "wireOrdinals": [
    {
      "ordinal": 1,
      "id": "turn-one",
      "characters": 23,
      "outcome": "fixture-answer"
    },
    {
      "ordinal": 2,
      "id": "turn-two",
      "characters": 23,
      "outcome": "fixture-answer"
    },
    {
      "ordinal": 3,
      "id": "turn-suspended",
      "characters": 80,
      "outcome": "provider-failure"
    },
    {
      "ordinal": 4,
      "id": "turn-resumed",
      "characters": 23,
      "outcome": "fixture-answer"
    }
  ],
  "successfulEmbeddedExecutions": 3,
  "remainingRoots": 0,
  "remainingSessions": 0,
  "resourcesReleased": true
}
```

The committed regression suite separately exercises restart-signal, restart-drain, disconnect and stale-owner controls; those are not mislabeled as extra WebSocket cases. The original baseline had two intended failures at actual session/command admission. Fixture setup failures (Vitest import form and a temporary provider-cancel adapter) were corrected before this passing receipt; no production assertion or admission fence was weakened.

</details>
