### PR TITLE
test(browser): remove duplicated profile allocation demonstrations

### DIFF
--- a/extensions/browser/src/browser/profiles.test.ts
+++ b/extensions/browser/src/browser/profiles.test.ts
@@ -1,6 +1,5 @@
 // Browser tests cover profiles plugin behavior.
 import { describe, expect, it } from "vitest";
-import { resolveBrowserConfig } from "./config.js";
 import { allocateCdpPort, getUsedPorts, isValidProfileName } from "./profiles.js";
 
 const CDP_PORT_RANGE_START = 18800;
@@ -132,47 +131,5 @@ describe("getUsedPorts", () => {
     };
     const used = getUsedPorts(profiles);
     expect(used).toEqual(new Set([18801]));
-  });
-});
-
-describe("port collision prevention", () => {
-  it("raw config vs resolved config - shows the data source difference", () => {
-    // This demonstrates WHY the route handler must use resolved config
-
-    // Fresh config with no profiles defined (like a new install)
-    const rawConfigProfiles = undefined;
-    const usedFromRaw = getUsedPorts(rawConfigProfiles);
-
-    // Raw config shows empty - no ports used
-    expect(usedFromRaw.size).toBe(0);
-
-    // But resolved config has implicit openclaw at 18800
-    const resolved = resolveBrowserConfig({});
-    const usedFromResolved = getUsedPorts(resolved.profiles);
-    expect(usedFromResolved.has(CDP_PORT_RANGE_START)).toBe(true);
-  });
-
-  it("create-profile must use resolved config to avoid port collision", () => {
-    // The route handler must use state.resolved.profiles, not raw config
-
-    // Simulate what happens with raw config (empty) vs resolved config
-    const rawConfig: { browser: { profiles?: Record<string, { cdpPort?: number }> } } = {
-      browser: {},
-    }; // Fresh config, no profiles
-    const buggyUsedPorts = getUsedPorts(rawConfig.browser?.profiles);
-    const buggyAllocatedPort = allocateCdpPort(buggyUsedPorts);
-
-    // Raw config: first allocation gets 18800
-    expect(buggyAllocatedPort).toBe(CDP_PORT_RANGE_START);
-
-    // Resolved config: includes implicit openclaw at 18800
-    const resolved = resolveBrowserConfig(
-      rawConfig.browser as Parameters<typeof resolveBrowserConfig>[0],
-    );
-    const fixedUsedPorts = getUsedPorts(resolved.profiles);
-    const fixedAllocatedPort = allocateCdpPort(fixedUsedPorts);
-
-    // Resolved: first NEW profile gets 18801, avoiding collision
-    expect(fixedAllocatedPort).toBe(CDP_PORT_RANGE_START + 1);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Two browser profile tests manually combine configuration resolution and port allocation while claiming to prove profile-creation collision prevention. They never call the creation owner and would pass if it selected raw profiles incorrectly.

## Why This Change Was Made

Delete those demonstrations and their sole direct config import. Keep every leaf-helper case. Existing service tests call real profile creation and its mutation callback: an empty persisted profile map must allocate 18801, and a rebased map already using 18801 must allocate 18802. Default-config tests retain the implicit profile at 18800.

## User Impact

Production +0/-0; tests +0/-43. This removes duplicated proof and one redundant import edge. No measured startup or test-time claim.

## Evidence

- The complete helper/service/config run passed before and after: 128 passing cases before, 126 after, with the same one Windows-only case skipped on macOS. All 28 remaining helper cases pass.
- Full changed-file checks, formatting, diff checks and structured Codex autoreview passed.
- Inspected the full helper and mutation/service owners, creation route, relevant service fixtures/default config assertions and introducing history. No new mock or production seam; retained service fixtures execute the real mutation callback.
