### PR TITLE
fix(test): stop returning the timer handle from a promise executor

### DIFF
--- a/src/gateway/server-kernel.test.ts
+++ b/src/gateway/server-kernel.test.ts
@@ -106,7 +106,9 @@ describe("createGatewayKernel", () => {
 
       await kernel.beginClosePrelude();
       kernel.releaseStartupAccountStarts();
-      await new Promise<void>((resolve) => setImmediate(resolve));
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
 
       expect(startAccount).not.toHaveBeenCalled();
       expect(kernel.channelManager.isAutoRestartScheduled("telegram", "default")).toBe(false);


### PR DESCRIPTION
## What Problem This Solves

`check-lint-core-1` is red on `main`, so every open pull request inherits the failure.

`src/gateway/server-kernel.test.ts` passes a concise arrow body to a `Promise` executor, which returns `setImmediate`'s `Timeout` handle:

```ts
await new Promise<void>((resolve) => setImmediate(resolve));
```

`eslint(no-promise-executor-return)` rejects that. Giving the executor a block body returns nothing and keeps the behavior identical, since the handle was never used.

Net production LOC **0** (test file, one statement reformatted into a block).

I hit this while working on something unrelated. It reds the lint shard on every PR, so a one-line repair seemed better than a follow-up note.

## Evidence

**The failure, from a CI run on an unrelated PR:**

```
/home/runner/work/openclaw/openclaw/src/gateway/server-kernel.test.ts
  109:44  error  Return statement should not be used in Promise executor.  eslint(no-promise-executor-return)
[oxlint] FAILED (exit 1)
```

It is not specific to one branch. The same shard fails on other contributors' open pull requests, and the offending line is present at `main` (`638ffcd45a`).

**After the change**, the repo's own lint wrapper on that file:

```
$ node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json src/gateway/server-kernel.test.ts
exit 0
```

**Behavior unchanged:**

```
Test Files  1 passed (1)
     Tests  5 passed (5)
```

`oxfmt --check` reports the file correctly formatted.
