### PR TITLE
perf(gateway): reduce repeated session snapshot copying

### DIFF
--- a/src/gateway/session-event-payload.ts
+++ b/src/gateway/session-event-payload.ts
@@ -145,7 +145,9 @@ export function buildGatewaySessionSnapshot(params: {
   if (!storedRow) {
     return {};
   }
-  const lifecycleRow = { ...storedRow, updatedAt: storedRow.updatedAt ?? undefined };
+  const lifecycleRow = event
+    ? { ...storedRow, updatedAt: storedRow.updatedAt ?? undefined }
+    : undefined;
   const patch =
     event &&
     !isStaleLifecycleEventForSession({
@@ -192,12 +194,10 @@ export function buildGatewaySessionSnapshot(params: {
     activeRunIds: params.activeRunState ? (params.activeRunState.runIds ?? null) : undefined,
   });
   const session: Record<string, unknown> | undefined = params.includeSession
-    ? {
-        ...sessionRow,
-        ...Object.fromEntries(
-          Object.entries(eventFields).filter(([, value]) => value !== undefined),
-        ),
-      }
+    ? Object.assign(
+        sessionRow,
+        Object.fromEntries(Object.entries(eventFields).filter(([, value]) => value !== undefined)),
+      )
     : undefined;
   if (session && sessionRow.key === "global" && !params.agentId) {
     delete session.goal;


### PR DESCRIPTION
## What Problem This Solves

Session events repeatedly copy the same projected row while preparing nested snapshots. The builder also creates a lifecycle adapter for ordinary events that do not have a lifecycle event to project. These costs recur in transcript, tool, lifecycle and history updates.

## Why This Change Was Made

Build the lifecycle adapter only when an event exists, and merge the existing defined-only event fields into the private row the builder already owns. Keep that adapter before the stale-event fence so event-present read ordering is unchanged. This is one assembly mechanism, with production +7/-7 and no test growth.

Field selection, null tombstones, nested-versus-flat timestamp behavior, key order, enumerable symbols, row-only metadata, nested references, input immutability, global-goal omission and lifecycle/status precedence remain unchanged. There is no new protocol, schema, option, API, cache or fallback. Unconditional assignment was rejected because it would replace a nested null timestamp with undefined; the existing defined-only filter remains.

## User Impact

Subscribed clients receive the same snapshot and history fields with less repeated local assembly work. This does not claim faster model inference or network responses.

## Evidence

Complete before/candidate owners with actual built lineage and lifecycle dependencies pass 645 paired cases and 26 independent oracles. Four fixed fresh timing children retain all 26 workloads, 1,144 samples and 416 warmups in both variant orders. Ordinary nested assembly improves from 23.60/25.24 to 12.65/11.50 microseconds (1.87/2.19x); including JSON serialization improves from 20.81/27.79 to 14.31/18.29 microseconds (1.45/1.52x). Rich nested JSON improves by 1.20/1.22x.

All costs remain visible. Eighteen rows are faster in both orders, including an unchanged fields-only control with a small difference; eight are slower or mixed. Missing-row controls add 0.4–2.1 nanoseconds, flat lifecycle start adds 148/29 nanoseconds, stale flat start adds 127/71 nanoseconds, and sparse nested adds 569 nanoseconds in one order while improving in the other. These unweighted rows are not an aggregate speed score. No V8-cause, physical allocation, startup, RSS or whole-Gateway/model latency claim is made.

The canonical baseline passes 101 tests. The corrected real OpenAI Gateway baseline passes two turns, exactly one workspace read, three model starts, metadata color/category clears, transcript/tool/lifecycle snapshots and history cursor catch-up, with all ten exact main-thread V8 coverage points positive. Independent raw-event, replay, coverage/profile-identity and cleanup audit passes. The initial failed harness attempt remains preserved: tool results persist in history but intentionally do not also broadcast as session.message; the corrected helper validates their exact session.tool correspondence and removes an unsupported broad-unsubscribe RPC. No production code was changed to accommodate that baseline.

The integrated candidate passes 298 tests across eight canonical Gateway suites and complete changed-file checks (235.69 seconds). Managed review is scoped-clean, and independent complete current-source/raw-measurement review is clean. Exact candidate 354b3aa87b6c51ca58445fc43883a28056d2fa7f builds successfully (153.98 seconds). Its equivalent real OpenAI two-turn Gateway run passes: one workspace read, three model starts, 41 events, 13 recorded successful responses and every declared metadata/transcript/tool/lifecycle/history outcome. The unchanged comparator passes against the preserved baseline; all eight selected raw key-shape observations also match. Complete per-input key/order/value equivalence belongs to the separate differential owner proof, not independent model runs.

All ten exact innermost Gateway-thread V8 coverage points are positive, including two executions inside the event-only adapter arm and 14 nested assemblies. Actual CPU/V8 profiles are retained as execution evidence, without latency or memory attribution. Gateway, client, wrapper and launcher leaders/groups are gone, the port is closed, task state is removed and shared temporary-directory identity is unchanged. Historical source/build labels remain distinct. Independent complete saved-run event/profile/cleanup audit also passes. The 13 recorded responses exclude the expected denied write, lane polls and targeted unsubscribe; they are not a total RPC count. No further runtime changes are proposed.


<details>
<summary>Actual redacted candidate execution receipt</summary>

This is a projection of the retained live Gateway/client receipts. Local paths, run/session identifiers and fixture nonces are omitted; values below are saved outcomes, not reconstructed terminal output.

```json
{
  "head": "354b3aa87b6c51ca58445fc43883a28056d2fa7f",
  "buildHead": "354b3aa87b6c51ca58445fc43883a28056d2fa7f",
  "started": "2026-08-31T14:21:32.639863+00:00",
  "ended": "2026-08-31T14:21:45.834338+00:00",
  "ok": true,
  "logicalTurns": 2,
  "events": 41,
  "recordedSuccessfulResponses": 13,
  "outcomes": {
    "exactReadToolCalls": 1,
    "scopeDenied": true,
    "flatSet": true,
    "flatClear": true,
    "nestedTranscript": true,
    "nestedTool": true,
    "nestedLifecycle": true,
    "cursorReplay": true,
    "toolResultReplay": true,
    "emptyCursor": true,
    "invalidCursorReset": true,
    "scopedGoalNull": true,
    "rowOnlyFlatFieldsAbsent": true,
    "previousTerminalIdCleared": true,
    "modelMetadataOmittedOnLifecycle": true,
    "activeUnknownIdsObserved": true,
    "modelCallStarts": 3
  },
  "coverageCounts": {
    "flat-metadata-snapshot": 7,
    "snapshot-event-adapter": 2,
    "snapshot-nested-assembly": 14,
    "snapshot-lifecycle-omissions": 4,
    "snapshot-field-tombstones": 15,
    "history-cursor-snapshot": 3,
    "history-replay-envelope": 4,
    "transcript-snapshot": 5,
    "session-tool-snapshot": 2,
    "lifecycle-start-snapshot": 2
  },
  "pendingRuns": [],
  "cleanupErrors": [],
  "gatewayExit": 0,
  "clientExit": 0,
  "cleanupComplete": true,
  "fixtureRemoved": true,
  "portClosed": true,
  "sourceStable": true,
  "resultSha256": "70c4da7e73ea024f0f61dae27b870efd8301ef9eef6d11b6cf9bdcc016ac6da2",
  "clientResultSha256": "f20b49d3768e3bf6b572af641eb503665e15907e22f662ef055f3bdb72e9d97a",
  "performanceClaim": false
}
```

</details>
