### PR TITLE
fix(release): support frozen Bun package artifacts

### DIFF
--- a/scripts/e2e/bun-global-install-smoke.sh
+++ b/scripts/e2e/bun-global-install-smoke.sh
@@ -77,6 +77,19 @@ prepare_ai_candidate() {
   if [ -z "$PACK_DIR" ]; then
     PACK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-bun-pack.XXXXXX")"
   fi
+  root_manifest="$PACK_DIR/openclaw-package.json"
+  tar -xOf "$PACKAGE_TGZ" package/package.json >"$root_manifest"
+  if ! tar -tzf "$PACKAGE_TGZ" package/node_modules/@openclaw/ai/package.json >/dev/null 2>&1; then
+    if node -e '
+const manifest = require(process.argv[1]);
+process.exit(manifest.dependencies?.["@openclaw/ai"] ? 0 : 1);
+' "$root_manifest"; then
+      echo "OpenClaw tarball declares @openclaw/ai but does not bundle it" >&2
+      exit 1
+    fi
+    echo "==> Candidate has no bundled @openclaw/ai dependency"
+    return
+  fi
   echo "==> Extract bundled candidate @openclaw/ai package"
   ai_package_dir="$PACK_DIR/ai-candidate"
   mkdir -p "$ai_package_dir"
@@ -84,9 +97,7 @@ prepare_ai_candidate() {
     -C "$ai_package_dir" \
     --strip-components=4 \
     package/node_modules/@openclaw/ai
-  root_manifest="$PACK_DIR/openclaw-package.json"
   ai_manifest="$ai_package_dir/package.json"
-  tar -xOf "$PACKAGE_TGZ" package/package.json >"$root_manifest"
   node scripts/e2e/lib/bun-global-install/assertions.mjs \
     assert-release-versions \
     "$root_manifest" \
@@ -249,11 +260,13 @@ main() {
     "$XDG_CACHE_HOME" \
     "$OPENCLAW_STATE_DIR"
   export PATH="$BUN_INSTALL/bin:$(dirname "$(command -v node)"):$PATH"
-  # Release publishes @openclaw/ai first. Pin the local tarball install to
-  # exact candidate bytes instead of allowing public-registry resolution.
-  node --input-type=module - \
-    "$BUN_INSTALL/install/global/package.json" \
-    "$AI_PACKAGE_TGZ" <<'NODE'
+  # Current root tarballs bundle @openclaw/ai, while older release tarballs do
+  # not declare it. Pin only the bundled dependency; inventing an override for
+  # the older package changes the artifact under test.
+  if [ -n "$AI_PACKAGE_TGZ" ]; then
+    node --input-type=module - \
+      "$BUN_INSTALL/install/global/package.json" \
+      "$AI_PACKAGE_TGZ" <<'NODE'
 import fs from "node:fs";
 
 const [, , packageJsonPath, aiPackageTarball] = process.argv;
@@ -262,6 +275,7 @@ fs.writeFileSync(
   `${JSON.stringify({ private: true, overrides: { "@openclaw/ai": `file:${aiPackageTarball}` } })}\n`,
 );
 NODE
+  fi
 
   INSTALL_LOG="$SMOKE_DIR/install.log"
   UNTRUSTED_LOG="$SMOKE_DIR/untrusted.log"

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -2146,9 +2146,22 @@ syncBuiltinESMExports();
   });
 
   it.runIf(process.platform !== "win32").each([
-    { name: "uses bundled AI bytes when a prebuilt tarball is provided", statusExit: 0 },
-    { name: "preserves redirected Bun command diagnostics and exit status", statusExit: 23 },
-  ])("$name", ({ statusExit }) => {
+    {
+      name: "uses bundled AI bytes when a prebuilt tarball is provided",
+      bundledAi: true,
+      statusExit: 0,
+    },
+    {
+      name: "installs an older tarball with no bundled AI dependency unchanged",
+      bundledAi: false,
+      statusExit: 0,
+    },
+    {
+      name: "preserves redirected Bun command diagnostics and exit status",
+      bundledAi: true,
+      statusExit: 23,
+    },
+  ])("$name", ({ bundledAi, statusExit }) => {
     const tempDir = tempDirs.make("openclaw-bun-prebuilt-");
     const packageDir = join(tempDir, "fixture", "package");
     const aiDir = join(packageDir, "node_modules", "@openclaw", "ai");
@@ -2156,20 +2169,27 @@ syncBuiltinESMExports();
     const bunPath = join(tempDir, "bun");
     const statePath = join(tempDir, "state-path");
     const aiTarballPath = join(tempDir, "ai-tarball-path");
-    mkdirSync(aiDir, { recursive: true });
+    mkdirSync(packageDir, { recursive: true });
     writeFileSync(
       join(packageDir, "package.json"),
       JSON.stringify({
         name: "openclaw",
         version: "2026.6.17",
-        dependencies: { "@openclaw/ai": "2026.6.17" },
-        bundleDependencies: ["@openclaw/ai"],
+        ...(bundledAi
+          ? {
+              dependencies: { "@openclaw/ai": "2026.6.17" },
+              bundleDependencies: ["@openclaw/ai"],
+            }
+          : {}),
       }),
     );
-    writeFileSync(
-      join(aiDir, "package.json"),
-      JSON.stringify({ name: "@openclaw/ai", version: "2026.6.17" }),
-    );
+    if (bundledAi) {
+      mkdirSync(aiDir, { recursive: true });
+      writeFileSync(
+        join(aiDir, "package.json"),
+        JSON.stringify({ name: "@openclaw/ai", version: "2026.6.17" }),
+      );
+    }
     const packed = spawnSync(
       "tar",
       ["-czf", packageTgz, "-C", join(tempDir, "fixture"), "package"],
@@ -2233,16 +2253,26 @@ case " $* " in
   *' --trust '*) ;;
   *) echo 'missing --trust' >&2; exit 1 ;;
 esac
+mkdir -p "$BUN_INSTALL/install/global"
+if [ ! -f "$BUN_INSTALL/install/global/package.json" ]; then
+  echo '{}' >"$BUN_INSTALL/install/global/package.json"
+fi
+if [ "$EXPECT_AI_OVERRIDE" = "1" ]; then
 override="$(node -e 'const p=require(process.argv[1]);process.stdout.write(p.overrides["@openclaw/ai"])' "$BUN_INSTALL/install/global/package.json")"
 case "\${override#file:}" in
   *.tgz) ;;
   *) exit 1 ;;
 esac
 test -f "\${override#file:}"
