### PR TITLE
test(ios): remove duplicated Watch source guards

### DIFF
--- a/apps/ios/Tests/WatchApprovalTransportSourceGuardTests.swift
+++ b/apps/ios/Tests/WatchApprovalTransportSourceGuardTests.swift
@@ -114,7 +114,7 @@ struct WatchApprovalTransportSourceGuardTests {
             "WatchGatewayID.key(snapshot.gatewayStableID) == WatchGatewayID.key(token.gatewayStableID)"))
     }
 
-    @Test func `watch applies retry reset only to its exact active attempt`() throws {
+    @Test func `retry reset matches the exact active attempt`() throws {
         let storeSource = try Self.readWatchSource("WatchInboxStore.swift")
         let promptConsume = try Self.extract(
             storeSource,
@@ -125,23 +125,11 @@ struct WatchApprovalTransportSourceGuardTests {
             from: "private func upsertExecApproval(",
             to: "private static func snapshotCanReplace(")
 
-        let guardedUpsert = try #require(promptConsume.range(of: "guard self.upsertExecApproval("))
-        let notificationOwnerCheck = try #require(promptConsume.range(of: "guard let approvalOwnerKey"))
-        #expect(guardedUpsert.lowerBound < notificationOwnerCheck.lowerBound)
-        let upsertAdmission = promptConsume[guardedUpsert.lowerBound..<notificationOwnerCheck.lowerBound]
-        #expect(upsertAdmission.contains("else { return }"))
-        #expect(upsert.contains("resetResolutionAttemptID: String? = nil) -> Bool"))
-        #expect(upsert.components(separatedBy: "return false").count >= 3)
-        #expect(upsert.contains("return true"))
-        #expect(promptConsume.contains(
-            "resetResolutionAttemptID: message.resetResolutionAttemptId"))
-        #expect(upsert.contains("let activeResolutionAttemptID ="))
+        #expect(promptConsume.contains("resetResolutionAttemptID: message.resetResolutionAttemptId"))
+        #expect(upsert.contains("resetResolutionAttemptID: String? = nil"))
         #expect(upsert.contains(
             "WatchOpaqueUTF8Key(resetResolutionAttemptID) == WatchOpaqueUTF8Key(activeResolutionAttemptID)"))
         #expect(upsert.contains("activeResolutionAttemptID = resetResolvingState ? nil"))
-        #expect(!storeSource.contains("appliedResetDeliveryIDs"))
-        #expect(!storeSource.contains("deliveryId"))
-        #expect(!storeSource.contains("resetResolvingState: Bool?"))
     }
 
     @Test func `watch rejects partial or missing approval snapshot arrays`() throws {
@@ -290,80 +278,35 @@ struct WatchApprovalTransportSourceGuardTests {
         #expect(detailScroll.contains("self.content"))
     }
 
-    @Test func `watch notification identity frames dotted components`() throws {
+    @Test func `notification identity keeps dotted owners distinct`() throws {
         let storeSource = try Self.readWatchSource("WatchInboxStore.swift")
-        let messagesSource = try Self.readWatchSource("WatchInboxMessages.swift")
-        let identifierSource = try Self.readIOSServiceSource("ExactOpaqueIdentifier.swift")
-        let promptConsume = try Self.extract(
-            storeSource,
-            from: "func consume(\n        execApprovalPrompt",
-            to: "func consume(\n        execApprovalSnapshot")
-        let rawLeft = "a.b" + "." + "c"
-        let rawRight = "a" + "." + "b.c"
-        #expect(rawLeft == rawRight)
-
-        let framedLeft = ExactOpaqueIdentifierKey("a.b").notificationComponent + "."
+        let left = ExactOpaqueIdentifierKey("a.b").notificationComponent + "."
             + ExactOpaqueIdentifierKey("c").notificationComponent
-        let framedRight = ExactOpaqueIdentifierKey("a").notificationComponent + "."
+        let right = ExactOpaqueIdentifierKey("a").notificationComponent + "."
             + ExactOpaqueIdentifierKey("b.c").notificationComponent
-        #expect(framedLeft != framedRight)
-        #expect(messagesSource.contains("typealias WatchOpaqueUTF8Key = ExactOpaqueIdentifierKey"))
-        #expect(identifierSource.contains("0x2D, 0x5F, 0x7E"))
-        #expect(!identifierSource.contains("0x2D, 0x2E, 0x5F, 0x7E"))
-        #expect(!storeSource.contains("0x2D, 0x2E, 0x5F, 0x7E"))
+
+        #expect(left != right)
         #expect(storeSource.contains("gatewayKey.notificationComponent).\\(approvalKey.notificationComponent"))
-        #expect(storeSource.contains("legacyExecApprovalNotificationIdentifier"))
-        #expect(storeSource.contains("hasLiveLegacyNotificationCollision"))
+        #expect(storeSource.contains("!self.hasLiveLegacyNotificationCollision("))
         #expect(storeSource.contains("recordKey != excludedKey"))
-        let legacyCleanup = try #require(
-            promptConsume.range(of: "if let legacyNotificationIdentifier"))
-        let notificationSchedule = try #require(
-            promptConsume.range(of: "await self.postLocalNotification("))
-        #expect(legacyCleanup.lowerBound < notificationSchedule.lowerBound)
-        #expect(promptConsume.contains("!self.hasLiveLegacyNotificationCollision("))
-        #expect(promptConsume.contains(
-            "self.removeLocalNotifications(identifiers: [legacyNotificationIdentifier])"))
     }
 
