### PR TITLE
fix(agents): stop fallback chain from cycling on active session turn claim

### DIFF
--- a/src/agents/failover-error.test.ts
+++ b/src/agents/failover-error.test.ts
@@ -870,6 +870,11 @@ describe("failover-error", () => {
         "WorkerWorkspaceReconciliationError",
         "cloud worker workspace result could not be reconciled",
       ],
+      [
+        "active turn claim",
+        "ActiveTurnClaimError",
+        "Session 4ecf5e11-9e20-432b-82a6-5cf1f878b278 already has an active turn claim",
+      ],
     ])("returns true for direct and nested runner %s failures", (_label, name, message) => {
       const coordination = new Error(message);
       coordination.name = name;

--- a/src/agents/failover-error.ts
+++ b/src/agents/failover-error.ts
@@ -44,6 +44,9 @@ const RUNTIME_COORDINATION_ERROR_NAMES = new Set([
   "WorkerRunnerUnavailableError",
   "WorkerRunnerCapacityError",
   "WorkerWorkspaceReconciliationError",
+  // Session-lane admission failure thrown before any provider attempt; no
+  // model choice can clear a busy turn claim, so fallback must abort (#134187).
+  "ActiveTurnClaimError",
 ]);
 
 function resolveNestedErrors(candidate: Record<string, unknown>): unknown[] {

--- a/src/agents/model-fallback.test.ts
+++ b/src/agents/model-fallback.test.ts
@@ -2335,6 +2335,28 @@ describe("runWithModelFallback", () => {
           }),
         }),
     ],
+    [
+      "active turn claim",
+      () =>
+        Object.assign(
+          new Error(
+            "Session 4ecf5e11-9e20-432b-82a6-5cf1f878b278 already has an active turn claim",
+          ),
+          { name: "ActiveTurnClaimError" },
+        ),
+    ],
+    [
+      "wrapped active turn claim",
+      () =>
+        new Error("worker turn failed", {
+          cause: Object.assign(
+            new Error(
+              "Session 4ecf5e11-9e20-432b-82a6-5cf1f878b278 already has an active turn claim",
+            ),
+            { name: "ActiveTurnClaimError" },
+          ),
+        }),
+    ],
   ])("aborts fallback on %s worker coordination failures", async (_label, makeError) => {
     const error = makeError();
     const run = vi.fn().mockRejectedValueOnce(error).mockResolvedValueOnce("too late");


### PR DESCRIPTION
> **AI-assisted: yes**

Closes #134187

## What Problem This Solves

Fixes an issue where a run blocked by a busy session turn claim (`ActiveTurnClaimError`) would walk the entire configured model fallback chain. The session lane being busy is a local admission condition — no model choice can change it — yet the fallback engine classified it as an unknown candidate failure, re-attempting the same doomed turn admission once per candidate. One blocked attempt emitted N `candidate_failed` decisions and N paired `lane task error` diagnostics (N = configured candidates; the reporter saw 6), recorded spurious failure accounting against every configured provider, and wasted wall-clock re-resolving routes that were guaranteed to fail.

- **Related:** #134186 (companion announce retry-loop issue that amplifies the log volume; separate fix). ClawSweeper review on this issue confirmed the shape: extend the shared local-coordination classifier so one blocked session consumes no fallback candidates.

## Why This Change Was Made

`ActiveTurnClaimError` is thrown by gateway turn-claim admission before any provider attempt starts and carries a distinct `name`. The shared failover classifier (`resolveModelFallbackError`) matches local coordination errors by error name, but the runtime coordination name set did not include it, so the error fell through to the unknown branch and the fallback runner continued to the next candidate. Adding the name to the coordination set makes the runner abort immediately and hand the error back to the caller's own retry/queue policy — matching the established treatment of `GatewayDrainingError`, `WorkerRunnerCapacityError`, and the other admission errors.

- **Intended outcome:** a run whose turn admission throws `ActiveTurnClaimError` aborts the fallback chain on the first attempt: one attempt, one error surfaced to the caller, no `candidate_failed` events, no provider failure attribution.
- **Out of scope:** message-text matching for unnamed admission errors ("placement changed during turn admission", "turn rejected for session …"), the companion announce retry loop (#134186), and retry/backoff policy changes.
- **Highest-risk area:** the classification change affects every code path that asks whether an error is a local coordination failure.
- **How is that risk mitigated?** the match is by exact error name, reuses the existing proven mechanism for the four established coordination errors, and regression tests cover both the direct error and a cause-wrapped form through the real fallback runner.

## User Impact

Busy-session runs now fail fast with the original admission error instead of burning through every configured fallback candidate. Operators stop seeing N identical `candidate_failed`/`lane task error` lines per blocked attempt, and providers no longer accumulate failure marks for a condition unrelated to them.

- **Success criteria:** `runWithModelFallback` with a candidate that throws `ActiveTurnClaimError` invokes the candidate exactly once, rejects with the original error, and emits no `candidate_failed` fallback step.
- **What should reviewers focus on?** `src/agents/failover-error.ts` (`RUNTIME_COORDINATION_ERROR_NAMES`); regressions in `src/agents/failover-error.test.ts` (`isNonProviderRuntimeCoordinationError` — "active turn claim" case) and `src/agents/model-fallback.test.ts` ("aborts fallback on active turn claim / wrapped active turn claim worker coordination failures").

## Evidence

- **Real environment tested:** local worktree on branch `feat/issue-134187-fallback-active-turn-claim` rebased onto current main, Node 26, `pnpm install` + targeted vitest shards green.
- **Exact steps or commands run after this patch:**
  ```bash
  pnpm install
  node scripts/run-vitest.mjs run src/agents/failover-error.test.ts src/agents/model-fallback.test.ts
  OPENCLAW_VITEST_NO_OUTPUT_TIMEOUT_MS=300000 node --import ./scripts/tsx.mjs scripts/test-projects.mts --changed origin/main
  pnpm exec oxfmt --check src/agents/failover-error.ts src/agents/failover-error.test.ts src/agents/model-fallback.test.ts
  ```
- **Evidence after fix:**
  ```text
   Test Files  2 passed (2)
        Tests  231 passed (231)   # failover-error + model-fallback, agents-core shard

   Test Files  2 passed (2)
        Tests  231 passed (231)   # full affected project via test-projects --changed origin/main
  ```
- **Observed result after fix:** the fallback runner aborts on the first `ActiveTurnClaimError`; the rejected promise is the original error itself, the run callback is invoked exactly once, and no `candidate_failed`/`onError`/`onFallbackStep` events fire for either the direct or cause-wrapped error form.
- **Before evidence (optional, visual changes encouraged):** with the fix reverted, the same regression tests fail (3 failed | 228 passed): the runner classifies the error as `reason: "unknown"`, records a `candidate_failed` attempt for the primary, and proceeds to the fallback candidate (`model: "gpt-5.4-mini"`, `outcome: "completed"`) — reproducing the chain traversal from the issue's logs.
- **What was not tested:** a live gateway run with multiple real providers and a genuinely busy concurrent turn claim; the companion announce retry loop (#134186).
- **Proof tier:** L2
- **Proof limitations:** none for the classification behavior — the regressions execute the real `runWithModelFallback` engine end-to-end with stubbed candidate callbacks, which is the proof shape the issue's ClawSweeper review accepted ("without a live provider"). No live multi-provider gateway is available in this environment.
- **Review state:** Awaiting CI + maintainer review; L2 vitest evidence complete.
