### PR TITLE
perf: avoid scanning unused package-root candidates

### DIFF
--- a/src/commands/doctor-sandbox.test.ts
+++ b/src/commands/doctor-sandbox.test.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { note } from "../../packages/terminal-core/src/note.js";
+import { resolveOpenClawPackageRootSync } from "../infra/openclaw-root.js";
 import { noteSandboxScopeWarnings } from "./doctor-sandbox.js";
 import { resolveSandboxScript } from "./doctor-sandbox.test-support.js";
 
@@ -143,7 +144,7 @@ describe("resolveSandboxScript", () => {
     expect(result?.cwd).toBe(repo);
   });
 
-  it("keeps searching cwd when the launcher resolves to a package root without the script", () => {
+  it("keeps searching cwd after a first-root lookup finds a package without the script", () => {
     // Installed/published openclaw package root: it carries the package.json marker but not
     // scripts/sandbox-setup.sh, because the npm files allowlist drops scripts/. It resolves from
     // argv1 before cwd, so stopping at the first root would miss the source checkout below.
@@ -155,7 +156,9 @@ describe("resolveSandboxScript", () => {
     // Valid source checkout (cwd) that does contain the script.
     const repo = mkRepo("ocsbx-source-");
 
-    const result = resolveSandboxScript(scriptRel, { argv1: entry, cwd: repo });
+    const options = { argv1: entry, cwd: repo };
+    expect(resolveOpenClawPackageRootSync(options)).toBe(installed);
+    const result = resolveSandboxScript(scriptRel, options);
 
     expect(result?.scriptPath).toBe(path.join(repo, scriptRel));
     expect(result?.cwd).toBe(repo);

--- a/src/infra/openclaw-root.ts
+++ b/src/infra/openclaw-root.ts
@@ -6,6 +6,8 @@ import { openClawRootFs, openClawRootFsSync } from "./openclaw-root.fs.runtime.j
 
 const CORE_PACKAGE_NAMES = new Set(["openclaw"]);
 
+type PackageRootOptions = { cwd?: string; argv1?: string; moduleUrl?: string };
+
 function parsePackageName(raw: string): string | null {
   const parsed = JSON.parse(raw) as { name?: unknown };
   return typeof parsed.name === "string" ? parsed.name : null;
@@ -118,11 +120,7 @@ function candidateDirsFromArgv1(argv1: string): string[] {
   return [...deduped];
 }
 
-export async function resolveOpenClawPackageRoot(opts: {
-  cwd?: string;
-  argv1?: string;
-  moduleUrl?: string;
-}): Promise<string | null> {
+export async function resolveOpenClawPackageRoot(opts: PackageRootOptions): Promise<string | null> {
   const candidates = buildCandidates(opts);
   const cacheKey = createPackageRootCacheKey(candidates);
   const searches = getPluginCache().sdk.packageSearches;
@@ -150,11 +148,7 @@ export async function resolveOpenClawPackageRoot(opts: {
 // pick the first root that actually contains it: an installed package root can resolve first but
 // omit files the npm allowlist drops (e.g. scripts/), so stopping at root[0] would skip a valid
 // source-checkout cwd that still has them.
-export function resolveOpenClawPackageRootsSync(opts: {
-  cwd?: string;
-  argv1?: string;
-  moduleUrl?: string;
-}): string[] {
+export function resolveOpenClawPackageRootsSync(opts: PackageRootOptions): string[] {
   const candidates = buildCandidates(opts);
   const cacheKey = createPackageRootCacheKey(candidates);
   const searches = getPluginCache().sdk.packageSearches;
@@ -175,15 +169,31 @@ export function resolveOpenClawPackageRootsSync(opts: {
   return [...roots];
 }
 
-export function resolveOpenClawPackageRootSync(opts: {
-  cwd?: string;
-  argv1?: string;
-  moduleUrl?: string;
-}): string | null {
-  return resolveOpenClawPackageRootsSync(opts)[0] ?? null;
+export function resolveOpenClawPackageRootSync(opts: PackageRootOptions): string | null {
+  const candidates = buildCandidates(opts);
+  const cacheKey = createPackageRootCacheKey(candidates);
+  const searches = getPluginCache().sdk.packageSearches;
+  const cached = searches.get(cacheKey);
+  if (cached?.all) {
+    return cached.all[0] ?? null;
+  }
+  if (cached?.first !== undefined) {
+    return cached.first;
+  }
+  for (const candidate of candidates) {
+    const found = findPackageRootSync(candidate);
+    if (found) {
+      // Cache only the selected root; Doctor may still request the complete inventory.
+      searches.set(cacheKey, { first: found });
+      return found;
+    }
+  }
+
+  searches.set(cacheKey, { first: null });
+  return null;
 }
 
-function buildCandidates(opts: { cwd?: string; argv1?: string; moduleUrl?: string }): string[] {
+function buildCandidates(opts: PackageRootOptions): string[] {
   const candidates: string[] = [];
 
   if (opts.moduleUrl) {


### PR DESCRIPTION
## What Problem This Solves

Startup and package-resolution callers that only need the active OpenClaw root still scan unrelated launcher and working-directory ancestors after finding it. That adds synchronous filesystem work during plugin, asset, and command preparation.

## Why This Change Was Made

The synchronous first-root resolver now uses the existing first-result cache and returns when the shared ancestor search finds a match. Candidate order, symlink precedence, `node_modules` boundaries, package readers, and cache lifetime are unchanged. The complete-inventory resolver remains separate: Doctor must still find a source checkout containing setup scripts when the installed package omits them.

The existing Doctor fallback test now performs a first-root lookup before requesting the script, protecting partial-cache ownership. A shared first/all mode helper was measured and rejected because it repeatedly slowed complete-inventory searches. Production is +27/−17 (net +10); tests are +5/−2 (net +3). The small production increase keeps the distinct first-result and complete-inventory contracts straightforward while sharing their path and filesystem policy.

## User Impact

Less local package-discovery work when an early runtime hint already identifies OpenClaw. Root selection, later-root fallback, public results, and configuration remain unchanged. This is a local preparation improvement; no overall Gateway or provider-response speedup is claimed.

## Evidence

Measured actual resolver snapshots from baseline `ace8a13f19ccc2805b3d458026de3ab4bbbd8878`, with the real filesystem and plugin-cache owner. Four fresh Node 26.8.1 processes ran both variant orders in a fixed forward/reverse/reverse/forward schedule: 13 layouts × 6 workloads, 14,976 measured samples plus 3,744 warmups. Cold means a fresh metadata owner with warm OS caches; imports and fixture creation are excluded. Each process passed 962 explicit correctness checks, including completed/pending async interleavings, all-root ordering, symlinks, missing/malformed hints, boundary stopping, and mutation of returned arrays.

| Fresh-owner first-root workload | Before, median µs | After, median µs | Package-file reads |
| --- | ---: | ---: | ---: |
| Module root followed by unrelated deep hints | 240.328 | 50.114 | 21 → 2 |
| Three distinct matching roots | 52.047 | 33.980 | 4 → 2 |
| Launcher root followed by unrelated deep cwd | 145.213 | 21.568 | 13 → 1 |
| Symlinked launcher and separate working copy | 112.802 | 31.054 | 12 → 1 |
| One cwd hint | 9.650 | 9.683 | 1 → 1 |

When the module, launcher, and cwd all refer to the same package, the fresh-owner first lookup changes only slightly: 38.315 → 37.292 µs (0.6–5.2% faster across the four runs). The larger savings above apply when later hints would otherwise trigger additional discovery.

All 78 workload controls are retained in local evidence. Costs are not uniformly neutral: same-package complete-inventory lookup added 0.225–1.398 µs across the four runs; malformed-URL warm-first fallback added 0.864–1.075 µs in three of four runs. Ordinary inspected callers supply file URLs. The rejected shared helper added roughly 4–6% to many complete-inventory controls. These measurements do not establish whole-process memory, Gateway latency, or cross-platform performance.

Focused validation: 156 tests passed, one existing skip across package-root resolution, Doctor, Control UI assets, bundled plugin resolution, SDK aliases, and plugin-cache ownership. Independent source/measurement review found no correctness issue; managed Codex review was clean at its P0 threshold.

Baseline integration: a fresh compiled development Gateway with isolated state and a real OpenAI key completed three turns (plain reply, workspace read, successful `web_fetch`) and twelve `sessions.list` RPCs. A Node CPU profile was saved; the task-owned process group and listener were confirmed gone. The exact candidate `c6419101661aa9427bbfd5986805a4f0914bf155` also passed a fresh `pnpm build` (156.53 s), the same three real OpenAI turns (including successful read and web-fetch receipts), twelve session-list RPCs, CPU profiling, and process/port cleanup. Full `node scripts/check-changed.mjs -- src/infra/openclaw-root.ts src/commands/doctor-sandbox.test.ts` passed in 254.06 s. These single live runs establish integration, not a latency comparison.

Review follow-up: the complete current ClawSweeper comment collection and its Rank-up move have been reconciled. The later comment is a review-started acknowledgement with no additional findings. The stored-data warning does not apply: `packageSearches` in `src/plugins/plugin-cache-sdk.ts` is an existing process-local Map, and this change introduces no serialized state, database, or migration. Native review validation passed, and exact-head CI run 33414765939 reports a successful `openclaw/ci-gate`.
