### PR TITLE
perf(sessions): reuse prepared transcript batch writers

### DIFF
--- a/src/commands/doctor-session-sqlite.memory.test.ts
+++ b/src/commands/doctor-session-sqlite.memory.test.ts
@@ -23,6 +23,10 @@ beforeAll(async () => {
     bundle: true,
     entryPoints: [fileURLToPath(sqliteImportMemorySupportUrl)],
     format: "esm",
+    // Keep generated source overhead out of the transcript-data heap budget;
+    // preserve function/class names used by runtime dispatch and diagnostics.
+    minify: true,
+    keepNames: true,
     outfile: childPath,
     packages: "external",
     platform: "node",

--- a/src/config/sessions/session-accessor.sqlite-import.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.ts
@@ -1,5 +1,4 @@
 import {
-  executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   iterateSqliteQuerySync,
 } from "../../infra/kysely-sync.js";
@@ -30,7 +29,10 @@ import {
   ensureTranscriptSessionRoot,
   touchTranscriptMutationInTransaction,
 } from "./session-accessor.sqlite-transcript-state.js";
-import { appendTranscriptEventsInTransaction } from "./session-accessor.sqlite-transcript-store.js";
+import {
+  appendTranscriptEventsInTransaction,
+  createTranscriptEventInserter,
+} from "./session-accessor.sqlite-transcript-store.js";
 import { reconcileSessionTranscriptIndexInTransaction } from "./session-transcript-index.js";
 import type { SessionEntry } from "./types.js";
 
@@ -133,6 +135,7 @@ function importSqliteSessionRowsInTransaction(
         .limit(1),
     );
     if (!existing) {
+      const insertEvent = createTranscriptEventInserter(database, params.entry.sessionId);
       for (const row of stage.rows(source)) {
         if (row.seq === 0) {
           ensureTranscriptSessionRoot(database, transcriptScope, row.createdAt!, {
@@ -140,15 +143,7 @@ function importSqliteSessionRowsInTransaction(
           });
           ensureTranscriptGenerationInTransaction(database, params.entry.sessionId);
         }
-        executeSqliteQuerySync(
-          database.db,
-          db.insertInto("transcript_events").values({
-            session_id: params.entry.sessionId,
-            seq: row.seq,
-            event_json: row.eventJson,
-            created_at: row.createdAt!,
-          }),
-        );
+        insertEvent({ seq: row.seq, eventJson: row.eventJson, createdAt: row.createdAt! });
         transcriptEvents += 1;
       }
       // Doctor imports run outside gateway requests and must finish with a complete projection.

--- a/src/config/sessions/session-accessor.sqlite-transcript-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-transcript-store.ts
@@ -64,7 +64,7 @@ type TranscriptAppendCursor = {
   insertIdentity?: ReturnType<typeof createTranscriptIdentityInserter>;
 };
 
-function createTranscriptEventInserter(database: OpenClawAgentDatabase, sessionId: string) {
+export function createTranscriptEventInserter(database: OpenClawAgentDatabase, sessionId: string) {
   return prepareSqliteQuerySync<{ seq: number; eventJson: string; createdAt: number }>(
     database.db,
     (parameter) =>
@@ -269,8 +269,6 @@ export function appendTranscriptEventsInTransaction(
 }
 
 function appendTranscriptEventRowInTransaction(
-  database: OpenClawAgentDatabase,
-  scope: ResolvedTranscriptScope,
   event: TranscriptEvent,
   seq: number,
   state: {
@@ -278,6 +276,7 @@ function appendTranscriptEventRowInTransaction(
     seenMessageIdempotencyKeys: Set<string>;
     insertEvent: ReturnType<typeof createTranscriptEventInserter>;
     insertIdentity: ReturnType<typeof createTranscriptIdentityInserter>;
+    appendToIndex: ReturnType<typeof createTranscriptIndexAppenderInTransaction>;
   },
   createdAtOverride?: number,
 ): boolean {
@@ -288,8 +287,7 @@ function appendTranscriptEventRowInTransaction(
     return false;
   }
   state.insertEvent({ seq, eventJson: JSON.stringify(persistedEvent), createdAt });
-  const appendToIndex = createTranscriptIndexAppenderInTransaction(database.db, scope.sessionId);
-  appendToIndex({
+  state.appendToIndex({
     seq,
     event: persistedEvent,
     eventId: identity?.eventId ?? null,
@@ -385,12 +383,12 @@ export function replaceSqliteTranscriptEventsInTransaction(
     seenMessageIdempotencyKeys: new Set<string>(),
     insertEvent: createTranscriptEventInserter(database, resolved.sessionId),
     insertIdentity: createTranscriptIdentityInserter(database, resolved.sessionId, false),
+    // The reset/dirty transition above owns the initial projection state for this whole batch.
+    appendToIndex: createTranscriptIndexAppenderInTransaction(database.db, resolved.sessionId),
   };
   for (const [eventIndex, event] of events.entries()) {
     if (
       appendTranscriptEventRowInTransaction(
-        database,
-        resolved,
         event,
         seq,
         state,


### PR DESCRIPTION
## What Problem This Solves

Exact SQLite transcript handoffs during legacy session migration and full transcript replacements still rebuild database query machinery for each event. Large histories therefore spend avoidable CPU in work that ordinary append/import batches already prepare once.

Related: #133802, which optimized projection writers for ordinary append batches.

## Why This Change Was Made

Exact handoffs reuse the existing transcript-event insert factory instead of constructing the same INSERT for every row. Replacement batches retain their index appender alongside their existing event and identity writers, after the owner resets or marks the projection dirty. This removes the row helper's database/session arguments.

The exact handoff remains distinct from normalized append: raw JSON bytes, duplicate event IDs, stored timestamps, ownership transfer, and absence of identity insertion are preserved. Replacement deduplication, contiguous sequences, timestamp overrides, branch transitions, mutation updates and final reconciliation remain unchanged. No schema, configuration, dependency, persistence semantics, or asynchronous transaction changes.

Runtime **+11 / -18, net -7 lines**, across two files. Test harness +4 lines; no new cache owner.

CI also exposed intermittent 256 MiB failures in the existing memory fixture after its shared entry grew to include public Doctor. Heap tracing reproduced the failure in navigation and identified substantial module/schema and generated-bundle overhead, not retention of the full transcript payload. The fixture now minifies its generated child while preserving function/class names; all source paths, static initialization, fixture sizes, heap limits, timeouts, byte hashes, projection assertions and replay checks remain unchanged. Generated source shrinks from 5,784,327 to 2,995,201 bytes (48.2%) with the same 7,212 esbuild input files. This is a test-harness repair, not a production-memory claim.

## User Impact

Less CPU work when migrating transcripts between SQLite stores or replacing transcript histories. Ordinary JSONL import already uses the prepared writers; this PR does not claim a further speedup for that path.

## Evidence

- **88 focused tests passed** across seven files: exact bytes/ownership and duplicate IDs; staging and transaction rollback; cross-store copy verification, source cleanup and races; small/large replacement projections and branch changes; context eligibility; Kysely binding, authorizer and re-entry contracts.
  ```sh
  node scripts/run-vitest.mjs src/config/sessions/session-accessor.sqlite-import.test.ts src/config/sessions/session-accessor.sqlite-transcript-store.test.ts src/config/sessions/legacy-main-session-migration.test.ts src/config/sessions/legacy-main-session-migration.race.test.ts src/config/sessions/session-transcript-search.test.ts src/config/sessions/session-transcript-context-eligibility.test.ts src/infra/kysely-sync.test.ts
  ```
- The original three-case bounded-memory suite (256 sessions × 64 large events; direct/public 100,000-event histories) passes on [Linux Testbox worker 33415373647](https://github.com/openclaw/openclaw/actions/runs/33415373647), unchanged 256 MiB heap. Five additional fresh deep/public child runs also pass (seven 100,000-event runs including the suite). A deliberate eager-retention mutation still fails with heap exhaustion under the minified bundle, so the guard still rejects materializing the full history. Source hashes were checked on the worker; the lease is stopped.
- Scoped type-aware lint, formatting and `git diff --check` passed.
  ```sh
  node scripts/run-oxlint.mjs --type-aware --tsconfig config/tsconfig/oxlint.core.json src/config/sessions/session-accessor.sqlite-import.ts src/config/sessions/session-accessor.sqlite-transcript-store.ts
  node_modules/.bin/oxfmt --check src/config/sessions/session-accessor.sqlite-import.ts src/config/sessions/session-accessor.sqlite-transcript-store.ts
  ```
- Independent Codex autoreview is clean through P3, supplied with complete owners, callers, staging, projection, executor and behavior tests. The Kysely parser/compiler binding contract was also directly inspected.
- Six alternating local benchmark pairs preserve complete digests of transcript bytes/timestamps, identities, windows, active positions/eligibility, projection state and FTS rows. Branch coverage includes a leaf change partway through replacement, followed by more rows. Local wall times are I/O-contended and are not used as a speed claim.
- [Clean Linux Testbox worker 33411445413](https://github.com/openclaw/openclaw/actions/runs/33411445413) completed **30 paired comparisons across six workloads**, five alternating pairs per workload in fresh processes. All persisted-data digests match. Only the two changed source owners are overridden for the baseline; build assertions and source hashes verify both versions, with identical surrounding code and dependencies. Six Node CPU profiles were collected. The worker is stopped.

| Workload | Before median | After median | Less wall time | Less CPU |
| --- | ---: | ---: | ---: | ---: |
| Exact handoff, 100,000 events | 3249.7 ms | 3102.6 ms | 4.5% | 5.6% |
| Exact handoff with branch, 10,000 events | 314.9 ms | 309.2 ms | 1.8% | -0.8% |
| Replacement, 2,000 events | 119.5 ms | 43.2 ms | 63.8% | 70.4% |
| Replacement with mid-batch branch, 2,000 events | 152.0 ms | 81.2 ms | 46.6% | 49.8% |
| Replacement, 10,000 events | 173.6 ms | 98.5 ms | 43.3% | 46.2% |
| Ordinary import control, 10,000 events | 358.7 ms | 354.9 ms | 1.1% | -1.0% |

The ordinary control and small branched handoff are effectively neutral. These timings cover the import/replacement API call, excluding fixture creation and verification. Large replacement defers projection reconciliation as before; the benchmark awaits and verifies it after the timer. Exact handoffs include their synchronous reconciliation. This is not a timing of the complete cross-store discovery/copy/cleanup command.

Profiles support the query-construction attribution: Kysely self samples fall from 335.6 to 158.3 ms for the deep exact handoff, 42.8 to zero sampled milliseconds for the small replacement, and 29.9 to zero sampled milliseconds for the large replacement. Zero sampled time does not mean literally zero setup cost. Headline timings are unprofiled. No general memory-reduction claim.

Local proof bundle: `.artifacts/migration-cpu-profile/round14/` (entry, runner, source manifest, results, six profiles). Collected archive SHA-256: `8b4256c2689738832b6768bebc016b8d5b47a24e072acf295180ab27974b2330`.

Validation notes: the local suite emitted a worker-termination timeout warning after every assertion passed; the test wrapper exited successfully. The first benchmark harness attempt compared a null-prototype SQLite row with a plain object; field-preserving comparison corrected the harness. Testbox initially received HTTP 429 from GitHub and recovered on one retry after a cooldown, without switching providers. Initial hosted CI failed only the deep bounded-heap case; the fixture correction follows failing phase traces and heap evidence. [Final exact-head CI33416929263](https://github.com/openclaw/openclaw/actions/runs/33416929263) passed, including Windows and SQLite lifecycle validation.

ClawSweeper disposition (final head, 17:11 UTC): no correctness findings or Rank-up moves. Its remaining merge risk, completion of exact-head CI, is now resolved by the green run linked above. The reviewer could not load esbuild; the maintainer directly checked installed esbuild 0.28.2 types and the JS adapter (`lib/main.js:598–671`) plus its [name-preservation contract](https://esbuild.github.io/api/#keep-names), and exercised the actual fixture builds. Normal maintainer handling is fulfilled by this review and the native landing flow. The stored-data warning is path-based: no schema, durable format, identity or projection semantics changed. Exact handoff and replacement parity cover that boundary.

Follow-up: reduce the broad Doctor module/schema baseline. Before reusing SQL navigation projection in migration, audit its accepted-input limits for deeply nested opaque JSON and escaped lone-surrogate IDs; this PR preserves the existing JavaScript parser.
