### PR TITLE
fix(gateway): refresh model catalog after auth changes

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1668,7 +1668,6 @@ src/agents/auth-profiles/policy.ts	1
 src/agents/auth-profiles/portability.ts	1
 src/agents/auth-profiles/profiles.ts	1
 src/agents/auth-profiles/repair.ts	1
-src/agents/auth-profiles/runtime-snapshots.ts	1
 src/agents/auth-profiles/source-check.ts	1
 src/agents/auth-profiles/sqlite.ts	2
 src/agents/auth-profiles/state.ts	5

--- a/extensions/memory-lancedb/embeddings.lifecycle.test.ts
+++ b/extensions/memory-lancedb/embeddings.lifecycle.test.ts
@@ -13,7 +13,11 @@ import type { MemoryConfig } from "./config.js";
 const providerMocks = vi.hoisted(() => ({
   getMemoryEmbeddingProvider: vi.fn(),
   authMutationListeners: new Set<
-    (event: { agentDir?: string; affectsInheritedStores: boolean }) => void
+    (event: {
+      agentDir?: string;
+      affectsInheritedStores: boolean;
+      profileSetChanged: boolean;
+    }) => void
   >(),
 }));
 
@@ -206,6 +210,7 @@ describe("memory-lancedb provider lifecycle", () => {
     listener?.({
       agentDir: "/tmp/agent-private/../agent-private",
       affectsInheritedStores: false,
+      profileSetChanged: false,
     });
 
     await embed(embeddings, "other", "other warm provider");

--- a/src/agents/auth-profiles/external-oauth.test.ts
+++ b/src/agents/auth-profiles/external-oauth.test.ts
@@ -323,7 +323,11 @@ describe("auth external oauth helpers", () => {
       expect(getRuntimeAuthProfileStoreSnapshot(agentDir)?.profiles["openai:default"]?.type).toBe(
         "oauth",
       );
-      expect(listener).toHaveBeenCalledWith({ agentDir, affectsInheritedStores: false });
+      expect(listener).toHaveBeenCalledWith({
+        agentDir,
+        affectsInheritedStores: false,
+        profileSetChanged: true,
+      });
     } finally {
       unregister();
     }

--- a/src/agents/auth-profiles/mutation-lineage.ts
+++ b/src/agents/auth-profiles/mutation-lineage.ts
@@ -1,0 +1,242 @@
+import { resolveSharedAuthStorePath, type AuthProfileOwnerScope } from "./path-resolve.js";
+import { resolveAuthProfileDatabasePath } from "./sqlite.js";
+
+type PersistedMutationRecord = {
+  credentialRevision: number;
+  credentialRevisionKnown: boolean;
+  profileSetRevision: number;
+  profileSetRevisionKnown: boolean;
+  stateRevision: number;
+  stateRevisionKnown: boolean;
+  mutationFloor: number;
+  profileRevisions: Map<string, number>;
+};
+
+const persistedMutationRecords = new Map<string, PersistedMutationRecord>();
+let persistedMutationRevision = 0;
+let evictedOwnerMutationFloor = 0;
+const MAX_PERSISTED_MUTATION_OWNERS = 256;
+const MAX_PERSISTED_MUTATION_PROFILES_PER_OWNER = 256;
+
+export type RuntimeAuthProfileStoreMutationToken = {
+  revision: number;
+  known: boolean;
+};
+
+export type RuntimeAuthProfileStoreMutationOwner =
+  | { kind: "resolved"; databasePath: string; sharedDatabasePath: string }
+  | { kind: "unresolved"; databasePath: string; scope: AuthProfileOwnerScope };
+
+// Runtime snapshots are keyed by the canonical database path so default-agent
+// and per-agent stores do not overwrite each other.
+export function resolveRuntimeStoreKey(agentDir?: string): string {
+  return agentDir ? resolveAuthProfileDatabasePath(agentDir) : resolveSharedAuthStorePath();
+}
+
+function maxMutationRevision(record: PersistedMutationRecord): number {
+  return Math.max(
+    record.credentialRevision,
+    record.profileSetRevision,
+    record.stateRevision,
+    record.mutationFloor,
+    ...record.profileRevisions.values(),
+  );
+}
+
+function getOrCreatePersistedMutationRecord(ownerKey: string): PersistedMutationRecord {
+  const existing = persistedMutationRecords.get(ownerKey);
+  if (existing) {
+    // Mutations, rather than reads, drive LRU recency so observation cannot
+    // retain dormant owners forever.
+    persistedMutationRecords.delete(ownerKey);
+    persistedMutationRecords.set(ownerKey, existing);
+    return existing;
+  }
+  const record: PersistedMutationRecord = {
+    credentialRevision: evictedOwnerMutationFloor,
+    credentialRevisionKnown: evictedOwnerMutationFloor === 0,
+    profileSetRevision: evictedOwnerMutationFloor,
+    profileSetRevisionKnown: evictedOwnerMutationFloor === 0,
+    stateRevision: evictedOwnerMutationFloor,
+    stateRevisionKnown: evictedOwnerMutationFloor === 0,
+    mutationFloor: evictedOwnerMutationFloor,
+    profileRevisions: new Map(),
+  };
+  persistedMutationRecords.set(ownerKey, record);
+  while (persistedMutationRecords.size > MAX_PERSISTED_MUTATION_OWNERS) {
+    const oldestOwnerKey = persistedMutationRecords.keys().next().value;
+    if (oldestOwnerKey === undefined) {
+      break;
+    }
+    const oldest = persistedMutationRecords.get(oldestOwnerKey);
+    persistedMutationRecords.delete(oldestOwnerKey);
+    if (oldest) {
+      // A floor trades false-positive rollback fences for bounded memory; it
+      // must never let an evicted persisted mutation look unchanged.
+      evictedOwnerMutationFloor = Math.max(evictedOwnerMutationFloor, maxMutationRevision(oldest));
+    }
+  }
+  record.mutationFloor = Math.max(record.mutationFloor, evictedOwnerMutationFloor);
+  return record;
+}
+
+function setProfileMutationRevision(
+  record: PersistedMutationRecord,
+  profileId: string,
+  revision: number,
+): void {
+  record.profileRevisions.delete(profileId);
+  record.profileRevisions.set(profileId, revision);
+  while (record.profileRevisions.size > MAX_PERSISTED_MUTATION_PROFILES_PER_OWNER) {
+    const oldestProfileId = record.profileRevisions.keys().next().value;
+    if (oldestProfileId === undefined) {
+      break;
+    }
+    const oldestRevision = record.profileRevisions.get(oldestProfileId) ?? 0;
+    record.profileRevisions.delete(oldestProfileId);
+    record.mutationFloor = Math.max(record.mutationFloor, oldestRevision);
+  }
+}
+
+function getPersistedMutationRecord(ownerKey: string): PersistedMutationRecord | undefined {
+  return persistedMutationRecords.get(ownerKey);
+}
+
+export function recordRuntimeAuthProfileStorePersistedMutation(
+  ownerKey: string,
+  mutation: {
+    credentialsChanged: boolean;
+    profileSetChanged?: boolean;
+    stateChanged: boolean;
+    profileIds: Iterable<string>;
+  },
+): void {
+  persistedMutationRevision += 1;
+  const record = getOrCreatePersistedMutationRecord(ownerKey);
+  if (mutation.profileSetChanged) {
+    record.profileSetRevision = persistedMutationRevision;
+    record.profileSetRevisionKnown = true;
+  }
+  if (mutation.credentialsChanged) {
+    record.credentialRevision = persistedMutationRevision;
+    record.credentialRevisionKnown = true;
+    for (const profileId of mutation.profileIds) {
+      setProfileMutationRevision(record, profileId, persistedMutationRevision);
+    }
+  }
+  if (mutation.stateChanged) {
+    record.stateRevision = persistedMutationRevision;
+    record.stateRevisionKnown = true;
+  }
+}
+
+function combineMutationTokens(
+  tokens: RuntimeAuthProfileStoreMutationToken[],
+): RuntimeAuthProfileStoreMutationToken {
+  return {
+    revision: Math.max(0, ...tokens.map((token) => token.revision)),
+    known: tokens.every((token) => token.known),
+  };
+}
+
+/** Bounded persisted credential lineage; unknown means its exact token was evicted. */
+export function getRuntimeAuthProfileStoreCredentialMutationToken(
+  agentDir?: string,
+  profileId?: string,
+  options?: { includeMain?: boolean; owner?: RuntimeAuthProfileStoreMutationOwner },
+): RuntimeAuthProfileStoreMutationToken {
+  const requestedKey = options?.owner?.databasePath ?? resolveRuntimeStoreKey(agentDir);
+  if (!profileId) {
+    const record = getPersistedMutationRecord(requestedKey);
+    return record
+      ? { revision: record.credentialRevision, known: record.credentialRevisionKnown }
+      : { revision: evictedOwnerMutationFloor, known: evictedOwnerMutationFloor === 0 };
+  }
+  if (options?.includeMain && options.owner?.kind === "unresolved") {
+    return { revision: 0, known: false };
+  }
+  const mainKey = !options?.includeMain
+    ? requestedKey
+    : options.owner?.kind === "resolved"
+      ? options.owner.sharedDatabasePath
+      : resolveRuntimeStoreKey(undefined);
+  const keys =
+    requestedKey === mainKey || options?.includeMain !== true
+      ? [requestedKey]
+      : [requestedKey, mainKey];
+  return combineMutationTokens(
+    keys.map((key) => {
+      const record = getPersistedMutationRecord(key);
+      if (!record) {
+        return { revision: evictedOwnerMutationFloor, known: evictedOwnerMutationFloor === 0 };
+      }
+      const revision = record.profileRevisions.get(profileId);
+      return revision === undefined
+        ? { revision: record.mutationFloor, known: record.mutationFloor === 0 }
+        : { revision, known: true };
+    }),
+  );
+}
+
+/** Persisted token for profile-id additions and removals in one owner store. */
+export function getRuntimeAuthProfileStoreProfileSetMutationToken(
+  agentDir?: string,
+  databasePath?: string,
+): RuntimeAuthProfileStoreMutationToken {
+  const ownerKey = databasePath ?? resolveRuntimeStoreKey(agentDir);
+  const record = getPersistedMutationRecord(ownerKey);
+  return record
+    ? { revision: record.profileSetRevision, known: record.profileSetRevisionKnown }
+    : { revision: evictedOwnerMutationFloor, known: evictedOwnerMutationFloor === 0 };
+}
+
+/** Persisted mutation token for non-secret selection state in one owner store. */
+export function getRuntimeAuthProfileStoreStateMutationToken(
+  agentDir?: string,
+  options?: { includeMain?: boolean; owner?: RuntimeAuthProfileStoreMutationOwner },
+): RuntimeAuthProfileStoreMutationToken {
+  const requestedKey = options?.owner?.databasePath ?? resolveRuntimeStoreKey(agentDir);
+  if (options?.includeMain && options.owner?.kind === "unresolved") {
+    return { revision: 0, known: false };
+  }
+  const mainKey = !options?.includeMain
+    ? requestedKey
+    : options.owner?.kind === "resolved"
+      ? options.owner.sharedDatabasePath
+      : resolveRuntimeStoreKey(undefined);
+  const keys =
+    requestedKey === mainKey || options?.includeMain !== true
+      ? [requestedKey]
+      : [requestedKey, mainKey];
+  return combineMutationTokens(
+    keys.map((key) => {
+      const record = getPersistedMutationRecord(key);
+      return record
+        ? { revision: record.stateRevision, known: record.stateRevisionKnown }
+        : { revision: evictedOwnerMutationFloor, known: evictedOwnerMutationFloor === 0 };
+    }),
+  );
+}
+
+const testing = {
+  MAX_PERSISTED_MUTATION_OWNERS,
+  MAX_PERSISTED_MUTATION_PROFILES_PER_OWNER,
+  getPersistedMutationRecordCounts(): { owners: number; profiles: number } {
+    return {
+      owners: persistedMutationRecords.size,
+      profiles: Math.max(
+        0,
+        ...Array.from(persistedMutationRecords.values(), (record) => record.profileRevisions.size),
+      ),
+    };
+  },
+  resetPersistedMutationLineage(): void {
+    persistedMutationRecords.clear();
+    persistedMutationRevision = 0;
+    evictedOwnerMutationFloor = 0;
+  },
+};
+if (process.env.VITEST || process.env.NODE_ENV === "test") {
+  (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.runtimeAuthSnapshotsTestApi")] =
+    testing;
+}

--- a/src/agents/auth-profiles/mutation-lineage.ts
+++ b/src/agents/auth-profiles/mutation-lineage.ts
@@ -237,6 +237,7 @@ const testing = {
   },
 };
 if (process.env.VITEST || process.env.NODE_ENV === "test") {
+  // SAFETY: test-only publication; globalThis is written as an open symbol-keyed bag.
   (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.runtimeAuthSnapshotsTestApi")] =
     testing;
 }

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -16,6 +16,10 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import { withEnvAsync } from "../../test-utils/env.js";
 import { AUTH_STORE_VERSION } from "./constants.js";
 import { testing as externalAuthTesting } from "./external-auth.test-support.js";
+import {
+  getRuntimeAuthProfileStoreCredentialMutationToken,
+  getRuntimeAuthProfileStoreStateMutationToken,
+} from "./mutation-lineage.js";
 import { resolveApiKeyForProfile } from "./oauth.js";
 import { loadPersistedAuthProfileStore } from "./persisted.js";
 import {
@@ -34,9 +38,7 @@ import {
 import {
   clearRuntimeAuthProfileStoreSnapshots,
   getRuntimeAuthProfileStoreSnapshotCore as getInternalRuntimeAuthProfileStoreSnapshot,
-  getRuntimeAuthProfileStoreCredentialMutationToken,
   getRuntimeAuthProfileStoreCredentialsRevision,
-  getRuntimeAuthProfileStoreStateMutationToken,
   listOwnedRuntimeAuthProfileStoreSnapshots,
   replaceRuntimeAuthProfileStoreSnapshots,
 } from "./runtime-snapshots.js";

--- a/src/agents/auth-profiles/runtime-snapshots.test-support.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.test-support.ts
@@ -1,4 +1,4 @@
-import "./runtime-snapshots.js";
+import "./mutation-lineage.js";
 
 type RuntimeSnapshotsTestApi = {
   MAX_PERSISTED_MUTATION_OWNERS: number;

--- a/src/agents/auth-profiles/runtime-snapshots.test.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.test.ts
@@ -105,7 +105,9 @@ describe("runtime auth profile snapshots", () => {
         runtimeOwnerId: "codex",
       });
 
-      expect(listener).toHaveBeenCalledWith({ affectsInheritedStores: true });
+      expect(listener).toHaveBeenCalledWith({
+        affectsInheritedStores: true,
+      });
     } finally {
       unregister();
       clearRuntimeAuthProfileStoreSnapshots();
@@ -202,10 +204,12 @@ describe("runtime auth profile snapshots", () => {
       expect(listener).toHaveBeenNthCalledWith(1, {
         agentDir,
         affectsInheritedStores: false,
+        profileSetChanged: true,
       });
       expect(listener).toHaveBeenNthCalledWith(2, {
         agentDir,
         affectsInheritedStores: false,
+        profileSetChanged: true,
       });
     } finally {
       unregister();
@@ -233,6 +237,7 @@ describe("runtime auth profile snapshots", () => {
       expect(listener).toHaveBeenCalledOnce();
       expect(listener).toHaveBeenCalledWith({
         affectsInheritedStores: true,
+        profileSetChanged: false,
       });
     } finally {
       unregister();
@@ -263,7 +268,10 @@ describe("runtime auth profile snapshots", () => {
       ]);
 
       expect(listener).toHaveBeenCalledOnce();
-      expect(listener).toHaveBeenCalledWith({ affectsInheritedStores: true });
+      expect(listener).toHaveBeenCalledWith({
+        affectsInheritedStores: true,
+        profileSetChanged: false,
+      });
     } finally {
       unregister();
       clearRuntimeAuthProfileStoreSnapshots();
@@ -284,10 +292,12 @@ describe("runtime auth profile snapshots", () => {
       expect(listener).toHaveBeenNthCalledWith(1, {
         agentDir,
         affectsInheritedStores: false,
+        profileSetChanged: false,
       });
       expect(listener).toHaveBeenNthCalledWith(2, {
         agentDir,
         affectsInheritedStores: false,
+        profileSetChanged: false,
       });
     } finally {
       unregister();

--- a/src/agents/auth-profiles/runtime-snapshots.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.ts
@@ -49,6 +49,7 @@ function runtimeStoreEntries(): Array<[string, RuntimeAuthProfileStore]> {
 type RuntimeAuthProfileStoreMutationListener = (event: {
   agentDir?: string;
   affectsInheritedStores: boolean;
+  profileSetChanged: boolean;
 }) => void;
 const runtimeAuthStoreMutationListeners = new Set<RuntimeAuthProfileStoreMutationListener>();
 let runtimeAuthStoreCredentialsRevision = 0;
@@ -233,10 +234,11 @@ function resolveRuntimeSnapshotEntryKey(entry: {
   return entry.databasePath ?? resolveRuntimeStoreKey(entry.agentDir);
 }
 
-function notifyRuntimeAuthStoreMutation(agentDir?: string): void {
+function notifyRuntimeAuthStoreMutation(agentDir?: string, profileSetChanged = false): void {
   const event = {
     ...(agentDir ? { agentDir } : {}),
     affectsInheritedStores: agentDir === undefined,
+    profileSetChanged,
   };
   for (const listener of runtimeAuthStoreMutationListeners) {
     listener(event);
@@ -248,6 +250,16 @@ function authProfilesChanged(
   next: RuntimeAuthProfileStore | undefined,
 ): boolean {
   return !isDeepStrictEqual(previous?.profiles ?? {}, next?.profiles ?? {});
+}
+
+function authProfileSetChanged(
+  previous: RuntimeAuthProfileStore | undefined,
+  next: RuntimeAuthProfileStore | undefined,
+): boolean {
+  return !isDeepStrictEqual(
+    Object.keys(previous?.profiles ?? {}).toSorted(),
+    Object.keys(next?.profiles ?? {}).toSorted(),
+  );
 }
 
 /** Observes credential snapshot changes at their lifecycle publication edge. */
@@ -394,6 +406,9 @@ export function replaceOwnedRuntimeAuthProfileStoreSnapshots(
   const next = new Map(
     entries.map((entry) => [resolveRuntimeSnapshotEntryKey(entry), entry.store] as const),
   );
+  const profileSetChanged = [
+    ...new Set([...runtimeAuthStoreSnapshots.keys(), ...next.keys()]),
+  ].some((key) => authProfileSetChanged(runtimeAuthStoreSnapshots.get(key)?.store, next.get(key)));
   for (const key of new Set([...runtimeAuthStoreSnapshots.keys(), ...next.keys()])) {
     if (
       reboundKeys.has(key) ||
@@ -419,7 +434,7 @@ export function replaceOwnedRuntimeAuthProfileStoreSnapshots(
     runtimeAuthStoreSnapshots.set(key, entry);
   }
   if (ownerChanged) {
-    notifyRuntimeAuthStoreMutation();
+    notifyRuntimeAuthStoreMutation(undefined, profileSetChanged);
   }
 }
 
@@ -427,6 +442,9 @@ export function replaceOwnedRuntimeAuthProfileStoreSnapshots(
 export function clearRuntimeAuthProfileStoreSnapshots(): void {
   const snapshotsChanged = runtimeAuthStoreSnapshots.size > 0;
   const credentialsChanged = credentialState(runtimeStoreEntries()).length > 0;
+  const profileSetChanged = runtimeStoreEntries().some(
+    ([, store]) => Object.keys(store.profiles).length > 0,
+  );
   if (credentialsChanged) {
     runtimeAuthStoreCredentialsRevision += 1;
   }
@@ -439,7 +457,7 @@ export function clearRuntimeAuthProfileStoreSnapshots(): void {
   clearAllRuntimeAuthMaterializations();
   runtimeAuthStoreSnapshotRevisions.clear();
   if (snapshotsChanged) {
-    notifyRuntimeAuthStoreMutation();
+    notifyRuntimeAuthStoreMutation(undefined, profileSetChanged);
   }
 }
 
@@ -466,7 +484,7 @@ export function clearRuntimeAuthProfileStoreSnapshotAtDatabasePath(
   runtimeAuthStoreSnapshots.delete(key);
   clearRuntimeAuthMaterializationsAtDatabasePath(key);
   runtimeAuthStoreSnapshotRevisions.delete(key);
-  notifyRuntimeAuthStoreMutation(agentDir);
+  notifyRuntimeAuthStoreMutation(agentDir, Object.keys(store.profiles).length > 0);
   return true;
 }
 
@@ -492,6 +510,7 @@ function setRuntimeAuthProfileStoreSnapshotAtKey(
     runtimeAuthStoreCredentialsRevision += 1;
   }
   const previousStore = previous?.store;
+  const profileSetChanged = authProfileSetChanged(previousStore, store);
   if (sharedOwnerRebound || authProfilesChanged(previousStore, store)) {
     clearRuntimeAuthMaterializationsAtDatabasePath(key);
   }
@@ -508,7 +527,7 @@ function setRuntimeAuthProfileStoreSnapshotAtKey(
     legacyCandidates: cloneRuntimeAuthProfileLegacyCandidates(legacyCandidates),
   });
   if (ownerChanged) {
-    notifyRuntimeAuthStoreMutation(agentDir);
+    notifyRuntimeAuthStoreMutation(agentDir, profileSetChanged);
   }
 }
 
@@ -649,7 +668,7 @@ export function noteRuntimeAuthProfileStorePersistedMutation(
     advanceRuntimeAuthStoreSnapshotsRevision();
   }
   if (mutation.credentialsChanged || mutation.profileSetChanged) {
-    notifyRuntimeAuthStoreMutation(agentDir);
+    notifyRuntimeAuthStoreMutation(agentDir, mutation.profileSetChanged === true);
   }
 }
 

--- a/src/agents/auth-profiles/runtime-snapshots.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.ts
@@ -6,10 +6,10 @@ import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import { cloneAuthProfileStore } from "./clone.js";
 import {
-  captureAuthProfileOwnerScope,
-  resolveSharedAuthStorePath,
-  type AuthProfileOwnerScope,
-} from "./path-resolve.js";
+  recordRuntimeAuthProfileStorePersistedMutation,
+  resolveRuntimeStoreKey,
+} from "./mutation-lineage.js";
+import { captureAuthProfileOwnerScope } from "./path-resolve.js";
 import { mergeAuthProfileStores } from "./persisted.js";
 import {
   clearAllRuntimeAuthMaterializations,
@@ -30,7 +30,6 @@ import {
 } from "./runtime-snapshot-owner.js";
 import {
   closeAuthProfileReadPool,
-  resolveAuthProfileDatabasePath,
   type AuthProfileStoreOwner,
   type PreparedAuthProfileStoreOwner,
 } from "./sqlite.js";
@@ -57,10 +56,6 @@ let runtimeAuthStoreSnapshotsRevision = 0;
 // Per-store generations isolate rollback ownership; the global counter remains
 // the deletion generation for keys no longer present in this map.
 const runtimeAuthStoreSnapshotRevisions = new Map<string, number>();
-let persistedMutationRevision = 0;
-let evictedOwnerMutationFloor = 0;
-const MAX_PERSISTED_MUTATION_OWNERS = 256;
-const MAX_PERSISTED_MUTATION_PROFILES_PER_OWNER = 256;
 
 type RuntimeAuthProfileStoreSnapshotEntry = {
   databasePath?: string;
@@ -73,92 +68,10 @@ export {
   type OwnedRuntimeAuthProfileStoreSnapshotEntry,
 } from "./runtime-snapshot-owner.js";
 
-type PersistedMutationRecord = {
-  credentialRevision: number;
-  credentialRevisionKnown: boolean;
-  profileSetRevision: number;
-  profileSetRevisionKnown: boolean;
-  stateRevision: number;
-  stateRevisionKnown: boolean;
-  mutationFloor: number;
-  profileRevisions: Map<string, number>;
-};
-
-const persistedMutationRecords = new Map<string, PersistedMutationRecord>();
-
 function advanceRuntimeAuthStoreSnapshotsRevision(): void {
   // Readers must close before consumers can observe the new snapshot generation.
   closeAuthProfileReadPool();
   runtimeAuthStoreSnapshotsRevision += 1;
-}
-
-function maxMutationRevision(record: PersistedMutationRecord): number {
-  return Math.max(
-    record.credentialRevision,
-    record.profileSetRevision,
-    record.stateRevision,
-    record.mutationFloor,
-    ...record.profileRevisions.values(),
-  );
-}
-
-function getOrCreatePersistedMutationRecord(ownerKey: string): PersistedMutationRecord {
-  const existing = persistedMutationRecords.get(ownerKey);
-  if (existing) {
-    // Mutations, rather than reads, drive LRU recency so observation cannot
-    // retain dormant owners forever.
-    persistedMutationRecords.delete(ownerKey);
-    persistedMutationRecords.set(ownerKey, existing);
-    return existing;
-  }
-  const record: PersistedMutationRecord = {
-    credentialRevision: evictedOwnerMutationFloor,
-    credentialRevisionKnown: evictedOwnerMutationFloor === 0,
-    profileSetRevision: evictedOwnerMutationFloor,
-    profileSetRevisionKnown: evictedOwnerMutationFloor === 0,
-    stateRevision: evictedOwnerMutationFloor,
-    stateRevisionKnown: evictedOwnerMutationFloor === 0,
-    mutationFloor: evictedOwnerMutationFloor,
-    profileRevisions: new Map(),
-  };
-  persistedMutationRecords.set(ownerKey, record);
-  while (persistedMutationRecords.size > MAX_PERSISTED_MUTATION_OWNERS) {
-    const oldestOwnerKey = persistedMutationRecords.keys().next().value;
-    if (oldestOwnerKey === undefined) {
-      break;
-    }
-    const oldest = persistedMutationRecords.get(oldestOwnerKey);
-    persistedMutationRecords.delete(oldestOwnerKey);
-    if (oldest) {
-      // A floor trades false-positive rollback fences for bounded memory; it
-      // must never let an evicted persisted mutation look unchanged.
-      evictedOwnerMutationFloor = Math.max(evictedOwnerMutationFloor, maxMutationRevision(oldest));
-    }
-  }
-  record.mutationFloor = Math.max(record.mutationFloor, evictedOwnerMutationFloor);
-  return record;
-}
-
-function setProfileMutationRevision(
-  record: PersistedMutationRecord,
-  profileId: string,
-  revision: number,
-): void {
-  record.profileRevisions.delete(profileId);
-  record.profileRevisions.set(profileId, revision);
-  while (record.profileRevisions.size > MAX_PERSISTED_MUTATION_PROFILES_PER_OWNER) {
-    const oldestProfileId = record.profileRevisions.keys().next().value;
-    if (oldestProfileId === undefined) {
-      break;
-    }
-    const oldestRevision = record.profileRevisions.get(oldestProfileId) ?? 0;
-    record.profileRevisions.delete(oldestProfileId);
-    record.mutationFloor = Math.max(record.mutationFloor, oldestRevision);
-  }
-}
-
-function getPersistedMutationRecord(ownerKey: string): PersistedMutationRecord | undefined {
-  return persistedMutationRecords.get(ownerKey);
 }
 
 function snapshotOwnershipState(entries: Iterable<[string, OwnedRuntimeSnapshot]>) {
@@ -218,12 +131,6 @@ function recordChangedSnapshotRevisions(
     }
   }
   return changed;
-}
-
-// Runtime snapshots are keyed by the canonical database path so default-agent
-// and per-agent stores do not overwrite each other.
-function resolveRuntimeStoreKey(agentDir?: string): string {
-  return agentDir ? resolveAuthProfileDatabasePath(agentDir) : resolveSharedAuthStorePath();
 }
 
 function resolveRuntimeSnapshotEntryKey(entry: {
@@ -627,7 +534,6 @@ export function noteRuntimeAuthProfileStorePersistedMutation(
   if (!mutation.credentialsChanged && !mutation.profileSetChanged && !mutation.stateChanged) {
     return;
   }
-  persistedMutationRevision += 1;
   if (mutation.credentialsChanged) {
     runtimeAuthStoreCredentialsRevision += 1;
   }
@@ -635,22 +541,7 @@ export function noteRuntimeAuthProfileStorePersistedMutation(
   if (mutation.credentialsChanged || mutation.profileSetChanged) {
     clearRuntimeAuthMaterializationsAtDatabasePath(ownerKey);
   }
-  const record = getOrCreatePersistedMutationRecord(ownerKey);
-  if (mutation.profileSetChanged) {
-    record.profileSetRevision = persistedMutationRevision;
-    record.profileSetRevisionKnown = true;
-  }
-  if (mutation.credentialsChanged) {
-    record.credentialRevision = persistedMutationRevision;
-    record.credentialRevisionKnown = true;
-    for (const profileId of mutation.profileIds) {
-      setProfileMutationRevision(record, profileId, persistedMutationRevision);
-    }
-  }
-  if (mutation.stateChanged) {
-    record.stateRevision = persistedMutationRevision;
-    record.stateRevisionKnown = true;
-  }
+  recordRuntimeAuthProfileStorePersistedMutation(ownerKey, mutation);
   const mainKey = owner?.sharedDatabasePath ?? resolveRuntimeStoreKey(undefined);
   if (ownerKey !== mainKey || (!mutation.credentialsChanged && !mutation.profileSetChanged)) {
     return;
@@ -672,103 +563,6 @@ export function noteRuntimeAuthProfileStorePersistedMutation(
   }
 }
 
-export type RuntimeAuthProfileStoreMutationToken = {
-  revision: number;
-  known: boolean;
-};
-
-export type RuntimeAuthProfileStoreMutationOwner =
-  | { kind: "resolved"; databasePath: string; sharedDatabasePath: string }
-  | { kind: "unresolved"; databasePath: string; scope: AuthProfileOwnerScope };
-
-function combineMutationTokens(
-  tokens: RuntimeAuthProfileStoreMutationToken[],
-): RuntimeAuthProfileStoreMutationToken {
-  return {
-    revision: Math.max(0, ...tokens.map((token) => token.revision)),
-    known: tokens.every((token) => token.known),
-  };
-}
-
-/** Bounded persisted credential lineage; unknown means its exact token was evicted. */
-export function getRuntimeAuthProfileStoreCredentialMutationToken(
-  agentDir?: string,
-  profileId?: string,
-  options?: { includeMain?: boolean; owner?: RuntimeAuthProfileStoreMutationOwner },
-): RuntimeAuthProfileStoreMutationToken {
-  const requestedKey = options?.owner?.databasePath ?? resolveRuntimeStoreKey(agentDir);
-  if (!profileId) {
-    const record = getPersistedMutationRecord(requestedKey);
-    return record
-      ? { revision: record.credentialRevision, known: record.credentialRevisionKnown }
-      : { revision: evictedOwnerMutationFloor, known: evictedOwnerMutationFloor === 0 };
-  }
-  if (options?.includeMain && options.owner?.kind === "unresolved") {
-    return { revision: 0, known: false };
-  }
-  const mainKey = !options?.includeMain
-    ? requestedKey
-    : options.owner?.kind === "resolved"
-      ? options.owner.sharedDatabasePath
-      : resolveRuntimeStoreKey(undefined);
-  const keys =
-    requestedKey === mainKey || options?.includeMain !== true
-      ? [requestedKey]
-      : [requestedKey, mainKey];
-  return combineMutationTokens(
-    keys.map((key) => {
-      const record = getPersistedMutationRecord(key);
-      if (!record) {
-        return { revision: evictedOwnerMutationFloor, known: evictedOwnerMutationFloor === 0 };
-      }
-      const revision = record.profileRevisions.get(profileId);
-      return revision === undefined
-        ? { revision: record.mutationFloor, known: record.mutationFloor === 0 }
-        : { revision, known: true };
-    }),
-  );
-}
-
-/** Persisted token for profile-id additions and removals in one owner store. */
-export function getRuntimeAuthProfileStoreProfileSetMutationToken(
-  agentDir?: string,
-  databasePath?: string,
-): RuntimeAuthProfileStoreMutationToken {
-  const ownerKey = databasePath ?? resolveRuntimeStoreKey(agentDir);
-  const record = getPersistedMutationRecord(ownerKey);
-  return record
-    ? { revision: record.profileSetRevision, known: record.profileSetRevisionKnown }
-    : { revision: evictedOwnerMutationFloor, known: evictedOwnerMutationFloor === 0 };
-}
-
-/** Persisted mutation token for non-secret selection state in one owner store. */
-export function getRuntimeAuthProfileStoreStateMutationToken(
-  agentDir?: string,
-  options?: { includeMain?: boolean; owner?: RuntimeAuthProfileStoreMutationOwner },
-): RuntimeAuthProfileStoreMutationToken {
-  const requestedKey = options?.owner?.databasePath ?? resolveRuntimeStoreKey(agentDir);
-  if (options?.includeMain && options.owner?.kind === "unresolved") {
-    return { revision: 0, known: false };
-  }
-  const mainKey = !options?.includeMain
-    ? requestedKey
-    : options.owner?.kind === "resolved"
-      ? options.owner.sharedDatabasePath
-      : resolveRuntimeStoreKey(undefined);
-  const keys =
-    requestedKey === mainKey || options?.includeMain !== true
-      ? [requestedKey]
-      : [requestedKey, mainKey];
-  return combineMutationTokens(
-    keys.map((key) => {
-      const record = getPersistedMutationRecord(key);
-      return record
-        ? { revision: record.stateRevision, known: record.stateRevisionKnown }
-        : { revision: evictedOwnerMutationFloor, known: evictedOwnerMutationFloor === 0 };
-    }),
-  );
-}
-
 /** Stable token for credential ownership without coupling to usage bookkeeping. */
 export function getRuntimeAuthProfileStoreCredentialsRevision(): number {
   return runtimeAuthStoreCredentialsRevision;
@@ -784,27 +578,4 @@ export function getRuntimeAuthProfileStoreSnapshotRevisionAtDatabasePath(
   databasePath: string,
 ): number {
   return runtimeAuthStoreSnapshotRevisions.get(databasePath) ?? runtimeAuthStoreSnapshotsRevision;
-}
-
-const testing = {
-  MAX_PERSISTED_MUTATION_OWNERS,
-  MAX_PERSISTED_MUTATION_PROFILES_PER_OWNER,
-  getPersistedMutationRecordCounts(): { owners: number; profiles: number } {
-    return {
-      owners: persistedMutationRecords.size,
-      profiles: Math.max(
-        0,
-        ...Array.from(persistedMutationRecords.values(), (record) => record.profileRevisions.size),
-      ),
-    };
-  },
-  resetPersistedMutationLineage(): void {
-    persistedMutationRecords.clear();
-    persistedMutationRevision = 0;
-    evictedOwnerMutationFloor = 0;
-  },
-};
-if (process.env.VITEST || process.env.NODE_ENV === "test") {
-  (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.runtimeAuthSnapshotsTestApi")] =
-    testing;
 }

--- a/src/agents/auth-profiles/store-owner-publication.test.ts
+++ b/src/agents/auth-profiles/store-owner-publication.test.ts
@@ -10,10 +10,12 @@ import {
   AuthProfileMigrationRequiredError,
   markAuthProfileMigrationRequired,
 } from "./legacy-source-diagnostic.js";
-import { loadPersistedSharedAuthProfileStore } from "./persisted.js";
 import {
   getRuntimeAuthProfileStoreCredentialMutationToken,
   getRuntimeAuthProfileStoreStateMutationToken,
+} from "./mutation-lineage.js";
+import { loadPersistedSharedAuthProfileStore } from "./persisted.js";
+import {
   replaceRuntimeAuthProfileStoreSnapshots,
   setRuntimeAuthProfileStoreSnapshot,
 } from "./runtime-snapshots.js";

--- a/src/agents/prepared-model-catalog.test.ts
+++ b/src/agents/prepared-model-catalog.test.ts
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   loadSnapshot: vi.fn(),
   prepareSnapshot: vi.fn(),
   prepareScopedCatalog: vi.fn(),
+  refreshStaleCatalog: vi.fn(),
   isFullCatalog: vi.fn(),
   releaseSnapshot: vi.fn(),
 }));
@@ -52,6 +53,8 @@ vi.mock("./prepared-model-runtime.js", () => {
     preparedModelRuntimeConfigsMatch: (left: object, right: object) =>
       JSON.stringify(left) === JSON.stringify(right),
     prepareModelRuntimeSnapshot: (...args: unknown[]) => mocks.prepareSnapshot(...args),
+    refreshStalePreparedModelRuntimeCatalog: (...args: unknown[]) =>
+      mocks.refreshStaleCatalog(...args),
   };
 });
 
@@ -106,6 +109,7 @@ describe("prepared model catalog access", () => {
     mocks.loadSnapshot.mockReset();
     mocks.prepareSnapshot.mockReset();
     mocks.prepareScopedCatalog.mockReset();
+    mocks.refreshStaleCatalog.mockReset();
     mocks.isFullCatalog.mockReset();
     mocks.releaseSnapshot.mockReset();
   });
@@ -175,6 +179,31 @@ describe("prepared model catalog access", () => {
     expect(mocks.prepareSnapshot.mock.calls[0]?.[0]).not.toHaveProperty("readOnly");
     expect(mocks.loadSnapshot).not.toHaveBeenCalled();
     expect(mocks.releaseSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("refreshes stale catalog content during an explicit read-only load", async () => {
+    const staleCatalog = {
+      entries: [{ provider: "test", id: "fresh", name: "Fresh" }],
+      routeVariants: [],
+    };
+    const snapshot = {
+      ...fullSnapshot,
+      loadFullModelCatalog: vi.fn(),
+      readFullModelCatalog: vi.fn(() => fullSnapshot.modelCatalog),
+    };
+    mocks.getSnapshot.mockReturnValue(snapshot);
+    mocks.prepareSnapshot.mockResolvedValue(snapshot);
+    mocks.refreshStaleCatalog.mockResolvedValue(staleCatalog);
+    setPreparedModelFullCatalogAuth(staleCatalog, {
+      authStore: fullSnapshot.authStore,
+      authModes: fullSnapshot.authModes,
+    });
+
+    await expect(loadPreparedModelCatalogOwnerSnapshot({ readOnly: true })).resolves.toMatchObject({
+      modelCatalog: staleCatalog,
+    });
+    expect(mocks.refreshStaleCatalog).toHaveBeenCalledWith(snapshot);
+    expect(snapshot.readFullModelCatalog).not.toHaveBeenCalled();
   });
 
   it("reuses a published full generation for a provider-scoped read-only load", async () => {

--- a/src/agents/prepared-model-catalog.test.ts
+++ b/src/agents/prepared-model-catalog.test.ts
@@ -206,6 +206,26 @@ describe("prepared model catalog access", () => {
     expect(snapshot.readFullModelCatalog).not.toHaveBeenCalled();
   });
 
+  it("keeps auth-only reads on the current catalog facts", async () => {
+    const snapshot = {
+      ...fullSnapshot,
+      loadFullModelCatalog: vi.fn(),
+      readFullModelCatalog: vi.fn(() => fullSnapshot.modelCatalog),
+    };
+    mocks.getSnapshot.mockReturnValue(snapshot);
+    mocks.prepareSnapshot.mockResolvedValue(snapshot);
+    setPreparedModelFullCatalogAuth(snapshot.modelCatalog, {
+      authStore: fullSnapshot.authStore,
+      authModes: fullSnapshot.authModes,
+    });
+
+    await expect(
+      loadPreparedModelCatalogOwnerSnapshot({ readOnly: true, refreshFullCatalog: false }),
+    ).resolves.toMatchObject({ modelCatalog: fullSnapshot.modelCatalog });
+    expect(mocks.refreshStaleCatalog).not.toHaveBeenCalled();
+    expect(snapshot.readFullModelCatalog).toHaveBeenCalledOnce();
+  });
+
   it("reuses a published full generation for a provider-scoped read-only load", async () => {
     mocks.prepareSnapshot.mockResolvedValue(fullSnapshot);
     mocks.isFullCatalog.mockReturnValue(true);

--- a/src/agents/prepared-model-catalog.test.ts
+++ b/src/agents/prepared-model-catalog.test.ts
@@ -199,9 +199,9 @@ describe("prepared model catalog access", () => {
       authModes: fullSnapshot.authModes,
     });
 
-    await expect(loadPreparedModelCatalogOwnerSnapshot({ readOnly: true })).resolves.toMatchObject({
-      modelCatalog: staleCatalog,
-    });
+    await expect(
+      loadPreparedModelCatalogOwnerSnapshot({ readOnly: true, refreshFullCatalog: true }),
+    ).resolves.toMatchObject({ modelCatalog: staleCatalog });
     expect(mocks.refreshStaleCatalog).toHaveBeenCalledWith(snapshot);
     expect(snapshot.readFullModelCatalog).not.toHaveBeenCalled();
   });
@@ -224,6 +224,26 @@ describe("prepared model catalog access", () => {
     ).resolves.toMatchObject({ modelCatalog: fullSnapshot.modelCatalog });
     expect(mocks.refreshStaleCatalog).not.toHaveBeenCalled();
     expect(snapshot.readFullModelCatalog).toHaveBeenCalledOnce();
+  });
+
+  it("does not await a stale full catalog for read-only request paths", async () => {
+    const snapshot = {
+      ...fullSnapshot,
+      loadFullModelCatalog: vi.fn(),
+      readFullModelCatalog: vi.fn(() => fullSnapshot.modelCatalog),
+    };
+    mocks.getSnapshot.mockReturnValue(snapshot);
+    mocks.prepareSnapshot.mockResolvedValue(snapshot);
+    mocks.refreshStaleCatalog.mockRejectedValue(new Error("full discovery was awaited"));
+    setPreparedModelFullCatalogAuth(snapshot.modelCatalog, {
+      authStore: fullSnapshot.authStore,
+      authModes: fullSnapshot.authModes,
+    });
+
+    await expect(loadPreparedModelCatalogSnapshot({ readOnly: true })).resolves.toBe(
+      snapshot.modelCatalog,
+    );
+    expect(mocks.refreshStaleCatalog).not.toHaveBeenCalled();
   });
 
   it("reuses a published full generation for a provider-scoped read-only load", async () => {
@@ -319,6 +339,7 @@ describe("prepared model catalog access", () => {
       expect.objectContaining({ readOnly: true, workspaceDir: "/tmp/dynamic-workspace" }),
     );
     expect(mocks.releaseSnapshot).toHaveBeenCalledOnce();
+    expect(mocks.refreshStaleCatalog).not.toHaveBeenCalled();
   });
 
   it("rejects a full generation replaced with another config", async () => {

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -76,7 +76,7 @@ async function materializeRequestedModelCatalog(
     return snapshot;
   }
   const staleCatalog =
-    readOnly === true && refreshFullCatalog !== false
+    readOnly === true && refreshFullCatalog === true
       ? await refreshStalePreparedModelRuntimeCatalog(snapshot)
       : undefined;
   const modelCatalog =

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -31,6 +31,7 @@ import {
   prepareModelRuntimeSnapshot,
   PreparedModelRuntimeOwnerNotPublishedError,
   preparedModelRuntimeConfigsMatch,
+  refreshStalePreparedModelRuntimeCatalog,
   type PreparedModelRuntimeInput,
   type PreparedModelRuntimeSnapshot,
 } from "./prepared-model-runtime.js";
@@ -74,9 +75,11 @@ async function materializeRequestedModelCatalog(
   if (!snapshot.loadFullModelCatalog) {
     return snapshot;
   }
+  const staleCatalog =
+    readOnly === true ? await refreshStalePreparedModelRuntimeCatalog(snapshot) : undefined;
   const modelCatalog =
     readOnly === true
-      ? snapshot.readFullModelCatalog?.()
+      ? (staleCatalog ?? snapshot.readFullModelCatalog?.())
       : await snapshot.loadFullModelCatalog({ refresh: refreshFullCatalog === true });
   if (!modelCatalog) {
     return snapshot;

--- a/src/agents/prepared-model-catalog.ts
+++ b/src/agents/prepared-model-catalog.ts
@@ -76,7 +76,9 @@ async function materializeRequestedModelCatalog(
     return snapshot;
   }
   const staleCatalog =
-    readOnly === true ? await refreshStalePreparedModelRuntimeCatalog(snapshot) : undefined;
+    readOnly === true && refreshFullCatalog !== false
+      ? await refreshStalePreparedModelRuntimeCatalog(snapshot)
+      : undefined;
   const modelCatalog =
     readOnly === true
       ? (staleCatalog ?? snapshot.readFullModelCatalog?.())

--- a/src/agents/prepared-model-runtime-auth-publication.ts
+++ b/src/agents/prepared-model-runtime-auth-publication.ts
@@ -10,6 +10,7 @@ import type {
 export type PreparedModelRuntimeAuthMutation = {
   agentDir?: string;
   affectsInheritedStores: boolean;
+  profileSetChanged: boolean;
 };
 
 type PreparedModelRuntimeAuthTransaction = {

--- a/src/agents/prepared-model-runtime-auth-publication.ts
+++ b/src/agents/prepared-model-runtime-auth-publication.ts
@@ -17,6 +17,7 @@ type PreparedModelRuntimeAuthTransaction = {
   adoptedBy?: PreparedModelRuntimeReplacementGateId;
   ownerGates: Map<PreparedModelRuntimeOwner, Deferred<PreparedModelRuntimeSnapshot>>;
   publicationQueued: boolean;
+  profileSetChanged: boolean;
 };
 
 function partitionAuthMutationOwners(
@@ -49,6 +50,7 @@ export class PreparedModelRuntimeAuthPublicationOwner {
 
   enqueue(
     invalidatedOwners: readonly PreparedModelRuntimeOwner[],
+    profileSetChanged = false,
   ): PreparedModelRuntimeAuthTransaction {
     this.#events.push([...invalidatedOwners]);
     const transaction =
@@ -56,7 +58,9 @@ export class PreparedModelRuntimeAuthPublicationOwner {
       (this.#transaction = {
         ownerGates: new Map(),
         publicationQueued: false,
+        profileSetChanged: false,
       });
+    transaction.profileSetChanged ||= profileSetChanged;
     for (const owner of invalidatedOwners) {
       let gate = transaction.ownerGates.get(owner);
       if (!gate) {
@@ -213,6 +217,7 @@ export class PreparedModelRuntimeAuthPublicationOwner {
         owner: PreparedModelRuntimeOwner;
         input: PreparedModelRuntimeOwner["input"];
       }>,
+      includeCredentialProviders: boolean,
     ) => Promise<void>;
     publishOwners: (owners: readonly PreparedModelRuntimeOwner[]) => void;
     commit?: () => void;
@@ -226,7 +231,7 @@ export class PreparedModelRuntimeAuthPublicationOwner {
         );
         try {
           if (entries.length > 0) {
-            await params.publish(entries);
+            await params.publish(entries, this.#transaction?.profileSetChanged === true);
           }
           const transaction = this.#transaction;
           if (transaction) {

--- a/src/agents/prepared-model-runtime-materializations.test.ts
+++ b/src/agents/prepared-model-runtime-materializations.test.ts
@@ -37,6 +37,7 @@ function createOwner(params: {
     provenance: "configured",
     generation: 1,
     needsRefresh: params.needsRefresh === true,
+    catalogStale: false,
     snapshot,
   };
 }

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -297,6 +297,7 @@ async function buildSnapshotBatch(
   agentBuildCompletions: Map<string, Promise<void>>,
   pluginMetadataSnapshot?: PreparedModelRuntimePluginGeneration["pluginMetadataSnapshot"],
   onBuildStats?: (stats: PreparedModelRuntimeBuildStats) => void,
+  includeCredentialProviders = catalogMode === "live",
 ): Promise<PreparedModelRuntimeBuildResult[]> {
   const freshGroups = new Map<string, PreparedModelRuntimeBuildCandidate[]>();
   const reusableGroups = new Map<
@@ -365,7 +366,10 @@ async function buildSnapshotBatch(
     const prepared = await prepareWorkspaceBuildGroup(
       groupCandidates.map(({ input }) => input),
       catalogMode,
-      { preferBuiltPluginArtifacts },
+      {
+        preferBuiltPluginArtifacts,
+        includeCredentialProviders,
+      },
       prepareInboundPluginRegistry ? loadInboundPluginRegistry : undefined,
       pluginGeneration,
       pluginMetadataSnapshot,
@@ -568,6 +572,7 @@ export function startSerializedSnapshotBuildBatch(
   catalogMode: PreparedModelRuntimeCatalogMode = "live",
   onBuildStats?: (stats: PreparedModelRuntimeBuildStats) => void,
   pluginMetadataSnapshot?: PreparedModelRuntimePluginGeneration["pluginMetadataSnapshot"],
+  includeCredentialProviders = catalogMode === "live",
 ): {
   pending: Promise<PreparedModelRuntimeBuildResult[]>;
   completion: Promise<void>;
@@ -593,6 +598,7 @@ export function startSerializedSnapshotBuildBatch(
         agentBuildCompletions,
         pluginMetadataSnapshot,
         onBuildStats,
+        includeCredentialProviders,
       ),
     };
   })();

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -95,6 +95,7 @@ function prepareAgentFacts(
   catalogMode: PreparedModelRuntimeCatalogMode,
   ambientCredentials: Readonly<AgentCredentialMap>,
   additionalProviderIds: readonly string[] = [],
+  includeCredentialProviders = catalogMode === "live",
 ): PreparedModelRuntimeAgentBaseFacts {
   const env = input.env ?? process.env;
   const preparedStore = loadPreparedModelRuntimeAuthStore(input);
@@ -135,7 +136,7 @@ function prepareAgentFacts(
         ...collectPreparedModelRuntimeProviderIds(
           input.config,
           credentials,
-          catalogMode === "live",
+          includeCredentialProviders,
           rawConfiguredModelRefs,
           input.agentId,
         ),
@@ -155,6 +156,7 @@ export async function prepareWorkspaceBuildGroup(
   options: {
     providerDiscoveryProviderIds?: readonly string[];
     preferBuiltPluginArtifacts?: boolean;
+    includeCredentialProviders?: boolean;
   } = {},
   loadInboundPluginRegistry?: PreparedInboundRegistryLoader,
   reusablePluginGeneration?: PreparedModelRuntimePluginGeneration,
@@ -346,6 +348,7 @@ export async function prepareWorkspaceBuildGroup(
         catalogMode,
         ambientCredentials,
         options.providerDiscoveryProviderIds,
+        options.includeCredentialProviders,
       ),
     );
     const agentFactsMs = performance.now() - agentFactsStartedAt;

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -61,7 +61,7 @@ export function prepareModelRuntimeOwner(
 ): PreparedModelRuntimeOwner {
   // Preparation precedes async discovery: auth may supersede the first build, or a new
   // preparation whose previous snapshot is still attached. Neither snapshot owns these facts.
-  return Object.assign(existing ?? { generation: 0, needsRefresh: true }, {
+  return Object.assign(existing ?? { generation: 0, needsRefresh: true, catalogStale: false }, {
     input,
     catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),
     environmentFingerprint: effectiveEnvironmentFingerprint(input),
@@ -455,6 +455,7 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
   owners: Map<string, PreparedModelRuntimeOwner>;
   agentBuildCompletions: Map<string, Promise<void>>;
   buildTimeoutMs: number;
+  includeCredentialProviders?: boolean;
   isPublicationCurrent?: () => boolean;
   isBuildCurrent?: () => boolean;
   onBuildStats?: (stats: PreparedModelRuntimeBuildStats) => void;
@@ -539,6 +540,7 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
               catalogMode,
               params.onBuildStats,
               params.pluginMetadataSnapshot,
+              params.includeCredentialProviders,
             );
             for (const candidate of currentGroup) {
               if (params.registerEntriesAfterBuildStart === true) {

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -40,6 +40,25 @@ import type {
   PreparedModelRuntimeSnapshot,
 } from "./prepared-model-runtime.types.js";
 
+const ownersBySnapshot = new WeakMap<PreparedModelRuntimeSnapshot, PreparedModelRuntimeOwner>();
+
+export function resolvePreparedModelRuntimeOwnerBySnapshot(
+  snapshot: PreparedModelRuntimeSnapshot,
+): PreparedModelRuntimeOwner | undefined {
+  return ownersBySnapshot.get(snapshot);
+}
+
+function publishPreparedModelRuntimeOwnerSnapshot(
+  owner: PreparedModelRuntimeOwner,
+  snapshot: PreparedModelRuntimeSnapshot,
+): void {
+  if (owner.snapshot) {
+    ownersBySnapshot.delete(owner.snapshot);
+  }
+  owner.snapshot = snapshot;
+  ownersBySnapshot.set(snapshot, owner);
+}
+
 export type {
   PreparedModelRuntimeInput,
   PreparedModelRuntimeLease,
@@ -593,7 +612,7 @@ export async function publishPreparedModelRuntimeOwnerBatch(params: {
           result.snapshot,
           candidate.owner.input.config,
         );
-        candidate.owner.snapshot = snapshot;
+        publishPreparedModelRuntimeOwnerSnapshot(candidate.owner, snapshot);
         results.set(candidate.owner, { ...result, snapshot });
         candidate.owner.pluginGeneration = result.pluginGeneration;
         candidate.owner.needsRefresh = false;
@@ -664,7 +683,7 @@ export async function publishModelRuntimeSnapshot(
         );
       }
       const snapshot = stampPreparedModelRuntimeSnapshotConfig(result.snapshot, owner.input.config);
-      owner.snapshot = snapshot;
+      publishPreparedModelRuntimeOwnerSnapshot(owner, snapshot);
       owner.pluginGeneration = result.pluginGeneration;
       owner.pendingPluginGeneration = undefined;
       owner.pending = undefined;

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -14,6 +14,8 @@ import {
 import {
   acquireAgentRunPreparedModelRuntime,
   loadPublishedGatewayReplyDispatchRuntime,
+  prepareModelRuntimeSnapshot,
+  refreshStalePreparedModelRuntimeCatalog,
   registerPreparedModelRuntimePublicationListener,
   refreshPreparedModelRuntimeSnapshots,
 } from "./prepared-model-runtime.js";
@@ -26,6 +28,121 @@ describe("prepared model runtime reload auth adoption", () => {
   beforeEach(async () => {
     state = await createOpenClawTestState({ label: "prepared-model-runtime" });
     resetPreparedModelRuntimeHarness(state);
+  });
+
+  it("refreshes stale catalog content only when an explicit read requests it", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const model = {
+      provider: "catalog-refresh-fixture",
+      id: "authenticated-model",
+      name: "Authenticated model",
+      api: "openai-completions" as const,
+    };
+    mocks.runPreparedModelCatalogWorker.mockResolvedValue({
+      entries: [model],
+      routeVariants: [model],
+    });
+    const input = {
+      agentId: "default",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
+      config: {},
+    };
+
+    await refreshPreparedModelRuntimeSnapshots(input.config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+    mocks.buildPreparedModelCatalogSnapshot.mockClear();
+    expect((await prepareModelRuntimeSnapshot(input)).modelCatalog.entries).toEqual([]);
+
+    mocks.mutationListener?.({
+      agentDir: input.agentDir,
+      affectsInheritedStores: false,
+      profileSetChanged: true,
+    });
+
+    const published = await prepareModelRuntimeSnapshot(input);
+    expect(published).toMatchObject({
+      modelCatalog: { entries: [] },
+    });
+    expect(mocks.buildPreparedModelCatalogSnapshot).not.toHaveBeenCalled();
+    expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
+
+    await expect(refreshStalePreparedModelRuntimeCatalog(published)).resolves.toMatchObject({
+      entries: [model],
+    });
+    expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
+    await expect(refreshStalePreparedModelRuntimeCatalog(published)).resolves.toBeUndefined();
+  });
+
+  it("does not live-refresh a token rotation with the same profile set", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const input = {
+      agentId: "default",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
+      config: {},
+    };
+
+    await refreshPreparedModelRuntimeSnapshots(input.config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+    mocks.runPreparedModelCatalogWorker.mockClear();
+    mocks.mutationListener?.({
+      agentDir: input.agentDir,
+      affectsInheritedStores: false,
+      profileSetChanged: false,
+    });
+
+    await prepareModelRuntimeSnapshot(input);
+    expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
+  });
+
+  it("shares one live rebuild across concurrent stale catalog reads", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const model = {
+      provider: "catalog-refresh-fixture",
+      id: "concurrent-model",
+      name: "Concurrent model",
+      api: "openai-completions" as const,
+    };
+    const liveBuild = createDeferred<{
+      entries: Array<typeof model>;
+      routeVariants: Array<typeof model>;
+    }>();
+    mocks.runPreparedModelCatalogWorker.mockImplementation(() => liveBuild.promise);
+    const input = {
+      agentId: "default",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
+      config: {},
+    };
+
+    await refreshPreparedModelRuntimeSnapshots(input.config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+    mocks.mutationListener?.({
+      agentDir: input.agentDir,
+      affectsInheritedStores: false,
+      profileSetChanged: true,
+    });
+    const published = await prepareModelRuntimeSnapshot(input);
+    expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
+
+    const first = refreshStalePreparedModelRuntimeCatalog(published);
+    const second = refreshStalePreparedModelRuntimeCatalog(published);
+    await vi.waitFor(() => expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce());
+    liveBuild.resolve({ entries: [model], routeVariants: [model] });
+
+    const catalogs = await Promise.all([first, second]);
+    expect(catalogs).toHaveLength(2);
+    for (const catalog of catalogs) {
+      expect(catalog).toMatchObject({ entries: [model], routeVariants: [model] });
+    }
+    expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
   });
 
   it("commits auth invalidation inside the active lifecycle publication", async () => {

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -11,6 +11,7 @@ import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../test-utils/openclaw-test-state.js";
+import { loadPreparedModelCatalogOwnerSnapshot } from "./prepared-model-catalog.js";
 import {
   acquireAgentRunPreparedModelRuntime,
   loadPublishedGatewayReplyDispatchRuntime,
@@ -48,6 +49,10 @@ describe("prepared model runtime reload auth adoption", () => {
       inheritedAuthDir: state.agentDir("default"),
       config: {},
     };
+    const liveBuild = createDeferred<{
+      entries: Array<typeof model>;
+      routeVariants: Array<typeof model>;
+    }>();
 
     await refreshPreparedModelRuntimeSnapshots(input.config, {
       gatewayLifecycle: true,
@@ -73,11 +78,46 @@ describe("prepared model runtime reload auth adoption", () => {
     expect(mocks.buildPreparedModelCatalogSnapshot).not.toHaveBeenCalled();
     expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
 
-    await expect(refreshStalePreparedModelRuntimeCatalog(published)).resolves.toMatchObject({
-      entries: [model],
+    let requestReadSettled = false;
+    const requestRead = loadPreparedModelCatalogOwnerSnapshot({
+      ...input,
+      readOnly: true,
+    }).then(() => {
+      requestReadSettled = true;
     });
+    for (let i = 0; i < 5; i += 1) {
+      await Promise.resolve();
+    }
+    expect(requestReadSettled).toBe(true);
+    expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
+    await requestRead;
+
+    mocks.runPreparedModelCatalogWorker.mockImplementation(() => liveBuild.promise);
+    const explicitRefresh = refreshStalePreparedModelRuntimeCatalog(published);
+    await vi.waitFor(() => expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce());
+    liveBuild.resolve({ entries: [model], routeVariants: [model] });
+    await expect(explicitRefresh).resolves.toMatchObject({ entries: [model] });
     expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
     await expect(refreshStalePreparedModelRuntimeCatalog(published)).resolves.toBeUndefined();
+  });
+
+  it("does not refresh a catalog snapshot that is not owned by the runtime", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const input = {
+      agentId: "default",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
+      config: {},
+    };
+    await refreshPreparedModelRuntimeSnapshots(input.config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+    const published = await prepareModelRuntimeSnapshot(input);
+    const unowned = { ...published };
+
+    await expect(refreshStalePreparedModelRuntimeCatalog(unowned)).resolves.toBeUndefined();
+    expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
   });
 
   it("does not live-refresh a token rotation with the same profile set", async () => {

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -54,6 +54,7 @@ describe("prepared model runtime reload auth adoption", () => {
       catalogMode: "static",
     });
     mocks.buildPreparedModelCatalogSnapshot.mockClear();
+    mocks.createPreparedModelCatalogWorkerInput.mockClear();
     expect((await prepareModelRuntimeSnapshot(input)).modelCatalog.entries).toEqual([]);
 
     mocks.mutationListener?.({
@@ -66,6 +67,9 @@ describe("prepared model runtime reload auth adoption", () => {
     expect(published).toMatchObject({
       modelCatalog: { entries: [] },
     });
+    expect(
+      mocks.createPreparedModelCatalogWorkerInput.mock.calls.at(-1)?.[0].agentFacts.providerIds,
+    ).toContain("custom");
     expect(mocks.buildPreparedModelCatalogSnapshot).not.toHaveBeenCalled();
     expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
 
@@ -90,6 +94,7 @@ describe("prepared model runtime reload auth adoption", () => {
       catalogMode: "static",
     });
     mocks.runPreparedModelCatalogWorker.mockClear();
+    mocks.createPreparedModelCatalogWorkerInput.mockClear();
     mocks.mutationListener?.({
       agentDir: input.agentDir,
       affectsInheritedStores: false,
@@ -98,6 +103,9 @@ describe("prepared model runtime reload auth adoption", () => {
 
     await prepareModelRuntimeSnapshot(input);
     expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
+    expect(
+      mocks.createPreparedModelCatalogWorkerInput.mock.calls.at(-1)?.[0].agentFacts.providerIds,
+    ).toEqual([]);
   });
 
   it("shares one live rebuild across concurrent stale catalog reads", async () => {

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -85,18 +85,25 @@ describe("prepared model runtime reload auth adoption", () => {
     }).then(() => {
       requestReadSettled = true;
     });
+    mocks.runPreparedModelCatalogWorker.mockImplementation(() => liveBuild.promise);
     for (let i = 0; i < 5; i += 1) {
       await Promise.resolve();
     }
-    expect(requestReadSettled).toBe(true);
-    expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
-    await requestRead;
+    try {
+      expect(requestReadSettled).toBe(true);
+      expect(mocks.runPreparedModelCatalogWorker).not.toHaveBeenCalled();
+    } finally {
+      liveBuild.resolve({ entries: [model], routeVariants: [model] });
+      await requestRead;
+    }
 
-    mocks.runPreparedModelCatalogWorker.mockImplementation(() => liveBuild.promise);
-    const explicitRefresh = refreshStalePreparedModelRuntimeCatalog(published);
-    await vi.waitFor(() => expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce());
-    liveBuild.resolve({ entries: [model], routeVariants: [model] });
-    await expect(explicitRefresh).resolves.toMatchObject({ entries: [model] });
+    mocks.runPreparedModelCatalogWorker.mockResolvedValue({
+      entries: [model],
+      routeVariants: [model],
+    });
+    await expect(refreshStalePreparedModelRuntimeCatalog(published)).resolves.toMatchObject({
+      entries: [model],
+    });
     expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledOnce();
     await expect(refreshStalePreparedModelRuntimeCatalog(published)).resolves.toBeUndefined();
   });

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -1,6 +1,7 @@
 import { vi } from "vitest";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import type { OpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import type { AuthStorageData } from "./sessions/auth-storage.js";
 
 type LoadStaticCatalog =
@@ -65,10 +66,12 @@ const preparedModelRuntimeMocks = vi.hoisted(() => ({
     pluginCatalogs: [],
   })),
   prepareStaticCatalog: vi.fn(async (..._args: unknown[]) => ({ entries: [] })),
-  runPreparedModelCatalogWorker: vi.fn(async (..._args: unknown[]) => ({
-    entries: [],
-    routeVariants: [],
-  })),
+  runPreparedModelCatalogWorker: vi.fn(
+    async (..._args: unknown[]): Promise<ModelCatalogSnapshot> => ({
+      entries: [],
+      routeVariants: [],
+    }),
+  ),
   runtimeSyntheticAuthProviderRefs: [] as string[],
   resolveAmbientCredentials: vi.fn((..._args: unknown[]) => ({})),
   resolveStaticCatalogModel: vi.fn<StaticCatalogResolver>(() => undefined),

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -47,6 +47,19 @@ const preparedModelRuntimeMocks = vi.hoisted(() => ({
     entries: [],
     routeVariants: [],
   })),
+  createPreparedModelCatalogWorkerInput: vi.fn(
+    ({
+      agentFacts,
+    }: {
+      agentFacts: { input: unknown; authStore: unknown; providerIds: unknown };
+    }) => ({
+      kind: "catalog",
+      generationFingerprint: "test-generation",
+      input: agentFacts.input,
+      authStore: agentFacts.authStore,
+      providerIds: agentFacts.providerIds,
+    }),
+  ),
   configuredAgentIds: [] as string[],
   configuredAgentIdsError: undefined as Error | undefined,
   configuredAgentDirs: new Map<string, string>(),
@@ -102,21 +115,9 @@ vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
 }));
 
 vi.mock("./prepared-model-catalog-worker.js", () => ({
-  createPreparedModelCatalogWorkerInput: ({
-    agentFacts,
-  }: {
-    agentFacts: {
-      input: unknown;
-      authStore: unknown;
-      providerIds: unknown;
-    };
-  }) => ({
-    kind: "catalog",
-    generationFingerprint: "test-generation",
-    input: agentFacts.input,
-    authStore: agentFacts.authStore,
-    providerIds: agentFacts.providerIds,
-  }),
+  createPreparedModelCatalogWorkerInput: (
+    ...args: Parameters<typeof preparedModelRuntimeMocks.createPreparedModelCatalogWorkerInput>
+  ) => preparedModelRuntimeMocks.createPreparedModelCatalogWorkerInput(...args),
   createPreparedModelCatalogWorker: () => ({
     loadCatalog: (...args: unknown[]) =>
       preparedModelRuntimeMocks.runPreparedModelCatalogWorker(...args),
@@ -397,6 +398,7 @@ export function resetPreparedModelRuntimeHarness(state: OpenClawTestState): void
   preparedModelRuntimeMocks.buildPreparedModelCatalogSnapshot
     .mockReset()
     .mockResolvedValue({ entries: [], routeVariants: [] });
+  preparedModelRuntimeMocks.createPreparedModelCatalogWorkerInput.mockClear();
   preparedModelRuntimeMocks.discoverAuthStorage
     .mockReset()
     .mockImplementation(() => preparedModelRuntimeMocks.authStorage);

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -74,10 +74,18 @@ const preparedModelRuntimeMocks = vi.hoisted(() => ({
   resolveStaticCatalogModel: vi.fn<StaticCatalogResolver>(() => undefined),
   warn: vi.fn(),
   mutationListener: undefined as
-    | ((event: { agentDir?: string; affectsInheritedStores: boolean }) => void)
+    | ((event: {
+        agentDir?: string;
+        affectsInheritedStores: boolean;
+        profileSetChanged?: boolean;
+      }) => void)
     | undefined,
   mutationListeners: new Set<
-    (event: { agentDir?: string; affectsInheritedStores: boolean }) => void
+    (event: {
+      agentDir?: string;
+      affectsInheritedStores: boolean;
+      profileSetChanged?: boolean;
+    }) => void
   >(),
   materializationListeners: new Set<
     (event: { agentDir?: string; affectsInheritedStores: boolean }) => void
@@ -231,7 +239,11 @@ vi.mock("./auth-profiles/runtime-materializations.js", () => ({
   getPreparedRuntimeAuthMaterializations: () =>
     preparedModelRuntimeMocks.preparedAuthMaterializations,
   registerRuntimeAuthMaterializationMutationListener: (
-    listener: (event: { agentDir?: string; affectsInheritedStores: boolean }) => void,
+    listener: (event: {
+      agentDir?: string;
+      affectsInheritedStores: boolean;
+      profileSetChanged?: boolean;
+    }) => void,
   ) => {
     preparedModelRuntimeMocks.materializationListeners.add(listener);
     return () => preparedModelRuntimeMocks.materializationListeners.delete(listener);

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -29,6 +29,7 @@ import {
   publishPreparedModelRuntimeOwnerBatch,
   publishModelRuntimeSnapshot,
   rebindInputToCommittedConfiguredOwner,
+  resolvePreparedModelRuntimeOwnerBySnapshot,
   resolveConfiguredOwnerPublication,
   resolvePublishedOwner,
   type PreparedModelRuntimeOwner,
@@ -375,7 +376,7 @@ export async function prepareModelRuntimeSnapshot(
 export async function refreshStalePreparedModelRuntimeCatalog(
   snapshot: PreparedModelRuntimeSnapshot,
 ): Promise<ModelCatalogSnapshot | undefined> {
-  const owner = [...owners.values()].find((candidate) => candidate.snapshot === snapshot);
+  const owner = resolvePreparedModelRuntimeOwnerBySnapshot(snapshot);
   if (!owner?.catalogStale || !snapshot.loadFullModelCatalog) {
     return undefined;
   }
@@ -577,11 +578,11 @@ export function refreshPreparedModelRuntimeSnapshots(
     if (!isPublicationCurrent()) {
       return;
     }
-    await drainPendingAuthMutations({
+    await drainPendingAuthMutations(
       // The final queue check, dispatch rebuild, and replacement resolution are one synchronous
       // commit. A mutation before it is adopted; a mutation after it starts a new auth transaction.
-      commit: commitReplacement,
-    });
+      commitReplacement,
+    );
   }).then(commitReplacement, (error: unknown) => {
     const refreshError = toStringifiedError(error);
     rejectReplacement(refreshError);
@@ -598,27 +599,20 @@ function enqueuePreparedModelRuntimePublication(task: () => Promise<void>): Prom
   return publication;
 }
 
-async function drainPendingAuthMutations(
-  options: {
-    includeCredentialProviders?: boolean;
-    commit?: () => void;
-  } = {},
-): Promise<void> {
+async function drainPendingAuthMutations(commit?: () => void): Promise<void> {
   await authPublication.drain({
     owners,
-    publish: async (entries) =>
+    publish: async (entries, includeCredentialProviders) =>
       await publishPreparedModelRuntimeOwnerBatch({
         entries,
         owners,
         agentBuildCompletions,
         buildTimeoutMs: modelRuntimeBuildTimeoutMs,
-        ...(options.includeCredentialProviders
-          ? { includeCredentialProviders: options.includeCredentialProviders }
-          : {}),
+        ...(includeCredentialProviders ? { includeCredentialProviders: true } : {}),
         reusePluginGenerations: true,
       }),
     publishOwners: (publishedOwners) => replyDispatchPublication.replace(publishedOwners),
-    commit: options.commit,
+    commit,
     onOwnerFailure: (error) => {
       const refreshError = toStringifiedError(error);
       notifyPreparedModelRuntimePublication({ phase: "failed", error: refreshError });
@@ -660,7 +654,7 @@ function invalidateForAuthMutation(event: PreparedModelRuntimeAuthMutation): voi
     return;
   }
   replyDispatchPublication.remove(invalidatedConfiguredAgentIds);
-  const transaction = authPublication.enqueue(invalidatedOwners);
+  const transaction = authPublication.enqueue(invalidatedOwners, normalizedEvent.profileSetChanged);
   if (pendingModelRuntimeReplacement) {
     // The active config transaction drains this event before its atomic dispatch commit. Retire
     // the superseded build gate; queuing another task would make this commit depend on future work.
@@ -681,22 +675,19 @@ function invalidateForAuthMutation(event: PreparedModelRuntimeAuthMutation): voi
       authPublication.adoptTransaction(transaction, pendingModelRuntimeReplacement.gateId);
       return;
     }
-    await drainPendingAuthMutations({
+    await drainPendingAuthMutations(() => {
       // Admission waits on this publication, so it must rebuild static content only. A profile-set
       // change leaves a stale flag for the explicit catalog-read path to consume later.
-      includeCredentialProviders: true,
-      commit: () => {
-        if (pendingModelRuntimeReplacement) {
-          authPublication.adoptTransaction(transaction, pendingModelRuntimeReplacement.gateId);
-          return;
-        }
-        if (!authPublication.resolve(transaction, owners)) {
-          return;
-        }
-        if (configuredOwnersAreRequestVisible(owners)) {
-          notifyPreparedModelRuntimePublication({ phase: "published" });
-        }
-      },
+      if (pendingModelRuntimeReplacement) {
+        authPublication.adoptTransaction(transaction, pendingModelRuntimeReplacement.gateId);
+        return;
+      }
+      if (!authPublication.resolve(transaction, owners)) {
+        return;
+      }
+      if (configuredOwnersAreRequestVisible(owners)) {
+        notifyPreparedModelRuntimePublication({ phase: "published" });
+      }
     });
   });
   notifyPreparedModelRuntimePublication({ phase: "invalidated" });

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -4,6 +4,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { registerRuntimeAuthProfileStoreMutationListener } from "./auth-profiles/runtime-snapshots.js";
+import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import {
   PreparedModelRuntimeAuthPublicationOwner,
   type PreparedModelRuntimeAuthMutation,
@@ -370,6 +371,26 @@ export async function prepareModelRuntimeSnapshot(
   );
 }
 
+/** Refreshes stale inventory only for an explicit catalog read; turn admission remains static. */
+export async function refreshStalePreparedModelRuntimeCatalog(
+  snapshot: PreparedModelRuntimeSnapshot,
+): Promise<ModelCatalogSnapshot | undefined> {
+  const owner = [...owners.values()].find((candidate) => candidate.snapshot === snapshot);
+  if (!owner?.catalogStale || !snapshot.loadFullModelCatalog) {
+    return undefined;
+  }
+  const generation = owner.generation;
+  const catalog = await snapshot.loadFullModelCatalog({ refresh: true });
+  if (
+    owner.catalogStale &&
+    owner.generation === generation &&
+    owners.get(ownerKey(owner.input)) === owner
+  ) {
+    owner.catalogStale = false;
+  }
+  return catalog;
+}
+
 /** Invalidates every published generation before config/plugin runtime replacement. */
 export function markPreparedModelRuntimeSnapshotsStale(
   reason = "prepared model runtime owner is stale after config publication",
@@ -556,11 +577,11 @@ export function refreshPreparedModelRuntimeSnapshots(
     if (!isPublicationCurrent()) {
       return;
     }
-    await drainPendingAuthMutations(
+    await drainPendingAuthMutations({
       // The final queue check, dispatch rebuild, and replacement resolution are one synchronous
       // commit. A mutation before it is adopted; a mutation after it starts a new auth transaction.
-      commitReplacement,
-    );
+      commit: commitReplacement,
+    });
   }).then(commitReplacement, (error: unknown) => {
     const refreshError = toStringifiedError(error);
     rejectReplacement(refreshError);
@@ -577,7 +598,12 @@ function enqueuePreparedModelRuntimePublication(task: () => Promise<void>): Prom
   return publication;
 }
 
-async function drainPendingAuthMutations(commit?: () => void): Promise<void> {
+async function drainPendingAuthMutations(
+  options: {
+    includeCredentialProviders?: boolean;
+    commit?: () => void;
+  } = {},
+): Promise<void> {
   await authPublication.drain({
     owners,
     publish: async (entries) =>
@@ -586,10 +612,13 @@ async function drainPendingAuthMutations(commit?: () => void): Promise<void> {
         owners,
         agentBuildCompletions,
         buildTimeoutMs: modelRuntimeBuildTimeoutMs,
+        ...(options.includeCredentialProviders
+          ? { includeCredentialProviders: options.includeCredentialProviders }
+          : {}),
         reusePluginGenerations: true,
       }),
     publishOwners: (publishedOwners) => replyDispatchPublication.replace(publishedOwners),
-    commit,
+    commit: options.commit,
     onOwnerFailure: (error) => {
       const refreshError = toStringifiedError(error);
       notifyPreparedModelRuntimePublication({ phase: "failed", error: refreshError });
@@ -618,6 +647,9 @@ function invalidateForAuthMutation(event: PreparedModelRuntimeAuthMutation): voi
     owner.generation += 1;
     owner.needsRefresh = true;
     owner.refreshError = staleError;
+    if (normalizedEvent.profileSetChanged) {
+      owner.catalogStale = true;
+    }
     if (owner.provenance === "configured" && owner.input.agentId) {
       invalidatedConfiguredAgentIds.add(owner.input.agentId);
     }
@@ -649,17 +681,22 @@ function invalidateForAuthMutation(event: PreparedModelRuntimeAuthMutation): voi
       authPublication.adoptTransaction(transaction, pendingModelRuntimeReplacement.gateId);
       return;
     }
-    await drainPendingAuthMutations(() => {
-      if (pendingModelRuntimeReplacement) {
-        authPublication.adoptTransaction(transaction, pendingModelRuntimeReplacement.gateId);
-        return;
-      }
-      if (!authPublication.resolve(transaction, owners)) {
-        return;
-      }
-      if (configuredOwnersAreRequestVisible(owners)) {
-        notifyPreparedModelRuntimePublication({ phase: "published" });
-      }
+    await drainPendingAuthMutations({
+      // Admission waits on this publication, so it must rebuild static content only. A profile-set
+      // change leaves a stale flag for the explicit catalog-read path to consume later.
+      includeCredentialProviders: true,
+      commit: () => {
+        if (pendingModelRuntimeReplacement) {
+          authPublication.adoptTransaction(transaction, pendingModelRuntimeReplacement.gateId);
+          return;
+        }
+        if (!authPublication.resolve(transaction, owners)) {
+          return;
+        }
+        if (configuredOwnersAreRequestVisible(owners)) {
+          notifyPreparedModelRuntimePublication({ phase: "published" });
+        }
+      },
     });
   });
   notifyPreparedModelRuntimePublication({ phase: "invalidated" });

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -377,7 +377,12 @@ export async function refreshStalePreparedModelRuntimeCatalog(
   snapshot: PreparedModelRuntimeSnapshot,
 ): Promise<ModelCatalogSnapshot | undefined> {
   const owner = resolvePreparedModelRuntimeOwnerBySnapshot(snapshot);
-  if (!owner?.catalogStale || !snapshot.loadFullModelCatalog) {
+  if (
+    !owner ||
+    owners.get(ownerKey(owner.input)) !== owner ||
+    !owner.catalogStale ||
+    !snapshot.loadFullModelCatalog
+  ) {
     return undefined;
   }
   const generation = owner.generation;

--- a/src/agents/prepared-model-runtime.types.ts
+++ b/src/agents/prepared-model-runtime.types.ts
@@ -156,6 +156,7 @@ export type PreparedModelRuntimeOwner = {
   provenance: "configured" | "standalone" | "explicit" | "run" | "ephemeral";
   generation: number;
   needsRefresh: boolean;
+  catalogStale: boolean;
   refreshError?: Error;
   snapshot?: PreparedModelRuntimeSnapshot;
   pluginGeneration?: PreparedModelRuntimePluginGeneration;

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -330,6 +330,7 @@ describe("handleModelsCommand", () => {
     await handleModelsCommand(buildParams("/models"), true);
 
     expect(modelCatalogMocks.loadModelCatalog.mock.calls[0]?.[0]?.readOnly).toBe(true);
+    expect(modelCatalogMocks.loadModelCatalog.mock.calls[0]?.[0]?.refreshFullCatalog).toBe(true);
     const authCheckerParams = preparedAuthCheckerParams();
     expect(authCheckerParams?.allowPluginSyntheticAuth).toBe(false);
     expect(authCheckerParams?.discoverExternalCliAuth).toBe(false);

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -204,6 +204,7 @@ async function buildPreparedDataForConfig(
       preparedModelCatalog.loadPreparedModelCatalogSnapshot({
         config: cfg,
         readOnly,
+        refreshFullCatalog: true,
         ...(agentId ? { agentId, agentDir: resolveAgentDir(cfg, agentId) } : {}),
         ...(options.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
       }),

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -286,7 +286,7 @@ describe("loadListModelCatalogSnapshot", () => {
   it("opts the unscoped model list into stale catalog refresh", async () => {
     mocks.loadModelCatalogSnapshot.mockResolvedValue({ entries: [], routeVariants: [] });
 
-    await loadListModelCatalogSnapshot(createRowContext({}));
+    await loadListModelCatalogSnapshot(createRowContext({ authIndex }));
 
     expect(mocks.loadModelCatalogSnapshot).toHaveBeenCalledWith(
       expect.objectContaining({ readOnly: true, refreshFullCatalog: true }),

--- a/src/commands/models/list.rows.test.ts
+++ b/src/commands/models/list.rows.test.ts
@@ -39,6 +39,7 @@ import {
   appendConfiguredProviderRows,
   appendDiscoveredRows,
   appendPreparedModelCatalogRows,
+  loadListModelCatalogSnapshot,
   type RowBuilderContext,
 } from "./list.rows.js";
 
@@ -278,6 +279,18 @@ describe("appendPreparedModelCatalogRows", () => {
       configuredKeys: [],
     });
     expect(mocks.loadModelCatalogSnapshot).not.toHaveBeenCalled();
+  });
+});
+
+describe("loadListModelCatalogSnapshot", () => {
+  it("opts the unscoped model list into stale catalog refresh", async () => {
+    mocks.loadModelCatalogSnapshot.mockResolvedValue({ entries: [], routeVariants: [] });
+
+    await loadListModelCatalogSnapshot(createRowContext({}));
+
+    expect(mocks.loadModelCatalogSnapshot).toHaveBeenCalledWith(
+      expect.objectContaining({ readOnly: true, refreshFullCatalog: true }),
+    );
   });
 });
 

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -381,6 +381,7 @@ export async function loadListModelCatalogSnapshot(
     agentDir: context.agentDir,
     ...(workspaceDir ? { workspaceDir } : {}),
     readOnly: true,
+    refreshFullCatalog: true,
   });
 }
 

--- a/src/gateway/http-utils.model-override.test.ts
+++ b/src/gateway/http-utils.model-override.test.ts
@@ -54,4 +54,15 @@ describe("resolveOpenAiCompatModelOverride", () => {
       errorMessage: "Model 'claude-cli/opus' is not allowed for agent 'main'.",
     });
   });
+
+  it("reads the prepared catalog without requesting a full refresh", async () => {
+    await expect(
+      resolveOpenAiCompatModelOverride({
+        req: createReq({ "x-openclaw-model": "openai/gpt-5.4" }),
+        agentId: "main",
+        model: "openclaw",
+      }),
+    ).resolves.toEqual({ modelOverride: "openai/gpt-5.4" });
+    expect(loadGatewayModelCatalogMock).toHaveBeenCalledExactlyOnceWith();
+  });
 });

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -510,6 +510,35 @@ describe("models.authStatus", () => {
     );
   });
 
+  it("does not wait for full catalog discovery during auth status refresh", async () => {
+    let releaseDiscovery!: () => void;
+    const discovery = new Promise<void>((resolve) => {
+      releaseDiscovery = resolve;
+    });
+    mocks.loadDeferredCatalog.mockImplementation(async (_context, agentId, options) => {
+      const deferredOptions = requireRecord(options);
+      if (deferredOptions.refreshFullCatalog !== false) {
+        await discovery;
+      }
+      return createPreparedOwnerSnapshot(agentId);
+    });
+
+    const request = handler(createOptions({ refresh: true }));
+    try {
+      await expect(
+        Promise.race([
+          request.then(() => "replied" as const),
+          new Promise<"timed-out">((resolve) => {
+            setTimeout(() => resolve("timed-out"), 25);
+          }),
+        ]),
+      ).resolves.toBe("replied");
+    } finally {
+      releaseDiscovery();
+    }
+    await request;
+  });
+
   it("reports an unavailable prepared owner without failing the RPC or discovering credentials", async () => {
     mocks.readPreparedCatalog.mockResolvedValueOnce(undefined);
 

--- a/src/gateway/server-methods/models-auth-status.test.ts
+++ b/src/gateway/server-methods/models-auth-status.test.ts
@@ -527,7 +527,7 @@ describe("models.authStatus", () => {
     try {
       await expect(
         Promise.race([
-          request.then(() => "replied" as const),
+          Promise.resolve(request).then(() => "replied" as const),
           new Promise<"timed-out">((resolve) => {
             setTimeout(() => resolve("timed-out"), 25);
           }),

--- a/src/gateway/server-methods/models-auth-status.ts
+++ b/src/gateway/server-methods/models-auth-status.ts
@@ -559,6 +559,7 @@ export const modelsAuthStatusHandlers: GatewayRequestHandlers = {
             readOnly: true,
             authScope: resolveAuthRefreshScope(cfg),
             refreshAuth: true,
+            refreshFullCatalog: false,
           })
         : await readPreparedCatalog(context, scope.agentId);
       if (!preparedSnapshot) {

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -452,7 +452,7 @@ export async function prepareModelsListResult(
       loadedSnapshot = await loadDeferredCatalog(params.context, initialAgentId, {
         readOnly: loadedReadOnly,
         refreshAuth: refresh && loadedReadOnly,
-        ...(loadParams.refresh === true ? { refreshFullCatalog: true } : {}),
+        ...(!preparedOnly ? { refreshFullCatalog: true } : {}),
       });
       return loadedSnapshot;
     },
@@ -480,7 +480,7 @@ export async function prepareModelsListResult(
         fullSnapshot = await loadDeferredCatalog(params.context, escalationAgentId, {
           readOnly,
           refreshAuth: refresh && readOnly,
-          ...(refresh ? { refreshFullCatalog: true } : {}),
+          refreshFullCatalog: true,
         });
         return fullSnapshot;
       },

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -452,7 +452,7 @@ export async function prepareModelsListResult(
       loadedSnapshot = await loadDeferredCatalog(params.context, initialAgentId, {
         readOnly: loadedReadOnly,
         refreshAuth: refresh && loadedReadOnly,
-        refreshFullCatalog: loadParams.refresh === true,
+        ...(loadParams.refresh === true ? { refreshFullCatalog: true } : {}),
       });
       return loadedSnapshot;
     },
@@ -480,7 +480,7 @@ export async function prepareModelsListResult(
         fullSnapshot = await loadDeferredCatalog(params.context, escalationAgentId, {
           readOnly,
           refreshAuth: refresh && readOnly,
-          refreshFullCatalog: refresh,
+          ...(refresh ? { refreshFullCatalog: true } : {}),
         });
         return fullSnapshot;
       },

--- a/src/gateway/server-model-catalog.ts
+++ b/src/gateway/server-model-catalog.ts
@@ -80,7 +80,9 @@ async function loadGatewayModelCatalogOwnerSnapshot(
     ...(params?.agentDir ? { agentDir: params.agentDir } : {}),
     config: (params?.getConfig ?? getRuntimeConfig)(),
     readOnly: params?.readOnly !== false,
-    ...(params?.refreshFullCatalog ? { refreshFullCatalog: true } : {}),
+    ...(params?.refreshFullCatalog !== undefined
+      ? { refreshFullCatalog: params.refreshFullCatalog }
+      : {}),
     ...(params?.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
   });
   const owner = resolvePublishedModelCatalogOwner(candidate);

--- a/src/secrets/apply.test.ts
+++ b/src/secrets/apply.test.ts
@@ -6,10 +6,10 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { registerResolvedAgentDir } from "../agents/agent-dir-registry.js";
+import { getRuntimeAuthProfileStoreCredentialMutationToken } from "../agents/auth-profiles/mutation-lineage.js";
 import { noteCommittedSharedAuthStoreOwnership } from "../agents/auth-profiles/path-resolve.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
-  getRuntimeAuthProfileStoreCredentialMutationToken,
   replaceRuntimeAuthProfileStoreSnapshots,
 } from "../agents/auth-profiles/runtime-snapshots.js";
 import {

--- a/src/secrets/runtime-state.ts
+++ b/src/secrets/runtime-state.ts
@@ -1,21 +1,21 @@
 /** Holds active secrets runtime snapshots, refresh context, and cleanup hooks. */
 import { isDeepStrictEqual } from "node:util";
 import { AuthProfileMigrationRequiredError } from "../agents/auth-profiles/legacy-source-diagnostic.js";
+import {
+  getRuntimeAuthProfileStoreCredentialMutationToken,
+  getRuntimeAuthProfileStoreProfileSetMutationToken,
+  getRuntimeAuthProfileStoreStateMutationToken,
+  type RuntimeAuthProfileStoreMutationOwner,
+  type RuntimeAuthProfileStoreMutationToken,
+} from "../agents/auth-profiles/mutation-lineage.js";
 import { loadRuntimeAuthProfileOwnerSnapshot } from "../agents/auth-profiles/runtime-snapshot-owner.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
-  getRuntimeAuthProfileStoreCredentialMutationToken,
   getRuntimeAuthProfileStoreCredentialsRevision,
-  getRuntimeAuthProfileStoreProfileSetMutationToken,
-  getRuntimeAuthProfileStoreStateMutationToken,
   listOwnedRuntimeAuthProfileStoreSnapshots,
   replaceOwnedRuntimeAuthProfileStoreSnapshots,
 } from "../agents/auth-profiles/runtime-snapshots.js";
-import type {
-  OwnedRuntimeAuthProfileStoreSnapshotEntry,
-  RuntimeAuthProfileStoreMutationOwner,
-  RuntimeAuthProfileStoreMutationToken,
-} from "../agents/auth-profiles/runtime-snapshots.js";
+import type { OwnedRuntimeAuthProfileStoreSnapshotEntry } from "../agents/auth-profiles/runtime-snapshots.js";
 import type {
   AuthProfileCredential,
   AuthProfileStore,


### PR DESCRIPTION
## What Problem This Solves

After `openclaw models auth login` succeeds for a new provider, `/models` and `models.authStatus` keep serving the catalog that was discovered before the login. The provider's models do not appear until the gateway restarts or an unrelated full rebuild happens. The operator just proved the credential works and then sees no models from it — a silent non-outcome on the default path.

## Why This Change Was Made

The auth-mutation listener already fires when profiles change, but its publication rebuilds static content only, so credential-identity changes never refresh catalog content. The naive fix — live discovery inside the mutation publication — is forbidden by a shipped invariant: ordinary run admissions await the owner's pending publication and must stay static (see `fix(agents): default run admissions to static catalog`, 06c2dc7eb10). OAuth token rotations also fire the same listener frequently; they must never pay for provider discovery.

This change records the distinction where it is produced and moves the live work to the surface that asks for it:

- `saveAuthProfileStoreInTransaction` already computes whether the profile **set** changed (vs. a same-profile token refresh); that fact now travels on the runtime auth mutation event (`profileSetChanged`).
- Auth publication stays static-only in every case. A profile-set change additionally marks the affected owners' catalog content **stale** — a cheap recorded flag, no discovery, no blocking.
- Explicit read-only catalog reads (`/models`, `models.authStatus`, `openclaw models list`) consume the flag: one owner-local `loadFullModelCatalog({ refresh: true })`, shared by concurrent readers through the loader's existing single-flight pending promise, generation-checked before the flag clears.
- Token rotations carry `profileSetChanged: false` and touch nothing but the static credential projection — identical cost to current main.
- Turn admission continues to await only the static owner publication; chat latency is unchanged.

## User Impact

- Log in with a new provider → the next `/models` (any channel) or `openclaw models list` shows that provider's models, no gateway restart.
- Token refreshes (frequent, automatic) trigger zero discovery work — no new load on gateways that stay up for weeks.
- Chat admissions never wait on provider discovery; the static-admission invariant is preserved and now has explicit regression coverage.

## Evidence

- New regression suite `src/agents/prepared-model-runtime.reload-auth.test.ts`: profile-set change marks the owner stale and an explicit read returns live content; a token-rotation-shaped mutation triggers no live discovery; auth publication stays static even while stale; two concurrent stale reads share one rebuild.
- Producer coverage in `src/agents/auth-profiles/runtime-snapshots.test.ts` and `src/agents/auth-profiles/external-oauth.test.ts`: replacement/set/clear operations carry the correct `profileSetChanged` fact.
- Focused suites: 295 tests across prepared-runtime, catalog, owner, lifecycle, startup, and gateway-method suites pass; `git diff --check` clean.
- Production diff is +98/−26 (net +72): the stale-read owner boundary and the producer fact; the earlier live-publication plumbing was removed.


## ClawSweeper review response (head `b919d5b8a23`)

**P1 fixed — stale refresh no longer blocks request paths.** The previous head let any read-only prepared-catalog read trigger a stale full-catalog refresh, so an attachment admission or an HTTP model override could block on provider discovery. Refresh is now opt-in: it requires `readOnly === true` **and** an explicit `refreshFullCatalog === true` (`src/agents/prepared-model-catalog.ts:70-98`).

- Browse callers opt in explicitly: `/models` (`src/auto-reply/reply/commands-models.ts:199-210`), Control UI `models.list` (`src/gateway/server-methods/models-list-result.ts:431-456` and `:474-485`), unscoped `openclaw models list` (`src/commands/models/list.rows.ts:377-385`).
- Request paths never pass the flag: attachment admission (`src/gateway/session-utils-model.ts:498-510`), HTTP model override (`src/gateway/http-utils.ts:199-201`). `models.authStatus` stays static by design (`src/gateway/server-methods/models-auth-status.ts:557-564`); Control UI automatic reads use `preparedOnly: true` (`ui/src/lib/model-catalog-store.ts:206-215`).

**Regression coverage:** `src/agents/prepared-model-runtime.reload-auth.test.ts:34-108` marks the catalog stale, blocks the discovery worker, then proves the default read settles without calling it and that an explicit refresh does call it. Independently verified to fail on the pre-fix gate.

**Production LOC delta (judged):** raw `+412 / -282` = net +130 over `src/**`. Subtracting `prepared-model-runtime.test-harness.ts` (test support, net +17) gives a production net of **+113**. Of that, `mutation-lineage.ts` (+243) is a pure extraction out of `runtime-snapshots.ts` (−240), so judged growth after discounting the move is roughly **+110**, concentrated in `prepared-model-runtime.ts` (+35/−2) and `prepared-model-runtime.owner.ts` (+24/−3).

That growth is the fix, not overhead: before this PR the prepared catalog had **no staleness concept at all** — a provider login was invisible until a Gateway restart, with no visible outcome and no recorded reason. There is no existing owner to absorb a fact that did not exist. The two lines the P1 repair itself added are the explicit browse opt-in; collapsing the mutation-lineage extraction back would delete the persisted-mutation token ownership that `src/secrets/runtime-state.ts` consumes.

**Performance:** token refreshes (the frequent case) trigger zero discovery work — `includeCredentialProviders` is already conditional on `profileSetChanged` (`src/agents/prepared-model-runtime.ts:610-617`). Chat admission never waits on discovery, and that invariant now has explicit regression coverage.
