### PR TITLE
test(tooling): use value fixtures for mobile release renderers

### DIFF
--- a/test/scripts/android-version.test.ts
+++ b/test/scripts/android-version.test.ts
@@ -208,74 +208,39 @@ describe("gateway version normalization", () => {
 
 describe("renderAndroidVersionProperties", () => {
   it("renders checked-in defaults from the pinned Android version", () => {
-    const rootDir = writeAndroidFixture({
-      version: "2026.6.2",
+    const properties = renderAndroidVersionProperties({
+      canonicalVersion: "2026.6.2",
       versionCode: 2026060201,
     });
-    const version = resolveAndroidVersion(rootDir);
 
-    expect(renderAndroidVersionProperties(version)).toContain(
-      "OPENCLAW_ANDROID_VERSION_NAME=2026.6.2",
-    );
-    expect(renderAndroidVersionProperties(version)).toContain(
-      "OPENCLAW_ANDROID_VERSION_CODE=2026060201",
-    );
+    expect(properties).toContain("OPENCLAW_ANDROID_VERSION_NAME=2026.6.2");
+    expect(properties).toContain("OPENCLAW_ANDROID_VERSION_CODE=2026060201");
   });
 });
 
 describe("renderAndroidReleaseNotes", () => {
   it("extracts exact pinned-version notes before Unreleased notes", () => {
-    const rootDir = writeAndroidFixture({
-      version: "2026.6.2",
-      versionCode: 2026060201,
-      changelog: [
-        "# OpenClaw Android Changelog",
-        "",
-        "## Unreleased",
-        "",
-        "Future Android changes.",
-        "",
-        "## 2026.6.2 - 2026-06-02",
-        "",
-        "Pinned Android release notes.",
-        "",
-      ].join("\n"),
-    });
-    const version = resolveAndroidVersion(rootDir);
-
     expect(
       renderAndroidReleaseNotes(
-        version,
+        { canonicalVersion: "2026.6.2" },
         "# OpenClaw Android Changelog\n\n## Unreleased\n\nFuture Android changes.\n\n## 2026.6.2 - 2026-06-02\n\nPinned Android release notes.\n",
       ),
     ).toBe("Pinned Android release notes.\n");
   });
 
   it("falls back to Unreleased notes while iterating on a release train", () => {
-    const rootDir = writeAndroidFixture({
-      version: "2026.6.2",
-      versionCode: 2026060201,
-    });
-    const version = resolveAndroidVersion(rootDir);
-
     expect(
       renderAndroidReleaseNotes(
-        version,
+        { canonicalVersion: "2026.6.2" },
         "# OpenClaw Android Changelog\n\n## Unreleased\n\nPending Android notes.\n",
       ),
     ).toBe("Pending Android notes.\n");
   });
 
   it("rejects changelogs without exact-version or Unreleased notes", () => {
-    const rootDir = writeAndroidFixture({
-      version: "2026.6.2",
-      versionCode: 2026060201,
-    });
-    const version = resolveAndroidVersion(rootDir);
-
     expect(() =>
       renderAndroidReleaseNotes(
-        version,
+        { canonicalVersion: "2026.6.2" },
         "# OpenClaw Android Changelog\n\n## 2026.6.1\n\nOld notes.\n",
       ),
     ).toThrow("Unable to find Android changelog notes for 2026.6.2");

--- a/test/scripts/ios-version.test.ts
+++ b/test/scripts/ios-version.test.ts
@@ -298,9 +298,11 @@ describe("gateway version normalization", () => {
 
 describe("release note extraction", () => {
   it("requires exact App Store version notes and adds the gateway association", () => {
-    const rootDir = writeIosFixture({
-      packageVersion: "2026.7.2",
-      changelog: `# OpenClaw iOS Changelog
+    const version = resolveIosVersion(".", {
+      appStoreRevision: 1,
+      releaseVersion: "2026.7.2",
+    });
+    const changelog = `# OpenClaw iOS Changelog
 
 ## Unreleased
 
@@ -309,13 +311,7 @@ Draft notes.
 ## 2026.7.21
 
 - App Store revision notes.
-`,
-    });
-    const version = resolveIosVersion(rootDir, {
-      appStoreRevision: 1,
-      releaseVersion: "2026.7.2",
-    });
-    const changelog = fs.readFileSync(path.join(rootDir, "apps", "ios", "CHANGELOG.md"), "utf8");
+`;
 
     expect(renderIosReleaseNotes(version, changelog)).toBe(
       "Gateway version: 2026.7.2\n\n- App Store revision notes.\n",
@@ -323,15 +319,11 @@ Draft notes.
   });
 
   it("does not fall back to gateway or Unreleased notes for App Store revisions", () => {
-    const rootDir = writeIosFixture({
-      packageVersion: "2026.7.2",
-      changelog: "# OpenClaw iOS Changelog\n\n## Unreleased\n\nDraft notes.\n",
-    });
-    const version = resolveIosVersion(rootDir, {
+    const version = resolveIosVersion(".", {
       appStoreRevision: 1,
       releaseVersion: "2026.7.2",
     });
-    const changelog = fs.readFileSync(path.join(rootDir, "apps", "ios", "CHANGELOG.md"), "utf8");
+    const changelog = "# OpenClaw iOS Changelog\n\n## Unreleased\n\nDraft notes.\n";
 
     expect(() => renderIosReleaseNotes(version, changelog)).toThrow(
       "Unable to find iOS changelog notes for 2026.7.21",
@@ -339,9 +331,8 @@ Draft notes.
   });
 
   it("extracts exact pinned version sections first", () => {
-    const rootDir = writeIosFixture({
-      packageVersion: "2026.4.6",
-      changelog: `# OpenClaw iOS Changelog
+    const version = resolveIosVersion(".", { releaseVersion: "2026.4.6" });
+    const changelog = `# OpenClaw iOS Changelog
 
 ## Unreleased
 
@@ -350,31 +341,25 @@ Draft notes.
 ## 2026.4.6
 
 - Exact release notes.
-`,
-    });
-    const version = resolveIosVersion(rootDir);
-    const changelog = fs.readFileSync(path.join(rootDir, "apps", "ios", "CHANGELOG.md"), "utf8");
+`;
 
     expect(renderIosReleaseNotes(version, changelog)).toBe("- Exact release notes.\n");
   });
 
   it("falls back to Unreleased when the release section does not exist yet", () => {
-    const rootDir = writeIosFixture({
-      packageVersion: "2026.4.6",
-      changelog: `# OpenClaw iOS Changelog
+    const version = resolveIosVersion(".", { releaseVersion: "2026.4.6" });
+    const changelog = `# OpenClaw iOS Changelog
 
 ## Unreleased
 
 ### Added
 
 - New iOS feature.
-`,
-    });
-    const version = resolveIosVersion(rootDir);
-    const changelog = fs.readFileSync(path.join(rootDir, "apps", "ios", "CHANGELOG.md"), "utf8");
+`;
+    const notes = renderIosReleaseNotes(version, changelog);
 
-    expect(renderIosReleaseNotes(version, changelog)).toContain("### Added");
-    expect(renderIosReleaseNotes(version, changelog)).toContain("- New iOS feature.");
+    expect(notes).toContain("### Added");
+    expect(notes).toContain("- New iOS feature.");
   });
 
   it("extracts markdown bodies without the version heading", () => {


### PR DESCRIPTION
## What Problem This Solves

Eight Android and iOS renderer cases build temporary filesystem fixtures merely to supply known version values and changelog text. Some then reread text they just wrote or render the same output twice.

## Why This Change Was Made

Pass Android's existing minimal value inputs directly. Resolve explicit iOS versions through its existing no-I/O path, retaining the real App Store revision encoder. Keep changelog text in memory and reuse each rendered result for its assertions.

## User Impact

Removes eight temporary directory roots, 28 file writes, 12 recursive directory creations, ten input reads and two duplicate render calls. File-backed resolution, real CLI execution, version pinning and artifact-write integration coverage remain. Production +0/-0; tests +24/-74. No elapsed-time speedup is claimed.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/android-version.test.ts test/scripts/ios-version.test.ts test/scripts/android-pin-version.test.ts test/scripts/release-version.test.ts` passed all 59 tests before and after.
- Full changed-file checks, formatting, diff checks and structured Codex autoreview passed.
- Reviewed complete renderer/resolver modules, CLI and release callers, sibling file-writing tests and release-note/revision history. Exact-note priority, Unreleased behavior, revision-only note matching and gateway association assertions are unchanged.
