### PR TITLE
fix(state): make schema-17 session repair atomic

### DIFF
--- a/src/commands/doctor-config-preflight.process.test-support.ts
+++ b/src/commands/doctor-config-preflight.process.test-support.ts
@@ -1,7 +1,9 @@
 import { execFile, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { promisify } from "node:util";
+import { ensureOpenClawAgentDatabaseSchema } from "../state/openclaw-agent-db.js";
 
 const execFileAsync = promisify(execFile);
 // The fixture owns its package assets; resolving linked source back to the checkout
@@ -68,4 +70,48 @@ export function createSourceRuntime(root: string): string {
   fs.mkdirSync(uiDir, { recursive: true });
   fs.writeFileSync(path.join(uiDir, "index.html"), "<!doctype html>\n");
   return runtimeRoot;
+}
+
+export function seedV17AdditiveRepairDatabase(
+  stateDir: string,
+  options: { participantDependency?: boolean } = {},
+): string {
+  const databasePath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+  fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+  const database = new DatabaseSync(databasePath);
+  try {
+    ensureOpenClawAgentDatabaseSchema(database, {
+      agentId: "main",
+      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
+      path: databasePath,
+      register: false,
+    });
+    database.exec(`
+      DROP TABLE session_participants;
+      DROP TRIGGER session_conversations_route_context_invalidate_after_update;
+      ALTER TABLE session_conversations DROP COLUMN route_context_json;
+      DROP INDEX idx_agent_transcript_event_identity_sequence;
+      PRAGMA user_version = 17;
+      UPDATE schema_meta SET schema_version = 17;
+    `);
+    if (options.participantDependency) {
+      database.exec(`
+        CREATE TABLE session_participants (
+          session_key TEXT NOT NULL,
+          actor_type TEXT NOT NULL,
+          actor_id TEXT NOT NULL,
+          actor_source TEXT,
+          contribution_count INTEGER,
+          first_prompted_at INTEGER NOT NULL,
+          last_prompted_at INTEGER NOT NULL,
+          PRIMARY KEY (session_key, actor_type, actor_id),
+          FOREIGN KEY (session_key) REFERENCES session_nodes(session_key) ON DELETE CASCADE
+        ) STRICT;
+        CREATE INDEX idx_test_participant_dependency ON session_participants(actor_id);
+      `);
+    }
+  } finally {
+    database.close();
+  }
+  return databasePath;
 }

--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -18,6 +18,7 @@ import {
   createSourceRuntime,
   runIsolatedModuleScript,
   runSourceRuntime,
+  seedV17AdditiveRepairDatabase,
 } from "./doctor-config-preflight.process.test-support.js";
 
 const STARTUP_REFUSAL =
@@ -93,31 +94,6 @@ function seedOwnerlessSchemaOnlyAgentDatabase(stateDir: string): string {
       register: false,
     });
     database.prepare("UPDATE schema_meta SET agent_id = NULL WHERE meta_key = 'primary'").run();
-  } finally {
-    database.close();
-  }
-  return databasePath;
-}
-
-function seedV17AdditiveRepairDatabase(stateDir: string): string {
-  const databasePath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
-  fs.mkdirSync(path.dirname(databasePath), { recursive: true });
-  const database = new DatabaseSync(databasePath);
-  try {
-    ensureOpenClawAgentDatabaseSchema(database, {
-      agentId: "main",
-      env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
-      path: databasePath,
-      register: false,
-    });
-    database.exec(`
-      DROP TABLE session_participants;
-      DROP TRIGGER session_conversations_route_context_invalidate_after_update;
-      ALTER TABLE session_conversations DROP COLUMN route_context_json;
-      DROP INDEX idx_agent_transcript_event_identity_sequence;
-      PRAGMA user_version = 17;
-      UPDATE schema_meta SET schema_version = 17;
-    `);
   } finally {
     database.close();
   }

--- a/src/commands/doctor-config-preflight.v17-atomicity.process.test.ts
+++ b/src/commands/doctor-config-preflight.v17-atomicity.process.test.ts
@@ -1,0 +1,87 @@
+// Process regression for schema-17 repair rollback through the shipped Doctor command.
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterAll, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import {
+  createSourceRuntime,
+  runSourceRuntime,
+  seedV17AdditiveRepairDatabase,
+} from "./doctor-config-preflight.process.test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterAll);
+
+describe("doctor schema-17 repair atomicity", () => {
+  it("rolls back rejected v17 repair through doctor --fix", () => {
+    const root = fs.realpathSync(tempDirs.make("openclaw-doctor-v17-atomicity-"));
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(stateDir, "openclaw.json");
+    fs.mkdirSync(path.join(stateDir, "agents", "main", "sessions"), { recursive: true });
+    fs.writeFileSync(configPath, "{}\n");
+    const databasePath = seedV17AdditiveRepairDatabase(stateDir, {
+      participantDependency: true,
+    });
+    const runtimeRoot = createSourceRuntime(root);
+    const result = runSourceRuntime(
+      runtimeRoot,
+      {
+        ...process.env,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_TEST_FAST: "1",
+        NO_COLOR: "1",
+      },
+      [
+        path.join(runtimeRoot, "src", "entry.ts"),
+        "doctor",
+        "--fix",
+        "--non-interactive",
+        "--yes",
+        "--no-workspace-suggestions",
+      ],
+      60_000,
+    );
+    const output = `${result.stdout}\n${result.stderr}`;
+
+    expect(result.error, output).toBeUndefined();
+    expect(output).toContain("Skipped agent database migration");
+    expect(output).toContain("Participant migration cannot rebuild unknown indexes");
+
+    const rejected = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(rejected.prepare("PRAGMA user_version").get()?.user_version).toBe(17);
+      expect(
+        rejected
+          .prepare(
+            "SELECT name FROM pragma_table_info('session_conversations') WHERE name = 'route_context_json'",
+          )
+          .get(),
+      ).toBeUndefined();
+      expect(
+        rejected
+          .prepare(
+            "SELECT name FROM sqlite_schema WHERE type = 'trigger' AND name = 'session_conversations_route_context_invalidate_after_update'",
+          )
+          .get(),
+      ).toBeUndefined();
+      expect(
+        rejected
+          .prepare(
+            "SELECT name FROM sqlite_schema WHERE type = 'index' AND name = 'idx_agent_transcript_event_identity_sequence'",
+          )
+          .get(),
+      ).toBeUndefined();
+      expect(
+        rejected
+          .prepare(
+            "SELECT name FROM sqlite_schema WHERE type = 'index' AND name = 'idx_test_participant_dependency'",
+          )
+          .get(),
+      ).toEqual({ name: "idx_test_participant_dependency" });
+    } finally {
+      rejected.close();
+    }
+  });
+});

