### PR TITLE
fix(installer): recover npm installs blocked by stale launchers

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1108,9 +1108,6 @@ run_npm_global_install() {
 
     local -a cmd
     cmd=(env -u NPM_CONFIG_BEFORE -u npm_config_before -u NPM_CONFIG_MIN_RELEASE_AGE -u npm_config_min_release_age -u npm_config_min-release-age "$npm_cmd" --loglevel "$NPM_LOGLEVEL")
-    if [[ -n "$NPM_SILENT_FLAG" ]]; then
-        cmd+=("$NPM_SILENT_FLAG")
-    fi
     cmd+=(--no-fund --no-audit "$freshness_flag" install -g)
     [[ -z "$lifecycle_arg" ]] || cmd+=("$lifecycle_arg")
     cmd+=("$spec")
@@ -1398,7 +1395,6 @@ GIT_DIR=${OPENCLAW_GIT_DIR:-"$(resolve_openclaw_effective_home)/openclaw"}
 GIT_DIR_EXPLICIT=${OPENCLAW_GIT_DIR:+1}
 GIT_UPDATE=${OPENCLAW_GIT_UPDATE:-1}
 NPM_LOGLEVEL="${OPENCLAW_NPM_LOGLEVEL:-error}"
-NPM_SILENT_FLAG="--silent"
 VERBOSE="${OPENCLAW_VERBOSE:-0}"
 VERIFY_INSTALL="${OPENCLAW_VERIFY_INSTALL:-0}"
 OPENCLAW_BIN=""
@@ -1536,7 +1532,6 @@ configure_verbose() {
     if [[ "$NPM_LOGLEVEL" == "error" ]]; then
         NPM_LOGLEVEL="notice"
     fi
-    NPM_SILENT_FLAG=""
     set -x
 }
 

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -1259,6 +1259,82 @@ EOF
     expect(result.status).toBe(0);
   });
 
