### PR TITLE
fix(update): npm-hardened global updates no longer roll back

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -8,6 +8,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { Command } from "commander";
 import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { writePackageDistInventory } from "../../scripts/lib/package-dist-inventory.ts";
+import { LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH } from "../../scripts/lib/package-lifecycle-marker.mjs";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig, ConfigFileSnapshot } from "../config/types.openclaw.js";
@@ -5019,6 +5020,63 @@ describe("update-cli", () => {
     const logs = getLogOutput();
     expect(logs).toContain("global install verify");
     expect(logs).toContain("unexpected packaged dist file dist/stale-runtime.js");
+  });
+
+  it("completes a suppressed npm lifecycle before activating the staged package", async () => {
+    const tempDir = tempDirs.make("openclaw-update-staged-lifecycle-");
+    const prefix = path.join(tempDir, "prefix");
+    const nodeModules = path.join(prefix, "lib", "node_modules");
+    const { pkgRoot } = await setupInstalledPackageAtNodeModules(nodeModules, "2026.7.1");
+    readPackageVersion.mockImplementation(async (packageRoot: string) =>
+      (await fs.readFile(path.join(packageRoot, "package.json"), "utf-8")).includes("2026.8.1")
+        ? "2026.8.1"
+        : "2026.7.1",
+    );
+    primeNpmChannelTag("latest", "2026.8.1");
+    vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValue(
+      path.join(pkgRoot, "dist", "index.js"),
+    );
+    runPostCorePluginConvergenceSpy.mockResolvedValueOnce(postCoreConvergenceResult());
+    vi.mocked(runExec).mockResolvedValue({ stdout: "", stderr: "" });
+    mockNpmGlobalCommands(nodeModules, async (argv) => {
+      if (argv[0] === "npm" && argv[1] === "i" && argv.includes("--prefix")) {
+        const stagePrefix = requireValue(argv[argv.indexOf("--prefix") + 1], "staged prefix");
+        const stageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+        await writeOpenClawPackageFixture(stageRoot, "2026.8.1", {
+          entrySource: "export {};\n",
+          inventory: true,
+        });
+        await fs.writeFile(
+          path.join(stageRoot, LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH),
+          "pending\n",
+        );
+      }
+      if (
+        argv[0] === process.execPath &&
+        argv[1]?.endsWith("preinstall-package-manager-warning.mjs")
+      ) {
+        await fs.rm(
+          path.join(path.dirname(path.dirname(argv[1])), "dist", "openclaw-install-guard"),
+        );
+      }
+      return undefined;
+    });
+
+    await updateCommand({ yes: true, restart: false, json: true });
+
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
+    expect(lastWriteJsonCall()).toMatchObject({ status: "ok", after: { version: "2026.8.1" } });
+    expect(
+      commandCalls()
+        .filter(([argv]) => argv[0] === process.execPath && argv[1]?.includes("/scripts/"))
+        .map(([argv]) => path.basename(requireValue(argv[1], "lifecycle script"))),
+    ).toEqual(["preinstall-package-manager-warning.mjs", "postinstall-bundled-plugins.mjs"]);
+    await expect(fs.readFile(path.join(pkgRoot, "package.json"), "utf-8")).resolves.toContain(
+      '"version":"2026.8.1"',
+    );
+    await expect(
+      fs.access(path.join(pkgRoot, LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH)),
+    ).rejects.toMatchObject({ code: "ENOENT" });
   });
 
   it("runs old package doctors without fix mode when service ownership is unknown", async () => {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -4987,9 +4987,9 @@ describe("update-cli", () => {
     const tempDir = tempDirs.make("openclaw-update-staged-fail-");
     const prefix = path.join(tempDir, "prefix");
     const nodeModules = path.join(prefix, "lib", "node_modules");
-    const { pkgRoot } = await setupInstalledPackageAtNodeModules(nodeModules, "2026.4.20");
-    readPackageVersion.mockResolvedValue("2026.4.20");
-    primeNpmChannelTag("latest", "2026.4.25");
+    const { pkgRoot } = await setupInstalledPackageAtNodeModules(nodeModules, "2026.7.1");
+    readPackageVersion.mockResolvedValue("2026.7.1");
+    primeNpmChannelTag("latest", "2026.8.1");
     mockNpmGlobalCommands(nodeModules, async (argv) => {
       if (argv[0] === "npm" && argv[1] === "i" && argv.includes("--prefix")) {
         const stagePrefix = argv[argv.indexOf("--prefix") + 1];
@@ -4997,15 +4997,17 @@ describe("update-cli", () => {
           throw new Error("missing stage prefix");
         }
         const stageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
-        await writeOpenClawPackageFixture(stageRoot, "2026.4.25", {
+        await writeOpenClawPackageFixture(stageRoot, "2026.8.1", {
           entrySource: "export {};\n",
           inventory: true,
         });
-        await fs.writeFile(
-          path.join(stageRoot, "dist", "stale-runtime.js"),
-          "export {};\n",
-          "utf-8",
-        );
+        await Promise.all([
+          fs.writeFile(
+            path.join(stageRoot, LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH),
+            "pending\n",
+          ),
+          fs.writeFile(path.join(stageRoot, "dist", "stale-runtime.js"), "export {};\n", "utf-8"),
+        ]);
       }
     });
 
@@ -5014,8 +5016,13 @@ describe("update-cli", () => {
     expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
     expect(doctorCommandCall()).toBeUndefined();
     expect(updateNpmInstalledPlugins).not.toHaveBeenCalled();
+    expect(
+      commandCalls().some(
+        ([argv]) => argv[0] === process.execPath && argv[1]?.includes("/scripts/"),
+      ),
+    ).toBe(false);
     await expect(fs.readFile(path.join(pkgRoot, "package.json"), "utf-8")).resolves.toContain(
-      '"version":"2026.4.20"',
+      '"version":"2026.7.1"',
     );
     const logs = getLogOutput();
     expect(logs).toContain("global install verify");

--- a/src/infra/package-lifecycle.test.ts
+++ b/src/infra/package-lifecycle.test.ts
@@ -136,12 +136,12 @@ describe("package lifecycle completion", () => {
             await expect(fs.readFile(markerPath, "utf8")).resolves.toBe("pending\n");
             if (script.name === "preinstall") {
               await fs.rm(legacyGuardPath);
-            } else {
-              await fs.rm(markerPath);
             }
           },
         }),
       ).resolves.toBe(true);
+      await expect(fs.access(markerPath)).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.access(legacyGuardPath)).rejects.toMatchObject({ code: "ENOENT" });
     });
   });
 });

