### PR TITLE
fix(macos): finish ChatGPT login after Gateway reconnect

### DIFF
--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -753,20 +753,6 @@ extension OnboardingAISetupModel {
             "No Gateway is selected. Select a Gateway, then try again.")
     }
 
-    /// Candidates the automatic ladder may try: skip definitively logged-out
-    /// installs and anything already attempted.
-    private func autoCandidateAfter(kind: String?) -> Candidate? {
-        let startIndex: Int = if let kind, let index = candidates.firstIndex(where: { $0.kind == kind }) {
-            index + 1
-        } else {
-            0
-        }
-        guard startIndex <= self.candidates.count else { return nil }
-        return self.candidates[startIndex...].first { candidate in
-            candidate.credentials != false && self.statuses[candidate.kind] == .untried
-        }
-    }
-
     func userSelect(kind: String) {
         guard self.canSelectCandidate(kind: kind) else { return }
         var supersededKind: String?
@@ -1241,17 +1227,6 @@ extension OnboardingAISetupModel {
         }
     }
 
-    func continueProviderAuth() {
-        guard let step = authStep else { return }
-        let value: AnyCodable? = switch wizardStepType(step) {
-        case "text": AnyCodable(self.authText)
-        case "select": self.selectedAuthWizardOption?.value
-        case "confirm": AnyCodable(self.authConfirmation)
-        default: nil
-        }
-        self.advanceProviderAuth(stepID: step.id, value: value)
-    }
-
     func cancelProviderAuth() {
         let sessionID = self.authSessionID
         let authServerLease = self.serverLease
@@ -1291,7 +1266,7 @@ extension OnboardingAISetupModel {
         }
     }
 
