### PR TITLE
test(tooling): cover profiler argument variants at the parser

### DIFF
--- a/test/scripts/profile-extension-memory.test.ts
+++ b/test/scripts/profile-extension-memory.test.ts
@@ -150,29 +150,32 @@ describe("scripts/profile-extension-memory", () => {
     ] as const;
 
     for (const [flag, value] of cases) {
-      const result = runProfileExtensionMemory([flag, value]);
-
-      expect(result.status).toBe(1);
-      expect(result.stdout).toBe("");
-      expect(result.stderr).toContain(`[extension-memory] ${flag} must be a positive integer`);
-      expect(result.stderr).not.toContain("dist/extensions");
-      expect(result.stderr).not.toContain("at ");
+      expect(() => parseArgs([flag, value])).toThrow(`${flag} must be a positive integer`);
     }
+
+    const result = runProfileExtensionMemory([...cases[0]]);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain(`[extension-memory] ${cases[0][0]} must be a positive integer`);
+    expect(result.stderr).not.toContain("dist/extensions");
+    expect(result.stderr).not.toContain("at ");
   });
 
   it("rejects option-looking string flag values before scanning built plugin artifacts", () => {
-    for (const args of [
+    const cases = [
       ["--extension", "-h"],
       ["--json", "-h"],
-    ]) {
-      const result = runProfileExtensionMemory(args);
-
-      expect(result.status).toBe(1);
-      expect(result.stdout).toBe("");
-      expect(result.stderr).toContain(`[extension-memory] ${args[0]} requires a value`);
-      expect(result.stderr).not.toContain("dist/extensions");
-      expect(result.stderr).not.toContain("at ");
+    ] as const;
+    for (const [flag, value] of cases) {
+      expect(() => parseArgs([flag, value])).toThrow(`${flag} requires a value`);
     }
+
+    const result = runProfileExtensionMemory([...cases[0]]);
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain(`[extension-memory] ${cases[0][0]} requires a value`);
+    expect(result.stderr).not.toContain("dist/extensions");
+    expect(result.stderr).not.toContain("at ");
   });
 
   it.each([


### PR DESCRIPTION
## What problem does this PR solve?

Six invalid-argument variants each launch the memory profiler in a new Node/tsx process, repeating the same CLI diagnostic path before any build discovery.

## Why this approach?

Exercise every existing malformed input through the already-exported parser. Keep one real CLI rejection for each error class, including exit status, empty stdout, diagnostic prefix and absence of a stack trace or build scan. This removes four process launches while retaining the real help, profiling, RSS, descendant-process and cleanup coverage.

## User impact

Test-only change. Production +0/-0; tests +19/-16.

## Evidence

All 31 profiler and build-owner cases pass before and after. Full changed-file checks and structured Codex autoreview pass. Reviewed the full CLI/parser and build owners plus numeric-validation history. No elapsed-time claim.

`node scripts/run-vitest.mjs test/scripts/profile-extension-memory.test.ts test/scripts/ensure-extension-memory-build.test.ts`
