### PR TITLE
fix(cli): preserve user data in uninstall defaults

### DIFF
--- a/docs/cli/uninstall.md
+++ b/docs/cli/uninstall.md
@@ -25,7 +25,7 @@ removed; uninstall it via npm/pnpm separately.
 | `--dry-run`         | `false` | Print planned actions without removing files.        |
 
 With no scope flags, an interactive multiselect prompts for which components
-to remove (defaults to service, state, workspace preselected).
+to remove (defaults to the Gateway service only).
 
 ## Examples
 

--- a/docs/install/uninstall.md
+++ b/docs/install/uninstall.md
@@ -21,7 +21,10 @@ Recommended: use the built-in uninstaller:
 openclaw uninstall
 ```
 
-State removal preserves configured workspace directories unless you also select `--workspace`.
+The interactive prompt preselects only the Gateway service. For complete local
+removal, also select state, workspace, and app in the prompt, or run
+`openclaw uninstall --all`. State removal preserves configured workspace
+directories unless you also select `--workspace`.
 
 Preview what will be removed (safe):
 

--- a/src/commands/uninstall.test.ts
+++ b/src/commands/uninstall.test.ts
@@ -13,6 +13,15 @@ import {
   silenceCleanupCommandRuntime,
 } from "./cleanup-command.test-support.js";
 
+const clackMocks = vi.hoisted(() => ({
+  cancel: vi.fn(),
+  confirm: vi.fn(),
+  isCancel: vi.fn(),
+  multiselect: vi.fn(),
+}));
+
+vi.mock("@clack/prompts", () => clackMocks);
+
 const { uninstallCommand } = await import("./uninstall.js");
 
 describe("uninstallCommand", () => {
@@ -21,6 +30,22 @@ describe("uninstallCommand", () => {
   beforeEach(() => {
     resetCleanupCommandMocks();
     silenceCleanupCommandRuntime(runtime);
+    clackMocks.confirm.mockResolvedValue(true);
+    clackMocks.isCancel.mockReturnValue(false);
+    clackMocks.multiselect.mockImplementation(
+      async (options: { initialValues?: string[] }) => options.initialValues ?? [],
+    );
+  });
+
+  it("defaults bare interactive uninstall to gateway service only", async () => {
+    await uninstallCommand(runtime, { yes: true, dryRun: true });
+
+    expect(clackMocks.multiselect).toHaveBeenCalledWith(
+      expect.objectContaining({ initialValues: ["service"] }),
+    );
+    expect(cleanupCommandLogMessages(runtime)).toContain("[dry-run] remove gateway service");
+    expect(removeStateAndLinkedPaths).not.toHaveBeenCalled();
+    expect(removeWorkspaceDirs).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -127,7 +127,7 @@ export async function uninstallCommand(runtime: RuntimeEnv, opts: UninstallOptio
           hint: "/Applications/OpenClaw.app",
         },
       ],
-      initialValues: ["service", "state", "workspace"],
+      initialValues: ["service"],
     });
     if (isCancel(selection)) {
       cancel(stylePromptTitle("Uninstall cancelled.") ?? "Uninstall cancelled.");


### PR DESCRIPTION
Closes #125694

## What Problem This Solves

Fixes an issue where users running bare interactive `openclaw uninstall` could accept the default selection and remove state, configuration, and agent workspaces even when they only intended to remove the Gateway service.

## Why This Change Was Made

The interactive multiselect now preselects only the Gateway service. Explicit `--state`, `--workspace`, and `--all` choices keep their existing behavior, as do non-interactive guards, confirmation, and cleanup safety checks.

## User Impact

Pressing Enter on a bare uninstall preserves user data by default. Operators can still select destructive scopes interactively or request them explicitly with flags.

## Evidence

- Regression first failed against the old three-scope default, then passed on this head: `node scripts/run-vitest.mjs src/commands/uninstall.test.ts` — 22/22 passed.
- Repository changed-file gate passed on the implementation snapshot against parent `a7466da1c0612f80e3e193ccb7317e259cc61dbe` for the core, core-test, and docs lanes; the current exact head `03fc0860b4eaf824ce7d4ed192152fb3168edfba` adds only the reviewed complete-uninstall documentation clarification.
- Exact-head build passed: `node --import ./scripts/tsx.mjs scripts/build-all.mts`.
- Formatting, docs MDX, docs links, and `git diff --check` passed.
- Built CLI proof in an isolated state directory:
  - bare `openclaw uninstall --dry-run --yes`, accepting the prompt default, displayed only `Gateway service` selected and printed only `[dry-run] remove gateway service`;
  - explicit `--state --workspace --dry-run --yes --non-interactive` enumerated the isolated state, config, and workspace paths and exited 0.
- Independent local Codex autoreview returned no findings and `patch is correct` with 0.99 confidence on both the implementation snapshot and the current docs-only exact head.

Exact-head terminal transcript (temporary paths shortened to `<proof>`):

```text
OpenClaw 2026.8.1 (03fc086)

◆  Uninstall which components?
│  ◼ Gateway service (launchd / systemd / schtasks)
│  ◻ State + config
│  ◻ Workspace
│  ◻ macOS app

◇  Uninstall which components?
│  Gateway service
[dry-run] remove gateway service
CLI still installed. Remove via npm/pnpm if desired.

$ openclaw uninstall --state --workspace --dry-run --yes --non-interactive
Recommended first: openclaw backup create
[dry-run] remove <proof>/state
[dry-run] remove <proof>/openclaw.json
[dry-run] remove <proof>/state/workspace
CLI still installed. Remove via npm/pnpm if desired.
```

### Owner acceptance

- **Intended behavior:** bare interactive uninstall defaults to service-only; destructive data scopes require an explicit selection or flag.
- **Boundary / blast radius:** only the interactive prompt default changes. Explicit flags and cleanup implementations are unchanged.
- **Strongest evidence:** built-CLI prompt proof plus a regression that accepts the prompt's actual `initialValues` and asserts no state/workspace cleanup.
- **Known gap / falsifier:** a future prompt wrapper that ignores `initialValues` would invalidate the default-selection proof; the built CLI and regression both exercise the current wrapper contract.
- **Rollback:** revert the two focused commits to restore the former preselection and documentation.
- **Reviewability:** one production-line change, one focused test, and two documentation clarifications.

## AI Assistance

This contribution was implemented with OpenAI Codex assistance. The final exact snapshot was independently reviewed by a separate Codex autoreview pass, and all behavior and verification claims above were read back from the local repository and built CLI.
