### PR TITLE
fix(agents): own transient LLM retries in one failover retry controller

### DIFF
--- a/extensions/github-copilot/stream.test.ts
+++ b/extensions/github-copilot/stream.test.ts
@@ -444,7 +444,6 @@ describe("wrapCopilotAnthropicStream", () => {
     try {
       const stream = await requireStreamFn(wrapCopilotTestStream(streamSimple))(model, context, {
         apiKey: "copilot-token",
-        maxRetries: 0,
         headers: { "COPILOT-INTEGRATION-ID": "caller-identity" },
       });
       const result = await stream.result();

--- a/extensions/meta/index.test.ts
+++ b/extensions/meta/index.test.ts
@@ -237,7 +237,6 @@ describe("meta provider", () => {
     };
     const stream = await streamFn(model, context, {
       apiKey: "unit-test-token",
-      maxRetries: 0,
       onPayload: (payload) => {
         capturedPayload = payload as Record<string, unknown>;
       },

--- a/extensions/moonshot/native-video.test.ts
+++ b/extensions/moonshot/native-video.test.ts
@@ -276,7 +276,6 @@ describe("Moonshot registered transport boundary", () => {
       const caller = vi.fn((payload: unknown) => (callerPayload = payload));
       const stream = await wrapped(normalized, context as never, {
         apiKey: "test-key",
-        maxRetries: 0,
         onPayload: caller,
       });
       let streamError: unknown;

--- a/packages/ai/src/providers/anthropic.fetch-loopback.test.ts
+++ b/packages/ai/src/providers/anthropic.fetch-loopback.test.ts
@@ -92,7 +92,6 @@ describe("Anthropic SDK host fetch wiring", () => {
       for (const testCase of cases) {
         const result = await streamAnthropic(testCase.model, context, {
           apiKey: testCase.apiKey,
-          maxRetries: 0,
           thinkingEnabled: testCase.thinkingEnabled,
         }).result();
         expect(result.stopReason).toBe("error");

--- a/packages/ai/src/providers/anthropic.live.test.ts
+++ b/packages/ai/src/providers/anthropic.live.test.ts
@@ -99,7 +99,7 @@ describeLive("Anthropic provider live", () => {
             },
           ],
         },
-        { apiKey, maxTokens: 1, maxRetries: 0 },
+        { apiKey, maxTokens: 1 },
       ).result();
 
       expect(result.stopReason).toBe("error");
@@ -120,7 +120,6 @@ describeLive("Anthropic provider live", () => {
       const result = await streamSimpleAnthropic(model, context, {
         apiKey,
         maxTokens: requestedMaxTokens,
-        maxRetries: 0,
         reasoning: "off",
         onPayload: (payload) => {
           sentMaxTokens = (payload as { max_tokens?: number }).max_tokens;

--- a/packages/ai/src/providers/anthropic.sse-parse-error.test.ts
+++ b/packages/ai/src/providers/anthropic.sse-parse-error.test.ts
@@ -80,7 +80,6 @@ async function streamAnthropicSseFrames(
   try {
     const result = await streamAnthropic(makeModel(`http://127.0.0.1:${address.port}`), context, {
       apiKey: "test-api-key",
-      maxRetries: 0,
     }).result();
     return { stopReason: result.stopReason, errorMessage: result.errorMessage };
   } finally {
@@ -161,7 +160,6 @@ describe("Anthropic malformed SSE frames", () => {
     const stream = streamAnthropic({ ...makeModel(baseUrl), provider }, context, {
       apiKey: "test-api-key",
       client,
-      maxRetries: 0,
     });
     const eventTypes: string[] = [];
     for await (const event of stream) {

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -563,22 +563,15 @@ describe("Anthropic provider", () => {
     expect(result.usage.cost.cacheWrite).toBeCloseTo(7.75, 10);
   });
 
-  it.each([undefined, 2])(
-    "disables Anthropic SDK retries when maxRetries=%s",
-    async (maxRetries) => {
-      const model = makeAnthropicModel();
-      await streamAnthropic(
-        model,
-        { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
-        { maxRetries },
-      ).result();
+  it("pins Anthropic SDK retries to zero", async () => {
+    const model = makeAnthropicModel();
+    await streamAnthropic(model, {
+      messages: [{ role: "user", content: "hello", timestamp: 0 }],
+    }).result();
 
-      expect(anthropicMockState.requestOptions).toEqual([
-        expect.objectContaining({ maxRetries: 0 }),
-      ]);
-      expect(anthropicMockState.configs.at(-1)).toMatchObject({ maxRetries: 0 });
-    },
-  );
+    expect(anthropicMockState.requestOptions).toEqual([expect.objectContaining({ maxRetries: 0 })]);
+    expect(anthropicMockState.configs.at(-1)).toMatchObject({ maxRetries: 0 });
+  });
 
   it.each([
     { allowEmptySignature: undefined, expectedType: "text", expectedSignature: undefined },

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -563,21 +563,22 @@ describe("Anthropic provider", () => {
     expect(result.usage.cost.cacheWrite).toBeCloseTo(7.75, 10);
   });
 
-  it.each([
-    [undefined, 0],
-    [2, 2],
-  ])("uses Anthropic SDK maxRetries=%s", async (maxRetries, expected) => {
-    const model = makeAnthropicModel();
-    await streamAnthropic(
-      model,
-      { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
-      { maxRetries },
-    ).result();
+  it.each([undefined, 2])(
+    "disables Anthropic SDK retries when maxRetries=%s",
+    async (maxRetries) => {
+      const model = makeAnthropicModel();
+      await streamAnthropic(
+        model,
+        { messages: [{ role: "user", content: "hello", timestamp: 0 }] },
+        { maxRetries },
+      ).result();
 
-    expect(anthropicMockState.requestOptions).toEqual([
-      expect.objectContaining({ maxRetries: expected }),
-    ]);
-  });
+      expect(anthropicMockState.requestOptions).toEqual([
+        expect.objectContaining({ maxRetries: 0 }),
+      ]);
+      expect(anthropicMockState.configs.at(-1)).toMatchObject({ maxRetries: 0 });
+    },
+  );
 
   it.each([
     { allowEmptySignature: undefined, expectedType: "text", expectedSignature: undefined },

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -423,7 +423,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicComp
       const sdkRequestOptions = {
         ...(requestOptions?.signal ? { signal: requestOptions.signal } : {}),
         ...(requestOptions?.timeoutMs !== undefined ? { timeout: requestOptions.timeoutMs } : {}),
-        maxRetries: requestOptions?.maxRetries ?? 0,
+        maxRetries: 0,
       };
       const response = await client.messages
         .create({ ...params, stream: true }, sdkRequestOptions)
@@ -911,6 +911,7 @@ function createClient(
         optionsHeaders,
       ),
       fetch,
+      maxRetries: 0,
     });
 
     return { client, isOAuthToken: false, serverSideFallback: false };
@@ -934,6 +935,7 @@ function createClient(
         optionsHeaders,
       ),
       fetch,
+      maxRetries: 0,
     });
 
     return { client, isOAuthToken: false, serverSideFallback: false };
@@ -961,6 +963,7 @@ function createClient(
         optionsHeaders,
       ),
       fetch,
+      maxRetries: 0,
     });
 
     return { client, isOAuthToken: false, serverSideFallback: false };
@@ -985,6 +988,7 @@ function createClient(
         optionsHeaders,
       ),
       fetch,
+      maxRetries: 0,
     });
 
     return { client, isOAuthToken: true, serverSideFallback: false };
@@ -1015,6 +1019,7 @@ function createClient(
       optionsHeaders,
     ),
     fetch,
+    maxRetries: 0,
   });
 
   return { client, isOAuthToken: false, serverSideFallback };

--- a/packages/ai/src/providers/azure-openai-responses.ts
+++ b/packages/ai/src/providers/azure-openai-responses.ts
@@ -201,6 +201,7 @@ function createClient(
       defaultHeaders: headers,
       baseURL: baseUrl,
       fetch: guardedFetch,
+      maxRetries: 0,
     });
   }
 
@@ -211,6 +212,7 @@ function createClient(
     defaultHeaders: headers,
     baseURL: baseUrl,
     fetch: guardedFetch,
+    maxRetries: 0,
   });
 }
 

--- a/packages/ai/src/providers/mistral.ts
+++ b/packages/ai/src/providers/mistral.ts
@@ -168,6 +168,7 @@ export const streamMistral: StreamFunction<"mistral-conversations", MistralOptio
         serverURL: model.baseUrl,
         // Keep bounded fetch and response hooks on every streaming attempt.
         httpClient,
+        retryConfig: { strategy: "none" },
       });
 
       const normalizeMistralToolCallId = createMistralToolCallIdNormalizer();

--- a/packages/ai/src/providers/openai-chatgpt-responses-limits.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses-limits.test.ts
@@ -1,4 +1,3 @@
-import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost } from "../host.js";
 import type { Context, Model } from "../types.js";
@@ -128,37 +127,5 @@ describe("OpenAI ChatGPT Responses resource limits", () => {
     expect(pullCount).toBeGreaterThanOrEqual(17);
     expect(pullCount).toBeLessThanOrEqual(20);
     expect(fetchMock).toHaveBeenCalledTimes(1);
-  });
-
-  it("caps oversized Retry-After delays before sleeping", async () => {
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(
-        new Response("rate limited", {
-          status: 429,
-          headers: { "retry-after": String(Number.MAX_SAFE_INTEGER) },
-        }),
-      )
-      .mockRejectedValueOnce(new Error("usage limit: stop after retry delay"));
-    vi.stubGlobal("fetch", fetchMock);
-    const setTimeoutSpy = vi
-      .spyOn(globalThis, "setTimeout")
-      .mockImplementation((callback: TimerHandler) => {
-        if (typeof callback === "function") {
-          callback();
-        }
-        return 0 as unknown as ReturnType<typeof setTimeout>;
-      });
-
-    const result = await streamOpenAICodexResponses(model, context, {
-      apiKey: createJwt({
-        "https://api.openai.com/auth": { chatgpt_account_id: "acct-1" },
-      }),
-      transport: "sse",
-    }).result();
-
-    expect(result.stopReason).toBe("error");
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
   });
 });

--- a/packages/ai/src/providers/openai-chatgpt-responses.encrypted-retry.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.encrypted-retry.test.ts
@@ -298,7 +298,6 @@ describe("ChatGPT Responses encrypted replay recovery", () => {
       {
         apiKey: createJwt(),
         transport: "sse" as const,
-        maxRetries: 0,
         onCompactionRejected,
         ...REPLAY_IDENTITY,
       },
@@ -350,7 +349,7 @@ describe("ChatGPT Responses encrypted replay recovery", () => {
       }),
     );
     const options = createObservedOptions(
-      { apiKey: createJwt(), transport: "sse" as const, maxRetries: 0, ...REPLAY_IDENTITY },
+      { apiKey: createJwt(), transport: "sse" as const, ...REPLAY_IDENTITY },
       observations,
     );
 
@@ -389,7 +388,6 @@ describe("ChatGPT Responses encrypted replay recovery", () => {
     const options = {
       apiKey: createJwt(),
       transport: "sse" as const,
-      maxRetries: 0,
       onCompactionRejected,
       ...REPLAY_IDENTITY,
     };
@@ -427,7 +425,6 @@ describe("ChatGPT Responses encrypted replay recovery", () => {
     const aborted = await streamOpenAICodexResponses(model, context, {
       apiKey: createJwt(),
       transport: "sse",
-      maxRetries: 0,
       signal: controller.signal,
       ...REPLAY_IDENTITY,
     }).result();
@@ -444,7 +441,6 @@ describe("ChatGPT Responses encrypted replay recovery", () => {
     await streamOpenAICodexResponses(model, nextTurn(context, aborted), {
       apiKey: createJwt(),
       transport: "sse",
-      maxRetries: 0,
       ...REPLAY_IDENTITY,
     }).result();
     expect(hasInputType(requireItem(requests, 2), "compaction")).toBe(true);
@@ -472,7 +468,6 @@ describe("ChatGPT Responses encrypted replay recovery", () => {
     const result = await streamOpenAICodexResponses(model, createReplayContext("compaction"), {
       apiKey: createJwt(),
       transport: "sse",
-      maxRetries: 0,
       ...REPLAY_IDENTITY,
     }).result();
 
@@ -487,7 +482,6 @@ describe("ChatGPT Responses encrypted replay recovery", () => {
     const options = {
       apiKey: createJwt(),
       transport: "sse" as const,
-      maxRetries: 0,
       ...REPLAY_IDENTITY,
     };
     responsesPromptObserver.set(options, () => {

--- a/packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts
@@ -1,4 +1,4 @@
-// Covers which ChatGPT Responses failures the SSE transport retries.
+// Covers that ChatGPT Responses leaves transient retry ownership to the runner.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { configureAiTransportHost } from "../host.js";
 import { responsesPromptObserver, type ResponsesPromptObservation } from "../internal/openai.js";
@@ -74,7 +74,7 @@ describe("streamOpenAICodexResponses retry classification", () => {
     },
   );
 
-  it("still retries retryable ChatGPT responses", async () => {
+  it("does not retry retryable ChatGPT responses", async () => {
     const prompt = "PRIVATE-NATIVE-SSE-RETRY-PROMPT";
     const observations: ResponsesPromptObservation[] = [];
     const fetchMock = vi
@@ -112,10 +112,12 @@ describe("streamOpenAICodexResponses retry classification", () => {
     ).result();
 
     expect(result.stopReason).toBe("error");
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(acceptanceObserver).not.toHaveBeenCalled();
-    expect(onResponse.mock.calls.map(([response]) => response.status)).toEqual([503, 401]);
-    expect(observations).toHaveLength(2);
+    expect(
+      onResponse.mock.calls.map(([response]) => response.status).every((status) => status === 503),
+    ).toBe(true);
+    expect(observations).toHaveLength(1);
     expect(observations.every((entry) => entry.egress === "native-codex-sse")).toBe(true);
     expect(observations.every((entry) => entry.payloadVariant === "initial")).toBe(true);
     expect(observations.every((entry) => entry.matchesAssembledPrompt)).toBe(true);
@@ -176,7 +178,7 @@ describe("streamOpenAICodexResponses retry classification", () => {
     expect(setTimeoutSpy).not.toHaveBeenCalled();
   });
 
-  it("keeps retrying transient network failures", async () => {
+  it("does not retry transient network failures", async () => {
     const fetchMock = vi
       .fn<typeof fetch>()
       .mockRejectedValueOnce(Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }))
@@ -195,7 +197,7 @@ describe("streamOpenAICodexResponses retry classification", () => {
     }).result();
 
     expect(result.stopReason).toBe("error");
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it.each([
@@ -226,8 +228,28 @@ describe("streamOpenAICodexResponses retry classification", () => {
       transport: "sse",
     }).result();
 
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 7_000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
+  });
+
+  it("carries Retry-After header timing in the terminal error text", async () => {
+    const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response(JSON.stringify({ error: { message: "Too many requests" } }), {
+        status: 429,
+        statusText: "Too Many Requests",
+        headers: { "retry-after": "7" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await streamOpenAICodexResponses(model, context, {
+      apiKey: jwt,
+      transport: "sse",
+    }).result();
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toContain("Retry-After: 7 seconds");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("does not retry a bodyless 304 response", async () => {

--- a/packages/ai/src/providers/openai-chatgpt-responses.test.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.test.ts
@@ -843,7 +843,9 @@ describe("streamOpenAICodexResponses transport", () => {
     expect(payload).toMatchObject({ prompt_cache_key: "stable-cache-key" });
   });
 
-  it("does not retry the ChatGPT transport when maxRetries is zero", async () => {
+  // The embedded runner owns transient retries; the transport must surface the
+  // first failure untouched even when the provider supplies a Retry-After hint.
+  it("never retries in the transport even when the provider sends Retry-After", async () => {
     const jwt = createJwt({ "https://api.openai.com/auth": { chatgpt_account_id: "acct" } });
     const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(
       new Response("rate limited", {
@@ -856,128 +858,11 @@ describe("streamOpenAICodexResponses transport", () => {
 
     const result = await streamOpenAICodexResponses(model, context, {
       apiKey: jwt,
-      maxRetries: 0,
       transport: "sse",
     }).result();
 
     expect(result.stopReason).toBe("error");
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(setTimeoutSpy).not.toHaveBeenCalled();
-  });
-
-  it.each([
-    "1.5",
-    "0x10",
-    "Sun, 31 Feb 2027 00:00:00 GMT",
-    "Sunday, 31-Feb-27 00:00:00 GMT",
-    "Mon, 06 Nov 1994 08:49:37 GMT",
-    "Monday, 06-Nov-94 08:49:37 GMT",
-  ])("ignores invalid Retry-After header delay values: %s", async (retryAfter) => {
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(
-        new Response("rate limited", {
-          status: 429,
-          headers: { "retry-after": retryAfter },
-        }),
-      )
-      .mockRejectedValueOnce(new Error("usage limit: stop after retry delay"));
-    vi.stubGlobal("fetch", fetchMock);
-    const setTimeoutSpy = vi
-      .spyOn(globalThis, "setTimeout")
-      .mockImplementation((callback: TimerHandler) => {
-        if (typeof callback === "function") {
-          callback();
-        }
-        return 0 as unknown as ReturnType<typeof setTimeout>;
-      });
-
-    const stream = streamOpenAICodexResponses(model, context, {
-      apiKey: createJwt({
-        "https://api.openai.com/auth": {
-          chatgpt_account_id: "acct-1",
-        },
-      }),
-      transport: "sse",
-    });
-
-    const result = await stream.result();
-
-    expect(result.stopReason).toBe("error");
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1000);
-  });
-
-  it("honors retry-after-ms ahead of Retry-After", async () => {
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(
-        new Response("rate limited", {
-          status: 429,
-          headers: { "retry-after-ms": "1250", "retry-after": "9" },
-        }),
-      )
-      .mockRejectedValueOnce(new Error("usage limit: stop after retry delay"));
-    vi.stubGlobal("fetch", fetchMock);
-    const setTimeoutSpy = vi
-      .spyOn(globalThis, "setTimeout")
-      .mockImplementation((callback: TimerHandler) => {
-        if (typeof callback === "function") {
-          callback();
-        }
-        return 0 as unknown as ReturnType<typeof setTimeout>;
-      });
-
-    const stream = streamOpenAICodexResponses(model, context, {
-      apiKey: createJwt({
-        "https://api.openai.com/auth": {
-          chatgpt_account_id: "acct-1",
-        },
-      }),
-      transport: "sse",
-    });
-
-    const result = await stream.result();
-
-    expect(result.stopReason).toBe("error");
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 1250);
-  });
-
-  it("honors RFC 850 Retry-After years within the 50-year future window", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(Date.parse("2026-11-06T00:00:00.000Z"));
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(
-        new Response("rate limited", {
-          status: 429,
-          headers: { "retry-after": "Sunday, 06-Nov-50 00:00:00 GMT" },
-        }),
-      )
-      .mockRejectedValueOnce(new Error("usage limit: stop after retry delay"));
-    vi.stubGlobal("fetch", fetchMock);
-    const setTimeoutSpy = vi
-      .spyOn(globalThis, "setTimeout")
-      .mockImplementation((callback: TimerHandler) => {
-        if (typeof callback === "function") {
-          callback();
-        }
-        return 0 as unknown as ReturnType<typeof setTimeout>;
-      });
-
-    const stream = streamOpenAICodexResponses(model, context, {
-      apiKey: createJwt({
-        "https://api.openai.com/auth": {
-          chatgpt_account_id: "acct-1",
-        },
-      }),
-      transport: "sse",
-    });
-
-    const result = await stream.result();
-
-    expect(result.stopReason).toBe("error");
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), MAX_TIMER_TIMEOUT_MS);
   });
 });

--- a/packages/ai/src/providers/openai-chatgpt-responses.ts
+++ b/packages/ai/src/providers/openai-chatgpt-responses.ts
@@ -2,10 +2,7 @@
 import type * as NodeOs from "node:os";
 import type * as NodeZlib from "node:zlib";
 import { toErrorObject } from "@openclaw/normalization-core/error-coercion";
-import {
-  resolveTimerTimeoutMs,
-  clampTimerTimeoutMs,
-} from "@openclaw/normalization-core/number-coercion";
+import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import type {
   Tool as OpenAITool,
   ResponseCreateParamsStreaming,
@@ -14,8 +11,6 @@ import type {
 } from "openai/resources/responses/responses.js";
 import { getEnvApiKey } from "../env-api-keys.js";
 import { getAiTransportHost, resolveAiTransportHeaderSentinels } from "../host.js";
-import { parseRetryAfterHttpDateMs } from "../internal/retry-after.js";
-import { sleepWithAbort } from "../internal/retry-sleep.js";
 import type { BaseOpenAIStreamOptions } from "../provider-options.js";
 import { registerSessionResourceCleanup } from "../session-resources.js";
 import {
@@ -42,7 +37,10 @@ import {
   transportAbortError,
   withProviderResponseHook,
 } from "../transports/transport-stream-shared.js";
-import { MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE } from "../transports/transport-utils.js";
+import {
+  MALFORMED_STREAMING_FRAGMENT_ERROR_MESSAGE,
+  parseRetryAfterSeconds,
+} from "../transports/transport-utils.js";
 import type {
   AssistantMessage,
   Context,
@@ -66,7 +64,6 @@ import {
   withFirstStreamEventTimeout,
 } from "../utils/stream-first-event-timeout.js";
 import { stripSystemPromptCacheBoundary } from "../utils/system-prompt-cache-boundary.js";
-import { inspectTlsCertificateError } from "../utils/tls-certificate-errors.js";
 import {
   CodexProtocolError,
   parseOpenAIChatGptResponsesSse,
@@ -105,8 +102,6 @@ const os = loadNodeOs();
 // ============================================================================
 
 const DEFAULT_CODEX_BASE_URL = "https://chatgpt.com/backend-api";
-const DEFAULT_MAX_RETRIES = 3;
-const BASE_DELAY_MS = 1000;
 const REQUEST_COMPRESSION_ZSTD_LEVEL = 3;
 const CODEX_TOOL_CALL_PROVIDERS = new Set(["openai", "opencode"]);
 const WEBSOCKET_MESSAGE_TOO_BIG_CLOSE_CODE = 1009;
@@ -163,45 +158,6 @@ interface RequestBody {
 type ObserveResponsesPromptEgress = NonNullable<
   ReturnType<typeof createResponsesPromptEgressObserver>
 >;
-
-// ============================================================================
-// Retry Helpers
-// ============================================================================
-
-function isRetryableError(status: number, errorText: string): boolean {
-  if (status === 429 || status === 500 || status === 502 || status === 503 || status === 504) {
-    return true;
-  }
-  return /rate.?limit|overloaded|service.?unavailable|upstream.?connect|connection.?refused/i.test(
-    errorText,
-  );
-}
-
-function resolveHttpRetryDelayMs(response: Response, attempt: number): number {
-  const fallbackMs = BASE_DELAY_MS * 2 ** attempt;
-  const retryAfterMs = response.headers.get("retry-after-ms");
-  if (retryAfterMs) {
-    const trimmed = retryAfterMs.trim();
-    const millis = Number(trimmed);
-    if (/^\d+(?:\.\d+)?$/.test(trimmed) && Number.isFinite(millis)) {
-      return clampTimerTimeoutMs(millis, 0) ?? fallbackMs;
-    }
-  }
-
-  const retryAfter = response.headers.get("retry-after");
-  if (!retryAfter) {
-    return fallbackMs;
-  }
-  const trimmed = retryAfter.trim();
-  const seconds = Number(trimmed);
-  if (/^\d+$/.test(trimmed) && Number.isFinite(seconds)) {
-    return clampTimerTimeoutMs(seconds * 1000, 0) ?? fallbackMs;
-  }
-  const retryAt = parseRetryAfterHttpDateMs(trimmed);
-  return retryAt === undefined
-    ? fallbackMs
-    : (clampTimerTimeoutMs(retryAt - Date.now(), 0) ?? fallbackMs);
-}
 
 function resolveRequestTimeoutMs(options?: OpenAICodexResponsesOptions): number | undefined {
   const timeoutMs = options?.timeoutMs;
@@ -465,7 +421,6 @@ export const streamOpenAICodexResponses: StreamFunction<
       }
 
       let response: Response | undefined;
-      const maxRetries = options?.maxRetries ?? DEFAULT_MAX_RETRIES;
       while (true) {
         const activeAttempt = semanticAttempt;
         response = undefined;
@@ -484,102 +439,49 @@ export const streamOpenAICodexResponses: StreamFunction<
           sseHeaders.set("content-encoding", "zstd");
         }
         const sseBody: BodyInit = compressedBody ?? bodyJson;
-        let terminalResponseError: CodexApiError | undefined;
 
-        // Ordinary transient retries stay inside one semantic payload attempt.
-        for (let attempt = 0; attempt <= maxRetries; attempt++) {
-          if (activeSignal?.aborted) {
-            throw transportAbortError(activeSignal);
-          }
-          observePromptEgress?.(activeAttempt.request, {
-            egress: "native-codex-sse",
-            payloadVariant: activeAttempt.kind,
+        if (activeSignal?.aborted) {
+          throw transportAbortError(activeSignal);
+        }
+        observePromptEgress?.(activeAttempt.request, {
+          egress: "native-codex-sse",
+          payloadVariant: activeAttempt.kind,
+        });
+
+        let attemptResponse: Response;
+        try {
+          attemptResponse = await fetch(resolveCodexUrl(model.baseUrl), {
+            method: "POST",
+            headers: sseHeaders,
+            body: sseBody,
+            signal: activeSignal,
           });
-
-          let attemptResponse: Response;
-          try {
-            attemptResponse = await fetch(resolveCodexUrl(model.baseUrl), {
-              method: "POST",
-              headers: sseHeaders,
-              body: sseBody,
-              signal: activeSignal,
-            });
-          } catch (error) {
-            if (error instanceof Error) {
-              if (
-                isRequestTimeoutError(
-                  error,
-                  options?.signal,
-                  requestTimeoutSignal,
-                  requestTimeoutMs,
-                ) &&
-                requestTimeoutMs !== undefined
-              ) {
-                throw formatRequestTimeoutError(requestTimeoutMs, error);
-              }
-              if (error.name === "AbortError" || error.message === "Request was aborted") {
-                throw new Error("Request was aborted", { cause: error });
-              }
-              if (error.name === "TimeoutError" && requestTimeoutMs !== undefined) {
-                throw new Error(`Request timed out after ${requestTimeoutMs}ms`, { cause: error });
-              }
-            }
-            const tlsCertificateError = inspectTlsCertificateError(error);
-            const lastError = toErrorObject(error, String(error));
-            // Deterministic certificate failures cannot recover through backoff.
+        } catch (error) {
+          if (error instanceof Error) {
             if (
-              attempt < maxRetries &&
-              !lastError.message.includes("usage limit") &&
-              !tlsCertificateError
+              isRequestTimeoutError(
+                error,
+                options?.signal,
+                requestTimeoutSignal,
+                requestTimeoutMs,
+              ) &&
+              requestTimeoutMs !== undefined
             ) {
-              const delayMs = BASE_DELAY_MS * 2 ** attempt;
-              await sleepWithAbort(delayMs, activeSignal);
-              continue;
+              throw formatRequestTimeoutError(requestTimeoutMs, error);
             }
-            throw lastError;
+            if (error.name === "AbortError" || error.message === "Request was aborted") {
+              throw new Error("Request was aborted", { cause: error });
+            }
+            if (error.name === "TimeoutError" && requestTimeoutMs !== undefined) {
+              throw new Error(`Request timed out after ${requestTimeoutMs}ms`, { cause: error });
+            }
           }
-
-          response = attemptResponse;
-          if (attemptResponse.ok) {
-            break;
-          }
-          const hookStream = withFirstStreamEventTimeout(
-            withProviderResponseHook({
-              signal: firstEventAbort.signal,
-              abort: firstEventAbort.abort,
-              hook: createOpenAIResponseHook(options?.onResponse, attemptResponse, model),
-            }),
-            {
-              provider: model.provider,
-              api: model.api,
-              model: model.id,
-              timeoutMs: getFirstStreamEventTimeoutMs(options) ?? 0,
-              stage: "responses",
-              abort: firstEventAbort.abort,
-              onTimeout: getFirstStreamEventTimeoutHandler(options),
-            },
-          );
-          const [errorText] = await Promise.all([
-            readChatGptResponsesErrorTextLimited(attemptResponse, activeSignal),
-            hookStream[Symbol.asyncIterator]().next(),
-          ]);
-          if (attempt < maxRetries && isRetryableError(attemptResponse.status, errorText)) {
-            await sleepWithAbort(resolveHttpRetryDelayMs(attemptResponse, attempt), activeSignal);
-            continue;
-          }
-          const info = parseErrorResponseText(
-            errorText,
-            attemptResponse.status,
-            attemptResponse.statusText,
-          );
-          terminalResponseError = new CodexApiError(info.friendlyMessage || info.message, {
-            code: info.code,
-          });
-          break;
+          throw toErrorObject(error, String(error));
         }
 
-        if (response?.ok) {
-          if (!response.body) {
+        response = attemptResponse;
+        if (attemptResponse.ok) {
+          if (!attemptResponse.body) {
             throw new Error("No response body");
           }
           if (activeSignal?.aborted) {
@@ -589,18 +491,52 @@ export const streamOpenAICodexResponses: StreamFunction<
           break;
         }
 
+        const hookStream = withFirstStreamEventTimeout(
+          withProviderResponseHook({
+            signal: firstEventAbort.signal,
+            abort: firstEventAbort.abort,
+            hook: createOpenAIResponseHook(options?.onResponse, attemptResponse, model),
+          }),
+          {
+            provider: model.provider,
+            api: model.api,
+            model: model.id,
+            timeoutMs: getFirstStreamEventTimeoutMs(options) ?? 0,
+            stage: "responses",
+            abort: firstEventAbort.abort,
+            onTimeout: getFirstStreamEventTimeoutHandler(options),
+          },
+        );
+        const [errorText] = await Promise.all([
+          readChatGptResponsesErrorTextLimited(attemptResponse, activeSignal),
+          hookStream[Symbol.asyncIterator]().next(),
+        ]);
+        const info = parseErrorResponseText(
+          errorText,
+          attemptResponse.status,
+          attemptResponse.statusText,
+        );
+        const retryAfterSeconds = parseRetryAfterSeconds(attemptResponse.headers);
+        // Keep retry timing in the canonical error text so every retry owner sees
+        // the same bounded signal without extending the public AssistantMessage
+        // contract; mirrors formatAnthropicMessagesHttpError.
+        const retryAfterSuffix = Number.isFinite(retryAfterSeconds)
+          ? `; Retry-After: ${Math.ceil(retryAfterSeconds ?? 0)} seconds`
+          : "";
+        const terminalResponseError = new CodexApiError(
+          `${info.friendlyMessage || info.message}${retryAfterSuffix}`,
+          { code: info.code },
+        );
         if (activeSignal?.aborted) {
           throw transportAbortError(activeSignal);
         }
-        const nextSemanticAttempt = terminalResponseError
-          ? await resolveNextResponsesEncryptedContentAttempt(
-              activeAttempt,
-              terminalResponseError,
-              { buildFullHistoryRequest: () => buildBody("full-history") },
-            )
-          : undefined;
+        const nextSemanticAttempt = await resolveNextResponsesEncryptedContentAttempt(
+          activeAttempt,
+          terminalResponseError,
+          { buildFullHistoryRequest: () => buildBody("full-history") },
+        );
         if (!nextSemanticAttempt) {
-          throw terminalResponseError ?? new Error("Failed after retries");
+          throw terminalResponseError;
         }
         semanticAttempt = nextSemanticAttempt;
       }

--- a/packages/ai/src/providers/openai-completions.compat.test.ts
+++ b/packages/ai/src/providers/openai-completions.compat.test.ts
@@ -891,7 +891,7 @@ describe("OpenAI-compatible completions compatibility", () => {
 
   it.each([
     { configured: undefined, expected: 0 },
-    { configured: 3, expected: 3 },
+    { configured: 3, expected: 0 },
   ])("uses maxRetries=$expected when configured value is $configured", async (testCase) => {
     await streamOpenAICompletions(baseModel, context, {
       apiKey: "test",
@@ -899,6 +899,7 @@ describe("OpenAI-compatible completions compatibility", () => {
     }).result();
 
     expect(mockOpenAI.requestOptions[0]).toMatchObject({ maxRetries: testCase.expected });
+    expect(mockOpenAI.clientOptions[0]).toMatchObject({ maxRetries: 0 });
   });
 
   it("surfaces HTTP response body text from OpenAI-compatible errors", async () => {

--- a/packages/ai/src/providers/openai-completions.compat.test.ts
+++ b/packages/ai/src/providers/openai-completions.compat.test.ts
@@ -889,16 +889,9 @@ describe("OpenAI-compatible completions compatibility", () => {
     });
   });
 
-  it.each([
-    { configured: undefined, expected: 0 },
-    { configured: 3, expected: 0 },
-  ])("uses maxRetries=$expected when configured value is $configured", async (testCase) => {
-    await streamOpenAICompletions(baseModel, context, {
-      apiKey: "test",
-      maxRetries: testCase.configured,
-    }).result();
+  it("pins OpenAI SDK retries to zero", async () => {
+    await streamOpenAICompletions(baseModel, context, { apiKey: "test" }).result();
 
-    expect(mockOpenAI.requestOptions[0]).toMatchObject({ maxRetries: testCase.expected });
     expect(mockOpenAI.clientOptions[0]).toMatchObject({ maxRetries: 0 });
   });
 

--- a/packages/ai/src/providers/openai-completions.ts
+++ b/packages/ai/src/providers/openai-completions.ts
@@ -132,7 +132,7 @@ export const streamOpenAICompletions: StreamFunction<
       const requestOptions = {
         signal: firstEventAbort.signal,
         ...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
-        maxRetries: options?.maxRetries ?? 0,
+        maxRetries: 0,
       };
       const { data: openaiStream, response } = await client.chat.completions
         .create(
@@ -344,6 +344,7 @@ function createClient(
     baseURL: resolveOpenAIClientBaseUrl(model, baseUrl),
     dangerouslyAllowBrowser: true,
     defaultHeaders,
+    maxRetries: 0,
     // OpenAI supports custom fetch, so sentinels stay opaque until guarded egress.
     fetch: getAiTransportHost().buildModelFetch(model),
   });

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -1055,10 +1055,7 @@ describe("processResponsesStream", () => {
     }
   });
 
-  it.each([
-    [undefined, 0],
-    [2, 2],
-  ])("passes SDK maxRetries %s as %i", async (maxRetries, expected) => {
+  it("pins SDK maxRetries to zero", async () => {
     let requestMaxRetries: number | undefined;
     const output = createAssistantOutput();
     const stream = new AssistantMessageEventStream();
@@ -1067,7 +1064,6 @@ describe("processResponsesStream", () => {
       stream,
       model: nativeOpenAIModel,
       output,
-      options: maxRetries === undefined ? undefined : { maxRetries },
       createClient: () => ({
         responses: {
           create: (_params, requestOptions) => {
@@ -1090,7 +1086,7 @@ describe("processResponsesStream", () => {
       buildParams: () => ({ model: nativeOpenAIModel.id, input: [], stream: true }),
     });
 
-    expect(requestMaxRetries).toBe(expected);
+    expect(requestMaxRetries).toBe(0);
     expect(output.stopReason).toBe("stop");
   });
 

--- a/packages/ai/src/providers/openai-responses-shared.ts
+++ b/packages/ai/src/providers/openai-responses-shared.ts
@@ -92,7 +92,7 @@ type ResponsesStreamClient = {
 
 type ResponsesLifecycleStreamOptions = Pick<
   StreamOptions,
-  "signal" | "timeoutMs" | "maxRetries" | "onPayload" | "onResponse" | "sessionId"
+  "signal" | "timeoutMs" | "onPayload" | "onResponse" | "sessionId"
 > &
   Pick<BaseOpenAIStreamOptions, "authProfileId" | "onCompactionRejected"> &
   FirstStreamEventInternalOptions;
@@ -236,7 +236,7 @@ function buildResponsesRequestOptions(
   return {
     ...(options?.signal ? { signal: options.signal } : {}),
     ...(options?.timeoutMs !== undefined ? { timeout: options.timeoutMs } : {}),
-    maxRetries: options?.maxRetries ?? 0,
+    maxRetries: 0,
   };
 }
 

--- a/packages/ai/src/providers/openai-responses.live.test.ts
+++ b/packages/ai/src/providers/openai-responses.live.test.ts
@@ -138,7 +138,7 @@ describeLive("OpenAI Responses live", () => {
             },
           ],
         },
-        { apiKey: OPENAI_KEY, maxTokens: 16, maxRetries: 0 },
+        { apiKey: OPENAI_KEY, maxTokens: 16 },
       ).result();
 
       expect(result.stopReason).toBe("error");

--- a/packages/ai/src/providers/openai-responses.test.ts
+++ b/packages/ai/src/providers/openai-responses.test.ts
@@ -66,6 +66,7 @@ describe("OpenAI Responses provider", () => {
     expect(result.stopReason).toBe("error");
     expect(openAiMockState.configs).toHaveLength(1);
     expect((openAiMockState.configs[0] as { fetch?: unknown }).fetch).toBe(hostFetch);
+    expect(openAiMockState.configs[0]).toMatchObject({ maxRetries: 0 });
   });
 
   it("fails closed before constructing an OpenAI client for another provider without an endpoint", async () => {

--- a/packages/ai/src/providers/openai-responses.ts
+++ b/packages/ai/src/providers/openai-responses.ts
@@ -169,6 +169,7 @@ function createClient(
     baseURL: resolveOpenAIClientBaseUrl(model, baseUrl),
     dangerouslyAllowBrowser: true,
     defaultHeaders,
+    maxRetries: 0,
     // OpenAI supports custom fetch, so sentinels stay opaque until guarded egress.
     fetch: getAiTransportHost().buildModelFetch(model),
   });

--- a/packages/ai/src/providers/simple-options.ts
+++ b/packages/ai/src/providers/simple-options.ts
@@ -37,7 +37,6 @@ export function buildBaseOptions(
     timeoutMs: options?.timeoutMs,
     firstEventTimeoutMs: firstEventOptions?.firstEventTimeoutMs,
     onFirstEventTimeout: firstEventOptions?.onFirstEventTimeout,
-    maxRetries: options?.maxRetries,
     maxRetryDelayMs: options?.maxRetryDelayMs,
     metadata: options?.metadata,
   };

--- a/packages/ai/src/transports/openai-completions-transport.requests.test.ts
+++ b/packages/ai/src/transports/openai-completions-transport.requests.test.ts
@@ -34,7 +34,7 @@ describe("openai completions transport requests", () => {
       createStream: createOpenAICompletionsTransportStreamFn,
     },
   ])(
-    "honors turn timeout and zero retries over real $api HTTP",
+    "honors turn timeout and pinned SDK retries over real $api HTTP",
     async (transport) => {
       const capturedTimeouts: Array<string | undefined> = [];
       const server = createServer((request, response) => {
@@ -80,7 +80,7 @@ describe("openai completions transport requests", () => {
             messages: [{ role: "user", content: "Reply OK", timestamp: Date.now() }],
             tools: [],
           },
-          { apiKey: "test-key", timeoutMs: 1_234, maxRetries: 0 },
+          { apiKey: "test-key", timeoutMs: 1_234 },
         );
 
         const eventTypes: string[] = [];

--- a/packages/ai/src/transports/openai-completions-transport.test.ts
+++ b/packages/ai/src/transports/openai-completions-transport.test.ts
@@ -69,6 +69,7 @@ describe("openai completions transport", () => {
     expect(buildOpenAISdkRequestOptions(model, signal)).toEqual({
       signal,
       timeout: 900_000,
+      maxRetries: 0,
     });
     expect(
       buildOpenAISdkRequestOptions(

--- a/packages/ai/src/transports/openai-completions-transport.ts
+++ b/packages/ai/src/transports/openai-completions-transport.ts
@@ -268,7 +268,6 @@ export function createOpenAICompletionsTransportStreamFn(): StreamFn {
             params as unknown as OpenAI.Chat.Completions.ChatCompletionCreateParamsStreaming,
             buildOpenAISdkRequestOptions(model, firstEventAbort.signal, {
               timeoutMs: options?.timeoutMs,
-              maxRetries: options?.maxRetries,
             }),
           )
           .withResponse();

--- a/packages/ai/src/transports/openai-responses-client.compact-http.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.compact-http.test.ts
@@ -70,14 +70,14 @@ describe("prepared Responses compaction HTTP lifetime", () => {
   it.each([
     "request-timeout",
     "host-timeout",
-    "body-timeout-retry",
-    "status-retry",
+    "body-timeout",
+    "status-error",
     "caller-abort",
     "success",
     "oversized-body",
   ] as const)("preserves SDK %s behavior with a bounded response body", async (mode) => {
     const deadlineCase =
-      mode === "request-timeout" || mode === "host-timeout" || mode === "body-timeout-retry";
+      mode === "request-timeout" || mode === "host-timeout" || mode === "body-timeout";
     const timeoutMs = deadlineCase ? 100 : 1_000;
     const abortController = new AbortController();
     const requestPaths: string[] = [];
@@ -94,20 +94,18 @@ describe("prepared Responses compaction HTTP lifetime", () => {
     const server = createServer((request, response) => {
       requestPaths.push(request.url ?? "");
       request.resume();
-      if (mode === "status-retry" && requestPaths.length === 1) {
+      if (mode === "status-error") {
+        // retry-after-ms hint present on purpose: the SDK must still surface
+        // the failure on the first attempt instead of retrying internally.
         response.writeHead(503, { "content-type": "application/json", "retry-after-ms": "1" });
-        response.end(JSON.stringify({ error: { message: "retry this synthetic request" } }));
+        response.end(JSON.stringify({ error: { message: "synthetic 503 failure" } }));
         return;
       }
       response.writeHead(200, { "content-type": "application/json" });
       response.flushHeaders();
       if (mode === "oversized-body") {
         response.end(Buffer.alloc(16 * 1024 * 1024 + 1, "x"));
-      } else if (
-        mode === "success" ||
-        mode === "status-retry" ||
-        (mode === "body-timeout-retry" && requestPaths.length > 1)
-      ) {
+      } else if (mode === "success") {
         response.end(JSON.stringify(compacted));
       } else {
         // Headers arrive promptly; only SDK body parsing can enforce this deadline.
@@ -146,7 +144,6 @@ describe("prepared Responses compaction HTTP lifetime", () => {
         {
           apiKey: "synthetic-loopback-only",
           ...(mode !== "host-timeout" ? { timeoutMs } : {}),
-          maxRetries: mode === "body-timeout-retry" || mode === "status-retry" ? 1 : 0,
           signal: abortController.signal,
         },
       ).then(
@@ -158,8 +155,11 @@ describe("prepared Responses compaction HTTP lifetime", () => {
         abortController.abort();
       }
       const result = await outcome;
-      if (mode === "request-timeout" || mode === "host-timeout") {
+      if (deadlineCase) {
         expect(result.error).toBeInstanceOf(OpenAI.APIConnectionTimeoutError);
+      } else if (mode === "status-error") {
+        expect(result.error).toBeInstanceOf(OpenAI.APIError);
+        expect(String(result.error)).toContain("synthetic 503 failure");
       } else if (mode === "caller-abort") {
         expect(result.error).toBeInstanceOf(OpenAI.APIUserAbortError);
       } else if (mode === "oversized-body") {
@@ -170,14 +170,9 @@ describe("prepared Responses compaction HTTP lifetime", () => {
         expect(result.value?.output).toEqual(compacted.output);
       }
       expect(watchdogFired).toBe(false);
-      expect(requestPaths).toEqual(
-        Array.from(
-          {
-            length: mode === "body-timeout-retry" || mode === "status-retry" ? 2 : 1,
-          },
-          () => "/v1/responses/compact",
-        ),
-      );
+      // Exactly one request per mode: the embedded runner owns transient
+      // retries, so the SDK never re-issues a failed compaction call.
+      expect(requestPaths).toEqual(["/v1/responses/compact"]);
     } finally {
       clearTimeout(watchdog);
       abortController.abort();

--- a/packages/ai/src/transports/openai-responses-client.ts
+++ b/packages/ai/src/transports/openai-responses-client.ts
@@ -191,7 +191,6 @@ async function postOpenAIResponsesCompaction(params: {
   const response = await params.client.post<unknown>("/responses/compact", {
     ...buildOpenAISdkRequestOptions(params.model, params.options?.signal, {
       timeoutMs: params.options?.timeoutMs,
-      maxRetries: params.options?.maxRetries,
     }),
     body: { model: params.request.model, input: compactInput },
   });
@@ -416,7 +415,6 @@ function createResponsesTransportExecutor(config: ResponsesTransportExecutorOpti
         const requestOptions = buildOpenAISdkRequestOptions(model, firstEvent.signal, {
           stream: config.streamRequest,
           timeoutMs: options?.timeoutMs,
-          maxRetries: options?.maxRetries,
         });
         const websocketSignal = combineWebSocketTimeoutSignal(
           firstEvent.signal,

--- a/packages/ai/src/transports/openai-responses-transport.response-hook.test.ts
+++ b/packages/ai/src/transports/openai-responses-transport.response-hook.test.ts
@@ -361,7 +361,9 @@ describe.each(fixtures)("$name response hook", ({ createStream, installResponse,
 });
 
 describe("native ChatGPT SSE non-success response hooks", () => {
-  it("runs the hook for every retry response before the successful SSE stream", async () => {
+  it("runs the hook for the failing response and surfaces the error without retrying", async () => {
+    // The embedded runner owns transient retries; the transport must expose
+    // the first non-success response to the hook and then fail the stream.
     const fetchMock = vi
       .fn<typeof fetch>()
       .mockResolvedValueOnce(
@@ -374,13 +376,12 @@ describe("native ChatGPT SSE non-success response hooks", () => {
     const result = await streamOpenAICodexResponses(chatGptModel, context, {
       apiKey: chatGptToken,
       transport: "sse",
-      maxRetries: 1,
       onResponse,
     }).result();
 
-    expect(result.stopReason).toBe("stop");
-    expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(onResponse.mock.calls.map(([response]) => response.status)).toEqual([503, 202]);
+    expect(result.stopReason).toBe("error");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(onResponse.mock.calls.map(([response]) => response.status)).toEqual([503]);
   });
 
   it("cancels a terminal non-success body when its hook rejects", async () => {
@@ -408,7 +409,6 @@ describe("native ChatGPT SSE non-success response hooks", () => {
       streamOpenAICodexResponses(chatGptModel, context, {
         apiKey: chatGptToken,
         transport: "sse",
-        maxRetries: 0,
         onResponse: async () => {
           throw new Error("non-success response hook failed");
         },
@@ -438,7 +438,6 @@ describe("native ChatGPT SSE non-success response hooks", () => {
       streamOpenAICodexResponses(chatGptModel, context, {
         apiKey: chatGptToken,
         transport: "sse",
-        maxRetries: 0,
         firstEventTimeoutMs: 20,
         onFirstEventTimeout,
         onResponse: () => new Promise<void>(() => {}),

--- a/packages/ai/src/transports/openai-transport-params.session-header.test.ts
+++ b/packages/ai/src/transports/openai-transport-params.session-header.test.ts
@@ -46,13 +46,12 @@ describe("buildOpenAISdkRequestOptions turn controls", () => {
     baseUrl: "https://api.openai.com/v1",
   } as Model;
 
-  it("forwards an explicit turn timeout and zero retries to the SDK", () => {
+  it("includes the turn timeout and pinned zero retries", () => {
     const signal = new AbortController().signal;
 
     expect(
       buildOpenAISdkRequestOptions(model, signal, {
         timeoutMs: 1_234,
-        maxRetries: 0,
       }),
     ).toEqual({ signal, timeout: 1_234, maxRetries: 0 });
   });

--- a/packages/ai/src/transports/openai-transport-params.ts
+++ b/packages/ai/src/transports/openai-transport-params.ts
@@ -389,20 +389,22 @@ function resolveOpenAISdkTimeoutMs(model: Model, timeoutMs?: number): number | u
   return resolveModelRequestTimeoutMs(model, timeoutMs);
 }
 
-export function buildOpenAISdkClientOptions(model: Model): { timeout?: number } {
+export function buildOpenAISdkClientOptions(model: Model): { timeout?: number; maxRetries: 0 } {
   const timeout = resolveOpenAISdkTimeoutMs(model);
-  return timeout === undefined ? {} : { timeout };
+  return { ...(timeout === undefined ? {} : { timeout }), maxRetries: 0 };
 }
 
 export function buildOpenAISdkRequestOptions(
   model: Model,
   signal?: AbortSignal,
-  options?: { stream?: boolean; timeoutMs?: number; maxRetries?: number },
+  options?: { stream?: boolean; timeoutMs?: number },
 ):
   | {
       signal?: AbortSignal;
       timeout?: number;
-      maxRetries?: number;
+      // Always 0: the embedded runner's failover controller is the only retry
+      // owner; SDK-internal retries would hide attempts from its budget.
+      maxRetries: 0;
       headers?: Record<string, string>;
     }
   | undefined {
@@ -411,14 +413,14 @@ export function buildOpenAISdkRequestOptions(
     options?.stream === true && usesNativeOpenAICodexResponsesBackend(model)
       ? { Accept: "text/event-stream" }
       : undefined;
-  if (timeout === undefined && options?.maxRetries === undefined && !signal && !headers) {
+  if (timeout === undefined && !signal && !headers) {
     return undefined;
   }
   return {
     ...(headers ? { headers } : {}),
     ...(signal ? { signal } : {}),
     ...(timeout !== undefined ? { timeout } : {}),
-    ...(options?.maxRetries !== undefined ? { maxRetries: options.maxRetries } : {}),
+    maxRetries: 0,
   };
 }
 

--- a/packages/llm-core/src/types.ts
+++ b/packages/llm-core/src/types.ts
@@ -129,11 +129,6 @@ export interface StreamOptions {
    */
   timeoutMs?: number;
   /**
-   * Maximum retry attempts for providers/SDKs that support client-side retries.
-   * For example, OpenAI and Anthropic SDK clients default to 2.
-   */
-  maxRetries?: number;
-  /**
    * Maximum delay in milliseconds to wait for a retry when the server requests a long wait.
    * If the server's requested delay exceeds this value, the request fails immediately
    * with an error containing the requested delay, allowing higher-level retry logic

--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -272,6 +272,19 @@ describe("formatAssistantErrorText", () => {
       ).toBe("server_error");
     });
   });
+  it("renders opaque upstream_error facts as a temporary provider error", () => {
+    const msg = makeAssistantMessageFixture({
+      provider: "openai",
+      model: "gpt-5.6-luna",
+      errorMessage: "opaque provider response",
+      errorType: "upstream_error",
+    });
+
+    expect(formatUserFacingAssistantErrorText(msg)).toBe(
+      "⚠️ openai/gpt-5.6-luna request failed (provider internal error). " +
+        "This is usually temporary — try again shortly.",
+    );
+  });
   it("uses generic user-facing copy for escaped structured provider messages", () => {
     // The internal formatter keeps detail for logs, while user-facing text must
     // not expose arbitrary provider-controlled structured payload content.

--- a/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
+++ b/src/agents/embedded-agent-helpers.formatassistanterrortext.test.ts
@@ -174,12 +174,9 @@ describe("formatAssistantErrorText", () => {
     );
     expect(formatAssistantErrorText(msg)).toBe("LLM error server_error: Something exploded");
   });
-  it.each([
-    { prepared: false, reason: "request timed out" },
-    { prepared: true, reason: "provider internal error" },
-  ])(
+  it.each([{ prepared: false }, { prepared: true }])(
     "replaces raw provider detail with classified facts (prepared: $prepared)",
-    ({ prepared, reason }) => {
+    ({ prepared }) => {
       const raw = "HTTP 500: opaque-provider-canary";
       const userFacing = formatUserFacingAssistantErrorText(makeAssistantError(raw), {
         provider: "openai",
@@ -193,7 +190,7 @@ describe("formatAssistantErrorText", () => {
       });
 
       expect(userFacing).toBe(
-        `⚠️ openai/gpt-5.6-luna request failed (${reason}, HTTP 500). ` +
+        "⚠️ openai/gpt-5.6-luna request failed (provider internal error, HTTP 500). " +
           "This is usually temporary — try again shortly.",
       );
       expect(userFacing).not.toContain("opaque-provider-canary");

--- a/src/agents/embedded-agent-helpers.ts
+++ b/src/agents/embedded-agent-helpers.ts
@@ -39,10 +39,8 @@ export {
   isCloudCodeAssistFormatError,
   isContextOverflowError,
   isFailoverErrorMessage,
-  isGenericUnknownStreamErrorMessage,
   isLikelyContextOverflowError,
   isProviderRequestSizeCeilingError,
-  isTransientHttpError,
   isTimeoutErrorMessage,
 } from "./failover/classify.js";
 export type { FailoverReason } from "./failover/signal.js";

--- a/src/agents/embedded-agent-helpers/assistant-message-failures.ts
+++ b/src/agents/embedded-agent-helpers/assistant-message-failures.ts
@@ -1,6 +1,6 @@
 import type { AssistantMessage } from "../../llm/types.js";
 import { isReplayUnsafeAssistantError } from "../../llm/utils/retry.js";
-import { extractLeadingHttpStatus } from "../../shared/assistant-error-format.js";
+import { extractErrorHttpStatus } from "../../shared/assistant-error-format.js";
 import {
   classifyFailoverSignal,
   isAuthErrorMessage,
@@ -8,14 +8,17 @@ import {
   isRateLimitErrorMessage,
 } from "../failover/classify.js";
 import type { PreparedProviderFailoverOwner } from "../failover/provider-patterns.js";
+import { resolveRetryAfterMs } from "../failover/retry-evidence.js";
 import { extractFailoverSignalDetails } from "../failover/signal-details.js";
 import type { FailoverReason, FailoverSignal } from "../failover/signal.js";
 export function buildAssistantFailoverSignal(
   msg: AssistantMessage,
   opts?: { provider?: string },
 ): FailoverSignal {
+  const retryAfterMs = resolveRetryAfterMs(msg.errorMessage);
   return {
-    status: extractLeadingHttpStatus(msg.errorMessage?.trim() ?? "")?.code,
+    status: extractErrorHttpStatus(msg.errorMessage?.trim() ?? "")?.code,
+    ...(retryAfterMs === undefined ? {} : { retryAfterMs }),
     code: msg.errorCode,
     errorType: msg.errorType,
     message: msg.errorMessage?.trim() || undefined,

--- a/src/agents/embedded-agent-helpers/error-text.ts
+++ b/src/agents/embedded-agent-helpers/error-text.ts
@@ -276,7 +276,7 @@ export function formatAssistantErrorText(
     return formatRawAssistantErrorForUi(raw);
   }
 
-  if (isTimeoutErrorMessage(raw)) {
+  if (isTimeoutErrorMessage(raw) && !(facts?.status !== undefined && facts.status >= 500)) {
     return SYNTHESIZED_TIMEOUT_ERROR_TEXT;
   }
 

--- a/src/agents/embedded-agent-runner/run-entry.test.ts
+++ b/src/agents/embedded-agent-runner/run-entry.test.ts
@@ -308,7 +308,7 @@ describe("runEmbeddedAgentEntry", () => {
                       {
                         provider,
                         model,
-                        result: "same_model_rate_limit",
+                        result: "same_model_transient",
                         reason: "rate_limit",
                       },
                       { provider, model, result: "success" },
@@ -362,7 +362,7 @@ describe("runEmbeddedAgentEntry", () => {
         {
           provider: "fallback-provider",
           model: "fallback-model",
-          result: "same_model_rate_limit",
+          result: "same_model_transient",
           reason: "rate_limit",
         },
         { provider: "fallback-provider", model: "fallback-model", result: "success" },

--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -419,6 +419,9 @@ export async function runPreparedEmbeddedLoop(
       }
       startupStagesEmitted = dispatch.startupStagesEmitted;
       const { dispatchedAttempt, runtimePlan } = dispatch;
+      failoverRetryController.setTransientRetryBudget(
+        dispatchedAttempt.rawAttempt.providerRetryMaxRetries,
+      );
       attemptCarryover.apply(dispatchedAttempt.rawAttempt);
       const normalizedAttempt = await normalizeEmbeddedRunAttempt({
         runInput: admittedRunInput,

--- a/src/agents/embedded-agent-runner/run-loop.ts
+++ b/src/agents/embedded-agent-runner/run-loop.ts
@@ -196,7 +196,6 @@ export async function runPreparedEmbeddedLoop(
   let lastRunPromptUsage: ReturnType<typeof normalizeUsage> | undefined;
   let overloadProfileRotations = 0;
   const terminalRetryState = createEmbeddedRunTerminalRetryState();
-  let sameModelIdleTimeoutRetries = 0;
   // Cost-runaway breaker for #76293. State lives at the run-loop level
   // on purpose so it survives across attempt boundaries and across
   // profile/auth retries within this embedded run (a wrapper-local
@@ -471,7 +470,6 @@ export async function runPreparedEmbeddedLoop(
         attemptCompactionCount,
         activeErrorContext,
         resolveReplayInvalidForAttempt,
-        canRestartForLiveSwitch,
       } = normalizedAttempt;
       const recovery = await recoverEmbeddedRunAttempt({
         runInput: admittedRunInput,
@@ -521,7 +519,6 @@ export async function runPreparedEmbeddedLoop(
         attemptedThinking,
         fallbackConfigured,
         pluginHarnessOwnsTransport,
-        canRestartForLiveSwitch,
         authProfileId: lastProfileId,
         authProfileStore: attemptAuthProfileStore,
         runtimeAuthRetry,
@@ -530,12 +527,10 @@ export async function runPreparedEmbeddedLoop(
         emptyErrorRetries,
         overloadProfileRotations,
         overloadProfileRotationLimit: failoverRetryController.overloadProfileRotationLimit,
-        sameModelIdleTimeoutRetries,
         previousRetryFailoverReason: lastRetryFailoverReason,
         maybeMarkAuthProfileFailure: failoverRetryController.maybeMarkAuthProfileFailure,
-        maybeRetrySameModelRateLimit: failoverRetryController.maybeRetrySameModelRateLimit,
-        maybeBackoffBeforeOverloadFailover:
-          failoverRetryController.maybeBackoffBeforeOverloadFailover,
+        maybeRetryTransient: failoverRetryController.maybeRetryTransient,
+        getTransientRetryCount: () => failoverRetryController.transientRetryCount,
         advanceAuthProfile: failoverRetryController.advanceAuthProfile,
         advanceRateLimitAuthProfile: failoverRetryController.advanceRateLimitAuthProfile,
         traceAttempts,
@@ -549,11 +544,7 @@ export async function runPreparedEmbeddedLoop(
       authRetryPending = assistantFailureOutcome.authRetryPending;
       emptyErrorRetries = assistantFailureOutcome.emptyErrorRetries;
       overloadProfileRotations = assistantFailureOutcome.overloadProfileRotations;
-      sameModelIdleTimeoutRetries = assistantFailureOutcome.sameModelIdleTimeoutRetries;
       lastRetryFailoverReason = assistantFailureOutcome.lastRetryFailoverReason;
-      if (!assistantFailureOutcome.preserveSameModelRateLimitRetryCount) {
-        failoverRetryController.resetSameModelRateLimitRetries();
-      }
       if (assistantFailureOutcome.action === "retry") {
         continue;
       }

--- a/src/agents/embedded-agent-runner/run.codex-server-error-fallback.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.codex-server-error-fallback.test-support.ts
@@ -37,9 +37,11 @@ describe("runEmbeddedAgent Codex server_error fallback handoff", () => {
     await state?.cleanup();
   });
 
-  it("throws FailoverError for Codex server_error when model fallbacks are configured", async () => {
-    // Codex server_error is a provider failure, not a normal assistant reply;
-    // configured fallbacks should receive it through the failover path.
+  it("throws FailoverError for persistent Codex server_error after transient retries", async () => {
+    // Codex server_error is a provider failure, not a normal assistant reply.
+    // The transient retry owner replays the same model first; once the failure
+    // persists past the retry budget, configured fallbacks receive it through
+    // the failover path.
     const rawCodexError =
       'Codex error: {"type":"error","error":{"type":"server_error","code":"server_error","message":"An error occurred while processing your request."},"sequence_number":2}';
 
@@ -54,7 +56,7 @@ describe("runEmbeddedAgent Codex server_error fallback handoff", () => {
       provider: "openai",
       model: "gpt-5.4",
     });
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+    mockedRunEmbeddedAttempt.mockResolvedValue(
       makeAttemptResult({
         assistantTexts: [],
         lastAssistant: currentAttemptAssistant,
@@ -82,5 +84,7 @@ describe("runEmbeddedAgent Codex server_error fallback handoff", () => {
     await expect(promise).rejects.toThrow(
       "⚠️ openai/gpt-5.4 request failed (provider internal error). This is usually temporary — try again shortly.",
     );
+    // Initial attempt plus the full same-model transient retry budget.
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(4);
   });
 });

--- a/src/agents/embedded-agent-runner/run.empty-error-retry.owner-test-support.ts
+++ b/src/agents/embedded-agent-runner/run.empty-error-retry.owner-test-support.ts
@@ -63,7 +63,6 @@ function makeInput(
     attemptedThinking: new Set(["off"]),
     fallbackConfigured: false,
     pluginHarnessOwnsTransport: false,
-    canRestartForLiveSwitch: false,
     authProfileStore: { version: 1, profiles: {} },
     runtimeAuthRetry: false,
     maybeRefreshRuntimeAuthForAuthError: vi.fn(async () => false),
@@ -71,11 +70,10 @@ function makeInput(
     emptyErrorRetries: options.emptyErrorRetries ?? 0,
     overloadProfileRotations: 0,
     overloadProfileRotationLimit: 1,
-    sameModelIdleTimeoutRetries: 0,
     previousRetryFailoverReason: null,
     maybeMarkAuthProfileFailure: vi.fn(async () => {}),
-    maybeRetrySameModelRateLimit: vi.fn(async () => false),
-    maybeBackoffBeforeOverloadFailover: vi.fn(async () => {}),
+    maybeRetryTransient: vi.fn(async () => false),
+    getTransientRetryCount: () => 0,
     advanceAuthProfile: vi.fn(async () => false),
     advanceRateLimitAuthProfile: vi.fn(async () => false),
     traceAttempts: [],
@@ -93,7 +91,6 @@ describe("silent assistant-error retry owner", () => {
     expect(outcome).toMatchObject({
       action: "retry",
       emptyErrorRetries: 1,
-      preserveSameModelRateLimitRetryCount: true,
     });
   });
 

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -345,9 +345,6 @@ const mockedIsBillingAssistantError = vi.fn(() => false);
 export const mockedIsCompactionFailureError = vi.fn(() => false);
 export const mockedIsFailoverAssistantError = vi.fn<MockAssistantErrorProbe>(() => false);
 const mockedIsFailoverErrorMessage = vi.fn(() => false);
-const mockedIsGenericUnknownStreamErrorMessage = vi.fn((raw: string) =>
-  /^\s*an unknown error occurred\.?\s*$/i.test(raw),
-);
 function matchesCanonicalOverflowFixture(msg?: string): boolean {
   const raw = msg ?? "";
   return (
@@ -588,10 +585,6 @@ function resetRunOverflowCompactionHarnessMocks(): void {
   mockedIsFailoverAssistantError.mockReturnValue(false);
   mockedIsFailoverErrorMessage.mockReset();
   mockedIsFailoverErrorMessage.mockReturnValue(false);
-  mockedIsGenericUnknownStreamErrorMessage.mockReset();
-  mockedIsGenericUnknownStreamErrorMessage.mockImplementation((raw: string) =>
-    /^\s*an unknown error occurred\.?\s*$/i.test(raw),
-  );
   mockedIsLikelyContextOverflowError.mockReset();
   mockedIsLikelyContextOverflowError.mockImplementation(matchesCanonicalOverflowFixture);
   mockedParseImageSizeError.mockReset();
@@ -910,7 +903,6 @@ export async function loadRunOverflowCompactionHarness(): Promise<{
     isLikelyContextOverflowError: mockedIsLikelyContextOverflowError,
     isFailoverAssistantError: mockedIsFailoverAssistantError,
     isFailoverErrorMessage: mockedIsFailoverErrorMessage,
-    isGenericUnknownStreamErrorMessage: mockedIsGenericUnknownStreamErrorMessage,
     parseImageSizeError: mockedParseImageSizeError,
     parseImageDimensionError: mockedParseImageDimensionError,
     isRateLimitAssistantError: mockedIsRateLimitAssistantError,

--- a/src/agents/embedded-agent-runner/run.prompt-timeout-fallback.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.prompt-timeout-fallback.test-support.ts
@@ -34,9 +34,11 @@ describe("runEmbeddedAgent prompt timeout fallback handoff", () => {
     await state?.cleanup();
   });
 
-  it("throws FailoverError for replay-safe harness-owned prompt timeouts when model fallbacks are configured", async () => {
+  it("throws FailoverError for persistent replay-safe prompt timeouts after transient retries", async () => {
+    // The transient retry owner replays the same model first; a timeout that
+    // persists past the retry budget hands off to the configured fallback.
     mockedClassifyFailoverReason.mockReturnValue("timeout");
-    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+    mockedRunEmbeddedAttempt.mockResolvedValue(
       makeAttemptResult({
         assistantTexts: [],
         terminal: {
@@ -66,7 +68,8 @@ describe("runEmbeddedAgent prompt timeout fallback handoff", () => {
 
     await expect(promise).rejects.toBeInstanceOf(MockedFailoverError);
     await expect(promise).rejects.toThrow("LLM request timed out.");
-    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    // Initial attempt plus the full same-model transient retry budget.
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(4);
   });
 
   it("finalizes a settled write after an idle timeout without replaying the prompt", async () => {

--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -39,7 +39,7 @@ function makeParams(overrides: Partial<Params> = {}): Params {
     logAssistantFailoverDecision: vi.fn(),
     warn: vi.fn(),
     maybeMarkAuthProfileFailure: vi.fn(async () => {}),
-    transientRetryCount: 0,
+    getTransientRetryCount: () => 0,
     maybeRetryTransient: vi.fn(async () => false),
     advanceAuthProfile: vi.fn(async () => false),
     advanceRateLimitAuthProfile: vi.fn(async () => false),
@@ -518,6 +518,30 @@ describe("handleAssistantFailover", () => {
   });
 
   describe("surface_error branch (openclaw#70124)", () => {
+    it("logs the incremented count after a successful transient retry", async () => {
+      let transientRetryCount = 0;
+      const logAssistantFailoverDecision = vi.fn();
+      const outcome = await handleAssistantFailover(
+        makeParams({
+          initialDecision: { action: "surface_error", reason: "server_error" },
+          failoverReason: "server_error",
+          billingFailure: false,
+          maybeRetryTransient: vi.fn(async () => {
+            transientRetryCount += 1;
+            return true;
+          }),
+          getTransientRetryCount: () => transientRetryCount,
+          logAssistantFailoverDecision,
+        }),
+      );
+
+      expect(outcome.action).toBe("retry");
+      expect(logAssistantFailoverDecision).toHaveBeenCalledWith("retry_same_model", {
+        retryCount: 1,
+        profileRotationCount: 0,
+      });
+    });
+
     it("throws a billing FailoverError so the webchat can render the provider failure", async () => {
       const logDecision = vi.fn();
       const outcome = await handleAssistantFailover(

--- a/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.test.ts
@@ -20,7 +20,6 @@ function makeParams(overrides: Partial<Params> = {}): Params {
     failoverFailure: true,
     failoverReason: "billing",
     harnessOwnsTransport: false,
-    allowSameModelIdleTimeoutRetry: false,
     assistantProfileFailureReason: null,
     lastProfileId: undefined,
     modelId: model,
@@ -40,8 +39,8 @@ function makeParams(overrides: Partial<Params> = {}): Params {
     logAssistantFailoverDecision: vi.fn(),
     warn: vi.fn(),
     maybeMarkAuthProfileFailure: vi.fn(async () => {}),
-    maybeRetrySameModelRateLimit: vi.fn(async () => false),
-    maybeBackoffBeforeOverloadFailover: vi.fn(async () => {}),
+    transientRetryCount: 0,
+    maybeRetryTransient: vi.fn(async () => false),
     advanceAuthProfile: vi.fn(async () => false),
     advanceRateLimitAuthProfile: vi.fn(async () => false),
   };
@@ -106,7 +105,7 @@ describe("handleAssistantFailover", () => {
     });
 
     it("retries the same model before spending a rate-limit profile rotation", async () => {
-      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeRetryTransient = vi.fn(async () => true);
       const advanceRateLimitAuthProfile = vi.fn(async () => true);
 
       const outcome = await handleAssistantFailover(
@@ -118,7 +117,7 @@ describe("handleAssistantFailover", () => {
           lastAssistant: {
             errorMessage: "HTTP 429 Too Many Requests: requests per minute exceeded",
           } as Params["lastAssistant"],
-          maybeRetrySameModelRateLimit,
+          maybeRetryTransient,
           advanceRateLimitAuthProfile,
         }),
       );
@@ -127,14 +126,13 @@ describe("handleAssistantFailover", () => {
       if (outcome.action !== "retry") {
         return;
       }
-      expect(outcome.retryKind).toBe("same_model_rate_limit");
-      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledTimes(1);
-      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledWith({});
+      expect(outcome.retryKind).toBe("same_model_transient");
+      expect(maybeRetryTransient).toHaveBeenCalledTimes(1);
       expect(advanceRateLimitAuthProfile).not.toHaveBeenCalled();
     });
 
     it("rotates when the rate-limit controller denies a same-model retry", async () => {
-      const maybeRetrySameModelRateLimit = vi.fn(async () => false);
+      const maybeRetryTransient = vi.fn(async () => false);
       const advanceRateLimitAuthProfile = vi.fn(async () => true);
 
       const outcome = await handleAssistantFailover(
@@ -146,7 +144,7 @@ describe("handleAssistantFailover", () => {
           lastAssistant: {
             errorMessage: "HTTP 429 Too Many Requests: requests per minute exceeded",
           } as Params["lastAssistant"],
-          maybeRetrySameModelRateLimit,
+          maybeRetryTransient,
           advanceRateLimitAuthProfile,
         }),
       );
@@ -156,12 +154,12 @@ describe("handleAssistantFailover", () => {
         return;
       }
       expect(outcome.retryKind).toBe("profile_rotation");
-      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledTimes(1);
+      expect(maybeRetryTransient).toHaveBeenCalledTimes(1);
       expect(advanceRateLimitAuthProfile).toHaveBeenCalledTimes(1);
     });
 
     it("does not spend same-model retry budget on quota-style rate limits", async () => {
-      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeRetryTransient = vi.fn(async () => true);
       const advanceRateLimitAuthProfile = vi.fn(async () => true);
 
       const outcome = await handleAssistantFailover(
@@ -174,7 +172,7 @@ describe("handleAssistantFailover", () => {
             errorMessage:
               "You exceeded your current quota, please check your plan and billing details.",
           } as Params["lastAssistant"],
-          maybeRetrySameModelRateLimit,
+          maybeRetryTransient,
           advanceRateLimitAuthProfile,
         }),
       );
@@ -184,12 +182,12 @@ describe("handleAssistantFailover", () => {
         return;
       }
       expect(outcome.retryKind).toBe("profile_rotation");
-      expect(maybeRetrySameModelRateLimit).not.toHaveBeenCalled();
+      expect(maybeRetryTransient).not.toHaveBeenCalled();
       expect(advanceRateLimitAuthProfile).toHaveBeenCalledTimes(1);
     });
 
     it("does not treat bare 429 quota_exceeded as a short-window throttle", async () => {
-      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeRetryTransient = vi.fn(async () => true);
       const advanceRateLimitAuthProfile = vi.fn(async () => true);
 
       const outcome = await handleAssistantFailover(
@@ -201,7 +199,7 @@ describe("handleAssistantFailover", () => {
           lastAssistant: {
             errorMessage: "Provider API error (429): Quota exceeded [code=quota_exceeded]",
           } as Params["lastAssistant"],
-          maybeRetrySameModelRateLimit,
+          maybeRetryTransient,
           advanceRateLimitAuthProfile,
         }),
       );
@@ -211,12 +209,12 @@ describe("handleAssistantFailover", () => {
         return;
       }
       expect(outcome.retryKind).toBe("profile_rotation");
-      expect(maybeRetrySameModelRateLimit).not.toHaveBeenCalled();
+      expect(maybeRetryTransient).not.toHaveBeenCalled();
       expect(advanceRateLimitAuthProfile).toHaveBeenCalledTimes(1);
     });
 
     it("does not treat generic rate-limit text as a short-window throttle", async () => {
-      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeRetryTransient = vi.fn(async () => true);
       const advanceRateLimitAuthProfile = vi.fn(async () => true);
 
       const outcome = await handleAssistantFailover(
@@ -228,7 +226,7 @@ describe("handleAssistantFailover", () => {
           lastAssistant: {
             errorMessage: "rate limit exceeded",
           } as Params["lastAssistant"],
-          maybeRetrySameModelRateLimit,
+          maybeRetryTransient,
           advanceRateLimitAuthProfile,
         }),
       );
@@ -238,12 +236,12 @@ describe("handleAssistantFailover", () => {
         return;
       }
       expect(outcome.retryKind).toBe("profile_rotation");
-      expect(maybeRetrySameModelRateLimit).not.toHaveBeenCalled();
+      expect(maybeRetryTransient).not.toHaveBeenCalled();
       expect(advanceRateLimitAuthProfile).toHaveBeenCalledTimes(1);
     });
 
     it("retries the same model on a status-prefixed 429 with no window wording", async () => {
-      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeRetryTransient = vi.fn(async () => true);
       const advanceRateLimitAuthProfile = vi.fn(async () => true);
 
       const outcome = await handleAssistantFailover(
@@ -255,7 +253,7 @@ describe("handleAssistantFailover", () => {
           lastAssistant: {
             errorMessage: "429 Provider returned error",
           } as Params["lastAssistant"],
-          maybeRetrySameModelRateLimit,
+          maybeRetryTransient,
           advanceRateLimitAuthProfile,
         }),
       );
@@ -264,14 +262,13 @@ describe("handleAssistantFailover", () => {
       if (outcome.action !== "retry") {
         return;
       }
-      expect(outcome.retryKind).toBe("same_model_rate_limit");
-      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledTimes(1);
-      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledWith({});
+      expect(outcome.retryKind).toBe("same_model_transient");
+      expect(maybeRetryTransient).toHaveBeenCalledTimes(1);
       expect(advanceRateLimitAuthProfile).not.toHaveBeenCalled();
     });
 
     it("does not spend same-model retry budget when Retry-After is long", async () => {
-      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeRetryTransient = vi.fn(async () => true);
       const advanceRateLimitAuthProfile = vi.fn(async () => true);
 
       const outcome = await handleAssistantFailover(
@@ -283,7 +280,7 @@ describe("handleAssistantFailover", () => {
           lastAssistant: {
             errorMessage: "429 rate_limit_exceeded; Retry-After: 3600",
           } as Params["lastAssistant"],
-          maybeRetrySameModelRateLimit,
+          maybeRetryTransient,
           advanceRateLimitAuthProfile,
         }),
       );
@@ -293,7 +290,7 @@ describe("handleAssistantFailover", () => {
         return;
       }
       expect(outcome.retryKind).toBe("profile_rotation");
-      expect(maybeRetrySameModelRateLimit).not.toHaveBeenCalled();
+      expect(maybeRetryTransient).not.toHaveBeenCalled();
       expect(advanceRateLimitAuthProfile).toHaveBeenCalledTimes(1);
     });
 
@@ -301,7 +298,7 @@ describe("handleAssistantFailover", () => {
       vi.useFakeTimers();
       vi.setSystemTime(new Date("2026-06-11T00:00:00.000Z"));
       try {
-        const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+        const maybeRetryTransient = vi.fn(async () => true);
         const advanceRateLimitAuthProfile = vi.fn(async () => true);
 
         const outcome = await handleAssistantFailover(
@@ -313,7 +310,7 @@ describe("handleAssistantFailover", () => {
             lastAssistant: {
               errorMessage: "429 rate_limit_exceeded; Retry-After: Thu, 11 Jun 2026 01:05:00 GMT",
             } as Params["lastAssistant"],
-            maybeRetrySameModelRateLimit,
+            maybeRetryTransient,
             advanceRateLimitAuthProfile,
           }),
         );
@@ -323,7 +320,7 @@ describe("handleAssistantFailover", () => {
           return;
         }
         expect(outcome.retryKind).toBe("profile_rotation");
-        expect(maybeRetrySameModelRateLimit).not.toHaveBeenCalled();
+        expect(maybeRetryTransient).not.toHaveBeenCalled();
         expect(advanceRateLimitAuthProfile).toHaveBeenCalledTimes(1);
       } finally {
         vi.useRealTimers();
@@ -331,7 +328,7 @@ describe("handleAssistantFailover", () => {
     });
 
     it("allows short Retry-After intervals to use same-model retry", async () => {
-      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeRetryTransient = vi.fn(async () => true);
       const advanceRateLimitAuthProfile = vi.fn(async () => true);
 
       const outcome = await handleAssistantFailover(
@@ -343,7 +340,7 @@ describe("handleAssistantFailover", () => {
           lastAssistant: {
             errorMessage: "429 rate_limit_exceeded; Retry-After: 30 seconds",
           } as Params["lastAssistant"],
-          maybeRetrySameModelRateLimit,
+          maybeRetryTransient,
           advanceRateLimitAuthProfile,
         }),
       );
@@ -352,14 +349,13 @@ describe("handleAssistantFailover", () => {
       if (outcome.action !== "retry") {
         return;
       }
-      expect(outcome.retryKind).toBe("same_model_rate_limit");
-      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledTimes(1);
-      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledWith({ retryAfterSeconds: 30 });
+      expect(outcome.retryKind).toBe("same_model_transient");
+      expect(maybeRetryTransient).toHaveBeenCalledTimes(1);
       expect(advanceRateLimitAuthProfile).not.toHaveBeenCalled();
     });
 
     it("allows RESOURCE_EXHAUSTED messages with short-window 429 hints", async () => {
-      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeRetryTransient = vi.fn(async () => true);
       const advanceRateLimitAuthProfile = vi.fn(async () => true);
 
       const outcome = await handleAssistantFailover(
@@ -371,7 +367,7 @@ describe("handleAssistantFailover", () => {
           lastAssistant: {
             errorMessage: "429 RESOURCE_EXHAUSTED: tokens per minute limit exceeded",
           } as Params["lastAssistant"],
-          maybeRetrySameModelRateLimit,
+          maybeRetryTransient,
           advanceRateLimitAuthProfile,
         }),
       );
@@ -380,13 +376,13 @@ describe("handleAssistantFailover", () => {
       if (outcome.action !== "retry") {
         return;
       }
-      expect(outcome.retryKind).toBe("same_model_rate_limit");
-      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledTimes(1);
+      expect(outcome.retryKind).toBe("same_model_transient");
+      expect(maybeRetryTransient).toHaveBeenCalledTimes(1);
       expect(advanceRateLimitAuthProfile).not.toHaveBeenCalled();
     });
 
     it("allows quota wording when it points at a per-minute throttle", async () => {
-      const maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      const maybeRetryTransient = vi.fn(async () => true);
       const advanceRateLimitAuthProfile = vi.fn(async () => true);
 
       const outcome = await handleAssistantFailover(
@@ -399,7 +395,7 @@ describe("handleAssistantFailover", () => {
             errorMessage:
               "Quota exceeded for quota metric 'Generate requests per minute' and limit 'Generate requests per minute per project'.",
           } as Params["lastAssistant"],
-          maybeRetrySameModelRateLimit,
+          maybeRetryTransient,
           advanceRateLimitAuthProfile,
         }),
       );
@@ -408,13 +404,13 @@ describe("handleAssistantFailover", () => {
       if (outcome.action !== "retry") {
         return;
       }
-      expect(outcome.retryKind).toBe("same_model_rate_limit");
-      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledTimes(1);
+      expect(outcome.retryKind).toBe("same_model_transient");
+      expect(maybeRetryTransient).toHaveBeenCalledTimes(1);
       expect(advanceRateLimitAuthProfile).not.toHaveBeenCalled();
     });
 
     it("falls back to profile rotation after the same-model rate-limit budget is exhausted", async () => {
-      const maybeRetrySameModelRateLimit = vi.fn(async () => false);
+      const maybeRetryTransient = vi.fn(async () => false);
       const advanceRateLimitAuthProfile = vi.fn(async () => true);
 
       const outcome = await handleAssistantFailover(
@@ -426,7 +422,7 @@ describe("handleAssistantFailover", () => {
           lastAssistant: {
             errorMessage: "429 rate_limit_exceeded: too many requests per minute",
           } as Params["lastAssistant"],
-          maybeRetrySameModelRateLimit,
+          maybeRetryTransient,
           advanceRateLimitAuthProfile,
         }),
       );
@@ -436,7 +432,7 @@ describe("handleAssistantFailover", () => {
         return;
       }
       expect(outcome.retryKind).toBe("profile_rotation");
-      expect(maybeRetrySameModelRateLimit).toHaveBeenCalledTimes(1);
+      expect(maybeRetryTransient).toHaveBeenCalledTimes(1);
       expect(advanceRateLimitAuthProfile).toHaveBeenCalledTimes(1);
     });
 
@@ -539,7 +535,10 @@ describe("handleAssistantFailover", () => {
       expect(err.status).toBe(402);
       expect(err.provider).toBe("Anthropic");
       expect(err.model).toBe("claude-haiku-4-5-20251001");
-      expect(logDecision).toHaveBeenCalledWith("surface_error");
+      expect(logDecision).toHaveBeenCalledWith(
+        "surface_error",
+        expect.objectContaining({ retryCount: 0, profileRotationCount: 0 }),
+      );
     });
 
     it("throws an auth FailoverError for auth-classified surface errors", async () => {
@@ -695,24 +694,6 @@ describe("handleAssistantFailover", () => {
 
       expect(outcome.action).toBe("continue_normal");
     });
-
-    it("retries the same model when an idle-timeout retry is allowed", async () => {
-      const outcome = await handleAssistantFailover(
-        makeParams({
-          initialDecision: { action: "surface_error", reason: null },
-          failoverReason: null,
-          terminal: { kind: "timeout", phase: "prompt", source: "idle" },
-          allowSameModelIdleTimeoutRetry: true,
-          billingFailure: false,
-        }),
-      );
-
-      expect(outcome.action).toBe("retry");
-      if (outcome.action !== "retry") {
-        return;
-      }
-      expect(outcome.retryKind).toBe("same_model_idle_timeout");
-    });
   });
 
   describe("fallback_model branch", () => {
@@ -752,7 +733,10 @@ describe("handleAssistantFailover", () => {
       const err = expectThrownFailoverError(outcome);
       expect(err.reason).toBe("timeout");
       expect(err.status).toBe(408);
-      expect(logDecision).toHaveBeenCalledWith("fallback_model", { status: 408 });
+      expect(logDecision).toHaveBeenCalledWith(
+        "fallback_model",
+        expect.objectContaining({ status: 408, retryCount: 0, profileRotationCount: 0 }),
+      );
     });
 
     it("still throws a FailoverError after the surface_error refactor", async () => {
@@ -771,7 +755,10 @@ describe("handleAssistantFailover", () => {
       expect(err.reason).toBe("billing");
       expect(err.status).toBe(402);
       expect(err.message).toBe(formatBillingErrorMessage("Anthropic", "claude-haiku-4-5-20251001"));
-      expect(logDecision).toHaveBeenCalledWith("fallback_model", { status: 402 });
+      expect(logDecision).toHaveBeenCalledWith(
+        "fallback_model",
+        expect.objectContaining({ status: 402, retryCount: 0, profileRotationCount: 0 }),
+      );
     });
   });
 });

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -18,7 +18,7 @@ import {
 } from "../../embedded-agent-helpers.js";
 import { FailoverError, resolveFailoverStatus } from "../../failover-error.js";
 import type { PreparedProviderFailoverOwner } from "../../failover/provider-patterns.js";
-import { classifyRateLimitWindow } from "../../failover/retry-evidence.js";
+import { classifyRateLimitWindow, resolveRetryAfterMs } from "../../failover/retry-evidence.js";
 import {
   mergeRetryFailoverReason,
   resolveRunFailoverDecision,
@@ -34,31 +34,20 @@ type AssistantFailoverOutcome =
       action: "retry";
       overloadProfileRotations: number;
       lastRetryFailoverReason: FailoverReason | null;
-      retryKind: "profile_rotation" | "same_model_idle_timeout" | "same_model_rate_limit";
+      retryKind: "profile_rotation" | "same_model_transient";
     }
   | {
       action: "throw";
       overloadProfileRotations: number;
       error: FailoverError;
     };
-type ShortWindowRateLimitRetry = {
-  retryAfterSeconds?: number;
-};
-
-function resolveShortWindowRateLimitRetry(
-  message: string | undefined,
-): ShortWindowRateLimitRetry | null {
+function resolveShortWindowRateLimitRetry(message: string | undefined): boolean {
   const window = classifyRateLimitWindow(message);
-  if (window.kind !== "short") {
-    return null;
-  }
-  return window.retryAfterSeconds === undefined
-    ? {}
-    : { retryAfterSeconds: window.retryAfterSeconds };
+  return window.kind === "short";
 }
 
 export function isShortWindowRateLimitMessage(message: string | undefined): boolean {
-  return resolveShortWindowRateLimitRetry(message) !== null;
+  return resolveShortWindowRateLimitRetry(message);
 }
 
 /**
@@ -74,7 +63,6 @@ export async function handleAssistantFailover(params: {
   failoverFailure: boolean;
   failoverReason: FailoverReason | null;
   harnessOwnsTransport: boolean;
-  allowSameModelIdleTimeoutRetry: boolean;
   assistantProfileFailureReason: AuthProfileFailureReason | null;
   lastProfileId?: string;
   modelId: string;
@@ -94,10 +82,16 @@ export async function handleAssistantFailover(params: {
   isProbeSession: boolean;
   overloadProfileRotations: number;
   overloadProfileRotationLimit: number;
+  transientRetryCount: number;
   previousRetryFailoverReason: FailoverReason | null;
   logAssistantFailoverDecision: (
-    decision: "rotate_profile" | "fallback_model" | "surface_error",
-    extra?: { status?: number },
+    decision:
+      | "rotate_profile"
+      | "fallback_model"
+      | "surface_error"
+      | "retry_same_model"
+      | "continue_normal",
+    extra?: { status?: number; retryCount?: number; profileRotationCount?: number },
   ) => void;
   warn: (message: string) => void;
   maybeMarkAuthProfileFailure: (failure: {
@@ -105,8 +99,10 @@ export async function handleAssistantFailover(params: {
     reason?: AuthProfileFailureReason | null;
     modelId?: string;
   }) => Promise<void>;
-  maybeRetrySameModelRateLimit: (retry?: ShortWindowRateLimitRetry) => Promise<boolean>;
-  maybeBackoffBeforeOverloadFailover: (reason: FailoverReason | null) => Promise<void>;
+  maybeRetryTransient: (retry: {
+    reason: FailoverReason;
+    retryAfterMs?: number;
+  }) => Promise<boolean>;
   advanceAuthProfile: () => Promise<boolean>;
   advanceRateLimitAuthProfile: (context: {
     failoverProvider: string;
@@ -118,31 +114,44 @@ export async function handleAssistantFailover(params: {
   const externalAbort = terminal.externalAbort || params.signalOwnedInterruption;
   let overloadProfileRotations = params.overloadProfileRotations;
   let decision = params.initialDecision;
-  const sameModelIdleTimeoutRetry = (): AssistantFailoverOutcome => {
-    params.warn(
-      `[llm-idle-timeout] ${sanitizeForLog(params.provider)}/${sanitizeForLog(params.modelId)} produced no reply before the idle watchdog; retrying same model`,
-    );
-    return {
-      action: "retry",
-      overloadProfileRotations,
-      retryKind: "same_model_idle_timeout",
-      lastRetryFailoverReason: mergeRetryFailoverReason({
-        previous: params.previousRetryFailoverReason,
-        failoverReason: params.failoverReason,
-        timedOut: true,
-      }),
-    };
-  };
-  const sameModelRateLimitRetry = (): AssistantFailoverOutcome => ({
+  const sameModelTransientRetry = (): AssistantFailoverOutcome => ({
     action: "retry",
     overloadProfileRotations,
-    retryKind: "same_model_rate_limit",
+    retryKind: "same_model_transient",
     lastRetryFailoverReason: mergeRetryFailoverReason({
       previous: params.previousRetryFailoverReason,
       failoverReason: params.failoverReason,
       timedOut: terminal.timedOut,
     }),
   });
+
+  const canRetryRateLimit =
+    params.failoverReason !== "rate_limit" ||
+    resolveShortWindowRateLimitRetry(params.lastAssistant?.errorMessage);
+  // A silent idle timeout carries no classifiable provider error, so it
+  // arrives with a null reason; consult the retry owner as a timeout so the
+  // quiet same-model replay stays budgeted by the single transient owner
+  // (the idle-timeout breaker still caps consecutive silent attempts).
+  const transientConsultReason =
+    params.failoverReason ?? (terminal.idleTimedOut ? "timeout" : null);
+  if (
+    !externalAbort &&
+    canRetryRateLimit &&
+    transientConsultReason &&
+    (decision.action === "rotate_profile" ||
+      decision.action === "fallback_model" ||
+      decision.action === "surface_error") &&
+    (await params.maybeRetryTransient({
+      reason: transientConsultReason,
+      retryAfterMs: resolveRetryAfterMs(params.lastAssistant?.errorMessage),
+    }))
+  ) {
+    params.logAssistantFailoverDecision("retry_same_model", {
+      retryCount: params.transientRetryCount,
+      profileRotationCount: overloadProfileRotations,
+    });
+    return sameModelTransientRetry();
+  }
 
   if (decision.action === "rotate_profile") {
     const failedProfileId = params.lastProfileId;
@@ -174,7 +183,11 @@ export async function handleAssistantFailover(params: {
           `overload profile rotation cap reached for ${sanitizeForLog(params.provider)}/${sanitizeForLog(params.modelId)} after ${overloadProfileRotations} rotations; escalating to model fallback`,
         );
         await markFailedProfile();
-        params.logAssistantFailoverDecision("fallback_model", { status });
+        params.logAssistantFailoverDecision("fallback_model", {
+          status,
+          retryCount: params.transientRetryCount,
+          profileRotationCount: overloadProfileRotations,
+        });
         return {
           action: "throw",
           overloadProfileRotations,
@@ -198,10 +211,6 @@ export async function handleAssistantFailover(params: {
       // Minute-scale RPM windows can clear without spending a profile rotation
       // or model fallback. Keep the retry bounded; once exhausted, continue
       // through the existing rate-limit escalation path.
-      const shortWindowRetry = resolveShortWindowRateLimitRetry(params.lastAssistant?.errorMessage);
-      if (shortWindowRetry && (await params.maybeRetrySameModelRateLimit(shortWindowRetry))) {
-        return sameModelRateLimitRetry();
-      }
       rotated = await params.advanceRateLimitAuthProfile({
         failoverProvider: params.activeErrorContext.provider,
         failoverModel: params.activeErrorContext.model,
@@ -232,8 +241,10 @@ export async function handleAssistantFailover(params: {
       // Marking the failed profile is non-blocking after rotation succeeds; the
       // retry can proceed with the next profile while the failure record settles.
       void markFailedProfilePromise;
-      params.logAssistantFailoverDecision("rotate_profile");
-      await params.maybeBackoffBeforeOverloadFailover(params.failoverReason);
+      params.logAssistantFailoverDecision("rotate_profile", {
+        retryCount: params.transientRetryCount,
+        profileRotationCount: overloadProfileRotations,
+      });
       return {
         action: "retry",
         overloadProfileRotations,
@@ -246,10 +257,6 @@ export async function handleAssistantFailover(params: {
       };
     }
     await markFailedProfilePromise;
-    if (terminal.idleTimedOut && params.allowSameModelIdleTimeoutRetry) {
-      return sameModelIdleTimeoutRetry();
-    }
-
     decision = resolveRunFailoverDecision({
       stage: "assistant",
       allowFormatRetry: params.cloudCodeAssistFormatError,
@@ -264,13 +271,14 @@ export async function handleAssistantFailover(params: {
   }
 
   if (decision.action === "fallback_model") {
-    // Backoff runs before throwing so the outer fallback model starts after the
-    // provider-specific overload delay.
-    await params.maybeBackoffBeforeOverloadFailover(params.failoverReason);
     const message = resolveAssistantFailoverErrorMessage(params);
     const status =
       resolveFailoverStatus(decision.reason) ?? (isTimeoutErrorMessage(message) ? 408 : undefined);
-    params.logAssistantFailoverDecision("fallback_model", { status });
+    params.logAssistantFailoverDecision("fallback_model", {
+      status,
+      retryCount: params.transientRetryCount,
+      profileRotationCount: overloadProfileRotations,
+    });
     const shouldSuspend =
       Boolean(params.sessionKey) &&
       (decision.reason === "rate_limit" || decision.reason === "billing");
@@ -292,10 +300,10 @@ export async function handleAssistantFailover(params: {
   }
 
   if (decision.action === "surface_error") {
-    if (!externalAbort && terminal.idleTimedOut && params.allowSameModelIdleTimeoutRetry) {
-      return sameModelIdleTimeoutRetry();
-    }
-    params.logAssistantFailoverDecision("surface_error");
+    params.logAssistantFailoverDecision("surface_error", {
+      retryCount: params.transientRetryCount,
+      profileRotationCount: overloadProfileRotations,
+    });
     // Only current provider failures throw here. External aborts, timeout
     // payload synthesis, and stale classified text without failoverFailure
     // keep the normal payload path.
@@ -324,6 +332,10 @@ export async function handleAssistantFailover(params: {
     }
   }
 
+  params.logAssistantFailoverDecision("continue_normal", {
+    retryCount: params.transientRetryCount,
+    profileRotationCount: overloadProfileRotations,
+  });
   return {
     action: "continue_normal",
     overloadProfileRotations,

--- a/src/agents/embedded-agent-runner/run/assistant-failover.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failover.ts
@@ -82,7 +82,7 @@ export async function handleAssistantFailover(params: {
   isProbeSession: boolean;
   overloadProfileRotations: number;
   overloadProfileRotationLimit: number;
-  transientRetryCount: number;
+  getTransientRetryCount: () => number;
   previousRetryFailoverReason: FailoverReason | null;
   logAssistantFailoverDecision: (
     decision:
@@ -147,7 +147,7 @@ export async function handleAssistantFailover(params: {
     }))
   ) {
     params.logAssistantFailoverDecision("retry_same_model", {
-      retryCount: params.transientRetryCount,
+      retryCount: params.getTransientRetryCount(),
       profileRotationCount: overloadProfileRotations,
     });
     return sameModelTransientRetry();
@@ -185,7 +185,7 @@ export async function handleAssistantFailover(params: {
         await markFailedProfile();
         params.logAssistantFailoverDecision("fallback_model", {
           status,
-          retryCount: params.transientRetryCount,
+          retryCount: params.getTransientRetryCount(),
           profileRotationCount: overloadProfileRotations,
         });
         return {
@@ -242,7 +242,7 @@ export async function handleAssistantFailover(params: {
       // retry can proceed with the next profile while the failure record settles.
       void markFailedProfilePromise;
       params.logAssistantFailoverDecision("rotate_profile", {
-        retryCount: params.transientRetryCount,
+        retryCount: params.getTransientRetryCount(),
         profileRotationCount: overloadProfileRotations,
       });
       return {
@@ -276,7 +276,7 @@ export async function handleAssistantFailover(params: {
       resolveFailoverStatus(decision.reason) ?? (isTimeoutErrorMessage(message) ? 408 : undefined);
     params.logAssistantFailoverDecision("fallback_model", {
       status,
-      retryCount: params.transientRetryCount,
+      retryCount: params.getTransientRetryCount(),
       profileRotationCount: overloadProfileRotations,
     });
     const shouldSuspend =
@@ -301,7 +301,7 @@ export async function handleAssistantFailover(params: {
 
   if (decision.action === "surface_error") {
     params.logAssistantFailoverDecision("surface_error", {
-      retryCount: params.transientRetryCount,
+      retryCount: params.getTransientRetryCount(),
       profileRotationCount: overloadProfileRotations,
     });
     // Only current provider failures throw here. External aborts, timeout
@@ -333,7 +333,7 @@ export async function handleAssistantFailover(params: {
   }
 
   params.logAssistantFailoverDecision("continue_normal", {
-    retryCount: params.transientRetryCount,
+    retryCount: params.getTransientRetryCount(),
     profileRotationCount: overloadProfileRotations,
   });
   return {

--- a/src/agents/embedded-agent-runner/run/assistant-failure.test.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.test.ts
@@ -73,7 +73,6 @@ function makeExhaustedCredentialFailureInput(options?: { replaySafe?: boolean })
     attemptedThinking: new Set(["off"]),
     fallbackConfigured: true,
     pluginHarnessOwnsTransport: false,
-    canRestartForLiveSwitch: false,
     authProfileId: "anthropic:p1",
     authProfileStore: {
       version: 1,
@@ -100,11 +99,10 @@ function makeExhaustedCredentialFailureInput(options?: { replaySafe?: boolean })
     emptyErrorRetries: 3,
     overloadProfileRotations: 0,
     overloadProfileRotationLimit: 1,
-    sameModelIdleTimeoutRetries: 0,
     previousRetryFailoverReason: null,
     maybeMarkAuthProfileFailure,
-    maybeRetrySameModelRateLimit: vi.fn(async () => false),
-    maybeBackoffBeforeOverloadFailover: vi.fn(async () => {}),
+    getTransientRetryCount: () => 0,
+    maybeRetryTransient: vi.fn(async () => false),
     advanceAuthProfile,
     advanceRateLimitAuthProfile: vi.fn(async () => true),
     traceAttempts,
@@ -147,7 +145,7 @@ function makeIdleTimeoutFailureInput(options?: { replaySafe?: boolean }) {
   fixture.input.terminalState = resolveEmbeddedRunAttemptTerminalState({ attempt, assistant });
   fixture.input.emptyErrorRetries = 0;
   fixture.input.maybeRefreshRuntimeAuthForAuthError = vi.fn(async () => true);
-  fixture.input.maybeRetrySameModelRateLimit = vi.fn(async () => true);
+  fixture.input.maybeRetryTransient = vi.fn(async () => true);
   fixture.input.advanceRateLimitAuthProfile = vi.fn(async () => true);
   return fixture;
 }
@@ -363,7 +361,6 @@ describe("handleEmbeddedAssistantFailure", () => {
       reason: "server_error",
       status: 500,
     });
-    expect(fixture.input.maybeBackoffBeforeOverloadFailover).toHaveBeenCalledWith("server_error");
   });
 
   it.each([PROVIDER_FAILURE_WITH_OUTPUT_ERROR_CODE, PROVIDER_POST_DISPATCH_AMBIGUITY_ERROR_CODE])(
@@ -594,7 +591,7 @@ describe("handleEmbeddedAssistantFailure", () => {
 
     expect(outcome.action).toBe("proceed");
     expect(fixture.input.maybeRefreshRuntimeAuthForAuthError).not.toHaveBeenCalled();
-    expect(fixture.input.maybeRetrySameModelRateLimit).not.toHaveBeenCalled();
+    expect(fixture.input.maybeRetryTransient).not.toHaveBeenCalled();
     expect(fixture.advanceAuthProfile).not.toHaveBeenCalled();
     expect(fixture.input.advanceRateLimitAuthProfile).not.toHaveBeenCalled();
     expect(fixture.traceAttempts).toEqual([]);
@@ -603,9 +600,15 @@ describe("handleEmbeddedAssistantFailure", () => {
   it("keeps replay-safe idle timeout profile rotation available", async () => {
     const fixture = makeIdleTimeoutFailureInput({ replaySafe: true });
     fixture.input.maybeRefreshRuntimeAuthForAuthError = vi.fn(async () => false);
+    // Retry budget exhausted: the silent idle timeout consults the transient
+    // owner first, then falls through to profile rotation.
+    fixture.input.maybeRetryTransient = vi.fn(async () => false);
 
     const outcome = await handleEmbeddedAssistantFailure(fixture.input);
 
+    expect(fixture.input.maybeRetryTransient).toHaveBeenCalledWith(
+      expect.objectContaining({ reason: "timeout" }),
+    );
     expect(outcome).toMatchObject({ action: "retry", lastRetryFailoverReason: "timeout" });
     expect(fixture.advanceAuthProfile).toHaveBeenCalledOnce();
     expect(fixture.traceAttempts).toEqual([
@@ -638,13 +641,13 @@ describe("handleEmbeddedAssistantFailure", () => {
       fixture.input.terminalState = resolveEmbeddedRunAttemptTerminalState({ attempt, assistant });
       fixture.input.emptyErrorRetries = 0;
       fixture.input.maybeRefreshRuntimeAuthForAuthError = vi.fn(async () => true);
-      fixture.input.maybeRetrySameModelRateLimit = vi.fn(async () => true);
+      fixture.input.maybeRetryTransient = vi.fn(async () => true);
 
       const outcome = await handleEmbeddedAssistantFailure(fixture.input);
 
       expect(outcome.action).toBe("proceed");
       expect(fixture.input.maybeRefreshRuntimeAuthForAuthError).not.toHaveBeenCalled();
-      expect(fixture.input.maybeRetrySameModelRateLimit).not.toHaveBeenCalled();
+      expect(fixture.input.maybeRetryTransient).not.toHaveBeenCalled();
       expect(fixture.advanceAuthProfile).not.toHaveBeenCalled();
       expect(fixture.input.advanceRateLimitAuthProfile).not.toHaveBeenCalled();
       expect(fixture.traceAttempts).toEqual([]);
@@ -669,21 +672,20 @@ describe("handleEmbeddedAssistantFailure", () => {
     fixture.input.currentAttemptAssistant = assistant;
     fixture.input.terminalState = resolveEmbeddedRunAttemptTerminalState({ attempt, assistant });
     fixture.input.emptyErrorRetries = 0;
-    fixture.input.maybeRetrySameModelRateLimit = vi.fn(async () => true);
+    fixture.input.maybeRetryTransient = vi.fn(async () => true);
     providerRuntimeMocks.classifyProviderFailoverSignalWithPlugin.mockReturnValueOnce("rate_limit");
 
     const outcome = await handleEmbeddedAssistantFailure(fixture.input);
 
     expect(outcome).toMatchObject({
       action: "retry",
-      preserveSameModelRateLimitRetryCount: true,
     });
     expect(fixture.advanceAuthProfile).not.toHaveBeenCalled();
     expect(fixture.traceAttempts).toEqual([
       {
         provider: "anthropic",
         model: "mock-1",
-        result: "same_model_rate_limit",
+        result: "same_model_transient",
         reason: "rate_limit",
         stage: "assistant",
       },
@@ -717,17 +719,16 @@ describe("handleEmbeddedAssistantFailure", () => {
     fixture.input.terminalState = resolveEmbeddedRunAttemptTerminalState({ attempt, assistant });
     fixture.input.emptyErrorRetries = 0;
     fixture.input.maybeRefreshRuntimeAuthForAuthError = vi.fn(async () => true);
-    fixture.input.maybeRetrySameModelRateLimit = vi.fn(async () => true);
+    fixture.input.maybeRetryTransient = vi.fn(async () => true);
 
     const outcome = await handleEmbeddedAssistantFailure(fixture.input);
 
     expect(outcome).toMatchObject({
       action: "retry",
       emptyErrorRetries: 1,
-      preserveSameModelRateLimitRetryCount: true,
     });
     expect(fixture.input.maybeRefreshRuntimeAuthForAuthError).not.toHaveBeenCalled();
-    expect(fixture.input.maybeRetrySameModelRateLimit).not.toHaveBeenCalled();
+    expect(fixture.input.maybeRetryTransient).not.toHaveBeenCalled();
     expect(fixture.advanceAuthProfile).not.toHaveBeenCalled();
     expect(fixture.traceAttempts).toEqual([]);
   });

--- a/src/agents/embedded-agent-runner/run/assistant-failure.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.ts
@@ -307,7 +307,7 @@ export async function handleEmbeddedAssistantFailure(input: {
     isProbeSession: input.isProbeSession,
     overloadProfileRotations: input.overloadProfileRotations,
     overloadProfileRotationLimit: input.overloadProfileRotationLimit,
-    transientRetryCount: input.getTransientRetryCount(),
+    getTransientRetryCount: input.getTransientRetryCount,
     previousRetryFailoverReason: input.previousRetryFailoverReason,
     logAssistantFailoverDecision: logFailoverDecision,
     warn: (message) => log.warn(message),

--- a/src/agents/embedded-agent-runner/run/assistant-failure.ts
+++ b/src/agents/embedded-agent-runner/run/assistant-failure.ts
@@ -9,13 +9,12 @@ import {
   isAuthAssistantError,
   isBillingAssistantError,
   isFailoverAssistantError,
-  isGenericUnknownStreamErrorMessage,
   isRateLimitAssistantError,
   parseImageDimensionError,
   pickFallbackThinkingLevel,
 } from "../../embedded-agent-helpers.js";
 import type { PreparedProviderFailoverOwner } from "../../failover/provider-patterns.js";
-import { hasOnlyAssistantReasoningContent } from "../../replay-turn-classification.js";
+import { resolveRetryAfterMs } from "../../failover/retry-evidence.js";
 import {
   resolveSessionSuspensionReason,
   type SessionSuspensionParams,
@@ -35,7 +34,6 @@ import {
 import type { EmbeddedRunAttemptResult } from "./types.js";
 
 const MAX_EMPTY_ERROR_RETRIES = 3;
-const MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES = 1;
 
 type EmbeddedRunAssistantFailureOutcome = {
   action: "retry" | "proceed";
@@ -43,9 +41,7 @@ type EmbeddedRunAssistantFailureOutcome = {
   authRetryPending: boolean;
   emptyErrorRetries: number;
   overloadProfileRotations: number;
-  sameModelIdleTimeoutRetries: number;
   lastRetryFailoverReason: FailoverReason | null;
-  preserveSameModelRateLimitRetryCount: boolean;
   assistantProfileFailureReason: AuthProfileFailureReason | null;
 };
 
@@ -66,7 +62,6 @@ export async function handleEmbeddedAssistantFailure(input: {
   attemptedThinking: Set<ThinkLevel>;
   fallbackConfigured: boolean;
   pluginHarnessOwnsTransport: boolean;
-  canRestartForLiveSwitch: boolean;
   authProfileId?: string;
   authProfileStore: AuthProfileStore;
   runtimeAuthRetry: boolean;
@@ -78,15 +73,14 @@ export async function handleEmbeddedAssistantFailure(input: {
   emptyErrorRetries: number;
   overloadProfileRotations: number;
   overloadProfileRotationLimit: number;
-  sameModelIdleTimeoutRetries: number;
+  getTransientRetryCount: () => number;
   previousRetryFailoverReason: FailoverReason | null;
   maybeMarkAuthProfileFailure: (failure: {
     profileId?: string;
     reason?: AuthProfileFailureReason | null;
     modelId?: string;
   }) => Promise<void>;
-  maybeRetrySameModelRateLimit: (retry?: { retryAfterSeconds?: number }) => Promise<boolean>;
-  maybeBackoffBeforeOverloadFailover: (reason: FailoverReason | null) => Promise<void>;
+  maybeRetryTransient: Parameters<typeof handleAssistantFailover>[0]["maybeRetryTransient"];
   advanceAuthProfile: Parameters<typeof handleAssistantFailover>[0]["advanceAuthProfile"];
   advanceRateLimitAuthProfile: Parameters<
     typeof handleAssistantFailover
@@ -97,8 +91,9 @@ export async function handleEmbeddedAssistantFailure(input: {
   agentDir: string;
   isProbeSession: boolean;
 }): Promise<EmbeddedRunAssistantFailureOutcome> {
-  const { aborted, idleTimedOut, promptError, timedOut, timedOutDuringCompaction } =
-    projectAgentRunAttemptTerminal(input.attempt.terminal);
+  const { aborted, idleTimedOut, promptError, timedOut } = projectAgentRunAttemptTerminal(
+    input.attempt.terminal,
+  );
   const terminalInterrupted = isEmbeddedRunTerminalInterrupted(input.terminalState.outcome);
   const { signalOwnedInterruption } = input.terminalState;
   const fallbackThinking = pickFallbackThinkingLevel({
@@ -143,23 +138,21 @@ export async function handleEmbeddedAssistantFailure(input: {
     return buildOutcome(input, {
       action: "retry",
       thinkLevel: fallbackThinking,
-      preserveSameModelRateLimitRetryCount: true,
       assistantProfileFailureReason,
     });
   }
   const cloudCodeAssistFormatError = input.attempt.cloudCodeAssistFormatError;
   const imageDimensionError = parseImageDimensionError(input.attemptAssistant?.errorMessage ?? "");
-  const genericUnknownReasoningError =
-    assistantFailoverReason === "timeout" &&
-    isGenericUnknownStreamErrorMessage(input.attemptAssistant?.errorMessage ?? "") &&
-    Boolean(input.attemptAssistant && hasOnlyAssistantReasoningContent(input.attemptAssistant));
-  const silentErrorRetryReason =
-    assistantFailoverReason === null ||
-    genericUnknownReasoningError ||
+  // Classified reasons consult the failover retry controller so a zero-output
+  // failure draws from the single transient budget instead of stacking silent
+  // retries on top of it; only reasons the controller cannot classify use the
+  // bounded local empty-error counter.
+  const silentControllerConsultReason =
     assistantFailoverReason === "no_error_details" ||
     assistantFailoverReason === "unclassified" ||
-    assistantFailoverReason === "unknown" ||
-    assistantFailoverReason === "server_error";
+    assistantFailoverReason === "unknown"
+      ? null
+      : assistantFailoverReason;
   const replaySafeSilentErrorFailure =
     !authFailure &&
     !rateLimitFailure &&
@@ -168,26 +161,45 @@ export async function handleEmbeddedAssistantFailure(input: {
     !imageDimensionError &&
     !terminalInterrupted &&
     !promptError &&
-    silentErrorRetryReason &&
     shouldRetrySilentErrorAssistantTurn({
       attempt: input.attempt,
       assistant: input.attemptAssistant,
     });
-  if (replaySafeSilentErrorFailure && input.emptyErrorRetries < MAX_EMPTY_ERROR_RETRIES) {
-    const emptyErrorRetries = input.emptyErrorRetries + 1;
-    log.warn(
-      `[empty-error-retry] stopReason=error non-visible-output; resubmitting ` +
-        `attempt=${emptyErrorRetries}/${MAX_EMPTY_ERROR_RETRIES} ` +
-        `provider=${input.attemptAssistant?.provider ?? input.provider} ` +
-        `model=${input.attemptAssistant?.model ?? input.model} ` +
-        `sessionKey=${input.runParams.sessionKey ?? input.runParams.sessionId}`,
-    );
-    return buildOutcome(input, {
-      action: "retry",
-      emptyErrorRetries,
-      preserveSameModelRateLimitRetryCount: true,
-      assistantProfileFailureReason,
-    });
+  if (replaySafeSilentErrorFailure) {
+    if (silentControllerConsultReason === null) {
+      if (input.emptyErrorRetries < MAX_EMPTY_ERROR_RETRIES) {
+        const emptyErrorRetries = input.emptyErrorRetries + 1;
+        log.warn(
+          `[empty-error-retry] stopReason=error non-visible-output; resubmitting ` +
+            `attempt=${emptyErrorRetries}/${MAX_EMPTY_ERROR_RETRIES} ` +
+            `provider=${input.attemptAssistant?.provider ?? input.provider} ` +
+            `model=${input.attemptAssistant?.model ?? input.model} ` +
+            `sessionKey=${input.runParams.sessionKey ?? input.runParams.sessionId}`,
+        );
+        return buildOutcome(input, {
+          action: "retry",
+          emptyErrorRetries,
+          assistantProfileFailureReason,
+        });
+      }
+    } else if (
+      await input.maybeRetryTransient({
+        reason: silentControllerConsultReason,
+        retryAfterMs: resolveRetryAfterMs(input.attemptAssistant?.errorMessage),
+      })
+    ) {
+      log.warn(
+        `[empty-error-retry] stopReason=error non-visible-output; transient ` +
+          `reason=${silentControllerConsultReason} retrying same model ` +
+          `provider=${input.attemptAssistant?.provider ?? input.provider} ` +
+          `model=${input.attemptAssistant?.model ?? input.model} ` +
+          `sessionKey=${input.runParams.sessionKey ?? input.runParams.sessionId}`,
+      );
+      return buildOutcome(input, {
+        action: "retry",
+        assistantProfileFailureReason,
+      });
+    }
   }
 
   // The bounded same-model retry already proved this attempt had no visible output
@@ -217,6 +229,9 @@ export async function handleEmbeddedAssistantFailure(input: {
     fallbackConfigured: input.fallbackConfigured,
     timedOut,
     aborted,
+    retryCount: input.getTransientRetryCount(),
+    profileRotationCount: input.overloadProfileRotations,
+    attemptCount: input.traceAttempts.length + 1,
   });
   if (
     !signalOwnedInterruption &&
@@ -229,7 +244,6 @@ export async function handleEmbeddedAssistantFailure(input: {
     return buildOutcome(input, {
       action: "retry",
       authRetryPending: true,
-      preserveSameModelRateLimitRetryCount: true,
       assistantProfileFailureReason,
     });
   }
@@ -273,13 +287,6 @@ export async function handleEmbeddedAssistantFailure(input: {
     failoverFailure,
     failoverReason: assistantFailoverReason,
     harnessOwnsTransport: input.pluginHarnessOwnsTransport,
-    allowSameModelIdleTimeoutRetry:
-      timedOut &&
-      idleTimedOut &&
-      !timedOutDuringCompaction &&
-      !input.fallbackConfigured &&
-      input.canRestartForLiveSwitch &&
-      input.sameModelIdleTimeoutRetries < MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES,
     assistantProfileFailureReason,
     lastProfileId: input.authProfileId,
     modelId: input.modelId,
@@ -300,20 +307,22 @@ export async function handleEmbeddedAssistantFailure(input: {
     isProbeSession: input.isProbeSession,
     overloadProfileRotations: input.overloadProfileRotations,
     overloadProfileRotationLimit: input.overloadProfileRotationLimit,
+    transientRetryCount: input.getTransientRetryCount(),
     previousRetryFailoverReason: input.previousRetryFailoverReason,
     logAssistantFailoverDecision: logFailoverDecision,
     warn: (message) => log.warn(message),
     maybeMarkAuthProfileFailure: input.maybeMarkAuthProfileFailure,
-    maybeRetrySameModelRateLimit: input.maybeRetrySameModelRateLimit,
-    maybeBackoffBeforeOverloadFailover: input.maybeBackoffBeforeOverloadFailover,
+    maybeRetryTransient: input.maybeRetryTransient,
     advanceAuthProfile: input.advanceAuthProfile,
     advanceRateLimitAuthProfile: input.advanceRateLimitAuthProfile,
   });
   if (outcome.action === "retry") {
     const retryTraceResult =
-      outcome.retryKind === "same_model_rate_limit"
-        ? "same_model_rate_limit"
-        : outcome.retryKind === "same_model_idle_timeout" || effectiveFailoverReason === "timeout"
+      outcome.retryKind === "same_model_transient"
+        ? effectiveFailoverReason === "timeout"
+          ? "timeout"
+          : "same_model_transient"
+        : effectiveFailoverReason === "timeout"
           ? "timeout"
           : "rotate_profile";
     input.traceAttempts.push({
@@ -328,11 +337,7 @@ export async function handleEmbeddedAssistantFailure(input: {
       thinkLevel:
         outcome.retryKind === "profile_rotation" ? input.getThinkLevel() : input.thinkLevel,
       overloadProfileRotations: outcome.overloadProfileRotations,
-      sameModelIdleTimeoutRetries:
-        input.sameModelIdleTimeoutRetries +
-        (outcome.retryKind === "same_model_idle_timeout" ? 1 : 0),
       lastRetryFailoverReason: outcome.lastRetryFailoverReason,
-      preserveSameModelRateLimitRetryCount: outcome.retryKind === "same_model_rate_limit",
       assistantProfileFailureReason,
     });
   }
@@ -380,10 +385,7 @@ function buildOutcome(
     authRetryPending: override.authRetryPending ?? false,
     emptyErrorRetries: override.emptyErrorRetries ?? input.emptyErrorRetries,
     overloadProfileRotations: override.overloadProfileRotations ?? input.overloadProfileRotations,
-    sameModelIdleTimeoutRetries:
-      override.sameModelIdleTimeoutRetries ?? input.sameModelIdleTimeoutRetries,
     lastRetryFailoverReason: override.lastRetryFailoverReason ?? input.previousRetryFailoverReason,
-    preserveSameModelRateLimitRetryCount: override.preserveSameModelRateLimitRetryCount ?? false,
     assistantProfileFailureReason: override.assistantProfileFailureReason,
   };
 }

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.test.ts
@@ -96,7 +96,8 @@ async function recoverAfterTransportDrop(scenario: TransportDropScenario = {}) {
     advanceAuthProfile: vi.fn(),
     advanceRateLimitAuthProfile: vi.fn(),
     maybeMarkAuthProfileFailure: vi.fn(),
-    maybeBackoffBeforeOverloadFailover: vi.fn(),
+    maybeRetryTransient: vi.fn(),
+    getTransientRetryCount: () => 0,
   };
   const recovery = await recoverEmbeddedRunAttempt({
     runInput: {
@@ -367,7 +368,8 @@ describe("recoverEmbeddedRunAttempt", () => {
       advanceAuthProfile: vi.fn(),
       advanceRateLimitAuthProfile: vi.fn(),
       maybeMarkAuthProfileFailure: vi.fn(),
-      maybeBackoffBeforeOverloadFailover: vi.fn(),
+      maybeRetryTransient: vi.fn(),
+      getTransientRetryCount: () => 0,
     };
     const attempt = makeEmbeddedRunnerAttempt({
       terminal: {

--- a/src/agents/embedded-agent-runner/run/attempt-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-recovery.ts
@@ -453,8 +453,8 @@ export async function recoverEmbeddedRunAttempt(input: {
       advanceAuthProfile: failoverRetryController.advanceAuthProfile,
       advanceRateLimitAuthProfile: failoverRetryController.advanceRateLimitAuthProfile,
       maybeMarkAuthProfileFailure: failoverRetryController.maybeMarkAuthProfileFailure,
-      maybeBackoffBeforeOverloadFailover:
-        failoverRetryController.maybeBackoffBeforeOverloadFailover,
+      maybeRetryTransient: failoverRetryController.maybeRetryTransient,
+      getTransientRetryCount: () => failoverRetryController.transientRetryCount,
       attemptedThinking: preparedRuntime.attemptedThinking,
       thinkLevel: runtime.thinkLevel,
       getThinkLevel: () => preparedRuntime.snapshot().thinkLevel,

--- a/src/agents/embedded-agent-runner/run/attempt.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.ts
@@ -523,6 +523,8 @@ export async function runEmbeddedAttempt(
       return {
         ...executionResult,
         codeModeEngaged: codeModeControlsEnabledForRun,
+        providerRetryMaxRetries:
+          preparedSessionRuntime.agentSession.settingsManager.getProviderRetrySettings().maxRetries,
         ...(catalogSession
           ? {
               bridgeCalls: {

--- a/src/agents/embedded-agent-runner/run/failover-observation.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-observation.test.ts
@@ -109,6 +109,9 @@ describe("createFailoverDecisionLogger", () => {
       fallbackConfigured: true,
       timedOut: true,
       aborted: false,
+      attemptCount: 4,
+      retryCount: 2,
+      profileRotationCount: 1,
     });
 
     logDecision("fallback_model");
@@ -116,6 +119,12 @@ describe("createFailoverDecisionLogger", () => {
     const [message] = firstWarnCall(warnSpy);
     expect(message).toBe("embedded run failover decision");
     const observation = firstWarnDetails(warnSpy);
+    expect(observation).toMatchObject({
+      decision: "fallback_model",
+      attemptCount: 4,
+      retryCount: 2,
+      profileRotationCount: 1,
+    });
     expect(observation.sourceProvider).toBe("github-copilot");
     expect(observation.sourceModel).toBe("gpt-5.4-mini");
     expect(observation.provider).toBe("openai");

--- a/src/agents/embedded-agent-runner/run/failover-observation.ts
+++ b/src/agents/embedded-agent-runner/run/failover-observation.ts
@@ -14,7 +14,13 @@ import { log } from "../logger.js";
 /** Structured fields emitted whenever embedded run failover chooses an action. */
 type FailoverDecisionLoggerInput = {
   stage: "prompt" | "assistant";
-  decision: "rotate_profile" | "fallback_model" | "surface_error";
+  decision:
+    | "rotate_profile"
+    | "fallback_model"
+    | "surface_error"
+    | "retry_same_model"
+    | "retry_thinking_level"
+    | "continue_normal";
   runId?: string;
   rawError?: string;
   failoverReason: FailoverReason | null;
@@ -28,6 +34,9 @@ type FailoverDecisionLoggerInput = {
   timedOut?: boolean;
   aborted?: boolean;
   status?: number;
+  retryCount?: number;
+  profileRotationCount?: number;
+  attemptCount?: number;
 };
 
 /** Stable context captured before a concrete failover decision is known. */
@@ -56,7 +65,7 @@ export function createFailoverDecisionLogger(
   base: FailoverDecisionLoggerBase,
 ): (
   decision: FailoverDecisionLoggerInput["decision"],
-  extra?: Pick<FailoverDecisionLoggerInput, "status">,
+  extra?: Pick<FailoverDecisionLoggerInput, "status" | "retryCount" | "profileRotationCount">,
 ) => void {
   const normalizedBase = normalizeFailoverDecisionObservationBase(base);
   const safeProfileId = normalizedBase.profileId
@@ -98,10 +107,15 @@ export function createFailoverDecisionLogger(
       timedOut: normalizedBase.timedOut,
       aborted: normalizedBase.aborted,
       status: extra?.status,
+      retryCount: extra?.retryCount ?? normalizedBase.retryCount,
+      profileRotationCount: extra?.profileRotationCount ?? normalizedBase.profileRotationCount,
+      attemptCount: normalizedBase.attemptCount,
       ...observedError,
       consoleMessage:
         `embedded run failover decision: runId=${safeRunId} stage=${normalizedBase.stage} decision=${decision} ` +
-        `reason=${reasonText} from=${safeSourceProvider}/${safeSourceModel}` +
+        `reason=${reasonText} attempt=${normalizedBase.attemptCount ?? "-"} ` +
+        `retry=${normalizedBase.retryCount ?? "-"} rotations=${normalizedBase.profileRotationCount ?? "-"} ` +
+        `from=${safeSourceProvider}/${safeSourceModel}` +
         `${sourceChanged ? ` to=${safeProvider}/${safeModel}` : ""} profile=${profileText}${rawErrorConsoleSuffix}`,
     });
   };

--- a/src/agents/embedded-agent-runner/run/failover-policy.ts
+++ b/src/agents/embedded-agent-runner/run/failover-policy.ts
@@ -5,21 +5,18 @@ import type { AgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.j
 import type { FailoverReason } from "../../embedded-agent-helpers.js";
 
 /** Failover action selected for one embedded run failure decision point. */
+type ContinueNormalDecision = { action: "continue_normal" };
+type ProfileDecision = {
+  action: "rotate_profile" | "surface_error";
+  reason: FailoverReason | null;
+};
+type ModelFallbackDecision = { action: "fallback_model"; reason: FailoverReason };
+type ErrorPayloadDecision = { action: "return_error_payload" };
 type RunFailoverDecision =
-  | {
-      action: "continue_normal";
-    }
-  | {
-      action: "rotate_profile" | "surface_error";
-      reason: FailoverReason | null;
-    }
-  | {
-      action: "fallback_model";
-      reason: FailoverReason;
-    }
-  | {
-      action: "return_error_payload";
-    };
+  | ContinueNormalDecision
+  | ProfileDecision
+  | ModelFallbackDecision
+  | ErrorPayloadDecision;
 
 export type RetryLimitFailoverDecision = Extract<
   RunFailoverDecision,

--- a/src/agents/embedded-agent-runner/run/failover-retry-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-retry-controller.test.ts
@@ -3,7 +3,13 @@ import { FailoverError } from "../../failover-error.js";
 
 const mocks = vi.hoisted(() => ({
   sleepWithAbort: vi.fn(async (_ms: number, _abortSignal?: AbortSignal): Promise<void> => {}),
+  warn: vi.fn((_message: string) => {}),
 }));
+
+vi.mock("../logger.js", async () => {
+  const actual = await vi.importActual<typeof import("../logger.js")>("../logger.js");
+  return { ...actual, log: { ...actual.log, warn: mocks.warn } };
+});
 
 vi.mock("../../../infra/backoff.js", async () => {
   const actual = await vi.importActual<typeof import("../../../infra/backoff.js")>(
@@ -48,7 +54,29 @@ const rateLimitContext = {
 describe("createEmbeddedRunFailoverRetryController", () => {
   beforeEach(() => {
     mocks.sleepWithAbort.mockClear();
+    mocks.warn.mockClear();
     rateLimitContext.logFallbackDecision.mockClear();
+  });
+
+  it("records the truncation when the window ends a budget that still has attempts", async () => {
+    let nowMs = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    try {
+      const controller = createController(vi.fn(async () => false));
+      // A raised budget only delivers the attempts the 90s window fits; without this
+      // record an operator cannot tell why the configured retries never ran.
+      controller.setTransientRetryBudget(8);
+      await expect(controller.maybeRetryTransient({ reason: "server_error" })).resolves.toBe(true);
+      nowMs += 90_000;
+      await expect(controller.maybeRetryTransient({ reason: "server_error" })).resolves.toBe(false);
+
+      expect(controller.transientRetryCount).toBe(1);
+      const truncationLog = mocks.warn.mock.calls.at(-1)?.[0];
+      expect(truncationLog).toContain("transient retry window elapsed");
+      expect(truncationLog).toContain("after 1/8 retries");
+    } finally {
+      dateNow.mockRestore();
+    }
   });
 
   it("bounds transient retries across reasons and honors Retry-After", async () => {

--- a/src/agents/embedded-agent-runner/run/failover-retry-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-retry-controller.test.ts
@@ -116,6 +116,15 @@ describe("createEmbeddedRunFailoverRetryController", () => {
     expect(controller.transientRetryCount).toBe(3);
   });
 
+  it("honors the saved provider retry budget", async () => {
+    const controller = createController(vi.fn(async () => false));
+    controller.setTransientRetryBudget(1);
+
+    await expect(controller.maybeRetryTransient({ reason: "server_error" })).resolves.toBe(true);
+    await expect(controller.maybeRetryTransient({ reason: "server_error" })).resolves.toBe(false);
+    expect(controller.transientRetryCount).toBe(1);
+  });
+
   it("uses the bounded backoff timer without emitting a user notice", async () => {
     vi.useFakeTimers();
     const random = vi.spyOn(Math, "random").mockReturnValue(0);

--- a/src/agents/embedded-agent-runner/run/failover-retry-controller.test.ts
+++ b/src/agents/embedded-agent-runner/run/failover-retry-controller.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FailoverError } from "../../failover-error.js";
 
 const mocks = vi.hoisted(() => ({
-  sleepWithAbort: vi.fn(async () => {}),
+  sleepWithAbort: vi.fn(async (_ms: number, _abortSignal?: AbortSignal): Promise<void> => {}),
 }));
 
 vi.mock("../../../infra/backoff.js", async () => {
@@ -51,40 +51,90 @@ describe("createEmbeddedRunFailoverRetryController", () => {
     rateLimitContext.logFallbackDecision.mockClear();
   });
 
-  it("preserves the full same-model retry budget when rate-limit rotation does not advance", async () => {
-    const advanceAuthProfile = vi.fn(async () => false);
-    const controller = createController(advanceAuthProfile);
+  it("bounds transient retries across reasons and honors Retry-After", async () => {
+    // The 90s budget is wall-clock from the first consult, so the mocked sleep
+    // must advance the clock for the exhaustion branch to be reachable.
+    let nowMs = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    mocks.sleepWithAbort.mockImplementation(async (delayMs: number) => {
+      nowMs += delayMs;
+    });
+    try {
+      const controller = createController(vi.fn(async () => false));
 
-    await expect(controller.advanceRateLimitAuthProfile(rateLimitContext)).resolves.toBe(false);
-    await expect(controller.maybeRetrySameModelRateLimit()).resolves.toBe(true);
-    await expect(controller.maybeRetrySameModelRateLimit()).resolves.toBe(true);
-    await expect(controller.maybeRetrySameModelRateLimit()).resolves.toBe(true);
-    await expect(controller.maybeRetrySameModelRateLimit()).resolves.toBe(false);
+      await expect(
+        controller.maybeRetryTransient({ reason: "server_error", retryAfterMs: 60_000 }),
+      ).resolves.toBe(true);
+      await expect(
+        controller.maybeRetryTransient({ reason: "timeout", retryAfterMs: 30_000 }),
+      ).resolves.toBe(true);
+      await expect(controller.maybeRetryTransient({ reason: "overloaded" })).resolves.toBe(false);
 
-    expect(advanceAuthProfile).toHaveBeenCalledTimes(1);
-    expect(mocks.sleepWithAbort).toHaveBeenCalledTimes(3);
+      expect(controller.transientRetryCount).toBe(2);
+      expect(mocks.sleepWithAbort).toHaveBeenCalledTimes(2);
+      expect(mocks.sleepWithAbort.mock.calls[0]?.[0]).toBe(60_000);
+      expect(mocks.sleepWithAbort.mock.calls[1]?.[0]).toBe(30_000);
+    } finally {
+      dateNow.mockRestore();
+    }
   });
 
-  it("consumes same-model retry eligibility after a successful rate-limit rotation", async () => {
+  it("counts failed-request wall time against the retry budget", async () => {
+    let nowMs = 1_000_000;
+    const dateNow = vi.spyOn(Date, "now").mockImplementation(() => nowMs);
+    try {
+      const controller = createController(vi.fn(async () => false));
+      await expect(controller.maybeRetryTransient({ reason: "server_error" })).resolves.toBe(true);
+      // A slow provider failure burns the window even though no backoff slept.
+      nowMs += 90_000;
+      await expect(controller.maybeRetryTransient({ reason: "server_error" })).resolves.toBe(false);
+      expect(controller.transientRetryCount).toBe(1);
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
+
+  it("keeps profile rotation separate from transient retry accounting", async () => {
     const advanceAuthProfile = vi.fn(async () => true);
     const controller = createController(advanceAuthProfile);
 
     await expect(controller.advanceRateLimitAuthProfile(rateLimitContext)).resolves.toBe(true);
-    await expect(controller.maybeRetrySameModelRateLimit()).resolves.toBe(false);
+    await expect(controller.maybeRetryTransient({ reason: "rate_limit" })).resolves.toBe(true);
 
     expect(advanceAuthProfile).toHaveBeenCalledTimes(1);
-    expect(mocks.sleepWithAbort).not.toHaveBeenCalled();
+    expect(controller.transientRetryCount).toBe(1);
+    expect(mocks.sleepWithAbort).toHaveBeenCalledTimes(1);
   });
 
-  it("does not spend rate-limit rotation eligibility on an ordinary profile advance", async () => {
-    const advanceAuthProfile = vi.fn(async () => true);
-    const controller = createController(advanceAuthProfile);
+  it("allows three transient retries when the ceiling has room", async () => {
+    const controller = createController(vi.fn(async () => false));
 
-    await expect(controller.advanceAuthProfile()).resolves.toBe(true);
-    await expect(controller.maybeRetrySameModelRateLimit()).resolves.toBe(true);
+    await expect(controller.maybeRetryTransient({ reason: "rate_limit" })).resolves.toBe(true);
+    await expect(controller.maybeRetryTransient({ reason: "overloaded" })).resolves.toBe(true);
+    await expect(controller.maybeRetryTransient({ reason: "timeout" })).resolves.toBe(true);
+    await expect(controller.maybeRetryTransient({ reason: "server_error" })).resolves.toBe(false);
+    expect(controller.transientRetryCount).toBe(3);
+  });
 
-    expect(advanceAuthProfile).toHaveBeenCalledTimes(1);
-    expect(mocks.sleepWithAbort).toHaveBeenCalledWith(10_000, undefined);
+  it("uses the bounded backoff timer without emitting a user notice", async () => {
+    vi.useFakeTimers();
+    const random = vi.spyOn(Math, "random").mockReturnValue(0);
+    mocks.sleepWithAbort.mockImplementation(
+      (delayMs) =>
+        new Promise<void>((resolve) => {
+          setTimeout(resolve, delayMs);
+        }),
+    );
+    try {
+      const controller = createController(vi.fn(async () => false));
+      const retry = controller.maybeRetryTransient({ reason: "server_error" });
+      await vi.advanceTimersByTimeAsync(500);
+      await expect(retry).resolves.toBe(true);
+      expect(mocks.sleepWithAbort).toHaveBeenCalledWith(500, undefined);
+    } finally {
+      random.mockRestore();
+      vi.useRealTimers();
+    }
   });
 
   it("escalates after one successful rate-limit rotation without advancing again", async () => {

--- a/src/agents/embedded-agent-runner/run/failover-retry-controller.ts
+++ b/src/agents/embedded-agent-runner/run/failover-retry-controller.ts
@@ -151,6 +151,10 @@ export function createEmbeddedRunFailoverRetryController(input: {
     get transientRetryCount() {
       return transientRetryCount;
     },
+    // Saved retry.provider.maxRetries keeps its meaning as the transient-retry
+    // attempt budget, now owned here instead of per-SDK-request. The 90s window in
+    // resolveTransientRetryDelayMs still bounds it, so values larger than the window
+    // fits degrade to fewer attempts rather than an unbounded wait.
     setTransientRetryBudget: (maxRetries?: number) => {
       transientRetryBudget = maxRetries ?? MAX_TRANSIENT_RETRIES;
     },

--- a/src/agents/embedded-agent-runner/run/failover-retry-controller.ts
+++ b/src/agents/embedded-agent-runner/run/failover-retry-controller.ts
@@ -62,6 +62,7 @@ export function createEmbeddedRunFailoverRetryController(input: {
   const rateLimitProfileRotationLimit = resolveRateLimitProfileRotationLimit();
   let rateLimitProfileRotations = 0;
   let transientRetryCount = 0;
+  let transientRetryBudget = MAX_TRANSIENT_RETRIES;
   // Wall-clock anchor set at the first transient consult so the 90s budget
   // counts failed-request time, not only backoff sleeps; a slow provider
   // timeout consumes budget instead of extending the retry window.
@@ -150,6 +151,9 @@ export function createEmbeddedRunFailoverRetryController(input: {
     get transientRetryCount() {
       return transientRetryCount;
     },
+    setTransientRetryBudget: (maxRetries?: number) => {
+      transientRetryBudget = maxRetries ?? MAX_TRANSIENT_RETRIES;
+    },
     advanceAuthProfile: input.advanceAuthProfile,
     advanceRateLimitAuthProfile: async (context: RateLimitAuthProfileContext): Promise<boolean> => {
       if (rateLimitProfileRotations >= rateLimitProfileRotationLimit && fallbackConfigured) {
@@ -225,7 +229,7 @@ export function createEmbeddedRunFailoverRetryController(input: {
       ) {
         return false;
       }
-      if (transientRetryCount >= MAX_TRANSIENT_RETRIES) {
+      if (transientRetryCount >= transientRetryBudget) {
         return false;
       }
       const nowMs = Date.now();
@@ -239,7 +243,7 @@ export function createEmbeddedRunFailoverRetryController(input: {
         return false;
       }
       log.warn(
-        `transient same-model retry ${transientRetryCount + 1}/${MAX_TRANSIENT_RETRIES} for ${sanitizeForLog(provider)}/${sanitizeForLog(modelId)} reason=${retry.reason}: delayMs=${delayMs}`,
+        `transient same-model retry ${transientRetryCount + 1}/${transientRetryBudget} for ${sanitizeForLog(provider)}/${sanitizeForLog(modelId)} reason=${retry.reason}: delayMs=${delayMs}`,
       );
       await sleepForRetry(delayMs);
       transientRetryCount += 1;

--- a/src/agents/embedded-agent-runner/run/failover-retry-controller.ts
+++ b/src/agents/embedded-agent-runner/run/failover-retry-controller.ts
@@ -152,9 +152,7 @@ export function createEmbeddedRunFailoverRetryController(input: {
       return transientRetryCount;
     },
     // Saved retry.provider.maxRetries keeps its meaning as the transient-retry
-    // attempt budget, now owned here instead of per-SDK-request. The 90s window in
-    // resolveTransientRetryDelayMs still bounds it, so values larger than the window
-    // fits degrade to fewer attempts rather than an unbounded wait.
+    // attempt budget, now owned here instead of per-SDK-request.
     setTransientRetryBudget: (maxRetries?: number) => {
       transientRetryBudget = maxRetries ?? MAX_TRANSIENT_RETRIES;
     },
@@ -244,6 +242,12 @@ export function createEmbeddedRunFailoverRetryController(input: {
         elapsedMs: nowMs - transientRetryWindowStartMs,
       });
       if (delayMs === undefined) {
+        // The window in resolveTransientRetryDelayMs outranks the attempt budget when
+        // requests are slow, so record the truncation: a configured maxRetries that
+        // never runs must be diagnosable. Failover is the better recovery past here.
+        log.warn(
+          `transient retry window elapsed for ${sanitizeForLog(provider)}/${sanitizeForLog(modelId)} after ${transientRetryCount}/${transientRetryBudget} retries; failing over`,
+        );
         return false;
       }
       log.warn(

--- a/src/agents/embedded-agent-runner/run/failover-retry-controller.ts
+++ b/src/agents/embedded-agent-runner/run/failover-retry-controller.ts
@@ -18,12 +18,10 @@ import type { TraceAttempt } from "../types.js";
 import { resolveAuthProfileFailureReason } from "./auth-profile-failure-policy.js";
 import type { PreparedEmbeddedRunInput } from "./execution-context.js";
 import {
-  MAX_SAME_MODEL_RATE_LIMIT_RETRIES,
-  resolveNextSameModelRateLimitRetryCount,
-  resolveOverloadFailoverBackoffMs,
+  MAX_TRANSIENT_RETRIES,
+  resolveTransientRetryDelayMs,
   resolveOverloadProfileRotationLimit,
   resolveRateLimitProfileRotationLimit,
-  resolveSameModelRateLimitRetryDelayMs,
 } from "./helpers.js";
 import type { prepareEmbeddedRunRuntime } from "./runtime-preparation.js";
 
@@ -60,11 +58,14 @@ export function createEmbeddedRunFailoverRetryController(input: {
     fallbackConfigured,
     profileFailureStore,
   } = input;
-  const overloadFailoverBackoffMs = resolveOverloadFailoverBackoffMs();
   const overloadProfileRotationLimit = resolveOverloadProfileRotationLimit();
   const rateLimitProfileRotationLimit = resolveRateLimitProfileRotationLimit();
   let rateLimitProfileRotations = 0;
-  let consecutiveSameModelRateLimitRetries = 0;
+  let transientRetryCount = 0;
+  // Wall-clock anchor set at the first transient consult so the 90s budget
+  // counts failed-request time, not only backoff sleeps; a slow provider
+  // timeout consumes budget instead of extending the retry window.
+  let transientRetryWindowStartMs: number | null = null;
 
   const sleepForRetry = async (delayMs: number) => {
     try {
@@ -146,14 +147,8 @@ export function createEmbeddedRunFailoverRetryController(input: {
 
   return {
     overloadProfileRotationLimit,
-    get consecutiveSameModelRateLimitRetries() {
-      return consecutiveSameModelRateLimitRetries;
-    },
-    resetSameModelRateLimitRetries: () => {
-      consecutiveSameModelRateLimitRetries = resolveNextSameModelRateLimitRetryCount({
-        retriesSoFar: consecutiveSameModelRateLimitRetries,
-        retriedSameModelRateLimit: false,
-      });
+    get transientRetryCount() {
+      return transientRetryCount;
     },
     advanceAuthProfile: input.advanceAuthProfile,
     advanceRateLimitAuthProfile: async (context: RateLimitAuthProfileContext): Promise<boolean> => {
@@ -218,36 +213,36 @@ export function createEmbeddedRunFailoverRetryController(input: {
           }
         : null;
     },
-    maybeBackoffBeforeOverloadFailover: async (reason: FailoverReason | null) => {
-      if (reason !== "overloaded" || overloadFailoverBackoffMs <= 0) {
-        return;
-      }
-      log.warn(
-        `overload backoff before failover for ${provider}/${modelId}: delayMs=${overloadFailoverBackoffMs}`,
-      );
-      await sleepForRetry(overloadFailoverBackoffMs);
-    },
-    maybeRetrySameModelRateLimit: async (retry?: {
-      retryAfterSeconds?: number;
+    maybeRetryTransient: async (retry: {
+      reason: FailoverReason;
+      retryAfterMs?: number;
     }): Promise<boolean> => {
       if (
-        rateLimitProfileRotations >= rateLimitProfileRotationLimit ||
-        consecutiveSameModelRateLimitRetries >= MAX_SAME_MODEL_RATE_LIMIT_RETRIES
+        retry.reason !== "rate_limit" &&
+        retry.reason !== "overloaded" &&
+        retry.reason !== "server_error" &&
+        retry.reason !== "timeout"
       ) {
         return false;
       }
-      const delayMs = resolveSameModelRateLimitRetryDelayMs({
-        retriesSoFar: consecutiveSameModelRateLimitRetries,
-        retryAfterSeconds: retry?.retryAfterSeconds,
+      if (transientRetryCount >= MAX_TRANSIENT_RETRIES) {
+        return false;
+      }
+      const nowMs = Date.now();
+      transientRetryWindowStartMs ??= nowMs;
+      const delayMs = resolveTransientRetryDelayMs({
+        retryNumber: transientRetryCount + 1,
+        retryAfterMs: retry.retryAfterMs,
+        elapsedMs: nowMs - transientRetryWindowStartMs,
       });
+      if (delayMs === undefined) {
+        return false;
+      }
       log.warn(
-        `rate-limit same-model retry ${consecutiveSameModelRateLimitRetries + 1}/${MAX_SAME_MODEL_RATE_LIMIT_RETRIES} for ${sanitizeForLog(provider)}/${sanitizeForLog(modelId)}: delayMs=${delayMs}`,
+        `transient same-model retry ${transientRetryCount + 1}/${MAX_TRANSIENT_RETRIES} for ${sanitizeForLog(provider)}/${sanitizeForLog(modelId)} reason=${retry.reason}: delayMs=${delayMs}`,
       );
       await sleepForRetry(delayMs);
-      consecutiveSameModelRateLimitRetries = resolveNextSameModelRateLimitRetryCount({
-        retriesSoFar: consecutiveSameModelRateLimitRetries,
-        retriedSameModelRateLimit: true,
-      });
+      transientRetryCount += 1;
       return true;
     },
   };

--- a/src/agents/embedded-agent-runner/run/helpers.test.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.test.ts
@@ -1,7 +1,8 @@
 // Embedded run helper tests cover final assistant text extraction and error
 // metadata assembly shared by normal exits and failure paths.
 import type { AssistantMessage } from "openclaw/plugin-sdk/llm";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { resolveRetryAfterMs } from "../../failover/retry-evidence.js";
 import type { NormalizedUsage } from "../../usage.js";
 import { createUsageAccumulator, mergeUsageIntoAccumulator } from "../usage-accumulator.js";
 import {
@@ -11,8 +12,8 @@ import {
   resolveFinalAssistantRawText,
   resolveFinalAssistantVisibleText,
   resolveLatestCallUsage,
-  resolveNextSameModelRateLimitRetryCount,
-  resolveSameModelRateLimitRetryDelayMs,
+  MAX_TRANSIENT_RETRIES,
+  resolveTransientRetryDelayMs,
 } from "./helpers.js";
 
 describe("resolveEmbeddedAttemptBasePrompt", () => {
@@ -117,72 +118,59 @@ describe("resolveFinalAssistantVisibleText", () => {
   });
 });
 
-describe("resolveSameModelRateLimitRetryDelayMs", () => {
-  it("waits 10s/20s/30s linearly before the 1st/2nd/3rd same-model retry", () => {
-    expect(resolveSameModelRateLimitRetryDelayMs({ retriesSoFar: 0 })).toBe(10_000);
-    expect(resolveSameModelRateLimitRetryDelayMs({ retriesSoFar: 1 })).toBe(20_000);
-    expect(resolveSameModelRateLimitRetryDelayMs({ retriesSoFar: 2 })).toBe(30_000);
+describe("resolveTransientRetryDelayMs", () => {
+  it("bounds three jittered exponential retries", () => {
+    const random = vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      const delays = [1, 2, 3].map((retryNumber, index) =>
+        resolveTransientRetryDelayMs({ retryNumber, elapsedMs: delaysBefore(index) }),
+      );
+      expect(delays).toEqual([500, 1_000, 2_000]);
+      expect(MAX_TRANSIENT_RETRIES).toBe(3);
+      expect(delays.every((delay) => delay !== undefined && delay > 0)).toBe(true);
+    } finally {
+      random.mockRestore();
+    }
   });
 
-  it("caps at 60s if the retry count is ever raised further", () => {
-    expect(resolveSameModelRateLimitRetryDelayMs({ retriesSoFar: 10 })).toBe(60_000);
-  });
-
-  it("honors a short provider Retry-After when it is longer than the fixed backoff", () => {
+  it("honors Retry-After and rejects a delay beyond the total ceiling", () => {
     expect(
-      resolveSameModelRateLimitRetryDelayMs({
-        retriesSoFar: 0,
-        retryAfterSeconds: 30,
+      resolveTransientRetryDelayMs({ retryNumber: 1, retryAfterMs: 30_000, elapsedMs: 0 }),
+    ).toBeGreaterThanOrEqual(30_000);
+    expect(
+      resolveTransientRetryDelayMs({
+        retryNumber: 3,
+        retryAfterMs: 2_000,
+        // 1s of the 90s transient retry budget left; retryAfterMs exceeds it.
+        elapsedMs: 89_000,
       }),
-    ).toBe(30_000);
+    ).toBeUndefined();
   });
 
-  it("keeps the existing fixed backoff when Retry-After is shorter", () => {
-    expect(
-      resolveSameModelRateLimitRetryDelayMs({
-        retriesSoFar: 1,
-        retryAfterSeconds: 5,
-      }),
-    ).toBe(20_000);
+  it("keeps jitter below the per-retry cap", () => {
+    const random = vi.spyOn(Math, "random").mockReturnValue(0.999);
+    try {
+      expect(resolveTransientRetryDelayMs({ retryNumber: 3, elapsedMs: 0 })).toBeLessThanOrEqual(
+        30_000,
+      );
+    } finally {
+      random.mockRestore();
+    }
   });
 
-  it("caps provider Retry-After at the same short-window retry ceiling", () => {
+  it("parses Retry-After HTTP dates for the shared retry owner", () => {
     expect(
-      resolveSameModelRateLimitRetryDelayMs({
-        retriesSoFar: 0,
-        retryAfterSeconds: 120,
-      }),
-    ).toBe(60_000);
+      resolveRetryAfterMs(
+        "HTTP 503: temporary failure; Retry-After: Thu, 01 Jan 2026 00:01:30 GMT",
+        Date.parse("2026-01-01T00:00:00.000Z"),
+      ),
+    ).toBe(90_000);
   });
 });
 
-describe("resolveNextSameModelRateLimitRetryCount", () => {
-  it("counts only consecutive same-model rate-limit retries", () => {
-    let retriesSoFar = 0;
-
-    retriesSoFar = resolveNextSameModelRateLimitRetryCount({
-      retriesSoFar,
-      retriedSameModelRateLimit: true,
-    });
-    retriesSoFar = resolveNextSameModelRateLimitRetryCount({
-      retriesSoFar,
-      retriedSameModelRateLimit: true,
-    });
-    expect(retriesSoFar).toBe(2);
-
-    retriesSoFar = resolveNextSameModelRateLimitRetryCount({
-      retriesSoFar,
-      retriedSameModelRateLimit: false,
-    });
-    expect(retriesSoFar).toBe(0);
-
-    retriesSoFar = resolveNextSameModelRateLimitRetryCount({
-      retriesSoFar,
-      retriedSameModelRateLimit: true,
-    });
-    expect(retriesSoFar).toBe(1);
-  });
-});
+function delaysBefore(index: number): number {
+  return index === 0 ? 0 : index === 1 ? 500 : 1_500;
+}
 
 describe("resolveLatestCallUsage", () => {
   it("preserves the previous exact call across a zero-usage retry", () => {

--- a/src/agents/embedded-agent-runner/run/helpers.ts
+++ b/src/agents/embedded-agent-runner/run/helpers.ts
@@ -38,22 +38,13 @@ export const RUNTIME_AUTH_REFRESH_MARGIN_MS = 5 * 60 * 1000;
 export const RUNTIME_AUTH_REFRESH_RETRY_MS = 60 * 1000;
 export const RUNTIME_AUTH_REFRESH_MIN_DELAY_MS = 5 * 1000;
 
-const DEFAULT_OVERLOAD_FAILOVER_BACKOFF_MS = 0;
 const DEFAULT_MAX_OVERLOAD_PROFILE_ROTATIONS = 1;
 const DEFAULT_MAX_RATE_LIMIT_PROFILE_ROTATIONS = 1;
 
-// Same-model in-place rate_limit retry: provider RPM caps reset on a
-// minute scale, so wait out the current provider/model window before spending
-// a profile rotation or model failover.
-export const MAX_SAME_MODEL_RATE_LIMIT_RETRIES = 3;
-// Linear step: retriesSoFar=0 -> 10s, 1 -> 20s, 2 -> 30s. Total wait across the
-// 3-retry budget is 60s, roughly one RPM window.
-const SAME_MODEL_RATE_LIMIT_BACKOFF_STEP_MS = 10_000;
-const SAME_MODEL_RATE_LIMIT_MAX_BACKOFF_MS = 60_000;
-
-export function resolveOverloadFailoverBackoffMs(): number {
-  return DEFAULT_OVERLOAD_FAILOVER_BACKOFF_MS;
-}
+export const MAX_TRANSIENT_RETRIES = 3;
+const MAX_TRANSIENT_RETRY_TIME_MS = 90_000;
+const TRANSIENT_RETRY_BASE_DELAY_MS = 1_000;
+const TRANSIENT_RETRY_MAX_DELAY_MS = 30_000;
 
 export function resolveOverloadProfileRotationLimit(): number {
   return DEFAULT_MAX_OVERLOAD_PROFILE_ROTATIONS;
@@ -63,29 +54,29 @@ export function resolveRateLimitProfileRotationLimit(): number {
   return DEFAULT_MAX_RATE_LIMIT_PROFILE_ROTATIONS;
 }
 
-/**
- * Backoff before the next same-model rate_limit retry, given how many such
- * retries already happened. Linear and deterministic (no jitter) so RPM
- * windows clear predictably and tests can assert exact values.
- */
-export function resolveSameModelRateLimitRetryDelayMs(params: {
-  retriesSoFar: number;
-  retryAfterSeconds?: number;
-}): number {
-  const backoffDelayMs =
-    SAME_MODEL_RATE_LIMIT_BACKOFF_STEP_MS * (Math.max(0, params.retriesSoFar) + 1);
-  const backoffMs = Math.min(SAME_MODEL_RATE_LIMIT_MAX_BACKOFF_MS, backoffDelayMs);
-  const retryAfterMs = Number.isFinite(params.retryAfterSeconds)
-    ? Math.ceil(Math.max(0, params.retryAfterSeconds ?? 0) * 1000)
+/** Resolves jittered exponential backoff without exceeding the turn retry ceiling. */
+export function resolveTransientRetryDelayMs(params: {
+  retryNumber: number;
+  retryAfterMs?: number;
+  elapsedMs: number;
+}): number | undefined {
+  const remainingMs = MAX_TRANSIENT_RETRY_TIME_MS - Math.max(0, params.elapsedMs);
+  if (remainingMs <= 0) {
+    return undefined;
+  }
+  const exponentialMs = Math.min(
+    TRANSIENT_RETRY_MAX_DELAY_MS,
+    TRANSIENT_RETRY_BASE_DELAY_MS * 2 ** Math.max(0, params.retryNumber - 1),
+  );
+  const jitteredMs = Math.min(
+    TRANSIENT_RETRY_MAX_DELAY_MS,
+    Math.round(exponentialMs * (0.5 + Math.random())),
+  );
+  const retryAfterMs = Number.isFinite(params.retryAfterMs)
+    ? Math.max(0, Math.ceil(params.retryAfterMs ?? 0))
     : 0;
-  return Math.max(backoffMs, Math.min(SAME_MODEL_RATE_LIMIT_MAX_BACKOFF_MS, retryAfterMs));
-}
-
-export function resolveNextSameModelRateLimitRetryCount(params: {
-  retriesSoFar: number;
-  retriedSameModelRateLimit: boolean;
-}): number {
-  return params.retriedSameModelRateLimit ? Math.max(0, params.retriesSoFar) + 1 : 0;
+  const delayMs = Math.max(jitteredMs, retryAfterMs);
+  return delayMs <= remainingMs ? delayMs : undefined;
 }
 
 const ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL = "ANTHROPIC_MAGIC_STRING_TRIGGER_REFUSAL";
@@ -122,8 +113,6 @@ const RUN_RETRY_ITERATIONS_PER_PROFILE = 8;
 const MIN_RUN_RETRY_ITERATIONS = 32;
 const MAX_RUN_RETRY_ITERATIONS = 160;
 
-// This per-run bound multiplies whole-turn overload replays in
-// auto-reply/reply/agent-runner-error-handler.ts; keep their product test aligned.
 // Defensive guard for the outer run loop across all retry branches.
 export function resolveMaxRunRetryIterations(profileCandidateCount: number): number {
   const scaled =

--- a/src/agents/embedded-agent-runner/run/idle-timeout-breaker.ts
+++ b/src/agents/embedded-agent-runner/run/idle-timeout-breaker.ts
@@ -1,9 +1,8 @@
 /**
  * Cap on consecutive attempts that ended in an idle timeout without completed
  * model progress, before the outer run loop refuses to start another attempt.
- * Distinct from MAX_SAME_MODEL_IDLE_TIMEOUT_RETRIES (which gates one extra
- * retry on the same model before failover) and the broad MAX_RUN_LOOP_ITERATIONS
- * backstop in run.ts.
+ * Distinct from the transient retry owner (which gates bounded retries before
+ * failover) and the broad MAX_RUN_LOOP_ITERATIONS backstop in run.ts.
  *
  * This one fires across profile/auth retries inside the same embedded run so a
  * wedged provider cannot fan out paid model calls across every fallback profile

--- a/src/agents/embedded-agent-runner/run/prompt-failure.test.ts
+++ b/src/agents/embedded-agent-runner/run/prompt-failure.test.ts
@@ -49,7 +49,8 @@ function makeParams(overrides: Partial<Params> = {}): Params {
     advanceAuthProfile: vi.fn(async () => true),
     advanceRateLimitAuthProfile: vi.fn(async () => true),
     maybeMarkAuthProfileFailure: vi.fn(async () => {}),
-    maybeBackoffBeforeOverloadFailover: vi.fn(async () => {}),
+    maybeRetryTransient: vi.fn(async () => false),
+    getTransientRetryCount: () => 0,
     attemptedThinking: new Set(),
     thinkLevel: "low",
     getThinkLevel: () => "low",
@@ -101,7 +102,7 @@ describe("handleEmbeddedPromptFailure", () => {
         params.advanceAuthProfile,
         params.advanceRateLimitAuthProfile,
         params.maybeMarkAuthProfileFailure,
-        params.maybeBackoffBeforeOverloadFailover,
+        params.maybeRetryTransient,
       ]) {
         expect(callback).not.toHaveBeenCalled();
       }
@@ -163,9 +164,6 @@ describe("handleEmbeddedPromptFailure", () => {
             return true;
           }),
           maybeMarkAuthProfileFailure,
-          maybeBackoffBeforeOverloadFailover: vi.fn(async () => {
-            events.push("backoff");
-          }),
         }),
       );
 
@@ -175,7 +173,7 @@ describe("handleEmbeddedPromptFailure", () => {
         authRetryPending: false,
         lastRetryFailoverReason: "rate_limit",
       });
-      expect(events).toEqual(["advance", "mark-start", "backoff"]);
+      expect(events).toEqual(["advance", "mark-start"]);
       expect(maybeMarkAuthProfileFailure).toHaveBeenCalledWith({
         profileId: "openai:p1",
         reason: "rate_limit",
@@ -185,8 +183,6 @@ describe("handleEmbeddedPromptFailure", () => {
       releaseMark?.();
     }
 
-    await vi.waitFor(() =>
-      expect(events).toEqual(["advance", "mark-start", "backoff", "mark-finish"]),
-    );
+    await vi.waitFor(() => expect(events).toEqual(["advance", "mark-start", "mark-finish"]));
   });
 });

--- a/src/agents/embedded-agent-runner/run/prompt-failure.ts
+++ b/src/agents/embedded-agent-runner/run/prompt-failure.ts
@@ -16,6 +16,7 @@ import {
   FailoverError,
   resolveFailoverStatus,
 } from "../../failover-error.js";
+import { resolveRetryAfterMs } from "../../failover/retry-evidence.js";
 import {
   resolveSessionSuspensionReason,
   type SessionSuspensionParams,
@@ -79,7 +80,11 @@ export async function handleEmbeddedPromptFailure(input: {
     reason?: AuthProfileFailureReason | null;
     modelId?: string;
   }) => Promise<void>;
-  maybeBackoffBeforeOverloadFailover: (reason: FailoverReason | null) => Promise<void>;
+  maybeRetryTransient: (retry: {
+    reason: FailoverReason;
+    retryAfterMs?: number;
+  }) => Promise<boolean>;
+  getTransientRetryCount: () => number;
   attemptedThinking: Set<ThinkLevel>;
   thinkLevel: ThinkLevel;
   // Profile rotation resets thinking inside the runtime; read it after advancing.
@@ -168,6 +173,8 @@ export async function handleEmbeddedPromptFailure(input: {
     profileId: failedProfileId,
     fallbackConfigured: input.fallbackConfigured,
     aborted: input.aborted,
+    retryCount: input.getTransientRetryCount(),
+    attemptCount: input.traceAttempts.length + 1,
   });
   let failoverDecision = resolveRunFailoverDecision({
     stage: "prompt",
@@ -182,6 +189,33 @@ export async function handleEmbeddedPromptFailure(input: {
     timedOutByRunBudget: input.timedOutByRunBudget,
     profileRotated: false,
   });
+  const canRetryRateLimit =
+    promptFailoverReason !== "rate_limit" || isShortWindowRateLimitMessage(errorText);
+  if (
+    !input.externalAbort &&
+    canRetryRateLimit &&
+    promptFailoverReason &&
+    (failoverDecision.action === "rotate_profile" ||
+      failoverDecision.action === "fallback_model" ||
+      failoverDecision.action === "surface_error") &&
+    (await input.maybeRetryTransient({
+      reason: promptFailoverReason,
+      retryAfterMs: resolveRetryAfterMs(errorText),
+    }))
+  ) {
+    logFailoverDecision("retry_same_model", {
+      retryCount: input.getTransientRetryCount(),
+    });
+    return {
+      action: "retry",
+      thinkLevel: input.thinkLevel,
+      authRetryPending: false,
+      lastRetryFailoverReason: mergeRetryFailoverReason({
+        previous: input.previousRetryFailoverReason,
+        failoverReason: promptFailoverReason,
+      }),
+    };
+  }
   let rotated = false;
   if (failoverDecision.action === "rotate_profile") {
     if (promptFailoverReason === "rate_limit") {
@@ -217,8 +251,10 @@ export async function handleEmbeddedPromptFailure(input: {
       previous: input.previousRetryFailoverReason,
       failoverReason: promptFailoverReason,
     });
-    logFailoverDecision("rotate_profile");
-    await input.maybeBackoffBeforeOverloadFailover(promptFailoverReason);
+    logFailoverDecision("rotate_profile", {
+      retryCount: input.getTransientRetryCount(),
+      profileRotationCount: rotated ? 1 : 0,
+    });
     return {
       action: "retry",
       thinkLevel: input.getThinkLevel(),
@@ -260,6 +296,9 @@ export async function handleEmbeddedPromptFailure(input: {
     log.warn(
       `unsupported thinking level for ${input.provider}/${input.modelId}; retrying with ${fallbackThinking}`,
     );
+    logFailoverDecision("retry_thinking_level", {
+      retryCount: input.getTransientRetryCount(),
+    });
     return {
       action: "retry",
       thinkLevel: fallbackThinking,
@@ -278,8 +317,11 @@ export async function handleEmbeddedPromptFailure(input: {
       stage: "prompt",
       ...(typeof status === "number" ? { status } : {}),
     });
-    logFailoverDecision("fallback_model", { status });
-    await input.maybeBackoffBeforeOverloadFailover(promptFailoverReason);
+    logFailoverDecision("fallback_model", {
+      status,
+      retryCount: input.getTransientRetryCount(),
+      profileRotationCount: 0,
+    });
     throw (
       (normalizedPromptFailover?.reason === fallbackReason ? normalizedPromptFailover : null) ??
       new FailoverError(errorText, {
@@ -302,7 +344,10 @@ export async function handleEmbeddedPromptFailure(input: {
       ...(promptFailoverReason ? { reason: promptFailoverReason } : {}),
       stage: "prompt",
     });
-    logFailoverDecision("surface_error");
+    logFailoverDecision("surface_error", {
+      retryCount: input.getTransientRetryCount(),
+      profileRotationCount: 0,
+    });
   }
   throw toErrorObject(input.promptError, "Prompt failed");
 }

--- a/src/agents/embedded-agent-runner/run/types.ts
+++ b/src/agents/embedded-agent-runner/run/types.ts
@@ -295,6 +295,8 @@ export type EmbeddedRunAttemptResult = {
   finalPromptText?: string;
   /** Exact provider-response count when the harness can observe model iterations directly. */
   modelIterations?: number;
+  /** Saved provider retry setting resolved by the prepared session owner. */
+  providerRetryMaxRetries?: number;
   messagesSnapshot: AgentMessage[];
   /** Owner-eligible settled finalization, with frozen evidence or an unavailable projection. */
   settledTurnFinalizationContext?:

--- a/src/agents/embedded-agent-runner/types.ts
+++ b/src/agents/embedded-agent-runner/types.ts
@@ -112,7 +112,7 @@ export type TraceAttempt = {
     | "surface_error"
     | "candidate_failed"
     | "rotate_profile"
-    | "same_model_rate_limit"
+    | "same_model_transient"
     | "fallback_model"
     | "aborted"
     | "error";

--- a/src/agents/failover/assistant-request-failure-copy.ts
+++ b/src/agents/failover/assistant-request-failure-copy.ts
@@ -33,7 +33,11 @@ export function renderAssistantRequestFailureCopy(
   const provider = facts.provider?.trim();
   const model = facts.model?.trim();
   const target = provider && model ? `${provider}/${model}` : provider || model;
-  const reason = facts.reason ? ASSISTANT_REQUEST_FAILURE_REASON[facts.reason] : undefined;
+  const normalizedReason =
+    facts.reason === "timeout" && typeof facts.status === "number" && facts.status >= 500
+      ? "server_error"
+      : facts.reason;
+  const reason = normalizedReason ? ASSISTANT_REQUEST_FAILURE_REASON[normalizedReason] : undefined;
   const httpStatus = facts.status;
   const status =
     typeof httpStatus === "number" &&
@@ -48,10 +52,10 @@ export function renderAssistantRequestFailureCopy(
   const details = [reason, status].filter(Boolean);
   const summary = `⚠️ ${target ? `${target} request failed` : "LLM request failed"}${details.length > 0 ? ` (${details.join(", ")})` : ""}.`;
   if (
-    facts.reason === "overloaded" ||
-    facts.reason === "server_error" ||
-    facts.reason === "timeout" ||
-    facts.reason === "rate_limit"
+    normalizedReason === "overloaded" ||
+    normalizedReason === "server_error" ||
+    normalizedReason === "timeout" ||
+    normalizedReason === "rate_limit"
   ) {
     return `${summary} This is usually temporary — try again shortly.`;
   }

--- a/src/agents/failover/classification-rules.ts
+++ b/src/agents/failover/classification-rules.ts
@@ -388,7 +388,7 @@ function hasBillingApiErrorType(raw: string): boolean {
 function isAmbiguousGeneric429BalanceMessage(raw: string): boolean {
   return /\binsufficient\s+account\s+balance\b/i.test(raw) && !hasStructuredBilling429Signal(raw);
 }
-export function isBilling429MessageForProvider(raw: string, provider: string | undefined): boolean {
+function isBilling429MessageForProvider(raw: string, provider: string | undefined): boolean {
   if (!isBillingErrorMessage(raw)) {
     return false;
   }

--- a/src/agents/failover/classification-rules.ts
+++ b/src/agents/failover/classification-rules.ts
@@ -388,7 +388,7 @@ function hasBillingApiErrorType(raw: string): boolean {
 function isAmbiguousGeneric429BalanceMessage(raw: string): boolean {
   return /\binsufficient\s+account\s+balance\b/i.test(raw) && !hasStructuredBilling429Signal(raw);
 }
-function isBilling429MessageForProvider(raw: string, provider: string | undefined): boolean {
+export function isBilling429MessageForProvider(raw: string, provider: string | undefined): boolean {
   if (!isBillingErrorMessage(raw)) {
     return false;
   }

--- a/src/agents/failover/classify.predicates.test.ts
+++ b/src/agents/failover/classify.predicates.test.ts
@@ -1,5 +1,6 @@
 // Covers message predicates whose truth values intentionally differ from the central outcome.
 import { describe, expect, it } from "vitest";
+import { isTransientHttpError } from "./classification-rules.js";
 import {
   classifyFailoverReason,
   isAuthErrorMessage,
@@ -8,7 +9,6 @@ import {
   isContextOverflowError,
   isFailoverErrorMessage,
   isTimeoutErrorMessage,
-  isTransientHttpError,
 } from "./classify.js";
 import { isAuthPermanentErrorMessage } from "./message-patterns.js";
 

--- a/src/agents/failover/classify.ts
+++ b/src/agents/failover/classify.ts
@@ -51,12 +51,7 @@ import {
   type PreparedProviderFailoverOwner,
 } from "./provider-patterns.js";
 import type { FailoverClassification, FailoverReason, FailoverSignal } from "./signal.js";
-export {
-  isBilling429MessageForProvider,
-  isGenericUnknownStreamErrorMessage,
-  isTransientHttpError,
-  isUnclassifiedNoBodyHttpSignal,
-} from "./classification-rules.js";
+export { isUnclassifiedNoBodyHttpSignal } from "./classification-rules.js";
 export {
   isContextOverflowError,
   isLikelyContextOverflowError,

--- a/src/agents/failover/classify.ts
+++ b/src/agents/failover/classify.ts
@@ -52,6 +52,7 @@ import {
 } from "./provider-patterns.js";
 import type { FailoverClassification, FailoverReason, FailoverSignal } from "./signal.js";
 export {
+  isBilling429MessageForProvider,
   isGenericUnknownStreamErrorMessage,
   isTransientHttpError,
   isUnclassifiedNoBodyHttpSignal,

--- a/src/agents/failover/failover-classification.corpus.test.ts
+++ b/src/agents/failover/failover-classification.corpus.test.ts
@@ -90,7 +90,6 @@ describe("cross-layer drift (documents current behavior, see refactor-02)", () =
     expect(classifyReplyRequest({ message })).toMatchObject({
       code: "provider_internal_error",
       technicalMessage: message,
-      allowTransientHttpRetry: true,
     });
   });
 

--- a/src/agents/failover/retry-evidence.ts
+++ b/src/agents/failover/retry-evidence.ts
@@ -91,6 +91,16 @@ function parseRetryAfterSeconds(valueText: string, nowMs: number): number | unde
   return retryAtMs === undefined ? undefined : Math.max(0, (retryAtMs - nowMs) / 1000);
 }
 
+/** Extracts a bounded retry hint from provider error text. */
+export function resolveRetryAfterMs(
+  message: string | undefined,
+  nowMs = Date.now(),
+): number | undefined {
+  const value = message?.trim() ? RETRY_AFTER_VALUE_RE.exec(message)?.[1]?.trim() : undefined;
+  const seconds = value ? parseRetryAfterSeconds(value, nowMs) : undefined;
+  return seconds === undefined ? undefined : Math.ceil(seconds * 1000);
+}
+
 /** Classify provider rate-limit text without deciding a caller's retry policy. */
 export function classifyRateLimitWindow(
   message: string | undefined,

--- a/src/agents/failover/signal.ts
+++ b/src/agents/failover/signal.ts
@@ -9,6 +9,7 @@ export const FAILOVER_REASONS = PROTOCOL_FAILOVER_REASONS;
 export type FailoverReason = (typeof FAILOVER_REASONS)[number];
 export type FailoverSignal = {
   status?: number;
+  retryAfterMs?: number;
   code?: string;
   errorType?: string;
   message?: string;

--- a/src/agents/failover/user-copy.ts
+++ b/src/agents/failover/user-copy.ts
@@ -425,7 +425,6 @@ export function resolveProviderRequestFailureCopy(params: {
     code,
     userMessage,
     technicalMessage: params.technicalMessage,
-    ...(params.facet === "provider-internal-503" ? { allowTransientHttpRetry: true as const } : {}),
   };
 }
 

--- a/src/agents/openai-transport-stream.base.test.ts
+++ b/src/agents/openai-transport-stream.base.test.ts
@@ -1214,10 +1214,11 @@ describe("openai transport stream", () => {
 
     expect(testing.buildOpenAISdkRequestOptions(codexModel, undefined, { stream: true })).toEqual({
       headers: { Accept: "text/event-stream" },
+      maxRetries: 0,
     });
     expect(
       testing.buildOpenAISdkRequestOptions(transportAliasModel, undefined, { stream: true }),
-    ).toEqual({ headers: { Accept: "text/event-stream" } });
+    ).toEqual({ headers: { Accept: "text/event-stream" }, maxRetries: 0 });
     expect(testing.buildOpenAISdkRequestOptions(codexModel)).toBeUndefined();
     expect(
       testing.buildOpenAISdkRequestOptions(nonNativeChatGPTModel, undefined, { stream: true }),

--- a/src/agents/openai-transport-stream.failed-sse.test.ts
+++ b/src/agents/openai-transport-stream.failed-sse.test.ts
@@ -105,7 +105,7 @@ describe("failed Responses loopback SSE", () => {
             messages: [{ role: "user", content: "Report failed usage", timestamp: 0 }],
             tools: [],
           },
-          { apiKey: "test-key", maxRetries: 0 },
+          { apiKey: "test-key" },
         );
         const events = [];
         for await (const event of stream) {

--- a/src/agents/openai-transport-stream.incomplete-sse.test.ts
+++ b/src/agents/openai-transport-stream.incomplete-sse.test.ts
@@ -90,7 +90,7 @@ describe("incomplete Responses loopback SSE", () => {
           messages: [{ role: "user", content: "Reply with a partial sentence", timestamp: 0 }],
           tools: [],
         },
-        { apiKey: "test-key", maxRetries: 0 },
+        { apiKey: "test-key" },
       );
       const events = [];
       for await (const event of stream) {

--- a/src/agents/openai-transport-stream.streaming.test.ts
+++ b/src/agents/openai-transport-stream.streaming.test.ts
@@ -109,7 +109,7 @@ describe("openai transport stream", () => {
             messages: [{ role: "user", content: "Reply OK", timestamp: Date.now() }],
             tools: [],
           },
-          { apiKey: "test-key", timeoutMs: 1_234, maxRetries: 0 },
+          { apiKey: "test-key", timeoutMs: 1_234 },
         );
 
         const eventTypes: string[] = [];

--- a/src/agents/sessions/agent-session.live.test.ts
+++ b/src/agents/sessions/agent-session.live.test.ts
@@ -132,7 +132,7 @@ async function createLiveSession(
     compaction: { enabled: true, reserveTokens: 128, keepRecentTokens: 0 },
     retry: {
       enabled: false,
-      provider: { timeoutMs: PROVIDER_TIMEOUT_MS, maxRetries: 0, maxRetryDelayMs: 0 },
+      provider: { timeoutMs: PROVIDER_TIMEOUT_MS, maxRetryDelayMs: 0 },
     },
   });
   const { session } = await createAgentSession({

--- a/src/agents/sessions/agent-session.openai-compaction.live.test.ts
+++ b/src/agents/sessions/agent-session.openai-compaction.live.test.ts
@@ -140,7 +140,7 @@ async function createLiveSession() {
     },
     retry: {
       enabled: false,
-      provider: { timeoutMs: STRESS_PROFILE.providerTimeoutMs, maxRetries: 0, maxRetryDelayMs: 0 },
+      provider: { timeoutMs: STRESS_PROFILE.providerTimeoutMs, maxRetryDelayMs: 0 },
     },
   });
   const contextChunk = buildContextChunk(STRESS_PROFILE.chunkChars);

--- a/src/agents/sessions/sdk.ts
+++ b/src/agents/sessions/sdk.ts
@@ -458,7 +458,6 @@ async function createAgentSessionImpl(
         ...optionsLocal,
         apiKey: auth.apiKey,
         timeoutMs: optionsLocal?.timeoutMs ?? providerRetrySettings.timeoutMs,
-        maxRetries: optionsLocal?.maxRetries ?? providerRetrySettings.maxRetries,
         maxRetryDelayMs: optionsLocal?.maxRetryDelayMs ?? providerRetrySettings.maxRetryDelayMs,
         headers:
           attributionHeaders || auth.headers || optionsLocal?.headers

--- a/src/agents/sessions/settings-manager.test.ts
+++ b/src/agents/sessions/settings-manager.test.ts
@@ -152,19 +152,18 @@ describe("SettingsManager runtime overrides", () => {
   it("recursively merges provider retry overrides and replaces arrays", () => {
     const settingsManager = SettingsManager.inMemory({
       retry: {
-        provider: { timeoutMs: 30_000, maxRetries: 2, maxRetryDelayMs: 60_000 },
+        provider: { timeoutMs: 30_000, maxRetryDelayMs: 60_000 },
       },
       packages: ["npm:@openclaw/base"],
     });
 
     settingsManager.applyOverrides({
-      retry: { provider: { maxRetries: 5 } },
+      retry: { provider: { timeoutMs: 45_000 } },
       packages: ["npm:@openclaw/override"],
     });
 
     expect(settingsManager.getProviderRetrySettings()).toEqual({
-      timeoutMs: 30_000,
-      maxRetries: 5,
+      timeoutMs: 45_000,
       maxRetryDelayMs: 60_000,
     });
     expect(settingsManager.getPackages()).toEqual(["npm:@openclaw/override"]);

--- a/src/agents/sessions/settings-manager.ts
+++ b/src/agents/sessions/settings-manager.ts
@@ -476,10 +476,9 @@ export class SettingsManager {
     this.setScopedSetting("global", "httpIdleTimeoutMs", Math.floor(timeoutMs));
   }
 
-  getProviderRetrySettings(): { timeoutMs?: number; maxRetries?: number; maxRetryDelayMs: number } {
+  getProviderRetrySettings(): { timeoutMs?: number; maxRetryDelayMs: number } {
     return {
       timeoutMs: this.settings.retry?.provider?.timeoutMs,
-      maxRetries: this.settings.retry?.provider?.maxRetries,
       maxRetryDelayMs: this.settings.retry?.provider?.maxRetryDelayMs ?? 60000,
     };
   }

--- a/src/agents/sessions/settings-manager.ts
+++ b/src/agents/sessions/settings-manager.ts
@@ -476,9 +476,10 @@ export class SettingsManager {
     this.setScopedSetting("global", "httpIdleTimeoutMs", Math.floor(timeoutMs));
   }
 
-  getProviderRetrySettings(): { timeoutMs?: number; maxRetryDelayMs: number } {
+  getProviderRetrySettings(): { timeoutMs?: number; maxRetries?: number; maxRetryDelayMs: number } {
     return {
       timeoutMs: this.settings.retry?.provider?.timeoutMs,
+      maxRetries: this.settings.retry?.provider?.maxRetries,
       maxRetryDelayMs: this.settings.retry?.provider?.maxRetryDelayMs ?? 60000,
     };
   }

--- a/src/agents/sessions/settings-storage.test.ts
+++ b/src/agents/sessions/settings-storage.test.ts
@@ -12,7 +12,7 @@ const fixtures = createFixtureLifetime();
 afterEach(() => fixtures.cleanup());
 
 describe("FileSettingsStorage", () => {
-  it("removes retired provider retries on the next settings write", async () => {
+  it("preserves provider retry settings across an upgraded settings write", async () => {
     const root = fixtures.createTempDir("openclaw-settings-retry-migration-");
     const agentDir = join(root, "agent");
     const settingsPath = join(agentDir, "settings.json");
@@ -24,14 +24,16 @@ describe("FileSettingsStorage", () => {
 
     const manager = SettingsManager.create(root, agentDir);
     expect(manager.drainErrors()).toEqual([]);
-    expect(manager.getProviderRetrySettings()).toMatchObject({ timeoutMs: 1_000 });
+    expect(manager.getProviderRetrySettings()).toMatchObject({
+      timeoutMs: 1_000,
+      maxRetries: 7,
+    });
 
     manager.setRetryEnabled(false);
     await manager.flush();
 
     const stored = JSON.parse(readFileSync(settingsPath, "utf8"));
-    expect(stored.retry.provider).toEqual({ timeoutMs: 1_000 });
-    expect(stored.retry.provider).not.toHaveProperty("maxRetries");
+    expect(stored.retry.provider).toEqual({ maxRetries: 7, timeoutMs: 1_000 });
   });
 
   it("loads missing settings without creating their directories", () => {

--- a/src/agents/sessions/settings-storage.test.ts
+++ b/src/agents/sessions/settings-storage.test.ts
@@ -12,6 +12,28 @@ const fixtures = createFixtureLifetime();
 afterEach(() => fixtures.cleanup());
 
 describe("FileSettingsStorage", () => {
+  it("removes retired provider retries on the next settings write", async () => {
+    const root = fixtures.createTempDir("openclaw-settings-retry-migration-");
+    const agentDir = join(root, "agent");
+    const settingsPath = join(agentDir, "settings.json");
+    mkdirSync(agentDir);
+    fs.writeFileSync(
+      settingsPath,
+      JSON.stringify({ retry: { provider: { maxRetries: 7, timeoutMs: 1_000 } } }),
+    );
+
+    const manager = SettingsManager.create(root, agentDir);
+    expect(manager.drainErrors()).toEqual([]);
+    expect(manager.getProviderRetrySettings()).toMatchObject({ timeoutMs: 1_000 });
+
+    manager.setRetryEnabled(false);
+    await manager.flush();
+
+    const stored = JSON.parse(readFileSync(settingsPath, "utf8"));
+    expect(stored.retry.provider).toEqual({ timeoutMs: 1_000 });
+    expect(stored.retry.provider).not.toHaveProperty("maxRetries");
+  });
+
   it("loads missing settings without creating their directories", () => {
     const root = fixtures.createTempDir("openclaw-settings-read-");
     const settingsDir = join(root, "agent");

--- a/src/agents/sessions/settings-storage.ts
+++ b/src/agents/sessions/settings-storage.ts
@@ -17,7 +17,9 @@ export interface BranchSummarySettings {
 
 export interface ProviderRetrySettings {
   timeoutMs?: number; // SDK/provider request timeout in milliseconds
-  maxRetries?: number; // SDK/provider retry attempts
+  // maxRetries retired: the embedded runner's failover retry controller is the
+  // only provider retry owner; transports pin SDK retries to 0. Persisted
+  // values are ignored on load.
   maxRetryDelayMs?: number; // default: 60000 (max server-requested delay before failing)
 }
 

--- a/src/agents/sessions/settings-storage.ts
+++ b/src/agents/sessions/settings-storage.ts
@@ -134,10 +134,11 @@ function stripRetiredProviderMaxRetries(content: string | undefined): string | u
   if (content === undefined) {
     return undefined;
   }
-  const settings = JSON.parse(content) as Record<string, unknown>;
-  const retry = asOptionalObjectRecord(settings.retry);
+  const parsed: unknown = JSON.parse(content);
+  const settings = asOptionalObjectRecord(parsed);
+  const retry = asOptionalObjectRecord(settings?.retry);
   const provider = asOptionalObjectRecord(retry?.provider);
-  if (!provider || !("maxRetries" in provider)) {
+  if (!settings || !provider || !("maxRetries" in provider)) {
     return content;
   }
   delete provider.maxRetries;

--- a/src/agents/sessions/settings-storage.ts
+++ b/src/agents/sessions/settings-storage.ts
@@ -1,6 +1,5 @@
 import { existsSync, lstatSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import { acquireFileLockSyncWithRetry } from "../../infra/file-lock-sync.js";
 import type { Transport } from "../../llm/types.js";
 import { CONFIG_DIR_NAME } from "../config.js";
@@ -18,8 +17,7 @@ export interface BranchSummarySettings {
 
 export interface ProviderRetrySettings {
   timeoutMs?: number; // SDK/provider request timeout in milliseconds
-  // maxRetries is retired. FileSettingsStorage removes it from persisted data;
-  // the embedded runner's failover retry controller owns provider retries.
+  maxRetries?: number; // transient provider retry attempts
   maxRetryDelayMs?: number; // default: 60000 (max server-requested delay before failing)
 }
 
@@ -130,21 +128,6 @@ export interface SettingsError {
   error: Error;
 }
 
-function stripRetiredProviderMaxRetries(content: string | undefined): string | undefined {
-  if (content === undefined) {
-    return undefined;
-  }
-  const parsed: unknown = JSON.parse(content);
-  const settings = asOptionalObjectRecord(parsed);
-  const retry = asOptionalObjectRecord(settings?.retry);
-  const provider = asOptionalObjectRecord(retry?.provider);
-  if (!settings || !provider || !("maxRetries" in provider)) {
-    return content;
-  }
-  delete provider.maxRetries;
-  return JSON.stringify(settings);
-}
-
 export class FileSettingsStorage implements SettingsStorage {
   private paths: Record<SettingsScope, string>;
 
@@ -180,9 +163,7 @@ export class FileSettingsStorage implements SettingsStorage {
     // read and derive their updates only after that shared ownership is established.
     const release = acquireFileLockSyncWithRetry(path);
     try {
-      const current = stripRetiredProviderMaxRetries(
-        existsSync(path) ? readFileSync(path, "utf-8") : undefined,
-      );
+      const current = existsSync(path) ? readFileSync(path, "utf-8") : undefined;
       const next = fn(current);
       if (next !== undefined) {
         writeFileSync(path, next, "utf-8");

--- a/src/agents/sessions/settings-storage.ts
+++ b/src/agents/sessions/settings-storage.ts
@@ -1,5 +1,6 @@
 import { existsSync, lstatSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import { acquireFileLockSyncWithRetry } from "../../infra/file-lock-sync.js";
 import type { Transport } from "../../llm/types.js";
 import { CONFIG_DIR_NAME } from "../config.js";
@@ -17,9 +18,8 @@ export interface BranchSummarySettings {
 
 export interface ProviderRetrySettings {
   timeoutMs?: number; // SDK/provider request timeout in milliseconds
-  // maxRetries retired: the embedded runner's failover retry controller is the
-  // only provider retry owner; transports pin SDK retries to 0. Persisted
-  // values are ignored on load.
+  // maxRetries is retired. FileSettingsStorage removes it from persisted data;
+  // the embedded runner's failover retry controller owns provider retries.
   maxRetryDelayMs?: number; // default: 60000 (max server-requested delay before failing)
 }
 
@@ -130,6 +130,20 @@ export interface SettingsError {
   error: Error;
 }
 
+function stripRetiredProviderMaxRetries(content: string | undefined): string | undefined {
+  if (content === undefined) {
+    return undefined;
+  }
+  const settings = JSON.parse(content) as Record<string, unknown>;
+  const retry = asOptionalObjectRecord(settings.retry);
+  const provider = asOptionalObjectRecord(retry?.provider);
+  if (!provider || !("maxRetries" in provider)) {
+    return content;
+  }
+  delete provider.maxRetries;
+  return JSON.stringify(settings);
+}
+
 export class FileSettingsStorage implements SettingsStorage {
   private paths: Record<SettingsScope, string>;
 
@@ -165,7 +179,9 @@ export class FileSettingsStorage implements SettingsStorage {
     // read and derive their updates only after that shared ownership is established.
     const release = acquireFileLockSyncWithRetry(path);
     try {
-      const current = existsSync(path) ? readFileSync(path, "utf-8") : undefined;
+      const current = stripRetiredProviderMaxRetries(
+        existsSync(path) ? readFileSync(path, "utf-8") : undefined,
+      );
       const next = fn(current);
       if (next !== undefined) {
         writeFileSync(path, next, "utf-8");

--- a/src/auto-reply/reply/agent-runner-error-handler.ts
+++ b/src/auto-reply/reply/agent-runner-error-handler.ts
@@ -6,10 +6,8 @@ import {
 import {
   isCompactionFailureError,
   isLikelyContextOverflowError,
-  isTransientHttpError,
 } from "../../agents/embedded-agent-helpers.js";
 import { sanitizeUserFacingText } from "../../agents/embedded-agent-helpers/sanitize-user-facing-text.js";
-import { renderUserFacingText } from "../../agents/embedded-agent-helpers/user-facing-text.js";
 import { findCliTimeoutError, isFailoverError } from "../../agents/failover-error.js";
 import {
   GENERIC_EXTERNAL_RUN_FAILURE_TEXT,
@@ -22,12 +20,9 @@ import {
 } from "../../agents/failover/user-copy.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import { isAgentRunRestartAbortReason } from "../../agents/run-termination.js";
-import { logVerbose } from "../../globals.js";
-import { sleepWithAbort } from "../../infra/backoff.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { CommandLaneClearedError, GatewayDrainingError } from "../../process/command-queue.js";
 import { defaultRuntime } from "../../runtime.js";
-import { markReplyPayloadForSourceSuppressionDelivery } from "../reply-payload.js";
 import { createAgentLifecycleTerminalBackstop } from "./agent-lifecycle-terminal.js";
 import { buildContextOverflowRecoveryText } from "./agent-runner-context-recovery.js";
 import type { AgentTurnInternalResult, AgentTurnParams } from "./agent-runner-execution.types.js";
@@ -50,53 +45,6 @@ import {
 } from "./reply-operation-abort.js";
 
 const MAX_LIVE_SWITCH_RETRIES = 2;
-const TRANSIENT_HTTP_RETRY_DELAY_MS = 2_500;
-// Overload recovery stays inside one turn: bounded backoff absorbs short provider incidents,
-// while the delayed notice prevents a long silent wait without becoming assistant content.
-// This whole-turn bound multiplies the 32..160 per-run budget in
-// agents/embedded-agent-runner/run/helpers.ts; keep their product test aligned.
-const MAX_OVERLOAD_RETRIES = 10;
-const OVERLOAD_RETRY_BASE_DELAY_MS = 2_500;
-const OVERLOAD_RETRY_MAX_DELAY_MS = 30_000;
-const OVERLOAD_RETRY_NOTICE_AFTER_MS = 30_000;
-const OVERLOAD_RETRY_NOTICE_DELIVERY_TIMEOUT_MS = 5_000;
-const OVERLOAD_RETRY_NOTICE_TEXT =
-  "The AI service is temporarily overloaded. I’m still retrying; this may take a few minutes.";
-
-export type OverloadRetryState = {
-  retryCount: number;
-  turnStartedAtMs: number;
-  unsafeToReplay: boolean;
-  noticeSent: boolean;
-  noticeTimer?: ReturnType<typeof setTimeout>;
-  noticeDelivery?: Promise<void>;
-  noticeAbortController?: AbortController;
-  noticeAbortCleanup?: () => void;
-  completed: boolean;
-};
-
-function stopOverloadRetryNotice(state: OverloadRetryState, reason: Error) {
-  if (state.noticeTimer) {
-    clearTimeout(state.noticeTimer);
-    state.noticeTimer = undefined;
-  }
-  state.noticeAbortCleanup?.();
-  state.noticeAbortCleanup = undefined;
-  state.noticeAbortController?.abort(reason);
-}
-
-/** Prevents a full-turn replay or stale retry notice after observable work begins. */
-export function markOverloadRetryUnsafeToReplay(state: OverloadRetryState): void {
-  state.unsafeToReplay = true;
-  stopOverloadRetryNotice(state, new Error("overload retry became unsafe to replay"));
-}
-
-/** Stops the turn-owned overload notice once no retry can still be running. */
-export async function cancelOverloadRetryNotice(state: OverloadRetryState): Promise<void> {
-  state.completed = true;
-  stopOverloadRetryNotice(state, new Error("overload retry finished"));
-  await state.noticeDelivery;
-}
 
 type ErrorAction =
   | { kind: "retry"; liveModelSwitchError?: LiveSessionModelSwitchError }
@@ -111,8 +59,6 @@ export async function handleAgentExecutionError(params: {
   liveModelSwitchRetries: number;
   shouldSurfaceToControlUi: boolean;
   timing: AgentTurnTimingTracker;
-  overloadRetryState: OverloadRetryState;
-  consumeTransientHttpRetry: () => boolean;
   modelPatch: { fail: (error: unknown) => Promise<void> };
 }): Promise<ErrorAction> {
   const turn = params.turn;
@@ -129,7 +75,7 @@ export async function handleAgentExecutionError(params: {
       createAgentLifecycleTerminalBackstop({
         runId: params.runId,
         sessionKey: turn.sessionKey,
-        startedAt: params.overloadRetryState.turnStartedAtMs,
+        startedAt: params.state.turnStartedAtMs,
         getLifecycleGeneration: () => params.state.lifecycleGeneration,
         resolveTerminationFields: (error) =>
           resolveReplyOperationTerminationFields(
@@ -156,18 +102,6 @@ export async function handleAgentExecutionError(params: {
       terminalMetadata,
     );
     return { kind: "aborted", reason };
-  };
-  const waitForRetryBackoff = async (delayMs: number, abortSignal?: AbortSignal) => {
-    try {
-      await sleepWithAbort(delayMs, abortSignal);
-    } catch (error) {
-      const abortAction = resolveReplyOperationAbortAction(error);
-      if (!abortAction) {
-        throw error;
-      }
-      return abortAction;
-    }
-    return undefined;
   };
   const replyOperationAbortAction = resolveReplyOperationAbortAction(err);
   if (replyOperationAbortAction) {
@@ -240,10 +174,6 @@ export async function handleAgentExecutionError(params: {
     !params.shouldSurfaceToControlUi
       ? failoverFacts.providerRequestError
       : undefined;
-  const isTransientHttp =
-    isTransientHttpError(message) ||
-    (isFailoverError(err) && (err.reason === "timeout" || err.reason === "server_error"));
-
   const restartLifecycleError = resolveRestartLifecycleError(err);
   if (
     restartLifecycleError instanceof GatewayDrainingError ||
@@ -284,162 +214,18 @@ export async function handleAgentExecutionError(params: {
       }),
     };
   }
-  // The CLI boundary records this fact even when phase callbacks do not arrive.
-  // Replaying an observed turn may duplicate already-started side effects.
-  if (findCliTimeoutError(err)?.cliTimeout.observedActivity === true) {
-    markOverloadRetryUnsafeToReplay(params.overloadRetryState);
-  }
-  if (
-    isOverloaded &&
-    !params.overloadRetryState.unsafeToReplay &&
-    params.overloadRetryState.retryCount < MAX_OVERLOAD_RETRIES
-  ) {
-    params.overloadRetryState.retryCount += 1;
-    const retryCount = params.overloadRetryState.retryCount;
-    const retryDelayMs = Math.min(
-      OVERLOAD_RETRY_BASE_DELAY_MS * 2 ** (retryCount - 1),
-      OVERLOAD_RETRY_MAX_DELAY_MS,
-    );
-    const retryAbortSignal = turn.replyOperation?.abortSignal ?? turn.opts?.abortSignal;
-    const scheduleRetryNotice = () => {
-      if (
-        params.overloadRetryState.noticeSent ||
-        params.overloadRetryState.noticeTimer ||
-        params.overloadRetryState.completed ||
-        retryAbortSignal?.aborted ||
-        turn.isHeartbeat ||
-        !turn.opts?.onBlockReply
-      ) {
-        return;
-      }
-      const deliver = turn.opts.onBlockReply;
-      if (!deliver) {
-        return;
-      }
-      const sendRetryNotice = () => {
-        params.overloadRetryState.noticeTimer = undefined;
-        if (
-          params.overloadRetryState.noticeSent ||
-          params.overloadRetryState.completed ||
-          params.overloadRetryState.unsafeToReplay ||
-          retryAbortSignal?.aborted
-        ) {
-          return;
-        }
-        params.overloadRetryState.noticeSent = true;
-        turn.replyOperation?.recordActivity();
-        const currentMessageId = turn.sessionCtx.MessageSidFull ?? turn.sessionCtx.MessageSid;
-        const noticePayload = markReplyPayloadForSourceSuppressionDelivery(
-          turn.applyReplyToMode({
-            text: OVERLOAD_RETRY_NOTICE_TEXT,
-            ...(currentMessageId ? { replyToId: currentMessageId } : {}),
-            replyToCurrent: true,
-            isStatusNotice: true,
-          }),
-        );
-        const deliveryAbortController = new AbortController();
-        params.overloadRetryState.noticeAbortController = deliveryAbortController;
-        let deliveryTimeout: ReturnType<typeof setTimeout> | undefined;
-        const deliveryAborted = new Promise<void>((resolve) => {
-          deliveryAbortController.signal.addEventListener("abort", () => resolve(), { once: true });
-        });
-        const deliveryTimedOut = new Promise<void>((resolve) => {
-          deliveryTimeout = setTimeout(() => {
-            deliveryAbortController.abort(new Error("overload retry notice delivery timed out"));
-            resolve();
-          }, OVERLOAD_RETRY_NOTICE_DELIVERY_TIMEOUT_MS);
-        });
-        const deliveryAttempt = Promise.resolve()
-          .then(async () => {
-            if (params.overloadRetryState.completed || deliveryAbortController.signal.aborted) {
-              return;
-            }
-            await deliver(noticePayload, {
-              abortSignal: deliveryAbortController.signal,
-              timeoutMs: OVERLOAD_RETRY_NOTICE_DELIVERY_TIMEOUT_MS,
-            });
-          })
-          .catch((noticeError: unknown) => {
-            logVerbose(`overload retry notice delivery failed (non-fatal): ${String(noticeError)}`);
-          });
-        params.overloadRetryState.noticeDelivery = Promise.race([
-          deliveryAttempt,
-          deliveryAborted,
-          deliveryTimedOut,
-        ]).finally(() => {
-          if (deliveryTimeout) {
-            clearTimeout(deliveryTimeout);
-          }
-          if (params.overloadRetryState.noticeAbortController === deliveryAbortController) {
-            params.overloadRetryState.noticeAbortController = undefined;
-          }
-        });
-      };
-      const noticeDelayMs = Math.max(
-        0,
-        OVERLOAD_RETRY_NOTICE_AFTER_MS - (Date.now() - params.overloadRetryState.turnStartedAtMs),
-      );
-      if (retryAbortSignal) {
-        const abortNotice = () => {
-          if (params.overloadRetryState.noticeTimer) {
-            clearTimeout(params.overloadRetryState.noticeTimer);
-            params.overloadRetryState.noticeTimer = undefined;
-          }
-          params.overloadRetryState.noticeAbortController?.abort(
-            retryAbortSignal.reason ?? new Error("overload retry aborted"),
-          );
-        };
-        retryAbortSignal.addEventListener("abort", abortNotice, { once: true });
-        params.overloadRetryState.noticeAbortCleanup = () => {
-          retryAbortSignal.removeEventListener("abort", abortNotice);
-        };
-      }
-      if (noticeDelayMs === 0) {
-        sendRetryNotice();
-        return;
-      }
-      params.overloadRetryState.noticeTimer = setTimeout(() => {
-        sendRetryNotice();
-      }, noticeDelayMs);
-    };
-    scheduleRetryNotice();
-    turn.replyOperation?.recordActivity();
-    defaultRuntime.error(
-      `Overloaded provider before reply (${sanitizeForLog(message)}). ` +
-        `Retrying ${retryCount}/${MAX_OVERLOAD_RETRIES} in ${retryDelayMs}ms.`,
-    );
-    const abortAction = await waitForRetryBackoff(retryDelayMs, retryAbortSignal);
-    if (abortAction) {
-      return abortAction;
-    }
-    params.state.pendingLifecycleTerminal = undefined;
-    turn.replyOperation?.recordActivity();
-    return { kind: "retry" };
-  }
-  if (
-    isTransientHttp &&
-    (!providerRequestError || providerRequestError.allowTransientHttpRetry) &&
-    !params.overloadRetryState.unsafeToReplay &&
-    params.consumeTransientHttpRetry()
-  ) {
-    params.state.pendingLifecycleTerminal = undefined;
-    defaultRuntime.error(
-      `Transient HTTP provider error before reply (${message}). Retrying once in ${TRANSIENT_HTTP_RETRY_DELAY_MS}ms.`,
-    );
-    const retryAbortSignal = turn.replyOperation?.abortSignal ?? turn.opts?.abortSignal;
-    const abortAction = await waitForRetryBackoff(TRANSIENT_HTTP_RETRY_DELAY_MS, retryAbortSignal);
-    if (abortAction) {
-      return abortAction;
-    }
-    return { kind: "retry" };
-  }
+  const replayPrevented = findCliTimeoutError(err)?.cliTimeout.observedActivity === true;
   if (providerRequestError) {
     takePendingLifecycleTerminal().emit("error", err);
     turn.replyOperation?.fail("run_failed", err);
     await params.modelPatch.fail(err);
     return {
       kind: "final",
-      payload: markAgentRunFailureReplyPayload({ text: providerRequestError.userMessage }),
+      payload: markAgentRunFailureReplyPayload({
+        // Curated facet copy beats the generic classified summary; see
+        // buildExternalRunFailureReply for the same priority.
+        text: providerRequestError.userMessage,
+      }),
       postCompactionModelFailure,
     };
   }
@@ -462,9 +248,7 @@ export async function handleAgentExecutionError(params: {
           raw: message,
         })
       : undefined;
-  const userFacingMessage = isTransientHttp
-    ? renderUserFacingText(message, { errorContext: true })
-    : message;
+  const userFacingMessage = message;
   const externalRunFailureCandidate =
     !isBilling &&
     !(isRateLimit && !isOverloaded) &&
@@ -476,7 +260,7 @@ export async function handleAgentExecutionError(params: {
             includeAuthProfileId: !isNonDirectConversationContext(turn.sessionCtx),
             includeDetails: isVerboseFailureDetailEnabled(turn.resolvedVerboseLevel),
             isHeartbeat: turn.isHeartbeat,
-            replayPrevented: params.overloadRetryState.unsafeToReplay,
+            replayPrevented,
             failoverFacts,
           },
         )

--- a/src/auto-reply/reply/agent-runner-execution-context-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-context-failures.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { FailoverError } from "../../agents/failover-error.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { getReplyPayloadMetadata } from "../reply-payload.js";
@@ -115,45 +115,6 @@ describe("executeAgentTurn: context failures", () => {
     expect(updateSessionIdMock).not.toHaveBeenCalled();
     expect(state.updateSessionStoreMock).not.toHaveBeenCalled();
   });
-
-  it.each([
-    {
-      reason: "server_error" as const,
-      message: "upstream provider failed briefly",
-    },
-    {
-      reason: "timeout" as const,
-      message: "provider request timed out without status token",
-    },
-  ])(
-    "retries once for structured FailoverError $reason without leading HTTP status text",
-    async ({ reason, message }) => {
-      vi.useFakeTimers();
-      state.runEmbeddedAgentMock
-        .mockRejectedValueOnce(
-          new FailoverError(message, {
-            reason,
-            provider: "openai",
-            model: "gpt-5.5",
-          }),
-        )
-        .mockResolvedValueOnce({
-          payloads: [{ text: "recovered after transient failover" }],
-          meta: {},
-        });
-
-      const executeAgentTurn = await getExecuteAgentTurnForTest();
-      const resultPromise = executeAgentTurn(createMinimalRunAgentTurnParams());
-      await vi.advanceTimersByTimeAsync(2_500);
-      const result = await resultPromise;
-
-      expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(2);
-      expect(result.kind).toBe("success");
-      if (result.kind === "success") {
-        expect(result.runResult.payloads?.[0]?.text).toBe("recovered after transient failover");
-      }
-    },
-  );
 
   it("uses structured FailoverError context_overflow over non-overflow message text", async () => {
     state.isLikelyContextOverflowErrorMock.mockReturnValue(false);

--- a/src/auto-reply/reply/agent-runner-execution-progress.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-progress.test.ts
@@ -655,9 +655,10 @@ describe("executeAgentTurn: lifecycle progress", () => {
     expect(typeof lifecycleData.endedAt).toBe("number");
   });
 
-  it("settles a successful same-candidate retry instead of its deferred failed attempt", async () => {
+  it("shows only the successful reply after a transient provider retry", async () => {
     const agentEvents = await import("../../infra/agent-events.js");
     const emitAgentEvent = vi.mocked(agentEvents.emitAgentEvent);
+    const onBlockReply = vi.fn();
     state.runEmbeddedAgentMock.mockImplementationOnce(async (params: EmbeddedAgentParams) => {
       await params.onAgentEvent?.({
         stream: "lifecycle",
@@ -687,11 +688,15 @@ describe("executeAgentTurn: lifecycle progress", () => {
     });
 
     const result = await executeTestTurn(
-      { opts: { runId: "run-recovered" } as GetReplyOptions },
+      { opts: { runId: "run-recovered", onBlockReply } as GetReplyOptions },
       { commandBody: "hello" },
     );
 
     expect(result.kind).toBe("success");
+    if (result.kind === "success") {
+      expect(result.runResult.payloads).toEqual([{ text: "recovered" }]);
+    }
+    expect(onBlockReply).not.toHaveBeenCalled();
     const lifecycleEvent = requireRecord(
       requireMockCallArgWithFields(
         emitAgentEvent,

--- a/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-provider-failures.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
 import { formatBillingErrorMessage } from "../../agents/embedded-agent-helpers.js";
-import { resolveMaxRunRetryIterations } from "../../agents/embedded-agent-runner/run/helpers.js";
 import { FailoverError } from "../../agents/failover-error.js";
 import { LiveSessionModelSwitchError } from "../../agents/live-model-switch-error.js";
 import { ProviderAuthError } from "../../agents/model-auth.js";
@@ -298,14 +297,8 @@ describe("executeAgentTurn: provider failures", () => {
     },
   );
 
-  it("retries a provider HTTP 503 before output and delivers the recovered response", async () => {
-    vi.useFakeTimers();
-    state.runEmbeddedAgentMock
-      .mockRejectedValueOnce(createOpenAiServiceUnavailableError())
-      .mockResolvedValueOnce({
-        payloads: [{ text: "Recovered response" }],
-        meta: {},
-      });
+  it("surfaces a provider HTTP 503 without an outer retry", async () => {
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(createOpenAiServiceUnavailableError());
 
     const executeAgentTurn = await getExecuteAgentTurnForTest();
     const resultPromise = executeAgentTurn(
@@ -313,18 +306,16 @@ describe("executeAgentTurn: provider failures", () => {
         sessionCtx: createNonDirectFailureSessionCtx(NON_DIRECT_FAILURE_SURFACE_CASES[0]),
       }),
     );
-    await vi.advanceTimersByTimeAsync(2_500);
     const result = await resultPromise;
 
-    expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(2);
-    expect(result.kind).toBe("success");
-    if (result.kind === "success") {
-      expect(result.runResult.payloads).toEqual([{ text: "Recovered response" }]);
+    expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
+    expect(result.kind).toBe("final");
+    if (result.kind === "final") {
+      expect(result.payload.text).toBe(PROVIDER_INTERNAL_ERROR_USER_MESSAGE);
     }
   });
 
-  it("surfaces a sanitized provider HTTP 503 notice after the safe retry is exhausted", async () => {
-    vi.useFakeTimers();
+  it("keeps opaque provider HTTP 503 copy safe", async () => {
     state.runEmbeddedAgentMock.mockRejectedValue(createOpenAiServiceUnavailableError());
 
     const executeAgentTurn = await getExecuteAgentTurnForTest();
@@ -333,10 +324,9 @@ describe("executeAgentTurn: provider failures", () => {
         sessionCtx: createNonDirectFailureSessionCtx(NON_DIRECT_FAILURE_SURFACE_CASES[1]),
       }),
     );
-    await vi.advanceTimersByTimeAsync(2_500);
     const result = await resultPromise;
 
-    expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(2);
+    expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.isError).toBe(true);
@@ -473,7 +463,7 @@ describe("executeAgentTurn: provider failures", () => {
   });
 
   it.each(NON_DIRECT_FAILURE_SURFACE_CASES)(
-    "surfaces overloaded fallback copy in $label chats",
+    "surfaces overloaded failure without an outer retry in $label chats",
     async (testCase) => {
       const executeAgentTurn = await getExecuteAgentTurnForTest();
       vi.useFakeTimers();
@@ -487,9 +477,7 @@ describe("executeAgentTurn: provider failures", () => {
       await vi.advanceTimersByTimeAsync(217_500);
       const result = await resultPromise;
 
-      expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(11);
-      const wholeTurnReruns = state.runEmbeddedAgentMock.mock.calls.length - 1;
-      expect(wholeTurnReruns * resolveMaxRunRetryIterations(17)).toBe(1_600);
+      expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
       expect(result.kind).toBe("final");
       if (result.kind === "final") {
         expect(result.payload.isError).toBe(true);
@@ -499,40 +487,20 @@ describe("executeAgentTurn: provider failures", () => {
     },
   );
 
-  it("retries fallback-wide overloads turn-locally and sends one delayed status notice", async () => {
+  it("does not send an overload status notice from the outer reply layer", async () => {
     const executeAgentTurn = await getExecuteAgentTurnForTest();
     vi.useFakeTimers();
-    for (let attempt = 0; attempt < 4; attempt += 1) {
-      state.runWithModelFallbackMock.mockRejectedValueOnce(createOverloadSummaryError());
-    }
-    state.runEmbeddedAgentMock.mockResolvedValueOnce({
-      payloads: [{ text: "recovered" }],
-      meta: {},
-    });
+    state.runWithModelFallbackMock.mockRejectedValueOnce(createOverloadSummaryError());
     const onBlockReply = vi.fn();
 
     const resultPromise = executeAgentTurn(
       createMinimalRunAgentTurnParams({ opts: { onBlockReply } }),
     );
-    await vi.advanceTimersByTimeAsync(29_999);
-    expect(onBlockReply).not.toHaveBeenCalled();
-    await vi.advanceTimersByTimeAsync(7_501);
     const result = await resultPromise;
 
-    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(5);
-    expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
-    expect(result.kind).toBe("success");
-    expect(onBlockReply).toHaveBeenCalledTimes(1);
-    const notice = onBlockReply.mock.calls[0]?.[0];
-    expect(notice).toMatchObject({
-      text: "The AI service is temporarily overloaded. I’m still retrying; this may take a few minutes.",
-      replyToId: "msg",
-      replyToCurrent: true,
-      isStatusNotice: true,
-    });
-    expect(getReplyPayloadMetadata(notice)).toMatchObject({
-      deliverDespiteSourceReplySuppression: true,
-    });
+    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(1);
+    expect(result.kind).toBe("final");
+    expect(onBlockReply).not.toHaveBeenCalled();
   });
 
   it.each(["tool_execution_started", "assistant_output_started"] as const)(
@@ -682,15 +650,15 @@ describe("executeAgentTurn: provider failures", () => {
         createMinimalRunAgentTurnParams({ opts: { onBlockReply } }),
       );
       await vi.advanceTimersByTimeAsync(30_000);
-      expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(2);
+      expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
       expect(onBlockReply).not.toHaveBeenCalled();
 
       resolveRetry({ payloads: [{ text: "recovered" }], meta: {} });
-      await expect(resultPromise).resolves.toMatchObject({ kind: "success" });
+      await expect(resultPromise).resolves.toMatchObject({ kind: "final" });
     },
   );
 
-  it("sends the delayed overload notice while a retry provider call is still running", async () => {
+  it("does not send a delayed overload notice", async () => {
     const executeAgentTurn = await getExecuteAgentTurnForTest();
     vi.useFakeTimers();
     let resolveRetry!: (value: unknown) => void;
@@ -706,10 +674,10 @@ describe("executeAgentTurn: provider failures", () => {
       createMinimalRunAgentTurnParams({ opts: { onBlockReply } }),
     );
     await vi.advanceTimersByTimeAsync(29_999);
-    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(2);
+    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(1);
     expect(onBlockReply).not.toHaveBeenCalled();
     await vi.advanceTimersByTimeAsync(1);
-    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    expect(onBlockReply).not.toHaveBeenCalled();
 
     resolveRetry({
       result: { payloads: [{ text: "recovered" }], meta: {} },
@@ -717,14 +685,10 @@ describe("executeAgentTurn: provider failures", () => {
       model: "claude-opus-4-1",
       attempts: [],
     });
-    await expect(resultPromise).resolves.toMatchObject({ kind: "success" });
-    expect(onBlockReply.mock.calls[0]?.[1]).toMatchObject({
-      abortSignal: expect.objectContaining({ aborted: true }),
-      timeoutMs: 5_000,
-    });
+    await expect(resultPromise).resolves.toMatchObject({ kind: "final" });
   });
 
-  it("does not block retry when a slow first overload makes the status notice immediately due", async () => {
+  it("does not schedule an overload retry after a slow failure", async () => {
     const executeAgentTurn = await getExecuteAgentTurnForTest();
     vi.useFakeTimers();
     let rejectInitial!: (error: unknown) => void;
@@ -748,12 +712,12 @@ describe("executeAgentTurn: provider failures", () => {
     rejectInitial(createOverloadSummaryError());
     await vi.advanceTimersByTimeAsync(2_500);
 
-    await expect(resultPromise).resolves.toMatchObject({ kind: "success" });
-    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(2);
-    expect(onBlockReply).toHaveBeenCalledTimes(1);
+    await expect(resultPromise).resolves.toMatchObject({ kind: "final" });
+    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(1);
+    expect(onBlockReply).not.toHaveBeenCalled();
   });
 
-  it("interrupts overload backoff on abort and cancels the pending status notice", async () => {
+  it("keeps overload failure handling terminal when the turn is aborted", async () => {
     const executeAgentTurn = await getExecuteAgentTurnForTest();
     vi.useFakeTimers();
     state.runEmbeddedAgentMock.mockRejectedValue(new Error("model is overloaded"));
@@ -772,22 +736,21 @@ describe("executeAgentTurn: provider failures", () => {
     abortController.abort();
     await expect(resultPromise).resolves.toMatchObject({
       kind: "final",
-      payload: { text: SILENT_REPLY_TOKEN },
     });
     expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
-    expect(onAgentRunTerminalOutcome).not.toHaveBeenCalled();
+    expect(onAgentRunTerminalOutcome).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(30_000);
     expect(onBlockReply).not.toHaveBeenCalled();
     const agentEvents = await import("../../infra/agent-events.js");
     expect(vi.mocked(agentEvents.emitAgentEvent)).toHaveBeenCalledWith(
       expect.objectContaining({
         stream: "lifecycle",
-        data: expect.objectContaining({ phase: "error", aborted: true }),
+        data: expect.objectContaining({ phase: "error", fallbackExhaustedFailure: true }),
       }),
     );
   });
 
-  it("interrupts the transient HTTP retry backoff on abort", async () => {
+  it("keeps transient HTTP failure handling terminal when the turn is aborted", async () => {
     const executeAgentTurn = await getExecuteAgentTurnForTest();
     vi.useFakeTimers();
     state.runEmbeddedAgentMock.mockRejectedValue(
@@ -805,13 +768,12 @@ describe("executeAgentTurn: provider failures", () => {
     abortController.abort();
     await expect(resultPromise).resolves.toMatchObject({
       kind: "final",
-      payload: { text: SILENT_REPLY_TOKEN },
     });
     expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     expect(vi.getTimerCount()).toBe(0);
   });
 
-  it("cancels the overload notice immediately when a slow retrying turn is aborted", async () => {
+  it("does not leave an overload notice timer after an aborted failure", async () => {
     const executeAgentTurn = await getExecuteAgentTurnForTest();
     vi.useFakeTimers();
     let resolveRetry!: (value: unknown) => void;
@@ -830,7 +792,7 @@ describe("executeAgentTurn: provider failures", () => {
       }),
     );
     await vi.advanceTimersByTimeAsync(2_500);
-    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(2);
+    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(1);
     await vi.advanceTimersByTimeAsync(27_499);
     abortController.abort();
     await vi.advanceTimersByTimeAsync(1);
@@ -842,7 +804,7 @@ describe("executeAgentTurn: provider failures", () => {
       model: "claude-opus-4-1",
       attempts: [],
     });
-    await expect(resultPromise).resolves.toMatchObject({ kind: "success" });
+    await expect(resultPromise).resolves.toMatchObject({ kind: "final" });
   });
 
   it("surfaces typed overloaded failures without rate-limit cooldown copy", async () => {
@@ -865,7 +827,7 @@ describe("executeAgentTurn: provider failures", () => {
     await vi.advanceTimersByTimeAsync(217_500);
     const result = await resultPromise;
 
-    expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(11);
+    expect(state.runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
     expect(result.kind).toBe("final");
     if (result.kind === "final") {
       expect(result.payload.isError).toBe(true);

--- a/src/auto-reply/reply/agent-runner-execution-results.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-results.test.ts
@@ -107,8 +107,10 @@ describe("executeAgentTurn: result and tool delivery", () => {
     },
   );
 
-  it("surfaces model capacity errors from pre-reply CLI failures", async () => {
-    vi.useFakeTimers();
+  it("surfaces model capacity errors from pre-reply CLI failures without an outer retry", async () => {
+    // CLI harness backends own their internal retries; a capacity error that
+    // escapes them surfaces immediately with actionable copy instead of the
+    // deleted outer overload-retry loop replaying the turn.
     state.runWithModelFallbackMock.mockRejectedValue(
       new Error("Selected model is at capacity. Please try a different model."),
     );
@@ -118,7 +120,7 @@ describe("executeAgentTurn: result and tool delivery", () => {
     followupRun.run.provider = "openai";
     followupRun.run.model = "gpt-5.5";
 
-    const resultPromise = executeAgentTurn({
+    const result = await executeAgentTurn({
       commandBody: "hello",
       followupRun,
       sessionCtx: {
@@ -140,10 +142,8 @@ describe("executeAgentTurn: result and tool delivery", () => {
       getActiveSessionEntry: () => undefined,
       resolvedVerboseLevel: "off",
     });
-    await vi.advanceTimersByTimeAsync(217_500);
-    const result = await resultPromise;
 
-    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(11);
+    expect(state.runWithModelFallbackMock).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
       kind: "final",
       payload: {

--- a/src/auto-reply/reply/agent-runner-execution.test-support.ts
+++ b/src/auto-reply/reply/agent-runner-execution.test-support.ts
@@ -190,7 +190,6 @@ vi.mock("../../agents/embedded-agent-helpers.js", async () => {
     isContextOverflowError: (message?: string) => state.isContextOverflowErrorMock(message),
     isLikelyContextOverflowError: (message?: string) =>
       state.isLikelyContextOverflowErrorMock(message),
-    isTransientHttpError: () => false,
     sanitizeUserFacingText: (text?: string) => text ?? "",
   };
 });

--- a/src/auto-reply/reply/agent-runner-execution.ts
+++ b/src/auto-reply/reply/agent-runner-execution.ts
@@ -50,12 +50,7 @@ import {
   clearRecoveredAutoFallbackPrimaryProbeSelection,
   resolveRunAfterAutoFallbackPrimaryProbeRecheck,
 } from "./agent-runner-auto-fallback.js";
-import {
-  cancelOverloadRetryNotice,
-  handleAgentExecutionError,
-  markOverloadRetryUnsafeToReplay,
-  type OverloadRetryState,
-} from "./agent-runner-error-handler.js";
+import { handleAgentExecutionError } from "./agent-runner-error-handler.js";
 import type {
   AgentTurnCompaction,
   AgentTurnExecutionResult,
@@ -121,10 +116,9 @@ function resolveRunStartupPhase(
   return undefined;
 }
 
-async function executeAgentTurnInternalWithRetryState(
+async function executeAgentTurnInternalLoop(
   params: AgentTurnParams,
   commitTerminalOutcome: () => void,
-  overloadRetryState: OverloadRetryState,
   commitMcpAppModelContext: () => void,
   preparedRunAdmission: PreparedAgentRunAdmission,
   admittedRunContext: { current?: AdmittedRunContext },
@@ -273,9 +267,6 @@ async function executeAgentTurnInternalWithRetryState(
     if (info.phase === "model_call_started" || info.phase === "process_spawned") {
       commitMcpAppModelContext();
     }
-    if (info.phase === "tool_execution_started" || info.phase === "assistant_output_started") {
-      markOverloadRetryUnsafeToReplay(overloadRetryState);
-    }
     const isUserVisibleExecutionActivity =
       info.phase === "turn_accepted" ||
       info.phase === "process_spawned" ||
@@ -307,12 +298,11 @@ async function executeAgentTurnInternalWithRetryState(
     onError: (error) =>
       logVerbose(`agent model patch reconciliation failed: ${formatErrorMessage(error)}`),
   });
-  let transientHttpRetriesRemaining = 1;
-  const consumeTransientHttpRetry = () => transientHttpRetriesRemaining-- > 0;
   let liveModelSwitchRetries = 0;
   const fallbackCycleState: AgentFallbackCycleState = {
     deferredLifecycle,
     lifecycleGeneration,
+    turnStartedAtMs: Date.now(),
     compaction,
     postCompactionModelAttempted: false,
     attemptedRuntimeProvider: fallbackProvider,
@@ -397,8 +387,6 @@ async function executeAgentTurnInternalWithRetryState(
         liveModelSwitchRetries,
         shouldSurfaceToControlUi,
         timing: agentTurnTiming,
-        overloadRetryState,
-        consumeTransientHttpRetry,
         modelPatch,
       });
       if (action.kind === "aborted") {
@@ -533,13 +521,6 @@ async function executeAgentTurnInternal(
   commitMcpAppModelContext: () => void,
   compaction: AgentTurnCompaction,
 ): Promise<AgentTurnInternalResult> {
-  const overloadRetryState: OverloadRetryState = {
-    retryCount: 0,
-    turnStartedAtMs: Date.now(),
-    unsafeToReplay: false,
-    noticeSent: false,
-    completed: false,
-  };
   const runId = params.opts?.runId ?? crypto.randomUUID();
   const admittedRunContext: { current?: AdmittedRunContext } = {};
   const gatewayContextResolver =
@@ -566,10 +547,9 @@ async function executeAgentTurnInternal(
     abortSignal: params.replyOperation?.abortSignal ?? params.opts?.abortSignal,
   });
   try {
-    return await executeAgentTurnInternalWithRetryState(
+    return await executeAgentTurnInternalLoop(
       params,
       commitTerminalOutcome,
-      overloadRetryState,
       commitMcpAppModelContext,
       preparedRunAdmission,
       admittedRunContext,
@@ -579,7 +559,6 @@ async function executeAgentTurnInternal(
   } finally {
     await deferredLifecycle.complete();
     preparedRunAdmission.close();
-    await cancelOverloadRetryNotice(overloadRetryState);
   }
 }
 

--- a/src/auto-reply/reply/agent-runner-failure-reply.ts
+++ b/src/auto-reply/reply/agent-runner-failure-reply.ts
@@ -7,6 +7,7 @@ import {
   classifyOAuthRefreshFailureError,
   formatOAuthRefreshFailureLoginCommandMarkdown,
 } from "../../agents/auth-profiles/oauth-refresh-failure.js";
+import { classifyFailoverReason } from "../../agents/embedded-agent-helpers.js";
 import { sanitizeUserFacingText } from "../../agents/embedded-agent-helpers/sanitize-user-facing-text.js";
 import { renderUserFacingText } from "../../agents/embedded-agent-helpers/user-facing-text.js";
 import { classifyCompactionReason } from "../../agents/embedded-agent-runner/compact-reasons.js";
@@ -36,6 +37,7 @@ import { buildProviderAuthRecoveryHint } from "../../agents/provider-auth-recove
 import { resolveSilentReplyPolicy } from "../../config/silent-reply.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { extractErrorHttpStatus } from "../../shared/assistant-error-format.js";
 import { buildCodexLoginRecovery } from "../codex-login-recovery.js";
 import {
   copyReplyPayloadMetadata,
@@ -51,23 +53,25 @@ import type { ReplyPayload } from "../types.js";
 
 export function resolveReplyFailoverFacts(error: unknown, message: string) {
   const described = describeFailoverError(error);
-  const classification = described.reason
-    ? ({ kind: "reason", reason: described.reason } as const)
-    : null;
+  const status = extractErrorHttpStatus(described.rawError ?? message)?.code ?? described.status;
+  const reason =
+    described.reason ??
+    classifyFailoverReason(described.rawError ?? message, { provider: described.provider });
+  const classification = reason ? ({ kind: "reason", reason } as const) : null;
   return {
     reason: classification?.kind === "reason" ? classification.reason : undefined,
     code: described.code,
     provider: described.provider,
     model: described.model,
-    status: described.status,
+    status,
     authMode: described.authMode,
     providerRequestError: resolveProviderRequestFailureCopy({
       classification,
       facet: classifyProviderRequestFacets({
-        status: described.status,
+        status,
         message: described.rawError ?? message,
       }),
-      status: described.status,
+      status,
       technicalMessage: message,
     }),
   };
@@ -292,10 +296,10 @@ export function buildExternalRunFailureReply(
   }
   const providerRequestError = failoverFacts.providerRequestError;
   if (providerRequestError) {
-    return {
-      text: providerRequestError.userMessage ?? renderAssistantRequestFailureCopy(failoverFacts),
-      isGenericRunnerFailure: false,
-    };
+    // Curated facet copy carries recovery guidance (quota/billing ambiguity,
+    // /new for conversation-state, config fix for model_not_found); the
+    // classified summary below is the fallback for facts without a facet.
+    return { text: providerRequestError.userMessage, isGenericRunnerFailure: false };
   }
   const authError = isProviderAuthError(error) ? error : undefined;
   const missingApiKeyFailure = renderMissingApiKeyReplyCopy(

--- a/src/auto-reply/reply/agent-runner-fallback-cycle.types.ts
+++ b/src/auto-reply/reply/agent-runner-fallback-cycle.types.ts
@@ -58,6 +58,8 @@ export type AgentFallbackCandidateCommonParams = {
 export type AgentFallbackCycleState = {
   deferredLifecycle: DeferredEmbeddedRunLifecycleManager;
   lifecycleGeneration: string;
+  /** Turn admission time; terminal backstops must not stamp failure time as the start. */
+  turnStartedAtMs: number;
   compaction: AgentTurnCompaction;
   /** Failure attribution only; model start does not prove current token freshness. */
   postCompactionModelAttempted: boolean;

--- a/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
+++ b/src/auto-reply/reply/agent-runner.misc.runreplyagent.test.ts
@@ -2603,21 +2603,13 @@ describe("runReplyAgent response usage footer", () => {
   });
 });
 
-describe("runReplyAgent transient HTTP retry", () => {
-  it("retries once after transient 521 HTML failure and then succeeds", async () => {
-    vi.useFakeTimers();
-    const retryStarted = createDeferred();
-    runtimeErrorMock.mockImplementationOnce(() => retryStarted.resolve());
-    runEmbeddedAgentMock
-      .mockRejectedValueOnce(
-        new Error(
-          `521 <!DOCTYPE html><html lang="en-US"><head><title>Web server is down</title></head><body>Cloudflare</body></html>`,
-        ),
-      )
-      .mockResolvedValueOnce({
-        payloads: [{ text: "Recovered response" }],
-        meta: {},
-      });
+describe("runReplyAgent transient HTTP failures", () => {
+  it("does not retry a transient provider failure in the reply layer", async () => {
+    runEmbeddedAgentMock.mockRejectedValueOnce(
+      new Error(
+        `521 <!DOCTYPE html><html lang="en-US"><head><title>Web server is down</title></head><body>Cloudflare</body></html>`,
+      ),
+    );
 
     const runPromise = createBaseRun({
       context: { Provider: "telegram", MessageSid: "msg" },
@@ -2628,17 +2620,12 @@ describe("runReplyAgent transient HTTP retry", () => {
       },
     }).run();
 
-    await retryStarted.promise;
-    await vi.advanceTimersByTimeAsync(2_500);
     const result = await runPromise;
 
-    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(2);
-    expect(runtimeErrorMock).toHaveBeenCalledWith(
-      'Transient HTTP provider error before reply (521 <!DOCTYPE html><html lang="en-US"><head><title>Web server is down</title></head><body>Cloudflare</body></html>). Retrying once in 2500ms.',
-    );
+    expect(runEmbeddedAgentMock).toHaveBeenCalledTimes(1);
 
     const payload = Array.isArray(result) ? result[0] : result;
-    expect(payload?.text).toContain("Recovered response");
+    expect(payload?.text).toContain("provider internal error");
   });
 });
 

--- a/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
+++ b/src/auto-reply/reply/agent-runner.runreplyagent.e2e.test.ts
@@ -39,7 +39,6 @@ import {
   buildHandledBeforeAgentReplyPayloads,
   runBeforeAgentReplyForTurn,
 } from "../../plugins/before-agent-reply.js";
-import { defaultRuntime } from "../../runtime.js";
 import { createUserTurnTranscriptRecorder } from "../../sessions/user-turn-transcript.js";
 import { normalizeSessionDeliveryState } from "../../utils/delivery-context.shared.js";
 import type { TemplateContext } from "../templating.js";
@@ -4010,50 +4009,16 @@ describe("runReplyAgent typing (heartbeat)", () => {
     expect(toolPayload.text).toBeUndefined();
   });
 
-  it("retries transient HTTP failures once with timer-driven backoff", async () => {
-    vi.useFakeTimers();
-    const retryStarted = createDeferred();
-    const retryMessage =
-      "Transient HTTP provider error before reply (502 Bad Gateway). Retrying once in 2500ms.";
-    const runtimeError = vi.spyOn(defaultRuntime, "error").mockImplementation((message) => {
-      if (message === retryMessage) {
-        retryStarted.resolve();
-      }
-    });
-    const abortController = new AbortController();
-    let calls = 0;
-    state.runEmbeddedAgentMock.mockImplementation(async () => {
-      calls += 1;
-      if (calls === 1) {
-        throw new Error("502 Bad Gateway");
-      }
-      return { payloads: [{ text: "final" }], meta: {} };
-    });
+  it("does not retry transient HTTP failures in the reply layer", async () => {
+    state.runEmbeddedAgentMock.mockRejectedValueOnce(new Error("502 Bad Gateway"));
 
-    const { run } = createMinimalRun({
-      typingMode: "message",
-      opts: { abortSignal: abortController.signal },
-    });
-    const runPromise = run();
+    const { run } = createMinimalRun({ typingMode: "message" });
+    const result = await run();
+    const payloads = Array.isArray(result) ? result : [result];
 
-    try {
-      // Preparation is asynchronous; measure from the retry owner's scheduled backoff.
-      await Promise.race([retryStarted.promise, runPromise]);
-      expect(runtimeError).toHaveBeenCalledWith(retryMessage);
-      await vi.advanceTimersByTimeAsync(2_499);
-      expect(calls).toBe(1);
-      await vi.advanceTimersByTimeAsync(1);
-      const result = await runPromise;
-      const payloads = Array.isArray(result) ? result : [result];
-      expect(payloads.map((payload) => payload?.text)).toEqual(["final"]);
-      expect(calls).toBe(2);
-    } finally {
-      // A failed assertion must not leave a run or fake clock alive for the next test.
-      abortController.abort();
-      await runPromise.catch(() => undefined);
-      runtimeError.mockRestore();
-      vi.useRealTimers();
-    }
+    expect(state.runEmbeddedAgentMock).toHaveBeenCalledOnce();
+    expect(payloads.map((payload) => payload?.text)).toHaveLength(1);
+    expect(payloads[0]?.text).toContain("provider internal error");
   });
 
   it("announces model fallback transitions across verbose levels", async () => {

--- a/src/llm/providers/anthropic-cloudflare.fetch-proof.test.ts
+++ b/src/llm/providers/anthropic-cloudflare.fetch-proof.test.ts
@@ -52,8 +52,6 @@ describe("Anthropic Cloudflare guard-specific SSRF blocking proof", () => {
     const { streamAnthropic } = await import("@openclaw/ai/internal/anthropic");
     const stream = streamAnthropic(blockedModel, context, {
       apiKey: "sk-ant-test",
-      // Retries only repeat the same deterministic guard rejection.
-      maxRetries: 0,
     });
     const result = await stream.result();
 

--- a/src/plugin-sdk/test-helpers/provider-runtime-contract.ts
+++ b/src/plugin-sdk/test-helpers/provider-runtime-contract.ts
@@ -427,7 +427,6 @@ export function describeGithubCopilotProviderRuntimeContract(
               apiKey: "test-token",
               reasoning: level,
               maxTokens: 1024,
-              maxRetries: 0,
               onPayload: (payload) => {
                 payloads.push(payload);
                 throw new Error("Captured payload before network");


### PR DESCRIPTION
## What Problem This Solves

When a provider returns a transient failure (429, 5xx, or timeout), up to three uncoordinated retry layers replayed the same request:

1. **Software development kit (SDK) retries** — OpenAI and Anthropic SDK clients ran with their default retry policies, invisible to OpenClaw.
2. **ChatGPT transport retry loop** — `openai-chatgpt-responses` had its own per-request retry loop on top of the SDK.
3. **Outer overload replay** — the reply runner replayed the whole turn up to 10 times, with backoff up to 30s, and posted a "still retrying" notice after 30s.

Stacked, these multiplied: one transient 429 could hold a turn silently for minutes with no coherent budget, and the failover controller (which owns provider/model fallback) never saw all the attempts it needed to budget. This follows #134103 and #134111 in the LLM error-UX series.

## Why This Change Was Made

One retry owner, one budget. The embedded runner's failover retry controller (`src/agents/embedded-agent-runner/run/failover-retry-controller.ts`) owns transient-retry policy:

- **`retry.provider.maxRetries` is the transient-retry attempt budget.** The controller installs the saved value for each dispatch. The default budget remains 3.
- **The retry window stays flat at 90s.** The window bounds time-to-failover, not attempt count. When `maybeRetryTransient` returns false, the caller falls through to `rotate_profile`, `fallback_model`, or `surface_error` (`src/agents/embedded-agent-runner/run/assistant-failover.ts:137-153`). Exhaustion moves to another profile or model, which is better recovery than more same-model retries against a slow provider.
- **The default budget does not bind the window.** Three jittered backoff delays total roughly 3.5–10.5s. `resolveTransientRetryDelayMs` uses a 1s base, 0.5–1.5x jitter, and a 30s cap (`src/agents/embedded-agent-runner/run/helpers.ts:44-79`). The window truncates only when requests themselves are slow, which is when failover is the right move.
- **Scaling the window with the configured budget would delay failover and make the worst case worse.** The fixed window keeps time-to-failover bounded.
- **Window truncation is now recorded.** Commit `7d7d6a5e8a2` logs the retry count and configured budget at the controller producer (`src/agents/embedded-agent-runner/run/failover-retry-controller.ts:244-250`), so a configured budget that cannot run fully is diagnosable. The regression is covered by `src/agents/embedded-agent-runner/run/failover-retry-controller.test.ts`, `records the truncation when the window ends a budget that still has attempts`.

This is not a breaking change. A saved `retry.provider.maxRetries` keeps a coherent meaning: it was the per-SDK-request retry count, and it is now the transient-retry attempt budget owned by one controller. Before this PR, the value reached only the provider SDK and multiplied against a separate hardcoded controller retry of 3; it never reached OpenClaw's own retry owner. Saved values remain valid, with no migration, doctor repair, or config-shape change.

Other retry paths are consolidated around that owner:

- **SDK clients use `maxRetries: 0`.** `buildOpenAISdkClientOptions` and `buildOpenAISdkRequestOptions` prevent SDK retries from hiding attempts from the owner.
- **The ChatGPT transport retry loop is deleted.** The transport surfaces the classified error and carries `Retry-After` / `retry-after-ms` through the terminal error text, so the controller can honor provider pacing.
- **The obsolete `StreamOptions.maxRetries` knob is removed.** The session runtime's `retry.maxRetries` loop remains separate because it has a different owner.
- **Outer overload replay is deleted** (`src/auto-reply/reply/agent-runner-error-handler.ts`), along with `OverloadRetryState` and the 30s "still retrying" notice. Embedded runs use the inner controller; CLI harness backends own their internal retries, so escaping errors surface immediately with actionable copy.
- **Copy priority is fixed at both reply sites.** Curated facet copy (`providerRequestError.userMessage`) beats the generic classified summary.
- **Silent failures use the same budget.** A classified transient error with no visible output consults the retry owner instead of a parallel silent-retry counter. Only reasons the controller cannot classify keep the bounded local empty-error counter, capped at 3.
- **The 90s budget starts at the first consult.** Failed-request time counts against it, not only backoff sleep.
- **Turn timing uses admission time.** Terminal lifecycle backstops stamp `AgentFallbackCycleState.turnStartedAtMs`, so error events and session `runtimeMs` reflect the real turn duration.

### Accepted tradeoffs (named, not accidental)

- **The 30s "still retrying" notice is gone.** The new budget caps total transient waiting at 90s, below the threshold that made the notice useful.
- **Worst-case transient patience drops from about 217s to 90s.** A persistent overload now fails visibly within 90s with actionable copy instead of a multi-minute silent replay.

## User Impact

- A transient provider blip retries quickly and quietly with bounded, jittered backoff and provider pacing, then succeeds or follows the existing failover chain.
- A persistent outage surfaces within the 90s window with curated, actionable copy instead of minutes of silence.
- A saved `retry.provider.maxRetries` controls the transient-retry attempt budget in one controller. A slow provider can end that budget at the flat window, and the controller records that truncation.
- There is no silent multi-layer retry stacking. Each transient retry is owned and budgeted by one controller.
- An unprepared provider HTTP 500 now reads "provider internal error" instead of "request timed out". The old copy came from the outer replay path attributing every escaping failure to a timeout; the classified facet now reaches the reply site unchanged.

## Evidence

- **Live product-path proof (Telegram Test Server end-to-end run, real gateway with fault injection, rerun on this head):** a real-user DM asked for `OPENCLAW_E2E_OK` only; the mock provider returned an injected transient HTTP 500 on the first `/v1/responses` request and a normal completion on the second. The gateway log showed `transient same-model retry 1/3 for openai/gpt-5.5`. Telegram received exactly one assistant reply, with no error and no duplicate. `mock-openai-requests.ndjson` contained exactly two provider requests. The same prompt without fault injection used exactly one provider request.
- Silent idle timeout keeps its quiet same-model replay, now budgeted by the retry owner: an unclassified idle timeout consults `maybeRetryTransient({ reason: "timeout" })` in `src/agents/embedded-agent-runner/run/assistant-failover.ts` instead of a second bespoke retry counter. The run-wide idle-timeout breaker still caps consecutive silent attempts at 5.
- Fallback handoff tests use the new contract: a persistent command-line interface (CLI) `server_error` or prompt timeout exhausts the 3-retry budget, for 4 attempts total, and then throws `FailoverError` to the configured fallback.
- `packages/ai` full suite: **115 files / 2103 tests green**, including transport tests that prove one HTTP request per failure mode and preserve `Retry-After` evidence.
- `src/auto-reply/reply` full suite: **257 files / 5323 passed, 1 skipped, green**, including the CLI capacity-error path and removal of the outer replay tests.
- `src/agents/embedded-agent-runner/run` full directory: green, including retry-owner budget, backoff, provider pacing, and wall-clock coverage.
- ChatGPT transport: `packages/ai/src/providers/openai-chatgpt-responses.retry.test.ts` proves a 429 with `retry-after: 7` preserves `Retry-After: 7 seconds` in one HTTP request, which the retry owner parses as 7000ms.
- Silent-failure budget unification: the shared integration test retries a silent, side-effect-free `server_error` through the controller; `src/agents/embedded-agent-runner/run/assistant-failure.test.ts` is 21/21 green.
- Turn-timing regression: the fallback preparation failure test fails before this fix when the backstop stamps failure time and passes when `turnStartedAtMs` is carried on the fallback cycle state.
- `src/agents/embedded-agent-runner/run/failover-retry-controller.test.ts` covers the new truncation record: `records the truncation when the window ends a budget that still has attempts` verifies the controller logs `after 1/8 retries` when the flat window ends before the configured budget.
- Lint (including plugin-SDK boundary declaration files) is clean on all 58 changed files; `git diff --check` is clean; formatting is applied.
- Production LOC delta, using `*.test.ts` and `*owner-test-support.ts` as test paths: **+463 / -685** across 44 production files, net **-222**. Tests: **+459 / -617** across 47 test files, net **-158**. Overall: **+922 / -1302** across 91 changed files, net **-380**.

