### PR TITLE
fix(macos): preserve config on Browser Control changes

### DIFF
--- a/apps/macos/Sources/OpenClaw/ChannelsStore+Config.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsStore+Config.swift
@@ -90,11 +90,17 @@ extension ChannelsStore {
         while true {
             self.configLoadingSourceKey = requestSourceKey
             do {
+                let route = try await GatewayConnection.shared.captureRequiredRoute()
                 let snap: ConfigSnapshot = try await GatewayConnection.shared.requestDecoded(
                     method: .configGet,
                     params: nil,
-                    timeoutMs: 10000)
-                self.applyConfigSnapshot(snap, sourceKey: requestSourceKey, force: requestForce)
+                    timeoutMs: 10000,
+                    ifCurrentRoute: route)
+                self.applyConfigSnapshot(
+                    snap,
+                    sourceKey: requestSourceKey,
+                    force: requestForce,
+                    saveSource: .gateway(baseHash: snap.hash?.nonEmpty, route: route))
             } catch {
                 self.configStatus = error.localizedDescription
             }
@@ -107,13 +113,26 @@ extension ChannelsStore {
         }
     }
 
-    func applyConfigSnapshot(_ snap: ConfigSnapshot, sourceKey: String, force: Bool) {
+    func applyConfigSnapshot(
+        _ snap: ConfigSnapshot,
+        sourceKey: String,
+        force: Bool,
+        saveSource: ConfigStore.SaveSource? = nil)
+    {
         guard self.configSourceKey == sourceKey else { return }
         guard force || !self.configDirty else { return }
 
         self.configStatus = snap.valid == false
             ? "Config invalid; fix it in ~/.openclaw/openclaw.json."
             : nil
+        let exists = snap.exists ?? true
+        self.configSaveSource = if snap.valid != false,
+                                   !exists || (snap.hash?.nonEmpty != nil && snap.config != nil)
+        {
+            saveSource
+        } else {
+            nil
+        }
         self.configRoot = snap.config?.mapValues { $0.foundationValue } ?? [:]
         self.configDraft = cloneConfigValue(self.configRoot) as? [String: Any] ?? self.configRoot
         self.configDirty = false
@@ -216,7 +235,12 @@ extension ChannelsStore {
         defer { self.isSavingConfig = false }
 
         do {
-            try await ConfigStore.save(self.configDraft)
+            guard let source = self.configSaveSource else {
+                throw NSError(domain: "ChannelsStore", code: 1, userInfo: [
+                    NSLocalizedDescriptionKey: "Gateway config read did not return a revision.",
+                ])
+            }
+            try await ConfigStore.save(self.configDraft, source: source)
             await self.loadConfig()
         } catch {
             self.configStatus = error.localizedDescription
@@ -251,6 +275,7 @@ extension ChannelsStore {
         self.configDraft = [:]
         self.configDirty = false
         self.configLoaded = false
+        self.configSaveSource = nil
         self.configSourceKey = sourceKey
     }
 

--- a/apps/macos/Sources/OpenClaw/ChannelsStore.swift
+++ b/apps/macos/Sources/OpenClaw/ChannelsStore.swift
@@ -316,6 +316,7 @@ final class ChannelsStore {
     var configRoot: [String: Any] = [:]
     var configLoaded = false
     var configSourceKey: String?
+    var configSaveSource: ConfigStore.SaveSource?
     @ObservationIgnored private var decodedChannelCache: [String: Any] = [:]
 
     func channelMetaEntry(_ id: String) -> ChannelsStatusSnapshot.ChannelUiMetaEntry? {

--- a/apps/macos/Sources/OpenClaw/ConfigStore.swift
+++ b/apps/macos/Sources/OpenClaw/ConfigStore.swift
@@ -1,7 +1,19 @@
 import Foundation
+import OpenClawKit
 import OpenClawProtocol
 
 enum ConfigStore {
+    enum SaveSource {
+        // The route is nil only when tests inject the transport; production writes require one.
+        case gateway(baseHash: String?, route: GatewayConnection.Route?)
+        case local
+    }
+
+    struct LoadedConfig {
+        let root: [String: Any]
+        let source: SaveSource
+    }
+
     private struct ConfigWriteAck: Decodable {
         let hash: String?
     }
@@ -13,6 +25,14 @@ enum ConfigStore {
         var loadRemote: (@MainActor @Sendable () async -> [String: Any])?
         var saveRemote: (@MainActor @Sendable ([String: Any]) async throws -> Void)?
         var saveGateway: (@MainActor @Sendable ([String: Any]) async throws -> Void)?
+        var loadGatewayRevision: (@MainActor @Sendable () async throws -> (
+            exists: Bool,
+            hash: String?,
+            valid: Bool?,
+            root: [String: Any]?))?
+        var loadGatewayBrowserEnabled: (@MainActor @Sendable () async throws -> Bool)?
+        var supportsGatewayMethod: (@MainActor @Sendable (String) -> Bool?)?
+        var writeGateway: (@MainActor @Sendable (String, [String: Any], String?) async throws -> String?)?
         #if DEBUG
         /// Isolates focused notification assertions without changing the production sender contract.
         var notificationCenter: NotificationCenter?
@@ -28,8 +48,6 @@ enum ConfigStore {
     }
 
     private static let overrideStore = OverrideStore()
-    @MainActor private static var lastHash: String?
-
     private static func isRemoteMode() async -> Bool {
         let overrides = await self.overrideStore.overrides
         if let override = overrides.isRemoteMode {
@@ -45,79 +63,280 @@ enum ConfigStore {
             if let override = overrides.loadRemote {
                 return await override()
             }
-            return await self.loadFromGateway() ?? [:]
+            return await (try? self.loadFromGateway())?.root ?? [:]
         }
         if let override = overrides.loadLocal {
             return override()
         }
-        if let gateway = await self.loadFromGateway() {
-            return gateway
+        if let gateway = try? await self.loadFromGateway() {
+            return gateway.root
         }
         return OpenClawConfigFile.loadDict()
     }
 
     @MainActor
+    static func loadForMutation() async throws -> LoadedConfig {
+        let overrides = await self.overrideStore.overrides
+        if await self.isRemoteMode() {
+            return try await self.loadFromGateway(overrides: overrides)
+        }
+        if let override = overrides.loadLocal {
+            return LoadedConfig(root: override(), source: .local)
+        }
+        do {
+            return try await self.loadFromGateway(overrides: overrides)
+        } catch is GatewayUnavailableBeforeConfigDispatchError {
+            return LoadedConfig(root: OpenClawConfigFile.loadDict(), source: .local)
+        }
+    }
+
+    @MainActor
     static func save(
         _ root: sending [String: Any],
+        source: SaveSource,
         allowGatewayAuthMutation: Bool = false) async throws
     {
         let overrides = await self.overrideStore.overrides
         if await self.isRemoteMode() {
+            guard case let .gateway(baseHash, route) = source else {
+                throw NSError(domain: "ConfigStore", code: 6, userInfo: [
+                    NSLocalizedDescriptionKey: "Gateway config must be loaded before saving it.",
+                ])
+            }
             do {
                 if let override = overrides.saveRemote {
                     try await override(root)
                 } else {
-                    try await self.saveToGateway(root)
+                    try await self.saveToGateway(
+                        root,
+                        baseHash: baseHash,
+                        ifCurrentRoute: route)
                 }
             } catch {
-                if !self.shouldFallbackToLocalWrite(afterGatewaySaveError: error) {
-                    self.lastHash = nil
-                }
                 throw error
             }
         } else {
-            if let override = overrides.saveLocal {
-                override(root)
-            } else {
-                do {
-                    try await self.saveToGateway(root)
-                } catch {
-                    guard self.shouldFallbackToLocalWrite(afterGatewaySaveError: error) else {
-                        self.lastHash = nil
-                        throw error
-                    }
-                    guard OpenClawConfigFile.saveDict(
-                        root,
-                        preserveExistingKeys: true,
-                        allowGatewayAuthMutation: allowGatewayAuthMutation)
-                    else {
-                        throw NSError(domain: "ConfigStore", code: 2, userInfo: [
-                            NSLocalizedDescriptionKey: "Local config write rejected to protect gateway auth/mode.",
-                        ])
-                    }
-                }
+            switch source {
+            case let .gateway(baseHash, route):
+                try await self.saveToGateway(root, baseHash: baseHash, ifCurrentRoute: route)
+            case .local:
+                try self.saveLocally(
+                    root,
+                    overrides: overrides,
+                    allowGatewayAuthMutation: allowGatewayAuthMutation)
             }
         }
-        #if DEBUG
-        let notificationCenter = overrides.notificationCenter ?? .default
-        #else
-        let notificationCenter = NotificationCenter.default
-        #endif
-        notificationCenter.post(name: .openclawConfigDidChange, object: nil)
+        self.postChangeNotification(overrides: overrides)
     }
 
     @MainActor
-    private static func loadFromGateway() async -> [String: Any]? {
+    static func setBrowserEnabled(_ enabled: Bool) async throws {
+        let overrides = await self.overrideStore.overrides
+        let startedRemote = await self.isRemoteMode()
         do {
-            let snap: ConfigSnapshot = try await GatewayConnection.shared.requestDecoded(
+            let route: GatewayConnection.Route? = if overrides.loadGatewayRevision != nil,
+                                                     overrides.writeGateway != nil
+            {
+                nil
+            } else {
+                try await GatewayConnection.shared.captureRequiredRoute()
+            }
+            try await self.requireConnectionMode(startedRemote)
+            var retriesRemaining = 1
+            while true {
+                do {
+                    let revision = try await self.loadGatewayRevision(overrides: overrides, ifCurrentRoute: route)
+                    let patch = ["browser": ["enabled": enabled]]
+                    let root: [String: Any]
+                    let method: GatewayConnection.Method
+                    let baseHash: String?
+                    let supportsPatch: Bool?
+                    if revision.exists {
+                        guard let revisionHash = revision.hash?.nonEmpty else {
+                            throw NSError(domain: "ConfigStore", code: 3, userInfo: [
+                                NSLocalizedDescriptionKey: "Gateway config read did not return a revision.",
+                            ])
+                        }
+                        supportsPatch = await self.supportsGatewayMethod(
+                            .configPatch,
+                            overrides: overrides,
+                            route: route)
+                        if supportsPatch == false {
+                            guard revision.valid != false, var completeRoot = revision.root else {
+                                throw NSError(domain: "ConfigStore", code: 4, userInfo: [
+                                    NSLocalizedDescriptionKey: "Gateway config read did not return " +
+                                        "a valid complete config.",
+                                ])
+                            }
+                            var browser = completeRoot["browser"] as? [String: Any] ?? [:]
+                            browser["enabled"] = enabled
+                            completeRoot["browser"] = browser
+                            root = completeRoot
+                            method = .configSet
+                        } else {
+                            root = patch
+                            method = .configPatch
+                        }
+                        baseHash = revisionHash
+                    } else {
+                        supportsPatch = nil
+                        root = patch
+                        method = .configSet
+                        baseHash = nil
+                    }
+                    do {
+                        _ = try await self.writeGateway(
+                            root,
+                            method: method,
+                            overrides: overrides,
+                            baseHash: baseHash,
+                            ifCurrentRoute: route)
+                    } catch {
+                        guard supportsPatch == nil,
+                              method == .configPatch,
+                              self.isUnsupportedConfigPatchError(error)
+                        else {
+                            throw error
+                        }
+                        let fallback = try await self.loadGatewayRevision(
+                            overrides: overrides,
+                            ifCurrentRoute: route)
+                        guard fallback.exists,
+                              let fallbackHash = fallback.hash?.nonEmpty,
+                              fallback.valid != false,
+                              var completeRoot = fallback.root
+                        else {
+                            throw error
+                        }
+                        var browser = completeRoot["browser"] as? [String: Any] ?? [:]
+                        browser["enabled"] = enabled
+                        completeRoot["browser"] = browser
+                        _ = try await self.writeGateway(
+                            completeRoot,
+                            method: .configSet,
+                            overrides: overrides,
+                            baseHash: fallbackHash,
+                            ifCurrentRoute: route)
+                    }
+                    // Full-root saves carry their own revision, so this partial patch cannot
+                    // authorize a root loaded before or after it.
+                    self.postChangeNotification(overrides: overrides)
+                    return
+                } catch {
+                    guard retriesRemaining > 0, self.isStaleConfigWriteError(error) else { throw error }
+                    retriesRemaining -= 1
+                }
+            }
+        } catch {
+            let currentlyRemote = await self.isRemoteMode()
+            guard !startedRemote,
+                  !currentlyRemote,
+                  self.shouldFallbackBrowserWriteToLocal(afterGatewayError: error)
+            else {
+                throw error
+            }
+            try self.saveBrowserLocally(enabled, overrides: overrides)
+            self.postChangeNotification(overrides: overrides)
+        }
+    }
+
+    @MainActor
+    static func readBrowserEnabled() async throws -> Bool {
+        let overrides = await self.overrideStore.overrides
+        if let loadGatewayBrowserEnabled = overrides.loadGatewayBrowserEnabled {
+            return try await loadGatewayBrowserEnabled()
+        }
+        let snapshot: ConfigSnapshot = try await GatewayConnection.shared.requestDecoded(
+            method: .configGet,
+            params: nil,
+            timeoutMs: 8000)
+        return snapshot.config?["browser"]?.dictionaryValue?["enabled"]?.boolValue ?? true
+    }
+
+    @MainActor
+    private static func loadFromGateway(overrides: Overrides? = nil) async throws -> LoadedConfig {
+        let snapshot: ConfigSnapshot
+        let source: SaveSource
+        if let loadGatewayRevision = overrides?.loadGatewayRevision {
+            let revision: (exists: Bool, hash: String?, valid: Bool?, root: [String: Any]?)
+            do {
+                revision = try await loadGatewayRevision()
+            } catch {
+                guard self.shouldAllowLocalMutationFallback(afterPreDispatchError: error) else { throw error }
+                throw GatewayUnavailableBeforeConfigDispatchError(underlying: error)
+            }
+            snapshot = ConfigSnapshot(
+                path: nil,
+                exists: revision.exists,
+                raw: nil,
+                hash: revision.hash,
+                parsed: nil,
+                valid: revision.valid,
+                config: revision.root?.mapValues(AnyCodable.init),
+                issues: nil)
+            source = .gateway(baseHash: revision.hash?.nonEmpty, route: nil)
+        } else {
+            let route: GatewayConnection.Route
+            do {
+                route = try await GatewayConnection.shared.captureRequiredRoute()
+            } catch {
+                guard self.shouldAllowLocalMutationFallback(afterPreDispatchError: error) else { throw error }
+                throw GatewayUnavailableBeforeConfigDispatchError(underlying: error)
+            }
+            snapshot = try await GatewayConnection.shared.requestDecoded(
                 method: .configGet,
                 params: nil,
-                timeoutMs: 8000)
-            self.lastHash = snap.hash
-            return snap.config?.mapValues { $0.foundationValue } ?? [:]
-        } catch {
-            return nil
+                timeoutMs: 8000,
+                ifCurrentRoute: route)
+            source = .gateway(baseHash: snapshot.hash?.nonEmpty, route: route)
         }
+        let exists = snapshot.exists ?? true
+        guard !exists || snapshot.hash?.nonEmpty != nil else {
+            throw NSError(domain: "ConfigStore", code: 7, userInfo: [
+                NSLocalizedDescriptionKey: "Gateway config read did not return a revision.",
+            ])
+        }
+        guard snapshot.valid != false, !exists || snapshot.config != nil else {
+            throw NSError(domain: "ConfigStore", code: 8, userInfo: [
+                NSLocalizedDescriptionKey: "Gateway config read did not return a valid complete config.",
+            ])
+        }
+        return LoadedConfig(
+            root: snapshot.config?.mapValues { $0.foundationValue } ?? [:],
+            source: source)
+    }
+
+    private struct GatewayUnavailableBeforeConfigDispatchError: LocalizedError {
+        let underlying: Error
+
+        var errorDescription: String? {
+            self.underlying.localizedDescription
+        }
+    }
+
+    private static func shouldAllowLocalMutationFallback(afterPreDispatchError error: Error) -> Bool {
+        guard !(error is CancellationError),
+              !(error is GatewayRouteChangedAfterDispatchError),
+              !(error is GatewayResponseError),
+              !(error is GatewayDecodingError),
+              (error as NSError).domain != "ConfigStore"
+        else {
+            return false
+        }
+        if let urlError = error as? URLError {
+            return [
+                .cannotFindHost,
+                .cannotConnectToHost,
+                .networkConnectionLost,
+                .notConnectedToInternet,
+                .timedOut,
+                .dnsLookupFailed,
+                .resourceUnavailable,
+            ].contains(urlError.code)
+        }
+        let nsError = error as NSError
+        return nsError.domain == "GatewayEndpoint" && nsError.code == 1 &&
+            self.shouldFallbackToLocalWrite(afterGatewaySaveError: error)
     }
 
     private static func shouldFallbackToLocalWrite(afterGatewaySaveError error: Error) -> Bool {
@@ -137,15 +356,87 @@ enum ConfigStore {
         return !blockedFragments.contains { message.contains($0) }
     }
 
-    @MainActor
-    private static func saveToGateway(_ root: [String: Any]) async throws {
-        let overrides = await self.overrideStore.overrides
-        if let saveGateway = overrides.saveGateway {
-            try await saveGateway(root)
-            return
+    private static func shouldFallbackBrowserWriteToLocal(afterGatewayError error: Error) -> Bool {
+        guard !(error is CancellationError),
+              !(error is GatewayRouteChangedAfterDispatchError),
+              !(error is GatewayResponseError),
+              !(error is GatewayDecodingError),
+              (error as NSError).domain != "ConfigStore"
+        else {
+            return false
         }
-        if self.lastHash == nil {
-            _ = await self.loadFromGateway()
+        return self.shouldFallbackToLocalWrite(afterGatewaySaveError: error)
+    }
+
+    private static func isStaleConfigWriteError(_ error: Error) -> Bool {
+        let message = (error as NSError).localizedDescription.lowercased()
+        return message.contains("config changed since last load") ||
+            message.contains("config base hash required")
+    }
+
+    private static func isUnsupportedConfigPatchError(_ error: Error) -> Bool {
+        guard let response = error as? GatewayResponseError else { return false }
+        return response.method == GatewayConnection.Method.configPatch.rawValue &&
+            response.code == "INVALID_REQUEST" &&
+            response.message == "unknown method: config.patch"
+    }
+
+    private static func requireConnectionMode(_ expectedRemote: Bool) async throws {
+        guard await self.isRemoteMode() == expectedRemote else {
+            throw NSError(domain: "ConfigStore", code: 5, userInfo: [
+                NSLocalizedDescriptionKey: "Gateway connection mode changed before the config write.",
+            ])
+        }
+    }
+
+    @MainActor
+    private static func loadGatewayRevision(
+        overrides: Overrides,
+        ifCurrentRoute route: GatewayConnection.Route?) async throws -> (
+        exists: Bool,
+        hash: String?,
+        valid: Bool?,
+        root: [String: Any]?)
+    {
+        if let loadGatewayRevision = overrides.loadGatewayRevision {
+            return try await loadGatewayRevision()
+        }
+        guard let route else { preconditionFailure("Gateway route required") }
+        let snapshot: ConfigSnapshot = try await GatewayConnection.shared.requestDecoded(
+            method: .configGet,
+            params: nil,
+            timeoutMs: 8000,
+            ifCurrentRoute: route)
+        return (
+            snapshot.exists ?? true,
+            snapshot.hash,
+            snapshot.valid,
+            snapshot.config?.mapValues { $0.foundationValue })
+    }
+
+    @MainActor
+    private static func supportsGatewayMethod(
+        _ method: GatewayConnection.Method,
+        overrides: Overrides,
+        route: GatewayConnection.Route?) async -> Bool?
+    {
+        if let supportsGatewayMethod = overrides.supportsGatewayMethod {
+            return supportsGatewayMethod(method.rawValue)
+        }
+        guard let route else { return nil }
+        return await GatewayConnection.shared.supportsServerMethod(method.rawValue, ifCurrentRoute: route)
+    }
+
+    @MainActor
+    private static func writeGateway(
+        _ root: [String: Any],
+        method: GatewayConnection.Method,
+        overrides: Overrides,
+        baseHash: String? = nil,
+        ifCurrentRoute route: GatewayConnection.Route? = nil) async throws -> String?
+    {
+        if let writeGateway = overrides.writeGateway {
+            return try await writeGateway(method.rawValue, root, baseHash)
         }
         let data = try JSONSerialization.data(withJSONObject: root, options: [.prettyPrinted, .sortedKeys])
         guard let raw = String(data: data, encoding: .utf8) else {
@@ -154,17 +445,87 @@ enum ConfigStore {
             ])
         }
         var params: [String: AnyCodable] = ["raw": AnyCodable(raw)]
-        if let baseHash = self.lastHash {
+        if let baseHash {
             params["baseHash"] = AnyCodable(baseHash)
         }
-        let ack: ConfigWriteAck = try await GatewayConnection.shared.requestDecoded(
-            method: .configSet,
-            params: params,
-            timeoutMs: 10000)
-        if let hash = ack.hash, !hash.isEmpty {
-            self.lastHash = hash
+        let ack: ConfigWriteAck = if let route {
+            try await GatewayConnection.shared.requestDecoded(
+                method: method,
+                params: params,
+                timeoutMs: 10000,
+                ifCurrentRoute: route)
+        } else {
+            try await GatewayConnection.shared.requestDecoded(
+                method: method,
+                params: params,
+                timeoutMs: 10000)
         }
-        _ = await self.loadFromGateway()
+        return ack.hash
+    }
+
+    @MainActor
+    private static func saveBrowserLocally(_ enabled: Bool, overrides: Overrides) throws {
+        var root = overrides.loadLocal?() ?? OpenClawConfigFile.loadDict()
+        var browser = root["browser"] as? [String: Any] ?? [:]
+        browser["enabled"] = enabled
+        root["browser"] = browser
+        if let saveLocal = overrides.saveLocal {
+            saveLocal(root)
+        } else if !OpenClawConfigFile.saveDict(root, preserveExistingKeys: true) {
+            throw NSError(domain: "ConfigStore", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "Local config write rejected to protect gateway auth/mode.",
+            ])
+        }
+    }
+
+    @MainActor
+    private static func saveLocally(
+        _ root: [String: Any],
+        overrides: Overrides,
+        allowGatewayAuthMutation: Bool) throws
+    {
+        if let saveLocal = overrides.saveLocal {
+            saveLocal(root)
+        } else if !OpenClawConfigFile.saveDict(
+            root,
+            preserveExistingKeys: true,
+            allowGatewayAuthMutation: allowGatewayAuthMutation)
+        {
+            throw NSError(domain: "ConfigStore", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "Local config write rejected to protect gateway auth/mode.",
+            ])
+        }
+    }
+
+    private static func postChangeNotification(overrides: Overrides) {
+        #if DEBUG
+        let notificationCenter = overrides.notificationCenter ?? .default
+        #else
+        let notificationCenter = NotificationCenter.default
+        #endif
+        notificationCenter.post(name: .openclawConfigDidChange, object: nil)
+    }
+
+    @MainActor
+    private static func saveToGateway(
+        _ root: [String: Any],
+        baseHash: String?,
+        ifCurrentRoute route: GatewayConnection.Route?) async throws
+    {
+        let overrides = await self.overrideStore.overrides
+        if let saveGateway = overrides.saveGateway {
+            try await saveGateway(root)
+            return
+        }
+        if route == nil, overrides.writeGateway == nil {
+            preconditionFailure("Gateway route required")
+        }
+        _ = try await self.writeGateway(
+            root,
+            method: .configSet,
+            overrides: overrides,
+            baseHash: baseHash,
+            ifCurrentRoute: route)
     }
 
     #if DEBUG
@@ -176,15 +537,6 @@ enum ConfigStore {
         await self.overrideStore.setOverride(.init())
     }
 
-    @MainActor
-    static func _testSetLastHash(_ hash: String?) {
-        self.lastHash = hash
-    }
-
-    @MainActor
-    static func _testLastHash() -> String? {
-        self.lastHash
-    }
     #endif
 }
 

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -864,6 +864,16 @@ extension GatewayConnection {
 
     func supportsServerMethod(
         _ method: String,
+        ifCurrentRoute route: Route) async -> Bool?
+    {
+        guard let endpoint = try? await currentEndpoint(),
+              self.routeMatchesCurrentState(route, endpoint: endpoint)
+        else { return nil }
+        return self.lastSnapshot?.advertisedServerMethods()?.contains(method)
+    }
+
+    func supportsServerMethod(
+        _ method: String,
         ifCurrentServerLease lease: ServerLease) async -> Bool?
     {
         guard await self.isCurrentServerLease(lease),

--- a/apps/macos/Sources/OpenClaw/StatusMenuHeaderView.swift
+++ b/apps/macos/Sources/OpenClaw/StatusMenuHeaderView.swift
@@ -10,6 +10,7 @@ struct StatusMenuHeaderView: View {
     @Bindable private var devicePairingPrompter = DevicePairingApprovalPrompter.shared
     @AppStorage(cameraEnabledKey, store: AppDefaults.standard) private var cameraEnabled = false
     @State private var browserEnabled = true
+    @State private var browserWriteInFlight = false
 
     private let isSleeping: Bool
     private let controlChannel = ControlChannel.shared
@@ -105,11 +106,15 @@ struct StatusMenuHeaderView: View {
             self.capabilityButton(
                 title: String(localized: "Browser"),
                 symbol: "globe",
-                enabled: self.browserEnabled)
+                enabled: self.browserEnabled,
+                interactive: !self.browserWriteInFlight)
             {
+                guard !self.browserWriteInFlight else { return }
+                self.browserWriteInFlight = true
+                let previousEnabled = self.browserEnabled
                 let enabled = !self.browserEnabled
                 self.browserEnabled = enabled
-                Task { await self.saveBrowserEnabled(enabled) }
+                Task { await self.saveBrowserEnabled(enabled, previousEnabled: previousEnabled) }
             }
 
             self.capabilityButton(
@@ -148,6 +153,7 @@ struct StatusMenuHeaderView: View {
         title: String,
         symbol: String,
         enabled: Bool,
+        interactive: Bool = true,
         action: @escaping () -> Void) -> some View
     {
         Button(action: action) {
@@ -166,6 +172,8 @@ struct StatusMenuHeaderView: View {
                 in: RoundedRectangle(cornerRadius: 7, style: .continuous))
         }
         .buttonStyle(.plain)
+        .disabled(!interactive)
+        .opacity(interactive ? 1 : 0.55)
         .accessibilityLabel(title)
         .accessibilityValue(enabled ? String(localized: "On") : String(localized: "Off"))
     }
@@ -314,15 +322,12 @@ struct StatusMenuHeaderView: View {
         self.browserEnabled = browser?["enabled"] as? Bool ?? true
     }
 
-    private func saveBrowserEnabled(_ enabled: Bool) async {
-        var config = await ConfigStore.load()
-        var browser = config["browser"] as? [String: Any] ?? [:]
-        browser["enabled"] = enabled
-        config["browser"] = browser
+    private func saveBrowserEnabled(_ enabled: Bool, previousEnabled: Bool) async {
+        defer { self.browserWriteInFlight = false }
         do {
-            try await ConfigStore.save(config)
+            try await ConfigStore.setBrowserEnabled(enabled)
         } catch {
-            await self.loadBrowserEnabled()
+            self.browserEnabled = await (try? ConfigStore.readBrowserEnabled()) ?? previousEnabled
         }
     }
 }

--- a/apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift
+++ b/apps/macos/Sources/OpenClaw/TailscaleIntegrationSection.swift
@@ -321,10 +321,13 @@ struct TailscaleIntegrationSection: View {
             mode: tailscaleMode,
             requireCredentialsForServe: requireCredentialsForServe,
             password: password)
-        let root = await self.buildTailscaleConfigRoot(root: ConfigStore.load(), settings: settings)
-
         do {
-            try await ConfigStore.save(root, allowGatewayAuthMutation: true)
+            let loaded = try await ConfigStore.loadForMutation()
+            let root = self.buildTailscaleConfigRoot(root: loaded.root, settings: settings)
+            try await ConfigStore.save(
+                root,
+                source: loaded.source,
+                allowGatewayAuthMutation: true)
             return (true, nil)
         } catch {
             return (false, error.localizedDescription)

--- a/apps/macos/Tests/OpenClawIPCTests/ConfigStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ConfigStoreTests.swift
@@ -1,4 +1,6 @@
 import Foundation
+import OpenClawKit
+import Synchronization
 import Testing
 @testable import OpenClaw
 
@@ -69,7 +71,7 @@ struct ConfigStoreTests {
             },
             notificationCenter: notificationCenter))
         {
-            try await ConfigStore.save(["remote": true])
+            try await ConfigStore.save(["remote": true], source: .gateway(baseHash: "revision-1", route: nil))
         }
 
         #expect(remoteHit)
@@ -86,7 +88,7 @@ struct ConfigStoreTests {
             saveLocal: { _ in localHit = true },
             saveRemote: { _ in remoteHit = true }))
 
-        try await ConfigStore.save(["local": true])
+        try await ConfigStore.save(["local": true], source: .local)
 
         await ConfigStore._testClearOverrides()
         #expect(localHit)
@@ -115,7 +117,7 @@ struct ConfigStoreTests {
             notificationCenter: notificationCenter))
         {
             do {
-                try await ConfigStore.save(["remote": true])
+                try await ConfigStore.save(["remote": true], source: .gateway(baseHash: "revision-1", route: nil))
                 Issue.record("Expected save to fail")
             } catch {}
         }
@@ -123,22 +125,412 @@ struct ConfigStoreTests {
         #expect(changeCount.value == 0)
     }
 
-    @Test func `remote stale-base rejection clears the cached revision`() async {
-        ConfigStore._testSetLastHash("legacy-raw-hash")
-        await self.withOverrides(.init(
+    @Test func `browser update patches only its field and retries a stale revision`() async throws {
+        var revisions = ["revision-1", "revision-2"]
+        var patches: [([String: Any], String?)] = []
+
+        try await self.withOverrides(.init(
             isRemoteMode: { true },
-            saveRemote: { _ in
+            loadGatewayRevision: { (true, revisions.removeFirst(), true, nil) },
+            writeGateway: { method, patch, baseHash in
+                #expect(method == "config.patch")
+                patches.append((patch, baseHash))
+                if patches.count == 1 {
+                    throw NSError(domain: "Gateway", code: 0, userInfo: [
+                        NSLocalizedDescriptionKey: "config changed since last load; re-run config.get and retry",
+                    ])
+                }
+                return "revision-3"
+            })) {
+                try await ConfigStore.setBrowserEnabled(false)
+            }
+
+        #expect(revisions.isEmpty)
+        #expect(patches.map(\.1) == ["revision-1", "revision-2"])
+        #expect(patches.allSatisfy {
+            let browser = $0.0["browser"] as? [String: Any]
+            return $0.0.count == 1 && browser?.count == 1 && browser?["enabled"] as? Bool == false
+        })
+    }
+
+    @Test func `full-root save uses the revision loaded with that root after a browser patch`() async throws {
+        var writes: [(String, String?)] = []
+        let channels = ChannelsStore(isPreview: true)
+        channels.configSourceKey = "gateway"
+        let previousAccent = AppStateStore.shared.seamColorHex
+        defer { AppStateStore.shared.seamColorHex = previousAccent }
+
+        try await self.withOverrides(.init(
+            isRemoteMode: { true },
+            loadGatewayRevision: { (true, "revision-1", true, ["browser": ["enabled": true]]) },
+            writeGateway: { method, _, baseHash in
+                writes.append((method, baseHash))
+                return method == "config.patch" ? "revision-2" : "revision-3"
+            })) {
+                try await ConfigStore.setBrowserEnabled(false)
+                channels.applyConfigSnapshot(
+                    ConfigSnapshot(
+                        path: nil,
+                        exists: true,
+                        raw: nil,
+                        hash: "revision-2",
+                        parsed: nil,
+                        valid: true,
+                        config: [
+                            "browser": AnyCodable(["enabled": false]),
+                            "channels": AnyCodable(["discord": ["enabled": true]]),
+                        ],
+                        issues: nil),
+                    sourceKey: "gateway",
+                    force: true,
+                    saveSource: .gateway(baseHash: "revision-2", route: nil))
+                guard let source = channels.configSaveSource else {
+                    Issue.record("Expected Channels to retain its loaded revision")
+                    return
+                }
+                try await ConfigStore.save(channels.configDraft, source: source)
+            }
+
+        #expect(writes.map(\.0) == ["config.patch", "config.set"])
+        #expect(writes.map(\.1) == ["revision-1", "revision-2"])
+    }
+
+    @Test func `channels cannot save an incomplete existing snapshot`() {
+        let channels = ChannelsStore(isPreview: true)
+        channels.configSourceKey = "gateway"
+
+        channels.applyConfigSnapshot(
+            ConfigSnapshot(
+                path: nil,
+                exists: true,
+                raw: nil,
+                hash: "revision-1",
+                parsed: nil,
+                valid: true,
+                config: nil,
+                issues: nil),
+            sourceKey: "gateway",
+            force: true,
+            saveSource: .gateway(baseHash: "revision-1", route: nil))
+
+        #expect(channels.configSaveSource == nil)
+    }
+
+    @Test func `mutation load carries its gateway revision with the complete root`() async throws {
+        let loaded = try await self.withOverrides(.init(
+            isRemoteMode: { true },
+            loadGatewayRevision: {
+                (true, "revision-7", true, ["unrelated": "kept"])
+            })) {
+                try await ConfigStore.loadForMutation()
+            }
+
+        #expect(loaded.root["unrelated"] as? String == "kept")
+        guard case let .gateway(baseHash, _) = loaded.source else {
+            Issue.record("Expected a Gateway mutation source")
+            return
+        }
+        #expect(baseHash == "revision-7")
+    }
+
+    @Test func `failed remote mutation load produces no writable root`() async {
+        var didThrow = false
+        _ = await self.withOverrides(.init(
+            isRemoteMode: { true },
+            loadGatewayRevision: {
                 throw NSError(domain: "Gateway", code: 0, userInfo: [
-                    NSLocalizedDescriptionKey: "config changed since last load; re-run config.get and retry",
+                    NSLocalizedDescriptionKey: "gateway unavailable",
                 ])
             })) {
                 do {
-                    try await ConfigStore.save(["browser": ["enabled": false]])
-                    Issue.record("Expected save to fail")
-                } catch {}
+                    _ = try await ConfigStore.loadForMutation()
+                    Issue.record("Expected mutation load to fail")
+                } catch {
+                    didThrow = true
+                }
+            }
+        #expect(didThrow)
+    }
+
+    @Test func `local mutation load does not fall back after a protocol failure`() async {
+        var attemptedLocalWrite = false
+
+        _ = await self.withOverrides(.init(
+            isRemoteMode: { false },
+            saveLocal: { _ in attemptedLocalWrite = true },
+            loadGatewayRevision: {
+                throw GatewayDecodingError(method: "config.get", message: "invalid snapshot")
+            })) {
+                await #expect(throws: GatewayDecodingError.self) {
+                    _ = try await ConfigStore.loadForMutation()
+                }
             }
 
-        #expect(ConfigStore._testLastHash() == nil)
+        #expect(!attemptedLocalWrite)
+    }
+
+    @Test func `browser update preserves a fresh full root when config patch is unavailable`() async throws {
+        var revisions = [
+            ("revision-1", ["unrelated": "first", "browser": ["other": "old"]] as [String: Any]),
+            ("revision-2", ["unrelated": "second", "browser": ["other": "kept"]] as [String: Any]),
+        ]
+        var writtenRoot: [String: Any]?
+        var writes = 0
+
+        try await self.withOverrides(.init(
+            isRemoteMode: { true },
+            loadGatewayRevision: {
+                let revision = revisions.removeFirst()
+                return (true, revision.0, true, revision.1)
+            },
+            supportsGatewayMethod: { method in
+                #expect(method == "config.patch")
+                return false
+            },
+            writeGateway: { method, root, baseHash in
+                #expect(method == "config.set")
+                writes += 1
+                writtenRoot = root
+                if writes == 1 {
+                    #expect(baseHash == "revision-1")
+                    throw NSError(domain: "Gateway", code: 0, userInfo: [
+                        NSLocalizedDescriptionKey: "config changed since last load; re-run config.get and retry",
+                    ])
+                }
+                #expect(baseHash == "revision-2")
+                return "revision-2"
+            })) {
+                try await ConfigStore.setBrowserEnabled(false)
+            }
+
+        #expect(revisions.isEmpty)
+        #expect(writes == 2)
+        let browser = writtenRoot?["browser"] as? [String: Any]
+        #expect(writtenRoot?["unrelated"] as? String == "second")
+        #expect(browser?["other"] as? String == "kept")
+        #expect(browser?["enabled"] as? Bool == false)
+    }
+
+    @Test func `browser update falls back after a definitive unsupported patch response`() async throws {
+        var revisions = [
+            ("revision-1", ["unrelated": "first"] as [String: Any]),
+            ("revision-2", ["unrelated": "kept", "browser": ["other": "kept"]] as [String: Any]),
+        ]
+        var writes: [(String, [String: Any], String?)] = []
+
+        try await self.withOverrides(.init(
+            isRemoteMode: { true },
+            loadGatewayRevision: {
+                let revision = revisions.removeFirst()
+                return (true, revision.0, true, revision.1)
+            },
+            supportsGatewayMethod: { _ in nil },
+            writeGateway: { method, root, baseHash in
+                writes.append((method, root, baseHash))
+                if method == "config.patch" {
+                    throw GatewayResponseError(
+                        method: method,
+                        code: "INVALID_REQUEST",
+                        message: "unknown method: config.patch",
+                        details: nil)
+                }
+                return "revision-3"
+            })) {
+                try await ConfigStore.setBrowserEnabled(false)
+            }
+
+        #expect(revisions.isEmpty)
+        #expect(writes.map(\.0) == ["config.patch", "config.set"])
+        #expect(writes.map(\.2) == ["revision-1", "revision-2"])
+        let browser = writes.last?.1["browser"] as? [String: Any]
+        #expect(writes.last?.1["unrelated"] as? String == "kept")
+        #expect(browser?["other"] as? String == "kept")
+        #expect(browser?["enabled"] as? Bool == false)
+    }
+
+    @Test func `browser update refuses incomplete full roots without config patch`() async {
+        let incompleteSnapshots: [(Bool?, [String: Any]?)] = [
+            (false, [:]),
+            (true, nil),
+        ]
+
+        for snapshot in incompleteSnapshots {
+            var attemptedWrite = false
+            _ = await self.withOverrides(.init(
+                isRemoteMode: { true },
+                loadGatewayRevision: { (true, "revision-1", snapshot.0, snapshot.1) },
+                supportsGatewayMethod: { _ in false },
+                writeGateway: { _, _, _ in
+                    attemptedWrite = true
+                    return nil
+                })) {
+                    await #expect(throws: NSError.self) {
+                        try await ConfigStore.setBrowserEnabled(false)
+                    }
+                }
+            #expect(!attemptedWrite)
+        }
+    }
+
+    @Test func `failed remote browser read cannot fall back after a mode switch`() async {
+        let remoteModes = Mutex([true, true, false])
+        var attemptedWrite = false
+        var attemptedLocalWrite = false
+
+        _ = await self.withOverrides(.init(
+            isRemoteMode: { remoteModes.withLock { $0.removeFirst() } },
+            saveLocal: { _ in attemptedLocalWrite = true },
+            loadGatewayRevision: {
+                throw CancellationError()
+            },
+            writeGateway: { _, _, _ in
+                attemptedWrite = true
+                return nil
+            })) {
+                await #expect(throws: NSError.self) {
+                    try await ConfigStore.setBrowserEnabled(false)
+                }
+            }
+
+        #expect(!attemptedWrite)
+        #expect(!attemptedLocalWrite)
+    }
+
+    @Test func `route-cancelled local browser update cannot fall back to disk`() async {
+        var attemptedLocalWrite = false
+
+        _ = await self.withOverrides(.init(
+            isRemoteMode: { false },
+            saveLocal: { _ in attemptedLocalWrite = true },
+            loadGatewayRevision: {
+                throw CancellationError()
+            },
+            writeGateway: { _, _, _ in nil }))
+        {
+            await #expect(throws: CancellationError.self) {
+                try await ConfigStore.setBrowserEnabled(false)
+            }
+        }
+
+        #expect(!attemptedLocalWrite)
+    }
+
+    @Test func `post-dispatch route change cannot fall back to disk`() async {
+        var attemptedLocalWrite = false
+
+        _ = await self.withOverrides(.init(
+            isRemoteMode: { false },
+            saveLocal: { _ in attemptedLocalWrite = true },
+            loadGatewayRevision: {
+                throw GatewayRouteChangedAfterDispatchError(method: "config.get")
+            },
+            writeGateway: { _, _, _ in nil }))
+        {
+            await #expect(throws: GatewayRouteChangedAfterDispatchError.self) {
+                try await ConfigStore.setBrowserEnabled(false)
+            }
+        }
+
+        #expect(!attemptedLocalWrite)
+    }
+
+    @Test func `invalid local gateway snapshots cannot fall back to disk`() async {
+        let snapshots: [(Bool, String?, Bool?, [String: Any]?)] = [
+            (true, nil, true, [:]),
+            (true, "revision-1", false, [:]),
+            (true, "revision-1", true, nil),
+        ]
+
+        for snapshot in snapshots {
+            var attemptedGatewayWrite = false
+            var attemptedLocalWrite = false
+            _ = await self.withOverrides(.init(
+                isRemoteMode: { false },
+                saveLocal: { _ in attemptedLocalWrite = true },
+                loadGatewayRevision: { snapshot },
+                supportsGatewayMethod: { _ in false },
+                writeGateway: { _, _, _ in
+                    attemptedGatewayWrite = true
+                    return nil
+                })) {
+                    await #expect(throws: NSError.self) {
+                        try await ConfigStore.setBrowserEnabled(false)
+                    }
+                }
+
+            #expect(!attemptedGatewayWrite)
+            #expect(!attemptedLocalWrite)
+        }
+    }
+
+    @Test func `browser update stops when connection mode changes before its read`() async {
+        let remoteModes = Mutex([true, false, false])
+        var attemptedRead = false
+        var attemptedWrite = false
+
+        _ = await self.withOverrides(.init(
+            isRemoteMode: { remoteModes.withLock { $0.removeFirst() } },
+            loadGatewayRevision: {
+                attemptedRead = true
+                return (true, "revision-1", true, [:])
+            },
+            writeGateway: { _, _, _ in
+                attemptedWrite = true
+                return nil
+            })) {
+                await #expect(throws: NSError.self) {
+                    try await ConfigStore.setBrowserEnabled(false)
+                }
+            }
+
+        #expect(!attemptedRead)
+        #expect(!attemptedWrite)
+    }
+
+    @Test func `browser update creates only browser config when no config exists`() async throws {
+        var created: [String: Any]?
+
+        try await self.withOverrides(.init(
+            isRemoteMode: { true },
+            loadGatewayRevision: { (false, nil, nil, nil) },
+            writeGateway: { method, root, baseHash in
+                #expect(method == "config.set")
+                #expect(baseHash == nil)
+                created = root
+                return "created-revision"
+            })) {
+                try await ConfigStore.setBrowserEnabled(false)
+            }
+
+        let browser = created?["browser"] as? [String: Any]
+        #expect(created?.count == 1)
+        #expect(browser?.count == 1)
+        #expect(browser?["enabled"] as? Bool == false)
+    }
+
+    @Test func `local browser update falls back to a field-only file write`() async throws {
+        var writtenRoot: [String: Any]?
+
+        try await self.withOverrides(.init(
+            isRemoteMode: { false },
+            loadLocal: { ["unrelated": true, "browser": ["other": "kept"]] },
+            saveLocal: { writtenRoot = $0 },
+            loadGatewayRevision: {
+                throw NSError(domain: "Gateway", code: 0, userInfo: [
+                    NSLocalizedDescriptionKey: "gateway not configured",
+                ])
+            },
+            writeGateway: { _, _, _ in
+                Issue.record("Unexpected gateway write")
+                return nil
+            })) {
+                try await ConfigStore.setBrowserEnabled(false)
+            }
+
+        let browser = writtenRoot?["browser"] as? [String: Any]
+        #expect(writtenRoot?["unrelated"] as? Bool == true)
+        #expect(browser?["other"] as? String == "kept")
+        #expect(browser?["enabled"] as? Bool == false)
     }
 
     @Test func `local save does not fall back to direct write after stale gateway rejection`() async throws {
@@ -171,7 +563,9 @@ struct ConfigStoreTests {
 
             var didThrow = false
             do {
-                try await ConfigStore.save(["browser": ["enabled": false]])
+                try await ConfigStore.save(
+                    ["browser": ["enabled": false]],
+                    source: .gateway(baseHash: "revision-1", route: nil))
             } catch {
                 didThrow = true
             }
@@ -183,7 +577,7 @@ struct ConfigStoreTests {
         }
     }
 
-    @Test func `local save can fall back to protected direct write when gateway is unavailable`() async throws {
+    @Test func `local mutation load falls back before dispatch when gateway is unavailable`() async throws {
         let stateDir = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-state-\(UUID().uuidString)", isDirectory: true)
         let configPath = stateDir.appendingPathComponent("openclaw.json")
@@ -195,15 +589,18 @@ struct ConfigStoreTests {
         ]) {
             await ConfigStore._testSetOverrides(.init(
                 isRemoteMode: { false },
-                saveGateway: { _ in
-                    throw NSError(domain: "Gateway", code: 0, userInfo: [
+                loadGatewayRevision: {
+                    throw NSError(domain: "GatewayEndpoint", code: 1, userInfo: [
                         NSLocalizedDescriptionKey: "gateway not configured",
                     ])
                 }))
-            try await ConfigStore.save([
-                "gateway": ["mode": "local"],
-                "browser": ["enabled": false],
-            ])
+            let loaded = try await ConfigStore.loadForMutation()
+            try await ConfigStore.save(
+                [
+                    "gateway": ["mode": "local"],
+                    "browser": ["enabled": false],
+                ],
+                source: loaded.source)
             await ConfigStore._testClearOverrides()
 
             let data = try Data(contentsOf: configPath)


### PR DESCRIPTION
Fixes #127615

## What Problem This Solves

The macOS Browser Control toggle used a full-config read/modify/write. A failed or incomplete read could pair a sparse root with a current revision and replace unrelated settings.

## Solution

Browser Control now uses one narrow mutation path:

- bind the operation to its starting connection mode and physical Gateway route;
- read the current revision and send only `browser.enabled` through revision-guarded `config.patch`;
- retry once after a stale revision;
- create only the Browser subtree when no config exists;
- use a freshly read, complete, revision-bound root only when an older Gateway definitively does not support `config.patch`;
- preserve the local field-only fallback for eligible pre-dispatch connectivity failures;
- serialize clicks, fail closed on mode/route changes, and restore authoritative UI state after ambiguous failures.

The existing Channels and Tailscale full-root callers now carry the complete loaded root, its revision, and its physical Gateway route as one save source. Incomplete snapshots cannot authorize a save, and a Gateway read/write failure cannot fall through to a local full-root write.

## User impact

Toggling Browser Control changes only `browser.enabled`. Unrelated channel, model, plugin, Gateway, and workspace settings survive concurrent changes, route switches, old-Gateway compatibility fallback, and eligible local outages.

## Scope

- 1 commit
- 7 files
- +891 / -98 lines

The original branch was 20 commits across 8 files (+1,631 / -72), so this recut removes about 45% of the additions while retaining the caller-bound safety required by the shared full-root writers.

## Evidence

Exact head: `cecf5b5d76290313c032084126f658dd1d80a8c1`

- Focused macOS suites: 51/51 passed across ConfigStore, Channels, and Tailscale behavior.
- Gateway `config.patch` contract suite: 51/51 passed.
- macOS release build: passed.
- Repository-pinned SwiftFormat: clean on all 7 changed files.
- Strict SwiftLint: 0 violations.
- `git diff --check`: clean.
- Independent exact-commit review: P1 scoped-clean.
- Isolated native macOS/Gateway proof used the real production transport on disposable config/state. The Gateway trace was `config.get` → `config.patch`, reported `changedPaths=browser.enabled`, and preserved the Browser profile, Discord setting, Gateway settings, and workspace path. No production state or credentials were used.

The broader changed-surface gate previously reached the macOS packaging tail and exposed two pre-existing worker-fixture permission mismatches; those tests do not load the changed Swift files. Hosted CI on this exact head is the final integration gate.

### Owner acceptance card

- **Intended behavior:** a Browser toggle changes only `browser.enabled`, is revision guarded, and cannot cross its starting Gateway route or connection mode.
- **Boundary / blast radius:** six macOS production files and one focused test file; no public protocol, schema, Gateway runtime, dependency, lockfile, or generated-file change.
- **Strongest evidence:** 102 focused tests, exact-head release/lint/format gates, independent P1-clean review, and a real isolated native-client/Gateway trace showing only `browser.enabled` changed.
- **Known falsifiers:** any payload beyond `browser.enabled`; unrelated-setting drift; an incomplete snapshot authorizing a full-root save; cross-route dispatch; a Gateway failure reaching local full-root persistence; or failed persistence leaving an optimistic value displayed.
- **Rollback:** revert this single commit to restore the prior status-menu mutation path.
- **Reviewability:** the diff stays on one configuration-integrity boundary. The extra caller changes bind pre-existing full-root saves to the exact root, revision, and route that produced them.

AI-assisted contribution: Codex assisted with implementation, adversarial review, focused regression coverage, and isolated native proof.
