### PR TITLE
fix: restore gateway recovery fixture lint and types

### DIFF
--- a/src/gateway/server-kernel.test.ts
+++ b/src/gateway/server-kernel.test.ts
@@ -106,7 +106,9 @@ describe("createGatewayKernel", () => {
 
       await kernel.beginClosePrelude();
       kernel.releaseStartupAccountStarts();
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
 
       expect(startAccount).not.toHaveBeenCalled();
       expect(kernel.channelManager.isAutoRestartScheduled("telegram", "default")).toBe(false);

--- a/src/gateway/server.channels-start-outcomes.test.ts
+++ b/src/gateway/server.channels-start-outcomes.test.ts
@@ -1,12 +1,19 @@
 /** Channel recovery replies preserve decisions from the real account lifecycle owner. */
 import { randomUUID } from "node:crypto";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { WebSocket } from "ws";
 import { createDeferred } from "../../test/helpers/promise.js";
 import "../secrets/runtime-telegram.test-support.ts";
 import type { ChannelGatewayContext } from "../channels/plugins/types.adapters.js";
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
-import { writeConfigFile } from "../config/config.js";
+import {
+  readConfigFileSnapshot,
+  resetConfigRuntimeState,
+  writeConfigFile,
+} from "../config/config.js";
 import { getRuntimeConfigSnapshot } from "../config/runtime-snapshot.js";
+import type { SecretRef } from "../config/types.secrets.js";
+import { writeJsonAtomic } from "../infra/json-files.js";
 import { setActiveDegradedSecretOwners } from "../secrets/runtime-degraded-state.js";
 import { createChannelTestPluginBase, createTestRegistry } from "../test-utils/channel-plugins.js";
 import { withEnvAsync } from "../test-utils/env.js";
@@ -92,38 +99,44 @@ describe("channels.start account outcomes", () => {
         setTestPluginRegistry(
           createTestRegistry([{ pluginId: "telegram", source: "test", plugin }]),
         );
-        await writeConfigFile({
-          gateway: {
-            mode: "local",
-            bind: "loopback",
-            auth: { mode: "none" },
-            reload: { mode: "off" },
-          },
-          secrets: { providers: { default: { source: "env" } } },
-          channels: {
-            telegram: {
-              enabled: true,
-              healthMonitor: { enabled: false },
-              accounts: {
-                plaintext: { botToken: "plaintext-channel-token" },
-                resolved: {
-                  botToken: {
-                    source: "env",
-                    provider: "default",
-                    id: "BREAKER_RESOLVED_CHANNEL_TOKEN",
+        // Authored SecretRefs belong in the source fixture, before runtime config resolution.
+        await writeJsonAtomic(
+          (await readConfigFileSnapshot()).path,
+          {
+            gateway: {
+              mode: "local",
+              bind: "loopback",
+              auth: { mode: "none" },
+              reload: { mode: "off" },
+            },
+            secrets: { providers: { default: { source: "env" } } },
+            channels: {
+              telegram: {
+                enabled: true,
+                healthMonitor: { enabled: false },
+                accounts: {
+                  plaintext: { botToken: "plaintext-channel-token" },
+                  resolved: {
+                    botToken: {
+                      source: "env",
+                      provider: "default",
+                      id: "BREAKER_RESOLVED_CHANNEL_TOKEN",
+                    } satisfies SecretRef,
                   },
-                },
-                unavailable: {
-                  botToken: {
-                    source: "env",
-                    provider: "default",
-                    id: "BREAKER_MISSING_CHANNEL_TOKEN",
+                  unavailable: {
+                    botToken: {
+                      source: "env",
+                      provider: "default",
+                      id: "BREAKER_MISSING_CHANNEL_TOKEN",
+                    } satisfies SecretRef,
                   },
                 },
               },
             },
           },
-        });
+          { durable: false, trailingNewline: true },
+        );
+        resetConfigRuntimeState();
         const port = await getGatewayTestPort();
         server = await startTestGatewayServer(port, {
           auth: { mode: "none" },


### PR DESCRIPTION
Related: #134165.

## What Problem This Solves

Resolves a problem where pull requests based on the channel recovery change fail the core lint and test-type checks before their own changes can be validated.

## Why This Change Was Made

Keep the existing recovery tests and their assertions intact: the shutdown test's Promise executor must not return the Immediate handle, and the RPC helper must use the actual `ws` WebSocket type. Write the intentionally unresolved SecretRef fixture through the existing atomic JSON fixture path, with canonical SecretRef checks and the same runtime-state reset, instead of passing authored source values to the resolved-config writer's string-token contract.

## User Impact

No production behavior or public API change. The existing tests still verify plaintext and resolved-secret account recovery, unavailable-secret isolation, breaker bypass, in-flight ownership, and shutdown fencing. No deadlines, retries, or assertions change.

## Evidence

- Reproduced the Promise-executor lint error on main; the failing core test-type stripe reports the DOM/`ws` mismatch and object-token errors in the same newly added fixture.
- Both complete gateway test files pass: 7 tests.
- Full changed-file core-test gate passes, including the affected gateway-root test type graph, focused lint, formatting, Knip, and boundary checks.
- Independent Codex autoreview: no accepted/actionable P0 findings.
- Production LOC delta: 0. Only the two existing test files change; no additional tests are needed for compiler/linter failures already covered by their existing gates.

The raw parent diff of c003292c236583f0b043be7f2f62234296de6e9d confirms these fixture additions in #134165. This follow-up preserves its channel-recovery behavior and coverage.
