### PR TITLE
test(sessions): await the conversation owner deadline

### DIFF
--- a/src/sessions/conversation-turns.test.ts
+++ b/src/sessions/conversation-turns.test.ts
@@ -355,9 +355,7 @@ describe("conversation turn correlation", () => {
       replyToId: "outbound-slow",
       text: "arrived before timeout",
     });
-    await new Promise((resolve) => {
-      setTimeout(resolve, 10);
-    });
+    expect(claim).toBeDefined();
     await expect(pending.wait()).resolves.toBeUndefined();
     claim?.complete();
   });


### PR DESCRIPTION
## What problem does this PR solve?

The reply-persistence deadline test waits on an unrelated 10 ms timer before observing a pending turn whose real deadline is already 1 ms. That extra timer provides no synchronization with the turn owner.

## Why this approach?

Assert that the reply was claimed, then await the owner's existing settlement promise. Keep the real 1 ms deadline and the late completion attempt. The new precondition prevents a missing claim from making the deadline assertion pass vacuously. Production code is unchanged; tests are +1/-3 lines.

## User impact

Test synchronization cleanup only. Conversation behavior, persistence and timeout settings are unchanged.

## Evidence

All 14 correlation-owner tests and all 9 reply-capture sibling tests pass before and after through their normal Vitest routes. Full changed-file checks and structured Codex autoreview pass. Source review covers registration, exact pending identity, claim/settlement ownership, gateway registration before delivery and reply persistence before claim completion. No measured elapsed-time claim or same-worker historical-order claim.

Commands:
- `node scripts/run-vitest.mjs src/sessions/conversation-turns.test.ts`
- `node scripts/run-vitest.mjs src/auto-reply/reply/conversation-turn-capture.test.ts`
