### PR TITLE
perf: reduce Control UI startup and history processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Docs: https://docs.openclaw.ai
 - Matrix lifecycle: drain in-flight monitor tasks without deadlocking shared-client retirement, and reject late acquisitions after their owning task closes.
 - Provider error handling: reuse prepared or already loaded provider hooks instead of cold-loading plugins during error classification, avoiding long stalls in failure reporting and model fallback.
 - **Session settings:** restore merging of concurrent first writes after a startup optimization regressed lock ordering, preserving both global and project settings without adding filesystem side effects to missing-settings reads. Thanks @MrSwagatRathod, @obviyus, and @yetval for the original fix.
+- **Control UI startup and history:** reduce configuration-schema construction and skip full-text duplicate comparisons for distinct transcript messages, preserving plugin hints, redaction, and message identity.
 - **Subagent completion:** recognize visible final answers delivered to internal and nested parent sessions, preventing false delivery failures while preserving external channel delivery checks.
 - Codex/Linux: wait for a live app-server process to expose its startup command line within the existing inspection deadline, preserving process identity checks and preventing intermittent startup failures.
 - **Cloud session lifecycle:** prevent archive, delete, and restart recovery from deadlocking behind an earlier worker move, keep work admission closed through cleanup, and preserve the same successor for concurrent recovery requests.

--- a/src/config/schema.tags.ts
+++ b/src/config/schema.tags.ts
@@ -119,27 +119,21 @@ function normalizeTag(tag: string): ConfigTag | null {
   return CONFIG_TAGS.includes(normalized) ? normalized : null;
 }
 
