### PR TITLE
test(teams): reuse prerequisite setup imports

### DIFF
--- a/extensions/teams-meetings/src/node-host.test.ts
+++ b/extensions/teams-meetings/src/node-host.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const spawnSyncMock = vi.hoisted(() => vi.fn());
 
@@ -29,13 +29,25 @@ function setupParams() {
 }
 
 describe("Teams meeting node-host prerequisite deadline", () => {
-  beforeEach(async () => {
+  beforeAll(async () => {
     vi.resetModules();
+    const platform = vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
+    try {
+      ({ teamsMeetingsConfig } = await import("./config.js"));
+      ({ handleTeamsMeetingsNodeHostCommand } = await import("./node-host.js"));
+    } finally {
+      platform.mockRestore();
+    }
+  });
+
+  beforeEach(() => {
     vi.spyOn(process, "platform", "get").mockReturnValue("darwin");
-    spawnSyncMock.mockReset();
-    spawnSyncMock.mockReturnValue(successfulProbe);
-    ({ teamsMeetingsConfig } = await import("./config.js"));
-    ({ handleTeamsMeetingsNodeHostCommand } = await import("./node-host.js"));
+    spawnSyncMock.mockReset().mockReturnValue(successfulProbe);
+  });
+
+  afterAll(() => {
+    vi.doUnmock("node:child_process");
+    vi.resetModules();
   });
 
   afterEach(() => {


### PR DESCRIPTION
## What Problem This Solves

Four Teams prerequisite setup cases reload the meeting runtime graph before each case even though the setup branch does not create or use a meeting session.

## Why This Change Was Made

Import the node host once under an explicit Darwin platform spy, restore that import-time spy immediately, and retain independent platform, clock, and spawn behavior for every case. Config still selects Darwin defaults at import, while per-call backend selection observes each case’s platform setup. Suite teardown releases module and mock state.

## User Impact

No runtime behavior change. The four prerequisite cases keep their shared deadline, probe deduplication, stop-after-deadline, and profiler-timeout distinctions while eliminating three repeated module graph evaluations. This removes repeated setup work; no end-to-end timing claim is made because the shared import now runs in beforeAll.

## Evidence

```text
node scripts/run-vitest.mjs extensions/teams-meetings/src/node-host.test.ts src/meeting-bot/configured-node-host.test.ts extensions/google-meet/node-host.test.ts
```

```json
{"numPassedTests":19,"numFailedTests":0,"numPendingTests":0,"success":true}
```

All four Teams cases and fifteen shared/Google Meet siblings pass together. Shared prerequisites, Linux command configuration, live bridge ownership, termination escalation and cleanup remain covered. Teams case execution decreased locally from 3913.3 ms to 13.6 ms, but that excludes the one-time import now performed by beforeAll; the deterministic reduction is three module graph evaluations.

Production +0/-0; tests +18/-6. Full changed-file validation, formatting, diff check and structured Codex autoreview pass. Exact-head CI is required before landing.

### ClawSweeper proof follow-up

Maintainer scope decision: skip a nonmocked node-host hardware setup for this test-only PR. At `2620cd78754a4f6e5340b80d3495859cd180bc10`, the only changed file is `extensions/teams-meetings/src/node-host.test.ts` (production +0/-0). The risk is the test fixture's import and mock lifetime. A real machine's BlackHole/SoX availability does not exercise that changed fixture boundary. The real `setup` branch and its audio prerequisite owner are unchanged; this work does not claim a successful hardware, Gateway, or live meeting setup.

The existing after-change native report is reused here, with all nineteen cases passing: four Teams deadline/probe cases, two shared configured-node-host cases, and thirteen Google Meet lifecycle cases. The four exact Teams result entries are below; this addendum does not claim a new test run. The current managed checkout was separately verified clean at the exact PR head.

```json
{
  "success": true,
  "numTotalTests": 19,
  "numPassedTests": 19,
  "numFailedTests": 0,
  "numPendingTests": 0,
  "numTodoTests": 0,
  "testResults": [
    {
      "name": "extensions/teams-meetings/src/node-host.test.ts",
      "status": "passed",
      "assertionResults": [
        {
          "fullName": "Teams meeting node-host prerequisite deadline shares one timeout budget across every prerequisite probe",
          "status": "passed",
          "duration": 12.367417000000387,
          "failureMessages": []
        },
        {
          "fullName": "Teams meeting node-host prerequisite deadline probes the default sox executable only once",
          "status": "passed",
          "duration": 0.4519170000003214,
          "failureMessages": []
        },
        {
          "fullName": "Teams meeting node-host prerequisite deadline does not start another probe after the shared deadline expires",
          "status": "passed",
          "duration": 0.642917000000125,
          "failureMessages": []
        },
        {
          "fullName": "Teams meeting node-host prerequisite deadline reports a timed-out profiler separately from a missing audio device",
          "status": "passed",
          "duration": 0.31883300000026793,
          "failureMessages": []
        }
      ]
    }
  ]
}
```

The installed dependency contract was inspected directly at Vitest **4.1.11** and `@vitest/spy` **4.1.11**. `vitest/dist/chunks/test.DNmyFkvJ.js:3654–3656` calls `resetModules` without `resetMocks`; `vitest/dist/chunks/utils.BX5Fg8C4.js:29–42` defaults that argument to false and preserves mock modules while invalidating evaluated ordinary modules. Suite teardown separately queues `doUnmock` at `test.DNmyFkvJ.js:3585–3589` before its module reset. In `@vitest/spy/dist/index.js:142–157`, `mockReset()` clears call/results state and queued one-shot implementations and resets the base implementation. `restoreAllMocks()` at lines 467–472 restores registered property descriptors; it does not replace the explicit per-case `spawnSyncMock.mockReset()`.

Those contracts match the fixture: the shared import runs under Darwin and restores its import-time spy in `finally`; every case gets a new Darwin spy and a reset spawn mock; `afterEach` restores the Date/platform descriptors. All original assertions remain, including the `[10000,7000,3000]` shared budgets, one SoX executable probe, no next probe after expiry, and the profiler timeout diagnostic. No host setup or service changes were performed for this addendum.
