### PR TITLE
test(imap): await committed cursor notifications

### DIFF
--- a/extensions/imap/src/imap-test-support.ts
+++ b/extensions/imap/src/imap-test-support.ts
@@ -3,11 +3,11 @@ import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { vi } from "vitest";
-import { createImapState } from "./state.js";
+import { createImapState, type ImapCursor } from "./state.js";
 
 export function createImapTestRuntime() {
   const namespaces = new Map<string, Map<string, unknown>>();
-  const initialCursorRegistered = createDeferred<void>();
+  let cursorChanged = createDeferred<void>();
   const dispatchHookAgentTurn = vi.fn<
     OpenClawPluginApi["runtime"]["hooks"]["dispatchHookAgentTurn"]
   >(async () => ({ ok: true, runId: "mail-run" }));
@@ -25,7 +25,9 @@ export function createImapTestRuntime() {
           register: async (key: string, value: T) => {
             entries.set(key, value);
             if (options.namespace === "cursor") {
-              initialCursorRegistered.resolve();
+              const previous = cursorChanged;
+              cursorChanged = createDeferred<void>();
+              previous.resolve();
             }
           },
           registerIfAbsent: async (key: string, value: T) => {
@@ -49,11 +51,28 @@ export function createImapTestRuntime() {
       },
     },
   });
+  const state = createImapState(runtime);
   return {
     runtime,
-    state: createImapState(runtime),
+    state,
     dispatchHookAgentTurn,
-    initialCursorRegistered: initialCursorRegistered.promise,
+    waitForCursor: async (
+      accountId: string,
+      expected: Pick<ImapCursor, "uidValidity" | "lastSeenUid">,
+    ) => {
+      for (;;) {
+        // Capture the notification before lookup so a concurrent write cannot be missed.
+        const changed = cursorChanged.promise;
+        const cursor = await state.cursors.lookup(accountId);
+        if (
+          cursor?.uidValidity === expected.uidValidity &&
+          cursor.lastSeenUid === expected.lastSeenUid
+        ) {
+          return cursor;
+        }
+        await changed;
+      }
+    },
   };
 }
 

--- a/extensions/imap/src/watcher.test.ts
+++ b/extensions/imap/src/watcher.test.ts
@@ -2,6 +2,7 @@ import { once } from "node:events";
 import { createServer, type Server, type Socket } from "node:net";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { OpenClawPluginServiceContext } from "openclaw/plugin-sdk/plugin-entry";
+import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { resolveImapConfig, type ImapAccountConfig } from "./config.js";
 import { createImapAuthResult, createImapTestRuntime } from "./imap-test-support.js";
@@ -176,8 +177,20 @@ async function startWatcher(
     throw new Error("fixture account was not configured");
   }
   Object.assign(account, options.account);