-    @Test func `watch snapshot acknowledgment advances only after store acceptance`() throws {
+    @Test func `snapshot acknowledgment follows store acceptance`() throws {
         let storeSource = try Self.readWatchSource("WatchInboxStore.swift")
         let receiverSource = try Self.readWatchSource("WatchConnectivityReceiver.swift")
         let snapshotConsume = try Self.extract(
             storeSource,
             from: "func consume(\n        execApprovalSnapshot",
             to: "func consume(appSnapshot")
-        let replay = try Self.extract(
-            storeSource,
-            from: "func replayDeferredGatewayPayloads()",
-            to: "private func clearMessagePrompt()")
-        let correlation = try #require(snapshotConsume.range(of: "let hasCanonicalRequestCorrelation"))
-        let ownerValidation = try #require(snapshotConsume.range(of: "let allApprovalOwnersMatch"))
-        let existingRecords = try #require(snapshotConsume.range(of: "let existingRecords = self.execApprovals"))
 
         #expect(snapshotConsume.contains("transport: String) -> Bool"))
-        #expect(snapshotConsume.components(separatedBy: "return false").count >= 4)
+        #expect(snapshotConsume.contains("guard allApprovalOwnersMatch else { return false }"))
         #expect(snapshotConsume.contains("self.persistState()\n        return true"))
         #expect(receiverSource.contains(
             "if self.store.consume(execApprovalSnapshot: execApprovalSnapshot, transport: transport)"))
         #expect(receiverSource.contains(
             "if self.store.consume(execApprovalSnapshot: snapshot, transport: transport)"))
-        #expect(replay.contains(
-            "func replayDeferredGatewayPayloads() -> [WatchExecApprovalSnapshotMessage]"))
-        #expect(replay.contains(
-            "var appliedExecApprovalSnapshots: [WatchExecApprovalSnapshotMessage] = []"))
-        #expect(replay.contains("if self.consume(execApprovalSnapshot: message, transport: transport)"))
-        #expect(replay.contains("appliedExecApprovalSnapshots.append(message)"))
-        #expect(replay.contains("return appliedExecApprovalSnapshots"))
-        #expect(receiverSource.components(
-            separatedBy: "for snapshot in self.store.replayDeferredGatewayPayloads()").count == 3)
-        #expect(receiverSource.components(
-            separatedBy: "self.recordAcceptedExecApprovalSnapshot(snapshot)").count >= 3)
-        #expect(!receiverSource.contains("execApprovalSnapshotRevision"))
-        #expect(correlation.lowerBound < ownerValidation.lowerBound)
-        #expect(ownerValidation.lowerBound < existingRecords.lowerBound)
-        #expect(snapshotConsume.contains("guard allApprovalOwnersMatch else { return false }"))
-        #expect(snapshotConsume.contains(
-            "Self.gatewayIDsMatch(approval.gatewayStableID, snapshotGatewayID)"))
+        #expect(receiverSource.contains("if self.consume(execApprovalSnapshot: message, transport: transport)"))
     }
 
     private static func readWatchSource(_ filename: String) throws -> String {
@@ -371,15 +314,6 @@ struct WatchApprovalTransportSourceGuardTests {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("WatchApp/Sources")
-            .appendingPathComponent(filename)
-        return try String(contentsOf: url, encoding: .utf8)
-    }
-
-    private static func readIOSServiceSource(_ filename: String) throws -> String {
-        let url = URL(fileURLWithPath: #filePath)
-            .deletingLastPathComponent()
-            .deletingLastPathComponent()
-            .appendingPathComponent("Sources/Services")
             .appendingPathComponent(filename)
         return try String(contentsOf: url, encoding: .utf8)
     }


### PR DESCRIPTION
## What Problem This Solves

The Watch approval test target carries several source-text assertions for private implementation ordering, identifier plumbing, and view structure. These tests require synchronized edits during behavior-preserving refactors without executing the approval flow.

## Why This Change Was Made

Replace the broad retry-reset, notification-identity, and snapshot-acceptance source mirrors with compact focused guards for their actual invariants. Retain the Watch-only decision-delivery, forced-refresh correlation, exact identifier, command-review accessibility, loading/screenshot, and parser checks.

## User Impact

No user-visible behavior changes. This reduces brittle native test maintenance by net 66 lines while preserving the independent Watch invariants identified during review.

## Evidence

- Test diff: +12/-78 LOC (net -66).
- `git diff --check`.
- Shared changed gates passed through dependency pins, duplicate coverage, coercion guards, package patches, and formatting; local SwiftLint could not load SourceKit on this command-line-tools-only host.
- Structured Autoreview on the narrowed exact patch: scoped clean, 0.99 confidence, no accepted/actionable findings.
- Exact-head Apple build/test and Swift lint remain required in CI.
