### PR TITLE
test(cli): scope module resets to mocked policy cases

### DIFF
--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -1,6 +1,6 @@
 // Command path policy tests cover allowed CLI command path shapes and lazy imports.
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { CliCommandCatalogEntry, CliCommandPathPolicy } from "./command-catalog.js";
 import {
   resolveCliCommandPathPolicy,
@@ -59,11 +59,6 @@ function expectConfigGuardResolver(
 }
 
 describe("command-path-policy", () => {
-  afterEach(() => {
-    vi.doUnmock("./command-catalog.js");
-    vi.resetModules();
-  });
-
   it("resolves status policy with shared startup semantics", () => {
     expectResolvedPolicy(["status"], {
       configGuard: "skip",
@@ -610,22 +605,28 @@ describe("command-path-policy", () => {
       },
     ];
 
-    vi.doMock("./command-catalog.js", async (importOriginal) => {
-      const actual = await importOriginal<typeof import("./command-catalog.js")>();
-      return { ...actual, cliCommandCatalog: catalog };
-    });
-    const { resolveCliNetworkProxyPolicy: resolveCliNetworkProxyPolicyLocal } =
-      await importFreshModule<typeof import("./command-path-policy.js")>(
-        import.meta.url,
-        "./command-path-policy.js?catalog-overrides",
-      );
+    vi.resetModules();
+    try {
+      vi.doMock("./command-catalog.js", async (importOriginal) => {
+        const actual = await importOriginal<typeof import("./command-catalog.js")>();
+        return { ...actual, cliCommandCatalog: catalog };
+      });
+      const { resolveCliNetworkProxyPolicy: resolveCliNetworkProxyPolicyLocal } =
+        await importFreshModule<typeof import("./command-path-policy.js")>(
+          import.meta.url,
+          "./command-path-policy.js?catalog-overrides",
+        );
 
-    expect(resolveCliNetworkProxyPolicyLocal(["node", "openclaw", "nodes", "camera", "snap"])).toBe(
-      "default",
-    );
-    expect(resolveCliNetworkProxyPolicyLocal(["node", "openclaw", "nodes", "camera", "list"])).toBe(
-      "bypass",
-    );
+      expect(
+        resolveCliNetworkProxyPolicyLocal(["node", "openclaw", "nodes", "camera", "snap"]),
+      ).toBe("default");
+      expect(
+        resolveCliNetworkProxyPolicyLocal(["node", "openclaw", "nodes", "camera", "list"]),
+      ).toBe("bypass");
+    } finally {
+      vi.doUnmock("./command-catalog.js");
+      vi.resetModules();
+    }
   });
 
   it("stops catalog policy resolution before positional arguments", () => {

--- a/src/cli/command-startup-policy.test.ts
+++ b/src/cli/command-startup-policy.test.ts
@@ -1,6 +1,6 @@
 // Command startup policy tests cover which CLI commands require startup side effects.
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { cliCommandCatalog } from "./command-catalog.js";
 import { resolveCliExecutionStartupContext } from "./command-execution-startup.js";
 import { resolveCliStartupPolicy } from "./command-startup-policy.js";
@@ -18,11 +18,6 @@ function resolvePolicy(params: {
 }
 
 describe("command-startup-policy", () => {
-  afterEach(() => {
-    vi.doUnmock("./command-path-policy.js");
-    vi.resetModules();
-  });
-
   it("resolves config guard policy for Commander and invocation-aware commands", () => {
     for (const commandPath of [
       ["backup", "create"],
@@ -165,27 +160,34 @@ describe("command-startup-policy", () => {
   });
 
   it("skips when-suppressed guards only for suppressed output", async () => {
-    vi.doMock("./command-path-policy.js", () => ({
-      resolveCliCommandPathPolicy: () => ({
-        configGuard: "when-suppressed",
-        loadPlugins: "never",
-        pluginRegistry: { scope: "all" },
-        ownsProtocolStdout: false,
-        hideBanner: false,
-        ensureCliPath: true,
-        networkProxy: "default",
-      }),
-    }));
-    const { resolveCliStartupPolicy: resolveWithSuppressedGuard } = await importFreshModule<
-      typeof import("./command-startup-policy.js")
-    >(import.meta.url, "./command-startup-policy.js?when-suppressed");
+    vi.resetModules();
+    try {
+      vi.doMock("./command-path-policy.js", () => ({
+        resolveCliCommandPathPolicy: () => ({
+          configGuard: "when-suppressed",
+          loadPlugins: "never",
+          pluginRegistry: { scope: "all" },
+          ownsProtocolStdout: false,
+          hideBanner: false,
+          ensureCliPath: true,
+          networkProxy: "default",
+        }),
+      }));
+      const { resolveCliStartupPolicy: resolveWithSuppressedGuard } = await importFreshModule<
+        typeof import("./command-startup-policy.js")
+      >(import.meta.url, "./command-startup-policy.js?when-suppressed");
 
-    expect(
-      resolveWithSuppressedGuard({ commandPath: ["test"], jsonOutputMode: false }).skipConfigGuard,
-    ).toBe(false);
-    expect(
-      resolveWithSuppressedGuard({ commandPath: ["test"], jsonOutputMode: true }).skipConfigGuard,
-    ).toBe(true);
+      expect(
+        resolveWithSuppressedGuard({ commandPath: ["test"], jsonOutputMode: false })
+          .skipConfigGuard,
+      ).toBe(false);
+      expect(
+        resolveWithSuppressedGuard({ commandPath: ["test"], jsonOutputMode: true }).skipConfigGuard,
+      ).toBe(true);
+    } finally {
+      vi.doUnmock("./command-path-policy.js");
+      vi.resetModules();
+    }
   });
 
   it("matches plugin preload policy", () => {


### PR DESCRIPTION
## What problem does this PR solve?

CLI policy tests reset the module cache after every case, although only two cases install module mocks. The remaining cases use immutable imports and fresh policy inputs.

## Why this approach?

Move reset/unmock ownership into those two cases. Each begins with a clean module cache, keeps its query-qualified fresh import, and restores the mock and cache in finally. This reduces 48 resets to four and 48 unmock calls to two without changing test inputs or outcomes.

## User impact

Test-only cleanup; production +0/-0, tests +50/-47. All 48 changed-file cases and 123 assertion sites remain, including deep catalog overrides and suppressed-output guards.

## Evidence

All 58 policy/startup/path-matching tests pass before and after through the default runner routes. Full changed-file checks and Codex autoreview pass after formatting. The original mock introduction, later query-qualified import change and runner cleanup were checked. Reset counts are structural; no elapsed-time improvement is claimed.

`node scripts/run-vitest.mjs src/cli/command-path-policy.test.ts src/cli/command-startup-policy.test.ts src/cli/command-execution-startup.test.ts src/cli/command-path-matches.test.ts`
