### PR TITLE
fix(slack): honor the configured image downscale limit on downloadFile

### DIFF
--- a/extensions/slack/src/action-runtime.download-image.test.ts
+++ b/extensions/slack/src/action-runtime.download-image.test.ts
@@ -1,0 +1,72 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { getImageMetadata } from "openclaw/plugin-sdk/media-runtime";
+import { createSolidPngBuffer } from "openclaw/plugin-sdk/test-fixtures";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { slackActionRuntime } from "./action-runtime.js";
+import { createSlackActions } from "./channel-actions.js";
+
+const handleAction = createSlackActions("slack").handleAction;
+if (!handleAction) {
+  throw new Error("Slack channel action handler is missing");
+}
+
+describe("Slack downloaded image results", () => {
+  let directory: string;
+  let imagePath: string;
+
+  beforeAll(async () => {
+    directory = await mkdtemp(path.join(tmpdir(), "slack-image-result-"));
+    imagePath = path.join(directory, "wide.png");
+    await writeFile(imagePath, createSolidPngBuffer(2600, 1300, { r: 40, g: 80, b: 120 }));
+  });
+  afterEach(() => vi.restoreAllMocks());
+  afterAll(async () => {
+    await rm(directory, { recursive: true, force: true });
+  });
+
+  it.each([
+    { configured: 600, expected: 600 },
+    { configured: 2000, expected: 2000 },
+    { configured: undefined, expected: 1200 },
+  ])(
+    "returns a $expected px image for configured limit $configured",
+    async ({ configured, expected }) => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { imageMaxDimensionPx: configured } },
+        channels: { slack: { botToken: "test-token", channels: { C123: { enabled: true } } } },
+      };
+      vi.spyOn(slackActionRuntime, "resolveSlackConversationInfo").mockResolvedValue({
+        type: "channel",
+      });
+      vi.spyOn(slackActionRuntime, "downloadSlackFile").mockResolvedValue({
+        path: imagePath,
+        contentType: "image/png",
+        placeholder: "synthetic Slack image",
+      });
+
+      const result = await handleAction({
+        action: "download-file",
+        channel: "slack",
+        accountId: "default",
+        cfg,
+        params: { fileId: "F123", channelId: "C123" },
+      });
+      const image = result.content.find((block) => block.type === "image");
+      if (!image || image.type !== "image") {
+        throw new Error("Slack download did not return an image");
+      }
+      const bytes = Buffer.from(image.data, "base64");
+      expect(await getImageMetadata(bytes)).toEqual({ width: expected, height: expected / 2 });
+      expect(bytes.byteLength).toBeLessThanOrEqual(5 * 1024 * 1024);
+      expect(result.details).toMatchObject({
+        fileId: "F123",
+        path: imagePath,
+        media: { outbound: false },
+      });
+    },
+    20_000,
+  );
+});

--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -796,24 +796,6 @@ describe("handleSlackAction", () => {
     });
   });
 
-  it("leaves the image downscale limit unset when none is configured", async () => {
-    downloadSlackFile.mockResolvedValueOnce({
-      path: "/tmp/slack-image.png",
-      contentType: "image/png",
-      placeholder: "image",
-    });
-
-    await handleSlackAction(
-      { action: "downloadFile", fileId: "F123", to: "channel:C1" },
-      slackConfig(),
-    );
-
-    const params = requireRecordArg(imageResultFromFile, "imageResultFromFile", 0, 0);
-    expect(
-      (params.imageSanitization as { maxDimensionPx?: number }).maxDimensionPx,
-    ).toBeUndefined();
-  });
-
   it("passes download scope (channel/thread) to downloadSlackFile", async () => {
     downloadSlackFile.mockResolvedValueOnce(null);
 

--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -1,15 +1,3 @@
-const { imageResultFromFile } = vi.hoisted(() => ({
-  imageResultFromFile: vi.fn(async (_params: Record<string, unknown>) => ({
-    content: [],
-    details: { ok: true },
-  })),
-}));
-
-vi.mock("openclaw/plugin-sdk/channel-actions", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("openclaw/plugin-sdk/channel-actions")>()),
-  imageResultFromFile,
-}));
-
 import { WebClient } from "@slack/web-api";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 // Slack tests cover action runtime plugin behavior.
