### PR TITLE
fix(text): keep astral letters separate when stripping model tokens

### DIFF
--- a/src/shared/text/model-special-tokens.ts
+++ b/src/shared/text/model-special-tokens.ts
@@ -32,8 +32,9 @@ export function stripModelSpecialTokens(text: string): string {
       out += matched;
     } else if (
       // Retained text handles adjacent tokens; two code units preserve astral letters.
+      // Keep alternation: Node 26.5's V8 misses astral letters in `$`-anchored `u` classes.
       // A following combining mark stays attached, and punctuation needs no separator.
-      /[\p{L}\p{M}\p{N}]$/u.test(out.slice(-2)) &&
+      /(?:\p{L}|\p{M}|\p{N})$/u.test(out.slice(-2)) &&
       /^[\p{L}\p{N}]/u.test(text.slice(end, end + 2))
     ) {
       out += " ";


### PR DESCRIPTION
## What Problem This Solves

`stripModelSpecialTokens` removes leaked provider control tokens such as
`<|assistant|>`, inserting a space when the removed token sat between two letters
so words do not fuse. On Node 26 that separator was silently skipped for
astral-plane (non-BMP) letters:

    input:    𐐀<|assistant|>𐐁
    expected: 𐐀 𐐁
    actual:   𐐀𐐁

Two distinct characters were run together. This is the repo's worst bug class —
silent corruption of user-visible text with no error — and it lands on a sanitizer
that runs over model output.

The cause is a V8 regression in Node 26.5.0. On the single astral letter
`"\u{10400}"`:

| Pattern | Node 22.22 | Node 24.15 | Node 25.9 | Node 26.5 |
| --- | --- | --- | --- | --- |
| `/[\p{L}]$/u` | true | true | true | **false** |
| `/\p{L}$/u` (no class) | true | true | true | true |
| `/[\p{L}]/u` (unanchored) | true | true | true | true |
| `/[\p{L}]$/v` | true | true | true | true |

Node 26's bracket-class parser sets `IS_CERTAINLY_ONE_CODE_POINT` from the pattern
string's storage width, so an ASCII-written Unicode class wrongly reports maximum
width 1; the end-anchor optimization then begins matching at the astral
character's low surrogate. Unbracketed property escapes do not take that path.
Source: `deps/v8/src/regexp/regexp-parser.cc`, `regexp-ast.h`, `regexp.cc` at
`v26.5.0`.

`AGENTS.md` recommends Node 26 while CI pins Node 24.x, so the recommended runtime
mangled text that the pinned one handled correctly — which is why CI never caught it.

## Why This Change Was Made

The categories are matched with an unbracketed alternation instead of a character
class, avoiding the defective parser path:

    /(?:\p{L}|\p{M}|\p{N})$/u

The `v` flag also fixes the runtime behavior, but this repo targets `es2023`
(`tsconfig.json:23`) and `v` requires `es2024`; using it produces two `TS1501`
errors under the real changed gate. The alternation keeps Unicode-category
matching, the bounded two-code-unit slices, and the existing ownership boundary
while compiling on the current target.

The right-hand `^`-anchored class is unaffected by the V8 bug and is left alone; a
comment records why the left side must stay an alternation so it is not "tidied"
back into a class.

## User Impact

Astral-plane text — Deseret, Gothic, Old Italic, many CJK Extension B+ ideographs,
and emoji-adjacent letterlike code points — is no longer fused when a leaked model
token is stripped between two such characters. An exhaustive probe over all
1,114,112 code points found the previous expression missed **99,057** of them on
Node 26.

Production LOC is net zero executable lines (one comment added).

## Evidence

    node scripts/run-vitest.mjs src/agents/embedded-agent-utils.strip-model-special-tokens.test.ts
      Node 26.5.0  18 passed, exit 0
      Node 24.15.0 18 passed, exit 0
    node scripts/check-changed.mjs -- src/shared/text/model-special-tokens.ts
      exit 0

The existing regression case `preserves astral letters when removing tokens` fails
on pre-fix source for the intended reason (`expected '𐐀𐐁' to be '𐐀 𐐁'`) and passes
after. Both runtimes are exercised because the defect is engine-specific: a
Node-24-only run cannot observe it.

Blast radius: the repository was searched for `u`-flag character classes anchored
with `$`; `src/shared/text/model-special-tokens.ts` is the only site whose
structure triggers the bug. Other `$`-anchored `u` classes exist
(`src/config/sessions/paths.ts:61`, `src/shared/text/strip-markdown.ts:93`,
`src/infra/exec-approval-text-sanitize.ts:18`) and were checked; their structures
do not reach the failure. An independent AST audit compared 3,011 `u`-flag literals
across 549 synthetic inputs on Node 24 and 26 and found no additional affected site.

Exhaustive code-point probes on Node 22.22, 24.15, 25.9 and 26.5 confirm the
repaired expression matches a property-based oracle on every code point.
