### PR TITLE
test(nostr): exercise cursor retries with virtual time

### DIFF
--- a/extensions/nostr/src/nostr-cursor.test.ts
+++ b/extensions/nostr/src/nostr-cursor.test.ts
@@ -1,5 +1,7 @@
 import type { Event } from "nostr-tools";
-import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createNostrCursorStateWriter, createNostrDurableCursor } from "./nostr-cursor.js";
 
 function event(createdAt: number): Event {
@@ -7,6 +9,10 @@ function event(createdAt: number): Event {
 }
 
 describe("Nostr durable cursor", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("waits for EOSE before persisting the largest durable timestamp", () => {
     const cursor = createNostrDurableCursor({
       since: 800,
@@ -46,13 +52,12 @@ describe("Nostr durable cursor", () => {
   });
 
   it("serializes a safety rewind after an older in-flight progress write", async () => {
-    let releaseHigh!: () => void;
-    const highGate = new Promise<void>((resolve) => {
-      releaseHigh = resolve;
-    });
+    const highStarted = createDeferred<void>();
+    const highGate = createDeferred<void>();
     const write = vi.fn(async (cursor: number) => {
       if (cursor === 2_000) {
-        await highGate;
+        highStarted.resolve();
+        await highGate.promise;
       }
     });
     const writer = createNostrCursorStateWriter({
@@ -64,16 +69,20 @@ describe("Nostr durable cursor", () => {
 
     writer.schedule(2_000);
     const highWrite = writer.flush();
-    await vi.waitFor(() => expect(write).toHaveBeenCalledWith(2_000));
+    await withTimeout(highStarted.promise, 1_000, {
+      message: "Nostr progress write did not start",
+    });
+    expect(write).toHaveBeenCalledWith(2_000);
     const rewind = writer.persistNow(1_050);
     const stricterRewind = writer.persistNow(1_020);
-    releaseHigh();
+    highGate.resolve();
     await Promise.all([highWrite, rewind, stricterRewind]);
 
     expect(write.mock.calls.map(([cursor]) => cursor)).toEqual([2_000, 1_020]);
   });
 
   it("keeps a failed cursor write dirty for a later flush retry", async () => {
+    vi.useFakeTimers();
     const write = vi
       .fn<(cursor: number) => Promise<void>>()
       .mockRejectedValue(new Error("state unavailable"));
@@ -85,7 +94,9 @@ describe("Nostr durable cursor", () => {
     });
 
     writer.schedule(1_100);
-    await expect(writer.flush()).rejects.toThrow("cursor state write failed");
+    const failedFlush = expect(writer.flush()).rejects.toThrow("cursor state write failed");
+    await vi.runAllTimersAsync();
+    await failedFlush;
     expect(write).toHaveBeenCalledTimes(3);
 
     write.mockResolvedValue(undefined);
@@ -94,6 +105,7 @@ describe("Nostr durable cursor", () => {
   });
 
   it("keeps retrying a failed safety write until it is durable", async () => {
+    vi.useFakeTimers();
     const write = vi
       .fn<(cursor: number) => Promise<void>>()
       .mockRejectedValueOnce(new Error("state unavailable"))
@@ -104,12 +116,13 @@ describe("Nostr durable cursor", () => {
       initialCursor: 1_000,
       minimumCursor: 1_000,
       debounceMs: 60_000,
-      recoveryRetryMs: 0,
       write,
     });
 
     writer.schedule(1_020);
-    await expect(writer.flushUntilSuccess()).resolves.toBeUndefined();
+    const recovered = expect(writer.flushUntilSuccess()).resolves.toBeUndefined();
+    await vi.runAllTimersAsync();
+    await recovered;
     expect(write).toHaveBeenCalledTimes(4);
     expect(write).toHaveBeenLastCalledWith(1_020);
   });

--- a/extensions/nostr/src/nostr-cursor.ts
+++ b/extensions/nostr/src/nostr-cursor.ts
@@ -64,7 +64,6 @@ export function createNostrCursorStateWriter(options: {
   debounceMs: number;
   write: (cursor: number) => Promise<void>;
   onBackgroundError?: (error: Error) => void;
-  recoveryRetryMs?: number;
 }) {
   let desiredCursor = Math.max(options.minimumCursor, options.initialCursor);
   let dirty = false;
@@ -160,9 +159,7 @@ export function createNostrCursorStateWriter(options: {
             return;
           } catch (error) {
             options.onBackgroundError?.(error as Error);
-            await new Promise((resolve) => {
-              setTimeout(resolve, options.recoveryRetryMs ?? CURSOR_RECOVERY_RETRY_MS);
-            });
+            await sleepWithAbort(CURSOR_RECOVERY_RETRY_MS);
           }
         }
       })().finally(() => {


### PR DESCRIPTION
## What Problem This Solves

Two Nostr cursor failure/recovery tests wait through real 100 ms and 300 ms retries. The safety-recovery case also bypasses the production recovery cadence through an internal zero-delay option.

## Why This Change Was Made

Use virtual time only for the two retry cases, attach rejection handling before advancing timers, and exercise the default 1,000 ms recovery delay. Replace write-start polling with a deferred guarded by the original 1,000 ms real-time deadline. Remove the internal recoveryRetryMs test override and reuse the owner’s existing sleepWithAbort helper; its default referenced timer remains 1,000 ms.

## User Impact

Normal Nostr behavior is unchanged. The tests remove 800 ms of configured real retry sleeps while retaining ordered safety rewinds, dirty-state retry, exhaustion, and durable recovery. The removed option shipped inside v2026.8.1, but public barrels/config/setup do not expose it and the sole production constructor omits it. The six-test cursor suite decreased locally from 913.6 ms to 21.5 ms. This is a focused suite measurement, not a CI-wide benchmark.

## Evidence

```text
node scripts/run-vitest.mjs extensions/nostr/src/nostr-cursor.test.ts extensions/nostr/src/nostr-bus.inbound.test.ts
```

```json
{"numPassedTests":35,"numFailedTests":0,"numPendingTests":0,"success":true}
```

The 29 inbound-bus siblings retain EOSE-gated persistence, unflushed safety rewinds, replay baselines and failed-relay handling. The two retry cases restore real timers after each test. The write-start signal retains its 1,000 ms failure bound through the existing public SDK timeout helper.

Production +1/-4; tests +24/-11. Full changed-file validation, formatting, diff check and structured Codex autoreview pass. The initial boundary check rejected a repo-only test-helper import; the final change uses existing public SDK helpers and passes that check.

Named follow-up: correct docs/channels/nostr.md:217–220, which calls duplicate responses expected with multiple relays before correctly stating that event IDs deduplicate delivery. The bus deduplicates duplicate events; that wording needs a separate documentation correction.

### ClawSweeper real cursor persistence recovery proof

At exact head `90b9378709ec94871a54efc332c152cff7d3a5e1`, an isolated diagnostic exercised the actual `createNostrCursorStateWriter` → `writeNostrBusState` → plugin SQLite store path with real timers. A regular file temporarily occupied the disposable state-directory path. Three real persistence attempts failed with `PLUGIN_STATE_OPEN_FAILED` caused by `ENOTDIR`. The actual background-error callback repaired that filesystem path; the writer then used its production 1000 ms recovery delay, and the fourth real write persisted cursor `1020`. The observed gap from the exhausted-flush error to the recovery attempt was **1002.237 ms**.

After recovery, the diagnostic closed the plugin/shared database handles and read through a fresh connection. It recovered `{version:2,lastProcessedAt:1020,gatewayStartedAt:1000,recentEventIds:[]}` from a file with the actual SQLite header. No write, filesystem, timer, or store result was mocked. The diagnostic supplies the real keyed-store factory through the existing test SDK and observes the real write callback. This is direct cursor-owner persistence/recovery proof; no relay connection or Gateway delivery run is claimed.

The repository Node wrapper ran the disposable diagnostic on Node **v24.19.0**, Vitest **4.1.11**, at **2026-08-31 14:47:56–14:48:07 UTC**, exit **0**:

```text
node scripts/run-vitest.mjs extensions/nostr/src/nostr-cursor.recovery-proof.test.ts --reporter=verbose --reporter=json --outputFile=/tmp/openclaw-test-audit-30/plugins/ci-snapshot-30/nostr-proof-90b93787/recovery-diagnostic.json
```

The file existed only for this diagnostic and was removed afterward; it is not part of the PR. All tracked source bytes and the PR head were unchanged, `git status --porcelain=v1` was empty before and after, and the temporary SQLite directory was removed. Native result fields:

```json
{
  "success": true,
  "numTotalTests": 1,
  "numPassedTests": 1,
  "numFailedTests": 0,
  "numPendingTests": 0,
  "numTodoTests": 0,
  "testResults": [
    {
      "name": "extensions/nostr/src/nostr-cursor.recovery-proof.test.ts",
      "status": "passed",
      "assertionResults": [
        {
          "fullName": "recovers a real cursor write after repairing its temporary state path",
          "status": "passed",
          "duration": 1563.1432910000003,
          "failureMessages": []
        }
      ]
    }
  ]
}
```

Literal diagnostic trace, with timings measured from `performance.now()`:

```json
{
  "scope": "cursor-writer -> writeNostrBusState -> real plugin SQLite store",
  "fakeTimers": false,
  "configuredRecoveryDelayMs": 1000,
  "attempts": [
    {
      "attempt": 1,
      "cursor": 1020,
      "startedMs": 0.295,
      "outcome": "failed",
      "errorCodes": [
        "PLUGIN_STATE_OPEN_FAILED",
        "ENOTDIR"
      ],
      "finishedMs": 2.571
    },
    {
      "attempt": 2,
      "cursor": 1020,
      "startedMs": 103.676,
      "outcome": "failed",
      "errorCodes": [
        "PLUGIN_STATE_OPEN_FAILED",
        "ENOTDIR"
      ],
      "finishedMs": 105.188
    },
    {
      "attempt": 3,
      "cursor": 1020,
      "startedMs": 406.687,
      "outcome": "failed",
      "errorCodes": [
        "PLUGIN_STATE_OPEN_FAILED",
        "ENOTDIR"
      ],
      "finishedMs": 410.893
    },
    {
      "attempt": 4,
      "cursor": 1020,
      "startedMs": 1413.45,
      "outcome": "written",
      "finishedMs": 1528.961
    }
  ],
  "backgroundErrors": [
    {
      "atMs": 411.213,
      "message": "Nostr cursor state write failed.",
      "errorCodes": [
        "PLUGIN_STATE_OPEN_FAILED",
        "ENOTDIR"
      ]
    }
  ],
  "repairedAtMs": 411.733,
  "recoveryAttemptGapMs": 1002.237,
  "closedStoreBeforeReopen": true,
  "sqliteHeader": "SQLite format 3\u0000",
  "afterReopen": {
    "version": 2,
    "lastProcessedAt": 1020,
    "gatewayStartedAt": 1000,
    "recentEventIds": []
  }
}
```

The unchanged focused cursor + state-store suites also passed **15/15** at the same clean head with verbose and JSON reporters. The earlier **35/35** cursor + inbound-bus proof remains separate. The installed `@openclaw/fs-safe` **0.5.6** timeout implementation was read directly: positive guards clear their timer in `finally` (`dist/timing.js:19–38`). The diagnostic's 10-second outer guard leaves the production retry schedule intact. The actual recovery sleeper comes from `packages/retry/src/index.ts:21–70`; without `{ref:false}` it retains a normal referenced timer. The real retry path uses the unchanged 100/300 ms attempt gaps and 1000 ms recovery constant in `extensions/nostr/src/nostr-cursor.ts`.

Named follow-up: the existing state-store case titled “persists and reloads state across restarts” does not close its cached handle between write and read; clarify the title or add a reopen at that test's owner. The disposable recovery diagnostic above explicitly closes and reopens. The previously recorded Nostr multi-relay documentation wording follow-up remains separate.
