### PR TITLE
refactor(plugins): use canonical command registry projections

### DIFF
--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -700,20 +700,11 @@ export async function loadCompactHooksHarness(options: { durableSession?: boolea
     withPluginMetadataSnapshotScope: (_snapshot: unknown, run: () => unknown) => run(),
   }));
 
-  vi.doMock("../../plugins/command-registry-state.js", () => {
-    const pluginCommands = new Map<string, unknown>();
-    return {
-      clearPluginCommands: vi.fn(() => pluginCommands.clear()),
-      clearPluginCommandsForPlugin: vi.fn(),
-      isPluginCommandRegistryLocked: vi.fn(() => false),
-      isTrustedReservedCommandOwner: vi.fn(() => false),
-      listRegisteredPluginCommands: vi.fn(() => []),
-      listRegisteredPluginAgentPromptGuidance: listRegisteredPluginAgentPromptGuidanceMock,
-      pluginCommands,
-      restorePluginCommands: vi.fn(),
-      setPluginCommandRegistryLocked: vi.fn(),
-    };
-  });
+  vi.doMock("../../plugins/command-registry-state.js", () => ({
+    clearPluginCommands: vi.fn(),
+    isTrustedReservedCommandOwner: vi.fn(() => false),
+    listRegisteredPluginAgentPromptGuidance: listRegisteredPluginAgentPromptGuidanceMock,
+  }));
 
   vi.doMock("../harness/compaction.js", () => ({
     maybeCompactAgentHarnessSession: maybeCompactAgentHarnessSessionMock,

--- a/src/gateway/gateway-codex-bind.live.test.ts
+++ b/src/gateway/gateway-codex-bind.live.test.ts
@@ -3,6 +3,7 @@ import { randomBytes, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { describe, expect, it } from "vitest";
 import { renderCatFacePngBase64 } from "../../test/helpers/live-image-probe.js";
 import { resolveDefaultAgentDir } from "../agents/agent-scope-config.js";
@@ -14,11 +15,11 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
 import { getSessionBindingService } from "../infra/outbound/session-binding-service.js";
 import { findBundledPluginMetadataById } from "../plugins/bundled-plugin-metadata.js";
-import { pluginCommands } from "../plugins/command-registry-state.js";
 import { getCurrentPluginConversationBinding } from "../plugins/conversation-binding.js";
 import { seedPluginConversationBindingApprovalForTest } from "../plugins/conversation-binding.test-fixtures.js";
 import { clearPluginLoaderCache } from "../plugins/loader.test-fixtures.js";
-import { resetPluginRuntimeStateForTest } from "../plugins/runtime.js";
+import { listRegisteredPluginCommands } from "../plugins/plugin-command-registry.js";
+import { requireActivePluginRegistry, resetPluginRuntimeStateForTest } from "../plugins/runtime.js";
 import { clearSecretsRuntimeSnapshot } from "../secrets/runtime.js";
 import { activateTestChannelRegistry, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
@@ -217,9 +218,10 @@ async function sendChatAndWait(params: {
 }
 
 function resolveCodexPluginRoot(): string {
+  const commands = listRegisteredPluginCommands(requireActivePluginRegistry());
   const command =
-    pluginCommands.get("/codex") ??
-    Array.from(pluginCommands.values()).find((candidate) => candidate.pluginId === "codex");
+    commands.find((candidate) => normalizeOptionalLowercaseString(candidate.name) === "codex") ??
+    commands.find((candidate) => candidate.pluginId === "codex");
   if (command?.pluginRoot) {
     return command.pluginRoot;
   }

--- a/src/plugins/command-registry-state.ts
+++ b/src/plugins/command-registry-state.ts
@@ -1,5 +1,4 @@
 // Stores plugin command registry state for the current process lifecycle.
-import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import { normalizeAgentPromptSurfaceKind } from "./agent-prompt-surface-kind.js";
 import { listRegisteredPluginCommands } from "./plugin-command-registry.js";
 import { requireActivePluginRegistry } from "./runtime.js";
@@ -16,31 +15,8 @@ export type RegisteredPluginCommand = OpenClawPluginCommandDefinition & {
   trustedOwnerStatusExposure?: true;
 };
 
-const getPluginCommandMap = () =>
-  new Map(
-    listRegisteredPluginCommands(resolveCompatibilityPluginCommandRegistry()).map((command) => [
-      `/${normalizeOptionalLowercaseString(command.name) ?? ""}`,
-      command,
-    ]),
-  );
-
-export const resolveCompatibilityPluginCommandRegistry = requireActivePluginRegistry;
-
-export const pluginCommands = new Proxy(new Map<string, RegisteredPluginCommand>(), {
-  get(_target, property) {
-    if (property === "clear") {
-      return () => {
-        resolveCompatibilityPluginCommandRegistry().commands.length = 0;
-      };
-    }
-    const map = getPluginCommandMap();
-    const value = Reflect.get(map, property, map);
-    return typeof value === "function" ? value.bind(map) : value;
-  },
-});
-
 export function clearPluginCommands(): void {
-  pluginCommands.clear();
+  requireActivePluginRegistry().commands.length = 0;
 }
 
 export function isTrustedReservedCommandOwner(command: RegisteredPluginCommand): boolean {
@@ -62,12 +38,14 @@ export function listRegisteredPluginAgentPromptGuidance(params?: {
   const seen = new Set<string>();
   // Plugin discovery can complete in a different order on the next run; only
   // canonical command ownership may decide bytes in the cached prompt prefix.
-  const commands = Array.from(pluginCommands.values()).toSorted((left, right) => {
-    if (left.pluginId !== right.pluginId) {
-      return left.pluginId < right.pluginId ? -1 : 1;
-    }
-    return left.name < right.name ? -1 : left.name > right.name ? 1 : 0;
-  });
+  const commands = listRegisteredPluginCommands(requireActivePluginRegistry()).toSorted(
+    (left, right) => {
+      if (left.pluginId !== right.pluginId) {
+        return left.pluginId < right.pluginId ? -1 : 1;
+      }
+      return left.name < right.name ? -1 : left.name > right.name ? 1 : 0;
+    },
+  );
   for (const command of commands) {
     for (const entry of command.agentPromptGuidance ?? []) {
       const trimmed = resolveAgentPromptGuidanceTextForSurface(entry, {

--- a/src/plugins/command-specs.ts
+++ b/src/plugins/command-specs.ts
@@ -3,12 +3,13 @@ import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/s
 import { getLoadedChannelPlugin } from "../channels/plugins/index.js";
 import { resolveReadOnlyChannelCommandDefaults } from "../channels/plugins/read-only-command-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { pluginCommands } from "./command-registry-state.js";
 import {
   pluginCommandSupportsChannel,
   projectPluginCommandNativeMetadata,
 } from "./plugin-command-metadata.js";
+import { listRegisteredPluginCommands } from "./plugin-command-registry.js";
 import type { PluginCommandRegistration } from "./registry-types.js";
+import { requireActivePluginRegistry } from "./runtime.js";
 import type { OpenClawPluginCommandDefinition } from "./types.js";
 
 type PluginCommandSpecOptions = {
@@ -72,7 +73,7 @@ export function getPluginCommandEntrySpecs(
 ): PluginCommandEntrySpec[] {
   const providerName = normalizeOptionalLowercaseString(provider);
   const nativeCommandsEnabled = pluginNativeCommandsEnabled(providerName, options);
-  return Array.from(pluginCommands.values())
+  return listRegisteredPluginCommands(requireActivePluginRegistry())
     .map((cmd) => serializePluginCommandEntrySpec(cmd, providerName, nativeCommandsEnabled))
     .filter((spec): spec is PluginCommandEntrySpec => spec !== null);
 }
@@ -98,7 +99,7 @@ export function listProviderPluginCommandSpecs(provider?: string): Array<{
   descriptionLocalizations?: Record<string, string>;
   acceptsArgs: boolean;
 }> {
-  return Array.from(pluginCommands.values())
+  return listRegisteredPluginCommands(requireActivePluginRegistry())
     .filter((cmd) => pluginCommandSupportsChannel(cmd, provider))
     .map((cmd) => serializePluginCommandSpec(cmd, provider));
 }

--- a/src/plugins/commands.ts
+++ b/src/plugins/commands.ts
@@ -7,8 +7,6 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { clearPluginCommands, registerPluginCommand } from "./command-registration.js";
 import {
   listRegisteredPluginAgentPromptGuidance,
-  pluginCommands,
-  resolveCompatibilityPluginCommandRegistry,
   type RegisteredPluginCommand,
 } from "./command-registry-state.js";
 import {
@@ -17,6 +15,7 @@ import {
 } from "./plugin-command-execution.js";
 import { matchRegisteredPluginCommand } from "./plugin-command-matcher.js";
 import { listRegisteredPluginCommands } from "./plugin-command-registry.js";
+import { requireActivePluginRegistry } from "./runtime.js";
 import type { PluginCommandContext, PluginCommandResult } from "./types.js";
 
 export { clearPluginCommands, listRegisteredPluginAgentPromptGuidance, registerPluginCommand };
@@ -26,7 +25,7 @@ export function matchPluginCommand(
   commandBody: string,
   options: { channel?: string } = {},
 ): { command: RegisteredPluginCommand; args?: string } | null {
-  const registry = resolveCompatibilityPluginCommandRegistry();
+  const registry = requireActivePluginRegistry();
   return matchRegisteredPluginCommand({
     commands: listRegisteredPluginCommands(registry),
     commandBody,
@@ -67,7 +66,7 @@ export function executePluginCommand(params: {
 export async function executePluginCommand(
   params: PluginCommandExecutionParams,
 ): Promise<PluginCommandResult> {
-  return await executeRegisteredPluginCommand(resolveCompatibilityPluginCommandRegistry(), params);
+  return await executeRegisteredPluginCommand(requireActivePluginRegistry(), params);
 }
 
 /** List registered plugin commands for help and command discovery. */
@@ -77,7 +76,7 @@ export function listPluginCommands(): Array<{
   pluginId: string;
   acceptsArgs: boolean;
 }> {
-  return Array.from(pluginCommands.values()).map((command) => ({
+  return listRegisteredPluginCommands(requireActivePluginRegistry()).map((command) => ({
     name: command.name,
     description: command.description,
     pluginId: command.pluginId,


### PR DESCRIPTION
## What Problem This Solves

Plugin command readers rebuilt a private Map projection of already validated registry rows. That duplicated the representation used for command listing and prompt guidance, making the ownership boundary harder to follow.

## Why This Change Was Made

Use the canonical registered-command rows directly. Registration already rejects normalized command and alias collisions, so the extra Map deduplication is redundant. Keep registry selection precedence, handler ownership, command ordering, sorted prompt bytes, public SDK exports and matcher behavior unchanged. Adapt the live-test lookup and remove an obsolete empty Map and five nonexistent mock exports from the compaction harness.

## User Impact

No intended user-visible behavior change. Production: +17/-39 (net -22); tests: +6/-4 (+2); test support: +5/-14 (-9); whole change: +28/-57 (net -29). No assertion or test case was removed. No configuration, dependency, storage or schema change.

## Evidence

- Baseline and candidate each passed the same 454 cases: 72 command-owner, 183 loader lifecycle and 199 compaction cases. Displayed identities, multiplicity and within-file order matched.
- All 29 normally selected changed checks and the normal default 14-stage build passed without skips, fallbacks or retries.
- Local precommit and separate exact-commit Codex reviews returned P0-scoped clean results. The separate review covered signed commit `815a16bef0adf1b941b8b02e49d52d477270e478` in two normal evidence passes.

This is an internal behavior-preserving cleanup, not live Codex/provider certification. The oversized unchanged compaction test file exceeded the normal review evidence cap and was omitted; the changed harness was reviewed and the full paired runtime suite passed. The pre-existing live fixture setup-before-try cleanup gap remains a source-only follow-up.

Disposed test-worker manifests prevent independent historical verification of every compiled output byte. Build warnings and read-only observer refusals are retained; no compiler-equivalence claim is made. An earlier raw-index metadata change has an unknown writer; retained bytes proved isolated metadata/checksum differences with semantic entries and source unchanged. Current-main composition and exact-head hosted CI remain pending before native landing.
