### PR TITLE
test(process): observe capacity group admission directly

### DIFF
--- a/src/process/command-queue.capacity-groups.test.ts
+++ b/src/process/command-queue.capacity-groups.test.ts
@@ -1,13 +1,8 @@
-/**
- * Capacity groups: a shared hard budget across lanes, with non-borrowable
- * per-member reservations.
- *
- * The invariant under test is the one the upstream maintainer asked for on
- * openclaw#98813: giving hook dispatch its own lane must NOT add a concurrent
- * slot outside the existing cron budget. A group whose budget equals that cap
- * is what makes the separate lane safe.
- */
+// Capacity groups keep cron and hook lanes within one shared hard budget.
+// Per-member reservations cannot be borrowed; giving hooks a lane must not
+// add concurrency beyond the existing cron cap.
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 import {
   enqueueCommandInLane,
   getCommandLaneSnapshot,
@@ -32,23 +27,6 @@ function clearCommandLaneGroup(group: string): void {
   publishLaneConfiguration({ clearGroups: [group] });
 }
 
-/** A task that blocks until released, so occupancy is controllable. */
-function gate() {
-  let release!: () => void;
-  const promise = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  return { promise, release };
-}
-
-async function settle(): Promise<void> {
-  for (let i = 0; i < 5; i++) {
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
-    });
-  }
-}
-
 beforeEach(() => {
   resetAllLanes();
   clearCommandLaneGroup(GROUP);
@@ -71,41 +49,38 @@ describe("command lane capacity groups", () => {
     });
 
     // Fill the group to its budget minus the hook's reservation.
-    const gates = Array.from({ length: 7 }, () => gate());
+    const gates = Array.from({ length: 7 }, () => createDeferred());
     const cronRuns = gates.map((g) =>
       enqueueCommandInLane(CRON, async () => await g.promise, { priority: "foreground" }),
     );
-    await settle();
     expect(getCommandLaneSnapshot(CRON).activeCount).toBe(7);
 
     // The 8th slot is the hook's hard reservation: cron must not take it.
     const waiting: string[] = [];
-    const extra = gate();
+    const extra = createDeferred();
     const blockedCron = enqueueCommandInLane(CRON, async () => await extra.promise, {
       priority: "foreground",
       onQueued: () => waiting.push(CRON),
     });
-    await settle();
     expect(getCommandLaneSnapshot(CRON).activeCount).toBe(7);
     expect(getCommandLaneSnapshot(CRON).blockedBy).toBe("sibling-reservation");
 
     // And the hook starts immediately despite the group being otherwise full.
-    const hookGate = gate();
+    const hookGate = createDeferred();
     const hookRun = enqueueCommandInLane(HOOK, async () => await hookGate.promise, {
       priority: "background",
       onQueued: () => waiting.push(HOOK),
     });
-    await settle();
     expect(getCommandLaneSnapshot(HOOK).activeCount).toBe(1);
     expect(getCommandLaneSnapshot(HOOK).groupActive).toBe(8);
     expect(waiting).toEqual([CRON]);
 
-    hookGate.release();
+    hookGate.resolve();
     await hookRun;
     for (const g of gates) {
-      g.release();
+      g.resolve();
     }
-    extra.release();
+    extra.resolve();
     await Promise.all([...cronRuns, blockedCron]);
   });
 
@@ -116,11 +91,10 @@ describe("command lane capacity groups", () => {
       reservations: { [HOOK]: 1 },
     });
 
-    const gates = Array.from({ length: 20 }, () => gate());
+    const gates = Array.from({ length: 20 }, () => createDeferred());
     const runs = gates.map((g, i) =>
       enqueueCommandInLane(i % 2 === 0 ? CRON : HOOK, async () => await g.promise),
     );
-    await settle();
 
     const cron = getCommandLaneSnapshot(CRON);
     const hook = getCommandLaneSnapshot(HOOK);
