### PR TITLE
fix(cli): honor usage options in full status reports

### DIFF
--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -13,6 +13,7 @@ openclaw status
 openclaw status --all
 openclaw status --deep
 openclaw status --usage
+openclaw status --all --usage
 openclaw status --usage --agent work
 ```
 
@@ -65,6 +66,7 @@ and `openclaw memory status --deep`.
 ## Usage and quota
 
 - `--usage` prints normalized provider usage windows as `X% left`.
+  It also adds usage snapshots to `--all`; `--agent` keeps the same usage-only scope.
 - In an explicit multi-agent setup, `--usage` reads the auth profiles owned by
   `agents.defaults.systemAgent.agentId` by default. Pass `--agent <id>` to
   inspect another agent; without either owner, OpenClaw does not guess one

--- a/src/commands/status-all.ts
+++ b/src/commands/status-all.ts
@@ -2,17 +2,21 @@
 // Orchestrates the scan, local service probes, and report rendering while report builders own formatting.
 
 import { withProgress } from "../cli/progress.js";
+import { formatUsageReportLines } from "../infra/provider-usage.format.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { buildStatusAllReportData } from "./status-all/report-data.js";
 import { buildStatusAllReportLines } from "./status-all/report-lines.js";
-import { resolveStatusServiceSummaries } from "./status-runtime-shared.ts";
+import {
+  resolveStatusServiceSummaries,
+  resolveStatusUsageSummary,
+} from "./status-runtime-shared.ts";
 import { resolveNodeOnlyGatewayInfo } from "./status.node-mode.js";
 import { collectStatusScanOverview } from "./status.scan-overview.ts";
 
 /** Runs the full read-only status report and writes it to the runtime logger. */
 export async function statusAllCommand(
   runtime: RuntimeEnv,
-  opts?: { timeoutMs?: number },
+  opts?: { timeoutMs?: number; usage?: boolean; agent?: string },
 ): Promise<void> {
   await withProgress({ label: "Scanning status --all…", total: 11 }, async (progress) => {
     const overview = await collectStatusScanOverview({
@@ -55,6 +59,15 @@ export async function statusAllCommand(
         timeoutMs: opts?.timeoutMs,
       })),
     });
+
+    if (opts?.usage) {
+      const usage = await resolveStatusUsageSummary({
+        config: overview.cfg,
+        timeoutMs: opts.timeoutMs,
+        ...(opts.agent ? { agentId: opts.agent } : {}),
+      });
+      lines.push("", ...formatUsageReportLines(usage));
+    }
 
     progress.setLabel("Rendering…");
     runtime.log(lines.join("\n"));

--- a/src/commands/status-runtime-shared.ts
+++ b/src/commands/status-runtime-shared.ts
@@ -40,11 +40,6 @@ export async function resolveStatusUsageSummary(params: StatusUsageSummaryOption
   return (await statusUsageModuleLoader.load()).resolveStatusUsageSummary(params);
 }
 
-/** Exposes provider-usage formatting for callers that requested usage. */
-export async function loadStatusProviderUsageModule() {
-  return (await statusUsageModuleLoader.load()).loadStatusProviderUsageModule();
-}
-
 /** Calls gateway health and lets errors propagate to deep status callers. */
 export async function resolveStatusGatewayHealth(params: {
   config: OpenClawConfig;

--- a/src/commands/status-usage.runtime.ts
+++ b/src/commands/status-usage.runtime.ts
@@ -108,8 +108,3 @@ export async function resolveStatusUsageSummary(params: StatusUsageSummaryOption
   });
   return mergeUsageSummaries(usage, codexUsage);
 }
-
-/** Exposes the lazily loaded provider-usage module for callers that need its helpers. */
-export async function loadStatusProviderUsageModule() {
-  return await providerUsageLoader.load();
-}

--- a/src/commands/status.cold-imports.test.ts
+++ b/src/commands/status.cold-imports.test.ts
@@ -19,8 +19,7 @@ describe("status cold imports", () => {
       getNodeDaemonStatusSummary: async () => ({ label: "node" }),
     }));
 
-    const { loadStatusProviderUsageModule, resolveStatusRuntimeSnapshot } =
-      await import("./status-runtime-shared.js");
+    const { resolveStatusRuntimeSnapshot } = await import("./status-runtime-shared.js");
     const params = { config: {}, sourceConfig: {}, gatewayReachable: false };
     const snapshot = await resolveStatusRuntimeSnapshot(params);
 
@@ -33,13 +32,14 @@ describe("status cold imports", () => {
       nodeService: { label: "node" },
     });
 
-    // Vitest wraps a failed module factory; both callers must preserve its cause.
+    // Usage collection must preserve its failure without breaking pure text formatting.
     await expect(resolveStatusRuntimeSnapshot({ ...params, usage: true })).rejects.toMatchObject({
       cause: usageImportFailure,
     });
-    await expect(loadStatusProviderUsageModule()).rejects.toMatchObject({
-      cause: usageImportFailure,
-    });
+    const { formatUsageReportLines } = await import("./status.command.text-runtime.js");
+    expect(formatUsageReportLines({ updatedAt: 0, providers: [] })).toEqual([
+      "Usage: no provider usage available.",
+    ]);
     await expect(resolveStatusRuntimeSnapshot(params)).resolves.toEqual(snapshot);
   });
 

--- a/src/commands/status.command.text-runtime.ts
+++ b/src/commands/status.command.text-runtime.ts
@@ -3,6 +3,7 @@
 
 export { formatCliCommand } from "../cli/command-format.js";
 export { info } from "../globals.js";
+export { formatUsageReportLines } from "../infra/provider-usage.format.js";
 export { formatTimeAgo } from "../infra/format-time/format-relative.ts";
 export { formatGitInstallLabel } from "../infra/update-check.js";
 export {

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -16,7 +16,6 @@ import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { assertStatusUsageAgentScope, runStatusJsonCommand } from "./status-json-command.ts";
 import { buildStatusOverviewSurfaceFromScan } from "./status-overview-surface.ts";
 import {
-  loadStatusProviderUsageModule,
   resolveStatusGatewayHealth,
   resolveStatusSecurityAudit,
   resolveStatusRuntimeSnapshot,
@@ -115,7 +114,7 @@ export async function statusCommand(
     // Human `--all` has a dedicated report path; JSON `--all` stays on the JSON schema.
     await statusAllModuleLoader
       .load()
-      .then(({ statusAllCommand }) => statusAllCommand(runtime, { timeoutMs: opts.timeoutMs }));
+      .then(({ statusAllCommand }) => statusAllCommand(runtime, opts));
     return;
   }
 
@@ -241,6 +240,7 @@ export async function statusCommand(
     formatPluginCompatibilityNotice,
     formatTimeAgo,
     formatTokensCompact,
+    formatUsageReportLines,
     formatUpdateAvailableHint,
     getTerminalTableWidth,
     info,
@@ -303,11 +303,7 @@ export async function statusCommand(
     details: gatewayProbe?.connectErrorDetails,
   });
 
-  const usageLines = usage
-    ? await loadStatusProviderUsageModule().then(({ formatUsageReportLines }) =>
-        formatUsageReportLines(usage),
-      )
-    : undefined;
+  const usageLines = usage ? formatUsageReportLines(usage) : undefined;
   const overviewSurface = buildStatusOverviewSurfaceFromScan({
     scan: {
       cfg,

--- a/src/commands/status.test.ts
+++ b/src/commands/status.test.ts
@@ -794,9 +794,6 @@ vi.mock("./status.scan.js", () => ({
 }));
 
 vi.mock("./status-runtime-shared.ts", () => ({
-  loadStatusProviderUsageModule: vi.fn(async () => ({
-    formatUsageReportLines: vi.fn(() => []),
-  })),
   resolveStatusGatewayHealth: vi.fn(async () => ({})),
   resolveStatusSecurityAudit: vi.fn(async (input: unknown) =>
     mocks.runSecurityAudit({

--- a/src/commands/status.usage-routing.test.ts
+++ b/src/commands/status.usage-routing.test.ts
@@ -1,0 +1,236 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerStatusHealthSessionsCommands } from "../cli/program/register.status-health-sessions.js";
+import type { OpenClawConfig } from "../config/types.js";
+import type { UsageSummary } from "../infra/provider-usage.types.js";
+import type { StatusUsageSummaryOptions } from "./status-usage.runtime.js";
+import type { StatusScanOverviewResult } from "./status.scan-overview.js";
+import type { StatusScanResult } from "./status.scan-result.js";
+import { baseStatusServices, createStatusScanResultFixture } from "./status.test-support.js";
+
+const mocks = vi.hoisted(() => ({
+  scan: vi.fn<() => Promise<StatusScanResult>>(),
+  usage: vi.fn<(options: StatusUsageSummaryOptions) => Promise<UsageSummary>>(),
+  gatewayService: vi.fn(),
+  nodeService: vi.fn(),
+  runtime: { log: vi.fn(), error: vi.fn(), exit: vi.fn() },
+}));
+
+vi.mock("../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../runtime.js")>()),
+  defaultRuntime: mocks.runtime,
+}));
+vi.mock("./status.scan.js", () => ({ scanStatus: mocks.scan }));
+vi.mock("./status.scan.fast-json.js", () => ({ scanStatusJsonFast: mocks.scan }));
+vi.mock("./status.scan-overview.js", () => ({
+  resolveStatusSummaryFromOverview: async () => (await mocks.scan()).summary,
+  collectStatusScanOverview: async () => {
+    const scan = await mocks.scan();
+    return {
+      ...scan,
+      coldStart: false,
+      hasConfiguredChannels: false,
+      skipColdStartNetworkChecks: false,
+      gatewaySnapshot: {
+        gatewayConnection: scan.gatewayConnection,
+        remoteUrlMissing: scan.remoteUrlMissing,
+        gatewayMode: scan.gatewayMode,
+        gatewayProbeAuth: scan.gatewayProbeAuth,
+        gatewayProbeAuthWarning: scan.gatewayProbeAuthWarning,
+        gatewayProbe: scan.gatewayProbe,
+        gatewayReachable: scan.gatewayReachable,
+        gatewaySelf: scan.gatewaySelf,
+      },
+      runtimeDegradation: { degradedSecretOwners: [], degradedPlugins: [] },
+      channelsStatus: null,
+    } satisfies StatusScanOverviewResult;
+  },
+}));
+vi.mock("./status-usage.runtime.js", () => ({
+  resolveStatusUsageSummary: mocks.usage,
+}));
+vi.mock("./status.daemon.js", () => ({
+  getDaemonStatusSummary: mocks.gatewayService,
+  getNodeDaemonStatusSummary: mocks.nodeService,
+}));
+vi.mock("../config/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/config.js")>()),
+  readConfigFileSnapshot: async () => ({
+    exists: true,
+    valid: true,
+    path: "/tmp/status-usage-fixture.json",
+    issues: [],
+  }),
+}));
+vi.mock("../daemon/diagnostics.js", () => ({ readLastGatewayErrorLine: async () => null }));
+vi.mock("../infra/ports-inspect.js", () => ({ inspectPortUsage: async () => null }));
+vi.mock("../infra/restart-sentinel.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/restart-sentinel.js")>()),
+  readRestartSentinelReadOnly: async () => null,
+}));
+vi.mock("../infra/exec-approvals.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/exec-approvals.js")>()),
+  loadExecApprovalsReadOnly: () => ({ version: 1, agents: {} }),
+}));
+vi.mock("../skills/discovery/status.js", () => ({ buildWorkspaceSkillStatus: () => null }));
+vi.mock("../plugins/status.js", async () => ({
+  ...(await import("../plugins/status-compatibility.js")),
+  buildPluginCompatibilityNotices: () => [],
+}));
+vi.mock("./status-all/gateway.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./status-all/gateway.js")>()),
+  readFileTailLines: async () => [],
+}));
+vi.mock("./backup-health.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./backup-health.js")>()),
+  readBackupFreshness: () => ({}),
+}));
+vi.mock("../security/audit.runtime.js", () => ({
+  runSecurityAudit: async () => ({
+    ts: 0,
+    summary: { critical: 0, warn: 0, info: 0 },
+    findings: [],
+  }),
+}));
+
+const config: OpenClawConfig = {
+  gateway: { mode: "local", bind: "loopback" },
+  agents: {
+    ownership: "explicit",
+    defaults: { systemAgent: { agentId: "main" } },
+    entries: { main: {}, work: {} },
+  },
+};
+
+function usageSummary(displayName: string, usedPercent: number): UsageSummary {
+  return {
+    updatedAt: 1_000,
+    providers: [{ provider: "fixture", displayName, windows: [{ label: "Window", usedPercent }] }],
+  };
+}
+
+const summaries = {
+  default: usageSummary("Fixture Default", 25),
+  work: usageSummary("Fixture Work", 60),
+  empty: { updatedAt: 1_000, providers: [] },
+  error: {
+    updatedAt: 1_000,
+    providers: [
+      {
+        provider: "fixture",
+        displayName: "Fixture Default",
+        windows: [],
+        error: "fixture quota unavailable",
+      },
+    ],
+  },
+} satisfies Record<string, UsageSummary>;
+
+describe("status usage routing through Commander", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    const scan = createStatusScanResultFixture({
+      cfg: config,
+      sourceConfig: config,
+      gatewayMode: "local",
+      gatewayReachable: false,
+      gatewayProbe: null,
+      gatewayProbeAuth: {},
+      gatewayProbeAuthWarning: undefined,
+      gatewayConnection: {
+        url: "ws://127.0.0.1:18789",
+        urlSource: "local loopback",
+        message: "Gateway target: ws://127.0.0.1:18789",
+      },
+      memory: null,
+      memoryPlugin: { enabled: false, slot: null, reason: "fixture" },
+      pluginCompatibility: [],
+    });
+    mocks.scan.mockResolvedValue({
+      ...scan,
+      agentStatus: {
+        ...scan.agentStatus,
+        bootstrapPendingCount: 0,
+        totalSessions: 0,
+        agents: [],
+      },
+    });
+    mocks.gatewayService.mockResolvedValue(baseStatusServices.gatewayService);
+    mocks.nodeService.mockResolvedValue(baseStatusServices.nodeService);
+  });
+
+  it.each([
+    {
+      name: "plain usage",
+      args: ["--usage"],
+      summary: summaries.default,
+      line: "Window: 75% left",
+    },
+    {
+      name: "full report usage",
+      args: ["--all", "--usage"],
+      summary: summaries.default,
+      line: "Window: 75% left",
+    },
+    {
+      name: "full report explicit agent",
+      args: ["--all", "--usage", "--agent", "work"],
+      summary: summaries.work,
+      agentId: "work",
+      line: "Window: 40% left",
+    },
+    { name: "full report without usage", args: ["--all"], summary: undefined },
+    {
+      name: "full report empty usage",
+      args: ["--all", "--usage"],
+      summary: summaries.empty,
+      line: "Usage: no provider usage available.",
+    },
+    {
+      name: "full report usage error",
+      args: ["--all", "--usage"],
+      summary: summaries.error,
+      line: "Fixture Default: fixture quota unavailable",
+    },
+    {
+      name: "JSON full report explicit agent",
+      args: ["--json", "--all", "--usage", "--agent", "work"],
+      summary: summaries.work,
+      agentId: "work",
+    },
+  ])("$name", async ({ args, summary, agentId, line }) => {
+    mocks.usage.mockResolvedValue(summary ?? summaries.default);
+    const program = new Command();
+    registerStatusHealthSessionsCommands(program);
+    await program.parseAsync(["status", ...args], { from: "user" });
+    expect(mocks.runtime.error).not.toHaveBeenCalled();
+    expect(mocks.runtime.exit).not.toHaveBeenCalled();
+    const output = mocks.runtime.log.mock.calls.map(([value]) => String(value)).join("\n");
+    if (args.includes("--json")) {
+      expect(JSON.parse(output).usage).toEqual(summary);
+    } else {
+      expect(output).toContain("OpenClaw status");
+      if (args.includes("--all")) {
+        expect(output).toContain("Diagnosis (read-only)");
+      }
+      if (line) {
+        expect(output).toContain(line);
+        for (const provider of summary?.providers ?? []) {
+          expect(output).toContain(provider.displayName);
+        }
+      } else {
+        expect(output).not.toContain("Usage:");
+      }
+    }
+    if (summary) {
+      expect(mocks.usage).toHaveBeenCalledOnce();
+      expect(mocks.usage).toHaveBeenCalledWith({
+        config,
+        timeoutMs: 10_000,
+        ...(agentId ? { agentId } : {}),
+      });
+    } else {
+      expect(mocks.usage).not.toHaveBeenCalled();
+    }
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `openclaw status --all --usage` received a full diagnostic report with no usage result. The same branch also lost the existing `--agent` usage scope.

## Why This Change Was Made

The human full-report dispatcher forwarded only the timeout. Pass the existing usage options to the full-report owner and reuse its scanned configuration with the existing lazy usage collector. Reuse the pure formatter directly and remove two redundant formatter-loader passthroughs; credential and provider loading remain lazy.

Production is **19 additions and 19 deletions (net 0)**. Tests are 242 additions/9 deletions; documentation adds 2 lines. No option, default, credential behavior, provider policy, quota calculation or persistence contract changes.

## User Impact

Full status reports now include the requested usage windows, provider error, or explicit `Usage: no provider usage available.` result. Explicit agent selection is retained. Reports without `--usage` keep their existing behavior.

## Evidence

The real Commander-to-report fixture produced **four missing-output failures and three passing controls before the fix**, then seven passes afterward. Final coverage totals **43 passing cases** across usage routing, existing status behavior, cold imports and usage formatting. Normal formatting and all **29 canonical repository checks** passed. Managed and independent P0–P2 review found no actionable issue in the unchanged nine-file patch.

Two independent full source copies passed normal frozen Linux installs and complete `pnpm run build`, including hooks and supply-chain checks. Archived source bytes remained unchanged. The canonical built launcher then produced:

| Command | Baseline | Candidate |
| --- | --- | --- |
| `node openclaw.mjs status --all --usage` | Full report, no usage result | Full report plus `Usage: no provider usage available.` |
| `node openclaw.mjs status --all` | Not repeated in this three-case proof | Full report with no usage section |

All three executed CLI cases exited 0 with empty stderr. The environment had no provider credentials or running Gateway; the report visibly recorded the unavailable Gateway. This proves the real built CLI's empty-usage outcome, not live provider quotas. Provider data, error and agent-scope cases are covered at the maintained mocked-I/O boundary.

Earlier raw-source launches timed out and were not accepted as proof. A first candidate build was interrupted by Testbox runner cleanup; the independently installed and fully built baseline/candidate sequence above completed successfully. Existing dependency-eval and browser-externalization build warnings remain recorded. Local focused validation used a narrowly qualified dependency installation with a disclosed fast-uri version difference; the isolated built proof used the tested source's complete frozen lockfile.

The Status and usage owner paths remain compatible with current main at `0e0b89663f945324a9a9698a58ff8019fe78da8a`. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33413780396) passed for `8183b37701676997b3c84bb08168940230a35548`: 167 jobs succeeded and 17 were intentionally skipped. The required `openclaw/ci-gate` check also passed.

Closes #134267
