### PR TITLE
fix(ci): remove redundant Anthropic worker probe

### DIFF
--- a/test/scripts/vitest-worker-artifacts.test.ts
+++ b/test/scripts/vitest-worker-artifacts.test.ts
@@ -554,43 +554,6 @@ describe("fresh compiled subprocess invocation", () => {
     },
   );
 
-  it("uses the prepared Anthropic failover hook in a fresh process without global activation", (context) =>
-    fixtureLifetime.run(async () => {
-      const { node, prepareWorkers } = createFixtureCommands(context);
-      const owner = createVitestWorkerRun();
-      try {
-        const manifest = await prepareWorkers(owner);
-        const directory = fixtureDirectory();
-        const bundled = path.join(directory, "bundled");
-        const pluginRoot = path.join(bundled, "anthropic");
-        writeFixture(
-          pluginRoot,
-          "openclaw.plugin.json",
-          fs.readFileSync(path.join(root, "extensions/anthropic/openclaw.plugin.json"), "utf8"),
-        );
-        writeFixture(
-          pluginRoot,
-          "index.mjs",
-          `export {default} from ${JSON.stringify(pathToFileURL(path.join(owner.descriptor.directory, "dist/extensions/anthropic/index.js")).href)};`,
-        );
-        const result = await node(
-          [path.join(owner.descriptor.directory, "dist/test-support/anthropic-preparation.js")],
-          root,
-          {
-            ...process.env,
-            OPENCLAW_BUNDLED_PLUGINS_DIR: bundled,
-            OPENCLAW_DISABLE_BUNDLED_PLUGINS: undefined,
-          },
-        );
-        console.log(JSON.stringify({ preparationMs: manifest.durationMs }));
-        console.log(result.stdout);
-        expect(result.code, result.stderr + result.stdout).toBe(0);
-      } finally {
-        await owner.dispose();
-      }
-      expect(fs.existsSync(owner.descriptor.directory)).toBe(false);
-    }));
-
   it("preserves scoped and prepared provider hooks in source and compiled TUI payloads", (context) =>
     fixtureLifetime.run(async () => {
       const { node, prepareWorkers } = createFixtureCommands(context);


### PR DESCRIPTION
## What Problem This Solves

Removes a redundant composite worker-artifact probe that repeatedly exhausts the 120-second per-test timeout on the Windows `test-1` lane.

Supersedes #134109, whose closed pull-request record remained attached to its obsolete head after the refreshed branch was pushed.

## Why This Change Was Made

The probe loads the packaged Anthropic provider in a fresh subprocess to combine several contracts already covered at their owning boundaries. The retained worker-artifact test proves scoped and prepared provider hooks in source and compiled fresh processes, while `extensions/anthropic/index.test.ts` directly proves that `API_ERROR` maps to `server_error`.

The earlier close as superseded by #134029 is no longer supported by current evidence. After #134029 landed, the rewritten probe timed out twice at the same line on the exact head of #134105:

- https://github.com/openclaw/openclaw/actions/runs/33393149983/job/99495129367
- https://github.com/openclaw/openclaw/actions/runs/33393149983/job/99511569195

Both runs reached 120 seconds with no probe output. The stronger generic source/compiled hook test immediately afterward passed in both jobs.

Production LOC: +0/-0
Tests: +0/-37

## User Impact

No user-visible behavior changes. This is a test-only Windows CI reliability repair.

## Evidence

- Current-main base: `9323eae1deab410118abc81c85837c5561ae4a3f`.
- `node scripts/run-vitest.mjs test/scripts/vitest-worker-artifacts.test.ts`: 32/32 passed.
- `node scripts/run-vitest.mjs extensions/anthropic/index.test.ts`: 54/54 passed.
- Pinned Sol/high autoreview: scoped-clean, 0.99, no actionable findings.
- `git diff --check`: passed.
- `node scripts/check-changed.mjs --dry-run -- test/scripts/vitest-worker-artifacts.test.ts`: `testRoot`, `tooling`.
- `pnpm check:changed`: all guards through formatting passed; the test-root typecheck then hit the linked sparse/shared-install environment's existing missing Telegram/UI/Android/QA files and mismatched installed `grammy` types. No changed-file diagnostic.
