### PR TITLE
fix(ui): include job name in Cron row action aria-labels

### DIFF
--- a/ui/src/e2e/cron-remove.e2e.test.ts
+++ b/ui/src/e2e/cron-remove.e2e.test.ts
@@ -65,7 +65,7 @@ suite.define(() => {
         await row.waitFor({ state: "visible", timeout: 10_000 });
         expect(await page.locator(".cron-table__head").getAttribute("role")).toBeNull();
         expect(await row.getAttribute("role")).toBeNull();
-        const openTask = row.getByRole("button", { name: /Nightly digest/ });
+        const openTask = row.locator("button.cron-table__name");
         await openTask.focus();
         await page.keyboard.press("Enter");
         const detail = page.locator('.cron-page[data-panel-mode="job"]');

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -6803,12 +6803,16 @@ export const en: TranslationMap = {
     },
     actions: {
       runNow: "Run now",
+      runNowJob: "Run now: {name}",
       runIfDue: "Run if due",
       pause: "Pause",
+      pauseJob: "Pause: {name}",
       resume: "Resume",
+      resumeJob: "Resume: {name}",
       clone: "Clone",
       remove: "Remove",
       removeConfirmTitle: 'Remove "{name}"?',
+      moreJob: "More actions for {name}",
       removeConfirmMessage:
         "This permanently deletes the automation and stops all future runs. This action cannot be undone.",
       more: "More actions",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -6805,17 +6805,14 @@ export const en: TranslationMap = {
       runNow: "Run now",
       runNowJob: "Run now: {name}",
       runIfDue: "Run if due",
-      pause: "Pause",
       pauseJob: "Pause: {name}",
-      resume: "Resume",
       resumeJob: "Resume: {name}",
       clone: "Clone",
       remove: "Remove",
       removeConfirmTitle: 'Remove "{name}"?',
-      moreJob: "More actions for {name}",
       removeConfirmMessage:
         "This permanently deletes the automation and stops all future runs. This action cannot be undone.",
-      more: "More actions",
+      moreJob: "More actions for {name}",
     },
     runNotStarted: {
       notDue: "This automation is not due yet.",

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -199,6 +199,26 @@ describe("cron view list pane", () => {
     expect(onSelectJob).not.toHaveBeenCalled();
   });
 
+  it("distinguishes row action aria-labels by job name across multiple jobs", () => {
+    const jobA = createJob("job-a", { name: "Daily backup" });
+    const jobB = createJob("job-b", { name: "Weekly report" });
+    const container = renderView({ jobs: [jobA, jobB], canManage: true });
+
+    const runLabels = Array.from(container.querySelectorAll('[data-test-id^="cron-row-run-"]')).map(
+      (btn) => (btn as HTMLElement).getAttribute("aria-label"),
+    );
+    expect(runLabels[0]).toContain("Daily backup");
+    expect(runLabels[1]).toContain("Weekly report");
+    expect(runLabels[0]).not.toBe(runLabels[1]);
+
+    const moreLabels = Array.from(container.querySelectorAll(".cron-job-menu__trigger")).map(
+      (btn) => (btn as HTMLElement).getAttribute("aria-label"),
+    );
+    expect(moreLabels[0]).toContain("Daily backup");
+    expect(moreLabels[1]).toContain("Weekly report");
+    expect(moreLabels[0]).not.toBe(moreLabels[1]);
+  });
+
   it("opens the create panel from the New task button and suggestions", () => {
     const onOpenCreate = vi.fn();
     const container = renderView({ onOpenCreate });

--- a/ui/src/pages/cron/view.test.ts
+++ b/ui/src/pages/cron/view.test.ts
@@ -199,24 +199,25 @@ describe("cron view list pane", () => {
     expect(onSelectJob).not.toHaveBeenCalled();
   });
 
-  it("distinguishes row action aria-labels by job name across multiple jobs", () => {
-    const jobA = createJob("job-a", { name: "Daily backup" });
-    const jobB = createJob("job-b", { name: "Weekly report" });
-    const container = renderView({ jobs: [jobA, jobB], canManage: true });
+  it("gives row actions job-specific accessible names", () => {
+    const jobs = [
+      createJob("job-a", { name: "Daily backup", enabled: true }),
+      createJob("job-b", { name: "Weekly report", enabled: false }),
+    ];
+    const container = renderView({ jobs, canManage: true });
+    const labels = jobs.map((job) => {
+      const row = getElement(container, `[data-test-id="cron-row-${job.id}"]`, HTMLDivElement);
+      return [
+        getElement(row, ".cron-row-run", HTMLButtonElement).getAttribute("aria-label"),
+        getElement(row, ".cron-job-menu__trigger", HTMLButtonElement).getAttribute("aria-label"),
+        getElement(row, "wa-switch", HTMLElement).textContent?.trim(),
+      ];
+    });
 
-    const runLabels = Array.from(container.querySelectorAll('[data-test-id^="cron-row-run-"]')).map(
-      (btn) => (btn as HTMLElement).getAttribute("aria-label"),
-    );
-    expect(runLabels[0]).toContain("Daily backup");
-    expect(runLabels[1]).toContain("Weekly report");
-    expect(runLabels[0]).not.toBe(runLabels[1]);
-
-    const moreLabels = Array.from(container.querySelectorAll(".cron-job-menu__trigger")).map(
-      (btn) => (btn as HTMLElement).getAttribute("aria-label"),
-    );
-    expect(moreLabels[0]).toContain("Daily backup");
-    expect(moreLabels[1]).toContain("Weekly report");
-    expect(moreLabels[0]).not.toBe(moreLabels[1]);
+    expect(labels).toEqual([
+      ["Run now: Daily backup", "More actions for Daily backup", "Pause: Daily backup"],
+      ["Run now: Weekly report", "More actions for Weekly report", "Resume: Weekly report"],
+    ]);
   });
 
   it("opens the create panel from the New task button and suggestions", () => {

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -851,8 +851,8 @@ function renderJobRow(job: CronJob, props: CronProps) {
                 type="button"
                 class="btn btn--sm btn--ghost cron-row-run"
                 data-test-id=${`cron-row-run-${job.id}`}
-                title=${t("cron.actions.runNow")}
-                aria-label=${t("cron.actions.runNow")}
+                title=${t("cron.actions.runNowJob", { name: job.name })}
+                aria-label=${t("cron.actions.runNowJob", { name: job.name })}
                 ?disabled=${props.busy}
                 @click=${() => props.onRun(job, "force")}
               >
@@ -1024,8 +1024,8 @@ function renderJobMenu(props: CronProps, job: CronJob) {
         slot="trigger"
         type="button"
         class="btn btn--sm btn--ghost cron-job-menu__trigger"
-        aria-label=${t("cron.actions.more")}
-        title=${t("cron.actions.more")}
+        aria-label=${t("cron.actions.moreJob", { name: job.name })}
+        title=${t("cron.actions.moreJob", { name: job.name })}
       >
         ${icon("moreHorizontal")}
       </button>
@@ -1181,7 +1181,9 @@ function renderEnabledSwitch(
   opts?: { compact?: boolean; testId?: string },
 ) {
   const stateLabel = job.enabled ? t("cron.detail.active") : t("cron.detail.paused");
-  const actionLabel = job.enabled ? t("cron.actions.pause") : t("cron.actions.resume");
+  const actionLabel = job.enabled
+    ? t("cron.actions.pauseJob", { name: job.name })
+    : t("cron.actions.resumeJob", { name: job.name });
   return html`
     <span
       class="cron-enabled-toggle"

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -1181,9 +1181,9 @@ function renderEnabledSwitch(
   opts?: { compact?: boolean; testId?: string },
 ) {
   const stateLabel = job.enabled ? t("cron.detail.active") : t("cron.detail.paused");
-  const actionLabel = job.enabled
-    ? t("cron.actions.pauseJob", { name: job.name })
-    : t("cron.actions.resumeJob", { name: job.name });
+  const actionLabel = t(job.enabled ? "cron.actions.pauseJob" : "cron.actions.resumeJob", {
+    name: job.name,
+  });
   return html`
     <span
       class="cron-enabled-toggle"


### PR DESCRIPTION
Related: #127330

## What Problem This Solves

Fixes an issue where screen-reader users managing several automations encountered repeated “Run now,” “More actions,” and “Pause” or “Resume” names without knowing which job each control affected.

## Why This Change Was Made

The Cron inventory renderer now includes the job name in those existing controls’ accessible names and tooltips, using the shared translation and switch-label paths. Detail-view state labels and action handlers stay consistent. New translation keys let languages awaiting translations use the complete English fallback; three unused generic English keys were removed.

The regression checks Run, More, and Pause/Resume names across enabled and paused jobs. The existing removal E2E locator now selects the job-name button directly because job-specific action names also contain that text. Thanks @SunnyShu0925 for the original repair.

## User Impact

Automation controls identify their target job, including in screen-reader button lists and tooltips. For example, “Run now” becomes “Run now: heartbeat-main,” and pausing “Morning summary” changes its switch name from “Pause: Morning summary” to “Resume: Morning summary.”

## Evidence

- A new two-job regression failed against unchanged production code, then all 47 Cron view and editor tests passed with the repair. The regression checks exact Run/More names and both enabled/paused switch labels.
- A normal isolated development Gateway and Vite Control UI were exercised in Chromium with synthetic state, no provider/channel credentials, and real Gateway RPC. Before: three Run controls shared “Run now,” three menus shared “More actions,” and the editable job switch was “Pause.” After: Chromium’s computed accessibility tree reported each job-qualified name.
- Keyboard pause/resume on the synthetic job produced successful real `cron.update` responses with `enabled: false` then `true`, matching `cron.list` responses, the renamed switch, and its native checked state. No browser page errors were observed.
- Source isolation: local behavior proof used trusted main `c0f1cbfddb909541b7ad88920d8ae0e59fff89b7` with an authored equivalent repair, Node24.20.0, and independent frozen dependencies. Runtime view, regression, and removal-test files match the native candidate byte-for-byte; the changed locale block matches while unrelated surrounding locale edits remain on their original ancestry. Contributor tooling was not executed locally.
- Candidate source delta: production +11/-8 (net+3), tests +22/-1 (net+21). The remaining production growth carries translated job identity; generic details labels remain in use.
- Local reviewed candidate: `047c08b06920777743892fff49ec5bcaeb0f0e45` (original contributor parent `f83ed3658c9e595f1bd926ff6ecfc13d50372a5e`). Explicit trusted formatting, whitespace checks, and complete-candidate independent Codex P0 review passed. Final published-head CI is green: 177 successful checks and 24 skipped, zero failures or pending checks. Hosted logs confirm the new label regression among 20 Cron view cases and the existing Cron removal E2E case (117 tests in that shard).

Before and after screenshots show the same real inventory and its tooltip; a third shows the paused synthetic job. All three captures were personally inspected and contain synthetic data only. Raw recordings are retained privately and are not offered as inspected evidence.

![Before: generic Run label](https://github.com/user-attachments/assets/9e8a7629-ed9f-4300-a4d6-f3615bfc5b05)

![After: job-specific Run label](https://github.com/user-attachments/assets/8b7b92ff-227d-4a1b-acfe-c28917dc9c17)

![After: paused synthetic job](https://github.com/user-attachments/assets/2fa6f046-cd36-41c6-82c0-c77c16b8d720)

Proof used the repository’s pre-approved isolated development browser path. The real Gateway, workspace, state, and ports were task-owned and stopped after verification.

Named follow-up: investigate an intermittent auth-none CLI device-identity setup failure. One synthetic `cron.add` call succeeded and the next was rejected before reaching Cron with “device identity required”; a later direct identity-owner diagnostic loaded the stored identity. This PR changes no authentication policy. The browser connected normally and proved the UI repair using the accepted synthetic job plus the Gateway’s normal reconciled jobs.
