### PR TITLE
test(auto-reply): avoid catalog discovery in media fixtures

### DIFF
--- a/src/auto-reply/reply/agent-runner.media-paths.test.ts
+++ b/src/auto-reply/reply/agent-runner.media-paths.test.ts
@@ -215,6 +215,18 @@ vi.mock("./reply-media-paths.runtime.js", async (importOriginal) => {
 
 const { runReplyAgent } = await import("./agent-runner.js");
 
+function createMediaFollowupRun(overrides: Parameters<typeof createMockFollowupRun>[0]) {
+  const followupRun = createMockFollowupRun(overrides);
+  followupRun.run.thinkingCatalog = [
+    {
+      provider: followupRun.run.provider,
+      id: followupRun.run.model,
+      input: ["text", "image"],
+    },
+  ];
+  return followupRun;
+}
+
 function makeRunReplyAgentParams(
   overrides: Partial<Parameters<typeof runReplyAgent>[0]> & {
     provider?: string;
@@ -227,7 +239,7 @@ function makeRunReplyAgentParams(
   const runWorkspaceDir = overrides.workspaceDir ?? testWorkspaceDir;
   const followupRun =
     overrides.followupRun ??
-    createMockFollowupRun({
+    createMediaFollowupRun({
       prompt,
       run: {
         agentId: "main",
@@ -397,7 +409,7 @@ describe("runReplyAgent media path normalization", () => {
       const result = await runReplyAgent(
         makeRunReplyAgentParams({
           sessionKey,
-          followupRun: createMockFollowupRun({
+          followupRun: createMediaFollowupRun({
             run: {
               agentId: "qa",
               sessionKey,
@@ -434,7 +446,7 @@ describe("runReplyAgent media path normalization", () => {
       target: "embedded_run",
       gatewayHealth: "live",
     }));
-    const followupRun = createMockFollowupRun({ prompt: "generate chart" });
+    const followupRun = createMediaFollowupRun({ prompt: "generate chart" });
     followupRun.run.taskSuggestionDeliveryMode = "gateway";
 
     await runReplyAgent(
@@ -477,7 +489,7 @@ describe("runReplyAgent media path normalization", () => {
       { type: "image" as const, data: "first", mimeType: "image/jpeg" },
       { type: "image" as const, data: "second", mimeType: "image/png" },
     ];
-    const followupRun = createMockFollowupRun({ prompt: "compare these" });
+    const followupRun = createMediaFollowupRun({ prompt: "compare these" });
     followupRun.images = images;
     followupRun.media = [
       { path: "/tmp/first.jpg", contentType: "image/jpeg" },
@@ -523,7 +535,7 @@ describe("runReplyAgent media path normalization", () => {
       gatewayHealth: "live",
     }));
     const images = [{ type: "image" as const, data: "png", mimeType: "image/png" }];
-    const followupRun = createMockFollowupRun({ prompt: "inspect this" });
+    const followupRun = createMediaFollowupRun({ prompt: "inspect this" });
     followupRun.images = images;
 
     await runReplyAgent(
@@ -549,7 +561,7 @@ describe("runReplyAgent media path normalization", () => {
 
   it("latches audio only after the active reply operation accepts the steer", async () => {
     const followupRun = {
-      ...createMockFollowupRun({ prompt: "summarize the audio" }),
+      ...createMediaFollowupRun({ prompt: "summarize the audio" }),
       currentInboundAudio: true,
     } as unknown as FollowupRun;
     const operation = createRegisteredReplyOperation({
@@ -696,7 +708,7 @@ describe("runReplyAgent media path normalization", () => {
       commandBody: prompt,
       followupRun:
         overrides.followupRun ??
-        createMockFollowupRun({
+        createMediaFollowupRun({
           prompt,
           run: {
             provider: "ollama",
@@ -754,7 +766,7 @@ describe("runReplyAgent media path normalization", () => {
         },
       });
 
-      const followupRun = createMockFollowupRun({
+      const followupRun = createMediaFollowupRun({
         prompt: "generate",
         run: {
           agentId: "qa",


### PR DESCRIPTION
## What Problem This Solves

The reply media-path suite spends tens of seconds discovering real provider capabilities even though it supplies a mocked embedded agent. Its first case has also exceeded the existing 120-second CI deadline, with the following row observing a second embedded-run call. The earlier failure is recorded in [CI run 33399018439](https://github.com/openclaw/openclaw/actions/runs/33399018439/job/99516303873).

## Why This Change Was Made

Give media follow-up fixtures the prepared image-capability catalog for their selected provider and model. One local fixture producer supplies that fact consistently across all eight call sites. The real capability resolver still runs; it can now use the prepared row instead of initializing provider discovery.

All fourteen existing cases and assertions remain, including prepared-agent ownership, exclusion of recent-history images, shared staging, and active-turn media/authority handling. The separate vision suite retains configured versus prepared capability precedence, text-only models, fallback candidates, and missing-metadata discovery coverage. The shared queue fixture stays unchanged because its other callers can intentionally exercise unprepared runs.

## User Impact

Faster, more predictable media tests. Production behavior and provider discovery remain unchanged. No mocks, assertions, isolation settings, or deadlines are weakened.

## Evidence

- Matching Node 24.19.0 CPU/heap-profile runs passed all 14 cases before and after. The first case fell from 54,709.3 ms to 309.5 ms; total case time fell from 56,480.3 ms to 881.6 ms. The before profile attributed 41.37 seconds of self samples to Jiti and 6.92 seconds to its Babel implementation. These are local profiled measurements, not a CI-wide benchmark.
- The original CI shard passed all 294 cases across 19 files in 63.83 seconds after the change, including the eight vision-capability cases. The diagnostic imported the unchanged auto-reply-reply config and changed only its sequencer to assert and restore the recorded file order: serial, non-isolated threads with the existing 120,000 ms timeout. No cases were skipped.
- Focused command: `node --import ./scripts/tsx.mjs scripts/run-vitest-profile.mts runner --output-dir <local-profile-dir> -- --config test/vitest/vitest.auto-reply.config.ts src/auto-reply/reply/agent-runner.media-paths.test.ts --reporter=verbose --reporter=json --outputFile=<local-report>`.
- `OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs -- src/auto-reply/reply/agent-runner.media-paths.test.ts`, formatting, diff check, and structured Codex autoreview passed. Required hosted CI is verified separately before landing.
- Production +0/-0; tests +20/-8. The added fixture metadata removes expensive incidental discovery while retaining the existing behavioral proof.

The prior timeout's possible late-completion interaction remains unproven. This change repairs the demonstrated fixture preparation cost; it does not claim a production timeout-disposal repair or Linux cold-cache equivalence.
