### PR TITLE
fix(plugins): require consent for legacy updates

### DIFF
--- a/src/plugins/update-capability-consent.ts
+++ b/src/plugins/update-capability-consent.ts
@@ -82,10 +82,7 @@ export function preparePluginUpdateCapabilityConsent(params: {
         );
 
       const requiresAcceptance =
-        !previousDeclared ||
-        hasWidening ||
-        (params.record.acceptedSurface !== undefined &&
-          (!priorAcceptanceCurrent || !priorIntegrity));
+        !previousDeclared || hasWidening || !priorAcceptanceCurrent || !priorIntegrity;
       if (requiresAcceptance && enabled) {
         const loadedManifest = loadPluginManifest(stagedArtifactDir);
         const packageManifest = readInstalledPackageManifest(stagedArtifactDir);

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -877,6 +877,24 @@ describe("updateNpmInstalledPlugins", () => {
       childEnabled: false,
     },
     {
+      label: "asks for consent when an enabled legacy record lacks artifact acceptance",
+      nextProviders: ["existing-child-provider"],
+      review: "accept",
+      priorAcceptance: "missing",
+      rejected: false,
+      ownerEnabled: true,
+      childEnabled: false,
+    },
+    {
+      label: "defers missing artifact acceptance for a disabled legacy record",
+      nextProviders: ["existing-child-provider"],
+      review: "none",
+      priorAcceptance: "missing",
+      rejected: false,
+      ownerEnabled: false,
+      childEnabled: false,
+    },
+    {
       label: "rejects an unchanged replacement when prior acceptance has no artifact integrity",
       nextProviders: ["existing-child-provider"],
       review: "none",
@@ -1028,11 +1046,15 @@ describe("updateNpmInstalledPlugins", () => {
               spec: packageName,
               installPath: installedDir,
               ...(priorAcceptance !== "unanchored" ? { integrity: "sha512-previous" } : {}),
-              acceptedSurface: previousDeclared,
-              acceptedSurfaceHash: computeDeclaredSurfaceHash(previousDeclared),
-              acceptedSurfaceAt: previousAcceptedAt,
-              ...(priorAcceptance !== "unanchored"
-                ? { acceptedSurfaceIntegrity: "sha512-previous" }
+              ...(priorAcceptance !== "missing"
+                ? {
+                    acceptedSurface: previousDeclared,
+                    acceptedSurfaceHash: computeDeclaredSurfaceHash(previousDeclared),
+                    acceptedSurfaceAt: previousAcceptedAt,
+                    ...(priorAcceptance !== "unanchored"
+                      ? { acceptedSurfaceIntegrity: "sha512-previous" }
+                      : {}),
+                  }
                 : {}),
             },
           },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where updating an enabled legacy plugin install record that predates artifact-bound capability consent could replace the artifact without asking for consent or persisting the new acceptance.

Closes #134076

## Why This Change Was Made

The updater now treats missing or stale artifact acceptance as requiring the existing staged-artifact consent flow. Disabled plugin records remain deferred and are not auto-accepted.

## User Impact

Enabled legacy plugin updates now require explicit capability consent and persist that consent against the replacement artifact.

## Evidence

- Real production-module proof: the exported `preparePluginUpdateCapabilityConsent` API was run against filesystem-backed previous and staged plugin artifacts with an enabled legacy record and a disabled negative control.

```text
$ pnpm exec tsx proof-live.ts
base (87dba63ec9c5b059f0cdbf4e56ee058f2273e19d):
enabled: prompt=0 accepted=false
disabled: prompt=0 accepted=false

head (a644777ffad36f695fa471f758e62b30c93ecfc1):
enabled: prompt=1 accepted=true
disabled: prompt=0 accepted=false
```

- `pnpm exec vitest run src/plugins/update.test.ts --reporter=dot`: 167 passed.
- `pnpm exec vitest run src/cli/plugins-cli.update.test.ts --reporter=dot`: 52 passed.
- `pnpm tsgo:core:test`: passed.

<details>
<summary>proof-live.ts</summary>

```ts
import fs from "node:fs";
import os from "node:os";
import path from "node:path";
import { preparePluginUpdateCapabilityConsent } from "./src/plugins/update-capability-consent.ts";

function createArtifact(version: string): string {
  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-capability-proof-"));
  fs.writeFileSync(
    path.join(dir, "package.json"),
    JSON.stringify({
      name: "@acme/legacy-fixture",
      version,
      openclaw: { extensions: ["./index.js"] },
    }),
  );
  fs.writeFileSync(path.join(dir, "index.js"), "export default () => {};\n");
  fs.writeFileSync(
    path.join(dir, "openclaw.plugin.json"),
    JSON.stringify({
      id: "legacy-fixture",
      name: "Legacy fixture",
      version,
      providers: ["fixture-provider"],
      configSchema: { type: "object" },
    }),
  );
  return dir;
}

async function run(enabled: boolean) {
  const installedDir = createArtifact("1.0.0");
  const stagedDir = createArtifact("2.0.0");
  try {
    let promptCount = 0;
    const record = {
      source: "npm" as const,
      spec: "@acme/legacy-fixture",
      installPath: installedDir,
      integrity: "sha512-previous",
    };
    const prepared = preparePluginUpdateCapabilityConsent({
      config: {
        plugins: {
          load: { paths: [installedDir] },
          entries: { "legacy-fixture": { enabled } },
        },
      },
      pluginId: "legacy-fixture",
      record,
      installPath: installedDir,
      packagePluginIds: ["legacy-fixture"],
      onCapabilityConsent: async (details) => {
        promptCount += 1;
        return { reviewToken: details.reviewToken };
      },
    });
    await prepared.onBeforePluginArtifactCommit({
      pluginId: "legacy-fixture",
      currentArtifactDir: installedDir,
      stagedArtifactDir: stagedDir,
      mode: "update",
    });
    const accepted = prepared.acceptInstallRecord({ ...record, integrity: "sha512-next" });
    return {
      promptCount,
      acceptedSurface: Boolean(accepted.acceptedSurface),
      acceptedSurfaceIntegrity: accepted.acceptedSurfaceIntegrity,
    };
  } finally {
    fs.rmSync(installedDir, { recursive: true, force: true });
    fs.rmSync(stagedDir, { recursive: true, force: true });
  }
}

const enabled = await run(true);
const disabled = await run(false);
console.log(`enabled: prompt=${enabled.promptCount} accepted=${enabled.acceptedSurface}`);
console.log(`disabled: prompt=${disabled.promptCount} accepted=${disabled.acceptedSurface}`);
if (
  enabled.promptCount !== 1 ||
  !enabled.acceptedSurface ||
  enabled.acceptedSurfaceIntegrity !== "sha512-next" ||
  disabled.promptCount !== 0 ||
  disabled.acceptedSurface
) {
  process.exitCode = 1;
}
```

</details>

AI-assisted: built with Codex
