### PR TITLE
refactor(channels): simplify configured-channel presence

### DIFF
--- a/src/channels/config-presence.test.ts
+++ b/src/channels/config-presence.test.ts
@@ -2,7 +2,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { isChannelConfigMetadataKey } from "./config-metadata.js";
 import {
@@ -11,17 +11,21 @@ import {
   listPotentialConfiguredChannelPresenceSignals,
   listPotentialConfiguredChannelIds,
 } from "./config-presence.js";
+import * as persistedAuthState from "./plugins/persisted-auth-state.js";
 
 const tempDirs: string[] = [];
 
-const matrixPresenceOptions = {
-  channelIds: ["matrix"],
-  persistedAuthStateProbe: {
-    listChannelIds: () => ["matrix"],
-    hasState: ({ channelId, env }: { channelId: string; env?: NodeJS.ProcessEnv }) =>
+const matrixPresenceOptions = { channelIds: ["matrix"] };
+
+beforeEach(() => {
+  vi.spyOn(persistedAuthState, "listBundledChannelIdsWithPersistedAuthState").mockReturnValue([
+    "matrix",
+  ]);
+  vi.spyOn(persistedAuthState, "hasBundledChannelPersistedAuthState").mockImplementation(
+    ({ channelId, env }) =>
       channelId === "matrix" && Boolean(env?.OPENCLAW_STATE_DIR?.includes("persisted-matrix")),
-  },
-};
+  );
+});
 
 function makeTempStateDir() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-channel-config-presence-"));
@@ -42,6 +46,7 @@ function expectPotentialConfiguredChannelCase(params: {
 }
 
 afterEach(() => {
+  vi.restoreAllMocks();
   while (tempDirs.length > 0) {
     const dir = tempDirs.pop();
     if (dir) {
@@ -154,12 +159,7 @@ describe("config presence", () => {
       cfg: {},
       env,
       expectedIds: ["matrix"],
-      options: {
-        persistedAuthStateProbe: {
-          listChannelIds: () => ["matrix"],
-          hasState: () => true,
-        },
-      },
+      options: {},
     });
   });
 });

--- a/src/channels/config-presence.ts
+++ b/src/channels/config-presence.ts
@@ -29,14 +29,6 @@ type ChannelPresenceOptions = {
   discovery?: PluginDiscoveryResult;
   includePersistedAuthState?: boolean;
   ambientEnvTriggers?: AmbientEnvTriggerPolicy;
-  persistedAuthStateProbe?: {
-    listChannelIds: () => readonly string[];
-    hasState: (params: {
-      channelId: string;
-      cfg: OpenClawConfig;
-      env: NodeJS.ProcessEnv;
-    }) => boolean;
-  };
 };
 
 /** Source that made a channel look potentially configured. */
@@ -85,31 +77,6 @@ function hasPersistedChannelState(env: NodeJS.ProcessEnv): boolean {
   return fs.existsSync(resolveStateDir(env, os.homedir));
 }
 
-function listPersistedAuthStateChannelIds(options: ChannelPresenceOptions): readonly string[] {
-  return (
-    options.persistedAuthStateProbe?.listChannelIds() ??
-    listBundledChannelIdsWithPersistedAuthState(options.discovery)
-  );
-}
-
-function hasPersistedAuthState(params: {
-  channelId: string;
-  cfg: OpenClawConfig;
-  env: NodeJS.ProcessEnv;
-  options: ChannelPresenceOptions;
-}): boolean {
-  const override = params.options.persistedAuthStateProbe;
-  if (override) {
-    return override.hasState(params);
-  }
-  return hasBundledChannelPersistedAuthState({
-    channelId: params.channelId,
-    cfg: params.cfg,
-    env: params.env,
-    discovery: params.options.discovery,
-  });
-}
-
 /** Lists channel ids detected from config, env vars, or persisted auth state. */
 export function listPotentialConfiguredChannelIds(
   cfg: OpenClawConfig,
@@ -131,7 +98,6 @@ export function listPotentialConfiguredChannelPresenceSignals(
 ): ChannelPresenceSignal[] {
   const signals: ChannelPresenceSignal[] = [];
   const seenSignals = new Set<string>();
-  const configuredChannelIds = new Set<string>();
   const addSignal = (rawChannelId: string, source: ChannelPresenceSignalSource) => {
     const channelId = rawChannelId.trim();
     if (!channelId || isChannelConfigMetadataKey(channelId)) {
@@ -142,7 +108,6 @@ export function listPotentialConfiguredChannelPresenceSignals(
       return;
     }
     seenSignals.add(key);
-    configuredChannelIds.add(channelId);
     signals.push({ channelId, source });
   };
   const channelIds = options.channelIds ?? listBundledChannelIds(env, options.discovery);
@@ -192,12 +157,19 @@ export function listPotentialConfiguredChannelPresenceSignals(
   if (options.includePersistedAuthState !== false && hasPersistedChannelState(env)) {
     // Persisted auth can make a channel usable even when config/env is empty, but only probe it
     // when the state directory exists to keep startup/status checks cheap.
-    for (const channelId of listPersistedAuthStateChannelIds(options)) {
-      if (hasPersistedAuthState({ channelId, cfg, env, options })) {
+    for (const channelId of listBundledChannelIdsWithPersistedAuthState(options.discovery)) {
+      if (
+        hasBundledChannelPersistedAuthState({
+          channelId,
+          cfg,
+          env,
+          discovery: options.discovery,
+        })
+      ) {
         addSignal(channelId, "persisted-auth");
       }
     }
   }
 
-  return signals.filter((signal) => configuredChannelIds.has(signal.channelId));
+  return signals;
 }


### PR DESCRIPTION
## What Problem This Solves

Configured-channel discovery carried a private test override and forwarding helpers around the canonical persisted-auth probes. A second local collection then rechecked signals that the same function had just added, obscuring the ownership of channel-presence decisions.

## Why This Change Was Made

Call the canonical probes directly and return the already-deduplicated signals. Keep state-directory gating, discovery and environment forwarding, signal order, and the distinction between persisted-auth discovery and plugin activation unchanged. Tests spy on the canonical module instead of exposing a production-only test seam.

## User Impact

No intended user-visible behavior change or public SDK/configuration/storage/schema change. Production: +10/-38 (net -28); tests: +14/-14 (net 0); whole: +24/-52 (net -28). All seven owner cases and assertions remain, including the empty-options persisted-auth case.

## Evidence

- Baseline and candidate each passed the same 50 cases across channel presence, persisted-auth probes, package probes, configured state, and effective plugin selection. Case multiplicity and within-suite order matched.
- All 29 selected changed checks and the normal 14-stage build passed.
- Precommit and separate exact-commit Codex reviews were P0-scoped clean; the latter reviewed signed commit `bd20b1267f4ff78021cba65fbf7e3c2243edf7fd`. Each used two complete evidence batches. The oversized unchanged lockfile was omitted under the normal evidence cap; second-batch live process identities were not independently captured, with cleanup owned by the canonical helper.

This is green/green refactor characterization, not live channel/provider, credential-serialization or SQLite-recovery proof. Historical raw-index and disposed compiler-manifest custody gaps remain documented; no independent historical compiled-byte equivalence is claimed. All 54 captured Channel contexts are unchanged through fetched main `57a7e86f8d06fde46f2a080f4bf02acb39f9f959`. Exact-head CI run `33423746236` and required `openclaw/ci-gate` check `99597136929` for `bd20b1267f4ff78021cba65fbf7e3c2243edf7fd` are successful and less than 24 hours old at this verification. The latest completed ClawSweeper review, completed at 09:26 UTC, has no source findings; its CI rank-up is addressed by those results. Mandatory native hosted prepare and merge remain pending.
