### PR TITLE
fix(line): tell the agent it has the buttons LINE renders

### DIFF
--- a/extensions/line/src/channel.rich-messages.test.ts
+++ b/extensions/line/src/channel.rich-messages.test.ts
@@ -11,6 +11,22 @@ import {
 } from "./rich-messages.js";
 import type { LineRichCard } from "./types.js";
 
+describe("LINE agent prompt capabilities", () => {
+  const cfg = {
+    channels: { line: { enabled: true, channelAccessToken: "token", channelSecret: "secret" } },
+  } as never;
+
+  it("tells the agent it has the buttons the renderer produces", () => {
+    const advertised = linePlugin.agentPrompt?.messageToolCapabilities?.({ cfg });
+    const renders = lineOutboundAdapter.presentationCapabilities?.buttons === true;
+
+    // The prompt and the renderer answer the same question; a channel that says
+    // no here loses the button hint and is told to set a config key it has not got.
+    expect(renders).toBe(true);
+    expect(advertised).toContain("inlineButtons");
+  });
+});
+
 function resolveChannelDataSchema() {
   const discovery = lineMessageActions.describeMessageTool({
     cfg: {

--- a/extensions/line/src/channel.ts
+++ b/extensions/line/src/channel.ts
@@ -120,6 +120,11 @@ export const linePlugin: ChannelPlugin<ResolvedLineAccount> = createChatChannelP
       defaultTopLevelPlacement: "current",
     },
     agentPrompt: {
+      // LINE renders presentation buttons on every account and has no switch to
+      // turn them off, so the prompt must offer them. Without this the agent is
+      // told inline buttons are off and to ask for a channels.line.capabilities
+      // key the strict account schema rejects.
+      messageToolCapabilities: () => ["inlineButtons"],
       messageToolHints: () => [
         "",
         "### LINE structured output",


### PR DESCRIPTION
## What Problem This Solves

LINE renders presentation buttons, and the agent is told it cannot. The system prompt carries both statements a few lines apart:

```
- Inline buttons OFF for line; ask owner for line.capabilities.inlineButtons=dm|group|all|allowlist.
### LINE structured output
Use `presentation.blocks` for buttons, yes/no choices, and selectable options; LINE maps them to Flex controls or quick replies.
```

The remedy in the first line cannot be followed. LINE's account schema is strict and has no `capabilities` key, so both the object form the prompt prescribes and the array form core reads are rejected:

```
LineConfigSchema.safeParse({ ..., capabilities: { inlineButtons: "all" } })
accepted: false
[{ "code": "unrecognized_keys", "keys": ["capabilities"], "message": "Unrecognized key: \"capabilities\"" }]
array form accepted: false
```

The same missing fact downgrades the exec-approval guidance: the agent is told to send `/approve` as text while the LINE user is looking at three tappable buttons.

Fixes #134233.

## Why This Change Was Made

Core decides this from the `inlineButtons` runtime capability, which comes from the channel plugin's own `agentPrompt.messageToolCapabilities` seam:

```
$ grep -rn "messageToolCapabilities" src extensions --include='*.ts' | grep -v test
src/agents/channel-tools.ts:150:    plugin?.agentPrompt?.messageToolCapabilities?.({ cfg, accountId: params.accountId }),
src/channels/plugins/types.core.ts:684:  messageToolCapabilities?: (params: {
extensions/telegram/src/channel.ts:798:      messageToolCapabilities: ({ cfg, accountId }) => {
```

The seam exists so the channel that owns the fact answers it; LINE simply never answered, so core fell to the off branch. LINE fills it now, unconditionally, because its renderer is unconditional and there is no switch to turn it off:

```
extensions/line/src/rich-messages.ts:120-124
export const LINE_PRESENTATION_CAPABILITIES = {
  supported: true,
  buttons: true,
```

Telegram answers the same seam conditionally because it has an `inlineButtons` scope an operator can set to `off`. LINE has no such setting, and this change deliberately does not add one: the capability is a property of the renderer, not a preference.

The regression test asserts the invariant rather than the declaration — it reads the advertised capability and the renderer's capability and requires them to agree, so the two cannot drift apart in either direction.

**Not done here, on purpose.** The other channels that declare `buttons: true` have the same unfilled seam:

```
$ for d in $(ls extensions); do \
    grep -rqs "presentationCapabilities\|PRESENTATION_CAPABILITIES" extensions/$d/src --include='*.ts' \
    && grep -rqs "buttons: true" extensions/$d/src --include='*.ts' && echo "$d"; done
discord
feishu
line
matrix
mattermost
msteams
slack
telegram
```

Slack is excluded from the generic hint (`src/agents/system-prompt.ts:589`) and Telegram fills the seam, so discord, feishu, matrix, mattermost and msteams still see the contradiction. A core derivation from `presentationCapabilities.buttons` would fix all of them in one move, but Telegram's scope can be switched off while its declared capabilities stay static (`extensions/telegram/src/interactive-fallback.ts:54`), so a pure derivation would override an operator's opt-out — and it would change the exec-approval wording for the three of those channels that have no `approvalFlags: ["native"]`. That is a maintainer call, recorded in #134233 rather than taken here.

## User Impact

On LINE the agent now offers tappable buttons for discrete choices instead of prose, and stops telling operators to set a key that fails config validation. Exec approvals read as what they are: a card with buttons, with the typed `/approve` command as the fallback rather than the instruction.

No configuration changes, no new config surface, no change for any other channel.

## Evidence

**Live, real LINE client, real webhook, one variable.** Two gateway processes on the same state dir, zero config reloads in either (`grep -c "config change detected"` → `0`), prompt captured at the model endpoint so the observable is what the agent actually received.

Before:

```
Inline buttons OFF for line; ask owner for line.capabilities.inlineButtons=dm|group|all|allowlist.
exec approval-pending: send exact /approve from "Reply with:"; never ask for another code.
capabilities=none
```

After:

```
Inline buttons: `send` with `presentation={"blocks":[{"type":"buttons","buttons":[{"label":"Yes","action":{"type":"callback","value":"yes"},"style":"primary"}]}]}`.
exec approval-pending: native card/buttons first. Plain /approve only when tool requires chat/manual approval; copy exact "Reply with:" command.
capabilities=inlinebuttons
```

Both statements are now true for LINE. The `callback` action in that example maps to a LINE postback (`extensions/line/src/rich-messages.ts:138`), and the approval payload really does arrive as buttons — rendering the shipped payload through the shipped renderer:

```
$ buildExecApprovalPendingReplyPayload(...) -> renderLinePresentation(...)
channelData.line.flexMessage.contents.footer.contents:
  { "type": "button", "action": { "type": "message", "label": "Allow Once",   "text": "/approve <id> allow-once" } }
  { "type": "button", "action": { "type": "message", "label": "Allow Always", "text": "/approve <id> allow-always" } }
  { "type": "button", "action": { "type": "message", "label": "Deny",         "text": "/approve <id> deny" } }
```

**Suite, types, lint, format, ratchets.**

```
$ pnpm exec vitest run --config test/vitest/vitest.extension-line.config.ts
      Tests  722 passed (722)

$ pnpm exec vitest run src/agents/channel-tools src/agents/cli-runner/prepare.test.ts
      Tests  127 passed (127)

$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json --noEmit
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json --noEmit
$ node scripts/run-oxlint.mjs extensions/line/src
(all clean)

$ ./node_modules/.bin/oxfmt --check extensions/line/src/channel.ts extensions/line/src/channel.rich-messages.test.ts
All matched files use the correct format.

$ pnpm check:assertion-safety --base origin/main
assertion SAFETY ratchet OK: 4146 files, 12787 grandfathered assertions.

$ pnpm check:max-lines-ratchet --base origin/main
max-lines ratchet OK: 875 grandfathered suppressions.
```

Production delta is +5 lines, four of which are the comment explaining why the answer is unconditional.