@@ -129,7 +103,7 @@ describe("command lane capacity groups", () => {
     expect(cron.activeCount + hook.activeCount).toBe(8);
 
     for (const g of gates) {
-      g.release();
+      g.resolve();
     }
     await Promise.all(runs);
   });
@@ -141,9 +115,8 @@ describe("command lane capacity groups", () => {
       reservations: { [HOOK]: 1 },
     });
 
-    const gates = Array.from({ length: 9 }, () => gate());
+    const gates = Array.from({ length: 9 }, () => createDeferred());
     const runs = gates.map((g) => enqueueCommandInLane(HOOK, async () => await g.promise));
-    await settle();
 
     expect(getCommandLaneSnapshot(HOOK)).toMatchObject({
       activeCount: 8,
@@ -156,7 +129,7 @@ describe("command lane capacity groups", () => {
     });
 
     for (const g of gates) {
-      g.release();
+      g.resolve();
     }
     await Promise.all(runs);
   });
@@ -164,29 +137,26 @@ describe("command lane capacity groups", () => {
   test("capacity freed by one member wakes a queued sibling", async () => {
     setCommandLaneGroup(GROUP, { budget: 2, members: [CRON, HOOK] });
 
-    const a = gate();
-    const b = gate();
+    const a = createDeferred();
+    const b = createDeferred();
     const first = enqueueCommandInLane(CRON, async () => await a.promise);
     const second = enqueueCommandInLane(CRON, async () => await b.promise);
-    await settle();
     expect(getCommandLaneSnapshot(CRON).activeCount).toBe(2);
 
     // Budget is full, so the hook cannot start.
-    const hookGate = gate();
+    const hookGate = createDeferred();
     const hookRun = enqueueCommandInLane(HOOK, async () => await hookGate.promise);
-    await settle();
     expect(getCommandLaneSnapshot(HOOK).activeCount).toBe(0);
     expect(getCommandLaneSnapshot(HOOK).blockedBy).toBe("group-budget");
 
     // Releasing a cron task must wake the hook, which lives on a DIFFERENT
     // lane — a lane-local pump would leave it queued behind free capacity.
-    a.release();
+    a.resolve();
     await first;
-    await settle();
     expect(getCommandLaneSnapshot(HOOK).activeCount).toBe(1);
 
-    hookGate.release();
-    b.release();
+    hookGate.resolve();
+    b.resolve();
     await Promise.all([second, hookRun]);
   });
 
@@ -199,8 +169,8 @@ describe("command lane capacity groups", () => {
         reservations: { [HOOK]: 1 },
       });
 
-      const firstHookGate = gate();
-      const secondHookGate = gate();
+      const firstHookGate = createDeferred();
+      const secondHookGate = createDeferred();
       const firstHook = enqueueCommandInLane(
         HOOK,
         async () => {
@@ -214,35 +184,32 @@ describe("command lane capacity groups", () => {
       const secondHook = enqueueCommandInLane(HOOK, async () => await secondHookGate.promise, {
         priority: "background",
       });
-      await settle();
       expect(getCommandLaneSnapshot(HOOK).activeCount).toBe(2);
 
       // Cron queues first. A later hook queues behind the same full group. The
       // completing hook lane must not synchronously reclaim the shared slot.
-      const cronGate = gate();
+      const cronGate = createDeferred();
       const cronRun = enqueueCommandInLane(CRON, async () => await cronGate.promise, {
         priority: "background",
       });
-      const thirdHookGate = gate();
+      const thirdHookGate = createDeferred();
       const thirdHook = enqueueCommandInLane(HOOK, async () => await thirdHookGate.promise, {
         priority: "background",
       });
-      await settle();
 
-      firstHookGate.release();
+      firstHookGate.resolve();
       if (outcome === "failing") {
         await expect(firstHook).rejects.toThrow("expected hook failure");
       } else {
         await firstHook;
       }
-      await settle();
 
       expect(getCommandLaneSnapshot(CRON)).toMatchObject({ activeCount: 1, queuedCount: 0 });
       expect(getCommandLaneSnapshot(HOOK)).toMatchObject({ activeCount: 1, queuedCount: 1 });
 
-      cronGate.release();
-      secondHookGate.release();
-      thirdHookGate.release();
+      cronGate.resolve();
+      secondHookGate.resolve();
+      thirdHookGate.resolve();
       await Promise.all([cronRun, secondHook, thirdHook]);
     },
   );
@@ -250,86 +217,79 @@ describe("command lane capacity groups", () => {
   test("priority outranks group-global enqueue sequence", async () => {
     setCommandLaneGroup(GROUP, { budget: 1, members: [CRON, HOOK] });
 
-    const blockerGate = gate();
+    const blockerGate = createDeferred();
     const blocker = enqueueCommandInLane(HOOK, async () => await blockerGate.promise);
-    await settle();
 
-    const cronGate = gate();
+    const cronGate = createDeferred();
     const olderBackground = enqueueCommandInLane(CRON, async () => await cronGate.promise, {
       priority: "background",
     });
-    const hookGate = gate();
+    const hookGate = createDeferred();
     const newerForeground = enqueueCommandInLane(HOOK, async () => await hookGate.promise, {
       priority: "foreground",
     });
 
-    blockerGate.release();
+    blockerGate.resolve();
     await blocker;
-    await settle();
 
     expect(getCommandLaneSnapshot(HOOK)).toMatchObject({ activeCount: 1, queuedCount: 0 });
     expect(getCommandLaneSnapshot(CRON)).toMatchObject({ activeCount: 0, queuedCount: 1 });
 
-    hookGate.release();
+    hookGate.resolve();
     await newerForeground;
-    cronGate.release();
+    cronGate.resolve();
     await olderBackground;
   });
 
   test("three-member arbitration is independent of member iteration order", async () => {
     setCommandLaneGroup(GROUP, { budget: 1, members: [CRON, HOOK, DELIVERY] });
 
-    const blockerGate = gate();
+    const blockerGate = createDeferred();
     const blocker = enqueueCommandInLane(CRON, async () => await blockerGate.promise, {
       priority: "background",
     });
-    await settle();
 
     // DELIVERY is last in the member Set but queues before HOOK. A simple
     // sibling-first loop would start HOOK merely because it is visited first.
-    const deliveryGate = gate();
+    const deliveryGate = createDeferred();
     const olderDelivery = enqueueCommandInLane(DELIVERY, async () => await deliveryGate.promise, {
       priority: "background",
     });
-    const hookGate = gate();
+    const hookGate = createDeferred();
     const newerHook = enqueueCommandInLane(HOOK, async () => await hookGate.promise, {
       priority: "background",
     });
 
-    blockerGate.release();
+    blockerGate.resolve();
     await blocker;
-    await settle();
 
     expect(getCommandLaneSnapshot(DELIVERY)).toMatchObject({ activeCount: 1, queuedCount: 0 });
     expect(getCommandLaneSnapshot(HOOK)).toMatchObject({ activeCount: 0, queuedCount: 1 });
 
-    deliveryGate.release();
+    deliveryGate.resolve();
     await olderDelivery;
-    hookGate.release();
+    hookGate.resolve();
     await newerHook;
   });
 
   test("multi-slot reset re-arbitrates before stale completions arrive", async () => {
     setCommandLaneGroup(GROUP, { budget: 2, members: [CRON, HOOK] });
 
-    const staleGates = [gate(), gate()];
+    const staleGates = [createDeferred(), createDeferred()];
     const staleHooks = staleGates.map((g) =>
       enqueueCommandInLane(HOOK, async () => await g.promise, { priority: "background" }),
     );
-    await settle();
 
-    const cronGate = gate();
+    const cronGate = createDeferred();
     const cronRun = enqueueCommandInLane(CRON, async () => await cronGate.promise, {
       priority: "background",
     });
-    const queuedHookGates = [gate(), gate()];
+    const queuedHookGates = [createDeferred(), createDeferred()];
     const queuedHooks = queuedHookGates.map((g) =>
       enqueueCommandInLane(HOOK, async () => await g.promise, { priority: "background" }),
     );
-    await settle();
 
     expect(resetCommandLane(HOOK)).toBe(2);
-    await settle();
     expect(getCommandLaneSnapshot(CRON)).toMatchObject({ activeCount: 1, queuedCount: 0 });
     expect(getCommandLaneSnapshot(HOOK)).toMatchObject({ activeCount: 1, queuedCount: 1 });
     expect(getCommandLaneSnapshot(HOOK).groupActive).toBe(2);
@@ -337,53 +297,48 @@ describe("command lane capacity groups", () => {
     // The reset invalidated these task IDs. Their late completions must neither
     // remove new-generation IDs nor admit the remaining queued hook.
     for (const g of staleGates) {
-      g.release();
+      g.resolve();
     }
     await Promise.all(staleHooks);
-    await settle();
     expect(getCommandLaneSnapshot(CRON).activeCount).toBe(1);
     expect(getCommandLaneSnapshot(HOOK)).toMatchObject({ activeCount: 1, queuedCount: 1 });
 
-    cronGate.release();
-    queuedHookGates[0]?.release();
+    cronGate.resolve();
+    queuedHookGates[0]?.resolve();
     await Promise.all([cronRun, queuedHooks[0]]);
-    queuedHookGates[1]?.release();
+    queuedHookGates[1]?.resolve();
     await queuedHooks[1];
   });
 
   test("resetAllLanes refills a group by queue order rather than lane order", async () => {
     setCommandLaneGroup(GROUP, { budget: 1, members: [HOOK, CRON] });
 
-    const staleGate = gate();
+    const staleGate = createDeferred();
     const staleHook = enqueueCommandInLane(HOOK, async () => await staleGate.promise, {
       priority: "background",
     });
-    await settle();
 
-    const cronGate = gate();
+    const cronGate = createDeferred();
     const olderCron = enqueueCommandInLane(CRON, async () => await cronGate.promise, {
       priority: "background",
     });
-    const hookGate = gate();
+    const hookGate = createDeferred();
     const newerHook = enqueueCommandInLane(HOOK, async () => await hookGate.promise, {
       priority: "background",
     });
-    await settle();
 
     resetAllLanes();
-    await settle();
     expect(getCommandLaneSnapshot(CRON)).toMatchObject({ activeCount: 1, queuedCount: 0 });
     expect(getCommandLaneSnapshot(HOOK)).toMatchObject({ activeCount: 0, queuedCount: 1 });
 
-    staleGate.release();
+    staleGate.resolve();
     await staleHook;
-    await settle();
     expect(getCommandLaneSnapshot(CRON).activeCount).toBe(1);
     expect(getCommandLaneSnapshot(HOOK).queuedCount).toBe(1);
 
-    cronGate.release();
+    cronGate.resolve();
     await olderCron;
-    hookGate.release();
+    hookGate.resolve();
     await newerHook;
   });
 
@@ -391,8 +346,9 @@ describe("command lane capacity groups", () => {
     setCommandLaneConcurrency(CRON, 0);
     setCommandLaneConcurrency(HOOK, 1);
 
-    const cronGate = gate();
-    const hookGate = gate();
+    const cronGate = createDeferred();
+    const cronStarted = createDeferred();
+    const hookGate = createDeferred();
     let hookRun: Promise<void> | undefined;
     let active = 0;
     let peak = 0;
@@ -401,6 +357,7 @@ describe("command lane capacity groups", () => {
       async () => {
         active += 1;
         peak = Math.max(peak, active);
+        cronStarted.resolve();
         await cronGate.promise;
         active -= 1;
       },
@@ -421,24 +378,26 @@ describe("command lane capacity groups", () => {
         },
       },
     );
-    await settle();
 
     publishLaneConfiguration({
       lanes: { [CRON]: 1 },
       groups: { [GROUP]: { budget: 1, members: [CRON, HOOK] } },
     });
-    await settle();
+    await withTestTimeout(
+      cronStarted.promise,
+      1_000,
+      "cron task did not start after capacity-group publication",
+    );
 
     expect(hookRun).toBeDefined();
     expect(peak).toBe(1);
     expect(getCommandLaneSnapshot(CRON).activeCount).toBe(1);
     expect(getCommandLaneSnapshot(HOOK)).toMatchObject({ activeCount: 0, queuedCount: 1 });
 
-    cronGate.release();
+    cronGate.resolve();
     await cronRun;
-    await settle();
     expect(getCommandLaneSnapshot(HOOK).activeCount).toBe(1);
-    hookGate.release();
+    hookGate.resolve();
     await hookRun;
     expect(peak).toBe(1);
   });
@@ -446,24 +405,21 @@ describe("command lane capacity groups", () => {
   test("a failing task releases group capacity like a successful one", async () => {
     setCommandLaneGroup(GROUP, { budget: 1, members: [CRON, HOOK] });
 
-    const boom = gate();
+    const boom = createDeferred();
     const failing = enqueueCommandInLane(CRON, async () => {
       await boom.promise;
       throw new Error("task blew up");
     });
-    await settle();
 
-    const hookGate = gate();
+    const hookGate = createDeferred();
     const hookRun = enqueueCommandInLane(HOOK, async () => await hookGate.promise);
-    await settle();
     expect(getCommandLaneSnapshot(HOOK).activeCount).toBe(0);
 
-    boom.release();
+    boom.resolve();
     await expect(failing).rejects.toThrow("task blew up");
-    await settle();
     expect(getCommandLaneSnapshot(HOOK).activeCount).toBe(1);
 
-    hookGate.release();
+    hookGate.resolve();
     await hookRun;
   });
 
@@ -473,35 +429,31 @@ describe("command lane capacity groups", () => {
     const timedOut = enqueueCommandInLane(CRON, async () => new Promise<never>(() => {}), {
       taskTimeoutMs: 10,
     });
-    const hookGate = gate();
+    const hookGate = createDeferred();
     const hookRun = enqueueCommandInLane(HOOK, async () => await hookGate.promise);
 
     await expect(timedOut).rejects.toMatchObject({ name: "CommandLaneTaskTimeoutError" });
-    await settle();
     expect(getCommandLaneSnapshot(HOOK).activeCount).toBe(1);
 
-    hookGate.release();
+    hookGate.resolve();
     await hookRun;
   });
 
   test("resetting a member releases group capacity to a queued sibling", async () => {
     setCommandLaneGroup(GROUP, { budget: 1, members: [CRON, HOOK] });
 
-    const cronGate = gate();
+    const cronGate = createDeferred();
     const cronRun = enqueueCommandInLane(CRON, async () => await cronGate.promise);
-    await settle();
 
-    const hookGate = gate();
+    const hookGate = createDeferred();
     const hookRun = enqueueCommandInLane(HOOK, async () => await hookGate.promise);
-    await settle();
     expect(getCommandLaneSnapshot(HOOK).activeCount).toBe(0);
 
     expect(resetCommandLane(CRON)).toBe(1);
-    await settle();
     expect(getCommandLaneSnapshot(HOOK).activeCount).toBe(1);
 
-    cronGate.release();
-    hookGate.release();
+    cronGate.resolve();
+    hookGate.resolve();
     await Promise.all([cronRun, hookRun]);
   });
 
@@ -512,23 +464,20 @@ describe("command lane capacity groups", () => {
       reservations: { [HOOK]: 1 },
     });
 
-    const gates = Array.from({ length: 6 }, () => gate());
+    const gates = Array.from({ length: 6 }, () => createDeferred());
     const runs = gates.map((g) => enqueueCommandInLane(CRON, async () => await g.promise));
-    await settle();
 
     // 3, not 4: the hook is idle but its reserved slot is genuinely held back.
     // A borrowable reservation would show 4 here and starve the hook.
     expect(getCommandLaneSnapshot(CRON).activeCount).toBe(3);
 
     for (const g of gates) {
-      g.release();
+      g.resolve();
     }
     await Promise.all(runs);
   });
 
   test("blockedBy reports hypothetical immediate admission with an EMPTY queue", async () => {
-    // The non-vacuity condition for the whole wait-visibility fix.
-    //
     // `noteLaneWaitIfBusy` runs BEFORE enqueue, so it sees queuedCount === 0. If
     // blockedBy were only populated for an already-queued head entry, the
     // pre-enqueue snapshot would read "not blocked", no onLaneWait(waiting:true)
@@ -542,9 +491,8 @@ describe("command lane capacity groups", () => {
       reservations: { [HOOK]: 1 },
     });
 
-    const gates = Array.from({ length: 7 }, () => gate());
+    const gates = Array.from({ length: 7 }, () => createDeferred());
     const runs = gates.map((g) => enqueueCommandInLane(CRON, async () => await g.promise));
-    await settle();
 
     const snapshot = getCommandLaneSnapshot(CRON);
     // Nothing queued, and the lane is under its own maxConcurrent of 8...
@@ -558,7 +506,7 @@ describe("command lane capacity groups", () => {
     expect(getCommandLaneSnapshot(HOOK).blockedBy).toBeNull();
 
     for (const g of gates) {
-      g.release();
+      g.resolve();
     }
     await Promise.all(runs);
   });
@@ -569,16 +517,15 @@ describe("command lane capacity groups", () => {
     // the not-found path must consult the group rather than return a bare
     // default that reads as "free".
     setCommandLaneGroup(GROUP, { budget: 1, members: [CRON, HOOK] });
-    const busy = gate();
+    const busy = createDeferred();
     const run = enqueueCommandInLane(CRON, async () => await busy.promise);
-    await settle();
 
     const snapshot = getCommandLaneSnapshot(HOOK);
     expect(snapshot.activeCount).toBe(0);
     expect(snapshot.blockedBy).toBe("group-budget");
     expect(snapshot.groupBudget).toBe(1);
 
-    busy.release();
+    busy.resolve();
     await run;
   });
 
@@ -586,15 +533,14 @@ describe("command lane capacity groups", () => {
     setCommandLaneGroup(GROUP, { budget: 1, members: [CRON, HOOK] });
     setCommandLaneConcurrency("unpooled", 4);
 
-    const gates = Array.from({ length: 4 }, () => gate());
+    const gates = Array.from({ length: 4 }, () => createDeferred());
     const runs = gates.map((g) => enqueueCommandInLane("unpooled", async () => await g.promise));
-    await settle();
     expect(getCommandLaneSnapshot("unpooled").activeCount).toBe(4);
     expect(getCommandLaneSnapshot("unpooled").blockedBy).toBe("lane");
     expect(getCommandLaneSnapshot("unpooled").group).toBeUndefined();
 
     for (const g of gates) {
-      g.release();
+      g.resolve();
     }
     await Promise.all(runs);
   });


### PR DESCRIPTION
## What problem does this PR solve?

Capacity-group tests repeatedly wait five timer turns even though admission snapshots are published synchronously, and completed queue promises already include arbitration.

## Why this approach?

Assert those owner boundaries directly. The reentrant publication case observes actual cron task entry through a bounded deferred signal. Reuse the canonical deferred helper for controllable tasks and delete the copied gate/settle helpers. This removes 200 zero-delay timer callbacks across the unchanged cases.

## User impact

Test-only cleanup; production +0/-0, tests +82/-136. All 21 capacity cases and 61 assertion sites remain, including reservations, priority, stale completions, real 10 ms task timeout and reentrant concurrency limits.

## Evidence

All 29 capacity/publication tests pass before and after. Full changed-file checks and Codex autoreview pass. The local lint gate caught one redundant default type argument; it was removed and the full gate rerun successfully. No runtime or timeout changes, and no elapsed-time claim.

`node scripts/run-vitest.mjs src/process/command-queue.capacity-groups.test.ts src/process/command-queue.publish-transaction.test.ts`
