### PR TITLE
test: consolidate duplicate Windows runtime import coverage

### DIFF
--- a/src/shared/runtime-import.test.ts
+++ b/src/shared/runtime-import.test.ts
@@ -1,4 +1,3 @@
-// Runtime import tests cover lazy runtime import caching and failure handling.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { toSafeImportPath } from "./import-specifier.js";
 import { importRuntimeModule } from "./runtime-import.js";
@@ -26,17 +25,6 @@ describe("runtime-import", () => {
     expect(toSafeImportPath("\\\\server\\share\\plugin\\index.mjs")).toBe(
       "file://server/share/plugin/index.mjs",
     );
-  });
-
-  it("resolves runtime imports from Windows absolute base paths", async () => {
-    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-
-    expect(
-      await captureRuntimeImportSpecifier(
-        "C:\\Users\\alice\\openclaw\\dist\\subagent-registry.js",
-        ["./subagent-registry.runtime.js"],
-      ),
-    ).toBe("file:///C:/Users/alice/openclaw/dist/subagent-registry.runtime.js");
   });
 
   it("resolves runtime imports from file URL base paths", async () => {
@@ -79,7 +67,7 @@ describe("runtime-import", () => {
       importModule,
     );
 
-    expect(importModule).toHaveBeenCalledWith(
+    expect(importModule.mock.calls[0]?.[0]).toBe(
       "file:///C:/Users/alice/openclaw/dist/subagent-registry.runtime.js",
     );
     expect(result).toEqual({


### PR DESCRIPTION
## What Problem This Solves

The Windows absolute-base-path case repeats the exact import request already exercised by the module-result test. The duplicate adds another invocation without protecting a different path.

## Why This Change Was Made

Move its exact first-importer-call assertion into the existing result test, then remove the duplicate case and a misleading generic header. The retained test now checks both the normalized file URL and the returned module.

## User Impact

Production unchanged. Tests: +1/-13, net -12 lines; six cases become five. File-URL bases, Windows absolute path components, UNC paths and non-Windows imports remain covered. No fixture lifecycle, runtime import behavior or public API changes.

## Evidence

Read the full runtime-import and import-specifier owners, callers, sibling cases, CI routing and available history. The removed case uses the same base, path parts and expected URL as the retained result test. The shared capture helper remains for other input cases; the platform spy still restores after each test.

On pinned main `00d542`, focused before/after proof passes all six original and five retained cases. All 20 changed-file checks pass, including core test types, lint and formatting; fresh scoped Codex review has no accepted findings. Local platform branches use the existing platform spy; actual Windows execution remains part of the required hosted CI.