@@ -778,22 +766,6 @@ describe("handleSlackAction", () => {
       channelId: "C1",
     });
     expect(requireDetails(result).ok).toBe(false);
-  });
-
-  it("forwards the configured image downscale limit when downloading an image", async () => {
-    downloadSlackFile.mockResolvedValueOnce({
-      path: "/tmp/slack-image.png",
-      contentType: "image/png",
-      placeholder: "image",
-    });
-    const cfg = slackConfig();
-    (cfg as Record<string, unknown>).agents = { defaults: { imageMaxDimensionPx: 600 } };
-
-    await handleSlackAction({ action: "downloadFile", fileId: "F123", to: "channel:C1" }, cfg);
-
-    expect(requireRecordArg(imageResultFromFile, "imageResultFromFile", 0, 0)).toMatchObject({
-      imageSanitization: { maxDimensionPx: 600 },
-    });
   });
 
   it("passes download scope (channel/thread) to downloadSlackFile", async () => {

--- a/extensions/slack/src/action-runtime.test.ts
+++ b/extensions/slack/src/action-runtime.test.ts
@@ -1,3 +1,15 @@
+const { imageResultFromFile } = vi.hoisted(() => ({
+  imageResultFromFile: vi.fn(async (_params: Record<string, unknown>) => ({
+    content: [],
+    details: { ok: true },
+  })),
+}));
+
+vi.mock("openclaw/plugin-sdk/channel-actions", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/channel-actions")>()),
+  imageResultFromFile,
+}));
+
 import { WebClient } from "@slack/web-api";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 // Slack tests cover action runtime plugin behavior.
@@ -766,6 +778,40 @@ describe("handleSlackAction", () => {
       channelId: "C1",
     });
     expect(requireDetails(result).ok).toBe(false);
+  });
+
+  it("forwards the configured image downscale limit when downloading an image", async () => {
+    downloadSlackFile.mockResolvedValueOnce({
+      path: "/tmp/slack-image.png",
+      contentType: "image/png",
+      placeholder: "image",
+    });
+    const cfg = slackConfig();
+    (cfg as Record<string, unknown>).agents = { defaults: { imageMaxDimensionPx: 600 } };
+
+    await handleSlackAction({ action: "downloadFile", fileId: "F123", to: "channel:C1" }, cfg);
+
+    expect(requireRecordArg(imageResultFromFile, "imageResultFromFile", 0, 0)).toMatchObject({
+      imageSanitization: { maxDimensionPx: 600 },
+    });
+  });
+
+  it("leaves the image downscale limit unset when none is configured", async () => {
+    downloadSlackFile.mockResolvedValueOnce({
+      path: "/tmp/slack-image.png",
+      contentType: "image/png",
+      placeholder: "image",
+    });
+
+    await handleSlackAction(
+      { action: "downloadFile", fileId: "F123", to: "channel:C1" },
+      slackConfig(),
+    );
+
+    const params = requireRecordArg(imageResultFromFile, "imageResultFromFile", 0, 0);
+    expect(
+      (params.imageSanitization as { maxDimensionPx?: number }).maxDimensionPx,
+    ).toBeUndefined();
   });
 
   it("passes download scope (channel/thread) to downloadSlackFile", async () => {

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -14,6 +14,7 @@ import {
 import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
+import { resolveOptionalIntegerOption } from "openclaw/plugin-sdk/number-runtime";
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -954,6 +955,12 @@ export async function handleSlackAction(
             path: downloaded.path,
             ...(downloaded.contentType ? { contentType: downloaded.contentType } : {}),
             media: { outbound: false },
+          },
+          imageSanitization: {
+            maxDimensionPx: resolveOptionalIntegerOption(
+              cfg.agents?.defaults?.imageMaxDimensionPx,
+              { min: 1 },
+            ),
           },
         });
       }

