### PR TITLE
fix: doctor --fix completes schema 17 agent database migrations

### DIFF
--- a/src/infra/state-migrations.media-persistence.additive-schema.test.ts
+++ b/src/infra/state-migrations.media-persistence.additive-schema.test.ts
@@ -68,4 +68,60 @@ describe("legacy media persistence additive schema repair", () => {
       repaired.close();
     }
   });
+
+  it("converges schema-17 session additions before validating the repaired canonical schema", async () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-schema-17-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const opened = openOpenClawAgentDatabase({ agentId: "main", env });
+    const databasePath = opened.path;
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    try {
+      database.exec(`
+        DROP TRIGGER session_conversations_route_context_invalidate_after_update;
+        ALTER TABLE session_conversations DROP COLUMN route_context_json;
+        DROP INDEX idx_agent_transcript_event_identity_sequence;
+        DROP TABLE session_participants;
+        PRAGMA user_version = 17;
+      `);
+      database
+        .prepare(
+          "UPDATE schema_meta SET schema_version = ?, app_version = ? WHERE meta_key = 'primary'",
+        )
+        .run(17, "legacy-test");
+    } finally {
+      database.close();
+    }
+
+    const result = await migrateLegacyMediaPersistence({ env });
+    expect(result.warnings).toEqual([]);
+    const repaired = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(repaired.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+      });
+      expect(
+        repaired
+          .prepare(
+            "SELECT name FROM pragma_table_info('session_conversations') WHERE name = 'route_context_json'",
+          )
+          .get(),
+      ).toEqual({ name: "route_context_json" });
+      expect(
+        repaired
+          .prepare("SELECT name FROM sqlite_schema WHERE type = 'trigger' AND name = ?")
+          .get("session_conversations_route_context_invalidate_after_update"),
+      ).toEqual({ name: "session_conversations_route_context_invalidate_after_update" });
+      expect(
+        repaired
+          .prepare("SELECT name FROM sqlite_schema WHERE type = 'index' AND name = ?")
+          .get("idx_agent_transcript_event_identity_sequence"),
+      ).toEqual({ name: "idx_agent_transcript_event_identity_sequence" });
+    } finally {
+      repaired.close();
+    }
+  });
 });

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -716,15 +716,17 @@ export function ensureOpenClawAgentDatabaseSchema(
   if (readSqliteUserVersion(db) === AGENT_MEDIA_SCHEMA_VERSION) {
     assertAgentDatabaseMaintenanceAuthority();
     const legacySql = withLegacySessionParticipantsSchema(OPENCLAW_AGENT_SCHEMA_SQL);
-    // Keep canonical index recovery reachable before rebuilding the v17 identity table.
+    // Keep canonical index recovery and additive convergence reachable before rebuilding v17 identity.
     verifyAndRepairCanonicalSqliteIndexes(db, pathname, legacySql, {
       allowMissingColumns: true,
-      validateAfterRepair: () =>
+      validateAfterRepair: () => {
+        ensureSessionAdditiveColumns(db);
         assertAgentSchemaVersion(
           db,
           { agentId, pathname, version: AGENT_MEDIA_SCHEMA_VERSION },
           legacySql,
-        ),
+        );
+      },
     });
   }
   assertAgentDatabaseIntegrityBeforeMutation(db, agentId, pathname);

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -536,15 +536,13 @@ export function assertAgentDatabaseIntegrityBeforeMutation(
       validateAfterRepair: () =>
         assertOpenClawAgentCurrentRuntimeSchema(database, { agentId, pathname }),
     });
+    assertOpenClawAgentCurrentRuntimeSchema(database, { agentId, pathname });
   } else {
     // Every physical open proves the full file before schema mutation or exposure.
     assertSqliteIntegrity(database, pathname);
   }
   // Current-version convergence runs atomically in ensureAgentSchema below.
   // Validating here would make same-version repair unreachable after an update.
-  if (userVersion === OPENCLAW_AGENT_SCHEMA_VERSION && !hasPendingCurrentVersionMigration) {
-    assertOpenClawAgentCurrentRuntimeSchema(database, { agentId, pathname });
-  }
   return hasPendingCurrentVersionMigration;
 }
 