--- a/src/infra/state-migrations.media-persistence.additive-schema.test.ts
+++ b/src/infra/state-migrations.media-persistence.additive-schema.test.ts
@@ -1,8 +1,5 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
-import { AGENT_MEDIA_SCHEMA_VERSION } from "../state/openclaw-agent-db-contract.js";
-import * as agentDatabaseLease from "../state/openclaw-agent-db-lease.js";
-import * as sessionMigrations from "../state/openclaw-agent-db-session-migrations.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   OPENCLAW_AGENT_SCHEMA_VERSION,
@@ -14,7 +11,9 @@ import { migrateLegacyMediaPersistence } from "./state-migrations.media-persiste
 
 const tempDirs: string[] = [];
 
-function createV17AdditiveFixture(options: { schemaDrift?: "missing-cache-table" } = {}) {
+function createV17AdditiveFixture(
+  options: { schemaDrift?: "missing-cache-table" | "participant-dependency" } = {},
+) {
   const stateDir = makeTempDir(tempDirs, "media-persistence-v17-additive-");
   const env = { OPENCLAW_STATE_DIR: stateDir };
   const opened = openOpenClawAgentDatabase({ agentId: "main", env });
@@ -32,6 +31,22 @@ function createV17AdditiveFixture(options: { schemaDrift?: "missing-cache-table"
     PRAGMA user_version = 17;
     UPDATE schema_meta SET schema_version = 17;
   `);
+  if (options.schemaDrift === "participant-dependency") {
+    database.exec(`
+      CREATE TABLE session_participants (
+        session_key TEXT NOT NULL,
+        actor_type TEXT NOT NULL,
+        actor_id TEXT NOT NULL,
+        actor_source TEXT,
+        contribution_count INTEGER,
+        first_prompted_at INTEGER NOT NULL,
+        last_prompted_at INTEGER NOT NULL,
+        PRIMARY KEY (session_key, actor_type, actor_id),
+        FOREIGN KEY (session_key) REFERENCES session_nodes(session_key) ON DELETE CASCADE
+      ) STRICT;
+      CREATE INDEX idx_test_participant_dependency ON session_participants(actor_id);
+    `);
+  }
   if (options.schemaDrift === "missing-cache-table") {
     database.exec("DROP TABLE cache_entries;");
   }
@@ -41,8 +56,6 @@ function createV17AdditiveFixture(options: { schemaDrift?: "missing-cache-table"
 
 describe("legacy media persistence additive schema repair", () => {
   afterEach(() => {
-    vi.useRealTimers();
-    vi.restoreAllMocks();
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
     cleanupTempDirs(tempDirs);
@@ -135,164 +148,21 @@ describe("legacy media persistence additive schema repair", () => {
     }
   });
 
-  it("renews maintenance before the v17 validity projection preflight", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
-    const stateDir = makeTempDir(tempDirs, "media-persistence-v17-lease-renewal-");
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    const opened = openOpenClawAgentDatabase({ agentId: "main", env });
-    const databasePath = opened.path;
-    opened.db
-      .prepare(
-        `INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at)
-         VALUES (?, ?, ?, ?)`,
-      )
-      .run(
-        "agent:main:v17-lease-renewal",
-        "v17-lease-renewal",
-        JSON.stringify({ sessionId: "v17-lease-renewal", updatedAt: 1 }),
-        1,
-      );
-    closeOpenClawAgentDatabasesForTest();
-    closeOpenClawStateDatabaseForTest();
-
-    const { DatabaseSync } = requireNodeSqlite();
-    const database = new DatabaseSync(databasePath);
-    try {
-      database.exec(`
-        DROP TABLE session_participants;
-        DROP TRIGGER session_conversations_route_context_invalidate_after_update;
-        DROP INDEX idx_agent_session_conversations_conversation;
-        ALTER TABLE session_conversations DROP COLUMN route_context_json;
-        DROP TRIGGER session_nodes_entry_valid_after_insert;
-        DROP TRIGGER session_nodes_entry_valid_after_entry_update;
-        DROP TRIGGER session_nodes_entry_valid_after_identity_update;
-        DROP INDEX idx_agent_session_nodes_entry_valid_pending;
-        DROP TABLE session_key_contract;
-        ALTER TABLE session_nodes DROP COLUMN entry_valid;
-        PRAGMA user_version = ${AGENT_MEDIA_SCHEMA_VERSION};
-        UPDATE schema_meta
-           SET schema_version = ${AGENT_MEDIA_SCHEMA_VERSION}
-         WHERE meta_key = 'primary';
-      `);
-    } finally {
-      database.close();
-    }
-
-    const events: string[] = [];
-    const originalAuthorityCheck = agentDatabaseLease.assertAgentDatabaseMaintenanceAuthority;
-    let firstAuthorityCheck = true;
-    vi.spyOn(agentDatabaseLease, "assertAgentDatabaseMaintenanceAuthority").mockImplementation(
-      () => {
-        originalAuthorityCheck();
-        if (firstAuthorityCheck) {
-          firstAuthorityCheck = false;
-          // Leave less than one lease interval before the v17 preflight starts.
-          vi.setSystemTime(Date.now() + 59_000);
-        }
-      },
-    );
-    const originalRenew = agentDatabaseLease.renewAgentDatabaseMaintenanceAuthorityIfPresent;
-    vi.spyOn(
-      agentDatabaseLease,
-      "renewAgentDatabaseMaintenanceAuthorityIfPresent",
-    ).mockImplementation(() => {
-      events.push("renew");
-      originalRenew();
+  it("rolls back v17 preflight repairs when identity migration rejects drift", async () => {
+    const { databasePath, env } = createV17AdditiveFixture({
+      schemaDrift: "participant-dependency",
     });
-    const originalProjection = sessionMigrations.ensureSessionEntryValidityProjection;
-    let projectionCalls = 0;
-    vi.spyOn(sessionMigrations, "ensureSessionEntryValidityProjection").mockImplementation((db) => {
-      projectionCalls += 1;
-      if (projectionCalls === 1) {
-        events.push("v17-preflight");
-        // The real projection is synchronous, so the heartbeat cannot run here.
-        vi.setSystemTime(Date.now() + 2_000);
-      }
-      originalProjection(db);
-    });
-
-    const result = await migrateLegacyMediaPersistence({ env });
-
-    expect(result.warnings).toEqual([]);
-    expect(events.slice(0, 2)).toEqual(["renew", "v17-preflight"]);
-    expect(projectionCalls).toBeGreaterThanOrEqual(1);
-    closeOpenClawAgentDatabasesForTest();
-    const repaired = new DatabaseSync(databasePath, { readOnly: true });
-    try {
-      expect(repaired.prepare("PRAGMA user_version").get()).toEqual({
-        user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
-      });
-      expect(
-        repaired
-          .prepare("SELECT entry_valid FROM session_nodes WHERE session_key = ?")
-          .get("agent:main:v17-lease-renewal"),
-      ).toEqual({ entry_valid: 1 });
-    } finally {
-      repaired.close();
-    }
-  });
-
-  it("rolls back v17 additive preflight when canonical validation rejects drift", async () => {
-    const stateDir = makeTempDir(tempDirs, "media-persistence-v17-rollback-");
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    const opened = openOpenClawAgentDatabase({ agentId: "main", env });
-    const databasePath = opened.path;
-    opened.db
-      .prepare(
-        `INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at)
-         VALUES (?, ?, ?, ?)`,
-      )
-      .run(
-        "agent:main:v17-rollback",
-        "v17-rollback",
-        JSON.stringify({ sessionId: "v17-rollback", updatedAt: 1 }),
-        1,
-      );
-    opened.db
-      .prepare(
-        `INSERT INTO session_windows (
-           session_id, session_key, created_at, updated_at
-         ) VALUES (?, ?, ?, ?)`,
-      )
-      .run("v17-rollback", "agent:main:v17-rollback", 1, 1);
-    closeOpenClawAgentDatabasesForTest();
-    closeOpenClawStateDatabaseForTest();
-
     const { DatabaseSync } = requireNodeSqlite();
-    const database = new DatabaseSync(databasePath);
-    try {
-      database.exec(`
-        DROP TABLE session_participants;
-        DROP TRIGGER session_conversations_route_context_invalidate_after_update;
-        DROP INDEX idx_agent_session_conversations_conversation;
-        ALTER TABLE session_conversations DROP COLUMN route_context_json;
-        DROP TRIGGER session_nodes_entry_valid_after_insert;
-        DROP TRIGGER session_nodes_entry_valid_after_entry_update;
-        DROP TRIGGER session_nodes_entry_valid_after_identity_update;
-        DROP INDEX idx_agent_session_nodes_entry_valid_pending;
-        DROP TABLE session_key_contract;
-        ALTER TABLE session_nodes DROP COLUMN entry_valid;
-        CREATE UNIQUE INDEX idx_test_unexpected_v17 ON session_windows(session_id);
-        PRAGMA user_version = ${AGENT_MEDIA_SCHEMA_VERSION};
-        UPDATE schema_meta
-           SET schema_version = ${AGENT_MEDIA_SCHEMA_VERSION}
-         WHERE meta_key = 'primary';
-      `);
-    } finally {
-      database.close();
-    }
-
     const result = await migrateLegacyMediaPersistence({ env });
     expect(result.warnings).toHaveLength(1);
-    expect(result.warnings[0]).toContain("unexpected unique index");
+    expect(result.warnings[0]).toContain(
+      "Participant migration cannot rebuild unknown indexes, views, or triggers",
+    );
     closeOpenClawAgentDatabasesForTest();
 
     const rolledBack = new DatabaseSync(databasePath, { readOnly: true });
     try {
-      expect(rolledBack.prepare("PRAGMA user_version").get()).toEqual({
-        user_version: AGENT_MEDIA_SCHEMA_VERSION,
-      });
+      expect(rolledBack.prepare("PRAGMA user_version").get()).toEqual({ user_version: 17 });
       expect(
         rolledBack
           .prepare("SELECT name FROM pragma_table_info('session_conversations') WHERE name = ?")
@@ -305,14 +175,14 @@ describe("legacy media persistence additive schema repair", () => {
       ).toBeUndefined();
       expect(
         rolledBack
-          .prepare("SELECT name FROM pragma_table_info('session_nodes') WHERE name = ?")
-          .get("entry_valid"),
+          .prepare("SELECT name FROM sqlite_schema WHERE type = 'index' AND name = ?")
+          .get("idx_agent_transcript_event_identity_sequence"),
       ).toBeUndefined();
       expect(
         rolledBack
-          .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
-          .get("session_key_contract"),
-      ).toBeUndefined();
+          .prepare("SELECT name FROM sqlite_schema WHERE type = 'index' AND name = ?")
+          .get("idx_test_participant_dependency"),
+      ).toEqual({ name: "idx_test_participant_dependency" });
     } finally {
       rolledBack.close();
     }

--- a/src/infra/state-migrations.media-persistence.additive-schema.test.ts
+++ b/src/infra/state-migrations.media-persistence.additive-schema.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { AGENT_MEDIA_SCHEMA_VERSION } from "../state/openclaw-agent-db-contract.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   OPENCLAW_AGENT_SCHEMA_VERSION,
@@ -127,6 +128,91 @@ describe("legacy media persistence additive schema repair", () => {
       ).toEqual({ name: "idx_agent_transcript_event_identity_sequence" });
     } finally {
       repaired.close();
+    }
+  });
+
+  it("rolls back v17 additive preflight when canonical validation rejects drift", async () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-v17-rollback-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const opened = openOpenClawAgentDatabase({ agentId: "main", env });
+    const databasePath = opened.path;
+    opened.db
+      .prepare(
+        `INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at)
+         VALUES (?, ?, ?, ?)`,
+      )
+      .run(
+        "agent:main:v17-rollback",
+        "v17-rollback",
+        JSON.stringify({ sessionId: "v17-rollback", updatedAt: 1 }),
+        1,
+      );
+    opened.db
+      .prepare(
+        `INSERT INTO session_windows (
+           session_id, session_key, created_at, updated_at
+         ) VALUES (?, ?, ?, ?)`,
+      )
+      .run("v17-rollback", "agent:main:v17-rollback", 1, 1);
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    try {
+      database.exec(`
+        DROP TABLE session_participants;
+        DROP TRIGGER session_conversations_route_context_invalidate_after_update;
+        DROP INDEX idx_agent_session_conversations_conversation;
+        ALTER TABLE session_conversations DROP COLUMN route_context_json;
+        DROP TRIGGER session_nodes_entry_valid_after_insert;
+        DROP TRIGGER session_nodes_entry_valid_after_entry_update;
+        DROP TRIGGER session_nodes_entry_valid_after_identity_update;
+        DROP INDEX idx_agent_session_nodes_entry_valid_pending;
+        DROP TABLE session_key_contract;
+        ALTER TABLE session_nodes DROP COLUMN entry_valid;
+        CREATE UNIQUE INDEX idx_test_unexpected_v17 ON session_windows(session_id);
+        PRAGMA user_version = ${AGENT_MEDIA_SCHEMA_VERSION};
+        UPDATE schema_meta
+           SET schema_version = ${AGENT_MEDIA_SCHEMA_VERSION}
+         WHERE meta_key = 'primary';
+      `);
+    } finally {
+      database.close();
+    }
+
+    const result = await migrateLegacyMediaPersistence({ env });
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain("unexpected unique index");
+    closeOpenClawAgentDatabasesForTest();
+
+    const rolledBack = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(rolledBack.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: AGENT_MEDIA_SCHEMA_VERSION,
+      });
+      expect(
+        rolledBack
+          .prepare("SELECT name FROM pragma_table_info('session_conversations') WHERE name = ?")
+          .get("route_context_json"),
+      ).toBeUndefined();
+      expect(
+        rolledBack
+          .prepare("SELECT name FROM sqlite_schema WHERE type = 'trigger' AND name = ?")
+          .get("session_conversations_route_context_invalidate_after_update"),
+      ).toBeUndefined();
+      expect(
+        rolledBack
+          .prepare("SELECT name FROM pragma_table_info('session_nodes') WHERE name = ?")
+          .get("entry_valid"),
+      ).toBeUndefined();
+      expect(
+        rolledBack
+          .prepare("SELECT name FROM sqlite_schema WHERE type = 'table' AND name = ?")
+          .get("session_key_contract"),
+      ).toBeUndefined();
+    } finally {
+      rolledBack.close();
     }
   });
 

--- a/src/infra/state-migrations.media-persistence.additive-schema.test.ts
+++ b/src/infra/state-migrations.media-persistence.additive-schema.test.ts
@@ -1,6 +1,8 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import { AGENT_MEDIA_SCHEMA_VERSION } from "../state/openclaw-agent-db-contract.js";
+import * as agentDatabaseLease from "../state/openclaw-agent-db-lease.js";
+import * as sessionMigrations from "../state/openclaw-agent-db-session-migrations.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   OPENCLAW_AGENT_SCHEMA_VERSION,
@@ -39,6 +41,8 @@ function createV17AdditiveFixture(options: { schemaDrift?: "missing-cache-table"
 
 describe("legacy media persistence additive schema repair", () => {
   afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
     closeOpenClawAgentDatabasesForTest();
     closeOpenClawStateDatabaseForTest();
     cleanupTempDirs(tempDirs);
@@ -126,6 +130,104 @@ describe("legacy media persistence additive schema repair", () => {
           )
           .get(),
       ).toEqual({ name: "idx_agent_transcript_event_identity_sequence" });
+    } finally {
+      repaired.close();
+    }
+  });
+
+  it("renews maintenance before the v17 validity projection preflight", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00Z"));
+    const stateDir = makeTempDir(tempDirs, "media-persistence-v17-lease-renewal-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const opened = openOpenClawAgentDatabase({ agentId: "main", env });
+    const databasePath = opened.path;
+    opened.db
+      .prepare(
+        `INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at)
+         VALUES (?, ?, ?, ?)`,
+      )
+      .run(
+        "agent:main:v17-lease-renewal",
+        "v17-lease-renewal",
+        JSON.stringify({ sessionId: "v17-lease-renewal", updatedAt: 1 }),
+        1,
+      );
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(databasePath);
+    try {
+      database.exec(`
+        DROP TABLE session_participants;
+        DROP TRIGGER session_conversations_route_context_invalidate_after_update;
+        DROP INDEX idx_agent_session_conversations_conversation;
+        ALTER TABLE session_conversations DROP COLUMN route_context_json;
+        DROP TRIGGER session_nodes_entry_valid_after_insert;
+        DROP TRIGGER session_nodes_entry_valid_after_entry_update;
+        DROP TRIGGER session_nodes_entry_valid_after_identity_update;
+        DROP INDEX idx_agent_session_nodes_entry_valid_pending;
+        DROP TABLE session_key_contract;
+        ALTER TABLE session_nodes DROP COLUMN entry_valid;
+        PRAGMA user_version = ${AGENT_MEDIA_SCHEMA_VERSION};
+        UPDATE schema_meta
+           SET schema_version = ${AGENT_MEDIA_SCHEMA_VERSION}
+         WHERE meta_key = 'primary';
+      `);
+    } finally {
+      database.close();
+    }
+
+    const events: string[] = [];
+    const originalAuthorityCheck = agentDatabaseLease.assertAgentDatabaseMaintenanceAuthority;
+    let firstAuthorityCheck = true;
+    vi.spyOn(agentDatabaseLease, "assertAgentDatabaseMaintenanceAuthority").mockImplementation(
+      () => {
+        originalAuthorityCheck();
+        if (firstAuthorityCheck) {
+          firstAuthorityCheck = false;
+          // Leave less than one lease interval before the v17 preflight starts.
+          vi.setSystemTime(Date.now() + 59_000);
+        }
+      },
+    );
+    const originalRenew = agentDatabaseLease.renewAgentDatabaseMaintenanceAuthorityIfPresent;
+    vi.spyOn(
+      agentDatabaseLease,
+      "renewAgentDatabaseMaintenanceAuthorityIfPresent",
+    ).mockImplementation(() => {
+      events.push("renew");
+      originalRenew();
+    });
+    const originalProjection = sessionMigrations.ensureSessionEntryValidityProjection;
+    let projectionCalls = 0;
+    vi.spyOn(sessionMigrations, "ensureSessionEntryValidityProjection").mockImplementation((db) => {
+      projectionCalls += 1;
+      if (projectionCalls === 1) {
+        events.push("v17-preflight");
+        // The real projection is synchronous, so the heartbeat cannot run here.
+        vi.setSystemTime(Date.now() + 2_000);
+      }
+      originalProjection(db);
+    });
+
+    const result = await migrateLegacyMediaPersistence({ env });
+
+    expect(result.warnings).toEqual([]);
+    expect(events.slice(0, 2)).toEqual(["renew", "v17-preflight"]);
+    expect(projectionCalls).toBeGreaterThanOrEqual(1);
+    closeOpenClawAgentDatabasesForTest();
+    const repaired = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(repaired.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+      });
+      expect(
+        repaired
+          .prepare("SELECT entry_valid FROM session_nodes WHERE session_key = ?")
+          .get("agent:main:v17-lease-renewal"),
+      ).toEqual({ entry_valid: 1 });
     } finally {
       repaired.close();
     }

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -7,10 +7,7 @@ import {
   hasLegacyMemoryRecallMetadataColumns,
   MEMORY_PATH_FTS_TRIGGER_DEFINITIONS,
 } from "../../packages/memory-host-sdk/src/host/memory-schema.js";
-import {
-  repairCanonicalSqliteIndexes,
-  verifyAndRepairCanonicalSqliteIndexes,
-} from "../infra/sqlite-index-schema.js";
+import { repairCanonicalSqliteIndexes } from "../infra/sqlite-index-schema.js";
 import {
   assertSqliteSchemaContains,
   assertSqliteSchemaTablesPresent,
@@ -39,10 +36,7 @@ import {
 } from "./openclaw-agent-db-session-migrations.js";
 import { SESSION_GOAL_OPERATIONS_TABLE } from "./openclaw-agent-goal-operations-schema.js";
 import { MESSAGE_TOOL_RUN_OUTCOMES_TABLE } from "./openclaw-agent-message-tool-outcome-schema.js";
-import {
-  LEGACY_PARTICIPANT_OPTIONAL_COLUMNS,
-  withLegacySessionParticipantsSchema,
-} from "./openclaw-agent-participants-migration.js";
+import { LEGACY_PARTICIPANT_OPTIONAL_COLUMNS } from "./openclaw-agent-participants-migration.js";
 import { SESSION_PENDING_INPUTS_TABLE } from "./openclaw-agent-pending-inputs-schema.js";
 import {
   ensureOpenClawAgentProgressCardSchemaInTransaction,
@@ -381,30 +375,6 @@ export function assertAgentSchemaVersion(
     schemaSql,
     options.version < 18 ? "legacy" : "current",
   );
-}
-
-/** Keep v17 additive convergence and legacy validation inside one migration transaction. */
-export function ensureOpenClawAgentV17MediaPreflightInTransaction(
-  db: DatabaseSync,
-  options: { agentId: string; pathname: string },
-): void {
-  const legacyMediaSchemaSql = withLegacySessionParticipantsSchema(OPENCLAW_AGENT_SCHEMA_SQL);
-  ensureSessionAdditiveColumns(db);
-  ensureSessionEntryValidityProjection(db);
-  ensureSessionKeyContractSchemaInTransaction(db);
-  verifyAndRepairCanonicalSqliteIndexes(db, options.pathname, legacyMediaSchemaSql, {
-    allowMissingColumns: true,
-    validateAfterRepair: () =>
-      assertAgentSchemaVersion(
-        db,
-        {
-          agentId: options.agentId,
-          pathname: options.pathname,
-          version: AGENT_MEDIA_SCHEMA_VERSION,
-        },
-        legacyMediaSchemaSql,
-      ),
-  });
 }
 
 function hasLegacyMemoryChunkProvenanceTrigger(db: DatabaseSync): boolean {

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -7,7 +7,10 @@ import {
   hasLegacyMemoryRecallMetadataColumns,
   MEMORY_PATH_FTS_TRIGGER_DEFINITIONS,
 } from "../../packages/memory-host-sdk/src/host/memory-schema.js";
-import { repairCanonicalSqliteIndexes } from "../infra/sqlite-index-schema.js";
+import {
+  repairCanonicalSqliteIndexes,
+  verifyAndRepairCanonicalSqliteIndexes,
+} from "../infra/sqlite-index-schema.js";
 import {
   assertSqliteSchemaContains,
   assertSqliteSchemaTablesPresent,
@@ -36,7 +39,10 @@ import {
 } from "./openclaw-agent-db-session-migrations.js";
 import { SESSION_GOAL_OPERATIONS_TABLE } from "./openclaw-agent-goal-operations-schema.js";
 import { MESSAGE_TOOL_RUN_OUTCOMES_TABLE } from "./openclaw-agent-message-tool-outcome-schema.js";
-import { LEGACY_PARTICIPANT_OPTIONAL_COLUMNS } from "./openclaw-agent-participants-migration.js";
+import {
+  LEGACY_PARTICIPANT_OPTIONAL_COLUMNS,
+  withLegacySessionParticipantsSchema,
+} from "./openclaw-agent-participants-migration.js";
 import { SESSION_PENDING_INPUTS_TABLE } from "./openclaw-agent-pending-inputs-schema.js";
 import {
   ensureOpenClawAgentProgressCardSchemaInTransaction,
@@ -375,6 +381,30 @@ export function assertAgentSchemaVersion(
     schemaSql,
     options.version < 18 ? "legacy" : "current",
   );
+}
+
+/** Keep v17 additive convergence and legacy validation inside one migration transaction. */
+export function ensureOpenClawAgentV17MediaPreflightInTransaction(
+  db: DatabaseSync,
+  options: { agentId: string; pathname: string },
+): void {
+  const legacyMediaSchemaSql = withLegacySessionParticipantsSchema(OPENCLAW_AGENT_SCHEMA_SQL);
+  ensureSessionAdditiveColumns(db);
+  ensureSessionEntryValidityProjection(db);
+  ensureSessionKeyContractSchemaInTransaction(db);
+  verifyAndRepairCanonicalSqliteIndexes(db, options.pathname, legacyMediaSchemaSql, {
+    allowMissingColumns: true,
+    validateAfterRepair: () =>
+      assertAgentSchemaVersion(
+        db,
+        {
+          agentId: options.agentId,
+          pathname: options.pathname,
+          version: AGENT_MEDIA_SCHEMA_VERSION,
+        },
+        legacyMediaSchemaSql,
+      ),
+  });
 }
 
 function hasLegacyMemoryChunkProvenanceTrigger(db: DatabaseSync): boolean {

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -41,7 +41,6 @@ import {
   migrateRetiredAgentStateLeaseSchema,
   migratedSessionColumn,
   ensureSessionKeyContractSchemaInTransaction,
-  ensureOpenClawAgentV17MediaPreflightInTransaction,
   readExistingAgentSchemaMeta,
   repairAndAssertOpenClawAgentV14SchemaForMigration,
 } from "./openclaw-agent-db-schema-helpers.js";
@@ -585,11 +584,20 @@ function ensureAgentSchema(
           `OpenClaw agent database ${pathname} uses schema version ${previousVersion}; expected at most ${targetVersion} for this migration.`,
         );
       }
-      migrateRetiredAgentStateLeaseSchema(db, pathname, targetVersion);
       if (previousVersion === AGENT_MEDIA_SCHEMA_VERSION) {
-        maintenanceAuthority.renewAgentDatabaseMaintenanceAuthorityIfPresent();
-        ensureOpenClawAgentV17MediaPreflightInTransaction(db, { agentId, pathname });
+        const legacySql = withLegacySessionParticipantsSchema(OPENCLAW_AGENT_SCHEMA_SQL);
+        ensureSessionAdditiveColumns(db);
+        verifyAndRepairCanonicalSqliteIndexes(db, pathname, legacySql, {
+          validateAfterRepair: () => {
+            assertAgentSchemaVersion(
+              db,
+              { agentId, pathname, version: AGENT_MEDIA_SCHEMA_VERSION },
+              legacySql,
+            );
+          },
+        });
       }
+      migrateRetiredAgentStateLeaseSchema(db, pathname, targetVersion);
       if (previousVersion === targetVersion) {
         ensureSessionAdditiveColumns(db);
         ensureSessionEntryValidityProjection(db);
@@ -714,7 +722,9 @@ export function ensureOpenClawAgentDatabaseSchema(
   db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
   assertSupportedAgentSchemaVersion(db, pathname);
   assertExistingAgentSchemaOwner(readExistingAgentSchemaMeta(db), agentId, pathname);
-  assertAgentDatabaseIntegrityBeforeMutation(db, agentId, pathname);
+  if (readSqliteUserVersion(db) !== AGENT_MEDIA_SCHEMA_VERSION) {
+    assertAgentDatabaseIntegrityBeforeMutation(db, agentId, pathname);
+  }
   configureSqlitePreSchemaPragmas(db, {
     busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   });

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -41,6 +41,7 @@ import {
   migrateRetiredAgentStateLeaseSchema,
   migratedSessionColumn,
   ensureSessionKeyContractSchemaInTransaction,
+  ensureOpenClawAgentV17MediaPreflightInTransaction,
   readExistingAgentSchemaMeta,
   repairAndAssertOpenClawAgentV14SchemaForMigration,
 } from "./openclaw-agent-db-schema-helpers.js";
@@ -585,6 +586,9 @@ function ensureAgentSchema(
         );
       }
       migrateRetiredAgentStateLeaseSchema(db, pathname, targetVersion);
+      if (previousVersion === AGENT_MEDIA_SCHEMA_VERSION) {
+        ensureOpenClawAgentV17MediaPreflightInTransaction(db, { agentId, pathname });
+      }
       if (previousVersion === targetVersion) {
         ensureSessionAdditiveColumns(db);
         ensureSessionEntryValidityProjection(db);
@@ -709,22 +713,6 @@ export function ensureOpenClawAgentDatabaseSchema(
   db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
   assertSupportedAgentSchemaVersion(db, pathname);
   assertExistingAgentSchemaOwner(readExistingAgentSchemaMeta(db), agentId, pathname);
-  if (readSqliteUserVersion(db) === AGENT_MEDIA_SCHEMA_VERSION) {
-    maintenanceAuthority.assertAgentDatabaseMaintenanceAuthority();
-    const legacySql = withLegacySessionParticipantsSchema(OPENCLAW_AGENT_SCHEMA_SQL);
-    verifyAndRepairCanonicalSqliteIndexes(db, pathname, legacySql, {
-      allowMissingColumns: true,
-      validateAfterRepair: () => {
-        // Share the savepoint so schema drift rolls back additive and index repairs together.
-        ensureSessionAdditiveColumns(db);
-        assertAgentSchemaVersion(
-          db,
-          { agentId, pathname, version: AGENT_MEDIA_SCHEMA_VERSION },
-          legacySql,
-        );
-      },
-    });
-  }
   assertAgentDatabaseIntegrityBeforeMutation(db, agentId, pathname);
   configureSqlitePreSchemaPragmas(db, {
     busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -587,6 +587,7 @@ function ensureAgentSchema(
       }
       migrateRetiredAgentStateLeaseSchema(db, pathname, targetVersion);
       if (previousVersion === AGENT_MEDIA_SCHEMA_VERSION) {
+        maintenanceAuthority.renewAgentDatabaseMaintenanceAuthorityIfPresent();
         ensureOpenClawAgentV17MediaPreflightInTransaction(db, { agentId, pathname });
       }
       if (previousVersion === targetVersion) {


### PR DESCRIPTION
## What Problem This Solves

Schema-17 repair was not atomic after #134208. Doctor repaired missing additive session objects and a canonical index before the main schema migration transaction began. If the later participant identity migration rejected an unknown dependency, the database stayed at version 17 but retained those prerequisite writes.

Related to #134163 and follows #134208.

## Why This Change Was Made

The schema owner now performs the v17 additive and canonical-index preflight inside the existing immediate migration transaction. A later migration rejection rolls back the whole attempt, while the preflight can still recover a damaged canonical index before strict integrity admission.

The regression uses a valid legacy participant table with an unknown non-unique dependency. Current main accepts and commits the prerequisite repair, then rejects the participant migration. The repaired head rejects the same database without leaving the route column, trigger, or repaired index behind.

The final diff also removes the one-use exported helper and the call-order lease test. Production is net-negative and the test now fails on pre-fix code for the intended reason.

## User Impact

`openclaw doctor --fix` still upgrades repairable schema-17 databases to schema 19. If later validation rejects a database, Doctor now leaves its schema unchanged instead of committing a partial repair.

## Evidence

- Current-main red at `c50533f9d944e7cced59c650b426d3ea18dfc7d0`: the focused regression failed because `route_context_json` remained present after the participant migration rejection.
- Exact-head green at `7e8b26722634ae730b1a1c62ef09f5882a7f00a3`: sanitized clean Linux proof passed the v17 migration, participant recovery, retired-lease, and full Doctor process suites — 34 tests.
- Doctor boundary: both the repairable-v17 and rejected-v17 `openclaw doctor --fix` process paths passed.
- Production-entrypoint anti-cheat probe: `migrateLegacyMediaPersistence` produced the same atomic rollback for `main` and a varied `secondary` agent id.
- Static proof: Oxfmt, Oxlint, and `git diff --check` passed. Production `+15/-16` (net `-1`); tests and test support `+193/-26` (net `+167`).

AI-assisted: built with Codex
