### PR TITLE
refactor(agents): reduce per-turn policy and tool preparation

### DIFF
--- a/extensions/codex/src/app-server/dynamic-tool-build.test.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.test.ts
@@ -36,6 +36,7 @@ import {
 } from "./dynamic-tool-profile.js";
 import { createCodexDynamicToolBridge } from "./dynamic-tools.js";
 import { createCodexTestHostCapabilities } from "./host-capability.test-support.js";
+import * as nativeExecutionPolicy from "./native-execution-policy.js";
 import { flattenCodexDynamicToolFunctions } from "./protocol.js";
 import { createCodexTestModel } from "./test-support.js";
 
@@ -1101,6 +1102,7 @@ describe("Codex app-server dynamic tool build", () => {
     expect(tools.map((tool) => tool.name)).toEqual(["message"]);
     expect(persistentWebSearchAllowed).toBe(true);
     expect(webSearchAllowed).toBe(false);
+    expect(hoisted.resolveWebSearchToolPolicy).not.toHaveBeenCalled();
   });
 
   it("keeps persistent search denied when runtime toolsAllow also excludes it", async () => {
@@ -1191,7 +1193,10 @@ describe("Codex app-server dynamic tool build", () => {
       return [createRuntimeDynamicTool("message")];
     });
 
-    await buildDynamicToolsForTest(params, workspaceDir);
+    const onPersistentWebSearchPolicyResolved = vi.fn();
+    await buildDynamicToolsForTest(params, workspaceDir, {
+      onPersistentWebSearchPolicyResolved,
+    });
 
     expect(receivedOptions).toMatchObject({
       inputProvenance: params.inputProvenance,
@@ -1205,6 +1210,7 @@ describe("Codex app-server dynamic tool build", () => {
         scheduledToolPolicy: params.scheduledToolPolicy,
       }),
     );
+    expect(onPersistentWebSearchPolicyResolved).toHaveBeenCalledWith(false);
   });
 
   it("keeps persistent search denied when global and sender policy both deny it", async () => {
@@ -1784,11 +1790,20 @@ describe("Codex app-server dynamic tool build", () => {
     params.disableTools = false;
     params.runtimePlan = createCodexRuntimePlanFixture();
     await bindProductionCodexHostCapabilities(params);
+    const resolveExecutionPolicy = vi.spyOn(
+      nativeExecutionPolicy,
+      "resolveCodexNativeExecutionPolicy",
+    );
 
     const tools = await buildDynamicToolsForTest(params, workspaceDir, {
+      sandbox: null,
       nativeToolSurfaceEnabled: true,
     });
 
+    expect(resolveExecutionPolicy).toHaveBeenCalledOnce();
+    expect(resolveExecutionPolicy).toHaveBeenCalledWith(
+      expect.objectContaining({ sandboxAvailable: false }),
+    );
     expect(shellTestToolNames(tools)).toEqual([
       "message",
       "gateway_exec",
@@ -1934,6 +1949,10 @@ describe("Codex app-server dynamic tool build", () => {
     const params = createParams(sessionFile, workspaceDir);
     params.disableTools = false;
     params.runtimePlan = createCodexRuntimePlanFixture();
+    const resolveExecutionPolicy = vi.spyOn(
+      nativeExecutionPolicy,
+      "resolveCodexNativeExecutionPolicy",
+    );
 
     const tools = await buildDynamicToolsForTest(params, workspaceDir, {
       sandbox: {
@@ -1944,6 +1963,10 @@ describe("Codex app-server dynamic tool build", () => {
       nativeToolSurfaceEnabled: false,
     });
 
+    expect(resolveExecutionPolicy).toHaveBeenCalledOnce();
+    expect(resolveExecutionPolicy).toHaveBeenCalledWith(
+      expect.objectContaining({ sandboxAvailable: true }),
+    );
     expect(tools.map((tool) => tool.name)).toEqual(["message", "sandbox_exec", "sandbox_process"]);
     expect(tools.find((tool) => tool.name === "sandbox_exec")?.description).toContain(
       "Docker container-path bind layout",
@@ -2327,6 +2350,7 @@ describe("Codex app-server dynamic tool build", () => {
       messageTool.description,
       heartbeatTool.description,
     ]);
+    expect(hoisted.resolveWebSearchToolPolicy).not.toHaveBeenCalled();
   });
 
   it("passes runtime config into Codex exec dynamic tool construction", async () => {
@@ -2525,21 +2549,31 @@ describe("Codex app-server dynamic tool build", () => {
     expect(tools.map((tool) => tool.name)).toEqual(["sessions_spawn"]);
   });
 
-  it("disables Codex native tool surfaces for restricted runtime allowlists", () => {
+  it.each([
+    { label: "unresolved", sandbox: undefined, sandboxAvailable: undefined },
+    { label: "resolved absent", sandbox: null, sandboxAvailable: false },
+  ])("disables native tools for restricted allowlists with $label sandbox", (testCase) => {
     const workspaceDir = path.join(tempDir, "workspace");
     const params = createParams(path.join(tempDir, "session.jsonl"), workspaceDir);
     params.disableTools = false;
+    const resolveExecutionPolicy = vi.spyOn(
+      nativeExecutionPolicy,
+      "resolveCodexNativeExecutionPolicy",
+    );
 
-    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(shouldEnableCodexAppServerNativeToolSurface(params, testCase.sandbox)).toBe(true);
+    expect(resolveExecutionPolicy).toHaveBeenCalledWith(
+      expect.objectContaining({ sandboxAvailable: testCase.sandboxAvailable }),
+    );
 
     params.toolsAllow = ["*"];
-    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(true);
+    expect(shouldEnableCodexAppServerNativeToolSurface(params, testCase.sandbox)).toBe(true);
 
     params.toolsAllow = [];
-    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+    expect(shouldEnableCodexAppServerNativeToolSurface(params, testCase.sandbox)).toBe(false);
 
     params.toolsAllow = ["message"];
-    expect(shouldEnableCodexAppServerNativeToolSurface(params)).toBe(false);
+    expect(shouldEnableCodexAppServerNativeToolSurface(params, testCase.sandbox)).toBe(false);
   });
 
   it("disables Codex native tool surfaces when all tools are disabled", () => {

--- a/extensions/codex/src/app-server/dynamic-tool-build.ts
+++ b/extensions/codex/src/app-server/dynamic-tool-build.ts
@@ -270,11 +270,11 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
   const modelHasVision = params.model.input?.includes("image") ?? false;
   const agentDir = params.agentDir ?? resolveAgentDir(params.config ?? {}, input.sessionAgentId);
   const injectedOpenClawCodingToolsFactory = dynamicToolBuildState.openClawCodingToolsFactory;
-  let agentHarnessModule: typeof import("openclaw/plugin-sdk/agent-harness") | undefined;
-  const loadAgentHarnessModule = async () =>
-    (agentHarnessModule ??= await import("openclaw/plugin-sdk/agent-harness"));
-  toolBuildStages.mark("load-agent-harness-tools");
-  const nativeExecutionPolicy = resolveCodexNativeExecutionPolicyForDynamicTools(input);
+  const nativeExecutionPolicy = resolveCodexNativeExecutionPolicyForRun(params, {
+    agentId: input.policyAgentId,
+    runtimeSessionKey: input.sandboxSessionKey,
+    sandbox: input.sandbox,
+  });
   const webSearchPlan = resolveCodexWebSearchPlan({
     config: params.config,
     disableTools: params.disableTools,
@@ -455,6 +455,7 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
           : profileFilteredTools,
         readableAllTools,
         input,
+        nativeExecutionPolicy,
       ),
       readableAllTools,
       input,
@@ -476,42 +477,42 @@ export async function buildDynamicTools(input: DynamicToolBuildParams) {
     !(input.pluginConfig.codexDynamicToolsExclude ?? []).some(
       (name) => normalizeCodexDynamicToolName(name) === "web_search",
     );
-  // An injected tool factory can prove that no managed or native search surface exists.
-  // Avoid loading the heavyweight default factory graph when no search policy can affect output.
-  const webSearchPolicy =
-    webSearchPresent || persistentCodexWebSearchSurface
-      ? (await loadAgentHarnessModule()).resolveWebSearchToolPolicy({
-          config: params.config,
-          modelProvider: params.model.provider,
-          modelId: params.modelId,
-          agentId: input.policyAgentId,
-          sessionKey: input.sandboxSessionKey,
-          sandboxToolPolicy: input.sandbox?.tools,
-          messageProvider: resolveCodexMessageToolProvider(params),
-          agentAccountId: params.agentAccountId,
-          groupId: params.groupId,
-          groupChannel: params.groupChannel,
-          groupSpace: params.groupSpace,
-          spawnedBy: params.spawnedBy,
-          senderId: params.senderId,
-          senderName: params.senderName,
-          senderUsername: params.senderUsername,
-          senderE164: params.senderE164,
-          inputProvenance: params.inputProvenance,
-          trustedInternalHandoff: params.trustedInternalHandoff,
-          scheduledToolPolicy: params.scheduledToolPolicy,
-        })
-      : { allowed: false, persistentAllowed: false };
-  const senderScopedWebSearchRestriction =
-    !webSearchPolicy.allowed && webSearchPolicy.persistentAllowed;
-  const transientWebSearchRestriction =
-    senderScopedWebSearchRestriction || isCodexMemoryFlushRun(params);
-  input.onPersistentWebSearchPolicyResolved?.(
-    webSearchPresent ||
-      (persistentCodexWebSearchSurface &&
-        transientWebSearchRestriction &&
-        webSearchPolicy.persistentAllowed),
-  );
+  // An authorized search tool already proves persistent availability. Only absent
+  // tools need policy resolution to distinguish transient restrictions from denial.
+  let persistentWebSearchAllowed = webSearchPresent;
+  if (
+    input.onPersistentWebSearchPolicyResolved &&
+    !webSearchPresent &&
+    persistentCodexWebSearchSurface
+  ) {
+    const webSearchPolicy = (
+      await import("openclaw/plugin-sdk/agent-harness")
+    ).resolveWebSearchToolPolicy({
+      config: params.config,
+      modelProvider: params.model.provider,
+      modelId: params.modelId,
+      agentId: input.policyAgentId,
+      sessionKey: input.sandboxSessionKey,
+      sandboxToolPolicy: input.sandbox?.tools,
+      messageProvider: resolveCodexMessageToolProvider(params),
+      agentAccountId: params.agentAccountId,
+      groupId: params.groupId,
+      groupChannel: params.groupChannel,
+      groupSpace: params.groupSpace,
+      spawnedBy: params.spawnedBy,
+      senderId: params.senderId,
+      senderName: params.senderName,
+      senderUsername: params.senderUsername,
+      senderE164: params.senderE164,
+      inputProvenance: params.inputProvenance,
+      trustedInternalHandoff: params.trustedInternalHandoff,
+      scheduledToolPolicy: params.scheduledToolPolicy,
+    });
+    persistentWebSearchAllowed =
+      webSearchPolicy.persistentAllowed &&
+      (!webSearchPolicy.allowed || isCodexMemoryFlushRun(params));
+  }
+  input.onPersistentWebSearchPolicyResolved?.(persistentWebSearchAllowed);
   const filteredTools = filterCodexDynamicToolsForAllowlist(
     visionFilteredTools,
     toolRunContext.runtimeToolAllowlist,
@@ -657,11 +658,11 @@ export function shouldEnableCodexAppServerNativeToolSurface(
     return false;
   }
   if (
-    isCodexNativeExecutionBlockedByNodeExecHost(params, {
+    !resolveCodexNativeExecutionPolicyForRun(params, {
       agentId: options.agentId,
       runtimeSessionKey: options.runtimeSessionKey,
       sandbox,
-    })
+    }).nativeToolSurfaceAllowed
   ) {
     return false;
   }
@@ -677,24 +678,24 @@ export function shouldEnableCodexAppServerNativeToolSurface(
     canCodexAppServerNativeToolSurfaceHonorSandbox(sandbox, options)
   );
 }
-/** Returns true when OpenClaw policy requires the Node-owned exec/process tools instead. */
-function isCodexNativeExecutionBlockedByNodeExecHost(
+function resolveCodexNativeExecutionPolicyForRun(
   params: EmbeddedRunAttemptParams,
   options: {
     agentId?: string;
     runtimeSessionKey?: string;
     sandbox?: OpenClawSandboxContext;
   } = {},
-): boolean {
-  return !resolveCodexNativeExecutionPolicy({
+): CodexNativeExecutionPolicy {
+  return resolveCodexNativeExecutionPolicy({
     config: params.config,
     sessionKey: resolveCodexRuntimePolicySessionKey(params, options.runtimeSessionKey),
     sessionId: params.sessionId,
     agentId: options.agentId,
     execOverrides: params.execOverrides,
-    sandboxAvailable: options.sandbox?.enabled,
+    // A resolved null sandbox is absence; undefined still requests runtime discovery.
+    sandboxAvailable: options.sandbox === null ? false : options.sandbox?.enabled,
     readRuntimeSessionEntry: true,
-  }).nativeToolSurfaceAllowed;
+  });
 }
 function resolveCodexRuntimePolicySessionKey(
   params: EmbeddedRunAttemptParams,
@@ -822,9 +823,14 @@ function addSandboxShellDynamicToolsIfAvailable(
   filteredTools: OpenClawDynamicTool[],
   allTools: OpenClawDynamicTool[],
   input: DynamicToolBuildParams,
+  executionPolicy: CodexNativeExecutionPolicy,
 ): OpenClawDynamicTool[] {
   if (
-    !shouldExposeSandboxExecDynamicTool(input) ||
+    isCodexMemoryFlushRun(input.params) ||
+    !executionPolicy.nativeToolSurfaceAllowed ||
+    !input.sandbox?.enabled ||
+    !input.sandbox.backendId.trim() ||
+    input.nativeToolSurfaceEnabled !== false ||
     isSandboxShellDynamicToolExcluded(input.pluginConfig)
   ) {
     return filteredTools;
@@ -865,22 +871,6 @@ function addSandboxShellDynamicToolsIfAvailable(
       "Manage background shell sessions through OpenClaw's configured sandbox backend for this session: list, poll, log, write, send-keys, submit, paste, kill, clear, or remove. Use only for sandbox follow-up; use Codex's native shell session handling only when no OpenClaw sandbox is active and native Code Mode is available.",
   };
   return [...filteredTools, sandboxExecTool, sandboxProcessTool];
-}
-function shouldExposeSandboxExecDynamicTool(input: DynamicToolBuildParams): boolean {
-  if (isCodexMemoryFlushRun(input.params)) {
-    return false;
-  }
-  if (
-    isCodexNativeExecutionBlockedByNodeExecHost(input.params, {
-      agentId: input.policyAgentId,
-      runtimeSessionKey: input.sandboxSessionKey,
-      sandbox: input.sandbox,
-    })
-  ) {
-    return false;
-  }
-  const backendId = input.sandbox?.enabled ? input.sandbox.backendId.trim().toLowerCase() : "";
-  return Boolean(backendId && input.nativeToolSurfaceEnabled === false);
 }
 function isSandboxShellDynamicToolExcluded(config: CodexPluginConfig): boolean {
   return isCodexDynamicToolExcluded(config, ["exec", "sandbox_exec", "process", "sandbox_process"]);
@@ -926,19 +916,6 @@ function shouldKeepOpenClawShellDynamicTools(
     input.sandbox?.enabled !== true &&
     nodePolicy.effectiveExecHost !== "node"
   );
-}
-function resolveCodexNativeExecutionPolicyForDynamicTools(
-  input: DynamicToolBuildParams,
-): CodexNativeExecutionPolicy {
-  return resolveCodexNativeExecutionPolicy({
-    config: input.params.config,
-    sessionKey: resolveCodexRuntimePolicySessionKey(input.params, input.sandboxSessionKey),
-    sessionId: input.params.sessionId,
-    agentId: input.policyAgentId,
-    execOverrides: input.params.execOverrides,
-    sandboxAvailable: input.sandbox?.enabled,
-    readRuntimeSessionEntry: true,
-  });
 }
 /** Applies a normalized tool allowlist while preserving shell aliases for exec/process. */
 function filterCodexDynamicToolsForAllowlist<T extends { name: string }>(

--- a/packages/ai/src/providers/tool-schema-json-projection.ts
+++ b/packages/ai/src/providers/tool-schema-json-projection.ts
@@ -16,26 +16,6 @@ export type RuntimeToolInputSchemaProjection = {
   readonly violations: readonly string[];
 };
 
-function isJsonValue(value: unknown): value is RuntimeToolInputSchemaJson {
-  if (value === null) {
-    return true;
-  }
-  switch (typeof value) {
-    case "boolean":
-    case "string":
-      return true;
-    case "number":
-      return Number.isFinite(value);
-    case "object":
-      if (Array.isArray(value)) {
-        return value.every(isJsonValue);
-      }
-      return Object.values(value as Record<string, unknown>).every(isJsonValue);
-    default:
-      return false;
-  }
-}
-
 function isNonFiniteNumberValue(value: unknown): boolean {
   if (typeof value === "number") {
     return !Number.isFinite(value);
@@ -55,20 +35,23 @@ function serializeToolInputSchema(value: unknown, path: string): RuntimeToolInpu
   let text: string | undefined;
   try {
     text = JSON.stringify(value, function (this: object, key, entry) {
-      const holderPath = paths.get(this);
-      const entryPath = isRoot
-        ? path
-        : holderPath === undefined
-          ? `${path}.${key}`
-          : Array.isArray(this)
-            ? `${holderPath}[${key}]`
-            : `${holderPath}.${key}`;
-      isRoot = false;
-      if (nonFiniteNumber.path === null && isNonFiniteNumberValue(entry)) {
-        nonFiniteNumber.path = entryPath;
-      } else if (entry && typeof entry === "object") {
-        paths.set(entry, entryPath);
+      const invalidNumber = nonFiniteNumber.path === null && isNonFiniteNumberValue(entry);
+      if (invalidNumber || (entry && typeof entry === "object")) {
+        const holderPath = paths.get(this);
+        const entryPath = isRoot
+          ? path
+          : holderPath === undefined
+            ? `${path}.${key}`
+            : Array.isArray(this)
+              ? `${holderPath}[${key}]`
+              : `${holderPath}.${key}`;
+        if (invalidNumber) {
+          nonFiniteNumber.path = entryPath;
+        } else {
+          paths.set(entry, entryPath);
+        }
       }
+      isRoot = false;
       return entry;
     });
   } catch {
@@ -90,15 +73,8 @@ function serializeToolInputSchema(value: unknown, path: string): RuntimeToolInpu
       violations: [`${violationPath} is not JSON-serializable`],
     };
   }
-  const parsed = JSON.parse(text) as unknown;
-  if (!isJsonValue(parsed)) {
-    return {
-      schema: {},
-      violations: [`${path} is not a JSON value`],
-    };
-  }
   return {
-    schema: parsed,
+    schema: JSON.parse(text) as RuntimeToolInputSchemaJson,
     violations: [],
   };
 }
@@ -112,39 +88,44 @@ const schemaMapKeywords = new Set([
   "properties",
 ]);
 
-function findDynamicSchemaKeywordViolations(
+function inspectJsonSchema(
   schema: RuntimeToolInputSchemaJson,
   path: string,
-): string[] {
+  violations: string[],
+): boolean {
   if (Array.isArray(schema)) {
-    return schema.flatMap((entry, index) =>
-      findDynamicSchemaKeywordViolations(entry, `${path}[${index}]`),
+    return schema.every((entry, index) =>
+      inspectJsonSchema(entry, `${path}[${index}]`, violations),
     );
   }
   if (!isJsonObject(schema)) {
-    return [];
+    // Raw JSON numeric literals can overflow during parsing without passing
+    // through the stringify replacer's non-finite number check.
+    return typeof schema !== "number" || Number.isFinite(schema);
   }
-  const violations: string[] = [];
   for (const key of ["$dynamicRef", "$dynamicAnchor"] as const) {
     if (key in schema) {
       violations.push(`${path}.${key}`);
     }
   }
   for (const [key, value] of Object.entries(schema)) {
+    if (typeof value === "number" && !Number.isFinite(value)) {
+      return false;
+    }
     if (!value || typeof value !== "object") {
       continue;
     }
     if (schemaMapKeywords.has(key) && isJsonObject(value)) {
       for (const [schemaName, childSchema] of Object.entries(value)) {
-        violations.push(
-          ...findDynamicSchemaKeywordViolations(childSchema, `${path}.${key}.${schemaName}`),
-        );
+        if (!inspectJsonSchema(childSchema, `${path}.${key}.${schemaName}`, violations)) {
+          return false;
+        }
       }
-    } else {
-      violations.push(...findDynamicSchemaKeywordViolations(value, `${path}.${key}`));
+    } else if (!inspectJsonSchema(value, `${path}.${key}`, violations)) {
+      return false;
     }
   }
-  return violations;
+  return true;
 }
 
 /** Projects one runtime tool input schema to JSON and reports runtime incompatibilities. */
@@ -159,7 +140,9 @@ export function projectRuntimeToolInputSchema(
   } else if (projection.schema.type !== undefined && projection.schema.type !== "object") {
     violations.push(`${path}.type must be "object"`);
   }
-  violations.push(...findDynamicSchemaKeywordViolations(projection.schema, path));
+  if (!inspectJsonSchema(projection.schema, path, violations)) {
+    return { schema: {}, violations: [`${path} is not a JSON value`] };
+  }
   return {
     schema: projection.schema,
     violations,

--- a/packages/ai/src/utils/reasoning-tag-text-partitioner.test.ts
+++ b/packages/ai/src/utils/reasoning-tag-text-partitioner.test.ts
@@ -1,5 +1,6 @@
 // Reasoning tag partitioner tests cover splitting reasoning and visible text segments.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import * as reasoningTagParser from "../../../markdown-core/src/reasoning-tag-parser.js";
 import {
   createReasoningTagTextPartitioner,
   type ReasoningTagTextDelta,
@@ -215,16 +216,35 @@ describe("createReasoningTagTextPartitioner", () => {
 
   it("recovers a byte-streamed 110KB malformed quoted tag without reparsing prefixes", () => {
     const input = `<think data-x="${"x".repeat(110_000)}<think>hidden</think>After`;
-    const startedAt = Date.now();
-    const result = collectVisibleMode(
-      input,
-      Array.from({ length: input.length }, (_value, index) => index + 1),
-    );
+    let parsedCharacters = 0;
+    const parserSpies = (
+      ["parseReasoningTagAt", "scanReasoningTags", "parseMarkdownOwnership"] as const
+    ).map((name) => {
+      const original = reasoningTagParser[name];
+      return vi
+        .spyOn(reasoningTagParser, name)
+        .mockImplementation((text: string, ...args: unknown[]) => {
+          // Bound reparsed input independently of runner speed, and fail before quadratic work.
+          parsedCharacters += text.length;
+          expect(parsedCharacters).toBeLessThanOrEqual(input.length * 4);
+          return Reflect.apply(original, undefined, [text, ...args]);
+        });
+    });
 
-    expect(result.text).not.toContain("hidden");
-    expect(result.text.endsWith("After")).toBe(true);
-    expect(result.thinking).toBe("hidden");
-    expect(Date.now() - startedAt).toBeLessThan(30_000);
+    try {
+      const result = collectVisibleMode(
+        input,
+        Array.from({ length: input.length }, (_value, index) => index + 1),
+      );
+
+      expect(result.text).not.toContain("hidden");
+      expect(result.text.endsWith("After")).toBe(true);
+      expect(result.thinking).toBe("hidden");
+    } finally {
+      for (const spy of parserSpies) {
+        spy.mockRestore();
+      }
+    }
   });
 
   it("keeps newline-heavy malformed-tag recovery linear", () => {

--- a/packages/tool-call-repair/src/stream-normalizer.test.ts
+++ b/packages/tool-call-repair/src/stream-normalizer.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { parseStandalonePlainTextToolCallBlocks } from "./payload.js";
 import {
   normalizePlainTextToolCallStreamEvents,
@@ -1068,15 +1068,7 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
   });
 
   it("keeps a large preceding block's prefix check bounded across many later candidates (#122513)", async () => {
-    // codex review: hasUntrackedPrecedingContext's deep (same-length) check materialized
-    // the tracked prefix via materializeProtectionPrefix, which joins EVERY chunk ever
-    // pushed -- including the current, still-growing block's own chunks -- before
-    // slicing. Doing that once per candidate made a large preceding block followed by a
-    // bracket-dense later block Theta(precedingBlockSize x candidateCount) again. This
-    // must stay bounded: derive it once per block (cached) using a prefix-bounded
-    // accumulator, not a full join, on every one of the many candidates that follow.
-    // Keep the prefix exactly 200,000 characters while ending its line so the next
-    // block's delimiter is a real CommonMark fence, not a mid-line backtick run.
+    // End the preceding line so the next block opens a CommonMark fence.
     const precedingBlock = `${"x".repeat(199_999)}\n`;
     const fenced = [
       "```toml",
@@ -1099,23 +1091,37 @@ describe("normalizePlainTextToolCallStreamEvents over-cap XML", () => {
     ];
 
     let resolverCalls = 0;
-    const start = performance.now();
-    const normalized = await collectNormalizedEvents(events, {
-      matcher,
-      createPromotedToolCallEvents: () => [],
-      normalizeTerminalMessage: () => undefined,
-      protectedRangesFenceCompatible: true,
-      resolveProtectedRanges: (text) => {
-        resolverCalls += 1;
-        return resolveTestFenceRanges(text);
-      },
-    });
-    const elapsedMs = performance.now() - start;
+    let precedingPrefixSlices = 0;
+    // oxlint-disable-next-line typescript/unbound-method -- called below with the intercepted string receiver.
+    const originalSlice = String.prototype.slice;
+    const sliceSpy = vi
+      .spyOn(String.prototype, "slice")
+      .mockImplementation(function (this: string, start, end) {
+        if (start === 0 && end === precedingBlock.length && this.length >= end) {
+          precedingPrefixSlices += 1;
+        }
+        return originalSlice.call(this, start, end);
+      });
+    let normalized: Record<string, unknown>[];
+    try {
+      normalized = await collectNormalizedEvents(events, {
+        matcher,
+        createPromotedToolCallEvents: () => [],
+        normalizeTerminalMessage: () => undefined,
+        protectedRangesFenceCompatible: true,
+        resolveProtectedRanges: (text) => {
+          resolverCalls += 1;
+          return resolveTestFenceRanges(text);
+        },
+      });
+    } finally {
+      sliceSpy.mockRestore();
+    }
 
     expect(resolverCalls).toBeLessThanOrEqual(3);
-    // A large preceding block re-materialized per candidate would push this into the
-    // hundreds of milliseconds; bounded (cached) prefix validation stays well under it.
-    expect(elapsedMs).toBeLessThan(200);
+    // Rechecking the entire preceding block for every candidate makes work quadratic.
+    // Count full-prefix operations so this bound does not depend on runner speed.
+    expect(precedingPrefixSlices).toBeLessThanOrEqual(4);
     expect(textDeltas(normalized).join("")).toBe(precedingBlock + fenced);
   });
 

--- a/src/agents/agent-tools.read.ts
+++ b/src/agents/agent-tools.read.ts
@@ -969,11 +969,9 @@ type SandboxToolParams = {
 };
 
 /** Create a sandbox-backed read tool with OpenClaw result normalization. */
-export function createSandboxedReadTool(
-  params: SandboxToolParams & { createTool?: typeof createReadTool },
-) {
+export function createSandboxedReadTool(params: SandboxToolParams) {
   const base = eraseSessionFileTool(
-    (params.createTool ?? createReadTool)(params.root, {
+    createReadTool(params.root, {
       operations: createSandboxReadOperations(params),
       maxBytes: resolveAdaptiveReadMaxBytes(params),
       modelBudget: resolveToolResultBudget(params.modelContextWindowTokens),
@@ -989,11 +987,9 @@ export function createSandboxedReadTool(
 }
 
 /** Create a sandbox-backed write tool with required-parameter validation. */
-export function createSandboxedWriteTool(
-  params: SandboxToolParams & { createTool?: typeof createWriteTool },
-) {
+export function createSandboxedWriteTool(params: SandboxToolParams) {
   const base = eraseSessionFileTool(
-    (params.createTool ?? createWriteTool)(params.root, {
+    createWriteTool(params.root, {
       operations: createSandboxWriteOperations(params),
     }),
   );
@@ -1001,11 +997,9 @@ export function createSandboxedWriteTool(
 }
 
 /** Create a sandbox-backed edit tool with required-parameter validation. */
-export function createSandboxedEditTool(
-  params: SandboxToolParams & { createTool?: typeof createEditTool },
-) {
+export function createSandboxedEditTool(params: SandboxToolParams) {
   const base = eraseSessionFileTool(
-    (params.createTool ?? createEditTool)(params.root, {
+    createEditTool(params.root, {
       operations: createSandboxEditOperations(params),
     }),
   );
@@ -1020,11 +1014,10 @@ export function createHostWorkspaceWriteTool(
     workspaceOnly?: boolean;
     abortSignal?: AbortSignal;
     memoryWriteProvenance?: MemoryWriteProvenanceObserver;
-    createTool?: typeof createWriteTool;
   },
 ) {
   const base = eraseSessionFileTool(
-    (options?.createTool ?? createWriteTool)(root, {
+    createWriteTool(root, {
       operations: createHostWriteOperations(options?.containmentRoot ?? root, options),
     }),
   );
@@ -1039,11 +1032,10 @@ export function createHostWorkspaceEditTool(
     workspaceOnly?: boolean;
     abortSignal?: AbortSignal;
     memoryWriteProvenance?: MemoryWriteProvenanceObserver;
-    createTool?: typeof createEditTool;
   },
 ) {
   const base = eraseSessionFileTool(
-    (options?.createTool ?? createEditTool)(root, {
+    createEditTool(root, {
       operations: createHostEditOperations(options?.containmentRoot ?? root, options),
     }),
   );

--- a/src/agents/agent-tools.ts
+++ b/src/agents/agent-tools.ts
@@ -93,12 +93,6 @@ import {
   resolveSessionPermissionExecPolicy,
 } from "./session-permission-exec-mode.js";
 import { resolveSessionPlacementComputer } from "./session-placement-computer.js";
-import {
-  createCodingTools,
-  createEditTool,
-  createReadTool,
-  createWriteTool,
-} from "./sessions/index.js";
 import type { TrustedSubagentCompletionHandoff } from "./subagents/announce/subagent-announce-handoff.js";
 import { resolveToolFsConfig } from "./tool-fs-policy.js";
 import type { PreparedSessionPermissionPolicy } from "./tool-fs-policy.js";
@@ -623,14 +617,6 @@ function createOpenClawCodingToolsInternal(options?: OpenClawCodingToolsOptions)
     imageSanitization,
     modelHasVision: options?.modelHasVision,
     memoryWriteProvenance,
-    ...(includeBaseCodingTools
-      ? { baseToolNames: createCodingTools(codingRoot).map((tool) => tool.name) }
-      : {}),
-    baseToolFactories: {
-      createEditTool,
-      createReadTool,
-      createWriteTool,
-    },
     applyPatchEnabled,
     applyPatchWorkspaceOnly,
     execDefaults: {

--- a/src/agents/core-coding-tools.ts
+++ b/src/agents/core-coding-tools.ts
@@ -24,11 +24,6 @@ import type { MemoryWriteProvenanceObserver } from "./memory-write-provenance.js
 import type { SandboxContext } from "./sandbox.js";
 import { buildSandboxFsMounts } from "./sandbox/fs-paths.js";
 import { resolveReadOnlyWorkspaceSkillMounts } from "./sandbox/workspace-mounts.js";
-import type {
-  createEditTool,
-  createReadTool as CreateReadTool,
-  createWriteTool,
-} from "./sessions/tools/index.js";
 import { createReadTool } from "./sessions/tools/read.js";
 import { resolveToolResultBudget } from "./tool-result-limits.js";
 
@@ -81,12 +76,6 @@ type CoreCodingToolsOptions = {
   imageSanitization?: ImageSanitizationLimits;
   modelHasVision?: boolean;
   memoryWriteProvenance?: MemoryWriteProvenanceObserver;
-  baseToolNames?: readonly string[];
-  baseToolFactories?: {
-    createEditTool: typeof createEditTool;
-    createReadTool: typeof CreateReadTool;
-    createWriteTool: typeof createWriteTool;
-  };
   applyPatchEnabled: boolean;
   applyPatchWorkspaceOnly: boolean;
   execDefaults: ExecToolDefaults;
@@ -124,76 +113,68 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
 
   const base: AnyAgentTool[] = [];
   if (options.includeBaseCodingTools) {
-    const baseToolNames = new Set(options.baseToolNames ?? ["read", "edit", "write"]);
-    if (baseToolNames.has("read")) {
-      const read = sandboxRoot
-        ? createSandboxedReadTool({
-            root: sandboxRoot,
-            bridge: sandboxFsBridge!,
-            modelContextWindowTokens: options.modelContextWindowTokens,
-            imageSanitization: options.imageSanitization,
-            modelHasVision: options.modelHasVision,
-            createTool: options.baseToolFactories?.createReadTool,
-          })
-        : (options.baseToolFactories?.createReadTool ?? createReadTool)(options.codingRoot, {
-            maxBytes: resolveAdaptiveReadMaxBytes(options),
-            modelBudget: resolveToolResultBudget(options.modelContextWindowTokens),
-            modelHasVision: options.modelHasVision,
-          });
-      const guarded = options.workspaceOnly
-        ? wrapToolWorkspaceRootGuardWithOptions(
-            read,
-            sandboxRoot ?? options.containmentRoot,
-            sandboxRoot
-              ? {
-                  additionalContainerMounts: sandboxReadMounts(sandbox),
-                  containerWorkdir: sandbox.containerWorkdir,
-                  bridge: sandboxFsBridge,
-                }
-              : {
-                  additionalRoots: skillReadRoots,
-                  resolutionCwd: options.codingRoot,
-                  normalizeGuardedPathParams: true,
-                },
-          )
-        : read;
-      // Relative read semantics (including optional daily journals) run before
-      // the guard forwards its checked absolute path to the filesystem reader.
-      const wrapped = sandboxRoot
-        ? guarded
-        : createOpenClawReadTool(guarded, {
-            modelContextWindowTokens: options.modelContextWindowTokens,
-            imageSanitization: options.imageSanitization,
-            cwd: options.codingRoot,
-          });
-      base.push(
-        wrapReadToolWithSkillContent(wrapped, options.skillsSnapshot?.resolvedSkills, {
+    const read = sandboxRoot
+      ? createSandboxedReadTool({
+          root: sandboxRoot,
+          bridge: sandboxFsBridge!,
+          modelContextWindowTokens: options.modelContextWindowTokens,
+          imageSanitization: options.imageSanitization,
+          modelHasVision: options.modelHasVision,
+        })
+      : createReadTool(options.codingRoot, {
+          maxBytes: resolveAdaptiveReadMaxBytes(options),
+          modelBudget: resolveToolResultBudget(options.modelContextWindowTokens),
+          modelHasVision: options.modelHasVision,
+        });
+    const guarded = options.workspaceOnly
+      ? wrapToolWorkspaceRootGuardWithOptions(
+          read,
+          sandboxRoot ?? options.containmentRoot,
+          sandboxRoot
+            ? {
+                additionalContainerMounts: sandboxReadMounts(sandbox),
+                containerWorkdir: sandbox.containerWorkdir,
+                bridge: sandboxFsBridge,
+              }
+            : {
+                additionalRoots: skillReadRoots,
+                resolutionCwd: options.codingRoot,
+                normalizeGuardedPathParams: true,
+              },
+        )
+      : read;
+    // Relative read semantics (including optional daily journals) run before
+    // the guard forwards its checked absolute path to the filesystem reader.
+    const wrapped = sandboxRoot
+      ? guarded
+      : createOpenClawReadTool(guarded, {
           modelContextWindowTokens: options.modelContextWindowTokens,
           imageSanitization: options.imageSanitization,
           cwd: options.codingRoot,
-          containerWorkdir: sandbox?.containerWorkdir,
-          instructionPaths: options.skillInstructionPaths,
-          instructionDeliveryCache: options.skillInstructionDeliveryCache,
-        }),
-      );
-    }
-    if (!options.readOnly && !sandboxRoot && baseToolNames.has("edit")) {
+        });
+    base.push(
+      wrapReadToolWithSkillContent(wrapped, options.skillsSnapshot?.resolvedSkills, {
+        modelContextWindowTokens: options.modelContextWindowTokens,
+        imageSanitization: options.imageSanitization,
+        cwd: options.codingRoot,
+        containerWorkdir: sandbox?.containerWorkdir,
+        instructionPaths: options.skillInstructionPaths,
+        instructionDeliveryCache: options.skillInstructionDeliveryCache,
+      }),
+    );
+    if (!options.readOnly && !sandboxRoot) {
       const edit = createHostWorkspaceEditTool(options.codingRoot, {
         containmentRoot: options.containmentRoot,
         workspaceOnly: options.workspaceOnly,
         memoryWriteProvenance: options.memoryWriteProvenance,
         abortSignal: options.abortSignal,
-        createTool: options.baseToolFactories?.createEditTool,
       });
       base.push(options.workspaceOnly ? guardHostWorkspaceTool(edit, options) : edit);
-    }
-    if (!options.readOnly && !sandboxRoot && baseToolNames.has("write")) {
       const write = createHostWorkspaceWriteTool(options.codingRoot, {
         containmentRoot: options.containmentRoot,
         workspaceOnly: options.workspaceOnly,
         memoryWriteProvenance: options.memoryWriteProvenance,
         abortSignal: options.abortSignal,
-        createTool: options.baseToolFactories?.createWriteTool,
       });
       base.push(options.workspaceOnly ? guardHostWorkspaceTool(write, options) : write);
     }
@@ -206,14 +187,8 @@ export function createCoreCodingTools(options: CoreCodingToolsOptions): AnyAgent
       memoryWriteProvenance: options.memoryWriteProvenance,
       abortSignal: options.abortSignal,
     };
-    const edit = createSandboxedEditTool({
-      ...toolOptions,
-      createTool: options.baseToolFactories?.createEditTool,
-    });
-    const write = createSandboxedWriteTool({
-      ...toolOptions,
-      createTool: options.baseToolFactories?.createWriteTool,
-    });
+    const edit = createSandboxedEditTool(toolOptions);
+    const write = createSandboxedWriteTool(toolOptions);
     base.push(
       options.workspaceOnly
         ? wrapToolWorkspaceRootGuardWithOptions(edit, sandboxRoot, {

--- a/src/agents/embedded-agent-runner/model.fixture.test-support.ts
+++ b/src/agents/embedded-agent-runner/model.fixture.test-support.ts
@@ -9,7 +9,7 @@ export function guardModelFixtureAuth(root: string) {
   const spy = vi
     .spyOn(authProfileStore, "ensureAuthProfileStore")
     .mockImplementation((dir, options) => {
-      // Discovery stores and prepared metadata do not bypass native auth reads.
+      // Any necessary native auth reads must remain inside the fixture's owned state.
       // Record even swallowed violations before the owner can inspect the path.
       if (!dir || !isPathInside(root, dir)) {
         violations.push(dir);

--- a/src/agents/embedded-agent-runner/model.provider-hooks.timeout.test.ts
+++ b/src/agents/embedded-agent-runner/model.provider-hooks.timeout.test.ts
@@ -37,7 +37,6 @@ beforeEach(async () => {
   return async () => {
     try {
       auth.verify();
-      expect(auth.spy).toHaveBeenCalled();
     } finally {
       auth.spy.mockRestore();
       await state.cleanup();

--- a/src/agents/embedded-agent-runner/model.registry-resolution.ts
+++ b/src/agents/embedded-agent-runner/model.registry-resolution.ts
@@ -215,37 +215,28 @@ export function resolveDynamicModelAuthProfile(params: {
   authProfileMode?: AuthProfileCredential["type"] | "aws-sdk";
 } {
   const explicitProfileId = params.authProfileId?.trim() || undefined;
-  const store = ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false });
-  if (explicitProfileId) {
-    const credential = store.profiles[explicitProfileId];
-    const configuredMode = params.cfg?.auth?.profiles?.[explicitProfileId]?.mode;
+  // A prepared mode is authoritative; model discovery does not reselect its credentials.
+  if (params.authProfileMode) {
     return {
-      authProfileId: explicitProfileId,
-      ...(params.authProfileMode || credential?.type || configuredMode
-        ? { authProfileMode: params.authProfileMode ?? credential?.type ?? configuredMode }
-        : {}),
+      ...(explicitProfileId ? { authProfileId: explicitProfileId } : {}),
+      authProfileMode: params.authProfileMode,
     };
   }
-  if (params.authProfileMode) {
-    return { authProfileMode: params.authProfileMode };
-  }
-  const order = [
-    ...new Set(
-      listOpenAIAuthProfileProvidersForAgentRuntime({
-        provider: params.provider,
-        config: params.cfg,
-      }).flatMap((provider) =>
-        resolveAuthProfileOrder({
-          cfg: params.cfg,
-          store,
-          provider,
-          preferredProfile: params.preferredProfile,
-          forModel: params.modelId,
-        }),
-      ),
-    ),
-  ];
-  const profileId = order[0];
+  const store = ensureAuthProfileStore(params.agentDir, { allowKeychainPrompt: false });
+  const profileId =
+    explicitProfileId ??
+    listOpenAIAuthProfileProvidersForAgentRuntime({
+      provider: params.provider,
+      config: params.cfg,
+    }).flatMap((provider) =>
+      resolveAuthProfileOrder({
+        cfg: params.cfg,
+        store,
+        provider,
+        preferredProfile: params.preferredProfile,
+        forModel: params.modelId,
+      }),
+    )[0];
   if (!profileId) {
     return {};
   }
@@ -265,33 +256,17 @@ function resolvePluginDynamicModelWithRegistry(
   const { provider, modelId, modelRegistry, cfg, agentDir, workspaceDir } = params;
   const runtimeHooks = params.runtimeHooks ?? DEFAULT_PROVIDER_RUNTIME_HOOKS;
   const providerConfig = resolveConfiguredProviderConfig(cfg, provider);
-  const agentHarnessPolicy = resolveAgentHarnessPolicy({ provider, modelId, config: cfg });
-  const inferredAgentRuntimeId =
-    agentHarnessPolicy.runtimeSource !== "implicit" ||
-    cfg?.plugins?.entries?.codex?.enabled === true
-      ? agentHarnessPolicy.runtime
-      : undefined;
-  const agentRuntimeId = params.agentRuntimeId ?? inferredAgentRuntimeId;
-  const authProfile = resolveDynamicModelAuthProfile({
-    provider,
-    modelId,
-    cfg,
-    agentDir,
-    authProfileId: params.authProfileId,
-    authProfileMode: params.authProfileMode,
-    preferredProfile: params.preferredProfile,
-  });
-  const preferDiscoveredModelMetadata = shouldCompareProviderRuntimeResolvedModel({
-    provider,
-    modelId,
-    cfg,
-    agentDir,
-    workspaceDir,
-    runtimeHooks,
-  });
-  const pluginDynamicModel =
-    params.preparedDynamicModel ??
-    (runtimeHooks.runProviderDynamicModel({
+  let pluginDynamicModel = params.preparedDynamicModel;
+  if (!pluginDynamicModel) {
+    // Prepared models already consumed discovery inputs; only a sync hook needs them again.
+    const agentHarnessPolicy = resolveAgentHarnessPolicy({ provider, modelId, config: cfg });
+    const inferredAgentRuntimeId =
+      agentHarnessPolicy.runtimeSource !== "implicit" ||
+      cfg?.plugins?.entries?.codex?.enabled === true
+        ? agentHarnessPolicy.runtime
+        : undefined;
+    const agentRuntimeId = params.agentRuntimeId ?? inferredAgentRuntimeId;
+    pluginDynamicModel = runtimeHooks.runProviderDynamicModel({
       provider,
       config: cfg,
       workspaceDir,
@@ -304,9 +279,10 @@ function resolvePluginDynamicModelWithRegistry(
         modelId,
         modelRegistry,
         providerConfig,
-        ...authProfile,
+        ...resolveDynamicModelAuthProfile(params),
       },
-    }) as ProviderRuntimeModel | undefined);
+    }) as ProviderRuntimeModel | undefined;
+  }
   if (!pluginDynamicModel) {
     return undefined;
   }
@@ -320,7 +296,10 @@ function resolvePluginDynamicModelWithRegistry(
     providerMetadataOwners: getRegistryProviderMetadataOwners(modelRegistry),
     runtimeHooks,
     workspaceDir,
-    preferDiscoveredModelMetadata,
+    preferDiscoveredModelMetadata: shouldCompareProviderRuntimeResolvedModel({
+      ...params,
+      runtimeHooks,
+    }),
     getStaticCatalogModel: params.getStaticCatalogModel,
   });
   return normalizeResolvedModel({

--- a/src/agents/embedded-agent-runner/model.test.ts
+++ b/src/agents/embedded-agent-runner/model.test.ts
@@ -601,7 +601,12 @@ describe("resolveModel", () => {
       contextWindow: 65_536,
       maxTokens: 8_192,
     };
-    const prepareProviderDynamicModel = vi.fn(async () => preparedModel);
+    const prepareProviderDynamicModel = vi.fn(async () => {
+      auth.spy.mockImplementation(() => {
+        throw new Error("Auth storage became unavailable after model preparation");
+      });
+      return preparedModel;
+    });
     const runProviderDynamicModel = vi.fn(() => undefined);
     const normalizeProviderResolvedModelWithPlugin = vi.fn(
       ({ context }: { context: { model: Model } }) => ({
@@ -689,6 +694,11 @@ describe("resolveModel", () => {
           },
         ],
       });
+      if (!preferRuntime) {
+        auth.spy.mockImplementation(() => {
+          throw new Error("Explicit model resolution must not read auth storage");
+        });
+      }
 
       const result = await resolveModelAsync("acme", "prepared-model", state.agentDir(), cfg, {
         runtimeHooks: {
@@ -1473,45 +1483,56 @@ describe("resolveModel", () => {
     expect(shouldPreferProviderRuntimeResolvedModel).toHaveBeenCalled();
   });
 
-  it("keeps the prepared auth mode through async provider model resolution", async () => {
-    const baseRuntimeHooks = createRuntimeHooks();
-    const prepareProviderDynamicModel = vi.fn(baseRuntimeHooks.prepareProviderDynamicModel);
-    const runProviderDynamicModel = vi.fn((params: { context: { authProfileMode?: string } }) => ({
-      provider: "openai",
-      ...makeModel("gpt-5.5"),
-      api:
-        params.context.authProfileMode === "api_key"
-          ? ("openai-responses" as const)
-          : ("openai-chatgpt-responses" as const),
-      baseUrl:
-        params.context.authProfileMode === "api_key"
-          ? "https://api.openai.com/v1"
-          : "https://chatgpt.com/backend-api",
-    }));
+  it.each([undefined, "openai:prepared"])(
+    "keeps the prepared auth mode through async provider model resolution (profile %s)",
+    async (authProfileId) => {
+      auth.spy.mockImplementation(() => {
+        throw new Error("Prepared auth mode must not read auth storage");
+      });
+      const baseRuntimeHooks = createRuntimeHooks();
+      const prepareProviderDynamicModel = vi.fn(baseRuntimeHooks.prepareProviderDynamicModel);
+      const runProviderDynamicModel = vi.fn(
+        (params: { context: { authProfileMode?: string } }) => ({
+          provider: "openai",
+          ...makeModel("gpt-5.5"),
+          api:
+            params.context.authProfileMode === "api_key"
+              ? ("openai-responses" as const)
+              : ("openai-chatgpt-responses" as const),
+          baseUrl:
+            params.context.authProfileMode === "api_key"
+              ? "https://api.openai.com/v1"
+              : "https://chatgpt.com/backend-api",
+        }),
+      );
 
-    const result = await resolveModelAsync("openai", "gpt-5.5", state.agentDir(), undefined, {
-      authProfileMode: "api_key",
-      runtimeHooks: {
-        ...baseRuntimeHooks,
-        prepareProviderDynamicModel,
-        runProviderDynamicModel,
-      },
-      skipAgentDiscovery: true,
-    });
+      const result = await resolveModelAsync("openai", "gpt-5.5", state.agentDir(), undefined, {
+        authProfileId,
+        authProfileMode: "api_key",
+        runtimeHooks: {
+          ...baseRuntimeHooks,
+          prepareProviderDynamicModel,
+          runProviderDynamicModel,
+        },
+        skipAgentDiscovery: true,
+      });
 
-    expectRecordFields(expectResolvedModel(result), {
-      provider: "openai",
-      id: "gpt-5.5",
-      api: "openai-responses",
-      baseUrl: "https://api.openai.com/v1",
-    });
-    expectRecordFields(mockCallArg(prepareProviderDynamicModel).context, {
-      authProfileMode: "api_key",
-    });
-    expectRecordFields(mockCallArg(runProviderDynamicModel).context, {
-      authProfileMode: "api_key",
-    });
-  });
+      expectRecordFields(expectResolvedModel(result), {
+        provider: "openai",
+        id: "gpt-5.5",
+        api: "openai-responses",
+        baseUrl: "https://api.openai.com/v1",
+      });
+      expectRecordFields(mockCallArg(prepareProviderDynamicModel).context, {
+        ...(authProfileId ? { authProfileId } : {}),
+        authProfileMode: "api_key",
+      });
+      expectRecordFields(mockCallArg(runProviderDynamicModel).context, {
+        ...(authProfileId ? { authProfileId } : {}),
+        authProfileMode: "api_key",
+      });
+    },
+  );
 
   it("looks up each static fallback candidate with its own normalized model id", async () => {
     resolveBundledStaticCatalogModelMock.mockImplementation(({ provider, modelId }) => ({

--- a/src/agents/embedded-agent-runner/model.ts
+++ b/src/agents/embedded-agent-runner/model.ts
@@ -250,15 +250,6 @@ export async function resolveModelAsync(
       };
     }
     const providerConfig = resolveConfiguredProviderConfig(cfg, normalizedRef.provider);
-    const authProfile = resolveDynamicModelAuthProfile({
-      provider: normalizedRef.provider,
-      modelId: normalizedRef.model,
-      cfg,
-      agentDir: resolvedAgentDir,
-      authProfileId: options?.authProfileId,
-      authProfileMode: options?.authProfileMode,
-      preferredProfile: options?.preferredProfile,
-    });
     const preparedMetadataSnapshot = preparedModelRuntime?.metadataSnapshot;
     let providerStaticCatalogLookup: Promise<ProviderRuntimeModel | undefined> | undefined;
     const resolveStaticCatalogModel = async () => {
@@ -304,6 +295,15 @@ export async function resolveModelAsync(
       });
     };
     const resolveDynamicAttempt = async () => {
+      const authProfile = resolveDynamicModelAuthProfile({
+        provider: normalizedRef.provider,
+        modelId: normalizedRef.model,
+        cfg,
+        agentDir: resolvedAgentDir,
+        authProfileId: options?.authProfileId,
+        authProfileMode: options?.authProfileMode,
+        preferredProfile: options?.preferredProfile,
+      });
       const preparedDynamicModel = await runtimeHooks.prepareProviderDynamicModel({
         provider: normalizedRef.provider,
         config: cfg,

--- a/src/agents/sessions/index.ts
+++ b/src/agents/sessions/index.ts
@@ -8,7 +8,6 @@ export * from "./model-registry.js";
 export * from "./model-resolver.js";
 export * from "./package-manager.js";
 export * from "./resource-loader.js";
-export { createCodingTools, createEditTool, createReadTool, createWriteTool } from "./sdk.js";
 export type {
   CreateAgentSessionOptions,
   ExtensionAPI,

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -43,13 +43,7 @@ import { DefaultResourceLoader, type ResourceLoader } from "./resource-loader.js
 import { SessionManager } from "./session-manager.js";
 import { SettingsManager } from "./settings-manager.js";
 import { isInstallTelemetryEnabled } from "./telemetry.js";
-import {
-  createCodingTools,
-  createEditTool,
-  createReadTool,
-  createWriteTool,
-  type ToolName,
-} from "./tools/index.js";
+import type { ToolName } from "./tools/index.js";
 
 export interface CreateAgentSessionOptions {
   /** Working directory for project-local discovery. Default: process.cwd() */
@@ -127,8 +121,6 @@ export type {
   ExtensionFactory,
   ToolDefinition,
 } from "./extensions/index.js";
-
-export { createCodingTools, createReadTool, createEditTool, createWriteTool };
 
 // Helper Functions
 

--- a/src/agents/tool-schema-projection.test.ts
+++ b/src/agents/tool-schema-projection.test.ts
@@ -84,6 +84,24 @@ describe("runtime tool input schema projection", () => {
     });
   });
 
+  it("rejects raw JSON numeric overflow at the root and inside schemas", ({ skip }) => {
+    if (!("rawJSON" in JSON) || typeof JSON.rawJSON !== "function") {
+      skip();
+      return;
+    }
+    const overflow: unknown = JSON.rawJSON("1e400");
+    for (const schema of [
+      overflow,
+      { type: "object", properties: { score: { default: overflow } } },
+      { type: "object", anyOf: [{ $dynamicRef: "#value", default: overflow }] },
+    ]) {
+      expect(projectRuntimeToolInputSchema(schema)).toEqual({
+        schema: {},
+        violations: ["parameters is not a JSON value"],
+      });
+    }
+  });
+
   it("reports non-finite values returned by nested toJSON serializers", () => {
     expect(
       projectRuntimeToolInputSchema({

--- a/src/gateway/server-methods/chat-send-admission.ts
+++ b/src/gateway/server-methods/chat-send-admission.ts
@@ -239,7 +239,8 @@ export async function admitChatSend(params: {
       }
       return;
     }
-    const latestSession = loadSessionEntry(sessionLoadKey, sessionLoadOptions);
+    // Admission only reads these entries; borrowing avoids cloning every unrelated session.
+    const latestSession = loadSessionEntry(sessionLoadKey, { ...sessionLoadOptions, clone: false });
     if (sessionRoutingChanged(latestSession.cfg)) {
       throw new Error(SESSION_ROUTING_CHANGED_ERROR_REASON);
     }

--- a/src/gateway/server-methods/chat-send-reply-dispatch.ts
+++ b/src/gateway/server-methods/chat-send-reply-dispatch.ts
@@ -117,7 +117,9 @@ export function createChatSendReplyDispatch(params: {
   userTurnRecorder: Pick<UserTurnTranscriptRecorder, "markBlocked">;
 }) {
   const { accountId, isAgentRunStarted, logGateway, session, userTurnRecorder } = params;
-  const { backingSessionId, cfg, clientRunId, sessionLoadOptions } = session;
+  const { backingSessionId, cfg, clientRunId } = session;
+  // Extract scalar transcript bindings from borrowed entries; reread after asynchronous work.
+  const sessionLoadOptions = { ...session.sessionLoadOptions, clone: false };
   let assistantTranscriptRewriteState = {
     sessionId: undefined as string | undefined,
     generation: null as string | null,

--- a/src/gateway/server-methods/chat-send-session-binding.test.ts
+++ b/src/gateway/server-methods/chat-send-session-binding.test.ts
@@ -26,6 +26,19 @@ it.each(["removed", "replaced", "aborted", "released", "terminal", "rotated", "q
       const runId = "retained-preparation";
       const sessionKey = "agent:main:binding";
       const scope = { agentId: "main", sessionKey };
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey: "agent:main:unrelated" },
+        { sessionId: "unrelated-session", updatedAt: Date.now() },
+      );
+      const clone = vi.spyOn(globalThis, "structuredClone");
+      const unrelatedCloneCount = () =>
+        clone.mock.calls.filter(
+          ([entry]) =>
+            entry &&
+            typeof entry === "object" &&
+            "sessionId" in entry &&
+            entry.sessionId === "unrelated-session",
+        ).length;
       const entered = createDeferred<DispatchOptions>();
       const release = createDeferred();
       const observeDispatch = vi.spyOn(chatDispatch, "startChatDispatch");
@@ -78,9 +91,12 @@ it.each(["removed", "replaced", "aborted", "released", "terminal", "rotated", "q
         options = await entered.promise;
         owned = observeDispatch.mock.calls.at(-1)?.[0];
         const prepared = options.replyOptions?.onSessionPrepared;
-        if (!owned || !prepared) {
+        const runStarted = options.replyOptions?.onAgentRunStart;
+        if (!owned || !prepared || !runStarted) {
           throw new Error("chat.send did not hand off its prepared-session callback");
         }
+        // Initial resolution needs detached entries; later admission must not clone unrelated rows.
+        expect.soft(unrelatedCloneCount()).toBeLessThanOrEqual(1);
         const { admission, userTurn } = owned;
         const original = admission.activeRunAbort.entry;
         expect(original?.sessionId).toBe(runId);
@@ -101,6 +117,9 @@ it.each(["removed", "replaced", "aborted", "released", "terminal", "rotated", "q
         prepared(binding);
         prepared(binding);
         prepared({ ...binding, sessionKey: "agent:main:unrelated", sessionId: "foreign" });
+        clone.mockClear();
+        runStarted(runId);
+        expect.soft(unrelatedCloneCount()).toBe(0);
 
         if (closure === "queued") {
           expect(original?.sessionId).toBe(binding.sessionId);
@@ -169,6 +188,7 @@ it.each(["removed", "replaced", "aborted", "released", "terminal", "rotated", "q
         }
         holdDispatch.mockRestore();
         observeDispatch.mockRestore();
+        clone.mockRestore();
       }
     });
   },

--- a/src/gateway/session-utils.single-row-cache.test.ts
+++ b/src/gateway/session-utils.single-row-cache.test.ts
@@ -5,7 +5,12 @@ import { afterEach, describe, expect, test, vi } from "vitest";
 import { resetConfigRuntimeState, setRuntimeConfigSnapshot } from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resolveSessionStorePathCore, type SessionEntry } from "../config/sessions.js";
-import { replaceSessionEntry, updateSessionEntry } from "../config/sessions/session-accessor.js";
+import { resolveInternalSessionEffectsIdentity } from "../config/sessions/internal-session-key.js";
+import {
+  loadExactSessionEntryReadOnly,
+  replaceSessionEntry,
+  updateSessionEntry,
+} from "../config/sessions/session-accessor.js";
 import { resetPluginRuntimeStateForTest } from "../plugins/runtime.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 
@@ -74,6 +79,7 @@ import {
   listSessionsFromStoreAsync,
   loadGatewaySessionEntryReadOnly,
   loadGatewaySessionRow,
+  loadSessionEntry,
 } from "./session-utils.js";
 
 const MAIN_AGENT_ID = "main";
@@ -209,6 +215,30 @@ describe("single gateway session row child projections", () => {
     resetPluginRuntimeStateForTest();
     subagentRegistryReadMock.setSubagentRunsForTest([]);
     vi.clearAllMocks();
+  });
+
+  test("hides internal effects from listings while preserving exact reads for private history", async () => {
+    await withSingleRowCacheStore(
+      "openclaw-single-row-hidden-effects-",
+      "/tmp/openclaw-single-row-hidden-effects",
+      async ({ now, storePath }) => {
+        const hidden = resolveInternalSessionEffectsIdentity({
+          agentId: MAIN_AGENT_ID,
+          runId: "suppressed-effects",
+        });
+        await seedSessionEntries(storePath, {
+          [hidden.sessionKey]: parentSession(hidden.sessionId, now),
+        });
+
+        expect(loadSessionEntry(hidden.sessionKey).entry).toBeUndefined();
+        expect(loadGatewaySessionEntryReadOnly(hidden.sessionKey).entry?.sessionId).toBe(
+          hidden.sessionId,
+        );
+        expect(loadExactSessionEntryReadOnly({ ...hidden, storePath })?.entry.sessionId).toBe(
+          hidden.sessionId,
+        );
+      },
+    );
   });
 
   test("keeps direct children visible with at most one candidate scan per exact snapshot", async () => {


### PR DESCRIPTION
## What Problem This Solves

Warm chat turns repeat policy and authentication discovery, build coding tools that are immediately discarded, traverse tool schemas more than necessary, and deep-copy unrelated session entries during admission and transcript handling. This adds preparation work before the model can respond, especially with larger session stores.

## Why This Change Was Made

Reuse the native execution policy within each Codex tool build, resolve absent-search policy only when its persistent-policy callback needs it, and consume prepared model/auth facts before discovering them again. Remove discarded coding-tool construction and redundant factory forwarding, and combine schema validation traversal while preserving numeric-overflow diagnostics.

Admission and transcript consumers use the existing borrowed-read option. Initial session resolution still owns detached entries; all later lookups and post-await session fences remain. This keeps listing visibility, private exact history, provisioning, validation, and lifecycle behavior unchanged. The rebase preserves main's separate policy/execution agent identities and catalog-pricing precedence. No new configuration, dependencies, caches, or storage/schema changes.

Related: #133782, #133184. These earlier preparation improvements cover different work.

## User Impact

Less repeated per-turn work and **114 fewer production lines** (+202/−316). Tests: +232/−84, net +148. Existing tools, policy decisions, session history, and model selection retain their behavior.

The first matched live experiment reduced median preparation from **115.71 to 96.55 ms (16.6%)**, but did not improve complete-reply latency or aggregate CPU. The additional session-copy change reduced isolated 1,000-row lookup time from **8.613 to 0.835 ms** and fixture-row copies across two live turns from **14,000 to 8,000**. It did **not** establish another live latency improvement: small-store preparation stayed near 95.9 ms; with 1,000 retained fixtures, median preparation was 187.09→191.76 ms and complete reply 1,390.55→1,492.55 ms. The candidate's 782.79 ms preparation outlier is included. These serial shared-machine measurements do not establish an end-to-end speedup, and the two comparisons must not be added together.

## Evidence

- Real loopback development Gateway with OpenAI API-key authentication and `openai/gpt-5.6-luna`, low reasoning, fast mode off. Matched stopped-state snapshots, persistent WebSocket client, fresh process per workload, warmups, CPU profiles, and separate copy/allocation instrumentation. First pass: 152 comparison turns (104 measured); session-copy continuation: 144 turns (96 measured). All measured replies matched the expected response. Plain reply, file-read, and session-status tool smoke passed.
- An initial large-store experiment was trimmed to 500 rows by maintenance. The final pair verified all 1,000 fixtures remained in both builds. Temporary settings and synthetic fixtures were removed afterward. No builds or test suites overlapped timed samples.
- 1,237 focused passing cases across the two implementation phases, full first-pass build, final runtime build, and changed-code gates. The copy-count regression failed on the original implementation before passing with borrowed reads.
- After integration with main, **359 cases across nine files passed**: Codex dynamic tools and connection preparation; model resolution and pricing overrides; schema projection; Gateway single-row projections, admission/session binding, reply dispatch, and history. Run with `node scripts/run-vitest.mjs` and those focused files.
- The timeout-hook fixture no longer requires an auth-store lookup for explicit model metadata; auth-isolation and real HTTP timeout assertions remain. Its seven cases and 12 model-generation/discovery/forward-compatibility siblings passed after the stale cleanup assertion was removed.
- Hosted CI also exposed two wall-clock parser-performance assertions on a loaded runner. Replaced them with call-through work bounds, retaining the same fixtures and output checks; 197 cases across the two files passed. In-memory regression mutations raise preceding-prefix slices from 2 to 600 and exceed the reasoning-parser input budget after 938 bytes. No timeouts were increased and no production parser code changed.
- Fresh Codex autoreview: no accepted/actionable findings at its configured P0 threshold. Independent integration audit verified retained policy ownership and pricing. Direct Codex source inspection covered `codex-rs/app-server/src/request_processors/turn_processor.rs` (turn admission), `codex-rs/core/src/client.rs` (WebSocket lifetime), and app-server protocol thread start/resume contracts. No Codex protocol changes.

An exact-reader replacement was rejected because private companion history intentionally reads hidden current-session rows and exact access has different provisioning/validation contracts. The retained borrowed mode preserves those contracts. Remaining follow-up: profile other full-store consumers and filesystem-watcher work; full-store enumeration remains in this PR.
