### PR TITLE
test(lmstudio): reuse oversized response source chunks

### DIFF
--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -841,6 +841,7 @@ describe("lmstudio-models", () => {
     // path must stop reading at the byte cap instead of buffering it all.
     let canceled = false;
     let bytesEmitted = 0;
+    const chunk = new Uint8Array(64 * 1024).fill(0x61);
     const oversizedStream = new ReadableStream<Uint8Array>({
       pull(controller) {
         // Far exceeds the 16 MiB provider JSON cap if read to completion.
@@ -848,8 +849,8 @@ describe("lmstudio-models", () => {
           controller.close();
           return;
         }
-        bytesEmitted += 64 * 1024;
-        controller.enqueue(new Uint8Array(64 * 1024).fill(0x61));
+        bytesEmitted += chunk.byteLength;
+        controller.enqueue(chunk);
       },
       cancel() {
         canceled = true;


### PR DESCRIPTION
## What Problem This Solves

The oversized model-load response fixture allocates and fills a new identical 64 KiB byte array on every pull until the real provider reader crosses its 16 MiB cap.

## Why This Change Was Made

Allocate the immutable source chunk once and reuse it. Keep the real ReadableStream and Response, 32 MiB terminal size, production bounded reader, cancellation and early-stop assertions unchanged.

## User Impact

Removes at least 16 MiB of repeated source-buffer allocation/fill work per successful test run. This is a source-derived allocation reduction, not a total-heap or wall-time benchmark. Production +0/-0; tests +3/-2.

## Evidence

- All 57 tests passed before and after across the model, response-release and actual loopback model-load error suites.
- Full changed-file checks, formatting, diff checks and structured Codex autoreview passed.
- Inspected the model-load owner, inference/embedding callers, bounded provider/HTTP reader, timeout owner and original response-cap regression history. The reader never mutates source chunks.
- Inspected Node 24.19.0's default stream enqueue/read implementation: it retains or forwards the supplied chunk without byte-stream transfer. The fixture uses a default stream and never mutates its repeated bytes; the actual size limit remains exercised.
