### PR TITLE
fix(auth): stop listing non-model tool plugins as model providers

### DIFF
--- a/src/gateway/server-methods/models-auth-status-api-keys.ts
+++ b/src/gateway/server-methods/models-auth-status-api-keys.ts
@@ -43,12 +43,26 @@ export function resolveProviderApiKeys(
     config: cfg,
     env: process.env,
   });
+  const owners = authAliasLookupParams.metadataSnapshot?.owners;
+  const modelCapableIds = new Set(
+    [
+      ...(owners?.providers ?? new Map()).keys(),
+      ...(owners?.modelCatalogProviders ?? new Map()).keys(),
+      ...(owners?.cliBackends ?? new Map()).keys(),
+    ]
+      .map((id) => normalizeProviderId(id))
+      .filter((id): id is string => Boolean(id)),
+  );
+  const envLookupProviderIds = listProviderEnvAuthLookupKeys(lookupMaps).filter((id) => {
+    const normalized = normalizeProviderId(id);
+    return Boolean(normalized) && modelCapableIds.has(normalized);
+  });
   const providerIds = new Set<string>([
     ...Object.keys(cfg.models?.providers ?? {}),
     ...Object.values(cfg.auth?.profiles ?? {})
       .map((profile) => profile?.provider)
       .filter((provider): provider is string => typeof provider === "string"),
-    ...listProviderEnvAuthLookupKeys(lookupMaps),
+    ...envLookupProviderIds,
   ]);
   const apiKeys = new Map<string, ModelAuthStatusProvider["apiKey"]>();
   for (const rawProvider of providerIds) {

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -625,6 +625,7 @@ describe("models.authStatus", () => {
       {
         id: "prepared-auth",
         origin: "bundled",
+        providers: ["prepared-owner"],
         setup: {
           providers: [{ id: "prepared-owner", envVars: ["PREPARED_OWNER_API_KEY"] }],
         },
@@ -647,6 +648,14 @@ describe("models.authStatus", () => {
       },
       manifestRegistry: { plugins },
       plugins,
+      owners: {
+        providers: new Map([
+          ["prepared-owner", ["prepared-auth"]],
+          ["prepared-owner-alias", ["prepared-auth"]],
+        ]),
+        modelCatalogProviders: new Map(),
+        cliBackends: new Map(),
+      },
     });
     vi.stubEnv("PREPARED_OWNER_API_KEY", "prepared-owner-secret");
 
@@ -656,6 +665,150 @@ describe("models.authStatus", () => {
       expect.objectContaining({
         providers: expect.arrayContaining(["prepared-owner", "prepared-owner-alias"]),
       }),
+    );
+  });
+
+  it("excludes credential-only tool plugins from env auth status providers", async () => {
+    const plugins = [
+      {
+        id: "brave",
+        origin: "bundled",
+        setup: { providers: [{ id: "brave", envVars: ["BRAVE_API_KEY"] }] },
+        contracts: { webSearchProviders: ["brave"] },
+      },
+    ];
+    setPreparedMetadataSnapshot({
+      index: { plugins: [] },
+      manifestRegistry: { plugins },
+      plugins,
+      owners: {
+        providers: new Map(),
+        modelCatalogProviders: new Map(),
+        cliBackends: new Map(),
+      },
+    });
+    vi.stubEnv("BRAVE_API_KEY", "bsa-test");
+
+    await readAuthStatus();
+
+    expect(mocks.buildAuthHealthSummary).toHaveBeenCalledWith(
+      expect.objectContaining({ providers: expect.not.arrayContaining(["brave"]) }),
+    );
+  });
+
+  it("keeps a model provider and drops a sibling tool plugin sharing an env var", async () => {
+    const plugins = [
+      {
+        id: "qwen",
+        origin: "bundled",
+        providers: ["qwen", "dashscope", "modelstudio"],
+        modelCatalog: { providers: { qwen: {}, "qwen-token-plan": {} } },
+        setup: {
+          providers: [{ id: "qwen", envVars: ["DASHSCOPE_API_KEY"] }],
+        },
+      },
+      {
+        id: "alibaba",
+        origin: "bundled",
+        setup: { providers: [{ id: "alibaba", envVars: ["DASHSCOPE_API_KEY"] }] },
+        contracts: { videoGenerationProviders: ["alibaba"] },
+      },
+    ];
+    setPreparedMetadataSnapshot({
+      index: { plugins: [] },
+      manifestRegistry: { plugins },
+      plugins,
+      owners: {
+        providers: new Map([
+          ["qwen", ["qwen"]],
+          ["dashscope", ["qwen"]],
+          ["modelstudio", ["qwen"]],
+        ]),
+        modelCatalogProviders: new Map([
+          ["qwen", ["qwen"]],
+          ["qwen-token-plan", ["qwen"]],
+        ]),
+        cliBackends: new Map(),
+      },
+    });
+    vi.stubEnv("DASHSCOPE_API_KEY", "ds-test");
+
+    await readAuthStatus();
+
+    expect(mocks.buildAuthHealthSummary).toHaveBeenCalledWith(
+      expect.objectContaining({ providers: expect.arrayContaining(["qwen"]) }),
+    );
+    expect(mocks.buildAuthHealthSummary).toHaveBeenCalledWith(
+      expect.objectContaining({ providers: expect.not.arrayContaining(["alibaba"]) }),
+    );
+  });
+
+  it("keeps multiple model providers that share an env var", async () => {
+    const plugins = [
+      {
+        id: "minimax",
+        origin: "bundled",
+        providers: ["minimax", "minimax-portal"],
+        setup: {
+          providers: [
+            { id: "minimax", envVars: ["MINIMAX_API_KEY"] },
+            { id: "minimax-portal", envVars: ["MINIMAX_API_KEY"] },
+          ],
+        },
+      },
+    ];
+    setPreparedMetadataSnapshot({
+      index: { plugins: [] },
+      manifestRegistry: { plugins },
+      plugins,
+      owners: {
+        providers: new Map([
+          ["minimax", ["minimax"]],
+          ["minimax-portal", ["minimax"]],
+        ]),
+        modelCatalogProviders: new Map(),
+        cliBackends: new Map(),
+      },
+    });
+    vi.stubEnv("MINIMAX_API_KEY", "m-test");
+
+    await readAuthStatus();
+
+    expect(mocks.buildAuthHealthSummary).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providers: expect.arrayContaining(["minimax", "minimax-portal"]),
+      }),
+    );
+  });
+
+  it("keeps an explicitly configured provider even when it is not a model owner", async () => {
+    const plugins = [
+      {
+        id: "brave",
+        origin: "bundled",
+        setup: { providers: [{ id: "brave", envVars: ["BRAVE_API_KEY"] }] },
+        contracts: { webSearchProviders: ["brave"] },
+      },
+    ];
+    mocks.getRuntimeConfig.mockReturnValue({
+      models: { providers: { brave: { api: "openai" } } },
+    });
+    setPreparedMetadataSnapshot({
+      index: { plugins: [] },
+      manifestRegistry: { plugins },
+      plugins,
+      owners: {
+        providers: new Map(),
+        modelCatalogProviders: new Map(),
+        cliBackends: new Map(),
+      },
+    });
+    vi.stubEnv("BRAVE_API_KEY", "bsa-test");
+
+    await readAuthStatus();
+
+    expect(mocks.buildAuthHealthSummary).toHaveBeenCalledWith(
+      expect.objectContaining({ providers: expect.arrayContaining(["brave"]) }),
     );
   });
 


