### PR TITLE
fix(gateway): use the npm WebSocket receiver under Bun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Bun Gateway:** restore Gateway health checks and agent connections under Bun 1.4 while preserving WebSocket frame limits and authenticated request scheduling.
 - **Doctor recovery notes:** show interrupted auth-profile archive recovery failures and completions even when no further migration runs or another migration is declined. (#134009) Thanks @angeliti999.
 - Matrix lifecycle: drain in-flight monitor tasks without deadlocking shared-client retirement, and reject late acquisitions after their owning task closes.
 - Provider error handling: reuse prepared or already loaded provider hooks instead of cold-loading plugins during error classification, avoiding long stalls in failure reporting and model fallback.

--- a/scripts/e2e/bun-global-install-smoke.sh
+++ b/scripts/e2e/bun-global-install-smoke.sh
@@ -52,7 +52,7 @@ cleanup() {
   fi
 }
 
-dump_failure_logs() {
+dump_debug_logs() {
   local status="$1"
   echo "bun global install smoke failed with exit code $status" >&2
   openclaw_e2e_dump_logs \
@@ -102,7 +102,7 @@ prepare_ai_candidate() {
 }
 
 trap cleanup EXIT
-trap 'status=$?; dump_failure_logs "$status"; exit "$status"' ERR
+openclaw_e2e_enable_failure_diagnostics
 
 run_with_timeout() {
   local timeout_ms="$1"

--- a/src/gateway/server-runtime-state.ts
+++ b/src/gateway/server-runtime-state.ts
@@ -1,8 +1,10 @@
 // Gateway HTTP/WebSocket runtime state factory.
 // Builds one server runtime with lazy plugin route handlers.
 import type { IncomingMessage, Server as HttpServer, ServerResponse } from "node:http";
+import { createRequire } from "node:module";
+import path from "node:path";
 import type { Duplex } from "node:stream";
-import { WebSocketServer } from "ws";
+import type { WebSocketServer } from "ws";
 import { resolveSandboxHostPort } from "../agents/sandbox-host.js";
 import { isCoreCanvasHostEnabled } from "../canvas/config.js";
 import { resolveCanvasNodeCapability } from "../canvas/constants.js";
@@ -49,6 +51,13 @@ import type { GatewayWsClient } from "./server/ws-types.js";
 import type { NodeWorkerBundleTransferHttpCallback } from "./worker-environments/node-worker-bundle-transfer-http.js";
 import type { NodeWorkspaceTransferHttpCallback } from "./worker-environments/node-workspace-transfer-http.js";
 import type { WorkerBootstrapArtifactTransferHttpCallback } from "./worker-environments/worker-bootstrap-artifact-transfer-http.js";
+
+// Gateway admission changes receiver frame limits after authentication. Load the
+// installed ws entry so Bun cannot substitute its receiver-less built-in adapter.
+const require = createRequire(import.meta.url);
+const { WebSocketServer: NpmWebSocketServer }: typeof import("ws") = require(
+  path.join(path.dirname(require.resolve("ws/package.json")), "index.js"),
+);
 
 type GatewayPluginRequestHandler = (
   req: IncomingMessage,
@@ -294,7 +303,7 @@ export async function createGatewayHttpTransport(params: {
   // Create WebSocketServer first (with noServer: true) so we can attach upgrade handlers
   // before HTTP servers start listening. This prevents a race condition where connections
   // arrive before the upgrade handler is attached, which causes silent 1006 errors.
-  const wss = new WebSocketServer({
+  const wss = new NpmWebSocketServer({
     noServer: true,
     maxPayload: MAX_PREAUTH_PAYLOAD_BYTES,
     // Yield between buffered frames so one RPC burst cannot monopolize the

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -2145,39 +2145,42 @@ syncBuiltinESMExports();
     expect(skipped.stderr).toContain("OpenClaw package lifecycle did not complete");
   });
 
-  it.runIf(process.platform !== "win32")(
-    "uses bundled AI bytes when a prebuilt tarball is provided",
-    () => {
-      const tempDir = tempDirs.make("openclaw-bun-prebuilt-");
-      const packageDir = join(tempDir, "fixture", "package");
-      const aiDir = join(packageDir, "node_modules", "@openclaw", "ai");
-      const packageTgz = join(tempDir, "openclaw-prebuilt.tgz");
-      const bunPath = join(tempDir, "bun");
-      mkdirSync(aiDir, { recursive: true });
-      writeFileSync(
-        join(packageDir, "package.json"),
-        JSON.stringify({
-          name: "openclaw",
-          version: "2026.6.17",
-          dependencies: { "@openclaw/ai": "2026.6.17" },
-          bundleDependencies: ["@openclaw/ai"],
-        }),
-      );
-      writeFileSync(
-        join(aiDir, "package.json"),
-        JSON.stringify({ name: "@openclaw/ai", version: "2026.6.17" }),
-      );
-      const packed = spawnSync(
-        "tar",
-        ["-czf", packageTgz, "-C", join(tempDir, "fixture"), "package"],
-        {
-          encoding: "utf8",
-        },
-      );
-      expect(packed.status, packed.stderr).toBe(0);
-      writeFileSync(
-        bunPath,
-        `#!/usr/bin/env bash
+  it.runIf(process.platform !== "win32").each([
+    { name: "uses bundled AI bytes when a prebuilt tarball is provided", statusExit: 0 },
+    { name: "preserves redirected Bun command diagnostics and exit status", statusExit: 23 },
+  ])("$name", ({ statusExit }) => {
+    const tempDir = tempDirs.make("openclaw-bun-prebuilt-");
+    const packageDir = join(tempDir, "fixture", "package");
+    const aiDir = join(packageDir, "node_modules", "@openclaw", "ai");
+    const packageTgz = join(tempDir, "openclaw-prebuilt.tgz");
+    const bunPath = join(tempDir, "bun");
+    const statePath = join(tempDir, "state-path");
+    const aiTarballPath = join(tempDir, "ai-tarball-path");
+    mkdirSync(aiDir, { recursive: true });
+    writeFileSync(
+      join(packageDir, "package.json"),
+      JSON.stringify({
+        name: "openclaw",
+        version: "2026.6.17",
+        dependencies: { "@openclaw/ai": "2026.6.17" },
+        bundleDependencies: ["@openclaw/ai"],
+      }),
+    );
+    writeFileSync(
+      join(aiDir, "package.json"),
+      JSON.stringify({ name: "@openclaw/ai", version: "2026.6.17" }),
+    );
+    const packed = spawnSync(
+      "tar",
+      ["-czf", packageTgz, "-C", join(tempDir, "fixture"), "package"],
+      {
+        encoding: "utf8",
+      },
+    );
+    expect(packed.status, packed.stderr).toBe(0);
+    writeFileSync(
+      bunPath,
+      `#!/usr/bin/env bash
 set -euo pipefail
 if [ "\${1:-}" = "--version" ]; then
   echo "1.4.0"
@@ -2199,6 +2202,9 @@ if [[ "\${1:-}" == */openclaw.mjs ]]; then
     echo "Usage: openclaw"
   elif [ "\${1:-}" = "infer" ]; then
     printf '[{"id":"google"},{"id":"openai"},{"id":"xai"}]\n'
+  elif [ "\${1:-}" = "status" ] && [ "$FAKE_STATUS_EXIT" != "0" ]; then
+    echo "synthetic Bun status failure" >&2
+    exit "$FAKE_STATUS_EXIT"
   elif [ "\${1:-}" = "status" ] || { [ "\${1:-}" = "plugins" ] && [ "\${2:-}" = "list" ]; }; then
     echo '{}'
   elif [ "\${1:-}" = "agent" ]; then
@@ -2234,7 +2240,13 @@ case "\${override#file:}" in
 esac
 test -f "\${override#file:}"
 package_root="$BUN_INSTALL/install/global/node_modules/openclaw"
-mkdir -p "$BUN_INSTALL/bin" "$package_root/dist"
+mkdir -p "$BUN_INSTALL/bin" "$package_root/dist/plugin-sdk"
+printf '%s\\n' "$OPENCLAW_STATE_DIR" >"$FAKE_STATE_PATH"
+printf '%s\\n' "\${override#file:}" >"$FAKE_AI_TARBALL_PATH"
+# Synthetic package redactor isolates stderr routing; canonical redaction has separate proof.
+cat >"$package_root/dist/plugin-sdk/logging-core.js" <<'REDACTOR'
+exports.redactSensitiveText = (text) => text;
+REDACTOR
 cat >"$package_root/openclaw.mjs" <<'OPENCLAW'
 #!/usr/bin/env node
 const args = process.argv.slice(2);
@@ -2252,27 +2264,38 @@ chmod +x "$package_root/openclaw.mjs"
 ln -s "$package_root/openclaw.mjs" "$BUN_INSTALL/bin/openclaw"
 node -e 'const fs=require("node:fs");const p=process.argv[1];const value=JSON.parse(fs.readFileSync(p,"utf8"));value.trustedDependencies=["openclaw"];fs.writeFileSync(p,JSON.stringify(value))' "$BUN_INSTALL/install/global/package.json"
 `,
-      );
-      chmodSync(bunPath, 0o755);
+    );
+    chmodSync(bunPath, 0o755);
 
-      const result = spawnSync("bash", [BUN_GLOBAL_SMOKE_PATH], {
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          BUN_BIN: bunPath,
-          OPENCLAW_BUN_GLOBAL_SMOKE_HOST_BUILD: "0",
-          OPENCLAW_BUN_GLOBAL_SMOKE_PACKAGE_TGZ: packageTgz,
-          OPENCLAW_BUN_GLOBAL_SMOKE_TIMEOUT_MS: "10000",
-        },
-      });
+    const result = spawnSync("bash", [BUN_GLOBAL_SMOKE_PATH], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        BUN_BIN: bunPath,
+        FAKE_STATUS_EXIT: String(statusExit),
+        FAKE_STATE_PATH: statePath,
+        FAKE_AI_TARBALL_PATH: aiTarballPath,
+        OPENCLAW_BUN_GLOBAL_SMOKE_HOST_BUILD: "0",
+        OPENCLAW_BUN_GLOBAL_SMOKE_PACKAGE_TGZ: packageTgz,
+        OPENCLAW_BUN_GLOBAL_SMOKE_TIMEOUT_MS: "10000",
+      },
+    });
 
-      expect(result.status, result.stderr).toBe(0);
-      expect(result.stdout).toContain("bun-global-install-smoke: image providers OK (3 providers)");
+    expect(result.status, result.stderr).toBe(statusExit);
+    expect(existsSync(path.dirname(readFileSync(statePath, "utf8").trim()))).toBe(false);
+    expect(existsSync(path.dirname(readFileSync(aiTarballPath, "utf8").trim()))).toBe(false);
+    expect(result.stdout).toContain("bun-global-install-smoke: image providers OK (3 providers)");
+    if (statusExit === 0) {
       expect(result.stdout).toContain(
         "bun-global-install-smoke: Bun 1.4.0 package, CLI, local agent, and Gateway runtime OK",
       );
-    },
-  );
+    } else {
+      expect(result.stderr).toContain("bun global install smoke failed with exit code 23");
+      expect(result.stderr).toContain("synthetic Bun status failure");
+      expect(result.stderr).not.toContain("failure log omitted");
+      expect(result.stdout).not.toContain("Gateway runtime OK");
+    }
+  });
 
   it.runIf(process.platform !== "win32" && existsSync("/usr/bin/time"))(
     "preserves Bun global timeout kill grace after the leader exits",


### PR DESCRIPTION
Bun 1.4 could install and run OpenClaw locally, but Gateway health checks and agent connections failed after authentication with `unsupported Gateway WebSocket receiver`. The receiver handoff correctly requires the npm `ws` parser's mutable frame limits and scheduling controls. Bun substitutes a native adapter for a bare `ws` import, and that adapter does not implement those capabilities.

Load the installed `ws` entry at the Gateway server constructor so Node and Bun use the same supported receiver. Authentication, preauth and authenticated payload limits, worker limits, request scheduling, and fail-closed receiver checks stay unchanged. This uses the existing pinned dependency, with no new package, configuration option, protocol or storage change. The runtime change is +11/-2 lines: the explicit dependency selection belongs at the existing transport owner and introduces no fallback path.

The Bun smoke also uses the existing failure-diagnostics helper. Previously, an inherited shell error trap wrote into the failing command's redirected log, which cleanup then removed. The shared helper preserves stderr before redirection. The executable fixture now retains the successful installation case and proves that a failed command preserves exit 23, exposes its diagnostic, and removes temporary state.

Validation:

- Reproduced the exact previously sealed package under Bun 1.4.0: installation, CLI checks and the local mocked turn passed; Gateway health failed. The unchanged script emitted zero stderr. The diagnostic-only arm preserved exit 1 and exposed the real error through the installed package's canonical redactor.
- Tested real HTTP upgrades with Node 24 and Bun 1.4.0 against `ws` 8.21.3. Explicit npm loading passed all four contract cases on both runtimes: receiver handoff, permitted postauth payload, preauth single-frame and fragmented limits, postauth limit, ping/pong, close, and complete cleanup. Bun's bare adapter failed those contract cases.
- Built and packaged the two-file runtime/harness candidate canonically. The full Bun global smoke passed, including lifecycle trust, CLI, nine image providers, local mocked agent turn, Gateway health and Gateway mocked agent turn. Source hashes were unchanged and temporary smoke/package directories were removed.
- All 151 tests across seven Gateway fairness, preauth, worker, admission and health files passed. Core types, focused owner lint, full build and packaging passed on fresh Linux dependencies.
- The permanent diagnostic fixture was red on the old script and green on the repaired script, preserving the original exit status and cleanup checks.

The first local gate caught a new type assertion; the final source uses a typed declaration instead, with byte-identical emitted JavaScript. Independent managed review passed with no actionable findings. The final four-path changed gate passed on the refreshed publication base, followed by all 98 tests in the complete shell-owner file. All four source hashes remained unchanged through both runs. The native package proof is bound to frozen `3ee32fb` plus the reviewed runtime/harness patch; the affected owner and dependency files are byte-identical on the `ace8a13` publication base. This is focused repair proof, not a claim that the full release-verification run is green.

Native Linux proof ran on the host prepared by [Testbox run 33409439549](https://github.com/openclaw/openclaw/actions/runs/33409439549). The original sealed package was `0dc2e41a020ee28d850cf6f17a3649435972b960de33abb6aacfd724624da92f`; the canonically built repair was `4dc4b476290970b42e45f56d7b49ce0c4e6fe8b4fca30061ade8d7806043bc89`. Both native leases were stopped and their completed state verified. The original smoke failure, diagnostic-only failure, bare-adapter contract failures, and first local assertion-ratchet failure remain retained; no failed result was relabeled as a pass.

The first complete local gate also exposed six type errors in an unchanged channel-recovery fixture on `ce178cb`. This branch was mechanically refreshed onto the existing upstream fix `ace8a13`; the Bun owners and dependency manifests are unchanged, and the upstream fixture bytes are preserved. No duplicate fixture repair is included.

GitHub could not create CI for the initial branch because another changelog entry landed at the same insertion point. The branch was mechanically refreshed onto `d01486f`; the runtime, smoke script and complete shell test file remain byte-identical to the reviewed and tested patch. Both changelog entries are retained. The dependency declarations and lockfile are unchanged; the only upstream package-script change is the separately landed plugin lint improvement. Required CI must pass on this refreshed head before merge.
