### PR TITLE
fix(state): migrate schema-17 agent databases missing route-context additions

### DIFF
--- a/src/infra/state-migrations.media-persistence.test.ts
+++ b/src/infra/state-migrations.media-persistence.test.ts
@@ -8,6 +8,7 @@ import {
   SESSION_ARCHIVE_ZSTD_SUFFIX,
 } from "../config/sessions/archive-compression.js";
 import { reconcileSessionTranscriptIndexInTransaction } from "../config/sessions/session-transcript-index.js";
+import { AGENT_MEDIA_SCHEMA_VERSION } from "../state/openclaw-agent-db-contract.js";
 import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -529,6 +530,66 @@ describe("legacy media persistence doctor migration", () => {
         expect.objectContaining({ path: "/media/b.pdf", contentType: "application/pdf" }),
       ],
     });
+  });
+
+  it("converges additive session objects before the schema-17 index repair assertion", async () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-v17-route-context-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = createLegacyDatabaseFixture({
+      env,
+      schemaVersion: AGENT_MEDIA_SCHEMA_VERSION,
+      eventsBySession: {
+        legacy: [
+          createEvent({
+            id: "event-1",
+            parentId: null,
+            timestamp: 1000,
+            message: { role: "user", content: "legacy", MediaPath: "/media/a.png" },
+          }),
+        ],
+      },
+    });
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    try {
+      // The beta.2 lineage stamped user_version 17 without the route-context
+      // additive column/trigger; a missing canonical index also forces the
+      // v17 index-repair callback to run before the additive convergence.
+      database.exec(`
+        DROP TRIGGER session_conversations_route_context_invalidate_after_update;
+        ALTER TABLE session_conversations DROP COLUMN route_context_json;
+        DROP INDEX idx_agent_transcript_event_parent;
+      `);
+    } finally {
+      database.close();
+    }
+
+    const result = await migrateLegacyMediaPersistence({ env });
+    expect(result.warnings).toEqual([]);
+    const after = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(after.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+      });
+      expect(
+        after
+          .prepare(
+            "SELECT name FROM pragma_table_info('session_conversations') WHERE name = 'route_context_json'",
+          )
+          .get(),
+      ).toEqual({ name: "route_context_json" });
+      expect(
+        after
+          .prepare(
+            "SELECT name FROM sqlite_schema WHERE type = 'trigger' AND name = 'session_conversations_route_context_invalidate_after_update'",
+          )
+          .get(),
+      ).toEqual({
+        name: "session_conversations_route_context_invalidate_after_update",
+      });
+    } finally {
+      after.close();
+    }
   });
 
   it("repairs a missing canonical v15 index before the media cutover", async () => {

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -715,6 +715,15 @@ export function ensureOpenClawAgentDatabaseSchema(
   assertExistingAgentSchemaOwner(readExistingAgentSchemaMeta(db), agentId, pathname);
   if (readSqliteUserVersion(db) === AGENT_MEDIA_SCHEMA_VERSION) {
     assertAgentDatabaseMaintenanceAuthority();
+    // Same-version writers may predate the additive session projections
+    // (route_context_json and its invalidation trigger, entry_valid, and the
+    // session_key_contract table). Converge them before the index-repair
+    // assertion below, which validates the canonical schema shape those
+    // additive objects belong to; otherwise a schema-17 database missing
+    // them fails the repair callback and is never migrated (#134163).
+    ensureSessionAdditiveColumns(db);
+    ensureSessionEntryValidityProjection(db);
+    ensureSessionKeyContractSchemaInTransaction(db);
     const legacySql = withLegacySessionParticipantsSchema(OPENCLAW_AGENT_SCHEMA_SQL);
     // Keep canonical index recovery reachable before rebuilding the v17 identity table.
     verifyAndRepairCanonicalSqliteIndexes(db, pathname, legacySql, {


### PR DESCRIPTION
## What Problem This Solves

`openclaw doctor --fix` could not migrate an agent database stamped `user_version = 17` on a lineage that predates `session_conversations.route_context_json` (produced by `2026.8.1-beta.2`). The 17→19 migration asserts the canonical agent schema before the additive convergence that creates the objects the assertion demands:

- `ensureOpenClawAgentDatabaseSchema()` runs `verifyAndRepairCanonicalSqliteIndexes()` with a `validateAfterRepair` callback that asserts the full canonical schema (including the `session_conversations_route_context_invalidate_after_update` trigger and the `route_context_json` column it reads).
- The additive convergence (`ensureSessionAdditiveColumns()`) that creates those objects only runs later, inside `ensureAgentSchema()` — never reached because the callback throws first.
- `migrateAgentDatabase()` catches the throw and downgrades it to a warning (`Skipped agent database migration for …`), so the database stays at 17 forever.

Every schema guard then prints *"stop active agents and run `openclaw doctor --fix` to migrate session identities"* — the prescribed repair is the command that fails. On a supervised host the gateway restart-loops on `startup migrations did not complete cleanly; refusing to report the gateway ready`.

## Why This Change Was Made

The 17→19 path must converge known additive session objects before any canonical-schema assertion, so the assertion validates the post-convergence schema instead of requiring it as a precondition. The two DDL statements (column + trigger) already ship in the same release — they were simply never reached on this lineage.

The fix mirrors the same-version convergence order already used in `ensureAgentSchema()`'s `previousVersion === targetVersion` branch (and the earlier `#120437` fix that converged v15 schema additions before canonical index repair): run `ensureSessionAdditiveColumns()`, `ensureSessionEntryValidityProjection()`, and `ensureSessionKeyContractSchemaInTransaction()` before the v17 index-repair assertion. Non-additive schema corruption still refuses migration.

## User Impact

- `openclaw doctor --fix` now converges schema-17 agent databases that predate `route_context_json` (column + invalidation trigger) and carries them 17 → 19 in one run, instead of skipping them with a warning.
- Operators no longer have to hand-apply the release's own DDL to every affected database to unblock the gateway.
- No behavior change for databases that already satisfy the canonical schema; refusal for genuine (non-additive) corruption is retained.

## Evidence

Real environment tested: No (local test suite only; the failure is fully deterministic below the model/provider layer).

Exact steps or commands run after this patch:

```
pnpm tsgo:core                                          # passes
pnpm exec oxfmt --write <changed files>                 # clean
pnpm exec oxlint <changed files>                        # clean
node scripts/run-vitest.mjs run src/infra/state-migrations.media-persistence.test.ts   # 15/15 pass
node scripts/run-vitest.mjs run src/state/openclaw-agent-db.test.ts src/state/openclaw-agent-db-session-migrations.test.ts   # 121 pass
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.infra.json ...           # passes
node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.core.test.other.json ...           # passes
```

Evidence after fix: The new regression test builds a schema-17 database missing `route_context_json`, its trigger, and one canonical index (forcing the v17 index-repair callback), runs `migrateLegacyMediaPersistence` (the `doctor --fix` path), and asserts: no warnings; `user_version` reaches `OPENCLAW_AGENT_SCHEMA_VERSION` (19); the column and trigger are present.

Observed result after fix: Before the patch the test failed with exactly the reported symptom —

```
Skipped agent database migration for …: … missing or drifted trigger session_conversations_route_context_invalidate_after_update
```

After the patch the migration converges and the database advances 17 → 19.

What was not tested: A live `openclaw doctor --fix` run against a production state directory with real 11 schema-17 databases; the second (separate) `openclaw database preflight` version-comparison misreport noted in the issue (out of scope for this fix).