--- a/extensions/slack/src/action-runtime.ts
+++ b/extensions/slack/src/action-runtime.ts
@@ -14,7 +14,6 @@ import {
 import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-contract";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
-import { resolveOptionalIntegerOption } from "openclaw/plugin-sdk/number-runtime";
 import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
 import { resolveOpenProviderRuntimeGroupPolicy } from "openclaw/plugin-sdk/runtime-group-policy";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
@@ -956,12 +955,7 @@ export async function handleSlackAction(
             ...(downloaded.contentType ? { contentType: downloaded.contentType } : {}),
             media: { outbound: false },
           },
-          imageSanitization: {
-            maxDimensionPx: resolveOptionalIntegerOption(
-              cfg.agents?.defaults?.imageMaxDimensionPx,
-              { min: 1 },
-            ),
-          },
+          imageSanitization: { maxDimensionPx: cfg.agents?.defaults?.imageMaxDimensionPx },
         });
       }
       default:


### PR DESCRIPTION
## What Problem This Solves

Slack image downloads ignore `agents.defaults.imageMaxDimensionPx`, even though the existing setting governs tool-result images. A configured limit of 600 or 2000 still produces a 1200-pixel maximum side because the Slack result owner omits the option when calling `imageResultFromFile`.

## What Changed

Forward the existing configured value in `imageSanitization.maxDimensionPx`. The canonical image sanitizer continues to own the default, integer normalization, minimum, and byte limit. The repair needs one production line; it adds no configuration or SDK surface.

Replace the submitted argument-shape test and broad SDK mock with focused coverage through the real Slack channel action adapter and image processing pipeline. Final branch delta: production +1/-0, tests +72/-0. Existing Slack action tests remain unchanged.

## Evidence

Maintainer proof used independently authored equivalent changes on trusted main `c0f1cbfddb909541b7ad88920d8ae0e59fff89b7`. The final PR owner file, applied to that main revision, matches the tested source byte-for-byte. The original contributor ancestry remains intact; final candidate commit: `8e2fb3f812208e876013357c6e1303c2e2d2ffaf`.

The regression calls `createSlackActions("slack").handleAction` with `download-file`. A synthetic 2600×1300 PNG passes through the real lazy action dispatcher, file-result owner, sanitizer, and Rastermill processing. Only the downloaded-file location and conversation metadata are fixture seams. Assertions decode the returned image bytes and inspect actual dimensions, the 5 MiB bound, and `media.outbound: false`.

| Existing configuration | Before | After |
| --- | --- | --- |
| `imageMaxDimensionPx: 600` | 1200×600 | 600×300 |
| `imageMaxDimensionPx: 2000` | 1200×600 | 2000×1000 |
| Unset | 1200×600 | 1200×600 |

Both configured cases fail before the repair; the default control passes. All three pass afterward. This proves the real channel action and actual processed-image output. It does not claim an authenticated Slack download or Gateway roundtrip; the changed boundary starts after file download, and the Slack API contract is unchanged.

The relevant shared directory, CLI, conversation discovery, LINE account/group/allowlist, Slack action/download, and image sanitizer suites passed: 231 tests across nine files. The two channel repairs' regression files add eight passing tests in total. Complete changed-scope type/lint/format/boundary checks and full `pnpm build` passed. Independent Codex review of the complete candidate found no actionable findings.

```json
{
  "passed": true,
  "flow": "Slack channel action to real image-result sanitizer",
  "casesPassed": 3,
  "actualOutputDimensionsChecked": true,
  "byteLimitChecked": true,
  "authenticatedSlackCalls": false
}
```

## Review and Release Context

The prior inline review's concern about an implementation-coupled no-config test is addressed by checking unchanged default image output directly. The reviewed candidate is pushed; exact-head hosted CI is pending; the original PR body's earlier test totals do not describe this final test suite.

User-visible release context: Slack downloaded images now honor the configured tool-result image dimension limit. Thanks @marmar9615-cloud for identifying and fixing the missing option; contributor credit is preserved in the commit.
