### PR TITLE
fix(docker): include shared lifecycle marker in install stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Docs: https://docs.openclaw.ai
 - Provider error handling: reuse prepared or already loaded provider hooks instead of cold-loading plugins during error classification, avoiding long stalls in failure reporting and model fallback.
 - **Session settings:** restore merging of concurrent first writes after a startup optimization regressed lock ordering, preserving both global and project settings without adding filesystem side effects to missing-settings reads. Thanks @MrSwagatRathod, @obviyus, and @yetval for the original fix.
 - **Control UI startup and history:** reduce configuration-schema construction and skip full-text duplicate comparisons for distinct transcript messages, preserving plugin hints, redaction, and message identity.
+- **Docker source builds:** include the shared package lifecycle module before dependency installation so production and cleanup smoke images build with lifecycle checks enabled.
 - **Subagent completion:** recognize visible final answers delivered to internal and nested parent sessions, preventing false delivery failures while preserving external channel delivery checks.
 - Codex/Linux: wait for a live app-server process to expose its startup command line within the existing inspection deadline, preserving process identity checks and preventing intermittent startup failures.
 - **Cloud session lifecycle:** prevent archive, delete, and restart recovery from deadlocking behind an earlier worker move, keep work admission closed through cleanup, and preserve the same successor for concurrent recovery requests.

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,7 @@ COPY patches ./patches
 COPY scripts/postinstall-bundled-plugins.mjs scripts/preinstall-package-manager-warning.mjs scripts/windows-cmd-helpers.mjs scripts/prepare-git-hooks.mjs ./scripts/
 COPY scripts/lib/guard-inventory-utils.mjs ./scripts/lib/guard-inventory-utils.mjs
 COPY scripts/lib/package-dist-imports.mjs ./scripts/lib/package-dist-imports.mjs
+COPY scripts/lib/package-lifecycle-marker.mjs ./scripts/lib/package-lifecycle-marker.mjs
 COPY scripts/docker/verify-native-addons.sh ./scripts/docker/verify-native-addons.sh
 
 COPY --from=workspace-deps /out/packages/ ./packages/

--- a/scripts/docker/cleanup-smoke/Dockerfile
+++ b/scripts/docker/cleanup-smoke/Dockerfile
@@ -23,6 +23,7 @@ COPY patches ./patches
 COPY scripts/postinstall-bundled-plugins.mjs scripts/preinstall-package-manager-warning.mjs scripts/prepare-git-hooks.mjs scripts/windows-cmd-helpers.mjs ./scripts/
 COPY scripts/lib/guard-inventory-utils.mjs ./scripts/lib/guard-inventory-utils.mjs
 COPY scripts/lib/package-dist-imports.mjs ./scripts/lib/package-dist-imports.mjs
+COPY scripts/lib/package-lifecycle-marker.mjs ./scripts/lib/package-lifecycle-marker.mjs
 RUN --mount=type=cache,id=openclaw-pnpm-store,target=/root/.local/share/pnpm/store,sharing=locked \
   corepack enable \
   && if ! pnpm install --frozen-lockfile >/tmp/openclaw-cleanup-pnpm-install.log 2>&1; then \

--- a/scripts/lib/vitest-worker-artifacts.mts
+++ b/scripts/lib/vitest-worker-artifacts.mts
@@ -10,6 +10,8 @@ export const runtimeProcessDeclarationEntries = {
 };
 export const vitestWorkerDeclarationEntries = {
   ...runtimeProcessDeclarationEntries,
+  "agents/command/cli-compaction-runtime.test-support":
+    "src/agents/command/cli-compaction-runtime.test-support.ts",
   "tui/tui-pty-runtime-test-support": "src/tui/tui-pty-runtime-test-support.ts",
 };
 

--- a/scripts/lib/vitest-worker-build-entries.mts
+++ b/scripts/lib/vitest-worker-build-entries.mts
@@ -1,10 +1,17 @@
 import { fileURLToPath } from "node:url";
