### PR TITLE
fix(release): scope frozen upgrade baselines

### DIFF
--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -691,6 +691,7 @@ jobs:
             BASELINE_SPEC="$(pnpm --dir workflow exec node --import tsx scripts/lib/release-upgrade-baseline.mts \
               --candidate-version "$(jq -er '.candidateVersion' "$CANDIDATE_JSON")" \
               --target-context-ref "$INPUT_TARGET_CONTEXT_REF" \
+              --previous-version "$INPUT_PREVIOUS_VERSION" \
               --versions-json "$PUBLISHED_VERSIONS")"
           elif [[ -n "${INPUT_PREVIOUS_VERSION}" ]]; then
             BASELINE_SPEC="openclaw@${INPUT_PREVIOUS_VERSION}"

--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -8,6 +8,11 @@ on:
         required: true
         default: main
         type: string
+      target_context_ref:
+        description: Optional canonical release branch or tag context for an exact-SHA target
+        required: false
+        default: ""
+        type: string
       workflow_ref:
         description: Optional openclaw/openclaw ref that provides the reusable workflow harness
         required: false
@@ -126,6 +131,11 @@ on:
       ref:
         description: Public OpenClaw ref to validate (tag, branch, or full commit SHA)
         required: true
+        type: string
+      target_context_ref:
+        description: Optional canonical release branch or tag context for an exact-SHA target
+        required: false
+        default: ""
         type: string
       workflow_ref:
         description: Optional openclaw/openclaw ref that provides the reusable workflow harness
@@ -670,14 +680,25 @@ jobs:
         id: baseline
         env:
           INPUT_PREVIOUS_VERSION: ${{ inputs.previous_version }}
