### PR TITLE
fix(logging): keep long secret redaction safe and defer repeated probes

### DIFF
--- a/src/logging/secret-redaction-registry.ts
+++ b/src/logging/secret-redaction-registry.ts
@@ -5,11 +5,11 @@ const MIN_SECRET_VALUE_LENGTH = 6;
 const MAX_SECRET_VALUES = 512;
 
 const registeredValues = new Map<string, true>();
-let compiledMatcher: RegExp | undefined;
-let firstChars = new Set<string>();
+let compiledMatcher: { prefixes: RegExp; buckets: Map<string, string[]> } | undefined;
+let firstChars: Set<string> | undefined;
 
-function rebuildProbe(): void {
-  firstChars = new Set([...registeredValues.keys()].map((value) => value.charAt(0)));
+function invalidateMatcher(): void {
+  firstChars = undefined;
   compiledMatcher = undefined;
 }
 
@@ -20,7 +20,7 @@ function registerOneSecretValue(value: string): void {
   }
   registeredValues.set(value, true);
   pruneMapToMaxSize(registeredValues, MAX_SECRET_VALUES);
-  rebuildProbe();
+  invalidateMatcher();
 }
 
 /** Registers one resolved secret for exact-value log redaction. */
@@ -62,6 +62,8 @@ export function redactRegisteredSecretValues(
     return text;
   }
   let couldMatch = false;
