### PR TITLE
refactor(core): share first-wins keyed dedupe

### DIFF
--- a/src/agents/harness/model-catalog.ts
+++ b/src/agents/harness/model-catalog.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginRegistry } from "../../plugins/registry-types.js";
 import { getActivePluginRegistry } from "../../plugins/runtime.js";
+import { dedupeByKey } from "../../shared/dedupe-by-key.js";
 import {
   resolveAgentEffectiveModelPrimary,
   resolveAgentWorkspaceDir,
@@ -13,20 +14,6 @@ import { resolveModelCatalogIdentityKey } from "../openai-model-routes.js";
 import type { PreparedModelRuntimeInput } from "../prepared-model-runtime.types.js";
 import { resolveDefaultAgentWorkspaceDir } from "../workspace.js";
 import { resolveAgentHarnessPolicy } from "./policy.js";
-
-function dedupeByKey(
-  entries: readonly ModelCatalogEntry[],
-  keyOf: (entry: ModelCatalogEntry) => string,
-): ModelCatalogEntry[] {
-  const merged = new Map<string, ModelCatalogEntry>();
-  for (const entry of entries) {
-    const key = keyOf(entry);
-    if (!merged.has(key)) {
-      merged.set(key, entry);
-    }
-  }
-  return [...merged.values()];
-}
 
 function normalizeRouteBaseUrl(value: string | undefined): string {
   if (!value) {

--- a/src/shared/dedupe-by-key.test.ts
+++ b/src/shared/dedupe-by-key.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import { dedupeByKey } from "./dedupe-by-key.js";
+
+describe("dedupeByKey", () => {
+  it("keeps the first item for each key in stable input order", () => {
+    const first = Object.freeze({ id: "first", key: "duplicate" });
+    const duplicate = Object.freeze({ id: "second", key: "duplicate" });
+    const last = Object.freeze({ id: "last", key: "unique" });
+    const items = Object.freeze([first, duplicate, last]);
+    const keyOf = vi.fn((item: (typeof items)[number]) => item.key);
+
+    const result = dedupeByKey(items, keyOf);
+
+    expect(result).toEqual([first, last]);
+    expect(result[0]).toBe(first);
+    expect(keyOf).toHaveBeenCalledTimes(items.length);
+    expect(items).toEqual([first, duplicate, last]);
+  });
+
+  it("returns an empty array without reading a key", () => {
+    const keyOf = vi.fn<(item: string) => string>();
+
+    expect(dedupeByKey([], keyOf)).toEqual([]);
+    expect(keyOf).not.toHaveBeenCalled();
+  });
+
+  it("propagates key errors and stops at the failing item", () => {
+    const failure = new Error("key failed");
+    const visited: string[] = [];
+    const keyOf = (item: string) => {
+      visited.push(item);
+      if (item === "bad") {
+        throw failure;
+      }
+      return item;
+    };
+
+    expect(() => dedupeByKey(["first", "bad", "unvisited"], keyOf)).toThrow(failure);
+    expect(visited).toEqual(["first", "bad"]);
+  });
+});

--- a/src/shared/dedupe-by-key.ts
+++ b/src/shared/dedupe-by-key.ts
@@ -1,0 +1,10 @@
+export function dedupeByKey<T>(items: readonly T[], keyOf: (item: T) => string): T[] {
+  const deduped = new Map<string, T>();
+  for (const item of items) {
+    const key = keyOf(item);
+    if (!deduped.has(key)) {
+      deduped.set(key, item);
+    }
+  }
+  return [...deduped.values()];
+}

--- a/src/status/status-plugin-health.ts
+++ b/src/status/status-plugin-health.ts
@@ -1,5 +1,6 @@
 // Builds compact plugin health summaries for chat status surfaces.
 import type { PluginDiagnosticCode } from "../plugins/manifest-types.js";
+import { dedupeByKey } from "../shared/dedupe-by-key.js";
 
 type StatusPluginDependencyStatus = {
   hasDependencies?: boolean;
@@ -82,22 +83,10 @@ export type StatusPluginHealthSnapshot = {
   }>;
 };
 
-/** Keeps the first record per key; later duplicates are dropped. */
-function dedupeBy<T>(items: readonly T[], keyOf: (item: T) => string): T[] {
-  const seen = new Map<string, T>();
-  for (const item of items) {
-    const key = keyOf(item);
-    if (!seen.has(key)) {
-      seen.set(key, item);
-    }
-  }
-  return [...seen.values()];
-}
-
 export function dedupePluginDiagnostics(
   diagnostics: readonly PluginDiagnosticRecord[],
 ): PluginDiagnosticRecord[] {
-  return dedupeBy(diagnostics, (entry) =>
+  return dedupeByKey(diagnostics, (entry) =>
     JSON.stringify([entry.level, entry.pluginId ?? "", entry.code ?? "", entry.message]),
   );
 }
@@ -107,7 +96,7 @@ export function dedupePluginDiagnostics(
 export function dedupeChannelPluginFailures(
   failures: readonly ChannelPluginFailureRecord[],
 ): ChannelPluginFailureRecord[] {
-  return dedupeBy(failures, (entry) =>
+  return dedupeByKey(failures, (entry) =>
     JSON.stringify([entry.channelId, entry.pluginId ?? "", entry.message]),
   );
 }
@@ -115,7 +104,7 @@ export function dedupeChannelPluginFailures(
 function dedupeCompatibilityNotices(
   notices: readonly PluginCompatibilityHealthNotice[],
 ): PluginCompatibilityHealthNotice[] {
-  return dedupeBy(notices, (entry) =>
+  return dedupeByKey(notices, (entry) =>
     JSON.stringify([entry.pluginId, entry.severity, entry.code ?? "", entry.message]),
   );
 }


### PR DESCRIPTION
## What Problem This Solves

Core had two separate implementations of the same first-wins keyed deduplication contract in model catalog assembly and plugin health reporting. Keeping that policy duplicated makes later changes prone to semantic drift.

## Why This Change Was Made

Moves the existing behavior into one private core helper and replaces the five equivalent call sites. The helper preserves first-object identity and stable input order without normalizing keys or mutating input. It is not exported through a barrel or plugin SDK surface.

Removed duplicate implementations:

- `src/agents/harness/model-catalog.ts`
- `src/status/status-plugin-health.ts`

Production LOC: `+15/-29` (net `-14`)  
Tests: `+41/-0`

## User Impact

No user-visible behavior change. Model catalog and plugin health deduplication continue to keep the first record for each key; the shared contract reduces maintenance risk.

## Evidence

- Pre-change owner baseline: 39 model catalog and plugin health tests passed.
- Final focused suite: 42 tests passed across the helper, model catalog, plugin health, installed health, and runtime health owners.
- Contract coverage verifies first-wins object identity, stable order, one key evaluation per visited item, readonly frozen input, empty input, and exact thrown-error propagation with iteration stopping at the failing item.
- Core source types, core test types, targeted lint, formatting, dead-export scan, import-cycle check, and changed static guards passed.
- Exact staged diff and privacy scrub passed.
- No config, protocol, security, persistence, docs, changelog, or public SDK surface changed.