+import { cliCompactionBackendEntrypoints } from "../../src/agents/command/cli-compaction-runtime.test-support.ts";
 import { tuiPtyRuntimeEntrypoints } from "../../src/tui/tui-pty-runtime-test-support.ts";
 import { runtimeProcessBuildEntries } from "./runtime-process-build-entries.mts";
 
 // Test-only roots share the invocation generation without changing package entries.
 export const vitestWorkerBuildEntries = {
   ...runtimeProcessBuildEntries,
+  ...Object.fromEntries(
+    cliCompactionBackendEntrypoints.map((entry) => [
+      entry.distWorkerPath.replace(/\.js$/u, ""),
+      fileURLToPath(new URL(`./${entry.sourceWorkerName}.ts`, entry.currentModuleUrl)),
+    ]),
+  ),
   ...Object.fromEntries(
     Object.values(tuiPtyRuntimeEntrypoints).map((entry) => [
       entry.distWorkerPath.replace(/\.js$/u, ""),

--- a/src/agents/command/cli-compaction-runtime.test-support.ts
+++ b/src/agents/command/cli-compaction-runtime.test-support.ts
@@ -1,0 +1,19 @@
+// Real setup entries share the invocation build instead of transforming plugins inside a test.
+const currentModuleUrl = import.meta.url;
+
+export const cliCompactionBackendEntrypoints = [
+  {
+    provider: "claude-cli",
+    pluginId: "anthropic",
+    currentModuleUrl,
+    sourceWorkerName: "../../../extensions/anthropic/setup-api",
+    distWorkerPath: "extensions/anthropic/setup-api.js",
+  },
+  {
+    provider: "google-gemini-cli",
+    pluginId: "google",
+    currentModuleUrl,
+    sourceWorkerName: "../../../extensions/google/setup-api",
+    distWorkerPath: "extensions/google/setup-api.js",
+  },
+] as const;

--- a/src/agents/command/cli-compaction.test.ts
+++ b/src/agents/command/cli-compaction.test.ts
@@ -9,9 +9,12 @@ import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import { SESSION_TOTAL_TOKENS_VERSION, type SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { ContextEngine } from "../../context-engine/types.js";
+import { resolveRuntimeWorkerUrl } from "../../infra/runtime-worker-url.js";
+import { withEnv } from "../../test-utils/env.js";
 import { resolveCliBackendConfig } from "../cli-backends.js";
 import { createModelGenerationFixture } from "../embedded-agent-runner/model.generation-scope.test-support.js";
 import { SessionManager } from "../sessions/session-manager.js";
+import { cliCompactionBackendEntrypoints } from "./cli-compaction-runtime.test-support.js";
 import {
   resetCliCompactionTestDeps,
   runCliTurnCompactionLifecycle,
@@ -1187,10 +1190,25 @@ describe("runCliTurnCompactionLifecycle", () => {
     );
   });
 
-  it.each(["claude-cli", "google-gemini-cli"])(
+  it.each(cliCompactionBackendEntrypoints.map((entry) => [entry.provider, entry] as const))(
     "preserves %s native history and resume binding under compaction pressure",
-    async (provider) => {
-      const backend = resolveCliBackendConfig(provider);
+    async (provider, entry) => {
+      const { pluginId } = entry;
+      const bundled = path.join(tmpDir, "bundled");
+      const pluginRoot = path.join(bundled, pluginId);
+      await fs.mkdir(pluginRoot, { recursive: true });
+      await fs.copyFile(
+        new URL(`../../../extensions/${pluginId}/openclaw.plugin.json`, import.meta.url),
+        path.join(pluginRoot, "openclaw.plugin.json"),
+      );
+      await fs.writeFile(
+        path.join(pluginRoot, "setup-api.mjs"),
+        `export { default } from ${JSON.stringify(resolveRuntimeWorkerUrl(entry).href)};`,
+      );
+      await fs.copyFile(path.join(pluginRoot, "setup-api.mjs"), path.join(pluginRoot, "index.mjs"));
+      const backend = withEnv({ OPENCLAW_BUNDLED_PLUGINS_DIR: bundled }, () =>
+        resolveCliBackendConfig(provider),
+      );
       expect(backend).not.toBeNull();
       const compactAgentHarnessSession = vi.fn();
       const scenario = await prepareCompactionScenario({

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -2,7 +2,7 @@
 import { execFileSync } from "node:child_process";
 import { access, cp, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { BUNDLED_PLUGIN_ROOT_DIR } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
@@ -298,35 +298,75 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain('OPENCLAW_EXTENSIONS="$(cat /tmp/openclaw-selected-plugin-dirs)"');
   });
 
-  it("copies root package lifecycle scripts before pnpm install", async () => {
-    const [dockerfile, packageJsonText] = await Promise.all([
-      readFile(dockerfilePath, "utf8"),
-      readFile(join(repoRoot, "package.json"), "utf8"),
-    ]);
-    const installIndex = dockerfile.indexOf("pnpm install --frozen-lockfile");
-    const packageJson = JSON.parse(packageJsonText) as {
-      scripts?: Record<string, string>;
-    };
-    const installLifecycleScripts = ["preinstall", "install", "postinstall", "prepare"] as const;
-
-    for (const lifecycleScript of installLifecycleScripts) {
-      const command = packageJson.scripts?.[lifecycleScript];
-      const scriptPath = command?.match(/\bnode\s+(scripts\/[^\s]+)/)?.[1];
-      if (!scriptPath) {
-        continue;
+  it.each(["Dockerfile", "scripts/docker/cleanup-smoke/Dockerfile"])(
+    "runs root lifecycle scripts from %s dependency inputs",
+    async (dockerfileName) => {
+      const dockerfile = collapseDockerContinuations(
+        await readFile(join(repoRoot, dockerfileName), "utf8"),
+      );
+      const installIndex = dockerfile.indexOf("pnpm install --frozen-lockfile");
+      expect(installIndex).toBeGreaterThan(-1);
+      const fixture = await mkdtemp(join(tmpdir(), "openclaw-docker-lifecycle-"));
+      try {
+        // Stage the actual local COPY inputs, not a separately maintained import list.
+        // Workspace manifests do not contribute executable root lifecycle modules.
+        for (const [, sources, destination] of dockerfile
+          .slice(0, installIndex)
+          .matchAll(/^COPY ([^\n]+) (\.\/\S*)$/gm)) {
+          if (!sources || !destination) {
+            throw new Error("Expected local COPY sources and destination");
+          }
+          if (sources.startsWith("--")) {
+            continue;
+          }
+          for (const input of sources.split(/\s+/)) {
+            if (input !== "package.json" && !input.endsWith(".mjs")) {
+              continue;
+            }
+            const target = join(
+              fixture,
+              destination.endsWith("/") ? join(destination, basename(input)) : destination,
+            );
+            await mkdir(dirname(target), { recursive: true });
+            await cp(join(repoRoot, input), target);
+          }
+        }
+        const packageJson = JSON.parse(await readFile(join(fixture, "package.json"), "utf8")) as {
+          scripts: Record<string, string>;
+        };
+        const home = join(fixture, "home");
+        await mkdir(home);
+        for (const lifecycle of ["preinstall", "install", "postinstall", "prepare"]) {
+          const command = packageJson.scripts[lifecycle];
+          if (!command) {
+            continue;
+          }
+          const scriptPath = command.match(/^node (scripts\/[^\s]+)$/)?.[1];
+          if (!scriptPath) {
+            throw new Error(`Unsupported root lifecycle command: ${command}`);
+          }
+          expect
+            .soft(
+              () =>
+                execFileSync(process.execPath, [scriptPath], {
+                  cwd: fixture,
+                  env: {
+                    HOME: home,
+                    USERPROFILE: home,
+                    PATH: process.env.PATH,
+                    npm_config_user_agent: "pnpm/12",
+                  },
+                  stdio: "pipe",
+                }),
+              lifecycle,
+            )
+            .not.toThrow();
+        }
+      } finally {
+        await rm(fixture, { recursive: true, force: true });
       }
-
-      const copyIndex = dockerfile.indexOf(scriptPath);
-      expect(
-        copyIndex,
-        `${lifecycleScript} must copy ${scriptPath} before pnpm install`,
-      ).toBeGreaterThan(-1);
-      expect(
-        copyIndex,
-        `${lifecycleScript} must copy ${scriptPath} before pnpm install`,
-      ).toBeLessThan(installIndex);
-    }
-  });
+    },
+  );
 
   it("does not let pnpm resync the full source workspace during Docker build scripts", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");

--- a/test/scripts/vitest-worker-artifacts.test-support.ts
+++ b/test/scripts/vitest-worker-artifacts.test-support.ts
@@ -219,11 +219,13 @@ export function workerProbe(
     import { runtimeProcessBuildEntries } from ${JSON.stringify(path.join(root, "scripts/lib/runtime-process-build-entries.mts"))};
     import { vitestWorkerBuildEntries } from ${JSON.stringify(path.join(root, "scripts/lib/vitest-worker-build-entries.mts"))};
     import { tuiPtyRuntimeEntrypoints } from ${JSON.stringify(path.join(root, "src/tui/tui-pty-runtime-test-support.ts"))};
+    import { cliCompactionBackendEntrypoints } from ${JSON.stringify(path.join(root, "src/agents/command/cli-compaction-runtime.test-support.ts"))};
     import { resolveRuntimeWorkerUrl } from ${JSON.stringify(path.join(root, "src/infra/runtime-worker-url.ts"))};
     import { prepareSqliteReadOnlyLocation } from ${JSON.stringify(path.join(root, "src/infra/sqlite-readonly-location.ts"))};
     const tuiUrls = Object.values(tuiPtyRuntimeEntrypoints).map(entry => resolveRuntimeWorkerUrl(entry).href);
+    const setupUrls = cliCompactionBackendEntrypoints.map(entry => resolveRuntimeWorkerUrl(entry).href);
     // Import acquisition must finish during collection, before any fixture hook starts.
-    const tuiPresentAtCollection = tuiUrls.every(url => fs.existsSync(new URL(url)));
+    const entriesPresentAtCollection = [...tuiUrls,...setupUrls].every(url => fs.existsSync(new URL(url)));
     vi.mock('node:child_process', async (original) => {
       const actual = await original();
       return {...actual, execFile: vi.fn(actual.execFile)};
@@ -238,8 +240,8 @@ export function workerProbe(
         expect(source).toMatch(/\\.ts$/);
         expect(fs.existsSync(source)).toBe(true);
       }
-      expect(tuiPresentAtCollection).toBe(true);
-      for (const entry of Object.values(tuiPtyRuntimeEntrypoints)) {
+      expect(entriesPresentAtCollection).toBe(true);
+      for (const entry of [...Object.values(tuiPtyRuntimeEntrypoints),...cliCompactionBackendEntrypoints]) {
         const source = vitestWorkerBuildEntries[entry.distWorkerPath.replace(/\\.js$/, '')];
         expect(source).not.toContain('/dist/');
         expect(source).toMatch(/\\.ts$/);
@@ -260,13 +262,14 @@ export function workerProbe(
           const generation = runtimeProcessEntrypoints.sqliteReadOnly.currentModuleUrl;
           const sourceMode = ${mode === "auto" ? "generation.endsWith('.ts')" : mode === "source"};
           expect(tuiUrls).toHaveLength(4);
-          for (const url of tuiUrls) {
+          expect(setupUrls).toHaveLength(2);
+          for (const url of [...tuiUrls,...setupUrls]) {
             expect(url.endsWith(sourceMode ? '.ts' : '.js')).toBe(true);
             if (!sourceMode) expect(fileURLToPath(url).startsWith(fileURLToPath(new URL('../', generation)))).toBe(true);
           }
           expect(args.includes('tsx')).toBe(sourceMode);
           expect(args[sourceMode ? 2 : 0]).toMatch(sourceMode ? /\\.ts$/ : /\\.js$/);
-          fs.appendFileSync(${JSON.stringify(path.join(directory, "observations.jsonl"))}, JSON.stringify({args, tuiUrls, value, configValue:inject('configValue'), knn:vectorKnnProcessEntrypoint.currentModuleUrl})+'\\n');
+          fs.appendFileSync(${JSON.stringify(path.join(directory, "observations.jsonl"))}, JSON.stringify({args, tuiUrls, setupUrls, value, configValue:inject('configValue'), knn:vectorKnnProcessEntrypoint.currentModuleUrl})+'\\n');
           fs.appendFileSync(${JSON.stringify(path.join(directory, "generations.jsonl"))}, JSON.stringify(generation)+'\\n');
           const release = inject('releaseFile');
           if (release) await new Promise(resolve => {


### PR DESCRIPTION
Source-built Docker images fail during dependency installation because preinstall and postinstall now import the shared package lifecycle marker module, while the manifest-only Docker install stages omit it. The full release runtime-assets job reproduced the missing-module failure before preinstall could execute. The cleanup smoke image has the same incomplete input set.

Copy that dependency-free module into both install stages. This preserves the existing cached dependency layout and all lifecycle execution; no script suppression, broad source copy, runtime policy, dependency, or timeout change is needed. Both production dependencies and the application build inherit the root Dockerfile repair.

Replace the lifecycle entrypoint-name assertion with execution of the actual declared lifecycle scripts from the Dockerfiles' copied JavaScript inputs, under an isolated home directory. Before the fix, preinstall and postinstall fail in both cases with the same missing-module error as the release job. With the two copy additions, all 140 focused and sibling tests pass.

Real Linux proof uses Node24.19.0 and Docker28.0.4 on 4 CPUs, with exact frozen source plus this patch. The original `runtime-assets` target with `diagnostics-otel,codex` and its existing 15-minute limit passed in 142.340 seconds, including pruning and the final package import-closure check. The cleanup smoke image build passed in 40.991 seconds and its real container lifecycle commands passed in 0.670 seconds. The native owning test typecheck, all 140 sibling tests, and complete changed-file gate pass, including all type graphs, lint, and import-cycle checks. The first native gate caught unchecked regex capture types in the new test; an explicit fixture invariant fixed that issue before the final complete gate. Both Dockerfiles stayed byte-identical to the successful build. The task images were removed and the Testbox was stopped. This is targeted repair proof, not a full-release pass.

Production/tooling delta: +2/-0, delivering the required module at two existing install boundaries. Test delta: +69/-29, replacing the old check; changelog updated. Shared packaged E2E and installer images already obtain the module through package contents, and their installation contracts remain unchanged.

Independent Codex review of the final four-file patch found no actionable P0–P2 findings. Native proof: [Linux Docker and changed-file validation](https://github.com/openclaw/openclaw/actions/runs/33404333753). Required exact-head CI remains the landing gate.


CI exposed a separate, reproducible test-harness timeout while validating this repair. The CLI compaction ownership test loaded the real Anthropic setup entry from TypeScript through Jiti inside the test deadline. The unchanged whole test file reproduced the 120-second timeout locally; diagnostic timing isolated 87.777 seconds in that single setup-module load, before any model or CLI process invocation. The cleanup error from the original hosted timeout did not reproduce locally and is not claimed as an independent persistence defect.

The bounded CI repair registers the real Anthropic and Google setup entries with the existing compiled-worker artifact owner. The existing cases still use real plugin manifests, setup registration, backend resolution, session persistence and all original compaction/history assertions. Test fixtures reexport the actual compiled entries; they do not replace backend behavior with mocks. Source/watch mode, source-hash verification, collection-time preparation and generation cleanup remain owned by the existing harness. No runtime production, timeout, retry, skip or scenario change is added.

On an independent frozen installation, all 82 owner and registry sibling tests passed, including the complete original 32-case compaction order. The Claude and Gemini checks took 365 ms and 96 ms; total owner/sibling execution was 71.589 seconds. Four existing compiler contract cases also passed, proving standalone source URLs and the shared compiled generation. The graph adds only 10 inputs and 12 outputs to the existing 7,369-input build; retained preparation timings vary with host/dependency state, so no controlled full-CI speedup is claimed. The final five-file fixture received a clean independent review. Its complete five-path changed gate passed in 420.707 seconds on the same independent frozen installation. All source hashes stayed unchanged through the final proof.

The failed first fixture candidate and the first gate's unrelated shared-install declaration errors remain recorded. The former correctly failed discovery without a runtime entry; the final fixture includes both real index and setup reexports. A task-owned frozen dependency installation cleared the declaration mismatch without changing source, dependencies or lockfile. This CI follow-up adds nine tooling lines and changes only test/support files otherwise.

The branch was mechanically refreshed onto d147d40 before combining the fixes. The three original Docker source/test files are byte-identical to their reviewed and native-tested versions; all five added fixture files match their independently reviewed and tested source. The changelog conflict was resolved while preserving upstream entries. The prior changelog-removal request remains explicitly declined for this maintainer-authored user-visible fix. Required CI on the combined head remains the final landing gate, and the next frozen full verification will test the integrated package.
