### PR TITLE
test(tooling): configure fixture identity in the commit command

### DIFF
--- a/test/scripts/apple-release-source-check.test.ts
+++ b/test/scripts/apple-release-source-check.test.ts
@@ -12,13 +12,24 @@ function makeRepository(): { root: string; commit: string } {
   const root = mkdtempSync(path.join(tmpdir(), "openclaw-apple-release-source-"));
   tempDirs.push(root);
   execFileSync("git", ["init", "--quiet"], { cwd: root });
-  execFileSync("git", ["config", "user.email", "release-test@openclaw.test"], { cwd: root });
-  execFileSync("git", ["config", "user.name", "OpenClaw Release Test"], { cwd: root });
   writeFileSync(path.join(root, "tracked.txt"), "clean\n", "utf8");
   execFileSync("git", ["add", "tracked.txt"], { cwd: root });
-  execFileSync("git", ["-c", "commit.gpgsign=false", "commit", "--quiet", "-m", "initial"], {
-    cwd: root,
-  });
+  execFileSync(
+    "git",
+    [
+      "-c",
+      "commit.gpgsign=false",
+      "-c",
+      "user.email=release-test@openclaw.test",
+      "-c",
+      "user.name=OpenClaw Release Test",
+      "commit",
+      "--quiet",
+      "-m",
+      "initial",
+    ],
+    { cwd: root },
+  );
   const commit = execFileSync("git", ["rev-parse", "HEAD"], {
     cwd: root,
     encoding: "utf8",


### PR DESCRIPTION
## What Problem This Solves

Each temporary repository in the Apple release source-check tests launches two extra Git commands only to configure the identity for its single fixture commit.

## Why This Change Was Made

Supply that identity through `git -c` on the existing commit command, alongside the existing signing override. This removes ten Git subprocesses across five temporary repositories while retaining the actual commits and separate clean, wrong-commit, modified, staged, and untracked scenarios.

The source guard reads HEAD and porcelain status; it does not consume persistent fixture identity configuration. No runtime guard, release command, or ambient identity policy changes.

## User Impact

Less fixture setup work in the release tooling tests, with the same provenance and dirty-checkout assertions.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/apple-release-source-check.test.ts test/scripts/ios-release-wrapper-args.test.ts test/scripts/write-build-info.test.ts` passed all 35 tests before and after.
- Full changed-file checks, formatting, diff checks, and structured Codex autoreview passed.
- The installed Git manual confirms `-c` applies configuration to that command. Real Bash/Git execution and cleanup remain.
- Production +0/-0; tests +16/-5. No elapsed-time speedup is claimed.