+  // Registration can add several surface forms; prepare their probe once on first use.
+  firstChars ??= new Set([...registeredValues.keys()].map((value) => value.charAt(0)));
   for (const firstChar of firstChars) {
     if (text.includes(firstChar)) {
       couldMatch = true;
@@ -71,19 +73,52 @@ export function redactRegisteredSecretValues(
   if (!couldMatch) {
     return text;
   }
-  compiledMatcher ??= new RegExp(
-    [...registeredValues.keys()]
-      .toSorted((left, right) => right.length - left.length)
-      .map(escapeRegExp)
-      .join("|"),
-    "g",
-  );
-  return text.replace(compiledMatcher, (value) => mask(value));
+  if (!compiledMatcher) {
+    const buckets = new Map<string, string[]>();
+    for (const value of [...registeredValues.keys()].toSorted(
+      (left, right) => right.length - left.length,
+    )) {
+      const prefix = value.slice(0, MIN_SECRET_VALUE_LENGTH);
+      const bucket = buckets.get(prefix);
+      if (bucket) {
+        bucket.push(value);
+      } else {
+        buckets.set(prefix, [value]);
+      }
+    }
+    // Supported store values can exceed the regex engine's literal span limit.
+    // Compile fixed-width prefixes; verify complete values against the text.
+    compiledMatcher = {
+      prefixes: new RegExp([...buckets.keys()].map(escapeRegExp).join("|"), "g"),
+      buckets,
+    };
+  }
+  const { prefixes, buckets } = compiledMatcher;
+  const matches: { index: number; value: string }[] = [];
+  prefixes.lastIndex = 0;
+  for (let match = prefixes.exec(text); match; match = prefixes.exec(text)) {
+    const index = match.index;
+    const value = buckets.get(match[0])?.find((candidate) => text.startsWith(candidate, index));
+    if (value !== undefined) {
+      matches.push({ index, value });
+    }
+    // A rejected prefix may overlap a real match beginning one code unit later.
+    prefixes.lastIndex = index + (value?.length ?? 1);
+  }
+  // Global replacement fixes its matches before callbacks. Nested registration
+  // must affect the next/nested call, never the remainder of this one.
+  let result = "";
+  let cursor = 0;
+  for (const match of matches) {
+    result += `${text.slice(cursor, match.index)}${mask(match.value)}`;
+    cursor = match.index + match.value.length;
+  }
+  return result + text.slice(cursor);
 }
 
 function resetSecretRedactionRegistryForTest(): void {
   registeredValues.clear();
-  rebuildProbe();
+  invalidateMatcher();
 }
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {

--- a/src/secrets/sentinel.test.ts
+++ b/src/secrets/sentinel.test.ts
@@ -86,8 +86,10 @@ describe("secret sentinels", () => {
     },
   );
 
-  it("registers minted values for exact redaction across registry eviction", () => {
-    const first = "sentinel-registry-value-000";
+  it.each([
+    { label: "ordinary", first: "sentinel-registry-value-000" },
+    { label: "64 KiB", first: "x".repeat(64 * 1024) },
+  ])("registers minted values across registry eviction ($label)", ({ first }) => {
     const firstSentinel = mintSecretSentinel(first, { label: "model-auth:0" });
     for (let index = 1; index <= 512; index += 1) {
       mintSecretSentinel(`sentinel-registry-value-${index.toString().padStart(3, "0")}`, {


### PR DESCRIPTION
## What Problem This Solves

Fixes a crash when formatting diagnostics after a supported 64 KiB secret has entered the exact-redaction registry. The store accepts that value, but compiling complete secret values into one regular expression can exceed the engine's limit. The built CLI baseline passes three sets, oversized rejection and metadata listing, then exits 7 while formatting the normal write-only get refusal instead of returning exit 2.

Registration also rebuilds its first-character probe after each newly admitted surface form, even when several forms are added before the next read.

## Why This Change Was Made

Keep one exact-redaction owner. Compile bounded six-code-unit prefixes and verify complete values in longest-first buckets. Advance rejected prefixes one code unit to preserve overlapping matches; collect matches before mask callbacks to preserve nested registration, reset and throw behavior. Invalidate the probe on membership changes and construct it on the first nonempty read.

The 512-value cap, minimum length, URI/JSON/raw forms, raw-newest eviction, duplicate refresh, mask conventions and store admission policy remain unchanged. There is no new dependency, configuration, schema, cache lifetime, public API or fallback. The complete-value indexOf alternative was measured and rejected because full-capacity collision reads were much slower.

Production is +49/-14, net +35; tests +4/-2, net +2. Growth preserves the existing supported-value and callback-order contracts. The performance campaign counts lazy preparation once; the long-value correctness repair adds zero performance counts.

## User Impact

Accepted long secrets are masked without crashing the diagnostic formatter. Bursts that register several secret forms avoid redundant probe construction. This is not a claim that every redaction workload becomes faster.

## Evidence

On current main, the existing eviction/resolve/redaction test passes its ordinary row and fails only its new 64 KiB row with the native regex-size error. Identical assertions pass both rows with the fix. All 291 tests across nine canonical suites pass, covering registry/redactor, sentinel, SQLite store, CLI, proxy capture and worker-output owners. Full changed-file checks pass (255.38 seconds). Managed review is scoped-clean; independent complete-source and saved-evidence review reports no actionable defect. The final measured owner differs only in type-declaration formatting.

Historical complete-owner differential proof retains 197,137 cases, 985,355 comparisons and 3,881,267 assertions. A separate 160-child repair proof retains 428 exact outputs, four fixed long-sentinel outcomes and 34 classified engine failures in unrepaired variants. Failures are not timing denominators.

All 60 serial timing children, 154 workloads and 16,632 raw samples are retained and independently reconciled. At capacity, three-form registration plus first read improves from 91.54/91.96 to 42.85/40.60 microseconds in forward/reverse orders. Actual three-form sentinel sealing improves from 41.67/40.77 to 21.86/22.13 microseconds. Comparing only the lazy step, eager-prefix registration plus first read takes 52.00/49.83 microseconds; selected takes 42.85/40.60.

Costs remain explicit: original-to-selected is faster in both orders on 50 rows, slower on 67, mixed/equal on 37. Eager-prefix-to-selected counts are 50/32/72. Some small-registry first-read compositions and warm reads regress; 128 KiB diagnostics add roughly 25–113 microseconds versus eager prefix. These unweighted counts are not an aggregate speed score. No long-value before/candidate timing, whole-Gateway/model latency, startup or memory-savings claim is made.

Fresh build at ab645ea2ea411b7a65fa76c4421fc2c87a7d9a0f passes (157.41 seconds). The unchanged seven-call built CLI candidate passes: three real SQLite sets, oversized rejection, metadata-only list, write-only get refusal with exit 2, and the real compiled store/sentinel/redactor owner check. All 74 owner checks pass, including complete 64 KiB masking, shared registry/export identity, transformed forms, duplicate reads and eviction/refresh. All seven leaders/groups are absent, all eight exact task coordinator paths are gone, parent directory identity is unchanged and the fixture is removed. Network was denied; only synthetic values were used. This is actual CLI/SQLite behavior proof, not another benchmark.

Historical source/build labels remain distinct. The original failed CLI baseline is preserved, not rerun or described as a pass. Regression introduction provenance is unclaimed; the current failing owner boundary is reproduced directly. The authorizing maintainer is an active member of the listed security-owner team; current enforced GitHub checks still govern landing.


## Inspectable after-fix execution receipt

This addresses the full ClawSweeper review and its Rank-up request at 14:10 UTC. Below is a redacted projection of the actual retained seven-call execution receipt and complete 74-check owner result from the built candidate. Local paths and process identifiers are omitted; no result is regenerated or inferred from tests. The private fixture and terminal bytes were removed after the runner checked them; these are saved assertion/exit receipts, not a reconstructed terminal transcript. An independent reviewer reconciled their hashes, compiled export identity, assertions and physical cleanup.

The executed owner assertion behind `supported-long-value-fully-redacted` was:

```js
const MAX = 'x'.repeat(65_536);
const fullMaskedLong = 'xxxxxx…xxxx';
// redactor is imported from the hash-bound actual built redactor module.
result = redactor.redactSensitiveText(MAX, { mode: 'tools' });
check(!engineLimit && result === fullMaskedLong, 'supported-long-value-fully-redacted');
```

The refusal step invokes the actual built `secrets store get PERF_REGISTRY_RAW --plain` command after listing the same three stored secrets, including the 64 KiB entry. It also asserts `write-only by design` in stderr. It returned 2; the preserved baseline returned 7.

<details>
<summary>Actual redacted candidate receipt</summary>

```json
{
  "head": "ab645ea2ea411b7a65fa76c4421fc2c87a7d9a0f",
  "started": "2026-08-31T14:02:28.235699+00:00",
  "ended": "2026-08-31T14:02:30.684508+00:00",
  "ok": true,
  "calls": [
    {
      "name": "set-raw",
      "expectedExit": 0,
      "exit": 0,
      "group": "dead"
    },
    {
      "name": "set-forms",
      "expectedExit": 0,
      "exit": 0,
      "group": "dead"
    },
    {
      "name": "set-max",
      "expectedExit": 0,
      "exit": 0,
      "group": "dead"
    },
    {
      "name": "reject-oversized",
      "expectedExit": 2,
      "exit": 2,
      "group": "dead"
    },
    {
      "name": "metadata-list",
      "expectedExit": 0,
      "exit": 0,
      "group": "dead"
    },
    {
      "name": "refuse-plaintext-get",
      "expectedExit": 2,
      "exit": 2,
      "group": "dead"
    },
    {
      "name": "owner-proof",
      "expectedExit": 0,
      "exit": 0,
      "group": "dead"
    }
  ],
  "ownerResult": {
    "ok": true,
    "stage": "complete",
    "failure": null,
    "longOutcome": "masked",
    "cliCreatedDatabaseObserved": true,
    "checks": [
      "absolute-task-paths",
      "declared-label",
      "owned-fixture",
      "private-fixture-mode",
      "sterile-cwd",
      "environment-HOME",
      "environment-OPENCLAW_HOME",
      "environment-OPENCLAW_STATE_DIR",
      "environment-OPENCLAW_CONFIG_PATH",
      "environment-TMPDIR",
      "absent-VITEST",
      "absent-NODE_ENV",
      "absent-NODE_OPTIONS",
      "absent-TSX_TSCONFIG_PATH",
      "absent-OPENAI_API_KEY",
      "absent-ANTHROPIC_API_KEY",
      "module-path-store",
      "module-hash-store",
      "module-export-store-assertSecretStoreValue",
      "module-export-store-readSecretStoreExecEnvironment",
      "module-export-store-readSecretStoreValue",
      "module-path-storeOwner",
      "module-hash-storeOwner",
      "module-export-storeOwner-assertSecretStoreValue",
      "module-export-storeOwner-readSecretStoreExecEnvironment",
      "module-export-storeOwner-readSecretStoreValue",
      "module-path-registry",
      "module-hash-registry",
      "module-export-registry-registerSecretValueForRedaction",
      "module-export-registry-isSecretValueRegisteredForRedaction",
      "module-export-registry-hasRegisteredSecretValuesForRedaction",
      "module-export-registry-redactRegisteredSecretValues",
      "module-path-sentinel",
      "module-hash-sentinel",
      "module-export-sentinel-looksLikeSecretSentinel",
      "module-export-sentinel-resolveSecretSentinel",
      "module-path-redactor",
      "module-hash-redactor",
      "module-export-redactor-redactSensitiveText",
      "module-path-coordinator",
      "module-hash-coordinator",
      "module-export-coordinator-resolveStateDatabaseCoordinatorPath",
      "actual-canonical-coordinator-path",
      "public-store-export-identity-assertSecretStoreValue",
      "public-store-export-identity-readSecretStoreExecEnvironment",
      "public-store-export-identity-readSecretStoreValue",
      "fresh-process-empty-registry",
      "empty-read",
      "empty-registry-full-redactor",
      "unregistered-raw-full-redactor",
      "cli-created-canonical-database",
      "secrets-not-plaintext-exec-env",
      "normal-exec-sentinel-names",
      "no-egress-hosts-granted",
      "store-registration-PERF_REGISTRY_RAW",
      "real-sentinel-PERF_REGISTRY_RAW",
      "store-registration-PERF_REGISTRY_FORMS",
      "real-sentinel-PERF_REGISTRY_FORMS",
      "excluded-long-row-not-registered",
      "cold-first-read-all-forms",
      "complete-full-redactor-registered-raw",
      "duplicate-store-read-stable-sentinel-projection",
      "duplicate-follow-up-read",
      "real-sentinel-open",
      "tampered-sentinel-refused",
      "actual-ordinary-eviction",
      "all-512-seeds-registered",
      "long-value-not-plaintext-env",
      "long-admission-evicts-exact-oldest",
      "real-long-sentinel-open-and-refresh",
      "canonical-long-store-reader",
      "supported-long-value-fully-redacted",
      "long-duplicate-warm-redaction",
      "long-complete-exact-value-redaction"
    ]
  },
  "sourceStable": true,
  "cleanupComplete": true,
  "fixtureRemoved": true,
  "allEightCoordinatorPathsAbsent": true,
  "networkPolicy": "all network denied by macOS sandbox",
  "originalResultSha256": "071708fc84d6b4a73b9629714e036586a1c2212d9a2719967d58f69a0159e9ff",
  "originalOwnerResultSha256": "41cbbc9dc037c02b0f2731a9bc8c9fb4ebdf4f96ae0071a89b3d9574e4a13477"
}
```

</details>

## Maintainer review disposition

The refreshed ClawSweeper review at 14:31 UTC found no actionable defect and accepted the exact-head behavior receipt. Its remaining production-size risk is accepted for the existing 64 KiB input and callback-order contracts: the simpler complete-value regex crashes, and the measured complete-value scan has substantially higher collision costs. The bounded matcher remains the sole owner; no fallback or separate repair lane is added. This decision does not waive the required exact-head CI gate.
