### PR TITLE
test(tooling): reuse Periphery workflow code fixtures

### DIFF
--- a/test/scripts/ios-periphery-comment-workflow.test.ts
+++ b/test/scripts/ios-periphery-comment-workflow.test.ts
@@ -2,7 +2,7 @@ import { Buffer } from "node:buffer";
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import { compileFunction } from "node:vm";
-import { deflateRawSync } from "node:zlib";
+import { crc32, deflateRawSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { markdownToIR } from "../../packages/markdown-core/src/ir.js";
@@ -76,7 +76,7 @@ type WorkflowRun = {
   workflow_id: number;
 };
 
-function commenterScript(): string {
+function readCommenterScript(): string {
   const workflow = parse(readFileSync(WORKFLOW_PATH, "utf8")) as Workflow;
   const step = workflow.jobs?.comment?.steps?.find(
     (candidate) => candidate.name === "Upsert Periphery PR comment",
@@ -87,6 +87,14 @@ function commenterScript(): string {
   }
   return script;
 }
+
+const commenterScript = readCommenterScript();
+const executeCommenter = compileFunction(`return (async () => {\n${commenterScript}\n})();`, [
+  "require",
+  "context",
+  "core",
+  "github",
+]) as (require: NodeJS.Require, context: unknown, core: unknown, github: unknown) => Promise<void>;
 
 async function runCommenter(
   artifact: Artifact,
@@ -103,7 +111,6 @@ async function runCommenter(
     workflowRuns?: WorkflowRun[];
   } = {},
 ) {
-  const script = commenterScript();
   const core = {
     infos: [] as string[],
     warnings: [] as string[],
@@ -225,19 +232,8 @@ async function runCommenter(
       repo: "openclaw",
     },
   };
-  const execute = compileFunction(`return (async () => {\n${script}\n})();`, [
-    "require",
-    "context",
-    "core",
-    "github",
-  ]) as (
-    require: NodeJS.Require,
-    context: unknown,
-    core: unknown,
-    github: unknown,
-  ) => Promise<void>;
 
-  await execute(createRequire(import.meta.url), context, core, github);
+  await executeCommenter(createRequire(import.meta.url), context, core, github);
 
   return {
     artifactListCount,
@@ -253,17 +249,6 @@ async function runCommenter(
 function expectUnavailableComment(bodies: string[]): void {
   expect(bodies).toHaveLength(1);
   expect(bodies[0]).toContain("Periphery did not complete or its report could not be safely read.");
-}
-
-function crc32(input: Buffer): number {
-  let crc = 0xffffffff;
-  for (const byte of input) {
-    crc ^= byte;
-    for (let bit = 0; bit < 8; bit += 1) {
-      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
-    }
-  }
-  return (crc ^ 0xffffffff) >>> 0;
 }
 
 function u16(value: number): Buffer {
@@ -375,7 +360,7 @@ function setFirstEntryUncompressedSize(archive: Buffer, size: number): Buffer {
 
 describe("iOS Periphery comment workflow", () => {
   it("parses the workflow YAML and embedded github-script JavaScript", () => {
-    const script = commenterScript();
+    const script = commenterScript;
     expect(script).not.toContain("node:child_process");
     expect(script).not.toContain("execFileSync");
     expect(() =>

--- a/test/scripts/periphery-scope-workflows.test.ts
+++ b/test/scripts/periphery-scope-workflows.test.ts
@@ -64,15 +64,27 @@ function readWorkflow(workflowPath: string): ScopeWorkflow {
   return parse(readFileSync(workflowPath, "utf8")) as ScopeWorkflow;
 }
 
-function scopeScript(workflowPath: string): string {
-  const step = readWorkflow(workflowPath).jobs?.scope?.steps?.find(
-    (candidate) => candidate.id === "scope",
-  );
-  if (!step?.with?.script) {
+function compileScopeWorkflow(workflowPath: string) {
+  const workflow = readWorkflow(workflowPath);
+  const step = workflow.jobs?.scope?.steps?.find((candidate) => candidate.id === "scope");
+  const script = step?.with?.script;
+  if (!script) {
     throw new Error(`missing Periphery scope script in ${workflowPath}`);
   }
-  return step.with.script;
+  const execute = compileFunction(`return (async () => {\n${script}\n})();`, [
+    "context",
+    "core",
+    "exec",
+  ]) as (context: unknown, core: unknown, exec: unknown) => Promise<void>;
+  return { workflow, script, execute };
 }
+
+const scopeWorkflows = new Map<string, ReturnType<typeof compileScopeWorkflow>>(
+  WORKFLOW_CASES.map(({ path: workflowPath }) => [
+    workflowPath,
+    compileScopeWorkflow(workflowPath),
+  ]),
+);
 
 async function runScope(workflowPath: string, options: ScopeOptions): Promise<string | undefined> {
   const outputs = new Map<string, string>();
@@ -102,11 +114,7 @@ async function runScope(workflowPath: string, options: ScopeOptions): Promise<st
       return { exitCode: changed ? 1 : 0 };
     },
   };
-  const execute = compileFunction(`return (async () => {\n${scopeScript(workflowPath)}\n})();`, [
-    "context",
-    "core",
-    "exec",
-  ]) as (context: unknown, core: unknown, exec: unknown) => Promise<void>;
+  const { execute } = scopeWorkflows.get(workflowPath)!;
 
   await execute(
     context,
@@ -134,10 +142,9 @@ describe("Periphery scope workflows", () => {
   it.each(WORKFLOW_CASES)(
     "uses the synthetic merge parent for $name scope",
     ({ path: workflowPath }) => {
-      const workflow = readWorkflow(workflowPath);
+      const { workflow, script } = scopeWorkflows.get(workflowPath)!;
       const steps = workflow.jobs?.scope?.steps ?? [];
       const checkout = steps.find((step) => step.name === "Checkout");
-      const script = scopeScript(workflowPath);
 
       expect(workflow.on?.pull_request?.types).toContain("converted_to_draft");
       expect(workflow.on?.pull_request?.paths).toBeUndefined();
@@ -210,10 +217,7 @@ describe("Periphery scope workflows", () => {
     expect(oldDiff.status).toBe(1);
 
     const outputs = new Map<string, string>();
-    const execute = compileFunction(
-      `return (async () => {\n${scopeScript(".github/workflows/shared-openclawkit-periphery.yml")}\n})();`,
-      ["context", "core", "exec"],
-    ) as (context: unknown, core: unknown, exec: unknown) => Promise<void>;
+    const { execute } = scopeWorkflows.get(".github/workflows/shared-openclawkit-periphery.yml")!;
     await execute(
       { eventName: "pull_request", payload: { pull_request: { draft: false, number: 123 } } },
       { setOutput: (name: string, value: string) => outputs.set(name, value) },


### PR DESCRIPTION
## What problem does this PR solve?

Periphery workflow tests repeatedly parse and compile unchanged scripts. Their hostile ZIP fixture also computes its checksum with a JavaScript bit loop over more than two million bytes.

## Why this approach?

Prepare the four immutable workflow executors once, while keeping every invocation's API mocks, output maps and counters fresh. Use Node's CRC implementation for the existing ZIP builder. This removes 43 YAML parses and 36 compilations, plus 16,777,248 JavaScript checksum bit iterations for the unchanged hostile payload. These are structural counts, not elapsed-time estimates.

## User impact

Test-only cleanup; production +0/-0, tests +34/-45. All 28 cases remain, including four explicit syntax checks, real Git merge-base drift, stale-head and comment-ownership checks, and the real inflate-size rejection.

## Evidence

All 28 cases pass before and after; full changed-file checks and structured Codex autoreview pass. A Node 24.19.0 diagnostic compares complete ZIP bytes and checksums for empty, ordinary stored/deflated and exact hostile inputs. All match. The hostile payload remains 2,097,156 bytes, both forged size fields remain 1, and both archives have SHA-256 `ccb75e9babf236a50505297062b7fa77f4fbcd52fd84858935e08913ef62a475`.

`node scripts/run-vitest.mjs test/scripts/ios-periphery-comment-workflow.test.ts test/scripts/periphery-scope-workflows.test.ts`