### PR DESCRIPTION
Closes #134077

## What Problem This Solves

Fixes an issue where operators who set an API key for a non-model plugin in the
environment would see irrelevant, non-removable "configured model provider"
cards on the **Settings → Model Providers** page.

Setting a credential-only tool plugin's key — for example `BRAVE_API_KEY`,
`FIRECRAWL_API_KEY`, `EXA_API_KEY`, `TAVILY_API_KEY`, `ELEVENLABS_API_KEY`, or
`DEEPGRAM_API_KEY` (search/web/speech tools) — made that plugin appear as a
model provider card, inflating the configured provider count even though it is
not a model provider.

(Note: `DASHSCOPE_API_KEY` is not an example of this — it keys Qwen, a genuine
model provider, which is intentionally retained; the fix targets only plugins
that declare no model catalog and are not configured.)

## Why This Change Was Made

The Model Providers page rendered a card for every provider reported by
`models.authStatus`. The gateway's env-based auth lookup seeds provider ids from
every plugin `setup.providers`, including credential-only tool plugins
(Brave/Firecrawl/search/speech/media) that declare no model catalog. Those rows
then surfaced as model cards.

The fix gates the env-discovered subset on plugin ownership metadata — the
union of the `providers`, `modelCatalogProviders`, and `cliBackends` owner maps
— so only model-capable providers become auth-status rows. Explicitly configured
providers (`models.providers`) are unaffected and bypass this gate via the
existing config path.

