### PR TITLE
refactor: remove catalog test-only URL re-exports

### DIFF
--- a/scripts/publish-model-catalog.mts
+++ b/scripts/publish-model-catalog.mts
@@ -22,10 +22,6 @@ import type {
   RemoteModelCatalogPricing,
 } from "../packages/model-catalog-core/src/remote-catalog-bundle.js";
 import { resolveRepoRoot } from "./lib/repo-root.mjs";
-export {
-  LITELLM_PRICING_URL,
-  OPENROUTER_MODELS_URL,
-} from "@openclaw/model-catalog-core/model-catalog-pricing";
 
 type ModelCatalogManifestInput = {
   pluginId: string;

--- a/test/scripts/publish-model-catalog.test.ts
+++ b/test/scripts/publish-model-catalog.test.ts
@@ -3,13 +3,15 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import type { RemoteModelCatalogBundle } from "@openclaw/model-catalog-core";
+import {
+  LITELLM_PRICING_URL,
+  OPENROUTER_MODELS_URL,
+} from "@openclaw/model-catalog-core/model-catalog-pricing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   assembleModelCatalogBundle,
   enrichModelCatalogPricing,
-  LITELLM_PRICING_URL,
   MODEL_CATALOG_MIN_MODELS,
-  OPENROUTER_MODELS_URL,
   parsePublishModelCatalogArgs,
   readModelCatalogManifests,
   serializeModelCatalogBundle,


### PR DESCRIPTION
## What Problem This Solves

The catalog publisher re-exports two pricing-source URL constants solely for its tests, although the pricing package already owns and exports them.

## Why This Change Was Made

Import the constants directly from their owning package and remove the publisher's forwarding export. The publisher already imports its pricing implementation from that module, so module loading, URL values and CLI behavior stay unchanged.

## User Impact

Tooling: -4 lines. Test imports: +4/-2. Every test body, fixture, assertion and CLI case remains, including the Cerebras/Chutes parsing and paid/free/missing-price cases added by #134311. Public pricing-package exports and plugin pricing APIs remain intact.

## Evidence

Read the full publisher, pricing owner, tests, exports, callers, native pricing parsers and relevant history. All 47 source and validation references match the reviewed current-owner composition on main `10564e2f`.

The current composed run passed 126 cases before and 125 after, including this patch and the separate benchmark cleanup in #133894. Catalog's 76 pricing and 42 publisher cases and the SDK cleanup case have identical names, order and results; only the benchmark's two overlapping cases combine into one. The catalog cases include real CLI dry-run and output-preserving failures with synthetic pricing responses. All 18 normal changed-file checks passed, including script/test types, lint and formatting. No live pricing request or catalog publication was performed.

## CI Refresh

CI 33434419614 failed in an unchanged SDK CLI test that required the shared `RUNNER_TEMP` parent to be empty. The child cancellation, deadline and Git cleanup assertions had passed. This refresh incorporates canonical #134422, which checks removal of the CLI's actual registered temporary root and preservation of unrelated sibling files. The revised SDK case passes in both composed runs; this PR adds no duplicate SDK repair. The two catalog afterimages remain byte-for-byte unchanged. Fresh exact-head hosted CI is required before landing.

Fresh managed Codex review of the complete composed diff is scoped-clean at the configured P0 threshold. Manual owner, coverage and source-composition review is recorded separately.
