### PR TITLE
refactor(plugin-state): share store option policy

### DIFF
--- a/src/plugin-state/plugin-blob-store.ts
+++ b/src/plugin-state/plugin-blob-store.ts
@@ -27,6 +27,7 @@ import type {
 } from "./plugin-blob-store.types.js";
 import { PluginBlobStoreError } from "./plugin-blob-store.types.js";
 import {
+  createPluginStoreOptionPolicy,
   serializePluginStoreJson,
   validateOptionalPluginStoreTtlMs,
   validatePluginStoreKey,
@@ -55,8 +56,6 @@ type PreparedBlob = {
   metadataJson: string;
   ttlMs?: number;
 };
-
-const namespaceOptionSignatures = new Map<string, BlobStoreOptionSignature>();
 
 function invalidInput(
   message: string,
@@ -108,15 +107,10 @@ function validatePositiveLimit(value: number, label: string, maximum: number): n
   return normalized;
 }
 
-function validateOverflowPolicy(value: unknown): PluginBlobOverflowPolicy {
-  if (value === undefined || value === "evict-oldest") {
-    return "evict-oldest";
-  }
-  if (value === "reject-new") {
-    return value;
-  }
-  throw invalidInput("plugin blob overflowPolicy must be evict-oldest or reject-new", "open");
-}
+const optionPolicy = createPluginStoreOptionPolicy<BlobStoreOptionSignature>({
+  label: "plugin blob",
+  invalid: (message) => invalidInput(message, "open"),
+});
 
 function validateTtl(
   value: number | undefined,
@@ -127,33 +121,6 @@ function validateTtl(
     label: "plugin blob ttlMs",
     errors: validationErrors(operation),
   });
-}
-
-function assertConsistentOptions(
-  pluginId: string,
-  namespace: string,
-  signature: BlobStoreOptionSignature,
-): void {
-  const key = `${pluginId}\0${namespace}`;
-  const existing = namespaceOptionSignatures.get(key);
-  if (!existing) {
-    namespaceOptionSignatures.set(key, signature);
-    return;
-  }
-  if (
-    existing.maxEntries !== signature.maxEntries ||
-    existing.maxBytesPerEntry !== signature.maxBytesPerEntry ||
-    existing.maxBytesPerNamespace !== signature.maxBytesPerNamespace ||
-    existing.overflowPolicy !== signature.overflowPolicy ||
-    existing.defaultTtlMs !== signature.defaultTtlMs
-  ) {
-    // Namespace limits are a shared contract. Reopening with different limits
-    // would make quota and eviction behavior depend on call order.
-    throw invalidInput(
-      `plugin blob namespace ${namespace} for ${pluginId} was reopened with incompatible options`,
-      "open",
-    );
-  }
 }
 
 function prepareBlob(params: {
@@ -256,9 +223,9 @@ function createPluginBlobStoreInternal<TMetadata>(
   if (maxBytesPerEntry > maxBytesPerNamespace) {
     throw invalidInput("plugin blob maxBytesPerEntry must not exceed maxBytesPerNamespace", "open");
   }
-  const overflowPolicy = validateOverflowPolicy(options.overflowPolicy);
+  const overflowPolicy = optionPolicy.resolveOverflowPolicy(options.overflowPolicy);
   const defaultTtlMs = validateTtl(options.defaultTtlMs, "open");
-  assertConsistentOptions(pluginId, namespace, {
+  optionPolicy.assertConsistent(pluginId, namespace, {
     maxEntries,
     maxBytesPerEntry,
     maxBytesPerNamespace,
@@ -371,7 +338,7 @@ export function createPluginBlobStoreForTests<TMetadata>(
 
 /** Resets facade signatures and the shared state database handle for tests. */
 export function resetPluginBlobStoreForTests(options: { closeDatabase?: boolean } = {}): void {
-  namespaceOptionSignatures.clear();
+  optionPolicy.clear();
   if (options.closeDatabase !== false) {
     closeOpenClawStateDatabaseForTest();
   }

--- a/src/plugin-state/plugin-state-store.runtime.test.ts
+++ b/src/plugin-state/plugin-state-store.runtime.test.ts
@@ -164,6 +164,33 @@ describe("plugin runtime state proxy", () => {
     });
   });
 
+  it("keeps blob and keyed namespace option policies independent", async () => {
+    await withOpenClawTestState({ label: "plugin-state-policy-independence" }, async () => {
+      const registry = createTestPluginRegistry();
+      const record = createPluginRecord("diffs", "bundled");
+      registry.registry.plugins.push(record);
+      const state = registry.createApi(record, { config: {} }).runtime.state;
+
+      const blob = state.openBlobStore({
+        namespace: "shared-policy",
+        maxEntries: 2,
+        maxBytesPerEntry: 8,
+        maxBytesPerNamespace: 16,
+        overflowPolicy: "reject-new",
+        defaultTtlMs: 100,
+      });
+      const keyed = state.openKeyedStore({
+        namespace: "shared-policy",
+        maxEntries: 3,
+        overflowPolicy: "evict-oldest",
+        defaultTtlMs: 200,
+      });
+
+      await expect(blob.register("blob", new Uint8Array([1]), {})).resolves.toBeUndefined();
+      await expect(keyed.register("keyed", { ok: true })).resolves.toBeUndefined();
+    });
+  });
+
   it("ignores plugin-supplied state directory overrides", async () => {
     await withOpenClawTestState({ label: "plugin-blob-runtime-env" }, async (state) => {
       const registry = createTestPluginRegistry();

--- a/src/plugin-state/plugin-state-store.ts
+++ b/src/plugin-state/plugin-state-store.ts
@@ -25,6 +25,7 @@ import type {
 } from "./plugin-state-store.types.js";
 import { PluginStateStoreError } from "./plugin-state-store.types.js";
 import {
+  createPluginStoreOptionPolicy,
   serializePluginStoreJson,
   validateOptionalPluginStoreTtlMs,
   validatePluginStoreKey,
@@ -74,7 +75,6 @@ type PluginStateImportEntry = {
   ttlMs?: number;
 };
 
-const namespaceOptionSignatures = new Map<string, StoreOptionSignature>();
 function invalidInput(
   message: string,
   operation: PluginStateStoreOperation = "register",
@@ -114,15 +114,10 @@ function validateMaxEntries(value: number): number {
   return value;
 }
 
-function validateOverflowPolicy(value: unknown): PluginStateOverflowPolicy {
-  if (value === undefined || value === "evict-oldest") {
-    return "evict-oldest";
-  }
-  if (value === "reject-new") {
-    return value;
-  }
-  throw invalidInput("plugin state overflowPolicy must be evict-oldest or reject-new", "open");
-}
+const optionPolicy = createPluginStoreOptionPolicy<StoreOptionSignature>({
+  label: "plugin state",
+  invalid: (message) => invalidInput(message, "open"),
+});
 
 function validateOptionalTtlMs(
   value: number | undefined,
@@ -166,31 +161,6 @@ function prepareRegisterParams(
   };
 }
 
-function assertConsistentOptions(
-  pluginId: string,
-  namespace: string,
-  signature: StoreOptionSignature,
-): void {
-  const key = `${pluginId}\0${namespace}`;
-  const existing = namespaceOptionSignatures.get(key);
-  if (!existing) {
-    namespaceOptionSignatures.set(key, signature);
-    return;
-  }
-  if (
-    existing.maxEntries !== signature.maxEntries ||
-    existing.overflowPolicy !== signature.overflowPolicy ||
-    existing.defaultTtlMs !== signature.defaultTtlMs
-  ) {
-    // A namespace is a shared storage contract. Reopening it with different
-    // limits would make eviction/TTL behavior depend on call order.
-    throw invalidInput(
-      `plugin state namespace ${namespace} for ${pluginId} was reopened with incompatible options`,
-      "open",
-    );
-  }
-}
-
 function createKeyedStoreForPluginId<T>(
   pluginId: string,
   options: OpenKeyedStoreOptions,
@@ -216,10 +186,14 @@ function createSyncKeyedStoreForPluginId<T>(
 ): Required<PluginStateSyncKeyedStore<T>> {
   const namespace = validateNamespace(options.namespace);
   const maxEntries = validateMaxEntries(options.maxEntries);
-  const overflowPolicy = validateOverflowPolicy(options.overflowPolicy);
+  const overflowPolicy = optionPolicy.resolveOverflowPolicy(options.overflowPolicy);
   const defaultTtlMs = validateOptionalTtlMs(options.defaultTtlMs);
   const env = options.env;
-  assertConsistentOptions(pluginId, namespace, { maxEntries, overflowPolicy, defaultTtlMs });
+  optionPolicy.assertConsistent(pluginId, namespace, {
+    maxEntries,
+    overflowPolicy,
+    defaultTtlMs,
+  });
 
   return {
     register(key, value, opts) {
@@ -344,7 +318,7 @@ export function registerMigratedPluginStateEntry(params: {
   }
   const namespace = validateNamespace(params.namespace, "register");
   const maxEntries = validateMaxEntries(params.maxEntries);
-  const overflowPolicy = validateOverflowPolicy(params.overflowPolicy);
+  const overflowPolicy = optionPolicy.resolveOverflowPolicy(params.overflowPolicy);
   const defaultTtlMs = validateOptionalTtlMs(params.defaultTtlMs);
   const prepared = prepareRegisterParams(
     params.key,
@@ -405,11 +379,15 @@ export function registerPluginStateSyncSequencedJournalEntry(params: {
   }
   const cursorNamespace = validateNamespace(params.cursorOptions.namespace);
   const cursorMaxEntries = validateMaxEntries(params.cursorOptions.maxEntries);
-  const cursorOverflowPolicy = validateOverflowPolicy(params.cursorOptions.overflowPolicy);
+  const cursorOverflowPolicy = optionPolicy.resolveOverflowPolicy(
+    params.cursorOptions.overflowPolicy,
+  );
   const cursorDefaultTtlMs = validateOptionalTtlMs(params.cursorOptions.defaultTtlMs);
   const journalNamespace = validateNamespace(params.journalOptions.namespace);
   const journalMaxEntries = validateMaxEntries(params.journalOptions.maxEntries);
-  const journalOverflowPolicy = validateOverflowPolicy(params.journalOptions.overflowPolicy);
+  const journalOverflowPolicy = optionPolicy.resolveOverflowPolicy(
+    params.journalOptions.overflowPolicy,
+  );
   const journalDefaultTtlMs = validateOptionalTtlMs(params.journalOptions.defaultTtlMs);
   if (
     cursorOverflowPolicy !== "evict-oldest" ||
@@ -423,12 +401,12 @@ export function registerPluginStateSyncSequencedJournalEntry(params: {
     throw invalidInput("sequenced plugin state journal stores must share one environment");
   }
   const cursorKey = validateKey(params.cursorKey);
-  assertConsistentOptions(params.pluginId, cursorNamespace, {
+  optionPolicy.assertConsistent(params.pluginId, cursorNamespace, {
     maxEntries: cursorMaxEntries,
     overflowPolicy: cursorOverflowPolicy,
     defaultTtlMs: cursorDefaultTtlMs,
   });
-  assertConsistentOptions(params.pluginId, journalNamespace, {
+  optionPolicy.assertConsistent(params.pluginId, journalNamespace, {
     maxEntries: journalMaxEntries,
     overflowPolicy: journalOverflowPolicy,
     defaultTtlMs: journalDefaultTtlMs,
@@ -478,10 +456,14 @@ export function importPluginStateEntriesForDoctor(
   }
   const namespace = validateNamespace(options.namespace);
   const maxEntries = validateMaxEntries(options.maxEntries);
-  const overflowPolicy = validateOverflowPolicy(options.overflowPolicy);
+  const overflowPolicy = optionPolicy.resolveOverflowPolicy(options.overflowPolicy);
   const defaultTtlMs = validateOptionalTtlMs(options.defaultTtlMs);
   const env = options.env;
-  assertConsistentOptions(pluginId, namespace, { maxEntries, overflowPolicy, defaultTtlMs });
+  optionPolicy.assertConsistent(pluginId, namespace, {
+    maxEntries,
+    overflowPolicy,
+    defaultTtlMs,
+  });
 
   for (const entry of entries) {
     if (!Number.isSafeInteger(entry.createdAt)) {
@@ -517,7 +499,7 @@ export function createCorePluginStateSyncKeyedStore<T>(
 /** Clears plugin-state rows and option signatures for tests. */
 function clearPluginStateStoreForTests(): void {
   clearPluginStateDatabaseForTests();
-  namespaceOptionSignatures.clear();
+  optionPolicy.clear();
 }
 
 /** Resets plugin-state module/database state for isolated tests. */
@@ -526,7 +508,7 @@ export function resetPluginStateStoreForTests(options: { closeDatabase?: boolean
     closePluginStateDatabase();
     closeOpenClawStateDatabaseForTest();
   }
-  namespaceOptionSignatures.clear();
+  optionPolicy.clear();
 }
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {

--- a/src/plugin-state/plugin-store-validation.ts
+++ b/src/plugin-state/plugin-store-validation.ts
@@ -12,6 +12,52 @@ type PluginStoreValidationErrors = {
   limit(message: string): Error;
 };
 
+type PluginStoreOptionSignature = Record<string, string | number | undefined>;
+
+type PluginStoreOptionPolicy<T extends PluginStoreOptionSignature> = {
+  resolveOverflowPolicy(value: unknown): "evict-oldest" | "reject-new";
+  assertConsistent(pluginId: string, namespace: string, signature: T): void;
+  clear(): void;
+};
+
+export function createPluginStoreOptionPolicy<T extends PluginStoreOptionSignature>(params: {
+  label: string;
+  invalid(message: string): Error;
+}): PluginStoreOptionPolicy<T> {
+  const signatures = new Map<string, T>();
+
+  return {
+    resolveOverflowPolicy(value) {
+      if (value === undefined || value === "evict-oldest") {
+        return "evict-oldest";
+      }
+      if (value === "reject-new") {
+        return value;
+      }
+      throw params.invalid(`${params.label} overflowPolicy must be evict-oldest or reject-new`);
+    },
+    assertConsistent(pluginId, namespace, signature) {
+      const key = `${pluginId}\0${namespace}`;
+      const existing = signatures.get(key);
+      if (!existing) {
+        signatures.set(key, signature);
+        return;
+      }
+      const compatible =
+        Object.entries(existing).every(([name, value]) => signature[name] === value) &&
+        Object.entries(signature).every(([name, value]) => existing[name] === value);
+      if (!compatible) {
+        throw params.invalid(
+          `${params.label} namespace ${namespace} for ${pluginId} was reopened with incompatible options`,
+        );
+      }
+    },
+    clear() {
+      signatures.clear();
+    },
+  };
+}
+
 function assertMaxUtf8Bytes(params: {
   label: string;
   value: string;


### PR DESCRIPTION
Related: #127621

## What Problem This Solves

Plugin blob and keyed state facades separately implemented the same overflow validation and process-local namespace option-admission contract. Keeping that policy duplicated made error, ordering, and reset behavior vulnerable to drifting apart.

## Why This Change Was Made

This centralizes the shared policy in the existing plugin-store validation owner while retaining one independent policy instance per facade. It preserves the existing first-valid-admission contract, synchronous typed `open` errors, call ordering, migration behavior, and test reset ordering.

Generation fencing, lifecycle authority, registry release/refcounting, and the security behavior tracked in #127621 are explicit non-goals.

## User Impact

No user-visible behavior changes. Blob and keyed/JSON stores continue to accept independent option contracts even when a plugin ID and namespace are identical, with less duplicated policy to maintain.

No Plugin SDK, config, protocol, schema, persistence, dependency, or changelog changes.

Production delta: `+82/-87` (net `-5`). Test delta: `+27/-0`.

## Evidence

- `node scripts/run-vitest.mjs src/plugin-state/plugin-blob-store.test.ts src/plugin-state/plugin-state-store.test.ts src/plugin-state/plugin-state-store.runtime.test.ts` — 61 tests passed.
- Focused blob, keyed-store, and cross-facade independence cases passed individually.
- `pnpm tsgo:test:src`, `pnpm tsgo:core`, and `pnpm tsgo:core:test` passed.
- `pnpm check:import-cycles` passed with zero runtime value cycles.
- The full changed-file plan passed. Sparse-worktree prerequisites for the UI dependency tree and native schema source were linked/expanded without tracked source changes before rerunning the affected gates.
- Structural duplicate scan is empty for the removed local validators and registries.
- `git diff --check` passed.
