### PR TITLE
test(telegram): await buffered media task completion

### DIFF
--- a/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
+++ b/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts
@@ -1,10 +1,10 @@
-// Telegram tests cover bot.create telegram bot.channel post media plugin behavior.
-import { setTimeout as delay } from "node:timers/promises";
+import { KeyedAsyncQueue } from "openclaw/plugin-sdk/keyed-async-queue";
 import {
   createPluginStateKeyedStoreForTests,
   createPluginStateSyncKeyedStoreForTests,
 } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
+import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   telegramBotInfoForTest,
@@ -156,24 +156,30 @@ function createChannelPostContext(params: {
   };
 }
 
-async function flushChannelPostMediaGroup(setTimeoutSpy: ReturnType<typeof vi.spyOn>) {
-  const flushTimer = resolveFlushTimerForDelay(
-    setTimeoutSpy,
-    TELEGRAM_TEST_TIMINGS.mediaGroupFlushMs,
-  );
-  expect(flushTimer).toBeTypeOf("function");
-  await flushTimer?.();
-  await delay(75);
-}
-
-async function flushChannelPostMediaGroupForDelay(
+async function flushChannelPostMediaGroup(
   setTimeoutSpy: ReturnType<typeof vi.spyOn>,
-  delayMs: number,
+  completionTimeoutMs = 75,
+  delayMs: number = TELEGRAM_TEST_TIMINGS.mediaGroupFlushMs,
 ) {
   const flushTimer = resolveFlushTimerForDelay(setTimeoutSpy, delayMs);
   expect(flushTimer).toBeTypeOf("function");
-  await flushTimer?.();
-  await delay(75);
+  const enqueueSpy = vi.spyOn(KeyedAsyncQueue.prototype, "enqueue");
+  let completion: Promise<unknown> | undefined;
+  try {
+    // These timers synchronously admit work, then discard the real queue promise.
+    flushTimer?.();
+    expect(enqueueSpy).toHaveBeenCalledTimes(1);
+    const queued = enqueueSpy.mock.results[0];
+    if (queued?.type === "return") {
+      completion = queued.value;
+    }
+  } finally {
+    enqueueSpy.mockRestore();
+  }
+  expect(completion).toBeDefined();
+  await withTimeout(Promise.resolve(completion), completionTimeoutMs, {
+    message: `Telegram buffered flush for the ${delayMs} ms timer did not complete`,
+  });
 }
 
 async function queueChannelPostAlbum(
@@ -450,10 +456,9 @@ describe("createTelegramBot channel_post media", () => {
         secondMessageId: 202,
       });
       expect(replySpy).not.toHaveBeenCalled();
-      await flushChannelPostMediaGroup(setTimeoutSpy);
-      await waitForTelegramMockCalls(replySpy, 1);
+      await flushChannelPostMediaGroup(setTimeoutSpy, 3_075);
 
-      await vi.waitFor(() => expect(replySpy).toHaveBeenCalledTimes(1));
+      expect(replySpy).toHaveBeenCalledTimes(1);
       const payload = replyPayload() as { Body?: string };
       expect(payload.Body).toContain("album caption");
     } finally {
@@ -498,9 +503,9 @@ describe("createTelegramBot channel_post media", () => {
       });
 
       expect(replySpy).not.toHaveBeenCalled();
-      await flushChannelPostMediaGroupForDelay(setTimeoutSpy, TEXT_FRAGMENT_COALESCE_TEST_GAP_MS);
+      await flushChannelPostMediaGroup(setTimeoutSpy, 1_075, TEXT_FRAGMENT_COALESCE_TEST_GAP_MS);
 
-      await vi.waitFor(() => expect(replySpy).toHaveBeenCalledTimes(1));
+      expect(replySpy).toHaveBeenCalledTimes(1);
       const payload = replyPayload() as { RawBody?: string };
       expect(payload.RawBody).toContain(part1.slice(0, 32));
       expect(payload.RawBody).toContain(part2.slice(0, 32));
@@ -958,7 +963,8 @@ describe("createTelegramBot channel_post media", () => {
         }),
       );
       expect(runs.map(({ deferredWork }) => Boolean(deferredWork))).toEqual([true, true]);
-      await flushChannelPostMediaGroup(setTimeoutSpy);
+      // Replay participant processing already uses the overall test timeout.
+      await flushChannelPostMediaGroup(setTimeoutSpy, 0);
       expect(await Promise.all(runs.map(({ deferredWork }) => deferredWork!.task))).toEqual([
         { kind: "failed-retryable", error: expect.any(MediaFetchError) },
         { kind: "failed-retryable", error: expect.any(MediaFetchError) },
@@ -996,8 +1002,7 @@ describe("createTelegramBot channel_post media", () => {
         firstMessageId,
         secondMessageId: firstMessageId + 1,
       });
-      await flushChannelPostMediaGroup(setTimeoutSpy);
-      await waitForTelegramMockCalls(replySpy, 1);
+      await flushChannelPostMediaGroup(setTimeoutSpy, 2_075);
 
       expect(replySpy).toHaveBeenCalledTimes(1);
       expect(replyPayload()).toMatchObject({
@@ -1039,12 +1044,10 @@ describe("createTelegramBot channel_post media", () => {
         secondGetFileResult: {},
       });
       expect(replySpy).not.toHaveBeenCalled();
-      await flushChannelPostMediaGroup(setTimeoutSpy);
+      await flushChannelPostMediaGroup(setTimeoutSpy, 1_075);
 
-      await vi.waitFor(() =>
-        expect(runtimeError).toHaveBeenCalledWith(
-          expect.stringContaining("media group handler failed"),
-        ),
+      expect(runtimeError).toHaveBeenCalledWith(
+        expect.stringContaining("media group handler failed"),
       );
       expect(runtimeError).toHaveBeenCalledWith(
         expect.stringContaining("Telegram getFile returned no file_path"),


### PR DESCRIPTION
## What Problem This Solves

Telegram buffered media tests sleep 75 ms after invoking a flush timer even though the timer discards the queued work promise. That adds a fixed delay and makes negative assertions depend on how far processing progressed during the sleep.

## Why This Change Was Made

Briefly observe the real KeyedAsyncQueue enqueue result while invoking the existing timer, restore the spy synchronously, and await the actual task through normal error and replay settlement. One helper covers text and media. Public SDK timeout guards use the previous nominal observation budgets: four policy cases at 75 ms, two live-partial cases at 2,075 ms, text/fatal cases at 1,075 ms, and the positive album case at 3,075 ms. Both replay cases retain their original overall test timeout for participant processing; a 75 ms queue deadline would incorrectly include that formerly unbounded stage. Exact participant outcomes are still asserted after queue settlement.

## User Impact

No runtime behavior change. Eleven flush executions lose their fixed 75 ms sleeps, removing 825 ms of explicit waiting from the test source. Album policy, text coalescing, live partial delivery, replay retries, and fatal errors retain their observable outcomes. The final local media test-body time was 25.65 s versus 26.33 s in the baseline; this is not an end-to-end CI benchmark.

## Evidence

Production +0/-0; tests +32/-29.

- The combined media, skip-warning, inbound-provenance, processing-outcome and public queue suites passed all 56 cases (42 + 3 + 1 + 4 + 6), with no failures or skips. This also verifies that the fixture and production owner share the public queue class in the actual test module graph.
- The first full gate found the helper additions crossed the file-length limit. Moving the common timeout override before the rarely overridden timer delay removed repeated default arguments. All 42 media cases passed again; the existing lint limit is unchanged.
- `OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs -- extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts` passed on the final version. Formatting, diff checks and independent structured Codex autoreview passed.
- Exact-head hosted CI remains required before landing.

Selected unchanged native reporter fields from the final 42-case run:

```json
[
  {
    "fullName": "createTelegramBot channel_post media buffers channel_post media groups and processes them together",
    "status": "passed"
  },
  {
    "fullName": "createTelegramBot channel_post media durably retries every spooled album update when 'shutdown aborts a download'",
    "status": "passed"
  },
  {
    "fullName": "createTelegramBot channel_post media drops the media group when a non-recoverable media error occurs",
    "status": "passed"
  }
]
```

Named follow-up: **Telegram buffered fixture failure teardown**. The existing fixture has no owner-supported queue cancellation/drain. A timeout restores the observation spy and clears its guard but does not cancel the task, as with a previous sleep/assert failure. Successful replay adoption can hand work to a separate agent-turn owner; this helper only covers the selected live/skip/download-failure fixtures.

### Exact-head buffered-work fixture proof and timeout contract

Addressing the [ClawSweeper proof and timeout-source requests](https://github.com/openclaw/openclaw/pull/134171#issuecomment-5479639284): independently reran the changed media suite at `b6ccaedfa4df81d9a2210015372a4f5270b0039d` on macOS with Node `v24.19.0` and Vitest **4.1.11**. The run completed on 2026-08-31 at 14:20:41 UTC with exit code 0: **42 tests passed**, with zero failed, pending, or todo tests. The worktree stayed clean at the same head before and after execution.

Output path is redacted below.

```sh
node scripts/run-vitest.mjs \
  extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts \
  --reporter=verbose --reporter=json \
  --outputFile=<local-report>
```

Selected verbatim terminal output:

```text
[test] starting test/vitest/vitest.extension-telegram.config.ts
 ✓ |extension-telegram| extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts > createTelegramBot channel_post media > buffers channel_post media groups and processes them together 177ms
 ✓ |extension-telegram| extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts > createTelegramBot channel_post media > coalesces channel_post near-limit text fragments into one message 11ms
 ✓ |extension-telegram| extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts > createTelegramBot channel_post media > applies group media album policy to 'all' (#92067) 3ms
 ✓ |extension-telegram| extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts > createTelegramBot channel_post media > applies group media album policy to 'partial' (#92067) 3ms
 ✓ |extension-telegram| extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts > createTelegramBot channel_post media > applies group media album policy to 'denied mention' (#92067) 3ms
 ✓ |extension-telegram| extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts > createTelegramBot channel_post media > applies group media album policy to 'unauthorized' (#92067) 3ms
stderr | extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts > createTelegramBot channel_post media > durably retries every spooled album update when 'shutdown aborts a download'
media group handler failed: MediaFetchError: aborted
stderr | extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts > createTelegramBot channel_post media > durably retries every spooled album update when 'Telegram temporarily throttles a down…'
media group handler failed: MediaFetchError: rate limited
 ✓ |extension-telegram| extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts > createTelegramBot channel_post media > durably retries every spooled album update when 'shutdown aborts a download' 3ms
 ✓ |extension-telegram| extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts > createTelegramBot channel_post media > durably retries every spooled album update when 'Telegram temporarily throttles a down…' 2ms
 ✓ |extension-telegram| extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts > createTelegramBot channel_post media > keeps live album delivery when 'a photo download fails' 8ms
 ✓ |extension-telegram| extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts > createTelegramBot channel_post media > keeps live album delivery when 'classic polling aborts a download' 6ms
 ✓ |extension-telegram| extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts > createTelegramBot channel_post media > drops the media group when a non-recoverable media error occurs 3ms
 Test Files  1 passed (1)
      Tests  42 passed (42)
[test] passed 1 Vitest shard in 48.53s
```

The [fixture helper](https://github.com/openclaw/openclaw/blob/b6ccaedfa4df81d9a2210015372a4f5270b0039d/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts#L159) invokes the captured production flush callback, observes the real `KeyedAsyncQueue.enqueue` return value without replacing its implementation, checks one synchronous admission, restores the spy immediately, and awaits that returned promise before the reply/error/replay assertions. The native results below include the buffered album, text coalescing, four policy cases, two durable replay failures, two partial live-delivery fixture cases, and terminal error handling. Both replay cases produced their expected `MediaFetchError` diagnostics, asserted two `failed-retryable` participant results, and retained the negative reply/send assertions.

The exact installed **@openclaw/fs-safe 0.5.6** implementation was resolved from this worktree and read directly. `@openclaw/fs-safe/dist/advanced.js:22` re-exports `withTimeout` from `dist/timing.js`; its lines **10–15** directly await the original promise when the timeout is nonpositive or non-finite. Positive timeouts race the promise with a timer at lines **19–33**, and clear the allocated timer in `finally` at lines **35–38**. The SDK forwarding chain (`src/plugin-sdk/text-utility-runtime.ts`, `src/utils/with-timeout.ts`, `src/infra/fs-safe.ts:60`) reaches that same implementation.

Consequently, [the existing replay call with zero](https://github.com/openclaw/openclaw/blob/b6ccaedfa4df81d9a2210015372a4f5270b0039d/extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts#L966) preserves the original overall test budget and waits for the actual queue task; zero does not create an immediate timeout or skip the wait. The ordinary bounded cases retain their explicit positive guards. Timeout cleanup clears the guard timer; it does not cancel queued work. The previously recorded fixture-failure teardown follow-up remains separate.

This is a maintainer-authored test-only PR. The Telegram media owner and shared queue are unchanged, so the review's external-contributor runtime-change framing does not describe this patch. These are actual buffered-work fixture results using the production timer/queue path with existing Telegram/provider mocks. No live-channel execution or gateway verdict is claimed. This rerun covers the changed 42 cases; the previously recorded sibling proof remains separate, and required exact-head CI is tracked separately.

Selected fields copied from the native JSON reporter follow. Only the local checkout prefix was removed from file names; native names (including reporter truncation), statuses, durations, and failure arrays are preserved.

```json
{
  "success": true,
  "numTotalTests": 42,
  "numPassedTests": 42,
  "numFailedTests": 0,
  "numPendingTests": 0,
  "numTodoTests": 0,
  "testResults": [
    {
      "name": "extensions/telegram/src/bot.create-telegram-bot.channel-post-media.test.ts",
      "status": "passed",
      "assertionResults": [
        {
          "fullName": "createTelegramBot channel_post media buffers channel_post media groups and processes them together",
          "status": "passed",
          "duration": 176.76787499999773,
          "failureMessages": []
        },
        {
          "fullName": "createTelegramBot channel_post media coalesces channel_post near-limit text fragments into one message",
          "status": "passed",
          "duration": 10.748957999996492,
          "failureMessages": []
        },
        {
          "fullName": "createTelegramBot channel_post media applies group media album policy to 'all' (#92067)",
          "status": "passed",
          "duration": 3.0373749999998836,
          "failureMessages": []
        },
        {
          "fullName": "createTelegramBot channel_post media applies group media album policy to 'partial' (#92067)",
          "status": "passed",
          "duration": 2.61554199999955,
          "failureMessages": []
        },
        {
          "fullName": "createTelegramBot channel_post media applies group media album policy to 'denied mention' (#92067)",
          "status": "passed",
          "duration": 2.6428329999980633,
          "failureMessages": []
        },
        {
          "fullName": "createTelegramBot channel_post media applies group media album policy to 'unauthorized' (#92067)",
          "status": "passed",
          "duration": 2.6111669999991136,
          "failureMessages": []
        },
        {
          "fullName": "createTelegramBot channel_post media durably retries every spooled album update when 'shutdown aborts a download'",
          "status": "passed",
          "duration": 2.9858749999984866,
          "failureMessages": []
        },
        {
          "fullName": "createTelegramBot channel_post media durably retries every spooled album update when 'Telegram temporarily throttles a down…'",
          "status": "passed",
          "duration": 2.134249999995518,
          "failureMessages": []
        },
        {
          "fullName": "createTelegramBot channel_post media keeps live album delivery when 'a photo download fails'",
          "status": "passed",
          "duration": 7.620375000005879,
          "failureMessages": []
        },
        {
          "fullName": "createTelegramBot channel_post media keeps live album delivery when 'classic polling aborts a download'",
          "status": "passed",
          "duration": 5.83570800000598,
          "failureMessages": []
        },
        {
          "fullName": "createTelegramBot channel_post media drops the media group when a non-recoverable media error occurs",
          "status": "passed",
          "duration": 2.589584000001196,
          "failureMessages": []
        }
      ]
    }
  ]
}
```
