### PR TITLE
test(llm-core): batch event stream sequence assertions

### DIFF
--- a/packages/llm-core/src/utils/event-stream.test.ts
+++ b/packages/llm-core/src/utils/event-stream.test.ts
@@ -33,9 +33,11 @@ describe("EventStream", () => {
       stream.push(value);
     }
 
+    const prefix: IteratorResult<number>[] = [];
     for (let value = 0; value < 1024; value += 1) {
-      expect(await iterator.next()).toEqual({ value, done: false });
+      prefix.push(await iterator.next());
     }
+    expect(prefix).toEqual(Array.from({ length: 1024 }, (_, value) => ({ value, done: false })));
     const queueState = stream as unknown as { queue: number[]; queueHead: number };
     expect(queueState.queueHead).toBe(0);
     expect(queueState.queue).toHaveLength(1024);
@@ -44,9 +46,13 @@ describe("EventStream", () => {
       stream.push(value);
     }
     stream.end();
+    const remaining: IteratorResult<number>[] = [];
     for (let value = 1024; value < 2052; value += 1) {
-      expect(await iterator.next()).toEqual({ value, done: false });
+      remaining.push(await iterator.next());
     }
+    expect(remaining).toEqual(
+      Array.from({ length: 1028 }, (_, index) => ({ value: index + 1024, done: false })),
+    );
     expect(await iterator.next()).toEqual({ value: undefined, done: true });
   });
 


### PR DESCRIPTION
## What Problem This Solves

The queue-compaction regression initializes 2,052 separate equality matchers to check one ordered event sequence. Matcher setup adds unnecessary work to a deliberately large boundary fixture.

## Why This Change Was Made

Collect the same iterator results sequentially and compare each half as one exact array. Both `value` and `done` remain checked for every event. The first comparison still precedes the queue-compaction assertions and the four appended events; the terminal iterator result remains separate.

The existing private queue observations intentionally protect compaction, not just output correctness, and remain unchanged. All other event-stream cases, including the unhandled-rejection observation turn, remain.

## User Impact

Less assertion overhead in the same five regression cases. Production code and stream behavior are unchanged.

## Evidence

- `node scripts/run-vitest.mjs packages/llm-core/src/utils/event-stream.test.ts` passed all five tests before and after.
- The compaction case took 13.08 ms before and 4.61 ms after in local runs. This is a small local observation, not a suite-wide benchmark; the deterministic change removes 2,050 matcher initializations.
- Full changed-file checks, formatting, diff checks, and structured Codex autoreview passed.
- Production +0/-0; tests +8/-2. The entire 2,052-event sequence, intermediate compaction boundary, and final completion assertion remain.
