### PR TITLE
test(plugins): expect structured registry differences

### DIFF
--- a/src/plugins/status.registry-snapshot.test.ts
+++ b/src/plugins/status.registry-snapshot.test.ts
@@ -555,16 +555,22 @@ describe("buildPluginRegistrySnapshotReport", () => {
       expect(report.workspaceDir).toBe(workspaceDir);
       expect(report.workspaceScope).toBe(workspaceScope);
       expect(report.registrySource).toBe(state === "persisted" ? "persisted" : "derived");
+      const expectedRegistryDiagnostic = {
+        level: state === "missing" ? "info" : "warn",
+        code: `persisted-registry-${state}`,
+        message: expect.any(String),
+        ...(state === "stale-source" && {
+          differences: [
+            {
+              pluginId: fixture.pluginId,
+              persistedSource: fixture.runtimeSource,
+              derivedSource: fixture.runtimeSource,
+            },
+          ],
+        }),
+      };
       expect(report.registryDiagnostics).toEqual(
-        state === "persisted"
-          ? []
-          : [
-              {
-                level: state === "missing" ? "info" : "warn",
-                code: `persisted-registry-${state}`,
-                message: expect.any(String),
-              },
-            ],
+        state === "persisted" ? [] : [expectedRegistryDiagnostic],
       );
       expect(report.diagnostics).toEqual(
         workspaceScope === "selected"


### PR DESCRIPTION
## What Problem This Solves

Full release verification fails two plugin status cases because their strict expected diagnostic predates the registry's structured differences. The fixture changes the persisted package version while keeping its source path, so the diagnostic correctly identifies the plugin with equal persisted and derived paths.

## Why This Change Was Made

Extend the existing stale-source expectation with that exact difference row for both selected and omitted workspaces. Preserve strict equality, warning count, other registry states, cold-runtime checks, and metadata reuse assertions. The production comparison and existing inspection sibling already agree; changing runtime diagnostics or broadening the matcher would hide the contract.

Provenance: the structured diagnostic was added by 4cc2fe74e15ade63b12697ca71af147ef5cc5c58. This assertion was not updated with it. The original full run is [33392987515](https://github.com/openclaw/openclaw/actions/runs/33392987515), with the two failures in its plugin prerelease child.

## User Impact

No product behavior changes. Release verification recognizes the existing diagnostic without losing coverage.

## Evidence

The original whole status file produced exactly two failures and 29 passes. The corrected file and real registry inspection sibling passed all 37 tests, repeated on the current-main-based candidate. Formatting and diff checks pass. Managed Codex review found no actionable P0–P2 findings. The final 37-test run, exact lint, formatting and complete one-path changed-file gate pass, including all dead-export scans and the actual plugins-platform consumer typecheck. Final independent Codex review is clean. Hosted CI remains required; this is not a full-release green claim.

Production delta: 0. Tests: +15/-9 (net +6) in the existing table. No new test, mock, production seam, retry, timeout, schema or dependency change.

The initial private-dependency gate caught the file’s existing line limit after the expectation grew; factoring the same complete expectation removed five lines without suppressing the rule or weakening equality. One subsequent canonical test invocation hit its unchanged startup watchdog before any assertions; a single unchanged-command rerun at reduced local contention passed all 37 tests. All outcomes are retained. The earlier shared dependency installation was incomplete; proof used a normal private frozen installation, without changing shared dependencies.
