### PR TITLE
fix(memory): keep dirty search maintenance incremental

### DIFF
--- a/extensions/memory-core/src/cli-index-search.runtime.ts
+++ b/extensions/memory-core/src/cli-index-search.runtime.ts
@@ -209,7 +209,8 @@ export async function runMemorySearch(
     commandName: "memory search",
     agent: opts.agent,
     diagnosticsToStderr: Boolean(opts.json),
-    purpose: "cli",
+    purpose: "cli-search",
+    inspectSources: true,
     ...hostOptions,
     run: async ({ manager, cfg, agentId }) => {
       const memoryPluginConfig = resolveMemoryPluginConfig(cfg);

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -1962,7 +1962,8 @@ describe("memory cli", () => {
     expect(getMemorySearchManager).toHaveBeenCalledWith({
       cfg: {},
       agentId: "main",
-      purpose: "cli",
+      purpose: "cli-search",
+      inspectSources: true,
     });
     expect(log).toHaveBeenCalledWith("No matches.");
     expect(close).toHaveBeenCalled();
@@ -1978,7 +1979,8 @@ describe("memory cli", () => {
     expect(getMemorySearchManager).toHaveBeenCalledWith({
       cfg: {},
       agentId: "main",
-      purpose: "cli",
+      purpose: "cli-search",
+      inspectSources: true,
       acquireLocalService,
     });
   });

--- a/extensions/memory-core/src/memory/manager-index.test-support.ts
+++ b/extensions/memory-core/src/memory/manager-index.test-support.ts
@@ -104,7 +104,7 @@ export type ManagerIndexFixture = {
   getPersistentManager: (cfg: ManagerConfig) => Promise<MemoryIndexManager>;
   getFreshManager: (
     cfg: ManagerConfig,
-    purpose?: "default" | "status" | "cli",
+    purpose?: "default" | "status" | "cli" | "cli-search",
     inspectSources?: boolean,
   ) => Promise<MemoryIndexManager>;
   getFtsSessionManager: (params: { stateDirName: string }) => Promise<MemoryIndexManager | null>;
@@ -476,7 +476,7 @@ export function createManagerIndexFixture(deps: {
 
   const getFreshManager = async (
     cfg: ManagerConfig,
-    purpose?: "default" | "status" | "cli",
+    purpose?: "default" | "status" | "cli" | "cli-search",
     inspectSources?: boolean,
   ): Promise<MemoryIndexManager> => {
     const manager = requireManager(

--- a/extensions/memory-core/src/memory/manager-provider-lifecycle.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle.ts
@@ -110,7 +110,7 @@ export function resolveMemoryEmbeddingProviderRequirement(params: {
 
 export abstract class MemoryProviderLifecycle extends MemoryManagerEmbeddingOps {
   protected abstract readonly cacheKey: string;
-  protected abstract readonly purpose: "default" | "status" | "cli" | "maintenance";
+  protected abstract readonly purpose: "default" | "status" | "cli" | "cli-search" | "maintenance";
   protected abstract readonly providerRequirement: MemoryEmbeddingProviderRequirement;
   protected abstract readonly requestedProvider: EmbeddingProviderRequest;
   protected abstract providerInitPromise: Promise<void> | null;
@@ -545,7 +545,11 @@ export abstract class MemoryProviderLifecycle extends MemoryManagerEmbeddingOps 
     // CLI request teardown must not wait after a published search result is ready;
     // its detached task owns a separate maintenance manager. Persistent managers
     // still drain maintenance before closing shared resources.
-    while (this.purpose !== "cli" && this.activeBackgroundSearchSyncs.size > 0) {
+    while (
+      this.purpose !== "cli" &&
+      this.purpose !== "cli-search" &&
+      this.activeBackgroundSearchSyncs.size > 0
+    ) {
       await Promise.all(Array.from(this.activeBackgroundSearchSyncs));
     }
   }

--- a/extensions/memory-core/src/memory/manager-registry.ts
+++ b/extensions/memory-core/src/memory/manager-registry.ts
@@ -19,12 +19,15 @@ const MEMORY_INDEX_MANAGER_GLOBAL_LIFECYCLE_KEY = Symbol.for(
 );
 const log = createSubsystemLogger("memory");
 
-export type MemoryIndexManagerPurpose = "default" | "status" | "cli" | "maintenance";
+export type MemoryIndexManagerPurpose = "default" | "status" | "cli" | "cli-search" | "maintenance";
 
 export function normalizeMemoryIndexManagerPurpose(
   purpose: MemoryIndexManagerPurpose | undefined,
 ): MemoryIndexManagerPurpose {
-  return purpose === "status" || purpose === "cli" || purpose === "maintenance"
+  return purpose === "status" ||
+    purpose === "cli" ||
+    purpose === "cli-search" ||
+    purpose === "maintenance"
     ? purpose
     : "default";
 }

--- a/extensions/memory-core/src/memory/manager-search-maintenance.ts
+++ b/extensions/memory-core/src/memory/manager-search-maintenance.ts
@@ -2,7 +2,7 @@
 import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 
 type MemorySearchMaintenanceManager = {
-  sync(params: { reason: string; force: true }): Promise<void>;
+  sync(params: { reason: string }): Promise<void>;
   status(): { dirty?: boolean; lastSyncError?: string };
   close(): Promise<void>;
 };
@@ -29,9 +29,9 @@ export async function runMemorySearchMaintenance<DirtyGeneration>(params: {
   let maintenanceError: Error | undefined;
   let incompleteReason: string | undefined;
   try {
-    // The transient manager has no watcher state. Force every source represented
-    // by the handed-off generation while the default manager serves published reads.
-    await manager.sync({ reason: params.reason, force: true });
+    // The transient manager inspects source deltas before acquisition. Apply only
+    // those deltas so routine search refreshes never become full reindexes.
+    await manager.sync({ reason: params.reason });
     const status = manager.status();
     if (status.dirty === true) {
       // A provider fallback may deliberately resolve in keyword-only mode while

--- a/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.test.ts
@@ -565,7 +565,7 @@ describe("memory index", () => {
     await pendingSync;
   });
 
-  it("keeps the published index searchable while dirty maintenance builds", async () => {
+  it("keeps search available while incremental dirty maintenance settles", async () => {
     providerFixture.forceNoProvider = true;
     const manager = await getPersistentManager(
       createCfg({ provider: "none", minScore: 0, onSearch: true, hybrid: { enabled: true } }),
@@ -596,6 +596,7 @@ describe("memory index", () => {
       };
       const syncMemoryFiles = fields.syncMemoryFiles.bind(acquired);
       vi.spyOn(fields, "syncMemoryFiles").mockImplementation(async (syncParams) => {
+        expect(syncParams).toMatchObject({ needsFullReindex: false });
         const result = await syncMemoryFiles(syncParams);
         maintenanceReady.resolve();
         await releaseMaintenance.promise;
@@ -613,7 +614,7 @@ describe("memory index", () => {
       expect(publishedResults.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
       await expect(
         manager.search("current dirty search sync", { maxResults: 5, minScore: 0 }),
-      ).resolves.toEqual([]);
+      ).resolves.toEqual([expect.objectContaining({ path: "memory/search-sync.md" })]);
 
       releaseMaintenance.resolve();
       await firstSearch;
@@ -629,6 +630,32 @@ describe("memory index", () => {
     } finally {
       releaseMaintenance.resolve();
       getSpy.mockRestore();
+    }
+  });
+
+  it("does not refresh a clean one-shot CLI search", async () => {
+    providerFixture.forceNoProvider = true;
+    const cfg = createCfg({
+      provider: "none",
+      minScore: 0,
+      onSearch: true,
+      hybrid: { enabled: true },
+    });
+    const initialManager = await getFreshManager(cfg, "cli");
+    await initialManager.sync({ reason: "test", force: true });
+    await initialManager.close?.();
+
+    const manager = await getFreshManager(cfg, "cli-search", true);
+    const getSpy = vi.spyOn(MemoryIndexManager, "get");
+    try {
+      const results = await manager.search("zebra", { maxResults: 5, minScore: 0 });
+
+      expect(results.some((entry) => entry.path === "memory/2026-01-12.md")).toBe(true);
+      expect(manager.status().dirty).toBe(false);
+      expect(getSpy).not.toHaveBeenCalledWith(expect.objectContaining({ purpose: "maintenance" }));
+    } finally {
+      getSpy.mockRestore();
+      await manager.close?.();
     }
   });
 
@@ -648,7 +675,7 @@ describe("memory index", () => {
       "Content published after transient CLI maintenance.",
     );
 
-    const manager = await getFreshManager(cfg, "cli");
+    const manager = await getFreshManager(cfg, "cli-search", true);
     const servingFields = manager as unknown as {
       syncMemoryFiles: (params: { needsFullReindex: boolean }) => Promise<unknown>;
     };
@@ -688,7 +715,9 @@ describe("memory index", () => {
         sessionKey: "agent:main:cli:memory-search",
       });
       await vi.waitFor(() =>
-        expect(getSpy).toHaveBeenCalledWith(expect.objectContaining({ purpose: "maintenance" })),
+        expect(getSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ purpose: "maintenance", inspectSources: true }),
+        ),
       );
       await maintenanceReady.promise;
       const results = await search;
@@ -742,7 +771,10 @@ describe("memory index", () => {
         ).syncPublishedIndexInBackground({ reason: "search" }),
       ).rejects.toThrow(syncError);
 
-      expect(maintenance.sync).toHaveBeenCalledWith({ reason: "search", force: true });
+      expect(getSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ purpose: "maintenance", inspectSources: true }),
+      );
+      expect(maintenance.sync).toHaveBeenCalledWith({ reason: "search" });
       expect(maintenance.close).toHaveBeenCalledTimes(1);
       expect(manager.status().lastSyncError).toContain("maintenance failed");
       expect(Reflect.get(manager, "dirty")).toBe(true);

--- a/extensions/memory-core/src/memory/manager-search-orchestration.ts
+++ b/extensions/memory-core/src/memory/manager-search-orchestration.ts
@@ -209,7 +209,7 @@ export abstract class MemorySearchOrchestration extends MemoryKeywordRetrieval {
       const backgroundSearchSync = startAsyncSearchSync({
         enabled:
           (this.settings.sync.onSearch || sessionStartSync) &&
-          (this.purpose === "default" || this.purpose === "cli"),
+          (this.purpose === "default" || this.purpose === "cli" || this.purpose === "cli-search"),
         dirty: this.dirty,
         sessionsDirty: this.sessionsDirty,
         sync: async (params) => await this.syncPublishedIndexInBackground(params),

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -160,7 +160,11 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
           });
           return {
             key,
-            transient: purpose === "status" || purpose === "cli" || purpose === "maintenance",
+            transient:
+              purpose === "status" ||
+              purpose === "cli" ||
+              purpose === "cli-search" ||
+              purpose === "maintenance",
             create: async () => {
               const manager = new MemoryIndexManager({
                 cacheKey: key,
@@ -234,7 +238,10 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
         initialIndexIdentity.status === "mismatched" ||
         (initialIndexIdentity.status === "missing" && this.sources.has("memory"));
       const transient =
-        params.purpose === "status" || params.purpose === "cli" || params.purpose === "maintenance";
+        params.purpose === "status" ||
+        params.purpose === "cli" ||
+        params.purpose === "cli-search" ||
+        params.purpose === "maintenance";
       if (!transient) {
         this.ensureWatcher();
         this.ensureSessionListener();
@@ -254,7 +261,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
       this.dirty =
         resolveInitialMemoryDirty({
           hasMemorySource: this.sources.has("memory"),
-          statusOnly: params.purpose === "status",
+          statusOnly: params.purpose === "status" || params.purpose === "cli-search",
           hasIndexedMeta: Boolean(meta),
         }) || this.memorySourceProvenanceRepairPending;
       if (this.sources.has("sessions") && invalidatedSources.has("sessions")) {
@@ -307,6 +314,7 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
               cfg: this.cfg,
               agentId: this.agentId,
               purpose: "maintenance",
+              inspectSources: true,
               acquireLocalService: this.acquireLocalService,
             }),
         }),

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -9,7 +9,8 @@ import type { MemoryCoreAcquireLocalService } from "./embedding-local-service.js
 const managerRuntimeLoader = createLazyRuntimeModule(() => import("../../manager-runtime.js"));
 const loadManagerRuntime = managerRuntimeLoader;
 
-type MemorySearchManagerPurpose = "default" | "status" | "cli";
+type MemorySearchManagerPurpose = "default" | "status" | "cli" | "cli-search";
+type MemorySearchManagerDebugPurpose = Exclude<MemorySearchManagerPurpose, "cli-search">;
 type MemorySearchManagerParams = {
   cfg: OpenClawConfig;
   agentId: string;
@@ -23,7 +24,7 @@ type MemorySearchManagerResult = {
   error?: string;
   debug?: {
     backend: "builtin";
-    purpose: MemorySearchManagerPurpose;
+    purpose: MemorySearchManagerDebugPurpose;
     managerMs: number;
   };
 };
@@ -37,7 +38,7 @@ export async function getMemorySearchManager(
     ...result,
     debug: {
       backend: "builtin",
-      purpose: params.purpose ?? "default",
+      purpose: params.purpose === "cli-search" ? "cli" : (params.purpose ?? "default"),
       managerMs: Math.max(0, Date.now() - startedAt),
     },
   };


### PR DESCRIPTION
## Summary

- keep dirty search-triggered memory maintenance incremental instead of forcing a full reindex
- inspect sources for detached maintenance and one-shot CLI search managers
- preserve standalone CLI catch-up while keeping the internal `cli-search` lifecycle transient
- retain full reindex behavior for explicit force requests and structural recovery paths

Closes #134337.

## What Problem This Solves

Detached maintenance currently calls `sync({ force: true })` whenever a search observes dirty state. A routine one-file change therefore rebuilds the entire corpus. If normal agent/session writes change the shared database revision before publication, the stale rebuild is rejected and the restored dirty generation causes the next search to repeat the same full rebuild.

The maintenance manager now inspects source state and runs an ordinary sync, allowing the existing delta logic to select incremental work. A private `cli-search` purpose distinguishes one-shot searches from explicit CLI index operations: clean searches do not refresh, dirty standalone searches still discover filesystem changes, and debug output remains compatible as `cli`.

## Evidence

- `pnpm test extensions/memory-core/src/cli.test.ts extensions/memory-core/src/memory/manager-search-orchestration.test.ts` — 121 passed
- `pnpm test:extension memory-core` — 1,386 passed, 3 Windows-only skipped
- `pnpm tsgo:extensions`
- `pnpm tsgo:extensions:test`
- `pnpm build`
- `git diff --check`

The focused suite was rerun after rebasing onto current `main`.

On the affected installation, equivalent core behavior reduced a dirty one-file refresh from repeated 51–63 second full rebuilds to an approximately 4.1 second incremental update; subsequent searches returned in 3.3–5.7 seconds.

## Scope

No configuration, schema, database format, embedding-provider behavior, or public debug contract changes. The new lifecycle purpose is internal and maps back to `cli` in debug metadata.

## Related Work

PR #134333 opened while this contribution was being prepared. It retries a revision conflict when a full maintenance reindex is genuinely required. This PR addresses the preceding cause: routine dirty search maintenance should not request a full reindex for ordinary source deltas. The changes are complementary, though both touch the internal manager-purpose type.

AI-assisted contribution; I reviewed and tested the code and understand the change.
