### PR TITLE
test(infra): synchronize approval shutdown races at callback entry

### DIFF
--- a/src/infra/approval-handler-runtime.test.ts
+++ b/src/infra/approval-handler-runtime.test.ts
@@ -1,5 +1,6 @@
 // Covers approval handler runtime adapter creation and lazy wiring.
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 import {
   createChannelApprovalNativeRuntimeAdapter,
   createChannelApprovalHandlerFromCapability,
@@ -439,14 +440,12 @@ describe("createLazyChannelApprovalNativeRuntimeAdapter", () => {
   });
 
   it("unbinds in-flight wrapped entry when stop() fires between bindPending and activeEntries.set", async () => {
-    const bindGate = { resolve: () => {}, promise: Promise.resolve() };
-    const bindPromise = new Promise<void>((resolve) => {
-      bindGate.resolve = resolve;
-    });
-    bindGate.promise = bindPromise;
+    const bindEntered = createDeferred();
+    const bindGate = createDeferred();
     const deliverPending = vi.fn().mockResolvedValue({ messageId: "in-flight" });
     const bindPending = vi.fn(async () => {
-      await bindPromise;
+      bindEntered.resolve();
+      await bindGate.promise;
       return { bindingId: "bound-in-flight" };
     });
     const unbindPending = vi.fn();
@@ -462,13 +461,7 @@ describe("createLazyChannelApprovalNativeRuntimeAdapter", () => {
     const request = makeExecApprovalRequest("exec:in-flight");
 
     const inflight = approvalRuntime.handleRequested(request);
-    // Flush microtasks so deliverPending resolves and bindPending parks at the gate.
-    await new Promise((r) => {
-      setTimeout(r, 0);
-    });
-    await new Promise((r) => {
-      setTimeout(r, 0);
-    });
+    await withTestTimeout(bindEntered.promise, 1_000, "in-flight approval binding did not start");
 
     // stop() flips the stopped flag while bindPending is parked.
     await approvalRuntime.stop();
@@ -485,14 +478,12 @@ describe("createLazyChannelApprovalNativeRuntimeAdapter", () => {
   });
 
   it("invokes cancelDelivered when stop() fires between deliverPending and bindPending", async () => {
-    const deliverGate = { resolve: () => {}, promise: Promise.resolve() };
-    const deliverPromise = new Promise<void>((resolve) => {
-      deliverGate.resolve = resolve;
-    });
-    deliverGate.promise = deliverPromise;
+    const deliverEntered = createDeferred();
+    const deliverGate = createDeferred();
     const deliveredEntry = { messageId: "pre-bind" };
     const deliverPending = vi.fn(async () => {
-      await deliverPromise;
+      deliverEntered.resolve();
+      await deliverGate.promise;
       return deliveredEntry;
     });
     const bindPending = vi.fn().mockResolvedValue({ bindingId: "should-not-bind" });
@@ -511,13 +502,11 @@ describe("createLazyChannelApprovalNativeRuntimeAdapter", () => {
     const request = makeExecApprovalRequest("exec:pre-bind");
 
     const inflight = approvalRuntime.handleRequested(request);
-    // Flush microtasks so deliverPending is awaited and parked at the gate.
-    await new Promise((r) => {
-      setTimeout(r, 0);
-    });
-    await new Promise((r) => {
-      setTimeout(r, 0);
-    });
+    await withTestTimeout(
+      deliverEntered.promise,
+      1_000,
+      "pre-bind approval delivery did not start",
+    );
 
     // stop() flips the stopped flag while deliverPending is still pending.
     await approvalRuntime.stop();
@@ -536,15 +525,13 @@ describe("createLazyChannelApprovalNativeRuntimeAdapter", () => {
   });
 
   it("invokes cancelDelivered when stop() fires after bindPending returned null", async () => {
-    const bindGate = { resolve: () => {}, promise: Promise.resolve() };
-    const bindPromise = new Promise<void>((resolve) => {
-      bindGate.resolve = resolve;
-    });
-    bindGate.promise = bindPromise;
+    const bindEntered = createDeferred();
+    const bindGate = createDeferred();
     const deliveredEntry = { messageId: "post-bind-null" };
     const deliverPending = vi.fn().mockResolvedValue(deliveredEntry);
     const bindPending = vi.fn(async () => {
-      await bindPromise;
+      bindEntered.resolve();
+      await bindGate.promise;
       return null;
     });
     const unbindPending = vi.fn();
@@ -562,13 +549,7 @@ describe("createLazyChannelApprovalNativeRuntimeAdapter", () => {
     const request = makeExecApprovalRequest("exec:post-bind-null");
 
     const inflight = approvalRuntime.handleRequested(request);
-    // Flush microtasks so deliverPending resolves and bindPending awaits the gate.
-    await new Promise((r) => {
-      setTimeout(r, 0);
-    });
-    await new Promise((r) => {
-      setTimeout(r, 0);
-    });
+    await withTestTimeout(bindEntered.promise, 1_000, "null approval binding did not start");
 
     // stop() flips the stopped flag while bindPending is parked; it then resolves to null.
     await approvalRuntime.stop();


### PR DESCRIPTION
## What Problem This Solves

Three approval shutdown race tests use two zero-delay timers each to guess when delivery or binding has reached its suspended phase. Scheduler turns do not establish that phase.

## Why This Change Was Made

Signal entry directly from the controlled delivery or binding callback, then await that signal before stopping the runtime. Shared deferred helpers also replace three handwritten promise holders. The existing one-second test helper bounds a missing entry signal.

## User Impact

More precise shutdown-race proof with six success-path timer callbacks removed. The same cancellation, unbinding, stopped-state and in-flight completion assertions remain; production behavior is unchanged.

## Evidence

- `node scripts/run-vitest.mjs src/infra/approval-handler-runtime.test.ts src/infra/approval-native-runtime.test.ts` passed all 19 tests before and after.
- Full changed-file checks, formatting, diff checks and structured Codex autoreview passed.
- Reviewed the handler, native adapter, bootstrap, execution-channel caller and deferred/timeout helpers. Each signal is emitted immediately before the callback awaits its release gate.
- Production +0/-0. No elapsed-time speedup is claimed.
