### PR TITLE
test(video): share provider imports across transport cases

### DIFF
--- a/extensions/deepinfra/video-generation-provider.transport.test.ts
+++ b/extensions/deepinfra/video-generation-provider.transport.test.ts
@@ -1,8 +1,7 @@
-// DeepInfra transport tests cover real provider-http request policy forwarding.
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { connect, type AddressInfo } from "node:net";
 import { withEnvAsync, withServer } from "openclaw/plugin-sdk/test-env";
-import { describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
 const resolveApiKeyForProviderMock = vi.hoisted(() =>
   vi.fn(async () => ({
@@ -27,15 +26,21 @@ type DestroyableConnection = {
   destroy: () => void;
 };
 
-async function buildTransportProofProvider() {
+let buildDeepInfraVideoGenerationProvider: typeof import("./video-generation-provider.js").buildDeepInfraVideoGenerationProvider;
+
+beforeAll(async () => {
   vi.resetModules();
   vi.doUnmock("openclaw/plugin-sdk/provider-http");
   vi.doMock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
     resolveApiKeyForProvider: resolveApiKeyForProviderMock,
   }));
-  const { buildDeepInfraVideoGenerationProvider } = await import("./video-generation-provider.js");
-  return buildDeepInfraVideoGenerationProvider();
-}
+  ({ buildDeepInfraVideoGenerationProvider } = await import("./video-generation-provider.js"));
+});
+
+afterAll(() => {
+  vi.doUnmock("openclaw/plugin-sdk/provider-auth-runtime");
+  vi.resetModules();
+});
 
 async function readRequestBody(request: IncomingMessage): Promise<string> {
   const chunks: Buffer[] = [];
@@ -144,7 +149,7 @@ async function generateLocalVideo(params: {
     proxy?: { mode: "env-proxy" };
   };
 }) {
-  const provider = await buildTransportProofProvider();
+  const provider = buildDeepInfraVideoGenerationProvider();
   return await provider.generateVideo({
     provider: "deepinfra",
     model: "deepinfra/Pixverse/Pixverse-T2V",

--- a/extensions/xai/video-generation-provider.transport.test.ts
+++ b/extensions/xai/video-generation-provider.transport.test.ts
@@ -1,7 +1,6 @@
-// xAI transport proof covers real provider HTTP request-policy forwarding.
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 const resolveApiKeyForProviderMock = vi.hoisted(() =>
   vi.fn(async () => ({
@@ -15,15 +14,21 @@ vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
   resolveApiKeyForProvider: resolveApiKeyForProviderMock,
 }));
 
-async function buildTransportProofProvider() {
+let buildXaiVideoGenerationProvider: typeof import("./video-generation-provider.js").buildXaiVideoGenerationProvider;
+
+beforeAll(async () => {
   vi.resetModules();
   vi.doUnmock("openclaw/plugin-sdk/provider-http");
   vi.doMock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
     resolveApiKeyForProvider: resolveApiKeyForProviderMock,
   }));
-  const { buildXaiVideoGenerationProvider } = await import("./video-generation-provider.js");
-  return buildXaiVideoGenerationProvider();
-}
+  ({ buildXaiVideoGenerationProvider } = await import("./video-generation-provider.js"));
+});
+
+afterAll(() => {
+  vi.doUnmock("openclaw/plugin-sdk/provider-auth-runtime");
+  vi.resetModules();
+});
 
 type CapturedRequest = {
   body: string;
@@ -124,7 +129,7 @@ describe("xai video generation provider transport", () => {
 
   it("uses configured policy for xAI API requests without leaking headers to video downloads", async () => {
     const server = await startXaiVideoServer();
-    const provider = await buildTransportProofProvider();
+    const provider = buildXaiVideoGenerationProvider();
 
     const result = await provider.generateVideo({
       provider: "xai",
@@ -178,7 +183,7 @@ describe("xai video generation provider transport", () => {
     "blocks %s loopback xAI video requests before reaching the server",
     async (policyName, requestPolicy) => {
       const server = await startXaiVideoServer();
-      const provider = await buildTransportProofProvider();
+      const provider = buildXaiVideoGenerationProvider();
 
       await expect(
         provider.generateVideo({


### PR DESCRIPTION
## What Problem This Solves

The DeepInfra and xAI real video transport suites reload their provider and HTTP/media module graphs for every case, repeating setup seven times for seven transport scenarios.

## Why This Change Was Made

Import each provider once within its suite isolation, construct a fresh provider for each operation, and clean up auth mocks and module state at suite teardown. Keep the actual HTTP servers, CONNECT proxy, request parsing, downloads, and private-network rejection checks. Request policy continues to be supplied for each operation, and the env-proxy case still changes its environment after import.

## User Impact

No runtime behavior change. The suites reduce seven graph imports to two while retaining real transport proof for policy forwarding, loopback rejection, proxy routing, and download header isolation. The deterministic saving is five repeated module graph loads. Imports move into suite setup, so no end-to-end timing gain is claimed from test-body durations.

## Evidence

Production +0/-0; tests +25/-15.

- `node scripts/run-vitest.mjs extensions/deepinfra/video-generation-provider.transport.test.ts extensions/deepinfra/video-generation-provider.test.ts extensions/xai/video-generation-provider.transport.test.ts extensions/xai/video-generation-provider.test.ts` passed all 39 cases: seven real transport cases and 32 provider cases, with no failures or skips.
- Direct HTTP-owner and installed undici `EnvHttpProxyAgent` source inspection confirms per-operation dispatcher construction reads the proxy environment. The real CONNECT case changes that environment after the suite import and still passed.
- Actual HTTP routing, policy forwarding, private-loopback rejection before server access, and download-header isolation remain exercised. Provider instances stay fresh per operation; auth mocks and module state are cleaned up after each suite.
- `OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs -- extensions/deepinfra/video-generation-provider.transport.test.ts extensions/xai/video-generation-provider.transport.test.ts` passed. Formatting, diff checks and independent structured Codex autoreview passed.
- Exact-head hosted CI remains required before landing.

Selected unchanged native reporter fields for the real transport cases:

```json
[
  {
    "fullName": "xai video generation provider transport uses configured policy for xAI API requests without leaking headers to video downloads",
    "status": "passed"
  },
  {
    "fullName": "xai video generation provider transport blocks default loopback xAI video requests before reaching the server",
    "status": "passed"
  },
  {
    "fullName": "xai video generation provider transport blocks explicit false loopback xAI video requests before reaching the server",
    "status": "passed"
  },
  {
    "fullName": "deepinfra video generation provider transport forwards configured request policy through the real local video transport path",
    "status": "passed"
  },
  {
    "fullName": "deepinfra video generation provider transport routes configured env proxy policy through a real CONNECT tunnel",
    "status": "passed"
  },
  {
    "fullName": "deepinfra video generation provider transport blocks loopback before transport with default private-network policy",
    "status": "passed"
  },
  {
    "fullName": "deepinfra video generation provider transport blocks loopback before transport with explicit false private-network policy",
    "status": "passed"
  }
]
```
