### PR TITLE
fix(gateway): keep TLS diagnostics from generating certificates

### DIFF
--- a/docs/gateway/configuration-reference.md
+++ b/docs/gateway/configuration-reference.md
@@ -933,10 +933,12 @@ See [Multiple Gateways](/gateway/multiple-gateways).
 ```
 
 - `enabled`: enables TLS termination at the gateway listener (HTTPS/WSS) (default: `false`).
-- `autoGenerate`: auto-generates a local self-signed cert/key pair when explicit files are not configured; for local/dev use only. Generated files are published without overwriting existing paths and their parent directories are synchronized when the filesystem supports it; unsupported directory flushing emits a structured degraded-durability warning.
+- `autoGenerate`: defaults to `true`. Gateway startup generates a local self-signed cert/key pair only when both files are missing, including at configured paths; for local/dev use only. An existing partial pair is left untouched and startup fails. Generated files are published without overwriting existing paths and their parent directories are synchronized when the filesystem supports it; unsupported directory flushing emits a structured degraded-durability warning.
 - `certPath`: filesystem path to the TLS certificate file.
 - `keyPath`: filesystem path to the TLS private key file; keep permission-restricted.
 - `caPath`: optional CA bundle path for client verification or custom trust chains.
+
+Client commands such as `triage`, `gateway status`, and `gateway probe` only read the public certificate to determine a local TLS pin. They never generate or repair TLS files and do not need the server private key or CA bundle. Without `certPath`, they inspect `gateway/tls/gateway-cert.pem` under the state directory. A missing or unreadable certificate supplies no implicit pin; normal connection trust checks still apply. Start the Gateway to generate a missing pair, or provide the configured certificate files before connecting.
 
 ### `gateway.reload`
 

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -41,10 +41,9 @@ const callGatewayStatusProbe = vi.fn<
 const isDefaultInstallIdentity = vi.fn((_env?: NodeJS.ProcessEnv) => true);
 const isGatewayExternallySupervised = vi.fn((_env?: NodeJS.ProcessEnv) => false);
 const resolveGatewayProbeAuthSafeWithSecretInputsCalls = vi.fn<(opts?: unknown) => void>();
-const loadGatewayTlsRuntime = vi.fn(async (_cfg?: unknown) => ({
-  enabled: true,
-  required: true,
-  fingerprintSha256: "sha256:11:22:33:44",
+const inspectGatewayTlsCertificate = vi.fn(async (_cfg?: unknown) => ({
+  ok: true as const,
+  value: { cert: "public-certificate", fingerprintSha256: "sha256:11:22:33:44" },
 }));
 const findExtraGatewayServices = vi.fn(async (_env?: unknown, _opts?: unknown) => []);
 const findStaleOpenClawUpdateLaunchdJobs = vi.fn<
@@ -313,7 +312,7 @@ vi.mock("../../infra/tailnet.js", () => ({
 }));
 
 vi.mock("../../infra/tls/gateway.js", () => ({
-  loadGatewayTlsRuntime: (cfg: unknown) => loadGatewayTlsRuntime(cfg),
+  inspectGatewayTlsCertificate: (cfg: unknown) => inspectGatewayTlsCertificate(cfg),
 }));
 
 vi.mock("../../infra/windows-gateway-firewall-diagnostics.js", () => ({
@@ -425,7 +424,7 @@ describe("gatherDaemonStatus", () => {
     findStaleOpenClawUpdateLaunchdJobs.mockResolvedValue([]);
     loadInstalledPluginIndexInstallRecords.mockClear();
     loadInstalledPluginIndexInstallRecords.mockResolvedValue({});
-    loadGatewayTlsRuntime.mockClear();
+    inspectGatewayTlsCertificate.mockClear();
     inspectGatewayRestart.mockClear();
     inspectPortUsage.mockReset();
     inspectPortUsage.mockImplementation(async (port: number) => ({
@@ -511,7 +510,7 @@ describe("gatherDaemonStatus", () => {
   it("uses wss probe URL and forwards TLS fingerprint when daemon TLS is enabled", async () => {
     const status = await gatherStatus();
 
-    expect(loadGatewayTlsRuntime).toHaveBeenCalledTimes(1);
+    expect(inspectGatewayTlsCertificate).toHaveBeenCalledTimes(1);
     const probeInput = callArg(callGatewayStatusProbe) as {
       url?: string;
       tlsFingerprint?: string;
@@ -751,7 +750,7 @@ describe("gatherDaemonStatus", () => {
 
     const status = await gatherStatus({ rpc: { url: rawUrl } });
 
-    expect(loadGatewayTlsRuntime).not.toHaveBeenCalled();
+    expect(inspectGatewayTlsCertificate).not.toHaveBeenCalled();
     const probeInput = callArg(callGatewayStatusProbe) as {
       url?: string;
       tlsFingerprint?: string;
@@ -1530,7 +1529,7 @@ describe("gatherDaemonStatus", () => {
   it("skips TLS runtime loading when probe is disabled", async () => {
     const status = await gatherStatus({ probe: false });
 
-    expect(loadGatewayTlsRuntime).not.toHaveBeenCalled();
+    expect(inspectGatewayTlsCertificate).not.toHaveBeenCalled();
     expect(callGatewayStatusProbe).not.toHaveBeenCalled();
     expect(status.rpc).toBeUndefined();
   });

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -668,12 +668,12 @@ export async function gatherDaemonStatus(
       : [];
 
   const tlsEnabled = daemonCfg.gateway?.tls?.enabled === true;
-  const shouldUseLocalTlsRuntime = opts.probe && !probeUrlOverride && tlsEnabled;
-  const tlsRuntime = shouldUseLocalTlsRuntime
-    ? await loadGatewayTlsModule().then(({ loadGatewayTlsRuntime }) =>
-        loadGatewayTlsRuntime(daemonCfg.gateway?.tls),
-      )
-    : undefined;
+  const localCertificate =
+    opts.probe && !probeUrlOverride && tlsEnabled
+      ? await loadGatewayTlsModule().then(({ inspectGatewayTlsCertificate }) =>
+          inspectGatewayTlsCertificate(daemonCfg.gateway?.tls),
+        )
+      : undefined;
   let daemonProbeAuth: { token?: string; password?: string } | undefined;
   let rpcAuthWarning: string | undefined;
   let allowRpcConfigCredentials = true;
@@ -719,10 +719,9 @@ export async function gatherDaemonStatus(
           token: daemonProbeAuth?.token,
           password: daemonProbeAuth?.password,
           config: daemonCfg,
-          tlsFingerprint:
-            shouldUseLocalTlsRuntime && tlsRuntime?.enabled
-              ? tlsRuntime.fingerprintSha256
-              : undefined,
+          tlsFingerprint: localCertificate?.ok
+            ? localCertificate.value.fingerprintSha256
+            : undefined,
           timeoutMs,
           json: opts.rpc.json,
           requireRpc: opts.requireRpc,

--- a/src/cli/gateway-cli/run.supervised-lock.test.ts
+++ b/src/cli/gateway-cli/run.supervised-lock.test.ts
@@ -6,12 +6,12 @@ import { TailscaleRouteOwnershipConflictError } from "../../infra/tailscale-rout
 import { OpenClawAgentDatabaseMediaMigrationRequiredError } from "../../state/openclaw-agent-db-migration-required.js";
 import { testing } from "./run.test-support.js";
 
-const loadGatewayTlsRuntimeMock = vi.hoisted(() =>
-  vi.fn(async () => ({ enabled: false, required: true })),
+const inspectGatewayTlsCertificateMock = vi.hoisted(() =>
+  vi.fn(async () => ({ ok: false as const, error: "missing certificate" })),
 );
 
 vi.mock("../../infra/tls/gateway.js", () => ({
-  loadGatewayTlsRuntime: loadGatewayTlsRuntimeMock,
+  inspectGatewayTlsCertificate: inspectGatewayTlsCertificateMock,
 }));
 
 function createLogger() {
@@ -213,7 +213,7 @@ describe("supervised gateway lock recovery", () => {
   );
 
   it("retries non-mutating TLS fingerprint loads until certificate material is ready", async () => {
-    loadGatewayTlsRuntimeMock.mockClear();
+    inspectGatewayTlsCertificateMock.mockClear();
     const probeHealth = testing.createConfiguredGatewayHealthProbe({
       gateway: { tls: { enabled: true, autoGenerate: true } },
     });
@@ -221,14 +221,14 @@ describe("supervised gateway lock recovery", () => {
     await expect(probeHealth({ host: "127.0.0.1", port: 18789 })).resolves.toBe(false);
     await expect(probeHealth({ host: "127.0.0.1", port: 18789 })).resolves.toBe(false);
 
-    expect(loadGatewayTlsRuntimeMock).toHaveBeenCalledTimes(2);
-    expect(loadGatewayTlsRuntimeMock).toHaveBeenNthCalledWith(1, {
+    expect(inspectGatewayTlsCertificateMock).toHaveBeenCalledTimes(2);
+    expect(inspectGatewayTlsCertificateMock).toHaveBeenNthCalledWith(1, {
       enabled: true,
-      autoGenerate: false,
+      autoGenerate: true,
     });
-    expect(loadGatewayTlsRuntimeMock).toHaveBeenNthCalledWith(2, {
+    expect(inspectGatewayTlsCertificateMock).toHaveBeenNthCalledWith(2, {
       enabled: true,
-      autoGenerate: false,
+      autoGenerate: true,
     });
   });
 

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -585,12 +585,10 @@ function createConfiguredGatewayHealthProbe(cfg: OpenClawConfig) {
       return await probeGatewayHealthz(params);
     }
     if (!tlsFingerprint) {
-      const gatewayTls = await import("../../infra/tls/gateway.js")
-        .then(({ loadGatewayTlsRuntime }) =>
-          loadGatewayTlsRuntime({ ...tlsConfig, autoGenerate: false }),
-        )
+      const certificate = await import("../../infra/tls/gateway.js")
+        .then(({ inspectGatewayTlsCertificate }) => inspectGatewayTlsCertificate(tlsConfig))
         .catch(() => undefined);
-      tlsFingerprint = gatewayTls?.fingerprintSha256;
+      tlsFingerprint = certificate?.ok ? certificate.value.fingerprintSha256 : undefined;
     }
     if (!tlsFingerprint) {
       return false;

--- a/src/cli/qr-cli.ts
+++ b/src/cli/qr-cli.ts
@@ -7,7 +7,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { hasConfiguredSecretInput } from "../config/types.secrets.js";
 import { trimToUndefined } from "../gateway/credentials.js";
 import { resolveRequiredConfiguredSecretRefInputString } from "../gateway/resolve-configured-secret-input-string.js";
-import { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
+import { inspectGatewayTlsCertificate } from "../infra/tls/gateway.js";
 import { renderQrTerminal } from "../media/qr-terminal.ts";
 import { resolvePairingSetupFromConfig, encodePairingSetupCode } from "../pairing/setup-code.js";
 import { runCommandWithTimeout } from "../process/exec.js";
@@ -225,8 +225,8 @@ export function registerQrCli(program: Command) {
               timeoutMs: runOpts.timeoutMs,
             }),
           loadLocalTlsFingerprint: async () => {
-            const tls = await loadGatewayTlsRuntime(cfg.gateway?.tls);
-            return tls.enabled ? tls.fingerprintSha256 : undefined;
+            const certificate = await inspectGatewayTlsCertificate(cfg.gateway?.tls);
+            return certificate.ok ? certificate.value.fingerprintSha256 : undefined;
           },
         });
 

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -151,14 +151,11 @@ const probeGatewayConfiguredModelMock = vi.hoisted(() =>
 const readActiveGatewayLockPortMock = vi.hoisted(() =>
   vi.fn(async (): Promise<number | undefined> => undefined),
 );
-const loadGatewayTlsRuntimeMock = vi.hoisted(() =>
-  vi.fn<
-    () => Promise<{
-      enabled: boolean;
-      required: boolean;
-      fingerprintSha256?: string;
-    }>
-  >(async () => ({ enabled: false, required: false })),
+const inspectGatewayTlsCertificateMock = vi.hoisted(() =>
+  vi.fn<typeof import("../infra/tls/gateway.js").inspectGatewayTlsCertificate>(async () => ({
+    ok: false,
+    error: "gateway tls is disabled",
+  })),
 );
 const resolveControlUiLinksMock = vi.hoisted(() =>
   vi.fn(() => ({
@@ -317,7 +314,7 @@ vi.mock("../infra/gateway-lock.js", async (importOriginal) => ({
 
 vi.mock("../infra/tls/gateway.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../infra/tls/gateway.js")>()),
-  loadGatewayTlsRuntime: loadGatewayTlsRuntimeMock,
+  inspectGatewayTlsCertificate: inspectGatewayTlsCertificateMock,
 }));
 
 vi.mock("../utils.js", async (importOriginal) => ({
@@ -597,9 +594,9 @@ describe("runCli exit behavior", () => {
     readLocalOnboardingStateMock.mockReset().mockReturnValue(undefined);
     probeGatewayConfiguredModelMock.mockResolvedValue({ kind: "configured" });
     readActiveGatewayLockPortMock.mockReset().mockResolvedValue(undefined);
-    loadGatewayTlsRuntimeMock.mockReset().mockResolvedValue({
-      enabled: false,
-      required: false,
+    inspectGatewayTlsCertificateMock.mockReset().mockResolvedValue({
+      ok: false,
+      error: "gateway tls is disabled",
     });
     resolveControlUiLinksMock.mockReturnValue({
       httpUrl: "http://127.0.0.1:18789/",
@@ -4056,10 +4053,9 @@ describe("runCli exit behavior", () => {
         auth: { mode: "token", token: "configured-token" },
       },
     });
-    loadGatewayTlsRuntimeMock.mockResolvedValueOnce({
-      enabled: true,
-      required: true,
-      fingerprintSha256: TLS_FINGERPRINT,
+    inspectGatewayTlsCertificateMock.mockResolvedValueOnce({
+      ok: true,
+      value: { cert: "public-certificate", fingerprintSha256: TLS_FINGERPRINT },
     });
 
     await runBareCli();

--- a/src/commands/control-ui-handoff.test.ts
+++ b/src/commands/control-ui-handoff.test.ts
@@ -1,9 +1,24 @@
+import { execFile } from "node:child_process";
+import { X509Certificate } from "node:crypto";
+import fs from "node:fs/promises";
+import { createServer } from "node:https";
+import path from "node:path";
 import type { PeerCertificate } from "node:tls";
-import { describe, expect, it, vi } from "vitest";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../test/helpers/tls-fixture.js";
 import type { fetchConfiguredLocalOriginWithSsrFGuard } from "../infra/net/fetch-guard.js";
+import { resolveSystemBin } from "../infra/resolve-system-bin.js";
+import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import { resolveControlUiHandoffTarget, waitForControlUiDocument } from "./control-ui-handoff.js";
 
 const documentUrl = "http://127.0.0.1:18789/dashboard/";
+const tempDirs = createTrackedTempDirs();
+const openssl = resolveSystemBin("openssl");
+afterEach(async () => {
+  vi.restoreAllMocks();
+  await tempDirs.cleanup();
+});
 type GuardedDocumentRequest = Parameters<typeof fetchConfiguredLocalOriginWithSsrFGuard>[0];
 
 function guardedResponse(response: Response) {
@@ -78,6 +93,102 @@ describe("resolveControlUiHandoffTarget", () => {
 });
 
 describe("waitForControlUiDocument", () => {
+  it.runIf(openssl)(
+    "verifies a CA-signed HTTPS leaf without the issuer or private key and rejects a replacement",
+    async () => {
+      const root = await tempDirs.make("openclaw-tls-owner-https-");
+      const certPath = path.join(root, "leaf.pem");
+      const keyPath = path.join(root, "signer.key");
+      const caPath = path.join(root, "signer.pem");
+      const csrPath = path.join(root, "leaf.csr");
+      await fs.writeFile(keyPath, TEST_TLS_KEY_PEM, { mode: 0o600 });
+      await fs.writeFile(caPath, TEST_TLS_CERT_PEM);
+      const run = promisify(execFile);
+      await run(
+        openssl!,
+        ["req", "-new", "-key", keyPath, "-subj", "/CN=gateway.test", "-out", csrPath],
+        { timeout: 10_000 },
+      );
+      await run(
+        openssl!,
+        [
+          "x509",
+          "-req",
+          "-in",
+          csrPath,
+          "-CA",
+          caPath,
+          "-CAkey",
+          keyPath,
+          "-set_serial",
+          "2",
+          "-days",
+          "1",
+          "-out",
+          certPath,
+        ],
+        { timeout: 10_000 },
+      );
+      const cert = await fs.readFile(certPath, "utf8");
+      await fs.unlink(keyPath);
+      await fs.unlink(caPath);
+      let requests = 0;
+      const server = createServer({ cert, key: TEST_TLS_KEY_PEM }, (_request, response) => {
+        requests++;
+        response.writeHead(200, { "content-type": "text/html" });
+        response.end();
+      });
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      try {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("expected a test HTTPS port");
+        }
+        const options = {
+          url: `https://127.0.0.1:${address.port}/dashboard/`,
+          tlsConfig: { enabled: true, certPath, keyPath, caPath },
+        };
+        await expect(waitForControlUiDocument(options)).resolves.toMatchObject({ ready: true });
+        expect(requests).toBe(1);
+        server.closeAllConnections();
+        server.setSecureContext({ cert: TEST_TLS_CERT_PEM, key: TEST_TLS_KEY_PEM });
+        await expect(waitForControlUiDocument(options)).resolves.toMatchObject({ ready: false });
+        expect(requests).toBe(1);
+      } finally {
+        server.closeAllConnections();
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
+
+  it("can inspect dashboard TLS using only the public certificate", async () => {
+    const root = await tempDirs.make("openclaw-tls-owner-dashboard-");
+    const certPath = path.join(root, "cert.pem");
+    await fs.writeFile(certPath, TEST_TLS_CERT_PEM);
+    const read = vi.spyOn(fs, "readFile");
+    const fetch = vi.fn(async () => htmlHead());
+
+    const result = await waitForControlUiDocument({
+      url: "https://127.0.0.1:32123/dashboard/",
+      tlsConfig: {
+        enabled: true,
+        certPath,
+        keyPath: path.join(root, "absent-key.pem"),
+        caPath: path.join(root, "absent-ca.pem"),
+      },
+      deps: { fetch },
+    });
+
+    expect(result.ready).toBe(true);
+    expect(read.mock.calls.map(([file]) => file)).toEqual([certPath]);
+    expect(fetch).toHaveBeenCalledOnce();
+    await expect(fs.readdir(root)).resolves.toEqual(["cert.pem"]);
+  });
+
   it("probes the exact HTML document without credentials or redirects", async () => {
     const response = htmlHead();
     const fetch = vi.fn(async () => response);
@@ -235,111 +346,50 @@ describe("waitForControlUiDocument", () => {
     expect(fetch).toHaveBeenCalledTimes(3);
   });
 
-  it("trusts only the configured Gateway certificate and pins the actual TLS peer", async () => {
-    const fingerprint = "ab".repeat(32);
-    const loadTls = vi.fn(async () => ({
-      enabled: true,
-      required: true,
-      fingerprintSha256: fingerprint,
-      tlsOptions: { cert: "exact-gateway-certificate" },
-    }));
+  it("trusts the public certificate and rejects a different peer without reading a server CA", async () => {
+    const root = await tempDirs.make("openclaw-tls-owner-dashboard-");
+    const certPath = path.join(root, "cert.pem");
+    await fs.writeFile(certPath, TEST_TLS_CERT_PEM);
+    const fingerprint = new X509Certificate(TEST_TLS_CERT_PEM).fingerprint256
+      .replaceAll(":", "")
+      .toLowerCase();
     const fetch = vi.fn(async (_request: GuardedDocumentRequest) => htmlHead());
 
     await expect(
       waitForControlUiDocument({
-        url: "https://127.0.0.1:18789/dashboard/",
-        tlsConfig: { enabled: true },
-        deps: { fetch, loadTls },
+        url: "https://127.0.0.1:32123/dashboard/",
+        tlsConfig: { enabled: true, certPath, caPath: path.join(root, "absent-ca.pem") },
+        deps: { fetch },
       }),
     ).resolves.toEqual({ ready: true, tlsFingerprint: fingerprint });
 
-    expect(loadTls).toHaveBeenCalledWith({ enabled: true, autoGenerate: false });
     const [request] = fetch.mock.calls[0] ?? [];
     if (!request) {
       throw new Error("expected dashboard TLS request");
     }
     const connect = requireDirectTlsConnect(request);
-    expect(connect.ca).toBe("exact-gateway-certificate");
+    expect(connect.ca).toBe(TEST_TLS_CERT_PEM);
     expect(connect).not.toHaveProperty("rejectUnauthorized");
-    const check = connect.checkServerIdentity as
-      | ((hostname: string, certificate: PeerCertificate) => Error | undefined)
-      | undefined;
-    expect(
-      check?.("127.0.0.1", { fingerprint256: fingerprint } as PeerCertificate),
-    ).toBeUndefined();
-    expect(check?.("127.0.0.1", { fingerprint256: "cd".repeat(32) } as PeerCertificate)).toEqual(
+    const check = connect.checkServerIdentity as (
+      hostname: string,
+      certificate: PeerCertificate,
+    ) => Error | undefined;
+    expect(check("127.0.0.1", { fingerprint256: fingerprint } as PeerCertificate)).toBeUndefined();
+    expect(check("127.0.0.1", { fingerprint256: "cd".repeat(32) } as PeerCertificate)).toEqual(
       new Error("Gateway TLS certificate fingerprint mismatch."),
     );
-  });
-
-  it("trusts the served Gateway certificate alongside a distinct client-verification CA", async () => {
-    const fingerprint = "ab".repeat(32);
-    const loadTls = vi.fn(async () => ({
-      enabled: true,
-      required: true,
-      fingerprintSha256: fingerprint,
-      tlsOptions: {
-        cert: "exact-gateway-certificate",
-        ca: "separate-client-verification-ca",
-      },
-    }));
-    const fetch = vi.fn(async (request: GuardedDocumentRequest) => {
-      const connect = requireDirectTlsConnect(request);
-      if (!Array.isArray(connect.ca) || !connect.ca.includes("exact-gateway-certificate")) {
-        throw new Error("self-signed Gateway certificate is not trusted");
-      }
-      const check = connect.checkServerIdentity as (
-        hostname: string,
-        certificate: PeerCertificate,
-      ) => Error | undefined;
-      const mismatch = check("127.0.0.1", { fingerprint256: fingerprint } as PeerCertificate);
-      if (mismatch) {
-        throw mismatch;
-      }
-      return htmlHead();
-    });
-
-    await expect(
-      waitForControlUiDocument({
-        url: "https://127.0.0.1:18789/dashboard/",
-        tlsConfig: { enabled: true, caPath: "/gateway/client-verification-ca.pem" },
-        deps: { fetch, loadTls },
-      }),
-    ).resolves.toEqual({ ready: true, tlsFingerprint: fingerprint });
-
-    const [request] = fetch.mock.calls[0] ?? [];
-    if (!request) {
-      throw new Error("expected dashboard TLS request");
-    }
-    const connect = requireDirectTlsConnect(request);
-    expect(connect.ca).toEqual(["exact-gateway-certificate", "separate-client-verification-ca"]);
-    expect(connect).not.toHaveProperty("rejectUnauthorized");
-  });
-
-  it("rejects a mismatched TLS certificate before accepting dashboard HTML", async () => {
-    const loadTls = vi.fn(async () => ({
-      enabled: true,
-      required: true,
-      fingerprintSha256: "ab".repeat(32),
-      tlsOptions: { cert: "exact-gateway-certificate" },
-    }));
-    const fetch = vi.fn(async (request: GuardedDocumentRequest) => {
-      const check = requireDirectTlsConnect(request).checkServerIdentity as (
-        hostname: string,
-        certificate: PeerCertificate,
-      ) => Error | undefined;
+    fetch.mockImplementation(async () => {
       const mismatch = check("127.0.0.1", { fingerprint256: "cd".repeat(32) } as PeerCertificate);
       if (mismatch) {
         throw mismatch;
       }
       return htmlHead();
     });
-
     await expect(
       waitForControlUiDocument({
-        url: "https://127.0.0.1:18789/dashboard/",
-        tlsConfig: { enabled: true },
-        deps: { fetch, loadTls },
+        url: "https://127.0.0.1:32123/dashboard/",
+        tlsConfig: { enabled: true, certPath },
+        deps: { fetch },
       }),
     ).resolves.toEqual({
       ready: false,

--- a/src/commands/control-ui-handoff.ts
+++ b/src/commands/control-ui-handoff.ts
@@ -17,7 +17,7 @@ import { readResponseTextSnippet } from "../infra/http-body.js";
 import { fetchConfiguredLocalOriginWithSsrFGuard } from "../infra/net/fetch-guard.js";
 import { isSameProcessSpecificIpv4WithLoopbackListeners } from "../infra/ports-format.js";
 import { inspectPortUsage } from "../infra/ports-inspect.js";
-import { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
+import { inspectGatewayTlsCertificate } from "../infra/tls/gateway.js";
 import { CONTROL_UI_OWNER_BOOTSTRAP_PROFILE } from "../shared/device-bootstrap-profile.js";
 import { sleep } from "../utils.js";
 import { resolveControlUiLinks } from "./onboard-helpers.js";
@@ -161,7 +161,6 @@ type ControlUiDocumentReadiness =
 
 type ControlUiDocumentReadinessDeps = {
   fetch?: typeof fetchConfiguredLocalOriginWithSsrFGuard;
-  loadTls?: typeof loadGatewayTlsRuntime;
   now?: () => number;
   sleep?: (timeoutMs: number) => Promise<void>;
 };
@@ -183,26 +182,19 @@ export async function waitForControlUiDocument(params: {
 
   if (params.tlsConfig?.enabled === true) {
     try {
-      const tls = await (params.deps?.loadTls ?? loadGatewayTlsRuntime)({
-        ...params.tlsConfig,
-        autoGenerate: false,
-      });
-      tlsFingerprint = normalizeTlsFingerprint(tls.fingerprintSha256 ?? "");
-      const serverCertificate = tls.tlsOptions?.cert;
-      if (!tls.enabled || !tlsFingerprint || !serverCertificate) {
-        return {
-          ready: false,
-          reason: tls.error || "Gateway TLS certificate fingerprint is unavailable.",
-        };
+      const certificate = await inspectGatewayTlsCertificate(params.tlsConfig);
+      if (!certificate.ok) {
+        return { ready: false, reason: certificate.error };
       }
+      tlsFingerprint = certificate.value.fingerprintSha256;
       const expectedFingerprint = tlsFingerprint;
-      const configuredCa = tls.tlsOptions?.ca;
-      // The Gateway CA may verify clients rather than issue its server cert;
-      // retain both trust anchors before checking the actual peer fingerprint.
+      // Trust the configured public certificate even when it is CA-signed;
+      // peer pinning still binds the connection to that exact leaf certificate.
       tlsConnect = {
-        ca: configuredCa ? [serverCertificate, configuredCa].flat() : serverCertificate,
-        checkServerIdentity: (_hostname: string, certificate: PeerCertificate) =>
-          normalizeTlsFingerprint(certificate.fingerprint256 ?? "") === expectedFingerprint
+        ca: certificate.value.cert,
+        allowPartialTrustChain: true,
+        checkServerIdentity: (_hostname: string, peerCertificate: PeerCertificate) =>
+          normalizeTlsFingerprint(peerCertificate.fingerprint256 ?? "") === expectedFingerprint
             ? undefined
             : new Error("Gateway TLS certificate fingerprint mismatch."),
       };

--- a/src/commands/dashboard/json.test.ts
+++ b/src/commands/dashboard/json.test.ts
@@ -6,7 +6,6 @@ const mocks = vi.hoisted(() => ({
   ensureGatewayReadyForOperation: vi.fn(),
   inspectPortUsage: vi.fn(),
   issueDeviceBootstrapToken: vi.fn(),
-  loadGatewayTlsRuntime: vi.fn(),
   openUrl: vi.fn(),
   readConfigFileSnapshot: vi.fn(),
   resolveControlUiLinks: vi.fn(),
@@ -36,10 +35,6 @@ vi.mock("../../infra/device-bootstrap.js", () => ({
 
 vi.mock("../../infra/ports-inspect.js", () => ({
   inspectPortUsage: mocks.inspectPortUsage,
-}));
-
-vi.mock("../../infra/tls/gateway.js", () => ({
-  loadGatewayTlsRuntime: mocks.loadGatewayTlsRuntime,
 }));
 
 vi.mock("../gateway-readiness.js", () => ({
@@ -112,7 +107,6 @@ describe("dashboardCommand --json", () => {
       token: "browser-bootstrap",
       expiresAtMs: 123_456,
     });
-    mocks.loadGatewayTlsRuntime.mockResolvedValue({ enabled: false, required: false });
     mocks.waitForControlUiDocument.mockResolvedValue({ ready: true });
   });
 
@@ -139,7 +133,6 @@ describe("dashboardCommand --json", () => {
     expect(mocks.copyToClipboard).not.toHaveBeenCalled();
     expect(mocks.inspectPortUsage).toHaveBeenCalledWith(18789);
     expect(mocks.openUrl).not.toHaveBeenCalled();
-    expect(mocks.loadGatewayTlsRuntime).not.toHaveBeenCalled();
     expect(mocks.issueDeviceBootstrapToken).toHaveBeenCalledWith({
       profile: {
         roles: ["operator"],
@@ -170,11 +163,6 @@ describe("dashboardCommand --json", () => {
     mocks.resolveControlUiLinks.mockReturnValue({
       httpUrl: "https://127.0.0.1:18789/",
       wsUrl: "wss://127.0.0.1:18789",
-    });
-    mocks.loadGatewayTlsRuntime.mockResolvedValue({
-      enabled: true,
-      required: true,
-      fingerprintSha256: "ab".repeat(32),
     });
     mocks.waitForControlUiDocument.mockResolvedValue({
       ready: true,

--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -4,7 +4,7 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GatewayProbeResult } from "../gateway/probe.js";
 import type { GatewayBonjourBeacon } from "../infra/bonjour-discovery.js";
-import type { GatewayTlsRuntime } from "../infra/tls/gateway.js";
+import type { inspectGatewayTlsCertificate as InspectGatewayTlsCertificate } from "../infra/tls/gateway.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { gatewayStatusCommand } from "./gateway-status.js";
@@ -42,11 +42,10 @@ const mocks = vi.hoisted(() => {
       stderr: [],
       stop: sshStop,
     })),
-    loadGatewayTlsRuntime: vi.fn(
-      async (): Promise<GatewayTlsRuntime> => ({
-        enabled: true,
-        required: true,
-        fingerprintSha256: "sha256:local-fingerprint",
+    inspectGatewayTlsCertificate: vi.fn(
+      async (): ReturnType<typeof InspectGatewayTlsCertificate> => ({
+        ok: true,
+        value: { cert: "public-certificate", fingerprintSha256: "sha256:local-fingerprint" },
       }),
     ),
     inspectWindowsGatewayFirewall: vi.fn<() => Promise<unknown>>(async () => ({
@@ -161,7 +160,7 @@ const {
   sshStop,
   resolveSshConfig,
   startSshPortForward,
-  loadGatewayTlsRuntime,
+  inspectGatewayTlsCertificate,
   inspectWindowsGatewayFirewall,
   probeGateway,
 } = mocks;
@@ -222,7 +221,7 @@ vi.mock("../infra/ssh-config.js", () => ({
 }));
 
 vi.mock("../infra/tls/gateway.js", () => ({
-  loadGatewayTlsRuntime: mocks.loadGatewayTlsRuntime,
+  inspectGatewayTlsCertificate: mocks.inspectGatewayTlsCertificate,
 }));
 
 vi.mock("../infra/windows-gateway-firewall-diagnostics.js", () => ({
@@ -1013,7 +1012,7 @@ describe("gateway-status command", () => {
   it("uses local TLS target strategy and fingerprint for local loopback probes", async () => {
     const { runtime } = createRuntimeCapture();
     probeGateway.mockClear();
-    loadGatewayTlsRuntime.mockClear();
+    inspectGatewayTlsCertificate.mockClear();
     readBestEffortConfig.mockResolvedValueOnce({
       gateway: {
         mode: "local",
@@ -1024,7 +1023,7 @@ describe("gateway-status command", () => {
 
     await runGatewayStatus(runtime, { timeout: "15000", json: true });
 
-    expect(loadGatewayTlsRuntime).toHaveBeenCalledTimes(1);
+    expect(inspectGatewayTlsCertificate).toHaveBeenCalledTimes(1);
     const localProbeCall = requireProbeCall("wss://127.0.0.1:18789");
     expect(localProbeCall.originScopedDeviceAuth).toBeUndefined();
     expect(localProbeCall.tlsFingerprint).toBe("sha256:local-fingerprint");
@@ -1034,10 +1033,9 @@ describe("gateway-status command", () => {
   it("warns when local TLS is enabled but the certificate fingerprint cannot be loaded", async () => {
     const { runtime, runtimeLogs } = createRuntimeCapture();
     probeGateway.mockClear();
-    loadGatewayTlsRuntime.mockResolvedValueOnce({
-      enabled: false,
-      required: true,
-      error: "gateway tls: cert/key missing",
+    inspectGatewayTlsCertificate.mockResolvedValueOnce({
+      ok: false,
+      error: "gateway tls: failed to load cert (missing certificate)",
     });
     readBestEffortConfig.mockResolvedValueOnce({
       gateway: {
@@ -1059,7 +1057,7 @@ describe("gateway-status command", () => {
       (warning) => warning.code === "local_tls_runtime_unavailable",
     );
     expect(tlsWarning?.targetIds).toEqual(["localLoopback"]);
-    expect(tlsWarning?.message).toContain("gateway tls: cert/key missing");
+    expect(tlsWarning?.message).toContain("gateway tls: failed to load cert");
   });
 
   it("passes the full caller timeout through to local loopback probes", async () => {

--- a/src/commands/gateway-status.ts
+++ b/src/commands/gateway-status.ts
@@ -100,10 +100,10 @@ export async function gatewayStatusCommand(
     }
   }
 
-  const localTlsRuntime =
+  const localCertificate =
     cfg.gateway?.tls?.enabled === true
-      ? await loadGatewayTlsModule().then(({ loadGatewayTlsRuntime }) =>
-          loadGatewayTlsRuntime(cfg.gateway?.tls),
+      ? await loadGatewayTlsModule().then(({ inspectGatewayTlsCertificate }) =>
+          inspectGatewayTlsCertificate(cfg.gateway?.tls),
         )
       : undefined;
 
@@ -125,8 +125,8 @@ export async function gatewayStatusCommand(
         sshTarget,
         sshIdentity,
         loadSshTunnelModule,
-        localTlsFingerprint: localTlsRuntime?.enabled
-          ? localTlsRuntime.fingerprintSha256
+        localTlsFingerprint: localCertificate?.ok
+          ? localCertificate.value.fingerprintSha256
           : undefined,
       }),
   );
@@ -137,10 +137,7 @@ export async function gatewayStatusCommand(
     sshTunnelStarted: probePass.sshTunnelStarted,
     sshTunnelError: probePass.sshTunnelError,
     discoveryCount: probePass.discovery.length,
-    localTlsLoadError:
-      localTlsRuntime && !localTlsRuntime.enabled && localTlsRuntime.required
-        ? (localTlsRuntime.error ?? "gateway tls is enabled but local TLS runtime could not load")
-        : null,
+    localTlsLoadError: localCertificate && !localCertificate.ok ? localCertificate.error : null,
   });
   const primary = pickPrimaryProbedTarget(probePass.probed);
 

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -23,7 +23,7 @@ const TLS_FINGERPRINT = "ab".repeat(32);
 
 const gatewayConfigMocks = vi.hoisted(() => ({
   getRuntimeConfig: vi.fn(),
-  loadGatewayTlsRuntime: vi.fn(),
+  inspectGatewayTlsCertificate: vi.fn(),
   resolveConfigPath: vi.fn(
     (env: NodeJS.ProcessEnv, stateDir: string) =>
       env.OPENCLAW_CONFIG_PATH ?? `${stateDir}/openclaw.json`,
@@ -158,7 +158,7 @@ vi.mock("../infra/tls/gateway.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../infra/tls/gateway.js")>();
   return {
     ...actual,
-    loadGatewayTlsRuntime: gatewayConfigMocks.loadGatewayTlsRuntime,
+    inspectGatewayTlsCertificate: gatewayConfigMocks.inspectGatewayTlsCertificate,
   };
 });
 
@@ -312,9 +312,9 @@ function resetGatewayCallMocks() {
   resolveGatewayPort.mockReset().mockReturnValue(18789);
   gatewayConfigMocks.resolveConfigPath.mockClear();
   gatewayConfigMocks.resolveStateDir.mockClear();
-  gatewayConfigMocks.loadGatewayTlsRuntime
+  gatewayConfigMocks.inspectGatewayTlsCertificate
     .mockReset()
-    .mockResolvedValue({ enabled: false, required: false });
+    .mockResolvedValue({ ok: false, error: "gateway tls is disabled" });
   gatewayConfigMocks.useActualDispatchConfig = false;
   pickPrimaryTailnetIPv4.mockClear();
   pickPrimaryLanIPv4.mockClear();
@@ -1504,10 +1504,9 @@ describe("buildGatewayConnectionDetails", () => {
       },
     } satisfies OpenClawConfig;
     resolveGatewayPort.mockReturnValue(18800);
-    gatewayConfigMocks.loadGatewayTlsRuntime.mockResolvedValue({
-      enabled: true,
-      fingerprintSha256: TLS_FINGERPRINT,
-      required: true,
+    gatewayConfigMocks.inspectGatewayTlsCertificate.mockResolvedValue({
+      ok: true,
+      value: { cert: "public-certificate", fingerprintSha256: TLS_FINGERPRINT },
     });
 
     const details = await buildGatewayProbeConnectionDetails({ config });

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -45,7 +45,6 @@ import {
 } from "../infra/device-identity.js";
 import { isVitestRuntimeEnv } from "../infra/env.js";
 import { extractErrorCodeOrErrno } from "../infra/error-graph-internal.js";
-import { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
 import type { DeviceAuthEntry } from "../shared/device-auth.js";
 import { roleScopesAllow } from "../shared/operator-scope-compat.js";
 import { resolveSafeTimeoutDelayMs } from "../utils/timer-delay.js";
@@ -96,7 +95,6 @@ import {
   resolveLeastPrivilegeOperatorScopesForMethod,
   type OperatorScope,
 } from "./method-scopes.js";
-import { resolveGatewayConnectionTlsFingerprint } from "./tls-fingerprint.js";
 import {
   GatewayTransportError,
   type GatewayTransportErrorKind,
@@ -1150,11 +1148,6 @@ async function callGatewayWithScopes<T = Record<string, unknown>>(
             "Fix: pass --token or --password with --url (or gatewayToken in tools).",
         }),
     buildConnectionDetails: buildGatewayConnectionDetails,
-    resolveTlsFingerprint: async (params) =>
-      await resolveGatewayConnectionTlsFingerprint({
-        ...params,
-        loadGatewayTlsRuntime,
-      }),
   });
   ensureRemoteModeUrlConfigured({
     context,
@@ -1299,11 +1292,6 @@ export async function buildGatewayProbeConnectionDetails(
     explicitTlsFingerprint: opts.tlsFingerprint,
     skipImplicitAuth: true,
     buildConnectionDetails: buildGatewayConnectionDetails,
-    resolveTlsFingerprint: async (params) =>
-      await resolveGatewayConnectionTlsFingerprint({
-        ...params,
-        loadGatewayTlsRuntime,
-      }),
   });
   ensureRemoteModeUrlConfigured({
     context,

--- a/src/gateway/client-bootstrap.test.ts
+++ b/src/gateway/client-bootstrap.test.ts
@@ -1,7 +1,7 @@
 // Gateway client bootstrap tests keep URL override provenance wired into shared
 // auth resolution so CLI and env callers authenticate against the intended target.
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
+import type { inspectGatewayTlsCertificate } from "../infra/tls/gateway.js";
 import type { buildGatewayConnectionDetailsWithResolvers } from "./connection-details.js";
 import type { resolveGatewayCredentialsWithSecretInputs } from "./credentials-secret-inputs.js";
 
@@ -9,13 +9,13 @@ type AuthResolutionParams = Parameters<typeof resolveGatewayCredentialsWithSecre
 
 const mockState = vi.hoisted(() => ({
   buildGatewayConnectionDetails: vi.fn<typeof buildGatewayConnectionDetailsWithResolvers>(),
-  loadGatewayTlsRuntime: vi.fn<typeof loadGatewayTlsRuntime>(),
+  inspectGatewayTlsCertificate: vi.fn<typeof inspectGatewayTlsCertificate>(),
   resolveGatewayCredentialsWithSecretInputs:
     vi.fn<typeof resolveGatewayCredentialsWithSecretInputs>(),
 }));
 
 vi.mock("../infra/tls/gateway.js", () => ({
-  loadGatewayTlsRuntime: mockState.loadGatewayTlsRuntime,
+  inspectGatewayTlsCertificate: mockState.inspectGatewayTlsCertificate,
 }));
 
 vi.mock("./connection-details.js", () => ({
@@ -47,10 +47,10 @@ function expectLastAuthResolutionParams(expected: {
 describe("resolveGatewayClientBootstrap", () => {
   beforeEach(() => {
     mockState.buildGatewayConnectionDetails.mockReset();
-    mockState.loadGatewayTlsRuntime.mockReset();
-    mockState.loadGatewayTlsRuntime.mockResolvedValue({
-      enabled: false,
-      required: false,
+    mockState.inspectGatewayTlsCertificate.mockReset();
+    mockState.inspectGatewayTlsCertificate.mockResolvedValue({
+      ok: false,
+      error: "gateway tls is disabled",
     });
     mockState.resolveGatewayCredentialsWithSecretInputs.mockReset();
     mockState.resolveGatewayCredentialsWithSecretInputs.mockResolvedValue({
@@ -119,10 +119,9 @@ describe("resolveGatewayClientBootstrap", () => {
       urlSource: "local loopback",
       message: "Gateway target: wss://127.0.0.1:18789",
     });
-    mockState.loadGatewayTlsRuntime.mockResolvedValue({
-      enabled: true,
-      required: true,
-      fingerprintSha256: LOCAL_TLS_FINGERPRINT,
+    mockState.inspectGatewayTlsCertificate.mockResolvedValue({
+      ok: true,
+      value: { cert: "public-certificate", fingerprintSha256: LOCAL_TLS_FINGERPRINT },
     });
 
     const result = await resolveGatewayClientBootstrap({
@@ -131,7 +130,7 @@ describe("resolveGatewayClientBootstrap", () => {
     });
 
     expect(result.tlsFingerprint).toBe(LOCAL_TLS_FINGERPRINT);
-    expect(mockState.loadGatewayTlsRuntime).toHaveBeenCalledWith(tlsConfig);
+    expect(mockState.inspectGatewayTlsCertificate).toHaveBeenCalledWith(tlsConfig);
   });
 
   it("reuses local auth without pinning an exact public-origin target to the local certificate", async () => {
@@ -148,10 +147,9 @@ describe("resolveGatewayClientBootstrap", () => {
         urlSource: "local loopback",
         message: "Gateway target: wss://127.0.0.1:18789",
       });
-    mockState.loadGatewayTlsRuntime.mockResolvedValue({
-      enabled: true,
-      required: true,
-      fingerprintSha256: LOCAL_TLS_FINGERPRINT,
+    mockState.inspectGatewayTlsCertificate.mockResolvedValue({
+      ok: true,
+      value: { cert: "public-certificate", fingerprintSha256: LOCAL_TLS_FINGERPRINT },
     });
 
     const result = await resolveGatewayClientBootstrap({
@@ -172,7 +170,7 @@ describe("resolveGatewayClientBootstrap", () => {
 
     expect(result.auth.token).toBe("configured-token");
     expect(result.tlsFingerprint).toBeUndefined();
-    expect(mockState.loadGatewayTlsRuntime).not.toHaveBeenCalled();
+    expect(mockState.inspectGatewayTlsCertificate).not.toHaveBeenCalled();
   });
 
   it("retains the local certificate pin for an exact direct-local target", async () => {
@@ -189,10 +187,9 @@ describe("resolveGatewayClientBootstrap", () => {
         urlSource: "local loopback",
         message: "Gateway target: wss://127.0.0.1:18789",
       });
-    mockState.loadGatewayTlsRuntime.mockResolvedValue({
-      enabled: true,
-      required: true,
-      fingerprintSha256: LOCAL_TLS_FINGERPRINT,
+    mockState.inspectGatewayTlsCertificate.mockResolvedValue({
+      ok: true,
+      value: { cert: "public-certificate", fingerprintSha256: LOCAL_TLS_FINGERPRINT },
     });
 
     const result = await resolveGatewayClientBootstrap({
@@ -213,7 +210,7 @@ describe("resolveGatewayClientBootstrap", () => {
 
     expect(result.auth.token).toBe("explicit-token");
     expect(result.tlsFingerprint).toBe(LOCAL_TLS_FINGERPRINT);
-    expect(mockState.loadGatewayTlsRuntime).toHaveBeenCalledWith(tlsConfig);
+    expect(mockState.inspectGatewayTlsCertificate).toHaveBeenCalledWith(tlsConfig);
   });
 
   it("prefers direct-local TLS ownership when publicOrigin resolves to the same URL", async () => {
@@ -230,10 +227,9 @@ describe("resolveGatewayClientBootstrap", () => {
         urlSource: "local loopback",
         message: "Gateway target: wss://127.0.0.1:18789",
       });
-    mockState.loadGatewayTlsRuntime.mockResolvedValue({
-      enabled: true,
-      required: true,
-      fingerprintSha256: LOCAL_TLS_FINGERPRINT,
+    mockState.inspectGatewayTlsCertificate.mockResolvedValue({
+      ok: true,
+      value: { cert: "public-certificate", fingerprintSha256: LOCAL_TLS_FINGERPRINT },
     });
 
     const result = await resolveGatewayClientBootstrap({
@@ -254,7 +250,7 @@ describe("resolveGatewayClientBootstrap", () => {
 
     expect(result.auth.token).toBe("configured-token");
     expect(result.tlsFingerprint).toBe(LOCAL_TLS_FINGERPRINT);
-    expect(mockState.loadGatewayTlsRuntime).toHaveBeenCalledWith(tlsConfig);
+    expect(mockState.inspectGatewayTlsCertificate).toHaveBeenCalledWith(tlsConfig);
   });
 
   it.each([
@@ -287,7 +283,7 @@ describe("resolveGatewayClientBootstrap", () => {
     });
 
     expect(result.tlsFingerprint).toBe(REMOTE_TLS_FINGERPRINT);
-    expect(mockState.loadGatewayTlsRuntime).not.toHaveBeenCalled();
+    expect(mockState.inspectGatewayTlsCertificate).not.toHaveBeenCalled();
   });
 
   it("does not inherit the configured remote pin for CLI URL overrides", async () => {
@@ -313,7 +309,7 @@ describe("resolveGatewayClientBootstrap", () => {
     });
 
     expect(result.tlsFingerprint).toBeUndefined();
-    expect(mockState.loadGatewayTlsRuntime).not.toHaveBeenCalled();
+    expect(mockState.inspectGatewayTlsCertificate).not.toHaveBeenCalled();
   });
 
   it("preserves the configured remote pin so plaintext targets fail closed", async () => {
@@ -338,7 +334,7 @@ describe("resolveGatewayClientBootstrap", () => {
     });
 
     expect(result.tlsFingerprint).toBe(REMOTE_TLS_FINGERPRINT);
-    expect(mockState.loadGatewayTlsRuntime).not.toHaveBeenCalled();
+    expect(mockState.inspectGatewayTlsCertificate).not.toHaveBeenCalled();
   });
 
   it("uses the local pin when remote mode falls back to the configured local gateway", async () => {
@@ -348,10 +344,9 @@ describe("resolveGatewayClientBootstrap", () => {
       urlSource: "missing gateway.remote.url (fallback local)",
       message: "Gateway target: wss://127.0.0.1:18789",
     });
-    mockState.loadGatewayTlsRuntime.mockResolvedValue({
-      enabled: true,
-      required: true,
-      fingerprintSha256: LOCAL_TLS_FINGERPRINT,
+    mockState.inspectGatewayTlsCertificate.mockResolvedValue({
+      ok: true,
+      value: { cert: "public-certificate", fingerprintSha256: LOCAL_TLS_FINGERPRINT },
     });
 
     const result = await resolveGatewayClientBootstrap({
@@ -366,7 +361,7 @@ describe("resolveGatewayClientBootstrap", () => {
     });
 
     expect(result.tlsFingerprint).toBe(LOCAL_TLS_FINGERPRINT);
-    expect(mockState.loadGatewayTlsRuntime).toHaveBeenCalledWith(tlsConfig);
+    expect(mockState.inspectGatewayTlsCertificate).toHaveBeenCalledWith(tlsConfig);
   });
 
   it("rejects an invalid explicit TLS fingerprint", async () => {

--- a/src/gateway/client-bootstrap.ts
+++ b/src/gateway/client-bootstrap.ts
@@ -3,7 +3,6 @@
 import { gatewayOriginScope } from "../../packages/gateway-client/src/gateway-origin-scope.js";
 import { resolveGatewayPublicOrigin } from "../config/gateway-public-origin.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
 import {
   resolveGatewayInteractiveSurfaceAuth,
   resolveGatewayProbeSurfaceAuth,
@@ -196,12 +195,6 @@ export async function resolveGatewayClientBootstrap(params: {
     ignoreEnvUrlOverride?: boolean;
     localPortOverride?: number;
   }) => GatewayConnectionDetails;
-  resolveTlsFingerprint?: (params: {
-    config: OpenClawConfig;
-    url: string;
-    urlSource: string;
-    explicitTlsFingerprint?: string;
-  }) => Promise<string | undefined>;
 }): Promise<{
   url: string;
   urlSource: string;
@@ -250,20 +243,12 @@ export async function resolveGatewayClientBootstrap(params: {
         })
       : undefined;
   const tlsUrlSource = configuredTarget?.tlsSource ?? connection.urlSource;
-  const tlsFingerprint = params.resolveTlsFingerprint
-    ? await params.resolveTlsFingerprint({
-        config: params.config,
-        url: connection.url,
-        urlSource: tlsUrlSource,
-        explicitTlsFingerprint: params.explicitTlsFingerprint,
-      })
-    : await resolveGatewayConnectionTlsFingerprint({
-        config: params.config,
-        url: connection.url,
-        urlSource: tlsUrlSource,
-        explicitTlsFingerprint: params.explicitTlsFingerprint,
-        loadGatewayTlsRuntime,
-      });
+  const tlsFingerprint = await resolveGatewayConnectionTlsFingerprint({
+    config: params.config,
+    url: connection.url,
+    urlSource: tlsUrlSource,
+    explicitTlsFingerprint: params.explicitTlsFingerprint,
+  });
   // Only direct CLI/env URL overrides should constrain token/password fallback. Config-derived
   // remote URLs are canonical config, not a caller override.
   const surface =

--- a/src/gateway/server-runtime-state-prepare.ts
+++ b/src/gateway/server-runtime-state-prepare.ts
@@ -6,7 +6,7 @@ import { createDefaultDeps } from "../cli/deps.js";
 import { getRuntimeConfig } from "../config/io.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isTruthyEnvValue } from "../infra/env.js";
-import { loadGatewayTlsRuntime } from "../infra/tls/gateway.js";
+import { loadGatewayTlsServerRuntime } from "../infra/tls/gateway.js";
 import type { createSubsystemLogger } from "../logging/subsystem.js";
 import { runtimeForLogger } from "../logging/subsystem.js";
 import { isGatewayDraining } from "../process/command-queue.js";
@@ -405,7 +405,7 @@ export async function prepareGatewayKernelState(params: {
   const runtimeStateRef: { current: GatewayServerLiveState | null } = { current: null };
   const cronStartState = { handled: false };
   const gatewayTls = await startupTrace.measure("tls.runtime", () =>
-    loadGatewayTlsRuntime(cfgAtStart.gateway?.tls, log.child("tls")),
+    loadGatewayTlsServerRuntime(cfgAtStart.gateway?.tls, log.child("tls")),
   );
   const serverStartedAt = Date.now();
   const readinessEventLoopHealth = createGatewayEventLoopHealthMonitor();

--- a/src/gateway/tls-fingerprint.test.ts
+++ b/src/gateway/tls-fingerprint.test.ts
@@ -1,0 +1,96 @@
+import { createHash, X509Certificate } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TEST_TLS_CERT_PEM } from "../../test/helpers/tls-fixture.js";
+import type { GatewayTlsConfig } from "../config/types.gateway.js";
+import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
+import { CONFIG_DIR, pinConfigDir } from "../utils.js";
+import { resolveGatewayConnectionTlsFingerprint } from "./tls-fingerprint.js";
+
+const tempDirs = createTrackedTempDirs();
+const originalConfigDir = CONFIG_DIR;
+const fingerprint = createHash("sha256")
+  .update(new X509Certificate(TEST_TLS_CERT_PEM).raw)
+  .digest("hex");
+
+afterEach(async () => {
+  vi.restoreAllMocks();
+  pinConfigDir({ OPENCLAW_STATE_DIR: originalConfigDir });
+  await tempDirs.cleanup();
+});
+
+function resolveLocalPin(tls: GatewayTlsConfig) {
+  return resolveGatewayConnectionTlsFingerprint({
+    config: { gateway: { mode: "local", tls } },
+    url: "wss://127.0.0.1:32123",
+    urlSource: "local loopback",
+  });
+}
+
+describe("Gateway client certificate inspection", () => {
+  it.each(["default", "custom"])("does not provision missing %s TLS files", async (location) => {
+    const root = await tempDirs.make("openclaw-tls-owner-client-");
+    pinConfigDir({ OPENCLAW_STATE_DIR: root });
+    const tlsDir = path.join(root, location === "default" ? "gateway/tls" : "custom/tls");
+    const tls =
+      location === "default"
+        ? { enabled: true }
+        : {
+            enabled: true,
+            certPath: path.join(tlsDir, "cert.pem"),
+            keyPath: path.join(tlsDir, "key.pem"),
+          };
+
+    await resolveLocalPin(tls);
+
+    await expect(fs.access(tlsDir)).rejects.toMatchObject({ code: "ENOENT" });
+    await expect(resolveLocalPin(tls)).resolves.toBeUndefined();
+  });
+
+  it.each([undefined, "", " \t", "custom"])(
+    "pins existing public certificate (%j) without a key or CA",
+    async (location) => {
+      const root = await tempDirs.make("openclaw-tls-owner-client-");
+      pinConfigDir({ OPENCLAW_STATE_DIR: root });
+      const certPath = path.join(
+        root,
+        location === "custom" ? "custom.pem" : "gateway/tls/gateway-cert.pem",
+      );
+      await fs.mkdir(path.dirname(certPath), { recursive: true });
+      await fs.writeFile(certPath, TEST_TLS_CERT_PEM, { mode: 0o644 });
+      const before = await fs.stat(certPath);
+      const read = vi.spyOn(fs, "readFile");
+
+      await expect(
+        resolveLocalPin({
+          enabled: true,
+          certPath: location === "custom" ? `  ${certPath}  ` : location,
+          keyPath: path.join(root, "missing-key.pem"),
+          caPath: path.join(root, "missing-ca.pem"),
+        }),
+      ).resolves.toBe(fingerprint);
+
+      expect(read.mock.calls.map(([file]) => file)).toEqual([certPath]);
+      const after = await fs.stat(certPath);
+      expect([after.mode, after.mtimeMs]).toEqual([before.mode, before.mtimeMs]);
+    },
+  );
+
+  it("leaves malformed certificates unchanged and returns no implicit pin", async () => {
+    const root = await tempDirs.make("openclaw-tls-owner-client-");
+    const certPath = path.join(root, "bad.pem");
+    await fs.writeFile(certPath, "not a certificate");
+    await expect(
+      resolveLocalPin({ enabled: true, certPath, keyPath: path.join(root, "key.pem") }),
+    ).resolves.toBeUndefined();
+    await expect(fs.readFile(certPath, "utf8")).resolves.toBe("not a certificate");
+    await expect(fs.readdir(root)).resolves.toEqual(["bad.pem"]);
+  });
+
+  it("does not read certificates when local TLS is disabled", async () => {
+    const read = vi.spyOn(fs, "readFile");
+    await expect(resolveLocalPin({ enabled: false })).resolves.toBeUndefined();
+    expect(read).not.toHaveBeenCalled();
+  });
+});

--- a/src/gateway/tls-fingerprint.ts
+++ b/src/gateway/tls-fingerprint.ts
@@ -1,10 +1,7 @@
 import { isWssUrl } from "@openclaw/net-policy/url-protocol";
 import { requireTlsFingerprint } from "../../packages/gateway-client/src/client-address-utils.js";
-import type { GatewayTlsConfig } from "../config/types.gateway.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { GatewayTlsRuntime } from "../infra/tls/gateway.js";
-
-type GatewayTlsRuntimeLoader = (config: GatewayTlsConfig | undefined) => Promise<GatewayTlsRuntime>;
+import { inspectGatewayTlsCertificate } from "../infra/tls/gateway.js";
 
 /** Resolve the certificate pin for one already-selected Gateway target. */
 export async function resolveGatewayConnectionTlsFingerprint(params: {
@@ -12,7 +9,6 @@ export async function resolveGatewayConnectionTlsFingerprint(params: {
   url: string;
   urlSource: string;
   explicitTlsFingerprint?: string;
-  loadGatewayTlsRuntime: GatewayTlsRuntimeLoader;
 }): Promise<string | undefined> {
   const explicitTlsFingerprint = params.explicitTlsFingerprint
     ? requireTlsFingerprint(params.explicitTlsFingerprint)
@@ -44,6 +40,6 @@ export async function resolveGatewayConnectionTlsFingerprint(params: {
   if (!usesConfiguredLocalGateway || params.config.gateway?.tls?.enabled !== true) {
     return undefined;
   }
-  const tlsRuntime = await params.loadGatewayTlsRuntime(params.config.gateway.tls);
-  return tlsRuntime.enabled ? tlsRuntime.fingerprintSha256 : undefined;
+  const certificate = await inspectGatewayTlsCertificate(params.config.gateway.tls);
+  return certificate.ok ? certificate.value.fingerprintSha256 : undefined;
 }

--- a/src/infra/tls/gateway.test.ts
+++ b/src/infra/tls/gateway.test.ts
@@ -45,7 +45,7 @@ vi.mock("../../process/exec.js", async (importOriginal) => ({
 
 vi.mock("../resolve-system-bin.js", () => ({ resolveSystemBin: resolveSystemBinMock }));
 
-import { loadGatewayTlsRuntime } from "./gateway.js";
+import { loadGatewayTlsServerRuntime } from "./gateway.js";
 
 const tempDirs = createTrackedTempDirs();
 const createTempDir = () => tempDirs.make("openclaw-gateway-tls-test-");
@@ -73,13 +73,13 @@ afterEach(async () => {
   await tempDirs.cleanup();
 });
 
-describe("loadGatewayTlsRuntime", () => {
+describe("loadGatewayTlsServerRuntime", () => {
   it("disables tls when config is absent or disabled", async () => {
-    await expect(loadGatewayTlsRuntime(undefined)).resolves.toEqual({
+    await expect(loadGatewayTlsServerRuntime(undefined)).resolves.toEqual({
       enabled: false,
       required: false,
     });
-    await expect(loadGatewayTlsRuntime({ enabled: false })).resolves.toEqual({
+    await expect(loadGatewayTlsServerRuntime({ enabled: false })).resolves.toEqual({
       enabled: false,
       required: false,
     });
@@ -94,7 +94,7 @@ describe("loadGatewayTlsRuntime", () => {
     await fs.writeFile(keyPath, KEY_PEM, "utf8");
     await fs.writeFile(caPath, CERT_PEM, "utf8");
 
-    const result = await loadGatewayTlsRuntime({
+    const result = await loadGatewayTlsServerRuntime({
       enabled: true,
       certPath,
       keyPath,
@@ -122,7 +122,7 @@ describe("loadGatewayTlsRuntime", () => {
     const certPath = path.join(dir, "missing-cert.pem");
     const keyPath = path.join(dir, "missing-key.pem");
 
-    const result = await loadGatewayTlsRuntime({
+    const result = await loadGatewayTlsServerRuntime({
       enabled: true,
       certPath,
       keyPath,
@@ -137,6 +137,28 @@ describe("loadGatewayTlsRuntime", () => {
   });
 
   it.each(["key", "cert"] as const)(
+    "does not replace an existing %s or generate its missing counterpart",
+    async (existing) => {
+      const dir = await createTempDir();
+      const certPath = path.join(dir, "gateway-cert.pem");
+      const keyPath = path.join(dir, "gateway-key.pem");
+      const existingPath = existing === "cert" ? certPath : keyPath;
+      await fs.writeFile(existingPath, "existing material");
+
+      const result = await loadGatewayTlsServerRuntime({ enabled: true, certPath, keyPath });
+
+      expect(result).toMatchObject({
+        enabled: false,
+        required: true,
+        error: "gateway tls: cert/key missing",
+      });
+      expect(runExecMock).not.toHaveBeenCalled();
+      await expect(fs.readFile(existingPath, "utf8")).resolves.toBe("existing material");
+      await expect(fs.readdir(dir)).resolves.toEqual([path.basename(existingPath)]);
+    },
+  );
+
+  it.each(["key", "cert"] as const)(
     "bounds generation and cleans a partial staged %s",
     async (partialOutput) => {
       const dir = await createTempDir();
@@ -148,7 +170,7 @@ describe("loadGatewayTlsRuntime", () => {
         throw new Error("openssl timed out");
       });
 
-      const result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+      const result = await loadGatewayTlsServerRuntime({ enabled: true, certPath, keyPath });
 
       expect(runExecMock).toHaveBeenCalledOnce();
       const [command, args, options] = runExecMock.mock.calls[0] as [
@@ -176,7 +198,7 @@ describe("loadGatewayTlsRuntime", () => {
       await writeGeneratedTlsPair(args);
     });
 
-    const result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+    const result = await loadGatewayTlsServerRuntime({ enabled: true, certPath, keyPath });
 
     expect(result.enabled).toBe(true);
     await expect(fs.readFile(certPath, "utf8")).resolves.toBe(CERT_PEM);
@@ -219,7 +241,7 @@ describe("loadGatewayTlsRuntime", () => {
 
     try {
       await expect(
-        loadGatewayTlsRuntime({ enabled: true, certPath, keyPath }),
+        loadGatewayTlsServerRuntime({ enabled: true, certPath, keyPath }),
       ).resolves.toMatchObject({ enabled: true });
     } finally {
       openSpy.mockRestore();
@@ -241,7 +263,7 @@ describe("loadGatewayTlsRuntime", () => {
       await writeGeneratedTlsPair(args);
     });
 
-    const result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+    const result = await loadGatewayTlsServerRuntime({ enabled: true, certPath, keyPath });
 
     expect(result.enabled).toBe(true);
     await expect(fs.readFile(certPath, "utf8")).resolves.toBe(CERT_PEM);
@@ -266,7 +288,7 @@ describe("loadGatewayTlsRuntime", () => {
       await originalLink(source, target);
     });
 
-    const result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath });
+    const result = await loadGatewayTlsServerRuntime({ enabled: true, certPath, keyPath });
 
     expect(result.enabled).toBe(false);
     expect(result.error).toContain("key destination appeared");
@@ -305,7 +327,7 @@ describe("loadGatewayTlsRuntime", () => {
       });
 
       await expect(
-        loadGatewayTlsRuntime({ enabled: true, certPath, keyPath }),
+        loadGatewayTlsServerRuntime({ enabled: true, certPath, keyPath }),
       ).resolves.toMatchObject({
         enabled: true,
       });
@@ -328,9 +350,9 @@ describe("loadGatewayTlsRuntime", () => {
       .spyOn(fs, "link")
       .mockRejectedValue(Object.assign(new Error("hard links unsupported"), { code: "ENOTSUP" }));
 
-    let result: Awaited<ReturnType<typeof loadGatewayTlsRuntime>> | undefined;
+    let result: Awaited<ReturnType<typeof loadGatewayTlsServerRuntime>> | undefined;
     try {
-      result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath }, { warn });
+      result = await loadGatewayTlsServerRuntime({ enabled: true, certPath, keyPath }, { warn });
     } finally {
       linkSpy.mockRestore();
     }
@@ -366,7 +388,10 @@ describe("loadGatewayTlsRuntime", () => {
     });
     durabilityTestState.syncOutcome = { status: "unsupported", code: "EISDIR" };
 
-    const result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath }, { warn });
+    const result = await loadGatewayTlsServerRuntime(
+      { enabled: true, certPath, keyPath },
+      { warn },
+    );
 
     expect(result.enabled).toBe(true);
     expect(warn).toHaveBeenCalledOnce();
@@ -392,7 +417,10 @@ describe("loadGatewayTlsRuntime", () => {
     );
     durabilityTestState.syncOutcome = { status: "unsupported", code: "EISDIR" };
 
-    const result = await loadGatewayTlsRuntime({ enabled: true, certPath, keyPath }, { warn });
+    const result = await loadGatewayTlsServerRuntime(
+      { enabled: true, certPath, keyPath },
+      { warn },
+    );
 
     expect(result.enabled).toBe(true);
     expect(warn).toHaveBeenCalledTimes(2);
@@ -419,7 +447,7 @@ describe("loadGatewayTlsRuntime", () => {
     await fs.writeFile(certPath, "not a certificate\n", "utf8");
     await fs.writeFile(keyPath, KEY_PEM, "utf8");
 
-    const result = await loadGatewayTlsRuntime({
+    const result = await loadGatewayTlsServerRuntime({
       enabled: true,
       certPath,
       keyPath,
@@ -434,7 +462,7 @@ describe("loadGatewayTlsRuntime", () => {
   });
 
   it("falls back to default paths when certPath and keyPath are empty strings", async () => {
-    const result = await loadGatewayTlsRuntime({
+    const result = await loadGatewayTlsServerRuntime({
       enabled: true,
       certPath: "",
       keyPath: "",
@@ -449,7 +477,7 @@ describe("loadGatewayTlsRuntime", () => {
   });
 
   it("falls back to default paths when certPath and keyPath are whitespace-only", async () => {
-    const result = await loadGatewayTlsRuntime({
+    const result = await loadGatewayTlsServerRuntime({
       enabled: true,
       certPath: "   ",
       keyPath: "\t",
@@ -463,7 +491,7 @@ describe("loadGatewayTlsRuntime", () => {
   });
 
   it("does not fall back for non-empty paths with leading/trailing spaces", async () => {
-    const result = await loadGatewayTlsRuntime({
+    const result = await loadGatewayTlsServerRuntime({
       enabled: true,
       certPath: "  /etc/ssl/cert.pem  ",
       keyPath: "  /etc/ssl/private/server.key  ",

--- a/src/infra/tls/gateway.ts
+++ b/src/infra/tls/gateway.ts
@@ -1,10 +1,10 @@
-// Gateway TLS runtime loads configured certificates or generates a local
-// self-signed pair, returning server-ready options plus client fingerprint.
+// Public certificate inspection is read-only; server startup alone provisions TLS material.
 import { X509Certificate } from "node:crypto";
 import type { Stats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import tls from "node:tls";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import { normalizeTlsFingerprint } from "../../../packages/gateway-client/src/client-address-utils.js";
 import type { GatewayTlsConfig } from "../../config/types.gateway.js";
 import { runExec } from "../../process/exec.js";
@@ -189,8 +189,35 @@ async function generateSelfSignedCert(params: {
   }
 }
 
-/** Load or generate gateway TLS material and return server-ready TLS options. */
-export async function loadGatewayTlsRuntime(
+function resolveGatewayTlsCertPath(certPath: string | undefined): string {
+  // Blank paths use the default; resolveUserPath owns trimming and home expansion.
+  return resolveUserPath(
+    typeof certPath === "string" && certPath.trim()
+      ? certPath
+      : path.join(CONFIG_DIR, "gateway", "tls", "gateway-cert.pem"),
+  );
+}
+
+/** Read only public certificate bytes. Inspection never provisions or requires server secrets. */
+export async function inspectGatewayTlsCertificate(
+  cfg: Pick<GatewayTlsConfig, "enabled" | "certPath"> | undefined,
+): Promise<Result<{ cert: string; fingerprintSha256: string }, string>> {
+  if (cfg?.enabled !== true) {
+    return err("gateway tls is disabled");
+  }
+  try {
+    const cert = await fs.readFile(resolveGatewayTlsCertPath(cfg.certPath), "utf8");
+    const fingerprintSha256 = normalizeTlsFingerprint(new X509Certificate(cert).fingerprint256);
+    return fingerprintSha256
+      ? ok({ cert, fingerprintSha256 })
+      : err("gateway tls: unable to compute certificate fingerprint");
+  } catch (error) {
+    return err(`gateway tls: failed to load cert (${String(error)})`);
+  }
+}
+
+/** Server startup only: load or provision TLS material and return listener options. */
+export async function loadGatewayTlsServerRuntime(
   cfg: GatewayTlsConfig | undefined,
   log?: GatewayTlsLog,
 ): Promise<GatewayTlsRuntime> {
@@ -204,11 +231,7 @@ export async function loadGatewayTlsRuntime(
   // passed through verbatim so resolveUserPath owns all normalization (it trims
   // and expands ~); trimming here would duplicate it and silently rewrite paths
   // that contain leading/trailing spaces.
-  const certPath = resolveUserPath(
-    typeof cfg.certPath === "string" && cfg.certPath.trim()
-      ? cfg.certPath
-      : path.join(baseDir, "gateway-cert.pem"),
-  );
+  const certPath = resolveGatewayTlsCertPath(cfg.certPath);
   const keyPath = resolveUserPath(
     typeof cfg.keyPath === "string" && cfg.keyPath.trim()
       ? cfg.keyPath
@@ -222,13 +245,13 @@ export async function loadGatewayTlsRuntime(
   if (!hasCert && !hasKey && autoGenerate) {
     try {
       await generateSelfSignedCert({ certPath, keyPath, log });
-    } catch (err) {
+    } catch (error) {
       return {
         enabled: false,
         required: true,
         certPath,
         keyPath,
-        error: `gateway tls: failed to generate cert (${String(err)})`,
+        error: `gateway tls: failed to generate cert (${String(error)})`,
       };
     }
   }
@@ -275,14 +298,14 @@ export async function loadGatewayTlsRuntime(
         minVersion: "TLSv1.3",
       },
     };
-  } catch (err) {
+  } catch (error) {
     return {
       enabled: false,
       required: true,
       certPath,
       keyPath,
       caPath,
-      error: `gateway tls: failed to load cert (${String(err)})`,
+      error: `gateway tls: failed to load cert (${String(error)})`,
     };
   }
 }

--- a/test/e2e/qa-lab/runtime/gateway-tls-pinning.ts
+++ b/test/e2e/qa-lab/runtime/gateway-tls-pinning.ts
@@ -16,7 +16,7 @@ import { clearConfigCache, clearRuntimeConfigSnapshot } from "../../../../src/co
 import { startGatewayServer } from "../../../../src/gateway/server.js";
 import { GATEWAY_STARTUP_MUTATED_ENV_KEYS } from "../../../../src/gateway/test-helpers.env.js";
 import { formatErrorMessage } from "../../../../src/infra/errors.js";
-import { loadGatewayTlsRuntime } from "../../../../src/infra/tls/gateway.js";
+import { loadGatewayTlsServerRuntime } from "../../../../src/infra/tls/gateway.js";
 import { createDeferred } from "../../../helpers/promise.js";
 import { createQaScriptEvidenceWriter } from "./script-evidence.js";
 
@@ -314,7 +314,7 @@ export async function runGatewayTlsPinningProof(): Promise<GatewayTlsPinningProo
     delete process.env.VITEST;
     await writeDiscoveryProbePlugin(pluginDir, advertisementPath);
 
-    const preparedTls = await loadGatewayTlsRuntime({
+    const preparedTls = await loadGatewayTlsServerRuntime({
       enabled: true,
       autoGenerate: true,
       certPath,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where running `triage --json`, `gateway status`, or related client checks could create a Gateway's missing TLS certificate and private key even when the server was offline. Inspecting an existing public certificate also unnecessarily required access to the server key and CA files.

Closes #134222

This is the maintainer-requested follow-up to a real isolated, dist-backed triage reproduction.

## Why This Change Was Made

Separate read-only public-certificate inspection from server TLS provisioning at the existing TLS owner. All client readers use `inspectGatewayTlsCertificate`; only server preparation and explicit server test setup use `loadGatewayTlsServerRuntime`. Remove the old mixed-use loader name, scattered generation overrides, and redundant bootstrap/call resolver injection plumbing.

Server startup keeps its default auto-generation, partial-pair preservation, bounded generation, no-clobber publication, private modes, and durability handling. Explicit/remote/local target pin selection and peer fingerprint checks are preserved. Dashboard HTTPS uses the configured certificate as its trust anchor, including CA-signed leaves, without reading server secrets. No configuration keys, environment variables, dependencies, storage schemas, or public CLI options are added.

## User Impact

Diagnostics and pairing/readiness clients no longer manufacture server TLS identity as a side effect. Existing certificates can be inspected without the private key or server CA bundle. Starting the Gateway still provisions an absent pair; an existing partial pair remains untouched and fails startup as before. Missing or unreadable certificates do not create an insecure connection fallback.

Documentation: [Gateway TLS configuration](https://docs.openclaw.ai/gateway/configuration-reference).

## Evidence

### Real before/after behavior

All runs used synthetic isolated homes/state/config/temp directories, dedicated profiles, and nondefault loopback ports. No operator Gateway or state was accessed or modified.

| Flow | Before repair | After repair |
| --- | --- | --- |
| `pnpm --silent openclaw triage --json`, TLS enabled, absent pair, offline Gateway | Exited 0; created certificate and key | Exited 0; valid JSON; no TLS directory or pair created |
| `pnpm --silent openclaw gateway status --json`, same conditions in a separate fixture | Exited 0; created certificate and key | Exited 0; valid JSON; no TLS directory or pair created |
| Fresh isolated Gateway startup | Server generation behavior retained | Created both files with mode 0600, served `/readyz` HTTP 200 over TLS 1.3, matching certificate fingerprint |
| Running Gateway with its fixture key moved away from the configured path | Client inspection previously required the key | Real status connected (`rpc.ok=true`) and triage exited 0 without recreating the key or changing cert/config; key restored afterward |

Six client filesystem regression cases failed on pre-fix production behavior, and the dashboard public-cert-only regression failed too. Server owner tests passed before and after. A real HTTPS test accepts a configured CA-signed leaf without issuer/private-key files and rejects a replacement before an extra HTTP request. Installed Undici's equivalent contract was also verified on Node 24.20.0 and Bun 1.4.0.

### Local validation

- Focused suites: 323 passing executions across nine files.
- Sibling suites: 408 passing executions across eight files (dashboard overlaps the focused run).
- Final owner rerun after mechanical lint fixes: 41 passing tests across three files.
- Complete changed-file gate: passed, including core/core-test/root-test typechecks, core/script lint, formatting, dead exports, architecture, import cycles, and remaining selected guards.
- Full `pnpm build` on the original reviewed candidate: passed; no ineffective dynamic-import warning. The subsequent mechanical rebase preserved the TLS patch exactly; current-head CI and focused tests verify that integration.
- `git diff --check`: passed.
- Fresh independent Codex autoreview before publication: exit 0, scoped-clean at the default P0 threshold, no findings.

Exact focused commands:

```bash
node scripts/run-vitest.mjs src/gateway/tls-fingerprint.test.ts src/infra/tls/gateway.test.ts src/gateway/client-bootstrap.test.ts src/gateway/call.test.ts src/cli/daemon-cli/status.gather.test.ts src/commands/gateway-status.test.ts src/commands/control-ui-handoff.test.ts src/commands/dashboard/json.test.ts src/cli/gateway-cli/run.supervised-lock.test.ts
```

```bash
node scripts/run-vitest.mjs src/commands/control-ui-handoff.test.ts src/cli/run-main.exit.test.ts src/cli/qr-cli.test.ts src/pairing/setup-code.test.ts src/gateway/probe.test.ts src/gateway/operator-approvals-client.test.ts packages/gateway-client/src/client.tls.test.ts src/gateway/server-kernel.test.ts
```

```bash
node scripts/run-vitest.mjs src/commands/control-ui-handoff.test.ts src/gateway/tls-fingerprint.test.ts src/infra/tls/gateway.test.ts
```

The changed gate was run with all 22 changed paths supplied to `node scripts/check-changed.mjs -- ...`; hosted exact-head CI and native landing receipts will supplement this proof.

Earlier validation attempts exposed a build-runner timeout, an abandoned task-local artifact lock, and new test/type/lint mistakes. Those were resolved and final checks rerun successfully; no guard was weakened or bypassed. The lock was recovered only after verifying its owner and associated processes were gone. No UI rendering change or provider inference is involved.

Production LOC: **+79/-101 (net -22)**. Tests/support: **+358/-209 (net +149)**. Docs: **+3/-1 (net +2)**. No proof assets or agent transcripts are committed.

### Delivery verification

The branch was mechanically rebased to include main commit `ace8a13f19c`, which fixes the exact unrelated `server-kernel.test.ts` lint failure observed in the first integration run. `git range-diff` shows the TLS patch is identical. Fresh rebased-head autoreview passed with no findings at the default P0 threshold. Sixty focused tests passed across the TLS reader/server owner, Gateway kernel, supervised health, and dashboard suites. One dashboard project stalled before collection and was stopped; the unchanged isolated retry passed all 14 tests and exited 0.

[CI run 33412067230, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33412067230) completed successfully for head `ba233bb209baa0aa617e0ce64dfcaddcd078e3a6`. The exact-head native watcher exited 0 with GREEN. The earlier CI run failed on Git/download setup and the verified main-owned lint defect; the required base refresh resolved it. Labeler run 33408775100 passed on its second attempt after a GitHub network error.

Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 134223` passed without changing the prepared head. Hosted verification used the exact head through CI 33412067230 and [Workflow Sanity 33412068693](https://github.com/openclaw/openclaw/actions/runs/33412068693); Testbox variants were not applicable. The latest ClawSweeper comment is an in-progress notice only: no substantive review or Rank-up moves have been published, and there are no review threads to resolve. Fresh independent autoreview and native review/prepare gates are complete; the pending publisher is not treated as approval. Live effective rules require the CI gate and linear history, with no independent-approval rule. No known proof gap remains for the repair. Introduction provenance remains unknown.
