### PR TITLE
fix(ci): run build artifact checks when tsdown changes

### DIFF
--- a/scripts/lib/ci-changed-node-test-plan.mts
+++ b/scripts/lib/ci-changed-node-test-plan.mts
@@ -111,7 +111,7 @@ function isTestOnlyPath(changedPath: string) {
 // Built-artifact test inputs below also require this lane even though they do
 // not change the bytes under test.
 const BUILD_INPUT_RE =
-  /^(?:src|extensions|packages)\/|^(?:openclaw\.mjs|package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml)$|^tsconfig[^/]*\.json$|^scripts\/(?:build-[^/]+|runtime-postbuild\.mts|write-plugin-sdk-entry-dts\.ts)$|^scripts\/lib\/(?:copy-assets\.ts|plugin-sdk-entries\.mts)$/u;
+  /^(?:src|extensions|packages)\/|^(?:openclaw\.mjs|package\.json|pnpm-lock\.yaml|pnpm-workspace\.yaml)$|^tsconfig[^/]*\.json$|^scripts\/(?:build-[^/]+|runtime-postbuild\.mts|tsdown-build\.mts|write-plugin-sdk-entry-dts\.ts)$|^scripts\/lib\/(?:copy-assets\.ts|plugin-sdk-entries\.mts)$/u;
 const BUILT_ARTIFACT_TEST_INPUTS = new Set([
   "extensions/browser/chrome-extension/relay-key.test-support.ts",
   "extensions/browser/src/browser/extension-install.native-host.e2e.test.ts",

--- a/test/scripts/ci-changed-node-test-plan.test.ts
+++ b/test/scripts/ci-changed-node-test-plan.test.ts
@@ -219,6 +219,7 @@ describe("CI changed Node test plan", () => {
     // Build-input classification: only sources and the build pipeline can
     // change dist bytes; repo scripts, workflows, and qa scenarios cannot.
     expect(hasBuildArtifactAffectingChange(["scripts/build-all.mts"])).toBe(true);
+    expect(hasBuildArtifactAffectingChange(["scripts/tsdown-build.mts"])).toBe(true);
     expect(hasBuildArtifactAffectingChange(["tsconfig.json"])).toBe(true);
     expect(hasBuildArtifactAffectingChange(["scripts/run-vitest.mjs"])).toBe(false);
     expect(hasBuildArtifactAffectingChange([".github/workflows/ci.yml"])).toBe(false);


### PR DESCRIPTION
<!-- Optional linked context: source-first CI bug; no public issue. -->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where CI could skip the build-artifacts validation lane when a pull request changed the TypeScript bundler implementation directly, allowing a dist or packaging regression to reach later checks without the build-specific validation intended for that change.

## Why This Change Was Made

The changed-path planner now treats `scripts/tsdown-build.mts` as a build-artifact input, matching the existing `build-all` pipeline and its CI build-artifacts consumer. A focused regression assertion preserves the routing contract; no new lane, fallback, or configuration surface is introduced.

## User Impact

Changes to the TypeScript build implementation now select the existing build-artifacts CI lane, so generated runtime and packaging regressions are checked before merge.

## Evidence

- Exact-head production manifest preflight trace (PR head `924995dc621ee05b0afa7d94935336df863c5b8f`) exercised the same changed-path planner and manifest decision used by `.github/workflows/ci.yml`: a tsdown build-runner-only change produced `run_build_artifacts: true`, while the ordinary script control path remained false.

```text
Observed output from the production planner/manifest probe:
{
  "changed_paths": [
    "scripts/tsdown-build.mts"
  ],
  "changed_node_test_shards": "compact-fallback",
  "run_node_full": true,
  "run_build_artifacts": true
}
{
  "control_changed_paths": [
    "scripts/run-vitest.mjs"
  ],
  "control_has_build_impact": false,
  "control_run_build_artifacts": false
}
```

- Focused regression coverage: `node scripts/run-vitest.mjs test/scripts/ci-changed-node-test-plan.test.ts` — 68 tests passed.
- Supporting checks: changed-plan dry-run classified the files as `scripts`, `testRoot`, and `tooling`; targeted formatting/oxlint and `git diff --check` passed.
- The production consumer assigns the planner result to `run_build_artifacts`, and the existing `build-artifacts` job is gated by that manifest output.

Proof boundary: this is CI planning logic. The transcript proves the exact-head routing result and its unchanged control behavior; the existing build-artifacts job remains the dist/packaging proof surface selected by the corrected classification.