### PR TITLE
test(tooling): batch startup benchmark state cases

### DIFF
--- a/test/scripts/cli-startup-bench-spawner.test.ts
+++ b/test/scripts/cli-startup-bench-spawner.test.ts
@@ -49,60 +49,61 @@ describe("CLI startup benchmark script spawners", () => {
         ].join("\n"),
       );
 
-      const runCase = (caseId: string) => {
-        fs.rmSync(homeLogPath, { force: true });
-        const reportPath = path.join(tmpDir, `${caseId}.json`);
-        execFileSync(
-          process.execPath,
-          [
-            "--import",
-            "tsx",
-            "scripts/bench-cli-startup.ts",
-            "--entry",
-            fixturePath,
-            "--case",
-            caseId,
-            "--runs",
-            "2",
-            "--warmup",
-            "1",
-            "--output",
-            reportPath,
-          ],
-          {
-            cwd: process.cwd(),
-            env: {
-              ...process.env,
-              OPENCLAW_BENCH_HOME_LOG: homeLogPath,
-            },
-            stdio: "pipe",
+      const caseIds = [
+        "gatewayHealthJsonWarmState",
+        "gatewayHealthJson",
+        "gatewayHealthJsonFreshState",
+      ];
+      const reportPath = path.join(tmpDir, "state-scopes.json");
+      execFileSync(
+        process.execPath,
+        [
+          "--import",
+          "tsx",
+          "scripts/bench-cli-startup.ts",
+          "--entry",
+          fixturePath,
+          ...caseIds.flatMap((caseId) => ["--case", caseId]),
+          "--runs",
+          "2",
+          "--warmup",
+          "1",
+          "--output",
+          reportPath,
+        ],
+        {
+          cwd: process.cwd(),
+          env: {
+            ...process.env,
+            OPENCLAW_BENCH_HOME_LOG: homeLogPath,
           },
-        );
-        return {
-          homes: fs.readFileSync(homeLogPath, "utf8").trim().split("\n"),
-          report: JSON.parse(fs.readFileSync(reportPath, "utf8")),
-        };
-      };
+          stdio: "pipe",
+        },
+      );
+      const homes = fs.readFileSync(homeLogPath, "utf8").trim().split("\n");
+      const report = JSON.parse(fs.readFileSync(reportPath, "utf8"));
 
-      const warmed = runCase("gatewayHealthJsonWarmState");
-      const warmedHomes = warmed.homes;
-      expect(warmedHomes).toHaveLength(3);
+      expect(report.primary.cases.map((commandCase: { id: string }) => commandCase.id)).toEqual(
+        caseIds,
+      );
+      expect(homes).toHaveLength(9);
+      expect(new Set(homes).size).toBe(7);
+      expect(homes.every((home) => !fs.existsSync(home))).toBe(true);
+      const warmedHomes = homes.slice(0, 3);
       expect(new Set(warmedHomes).size).toBe(1);
-      expect(warmedHomes.every((home) => !fs.existsSync(home))).toBe(true);
-      const warmedCase = warmed.report.primary.cases[0];
-      expect(warmedCase.warmupSamples).toHaveLength(1);
-      expect(warmedCase.samples).toHaveLength(2);
-      for (const sample of [...warmedCase.warmupSamples, ...warmedCase.samples]) {
-        expect(new Date(sample.startedAt).toISOString()).toBe(sample.startedAt);
-        expect(new Date(sample.endedAt).toISOString()).toBe(sample.endedAt);
-        expect(Date.parse(sample.endedAt)).toBeGreaterThanOrEqual(Date.parse(sample.startedAt));
+      for (const commandCase of report.primary.cases) {
+        expect(commandCase.warmupSamples).toHaveLength(1);
+        expect(commandCase.samples).toHaveLength(2);
+        for (const sample of [...commandCase.warmupSamples, ...commandCase.samples]) {
+          expect(new Date(sample.startedAt).toISOString()).toBe(sample.startedAt);
+          expect(new Date(sample.endedAt).toISOString()).toBe(sample.endedAt);
+          expect(Date.parse(sample.endedAt)).toBeGreaterThanOrEqual(Date.parse(sample.startedAt));
+        }
       }
 
-      for (const caseId of ["gatewayHealthJson", "gatewayHealthJsonFreshState"]) {
-        const sampleHomes = runCase(caseId).homes;
-        expect(sampleHomes).toHaveLength(3);
+      for (const start of [3, 6]) {
+        const sampleHomes = homes.slice(start, start + 3);
         expect(new Set(sampleHomes).size).toBe(3);
-        expect(sampleHomes.every((home) => !fs.existsSync(home))).toBe(true);
       }
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });


### PR DESCRIPTION
## What Problem This Solves

The startup benchmark's HOME-isolation test launches the benchmark driver separately for warm, ordinary and explicitly fresh health cases, even though the CLI supports multiple ordered cases in one invocation.

## Why This Change Was Made

Run those three cases together with the same one warmup and two measured samples each. Assert the ordered report IDs, all nine HOME observations, per-case reuse/isolation, timestamps and cleanup. Also require seven distinct homes across the complete run, catching accidental sharing between cases.

## User Impact

Removes two Node/tsx driver launches and two RSS-hook temporary roots. All nine real sample processes remain, as do the separate CLI exit-status and descendant-timeout tests. Production +0/-0; tests +49/-48. This measures the benchmark harness with an offline entry fixture, not product startup latency.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/cli-startup-bench-spawner.test.ts test/scripts/bench-cli-startup.test.ts` passed all 29 tests before and after.
- Full changed-file checks, formatting, diff checks and structured Codex autoreview passed.
- Reviewed the complete driver, spawner and sibling tests, budget/update callers, documented repeatable case flag and warm-state/warmup history. The real owner executes cases serially and releases each owned HOME before the next case.
