### PR TITLE
fix: restore channel recovery after crash-loop suppression

### DIFF
--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -1781,6 +1781,8 @@ describe("gateway run option collisions", () => {
   });
 
   it("re-inspects crash-loop breaker state for each boot iteration", async () => {
+    let firstBootRecovery: (() => boolean) | undefined;
+    bootLifecycle.record.mockReturnValueOnce("boot-1").mockReturnValueOnce("boot-2");
     runGatewayLoop.mockImplementationOnce(
       async ({
         beginBoot,
@@ -1791,6 +1793,7 @@ describe("gateway run option collisions", () => {
       }) => {
         await beginBoot?.(1000);
         await start({ startupStartedAt: 1000 });
+        firstBootRecovery = gatewayStartOptions(0).tryRecoverChannelAutostartSuppression;
         await beginBoot?.(2000);
         await start({ startupStartedAt: 2000 });
       },
@@ -1828,6 +1831,16 @@ describe("gateway run option collisions", () => {
       bootLifecycle.manualChannelStartHint,
     );
     expect(gatewayStartOptions(1).channelAutostartSuppression).toBeUndefined();
+    bootLifecycle.decisions.push({
+      tripped: false,
+      uncleanBoots: 0,
+      windowMs: 300_000,
+      shouldWriteStabilityBundle: false,
+      recovered: true,
+    });
+    expect(firstBootRecovery?.()).toBe(false);
+    expect(bootLifecycle.inspect).toHaveBeenCalledTimes(2);
+    expect(bootLifecycle.recover).not.toHaveBeenCalled();
     expect(gatewayLogMessages.some((message) => message.includes("breaker recovered"))).toBe(true);
   });
 

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -1125,23 +1125,8 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
       : "start";
   let crashLoopDecision: GatewayCrashLoopBreakerDecision | undefined;
   let channelAutostartSuppression: { reason: "crash-loop-breaker"; message: string } | undefined;
+  let tryRecoverChannelAutostartSuppression: (() => boolean) | undefined;
   let activeBootId: string | undefined;
-  const tryRecoverChannelAutostartSuppression = () => {
-    const decision = inspectGatewayCrashLoopBreaker(process.env);
-    // The current safe-mode boot remains an open row until the full window has
-    // drained. Requiring zero prevents a near-expiry history from restoring
-    // channels before this process itself has proven stable for the whole window.
-    if (!decision.recovered || decision.uncleanBoots !== 0) {
-      return false;
-    }
-    const recoveredBootId = recordGatewayCrashLoopRecovery(activeBootId, process.env);
-    if (!recoveredBootId) {
-      return false;
-    }
-    activeBootId = recoveredBootId;
-    gatewayLog.info("gateway restart-loop breaker recovered; channel auto-start restored");
-    return true;
-  };
   const beginBoot = async (startedAtMs: number) => {
     // run-loop calls beginBoot before every startGatewayServer invocation, so
     // in-process restarts re-evaluate breaker state instead of reusing stale mode.
@@ -1157,6 +1142,7 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
     // row exists for Doctor to reconcile after it repairs the schema.
     activeBootId = recordGatewayBootStart(process.env, startedAtMs, bootStartReason);
     channelAutostartSuppression = undefined;
+    tryRecoverChannelAutostartSuppression = undefined;
     if (crashLoopDecision.recovered) {
       gatewayLog.info("gateway restart-loop breaker recovered; channel auto-start restored");
     }
@@ -1167,6 +1153,26 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
       `gateway restart-loop breaker tripped: ${crashLoopDecision.uncleanBoots} unclean boot(s) within ${crashLoopDecision.windowMs}ms; ` +
       `suppressing channel/provider account auto-start. Inspect the stability bundle and fix the startup crash before restarting the service. ${formatGatewayCrashLoopManualChannelStartHint()}`;
     channelAutostartSuppression = { reason: "crash-loop-breaker", message };
+    const suppressedBootId = activeBootId;
+    tryRecoverChannelAutostartSuppression = () => {
+      if (!suppressedBootId || activeBootId !== suppressedBootId) {
+        return false;
+      }
+      const decision = inspectGatewayCrashLoopBreaker(process.env);
+      // The current safe-mode boot remains an open row until the full window has
+      // drained. Requiring zero prevents a near-expiry history from restoring
+      // channels before this process itself has proven stable for the whole window.
+      if (!decision.recovered || decision.uncleanBoots !== 0) {
+        return false;
+      }
+      const recoveredBootId = recordGatewayCrashLoopRecovery(suppressedBootId, process.env);
+      if (!recoveredBootId || activeBootId !== suppressedBootId) {
+        return false;
+      }
+      activeBootId = recoveredBootId;
+      gatewayLog.info("gateway restart-loop breaker recovered; channel auto-start restored");
+      return true;
+    };
     gatewayLog.error(message);
     if (crashLoopDecision.shouldWriteStabilityBundle) {
       await maybeWriteGatewayStartupFailureBundle(

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -271,6 +271,7 @@ function createManager(options?: {
   fillChannelDependencies?: boolean;
   ambientAutostartSuppressedChannelIds?: ReadonlySet<string>;
   tryRecoverAutostartSuppression?: () => boolean;
+  isClosing?: () => boolean;
   getNativeApprovalRuntime?: () => GatewayNativeApprovalRuntime | undefined;
 }) {
   const log = createSubsystemLogger("gateway/server-channels-test");
@@ -302,6 +303,7 @@ function createManager(options?: {
     ...(options?.tryRecoverAutostartSuppression
       ? { tryRecoverAutostartSuppression: options.tryRecoverAutostartSuppression }
       : {}),
+    ...(options?.isClosing ? { isClosing: options.isClosing } : {}),
     ...(options?.getNativeApprovalRuntime
       ? { getNativeApprovalRuntime: options.getNativeApprovalRuntime }
       : {}),
@@ -2553,6 +2555,32 @@ describe("server-channels auto restart", () => {
     ]);
     expect(manager.isHealthMonitorEnabled("discord", "work")).toBe(false);
     expect(manager.isManuallyStopped("discord", DEFAULT_ACCOUNT_ID)).toBe(true);
+  });
+
+  it("does not start recovered accounts after gateway close begins during handoff", async () => {
+    const accountStartReady = createDeferred();
+    const startAccount = vi.fn(async () => {});
+    let closing = false;
+    installTestRegistry(createTestPlugin({ startAccount }));
+    const manager = createManager({
+      deferStartupAccountStartsUntil: accountStartReady.promise,
+      isClosing: () => closing,
+      tryRecoverAutostartSuppression: () => true,
+    });
+    manager.setAutostartSuppression({
+      reason: "crash-loop-breaker",
+      message: "safe mode",
+    });
+
+    const recovery = manager.recoverAutostartSuppression();
+    await flushMicrotasks();
+    closing = true;
+    accountStartReady.resolve();
+    await recovery;
+    await flushMicrotasks();
+
+    expect(manager.getAutostartSuppression()).toBeNull();
+    expect(startAccount).not.toHaveBeenCalled();
   });
 
   it("keeps suppression when persisted recovery is not proven", async () => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -236,6 +236,7 @@ type ChannelManagerOptions = {
   getNativeApprovalRuntime?: () => GatewayNativeApprovalRuntime | undefined;
   ambientAutostartSuppressedChannelIds?: ReadonlySet<string>;
   tryRecoverAutostartSuppression?: () => boolean;
+  isClosing?: () => boolean;
 };
 
 type StopChannelOptions = {
@@ -823,7 +824,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             } else if (startupTrace) {
               await waitForChannelStartupHandoff();
             }
-            if (abort.signal.aborted || manuallyStopped.has(rKey)) {
+            if (abort.signal.aborted || manuallyStopped.has(rKey) || opts.isClosing?.()) {
               return;
             }
             const gatewayApprovalRuntime = opts.getNativeApprovalRuntime?.();
@@ -855,7 +856,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             }
             let startAccountTask: ReturnType<typeof startAccount> | undefined;
             await measureStartup(`channels.${channelId}.start-account-handoff`, () => {
-              if (abort.signal.aborted || manuallyStopped.has(rKey)) {
+              if (abort.signal.aborted || manuallyStopped.has(rKey) || opts.isClosing?.()) {
                 return;
               }
               const runStartAccount = () => {
@@ -917,7 +918,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
           // Only the task that still owns the store slot may write lifecycle state.
           const trackedPromise = task
             .then(() => {
-              if (abort.signal.aborted || manuallyStopped.has(rKey) || !isCurrentTask()) {
+              if (
+                abort.signal.aborted ||
+                manuallyStopped.has(rKey) ||
+                opts.isClosing?.() ||
+                !isCurrentTask()
+              ) {
                 return;
               }
               if (getRuntime(channelId, id).terminalDisconnect) {
@@ -930,7 +936,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               log.error?.(`[${id}] ${message}`);
             })
             .catch((err: unknown) => {
-              if (!isCurrentTask() || store.stops.has(id)) {
+              if (!isCurrentTask() || store.stops.has(id) || opts.isClosing?.()) {
                 return;
               }
               const message = formatErrorMessage(err);
@@ -948,7 +954,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               await cleanupTaskScopedApprovalRuntime("channel cleanup failed");
               // stopChannel owns the failed-teardown snapshot until a later
               // successful stop proves replacement is safe.
-              if (!isCurrentTask() || store.stops.has(id)) {
+              if (!isCurrentTask() || store.stops.has(id) || opts.isClosing?.()) {
                 return;
               }
               setStoppedRuntime(channelId, id, {
@@ -956,7 +962,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               });
             })
             .then(async () => {
-              if (!isCurrentTask() || store.stops.has(id)) {
+              if (!isCurrentTask() || store.stops.has(id) || opts.isClosing?.()) {
                 return;
               }
               if (manuallyStopped.has(rKey)) {
@@ -1052,7 +1058,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
               pendingAutoRestarts.add(rKey);
               try {
                 await sleepWithAbort(retry.delayMs, retry.signal);
-                if (manuallyStopped.has(rKey)) {
+                if (manuallyStopped.has(rKey) || opts.isClosing?.()) {
                   return;
                 }
                 if (store.tasks.get(id) === trackedPromise) {
@@ -1350,7 +1356,12 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
   const startChannels = async () => await startChannelsWithOptions();
 
   const recoverAutostartSuppression = async (): Promise<boolean> => {
-    if (!autostartSuppression || !opts.tryRecoverAutostartSuppression?.()) {
+    if (
+      !autostartSuppression ||
+      opts.isClosing?.() ||
+      !opts.tryRecoverAutostartSuppression?.() ||
+      opts.isClosing?.()
+    ) {
       return false;
     }
     autostartSuppression = null;

--- a/src/gateway/server-kernel.test.ts
+++ b/src/gateway/server-kernel.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import type { ChannelPlugin } from "../channels/plugins/types.public.js";
 import { flushDiagnosticsTimeline } from "../infra/diagnostics-timeline.js";
 import { createPluginRecord } from "../plugins/loader-records.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
@@ -20,6 +21,105 @@ import { createGatewayKernel } from "./server-kernel.js";
 import { createSyntheticPluginRuntimeClient } from "./server-plugin-runtime-client.js";
 
 describe("createGatewayKernel", () => {
+  it("does not start recovered channels after close prelude begins", async () => {
+    const port = await getFreePort();
+    const state = await createOpenClawTestState({
+      label: "gateway-kernel-breaker-recovery-close",
+      layout: "home",
+      env: {
+        OPENCLAW_GATEWAY_PASSWORD: undefined,
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+        OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+        OPENCLAW_SKIP_CANVAS_HOST: "1",
+        OPENCLAW_SKIP_CHANNELS: undefined,
+        OPENCLAW_SKIP_CRON: "1",
+        OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+        OPENCLAW_SKIP_PROVIDERS: undefined,
+        OPENCLAW_TEST_MINIMAL_GATEWAY: "0",
+        VITEST: "1",
+      },
+    });
+    const originalPluginRegistry = captureActivePluginRegistrySnapshot();
+    const startAccount = vi.fn(async () => {});
+    const channelPlugin: ChannelPlugin = {
+      ...createChannelTestPluginBase({
+        id: "telegram",
+        config: {
+          listAccountIds: (config) => Object.keys(config.channels?.telegram?.accounts ?? {}),
+          resolveAccount: (config, accountId) =>
+            config.channels?.telegram?.accounts?.[accountId ?? "default"] ?? {},
+          isConfigured: (account) =>
+            typeof (account as { botToken?: unknown }).botToken === "string",
+        },
+      }),
+      gateway: { startAccount },
+    };
+    const registry = createTestRegistry([
+      {
+        pluginId: channelPlugin.id,
+        plugin: channelPlugin,
+        source: "gateway-kernel-test",
+      },
+    ]);
+    registry.plugins.push(
+      createPluginRecord({
+        id: channelPlugin.id,
+        source: "gateway-kernel-test",
+        origin: "bundled",
+        enabled: true,
+        configSchema: false,
+      }),
+    );
+    let kernel: Awaited<ReturnType<typeof createGatewayKernel>> | undefined;
+    try {
+      stageActivePluginRegistry(registry, null, "default");
+      const token = "gateway-kernel-breaker-recovery-token";
+      await state.writeConfig({
+        gateway: {
+          auth: { mode: "token", token },
+          controlUi: { enabled: false },
+          port,
+        },
+        channels: {
+          telegram: {
+            accounts: {
+              default: { botToken: "telegram-breaker-recovery-token" },
+            },
+          },
+        },
+      });
+      state.applyEnv();
+      kernel = await createGatewayKernel(port, {
+        auth: { mode: "token", token },
+        bind: "loopback",
+        channelAutostartSuppression: {
+          reason: "crash-loop-breaker",
+          message: "safe mode",
+        },
+        controlUiEnabled: false,
+        sidecarStartup: "defer",
+        tryRecoverChannelAutostartSuppression: () => true,
+      });
+
+      await expect(kernel.channelManager.recoverAutostartSuppression()).resolves.toBe(true);
+      expect(startAccount).not.toHaveBeenCalled();
+
+      await kernel.beginClosePrelude();
+      kernel.releaseStartupAccountStarts();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(startAccount).not.toHaveBeenCalled();
+      expect(kernel.channelManager.isAutoRestartScheduled("telegram", "default")).toBe(false);
+    } finally {
+      try {
+        await kernel?.closeOnStartupFailure();
+      } finally {
+        restoreActivePluginRegistrySnapshot(originalPluginRegistry);
+        await state.cleanup();
+      }
+    }
+  });
+
   it("reports startup and readiness as draining during a direct close", async () => {
     const port = 19_789;
     const state = await createOpenClawTestState({

--- a/src/gateway/server-runtime-state-prepare.ts
+++ b/src/gateway/server-runtime-state-prepare.ts
@@ -444,6 +444,7 @@ export async function prepareGatewayKernelState(params: {
     ...(opts.tryRecoverChannelAutostartSuppression
       ? { tryRecoverAutostartSuppression: opts.tryRecoverChannelAutostartSuppression }
       : {}),
+    isClosing: () => lifecycle.closePreludeStarted,
   });
   channelManager.setAutostartSuppression(opts.channelAutostartSuppression ?? null);
   const sidecarStartup = opts.sidecarStartup ?? "start";

--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -221,7 +221,6 @@ export async function prepareGatewayServerBootstrap(input: {
   const activateRuntimeSecrets = createRuntimeSecretsActivator({
     logSecrets,
     emitStateEvent: emitSecretsStateEvent,
-    channelAutostartSuppression: opts.channelAutostartSuppression,
     ...(startupConfigLoad.pluginMetadataSnapshot
       ? { pluginMetadataSnapshot: startupConfigLoad.pluginMetadataSnapshot }
       : {}),

--- a/src/gateway/server-startup-config.breaker-secrets.integration.test.ts
+++ b/src/gateway/server-startup-config.breaker-secrets.integration.test.ts
@@ -1,4 +1,4 @@
-/** Integration coverage for breaker-suppressed startup SecretRef projection. */
+/** Integration coverage for breaker-safe startup SecretRef activation. */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "../secrets/runtime-telegram.test-support.ts";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
@@ -52,7 +52,7 @@ describe("gateway breaker SecretRef integration", () => {
   });
 
   it(
-    "preserves suppressed channel source for full reload projection",
+    "keeps unavailable channel owners isolated in the active startup config",
     async () => {
       await withEnvAsync(
         {
@@ -111,10 +111,6 @@ describe("gateway breaker SecretRef integration", () => {
             emitStateEvent: vi.fn(),
             prepareRuntimeSecretsSnapshot,
             activateRuntimeSecretsSnapshot: activateSecretsRuntimeSnapshot,
-            channelAutostartSuppression: {
-              reason: "crash-loop-breaker",
-              message: "breaker tripped: 20 unclean boots",
-            },
           });
 
           const startup = await prepareGatewayStartupConfig({
@@ -123,14 +119,22 @@ describe("gateway breaker SecretRef integration", () => {
           });
 
           expect(startup.cfg.gateway?.auth?.token).toBe("resolved-gateway-token");
-          expect(startup.cfg.channels).toBeUndefined();
+          expect(startup.cfg.channels?.telegram?.botToken).toEqual(channelTokenRef);
           const activeStartup = getActiveSecretsRuntimeSnapshot();
           if (!activeStartup) {
             throw new Error("Expected an active startup secrets snapshot");
           }
           expect(activeStartup.sourceConfig.gateway?.auth?.token).toEqual(gatewayTokenRef);
           expect(activeStartup.sourceConfig.channels?.telegram?.botToken).toEqual(channelTokenRef);
-          expect(activeStartup.config.channels).toBeUndefined();
+          expect(activeStartup.config.channels?.telegram?.botToken).toEqual(channelTokenRef);
+          expect(activeStartup.degradedOwners).toMatchObject([
+            {
+              ownerKind: "account",
+              ownerId: "telegram:default",
+              state: "unavailable",
+              paths: ["channels.telegram.botToken"],
+            },
+          ]);
 
           process.env[CHANNEL_TOKEN_ENV] = "restored-channel-token";
           const reloaded = await activateRuntimeSecrets(activeStartup.sourceConfig, {

--- a/src/gateway/server-startup-config.ts
+++ b/src/gateway/server-startup-config.ts
@@ -37,7 +37,6 @@ import {
 } from "../secrets/runtime-state.js";
 import { logRuntimeSecretWarnings } from "../secrets/runtime-warning-log.js";
 import { createLazyPromise } from "../shared/lazy-runtime.js";
-import type { ChannelAutostartSuppression } from "./server-channels.js";
 import {
   applyGatewayAuthOverridesForStartupPreflight,
   assertRuntimeGatewayAuthNotKnownWeak,
@@ -51,10 +50,7 @@ import {
   logPreparedSecretDegradations,
   logThrownSecretDegradations,
 } from "./server-startup-secret-diagnostics.js";
-import {
-  resolveGatewayStartupSecretProjection,
-  resolveGatewayStartupSourceConfig,
-} from "./server-startup-secret-surfaces.js";
+import { resolveGatewayStartupSourceConfig } from "./server-startup-secret-surfaces.js";
 import { ensureGatewayStartupAuth } from "./startup-auth.js";
 export {
   loadGatewayStartupConfigSnapshot,
@@ -139,7 +135,6 @@ export function createRuntimeSecretsActivator(params: {
   activateRuntimeSecretsSnapshot?: ActivateRuntimeSecretsSnapshot;
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
   pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins" | "manifestRegistry">;
-  channelAutostartSuppression?: ChannelAutostartSuppression | null;
 }): ActivateRuntimeSecrets {
   let secretsDegraded = false;
   let degradationGeneration = 0;
@@ -358,12 +353,10 @@ export function createRuntimeSecretsActivator(params: {
     await runWithSecretsActivationLock(async () => {
       let activationSourceConfig = config;
       try {
-        const { sourceConfig, assignmentConfig } = resolveGatewayStartupSecretProjection({
+        const sourceConfig = resolveGatewayStartupSourceConfig(
           config,
-          reason: activationParams.reason,
-          channelAutostartSuppression: params.channelAutostartSuppression,
-          ...(activationParams.env ? { env: activationParams.env } : {}),
-        });
+          activationParams.env ?? process.env,
+        );
         activationSourceConfig = sourceConfig;
         const startupPreflight =
           activationParams.reason === "startup" || activationParams.reason === "restart-check";
@@ -371,8 +364,7 @@ export function createRuntimeSecretsActivator(params: {
           activationParams.reason === "startup" &&
           activationParams.activate &&
           !params.prepareRuntimeSecretsSnapshot &&
-          !params.activateRuntimeSecretsSnapshot &&
-          assignmentConfig === undefined
+          !params.activateRuntimeSecretsSnapshot
         ) {
           const startupEnv = activationParams.env ?? process.env;
           const fastPath = hasLegacyAuthProfileSourcesForStartup({
@@ -423,7 +415,6 @@ export function createRuntimeSecretsActivator(params: {
           () =>
             prepareRuntimeSecretsSnapshot({
               config: sourceConfig,
-              ...(assignmentConfig !== undefined ? { assignmentConfig } : {}),
               allowUnavailableSecretOwners,
               ...(activationParams.env ? { env: activationParams.env } : {}),
               includeAuthStoreRefs: activationParams.includeAuthStoreRefs,

--- a/src/gateway/server-startup-secret-surfaces.test-support.ts
+++ b/src/gateway/server-startup-secret-surfaces.test-support.ts
@@ -1,7 +1,7 @@
 /** Secret-surface projection coverage loaded by the startup SecretRef suite. */
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { resolveGatewayStartupSecretProjection } from "./server-startup-secret-surfaces.js";
+import { resolveGatewayStartupSourceConfig } from "./server-startup-secret-surfaces.js";
 
 function channelConfig(): OpenClawConfig {
   return {
@@ -14,64 +14,17 @@ function channelConfig(): OpenClawConfig {
 }
 
 describe("gateway startup secret surfaces", () => {
-  it("preserves source while pruning breaker-suppressed startup assignments", () => {
+  it("preserves channel config during ordinary startup", () => {
     const config = channelConfig();
-    const projection = resolveGatewayStartupSecretProjection({
-      config,
-      reason: "startup",
-      channelAutostartSuppression: {
-        reason: "crash-loop-breaker",
-        message: "safe mode",
-      },
-      env: {},
-    });
-
-    expect(projection.sourceConfig).toBe(config);
-    expect(projection.sourceConfig.channels).toBeDefined();
-    expect(projection.assignmentConfig).toBeDefined();
-    expect(projection.assignmentConfig?.channels).toBeUndefined();
+    expect(resolveGatewayStartupSourceConfig(config, {})).toBe(config);
   });
 
-  it.each(["reload", "restart-check"] as const)(
-    "keeps full assignments during %s while startup suppression is active",
-    (reason) => {
-      const config = channelConfig();
-      const projection = resolveGatewayStartupSecretProjection({
-        config,
-        reason,
-        channelAutostartSuppression: {
-          reason: "crash-loop-breaker",
-          message: "safe mode",
-        },
-        env: {},
-      });
-
-      expect(projection.sourceConfig).toBe(config);
-      expect(projection.assignmentConfig).toBeUndefined();
+  it.each(["OPENCLAW_SKIP_CHANNELS", "OPENCLAW_SKIP_PROVIDERS"] as const)(
+    "preserves explicit %s behavior",
+    (key) => {
+      expect(
+        resolveGatewayStartupSourceConfig(channelConfig(), { [key]: "1" }).channels,
+      ).toBeUndefined();
     },
   );
-
-  it("keeps full startup assignments without breaker suppression", () => {
-    const config = channelConfig();
-    const projection = resolveGatewayStartupSecretProjection({
-      config,
-      reason: "startup",
-      channelAutostartSuppression: null,
-      env: {},
-    });
-
-    expect(projection.sourceConfig).toBe(config);
-    expect(projection.assignmentConfig).toBeUndefined();
-  });
-
-  it("preserves explicit skip behavior", () => {
-    const projection = resolveGatewayStartupSecretProjection({
-      config: channelConfig(),
-      reason: "startup",
-      env: { OPENCLAW_SKIP_CHANNELS: "1" },
-    });
-
-    expect(projection.sourceConfig.channels).toBeUndefined();
-    expect(projection.assignmentConfig).toBeUndefined();
-  });
 });

--- a/src/gateway/server-startup-secret-surfaces.ts
+++ b/src/gateway/server-startup-secret-surfaces.ts
@@ -1,35 +1,5 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
-import type { ChannelAutostartSuppression } from "./server-channels.js";
-
-type GatewaySecretsActivationReason = "startup" | "reload" | "restart-check";
-
-/**
- * Keeps the recoverable source config separate from the SecretRef assignment
- * surface that is safe to resolve during crash-loop recovery.
- */
-export function resolveGatewayStartupSecretProjection(params: {
-  config: OpenClawConfig;
-  reason: GatewaySecretsActivationReason;
-  channelAutostartSuppression?: ChannelAutostartSuppression | null;
-  env?: NodeJS.ProcessEnv;
-}): { sourceConfig: OpenClawConfig; assignmentConfig?: OpenClawConfig } {
-  const sourceConfig = resolveGatewayStartupSourceConfig(params.config, params.env ?? process.env);
-  if (
-    params.reason !== "startup" ||
-    params.channelAutostartSuppression == null ||
-    !sourceConfig.channels
-  ) {
-    return { sourceConfig };
-  }
-  return {
-    sourceConfig,
-    assignmentConfig: {
-      ...sourceConfig,
-      channels: undefined,
-    },
-  };
-}
 
 export function resolveGatewayStartupSourceConfig(
   config: OpenClawConfig,

--- a/src/gateway/server.channels-start-outcomes.test.ts
+++ b/src/gateway/server.channels-start-outcomes.test.ts
@@ -1,9 +1,11 @@
 /** Channel recovery replies preserve decisions from the real account lifecycle owner. */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import "../secrets/runtime-telegram.test-support.ts";
 import type { ChannelGatewayContext } from "../channels/plugins/types.adapters.js";
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
 import { writeConfigFile } from "../config/config.js";
+import { getRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
 import { setActiveDegradedSecretOwners } from "../secrets/runtime-degraded-state.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { withEnvAsync } from "../test-utils/env.js";
@@ -18,7 +20,11 @@ import {
 
 installGatewayTestHooks({ scope: "suite" });
 
-type TestAccount = { accountId: string };
+type TestAccount = {
+  accountId: string;
+  enabled?: boolean;
+  token?: string;
+};
 
 describe("channels.start account outcomes", () => {
   let server: Awaited<ReturnType<typeof startTestGatewayServer>> | undefined;
@@ -27,6 +33,138 @@ describe("channels.start account outcomes", () => {
     await server?.close();
     server = undefined;
     setActiveDegradedSecretOwners([]);
+  });
+
+  it("starts config-backed accounts manually while breaker suppression remains active", async () => {
+    await withEnvAsync(
+      {
+        BREAKER_RESOLVED_CHANNEL_TOKEN: "resolved-channel-token",
+        BREAKER_MISSING_CHANNEL_TOKEN: undefined,
+        TELEGRAM_BOT_TOKEN: "ambient-token-must-not-win",
+        OPENCLAW_SKIP_CHANNELS: undefined,
+        OPENCLAW_SKIP_PROVIDERS: undefined,
+      },
+      async () => {
+        const startAccount = vi.fn(
+          async ({ abortSignal }: ChannelGatewayContext<TestAccount>) =>
+            await new Promise<void>((resolve) => {
+              abortSignal.addEventListener("abort", () => resolve(), { once: true });
+            }),
+        );
+        const plugin: ChannelPlugin<TestAccount> = {
+          ...createChannelTestPluginBase({ id: "telegram" }),
+          config: {
+            listAccountIds: (config) => Object.keys(config.channels?.telegram?.accounts ?? {}),
+            defaultAccountId: () => "plaintext",
+            resolveAccount: (config, accountId) => {
+              const id = accountId ?? "plaintext";
+              const configured = config.channels?.telegram?.accounts?.[id];
+              return {
+                accountId: id,
+                enabled: configured?.enabled !== false,
+                token: typeof configured?.botToken === "string" ? configured.botToken : undefined,
+              };
+            },
+            isEnabled: (account) => account.enabled !== false,
+            isConfigured: (account) => Boolean(account.token),
+          },
+          gateway: { startAccount },
+        };
+        setTestPluginRegistry(
+          createTestRegistry([{ pluginId: "telegram", source: "test", plugin }]),
+        );
+        await writeConfigFile({
+          gateway: {
+            mode: "local",
+            bind: "loopback",
+            auth: { mode: "none" },
+            reload: { mode: "off" },
+          },
+          secrets: { providers: { default: { source: "env" } } },
+          channels: {
+            telegram: {
+              enabled: true,
+              healthMonitor: { enabled: false },
+              accounts: {
+                plaintext: { botToken: "plaintext-channel-token" },
+                resolved: {
+                  botToken: {
+                    source: "env",
+                    provider: "default",
+                    id: "BREAKER_RESOLVED_CHANNEL_TOKEN",
+                  },
+                },
+                unavailable: {
+                  botToken: {
+                    source: "env",
+                    provider: "default",
+                    id: "BREAKER_MISSING_CHANNEL_TOKEN",
+                  },
+                },
+              },
+            },
+          },
+        });
+        const port = await getGatewayTestPort();
+        server = await startTestGatewayServer(port, {
+          auth: { mode: "none" },
+          channelAutostartSuppression: {
+            reason: "crash-loop-breaker",
+            message: "synthetic safe mode",
+          },
+        });
+        const runtimeConfig = getRuntimeConfigSnapshot();
+        expect(runtimeConfig?.channels?.telegram?.accounts?.plaintext?.botToken).toBe(
+          "plaintext-channel-token",
+        );
+        expect(runtimeConfig?.channels?.telegram?.accounts?.resolved?.botToken).toBe(
+          "resolved-channel-token",
+        );
+        expect(runtimeConfig?.channels?.telegram?.accounts?.unavailable?.botToken).toMatchObject({
+          source: "env",
+          provider: "default",
+          id: "BREAKER_MISSING_CHANNEL_TOKEN",
+        });
+        expect(startAccount).not.toHaveBeenCalled();
+
+        const ws = await connectWebchatClient({ port, scopes: ["operator.admin"] });
+        try {
+          const plaintext = await rpcReq(ws, "channels.start", {
+            channel: "telegram",
+            accountId: "plaintext",
+          });
+          expect(plaintext, JSON.stringify(plaintext)).toMatchObject({
+            ok: true,
+            payload: {
+              accountId: "plaintext",
+              started: true,
+              outcome: { status: "handed-off" },
+            },
+          });
+          await vi.waitFor(() => expect(startAccount).toHaveBeenCalledOnce());
+          expect(
+            startAccount.mock.calls.map(([context]) => ({
+              accountId: context.accountId,
+              token: context.account.token,
+            })),
+          ).toEqual(
+            expect.arrayContaining([{ accountId: "plaintext", token: "plaintext-channel-token" }]),
+          );
+
+          const unavailable = await rpcReq(ws, "channels.start", {
+            channel: "telegram",
+            accountId: "unavailable",
+          });
+          expect(unavailable).toMatchObject({
+            ok: false,
+            error: { code: "UNAVAILABLE" },
+          });
+          expect(startAccount).toHaveBeenCalledOnce();
+        } finally {
+          ws.close();
+        }
+      },
+    );
   });
 
   it("reports skips and in-flight ownership while manual recovery bypasses the breaker", async () => {

--- a/src/gateway/server.channels-start-outcomes.test.ts
+++ b/src/gateway/server.channels-start-outcomes.test.ts
@@ -1,4 +1,5 @@
 /** Channel recovery replies preserve decisions from the real account lifecycle owner. */
+import { randomUUID } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import "../secrets/runtime-telegram.test-support.ts";
@@ -13,6 +14,7 @@ import {
   connectWebchatClient,
   getGatewayTestPort,
   installGatewayTestHooks,
+  onceMessage,
   rpcReq,
   setTestPluginRegistry,
   startTestGatewayServer,
@@ -25,6 +27,19 @@ type TestAccount = {
   enabled?: boolean;
   token?: string;
 };
+
+async function rpcReqWithActiveRuntime(ws: WebSocket, method: string, params: unknown) {
+  const id = randomUUID();
+  const response = onceMessage<{
+    type: "res";
+    id: string;
+    ok: boolean;
+    payload?: Record<string, unknown>;
+    error?: { message?: string; code?: string; details?: unknown };
+  }>(ws, (value) => value?.type === "res" && value.id === id);
+  ws.send(JSON.stringify({ type: "req", id, method, params }));
+  return await response;
+}
 
 describe("channels.start account outcomes", () => {
   let server: Awaited<ReturnType<typeof startTestGatewayServer>> | undefined;
@@ -51,20 +66,24 @@ describe("channels.start account outcomes", () => {
               abortSignal.addEventListener("abort", () => resolve(), { once: true });
             }),
         );
+        const resolveAccount: ChannelPlugin<TestAccount>["config"]["resolveAccount"] = (
+          config,
+          accountId,
+        ) => {
+          const id = accountId ?? "plaintext";
+          const configured = config.channels?.telegram?.accounts?.[id];
+          return {
+            accountId: id,
+            enabled: configured?.enabled !== false,
+            token: typeof configured?.botToken === "string" ? configured.botToken : undefined,
+          };
+        };
         const plugin: ChannelPlugin<TestAccount> = {
           ...createChannelTestPluginBase({ id: "telegram" }),
           config: {
             listAccountIds: (config) => Object.keys(config.channels?.telegram?.accounts ?? {}),
             defaultAccountId: () => "plaintext",
-            resolveAccount: (config, accountId) => {
-              const id = accountId ?? "plaintext";
-              const configured = config.channels?.telegram?.accounts?.[id];
-              return {
-                accountId: id,
-                enabled: configured?.enabled !== false,
-                token: typeof configured?.botToken === "string" ? configured.botToken : undefined,
-              };
-            },
+            resolveAccount,
             isEnabled: (account) => account.enabled !== false,
             isConfigured: (account) => Boolean(account.token),
           },
@@ -129,7 +148,7 @@ describe("channels.start account outcomes", () => {
 
         const ws = await connectWebchatClient({ port, scopes: ["operator.admin"] });
         try {
-          const plaintext = await rpcReq(ws, "channels.start", {
+          const plaintext = await rpcReqWithActiveRuntime(ws, "channels.start", {
             channel: "telegram",
             accountId: "plaintext",
           });
@@ -151,7 +170,20 @@ describe("channels.start account outcomes", () => {
             expect.arrayContaining([{ accountId: "plaintext", token: "plaintext-channel-token" }]),
           );
 
-          const unavailable = await rpcReq(ws, "channels.start", {
+          const resolved = await rpcReqWithActiveRuntime(ws, "channels.start", {
+            channel: "telegram",
+            accountId: "resolved",
+          });
+          expect(resolved, JSON.stringify(resolved)).toMatchObject({
+            ok: true,
+            payload: {
+              accountId: "resolved",
+              started: true,
+              outcome: { status: "handed-off" },
+            },
+          });
+
+          const unavailable = await rpcReqWithActiveRuntime(ws, "channels.start", {
             channel: "telegram",
             accountId: "unavailable",
           });
@@ -159,7 +191,7 @@ describe("channels.start account outcomes", () => {
             ok: false,
             error: { code: "UNAVAILABLE" },
           });
-          expect(startAccount).toHaveBeenCalledOnce();
+          expect(startAccount).toHaveBeenCalledTimes(2);
         } finally {
           ws.close();
         }


### PR DESCRIPTION
Closes #134134

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Fixes an issue where operators following the documented crash-loop recovery procedure could not manually start configured channel accounts because safe-mode startup removed their channel configuration from the active runtime.

## Why This Change Was Made

Crash-loop suppression now remains a channel lifecycle decision while the active secrets runtime retains owner-isolated channel configuration. Recovery callbacks are bound to the Gateway boot that created them, and deferred or retrying channel starts stop when that Gateway lifetime begins closing.

The change does not add configuration, protocol, persistence, migration, or plugin-specific behavior.

## User Impact

Operators can use `channels.start` to recover configured accounts while crash-loop suppression remains active, without first running `secrets reload`. Unavailable channel credentials remain isolated and fail closed, healthy sibling accounts remain usable, and automatic channel startup remains suppressed until recovery is proven.

## Evidence

The live reproduction in #134134 showed the Gateway remain healthy while a configured SMS account was reported as `unconfigured`; `secrets reload` made the same manual start succeed. The same failure occurred with plaintext and SecretRef credentials.

The first focused Blacksmith Testbox run passed 115 of 116 assertions across the Gateway composition, startup secrets, channel lifecycle, and CLI boot-recovery suites. It verified plaintext manual recovery, unavailable-owner isolation, suppression behavior, close-time handoff fencing, boot-bound callback behavior, and existing channel ownership/retry regressions. The remaining newly added resolved-SecretRef assertion is being completed on this PR before final review and landing.

Exact-head changed gates, independent Workloop review, repository autoreview, and required CI will complete on this PR before merge.
