### PR TITLE
fix(ui): keep images visible during hard refresh

### DIFF
--- a/ui/src/lib/chat/message-extract.ts
+++ b/ui/src/lib/chat/message-extract.ts
@@ -122,6 +122,7 @@ function extractRawText(message: unknown): string | null {
 }
 
 export function readTranscriptMediaEntries(message: unknown): Array<{
+  factIndex: number;
   path: string;
   mediaType: string | undefined;
   fileName: string | undefined;
@@ -133,11 +134,12 @@ export function readTranscriptMediaEntries(message: unknown): Array<{
   if (!message || typeof message !== "object") {
     return [];
   }
-  return (readPersistedMediaFacts(message) ?? []).flatMap((fact) => {
+  return (readPersistedMediaFacts(message) ?? []).flatMap((fact, factIndex) => {
     const path = fact.path ?? fact.url;
     return path
       ? [
           {
+            factIndex,
             path,
             mediaType: fact.contentType ?? fact.kind,
             fileName: fact.fileName,

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -1,7 +1,9 @@
+import { readSessionMessageIdentity } from "@openclaw/gateway-client/browser";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, nothing } from "lit";
 import { ref } from "lit/directives/ref.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
+import { CHAT_PENDING_INPUT_MESSAGE_PREFIX } from "../../../../../packages/gateway-protocol/src/schema/chat-history-constants.js";
 import { icons, type IconName } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import type { MarkdownRenderOptions } from "../../../components/markdown-render-options.ts";
@@ -30,10 +32,11 @@ import {
   isToolCardError,
 } from "../../../lib/chat/tool-cards.ts";
 import { type EmbedSandboxMode, resolveToolDisplay } from "../../../lib/chat/tool-display.ts";
+import { isPendingSendMessage } from "../chat-thread-items.ts";
 import type { LinkFaviconFetcher } from "../link-favicon-loader.ts";
 import { workspaceResultConflictFromTranscript } from "../workspace-conflict.ts";
 import { renderAssistantAttachments } from "./chat-message-attachments.ts";
-import { renderMessageImages, resolveRenderableMessageImages } from "./chat-message-images.ts";
+import { renderMessageImages } from "./chat-message-images.ts";
 import {
   detectJson,
   jsonSummaryLabel,
@@ -69,6 +72,17 @@ import { renderWorkspaceConflictTranscriptMessage } from "./chat-workspace-confl
 
 function renderChatIcon(name: string) {
   return icons[name as IconName] ?? icons.zap;
+}
+
+function canonicalImageMessageKey(message: unknown, sessionKey: string | undefined) {
+  const identity = readSessionMessageIdentity(message);
+  return identity?.role === "user" &&
+    identity.id &&
+    !identity.isImported &&
+    !isPendingSendMessage(message) &&
+    !identity.id.startsWith(CHAT_PENDING_INPUT_MESSAGE_PREFIX)
+    ? JSON.stringify([sessionKey, identity.id, identity.sequence])
+    : undefined;
 }
 
 function renderInlineToolCards(
@@ -246,7 +260,11 @@ export function renderGroupedMessage(
 
   const toolCards = (opts.showToolCalls ?? true) ? extractToolCardsCached(message, messageKey) : [];
   const hasToolCards = toolCards.length > 0;
+  schedulePairingQrExpiryRefresh(messageKey, message, opts.onRequestUpdate);
+  const images = extractImages(message);
+  const hasImages = images.length > 0;
   const imageRenderOptions = {
+    canonicalMessageKey: hasImages ? canonicalImageMessageKey(message, opts.sessionKey) : undefined,
     connectionEpoch: opts.connectionEpoch,
     localMediaPreviewRoots: opts.localMediaPreviewRoots ?? [],
     resourceBasePath: opts.resourceBasePath,
@@ -256,9 +274,6 @@ export function renderGroupedMessage(
     onOpenImage: opts.onOpenImage,
     resolveArtifactDownload: opts.resolveArtifactDownload,
   };
-  schedulePairingQrExpiryRefresh(messageKey, message, opts.onRequestUpdate);
-  const images = resolveRenderableMessageImages(extractImages(message), imageRenderOptions);
-  const hasImages = images.length > 0;
   const pairingQrExpiryNotices = extractPairingQrExpiryNotices(message);
   const hasPairingQrExpiryNotices = pairingQrExpiryNotices.length > 0;
 

--- a/ui/src/pages/chat/components/chat-message-images.ts
+++ b/ui/src/pages/chat/components/chat-message-images.ts
@@ -379,7 +379,6 @@ export function renderMessageImages(images: ImageBlock[], opts?: ImageRenderOpti
     .filter(Boolean)
     .join(" ");
   const scope = JSON.stringify([
-    opts?.canonicalMessageKey,
     opts?.connectionEpoch,
     opts?.authToken?.trim(),
     opts?.resourceBasePath,
@@ -387,8 +386,10 @@ export function renderMessageImages(images: ImageBlock[], opts?: ImageRenderOpti
   return html`<div class=${layoutClasses}>
     ${repeat(
       images,
+      // Canonical identity scopes persisted slots, not unchanged initial-send
+      // images: adopting their message ID must not remount their inline pixels.
       (img, index) =>
-        `${scope}:${img.factIndex === undefined ? `image:${index}` : `fact:${img.factIndex}`}`,
+        `${scope}:${img.factIndex === undefined ? `image:${index}` : `${opts?.canonicalMessageKey}:fact:${img.factIndex}`}`,
       // The template owns the directive so repeat removal disconnects it.
       (img) => html`${renderMessageImageResource(img, opts)}`,
     )}

--- a/ui/src/pages/chat/components/chat-message-images.ts
+++ b/ui/src/pages/chat/components/chat-message-images.ts
@@ -1,5 +1,7 @@
-import { html, noChange, nothing, type TemplateResult } from "lit";
+import { html, noChange, nothing } from "lit";
 import { AsyncDirective, directive } from "lit/async-directive.js";
+import { keyed } from "lit/directives/keyed.js";
+import { repeat } from "lit/directives/repeat.js";
 import { until } from "lit/directives/until.js";
 import { normalizeBasePath } from "../../../app-route-paths.ts";
 import { icons } from "../../../components/icons.ts";
@@ -14,8 +16,12 @@ import {
   resolveAssistantAttachmentAvailability,
   resolveManagedOutgoingMediaSessionKey,
 } from "./chat-message-attachment-availability.ts";
+import { renderAssistantAttachmentStatusCard } from "./chat-message-attachment-status.ts";
 import { openResolvedImage } from "./chat-message-image-open.ts";
-import { buildAssistantAttachmentUrl } from "./chat-message-local-media.ts";
+import {
+  buildAssistantAttachmentUrl,
+  isCanonicalInboundMediaSource,
+} from "./chat-message-local-media.ts";
 import {
   cacheManagedImageBlobUrl,
   isChatMediaResourceCurrent,
@@ -35,46 +41,82 @@ import {
 
 const MANAGED_OUTGOING_IMAGE_FETCH_TIMEOUT_MS = 30_000;
 const MANAGED_OUTGOING_IMAGE_RETRY_MS = 5_000;
+const CANONICAL_IMAGE_HANDOFF_TIMEOUT_MS = 30_000;
 const MIN_CHAT_IMAGE_PREVIEW_WIDTH = 160;
 type ManagedImageVariant = "full" | "thumbnail";
 
-class ManagedImageResourceDirective extends AsyncDirective {
-  private cacheKey: string | undefined;
-  private image: RenderableImageBlock | undefined;
+type RetainedInlineImage = {
+  status: "retaining";
+  source: string;
+  previewUrl: string;
+  preparation?: {
+    url: string;
+    image: HTMLImageElement;
+    decoded: boolean;
+    cancel: () => void;
+  };
+};
+
+class MessageImageResourceDirective extends AsyncDirective {
+  private image: ImageBlock | undefined;
   private options: ImageRenderOptions | undefined;
-  private renderImageElement:
-    | ((image: RenderableImageBlock, previewUrl: string) => TemplateResult)
-    | undefined;
+  private element: HTMLImageElement | undefined;
+  private presentationKey = Symbol("image-presentation");
+  private retained: RetainedInlineImage | { status: "unavailable" } | undefined;
   private onRequestUpdate: (() => void) | undefined;
   private readonly requestUpdate = () => this.onRequestUpdate?.();
+  private readonly onSettled = (event: Event, source: string) => {
+    if (!this.isConnected || this.image?.url !== source) {
+      return;
+    }
+    this.element =
+      event.type === "load" && event.currentTarget instanceof HTMLImageElement
+        ? event.currentTarget
+        : undefined;
+    if (
+      this.retained?.status === "retaining" &&
+      this.element?.getAttribute("src") !== this.retained.previewUrl
+    ) {
+      if (event.type === "error") {
+        this.failRetainedImage();
+      } else {
+        this.releaseRetainedImage();
+      }
+    }
+  };
 
-  override render(
-    image: RenderableImageBlock,
-    options: ImageRenderOptions | undefined,
-    renderImageElement: (image: RenderableImageBlock, previewUrl: string) => TemplateResult,
-  ) {
+  override render(image: ImageBlock, options: ImageRenderOptions | undefined) {
+    const previous = this.image;
+    if (previous?.url !== image.url || previous?.artifactId !== image.artifactId) {
+      this.releaseRetainedImage();
+      // Bind once, only from an actually displayed inline image to its exact
+      // persisted slot. A later source replacement cannot borrow that preview.
+      this.retained =
+        options?.canonicalMessageKey &&
+        image.factIndex !== undefined &&
+        previous?.url.startsWith("data:image/") &&
+        previous.artifactId === image.artifactId &&
+        isCanonicalInboundMediaSource(image.url) &&
+        this.element?.getAttribute("src") === previous.url &&
+        this.element.naturalWidth > 0
+          ? { status: "retaining", source: image.url, previewUrl: previous.url }
+          : undefined;
+      if (!this.retained) {
+        this.element = undefined;
+        this.presentationKey = Symbol("image-presentation");
+      }
+      releaseChatMediaResourceSubscriber(this.requestUpdate);
+    }
     this.image = image;
     this.options = options;
-    this.renderImageElement = renderImageElement;
     if (!this.isConnected) {
+      this.releaseRetainedImage();
       releaseChatMediaResourceSubscriber(this.requestUpdate);
-      this.cacheKey = undefined;
-      this.onRequestUpdate = options?.onRequestUpdate;
       return noChange;
     }
-
-    const cacheKey = resolveManagedOutgoingImageBlobUrlCacheKey(
-      image.displayUrl,
-      options,
-      image.artifactId,
-    );
-    if (
-      (this.cacheKey !== undefined && this.cacheKey !== cacheKey) ||
-      this.onRequestUpdate !== options?.onRequestUpdate
-    ) {
+    if (this.onRequestUpdate !== options?.onRequestUpdate) {
       releaseChatMediaResourceSubscriber(this.requestUpdate);
     }
-    this.cacheKey = cacheKey;
     this.onRequestUpdate = options?.onRequestUpdate;
 
     // A transcript shares one pane callback across many guarded rows. Lit owns
@@ -85,114 +127,66 @@ class ManagedImageResourceDirective extends AsyncDirective {
     const subscriptionOptions = this.onRequestUpdate
       ? { ...options, onRequestUpdate: this.requestUpdate }
       : options;
-    const preview = resolveManagedOutgoingImageBlobUrl(
-      image.displayUrl,
-      subscriptionOptions,
-      image.artifactId,
-    ).then((previewUrl) => (previewUrl ? renderImageElement(image, previewUrl) : nothing));
-    return until(preview, nothing);
-  }
-
-  protected override disconnected() {
-    releaseChatMediaResourceSubscriber(this.requestUpdate);
-  }
-
-  protected override reconnected() {
-    if (this.image && this.renderImageElement) {
-      // Guarded transcript rows can skip their next pane render. Reinstall the
-      // image promise and its subscriber directly when Lit reconnects its part.
-      this.setValue(this.render(this.image, this.options, this.renderImageElement));
-    }
-  }
-}
-
-const renderManagedImageResource = directive(ManagedImageResourceDirective);
-
-export function resolveRenderableMessageImages(
-  images: ImageBlock[],
-  opts?: ImageRenderOptions,
-): RenderableImageBlock[] {
-  return images.flatMap((img) => {
     const availability = resolveAssistantAttachmentAvailability(
-      img.url,
-      opts?.localMediaPreviewRoots ?? [],
-      opts?.resourceBasePath,
-      opts?.authToken,
-      opts?.onRequestUpdate,
+      image.url,
+      options?.localMediaPreviewRoots ?? [],
+      options?.resourceBasePath,
+      options?.authToken,
+      subscriptionOptions?.onRequestUpdate,
     );
-    if (availability.status !== "available") {
-      return [];
+    const decodeFailed = this.retained?.status === "unavailable";
+    if (availability.status !== "available" || decodeFailed) {
+      if (availability.status === "checking" && this.retained?.status === "retaining") {
+        const previewUrl = this.retained.previewUrl;
+        return this.present(
+          this.renderImageElement({ ...image, displayUrl: previewUrl }, previewUrl, options),
+        );
+      }
+      if (!decodeFailed) {
+        this.releaseRetainedImage();
+      }
+      const reason =
+        availability.status === "unavailable"
+          ? availability.reason
+          : decodeFailed
+            ? t("chat.imageLightbox.loadFailed")
+            : undefined;
+      return renderAssistantAttachmentStatusCard({
+        label: image.fileName ?? image.alt ?? t("chat.imageLightbox.untitled"),
+        badge: reason === undefined ? "" : t("chat.attachments.unavailable"),
+        reason,
+      });
     }
     const displayUrl = buildAssistantAttachmentUrl(
-      img.url,
-      opts?.resourceBasePath,
+      image.url,
+      options?.resourceBasePath,
       availability.mediaTicket,
     );
-    return [{ ...img, displayUrl }];
-  });
-}
-
-export function renderMessageImages(images: RenderableImageBlock[], opts?: ImageRenderOptions) {
-  if (images.length === 0) {
-    return nothing;
+    const renderable = { ...image, displayUrl };
+    if (!isManagedOutgoingImageSource(displayUrl)) {
+      const retained = this.retained;
+      const previewUrl =
+        retained?.status === "retaining" && !this.prepareRetainedImage(retained, displayUrl).decoded
+          ? retained.previewUrl
+          : displayUrl;
+      return this.present(this.renderImageElement(renderable, previewUrl, options));
+    }
+    // Keep this render's callbacks when the image resolves, not later directive options.
+    const preview = resolveManagedOutgoingImageBlobUrl(
+      displayUrl,
+      subscriptionOptions,
+      image.artifactId,
+    ).then((previewUrl) =>
+      previewUrl ? this.renderImageElement(renderable, previewUrl, options) : nothing,
+    );
+    return this.present(until(preview, nothing));
   }
 
-  const openImage = (img: RenderableImageBlock, previewUrl: string) => {
-    const title = img.alt?.trim() || t("chat.imageLightbox.untitled");
-    const requestVersion = opts?.onRequestOpenImage?.();
-    if (!isManagedOutgoingImageSource(img.displayUrl)) {
-      openResolvedImage(opts?.onOpenImage, previewUrl, title, undefined, requestVersion);
-      return;
-    }
-
-    const cacheKey = resolveManagedOutgoingImageBlobUrlCacheKey(
-      img.displayUrl,
-      opts,
-      img.artifactId,
-      "full",
-    );
-    const cached = readManagedImageBlobUrl(cacheKey);
-    if (cached) {
-      const release = opts?.onOpenImage ? retainManagedImageBlobUrl(cacheKey) : undefined;
-      openResolvedImage(opts?.onOpenImage, cached, title, release, requestVersion);
-      return;
-    }
-
-    if (!opts?.onOpenImage) {
-      const pendingWindow = reserveExternalWindowForDeferredNavigation();
-      void resolveManagedOutgoingImageBlobUrl(img.displayUrl, opts, img.artifactId, "full")
-        .then((freshUrl) => {
-          const safeUrl = freshUrl
-            ? resolveSafeExternalUrl(freshUrl, window.location.href, { allowDataImage: true })
-            : null;
-          if (!safeUrl) {
-            pendingWindow?.close();
-            showToast({ message: t("chat.imageLightbox.loadFailed") });
-          } else if (pendingWindow) {
-            pendingWindow.location.replace(safeUrl);
-          } else {
-            openExternalUrlSafe(safeUrl, { allowDataImage: true });
-          }
-        })
-        .catch(() => {
-          pendingWindow?.close();
-          showToast({ message: t("chat.imageLightbox.loadFailed") });
-        });
-      return;
-    }
-    void resolveManagedOutgoingImageBlobUrl(img.displayUrl, opts, img.artifactId, "full")
-      .then((freshUrl) => {
-        if (!freshUrl) {
-          showToast({ message: t("chat.imageLightbox.loadFailed") });
-          return;
-        }
-        const release = cacheKey ? retainManagedImageBlobUrl(cacheKey) : undefined;
-        openResolvedImage(opts.onOpenImage, freshUrl, title, release, requestVersion);
-      })
-      .catch(() => showToast({ message: t("chat.imageLightbox.loadFailed") }));
-  };
-
-  const renderImageElement = (img: RenderableImageBlock, previewUrl: string) => {
+  private renderImageElement(
+    img: RenderableImageBlock,
+    previewUrl: string,
+    opts: ImageRenderOptions | undefined,
+  ) {
     const title = img.alt?.trim() || t("chat.imageLightbox.untitled");
     const managed = isManagedOutgoingImageSource(img.displayUrl);
     // Upscale genuinely tiny sources enough to read and operate without
@@ -209,10 +203,12 @@ export function renderMessageImages(images: RenderableImageBlock[], opts?: Image
           aria-label=${t("chat.imageLightbox.open", { title })}
           @click=${(event: MouseEvent) => {
             event.stopPropagation();
-            openImage(img, previewUrl);
+            openMessageImage(img, previewUrl, opts);
           }}
         >
           <img
+            @load=${(event: Event) => this.onSettled(event, img.url)}
+            @error=${(event: Event) => this.onSettled(event, img.url)}
             src=${previewUrl}
             alt=${title}
             class=${imageClass}
@@ -223,14 +219,156 @@ export function renderMessageImages(images: RenderableImageBlock[], opts?: Image
         ${managed ? renderManagedImageActions(img, opts) : nothing}
       </span>
     `;
-  };
+  }
 
-  const renderImage = (img: RenderableImageBlock) => {
-    if (!isManagedOutgoingImageSource(img.displayUrl)) {
-      return renderImageElement(img, img.displayUrl);
+  private prepareRetainedImage(retained: RetainedInlineImage, url: string) {
+    if (retained.preparation?.url === url) {
+      return retained.preparation;
     }
-    return renderManagedImageResource(img, opts, renderImageElement);
-  };
+    retained.preparation?.cancel();
+    const image = new Image();
+    const preparation = {
+      url,
+      image,
+      decoded: false,
+      cancel: () => {
+        clearTimeout(timeout);
+        image.removeAttribute("src");
+      },
+    };
+    const finish = (decoded: boolean) => {
+      if (
+        !this.isConnected ||
+        this.retained !== retained ||
+        retained.preparation !== preparation ||
+        this.image?.url !== retained.source
+      ) {
+        return;
+      }
+      if (!decoded) {
+        this.failRetainedImage();
+        return;
+      }
+      preparation.decoded = true;
+      this.refreshImage();
+    };
+    // Metadata proves access, not decoded pixels. Keep this preloader alive
+    // through the displayed IMG's load; the deadline bounds both requests.
+    const timeout = setTimeout(() => finish(false), CANONICAL_IMAGE_HANDOFF_TIMEOUT_MS);
+    retained.preparation = preparation;
+    image.src = url;
+    void image.decode().then(
+      () => finish(true),
+      () => finish(false),
+    );
+    return preparation;
+  }
+
+  private releaseRetainedImage() {
+    const retained = this.retained;
+    this.retained = undefined;
+    if (retained) {
+      this.element = undefined;
+    }
+    if (retained?.status === "retaining") {
+      retained.preparation?.cancel();
+    }
+  }
+
+  private failRetainedImage() {
+    this.releaseRetainedImage();
+    this.retained = { status: "unavailable" };
+    this.refreshImage();
+  }
+
+  private refreshImage() {
+    if (this.isConnected && this.image) {
+      this.setValue(this.render(this.image, this.options));
+    }
+  }
+
+  private present(value: unknown) {
+    return html`${keyed(this.presentationKey, value)}`;
+  }
+
+  protected override disconnected() {
+    this.releaseRetainedImage();
+    this.element = undefined;
+    this.presentationKey = Symbol("image-presentation");
+    releaseChatMediaResourceSubscriber(this.requestUpdate);
+  }
+
+  protected override reconnected() {
+    // Guarded rows may skip the next pane render; reconnect their own resource.
+    this.refreshImage();
+  }
+}
+
+const renderMessageImageResource = directive(MessageImageResourceDirective);
+
+function openMessageImage(
+  img: RenderableImageBlock,
+  previewUrl: string,
+  opts: ImageRenderOptions | undefined,
+) {
+  const title = img.alt?.trim() || t("chat.imageLightbox.untitled");
+  const requestVersion = opts?.onRequestOpenImage?.();
+  if (!isManagedOutgoingImageSource(img.displayUrl)) {
+    openResolvedImage(opts?.onOpenImage, previewUrl, title, undefined, requestVersion);
+    return;
+  }
+
+  const cacheKey = resolveManagedOutgoingImageBlobUrlCacheKey(
+    img.displayUrl,
+    opts,
+    img.artifactId,
+    "full",
+  );
+  const cached = readManagedImageBlobUrl(cacheKey);
+  if (cached) {
+    const release = opts?.onOpenImage ? retainManagedImageBlobUrl(cacheKey) : undefined;
+    openResolvedImage(opts?.onOpenImage, cached, title, release, requestVersion);
+    return;
+  }
+
+  if (!opts?.onOpenImage) {
+    const pendingWindow = reserveExternalWindowForDeferredNavigation();
+    void resolveManagedOutgoingImageBlobUrl(img.displayUrl, opts, img.artifactId, "full")
+      .then((freshUrl) => {
+        const safeUrl = freshUrl
+          ? resolveSafeExternalUrl(freshUrl, window.location.href, { allowDataImage: true })
+          : null;
+        if (!safeUrl) {
+          pendingWindow?.close();
+          showToast({ message: t("chat.imageLightbox.loadFailed") });
+        } else if (pendingWindow) {
+          pendingWindow.location.replace(safeUrl);
+        } else {
+          openExternalUrlSafe(safeUrl, { allowDataImage: true });
+        }
+      })
+      .catch(() => {
+        pendingWindow?.close();
+        showToast({ message: t("chat.imageLightbox.loadFailed") });
+      });
+    return;
+  }
+  void resolveManagedOutgoingImageBlobUrl(img.displayUrl, opts, img.artifactId, "full")
+    .then((freshUrl) => {
+      if (!freshUrl) {
+        showToast({ message: t("chat.imageLightbox.loadFailed") });
+        return;
+      }
+      const release = cacheKey ? retainManagedImageBlobUrl(cacheKey) : undefined;
+      openResolvedImage(opts.onOpenImage, freshUrl, title, release, requestVersion);
+    })
+    .catch(() => showToast({ message: t("chat.imageLightbox.loadFailed") }));
+}
+
+export function renderMessageImages(images: ImageBlock[], opts?: ImageRenderOptions) {
+  if (images.length === 0) {
+    return nothing;
+  }
 
   const layoutClasses = [
     "chat-message-images",
@@ -240,7 +378,21 @@ export function renderMessageImages(images: RenderableImageBlock[], opts?: Image
   ]
     .filter(Boolean)
     .join(" ");
-  return html` <div class=${layoutClasses}>${images.map((img) => renderImage(img))}</div> `;
+  const scope = JSON.stringify([
+    opts?.canonicalMessageKey,
+    opts?.connectionEpoch,
+    opts?.authToken?.trim(),
+    opts?.resourceBasePath,
+  ]);
+  return html`<div class=${layoutClasses}>
+    ${repeat(
+      images,
+      (img, index) =>
+        `${scope}:${img.factIndex === undefined ? `image:${index}` : `fact:${img.factIndex}`}`,
+      // The template owns the directive so repeat removal disconnects it.
+      (img) => html`${renderMessageImageResource(img, opts)}`,
+    )}
+  </div>`;
 }
 
 function isManagedOutgoingImageSource(source: string): boolean {

--- a/ui/src/pages/chat/components/chat-message-local-media.ts
+++ b/ui/src/pages/chat/components/chat-message-local-media.ts
@@ -14,7 +14,7 @@ export function isLocalAssistantAttachmentSource(source: string): boolean {
   );
 }
 
-function isCanonicalInboundMediaSource(source: string): boolean {
+export function isCanonicalInboundMediaSource(source: string): boolean {
   // Match the raw one-segment form first; URL parsing would erase dot segments.
   const match = /^media:\/\/inbound\/([^/?#]+)$/i.exec(source.trim());
   if (!match?.[1]) {

--- a/ui/src/pages/chat/components/chat-message-media.ts
+++ b/ui/src/pages/chat/components/chat-message-media.ts
@@ -17,6 +17,7 @@ export type PairingQrExpiryNotice = {
 
 export type ImageBlock = {
   url: string;
+  factIndex?: number;
   artifactId?: string;
   fileName?: string;
   openUrl?: string;
@@ -32,6 +33,7 @@ export type ArtifactDownloadResolver = (params: {
 }) => Promise<{ url: string; expiresAt?: string } | null>;
 
 export type ImageRenderOptions = {
+  canonicalMessageKey?: string;
   connectionEpoch?: number;
   localMediaPreviewRoots?: readonly string[];
   resourceBasePath?: string;
@@ -328,7 +330,13 @@ export function cacheManagedImageBlobUrl(cacheKey: string, blobUrl: string) {
 }
 
 function appendImageBlock(images: ImageBlock[], block: ImageBlock) {
-  if (!images.some((entry) => entry.url === block.url && entry.alt === block.alt)) {
+  if (
+    !images.some((entry) =>
+      block.factIndex !== undefined
+        ? entry.factIndex === block.factIndex
+        : entry.factIndex === undefined && entry.url === block.url && entry.alt === block.alt,
+    )
+  ) {
     images.push(block);
   }
 }
@@ -486,6 +494,29 @@ export function extractImages(message: unknown): ImageBlock[] {
   const m = message as Record<string, unknown>;
   const content = m.content;
   const images: ImageBlock[] = [];
+  const layout = asNonArrayRecord(asNonArrayRecord(m["__openclaw"]).mediaImageLayout);
+  const slots = Array.isArray(layout.slots) ? layout.slots.map(asNonArrayRecord) : [];
+  const factIndexes = slots.length > 0 ? new Set(slots.map((slot) => slot.factIndex)) : undefined;
+  // Reject ambiguous layouts before deduplication: fact positions, including
+  // holes and duplicate sources, are the persisted attachment identity.
+  const validLayout =
+    factIndexes !== undefined &&
+    !(Array.isArray(layout.suppressedFactIndexes) && layout.suppressedFactIndexes.length > 0) &&
+    slots.every(
+      (slot) =>
+        (slot.kind === "inline" || slot.kind === "offloaded") &&
+        typeof slot.factIndex === "number" &&
+        Number.isSafeInteger(slot.factIndex) &&
+        slot.factIndex >= 0,
+    ) &&
+    factIndexes.size === slots.length;
+  const inlineSlots = validLayout ? slots.filter((slot) => slot.kind === "inline") : [];
+  const alignedInline =
+    inlineSlots.length > 0 &&
+    Array.isArray(content) &&
+    content.filter((block) => asNonArrayRecord(block).type === "image").length ===
+      inlineSlots.length;
+  let inlineIndex = 0;
 
   if (Array.isArray(content)) {
     for (const block of content) {
@@ -497,7 +528,9 @@ export function extractImages(message: unknown): ImageBlock[] {
       if (b.type === "image") {
         // Handle source object format from optimistic user sends.
         const source = b.source as Record<string, unknown> | undefined;
+        const factIndex = alignedInline ? inlineSlots[inlineIndex]?.factIndex : undefined;
         const imageMeta = {
+          ...(typeof factIndex === "number" ? { factIndex } : {}),
           artifactId: typeof b.artifactId === "string" ? b.artifactId : undefined,
           alt: typeof b.alt === "string" ? b.alt : undefined,
           fileName: typeof b.fileName === "string" ? b.fileName : undefined,
@@ -506,6 +539,7 @@ export function extractImages(message: unknown): ImageBlock[] {
           width: typeof b.width === "number" ? b.width : undefined,
           height: typeof b.height === "number" ? b.height : undefined,
         };
+        inlineIndex += 1;
         if (source?.type === "base64" && typeof source.data === "string") {
           appendImageBlock(images, {
             url: buildBase64ImageUrl({
@@ -580,13 +614,22 @@ export function extractImages(message: unknown): ImageBlock[] {
     }
   }
 
-  for (const { path: mediaPath, mediaType, fileName, sizeBytes } of readTranscriptMediaEntries(
-    message,
-  )) {
+  for (const {
+    path: mediaPath,
+    mediaType,
+    fileName,
+    sizeBytes,
+    factIndex,
+  } of readTranscriptMediaEntries(message)) {
     if (!isImageMediaPath(mediaPath, mediaType) || isSvgImageMediaPath(mediaPath, mediaType)) {
       continue;
     }
-    appendImageBlock(images, { url: mediaPath, fileName, sizeBytes });
+    appendImageBlock(images, {
+      url: mediaPath,
+      fileName,
+      sizeBytes,
+      ...(validLayout && factIndexes.has(factIndex) ? { factIndex } : {}),
+    });
   }
 
   return images;

--- a/ui/src/pages/chat/components/chat-transcript-media-handoff.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-media-handoff.test.ts
@@ -1,0 +1,454 @@
+/* @vitest-environment jsdom */
+
+import { expectDefined } from "@openclaw/normalization-core";
+import { render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { createTestTranscript } from "../chat-view.test-helpers.ts";
+import { releaseChatMediaResourceSubscriber } from "./chat-message-media.ts";
+import { renderChatThread } from "./chat-thread.ts";
+import {
+  flushDeferredRowPrune,
+  installTranscriptDomMocks,
+  resetTranscriptTestDom,
+  threadProps,
+} from "./chat-transcript.test-support.ts";
+
+function expectSameImageNodes(actual: HTMLImageElement[], expected: HTMLImageElement[]) {
+  expect(actual).toHaveLength(expected.length);
+  for (const [index, image] of expected.entries()) {
+    expect(actual[index]).toBe(image);
+  }
+}
+
+function mediaMetadataResponse(available = true, mediaTicket?: string): Response {
+  return {
+    ok: true,
+    json: async () => ({
+      available,
+      reason: available ? undefined : "Attachment removed",
+      retryable: false,
+      ...(mediaTicket
+        ? { mediaTicket, mediaTicketExpiresAt: new Date(Date.now() + 31_000).toISOString() }
+        : {}),
+    }),
+  } as Response;
+}
+
+function mountTranscriptPane(props: Parameters<typeof renderChatThread>[0]) {
+  const transcript = createTestTranscript();
+  const container = document.body.appendChild(document.createElement("div"));
+  let root!: ReturnType<typeof render>;
+  const renderPane = () => {
+    root = render(
+      renderChatThread({ ...props, onRequestUpdate: renderPane }, transcript),
+      container,
+    );
+    transcript.hostUpdated();
+  };
+  onTestFinished(() => {
+    render(null, container);
+    releaseChatMediaResourceSubscriber(renderPane);
+    transcript.hostDisconnected();
+  });
+  renderPane();
+  transcript.hostConnected();
+  return { container, renderPane, root: () => root };
+}
+
+function createCanonicalImageTranscript(
+  factIndexes = [0],
+  inlineUrls = ["data:image/png;base64,aW5saW5l"],
+) {
+  const decodes: Array<{ image: HTMLImageElement; resolve: () => void; reject: () => void }> = [];
+  vi.stubGlobal(
+    "Image",
+    vi.fn(function () {
+      const image = document.createElement("img");
+      const decoded = new Promise<void>((resolve, reject) => {
+        decodes.push({ image, resolve, reject: () => reject(new Error("Image decode failed")) });
+      });
+      image.decode = vi.fn(() => decoded);
+      return image;
+    }),
+  );
+  const requests: Array<{ resolve: (response: Response) => void; signal?: AbortSignal | null }> =
+    [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn((_source: string, init?: RequestInit) => {
+      return new Promise<Response>((resolve) => {
+        requests.push({ resolve, signal: init?.signal });
+      });
+    }),
+  );
+  const canonical = {
+    id: crypto.randomUUID(),
+    seq: 1,
+    idempotencyKey: "canonical-image-send",
+    mediaImageLayout: { slots: factIndexes.map((factIndex) => ({ kind: "inline", factIndex })) },
+  };
+  const cached = {
+    role: "user",
+    timestamp: 1_000,
+    content: [
+      { type: "text", text: "Cached text" },
+      ...inlineUrls.map((url) => ({ type: "image", url })),
+    ],
+    __openclaw: canonical,
+  };
+  const media = Array.from({ length: Math.max(...factIndexes) + 1 }, (_, index) =>
+    factIndexes.includes(index)
+      ? { path: `media://inbound/${crypto.randomUUID()}.png`, contentType: "image/png" }
+      : null,
+  );
+  const props = {
+    ...threadProps(`pane-${crypto.randomUUID()}`, "agent:main:main", [cached]),
+    assistantAttachmentAuthToken: "test-auth-token",
+    connectionEpoch: 1,
+  };
+  const { container, renderPane, root } = mountTranscriptPane(props);
+  const images = () => [...container.querySelectorAll<HTMLImageElement>(".chat-message-image")];
+  const displayed = images();
+  expect(displayed).toHaveLength(inlineUrls.length);
+  for (const image of displayed) {
+    // jsdom has no decoder; deliver the browser's successful load boundary.
+    Object.defineProperty(image, "naturalWidth", { value: 1 });
+    image.dispatchEvent(new Event("load"));
+  }
+  const publish = (
+    metadata: Record<string, unknown> = {},
+    nextMedia = media,
+    text = "Fresh authoritative text",
+  ) => {
+    props.messages = [
+      {
+        ...cached,
+        content: [{ type: "text", text }],
+        __openclaw: { ...canonical, media: nextMedia, ...metadata },
+      },
+    ];
+    renderPane();
+  };
+  return {
+    container,
+    props,
+    displayed,
+    inlineUrls,
+    media,
+    requests,
+    decodes,
+    images,
+    publish,
+    renderPane,
+    root,
+  };
+}
+
+describe("canonical image presentation handoff", () => {
+  beforeEach(installTranscriptDomMocks);
+  afterEach(resetTranscriptTestDom);
+
+  it("keeps the displayed canonical inline image while fresh history text and media metadata arrive", async () => {
+    const fixture = createCanonicalImageTranscript();
+    const displayed = expectDefined(fixture.displayed[0], "displayed inline image");
+    fixture.publish();
+
+    expect(fixture.container.textContent).toContain("Fresh authoritative text");
+    expect(fixture.container.textContent).not.toContain("Cached text");
+    expectSameImageNodes(fixture.images(), [displayed]);
+    expect(displayed.getAttribute("src")).toBe(fixture.inlineUrls[0]);
+
+    fixture.requests[0]?.resolve(mediaMetadataResponse());
+    await flushDeferredRowPrune();
+    expectSameImageNodes(fixture.images(), [displayed]);
+    expect(displayed.getAttribute("src")).toBe(fixture.inlineUrls[0]);
+    const prepared = expectDefined(fixture.decodes[0], "canonical decode request");
+    expect(prepared.image.getAttribute("src")).toContain(
+      encodeURIComponent(expectDefined(fixture.media[0], "canonical media fact").path),
+    );
+    fixture.renderPane();
+    expect(fixture.decodes).toHaveLength(1);
+    prepared.resolve();
+    await flushDeferredRowPrune();
+    expectSameImageNodes(fixture.images(), [displayed]);
+    expect(displayed.getAttribute("src")).toContain(
+      encodeURIComponent(expectDefined(fixture.media[0], "canonical media fact").path),
+    );
+    expect(prepared.image.getAttribute("src")).not.toBeNull();
+    displayed.dispatchEvent(new Event("load"));
+    expect(prepared.image.getAttribute("src")).toBeNull();
+  });
+
+  it.each([
+    {
+      name: "different canonical ID with identical text and send key",
+      metadata: { id: "different-native-id" },
+    },
+    { name: "different canonical sequence", metadata: { seq: 2 } },
+    { name: "missing persisted ID", metadata: { id: undefined } },
+    { name: "imported message identity", metadata: { importedFrom: "external" } },
+    { name: "pending message identity", metadata: { id: "pending:input" } },
+    { name: "missing layout", metadata: { mediaImageLayout: undefined } },
+    {
+      name: "ambiguous duplicate slots",
+      metadata: {
+        mediaImageLayout: {
+          slots: [
+            { kind: "inline", factIndex: 0 },
+            { kind: "inline", factIndex: 0 },
+          ],
+        },
+      },
+    },
+  ])("does not borrow an inline preview for $name", ({ metadata }) => {
+    const fixture = createCanonicalImageTranscript();
+    fixture.publish(metadata, fixture.media, "Cached text");
+    expect(fixture.images()).toHaveLength(0);
+    expect(fixture.container.querySelector('[aria-busy="true"]')).not.toBeNull();
+  });
+
+  it.each([
+    { name: "missing inline block", factIndexes: [0, 2] },
+    { name: "duplicate fact index", factIndexes: [0, 0] },
+  ])("does not guess cached correspondence with $name", ({ factIndexes }) => {
+    const fixture = createCanonicalImageTranscript(factIndexes);
+    fixture.publish();
+    expect(fixture.images()).toHaveLength(0);
+  });
+
+  it("does not lend a displayed inline image to another pane of the same canonical message", () => {
+    const fixture = createCanonicalImageTranscript();
+    fixture.publish();
+    const { container } = mountTranscriptPane({ ...fixture.props, paneId: "other-image-pane" });
+    expectSameImageNodes(fixture.images(), fixture.displayed);
+    expect(container.querySelector(".chat-message-image")).toBeNull();
+    expect(fixture.requests).toHaveLength(1);
+  });
+
+  it.each([
+    {
+      name: "ordered images",
+      factIndexes: [0, 1],
+      inlineUrls: ["data:image/png;base64,YQ==", "data:image/png;base64,Yg=="],
+    },
+    {
+      name: "sparse reordered facts with duplicate previews and references",
+      factIndexes: [2, 0, 3],
+      inlineUrls: [
+        "data:image/png;base64,YQ==",
+        "data:image/png;base64,Yg==",
+        "data:image/png;base64,YQ==",
+      ],
+    },
+  ])(
+    "retains exact slots for $name through reversed completion and removal",
+    async ({ factIndexes, inlineUrls }) => {
+      const fixture = createCanonicalImageTranscript(factIndexes, inlineUrls);
+      const firstIndexByUrl = new Map<string, number>();
+      for (const [index, url] of inlineUrls.entries()) {
+        const factIndex = expectDefined(factIndexes[index], "image fact index");
+        const firstIndex = firstIndexByUrl.get(url);
+        if (firstIndex === undefined) {
+          firstIndexByUrl.set(url, factIndex);
+        } else {
+          fixture.media[factIndex] = fixture.media[firstIndex] ?? null;
+        }
+      }
+      fixture.publish();
+      const order = factIndexes
+        .map((factIndex, index) => ({ factIndex, index }))
+        .toSorted((a, b) => a.factIndex - b.factIndex);
+      const expected = order.map(({ index }) =>
+        expectDefined(fixture.displayed[index], "displayed slot"),
+      );
+      expectSameImageNodes(fixture.images(), expected);
+      expect(fixture.images().map((image) => image.getAttribute("src"))).toEqual(
+        order.map(({ index }) => inlineUrls[index]),
+      );
+
+      for (const request of fixture.requests.toReversed()) {
+        request.resolve(mediaMetadataResponse());
+        await flushDeferredRowPrune();
+        expectSameImageNodes(fixture.images(), expected);
+      }
+      for (const prepared of fixture.decodes.toReversed()) {
+        prepared.resolve();
+        await flushDeferredRowPrune();
+        expectSameImageNodes(fixture.images(), expected);
+      }
+      for (const [index, { factIndex }] of order.entries()) {
+        expect(fixture.images()[index]?.getAttribute("src")).toContain(
+          encodeURIComponent(expectDefined(fixture.media[factIndex], "canonical media fact").path),
+        );
+      }
+      fixture.publish(
+        {},
+        fixture.media.map((fact, index) => (index === order[0]?.factIndex ? null : fact)),
+      );
+      expectSameImageNodes(fixture.images(), expected.slice(1));
+    },
+  );
+
+  it.each(["auth", "connection epoch", "session"] as const)(
+    "clears retained inline presentation on %s change and ignores old metadata",
+    async (change) => {
+      const fixture = createCanonicalImageTranscript();
+      fixture.publish();
+      expectSameImageNodes(fixture.images(), fixture.displayed);
+      const old = expectDefined(fixture.requests[0], "pending metadata");
+      if (change === "auth") {
+        fixture.props.assistantAttachmentAuthToken = "rotated-token";
+      } else if (change === "connection epoch") {
+        fixture.props.connectionEpoch = 2;
+      } else {
+        fixture.props.sessionKey = "agent:main:other";
+      }
+      fixture.renderPane();
+      expect(fixture.images()).toHaveLength(0);
+      expect(old.signal?.aborted).toBe(true);
+      old.resolve(mediaMetadataResponse());
+      await flushDeferredRowPrune();
+      expect(fixture.images()).toHaveLength(0);
+      fixture.requests.at(-1)?.resolve(mediaMetadataResponse());
+      await flushDeferredRowPrune();
+      expect(fixture.images()).toHaveLength(1);
+      expect(fixture.images()[0]).not.toBe(fixture.displayed[0]);
+    },
+  );
+
+  it.each(["removal", "replacement", "disconnect", "denial"] as const)(
+    "clears an exact image handoff on %s without resurrection",
+    async (change) => {
+      const fixture = createCanonicalImageTranscript();
+      fixture.publish();
+      expectSameImageNodes(fixture.images(), fixture.displayed);
+      const old = expectDefined(fixture.requests[0], "pending metadata");
+      if (change === "removal") {
+        fixture.publish({}, []);
+      } else if (change === "replacement") {
+        fixture.publish({}, [
+          { path: `media://inbound/${crypto.randomUUID()}.png`, contentType: "image/png" },
+        ]);
+      } else if (change === "disconnect") {
+        fixture.root().setConnected(false);
+        fixture.root().setConnected(true);
+      }
+      if (change !== "denial") {
+        expect(old.signal?.aborted).toBe(true);
+        expect(fixture.images()).toHaveLength(0);
+      }
+      old.resolve(mediaMetadataResponse(change !== "denial"));
+      await flushDeferredRowPrune();
+      expect(fixture.images()).toHaveLength(0);
+      if (change === "denial") {
+        expect(fixture.container.textContent).toContain("Attachment removed");
+      }
+    },
+  );
+
+  it.each(["removal", "auth", "replacement", "disconnect"] as const)(
+    "discards a pending decode on %s and ignores its late completion",
+    async (change) => {
+      const fixture = createCanonicalImageTranscript();
+      fixture.publish();
+      fixture.requests[0]?.resolve(mediaMetadataResponse());
+      await flushDeferredRowPrune();
+      const prepared = expectDefined(fixture.decodes[0], "pending decode");
+      expectSameImageNodes(fixture.images(), fixture.displayed);
+      if (change === "removal") {
+        fixture.publish({}, []);
+      } else if (change === "auth") {
+        fixture.props.assistantAttachmentAuthToken = "rotated-token";
+        fixture.renderPane();
+      } else if (change === "replacement") {
+        fixture.publish({}, [
+          { path: `media://inbound/${crypto.randomUUID()}.png`, contentType: "image/png" },
+        ]);
+      } else {
+        fixture.root().setConnected(false);
+      }
+      expect(prepared.image.getAttribute("src")).toBeNull();
+      prepared.resolve();
+      await flushDeferredRowPrune();
+      expect(fixture.displayed[0]?.getAttribute("src")).toBe(fixture.inlineUrls[0]);
+      if (change === "disconnect") {
+        fixture.root().setConnected(true);
+      }
+      expect(fixture.images()).toHaveLength(0);
+    },
+  );
+
+  it.each(["renewal", "denial"] as const)(
+    "discards the old decode after metadata ticket %s",
+    async (change) => {
+      vi.useFakeTimers();
+      try {
+        const fixture = createCanonicalImageTranscript();
+        fixture.publish();
+        fixture.requests[0]?.resolve(mediaMetadataResponse(true, "before-refresh"));
+        await vi.advanceTimersByTimeAsync(0);
+        const old = expectDefined(fixture.decodes[0], "old ticket decode");
+        await vi.advanceTimersByTimeAsync(1_000);
+        fixture.requests[1]?.resolve(mediaMetadataResponse(change === "renewal", "after-refresh"));
+        await vi.advanceTimersByTimeAsync(0);
+        expect(old.image.getAttribute("src")).toBeNull();
+        old.reject();
+        await vi.advanceTimersByTimeAsync(0);
+        if (change === "denial") {
+          expect(fixture.images()).toHaveLength(0);
+          expect(fixture.container.textContent).toContain("Attachment removed");
+        } else {
+          expectSameImageNodes(fixture.images(), fixture.displayed);
+          expect(fixture.displayed[0]?.getAttribute("src")).toBe(fixture.inlineUrls[0]);
+          const current = expectDefined(fixture.decodes[1], "renewed ticket decode");
+          current.resolve();
+          await vi.advanceTimersByTimeAsync(0);
+          expectSameImageNodes(fixture.images(), fixture.displayed);
+          expect(fixture.displayed[0]?.getAttribute("src")).toContain("mediaTicket=after-refresh");
+        }
+      } finally {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each(["decode rejection", "decode deadline", "display load deadline"] as const)(
+    "ends the retained handoff visibly on %s without retrying or resurrecting it",
+    async (failure) => {
+      vi.useFakeTimers();
+      try {
+        const fixture = createCanonicalImageTranscript();
+        fixture.publish();
+        fixture.requests[0]?.resolve(mediaMetadataResponse());
+        await vi.advanceTimersByTimeAsync(0);
+        const prepared = expectDefined(fixture.decodes[0], "pending decode");
+        if (failure === "decode rejection") {
+          prepared.reject();
+          await vi.advanceTimersByTimeAsync(0);
+        } else {
+          if (failure === "display load deadline") {
+            prepared.resolve();
+            await vi.advanceTimersByTimeAsync(0);
+          }
+          await vi.advanceTimersByTimeAsync(29_999);
+          expectSameImageNodes(fixture.images(), fixture.displayed);
+          await vi.advanceTimersByTimeAsync(1);
+        }
+        expect(prepared.image.getAttribute("src")).toBeNull();
+        expect(fixture.images()).toHaveLength(0);
+        expect(
+          fixture.container.querySelector(".chat-assistant-attachment-card--definitive"),
+        ).not.toBeNull();
+        prepared.resolve();
+        fixture.renderPane();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(fixture.images()).toHaveLength(0);
+        expect(fixture.decodes).toHaveLength(1);
+      } finally {
+        vi.clearAllTimers();
+        vi.useRealTimers();
+      }
+    },
+  );
+});

--- a/ui/src/pages/chat/components/chat-transcript-projection.ts
+++ b/ui/src/pages/chat/components/chat-transcript-projection.ts
@@ -612,6 +612,7 @@ export function projectChatTranscript(
     props.resourceBasePath,
     (props.localMediaPreviewRoots ?? []).join("\u0000"),
     props.assistantAttachmentAuthToken,
+    props.connectionEpoch,
     props.canvasPluginSurfaceUrl,
     props.embedSandboxMode ?? "scripts",
     props.allowExternalEmbedUrls ?? false,


### PR DESCRIPTION
Closes #134237 (Control UI images flashing during hard-refresh hydration).

Related context only: #133719 fixed initial image-prompt duplication during worktree preparation. That repair remains unchanged; this PR covers a separate reload lifecycle.

<details>
<summary>Additional instructions</summary>

The PR branch is in the main repository, so maintainers with push access can update it.

</details>

## What Problem This Solves

Fixes an issue where users hard-refreshing a Control UI conversation would see an already displayed image disappear temporarily while its text remained visible. The browser could show the cached inline image, remove it while canonical media metadata loaded, then briefly lose decoded pixels again when switching the image source. No duplicate message or persistent attachment loss was observed.

## Why This Change Was Made

Keep presentation ownership inside the existing Lit image directive: only the same native canonical message/sequence and persisted attachment slot may retain an already displayed inline preview until the managed replacement has passed metadata checks and native image decoding. Preparation is bounded and retired on removal, access/connection changes, source replacement, or disconnection; fresh authoritative text and removals still apply immediately.

The requested simplification pass removed the single-implementation renderer callback plumbing, reused pending-message classification and slot lookups, avoided image-only work for text-only messages, and consolidated the test mount/cleanup and sparse-media fixture. No global image cache, history enrichment, storage/schema/config change, or initial-send handoff change was added.

Canonical identity keys apply only to persisted attachment slots. Unindexed inline images keep their existing presentation identity when initial-send adoption supplies a canonical message ID. This preserves the original initial-send image node without changing that handoff's producer or weakening its regression coverage.

## User Impact

Images stay visible and keep their space through hard-refresh hydration instead of flashing out and moving the conversation. Removal or denial retires the retained preview, and distinct same-text submissions remain separate. No operator action or new setting is required.

## Evidence

### Real Gateway and built Control UI

A real isolated Gateway served the built UI with real session/worktree/input-custody/transcript state and a synthetic 480×160 blue PNG. Only the external OpenAI-compatible provider was mocked. Browser cache was populated through the ordinary UI flow, not injected; no Gateway responses or WebSocket messages were substituted. Both runs used the same PNG and 300 ms browser transport latency with HTTP cache disabled, and required the cached inline image to actually paint before fresh history arrived.

| Refresh proof | Baseline `836b2efd406` | Final candidate `e6313d56b0c` |
| --- | ---: | ---: |
| Sampled refresh frames | 210 | 264 |
| Frames without the image element | 158 | 0 |
| Frames without decoded pixels | 202 | 0 |
| Same image node across canonical handoff | No | Yes |
| Initial-send handoff present after reload | No | No |

Initial sending, a fresh remount, and a deliberate identical second text submission also passed. The final candidate had 486 clean initial-send frames and 60 clean second-submission frames. Both mock-provider runs received the uploaded image bytes. Browser runtime errors: none.

The affected renderer and identity contracts were byte-identical on main at `7019b35f289`, verified through the native main-baseline review checkout. Introducing commit/release: unknown; this PR does not attribute the bug to the initial-send repair.

**Before: the image is absent during reload while the text remains.**

![Before: canonical image missing during refresh](https://github.com/user-attachments/assets/82cf16a5-bec0-4e70-8680-0b6b634d5889)

**After: the same decoded image remains visible through hydration on the final commit.**

![After: canonical image remains visible during refresh](https://github.com/user-attachments/assets/5249d414-5359-4c70-9862-b1f411a0bae2)

Both captures were inspected and contain only synthetic task data. The timing/decoded-pixel assertions come from animation-frame instrumentation, not a visual inference from a single screenshot. Final source SHA256: `0080958e0c14cc03134a30dd3057ca99401841e15ebeb19d2556fbb84fdc6d81`; built artifact SHA256: `d471d4081fa57e7ae5e63ae5a7823f9d8ee5d9b5b626691bf657450592a53e2d`. Served asset bytes were verified before and after the flow.

### Regression and checks

The new regression test was copied unchanged onto the unmodified baseline and failed for the intended reason after fresh history arrived: the image list was empty. The earlier metadata-only repair also failed the separate decode-readiness regression and real-browser pixel sampling; the final implementation waits for decoding rather than relying on DOM-node identity alone.

**302 focused tests passed** across seven files: 289 unit/boundary tests plus all 13 new-session attachment browser tests. Coverage includes sparse/duplicate slots, reverse completion, identity mismatches, cross-pane isolation, ticket renewal, cancellation, denial, bounded failure outcomes, and initial-send DOM continuity:

```bash
node scripts/run-vitest.mjs ui/src/pages/chat/components/chat-transcript-invalidation.test.ts ui/src/pages/chat/components/chat-message-media-lifecycle.test.ts ui/src/pages/chat/components/chat-message.test.ts ui/src/pages/chat/components/chat-message-local-media.test.ts ui/src/lib/chat/message-extract.test.ts ui/src/pages/chat/components/chat-transcript-media-handoff.test.ts ui/src/e2e/new-session-page.prompt-attachments.e2e.test.ts
```

Complete changed checks passed:

```bash
node scripts/check-changed.mjs -- ui/src/lib/chat/message-extract.ts ui/src/pages/chat/components/chat-message-bubble.ts ui/src/pages/chat/components/chat-message-images.ts ui/src/pages/chat/components/chat-message-local-media.ts ui/src/pages/chat/components/chat-message-media.ts ui/src/pages/chat/components/chat-transcript-media-handoff.test.ts ui/src/pages/chat/components/chat-transcript-projection.ts
```

Full final-candidate build passed:

```bash
pnpm build
```

The baseline used the canonical runtime build profile plus `pnpm ui:build`; no declaration artifacts were needed for its browser flow. Four independent reuse/simplification/efficiency/ownership reviews informed the cleanup. Fresh whole-patch Codex autoreview after the final correction was scoped-clean at the house P0 threshold; it is not represented as an all-priority audit.

### CI feedback and maintainer disposition

The [first CI run](https://github.com/openclaw/openclaw/actions/runs/33418077026) caught an overly broad image key: gaining a canonical message ID remounted an unchanged initial-send image. The existing browser test reproduced that failure locally. Commit `e6313d56b0c` scopes the canonical key to persisted slots, and the test now passes unchanged. No initial-send producer, expectation, or timeout was changed.

The same run also failed the tooling cancellation test while waiting for process startup, before sending SIGTERM. The existing [doctor diagnostics repair PR](https://github.com/openclaw/openclaw/pull/133952) landed the exact readiness-barrier repair as `7019b35f289`; this PR does not duplicate that work. The pre-fix second CI run was cancelled, then this PR was closed/reopened without changing its head to create [fresh merge-snapshot CI](https://github.com/openclaw/openclaw/actions/runs/33420776124) against healed main. That run passed on `e6313d56b0c519ad6770856122e283aac797c0bc`, including all 14 browser E2E shards, the real-Gateway UI lane, the previously failing tooling shard, and the required `openclaw/ci-gate`. No gate was bypassed.

The [ClawSweeper review](https://github.com/openclaw/openclaw/pull/134310#issuecomment-5481922378) found no actionable code defect and recommended retaining directive-local ownership and completing exact-head checks. Maintainer disposition: retain that bounded owner; a same-node-only implementation was directly disproven in Chromium, and moving previews into history or a shared cache would create competing ownership. Its inferred persistent-data-model flags do not apply: the added state is private to the mounted directive, and `JSON.stringify` only constructs in-memory Lit keys. No database, snapshot schema, serialized message contract, or migration changes occur. Its rank-up request is handled through the required exact-head CI/native landing gates, not a bypass.

### Scope and proof notes

Production LOC: **+359/−145 (net +214)**; tests: **+454/−0**. Raw churn includes moving the existing image template and open action; positive production growth implements exact presentation identity and bounded decode/cleanup ownership, not another cache or persistence path.

The earlier full build hit an incomplete local Zod installation. A lockfile-preserving forced reinstall restored the missing runtime files without dependency or source changes; the final full build and 302 tests passed. All real-browser scenario assertions passed, but the manual rig's provider-group cleanup deadline expired afterward; separate checks confirmed all owned processes/groups absent and removed only the synthetic state. Original cleanup receipts were retained. No operator Gateway was touched.

Proof scope is Chromium with synthetic media and a mock external provider. The source-Gateway fixture also logs an unrelated OpenAI plugin ESM-loading warning; actual tested turns still delivered the image to the mock provider. That loader issue is a separate follow-up, not part of this repair.
