### PR TITLE
fix: model fallback cycles every provider when session already has an active turn claim

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -870,6 +870,7 @@ describe("failover-error", () => {
         "WorkerWorkspaceReconciliationError",
         "cloud worker workspace result could not be reconciled",
       ],
+      ["active turn claim", "ActiveTurnClaimError", "session already has an active turn claim"],
     ])("returns true for direct and nested runner %s failures", (_label, name, message) => {
       const coordination = new Error(message);
       coordination.name = name;

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -44,7 +44,6 @@ const RUNTIME_COORDINATION_ERROR_NAMES = new Set([
   "WorkerRunnerUnavailableError",
   "WorkerRunnerCapacityError",
   "WorkerWorkspaceReconciliationError",
-  // Session already holds an active turn claim — retrying other models cannot help.
   "ActiveTurnClaimError",
 ]);
 

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -44,6 +44,8 @@ const RUNTIME_COORDINATION_ERROR_NAMES = new Set([
   "WorkerRunnerUnavailableError",
   "WorkerRunnerCapacityError",
   "WorkerWorkspaceReconciliationError",
+  // Session already holds an active turn claim — retrying other models cannot help.
+  "ActiveTurnClaimError",
 ]);
 
 function resolveNestedErrors(candidate: Record<string, unknown>): unknown[] {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -2335,6 +2335,22 @@ describe("runWithModelFallback", () => {
           }),
         }),
     ],
+    [
+      "active turn claim",
+      () =>
+        Object.assign(new Error("session already has an active turn claim"), {
+          name: "ActiveTurnClaimError",
+        }),
+    ],
+    [
+      "wrapped active turn claim",
+      () =>
+        new Error("worker turn failed", {
+          cause: Object.assign(new Error("session already has an active turn claim"), {
+            name: "ActiveTurnClaimError",
+          }),
+        }),
+    ],
   ])("aborts fallback on %s worker coordination failures", async (_label, makeError) => {
     const error = makeError();
     const run = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce("too late");


### PR DESCRIPTION
<!--
Optional linked context:
Add a visible `Closes #<issue-number>` or `Related: #<issue-number>` line
below this comment.

Required PR title:
type: user-facing description
-->

Closes #134187

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

When a session already owns an active turn claim, model fallback treats that local admission failure as a model failure. It then tries every configured provider and model, even though none can admit the same busy session.

## Why This Change Was Made

Add `ActiveTurnClaimError` to the shared local coordination classifier. This makes fallback return the original direct or wrapped error before candidate failure accounting. Turn-claim acquisition, waiting, release, and provider-failure behavior do not change.

## User Impact

Busy-session conflicts stop after one candidate. Normal provider failures still use configured fallbacks.

## Evidence

### Current-main red

Baseline: `9ca9c1106e2784bf6aca5543ef089269fd3752e8`

A proof harness used the real OpenClaw state database and `createWorkerSessionPlacementStore`:

1. Hold a local turn claim.
2. Attempt a new turn through model fallback.
3. Configure `openai/primary` and cross-provider fallback `anthropic/fallback`.

Current main attempted both candidates before returning `ActiveTurnClaimError`.
The anti-cheat case released the held claim and completed once on the primary candidate.

### Exact-head green

Head: `d672e587ac6d4c9d04ed4acfde3febd487b8c72c`

The same real-store proof attempted only `openai/primary`, returned the original `ActiveTurnClaimError`, and emitted no fallback step. The released-claim control still completed once on the primary candidate.

### Focused tests

```text
node scripts/run-vitest.mjs src/agents/failover-error.test.ts src/agents/model-fallback.test.ts
# Test Files  2 passed (2)
# Tests  231 passed (231)
```

Removing the classifier entry makes the new classifier case and both direct/wrapped fallback cases fail. The adjacent rate-limit control still proves genuine provider failures advance.
