### PR TITLE
fix(cli): omit hidden options from generated shell completions

### DIFF
--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -86,22 +86,6 @@ describe("completion-cli", () => {
     expect(script).not.toContain("John'\\''s");
   });
 
-  it.each(["bash", "zsh", "fish", "powershell"] as const)(
-    "omits hidden options from %s completions",
-    (shell) => {
-      const program = new Command()
-        .name("openclaw")
-        .option("--visible", "Advertised")
-        .addOption(new Option("--internal-only").hideHelp());
-
-      const script = getCompletionScript(shell, program);
-
-      // fish spells long flags as `-l visible`, so match the bare name.
-      expect(script).toContain("visible");
-      expect(script).not.toContain("internal-only");
-    },
-  );
-
   it("marks zsh option arguments and completes validated shell choices", () => {
     const script = getCompletionScript("zsh", createDocumentedCompletionProgram());
 

--- a/src/cli/completion-cli.test.ts
+++ b/src/cli/completion-cli.test.ts
@@ -86,6 +86,22 @@ describe("completion-cli", () => {
     expect(script).not.toContain("John'\\''s");
   });
 
+  it.each(["bash", "zsh", "fish", "powershell"] as const)(
+    "omits hidden options from %s completions",
+    (shell) => {
+      const program = new Command()
+        .name("openclaw")
+        .option("--visible", "Advertised")
+        .addOption(new Option("--internal-only").hideHelp());
+
+      const script = getCompletionScript(shell, program);
+
+      // fish spells long flags as `-l visible`, so match the bare name.
+      expect(script).toContain("visible");
+      expect(script).not.toContain("internal-only");
+    },
+  );
+
   it("marks zsh option arguments and completes validated shell choices", () => {
     const script = getCompletionScript("zsh", createDocumentedCompletionProgram());
 

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -295,6 +295,7 @@ fi
 
 function generateZshArgs(cmd: Command): string {
   return (cmd.options || [])
+    .filter((opt) => !opt.hidden)
     .map((opt) => {
       const flags = completionFlags(opt);
       const name = preferredCompletionFlag(opt);
@@ -720,7 +721,7 @@ function generateFishCompletion(program: Command): string {
         }
       }
       // Options
-      for (const opt of cmd.options) {
+      for (const opt of cmd.options.filter((option) => !option.hidden)) {
         segments.push(
           buildFishOptionCompletionLine({
             rootCmd,

--- a/src/cli/completion-cli.ts
+++ b/src/cli/completion-cli.ts
@@ -9,6 +9,7 @@ import {
   collectShellCompletionCommandTree,
   commandNameVariants,
   completionFlags,
+  visibleCompletionCommands,
   type ShellCompletionContext,
 } from "./completion-command-tree.js";
 import {
@@ -295,11 +296,12 @@ fi
 
 function generateZshArgs(cmd: Command): string {
   return (cmd.options || [])
-    .filter((opt) => !opt.hidden)
     .map((opt) => {
       const flags = completionFlags(opt);
       const name = preferredCompletionFlag(opt);
       const alternate = flags.find((flag) => flag !== name);
+      // `_arguments` hides `!` specs but still skips their values when locating subcommands.
+      const visibility = opt.hidden ? "!" : "";
       const desc = escapeZshDoubleQuotedDescription(opt.description);
       const choices = opt.argChoices?.map(escapeZshCompletionChoice).join(" ");
       const argument =
@@ -307,9 +309,9 @@ function generateZshArgs(cmd: Command): string {
           ? `${opt.optional ? "::" : ":"}${opt.attributeName()}:${choices ? `(${choices})` : ""}`
           : "";
       if (alternate) {
-        return `"(${name} ${alternate})"{${name},${alternate}}"[${desc}]${argument}"`;
+        return `"${visibility}(${name} ${alternate})"{${name},${alternate}}"[${desc}]${argument}"`;
       }
-      return `"${name}[${desc}]${argument}"`;
+      return `"${visibility}${name}[${desc}]${argument}"`;
     })
     .join(" \\\n    ");
 }
@@ -320,7 +322,7 @@ function escapeZshCompletionChoice(choice: string): string {
 }
 
 function generateZshSubcmdList(cmd: Command): string {
-  const list = cmd.commands
+  const list = visibleCompletionCommands(cmd)
     .flatMap((c) => {
       const desc = c
         .description()
@@ -708,7 +710,7 @@ function generateFishCompletion(program: Command): string {
     );
     for (const condition of conditions) {
       // Subcommands (canonical names and aliases)
-      for (const sub of cmd.commands) {
+      for (const sub of visibleCompletionCommands(cmd)) {
         for (const name of commandNameVariants(sub)) {
           segments.push(
             buildFishSubcommandCompletionLine({

--- a/src/cli/completion-cli.visibility.test.ts
+++ b/src/cli/completion-cli.visibility.test.ts
@@ -1,0 +1,95 @@
+import { Command, Option } from "commander";
+import { afterAll, describe, expect, it } from "vitest";
+import {
+  itWithFish,
+  itWithPowerShell,
+  PowerShellCompletionRunner,
+  runGeneratedBashCompletion,
+  runGeneratedFishCompletion,
+} from "./completion-cli.test-support.js";
+
+const powerShellCompletion = new PowerShellCompletionRunner();
+
+afterAll(async () => {
+  await powerShellCompletion.close();
+});
+
+function createVisibilityProgram(): Command {
+  const program = new Command()
+    .name("openclaw")
+    .option("--visible-root", "Visible root option")
+    .addOption(new Option("--hidden-root").hideHelp())
+    .addOption(new Option("--internal-value <value>").hideHelp());
+  program.command("visible").alias("public");
+  program.command("hidden", { hidden: true }).alias("private").command("child");
+  const parent = program.command("parent");
+  parent.option("--visible-child", "Visible child option");
+  parent.addOption(new Option("--hidden-child").hideHelp());
+  parent.command("visible").alias("public");
+  parent.command("hidden", { hidden: true }).alias("private").option("--inside");
+  return program;
+}
+
+const engines = [
+  {
+    name: "Bash",
+    test: it.skipIf(process.platform === "win32"),
+    complete: (program: Command, words: string[]) => runGeneratedBashCompletion(program, words),
+  },
+  {
+    name: "Fish",
+    test: itWithFish,
+    complete: (program: Command, words: string[]) =>
+      runGeneratedFishCompletion(program, words.join(" ")),
+  },
+  {
+    name: "PowerShell",
+    test: itWithPowerShell,
+    complete: (program: Command, words: string[]) =>
+      powerShellCompletion.complete(program, words.join(" ")),
+  },
+];
+
+for (const engine of engines) {
+  describe(`${engine.name} completion visibility`, () => {
+    engine.test.each([
+      { name: "root", prefix: ["openclaw"], visible: "--visible-root", hidden: "--hidden-root" },
+      {
+        name: "nested",
+        prefix: ["openclaw", "parent"],
+        visible: "--visible-child",
+        hidden: "--hidden-child",
+      },
+    ])("offers only visible $name options and commands", async ({ prefix, visible, hidden }) => {
+      const program = createVisibilityProgram();
+      const flags = await engine.complete(program, [...prefix, "--"]);
+      expect(flags).toContain(visible);
+      expect(flags).not.toContain(hidden);
+      const commands = await engine.complete(program, [...prefix, ""]);
+      expect(commands).toEqual(expect.arrayContaining(["visible", "public"]));
+      expect(commands).not.toContain("hidden");
+      expect(commands).not.toContain("private");
+    });
+
+    engine.test("keeps the context after a typed hidden value option", async () => {
+      const completions = await engine.complete(createVisibilityProgram(), [
+        "openclaw",
+        "--internal-value",
+        "parent",
+        "parent",
+        "--v",
+      ]);
+      expect(completions).toContain("--visible-child");
+      expect(completions).not.toContain("--visible-root");
+    });
+
+    engine.test("keeps descendants after manually typed hidden command aliases", async () => {
+      expect(
+        await engine.complete(createVisibilityProgram(), ["openclaw", "private", "ch"]),
+      ).toContain("child");
+      expect(
+        await engine.complete(createVisibilityProgram(), ["openclaw", "parent", "private", "--i"]),
+      ).toContain("--inside");
+    });
+  });
+}

--- a/src/cli/completion-command-tree.test.ts
+++ b/src/cli/completion-command-tree.test.ts
@@ -24,6 +24,18 @@ describe("shell completion command tree", () => {
     expect(tree.root.valueOptions).toEqual(["-p", "--profile"]);
   });
 
+  it("omits hidden options from the suggested completions", () => {
+    const program = new Command()
+      .name("openclaw")
+      .option("-p, --profile <name>", "Profile")
+      .addOption(new Option("--internal-only").hideHelp());
+
+    const tree = collectShellCompletionCommandTree(program);
+
+    expect(tree.root.completions).toEqual(["-p", "--profile"]);
+    expect(tree.root.completions).not.toContain("--internal-only");
+  });
+
   it("expands aliases across every ancestor and inherits value-taking options", () => {
     const program = new Command().name("openclaw").option("-p, --profile <name>", "Profile");
     const cron = program.command("cron").alias("schedule").option("-z, --timezone <zone>");

--- a/src/cli/completion-command-tree.test.ts
+++ b/src/cli/completion-command-tree.test.ts
@@ -24,18 +24,6 @@ describe("shell completion command tree", () => {
     expect(tree.root.valueOptions).toEqual(["-p", "--profile"]);
   });
 
-  it("omits hidden options from the suggested completions", () => {
-    const program = new Command()
-      .name("openclaw")
-      .option("-p, --profile <name>", "Profile")
-      .addOption(new Option("--internal-only").hideHelp());
-
-    const tree = collectShellCompletionCommandTree(program);
-
-    expect(tree.root.completions).toEqual(["-p", "--profile"]);
-    expect(tree.root.completions).not.toContain("--internal-only");
-  });
-
   it("expands aliases across every ancestor and inherits value-taking options", () => {
     const program = new Command().name("openclaw").option("-p, --profile <name>", "Profile");
     const cron = program.command("cron").alias("schedule").option("-z, --timezone <zone>");
@@ -126,6 +114,25 @@ describe("shell completion command tree", () => {
 
     expect(tree.root.valueChoices).toEqual([colorChoice]);
     expect(tree.descendants[0]?.valueChoices).toEqual([colorChoice]);
+  });
+
+  it("retains hidden value consumption and inherited-choice shadowing", () => {
+    const program = new Command()
+      .name("openclaw")
+      .addOption(new Option("-p, --profile <name>").choices(["parent"]));
+    program
+      .command("child")
+      .addOption(new Option("--profile <name>").choices(["child"]).hideHelp())
+      .option("--visible", "Visible option");
+
+    const context = collectShellCompletionCommandTree(program).descendants[0];
+
+    expect(context?.completions).toEqual(["--visible"]);
+    expect(context?.valueOptions).toEqual(["-p", "--profile"]);
+    expect(context?.valueChoices).toEqual([
+      { flags: ["-p"], choices: ["parent"], requiresValue: true },
+      { flags: ["--profile"], choices: ["child"], requiresValue: true },
+    ]);
   });
 
   it("keeps commandless roots valid for every shell", () => {

--- a/src/cli/completion-command-tree.ts
+++ b/src/cli/completion-command-tree.ts
@@ -39,12 +39,13 @@ export function collectShellCompletionCommandTree(program: Command): ShellComple
     inheritedValueChoices: readonly ShellCompletionValueChoice[],
   ): ShellCompletionContext => {
     const ownOptionFlags = new Set(command.options.flatMap(completionFlags));
+    const visibleOptions = command.options.filter((option) => !option.hidden);
     const context: ShellCompletionContext = {
       command,
       pathVariants,
       completions: [
         ...command.commands.flatMap(commandNameVariants),
-        ...command.options.flatMap(completionFlags),
+        ...visibleOptions.flatMap(completionFlags),
       ],
       valueOptions: [
         ...new Set([

--- a/src/cli/completion-command-tree.ts
+++ b/src/cli/completion-command-tree.ts
@@ -29,6 +29,14 @@ export function commandNameVariants(command: Command): string[] {
   return [command.name(), ...command.aliases()];
 }
 
+export function visibleCompletionCommands(command: Command): Command[] {
+  // The help API also synthesizes a help command; completion dispatch uses registered nodes.
+  return command
+    .createHelp()
+    .visibleCommands(command)
+    .filter((child) => command.commands.includes(child));
+}
+
 export function collectShellCompletionCommandTree(program: Command): ShellCompletionCommandTree {
   const descendants: ShellCompletionContext[] = [];
 
@@ -39,13 +47,12 @@ export function collectShellCompletionCommandTree(program: Command): ShellComple
     inheritedValueChoices: readonly ShellCompletionValueChoice[],
   ): ShellCompletionContext => {
     const ownOptionFlags = new Set(command.options.flatMap(completionFlags));
-    const visibleOptions = command.options.filter((option) => !option.hidden);
     const context: ShellCompletionContext = {
       command,
       pathVariants,
       completions: [
-        ...command.commands.flatMap(commandNameVariants),
-        ...visibleOptions.flatMap(completionFlags),
+        ...visibleCompletionCommands(command).flatMap(commandNameVariants),
+        ...command.options.filter((option) => !option.hidden).flatMap(completionFlags),
       ],
       valueOptions: [
         ...new Set([


### PR DESCRIPTION
## What Problem This Solves

Shell completions advertise options and commands that Commander intentionally hides from help. This exposes internal flags and deprecated command spellings when operators press Tab, including nested commands and aliases.

## Why This Change Was Made

The three suggestion builders ignored Commander's visibility metadata. Bash and PowerShell consume the shared command tree; Zsh and Fish also build suggestions directly.

The repair filters suggestions at those owners. Hidden command names and aliases use Commander's public help API, limited to registered commands. All command traversal and option-value metadata remain available for manually typed hidden inputs. Zsh uses its documented `!` argument specification: suppress the suggestion while retaining value consumption. Simply deleting a hidden Zsh value specification would lose that distinction.

The contributor's option fix is preserved and extended to the same visibility defect in command suggestions. No parser, authorization, configuration or package dependency changes are introduced. Production is +18/-7 (net +11); the shared visibility projection serves three generators, and Zsh needs a separate existing shell contract. Tests add 114 lines.

## User Impact

Tab completion offers visible root and nested commands, aliases and flags. It omits hidden ones. Manually typed hidden commands still select their correct completion context, and hidden value-taking options still consume their values before nested command matching.

This also supplies the shared completion behavior needed by #134212, which stops advertising an inert message-read flag while preserving its shipped spelling.

## Evidence

The defect is present in current main and stable v2026.8.1. Commander 15.0.0 source confirms that visibility is independent of parsing; installed Zsh documentation defines the `!` specification used here.

Independent before/after proof used immutable trusted main plus equivalent authored changes, with exact dependencies, without executing contributor code locally:

- Real Bash and PowerShell engines: baseline 4 intended visibility failures and 4 passing context controls; repaired cases pass.
- Real Fish 4.8.1 engine: baseline 2 intended visibility failures and 2 passing controls; repaired cases pass.
- Real Zsh 5.9.2 ZLE Tab input: six hidden root/nested flag, command and alias suggestions disappear; five visible/value/context controls remain unchanged. For example, `openclaw parent hid<Tab>` previously inserted `hidden`; after the repair it stays unchanged. `openclaw --internal-value parent parent --visible-c<Tab>` still completes `--visible-child`.
- Focused owner and sibling suites: 182 tests across five files, no skips, through the canonical repository test runner with frozen dependencies (pnpm 12.1.0 / Vitest 4.1.11).

```text
node scripts/run-vitest.mjs src/cli/completion-cli.visibility.test.ts src/cli/completion-cli.test.ts src/cli/completion-command-tree.test.ts src/cli/completion-cli.aliases.test.ts src/cli/completion-fish.test.ts --reporter=verbose
```

The inherited-choice regression ensures a hidden child option shadows the matching parent flag while an unshadowed short alias retains its choices. Existing quoting, option values, aliases and nested-path tests also pass.

Changed-file checks passed, including formatting, lint, core and test typechecks, dead exports, runtime import cycles and the selected repository guards. Fresh complete-candidate Codex review passed with no actionable P0 findings. The current ClawSweeper request for real generated-shell proof is addressed by the four-engine results above. Published head731ed5f676a34254252e5cee5039b0c8e6b15041 passed [CI33427478739](https://github.com/openclaw/openclaw/actions/runs/33427478739) and native validation. Hosted logs show all four new Bash and four PowerShell cases plus the hidden-value tree regression executed successfully; optional Fish cases skipped there, with actual Fish/Zsh covered independently above. Two ancillary workflows initially received GitHub API500 responses; each passed one failed-job retry.
