### PR TITLE
refactor: remove synthetic chat callback recovery

### DIFF
--- a/src/shared/chat-content.test.ts
+++ b/src/shared/chat-content.test.ts
@@ -1,4 +1,3 @@
-// Chat content tests cover message content normalization for chat surfaces.
 import { describe, expect, it } from "vitest";
 import { extractTextFromChatContent } from "./chat-content.js";
 
@@ -59,24 +58,6 @@ describe("shared/chat-content", () => {
     expect(
       extractTextFromChatContent("  ", {
         sanitizeText: () => "",
-      }),
-    ).toBeNull();
-  });
-
-  it("tolerates sanitize and normalize hooks that return non-string values", () => {
-    expect(
-      extractTextFromChatContent("hello", {
-        sanitizeText: () => undefined as unknown as string,
-      }),
-    ).toBeNull();
-    expect(
-      extractTextFromChatContent([{ type: "text", text: "hello" }], {
-        sanitizeText: () => 42 as unknown as string,
-      }),
-    ).toBe("42");
-    expect(
-      extractTextFromChatContent("hello", {
-        normalizeText: () => undefined as unknown as string,
       }),
     ).toBeNull();
   });

--- a/src/shared/chat-content.ts
+++ b/src/shared/chat-content.ts
@@ -33,15 +33,12 @@ export function extractTextFromChatContent(
     normalizeText?: (text: string) => string;
   },
 ): string | null {
-  const normalizeText = opts?.normalizeText ?? ((text: string) => text.replace(/\s+/g, " ").trim());
+  const normalize = opts?.normalizeText ?? ((text: string) => text.replace(/\s+/g, " ").trim());
   const joinWith = opts?.joinWith ?? " ";
   const sanitize = (text: unknown): string => {
     const raw = coerceChatContentText(text);
-    const sanitized = opts?.sanitizeText ? opts.sanitizeText(raw) : raw;
-    return coerceChatContentText(sanitized);
+    return opts?.sanitizeText ? opts.sanitizeText(raw) : raw;
   };
-  const normalize = (text: unknown): string =>
-    coerceChatContentText(normalizeText(coerceChatContentText(text)));
 
   if (typeof content === "string") {
     const value = sanitize(content);

--- a/src/shared/chat-envelope.test.ts
+++ b/src/shared/chat-envelope.test.ts
@@ -1,4 +1,3 @@
-// Chat envelope tests cover parsing and formatting channel-prefixed chat text.
 import { describe, expect, it } from "vitest";
 import { stripEnvelope, stripMessageIdHints } from "./chat-envelope.js";
 

--- a/src/shared/chat-envelope.ts
+++ b/src/shared/chat-envelope.ts
@@ -1,4 +1,3 @@
-// Chat envelope helpers parse and format channel prefixes in chat text.
 const ENVELOPE_PREFIX = /^\[([^\]]+)\]\s*/;
 const ENVELOPE_CHANNELS = [
   "WebChat",
@@ -13,7 +12,6 @@ const ENVELOPE_CHANNELS = [
   "Matrix",
   "Zalo",
   "Zalo Personal",
-  "iMessage",
 ];
 
 const MESSAGE_ID_LINE = /^\s*\[message_id:\s*[^\]]+\]\s*$/i;


### PR DESCRIPTION
## What Problem This Solves

The chat-content tests require recovery from internal string callbacks that deliberately violate their declared contract. That synthetic case keeps redundant coercion around values already produced by the internal normalizer and sanitizer. The envelope helper also lists iMessage twice.

## Why This Change Was Made

Keep coercion at the raw message-content boundary and use the typed internal callback results directly. Remove the invalid-callback case, the unreachable duplicate label, and three generic header comments. All concrete callback producers return strings; the public extraction facade does not expose callback options.

## User Impact

Valid message extraction and envelope stripping are unchanged. Raw unknown content still uses the identical coercion helper, including object serialization and cycle handling. Sanitizer receiver binding, normalizer invocation order, separators, empty-result behavior, and all unique envelope labels remain intact. Deliberately invalid internal callbacks no longer receive accidental recovery.

Production: +2/-7, net -5 lines. Tests: -20 lines, one case removed.

## Evidence

Read the owners, internal callers and callback producers, public facade, sibling sanitizers and envelope consumers, and the raw-parent history introducing both the synthetic case and duplicate label. The same six focused suites pass before (103 cases) and after (102), with every surviving case name and per-file order preserved.

Nine temporary executable before/after vectors produce identical results and callback traces, covering malformed raw values, cyclic content, custom separators, default and supplied normalization, canonical sanitization, callback receiver/order, empty arrays, and unsupported top-level values. These probes are not added to the permanent suite.

All 29 required changed-file checks pass, including core and core-test typechecks, lint, formatting, dead exports, and repository guards. Scoped Codex review is clean. No external provider behavior, configuration, persistence, or public callback API changes.
