### PR TITLE
fix(migrate-claude): preserve overwritten generated skills in backups

### DIFF
--- a/docs/install/migrating-claude.md
+++ b/docs/install/migrating-claude.md
@@ -124,8 +124,10 @@ When `--from` points at a project root, OpenClaw imports only that project's Cla
 Apply refuses to continue when the plan reports conflicts (a file or config value already exists at the target).
 
 <Warning>
-Rerun with `--overwrite` only when replacing the existing target is intentional. Providers may still write item-level backups for overwritten files in the migration report directory.
+Rerun with `--overwrite` only when replacing the existing target is intentional.
 </Warning>
+
+Before overwriting a skill generated from a Claude command, OpenClaw backs up its whole directory and records the path in the item's `details.backupPath` in `report.json`. That path remains available if the overwrite fails. If the command source cannot be read, migration reports an error without changing the existing skill.
 
 For a fresh OpenClaw install, conflicts are unusual. They typically appear when you re-run the import on a setup that already has user edits.
 

--- a/extensions/migrate-claude/apply.ts
+++ b/extensions/migrate-claude/apply.ts
@@ -48,7 +48,9 @@ export async function applyClaudePlan(params: {
     } else if (item.action === "append") {
       items.push(await appendItem(item));
     } else if (item.action === "create" && item.kind === "skill") {
-      items.push(await applyGeneratedSkillItem(item, { overwrite: params.ctx.overwrite }));
+      items.push(
+        await applyGeneratedSkillItem(item, reportDir, { overwrite: params.ctx.overwrite }),
+      );
     } else if (item.kind === "memory") {
       items.push(
         await copyMemoryMigrationFileItem(item, reportDir, {

--- a/extensions/migrate-claude/helpers.ts
+++ b/extensions/migrate-claude/helpers.ts
@@ -43,26 +43,14 @@ export function sanitizeName(name: string): string {
     .replaceAll(/^-+|-+$/g, "");
 }
 
-export async function readText(filePath: string | undefined): Promise<string | undefined> {
-  if (!filePath) {
-    return undefined;
-  }
-  try {
-    return await fs.readFile(filePath, "utf8");
-  } catch {
-    return undefined;
-  }
-}
-
 export async function readJsonObject(
   filePath: string | undefined,
 ): Promise<Record<string, unknown>> {
-  const content = await readText(filePath);
-  if (!content) {
+  if (!filePath) {
     return {};
   }
   try {
-    const parsed = JSON.parse(content) as unknown;
+    const parsed = JSON.parse(await fs.readFile(filePath, "utf8")) as unknown;
     return isRecord(parsed) ? parsed : {};
   } catch {
     return {};

--- a/extensions/migrate-claude/provider.test.ts
+++ b/extensions/migrate-claude/provider.test.ts
@@ -24,6 +24,7 @@ function planItemById(
     action?: string;
     status?: string;
     reason?: string;
+    details?: Record<string, unknown>;
   }[],
   id: string,
 ) {
@@ -667,6 +668,8 @@ describe("Claude migration provider", () => {
     expect(await fs.readFile(path.join(workspaceDir, "AGENTS.md"), "utf8")).toContain(
       "Imported from Claude: project CLAUDE.md",
     );
+    const generatedSkillItem = planItemById(result.items, "skill:claude-command-ship");
+    expect(generatedSkillItem.details?.backupPath).toBeUndefined();
     const generatedSkill = await fs.readFile(
       path.join(workspaceDir, "skills", "claude-command-ship", "SKILL.md"),
       "utf8",
@@ -679,4 +682,135 @@ describe("Claude migration provider", () => {
     ).resolves.toBeUndefined();
     await expect(fs.access(path.join(reportDir, "summary.md"))).resolves.toBeUndefined();
   });
+
+  it("backs up the whole generated skill directory before overwriting it", async () => {
+    const root = testWorkspace.dir;
+    const source = path.join(root, "project");
+    const workspaceDir = path.join(root, "workspace");
+    const stateDir = path.join(root, "state");
+    const reportDir = path.join(root, "report");
+    const targetDir = path.join(workspaceDir, "skills", "claude-command-ship");
+    await writeFile(path.join(source, ".claude", "commands", "ship.md"), "Ship safely.\n");
+    const provider = buildClaudeMigrationProvider();
+    const context = makeContext({ source, stateDir, workspaceDir, reportDir });
+    const plan = await provider.plan(context);
+    await writeFile(path.join(targetDir, "SKILL.md"), "# Local skill\n");
+    await writeFile(path.join(targetDir, "notes.md"), "Keep these notes.\n");
+
+    const conflict = await provider.apply(context, plan);
+    expect(planItemById(conflict.items, "skill:claude-command-ship")).toMatchObject({
+      status: "conflict",
+      reason: "target exists",
+    });
+    await expect(fs.readFile(path.join(targetDir, "SKILL.md"), "utf8")).resolves.toBe(
+      "# Local skill\n",
+    );
+
+    const result = await provider.apply({ ...context, overwrite: true }, plan);
+
+    const item = planItemById(result.items, "skill:claude-command-ship");
+    expect(item.status).toBe("migrated");
+    expect(await fs.readFile(path.join(targetDir, "SKILL.md"), "utf8")).toContain("Ship safely.");
+    await expect(fs.readFile(path.join(targetDir, "notes.md"), "utf8")).resolves.toBe(
+      "Keep these notes.\n",
+    );
+    const backupPath = item.details?.backupPath;
+    if (typeof backupPath !== "string") {
+      throw new Error("expected generated skill backup path");
+    }
+    await expect(fs.readFile(path.join(backupPath, "SKILL.md"), "utf8")).resolves.toBe(
+      "# Local skill\n",
+    );
+    await expect(fs.readFile(path.join(backupPath, "notes.md"), "utf8")).resolves.toBe(
+      "Keep these notes.\n",
+    );
+    expect(
+      JSON.parse(await fs.readFile(path.join(reportDir, "report.json"), "utf8")).items.find(
+        (reportItem: { id?: string }) => reportItem.id === item.id,
+      )?.details?.backupPath,
+    ).toBe(backupPath);
+  });
+
+  it("reports the generated skill backup when the overwrite fails", async () => {
+    const root = testWorkspace.dir;
+    const source = path.join(root, "project");
+    const workspaceDir = path.join(root, "workspace");
+    const reportDir = path.join(root, "report");
+    const targetDir = path.join(workspaceDir, "skills", "claude-command-ship");
+    await writeFile(path.join(source, ".claude", "commands", "ship.md"), "Ship safely.\n");
+    await writeFile(path.join(targetDir, "SKILL.md", "original.md"), "# Local skill\n");
+
+    const provider = buildClaudeMigrationProvider();
+    const result = await provider.apply(
+      makeContext({
+        source,
+        stateDir: path.join(root, "state"),
+        workspaceDir,
+        reportDir,
+        overwrite: true,
+      }),
+    );
+
+    const item = planItemById(result.items, "skill:claude-command-ship");
+    expect(item.status).toBe("error");
+    const backupPath = item.details?.backupPath;
+    if (typeof backupPath !== "string") {
+      throw new Error("expected failed generated skill overwrite to report its backup path");
+    }
+    await expect(
+      fs.readFile(path.join(backupPath, "SKILL.md", "original.md"), "utf8"),
+    ).resolves.toBe("# Local skill\n");
+    expect(
+      JSON.parse(await fs.readFile(path.join(reportDir, "report.json"), "utf8")).items.find(
+        (reportItem: { id?: string }) => reportItem.id === item.id,
+      )?.details?.backupPath,
+    ).toBe(backupPath);
+  });
+
+  it.runIf(process.platform !== "win32")(
+    "materializes symlinked generated skills in the backup before overwriting them",
+    async () => {
+      for (const scenario of ["target-directory", "skill-file"] as const) {
+        const root = path.join(testWorkspace.dir, scenario);
+        const source = path.join(root, "project");
+        const workspaceDir = path.join(root, "workspace");
+        const targetDir = path.join(workspaceDir, "skills", "claude-command-ship");
+        const outsideDir = path.join(root, "outside");
+        const outsideSkill = path.join(outsideDir, "SKILL.md");
+        await writeFile(path.join(source, ".claude", "commands", "ship.md"), "Ship safely.\n");
+        await writeFile(outsideSkill, "# Outside skill\n");
+        if (scenario === "target-directory") {
+          await fs.mkdir(path.dirname(targetDir), { recursive: true });
+          await fs.symlink(outsideDir, targetDir);
+        } else {
+          await fs.mkdir(targetDir, { recursive: true });
+          await fs.symlink(outsideSkill, path.join(targetDir, "SKILL.md"));
+        }
+
+        const provider = buildClaudeMigrationProvider();
+        const result = await provider.apply(
+          makeContext({
+            source,
+            stateDir: path.join(root, "state"),
+            workspaceDir,
+            reportDir: path.join(root, "report"),
+            overwrite: true,
+          }),
+        );
+
+        const item = planItemById(result.items, "skill:claude-command-ship");
+        expect(item.status).toBe("migrated");
+        const backupPath = item.details?.backupPath;
+        if (typeof backupPath !== "string") {
+          throw new Error("expected symlinked generated skill backup path");
+        }
+        expect((await fs.lstat(backupPath)).isSymbolicLink()).toBe(false);
+        expect((await fs.lstat(path.join(backupPath, "SKILL.md"))).isSymbolicLink()).toBe(false);
+        await expect(fs.readFile(path.join(backupPath, "SKILL.md"), "utf8")).resolves.toBe(
+          "# Outside skill\n",
+        );
+        await expect(fs.readFile(outsideSkill, "utf8")).resolves.toContain("Ship safely.");
+      }
+    },
+  );
 });

--- a/extensions/migrate-claude/provider.test.ts
+++ b/extensions/migrate-claude/provider.test.ts
@@ -731,6 +731,48 @@ describe("Claude migration provider", () => {
     ).toBe(backupPath);
   });
 
+  it.each([false, true])(
+    "reports a removed command source without changing its generated skill (overwrite: %s)",
+    async (overwrite) => {
+      const root = testWorkspace.dir;
+      const source = path.join(root, "project");
+      const sourceFile = path.join(source, ".claude", "commands", "ship.md");
+      const workspaceDir = path.join(root, "workspace");
+      const targetDir = path.join(workspaceDir, "skills", "claude-command-ship");
+      const targetFile = path.join(targetDir, "SKILL.md");
+      const reportDir = path.join(root, "report");
+      await writeFile(sourceFile, "Ship safely.\n");
+      if (overwrite) {
+        await writeFile(targetFile, "# Local skill\n");
+      }
+      const provider = buildClaudeMigrationProvider();
+      const context = makeContext({
+        source,
+        stateDir: path.join(root, "state"),
+        workspaceDir,
+        reportDir,
+        overwrite,
+      });
+      const plan = await provider.plan(context);
+      await fs.unlink(sourceFile);
+
+      const result = await provider.apply(context, plan);
+
+      const item = planItemById(result.items, "skill:claude-command-ship");
+      expect(item).toMatchObject({ status: "error", reason: expect.stringContaining("ENOENT") });
+      expect(result.summary).toMatchObject({ migrated: 0, errors: 1 });
+      expect(item.details?.backupPath).toBeUndefined();
+      if (overwrite) {
+        await expect(fs.readFile(targetFile, "utf8")).resolves.toBe("# Local skill\n");
+      } else {
+        await expect(fs.access(targetDir)).rejects.toThrow();
+      }
+      const report = JSON.parse(await fs.readFile(path.join(reportDir, "report.json"), "utf8"));
+      expect(planItemById(report.items, item.id)).toEqual(item);
+      await expect(fs.access(path.join(reportDir, "item-backups"))).rejects.toThrow();
+    },
+  );
+
   it("reports the generated skill backup when the overwrite fails", async () => {
     const root = testWorkspace.dir;
     const source = path.join(root, "project");

--- a/extensions/migrate-claude/skills.ts
+++ b/extensions/migrate-claude/skills.ts
@@ -8,6 +8,7 @@ import {
   MIGRATION_REASON_MISSING_SOURCE_OR_TARGET,
   MIGRATION_REASON_TARGET_EXISTS,
 } from "openclaw/plugin-sdk/migration";
+import { backupMigrationItemTarget } from "openclaw/plugin-sdk/migration-runtime";
 import type { MigrationItem } from "openclaw/plugin-sdk/plugin-entry";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { exists, readText, sanitizeName } from "./helpers.js";
@@ -167,13 +168,16 @@ function generatedCommandSkillContent(params: {
 
 export async function applyGeneratedSkillItem(
   item: MigrationItem,
+  reportDir: string,
   opts: { overwrite?: boolean } = {},
 ): Promise<MigrationItem> {
   if (!item.source || !item.target) {
     return markMigrationItemError(item, MIGRATION_REASON_MISSING_SOURCE_OR_TARGET);
   }
+  let backupPath: string | undefined;
   try {
-    if ((await exists(item.target)) && !opts.overwrite) {
+    const targetExists = await exists(item.target);
+    if (targetExists && !opts.overwrite) {
       return markMigrationItemConflict(item, MIGRATION_REASON_TARGET_EXISTS);
     }
     const sourceLabel =
@@ -187,10 +191,20 @@ export async function applyGeneratedSkillItem(
       sourceLabel,
       commandContent: (await readText(item.source)) ?? "",
     });
+    backupPath = targetExists
+      ? await backupMigrationItemTarget(item.target, reportDir, { dereference: true })
+      : undefined;
     await fs.mkdir(item.target, { recursive: true });
     await fs.writeFile(path.join(item.target, "SKILL.md"), content, "utf8");
-    return { ...item, status: "migrated" };
+    return {
+      ...item,
+      status: "migrated",
+      details: { ...item.details, ...(backupPath ? { backupPath } : {}) },
+    };
   } catch (err) {
-    return markMigrationItemError(item, err instanceof Error ? err.message : String(err));
+    return {
+      ...markMigrationItemError(item, err instanceof Error ? err.message : String(err)),
+      details: { ...item.details, ...(backupPath ? { backupPath } : {}) },
+    };
   }
 }

--- a/extensions/migrate-claude/skills.ts
+++ b/extensions/migrate-claude/skills.ts
@@ -11,7 +11,7 @@ import {
 import { backupMigrationItemTarget } from "openclaw/plugin-sdk/migration-runtime";
 import type { MigrationItem } from "openclaw/plugin-sdk/plugin-entry";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-import { exists, readText, sanitizeName } from "./helpers.js";
+import { exists, sanitizeName } from "./helpers.js";
 import type { ClaudeSource } from "./source.js";
 import type { PlannedTargets } from "./targets.js";
 
@@ -174,7 +174,7 @@ export async function applyGeneratedSkillItem(
   if (!item.source || !item.target) {
     return markMigrationItemError(item, MIGRATION_REASON_MISSING_SOURCE_OR_TARGET);
   }
-  let backupPath: string | undefined;
+  let result = item;
   try {
     const targetExists = await exists(item.target);
     if (targetExists && !opts.overwrite) {
@@ -189,22 +189,20 @@ export async function applyGeneratedSkillItem(
     const content = generatedCommandSkillContent({
       skillName,
       sourceLabel,
-      commandContent: (await readText(item.source)) ?? "",
+      commandContent: await fs.readFile(item.source, "utf8"),
     });
-    backupPath = targetExists
+    const backupPath = targetExists
       ? await backupMigrationItemTarget(item.target, reportDir, { dereference: true })
       : undefined;
+    // Keep the recovery path when a subsequent write fails.
+    result = {
+      ...item,
+      details: { ...item.details, ...(backupPath ? { backupPath } : {}) },
+    };
     await fs.mkdir(item.target, { recursive: true });
     await fs.writeFile(path.join(item.target, "SKILL.md"), content, "utf8");
-    return {
-      ...item,
-      status: "migrated",
-      details: { ...item.details, ...(backupPath ? { backupPath } : {}) },
-    };
+    return { ...result, status: "migrated" };
   } catch (err) {
-    return {
-      ...markMigrationItemError(item, err instanceof Error ? err.message : String(err)),
-      details: { ...item.details, ...(backupPath ? { backupPath } : {}) },
-    };
+    return markMigrationItemError(result, err instanceof Error ? err.message : String(err));
   }
 }

--- a/src/plugin-sdk/migration-runtime.test.ts
+++ b/src/plugin-sdk/migration-runtime.test.ts
@@ -12,7 +12,7 @@ import {
   withCachedMigrationConfigRuntime,
   writeMigrationReport,
 } from "./migration-runtime.js";
-import { createMigrationItem } from "./migration.js";
+import { createMigrationItem, summarizeMigrationItems } from "./migration.js";
 import type { MigrationProviderContext } from "./plugin-entry.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -107,6 +107,43 @@ describe("withCachedMigrationConfigRuntime", () => {
 describe("copyMigrationFileItem", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+  });
+
+  it("reports the completed backup when copying the source fails", async () => {
+    const root = tempDirs.make("openclaw-migration-runtime-");
+    const reportDir = path.join(root, "report");
+    const source = path.join(root, "source", "SKILL.md");
+    const target = path.join(root, "target", "SKILL.md");
+    await writeFile(source, "new skill");
+    await writeFile(target, "local skill");
+    const item = createMigrationItem({
+      id: "skill:review",
+      kind: "skill",
+      action: "copy",
+      source,
+      target,
+      details: { sourceLabel: "reviewed skill" },
+    });
+    await fs.unlink(source);
+
+    const result = await copyMigrationFileItem(item, reportDir, { overwrite: true });
+
+    expect(result).toMatchObject({ status: "error", reason: expect.stringContaining("ENOENT") });
+    expect(result.details?.sourceLabel).toBe("reviewed skill");
+    const backupPath = result.details?.backupPath;
+    expect(backupPath).toBeTypeOf("string");
+    await expect(fs.readFile(String(backupPath), "utf8")).resolves.toBe("local skill");
+    await expect(fs.readFile(target, "utf8")).resolves.toBe("local skill");
+    await writeMigrationReport({
+      providerId: "claude",
+      source: path.dirname(source),
+      reportDir,
+      items: [result],
+      summary: summarizeMigrationItems([result]),
+    });
+    expect(
+      JSON.parse(await fs.readFile(path.join(reportDir, "report.json"), "utf8")).items,
+    ).toEqual([result]);
   });
 
   it("uses unique backup paths for same-basename targets in the same millisecond", async () => {

--- a/src/plugin-sdk/migration-runtime.ts
+++ b/src/plugin-sdk/migration-runtime.ts
@@ -295,6 +295,7 @@ export async function copyMigrationFileItem(
   if (!item.source || !item.target) {
     return markMigrationItemError(item, MIGRATION_REASON_MISSING_SOURCE_OR_TARGET);
   }
+  let result = item;
   try {
     const targetExists = await pathExists(item.target);
     if (targetExists && !opts.overwrite) {
@@ -303,22 +304,23 @@ export async function copyMigrationFileItem(
     const backupPath = opts.overwrite
       ? await backupMigrationItemTarget(item.target, reportDir)
       : undefined;
+    // Keep the recovery path when a subsequent copy fails.
+    result = {
+      ...item,
+      details: { ...item.details, ...(backupPath ? { backupPath } : {}) },
+    };
     await fs.mkdir(path.dirname(item.target), { recursive: true });
     await fs.cp(item.source, item.target, {
       recursive: true,
       force: Boolean(opts.overwrite),
       errorOnExist: !opts.overwrite,
     });
-    return {
-      ...item,
-      status: "migrated",
-      details: { ...item.details, ...(backupPath ? { backupPath } : {}) },
-    };
+    return { ...result, status: "migrated" };
   } catch (err) {
     if (isFileAlreadyExistsError(err)) {
-      return markMigrationItemConflict(item, MIGRATION_REASON_TARGET_EXISTS);
+      return markMigrationItemConflict(result, MIGRATION_REASON_TARGET_EXISTS);
     }
-    return markMigrationItemError(item, err instanceof Error ? err.message : String(err));
+    return markMigrationItemError(result, err instanceof Error ? err.message : String(err));
   }
 }
 

--- a/src/plugin-sdk/migration-runtime.ts
+++ b/src/plugin-sdk/migration-runtime.ts
@@ -105,9 +105,11 @@ export function withCachedMigrationConfigRuntime(
   };
 }
 
-async function backupExistingMigrationTarget(
+/** Back up an existing migration target within the report's item backup directory. */
+export async function backupMigrationItemTarget(
   target: string,
   reportDir: string,
+  opts: { dereference?: boolean } = {},
 ): Promise<string | undefined> {
   if (!(await pathExists(target))) {
     return undefined;
@@ -121,7 +123,11 @@ async function backupExistingMigrationTarget(
     .slice(0, 12);
   const backupDir = await fs.mkdtemp(path.join(backupRoot, `${Date.now()}-${targetHash}-`));
   const backupPath = path.join(backupDir, path.basename(target));
-  await fs.cp(target, backupPath, { recursive: true, force: true });
+  await fs.cp(target, backupPath, {
+    recursive: true,
+    force: true,
+    ...(opts.dereference === undefined ? {} : { dereference: opts.dereference }),
+  });
   return backupPath;
 }
 
@@ -295,7 +301,7 @@ export async function copyMigrationFileItem(
       return markMigrationItemConflict(item, MIGRATION_REASON_TARGET_EXISTS);
     }
     const backupPath = opts.overwrite
-      ? await backupExistingMigrationTarget(item.target, reportDir)
+      ? await backupMigrationItemTarget(item.target, reportDir)
       : undefined;
     await fs.mkdir(path.dirname(item.target), { recursive: true });
     await fs.cp(item.source, item.target, {


### PR DESCRIPTION
## What Problem This Solves

Overwriting a skill generated from a Claude command could replace local work without an item-level recovery copy. The generated-skill writer now uses the migration report's existing backup owner to save the whole target directory before writing. The report records the recovery path on both success and a later write failure.

The maintainer pass also fixes two failures found while testing the contribution. A command deleted after planning was treated as empty content and reported as migrated; it is now read before any target change, so the operation reports an error and preserves the existing skill. The shared file-copy owner now retains a completed backup path if the subsequent copy fails. The obsolete optional text reader is removed, while optional JSON reads keep their existing behavior. Thanks @PollyBot13.

## Recovery Policy

Maintainer acceptance: explicit `--overwrite` keeps the existing write-through behavior for a symlinked skill target. The new backup deliberately materializes the directory or file referent, so recovery does not depend on a symlink pointing at the overwritten content. Existing ordinary migration-copy symlink semantics are unchanged. The tests cover both symlink shapes, failed writes, fresh targets, overwrite conflicts, and backup uniqueness.

The whole PR adds 10 net production lines (+40/-30), implementing the whole-directory recovery boundary; the maintainer repairs themselves remove 12 net production lines. Tests are +214/-1 and docs +3/-1. No config option, environment variable, public SDK contract, dependency, SQLite schema, or persistent-store design is added. The report and backups remain named migration artifacts.

## Evidence

Independent runs used synthetic project, workspace, and state directories in a fresh isolated Linux environment with no credential hydration:

- Original published head `931a7eb1756f7ad46c0c9817dc18e8dc77401440`: 38 owner/SDK tests passed. The new deleted-command cases then failed twice against that code, and the shared-copy failure case failed because the completed backup path was absent.
- Final candidate: all 60 Claude, shared SDK, and Hermes tests passed. Complete native changed-file checks passed, including production/test types, type-aware lint, dead exports, SDK boundaries, and structural guards.
- Real built CLI, normal `migrate apply claude --overwrite --yes --json`: exit 0; the whole-directory backup contains the original skill and its sibling notes; the reopened report matches stdout; the independent pre-migration archive is verified.
- Real built CLI, source deleted at its confirmation prompt: the published code exited 0, reported migrated, and overwrote the skill. The candidate exits 1, records an `ENOENT` item error, preserves the skill and notes, and keeps the independent pre-migration archive. It does not claim an item backup when no item mutation occurred.
- Fresh independent Codex Autoreview completed with no actionable P0-P2 findings and verified source integrity. All seven candidate file hashes match the completed Linux proof.

The production owner, apply/report entrypoints, Node file-copy contract, and Hermes/shared-copy siblings were inspected. The latest ClawSweeper review's two merge risks are addressed above: explicit symlink recovery policy and justified production growth. Its review will be refreshed after the fixup because it is older than 12 hours. Exact published-head CI remains a landing gate.

Fixes #127403.
