### PR TITLE
fix(models): refresh Chutes and Cerebras price estimates

### DIFF
--- a/.agents/skills/openclaw-pr-maintainer/SKILL.md
+++ b/.agents/skills/openclaw-pr-maintainer/SKILL.md
@@ -330,6 +330,41 @@ gh search issues --repo openclaw/openclaw --match title,body --limit 50 \
   --jq '.[] | "\(.number) | \(.state) | \(.title) | \(.url)"'
 ```
 
+## Choose a writable landing checkout
+
+Before `review-init`, compare the editor's writable workspace with the Git
+common-directory parent. `scripts/pr` intentionally creates its worktree at
+`<canonical-repo>/.worktrees/pr-<PR>`; running it from a linked checkout does not
+put review artifacts under that caller. Shell access or a directory grant alone
+may not make those artifacts editable in an isolated session.
+
+When the canonical PR worktree lies outside the permitted workspace, start from
+a fresh ordinary checkout **inside** that workspace. Use the verified repository
+URL and normal Git, not another linked worktree pointing at the same outside
+common directory. Keep full history and blobs: shallow history breaks provenance
+checks, and blob filters can turn journaled historical restores into serial
+network fetches.
+
+```bash
+git clone --single-branch <verified-repository-url> <permitted-workspace>/landing-checkout
+```
+
+Verify its origin and Git root, then use that checkout's trusted `main` wrapper
+for the unchanged review/prepare/merge sequence. Its native PR worktrees now stay
+inside the permitted tree. Initialize review templates and verify editor access
+before investing in proof. Preserve the original checkout and unique work; never
+use symlinks, shell-mediated writes to denied paths, or weaker isolation flags.
+
+This is fresh workspace selection, not recovery: if another checkout has an
+active operation, uncertain merge capture/outcome, or pending auto/queue request
+for this PR, reconcile that original state first. Never clone away retained evidence or retry
+an uncertain dispatch from a new repository's independent lock/ref namespace.
+
+Keep the generated first line of `review.md` byte-for-byte, and keep `review.json`
+`pr.number`/`pr.headSha` aligned with the initialized metadata. Put descriptive
+prose below that line. Run native artifact validation before calling the review
+ready; regenerated templates, not hand-edited stamps, own head changes.
+
 ## Follow PR review and landing hygiene
 
 - `scripts/pr` requires `git`, `gh`, `jq`, `rg` (ripgrep), `pnpm`, and `node`

--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -292,9 +292,12 @@ Its scheduled workflow checks OpenClaw's default-branch plugin manifests and
 public pricing sources every four hours; every catalog content change is
 preserved as a public commit. Provider-owned policies select complete price
 schedules, including context tiers, without mixing rates from different sources.
-Declared native sources read OpenCode's official catalog or Venice's public model
-API, so connected installations can receive advertised price changes without a
-new OpenClaw release.
+Declared native sources read the public Cerebras, Chutes, OpenCode, and Venice
+catalogs, so connected installations can receive advertised price changes without
+a new OpenClaw release. When a valid native feed no longer supplies a model's
+price, publication preserves the model metadata without an estimate; it does not
+infer retirement or substitute another source's rate. Explicit user costs still
+win.
 
 Run `openclaw models refresh` for an immediate metadata and pricing check, or
 disable every hosted catalog request with `models.catalogRefresh.enabled:

--- a/docs/plugins/manifest.md
+++ b/docs/plugins/manifest.md
@@ -1297,6 +1297,8 @@ Provider fields:
 
 | Field        | Type              | What it means                                                                                   |
 | ------------ | ----------------- | ----------------------------------------------------------------------------------------------- |
+| `cerebras`   | `false \| object` | Explicit mapping to the public Cerebras `/public/v1/models` catalog. Never enabled implicitly.  |
+| `chutes`     | `false \| object` | Explicit mapping to the public Chutes `/v1/models` catalog. Never enabled implicitly.           |
 | `external`   | `boolean`         | Set `false` for local/self-hosted providers that should never use published external pricing.   |
 | `openCode`   | `false \| object` | Explicit mapping to the public `models.opencode.ai/api.json` catalog. Never enabled implicitly. |
 | `openRouter` | `false \| object` | OpenRouter publication-key mapping. `false` disables OpenRouter matching for this provider.     |
@@ -1331,15 +1333,21 @@ For authoritative native source mappings, use:
 }
 ```
 
-The publisher fetches the fixed OpenCode or Venice public endpoint without
-credentials only when its source is declared, and publishes native prices only
-in explicitly mapped owner namespaces. Venice's lightweight public
-`pricing-api.ts` keeps its payload parsing in the plugin and shares the complete
-schedule parser with runtime discovery. Fetch failure, malformed response
-bodies, or missing or invalid pricing for a paid bundled model stops
-publication, leaving the previous hosted catalog intact rather than publishing
-stale seed rates with a new timestamp. This authoring metadata does not add an
-operator setting or change the Gateway's existing refresh and restart lifecycle.
+The publisher fetches a fixed public endpoint without credentials only when its
+source is declared, and publishes native prices only in explicitly mapped owner
+namespaces. Cerebras and Chutes use the same shape with their respective source
+and provider IDs. Lightweight plugin-owned `pricing-api.ts` artifacts share
+payload parsing with runtime discovery without importing provider runtimes.
+
+An opted-in native source owns the complete provider schedule, including missing
+prices: generic sources cannot fill its gaps. A successful feed with no price for
+a bundled model preserves that model's metadata, omits its cost, and emits a
+publication warning. Missing pricing is not evidence of model retirement or free
+usage. Explicit native zero prices remain known-free estimates. Fetch failure,
+malformed response bodies or declared prices, and feeds with no usable prices
+stop publication, leaving the previous hosted catalog intact. Explicit operator
+rates remain unchanged. This authoring metadata adds no operator setting and does
+not change the Gateway's existing refresh and restart lifecycle.
 
 ### OpenClaw Provider Index
 

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -409,7 +409,17 @@ catalog, API-key auth, and dynamic model resolution.
     Public metadata never establishes account entitlement or expands the
     credential scope of discovery.
 
-    The same subpath exposes `normalizeOpenRouterModelPricing(pricing)` for
+    Official plugins use the private, pure
+    `openclaw/plugin-sdk/model-catalog-pricing` runtime subpath. It exposes
+    `normalizeModelPricingCatalog(rows, normalizePricing, readPricing?)` for
+    provider-owned pricing feeds. It returns a map of complete costs: absent
+    prices are omitted, while malformed declared prices, invalid or duplicate
+    model IDs, and a feed with no usable prices return `undefined`. Supply the
+    provider's unit conversion and optional price-field selector; the default
+    selector reads `model.pricing`. No auth, discovery, or runtime loader is
+    imported.
+
+    This subpath also exposes `normalizeOpenRouterModelPricing(pricing)` for
     native OpenRouter pricing objects. It converts per-token rates and static
     prompt-length overrides into a complete per-million cost schedule, without
     network access or prices from another source. Overrides apply strictly above

--- a/docs/providers/cerebras.md
+++ b/docs/providers/cerebras.md
@@ -6,7 +6,7 @@ read_when:
   - You need the Cerebras API key env var or CLI auth choice
 ---
 
-[Cerebras](https://www.cerebras.ai) provides high-speed OpenAI-compatible inference on custom inference hardware. The plugin ships a static three-model catalog (no live discovery).
+[Cerebras](https://www.cerebras.ai) provides high-speed OpenAI-compatible inference on custom inference hardware. The plugin discovers native model metadata and pricing, with a bundled catalog for offline fallback.
 
 | Property        | Value                                                     |
 | --------------- | --------------------------------------------------------- |
@@ -57,7 +57,7 @@ export CEREBRAS_API_KEY=csk-...
     openclaw models list --provider cerebras
     ```
 
-    Lists all three static models. If `CEREBRAS_API_KEY` is unresolved, `openclaw models status --json` reports the missing credential under `auth.unusableProfiles`.
+    Lists the configured Cerebras models. If `CEREBRAS_API_KEY` is unresolved, `openclaw models status --json` reports the missing credential under `auth.unusableProfiles`.
 
   </Step>
 </Steps>
