### PR TITLE
fix(agents): prevent native hook failures during overlapping Codex runs

### DIFF
--- a/extensions/codex/src/app-server/native-hook-relay.test.ts
+++ b/extensions/codex/src/app-server/native-hook-relay.test.ts
@@ -442,6 +442,7 @@ function createRelay(options?: {
           ? " --pre-tool-use-unavailable noop"
           : ""
       }${commandOptions?.timeoutMs ? ` --timeout ${commandOptions.timeoutMs}` : ""}`,
+    claimTurn: () => undefined,
     renew: () => undefined,
     unregister: () => undefined,
   };

--- a/extensions/codex/src/app-server/run-attempt-turn-request.ts
+++ b/extensions/codex/src/app-server/run-attempt-turn-request.ts
@@ -148,6 +148,14 @@ export async function prepareCodexAttemptTurnRequest(
         }),
       );
       acceptedTurnId = startedTurn.turn.id;
+      // Bind this turn's native hook traffic to this run's relay registration
+      // immediately: an overlapping same-generation sibling (bound-thread
+      // resume) must never consume this turn's hooks or policy context, and
+      // unclaimed hooks on a contested generation fail closed. Codex
+      // turn/start is start-or-steer — when it steered a sibling's live turn
+      // it returns THAT turn's id, and the relay refuses the duplicate claim
+      // so hook ownership stays with the original claimant.
+      resourceState.nativeHookRelay?.claimTurn(acceptedTurnId);
       throwIfTurnStartAcceptedAfterAbort();
       return startedTurn;
     } catch (error) {

--- a/extensions/codex/src/app-server/side-question.ts
+++ b/extensions/codex/src/app-server/side-question.ts
@@ -836,6 +836,9 @@ export async function runCodexAppServerSideQuestion(
         }),
     );
     turnId = turnResponse.turn.id;
+    // Bind the side turn's hooks to this side relay so they can never fall
+    // through to a session sibling's registration.
+    nativeHookRelay?.claimTurn(turnId);
     collector.setTurn(childThreadId, turnId);
     nativeToolLifecycleProjector = new CodexNativeToolLifecycleProjector(
       { ...sideRunParams, agentId: sessionAgentId },

--- a/src/agents/harness/native-hook-relay-bridge.ts
+++ b/src/agents/harness/native-hook-relay-bridge.ts
@@ -4,9 +4,13 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { isPidDefinitelyDead } from "../../shared/pid-alive.js";
 import {
   isNativeHookRelayBridgeStaleRegistrationError,
+  NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS,
   NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR,
 } from "./native-hook-relay-client.js";
-import { nativeHookRelayState } from "./native-hook-relay-state.js";
+import {
+  nativeHookRelayRegistrationsById,
+  nativeHookRelayState,
+} from "./native-hook-relay-state.js";
 import {
   clearNativeHookRelayBridgeRecordsForTests,
   deleteNativeHookRelayBridgeRecordIfOwned,
@@ -34,11 +38,11 @@ const log = createSubsystemLogger("agents/harness/native-hook-relay");
 
 export {
   isRetryableNativeHookRelayBridgeLookupError,
-  NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS,
   NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR,
 } from "./native-hook-relay-client.js";
 
 const { relays, relayBridges } = nativeHookRelayState;
+const relayRegistrationsById = nativeHookRelayRegistrationsById;
 
 type InvokeNativeHookRelay = (
   params: InvokeNativeHookRelayParams,
@@ -48,7 +52,6 @@ type NativeHookRelayBridgeRequestAuth = {
   provider: NativeHookRelayProvider;
   relayId: string;
   token: string;
-  registration: ActiveNativeHookRelayRegistration;
   bridge: NativeHookRelayBridgeRegistration;
   invokeRelay: InvokeNativeHookRelay;
 };
@@ -58,89 +61,155 @@ export function registerNativeHookRelayBridge(
   stateDbPath: string,
   invokeRelay: InvokeNativeHookRelay,
 ): void {
-  // Liveness checks stay outside the write transaction. The store rereads each
-  // authoritative row before deletion so renewal or replacement wins the race.
-  try {
-    const pruned = pruneNativeHookRelayBridgeRecords({
-      currentPid: process.pid,
-      isPidDead: isPidDefinitelyDead,
-      stateDbPath,
-    });
-    for (const row of pruned) {
-      log.debug("pruned stale native hook relay bridge record", {
-        relayId: row.relayId,
-        stalePid: row.pid,
-        currentPid: process.pid,
-        reason: row.reason,
-      });
+  const relayId = registration.relayId;
+  const existing = relayBridges.get(relayId);
+  if (existing) {
+    if (existing.server.listening) {
+      // Reuse the live bridge so re-registration never interrupts in-flight
+      // hook subprocesses from sibling runs on the same relayId. Refresh the
+      // record so its expiry covers the new registration.
+      refreshNativeHookRelayBridgeRecord(relayId);
+      return;
     }
-  } catch (error) {
-    log.debug("native hook relay bridge record prune skipped", { error });
+    if (existing.pendingListen) {
+      // Server is still starting; its listen callback publishes the record
+      // with relay-wide expiry once bound.
+      return;
+    }
+    // The previous bridge server closed or failed. Replace it, leaving the old
+    // record in place briefly so racing hook subprocesses retry instead of
+    // observing a missing relay.
+    unregisterNativeHookRelayBridge(relayId, {
+      deferBridgeRecordRemovalMs: NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS,
+      expectedBridge: existing,
+    });
+  } else {
+    // Liveness checks stay outside the write transaction. The store rereads
+    // each authoritative row before deletion so renewal or replacement wins
+    // the race.
+    try {
+      const pruned = pruneNativeHookRelayBridgeRecords({
+        currentPid: process.pid,
+        isPidDead: isPidDefinitelyDead,
+        stateDbPath,
+      });
+      for (const row of pruned) {
+        log.debug("pruned stale native hook relay bridge record", {
+          relayId: row.relayId,
+          stalePid: row.pid,
+          currentPid: process.pid,
+          reason: row.reason,
+        });
+      }
+    } catch (error) {
+      log.debug("native hook relay bridge record prune skipped", { error });
+    }
   }
-  unregisterNativeHookRelayBridge(registration.relayId);
   const token = randomUUID();
   const server = createServer();
   const bridge: NativeHookRelayBridgeRegistration = {
-    relayId: registration.relayId,
+    relayId,
     stateDbPath,
     token,
     server,
+    pendingListen: true,
   };
   server.on("request", (req, res) => {
     void handleNativeHookRelayBridgeRequest(req, res, {
       provider: registration.provider,
-      relayId: registration.relayId,
+      relayId,
       token,
-      registration,
       bridge,
       invokeRelay,
     });
   });
-  relayBridges.set(registration.relayId, bridge);
+  relayBridges.set(relayId, bridge);
   server.on("error", (error) => {
-    log.debug("native hook relay bridge server error", { error, relayId: registration.relayId });
+    bridge.pendingListen = false;
+    log.debug("native hook relay bridge server error", { error, relayId });
   });
   server.listen(0, "127.0.0.1", () => {
-    if (relayBridges.get(registration.relayId) !== bridge) {
+    bridge.pendingListen = false;
+    if (relayBridges.get(relayId) !== bridge) {
       return;
     }
     try {
-      writeNativeHookRelayBridgeRecordForRegistration(registration, bridge);
+      writeNativeHookRelayBridgeRecordForRelay(relayId, bridge);
     } catch (error) {
       log.debug("failed to publish native hook relay bridge record", {
         error,
-        relayId: registration.relayId,
+        relayId,
       });
     }
   });
   server.unref();
 }
 
-function writeNativeHookRelayBridgeRecordForRegistration(
-  registration: ActiveNativeHookRelayRegistration,
+/**
+ * One bridge serves every live registration for the relayId, so the record
+ * must outlive the longest-lived one. A shared-state registration written by
+ * an older module copy lives only in `relays`; keep the record alive for it
+ * too.
+ */
+export function resolveNativeHookRelayBridgeRecordExpiresAtMs(
+  relayId: string,
+  floorExpiresAtMs?: number,
+): number | undefined {
+  let expiresAtMs = floorExpiresAtMs;
+  for (const registration of relayRegistrationsById.get(relayId) ?? []) {
+    if (expiresAtMs === undefined || registration.expiresAtMs > expiresAtMs) {
+      expiresAtMs = registration.expiresAtMs;
+    }
+  }
+  const current = relays.get(relayId);
+  if (current && (expiresAtMs === undefined || current.expiresAtMs > expiresAtMs)) {
+    expiresAtMs = current.expiresAtMs;
+  }
+  return expiresAtMs;
+}
+
+function writeNativeHookRelayBridgeRecordForRelay(
+  relayId: string,
   bridge: NativeHookRelayBridgeRegistration,
 ): void {
-  const record = resolveNativeHookRelayBridgeRecord(registration, bridge);
+  const expiresAtMs = resolveNativeHookRelayBridgeRecordExpiresAtMs(relayId);
+  if (expiresAtMs === undefined) {
+    return;
+  }
+  const record = resolveNativeHookRelayBridgeRecord(relayId, bridge, expiresAtMs);
   if (!record) {
     return;
   }
   writeNativeHookRelayBridgeRecord({ record, stateDbPath: bridge.stateDbPath });
 }
 
+/** Republish the shared record after registration-set changes on a live bridge. */
+export function refreshNativeHookRelayBridgeRecord(relayId: string): void {
+  const bridge = relayBridges.get(relayId);
+  if (!bridge || !bridge.server.listening) {
+    return;
+  }
+  try {
+    writeNativeHookRelayBridgeRecordForRelay(relayId, bridge);
+  } catch (error) {
+    log.debug("failed to publish native hook relay bridge record", { error, relayId });
+  }
+}
+
 function resolveNativeHookRelayBridgeRecord(
-  registration: ActiveNativeHookRelayRegistration,
+  relayId: string,
   bridge: NativeHookRelayBridgeRegistration,
-  expiresAtMs = registration.expiresAtMs,
+  expiresAtMs: number,
 ): NativeHookRelayBridgeRecord | undefined {
   const address = bridge.server.address();
   if (!address || typeof address === "string") {
     log.debug("native hook relay bridge server address unavailable", {
-      relayId: registration.relayId,
+      relayId,
     });
     return undefined;
   }
   return {
-    relayId: registration.relayId,
+    relayId,
     pid: process.pid,
     hostname: "127.0.0.1",
     port: address.port,
@@ -154,7 +223,7 @@ export function renewNativeHookRelayBridgeRecord(
   bridge: NativeHookRelayBridgeRegistration,
   expiresAtMs: number,
 ): "renewed" | "unavailable" | "ownership-changed" {
-  const record = resolveNativeHookRelayBridgeRecord(registration, bridge, expiresAtMs);
+  const record = resolveNativeHookRelayBridgeRecord(registration.relayId, bridge, expiresAtMs);
   if (!record) {
     return "unavailable";
   }
@@ -251,8 +320,13 @@ async function handleNativeHookRelayBridgeRequest(
 }
 
 function isCurrentNativeHookRelayBridgeRequest(auth: NativeHookRelayBridgeRequestAuth): boolean {
+  // The bridge outlives individual registrations; a request is current while
+  // this bridge is still installed and any registration is live. Per-request
+  // generation resolution happens in invokeNativeHookRelay and fails closed.
+  // `relays` alone can hold a registration written by an older module copy.
   return (
-    relays.get(auth.relayId) === auth.registration && relayBridges.get(auth.relayId) === auth.bridge
+    relayBridges.get(auth.relayId) === auth.bridge &&
+    ((relayRegistrationsById.get(auth.relayId)?.size ?? 0) > 0 || relays.has(auth.relayId))
   );
 }
 

--- a/src/agents/harness/native-hook-relay-registrations.ts
+++ b/src/agents/harness/native-hook-relay-registrations.ts
@@ -1,0 +1,487 @@
+/** Registration slot bookkeeping and lifetime teardown for native hook relays. */
+import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
+import { retainBeforeToolCallForNativeHookRelay } from "./host-capability.js";
+import {
+  refreshNativeHookRelayBridgeRecord,
+  unregisterNativeHookRelayBridge,
+} from "./native-hook-relay-bridge.js";
+import {
+  removeNativeHookRelayPermissionState,
+  removeNativeHookRelayPreToolUseApprovals,
+} from "./native-hook-relay-permissions.js";
+import {
+  nativeHookRelayRegistrationsById,
+  nativeHookRelayState,
+} from "./native-hook-relay-state.js";
+import type {
+  ActiveNativeHookRelayRegistration,
+  NativeHookRelayEvent,
+  NativeHookRelayRegistration,
+} from "./native-hook-relay-types.js";
+
+const log = createSubsystemLogger("agents/harness/native-hook-relay");
+
+const { relays, relayBridges, invocations } = nativeHookRelayState;
+const relayRegistrationsById = nativeHookRelayRegistrationsById;
+
+export type RelayLifetime = {
+  foregroundOpen: boolean;
+  foregroundToken: symbol;
+  retained?: ReturnType<typeof retainBeforeToolCallForNativeHookRelay>;
+  retention?: NativeHookRelayRetention;
+  removeAbortListener?: () => void;
+  expiryTimer?: ReturnType<typeof setTimeout>;
+};
+
+const RELAY_LIFETIME = "__openclawNativeHookRelayLifetimeV1";
+
+// A run claims one native turn (side questions and retries register their own
+// relay), so the cap only bounds leaks. Evicting the oldest claim degrades
+// that turn's hooks to the fail-closed contested-generation rejection below,
+// never to cross-run routing.
+const MAX_NATIVE_HOOK_RELAY_TURN_CLAIMS = 32;
+
+/** Private bundled-runtime callbacks for retained direct-child hook policy. */
+export type NativeHookRelayRetention = Readonly<{
+  readClaim: (rawPayload: unknown) => string | undefined;
+  shouldRetainAfterForegroundClose: () => boolean;
+  allowPreToolUse: (claim: string) => boolean;
+  awaitForegroundAdmission?: (claim: string) => Promise<(() => boolean) | undefined>;
+  onDispose: () => void;
+}>;
+
+export function readRelayLifetime(
+  registration: ActiveNativeHookRelayRegistration,
+): RelayLifetime | undefined {
+  // SAFETY: this private symbol-keyed expando is installed only by setRelayLifetime below.
+  return (registration as ActiveNativeHookRelayRegistration & { [RELAY_LIFETIME]?: RelayLifetime })[
+    RELAY_LIFETIME
+  ];
+}
+
+export function setRelayLifetime(
+  registration: ActiveNativeHookRelayRegistration,
+  lifetime: RelayLifetime,
+): void {
+  Object.defineProperty(registration, RELAY_LIFETIME, {
+    configurable: true,
+    value: lifetime,
+  });
+}
+
+export function scheduleNativeHookRelayExpiry(
+  relayId: string,
+  registration: ActiveNativeHookRelayRegistration,
+): void {
+  const lifetime = readRelayLifetime(registration);
+  if (!lifetime) {
+    return;
+  }
+  if (lifetime.expiryTimer) {
+    clearTimeout(lifetime.expiryTimer);
+  }
+  const rearm = () => {
+    if (!relayRegistrationsById.get(relayId)?.has(registration)) {
+      return;
+    }
+    const remainingMs = registration.expiresAtMs - Date.now();
+    if (remainingMs < 0) {
+      unregisterNativeHookRelay(relayId, registration);
+      return;
+    }
+    lifetime.expiryTimer = setTimeout(rearm, Math.min(remainingMs + 1, MAX_TIMER_TIMEOUT_MS));
+    lifetime.expiryTimer.unref();
+  };
+  rearm();
+}
+
+export function unregisterNativeHookRelay(
+  relayId: string,
+  expectedRegistration: ActiveNativeHookRelayRegistration,
+): void {
+  const registrations = relayRegistrationsById.get(relayId);
+  if (registrations?.has(expectedRegistration)) {
+    // Detach first: owner cleanup may register a same-id successor, which must
+    // never be removed by this registration's later resource cleanup.
+    registrations.delete(expectedRegistration);
+    if (relays.get(relayId) === expectedRegistration) {
+      // Promote the most recently registered surviving registration so callers
+      // without a generation (bootstrap grace) keep resolving.
+      const latest = latestNativeHookRelayRegistration(registrations);
+      if (latest) {
+        relays.set(relayId, latest);
+      } else {
+        relays.delete(relayId);
+      }
+    }
+    if (registrations.size === 0) {
+      relayRegistrationsById.delete(relayId);
+    }
+    releaseNativeHookRelayRegistration(relayId, expectedRegistration);
+    return;
+  }
+  if (relays.get(relayId) === expectedRegistration) {
+    // Compatibility: this registration lives only in `relays` — written by an
+    // older module copy that predates the registration slot map. Removing it
+    // must never tear down slot-tracked live siblings.
+    const latest = latestNativeHookRelayRegistration(registrations);
+    if (latest) {
+      relays.set(relayId, latest);
+    } else {
+      relays.delete(relayId);
+    }
+    releaseNativeHookRelayRegistration(relayId, expectedRegistration);
+  }
+  // Otherwise: already unregistered, expired, or removed — or a sibling run's
+  // live registration. Never remove a registration the caller does not own.
+}
+
+/** Frees one registration's own resources; relayId-wide state goes with the last one. */
+function releaseNativeHookRelayRegistration(
+  relayId: string,
+  registration: ActiveNativeHookRelayRegistration,
+): void {
+  const lifetime = readRelayLifetime(registration);
+  if (lifetime?.expiryTimer) {
+    clearTimeout(lifetime.expiryTimer);
+  }
+  lifetime?.removeAbortListener?.();
+  lifetime?.retained?.release();
+  // Claims die with the registration: a released run's turns must never keep
+  // routing authority through retained handle copies.
+  registration.claimedTurnIds.clear();
+  // SAFETY: this deletes the same private expando installed by setRelayLifetime.
+  delete (registration as ActiveNativeHookRelayRegistration & { [RELAY_LIFETIME]?: RelayLifetime })[
+    RELAY_LIFETIME
+  ];
+  if (!relayRegistrationsById.get(relayId)?.size && !relays.has(relayId)) {
+    teardownNativeHookRelayId(relayId);
+  } else {
+    // Live siblings keep the shared bridge; retighten the record's expiry to
+    // the surviving registrations.
+    refreshNativeHookRelayBridgeRecord(relayId);
+  }
+  try {
+    lifetime?.retention?.onDispose();
+  } catch (error) {
+    try {
+      log.warn("native hook relay unregister callback failed", { error, relayId });
+    } catch {
+      // Teardown has already detached every identity-bound resource. Logging
+      // must not turn an observer callback failure into a cleanup failure.
+    }
+  }
+}
+
+/** Tears down relayId-wide resources once no registration remains. */
+function teardownNativeHookRelayId(relayId: string): void {
+  const bridge = relayBridges.get(relayId);
+  unregisterNativeHookRelayBridge(relayId, bridge ? { expectedBridge: bridge } : undefined);
+  removeNativeHookRelayInvocations(relayId);
+  removeNativeHookRelayPreToolUseApprovals(relayId);
+  removeNativeHookRelayPermissionState(relayId);
+}
+
+function latestNativeHookRelayRegistration(
+  registrations: Set<ActiveNativeHookRelayRegistration> | undefined,
+): ActiveNativeHookRelayRegistration | undefined {
+  let latest: ActiveNativeHookRelayRegistration | undefined;
+  for (const candidate of registrations ?? []) {
+    latest = candidate;
+  }
+  return latest;
+}
+
+function isLiveNativeHookRelayRegistration(
+  relayId: string,
+  registration: ActiveNativeHookRelayRegistration,
+): boolean {
+  return (
+    relayRegistrationsById.get(relayId)?.has(registration) === true ||
+    // A shared-state registration written by an older module copy that
+    // predates the registration slot map lives only in `relays`.
+    relays.get(relayId) === registration
+  );
+}
+
+export function claimNativeHookRelayTurn(
+  relayId: string,
+  registration: ActiveNativeHookRelayRegistration,
+  turnId: string,
+): void {
+  const trimmed = turnId.trim();
+  if (!trimmed || !isLiveNativeHookRelayRegistration(relayId, registration)) {
+    return;
+  }
+  // Codex turn/start is start-or-steer: with a sibling's turn already active it
+  // steers and returns that ACTIVE turn's id (../codex turn_processor.rs
+  // start_or_steer_turn -> TurnInputSubmission::Steered { turn_id }). Claiming
+  // the returned id here would silently hand the live sibling's hook and
+  // approval routing to this run, so the duplicate is refused: the original
+  // claimant keeps owning its own live turn. Only slot-tracked siblings can
+  // hold claims — registrations from older module copies predate turn claims.
+  for (const sibling of relayRegistrationsById.get(relayId) ?? []) {
+    if (sibling !== registration && sibling.claimedTurnIds.has(trimmed)) {
+      log.warn("native hook relay refused duplicate turn claim from steered turn start", {
+        relayId,
+        runId: registration.runId,
+        claimantRunId: sibling.runId,
+      });
+      return;
+    }
+  }
+  if (
+    registration.claimedTurnIds.size >= MAX_NATIVE_HOOK_RELAY_TURN_CLAIMS &&
+    !registration.claimedTurnIds.has(trimmed)
+  ) {
+    const oldest = registration.claimedTurnIds.values().next().value;
+    if (oldest !== undefined) {
+      registration.claimedTurnIds.delete(oldest);
+    }
+  }
+  registration.claimedTurnIds.add(trimmed);
+}
+
+export type NativeHookRelayInvocationTarget =
+  | { outcome: "resolved"; registration: ActiveNativeHookRelayRegistration }
+  | { outcome: "contested-generation" }
+  | { outcome: "not-found" };
+
+/**
+ * Resolves the one live registration that owns an invocation, in ownership
+ * order: retained direct-child claim, then claimed turn id, then unique
+ * generation match. Overlapping runs of one bound thread share
+ * (relayId, generation) and byte-identical persisted hook commands, so an
+ * unclaimed hook on a generation with two live registrations has no provable
+ * originating run: routing it to the newest sibling would execute it under the
+ * wrong run's policy context (the P1 cross-bind). That case fails closed.
+ * Unclaimed direct-child subjects are the one deliberate exception: monitor
+ * claims arrive asynchronously, so with a single live retained candidate the
+ * hook resolves to it and invocation binding decides — admission-wait while
+ * the foreground is open, rejection once it closes.
+ */
+export function resolveNativeHookRelayInvocationTarget(params: {
+  relayId: string;
+  requestedGeneration: string | undefined;
+  turnSelector: string | undefined;
+  rawPayload: unknown;
+}): NativeHookRelayInvocationTarget {
+  const registrations = relayRegistrationsById.get(params.relayId);
+  // Retained direct-child owner first: subagent hooks present the child
+  // subject, and a registration that already claimed that child runs them
+  // under its retained policy capability. Newest claimant wins the
+  // degenerate double-claim case deterministically.
+  let childOwner: ActiveNativeHookRelayRegistration | undefined;
+  let childCandidate: ActiveNativeHookRelayRegistration | undefined;
+  let childCandidateCount = 0;
+  for (const candidate of registrations ?? []) {
+    const retention = readRelayLifetime(candidate)?.retention;
+    if (!retention) {
+      continue;
+    }
+    try {
+      const claim = retention.readClaim(params.rawPayload);
+      if (!claim) {
+        continue;
+      }
+      childCandidate = candidate;
+      childCandidateCount += 1;
+      if (retention.allowPreToolUse(claim)) {
+        childOwner = candidate;
+      }
+    } catch {
+      // A throwing retention probe grants no ownership; other live
+      // registrations and the generation path still resolve.
+    }
+  }
+  if (childOwner) {
+    return { outcome: "resolved", registration: childOwner };
+  }
+  if (childCandidateCount === 1 && childCandidate) {
+    // Unclaimed child subject with exactly one live retained candidate:
+    // subagent-monitor claims are asynchronous (a racing child hook can beat
+    // its own claim), so ownership is not yet provable but also not
+    // contested. Binding decides — admission-wait while the candidate's
+    // foreground is open, rejection once it closes.
+    return { outcome: "resolved", registration: childCandidate };
+  }
+  if (childCandidateCount > 1) {
+    return { outcome: "contested-generation" };
+  }
+  if (params.turnSelector) {
+    let turnOwner: ActiveNativeHookRelayRegistration | undefined;
+    let turnOwnerCount = 0;
+    for (const candidate of registrations ?? []) {
+      if (candidate.claimedTurnIds.has(params.turnSelector)) {
+        turnOwner = candidate;
+        turnOwnerCount += 1;
+      }
+    }
+    if (turnOwnerCount > 1) {
+      // Two live registrations claiming one provider-minted turn id is corrupt
+      // routing state (steer duplicates are refused at claim time): no provable
+      // owner, so policy and approval dispatch must fail closed rather than
+      // pick the newest claimant.
+      return { outcome: "contested-generation" };
+    }
+    if (turnOwner) {
+      return { outcome: "resolved", registration: turnOwner };
+    }
+    if (registrations?.size) {
+      // A provider-minted turn selector is an exact claim, never a hint. Once
+      // present, missing/stale/wrong claims must not downgrade to generation
+      // routing, even if only one same-generation sibling remains live.
+      return { outcome: "contested-generation" };
+    }
+    // No slot-tracked registration exists: fall through to the shared-state
+    // fallback so a claim-incapable registration written by an older module
+    // copy keeps serving real payloads, which always carry a turn id.
+  }
+  if (params.requestedGeneration !== undefined && registrations) {
+    let match: ActiveNativeHookRelayRegistration | undefined;
+    let matchCount = 0;
+    for (const candidate of registrations) {
+      if (candidate.generation === params.requestedGeneration) {
+        match = candidate;
+        matchCount += 1;
+      }
+    }
+    // Without a request selector, more than one same-generation registration
+    // is inherently ambiguous and must fail before policy dispatch.
+    if (matchCount > 1) {
+      return { outcome: "contested-generation" };
+    }
+    if (match) {
+      return { outcome: "resolved", registration: match };
+    }
+  }
+  // Fall back to the current registration so bootstrap generation-mismatch
+  // grace and generation-less callers keep resolving. Also covers shared-state
+  // entries written by an older module copy that predates the slot map.
+  const fallback = relays.get(params.relayId) ?? latestNativeHookRelayRegistration(registrations);
+  return fallback ? { outcome: "resolved", registration: fallback } : { outcome: "not-found" };
+}
+
+export function deactivateNativeHookRelayForeground(
+  relayId: string,
+  registration: ActiveNativeHookRelayRegistration,
+): void {
+  if (!isLiveNativeHookRelayRegistration(relayId, registration)) {
+    return;
+  }
+  const lifetime = readRelayLifetime(registration);
+  if (!lifetime) {
+    return;
+  }
+  lifetime.foregroundOpen = false;
+  let shouldRetain = false;
+  if (lifetime.retained && lifetime.retention) {
+    try {
+      shouldRetain = lifetime.retention.shouldRetainAfterForegroundClose();
+    } catch (error) {
+      try {
+        log.warn("native hook relay retention predicate failed", { error, relayId });
+      } catch {
+        // A logging failure cannot make a throwing retention predicate retain authority.
+      }
+    }
+  }
+  if (shouldRetain) {
+    return;
+  }
+  unregisterNativeHookRelay(relayId, registration);
+}
+
+export async function resolveNativeHookRelayInvocationBinding(
+  registration: ActiveNativeHookRelayRegistration,
+  event: NativeHookRelayEvent,
+  rawPayload: unknown,
+): Promise<NativeHookRelayRegistration> {
+  const lifetime = readRelayLifetime(registration);
+  if (!lifetime) {
+    throw new Error("native hook relay registration is inactive");
+  }
+  const claim = lifetime.retention?.readClaim(rawPayload);
+  if (claim && event === "pre_tool_use" && lifetime.retained && lifetime.retention) {
+    const retained = lifetime.retained;
+    const retention = lifetime.retention;
+    let assertAdmission: (() => boolean) | undefined;
+    const assertRetainedAuthority = () => {
+      if (
+        !isLiveNativeHookRelayRegistration(registration.relayId, registration) ||
+        Date.now() > registration.expiresAtMs
+      ) {
+        throw new Error("native hook relay registration is inactive");
+      }
+      registration.signal?.throwIfAborted();
+      retained.assertActive();
+      if (assertAdmission && !assertAdmission()) {
+        throw new Error("native hook relay retained invocation not allowed");
+      }
+      if (!retention.allowPreToolUse(claim)) {
+        throw new Error("native hook relay retained invocation not allowed");
+      }
+    };
+    if (lifetime.foregroundOpen && retention.awaitForegroundAdmission) {
+      assertAdmission = await retention.awaitForegroundAdmission(claim);
+      if (!assertAdmission) {
+        throw new Error("native hook relay retained invocation not allowed");
+      }
+      assertRetainedAuthority();
+    } else if (!retention.allowPreToolUse(claim)) {
+      throw new Error("native hook relay retained invocation not allowed");
+    }
+    return {
+      ...registration,
+      assertActive: assertRetainedAuthority,
+      runBeforeToolCall: retained.runBeforeToolCall,
+    };
+  }
+  if (!lifetime.foregroundOpen) {
+    throw new Error("native hook relay foreground invocation not allowed");
+  }
+  const foregroundToken = lifetime.foregroundToken;
+  const assertActive = () => {
+    if (
+      !isLiveNativeHookRelayRegistration(registration.relayId, registration) ||
+      Date.now() > registration.expiresAtMs
+    ) {
+      throw new Error("native hook relay registration is inactive");
+    }
+    registration.signal?.throwIfAborted();
+    registration.assertActive?.();
+    if (!lifetime.foregroundOpen || lifetime.foregroundToken !== foregroundToken) {
+      throw new Error("native hook relay foreground invocation not allowed");
+    }
+  };
+  return { ...registration, assertActive };
+}
+
+function removeNativeHookRelayInvocations(relayId: string): void {
+  for (let index = invocations.length - 1; index >= 0; index -= 1) {
+    if (invocations[index]?.relayId === relayId) {
+      invocations.splice(index, 1);
+    }
+  }
+}
+
+export function pruneExpiredNativeHookRelays(now = Date.now()): void {
+  // unregisterNativeHookRelay only removes the caller's own entry (and
+  // possibly its relayId key), which is safe during Map/Set iteration.
+  for (const registrations of relayRegistrationsById.values()) {
+    for (const registration of registrations) {
+      if (now > registration.expiresAtMs) {
+        unregisterNativeHookRelay(registration.relayId, registration);
+      }
+    }
+  }
+  // Compatibility sweep: a registration written by an older module copy that
+  // predates the slot map lives only in `relays`. Expire it here so it cannot
+  // pin the relayId, the bridge auth fallback, or a routing fallback forever.
+  for (const [relayId, registration] of relays) {
+    if (now > registration.expiresAtMs && !relayRegistrationsById.get(relayId)?.has(registration)) {
+      unregisterNativeHookRelay(relayId, registration);
+    }
+  }
+}

--- a/src/agents/harness/native-hook-relay-state.ts
+++ b/src/agents/harness/native-hook-relay-state.ts
@@ -1,4 +1,7 @@
-import type { NativeHookRelaySharedState } from "./native-hook-relay-types.js";
+import type {
+  ActiveNativeHookRelayRegistration,
+  NativeHookRelaySharedState,
+} from "./native-hook-relay-types.js";
 
 const NATIVE_HOOK_RELAY_STATE_SYMBOL = Symbol.for("openclaw.nativeHookRelay.state");
 export const MAX_NATIVE_HOOK_RELAY_INVOCATIONS = 200;
@@ -20,3 +23,11 @@ function getNativeHookRelaySharedState(): NativeHookRelaySharedState {
 }
 
 export const nativeHookRelayState = getNativeHookRelaySharedState();
+
+// Upgrade shared state created by an older module copy that predates the
+// registration slot map (duplicate module instances share this object via the
+// global symbol, so the property can be missing at runtime).
+export const nativeHookRelayRegistrationsById: Map<
+  string,
+  Set<ActiveNativeHookRelayRegistration>
+> = (nativeHookRelayState.relayRegistrationsById ??= new Map());

--- a/src/agents/harness/native-hook-relay-types.ts
+++ b/src/agents/harness/native-hook-relay-types.ts
@@ -97,6 +97,16 @@ export type NativeHookRelayRegistration = {
 
 export type NativeHookRelayRegistrationHandle = NativeHookRelayRegistration & {
   generation?: string;
+  /**
+   * Binds a provider-minted turn id to this registration. Overlapping runs of
+   * one bound thread share (relayId, generation) and their persisted hook
+   * commands are byte-identical, so the payload turn id is the only
+   * run-exact routing key; claiming it keeps this run's hooks from binding a
+   * same-generation sibling's policy context. A turn id already claimed by a
+   * live sibling is refused: a steered turn/start returns the sibling's
+   * ACTIVE turn id, and claiming it would silently transfer hook ownership.
+   */
+  claimTurn: (turnId: string) => void;
   shouldRelayEvent: (event: NativeHookRelayEvent) => boolean;
   toolMatcherForEvent: (event: NativeHookRelayEvent) => readonly string[] | undefined;
   commandForEvent: (
@@ -202,6 +212,10 @@ export type ActiveNativeHookRelayRegistration = NativeHookRelayRegistration & {
   generation: string;
   preToolUseLoopDetection: boolean;
   preToolUseFailureProjections: Map<string, { promise: Promise<void>; settled: boolean }>;
+  // Provider turn ids claimed by this registration's run, insertion-ordered
+  // for bounded FIFO eviction. Consulted before generation routing so
+  // same-generation siblings never consume each other's turn hooks.
+  claimedTurnIds: Set<string>;
 };
 
 export type ActiveNativeHookRelayRegistrationHandle = NativeHookRelayRegistrationHandle & {
@@ -249,6 +263,9 @@ export type NativeHookRelayBridgeRegistration = {
   stateDbPath: string;
   token: string;
   server: Server;
+  // True from listen() until the server reports listening or errors. Guards
+  // bridge reuse against replacing a server that is still starting up.
+  pendingListen: boolean;
 };
 
 export type NativeHookRelaySharedState = {
@@ -259,4 +276,11 @@ export type NativeHookRelaySharedState = {
   pendingPreToolUseApprovals: Map<string, NativeHookRelayPreToolUseApproval>;
   permissionApprovalWindows: Map<string, number[]>;
   permissionAllowAlwaysApprovals: Map<string, { expiresAtMs: number }>;
+  // relayId -> live registrations in registration order (oldest first).
+  // Multiple runs on the same agent/session share one stable relayId, and
+  // overlapping runs may even share one generation (bound-thread resume
+  // persists the generation), so every live registration keeps its own slot.
+  // Kept optional-at-runtime so a shared-state object created by an older
+  // module copy under the same global symbol can be upgraded in place.
+  relayRegistrationsById?: Map<string, Set<ActiveNativeHookRelayRegistration>>;
 };

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -37,6 +37,7 @@ import {
   writeNativeHookRelayBridgeRecord,
   type NativeHookRelayBridgeRecord,
 } from "./native-hook-relay-store.js";
+import type { ActiveNativeHookRelayRegistration } from "./native-hook-relay-types.js";
 import {
   registerRetainedNativeHookRelay,
   testing,
@@ -862,8 +863,8 @@ describe("native hook relay registry", () => {
     expect(testing.getNativeHookRelayRegistrationForTests(relayId)?.runId).toBe("run-successor");
   });
 
-  it("keeps the callback-created successor after replacement teardown", async () => {
-    const relayId = uniqueNativeHookRelayIdForTests("replacement-reentrant-successor");
+  it("keeps an earlier retained registration undisposed when a sibling registers the same id", async () => {
+    const relayId = uniqueNativeHookRelayIdForTests("overlapping-retained-siblings");
     let callbackSuccessor: ReturnType<typeof registerNativeHookRelay> | undefined;
     const first = registerRetainedNativeHookRelay({
       provider: "codex",
@@ -886,23 +887,35 @@ describe("native hook relay registry", () => {
         },
       },
     });
-    const replacementUnregistered = vi.fn();
-    registerRetainedNativeHookRelay({
+    const siblingDisposed = vi.fn();
+    const sibling = registerRetainedNativeHookRelay({
       provider: "codex",
       relayId,
       sessionId: "session-1",
-      runId: "run-replacement",
+      runId: "run-sibling",
       allowedEvents: ["post_tool_use"],
       retention: {
         readClaim: readTestNativeAgentId,
         shouldRetainAfterForegroundClose: () => false,
         allowPreToolUse: () => false,
-        onDispose: replacementUnregistered,
+        onDispose: siblingDisposed,
       },
     });
 
+    // Registering a sibling on the stable id must not dispose the live first
+    // registration or fire retention callbacks.
+    expect(callbackSuccessor).toBeUndefined();
+    expect(siblingDisposed).not.toHaveBeenCalled();
+    expect(testing.getNativeHookRelayRegistrationGenerationsForTests(relayId)).toEqual([
+      first.generation,
+      sibling.generation,
+    ]);
+
+    // The first registration's own unregister still delivers its dispose
+    // callback, and a reentrant same-id successor coexists with the sibling.
+    first.unregister();
     expect(callbackSuccessor).toBeDefined();
-    expect(replacementUnregistered).toHaveBeenCalledOnce();
+    expect(siblingDisposed).not.toHaveBeenCalled();
     expect(testing.getNativeHookRelayRegistrationForTests(relayId)?.runId).toBe(
       "run-callback-successor",
     );
@@ -916,14 +929,26 @@ describe("native hook relay registry", () => {
         rawPayload: { hook_event_name: "PostToolUse", tool_name: "Bash", tool_response: {} },
       }),
     ).resolves.toMatchObject({ exitCode: 0 });
-    first.unregister();
+    await expect(
+      invokeNativeHookRelayBridge({
+        provider: "codex",
+        relayId,
+        generation: sibling.generation,
+        event: "post_tool_use",
+        timeoutMs: 2_000,
+        rawPayload: { hook_event_name: "PostToolUse", tool_name: "Bash", tool_response: {} },
+      }),
+    ).resolves.toMatchObject({ exitCode: 0 });
+    sibling.unregister();
+    expect(siblingDisposed).toHaveBeenCalledOnce();
     callbackSuccessor?.unregister();
+    expect(testing.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
   });
 
-  it("delivers old replacement callback when the successor signal is already aborted", () => {
-    const relayId = uniqueNativeHookRelayIdForTests("replacement-preaborted");
-    const oldUnregistered = vi.fn();
-    registerRetainedNativeHookRelay({
+  it("keeps the live registration when a pre-aborted successor registration throws", async () => {
+    const relayId = uniqueNativeHookRelayIdForTests("preaborted-successor");
+    const oldDisposed = vi.fn();
+    const old = registerRetainedNativeHookRelay({
       provider: "codex",
       relayId,
       sessionId: "session-1",
@@ -932,7 +957,7 @@ describe("native hook relay registry", () => {
         readClaim: readTestNativeAgentId,
         shouldRetainAfterForegroundClose: () => false,
         allowPreToolUse: () => false,
-        onDispose: oldUnregistered,
+        onDispose: oldDisposed,
       },
     });
     const controller = new AbortController();
@@ -948,7 +973,17 @@ describe("native hook relay registry", () => {
       }),
     ).toThrow("native hook relay registration aborted");
 
-    expect(oldUnregistered).toHaveBeenCalledOnce();
+    // The aborted registration removes only its own slot; the live sibling
+    // stays registered, undisposed, and current.
+    expect(oldDisposed).not.toHaveBeenCalled();
+    expect(testing.getNativeHookRelayRegistrationForTests(relayId)?.runId).toBe("run-old");
+    expect(testing.getNativeHookRelayRegistrationGenerationsForTests(relayId)).toEqual([
+      old.generation,
+    ]);
+    await waitForNativeHookRelayBridgeRecord(relayId);
+
+    old.unregister();
+    expect(oldDisposed).toHaveBeenCalledOnce();
     expect(testing.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
     expect(testing.getNativeHookRelayBridgeRecordForTests(relayId)).toBeUndefined();
   });
@@ -1457,7 +1492,7 @@ describe("native hook relay registry", () => {
     );
   });
 
-  it("allows callers to replace a relay at a stable id", async () => {
+  it("keeps overlapping registrations live at a stable id", async () => {
     const first = registerNativeHookRelay({
       provider: "codex",
       relayId: "codex-stable-session",
@@ -1475,6 +1510,10 @@ describe("native hook relay registry", () => {
     });
 
     expect(second.relayId).toBe(first.relayId);
+    expect(testing.getNativeHookRelayRegistrationGenerationsForTests(first.relayId)).toEqual([
+      first.generation,
+      second.generation,
+    ]);
     expectRecordFields(
       requireRecord(
         testing.getNativeHookRelayRegistrationForTests(first.relayId),
@@ -1487,22 +1526,25 @@ describe("native hook relay registry", () => {
     );
     const secondExpiresAtMs = requireRecord(
       testing.getNativeHookRelayRegistrationForTests(first.relayId),
-      "replacement native hook relay registration",
+      "newest native hook relay registration",
     ).expiresAtMs;
 
     first.renew(60_000);
     expect(
       requireRecord(
         testing.getNativeHookRelayRegistrationForTests(first.relayId),
-        "replacement native hook relay registration",
+        "newest native hook relay registration",
       ).expiresAtMs,
     ).toBe(secondExpiresAtMs);
 
     first.unregister();
+    expect(testing.getNativeHookRelayRegistrationGenerationsForTests(first.relayId)).toEqual([
+      second.generation,
+    ]);
     expectRecordFields(
       requireRecord(
         testing.getNativeHookRelayRegistrationForTests(first.relayId),
-        "replacement native hook relay registration",
+        "surviving native hook relay registration",
       ),
       {
         runId: "run-2",
@@ -1515,7 +1557,9 @@ describe("native hook relay registry", () => {
         relayId: second.relayId,
         generation: second.generation,
         event: "post_tool_use",
-        timeoutMs: 2_000,
+        // Generous budget: this is the file's first bridge await, so it also
+        // absorbs the deferred listen/publish backlog on slow hosts.
+        timeoutMs: 10_000,
         rawPayload: {
           hook_event_name: "PostToolUse",
           tool_name: "Bash",
@@ -1528,6 +1572,969 @@ describe("native hook relay registry", () => {
 
     second.unregister();
     expect(testing.getNativeHookRelayRegistrationForTests(first.relayId)).toBeUndefined();
+    expect(testing.getNativeHookRelayRegistrationGenerationsForTests(first.relayId)).toEqual([]);
+  });
+
+  it("keeps an active run routable when an overlapping sibling registers and unregisters", async () => {
+    // Regression: a stable per-session relayId with a single registration slot
+    // let an overlapping run replace the active registration and remove it on
+    // its own unregister, failing every later hook closed mid-turn.
+    const active = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-overlapping-siblings",
+      sessionId: "session-1",
+      runId: "run-active",
+      allowedEvents: ["pre_tool_use"],
+    });
+    const invokeActive = (toolUseId: string) =>
+      invokeNativeHookRelayBridge({
+        provider: "codex",
+        relayId: active.relayId,
+        generation: active.generation,
+        event: "pre_tool_use",
+        timeoutMs: 2_000,
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_use_id: toolUseId,
+          tool_input: { command: "pnpm test" },
+        },
+      });
+    await expect(invokeActive("call-before-overlap")).resolves.toEqual({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const sibling = registerNativeHookRelay({
+      provider: "codex",
+      relayId: active.relayId,
+      sessionId: "session-1",
+      runId: "run-sibling",
+      allowedEvents: ["pre_tool_use"],
+    });
+    // Sibling registration must not stale the active run's generation.
+    await expect(invokeActive("call-during-overlap")).resolves.toEqual({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    // Sibling completion must not remove the active run's registration.
+    sibling.unregister();
+    await expect(invokeActive("call-after-sibling-unregister")).resolves.toEqual({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(
+      testing
+        .getNativeHookRelayInvocationsForTests()
+        .map((invocation) => [invocation.runId, invocation.toolUseId]),
+    ).toEqual([
+      ["run-active", "call-before-overlap"],
+      ["run-active", "call-during-overlap"],
+      ["run-active", "call-after-sibling-unregister"],
+    ]);
+
+    active.unregister();
+    expect(testing.getNativeHookRelayRegistrationForTests(active.relayId)).toBeUndefined();
+    expect(testing.getNativeHookRelayRegistrationGenerationsForTests(active.relayId)).toEqual([]);
+  });
+
+  it("binds concurrent same-generation registrations to their own run's policy context", async () => {
+    // Regression: two overlapping live runs of one bound thread share
+    // (relayId, generation) and byte-identical persisted hook commands, and
+    // generation-based routing sent the older run's hooks to the newest
+    // sibling — running them under the wrong run's policy context. The
+    // provider-minted turn id claimed at turn start is the run-exact binding.
+    const runPolicyFirst = vi.fn(async () => ({ blocked: false as const, params: {} }));
+    const runPolicySecond = vi.fn(async () => ({ blocked: false as const, params: {} }));
+    const first = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-same-generation-policy",
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["pre_tool_use"],
+      runBeforeToolCall: runPolicyFirst,
+    });
+    first.claimTurn("turn-1");
+    const second = registerNativeHookRelay({
+      provider: "codex",
+      relayId: first.relayId,
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-2",
+      allowedEvents: ["pre_tool_use"],
+      runBeforeToolCall: runPolicySecond,
+    });
+    second.claimTurn("turn-2");
+    expect(second.generation).toBe(first.generation);
+    const invokeForTurn = (turnId: string, toolUseId: string) =>
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: first.relayId,
+        generation: "generation-thread-1",
+        requireGeneration: true,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          turn_id: turnId,
+          tool_name: "Bash",
+          tool_use_id: toolUseId,
+          tool_input: { command: "pnpm test" },
+        },
+      });
+
+    // The older run's hook must bind the older registration even though a
+    // newer same-generation sibling is live.
+    await expect(invokeForTurn("turn-1", "call-run-1")).resolves.toMatchObject({ exitCode: 0 });
+    expect(runPolicyFirst).toHaveBeenCalledTimes(1);
+    expect(runPolicySecond).not.toHaveBeenCalled();
+
+    await expect(invokeForTurn("turn-2", "call-run-2")).resolves.toMatchObject({ exitCode: 0 });
+    expect(runPolicyFirst).toHaveBeenCalledTimes(1);
+    expect(runPolicySecond).toHaveBeenCalledTimes(1);
+
+    // Same proof through the loopback bridge transport.
+    await expect(
+      invokeNativeHookRelayBridge({
+        provider: "codex",
+        relayId: first.relayId,
+        generation: "generation-thread-1",
+        event: "pre_tool_use",
+        timeoutMs: 10_000,
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          turn_id: "turn-1",
+          tool_name: "Bash",
+          tool_use_id: "call-run-1-bridge",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).resolves.toMatchObject({ exitCode: 0 });
+    expect(runPolicyFirst).toHaveBeenCalledTimes(2);
+    expect(runPolicySecond).toHaveBeenCalledTimes(1);
+
+    expect(
+      testing
+        .getNativeHookRelayInvocationsForTests()
+        .map((invocation) => [invocation.runId, invocation.toolUseId]),
+    ).toEqual([
+      ["run-1", "call-run-1"],
+      ["run-2", "call-run-2"],
+      ["run-1", "call-run-1-bridge"],
+    ]);
+
+    first.unregister();
+    second.unregister();
+  });
+
+  it("fails closed for unclaimed hooks while same-generation registrations overlap", async () => {
+    const runPolicyFirst = vi.fn(async () => ({ blocked: false as const, params: {} }));
+    const runPolicySecond = vi.fn(async () => ({ blocked: false as const, params: {} }));
+    const first = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-contested-generation",
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["pre_tool_use"],
+      runBeforeToolCall: runPolicyFirst,
+    });
+    first.claimTurn("turn-1");
+    const second = registerNativeHookRelay({
+      provider: "codex",
+      relayId: first.relayId,
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-2",
+      allowedEvents: ["pre_tool_use"],
+      runBeforeToolCall: runPolicySecond,
+    });
+    const invokeForPayload = (rawPayload: Record<string, unknown>) =>
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: first.relayId,
+        generation: "generation-thread-1",
+        requireGeneration: true,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_use_id: "call-contested",
+          tool_input: { command: "pnpm test" },
+          ...rawPayload,
+        },
+      });
+
+    // No live registration claimed this turn and two live runs share the
+    // generation: no provable originating run, so policy must fail closed
+    // instead of executing under the newest sibling's context.
+    await expect(invokeForPayload({ turn_id: "turn-unknown" })).rejects.toThrow(
+      "native hook relay bridge stale registration",
+    );
+    // A payload without any turn id is equally unprovable while contested.
+    await expect(invokeForPayload({})).rejects.toThrow(
+      "native hook relay bridge stale registration",
+    );
+    expect(testing.getNativeHookRelayInvocationsForTests()).toStrictEqual([]);
+    expect(runPolicyFirst).not.toHaveBeenCalled();
+    expect(runPolicySecond).not.toHaveBeenCalled();
+
+    // Once the older run ends, its claimed selector is stale and must not
+    // downgrade to the surviving sibling even though the generation is no
+    // longer contested.
+    first.unregister();
+    await expect(invokeForPayload({ turn_id: "turn-1" })).rejects.toThrow(
+      "native hook relay bridge stale registration",
+    );
+    await expect(invokeForPayload({ turn_id: "turn-unknown" })).rejects.toThrow(
+      "native hook relay bridge stale registration",
+    );
+    expect(runPolicySecond).not.toHaveBeenCalled();
+    expect(testing.getNativeHookRelayInvocationsForTests()).toStrictEqual([]);
+
+    second.unregister();
+  });
+
+  it("refuses a steered duplicate turn claim so hook ownership stays with the original run", async () => {
+    // Codex turn/start is start-or-steer: with run A's turn already active,
+    // run B's turn/start steers it and returns A's ACTIVE turn id. B claiming
+    // that id must never transfer A's live hook and approval routing to B's
+    // policy context.
+    const runPolicyFirst = vi.fn(async () => ({ blocked: false as const, params: {} }));
+    const runPolicySecond = vi.fn(async () => ({ blocked: false as const, params: {} }));
+    const first = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-steered-turn-claim",
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["pre_tool_use"],
+      runBeforeToolCall: runPolicyFirst,
+    });
+    first.claimTurn("turn-live");
+    const second = registerNativeHookRelay({
+      provider: "codex",
+      relayId: first.relayId,
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-2",
+      allowedEvents: ["pre_tool_use"],
+      runBeforeToolCall: runPolicySecond,
+    });
+    // The steered turn/start handed run-2 the sibling's active turn id.
+    second.claimTurn("turn-live");
+    const invokeForTurn = (turnId: string, toolUseId: string) =>
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: first.relayId,
+        generation: "generation-thread-1",
+        requireGeneration: true,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          turn_id: turnId,
+          tool_name: "Bash",
+          tool_use_id: toolUseId,
+          tool_input: { command: "pnpm test" },
+        },
+      });
+
+    // The live turn's hooks keep binding the original claimant's policy.
+    await expect(invokeForTurn("turn-live", "call-after-steer")).resolves.toMatchObject({
+      exitCode: 0,
+    });
+    expect(runPolicyFirst).toHaveBeenCalledTimes(1);
+    expect(runPolicySecond).not.toHaveBeenCalled();
+    expect(getOnlyNativeHookRelayInvocation()).toMatchObject({ runId: "run-1" });
+
+    // The refusal is claim-scoped: run-2's own later turn still claims and
+    // routes normally.
+    second.claimTurn("turn-own");
+    await expect(invokeForTurn("turn-own", "call-own-turn")).resolves.toMatchObject({
+      exitCode: 0,
+    });
+    expect(runPolicyFirst).toHaveBeenCalledTimes(1);
+    expect(runPolicySecond).toHaveBeenCalledTimes(1);
+
+    first.unregister();
+    second.unregister();
+  });
+
+  it("fails closed when two live registrations hold the same turn claim", async () => {
+    // claimTurn refuses steer duplicates, but shared module-copy state could
+    // still carry a double claim. That state has no provable owner and must
+    // fail closed instead of resolving to the newest claimant.
+    const runPolicyFirst = vi.fn(async () => ({ blocked: false as const, params: {} }));
+    const runPolicySecond = vi.fn(async () => ({ blocked: false as const, params: {} }));
+    const first = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-double-turn-claim",
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["pre_tool_use"],
+      runBeforeToolCall: runPolicyFirst,
+    });
+    first.claimTurn("turn-dup");
+    const second = registerNativeHookRelay({
+      provider: "codex",
+      relayId: first.relayId,
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-2",
+      allowedEvents: ["pre_tool_use"],
+      runBeforeToolCall: runPolicySecond,
+    });
+    // Simulate a claim written by a module copy without steer-duplicate
+    // refusal directly on the shared registration object.
+    const secondRegistration = testing.getNativeHookRelayLiveRegistrationForTests(
+      first.relayId,
+      second.generation,
+    ) as ActiveNativeHookRelayRegistration | undefined;
+    if (secondRegistration?.runId !== "run-2") {
+      throw new Error("Expected the sibling registration to be live");
+    }
+    secondRegistration.claimedTurnIds.add("turn-dup");
+
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: first.relayId,
+        generation: "generation-thread-1",
+        requireGeneration: true,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          turn_id: "turn-dup",
+          tool_name: "Bash",
+          tool_use_id: "call-double-claim",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).rejects.toThrow("native hook relay bridge stale registration");
+    expect(runPolicyFirst).not.toHaveBeenCalled();
+    expect(runPolicySecond).not.toHaveBeenCalled();
+    expect(testing.getNativeHookRelayInvocationsForTests()).toStrictEqual([]);
+
+    first.unregister();
+    second.unregister();
+  });
+
+  it("routes retained direct-child hooks to their claiming registration during same-generation overlap", async () => {
+    // A retained parent registration owns its claimed child threads even after
+    // a same-generation sibling registers on the relayId; the child's hooks
+    // must bind the claimant, not the newest sibling.
+    const retainedPolicy = vi.fn(async () => ({ blocked: false as const, params: {} }));
+    const siblingPolicy = vi.fn(async () => ({ blocked: false as const, params: {} }));
+    const retained = registerRetainedNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-retained-child-overlap",
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-retained",
+      allowedEvents: ["pre_tool_use"],
+      runBeforeToolCall: retainedPolicy,
+      retention: {
+        readClaim: readTestNativeAgentId,
+        shouldRetainAfterForegroundClose: () => true,
+        allowPreToolUse: (claim) => claim === "child-thread-1",
+        onDispose: () => undefined,
+      },
+    });
+    const sibling = registerNativeHookRelay({
+      provider: "codex",
+      relayId: retained.relayId,
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-sibling",
+      allowedEvents: ["pre_tool_use"],
+      runBeforeToolCall: siblingPolicy,
+    });
+
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: retained.relayId,
+        generation: "generation-thread-1",
+        requireGeneration: true,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          agent_id: "child-thread-1",
+          turn_id: "child-turn-1",
+          tool_name: "Bash",
+          tool_use_id: "call-child",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).resolves.toMatchObject({ exitCode: 0 });
+    expect(retainedPolicy).toHaveBeenCalledTimes(1);
+    expect(siblingPolicy).not.toHaveBeenCalled();
+    expect(getOnlyNativeHookRelayInvocation()).toMatchObject({ runId: "run-retained" });
+
+    retained.unregister();
+    sibling.unregister();
+  });
+
+  it("holds an open-foreground unclaimed child hook in admission-wait until the child is claimed", async () => {
+    // Regression: subagent-monitor child claims arrive asynchronously, so a
+    // racing child hook can beat its own claim. With a single live retained
+    // registration the hook must reach admission-wait and resolve when the
+    // claim lands — not fail closed as contested.
+    const { admittedRunContext, hostCapabilities } = await createAdmittedHostCapabilityTestFixture({
+      runId: "run-parent",
+    });
+    const relayId = uniqueNativeHookRelayIdForTests("child-admission-wait");
+    const claims = new Map<string, symbol>();
+    const pendingAdmissions = new Map<string, (claim: symbol) => void>();
+    const relay = registerRetainedNativeHookRelay({
+      provider: "codex",
+      relayId,
+      sessionId: "session-1",
+      runId: "run-parent",
+      allowedEvents: ["pre_tool_use"],
+      runBeforeToolCall: hostCapabilities.runBeforeToolCall,
+      assertActive: hostCapabilities.assertActive,
+      retention: {
+        readClaim: readTestNativeAgentId,
+        shouldRetainAfterForegroundClose: () => false,
+        allowPreToolUse: (claim) => claims.has(claim),
+        // Mirrors the Codex plugin's deferral: unclaimed children wait for
+        // the asynchronous claim instead of failing immediately.
+        awaitForegroundAdmission: (childThreadId) =>
+          new Promise((resolve) => {
+            const existing = claims.get(childThreadId);
+            if (existing) {
+              resolve(() => claims.get(childThreadId) === existing);
+              return;
+            }
+            pendingAdmissions.set(childThreadId, (claim) => {
+              resolve(() => claims.get(childThreadId) === claim);
+            });
+          }),
+        onDispose: () => undefined,
+      },
+    });
+
+    const invocation = invokeNativeHookRelay({
+      provider: "codex",
+      relayId,
+      event: "pre_tool_use",
+      // Real child payloads carry the child's own (unclaimed) turn id; the
+      // child subject must take precedence over turn-selector routing.
+      rawPayload: {
+        hook_event_name: "PreToolUse",
+        agent_id: "child-thread-1",
+        turn_id: "child-turn-1",
+        tool_name: "Bash",
+        tool_use_id: "call-child-admission",
+        tool_input: { command: "pnpm test" },
+      },
+    });
+    await vi.waitFor(() => {
+      expect(pendingAdmissions.has("child-thread-1")).toBe(true);
+    });
+    // Still in admission-wait: nothing dispatched, nothing recorded.
+    expect(testing.getNativeHookRelayInvocationsForTests()).toStrictEqual([]);
+
+    // claimDirectChild equivalent: the monitor claims the child, which
+    // resolves the pending admission.
+    const claim = Symbol("child-thread-1");
+    claims.set("child-thread-1", claim);
+    pendingAdmissions.get("child-thread-1")?.(claim);
+    pendingAdmissions.delete("child-thread-1");
+
+    await expect(invocation).resolves.toMatchObject({ exitCode: 0 });
+    expect(getOnlyNativeHookRelayInvocation()).toMatchObject({ runId: "run-parent" });
+
+    relay.unregister();
+    expect(testing.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
+    closeAdmittedRunDelegatedAuthority(admittedRunContext);
+  });
+
+  it("fails closed for an unclaimed child while two retained registrations overlap", async () => {
+    // With two live retained candidates the racing child has no provable
+    // parent; admission-wait would guess, so the hook fails closed instead.
+    const firstPolicy = vi.fn(async () => ({ blocked: false as const, params: {} }));
+    const secondPolicy = vi.fn(async () => ({ blocked: false as const, params: {} }));
+    const first = registerRetainedNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-contested-child",
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["pre_tool_use"],
+      runBeforeToolCall: firstPolicy,
+      retention: {
+        readClaim: readTestNativeAgentId,
+        shouldRetainAfterForegroundClose: () => false,
+        allowPreToolUse: () => false,
+        onDispose: () => undefined,
+      },
+    });
+    const second = registerRetainedNativeHookRelay({
+      provider: "codex",
+      relayId: first.relayId,
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-2",
+      allowedEvents: ["pre_tool_use"],
+      runBeforeToolCall: secondPolicy,
+      retention: {
+        readClaim: readTestNativeAgentId,
+        shouldRetainAfterForegroundClose: () => false,
+        allowPreToolUse: () => false,
+        onDispose: () => undefined,
+      },
+    });
+
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: first.relayId,
+        generation: "generation-thread-1",
+        requireGeneration: true,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          agent_id: "child-unclaimed",
+          turn_id: "child-turn-1",
+          tool_name: "Bash",
+          tool_use_id: "call-contested-child",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).rejects.toThrow("native hook relay bridge stale registration");
+    expect(firstPolicy).not.toHaveBeenCalled();
+    expect(secondPolicy).not.toHaveBeenCalled();
+    expect(testing.getNativeHookRelayInvocationsForTests()).toStrictEqual([]);
+
+    first.unregister();
+    second.unregister();
+  });
+
+  it("keeps a shared-generation registration live until the last sibling unregisters", async () => {
+    // Bound-thread resumes persist the relay generation, so overlapping runs
+    // of one thread share (relayId, generation). The earlier run's deferred
+    // unregister must not tear down the generation while the newer run needs it.
+    const first = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-shared-generation",
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["pre_tool_use"],
+    });
+    const second = registerNativeHookRelay({
+      provider: "codex",
+      relayId: first.relayId,
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-2",
+      allowedEvents: ["pre_tool_use"],
+    });
+    expect(second.generation).toBe(first.generation);
+
+    first.unregister();
+    await expect(
+      invokeNativeHookRelayBridge({
+        provider: "codex",
+        relayId: first.relayId,
+        generation: "generation-thread-1",
+        event: "pre_tool_use",
+        timeoutMs: 2_000,
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_use_id: "call-shared-generation",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    expect(getOnlyNativeHookRelayInvocation()).toMatchObject({
+      relayId: first.relayId,
+      runId: "run-2",
+      toolUseId: "call-shared-generation",
+    });
+
+    second.unregister();
+    expect(testing.getNativeHookRelayRegistrationForTests(first.relayId)).toBeUndefined();
+    expect(testing.getNativeHookRelayBridgeRecordForTests(first.relayId)).toBeUndefined();
+  });
+
+  it("fails closed for a generation that unregistered while siblings remain", async () => {
+    const first = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-dead-generation",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["pre_tool_use"],
+    });
+    const second = registerNativeHookRelay({
+      provider: "codex",
+      relayId: first.relayId,
+      sessionId: "session-1",
+      runId: "run-2",
+      allowedEvents: ["pre_tool_use"],
+    });
+
+    first.unregister();
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: first.relayId,
+        generation: first.generation,
+        requireGeneration: true,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_use_id: "call-dead-generation",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).rejects.toThrow("native hook relay bridge stale registration");
+    expect(testing.getNativeHookRelayInvocationsForTests()).toStrictEqual([]);
+
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: second.relayId,
+        generation: second.generation,
+        requireGeneration: true,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_use_id: "call-live-generation",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
+
+    second.unregister();
+  });
+
+  it("shares one direct bridge across overlapping registrations and cleans up after the last unregister", async () => {
+    const first = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-shared-bridge-lifetime",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["pre_tool_use"],
+    });
+    const before = await waitForNativeHookRelayBridgeRecord(first.relayId);
+
+    const second = registerNativeHookRelay({
+      provider: "codex",
+      relayId: first.relayId,
+      sessionId: "session-1",
+      runId: "run-2",
+      allowedEvents: ["pre_tool_use"],
+    });
+    const during = await waitForNativeHookRelayBridgeRecord(first.relayId);
+    // Re-registration reuses the live bridge: no port/token churn that would
+    // interrupt in-flight hook subprocesses from sibling runs.
+    expect(during.port).toBe(before.port);
+    expect(during.token).toBe(before.token);
+
+    first.unregister();
+    const afterFirstUnregister = await waitForNativeHookRelayBridgeRecord(first.relayId);
+    expect(afterFirstUnregister.port).toBe(before.port);
+    expect(afterFirstUnregister.token).toBe(before.token);
+
+    second.unregister();
+    expect(testing.getNativeHookRelayBridgeRecordForTests(first.relayId)).toBeUndefined();
+  });
+
+  it("renews a non-current registration and extends the shared bridge record", async () => {
+    // Regression: renew previously no-oped once any sibling re-registered the
+    // stable id, so long-running turns lost their relay at the original TTL.
+    const first = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-sibling-renewal",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["pre_tool_use"],
+      ttlMs: 10_000,
+    });
+    const before = await waitForNativeHookRelayBridgeRecord(first.relayId);
+    const second = registerNativeHookRelay({
+      provider: "codex",
+      relayId: first.relayId,
+      sessionId: "session-1",
+      runId: "run-2",
+      allowedEvents: ["pre_tool_use"],
+      ttlMs: 10_000,
+    });
+
+    await new Promise((resolve) => {
+      setTimeout(resolve, 5);
+    });
+    first.renew(60_000);
+
+    const after = await waitForNativeHookRelayBridgeRecord(first.relayId);
+    expect(after.port).toBe(before.port);
+    expect(after.token).toBe(before.token);
+    expect(after.expiresAtMs).toBeGreaterThan(before.expiresAtMs);
+    const renewed = testing.getNativeHookRelayLiveRegistrationForTests(
+      first.relayId,
+      first.generation,
+    );
+    expect(renewed?.expiresAtMs).toBe(first.expiresAtMs);
+    expect(first.expiresAtMs).toBeGreaterThan(second.expiresAtMs);
+
+    first.unregister();
+    second.unregister();
+    expect(testing.getNativeHookRelayRegistrationForTests(first.relayId)).toBeUndefined();
+  });
+
+  it("rejects registrations at the concurrent cap without evicting live siblings", async () => {
+    const relayId = "codex-registration-cap";
+    const cap = testing.getNativeHookRelayConcurrentRegistrationCapForTests();
+    const handles = Array.from({ length: cap }, (_, index) =>
+      registerNativeHookRelay({
+        provider: "codex",
+        relayId,
+        sessionId: "session-1",
+        runId: `run-${index}`,
+        allowedEvents: ["pre_tool_use"],
+      }),
+    );
+
+    expect(testing.getNativeHookRelayRegistrationGenerationsForTests(relayId)).toHaveLength(cap);
+    expect(() =>
+      registerNativeHookRelay({
+        provider: "codex",
+        relayId,
+        sessionId: "session-1",
+        runId: "run-over-cap",
+        allowedEvents: ["pre_tool_use"],
+      }),
+    ).toThrow("native hook relay concurrent registration limit reached");
+
+    // The cap rejects the newcomer; it must never evict a live sibling. The
+    // oldest registration stays registered and routable mid-turn.
+    const generations = testing.getNativeHookRelayRegistrationGenerationsForTests(relayId);
+    expect(generations).toHaveLength(cap);
+    expect(generations[0]).toBe(handles[0]?.generation);
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId,
+        generation: handles[0]?.generation,
+        requireGeneration: true,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_use_id: "call-oldest-live",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
+
+    // Releasing one slot makes registration succeed again.
+    handles[0]?.unregister();
+    const replacement = registerNativeHookRelay({
+      provider: "codex",
+      relayId,
+      sessionId: "session-1",
+      runId: "run-after-free",
+      allowedEvents: ["pre_tool_use"],
+    });
+    expect(testing.getNativeHookRelayRegistrationGenerationsForTests(relayId)).toHaveLength(cap);
+
+    replacement.unregister();
+    for (const handle of handles) {
+      handle.unregister();
+    }
+    expect(testing.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
+    expect(testing.getNativeHookRelayRegistrationGenerationsForTests(relayId)).toEqual([]);
+  });
+
+  it("frees cap slots held by expired registrations instead of rejecting new ones", async () => {
+    const relayId = "codex-registration-cap-expiry";
+    const cap = testing.getNativeHookRelayConcurrentRegistrationCapForTests();
+    const shortLived = registerNativeHookRelay({
+      provider: "codex",
+      relayId,
+      sessionId: "session-1",
+      runId: "run-short",
+      ttlMs: 1,
+      allowedEvents: ["pre_tool_use"],
+    });
+    const longLived = Array.from({ length: cap - 1 }, (_, index) =>
+      registerNativeHookRelay({
+        provider: "codex",
+        relayId,
+        sessionId: "session-1",
+        runId: `run-long-${index}`,
+        allowedEvents: ["pre_tool_use"],
+      }),
+    );
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(shortLived.expiresAtMs + 1));
+
+    // Registration-time pruning frees the expired slot, so the cap does not
+    // reject a legitimate new registration.
+    const replacement = registerNativeHookRelay({
+      provider: "codex",
+      relayId,
+      sessionId: "session-1",
+      runId: "run-replacement",
+      allowedEvents: ["pre_tool_use"],
+    });
+    const generations = testing.getNativeHookRelayRegistrationGenerationsForTests(relayId);
+    expect(generations).toHaveLength(cap);
+    expect(generations).not.toContain(shortLived.generation);
+
+    // The expired generation stays fail-closed.
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId,
+        generation: shortLived.generation,
+        requireGeneration: true,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_use_id: "call-expired",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).rejects.toThrow("native hook relay bridge stale registration");
+
+    vi.useRealTimers();
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId,
+        generation: longLived[0]?.generation,
+        requireGeneration: true,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_use_id: "call-surviving",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
+
+    replacement.unregister();
+    shortLived.unregister();
+    for (const handle of longLived) {
+      handle.unregister();
+    }
+    expect(testing.getNativeHookRelayRegistrationForTests(relayId)).toBeUndefined();
+    expect(testing.getNativeHookRelayRegistrationGenerationsForTests(relayId)).toEqual([]);
+  });
+
+  it("keeps a legacy shared-state registration routable and expires it cleanly", async () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-legacy-shared-state",
+      sessionId: "session-1",
+      runId: "run-legacy",
+      allowedEvents: ["pre_tool_use"],
+    });
+    await waitForNativeHookRelayBridgeRecord(relay.relayId);
+    // Simulate a registration written by an older module copy that predates
+    // the registration slot map: it exists only in the shared `relays` map.
+    testing.simulateLegacyModuleNativeHookRelayRegistrationForTests(relay.relayId);
+    expect(testing.getNativeHookRelayRegistrationGenerationsForTests(relay.relayId)).toEqual([]);
+
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: relay.relayId,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_use_id: "call-legacy-generationless",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: relay.relayId,
+        generation: relay.generation,
+        requireGeneration: true,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          tool_name: "Bash",
+          tool_use_id: "call-legacy-generation",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
+    // Real Codex payloads always carry a turn id, and a legacy registration
+    // can never claim one; the selector must not strand the compat path.
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: relay.relayId,
+        event: "pre_tool_use",
+        rawPayload: {
+          hook_event_name: "PreToolUse",
+          turn_id: "legacy-turn-1",
+          tool_name: "Bash",
+          tool_use_id: "call-legacy-turn-selector",
+          tool_input: { command: "pnpm test" },
+        },
+      }),
+    ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(relay.expiresAtMs + 1));
+    await expect(
+      invokeNativeHookRelay({
+        provider: "codex",
+        relayId: relay.relayId,
+        event: "pre_tool_use",
+        rawPayload: {},
+      }),
+    ).rejects.toThrow("expired");
+    expect(testing.getNativeHookRelayRegistrationForTests(relay.relayId)).toBeUndefined();
+    expect(testing.getNativeHookRelayBridgeRecordForTests(relay.relayId)).toBeUndefined();
+  });
+
+  it("sweeps an expired legacy shared-state registration during unrelated registration", async () => {
+    const relay = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-legacy-sweep",
+      sessionId: "session-1",
+      runId: "run-legacy-sweep",
+      ttlMs: 1,
+      allowedEvents: ["pre_tool_use"],
+    });
+    testing.simulateLegacyModuleNativeHookRelayRegistrationForTests(relay.relayId);
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(relay.expiresAtMs + 1));
+    const other = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "codex-legacy-sweep-other",
+      sessionId: "session-1",
+      runId: "run-other",
+      allowedEvents: ["pre_tool_use"],
+    });
+    vi.useRealTimers();
+
+    expect(testing.getNativeHookRelayRegistrationForTests(relay.relayId)).toBeUndefined();
+    expect(testing.getNativeHookRelayRegistrationForTests(other.relayId)).toBeDefined();
+    other.unregister();
   });
 
   it("exposes registered relays through the direct hook bridge", async () => {
@@ -1560,7 +2567,7 @@ describe("native hook relay registry", () => {
     });
   });
 
-  it("rejects stale direct bridge requests after stable relay id replacement", async () => {
+  it("rejects stale direct bridge requests after a generation unregisters", async () => {
     const first = registerNativeHookRelay({
       provider: "codex",
       relayId: "codex-stale-bridge-request",
@@ -1592,6 +2599,9 @@ describe("native hook relay registry", () => {
       runId: "run-2",
       allowedEvents: ["pre_tool_use"],
     });
+    // Overlapping registrations keep both generations live; staleness begins
+    // when a generation's own registration unregisters.
+    first.unregister();
     staleRequest.sendBody();
 
     await expect(staleRequest.response).resolves.toMatchObject({
@@ -1616,7 +2626,7 @@ describe("native hook relay registry", () => {
     ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
   });
 
-  it("rejects late stale direct bridge commands after stable relay id replacement", async () => {
+  it("rejects late stale direct bridge commands after a generation unregisters", async () => {
     const first = registerNativeHookRelay({
       provider: "codex",
       relayId: "codex-late-stale-bridge-command",
@@ -1636,6 +2646,7 @@ describe("native hook relay registry", () => {
       runId: "run-2",
       allowedEvents: ["pre_tool_use"],
     });
+    first.unregister();
 
     await expect(
       invokeNativeHookRelayBridge({
@@ -2786,7 +3797,6 @@ describe("native hook relay registry", () => {
       runId: "run-1",
       channelId: "telegram",
     });
-
     const response = await invokeNativeHookRelay({
       provider: "codex",
       relayId: relay.relayId,
@@ -3746,6 +4756,7 @@ describe("native hook relay registry", () => {
       runId: "run-1",
       channelId: "telegram",
     });
+    relay.claimTurn("turn-1");
 
     const response = await invokeNativeHookRelay({
       provider: "codex",

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -1,20 +1,16 @@
 /** Native harness hook event relay and public Plugin SDK facade. */
 import { randomUUID } from "node:crypto";
-import {
-  MAX_TIMER_TIMEOUT_MS,
-  resolveExpiresAtMsFromDurationMs,
-} from "@openclaw/normalization-core/number-coercion";
+import { resolveExpiresAtMsFromDurationMs } from "@openclaw/normalization-core/number-coercion";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
 import { retainBeforeToolCallForNativeHookRelay } from "./host-capability.js";
 import {
   clearNativeHookRelayBridgesForTests,
-  NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS,
   NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR,
   readNativeHookRelayBridgeRecordIfExists,
   registerNativeHookRelayBridge,
   renewNativeHookRelayBridgeRecord,
-  unregisterNativeHookRelayBridge,
+  resolveNativeHookRelayBridgeRecordExpiresAtMs,
   isRetryableNativeHookRelayBridgeLookupError,
 } from "./native-hook-relay-bridge.js";
 import {
@@ -38,14 +34,25 @@ import {
   permissionRequestContentFingerprintForTests as permissionRequestContentFingerprintForTestsImpl,
   permissionRequestToolInputKeyFingerprintForTests as permissionRequestToolInputKeyFingerprintForTestsImpl,
   pruneNativeHookRelayPermissionAllowAlways,
-  removeNativeHookRelayPermissionState,
-  removeNativeHookRelayPreToolUseApprovals,
   setNativeHookRelayDeferredToolApprovalRequesterForTests as setNativeHookRelayDeferredToolApprovalRequesterForTestsImpl,
   setNativeHookRelayPermissionApprovalRequesterForTests as setNativeHookRelayPermissionApprovalRequesterForTestsImpl,
 } from "./native-hook-relay-permissions.js";
 import type { NativeHookRelayDeferredToolApprovalRequester } from "./native-hook-relay-permissions.js";
+import type { NativeHookRelayRetention } from "./native-hook-relay-registrations.js";
+import {
+  claimNativeHookRelayTurn,
+  deactivateNativeHookRelayForeground,
+  pruneExpiredNativeHookRelays,
+  readRelayLifetime,
+  resolveNativeHookRelayInvocationBinding,
+  resolveNativeHookRelayInvocationTarget,
+  scheduleNativeHookRelayExpiry,
+  setRelayLifetime,
+  unregisterNativeHookRelay,
+} from "./native-hook-relay-registrations.js";
 import {
   MAX_NATIVE_HOOK_RELAY_INVOCATIONS,
+  nativeHookRelayRegistrationsById,
   nativeHookRelayState,
 } from "./native-hook-relay-state.js";
 import type {
@@ -71,6 +78,7 @@ import {
 } from "./native-hook-relay-utils.js";
 export { buildNativeHookRelayCommand } from "./native-hook-relay-command.js";
 export { resolveNativeHookRelayDeferredToolApproval } from "./native-hook-relay-permissions.js";
+export type { NativeHookRelayRetention } from "./native-hook-relay-registrations.js";
 export type {
   NativeHookRelayEvent,
   NativeHookRelayProcessResponse,
@@ -79,77 +87,23 @@ export type {
 } from "./native-hook-relay-types.js";
 
 const DEFAULT_RELAY_TTL_MS = 30 * 60 * 1000;
+// Overlapping runs on one agent/session (main lane, nested announce runs,
+// bound-thread resumes) each hold a live registration on the same stable
+// relayId until their own deferred unregister fires. The cap bounds leak
+// growth, but hitting it must reject the NEW registration: evicting a live
+// sibling would strand a still-active run's hooks mid-turn, which is exactly
+// the lifecycle bug this module guards against. Sized well above legitimate
+// overlap (rapid short turns each hold a deferred-unregister registration
+// for ~10-15s; expired slots are pruned before the cap is enforced).
+const MAX_NATIVE_HOOK_RELAY_CONCURRENT_REGISTRATIONS = 32;
 const log = createSubsystemLogger("agents/harness/native-hook-relay");
 
 const { relays, relayBridges, invocations } = nativeHookRelayState;
-type RelayLifetime = {
-  foregroundOpen: boolean;
-  foregroundToken: symbol;
-  retained?: ReturnType<typeof retainBeforeToolCallForNativeHookRelay>;
-  retention?: NativeHookRelayRetention;
-  removeAbortListener?: () => void;
-  expiryTimer?: ReturnType<typeof setTimeout>;
-};
-
-const RELAY_LIFETIME = "__openclawNativeHookRelayLifetimeV1";
-
-/** Private bundled-runtime callbacks for retained direct-child hook policy. */
-export type NativeHookRelayRetention = Readonly<{
-  readClaim: (rawPayload: unknown) => string | undefined;
-  shouldRetainAfterForegroundClose: () => boolean;
-  allowPreToolUse: (claim: string) => boolean;
-  awaitForegroundAdmission?: (claim: string) => Promise<(() => boolean) | undefined>;
-  onDispose: () => void;
-}>;
+const relayRegistrationsById = nativeHookRelayRegistrationsById;
 
 type RetainedNativeHookRelayParams = RegisterNativeHookRelayParams & {
   retention: NativeHookRelayRetention;
 };
-
-function readRelayLifetime(
-  registration: ActiveNativeHookRelayRegistration,
-): RelayLifetime | undefined {
-  // SAFETY: this private symbol-keyed expando is installed only by setRelayLifetime below.
-  return (registration as ActiveNativeHookRelayRegistration & { [RELAY_LIFETIME]?: RelayLifetime })[
-    RELAY_LIFETIME
-  ];
-}
-
-function setRelayLifetime(
-  registration: ActiveNativeHookRelayRegistration,
-  lifetime: RelayLifetime,
-): void {
-  Object.defineProperty(registration, RELAY_LIFETIME, {
-    configurable: true,
-    value: lifetime,
-  });
-}
-
-function scheduleNativeHookRelayExpiry(
-  relayId: string,
-  registration: ActiveNativeHookRelayRegistration,
-): void {
-  const lifetime = readRelayLifetime(registration);
-  if (!lifetime) {
-    return;
-  }
-  if (lifetime.expiryTimer) {
-    clearTimeout(lifetime.expiryTimer);
-  }
-  const rearm = () => {
-    if (relays.get(relayId) !== registration) {
-      return;
-    }
-    const remainingMs = registration.expiresAtMs - Date.now();
-    if (remainingMs < 0) {
-      unregisterNativeHookRelay(relayId, registration);
-      return;
-    }
-    lifetime.expiryTimer = setTimeout(rearm, Math.min(remainingMs + 1, MAX_TIMER_TIMEOUT_MS));
-    lifetime.expiryTimer.unref();
-  };
-  rearm();
-}
 
 function resolveNativeHookRelayExpiresAtMs(ttlMs: number | undefined): number | undefined {
   return resolveExpiresAtMsFromDurationMs(normalizePositiveInteger(ttlMs, DEFAULT_RELAY_TTL_MS));
@@ -185,10 +139,25 @@ function registerNativeHookRelayInternal(
   }
   const allowedEvents = normalizeAllowedEvents(params.allowedEvents);
   const stateDbPath = resolveOpenClawStateSqlitePath();
-  const deliverReplacedRegistrationUnregister = unregisterNativeHookRelay(relayId, undefined, {
-    deferBridgeRecordRemovalMs: NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS,
-    deferOnUnregister: true,
-  });
+  // Concurrent runs of the same agent/session share this stable relayId, and
+  // bound-thread resumes can even share one generation. Registering must not
+  // evict a sibling run's live registration: every registration keeps its own
+  // slot, and the newest one becomes "current" for callers that cannot
+  // present a generation.
+  const registrations =
+    relayRegistrationsById.get(relayId) ?? new Set<ActiveNativeHookRelayRegistration>();
+  if (registrations.size >= MAX_NATIVE_HOOK_RELAY_CONCURRENT_REGISTRATIONS) {
+    // pruneExpiredNativeHookRelays() at the top of this function already freed
+    // expired slots, so everything still counted here is live. Reject the new
+    // registration instead of evicting a live sibling mid-turn.
+    log.error("native hook relay concurrent registration limit reached", {
+      relayId,
+      runId: params.runId,
+      liveRegistrations: registrations.size,
+      cap: MAX_NATIVE_HOOK_RELAY_CONCURRENT_REGISTRATIONS,
+    });
+    throw new Error("native hook relay concurrent registration limit reached");
+  }
   let partialRegistration: ActiveNativeHookRelayRegistration | undefined;
   try {
     const retained =
@@ -214,6 +183,7 @@ function registerNativeHookRelayInternal(
       preToolUseLoopDetection: params.preToolUseLoopDetection !== false,
       expiresAtMs,
       preToolUseFailureProjections: new Map(),
+      claimedTurnIds: new Set<string>(),
       ...(params.signal ? { signal: params.signal } : {}),
       ...(params.runBeforeToolCall ? { runBeforeToolCall: params.runBeforeToolCall } : {}),
       ...(params.assertActive ? { assertActive: params.assertActive } : {}),
@@ -221,6 +191,8 @@ function registerNativeHookRelayInternal(
       // SAFETY: the literal supplies the complete mutable internal registration contract.
     } as ActiveNativeHookRelayRegistration;
     partialRegistration = registration;
+    relayRegistrationsById.set(relayId, registrations);
+    registrations.add(registration);
     relays.set(relayId, registration);
     setRelayLifetime(registration, {
       foregroundOpen: true,
@@ -259,9 +231,12 @@ function registerNativeHookRelayInternal(
           executable: params.command?.executable,
           nodeExecutable: params.command?.nodeExecutable,
         }),
+      claimTurn: (turnId) => claimNativeHookRelayTurn(relayId, registration, turnId),
       renew: (ttlMs) => {
-        const current = relays.get(relayId);
-        if (current !== registration) {
+        // Renewal must work for non-current siblings too: a long-running turn
+        // keeps its own registration alive even after a newer run registered
+        // on the same relayId.
+        if (!relayRegistrationsById.get(relayId)?.has(registration)) {
           return;
         }
         const renewedExpiresAtMs = resolveNativeHookRelayExpiresAtMs(ttlMs);
@@ -271,13 +246,21 @@ function registerNativeHookRelayInternal(
         const bridge = relayBridges.get(relayId);
         if (bridge && bridge.server.listening) {
           try {
-            const renewal = renewNativeHookRelayBridgeRecord(current, bridge, renewedExpiresAtMs);
+            // One bridge record covers every live registration for the
+            // relayId, so renewal must never shorten it below the
+            // longest-lived sibling.
+            const renewal = renewNativeHookRelayBridgeRecord(
+              registration,
+              bridge,
+              resolveNativeHookRelayBridgeRecordExpiresAtMs(relayId, renewedExpiresAtMs) ??
+                renewedExpiresAtMs,
+            );
             if (renewal === "unavailable") {
               return;
             }
             if (renewal === "ownership-changed") {
               log.debug("native hook relay bridge record ownership changed", { relayId });
-              unregisterNativeHookRelay(relayId, current);
+              unregisterNativeHookRelay(relayId, registration);
               return;
             }
           } catch (error) {
@@ -285,9 +268,9 @@ function registerNativeHookRelayInternal(
             return;
           }
         }
-        current.expiresAtMs = renewedExpiresAtMs;
+        registration.expiresAtMs = renewedExpiresAtMs;
         handle.expiresAtMs = renewedExpiresAtMs;
-        scheduleNativeHookRelayExpiry(relayId, current);
+        scheduleNativeHookRelayExpiry(relayId, registration);
       },
       unregister: () => deactivateNativeHookRelayForeground(relayId, registration),
     };
@@ -297,162 +280,7 @@ function registerNativeHookRelayInternal(
       unregisterNativeHookRelay(relayId, partialRegistration);
     }
     throw error;
-  } finally {
-    // The successor is authoritative before the old callback runs. A reentrant
-    // callback can therefore replace this registration normally instead of
-    // being overwritten by the outer replacement path. Finally also preserves
-    // the old callback if successor setup aborts partway through.
-    deliverReplacedRegistrationUnregister?.();
   }
-}
-
-function unregisterNativeHookRelay(
-  relayId: string,
-  expectedRegistration?: ActiveNativeHookRelayRegistration,
-  options?: { deferBridgeRecordRemovalMs?: number; deferOnUnregister?: boolean },
-): (() => void) | undefined {
-  if (expectedRegistration && relays.get(relayId) !== expectedRegistration) {
-    return undefined;
-  }
-  const registration = expectedRegistration ?? relays.get(relayId);
-  if (!registration) {
-    return undefined;
-  }
-  const lifetime = readRelayLifetime(registration);
-  const bridge = relayBridges.get(relayId);
-  // Detach first: owner cleanup may register a same-id successor, which must
-  // never be removed by this registration's later resource cleanup.
-  if (relays.get(relayId) === registration) {
-    relays.delete(relayId);
-  }
-  if (lifetime?.expiryTimer) {
-    clearTimeout(lifetime.expiryTimer);
-  }
-  lifetime?.removeAbortListener?.();
-  lifetime?.retained?.release();
-  // SAFETY: this deletes the same private expando installed by setRelayLifetime.
-  delete (registration as ActiveNativeHookRelayRegistration & { [RELAY_LIFETIME]?: RelayLifetime })[
-    RELAY_LIFETIME
-  ];
-  unregisterNativeHookRelayBridge(relayId, {
-    ...options,
-    ...(bridge ? { expectedBridge: bridge } : {}),
-  });
-  removeNativeHookRelayInvocations(relayId);
-  removeNativeHookRelayPreToolUseApprovals(relayId);
-  removeNativeHookRelayPermissionState(relayId);
-  const deliverOnUnregister = () => {
-    try {
-      lifetime?.retention?.onDispose();
-    } catch (error) {
-      try {
-        log.warn("native hook relay unregister callback failed", { error, relayId });
-      } catch {
-        // Teardown has already detached every identity-bound resource. Logging
-        // must not turn an observer callback failure into a cleanup failure.
-      }
-    }
-  };
-  if (options?.deferOnUnregister) {
-    return deliverOnUnregister;
-  }
-  deliverOnUnregister();
-  return undefined;
-}
-
-function deactivateNativeHookRelayForeground(
-  relayId: string,
-  registration: ActiveNativeHookRelayRegistration,
-): void {
-  if (relays.get(relayId) !== registration) {
-    return;
-  }
-  const lifetime = readRelayLifetime(registration);
-  if (!lifetime) {
-    return;
-  }
-  lifetime.foregroundOpen = false;
-  let shouldRetain = false;
-  if (lifetime.retained && lifetime.retention) {
-    try {
-      shouldRetain = lifetime.retention.shouldRetainAfterForegroundClose();
-    } catch (error) {
-      try {
-        log.warn("native hook relay retention predicate failed", { error, relayId });
-      } catch {
-        // A logging failure cannot make a throwing retention predicate retain authority.
-      }
-    }
-  }
-  if (shouldRetain) {
-    return;
-  }
-  unregisterNativeHookRelay(relayId, registration);
-}
-
-async function resolveNativeHookRelayInvocationBinding(
-  registration: ActiveNativeHookRelayRegistration,
-  event: NativeHookRelayEvent,
-  rawPayload: unknown,
-): Promise<NativeHookRelayRegistration> {
-  const lifetime = readRelayLifetime(registration);
-  if (!lifetime) {
-    throw new Error("native hook relay registration is inactive");
-  }
-  const claim = lifetime.retention?.readClaim(rawPayload);
-  if (claim && event === "pre_tool_use" && lifetime.retained && lifetime.retention) {
-    const retained = lifetime.retained;
-    const retention = lifetime.retention;
-    let assertAdmission: (() => boolean) | undefined;
-    const assertRetainedAuthority = () => {
-      if (
-        relays.get(registration.relayId) !== registration ||
-        Date.now() > registration.expiresAtMs
-      ) {
-        throw new Error("native hook relay registration is inactive");
-      }
-      registration.signal?.throwIfAborted();
-      retained.assertActive();
-      if (assertAdmission && !assertAdmission()) {
-        throw new Error("native hook relay retained invocation not allowed");
-      }
-      if (!retention.allowPreToolUse(claim)) {
-        throw new Error("native hook relay retained invocation not allowed");
-      }
-    };
-    if (lifetime.foregroundOpen && retention.awaitForegroundAdmission) {
-      assertAdmission = await retention.awaitForegroundAdmission(claim);
-      if (!assertAdmission) {
-        throw new Error("native hook relay retained invocation not allowed");
-      }
-      assertRetainedAuthority();
-    } else if (!retention.allowPreToolUse(claim)) {
-      throw new Error("native hook relay retained invocation not allowed");
-    }
-    return {
-      ...registration,
-      assertActive: assertRetainedAuthority,
-      runBeforeToolCall: retained.runBeforeToolCall,
-    };
-  }
-  if (!lifetime.foregroundOpen) {
-    throw new Error("native hook relay foreground invocation not allowed");
-  }
-  const foregroundToken = lifetime.foregroundToken;
-  const assertActive = () => {
-    if (
-      relays.get(registration.relayId) !== registration ||
-      Date.now() > registration.expiresAtMs
-    ) {
-      throw new Error("native hook relay registration is inactive");
-    }
-    registration.signal?.throwIfAborted();
-    registration.assertActive?.();
-    if (!lifetime.foregroundOpen || lifetime.foregroundToken !== foregroundToken) {
-      throw new Error("native hook relay foreground invocation not allowed");
-    }
-  };
-  return { ...registration, assertActive };
 }
 
 function normalizeRelayKey(
@@ -475,11 +303,41 @@ export async function invokeNativeHookRelay(
   const provider = readNativeHookRelayProvider(params.provider);
   const relayId = readNonEmptyString(params.relayId, "relayId");
   const event = readNativeHookRelayEvent(params.event);
-  const registration = relays.get(relayId);
-  if (!registration) {
+  if (!relayRegistrationsById.get(relayId)?.size && !relays.has(relayId)) {
     pruneExpiredNativeHookRelays();
     throw new Error("native hook relay not found");
   }
+  const requestedGeneration = params.requireGeneration
+    ? readNonEmptyString(params.generation, "generation")
+    : undefined;
+  if (!isJsonValue(params.rawPayload)) {
+    throw new Error("native hook relay payload must be JSON-compatible");
+  }
+  const adapter = getNativeHookRelayProviderAdapter(provider);
+  // Resolve the caller's own registration before any policy, approval, or
+  // recording work. Concurrent runs on the same relayId each keep a live
+  // registration; a sibling run registering later must not make this caller's
+  // hooks stale, a sibling unregistering must not remove them, and an
+  // unclaimed hook on a generation shared by two live runs fails closed
+  // instead of executing under the newest sibling's policy context.
+  const target = resolveNativeHookRelayInvocationTarget({
+    relayId,
+    requestedGeneration,
+    turnSelector: adapter.normalizeMetadata(params.rawPayload).turnId,
+    rawPayload: params.rawPayload,
+  });
+  if (target.outcome === "contested-generation") {
+    log.warn("native hook relay rejected unclaimed hook on contested generation", {
+      relayId,
+      event,
+    });
+    throw new Error(NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR);
+  }
+  if (target.outcome === "not-found") {
+    pruneExpiredNativeHookRelays();
+    throw new Error("native hook relay not found");
+  }
+  const registration = target.registration;
   if (Date.now() > registration.expiresAtMs) {
     unregisterNativeHookRelay(relayId, registration);
     throw new Error("native hook relay expired");
@@ -487,24 +345,18 @@ export async function invokeNativeHookRelay(
   if (registration.provider !== provider) {
     throw new Error("native hook relay provider mismatch");
   }
-  if (params.requireGeneration) {
-    const generation = readNonEmptyString(params.generation, "generation");
-    if (generation !== registration.generation) {
-      if (!canAcceptNativeHookRelayGenerationMismatch(registration, generation)) {
-        throw new Error(NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR);
-      }
-      log.debug("native hook relay accepted bootstrap generation mismatch", {
-        relayId,
-        event,
-        runId: registration.runId,
-      });
+  if (requestedGeneration !== undefined && requestedGeneration !== registration.generation) {
+    if (!canAcceptNativeHookRelayGenerationMismatch(registration, requestedGeneration)) {
+      throw new Error(NATIVE_HOOK_RELAY_BRIDGE_STALE_REGISTRATION_ERROR);
     }
+    log.debug("native hook relay accepted bootstrap generation mismatch", {
+      relayId,
+      event,
+      runId: registration.runId,
+    });
   }
   if (!registration.allowedEvents.includes(event)) {
     throw new Error("native hook relay event not allowed");
-  }
-  if (!isJsonValue(params.rawPayload)) {
-    throw new Error("native hook relay payload must be JSON-compatible");
   }
 
   const normalized = normalizeNativeHookInvocation({
@@ -525,7 +377,7 @@ export async function invokeNativeHookRelay(
   const response = await processNativeHookRelayInvocation({
     registration: effectiveRegistration,
     invocation: normalized,
-    adapter: getNativeHookRelayProviderAdapter(provider),
+    adapter,
   });
   // Policy and approval callbacks may yield while their admitted run closes.
   // Never let a late allow cross back into the native runtime.
@@ -618,14 +470,6 @@ function recordNativeHookRelayInvocation(invocation: NativeHookRelayInvocation):
   }
 }
 
-function removeNativeHookRelayInvocations(relayId: string): void {
-  for (let index = invocations.length - 1; index >= 0; index -= 1) {
-    if (invocations[index]?.relayId === relayId) {
-      invocations.splice(index, 1);
-    }
-  }
-}
-
 function canAcceptNativeHookRelayGenerationMismatch(
   registration: NativeHookRelayRegistration,
   generation: string,
@@ -641,14 +485,6 @@ function canAcceptNativeHookRelayGenerationMismatch(
   return true;
 }
 
-function pruneExpiredNativeHookRelays(now = Date.now()): void {
-  for (const [relayId, registration] of relays) {
-    if (now > registration.expiresAtMs) {
-      unregisterNativeHookRelay(relayId, registration);
-    }
-  }
-}
-
 function normalizeAllowedEvents(
   events: readonly NativeHookRelayEvent[] | undefined,
 ): readonly NativeHookRelayEvent[] {
@@ -660,9 +496,17 @@ function normalizeAllowedEvents(
 
 export const testing = {
   clearNativeHookRelaysForTests(): void {
+    // unregisterNativeHookRelay only removes the caller's own entry (and
+    // possibly its relayId key), which is safe during Map/Set iteration.
+    for (const registrations of relayRegistrationsById.values()) {
+      for (const registration of registrations) {
+        unregisterNativeHookRelay(registration.relayId, registration);
+      }
+    }
     for (const [relayId, registration] of relays) {
       unregisterNativeHookRelay(relayId, registration);
     }
+    relayRegistrationsById.clear();
     clearNativeHookRelayBridgesForTests();
     invocations.length = 0;
     clearNativeHookRelayPermissionsForTests();
@@ -672,6 +516,32 @@ export const testing = {
   },
   getNativeHookRelayRegistrationForTests(relayId: string): NativeHookRelayRegistration | undefined {
     return relays.get(relayId);
+  },
+  getNativeHookRelayRegistrationGenerationsForTests(relayId: string): string[] {
+    return [...(relayRegistrationsById.get(relayId) ?? [])].map(
+      (registration) => registration.generation,
+    );
+  },
+  getNativeHookRelayLiveRegistrationForTests(
+    relayId: string,
+    generation: string,
+  ): NativeHookRelayRegistration | undefined {
+    let match: NativeHookRelayRegistration | undefined;
+    for (const registration of relayRegistrationsById.get(relayId) ?? []) {
+      if (registration.generation === generation) {
+        match = registration;
+      }
+    }
+    return match;
+  },
+  getNativeHookRelayConcurrentRegistrationCapForTests(): number {
+    return MAX_NATIVE_HOOK_RELAY_CONCURRENT_REGISTRATIONS;
+  },
+  simulateLegacyModuleNativeHookRelayRegistrationForTests(relayId: string): void {
+    // Mimics a registration written by an older module copy that predates the
+    // registration slot map: present in the shared `relays` map, absent from
+    // relayRegistrationsById.
+    relayRegistrationsById.delete(relayId);
   },
   getNativeHookRelayBridgeDirForTests(): string {
     throw new Error("native hook relay bridge files were retired");

--- a/src/gateway/server-methods/native-hook-relay.test.ts
+++ b/src/gateway/server-methods/native-hook-relay.test.ts
@@ -49,6 +49,70 @@ describe("native hook relay gateway method", () => {
     expectInvalidRequest(respond, "not found");
   });
 
+  it("binds gateway invocations to the registration that claimed the payload turn", async () => {
+    // Same-generation overlap: the gateway path must honor the claimed turn id
+    // instead of routing to the newest sibling's policy context.
+    const first = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "relay-turn-claim",
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["post_tool_use"],
+    });
+    first.claimTurn("turn-1");
+    const second = registerNativeHookRelay({
+      provider: "codex",
+      relayId: first.relayId,
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-2",
+      allowedEvents: ["post_tool_use"],
+    });
+    second.claimTurn("turn-2");
+
+    const respond = await invokeNativeHook({
+      provider: "codex",
+      relayId: first.relayId,
+      generation: first.generation,
+      event: "post_tool_use",
+      rawPayload: { ...POST_TOOL_USE_PAYLOAD, turn_id: "turn-1" },
+    });
+
+    expect(respond).toHaveBeenCalledWith(true, { stdout: "", stderr: "", exitCode: 0 });
+    expect(testing.getNativeHookRelayInvocationsForTests()).toMatchObject([{ runId: "run-1" }]);
+  });
+
+  it("rejects unclaimed hooks while live registrations contest one generation", async () => {
+    const first = registerNativeHookRelay({
+      provider: "codex",
+      relayId: "relay-contested",
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-1",
+      allowedEvents: ["post_tool_use"],
+    });
+    registerNativeHookRelay({
+      provider: "codex",
+      relayId: first.relayId,
+      generation: "generation-thread-1",
+      sessionId: "session-1",
+      runId: "run-2",
+      allowedEvents: ["post_tool_use"],
+    });
+
+    const respond = await invokeNativeHook({
+      provider: "codex",
+      relayId: first.relayId,
+      generation: first.generation,
+      event: "post_tool_use",
+      rawPayload: { ...POST_TOOL_USE_PAYLOAD, turn_id: "turn-unclaimed" },
+    });
+
+    expectInvalidRequest(respond, "native hook relay bridge stale registration");
+    expect(testing.getNativeHookRelayInvocationsForTests()).toStrictEqual([]);
+  });
+
   it("rejects stale relay generations", async () => {
     const first = registerNativeHookRelay({
       provider: "codex",
@@ -64,6 +128,9 @@ describe("native hook relay gateway method", () => {
       runId: "run-2",
       allowedEvents: ["post_tool_use"],
     });
+    // Overlapping registrations keep both generations live; staleness begins
+    // when a generation's own registration unregisters.
+    first.unregister();
 
     const respond = await invokeNativeHook({
       provider: "codex",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Codex sessions with overlapping runs could lose native hook routing mid-turn and fail closed with `native hook relay bridge stale registration` or `not found` errors. A new turn, nested run, or bound-thread resume reused the session's stable relay identifier and replaced a still-live registration.

## Why This Change Was Made

Tracks live registrations per relay identifier and routes each invocation to the newest registration matching its generation. The loopback bridge and SQLite locator remain shared until the final registration exits; renewals cover non-current siblings; retained relays remain valid across sibling churn; and the bounded registration cap rejects a newcomer instead of evicting active work.

The implementation preserves exact-generation fail-closed behavior and upgrades shared state created by older module copies in place.

## User Impact

Overlapping Codex runs in the same session can continue using PreToolUse and related native hooks without one run invalidating another. Stale or unknown generations remain rejected.

## Evidence

- 158/158 focused relay tests passed on the current head (`src/agents/harness/native-hook-relay.test.ts`, `src/gateway/server-methods/native-hook-relay.test.ts`, `extensions/codex/src/app-server/native-hook-relay.test.ts`), including new regression coverage for: an invocation binding to the registration that claimed the payload turn; unclaimed hooks rejected while multiple live registrations contest one generation; a steered/duplicate `turn/start` claim refused instead of transferring hook ownership; an open-foreground unclaimed direct child parking in admission-wait and resolving on `claimDirectChild`; and closed-foreground unknown children still rejected.
- Reverting the fix (tests kept) makes the new tests fail for the intended reasons: the cross-bind cases route to the wrong sibling and the admission-wait case hard-blocks.
- Core and extension TypeScript checks passed; oxlint, formatting, max-lines, and assertion-safety checks passed. The earlier `CHANGELOG.md` edit is removed per review.
- Codex-side contract verified against the sibling `codex-rs` source: `turn/start` is start-or-steer (`app-server/src/request_processors/turn_processor.rs` — a steered start returns the live sibling's turn id in the same `TurnStartResponse` shape), and every hook payload carries a mandatory `turn_id` set from the active turn (`core/src/hook_runtime.rs`, `hooks/src/schema.rs`). The turn-claim registry therefore keys on a selector that is always present, and a steered `turn/start` can no longer silently transfer hook ownership: a turn id already claimed by a live sibling is refused, and a double-claimed turn id fails closed (block/deny) rather than routing to the newest registration.
- Live behavior proof (equivalent lifecycle semantics deployed against a v2026.7.1 gateway, journal excerpts redacted to markers): fresh native session `NATIVE_HOOK_SMOKE_OK`; two simultaneous overlapping native sessions in one Codex thread completed `OVERLAP_A_OK` / `OVERLAP_B_OK` with zero `native hook relay not found` / stale-registration errors over the observation window, where the pre-fix build reproducibly failed mid-turn.
- Fail-closed posture unchanged on every rejection path: stale, unknown, contested, or capped registrations produce a block/deny at the hook boundary with no gateway fallback (`src/cli/native-hook-relay-cli.ts`), and the cap rejects the newcomer instead of evicting live work.