+  it("recovers a dangling launcher from the default npm error log", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "openclaw-install-eexist-recovery-"));
+    const bin = join(tmp, "bin");
+    const npmRoot = join(tmp, "lib", "node_modules");
+    const packageDir = join(npmRoot, "openclaw");
+    const attempts = join(tmp, "attempts");
+    const target = join(bin, "openclaw");
+    mkdirSync(bin, { recursive: true });
+    mkdirSync(npmRoot, { recursive: true });
+    linkNodeExecutable(bin);
+    symlinkSync("/missing/ClawX.app/Contents/Resources/cli/openclaw", target);
+
+    const fakeNpm = join(bin, "npm");
+    writeFileSync(
+      fakeNpm,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        'case "${1:-}" in',
+        "  --version) printf '11.8.0\\n'; exit 0 ;;",
+        '  config) printf "null\\n"; exit 0 ;;',
+        '  prefix) printf "%s\\n" "$NPM_FAKE_PREFIX"; exit 0 ;;',
+        '  root) printf "%s\\n" "$NPM_FAKE_ROOT"; exit 0 ;;',
+        "esac",
+        "install=0",
+        "silent=0",
+        'for arg in "$@"; do',
+        '  [[ "$arg" == "install" ]] && install=1',
+        '  [[ "$arg" == "--silent" ]] && silent=1',
+        "done",
+        "(( install == 1 )) || exit 1",
+        'count=0; [[ ! -f "$NPM_FAKE_ATTEMPTS" ]] || count="$(cat "$NPM_FAKE_ATTEMPTS")"',
+        'count=$((count + 1)); printf "%s\\n" "$count" > "$NPM_FAKE_ATTEMPTS"',
+        'if [[ -e "$NPM_FAKE_BIN/openclaw" || -L "$NPM_FAKE_BIN/openclaw" ]]; then',
+        "  if (( silent == 0 )); then",
+        "    printf 'npm error code EEXIST\\n' >&2",
+        "    printf 'npm error path %s\\n' \"$NPM_FAKE_BIN/openclaw\" >&2",
+        "    printf 'npm error File exists: %s\\n' \"$NPM_FAKE_BIN/openclaw\" >&2",
+        "  fi",
+        "  exit 1",
+        "fi",
+        'mkdir -p "$NPM_FAKE_PACKAGE"',
+        'printf "#!/usr/bin/env bash\\nexit 0\\n" > "$NPM_FAKE_PACKAGE/openclaw.mjs"',
+        'chmod +x "$NPM_FAKE_PACKAGE/openclaw.mjs"',
+        'ln -s "$NPM_FAKE_PACKAGE/openclaw.mjs" "$NPM_FAKE_BIN/openclaw"',
+        "",
+      ].join("\n"),
+    );
+    chmodSync(fakeNpm, 0o755);
+
+    try {
+      const result = runInstallShell(
+        [
+          "set -euo pipefail",
+          `source ${JSON.stringify(SCRIPT_PATH)}`,
+          `PATH=${JSON.stringify(`${bin}:/usr/bin:/bin`)}`,
+          "NPM_LOGLEVEL=error",
+          "install_openclaw_npm openclaw@latest",
+        ].join("\n"),
+        {
+          NPM_FAKE_ATTEMPTS: attempts,
+          NPM_FAKE_BIN: bin,
+          NPM_FAKE_PACKAGE: packageDir,
+          NPM_FAKE_PREFIX: tmp,
+          NPM_FAKE_ROOT: npmRoot,
+        },
+      );
+
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(readFileSync(attempts, "utf8")).toBe("2\n");
+      expect(lstatSync(target).isSymbolicLink()).toBe(true);
+    } finally {
+      rmSync(tmp, { force: true, recursive: true });
+    }
+  });
+
   it("does not report npm owner retirement when uninstall fails", () => {
     const result = runInstallShell(`
       source "${SCRIPT_PATH}"
@@ -2367,7 +2443,6 @@ EOF
             `OPENCLAW_VERSION=${requested}`,
             "USE_BETA=0",
             "NPM_LOGLEVEL=error",
-            "NPM_SILENT_FLAG=",
             `npm_global_bin_dir() { printf '%s\\n' ${JSON.stringify(bin)}; }`,
             "set +e",
             "install_openclaw",
@@ -2417,7 +2492,6 @@ EOF
           "OPENCLAW_VERSION=latest",
           "USE_BETA=0",
           "NPM_LOGLEVEL=error",
-          "NPM_SILENT_FLAG=",
           `npm_global_bin_dir() { printf '%s\\n' ${JSON.stringify(bin)}; }`,
           "install_openclaw",
         ].join("\n"),
@@ -2464,7 +2538,6 @@ EOF
           `HOME=${JSON.stringify(home)}`,
           `PATH=${JSON.stringify(`${bin}:/usr/bin:/bin`)}`,
           "NPM_LOGLEVEL=error",
-          "NPM_SILENT_FLAG=",
           `run_npm_global_install openclaw@latest ${JSON.stringify(join(tmp, "install.log"))}`,
         ].join("\n"),
       );
@@ -2503,7 +2576,6 @@ EOF
           `HOME=${JSON.stringify(home)}`,
           `PATH=${JSON.stringify(`${bin}:/usr/bin:/bin`)}`,
           "NPM_LOGLEVEL=error",
-          "NPM_SILENT_FLAG=",
           `run_npm_global_install openclaw@latest ${JSON.stringify(join(tmp, "install.log"))}`,
         ].join("\n"),
       );


### PR DESCRIPTION
Closes #134201

## What Problem This Solves

Fixes an issue where npm installs blocked by a stale or dangling `openclaw` launcher would fail without useful diagnostics instead of using the installer's existing conflict recovery.

The default npm command suppressed the error log that recovery reads, so recoverable EEXIST/ENOTEMPTY failures became hard failures.

## Why This Change Was Made

The installer now keeps npm's configured error log level and removes the internal silent-command branch. This restores the existing log-driven diagnostics and recovery without adding a new retry policy, configuration surface, or fallback.

A parallel implementation exists in #134236. This variant removes the silent branch completely rather than retaining an empty internal variable, cleans up its obsolete test setup, and includes a real npm/full-installer E2E in addition to the committed regression test.

## User Impact

Users installing over a stale or dangling launcher can now have that launcher moved aside and the npm install retried automatically. When recovery is not possible, npm's failure diagnostics remain available instead of being blanked.

## Evidence

- RED: on the pre-fix implementation, the new regression test exited 1 after one npm attempt because `--silent` blanked the captured EEXIST log.
- GREEN: `test/scripts/install-sh.test.ts` passed 178/178 on Node 24.15.0; the focused post-cleanup set passed 10/10.
- Real isolated E2E: ran the complete `scripts/install.sh --npm` main path with npm 11.12.1 and a local package tarball against a temporary prefix containing a dangling launcher. The first install produced EEXIST, the installer moved the launcher aside, the retry succeeded, and the resulting command reported `OpenClaw 0.0.0-e2e` (exit 0).
- `pnpm lint:scripts` and `git diff --check` passed.
- The routed changed-file checks completed except `tsgo:test:root`, which was terminated locally with exit 137 on two attempts without a type diagnostic. CI remains the type-check authority for this PR.
- Remote validation on this exact head completed GREEN: 153 checks passed, including Debian, Linux non-root, Linux Docker, build-tools failure, Fedora root/non-root, macOS, Windows, lint, types, and test shards; no check failed.

<details>
<summary>Redacted real npm/full-installer terminal transcript</summary>

```console
$ ls -l "$E2E_ROOT/prefix/bin/openclaw"
... $E2E_ROOT/prefix/bin/openclaw -> /missing/ClawX.app/Contents/Resources/cli/openclaw

$ env HOME="$E2E_ROOT/home" OPENCLAW_HOME="$E2E_ROOT/home/.openclaw" \
    NPM_CONFIG_PREFIX="$E2E_ROOT/prefix" \
    bash scripts/install.sh --npm --version "$LOCAL_TARBALL" --no-onboard --no-prompt
✓ Node.js v24.15.0 found
· Active npm: 11.12.1
· Installing OpenClaw package
! npm install failed for $LOCAL_TARBALL
  Command: ... npm-cli.js --loglevel error --no-fund --no-audit --min-release-age=0 install -g $LOCAL_TARBALL
  npm code: EEXIST
  First npm error: npm error code EEXIST
npm error path $E2E_ROOT/prefix/bin/openclaw
npm error EEXIST: file already exists
npm error File exists: $E2E_ROOT/prefix/bin/openclaw
· Moved existing openclaw command aside for npm retry
· Installing OpenClaw package
✓ OpenClaw npm package installed
· Published openclaw bin link at $E2E_ROOT/prefix/bin/openclaw
· Preserved previous openclaw command at $E2E_ROOT/prefix/bin/openclaw.openclaw-backup.REDACTED
✓ OpenClaw installed
🦞 OpenClaw installed successfully (0.0.0-e2e)!

$ echo $?
0
$ ls -l "$E2E_ROOT/prefix/bin/openclaw"
... $E2E_ROOT/prefix/bin/openclaw -> $E2E_ROOT/prefix/lib/node_modules/openclaw/openclaw.mjs
$ ls -l "$E2E_ROOT/prefix/bin"/openclaw.openclaw-backup.*
... openclaw.openclaw-backup.REDACTED -> /missing/ClawX.app/Contents/Resources/cli/openclaw
$ "$E2E_ROOT/prefix/bin/openclaw" --version
OpenClaw 0.0.0-e2e
```

</details>

Verification boundary: the real E2E ran on isolated Linux filesystem/npm state. I did not exercise macOS App Translocation or a live user installation.