-  const { runtime, state, dispatchHookAgentTurn, initialCursorRegistered } =
-    createImapTestRuntime();
+  const {
+    runtime,
+    state,
+    dispatchHookAgentTurn,
+    waitForCursor: waitForAccountCursor,
+  } = createImapTestRuntime();
+  const waitForCursor = (
+    lastSeenUid: number,
+    timeoutMs = 1_000,
+    uidValidity = server.uidValidity,
+  ) =>
+    withTimeout(waitForAccountCursor("inbox", { uidValidity, lastSeenUid }), timeoutMs, {
+      message: `IMAP inbox cursor did not reach UIDVALIDITY ${uidValidity}, UID ${lastSeenUid}`,
+    });
   const context: OpenClawPluginServiceContext = {
     config: {},
     stateDir: "/unused-imap-test-state",
@@ -200,9 +213,9 @@ async function startWatcher(
   // start() is fire-and-forget; observe the committed baseline before driving mail.
   // Authentication-failure tests intentionally never reach cursor registration.
   if (!options.rejectAuthentication) {
-    await initialCursorRegistered;
+    await waitForAccountCursor("inbox", { uidValidity: server.uidValidity, lastSeenUid: 1 });
   }
-  return { server, watcher, state, context, authenticator, dispatchHookAgentTurn };
+  return { server, watcher, state, context, authenticator, dispatchHookAgentTurn, waitForCursor };
 }
 
 describe("IMAP watcher protocol boundary", () => {
@@ -220,25 +233,24 @@ describe("IMAP watcher protocol boundary", () => {
   ] as const)(
     "dispatches %s mail with the actual admission evidence",
     async (gate, dmarc, headers, log, contentType) => {
-      const { server, state, context, authenticator, dispatchHookAgentTurn } = await startWatcher({
-        account: {
-          senderAuth: {
-            min: gate === "token" ? "verified" : gate,
-            trustedAuthservIds: ["mx.example.com"],
-            acceptTrustedAuthservId: gate === "asserted",
+      const { server, state, context, authenticator, dispatchHookAgentTurn, waitForCursor } =
+        await startWatcher({
+          account: {
+            senderAuth: {
+              min: gate === "token" ? "verified" : gate,
+              trustedAuthservIds: ["mx.example.com"],
+              acceptTrustedAuthservId: gate === "asserted",
+            },
+            addressTokens: [{ token: "secret-token", senders: ["trusted@example.com"] }],
           },
-          addressTokens: [{ token: "secret-token", senders: ["trusted@example.com"] }],
-        },
-      });
+        });
       expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 });
       authenticator.mockResolvedValue(createImapAuthResult(dmarc));
       const body = contentType === "text/html" ? "<p>Email <b>content</b></p>" : "Email content";
       server.append(
         `From: trusted@example.com\r\n${headers}Subject: Admission\r\nContent-Type: ${contentType}; charset=utf-8\r\n\r\n${body}`,
       );
-      await vi.waitFor(async () =>
-        expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 2 }),
-      );
+      await waitForCursor(2);
       expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(1);
       expect(dispatchHookAgentTurn).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -270,15 +282,13 @@ describe("IMAP watcher protocol boundary", () => {
   ])(
     "preserves Unicode through fetched mail at the $boundary limit",
     async ({ body, maxBytes, truncated }) => {
-      const { server, state, dispatchHookAgentTurn } = await startWatcher({
+      const { server, dispatchHookAgentTurn, waitForCursor } = await startWatcher({
         account: { includeBody: true, maxBytes },
       });
       server.append(
         `From: trusted@example.com\r\nSubject: Unicode limits\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n${body}`,
       );
-      await vi.waitFor(async () =>
-        expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 2 }),
-      );
+      await waitForCursor(2);
       expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(1);
       const call = dispatchHookAgentTurn.mock.calls[0]?.[0];
       if (!call) {
@@ -306,16 +316,15 @@ describe("IMAP watcher protocol boundary", () => {
   ])(
     "records pre-auth rejection for %s without claiming strength",
     async (from, reason, domain) => {
-      const { server, state, context, authenticator, dispatchHookAgentTurn } = await startWatcher({
-        account: {
-          addressTokens: [{ token: "secret-token", senders: ["@evil.example"] }],
-        },
-      });
+      const { server, state, context, authenticator, dispatchHookAgentTurn, waitForCursor } =
+        await startWatcher({
+          account: {
+            addressTokens: [{ token: "secret-token", senders: ["@evil.example"] }],
+          },
+        });
       expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 });
       server.append(`${from}\r\nTo: reader+secret-token@example.com\r\n\r\nRejected mail`);
-      await vi.waitFor(async () =>
-        expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 2 }),
-      );
+      await waitForCursor(2);
       expect(authenticator).not.toHaveBeenCalled();
       expect(dispatchHookAgentTurn).not.toHaveBeenCalled();
       expect(context.logger.warn).toHaveBeenCalledWith(
@@ -329,9 +338,10 @@ describe("IMAP watcher protocol boundary", () => {
   it.each(["rejected admission", "throwing admission", "transient authentication"] as const)(
     "retries %s without waiting for another email",
     async (failure) => {
-      const { server, state, authenticator, dispatchHookAgentTurn } = await startWatcher({
-        account: { watch: { mode: "auto", pollSeconds: 0.02 } },
-      });
+      const { server, state, authenticator, dispatchHookAgentTurn, waitForCursor } =
+        await startWatcher({
+          account: { watch: { mode: "auto", pollSeconds: 0.02 } },
+        });
       expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 });
       if (failure === "rejected admission") {
         dispatchHookAgentTurn.mockResolvedValueOnce({ ok: false, reason: "Gateway unavailable" });
@@ -341,9 +351,7 @@ describe("IMAP watcher protocol boundary", () => {
         authenticator.mockResolvedValueOnce(createImapAuthResult("temperror"));
       }
       server.append("From: trusted@example.com\r\nSubject: Retry\r\n\r\nRecover this email");
-      await vi.waitFor(async () =>
-        expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 2 }),
-      );
+      await waitForCursor(2);
       expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(
         failure === "transient authentication" ? 1 : 2,
       );
@@ -359,15 +367,14 @@ describe("IMAP watcher protocol boundary", () => {
   );
 
   it("records exhausted admission retries and continues with the next email", async () => {
-    const { server, state, dispatchHookAgentTurn } = await startWatcher({
+    const { server, state, dispatchHookAgentTurn, waitForCursor } = await startWatcher({
       account: { watch: { mode: "auto", pollSeconds: 0.02 } },
     });
     expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 });
     dispatchHookAgentTurn.mockRejectedValue(new Error("Gateway unavailable"));
     server.append("From: trusted@example.com\r\nSubject: Exhausted\r\n\r\nNo admission");
-    await vi.waitFor(async () =>
-      expect(await state.skips.lookup("inbox:dispatch-rejected")).toEqual({ count: 1 }),
-    );
+    await waitForCursor(2);
+    expect(await state.skips.lookup("inbox:dispatch-rejected")).toEqual({ count: 1 });
     expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(3);
     expect(await state.claims.lookup("attempt:inbox:17:2")).toEqual({
       count: 3,
@@ -375,14 +382,12 @@ describe("IMAP watcher protocol boundary", () => {
     });
     dispatchHookAgentTurn.mockResolvedValue({ ok: true, runId: "recovered-run" });
     server.append("From: trusted@example.com\r\nSubject: Next\r\n\r\nAdmitted");
-    await vi.waitFor(async () =>
-      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 3 }),
-    );
+    await waitForCursor(3);
     expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(4);
   });
 
   it("serializes reconnect admission with later mailbox wakeups", async () => {
-    const { server, state, dispatchHookAgentTurn } = await startWatcher({
+    const { server, state, dispatchHookAgentTurn, waitForCursor } = await startWatcher({
       account: { watch: { mode: "auto", pollSeconds: 0.02 } },
     });
     expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 });
@@ -399,10 +404,7 @@ describe("IMAP watcher protocol boundary", () => {
       uid: 2,
       raw: "From: trusted@example.com\r\nSubject: Reconnect\r\n\r\nRetry after reconnect",
     });
-    await vi.waitFor(
-      async () => expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 3 }),
-      { timeout: 5_000 },
-    );
+    await waitForCursor(3, 5_000);
     expect(dispatchHookAgentTurn.mock.calls.map(([params]) => params.sessionKey)).toEqual([
       "hook:imap:inbox:17:2",
       "hook:imap:inbox:17:2",
@@ -447,7 +449,7 @@ describe("IMAP watcher protocol boundary", () => {
     } finally {
       greeting.resolve();
     }
-    const { server, state, dispatchHookAgentTurn } = await starting;
+    const { server, state, dispatchHookAgentTurn, waitForCursor } = await starting;
     expect(await state.cursors.lookup("inbox")).toMatchObject({
       uidValidity: "17",
       lastSeenUid: 1,
@@ -455,9 +457,8 @@ describe("IMAP watcher protocol boundary", () => {
     server.append(
       "From: trusted@example.com\r\nTo: reader@example.com\r\nSubject: New mail\r\nMessage-ID: <new@example.com>\r\n\r\nHello safely",
     );
-    await vi.waitFor(() => expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(1), {
-      timeout: 5_000,
-    });
+    await waitForCursor(2, 5_000);
+    expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(1);
     expect(dispatchHookAgentTurn).toHaveBeenCalledWith({
       name: "IMAP inbox",
       agentId: "mail_reader",
@@ -469,9 +470,7 @@ describe("IMAP watcher protocol boundary", () => {
     });
     expect(server.commands.some((command) => /UID FETCH/u.test(command))).toBe(true);
     expect(server.commands.every((command) => !/STORE|BODY\[/u.test(command))).toBe(true);
-    await vi.waitFor(async () =>
-      expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 2 }),
-    );
+
     const previousFetches = server.commands.filter((command) => /UID FETCH/u.test(command)).length;
     server.disconnect();
     await vi.waitFor(
@@ -485,16 +484,15 @@ describe("IMAP watcher protocol boundary", () => {
   });
 
   it("delivers mail that arrived during an IDLE connection interruption", async () => {
-    const { server, state, dispatchHookAgentTurn } = await startWatcher();
+    const { server, state, dispatchHookAgentTurn, waitForCursor } = await startWatcher();
     expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 });
     server.disconnect();
     server.messages.push({
       uid: 2,
       raw: "From: trusted@example.com\r\nSubject: During disconnect\r\n\r\nRecovered",
     });
-    await vi.waitFor(() => expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(1), {
-      timeout: 5_000,
-    });
+    await waitForCursor(2, 5_000);
+    expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(1);
     expect(server.connectionCount).toBe(2);
     expect(dispatchHookAgentTurn).toHaveBeenCalledWith(
       expect.objectContaining({ sessionKey: "hook:imap:inbox:17:2" }),
@@ -502,7 +500,7 @@ describe("IMAP watcher protocol boundary", () => {
   });
 
   it("coalesces a wakeup that arrives during an active sweep", async () => {
-    const { server, state, dispatchHookAgentTurn } = await startWatcher();
+    const { server, state, dispatchHookAgentTurn, waitForCursor } = await startWatcher();
     expect(await state.cursors.lookup("inbox")).toMatchObject({ lastSeenUid: 1 });
     let releaseFetch = () => {};
     server.fetchGate = new Promise<void>((resolve) => {
@@ -515,16 +513,15 @@ describe("IMAP watcher protocol boundary", () => {
     server.append("From: trusted@example.com\r\nSubject: Second\r\n\r\nDuring sweep");
     server.fetchGate = undefined;
     releaseFetch();
-    await vi.waitFor(() => expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(2), {
-      timeout: 5_000,
-    });
+    await waitForCursor(3, 5_000);
+    expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(2);
     expect(dispatchHookAgentTurn).toHaveBeenCalledWith(
       expect.objectContaining({ sessionKey: "hook:imap:inbox:17:3" }),
     );
   });
 
   it("re-baselines a rotated UIDVALIDITY without replaying existing mail", async () => {
-    const { server, state, dispatchHookAgentTurn } = await startWatcher();
+    const { server, state, dispatchHookAgentTurn, waitForCursor } = await startWatcher();
     expect(await state.cursors.lookup("inbox")).toMatchObject({ uidValidity: "17" });
     server.uidValidity = "18";
     server.disconnect();
@@ -532,19 +529,12 @@ describe("IMAP watcher protocol boundary", () => {
       uid: 2,
       raw: "From: trusted@example.com\r\nSubject: Old validity\r\n\r\nNever replay",
     });
-    await vi.waitFor(
-      async () =>
-        expect(await state.cursors.lookup("inbox")).toMatchObject({
-          uidValidity: "18",
-          lastSeenUid: 2,
-        }),
-      { timeout: 5_000 },
-    );
+    await waitForCursor(2, 5_000, "18");
     expect(dispatchHookAgentTurn).not.toHaveBeenCalled();
   });
 
   it("polls when the IMAP server does not advertise IDLE", async () => {
-    const { server, state, dispatchHookAgentTurn } = await startWatcher({
+    const { server, state, dispatchHookAgentTurn, waitForCursor } = await startWatcher({
       supportsIdle: false,
       account: { watch: { mode: "auto", pollSeconds: 0.02 } },
     });
@@ -553,9 +543,8 @@ describe("IMAP watcher protocol boundary", () => {
       uid: 2,
       raw: "From: trusted@example.com\r\nSubject: Poll\r\n\r\nPolled",
     });
-    await vi.waitFor(() => expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(1), {
-      timeout: 5_000,
-    });
+    await waitForCursor(2, 5_000);
+    expect(dispatchHookAgentTurn).toHaveBeenCalledTimes(1);
     expect(server.commands.some((command) => command.includes(" IDLE"))).toBe(false);
   });
 


### PR DESCRIPTION
## What Problem This Solves

IMAP watcher protocol tests repeatedly poll cursor state or dispatch calls after real mailbox activity. Polling adds observation latency, and dispatch-call waits can proceed before cursor bookkeeping finishes.

## Why This Change Was Made

Extend the existing test-store cursor notification into an exact UIDVALIDITY/UID waiter. Observe committed admission after MIME parsing, sender checks, claims, Message-ID bookkeeping, and logging. Ordinary observations retain their 1,000 ms failure bound, and six protocol/reconnect observations retain 5,000 ms. Successful initial startup directly awaits the baseline cursor without a local timeout, preserving its original overall test budget; authentication-failure cases still skip that wait. The 100 ms overlap stimulus and 150 ms stopped-retry observation remain.

## User Impact

No runtime behavior change. Developers keep real TCP, ImapFlow, mailparser, reconnect, IDLE, polling fallback, and admission coverage while 13 polling sites (23 expanded observations) become cursor completion. Watcher test bodies decreased locally from 1,716.6 ms to 725.7 ms; this is not an end-to-end CI benchmark.

## Evidence

Production +0/-0; tests/support +87/-79.

- `node scripts/run-vitest.mjs extensions/imap/src/watcher.test.ts extensions/imap/src/state.test.ts` passed all 27 cases (23 watcher, 4 state), with no failures or skips. The real TCP, ImapFlow and mailparser path remains exercised.
- Temporarily suppressing the post-baseline cursor notification made the selected admission case fail after 1,020 ms: `IMAP inbox cursor did not reach UIDVALIDITY 17, UID 2`. The fixture was restored byte-for-byte, then all 23 watcher cases passed again. No injected fault or diagnostic-only code is included.
- Direct owner and dependency source inspection confirmed cursor registration follows the awaited admission/bookkeeping path. Capturing the next notification before lookup prevents a missed update.
- `OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs -- extensions/imap/src/watcher.test.ts extensions/imap/src/imap-test-support.ts` passed. Formatting, diff checks and independent structured Codex autoreview passed.
- Exact-head hosted CI remains required before landing.

Four polls remain where this cursor signal does not own completion, and the stopped-retry negative window remains. A future fixture-owned completion signal could address those separately; this change does not shorten retry or absence observations.
