### PR TITLE
test(infra): exercise real transport backoff

### DIFF
--- a/src/infra/transport-ready.test.ts
+++ b/src/infra/transport-ready.test.ts
@@ -9,31 +9,17 @@ const transportReadyMocks = vi.hoisted(() => ({
 type TransportReadyModule = typeof import("./transport-ready.js");
 let waitForTransportReady: TransportReadyModule["waitForTransportReady"];
 
-vi.mock("./backoff.js", () => ({
-  sleepWithAbort: async (ms: number, signal?: AbortSignal) => {
-    if (transportReadyMocks.injectedSleepError) {
-      throw transportReadyMocks.injectedSleepError;
-    }
-    if (signal?.aborted) {
-      throw new Error("aborted");
-    }
-    if (ms <= 0) {
-      return;
-    }
-    await new Promise<void>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        signal?.removeEventListener("abort", onAbort);
-        resolve();
-      }, ms);
-      const onAbort = () => {
-        clearTimeout(timer);
-        signal?.removeEventListener("abort", onAbort);
-        reject(new Error("aborted"));
-      };
-      signal?.addEventListener("abort", onAbort, { once: true });
-    });
-  },
-}));
+vi.mock("./backoff.js", async (importOriginal) => {
+  const { sleepWithAbort } = await importOriginal<typeof import("./backoff.js")>();
+  return {
+    sleepWithAbort: async (ms: number, signal?: AbortSignal) => {
+      if (transportReadyMocks.injectedSleepError) {
+        throw transportReadyMocks.injectedSleepError;
+      }
+      return sleepWithAbort(ms, signal);
+    },
+  };
+});
 
 function createRuntime() {
   return { log: vi.fn(), error: vi.fn(), exit: vi.fn() };


### PR DESCRIPTION
## What Problem This Solves

The transport-readiness tests maintain a second implementation of abortable backoff. It was introduced when the real helper used promise-based timers that the suite's fake clock could not advance. The real helper now uses ordinary timers, so the copy hides the implementation actually used by the Signal daemon.

## Why This Change Was Made

Delegate ordinary sleeps to the real backoff helper, retaining only the existing unexpected-error injection. Remove the copied timer, abort listener, cleanup, and rejection logic. The seven readiness tests keep their assertions and fake-clock deadlines; the nine backoff tests continue to exercise the timer owner directly.

## User Impact

More faithful readiness coverage and less duplicate test code. Production behavior is unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/infra/transport-ready.test.ts src/infra/backoff.test.ts` passed all 16 tests before and after.
- `OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs -- src/infra/transport-ready.test.ts` passed, including type checks and lint.
- Formatting, diff checks, and structured Codex autoreview passed.
- Source and history inspection confirmed the original promise-timer constraint is obsolete. Existing polling, timeout, abort, logging, and unexpected-error assertions remain.
- Production +0/-0; tests +11/-25. This is a coverage and maintenance improvement; no wall-clock speedup is claimed.