--- a/src/infra/package-lifecycle.ts
+++ b/src/infra/package-lifecycle.ts
@@ -157,6 +157,7 @@ export async function completePendingPackageLifecycle(params: {
     if (!(await isPackageLifecyclePending(paths))) {
       return false;
     }
+    const finalizePromotedLegacyMarker = !(await pathExists(paths.pending));
     // Promote the shipped 2026.8.1 dist guard before preinstall removes it.
     // Postinstall alone clears the canonical marker after all lifecycle work succeeds.
     await ensurePendingMarker(paths.pending);
@@ -165,6 +166,10 @@ export async function completePendingPackageLifecycle(params: {
       ((script) => runPackageLifecycleScript(packageRoot, script, scriptTimeoutMs));
     for (const script of PACKAGE_LIFECYCLE_SCRIPTS) {
       await runScript(script);
+    }
+    if (finalizePromotedLegacyMarker) {
+      // v2026.8.1 postinstall predates this marker; finalize it after both scripts succeed.
+      await fs.rm(paths.pending, { force: true });
     }
     if (await isPackageLifecyclePending(paths)) {
       throw new Error("OpenClaw package postinstall did not complete its lifecycle marker");

--- a/src/infra/package-update-steps.test.ts
+++ b/src/infra/package-update-steps.test.ts
@@ -2,7 +2,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
-import { LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH } from "../../scripts/lib/package-lifecycle-marker.mjs";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import {
   markPackagePostInstallDoctorAdvisory,
@@ -785,69 +784,6 @@ describe("runGlobalPackageUpdateSteps", () => {
       } finally {
         rmSpy.mockRestore();
       }
-    });
-  });
-
-  it("completes a staged npm package lifecycle before strict dist verification", async () => {
-    await withTestDir({ prefix: "openclaw-package-update-npm-lifecycle-" }, async (base) => {
-      const prefix = path.join(base, "prefix");
-      const globalRoot = path.join(prefix, "lib", "node_modules");
-      const packageRoot = path.join(globalRoot, "openclaw");
-      await writePackageRoot(packageRoot, "1.0.0");
-
-      const runStep = vi.fn(async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
-        if (name === "global update") {
-          const stagePrefix = argv[argv.indexOf("--prefix") + 1];
-          if (!stagePrefix) {
-            throw new Error("missing staged prefix");
-          }
-          const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
-          await writePackageRoot(stagedPackageRoot, "2.0.0");
-          await fs.writeFile(
-            path.join(stagedPackageRoot, LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH),
-            "pending\n",
-          );
-        } else {
-          if (!cwd) {
-            throw new Error("missing lifecycle package root");
-          }
-          if (name === "npm package preinstall") {
-            await fs.rm(path.join(cwd, LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH));
-          }
-        }
-        return {
-          name,
-          command: argv.join(" "),
-          cwd: cwd ?? process.cwd(),
-          durationMs: 1,
-          exitCode: 0,
-        };
-      });
-
-      const result = await runGlobalPackageUpdateSteps({
-        installTarget: createNpmTarget(globalRoot),
-        installSpec: "openclaw@2.0.0",
-        packageName: "openclaw",
-        packageRoot,
-        runCommand: createRootRunner(globalRoot),
-        runStep,
-        timeoutMs: 1000,
-      });
-
-      expect(result.failedStep).toBeNull();
-      expect(result.afterVersion).toBe("2.0.0");
-      expect(result.steps.map((step) => step.name)).toEqual([
-        "global update",
-        "npm package preinstall",
-        "npm package postinstall",
-        "global install swap",
-      ]);
-      await expect(
-        fs.access(path.join(packageRoot, LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH)),
-      ).rejects.toMatchObject({ code: "ENOENT" });
-      await expect(fs.readFile(path.join(packageRoot, "package.json"), "utf8")).resolves.toContain(
-        '"version":"2.0.0"',
-      );
     });
   });
 

--- a/src/infra/package-update-steps.test.ts
+++ b/src/infra/package-update-steps.test.ts
@@ -2,6 +2,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH } from "../../scripts/lib/package-lifecycle-marker.mjs";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import {
   markPackagePostInstallDoctorAdvisory,
@@ -784,6 +785,69 @@ describe("runGlobalPackageUpdateSteps", () => {
       } finally {
         rmSpy.mockRestore();
       }
+    });
+  });
+
+  it("completes a staged npm package lifecycle before strict dist verification", async () => {
+    await withTestDir({ prefix: "openclaw-package-update-npm-lifecycle-" }, async (base) => {
+      const prefix = path.join(base, "prefix");
+      const globalRoot = path.join(prefix, "lib", "node_modules");
+      const packageRoot = path.join(globalRoot, "openclaw");
+      await writePackageRoot(packageRoot, "1.0.0");
+
+      const runStep = vi.fn(async ({ name, argv, cwd }): Promise<PackageUpdateStepResult> => {
+        if (name === "global update") {
+          const stagePrefix = argv[argv.indexOf("--prefix") + 1];
+          if (!stagePrefix) {
+            throw new Error("missing staged prefix");
+          }
+          const stagedPackageRoot = path.join(stagePrefix, "lib", "node_modules", "openclaw");
+          await writePackageRoot(stagedPackageRoot, "2.0.0");
+          await fs.writeFile(
+            path.join(stagedPackageRoot, LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH),
+            "pending\n",
+          );
+        } else {
+          if (!cwd) {
+            throw new Error("missing lifecycle package root");
+          }
+          if (name === "npm package preinstall") {
+            await fs.rm(path.join(cwd, LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH));
+          }
+        }
+        return {
+          name,
+          command: argv.join(" "),
+          cwd: cwd ?? process.cwd(),
+          durationMs: 1,
+          exitCode: 0,
+        };
+      });
+
+      const result = await runGlobalPackageUpdateSteps({
+        installTarget: createNpmTarget(globalRoot),
+        installSpec: "openclaw@2.0.0",
+        packageName: "openclaw",
+        packageRoot,
+        runCommand: createRootRunner(globalRoot),
+        runStep,
+        timeoutMs: 1000,
+      });
+
+      expect(result.failedStep).toBeNull();
+      expect(result.afterVersion).toBe("2.0.0");
+      expect(result.steps.map((step) => step.name)).toEqual([
+        "global update",
+        "npm package preinstall",
+        "npm package postinstall",
+        "global install swap",
+      ]);
+      await expect(
+        fs.access(path.join(packageRoot, LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH)),
+      ).rejects.toMatchObject({ code: "ENOENT" });
+      await expect(fs.readFile(path.join(packageRoot, "package.json"), "utf8")).resolves.toContain(
+        '"version":"2.0.0"',
+      );
     });
   });
 

