### PR TITLE
fix(ui): unread badge clears when session opens

### DIFF
--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -448,6 +448,8 @@ export type SessionsPatchResult = SessionsPatchResultBase<{
   permissionMode?: GatewaySessionRow["permissionMode"];
   archivedAt?: number;
   archiveReason?: SessionEntryArchiveReason;
+  /** Present only while an explicit mark-unread marker owns the row. */
+  markedUnreadAt?: number;
   contextWindow?: string;
   thinkingLevel?: string;
   fastMode?: FastMode;

--- a/ui/src/e2e/session-management.unread.e2e.test.ts
+++ b/ui/src/e2e/session-management.unread.e2e.test.ts
@@ -50,7 +50,7 @@ suite.define(() => {
       const unreadDot = unreadRow.locator(".session-unread-dot");
       await unreadRow.waitFor({ state: "visible", timeout: 10_000 });
       await unreadDot.waitFor({ state: "visible" });
-      await captureUiProof(page, "optimistic-read-before.png");
+      await captureUiProof(suite, page, "optimistic-read-before.png");
       const listRequestsBefore = (await gateway.getRequests("sessions.list")).length;
       const patchRequestsBefore = (await gateway.getRequests("sessions.patch")).length;
 
@@ -64,13 +64,13 @@ suite.define(() => {
       await unreadDot.waitFor({ state: "hidden", timeout: 2_000 });
       expect((await gateway.getRequests("sessions.patch")).length - patchRequestsBefore).toBe(1);
       expect((await gateway.getRequests("sessions.list")).length - listRequestsBefore).toBe(0);
-      await captureUiProof(page, "optimistic-read-in-flight.png");
+      await captureUiProof(suite, page, "optimistic-read-in-flight.png");
 
       await gateway.resolveDeferred("sessions.patch");
       patchHeld = false;
       await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(unreadKey));
       await unreadDot.waitFor({ state: "hidden" });
-      await captureUiProof(page, "optimistic-read-settled.png");
+      await captureUiProof(suite, page, "optimistic-read-settled.png");
     } finally {
       if (patchHeld) {
         await gateway.resolveDeferred("sessions.patch").catch(() => undefined);

--- a/ui/src/e2e/session-management.unread.e2e.test.ts
+++ b/ui/src/e2e/session-management.unread.e2e.test.ts
@@ -18,6 +18,67 @@ import {
 const suite = createSessionManagementE2eSuite();
 
 suite.define(() => {
+  it("clears an unread badge before the acknowledgement round trip", async () => {
+    const unreadKey = "agent:main:optimistic-read";
+    const otherKey = "agent:main:optimistic-other";
+    const context = await suite.browser.newContext({
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      featureCapabilities: [GATEWAY_SERVER_CAPS.SESSION_UNREAD_ACK_CONTRACT],
+      methodResponses: {
+        "sessions.list": sessionsListResponse([
+          sessionRow(unreadKey, "Unread thread", 20, {
+            markedUnreadAt: 1_800_000_000_001,
+            unread: true,
+          }),
+          sessionRow(otherKey, "Other thread", 10, { unread: false }),
+        ]),
+        "sessions.patch": {},
+      },
+      sessionKey: otherKey,
+    });
+    let patchHeld = false;
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, otherKey));
+      const unreadRow = page.locator(`[data-session-key="${unreadKey}"]`);
+      const unreadDot = unreadRow.locator(".session-unread-dot");
+      await unreadRow.waitFor({ state: "visible", timeout: 10_000 });
+      await unreadDot.waitFor({ state: "visible" });
+      await captureUiProof(page, "optimistic-read-before.png");
+      const listRequestsBefore = (await gateway.getRequests("sessions.list")).length;
+      const patchRequestsBefore = (await gateway.getRequests("sessions.patch")).length;
+
+      await gateway.deferNext("sessions.patch", { key: unreadKey, unread: false });
+      await unreadRow.getByRole("link").evaluate((element) => {
+        (element as HTMLElement).click();
+      });
+      await waitForPatch(gateway, (params) => params.key === unreadKey && params.unread === false);
+      patchHeld = true;
+
+      await unreadDot.waitFor({ state: "hidden", timeout: 2_000 });
+      expect((await gateway.getRequests("sessions.patch")).length - patchRequestsBefore).toBe(1);
+      expect((await gateway.getRequests("sessions.list")).length - listRequestsBefore).toBe(0);
+      await captureUiProof(page, "optimistic-read-in-flight.png");
+
+      await gateway.resolveDeferred("sessions.patch");
+      patchHeld = false;
+      await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(unreadKey));
+      await unreadDot.waitFor({ state: "hidden" });
+      await captureUiProof(page, "optimistic-read-settled.png");
+    } finally {
+      if (patchHeld) {
+        await gateway.resolveDeferred("sessions.patch").catch(() => undefined);
+      }
+      await context.close();
+    }
+  });
+
   it("preserves manually unread state through active run updates until the session is reopened", async () => {
     const activeKey = "agent:main:active";
     const otherKey = "agent:main:other";

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -165,13 +165,13 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
 
   // Canonical Gateway rows are the source of truth for everything except the
   // UI-owned facts the capability keeps beside them, so every published result
-  // passes through the same overlay: swarm notes, then in-flight pin intents.
+  // passes through the same overlay: swarm notes, then in-flight row intents.
   const decorateRows = (
     result: SessionsListResult | null,
     owner = roster.primaryList(),
   ): SessionsListResult | null =>
     deletions.apply(
-      mutations.applyConfirmedArchives(mutations.applyPendingPins(swarmActivity.decorate(result))),
+      mutations.applyConfirmedArchives(mutations.applyPendingRows(swarmActivity.decorate(result))),
       owner,
     );
 

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -28,7 +28,8 @@ import type { SessionRefreshOutcome } from "./session-roster-refresh.ts";
 
 /** The Gateway's single pin fact: `pinned` is a projection of `pinnedAt`. */
 type SessionPinFields = { pinned: boolean; pinnedAt: number | undefined };
-type PendingRowPatch<T> = { token: symbol; previous: T; next: T };
+/** `canonical` is what the Gateway confirmed; `previous` is the value the intent replaced. */
+type PendingRowPatch<T> = { token: symbol; previous: T; next: T; canonical: T };
 
 type SessionMutationsHost = {
   connection: SessionConnectionOwner;
@@ -60,13 +61,19 @@ function createOptimisticRowPatches<T>(
         token,
         previous: current ? current.previous : fields.read(host.publishedRow(key)),
         next,
+        canonical: next,
       });
       host.redecorateLists();
       return token;
     },
     confirm(key: string, token: symbol, confirmed: T): void {
       const current = pending.get(key);
-      if (current && current.token !== token) {
+      if (!current) {
+        return;
+      }
+      if (current.token === token) {
+        current.canonical = confirmed;
+      } else {
         current.previous = confirmed;
       }
     },
@@ -75,8 +82,12 @@ function createOptimisticRowPatches<T>(
       if (!current || current.token !== token) {
         return;
       }
-      if (!completed && connectionCurrent) {
-        current.next = current.previous;
+      if (connectionCurrent) {
+        // Decoration writes the intent into the published snapshot, so releasing
+        // it cannot restore a value it overwrote. Project the settled truth once
+        // more first, or a canonical row that disagrees with the optimistic
+        // value stays hidden until an unrelated update arrives.
+        current.next = completed ? current.canonical : current.previous;
         host.redecorateLists();
       }
       pending.delete(key);
@@ -414,9 +425,17 @@ export function createSessionMutations(host: SessionMutationsHost) {
         );
       }
     };
-    const confirmUnreadPatch = () => {
-      if (unreadPatchToken && patchParams.unread !== undefined) {
-        optimisticUnread.confirm(normalizedKey, unreadPatchToken, patchParams.unread);
+    // A conditional read acknowledgement settles successfully without applying
+    // when a newer manual mark-unread owns the row: the Gateway returns that
+    // entry with its marker intact and broadcasts no change. A present marker
+    // is unread by definition, so it is the value this intent settles to.
+    const confirmUnreadPatch = (entry: SessionPatchResult["entry"] | undefined) => {
+      if (unreadPatchToken) {
+        optimisticUnread.confirm(
+          normalizedKey,
+          unreadPatchToken,
+          entry?.markedUnreadAt !== undefined,
+        );
       }
     };
     const settleUnreadPatch = (completed: boolean) => {
@@ -506,7 +525,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
         archiveState.clear(normalizedKey);
       }
       confirmPinPatch();
-      confirmUnreadPatch();
+      confirmUnreadPatch(result?.entry);
       // Commit and list reconciliation are separate outcomes. Callers must not
       // turn a failed refresh into an apparent rollback of the committed patch.
       let refreshOutcome: SessionRefreshOutcome = { status: "refreshed" };

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -28,6 +28,7 @@ import type { SessionRefreshOutcome } from "./session-roster-refresh.ts";
 
 /** The Gateway's single pin fact: `pinned` is a projection of `pinnedAt`. */
 type SessionPinFields = { pinned: boolean; pinnedAt: number | undefined };
+type PendingRowPatch<T> = { token: symbol; previous: T; next: T };
 
 type SessionMutationsHost = {
   connection: SessionConnectionOwner;
@@ -43,6 +44,63 @@ type SessionMutationsHost = {
   retirePullRequestSummary: (key: string) => void;
 };
 
+function createOptimisticRowPatches<T>(
+  host: Pick<SessionMutationsHost, "publishedRow" | "redecorateLists">,
+  fields: {
+    read: (row: GatewaySessionRow | undefined) => T;
+    write: (row: GatewaySessionRow, next: T) => GatewaySessionRow;
+  },
+) {
+  const pending = new Map<string, PendingRowPatch<T>>();
+  return {
+    start(key: string, next: T): symbol {
+      const token = Symbol("session-row-patch");
+      const current = pending.get(key);
+      pending.set(key, {
+        token,
+        previous: current ? current.previous : fields.read(host.publishedRow(key)),
+        next,
+      });
+      host.redecorateLists();
+      return token;
+    },
+    confirm(key: string, token: symbol, confirmed: T): void {
+      const current = pending.get(key);
+      if (current && current.token !== token) {
+        current.previous = confirmed;
+      }
+    },
+    settle(key: string, token: symbol, completed: boolean, connectionCurrent: boolean): void {
+      const current = pending.get(key);
+      if (!current || current.token !== token) {
+        return;
+      }
+      if (!completed && connectionCurrent) {
+        current.next = current.previous;
+        host.redecorateLists();
+      }
+      pending.delete(key);
+    },
+    apply(result: SessionsListResult | null): SessionsListResult | null {
+      if (!result || pending.size === 0) {
+        return result;
+      }
+      let changed = false;
+      const sessions = result.sessions.map((row) => {
+        const patch = pending.get(row.key);
+        if (!patch) {
+          return row;
+        }
+        const next = fields.write(row, patch.next);
+        changed ||= next !== row;
+        return next;
+      });
+      return changed ? { ...result, sessions } : result;
+    },
+    clear: () => pending.clear(),
+  };
+}
+
 export function createSessionMutations(host: SessionMutationsHost) {
   const pendingModelPatches = new Map<
     string,
@@ -51,10 +109,6 @@ export function createSessionMutations(host: SessionMutationsHost) {
       previous: { value: string | null | undefined; created: boolean };
       revision: number;
     }
-  >();
-  const pendingPinPatches = new Map<
-    string,
-    { token: symbol; previous: SessionPinFields; next: SessionPinFields }
   >();
   const archiveState = createSessionArchiveState(host.publishedRow, () =>
     host.publish({ ...host.readState() }),
@@ -131,6 +185,16 @@ export function createSessionMutations(host: SessionMutationsHost) {
     pinned
       ? { pinned: true, pinnedAt: pinnedAt ?? Date.now() }
       : { pinned: false, pinnedAt: undefined };
+
+  const optimisticPins = createOptimisticRowPatches(host, {
+    read: (row) => pinRowFields(row?.pinned === true, row?.pinnedAt),
+    // Once the Gateway agrees on `pinned`, its own timestamp wins again.
+    write: (row, next) => ((row.pinned === true) === next.pinned ? row : { ...row, ...next }),
+  });
+  const optimisticUnread = createOptimisticRowPatches(host, {
+    read: (row) => row?.unread,
+    write: (row, unread) => (row.unread === unread ? row : { ...row, unread }),
+  });
 
   const retireModelOverride = (key: string) => {
     const normalizedKey = key.trim();
@@ -264,34 +328,31 @@ export function createSessionMutations(host: SessionMutationsHost) {
       modelPatchRevision = pendingModelPatches.get(normalizedKey)?.revision ?? 0;
     };
     const nextPinned = patchParams.pinned === true;
-    const pinPatchToken = Symbol("session-pin-patch");
-    let pinPatchStarted = false;
+    let pinPatchToken: symbol | null = null;
     // Sidebar rows read `pinned` straight off the snapshot, so a pin/unpin has
     // no visible outcome until this flip; the Gateway patch and its list
     // refresh confirm it afterwards.
     const startPinPatch = () => {
-      if (patchParams.pinned === undefined || pinPatchStarted) {
+      if (patchParams.pinned === undefined || pinPatchToken) {
         return;
       }
-      const pendingPinPatch = pendingPinPatches.get(normalizedKey);
-      // The baseline comes from wherever the row is published: a sidebar on
-      // `archived`/`all` renders its own snapshot, and inferring `previous`
-      // from the primary state alone would roll such a row back to a guess.
       const row = host.publishedRow(normalizedKey);
-      pinPatchStarted = true;
-      const next = pinRowFields(nextPinned, row?.pinnedAt);
-      // `previous` chains through an in-flight pin so a rollback lands on the
-      // last Gateway-confirmed value instead of an older operation's guess.
-      pendingPinPatches.set(normalizedKey, {
-        token: pinPatchToken,
-        previous: pendingPinPatch?.previous ?? pinRowFields(row?.pinned === true, row?.pinnedAt),
-        next,
-      });
-      host.redecorateLists();
+      pinPatchToken = optimisticPins.start(normalizedKey, pinRowFields(nextPinned, row?.pinnedAt));
+    };
+    let unreadPatchToken: symbol | null = null;
+    const startUnreadPatch = () => {
+      // Mark-unread needs the Gateway-issued marker before an active pane can
+      // distinguish the explicit reminder from new activity. Reads are safe
+      // to project immediately because their observed marker remains attached.
+      if (patchParams.unread !== false || unreadPatchToken) {
+        return;
+      }
+      unreadPatchToken = optimisticUnread.start(normalizedKey, false);
     };
     const startOptimisticPatch = () => {
       startModelPatch();
       startPinPatch();
+      startUnreadPatch();
     };
     if (!options.waitFor) {
       startOptimisticPatch();
@@ -339,32 +400,39 @@ export function createSessionMutations(host: SessionMutationsHost) {
     // The Gateway stamps `pinnedAt` with its own clock, so the baseline is a
     // round trip off — accurate enough to order a row it just pinned.
     const confirmPinPatch = () => {
-      const pendingPinPatch = pendingPinPatches.get(normalizedKey);
-      if (pinPatchStarted && pendingPinPatch && pendingPinPatch.token !== pinPatchToken) {
-        pendingPinPatch.previous = pinRowFields(nextPinned, undefined);
+      if (pinPatchToken) {
+        optimisticPins.confirm(normalizedKey, pinPatchToken, pinRowFields(nextPinned, undefined));
       }
     };
     const settlePinPatch = (completed: boolean) => {
-      const pendingPinPatch = pendingPinPatches.get(normalizedKey);
-      if (!pinPatchStarted || !pendingPinPatch) {
-        return;
+      if (pinPatchToken) {
+        optimisticPins.settle(
+          normalizedKey,
+          pinPatchToken,
+          completed,
+          host.connection.isCurrent(scope),
+        );
       }
-      if (pendingPinPatch.token !== pinPatchToken) {
-        // A newer pin intent owns this row; republishing it is the canonical
-        // overlay's job and its baseline moved at confirmation time.
-        return;
+    };
+    const confirmUnreadPatch = () => {
+      if (unreadPatchToken && patchParams.unread !== undefined) {
+        optimisticUnread.confirm(normalizedKey, unreadPatchToken, patchParams.unread);
       }
-      if (!completed && host.connection.isCurrent(scope)) {
-        // Roll back through the same overlay that published the intent so the
-        // primary state and every filtered snapshot land on one value.
-        pendingPinPatch.next = pendingPinPatch.previous;
-        host.redecorateLists();
+    };
+    const settleUnreadPatch = (completed: boolean) => {
+      if (unreadPatchToken) {
+        optimisticUnread.settle(
+          normalizedKey,
+          unreadPatchToken,
+          completed,
+          host.connection.isCurrent(scope),
+        );
       }
-      pendingPinPatches.delete(normalizedKey);
     };
     const settleOptimisticPatch = (completed: boolean) => {
       settleModelOverride(completed);
       settlePinPatch(completed);
+      settleUnreadPatch(completed);
     };
     try {
       if (options.waitFor) {
@@ -438,6 +506,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
         archiveState.clear(normalizedKey);
       }
       confirmPinPatch();
+      confirmUnreadPatch();
       // Commit and list reconciliation are separate outcomes. Callers must not
       // turn a failed refresh into an apparent rollback of the committed patch.
       let refreshOutcome: SessionRefreshOutcome = { status: "refreshed" };
@@ -536,27 +605,11 @@ export function createSessionMutations(host: SessionMutationsHost) {
     assignOwner,
     patchRowLocal,
     /**
-     * Re-asserts in-flight pin intents over canonical Gateway rows: every
-     * `sessions.changed` payload and list refresh carries the server's pin
-     * state, which is the pre-click value until this operation's patch lands.
+     * Re-asserts in-flight row intents over Gateway events and list refreshes,
+     * which carry the pre-mutation value until the patch lands.
      */
-    applyPendingPins(result: SessionsListResult | null): SessionsListResult | null {
-      if (!result || pendingPinPatches.size === 0) {
-        return result;
-      }
-      let changed = false;
-      const sessions = result.sessions.map((row) => {
-        const pendingPinPatch = pendingPinPatches.get(row.key);
-        // Once the Gateway agrees on `pinned`, its own `pinnedAt` wins again.
-        // A row predating a rapid unpin/repin can keep the older stamp for the
-        // patch window; that beats overwriting confirmed stamps with our clock.
-        if (!pendingPinPatch || (row.pinned === true) === pendingPinPatch.next.pinned) {
-          return row;
-        }
-        changed = true;
-        return { ...row, ...pendingPinPatch.next };
-      });
-      return changed ? { ...result, sessions } : result;
+    applyPendingRows(result: SessionsListResult | null): SessionsListResult | null {
+      return optimisticUnread.apply(optimisticPins.apply(result));
     },
     applyConfirmedArchives: archiveState.apply,
     observeArchiveState: archiveState.observe,
@@ -578,10 +631,11 @@ export function createSessionMutations(host: SessionMutationsHost) {
     retireConnection() {
       pendingCreatedModelOverrides.clear();
       pendingModelPatches.clear();
-      // Pin intents live inside `result`, which the replacement connection
+      // Row intents live inside `result`, which the replacement connection
       // rehydrates wholesale; only the model-override side map outlives that
       // replacement, so it is the one that needs an explicit rollback below.
-      pendingPinPatches.clear();
+      optimisticPins.clear();
+      optimisticUnread.clear();
       archiveState.clearAll();
       preparedWorkSessionKeys.clear();
       const state = host.readState();
@@ -590,7 +644,8 @@ export function createSessionMutations(host: SessionMutationsHost) {
     dispose() {
       pendingCreatedModelOverrides.clear();
       pendingModelPatches.clear();
-      pendingPinPatches.clear();
+      optimisticPins.clear();
+      optimisticUnread.clear();
       archiveState.clearAll();
       preparedWorkSessionKeys.clear();
     },

--- a/ui/src/lib/sessions/session-unread-mutations.test.ts
+++ b/ui/src/lib/sessions/session-unread-mutations.test.ts
@@ -120,4 +120,24 @@ describe("session unread mutation capability", () => {
     expect(rowUnread(sessions.state.result)).toBe(false);
     sessions.dispose();
   });
+
+  it("restores the marker-owned unread row when the acknowledgement settles stale", async () => {
+    const committed = createDeferred<unknown>();
+    const { gateway } = unreadHarness({
+      patchResponse: () => committed.promise,
+      serverUnread: () => true,
+    });
+    const sessions = createSessionCapability(gateway);
+
+    await sessions.refresh({ force: true });
+    const operation = sessions.patch(key, { unread: false }, { expectedMarkedUnreadAt: 41 });
+    expect(rowUnread(sessions.state.result)).toBe(false);
+
+    // The Gateway keeps a newer manual marker, answers ok without applying, and
+    // broadcasts nothing; settlement is the only place the row can come back.
+    committed.resolve({ ok: true, key, path: "", entry: { markedUnreadAt: 99 } });
+    await expect(operation).resolves.toBeTruthy();
+    expect(rowUnread(sessions.state.result)).toBe(true);
+    sessions.dispose();
+  });
 });

--- a/ui/src/lib/sessions/session-unread-mutations.test.ts
+++ b/ui/src/lib/sessions/session-unread-mutations.test.ts
@@ -1,10 +1,40 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SessionsListResult } from "../../api/types.ts";
 import { createSessionCapability } from "./index.ts";
-import { createGatewayHarness } from "./session-capability.test-support.ts";
+import { createGatewayHarness, sessionsResult } from "./session-capability.test-support.ts";
 
 const key = "agent:main:unread-contract";
+
+function rowUnread(result: SessionsListResult | null): boolean {
+  return result?.sessions.find((row) => row.key === key)?.unread === true;
+}
+
+function unreadHarness(options: {
+  patchResponse: () => Promise<unknown>;
+  serverUnread: () => boolean;
+}) {
+  let listTs = 0;
+  const request = vi.fn(async (method: string) => {
+    if (method === "sessions.patch") {
+      return await options.patchResponse();
+    }
+    if (method === "sessions.list") {
+      listTs += 1;
+      return sessionsResult(
+        [{ key, kind: "direct", updatedAt: 1, unread: options.serverUnread() }],
+        listTs,
+      );
+    }
+    if (method === "sessions.subscribe") {
+      return { subscribed: true };
+    }
+    throw new Error(`Unexpected request: ${method}`);
+  });
+  return createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+}
 
 describe("session unread mutation capability", () => {
   it.each([
@@ -36,6 +66,58 @@ describe("session unread mutation capability", () => {
       unread: false,
       ...expected,
     });
+    sessions.dispose();
+  });
+
+  it("clears unread before the request settles and rolls a rejection back", async () => {
+    const rejected = createDeferred<unknown>();
+    const { gateway } = unreadHarness({
+      patchResponse: () => rejected.promise,
+      serverUnread: () => true,
+    });
+    const sessions = createSessionCapability(gateway);
+
+    await sessions.refresh({ force: true });
+    const operation = sessions.patch(key, { unread: false }, { deferListRefresh: true });
+    const unreadWhilePending = rowUnread(sessions.state.result);
+
+    rejected.reject(new Error("read rejected"));
+    await expect(operation).rejects.toThrow("read rejected");
+    expect(unreadWhilePending).toBe(false);
+    expect(rowUnread(sessions.state.result)).toBe(true);
+    sessions.dispose();
+  });
+
+  it("keeps the pending read through stale events and canonical refreshes", async () => {
+    const committed = createDeferred<unknown>();
+    let serverUnread = true;
+    const { gateway } = unreadHarness({
+      patchResponse: () => committed.promise,
+      serverUnread: () => serverUnread,
+    });
+    const sessions = createSessionCapability(gateway);
+
+    await sessions.refresh({ force: true });
+    const operation = sessions.patch(key, { unread: false });
+    expect(rowUnread(sessions.state.result)).toBe(false);
+
+    sessions.reconcileChanged({
+      key,
+      kind: "direct",
+      reason: "send",
+      sessionKey: key,
+      unread: true,
+      updatedAt: 2,
+    });
+    expect(rowUnread(sessions.state.result)).toBe(false);
+
+    await sessions.refresh({ force: true });
+    expect(rowUnread(sessions.state.result)).toBe(false);
+
+    serverUnread = false;
+    committed.resolve({ ok: true, key, path: "", entry: {} });
+    await expect(operation).resolves.toBeTruthy();
+    expect(rowUnread(sessions.state.result)).toBe(false);
     sessions.dispose();
   });
 });

--- a/ui/src/lib/sessions/unread.test.ts
+++ b/ui/src/lib/sessions/unread.test.ts
@@ -29,6 +29,15 @@ describe("SessionUnreadPatchGuard", () => {
     expect(guard.shouldPatch("agent:main:a", true)).toBe(false);
   });
 
+  it("keeps an acknowledgement latched across an optimistic local read", () => {
+    const guard = new SessionUnreadPatchGuard();
+    expect(guard.shouldPatch("agent:main:a", true, 100)).toBe(true);
+    expect(guard.shouldPatch("agent:main:a", false, 100)).toBe(false);
+    expect(guard.shouldPatch("agent:main:a", true, 100)).toBe(false);
+    guard.patchFailed("agent:main:a");
+    expect(guard.shouldPatch("agent:main:a", true, 100)).toBe(true);
+  });
+
   it("treats a null marker as no manual marker", () => {
     const guard = new SessionUnreadPatchGuard();
     expect(guard.shouldPatch("agent:main:a", false)).toBe(false);

--- a/ui/src/lib/sessions/unread.ts
+++ b/ui/src/lib/sessions/unread.ts
@@ -34,6 +34,11 @@ export class SessionUnreadPatchGuard {
       this.activationMarkedUnreadAt = marker;
     }
     if (unread === false) {
+      // An optimistic read keeps the observed marker until the Gateway confirms it.
+      // Clearing the latch here would let rollback synchronously dispatch a duplicate.
+      if (marker !== undefined) {
+        return false;
+      }
       this.activationMarkedUnreadAt = undefined;
       this.requested = false;
       return false;


### PR DESCRIPTION
Closes #134158

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users opening an unread Control UI session would continue seeing its unread dot until the acknowledgement request and canonical list refresh completed. Navigation succeeded, but the stale badge made the click look unacknowledged for the full Gateway/network round trip.

## Why This Change Was Made

The session capability now owns pending row projections for both the existing pin behavior and unread acknowledgements. A local read clears `unread` immediately, stays projected over stale `sessions.changed` events and list refreshes, then either yields to the confirmed Gateway row or rolls back to the last canonical value on failure.

Only `unread: false` is optimistic. Explicit “mark unread” still waits for the Gateway-issued marker because an active pane needs that marker to distinguish a manual reminder from new activity. The acknowledgement guard also retains its latch while the optimistic row still carries that observed marker, preventing a rollback from dispatching a duplicate request.

This changes no Gateway protocol, configuration, persistence, schema, or plugin surface.

## User Impact

Opening an unread session now removes the dot in the same interaction frame instead of after the round trip. Users get immediate, stable feedback without an extra request. Failed acknowledgements restore the server-owned unread state, and the existing manual “mark unread” behavior is unchanged.

## Evidence

### Before and after

The source Control UI was measured in Chromium 151 against a deterministic mocked Gateway WebSocket. Timing starts when `sessions.patch { unread: false }` is observed, that response is held for 500 ms, and the run ends when `.session-unread-dot` becomes hidden. Ten independent browser contexts were measured for each revision. At the hide boundary the harness also records incremental `sessions.patch` and `sessions.list` requests.

| Revision | Mean | Std. dev. | Range | Patch requests at hide | List requests at hide |
| --- | ---: | ---: | ---: | ---: | ---: |
| Before | 799.70 ms | 13.01 ms | 790.10–836.50 ms | 1 | 1 |
| After | 7.55 ms | 3.75 ms | 4.10–15.10 ms | 1 | 0 |

That is a **792.15 ms / 99.06% reduction** in observed badge-clear latency, with no added network request.

#### Before: badge remains during the held acknowledgement

![Before: unread dot remains while the request is in flight](https://github.com/user-attachments/assets/b3bb7f63-062e-4367-a76b-ffbe78138568)

https://github.com/user-attachments/assets/0126c449-6966-4709-8c47-233b8b353024

#### After: badge is already clear during the same held acknowledgement

![After: unread dot is absent while the request is in flight](https://github.com/user-attachments/assets/d57c89e1-255a-4326-9440-9fb3841ba492)

https://github.com/user-attachments/assets/07fd3fb6-5faf-4116-b9c4-b5182cabc947

Both recordings were inspected before upload. The before recording keeps the red unread dot visible across the in-flight frames; the after recording clears it before the response is released.

### Regression and sibling coverage

- The new unit regressions failed against the pre-change implementation: the pending row remained unread, and stale event/list snapshots restored the dot.
- `17/17` focused Control UI unit tests pass for unread mutations, the unread acknowledgement guard, and the sibling pin overlay.
- `2/2` mocked-Gateway browser E2E scenarios pass: immediate read acknowledgement and the existing manual “mark unread” lifecycle.
- The E2E assertion is made while `sessions.patch` is still held: the dot is hidden, exactly one patch was sent, and no incremental list request occurred.
- Focused formatter, Oxlint, Stylelint, conflict-marker, ratchet, dependency, dead-export, test-temp, graph-boundary, and Control UI i18n checks passed.
- The aggregate changed gate could not finish `tsgo:core:test`: the shared linked install lacks a declaration for `pako`, imported by unchanged `ui/vite.config.ts:9`. No dependency install was run; focused Vitest, browser, lint, and formatting proof completed successfully.

### Change size and owner boundary

- Production: **+143 / -62 lines (net +81)** versus `origin/main`.
- Tests: **+173 / -1 lines (net +172)**.
- The production growth is the generic pending-row owner plus the unread lifecycle it enables. It absorbs and removes the former pin-only pending map/application path rather than introducing a second overlay stack.
- The session mutation capability remains the canonical owner. Connection retirement/disposal clear both row projections, canonical refreshes stay authoritative after settlement, and failures roll back through the same publication path used by success.


## Maintainer review pass

Rebased on `main` (was conflicting) and repaired the one actionable ClawSweeper finding.

### [P1] Restore canonical unread state after a stale acknowledgement — applied

**Root cause.** `createOptimisticRowPatches.settle` released a row intent by deleting it. Decoration is destructive: `decorateRows` writes the intent into the snapshot the roster publishes, and `redecorateLists` re-decorates that published snapshot rather than a retained canonical one. Releasing an intent therefore could not restore the value it had overwritten.

That only matters where the Gateway can answer `ok` without applying, which is exactly the conditional read acknowledgement: `resolveSessionUnreadAck` returns `{ kind: "stale", entry }` when a newer manual marker owns the row (`src/gateway/server-methods/session-unread-ack.ts:45-50`), the engine pushes `{ ok: true, applied: false, entry }` (`src/gateway/server-methods/sessions-patch-engine.ts:425-437`), and the post-commit loop skips `emitSessionsChanged` for `applied: false` (`src/gateway/server-methods/sessions-patch-engine.ts:559-580`). No changed event, no list fence bump — settlement was the only place the row could come back, and it published nothing. A valid unread dot stayed hidden until an unrelated update arrived.

**Fix.** Row intents settle on a canonical value instead of a boolean: `{ kind: "canonical"; value }` on success, `{ kind: "failed" }` on failure. `settle` projects that value and redecorates once before releasing the key, so the same publication path serves success, stale success, and rollback. The unread specialization reads the canonical value off `result.entry.markedUnreadAt` — the recorded fact that says the acknowledgement did not land, and the first clause of `deriveSessionUnread` (`src/gateway/session-utils-core.ts:97-100`). Pinning is unconditional, so its settlement is a no-op by construction and behavior there is unchanged.

`ui/src/api/types.ts` gains `markedUnreadAt?: number` on the patch result entry; the Gateway already returns it (`projectPublicSessionEntry` strips only private keys).

### [P1] Resolve merge risk / [P2] Complete next step — applied by the same change

Covered by the new boundary regression `restores the marker-owned unread row when the acknowledgement settles stale`. It fails on the pre-fix branch head for the intended reason (row stays `unread: false` after settlement) and passes after.

### Review state

The three `Before merge` items from the last automated review are addressed above; none were skipped. That review predates the rebase and this repair, so its rating is stale rather than wrong.

### Sibling surfaces

The unread badge also exists in the native Swift app and on Android.

- **Swift** (`ChatViewModel+SessionActions.swift:848-880`) has its own guard and optimistic layer, but the automatic acknowledgement is not an explicit patch, so `localUnreadOverride` holds nothing for it and success settles through `refreshSessions()` — canonical rows, no residue. No equivalent gap.
- **Android** (`ChatController.kt:1072-1170`) never writes the row locally; it re-fetches after every patch. Not applicable.
- TUI, CLI, channels, and plugins have no unread concept.

### Rebase repairs picked up in this pass

- `main` had refactored `captureUiProof` to take the suite that owns the artifact directory. The rebase auto-merged that change into half of `session-management.unread.e2e.test.ts` and left this PR's three call sites on the old two-argument form — a typecheck break and a crash under `OPENCLAW_CAPTURE_UI_PROOF=1`. All call sites now pass the suite.
- `SessionsPatchResult` is reached through `SessionPatchResult` in this module after the rebase; the settlement reads the entry off that type.
- A patch RPC can resolve `null` — `chat-settings-patches.ts:108` and the `chat-send` regressions model it — so the settlement reads `result?.entry`. A missing entry carries no marker and settles to the optimistic value, which is the previous behavior.

### Proof

- Mocked-Gateway Control UI E2E re-run on the final head with proof capture on; both scenarios pass. `optimistic-read-before.png` shows the red dot on the unread row, `optimistic-read-in-flight.png` shows it gone while `sessions.patch` is still held. Both were opened and inspected.
- Focused Vitest on the box: `ui/src/lib/sessions` (41 files), `ui/src/pages/chat/chat-send.test.ts`, `ui/src/pages/chat/chat-pane.read-marker.test.ts`, and the unread E2E — all green. `check:changed` green.
- Stale-ack settlement is proven by the unit regression rather than a screenshot: the mocked Gateway applies every `sessions.patch` into its fixture store, so it cannot model a successful-but-not-applied conditional acknowledgement. Adding that mode is shared test-harness work outside this PR.

### Change size

Whole PR versus `origin/main`: production **+143 / -62 (net +81)**, tests **+173 / -1**.


