### PR TITLE
fix: publish Linux bundles from canonical release branches

### DIFF
--- a/.github/workflows/linux-app-release.yml
+++ b/.github/workflows/linux-app-release.yml
@@ -55,10 +55,37 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Ensure tag commit is reachable from main
+      - name: Checkout trusted release tooling
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .release-tooling
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: |
+            scripts/lib/record-shared.mjs
+            scripts/release-tooling-identity.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Verify trusted release tooling identity
+        env:
+          GH_TOKEN: ${{ github.token }}
+          WORKFLOW_FULL_REF: ${{ github.ref }}
+          WORKFLOW_REF: ${{ github.ref_name }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          node .release-tooling/scripts/release-tooling-identity.mjs verify \
+            --repository "$GITHUB_REPOSITORY" \
+            --workflow-ref "$WORKFLOW_REF" \
+            --workflow-full-ref "$WORKFLOW_FULL_REF" \
+            --workflow-sha "$WORKFLOW_SHA"
+
+      - name: Ensure tag commit is reachable from its release branch
         id: ancestry
         env:
           RELEASE_TAG: ${{ inputs.tag }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
           exec python3 -I -S "$CI_GIT_OWNER" --policy - <<'PYTHON'
@@ -69,28 +96,54 @@ jobs:
 
           workspace = os.environ["GITHUB_WORKSPACE"]
           release_tag = os.environ["RELEASE_TAG"]
+
+          def is_ancestor(sha, ref):
+              try:
+                  run_git(workspace, "merge-base", "--is-ancestor", sha, ref)
+                  return True
+              except GitFailure as error:
+                  if error.code == 1:
+                      return False
+                  raise
+
           run_git(
               workspace,
               "fetch",
-              "--quiet",
+              "--no-tags",
               "origin",
-              "main",
+              "+refs/heads/main:refs/remotes/origin/main",
               timeout=120,
               reclaim_locks=True,
           )
+          if not is_ancestor(os.environ["WORKFLOW_SHA"], "origin/main"):
+              print("Linux release tooling must be reachable from current main.", file=sys.stderr)
+              raise SystemExit(1)
           tag_sha = git_output(
               workspace,
               "rev-parse",
               f"refs/tags/{release_tag}^{{commit}}",
           ).rstrip("\n")
-          try:
-              run_git(workspace, "merge-base", "--is-ancestor", tag_sha, "origin/main")
-          except GitFailure:
-              print(
-                  f"Tag {release_tag} ({tag_sha}) is not reachable from main; "
-                  "Linux bundles ship for main-based releases only."
+          if not is_ancestor(tag_sha, "origin/main"):
+              # The validated stable tag chooses its sole eligible release branch;
+              # numeric correction tags share the base version's release branch.
+              release_branch = f"release/{release_tag[1:].split('-', 1)[0]}"
+              release_ref = f"refs/remotes/origin/{release_branch}"
+              run_git(
+                  workspace,
+                  "fetch",
+                  "--no-tags",
+                  "origin",
+                  f"+refs/heads/{release_branch}:{release_ref}",
+                  timeout=120,
+                  reclaim_locks=True,
               )
-              raise SystemExit(1)
+              if not is_ancestor(tag_sha, release_ref):
+                  print(
+                      f"Tag {release_tag} ({tag_sha}) is not reachable from main "
+                      f"or {release_branch}.",
+                      file=sys.stderr,
+                  )
+                  raise SystemExit(1)
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
               output.write(f"tag_sha={tag_sha}\n")
           PYTHON

--- a/apps/linux/README.md
+++ b/apps/linux/README.md
@@ -146,6 +146,8 @@ requests touching `apps/linux/**` and on manual dispatch.
 The `Linux App Release` workflow (manual dispatch, release operators) builds
 the bundles from an existing stable release tag (prerelease tags are
 rejected: their semver suffix breaks Debian upgrade ordering) and attaches them to that tag's
-GitHub release with a `SHA256SUMS.linux-app.txt` checksum file. It refuses
-tags whose commit is not reachable from `main`: Linux bundles ship for
-main-based releases only.
+GitHub release with a `SHA256SUMS.linux-app.txt` checksum file. The tag commit
+must be reachable from `main` or its matching `release/YYYY.M.PATCH` branch;
+numeric correction tags use the base version's release branch. Dispatch from
+`main` or an exact protected `release-publish/<sha-prefix>-<serial>` tooling tag
+whose commit is contained in `main`. Builds use the validated release tag SHA.

--- a/docs/platforms/linux.md
+++ b/docs/platforms/linux.md
@@ -111,7 +111,8 @@ the shell does not grant microphone capture to the WebKitGTK WebView, so
 `getUserMedia` is expected to fail there. Until that lands, open the Gateway's
 Control UI in a regular browser for [Talk mode](/nodes/talk).
 
-Stable releases built from `main` ship `.deb` and AppImage bundles as assets on the
+Stable releases built from `main` or their matching `release/YYYY.M.PATCH` branch
+ship `.deb` and AppImage bundles as assets on the
 [GitHub release](https://github.com/openclaw/openclaw/releases) for the tag,
 named `OpenClaw-<version>-amd64.deb` and `OpenClaw-<version>-amd64.AppImage`,
 with a `SHA256SUMS.linux-app.txt` checksum file next to them. Download the

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -11638,7 +11638,7 @@ it("pins simple release admission owners before selected checkout and preserves 
       file: ".github/workflows/linux-app-release.yml",
       job: "validate_release",
       checkout: "Checkout selected tag",
-      validation: "Ensure tag commit is reachable from main",
+      validation: "Ensure tag commit is reachable from its release branch",
     },
     {
       file: ".github/workflows/macos-release.yml",
@@ -11665,6 +11665,32 @@ it("pins simple release admission owners before selected checkout and preserves 
   }
 
   const linux = parse(readFileSync(workflows[0].file, "utf8"));
+  const linuxSteps = linux.jobs.validate_release.steps as WorkflowStep[];
+  expect(
+    linuxSteps.find(({ name }) => name === "Checkout trusted release tooling")?.with,
+  ).toMatchObject({
+    ref: "${{ github.workflow_sha }}",
+    path: ".release-tooling",
+    "persist-credentials": false,
+  });
+  const tooling = linuxSteps.find(({ name }) => name === "Verify trusted release tooling identity");
+  expect(tooling?.env).toMatchObject({
+    WORKFLOW_FULL_REF: "${{ github.ref }}",
+    WORKFLOW_REF: "${{ github.ref_name }}",
+    WORKFLOW_SHA: "${{ github.workflow_sha }}",
+  });
+  expect(tooling?.run).toContain(
+    "node .release-tooling/scripts/release-tooling-identity.mjs verify",
+  );
+  expect(tooling?.run).not.toContain("--allow-prevalidated-ref");
+  expect(linuxSteps.indexOf(tooling!)).toBeLessThan(
+    linuxSteps.findIndex(({ id }) => id === "ancestry"),
+  );
+  for (const name of ["build_linux", "build_macos", "build_windows"]) {
+    expect(linux.jobs[name].steps[0].with.ref).toBe(
+      "${{ needs.validate_release.outputs.tag_sha }}",
+    );
+  }
   const linuxBody = expectDefined(
     (linux.jobs.validate_release.steps as WorkflowStep[]).find(
       ({ name }) => name === workflows[0].validation,
@@ -11672,11 +11698,9 @@ it("pins simple release admission owners before selected checkout and preserves 
     "Linux release admission body",
   );
   expect(linuxBody).toContain('exec python3 -I -S "$CI_GIT_OWNER" --policy -');
-  expect(linuxBody.match(/timeout=120/gu)).toHaveLength(1);
-  expect(linuxBody).toMatch(/"fetch",\s+"--quiet",\s+"origin",\s+"main",/u);
-  expect(linuxBody).toContain(
-    'run_git(workspace, "merge-base", "--is-ancestor", tag_sha, "origin/main")',
-  );
+  expect(linuxBody.match(/timeout=120/gu)).toHaveLength(2);
+  expect(linuxBody).toContain('"+refs/heads/main:refs/remotes/origin/main"');
+  expect(linuxBody).toContain('run_git(workspace, "merge-base", "--is-ancestor", sha, ref)');
 
   const macos = parse(readFileSync(workflows[1].file, "utf8"));
   const macosBody = expectDefined(

--- a/test/scripts/release-workflow-git-lifecycle.test.ts
+++ b/test/scripts/release-workflow-git-lifecycle.test.ts
@@ -23,9 +23,9 @@ const releases: Record<
     workflow: {
       file: ".github/workflows/linux-app-release.yml",
       job: "validate_release",
-      step: "Ensure tag commit is reachable from main",
+      step: "Ensure tag commit is reachable from its release branch",
     },
-    env: { RELEASE_TAG: releaseTag },
+    env: { RELEASE_TAG: releaseTag, WORKFLOW_SHA: otherSha },
     revisions: { [`refs/tags/${releaseTag}^{commit}`]: sha },
   },
   macos: {
@@ -66,11 +66,35 @@ function gitCommands(report: Awaited<ReturnType<typeof releaseRun>>) {
   return report.commands.filter(({ tool }) => tool === "git").map(({ args }) => args);
 }
 
+posixIt.each([releaseTag, `${releaseTag}-2`])(
+  "Linux admits a stable tag from its matching release branch: %s",
+  async (tag) => {
+    const report = await releaseRun("linux", {
+      env: { RELEASE_TAG: tag },
+      revisions: { [`refs/tags/${tag}^{commit}`]: sha },
+      commandResults: {
+        [`merge-base --is-ancestor ${sha} origin/main`]: { code: 1 },
+        [`merge-base --is-ancestor ${sha} refs/remotes/origin/release/2026.8.1`]: { code: 0 },
+      },
+    });
+    expect(report.code, report.output).toBe(0);
+    expect(report.githubOutput).toBe(`tag_sha=${sha}\n`);
+    expect(gitCommands(report)).toContainEqual([
+      "fetch",
+      "--no-tags",
+      "origin",
+      "+refs/heads/release/2026.8.1:refs/remotes/origin/release/2026.8.1",
+    ]);
+  },
+  55_000,
+);
+
 posixIt.each([
   {
     mode: "linux" as const,
     commands: [
-      ["fetch", "--quiet", "origin", "main"],
+      ["fetch", "--no-tags", "origin", "+refs/heads/main:refs/remotes/origin/main"],
+      ["merge-base", "--is-ancestor", otherSha, "origin/main"],
       ["rev-parse", `refs/tags/${releaseTag}^{commit}`],
       ["merge-base", "--is-ancestor", sha, "origin/main"],
     ],
@@ -205,16 +229,62 @@ posixIt.each(
   55_000,
 );
 
-posixIt.each([1, 23, 124, 125, 143])(
-  "Linux ordinary merge-base status %s retains the release rejection",
+posixIt.each([23, 124, 125, 143])(
+  "Linux ordinary merge-base status %s is terminal without trying another branch",
   async (code) => {
     const report = await releaseRun("linux", {
       gitFault: { match: "^merge-base ", code },
     });
+    expect(report.code, report.output).toBe(code);
+    expect(gitCommands(report).at(-1)?.[0]).toBe("merge-base");
+    expect(report.githubOutput).toBe("");
+  },
+  55_000,
+);
+
+posixIt(
+  "Linux rejects a tag outside main and its matching release branch",
+  async () => {
+    const report = await releaseRun("linux", {
+      commandResults: {
+        [`merge-base --is-ancestor ${sha} origin/main`]: { code: 1 },
+        [`merge-base --is-ancestor ${sha} refs/remotes/origin/release/2026.8.1`]: { code: 1 },
+      },
+    });
     expect(report.code, report.output).toBe(1);
     expect(report.output).toContain(
-      `Tag ${releaseTag} (${sha}) is not reachable from main; Linux bundles ship for main-based releases only.`,
+      `Tag ${releaseTag} (${sha}) is not reachable from main or release/2026.8.1.`,
     );
+    expect(report.githubOutput).toBe("");
+  },
+  55_000,
+);
+
+posixIt(
+  "Linux rejects tooling outside main before inspecting the candidate",
+  async () => {
+    const report = await releaseRun("linux", {
+      commandResults: { [`merge-base --is-ancestor ${otherSha} origin/main`]: { code: 1 } },
+    });
+    expect(report.code, report.output).toBe(1);
+    expect(report.output).toContain("Linux release tooling must be reachable from current main.");
+    expect(gitCommands(report).some(([operation]) => operation === "rev-parse")).toBe(false);
+    expect(report.githubOutput).toBe("");
+  },
+  55_000,
+);
+
+posixIt.each([128, "cleanup-failure", "cancel"] as const)(
+  "Linux matching release branch fetch failure %s cannot admit a stale ref",
+  async (failure) => {
+    const report = await releaseRun("linux", {
+      commandResults: { [`merge-base --is-ancestor ${sha} origin/main`]: { code: 1 } },
+      gitFault: { match: "^fetch ", occurrence: 2, code: failure },
+    });
+    expect(report.code, report.output).toBe(
+      failure === "cancel" ? 143 : failure === "cleanup-failure" ? 125 : failure,
+    );
+    expect(gitCommands(report).at(-1)?.[0]).toBe("fetch");
     expect(report.githubOutput).toBe("");
   },
   55_000,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where release operators cannot attach Linux companion bundles to a stable release cut from its canonical release branch. The publisher rejects a release-only commit because it checks only `main` ancestry, blocking the first stable Linux publication.

## Why This Change Was Made

Keep workflow authority separate from release source: load the existing tooling-identity verifier at the executing workflow SHA, accept trusted `main` or an exact protected tooling tag, and prove that tooling commit is contained in `main`. Admit the candidate tag from `main` or its matching `release/YYYY.M.PATCH` branch; numeric correction tags share the base version's branch. All build jobs still consume the exact validated tag SHA, and Git failures or cancellation cannot authorize publication.

## User Impact

Release operators can publish stable Linux `.deb` and AppImage bundles from canonical release branches using an immutable protected workflow tag. No new workflow input or application configuration is needed. The Linux operator and platform docs now describe the supported path.

## Evidence

- Before the fix, the added stable and numeric-correction regression cases fail with the existing main-only rejection. After the fix, 136 lifecycle and tooling-identity tests pass, plus the focused workflow wiring guard.
- A separate actual local Git graph verifies acceptance of a main tag, matching release-branch tag, and numeric correction; unrelated candidates and tooling outside main fail without emitting a build SHA.
- P0–P2 Codex autoreview has no actionable findings. Targeted formatting, `docs:list`, and `git diff --check` pass.
- Local full workflow lint is blocked because the package index cannot supply the repository's pinned `pre-commit==4.6.2`. Root test typecheck is blocked by the shared dependency tree's missing `pako` declarations. Targeted lint reports seven unchanged baseline lines in the existing test files. Hosted CI remains the landing gate.
- Product runtime delta: zero. Workflow tooling: +63/-10; tests: +106/-12; docs: +7/-4. The tooling growth owns separate workflow identity and release-target authorization boundaries.

No signing or upload was performed during validation; publication waits for the release tag.
