### PR TITLE
fix(talk): detach agent consult dispatch from retired root admission

### DIFF
--- a/src/gateway/talk-agent-consult.admission.test.ts
+++ b/src/gateway/talk-agent-consult.admission.test.ts
@@ -1,0 +1,89 @@
+// Talk agent consult admission tests: the realtime provider fires consults
+// long after the voice session's creating request has released its gateway
+// root admission, and in-process callbacks still inherit that retired root
+// through async context. The consult dispatch must detach from it so agent
+// work re-enters admission instead of being rejected as subordinate work of
+// a closed root (issue #134081).
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  isGatewaySubordinateWorkAdmissionClosed,
+  resetGatewayWorkAdmission,
+  tryBeginGatewayRootWorkAdmission,
+} from "../process/gateway-work-admission.js";
+
+const dispatchCalls = vi.hoisted(() => ({
+  chatSend: vi.fn(),
+  chatSendWithRuntimeTools: vi.fn(),
+}));
+
+vi.mock("./server-methods/chat-send-handler.js", () => ({
+  handleChatSend: dispatchCalls.chatSend,
+  handleChatSendWithRuntimeTools: dispatchCalls.chatSendWithRuntimeTools,
+}));
+
+import { startTalkRealtimeAgentConsult } from "./talk-agent-consult.js";
+
+type CapturedChatSendOptions = {
+  params: Record<string, unknown>;
+  respond: (ok: boolean, result?: unknown, error?: unknown) => void;
+};
+
+function consultParams() {
+  return {
+    context: {
+      getRuntimeConfig: () => ({}),
+      logGateway: { warn: vi.fn() },
+    },
+    client: null,
+    isWebchatConnect: () => false,
+    requestId: "req-1",
+    sessionKey: "agent:main:main",
+    callId: "call-1",
+    args: { question: "What changed in the Dockerfile?" },
+  };
+}
+
+describe("startTalkRealtimeAgentConsult admission boundary", () => {
+  beforeEach(() => {
+    resetGatewayWorkAdmission();
+    dispatchCalls.chatSend.mockReset();
+    dispatchCalls.chatSendWithRuntimeTools.mockReset();
+  });
+
+  it("dispatches agent work that is not subordinate to a released root admission", async () => {
+    let admissionClosedAtDispatch: boolean | undefined;
+    dispatchCalls.chatSendWithRuntimeTools.mockImplementation(
+      (options: CapturedChatSendOptions) => {
+        admissionClosedAtDispatch = isGatewaySubordinateWorkAdmissionClosed();
+        options.respond(true, { status: "started", runId: "run-consult-1" });
+        return Promise.resolve();
+      },
+    );
+
+    const lease = tryBeginGatewayRootWorkAdmission();
+    expect(lease).not.toBeNull();
+    await lease!.run(async () => {
+      // The creating request completes (releasing its root) while the
+      // long-lived realtime callback chain survives and fires a consult.
+      lease!.release();
+      const result = await startTalkRealtimeAgentConsult(consultParams());
+      expect(result).toMatchObject({ ok: true, runId: "run-consult-1" });
+    });
+
+    expect(admissionClosedAtDispatch).toBe(false);
+  });
+
+  it("still starts a normal consult run when no root admission is inherited", async () => {
+    dispatchCalls.chatSendWithRuntimeTools.mockImplementation(
+      (options: CapturedChatSendOptions) => {
+        options.respond(true, { status: "started", runId: "run-consult-2" });
+        return Promise.resolve();
+      },
+    );
+
+    const result = await startTalkRealtimeAgentConsult(consultParams());
+
+    expect(result).toMatchObject({ ok: true, runId: "run-consult-2" });
+    expect(isGatewaySubordinateWorkAdmissionClosed()).toBe(false);
+  });
+});

--- a/src/gateway/talk-agent-consult.ts
+++ b/src/gateway/talk-agent-consult.ts
@@ -8,6 +8,7 @@ import {
   type ErrorShape,
 } from "../../packages/gateway-protocol/src/index.js";
 import { normalizeTalkSection } from "../config/talk.js";
