### PR TITLE
test(tooling): remove delayed activity fixture responses

### DIFF
--- a/test/scripts/github-activity-helper.test.ts
+++ b/test/scripts/github-activity-helper.test.ts
@@ -13,7 +13,7 @@ const helperPath = path.join(
 const { createTempDir } = createScriptTestHarness();
 
 type Fixture = {
-  blockActivity?: boolean;
+  timeoutActivity?: boolean;
   now?: string;
   profile?: unknown;
   search?: unknown[];
@@ -57,7 +57,7 @@ if body=$(jq -cn --slurpfile fixtures "$FIXTURE" --slurpfile requests "$REQUEST_
   $fixtures[0] as $fixture | $ARGS.positional as $args |
   if any($fixture.fail[]?; . as $needle | any($args[]; contains($needle))) then
     null | halt_error(1)
-  elif $fixture.blockActivity and $args[0] == "api" and ($args[1] | startswith("users/") | not) then
+  elif $fixture.timeoutActivity and $args[0] == "api" and ($args[1] | startswith("users/") | not) then
     null | halt_error(124)
   elif $args[0] == "api" and ($args[1] | startswith("users/")) then
     if $fixture | has("profile") then $fixture.profile else
@@ -90,8 +90,6 @@ if body=$(jq -cn --slurpfile fixtures "$FIXTURE" --slurpfile requests "$REQUEST_
   fi
 else
   response_code=$?
-  # Bound the blocked-scan reproduction without network or a surviving child process.
-  if [[ "$response_code" == 124 ]]; then sleep 0.5; fi
   exit "$response_code"
 fi
 `,
@@ -132,8 +130,8 @@ fi
 }
 
 describe("openclaw-pr-maintainer github activity helper", () => {
-  it("prints canonical identity before the first activity request, even when a scan blocks", () => {
-    const { requests } = runHelper(["alias"], { blockActivity: true });
+  it("prints canonical identity before the first activity request returns a timeout", () => {
+    const { requests } = runHelper(["alias"], { timeoutActivity: true });
     expect(requiredAt(requests, 0).args[1]).toBe("users/alias");
     expect(requiredAt(requests, 1).output).toContain(
       "Example Author (@Canonical, User, account created 2010-09-21",


### PR DESCRIPTION
## What Problem This Solves

The GitHub activity helper's output-order regression waits through three artificial 500 ms sleeps after its fake CLI has already captured the output it asserts.

## Why This Change Was Made

Return the existing timeout response immediately. The fake CLI still uses real jq to snapshot stdout before processing each request, so the first activity request independently proves canonical identity was already printed. Rename the fixture and case to describe the timeout response rather than elapsed blocking time.

All 22 cases, exit codes, real Bash/jq execution, output capture, request logging, and the five-second child-process bound remain unchanged.

## User Impact

Remove 1.5 seconds of intentional sleeps from this suite without weakening its ordering proof. Production tooling is unchanged.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/github-activity-helper.test.ts` passed all 22 tests before and after.
- The output-order case measured 2,052.17 ms before and 351.66 ms after locally. This is a local case measurement, not a CI-wide benchmark.
- Full changed-file checks, formatting, diff checks, and structured Codex autoreview passed.
- The request-side stdout snapshot still fails if identity is printed after activity begins. Offline fixture proof makes no claim about live GitHub network timeout behavior.
- Production +0/-0; tests +4/-6.