@@ -71,21 +71,54 @@ openclaw onboard --non-interactive --accept-risk --skip-health \
   --cerebras-api-key "$CEREBRAS_API_KEY"
 ```
 
+## Discovery and pricing
+
+When Cerebras auth is configured and the inference base URL is the canonical
+`https://api.cerebras.ai/v1`, OpenClaw reads
+[`GET /public/v1/models`](https://inference-docs.cerebras.ai/api-reference/models/public-models).
+This request uses public headers only: inference API keys and discovery
+credentials are never sent to the metadata endpoint. A custom base URL skips
+this public discovery rather than mixing a proxy's catalog with Cerebras metadata.
+Without a Cerebras credential, the runtime provider stays inactive. Public
+metadata listing does not establish account entitlement.
+
+Live rows supply the native context and completion limits, reasoning and vision
+capabilities, and prompt/completion prices. Cerebras returns those prices as USD
+per-token strings; OpenClaw converts them to USD per million tokens. The public
+feed does not provide cache tariffs. Zero cache fields in OpenClaw's runtime
+estimate are not a claim about enterprise caching or billing.
+
+Successful catalogs are cached for 60 seconds. If discovery fails, returns an
+empty catalog, or has no usable model rows, OpenClaw uses the bundled offline
+seed. In the default `models.mode: "merge"`, fresh onboarding does not copy
+generated model rows or prices into your config, allowing prices to refresh.
+Explicitly authored model rows and costs remain intact. In
+`models.mode: "replace"`, discovery is disabled and onboarding keeps the offline
+seed as explicit config instead.
+
 ## Built-in catalog
 
-All three models have a 131,072-token context window and a 40,960-token max output.
+The three offline fallback models have a 131,072-token context window and a
+40,960-token max output. Prices for models still present in the native
+[public feed](https://api.cerebras.ai/public/v1/models) were refreshed from its
+August 31, 2026 response; absent legacy references retain their seed snapshots.
 
-| Model ref               | Name         | Reasoning | Notes                                     |
-| ----------------------- | ------------ | --------- | ----------------------------------------- |
-| `cerebras/zai-glm-4.7`  | Z.ai GLM 4.7 | yes       | Scheduled for deprecation August 17, 2026 |
-| `cerebras/gpt-oss-120b` | GPT OSS 120B | yes       | Production reasoning model                |
-| `cerebras/gemma-4-31b`  | Gemma 4 31B  | yes       | Default; preview; text-and-image input    |
+| Model ref               | Name         | Reasoning | Notes                                                     |
+| ----------------------- | ------------ | --------- | --------------------------------------------------------- |
+| `cerebras/zai-glm-4.7`  | Z.ai GLM 4.7 | yes       | Deprecated August 17, 2026; retained for explicit configs |
+| `cerebras/gpt-oss-120b` | GPT OSS 120B | yes       | Production reasoning model                                |
+| `cerebras/gemma-4-31b`  | Gemma 4 31B  | yes       | Default; preview; text-and-image input                    |
+
+Cerebras's [deprecation notice](https://inference-docs.cerebras.ai/support/deprecation)
+marks `zai-glm-4.7` deprecated without naming a replacement. OpenClaw keeps the
+shipped reference rather than deleting it or rewriting existing selections;
+retention does not guarantee upstream availability.
 
 Fresh onboarding follows Cerebras's current [Gemma 4 recommendation](https://www.cerebras.ai/blog/gemma-4-on-cerebras-the-fastest-inference-is-now-multimodal). Cerebras describes Gemma 4 31B as its reference medium-size model for equal-or-higher intelligence than GPT OSS, with multimodal agentic support. It is a public-preview model and may change or be discontinued on shorter notice than the production GPT OSS endpoint; existing OpenClaw configurations keep their selected model.
 
 ## Manual config
 
-Most setups only need the API key. Use explicit `models.providers.cerebras` config to override model metadata or run in `mode: "merge"` against the static catalog:
+Most setups only need the API key. Use explicit `models.providers.cerebras` config to override model metadata in `mode: "merge"`; leave `models` empty to use discovered rows without pinning generated prices:
 
 ```json5
 {
@@ -102,11 +135,7 @@ Most setups only need the API key. Use explicit `models.providers.cerebras` conf
         baseUrl: "https://api.cerebras.ai/v1",
         apiKey: "${CEREBRAS_API_KEY}",
         api: "openai-completions",
-        models: [
-          { id: "zai-glm-4.7", name: "Z.ai GLM 4.7" },
-          { id: "gpt-oss-120b", name: "GPT OSS 120B" },
-          { id: "gemma-4-31b", name: "Gemma 4 31B" },
-        ],
+        models: [],
       },
     },
   },

--- a/docs/providers/chutes.md
+++ b/docs/providers/chutes.md
@@ -72,6 +72,18 @@ other non-2xx status, it falls back to the bundled static catalog (both API-key
 and OAuth discovery use this same path). If discovery fails at startup, the
 static catalog is used automatically.
 
+Token prices come from the native [Chutes model catalog](https://llm.chutes.ai/v1/models).
+Its numeric prompt, completion, and cached-input rates are already in USD per
+million tokens; they are not per-token OpenRouter rates. Unavailable or invalid
+price metadata does not establish that a model is free.
+
+In the default `models.mode: "merge"`, fresh onboarding records the provider and
+aliases without copying generated model rows or prices into your config. Live
+prices can then refresh without overwriting explicitly authored model costs.
+`models.mode: "replace"` disables discovery, so onboarding retains the bundled
+catalog as an explicit offline seed in that mode. Existing configured model rows
+and their prices are preserved when applying provider setup again.
+
 ## Default aliases
 
 OpenClaw registers two convenience aliases for the Chutes catalog:
@@ -98,6 +110,12 @@ pickers:
 | `chutes/Qwen/Qwen3.5-397B-A17B-TEE`    | Hidden        |
 
 Run `openclaw models list --all --provider chutes` for the full list.
+
+Fallback prices for starter models still listed by the native endpoint were
+refreshed from its August 31, 2026 response. An absent model keeps its previous
+seed snapshot: feed absence alone does not retire a shipped reference or change
+its picker status. Listing metadata is not proof that your account can invoke a
+model.
 
 ## Config example
 

--- a/extensions/cerebras/index.ts
+++ b/extensions/cerebras/index.ts
@@ -4,6 +4,7 @@
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { applyCerebrasConfig } from "./onboard.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
+import { CEREBRAS_MODEL_DISCOVERY } from "./provider-catalog.js";
 
 const PROVIDER_ID = "cerebras";
 
@@ -24,6 +25,9 @@ export default defineSingleProviderPluginEntry({
       ].join("\n"),
       noteTitle: "Cerebras",
     },
-    catalog: {},
+    catalog: {
+      allowExplicitBaseUrl: true,
+      liveModelDiscovery: CEREBRAS_MODEL_DISCOVERY,
+    },
   },
 });

--- a/extensions/cerebras/onboard.test.ts
+++ b/extensions/cerebras/onboard.test.ts
@@ -1,38 +1,135 @@
 import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+import {
+  clearLiveCatalogCacheForTests,
+  type LiveModelCatalogFetchGuard,
+} from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import type { ProviderPlugin } from "openclaw/plugin-sdk/provider-model-shared";
 import { resolveAgentModelPrimaryValue } from "openclaw/plugin-sdk/provider-onboard";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildCerebrasCatalogModels } from "./api.js";
 import plugin from "./index.js";
 import { applyCerebrasConfig, CEREBRAS_DEFAULT_MODEL_REF } from "./onboard.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 const ssrfRuntimeMocks = vi.hoisted(() => ({
-  fetchWithSsrFGuard: vi.fn(),
-  ssrfPolicyFromHttpBaseUrlAllowedHostname: vi.fn((baseUrl: string) => ({
-    allowedHostnames: [new URL(baseUrl).hostname],
-  })),
+  fetchWithSsrFGuard: vi.fn<LiveModelCatalogFetchGuard>(),
 }));
 
-vi.mock("openclaw/plugin-sdk/ssrf-runtime", () => ssrfRuntimeMocks);
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>()),
+  ...ssrfRuntimeMocks,
+}));
+
+const CEREBRAS_PUBLIC_MODELS_URL = "https://api.cerebras.ai/public/v1/models";
+const NATIVE_TEXT_MODEL = {
+  id: "fixture-text-model",
+  object: "model",
+  name: "Fixture Text Model",
+  pricing: { prompt: "0.00000035", completion: "0.00000075" },
+  capabilities: { reasoning: true, vision: false, tools: true },
+  limits: { max_context_length: 131072, max_completion_tokens: 40960 },
+};
+
+type CatalogContext = Parameters<NonNullable<ProviderPlugin["catalog"]>["run"]>[0];
+
+function createCatalogContext(overrides: Partial<CatalogContext> = {}): CatalogContext {
+  return {
+    config: {},
+    env: {},
+    resolveProviderApiKey: () => ({
+      apiKey: "fixture-cerebras-key",
+      discoveryApiKey: "fixture-discovery-key",
+    }),
+    resolveProviderAuth: () => ({
+      apiKey: "fixture-cerebras-key",
+      discoveryApiKey: "fixture-discovery-key",
+      mode: "api_key",
+      source: "env",
+    }),
+    ...overrides,
+  };
+}
+
+function mockCatalogResponse(body: unknown, init?: ResponseInit) {
+  ssrfRuntimeMocks.fetchWithSsrFGuard.mockImplementation(async ({ url }) => ({
+    response: Response.json(body, init),
+    finalUrl: url,
+    release: async () => {},
+  }));
+}
+
+async function runCerebrasCatalog(ctx = createCatalogContext()) {
+  const provider = await registerSingleProviderPlugin(plugin);
+  const result = await provider.catalog?.run(ctx);
+  if (!result || !("provider" in result)) {
+    throw new Error("expected authenticated Cerebras provider catalog");
+  }
+  return result.provider;
+}
+
+beforeEach(() => {
+  clearLiveCatalogCacheForTests();
+});
 
 afterEach(() => {
+  clearLiveCatalogCacheForTests();
   ssrfRuntimeMocks.fetchWithSsrFGuard.mockReset();
-  ssrfRuntimeMocks.ssrfPolicyFromHttpBaseUrlAllowedHostname.mockClear();
 });
 
 describe("Cerebras onboarding", () => {
-  it("applies the manifest catalog, default, and alias", () => {
-    const config = applyCerebrasConfig({});
+  it.each(["default", "merge", "replace"] as const)(
+    "keeps generated prices replace-only while selecting the default and alias in %s mode",
+    (mode) => {
+      const config = applyCerebrasConfig(mode === "default" ? {} : { models: { mode } });
 
-    expect(config.models?.providers?.cerebras?.models.map((model) => model.id)).toEqual(
-      manifest.modelCatalog.providers.cerebras.models.map((model) => model.id),
-    );
-    expect(resolveAgentModelPrimaryValue(config.agents?.defaults?.model)).toBe(
-      CEREBRAS_DEFAULT_MODEL_REF,
-    );
-    expect(config.agents?.defaults?.models).toEqual({
-      [CEREBRAS_DEFAULT_MODEL_REF]: { alias: "Cerebras Gemma 4 31B" },
-    });
-  });
+      expect(config.models?.mode).toBe(mode === "replace" ? "replace" : "merge");
+      expect(config.models?.providers?.cerebras?.models.map((model) => model.id)).toEqual(
+        mode === "replace"
+          ? manifest.modelCatalog.providers.cerebras.models.map((model) => model.id)
+          : [],
+      );
+      if (mode === "replace") {
+        expect(config.models?.providers?.cerebras?.models).toEqual(buildCerebrasCatalogModels());
+      }
+      expect(resolveAgentModelPrimaryValue(config.agents?.defaults?.model)).toBe(
+        CEREBRAS_DEFAULT_MODEL_REF,
+      );
+      expect(config.agents?.defaults?.models).toEqual({
+        [CEREBRAS_DEFAULT_MODEL_REF]: { alias: "Cerebras Gemma 4 31B" },
+      });
+    },
+  );
+
+  it.each([
+    { label: "zero", cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
+    { label: "custom", cost: { input: 1, output: 2, cacheRead: 0.25, cacheWrite: 0.5 } },
+  ])(
+    "preserves authored $label prices, aliases, and selections without adding merge-mode pins",
+    ({ cost }) => {
+      const config = applyCerebrasConfig({});
+      const [seed] = buildCerebrasCatalogModels();
+      if (!seed) {
+        throw new Error("expected a Cerebras seed model");
+      }
+      const model = { ...structuredClone(seed), id: "fixture-authored-model", cost };
+      config.models!.providers!.cerebras!.models = [model];
+      config.models!.providers!.cerebras!.apiKey = "fixture-key";
+      config.agents!.defaults!.model = {
+        primary: "cerebras/fixture-authored-model",
+        fallbacks: ["fixture-provider/fallback"],
+      };
+      config.agents!.defaults!.models = {
+        [CEREBRAS_DEFAULT_MODEL_REF]: { alias: "My default alias" },
+        "cerebras/fixture-authored-model": { alias: "My authored model" },
+      };
+
+      const reapplied = applyCerebrasConfig(config);
+
+      expect(reapplied.models?.providers?.cerebras?.models).toEqual([model]);
+      expect(reapplied.models?.providers?.cerebras?.apiKey).toBe("fixture-key");
+      expect(reapplied.agents?.defaults).toEqual(config.agents?.defaults);
+    },
+  );
 
   it("preserves an existing primary during non-interactive auth setup", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
@@ -65,55 +162,185 @@ describe("Cerebras onboarding", () => {
       [CEREBRAS_DEFAULT_MODEL_REF]: { alias: "Cerebras Gemma 4 31B" },
     });
   });
+});
 
-  it("keeps the authenticated runtime catalog static without querying the model endpoint", async () => {
-    ssrfRuntimeMocks.fetchWithSsrFGuard.mockResolvedValueOnce({
-      response: Response.json({ data: [{ id: "gpt-oss-120b", object: "model" }] }),
-      finalUrl: "https://api.cerebras.ai/v1/models",
-      release: vi.fn(),
+describe("Cerebras native catalog", () => {
+  it("discovers native prices, limits, and capabilities without sending credentials", async () => {
+    mockCatalogResponse({
+      object: "list",
+      data: [
+        NATIVE_TEXT_MODEL,
+        {
+          ...NATIVE_TEXT_MODEL,
+          id: "fixture-vision-model",
+          name: "Fixture Vision Model",
+          pricing: { prompt: "0.00000099", completion: "0.00000149" },
+          capabilities: { reasoning: false, vision: true, tools: true },
+          limits: { max_context_length: 262144, max_completion_tokens: 65536 },
+        },
+      ],
     });
+
+    const catalog = await runCerebrasCatalog();
+
+    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledOnce();
+    const request = ssrfRuntimeMocks.fetchWithSsrFGuard.mock.calls[0]?.[0];
+    expect(request?.url).toBe(CEREBRAS_PUBLIC_MODELS_URL);
+    expect(Object.fromEntries(new Headers(request?.init?.headers))).toEqual({
+      accept: "application/json",
+    });
+    expect(catalog).toMatchObject({
+      apiKey: "fixture-cerebras-key",
+      api: "openai-completions",
+      baseUrl: "https://api.cerebras.ai/v1",
+    });
+    expect(catalog.models).toHaveLength(2);
+    expect(catalog.models).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "fixture-text-model",
+          name: "Fixture Text Model",
+          reasoning: true,
+          input: ["text"],
+          contextWindow: 131072,
+          maxTokens: 40960,
+        }),
+        expect.objectContaining({
+          id: "fixture-vision-model",
+          name: "Fixture Vision Model",
+          reasoning: false,
+          input: ["text", "image"],
+          contextWindow: 262144,
+          maxTokens: 65536,
+        }),
+      ]),
+    );
+    for (const [id, input, output] of [
+      ["fixture-text-model", 0.35, 0.75],
+      ["fixture-vision-model", 0.99, 1.49],
+    ] as const) {
+      const model = catalog.models.find((entry) => entry.id === id);
+      expect(model?.cost.input).toBeCloseTo(input, 10);
+      expect(model?.cost.output).toBeCloseTo(output, 10);
+      expect(model?.cost).toMatchObject({ cacheRead: 0, cacheWrite: 0 });
+    }
+  });
+
+  it("preserves zero input prices without discarding a paid output rate", async () => {
+    mockCatalogResponse({
+      data: [{ ...NATIVE_TEXT_MODEL, pricing: { prompt: "0", completion: "0.00000075" } }],
+    });
+
+    const catalog = await runCerebrasCatalog();
+
+    expect(catalog.models).toEqual([
+      expect.objectContaining({
+        id: NATIVE_TEXT_MODEL.id,
+        cost: { input: 0, output: 0.75, cacheRead: 0, cacheWrite: 0 },
+      }),
+    ]);
+  });
+
+  it.each([
+    { label: "absent pricing", pricing: undefined },
+    { label: "missing completion", pricing: { prompt: "0.00000035" } },
+    { label: "negative prompt", pricing: { prompt: "-0.00000035", completion: "0.00000075" } },
+    { label: "malformed completion", pricing: { prompt: "0.00000035", completion: "unknown" } },
+  ])("keeps an available row with the unknown runtime price for $label", async ({ pricing }) => {
+    mockCatalogResponse({ data: [{ ...NATIVE_TEXT_MODEL, pricing }] });
+
+    const catalog = await runCerebrasCatalog();
+
+    expect(catalog.models).toEqual([
+      expect.objectContaining({
+        id: NATIVE_TEXT_MODEL.id,
+        // Required runtime cost retains its unknown placeholder, not a free-billing claim.
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      }),
+    ]);
+  });
+
+  it.each(["https://proxy.example.test/cerebras/v1", "https://api.cerebras.ai/custom/v1"])(
+    "does not query public metadata for custom inference base %s",
+    async (baseUrl) => {
+      const catalog = await runCerebrasCatalog(
+        createCatalogContext({
+          config: { models: { providers: { cerebras: { baseUrl, models: [] } } } },
+        }),
+      );
+
+      expect(ssrfRuntimeMocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
+      expect(catalog.baseUrl).toBe(baseUrl);
+      expect(catalog.apiKey).toBe("fixture-cerebras-key");
+      expect(catalog.models.map((model) => model.id)).toEqual(
+        manifest.modelCatalog.providers.cerebras.models.map((model) => model.id),
+      );
+    },
+  );
+
+  it("keeps static discovery offline and retains the shipped GLM reference", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
-    const result = await provider.catalog?.run({
-      config: {},
-      env: {},
-      resolveProviderApiKey: () => ({ apiKey: "fixture-cerebras-key" }),
-    } as never);
+    const result = await provider.staticCatalog?.run(createCatalogContext());
 
     expect(ssrfRuntimeMocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
     if (!result || !("provider" in result)) {
-      throw new Error("expected authenticated Cerebras provider catalog");
+      throw new Error("expected static Cerebras provider catalog");
     }
-    expect(result.provider.apiKey).toBe("fixture-cerebras-key");
     expect(result.provider.models.map((model) => model.id)).toEqual(
       manifest.modelCatalog.providers.cerebras.models.map((model) => model.id),
     );
-    expect(result.provider.models.find((model) => model.id === "gemma-4-31b")?.input).toEqual([
-      "text",
-      "image",
-    ]);
-    const staticResult = await provider.staticCatalog?.run({ config: {}, env: {} } as never);
-    if (!staticResult || !("provider" in staticResult)) {
-      throw new Error("expected static Cerebras provider catalog");
-    }
-    expect(staticResult.provider.models.map((model) => model.id)).toEqual(
-      manifest.modelCatalog.providers.cerebras.models.map((model) => model.id),
+    expect(result.provider.models).toContainEqual(expect.objectContaining({ id: "zai-glm-4.7" }));
+    const glm = manifest.modelCatalog.providers.cerebras.models.find(
+      (model) => model.id === "zai-glm-4.7",
     );
+    expect(glm).toBeDefined();
+    expect(glm).not.toMatchObject({ status: "disabled" });
+    expect(glm).not.toHaveProperty("replacedBy");
   });
 
-  it("declares the bundled provider catalog as static", () => {
-    expect(manifest.modelCatalog.discovery.cerebras).toBe("static");
+  it("falls back offline after discovery failure and retries on the next request", async () => {
+    mockCatalogResponse({ error: "unavailable" }, { status: 503 });
+    const fallback = await runCerebrasCatalog();
+    expect(fallback.models.map((model) => model.id)).toEqual(
+      manifest.modelCatalog.providers.cerebras.models.map((model) => model.id),
+    );
+
+    mockCatalogResponse({ data: [NATIVE_TEXT_MODEL] });
+    const recovered = await runCerebrasCatalog();
+
+    expect(recovered.models).toEqual([
+      expect.objectContaining({
+        id: NATIVE_TEXT_MODEL.id,
+        cost: { input: 0.35, output: 0.75, cacheRead: 0, cacheWrite: 0 },
+      }),
+    ]);
+    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).toHaveBeenCalledTimes(2);
   });
 
   it("keeps the runtime catalog inactive without a Cerebras credential", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
+    const ctx = createCatalogContext({
+      resolveProviderApiKey: () => ({ apiKey: undefined }),
+      resolveProviderAuth: () => ({ apiKey: undefined, mode: "none", source: "none" }),
+    });
 
-    await expect(
-      provider.catalog?.run({
-        config: {},
-        env: {},
-        resolveProviderApiKey: () => ({}),
-      } as never),
-    ).resolves.toBeNull();
+    await expect(provider.catalog?.run(ctx)).resolves.toBeNull();
+    expect(ssrfRuntimeMocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
+  });
+
+  it("does not resolve credentials or query metadata for an unrelated provider scope", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const resolveProviderApiKey = vi.fn<CatalogContext["resolveProviderApiKey"]>();
+    const resolveProviderAuth = vi.fn<CatalogContext["resolveProviderAuth"]>();
+    const ctx = createCatalogContext({
+      providerIds: ["fixture-other-provider"],
+      resolveProviderApiKey,
+      resolveProviderAuth,
+    });
+
+    await expect(provider.catalog?.run(ctx)).resolves.toBeNull();
+    expect(resolveProviderApiKey).not.toHaveBeenCalled();
+    expect(resolveProviderAuth).not.toHaveBeenCalled();
     expect(ssrfRuntimeMocks.fetchWithSsrFGuard).not.toHaveBeenCalled();
   });
 });

--- a/extensions/cerebras/onboard.ts
+++ b/extensions/cerebras/onboard.ts
@@ -10,11 +10,12 @@ export const CEREBRAS_DEFAULT_MODEL_REF = readManifestProviderDefaultModelRef(
 
 export const { applyConfig: applyCerebrasConfig } = createModelCatalogPresetAppliers<[]>({
   primaryModelRef: CEREBRAS_DEFAULT_MODEL_REF,
-  resolveParams: () => ({
+  resolveParams: (cfg) => ({
     providerId: "cerebras",
     api: "openai-completions",
     baseUrl: CEREBRAS_BASE_URL,
-    catalogModels: buildCerebrasCatalogModels(),
+    // Replace mode skips discovery; merge mode must not persist generated pricing as authored pins.
+    catalogModels: cfg.models?.mode === "replace" ? buildCerebrasCatalogModels() : [],
     aliases: [{ modelRef: CEREBRAS_DEFAULT_MODEL_REF, alias: "Cerebras Gemma 4 31B" }],
   }),
 });

--- a/extensions/cerebras/openclaw.plugin.json
+++ b/extensions/cerebras/openclaw.plugin.json
@@ -5,6 +5,11 @@
   },
   "enabledByDefault": true,
   "providers": ["cerebras"],
+  "modelPricing": {
+    "providers": {
+      "cerebras": { "cerebras": { "provider": "cerebras" } }
+    }
+  },
   "providerEndpoints": [
     {
       "endpointClass": "cerebras-native",
@@ -28,6 +33,7 @@
           {
             "id": "zai-glm-4.7",
             "name": "Z.ai GLM 4.7",
+            "status": "deprecated",
             "input": ["text"],
             "reasoning": true,
             "contextWindow": 131072,
@@ -49,8 +55,8 @@
             "cost": {
               "input": 0.35,
               "output": 0.75,
-              "cacheRead": 0.35,
-              "cacheWrite": 0.75
+              "cacheRead": 0,
+              "cacheWrite": 0
             }
           },
           {
@@ -63,15 +69,15 @@
             "cost": {
               "input": 0.99,
               "output": 1.49,
-              "cacheRead": 0.99,
-              "cacheWrite": 1.49
+              "cacheRead": 0,
+              "cacheWrite": 0
             }
           }
         ]
       }
     },
     "discovery": {
-      "cerebras": "static"
+      "cerebras": "refreshable"
     }
   },
   "setup": {

--- a/extensions/cerebras/pricing-api.ts
+++ b/extensions/cerebras/pricing-api.ts
@@ -1,0 +1,12 @@
+import {
+  normalizeModelPricingCatalog,
+  normalizeOpenRouterModelPricing,
+} from "openclaw/plugin-sdk/model-catalog-pricing";
+import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+export function parseCerebrasPricingCatalog(payload: unknown) {
+  return normalizeModelPricingCatalog(
+    asOptionalRecord(payload)?.data,
+    normalizeOpenRouterModelPricing,
+  );
+}

--- a/extensions/cerebras/provider-catalog.ts
+++ b/extensions/cerebras/provider-catalog.ts
@@ -1,9 +1,79 @@
 /**
  * Cerebras model provider builder.
  */
+import { normalizeOpenRouterModelPricing } from "openclaw/plugin-sdk/model-catalog-pricing";
+import type { OpenAICompatibleModelDiscoveryOptions } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
-import type { ModelProviderConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import type {
+  ModelDefinitionConfig,
+  ModelProviderConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  asOptionalRecord,
+  asPositiveSafeInteger,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
+
+function projectCerebrasModels(
+  rows: readonly unknown[],
+  fallback: ModelProviderConfig,
+): ModelDefinitionConfig[] {
+  const seeds = new Map(fallback.models.map((model) => [model.id, model]));
+  const models = new Map<string, ModelDefinitionConfig>();
+  for (const row of rows) {
+    const record = asOptionalRecord(row);
+    const id = normalizeOptionalString(record?.id);
+    const limits = asOptionalRecord(record?.limits);
+    const contextWindow = asPositiveSafeInteger(limits?.max_context_length);
+    const maxTokens = asPositiveSafeInteger(limits?.max_completion_tokens);
+    if (
+      !record ||
+      !id ||
+      id.length > 512 ||
+      /[\s\p{Cc}]/u.test(id) ||
+      (record.object !== undefined && record.object !== "model") ||
+      record.deprecated === true ||
+      !contextWindow ||
+      !maxTokens
+    ) {
+      continue;
+    }
+    const seed = seeds.get(id);
+    const capabilities = asOptionalRecord(record.capabilities);
+    // Native metadata owns prices and limits; only the seed supplies trusted transport settings.
+    models.set(id, {
+      ...seed,
+      id,
+      name: normalizeOptionalString(record.name) ?? id,
+      reasoning: capabilities?.reasoning === true,
+      input: capabilities?.vision === true ? ["text", "image"] : ["text"],
+      contextWindow,
+      maxTokens,
+      cost: normalizeOpenRouterModelPricing(record.pricing) ?? {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      },
+      compat: {
+        ...seed?.compat,
+        ...(typeof capabilities?.tools === "boolean" ? { supportsTools: capabilities.tools } : {}),
+      },
+    });
+  }
+  return [...models.values()].toSorted((left, right) => left.id.localeCompare(right.id));
+}
+
+export const CEREBRAS_MODEL_DISCOVERY: OpenAICompatibleModelDiscoveryOptions = {
+  // Public metadata must not receive inference credentials or describe a custom proxy's catalog.
+  endpointUrl: {
+    url: "https://api.cerebras.ai/public/v1/models",
+    requireBaseUrl: manifest.modelCatalog.providers.cerebras.baseUrl,
+  },
+  buildRequestHeaders: () => ({ Accept: "application/json" }),
+  projectRows: projectCerebrasModels,
+};
 
 /** Builds the Cerebras OpenAI-compatible model provider config. */
 export function buildCerebrasProvider(): ModelProviderConfig {

--- a/extensions/chutes/models.test.ts
+++ b/extensions/chutes/models.test.ts
@@ -3,7 +3,11 @@ import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-cata
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CHUTES_DEFAULT_MODEL_ID } from "./api.js";
 import { CHUTES_MODEL_CATALOG, discoverChutesModels } from "./models.js";
-import { applyChutesConfig, CHUTES_DEFAULT_MODEL_REF } from "./onboard.js";
+import {
+  applyChutesConfig,
+  applyChutesProviderConfig,
+  CHUTES_DEFAULT_MODEL_REF,
+} from "./onboard.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 const EXPECTED_STATIC_MODEL_IDS = [
@@ -84,75 +88,127 @@ describe("chutes-models", () => {
     }
   });
 
-  it("keeps manifest, runtime catalog, defaults, and aliases aligned", () => {
-    const manifestIds = manifest.modelCatalog.providers.chutes.models.map((model) => model.id);
-    const runtimeIds = CHUTES_MODEL_CATALOG.map((model) => model.id);
-    expect(manifestIds).toEqual(EXPECTED_STATIC_MODEL_IDS);
-    expect(runtimeIds).toEqual(EXPECTED_STATIC_MODEL_IDS);
-    expect(
-      CHUTES_MODEL_CATALOG.every((model) => model.compat?.supportsUsageInStreaming === false),
-    ).toBe(true);
-    expect(CHUTES_DEFAULT_MODEL_ID).toBe(manifest.modelCatalog.providers.chutes.defaultModel);
-    expect(manifest.modelCatalog.providers.chutes.defaultModel).toBe("zai-org/GLM-5.2-TEE");
-    expect(
-      manifest.modelCatalog.providers.chutes.models
-        .filter((model) => "status" in model && model.status === "deprecated")
-        .map((model) => ({ id: model.id, replacedBy: model.replacedBy })),
-    ).toEqual([
-      {
-        id: "moonshotai/Kimi-K2.5-TEE",
-        replacedBy: "moonshotai/Kimi-K2.6-TEE",
-      },
-      {
-        id: "Qwen/Qwen3.5-397B-A17B-TEE",
-        replacedBy: "Qwen/Qwen3.6-27B-TEE",
-      },
-    ]);
+  it.each(["default", "merge", "replace"] as const)(
+    "keeps catalog ownership, defaults, and aliases aligned in %s mode",
+    (mode) => {
+      const manifestIds = manifest.modelCatalog.providers.chutes.models.map((model) => model.id);
+      const runtimeIds = CHUTES_MODEL_CATALOG.map((model) => model.id);
+      expect(manifestIds).toEqual(EXPECTED_STATIC_MODEL_IDS);
+      expect(runtimeIds).toEqual(EXPECTED_STATIC_MODEL_IDS);
+      expect(
+        CHUTES_MODEL_CATALOG.every((model) => model.compat?.supportsUsageInStreaming === false),
+      ).toBe(true);
+      expect(CHUTES_DEFAULT_MODEL_ID).toBe(manifest.modelCatalog.providers.chutes.defaultModel);
+      expect(manifest.modelCatalog.providers.chutes.defaultModel).toBe("zai-org/GLM-5.2-TEE");
+      expect(
+        manifest.modelCatalog.providers.chutes.models
+          .filter((model) => "status" in model && model.status === "deprecated")
+          .map((model) => ({ id: model.id, replacedBy: model.replacedBy })),
+      ).toEqual([
+        {
+          id: "moonshotai/Kimi-K2.5-TEE",
+          replacedBy: "moonshotai/Kimi-K2.6-TEE",
+        },
+        {
+          id: "Qwen/Qwen3.5-397B-A17B-TEE",
+          replacedBy: "Qwen/Qwen3.6-27B-TEE",
+        },
+      ]);
 
-    const cfg = applyChutesConfig({});
-    expect(cfg.models?.providers?.chutes?.models.map((model) => model.id)).toEqual(
-      EXPECTED_STATIC_MODEL_IDS,
-    );
-    expect(cfg.agents?.defaults?.model).toEqual({
-      primary: CHUTES_DEFAULT_MODEL_REF,
-      fallbacks: ["chutes/deepseek-ai/DeepSeek-V3.2-TEE", "chutes/moonshotai/Kimi-K2.6-TEE"],
-    });
-    expect(cfg.agents?.defaults?.imageModel).toEqual({
-      primary: "chutes/moonshotai/Kimi-K2.6-TEE",
-      fallbacks: ["chutes/Qwen/Qwen3.6-27B-TEE"],
-    });
-    expect(cfg.agents?.defaults?.models?.["chutes-fast"]).toBeUndefined();
-    expect(cfg.agents?.defaults?.models?.["chutes-pro"]?.alias).toBe(
-      "chutes/deepseek-ai/DeepSeek-V3.2-TEE",
-    );
-    expect(cfg.agents?.defaults?.models?.["chutes-vision"]?.alias).toBe(
-      "chutes/moonshotai/Kimi-K2.6-TEE",
-    );
-    expect(Object.keys(cfg.agents?.defaults?.models ?? {}).toSorted()).toEqual(
-      [
-        ...EXPECTED_STATIC_MODEL_IDS.map((id) => `chutes/${id}`),
-        "chutes-pro",
-        "chutes-vision",
-      ].toSorted(),
-    );
-    const catalogBackedTargets = [
-      CHUTES_DEFAULT_MODEL_REF,
-      "chutes/deepseek-ai/DeepSeek-V3.2-TEE",
-      "chutes/moonshotai/Kimi-K2.6-TEE",
-      "chutes/Qwen/Qwen3.6-27B-TEE",
-    ];
-    expect(
-      catalogBackedTargets.every((modelRef) =>
-        runtimeIds.includes(modelRef.slice("chutes/".length)),
-      ),
-    ).toBe(true);
-  });
+      const miniMax = manifest.modelCatalog.providers.chutes.models.find(
+        (model) => model.id === "MiniMaxAI/MiniMax-M2.5-TEE",
+      );
+      expect(miniMax).toBeDefined();
+      expect(miniMax).not.toHaveProperty("status");
+      expect(miniMax).not.toHaveProperty("replacedBy");
 
-  it("discoverChutesModels correctly maps API responses", async () => {
+      const cfg = applyChutesConfig(mode === "default" ? {} : { models: { mode } });
+      expect(cfg.models?.mode).toBe(mode === "replace" ? "replace" : "merge");
+      expect(cfg.models?.providers?.chutes?.models.map((model) => model.id)).toEqual(
+        mode === "replace" ? EXPECTED_STATIC_MODEL_IDS : [],
+      );
+      if (mode === "replace") {
+        expect(cfg.models?.providers?.chutes?.models).toEqual(CHUTES_MODEL_CATALOG);
+      }
+      expect(cfg.agents?.defaults?.model).toEqual({
+        primary: CHUTES_DEFAULT_MODEL_REF,
+        fallbacks: ["chutes/deepseek-ai/DeepSeek-V3.2-TEE", "chutes/moonshotai/Kimi-K2.6-TEE"],
+      });
+      expect(cfg.agents?.defaults?.imageModel).toEqual({
+        primary: "chutes/moonshotai/Kimi-K2.6-TEE",
+        fallbacks: ["chutes/Qwen/Qwen3.6-27B-TEE"],
+      });
+      expect(cfg.agents?.defaults?.models?.["chutes-fast"]).toBeUndefined();
+      expect(cfg.agents?.defaults?.models?.["chutes-pro"]?.alias).toBe(
+        "chutes/deepseek-ai/DeepSeek-V3.2-TEE",
+      );
+      expect(cfg.agents?.defaults?.models?.["chutes-vision"]?.alias).toBe(
+        "chutes/moonshotai/Kimi-K2.6-TEE",
+      );
+      expect(Object.keys(cfg.agents?.defaults?.models ?? {}).toSorted()).toEqual(
+        [
+          ...EXPECTED_STATIC_MODEL_IDS.map((id) => `chutes/${id}`),
+          "chutes-pro",
+          "chutes-vision",
+        ].toSorted(),
+      );
+      const catalogBackedTargets = [
+        CHUTES_DEFAULT_MODEL_REF,
+        "chutes/deepseek-ai/DeepSeek-V3.2-TEE",
+        "chutes/moonshotai/Kimi-K2.6-TEE",
+        "chutes/Qwen/Qwen3.6-27B-TEE",
+      ];
+      expect(
+        catalogBackedTargets.every((modelRef) =>
+          runtimeIds.includes(modelRef.slice("chutes/".length)),
+        ),
+      ).toBe(true);
+    },
+  );
+
+  it.each([
+    { label: "zero", cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } },
+    { label: "custom", cost: { input: 1, output: 2, cacheRead: 0.25, cacheWrite: 0.5 } },
+  ])(
+    "preserves authored $label prices, aliases, and selections without adding merge-mode pins",
+    ({ cost }) => {
+      const config = applyChutesProviderConfig({});
+      const [seed] = CHUTES_MODEL_CATALOG;
+      if (!seed) {
+        throw new Error("expected a Chutes seed model");
+      }
+      const model = { ...structuredClone(seed), id: "fixture-provider/authored-model", cost };
+      config.models!.providers!.chutes!.models = [model];
+      config.models!.providers!.chutes!.apiKey = "fixture-key";
+      config.agents!.defaults!.model = {
+        primary: "chutes/fixture-provider/authored-model",
+        fallbacks: ["fixture-provider/fallback"],
+      };
+      config.agents!.defaults!.imageModel = {
+        primary: "fixture-provider/image-model",
+        fallbacks: ["fixture-provider/image-fallback"],
+      };
+      config.agents!.defaults!.models!["chutes/fixture-provider/authored-model"] = {
+        alias: "My authored model",
+      };
+      config.agents!.defaults!.models!["chutes-pro"] = { alias: "My pro alias" };
+
+      const reapplied = applyChutesProviderConfig(config);
+
+      expect(reapplied.models?.providers?.chutes?.models).toEqual([model]);
+      expect(reapplied.models?.providers?.chutes?.apiKey).toBe("fixture-key");
+      expect(reapplied.agents?.defaults).toEqual(config.agents?.defaults);
+    },
+  );
+
+  it("preserves native per-million prices and exact zero rates during discovery", async () => {
     const mockFetch = vi.fn().mockResolvedValue(
       jsonResponse({
         data: [
-          { id: "zai-org/GLM-5.2-TEE" },
+          {
+            id: "fixture-provider/zero-input",
+            pricing: { prompt: 0, completion: 0.2, input_cache_read: 0 },
+          },
           {
             id: "new-provider/new-model-r1",
             supported_features: ["reasoning"],
@@ -161,7 +217,10 @@ describe("chutes-models", () => {
             max_output_length: 16384,
             pricing: { prompt: 0.1, completion: 0.2, input_cache_read: 0.05 },
           },
-          { id: "new-provider/simple-model" },
+          {
+            id: "fixture-provider/free-model",
+            pricing: { prompt: 0, completion: 0, input_cache_read: 0 },
+          },
         ],
       }),
     );
@@ -170,8 +229,22 @@ describe("chutes-models", () => {
       expect(models).toHaveLength(3);
       const firstModel = requireChutesModel(models, 0);
       const secondModel = requireChutesModel(models, 1);
-      expect(firstModel.id).toBe("zai-org/GLM-5.2-TEE");
-      expect(secondModel.reasoning).toBe(true);
+      expect(firstModel).toMatchObject({
+        id: "fixture-provider/zero-input",
+        cost: { input: 0, output: 0.2, cacheRead: 0, cacheWrite: 0 },
+      });
+      expect(requireChutesModel(models, 2).cost).toEqual({
+        input: 0,
+        output: 0,
+        cacheRead: 0,
+        cacheWrite: 0,
+      });
+      expect(secondModel).toMatchObject({
+        reasoning: true,
+        input: ["text", "image"],
+        contextWindow: 200000,
+        maxTokens: 16384,
+      });
       expect(secondModel.cost).toEqual({
         input: 0.1,
         output: 0.2,
@@ -182,6 +255,36 @@ describe("chutes-models", () => {
         throw new Error("expected Chutes API model compat");
       }
       expect(secondModel.compat.supportsUsageInStreaming).toBe(false);
+    });
+  });
+
+  it.each([
+    { label: "absent pricing", pricing: undefined },
+    { label: "missing prompt", pricing: { completion: 0.2 } },
+    { label: "missing completion", pricing: { prompt: 0.1 } },
+    { label: "negative prompt", pricing: { prompt: -0.1, completion: 0.2 } },
+    { label: "null completion", pricing: { prompt: 0.1, completion: null } },
+    { label: "string prompt", pricing: { prompt: "0.1", completion: 0.2 } },
+    {
+      label: "invalid cache rate",
+      pricing: { prompt: 0.1, completion: 0.2, input_cache_read: -0.05 },
+    },
+  ])("keeps an unknown runtime price, not partial paid rates, for $label", async ({ pricing }) => {
+    const mockFetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        data: [{ id: "fixture-provider/unpriced-model", pricing }],
+      }),
+    );
+
+    await withLiveChutesDiscovery(mockFetch, async () => {
+      const models = await discoverChutesModels("fixture-pricing-token");
+      expect(models).toHaveLength(1);
+      expect(requireChutesModel(models, 0)).toMatchObject({
+        id: "fixture-provider/unpriced-model",
+        // Runtime requires a complete cost; this existing placeholder is not proof of free billing.
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        compat: { supportsUsageInStreaming: false },
+      });
     });
   });
 

--- a/extensions/chutes/models.test.ts
+++ b/extensions/chutes/models.test.ts
@@ -31,21 +31,13 @@ function jsonResponse(payload: unknown, init: ResponseInit = {}): Response {
 async function withLiveChutesDiscovery<T>(
   fetchMock: ReturnType<typeof vi.fn>,
   run: () => Promise<T>,
-  options?: { now?: string },
 ): Promise<T> {
-  if (options?.now) {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date(options.now));
-  }
   vi.stubGlobal("fetch", fetchMock);
 
   try {
     return await run();
   } finally {
     vi.unstubAllGlobals();
-    if (options?.now) {
-      vi.useRealTimers();
-    }
   }
 }
 

--- a/extensions/chutes/models.ts
+++ b/extensions/chutes/models.ts
@@ -15,6 +15,7 @@ import {
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
+import { normalizeChutesModelPricing } from "./pricing-api.js";
 
 const CHUTES_MANIFEST_CATALOG = manifest.modelCatalog.providers.chutes;
 
@@ -48,11 +49,7 @@ interface ChutesModelEntry {
   context_length?: number;
   max_model_len?: number;
   max_output_length?: number;
-  pricing?: {
-    prompt?: number;
-    completion?: number;
-    input_cache_read?: number;
-  };
+  pricing?: unknown;
   [key: string]: unknown;
 }
 
@@ -84,10 +81,11 @@ function projectChutesModels(rows: readonly unknown[]): ModelDefinitionConfig[] 
       input: (entry.input_modalities || ["text"]).filter(
         (item): item is "text" | "image" => item === "text" || item === "image",
       ),
-      cost: {
-        input: entry.pricing?.prompt || 0,
-        output: entry.pricing?.completion || 0,
-        cacheRead: entry.pricing?.input_cache_read || 0,
+      // Runtime requires a cost object; unknown pricing must not retain partial paid rates.
+      cost: normalizeChutesModelPricing(entry.pricing) ?? {
+        input: 0,
+        output: 0,
+        cacheRead: 0,
         cacheWrite: 0,
       },
       contextWindow:

--- a/extensions/chutes/onboard.ts
+++ b/extensions/chutes/onboard.ts
@@ -12,11 +12,12 @@ export const CHUTES_DEFAULT_MODEL_REF = readManifestProviderDefaultModelRef(mani
 
 const chutesPresetAppliers = createModelCatalogPresetAppliers({
   primaryModelRef: CHUTES_DEFAULT_MODEL_REF,
-  resolveParams: (_cfg: OpenClawConfig) => ({
+  resolveParams: (cfg: OpenClawConfig) => ({
     providerId: "chutes",
     api: "openai-completions",
     baseUrl: CHUTES_BASE_URL,
-    catalogModels: structuredClone(CHUTES_MODEL_CATALOG),
+    // Replace mode skips discovery; merge mode must not persist generated pricing as authored pins.
+    catalogModels: cfg.models?.mode === "replace" ? structuredClone(CHUTES_MODEL_CATALOG) : [],
     aliases: [
       ...CHUTES_MODEL_CATALOG.map((model) => `chutes/${model.id}`),
       {

--- a/extensions/chutes/openclaw.plugin.json
+++ b/extensions/chutes/openclaw.plugin.json
@@ -5,6 +5,11 @@
   },
   "enabledByDefault": true,
   "providers": ["chutes"],
+  "modelPricing": {
+    "providers": {
+      "chutes": { "chutes": { "provider": "chutes" } }
+    }
+  },
   "providerEndpoints": [
     {
       "endpointClass": "chutes-native",
@@ -76,7 +81,7 @@
             "cost": {
               "input": 1,
               "output": 1,
-              "cacheRead": 0.5,
+              "cacheRead": 0.09999999999999998,
               "cacheWrite": 0
             }
           },
@@ -88,9 +93,9 @@
             "contextWindow": 262144,
             "maxTokens": 65535,
             "cost": {
-              "input": 0.66,
-              "output": 3.5,
-              "cacheRead": 0.33,
+              "input": 0.58,
+              "output": 3.4,
+              "cacheRead": 0.05799999999999998,
               "cacheWrite": 0
             }
           },
@@ -120,7 +125,7 @@
             "cost": {
               "input": 1.25,
               "output": 3.95,
-              "cacheRead": 0.625,
+              "cacheRead": 0.12499999999999997,
               "cacheWrite": 0
             }
           },
@@ -148,7 +153,7 @@
             "cost": {
               "input": 0.3,
               "output": 2,
-              "cacheRead": 0.15,
+              "cacheRead": 0.029999999999999992,
               "cacheWrite": 0
             }
           },
@@ -162,7 +167,7 @@
             "cost": {
               "input": 0.45,
               "output": 3,
-              "cacheRead": 0.225,
+              "cacheRead": 0.04499999999999999,
               "cacheWrite": 0
             },
             "status": "deprecated",

--- a/extensions/chutes/pricing-api.ts
+++ b/extensions/chutes/pricing-api.ts
@@ -1,0 +1,24 @@
+import { normalizeModelPricingCatalog } from "openclaw/plugin-sdk/model-catalog-pricing";
+import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
+import { asFiniteNumberInRange, asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+/** Chutes publishes numeric USD-per-million rates, not OpenRouter's per-token strings. */
+export function normalizeChutesModelPricing(
+  value: unknown,
+): ModelDefinitionConfig["cost"] | undefined {
+  const pricing = asOptionalRecord(value);
+  const input = asFiniteNumberInRange(pricing?.prompt, { min: 0 });
+  const output = asFiniteNumberInRange(pricing?.completion, { min: 0 });
+  const cacheRead =
+    pricing?.input_cache_read === undefined
+      ? 0
+      : asFiniteNumberInRange(pricing.input_cache_read, { min: 0 });
+  if (input === undefined || output === undefined || cacheRead === undefined) {
+    return undefined;
+  }
+  return { input, output, cacheRead, cacheWrite: 0 };
+}
+
+export function parseChutesPricingCatalog(payload: unknown) {
+  return normalizeModelPricingCatalog(asOptionalRecord(payload)?.data, normalizeChutesModelPricing);
+}

--- a/extensions/chutes/provider-catalog.ts
+++ b/extensions/chutes/provider-catalog.ts
@@ -19,10 +19,9 @@ export function buildStaticChutesProvider(): ModelProviderConfig {
  * Accepts an optional access token (API key or OAuth access token) for authenticated discovery.
  */
 export async function buildChutesProvider(accessToken?: string): Promise<ModelProviderConfig> {
-  const models = await discoverChutesModels(accessToken);
   return {
     baseUrl: CHUTES_BASE_URL,
     api: "openai-completions",
-    models: models.length > 0 ? models : structuredClone(CHUTES_MODEL_CATALOG),
+    models: await discoverChutesModels(accessToken),
   };
 }

--- a/extensions/openrouter/provider-catalog.ts
+++ b/extensions/openrouter/provider-catalog.ts
@@ -1,7 +1,7 @@
 // Openrouter provider module implements model/runtime integration.
+import { normalizeOpenRouterModelPricing } from "openclaw/plugin-sdk/model-catalog-pricing";
 import {
   buildLiveModelProviderConfig,
-  normalizeOpenRouterModelPricing,
   type LiveModelCatalogFetchGuard,
 } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import {

--- a/extensions/tsconfig.package-boundary.paths.json
+++ b/extensions/tsconfig.package-boundary.paths.json
@@ -894,6 +894,9 @@
       ],
       "openclaw/plugin-sdk/gateway-config-runtime": [
         "../packages/plugin-sdk/dist/src/plugin-sdk/gateway-config-runtime.d.ts"
+      ],
+      "openclaw/plugin-sdk/model-catalog-pricing": [
+        "../packages/plugin-sdk/dist/src/plugin-sdk/model-catalog-pricing.d.ts"
       ]
     }
   }

--- a/extensions/venice/pricing-api.ts
+++ b/extensions/venice/pricing-api.ts
@@ -1,9 +1,6 @@
+import { normalizeModelPricingCatalog } from "openclaw/plugin-sdk/model-catalog-pricing";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
-import {
-  asFiniteNumberInRange,
-  asOptionalRecord,
-  normalizeOptionalString,
-} from "openclaw/plugin-sdk/string-coerce-runtime";
+import { asFiniteNumberInRange, asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 
 function readVeniceRates(value: unknown): ModelDefinitionConfig["cost"] | undefined {
   const row = asOptionalRecord(value);
@@ -71,21 +68,9 @@ export function parseVeniceModelPricing(value: unknown): ModelDefinitionConfig["
 export function parseVenicePricingCatalog(
   payload: unknown,
 ): Map<string, ModelDefinitionConfig["cost"]> | undefined {
-  const data = asOptionalRecord(payload)?.data;
-  if (!Array.isArray(data)) {
-    return undefined;
-  }
-  const prices = new Map<string, ModelDefinitionConfig["cost"]>();
-  for (const value of data) {
-    const row = asOptionalRecord(value);
-    const id = normalizeOptionalString(row?.id);
-    if (!id || row?.type !== "text") {
-      continue;
-    }
-    const price = parseVeniceModelPricing(asOptionalRecord(row.model_spec)?.pricing);
-    if (price) {
-      prices.set(id, price);
-    }
-  }
-  return prices;
+  return normalizeModelPricingCatalog(
+    asOptionalRecord(payload)?.data,
+    parseVeniceModelPricing,
+    (model) => (model.type === "text" ? asOptionalRecord(model.model_spec)?.pricing : undefined),
+  );
 }

--- a/extensions/xai/tsconfig.json
+++ b/extensions/xai/tsconfig.json
@@ -878,6 +878,9 @@
       ],
       "openclaw/plugin-sdk/gateway-config-runtime": [
         "../../packages/plugin-sdk/dist/src/plugin-sdk/gateway-config-runtime.d.ts"
+      ],
+      "openclaw/plugin-sdk/model-catalog-pricing": [
+        "../../packages/plugin-sdk/dist/src/plugin-sdk/model-catalog-pricing.d.ts"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -389,7 +389,8 @@
     "scripts/lib/package-dist-imports.mjs",
     "scripts/lib/recommended-tool-installs.json",
     "scripts/postinstall-bundled-plugins.mjs",
-    "scripts/windows-cmd-helpers.mjs"
+    "scripts/windows-cmd-helpers.mjs",
+    "!dist/plugin-sdk/model-catalog-pricing.d.ts"
   ],
   "type": "module",
   "main": "dist/index.js",
@@ -422,6 +423,9 @@
     },
     "./plugin-sdk/model-ref-parse": {
       "default": "./dist/plugin-sdk/model-ref-parse.js"
+    },
+    "./plugin-sdk/model-catalog-pricing": {
+      "default": "./dist/plugin-sdk/model-catalog-pricing.js"
     },
     "./plugin-sdk/outbound-echo-runtime": {
       "default": "./dist/plugin-sdk/outbound-echo-runtime.js"

--- a/packages/model-catalog-core/src/model-catalog-pricing.test.ts
+++ b/packages/model-catalog-core/src/model-catalog-pricing.test.ts
@@ -1,6 +1,7 @@
 import { calculateUsageCost } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
 import {
+  normalizeModelPricingCatalog,
   normalizeModelPricingProvider,
   normalizeOpenRouterModelPricing,
   normalizeUpstreamModelPricing,
@@ -42,6 +43,37 @@ describe("model pricing source policy", () => {
   ])("ignores empty or unrecognized policy $value", ({ value }) =>
     expect(normalizeModelPricingProvider(value)).toBeUndefined(),
   );
+});
+
+describe("native pricing catalogs", () => {
+  const paid = { id: "paid", pricing: { input: 2, output: 10 } };
+
+  it("keeps declared free prices distinct from missing prices", () => {
+    expect(
+      normalizeModelPricingCatalog(
+        [paid, { id: "unknown" }, { id: "free", pricing: { input: 0, output: 0 } }],
+        normalizeUpstreamModelPricing,
+      ),
+    ).toEqual(
+      new Map([
+        ["paid", BASE_COST],
+        ["free", { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 }],
+      ]),
+    );
+  });
+
+  it.each([
+    { label: "non-array", rows: {} },
+    { label: "empty", rows: [] },
+    { label: "entirely unpriced", rows: [{ id: "unknown" }] },
+    { label: "invalid identity", rows: [paid, { id: " " }] },
+    { label: "malformed row", rows: [paid, null] },
+    { label: "malformed declared price", rows: [paid, { id: "bad", pricing: null }] },
+    { label: "duplicate priced identity", rows: [paid, paid] },
+    { label: "duplicate unpriced identity", rows: [paid, { id: "paid" }] },
+  ])("rejects $label rather than publishing a partial native feed", ({ rows }) => {
+    expect(normalizeModelPricingCatalog(rows, normalizeUpstreamModelPricing)).toBeUndefined();
+  });
 });
 
 describe.each([

--- a/packages/model-catalog-core/src/model-catalog-pricing.ts
+++ b/packages/model-catalog-core/src/model-catalog-pricing.ts
@@ -26,6 +26,18 @@ export const MODEL_PRICING_SOURCES = [
     url: "https://api.venice.ai/api/v1/models",
     authoritative: true,
   },
+  {
+    id: "chutes",
+    label: "Chutes",
+    url: "https://llm.chutes.ai/v1/models",
+    authoritative: true,
+  },
+  {
+    id: "cerebras",
+    label: "Cerebras",
+    url: "https://api.cerebras.ai/public/v1/models",
+    authoritative: true,
+  },
   { id: "openRouter", label: "OpenRouter", url: OPENROUTER_MODELS_URL, authoritative: false },
   { id: "liteLLM", label: "LiteLLM", url: LITELLM_PRICING_URL, authoritative: false },
 ] as const;
@@ -72,6 +84,38 @@ export function normalizeModelPricingProvider(value: unknown): ModelPricingProvi
     }
   }
   return Object.keys(policy).length > 0 ? policy : undefined;
+}
+
+/** Keep unavailable prices distinct from malformed native catalogs and declared rates. */
+export function normalizeModelPricingCatalog(
+  rows: unknown,
+  normalizePricing: (value: unknown) => CompleteModelCost | undefined,
+  readPricing: (model: Record<string, unknown>) => unknown = (model) => model.pricing,
+): Map<string, CompleteModelCost> | undefined {
+  if (!Array.isArray(rows)) {
+    return undefined;
+  }
+  const prices = new Map<string, CompleteModelCost>();
+  const ids = new Set<string>();
+  for (const value of rows) {
+    const model = asOptionalRecord(value);
+    const id = normalizeOptionalString(model?.id);
+    if (!model || !id || ids.has(id)) {
+      return undefined;
+    }
+    ids.add(id);
+    const rawPricing = readPricing(model);
+    if (rawPricing === undefined) {
+      continue;
+    }
+    const pricing = normalizePricing(rawPricing);
+    if (!pricing) {
+      return undefined;
+    }
+    prices.set(id, pricing);
+  }
+  // An empty price feed cannot establish that every previously known price disappeared.
+  return prices.size > 0 ? prices : undefined;
 }
 
 function readPricingCost(

--- a/scripts/lib/plugin-sdk-entrypoints.json
+++ b/scripts/lib/plugin-sdk-entrypoints.json
@@ -7,6 +7,7 @@
   "health",
   "doctor-repair-runtime",
   "model-ref-parse",
+  "model-catalog-pricing",
   "outbound-echo-runtime",
   "secret-provider-alias",
   "session-store-paths",

--- a/scripts/lib/plugin-sdk-private-local-only-subpaths.json
+++ b/scripts/lib/plugin-sdk-private-local-only-subpaths.json
@@ -90,6 +90,7 @@
   "message-tool-delivery-hints",
   "migration",
   "migration-runtime",
+  "model-catalog-pricing",
   "model-ref-parse",
   "music-generation",
   "node-host",

--- a/scripts/publish-model-catalog.mts
+++ b/scripts/publish-model-catalog.mts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
   MODEL_PRICING_SOURCES,
+  normalizeModelPricingCatalog,
   normalizeModelPricingProvider,
   normalizeOpenRouterModelPricing,
   normalizeUpstreamModelPricing,
@@ -13,6 +14,8 @@ import {
 import { normalizeModelCatalogProviderId } from "@openclaw/model-catalog-core/model-catalog-refs";
 import { parseStrictFiniteNumber } from "@openclaw/normalization-core/number-coercion";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { parseCerebrasPricingCatalog } from "../extensions/cerebras/pricing-api.js";
+import { parseChutesPricingCatalog } from "../extensions/chutes/pricing-api.js";
 import { parseVenicePricingCatalog } from "../extensions/venice/pricing-api.js";
 import type {
   RemoteModelCatalogBundle,
@@ -53,6 +56,14 @@ const MAX_PRICING_CATALOG_BYTES = 5 * 1024 * 1024;
 const BUNDLE_SIZE_WARNING_BYTES = 2 * 1024 * 1024;
 const CLIENT_BUNDLE_LIMIT_BYTES = 4 * 1024 * 1024;
 const defaultRootDir = resolveRepoRoot(import.meta.url);
+const NATIVE_CATALOG_PARSERS = {
+  cerebras: parseCerebrasPricingCatalog,
+  chutes: parseChutesPricingCatalog,
+  venice: parseVenicePricingCatalog,
+} satisfies Record<
+  Exclude<Extract<PricingSource, { authoritative: true }>["id"], "openCode">,
+  (payload: unknown) => PricingCatalog | undefined
+>;
 
 function requireOptionValue(args: string[], index: number, flag: string): string {
   const value = args[index + 1]?.trim();
@@ -398,23 +409,28 @@ function parsePricingCatalog(
       if (!isRecord(provider) || provider.id !== upstreamId || !isRecord(provider.models)) {
         throw new Error(`${source.label} pricing missing provider ${upstreamId}`);
       }
-      for (const [id, model] of Object.entries(provider.models)) {
-        const pricing =
-          isRecord(model) && model.id === id
-            ? normalizeUpstreamModelPricing(model.cost)
-            : undefined;
-        if (pricing) {
-          catalog.set(`${upstreamId}/${id}`, pricing);
-        }
+      const rows = Object.entries(provider.models).map(([id, model]) =>
+        isRecord(model) && model.id === id ? model : undefined,
+      );
+      const prices = normalizeModelPricingCatalog(
+        rows,
+        normalizeUpstreamModelPricing,
+        (model) => model.cost,
+      );
+      if (!prices) {
+        throw new Error(`${source.label} pricing malformed for provider ${upstreamId}`);
+      }
+      for (const [id, pricing] of prices) {
+        catalog.set(`${upstreamId}/${id}`, pricing);
       }
     }
-  } else if (source.id === "venice") {
-    const prices = parseVenicePricingCatalog(body);
+  } else if (source.authoritative) {
+    const prices = NATIVE_CATALOG_PARSERS[source.id](body);
     if (!prices) {
       throw new Error(`${source.label} pricing response is malformed`);
     }
     for (const [id, pricing] of prices) {
-      catalog.set(`venice/${id}`, pricing);
+      catalog.set(`${source.id}/${id}`, pricing);
     }
   } else if (source.id === "openRouter") {
     for (const row of Array.isArray(body.data) ? body.data : []) {
@@ -486,11 +502,22 @@ async function fetchPricingSources(fetchImpl: typeof fetch, policies: PricingPol
   return result;
 }
 
+function selectProviderPricingSources(
+  providerId: string,
+  sources: LoadedPricingSource[],
+  policies: PricingPolicies,
+): LoadedPricingSource[] {
+  const eligible = sources.filter((source) => sourcePolicy(policies, providerId, source));
+  // A native feed owns unavailable prices too; other vendors cannot fill its gaps.
+  const native = eligible.find((source) => source.authoritative);
+  return native ? [native] : eligible;
+}
+
 function materializePolicyRuntimePricing(
   hosted: PricingCatalog,
   policies: PricingPolicies,
   sources: LoadedPricingSource[],
-  pricedModels: Set<string>,
+  metadataOwnedKeys: Set<string>,
 ): void {
   for (const [providerId] of policies) {
     for (const key of hosted.keys()) {
@@ -498,7 +525,7 @@ function materializePolicyRuntimePricing(
         hosted.delete(key);
       }
     }
-    for (const source of sources) {
+    for (const source of selectProviderPricingSources(providerId, sources, policies)) {
       const policy = sourcePolicy(policies, providerId, source);
       if (!policy) {
         continue;
@@ -521,7 +548,7 @@ function materializePolicyRuntimePricing(
           runtimeKeys.push(`${providerId}/${key}`);
         }
         for (const runtimeKey of runtimeKeys) {
-          if (!pricedModels.has(runtimeKey) && !hosted.has(runtimeKey)) {
+          if (!metadataOwnedKeys.has(runtimeKey) && !hosted.has(runtimeKey)) {
             hosted.set(runtimeKey, pricing);
           }
         }
@@ -540,10 +567,11 @@ export async function enrichModelCatalogPricing(options: {
   const sources = await fetchPricingSources(options.fetchImpl ?? fetch, policies);
   let enriched = 0;
   const coveredKeys = new Set<string>();
-  const pricedModels = new Set<string>();
+  const metadataOwnedKeys = new Set<string>();
   for (const [providerId, provider] of Object.entries(options.bundle.providers)) {
+    const providerSources = selectProviderPricingSources(providerId, sources, policies);
     for (const model of provider.models) {
-      const matches = sources.map((source) => {
+      const matches = providerSources.map((source) => {
         const candidates = buildPricingCandidates(providerId, model.id, source, policies);
         return {
           source,
@@ -551,30 +579,24 @@ export async function enrichModelCatalogPricing(options: {
           pricing: candidates.map((key) => source.catalog.get(key)).find(Boolean),
         };
       });
-      for (const { source, candidates, pricing } of matches) {
-        if (
-          source.authoritative &&
-          candidates.length > 0 &&
-          model.cost &&
-          hasKnownPricing(model.cost) &&
-          !pricing
-        ) {
-          throw new Error(
-            `${source.label} pricing missing or invalid for ${providerId}/${model.id}`,
-          );
-        }
-      }
       const chosen = matches.find(
-        ({ source, pricing }) => pricing && (source.authoritative || hasKnownPricing(pricing)),
+        ({ source, pricing }) => source.authoritative || (pricing && hasKnownPricing(pricing)),
       );
       if (chosen?.pricing) {
         model.cost = chosen.pricing;
         enriched += 1;
+      } else if (chosen) {
+        // Keep the metadata row: removing it would revive the bundled seed's stale price.
+        delete model.cost;
+        process.stderr.write(
+          `[${SCRIPT_LABEL}] warning: ${chosen.source.label} pricing unavailable for ${providerId}/${model.id}; preserving metadata without cost\n`,
+        );
       }
-      if (model.cost && hasKnownPricing(model.cost)) {
+      // Native zero prices keep standalone entries as evidence of free, not unknown, usage.
+      if ((model.cost && hasKnownPricing(model.cost)) || (chosen && !chosen.pricing)) {
         const key = `${providerId}/${model.id}`;
         coveredKeys.add(key);
-        pricedModels.add(key);
+        metadataOwnedKeys.add(key);
         for (const { candidates } of matches) {
           for (const candidate of candidates) {
             coveredKeys.add(candidate);
@@ -606,7 +628,7 @@ export async function enrichModelCatalogPricing(options: {
   for (const key of coveredKeys) {
     hosted.delete(key);
   }
-  materializePolicyRuntimePricing(hosted, policies, sources, pricedModels);
+  materializePolicyRuntimePricing(hosted, policies, sources, metadataOwnedKeys);
   options.bundle.pricing = Object.fromEntries(
     [...hosted.entries()]
       .toSorted(([left], [right]) => left.localeCompare(right))

--- a/src/plugin-sdk/model-catalog-pricing.ts
+++ b/src/plugin-sdk/model-catalog-pricing.ts
@@ -1,0 +1,5 @@
+// Private official-plugin pricing translation stays independent of auth and runtime loaders.
+export {
+  normalizeModelPricingCatalog,
+  normalizeOpenRouterModelPricing,
+} from "@openclaw/model-catalog-core/model-catalog-pricing";

--- a/src/plugin-sdk/provider-catalog-live-runtime.ts
+++ b/src/plugin-sdk/provider-catalog-live-runtime.ts
@@ -43,7 +43,6 @@ export type LiveModelCatalogHeaderContext = {
   discoveryApiKey?: string;
 };
 
-export { normalizeOpenRouterModelPricing } from "@openclaw/model-catalog-core/model-catalog-pricing";
 export { clearLiveCatalogCacheForTests } from "./provider-catalog-shared.js";
 export {
   readLiveModelCatalogBooleanField,

--- a/test/scripts/publish-model-catalog.test.ts
+++ b/test/scripts/publish-model-catalog.test.ts
@@ -79,8 +79,9 @@ function writeFixtureManifest(root: string, pluginId: string, providers: Record<
   );
 }
 
-function nativeManifests(source: "OpenCode" | "Venice") {
-  const provider = source === "OpenCode" ? "opencode" : "venice";
+function nativeManifests(source: "OpenCode" | "Venice" | "Chutes" | "Cerebras") {
+  const provider = source.toLowerCase();
+  const sourceId = source === "OpenCode" ? "openCode" : provider;
   return [
     {
       pluginId: "fixture",
@@ -96,20 +97,12 @@ function nativeManifests(source: "OpenCode" | "Venice") {
         },
         modelPricing: {
           providers: {
-            [provider]:
-              source === "OpenCode"
-                ? {
-                    external: true,
-                    openCode: { provider: "upstream-zen" },
-                    openRouter: { provider },
-                    liteLLM: { provider },
-                  }
-                : {
-                    external: true,
-                    venice: { provider },
-                    openRouter: { provider },
-                    liteLLM: { provider },
-                  },
+            [provider]: {
+              external: true,
+              [sourceId]: { provider: source === "OpenCode" ? "upstream-zen" : provider },
+              openRouter: { provider },
+              liteLLM: { provider },
+            },
           },
         },
       },
@@ -117,21 +110,24 @@ function nativeManifests(source: "OpenCode" | "Venice") {
   ];
 }
 
-function openCodePrices(cost: Record<string, unknown>) {
+function openCodePrices(
+  cost: Record<string, unknown>,
+  ids = ["priced-fixture", "new-priced-fixture"],
+) {
   return {
     "upstream-zen": {
       id: "upstream-zen",
-      models: {
-        "priced-fixture": { id: "priced-fixture", cost },
-        "new-priced-fixture": { id: "new-priced-fixture", cost },
-      },
+      models: Object.fromEntries(ids.map((id) => [id, { id, cost }])),
     },
   };
 }
 
-function venicePrices(pricing: Record<string, unknown>) {
+function venicePrices(
+  pricing: Record<string, unknown>,
+  ids = ["priced-fixture", "new-priced-fixture"],
+) {
   return {
-    data: ["priced-fixture", "new-priced-fixture"].map((id) => ({
+    data: ids.map((id) => ({
       id,
       type: "text",
       model_spec: { pricing },
@@ -400,6 +396,55 @@ describe("publish model catalog", () => {
     expect(Object.hasOwn(bundle.providers, "unknown")).toBe(false);
   });
 
+  it.each([
+    {
+      source: "Chutes" as const,
+      url: "https://llm.chutes.ai/v1/models",
+      pricing: { prompt: 2, completion: 3, input_cache_read: 0.2 },
+      cost: { input: 2, output: 3, cacheRead: 0.2, cacheWrite: 0 },
+    },
+    {
+      source: "Cerebras" as const,
+      url: "https://api.cerebras.ai/public/v1/models",
+      pricing: { prompt: "0.000002", completion: "0.000003" },
+      cost: { input: 2, output: 3, cacheRead: 0, cacheWrite: 0 },
+    },
+  ])(
+    "publishes $source native rates with the provider's actual units",
+    async ({ source, url, pricing, cost }) => {
+      const provider = source.toLowerCase();
+      const manifests = nativeManifests(source);
+      const bundle = await assembleModelCatalogBundle({
+        manifests,
+        generatedAt: Date.now(),
+        sourceCommit: "fixture",
+      });
+      const fetchImpl = vi.fn<typeof fetch>(async (input, init) => {
+        expect(new Headers(init?.headers).has("authorization")).toBe(false);
+        if (requestUrl(input) === url) {
+          return Response.json({
+            data: ["priced-fixture", "new-priced-fixture", "foreign/hidden"].map((id) => ({
+              id,
+              pricing,
+            })),
+          });
+        }
+        return Response.json({ data: [] });
+      });
+      await enrichModelCatalogPricing({ bundle, manifests, fetchImpl });
+      expect(bundle.providers[provider]?.models[0]?.cost).toEqual(cost);
+      expect(bundle.pricing?.[`${provider}/new-priced-fixture`]).toEqual({
+        input: 2,
+        output: 3,
+        ...(cost.cacheRead > 0 ? { cacheRead: cost.cacheRead } : {}),
+      });
+      expect(bundle.pricing).not.toHaveProperty(`${provider}/priced-fixture`);
+      expect(bundle.pricing).not.toHaveProperty("foreign/hidden");
+      expect(bundle.providers).not.toHaveProperty("foreign");
+      expect(fetchImpl.mock.calls.filter(([input]) => requestUrl(input) === url)).toHaveLength(1);
+    },
+  );
+
   describe.each(NATIVE_SOURCES)("$source native source", ({ source, provider, url }) => {
     it("refreshes one complete owner schedule and publishes new models in that namespace only", async () => {
       const manifests = nativeManifests(source);
@@ -534,100 +579,141 @@ describe("publish model catalog", () => {
       }
     });
 
-    it.each(["missing", "invalid"])(
-      "keeps zero seeds unknown when native pricing is %s",
-      async (scenario) => {
+    it.each([
+      { kind: "paid", cost: { input: 99, output: 99 } },
+      { kind: "zero", cost: { input: 0, output: 0 } },
+      { kind: "unpriced", cost: undefined },
+    ])(
+      "preserves $kind model metadata without inventing an unavailable native price",
+      async ({ cost }) => {
         const manifests = nativeManifests(source);
         const bundle = await assembleModelCatalogBundle({
           manifests,
           generatedAt: Date.now(),
           sourceCommit: "fixture",
         });
-        bundle.providers[provider]!.models[0]!.cost = { input: 0, output: 0 };
-        await enrichModelCatalogPricing({
-          bundle,
-          manifests,
-          fetchImpl: async (input) => {
-            if (requestUrl(input) === OPENROUTER_MODELS_URL) {
+        const model = bundle.providers[provider]!.models[0]!;
+        model.cost = cost;
+        model.name = "Existing explicit model";
+        model.contextWindow = 123_456;
+        model.status = "deprecated";
+        const expected = { ...model };
+        delete expected.cost;
+        const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+        try {
+          await enrichModelCatalogPricing({
+            bundle,
+            manifests,
+            fetchImpl: async (input) => {
+              const request = requestUrl(input);
+              if (request === url) {
+                return Response.json(
+                  source === "OpenCode"
+                    ? openCodePrices({ input: 2, output: 3 }, ["new-priced-fixture"])
+                    : venicePrices({ input: { usd: 2 }, output: { usd: 3 } }, [
+                        "new-priced-fixture",
+                      ]),
+                );
+              }
+              if (request === OPENROUTER_MODELS_URL) {
+                return Response.json({
+                  data: [
+                    { id: `${provider}/priced-fixture`, pricing: { prompt: "1", completion: "1" } },
+                    {
+                      id: `${provider}/absent-unbundled`,
+                      pricing: { prompt: "1", completion: "1" },
+                    },
+                  ],
+                });
+              }
               return Response.json({
-                data: [
-                  { id: `${provider}/priced-fixture`, pricing: { prompt: "0", completion: "0" } },
-                ],
+                "priced-fixture": {
+                  litellm_provider: provider,
+                  input_cost_per_token: 1,
+                  output_cost_per_token: 1,
+                },
               });
-            }
-            if (requestUrl(input) !== url) {
-              return Response.json({ data: [] });
-            }
-            return Response.json(
-              source === "OpenCode"
-                ? scenario === "missing"
-                  ? { "upstream-zen": { id: "upstream-zen", models: {} } }
-                  : openCodePrices({ input: 0 })
-                : scenario === "missing"
-                  ? { data: [] }
-                  : venicePrices({ input: { usd: 0 } }),
-            );
-          },
-        });
-        expect(bundle.pricing).toEqual({});
-        expect(
-          resolveModelCostConfig({
-            ...publishedPricingParams(bundle, provider),
-            model: "priced-fixture",
-          }),
-        ).toBeUndefined();
+            },
+          });
+          expect(bundle.providers[provider]?.models[0]).toEqual(expected);
+          expect(bundle.pricing).not.toHaveProperty(`${provider}/priced-fixture`);
+          expect(bundle.pricing).not.toHaveProperty(`${provider}/absent-unbundled`);
+          expect(bundle.pricing).not.toHaveProperty("priced-fixture");
+          expect(bundle.pricing?.[`${provider}/new-priced-fixture`]).toEqual({
+            input: 2,
+            output: 3,
+          });
+          expect(stderr.mock.calls.map(([message]) => String(message)).join("")).toContain(
+            `${source} pricing unavailable for ${provider}/priced-fixture`,
+          );
+          expect(
+            resolveModelCostConfig({
+              ...publishedPricingParams(bundle, provider),
+              model: "priced-fixture",
+            }),
+          ).toBeUndefined();
+        } finally {
+          stderr.mockRestore();
+        }
       },
     );
 
-    it.each(["unreachable", "malformed JSON", "malformed body", "missing model", "invalid price"])(
-      "rejects %s instead of re-stamping stale paid seed rates",
-      async (scenario) => {
-        const manifests = nativeManifests(source);
-        const bundle = await assembleModelCatalogBundle({
-          manifests,
-          generatedAt: Date.now(),
-          sourceCommit: "fixture",
-        });
-        const fetchImpl: typeof fetch = async (input) => {
-          const request = requestUrl(input);
-          if (request === OPENROUTER_MODELS_URL) {
-            return Response.json({ data: [] });
-          }
-          if (request === LITELLM_PRICING_URL) {
-            return Response.json({});
-          }
-          expect(request).toBe(url);
-          if (scenario === "unreachable") {
-            throw new Error("source unavailable");
-          }
-          if (scenario === "malformed JSON") {
-            return new Response("not JSON");
-          }
-          if (scenario === "malformed body") {
-            return Response.json({});
-          }
-          if (scenario === "missing model") {
-            return Response.json(
-              source === "OpenCode"
-                ? { "upstream-zen": { id: "upstream-zen", models: {} } }
-                : { data: [] },
-            );
-          }
+    it.each([
+      "unreachable",
+      "malformed JSON",
+      "malformed body",
+      "empty catalog",
+      "invalid price",
+      "invalid zero seed",
+    ])("rejects %s instead of publishing unverified prices", async (scenario) => {
+      const manifests = nativeManifests(source);
+      const bundle = await assembleModelCatalogBundle({
+        manifests,
+        generatedAt: Date.now(),
+        sourceCommit: "fixture",
+      });
+      if (scenario === "invalid zero seed") {
+        bundle.providers[provider]!.models[0]!.cost = { input: 0, output: 0 };
+      }
+      const fetchImpl: typeof fetch = async (input) => {
+        const request = requestUrl(input);
+        if (request === OPENROUTER_MODELS_URL) {
+          return Response.json({ data: [] });
+        }
+        if (request === LITELLM_PRICING_URL) {
+          return Response.json({});
+        }
+        expect(request).toBe(url);
+        if (scenario === "unreachable") {
+          throw new Error("source unavailable");
+        }
+        if (scenario === "malformed JSON") {
+          return new Response("not JSON");
+        }
+        if (scenario === "malformed body") {
+          return Response.json({});
+        }
+        if (scenario === "empty catalog") {
           return Response.json(
             source === "OpenCode"
-              ? openCodePrices({ input: -1, output: 2 })
-              : venicePrices({
-                  input: { usd: 2 },
-                  output: { usd: 10 },
-                  extended: { context_token_threshold: 200_000, input: { usd: 4 } },
-                }),
+              ? { "upstream-zen": { id: "upstream-zen", models: {} } }
+              : { data: [] },
           );
-        };
-        await expect(enrichModelCatalogPricing({ bundle, manifests, fetchImpl })).rejects.toThrow(
-          `${source} pricing`,
+        }
+        return Response.json(
+          source === "OpenCode"
+            ? openCodePrices({ input: -1, output: 2 })
+            : venicePrices({
+                input: { usd: 2 },
+                output: { usd: 10 },
+                extended: { context_token_threshold: 200_000, input: { usd: 4 } },
+              }),
         );
-      },
-    );
+      };
+      await expect(enrichModelCatalogPricing({ bundle, manifests, fetchImpl })).rejects.toThrow(
+        `${source} pricing`,
+      );
+    });
 
     it.each(["missing policy", "unowned policy", "disabled policy"])(
       "does not fetch without an owning opt-in: %s",


### PR DESCRIPTION
Closes #134248 (Chutes hosted cache-read prices drift from the native catalog).

<details>
<summary>Additional instructions</summary>

This branch is in `openclaw/openclaw`; maintainers with repository write access can take it over.

</details>

## What Problem This Solves

Fixes an issue where users viewing Chutes cost estimates could receive stale cache-read rates even though Chutes advertised newer prices. The hosted catalog had no Chutes-native source, and fresh provider setup copied generated prices into explicit configuration, preventing later catalog refreshes from taking effect. Cerebras also depended entirely on its bundled catalog despite offering anonymous native model metadata and prices.

The live Chutes comparison found cache-read estimates of $0.50 versus approximately $0.10 per million for DeepSeek V3.2, and $0.625 versus approximately $0.125 for GLM 5.2. This affects estimates, not provider billing or message delivery.

## Why This Change Was Made

Use provider-owned native pricing artifacts for Chutes and Cerebras through the existing shared publisher. Chutes discovery and publication share one numeric USD-per-million parser; Cerebras uses the existing per-token conversion and shared guarded discovery, with public Accept-only requests fenced to its canonical inference endpoint. Fresh merge-mode setup leaves generated model rows out of authored configuration; explicit replace-mode seeds remain supported.

A valid native feed can withdraw a price without retiring a model. Publication now preserves that metadata row without cost, emits a warning, and refuses to substitute stale or generic prices. Malformed declared prices, invalid/duplicate identities, unusable feeds, and native-source outages still stop publication before output replacement. Genuine native zero prices retain their standalone hosted evidence. Existing OpenCode/Venice consumers share the same integrity boundary.

Pure translation was extracted from the heavy private provider-runtime facade into a private, JavaScript-packaged SDK subpath. The public SDK footprint is unchanged: 147 entrypoints, 4,353 exports, and 2,591 callable exports. No new store, polling loop, operator option, dependency, or runtime type expansion.

The cleanup removes unused Chutes fake-timer support and repairs the maintainer workflow guidance that caused this landing to stall: choose an ordinary, full-history/full-blob checkout inside the editor's writable workspace before native review, and preserve the generated review identity line. Canonical worktree ownership, wrapper provenance, locks, recovery evidence, cleanup, and artifact validation remain unchanged; no path override or weaker permission mode was added.

## User Impact

Chutes and Cerebras can receive advertised pricing updates through the existing hosted-catalog refresh lifecycle. Cerebras runtime discovery also picks up native capabilities and limits without sending inference credentials to the public catalog; custom inference base URLs skip that native discovery. Public metadata does not prove account entitlement.

Fresh default/merge onboarding no longer pins generated prices. Existing explicit model costs—including values copied by older setup—remain unchanged. An operator who wants an existing configured model to inherit advertised rates can remove that model's explicit cost override; intentional custom and zero prices should remain pinned. Replace mode continues to retain offline seed rows.

Missing native prices are unknown, not free. Shipped legacy model references remain present; Cerebras GLM 4.7 is marked deprecated according to its published deprecation notice, without an invented replacement. Public Cerebras rates are standard estimates, not an enterprise-cache or invoice claim.

Release boundary: the new private runtime subpath requires the next coordinated host/plugin release. Standard release preparation raises existing `compat.pluginApi` floors to that host version. Chutes, Cerebras, and Venice must not publish these plugin changes independently against the old floor; a plugin-only release needs the actual first supporting host version. This PR does not bump versions or publish software.

## Evidence

Exact-head CI for `5623b86c7b5f4611afac4c4ab3ca0f20812a0b3e` finished GREEN with `pending=0`: https://github.com/openclaw/openclaw/actions/runs/33428084182.

- Captured 33 intended pre-fix failures across publisher, provider discovery, and onboarding boundaries. A separate duplicate/unpriced-ID regression was captured and repaired in the new shared validator.
- 202 focused tests passed: 76 pure pricing tests, 42 publisher tests, 66 Chutes/OpenRouter/Venice tests, and 18 Cerebras tests. Coverage includes native units, zero rates, missing/invalid prices, stale-price suppression, output preservation, provider namespace ownership, proxy/credential isolation, offline recovery, and explicit override preservation.
- Full changed-file verification passed, including the five doctor-contract tests, SDK registration/surface checks, all TypeScript lanes, lint, dead exports, and zero runtime import cycles.
- Anonymous publisher dry-run passed with 263 metadata models, 108 enriched models, and a 1,872,588-byte artifact, below the existing 4 MiB client limit. No timeout or size limit was raised.
- Independent live comparison rerun on final head `5623b86c7b5f4611afac4c4ab3ca0f20812a0b3e` at 2026-08-31 19:11 UTC checked all 64 normalized rate fields from 2 Cerebras and 14 Chutes rows. The candidate retained one Cerebras and two Chutes seed rows without cost when the native feed omitted their prices.
- Real guarded runtime discovery rerun at 2026-08-31 19:11 UTC returned those 2/14 model counts. Undici diagnostics observed exactly two public GET requests, both HTTP 200 and neither carrying Authorization. The real footer formatter produced `est $0.0025` and `est $0.0005` for synthetic token usage against freshly discovered sample rates. The first probe instrumented ambient fetch rather than the guard's Undici dispatcher; it was corrected to observe the actual transport. A sub-trillionth-dollar floating-point comparison uses a numeric tolerance.
- Full `pnpm build` passed, including the new private SDK artifact; no ineffective dynamic-import warnings. Production code did not change during cleanup. Cleanup reran all 19 Chutes tests and the two-file changed gate successfully; final complete-candidate Codex autoreview returned scoped-clean at P0.
- The native workflow repair is exercised, not just described: fresh review initialization, head guard, editor writes and native artifact validation all succeeded inside the contained checkout on the final head. The interrupted initial filtered checkout and original denied workspace remain preserved; no guard or recovery journal was bypassed.

Commands run:

```bash
node scripts/run-vitest.mjs packages/model-catalog-core/src/model-catalog-pricing.test.ts test/scripts/publish-model-catalog.test.ts extensions/chutes/models.test.ts extensions/cerebras/onboard.test.ts extensions/openrouter/provider-catalog.test.ts extensions/venice/models.test.ts
```

```bash
node scripts/check-changed.mjs
```

```bash
pnpm build
```

```bash
node --import tsx scripts/publish-model-catalog.mts --pricing --dry-run
```

Cleanup and native review verification:

```bash
node scripts/run-vitest.mjs extensions/chutes/models.test.ts
```

```bash
node scripts/check-changed.mjs -- .agents/skills/openclaw-pr-maintainer/SKILL.md extensions/chutes/models.test.ts
```

```bash
scripts/pr review-validate-artifacts 134311
```

Task-local live probes (retained locally, not shipped product files):

```bash
node --import tsx .artifacts/native-pricing-campaign/verify-native-prices.mts
```

```bash
node --import tsx .artifacts/native-pricing-campaign/verify-native-runtime.mts
```

Production/tooling: +238/-74 (net +164); production/registration metadata: +36/-13 (net +23); tests: +668/-228 (net +440); docs/instructions: +130/-27 (net +103). The growth adds previously missing Cerebras discovery and two native publication integrations with a shared strict validation boundary. Removed paths include the duplicate Venice catalog-validation loop and redundant Chutes fallback; no duplicate fetch/cache implementation was added.

Proof limits: no real provider credentials, inference calls, billing receipts, subscription charges, operator Gateway changes, or live chat/channel sends. The live evidence covers native metadata HTTP and actual footer rendering, not an end-to-end paid conversation. Post-merge [catalog publication](https://github.com/openclaw/catalog/actions/runs/33431143994) succeeded. At 2026-08-31 19:35 UTC, the actual client URL served source `9d3cf37c71ff4dee1f103f0b341f20f4251292c2`, containing merge `8affd61977b5c6a34881560aaf7c65dbe06e9187`; all 64 native rate fields and three metadata-only legacy rows were verified. Client activation still follows the documented refresh/restart lifecycle; no operator Gateway activation is claimed.

Sources: [Cerebras public models](https://inference-docs.cerebras.ai/api-reference/models/public-models), [Cerebras deprecation notice](https://inference-docs.cerebras.ai/support/deprecation), [Chutes native catalog](https://llm.chutes.ai/v1/models), [hosted refresh lifecycle](https://docs.openclaw.ai/concepts/models#hosted-catalog-updates).
