### PR TITLE
perf(ci): report type failures before broad audits

### DIFF
--- a/scripts/check-changed.mts
+++ b/scripts/check-changed.mts
@@ -457,6 +457,8 @@ export function createChangedCheckPlan(
   options: ChangedCheckPlanOptions = {},
 ) {
   const commands: ChangedCheckCommand[] = [];
+  const broadAudits = new Set<ChangedCheckCommand>();
+  const typechecks = new Set<ChangedCheckCommand>();
   const baseEnv: NodeJS.ProcessEnv = createChangedCheckChildEnv(options.env ?? process.env);
   const generatedExtensionAssetPaths = result.paths.some((changedPath) =>
     LINTABLE_EXTENSION_PATH_RE.test(changedPath),
@@ -464,21 +466,43 @@ export function createChangedCheckPlan(
     ? (cachedGeneratedExtensionAssetPaths ??= new Set(listGeneratedExtensionAssetSources()))
     : new Set<string>();
   const add = (name: string, args: string[], env?: NodeJS.ProcessEnv) => {
-    if (!commands.some((command) => command.name === name && sameArgs(command.args, args))) {
-      commands.push({ name, args, ...(env ? { env } : {}) });
+    const existing = commands.find(
+      (command) => command.name === name && sameArgs(command.args, args),
+    );
+    if (existing) {
+      return existing;
     }
+    const command = { name, args, ...(env ? { env } : {}) };
+    commands.push(command);
+    return command;
   };
   const addCommand = (name: string, bin: string, args: string[], env?: NodeJS.ProcessEnv) => {
-    if (
-      !commands.some(
-        (command) => command.name === name && command.bin === bin && sameArgs(command.args, args),
-      )
-    ) {
-      commands.push({ name, bin, args, ...(env ? { env } : {}) });
+    const existing = commands.find(
+      (command) => command.name === name && command.bin === bin && sameArgs(command.args, args),
+    );
+    if (existing) {
+      return existing;
     }
+    const command = { name, bin, args, ...(env ? { env } : {}) };
+    commands.push(command);
+    return command;
   };
   const addTypecheck = (name: string, args: string[]) =>
-    add(name, args, createSparseTsgoSkipEnv(baseEnv));
+    typechecks.add(add(name, args, createSparseTsgoSkipEnv(baseEnv)));
+  const finishPlan = (summary: string) => {
+    const end = commands.findLastIndex((command) => typechecks.has(command)) + 1;
+    const prefix = commands.slice(0, end);
+    // These audits produce diagnostics, not compiler inputs. Defer them without
+    // moving compiler prerequisites or overlapping their resource-heavy processes.
+    return {
+      commands: [
+        ...prefix.filter((command) => !broadAudits.has(command)),
+        ...prefix.filter((command) => broadAudits.has(command)),
+        ...commands.slice(end),
+      ],
+      summary,
+    };
+  };
   const addLint = (name: string, args: string[]) => add(name, args, baseEnv);
   const addTargetedLint = (
     createCommand: (
@@ -583,7 +607,7 @@ export function createChangedCheckPlan(
     add("extension test core imports", ["lint:plugins:no-extension-test-core-imports"]);
   }
   add("duplicate scan target coverage", ["dup:check:coverage"]);
-  add("coercion helper declaration guard", ["check:coercion-helpers"]);
+  broadAudits.add(add("coercion helper declaration guard", ["check:coercion-helpers"]));
   add("dependency pin guard", ["deps:pins:check"]);
   if (result.paths.length > 0) {
     add("format changed files", [
@@ -642,7 +666,7 @@ export function createChangedCheckPlan(
     add("Plugin SDK surface budget", ["plugin-sdk:surface:check"]);
   }
   if (result.lanes.all || shouldRunDeprecationHygieneChecks(result.paths)) {
-    add("deprecated API usage", ["check:deprecated-api-usage"]);
+    broadAudits.add(add("deprecated API usage", ["check:deprecated-api-usage"]));
     // After 2026-07-24, lapsed compatibility windows intentionally fail this gate
     // until their scheduled deletion PRs land.
     add("plugin boundaries", ["plugins:boundary-report:ci"]);
@@ -662,19 +686,18 @@ export function createChangedCheckPlan(
     hasDeadcodeScannedSource(result.paths) &&
     !isOpenEndedTruthyValue(baseEnv.OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE)
   ) {
-    addCommand(
-      "dead export scan (skip with OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1)",
-      "node",
-      ["--import", "tsx", "scripts/check-deadcode-exports.mts"],
-      baseEnv,
+    broadAudits.add(
+      addCommand(
+        "dead export scan (skip with OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1)",
+        "node",
+        ["--import", "tsx", "scripts/check-deadcode-exports.mts"],
+        baseEnv,
+      ),
     );
   }
 
   if (result.docsOnly) {
-    return {
-      commands,
-      summary: "docs-only",
-    };
+    return finishPlan("docs-only");
   }
 
   addTestTempCreationReport();
@@ -718,10 +741,7 @@ export function createChangedCheckPlan(
     add("config schema baseline", ["config:schema:check"]);
     add("config docs baseline", ["config:docs:check"]);
     add("root dependency ownership", ["deps:root-ownership:check"]);
-    return {
-      commands,
-      summary: "release metadata",
-    };
+    return finishPlan("release metadata");
   }
 
   if (shouldRunAndroidVersionSync) {
@@ -735,10 +755,7 @@ export function createChangedCheckPlan(
     addTypecheck("typecheck all", ["tsgo:all"]);
     addLint("lint", ["lint"]);
     add("runtime import cycles", ["check:import-cycles"]);
-    return {
-      commands,
-      summary: "all",
-    };
+    return finishPlan("all");
   }
 
   if (shouldRunControlUiI18nVerify(result.paths)) {
@@ -905,13 +922,12 @@ export function createChangedCheckPlan(
     });
   }
 
-  return {
-    commands,
-    summary: Object.entries(lanes)
+  return finishPlan(
+    Object.entries(lanes)
       .filter(([, enabled]) => enabled)
       .map(([lane]) => lane)
       .join(", "),
-  };
+  );
 }
 
 export function createTargetedCoreLintCommand(

--- a/test/scripts/changed-lanes.test.ts
+++ b/test/scripts/changed-lanes.test.ts
@@ -1,6 +1,6 @@
 // Changed Lanes tests cover changed lanes script behavior.
 import { execFileSync, spawnSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -163,6 +163,62 @@ function runChangedFormatLaneWithRepoOxfmt(cwd: string, changedPaths: string[]) 
     shell: invocation.shell,
     windowsVerbatimArguments: invocation.windowsVerbatimArguments,
   });
+}
+
+// Keep the real gate and managed children; only the external check commands are synthetic.
+function runChangedCheckWithRecordedCommands(failingCommand: string | null) {
+  const dir = makeTempRepoRoot(tempDirs, "openclaw-changed-check-order-");
+  const binDir = path.join(dir, "bin");
+  const eventsPath = path.join(dir, "events.jsonl");
+  const childPath = path.join(dir, "command.cjs");
+  mkdirSync(binDir);
+  writeFileSync(eventsPath, "");
+  writeFileSync(
+    childPath,
+    `
+const fs = require("node:fs");
+const bin = process.argv[2];
+const args = process.argv.slice(3);
+const events = ${JSON.stringify(eventsPath)};
+const active = ${JSON.stringify(path.join(dir, "active"))};
+const record = (event) => fs.appendFileSync(events, JSON.stringify({event, bin, args}) + "\\n");
+fs.mkdirSync(active);
+record("start");
+process.on("exit", () => { record("finish"); fs.rmdirSync(active); });
+if (bin === "pnpm" && args[0] === ${JSON.stringify(failingCommand)}) {
+  console.error("Synthetic check failure: " + args[0]);
+  process.exitCode = 23;
+}
+`,
+  );
+  const quote = (value: string) => `'${value.replaceAll("'", "'\\''")}'`;
+  for (const bin of ["pnpm", "node"]) {
+    const launcher = path.join(binDir, bin);
+    writeFileSync(
+      launcher,
+      `#!/bin/sh\nexec ${quote(process.execPath)} ${quote(childPath)} ${bin} "$@"\n`,
+    );
+    chmodSync(launcher, 0o755);
+    writeFileSync(
+      `${launcher}.cmd`,
+      `@echo off\r\n"${process.execPath}" "${childPath}" ${bin} %*\r\n`,
+    );
+  }
+  const paths = ["src/gateway/server-runtime-state.ts"];
+  const result = runRepoScript("scripts/check-changed.mjs", ["--", ...paths], {
+    ...createNestedGitEnv(),
+    CI: "",
+    GITHUB_ACTIONS: "",
+    OPENCLAW_CHECK_CHANGED_REMOTE_CHILD: "1",
+    OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE: "",
+    PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+  });
+  const events: { event: string; bin: string; args: string[] }[] = readFileSync(eventsPath, "utf8")
+    .trim()
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => JSON.parse(line));
+  return { events, paths, result };
 }
 
 function createSyntheticMergeRepo(prefix: string): { dir: string; staleBase: string } {
@@ -367,6 +423,51 @@ describe("scripts/changed-lanes", () => {
     ]);
   });
 
+  it.each(["tsgo:core:test", "lint:tmp:tsgo-core-boundary", null])(
+    "runs types before broad audits while retaining serial gate execution (%s)",
+    (failingCommand) => {
+      const { events, paths, result } = runChangedCheckWithRecordedCommands(failingCommand);
+      expect(result.error, result.stderr).toBeUndefined();
+      expect(result.signal, result.stderr).toBeNull();
+      expect(result.status, result.stderr).toBe(failingCommand === null ? 0 : 23);
+      const commands = events.filter((event) => event.event === "start");
+      const planned = createChangedCheckPlan(detectChangedLanes(paths)).commands.map((command) => ({
+        bin: command.bin ?? "pnpm",
+        args: command.args,
+      }));
+      const end =
+        failingCommand === null
+          ? planned.length
+          : planned.findIndex((command) => command.args[0] === failingCommand) + 1;
+      expect(commands.map(({ bin, args }) => ({ bin, args }))).toEqual(planned.slice(0, end));
+      expect(events).toEqual(
+        commands.flatMap(({ bin, args }) => [
+          { event: "start", bin, args },
+          { event: "finish", bin, args },
+        ]),
+      );
+      const broadAudits = commands.filter(({ args }) =>
+        args.some((arg) =>
+          [
+            "check:coercion-helpers",
+            "check:deprecated-api-usage",
+            "scripts/check-deadcode-exports.mts",
+          ].includes(arg),
+        ),
+      );
+      if (failingCommand !== null) {
+        expect(result.stderr).toContain(`Synthetic check failure: ${failingCommand}`);
+        expect(broadAudits).toEqual([]);
+      } else {
+        expect(broadAudits).toHaveLength(3);
+        const lastTypecheck = commands.findLastIndex(({ args }) => args[0]?.startsWith("tsgo:"));
+        for (const audit of broadAudits) {
+          expect(commands.indexOf(audit)).toBeGreaterThan(lastTypecheck);
+        }
+      }
+    },
+  );
+
   it("prints changed check dry-run commands", () => {
     const result = runRepoScript("scripts/check-changed.mjs", [
       "--dry-run",
@@ -406,13 +507,13 @@ describe("scripts/changed-lanes", () => {
       "pnpm lint:extensions:no-guarded-wildcard-reexports",
       "pnpm lint:extensions:no-plugin-sdk-wildcard-reexports",
       "pnpm dup:check:coverage",
-      "pnpm check:coercion-helpers",
       "pnpm deps:pins:check",
       `pnpm format:check --no-error-on-unmatched-pattern -- ${lanes.paths.join(" ")}`,
       "pnpm deps:patches:check",
       "node scripts/report-test-temp-creations.mjs --base origin/main --head HEAD",
       "pnpm lint:tmp:tsgo-core-boundary",
       "pnpm tsgo:test:root",
+      "pnpm check:coercion-helpers",
       "pnpm lint:scripts",
     ]);
   });
@@ -1472,20 +1573,20 @@ describe("scripts/changed-lanes", () => {
       "guarded extension wildcard re-exports",
       "plugin-sdk wildcard re-exports",
       "duplicate scan target coverage",
-      "coercion helper declaration guard",
       "dependency pin guard",
       "format changed files",
-      "deprecated API usage",
       "plugin boundaries",
       "wrapper shadowing",
       "package patch guard",
+      "test temp creation report (warning-only)",
+      "core tsgo graph boundary",
+      "typecheck core tests",
+      "coercion helper declaration guard",
+      "deprecated API usage",
       // These live-Docker paths include `src/gateway/*.live.test.ts`, and the
       // full-tree knip scan sees test files, so a deleted last consumer can
       // orphan an export here too.
       "dead export scan (skip with OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1)",
-      "test temp creation report (warning-only)",
-      "core tsgo graph boundary",
-      "typecheck core tests",
       "lint core",
       "lint scripts",
       "live Docker shell syntax",


### PR DESCRIPTION
Changed-file verification can spend several minutes on whole-repository audits before reporting an inexpensive compiler error. In a retained failing gate, coercion, deprecated-API and unused-export scans consumed 389 seconds before the core-test compiler reported its errors.

Run those three existing audits after the last selected typecheck. The existing planner retains each canonical command descriptor and finalizes its order; the managed executor stays unchanged and serial. Compiler prerequisites, graph-boundary inventory reuse, command arguments and environments, deduplication, no-type plans and all successful coverage are preserved. No new option, skip, retry, cache or concurrency is introduced.

This prioritizes compiler feedback: audit failures can appear later when types pass, and successful gates still run everything. Holding the recorded command durations fixed would expose that particular failure at 166 seconds instead of 555 seconds. That is an ordering counterfactual, not a measured full-release or successful-gate speedup.

Validation:

- Three executable CLI/planner/managed-child regressions fail with the old order and pass with the repair. They verify compiler/boundary exit status, no audit launch before a compiler failure, serial child completion and complete successful command visitation.
- All 222 existing owner and real compiler-graph sibling tests passed, repeated against an independent frozen dependency installation.
- Thirty representative before/after plans retain complete command descriptors and all non-audit relative order, including mixed live-Docker/core, narrowed tests, all, docs and release-metadata paths.
- All 19 commands in the actual two-path changed gate passed; formatting and whitespace checks passed. Independent managed review found no actionable P0–P2 findings.

The first actual gate failed because the shared installation lacked existing dependency declarations. That failure is retained; the independent frozen installation cleared those errors without source or lockfile changes. Runtime production delta is zero; planner tooling is +48/-32, and tests are +108/-7. The small planner increase provides explicit per-invocation command identity and one finalization path rather than a name-based priority scheduler.
