### PR TITLE
fix(ui): retain real-Gateway browser proof across reruns

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -616,12 +616,21 @@ automatically track arbitrary detached work or replace native test-timeout owner
 Other Gateway subsystems can retain documented bounded shutdown behavior, so close
 is not a guarantee of universal subsystem or descendant-process quiescence.
 
-### Retained mocked Control UI proof
+<a id="retained-mocked-control-ui-proof" />
+
+### Retained Control UI proof
 
 For startup ownership changes, exercise authenticated hello before browser recovery migration finishes. Project and environment discovery can start from hello; migration completion must not refetch those catalogs or invalidate an admitted start. Keep changed-owner, process-restart, and late-result fences covered separately. Count storage reads by key around rerenders, typing, and streaming without recording credential values. Compare route payload bytes and loaded module closures separately from timings; CSS ownership changes also need retained screenshots and computed-style or geometry checks across New session and Chat.
 
-Ordinary mocked browser screenshots, recordings, and reports use fresh directories
-for each test attempt or standalone capture invocation. The Node-only
+Migrated mocked and real-Gateway browser proof uses fresh retained directories.
+Scenario captures using `suite.artifactDir`, including Logs and Usage, allocate
+lazily per test attempt; standalone captures allocate per invocation. MCP
+conformance and auth transports each allocate one suite-owned directory after the
+browser-availability check, even when media capture is disabled. Auth transport
+screenshots wait for meaningful content and the presentation owner's finite
+entrance or resize animations, while perpetual descendant activity continues.
+The shared agent-file capture helper allocates once per module evaluation when
+capture is enabled, sharing that directory across the module's scenarios. The Node-only
 `createControlUiE2eArtifactDir(scope, parentDir?)` helper in
 `ui/src/test-helpers/control-ui-e2e-artifacts.ts` prints the actual allocated path.
 An explicit parent wins; otherwise it uses the trimmed existing
@@ -632,9 +641,10 @@ controls preserve the basename and print the relocated path.
 
 Keep capture gates independent from allocation: `OPENCLAW_CAPTURE_UI_PROOF`,
 `OPENCLAW_UI_E2E_RECORD`, and output-presence gates retain their existing meanings.
-Allocate during scenario execution or `beforeEach`, and pass the same owner to
-shared capture helpers so screenshots, reports, and video stay together. Distinguish
-stage names within an attempt. Close the browser context before finalizing video.
+For per-attempt captures, allocate during scenario execution or `beforeEach`.
+Pass the same owner to shared capture helpers so screenshots, reports, and video
+stay together. Distinguish stage names within an attempt. Close the browser context
+before finalizing video.
 
 Successful and failed evidence is retained. Cleanup is manual: remove only exact
 directories that you own and have finished reviewing. Never recursively delete
@@ -653,14 +663,8 @@ Mantis allocates an invocation directory for setup logs,
 capture attempts, and its report; the builder preserves each attempt's relative
 paths and refuses to overwrite an existing report.
 
-The real-Gateway auth transport suite also allocates one fresh directory per
-suite invocation. Its screenshots wait for meaningful content and the presentation
-owner's finite entrance or resize animations, while perpetual descendant activity
-continues.
-
-Separate output owners remain: other real-Gateway suites, `chat-outbox-*`, and
-`chat-attachment-read-lifecycle`. Do not assume those owners have the ordinary
-mocked proof retention guarantee.
+Separate output owners remain, including `chat-attachment-read-lifecycle`.
+Do not assume unmigrated owners share this retention guarantee.
 
 ### Screenshots during Chromium recordings
 

