### PR TITLE
fix(slack): workspace-scoped plugin approvers can approve

### DIFF
--- a/extensions/slack/src/approval-auth.test.ts
+++ b/extensions/slack/src/approval-auth.test.ts
@@ -1,6 +1,6 @@
 // Slack tests cover approval auth plugin behavior.
 import { describe, expect, it } from "vitest";
-import { isSlackApprovalAuthorizedSender } from "./approval-auth.js";
+import { getSlackApprovalApprovers, isSlackApprovalAuthorizedSender } from "./approval-auth.js";
 
 describe("isSlackApprovalAuthorizedSender", () => {
   it("authorizes general Slack approvers from allowFrom and defaultTo", () => {
@@ -34,6 +34,43 @@ describe("isSlackApprovalAuthorizedSender", () => {
 
     for (const senderId of ["U123OWNER", "U345DEFAULT"]) {
       expect(isSlackApprovalAuthorizedSender({ cfg, senderId })).toBe(true);
+    }
+  });
+
+  it("keeps workspace-qualified plugin approvers scoped to their workspace", () => {
+    const qualifiedApprover = "team:T11111111:user:U123OWNER";
+    const qualifiedCfg = {
+      channels: {
+        slack: {
+          allowFrom: [qualifiedApprover],
+        },
+      },
+    };
+
+    expect(getSlackApprovalApprovers({ cfg: qualifiedCfg })).toEqual([qualifiedApprover]);
+    expect(
+      isSlackApprovalAuthorizedSender({
+        cfg: qualifiedCfg,
+        senderId: qualifiedApprover,
+      }),
+    ).toBe(true);
+    for (const senderId of ["team:T22222222:user:U123OWNER", "U123OWNER"]) {
+      expect(isSlackApprovalAuthorizedSender({ cfg: qualifiedCfg, senderId })).toBe(false);
+    }
+
+    const unqualifiedCfg = {
+      channels: {
+        slack: {
+          allowFrom: ["U123OWNER"],
+        },
+      },
+    };
+    for (const senderId of [
+      "U123OWNER",
+      "team:T11111111:user:U123OWNER",
+      "team:T22222222:user:U123OWNER",
+    ]) {
+      expect(isSlackApprovalAuthorizedSender({ cfg: unqualifiedCfg, senderId })).toBe(true);
     }
   });
 

--- a/extensions/slack/src/approval-auth.ts
+++ b/extensions/slack/src/approval-auth.ts
@@ -1,25 +1,68 @@
 // Slack plugin module implements approval auth behavior.
-import { createChannelApprovalAuth } from "openclaw/plugin-sdk/approval-auth-runtime";
+import {
+  createChannelApprovalAuth,
+  resolveApprovalApprovers,
+} from "openclaw/plugin-sdk/approval-auth-runtime";
 import { resolveSlackAccount, resolveSlackAccountAllowFrom } from "./accounts.js";
-import { normalizeSlackApproverId } from "./exec-approvals.js";
+import { normalizeSlackApproverTarget } from "./exec-approvals.js";
+import {
+  normalizeAllowListLower,
+  resolveSlackAllowListMatch,
+  resolveSlackUserAllowListForTeam,
+} from "./monitor/allow-list.js";
+import { parseSlackTarget } from "./target-parsing.js";
+
+type SlackApprovalContext = Parameters<typeof resolveSlackAccount>[0];
+
+function resolveSlackApprovalInputs(params: SlackApprovalContext) {
+  const account = resolveSlackAccount(params).config;
+  return {
+    allowFrom: resolveSlackAccountAllowFrom(params),
+    defaultTo: account.defaultTo,
+  };
+}
+
+function slackApprovalTargetMatches(senderId: string, approvers: readonly string[]): boolean {
+  const sender = parseSlackTarget(senderId, { defaultKind: "user" });
+  return (
+    sender?.kind === "user" &&
+    resolveSlackAllowListMatch({
+      allowList: normalizeAllowListLower([...approvers]),
+      teamId: sender.teamId,
+      id: sender.id,
+    }).allowed
+  );
+}
 
 const slackApproval = createChannelApprovalAuth({
   channelLabel: "Slack",
-  resolveInputs: ({ cfg, accountId }) => {
-    const account = resolveSlackAccount({ cfg, accountId }).config;
-    return {
-      allowFrom: resolveSlackAccountAllowFrom({ cfg, accountId }),
-      defaultTo: account.defaultTo,
-    };
-  },
-  normalizeApprover: normalizeSlackApproverId,
-  normalizeDefaultTo: normalizeSlackApproverId,
+  resolveInputs: resolveSlackApprovalInputs,
+  normalizeApprover: normalizeSlackApproverTarget,
+  normalizeDefaultTo: normalizeSlackApproverTarget,
+  normalizeSenderId: normalizeSlackApproverTarget,
   isWildcardAuthorized: ({ purpose, senderId, inputs, approvers }) =>
-    purpose === "sender" &&
-    Boolean(senderId) &&
-    approvers.length === 0 &&
-    inputs.allowFrom?.some((entry) => String(entry).trim() === "*") === true,
+    Boolean(
+      senderId &&
+      (slackApprovalTargetMatches(senderId, approvers) ||
+        (purpose === "sender" &&
+          approvers.length === 0 &&
+          inputs.allowFrom?.some((entry) => String(entry).trim() === "*"))),
+    ),
 });
 
 export const getSlackApprovalApprovers = slackApproval.resolveApprovers;
 export const isSlackApprovalAuthorizedSender = slackApproval.isAuthorizedSender;
+
+export function getSlackApprovalApproversForTeam(
+  params: SlackApprovalContext & { teamId: string | undefined },
+): string[] {
+  // Potential routing retains qualified selectors, but concrete delivery must
+  // bind them to the validated request workspace before it creates any DM.
+  return resolveApprovalApprovers({
+    allowFrom: resolveSlackUserAllowListForTeam({
+      allowList: getSlackApprovalApprovers(params),
+      teamId: params.teamId,
+    }),
+    normalizeApprover: normalizeSlackApproverTarget,
+  });
+}

--- a/extensions/slack/src/approval-native-gates.ts
+++ b/extensions/slack/src/approval-native-gates.ts
@@ -31,7 +31,7 @@ import {
   resolveDefaultSlackAccountId,
   resolveSlackAccount,
 } from "./accounts.js";
-import { getSlackApprovalApprovers } from "./approval-auth.js";
+import { getSlackApprovalApprovers, getSlackApprovalApproversForTeam } from "./approval-auth.js";
 import {
   getSlackExecApprovalApprovers,
   isSlackExecApprovalClientEnabled,
@@ -262,8 +262,9 @@ const {
 export function hasSlackPluginApprovers(params: {
   cfg: OpenClawConfig;
   accountId?: string | null;
+  teamId: string | undefined;
 }): boolean {
-  return getSlackApprovalApprovers(params).length > 0;
+  return getSlackApprovalApproversForTeam(params).length > 0;
 }
 
 function isSlackPluginNativeApprovalClientConfigEnabled(params: {
@@ -340,7 +341,10 @@ function isSlackNativeApprovalAccountEligible(params: {
   const approverCount =
     params.approvalKind === "exec"
       ? getSlackExecApprovalApprovers(params).length
-      : getSlackApprovalApprovers(params).length;
+      : getSlackApprovalApproversForTeam({
+          ...params,
+          teamId: resolveEnterpriseApprovalTeamId(params.request),
+        }).length;
   return (
     isSlackApprovalTransportEnabled(params) &&
     isChannelExecApprovalClientEnabledFromConfig({ enabled: config?.enabled, approverCount }) &&

--- a/extensions/slack/src/approval-native.test.ts
+++ b/extensions/slack/src/approval-native.test.ts
@@ -296,6 +296,57 @@ describe("slack native approval adapter", () => {
     ).toEqual([{ to: "team:T123:user:U123APPROVER" }]);
   });
 
+  it("selects plugin approver DMs for the validated Grid workspace", async () => {
+    const cfg = buildConfig({
+      allowFrom: ["team:T11111111:user:U111OWNER", "U222OWNER"],
+      execApprovals: { enabled: "auto", target: "dm" },
+    });
+    installationStates.push(registerSlackInstallationState("default", "enterprise"));
+    const request = {
+      id: "plugin:req-1",
+      request: {
+        title: "Plugin approval",
+        description: "Allow access",
+        turnSourceChannel: "slack",
+        turnSourceAccountId: "default",
+        turnSourceTo: "team:T11111111:channel:C11111111",
+      },
+      createdAtMs: 0,
+      expiresAtMs: 1000,
+    };
+
+    expect(
+      slackApprovalCapability.native?.resolveApproverDmTargets?.({
+        cfg,
+        accountId: "default",
+        approvalKind: "plugin",
+        request,
+      }),
+    ).toEqual([{ to: "team:T11111111:user:U111OWNER" }, { to: "team:T11111111:user:U222OWNER" }]);
+    expect(
+      slackApprovalCapability.native?.resolveApproverDmTargets?.({
+        cfg,
+        accountId: "default",
+        approvalKind: "plugin",
+        request: {
+          ...request,
+          request: { ...request.request, turnSourceTo: "team:T22222222:channel:C22222222" },
+        },
+      }),
+    ).toEqual([{ to: "team:T22222222:user:U222OWNER" }]);
+    expect(
+      slackApprovalCapability.native?.resolveApproverDmTargets?.({
+        cfg,
+        accountId: "default",
+        approvalKind: "plugin",
+        request: {
+          ...request,
+          request: { ...request.request, turnSourceTo: "channel:C11111111" },
+        },
+      }),
+    ).toEqual([]);
+  });
+
   it("does not enable Grid approval delivery without a trusted team-qualified origin", () => {
     installationStates.push(registerSlackInstallationState("default", "enterprise"));
     const capabilities = slackApprovalCapability.native?.describeDeliveryCapabilities({

--- a/extensions/slack/src/approval-native.ts
+++ b/extensions/slack/src/approval-native.ts
@@ -13,7 +13,10 @@ import type { ChannelApprovalCapability } from "openclaw/plugin-sdk/channel-cont
 import { normalizeMessageChannel } from "openclaw/plugin-sdk/routing";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { listSlackAccountIds } from "./accounts.js";
-import { getSlackApprovalApprovers, isSlackApprovalAuthorizedSender } from "./approval-auth.js";
+import {
+  getSlackApprovalApproversForTeam,
+  isSlackApprovalAuthorizedSender,
+} from "./approval-auth.js";
 import {
   hasSlackPluginApprovers,
   isSlackAnyNativeApprovalClientEnabled,
@@ -35,7 +38,7 @@ import {
   isSlackExecApprovalClientEnabled,
   resolveSlackExecApprovalTarget,
 } from "./exec-approvals.js";
-import { formatSlackTarget } from "./target-parsing.js";
+import { formatSlackTarget, parseSlackTarget } from "./target-parsing.js";
 
 type ApprovalRequest = SlackNativeApprovalRequest;
 type SlackSuppressionAccountInput = {
@@ -104,14 +107,25 @@ function resolveSlackApproverDmTargets(params: {
   ) {
     return [];
   }
+  const teamId = resolveEnterpriseApprovalTeamId(params.request);
   const approvers =
     params.approvalKind === "plugin"
-      ? getSlackApprovalApprovers(params)
+      ? getSlackApprovalApproversForTeam({ ...params, teamId })
       : getSlackExecApprovalApprovers(params);
-  const teamId = resolveEnterpriseApprovalTeamId(params.request);
-  return approvers.map((approver) => ({
-    to: formatSlackTarget({ kind: "user", id: approver, teamId, explicitKind: true }),
-  }));
+  return approvers.map((approver) => {
+    const target = parseSlackTarget(approver, { defaultKind: "user" });
+    if (!target || target.kind !== "user") {
+      throw new Error("Slack approval approver target must be a user");
+    }
+    return {
+      to: formatSlackTarget({
+        kind: "user",
+        id: target.id,
+        teamId: target.teamId ?? teamId,
+        explicitKind: true,
+      }),
+    };
+  });
 }
 
 const shouldSuppressSlackForwardingFallback =
@@ -223,6 +237,7 @@ export const slackApprovalCapability: ChannelApprovalCapability = {
                   supportsApproverDmSurface: hasSlackPluginApprovers({
                     cfg: params.cfg,
                     accountId: params.accountId,
+                    teamId: resolveEnterpriseApprovalTeamId(request),
                   }),
                 }
               : {}),

--- a/extensions/slack/src/exec-approvals.ts
+++ b/extensions/slack/src/exec-approvals.ts
@@ -7,26 +7,32 @@ import {
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { normalizeStringifiedOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveSlackAccount } from "./accounts.js";
+import { formatSlackTarget, parseSlackTarget } from "./target-parsing.js";
 
 function normalizeSlackUserLikeId(value: string): string | undefined {
   const upper = value.toUpperCase();
   return /^[UW][A-Z0-9]+$/.test(upper) ? upper : undefined;
 }
 
-export function normalizeSlackApproverId(value: string | number): string | undefined {
+export function normalizeSlackApproverTarget(value: string | number): string | undefined {
   const trimmed = normalizeStringifiedOptionalString(value);
   if (!trimmed) {
     return undefined;
   }
-  const prefixed = trimmed.match(/^(?:slack|user):([A-Z0-9]+)$/i);
-  if (prefixed?.[1]) {
-    return normalizeSlackUserLikeId(prefixed[1]);
+  try {
+    const target = parseSlackTarget(trimmed, { defaultKind: "user" });
+    const id = target?.kind === "user" ? normalizeSlackUserLikeId(target.id) : undefined;
+    return target?.teamId && id
+      ? formatSlackTarget({ kind: "user", id, teamId: target.teamId.toUpperCase() })
+      : id;
+  } catch {
+    return undefined;
   }
-  const mention = trimmed.match(/^<@([A-Z0-9]+)>$/i);
-  if (mention?.[1]) {
-    return normalizeSlackUserLikeId(mention[1]);
-  }
-  return normalizeSlackUserLikeId(trimmed);
+}
+
+export function normalizeSlackApproverId(value: string | number): string | undefined {
+  const target = normalizeSlackApproverTarget(value);
+  return target?.startsWith("team:") ? undefined : target;
 }
 
 function resolveSlackOwnerApprovers(cfg: OpenClawConfig): string[] {

--- a/extensions/slack/src/monitor/events/interactions.block-actions.ts
+++ b/extensions/slack/src/monitor/events/interactions.block-actions.ts
@@ -35,6 +35,7 @@ import {
   SLACK_REPLY_SELECT_ACTION_ID,
   SLACK_SESSION_LINK_ACTION_ID,
 } from "../../reply-action-ids.js";
+import { formatSlackTarget } from "../../target-parsing.js";
 import { truncateSlackText } from "../../truncate.js";
 import {
   authorizeSlackSystemEventSender,
@@ -622,6 +623,12 @@ async function handleSlackPluginBindingApproval(params: {
   return true;
 }
 
+function formatSlackPluginApprovalSenderId(userId: string, eventScope?: SlackEventScope): string {
+  // Carry the listener-validated team into Gateway custody. A bare Enterprise
+  // user ID would lose the configured workspace boundary after this callback.
+  return formatSlackTarget({ kind: "user", id: userId, teamId: eventScope?.teamId });
+}
+
 async function handleSlackApprovalInteraction(params: {
   ctx: SlackMonitorContext;
   eventScope?: SlackEventScope;
@@ -629,10 +636,11 @@ async function handleSlackApprovalInteraction(params: {
   approval: SlackApprovalAction;
   respond?: SlackBlockActionRespond;
 }): Promise<boolean> {
+  const pluginSenderId = formatSlackPluginApprovalSenderId(params.parsed.userId, params.eventScope);
   const pluginApprovalAuthorizedSender = isSlackApprovalAuthorizedSender({
     cfg: params.ctx.cfg,
     accountId: params.ctx.accountId,
-    senderId: params.parsed.userId,
+    senderId: pluginSenderId,
   });
   const execApprovalAuthorizedSender = isSlackExecApprovalAuthorizedSender({
     cfg: params.ctx.cfg,
@@ -659,7 +667,7 @@ async function handleSlackApprovalInteraction(params: {
       decision: params.approval.decision,
       channel: "slack",
       accountId: params.ctx.accountId,
-      senderId: params.parsed.userId,
+      senderId: params.approval.approvalKind === "plugin" ? pluginSenderId : params.parsed.userId,
     });
     const terminalLabel = resolveSlackApprovalTerminalLabel(result.approval);
     const prefix = result.applied ? "Resolved" : "Already resolved";
@@ -722,10 +730,11 @@ async function handleSlackLegacyApprovalInteraction(params: {
   if (!parsedApproval) {
     return false;
   }
+  const pluginSenderId = formatSlackPluginApprovalSenderId(params.parsed.userId, params.eventScope);
   const pluginAuthorized = isSlackApprovalAuthorizedSender({
     cfg: params.ctx.cfg,
     accountId: params.ctx.accountId,
-    senderId: params.parsed.userId,
+    senderId: pluginSenderId,
   });
   const execAuthorized = isSlackExecApprovalAuthorizedSender({
     cfg: params.ctx.cfg,
@@ -755,7 +764,7 @@ async function handleSlackLegacyApprovalInteraction(params: {
         decision: parsedApproval.decision,
         channel: "slack",
         accountId: params.ctx.accountId,
-        senderId: params.parsed.userId,
+        senderId: resolveMethod === "plugin" ? pluginSenderId : params.parsed.userId,
         resolveMethod,
       });
       try {

--- a/extensions/slack/src/monitor/events/interactions.test.ts
+++ b/extensions/slack/src/monitor/events/interactions.test.ts
@@ -1591,6 +1591,66 @@ describe("registerSlackInteractionEvents", () => {
     expect(respond).not.toHaveBeenCalled();
   });
 
+  it("authorizes plugin approval buttons only in the configured Grid workspace", async () => {
+    const { ctx, getHandler } = createContext({
+      installationIdentity: { kind: "enterprise", enterpriseId: "E1" },
+      cfg: {
+        channels: {
+          slack: {
+            accounts: {
+              default: {
+                allowFrom: ["team:T11111111:user:U123OWNER"],
+                execApprovals: { enabled: "auto", target: "dm" },
+              },
+            },
+          },
+        },
+      },
+    });
+    registerSlackInteractionEvents({ ctx: ctx as never });
+    const handler = getHandler();
+    const respond = vi.fn().mockResolvedValue(undefined);
+    const invoke = async (teamId: string) =>
+      await handler({
+        ack: vi.fn().mockResolvedValue(undefined),
+        respond,
+        context: { teamId },
+        body: {
+          user: { id: "U123OWNER" },
+          team: { id: teamId },
+          channel: { id: "C11111111" },
+          container: { channel_id: "C11111111", message_ts: "100.200" },
+          message: { ts: "100.200", text: "Plugin approval required", blocks: [] },
+        },
+        action: {
+          type: "button",
+          action_id: "openclaw:approval_button:1:1",
+          block_id: "plugin_actions",
+          value:
+            'openclaw:approval:v1:{"approvalId":"req-123","approvalKind":"plugin","decision":"allow-once"}',
+          text: { type: "plain_text", text: "Allow once" },
+        },
+      });
+
+    await invoke("T11111111");
+    await invoke("T22222222");
+
+    expect(resolveApprovalOverGatewayMock).toHaveBeenCalledOnce();
+    expect(resolveApprovalOverGatewayMock).toHaveBeenCalledWith({
+      cfg: ctx.cfg,
+      approvalId: "req-123",
+      approvalKind: "plugin",
+      decision: "allow-once",
+      senderId: "team:T11111111:user:U123OWNER",
+      channel: "slack",
+      accountId: "default",
+    });
+    expect(respond).toHaveBeenCalledWith({
+      text: "You are not authorized to approve this request.",
+      response_type: "ephemeral",
+    });
+  });
+
   it("resolves typed question buttons without enqueueing an agent interaction", async () => {
     const questionId = "ask_0123456789abcdef0123456789abcdef";
     const { ctx, getHandler } = createContext();


### PR DESCRIPTION
Closes #133932

## What Problem This Solves

Fixes an issue where an Enterprise Grid operator could configure a documented workspace-qualified Slack plugin approver, but OpenClaw silently dropped that approver before delivery and rejected the approval button.

## Why This Change Was Made

Slack now retains qualified approver targets, selects them only for the validated request workspace, and sends the validated click workspace through Gateway authorization. Unqualified Slack user IDs keep their documented organization-wide behavior.

The change stays in the Slack plugin. The generic approval `senderId` is already opaque, so no Plugin SDK or Gateway protocol change is needed. Same-chat `/approve` still has no validated workspace in its generic sender identity; qualified-only policy therefore fails closed there instead of weakening the workspace boundary.

## User Impact

Enterprise Grid plugin approval DMs now reach workspace-qualified approvers. The same Slack user ID cannot approve from another workspace, and missing workspace identity is denied.

## Evidence

- Baseline: current `main` at `ace8a13f19ccc2805b3d458026de3ab4bbbd8878` accepted `team:T01234567:user:U0123ABCDE` in Enterprise policy, then returned no plugin approvers, no DM targets, and no authorized sender.
- Anti-cheat: changing only the entry to unqualified `U0123ABCDE` produced a workspace-qualified DM target and authorized the sender on the same baseline.
- Regression test before the fix: 3 intended failures and 111 passes.
- Exact head `544c4458ec3aa4127a186e301ee2247dd4a6bf1e`: 7 focused Slack files passed, 180 tests passed.
- Boundary probe: same-workspace delivery and final capability authorization passed; cross-workspace and missing-workspace delivery and authorization failed closed; unqualified authorization remained organization-wide.
- Enterprise DM handler proof passed through the existing team-client boundary in `extensions/slack/src/approval-handler.enterprise.test.ts`.
- Formatting: pinned `oxfmt 0.60.0` passed on all changed files. GitHub owns build, typecheck, continuous integration, and merge gates.

Live authenticated Enterprise Grid proof is unavailable. The existing Slack QA lease contains one channel, one driver token, and one workspace SUT token pair; it does not provide an org-wide Enterprise install or two workspace identities. Local Slack credentials are also absent. The focused tests therefore use the validated listener event-scope, Enterprise DM handler, approval capability, and button-handler boundaries without claiming live proof.

Production LOC: +115/-38 (net +77) | Tests: +149/-1

The production growth is the workspace identity boundary: one canonical Slack target normalizer, team-filtered delivery, and qualified reviewer custody. Stripping the team would be smaller but would permit cross-workspace rebinding.

Provenance: PR #122346, merge commit `00fc1bd123820eb759bfe65ba778c37c1f4c0f9f`, added workspace-qualified `allowFrom` policy and docs without updating plugin approval normalization. The commit was authored and merged by @sjf-oa; GitHub recorded the merge commit.

Best-fix verdict: best. It reuses Slack's existing workspace filter, allow-list matcher, and target parser at the plugin owner boundary.

Alternatives considered:

- Strip the team before delivery: rejected because another workspace could rebind the same user ID.
- Add a generic approval workspace field: rejected because the existing opaque reviewer sender carries the Slack target without widening the SDK.
- Qualify generic same-chat `/approve`: rejected because that path has no listener-validated Slack workspace identity.

Remaining uncertainty: no authenticated Enterprise Grid account was available for a two-workspace live click.
