### PR TITLE
perf(ui): prepare usage query predicates once

### DIFF
--- a/ui/src/pages/usage/helpers.ts
+++ b/ui/src/pages/usage/helpers.ts
@@ -221,59 +221,81 @@ const QUERY_KEYS = new Set([
 ]);
 const MULTI_VALUE_QUERY_KEYS = new Set(["channel", "provider", "model", "tool"]);
 
-const matchesUsageQuery = (session: UsageSessionQueryTarget, term: UsageQueryTerm): boolean => {
-  const value = normalizeQueryText(term.value ?? "");
-  if (!value) {
-    return true;
+const matchesEverySession: UsageQueryPredicate = () => true;
+
+const prepareUsageQuery = (
+  term: UsageQueryTerm,
+  key: string,
+  warnings: string[],
+): UsageQueryPredicate => {
+  if (term.key && !QUERY_KEYS.has(key)) {
+    warnings.push(`Unknown filter: ${term.key}`);
+    return matchesEverySession;
   }
-  if (!term.key) {
-    return getSessionText(session).some((text) => text.includes(value));
+  if (term.key && term.value === "") {
+    warnings.push(`Missing value for ${term.key}`);
   }
 
-  const key = normalizeQueryText(term.key);
+  const value = normalizeQueryText(term.value ?? "");
+  const numericSpec = Object.hasOwn(NUMERIC_QUERY_SPECS, key)
+    ? NUMERIC_QUERY_SPECS[key]
+    : undefined;
+  const threshold = numericSpec && term.value ? parseQueryNumber(term.value) : null;
+  if (numericSpec && term.value && threshold === null) {
+    warnings.push(`Invalid number for ${term.key}`);
+  }
+  if (key === "has") {
+    const predicate = Object.hasOwn(HAS_PREDICATES, value) ? HAS_PREDICATES[value] : undefined;
+    if (term.value && !predicate) {
+      warnings.push(`Unknown has:${term.value}`);
+    }
+    return predicate ?? matchesEverySession;
+  }
+  if (!value) {
+    return matchesEverySession;
+  }
+  if (!term.key) {
+    return (session) => getSessionText(session).some((text) => text.includes(value));
+  }
+
   switch (key) {
     case "agent":
-      return normalizeLowercaseStringOrEmpty(session.agentId).includes(value);
+      return (session) => normalizeLowercaseStringOrEmpty(session.agentId).includes(value);
     case "channel":
-      return normalizeLowercaseStringOrEmpty(session.channel).includes(value);
+      return (session) => normalizeLowercaseStringOrEmpty(session.channel).includes(value);
     case "chat":
-      return normalizeLowercaseStringOrEmpty(session.chatType).includes(value);
+      return (session) => normalizeLowercaseStringOrEmpty(session.chatType).includes(value);
     case "provider":
-      return getSessionProviders(session).some((provider) => provider.includes(value));
+      return (session) => getSessionProviders(session).some((provider) => provider.includes(value));
     case "model":
-      return getSessionModels(session).some((model) => model.includes(value));
+      return (session) => getSessionModels(session).some((model) => model.includes(value));
     case "tool":
-      return getSessionTools(session).some((tool) => tool.includes(value));
+      return (session) => getSessionTools(session).some((tool) => tool.includes(value));
     case "label":
-      return normalizeLowercaseStringOrEmpty(session.label).includes(value);
+      return (session) => normalizeLowercaseStringOrEmpty(session.label).includes(value);
     case "key":
     case "session":
     case "id":
       if (value.includes("*") || value.includes("?")) {
-        const regex = globToRegex(value);
-        return (
-          regex.test(session.key) || (session.sessionId ? regex.test(session.sessionId) : false)
-        );
+        let regex: RegExp | undefined;
+        return (session) => {
+          // Preserve lazy construction after earlier predicates, then reuse this call's matcher.
+          regex ??= globToRegex(value);
+          return (
+            regex.test(session.key) || (session.sessionId ? regex.test(session.sessionId) : false)
+          );
+        };
       }
-      return (
+      return (session) =>
         normalizeLowercaseStringOrEmpty(session.key).includes(value) ||
-        normalizeLowercaseStringOrEmpty(session.sessionId).includes(value)
-      );
-    case "has": {
-      const predicate = Object.hasOwn(HAS_PREDICATES, value) ? HAS_PREDICATES[value] : undefined;
-      return predicate?.(session) ?? true;
-    }
+        normalizeLowercaseStringOrEmpty(session.sessionId).includes(value);
   }
 
-  const numericSpec = Object.hasOwn(NUMERIC_QUERY_SPECS, key)
-    ? NUMERIC_QUERY_SPECS[key]
-    : undefined;
-  if (!numericSpec) {
-    return true;
+  if (!numericSpec || threshold === null) {
+    return matchesEverySession;
   }
-  const threshold = parseQueryNumber(value);
   const [getValue, matches] = numericSpec;
-  return threshold === null || matches(getValue(session), threshold);
+  return (session) => matches(getValue(session), threshold);
 };
 
 export const filterSessionsByQuery = <TSession extends UsageSessionQueryTarget>(
@@ -286,50 +308,24 @@ export const filterSessionsByQuery = <TSession extends UsageSessionQueryTarget>(
   }
 
   const warnings: string[] = [];
-  const categoricalTerms = new Map<string, UsageQueryTerm[]>();
-  for (const term of terms) {
-    if (!term.key) {
-      continue;
+  const categoricalTerms = new Map<string, UsageQueryPredicate[]>();
+  const predicates = terms.map((term) => {
+    const key = normalizeQueryText(term.key ?? "");
+    const predicate = prepareUsageQuery(term, key, warnings);
+    if (!MULTI_VALUE_QUERY_KEYS.has(key)) {
+      return predicate;
     }
-    const normalizedKey = normalizeQueryText(term.key);
-    if (!QUERY_KEYS.has(normalizedKey)) {
-      warnings.push(`Unknown filter: ${term.key}`);
-      continue;
+    const alternatives = categoricalTerms.get(key) ?? [];
+    if (term.value) {
+      alternatives.push(predicate);
     }
-    if (term.value && MULTI_VALUE_QUERY_KEYS.has(normalizedKey)) {
-      const alternatives = categoricalTerms.get(normalizedKey) ?? [];
-      alternatives.push(term);
-      categoricalTerms.set(normalizedKey, alternatives);
-    }
-    if (term.value === "") {
-      warnings.push(`Missing value for ${term.key}`);
-    }
-    if (
-      normalizedKey === "has" &&
-      term.value &&
-      !Object.hasOwn(HAS_PREDICATES, normalizeQueryText(term.value))
-    ) {
-      warnings.push(`Unknown has:${term.value}`);
-    }
-    if (
-      Object.hasOwn(NUMERIC_QUERY_SPECS, normalizedKey) &&
-      term.value &&
-      parseQueryNumber(term.value) === null
-    ) {
-      warnings.push(`Invalid number for ${term.key}`);
-    }
-  }
+    categoricalTerms.set(key, alternatives);
+    // Every original term still revisits its completed OR group, including empty terms.
+    return (session: UsageSessionQueryTarget) =>
+      alternatives.length === 0 || alternatives.some((match) => match(session));
+  });
 
-  const filtered = sessions.filter((session) =>
-    terms.every((term) => {
-      const alternatives = term.key
-        ? categoricalTerms.get(normalizeQueryText(term.key))
-        : undefined;
-      return alternatives
-        ? alternatives.some((alternative) => matchesUsageQuery(session, alternative))
-        : matchesUsageQuery(session, term);
-    }),
-  );
+  const filtered = sessions.filter((session) => predicates.every((match) => match(session)));
   return { sessions: filtered, warnings };
 };
 


### PR DESCRIPTION
## Why

Usage filtering repeated query normalization, numeric parsing, filter dispatch and glob construction for each session. This added work on every filtered render, including updates unrelated to the query.

## What changes

Prepare query predicates once per `filterSessionsByQuery` call, combining warning validation with preparation and removing the separate validation pass. Keep the existing categorical OR groups, other AND constraints, warning order, short-circuit order, and row identity. Glob matchers are still constructed only when reached and reused only within that call; there is no cross-render cache or invalidation policy.

The change stays inside the Usage query owner. Query syntax, debounce/apply behavior, loading, selection, exports, and rendering remain unchanged. Production delta: **+66/−70, net −4 lines**; no test or generated lines added. No dependencies, configuration, protocol or storage changes.

## Measurements

Six fresh Node 26.8.1 processes ran the complete filter call, including preparation, in forward/reverse order across 40 fixed workloads. All 240 medians were independently recomputed from 2,160 retained samples, and corresponding result hashes matched across all processes. These are owner-level measurements, not browser rendering or perceived UI latency.

| Query | 10 sessions: elapsed reduction, forward/reverse | 1,000 sessions: elapsed reduction, forward/reverse |
| --- | ---: | ---: |
| Single provider | 21.7% / 26.5% | 44.6% / 43.9% |
| Provider alternatives | 33.4% / 35.5% | 39.2% / 38.8% |
| Mixed filters | 44.7% / 45.1% | 58.4% / 57.7% |
| Free text | 11.8% / 8.7% | 13.6% / 17.6% |

Preparation costs more for most empty-list nonempty queries (up to 0.153 µs added) and some one-session cases: glob +5.5–7.2%, short-circuit +5.6–9.5%, and free text flat/slower. The unchanged empty-query path has substantial relative measurement noise at nanosecond scale and earns no speedup claim. The largest absolute saving in the corpus is about 0.297 ms per 1,000-session filter call. The corpus repeats five synthetic session shapes; actual query frequencies are unknown. Warmup blocks ran, but the original harness did not retain their durations.

## Verification

Baseline helper/query suites: 28 tests passed. The source-bound differential harness passed 1,182 records plus 21 lazy-regex/getter checks across the two considered implementations, covering warnings, numeric inputs, OR/AND behavior, identity, ordering, and nonmutation. A larger DTO-based alternative was measured and rejected in favor of this simpler predicate owner.

Candidate verification passed:

- 76 tests across the helper, query, view, page, and page-detail suites: `pnpm --dir ui test src/pages/usage/helpers.node.test.ts src/pages/usage/query.test.ts src/pages/usage/view.test.ts src/pages/usage/usage-page.test.ts src/pages/usage/usage-page-details.test.ts`.
- `node scripts/check-changed.mjs -- ui/src/pages/usage/helpers.ts`, including core-test/UI typechecks, UI i18n verification, formatting and dead-export checks.
- The unchanged canonical `ui/src/e2e/usage-cost-analysis.e2e.test.ts`: **8/8 before and 8/8 after**, no skips or retries. It exercises the built UI with a mocked Gateway, provider alternatives, quoted labels, filter clearing, visible Shift-selection, totals and empty aggregates. Browser runs used signed Chrome 152.0.7977.64 through the existing executable override, separate temporary profiles and bundled output; no personal browser state or running Gateway.
- Full `pnpm build` passed on the committed head.
- Managed Codex autoreview, including a fresh committed-head pre-landing pass, at its default P0 threshold and a separate all-priority source/evidence review found no actionable findings. The integrated helper is byte-identical to the measured candidate.

No query behavior or operator instructions change, so no docs/config migration is needed. Local proof artifacts retain the raw samples, source/compiled hashes, browser result JSON, screenshots/video and cleanup records. Hosted CI initially failed in the unrelated `doctor-session-sqlite.memory.test.ts` deep-import case: Linux Node 24.19.0 exhausted the existing 256 MiB child heap while importing 100,000 events. The unchanged canonical three-case suite passes locally on both Node 26.8.1 and exact Node 24.19.0, with the same heap limit and scenario order. The unchanged failed-job rerun passed on the same head (CI run 33418988949, attempt 2); no heap, timeout, test or production code was changed to obtain those passes. The Linux failure remains unexplained, with a follow-up to profile migration navigation retention.

The latest ClawSweeper review on this head reported no actionable findings and no Rank-up moves; exact-head CI is now green and the native maintainer landing workflow is completing. A newly queued bot refresh does not replace the current clean source review.

## Before / after

Synthetic quoted-label filtering remains visually unchanged: one of two sessions matches in both runs. These canonical captures show the same scrolled viewport, not the whole page; assertions provide the selection and result proof. The screenshots are byte-identical, and contain no personal data.


| Before | After |
| --- | --- |
| ![Before: quoted Usage filter](https://github.com/user-attachments/assets/8fc2e1ce-a761-4220-909e-e7bd61d9ae09) | ![After: quoted Usage filter](https://github.com/user-attachments/assets/557c1517-3e43-4152-99f4-61debd9099b5) |