+fi
 package_root="$BUN_INSTALL/install/global/node_modules/openclaw"
 mkdir -p "$BUN_INSTALL/bin" "$package_root/dist/plugin-sdk"
 printf '%s\\n' "$OPENCLAW_STATE_DIR" >"$FAKE_STATE_PATH"
-printf '%s\\n' "\${override#file:}" >"$FAKE_AI_TARBALL_PATH"
+if [ "$EXPECT_AI_OVERRIDE" = "1" ]; then
+  printf '%s\\n' "\${override#file:}" >"$FAKE_AI_TARBALL_PATH"
+else
+  node -e 'const p=require(process.argv[1]);process.exit(p.overrides ? 1 : 0)' "$BUN_INSTALL/install/global/package.json"
+fi
 # Synthetic package redactor isolates stderr routing; canonical redaction has separate proof.
 cat >"$package_root/dist/plugin-sdk/logging-core.js" <<'REDACTOR'
 exports.redactSensitiveText = (text) => text;
@@ -2272,6 +2302,7 @@ node -e 'const fs=require("node:fs");const p=process.argv[1];const value=JSON.pa
       env: {
         ...process.env,
         BUN_BIN: bunPath,
+        EXPECT_AI_OVERRIDE: bundledAi ? "1" : "0",
         FAKE_STATUS_EXIT: String(statusExit),
         FAKE_STATE_PATH: statePath,
         FAKE_AI_TARBALL_PATH: aiTarballPath,
@@ -2283,7 +2314,9 @@ node -e 'const fs=require("node:fs");const p=process.argv[1];const value=JSON.pa
 
     expect(result.status, result.stderr).toBe(statusExit);
     expect(existsSync(path.dirname(readFileSync(statePath, "utf8").trim()))).toBe(false);
-    expect(existsSync(path.dirname(readFileSync(aiTarballPath, "utf8").trim()))).toBe(false);
+    if (bundledAi) {
+      expect(existsSync(path.dirname(readFileSync(aiTarballPath, "utf8").trim()))).toBe(false);
+    }
     expect(result.stdout).toContain("bun-global-install-smoke: image providers OK (3 providers)");
     if (statusExit === 0) {
       expect(result.stdout).toContain(


### PR DESCRIPTION
Summary: make the Bun global-install smoke derive its @openclaw/ai override from the candidate tarball contract. Current tarballs bundle and declare the dependency, so the smoke pins exact bytes. Historical tarballs such as extended-stable 2026.6.35 neither declare nor bundle it, so the smoke installs their sealed artifact unchanged. A tarball declaring the dependency but omitting its bundled package still fails.

Evidence:
- Full validation 33358192129 bun global-install smoke fails extracting package/node_modules/@openclaw/ai from the sealed 2026.6.35 tarball.
- The frozen artifact manifest has neither dependencies[@openclaw/ai] nor a bundled AI path.
- This preserves the existing Bun workaround for current bundled packages without fabricating a dependency for older artifacts.
- Focused behavior regression passes: node scripts/run-vitest.mjs test/scripts/test-install-sh-docker.test.ts (99/99), covering bundled, legacy no-dependency, and diagnostics/exit-status paths.
- bash -n, focused oxlint, changed-file gate, formatting, and diff check pass.

Production LOC: +21/-7 (net +14) | Tests: +45/-12 (net +33). The production distinction is necessary to preserve exact-byte pinning where the bundle exists and leave historical artifact resolution untouched.