Non-goals: the fix does not change auth-status data for configured providers,
model catalogs, pickers, or secret scrubbing, and does not alter agent
credential mirroring, which intentionally keeps the unfiltered env lookup.
Follow-ups are tracked for the same invariant in the CLI `models status` output,
model auth discovery, and the Quick-Add provider list.

## User Impact

Operators now see only genuine or configured model providers on the Model
Providers page. Setting a search/speech/media plugin's key no longer produces a
bogus, non-removable provider card, so the configured-provider count is
accurate. Model providers that share an environment variable (for example
Qwen under `DASHSCOPE_API_KEY`, or MiniMax and MiniMax Portal) remain visible,
and a provider the operator explicitly configures is always kept.

## Evidence

- **Regression was failing before the fix**: with the gate removed, the new
  gateway tests (`excludes credential-only tool plugins`, `keeps a model
  provider and drops a sibling tool plugin`) fail red; with the fix they pass.
- **Focused suite**: `node scripts/run-vitest.mjs src/gateway/server-methods/models-auth-status.test.ts` → 96 passed (includes the updated "published metadata owner" test and 4 new gate tests).
- **Real-behavior proof** (real Gateway + real plugin metadata snapshot, no mocks
  or monkey-patching): the same capture
  (`model-providers-producer-proof.test.ts`, archived under
  `/media/vdb/outcoco/checklang/cap-pic/fix-134077/`) starts a REAL Gateway via
  `startGatewayServer` (so the real bundled-plugin metadata snapshot — the exact
  data `models.authStatus` consumes — is loaded), then calls the exact production
  function the RPC uses, `resolveProviderApiKeys()` from
  `src/gateway/server-methods/models-auth-status-api-keys.ts`, with a seeded env
  var and records which provider ids become auth-status rows. It is run
  unchanged against BOTH commits and the JSON outputs are diffed:
  - **BEFORE (ace8a13f19c, no gate)**:
    - `BRAVE_API_KEY` → `["brave"]` (bug: tool plugin listed as a provider);
    - `DASHSCOPE_API_KEY` → `["alibaba","modelstudio-api-key","modelstudio-api-key-cn","modelstudio-standard-api-key","modelstudio-standard-api-key-cn","qwen","qwen-dashscope"]`
      (duplicate-alias noise + the video tool sibling `alibaba`, per the issue
      title "duplicate auth aliases").
  - **AFTER (67bd36b5b0b, gate)**:
    - `BRAVE_API_KEY` → `[]` (brave dropped);
    - `DASHSCOPE_API_KEY` → `["qwen"]` (real model provider retained; `alibaba`
      and the `qwen-dashscope`/`modelstudio-api-*` duplicate aliases dropped).

  This is a real-behavior before/after of the exact producer code path the fix
  changes, using the genuine metadata snapshot rather than a hand-built one, and
  it complements (does not duplicate) the vitest cases (which assert the
  `buildAuthHealthSummary` call arguments through the mocked gateway).
- **Browser-level UI note**: a real-browser capture (real Control UI + Chromium +
  real gateway over WebSocket) was also exercised. Playwright's
  `page.on("websocket")` `framereceived`/`framesent` events do not surface the
  raw `models.authStatus` response frames in this environment, so the browser
  wire recorder could not observe the RPC payload; the producer-level capture
  above is the authoritative record of the behavior change and is what the
  rendered cards are derived from.
- **Type/lint/format**: `node scripts/run-tsgo.mjs -p tsconfig.core.json` passes. `node scripts/check-changed.mjs -- <the two changed files>` passes all fast lanes observed (format via oxfmt, deadcode, coercion-helper guards, dependency pins); the full `check:changed` run was not observed to complete in the authoring environment (the typecheck lane exceeded the run timeout), so the run-timeout typecheck step is covered by the dedicated `tsgo` pass above rather than by a single completed `check:changed` invocation.

### Production vs test LOC

Production: `src/gateway/server-methods/models-auth-status-api-keys.ts` (+15/−1,
net ≈ +14, no comments). Test: `src/gateway/server-methods/models-auth-status.test.ts` (+153: one test fixed + 4 new tests).

The production delta is the additive producer-side filter step (build the owner
id set and filter the env-discovered ids). It is confined to the single gateway
file that owns the leak rather than a larger downstream/UI change, which is why
it is net-positive rather than net-zero; there are no removed production paths
in this change.

### Follow-ups (not in this PR)

- `src/commands/models/list.status-command.ts` — CLI `models status` lists tool providers from the same unfiltered env lookup.
- `src/agents/model-auth-availability.ts` — model auth discovery iterates tool providers.
- Quick-Add `providerCapabilities` — over-broad provider list (currently not operator-visible under default conditions).
