### PR TITLE
test(browser): consolidate trash behavior at the SDK owner

### DIFF
--- a/extensions/browser/src/browser/trash.test.ts
+++ b/extensions/browser/src/browser/trash.test.ts
@@ -1,8 +1,7 @@
-// Browser tests cover trash plugin behavior.
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const browserUtilsMock = vi.hoisted(() => ({ configDir: "/tmp/openclaw-state" }));
 const realMkdirSync = fs.mkdirSync.bind(fs);
@@ -17,16 +16,17 @@ vi.mock("../utils.js", () => ({
   },
 }));
 
-function mockTrashContainer(...suffixes: string[]) {
-  let call = 0;
-  return vi.spyOn(fs, "mkdtempSync").mockImplementation((prefix) => {
-    const suffix = suffixes[call] ?? "secure";
-    call += 1;
-    const container = `${prefix}${suffix}`;
-    realMkdirSync(container, { recursive: true });
-    return container;
-  });
-}
+let movePathToTrash: typeof import("./trash.js").movePathToTrash;
+
+beforeAll(async () => {
+  vi.resetModules();
+  ({ movePathToTrash } = await import("./trash.js"));
+});
+
+afterAll(() => {
+  vi.doUnmock("../utils.js");
+  vi.resetModules();
+});
 
 describe("browser trash", () => {
   let testRoot = "";
@@ -35,7 +35,6 @@ describe("browser trash", () => {
 
   beforeEach(() => {
     vi.restoreAllMocks();
-    vi.resetModules();
     testRoot = realRealpathSyncNative(realMkdtempSync(path.join(os.tmpdir(), "openclaw-browser-")));
     configDir = path.join(testRoot, "state");
     homeDir = path.join(testRoot, "home", "test");
@@ -56,39 +55,13 @@ describe("browser trash", () => {
     }
   });
 
-  function writeTrashTarget(name = "demo"): string {
-    const browserDir = path.join(configDir, "browser");
-    realMkdirSync(browserDir, { recursive: true });
-    const target = path.join(browserDir, name);
-    realWriteFileSync(target, "demo");
-    return target;
-  }
-
-  it("moves paths to a reserved user trash container without invoking a PATH-resolved command", async () => {
-    const { movePathToTrash } = await import("./trash.js");
-    const mkdirSync = vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
-    const mkdtempSync = mockTrashContainer("secure");
-    const renameSync = vi.spyOn(fs, "renameSync").mockImplementation(() => undefined);
-    const cpSync = vi.spyOn(fs, "cpSync");
-    const rmSync = vi.spyOn(fs, "rmSync");
-    const target = writeTrashTarget();
-    const expected = path.join(homeDir, ".Trash", "demo-123-secure", "demo");
-
-    await expect(movePathToTrash(target)).resolves.toBe(expected);
-    expect(mkdirSync).toHaveBeenCalledWith(path.join(homeDir, ".Trash"), {
-      recursive: true,
-      mode: 0o700,
-    });
-    expect(mkdtempSync).toHaveBeenCalledWith(path.join(homeDir, ".Trash", "demo-123-"));
-    expect(renameSync).toHaveBeenCalledWith(target, expected);
-    expect(cpSync).not.toHaveBeenCalled();
-    expect(rmSync).not.toHaveBeenCalled();
-  });
-
-  it("allows managed browser data under a configured state directory outside home and temp", async () => {
-    const { movePathToTrash } = await import("./trash.js");
+  it("allows managed browser data under a configured state directory outside home", async () => {
     vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
-    mockTrashContainer("secure");
+    vi.spyOn(fs, "mkdtempSync").mockImplementation((prefix) => {
+      const container = `${prefix}secure`;
+      realMkdirSync(container, { recursive: true });
+      return container;
+    });
     const renameSync = vi.spyOn(fs, "renameSync").mockImplementation(() => undefined);
     const target = path.join(configDir, "browser", "constructor");
     realMkdirSync(target, { recursive: true });
@@ -99,7 +72,6 @@ describe("browser trash", () => {
   });
 
   it("does not authorize other configured-state paths", async () => {
-    const { movePathToTrash } = await import("./trash.js");
     const target = path.join(configDir, "credentials", "token.json");
     realMkdirSync(path.dirname(target), { recursive: true });
     realWriteFileSync(target, "secret");
@@ -111,7 +83,6 @@ describe("browser trash", () => {
 
   it("does not grant arbitrary filesystem authority for a root config directory", async () => {
     browserUtilsMock.configDir = path.parse(testRoot).root;
-    const { movePathToTrash } = await import("./trash.js");
     const target = path.join(testRoot, "outside-root-browser");
     realWriteFileSync(target, "outside");
 
@@ -121,7 +92,6 @@ describe("browser trash", () => {
   });
 
   it("rejects browser-subtree symlinks that escape the configured state directory", async () => {
-    const { movePathToTrash } = await import("./trash.js");
     const browserDir = path.join(configDir, "browser");
     const outsideDir = path.join(testRoot, "outside-profile");
     realMkdirSync(browserDir, { recursive: true });
@@ -132,142 +102,5 @@ describe("browser trash", () => {
     await expect(movePathToTrash(target)).rejects.toThrow(
       "Refusing to trash path outside allowed roots",
     );
-  });
-
-  it("uses the resolved trash directory for reserved destinations", async () => {
-    const { movePathToTrash } = await import("./trash.js");
-    vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
-    const resolvedHomeDir = path.join(testRoot, "real", "home", "test");
-    const resolvedTrashDir = path.join(resolvedHomeDir, ".Trash");
-    realMkdirSync(resolvedTrashDir, { recursive: true, mode: 0o700 });
-    vi.spyOn(fs.realpathSync, "native").mockImplementation((candidate) => {
-      const value = String(candidate);
-      if (value === homeDir) {
-        return resolvedHomeDir;
-      }
-      if (value === path.join(homeDir, ".Trash")) {
-        return resolvedTrashDir;
-      }
-      return realRealpathSyncNative(candidate);
-    });
-    const mkdtempSync = mockTrashContainer("secure");
-    const renameSync = vi.spyOn(fs, "renameSync").mockImplementation(() => undefined);
-    const target = writeTrashTarget();
-    const expected = path.join(resolvedTrashDir, "demo-123-secure", "demo");
-
-    await expect(movePathToTrash(target)).resolves.toBe(expected);
-    expect(mkdtempSync).toHaveBeenCalledWith(path.join(resolvedTrashDir, "demo-123-"));
-    expect(renameSync).toHaveBeenCalledWith(target, expected);
-  });
-
-  it("refuses to trash filesystem roots", async () => {
-    const { movePathToTrash } = await import("./trash.js");
-
-    await expect(movePathToTrash("/")).rejects.toThrow("Refusing to trash root path");
-  });
-
-  it("refuses to trash paths outside allowed roots", async () => {
-    const { movePathToTrash } = await import("./trash.js");
-    const outsideDir = path.join(testRoot, "outside");
-    realMkdirSync(outsideDir, { recursive: true });
-    const outsidePath = path.join(outsideDir, "openclaw-demo");
-    realWriteFileSync(outsidePath, "outside");
-
-    await expect(movePathToTrash(outsidePath)).rejects.toThrow(
-      "Refusing to trash path outside allowed roots",
-    );
-  });
-
-  it("refuses to use a symlinked trash directory", async () => {
-    const { movePathToTrash } = await import("./trash.js");
-    const realTrashDir = path.join(testRoot, "real-trash");
-    realRmSync(path.join(homeDir, ".Trash"), { recursive: true, force: true });
-    realMkdirSync(realTrashDir, { recursive: true, mode: 0o700 });
-    fs.symlinkSync(realTrashDir, path.join(homeDir, ".Trash"), "dir");
-    vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
-
-    await expect(movePathToTrash(writeTrashTarget())).rejects.toThrow(
-      "Refusing to use non-directory/symlink trash directory",
-    );
-  });
-
-  it("falls back to copy and remove when rename crosses filesystems", async () => {
-    const { movePathToTrash } = await import("./trash.js");
-    const exdev = Object.assign(new Error("cross-device"), { code: "EXDEV" });
-    vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
-    mockTrashContainer("secure");
-    vi.spyOn(fs, "renameSync").mockImplementation(() => {
-      throw exdev;
-    });
-    const cpSync = vi.spyOn(fs, "cpSync").mockImplementation(() => undefined);
-    const rmSync = vi.spyOn(fs, "rmSync").mockImplementation(() => undefined);
-    const target = writeTrashTarget();
-    const expected = path.join(homeDir, ".Trash", "demo-123-secure", "demo");
-
-    await expect(movePathToTrash(target)).resolves.toBe(expected);
-    expect(cpSync).toHaveBeenCalledWith(target, expected, {
-      recursive: true,
-      force: false,
-      errorOnExist: true,
-    });
-    expect(rmSync).toHaveBeenCalledWith(target, { recursive: true, force: false });
-  });
-
-  it("retries copy fallback when the copy destination is created concurrently", async () => {
-    const { movePathToTrash } = await import("./trash.js");
-    const exdev = Object.assign(new Error("cross-device"), { code: "EXDEV" });
-    const copyCollision = Object.assign(new Error("copy exists"), {
-      code: "ERR_FS_CP_EEXIST",
-    });
-    vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
-    mockTrashContainer("first", "second");
-    vi.spyOn(fs, "renameSync").mockImplementation(() => {
-      throw exdev;
-    });
-    const cpSync = vi
-      .spyOn(fs, "cpSync")
-      .mockImplementationOnce(() => {
-        throw copyCollision;
-      })
-      .mockImplementation(() => undefined);
-    const rmSync = vi.spyOn(fs, "rmSync").mockImplementation(() => undefined);
-    const target = writeTrashTarget();
-    const first = path.join(homeDir, ".Trash", "demo-123-first", "demo");
-    const second = path.join(homeDir, ".Trash", "demo-123-second", "demo");
-
-    await expect(movePathToTrash(target)).resolves.toBe(second);
-    expect(cpSync).toHaveBeenNthCalledWith(1, target, first, {
-      recursive: true,
-      force: false,
-      errorOnExist: true,
-    });
-    expect(cpSync).toHaveBeenNthCalledWith(2, target, second, {
-      recursive: true,
-      force: false,
-      errorOnExist: true,
-    });
-    expect(rmSync).toHaveBeenCalledTimes(1);
-    expect(Date.now).toHaveBeenCalledTimes(1);
-  });
-
-  it("retries with the same timestamp when the destination is created concurrently", async () => {
-    const { movePathToTrash } = await import("./trash.js");
-    const collision = Object.assign(new Error("exists"), { code: "EEXIST" });
-    vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
-    mockTrashContainer("first", "second");
-    const renameSync = vi
-      .spyOn(fs, "renameSync")
-      .mockImplementationOnce(() => {
-        throw collision;
-      })
-      .mockImplementation(() => undefined);
-    const target = writeTrashTarget();
-    const first = path.join(homeDir, ".Trash", "demo-123-first", "demo");
-    const second = path.join(homeDir, ".Trash", "demo-123-second", "demo");
-
-    await expect(movePathToTrash(target)).resolves.toBe(second);
-    expect(renameSync).toHaveBeenNthCalledWith(1, target, first);
-    expect(renameSync).toHaveBeenNthCalledWith(2, target, second);
-    expect(Date.now).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/plugin-sdk/browser-maintenance.test.ts
+++ b/src/plugin-sdk/browser-maintenance.test.ts
@@ -206,11 +206,11 @@ describe("browser maintenance", () => {
   });
 
   it("refuses to use a symlinked trash directory", async () => {
+    const realTrashDir = path.join(testRoot, "real-trash");
+    realRmSync(path.join(homeDir, ".Trash"), { recursive: true, force: true });
+    realMkdirSync(realTrashDir, { recursive: true, mode: 0o700 });
+    fs.symlinkSync(realTrashDir, path.join(homeDir, ".Trash"), "dir");
     vi.spyOn(fs, "mkdirSync").mockImplementation(() => undefined);
-    vi.spyOn(fs, "lstatSync").mockReturnValue({
-      isDirectory: () => true,
-      isSymbolicLink: () => true,
-    } as fs.Stats);
 
     const { movePathToTrash } = await import("./browser-maintenance.js");
 


### PR DESCRIPTION
## What Problem This Solves

The Browser trash wrapper suite repeats eight generic filesystem scenarios owned by the SDK, creating duplicate fixtures and repeated module reloads. Consolidating that coverage also needs to preserve the plugin's real symlink fixture, which is stronger than the SDK's mocked file metadata.

## Why This Change Was Made

Keep the four Browser-owned authority cases: configured-state access, rejection of other configured-state paths, root-config restriction, and escaping subtree symlinks. Let the existing SDK suite own generic trash behavior, and replace its mocked `.Trash` metadata with the plugin's real directory symlink fixture and the same rejection assertion. Load the stateless wrapper once while keeping independent filesystem/home fixtures and the live CONFIG_DIR getter. Name the configured-state case "outside home" to match its actual fixture under real temp.

## User Impact

No runtime behavior or filesystem authority change. Eight duplicate plugin cases are removed; the SDK retains all eight generic trash cases, including the real symlink rejection. The four Browser policy cases and four SDK facade cases remain. The deterministic saving is eight duplicate cases and eleven repeated wrapper imports; no end-to-end timing claim is made.

## Evidence

Production +0/-0; tests +22/-189 (net -167). SDK case count stays twelve; combined case count falls from 24 to 16.

- Complete assertion mapping confirmed eight generic scenarios remain in the SDK suite, including destination reservation/resolution, root and allowed-root refusal, real symlink rejection, EXDEV copy/remove and both collision paths. Reserved-container coverage also asserts no process execution.
- `node scripts/run-vitest.mjs extensions/browser/src/browser/trash.test.ts src/plugin-sdk/browser-maintenance.test.ts` passed all sixteen cases with zero failures or skips. This runs the retained policy cases and their shared owner together, including the actual `.Trash` directory symlink.
- `OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs -- extensions/browser/src/browser/trash.test.ts src/plugin-sdk/browser-maintenance.test.ts` passed core/plugin typechecks, lint, formatting, SDK/boundary checks and repository guards.
- Diff check and independent structured Codex autoreview passed. Exact-head required CI passed on the unchanged head; see the CI investigation below.

The baseline Browser suite took 175.5 ms in test bodies; the retained Browser cases took 48.6 ms and the SDK suite 69.8 ms locally. Suite setup and import costs differ, so these are observations rather than an end-to-end benchmark.

### Exact-head filesystem fixture proof

Addressing the [ClawSweeper proof request](https://github.com/openclaw/openclaw/pull/134151#issuecomment-5479383452): independently reran both focused suites at `46ee0bbfdd319a29d177faf46693ded4bc996cce` on macOS with Node `v24.19.0`. The worktree was clean before and after the run, with the head unchanged. The command completed on 2026-08-31 at 14:07:44 UTC with exit code 0: **16 tests passed, zero failed, pending, or todo** across the SDK and Browser plugin files. Both native shard records finished on their first attempt with no timeout or signal.

Output path is redacted below.

```sh
node scripts/run-vitest.mjs \
  extensions/browser/src/browser/trash.test.ts \
  src/plugin-sdk/browser-maintenance.test.ts \
  --reporter=verbose --reporter=json \
  --outputFile=<local-report>
```

Selected verbatim terminal lines:

```text
[test] starting test/vitest/vitest.plugin-sdk.config.ts
 ✓ |plugin-sdk| src/plugin-sdk/browser-maintenance.test.ts > browser maintenance > refuses to use a symlinked trash directory 2ms
 Test Files  1 passed (1)
      Tests  12 passed (12)
[test] starting test/vitest/vitest.extension-browser.config.ts
 ✓ |extension-browser| extensions/browser/src/browser/trash.test.ts > browser trash > rejects browser-subtree symlinks that escape the configured state directory 2ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
[test] passed 2 Vitest shards in 7.03s
```

Selected fields from the repository wrapper's native aggregate JSON are reproduced below. Only the local checkout prefix in file names was removed; results, names, durations, and failure arrays are unchanged. The native per-shard JSON/blob reports and process-outcome index were also retained.

```json
{
  "success": true,
  "numTotalTests": 16,
  "numPassedTests": 16,
  "numFailedTests": 0,
  "numPendingTests": 0,
  "numTodoTests": 0,
  "testResults": [
    {
      "name": "src/plugin-sdk/browser-maintenance.test.ts",
      "status": "passed",
      "assertionResults": [
        {
          "fullName": "browser maintenance refuses to use a symlinked trash directory",
          "status": "passed",
          "duration": 1.8950419999999895,
          "failureMessages": []
        }
      ]
    },
    {
      "name": "extensions/browser/src/browser/trash.test.ts",
      "status": "passed",
      "assertionResults": [
        {
          "fullName": "browser trash rejects browser-subtree symlinks that escape the configured state directory",
          "status": "passed",
          "duration": 1.6691670000000158,
          "failureMessages": []
        }
      ]
    }
  ]
}
```

The [SDK symlink case](https://github.com/openclaw/openclaw/blob/46ee0bbfdd319a29d177faf46693ded4bc996cce/src/plugin-sdk/browser-maintenance.test.ts#L208) creates a real temporary directory and a real `.Trash` directory symlink, then exercises the SDK's production trash helper with real `lstatSync` metadata. It asserts the exact `Refusing to use non-directory/symlink trash directory` rejection. The case retains its existing no-op `mkdirSync` stub; the suite's rename/copy/collision fault cases also retain their explicit mocks. This is filesystem-boundary fixture proof, not an end-to-end operator trash workflow. The retained Browser escaping-subtree symlink check passed in the same focused invocation.

The wrapper reported two non-fatal Vite import-analysis warnings during native report aggregation; both test shards and the report merge exited 0. Required exact-head CI is tracked separately.

### CI failure investigation

The first exact-head CI run failed in the unrelated auto-reply shard: [run 33399018439, job 99516303873](https://github.com/openclaw/openclaw/actions/runs/33399018439/job/99516303873). In `src/auto-reply/reply/agent-runner.media-paths.test.ts`, the first prepared-owner MEDIA case hit the existing 120,000 ms timeout; the verbose reporter recorded 163,993 ms elapsed. The following global-owner case observed two embedded-run mock calls instead of one. The other 292 cases passed. This PR changes only the Browser trash and SDK maintenance tests; neither changed file is included in that shard.

Two unchanged-source local runs at head `46ee0bbfdd319a29d177faf46693ded4bc996cce` passed:

- The complete media-paths file: 14 passed, 0 failed or skipped; 86.379 s command elapsed. The repository wrapper selected `test/vitest/vitest.auto-reply.config.ts`.
- The original hosted shard: 19 files and 294 cases passed, 0 failed or skipped; 126.503 s command elapsed (124.88 s native Vitest duration). Every emitted case name and its execution order matched the original CI log. The canonical `test/vitest/vitest.auto-reply-reply.config.ts` retained serial, non-isolated threads and the 120,000 ms timeout. A scratch config imported that unchanged canonical config and supplied only a sequencer that asserted exact membership/settings and restored the recorded CI file order.

The shard's native report excerpt is:

```json
{
  "numTotalTests": 294,
  "numPassedTests": 294,
  "numFailedTests": 0,
  "numPendingTests": 0,
  "success": true
}
```

Both runs used Node v24.19.0 on macOS with existing local caches retained; CI used Blacksmith Ubuntu 24.04. They do not establish Linux or cold-cache equivalence. No repository source, fixture, mock, assertion, isolation setting or timeout was changed. The worktree stayed clean at the same head. An initial scratch sequencer CLI launch failed before executing any tests because the installed Vitest API required a constructor; its zero-test launch artifacts were preserved separately and are not counted as test proof.

**Named follow-up: Auto-reply first invocation preparation cost and timeout disposal.** The first MEDIA case took 61,562.538 ms in the file run and 62,262.328 ms in the original-order run; the next case took 320.054 ms and 299.881 ms respectively. Existing artifacts have case durations and aggregate setup/import timing, but no operation trace that identifies the expensive preparation or execution boundary. Late completion crossing into the following row is a hypothesis, not a demonstrated cause. A recurrence needs original-order timestamps and invocation ownership at the preparation, execution and cleanup boundaries before a source repair. The evidence does not justify broader mocks, weaker assertions or larger timeouts.

After reviewing the original failure and both local proofs, the maintainer requested one failed-job retry of the same CI run at 15:09 UTC on August 31, 2026. Attempt 2 completed successfully at 15:14:04 UTC on the unchanged head, with the required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33399018439/job/99537735969) passing. No source changes were needed for the retry.
