### PR TITLE
ci: remove a serial release candidate queue hop

### DIFF
--- a/.github/workflows/full-release-candidate.yml
+++ b/.github/workflows/full-release-candidate.yml
@@ -18,10 +18,10 @@ on:
     outputs:
       state:
         description: Candidate acquisition state
-        value: ${{ jobs.finalize.outputs.state }}
+        value: ${{ jobs.resolve_candidate.outputs.state }}
       source:
         description: Whether the ready candidate was reused or freshly produced
-        value: ${{ jobs.finalize.outputs.source }}
+        value: ${{ jobs.resolve_candidate.outputs.source }}
       reuse_reason:
         description: Candidate acquisition result
         value: ${{ jobs.discover.outputs.reuse_reason }}
@@ -33,10 +33,10 @@ on:
         value: ${{ jobs.discover.outputs.request_sha256 }}
       binding_json:
         description: Validated immutable candidate binding
-        value: ${{ jobs.finalize.outputs.binding_json }}
+        value: ${{ jobs.resolve_candidate.outputs.binding_json }}
       candidate_artifact_json:
         description: Candidate artifact tuple for child workflows
-        value: ${{ jobs.finalize.outputs.candidate_artifact_json }}
+        value: ${{ jobs.resolve_candidate.outputs.candidate_artifact_json }}
 
 permissions:
   actions: read
@@ -140,16 +140,17 @@ jobs:
   resolve_candidate:
     name: Resolve release candidate
     needs: [discover, prepare]
-    if: ${{ always() && needs.discover.result == 'success' && (needs.prepare.result == 'success' || needs.prepare.result == 'skipped') }}
+    if: always()
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     outputs:
-      state: ${{ steps.resolve.outputs.state }}
-      source: ${{ steps.resolve.outputs.source }}
-      binding_json: ${{ steps.resolve.outputs.binding_json }}
-      candidate_artifact_json: ${{ steps.resolve.outputs.candidate_artifact_json }}
+      state: ${{ steps.result.outputs.state }}
+      source: ${{ steps.result.outputs.source }}
+      binding_json: ${{ steps.result.outputs.binding_json }}
+      candidate_artifact_json: ${{ steps.result.outputs.candidate_artifact_json }}
     steps:
       - name: Checkout candidate binding authority
+        if: ${{ !cancelled() && needs.discover.result == 'success' && (needs.prepare.result == 'success' || needs.prepare.result == 'skipped') }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.sha }}
@@ -166,6 +167,7 @@ jobs:
           persist-credentials: false
 
       - name: Resolve candidate binding
+        if: ${{ success() && needs.discover.result == 'success' && (needs.prepare.result == 'success' || needs.prepare.result == 'skipped') }}
         id: resolve
         env:
           CANDIDATE_REQUEST_JSON: ${{ needs.discover.outputs.request_json }}
@@ -193,36 +195,29 @@ jobs:
             printf 'candidate_artifact_json=%s\n' "$(jq -r '.candidateArtifactJson' <<< "$result")"
           } >> "$GITHUB_OUTPUT"
 
-  finalize:
-    name: Finalize release candidate acquisition
-    needs: [discover, prepare, resolve_candidate]
-    if: always()
-    runs-on: ubuntu-24.04
-    timeout-minutes: 5
-    outputs:
-      state: ${{ steps.result.outputs.state }}
-      source: ${{ steps.result.outputs.source }}
-      binding_json: ${{ steps.result.outputs.binding_json }}
-      candidate_artifact_json: ${{ steps.result.outputs.candidate_artifact_json }}
-    steps:
+      # A failed or cancelled binding must never publish ready, even if it wrote outputs.
+      # Runner loss may omit this projection; callers also require acquisition success.
       - name: Record candidate acquisition result
+        if: always()
         id: result
         env:
+          JOB_STATUS: ${{ job.status }}
           DISCOVERY_RESULT: ${{ needs.discover.result }}
           DISCOVERY_STATE: ${{ needs.discover.outputs.state }}
           PREPARE_RESULT: ${{ needs.prepare.result }}
