### PR TITLE
fix(sessions): avoid excessive history copies and preserve fork provenance

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -207,7 +207,6 @@ extensions/codex/src/app-server/reasoning-effort.ts	1
 extensions/codex/src/app-server/remote-workspace-media.ts	6
 extensions/codex/src/app-server/request.ts	2
 extensions/codex/src/app-server/run-attempt-context.ts	2
-extensions/codex/src/app-server/run-attempt-prompt.ts	2
 extensions/codex/src/app-server/run-attempt-resources.ts	13
 extensions/codex/src/app-server/run-attempt-runtime.ts	1
 extensions/codex/src/app-server/run-attempt-server-requests.ts	2
@@ -223,8 +222,7 @@ extensions/codex/src/app-server/sandbox-exec-server/processes.ts	1
 extensions/codex/src/app-server/sandbox-guard.ts	2
 extensions/codex/src/app-server/scheduled-app-authority.ts	5
 extensions/codex/src/app-server/session-binding.ts	4
-extensions/codex/src/app-server/session-history.ts	4
-extensions/codex/src/app-server/settled-turn-context.ts	3
+extensions/codex/src/app-server/settled-turn-context.ts	2
 extensions/codex/src/app-server/shared-client.ts	4
 extensions/codex/src/app-server/side-question.ts	8
 extensions/codex/src/app-server/startup-binding.ts	2
@@ -236,7 +234,7 @@ extensions/codex/src/app-server/transcript-history-projection.ts	2
 extensions/codex/src/app-server/transcript-mirror-attestation.ts	2
 extensions/codex/src/app-server/transcript-mirror.ts	4
 extensions/codex/src/app-server/transport-stdio.ts	1
-extensions/codex/src/app-server/upstream-fork-boundary.ts	2
+extensions/codex/src/app-server/upstream-fork-boundary.ts	1
 extensions/codex/src/app-server/usage-limit-error.ts	2
 extensions/codex/src/app-server/user-prompt-message.ts	1
 extensions/codex/src/command-handlers.ts	3
@@ -1459,7 +1457,6 @@ packages/agent-core/src/agent-loop.ts	3
 packages/agent-core/src/harness/compaction/branch-summarization.ts	1
 packages/agent-core/src/harness/compaction/compaction.ts	2
 packages/agent-core/src/harness/messages.ts	3
-packages/agent-core/src/harness/session/session.ts	1
 packages/agent-core/src/harness/session/tool-result-pairing.ts	17
 packages/agent-core/src/harness/session/uuid.ts	1
 packages/agent-core/src/harness/utils/truncate.ts	1
@@ -1791,7 +1788,7 @@ src/agents/embedded-agent-runner/run/attempt-finalize.ts	3
 src/agents/embedded-agent-runner/run/attempt-history.ts	17
 src/agents/embedded-agent-runner/run/attempt-llm-boundary.ts	19
 src/agents/embedded-agent-runner/run/attempt-normalization.ts	1
-src/agents/embedded-agent-runner/run/attempt-prompt-build.ts	2
+src/agents/embedded-agent-runner/run/attempt-prompt-build.ts	1
 src/agents/embedded-agent-runner/run/attempt-prompt-helpers.ts	4
 src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts	2
 src/agents/embedded-agent-runner/run/attempt-queue-message.ts	3

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -775,14 +775,23 @@ rejects canonical failure, tool, delivery, replay, and lifecycle evidence, then
 projects only the narrow result. It is defense in depth after native isolation,
 not a substitute for removing the native capability surface.
 
-A projection-backed harness must put the complete context on
-`settledAttempt.settledTurnFinalizationContext` with
-`source: "openclaw-transcript"`. It must capture the active branch after the
-settled turn is mirrored, prove that the current prompt and every current tool
-call/result are present through that boundary, and freeze the resulting message
-array before returning the attempt. The finalizer must reject a missing,
+A projection-backed harness must capture the active branch after the settled
+turn is mirrored and prove that the current prompt and every current tool
+call/result are present through that boundary. Put the frozen evidence on
+`settledAttempt.settledTurnFinalizationContext` as either:
+
+- `source: "openclaw-transcript"` with `messages`: the complete application
+  transcript through the boundary.
+- `source: "harness"` with `data`: an immutable, bounded projection interpreted
+  only by the owning harness. Core passes this opaque value through; the
+  finalizer must verify its own context type before using it.
+
+Enforce projection limits while acquiring messages, rather than cloning the
+whole transcript before checking its size. Successful capture must finish all
+identity and source-evidence checks before returning the attempt. Do not retain
+an open transcript reader in `data`. The finalizer must reject a missing,
 unsupported, ambiguous, or oversized context. It must not truncate messages,
-drop earlier history, or describe this application transcript as exact native
+drop earlier history, or describe an application projection as exact native
 history. Harnesses that resume one restricted native session do not need this
 projection field.
 

--- a/docs/plugins/sdk-agent-harness.md
+++ b/docs/plugins/sdk-agent-harness.md
@@ -778,13 +778,25 @@ not a substitute for removing the native capability surface.
 A projection-backed harness must capture the active branch after the settled
 turn is mirrored and prove that the current prompt and every current tool
 call/result are present through that boundary. Put the frozen evidence on
-`settledAttempt.settledTurnFinalizationContext` as either:
+`settledAttempt.settledTurnFinalizationContext` as one of:
 
 - `source: "openclaw-transcript"` with `messages`: the complete application
   transcript through the boundary.
 - `source: "harness"` with `data`: an immutable, bounded projection interpreted
   only by the owning harness. Core passes this opaque value through; the
   finalizer must verify its own context type before using it.
+- `source: "unavailable"`: the harness permits finalization for this settled
+  turn, but safe replay evidence could not be captured. The finalizer must
+  reject this state before provider or native I/O; core can still use its
+  existing host-owned fallback without repeating tools.
+
+The unavailable state records eligibility, not validated history. Eligible
+capture failures, including missing, drifting, or oversized evidence, can reach
+that no-model fallback. Do not emit it for failures the harness excludes from
+finalization, such as authentication or usage-limit errors. Command-only
+harnesses must retain the attributed assistant tool-call entry in
+`messagesSnapshot`; the host fallback can use that settled-batch identity when
+visible-assistant fields are absent.
 
 Enforce projection limits while acquiring messages, rather than cloning the
 whole transcript before checking its size. Successful capture must finish all

