### PR TITLE
refactor: simplify media-core test assertions

### DIFF
--- a/packages/media-core/src/base64.test.ts
+++ b/packages/media-core/src/base64.test.ts
@@ -1,12 +1,7 @@
-// Media Core tests cover base64 behavior.
 import { describe, expect, it } from "vitest";
 import { canonicalizeBase64, estimateBase64DecodedBytes } from "./base64.js";
 
 describe("base64 helpers", () => {
-  function expectBase64HelperCase<T>(actual: T, expected: T) {
-    expect(actual).toBe(expected);
-  }
-
   it("canonicalizeBase64 validates large payloads without cons-string overflow", () => {
     const encoded = Buffer.alloc(1_900_000).toString("base64");
 
@@ -123,6 +118,6 @@ describe("base64 helpers", () => {
       expected: 0,
     },
   ] as const)("$name", ({ actual, expected }) => {
-    expectBase64HelperCase(actual, expected);
+    expect(actual).toBe(expected);
   });
 });

--- a/packages/media-core/src/inbound-path-policy.test.ts
+++ b/packages/media-core/src/inbound-path-policy.test.ts
@@ -1,4 +1,3 @@
-// Media Core tests cover inbound path policy behavior.
 import { describe, expect, it } from "vitest";
 import {
   isInboundPathAllowed,
@@ -8,31 +7,13 @@ import {
 } from "./inbound-path-policy.js";
 
 describe("inbound-path-policy", () => {
-  function expectInboundRootPatternCase(pattern: string, expected: boolean) {
-    expect(isValidInboundPathRootPattern(pattern)).toBe(expected);
-  }
-
-  function expectInboundPathAllowedCase(filePath: string, expected: boolean) {
-    expect(
-      isInboundPathAllowed({ filePath, roots: ["/Users/*/Library/Messages/Attachments"] }),
-    ).toBe(expected);
-  }
-
-  function expectMergedInboundPathRootsCase(params: {
-    defaults: string[];
-    additions: string[];
-    expected: readonly string[];
-  }) {
-    expect(mergeInboundPathRoots(params.defaults, params.additions)).toEqual(params.expected);
-  }
-
   it.each([
     { pattern: "/Users/*/Library/Messages/Attachments", expected: true },
     { pattern: "/Volumes/relay/attachments", expected: true },
     { pattern: "./attachments", expected: false },
     { pattern: "/Users/**/Attachments", expected: false },
   ] as const)("validates absolute root pattern %s", ({ pattern, expected }) => {
-    expectInboundRootPatternCase(pattern, expected);
+    expect(isValidInboundPathRootPattern(pattern)).toBe(expected);
   });
 
   it.each([
@@ -45,7 +26,9 @@ describe("inbound-path-policy", () => {
       expected: false,
     },
   ] as const)("matches wildcard roots for %s => $expected", ({ filePath, expected }) => {
-    expectInboundPathAllowedCase(filePath, expected);
+    expect(
+      isInboundPathAllowed({ filePath, roots: ["/Users/*/Library/Messages/Attachments"] }),
+    ).toBe(expected);
   });
 
   it("matches Windows drive roots case-insensitively", () => {
@@ -96,20 +79,12 @@ describe("inbound-path-policy", () => {
     });
   });
 
-  it.each([
-    {
-      name: "normalizes and de-duplicates merged roots",
-      run: () =>
-        expectMergedInboundPathRootsCase({
-          defaults: [
-            "/Users/*/Library/Messages/Attachments/",
-            "/Users/*/Library/Messages/Attachments",
-          ],
-          additions: ["/Volumes/relay/attachments"],
-          expected: ["/Users/*/Library/Messages/Attachments", "/Volumes/relay/attachments"],
-        }),
-    },
-  ] as const)("$name", ({ run }) => {
-    run();
+  it("normalizes and de-duplicates merged roots", () => {
+    expect(
+      mergeInboundPathRoots(
+        ["/Users/*/Library/Messages/Attachments/", "/Users/*/Library/Messages/Attachments"],
+        ["/Volumes/relay/attachments"],
+      ),
+    ).toEqual(["/Users/*/Library/Messages/Attachments", "/Volumes/relay/attachments"]);
   });
 });

--- a/packages/media-core/src/mime.test.ts
+++ b/packages/media-core/src/mime.test.ts
@@ -1,4 +1,3 @@
-// Media Core tests cover mime behavior.
 import JSZip from "jszip";
 import { describe, expect, it } from "vitest";
 import { mediaKindFromMime } from "./constants.js";
@@ -33,13 +32,6 @@ const ISOM_BRAND_BUFFER = Buffer.from(
 );
 
 describe("mime detection", () => {
-  async function expectDetectedMime(params: {
-    input: Parameters<typeof detectMime>[0];
-    expected: string;
-  }) {
-    expect(await detectMime(params.input)).toBe(params.expected);
-  }
-
   it.each([{ filePath: "clip.avi" }, {}, { filePath: "clip.bin", headerMime: "video/x-msvideo" }])(
     "normalizes byte-detected AVI independently of filename/header hints %#",
     async (hints) => {
@@ -85,13 +77,12 @@ describe("mime detection", () => {
       expected: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
     },
   ] as const)("$name", async ({ mainMime, partPath, expected }) => {
-    await expectDetectedMime({
-      input: {
+    expect(
+      await detectMime({
         buffer: await makeOoxmlZip({ mainMime, partPath }),
         filePath: "/tmp/file.bin",
-      },
-      expected,
-    });
+      }),
+    ).toBe(expected);
   });
 
   it.each([
@@ -153,10 +144,7 @@ describe("mime detection", () => {
       expected: "application/yaml",
     },
   ] as const)("$name", async ({ input, expected }) => {
-    await expectDetectedMime({
-      input: await input(),
-      expected,
-    });
+    expect(await detectMime(await input())).toBe(expected);
   });
 
   it.each([
@@ -175,23 +163,21 @@ describe("mime detection", () => {
     const zip = new JSZip();
     zip.file("hello.txt", "hi");
 
-    await expectDetectedMime({
-      input: { buffer: await zip.generateAsync({ type: "nodebuffer" }), headerMime },
-      expected: headerMime,
-    });
+    expect(
+      await detectMime({ buffer: await zip.generateAsync({ type: "nodebuffer" }), headerMime }),
+    ).toBe(headerMime);
   });
 
   it("does not let unrelated document metadata override generic ZIP bytes", async () => {
     const zip = new JSZip();
     zip.file("hello.txt", "hi");
 
-    await expectDetectedMime({
-      input: {
+    expect(
+      await detectMime({
         buffer: await zip.generateAsync({ type: "nodebuffer" }),
         headerMime: "application/pdf",
-      },
-      expected: "application/zip",
-    });
+      }),
+    ).toBe("application/zip");
   });
 
   it.each(["application/vnd.oasis.opendocument.text-flat-xml", "application/vnd.visio"])(
@@ -200,10 +186,9 @@ describe("mime detection", () => {
       const zip = new JSZip();
       zip.file("hello.txt", "hi");
 
-      await expectDetectedMime({
-        input: { buffer: await zip.generateAsync({ type: "nodebuffer" }), headerMime },
-        expected: "application/zip",
-      });
+      expect(
+        await detectMime({ buffer: await zip.generateAsync({ type: "nodebuffer" }), headerMime }),
+      ).toBe("application/zip");
     },
   );
 
@@ -212,14 +197,13 @@ describe("mime detection", () => {
     zip.file("hello.txt", "hi");
     const docxMime = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 
-    await expectDetectedMime({
-      input: {
+    expect(
+      await detectMime({
         buffer: await zip.generateAsync({ type: "nodebuffer" }),
         filePath: "upload.pdf",
         headerMime: docxMime,
-      },
-      expected: docxMime,
-    });
+      }),
+    ).toBe(docxMime);
   });
 
   it("preserves audio metadata for ambiguous WebM container bytes", async () => {
@@ -227,24 +211,22 @@ describe("mime detection", () => {
     // but defaults it to video/webm because no track metadata is present.
     const webm = Buffer.from("1a45dfa3874282847765626d", "hex");
 
-    await expectDetectedMime({
-      input: { buffer: webm, filePath: "voice.webm", headerMime: "audio/webm" },
-      expected: "audio/webm",
-    });
+    expect(
+      await detectMime({ buffer: webm, filePath: "voice.webm", headerMime: "audio/webm" }),
+    ).toBe("audio/webm");
   });
 
   it("uses a secondary audio hint when primary metadata is stale", async () => {
     const webm = Buffer.from("1a45dfa3874282847765626d", "hex");
 
-    await expectDetectedMime({
-      input: {
+    expect(
+      await detectMime({
         buffer: webm,
         filePath: "voice.webm",
         headerMime: "application/pdf",
         additionalMimeHints: ["audio/webm"],
-      },
-      expected: "audio/webm",
-    });
+      }),
+    ).toBe("audio/webm");
   });
 
   it.each([
@@ -285,14 +267,13 @@ describe("mime detection", () => {
       expected: "video/mp4",
     },
   ] as const)("resolves ambiguous isom-brand bytes from $name", async (testCase) => {
-    await expectDetectedMime({
-      input: {
+    expect(
+      await detectMime({
         buffer: ISOM_BRAND_BUFFER,
         filePath: testCase.filePath,
         headerMime: testCase.headerMime,
-      },
-      expected: testCase.expected,
-    });
+      }),
+    ).toBe(testCase.expected);
   });
 
   it.each([
@@ -308,16 +289,15 @@ describe("mime detection", () => {
     buffer.write("ftyp", 4, "ascii");
     buffer.write(testCase.brand, 8, "ascii");
 
-    await expectDetectedMime({ input: { buffer }, expected: testCase.expected });
+    expect(await detectMime({ buffer })).toBe(testCase.expected);
   });
 
   it("does not let conflicting audio metadata override MPEG video bytes", async () => {
     const mpegProgramStream = Buffer.from([0x00, 0x00, 0x01, 0xba, 0x00, 0x00, 0x00, 0x00]);
 
-    await expectDetectedMime({
-      input: { buffer: mpegProgramStream, headerMime: "audio/mpeg" },
-      expected: "video/mpeg",
-    });
+    expect(await detectMime({ buffer: mpegProgramStream, headerMime: "audio/mpeg" })).toBe(
+      "video/mpeg",
+    );
   });
 
   it("detects HTML files by extension (no magic bytes)", async () => {
@@ -364,10 +344,7 @@ describe("mime detection", () => {
     buffer.writeUInt32BE(buffer.length - 8, 4);
     buffer.write(form, 8, "ascii");
 
-    await expectDetectedMime({
-      input: { buffer, filePath: fileName },
-      expected: "audio/aiff",
-    });
+    expect(await detectMime({ buffer, filePath: fileName })).toBe("audio/aiff");
   });
 
   it("detects Apple CAF audio by magic bytes when file-type does not recognize the container", async () => {
@@ -469,13 +446,6 @@ describe("mimeTypeFromFilePath", () => {
 });
 
 describe("extensionForMime", () => {
-  function expectMimeExtensionCase(
-    mime: Parameters<typeof extensionForMime>[0],
-    expected: ReturnType<typeof extensionForMime>,
-  ) {
-    expect(extensionForMime(mime)).toBe(expected);
-  }
-
   it.each([
     { mime: "image/avif", expected: ".avif" },
     { mime: "image/jpeg", expected: ".jpg" },
@@ -528,15 +498,11 @@ describe("extensionForMime", () => {
     { mime: null, expected: undefined },
     { mime: undefined, expected: undefined },
   ] as const)("maps $mime to extension", ({ mime, expected }) => {
-    expectMimeExtensionCase(mime, expected);
+    expect(extensionForMime(mime)).toBe(expected);
   });
 });
 
 describe("isAudioFileName", () => {
-  function expectAudioFileNameCase(fileName: string, expected: boolean) {
-    expect(isAudioFileName(fileName)).toBe(expected);
-  }
-
   it.each([
     { fileName: "audiobook.M4B", expected: true },
     { fileName: "voice.mp3", expected: true },
@@ -552,7 +518,7 @@ describe("isAudioFileName", () => {
     { fileName: "voice.webm", expected: false },
     { fileName: "voice.bin", expected: false },
   ] as const)("matches audio extension for $fileName", ({ fileName, expected }) => {
-    expectAudioFileNameCase(fileName, expected);
+    expect(isAudioFileName(fileName)).toBe(expected);
   });
 });
 
@@ -580,13 +546,6 @@ describe("isGifMedia", () => {
 });
 
 describe("normalizeMimeType", () => {
-  function expectNormalizedMimeCase(
-    input: Parameters<typeof normalizeMimeType>[0],
-    expected: ReturnType<typeof normalizeMimeType>,
-  ) {
-    expect(normalizeMimeType(input)).toBe(expected);
-  }
-
   it.each([
     { input: "Audio/MP4; codecs=mp4a.40.2", expected: "audio/mp4" },
     { input: "image/apng", expected: "image/png" },
@@ -594,25 +553,11 @@ describe("normalizeMimeType", () => {
     { input: null, expected: undefined },
     { input: undefined, expected: undefined },
   ] as const)("normalizes $input", ({ input, expected }) => {
-    expectNormalizedMimeCase(input, expected);
+    expect(normalizeMimeType(input)).toBe(expected);
   });
 });
 
 describe("mediaKindFromMime", () => {
-  function expectMediaKindCase(
-    mime: Parameters<typeof mediaKindFromMime>[0],
-    expected: ReturnType<typeof mediaKindFromMime>,
-  ) {
-    expect(mediaKindFromMime(mime)).toBe(expected);
-  }
-
-  function expectMimeKindCase(
-    mime: Parameters<typeof kindFromMime>[0],
-    expected: ReturnType<typeof kindFromMime>,
-  ) {
-    expect(kindFromMime(mime)).toBe(expected);
-  }
-
   it.each([
     { mime: "text/plain", expected: "document" },
     { mime: "text/csv", expected: "document" },
@@ -621,7 +566,7 @@ describe("mediaKindFromMime", () => {
     { mime: null, expected: undefined },
     { mime: undefined, expected: undefined },
   ] as const)("classifies $mime", ({ mime, expected }) => {
-    expectMediaKindCase(mime, expected);
+    expect(mediaKindFromMime(mime)).toBe(expected);
   });
 
   it.each([
@@ -629,6 +574,6 @@ describe("mediaKindFromMime", () => {
     { mime: undefined, expected: undefined },
     { mime: "model/gltf+json", expected: undefined },
   ] as const)("maps kindFromMime($mime) => $expected", ({ mime, expected }) => {
-    expectMimeKindCase(mime, expected);
+    expect(kindFromMime(mime)).toBe(expected);
   });
 });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Media-core tests hide simple assertions behind ten private forwarding helpers and a one-row runner table, adding navigation and boilerplate without independent coverage.

## Why This Change Was Made

Inline the existing assertions in the base64, inbound-path and MIME suites and remove their generic file headers. Every input, oracle and case order remains. Test code changes by +52/-137 (net -85); production code changes by 0 lines.

MIME fixtures and `detectMime` remain awaited. Removing the assertion wrapper eliminates its extra promise completion; identical microtask counts are not a contract here. The singleton case now displays `normalizes and de-duplicates merged roots` in full instead of the table-rendered `'normalizes and de-duplicates merged r…'`.

## User Impact

No product behavior changes. Developers can read each assertion at its test case; public API, malformed-input, byte-limit, memory, path-security and container-format coverage remains intact.

## Evidence

- All 236 owner and sibling cases passed before and after: 216 in the changed suites, plus 20 inline-image, MIME-sniffing, Anthropic-image and audio cases. Event order and statuses match, with only the singleton display change above.
- Targeted formatting, `git diff --check`, the complete normal `coreTests` changed gate, and managed Codex autoreview passed. Review was scoped-clean at its default P0 priority. Local proof used immutable base `fa0f9e786cc8b10f2929eddfd01d07bf422e47d0`; exact publication-head CI remains separate.
- An inherited `OPENCLAW_TESTBOX=1` initially routed the gate remotely. That queued attempt was interrupted and its lease, sync checkout and registration were verified cleaned up. The same gate passed locally with `env -u OPENCLAW_TESTBOX`; the interrupted attempt is not passing proof.
