### PR TITLE
refactor: reuse prepared plugin facts during Gateway turns

### DIFF
--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -129,6 +129,11 @@ hashing. Activation and runtime service generations can change while their
 package metadata stays fixed. Account health and authentication state are not
 part of the immutable package inventory.
 
+Provider auth aliases are normalized and indexed with the snapshot. Lookups
+select among those prepared candidates using the current workspace trust config;
+they do not cache trust decisions or credentials. Callers supplying a partial
+manifest view keep fresh per-call projection rather than sharing mutable metadata.
+
 Explicit install, update, registry refresh, and doctor operations use isolated
 generations of the same cache type, acquired after their lifecycle lease. They may inspect changed files and rebuild the persisted
 installed index, but cannot clear or replace the running Gateway's inventory.

--- a/packages/ai/src/transports/openai-responses-websocket-client.test.ts
+++ b/packages/ai/src/transports/openai-responses-websocket-client.test.ts
@@ -847,7 +847,6 @@ describe("native OpenAI Responses WebSocket client integration", () => {
     // here so the transport fixture exercises core retry policy without plugin discovery.
     withPluginRuntimeGenerationScope(
       {
-        config: {},
         metadataSnapshot: createPluginMetadataSnapshot({
           manifestRegistry: makeRegistry([{ id: "openai", channels: [], providers: ["openai"] }]),
         }),

--- a/src/agents/agent-command.ts
+++ b/src/agents/agent-command.ts
@@ -678,7 +678,6 @@ async function agentCommandFromIngressInternal(
   return generation && runtimeContext
     ? await withPluginRuntimeGenerationScope(
         {
-          config: runtimeContext.config,
           metadataSnapshot: generation.pluginMetadataSnapshot,
           pluginRegistry: generation.pluginRegistry,
         },

--- a/src/agents/harness/runtime-plugin-load-plan.ts
+++ b/src/agents/harness/runtime-plugin-load-plan.ts
@@ -2,6 +2,7 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { withActivatedPluginIds } from "../../plugins/activation-context.js";
 import { resolveManifestActivationPlan } from "../../plugins/activation-planner.js";
+import { normalizePluginsConfigWithResolverCore } from "../../plugins/config-normalization-shared.js";
 import {
   isTestDefaultMemorySlotDisabled,
   resolveEffectivePluginActivationState,
@@ -69,12 +70,16 @@ function resolveSelectedMemoryPluginIds(params: {
   if (isTestDefaultMemorySlotDisabled(params.config ?? {})) {
     return [];
   }
-  const registry = loadPluginRegistrySnapshot({
-    config: params.config,
-    workspaceDir: params.metadataSnapshot?.workspaceDir ?? params.workspaceDir,
-    ...(params.metadataSnapshot ? { index: params.metadataSnapshot.index } : {}),
-  });
-  const plugins = normalizePluginsConfigWithRegistry(params.config?.plugins, registry);
+  const registry =
+    params.metadataSnapshot?.index ??
+    loadPluginRegistrySnapshot({ config: params.config, workspaceDir: params.workspaceDir });
+  // The generation owns aliases; activation still follows this call's config.
+  const plugins = params.metadataSnapshot
+    ? normalizePluginsConfigWithResolverCore(
+        params.config?.plugins,
+        params.metadataSnapshot.normalizePluginId,
+      )
+    : normalizePluginsConfigWithRegistry(params.config?.plugins, registry);
   const memorySlot = plugins.slots.memory;
   if (
     typeof memorySlot !== "string" ||

--- a/src/agents/harness/runtime-plugin.test.ts
+++ b/src/agents/harness/runtime-plugin.test.ts
@@ -1,6 +1,12 @@
 // Verifies harness ownership, payload availability, and run-owned registry lookup.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createPluginMetadataSnapshot,
+  makeRegistry,
+} from "../../config/plugin-auto-enable.test-helpers.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import * as installedManifests from "../../plugins/manifest-registry-installed.js";
+import { restorePluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import {
   createAgentRuntimeMetadataPluginIdScope,
@@ -303,6 +309,47 @@ describe("harness runtime plugins", () => {
       }
     },
   );
+
+  it("reuses prepared memory aliases while applying current activation policy", () => {
+    const config: OpenClawConfig = { plugins: { slots: { memory: "fixture-memory" } } };
+    const snapshot = createPluginMetadataSnapshot({
+      config,
+      manifestRegistry: makeRegistry([
+        { id: "fixture-memory", channels: [], providers: ["memory-alias"] },
+      ]),
+    });
+    snapshot.index.plugins = [
+      {
+        ...installedProviderRecord("fixture-memory"),
+        origin: "config",
+        rootDir: "/fake/fixture-memory",
+        manifestPath: "/fake/fixture-memory/openclaw.plugin.json",
+        manifestHash: "fixture",
+        enabled: true,
+        enabledByDefault: true,
+        startup: { sidecar: false, memory: true, agentHarnesses: [] },
+      },
+    ];
+    const metadataSnapshot = restorePluginMetadataSnapshot(snapshot);
+    const rebuildManifests = vi
+      .spyOn(installedManifests, "loadPluginManifestRegistryForInstalledIndex")
+      .mockReturnValue(metadataSnapshot.manifestRegistry);
+    try {
+      for (const enabled of [true, false, true]) {
+        config.plugins!.entries = { "memory-alias": { enabled } };
+        const plan = resolveAgentRuntimePluginLoadPlan({
+          config,
+          metadataSnapshot,
+          workspaceDir: "/tmp/agent-workspace",
+          selections: [],
+        });
+        expect(plan.pluginIds ?? []).toEqual(enabled ? ["fixture-memory"] : []);
+      }
+      expect(rebuildManifests).not.toHaveBeenCalled();
+    } finally {
+      rebuildManifests.mockRestore();
+    }
+  });
 
   it("keeps standalone activation unrestricted when no complete startup base exists", () => {
     const plan = resolveAgentRuntimePluginLoadPlan({

--- a/src/agents/model-suppression.test.ts
+++ b/src/agents/model-suppression.test.ts
@@ -174,30 +174,27 @@ describe("model suppression", () => {
     const aReady = new Promise<void>((resolve) => {
       markAReady = resolve;
     });
-    const resultA = withPluginRuntimeGenerationScope(
-      { config, metadataSnapshot: snapshotA },
-      async () => {
-        const result = shouldSuppressBuiltInModelCore({
+    const resultA = withPluginRuntimeGenerationScope({ metadataSnapshot: snapshotA }, async () => {
+      const result = shouldSuppressBuiltInModelCore({
+        provider: "openai",
+        id: "generation-model",
+        config,
+      });
+      markAReady();
+      await holdA;
+      return [
+        result,
+        shouldSuppressBuiltInModelCore({
           provider: "openai",
           id: "generation-model",
           config,
-        });
-        markAReady();
-        await holdA;
-        return [
-          result,
-          shouldSuppressBuiltInModelCore({
-            provider: "openai",
-            id: "generation-model",
-            config,
-          }),
-        ];
-      },
-    );
+        }),
+      ];
+    });
     await aReady;
 
     const resultB = await withPluginRuntimeGenerationScope(
-      { config, metadataSnapshot: snapshotB },
+      { metadataSnapshot: snapshotB },
       async () =>
         shouldSuppressBuiltInModelCore({
           provider: "openai",
@@ -222,7 +219,7 @@ describe("model suppression", () => {
     mocks.buildManifestBuiltInModelSuppressionResolver.mockReturnValue(() => undefined);
 
     const check = (config: OpenClawConfig, workspaceDir: string) =>
-      withPluginRuntimeGenerationScope({ config, metadataSnapshot: snapshot }, () =>
+      withPluginRuntimeGenerationScope({ metadataSnapshot: snapshot }, () =>
         shouldSuppressBuiltInModelCore({
           provider: "openai",
           id: "generation-model",
@@ -251,7 +248,7 @@ describe("model suppression", () => {
     );
     const envFingerprint = vi.spyOn(pluginMetadataSnapshot, "resolvePluginMetadataEnvFingerprint");
 
-    withPluginRuntimeGenerationScope({ config, metadataSnapshot: snapshot }, () => {
+    withPluginRuntimeGenerationScope({ metadataSnapshot: snapshot }, () => {
       shouldSuppressBuiltInModelCore({ provider: "openai", id: "gpt-5.3", config });
       controlPlaneFingerprint.mockClear();
       envFingerprint.mockClear();

--- a/src/agents/prepared-model-catalog.worker.ts
+++ b/src/agents/prepared-model-catalog.worker.ts
@@ -66,7 +66,6 @@ function refreshAuthStore(params: {
   });
   return withPluginRuntimeGenerationScope(
     {
-      config: params.config,
       metadataSnapshot: params.pluginGeneration.pluginMetadataSnapshot,
       pluginRegistry: params.pluginGeneration.pluginRegistry,
     },
@@ -167,7 +166,6 @@ export async function runPreparedModelCatalogWorkerRequest(
     replaceRuntimeAuthProfileStoreSnapshots([{ agentDir: value.input.agentDir, store: authStore }]);
     const ambientCredentials = withPluginRuntimeGenerationScope(
       {
-        config: value.input.config,
         metadataSnapshot: prepared.pluginGeneration.pluginMetadataSnapshot,
         pluginRegistry: prepared.pluginGeneration.pluginRegistry,
       },

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -453,7 +453,6 @@ export async function prepareWorkspaceBuildGroup(
   };
   return await withPluginRuntimeGenerationScope(
     {
-      config: input.config,
       metadataSnapshot: pluginMetadataSnapshot,
       pluginRegistry: runtimePluginRegistry,
     },

--- a/src/agents/prepared-model-runtime.plugin-context.ts
+++ b/src/agents/prepared-model-runtime.plugin-context.ts
@@ -1,5 +1,4 @@
 import type { PluginDiscoveryResult } from "../plugins/discovery.js";
-import { extractPluginInstallRecordsFromInstalledPluginIndex } from "../plugins/installed-plugin-index-install-records.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import type { PluginRegistry } from "../plugins/registry-types.js";
@@ -61,7 +60,6 @@ export function prepareOwnedPluginLoadContext(
       preferBuiltPluginArtifacts,
     }),
     metadataSnapshot,
-    installRecords: extractPluginInstallRecordsFromInstalledPluginIndex(metadataSnapshot.index),
   };
   // The prepared registry is the lifecycle-owned carrier; standalone callers keep the cold path.
   setPluginRuntimeLoadContext(registry, context);

--- a/src/agents/prepared-model-runtime.plugin-generation.ts
+++ b/src/agents/prepared-model-runtime.plugin-generation.ts
@@ -123,27 +123,24 @@ export async function buildPreparedPluginModelCatalog(params: {
 }) {
   const { credentials, input } = params.agentFacts;
   const { pluginMetadataSnapshot: metadataSnapshot, pluginRegistry } = params.pluginGeneration;
-  return await withPluginRuntimeGenerationScope(
-    { config: input.config, metadataSnapshot, pluginRegistry },
-    async () => {
-      const snapshot = await buildPreparedModelCatalogSnapshot({
-        agentDir: input.agentDir,
-        authCredentials: credentials,
-        config: input.config,
-        modelRegistry: params.modelRegistry,
-        metadataSnapshot,
-        includeProviderPluginAugmentation: params.catalogMode === "live",
-        ...(input.env ? { env: input.env } : {}),
-        ...(input.readOnly ? { readOnly: true } : {}),
-        ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
-      });
-      return params.catalogMode === "live"
-        ? await augmentPreparedModelCatalogWithAgentHarness({
-            input,
-            snapshot,
-            pluginRegistry,
-          })
-        : snapshot;
-    },
-  );
+  return await withPluginRuntimeGenerationScope({ metadataSnapshot, pluginRegistry }, async () => {
+    const snapshot = await buildPreparedModelCatalogSnapshot({
+      agentDir: input.agentDir,
+      authCredentials: credentials,
+      config: input.config,
+      modelRegistry: params.modelRegistry,
+      metadataSnapshot,
+      includeProviderPluginAugmentation: params.catalogMode === "live",
+      ...(input.env ? { env: input.env } : {}),
+      ...(input.readOnly ? { readOnly: true } : {}),
+      ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
+    });
+    return params.catalogMode === "live"
+      ? await augmentPreparedModelCatalogWithAgentHarness({
+          input,
+          snapshot,
+          pluginRegistry,
+        })
+      : snapshot;
+  });
 }

--- a/src/agents/provider-auth-aliases.test.ts
+++ b/src/agents/provider-auth-aliases.test.ts
@@ -57,7 +57,7 @@ import { createPluginCache, getPluginCache, withPluginCache } from "../plugins/p
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { createProviderAuthResolver } from "./models-config.providers.secrets.js";
-import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
+import { resolveProviderAuthAliasMap, resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 
 function createPluginManifestRecord(
   plugin: Partial<PluginManifestRecord> & Pick<PluginManifestRecord, "id" | "origin">,
@@ -142,6 +142,17 @@ function createPluginMetadataSnapshot(params: {
   };
 }
 
+async function prepareAliasSnapshot(plugins: PluginManifestRecord[]) {
+  const metadata = await vi.importActual<typeof import("../plugins/plugin-metadata-snapshot.js")>(
+    "../plugins/plugin-metadata-snapshot.js",
+  );
+  const source = createPluginMetadataSnapshot({ plugins });
+  const snapshot = metadata.restorePluginMetadataSnapshot(
+    metadata.rebasePluginMetadataSnapshotManifestRegistry(source, source.manifestRegistry),
+  );
+  return { metadata, snapshot };
+}
+
 describe("provider auth aliases", () => {
   beforeEach(() => {
     clearPluginMetadataLifecycleCaches();
@@ -154,6 +165,234 @@ describe("provider auth aliases", () => {
     pluginRegistryMocks.loadPluginRegistrySnapshot.mockReset();
     pluginRegistryMocks.loadPluginRegistrySnapshot.mockReturnValue({ plugins: [] });
     pluginRegistryMocks.loadPluginMetadataSnapshot.mockClear();
+  });
+
+  it("does not enumerate alias metadata again after snapshot preparation", async () => {
+    const enumerateAliases = vi.fn(Reflect.ownKeys);
+    const { snapshot } = await prepareAliasSnapshot([
+      createPluginManifestRecord({
+        id: "selected",
+        origin: "bundled",
+        providerAuthAliases: { selected: "selected-provider" },
+      }),
+      createPluginManifestRecord({
+        id: "unrelated",
+        origin: "bundled",
+        providerAuthAliases: new Proxy<Record<string, string>>(
+          { unrelated: "unrelated-provider" },
+          {
+            ownKeys: enumerateAliases,
+          },
+        ),
+      }),
+    ]);
+    enumerateAliases.mockClear();
+
+    for (let repeat = 0; repeat < 8; repeat += 1) {
+      expect(resolveProviderIdForAuth("selected", { metadataSnapshot: snapshot })).toBe(
+        "selected-provider",
+      );
+      expect(resolveProviderIdForAuth("unrelated", { metadataSnapshot: snapshot })).toBe(
+        "unrelated-provider",
+      );
+      expect(resolveProviderIdForAuth("missing", { metadataSnapshot: snapshot })).toBe("missing");
+    }
+    expect(enumerateAliases).not.toHaveBeenCalled();
+  });
+
+  it("preserves alias precedence, normalized collisions and eligible declaration order", async () => {
+    const { snapshot } = await prepareAliasSnapshot([
+      createPluginManifestRecord({
+        id: "early-workspace",
+        origin: "workspace",
+        providerAuthAliases: { "early-only": "workspace", shared: "workspace" },
+      }),
+      createPluginManifestRecord({
+        id: "first-global",
+        origin: "global",
+        providerAuthAliases: {
+          "duplicate ": "later-raw-alias",
+          duplicate: "first-raw-alias",
+          middle: "first-global",
+          shared: "global",
+        },
+        providerAuthChoices: [
+          {
+            provider: "choice-provider",
+            method: "oauth",
+            choiceId: "choice",
+            deprecatedChoiceIds: ["legacy", "duplicate"],
+          },
+        ],
+      }),
+      createPluginManifestRecord({
+        id: "later-bundled",
+        origin: "bundled",
+        providerAuthAliases: { shared: "bundled", tail: "bundled" },
+      }),
+      createPluginManifestRecord({
+        id: "same-priority",
+        origin: "global",
+        providerAuthAliases: { middle: "later-global" },
+      }),
+      createPluginManifestRecord({
+        id: "configured",
+        origin: "config",
+        providerAuthAliases: { shared: "configured" },
+      }),
+    ]);
+    const withoutWorkspace = resolveProviderAuthAliasMap({ metadataSnapshot: snapshot });
+    expect(Object.keys(withoutWorkspace)).toEqual([
+      "duplicate",
+      "middle",
+      "shared",
+      "legacy",
+      "tail",
+    ]);
+    expect(withoutWorkspace).toEqual({
+      duplicate: "first-raw-alias",
+      middle: "first-global",
+      shared: "configured",
+      legacy: "choice-provider",
+      tail: "bundled",
+    });
+    const withWorkspace = resolveProviderAuthAliasMap({
+      config: { plugins: { allow: ["early-workspace"] } },
+      metadataSnapshot: snapshot,
+    });
+    expect(Object.keys(withWorkspace)).toEqual([
+      "early-only",
+      "shared",
+      "duplicate",
+      "middle",
+      "legacy",
+      "tail",
+    ]);
+    for (const [alias, target] of Object.entries(withWorkspace)) {
+      expect(
+        resolveProviderIdForAuth(alias, {
+          config: { plugins: { allow: ["early-workspace"] } },
+          metadataSnapshot: snapshot,
+        }),
+      ).toBe(target);
+    }
+    const proto = resolveProviderAuthAliasMap({
+      metadataSnapshot: {
+        plugins: [
+          createPluginManifestRecord({
+            id: "prototype-alias",
+            origin: "bundled",
+            providerAuthAliases: { ["__proto__"]: "prototype-provider" },
+          }),
+        ],
+      },
+    });
+    expect(Object.getPrototypeOf(withWorkspace)).toBeNull();
+    expect(Object.getPrototypeOf(proto)).toBeNull();
+    expect(Object.getOwnPropertyDescriptor(proto, "__proto__")?.value).toBe("prototype-provider");
+    withoutWorkspace.shared = "caller-mutation";
+    expect(resolveProviderIdForAuth("shared", { metadataSnapshot: snapshot })).toBe("configured");
+  });
+
+  it("rechecks workspace trust against current config within one prepared snapshot", async () => {
+    const { snapshot } = await prepareAliasSnapshot([
+      createPluginManifestRecord({
+        id: "first-workspace",
+        origin: "workspace",
+        providerAuthAliases: { shared: "first-provider" },
+      }),
+      createPluginManifestRecord({
+        id: "second-workspace",
+        origin: "workspace",
+        providerAuthAliases: { shared: "second-provider" },
+      }),
+    ]);
+    const config: NonNullable<Parameters<typeof resolveProviderIdForAuth>[1]>["config"] = {};
+    const resolve = () =>
+      resolveProviderIdForAuth("shared", { config, metadataSnapshot: snapshot });
+    expect(resolve()).toBe("shared");
+    config.plugins = { allow: ["first-workspace", "second-workspace"] };
+    expect(resolve()).toBe("first-provider");
+    config.plugins.deny = ["first-workspace"];
+    expect(resolve()).toBe("second-provider");
+    config.plugins.entries = { "second-workspace": { enabled: false } };
+    expect(resolve()).toBe("shared");
+    config.plugins = { slots: { contextEngine: "first-workspace" } };
+    expect(resolve()).toBe("first-provider");
+    config.plugins.enabled = false;
+    expect(resolve()).toBe("shared");
+    expect(
+      resolveProviderIdForAuth("shared", {
+        config,
+        metadataSnapshot: snapshot,
+        includeUntrustedWorkspacePlugins: true,
+      }),
+    ).toBe("first-provider");
+  });
+
+  it("keeps public partial metadata views fresh when the caller mutates them", () => {
+    const aliases = { fixture: "first-provider" };
+    const plugins = [
+      createPluginManifestRecord({
+        id: "mutable-view",
+        origin: "global",
+        providerAuthAliases: aliases,
+      }),
+    ];
+    const metadataSnapshot = { plugins };
+    expect(resolveProviderIdForAuth("fixture", { metadataSnapshot })).toBe("first-provider");
+    aliases.fixture = "second-provider";
+    expect(resolveProviderIdForAuth("fixture", { metadataSnapshot })).toBe("second-provider");
+    plugins.push(
+      createPluginManifestRecord({
+        id: "added-view",
+        origin: "bundled",
+        providerAuthAliases: { added: "added-provider" },
+      }),
+    );
+    expect(resolveProviderIdForAuth("added", { metadataSnapshot })).toBe("added-provider");
+  });
+
+  it("retains alias ownership through worker cloning, projection and metadata replacement", async () => {
+    const { metadata, snapshot } = await prepareAliasSnapshot([
+      createPluginManifestRecord({
+        id: "first",
+        origin: "bundled",
+        providerAuthAliases: { fixture: "first-provider" },
+      }),
+      createPluginManifestRecord({
+        id: "second",
+        origin: "bundled",
+        providerAuthAliases: { second: "second-provider" },
+      }),
+    ]);
+    const { normalizePluginId: _normalizePluginId, ...serialized } = snapshot;
+    const restored = metadata.restorePluginMetadataSnapshot(structuredClone(serialized));
+    expect(resolveProviderAuthAliasMap({ metadataSnapshot: restored })).toEqual({
+      fixture: "first-provider",
+      second: "second-provider",
+    });
+    const projected = metadata.projectPluginMetadataSnapshot(restored, ["second"]);
+    expect(resolveProviderIdForAuth("fixture", { metadataSnapshot: projected })).toBe("fixture");
+    expect(resolveProviderIdForAuth("second", { metadataSnapshot: projected })).toBe(
+      "second-provider",
+    );
+    const replacement = metadata.rebasePluginMetadataSnapshotManifestRegistry(restored, {
+      plugins: [
+        createPluginManifestRecord({
+          id: "first",
+          origin: "bundled",
+          providerAuthAliases: { fixture: "replacement-provider" },
+        }),
+      ],
+      diagnostics: [],
+    });
+    expect(resolveProviderIdForAuth("fixture", { metadataSnapshot: replacement })).toBe(
+      "replacement-provider",
+    );
+    expect(resolveProviderIdForAuth("fixture", { metadataSnapshot: restored })).toBe(
+      "first-provider",
+    );
   });
 
   it("does not reuse implicit auth aliases across fresh operation owners", () => {

--- a/src/agents/provider-auth-aliases.ts
+++ b/src/agents/provider-auth-aliases.ts
@@ -12,9 +12,12 @@ import {
   isWorkspacePluginAllowedByConfig,
   normalizePluginConfigId,
 } from "../plugins/plugin-config-trust.js";
+import { buildPluginMetadataProviderAuthAliases } from "../plugins/plugin-metadata-provider-facts.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
-import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
-import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
+import type {
+  PluginMetadataSnapshot,
+  PluginProviderAuthAliasCandidate,
+} from "../plugins/plugin-metadata-snapshot.types.js";
 
 /** Inputs that control plugin metadata and trust scope for auth alias lookup. */
 export type ProviderAuthAliasLookupParams = {
@@ -22,38 +25,10 @@ export type ProviderAuthAliasLookupParams = {
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
   includeUntrustedWorkspacePlugins?: boolean;
-  metadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins">;
+  metadataSnapshot?: Pick<PluginMetadataSnapshot, "plugins"> & {
+    owners?: Pick<PluginMetadataSnapshot["owners"], "providerAuthAliases">;
+  };
 };
-
-type ProviderAuthAliasCandidate = {
-  origin?: PluginOrigin;
-  target: string;
-};
-
-const PROVIDER_AUTH_ALIAS_ORIGIN_PRIORITY: Readonly<Record<PluginOrigin, number>> = {
-  config: 0,
-  bundled: 1,
-  global: 2,
-  workspace: 3,
-};
-function resolveProviderAuthAliasOriginPriority(origin: PluginOrigin | undefined): number {
-  if (!origin) {
-    return Number.MAX_SAFE_INTEGER;
-  }
-  return PROVIDER_AUTH_ALIAS_ORIGIN_PRIORITY[origin] ?? Number.MAX_SAFE_INTEGER;
-}
-
-function isWorkspacePluginTrustedForAuthAliases(
-  plugin: PluginManifestRecord,
-  config: OpenClawConfig | undefined,
-): boolean {
-  return isWorkspacePluginAllowedByConfig({
-    config,
-    isImplicitlyAllowed: (pluginId) =>
-      normalizePluginConfigId(config?.plugins?.slots?.contextEngine) === pluginId,
-    plugin,
-  });
-}
 
 function shouldUsePluginAuthAliases(
   plugin: PluginManifestRecord,
@@ -62,100 +37,62 @@ function shouldUsePluginAuthAliases(
   if (plugin.origin !== "workspace" || params?.includeUntrustedWorkspacePlugins === true) {
     return true;
   }
-  return isWorkspacePluginTrustedForAuthAliases(plugin, params?.config);
+  return isWorkspacePluginAllowedByConfig({
+    config: params?.config,
+    isImplicitlyAllowed: (pluginId) =>
+      normalizePluginConfigId(params?.config?.plugins?.slots?.contextEngine) === pluginId,
+    plugin,
+  });
 }
 
-function setPreferredAlias(params: {
-  aliases: Map<string, ProviderAuthAliasCandidate>;
-  alias: string;
-  origin?: PluginOrigin;
-  target: string;
-}) {
-  const normalizedAlias = normalizeProviderId(params.alias);
-  const normalizedTarget = normalizeProviderId(params.target);
-  if (!normalizedAlias || !normalizedTarget) {
-    return;
-  }
-  const existing = params.aliases.get(normalizedAlias);
-  if (
-    !existing ||
-    resolveProviderAuthAliasOriginPriority(params.origin) <
-      resolveProviderAuthAliasOriginPriority(existing.origin)
-  ) {
-    params.aliases.set(normalizedAlias, {
-      origin: params.origin,
-      target: normalizedTarget,
-    });
-  }
+function resolveProviderAuthAliasCandidates(
+  params?: ProviderAuthAliasLookupParams,
+): ReadonlyMap<string, readonly PluginProviderAuthAliasCandidate[]> {
+  const config = params?.config;
+  const context = { env: params?.env ?? process.env, workspaceDir: params?.workspaceDir };
+  const lookup = { ...context, allowWorkspaceScopedSnapshot: true };
+  const snapshot =
+    params?.metadataSnapshot ??
+    getCurrentPluginMetadataSnapshot({
+      ...lookup,
+      config,
+      requireDefaultDiscoveryContext: !config,
+    }) ??
+    (config && normalizePluginsConfig(config.plugins).loadPaths.length === 0
+      ? getCurrentPluginMetadataSnapshot({ ...lookup, requireDefaultDiscoveryContext: true })
+      : undefined) ??
+    loadPluginMetadataSnapshot({ ...context, config: config ?? {} });
+  return (
+    snapshot.owners?.providerAuthAliases ?? buildPluginMetadataProviderAuthAliases(snapshot.plugins)
+  );
 }
 
 /** Resolve canonical auth provider aliases from plugin metadata. */
 export function resolveProviderAuthAliasMap(
   params?: ProviderAuthAliasLookupParams,
 ): Record<string, string> {
-  const env = params?.env ?? process.env;
-  const config = params?.config;
-  const snapshot =
-    params?.metadataSnapshot ??
-    (config
-      ? getCurrentPluginMetadataSnapshot({
-          config,
-          ...(params?.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
-          env,
-          allowWorkspaceScopedSnapshot: true,
-        })
-      : getCurrentPluginMetadataSnapshot({
-          ...(params?.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
-          env,
-          allowWorkspaceScopedSnapshot: true,
-          requireDefaultDiscoveryContext: true,
-        })) ??
-    (() => {
-      if (!config || normalizePluginsConfig(config.plugins).loadPaths.length !== 0) {
-        return undefined;
+  const allowedPlugins = new Map<PluginManifestRecord, boolean>();
+  const selected: Array<{ alias: string; target: string; order: number }> = [];
+  for (const [alias, candidates] of resolveProviderAuthAliasCandidates(params)) {
+    let preferred: PluginProviderAuthAliasCandidate | undefined;
+    let order = Infinity;
+    for (const candidate of candidates) {
+      const { plugin } = candidate;
+      const allowed = allowedPlugins.get(plugin) ?? shouldUsePluginAuthAliases(plugin, params);
+      allowedPlugins.set(plugin, allowed);
+      if (allowed) {
+        preferred ??= candidate;
+        order = Math.min(order, candidate.order);
       }
-      const currentSnapshot = getCurrentPluginMetadataSnapshot({
-        ...(params?.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
-        env,
-        allowWorkspaceScopedSnapshot: true,
-        requireDefaultDiscoveryContext: true,
-      });
-      return currentSnapshot;
-    })() ??
-    loadPluginMetadataSnapshot({
-      config: config ?? {},
-      ...(params?.workspaceDir !== undefined ? { workspaceDir: params.workspaceDir } : {}),
-      env,
-    });
-  const preferredAliases = new Map<string, ProviderAuthAliasCandidate>();
-  const aliases: Record<string, string> = Object.create(null) as Record<string, string>;
-  for (const plugin of snapshot.plugins) {
-    if (!shouldUsePluginAuthAliases(plugin, params)) {
-      continue;
     }
-    for (const [alias, target] of Object.entries(plugin.providerAuthAliases ?? {}).toSorted(
-      ([left], [right]) => left.localeCompare(right),
-    )) {
-      setPreferredAlias({
-        aliases: preferredAliases,
-        alias,
-        origin: plugin.origin,
-        target,
-      });
-    }
-    for (const choice of plugin.providerAuthChoices ?? []) {
-      for (const deprecatedChoiceId of choice.deprecatedChoiceIds ?? []) {
-        setPreferredAlias({
-          aliases: preferredAliases,
-          alias: deprecatedChoiceId,
-          origin: plugin.origin,
-          target: choice.provider,
-        });
-      }
+    if (preferred) {
+      selected.push({ alias, target: preferred.target, order });
     }
   }
-  for (const [alias, candidate] of preferredAliases) {
-    aliases[alias] = candidate.target;
+  const aliases: Record<string, string> = Object.create(null) as Record<string, string>;
+  // A later winning owner must not move a key inserted by an earlier eligible owner.
+  for (const { alias, target } of selected.toSorted((left, right) => left.order - right.order)) {
+    aliases[alias] = target;
   }
   return aliases;
 }
@@ -169,5 +106,10 @@ export function resolveProviderIdForAuth(
   if (!normalized) {
     return normalized;
   }
-  return resolveProviderAuthAliasMap(params)[normalized] ?? normalized;
+  const candidates = resolveProviderAuthAliasCandidates(params).get(normalized);
+  // Package facts are stable; workspace trust follows the current call's config.
+  return (
+    candidates?.find((candidate) => shouldUsePluginAuthAliases(candidate.plugin, params))?.target ??
+    normalized
+  );
 }

--- a/src/agents/test-helpers/provider-failover-generation.ts
+++ b/src/agents/test-helpers/provider-failover-generation.ts
@@ -17,7 +17,6 @@ export function withPreparedFailoverProviders<T>(providerIds: string[], run: () 
   }
   return withPluginRuntimeGenerationScope(
     {
-      config: {},
       metadataSnapshot: createPluginMetadataSnapshot({
         manifestRegistry: makeRegistry(
           providerIds.map((id) => ({ id, channels: [], providers: [id] })),

--- a/src/plugins/current-plugin-metadata-snapshot.test.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { normalizeConfiguredProviderCatalogModelId } from "@openclaw/model-catalog-core/provider-model-id-normalization";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   getCurrentPluginMetadataSnapshot,
   installTemporaryCurrentPluginMetadataSnapshot,
@@ -14,9 +14,10 @@ import {
 import { clearCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-state.js";
 import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata.test-support.js";
 import { getGlobalHookRunnerRegistry } from "./hook-runner-global-state.js";
-import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
+import * as installedPluginIndexPolicy from "./installed-plugin-index-policy.js";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store-write.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
+import * as pluginControlPlaneContext from "./plugin-control-plane-context.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import { classifyProviderFailoverSignalWithPlugin } from "./provider-failover.js";
@@ -28,7 +29,7 @@ import { withPluginRuntimeGenerationScope } from "./runtime/generation-scope.js"
 
 function createSnapshot(
   params: {
-    config?: Parameters<typeof resolveInstalledPluginIndexPolicyHash>[0];
+    config?: Parameters<typeof installedPluginIndexPolicy.resolveInstalledPluginIndexPolicyHash>[0];
     pluginIds?: readonly string[];
     normalizationAlias?: string;
     registrySource?: PluginMetadataSnapshot["registrySource"];
@@ -63,14 +64,14 @@ function createSnapshot(
     hostContractVersion: "test",
     compatRegistryVersion: "test",
     migrationVersion: 1,
-    policyHash: resolveInstalledPluginIndexPolicyHash(params.config),
+    policyHash: installedPluginIndexPolicy.resolveInstalledPluginIndexPolicyHash(params.config),
     generatedAtMs: 1,
     installRecords: {},
     plugins: [],
     diagnostics: [],
   };
   return {
-    policyHash: resolveInstalledPluginIndexPolicyHash(params.config),
+    policyHash: installedPluginIndexPolicy.resolveInstalledPluginIndexPolicyHash(params.config),
     ...(params.pluginIds !== undefined ? { pluginIds: params.pluginIds } : {}),
     ...(params.registrySource ? { registrySource: params.registrySource } : {}),
     ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
@@ -179,9 +180,16 @@ describe("current plugin metadata snapshot", () => {
     const pluginRegistry = createEmptyPluginRegistry();
     setCurrentPluginMetadataSnapshot(undefined);
 
-    await withPluginRuntimeGenerationScope(
-      { config, metadataSnapshot, pluginRegistry },
-      async () => {
+    const controlPlaneFingerprint = vi.spyOn(
+      pluginControlPlaneContext,
+      "resolvePluginControlPlaneFingerprint",
+    );
+    const policyHash = vi.spyOn(
+      installedPluginIndexPolicy,
+      "resolveInstalledPluginIndexPolicyHash",
+    );
+    try {
+      await withPluginRuntimeGenerationScope({ metadataSnapshot, pluginRegistry }, async () => {
         await Promise.resolve();
         expect(getCurrentPluginMetadataSnapshot({ config, workspaceDir: agentWorkspaceDir })).toBe(
           metadataSnapshot,
@@ -197,14 +205,19 @@ describe("current plugin metadata snapshot", () => {
         ).toBe(metadataSnapshot);
         expect(isCurrentPluginMetadataSnapshotRuntimeGeneration(metadataSnapshot)).toBe(true);
         expect(getPluginRuntimeGatewayRequestScope()?.pluginRegistry).toBe(pluginRegistry);
-      },
-    );
+      });
 
-    expect(isCurrentPluginMetadataSnapshotRuntimeGeneration(metadataSnapshot)).toBe(false);
-    expect(
-      getCurrentPluginMetadataSnapshot({ config, workspaceDir: agentWorkspaceDir }),
-    ).toBeUndefined();
-    expect(getPluginRuntimeGatewayRequestScope()).toBeUndefined();
+      expect(isCurrentPluginMetadataSnapshotRuntimeGeneration(metadataSnapshot)).toBe(false);
+      expect(
+        getCurrentPluginMetadataSnapshot({ config, workspaceDir: agentWorkspaceDir }),
+      ).toBeUndefined();
+      expect(getPluginRuntimeGatewayRequestScope()).toBeUndefined();
+      expect(controlPlaneFingerprint).not.toHaveBeenCalled();
+      expect(policyHash).not.toHaveBeenCalled();
+    } finally {
+      controlPlaneFingerprint.mockRestore();
+      policyHash.mockRestore();
+    }
   });
 
   it("isolates a registry-less nested generation and restores the outer generation on rejection", async () => {
@@ -235,7 +248,6 @@ describe("current plugin metadata snapshot", () => {
     try {
       await withPluginRuntimeGenerationScope(
         {
-          config: outerConfig,
           metadataSnapshot: outerSnapshot,
           pluginRegistry: outerRegistry,
         },
@@ -243,7 +255,6 @@ describe("current plugin metadata snapshot", () => {
           await expect(
             withPluginRuntimeGenerationScope(
               {
-                config: innerConfig,
                 metadataSnapshot: innerSnapshot,
               },
               async () => {
@@ -445,7 +456,7 @@ describe("current plugin metadata snapshot", () => {
     const workspaceDir = "/workspace";
     const snapshot = createSnapshot({ config: sourceConfig, workspaceDir });
 
-    withPluginRuntimeGenerationScope({ config: runtimeConfig, metadataSnapshot: snapshot }, () => {
+    withPluginRuntimeGenerationScope({ metadataSnapshot: snapshot }, () => {
       expect(getCurrentPluginMetadataSnapshot({ config: runtimeConfig, workspaceDir })).toBe(
         snapshot,
       );

--- a/src/plugins/plugin-metadata-provider-facts.ts
+++ b/src/plugins/plugin-metadata-provider-facts.ts
@@ -1,3 +1,4 @@
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -10,6 +11,8 @@ import type {
   PluginManifestProviderRequestProvider,
 } from "./manifest.js";
 import { listOfficialExternalProviderEndpointManifests } from "./official-external-provider-endpoints.js";
+import type { PluginProviderAuthAliasCandidate } from "./plugin-metadata-snapshot.types.js";
+import type { PluginOrigin } from "./plugin-origin.types.js";
 
 const PROVIDER_ENDPOINT_CLASSES = new Set(
   "anthropic-public cerebras-native chutes-native deepseek-native github-copilot-native groq-native meta-native mistral-public minimax-native moonshot-native modelstudio-native nvidia-native openai-public openai opencode-native azure-openai openrouter xai-native xiaomi-native zai-native google-generative-ai google-vertex".split(
@@ -69,6 +72,47 @@ function prepareProviderEndpoints(value: unknown): PluginManifestProviderEndpoin
     });
 }
 
+const PROVIDER_AUTH_ALIAS_ORIGIN_PRIORITY: Readonly<Record<PluginOrigin, number>> = {
+  config: 0,
+  bundled: 1,
+  global: 2,
+  workspace: 3,
+};
+
+/** Prepares package alias candidates without capturing current workspace trust. */
+export function buildPluginMetadataProviderAuthAliases(plugins: readonly PluginManifestRecord[]) {
+  const aliases = new Map<string, PluginProviderAuthAliasCandidate[]>();
+  let order = 0;
+  for (const plugin of plugins) {
+    const entries = [
+      ...Object.entries(plugin.providerAuthAliases ?? {}).toSorted(([left], [right]) =>
+        left.localeCompare(right),
+      ),
+      ...(plugin.providerAuthChoices ?? []).flatMap((choice) =>
+        (choice.deprecatedChoiceIds ?? []).map((alias) => [alias, choice.provider] as const),
+      ),
+    ];
+    for (const [rawAlias, rawTarget] of entries) {
+      const alias = normalizeProviderId(rawAlias);
+      const target = normalizeProviderId(rawTarget);
+      if (!alias || !target) {
+        continue;
+      }
+      const candidates = aliases.get(alias) ?? [];
+      candidates.push({ plugin, target, order: order++ });
+      aliases.set(alias, candidates);
+    }
+  }
+  for (const candidates of aliases.values()) {
+    candidates.sort(
+      (left, right) =>
+        (PROVIDER_AUTH_ALIAS_ORIGIN_PRIORITY[left.plugin.origin] ?? Number.MAX_SAFE_INTEGER) -
+        (PROVIDER_AUTH_ALIAS_ORIGIN_PRIORITY[right.plugin.origin] ?? Number.MAX_SAFE_INTEGER),
+    );
+  }
+  return aliases;
+}
+
 export function buildPluginMetadataProviderFacts(plugins: readonly PluginManifestRecord[]) {
   const providerEndpoints = plugins.flatMap((plugin) =>
     prepareProviderEndpoints(plugin.providerEndpoints),
@@ -105,5 +149,9 @@ export function buildPluginMetadataProviderFacts(plugins: readonly PluginManifes
   for (const manifest of listOfficialExternalProviderEndpointManifests()) {
     providerEndpoints.push(...prepareProviderEndpoints(manifest.providerEndpoints));
   }
-  return { providerEndpoints, providerRequests };
+  return {
+    providerEndpoints,
+    providerRequests,
+    providerAuthAliases: buildPluginMetadataProviderAuthAliases(plugins),
+  };
 }

--- a/src/plugins/plugin-metadata-snapshot.types.ts
+++ b/src/plugins/plugin-metadata-snapshot.types.ts
@@ -17,6 +17,13 @@ export type PluginMetadataSnapshotPluginIdScope = {
   resolve: (params: { index: InstalledPluginIndex }) => readonly string[] | undefined;
 };
 
+export type PluginProviderAuthAliasCandidate = {
+  plugin: PluginManifestRecord;
+  target: string;
+  /** First eligible declaration owns public map order, even if a later candidate wins. */
+  order: number;
+};
+
 export type PluginMetadataSnapshotOwnerMaps = {
   channels: ReadonlyMap<string, readonly string[]>;
   channelConfigs: ReadonlyMap<string, readonly string[]>;
@@ -26,6 +33,7 @@ export type PluginMetadataSnapshotOwnerMaps = {
   setupProviders: ReadonlyMap<string, readonly string[]>;
   commandAliases: ReadonlyMap<string, readonly string[]>;
   contracts: ReadonlyMap<string, readonly string[]>;
+  providerAuthAliases?: ReadonlyMap<string, readonly PluginProviderAuthAliasCandidate[]>;
   providerEndpoints?: readonly PluginManifestProviderEndpoint[];
   providerRequests?: ReadonlyMap<string, PluginManifestProviderRequestProvider>;
 };

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -1790,7 +1790,7 @@ describe("provider-runtime", () => {
         config,
         manifestRegistry: { plugins: [], diagnostics: [] },
       });
-      withPluginRuntimeGenerationScope({ config, metadataSnapshot }, () => {
+      withPluginRuntimeGenerationScope({ metadataSnapshot }, () => {
         expect(
           classifyProviderFailoverSignalWithPlugin({
             provider,

--- a/src/plugins/runtime/generation-scope.ts
+++ b/src/plugins/runtime/generation-scope.ts
@@ -1,5 +1,4 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import { withPluginMetadataSnapshotScope } from "../current-plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugin-metadata-snapshot.types.js";
@@ -18,7 +17,6 @@ const pluginRuntimeGenerationRegistryScope = resolveGlobalSingleton<
 /** Carries one prepared plugin generation through all nested runtime lookups. */
 export function withPluginRuntimeGenerationScope<T>(
   generation: {
-    config: OpenClawConfig;
     metadataSnapshot: PluginMetadataSnapshot;
     pluginRegistry?: PluginRegistry;
   },
@@ -31,13 +29,8 @@ export function withPluginRuntimeGenerationScope<T>(
       pluginRuntimeGenerationRegistryScope.run(pluginRegistry, () =>
         withPluginRuntimeRegistryScope(pluginRegistry, run),
       ),
-    {
-      config: generation.config,
-      trustConfigIdentity: true,
-      ...(generation.metadataSnapshot.workspaceDir
-        ? { workspaceDir: generation.metadataSnapshot.workspaceDir }
-        : {}),
-    },
+    // The prepared generation already owns discovery and policy compatibility.
+    { trustConfigIdentity: true },
   );
 }
 


### PR DESCRIPTION
Related: #133903

## What Problem This Solves

Concurrent Gateway turns repeatedly rebuild provider auth aliases, plugin ID normalization and discovery fingerprints even when their prepared plugin generation already contains those package facts. This consumes event-loop time that could serve chat history and control-plane requests.

## Why This Change Was Made

The existing immutable metadata snapshot now owns normalized auth-alias candidates. Scalar lookups select the requested alias directly; full-map callers retain declaration order and origin precedence. Current workspace trust is evaluated on every lookup, credentials are not cached, and callers supplying a mutable partial manifest view still get a fresh projection.

Prepared runtime scopes carry their existing metadata and registry without repeating discovery/policy hashing. Memory selection reuses the snapshot's plugin ID normalizer while applying current activation config. The runtime load-context owner already supplies install records, so its duplicate projection is removed. Snapshot projection, replacement and worker restoration share these facts through the existing lifecycle; no global memoization or new configuration, persistence, protocol or dependency surface is added.

Production: **148 added / 161 removed, net −13**. Tests/support: **334 added / 42 removed, net +292**. Documentation: **+5**. This is an internal performance refactor; release changelog is unchanged.

## User Impact

Gateway turns do less repeated metadata work while retaining current trust, activation and runtime authority. This is a measured improvement to one owner boundary, not a claim that every saturation source is fixed. Restart and explicit metadata-management behavior are unchanged.

## Evidence

Validated source was committed unchanged as `295f2adfc1a5757246817e7c7ebe0e3987ca5308`; the build/profile manifests pin its exact source afterimages.

- Three regressions fail on the original owners: repeated auth lookup enumerates an unrelated alias dictionary 24 times, memory selection rebuilds manifest normalization three times, and prepared scope entry recomputes a discovery fingerprint. All pass after the refactor. Behavior coverage includes alias precedence/order, prototype keys, caller mutation isolation, changing workspace trust, enable/disable transitions, nested scopes, projected/replaced/retained snapshots and worker restoration.
- The focused owner/sibling set passes **296 tests across 11 files**; the final equivalent lint expressions also pass the 15 alias tests. The canonical changed-code gate and full source/UI build pass on base `ace8a13f19ccc2805b3d458026de3ab4bbbd8878`. A Codex review of the final patch is scoped-clean at its configured P0 threshold. An earlier unchanged Gateway test typing failure was resolved by adopting the separately landed canonical #134207, not by weakening a gate.
- Synthetic lookup benchmark, 64 plugins / 512 aliases, five samples: median for 2,000 scalar lookups **120.807 → 0.142 ms**; 100 complete maps **6.656 → 4.409 ms**. Setup is excluded and outputs are checked. These are operation-cost measurements, not predicted Gateway speedups.
- Both clean baseline and candidate use the full build, separately isolated HOME/state and owned loopback ports. The workload is identical: 32 turns, 48 seed sessions, 128 updates over four clients, three history clients with bursts of five, six subscribers, visible observer, 100 ms cadence and 1,000 ms mock stream delay. The original **2,000 ms control/handshake budgets are unchanged**. Standard and browser/CPU runs pass; original operation-failure counters and metadata rescans are zero.

| Browser/CPU run, milliseconds | Clean baseline | Candidate |
| --- | ---: | ---: |
| sessions.list maximum | 392.4 | 396.3 |
| history p99 / maximum | 484.4 / 485.8 | 444.5 / 505.5 |
| Control UI HTTP maximum | 453.4 | 429.9 |
| readyz maximum | 279.5 | 121.8 |
| Fresh handshake | 107.1 | 108.7 |
| Original load duration | 6,552.3 | 6,533.9 |

The complete CPU ancestry shows sampled inclusive auth-provider lookup work of **28.177 → 2.994 ms** during load. Sample weights are estimates, not exact CPU service; timings are a single paired observation with different completed history/browser work. No overall latency or throughput improvement is inferred from this table. ELU still reaches 1, and readiness reports degradation during the burst before both runs recover to two distinct healthy observations about four seconds after load.

The real Control UI renders the complete synthetic reply. Browser observation/closure uses the same frozen adapter on both runs and completes within the unchanged ten-second parent barrier; its separate post-load phase is excluded from original load timing. Source/build pins, request joins and owned-process cleanup pass. An earlier baseline observer stopped before reply proof and remains failed evidence; it was not relabeled as passing. Four separate `tasks.list UNAVAILABLE` responses remain recorded in the passing baseline, outside the original benchmark counters; none are logged in this candidate run, which does not establish a task-list fix.

Follow-ups remain separately scoped: repeated model-ID policy projection, and attribution of task-list fencing during session-label churn. Neither is included here or treated as a proven cause of the original stall.

Synthetic candidate reply after the measured load (the UI itself is unchanged):

![Synthetic Control UI reply under concurrent Gateway load](https://github.com/user-attachments/assets/ca881713-21d1-4701-a1b0-64c0a8f21902)


## Review follow-through

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33416611557) completed successfully at `295f2adfc1a5757246817e7c7ebe0e3987ca5308`. The completed ClawSweeper review found no actionable issue and listed no Rank-up moves. Its automated stored-data warning was checked against the source: the new alias map is built by `buildPluginMetadataProviderFacts`, frozen by the existing metadata-snapshot owner, and transferred/restored with the existing worker snapshot. No database schema, stored row, persistence writer, migration, or embedding/vector format changes.