### PR DESCRIPTION
Closes #134163

## What Problem This Solves

Fixes an issue where operators running `openclaw doctor --fix` against an agent database at schema 17 could receive a skipped-migration warning when the database was missing session conversation routing objects and had canonical index drift. The database stayed at schema 17, so repeating the prescribed repair did not resolve the problem.

## Why This Change Was Made

The schema-17 preflight repaired a canonical index and then asserted the legacy schema before same-version session additions had converged. This change runs the existing idempotent additive convergence inside the index-repair savepoint before the strict assertion, preserving rollback and canonical validation without adding DDL or changing the schema version.

## User Impact

`openclaw doctor --fix` can now complete the schema 17 → 19 agent database migration when the route-context column, trigger, and transcript identity index need repair. The repaired database retains its data, emits no skipped-migration warning, and can start the gateway successfully.

## Evidence

- Before the fix, `node scripts/run-vitest.mjs src/infra/state-migrations.media-persistence.additive-schema.test.ts` reproduced the reported failure: canonical index repair rejected the missing `session_conversations_route_context_invalidate_after_update` trigger and left the database at schema 17.
- After the fix, the same focused migration suite passed 2/2 tests.
- `node scripts/run-vitest.mjs src/state/openclaw-agent-participants-migration.test.ts` passed 14/14 adjacent schema-17 migration tests.
- `node scripts/check-changed.mjs -- src/state/openclaw-agent-db-schema.ts src/infra/state-migrations.media-persistence.additive-schema.test.ts` passed the required core checks, including formatting, type checks, oxlint, database schema guards, and import-cycle checks.
- An isolated fixture began at `user_version = 17` with the route-context column, route-context trigger, and transcript identity index absent. The real `CI=1 pnpm openclaw doctor --fix` path migrated it to user and metadata schema version 19, restored all three canonical objects, and returned `PRAGMA integrity_check = ok`.
- The same migrated state then started an isolated development gateway; `/readyz` returned `ready: true` and `/healthz` returned `ok: true`.

## Exact-head real behavior proof

Commit `d54f46a0bf3d5438b2fafbe09db37695133940a8` was exercised in an isolated state directory on 2026-09-01 (Asia/Shanghai). Runtime: Node `v24.15.0`, SQLite `3.51.3`. No Discord or external provider credentials were used.

Fixture setup created an agent database at `user_version = 17`, removed `route_context_json`, `session_conversations_route_context_invalidate_after_update`, `idx_agent_transcript_event_identity_sequence`, and `session_participants`, and set `schema_meta.schema_version = 17`.

Command executed against that persisted fixture:

```text
CI=1 pnpm openclaw doctor --fix --non-interactive
[state-migrations] Auto-migrated legacy state:
- Upgraded agent database schema in .../agents/main/agent/openclaw-agent.sqlite: v17 -> v19.
```

Post-doctor read-only SQLite inspection (exact output, path redacted):

```json
{"userVersion":19,"schemaMeta":{"schema_version":19,"app_version":"2026.8.1"},"routeContextColumn":{"name":"route_context_json","type":"TEXT","notnull":0},"routeContextTrigger":{"name":"session_conversations_route_context_invalidate_after_update","type":"trigger"},"transcriptIdentityIndex":{"name":"idx_agent_transcript_event_identity_sequence","type":"index"},"sessionParticipantsTable":{"name":"session_participants","type":"table"},"integrityCheck":"ok","foreignKeyViolations":[]}
```

The same migrated state started an isolated development Gateway on a dynamically allocated loopback port (`OPENCLAW_SKIP_CHANNELS=1`); both operator health endpoints returned HTTP 200:

```text
GET /readyz  -> HTTP/1.1 200 OK; {"ready":true,"failing":[]}
GET /healthz -> HTTP/1.1 200 OK; {"ok":true,"status":"live"}
```

The gateway log recorded `http server listening` and `ready` after the migrated database was loaded. The Gateway process was terminated cleanly after the probes.