### PR TITLE
test(infra): move duration cases to the formatter owner

### DIFF
--- a/src/infra/format-time/format-time.test.ts
+++ b/src/infra/format-time/format-time.test.ts
@@ -8,6 +8,7 @@ import {
   resolveTimeZoneDayStartMs,
   resolveTimezone,
 } from "./format-datetime.js";
+import { formatSingleUnitDuration } from "./format-duration-internal.js";
 import {
   formatDurationCompact,
   formatDurationHuman,
@@ -94,6 +95,27 @@ describe("format-duration", () => {
         { input: 25 * 3600000, expected: "1d" },
         { input: 172800000, expected: "2d" },
       ]);
+    });
+  });
+
+  describe("formatSingleUnitDuration", () => {
+    it.each([
+      [59_500, "60 seconds", "1 minute"],
+      [3_570_000, "60 minutes", "1 hour"],
+      [86_370_000, "24 hours", "1 day"],
+    ])("rolls over %dms to the next unit instead of %s", (input, _buggyOutput, expected) => {
+      expect(formatSingleUnitDuration(input, true)).toBe(expected);
+    });
+
+    it.each([
+      [30_000, "30 seconds"],
+      [89_500, "1 minute"],
+      [1_800_000, "30 minutes"],
+      [5_370_000, "1 hour"],
+      [43_200_000, "12 hours"],
+      [129_570_000, "1 day"],
+    ])("keeps %dms in its own unit as %s", (input, expected) => {
+      expect(formatSingleUnitDuration(input, true)).toBe(expected);
     });
   });
 

--- a/src/infra/session-maintenance-warning.test.ts
+++ b/src/infra/session-maintenance-warning.test.ts
@@ -199,42 +199,6 @@ describe("deliverSessionMaintenanceWarning", () => {
     ]);
   });
 
-  it.each([
-    [59_500, "60 seconds", "1 minute"],
-    [3_570_000, "60 minutes", "1 hour"],
-    [86_370_000, "24 hours", "1 day"],
-  ])(
-    "formatDuration rolls over %dms to next unit instead of %s",
-    async (pruneAfterMs, _buggyOutput, expected) => {
-      mocks.deliverOutboundPayloads.mockRejectedValueOnce(new Error("force system event"));
-      const params = createParams({
-        warning: { pruneAfterMs, wouldPrune: true, wouldCap: false, maxEntries: 100 } as never,
-      });
-
-      await deliverSessionMaintenanceWarning(params);
-
-      expect(firstSystemEventCall()?.[0]).toContain(`older than ${expected}`);
-    },
-  );
-
-  it.each([
-    [30_000, "30 seconds"],
-    [89_500, "1 minute"],
-    [1_800_000, "30 minutes"],
-    [5_370_000, "1 hour"],
-    [43_200_000, "12 hours"],
-    [129_570_000, "1 day"],
-  ])("formatDuration keeps %dms in its own unit as %s", async (pruneAfterMs, expected) => {
-    mocks.deliverOutboundPayloads.mockRejectedValueOnce(new Error("force system event"));
-    const params = createParams({
-      warning: { pruneAfterMs, wouldPrune: true, wouldCap: false, maxEntries: 100 } as never,
-    });
-
-    await deliverSessionMaintenanceWarning(params);
-
-    expect(firstSystemEventCall()?.[0]).toContain(`older than ${expected}`);
-  });
-
   it("keeps a recently used context while evicting the least-recently-used entry", async () => {
     const maxEntries = 4096;
     const createSessionParams = (sessionKey: string) =>


### PR DESCRIPTION
## What Problem This Solves

Nine duration-formatting regressions still run through session warning delivery, including module resets, environment setup, session fixture generation, and a forced delivery failure for each row. The formatter was extracted into a shared owner, but these tests stayed behind.

## Why This Change Was Made

Move all nine rounding and unit-boundary rows to the existing formatter suite and call the real `formatSingleUnitDuration` with verbose output. Keep every historical input and exact expected string.

The warning suite retains its seven behavioral cases, including delivery context, duplicate suppression, test-mode suppression, fallback wording, LRU eviction, and changed-context delivery. Its necessary module resets remain. The exact `older than 1 second` integration assertion still proves the warning uses verbose formatting.

## User Impact

Avoid nine warning setup/import/delivery paths while keeping the same aggregate regression coverage. Production behavior, formatting, and persistence are unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/infra/session-maintenance-warning.test.ts src/infra/format-time/format-time.test.ts` passed all 81 tests before and after.
- Warning cases move from 16 to 7; formatter cases move from 65 to 74. No case or historical rounding input is discarded.
- Full changed-file checks, formatting, diff checks, and structured Codex autoreview passed.
- Source/history inspection confirmed the extracted owner and its actual warning caller. Tests use the installed pretty-ms implementation with its existing verbose/unit-count options.
- Production +0/-0; tests +22/-36. The deterministic improvement is nine fewer integration setup paths; no CI-wide timing claim is made.