-          RESOLVE_RESULT: ${{ needs.resolve_candidate.result }}
-          RESOLVED_STATE: ${{ needs.resolve_candidate.outputs.state }}
-          RESOLVED_SOURCE: ${{ needs.resolve_candidate.outputs.source }}
-          BINDING_JSON: ${{ needs.resolve_candidate.outputs.binding_json }}
-          CANDIDATE_ARTIFACT_JSON: ${{ needs.resolve_candidate.outputs.candidate_artifact_json }}
+          RESOLVE_RESULT: ${{ steps.resolve.outcome }}
+          RESOLVED_STATE: ${{ steps.resolve.outputs.state }}
+          RESOLVED_SOURCE: ${{ steps.resolve.outputs.source }}
+          BINDING_JSON: ${{ steps.resolve.outputs.binding_json }}
+          CANDIDATE_ARTIFACT_JSON: ${{ steps.resolve.outputs.candidate_artifact_json }}
         run: |
           set -euo pipefail
           state=unavailable
           source=""
           binding_json=""
           candidate_artifact_json=""
-          if [[ "$DISCOVERY_RESULT" == "success" &&
+          if [[ "$JOB_STATUS" == "success" &&
+                "$DISCOVERY_RESULT" == "success" &&
                 "$DISCOVERY_STATE" != "unavailable" &&
                 "$PREPARE_RESULT" =~ ^(success|skipped)$ &&
                 "$RESOLVE_RESULT" == "success" &&
@@ -240,6 +235,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Enforce candidate acquisition
+        if: always()
         env:
           STATE: ${{ steps.result.outputs.state }}
         run: |

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -14,8 +14,13 @@ import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
+import { buildFullReleaseCandidateBinding } from "../../scripts/full-release-candidate-contract.mjs";
 import { FULL_RELEASE_WAIT_TIMEOUT_MINUTES } from "../../scripts/full-release-validation-at-sha.mts";
 import { createReleaseWorkflowMatrixPlan } from "../../scripts/plan-release-workflow-matrix.mjs";
+import {
+  fullReleaseCandidateArtifact,
+  fullReleaseCandidateManifestFixture,
+} from "../helpers/full-release-candidate.js";
 import {
   pluginPrereleaseTimeoutComponents,
   releaseTimeoutForProfile as timeoutForProfile,
@@ -520,6 +525,34 @@ function runReleaseChecksShellStep(
     },
   });
   return { output: readFileSync(outputPath, "utf8"), result };
+}
+
+function runCandidateAcquisitionStep(
+  stepName: string,
+  env: Record<string, string>,
+  workdir = tempDirs.make("candidate-acquisition-step-"),
+) {
+  const step = workflowStep(
+    workflowJob(FULL_RELEASE_CANDIDATE_WORKFLOW, "resolve_candidate"),
+    stepName,
+  );
+  const outputPath = resolve(workdir, "github-output");
+  writeFileSync(outputPath, "", "utf8");
+  const result = spawnSync("bash", ["-c", step.run ?? ""], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: { ...env, GITHUB_OUTPUT: outputPath, PATH: process.env.PATH, RUNNER_TEMP: workdir },
+  });
+  const output = Object.fromEntries(
+    readFileSync(outputPath, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const separator = line.indexOf("=");
+        return [line.slice(0, separator), line.slice(separator + 1)];
+      }),
+  );
+  return { output, result };
 }
 
 function createReleaseChecksContextFixture() {
@@ -4121,7 +4154,6 @@ describe("package artifact reuse", () => {
     const discovery = workflowJob(FULL_RELEASE_CANDIDATE_WORKFLOW, "discover");
     const prepare = workflowJob(FULL_RELEASE_CANDIDATE_WORKFLOW, "prepare");
     const candidateBinding = workflowJob(FULL_RELEASE_CANDIDATE_WORKFLOW, "resolve_candidate");
-    const finalize = workflowJob(FULL_RELEASE_CANDIDATE_WORKFLOW, "finalize");
     const summary = workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "summary");
     const producer = workflowJob(LIVE_E2E_WORKFLOW, "prepare_docker_e2e_image");
     const binder = workflowJob(LIVE_E2E_WORKFLOW, "bind_full_release_candidate_evidence");
@@ -4142,6 +4174,7 @@ describe("package artifact reuse", () => {
     );
     const pluginDocker = workflowJob(PLUGIN_PRERELEASE_WORKFLOW, "plugin-prerelease-docker-suite");
 
+    expect(candidateWorkflow.jobs).not.toHaveProperty("finalize");
     expect(candidateWorkflow.concurrency).toEqual({
       group: "full-release-candidate-${{ inputs.request_sha256 }}",
       "cancel-in-progress": false,
@@ -4167,11 +4200,17 @@ describe("package artifact reuse", () => {
     expect(workflowStep(candidateBinding, "Resolve candidate binding").run).toContain(
       "full-release-candidate-reuse.mjs resolve",
     );
-    expect(jobNeeds(finalize)).toEqual(["discover", "prepare", "resolve_candidate"]);
-    expect(workflowStep(finalize, "Record candidate acquisition result").run).toContain(
+    expect(candidateBinding.if).toBe("always()");
+    const resultStep = workflowStep(candidateBinding, "Record candidate acquisition result");
+    expect(resultStep.if).toBe("always()");
+    expect(resultStep.env?.RESOLVE_RESULT).toBe("${{ steps.resolve.outcome }}");
+    expect(resultStep.env?.JOB_STATUS).toBe("${{ job.status }}");
+    expect(candidateBinding.outputs?.state).toBe("${{ steps.result.outputs.state }}");
+    expect(workflowStep(candidateBinding, "Enforce candidate acquisition").if).toBe("always()");
+    expect(workflowStep(candidateBinding, "Record candidate acquisition result").run).toContain(
       "state=unavailable",
     );
-    expect(workflowStep(finalize, "Enforce candidate acquisition").run).toContain(
+    expect(workflowStep(candidateBinding, "Enforce candidate acquisition").run).toContain(
       'if [[ "$STATE" == "ready" ]]',
     );
     expect(upload.with?.overwrite).toBe(false);
@@ -4374,6 +4413,116 @@ describe("package artifact reuse", () => {
     );
     expect(legacyTuple.run).not.toContain("candidate_request");
     expect(legacyTuple.run).not.toContain("expiresAt");
+  });
+
+  it.each(["fresh", "reused"])(
+    "resolves and admits a %s candidate without a second job",
+    (source) => {
+      const manifest = fullReleaseCandidateManifestFixture();
+      const expiresAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+      for (const artifact of [
+        manifest.package.artifact,
+        manifest.prepublishPluginRegistry.artifact,
+        manifest.sharedImage.artifact,
+      ]) {
+        artifact.expiresAt = expiresAt;
+      }
+      const binding = buildFullReleaseCandidateBinding({
+        manifest,
+        artifact: fullReleaseCandidateArtifact(
+          `full-release-candidate-v2-${manifest.requestSha256}`,
+          { expiresAt },
+        ),
+      });
+      const resolved = runCandidateAcquisitionStep("Resolve candidate binding", {
+        CANDIDATE_REQUEST_JSON: JSON.stringify(manifest.request),
+        DISCOVERY_STATE: source === "fresh" ? "miss" : "hit",
+        FRESH_CANDIDATE_BINDING_JSON: source === "fresh" ? JSON.stringify(binding) : "",
+        REUSED_CANDIDATE_BINDING_JSON: source === "reused" ? JSON.stringify(binding) : "",
+      });
+      expect(resolved.result.status, resolved.result.stderr).toBe(0);
+      const recorded = runCandidateAcquisitionStep("Record candidate acquisition result", {
+        JOB_STATUS: "success",
+        DISCOVERY_RESULT: "success",
+        DISCOVERY_STATE: source === "fresh" ? "miss" : "hit",
+        PREPARE_RESULT: source === "fresh" ? "success" : "skipped",
+        RESOLVE_RESULT: "success",
+        RESOLVED_STATE: resolved.output.state ?? "",
+        RESOLVED_SOURCE: resolved.output.source ?? "",
+        BINDING_JSON: resolved.output.binding_json ?? "",
+        CANDIDATE_ARTIFACT_JSON: resolved.output.candidate_artifact_json ?? "",
+      });
+      expect(recorded.result.status, recorded.result.stderr).toBe(0);
+      expect(recorded.output).toEqual(resolved.output);
+      expect(JSON.parse(recorded.output.binding_json ?? "")).toEqual(binding);
+      expect(recorded.output.source).toBe(source);
+      expect(JSON.parse(recorded.output.candidate_artifact_json ?? "")).toMatchObject({
+        packageArtifactId: binding.package.artifact.id,
+        packageSha256: binding.package.packageSha256,
+        imageArtifactId: binding.sharedImage.artifact.id,
+        prepublishPluginRegistryArtifactId: binding.prepublishPluginRegistry.artifact.id,
+      });
+      expect(
+        runCandidateAcquisitionStep("Enforce candidate acquisition", {
+          STATE: recorded.output.state ?? "",
+        }).result.status,
+      ).toBe(0);
+    },
+  );
+
+  it.each([
+    ["discovery failure", { DISCOVERY_RESULT: "failure" }],
+    ["unavailable discovery", { DISCOVERY_STATE: "unavailable" }],
+    ["prepare failure", { PREPARE_RESULT: "failure" }],
+    ["prepare cancellation", { PREPARE_RESULT: "cancelled" }],
+    ["checkout failure", { JOB_STATUS: "failure", RESOLVE_RESULT: "skipped" }],
+    ["resolution failure", { JOB_STATUS: "failure", RESOLVE_RESULT: "failure" }],
+    ["resolution cancellation", { JOB_STATUS: "cancelled", RESOLVE_RESULT: "cancelled" }],
+    ["cancellation after resolution", { JOB_STATUS: "cancelled" }],
+    ["missing resolution", { RESOLVE_RESULT: "" }],
+  ] satisfies Array<[string, Record<string, string>]>)(
+    "keeps candidate acquisition unavailable after %s",
+    (_label, failure) => {
+      const recorded = runCandidateAcquisitionStep("Record candidate acquisition result", {
+        JOB_STATUS: "success",
+        DISCOVERY_RESULT: "success",
+        DISCOVERY_STATE: "hit",
+        PREPARE_RESULT: "skipped",
+        RESOLVE_RESULT: "success",
+        RESOLVED_STATE: "ready",
+        RESOLVED_SOURCE: "reused",
+        BINDING_JSON: "must-not-forward",
+        CANDIDATE_ARTIFACT_JSON: "must-not-forward",
+        ...failure,
+      });
+      expect(recorded.result.status, recorded.result.stderr).toBe(0);
+      expect(recorded.output).toEqual({
+        state: "unavailable",
+        source: "",
+        binding_json: "",
+        candidate_artifact_json: "",
+      });
+      expect(
+        runCandidateAcquisitionStep("Enforce candidate acquisition", {
+          STATE: recorded.output.state ?? "",
+        }).result.status,
+      ).toBe(1);
+    },
+  );
+
+  it("rejects malformed candidate resolution and missing terminal output", () => {
+    const resolved = runCandidateAcquisitionStep("Resolve candidate binding", {
+      CANDIDATE_REQUEST_JSON: "{}",
+      DISCOVERY_STATE: "miss",
+      FRESH_CANDIDATE_BINDING_JSON: "",
+      REUSED_CANDIDATE_BINDING_JSON: "",
+    });
+    expect(resolved.result.status).toBe(1);
+    expect(resolved.result.stderr).toContain("exactly one fresh or reused");
+    expect(resolved.output).toEqual({});
+    expect(
+      runCandidateAcquisitionStep("Enforce candidate acquisition", { STATE: "" }).result.status,
+    ).toBe(1);
   });
 
   it("enables prerelease plugin companions for scheduled ref validation", () => {
@@ -9153,7 +9302,6 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     );
     const candidatePrepare = workflowJob(FULL_RELEASE_CANDIDATE_WORKFLOW, "prepare");
     const candidateBinding = workflowJob(FULL_RELEASE_CANDIDATE_WORKFLOW, "resolve_candidate");
-    const candidateFinalize = workflowJob(FULL_RELEASE_CANDIDATE_WORKFLOW, "finalize");
     expect(jobNeeds(workflowJob(FULL_RELEASE_VALIDATION_WORKFLOW, "evidence_reuse"))).toEqual([
       "resolve_target",
     ]);
@@ -9161,7 +9309,6 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     expect(jobNeeds(candidatePrepare)).toEqual(["discover"]);
     expect(candidatePrepare.with?.prepare_only).toBe(true);
     expect(jobNeeds(candidateBinding)).toEqual(["discover", "prepare"]);
-    expect(jobNeeds(candidateFinalize)).toEqual(["discover", "prepare", "resolve_candidate"]);
     expect(jobNeeds(releaseChecksParent)).toEqual([
       "resolve_target",
       "evidence_reuse",
@@ -9181,12 +9328,11 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
         "full",
       ),
       timeoutForProfile(candidateBinding["timeout-minutes"], "full"),
-      timeoutForProfile(candidateFinalize["timeout-minutes"], "full"),
       timeoutForProfile(releaseChecksParent["timeout-minutes"], "full"),
     ];
-    expect(fullParentPath).toEqual([10, 10, 10, 30, 90, 15, 5, 5, 15]);
+    expect(fullParentPath).toEqual([10, 10, 10, 30, 90, 15, 5, 15]);
     const fullParentTimeoutFloor = fullParentPath.reduce((total, timeout) => total + timeout, 0);
-    expect(fullParentTimeoutFloor).toBe(190);
+    expect(fullParentTimeoutFloor).toBe(185);
     expect(FULL_RELEASE_WAIT_TIMEOUT_MINUTES).toBe(diagnosticDrainTimeout);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Full release candidate acquisition schedules an additional runner after binding validation only to copy its outputs and enforce readiness. Candidate-dependent release and plugin checks cannot start until that extra job finishes, so its runner-queue delay sits on the release verification path.

## Why This Change Was Made

Run the existing result projection and readiness enforcement as final steps of the binding job, and remove the separate finalizer job. The acquisition job always records a result when its runner remains available. Checkout and resolution keep their prerequisite guards, and ready outputs require both a successful job and a successful resolution step; failure or cancellation cannot forward partial binding outputs.

Discovery, exact request locking, preparation, package/image/registry digests, producer and publisher verification, permissions, runner labels and resource limits remain unchanged. Both downstream candidate consumers still require acquisition success and ready state. A hard runner loss may prevent result projection entirely; missing outputs remain blocking through the existing acquisition-result and execution-plan checks.

## User Impact

Full release verification removes one serial runner admission without dropping validation or adding concurrency. This is internal release tooling; product runtime behavior does not change. In the current frozen full run, the old finalizer [waited 525 seconds and executed for 3 seconds](https://github.com/openclaw/openclaw/actions/runs/33392987515/job/99517648225). This PR removes that serial boundary. That is an observed cost of the deleted job, not a controlled end-to-end speedup measurement.

## Evidence

The tests-only baseline reproduction fails because the separate finalizer is still present. After the change, 13 focused cases pass and all 328 cases across the complete package-workflow, candidate-contract and candidate-reuse test files pass. These execute the actual YAML shell bodies and real binding resolver for fresh/reused success, discovery/prepare/checkout/resolution failure, cancellation, partial output and missing terminal output. Actionlint passes.

Managed Codex review of the exact two-file diff found no actionable P0-P2 findings. [Native Linux proof](https://github.com/openclaw/openclaw/actions/runs/33396595288) passed all 328 sibling cases (zero skips) in 12.03 seconds and the actual two-path changed-files gate in 114.63 seconds on a four-CPU Node 24.19 runner. Exact changed-source hashes matched before and after; the Testbox is stopped and all owned processes are joined. The changed-files plan did not include workflow validation, so the dedicated canonical workflow checker was run separately and passed locally, including actionlint, zizmor, CI Git ownership and composite interpolation/conflict guards. Exact-head CI passed on df957d0b9407c73653fe40d8ee7970fb451b05cb, including openclaw/ci-gate (148 successful checks; the cancelled label job is unrelated). GitHub scheduling and hard runner shutdown are not simulated by the shell tests; their wiring is checked statically and reviewed against the documented expression semantics.

Product runtime delta: 0. Workflow tooling: 23 additions / 27 removals, net -4. Tests: 155 additions / 9 removals, net +146. The redundant job is deleted; there is one canonical acquisition completion path and no new fallback, configuration option, dependency, timeout or retry.


Named follow-up: the runtime-assets row in the full release validation documentation still describes an obsolete serial prerequisite; adjacent prose and the existing DAG already allow independent fanout. This PR does not change that dispatch policy.
## Hosted output-propagation proof

The [task-only Actions caller](https://github.com/openclaw/openclaw/blob/5fc6007a9e0d1c09602d314566c2b6709e18b836/.github/workflows/frv-candidate-output-proof.yml) invokes the unchanged reusable workflow pinned to this PR's exact head. The caller commit adds only this diagnostic file on top of the reviewed head; it is not part of this PR and will not be merged. The caller passed managed review and canonical actionlint before execution.

- Positive path: real retained-candidate discovery and [resolution succeeded](https://github.com/openclaw/openclaw/actions/runs/33403217138/job/99524485293); preparation was skipped. Propagated readiness, binding, request and artifact identities were checked by the canonical validators before the [actual candidate-dependent dispatch succeeded](https://github.com/openclaw/openclaw/actions/runs/33403217138/job/99524519224).
- Negative path: the same reusable received an intentionally wrong request digest. Discovery and [acquisition enforcement failed](https://github.com/openclaw/openclaw/actions/runs/33403217138/job/99524472355), and the negative consumer was skipped. The final [hosted assertion job passed](https://github.com/openclaw/openclaw/actions/runs/33403217138/job/99524620444), requiring positive success/ready/reused, a dispatched child, negative failure with no binding/artifact outputs, and the blocked consumer.
- The real [plugin candidate child 33403283819](https://github.com/openclaw/openclaw/actions/runs/33403283819) is attempt 1, workflow_dispatch, with the exact expected title and retained tooling SHA 23bd8fb98adce84f6f87c6c4f7c082bbe991e536. Its source matches the retained candidate's artifact contract. It subsequently completed successfully, including the real Docker candidate consumers. This proves downstream consumption as well as dispatch; it is not a full-release validation pass.

The diagnostic's overall conclusion is intentionally **failure** because its bad-digest reusable call must fail; the passing assertion job is the proof of the positive and negative propagation contracts. The receipt artifact was uploaded as candidate-output-proof-33403217138-1, ID 9762092218, digest 957810c325d36a75b81bc9e84bb42fab9072bd65bbdcfe6ca838af4e0071a87a. After GitHub quota recovered, the archive was downloaded, its bytes matched that SHA-256, and the receipt was independently checked against the exact caller/head, positive ready/reused output, negative unavailable/empty output, skipped negative consumer, and successful child run 33403283819. No forced runner-loss test is claimed.

Review disposition: the real Actions trace addresses the three proof-related items and the evidence rank-up move in the current ClawSweeper review. Hard runner loss remains fail-closed through absent outputs and the unchanged consumer/execution-plan checks; local cancellation/missing-output cases remain covered. A second review request is omitted because the existing review is less than 12 hours old, the reviewed code is unchanged, and the missing runtime proof is now supplied.