+import { runOutsideGatewayRootWorkAdmission } from "../process/gateway-work-admission.js";
 import { buildRealtimeVoiceAgentConsultChatMessage } from "../talk/agent-consult-tool.js";
 import { abortChatRunById } from "./chat-abort.js";
 import {
@@ -57,10 +58,7 @@ function terminalTalkChatSendAckError(status: TalkChatSendAckStatus): ErrorShape
   return undefined;
 }
 
-/**
- * Starts the agent-consult chat run that backs realtime Talk tool calls.
- */
-export async function startTalkRealtimeAgentConsult(params: {
+type TalkRealtimeAgentConsultParams = {
   context: GatewayRequestContext;
   client: GatewayClient | null;
   isWebchatConnect: (params: ConnectParams | null | undefined) => boolean;
@@ -71,9 +69,26 @@ export async function startTalkRealtimeAgentConsult(params: {
   relaySessionId?: string;
   connId?: string;
   onRunStarted?: (runId: string) => void;
-}): Promise<
-  { ok: true; runId: string; idempotencyKey: string } | { ok: false; error: ErrorShape }
-> {
+};
+
+/**
+ * Starts the agent-consult chat run that backs realtime Talk tool calls.
+ *
+ * Realtime providers invoke the consult long after the request that created
+ * the voice session has released its gateway root admission, and in-process
+ * callbacks still inherit that retired root through async context. Dispatch
+ * outside the inherited root so agent work re-enters admission on its own
+ * instead of being rejected as subordinate work of a closed root.
+ */
+export async function startTalkRealtimeAgentConsult(
+  params: TalkRealtimeAgentConsultParams,
+): Promise<{ ok: true; runId: string; idempotencyKey: string } | { ok: false; error: ErrorShape }> {
+  return runOutsideGatewayRootWorkAdmission(() => startTalkRealtimeAgentConsultDetached(params));
+}
+
+async function startTalkRealtimeAgentConsultDetached(
+  params: TalkRealtimeAgentConsultParams,
+): Promise<{ ok: true; runId: string; idempotencyKey: string } | { ok: false; error: ErrorShape }> {
   let message: string;
   try {
     message = buildRealtimeVoiceAgentConsultChatMessage(params.args);


### PR DESCRIPTION
## What Problem This Solves

Browser Talk consults fail with `Gateway is draining; new tasks are not accepted` after the realtime session's creating request has finished. The realtime provider fires the `openclaw_agent_consult` callback long after that request released its gateway root admission, but the in-process callback chain still inherits the retired root through async context. Subordinate admission checks then see the inherited root as closed, reject the consult's agent dispatch, and the voice layer enters a retry loop where every attempt fails the same way.

## Why This Change Was Made

`startTalkRealtimeAgentConsult` ran inside whatever admission context the callback inherited. For a retired root, `isGatewaySubordinateWorkAdmissionClosed()` reports closed even while the gateway is globally healthy, so the consult is never dispatched. The consult is provider-driven work that begins a new agent run; it should re-enter admission on its own instead of riding a root that no longer exists.

## Changes

- **`src/gateway/talk-agent-consult.ts`** — dispatch the consult through `runOutsideGatewayRootWorkAdmission(...)`, detaching it from the inherited (and possibly retired) root admission context. Agent dispatch then begins a fresh root as it would for any other independent work; behavior under restart drain or suspension is unchanged because the independent-root fence still applies inside the detached context.
- **`src/gateway/talk-agent-consult.admission.test.ts`** — regression coverage following the issue's RED/GREEN shape: inside a released root admission context, the consult dispatch observes admission as open and the run starts; the test fails without the boundary change.

## Evidence

- `startTalkRealtimeAgentConsult.admission` test: with a root lease released while its async chain survives, the dispatch observes `isGatewaySubordinateWorkAdmissionClosed() === false` and the run starts; without the change the same test observes the closed inherited root (RED verified by reverting the dispatch boundary).
- Existing Talk consult suites (`talk-client.test.ts`, `talk-client-gateway-control.agent-consult.test.ts`) pass unchanged.
- Same admission-boundary pattern is already established for other process-lifetime work: `ingress-drain.ts`, `timer-scheduler.ts`, and `request-start.ts` all use `runOutsideGatewayRootWorkAdmission(...)`.

## Related

Fixes #134081
