### PR TITLE
test(infra): load execution policy modules once per suite

### DIFF
--- a/src/infra/exec-approvals-policy.test.ts
+++ b/src/infra/exec-approvals-policy.test.ts
@@ -1,6 +1,6 @@
 // Tests execution approval policy matching and persistence.
 import path from "node:path";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { LEGACY_IMPLICIT_AGENT_ID as DEFAULT_AGENT_ID } from "../routing/session-key.js";
 import {
@@ -113,7 +113,8 @@ function expectMalformedAgentAskUsesDefaults(agentAsk: unknown): void {
 }
 
 describe("exec approvals policy helpers", () => {
-  beforeEach(async () => {
+  beforeAll(async () => {
+    // Reload once to isolate this suite from facade mocks left by other test files.
     await loadActualExecApprovalModules();
   });
 


### PR DESCRIPTION
## What Problem This Solves

Every execution-policy case resets and imports the same real approval module graph, even though the 69 cases use fresh argument objects and do not install per-case mocks or mutate module state.

## Why This Change Was Made

Run the existing real-module loader once in `beforeAll`. Keep both explicit unmock declarations, the graph reset and both actual imports at suite entry. The environment override remains restored in `finally` and is read by its owner at call time.

## User Impact

Removes 68 graph resets and 136 actual-import calls while retaining every policy case and assertion. Production +0/-0; tests +3/-2. No execution-approval policy, persistence or isolation configuration changes.

## Evidence

- All 102 policy/config tests passed before and after through the existing infra configuration. One local complete wrapper run decreased from 19.55 s to 11.83 s; this is an observed run, not a controlled benchmark.
- Full changed-file checks, formatting, diff checks and structured Codex autoreview passed.
- Reviewed the complete policy test, effective/config/resolver owners, durable matching and allowlist call paths, real doctor caller, helper allocation and config sibling coverage.
- The historical isolation loader remains. Current infra is isolated; the introducing history does not identify its original failing file order, so this proof does not claim to reproduce that historical sequence.
