### PR TITLE
fix(state): converge same-version session schema before the v17 canonical guard

### DIFF
--- a/src/infra/state-migrations.media-persistence.historical-schema.test-support.ts
+++ b/src/infra/state-migrations.media-persistence.historical-schema.test-support.ts
@@ -1,3 +1,4 @@
+import { withLegacySessionParticipantsSchema } from "../state/openclaw-agent-participants-migration.js";
 import { OPENCLAW_AGENT_SCHEMA_SQL } from "../state/openclaw-agent-schema.js";
 
 const HISTORICAL_AGENT_LEASE_SCHEMA = `CREATE TABLE IF NOT EXISTS state_leases (
@@ -116,5 +117,36 @@ export function historicalV14AgentSchemaSql(): string {
     historicalV15AgentSchemaSql(),
     "\nCREATE TABLE IF NOT EXISTS session_suggestions (",
     "CREATE TABLE IF NOT EXISTS board_tabs (",
+  );
+}
+
+/**
+ * A v17 database from a binary that predates the same-version additive session
+ * convergence: the canonical v17 contract (legacy session_participants) minus
+ * the objects `ensureSessionAdditiveColumns` installs, minus the two
+ * context-pending indexes whose columns it adds. Not exact release bytes — the
+ * lineage that stamped v17 before the route-context convergence is not
+ * captured here; the stamped version plus these missing objects are what the
+ * v17 canonical guard asserts on.
+ */
+export function historicalV17AgentSchemaSql(): string {
+  let sql = withLegacySessionParticipantsSchema(OPENCLAW_AGENT_SCHEMA_SQL)
+    .replace("  route_context_json TEXT,\n", "")
+    .replace("  context_eligible INTEGER,\n", "")
+    .replace("  project_id TEXT,\n", "");
+  sql = removeSchemaRange(
+    sql,
+    "-- Older same-version writers preserve the envelope while updating the association.",
+    "CREATE INDEX IF NOT EXISTS idx_agent_session_conversations_conversation",
+  );
+  sql = removeSchemaRange(
+    sql,
+    "CREATE INDEX IF NOT EXISTS idx_agent_transcript_context_pending",
+    "CREATE VIRTUAL TABLE IF NOT EXISTS session_transcript_fts",
+  );
+  return removeSchemaRange(
+    sql,
+    "CREATE INDEX IF NOT EXISTS idx_agent_transcript_event_identity_sequence",
+    "CREATE INDEX IF NOT EXISTS idx_agent_transcript_event_parent",
   );
 }

--- a/src/infra/state-migrations.media-persistence.historical-v17.test.ts
+++ b/src/infra/state-migrations.media-persistence.historical-v17.test.ts
@@ -1,0 +1,125 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
+import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  OPENCLAW_AGENT_SCHEMA_VERSION,
+} from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import { historicalV17AgentSchemaSql } from "./state-migrations.media-persistence.historical-schema.test-support.js";
+import { migrateLegacyMediaPersistence } from "./state-migrations.media-persistence.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  cleanupTempDirs(tempDirs);
+});
+
+describe("same-version additive convergence before the v17 canonical guard", () => {
+  it("migrates a v17 database that predates the route-context additive objects", async () => {
+    const stateDir = makeTempDir(tempDirs, "media-persistence-historical-v17-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const databasePath = path.join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite");
+    fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+
+    const { DatabaseSync } = requireNodeSqlite();
+    const historical = new DatabaseSync(databasePath);
+    try {
+      historical.exec(historicalV17AgentSchemaSql());
+      historical.exec("PRAGMA user_version = 17;");
+      historical
+        .prepare(
+          `INSERT INTO schema_meta (
+             meta_key, role, schema_version, agent_id, app_version, created_at, updated_at
+           ) VALUES ('primary', 'agent', 17, 'main', '2026.8.1-beta.2', 1000, 1000)`,
+        )
+        .run();
+      const entry = JSON.stringify({
+        sessionId: "historical-v17",
+        status: "done",
+        updatedAt: 1000,
+      });
+      historical
+        .prepare(
+          `INSERT INTO session_nodes (
+             session_key, current_session_id, entry_json, updated_at, status, created_at, created_via
+           ) VALUES (?, ?, ?, ?, 'done', ?, 'operator')`,
+        )
+        .run("agent:main:historical-v17", "historical-v17", entry, 1000, 1000);
+      historical
+        .prepare(
+          `INSERT INTO session_windows (
+             session_id, session_key, session_scope, created_at, updated_at, status, display_name
+           ) VALUES (?, ?, 'conversation', ?, ?, 'done', 'historical v17')`,
+        )
+        .run("historical-v17", "agent:main:historical-v17", 1000, 1000);
+      const event = {
+        id: "event-v17",
+        message: { content: "historical", role: "user" },
+        parentId: null,
+        timestamp: 1000,
+        type: "message",
+      };
+      historical
+        .prepare(
+          "INSERT INTO transcript_events (session_id, seq, event_json, created_at) VALUES (?, 0, ?, ?)",
+        )
+        .run("historical-v17", JSON.stringify(event), 1100);
+      historical
+        .prepare(
+          `INSERT INTO transcript_event_identities (
+             session_id, event_id, seq, event_type, parent_id, message_idempotency_key, created_at
+           ) VALUES (?, ?, 0, 'message', NULL, NULL, ?)`,
+        )
+        .run("historical-v17", "event-v17", 1100);
+    } finally {
+      historical.close();
+    }
+    registerOpenClawAgentDatabase({ agentId: "main", env, path: databasePath, schemaVersion: 17 });
+
+    const result = await migrateLegacyMediaPersistence({ env });
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([
+      expect.stringContaining(
+        `Upgraded agent database schema in ${databasePath}: v17 -> v${OPENCLAW_AGENT_SCHEMA_VERSION}.`,
+      ),
+    ]);
+    closeOpenClawAgentDatabasesForTest();
+
+    const migrated = new DatabaseSync(databasePath, { readOnly: true });
+    try {
+      expect(migrated.prepare("PRAGMA user_version").get()).toEqual({
+        user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
+      });
+      expect(
+        migrated
+          .prepare(
+            "SELECT count(*) AS c FROM sqlite_schema WHERE type = 'trigger' AND name = 'session_conversations_route_context_invalidate_after_update'",
+          )
+          .get(),
+      ).toEqual({ c: 1 });
+      expect(
+        migrated
+          .prepare(
+            "SELECT count(*) AS c FROM pragma_table_info('session_conversations') WHERE name = 'route_context_json'",
+          )
+          .get(),
+      ).toEqual({ c: 1 });
+      // The drifted index whose repair exposed the guard must exist again.
+      expect(
+        migrated
+          .prepare(
+            "SELECT count(*) AS c FROM sqlite_schema WHERE type = 'index' AND name = 'idx_agent_transcript_event_identity_sequence'",
+          )
+          .get(),
+      ).toEqual({ c: 1 });
+    } finally {
+      migrated.close();
+    }
+  });
+});

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -194,6 +194,19 @@ export function ensureSessionKeyContractSchemaInTransaction(db: DatabaseSync): v
   db.exec(OPENCLAW_AGENT_SCHEMA_SQL.slice(start, end)); // sqlite-allow-raw -- Idempotent additive lazy ensure.
 }
 
+/**
+ * Install every same-version additive session object. Databases opened by a
+ * binary older than a later same-version addition converge here, so canonical
+ * schema guards must run this before asserting the current shape — the guard
+ * would otherwise demand as a precondition exactly the objects it exists to
+ * validate.
+ */
+export function convergeSameVersionSessionSchema(db: DatabaseSync): void {
+  ensureSessionAdditiveColumns(db);
+  ensureSessionEntryValidityProjection(db);
+  ensureSessionKeyContractSchemaInTransaction(db);
+}
+
 export function repairAndAssertOpenClawAgentV14SchemaForMigration(
   database: DatabaseSync,
   options: { agentId: string; pathname: string },
@@ -218,9 +231,7 @@ export function repairAndAssertOpenClawAgentV14SchemaForMigration(
     );
   }
 
-  ensureSessionAdditiveColumns(database);
-  ensureSessionEntryValidityProjection(database);
-  ensureSessionKeyContractSchemaInTransaction(database);
+  convergeSameVersionSessionSchema(database);
 
   // v14 always owned the core schema. Board and collaboration groups were
   // lazy, but a partially present group still has to be complete and canonical.

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -36,11 +36,11 @@ import {
   assertOpenClawAgentCurrentRuntimeSchema,
   assertSupportedAgentSchemaVersion,
   assertAgentSchemaVersion,
+  convergeSameVersionSessionSchema,
   hasRetiredAgentStateLeaseSchema,
   hasPendingMemoryChunkMetadataMigration,
   migrateRetiredAgentStateLeaseSchema,
   migratedSessionColumn,
-  ensureSessionKeyContractSchemaInTransaction,
   readExistingAgentSchemaMeta,
   repairAndAssertOpenClawAgentV14SchemaForMigration,
 } from "./openclaw-agent-db-schema-helpers.js";
@@ -588,9 +588,7 @@ function ensureAgentSchema(
       }
       migrateRetiredAgentStateLeaseSchema(db, pathname, targetVersion);
       if (previousVersion === targetVersion) {
-        ensureSessionAdditiveColumns(db);
-        ensureSessionEntryValidityProjection(db);
-        ensureSessionKeyContractSchemaInTransaction(db);
+        convergeSameVersionSessionSchema(db);
         if (hasPendingMemoryChunkMetadataMigration(db)) {
           migrateMemoryChunkMetadataSchema(db);
           db.exec(schemaSql);
@@ -717,12 +715,20 @@ export function ensureOpenClawAgentDatabaseSchema(
     // Keep canonical index recovery reachable before rebuilding the v17 identity table.
     verifyAndRepairCanonicalSqliteIndexes(db, pathname, legacySql, {
       allowMissingColumns: true,
-      validateAfterRepair: () =>
+      validateAfterRepair: () => {
+        // A v17 database from a binary predating the same-version additive
+        // session objects is missing exactly what the canonical assertion
+        // demands; converge first or every such database stays stranded on the
+        // version the doctor message itself prescribes fixing. Inside this
+        // savepoint the repair, convergence, and assertion commit or roll back
+        // as one step.
+        convergeSameVersionSessionSchema(db);
         assertAgentSchemaVersion(
           db,
           { agentId, pathname, version: AGENT_MEDIA_SCHEMA_VERSION },
           legacySql,
-        ),
+        );
+      },
     });
   }
   assertAgentDatabaseIntegrityBeforeMutation(db, agentId, pathname);


### PR DESCRIPTION
Closes #134163

## What Problem This Solves

An agent database stamped `user_version = 17` by a binary that predates the same-version route-context additive session objects could never be migrated. The v17 preflight in `ensureOpenClawAgentDatabaseSchema` runs canonical index repair whose `validateAfterRepair` asserts the full current canonical schema — including `session_conversations_route_context_invalidate_after_update` and the `route_context_json` column its body reads — before `ensureAgentSchema` converges those objects. Every open and every `openclaw doctor --fix` therefore aborted with:

```
Error: SQLite canonical index idx_agent_transcript_event_identity_sequence failed for …:
SQLite schema is incomplete or noncanonical for …: missing or drifted trigger
session_conversations_route_context_invalidate_after_update
```

caught and downgraded to `Skipped agent database migration for …`, leaving the database at version 17 forever — the exact version the guard's own operator message prescribes fixing with `openclaw doctor --fix`. The two DDL statements that would satisfy the assertion ship in the same bundle; they were simply never reached on this lineage.

## Why This Change Was Made

The canonical guard must validate post-convergence shape, not demand it as a precondition. `repairAndAssertOpenClawAgentV14SchemaForMigration` already converges the same-version additive session objects before it asserts; the v17 guard was missing that ordering. The fix converges the same-version trio inside the repair savepoint, before `assertAgentSchemaVersion`, so repair + convergence + assertion commit or roll back as one step, and the integrity proof at the start of `verifyAndRepairCanonicalSqliteIndexes` still precedes every mutation.

The trio (`ensureSessionAdditiveColumns` → `ensureSessionEntryValidityProjection` → `ensureSessionKeyContractSchemaInTransaction`) already existed verbatim in the v14 preflight and in the same-version arm of `ensureAgentSchema`; it is extracted into `convergeSameVersionSessionSchema` and called from all three sites.

No new DDL. Additive-only convergence, structure-gated per object; same-version convergence stays idempotent, and the later migration path re-runs it harmlessly.

## User Impact

`openclaw doctor --fix` now migrates a schema-17 database from the affected lineage to version 19 instead of skipping it with a warning that sends the operator back to the command that failed. Gateway startup on such a host no longer hard-stops in a supervisor restart loop.

## Evidence

- Regression fixture: `src/infra/state-migrations.media-persistence.historical-v17.test.ts` builds a v17 database from the canonical v17 contract minus the same-version additive objects (legacy session-participants shape), seeds rows, and runs the real Doctor migration (`migrateLegacyMediaPersistence`).
- Pre-fix failure, reproduced on this PR's base before the change — the reporter's verbatim error:
  ```
  Skipped agent database migration for …/openclaw-agent.sqlite: Error: SQLite canonical index
  idx_agent_transcript_event_identity_sequence failed for …/openclaw-agent.sqlite: SQLite schema
  is incomplete or noncanonical for …/openclaw-agent.sqlite: missing or drifted trigger
  session_conversations_route_context_invalidate_after_update; column definitions differ for session_nodes
  ```
  with `user_version` still 17 after the run.
- Post-fix: the same fixture converges — `result.warnings` empty, `changes` records `Upgraded agent database schema in …: v17 -> v19.`, `user_version` 19, the route-context trigger, `route_context_json`, and the repaired `idx_agent_transcript_event_identity_sequence` all present.
- Sibling coverage green after the refactor: `node scripts/run-vitest.mjs src/infra/state-migrations.media-persistence src/state/openclaw-agent-db.test.ts src/state/openclaw-agent-db-session-migrations.test.ts` — 7 files, 29 tests, including the v14/v15 historical ladders and `media-persistence.additive-schema.test.ts`.
- Types and lint: `node scripts/run-tsgo.mjs -p tsconfig.core.json` clean; infra test shard clean; `node_modules/.bin/oxlint -c .oxlintrc.json` clean on touched files; `oxfmt` applied.

## Production vs test LOC

Production +11 net (guard convergence + shared helper, minus the two pre-existing duplicate sequences it absorbs); tests +157 (fixture builder + regression test).