-function normalizeTags(tags: ReadonlyArray<string>): ConfigTag[] {
+function normalizeTags(tags: ReadonlyArray<string>): string[] {
   const out = new Set<ConfigTag>();
+  const custom = new Set<string>();
   for (const tag of tags) {
-    const normalized = normalizeTag(tag);
-    if (normalized) {
-      out.add(normalized);
+    const known = normalizeTag(tag);
+    if (known) {
+      out.add(known);
+    } else {
+      const normalized = normalizeLowercaseStringOrEmpty(tag);
+      if (normalized) {
+        custom.add(normalized);
+      }
     }
   }
-  return [...out].toSorted((a, b) => TAG_PRIORITY[a] - TAG_PRIORITY[b]);
-}
-
-function collectUnknownTags(tags: ReadonlyArray<string>): string[] {
-  const out = new Set<string>();
-  for (const tag of tags) {
-    const normalized = normalizeLowercaseStringOrEmpty(tag);
-    if (!normalized || normalizeTag(normalized)) {
-      continue;
-    }
-    out.add(normalized);
-  }
-  return [...out];
+  return [...[...out].toSorted((a, b) => TAG_PRIORITY[a] - TAG_PRIORITY[b]), ...custom];
 }
 
 function patternToRegExp(pattern: string): RegExp {
@@ -147,21 +141,9 @@ function patternToRegExp(pattern: string): RegExp {
   return new RegExp(`^${escaped}$`, "i");
 }
 
-function resolveOverride(path: string): ConfigTag[] | undefined {
-  const direct = TAG_OVERRIDES[path];
-  if (direct) {
-    return direct;
-  }
-  for (const [pattern, tags] of Object.entries(TAG_OVERRIDES)) {
-    if (!pattern.includes("*")) {
-      continue;
-    }
-    if (patternToRegExp(pattern).test(path)) {
-      return tags;
-    }
-  }
-  return undefined;
-}
+const WILDCARD_TAG_OVERRIDES = Object.entries(TAG_OVERRIDES)
+  .filter(([pattern]) => pattern.includes("*"))
+  .map(([pattern, tags]) => ({ pattern: patternToRegExp(pattern), tags }));
 
 function addTags(set: Set<ConfigTag>, tags: ReadonlyArray<ConfigTag>): void {
   for (const tag of tags) {
@@ -172,9 +154,10 @@ function addTags(set: Set<ConfigTag>, tags: ReadonlyArray<ConfigTag>): void {
 /** Derive known config UI tags from a schema path and optional hint metadata. */
 function deriveTagsForPath(path: string, hint?: ConfigUiHint): ConfigTag[] {
   const lowerPath = normalizeLowercaseStringOrEmpty(path);
-  const override = resolveOverride(path);
+  const override =
+    TAG_OVERRIDES[path] ?? WILDCARD_TAG_OVERRIDES.find(({ pattern }) => pattern.test(path))?.tags;
   if (override) {
-    return normalizeTags(override);
+    return override;
   }
 
   const tags = new Set<ConfigTag>();
@@ -210,7 +193,7 @@ function deriveTagsForPath(path: string, hint?: ConfigUiHint): ConfigTag[] {
     tags.add("advanced");
   }
 
-  return normalizeTags([...tags]);
+  return [...tags];
 }
 
 /** Return hints with derived known tags merged ahead of any existing custom tags. */
@@ -220,10 +203,7 @@ export function applyDerivedTags(hints: ConfigUiHints): ConfigUiHints {
     const existingTags = Array.isArray(hint?.tags) ? hint.tags : [];
     const derivedTags = deriveTagsForPath(path, hint);
     // Preserve unknown tags after known tags so external/custom UI tags survive normalization.
-    const tags = [
-      ...normalizeTags([...derivedTags, ...existingTags]),
-      ...collectUnknownTags(existingTags),
-    ];
+    const tags = normalizeTags([...derivedTags, ...existingTags]);
     next[path] = { ...hint, tags };
   }
   return next;

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -802,11 +802,30 @@ describe("config schema", () => {
     expect(second).toBe(first);
   });
 
+  it("keeps merged plugin schema fragments independent of manifest metadata", () => {
+    const value = { type: "string" };
+    const result = buildConfigSchemaCore({
+      plugins: [
+        {
+          id: "independent-schema",
+          configSchema: { type: "object", properties: { value } },
+        },
+      ],
+    });
+    value.type = "number";
+    expect(
+      lookupConfigSchema(result, "plugins.entries.independent-schema.config.value")?.schema.type,
+    ).toBe("string");
+  });
+
   it("derives tags for security, network, storage, tools, and performance paths", () => {
     const tagged = applyDerivedTags({
       "gateway.auth.token": {},
       "proxy.tls.caFile": {},
       "tools.web.fetch.timeoutSeconds": {},
+      "SESSION.SHARING.peer": {
+        tags: [" Custom ", "AUTH", "security", "custom", "unknown"],
+      },
     });
     expect(tagged["gateway.auth.token"]?.tags).toEqual(
       expect.arrayContaining(["security", "auth"]),
@@ -817,6 +836,15 @@ describe("config schema", () => {
     expect(tagged["tools.web.fetch.timeoutSeconds"]?.tags).toEqual(
       expect.arrayContaining(["tools", "performance"]),
     );
+    expect(tagged["SESSION.SHARING.peer"]?.tags).toEqual([
+      "security",
+      "auth",
+      "access",
+      "privacy",
+      "storage",
+      "custom",
+      "unknown",
+    ]);
   });
 
   it("only derives the advanced tag from an explicit advanced hint", () => {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -219,9 +219,11 @@ function collectExtensionHintKeys(
   channels: ChannelUiMetadata[],
 ): Set<string> {
   const keys = new Set<string>();
+  const hintKeys = Object.keys(hints);
   const collectPrefixedHintKeys = (prefix: string) => {
-    for (const key of Object.keys(hints)) {
-      if (key === prefix || key.startsWith(`${prefix}.`)) {
+    const childPrefix = `${prefix}.`;
+    for (const key of hintKeys) {
+      if (key === prefix || key.startsWith(childPrefix)) {
         keys.add(key);
       }
     }
@@ -393,21 +395,23 @@ function applyHeartbeatTargetHints(
   return next;
 }
 
-function applyPluginSchemas(schema: ConfigSchema, plugins: PluginUiMetadata[]): ConfigSchema {
+function applyExtensionSchemas(
+  schema: ConfigSchema,
+  channels: ChannelUiMetadata[],
+  plugins?: PluginUiMetadata[],
+): ConfigSchema {
   const next = cloneSchema(schema);
   const root = asSchemaObject(next);
   const pluginsNode = asSchemaObject(root?.properties?.plugins);
   const entriesNode = asSchemaObject(pluginsNode?.properties?.entries);
-  if (!entriesNode) {
-    return next;
+  const entryBase = asSchemaObject(entriesNode?.additionalProperties);
+  const entryProperties = entriesNode?.properties ?? {};
+  if (entriesNode && plugins) {
+    entriesNode.properties = entryProperties;
   }
 
-  const entryBase = asSchemaObject(entriesNode.additionalProperties);
-  const entryProperties = entriesNode.properties ?? {};
-  entriesNode.properties = entryProperties;
-
-  for (const plugin of plugins) {
-    if (!plugin.configSchema) {
+  for (const plugin of plugins ?? []) {
+    if (!entriesNode || !plugin.configSchema) {
       continue;
     }
     const entrySchema = entryBase
@@ -415,14 +419,16 @@ function applyPluginSchemas(schema: ConfigSchema, plugins: PluginUiMetadata[]): 
       : ({ type: "object" } as JsonSchemaObject);
     const entryObject = asSchemaObject(entrySchema) ?? ({ type: "object" } as JsonSchemaObject);
     const baseConfigSchema = asSchemaObject(entryObject.properties?.config);
-    const pluginSchema = asSchemaObject(plugin.configSchema);
+    // The merged response owns plugin fragments independently of manifest metadata.
+    const pluginConfigSchema = cloneSchema(plugin.configSchema);
+    const pluginSchema = asSchemaObject(pluginConfigSchema);
     const nextConfigSchema =
       baseConfigSchema &&
       pluginSchema &&
       isObjectSchema(baseConfigSchema) &&
       isObjectSchema(pluginSchema)
         ? mergeObjectSchema(baseConfigSchema, pluginSchema)
-        : cloneSchema(plugin.configSchema);
+        : pluginConfigSchema;
 
     entryObject.properties = {
       ...entryObject.properties,
@@ -431,12 +437,6 @@ function applyPluginSchemas(schema: ConfigSchema, plugins: PluginUiMetadata[]): 
     entryProperties[plugin.id] = entryObject;
   }
 
-  return next;
-}
-
-function applyChannelSchemas(schema: ConfigSchema, channels: ChannelUiMetadata[]): ConfigSchema {
-  const next = cloneSchema(schema);
-  const root = asSchemaObject(next);
   const channelsNode = asSchemaObject(root?.properties?.channels);
   if (!channelsNode) {
     return next;
@@ -557,7 +557,7 @@ function buildBaseConfigSchema(): ConfigSchemaResponse {
       collectExtensionHintKeys(mergedWithoutSensitiveHints, [], bundledChannels),
     ),
   );
-  const mergedSchema = applyChannelSchemas(generated.schema, bundledChannels);
+  const mergedSchema = applyExtensionSchemas(generated.schema, bundledChannels);
   const next = {
     ...generated,
     schema: mergedSchema,
@@ -603,7 +603,7 @@ export function buildConfigSchemaCore(params?: {
       extensionHintKeys,
     ),
   );
-  const mergedSchema = applyChannelSchemas(applyPluginSchemas(base.schema, plugins), channels);
+  const mergedSchema = applyExtensionSchemas(base.schema, channels, plugins);
   const merged = {
     ...base,
     schema: mergedSchema,

--- a/ui/src/pages/chat/chat-thread-duplicates.ts
+++ b/ui/src/pages/chat/chat-thread-duplicates.ts
@@ -96,7 +96,6 @@ function collapseDuplicateDisplaySignature(parts: TextOnlyMessageParts): string 
 export function prepareMessagesForGrouping(items: ChatItem[]): PreparedChatItem[] {
   const collapsed: PreparedChatItem[] = [];
   let previousParts: TextOnlyMessageParts = null;
-  let previousSignature: string | null = null;
   let previousSourceKey: string | null = null;
   let previousSourceIsUnprovenImport = false;
 
@@ -104,7 +103,6 @@ export function prepareMessagesForGrouping(items: ChatItem[]): PreparedChatItem[
     if (item.kind !== "message") {
       collapsed.push(item);
       previousParts = null;
-      previousSignature = null;
       previousSourceKey = null;
       previousSourceIsUnprovenImport = false;
       continue;
@@ -116,7 +114,6 @@ export function prepareMessagesForGrouping(items: ChatItem[]): PreparedChatItem[
     const role = normalizeRoleForGrouping(normalized.role).toLowerCase();
     const pending = isPendingSendMessage(item.message);
     const parts = pending ? null : textOnlyMessageParts(normalized, role);
-    const signature = collapseDuplicateDisplaySignature(parts);
     const identity = readChatThreadMessageIdentity(item.message);
     const sourceKey = pending ? null : collapseDuplicateSourceKey(identity, role);
     const sourceIsUnprovenImport =
@@ -134,24 +131,26 @@ export function prepareMessagesForGrouping(items: ChatItem[]): PreparedChatItem[
       if (!parts?.senderLabel) {
         collapsed[collapsed.length - 1] = prepared;
         previousParts = parts;
-        previousSignature = signature;
       }
       continue;
     }
+    // Distinct transcript identities cannot collapse. Compare full display text
+    // only for adjacent candidates whose source and role still permit a replay.
     if (
-      signature &&
-      previousSignature === signature &&
       previous?.kind === "message" &&
       !sourceIsUnprovenImport &&
       !previousSourceIsUnprovenImport &&
-      !(sourceKey && previousSourceKey && sourceKey !== previousSourceKey)
+      !(sourceKey && previousSourceKey && sourceKey !== previousSourceKey) &&
+      parts?.role === previousParts?.role
     ) {
-      previous.item.duplicateCount = (previous.item.duplicateCount ?? 1) + 1;
-      continue;
+      const signature = collapseDuplicateDisplaySignature(parts);
+      if (signature && signature === collapseDuplicateDisplaySignature(previousParts)) {
+        previous.item.duplicateCount = (previous.item.duplicateCount ?? 1) + 1;
+        continue;
+      }
     }
     collapsed.push(prepared);
     previousParts = parts;
-    previousSignature = signature;
     previousSourceKey = sourceKey;
     previousSourceIsUnprovenImport = sourceIsUnprovenImport;
   }


### PR DESCRIPTION
## What Problem This Solves

Opening a long Control UI conversation still spends avoidable time preparing configuration metadata and comparing transcript text before the initial history becomes usable. This continues the measured history-loading work in #133870.

## Why This Change Was Made

Build the combined plugin/channel schema with one owned clone, enumerate hint keys once, and prepare immutable wildcard tag patterns once. Tag merging now normalizes known and custom tags in one pass. Transcript deduplication checks message source identity and role before scanning and serializing full display text.

Plugin schema fragments remain independent of caller metadata. Existing tag order, wildcard precedence, sensitivity/redaction, replay handling, imports, pending sends, history limits, and cache lifetimes are preserved. Production LOC: +49/-70 (net -21); tests: +28/-0; changelog: +1.

## User Impact

Initial history renders sooner without reducing the loaded history. Five unprofiled Chromium contexts per build against a full development Gateway measured initial 800-message first paint at **840.7 → 766.9 ms median (8.8% lower)** and initial long-task time at **389 → 351 ms**. Earlier-history pagination and return to a saved reading position were roughly unchanged (373.0 → 386.3 ms and 132.3 → 136.3 ms). These are synthetic same-machine measurements, not a universal performance guarantee.

## Evidence

The baseline was profiled before production edits. A full built Gateway runs in isolated HOME/config/state/workspace with normal bundled plugin discovery and sidecars. A real Chromium browser uses the normal dashboard owner handoff and same-origin HTTP/WebSocket flow; 3,000 synthetic rich messages are seeded through canonical SQLite transcript APIs. No mock Gateway, minimal mode, auth bypass, operator state, or provider calls. Node 24.19.0, Chromium 151.0.7922.34, 1280×800, CPU throttle 1. Source, fixture, and served-bundle hashes were recorded. [Clean-machine proof run](https://github.com/openclaw/openclaw/actions/runs/33367769039).

- Initial history: 800 messages. Prepend: 1,000 messages, 1,800 retained, with the existing next-page prefetch also requesting 1,000. Saved reader row and viewport position matched on every run; no browser page errors.
- Diagnostic CPU captures: initial transcript construction 176.9 → 67.8 ms; duplicate display signatures 65.5 ms → no samples; Gateway hint-prefix scanning 115.4 → 12.4 ms; tag derivation 129.6 → 106.4 ms; overall schema construction 549.9 → 523.6 ms. Profiles are diagnostic single captures; the optimized capture also recorded video. Total process CPU did not consistently improve.
- The first separately scheduled cold-process series worsened (1,041.6 → 2,380.3 ms median) while Gateway readiness drifted from 6 to 11 seconds. A subsequent same-install baseline/optimized/optimized/baseline control measured first paints of 1,817.9/1,390.3/905.6/1,133.5 ms. Both adjacent pairs favor the optimized build, but two trials each and substantial order/environment variation limit cold-load conclusions. All original samples were retained.
- `node scripts/run-vitest.mjs src/config/schema.test.ts src/config/schema.channel-field-help.test.ts src/config/runtime-schema.test.ts src/config/redact-snapshot.schema.test.ts ui/src/pages/chat/chat-thread.test.ts`: **307 tests passed**. The local runtime-config worker logged a termination timeout after tests passed; wrapper exited 0.
- Four complete before/after schema responses, 25,289 hints total, match in deep values and serialized property order, including custom/wildcard/sensitive hints, explicit sensitivity overrides, tuple/primitive fragments, budget omission, and caller-input independence.
- Clean frozen installation: runtime build (`node --import ./scripts/tsx.mjs scripts/build-all.mts sourcePerformance`), UI build (`node scripts/ui.js build`), `pnpm tsgo:core`, `pnpm tsgo:ui`, and changed-file lint passed. Local changed guards passed through typecheck; the shared local dependency installation had unrelated logger/Lit declaration failures resolved by the clean installation. No dependency/lockfile change.
- Fresh independent Codex autoreview: scoped-clean at its configured P0 threshold; no accepted findings. Formatting and `git diff --check` pass.

Before and after are visually identical; the change removes processing work:

| Before | After |
|---|---|
| ![Initial history before](https://github.com/user-attachments/assets/08855a06-30f7-41c1-8d88-65fc4c9eb553) | ![Initial history after](https://github.com/user-attachments/assets/5645ad93-bd8d-4f62-96ab-da763ea33055) |

Real Gateway flow: initial history, earlier-page load, and session switch/return. Inspected synthetic-only capture:

https://github.com/user-attachments/assets/01abb204-df0c-4ec9-af30-fa1e67ea223d
