### PR TITLE
fix(ci): record complete native UI file timings

### DIFF
--- a/scripts/lib/ci-test-timings-refit.mts
+++ b/scripts/lib/ci-test-timings-refit.mts
@@ -29,21 +29,27 @@ function seconds(value: string, unit: string): number {
 }
 
 function readUiLog(text: string, samples: Samples, overhead: number[]) {
-  let fileCount = 0;
+  const files = new Map<string, number>();
   for (const line of text.split("\n")) {
-    const file = /ui-e2e\s+(\S+\.e2e\.test\.ts)\s+\((\d+) tests?\)\s+([\d.]+)(m?s)/u.exec(line);
+    const file =
+      /^\s*(?:\d{4}-\d\d-\d\dT[\d:.]+Z\s+)?✓\s+(?:\|ui-e2e\||ui-e2e)\s+(\S+\.e2e\.test\.ts)\s+\((\d+) tests?(?: \| \d+ (?:skipped|todo))*\)\s+([\d.]+)(m?s)(?:\s|$)/u.exec(
+        line,
+      );
     if (file) {
-      recordSample(samples, file[1]!, seconds(file[3]!, file[4]!));
-      fileCount += 1;
+      files.set(file[1]!, seconds(file[3]!, file[4]!));
     }
     const summary = /\bDuration\s+([\d.]+)(m?s)\s+\([^)]*\btests\s+([\d.]+)(m?s)/u.exec(line);
-    if (summary && fileCount > 0) {
+    if (summary && files.size > 0) {
+      // Commit complete native file times, including suite hooks, once per invocation.
+      for (const [name, duration] of files) {
+        recordSample(samples, name, duration);
+      }
       const value =
-        (seconds(summary[1]!, summary[2]!) - seconds(summary[3]!, summary[4]!)) / fileCount;
+        (seconds(summary[1]!, summary[2]!) - seconds(summary[3]!, summary[4]!)) / files.size;
       if (Number.isFinite(value)) {
         overhead.push(value);
       }
-      fileCount = 0;
+      files.clear();
     }
   }
 }

--- a/test/scripts/ci-test-timings.test.ts
+++ b/test/scripts/ci-test-timings.test.ts
@@ -5,6 +5,7 @@ import { syncBuiltinESMExports } from "node:module";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { stripVTControlCharacters } from "node:util";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { refitTestTimings, type CiTimingRun } from "../../scripts/lib/ci-test-timings-refit.mts";
 import {
@@ -69,6 +70,86 @@ it("rejects non-plain timing objects even when their fields are valid", () => {
 });
 
 describe("CI test timing refit", () => {
+  it("ingests the native UI reporters without losing case progress or suite hooks", async () => {
+    const { default: config } = await import("../vitest/vitest.ui-e2e.config.ts");
+    const root = fileURLToPath(new URL("../../", import.meta.url));
+    const artifacts = path.join(root, ".artifacts");
+    fs.mkdirSync(artifacts, { recursive: true });
+    const directory = mkdtempSync(path.join(artifacts, "ci-ui-timings-"));
+    const files = ["ui/src/e2e/first.e2e.test.ts", "ui/src/e2e/second.e2e.test.ts"];
+    const configFile = path.join(directory, "vitest.config.mjs");
+    try {
+      for (const file of files) {
+        fs.mkdirSync(path.dirname(path.join(directory, file)), { recursive: true });
+        writeFileSync(
+          path.join(directory, file),
+          `import { setTimeout } from "node:timers/promises";
+import { beforeAll, afterAll, it } from "vitest";
+beforeAll(() => setTimeout(50));
+afterAll(() => setTimeout(50));
+it("reports completed case progress", () => {});
+it.skip("retains skipped coverage", () => {});
+it.todo("retains todo coverage");
+`,
+        );
+      }
+      writeFileSync(
+        configFile,
+        `export default ${JSON.stringify({
+          root: directory,
+          test: {
+            name: "ui-e2e",
+            include: files,
+            reporters: config.test?.reporters,
+            fileParallelism: false,
+          },
+        })};\n`,
+      );
+      const runs = [1, 2].map((id) => {
+        const result = spawnSync(
+          process.execPath,
+          ["scripts/run-vitest.mjs", "run", "--config", configFile, "--configLoader", "runner"],
+          {
+            cwd: root,
+            encoding: "utf8",
+            timeout: 30_000,
+            env: { ...process.env, GITHUB_STEP_SUMMARY: path.join(directory, "summary.md") },
+          },
+        );
+        expect(result.status, result.stderr || result.stdout).toBe(0);
+        const text = stripVTControlCharacters(result.stdout);
+        expect(text).toContain("> reports completed case progress");
+        const nativeFileDurations = [...text.matchAll(/\.e2e\.test\.ts[^\n]*\)\s+(\d+)ms/gu)];
+        expect(nativeFileDurations, text).toHaveLength(files.length);
+        // Native file time includes both suite hooks, unlike the case-only verbose rows.
+        expect(nativeFileDurations.every((match) => Number(match[1]) >= 90)).toBe(true);
+        return timingRun(id, [{ kind: "uiE2e", text: result.stdout }]);
+      });
+      expect(refitTestTimings(runs).timings.uiE2e.fileSeconds).toEqual(
+        Object.fromEntries(files.map((file) => [file, 1])),
+      );
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts completed passed file summaries once, excluding failed, skipped and unfinished files", () => {
+    const log = [
+      `✓ |ui-e2e| ${measuredFile} (3 tests | 1 skipped | 1 todo) 4000ms`,
+      `✓ \u001b[32mui-e2e\u001b[0m ${measuredFile} (3 tests | 1 skipped | 1 todo) 4000ms`,
+      "❯ ui-e2e ui/src/e2e/failed.e2e.test.ts (1 test | 1 failed) 20s",
+      "❯ ui-e2e ui/src/e2e/timeout.e2e.test.ts (0 test) 30s",
+      "↓ ui-e2e ui/src/e2e/skipped.e2e.test.ts (1 test | 1 skipped) 0ms",
+      "Duration 56s (transform 1s, setup 1s, tests 54s, environment 0ms)",
+      "✓ ui-e2e ui/src/e2e/unfinished.e2e.test.ts (1 test) 5s",
+    ].join("\n");
+    const runs = [1, 2].map((id) => timingRun(id, [{ kind: "uiE2e", text: log }]));
+    expect(refitTestTimings(runs).timings.uiE2e).toEqual({
+      fileSeconds: { [measuredFile]: 4 },
+      perFileOverheadSeconds: 2,
+    });
+  });
+
   it("records per-file medians without outliers or one-run weights and measures excluded overhead", () => {
     const pageFile = "ui/src/pages/settings/measured.e2e.test.ts";
     const singleFile = "ui/src/e2e/single.e2e.test.ts";

--- a/test/vitest-reporters-config.test.ts
+++ b/test/vitest-reporters-config.test.ts
@@ -101,7 +101,9 @@ describe("Vitest reporter contracts", () => {
         expect(
           reporters.map(([name]) => name),
           config,
-        ).toEqual(expected);
+        ).toEqual(
+          config === "test/vitest/vitest.ui-e2e.config.ts" ? [...expected, "default"] : expected,
+        );
         expect(cli, `${config} CLI override`).toEqual([["json", {}]]);
       }
       expect(resolved.defaults).toHaveLength(reporterConfigs.length);

--- a/test/vitest/vitest.ui-e2e.config.ts
+++ b/test/vitest/vitest.ui-e2e.config.ts
@@ -47,6 +47,8 @@ function createUiE2eVitestConfig(
       isolate: true,
       name: "ui-e2e",
       pool: "forks",
+      // Refit needs native file totals; verbose still reports cases to the output watchdog.
+      reporters: [...baseTest.reporters, "default"],
       runner: undefined,
       sequence: { ...baseSequence, sequencer: UiE2eSequencer },
       setupFiles: ["test/vitest/vitest.ui-e2e.setup.ts"],


### PR DESCRIPTION
## What Problem This Solves

The CI timing importer expects completed UI E2E file durations, but Vitest's verbose reporter emits only individual case durations. Successful runs therefore contribute no UI file measurements, leaving the shard planner with stale costs. A retained 354-second UI step was modeled at about 177 seconds before overhead.

## Why This Change Was Made

Keep verbose case progress for the output watchdog and add Vitest's existing default reporter to emit whole-file durations, including suite hooks. Stage and deduplicate passed file rows until their invocation summary appears. Failed, wholly skipped, timed-out and unfinished files do not become timing weights.

The successful-main-push provenance checks, distinct-run minimum, outlier rejection, 15% write threshold, pruning policy and canonical sequencer remain intact. No custom reporter, job, dependency, concurrency limit or timing weight is introduced.

## User Impact

Future successful main runs provide the measurements needed to balance UI E2E work. Case progress remains visible. This change enables a trustworthy refit; it does not itself claim a shorter CI duration or the five-minute target.

## Evidence

`node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/vitest-reporters-config.test.ts test/scripts/ci-test-timings.test.ts test/vitest-ui-e2e-config.test.ts` passes all 86 tests. Both new regressions fail before the repair. The real reporter fixture executes two independent runs and verifies that file totals include before/after hooks, that verbose case progress remains, and that duplicate summaries do not supply duplicate samples. ANSI/plain labels and skipped/todo counts are covered.

All changed-gate stages pass, including complete scripts/root-test type graphs and script lint. An initial lint failure required braces around the new loop; the corrected scripts lint passes. Independent Codex review is clean. Direct Vitest 4.1.11 source inspection confirms that VerboseReporter suppresses file totals and that the default reporter uses the module's duration.

The isolated partition replay preserves all 334 discovered UI files exactly once, with identical ordered shards: 13 UI shards plus one browser-extension row for GitHub/hybrid, and three plus one for Blacksmith. Existing max-parallel values remain 14/4. The three source files on the integration base are byte-identical to the proof baseline.

ClawSweeper follow-through: the existing reporter contract now expects the extra default reporter only for UI E2E. Both GitHub Actions modes fail before this expectation repair and pass after it. All eight configurations still preserve explicit CLI reporter replacement, custom options, deduplication and the injected PTY environment. The complete changed-file gate and scoped Codex review pass after this correction.

Tooling production +13/-7 (net +6); test configuration +2/-0; regression tests +84/-1 (net +83). The small growth adds bounded per-invocation staging at the existing measurement owner. No model/runtime or product behavior changes.

No weights were regenerated from historical case sums or PR runs. After at least two successful applicable main runs include this producer, run `pnpm ci:timings:refit` and validate the resulting full inventory and matrix. Native exact-head CI remains required before landing.

