### PR TITLE
fix(update): block restart while plugin consent is pending

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -141,9 +141,9 @@ plugin finalization steps still exit non-zero.
 
 Plugin artifacts that require capability consent are not installed without an
 interactive review or explicit `--accept-capabilities`. `--yes` alone does not
-accept capability changes, and JSON mode does not prompt. A denied update can
-preserve the previous usable plugin and finish with a warning; an unresolved
-missing or invalid active payload can still fail finalization.
+accept capability changes, and JSON mode does not prompt. An unresolved review
+preserves the previous plugin, exits non-zero, and blocks any requested Gateway
+restart.
 
 If the core package has already changed, run `openclaw update repair` in an
 interactive terminal to review plugin capabilities. After reviewing the changes,

--- a/scripts/e2e/lib/plugin-update/consent-scenario.mjs
+++ b/scripts/e2e/lib/plugin-update/consent-scenario.mjs
@@ -246,11 +246,17 @@ export async function runConsentScenario(entry, coreTarball) {
       await serve(2);
       const denied = await cli(
         "update-denied",
-        ["update", "--tag", coreTarball, "--yes", "--no-restart", "--json"],
+        ["update", "--tag", coreTarball, "--yes", "--json"],
         { allowFailure: true },
       );
       const deniedResult = JSON.parse(denied.output);
       assertConsentBlocked(denied, deniedResult, "post-update-plugins");
+      assert(
+        !denied.children.some(
+          (child) => child.argv.includes("gateway") && child.argv.includes("restart"),
+        ),
+        "denied update attempted a Gateway restart",
+      );
       assert(
         denied.children.some((child) => child.postCore),
         "denied update did not hand off",

--- a/scripts/e2e/lib/plugin-update/consent-scenario.mjs
+++ b/scripts/e2e/lib/plugin-update/consent-scenario.mjs
@@ -20,6 +20,7 @@ export async function runConsentScenario(entry, coreTarball) {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-update-consent-"));
   const pluginId = "update-consent-fixture";
   const packageName = `@acme/${pluginId}`;
+  const capabilityConsentRequired = "PLUGIN_CAPABILITY_CONSENT_REQUIRED";
   const groups = [
     "channels",
     "providers",
@@ -176,6 +177,21 @@ export async function runConsentScenario(entry, coreTarball) {
     return { record, bytes };
   }
 
+  function assertConsentBlocked(command, result, expectedReason) {
+    assert.equal(command.code, 1, `${command.output}\n${command.diagnostic}`);
+    assert.equal(result.status, "error");
+    if (expectedReason) {
+      assert.equal(result.reason, expectedReason);
+    }
+    assert.equal(result.postUpdate?.plugins?.status, "error");
+    assert.equal(
+      result.postUpdate?.plugins?.npm?.outcomes?.find(
+        (outcome) => outcome.pluginId === pluginId && outcome.status === "error",
+      )?.code,
+      capabilityConsentRequired,
+    );
+  }
+
   try {
     const help = await cli("update-help", ["update", "--help"]);
     if (fixtureCapabilityConsentArgs(help.output).length === 0) {
@@ -228,16 +244,13 @@ export async function runConsentScenario(entry, coreTarball) {
         "updates must keep an unpinned registry selector",
       );
       await serve(2);
-      const denied = await cli("update-denied", [
-        "update",
-        "--tag",
-        coreTarball,
-        "--yes",
-        "--no-restart",
-        "--json",
-      ]);
+      const denied = await cli(
+        "update-denied",
+        ["update", "--tag", coreTarball, "--yes", "--no-restart", "--json"],
+        { allowFailure: true },
+      );
       const deniedResult = JSON.parse(denied.output);
-      assert.match(JSON.stringify(deniedResult), /capabilit/i);
+      assertConsentBlocked(denied, deniedResult, "post-update-plugins");
       assert(
         denied.children.some((child) => child.postCore),
         "denied update did not hand off",
@@ -252,7 +265,12 @@ export async function runConsentScenario(entry, coreTarball) {
       ]);
       const repaired = await snapshot("repaired", 2);
       await serve(3);
-      await cli("later-repair-denied", ["update", "repair", "--yes", "--json"]);
+      const laterDenied = await cli(
+        "later-repair-denied",
+        ["update", "repair", "--yes", "--json"],
+        { allowFailure: true },
+      );
+      assertConsentBlocked(laterDenied, JSON.parse(laterDenied.output));
       assert.deepEqual(await snapshot("no-future-permission", 2), repaired);
       const accepted = await cli("update-accepted", [
         "update",

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { Command } from "commander";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PLUGIN_CAPABILITY_CONSENT_REQUIRED } from "../../packages/gateway-protocol/src/capability-consent-error-details.js";
 import { writePackageDistInventory } from "../../scripts/lib/package-dist-inventory.ts";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -3481,6 +3482,44 @@ describe("update-cli", () => {
       }),
     ).resolves.toBe(false);
     expect(getLogOutput()).toContain("Plugin update aborted");
+  });
+
+  it("blocks restart when a plugin update awaits capability consent", async () => {
+    mockOwnedGitService();
+    mockGitUpdateAfterMutation();
+    serviceLoaded.mockResolvedValue(true);
+    mockNpmPluginOutcomes([
+      {
+        pluginId: "consent-fixture",
+        status: "error",
+        code: PLUGIN_CAPABILITY_CONSENT_REQUIRED,
+        message: "Operator review token changed.",
+      },
+    ]);
+
+    await updateCommand({ yes: true, json: true });
+
+    const jsonOutput = lastWriteJsonCall() as UpdateRunResult | undefined;
+    expect(jsonOutput?.status).toBe("error");
+    expect(jsonOutput?.reason).toBe("post-update-plugins");
+    expect(jsonOutput?.postUpdate?.plugins?.status).toBe("error");
+    expect(lastWriteJsonCall()).toMatchObject({
+      postUpdate: {
+        plugins: {
+          npm: {
+            outcomes: [
+              {
+                pluginId: "consent-fixture",
+                status: "error",
+                code: PLUGIN_CAPABILITY_CONSENT_REQUIRED,
+              },
+            ],
+          },
+        },
+      },
+    });
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
+    expectNoSideEffects(serviceRestart, runRestartScript, runDaemonRestart);
   });
 
   it("keeps json update output successful when post-core plugin updates warn", async () => {

--- a/src/cli/update-cli/update-command-plugins.ts
+++ b/src/cli/update-cli/update-command-plugins.ts
@@ -1,4 +1,5 @@
 // Plugin synchronization and convergence after the core update.
+import { PLUGIN_CAPABILITY_CONSENT_REQUIRED } from "../../../packages/gateway-protocol/src/capability-consent-error-details.js";
 import { stripAnsi } from "../../../packages/terminal-core/src/ansi.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
 import { readConfigFileSnapshot } from "../../config/config.js";
@@ -450,24 +451,36 @@ export async function updatePluginsAfterCoreUpdate(params: {
     });
   }
 
+  const status =
+    convergenceErrored ||
+    pluginUpdateOutcomes.some(
+      (outcome) =>
+        outcome.status === "error" && outcome.code === PLUGIN_CAPABILITY_CONSENT_REQUIRED,
+    )
+      ? "error"
+      : warnings.length > 0
+        ? "warning"
+        : "ok";
+  const result: PostCorePluginUpdateResult = {
+    status,
+    changed: pluginsChanged,
+    warnings,
+    sync: {
+      changed: syncResult.changed,
+      switchedToBundled: syncResult.summary.switchedToBundled,
+      switchedToNpm: syncResult.summary.switchedToNpm,
+      warnings: syncResult.summary.warnings,
+      errors: syncResult.summary.errors,
+    },
+    npm: {
+      changed: npmPluginsChanged,
+      outcomes: pluginUpdateOutcomes,
+    },
+    integrityDrifts,
+  };
+
   if (params.opts.json) {
-    return {
-      status: convergenceErrored ? "error" : warnings.length > 0 ? "warning" : "ok",
-      changed: pluginsChanged,
-      warnings,
-      sync: {
-        changed: syncResult.changed,
-        switchedToBundled: syncResult.summary.switchedToBundled,
-        switchedToNpm: syncResult.summary.switchedToNpm,
-        warnings: syncResult.summary.warnings,
-        errors: syncResult.summary.errors,
-      },
-      npm: {
-        changed: npmPluginsChanged,
-        outcomes: pluginUpdateOutcomes,
-      },
-      integrityDrifts,
-    };
+    return result;
   }
 
   const summarizeList = (list: string[]) => {
@@ -527,21 +540,5 @@ export async function updatePluginsAfterCoreUpdate(params: {
     defaultRuntime.log(theme.warn(outcome.message));
   }
 
-  return {
-    status: convergenceErrored ? "error" : warnings.length > 0 ? "warning" : "ok",
-    changed: pluginsChanged,
-    warnings,
-    sync: {
-      changed: syncResult.changed,
-      switchedToBundled: syncResult.summary.switchedToBundled,
-      switchedToNpm: syncResult.summary.switchedToNpm,
-      warnings: syncResult.summary.warnings,
-      errors: syncResult.summary.errors,
-    },
-    npm: {
-      changed: npmPluginsChanged,
-      outcomes: pluginUpdateOutcomes,
-    },
-    integrityDrifts,
-  };
+  return result;
 }


### PR DESCRIPTION
Closes #134156

## What Problem This Solves

Fixes an issue where a core update could report success and restart the Gateway after a managed plugin refused an unreviewed capability change. The update retained the older plugin payload but started the newer host, which created a mixed host/plugin state.

## Why This Change Was Made

The post-core result owner now treats the existing typed `PLUGIN_CAPABILITY_CONSENT_REQUIRED` outcome as an unresolved convergence error. It keeps other recoverable plugin failures as warnings, preserves the previous plugin, and does not bypass capability review or change inbound dispatch lifecycle checks.

The JSON and terminal paths now return one shared plugin result object.

## User Impact

`openclaw update` now exits non-zero and blocks a requested Gateway restart until the operator reviews the plugin capabilities and runs `openclaw update repair`. The result still names the affected plugin and preserves the exact retry guidance.

## Evidence

- Exact current-main baseline `9ac61cdbab71ebba3a2f7ae9ffcbb6834a4afe32` and release `v2026.8.1` (`ea806575e6450e4d1efdfc72c19f04be982a1b9b`) both accepted the existing consent-deferral fixture while the outer core update stayed successful.
- The new owner-boundary regression failed before the production repair because the outer status was `ok`, not `error`.
- `node scripts/run-vitest.mjs src/cli/update-cli.test.ts`: 286 passed.
- `node scripts/run-vitest.mjs test/scripts/docker-build-helper.test.ts -t 'capability consent|upgrade survivor'`: 14 passed.
- Core Oxlint, script Oxlint, Oxfmt, script syntax, and `git diff --check`: passed.
- Autoreview: no P0 findings, 0.98 confidence.
- Exact built production bytes came from green CI run [33403041210](https://github.com/openclaw/openclaw/actions/runs/33403041210) at `6a89535b5a85cd57504b07af0a2f74692e60cd88`; the next commit changes only the proof fixture.
- The isolated installed-package fixture requested the default restart and passed. The denied update exited 1 with `status: "error"`, `reason: "post-update-plugins"`, and `PLUGIN_CAPABILITY_CONSENT_REQUIRED`; it spawned the fresh post-core child but no `gateway restart` child, and the old plugin payload and record remained at version 1.0.0.
- The same fixture then accepted reviewed consent, updated to version 2.0.0, proved consent did not apply to a later widening, accepted a fresh review for version 3.0.0, and repaired a missing payload only after explicit consent.
