### PR TITLE
fix: fail updates when session migration is incomplete

### DIFF
--- a/src/cli/doctor-output.process.test.ts
+++ b/src/cli/doctor-output.process.test.ts
@@ -177,6 +177,56 @@ registerHooks({
     expect(cleanOutput).not.toContain("Legacy state detected");
   }, 180_000);
 
+  it("fails repair when session import leaves a startup-blocking legacy store", () => {
+    const root = tempDirs.make("openclaw-doctor-session-convergence-");
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(root, "openclaw.json");
+    const storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+    const loaderPath = path.join(root, "doctor-test-loader.mjs");
+    const original = Buffer.from('{"agent:main:legacy":');
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(configPath, `${JSON.stringify({ heartbeat: { every: "30m" } })}\n`);
+    fs.writeFileSync(storePath, original);
+    fs.writeFileSync(
+      loaderPath,
+      `import { registerHooks } from "node:module";
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.endsWith("/doctor-ui.js")) {
+      return {
+        shortCircuit: true,
+        url: "data:text/javascript," + encodeURIComponent(
+          [
+            "export async function detectUiProtocolFreshnessIssues() { return []; }",
+            "export function uiProtocolFreshnessIssueToHealthFinding() { return {}; }",
+            "export function uiProtocolFreshnessIssueToRepairEffects() { return []; }",
+            "export async function maybeRepairUiProtocolFreshness() {}",
+          ].join("\\n"),
+        ),
+      };
+    }
+    return nextResolve(specifier, context);
+  },
+});
+`,
+    );
+
+    const result = runDoctorFix({ root, configPath, loaderPath });
+    const output = `${result.stderr}\n${result.stdout}`;
+
+    expect(result.error, output).toBeUndefined();
+    expect(result.signal, output).toBeNull();
+    expect(result.status, output).toBe(1);
+    expect(output).toContain("Legacy session store requires migration");
+    expect(output).toContain("openclaw doctor --fix");
+    expect(output).not.toContain("Doctor complete.");
+    expect(fs.readFileSync(storePath)).toEqual(original);
+    expect(JSON.parse(fs.readFileSync(configPath, "utf8"))).toMatchObject({
+      agents: { defaults: { heartbeat: { every: "30m" } } },
+    });
+    expect(JSON.parse(fs.readFileSync(configPath, "utf8"))).not.toHaveProperty("heartbeat");
+  }, 120_000);
+
   it("omits backup tips for Git-backed nested agent workspaces", () => {
     const root = tempDirs.make("openclaw-doctor-workspace-git-");
     const repoRoot = path.join(root, "repo");

--- a/src/config/sessions/startup-migration.ts
+++ b/src/config/sessions/startup-migration.ts
@@ -22,6 +22,24 @@ import { migrateManagedWorktreeCanonicalWorkspaces } from "./worktree-workspace-
 
 export type SessionStartupMigrationLogger = Record<"info" | "warn", (message: string) => void>;
 
+export function assertSessionStoreMigrationComplete(params: {
+  cfg: OpenClawConfig;
+  env?: NodeJS.ProcessEnv;
+  targets?: readonly { storePath: string }[];
+}): void {
+  const env = params.env ?? process.env;
+  const targets = params.targets ?? resolveAllAgentSessionStoreTargetsSync(params.cfg, { env });
+  const legacyStore = [
+    path.join(resolveStateDir(env), "sessions", "sessions.json"),
+    ...targets.map((target) => target.storePath),
+  ].find((storePath) => !storePath.endsWith(".sqlite") && fs.existsSync(storePath));
+  if (legacyStore) {
+    throw new Error(
+      `Legacy session store requires migration: ${legacyStore}. Run "${formatCliCommand("openclaw doctor --fix", env)}" against the same state/config before starting OpenClaw.`,
+    );
+  }
+}
+
 /** Maintains existing SQLite stores and returns their physical owners for startup reconciliation. */
 export async function runSessionStartupMigration(params: {
   cfg: OpenClawConfig;
@@ -39,15 +57,7 @@ export async function runSessionStartupMigration(params: {
   let targets = resolveTargets(params.cfg, { env });
   // Stable installations may still have file-backed history. Only Doctor imports it;
   // do not serve an empty SQLite history or rewrite those files during startup.
-  const legacyStore = [
-    path.join(resolveStateDir(env), "sessions", "sessions.json"),
-    ...targets.map((target) => target.storePath),
-  ].find((storePath) => !storePath.endsWith(".sqlite") && fs.existsSync(storePath));
-  if (legacyStore) {
-    throw new Error(
-      `Legacy session store requires migration: ${legacyStore}. Run "${formatCliCommand("openclaw doctor --fix", env)}" against the same state/config before starting OpenClaw.`,
-    );
-  }
+  assertSessionStoreMigrationComplete({ cfg: params.cfg, env, targets });
   const migrateLegacyMain =
     params.deps?.migrateLegacyMainSessionKeys ?? migrateLegacyMainSessionKeys;
   const result = await migrateLegacyMain({ cfg: params.cfg, env, mode: "automatic" });

--- a/src/flows/doctor-health.test.ts
+++ b/src/flows/doctor-health.test.ts
@@ -756,6 +756,28 @@ describe("runDoctorHealthFlow", () => {
     });
   });
 
+  it("fails repair when a startup-blocking legacy session store remains", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const storePath = await state.writeText(
+        "agents/main/sessions/sessions.json",
+        '{"agent:main:legacy":',
+      );
+      const before = fs.readFileSync(storePath);
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+      await runCommandWithRuntime(runtime, () =>
+        runDoctorHealthFlow(runtime, { repair: true, nonInteractive: true }),
+      );
+
+      expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(1);
+      expect(runtime.error).toHaveBeenCalledWith(
+        expect.stringContaining("Legacy session store requires migration"),
+      );
+      expect(mocks.outro).not.toHaveBeenCalledWith("Doctor complete.");
+      expect(fs.readFileSync(storePath)).toEqual(before);
+    });
+  });
+
   it.each(["configured", "sandbox"] as const)(
     "refuses incomplete %s workspace cleanup with current SQLite schemas, then completes on retry",
     async (kind) => {

--- a/src/flows/doctor-health.test.ts
+++ b/src/flows/doctor-health.test.ts
@@ -5,8 +5,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { assertNoUnmigratedWorkspaceState } from "../agents/workspace-legacy-state.js";
 import { readWorkspaceStateSnapshot } from "../agents/workspace-state-store.js";
 import { runCommandWithRuntime } from "../cli/cli-utils.js";
+import { noteSessionTranscriptHealth } from "../commands/doctor-session-transcripts.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { acquireGatewayLock } from "../infra/gateway-lock.js";
 import {
   resolveStateDatabaseCoordinatorPath,
   resolveStateLifecycleRuntimeDirectory,
@@ -60,6 +62,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("@clack/prompts", () => ({
   intro: vi.fn(),
+  note: vi.fn(),
   outro: mocks.outro,
 }));
 
@@ -756,18 +759,69 @@ describe("runDoctorHealthFlow", () => {
     });
   });
 
-  it("fails repair when a startup-blocking legacy session store remains", async () => {
+  it.each(["default", "configured"] as const)(
+    "fails repair when a startup-blocking %s legacy session store remains",
+    async (layout) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+        const storePath =
+          layout === "configured"
+            ? state.path("custom", "sessions.json")
+            : state.statePath("agents", "main", "sessions", "sessions.json");
+        fs.mkdirSync(path.dirname(storePath), { recursive: true });
+        fs.writeFileSync(storePath, '{"agent:main:legacy":');
+        mocks.config.mockReturnValue(
+          layout === "configured" ? { session: { store: storePath } } : {},
+        );
+        const before = fs.readFileSync(storePath);
+        const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+        await runCommandWithRuntime(runtime, () =>
+          runDoctorHealthFlow(runtime, { repair: true, nonInteractive: true }),
+        );
+
+        expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(1);
+        expect(runtime.error).toHaveBeenCalledWith(
+          expect.stringContaining("Legacy session store requires migration"),
+        );
+        expect(mocks.outro).not.toHaveBeenCalledWith("Doctor complete.");
+        expect(fs.readFileSync(storePath)).toEqual(before);
+      });
+    },
+  );
+
+  it("fails public repair after the Gateway lock skips session import", async () => {
     await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
       const storePath = await state.writeText(
         "agents/main/sessions/sessions.json",
-        '{"agent:main:legacy":',
+        JSON.stringify({
+          "agent:main:legacy": { sessionId: "legacy-session", updatedAt: 1 },
+        }),
       );
       const before = fs.readFileSync(storePath);
+      const gatewayLock = await acquireGatewayLock({
+        allowInTests: true,
+        env: state.env,
+        port: 19566,
+      });
+      if (!gatewayLock) {
+        throw new Error("expected Gateway lock");
+      }
+      mocks.runContributions.mockImplementation(async (ctx) => {
+        await noteSessionTranscriptHealth({
+          cfg: ctx.cfg,
+          env: state.env,
+          shouldRepair: true,
+        });
+      });
       const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
 
-      await runCommandWithRuntime(runtime, () =>
-        runDoctorHealthFlow(runtime, { repair: true, nonInteractive: true }),
-      );
+      try {
+        await runCommandWithRuntime(runtime, () =>
+          runDoctorHealthFlow(runtime, { repair: true, nonInteractive: true }),
+        );
+      } finally {
+        await gatewayLock.release();
+      }
 
       expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(1);
       expect(runtime.error).toHaveBeenCalledWith(

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -141,8 +141,11 @@ export async function runDoctorHealthFlow(runtime?: RuntimeEnv, options: DoctorO
       return;
     }
     if (options.repair === true || options.yes === true) {
-      // Migration warnings also cover optional archives; certify required runtime
-      // schemas independently before reporting success or a recoverable advisory.
+      // Contributions can report optional migration warnings, but repair must not
+      // complete while startup would still reject a legacy session store.
+      const { assertSessionStoreMigrationComplete } =
+        await import("../config/sessions/startup-migration.js");
+      assertSessionStoreMigrationComplete({ cfg: ctx.cfg, env: process.env });
       const { assertOpenClawDatabasesReady } =
         await import("../state/openclaw-database-preflight.js");
       const { resolveConfiguredAgentDatabaseTargets } =

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1,4 +1,5 @@
 // Covers embedded backend behavior used by the TUI runtime.
+import fs from "node:fs/promises";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
@@ -13,6 +14,7 @@ import { defaultRuntime } from "../runtime.js";
 import { AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE } from "../sessions/agent-harness-session-key.js";
 import { notifyListeners } from "../shared/listeners.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { EmbeddedTuiBackend as EmbeddedTuiBackendType } from "./embedded-backend.js";
 
 type EmbeddedAgentResult = {
@@ -38,7 +40,7 @@ const updateSessionGoalStatusMock = vi.fn();
 const loadAgentRuntimePluginRegistryHandleMock = vi.fn();
 const withPluginRuntimeRegistryScopeMock = vi.fn((_registry: unknown, run: () => unknown) => run());
 const ensureContextWindowCacheLoadedMock = vi.fn(async () => undefined);
-const runSessionStartupMigrationMock = vi.fn<() => Promise<void>>(async () => undefined);
+const runSessionStartupMigrationMock = vi.fn(async (..._args: unknown[]) => undefined);
 const refreshPreparedModelRuntimeSnapshotsMock = vi.fn<
   (_config: unknown, _options?: unknown) => Promise<void>
 >(async () => undefined);
@@ -154,7 +156,8 @@ vi.mock("../config/sessions/session-accessor.js", () => ({
   applySessionPatchProjection: (...args: unknown[]) => applySessionPatchProjectionMock(...args),
 }));
 
-vi.mock("../agents/agent-scope.js", () => ({
+vi.mock("../agents/agent-scope.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../agents/agent-scope.js")>()),
   resolveAgentDir: (_cfg: unknown, agentId: string) => `/tmp/openclaw-agent-${agentId}/agent`,
   resolveAgentWorkspaceDir: (_cfg: unknown, agentId: string) => `/tmp/openclaw-agent-${agentId}`,
   resolveDefaultAgentId: (cfg?: {
@@ -938,6 +941,38 @@ describe("EmbeddedTuiBackend", () => {
       },
     });
     expect(listSessionsFromStoreAsyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects embedded session reads when the actual startup migration finds a legacy store", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const storePath = await state.writeText(
+        "custom/sessions.json",
+        JSON.stringify({
+          "agent:main:legacy": { sessionId: "legacy-session", updatedAt: 1 },
+        }),
+      );
+      const before = await fs.readFile(storePath);
+      getRuntimeConfigMock.mockReturnValue({ session: { store: storePath } });
+      const actual = await vi.importActual<
+        typeof import("../config/sessions/startup-migration.js")
+      >("../config/sessions/startup-migration.js");
+      runSessionStartupMigrationMock.mockImplementationOnce(async (...args: unknown[]) => {
+        await actual.runSessionStartupMigration(
+          args[0] as Parameters<typeof actual.runSessionStartupMigration>[0],
+        );
+      });
+      const backend = new EmbeddedTuiBackend();
+
+      backend.start();
+      try {
+        await expect(backend.listSessions({ agentId: "main" })).rejects.toThrow(
+          "Legacy session store requires migration",
+        );
+      } finally {
+        await backend.stop();
+      }
+      expect(await fs.readFile(storePath)).toEqual(before);
+    });
   });
 
   it("publishes a static configured runtime before admitting the first local turn", async () => {

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -40,7 +40,9 @@ const updateSessionGoalStatusMock = vi.fn();
 const loadAgentRuntimePluginRegistryHandleMock = vi.fn();
 const withPluginRuntimeRegistryScopeMock = vi.fn((_registry: unknown, run: () => unknown) => run());
 const ensureContextWindowCacheLoadedMock = vi.fn(async () => undefined);
-const runSessionStartupMigrationMock = vi.fn(async (..._args: unknown[]) => undefined);
+const runSessionStartupMigrationMock = vi.fn<(...args: unknown[]) => Promise<void>>(
+  async () => undefined,
+);
 const refreshPreparedModelRuntimeSnapshotsMock = vi.fn<
   (_config: unknown, _options?: unknown) => Promise<void>
 >(async () => undefined);


### PR DESCRIPTION
Closes #134206

## What Problem This Solves

Fixes an issue where an existing OpenClaw installation could finish an update successfully even though its legacy session store had not completed migration to SQLite.

The session importer already preserved failed source files and recorded blocking migration issues. However, the public `openclaw doctor --fix` path could treat the session contribution as advisory and still exit successfully. Update finalization trusted that exit code, published the upgraded runtime, and then Gateway startup rejected the remaining `sessions.json` with:

```text
Legacy session store requires migration. Run "openclaw doctor --fix".
```

Under a service supervisor, that false-successful update can become a Gateway startup crash loop.

## Why This Change Was Made

Gateway startup already owns the definitive readiness rule: OpenClaw must not start while a root or configured per-agent legacy session store remains.

This change extracts that existing read-only assertion and reuses it as Doctor's final session-migration postcondition. Repairing Doctor now checks the invariant after all contributions and config persistence complete, but before reporting readiness or restarting the Gateway.

That placement is deliberate:

- successful imports continue through the existing import, verification, manifest, and archive machinery;
- blocking import, verification, archive, or maintenance-lock outcomes leave the source intact and make Doctor exit nonzero;
- unrelated config repairs completed earlier in the run remain committed;
- warning-only imports may still succeed when the startup-blocking source was safely archived;
- update finalization already treats a nonzero fresh-Doctor process as failure, so no OCM-specific migration path or second importer is added;
- Gateway and embedded TUI startup remain fail-closed and do not migrate state at runtime.

No config surface, SQLite schema, migration format, or targeted `doctor --session-sqlite` contract changes.

## User Impact

Operators updating an installation with legacy session state now get a truthful outcome:

- if migration converges, the verified legacy source is archived and the upgraded Gateway can start;
- if migration does not converge, Doctor and update finalization fail before claiming success, preserving the legacy files for repair or rollback;
- an update no longer reports success immediately before the Gateway refuses to start on the same state.

## Evidence

The regression coverage exercises the public behavior rather than only the importer:

- a real `doctor --fix --non-interactive` process receives a malformed legacy store, exits `1`, retains the source byte-for-byte, emits the actionable migration error, and does not print `Doctor complete.`;
- the same process proves an unrelated legacy heartbeat config migration is still persisted before the terminal session postcondition;
- the Doctor flow test proves a remaining per-agent `sessions.json` prevents repair success;
- existing startup tests prove configured and retired-root legacy stores use the same assertion, remain unchanged before Doctor import, and permit startup after successful import.

Completed verification:

- Blacksmith Testbox `tbx_01m1c77wgtkvky0g53me618yhd`: 55 focused Doctor flow, process CLI, and Gateway startup tests passed against the production patch;
- exact-head `oxfmt --check` passed;
- exact-head `git diff --check` passed.

Exact-head changed checks, the built-CLI SQLite lifecycle proof, and the isolated Nora OCM upgrade/Gateway-start rehearsal are continuing on this draft PR.
