### PR TITLE
test(auto-reply): cover silent implicit Slack turns

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -472,6 +472,19 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
         },
       } as OpenClawConfig,
     },
+    {
+      name: "implicit Slack thread turns",
+      ctx: buildTestCtx({
+        ChatType: "channel",
+        Surface: "slack",
+        Provider: "slack",
+        SessionKey: "agent:main:slack:channel:C123:thread:456",
+        WasMentioned: true,
+        MentionSource: "implicit_thread",
+        ImplicitMentionKinds: ["bot_thread_participant"],
+      }),
+      cfg: emptyConfig,
+    },
   ])("records explicit NO_REPLY without a generic fallback in $name", async ({ ctx, cfg }) => {
     setNoAbort();
     const deliver = vi.fn(async () => {});


### PR DESCRIPTION
## Summary

Add the missing regression case for a deliberate `NO_REPLY` on an implicitly admitted Slack thread turn.

## Why

Slack preserves `WasMentioned: true` for thread-participation admission and distinguishes the turn with `MentionSource: "implicit_thread"`. Core now classifies model-produced `NO_REPLY` as a deliberate silent terminal reply. This test locks the interaction between those two contracts: an implicit thread turn must remain silent and must not emit the generic no-visible-reply fallback.

Existing coverage already verifies the adjacent outcomes:

- an explicitly mentioned turn with an accidental empty result receives the fallback;
- an explicitly mentioned turn with a deliberate `NO_REPLY` remains silent.

## User impact

Future reply-dispatch changes cannot regress implicit Slack acknowledgements into a visible temporary-failure message while preserving the deliberate-silence contract for explicit turns.

## Validation

- `corepack pnpm vitest run src/auto-reply/reply/dispatch-from-config.test.ts` (129 passed)
- `git diff --check`
- structured Codex autoreview: no actionable findings