--- a/docs/reference/session-management-compaction.md
+++ b/docs/reference/session-management-compaction.md
@@ -156,7 +156,7 @@ Each `sessionKey` points at a current `sessionId` (the SQLite transcript identit
 - **System events** (heartbeat, cron wakeups, exec notifications, gateway bookkeeping) may mutate the session row but never extend daily/idle reset freshness. Reset rollover discards queued system-event notices for the previous session before the fresh prompt is built.
 - **Automatic parent fork policy** uses OpenClaw's active branch when creating a thread or subagent fork. If that branch is too large (over a fixed internal cap, currently 100K tokens), OpenClaw starts the child with isolated context instead of failing or inheriting unusable history. Sizing is automatic and not configurable; legacy `session.parentForkMaxTokens` config is removed by `openclaw doctor --fix`.
 - **Operator forks**: `sessions.create { parentSessionKey, fork: true }` branches from the parent's current state. Admission uses the selected child model's effective usable input capacity, falling back to the 100K safety cap when model capacity is unavailable. A normal fork is refused while the parent has an active run; adding `forkFrom: "last-completed"` copies only through the last completed assistant message, excluding the in-progress tail. Unlike automatic parent forks, an operator fork over its capacity limit is rejected rather than accepted with isolated context. The child inherits the parent's model selection unless one is passed explicitly. The response marks it `forkedFromParent`, and token counters start fresh.
-- **Message forks**: `sessions.fork { sessionKey, entryId }` creates a child from the active-path prefix before the selected user message and returns that message to the composer for editing. The parent remains unchanged. Incognito forks retain the parent's in-memory storage class; restarting the Gateway removes both sessions. See [Control UI](/web/control-ui) for fork and rewind actions.
+- **Message forks**: `sessions.fork { sessionKey, entryId }` creates a child from the active-path prefix before the selected user message and returns that message to the composer for editing. The parent remains unchanged. Incognito forks retain the parent's in-memory storage class; restarting the Gateway removes both sessions. Codex fork verification compares complete attested submitted prompts, including whitespace; the bounded display-import projection is not a substitute for that evidence. See [Control UI](/web/control-ui) for fork and rewind actions.
 
 ## Session store schema
 
@@ -205,6 +205,18 @@ Notable entry types:
 History readers keep the latest reset window across later compactions: explicitly retained reset messages and messages after that reset remain visible, but older messages and compaction summaries do not reappear. Model context follows the latest reset or compaction instead, so compaction can summarize the current conversation without reopening its earlier history.
 
 Model-only callers can use `SessionManager.openModelContext()` to create a detached, non-persisting view. The reader selects payloads in SQLite and retains lightweight navigation outside the model window, without introducing a history size cutoff. Storage-only native prompt text and tool-result details stay out of that view; mirror identity, sender and media facts, tool content, and valid provider replay state remain available. Native fork verification, replay, exports, and doctor operations continue to use full-fidelity evidence readers.
+
+`SessionManager.readSessionContext(target, read, { admission? })` lets a synchronous
+consumer process full-fidelity context messages inside one read-only snapshot.
+The callback receives `(messages, header)`: a lazy message iterable and the
+unvalidated stored header. Missing stores supply an empty iterable and no header
+without creating a database. An optional admission excludes the current admitted
+user row and later events. Callback errors propagate, and the iterator closes
+when the callback returns or throws; it cannot be retained for later reads.
+This lets replay consumers enforce their existing limits during acquisition
+without silently dropping earlier history. Navigation still scales with the
+transcript, and individual selected rows are decoded whole; this is not a fixed
+process-memory ceiling.
 
 OpenClaw intentionally does not "fix up" transcripts; the Gateway uses `SessionManager` to read/write them.
 

--- a/extensions/codex/src/app-server/run-attempt-finalize.ts
+++ b/extensions/codex/src/app-server/run-attempt-finalize.ts
@@ -359,16 +359,16 @@ export async function finalizeCodexAttempt(
     result.messagesSnapshot.some((message) => message.role === "toolResult") &&
     (!finalPromptError || activeProjector.settledTurnFailureFinalizationAllowed);
   const settledTurnFinalizationContext = shouldCaptureSettledTurnFinalizationContext
-    ? await captureCodexSettledTurnFinalizationContext({
+    ? ((await captureCodexSettledTurnFinalizationContext({
         ...activeTranscriptTarget,
         mirroredMessages: mirrorOutcome.mirroredMessages,
         settledMessages: result.messagesSnapshot,
         turnId: activeTurnId,
-      })
+      })) ?? Object.freeze({ source: "unavailable" as const }))
     : undefined;
-  if (shouldCaptureSettledTurnFinalizationContext && !settledTurnFinalizationContext) {
-    // The isolated child must not infer around a partial or drifting transcript.
-    // Omitting this field preserves the existing incomplete-turn failure.
+  if (settledTurnFinalizationContext?.source === "unavailable") {
+    // Unavailable evidence forbids native inference, but must not revoke this
+    // eligible turn's path to the existing host-owned fallback.
     embeddedAgentLog.warn("codex settled-turn finalization context is unavailable", {
       threadId: resourceState.thread.threadId,
       turnId: activeTurnId,

--- a/extensions/codex/src/app-server/run-attempt-prompt.ts
+++ b/extensions/codex/src/app-server/run-attempt-prompt.ts
@@ -32,8 +32,8 @@ import {
   codexDynamicToolsFingerprint,
   codexLegacyDynamicToolsFingerprint,
 } from "./thread-lifecycle.js";
-
-const CODEX_META_KEY = "__openclaw";
+import { hasCodexMirrorOrigin } from "./transcript-mirror-attestation.js";
+import { readMirrorIdentity } from "./upstream-prompt-provenance.js";
 
 function isRestrictivePromptToolsAllow(toolsAllow: string[] | undefined): boolean {
   return toolsAllow !== undefined && !toolsAllow.some((name) => name.trim() === "*");
@@ -343,15 +343,7 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
       if (message.role !== "user" && message.role !== "assistant") {
         return false;
       }
-      const meta = CODEX_META_KEY in message ? message[CODEX_META_KEY] : undefined;
-      const mirrorIdentity =
-        meta && typeof meta === "object" && !Array.isArray(meta)
-          ? (meta as Record<string, unknown>).mirrorIdentity
-          : undefined;
-      const mirrorOrigin =
-        meta && typeof meta === "object" && !Array.isArray(meta)
-          ? (meta as Record<string, unknown>).mirrorOrigin
-          : undefined;
+      const mirrorIdentity = readMirrorIdentity(message);
       const timestamp =
         typeof message.timestamp === "number"
           ? message.timestamp
@@ -364,8 +356,8 @@ export async function prepareCodexAttemptPrompt(context: CodexAttemptContext) {
           typeof message.idempotencyKey === "string" &&
           message.idempotencyKey.startsWith("codex-app-server:")
         ) &&
-        mirrorOrigin !== "codex-app-server" &&
-        !(typeof mirrorIdentity === "string" && mirrorIdentity.startsWith("codex-app-server:")) &&
+        !hasCodexMirrorOrigin(message) &&
+        !mirrorIdentity?.startsWith("codex-app-server:") &&
         Number.isFinite(timestamp) &&
         timestamp > (Number.isFinite(cutoff) ? cutoff : 0)
       );

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -4854,14 +4854,14 @@ describe("runCodexAppServerAttempt", () => {
       expect(Boolean(result.settledTurnFinalizationContext)).toBe(expectedContext);
       if (result.settledTurnFinalizationContext) {
         expect(result.settledTurnFinalizationContext).toMatchObject({
-          source: "openclaw-transcript",
-          messages: [
+          source: "harness",
+          data: [
             expect.objectContaining({ role: "user" }),
-            expect.objectContaining({ role: "assistant" }),
-            expect.objectContaining({ role: "toolResult", toolCallId: "tool-settled" }),
+            expect.objectContaining({ type: "function_call" }),
+            expect.objectContaining({ type: "function_call_output", call_id: "tool-settled" }),
           ],
         });
-        expect(Object.isFrozen(result.settledTurnFinalizationContext.messages)).toBe(true);
+        expect(Object.isFrozen(result.settledTurnFinalizationContext)).toBe(true);
       }
     },
   );
@@ -4933,14 +4933,14 @@ describe("runCodexAppServerAttempt", () => {
     });
     expect(result.itemLifecycle).toEqual({ startedCount: 1, completedCount: 1, activeCount: 0 });
     expect(result.settledTurnFinalizationContext).toMatchObject({
-      source: "openclaw-transcript",
-      messages: [
+      source: "harness",
+      data: [
         expect.objectContaining({ role: "user" }),
-        expect.objectContaining({ role: "assistant" }),
-        expect.objectContaining({ role: "toolResult", toolCallId: "tool-settled" }),
+        expect.objectContaining({ type: "function_call" }),
+        expect.objectContaining({ type: "function_call_output", call_id: "tool-settled" }),
       ],
     });
-    expect(Object.isFrozen(result.settledTurnFinalizationContext?.messages)).toBe(true);
+    expect(Object.isFrozen(result.settledTurnFinalizationContext)).toBe(true);
   });
   it("preserves every command failure from official app-server events", async () => {
     const sessionFile = path.join(tempDir, "session-multi-command-failure.jsonl");

--- a/extensions/codex/src/app-server/run-attempt.test.ts
+++ b/extensions/codex/src/app-server/run-attempt.test.ts
@@ -4775,35 +4775,39 @@ describe("runCodexAppServerAttempt", () => {
     });
   });
 
-  it.each([
-    { label: "completed turn", failure: undefined, expectedContext: true },
-    {
-      label: "provider overload after the tool result",
-      failure: {
-        message: "Selected model is at capacity. Please try a different model.",
-        codexErrorInfo: "serverOverloaded",
+  it.each(
+    [
+      { label: "completed turn", failure: undefined, expectedContext: true },
+      {
+        label: "provider overload after the tool result",
+        failure: {
+          message: "Selected model is at capacity. Please try a different model.",
+          codexErrorInfo: "serverOverloaded",
+        },
+        expectedContext: true,
       },
-      expectedContext: true,
-    },
-    {
-      label: "usage limit after the tool result",
-      failure: {
-        message: "Usage limit exceeded.",
-        codexErrorInfo: "usageLimitExceeded",
+      {
+        label: "usage limit after the tool result",
+        failure: {
+          message: "Usage limit exceeded.",
+          codexErrorInfo: "usageLimitExceeded",
+        },
+        expectedContext: false,
       },
-      expectedContext: false,
-    },
-    {
-      label: "unauthorized response after the tool result",
-      failure: {
-        message: "Unauthorized.",
-        codexErrorInfo: "unauthorized",
+      {
+        label: "unauthorized response after the tool result",
+        failure: {
+          message: "Unauthorized.",
+          codexErrorInfo: "unauthorized",
+        },
+        expectedContext: false,
       },
-      expectedContext: false,
-    },
-  ])(
-    "captures the complete mirrored branch through a settled tool-result boundary for a $label",
-    async ({ failure, expectedContext }) => {
+    ].flatMap((scenario) =>
+      [false, true].map((oversizedHistory) => ({ scenario, oversizedHistory })),
+    ),
+  )(
+    "preserves settled finalization eligibility for a $scenario.label (oversized history: $oversizedHistory)",
+    async ({ scenario: { failure, expectedContext }, oversizedHistory }) => {
       const storePath = path.join(tempDir, "settled-finalization-context.sqlite");
       const sessionId = "session-settled-finalization-context";
       const sessionFile = `agent:main:${sessionId}`;
@@ -4811,9 +4815,20 @@ describe("runCodexAppServerAttempt", () => {
       const harness = createStartedThreadHarness();
       const params = createParams(sessionFile, workspaceDir);
       await attachSqliteSessionTarget(params, storePath, sessionId);
+      if (oversizedHistory) {
+        for (let index = 0; index < 201; index += 1) {
+          await appendSqliteHistoryMessage(
+            params,
+            userMessage(`Prior message ${index}`, index + 1),
+          );
+        }
+      }
       params.prompt = "Send the update to Alice.";
       const run = runCodexAppServerAttempt(params);
       await harness.waitForMethod("turn/start");
+      const emptyAssistant = { type: "agentMessage", id: "empty-assistant", text: "" };
+      await harness.notify(itemNotification("item/started", emptyAssistant));
+      await harness.notify(itemNotification("item/completed", emptyAssistant));
       await harness.notify(
         itemNotification("item/started", {
           type: "commandExecution",
@@ -4852,7 +4867,20 @@ describe("runCodexAppServerAttempt", () => {
       const result = await run;
       expect(Boolean(readAttemptTerminal(result).promptError)).toBe(Boolean(failure));
       expect(Boolean(result.settledTurnFinalizationContext)).toBe(expectedContext);
-      if (result.settledTurnFinalizationContext) {
+      expect(result.currentAttemptAssistant).toBeDefined();
+      expect(result.replayMetadata).toMatchObject({
+        hadPotentialSideEffects: true,
+        replaySafe: false,
+      });
+      expect(result.itemLifecycle).toMatchObject({
+        startedCount: 2,
+        completedCount: 2,
+        activeCount: 0,
+      });
+      if (expectedContext && oversizedHistory) {
+        expect(result.settledTurnFinalizationContext).toEqual({ source: "unavailable" });
+        expect(Object.isFrozen(result.settledTurnFinalizationContext)).toBe(true);
+      } else if (result.settledTurnFinalizationContext) {
         expect(result.settledTurnFinalizationContext).toMatchObject({
           source: "harness",
           data: [

--- a/extensions/codex/src/app-server/session-history.test.ts
+++ b/extensions/codex/src/app-server/session-history.test.ts
@@ -3,12 +3,18 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { CURRENT_SESSION_VERSION } from "openclaw/plugin-sdk/agent-sessions";
 import { upsertSessionEntry } from "openclaw/plugin-sdk/session-store-runtime";
 import { appendSessionTranscriptMessageByIdentity } from "openclaw/plugin-sdk/session-transcript-runtime";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { readCodexMirroredSessionHistoryMessages } from "./session-history.js";
-import { readMirrorIdentity, readUpstreamUserText } from "./upstream-prompt-provenance.js";
+import { captureCodexSettledTurnFinalizationContext } from "./settled-turn-context.js";
+import {
+  attachCodexMirrorIdentity,
+  readMirrorIdentity,
+  readUpstreamUserText,
+} from "./upstream-prompt-provenance.js";
 
 const tempDirs: string[] = [];
 
@@ -132,6 +138,71 @@ async function writeSqliteSession(params: { storedSessionFile?: string } = {}): 
 }
 
 describe("readCodexMirroredSessionHistoryMessages", () => {
+  it("rejects oversized settled history before acquiring later transcript payloads", async () => {
+    const { marker, sessionTarget } = await writeSqliteSession();
+    for (let index = 0; index < 201; index += 1) {
+      await appendSessionTranscriptMessageByIdentity({
+        ...sessionTarget,
+        message: { role: "user", content: `prior-${index}`, timestamp: index + 3 },
+      });
+    }
+    const unreadMarker = "synthetic-unread-settled-payload:";
+    await appendSessionTranscriptMessageByIdentity({
+      ...sessionTarget,
+      message: { role: "user", content: unreadMarker + "x".repeat(1024 * 1024), timestamp: 205 },
+    });
+    const settledMessages = [
+      attachCodexMirrorIdentity(
+        { role: "user", content: "Send the synthetic update.", timestamp: 206 },
+        "settled:prompt",
+      ),
+      attachCodexMirrorIdentity(
+        {
+          role: "assistant",
+          content: [{ type: "toolCall", id: "sent", name: "message", arguments: {} }],
+          timestamp: 207,
+        } as AgentMessage,
+        "settled:tool:sent:call",
+      ),
+      attachCodexMirrorIdentity(
+        {
+          role: "toolResult",
+          toolCallId: "sent",
+          toolName: "message",
+          isError: false,
+          content: [{ type: "text", text: "Synthetic update sent." }],
+          timestamp: 208,
+        },
+        "settled:tool:sent:result",
+      ),
+    ];
+    for (const message of settledMessages) {
+      await appendSessionTranscriptMessageByIdentity({ ...sessionTarget, message });
+    }
+    const originalParse = JSON.parse;
+    let laterPayloadReads = 0;
+    const parse = vi.spyOn(JSON, "parse").mockImplementation((text, reviver) => {
+      if (typeof text === "string" && text.includes(unreadMarker)) {
+        laterPayloadReads += 1;
+      }
+      return originalParse(text, reviver);
+    });
+    try {
+      const captured = await captureCodexSettledTurnFinalizationContext({
+        ...sessionTarget,
+        sessionTarget,
+        sessionFile: marker,
+        settledMessages,
+        mirroredMessages: settledMessages,
+        turnId: "settled",
+      });
+      expect(captured === undefined).toBe(true);
+      expect(laterPayloadReads).toBe(0);
+    } finally {
+      parse.mockRestore();
+    }
+  });
+
   it("preserves native prompt evidence across explicit model-only reads", async () => {
     const { marker, sessionTarget } = await writeSqliteSession();
     const upstreamUserText = "synthetic-native-prompt:" + "x".repeat(1024 * 1024);

--- a/extensions/codex/src/app-server/session-history.ts
+++ b/extensions/codex/src/app-server/session-history.ts
@@ -1,7 +1,4 @@
-/**
- * Reads OpenClaw session history for Codex transcript mirroring and sanitizes
- * image payloads before replaying messages into the app-server projector.
- */
+/** Reads model context separately from full-fidelity Codex mirror evidence. */
 import fs from "node:fs/promises";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-harness-runtime";
 import type { SessionEntry } from "openclaw/plugin-sdk/agent-sessions";
@@ -11,24 +8,20 @@ import {
   parseSessionEntries,
   SessionManager,
 } from "openclaw/plugin-sdk/agent-sessions";
-import { readCodexSessionTranscriptEventsBeforeAdmission } from "openclaw/plugin-sdk/codex-session-transcript-runtime";
 import {
   getSessionEntry,
   parseSqliteSessionFileMarker,
   resolveTranscriptSessionKeyBySessionId,
   type SqliteSessionFileMarker,
 } from "openclaw/plugin-sdk/session-store-runtime";
-import {
-  readSessionTranscriptEvents,
-  type TranscriptTurnAdmission,
-  type SessionTranscriptTargetParams,
+import type {
+  TranscriptTurnAdmission,
+  SessionTranscriptTargetParams,
 } from "openclaw/plugin-sdk/session-transcript-runtime";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { sanitizeCodexHistoryImagePayloads } from "./image-payload-sanitizer.js";
 
-function isMissingFileError(error: unknown): boolean {
-  return Boolean(error && typeof error === "object" && "code" in error && error.code === "ENOENT");
-}
-
+type CodexHistoryView = "native-evidence" | "model-context";
 export type CodexMirroredSessionHistoryTarget = {
   agentId?: string;
   sessionFile: string;
@@ -37,138 +30,134 @@ export type CodexMirroredSessionHistoryTarget = {
   sessionTarget?: Partial<SessionTranscriptTargetParams>;
 };
 
-/** Returns sanitized session-context messages for a Codex mirrored session file. */
+/** Returns sanitized session-context messages for consumers that need an owned array. */
 export async function readCodexMirroredSessionHistoryMessages(
   target: CodexMirroredSessionHistoryTarget,
   admission?: TranscriptTurnAdmission,
-  view: "native-evidence" | "model-context" = "native-evidence",
+  view: CodexHistoryView = "native-evidence",
 ): Promise<AgentMessage[] | undefined> {
-  try {
-    const loaded = await readCodexMirroredSessionEntries(target, admission, view);
-    if (!Array.isArray(loaded)) {
-      if (loaded.getHeader()?.id !== target.sessionId) {
-        return [];
-      }
-      return sanitizeCodexHistoryImagePayloads(
-        loaded.buildSessionContext().messages,
-        "codex mirrored model context",
-      );
-    }
-    const entries = loaded;
-    if (entries.length === 0) {
-      return [];
-    }
-    const firstEntry = entries[0] as { type?: unknown; id?: unknown } | undefined;
-    if (firstEntry?.type !== "session") {
-      // A well-formed transcript that does not open with a `session` marker is
-      // simply not a Codex-mirrored session (e.g. a non-Codex model run reusing
-      // this hook) — an empty mirror, not a read failure, so callers must not
-      // warn. `undefined` stays reserved for genuine failures: read/parse errors
-      // (caught below) and malformed `session` headers (next check).
-      return [];
-    }
-    if (typeof firstEntry.id !== "string") {
-      // A `session` header without a string id is a corrupted Codex transcript,
-      // not a foreign one — keep it on the warn path.
-      return undefined;
-    }
-    if (firstEntry.id !== target.sessionId) {
-      return [];
-    }
-    migrateSessionEntries(entries);
-    const sessionEntries = entries.filter((entry): entry is SessionEntry => {
-      return (
-        entry !== null &&
-        typeof entry === "object" &&
-        !Array.isArray(entry) &&
-        (entry as { type?: unknown }).type !== "session"
-      );
-    });
-    return sanitizeCodexHistoryImagePayloads(
-      buildSessionContext(sessionEntries).messages,
-      "codex mirrored history",
-    );
-  } catch (error) {
-    // A new Codex session can be read before its transcript exists; other failures still warn.
-    if (isMissingFileError(error)) {
-      return [];
-    }
-    return undefined;
-  }
+  return readCodexMirroredSessionHistory(
+    target,
+    (messages) => Array.from(messages),
+    admission,
+    view,
+  );
 }
 
-async function readCodexMirroredSessionEntries(
+/** The synchronous consumer can reject before further SQLite message payloads are acquired. */
+export async function readCodexMirroredSessionHistory<T>(
   target: CodexMirroredSessionHistoryTarget,
-  admission: TranscriptTurnAdmission | undefined,
-  view: "native-evidence" | "model-context",
-): Promise<SessionEntry[] | SessionManager> {
-  const readTarget = async (
+  read: (messages: Iterable<AgentMessage>) => T,
+  admission?: TranscriptTurnAdmission,
+  view: CodexHistoryView = "native-evidence",
+): Promise<T | undefined> {
+  const consume = (
+    messages: Iterable<AgentMessage>,
+    header: unknown,
+    imageLabel = "codex mirrored history",
+  ): T | undefined => {
+    // Foreign or absent headers are empty history; malformed session headers are read failures.
+    if (!isRecord(header) || header.type !== "session") {
+      return read([]);
+    }
+    if (typeof header.id !== "string") {
+      return undefined;
+    }
+    if (header.id !== target.sessionId) {
+      return read([]);
+    }
+    return read(
+      (function* () {
+        for (const message of messages) {
+          yield sanitizeCodexHistoryImagePayloads(message, imageLabel);
+        }
+      })(),
+    );
+  };
+  const readTarget = (
     transcriptTarget: Required<
       Pick<SessionTranscriptTargetParams, "agentId" | "sessionId" | "sessionKey" | "storePath">
     >,
-  ) =>
-    view === "model-context"
-      ? SessionManager.openModelContext(transcriptTarget, { admission })
-      : ((await (admission
-          ? readCodexSessionTranscriptEventsBeforeAdmission(transcriptTarget, admission)
-          : readSessionTranscriptEvents(transcriptTarget))) as SessionEntry[]);
-  if (target.sessionTarget) {
-    const { agentId, sessionId, sessionKey, storePath } = target.sessionTarget;
-    if (
-      !agentId ||
-      !sessionId ||
-      !sessionKey ||
-      !storePath ||
-      sessionId !== target.sessionId ||
-      (target.agentId !== undefined && agentId !== target.agentId) ||
-      (target.sessionKey !== undefined && sessionKey !== target.sessionKey)
-    ) {
-      return [];
+  ) => {
+    if (view === "native-evidence") {
+      return SessionManager.readSessionContext(transcriptTarget, consume, { admission });
     }
-    const transcriptTarget = {
-      agentId,
-      sessionId,
-      sessionKey,
-      storePath,
-    };
-    return readTarget(transcriptTarget);
+    const loaded = SessionManager.openModelContext(transcriptTarget, { admission });
+    return consume(
+      loaded.buildSessionContext().messages,
+      loaded.getHeader(),
+      "codex mirrored model context",
+    );
+  };
+  try {
+    if (target.sessionTarget) {
+      const { agentId, sessionId, sessionKey, storePath } = target.sessionTarget;
+      if (
+        !agentId ||
+        !sessionId ||
+        !sessionKey ||
+        !storePath ||
+        sessionId !== target.sessionId ||
+        (target.agentId !== undefined && agentId !== target.agentId) ||
+        (target.sessionKey !== undefined && sessionKey !== target.sessionKey)
+      ) {
+        return read([]);
+      }
+      return readTarget({ agentId, sessionId, sessionKey, storePath });
+    }
+    const sqliteMarker = parseSqliteSessionFileMarker(target.sessionFile);
+    if (sqliteMarker) {
+      if (
+        sqliteMarker.sessionId !== target.sessionId ||
+        (target.agentId !== undefined && sqliteMarker.agentId !== target.agentId)
+      ) {
+        return read([]);
+      }
+      const sessionKey = resolveSqliteMarkerSessionKey(target, sqliteMarker);
+      if (!sessionKey) {
+        return read([]);
+      }
+      return readTarget({
+        agentId: sqliteMarker.agentId,
+        sessionId: sqliteMarker.sessionId,
+        sessionKey,
+        storePath: sqliteMarker.storePath,
+      });
+    }
+    if (admission) {
+      if (
+        admission.sessionId !== target.sessionId ||
+        (target.agentId !== undefined && admission.agentId !== target.agentId) ||
+        (target.sessionKey !== undefined && admission.sessionKey !== target.sessionKey)
+      ) {
+        return read([]);
+      }
+      return readTarget({
+        agentId: admission.agentId,
+        sessionId: admission.sessionId,
+        sessionKey: admission.sessionKey,
+        storePath: admission.storePath,
+      });
+    }
+    // File-only callers retain the legacy import codec; runtime identities never read this path.
+    const entries = parseSessionEntries(await fs.readFile(target.sessionFile, "utf-8"));
+    return consume(
+      (function* () {
+        migrateSessionEntries(entries);
+        const sessionEntries = entries.filter(
+          (entry): entry is SessionEntry => isRecord(entry) && entry.type !== "session",
+        );
+        yield* buildSessionContext(sessionEntries).messages;
+      })(),
+      entries[0],
+    );
+  } catch (error) {
+    // A new session can be read before its transcript exists; other failures still warn.
+    if (isRecord(error) && error.code === "ENOENT") {
+      return read([]);
+    }
+    return undefined;
   }
-  const sqliteMarker = parseSqliteSessionFileMarker(target.sessionFile);
-  if (sqliteMarker) {
-    if (
-      sqliteMarker.sessionId !== target.sessionId ||
-      (target.agentId !== undefined && sqliteMarker.agentId !== target.agentId)
-    ) {
-      return [];
-    }
-    const sessionKey = resolveSqliteMarkerSessionKey(target, sqliteMarker);
-    if (!sessionKey) {
-      return [];
-    }
-    const transcriptTarget = {
-      agentId: sqliteMarker.agentId,
-      sessionId: sqliteMarker.sessionId,
-      sessionKey,
-      storePath: sqliteMarker.storePath,
-    };
-    return readTarget(transcriptTarget);
-  }
-  if (admission) {
-    if (
-      admission.sessionId !== target.sessionId ||
-      (target.agentId !== undefined && admission.agentId !== target.agentId) ||
-      (target.sessionKey !== undefined && admission.sessionKey !== target.sessionKey)
-    ) {
-      return [];
-    }
-    return readTarget({
-      agentId: admission.agentId,
-      sessionId: admission.sessionId,
-      sessionKey: admission.sessionKey,
-      storePath: admission.storePath,
-    });
-  }
-  return parseSessionEntries(await fs.readFile(target.sessionFile, "utf-8")) as SessionEntry[];
 }
 
 function resolveSqliteMarkerSessionKey(

--- a/extensions/codex/src/app-server/settled-turn-context.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-context.test.ts
@@ -14,7 +14,7 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("./session-history.js", () => ({
-  readCodexMirroredSessionHistoryMessages: mocks.readHistory,
+  readCodexMirroredSessionHistory: mocks.readHistory,
 }));
 
 function message(value: unknown, identity: string): AgentMessage {
@@ -73,7 +73,9 @@ async function captureContext(params: {
   settledMessages: AgentMessage[];
   turnId?: string;
 }) {
-  mocks.readHistory.mockResolvedValue(params.historyMessages);
+  mocks.readHistory.mockImplementation(
+    (_target, read: (messages: Iterable<AgentMessage>) => unknown) => read(params.historyMessages),
+  );
   return captureCodexSettledTurnFinalizationContext({
     sessionFile: "/tmp/session.jsonl",
     sessionId: "session-1",
@@ -101,12 +103,20 @@ describe("captureCodexSettledTurnFinalizationContext", () => {
       turnId: "turn-2",
     });
 
-    expect(context).toEqual({
-      source: "openclaw-transcript",
-      messages: [prior, ...settledMessages],
-    });
-    expect(Object.isFrozen(context?.messages)).toBe(true);
-    expect(context?.messages).not.toBe(historyMessages);
+    Object.assign(prior, { content: "changed after capture" });
+    expect(context?.data).toEqual([
+      {
+        type: "message",
+        role: "user",
+        content: [{ type: "input_text", text: "Alice is the recipient." }],
+      },
+      { type: "message", role: "user", content: [{ type: "input_text", text: "Send it." }] },
+      { type: "function_call", call_id: "call-2", name: "message", arguments: "{}" },
+      { type: "function_call_output", call_id: "call-2", output: "sent" },
+    ]);
+    expect(Object.isFrozen(context)).toBe(true);
+    expect(Object.isFrozen(context?.data)).toBe(true);
+    expect(Object.isFrozen(context?.data[0])).toBe(true);
   });
 
   it("adopts an exact host-persisted prompt without rewriting its canonical metadata", async () => {
@@ -114,12 +124,14 @@ describe("captureCodexSettledTurnFinalizationContext", () => {
 
     const context = await captureContext(turn);
 
-    expect(context).toEqual({ source: "openclaw-transcript", messages: turn.historyMessages });
-    expect(Object.isFrozen(context?.messages)).toBe(true);
-    expect(context?.messages[0]).toEqual(persistedPrompt);
-    expect(readMirrorIdentity(context!.messages[0]!)).toBeUndefined();
-    expect(readUpstreamUserText(context!.messages[0]!)).toBeUndefined();
-    expect(context?.messages[0]).toMatchObject({
+    expect(context?.data[0]).toEqual({
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text: "Send it." }],
+    });
+    expect(readMirrorIdentity(persistedPrompt)).toBeUndefined();
+    expect(readUpstreamUserText(persistedPrompt)).toBeUndefined();
+    expect(persistedPrompt).toMatchObject({
       __openclaw: { senderIsOwner: true, transport: { messageId: "transport-message" } },
     });
   });
@@ -142,8 +154,15 @@ describe("captureCodexSettledTurnFinalizationContext", () => {
       change: (prompt: AgentMessage) => attachCodexMirrorIdentity(prompt, "foreign-turn:prompt"),
     },
     {
-      name: "stale Codex mirror attestation",
-      change: (prompt: AgentMessage) => attachCodexMirrorAttestation(prompt, "stale-fingerprint"),
+      name: "Codex mirror origin without a fingerprint",
+      change: (prompt: AgentMessage) => attachCodexMirrorAttestation(prompt),
+    },
+    {
+      name: "Codex source fingerprint without an origin",
+      change: (prompt: AgentMessage) => ({
+        ...prompt,
+        __openclaw: { mirrorSourceFingerprint: "stale-fingerprint" },
+      }),
     },
     {
       name: "conflicting upstream prompt",
@@ -157,12 +176,18 @@ describe("captureCodexSettledTurnFinalizationContext", () => {
     await expect(captureContext(turn)).resolves.toBeUndefined();
   });
 
-  it("rejects duplicate host-persisted prompt idempotency keys", async () => {
-    const turn = settledHostPromptTurn();
-    turn.historyMessages.unshift({ ...turn.persistedPrompt });
-
-    await expect(captureContext(turn)).resolves.toBeUndefined();
-  });
+  it.each(["before", "after"])(
+    "rejects duplicate host prompt keys %s the settled boundary",
+    async (position) => {
+      const turn = settledHostPromptTurn();
+      if (position === "before") {
+        turn.historyMessages.unshift({ ...turn.persistedPrompt });
+      } else {
+        turn.historyMessages.push({ ...turn.persistedPrompt });
+      }
+      await expect(captureContext(turn)).resolves.toBeUndefined();
+    },
+  );
 
   it.each([
     {
@@ -246,17 +271,39 @@ describe("captureCodexSettledTurnFinalizationContext", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("contains transcript clone failures after tools have settled", async () => {
+  it("retains replay evidence without copying storage-only tool details", async () => {
     const historyMessages = settledTurn();
-    Object.assign(historyMessages[2]!, { uncloneable: () => undefined });
-    mocks.readHistory.mockResolvedValue(historyMessages);
+    Object.assign(historyMessages[2]!, { details: { payload: "x".repeat(1024 * 1024) } });
+    const context = await captureContext({
+      historyMessages,
+      mirroredMessages: historyMessages,
+      settledMessages: historyMessages,
+    });
+    expect(context?.data.at(-1)).toEqual({
+      type: "function_call_output",
+      call_id: "call-2",
+      output: "sent",
+    });
+    expect(JSON.stringify(context).length).toBeLessThan(1024);
+  });
 
+  it("rejects a read failure after the complete prefix instead of accepting partial verification", async () => {
+    const settledMessages = settledTurn();
+    mocks.readHistory.mockImplementation(
+      (_target, read: (messages: Iterable<AgentMessage>) => unknown) =>
+        read(
+          (function* () {
+            yield* settledMessages;
+            throw new Error("synthetic suffix read failure");
+          })(),
+        ),
+    );
     await expect(
       captureCodexSettledTurnFinalizationContext({
         sessionFile: "/tmp/session.jsonl",
         sessionId: "session-1",
-        mirroredMessages: historyMessages,
-        settledMessages: historyMessages,
+        mirroredMessages: settledMessages,
+        settledMessages,
         turnId: "turn-2",
       }),
     ).resolves.toBeUndefined();

--- a/extensions/codex/src/app-server/settled-turn-context.ts
+++ b/extensions/codex/src/app-server/settled-turn-context.ts
@@ -3,12 +3,14 @@ import {
   formatErrorMessage,
   type AgentMessage,
 } from "openclaw/plugin-sdk/agent-harness-runtime";
-import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
+import type { JsonValue } from "./protocol.js";
 import {
-  readCodexMirroredSessionHistoryMessages,
+  readCodexMirroredSessionHistory,
   type CodexMirroredSessionHistoryTarget,
 } from "./session-history.js";
+import { projectSettledCodexMessages } from "./settled-turn-projection.js";
 import {
+  hasCodexMirrorOrigin,
   readCodexMirrorSourceFingerprint,
   serializeCodexMirrorSourceEvidence,
 } from "./transcript-mirror-attestation.js";
@@ -19,188 +21,163 @@ import {
   readUpstreamUserText,
 } from "./upstream-prompt-provenance.js";
 
-type SettledTurnFinalizationContext = EmbeddedRunAttemptResult["settledTurnFinalizationContext"];
-
-function collectUniqueMessageIdentities(
-  messages: readonly AgentMessage[],
-): Map<string, number> | undefined {
-  const identities = new Map<string, number>();
-  for (const [index, message] of messages.entries()) {
-    const identity = readMirrorIdentity(message);
-    if (!identity) {
-      continue;
+function freezeProjection(value: JsonValue): void {
+  if (value !== null && typeof value === "object") {
+    for (const child of Object.values(value)) {
+      freezeProjection(child);
     }
-    if (identities.has(identity)) {
-      return undefined;
-    }
-    identities.set(identity, index);
+    Object.freeze(value);
   }
-  return identities;
 }
 
-function adoptPersistedHostPrompt(params: {
-  historyMessages: readonly AgentMessage[];
+/** Only the Codex owner interprets this bounded, detached replay projection. */
+export class CodexSettledTurnContext {
+  readonly source = "harness";
+
+  constructor(readonly data: JsonValue[]) {
+    freezeProjection(data);
+    Object.freeze(this);
+  }
+}
+
+type SettledTurnMessages = {
   mirroredMessages: readonly AgentMessage[];
   settledMessages: readonly AgentMessage[];
   turnId: string;
-}): { historyMessages: readonly AgentMessage[]; mirroredMessages: readonly AgentMessage[] } {
+};
+
+function rejectEvidence(): never {
+  throw new Error("Codex settled-turn transcript does not match the settled turn");
+}
+
+function adoptPersistedHostPrompt(message: AgentMessage, source: AgentMessage): AgentMessage {
+  const sourceText = readUpstreamUserText(source);
+  const persistedText = readUpstreamUserText(message);
+  if (
+    readMirrorIdentity(message) !== undefined ||
+    readCodexMirrorSourceFingerprint(message) !== undefined ||
+    hasCodexMirrorOrigin(message) ||
+    (persistedText !== undefined && persistedText !== sourceText)
+  ) {
+    rejectEvidence();
+  }
+  let logical = attachCodexMirrorIdentity(message, readMirrorIdentity(source)!);
+  if (sourceText !== undefined) {
+    logical = attachUpstreamUserText(logical, sourceText);
+  }
+  if (serializeCodexMirrorSourceEvidence(logical) !== serializeCodexMirrorSourceEvidence(source)) {
+    rejectEvidence();
+  }
+  return logical;
+}
+
+/** Yields only the settled prefix, but exhausts suffix identity checks before accepting it. */
+function* verifiedSettledMessages(
+  history: Iterable<AgentMessage>,
+  params: SettledTurnMessages,
+): Generator<AgentMessage> {
   const promptIdentity = `${params.turnId}:prompt`;
-  if (params.mirroredMessages.some((message) => readMirrorIdentity(message) === promptIdentity)) {
-    return params;
+  const boundaryIndex = params.settledMessages.findLastIndex(
+    (message) => message.role === "toolResult",
+  );
+  const boundary = params.settledMessages[boundaryIndex];
+  const boundaryIdentity = boundary && readMirrorIdentity(boundary);
+  const requiredIds = params.settledMessages
+    .slice(0, boundaryIndex + 1)
+    .flatMap((message) => readMirrorIdentity(message) ?? []);
+  if (
+    !boundaryIdentity?.startsWith(`${params.turnId}:tool:`) ||
+    requiredIds.length !== boundaryIndex + 1 ||
+    new Set(requiredIds).size !== requiredIds.length ||
+    !requiredIds.includes(promptIdentity)
+  ) {
+    rejectEvidence();
   }
   const sourcePrompt = params.settledMessages[0];
   const sourceKey = (sourcePrompt as { idempotencyKey?: unknown } | undefined)?.idempotencyKey;
-  if (
-    sourcePrompt?.role !== "user" ||
-    readMirrorIdentity(sourcePrompt) !== promptIdentity ||
-    typeof sourceKey !== "string" ||
-    sourceKey.trim().length === 0
-  ) {
-    return params;
-  }
-  const matches = params.historyMessages.flatMap((message, index) =>
-    message.role === "user" &&
-    (message as { idempotencyKey?: unknown }).idempotencyKey === sourceKey
-      ? [{ index, message }]
-      : [],
+  const adoption =
+    !params.mirroredMessages.some((message) => readMirrorIdentity(message) === promptIdentity) &&
+    sourcePrompt?.role === "user" &&
+    readMirrorIdentity(sourcePrompt) === promptIdentity &&
+    typeof sourceKey === "string" &&
+    sourceKey.trim().length > 0
+      ? { prompt: sourcePrompt, key: sourceKey }
+      : undefined;
+  const mirrored = adoption
+    ? [adoption.prompt, ...params.mirroredMessages]
+    : params.mirroredMessages;
+  const mirroredIds = mirrored.flatMap((message) => readMirrorIdentity(message) ?? []);
+  const mirroredBoundaryIndex = mirrored.findIndex(
+    (message) => readMirrorIdentity(message) === boundaryIdentity,
   );
-  const persistedPrompt = matches.length === 1 ? matches[0] : undefined;
-  const persistedMetadata = persistedPrompt?.message as
-    | { __openclaw?: { mirrorOrigin?: unknown } }
-    | undefined;
   if (
-    !persistedPrompt ||
-    readMirrorIdentity(persistedPrompt.message) !== undefined ||
-    readCodexMirrorSourceFingerprint(persistedPrompt.message) !== undefined ||
-    persistedMetadata?.["__openclaw"]?.mirrorOrigin === "codex-app-server"
+    new Set(mirroredIds).size !== mirroredIds.length ||
+    mirroredBoundaryIndex + 1 !== requiredIds.length ||
+    requiredIds.some((id, index) => readMirrorIdentity(mirrored[index]!) !== id)
   ) {
-    return params;
+    rejectEvidence();
   }
-  const sourceUpstreamText = readUpstreamUserText(sourcePrompt);
-  const persistedUpstreamText = readUpstreamUserText(persistedPrompt.message);
-  if (persistedUpstreamText !== undefined && persistedUpstreamText !== sourceUpstreamText) {
-    return params;
-  }
-  let logicalPrompt = attachCodexMirrorIdentity(persistedPrompt.message, promptIdentity);
-  if (sourceUpstreamText !== undefined) {
-    logicalPrompt = attachUpstreamUserText(logicalPrompt, sourceUpstreamText);
-  }
-  if (
-    serializeCodexMirrorSourceEvidence(logicalPrompt) !==
-    serializeCodexMirrorSourceEvidence(sourcePrompt)
-  ) {
-    return params;
-  }
-  // Host-owned prompts are authoritative by durable turn key; adopt their identity
-  // only in verification views so canonical channel metadata remains untouched.
-  const historyMessages = [...params.historyMessages];
-  historyMessages[persistedPrompt.index] = logicalPrompt;
-  return { historyMessages, mirroredMessages: [logicalPrompt, ...params.mirroredMessages] };
-}
-
-/** Freezes one complete active transcript branch through the settled tool-result boundary. */
-function buildCodexSettledTurnFinalizationContext(params: {
-  historyMessages: readonly AgentMessage[];
-  mirroredMessages: readonly AgentMessage[];
-  settledMessages: readonly AgentMessage[];
-  turnId: string;
-}): SettledTurnFinalizationContext | undefined {
-  const { historyMessages, mirroredMessages } = adoptPersistedHostPrompt(params);
-  const boundaryMessage = params.settledMessages.findLast(
-    (message) => message.role === "toolResult",
-  );
-  const boundaryIdentity = boundaryMessage ? readMirrorIdentity(boundaryMessage) : undefined;
-  if (
-    !boundaryMessage ||
-    !boundaryIdentity ||
-    !boundaryIdentity.startsWith(`${params.turnId}:tool:`)
-  ) {
-    return undefined;
-  }
-
-  const settledBoundaryIndex = params.settledMessages.indexOf(boundaryMessage);
-  const requiredIdentities = params.settledMessages
-    .slice(0, settledBoundaryIndex + 1)
-    .map(readMirrorIdentity);
-  if (
-    requiredIdentities.length === 0 ||
-    requiredIdentities.some((identity) => !identity) ||
-    new Set(requiredIdentities).size !== requiredIdentities.length ||
-    !requiredIdentities.includes(`${params.turnId}:prompt`)
-  ) {
-    return undefined;
-  }
-
-  const historyIdentities = collectUniqueMessageIdentities(historyMessages);
-  const mirroredIdentities = collectUniqueMessageIdentities(mirroredMessages);
-  if (!historyIdentities || !mirroredIdentities) {
-    return undefined;
-  }
-  const mirroredBoundaryIndex = mirroredIdentities.get(boundaryIdentity);
-  if (mirroredBoundaryIndex === undefined) {
-    return undefined;
-  }
-  const mirroredThroughBoundary = mirroredMessages.slice(0, mirroredBoundaryIndex + 1);
-  if (
-    mirroredThroughBoundary.length !== requiredIdentities.length ||
-    mirroredThroughBoundary.some(
-      (message, index) => readMirrorIdentity(message) !== requiredIdentities[index],
-    )
-  ) {
-    return undefined;
-  }
-  const historyBoundaryIndex = historyIdentities.get(boundaryIdentity);
-  if (historyBoundaryIndex === undefined) {
-    return undefined;
-  }
-  let previousHistoryIndex = -1;
-  for (const mirroredMessage of mirroredThroughBoundary) {
-    const identity = readMirrorIdentity(mirroredMessage);
-    const historyIndex = identity ? historyIdentities.get(identity) : undefined;
-    const historyMessage = historyIndex === undefined ? undefined : historyMessages[historyIndex];
+  const required = new Map(requiredIds.map((id, index) => [id, mirrored[index]!]));
+  const seen = new Set<string>();
+  let matched = 0;
+  let hostPromptMatches = 0;
+  let throughBoundary = false;
+  for (const message of history) {
+    let verificationMessage = message;
     if (
-      historyIndex === undefined ||
-      historyIndex <= previousHistoryIndex ||
-      historyIndex > historyBoundaryIndex ||
-      !historyMessage ||
-      serializeCodexMirrorSourceEvidence(historyMessage) !==
-        serializeCodexMirrorSourceEvidence(mirroredMessage)
+      adoption &&
+      message.role === "user" &&
+      (message as { idempotencyKey?: unknown }).idempotencyKey === adoption.key
     ) {
-      return undefined;
+      hostPromptMatches += 1;
+      if (hostPromptMatches > 1) {
+        rejectEvidence();
+      }
+      verificationMessage = adoptPersistedHostPrompt(message, adoption.prompt);
     }
-    previousHistoryIndex = historyIndex;
+    const identity = readMirrorIdentity(verificationMessage);
+    if (identity) {
+      if (seen.has(identity)) {
+        rejectEvidence();
+      }
+      seen.add(identity);
+      const expected = required.get(identity);
+      if (expected) {
+        if (
+          identity !== requiredIds[matched] ||
+          serializeCodexMirrorSourceEvidence(verificationMessage) !==
+            serializeCodexMirrorSourceEvidence(expected)
+        ) {
+          rejectEvidence();
+        }
+        matched += 1;
+      }
+    }
+    if (!throughBoundary) {
+      // Adoption is verification-only: replay the canonical persisted prompt, not its synthetic view.
+      yield message;
+    }
+    throughBoundary ||= identity === boundaryIdentity;
   }
-
-  // Clone before returning so later transcript/cache mutation cannot change the
-  // exact application evidence authorized for the isolated finalization turn.
-  const messages = Object.freeze(
-    structuredClone(params.historyMessages.slice(0, historyBoundaryIndex + 1)),
-  );
-  return { source: "openclaw-transcript", messages };
+  if (!throughBoundary || matched !== requiredIds.length || (adoption && hostPromptMatches !== 1)) {
+    rejectEvidence();
+  }
 }
 
-/** Reads and freezes the current active transcript branch after mirroring has settled. */
+/** Verifies and freezes a complete replay projection while reading the active branch. */
 export async function captureCodexSettledTurnFinalizationContext(
-  params: CodexMirroredSessionHistoryTarget & {
-    mirroredMessages: readonly AgentMessage[];
-    settledMessages: readonly AgentMessage[];
-    turnId: string;
-  },
-): Promise<SettledTurnFinalizationContext | undefined> {
+  params: CodexMirroredSessionHistoryTarget & SettledTurnMessages,
+): Promise<CodexSettledTurnContext | undefined> {
   try {
-    const historyMessages = await readCodexMirroredSessionHistoryMessages(params);
-    if (!historyMessages) {
-      return undefined;
-    }
-    return buildCodexSettledTurnFinalizationContext({
-      historyMessages,
-      mirroredMessages: params.mirroredMessages,
-      settledMessages: params.settledMessages,
-      turnId: params.turnId,
-    });
+    return await readCodexMirroredSessionHistory(
+      params,
+      (messages) =>
+        new CodexSettledTurnContext(
+          projectSettledCodexMessages(verifiedSettledMessages(messages, params)),
+        ),
+    );
   } catch (error) {
-    // Capture runs after tools have settled. Never let transcript I/O or cloning
-    // bypass the caller's side-effect-aware incomplete-turn result.
+    // Capture follows settled side effects; any failure must preserve the incomplete-turn result.
     embeddedAgentLog.warn("codex settled-turn finalization context capture failed", {
       error: formatErrorMessage(error),
       turnId: params.turnId,

--- a/extensions/codex/src/app-server/settled-turn-finalizer.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-finalizer.test.ts
@@ -2,6 +2,8 @@ import { normalizeUsage, type AgentHarnessV2 } from "openclaw/plugin-sdk/agent-h
 import type { Model } from "openclaw/plugin-sdk/llm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { EmbeddedRunAttemptResult } from "./attempt-terminal.js";
+import { CodexSettledTurnContext } from "./settled-turn-context.js";
+import { projectSettledCodexMessages } from "./settled-turn-projection.js";
 import {
   attachCodexMirrorAttestation,
   fingerprintCodexMirrorSourceMessage,
@@ -66,9 +68,8 @@ function createSettledAttempt(): EmbeddedRunAttemptResult {
         content: [{ type: "text", text: "Message sent." }],
       } as never,
     ],
-    settledTurnFinalizationContext: {
-      source: "openclaw-transcript",
-      messages: [
+    settledTurnFinalizationContext: new CodexSettledTurnContext(
+      projectSettledCodexMessages([
         { role: "user", content: "Send the update to Alice." } as never,
         {
           role: "assistant",
@@ -80,8 +81,8 @@ function createSettledAttempt(): EmbeddedRunAttemptResult {
           toolName: "message",
           content: [{ type: "text", text: "Message sent." }],
         } as never,
-      ],
-    },
+      ]),
+    ),
     assistantTexts: [],
     toolMetas: [{ toolName: "message", replaySafe: false }],
     lastAssistant: undefined,
@@ -336,16 +337,19 @@ describe("runCodexSettledTurnFinalization", () => {
     expect(mocks.mirror).not.toHaveBeenCalled();
   });
 
-  it("rejects a missing frozen context before starting the isolated turn", async () => {
-    const settledAttempt = createSettledAttempt();
-    delete settledAttempt.settledTurnFinalizationContext;
-
-    await expect(
-      runCodexSettledTurnFinalization({ attempt: createAttempt(), settledAttempt }, {}),
-    ).rejects.toThrow("finalization context is unavailable");
-    expect(mocks.runBounded).not.toHaveBeenCalled();
-    expect(mocks.mirror).not.toHaveBeenCalled();
-  });
+  it.each(["missing", "foreign"])(
+    "rejects a %s context before starting the isolated turn",
+    async (kind) => {
+      const settledAttempt = createSettledAttempt();
+      settledAttempt.settledTurnFinalizationContext =
+        kind === "missing" ? undefined : { source: "harness", data: [] };
+      await expect(
+        runCodexSettledTurnFinalization({ attempt: createAttempt(), settledAttempt }, {}),
+      ).rejects.toThrow("finalization context is unavailable");
+      expect(mocks.runBounded).not.toHaveBeenCalled();
+      expect(mocks.mirror).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects a stale idempotency hit instead of delivering an unpersisted answer", async () => {
     mocks.mirror.mockImplementation(

--- a/extensions/codex/src/app-server/settled-turn-finalizer.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-finalizer.test.ts
@@ -337,12 +337,16 @@ describe("runCodexSettledTurnFinalization", () => {
     expect(mocks.mirror).not.toHaveBeenCalled();
   });
 
-  it.each(["missing", "foreign"])(
-    "rejects a %s context before starting the isolated turn",
+  it.each(["missing", "foreign", "unavailable"])(
+    "rejects %s context before starting the isolated turn",
     async (kind) => {
       const settledAttempt = createSettledAttempt();
       settledAttempt.settledTurnFinalizationContext =
-        kind === "missing" ? undefined : { source: "harness", data: [] };
+        kind === "missing"
+          ? undefined
+          : kind === "foreign"
+            ? { source: "harness", data: [] }
+            : { source: "unavailable" };
       await expect(
         runCodexSettledTurnFinalization({ attempt: createAttempt(), settledAttempt }, {}),
       ).rejects.toThrow("finalization context is unavailable");

--- a/extensions/codex/src/app-server/settled-turn-finalizer.ts
+++ b/extensions/codex/src/app-server/settled-turn-finalizer.ts
@@ -6,7 +6,7 @@ import { isSilentReplyText } from "openclaw/plugin-sdk/reply-runtime";
 import { runBoundedCodexAppServerTurn, type CodexBoundedTurnOptions } from "./bounded-turn.js";
 import { createAssistantMessage } from "./event-projector-assistant-message.js";
 import { isJsonObject, type CodexThreadItem } from "./protocol.js";
-import { projectSettledCodexMessages } from "./settled-turn-projection.js";
+import { CodexSettledTurnContext } from "./settled-turn-context.js";
 import {
   fingerprintCodexMirrorSourceMessage,
   readCodexMirrorSourceFingerprint,
@@ -32,10 +32,10 @@ export async function runCodexSettledTurnFinalization(
 ): Promise<AgentHarnessSettledTurnFinalizationResult> {
   const { attempt, settledAttempt } = operation;
   const finalizationContext = settledAttempt.settledTurnFinalizationContext;
-  if (finalizationContext?.source !== "openclaw-transcript") {
+  if (!(finalizationContext instanceof CodexSettledTurnContext)) {
     throw new Error("Codex settled-turn finalization context is unavailable");
   }
-  const historyItems = projectSettledCodexMessages(finalizationContext.messages);
+  const historyItems = finalizationContext.data;
   const bounded = await runBoundedCodexAppServerTurn({
     config: attempt.config,
     model: { mode: "required", id: attempt.modelId },

--- a/extensions/codex/src/app-server/settled-turn-projection.test.ts
+++ b/extensions/codex/src/app-server/settled-turn-projection.test.ts
@@ -208,13 +208,25 @@ describe("projectSettledCodexMessages", () => {
     ]);
   });
 
-  it("rejects an oversized item count instead of dropping earlier context", () => {
-    const oldMessages = Array.from({ length: 205 }, (_, index) =>
-      message({ role: "user", content: `old-${index}` }),
+  it.each([
+    { count: 205, text: "old", error: "exceeds the item limit" },
+    { count: 9, text: "x".repeat(60 * 1024), error: "exceeds the byte limit" },
+  ])("stops acquiring later payloads after $error", ({ count, text, error }) => {
+    let laterReads = 0;
+    const later = message({
+      role: "user",
+      get content() {
+        laterReads += 1;
+        return "must not acquire this later payload";
+      },
+    });
+    const oldMessages = Array.from({ length: count }, () =>
+      message({ role: "user", content: text }),
     );
-    expect(() => projectSettledCodexMessages([...oldMessages, toolCall(), toolResult()])).toThrow(
-      "exceeds the item limit",
-    );
+    expect(() =>
+      projectSettledCodexMessages([...oldMessages, later, toolCall(), toolResult()]),
+    ).toThrow(error);
+    expect(laterReads).toBe(0);
   });
 
   it("prefers the undecorated upstream user text", () => {

--- a/extensions/codex/src/app-server/settled-turn-projection.ts
+++ b/extensions/codex/src/app-server/settled-turn-projection.ts
@@ -16,11 +16,10 @@ const TOOL_NAME_PATTERN = /^[a-zA-Z0-9._-]{1,128}$/u;
 const TOOL_ERROR_STATUS_PREFIX = "[Tool result status: error]\n";
 
 type ProjectedToolReference = { id: string; name: string };
-type ProjectedMessageGroup = {
-  items: JsonValue[];
-  calls: ProjectedToolReference[];
-  results: ProjectedToolReference[];
-  bytes: number;
+type ProjectedResponseItem = {
+  item: JsonValue;
+  call?: ProjectedToolReference;
+  result?: ProjectedToolReference;
 };
 
 function readBoundedText(
@@ -92,60 +91,45 @@ function serializeToolArguments(value: unknown): string {
   return requireBoundedText(serialized, "tool arguments");
 }
 
-function projectUserMessage(message: Extract<AgentMessage, { role: "user" }>): JsonValue[] {
+function projectUserMessage(message: Extract<AgentMessage, { role: "user" }>): JsonValue {
   const upstreamUserText = readUpstreamUserText(message);
-  if (upstreamUserText && typeof message.content === "string") {
-    return [
-      {
-        type: "message",
-        role: "user",
-        content: [
-          {
-            type: "input_text",
-            text: requireBoundedText(upstreamUserText, "upstream user text", MAX_PROJECTION_BYTES),
-          },
-        ],
-      },
-    ];
-  }
   if (typeof message.content === "string") {
-    return [
-      {
-        type: "message",
-        role: "user",
-        content: [
-          { type: "input_text", text: requireBoundedText(message.content, "user message") },
-        ],
-      },
-    ];
+    const text = upstreamUserText
+      ? requireBoundedText(upstreamUserText, "upstream user text", MAX_PROJECTION_BYTES)
+      : requireBoundedText(message.content, "user message");
+    return { type: "message", role: "user", content: [{ type: "input_text", text }] };
   }
   if (!Array.isArray(message.content)) {
     throw new Error("Codex settled-turn projection found unsupported user content");
   }
   const content: JsonValue[] = [];
+  let bytes = responseItemBytes({ type: "message", role: "user", content });
   for (const value of message.content) {
     if (!isRecord(value)) {
       throw new Error("Codex settled-turn projection found malformed user content");
     }
-    if (value.type === "text") {
-      const text = readBoundedText(value.text, "user text");
-      if (text) {
-        content.push({ type: "input_text", text });
-      }
-      continue;
+    if (value.type !== "text") {
+      throw new Error(`Codex settled-turn projection does not support user content ${value.type}`);
     }
-    throw new Error(`Codex settled-turn projection does not support user content ${value.type}`);
+    const text = readBoundedText(value.text, "user text");
+    if (text) {
+      const part = { type: "input_text", text };
+      bytes += responseItemBytes(part) + (content.length > 0 ? 1 : 0);
+      if (bytes > MAX_PROJECTION_BYTES) {
+        throw new Error("Codex settled-turn projection exceeds the byte limit");
+      }
+      content.push(part);
+    }
   }
   if (content.length === 0) {
     throw new Error("Codex settled-turn projection found an empty user message");
   }
-  return [{ type: "message", role: "user", content }];
+  return { type: "message", role: "user", content };
 }
 
-function projectAssistantMessage(message: Extract<AgentMessage, { role: "assistant" }>): {
-  items: JsonValue[];
-  calls: ProjectedToolReference[];
-} {
+function* projectAssistantMessage(
+  message: Extract<AgentMessage, { role: "assistant" }>,
+): Generator<ProjectedResponseItem> {
   const values: unknown =
     typeof message.content === "string"
       ? [{ type: "text", text: message.content }]
@@ -153,8 +137,6 @@ function projectAssistantMessage(message: Extract<AgentMessage, { role: "assista
   if (!Array.isArray(values)) {
     throw new Error("Codex settled-turn projection found unsupported assistant content");
   }
-  const items: JsonValue[] = [];
-  const calls: ProjectedToolReference[] = [];
   for (const value of values) {
     if (!isRecord(value)) {
       throw new Error("Codex settled-turn projection found malformed assistant content");
@@ -162,24 +144,24 @@ function projectAssistantMessage(message: Extract<AgentMessage, { role: "assista
     if (value.type === "text") {
       const text = readBoundedText(value.text, "assistant text");
       if (text) {
-        items.push({
-          type: "message",
-          role: "assistant",
-          content: [{ type: "output_text", text }],
-        });
+        yield {
+          item: { type: "message", role: "assistant", content: [{ type: "output_text", text }] },
+        };
       }
       continue;
     }
     if (value.type === "toolCall") {
       const id = requireCallId(value.id ?? value.toolCallId);
       const name = requireToolName(value.name ?? value.toolName);
-      calls.push({ id, name });
-      items.push({
-        type: "function_call",
-        call_id: id,
-        name,
-        arguments: serializeToolArguments(value.arguments ?? value.input),
-      });
+      yield {
+        call: { id, name },
+        item: {
+          type: "function_call",
+          call_id: id,
+          name,
+          arguments: serializeToolArguments(value.arguments ?? value.input),
+        },
+      };
       continue;
     }
     if (value.type === "thinking" || value.type === "reasoning") {
@@ -190,7 +172,6 @@ function projectAssistantMessage(message: Extract<AgentMessage, { role: "assista
       `Codex settled-turn projection does not support assistant content ${String(value.type)}`,
     );
   }
-  return { items, calls };
 }
 
 function projectToolResult(message: Extract<AgentMessage, { role: "toolResult" }>): {
@@ -208,6 +189,14 @@ function projectToolResult(message: Extract<AgentMessage, { role: "toolResult" }
   }
   const isError = isErrorValue === true;
   const parts: string[] = [];
+  let bytes = 0;
+  const appendText = (text: string) => {
+    bytes += Buffer.byteLength(text, "utf8") + (parts.length > 0 ? 1 : 0);
+    if (bytes > MAX_TEXT_BYTES) {
+      throw new Error("Codex settled-turn projection found oversized tool result output");
+    }
+    parts.push(text);
+  };
   for (const value of message.content) {
     if (!isRecord(value)) {
       throw new Error("Codex settled-turn projection found malformed tool result content");
@@ -216,7 +205,7 @@ function projectToolResult(message: Extract<AgentMessage, { role: "toolResult" }
       const mimeType = normalizeOptionalString(value.mimeType) ?? "unknown type";
       // The finalizer selects by text capability. Preserve image evidence as
       // metadata without embedding an executable or oversized multimodal payload.
-      parts.push(`[Image tool result: ${mimeType}]`);
+      appendText(`[Image tool result: ${mimeType}]`);
       continue;
     }
     if (value.type !== "text" && value.type !== "toolResult") {
@@ -227,7 +216,7 @@ function projectToolResult(message: Extract<AgentMessage, { role: "toolResult" }
         ? readBoundedText(value.text, "tool result text")
         : readBoundedText(value.content ?? value.text, "tool result text");
     if (text) {
-      parts.push(text);
+      appendText(text);
     }
   }
   const resultText =
@@ -246,81 +235,53 @@ function projectToolResult(message: Extract<AgentMessage, { role: "toolResult" }
   };
 }
 
-function projectMessage(message: AgentMessage): ProjectedMessageGroup | undefined {
-  let items: JsonValue[];
-  let calls: ProjectedToolReference[] = [];
-  let results: ProjectedToolReference[] = [];
+function* projectMessage(message: AgentMessage): Generator<ProjectedResponseItem> {
   if (message.role === "user") {
-    items = projectUserMessage(message);
+    yield { item: projectUserMessage(message) };
   } else if (message.role === "assistant") {
-    const projected = projectAssistantMessage(message);
-    items = projected.items;
-    calls = projected.calls;
+    yield* projectAssistantMessage(message);
   } else if (message.role === "toolResult") {
-    const projected = projectToolResult(message);
-    items = [projected.item];
-    results = [projected.result];
+    yield projectToolResult(message);
   } else {
     throw new Error(`Codex settled-turn projection does not support role ${message.role}`);
   }
-  if (items.length === 0) {
-    return undefined;
-  }
-  return {
-    items,
-    calls,
-    results,
-    bytes: items.reduce<number>((total, item) => total + responseItemBytes(item), 0),
-  };
 }
 
-function validateExactlyPairedCalls(groups: readonly ProjectedMessageGroup[]): number {
-  const calls = new Map<string, { name: string; groupIndex: number }>();
+/** Consumes complete evidence or rejects at the existing limits, never truncating its history. */
+export function projectSettledCodexMessages(messages: Iterable<AgentMessage>): JsonValue[] {
+  const items: JsonValue[] = [];
+  const calls = new Map<string, string>();
   const results = new Set<string>();
-  let resultCount = 0;
-  for (const [groupIndex, group] of groups.entries()) {
-    for (const call of group.calls) {
-      if (calls.has(call.id)) {
-        throw new Error("Codex settled-turn projection found a duplicate tool call");
+  let bytes = 0;
+  for (const message of messages) {
+    for (const { item, call, result } of projectMessage(message)) {
+      if (call) {
+        if (calls.has(call.id)) {
+          throw new Error("Codex settled-turn projection found a duplicate tool call");
+        }
+        calls.set(call.id, call.name);
       }
-      calls.set(call.id, { name: call.name, groupIndex });
-    }
-    for (const result of group.results) {
-      const call = calls.get(result.id);
-      if (
-        !call ||
-        call.groupIndex >= groupIndex ||
-        call.name !== result.name ||
-        results.has(result.id)
-      ) {
-        throw new Error("Codex settled-turn projection found an ambiguous tool transcript");
+      if (result) {
+        if (calls.get(result.id) !== result.name || results.has(result.id)) {
+          throw new Error("Codex settled-turn projection found an ambiguous tool transcript");
+        }
+        results.add(result.id);
       }
-      results.add(result.id);
-      resultCount += 1;
+      if (items.length === MAX_RESPONSE_ITEMS) {
+        throw new Error("Codex settled-turn projection exceeds the item limit");
+      }
+      bytes += responseItemBytes(item);
+      if (bytes > MAX_PROJECTION_BYTES) {
+        throw new Error("Codex settled-turn projection exceeds the byte limit");
+      }
+      items.push(item);
     }
   }
   if (calls.size !== results.size) {
     throw new Error("Codex settled-turn projection found an incomplete tool transcript");
   }
-  return resultCount;
-}
-
-/** Projects the complete frozen transcript or rejects it without truncation or tail dropping. */
-export function projectSettledCodexMessages(messages: readonly AgentMessage[]): JsonValue[] {
-  const groups = messages.flatMap((message) => {
-    const projected = projectMessage(message);
-    return projected ? [projected] : [];
-  });
-  if (validateExactlyPairedCalls(groups) === 0) {
+  if (results.size === 0) {
     throw new Error("Codex settled-turn projection found no completed tool result");
-  }
-  const items = groups.flatMap((group) => group.items);
-  if (items.length > MAX_RESPONSE_ITEMS) {
-    throw new Error("Codex settled-turn projection exceeds the item limit");
-  }
-  const bytes = groups.reduce((total, group) => total + group.bytes, 0);
-  if (bytes > MAX_PROJECTION_BYTES) {
-    throw new Error("Codex settled-turn projection exceeds the byte limit");
   }
   return items;
 }

--- a/extensions/codex/src/app-server/transcript-mirror-attestation.ts
+++ b/extensions/codex/src/app-server/transcript-mirror-attestation.ts
@@ -64,6 +64,11 @@ export function attachCodexMirrorRunId<T extends AgentMessage>(
   } as T; // SAFETY: AgentMessage variants permit provider metadata at runtime; preserve T.
 }
 
+export function hasCodexMirrorOrigin(message: AgentMessage): boolean {
+  const meta = CODEX_META_KEY in message ? message[CODEX_META_KEY] : undefined;
+  return asOptionalRecord(meta)?.[MIRROR_ORIGIN_META_KEY] === CODEX_APP_SERVER_MIRROR_ORIGIN;
+}
+
 export function readCodexMirrorSourceFingerprint(message: AgentMessage): string | undefined {
   const meta = CODEX_META_KEY in message ? message[CODEX_META_KEY] : undefined;
   if (!meta || typeof meta !== "object" || Array.isArray(meta)) {

--- a/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.test.ts
@@ -31,6 +31,17 @@ function turn(id: string, items: CodexThreadItem[], overrides: Partial<CodexTurn
   return { id, status: "completed", items, ...overrides };
 }
 
+function attestedHarnessPrompt(upstreamText: string) {
+  const prompt = attachUpstreamUserText(
+    attachCodexMirrorIdentity(
+      { role: "user", content: "visible question", timestamp: 0 },
+      "turn-1:prompt",
+    ),
+    upstreamText,
+  );
+  return attachCodexMirrorAttestation(prompt, fingerprintCodexMirrorSourceMessage(prompt));
+}
+
 async function resolveFromTurns(params: {
   turns: readonly CodexTurn[];
   userMessageOrdinal: number;
@@ -224,17 +235,7 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
   it.each([false, true])(
     "validates a recorded harness prompt and its local content (edited: %s)",
     async (edited) => {
-      const prompt = attachUpstreamUserText(
-        attachCodexMirrorIdentity(
-          { role: "user", content: "visible question", timestamp: 0 },
-          "turn-1:prompt",
-        ),
-        "harness context\nvisible question",
-      );
-      const message = attachCodexMirrorAttestation(
-        prompt,
-        fingerprintCodexMirrorSourceMessage(prompt),
-      );
+      const message = attestedHarnessPrompt("harness context\nvisible question");
       if (message.role !== "user") {
         throw new Error("Attestation changed the user fixture's role");
       }
@@ -260,6 +261,59 @@ describe("resolveCodexUpstreamForkBoundaryFromTurns", () => {
               boundary: { beforeTurnId: "turn-1" },
             },
       );
+    },
+  );
+
+  it.each([
+    { name: "matching long text", prefix: "x".repeat(70 * 1024), suffix: "Q1", matches: true },
+    {
+      name: "changed long-text suffix",
+      prefix: "x".repeat(70 * 1024),
+      suffix: "Q2",
+      matches: false,
+    },
+    { name: "changed whitespace", prefix: "harness context\n", suffix: "Q1 \n", matches: false },
+  ])(
+    "compares complete attested harness prompts with $name",
+    async ({ prefix, suffix, matches }) => {
+      const entries: SessionTranscriptMessageEntry[] = [
+        {
+          entryId: "entry-0",
+          parentId: null,
+          seq: 0,
+          role: "user",
+          message: attestedHarnessPrompt(`${prefix}Q1`),
+        },
+        {
+          entryId: "entry-1",
+          parentId: "entry-0",
+          seq: 1,
+          role: "user",
+          message: attachCodexMirrorIdentity(
+            { role: "user", content: "target", timestamp: 1 },
+            "turn-2:target-user",
+          ),
+        },
+      ];
+      const turns = [
+        turn("turn-1", [
+          item("userMessage", {
+            id: "native-prompt",
+            content: [{ type: "text", text: `${prefix}${suffix}`, text_elements: [] }],
+          }),
+        ]),
+        turn("turn-2", [user("target")]),
+      ];
+
+      // Verify the full prompt both when selected and when retained before an unchanged target.
+      for (const targetIndex of [0, 1]) {
+        const result = await resolveEntries(turns, entries, `entry-${targetIndex}`);
+        expect(result).toMatchObject(
+          matches
+            ? { ok: true, boundary: { beforeTurnId: `turn-${targetIndex + 1}` } }
+            : { ok: false, code: "drift-mismatch" },
+        );
+      }
     },
   );
 

--- a/extensions/codex/src/app-server/upstream-fork-boundary.ts
+++ b/extensions/codex/src/app-server/upstream-fork-boundary.ts
@@ -3,7 +3,7 @@ import {
   type SessionTranscriptMessageEntry,
 } from "openclaw/plugin-sdk/session-transcript-runtime";
 import type { CodexSessionCatalogControl } from "../session-catalog-types.js";
-import type { CodexThreadItem, CodexTurn } from "./protocol.js";
+import type { CodexTurn } from "./protocol.js";
 import { projectCodexUserItemText } from "./transcript-history-projection.js";
 import {
   fingerprintCodexMirrorSourceMessage,
@@ -32,10 +32,6 @@ type CodexUpstreamForkBoundaryResult =
 
 const TURN_PAGE_LIMIT = 100;
 
-type UserInput = {
-  type?: unknown;
-};
-
 function failure(
   code: CodexUpstreamForkBoundaryFailureCode,
   message: string,
@@ -43,11 +39,7 @@ function failure(
   return { ok: false, code, message };
 }
 
-function asInputs(item: CodexThreadItem): UserInput[] {
-  return Array.isArray(item.content) ? (item.content as UserInput[]) : [];
-}
-
-function localMessageText(content: unknown): string | undefined {
+function textOnlyMessage(content: unknown): string | undefined {
   if (typeof content === "string") {
     return content;
   }
@@ -85,17 +77,21 @@ function resolveCodexUpstreamForkBoundaryFromTurns(params: {
       const isSteer = userMessagesInTurn > 0;
       userMessagesInTurn += 1;
       // Display placeholders are not evidence of attachment identity.
-      if (asInputs(item).some((input) => input.type !== "text")) {
+      const nativeText = textOnlyMessage(item.content);
+      if (nativeText === undefined) {
         return failure(
           "drift-mismatch",
           "A message before the fork point contains images or attachments that cannot be verified across OpenClaw and Codex. Fork from a text-only span instead.",
         );
       }
-      const text = projectCodexUserItemText(item);
+      const local = params.localPrefix[localIndex];
+      const upstreamText = local && readUpstreamUserText(local.message);
+      // Harness evidence binds the complete submitted text, not the trimmed/truncated
+      // display projection that legacy imported mirrors retain.
+      const text = upstreamText ? nativeText : projectCodexUserItemText(item);
       if (!text) {
         continue;
       }
-      const local = params.localPrefix[localIndex];
       const identity = local && readMirrorIdentity(local.message);
       // Imports retain a bounded tail. Locate its recorded start, then verify every
       // retained user in order; repeated text must never choose an earlier native turn.
@@ -105,10 +101,9 @@ function resolveCodexUpstreamForkBoundaryFromTurns(params: {
         continue;
       }
       matchedPrefix = true;
-      const localText = localMessageText(
+      const localText = textOnlyMessage(
         local && "content" in local.message ? local.message.content : undefined,
       );
-      const upstreamText = local && readUpstreamUserText(local.message);
       // Harness prompts carry the sent text separately from the display text.
       // Its existing attestation must still bind both, or a local edit could pass drift checks.
       const upstreamPromptVerified =
@@ -116,14 +111,11 @@ function resolveCodexUpstreamForkBoundaryFromTurns(params: {
         (local?.message.role === "user" &&
           readCodexMirrorSourceFingerprint(local.message) ===
             fingerprintCodexMirrorSourceMessage(local.message));
-      const expectedText = upstreamText
-        ? projectCodexUserItemText({ content: [{ type: "text", text: upstreamText }] })
-        : localText;
       if (
         !matchesIdentity ||
         !upstreamPromptVerified ||
         localText === undefined ||
-        text !== expectedText
+        text !== (upstreamText ?? localText)
       ) {
         return failure(
           "drift-mismatch",
@@ -237,7 +229,7 @@ export async function resolveCodexUpstreamForkBoundary(params: {
     return resolved.ok
       ? {
           ...resolved,
-          editorText: localMessageText(target && "content" in target ? target.content : undefined),
+          editorText: textOnlyMessage(target && "content" in target ? target.content : undefined),
         }
       : resolved;
   } catch {

--- a/packages/agent-core/src/harness/session/session.ts
+++ b/packages/agent-core/src/harness/session/session.ts
@@ -6,14 +6,13 @@ import {
   createCompactionSummaryMessage,
   createCustomMessage,
 } from "../messages.js";
-import type { CompactionEntry, ResetEntry, SessionContext, SessionTreeEntry } from "../types.js";
+import type { SessionContext, SessionTreeEntry } from "../types.js";
 import { selectResetKeptEntries } from "./tool-result-pairing.js";
 
-type ContextBoundary = CompactionEntry | ResetEntry;
 const SESSION_HISTORY_PRELUDE = Symbol.for("openclaw.sessionHistoryPrelude");
 
 /** The same semantic cut is used before payload acquisition and when building messages. */
-export function resolveSessionContextWindow(
+function resolveSessionContextWindow(
   entries: readonly { id: string; type: string; firstKeptEntryId?: string }[],
 ): { boundaryIndex: number; firstKeptIndex: number } {
   const boundaryIndex = entries.findLastIndex(
@@ -60,40 +59,78 @@ export function projectSessionEntryMessage(entry: SessionTreeEntry): AgentMessag
   }
 }
 
-function stripStalePrefixReplay(message: AgentMessage): AgentMessage {
-  return message.role === "assistant" ? stripCompactionReplayCheckpoint(message) : message;
+/** Select the canonical window using only navigation and tool-pairing facts. */
+export function* iterateSessionContextEntries<T extends SessionTreeEntry>(
+  pathEntries: readonly T[],
+): Generator<{ entry: T; context: "current" | "retained" | "reset-retained" }> {
+  const { boundaryIndex, firstKeptIndex } = resolveSessionContextWindow(pathEntries);
+  const boundary = pathEntries[boundaryIndex];
+  const resetKept =
+    boundary?.type === "reset"
+      ? new Set(selectResetKeptEntries(pathEntries.slice(firstKeptIndex, boundaryIndex)))
+      : undefined;
+  if (boundary) {
+    yield { entry: boundary, context: "current" };
+  }
+  for (const [index, entry] of pathEntries.entries()) {
+    const retained = index < boundaryIndex;
+    if (
+      index === boundaryIndex ||
+      (retained && (index < firstKeptIndex || (resetKept && !resetKept.has(entry))))
+    ) {
+      continue;
+    }
+    const hasMessage =
+      entry.type === "message" ||
+      entry.type === "custom_message" ||
+      entry.type === "branch_summary";
+    if (
+      !hasMessage ||
+      (!resetKept?.has(entry) &&
+        entry.type === "message" &&
+        "excludeFromContext" in entry.message &&
+        entry.message.excludeFromContext === true)
+    ) {
+      continue;
+    }
+    const context = retained ? (resetKept ? "reset-retained" : "retained") : "current";
+    yield { entry, context };
+  }
 }
 
-function appendContextMessage(
-  messages: AgentMessage[],
-  entry: SessionTreeEntry,
-  options?: { prefixWasRewritten?: boolean },
-): void {
-  if (entry.type === "compaction" || (entry.type === "branch_summary" && !entry.summary)) {
-    return;
-  }
-  const message = projectSessionEntryMessage(entry);
-  if (message) {
-    messages.push(options?.prefixWasRewritten ? stripStalePrefixReplay(message) : message);
-  }
-}
-
-function appendResetKeptMessage(messages: AgentMessage[], entry: SessionTreeEntry): void {
-  if (entry.type !== "message") {
-    return;
-  }
-  if (entry.message.role === "user" || entry.message.role === "assistant") {
-    const message = { ...stripStalePrefixReplay(entry.message) } as AgentMessage & {
-      [SESSION_HISTORY_PRELUDE]?: true;
-    };
-    Object.defineProperty(message, SESSION_HISTORY_PRELUDE, {
-      configurable: true,
-      enumerable: false,
-      value: true,
-    });
-    messages.push(message);
-  } else if (entry.message.role === "toolResult") {
-    messages.push(entry.message);
+/** Hydrate selected messages lazily so bounded consumers can stop before later payloads. */
+export function* iterateSessionContextMessages<T extends SessionTreeEntry>(
+  pathEntries: readonly T[],
+  readEntry: (entry: T) => SessionTreeEntry = (entry) => entry,
+): Generator<AgentMessage> {
+  for (const { entry, context } of iterateSessionContextEntries(pathEntries)) {
+    if (entry.type === "reset") {
+      continue;
+    }
+    const hydrated = readEntry(entry);
+    if (hydrated.type === "branch_summary" && !hydrated.summary) {
+      continue;
+    }
+    // Explicit reset retention can include otherwise excluded user/assistant messages.
+    let message =
+      context === "reset-retained" && hydrated.type === "message"
+        ? hydrated.message
+        : projectSessionEntryMessage(hydrated);
+    if (!message) {
+      continue;
+    }
+    if (context !== "current" && message.role === "assistant") {
+      message = stripCompactionReplayCheckpoint(message);
+    }
+    if (context === "reset-retained" && (message.role === "user" || message.role === "assistant")) {
+      message = { ...message };
+      Object.defineProperty(message, SESSION_HISTORY_PRELUDE, {
+        configurable: true,
+        enumerable: false,
+        value: true,
+      });
+    }
+    yield message;
   }
 }
 
@@ -101,8 +138,6 @@ function appendResetKeptMessage(messages: AgentMessage[], entry: SessionTreeEntr
 export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionContext {
   let thinkingLevel = "off";
   let model: { provider: string; modelId: string } | null = null;
-  let boundary: ContextBoundary | null = null;
-
   for (const entry of pathEntries) {
     if (entry.type === "thinking_level_change") {
       thinkingLevel = entry.thinkingLevel;
@@ -110,43 +145,7 @@ export function buildSessionContext(pathEntries: SessionTreeEntry[]): SessionCon
       model = { provider: entry.provider, modelId: entry.modelId };
     } else if (entry.type === "message" && entry.message.role === "assistant") {
       model = { provider: entry.message.provider, modelId: entry.message.model };
-    } else if (entry.type === "compaction" || entry.type === "reset") {
-      boundary = entry;
     }
   }
-
-  const messages: AgentMessage[] = [];
-  if (boundary) {
-    if (boundary.type === "compaction") {
-      const summary = projectSessionEntryMessage(boundary);
-      if (summary) {
-        messages.push(summary);
-      }
-    }
-    const { boundaryIndex: boundaryIdx, firstKeptIndex: firstKeptIdx } =
-      resolveSessionContextWindow(pathEntries);
-    const keptEntries =
-      firstKeptIdx >= 0 && firstKeptIdx < boundaryIdx
-        ? pathEntries.slice(firstKeptIdx, boundaryIdx)
-        : [];
-    const replayEntries =
-      boundary.type === "reset" ? selectResetKeptEntries(keptEntries) : keptEntries;
-    // Both retained-tail forms follow rewritten prefixes, so prefix-bound checkpoints are stale.
-    for (const entry of replayEntries) {
-      if (boundary.type === "reset") {
-        appendResetKeptMessage(messages, entry);
-      } else {
-        appendContextMessage(messages, entry, { prefixWasRewritten: true });
-      }
-    }
-    for (const entry of pathEntries.slice(boundaryIdx + 1)) {
-      appendContextMessage(messages, entry);
-    }
-  } else {
-    for (const entry of pathEntries) {
-      appendContextMessage(messages, entry);
-    }
-  }
-
-  return { messages, thinkingLevel, model };
+  return { messages: Array.from(iterateSessionContextMessages(pathEntries)), thinkingLevel, model };
 }

--- a/packages/agent-core/src/harness/types.ts
+++ b/packages/agent-core/src/harness/types.ts
@@ -59,7 +59,7 @@ interface ModelChangeEntry extends SessionTreeEntryBase {
   modelId: string;
 }
 
-export interface CompactionEntry<T = unknown> extends SessionTreeEntryBase {
+interface CompactionEntry<T = unknown> extends SessionTreeEntryBase {
   type: "compaction";
   summary: string;
   firstKeptEntryId: string;
@@ -70,7 +70,7 @@ export interface CompactionEntry<T = unknown> extends SessionTreeEntryBase {
 
 type ResetReason = "new" | "reset" | "idle" | "daily" | "cron-stale";
 
-export interface ResetEntry extends SessionTreeEntryBase {
+interface ResetEntry extends SessionTreeEntryBase {
   type: "reset";
   reason: ResetReason;
   firstKeptEntryId?: string;

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-build.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-build.ts
@@ -133,6 +133,7 @@ export async function prepareEmbeddedAttemptPromptAssembly(input: {
 }): Promise<EmbeddedAttemptPromptAssembly> {
   const { attempt } = input;
   const isSettledTurnFinalization = attempt.operation === "settled-tool-finalization";
+  const preserveExactPrompt = input.isRawModelRun || isSettledTurnFinalization;
   let systemPromptText = input.systemPromptText;
   const setSystemPrompt = (next: string) => {
     systemPromptText = next;
@@ -161,17 +162,16 @@ export async function prepareEmbeddedAttemptPromptAssembly(input: {
   const promptBuildMessages =
     pruneProcessedHistoryImages(input.activeSession.messages) ?? input.activeSession.messages;
   const promptEvent = { prompt: attempt.prompt, messages: promptBuildMessages };
-  const hookResult =
-    input.isRawModelRun || isSettledTurnFinalization
-      ? undefined
-      : await resolvePromptBuildHookResult({
-          config: attempt.config ?? getRuntimeConfig(),
-          prompt: attempt.prompt,
-          messages: promptBuildMessages,
-          hookCtx,
-          hookRunner: input.hookRunner,
-          bootstrapContextRunKind: attempt.bootstrapContextRunKind,
-        });
+  const hookResult = preserveExactPrompt
+    ? undefined
+    : await resolvePromptBuildHookResult({
+        config: attempt.config ?? getRuntimeConfig(),
+        prompt: attempt.prompt,
+        messages: promptBuildMessages,
+        hookCtx,
+        hookRunner: input.hookRunner,
+        bootstrapContextRunKind: attempt.bootstrapContextRunKind,
+      });
   const promptCacheToolNames = input.applyPromptBuildToolsAllow(hookResult?.toolsAllow);
   const hookRunner = input.hookRunner;
   const assertHostActive = resolveAdmittedRunActiveAssertion(
@@ -179,11 +179,7 @@ export async function prepareEmbeddedAttemptPromptAssembly(input: {
     attempt.abortSignal,
   );
   const authorizedHookResult =
-    input.isRawModelRun ||
-    isSettledTurnFinalization ||
-    !hookRunner ||
-    !attempt.toolAuthorityFingerprint ||
-    !assertHostActive
+    preserveExactPrompt || !hookRunner || !attempt.toolAuthorityFingerprint || !assertHostActive
       ? undefined
       : await hookRunner.runAuthorizedPromptBuild(promptEvent, hookCtx, {
           toolAuthorityFingerprint: attempt.toolAuthorityFingerprint,
@@ -359,7 +355,7 @@ export async function prepareEmbeddedAttemptPromptAssembly(input: {
   }
 
   let leasedSteering: EmbeddedAttemptSteeringLease | undefined;
-  if (attempt.sessionKey && !input.isRawModelRun && !isSettledTurnFinalization) {
+  if (attempt.sessionKey && !preserveExactPrompt) {
     const leaseId = `${attempt.runId}:agent-steering`;
     const leased = leasePendingAgentSteeringItems({
       requesterSessionKey: attempt.sessionKey,
@@ -392,14 +388,21 @@ export async function prepareEmbeddedAttemptPromptAssembly(input: {
 
   const promptForModelBeforeRuntimeContextSplit = effectivePrompt;
   const promptForRuntimeContextBeforeAnnotation = promptForRuntimeContextSplit;
-  if (!input.isRawModelRun && !isSettledTurnFinalization) {
+  if (!preserveExactPrompt) {
     promptForRuntimeContextSplit = annotateInterSessionPromptText(
       promptForRuntimeContextSplit,
       attempt.inputProvenance,
     );
   }
-  const transcriptLeafId =
-    (input.sessionManager.getLeafEntry() as { id?: string } | null | undefined)?.id ?? null;
+  const currentUserAdmission =
+    !preserveExactPrompt && !attempt.skipPreparedUserTurnMessage
+      ? attempt.userTurnTranscriptRecorder?.getAdmissionReceipt()
+      : undefined;
+  // Preparation can hide the current runtime message while preserving its durable leaf.
+  // Pin BTW to that exact admission's parent; null intentionally means no prior history.
+  const transcriptLeafId = currentUserAdmission
+    ? currentUserAdmission.effectiveParentId
+    : input.sessionManager.getLeafId();
   const heartbeatSummary =
     !isSettledTurnFinalization && attempt.config && input.sessionAgentId
       ? resolveHeartbeatSummaryForAgent(attempt.config, input.sessionAgentId)

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
@@ -1,17 +1,34 @@
+import path from "node:path";
 import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  loadTranscriptEventsSync,
+  upsertSessionEntryCore,
+} from "../../../config/sessions/session-accessor.js";
 import type { ImageContent } from "../../../llm/types.js";
 import { createUserTurnTranscriptRecorder } from "../../../sessions/user-turn-transcript.js";
+import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
+import { prepareSystemAgentRunAdmission } from "../../admitted-run-context.js";
+import { readBtwTranscriptMessages } from "../../btw-transcript.js";
 import type { AgentMessage } from "../../runtime/index.js";
+import { SessionManager } from "../../sessions/session-manager.js";
 import {
   beginPromptCacheObservation,
   completePromptCacheObservation,
 } from "../prompt-cache-observability.js";
 import {
+  clearActiveEmbeddedRun,
+  getActiveEmbeddedRunSnapshot,
+  setActiveEmbeddedRun,
+} from "../runs.js";
+import {
   clearEmbeddedSessionPromptStates,
   getEmbeddedSessionPromptState,
 } from "../session-prompt-state.js";
+import { prepareEmbeddedAttemptPromptAssembly } from "./attempt-prompt-build.js";
+import { forgetPromptBuildDrainCacheForRun } from "./attempt-prompt-helpers.js";
 import { submitEmbeddedAttemptPrompt } from "./attempt-prompt-submit.js";
+import { prepareEmbeddedAttemptSessionBoundary } from "./attempt-session-prepare.js";
 import type { RuntimeContextCustomMessage } from "./runtime-context-prompt.js";
 
 const sessionId = "attempt-prompt-submit-test";
@@ -30,6 +47,9 @@ function createSession() {
     state,
     streamFn: baseStreamFn,
     transformContext: originalTransformContext,
+    reset: () => {
+      state.messages = [];
+    },
   };
   const activeSession = {
     get messages() {
@@ -68,6 +88,159 @@ afterEach(() => {
 });
 
 describe("submitEmbeddedAttemptPrompt", () => {
+  it.each([
+    { scenario: "first-turn", excludeCurrentUser: true },
+    { scenario: "after-reset", excludeCurrentUser: true },
+    { scenario: "after-reset-metadata", excludeCurrentUser: true },
+    { scenario: "skipped-prepared", excludeCurrentUser: false },
+    { scenario: "raw-probe", excludeCurrentUser: false },
+    { scenario: "settled-finalization", excludeCurrentUser: false },
+  ])(
+    "preserves the pre-turn BTW snapshot boundary: $scenario",
+    async ({ scenario, excludeCurrentUser }) => {
+      await withOpenClawTestState({ label: "btw-current-user" }, async (state) => {
+        const target = {
+          agentId: "main",
+          sessionId,
+          sessionKey: `agent:main:btw-current-user-${scenario}`,
+          storePath: path.join(state.agentDir("main"), "openclaw-agent.sqlite"),
+        };
+        await upsertSessionEntryCore(target, { sessionId, updatedAt: 1 });
+        const sessionManager = SessionManager.open(target, state.workspaceDir);
+        if (scenario !== "first-turn") {
+          sessionManager.appendMessage({ role: "user", content: "old conversation", timestamp: 1 });
+          sessionManager.appendResetBoundary("reset");
+        }
+        const beforeCurrentUserLeaf = sessionManager.getLeafId();
+        const currentUser = {
+          role: "user" as const,
+          content: "Current main task, not prior conversation",
+          idempotencyKey: "btw-current-user:user",
+          timestamp: 2,
+        };
+        const appended = sessionManager.appendMessageWithTranscriptAnchor(currentUser);
+        if (!appended.anchor) {
+          throw new Error("Expected a persisted current-user admission");
+        }
+        const recorder = createUserTurnTranscriptRecorder({
+          message: currentUser,
+          target: () => undefined,
+        });
+        recorder.markRuntimePersisted(currentUser, appended.anchor);
+        const { activeSession } = createSession();
+        activeSession.agent.state.messages = sessionManager.buildSessionContext().messages;
+        const input = createBaseInput();
+        const isRawModelRun = scenario === "raw-probe";
+        const isFinalization = scenario === "settled-finalization";
+        const attempt = {
+          config: {},
+          operation: isFinalization ? "settled-tool-finalization" : "attempt",
+          skipPreparedUserTurnMessage: isFinalization || scenario === "skipped-prepared",
+          model: { id: "test-model", provider: "test-provider", api: "openai-responses" },
+          modelId: "test-model",
+          provider: "test-provider",
+          prompt: currentUser.content,
+          runId: "btw-current-user",
+          sessionId,
+          sessionKey: target.sessionKey,
+          sessionTarget: target,
+          trigger: "user",
+          userTurnTranscriptRecorder: recorder,
+          workspaceDir: state.workspaceDir,
+        } as Parameters<typeof prepareEmbeddedAttemptPromptAssembly>[0]["attempt"];
+        await prepareEmbeddedAttemptSessionBoundary({
+          activeSession: activeSession as unknown as Parameters<
+            typeof prepareEmbeddedAttemptSessionBoundary
+          >[0]["activeSession"],
+          attempt,
+          getUserTranscriptContexts: () => undefined,
+          isRawModelRun,
+          preparedUserTurnMessage: attempt.skipPreparedUserTurnMessage ? undefined : currentUser,
+          sessionManager,
+          setActiveSessionSystemPrompt: vi.fn(),
+        });
+        const expectedSnapshotMessages = isFinalization ? [currentUser] : [];
+        expect(activeSession.messages).toEqual(expectedSnapshotMessages);
+        expect(sessionManager.getLeafId()).toBe(appended.entryId);
+        if (scenario === "after-reset-metadata") {
+          sessionManager.appendThinkingLevelChange("low");
+        }
+        const persistedBefore = loadTranscriptEventsSync(target);
+        const handle = {
+          runId: attempt.runId,
+          queueMessage: async () => undefined,
+          isStreaming: () => true,
+          isCompacting: () => false,
+          abort: () => undefined,
+        };
+        const admission = prepareSystemAgentRunAdmission(
+          {},
+          attempt.runId,
+          target.agentId,
+          "btw-snapshot-test",
+        );
+        setActiveEmbeddedRun(sessionId, handle, target.sessionKey);
+        try {
+          attempt.admittedRunContext = await admission.admit("embedded");
+          const assembly = await prepareEmbeddedAttemptPromptAssembly({
+            attempt,
+            activeSession: activeSession as unknown as Parameters<
+              typeof prepareEmbeddedAttemptPromptAssembly
+            >[0]["activeSession"],
+            sessionManager,
+            hookRunner: null,
+            hookAgentId: "main",
+            diagnosticTrace: { traceId: "11111111111111111111111111111111" },
+            isRawModelRun,
+            sessionAgentId: "main",
+            runtimeModel: "test-model",
+            systemPromptText: input.systemPrompt,
+            applyPromptBuildToolsAllow: () => [],
+            setActiveSessionSystemPrompt: vi.fn(),
+            setLeasedSteering: vi.fn(),
+            cache: {
+              observabilityEnabled: false,
+              retention: "none",
+              streamStrategy: "default",
+              transport: "sse",
+              tools: [],
+              trace: null,
+            },
+          });
+          await submitEmbeddedAttemptPrompt({
+            ...input,
+            attempt,
+            activeSession,
+            transcriptLeafId: assembly.transcriptLeafId,
+            transcriptPrompt: currentUser.content,
+            modelPrompt: currentUser.content,
+            promptActiveSession: async () => undefined,
+          });
+          const snapshot = getActiveEmbeddedRunSnapshot(sessionId);
+          if (!snapshot) {
+            throw new Error("Expected the submitted main-run snapshot");
+          }
+          expect(snapshot.messages).toEqual(expectedSnapshotMessages);
+          expect(snapshot.inFlightPrompt).toBe(currentUser.content);
+          const messages = await readBtwTranscriptMessages({
+            ...target,
+            sessionFile: target.sessionKey,
+            snapshotLeafId: snapshot.transcriptLeafId,
+          });
+          expect(messages).toEqual(excludeCurrentUser ? [] : [currentUser]);
+          expect(snapshot.transcriptLeafId).toBe(
+            excludeCurrentUser ? beforeCurrentUserLeaf : sessionManager.getLeafId(),
+          );
+          expect(loadTranscriptEventsSync(target)).toEqual(persistedBefore);
+        } finally {
+          admission.close();
+          clearActiveEmbeddedRun(sessionId, handle, target.sessionKey);
+          forgetPromptBuildDrainCacheForRun(attempt.runId);
+        }
+      });
+    },
+  );
+
   it.each([
     { skipPreparedUserTurnMessage: false, expectedKey: "persisted-current-user" },
     { skipPreparedUserTurnMessage: true, expectedKey: undefined },

--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -69,6 +69,7 @@ function normalizeMockProviderId(providerId?: string): string {
 
 type SessionManagerMocks = {
   getSessionTarget: Mock<() => undefined>;
+  getLeafId: Mock<() => string | null>;
   getLeafEntry: UnknownMock;
   getEntry: UnknownMock;
   getBoundaryCount: UnknownMock;
@@ -275,6 +276,7 @@ const hoisted = vi.hoisted((): AttemptSpawnWorkspaceHoisted => {
   const trajectoryEvents: CapturedTrajectoryEvent[] = [];
   const sessionManager = {
     getSessionTarget: vi.fn(() => undefined),
+    getLeafId: vi.fn<() => string | null>(() => null),
     getLeafEntry: vi.fn(() => null),
     getEntry: vi.fn(() => undefined),
     getBoundaryCount: vi.fn(() => 0),
@@ -1142,6 +1144,7 @@ export function resetEmbeddedAttemptHarness(
   hoisted.embeddedSystemPromptInputs.length = 0;
   hoisted.trajectoryEvents.length = 0;
   hoisted.sessionManager.getSessionTarget.mockReset().mockReturnValue(undefined);
+  hoisted.sessionManager.getLeafId.mockReset().mockReturnValue(null);
   hoisted.sessionManager.getLeafEntry.mockReset().mockReturnValue(null);
   hoisted.sessionManager.getEntry.mockReset().mockReturnValue(undefined);
   hoisted.sessionManager.getBoundaryCount.mockReset().mockReturnValue(0);

--- a/src/agents/embedded-agent-runner/run/attempt.settled-turn-finalization-context.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.settled-turn-finalization-context.test.ts
@@ -68,14 +68,12 @@ describe("settled post-tool turn finalization context", () => {
     expect(result.assistantTexts.every((text) => !text.trim())).toBe(true);
     // Without this context the provider-failure branch of incomplete-turn
     // recovery fails closed and the whole completed turn is discarded.
-    expect(result.settledTurnFinalizationContext).toBeDefined();
-    expect(result.settledTurnFinalizationContext?.source).toBe("openclaw-transcript");
-    expect(
-      result.settledTurnFinalizationContext?.messages.some(
-        (message) => message.role === "toolResult",
-      ),
-    ).toBe(true);
-    expect(Object.isFrozen(result.settledTurnFinalizationContext?.messages)).toBe(true);
+    const context = result.settledTurnFinalizationContext;
+    if (context?.source !== "openclaw-transcript") {
+      throw new Error("Expected the built-in settled transcript context");
+    }
+    expect(context.messages.some((message) => message.role === "toolResult")).toBe(true);
+    expect(Object.isFrozen(context.messages)).toBe(true);
   });
 
   it("omits the context when the turn settled no tool result", async () => {

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test.ts
@@ -623,6 +623,70 @@ describe("prepareTerminalWithSettledTurnFinalization", () => {
     });
   });
 
+  it.each([false, true])(
+    "uses the settled tool-batch identity for command-only fallback (context unavailable: %s)",
+    async (unavailable) => {
+      const assistant = buildEmbeddedRunnerAssistant({
+        model: "gpt-5.6-luna",
+        stopReason: "toolUse",
+        content: [{ type: "toolCall", id: "command-1", name: "exec", arguments: {} }],
+      });
+      const messagesSnapshot: EmbeddedRunAttemptWithReceiptEvidence["messagesSnapshot"] = [
+        { role: "user", content: "Run the command.", timestamp: 1 },
+        assistant,
+        {
+          role: "toolResult",
+          toolCallId: "command-1",
+          toolName: "exec",
+          content: [{ type: "text", text: "done" }],
+          isError: false,
+          timestamp: 3,
+        },
+      ];
+      const attempt = {
+        ...makeEmbeddedRunnerAttempt({
+          terminal: {
+            kind: "failed",
+            source: "prompt",
+            error: new Error("The provider is overloaded"),
+          },
+          sessionIdUsed: "session-settled",
+          sessionFileUsed: "/tmp/session-settled.jsonl",
+          messagesSnapshot,
+          toolMetas: [
+            { toolName: "exec", toolCallId: "command-1", isError: false, replaySafe: false },
+          ],
+          itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+          currentAttemptReplayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+          replayMetadata: { hadPotentialSideEffects: true, replaySafe: false },
+          currentAttemptAssistant: undefined,
+          lastAssistant: undefined,
+          settledTurnFinalizationContext: unavailable
+            ? { source: "unavailable" }
+            : { source: "openclaw-transcript", messages: messagesSnapshot },
+        }),
+        successfulNestedToolNames: [],
+      };
+      const input = finalizationInput(attempt);
+      input.terminalBase.runParams.trigger = "user";
+      backendMocks.runSettledFinalization.mockRejectedValueOnce(new Error("finalizer failed"));
+
+      const result = await prepareTerminalWithSettledTurnFinalization(input);
+
+      expect(backendMocks.runSettledFinalization).toHaveBeenCalledOnce();
+      expect(result.finalizationOutcome).toBe("failed");
+      expect(result.prepared.payloadsWithToolMedia).toEqual([
+        expect.objectContaining({ text: SETTLED_TOOL_FINALIZATION_FALLBACK_TEXT }),
+      ]);
+      expect(result.prepared.payloadsWithToolMedia?.[0]?.isError).not.toBe(true);
+      expect(result.prepared.failureSignal).toBeUndefined();
+      expect(result.attempt.currentAttemptAssistant).toMatchObject({
+        provider: assistant.provider,
+        model: assistant.model,
+      });
+    },
+  );
+
   it("preserves an explicit cancellation instead of delivering a fallback", async () => {
     const attempt = settledFailedAttempt();
     const input = finalizationInput(attempt);

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.ts
@@ -24,6 +24,7 @@ import {
   resolveRuntimeModelAttempt,
   runEmbeddedSettledTurnFinalizationWithBackend,
 } from "./backend.js";
+import { resolveSettledToolBatchEvidence } from "./incomplete-turn-recovery.js";
 import { withEmbeddedRunLaneProgressHeartbeat } from "./lane-runtime.js";
 import {
   resolveEmbeddedRunAttemptTerminalOutcome,
@@ -404,11 +405,14 @@ function buildSettledToolFallbackAttemptResult(input: {
   runtimePlan?: EmbeddedRunAttemptParams["runtimePlan"];
   transcriptIdempotencyKey?: string;
 }): EmbeddedRunAttemptWithReceiptEvidence {
+  // Command-only harnesses retain assistant identity in the settled tool batch,
+  // even when neither visible-assistant field exists.
   const sourceAssistant =
     input.sourceAttempt.currentAttemptAssistant ??
     input.sourceAttempt.lastAssistant ??
     input.settledAttempt.currentAttemptAssistant ??
-    input.settledAttempt.lastAssistant;
+    input.settledAttempt.lastAssistant ??
+    resolveSettledToolBatchEvidence(input.settledAttempt).assistant;
   if (!sourceAssistant) {
     throw new Error("Settled-turn fallback has no assistant identity");
   }

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -296,14 +296,10 @@ export type EmbeddedRunAttemptResult = {
   /** Exact provider-response count when the harness can observe model iterations directly. */
   modelIterations?: number;
   messagesSnapshot: AgentMessage[];
-  /**
-   * Complete application transcript frozen through a settled tool boundary.
-   * Projection-backed finalizers must fail closed when their harness does not provide it.
-   */
-  settledTurnFinalizationContext?: {
-    readonly source: "openclaw-transcript";
-    readonly messages: readonly AgentMessage[];
-  };
+  /** Complete settled evidence, frozen as transcript messages or an owning harness's bounded projection. */
+  settledTurnFinalizationContext?:
+    | { readonly source: "openclaw-transcript"; readonly messages: readonly AgentMessage[] }
+    | { readonly source: "harness"; readonly data: unknown };
   beforeAgentFinalizeRevisionReason?: string;
   assistantTexts: string[];
   latestMcpAppChannelView?: McpAppChannelView;

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -296,10 +296,11 @@ export type EmbeddedRunAttemptResult = {
   /** Exact provider-response count when the harness can observe model iterations directly. */
   modelIterations?: number;
   messagesSnapshot: AgentMessage[];
-  /** Complete settled evidence, frozen as transcript messages or an owning harness's bounded projection. */
+  /** Owner-eligible settled finalization, with frozen evidence or an unavailable projection. */
   settledTurnFinalizationContext?:
     | { readonly source: "openclaw-transcript"; readonly messages: readonly AgentMessage[] }
-    | { readonly source: "harness"; readonly data: unknown };
+    | { readonly source: "harness"; readonly data: unknown }
+    | { readonly source: "unavailable" };
   beforeAgentFinalizeRevisionReason?: string;
   assistantTexts: string[];
   latestMcpAppChannelView?: McpAppChannelView;

--- a/src/agents/sessions/session-manager-model-context.test.ts
+++ b/src/agents/sessions/session-manager-model-context.test.ts
@@ -121,6 +121,9 @@ it.each(["whole", "reset", "compaction", "reset-compaction", "leaf", "opaque"])(
       }
       source.appendMessage({ role: "user", content: "latest", timestamp: 5 });
       const expected = source.buildSessionContext();
+      expect(SessionManager.readSessionContext(scope, (messages) => Array.from(messages))).toEqual(
+        expected.messages,
+      );
       const visible = (messages: typeof expected.messages) =>
         messages.map((message) => ({
           role: message.role,
@@ -227,6 +230,11 @@ it.each(["whole", "reset", "compaction", "reset-compaction", "leaf", "opaque"])(
         ]) {
           expect(() =>
             SessionManager.openModelContext(scope, {
+              admission: { ...admission, ...patch } as typeof admission,
+            }),
+          ).toThrow(/Current-turn transcript admission/);
+          expect(() =>
+            SessionManager.readSessionContext(scope, () => [], {
               admission: { ...admission, ...patch } as typeof admission,
             }),
           ).toThrow(/Current-turn transcript admission/);
@@ -348,6 +356,9 @@ it.each([false, true])("keeps model reads non-persisting (incognito=%s)", async 
       storePath: path.join(state.agentDir("main"), "openclaw-agent.sqlite"),
     };
     expect(SessionManager.openModelContext(scope).buildSessionContext().messages).toEqual([]);
+    expect(SessionManager.readSessionContext(scope, (messages) => Array.from(messages))).toEqual(
+      [],
+    );
     expect(fs.existsSync(scope.storePath)).toBe(false);
     await upsertSessionEntryCore(scope, {
       sessionId: scope.sessionId,
@@ -400,6 +411,60 @@ it.each([false, true])("keeps model reads non-persisting (incognito=%s)", async 
     }
   });
 });
+
+it.each([false, true])(
+  "closes lazy context without acquiring unread payloads (rejected=%s)",
+  async (rejected) => {
+    await withOpenClawTestState({ label: "context-reader-lifetime" }, async (state) => {
+      const scope = {
+        agentId: "main",
+        sessionId: "lazy-context",
+        sessionKey: "agent:main:lazy-context",
+        storePath: path.join(state.agentDir("main"), "openclaw-agent.sqlite"),
+      };
+      await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
+      const source = SessionManager.open(scope);
+      source.appendMessage({ role: "user", content: "first", timestamp: 1 });
+      const marker = "synthetic-unread-context:";
+      source.appendMessage({
+        role: "user",
+        content: marker + "x".repeat(256 * 1024),
+        timestamp: 2,
+      });
+      let retained: Iterator<unknown> | undefined;
+      let unreadPayloads = 0;
+      const parse = JSON.parse;
+      const spy = vi.spyOn(JSON, "parse").mockImplementation((text, reviver) => {
+        if (typeof text === "string" && text.includes(marker)) {
+          unreadPayloads += 1;
+        }
+        return parse(text, reviver);
+      });
+      try {
+        const read = () =>
+          SessionManager.readSessionContext(scope, (messages) => {
+            retained = messages[Symbol.iterator]();
+            expect(retained.next().value).toMatchObject({ role: "user", content: "first" });
+            if (rejected) {
+              throw new Error("synthetic projection rejection");
+            }
+          });
+        if (rejected) {
+          expect(read).toThrow("synthetic projection rejection");
+        } else {
+          read();
+        }
+        expect(retained?.next()).toEqual({ done: true, value: undefined });
+        expect(unreadPayloads).toBe(0);
+      } finally {
+        spy.mockRestore();
+      }
+      expect(SessionManager.readSessionContext(scope, (messages) => Array.from(messages))).toEqual(
+        source.buildSessionContext().messages,
+      );
+    });
+  },
+);
 
 it("keeps the real result when reset retention replaces a synthetic missing result", async () => {
   await withOpenClawTestState({ label: "model-pairing" }, async (state) => {

--- a/src/agents/sessions/session-manager.ts
+++ b/src/agents/sessions/session-manager.ts
@@ -4,13 +4,17 @@
  * The public facade lives here; codec, storage, persistence, and branching
  * behavior are split into focused internal modules.
  */
+import type { AgentMessage } from "../../../packages/agent-core/src/types.js";
 import {
   appendTranscriptMessageSync,
   loadTranscriptEventsSync,
   type SessionTranscriptRuntimeTarget,
 } from "../../config/sessions/session-accessor.js";
 import { readSessionTranscriptBoundedActiveContextCore } from "../../config/sessions/session-accessor.sqlite-active-context.js";
-import { readSessionTranscriptModelContext } from "../../config/sessions/session-accessor.sqlite-model-context.js";
+import {
+  readSessionTranscriptContextMessages,
+  readSessionTranscriptModelContext,
+} from "../../config/sessions/session-accessor.sqlite-model-context.js";
 import {
   runWithSessionTranscriptReadFence,
   SessionTranscriptReadFenceError,
@@ -56,6 +60,24 @@ export type {
   SessionTreeNode,
   ThinkingLevelChangeEntry,
 } from "./session-manager-types.js";
+
+function withSessionContextAdmission<T>(
+  target: SessionTranscriptRuntimeTarget,
+  admission: UserTurnTranscriptAdmissionReceipt | undefined,
+  read: () => T,
+): T {
+  if (
+    admission &&
+    (target.agentId !== admission.agentId ||
+      target.sessionId !== admission.sessionId ||
+      target.sessionKey !== admission.sessionKey)
+  ) {
+    throw new SessionTranscriptReadFenceError(
+      "Current-turn transcript admission belongs to a different transcript target",
+    );
+  }
+  return runWithSessionTranscriptReadFence(admission, read);
+}
 
 export class SessionManager extends SessionManagerBranching {
   private constructor(
@@ -134,18 +156,7 @@ export class SessionManager extends SessionManagerBranching {
       admission?: UserTurnTranscriptAdmissionReceipt;
     } = {},
   ): SessionManager {
-    const { admission } = options;
-    if (
-      admission &&
-      (target.agentId !== admission.agentId ||
-        target.sessionId !== admission.sessionId ||
-        target.sessionKey !== admission.sessionKey)
-    ) {
-      throw new SessionTranscriptReadFenceError(
-        "Current-turn transcript admission belongs to a different transcript target",
-      );
-    }
-    const contextEntries = runWithSessionTranscriptReadFence(admission, () =>
+    const contextEntries = withSessionContextAdmission(target, options.admission, () =>
       readSessionTranscriptModelContext(target),
     );
     // SAFETY: The transcript owner preserves the entry union; the constructor applies the normal codec.
@@ -157,6 +168,17 @@ export class SessionManager extends SessionManagerBranching {
       );
     }
     return new SessionManager(options.cwd ?? header?.cwd ?? process.cwd(), undefined, entries);
+  }
+
+  /** Synchronously consumes full-fidelity context; its iterator closes with the read snapshot. */
+  static readSessionContext<T>(
+    target: SessionTranscriptRuntimeTarget,
+    read: (messages: Iterable<AgentMessage>, header: unknown) => T,
+    options: { admission?: UserTurnTranscriptAdmissionReceipt } = {},
+  ): T {
+    return withSessionContextAdmission(target, options.admission, () =>
+      readSessionTranscriptContextMessages(target, read),
+    );
   }
 
   /** Appends to the current transcript leaf without hydrating its history. */

--- a/src/config/sessions/session-accessor.sqlite-active-context.ts
+++ b/src/config/sessions/session-accessor.sqlite-active-context.ts
@@ -112,14 +112,15 @@ export function readSessionTranscriptBoundedActiveContextCore(
       database: projection.database,
       ...projection.resolved,
     });
+    const transcript = db
+      .selectFrom("transcript_events")
+      .where("session_id", "=", projection.resolved.sessionId);
     // Migrated transcripts may place a delivery mirror before the header or lack the auxiliary
     // identity rows entirely. Select the canonical stored event by type so runtime keeps its version.
     const header = executeSqliteQueryTakeFirstSync(
       projection.database.db,
-      db
-        .selectFrom("transcript_events")
-        .select("event_json")
-        .where("session_id", "=", projection.resolved.sessionId)
+      transcript
+        .select("seq")
         .where(
           /* kysely-allow-raw: the canonical transcript event type is stored inside event_json. */
           sql<string>`json_extract(event_json, '$.type')`,
@@ -129,7 +130,17 @@ export function readSessionTranscriptBoundedActiveContextCore(
         .orderBy("seq", "asc")
         .limit(1),
     );
-    const headerBytes = header ? Buffer.byteLength(header.event_json, "utf8") + 1 : 0;
+    const headerBytes = header
+      ? executeSqliteQueryTakeFirstSync(
+          projection.database.db,
+          transcript
+            .select(
+              /* kysely-allow-raw: reject an oversized header before acquiring its JSON payload. */
+              sql<number>`OCTET_LENGTH(event_json) + 1`.as("serialized_bytes"),
+            )
+            .where("seq", "=", header.seq),
+        )!.serialized_bytes
+      : 0;
     if (headerBytes > maxBytes) {
       throw new RangeError("Session transcript header exceeds the active-context byte limit");
     }
@@ -143,7 +154,6 @@ export function readSessionTranscriptBoundedActiveContextCore(
             .onRef("event.seq", "=", "active.event_seq"),
         )
         .select([
-          "active.active_position",
           "active.event_seq",
           /* kysely-allow-raw: active-context byte caps exclude rows before fetching or parsing. */
           sql<number>`OCTET_LENGTH(event.event_json) + 1`.as("serialized_bytes"),
@@ -168,88 +178,85 @@ export function readSessionTranscriptBoundedActiveContextCore(
       selectedSequences.push(row.event_seq);
       serializedBytes += row.serialized_bytes;
     }
-    const selectedRows =
-      selectedSequences.length === 0
-        ? []
-        : executeSqliteQuerySync(
-            projection.database.db,
-            db
-              .selectFrom("transcript_events")
-              .select(["event_json", "seq"])
-              .where("session_id", "=", projection.resolved.sessionId)
-              .where("seq", "in", selectedSequences)
-              .orderBy("seq", "asc"),
-          ).rows;
     const boundary = executeSqliteQueryTakeFirstSync(
       projection.database.db,
       db
-        .selectFrom("transcript_event_identities as identity")
-        .innerJoin("session_transcript_active_events as active", (join) =>
-          join
-            .onRef("active.session_id", "=", "identity.session_id")
-            .onRef("active.event_seq", "=", "identity.seq"),
+        .selectFrom(
+          db
+            .selectFrom("transcript_event_identities as identity")
+            .innerJoin("session_transcript_active_events as active", (join) =>
+              join
+                .onRef("active.session_id", "=", "identity.session_id")
+                .onRef("active.event_seq", "=", "identity.seq"),
+            )
+            .select((eb) => [
+              "identity.seq",
+              eb.fn.count<number>("identity.seq").over().as("boundary_count"),
+            ])
+            .where("identity.session_id", "=", projection.resolved.sessionId)
+            .where("identity.event_type", "in", ["compaction", "reset"])
+            .$if(fence !== undefined, (query) =>
+              query.where("identity.seq", "<", fence!.beforeRawSeq),
+            )
+            .orderBy("active.active_position", "desc")
+            .limit(1)
+            .as("boundary"),
         )
         .innerJoin("transcript_events as event", (join) =>
           join
-            .onRef("event.session_id", "=", "identity.session_id")
-            .onRef("event.seq", "=", "identity.seq"),
+            .on("event.session_id", "=", projection.resolved.sessionId)
+            .onRef("event.seq", "=", "boundary.seq"),
         )
-        .select(["event.event_json", "identity.seq"])
-        .where("identity.session_id", "=", projection.resolved.sessionId)
-        .where("identity.event_type", "in", ["compaction", "reset"])
-        .$if(fence !== undefined, (query) => query.where("identity.seq", "<", fence!.beforeRawSeq))
-        .orderBy("active.active_position", "desc")
-        .limit(1),
+        .select([
+          "boundary.seq",
+          "boundary.boundary_count",
+          /* kysely-allow-raw: count boundaries without carrying payloads through the window query. */
+          sql<number>`OCTET_LENGTH(event.event_json) + 1`.as("serialized_bytes"),
+        ]),
     );
-    const boundaryCount = executeSqliteQueryTakeFirstSync(
-      projection.database.db,
-      db
-        .selectFrom("transcript_event_identities as identity")
-        .innerJoin("session_transcript_active_events as active", (join) =>
-          join
-            .onRef("active.session_id", "=", "identity.session_id")
-            .onRef("active.event_seq", "=", "identity.seq"),
-        )
-        .select((eb) => eb.fn.count<number>("identity.seq").as("boundary_count"))
-        .where("identity.session_id", "=", projection.resolved.sessionId)
-        .where("identity.event_type", "in", ["compaction", "reset"])
-        .$if(fence !== undefined, (query) => query.where("identity.seq", "<", fence!.beforeRawSeq)),
-    )?.boundary_count;
-    const events: TranscriptEvent[] = header ? [JSON.parse(header.event_json)] : [];
-    const rows: Array<{ event: TranscriptEvent; seq: number }> = [];
-    let injectedBoundary: { id?: unknown } | undefined;
+    const contextSequences = selectedSequences.toSorted((left, right) => left - right);
+    let injectedBoundarySeq: number | undefined;
     let boundaryOmitted = false;
     if (boundary && !selectedSequences.includes(boundary.seq)) {
-      const boundaryBytes = Buffer.byteLength(boundary.event_json, "utf8") + 1;
-      if (serializedBytes + boundaryBytes <= maxBytes) {
-        const event: TranscriptEvent = JSON.parse(boundary.event_json);
-        events.push(event);
-        rows.push({ event, seq: boundary.seq });
-        if (event !== null && typeof event === "object" && "id" in event) {
-          injectedBoundary = event;
-        }
-        serializedBytes += boundaryBytes;
+      if (serializedBytes + boundary.serialized_bytes <= maxBytes) {
+        injectedBoundarySeq = boundary.seq;
+        contextSequences.unshift(boundary.seq);
+        serializedBytes += boundary.serialized_bytes;
       } else {
         boundaryOmitted = true;
       }
     }
+    const payloadSequences = header ? [header.seq, ...contextSequences] : contextSequences;
+    // One payload read follows all byte decisions; header-first ordering also supports migrated mirrors.
+    const payloads = new Map<number, TranscriptEvent>(
+      (payloadSequences.length === 0
+        ? []
+        : executeSqliteQuerySync(
+            projection.database.db,
+            transcript.select(["seq", "event_json"]).where("seq", "in", payloadSequences),
+          ).rows
+      ).map((row) => [row.seq, JSON.parse(row.event_json)]),
+    );
+    const events: TranscriptEvent[] = header ? [payloads.get(header.seq)!] : [];
+    const rows = contextSequences.map((seq) => ({ event: payloads.get(seq)!, seq }));
     const opaqueParents = new Map<string, string | null>();
-    let previousId = injectedBoundary?.id;
-    for (const row of selectedRows) {
-      const event: TranscriptEvent = JSON.parse(row.event_json);
-      if (event !== null && typeof event === "object" && "id" in event && "parentId" in event) {
+    let previousId: unknown;
+    for (const { event, seq } of rows) {
+      const entry = asOptionalRecord(event);
+      if (seq === injectedBoundarySeq) {
+        previousId = entry?.id;
+      } else if (entry && "id" in entry && "parentId" in entry) {
         // Omitted display payloads retain an opaque ancestry link, never a fabricated event.
         if (
           typeof previousId === "string" &&
-          typeof event.parentId === "string" &&
-          event.parentId !== previousId
+          typeof entry.parentId === "string" &&
+          entry.parentId !== previousId
         ) {
-          opaqueParents.set(event.parentId, previousId);
+          opaqueParents.set(entry.parentId, previousId);
         }
-        previousId = event.id;
+        previousId = entry.id;
       }
       events.push(event);
-      rows.push({ event, seq: row.seq });
     }
     const activeLeafEntryId = fence
       ? fence.admission.effectiveParentId
@@ -264,7 +271,7 @@ export function readSessionTranscriptBoundedActiveContextCore(
       activeLeafEntryId,
       opaqueParents,
       firstKeptRanges,
-      boundaryCount: boundaryCount ?? 0,
+      boundaryCount: boundary?.boundary_count ?? 0,
       events,
       serializedBytes,
       totalEvents: projection.state.activeEventCount,

--- a/src/config/sessions/session-accessor.sqlite-bounded-context.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-bounded-context.test.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
 import { expect, it, vi } from "vitest";
-import { SessionManager } from "../../agents/sessions/session-manager.js";
+import { CURRENT_SESSION_VERSION, SessionManager } from "../../agents/sessions/session-manager.js";
 import { makeAgentAssistantMessage } from "../../agents/test-helpers/agent-message-fixtures.js";
+import { clearNodeSqliteKyselyCacheForDatabase } from "../../infra/kysely-sync.js";
 import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import {
@@ -40,6 +41,44 @@ async function withBoundedContextScope(
     await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 1 });
     await run(scope);
   });
+}
+
+function countAcquiredTranscriptPayloadBytes(
+  db: ReturnType<typeof openOpenClawAgentDatabase>["db"],
+  marker: string,
+  read: () => void,
+): number {
+  clearNodeSqliteKyselyCacheForDatabase(db);
+  const prepare = db.prepare.bind(db);
+  const restoreStatements: Array<() => void> = [];
+  let acquiredBytes = 0;
+  const prepareSpy = vi.spyOn(db, "prepare").mockImplementation((query) => {
+    const statement = prepare(query);
+    const iterate = statement.iterate.bind(statement);
+    // Observe SQLite result acquisition, including payloads rejected before JSON.parse.
+    const iterateSpy = vi.spyOn(statement, "iterate").mockImplementation(function* (...params) {
+      for (const row of iterate(...params)) {
+        for (const value of Object.values(row)) {
+          if (typeof value === "string" && value.includes(marker)) {
+            acquiredBytes += Buffer.byteLength(value);
+          }
+        }
+        yield row;
+      }
+      return undefined;
+    });
+    restoreStatements.push(() => iterateSpy.mockRestore());
+    return statement;
+  });
+  try {
+    read();
+  } finally {
+    prepareSpy.mockRestore();
+    for (const restore of restoreStatements) {
+      restore();
+    }
+  }
+  return acquiredBytes;
 }
 
 it("reads only the newest bounded active context and accounts for its header", async () => {
@@ -98,6 +137,70 @@ it("reserves the transcript header inside the exact byte limit", async () => {
     expect(context.truncated).toBe(true);
   });
 });
+
+it("rejects an oversized header before acquiring its payload", async () => {
+  await withBoundedContextScope(async (scope) => {
+    const marker = "synthetic-oversized-header:";
+    await appendTranscriptEvent(scope, {
+      type: "session",
+      version: CURRENT_SESSION_VERSION,
+      id: scope.sessionId,
+      cwd: marker + "x".repeat(4096),
+    });
+    const { db } = openOpenClawAgentDatabase({ agentId: scope.agentId });
+    const acquiredBytes = countAcquiredTranscriptPayloadBytes(db, marker, () => {
+      expect(() =>
+        readSessionTranscriptBoundedActiveContextCore(scope, { maxBytes: 1024, maxEvents: 10 }),
+      ).toThrow("Session transcript header exceeds the active-context byte limit");
+    });
+    expect(acquiredBytes).toBe(0);
+  });
+});
+
+it.each(["compaction", "reset"] as const)(
+  "omits an oversized latest %s boundary before acquiring its payload",
+  async (type) => {
+    await withBoundedContextScope(async (scope) => {
+      const manager = SessionManager.open(scope);
+      const kept = manager.appendMessage({ role: "user", content: "retained", timestamp: 1 });
+      const marker = "synthetic-oversized-boundary:";
+      await appendTranscriptEvent(scope, {
+        type,
+        id: "oversized-boundary",
+        parentId: kept,
+        timestamp: "2026-08-30T00:00:00.000Z",
+        firstKeptEntryId: kept,
+        ...(type === "compaction" ? { summary: "summary", tokensBefore: 100 } : { reason: "new" }),
+        details: { payload: marker + "x".repeat(4096) },
+      });
+      await appendTranscriptMessage(scope, {
+        eventId: "tail",
+        message: { role: "user", content: "latest", timestamp: 2 },
+      });
+      await waitForSessionTranscriptProjection(scope);
+      const { db } = openOpenClawAgentDatabase({ agentId: scope.agentId });
+      const acquiredBytes = countAcquiredTranscriptPayloadBytes(db, marker, () => {
+        const context = readSessionTranscriptBoundedActiveContextCore(scope, {
+          maxBytes: 1024,
+          maxEvents: 1,
+        });
+        expect(context.events.map((event) => (event as { id: string }).id)).toEqual([
+          scope.sessionId,
+          "tail",
+        ]);
+        expect(context.truncated).toBe(true);
+        expect(context.boundaryCount).toBe(1);
+        expect(context.serializedBytes).toBe(
+          context.events.reduce<number>(
+            (bytes, event) => bytes + Buffer.byteLength(JSON.stringify(event)) + 1,
+            0,
+          ),
+        );
+      });
+      expect(acquiredBytes).toBe(0);
+    });
+  },
+);
 
 it("selects the session header by type when a mirror row precedes it", async () => {
   await withBoundedContextScope(async (scope) => {
@@ -207,16 +310,23 @@ it("selects the session header when an exact migrated transcript has no identity
   });
 });
 
-it("retains the latest compaction boundary before a truncated tail", async () => {
+it("retains the latest boundary and counts earlier resets before a truncated tail", async () => {
   await withBoundedContextScope(async (scope) => {
     await persistSessionTranscriptTurn(scope, {
       messages: [{ eventId: "old", parentId: null, message: { role: "user", content: "old" } }],
       touchSessionEntry: false,
     });
     await appendTranscriptEvent(scope, {
+      type: "reset",
+      id: "prior-reset",
+      parentId: "old",
+      timestamp: "2026-08-24T00:00:00.000Z",
+      reason: "new",
+    });
+    await appendTranscriptEvent(scope, {
       type: "compaction",
       id: "summary",
-      parentId: "old",
+      parentId: "prior-reset",
       timestamp: "2026-08-25T00:00:00.000Z",
       summary: "earlier work",
       firstKeptEntryId: "old",
@@ -242,7 +352,7 @@ it("retains the latest compaction boundary before a truncated tail", async () =>
     ]);
     expect(context.events.at(-1)).toMatchObject({ parentId: "middle" });
     expect(context.opaqueParents.get("middle")).toBe("summary");
-    expect(context.boundaryCount).toBe(1);
+    expect(context.boundaryCount).toBe(2);
   });
 });
 
@@ -510,6 +620,40 @@ it("counts paired reset tool results without counting discarded orphan results",
       "second-post-reset",
     ]);
     expect(readSessionTranscriptActiveStats(scope).eventCount).toBe(3);
+  });
+});
+
+it("resolves reset history and raw-byte stats without acquiring unrelated reset fields", async () => {
+  await withBoundedContextScope(async (scope) => {
+    const manager = SessionManager.open(scope);
+    manager.appendMessage({ role: "user", content: "discarded", timestamp: 1 });
+    const kept = manager.appendMessage({ role: "user", content: "retained", timestamp: 2 });
+    const marker = "synthetic-reset-only-payload:";
+    await appendTranscriptEvent(scope, {
+      type: "reset",
+      id: "reset-with-extra-fields",
+      parentId: kept,
+      timestamp: "2026-08-30T00:00:00.000Z",
+      reason: "new",
+      firstKeptEntryId: kept,
+      details: { payload: marker + "x".repeat(4096) },
+    });
+    await waitForSessionTranscriptProjection(scope);
+    const { db } = openOpenClawAgentDatabase({ agentId: scope.agentId });
+    const acquiredBytes = countAcquiredTranscriptPayloadBytes(db, marker, () => {
+      const history = readSessionTranscriptBoundedMessageTailPage(scope, {
+        maxBytes: 1024,
+        maxMessages: 100,
+        offset: 0,
+      });
+      expect(history.totalMessages).toBe(1);
+      expect(history.events.map(({ event }) => (event as { id: string }).id)).toEqual([kept]);
+      expect(readSessionTranscriptActiveStats(scope)).toEqual({
+        eventCount: 1,
+        sizeBytes: history.serializedBytes,
+      });
+    });
+    expect(acquiredBytes).toBe(0);
   });
 });
 

--- a/src/config/sessions/session-accessor.sqlite-model-context.ts
+++ b/src/config/sessions/session-accessor.sqlite-model-context.ts
@@ -1,8 +1,10 @@
-import type { SessionTreeEntry } from "@openclaw/agent-core";
+import type { AgentMessage, SessionTreeEntry } from "@openclaw/agent-core";
 import { isCompactionReplayCheckpoint } from "@openclaw/ai/transports";
 import { sql } from "kysely";
-import { resolveSessionContextWindow } from "../../../packages/agent-core/src/harness/session/session.js";
-import { selectResetKeptEntries } from "../../../packages/agent-core/src/harness/session/tool-result-pairing.js";
+import {
+  iterateSessionContextEntries,
+  iterateSessionContextMessages,
+} from "../../../packages/agent-core/src/harness/session/session.js";
 import {
   executeSqliteQueryTakeFirstSync,
   iterateSqliteQuerySync,
@@ -29,10 +31,62 @@ import {
   selectSessionTranscriptTreePathNodes,
 } from "./transcript-tree.js";
 
+type ContextEntry = SessionTreeEntry & { seq: number };
+type TranscriptContextSnapshot = {
+  header: TranscriptEvent;
+  entries: ContextEntry[];
+  readEntry: (entry: ContextEntry, omitCheckpoint?: boolean) => SessionTreeEntry;
+};
+
 /** Read a transient context without opening the writer lifecycle or copying native evidence. */
 export function readSessionTranscriptModelContext(
   scope: SessionTranscriptReadScope,
 ): TranscriptEvent[] {
+  const result = withTranscriptContextSnapshot(
+    scope,
+    "model-context",
+    ({ header, entries, readEntry }) => {
+      const payloads = new Map<ContextEntry, SessionTreeEntry>();
+      for (const { entry, context } of iterateSessionContextEntries(entries)) {
+        const omitCheckpoint =
+          context !== "current" &&
+          entry.type === "message" &&
+          entry.message.role === "assistant" &&
+          isCompactionReplayCheckpoint(entry.message.providerReplay);
+        payloads.set(entry, readEntry(entry, omitCheckpoint));
+      }
+      return [...(header ? [header] : []), ...entries.map((entry) => payloads.get(entry) ?? entry)];
+    },
+  );
+  return result.found ? result.value : [];
+}
+
+/** Consume full-fidelity context lazily inside one read snapshot, never retaining raw history. */
+export function readSessionTranscriptContextMessages<T>(
+  scope: SessionTranscriptReadScope,
+  read: (messages: Iterable<AgentMessage>, header: unknown) => T,
+): T {
+  const result = withTranscriptContextSnapshot(
+    scope,
+    "transcript",
+    ({ header, entries, readEntry }) => {
+      const messages = iterateSessionContextMessages(entries, readEntry);
+      try {
+        return read(messages, header);
+      } finally {
+        // Retained iterators cannot read after the snapshot closes, including early rejection.
+        messages.return(undefined);
+      }
+    },
+  );
+  return result.found ? result.value : read([], undefined);
+}
+
+function withTranscriptContextSnapshot<T>(
+  scope: SessionTranscriptReadScope,
+  view: "model-context" | "transcript",
+  read: (snapshot: TranscriptContextSnapshot) => T,
+): { found: true; value: T } | { found: false } {
   const resolved = resolveSqliteTranscriptReadScope(scope);
   const result = withOpenClawAgentDatabaseReadOnly(
     (database) =>
@@ -69,30 +123,31 @@ export function readSessionTranscriptModelContext(
                   ])
                   .orderBy("seq", "asc"),
               )) {
-                // The navigation projection preserves discriminants and state, with empty
-                // bodies. Only selected model messages are subsequently hydrated.
-                // SAFETY: SQL retains entry discriminants/state; the detached manager validates readability.
+                // Only navigation crosses into JavaScript before the canonical context is selected.
+                // SAFETY: SQL preserves entry discriminants and replaces payloads with readable empty bodies.
                 yield { ...(JSON.parse(row.navigation_json) as SessionTreeEntry), seq: row.seq };
               }
             })(),
           );
-          const selected = selectSessionTranscriptTreePathNodes(tree, tree.leafId);
-          const entries = selected.map((node) => node.entry);
-          const window = resolveSessionContextWindow(entries);
-          const boundary = entries[window.boundaryIndex];
-          const kept = entries.slice(window.firstKeptIndex, window.boundaryIndex);
-          const resetKept =
-            boundary?.type === "reset" ? new Set(selectResetKeptEntries(kept)) : undefined;
+          // Navigation entries belong to this snapshot; normalize ancestry without another copy.
+          const entries = selectSessionTranscriptTreePathNodes(tree, tree.leafId).map(
+            ({ entry, parentId }) => {
+              entry.parentId = parentId;
+              return entry;
+            },
+          );
           const readPayload = prepareSqliteQuerySync<
             { seq: number; omitCheckpoint: number },
             { event_json: string }
           >(database.db, (parameter) =>
             base
               .select((eb) =>
-                projectModelContextEventSql(
-                  eb.ref("event_json"),
-                  parameter((row) => row.omitCheckpoint),
-                ).as("event_json"),
+                view === "model-context"
+                  ? projectModelContextEventSql(
+                      eb.ref("event_json"),
+                      parameter((row) => row.omitCheckpoint),
+                    ).as("event_json")
+                  : eb.ref("event_json").as("event_json"),
               )
               .where(
                 "seq",
@@ -100,48 +155,24 @@ export function readSessionTranscriptModelContext(
                 parameter((row) => row.seq),
               ),
           );
-          const events: TranscriptEvent[] = header ? [JSON.parse(header.event_json)] : [];
-          for (const [index, node] of selected.entries()) {
-            const entry = node.entry;
-            const retained = index >= window.firstKeptIndex && index < window.boundaryIndex;
-            const inContext =
-              window.boundaryIndex < 0 ||
-              index >= window.boundaryIndex ||
-              (retained && (!resetKept || resetKept.has(entry)));
-            const hasModelPayload =
-              entry.type === "message" ||
-              entry.type === "custom_message" ||
-              entry.type === "branch_summary" ||
-              index === window.boundaryIndex;
-            // appendResetKeptMessage consumes explicit reset retention regardless of ordinary exclusion.
-            const excluded =
-              !resetKept?.has(entry) &&
-              entry.type === "message" &&
-              "excludeFromContext" in entry.message &&
-              entry.message.excludeFromContext === true;
-            const row =
-              inContext && hasModelPayload && !excluded
-                ? readPayload({
-                    seq: node.entry.seq,
-                    omitCheckpoint:
-                      retained &&
-                      entry.type === "message" &&
-                      entry.message.role === "assistant" &&
-                      isCompactionReplayCheckpoint(entry.message.providerReplay)
-                        ? 1
-                        : 0,
-                  }).rows[0]
-                : undefined;
-            // SAFETY: Payload selection changes only storage-only message fields, not the persisted entry union.
-            const projected = row ? (JSON.parse(row.event_json) as SessionTreeEntry) : entry;
-            events.push({ ...projected, parentId: node.parentId });
-          }
-          return events;
+          return read({
+            header: header ? JSON.parse(header.event_json) : undefined,
+            entries,
+            readEntry: (entry, omitCheckpoint = false) => {
+              const row = readPayload({ seq: entry.seq, omitCheckpoint: omitCheckpoint ? 1 : 0 })
+                .rows[0];
+              return {
+                // SAFETY: The canonical payload is selected by its navigation row in this snapshot.
+                ...(JSON.parse(row!.event_json) as SessionTreeEntry),
+                parentId: entry.parentId,
+              };
+            },
+          });
         },
-        { operationLabel: "session model-context read" },
+        { operationLabel: "session context snapshot read" },
       ),
     toDatabaseOptions(resolved),
     { throwOnMissingTable: true },
   );
-  return result.found ? result.value : [];
+  return result;
 }

--- a/src/config/sessions/session-accessor.sqlite-reset-window.ts
+++ b/src/config/sessions/session-accessor.sqlite-reset-window.ts
@@ -159,7 +159,7 @@ function readLatestActiveBoundaryMetadata(
   return reset && (!compaction || reset.seq > compaction.seq) ? reset : compaction;
 }
 
-function readBoundaryPayload(
+function readBoundaryWindowFacts(
   projection: ResetWindowProjection,
   seq: number,
   scope: BoundaryWindowScope,
@@ -168,7 +168,11 @@ function readBoundaryPayload(
     projection.database.db,
     getResetWindowKysely(projection.database)
       .selectFrom("transcript_events")
-      .select("event_json")
+      .select((eb) => [
+        projectModelContextNavigationSql(eb.ref("event_json")).as("event_json"),
+        /* kysely-allow-raw: window accounting needs original bytes, not summary or reset payloads. */
+        sql<number>`OCTET_LENGTH(event_json) + 1`.as("serialized_bytes"),
+      ])
       .where("session_id", "=", projection.resolved.sessionId)
       .where("seq", "=", seq)
       .limit(1),
@@ -180,10 +184,7 @@ function readBoundaryPayload(
   if (!isWindowBoundary(parsed.type, scope)) {
     throw new Error("Active transcript boundary has invalid payload");
   }
-  return {
-    event: parsed,
-    sizeBytes: Buffer.byteLength(row.event_json, "utf8") + 1,
-  };
+  return { firstKeptEntryId: parsed.firstKeptEntryId, sizeBytes: row.serialized_bytes };
 }
 
 function findLatestResetMessageWindow(
@@ -196,8 +197,7 @@ function findLatestResetMessageWindow(
   if (!latestBoundary) {
     return null;
   }
-  const boundaryPayload = readBoundaryPayload(projection, latestBoundary.seq, scope);
-  const boundary = boundaryPayload.event;
+  const boundary = readBoundaryWindowFacts(projection, latestBoundary.seq, scope);
   const postBoundaryMessagePosition =
     executeSqliteQueryTakeFirstSync(
       projection.database.db,
@@ -213,7 +213,7 @@ function findLatestResetMessageWindow(
   let keptMessagePositions: number[] = [];
   const includesBoundary = latestBoundary.event_type === "compaction";
   let contextPrefixEventCount = includesBoundary ? 1 : 0;
-  let contextPrefixSizeBytes = includesBoundary ? boundaryPayload.sizeBytes : 0;
+  let contextPrefixSizeBytes = includesBoundary ? boundary.sizeBytes : 0;
   if (typeof boundary.firstKeptEntryId === "string") {
     const firstKept = executeSqliteQueryTakeFirstSync(
       projection.database.db,


### PR DESCRIPTION
Related: [active Codex transcript overhead (#115049)](https://github.com/openclaw/openclaw/pull/115049). This does not claim to supersede that broader work.

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled. This is a same-repository maintainer branch.

</details>

## What Problem This Solves

Long sessions could incur large, unnecessary history allocations while preparing a final answer after tools completed: settled-turn capture loaded and cloned the complete application-context prefix before the finalizer enforced its existing replay limits.

The same acquisition audit found three connected defects: native Codex forks accepted prompt drift beyond a display-text truncation boundary or normalized away whitespace changes; CLI byte-bounded history fetched oversized headers/boundaries before deciding whether they fit; and an empty BTW snapshot reloaded the already-persisted current user message.

Integration with newer main also exposed eligible finalization losing its host fallback when evidence was rejected earlier, and command-only fallback throwing despite an attributed assistant tool-call in the settled batch.

## Why This Change Was Made

Reuse one canonical context-window selector and a synchronous, read-only SQLite snapshot consumer. Codex validates identities and source evidence while projecting under the existing limits, then hands off frozen native input items instead of a raw history clone. Successful capture still finishes suffix duplicate checks; host-prompt adoption remains verification-only. Core passes harness-owned evidence opaquely and retains the built-in transcript handoff.

Native fork verification compares complete attested submitted text, CLI acquisition preflights metadata before payload reads, and BTW records the exact admission parent, including an intentionally empty parent. Shared Codex mirror-origin checks replace duplicated untyped reads. This preserves the existing model-only context repair.

An explicit unavailable-evidence state preserves only the owning harness's existing finalization eligibility; it does not authorize replay. The native finalizer rejects it before provider I/O, leaving the existing no-model host fallback available. Authentication and usage-limit exclusions remain unchanged. Command-only fallback reuses assistant identity from the canonical settled-tool-batch owner, rather than fabricating model/provider metadata.

## User Impact

- Lower transient/retained history memory during settled-turn finalization, without silently truncating evidence or raising limits.
- Native message forks reject changed submitted prompts, including long suffixes and whitespace.
- CLI byte limits apply before header/reset/compaction payload acquisition.
- BTW does not duplicate the current user when its in-memory snapshot is empty.
- Eligible post-tool turns retain a visible host fallback when safe finalizer evidence is unavailable, without repeating completed actions.

No configuration, schema, storage-policy, retention, projection-limit, timeout, or heap-limit changes. Legacy file-only imports and upstream pagination remain unchanged. Navigation and individual selected rows still scale with the transcript; this is not a fixed process-memory ceiling.

## Evidence

Candidate: `e27db7b938e7d6e6975fee1f86881aff28761a58`, based on main `ace8a13f19ccc2805b3d458026de3ab4bbbd8878`. Both commits retained identical patches through the rebase (`git range-diff`). The final `OPENCLAW_BUILD_PRIVATE_QA=1 pnpm build` passed in 6m17s, including runtime/SDK compilation, import-boundary checks, and Control UI budgets. No ineffective dynamic import warning or budget increase.

[Exact-head CI run 33418461319](https://github.com/openclaw/openclaw/actions/runs/33418461319) passed, including the required `openclaw/ci-gate` and the Windows lane. The previous [run 33412016671](https://github.com/openclaw/openclaw/actions/runs/33412016671) failed two pre-existing Gateway fixture checks; this candidate incorporates the existing [Gateway recovery fixture repair (#134207)](https://github.com/openclaw/openclaw/pull/134207), not a duplicate fix or a retry of the stale head.

Production: **+664/-685, net -21**. Tests/support: +777/-110, net +667. Docs: net +33. Assertion-baseline maintenance: net -3, recording only removed violations.

The original regressions failed before production repair: native prompt drift was accepted; oversized settled context was captured and later payloads decoded; four CLI metadata fixtures acquired payloads before rejection; three real SQLite → prompt preparation → snapshot → BTW cases included the current user when the snapshot should be empty. The integration regressions also failed for their intended reasons: two eligible oversized cases lost context presence, and command-only fallback threw `Settled-turn fallback has no assistant identity`.

Focused validation passed 295 tests during the original repair, then 106 Codex support and 111 core snapshot/finalization/context tests after integration with main. The final eligibility/fallback repair passed 24 native tests and 55 core finalization/settled-tool-evidence tests; these groups overlap earlier coverage and are not an aggregate total. The complete changed-file gate passed again on the published candidate: all four type lanes, core/plugin/scripts lint, dead exports, import cycles, and architecture/storage guards. The SDK surface gate also passed during the original repair. Fresh isolated Codex autoreview passed at the configured P0 threshold for both the primary repair and final integration diff.

The maintained `subagent-forked-context` QA smoke passed in both embedded and actual Codex 0.151.0 runtimes against a local mock Responses server on the pre-integration head, using synthetic homes and ephemeral auth. Native process identity and `codex-app-server` mirror provenance were observed; all owned processes were cleaned up. Parity reported `sessions_spawn` tool-result-shape drift, not zero drift. This is runtime smoke, not independent proof that a child recalled inherited history or of operator message-fork/BTW acquisition; targeted regressions own those assertions, and the child-history assertion gap is recorded separately. The harness performed an update-check Git fetch; candidate HEAD, build identity, and tracked source remained unchanged.

A source-only benchmark with 20,002 synthetic messages rejected oversized history under the existing limits in both versions. Payload reads fell from 40,000 to 128; peak process RSS from about 397 MiB to 118 MiB; projection time from about 618 ms to 1.2 ms. This is an isolated stress case, not a production Gateway measurement.

Pinned Codex 0.151.0 source was personally inspected: exclusive `beforeTurnId`, literal text conversion, native item validation/history-only injection, and persisted canonical fork boundaries. [Source citations and ClawSweeper finding disposition](https://github.com/openclaw/openclaw/pull/134238#issuecomment-5481752294) explain why the proposed adopted-prompt rewrite is not applied: the previous implementation also cloned the original persisted prompt. The projection is a transient host-process handoff, not a persistent data-model change.

All application proof uses source and synthetic fixtures. No operator conversations, configuration, credentials, core dumps, heaps, or running Gateway were used. Authenticated provider/channel behavior and visual UI proof are not claimed; the exercised surface is source/native-runtime synthetic evidence, not a signed-in operator flow. The separate oversized weekly skill-collection review issue remains out of scope.
