### PR TITLE
fix(macos): retry provider auth callbacks after socket rotation

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -1306,12 +1306,32 @@ extension OnboardingAISetupModel {
         let token = self.attemptToken
         let authAttemptID = self.authAttemptID
         Task {
+            var requestLease = serverLease
             do {
-                let data = try await self.gateway.request(
-                    method: "wizard.next",
-                    params: params,
-                    timeoutMs: Self.providerAuthRequestTimeoutMs,
-                    ifCurrentServerLease: serverLease)
+                let data: Data
+                do {
+                    data = try await self.gateway.request(
+                        method: "wizard.next",
+                        params: params,
+                        timeoutMs: Self.providerAuthRequestTimeoutMs,
+                        ifCurrentServerLease: requestLease)
+                } catch is OpenClawChatTransportSendError {
+                    // A stale lease is rejected before dispatch. Reacquire only the same route
+                    // and retry once; a post-dispatch cancellation remains ambiguous and must
+                    // continue through the existing cancellation/reconciliation path.
+                    requestLease = try await self.gateway.acquireServerLease(
+                        ifSameRouteAs: requestLease,
+                        timeoutMs: 5000)
+                    guard token == self.attemptToken, authAttemptID == self.authAttemptID else {
+                        throw CancellationError()
+                    }
+                    self.serverLease = requestLease
+                    data = try await self.gateway.request(
+                        method: "wizard.next",
+                        params: params,
+                        timeoutMs: Self.providerAuthRequestTimeoutMs,
+                        ifCurrentServerLease: requestLease)
+                }
                 guard token == self.attemptToken, authAttemptID == self.authAttemptID else { return }
                 let result = try JSONDecoder().decode(WizardNextResult.self, from: data)
                 self.applyAuthWizardResult(
@@ -1321,13 +1341,13 @@ extension OnboardingAISetupModel {
                     error: result.error,
                     preparedModelRef: result.preparedmodelref)
             } catch {
-                let cancellation = await self.gateway.cancelWizardSession(sessionID, on: serverLease)
+                let cancellation = await self.gateway.cancelWizardSession(sessionID, on: requestLease)
                 guard token == self.attemptToken, authAttemptID == self.authAttemptID else { return }
                 if cancellation != .cancelled,
                    await self.reconcileProviderAuthAfterUnknownOutcome(
                        token: token,
                        before: self.lastDetectedActivationState,
-                       originalServerLease: serverLease)
+                       originalServerLease: requestLease)
                 {
                     return
                 }

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -836,6 +836,94 @@ struct OnboardingAISetupTests {
         #expect(OnboardingAISetupModel.providerAuthRequestTimeoutMs > 15 * 60 * 1000)
     }
 
+    @Test func `provider auth retries a callback after socket rotation before dispatch`() async throws {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingProviderAuthLeaseRetryTests"))
+        let recorder = AISetupRequestRecorder()
+        let socketGeneration = AISetupSocketGeneration()
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let session = GatewayTestWebSocketSession(taskFactory: {
+            let generation = socketGeneration.claim()
+            return GatewayTestWebSocketTask(
+                sendHook: { task, message, sendIndex in
+                    guard sendIndex > 0, let request = aiSetupRequest(from: message) else { return }
+                    if respondToAISetupHealth(task: task, request: request) {
+                        return
+                    }
+                    await recorder.record(message)
+                    switch request.method {
+                    case "openclaw.setup.detect":
+                        task.emitReceiveSuccess(.data(detectedSetupResponse(id: request.id)))
+                    case "openclaw.setup.auth.start":
+                        let sessionID = try #require(request.params["sessionId"] as? String)
+                        task.emitReceiveSuccess(.data(Data(
+                            """
+                            {"type":"res","id":"\(request.id)","ok":true,"payload":{
+                              "sessionId":"\(sessionID)","done":false,"status":"running",
+                              "step":{"id":"login","type":"text","executor":"client",
+                                "message":"Enter the sign-in response"}}}
+                            """.utf8)))
+                    case "wizard.next":
+                        #expect(generation == 1, "the callback must be sent on the replacement socket")
+                        let sessionID = try #require(request.params["sessionId"] as? String)
+                        task.emitReceiveSuccess(.data(wizardDoneResponse(
+                            id: request.id,
+                            sessionID: sessionID)))
+                    case "wizard.cancel":
+                        Issue.record("pre-dispatch callback failure should not cancel the wizard")
+                        task.emitReceiveSuccess(.data(Data(
+                            #"{"type":"res","id":"\#(request.id)","ok":true,"payload":{"status":"cancelled"}}"#
+                                .utf8)))
+                    default:
+                        Issue.record("Unexpected provider auth request: \(request.method)")
+                    }
+                },
+                receiveHook: { task, receiveIndex in
+                    if receiveIndex == 0 {
+                        return .data(GatewayWebSocketTestSupport.connectChallengeData())
+                    }
+                    return .data(GatewayWebSocketTestSupport.connectOkData(
+                        id: task.snapshotConnectRequestID() ?? "connect"))
+                })
+        })
+        let gateway = makeAISetupGateway(url: url, session: session)
+        let model = makeAISetupModel(gateway: gateway, defaults: defaults)
+
+        await model.detectAndAutoConnect()
+        let option = OnboardingAISetupModel.AuthOption(
+            id: "test-provider-login", brandId: nil, label: "Test provider", hint: nil,
+            groupLabel: nil, icon: nil, website: nil, kind: "oauth", featured: false)
+        model.startProviderAuth(option)
+        for _ in 0..<400 where model.authStep == nil {
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        #expect(model.authStep?.id == "login")
+        let originalLease = try #require(await gateway.captureServerLease())
+        let originalTask = try #require(session.latestTask())
+        originalTask.emitReceiveFailure()
+
+        var replacementReady = false
+        for _ in 0..<600 {
+            if !(await gateway.isCurrentServerLease(originalLease)),
+               await gateway.captureServerLease() != nil
+            {
+                replacementReady = true
+                break
+            }
+            try? await Task.sleep(nanoseconds: 5_000_000)
+        }
+        #expect(replacementReady)
+
+        model.continueProviderAuth()
+        let requests = await waitForAISetupRequests(recorder, count: 4)
+
+        #expect(requests.methods.filter { $0 == "wizard.next" }.count == 1)
+        #expect(!requests.methods.contains("wizard.cancel"))
+        #expect(model.authError == nil)
+        #expect(model._test_authSessionID == nil)
+        #expect(model.authStep == nil)
+        await gateway.shutdown()
+    }
+
     @Test func `reconciliation deadline recomputes each RPC budget`() async throws {
         let deadline = OnboardingAISetupModel.ReconciliationDeadline(timeout: .seconds(2))
         let detectionBudget = deadline.remainingMilliseconds(cappedAt: 10000)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the macOS onboarding provider-auth wizard can stop advancing when the gateway socket rotates while a callback is being submitted.

Fixes #134182

## Why This Change Was Made

Provider-auth callbacks now retry exactly once when the gateway rejects a stale server lease before dispatch, reacquiring the same route and resending the unchanged wizard answer. A post-dispatch cancellation remains ambiguous and is still handled by the existing reconciliation path without retrying.

## User Impact

Users can continue provider authentication across a gateway socket rotation that happens before the callback is sent, without duplicate wizard submissions.

## Evidence

- The new focused test drives `OnboardingAISetupModel` through the real `GatewayConnection` request path and rotates the test WebSocket before `wizard.next` dispatch.
- The test asserts that the replacement socket receives exactly one `wizard.next`, no `wizard.cancel` is sent for the pre-dispatch rejection, and the completed auth session is cleared.
- Source and test syntax validation: `swiftc -parse` on both changed Swift files passed; `git diff --check` passed.

```text
before: a stale pre-dispatch lease rejection entered the existing cancellation path, leaving the provider wizard unable to advance.
after: the replacement same-route lease receives one wizard.next; no wizard.cancel is sent; authError is nil and the wizard session is cleared.
environment note: the native Swift test target could not be executed on this machine because CommandLineTools lacks the SwiftUI/Previews macro plugins; this is recorded in local validation evidence.
```

<details>
<summary>Reproducible behavior test command</summary>

```bash
#!/usr/bin/env bash
set -euo pipefail
swift test --filter 'OnboardingAISetupTests/provider auth retries a callback after socket rotation before dispatch'
```

</details>

AI-assisted: built with Codex
