### PR TITLE
fix(agents): preserve Code Mode budget across clock rollback

### DIFF
--- a/src/agents/agent-run-approval-wait.test.ts
+++ b/src/agents/agent-run-approval-wait.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { emitAgentEvent } from "../infra/agent-events.js";
+import { observeAgentRunApprovalWait } from "./agent-run-approval-wait.js";
+
+describe("observeAgentRunApprovalWait", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not report a negative pause when the wall clock rolls back", () => {
+    vi.useFakeTimers({ toFake: ["Date", "performance"] });
+    vi.setSystemTime(100);
+    const wait = observeAgentRunApprovalWait({ runId: "run-1", sessionId: "session-1" });
+
+    emitAgentEvent({
+      runId: "run-1",
+      sessionId: "session-1",
+      stream: "lifecycle",
+      data: { phase: "waiting-approval", approvalId: "approval-1" },
+    });
+    vi.advanceTimersByTime(25);
+    vi.setSystemTime(50);
+    emitAgentEvent({
+      runId: "run-1",
+      sessionId: "session-1",
+      stream: "lifecycle",
+      data: { phase: "approval-resolved", approvalId: "approval-1" },
+    });
+
+    expect(wait.pausedMs).toBe(25);
+    wait.dispose();
+  });
+});

--- a/src/agents/agent-run-approval-wait.ts
+++ b/src/agents/agent-run-approval-wait.ts
@@ -50,9 +50,9 @@ export function observeAgentRunApprovalWait(params: {
       return;
     }
     if (pending) {
-      pausedAtMs = Date.now();
+      pausedAtMs = performance.now();
     } else {
-      state.pausedMs += Date.now() - pausedAtMs;
+      state.pausedMs += Math.max(0, performance.now() - pausedAtMs);
     }
     state.pending = pending;
     state.onChange?.(pending);

--- a/src/agents/code-mode-execution.ts
+++ b/src/agents/code-mode-execution.ts
@@ -82,7 +82,7 @@ export async function runCodeModeExec(params: {
   });
   params.onRuntime?.(runtime);
   const bridgeDispatch = createCodeModeBridgeDispatchState();
-  const deadlineMs = Date.now() + config.timeoutMs;
+  const deadlineMs = performance.now() + config.timeoutMs;
   const namespaceCatalog = runtime.namespaceEntries();
   const swarmEnabled = resolveSwarmConfig(
     params.ctx.runtimeConfig ?? params.ctx.config,
@@ -106,12 +106,12 @@ export async function runCodeModeExec(params: {
   try {
     const source = await awaitCodeModeDeadline({
       operation: () => prepareSource({ code: params.code, language: params.language, config }),
-      remainingMs: deadlineMs - Date.now(),
+      remainingMs: deadlineMs - performance.now(),
       signal,
       createTimeoutError: () => new Error("interrupted"),
       createAbortError: () => new Error("code mode execution aborted"),
     });
-    const remainingMs = deadlineMs - Date.now();
+    const remainingMs = deadlineMs - performance.now();
     if (remainingMs <= 0) {
       throw new Error("interrupted");
     }
@@ -181,7 +181,7 @@ function usableResumeBudgetMs(deadlineMs: number, config: CodeModeConfig): numbe
   // resuming with less than this floor converts an otherwise successful run
   // into an immediate interrupt timeout, so callers park the snapshot instead.
   const minimum = Math.min(250, Math.max(1, Math.floor(config.timeoutMs / 2)));
-  const remaining = deadlineMs - Date.now();
+  const remaining = deadlineMs - performance.now();
   return remaining >= minimum ? remaining : undefined;
 }
 
@@ -278,7 +278,7 @@ async function settleCodeModeResult(params: {
   }
   const activeRunId = params.owner.runId;
   const output = params.output;
-  // One exec/wait call shares a single wall-clock deadline across its initial
+  // One exec/wait call shares a single monotonic deadline across its initial
   // worker run and this inline settle phase, so auto-draining bridge calls
   // cannot stack a second full `timeoutMs` budget on top of the run that
   // produced them. The deadline is also the only bound on sequential drain
@@ -307,7 +307,7 @@ async function settleCodeModeResult(params: {
     ) {
       break;
     }
-    const remainingMs = settleDeadline() - Date.now();
+    const remainingMs = settleDeadline() - performance.now();
     if (remainingMs <= 0) {
       break;
     }
@@ -337,7 +337,7 @@ async function settleCodeModeResult(params: {
           namespaceRuntime: params.namespaceRuntime,
           parentToolCallId: params.parentToolCallId,
           codeModeRunId: params.codeModeReplayId,
-          remainingMs: settleDeadline() - Date.now(),
+          remainingMs: settleDeadline() - performance.now(),
           activeRunId,
           ctx: params.ctx,
           signal: params.signal,
@@ -558,9 +558,9 @@ export async function runWait(params: {
   }
   params.onRuntime?.(state.runtime);
   resumingRunIds.add(state.runId);
-  // One wait call shares a single wall-clock deadline across draining the prior
+  // One wait call shares a single monotonic deadline across draining the prior
   // pending calls, the resume worker, and the inline settle phase.
-  const deadlineMs = Date.now() + state.config.timeoutMs;
+  const deadlineMs = performance.now() + state.config.timeoutMs;
   const approvalWait = observeAgentRunApprovalWait(state.ctx);
   const signal = state.owner.bindCall(
     params.ctx.abortSignal && params.signal
@@ -572,7 +572,7 @@ export async function runWait(params: {
     const ready = await waitForPending(
       state.pending,
       state.settlementMode,
-      Math.max(1, deadlineMs - Date.now()),
+      Math.max(1, deadlineMs - performance.now()),
       approvalWait,
       signal,
     );


### PR DESCRIPTION
<!-- Source-first agents bug fix; no public issue is linked. -->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where an approval-required Code Mode tool call could lose part of its remaining execution budget when the Gateway host system clock moved backward while an operator was deciding.

## Why This Change Was Made

Approval pause accounting and Code Mode execution deadlines now use the process monotonic clock, so wall-clock adjustments cannot produce negative paused time or mix incompatible deadline bases. The existing approval ownership, cancellation, persistence, and wall-clock snapshot-expiry behavior are unchanged.

## User Impact

Code Mode runs waiting for human approval no longer expire prematurely after a system clock rollback. Normal approval, cancellation, and suspended-run behavior remains unchanged.

## Evidence

### Failing before, passing after

- On the unmodified implementation, the regression case produced `pausedMs=-50` after the wall clock moved from 100 to 50.
- On the final implementation, the same case records elapsed approval time from the monotonic clock and passes.

### Final behavior proof

The production Code Mode execution path, inline approval flow, and clock-rollback regression pass through the repository test runner:

```text
node scripts/run-vitest.mjs src/agents/agent-run-approval-wait.test.ts src/agents/code-mode.wait.test.ts
Test Files  2 passed (2)
Tests       19 passed (19)
```

The adjacent embedded attempt timeout owner and inline approval producer coverage also pass:

```text
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/run/attempt-timeout-prepare.test.ts
Test Files  1 passed (1)
Tests       6 passed (6)

node scripts/run-vitest.mjs src/agents/bash-tools.exec-host-gateway.test.ts -t "emits inline approval park and clear events"
Test Files  1 passed (1)
Tests       2 passed (2)
```

Supporting checks: targeted `oxfmt --check` and `git diff --check` passed. Final relay-backed autoreview reported no accepted/actionable findings; TruffleHog reported clean.

Proof boundary: the focused Code Mode runtime uses deterministic test tools and fake clock control; it does not claim live provider or channel delivery.

Exact head: `ddba237dd45443616526ade03fe151b80fee1211`
