### PR TITLE
fix(test): preserve Git update fixture identity through postinstall

### DIFF
--- a/scripts/e2e/lib/doctor-install-switch/scenario.sh
+++ b/scripts/e2e/lib/doctor-install-switch/scenario.sh
@@ -46,6 +46,7 @@ fi
 
 npm_bin="/tmp/npm-prefix/bin/openclaw"
 npm_root="/tmp/npm-prefix/lib/node_modules/openclaw"
+export OPENCLAW_E2E_REDACTOR_MODULE="$npm_root/dist/plugin-sdk/logging-core.js"
 if [ -f "$npm_root/dist/index.mjs" ]; then
   npm_entry="$npm_root/dist/index.mjs"
 else

--- a/scripts/e2e/lib/package-git-fixture.mjs
+++ b/scripts/e2e/lib/package-git-fixture.mjs
@@ -41,6 +41,12 @@ function ensureDependencyIgnores(root) {
 
 function prepare(root) {
   ensureDependencyIgnores(root);
+  // Preserve source-checkout identity through preflight clones and global links;
+  // packaged postinstall cleanup would otherwise delete the fixture's build stamps.
+  for (const directory of ["src", "extensions"]) {
+    fs.mkdirSync(path.join(root, directory), { recursive: true });
+    fs.writeFileSync(path.join(root, directory, ".gitkeep"), "");
+  }
   const packageJsonPath = path.join(root, "package.json");
   const packageJson = readJson(packageJsonPath);
   // npm still resolves omitted dev dependencies; this fixture runs the packed runtime.

--- a/test/scripts/update-channel-switch-fixture.test.ts
+++ b/test/scripts/update-channel-switch-fixture.test.ts
@@ -2,6 +2,7 @@ import { execFileSync, execSync } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, expect, it } from "vitest";
+import { runBundledPluginPostinstall } from "../../scripts/postinstall-bundled-plugins.mjs";
 import { collectGitRuntimeErrors } from "../../src/infra/update-git-runtime.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
@@ -17,6 +18,10 @@ it("builds the package-derived Git fixture with its own checkout identity", asyn
     JSON.stringify({ name: "openclaw", version: "2026.8.1" }),
   );
   writeFileSync(join(root, "dist/entry.js"), runtimeEntry);
+  writeFileSync(
+    join(root, "dist/postinstall-inventory.json"),
+    JSON.stringify(["dist/entry.js", "dist/build-info.json", "dist/control-ui/index.html"]),
+  );
   writeFileSync(
     join(root, "dist/build-info.json"),
     JSON.stringify({ commit: packageCommit, version: "2026.8.1" }),
@@ -50,6 +55,10 @@ it("builds the package-derived Git fixture with its own checkout identity", asyn
   for (const checkout of [preflight, root]) {
     expect(await collectGitRuntimeErrors({ root: checkout, sha })).not.toEqual([]);
     execSync(manifest.scripts.build, { cwd: checkout });
+    runBundledPluginPostinstall({
+      packageRoot: checkout,
+      env: { HOME: join(root, "home"), OPENCLAW_STATE_DIR: join(root, "state") },
+    });
     expect(await collectGitRuntimeErrors({ root: checkout, sha })).toEqual([]);
     expect(JSON.parse(readFileSync(join(checkout, "dist/build-info.json"), "utf8"))).toEqual({
       commit: sha,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where release validation rejects a package-derived Git update after its verified post-install lifecycle deletes the fixture's generated build stamps. The fixture omitted the source directories that distinguish a real checkout from an installed package. A separate Doctor-switch failure also hid its diagnostic log because the bare test image could not locate the canonical redactor.

## Why This Change Was Made

Track the fixture's source directories through Git clones and global links, preserving the existing production checkout detection and package cleanup rules. Point Doctor-switch diagnostics at the installed package's existing redactor so failures remain readable and redacted.

## User Impact

No production runtime or configuration change. This repairs the trusted release harness needed to validate npm/Git update transitions for 2026.8.2.

## Evidence

The original candidate [plugin validation run](https://github.com/openclaw/openclaw/actions/runs/33417998826) reported missing build/runtime stamps immediately after post-install cleanup pruned them. The extended fixture regression fails before the fix and passes afterward for both the original checkout and a fresh Git clone. All 33 fixture and post-install sibling tests pass; the regression also passes on this main-based branch.

Using the exact failed candidate tarball locally, the corrected Git fixture retained both stamps after an npm global local link and the packaged post-install lifecycle. Plugin discovery stayed identical: 59 plugins, all from `dist/extensions`. This used existing local runtime dependencies; it is not clean-install or Linux service proof. The original Docker lanes still need to pass with the landed trusted harness. Local Docker is unavailable on this worker.

P0–P2 independent review: no findings. Runtime production delta: 0. Test harness: +7/-0; regression test: +9/-0. No assertions, cleanup guards, or runtime verification were weakened.