+          INPUT_TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
+          CANDIDATE_JSON: ${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/candidate.json
         run: |
           set -euo pipefail
-          if [[ -n "${INPUT_PREVIOUS_VERSION}" ]]; then
-            echo "value=openclaw@${INPUT_PREVIOUS_VERSION}" >> "$GITHUB_OUTPUT"
-            exit 0
+          if [[ "$INPUT_TARGET_CONTEXT_REF" == "extended-stable/"* ||
+                "$INPUT_TARGET_CONTEXT_REF" == "refs/heads/extended-stable/"* ]]; then
+            PUBLISHED_VERSIONS="$RUNNER_TEMP/openclaw-published-versions.json"
+            npm view openclaw versions --json > "$PUBLISHED_VERSIONS"
+            BASELINE_SPEC="$(pnpm --dir workflow exec node --import tsx scripts/lib/release-upgrade-baseline.mts \
+              --candidate-version "$(jq -er '.candidateVersion' "$CANDIDATE_JSON")" \
+              --target-context-ref "$INPUT_TARGET_CONTEXT_REF" \
+              --versions-json "$PUBLISHED_VERSIONS")"
+          elif [[ -n "${INPUT_PREVIOUS_VERSION}" ]]; then
+            BASELINE_SPEC="openclaw@${INPUT_PREVIOUS_VERSION}"
+          else
+            BASELINE_VERSION="$(npm view openclaw@latest version)"
+            BASELINE_SPEC="openclaw@${BASELINE_VERSION}"
           fi
-          BASELINE_VERSION="$(npm view openclaw@latest version)"
-          echo "value=openclaw@${BASELINE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "value=${BASELINE_SPEC}" >> "$GITHUB_OUTPUT"
 
       - name: Pack baseline artifact
         if: ${{ inputs.mode != 'fresh' }}

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -1233,6 +1233,7 @@ jobs:
     with:
       advisory: ${{ startsWith(github.ref, 'refs/heads/tideclaw/alpha/') }}
       ref: ${{ needs.resolve_target.outputs.revision }}
+      target_context_ref: ${{ inputs.target_context_ref }}
       provider: ${{ needs.resolve_target.outputs.provider }}
       mode: ${{ needs.resolve_target.outputs.mode }}
       suite_filter: ${{ needs.resolve_target.outputs.cross_os_suite_filter }}

--- a/scripts/lib/release-upgrade-baseline.mts
+++ b/scripts/lib/release-upgrade-baseline.mts
@@ -29,12 +29,28 @@ function normalizePublishedVersions(publishedVersions: readonly unknown[]) {
 }
 
 type FrozenExtendedStableUpgradeContext = {
+  previousVersion?: unknown;
   targetContextRef: unknown;
 };
 
 function normalizeTargetContextRef(value: unknown) {
   const raw = normalizeStringifiedOptionalString(value) ?? "";
   return raw.replace(/^refs\/heads\//u, "");
+}
+
+function isEarlierFinalSameExtendedStableLine(params: {
+  baseline: ReturnType<typeof parseVersion>;
+  candidate: NonNullable<ReturnType<typeof parseVersion>>;
+}) {
+  const { baseline, candidate } = params;
+  return (
+    baseline?.channel === "stable" &&
+    baseline.correctionNumber === undefined &&
+    baseline.year === candidate.year &&
+    baseline.month === candidate.month &&
+    baseline.patch >= 33 &&
+    compareOpenClawVersions(baseline.version, candidate.version) < 0
+  );
 }
 
 /**
@@ -72,17 +88,28 @@ export function resolveFrozenExtendedStableUpgradeBaseline(
     );
   }
 
-  const baseline = normalizePublishedVersions(publishedVersions).find((version) => {
-    const parsed = parseVersion(version);
-    return (
-      parsed?.channel === "stable" &&
-      parsed.correctionNumber === undefined &&
-      parsed.year === candidate.year &&
-      parsed.month === candidate.month &&
-      parsed.patch >= 33 &&
-      compareOpenClawVersions(version, candidate.version) < 0
-    );
-  });
+  const published = normalizePublishedVersions(publishedVersions);
+  const requestedBaseline = parseVersion(
+    normalizeStringifiedOptionalString(context.previousVersion) ?? "",
+  );
+  if (context.previousVersion !== undefined && !requestedBaseline) {
+    throw new Error("previous_version must be a final published extended-stable predecessor");
+  }
+  if (requestedBaseline) {
+    if (
+      !isEarlierFinalSameExtendedStableLine({ baseline: requestedBaseline, candidate }) ||
+      !published.includes(requestedBaseline.version)
+    ) {
+      throw new Error(
+        `previous_version ${requestedBaseline.version} is not a published final predecessor of ${candidate.version} on ${targetContextRef}`,
+      );
+    }
+    return `openclaw@${requestedBaseline.version}`;
+  }
+
+  const baseline = published.find((version) =>
+    isEarlierFinalSameExtendedStableLine({ baseline: parseVersion(version), candidate }),
+  );
   if (!baseline) {
     throw new Error(
       `no published final extended-stable baseline predates candidate ${candidate.version} on ${targetContextRef}`,
@@ -172,8 +199,10 @@ if (isMain) {
   }
   const publishedVersions = readPublishedVersions(args);
   const targetContextRef = args.get("target-context-ref");
+  const previousVersion = args.get("previous-version");
   const baseline = targetContextRef
     ? resolveFrozenExtendedStableUpgradeBaseline(candidateVersion, publishedVersions, {
+        ...(previousVersion ? { previousVersion } : {}),
         targetContextRef,
       })
     : resolveDefaultReleaseUpgradeBaseline(candidateVersion, publishedVersions);

--- a/scripts/lib/release-upgrade-baseline.mts
+++ b/scripts/lib/release-upgrade-baseline.mts
@@ -28,6 +28,69 @@ function normalizePublishedVersions(publishedVersions: readonly unknown[]) {
     .toSorted((left, right) => compareOpenClawVersions(right, left));
 }
 
+type FrozenExtendedStableUpgradeContext = {
+  targetContextRef: unknown;
+};
+
+function normalizeTargetContextRef(value: unknown) {
+  const raw = normalizeStringifiedOptionalString(value) ?? "";
+  return raw.replace(/^refs\/heads\//u, "");
+}
+
+/**
+ * Frozen extended-stable validation must upgrade from an earlier release in
+ * the same line. A current latest install can have a newer SQLite schema.
+ */
+export function resolveFrozenExtendedStableUpgradeBaseline(
+  candidateVersion: unknown,
+  publishedVersions: readonly unknown[],
+  context: FrozenExtendedStableUpgradeContext,
+) {
+  const targetContextRef = normalizeTargetContextRef(context.targetContextRef);
+  if (!targetContextRef.startsWith("extended-stable/")) {
+    return undefined;
+  }
+
+  const line = /^extended-stable\/(?<year>\d{4})\.(?<month>[1-9]\d?)\.33$/u.exec(
+    targetContextRef,
+  )?.groups;
+  if (!line) {
+    throw new Error(`invalid frozen extended-stable context: ${targetContextRef}`);
+  }
+
+  const candidate = parseVersion(candidateVersion);
+  if (
+    !candidate ||
+    candidate.channel !== "stable" ||
+    candidate.correctionNumber !== undefined ||
+    candidate.year !== Number(line.year) ||
+    candidate.month !== Number(line.month) ||
+    candidate.patch < 33
+  ) {
+    throw new Error(
+      `candidate ${normalizeStringifiedOptionalString(candidateVersion) ?? ""} is incompatible with frozen extended-stable context ${targetContextRef}`,
+    );
+  }
+
+  const baseline = normalizePublishedVersions(publishedVersions).find((version) => {
+    const parsed = parseVersion(version);
+    return (
+      parsed?.channel === "stable" &&
+      parsed.correctionNumber === undefined &&
+      parsed.year === candidate.year &&
+      parsed.month === candidate.month &&
+      parsed.patch >= 33 &&
+      compareOpenClawVersions(version, candidate.version) < 0
+    );
+  });
+  if (!baseline) {
+    throw new Error(
+      `no published final extended-stable baseline predates candidate ${candidate.version} on ${targetContextRef}`,
+    );
+  }
+  return `openclaw@${baseline}`;
+}
+
 export function resolveDefaultReleaseUpgradeBaseline(
   candidateVersion: unknown,
   publishedVersions: readonly unknown[],
@@ -107,9 +170,15 @@ if (isMain) {
   if (!candidateVersion) {
     throw new Error("--candidate-version is required");
   }
-  const baseline = resolveDefaultReleaseUpgradeBaseline(
-    candidateVersion,
-    readPublishedVersions(args),
-  );
+  const publishedVersions = readPublishedVersions(args);
+  const targetContextRef = args.get("target-context-ref");
+  const baseline = targetContextRef
+    ? resolveFrozenExtendedStableUpgradeBaseline(candidateVersion, publishedVersions, {
+        targetContextRef,
+      })
+    : resolveDefaultReleaseUpgradeBaseline(candidateVersion, publishedVersions);
+  if (!baseline) {
+    throw new Error("target-context-ref does not identify a frozen extended-stable release");
+  }
   process.stdout.write(`${baseline}\n`);
 }

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -111,12 +111,14 @@ describe("cross-OS release checks workflow", () => {
     });
     expect(baseline.env).toMatchObject({
       CANDIDATE_JSON: "${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/candidate.json",
+      INPUT_PREVIOUS_VERSION: "${{ inputs.previous_version }}",
       INPUT_TARGET_CONTEXT_REF: "${{ inputs.target_context_ref }}",
     });
     expect(baseline.run).toContain('"$INPUT_TARGET_CONTEXT_REF" == "extended-stable/"*');
     expect(baseline.run).toContain("npm view openclaw versions --json");
     expect(baseline.run).toContain("scripts/lib/release-upgrade-baseline.mts");
     expect(baseline.run).toContain('--target-context-ref "$INPUT_TARGET_CONTEXT_REF"');
+    expect(baseline.run).toContain('--previous-version "$INPUT_PREVIOUS_VERSION"');
     expect(baseline.run).toContain('BASELINE_VERSION="$(npm view openclaw@latest version)"');
     expect(readFileSync(WORKFLOW_PATH, "utf8")).toContain(
       "timeout --preserve-status 300s npm pack --ignore-scripts",

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -98,8 +98,26 @@ describe("cross-OS release checks workflow", () => {
 
   it("bounds npm baseline packing during prepare", () => {
     const workflow = readWorkflow(WORKFLOW_PATH);
+    const baseline = step(job(workflow, "prepare"), "Resolve baseline package spec");
     const baselineMetadata = step(job(workflow, "prepare"), "Capture baseline metadata");
 
+    expect(workflow.on?.workflow_dispatch?.inputs?.target_context_ref).toMatchObject({
+      default: "",
+      required: false,
+    });
+    expect(workflow.on?.workflow_call?.inputs?.target_context_ref).toMatchObject({
+      default: "",
+      required: false,
+    });
+    expect(baseline.env).toMatchObject({
+      CANDIDATE_JSON: "${{ runner.temp }}/openclaw-cross-os-release-checks/prepare/candidate.json",
+      INPUT_TARGET_CONTEXT_REF: "${{ inputs.target_context_ref }}",
+    });
+    expect(baseline.run).toContain('"$INPUT_TARGET_CONTEXT_REF" == "extended-stable/"*');
+    expect(baseline.run).toContain("npm view openclaw versions --json");
+    expect(baseline.run).toContain("scripts/lib/release-upgrade-baseline.mts");
+    expect(baseline.run).toContain('--target-context-ref "$INPUT_TARGET_CONTEXT_REF"');
+    expect(baseline.run).toContain('BASELINE_VERSION="$(npm view openclaw@latest version)"');
     expect(readFileSync(WORKFLOW_PATH, "utf8")).toContain(
       "timeout --preserve-status 300s npm pack --ignore-scripts",
     );
@@ -236,6 +254,7 @@ describe("cross-OS release checks workflow", () => {
       candidate_version: "${{ needs.prepare_release_package.outputs.package_version }}",
       prepublish_plugin_registry_json:
         "${{ needs.prepare_release_package.outputs.prepublish_plugin_registry_json }}",
+      target_context_ref: "${{ inputs.target_context_ref }}",
     });
     expect(crossOs.with?.required_companion_packages_json).toBeUndefined();
 

--- a/test/scripts/release-upgrade-baseline.test.ts
+++ b/test/scripts/release-upgrade-baseline.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   parseArgs,
   resolveDefaultReleaseUpgradeBaseline,
+  resolveFrozenExtendedStableUpgradeBaseline,
 } from "../../scripts/lib/release-upgrade-baseline.mts";
 
 describe("release upgrade baseline resolver", () => {
@@ -50,5 +51,41 @@ describe("release upgrade baseline resolver", () => {
     expect(() => resolveDefaultReleaseUpgradeBaseline(candidate, versions)).toThrow(
       "no published stable OpenClaw baseline",
     );
+  });
+
+  it("selects an older final release from the frozen extended-stable line", () => {
+    expect(
+      resolveFrozenExtendedStableUpgradeBaseline(
+        "2026.6.35",
+        ["2026.6.34", "2026.6.33", "2026.6.35", "2026.7.1", "2026.6.34-1"],
+        {
+          targetContextRef: "extended-stable/2026.6.33",
+        },
+      ),
+    ).toBe("openclaw@2026.6.34");
+  });
+
+  it.each([
+    ["2026.7.1", "extended-stable/2026.6.33"],
+    ["2026.6.35-beta.1", "extended-stable/2026.6.33"],
+    ["2026.6.33", "extended-stable/2026.6.33"],
+    ["2026.6.35", "extended-stable/2026.6.34"],
+  ])(
+    "rejects incompatible frozen extended-stable targets",
+    (candidateVersion, targetContextRef) => {
+      expect(() =>
+        resolveFrozenExtendedStableUpgradeBaseline(candidateVersion, ["2026.6.34", "2026.6.33"], {
+          targetContextRef,
+        }),
+      ).toThrow();
+    },
+  );
+
+  it("leaves non-extended-stable contexts on their latest baseline policy", () => {
+    expect(
+      resolveFrozenExtendedStableUpgradeBaseline("2026.6.35", ["2026.6.34"], {
+        targetContextRef: "release/2026.6.35",
+      }),
+    ).toBeUndefined();
   });
 });

--- a/test/scripts/release-upgrade-baseline.test.ts
+++ b/test/scripts/release-upgrade-baseline.test.ts
@@ -65,6 +65,35 @@ describe("release upgrade baseline resolver", () => {
     ).toBe("openclaw@2026.6.34");
   });
 
+  it("honors an explicit published predecessor from the frozen extended-stable line", () => {
+    expect(
+      resolveFrozenExtendedStableUpgradeBaseline(
+        "2026.6.35",
+        ["2026.6.33", "2026.6.34", "2026.6.35"],
+        {
+          previousVersion: "2026.6.33",
+          targetContextRef: "extended-stable/2026.6.33",
+        },
+      ),
+    ).toBe("openclaw@2026.6.33");
+  });
+
+  it.each(["2026.6.35", "2026.6.34-1", "2026.7.1", "2026.6.32", "2026.6.31"])(
+    "rejects an incompatible explicit frozen baseline %s",
+    (previousVersion) => {
+      expect(() =>
+        resolveFrozenExtendedStableUpgradeBaseline(
+          "2026.6.35",
+          ["2026.6.33", "2026.6.34", "2026.6.35"],
+          {
+            previousVersion,
+            targetContextRef: "extended-stable/2026.6.33",
+          },
+        ),
+      ).toThrow("previous_version");
+    },
+  );
+
   it.each([
     ["2026.7.1", "extended-stable/2026.6.33"],
     ["2026.6.35-beta.1", "extended-stable/2026.6.33"],


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a frozen extended-stable validation attempted to upgrade from npm latest, which can carry a newer SQLite schema than the candidate. The packaged upgrade lane then tests an unsupported downgrade instead of the release upgrade it claims to validate.

## Why This Change Was Made

The cross-OS reusable workflow now receives the canonical target context. An extended-stable/YYYY.M.33 context selects the newest earlier published final release on the same YYYY.M line and validates that the candidate is a final same-line patch at least 33. Other contexts retain their existing npm latest baseline behavior. Exact-SHA and release ancestry remain enforced by the upstream Release Checks target resolver.

## User Impact

Release maintainers get a real predecessor-to-candidate upgrade check for frozen extended-stable releases, without mutating product artifacts or weakening normal release validation.

## Evidence

The failing packaged-upgrade job installed 2026.8.1 before the 2026.6.35 candidate and failed at the newer SQLite schema boundary: https://github.com/openclaw/openclaw/actions/runs/33358560655/job/99385696947

Focused regression proof:
- node scripts/run-vitest.mjs test/scripts/release-upgrade-baseline.test.ts test/scripts/openclaw-cross-os-release-workflow.test.ts
- actionlint .github/workflows/openclaw-cross-os-release-checks-reusable.yml .github/workflows/openclaw-release-checks.yml
- git diff --check origin/main...HEAD

The resolver test fails before this change because the frozen-target resolver does not exist; it now covers .35 selecting .34, no older same-line baseline failing closed, incompatible candidate/context tuples failing closed, and ordinary release contexts retaining the latest policy.