### PR TITLE
fix(docker): include lifecycle marker in install stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ Docs: https://docs.openclaw.ai
 ### Fixes
 
 - **Doctor recovery notes:** show interrupted auth-profile archive recovery failures and completions even when no further migration runs or another migration is declined. (#134009) Thanks @angeliti999.
+- **Docker source builds:** include the shared package lifecycle module before dependency installation so production and cleanup smoke images build with lifecycle checks enabled.
 - Matrix lifecycle: drain in-flight monitor tasks without deadlocking shared-client retirement, and reject late acquisitions after their owning task closes.
 - Provider error handling: reuse prepared or already loaded provider hooks instead of cold-loading plugins during error classification, avoiding long stalls in failure reporting and model fallback.
 - **Session settings:** restore merging of concurrent first writes after a startup optimization regressed lock ordering, preserving both global and project settings without adding filesystem side effects to missing-settings reads. Thanks @MrSwagatRathod, @obviyus, and @yetval for the original fix.

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,6 +79,7 @@ COPY patches ./patches
 COPY scripts/postinstall-bundled-plugins.mjs scripts/preinstall-package-manager-warning.mjs scripts/windows-cmd-helpers.mjs scripts/prepare-git-hooks.mjs ./scripts/
 COPY scripts/lib/guard-inventory-utils.mjs ./scripts/lib/guard-inventory-utils.mjs
 COPY scripts/lib/package-dist-imports.mjs ./scripts/lib/package-dist-imports.mjs
+COPY scripts/lib/package-lifecycle-marker.mjs ./scripts/lib/package-lifecycle-marker.mjs
 COPY scripts/docker/verify-native-addons.sh ./scripts/docker/verify-native-addons.sh
 
 COPY --from=workspace-deps /out/packages/ ./packages/

--- a/scripts/docker/cleanup-smoke/Dockerfile
+++ b/scripts/docker/cleanup-smoke/Dockerfile
@@ -23,6 +23,7 @@ COPY patches ./patches
 COPY scripts/postinstall-bundled-plugins.mjs scripts/preinstall-package-manager-warning.mjs scripts/prepare-git-hooks.mjs scripts/windows-cmd-helpers.mjs ./scripts/
 COPY scripts/lib/guard-inventory-utils.mjs ./scripts/lib/guard-inventory-utils.mjs
 COPY scripts/lib/package-dist-imports.mjs ./scripts/lib/package-dist-imports.mjs
+COPY scripts/lib/package-lifecycle-marker.mjs ./scripts/lib/package-lifecycle-marker.mjs
 RUN --mount=type=cache,id=openclaw-pnpm-store,target=/root/.local/share/pnpm/store,sharing=locked \
   corepack enable \
   && if ! pnpm install --frozen-lockfile >/tmp/openclaw-cleanup-pnpm-install.log 2>&1; then \

--- a/src/dockerfile.test.ts
+++ b/src/dockerfile.test.ts
@@ -2,7 +2,7 @@
 import { execFileSync } from "node:child_process";
 import { access, cp, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { BUNDLED_PLUGIN_ROOT_DIR } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
@@ -298,35 +298,75 @@ describe("Dockerfile", () => {
     expect(dockerfile).toContain('OPENCLAW_EXTENSIONS="$(cat /tmp/openclaw-selected-plugin-dirs)"');
   });
 
-  it("copies root package lifecycle scripts before pnpm install", async () => {
-    const [dockerfile, packageJsonText] = await Promise.all([
-      readFile(dockerfilePath, "utf8"),
-      readFile(join(repoRoot, "package.json"), "utf8"),
-    ]);
-    const installIndex = dockerfile.indexOf("pnpm install --frozen-lockfile");
-    const packageJson = JSON.parse(packageJsonText) as {
-      scripts?: Record<string, string>;
-    };
-    const installLifecycleScripts = ["preinstall", "install", "postinstall", "prepare"] as const;
-
-    for (const lifecycleScript of installLifecycleScripts) {
-      const command = packageJson.scripts?.[lifecycleScript];
-      const scriptPath = command?.match(/\bnode\s+(scripts\/[^\s]+)/)?.[1];
-      if (!scriptPath) {
-        continue;
+  it.each(["Dockerfile", "scripts/docker/cleanup-smoke/Dockerfile"])(
+    "runs root lifecycle scripts from %s dependency inputs",
+    async (dockerfileName) => {
+      const dockerfile = collapseDockerContinuations(
+        await readFile(join(repoRoot, dockerfileName), "utf8"),
+      );
+      const installIndex = dockerfile.indexOf("pnpm install --frozen-lockfile");
+      expect(installIndex).toBeGreaterThan(-1);
+      const fixture = await mkdtemp(join(tmpdir(), "openclaw-docker-lifecycle-"));
+      try {
+        // Stage the actual local COPY inputs, not a separately maintained import list.
+        // Workspace manifests do not contribute executable root lifecycle modules.
+        for (const [, sources, destination] of dockerfile
+          .slice(0, installIndex)
+          .matchAll(/^COPY ([^\n]+) (\.\/\S*)$/gm)) {
+          if (!sources || !destination) {
+            throw new Error("Expected local COPY sources and destination");
+          }
+          if (sources.startsWith("--")) {
+            continue;
+          }
+          for (const input of sources.split(/\s+/)) {
+            if (input !== "package.json" && !input.endsWith(".mjs")) {
+              continue;
+            }
+            const target = join(
+              fixture,
+              destination.endsWith("/") ? join(destination, basename(input)) : destination,
+            );
+            await mkdir(dirname(target), { recursive: true });
+            await cp(join(repoRoot, input), target);
+          }
+        }
+        const packageJson = JSON.parse(await readFile(join(fixture, "package.json"), "utf8")) as {
+          scripts: Record<string, string>;
+        };
+        const home = join(fixture, "home");
+        await mkdir(home);
+        for (const lifecycle of ["preinstall", "install", "postinstall", "prepare"]) {
+          const command = packageJson.scripts[lifecycle];
+          if (!command) {
+            continue;
+          }
+          const scriptPath = command.match(/^node (scripts\/[^\s]+)$/)?.[1];
+          if (!scriptPath) {
+            throw new Error(`Unsupported root lifecycle command: ${command}`);
+          }
+          expect
+            .soft(
+              () =>
+                execFileSync(process.execPath, [scriptPath], {
+                  cwd: fixture,
+                  env: {
+                    HOME: home,
+                    USERPROFILE: home,
+                    PATH: process.env.PATH,
+                    npm_config_user_agent: "pnpm/12",
+                  },
+                  stdio: "pipe",
+                }),
+              lifecycle,
+            )
+            .not.toThrow();
+        }
+      } finally {
+        await rm(fixture, { recursive: true, force: true });
       }
-
-      const copyIndex = dockerfile.indexOf(scriptPath);
-      expect(
-        copyIndex,
-        `${lifecycleScript} must copy ${scriptPath} before pnpm install`,
-      ).toBeGreaterThan(-1);
-      expect(
-        copyIndex,
-        `${lifecycleScript} must copy ${scriptPath} before pnpm install`,
-      ).toBeLessThan(installIndex);
-    }
-  });
+    },
+  );
 
   it("does not let pnpm resync the full source workspace during Docker build scripts", async () => {
     const dockerfile = await readFile(dockerfilePath, "utf8");


### PR DESCRIPTION
## What Problem This Solves

Docker dependency-install stages copy the root lifecycle entrypoints but omit
`scripts/lib/package-lifecycle-marker.mjs`, which those entrypoints import.
Source and cleanup-smoke image builds therefore fail before dependency
installation completes.

Related: #134231

## Why This Change Was Made

This preserves Peter Steinberger's original repair and commit authorship from
#134231 while rebasing the focused four-file change onto current `main`.
The source PR cannot be landed as-is because `maintainerCanModify=false` and its
release-note hunk conflicts with current `CHANGELOG.md`.

The Docker fix remains at the owning boundary: both install contexts receive the
module required by the lifecycle scripts they execute. The prior static filename
check is replaced with executable coverage that stages each Dockerfile's actual
dependency inputs and runs the declared lifecycle commands.

## User Impact

Docker source builds and cleanup-smoke builds can install dependencies with
package lifecycle checks enabled.

## Evidence

- `node scripts/run-vitest.mjs src/dockerfile.test.ts` - 38/38 passed
- Pre-fix fixture failed in both Dockerfile cases with
  `ERR_MODULE_NOT_FOUND` for `package-lifecycle-marker.mjs`
- `pnpm format:check --no-error-on-unmatched-pattern -- CHANGELOG.md Dockerfile scripts/docker/cleanup-smoke/Dockerfile src/dockerfile.test.ts`
- `pnpm check:no-conflict-markers`
- `pnpm check:changelog-attributions`
- `git diff --check origin/main...HEAD`
- Sol/high autoreview: scoped clean

Production/tooling delta: +2/-0. Tests: +69/-29. Changelog: +1/-0.

## Review Disposition

ClawSweeper's request to remove `CHANGELOG.md` is explicitly declined. The cited
restriction applies to external contributor PRs; this replacement is
maintainer-authored, and the root repository policy requires release-note-worthy
operational fixes to update the changelog in the same commit. No implementation
or test finding remains.