--- a/ui/src/e2e/logs-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/logs-lifecycle.e2e.test.ts
@@ -22,10 +22,6 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.resolve(
-  process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim() || ".artifacts/control-ui-e2e",
-  "logs-lifecycle",
-);
 const viewport = { height: 900, width: 1_440 };
 
 function logLine(message: string, level: "error" | "info" | "warn", second: number) {
@@ -42,9 +38,8 @@ async function capture(page: Page, name: string) {
   if (!captureUiProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await writeFile(
-    path.join(proofDir, name),
+    path.join(suite.artifactDir, name),
     await takeControlUiViewportScreenshot(page, page.locator(".logs-card"), [
       page.locator(".log-message").first(),
     ]),
@@ -140,7 +135,7 @@ suite.define(() => {
             locale: "en-US",
             serviceWorkers: "block",
             viewport,
-            ...(captureUiProof ? { recordVideo: { dir: proofDir, size: viewport } } : {}),
+            ...(captureUiProof ? { recordVideo: { dir: suite.artifactDir, size: viewport } } : {}),
           },
           async ({ page }) => {
             const pageErrors: string[] = [];

--- a/ui/src/e2e/mcp-app-conformance.e2e.test.ts
+++ b/ui/src/e2e/mcp-app-conformance.e2e.test.ts
@@ -19,6 +19,7 @@ import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../../../src/test-utils/openclaw-test-state.ts";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { startControlUiE2eServer } from "../test-helpers/control-ui-e2e.ts";
 import {
   appHtml,
@@ -47,12 +48,7 @@ const { executablePath: chromiumExecutablePath } = inject("controlUiE2eChromium"
 const authValue = "test";
 const sessionKey = "agent:main:mcp-app-conformance";
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.resolve(
-  process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim() || ".artifacts/control-ui-e2e",
-  "mcp-app-request-lifetime",
-);
-const proofOptions = { proofDir, captureUiProof };
-const recordHost = recordMcpAppHost.bind(undefined, proofOptions);
+let proofDir: string;
 
 let state: OpenClawTestState | undefined;
 let gatewayStartup: ReturnType<typeof startGatewayServer> | undefined;
@@ -78,10 +74,12 @@ async function settleCleanup(step: string, cleanup: () => Promise<unknown>) {
   }
 }
 async function recordCleanup() {
-  await fs.writeFile(
-    path.join(proofDir, "cleanup.json"),
-    JSON.stringify({ failures, terminalAtMs: Date.now() }, null, 2),
-  );
+  if (proofDir) {
+    await fs.writeFile(
+      path.join(proofDir, "cleanup.json"),
+      JSON.stringify({ failures, terminalAtMs: Date.now() }, null, 2),
+    );
+  }
   expect(failures).toEqual([]);
 }
 
@@ -95,9 +93,8 @@ const suite = createControlUiE2eSuite({
   resources: {
     retainedState: () => state?.root,
     run: async (signal) => {
-      // Both tests share this artifact owner; never clear between their recordings.
-      await fs.rm(proofDir, { recursive: true, force: true });
-      await fs.mkdir(proofDir, { recursive: true });
+      // Both tests share retained reports even when screenshots and video are disabled.
+      proofDir = createControlUiE2eArtifactDir("mcp-app-request-lifetime");
       signal.throwIfAborted();
       state = await createOpenClawTestState({
         prefix: "openclaw-mcp-app-conformance-",
@@ -256,7 +253,6 @@ const suite = createControlUiE2eSuite({
         );
       }
       if (tempRoot) {
-        await fs.mkdir(proofDir, { recursive: true });
         await settleCleanup("archive fixture events", () =>
           fs.copyFile(fixtureEventsPath, path.join(proofDir, "fixture-events.jsonl")),
         );
@@ -288,9 +284,6 @@ suite.define(() => {
     await suite.runScenario(context, {
       run: async (signal) => {
         signal.throwIfAborted();
-        if (captureUiProof) {
-          await fs.mkdir(proofDir, { recursive: true });
-        }
         const teardownProof = createMcpAppTeardownRecorder(proofDir, fixtureEventsPath);
         const controlContext = await newProofContext();
         const controlPage = await controlContext.newPage();
@@ -572,7 +565,7 @@ suite.define(() => {
     await suite.runScenario(context, {
       run: async (signal) => {
         signal.throwIfAborted();
-        await fs.mkdir(proofDir, { recursive: true });
+        const recordHost = recordMcpAppHost.bind(undefined, { proofDir, captureUiProof });
         await fs.writeFile(
           path.join(proofDir, "runtime.json"),
           JSON.stringify(

--- a/ui/src/e2e/usage-sessions-owner-attribution.e2e.test.ts
+++ b/ui/src/e2e/usage-sessions-owner-attribution.e2e.test.ts
@@ -1,4 +1,3 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect, it } from "vitest";
@@ -18,10 +17,6 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const proofDir = path.resolve(
-  process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim() || ".artifacts/control-ui-e2e",
-  "usage-sessions-owner-attribution",
-);
 const viewport = { height: 900, width: 1_440 };
 
 const PROOF_SESSION_ID = "tg-dm-owner-attribution-proof";
@@ -32,11 +27,10 @@ async function capture(page: Page, name: string) {
   if (!captureUiProof) {
     return;
   }
-  await mkdir(proofDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,
-    path: path.join(proofDir, name),
+    path: path.join(suite.artifactDir, name),
   });
 }
 
@@ -179,10 +173,7 @@ suite.define(() => {
               await otherRow.waitFor();
               await expect.poll(() => otherRow.count()).toBe(1);
               await otherRow.scrollIntoViewIfNeeded();
-              await capture(
-                page,
-                resetCurrentSession ? "02-empty-current-family.png" : "01-same-id-owners.png",
-              );
+              await capture(page, "01-other-owner.png");
 
               // The named family stays visible before its new current instance has a transcript.
               const row = page.locator(`.session-bar-row[title="${PROOF_STORE_KEY}"]`);
@@ -201,10 +192,7 @@ suite.define(() => {
               await expect.poll(() => page.locator(".session-bar-row").count()).toBe(2);
 
               await row.scrollIntoViewIfNeeded();
-              await capture(
-                page,
-                resetCurrentSession ? "02-empty-current-family.png" : "01-same-id-owners.png",
-              );
+              await capture(page, "02-current-owner.png");
               expect(pageErrors).toEqual([]);
             },
           );


### PR DESCRIPTION
Related: [mocked Control UI proof retention](https://github.com/openclaw/openclaw/pull/133918). This is the separate real-Gateway consumer follow-up.

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled wherever applicable. This is a same-repository maintainer branch.

</details>

## What Problem This Solves

Repeated real-Gateway Control UI captures can overwrite previous evidence. MCP conformance clears a fixed shared directory, Logs writes repeated stages into a fixed directory, and Usage writes two owner views to the same screenshot name within a case.

## Why This Change Was Made

Reuse the canonical exclusive artifact allocator and the shared suite's existing lazy attempt owner rather than add another capture abstraction. Logs and Usage use `suite.artifactDir`; Usage gives its two stages distinct names. MCP allocates one retained suite directory after browser acquisition and keeps reports independent from optional media capture.

The current port preserves main's newer native fixture lifetime owner, joined startup/context teardown, viewport-safe Logs capture, parameterized native scenarios, current MCP cases, and diagnostic provenance documentation. The allocator, shared lifetime owner, fixtures, screenshot helper, assertions, deadlines, capture methods, and capture gates are unchanged relative to the pinned base. Auth retention/readiness and the module-owned agent-file helper are already on main and are not changed here. No active outbox code, branch, instance, or evidence is touched.

**Scope: four files, +34/−54 (net −20).** Tests: +16/−40. Docs: +18/−14. Production and shared-support changes: zero. No configuration, dependency declaration, protocol, SQLite schema, or release changes.

## User Impact

Developers retain separate captures across repeated attempts, with screenshots, recordings, and reports associated with the correct owner. This does not change end-user bot behavior or visual UI design. It does not recover deleted evidence or claim universal Gateway/subprocess quiescence.

## Evidence

Current candidate: [`f9227c19b4121bd9c80fd3a0149000394619fbd3`](https://github.com/openclaw/openclaw/commit/f9227c19b4121bd9c80fd3a0149000394619fbd3), based on `672adca9aa6f0fbc7d57926212fcbe777612381b`.

### Current source and CI

- Seven allocator regressions passed on Vitest 5, covering prior-file preservation, repeated names, concurrent allocation, parent precedence, and independent capture enablement.
- Pinned-base changed checks passed, including the UI E2E type graph, formatting, targeted lint, guards, i18n and dead-export checks. Documentation listing and whitespace checks passed.
- Restricted independent source review completed with no P0–P2 findings. No source edits followed that review; hooks preserved the reviewed patch.
- The committed four-file patch has SHA-256 `b382502d8fba20bfca6ebf61685aa82a57863eef8a804bf39e723d1811ba3c24`; the commit tree is `d41f597b04e1006d32506d52670c3f75493ce9d9`. The parent independently verified the actual commit, remote branch and PR head.
- [Exact-head CI run 33989130214](https://github.com/openclaw/openclaw/actions/runs/33989130214) completed successfully, including the required [CI gate](https://github.com/openclaw/openclaw/actions/runs/33989130214/job/101368966105), with no failed or cancelled jobs.

Local validation used Node 24.20.0, pnpm 12.3.4, Vitest 5.0.0 and oxfmt 0.65.0. Dependency refresh used the frozen lockfile, a checkout-owned store, copy imports and disabled install lifecycle scripts; it did not alter dependency declarations or other checkouts. This is not a clean-install or packaging certification. The allocator run emitted a nonfatal dynamic-import analysis warning from the unchanged Vitest worker bootstrap.

Principal commands, from the source checkout:

```bash
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH="$PWD/.artifacts/retention-port-672-vitest5-allocator" OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --root "$PWD/ui" --config "$PWD/ui/vitest.node.config.ts" --configLoader runner src/test-helpers/control-ui-e2e-artifacts.node.test.ts
```

```bash
OPENCLAW_TESTBOX=0 OPENCLAW_VITEST_FS_MODULE_CACHE_PATH="$PWD/.artifacts/retention-port-672-vitest5-checks" node scripts/check-changed.mjs --base 672adca9aa6f0fbc7d57926212fcbe777612381b -- docs/reference/test.md ui/src/e2e/logs-lifecycle.e2e.test.ts ui/src/e2e/mcp-app-conformance.e2e.test.ts ui/src/e2e/usage-sessions-owner-attribution.e2e.test.ts
```

The source checks used fresh, separate task-owned module caches. `OPENCLAW_TESTBOX=0` applied only to local source validation; it does not replace the native landing workflow's hosted-gate requirement.

The maintainer accepts unavailable npm advisory coverage under the repository's adopted ordinary-CI policy. This PR does not change that policy, and green CI is not a claim of comprehensive vulnerability clearance.

### Approved fresh browser proof — complete

The maintainer-selected fresh proof is complete on the current candidate. [Full results, exact commands and inspected before/after screenshots plus the Gateway reconnect recording](https://github.com/openclaw/openclaw/pull/134274#issuecomment-5556314007) are recorded in the proof comment. Provider: **Blacksmith Testbox**, owned lease `tbx_01m1t48xy9je1twx4aey14kyea`, [workflow run 34003210448](https://github.com/openclaw/openclaw/actions/runs/34003210448).

- Baseline A/B: **10 native browser cases passed**, while retention checks correctly rejected the original deletion, overwrite, shared-owner and Usage stage-pairing defects.
- Candidate real-Gateway A/B: **20/20 cases passed**, with **6 new owner directories and 71 files per run**, zero retention violations and prior bytes/timestamps preserved.
- Mocked agent-file A/B: **4/4 cases passed**, with **1 new owner and 10 files per run**, zero retention violations.
- Maintained native lifetime-owner suite: **12/12 passed**, including close failures, late setup/contexts, timeouts, unsafe-fork retirement and shared-state cleanup.

The candidate retained **14 disjoint owner directories and 162 owner files: 76 PNG, 32 WebM, 52 JSON and 2 JSONL**. Exact stage/report inventories, video counts, full video decoding, MCP bridge/cleanup reports, Auth Gateway/proxy port closure and native budget/project parity passed. Every required candidate case ran; none failed or skipped. The ordinary native batches, global setup and late worker-stop semantics were preserved; only a supported task-only sequencer changed file sort order.

The remote proof used Node **24.19.0**, pnpm **12.3.4**, Vitest **5.0.0** and Playwright **1.62.1**, independently verified source/dependencies, frozen installs and both builds. Actual SSH environment absence of `CI`/`GITHUB_ACTIONS` was preserved, including the native 10-second default action budget; explicit case/hook/cleanup deadlines were unchanged. No product or test assertion changes were needed.

The **45,409,824-byte** archive has SHA-256 `b444e091a74f245e93a0b44e9b11feb1e28f6c26b91a16e7f23fdadd8608654d`. It was downloaded and **all 583 retained files** verified against its manifest before the VM was stopped and native terminal completion confirmed. Retained evidence lives outside Git worktrees. All screenshot sheets and full-frame video storyboards were inspected, with verified identical-byte copies deduplicated. Storyboards are sampled, not a claim of watching every frame in real time. Auxiliary blank recordings are not cited as visual state proof; Auth captures with host telemetry remain local. Only separately inspected synthetic Logs media is published.

The first fresh candidate launch hit an overlong rig-owned Chromium socket path, and a later setup ended with exit255 during dependency listing. The failed browser archive was retained and verified, and the uncertain VM was stopped before the successful fresh-lease replay. The rig's atomic root was shortened rather than changing consumer temp overrides, assertions, deadlines or cleanup. Native landing uses a fresh ordinary clone inside the permitted workspace; no GitHub credentials were sent through unsupported Testbox stdin and the denied shared native path was not modified.

This completes the approved invocation-boundary retention and native-lifetime proof, **not syscall-completeness or universal filesystem/process-quiescence proof**. No unavailable low-level verifier work was rerouted, and no missing historical evidence was reconstructed.

### Historical evidence — not current-head acceptance

Earlier attempts remain historical and must not be relabeled:

- The original `b19dcf8` attempt passed eight real cases before its observer detected ambient SQLite open attempts during Usage cleanup. [The recorded failure](https://github.com/openclaw/openclaw/pull/134274#issuecomment-5483194740) is not a successful retention proof.
- An early `17e7033` [attempt](https://crabbox.openclaw.ai/portal/runs/run_a5e2cb347dad) stopped because observation did not cover active `io_uring`. A later [run](https://crabbox.openclaw.ai/portal/runs/run_33463c5b8448) completed both real-Gateway orders, but its final B-order audit rejected incomplete pathname evidence and the mocked repetitions did not run.
- On `7738c275`, 62 producer and 70 pathname qualification checks passed. The subsequent [native run](https://crabbox.openclaw.ai/portal/runs/run_bf330647cf07) passed 10 browser assertions but rejected three trace gaps and one witness problem; later repetitions did not run. Its archive was recorded as hash-verified at collection, with 3,745 new files and 17,317 prior files unchanged. The 32 screenshots and sampled sheets from 14 videos were inspected then, not certified as complete replay or all-frame publication proof.
- On `9325eec3`, [CI](https://github.com/openclaw/openclaw/actions/runs/33838184112) passed the UI/browser and 20 real-Gateway tests. Two initially unacquired jobs passed one scoped retry each; the strict audit still lacked coverage. These are prior-head results, not the new replay.

The previously recorded local verifier worktree and large archive were not found in the current scoped inventory. Source review/check records and broker run metadata survive; no archive recovery or reconstruction of missing original telemetry or captures is claimed. All new evidence must be identified as fresh synthetic proof, not recovery of old or outbox-owned captures.

**The approved fresh candidate-bound proof is complete; normal native review/prepare/merge gates remain required.** No proof media, raw telemetry, credentials, local host metadata, or agent transcripts are committed to the product repository.
