### PR TITLE
test(xai): verify OAuth runtime imports stay lazy

### DIFF
--- a/extensions/xai/xai-oauth-entry.test.ts
+++ b/extensions/xai/xai-oauth-entry.test.ts
@@ -1,11 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const oauthRuntimeMocks = vi.hoisted(() => ({
-  loginXaiDeviceCode: vi.fn(),
-  refreshXaiOAuthCredential: vi.fn(),
+const { oauthRuntimeMocks, oauthRuntimeLoaded } = vi.hoisted(() => ({
+  oauthRuntimeMocks: {
+    loginXaiDeviceCode: vi.fn(),
+    refreshXaiOAuthCredential: vi.fn(),
+  },
+  oauthRuntimeLoaded: vi.fn(),
 }));
 
-vi.mock("./xai-oauth.js", () => oauthRuntimeMocks);
+vi.mock("./xai-oauth.js", () => {
+  oauthRuntimeLoaded();
+  return oauthRuntimeMocks;
+});
 
 beforeEach(() => {
   vi.resetModules();
@@ -26,10 +32,12 @@ describe("xAI OAuth lazy entry", () => {
     const entry = await import("./xai-oauth-entry.js");
     const method = entry.createXaiOAuthAuthMethod();
 
+    expect(oauthRuntimeLoaded).not.toHaveBeenCalled();
     expect(oauthRuntimeMocks.loginXaiDeviceCode).not.toHaveBeenCalled();
     expect(oauthRuntimeMocks.refreshXaiOAuthCredential).not.toHaveBeenCalled();
 
     await method.run({} as never);
+    expect(oauthRuntimeLoaded).toHaveBeenCalledOnce();
     expect(oauthRuntimeMocks.loginXaiDeviceCode).toHaveBeenCalledOnce();
 
     await entry.refreshXaiOAuthCredential({
@@ -39,6 +47,7 @@ describe("xAI OAuth lazy entry", () => {
       refresh: "refresh",
       expires: 1,
     });
+    expect(oauthRuntimeLoaded).toHaveBeenCalledOnce();
     expect(oauthRuntimeMocks.refreshXaiOAuthCredential).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The xAI lazy-entry test checked that OAuth operations had not run, but it still passed if the entry eagerly imported the OAuth runtime. It could not detect the startup-loading regression named by the test.

## Why This Change Was Made

Observe realization of the existing runtime mock factory. Assert that importing the entry and constructing its method leave the runtime unloaded, then retain the operation assertions and verify loading begins on use. The generic lazy-runtime suite continues to own loader caching behavior.

## User Impact

Test-only improvement: production +0/-0; tests +13/-4. No OAuth behavior, timeout, or runtime implementation changes.

## Evidence

- All 20 tests passed before and after across `extensions/xai/xai-oauth-entry.test.ts`, `extensions/xai/xai-oauth.test.ts`, and `src/shared/lazy-runtime.test.ts`.
- A temporary eager import in the real entry made the original test pass and the new test fail at the unloaded assertion. Restored the production file byte-for-byte before the passing run.
- Full changed-file checks, formatting, diff checks, and structured Codex autoreview passed.
- Inspected the entry, plugin registration, OAuth owner, lazy-runtime/promise helpers, installed Vitest mock-factory realization, and introducing history. This checks deferred loading; it makes no live OAuth or startup benchmark claim.
