### PR TITLE
refactor: use the shared Tavily response reader directly

### DIFF
--- a/extensions/tavily/src/tavily-client.ts
+++ b/extensions/tavily/src/tavily-client.ts
@@ -122,18 +122,10 @@ async function postTavilyJson(params: {
       ...(params.signal ? { signal: params.signal } : {}),
     },
     async (response) =>
-      readTavilyJsonResponse(response, params.errorLabel, {
+      readProviderJsonResponse<Record<string, unknown>>(response, params.errorLabel, {
         maxBytes: params.responseMaxBytes,
       }),
   );
-}
-
-async function readTavilyJsonResponse(
-  response: Response,
-  label: string,
-  opts?: { maxBytes?: number },
-): Promise<Record<string, unknown>> {
-  return await readProviderJsonResponse<Record<string, unknown>>(response, label, opts);
 }
 
 export async function runTavilySearch(
@@ -415,6 +407,5 @@ export async function runTavilyExtract(
 }
 
 export const testing = {
-  readTavilyJsonResponse,
   resolveEndpoint,
 };


### PR DESCRIPTION
## What Problem This Solves

Tavily's private response-reader wrapper immediately forwards to the shared bounded JSON parser. Its property on the testing object has no consumer, so the wrapper and property add an unnecessary path between transport and parsing.

## Why This Change Was Made

Call the existing shared parser directly from the same async transport callback. Keep the same response, error label, generic result type and maxBytes option. The transport still awaits parsing before cleanup. Keep testing.resolveEndpoint and its reverse-proxy and fallback cases.

## User Impact

No intended behavior change. The one-file diff is +1/-10: eight net runtime lines and one unused test-support property removed. Search and extract retain their separate response caps, cancellation and cleanup boundaries, errors, request construction, cache behavior and configuration. No new export or test is added.

## Evidence

Read the full client, transport/parser owners and tests, callers, sibling tools/configuration/cache tests, public barrels, manifest, documentation and raw-parent history. All 32 source references still match the previously tested candidate. No caller uses the removed testing property.

The exact change passed 46 cases before and after with identical names and order. These include the client and canonical parser suites plus two temporary synthetic transport probes: valid 17 MiB JSON exercises distinct search/extract caps, and an 80 MiB extract stream exercises overflow and cancellation of unread data. The temporary probes were removed and the original test restored. The remaining 29 tool, configuration and cache cases also pass.

All 24 required changed-file checks and fresh scoped Codex review pass. This is synthetic parser/transport proof, not live Tavily API, latency, exact microtask-count or bundled-release proof.
