### PR TITLE
perf(ci): use runtime-only builds for Node test prerequisites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3042,17 +3042,16 @@ jobs:
           sparse-checkout-cone-mode: false
           persist-credentials: false
 
-      # A few real-CLI E2E tests need a current dist tree. Build it before
-      # Vitest starts so the shard's worker processes cannot consume the
-      # cgroup memory that the build admission check must reserve. Reuse the
-      # CI artifact profile: these runtime readers do not need global declarations.
+      # Build the CLI runtime before Vitest workers consume memory or import dist.
+      # qaRuntime supplies the shared JavaScript, assets, and freshness stamps;
+      # build-artifacts owns SDK declaration and Control UI validation.
       - name: Build Node test runtime
         if: matrix.pretest_build_mode != null
         env:
           NODE_OPTIONS: --max-old-space-size=8192
           OPENCLAW_BUILD_PRIVATE_QA: ${{ matrix.pretest_build_mode == 'private-qa' && '1' || '0' }}
           VITEST: "1"
-        run: pnpm build:ci-artifacts
+        run: pnpm build qaRuntime
 
       - name: Install ripgrep for native grep tests
         if: matrix.requires_ripgrep == true && runner.os == 'Linux'

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -97,11 +97,11 @@ Use `pnpm ci:timings`, `pnpm ci:timings:recent`, or `node scripts/ci-run-timings
 
 Run the timing helper locally; there is no in-workflow timing-summary job (a permanently disabled one was removed once the local helper became the tool everyone actually used). For build timing, check the `build-artifacts` job's `Build dist` step: `pnpm build:ci-artifacts` prints `[build-all] phase timings:` and includes `ui:build`; the job also uploads the `startup-memory` artifact.
 
-Node test shards that need a built CLI use the same `build:ci-artifacts` profile
-before starting Vitest. It builds the runtime, Control UI, and scoped plugin SDK
-declarations without repeating global declaration emission in each shard.
-Private QA shards retain their private runtime build selection. Release package
-builds still generate the full declarations.
+Node test shards that need a built CLI run `pnpm build qaRuntime` before starting
+Vitest. This profile builds runtime JavaScript, plugin assets, and freshness and
+provenance metadata. Private QA shards select their private runtime entries. The
+`build-artifacts` job owns Control UI and SDK declaration validation; release
+package builds still generate the full declarations.
 
 Local `pnpm build:ci-artifacts` uses the same memory admission as full and package
 builds. The orchestrator passes the resolved heap budget to every child process,

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -9499,7 +9499,7 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
         OPENCLAW_BUILD_PRIVATE_QA: "${{ matrix.pretest_build_mode == 'private-qa' && '1' || '0' }}",
         VITEST: "1",
       },
-      run: "pnpm build:ci-artifacts",
+      run: "pnpm build qaRuntime",
     });
     expect(installRipgrepStep).toMatchObject({
       if: "matrix.requires_ripgrep == true && runner.os == 'Linux'",


### PR DESCRIPTION
Node test shards currently rebuild plugin SDK declarations and Control UI before running tests that consume only the compiled CLI runtime. In the retained native run, SDK declarations alone consumed 149.4 seconds of a 236.1-second pretest build.

Use the existing `qaRuntime` build profile for these prerequisites. It keeps runtime JavaScript, plugin assets, private QA entry selection, build provenance, freshness stamps, and the build-before-workers ordering. The separate `build-artifacts` job continues to own SDK declaration and Control UI validation. Release/package builds are unchanged. No jobs, runners, configuration options, concurrency caps, timeouts, or tests are removed.

Validation: all 75 existing build-profile tests plus the changed workflow guard pass; the guard was observed failing before the command change. The full changed-file gate, canonical workflow checks, and scoped Codex review pass. Parsed-workflow comparison changes only the pretest command. Two cold local exact-head builds completed in 53.46 seconds (ordinary) and 47.41 seconds (private QA), starting with no dist trees. All five registered consumer files / 12 cases passed through their normal configs without a runtime rebuild. Both builds retained exact-head build-info and freshness stamps; runtime-postbuild owns provenance publication. Native CI/Testbox results remain required before landing; these local times are not directly comparable to the retained hosted baseline.

Runtime production LOC: 0. Workflow: 4 added / 5 removed. Documentation: 5 / 5. Existing test assertion: 1 / 1.
