### PR TITLE
fix(browser): partition relay pre-auth admission [AI]

### DIFF
--- a/extensions/browser/src/browser/extension-relay/auth-v2-websocket.ts
+++ b/extensions/browser/src/browser/extension-relay/auth-v2-websocket.ts
@@ -18,6 +18,7 @@ const log = createSubsystemLogger("browser").child("extension-relay");
 export function authenticateExtensionWebSocket(params: {
   ws: WebSocket;
   authority: BrowserRelayAuthV2Authority;
+  source: string;
   resource: string;
   binding?: Pick<BrowserRelayProofFields, "role" | "flow">;
   prepareAuthenticated: () => Promise<() => void>;
@@ -36,6 +37,11 @@ export function authenticateExtensionWebSocket(params: {
     preAuthGuardActive = false;
     params.removePreAuthGuard?.();
   };
+  const closePreAuthSocket = (code: number, reason: string) => {
+    ws.close(code, reason);
+    const terminateTimer = setTimeout(() => ws.terminate(), 100);
+    terminateTimer.unref?.();
+  };
   const timer = setTimeout(() => {
     stage = "failed";
     ws.off("message", onMessage);
@@ -49,12 +55,16 @@ export function authenticateExtensionWebSocket(params: {
     authority.releaseConnection(ws);
   };
   if (
-    !authority.registerPendingConnection(ws, () => {
-      ws.close(4003, "browser relay key rotated");
-    })
+    !authority.registerPendingConnection(
+      ws,
+      () => {
+        ws.close(4003, "browser relay key rotated");
+      },
+      params.source,
+    )
   ) {
     clearTimeout(timer);
-    ws.close(4013, "browser relay auth capacity reached");
+    closePreAuthSocket(4013, "browser relay auth capacity reached");
     return;
   }
   ws.once("close", release);
@@ -65,9 +75,7 @@ export function authenticateExtensionWebSocket(params: {
     stage = "failed";
     clearTimeout(timer);
     ws.off("message", onMessage);
-    ws.close(code, reason);
-    const terminateTimer = setTimeout(() => ws.terminate(), 100);
-    terminateTimer.unref?.();
+    closePreAuthSocket(code, reason);
   };
   const onMessage = (data: RawData, isBinary: boolean) => {
     if (isBinary) {

--- a/extensions/browser/src/browser/extension-relay/auth-v2.test.ts
+++ b/extensions/browser/src/browser/extension-relay/auth-v2.test.ts
@@ -225,6 +225,42 @@ describe("BrowserRelayAuthV2Authority", () => {
     expect(authority.registerPendingConnection({}, vi.fn(), "198.51.100.10")).toBe(true);
   });
 
+  it("counts loopback aliases as one pending source", () => {
+    const authority = new BrowserRelayAuthV2Authority(KEY);
+    for (let index = 0; index < 32; index += 1) {
+      expect(authority.registerPendingConnection({}, vi.fn(), "127.0.0.2")).toBe(true);
+    }
+    expect(authority.registerPendingConnection({}, vi.fn(), "127.0.0.3")).toBe(false);
+    expect(authority.registerPendingConnection({}, vi.fn(), "::ffff:127.0.0.4")).toBe(false);
+    expect(authority.registerPendingConnection({}, vi.fn(), "::1")).toBe(false);
+  });
+
+  it("counts loopback aliases as one replay source", () => {
+    const authority = new BrowserRelayAuthV2Authority(KEY);
+    for (let index = 0; index < 256; index += 1) {
+      const connection = {};
+      expect(
+        authority.registerPendingConnection(connection, vi.fn(), `127.0.0.${2 + (index % 2)}`),
+      ).toBe(true);
+      const nonce = Buffer.alloc(32);
+      nonce.writeUInt32BE(index, 28);
+      expect(
+        authority.issueChallenge(connection, hello(nonce.toString("base64url")), BINDING, 1_000),
+      ).not.toBeNull();
+      authority.releaseConnection(connection);
+    }
+    const overflow = {};
+    expect(authority.registerPendingConnection(overflow, vi.fn(), "::1")).toBe(true);
+    expect(
+      authority.issueChallenge(
+        overflow,
+        hello(Buffer.alloc(32, 0xff).toString("base64url")),
+        BINDING,
+        1_000,
+      ),
+    ).toBeNull();
+  });
+
   it("rejects promotion at active capacity without disturbing active connections", () => {
     const authority = new BrowserRelayAuthV2Authority(KEY);
     const pending = {};

--- a/extensions/browser/src/browser/extension-relay/auth-v2.test.ts
+++ b/extensions/browser/src/browser/extension-relay/auth-v2.test.ts
@@ -16,6 +16,7 @@ import {
 } from "./auth-v2.js";
 
 const KEY = Array.from({ length: 32 }, (_, index) => index.toString(16).padStart(2, "0")).join("");
+const SOURCE = "127.0.0.1";
 const VECTOR_FIELDS: BrowserRelayProofFields = {
   keyId: "Yw3NKWbEM2aRElRIu7JbT_",
   instanceId: "EREREREREREREREREREREQ",
@@ -92,8 +93,8 @@ describe("BrowserRelayAuthV2Authority", () => {
     const authority = new BrowserRelayAuthV2Authority(KEY);
     const socket = {};
     const otherSocket = {};
-    expect(authority.registerPendingConnection(socket, vi.fn())).toBe(true);
-    expect(authority.registerPendingConnection(otherSocket, vi.fn())).toBe(true);
+    expect(authority.registerPendingConnection(socket, vi.fn(), SOURCE)).toBe(true);
+    expect(authority.registerPendingConnection(otherSocket, vi.fn(), SOURCE)).toBe(true);
     const challenge = authority.issueChallenge(socket, hello(), BINDING, 1_000);
     expect(challenge).not.toBeNull();
     const fields = challenge as BrowserRelayProofFields;
@@ -113,8 +114,8 @@ describe("BrowserRelayAuthV2Authority", () => {
     const authority = new BrowserRelayAuthV2Authority(KEY);
     const first = {};
     const second = {};
-    authority.registerPendingConnection(first, vi.fn());
-    authority.registerPendingConnection(second, vi.fn());
+    authority.registerPendingConnection(first, vi.fn(), SOURCE);
+    authority.registerPendingConnection(second, vi.fn(), SOURCE);
     expect(authority.issueChallenge(first, hello(), BINDING, 1_000)).not.toBeNull();
     expect(authority.issueChallenge(first, hello(), BINDING, 1_001)).toBeNull();
     expect(authority.issueChallenge(second, hello(), BINDING, 1_001)).toBeNull();
@@ -124,7 +125,7 @@ describe("BrowserRelayAuthV2Authority", () => {
   it("rejects expired challenges and wrong client proofs", () => {
     const authority = new BrowserRelayAuthV2Authority(KEY);
     const first = {};
-    authority.registerPendingConnection(first, vi.fn());
+    authority.registerPendingConnection(first, vi.fn(), SOURCE);
     const expired = authority.issueChallenge(first, hello(), BINDING, 1_000);
     expect(expired).not.toBeNull();
     expect(
@@ -141,7 +142,7 @@ describe("BrowserRelayAuthV2Authority", () => {
     ).toBeNull();
 
     const second = {};
-    authority.registerPendingConnection(second, vi.fn());
+    authority.registerPendingConnection(second, vi.fn(), SOURCE);
     const challenge = authority.issueChallenge(
       second,
       hello("REREREREREREREREREREREREREREREREREREREREREQ"),
@@ -170,7 +171,7 @@ describe("BrowserRelayAuthV2Authority", () => {
     const pending = {};
     const authenticated = {};
     const first = getBrowserRelayAuthV2Authority(KEY);
-    first.registerPendingConnection(pending, pendingInvalidated);
+    first.registerPendingConnection(pending, pendingInvalidated, SOURCE);
     first.registerAuthenticatedConnection(authenticated, authenticatedInvalidated);
     expect(first.issueChallenge(pending, hello(), BINDING, 1_000)).not.toBeNull();
     const rotated = getBrowserRelayAuthV2Authority("f".repeat(64));
@@ -184,26 +185,51 @@ describe("BrowserRelayAuthV2Authority", () => {
     invalidateBrowserRelayAuthV2Authority();
   });
 
-  it("keeps pending admission independent from authenticated capacity", () => {
+  it("reserves pending admission for independent sources within the global bound", () => {
     const authority = new BrowserRelayAuthV2Authority(KEY);
-    const pendingInvalidators = Array.from({ length: 128 }, () => vi.fn());
-    for (const invalidate of pendingInvalidators) {
-      expect(authority.registerPendingConnection({}, invalidate)).toBe(true);
+    const attackerInvalidators = Array.from({ length: 128 }, () => vi.fn());
+    const attackerBindings = attackerInvalidators.map(() => ({}));
+    const attackerAdmissions = attackerBindings.map((binding, index) =>
+      authority.registerPendingConnection(binding, attackerInvalidators[index]!, "198.51.100.10"),
+    );
+    expect(attackerAdmissions.filter(Boolean)).toHaveLength(32);
+
+    const independent = {};
+    expect(authority.registerPendingConnection(independent, vi.fn(), "203.0.113.20")).toBe(true);
+    const challenge = authority.issueChallenge(independent, hello(), BINDING, 1_000)!;
+    expect(
+      authority.completeChallenge(
+        independent,
+        {
+          type: "auth.response",
+          v: 2,
+          sessionId: challenge.sessionId,
+          clientProof: createRelayProof(KEY, "client", challenge),
+        },
+        1_001,
+      )?.ok.type,
+    ).toBe("auth.ok");
+
+    for (let index = 0; index < 96; index += 1) {
+      expect(authority.registerPendingConnection({}, vi.fn(), `192.0.2.${index}`)).toBe(true);
     }
-    expect(authority.registerPendingConnection({}, vi.fn())).toBe(false);
+    expect(authority.registerPendingConnection({}, vi.fn(), "203.0.113.21")).toBe(false);
 
     const active = {};
     const activeInvalidated = vi.fn();
     expect(authority.registerAuthenticatedConnection(active, activeInvalidated)).toBe(true);
     expect(activeInvalidated).not.toHaveBeenCalled();
-    expect(pendingInvalidators.every((invalidate) => !invalidate.mock.calls.length)).toBe(true);
+    expect(attackerInvalidators.every((invalidate) => !invalidate.mock.calls.length)).toBe(true);
+
+    authority.releaseConnection(attackerBindings[0]!);
+    expect(authority.registerPendingConnection({}, vi.fn(), "198.51.100.10")).toBe(true);
   });
 
   it("rejects promotion at active capacity without disturbing active connections", () => {
     const authority = new BrowserRelayAuthV2Authority(KEY);
     const pending = {};
     const pendingInvalidated = vi.fn();
-    expect(authority.registerPendingConnection(pending, pendingInvalidated)).toBe(true);
+    expect(authority.registerPendingConnection(pending, pendingInvalidated, SOURCE)).toBe(true);
     const challenge = authority.issueChallenge(pending, hello(), BINDING, 1_000);
     expect(challenge).not.toBeNull();
 
@@ -242,7 +268,7 @@ describe("BrowserRelayAuthV2Authority", () => {
     authority.registerAuthenticatedConnection(active, activeInvalidated);
 
     const failed = {};
-    authority.registerPendingConnection(failed, vi.fn());
+    authority.registerPendingConnection(failed, vi.fn(), SOURCE);
     const failedChallenge = authority.issueChallenge(failed, hello(), BINDING, 1_000)!;
     expect(
       authority.completeChallenge(
@@ -259,7 +285,7 @@ describe("BrowserRelayAuthV2Authority", () => {
     authority.releaseConnection(failed);
 
     const expired = {};
-    authority.registerPendingConnection(expired, vi.fn());
+    authority.registerPendingConnection(expired, vi.fn(), SOURCE);
     const expiredChallenge = authority.issueChallenge(
       expired,
       hello("REREREREREREREREREREREREREREREREREREREREREQ"),
@@ -280,14 +306,14 @@ describe("BrowserRelayAuthV2Authority", () => {
     ).toBeNull();
     authority.releaseConnection(expired);
     expect(activeInvalidated).not.toHaveBeenCalled();
-    expect(authority.registerPendingConnection({}, vi.fn())).toBe(true);
+    expect(authority.registerPendingConnection({}, vi.fn(), SOURCE)).toBe(true);
   });
 
   it("fails closed at the bounded replay-cache limit", () => {
     const authority = new BrowserRelayAuthV2Authority(KEY);
     for (let index = 0; index < 1_024; index += 1) {
       const connection = {};
-      authority.registerPendingConnection(connection, vi.fn());
+      authority.registerPendingConnection(connection, vi.fn(), `192.0.2.${index}`);
       const nonce = Buffer.alloc(32);
       nonce.writeUInt32BE(index, 28);
       expect(
@@ -296,7 +322,7 @@ describe("BrowserRelayAuthV2Authority", () => {
       authority.releaseConnection(connection);
     }
     const overflow = {};
-    authority.registerPendingConnection(overflow, vi.fn());
+    authority.registerPendingConnection(overflow, vi.fn(), SOURCE);
     expect(
       authority.issueChallenge(
         overflow,
@@ -305,6 +331,42 @@ describe("BrowserRelayAuthV2Authority", () => {
         1_000,
       ),
     ).toBeNull();
+  });
+
+  it("reserves replay capacity for independent sources during reconnect churn", () => {
+    const authority = new BrowserRelayAuthV2Authority(KEY);
+    for (let index = 0; index < 256; index += 1) {
+      const connection = {};
+      authority.registerPendingConnection(connection, vi.fn(), "198.51.100.10");
+      const nonce = Buffer.alloc(32);
+      nonce.writeUInt32BE(index, 28);
+      expect(
+        authority.issueChallenge(connection, hello(nonce.toString("base64url")), BINDING, 1_000),
+      ).not.toBeNull();
+      authority.releaseConnection(connection);
+    }
+
+    const sameSource = {};
+    authority.registerPendingConnection(sameSource, vi.fn(), "198.51.100.10");
+    expect(
+      authority.issueChallenge(
+        sameSource,
+        hello(Buffer.alloc(32, 0xfe).toString("base64url")),
+        BINDING,
+        1_000,
+      ),
+    ).toBeNull();
+
+    const independent = {};
+    authority.registerPendingConnection(independent, vi.fn(), "203.0.113.20");
+    expect(
+      authority.issueChallenge(
+        independent,
+        hello(Buffer.alloc(32, 0xff).toString("base64url")),
+        BINDING,
+        1_000,
+      ),
+    ).not.toBeNull();
   });
 });
 

--- a/extensions/browser/src/browser/extension-relay/auth-v2.ts
+++ b/extensions/browser/src/browser/extension-relay/auth-v2.ts
@@ -24,6 +24,21 @@ const MAX_PENDING_AUTH_CONNECTIONS_PER_SOURCE = 32;
 const MAX_AUTHENTICATED_CONNECTIONS = 128;
 const MAX_REPLAY_ENTRIES = 1_024;
 const MAX_REPLAY_ENTRIES_PER_SOURCE = MAX_PENDING_AUTH_CONNECTIONS_PER_SOURCE * 8;
+const LOOPBACK_AUTH_SOURCE = "loopback";
+
+function normalizeAuthSource(source: string): string {
+  const normalized = source.trim().toLowerCase();
+  // A local process can choose any 127/8 alias. Treat mapped and native
+  // loopback addresses as one principal or the per-source bound is bypassable.
+  if (
+    normalized === "::1" ||
+    /^127(?:\.\d{1,3}){3}$/.test(normalized) ||
+    /^::ffff:127(?:\.\d{1,3}){3}$/.test(normalized)
+  ) {
+    return LOOPBACK_AUTH_SOURCE;
+  }
+  return normalized || "unknown";
+}
 
 type BrowserRelayAuthHello = {
   type: "auth.hello";
@@ -308,9 +323,10 @@ export class BrowserRelayAuthV2Authority {
   }
 
   registerPendingConnection(binding: object, onInvalidate: () => void, source: string): boolean {
+    const normalizedSource = normalizeAuthSource(source);
     let pendingForSource = 0;
     for (const pending of this.pendingConnections.values()) {
-      pendingForSource += pending.source === source ? 1 : 0;
+      pendingForSource += pending.source === normalizedSource ? 1 : 0;
     }
     if (
       this.disposed ||
@@ -321,7 +337,7 @@ export class BrowserRelayAuthV2Authority {
     ) {
       return false;
     }
-    this.pendingConnections.set(binding, { onInvalidate, source });
+    this.pendingConnections.set(binding, { onInvalidate, source: normalizedSource });
     return true;
   }
 

--- a/extensions/browser/src/browser/extension-relay/auth-v2.ts
+++ b/extensions/browser/src/browser/extension-relay/auth-v2.ts
@@ -18,8 +18,12 @@ export const BROWSER_RELAY_AUTH_COMPLETE_PATH = "/_openclaw/relay/auth/v2/comple
 export const BROWSER_RELAY_CHALLENGE_TTL_MS = 10_000;
 
 const MAX_PENDING_AUTH_CONNECTIONS = 128;
+// Match Gateway pre-auth admission: reconnect bursts fit while one source
+// cannot consume the shared Browser relay proof budget.
+const MAX_PENDING_AUTH_CONNECTIONS_PER_SOURCE = 32;
 const MAX_AUTHENTICATED_CONNECTIONS = 128;
 const MAX_REPLAY_ENTRIES = 1_024;
+const MAX_REPLAY_ENTRIES_PER_SOURCE = MAX_PENDING_AUTH_CONNECTIONS_PER_SOURCE * 8;
 
 type BrowserRelayAuthHello = {
   type: "auth.hello";
@@ -260,18 +264,25 @@ export function parseStrictJsonObject(text: string): Record<string, unknown> | n
 }
 
 class BoundedReplayCache {
-  private readonly entries = new Map<string, number>();
+  private readonly entries = new Map<string, { expiresAtMs: number; source: string }>();
 
-  reserve(key: string, expiresAtMs: number, nowMs: number): boolean {
-    for (const [candidate, expiry] of this.entries) {
-      if (expiry < nowMs) {
+  reserve(key: string, expiresAtMs: number, nowMs: number, source: string): boolean {
+    let entriesForSource = 0;
+    for (const [candidate, entry] of this.entries) {
+      if (entry.expiresAtMs < nowMs) {
         this.entries.delete(candidate);
+      } else {
+        entriesForSource += entry.source === source ? 1 : 0;
       }
     }
-    if (this.entries.has(key) || this.entries.size >= MAX_REPLAY_ENTRIES) {
+    if (
+      this.entries.has(key) ||
+      entriesForSource >= MAX_REPLAY_ENTRIES_PER_SOURCE ||
+      this.entries.size >= MAX_REPLAY_ENTRIES
+    ) {
       return false;
     }
-    this.entries.set(key, expiresAtMs);
+    this.entries.set(key, { expiresAtMs, source });
     return true;
   }
 
@@ -284,7 +295,10 @@ export class BrowserRelayAuthV2Authority {
   readonly keyId: string;
   readonly instanceId = randomRelayId();
   private readonly challenges = new Map<string, ChallengeState>();
-  private readonly pendingConnections = new Map<object, () => void>();
+  private readonly pendingConnections = new Map<
+    object,
+    { onInvalidate: () => void; source: string }
+  >();
   private readonly authenticatedConnections = new Map<object, () => void>();
   private readonly replay = new BoundedReplayCache();
   private disposed = false;
@@ -293,16 +307,21 @@ export class BrowserRelayAuthV2Authority {
     this.keyId = relayKeyIdFromHex(keyHex);
   }
 
-  registerPendingConnection(binding: object, onInvalidate: () => void): boolean {
+  registerPendingConnection(binding: object, onInvalidate: () => void, source: string): boolean {
+    let pendingForSource = 0;
+    for (const pending of this.pendingConnections.values()) {
+      pendingForSource += pending.source === source ? 1 : 0;
+    }
     if (
       this.disposed ||
       this.pendingConnections.has(binding) ||
       this.authenticatedConnections.has(binding) ||
+      pendingForSource >= MAX_PENDING_AUTH_CONNECTIONS_PER_SOURCE ||
       this.pendingConnections.size >= MAX_PENDING_AUTH_CONNECTIONS
     ) {
       return false;
     }
-    this.pendingConnections.set(binding, onInvalidate);
+    this.pendingConnections.set(binding, { onInvalidate, source });
     return true;
   }
 
@@ -335,16 +354,19 @@ export class BrowserRelayAuthV2Authority {
     expected: BrowserRelayBinding,
     nowMs = Date.now(),
   ): BrowserRelayAuthChallenge | null {
+    const pending = this.pendingConnections.get(binding);
     if (
       this.disposed ||
-      !this.pendingConnections.has(binding) ||
+      !pending ||
       hello.keyId !== this.keyId ||
       this.challenges.size >= MAX_PENDING_AUTH_CONNECTIONS
     ) {
       return null;
     }
     const expiresAtMs = nowMs + BROWSER_RELAY_CHALLENGE_TTL_MS;
-    if (!this.replay.reserve(`${this.keyId}:${hello.clientNonce}`, expiresAtMs, nowMs)) {
+    if (
+      !this.replay.reserve(`${this.keyId}:${hello.clientNonce}`, expiresAtMs, nowMs, pending.source)
+    ) {
       return null;
     }
     const fields: BrowserRelayProofFields = {
@@ -384,14 +406,14 @@ export class BrowserRelayAuthV2Authority {
     ) {
       return null;
     }
-    const invalidate = this.pendingConnections.get(binding);
-    if (!invalidate || this.authenticatedConnections.size >= MAX_AUTHENTICATED_CONNECTIONS) {
+    const pending = this.pendingConnections.get(binding);
+    if (!pending || this.authenticatedConnections.size >= MAX_AUTHENTICATED_CONNECTIONS) {
       return null;
     }
     // Promotion is synchronous and moves the exact binding between disjoint
     // registries, so pending admission can never consume active capacity.
     this.pendingConnections.delete(binding);
-    this.authenticatedConnections.set(binding, invalidate);
+    this.authenticatedConnections.set(binding, pending.onInvalidate);
     return {
       fields: challenge.fields,
       ok: {
@@ -414,7 +436,7 @@ export class BrowserRelayAuthV2Authority {
     }
     this.disposed = true;
     const invalidators = [
-      ...this.pendingConnections.values(),
+      ...Array.from(this.pendingConnections.values(), ({ onInvalidate }) => onInvalidate),
       ...this.authenticatedConnections.values(),
     ];
     this.pendingConnections.clear();

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
@@ -8,7 +8,7 @@ import {
   setRuntimeConfigSnapshot,
 } from "openclaw/plugin-sdk/runtime-config-snapshot";
 import { withEnvAsync, withTempDir } from "openclaw/plugin-sdk/test-env";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { WebSocket, type RawData } from "ws";
 import { parsePairingString } from "../../../chrome-extension/modules/relay-core.js";
 import { relayTestKey } from "../../../chrome-extension/relay-key.test-support.js";
@@ -35,6 +35,11 @@ import {
 } from "./auth-v2.js";
 import { handleGatewayExtensionUpgrade } from "./gateway-relay-route.js";
 import { RawHttpConnection } from "./relay-http.test-support.js";
+
+const getPluginRuntimeGatewayRequestScopeMock = vi.hoisted(() => vi.fn());
+vi.mock("openclaw/plugin-sdk/plugin-runtime", () => ({
+  getPluginRuntimeGatewayRequestScope: () => getPluginRuntimeGatewayRequestScopeMock(),
+}));
 
 const RELAY_KEY = relayTestKey(8);
 const EXTENSION_HELLO = {
@@ -122,6 +127,7 @@ async function closeServer(server: Server): Promise<void> {
 afterEach(async () => {
   await stopBrowserControlService();
   clearRuntimeConfigSnapshot();
+  getPluginRuntimeGatewayRequestScopeMock.mockReset();
 });
 
 describe.sequential("local Gateway extension relay wakeup", () => {
@@ -241,6 +247,12 @@ describe.sequential("local Gateway extension relay wakeup", () => {
               // TCP writes cannot guarantee Node's upgrade-head size; supply that exact boundary.
               const initialHead = coalesced ?? head;
               upgradeHeadBytes = initialHead.byteLength;
+              const preparedClientIp = req.headers["x-test-client-ip"];
+              getPluginRuntimeGatewayRequestScopeMock.mockReturnValue(
+                typeof preparedClientIp === "string"
+                  ? { client: { clientIp: preparedClientIp } }
+                  : undefined,
+              );
               void handleGatewayExtensionUpgrade(req, socket, initialHead);
             });
             let extension: WebSocket | undefined;
@@ -281,7 +293,7 @@ describe.sequential("local Gateway extension relay wakeup", () => {
                 saturationSockets = await Promise.all(
                   Array.from({ length: 32 }, async () => {
                     const ws = new WebSocket(parsed.relayUrl, protocols, {
-                      localAddress: "127.0.0.2",
+                      headers: { "x-test-client-ip": "198.51.100.10" },
                     });
                     ws.on("error", () => {});
                     await once(ws, "open");
@@ -289,7 +301,7 @@ describe.sequential("local Gateway extension relay wakeup", () => {
                   }),
                 );
                 const overflow = new WebSocket(parsed.relayUrl, protocols, {
-                  localAddress: "127.0.0.2",
+                  headers: { "x-test-client-ip": "198.51.100.10" },
                 });
                 overflow.on("error", () => {});
                 const overflowClosed = once(overflow, "close");
@@ -298,7 +310,7 @@ describe.sequential("local Gateway extension relay wakeup", () => {
                 expect(overflowCode).toBe(4013);
               }
               extension = new WebSocket(parsed.relayUrl, protocols, {
-                ...(saturatedSource ? { localAddress: "127.0.0.3" } : {}),
+                ...(saturatedSource ? { headers: { "x-test-client-ip": "203.0.113.20" } } : {}),
                 origin: "chrome-extension://gateway-wakeup-integration",
               });
               await once(extension, "open");

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts
@@ -159,6 +159,12 @@ describe.sequential("local Gateway extension relay wakeup", () => {
     { browserRequestAlreadyWaiting: true, standaloneFirst: false, malformedFrame: false },
     { browserRequestAlreadyWaiting: true, standaloneFirst: true, malformedFrame: false },
     { browserRequestAlreadyWaiting: true, standaloneFirst: true, malformedFrame: true },
+    {
+      browserRequestAlreadyWaiting: false,
+      standaloneFirst: false,
+      malformedFrame: false,
+      saturatedSource: true,
+    },
     { browserRequestAlreadyWaiting: false, standaloneFirst: false, legacy: "open" },
     {
       browserRequestAlreadyWaiting: true,
@@ -169,8 +175,14 @@ describe.sequential("local Gateway extension relay wakeup", () => {
     { browserRequestAlreadyWaiting: false, standaloneFirst: false, legacy: "head" },
     { browserRequestAlreadyWaiting: true, standaloneFirst: true, legacy: "head" },
   ])(
-    "authenticates Gateway ingress: waiting=$browserRequestAlreadyWaiting standalone=$standaloneFirst malformed=$malformedFrame legacy=$legacy",
-    async ({ browserRequestAlreadyWaiting, standaloneFirst, malformedFrame, legacy }) => {
+    "authenticates Gateway ingress: waiting=$browserRequestAlreadyWaiting standalone=$standaloneFirst malformed=$malformedFrame legacy=$legacy saturated=$saturatedSource",
+    async ({
+      browserRequestAlreadyWaiting,
+      standaloneFirst,
+      malformedFrame,
+      legacy,
+      saturatedSource,
+    }) => {
       const stateDir = await fs.realpath(
         await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-gateway-relay-wakeup-")),
       );
@@ -232,6 +244,7 @@ describe.sequential("local Gateway extension relay wakeup", () => {
               void handleGatewayExtensionUpgrade(req, socket, initialHead);
             });
             let extension: WebSocket | undefined;
+            let saturationSockets: WebSocket[] = [];
             let daemon: Awaited<ReturnType<typeof runExtensionRelayDaemon>> | undefined;
             const requestController = new AbortController();
             let browserAvailable: Promise<void> | undefined;
@@ -264,7 +277,28 @@ describe.sequential("local Gateway extension relay wakeup", () => {
               const protocols = legacy
                 ? ["openclaw-extension-relay", `openclaw-extension-token.${RELAY_KEY}`]
                 : BROWSER_RELAY_EXTENSION_SUBPROTOCOL;
+              if (saturatedSource) {
+                saturationSockets = await Promise.all(
+                  Array.from({ length: 32 }, async () => {
+                    const ws = new WebSocket(parsed.relayUrl, protocols, {
+                      localAddress: "127.0.0.2",
+                    });
+                    ws.on("error", () => {});
+                    await once(ws, "open");
+                    return ws;
+                  }),
+                );
+                const overflow = new WebSocket(parsed.relayUrl, protocols, {
+                  localAddress: "127.0.0.2",
+                });
+                overflow.on("error", () => {});
+                const overflowClosed = once(overflow, "close");
+                await once(overflow, "open");
+                const [overflowCode] = await overflowClosed;
+                expect(overflowCode).toBe(4013);
+              }
               extension = new WebSocket(parsed.relayUrl, protocols, {
+                ...(saturatedSource ? { localAddress: "127.0.0.3" } : {}),
                 origin: "chrome-extension://gateway-wakeup-integration",
               });
               await once(extension, "open");
@@ -369,6 +403,9 @@ describe.sequential("local Gateway extension relay wakeup", () => {
               requestController.abort();
               await browserAvailable?.catch(() => {});
               extension?.terminate();
+              for (const socket of saturationSockets) {
+                socket.terminate();
+              }
               await stopBrowserControlService();
               daemon?.stop();
               await daemon?.done;

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.test.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.test.ts
@@ -4,6 +4,11 @@ import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const getPluginRuntimeGatewayRequestScopeMock = vi.fn();
+vi.mock("openclaw/plugin-sdk/plugin-runtime", () => ({
+  getPluginRuntimeGatewayRequestScope: () => getPluginRuntimeGatewayRequestScopeMock(),
+}));
+
 const getBrowserControlStateMock = vi.fn();
 const startBrowserControlServiceFromConfigMock = vi.fn();
 vi.mock("../../control-service.js", () => ({
@@ -126,6 +131,7 @@ function stateWithExtensionProfile() {
 
 beforeEach(() => {
   configState.allowLegacyAuth = true;
+  getPluginRuntimeGatewayRequestScopeMock.mockReturnValue(undefined);
   readExtensionRelayTokenMock.mockReturnValue(TOKEN);
 });
 
@@ -270,6 +276,9 @@ describe("handleGatewayExtensionUpgrade", () => {
   });
 
   it("does not lazy-start or attach v2 before the in-band client proof succeeds", async () => {
+    getPluginRuntimeGatewayRequestScopeMock.mockReturnValue({
+      client: { clientIp: "203.0.113.20" },
+    });
     getBrowserControlStateMock.mockReturnValue(null);
     startBrowserControlServiceFromConfigMock.mockResolvedValue(stateWithExtensionProfile());
     primeProfile();
@@ -291,8 +300,10 @@ describe("handleGatewayExtensionUpgrade", () => {
     const authParams = authenticateExtensionWebSocketMock.mock.calls[0]?.[0] as {
       prepareAuthenticated: () => Promise<() => void>;
       resource: string;
+      source: string;
     };
     expect(authParams.resource).toBe("/browser/extension");
+    expect(authParams.source).toBe("203.0.113.20");
     const attach = await authParams.prepareAuthenticated();
     expect(startBrowserControlServiceFromConfigMock).toHaveBeenCalledOnce();
     expect(ensureExtensionRelayForProfileMock).toHaveBeenCalledOnce();

--- a/extensions/browser/src/browser/extension-relay/gateway-relay-route.ts
+++ b/extensions/browser/src/browser/extension-relay/gateway-relay-route.ts
@@ -1,6 +1,7 @@
 /** Direct Gateway extension relay with in-band Browser Relay Authentication v2. */
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
+import { getPluginRuntimeGatewayRequestScope } from "openclaw/plugin-sdk/plugin-runtime";
 import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import { WebSocketServer, type WebSocket } from "ws";
 import { getRuntimeConfig } from "../../config/config.js";
@@ -140,6 +141,12 @@ export async function handleGatewayExtensionUpgrade(
   }
 
   const protocols = requestProtocols(req);
+  // Gateway resolves trusted-proxy attribution before plugin dispatch. The raw
+  // peer is only a fallback for direct harnesses outside that request scope.
+  const source =
+    getPluginRuntimeGatewayRequestScope()?.client?.clientIp ??
+    req.socket?.remoteAddress ??
+    "unknown";
   const token = readExtensionRelayToken();
   if (!token) {
     invalidateBrowserRelayAuthV2Authority();
@@ -159,6 +166,7 @@ export async function handleGatewayExtensionUpgrade(
           authenticateExtensionWebSocket({
             ws,
             authority,
+            source,
             resource,
             removePreAuthGuard,
             prepareAuthenticated: async () => {

--- a/extensions/browser/src/browser/extension-relay/owner-auth-client.test.ts
+++ b/extensions/browser/src/browser/extension-relay/owner-auth-client.test.ts
@@ -41,7 +41,7 @@ it.each(["port", "profile", "owner", "key"] as const)(
     const observed: string[] = [];
     server.on("connection", (ws, request) => {
       observed.push(JSON.stringify({ url: request.url, headers: request.headers }));
-      authority.registerPendingConnection(ws, () => ws.terminate());
+      authority.registerPendingConnection(ws, () => ws.terminate(), "127.0.0.1");
       ws.on("message", (raw) => {
         observed.push(rawDataToString(raw));
         const hello = parseRelayAuthHello(parseStrictJsonObject(rawDataToString(raw)));

--- a/extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts
@@ -30,6 +30,7 @@ import {
 } from "./relay-server.js";
 
 const KEY = "0123456789abcdef".repeat(4);
+const SOURCE = "127.0.0.1";
 
 async function authenticate(
   connection: RawHttpConnection,
@@ -101,8 +102,10 @@ function rawDataText(data: RawData): string {
 async function openExtensionSocket(
   handle: ExtensionRelayHandle,
   protocols: string | string[],
+  localAddress?: string,
 ): Promise<WebSocket> {
   const ws = new WebSocket(`ws://127.0.0.1:${handle.port}/extension`, protocols, {
+    localAddress,
     origin: "chrome-extension://relay-auth-v2-test",
   });
   ws.on("error", () => {});
@@ -110,8 +113,11 @@ async function openExtensionSocket(
   return ws;
 }
 
-async function authenticateV2Extension(handle: ExtensionRelayHandle): Promise<WebSocket> {
-  const ws = await openExtensionSocket(handle, BROWSER_RELAY_EXTENSION_SUBPROTOCOL);
+async function authenticateV2Extension(
+  handle: ExtensionRelayHandle,
+  localAddress?: string,
+): Promise<WebSocket> {
+  const ws = await openExtensionSocket(handle, BROWSER_RELAY_EXTENSION_SUBPROTOCOL, localAddress);
   const challengeMessage = once(ws, "message");
   ws.send(
     JSON.stringify({
@@ -161,6 +167,7 @@ function createWebSocketAuthHarness(
   authenticateExtensionWebSocket({
     ws: socket,
     authority,
+    source: SOURCE,
     resource: "/extension",
     prepareAuthenticated,
     removePreAuthGuard: options.removePreAuthGuard,
@@ -266,16 +273,18 @@ describe("extension relay WebSocket auth v2 frame boundary", () => {
       const activeInvalidated = vi.fn();
       expect(harness.authority.registerAuthenticatedConnection({}, activeInvalidated)).toBe(true);
       for (let index = 0; index < 127; index += 1) {
-        expect(harness.authority.registerPendingConnection({}, vi.fn())).toBe(true);
+        expect(harness.authority.registerPendingConnection({}, vi.fn(), `192.0.2.${index}`)).toBe(
+          true,
+        );
       }
-      expect(harness.authority.registerPendingConnection({}, vi.fn())).toBe(false);
+      expect(harness.authority.registerPendingConnection({}, vi.fn(), SOURCE)).toBe(false);
 
       await vi.advanceTimersByTimeAsync(10_000);
       expect(harness.close).toHaveBeenCalledWith(4008, "browser relay auth timeout");
       expect(removePreAuthGuard).not.toHaveBeenCalled();
       harness.socket.emit("close");
       expect(removePreAuthGuard).toHaveBeenCalledOnce();
-      expect(harness.authority.registerPendingConnection({}, vi.fn())).toBe(true);
+      expect(harness.authority.registerPendingConnection({}, vi.fn(), SOURCE)).toBe(true);
       expect(activeInvalidated).not.toHaveBeenCalled();
     } finally {
       vi.useRealTimers();
@@ -646,7 +655,7 @@ describe.sequential("extension relay HTTP auth v2", () => {
     }
   });
 
-  it("keeps an active extension while pending admission is full and recovers after release", async () => {
+  it("keeps independent relay authentication available under one saturated source", async () => {
     handle = await startExtensionRelayServer({ port: 0, token: KEY, allowLegacyAuth: true });
     const active = await openExtensionSocket(handle, [
       "openclaw-extension-relay",
@@ -663,9 +672,9 @@ describe.sequential("extension relay HTTP auth v2", () => {
     );
     await vi.waitFor(() => expect(handle?.bridge.extensionConnected).toBe(true));
 
-    const pending = await Promise.all(
-      Array.from({ length: 128 }, () =>
-        openExtensionSocket(handle!, BROWSER_RELAY_EXTENSION_SUBPROTOCOL),
+    const attacker = await Promise.all(
+      Array.from({ length: 32 }, () =>
+        openExtensionSocket(handle!, BROWSER_RELAY_EXTENSION_SUBPROTOCOL, "127.0.0.2"),
       ),
     );
     expect(active.readyState).toBe(WebSocket.OPEN);
@@ -674,7 +683,7 @@ describe.sequential("extension relay HTTP auth v2", () => {
     const overflow = new WebSocket(
       `ws://127.0.0.1:${handle.port}/extension`,
       BROWSER_RELAY_EXTENSION_SUBPROTOCOL,
-      { origin: "chrome-extension://relay-auth-v2-test" },
+      { localAddress: "127.0.0.2", origin: "chrome-extension://relay-auth-v2-test" },
     );
     overflow.on("error", () => {});
     const overflowClosed = once(overflow, "close");
@@ -684,10 +693,13 @@ describe.sequential("extension relay HTTP auth v2", () => {
     expect(active.readyState).toBe(WebSocket.OPEN);
     expect(handle.bridge.extensionConnected).toBe(true);
 
-    const released = once(pending[0]!, "close");
-    pending[0]!.close();
+    const independent = await authenticateV2Extension(handle, "127.0.0.3");
+    independent.terminate();
+
+    const released = once(attacker[0]!, "close");
+    attacker[0]!.close();
     await released;
-    const promoted = await authenticateV2Extension(handle);
+    const promoted = await authenticateV2Extension(handle, "127.0.0.2");
     promoted.send(
       JSON.stringify({
         type: "hello",
@@ -701,7 +713,7 @@ describe.sequential("extension relay HTTP auth v2", () => {
 
     promoted.close();
     active.close();
-    for (const socket of pending.slice(1)) {
+    for (const socket of attacker.slice(1)) {
       socket.close();
     }
   }, 30_000);

--- a/extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts
@@ -655,7 +655,7 @@ describe.sequential("extension relay HTTP auth v2", () => {
     }
   });
 
-  it("keeps independent relay authentication available under one saturated source", async () => {
+  it("collapses loopback aliases into one relay authentication source", async () => {
     handle = await startExtensionRelayServer({ port: 0, token: KEY, allowLegacyAuth: true });
     const active = await openExtensionSocket(handle, [
       "openclaw-extension-relay",
@@ -683,7 +683,7 @@ describe.sequential("extension relay HTTP auth v2", () => {
     const overflow = new WebSocket(
       `ws://127.0.0.1:${handle.port}/extension`,
       BROWSER_RELAY_EXTENSION_SUBPROTOCOL,
-      { localAddress: "127.0.0.2", origin: "chrome-extension://relay-auth-v2-test" },
+      { localAddress: "127.0.0.3", origin: "chrome-extension://relay-auth-v2-test" },
     );
     overflow.on("error", () => {});
     const overflowClosed = once(overflow, "close");
@@ -693,13 +693,10 @@ describe.sequential("extension relay HTTP auth v2", () => {
     expect(active.readyState).toBe(WebSocket.OPEN);
     expect(handle.bridge.extensionConnected).toBe(true);
 
-    const independent = await authenticateV2Extension(handle, "127.0.0.3");
-    independent.terminate();
-
     const released = once(attacker[0]!, "close");
     attacker[0]!.close();
     await released;
-    const promoted = await authenticateV2Extension(handle, "127.0.0.2");
+    const promoted = await authenticateV2Extension(handle, "127.0.0.3");
     promoted.send(
       JSON.stringify({
         type: "hello",

--- a/extensions/browser/src/browser/extension-relay/relay-server.ts
+++ b/extensions/browser/src/browser/extension-relay/relay-server.ts
@@ -6,6 +6,7 @@ import { safeEqualSecret } from "openclaw/plugin-sdk/security-runtime";
 import {
   rawDataToString,
   readRequestBodyWithLimit,
+  resolveRequestClientIp,
   WEBHOOK_BODY_READ_DEFAULTS,
 } from "openclaw/plugin-sdk/webhook-ingress";
 import { WebSocketServer, type WebSocket } from "ws";
@@ -272,11 +273,15 @@ export async function startExtensionRelayServer(params: {
     timer.unref?.();
     return timer;
   };
-  const registerHttpSocket = (socket: Duplex, authority: BrowserRelayAuthV2Authority): boolean => {
+  const registerHttpSocket = (
+    socket: Duplex,
+    authority: BrowserRelayAuthV2Authority,
+    source: string,
+  ): boolean => {
     if (authSockets.has(socket)) {
       return true;
     }
-    if (!authority.registerPendingConnection(socket, () => socket.destroy())) {
+    if (!authority.registerPendingConnection(socket, () => socket.destroy(), source)) {
       return false;
     }
     authSockets.add(socket);
@@ -300,6 +305,7 @@ export async function startExtensionRelayServer(params: {
       }
       const path = (req.url ?? "/").split("?")[0];
       const socket = req.socket;
+      const source = resolveRequestClientIp(req) ?? "unknown";
       const existingState = httpStates.get(socket);
       const authority = currentAuthority();
 
@@ -309,7 +315,7 @@ export async function startExtensionRelayServer(params: {
           req.method !== "POST" ||
           existingState ||
           !authority ||
-          !registerHttpSocket(socket, authority)
+          !registerHttpSocket(socket, authority, source)
         ) {
           rejectHttp(res, existingState ? 409 : 400, "Invalid relay auth sequence");
           return;
@@ -473,6 +479,7 @@ export async function startExtensionRelayServer(params: {
 
   server.on("upgrade", (req, socket, head) => {
     const path = (req.url ?? "/").split("?")[0];
+    const source = resolveRequestClientIp(req) ?? "unknown";
     if (retired) {
       destroySocket(socket, "HTTP/1.1 503 Service Unavailable\r\nConnection: close\r\n\r\n");
       return;
@@ -508,6 +515,7 @@ export async function startExtensionRelayServer(params: {
           authenticateExtensionWebSocket({
             ws,
             authority,
+            source,
             resource: `${resource}&owner=${owner}`,
             binding: { role: "cdp", flow: "owner" },
             removePreAuthGuard,
@@ -560,6 +568,7 @@ export async function startExtensionRelayServer(params: {
               authenticateExtensionWebSocket({
                 ws,
                 authority,
+                source,
                 resource,
                 removePreAuthGuard,
                 prepareAuthenticated: async () => () => {


### PR DESCRIPTION
## What Problem This Solves

A burst of silent Browser relay WebSocket handshakes from one client address could consume every shared pre-authentication slot and reject an independently paired Chrome extension.

## Why This Change Was Made

The Browser relay authority now records the Gateway-prepared client address with each pending connection. It limits one normalized source to 32 concurrent handshakes while retaining the existing 128-connection global bound. Replay reservations use the same source partition so rapid reconnect churn cannot move starvation to another shared pre-proof pool.

Standalone relay paths pass their normalized socket peer into the same authority. All loopback aliases share one local principal, keeping one canonical admission and cleanup lifecycle across Gateway, extension, owner, and HTTP challenge flows.

## User Impact

A paired extension from an independent address can complete relay authentication while another source is saturated. Connections from the saturated source receive the existing capacity close result, and capacity becomes available again when a pending connection closes or authenticates.

More than 32 simultaneous unproved connections attributed to one normalized address are now rejected. Clients behind one NAT, proxy attribution, unknown-source bucket, or loopback principal share that allowance and may need to stagger unusually large reconnect bursts.

This does not change configuration, pairing strings, relay messages, authenticated connection limits, persisted state, dependencies, or legacy-auth behavior.

## Evidence

- Baseline reproduction admitted all 128 silent reservations from one source and left no independent capacity.
- `node scripts/run-vitest.mjs extensions/browser/src/browser/extension-relay/auth-v2.test.ts extensions/browser/src/browser/extension-relay/relay-server.auth-v2.test.ts extensions/browser/src/browser/extension-relay/gateway-relay-route.test.ts extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts extensions/browser/src/browser/extension-relay/owner-auth-client.test.ts` — 74 tests passed.
- The direct Gateway integration keeps 32 silent sockets attributed to `198.51.100.10`, rejects that source's overflow with code 4013, and authenticates a key-holding client attributed to `203.0.113.20`.
- The authority receipt records 32 of 128 same-source admissions, preserved independent capacity, and one shared limit for alternating loopback aliases.
- Touched formatting/lint, extension typecheck, test typecheck, `git diff --check`, and exact-head CI passed.

AI-assisted change.

<!-- behavior-proof-pack-section:start -->
## Behavior Proof

ClawSweeper proof for current head `1ab43966958fb8958d8e8a4a73aba57f99e929b0`

<!-- behavior-proof-pack-v1 sha256=bf4b6b19fd9f21d9858cc72da09f06848a803303c8fe8dcec27aef7edb049505 -->

Behavior proved: One unproved Browser Relay client source is denied after its bounded share without preventing a paired client from a distinct prepared source from completing authentication.
Environment: local-integration - Clean current-head OpenClaw worktree using the real Browser plugin Gateway upgrade handler, real WebSocket clients, and the production Browser Relay Authentication v2 authority.
Entry point: `node scripts/run-vitest.mjs extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts -t 'saturated=true'` via handleGatewayExtensionUpgrade -> authenticateExtensionWebSocket -> BrowserRelayAuthV2Authority; faithful because The harness opens real WebSockets through the production Gateway plugin route and performs the real challenge/proof exchange; only Gateway's already-prepared client IP fact is supplied by the test harness.
Protected boundary: admission-capacity `Browser Relay v2 pending-proof authority`; sink/source: shared pending authentication reservation and replay capacity; denied effect: The saturated source's overflow socket closes with code 4013 without acquiring another reservation, while a distinct prepared source remains admissible.
Command/artifact:
- `node scripts/run-vitest.mjs extensions/browser/src/browser/extension-relay/gateway-relay-route.integration.test.ts -t 'saturated=true'` -> exit_code=0; artifact: `proof-output.txt`; artifact_sha256=bf13800791d8e624; The production Gateway route denied the same-source overflow and authenticated the distinct-source positive control.
- `node_modules/.bin/tsx /tmp/browser-relay-capacity-proof.ts` -> exit_code=0; artifact: `proof-output.txt`; artifact_sha256=bf13800791d8e624; The authority admitted 32 of 128 same-source requests, admitted the legitimate source, preserved 97 independent admissions in the measured sequence, and collapsed loopback aliases to 32.
Evidence:
- fixed/denied: same-source pending-authentication saturation; status=pass; protected sink/source result: not_reached; calls=0; After 32 reservations for the prepared source, the overflow connection is closed before another pending authority entry is allocated.; artifact: `proof-output.txt`; excerpt: sameSourceAttempted=128, sameSourceAdmitted=32, overflowDenied=true; the real Gateway overflow socket closed with code 4013
- control: paired client authenticates from an independent prepared source; status=pass; intended behavior: success; The same production route authenticates a valid proof from 203.0.113.20 while 32 sockets from 198.51.100.10 remain pending.; artifact: `proof-output.txt`; excerpt: legitimateSourceAdmitted=true; the distinct-source client completed auth.hello/auth.response and received auth.ok
Compatibility/operator note: The 33rd concurrent unproved connection from one normalized source now receives the existing capacity close response; authenticated capacity, protocol messages, configuration, persistence, dependencies, and legacy-auth behavior are unchanged.
Live gaps: No separately deployed remote Gateway and Chrome native client were available; the local integration uses real WebSocket transport and production authentication code but supplie...
Proof pack digest: `sha256:bf4b6b19fd9f21d9858cc72da09f06848a803303c8fe8dcec27aef7edb049505`

<!-- behavior-proof-pack-section:end -->