--- a/src/infra/package-update-steps.ts
+++ b/src/infra/package-update-steps.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH } from "../../scripts/lib/package-lifecycle-marker.mjs";
 import { resolveBunGlobalInstallOwner } from "./detect-package-manager.js";
 import { formatErrorMessage } from "./errors.js";
 import { pathExists } from "./fs-safe.js";
@@ -1101,44 +1102,6 @@ export async function runGlobalPackageUpdateSteps(params: {
       return packageUpdateFailure(failedStep, null, [...steps, failedStep]);
     }
 
-    if (finalInstallStep.exitCode === 0 && verificationPackageRoot) {
-      let failedLifecycleStep: PackageUpdateStepResult | null = null;
-      try {
-        await completePendingPackageLifecycle({
-          packageRoot: verificationPackageRoot,
-          timeoutMs: params.timeoutMs,
-          runScript: async (script) => {
-            const lifecycleStep = await params.runStep({
-              name: `${params.installTarget.manager} package ${script.name}`,
-              argv: [process.execPath, path.join(verificationPackageRoot, script.relativePath)],
-              cwd: verificationPackageRoot,
-              env: effectiveInstallEnv,
-              timeoutMs: params.timeoutMs,
-            });
-            steps.push(lifecycleStep);
-            if (lifecycleStep.exitCode !== 0) {
-              failedLifecycleStep = lifecycleStep;
-              throw new Error(lifecycleStep.stderrTail ?? `${lifecycleStep.name} failed`);
-            }
-          },
-        });
-      } catch (error) {
-        if (failedLifecycleStep) {
-          return packageUpdateFailure(failedLifecycleStep, verifiedPackageRoot, steps);
-        }
-        const lifecycleStep: PackageUpdateStepResult = {
-          name: `${params.installTarget.manager} package lifecycle`,
-          command: `complete ${verificationPackageRoot}`,
-          cwd: verificationPackageRoot,
-          durationMs: 0,
-          exitCode: 1,
-          stderrTail: formatErrorMessage(error),
-        };
-        steps.push(lifecycleStep);
-        return packageUpdateFailure(lifecycleStep, verifiedPackageRoot, steps);
-      }
-    }
-
     let afterVersion: string | null = null;
     if (finalInstallStep.exitCode === 0 && verificationPackageRoot) {
       const candidateVersion = await readPackageVersion(verificationPackageRoot);
@@ -1149,11 +1112,61 @@ export async function runGlobalPackageUpdateSteps(params: {
         params.packageName,
         params.installSpec,
       );
-      const verificationErrors = await collectInstalledGlobalPackageErrors({
+      let verificationErrors = await collectInstalledGlobalPackageErrors({
         packageRoot: verificationPackageRoot,
         expectedVersion,
         expectedGitCheckout: params.expectedGitCheckout,
       });
+      // v2026.8.1 alone shipped this pending marker inside the closed dist inventory.
+      const blockingVerificationErrors = verificationErrors.filter(
+        (error) =>
+          params.installSpec !== "openclaw@2026.8.1" ||
+          error !== `unexpected packaged dist file ${LEGACY_PACKAGE_INSTALL_GUARD_RELATIVE_PATH}`,
+      );
+      if (blockingVerificationErrors.length === 0) {
+        let failedLifecycleStep: PackageUpdateStepResult | null = null;
+        try {
+          const completedLifecycle = await completePendingPackageLifecycle({
+            packageRoot: verificationPackageRoot,
+            timeoutMs: params.timeoutMs,
+            runScript: async (script) => {
+              const lifecycleStep = await params.runStep({
+                name: `${params.installTarget.manager} package ${script.name}`,
+                argv: [process.execPath, path.join(verificationPackageRoot, script.relativePath)],
+                cwd: verificationPackageRoot,
+                env: effectiveInstallEnv,
+                timeoutMs: params.timeoutMs,
+              });
+              steps.push(lifecycleStep);
+              if (lifecycleStep.exitCode !== 0) {
+                failedLifecycleStep = lifecycleStep;
+                throw new Error(lifecycleStep.stderrTail ?? `${lifecycleStep.name} failed`);
+              }
+            },
+          });
+          if (completedLifecycle) {
+            verificationErrors = await collectInstalledGlobalPackageErrors({
+              packageRoot: verificationPackageRoot,
+              expectedVersion,
+              expectedGitCheckout: params.expectedGitCheckout,
+            });
+          }
+        } catch (error) {
+          if (failedLifecycleStep) {
+            return packageUpdateFailure(failedLifecycleStep, verifiedPackageRoot, steps);
+          }
+          const lifecycleStep: PackageUpdateStepResult = {
+            name: `${params.installTarget.manager} package lifecycle`,
+            command: `complete ${verificationPackageRoot}`,
+            cwd: verificationPackageRoot,
+            durationMs: 0,
+            exitCode: 1,
+            stderrTail: formatErrorMessage(error),
+          };
+          steps.push(lifecycleStep);
+          return packageUpdateFailure(lifecycleStep, verifiedPackageRoot, steps);
+        }
+      }
       if (verificationErrors.length > 0) {
         steps.push({
           name: "global install verify",

--- a/src/infra/package-update-steps.ts
+++ b/src/infra/package-update-steps.ts
@@ -1101,12 +1101,7 @@ export async function runGlobalPackageUpdateSteps(params: {
       return packageUpdateFailure(failedStep, null, [...steps, failedStep]);
     }
 
-    if (
-      finalInstallStep.exitCode === 0 &&
-      !stagedInstall &&
-      params.installTarget.manager === "pnpm" &&
-      verificationPackageRoot
-    ) {
+    if (finalInstallStep.exitCode === 0 && verificationPackageRoot) {
       let failedLifecycleStep: PackageUpdateStepResult | null = null;
       try {
         await completePendingPackageLifecycle({
@@ -1114,7 +1109,7 @@ export async function runGlobalPackageUpdateSteps(params: {
           timeoutMs: params.timeoutMs,
           runScript: async (script) => {
             const lifecycleStep = await params.runStep({
-              name: `pnpm package ${script.name}`,
+              name: `${params.installTarget.manager} package ${script.name}`,
               argv: [process.execPath, path.join(verificationPackageRoot, script.relativePath)],
               cwd: verificationPackageRoot,
               env: effectiveInstallEnv,
@@ -1132,7 +1127,7 @@ export async function runGlobalPackageUpdateSteps(params: {
           return packageUpdateFailure(failedLifecycleStep, verifiedPackageRoot, steps);
         }
         const lifecycleStep: PackageUpdateStepResult = {
-          name: "pnpm package lifecycle",
+          name: `${params.installTarget.manager} package lifecycle`,
           command: `complete ${verificationPackageRoot}`,
           cwd: verificationPackageRoot,
           durationMs: 0,


### PR DESCRIPTION
Closes #134177

## What Problem This Solves

Fixes an issue where operators with npm `ignore-scripts=true` could download an OpenClaw update successfully, but strict package verification rejected the retained lifecycle guard and left the old version active.

## Why This Change Was Made

The staged npm install remains fully script-disabled, including for every dependency. Strict package verification runs before any lifecycle code. That boundary allows only the documented legacy guard from the exact `openclaw@2026.8.1` registry target. The shared owner then completes only OpenClaw's pending preinstall and postinstall work, and strict verification runs again before activation.

npm keeps its package-scoped allowance when supported, packaged-dist verification stays strict, and no global script policy changes.

The shipped `2026.8.1` postinstall predates the root lifecycle marker. The owner now finalizes that promoted marker only after both legacy scripts succeed.

## User Impact

Managed npm updates work on hardened hosts without enabling lifecycle scripts for unrelated packages or weakening package verification.

## Evidence

- Published `v2026.8.1` red: `2026.7.1 -> 2026.8.1` staged install exited 0, verification rejected `dist/openclaw-install-guard`, update exited 1, and `2026.7.1` stayed active.
- Main red at `0e0b89663f945324a9a9698a58ff8019fe78da8a`: a varied real-npm `1.0.0 -> 2.2.0` update reproduced the same retained guard and rollback.
- Exact-head green: the real published `openclaw@2026.8.1` package passed the narrow pre-lifecycle check, completed only its two lifecycle scripts, passed strict post-lifecycle verification, and activated `2026.8.1`.
- Security anti-cheat: a guard plus another unexpected dist file runs no lifecycle script, performs no swap, and leaves the old version active.
- CLI and owner tests: `node scripts/run-vitest.mjs src/cli/update-cli.test.ts src/infra/package-lifecycle.test.ts src/infra/package-update-steps.test.ts src/infra/package-update-steps.pnpm11-guard.test.ts` — 329 passed.
- Formatting, focused Oxlint, conflict-marker, max-lines, assertion-safety, test-temp, and diff checks passed.
- Production delta: `+57/-44`, net `+13`. The growth enforces verify-before-execute and strict verify-after-execute around the shipped legacy exception. Tests: `+77/-12`.

GitHub CI owns build, typecheck, platform, and merge gates.
