### PR TITLE
test(telegram): isolate network imports only for cache cases

### DIFF
--- a/extensions/telegram/src/network-config.test.ts
+++ b/extensions/telegram/src/network-config.test.ts
@@ -1,6 +1,5 @@
-// Telegram tests cover network config plugin behavior.
 import type { TelegramNetworkConfig } from "openclaw/plugin-sdk/config-contracts";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("openclaw/plugin-sdk/runtime-env", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/runtime-env")>()),
@@ -18,19 +17,23 @@ async function loadModule() {
     await import("./network-config.js"));
 }
 
+beforeAll(async () => {
+  vi.resetModules();
+  await loadModule();
+});
+
+afterAll(() => {
+  vi.doUnmock("openclaw/plugin-sdk/runtime-env");
+  vi.resetModules();
+});
+
 describe("resolveTelegramAutoSelectFamilyDecision", () => {
-  beforeAll(async () => {
-    await loadModule();
-  });
-
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.mocked(isWSL2Sync).mockReset().mockReturnValue(false);
   });
 
-  afterEach(async () => {
+  afterEach(() => {
     vi.restoreAllMocks();
-    vi.resetModules();
-    await loadModule();
   });
 
   it.each([
@@ -78,9 +81,6 @@ describe("resolveTelegramAutoSelectFamilyDecision", () => {
       expected: { value: true, source: "config" },
     },
   ])("$name", ({ env, network, expected }) => {
-    if (!resolveTelegramAutoSelectFamilyDecision) {
-      throw new Error("network-config module not loaded");
-    }
     const decision = resolveTelegramAutoSelectFamilyDecision({
       env,
       network,
@@ -100,6 +100,12 @@ describe("resolveTelegramAutoSelectFamilyDecision", () => {
   });
 
   describe("WSL2 detection", () => {
+    beforeEach(async () => {
+      vi.resetModules();
+      await loadModule();
+      vi.mocked(isWSL2Sync).mockReset().mockReturnValue(false);
+    });
+
     it.each([
       {
         name: "disables autoSelectFamily on WSL2",
@@ -127,9 +133,6 @@ describe("resolveTelegramAutoSelectFamilyDecision", () => {
         expected: { value: true, source: "default-node22" },
       },
     ])("$name", ({ env, network, expected, wsl2 = true }) => {
-      if (!isWSL2Sync) {
-        throw new Error("runtime-env mock not loaded");
-      }
       vi.mocked(isWSL2Sync).mockReturnValue(wsl2);
       const decision = resolveTelegramAutoSelectFamilyDecision({
         env,
@@ -141,10 +144,15 @@ describe("resolveTelegramAutoSelectFamilyDecision", () => {
 
     it("memoizes WSL2 detection across repeated defaults", () => {
       vi.mocked(isWSL2Sync).mockReturnValue(true);
-      vi.mocked(isWSL2Sync).mockClear();
+      expect(resolveTelegramAutoSelectFamilyDecision({ env: {}, nodeMajor: 22 })).toEqual({
+        value: false,
+        source: "default-wsl2",
+      });
       vi.mocked(isWSL2Sync).mockReturnValue(false);
-      resolveTelegramAutoSelectFamilyDecision({ env: {}, nodeMajor: 22 });
-      resolveTelegramAutoSelectFamilyDecision({ env: {}, nodeMajor: 22 });
+      expect(resolveTelegramAutoSelectFamilyDecision({ env: {}, nodeMajor: 22 })).toEqual({
+        value: false,
+        source: "default-wsl2",
+      });
       expect(isWSL2Sync).toHaveBeenCalledTimes(1);
     });
   });


### PR DESCRIPTION
## What Problem This Solves

Telegram network decision tests reload the runtime/network graph even for pure env/config precedence cases that never consult the WSL cache. The memoization case changes both mock values before its first decision, so it does not prove the cached value affects later decisions.

## Why This Change Was Made

Load the owner once, reload only the WSL group that needs independent cache state, and retain case-local mocks plus final module cleanup. Strengthen memoization by observing a WSL decision, changing the underlying detector, and checking that the cached decision and single-probe count remain.

## User Impact

No runtime behavior change. All 22 cases retain environment/config precedence, Node-version defaults, WSL behavior, DNS normalization, and process-default inheritance. Graph imports fall from 13 to six, and memoization gains a direct decision-value oracle. The deterministic saving is seven graph loads; no end-to-end speed claim is made.

## Evidence

Production +0/-0; tests +27/-19.

- `node scripts/run-vitest.mjs extensions/telegram/src/network-config.test.ts extensions/telegram/src/fetch.test.ts` passed all 70 cases: 22 network-owner cases and 48 fetch siblings, with no failures or skips.
- WSL cache isolation, actual cached decision values, environment/config precedence, Node defaults, DNS decisions and fetch policy forwarding remain covered. Case-local reset and suite-final unmock/module reset passed in the combined execution.
- `OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs -- extensions/telegram/src/network-config.test.ts` passed, including plugin typechecks, lint, formatting and repository guards. Diff check and independent structured Codex autoreview passed.
- Exact-head hosted CI remains required before landing.

The local network test-body observation was 17.5 ms versus 19.1 ms in the baseline. The once-per-suite import is outside test-body timings, so those values do not measure the import savings.

### Exact-head network fixture proof and Vitest lifecycle

Addressing the [ClawSweeper proof and dependency-source requests](https://github.com/openclaw/openclaw/pull/134164#issuecomment-5479552051): independently reran the network-config owner and fetch sibling suites at `bc215789f0765227333d84eda540a5f24b881a02` on macOS with Node `v24.19.0` and installed Vitest **4.1.11**. The run completed on 2026-08-31 at 14:20:04 UTC with exit code 0: **70 tests passed** (22 network-config, 48 fetch), with zero failed, pending, or todo tests. The worktree stayed clean at the same head before and after execution.

Output path is redacted below.

```sh
node scripts/run-vitest.mjs \
  extensions/telegram/src/network-config.test.ts \
  extensions/telegram/src/fetch.test.ts \
  --reporter=verbose --reporter=json \
  --outputFile=<local-report>
```

Selected verbatim terminal output:

```text
[test] starting test/vitest/vitest.extension-telegram.config.ts
 ✓ |extension-telegram| extensions/telegram/src/fetch.test.ts > resolveTelegramFetch > keeps per-resolver transport policy isolated across multiple accounts 0ms
 ✓ |extension-telegram| extensions/telegram/src/network-config.test.ts > resolveTelegramAutoSelectFamilyDecision > WSL2 detection > 'disables autoSelectFamily on WSL2' 1ms
 ✓ |extension-telegram| extensions/telegram/src/network-config.test.ts > resolveTelegramAutoSelectFamilyDecision > WSL2 detection > 'respects config override on WSL2' 1ms
 ✓ |extension-telegram| extensions/telegram/src/network-config.test.ts > resolveTelegramAutoSelectFamilyDecision > WSL2 detection > 'respects env override on WSL2' 1ms
 ✓ |extension-telegram| extensions/telegram/src/network-config.test.ts > resolveTelegramAutoSelectFamilyDecision > WSL2 detection > 'uses Node 22 default when not on WSL2' 0ms
 ✓ |extension-telegram| extensions/telegram/src/network-config.test.ts > resolveTelegramAutoSelectFamilyDecision > WSL2 detection > memoizes WSL2 detection across repeated defaults 1ms
 Test Files  2 passed (2)
      Tests  70 passed (70)
[test] passed 1 Vitest shard in 11.38s
```

The [memoization case](https://github.com/openclaw/openclaw/blob/bc215789f0765227333d84eda540a5f24b881a02/extensions/telegram/src/network-config.test.ts#L145) observes the actual resolver cache: after the mocked WSL detector changes from true to false, the next default decision remains `{ value: false, source: "default-wsl2" }` and the detector has exactly one call. All five WSL cases and the retained transport-policy sibling case appear in the native results below. Environment/config precedence and DNS decisions also passed in the same focused invocation.

The installed dependency source was inspected directly, including package versions **vitest 4.1.11** and **@vitest/spy 4.1.11**:

- `vitest/dist/chunks/test.DNmyFkvJ.js:3654–3656` calls `resetModules(state().evaluatedModules)` without enabling mock reset. `vitest/dist/chunks/utils.BX5Fg8C4.js:29–42` retains `mock:` entries by default while invalidating ordinary module evaluation state. This is the dependency contract behind re-evaluating the resolver's cache while retaining the manual runtime-env mock.
- `@vitest/spy/dist/index.js:142–157` clears call/results state and resets the base/once implementations in `mockReset()`. The suite explicitly performs `mockReset().mockReturnValue(false)` before relevant cases; it does not rely on descriptor restoration to reset that manual mock.
- `@vitest/spy/dist/index.js:237–247,467–472` restores spied property descriptors through registered restore callbacks. Final module unmocking is explicit in the test's `afterAll`; Vitest's `doUnmock` queues removal at `vitest/dist/chunks/test.DNmyFkvJ.js:3585–3589`, with the registry contract documented at `vitest/dist/index.d.ts:451–459,602–608`.

This maintainer-authored PR changes one test file and leaves Telegram's production network owner unchanged. The evidence exercises the resolver and fetch fixtures with their existing mocks; no live Telegram or WSL-host run is claimed. Required exact-head CI is tracked separately.

Selected fields copied from the native JSON reporter follow. Only the local checkout prefix was removed from file names; native names (including reporter truncation), statuses, durations, and failure arrays are preserved.

```json
{
  "success": true,
  "numTotalTests": 70,
  "numPassedTests": 70,
  "numFailedTests": 0,
  "numPendingTests": 0,
  "numTodoTests": 0,
  "testResults": [
    {
      "name": "extensions/telegram/src/fetch.test.ts",
      "status": "passed",
      "assertionResults": [
        {
          "fullName": "resolveTelegramFetch keeps per-resolver transport policy isolated across multiple accounts",
          "status": "passed",
          "duration": 0.32254199999988487,
          "failureMessages": []
        }
      ]
    },
    {
      "name": "extensions/telegram/src/network-config.test.ts",
      "status": "passed",
      "assertionResults": [
        {
          "fullName": "resolveTelegramAutoSelectFamilyDecision WSL2 detection 'disables autoSelectFamily on WSL2'",
          "status": "passed",
          "duration": 0.6643340000000535,
          "failureMessages": []
        },
        {
          "fullName": "resolveTelegramAutoSelectFamilyDecision WSL2 detection 'respects config override on WSL2'",
          "status": "passed",
          "duration": 0.5455830000000788,
          "failureMessages": []
        },
        {
          "fullName": "resolveTelegramAutoSelectFamilyDecision WSL2 detection 'respects env override on WSL2'",
          "status": "passed",
          "duration": 0.5993330000001151,
          "failureMessages": []
        },
        {
          "fullName": "resolveTelegramAutoSelectFamilyDecision WSL2 detection 'uses Node 22 default when not on WSL2'",
          "status": "passed",
          "duration": 0.47541699999965203,
          "failureMessages": []
        },
        {
          "fullName": "resolveTelegramAutoSelectFamilyDecision WSL2 detection memoizes WSL2 detection across repeated defaults",
          "status": "passed",
          "duration": 0.5445410000002084,
          "failureMessages": []
        }
      ]
    }
  ]
}
```

Dependency documentation follow-up: the installed Vitest 4.1.11 declaration comment describes more mock-state resetting than its implementation performs. The source inspection above and the explicit per-case `mockReset()` establish the contract used by this suite.