-    private func advanceProviderAuth(stepID: String?, value: AnyCodable?) {
+    func advanceProviderAuth(stepID: String?, value: AnyCodable?) {
         guard let sessionID = authSessionID, let serverLease else { return }
         self.authBusy = true
         self.authError = nil
@@ -1306,12 +1281,31 @@ extension OnboardingAISetupModel {
         let token = self.attemptToken
         let authAttemptID = self.authAttemptID
         Task {
+            var requestLease = serverLease
             do {
-                let data = try await self.gateway.request(
-                    method: "wizard.next",
-                    params: params,
-                    timeoutMs: Self.providerAuthRequestTimeoutMs,
-                    ifCurrentServerLease: serverLease)
+                let data: Data
+                do {
+                    data = try await self.gateway.request(
+                        method: "wizard.next",
+                        params: params,
+                        timeoutMs: Self.providerAuthRequestTimeoutMs,
+                        ifCurrentServerLease: requestLease)
+                } catch OpenClawChatTransportSendError.notDispatched {
+                    guard token == self.attemptToken, authAttemptID == self.authAttemptID else { return }
+                    // Only this error proves the callback never reached the Gateway.
+                    // Keep the wizard identity and retry once on the same route.
+                    let replacementLease = try await self.gateway.acquireServerLease(
+                        ifSameRouteAs: requestLease,
+                        timeoutMs: 5000)
+                    guard token == self.attemptToken, authAttemptID == self.authAttemptID else { return }
+                    requestLease = replacementLease
+                    self.serverLease = requestLease
+                    data = try await self.gateway.request(
+                        method: "wizard.next",
+                        params: params,
+                        timeoutMs: Self.providerAuthRequestTimeoutMs,
+                        ifCurrentServerLease: requestLease)
+                }
                 guard token == self.attemptToken, authAttemptID == self.authAttemptID else { return }
                 let result = try JSONDecoder().decode(WizardNextResult.self, from: data)
                 self.applyAuthWizardResult(
@@ -1321,13 +1315,13 @@ extension OnboardingAISetupModel {
                     error: result.error,
                     preparedModelRef: result.preparedmodelref)
             } catch {
-                let cancellation = await self.gateway.cancelWizardSession(sessionID, on: serverLease)
+                let cancellation = await self.gateway.cancelWizardSession(sessionID, on: requestLease)
                 guard token == self.attemptToken, authAttemptID == self.authAttemptID else { return }
                 if cancellation != .cancelled,
                    await self.reconcileProviderAuthAfterUnknownOutcome(
                        token: token,
                        before: self.lastDetectedActivationState,
-                       originalServerLease: serverLease)
+                       originalServerLease: requestLease)
                 {
                     return
                 }

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
@@ -236,6 +236,31 @@ extension OnboardingAISetupModel {
         self.startProviderWizard(option, kind: .auth)
     }
 
+    func continueProviderAuth() {
+        guard let step = authStep else { return }
+        let value: AnyCodable? = switch wizardStepType(step) {
+        case "text": AnyCodable(self.authText)
+        case "select": self.selectedAuthWizardOption?.value
+        case "confirm": AnyCodable(self.authConfirmation)
+        default: nil
+        }
+        self.advanceProviderAuth(stepID: step.id, value: value)
+    }
+
+    /// Candidates the automatic ladder may try: skip definitively logged-out
+    /// installs and anything already attempted.
+    func autoCandidateAfter(kind: String?) -> Candidate? {
+        let startIndex: Int = if let kind, let index = candidates.firstIndex(where: { $0.kind == kind }) {
+            index + 1
+        } else {
+            0
+        }
+        guard startIndex <= self.candidates.count else { return nil }
+        return self.candidates[startIndex...].first { candidate in
+            candidate.credentials != false && self.statuses[candidate.kind] == .untried
+        }
+    }
+
     func startProviderPrepare(_ option: PrepareOption) {
         self.startProviderWizard(
             AuthOption(

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -1137,6 +1137,83 @@ struct OnboardingAISetupTests {
         #expect(model.authError == nil)
     }
 
+    @Test func `provider auth callback reacquires its route after a pre-dispatch disconnect`() async throws {
+        let defaults = try #require(isolatedAISetupDefaults(prefix: "OnboardingProviderAuthReconnectTests"))
+        let detections = AISetupSocketGeneration()
+        let answeredSessions = LockIsolated<[String]>([])
+        let cancelledSessions = LockIsolated<[String]>([])
+        let url = try #require(URL(string: "ws://example.invalid"))
+        let harness = AISetupHarness(url: url) { _, request, _ in
+            switch request.method {
+            case "openclaw.setup.detect":
+                return detections.claim() == 0
+                    ? detectedSetupResponse(id: request.id)
+                    : persistedDetectedSetupResponse(id: request.id)
+            case "openclaw.setup.auth.start":
+                let sessionID = try #require(request.params["sessionId"] as? String)
+                return Data(
+                    """
+                    {"type":"res","id":"\(request.id)","ok":true,"payload":{
+                      "sessionId":"\(sessionID)","done":false,"status":"running",
+                      "step":{"id":"login","type":"text","executor":"client",
+                        "message":"Enter the sign-in response"}}}
+                    """.utf8)
+            case "wizard.next":
+                let sessionID = try #require(request.params["sessionId"] as? String)
+                let answer = try #require(request.params["answer"] as? [String: Any])
+                #expect(answer["stepId"] as? String == "login")
+                #expect(answer["value"] as? String == "callback-value")
+                answeredSessions.withValue { $0.append(sessionID) }
+                return wizardDoneResponse(id: request.id, sessionID: sessionID)
+            case "wizard.cancel":
+                let sessionID = try #require(request.params["sessionId"] as? String)
+                cancelledSessions.withValue { $0.append(sessionID) }
+                return Data(
+                    #"{"type":"res","id":"\#(request.id)","ok":true,"payload":{"status":"cancelled"}}"#.utf8)
+            default:
+                Issue.record("Unexpected setup request: \(request.method)")
+                return successfulEmptyResponse(id: request.id)
+            }
+        }
+        let model = harness.model(defaults: defaults)
+        let option = OnboardingAISetupModel.AuthOption(
+            id: "test-provider-login", brandId: nil, label: "Test provider", hint: nil,
+            groupLabel: nil, icon: nil, website: nil, kind: "oauth", featured: false)
+
+        await model.detectAndAutoConnect()
+        model.startProviderAuth(option)
+        for _ in 0..<200 where model.authStep == nil {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        let sessionID = try #require(model._test_authSessionID)
+        let staleLease = try #require(await harness.gateway.captureServerLease())
+        let firstSocket = try #require(harness.session.latestTask())
+
+        firstSocket.emitReceiveFailure()
+        for _ in 0..<200 {
+            guard await harness.gateway.isCurrentServerLease(staleLease) else { break }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(await !harness.gateway.isCurrentServerLease(staleLease))
+        model.authText = "callback-value"
+        model.continueProviderAuth()
+        for _ in 0..<400 where !model.connected && model.authError == nil {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+
+        #expect(answeredSessions.value == [sessionID])
+        #expect(cancelledSessions.value.isEmpty)
+        #expect(harness.session.snapshotMakeCount() == 2)
+        #expect(model.authError == nil)
+        #expect(model.connected)
+
+        let requestCount = (await harness.recorder.snapshot()).methods.count
+        model.continueProviderAuth()
+        await settleQueuedAISetupTasks()
+        #expect((await harness.recorder.snapshot()).methods.count == requestCount)
+        await harness.gateway.shutdown()
+    }
+
     @Test(arguments: ["timeout", "replacement-unavailable", "commit-locked", "commit-locked-after-completion"])
     func `unresolved provider auth cancellation reports recovery without discarding the session`(
         failure: String) async throws


### PR DESCRIPTION
Closes #134182

## What Problem This Solves

Fixes an issue where users who started ChatGPT Login during macOS onboarding could receive a generic Gateway transport error after the socket reconnected. The callback was rejected before dispatch, but the app cancelled the live wizard session and left the visible Submit control unable to send another request.

## Why This Change Was Made

The native onboarding owner now retries only the typed `notDispatched` failure, which proves the callback did not reach the Gateway. It reacquires the same route, preserves the existing wizard session and answer, and sends one replacement request.

Post-dispatch failures, provider errors, cancellation, route changes, and a failed replacement request keep their existing cancellation and reconciliation behavior. The retry never starts a second provider login.

## User Impact

ChatGPT Login can finish after a same-route Gateway socket reconnect during the browser flow. Users still see the provider's real error when the provider rejects the callback.

## Evidence

| Proof | Result |
| --- | --- |
| [Exact-main macOS run](https://github.com/openclaw/openclaw/actions/runs/33404854399) at `2278fbc9df879d52efbb6a0b81f7798a9f7c16c1` plus the regression test | The replacement socket received no `wizard.next`; onboarding sent `wizard.cancel`, showed `OpenClawChatTransportSendError error 0`, and stayed disconnected. |
| [Exact-head pull request CI](https://github.com/openclaw/openclaw/actions/runs/33414196718) at `a603799a69a9d230d34de146769174ffe3e169b5` | Swift lint, native release build, existing onboarding tests, and the focused stale-lease regression passed. All required checks are green. |

The regression rotates the physical socket after provider auth starts. It verifies that one replacement `wizard.next` carries the same session ID, step ID, and callback value, and that no wizard cancellation occurs.

Production LOC: +52/-33, net +19. Of these additions, 25 are a pure move of existing non-localized helpers into the existing support file so the owner stays under its enforced file-length limit without changing the string inventory. The remaining growth implements the typed, same-route, exactly-once recovery boundary.
