### PR TITLE
fix(scripts): restore missing helpers in materialized PR anchors

### DIFF
--- a/scripts/pr
+++ b/scripts/pr
@@ -41,7 +41,8 @@ requested_subcommand="${1-}"
 
 # Select trusted wrapper code independently from the canonical repository root;
 # a linked wrapper may be removed by merge-run or gc before supervision ends.
-script_self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+# Physical paths keep helper argv aligned with Node's canonical module URLs.
+script_self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)/$(basename "${BASH_SOURCE[0]}")"
 script_parent_dir="$(dirname "$script_self")"
 canonical_repo_root="$script_parent_dir/.."
 pr_wrapper_components=(

--- a/scripts/pr
+++ b/scripts/pr
@@ -47,6 +47,80 @@ canonical_repo_root="$script_parent_dir/.."
 pr_wrapper_components=(
   scripts/pr
   scripts/pr-lib
+  # Complete repository-source closure, including the publisher test planner.
+  # Candidate build/test commands still run from the PR worktree.
+  packages/normalization-core/src/record-coerce.ts
+  packages/normalization-core/src/stable-stringify.ts
+  scripts/changed-lanes.mts
+  scripts/check-changelog-attributions.mjs
+  scripts/check-changelog-attributions.mts
+  scripts/lib/arg-utils.mts
+  scripts/lib/arg-utils.runtime.mjs
+  scripts/lib/bundled-plugin-paths.mjs
+  scripts/lib/changed-extensions.mts
+  scripts/lib/changed-path-facts.mjs
+  scripts/lib/extension-test-plan.mts
+  scripts/lib/failed-trailer.mts
+  scripts/lib/gateway-server-test-plan.mts
+  scripts/lib/managed-child-process.mts
+  scripts/lib/merge-head-diff-base.mjs
+  scripts/lib/numeric-options.mjs
+  scripts/lib/record-shared.mjs
+  scripts/lib/repo-root.mjs
+  scripts/lib/test-projects-delegation.mts
+  scripts/lib/test-selector-source-facts.mts
+  scripts/lib/vitest-build-prerequisites.mts
+  scripts/lib/vitest-cli-mode.mts
+  scripts/lib/vitest-local-scheduling.mts
+  scripts/lib/vitest-process-env.mts
+  scripts/lib/vitest-process.mts
+  scripts/lib/vitest-unhandled-errors.mts
+  scripts/lib/vitest-worker-artifacts.mts
+  scripts/lib/vitest-worker-run.mts
+  scripts/lib/windows-cmd-helpers-runtime.mts
+  scripts/lib/windows-taskkill.mjs
+  scripts/pnpm-runner.mts
+  scripts/run-vitest.mts
+  scripts/test-projects.test-support.mts
+  scripts/vitest-process-group.mts
+  scripts/windows-cmd-helpers.mjs
+  test/helpers/temp-dir.ts
+  test/vitest/vitest.agents-paths.mjs
+  test/vitest/vitest.channel-paths.mjs
+  test/vitest/vitest.cli-process-paths.mjs
+  test/vitest/vitest.commands-light-paths.mjs
+  test/vitest/vitest.contracts-paths.mjs
+  test/vitest/vitest.extension-acpx-paths.mjs
+  test/vitest/vitest.extension-active-memory-paths.mjs
+  test/vitest/vitest.extension-browser-paths.mjs
+  test/vitest/vitest.extension-channel-split-paths.mjs
+  test/vitest/vitest.extension-codex-paths.mjs
+  test/vitest/vitest.extension-diffs-paths.mjs
+  test/vitest/vitest.extension-feishu-paths.mjs
+  test/vitest/vitest.extension-irc-paths.mjs
+  test/vitest/vitest.extension-matrix-paths.mjs
+  test/vitest/vitest.extension-mattermost-paths.mjs
+  test/vitest/vitest.extension-media-paths.mjs
+  test/vitest/vitest.extension-memory-paths.mjs
+  test/vitest/vitest.extension-messaging-paths.mjs
+  test/vitest/vitest.extension-misc-paths.mjs
+  test/vitest/vitest.extension-msteams-paths.mjs
+  test/vitest/vitest.extension-provider-paths.mjs
+  test/vitest/vitest.extension-qa-paths.mjs
+  test/vitest/vitest.extension-telegram-paths.mjs
+  test/vitest/vitest.extension-voice-call-paths.mjs
+  test/vitest/vitest.extension-whatsapp-paths.mjs
+  test/vitest/vitest.extension-zalo-paths.mjs
+  test/vitest/vitest.gateway-server-paths.mjs
+  test/vitest/vitest.pattern-file.ts
+  test/vitest/vitest.performance-config.ts
+  test/vitest/vitest.plugin-sdk-paths.mjs
+  test/vitest/vitest.test-shards.mjs
+  test/vitest/vitest.tooling-isolated-paths.mjs
+  test/vitest/vitest.ui-isolated-paths.mjs
+  test/vitest/vitest.ui-paths.mjs
+  test/vitest/vitest.unit-fast-paths.mjs
+  test/vitest/vitest.unit-paths.mjs
   scripts/lib/plain-gh.sh
   scripts/lib/plain-gh.mjs
   scripts/lib/direct-run.mjs
@@ -172,9 +246,15 @@ elif common_git_dir=$(git -C "$script_parent_dir" rev-parse --path-format=absolu
           fi
           if [ "$anchor_extraction_valid" = "1" ] &&
             grep -q "OPENCLAW_PR_ANCHOR_REPO_ROOT" "$anchor_exec_dir/scripts/pr" 2>/dev/null; then
+            # Only third-party tooling comes from the installed canonical tree.
+            # A whole node_modules link could load unanchored workspace source.
+            mkdir "$anchor_exec_dir/node_modules"
+            for anchor_package in tsx zod minimatch yaml; do
+              ln -s "$canonical_repo_root/node_modules/$anchor_package" "$anchor_exec_dir/node_modules/$anchor_package"
+            done
             # Not cleaned by trap: exec replaces this shell, and bash re-reads
             # the script file during execution, so the copy must outlive the
-            # whole supervised run. OS tmp reaping owns the ~200 KiB dir.
+            # whole supervised run. OS tmp reaping owns this directory.
             echo "scripts/pr wrapper in this worktree differs from origin/main; running wrapper code materialized from the refs/remotes/origin/main trust anchor at revision $(git -C "$script_parent_dir" rev-parse --short refs/remotes/origin/main)." >&2
             OPENCLAW_PR_ANCHOR_REPO_ROOT="$canonical_repo_root" exec "$anchor_exec_dir/scripts/pr" "$@"
           fi

--- a/scripts/verify-pr-hosted-gates.mts
+++ b/scripts/verify-pr-hosted-gates.mts
@@ -2,9 +2,9 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { isRecord, readStringField } from "@openclaw/normalization-core/record-coerce";
 import { minimatch } from "minimatch";
 import { parse } from "yaml";
+import { isRecord, readStringField } from "../packages/normalization-core/src/record-coerce.ts";
 import {
   booleanFlag,
   classifyBoundedUnsignedDecimal,

--- a/test/scripts/pr-main-refresh.test-support.ts
+++ b/test/scripts/pr-main-refresh.test-support.ts
@@ -12,6 +12,7 @@ import {
 import { delimiter, join } from "node:path";
 import { afterAll } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+import { copyPrWrapperSources } from "./pr-wrapper.test-support.js";
 
 const templateDirs = useAutoCleanupTempDirTracker(afterAll);
 let fixtureTemplate: ReturnType<typeof createMainRefreshTemplate> | undefined;
@@ -55,33 +56,12 @@ function createMainRefreshTemplate(directory: string) {
   git(canonical, "config", "user.email", "test@example.invalid");
   git(canonical, "config", "core.hooksPath", "/dev/null");
   git(canonical, "config", "extensions.worktreeConfig", "true");
-  mkdirSync(join(canonical, "scripts"));
-  for (const item of [
-    "pr",
-    "pr-lib",
-    "lib",
-    "tsx.mjs",
-    "verify-pr-hosted-gates.mjs",
-    "verify-pr-hosted-gates.mts",
-    "watch-pr-ci.mjs",
-    "watch-pr-ci.mts",
-    "crabbox-untrusted-bootstrap.sh",
-    "pr-crabbox-gate-publisher.mjs",
-  ]) {
-    cpSync(join(process.cwd(), "scripts", item), join(canonical, "scripts", item), {
-      recursive: true,
-    });
-  }
+  copyPrWrapperSources(canonical);
   cpSync(join(process.cwd(), ".github", "workflows"), join(canonical, ".github", "workflows"), {
     recursive: true,
   });
   writeFileSync(join(canonical, "package.json"), '{"type":"module"}\n');
   cpSync(join(process.cwd(), "tsconfig.json"), join(canonical, "tsconfig.json"));
-  cpSync(
-    join(process.cwd(), "packages", "normalization-core"),
-    join(canonical, "packages", "normalization-core"),
-    { recursive: true },
-  );
   writeFileSync(join(canonical, ".gitignore"), ".worktrees/\n.local/\nnode_modules\n");
   mkdirSync(join(canonical, "src"));
   writeFileSync(join(canonical, "src", "subject.ts"), "export const subject = 'base';\n");

--- a/test/scripts/pr-operation-lock.test.ts
+++ b/test/scripts/pr-operation-lock.test.ts
@@ -28,6 +28,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 import { validReview, writeReviewArtifacts } from "./pr-review-artifact-fixture.js";
+import { copyPrWrapperSources } from "./pr-wrapper.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const freshMainTemplateDirs = useAutoCleanupTempDirTracker(afterAll);
@@ -230,45 +231,7 @@ function writeEscapedPipeHolderLauncher(repoDir: string, pidFile: string) {
 }
 
 function installPrCliFixture(repoDir: string, env?: NodeJS.ProcessEnv) {
-  const files = [
-    "scripts/pr",
-    "scripts/watch-pr-ci.mjs",
-    "scripts/watch-pr-ci.mts",
-    "scripts/verify-pr-hosted-gates.mjs",
-    "scripts/verify-pr-hosted-gates.mts",
-    "scripts/lib/plain-gh.sh",
-    "scripts/lib/plain-gh.mjs",
-    "scripts/lib/direct-run.mjs",
-    "scripts/lib/record-shared.mjs",
-    "scripts/lib/tsx-cli-shim.mjs",
-    "scripts/lib/local-check-runtime.mts",
-    "scripts/tsx.mjs",
-    "scripts/pr-lib/worktree.sh",
-    "scripts/pr-lib/operation-lock.sh",
-    "scripts/pr-lib/process-group-runner.mjs",
-    "scripts/pr-lib/common.sh",
-    "scripts/pr-lib/changelog.sh",
-    "scripts/pr-lib/gates.sh",
-    "scripts/pr-lib/ci-dispatch.mjs",
-    "scripts/pr-lib/crabbox-gate-contract.mjs",
-    "scripts/pr-lib/crabbox-gate-plan.mts",
-    "scripts/pr-lib/crabbox-merge-bypass.mjs",
-    "scripts/pr-lib/crabbox-merge-bypass.sh",
-    "scripts/pr-lib/push.sh",
-    "scripts/pr-lib/review.sh",
-    "scripts/pr-lib/review-artifacts.mjs",
-    "scripts/pr-lib/prepare-core.sh",
-    "scripts/pr-lib/merge.sh",
-    "scripts/pr-lib/merge-outcome.sh",
-    "scripts/crabbox-untrusted-bootstrap.sh",
-    "scripts/pr-crabbox-gate-publisher.mjs",
-    ".github/workflows/pr-crabbox-gate-publisher.yml",
-  ];
-  for (const file of files) {
-    const target = join(repoDir, file);
-    mkdirSync(dirname(target), { recursive: true });
-    cpSync(join(repoRoot, file), target);
-  }
+  const wrapperSources = copyPrWrapperSources(repoDir);
   const cli = join(repoDir, "scripts/pr");
   chmodSync(cli, 0o755);
   const binDir = join(repoDir, "isolated-bin");
@@ -277,7 +240,7 @@ function installPrCliFixture(repoDir: string, env?: NodeJS.ProcessEnv) {
     const resolved = execFileSync("which", [command], { encoding: "utf8", env }).trim();
     symlinkSync(resolved, join(binDir, command));
   }
-  return { binDir, cli };
+  return { binDir, cli, wrapperSources };
 }
 
 function createFreshMainTemplate() {
@@ -291,7 +254,7 @@ function createFreshMainTemplate() {
   mkdirSync(homeDir, { recursive: true });
   mkdirSync(tmpDir, { recursive: true });
   const setupEnv = createPrFixtureEnv(homeDir, process.env.PATH ?? "");
-  const { binDir } = installPrCliFixture(repoDir, setupEnv);
+  const { binDir, wrapperSources } = installPrCliFixture(repoDir, setupEnv);
   const realGit = realpathSync(join(binDir, "git"));
   // Only these real tools are reachable. rg/pnpm are required by the CLI
   // preflight; these cases must stop before invoking either of them.
@@ -334,7 +297,7 @@ function createFreshMainTemplate() {
     join(repoDir, ".git/info/exclude"),
     "/.local/\n/.worktrees/\n/isolated-bin/\n/fixture-state/\n",
   );
-  git("add", "scripts", ".github");
+  git("add", "--", ...wrapperSources);
   git("commit", "-qm", "test: unmodified public PR wrapper fixture");
   const cachedMain = git("rev-parse", "HEAD");
   const canonicalTree = git("rev-parse", "HEAD^{tree}");
@@ -1793,7 +1756,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
     "finishes native cleanup with $wrapper wrapper ($command, failure=$failure)",
     ({ wrapper, command, failure }) => {
       const repoDir = createRepo();
-      const { binDir, cli } = installPrCliFixture(repoDir);
+      const { binDir, cli, wrapperSources } = installPrCliFixture(repoDir);
       const rg = writeFixtureFile(binDir, "rg", [
         "#!/usr/bin/env bash",
         "set -euo pipefail",
@@ -1823,7 +1786,7 @@ describePosix("scripts/pr per-PR operation lock", () => {
           "validate_review_artifact_data() { :; }\n" +
           "merge_verify() { MERGE_USE_CRABBOX_ADMIN_BYPASS=false; mark_pr_operation_side_effects_started; }\n",
       );
-      git("add", "scripts", ".github");
+      git("add", "--", ...wrapperSources);
       git("commit", "-qm", "test: native cleanup fixture");
       const preparedHead = git("rev-parse", "HEAD");
       const origin = tempDirs.make("openclaw-pr-cleanup-origin-");

--- a/test/scripts/pr-wrapper.test-support.ts
+++ b/test/scripts/pr-wrapper.test-support.ts
@@ -1,0 +1,22 @@
+import { cpSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export function copyPrWrapperSources(destination: string): string[] {
+  // Keep fixture sources and commits on the production inventory. Extracted
+  // execution tests catch missing dependencies without a second source list.
+  const inventory = readFileSync("scripts/pr", "utf8").match(
+    /pr_wrapper_components=\(\n([\s\S]*?)\n\)/,
+  )?.[1];
+  if (!inventory) {
+    throw new Error("Missing scripts/pr wrapper component inventory");
+  }
+  const components = inventory
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith("#"));
+  for (const component of components) {
+    mkdirSync(dirname(join(destination, component)), { recursive: true });
+    cpSync(component, join(destination, component), { recursive: true });
+  }
+  return components;
+}

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -6,15 +6,24 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   realpathSync,
   rmSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { describe, expect, it } from "vitest";
+import {
+  REVIEWED_HEAD,
+  REVIEWED_PR,
+  validReview,
+  writeReviewArtifacts,
+} from "./pr-review-artifact-fixture.js";
+import { copyPrWrapperSources } from "./pr-wrapper.test-support.js";
 
 function readScript(path: string): string {
   return readFileSync(path, "utf8");
@@ -24,15 +33,27 @@ const anchorSubstitutionNotice = (repo: string) =>
   `scripts/pr wrapper in this worktree differs from origin/main; running the canonical checkout's wrapper (matches the origin/main trust anchor): ${repo}`;
 const itPosix = process.platform === "win32" ? it.skip : it;
 
-function makeMismatchedWrapperRepo() {
+function isolatedWrapperEnv(root: string) {
+  const home = join(root, "home");
+  mkdirSync(home, { recursive: true });
+  return {
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_NOSYSTEM: "1",
+    HOME: home,
+    PATH: `${join(root, "bin")}${delimiter}${process.env.PATH ?? ""}`,
+    TMPDIR: root,
+    XDG_CONFIG_HOME: join(home, ".config"),
+    GH_CONFIG_DIR: join(home, "gh"),
+  };
+}
+
+function makeMismatchedWrapperRepo({ realModules = false } = {}) {
   const root = realpathSync(mkdtempSync(join(realpathSync(tmpdir()), "openclaw-pr-dev-wrapper-")));
   const bin = join(root, "bin");
-  const home = join(root, "home");
   const canonicalPath = join(root, "canonical");
   const linkedPath = join(root, "linked");
   const originPath = join(root, "origin.git");
   mkdirSync(bin, { recursive: true });
-  mkdirSync(home, { recursive: true });
   // This fixture exercises wrapper trust routing, not the host command inventory.
   for (const command of ["pnpm", "rg"]) {
     const commandPath = join(bin, command);
@@ -44,18 +65,11 @@ function makeMismatchedWrapperRepo() {
   const ghStub = join(bin, "gh");
   writeFileSync(
     ghStub,
-    '#!/bin/sh\nif [ "$1" = "pr" ] && [ "$2" = "view" ]; then\n  printf \'{"baseRefName":"not-main"}\\n\'\n  exit 0\nfi\nexit 0\n',
+    '#!/bin/sh\nif [ "$1" = "pr" ] && [ "$2" = "view" ]; then\n  printf \'{"baseRefName":"not-main"}\\n\'\n  exit 0\nfi\necho "Unexpected gh call: $*" >&2\nexit 99\n',
   );
   chmodSync(ghStub, 0o755);
 
-  const fixtureEnv = {
-    ...process.env,
-    GIT_CONFIG_GLOBAL: "/dev/null",
-    GIT_CONFIG_NOSYSTEM: "1",
-    HOME: home,
-    PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`,
-    XDG_CONFIG_HOME: join(home, ".config"),
-  };
+  const fixtureEnv = isolatedWrapperEnv(root);
   const git = (cwd: string, args: string[]) => {
     const result = spawnSync("git", args, {
       cwd,
@@ -71,50 +85,14 @@ function makeMismatchedWrapperRepo() {
   git(root, ["init", "-b", "main", canonicalPath]);
   const canonical = realpathSync(canonicalPath);
   const origin = realpathSync(originPath);
-  mkdirSync(join(canonical, ".github", "workflows"), { recursive: true });
-  mkdirSync(join(canonical, "scripts", "lib"), { recursive: true });
-  cpSync("scripts/pr-lib", join(canonical, "scripts", "pr-lib"), { recursive: true });
-  writeFileSync(join(canonical, "scripts", "pr"), readScript("scripts/pr"));
-  cpSync(
-    ".github/workflows/pr-crabbox-gate-publisher.yml",
-    join(canonical, ".github", "workflows", "pr-crabbox-gate-publisher.yml"),
-  );
-  cpSync(
-    "scripts/crabbox-untrusted-bootstrap.sh",
-    join(canonical, "scripts", "crabbox-untrusted-bootstrap.sh"),
-  );
-  cpSync(
-    "scripts/pr-crabbox-gate-publisher.mjs",
-    join(canonical, "scripts", "pr-crabbox-gate-publisher.mjs"),
-  );
-  cpSync("scripts/watch-pr-ci.mjs", join(canonical, "scripts", "watch-pr-ci.mjs"));
-  cpSync("scripts/watch-pr-ci.mts", join(canonical, "scripts", "watch-pr-ci.mts"));
-  cpSync(
-    "scripts/verify-pr-hosted-gates.mjs",
-    join(canonical, "scripts", "verify-pr-hosted-gates.mjs"),
-  );
-  cpSync(
-    "scripts/verify-pr-hosted-gates.mts",
-    join(canonical, "scripts", "verify-pr-hosted-gates.mts"),
-  );
-  cpSync("scripts/lib/plain-gh.mjs", join(canonical, "scripts", "lib", "plain-gh.mjs"));
-  cpSync("scripts/lib/direct-run.mjs", join(canonical, "scripts", "lib", "direct-run.mjs"));
-  cpSync("scripts/lib/tsx-cli-shim.mjs", join(canonical, "scripts", "lib", "tsx-cli-shim.mjs"));
-  cpSync(
-    "scripts/lib/local-check-runtime.mts",
-    join(canonical, "scripts", "lib", "local-check-runtime.mts"),
-  );
-  cpSync("scripts/tsx.mjs", join(canonical, "scripts", "tsx.mjs"));
-  writeFileSync(
-    join(canonical, "scripts", "lib", "plain-gh.sh"),
-    "resolve_plain_gh_bin() { printf '/usr/bin/true\\n'; }\ngh_plain() { :; }\n",
-  );
+  copyPrWrapperSources(canonical);
   // Marker stub committed to main (the origin/main anchor), so tests can tell
   // an anchor-substituted canonical run apart from a local wrapper run.
-  writeFileSync(
-    join(canonical, "scripts", "pr-lib", "gates.sh"),
-    'ci_dispatch() { echo "canonical wrapper executed"; }\n',
-  );
+  if (!realModules)
+    writeFileSync(
+      join(canonical, "scripts", "pr-lib", "gates.sh"),
+      'ci_dispatch() { echo "canonical wrapper executed"; }\n',
+    );
   chmodSync(join(canonical, "scripts", "pr"), 0o755);
 
   git(canonical, ["config", "user.name", "OpenClaw Test"]);
@@ -122,7 +100,7 @@ function makeMismatchedWrapperRepo() {
   git(canonical, ["config", "commit.gpgSign", "false"]);
   git(canonical, ["config", "core.hooksPath", "/dev/null"]);
   git(canonical, ["remote", "add", "origin", origin]);
-  git(canonical, ["add", "scripts", ".github"]);
+  git(canonical, ["add", "."]);
   git(canonical, ["commit", "-m", "test: canonical wrapper"]);
   git(canonical, ["push", "-u", "origin", "main"]);
   git(canonical, ["worktree", "add", "-b", "feature", linkedPath, "main"]);
@@ -142,6 +120,17 @@ function makeMismatchedWrapperRepo() {
   git(linked, ["add", "scripts/pr-lib/gates.sh"]);
   git(linked, ["commit", "-m", "test: local wrapper"]);
   const localRevision = git(linked, ["rev-parse", "HEAD"]).stdout.trim();
+
+  if (realModules) {
+    mkdirSync(join(canonical, "node_modules"));
+    // Use installed third-party packages only, never workspace source or loader mocks.
+    for (const dependency of ["tsx", "zod", "minimatch", "yaml"]) {
+      symlinkSync(
+        realpathSync(join("node_modules", dependency)),
+        join(canonical, "node_modules", dependency),
+      );
+    }
+  }
 
   return {
     bin,
@@ -469,6 +458,24 @@ describe("scripts/pr wrappers", () => {
     fixture.git(fixture.canonical, ["commit", "-m", "test: parked canonical wrapper"]);
   }
 
+  function materializeAnchor(fixture: ReturnType<typeof makeMismatchedWrapperRepo>) {
+    parkCanonicalOffAnchor(fixture);
+    const materialized = spawnSync(join(fixture.linked, "scripts/pr"), ["unknown-command"], {
+      cwd: fixture.linked,
+      encoding: "utf8",
+      env: fixture.env,
+    });
+    expect(materialized.status, materialized.stderr).toBe(2);
+    expect(materialized.stderr).toContain("running wrapper code materialized from");
+    const anchors = readdirSync(fixture.root).filter((name) =>
+      name.startsWith("openclaw-pr-anchor."),
+    );
+    expect(anchors).toHaveLength(1);
+    const anchor = join(fixture.root, anchors[0]!);
+    expect(statSync(anchor).mode & 0o777).toBe(0o700);
+    return anchor;
+  }
+
   it("materializes the origin/main anchor wrapper when canonical is parked elsewhere", () => {
     const fixture = makeMismatchedWrapperRepo();
     try {
@@ -488,6 +495,173 @@ describe("scripts/pr wrappers", () => {
         "running wrapper code materialized from the refs/remotes/origin/main trust anchor",
       );
       expect(result.stderr).not.toContain("Refusing to silently substitute");
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  itPosix("executes review artifacts from the extracted anchor dependency closure", () => {
+    const fixture = makeMismatchedWrapperRepo({ realModules: true });
+    try {
+      const anchor = materializeAnchor(fixture);
+      writeFileSync(join(fixture.bin, "gh"), "#!/bin/sh\necho forbidden-gh >&2\nexit 99\n");
+      writeReviewArtifacts(fixture.linked, validReview());
+      const result = spawnSync(
+        "bash",
+        [
+          "-c",
+          [
+            "set -euo pipefail",
+            'script_parent_dir="$1/scripts"',
+            'source "$script_parent_dir/pr-lib/review.sh"',
+            'node "$(review_artifacts_helper_path)" template "$2" "$3"',
+            'node "$(review_artifacts_helper_path)" validate .local/review.json .local/review.md .local/pr-meta.json',
+          ].join("\n"),
+          "anchor-review",
+          anchor,
+          String(REVIEWED_PR),
+          REVIEWED_HEAD,
+        ],
+        {
+          cwd: fixture.linked,
+          encoding: "utf8",
+          env: fixture.env,
+        },
+      );
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(JSON.parse(result.stdout).pr).toEqual({ number: REVIEWED_PR, headSha: REVIEWED_HEAD });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
+  itPosix(
+    "executes tooling and publisher code from the extracted anchor dependency closure",
+    () => {
+      const fixture = makeMismatchedWrapperRepo({ realModules: true });
+      try {
+        const anchor = materializeAnchor(fixture);
+        writeFileSync(join(fixture.bin, "gh"), "#!/bin/sh\necho forbidden-gh >&2\nexit 99\n");
+        const run = (args: string[]) =>
+          spawnSync(process.execPath, args, {
+            cwd: anchor,
+            encoding: "utf8",
+            env: fixture.env,
+          });
+        // These .mjs files launch children at import time. Execute the real shims
+        // with invalid arguments so their .mts owners reject before any GitHub IO.
+        for (const [entry, exitCode, message] of [
+          ["watch-pr-ci.mjs", 2, "Usage: node scripts/watch-pr-ci.mjs"],
+          ["verify-pr-hosted-gates.mjs", 1, "Usage: node scripts/verify-pr-hosted-gates.mjs"],
+          ["pr-lib/ci-dispatch.mjs", 2, "Usage: ci-dispatch.mjs"],
+        ] as const) {
+          const result = run([join(anchor, "scripts", entry)]);
+          expect.soft(result.status, `${entry}\n${result.stdout}\n${result.stderr}`).toBe(exitCode);
+          expect.soft(result.stderr, entry).toContain(message);
+        }
+        const attribution = run([
+          "scripts/check-changelog-attributions.mjs",
+          "--is-forbidden-handle",
+          "fixture[bot]",
+        ]);
+        expect.soft(attribution.status, attribution.stderr).toBe(0);
+        const bypass = run([
+          "--input-type=module",
+          "-e",
+          "await import('./scripts/pr-lib/crabbox-merge-bypass.mjs')",
+        ]);
+        expect.soft(bypass.status, bypass.stderr).toBe(0);
+
+        const plan = {
+          version: 1,
+          baseSha: "a".repeat(40),
+          headSha: REVIEWED_HEAD,
+          changedPaths: [{ path: "docs/example.md", status: "M" }],
+          targets: [],
+        };
+        const planFile = join(fixture.root, "plan.json");
+        writeFileSync(planFile, JSON.stringify(plan));
+        const publisher = run([
+          "scripts/pr-crabbox-gate-publisher.mjs",
+          "--print-command",
+          planFile,
+          "c".repeat(64),
+        ]);
+        expect.soft(publisher.status, publisher.stderr).toBe(0);
+        expect.soft(publisher.stdout).toContain(`OPENCLAW_CRABBOX_GATE_HEAD=${REVIEWED_HEAD}`);
+        expect.soft(publisher.stdout).toContain("OPENCLAW_CRABBOX_GATE_TARGET_COUNT=0");
+        expect.soft(publisher.stdout).toContain("pnpm build");
+        expect.soft(publisher.stdout).toContain("pnpm check");
+
+        // The trusted planner reads candidate sources without executing them. A
+        // non-sibling importer exercises its real source-scanning child as well.
+        mkdirSync(join(fixture.linked, "src"));
+        mkdirSync(join(fixture.linked, "test/probe"), { recursive: true });
+        writeFileSync(join(fixture.linked, "src/anchor-value.ts"), "export const value = 1;\n");
+        writeFileSync(
+          join(fixture.linked, "test/probe/anchor.test.ts"),
+          'import { value } from "../../src/anchor-value.js";\nvoid value;\n',
+        );
+        fixture.git(fixture.linked, ["add", "src", "test/probe"]);
+        fixture.git(fixture.linked, ["commit", "-m", "test: candidate import graph"]);
+        const base = fixture.git(fixture.linked, ["rev-parse", "HEAD"]).stdout.trim();
+        writeFileSync(join(fixture.linked, "src/anchor-value.ts"), "export const value = 2;\n");
+        fixture.git(fixture.linked, ["add", "src/anchor-value.ts"]);
+        fixture.git(fixture.linked, ["commit", "-m", "test: candidate change"]);
+        const head = fixture.git(fixture.linked, ["rev-parse", "HEAD"]).stdout.trim();
+        const planned = spawnSync(
+          process.execPath,
+          [join(anchor, "scripts/pr-lib/crabbox-gate-plan.mts"), "--base", base, "--head", head],
+          {
+            cwd: fixture.linked,
+            encoding: "utf8",
+            env: fixture.env,
+          },
+        );
+        expect(planned.status, planned.stderr).toBe(0);
+        expect(JSON.parse(planned.stdout)).toMatchObject({
+          baseSha: base,
+          headSha: head,
+          changedPaths: [{ path: "src/anchor-value.ts", status: "M" }],
+          targets: ["test/probe/anchor.test.ts"],
+        });
+      } finally {
+        fixture.cleanup();
+      }
+    },
+  );
+
+  itPosix("refuses an extracted anchor with a tampered dependency", () => {
+    const fixture = makeMismatchedWrapperRepo({ realModules: true });
+    try {
+      parkCanonicalOffAnchor(fixture);
+      const tar = join(fixture.bin, "tar");
+      writeFileSync(
+        tar,
+        `#!/bin/sh
+"$OPENCLAW_TEST_TAR" "$@" || exit
+while [ "$#" -gt 0 ]; do
+  if [ "$1" = "-C" ]; then
+    printf '\\n// tampered\\n' >> "$2/scripts/lib/record-shared.mjs"
+    exit
+  fi
+  shift
+done
+exit 99
+`,
+      );
+      chmodSync(tar, 0o755);
+      const result = spawnSync(join(fixture.linked, "scripts/pr"), ["unknown-command"], {
+        cwd: fixture.linked,
+        encoding: "utf8",
+        env: { ...fixture.env, OPENCLAW_TEST_TAR: resolveCommand("tar") },
+      });
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(1);
+      expect(result.stderr).toContain("Refusing to silently substitute");
+      expect(result.stderr).not.toContain("running wrapper code materialized from");
+      expect(
+        readdirSync(fixture.root).filter((name) => name.startsWith("openclaw-pr-anchor.")),
+      ).toEqual([]);
     } finally {
       fixture.cleanup();
     }
@@ -593,35 +767,17 @@ describe("scripts/pr wrappers", () => {
     const dir = mkdtempSync(join(tmpdir(), "openclaw-pr-wrapper-revision-"));
     const repo = join(dir, "repo");
     const linked = join(dir, "linked");
-    mkdirSync(join(repo, ".github", "workflows"), { recursive: true });
-    mkdirSync(join(repo, "scripts", "lib"), { recursive: true });
-    mkdirSync(join(repo, "scripts", "pr-lib"), { recursive: true });
-    writeFileSync(join(repo, "scripts", "pr"), readScript("scripts/pr"));
-    writeFileSync(
-      join(repo, ".github", "workflows", "pr-crabbox-gate-publisher.yml"),
-      "name: canonical\n",
-    );
-    writeFileSync(join(repo, "scripts", "crabbox-untrusted-bootstrap.sh"), "# canonical\n");
-    writeFileSync(join(repo, "scripts", "pr-crabbox-gate-publisher.mjs"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "lib", "plain-gh.sh"), "# canonical\n");
-    writeFileSync(join(repo, "scripts", "lib", "plain-gh.mjs"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "lib", "direct-run.mjs"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "lib", "tsx-cli-shim.mjs"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "lib", "local-check-runtime.mts"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "tsx.mjs"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "watch-pr-ci.mjs"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "watch-pr-ci.mts"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "verify-pr-hosted-gates.mjs"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "verify-pr-hosted-gates.mts"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "pr-lib", "merge.sh"), "# canonical\n");
-    chmodSync(join(repo, "scripts", "pr"), 0o755);
-
+    copyPrWrapperSources(repo);
+    const env = isolatedWrapperEnv(dir);
+    mkdirSync(join(dir, "bin"));
+    writeFileSync(join(dir, "bin/gh"), "#!/bin/sh\nexit 99\n");
+    chmodSync(join(dir, "bin/gh"), 0o755);
     const git = (cwd: string, args: string[]) =>
-      spawnSync("git", args, { cwd, encoding: "utf8", stdio: "pipe" });
+      spawnSync("git", args, { cwd, env, encoding: "utf8", stdio: "pipe" });
     expect(git(repo, ["init", "-b", "main"]).status).toBe(0);
     expect(git(repo, ["config", "user.name", "OpenClaw Test"]).status).toBe(0);
     expect(git(repo, ["config", "user.email", "test@example.invalid"]).status).toBe(0);
-    expect(git(repo, ["add", "scripts", ".github"]).status).toBe(0);
+    expect(git(repo, ["add", "."]).status).toBe(0);
     expect(git(repo, ["commit", "-m", "test: canonical wrapper"]).status).toBe(0);
     expect(git(repo, ["worktree", "add", "-b", "feature", linked]).status).toBe(0);
 
@@ -635,6 +791,7 @@ describe("scripts/pr wrappers", () => {
       const dirtyResult = spawnSync(join(linked, "scripts", "pr"), ["ls"], {
         cwd: linked,
         encoding: "utf8",
+        env,
       });
       expect(dirtyResult.status, component).toBe(1);
       expect(dirtyResult.stderr, component).toContain(
@@ -647,6 +804,7 @@ describe("scripts/pr wrappers", () => {
     const dirtyPreloaderResult = spawnSync(join(linked, "scripts", "pr"), ["ls"], {
       cwd: linked,
       encoding: "utf8",
+      env,
     });
     expect(dirtyPreloaderResult.status).toBe(1);
     expect(dirtyPreloaderResult.stderr).toContain(
@@ -661,6 +819,7 @@ describe("scripts/pr wrappers", () => {
     const dirtyResult = spawnSync(join(linked, "scripts", "pr"), ["ls"], {
       cwd: linked,
       encoding: "utf8",
+      env,
     });
     expect(dirtyResult.status).toBe(1);
     expect(dirtyResult.stderr).toContain(
@@ -675,6 +834,7 @@ describe("scripts/pr wrappers", () => {
     const result = spawnSync(join(linked, "scripts", "pr"), ["ls"], {
       cwd: linked,
       encoding: "utf8",
+      env,
     });
     rmSync(dir, { recursive: true, force: true });
 
@@ -689,35 +849,17 @@ describe("scripts/pr wrappers", () => {
     const dir = mkdtempSync(join(tmpdir(), "openclaw-pr-wrapper-anchor-"));
     const repo = join(dir, "repo");
     const linked = join(dir, "linked");
-    mkdirSync(join(repo, ".github", "workflows"), { recursive: true });
-    mkdirSync(join(repo, "scripts", "lib"), { recursive: true });
-    mkdirSync(join(repo, "scripts", "pr-lib"), { recursive: true });
-    writeFileSync(join(repo, "scripts", "pr"), readScript("scripts/pr"));
-    writeFileSync(
-      join(repo, ".github", "workflows", "pr-crabbox-gate-publisher.yml"),
-      "name: canonical\n",
-    );
-    writeFileSync(join(repo, "scripts", "crabbox-untrusted-bootstrap.sh"), "# canonical\n");
-    writeFileSync(join(repo, "scripts", "pr-crabbox-gate-publisher.mjs"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "lib", "plain-gh.sh"), "# canonical\n");
-    writeFileSync(join(repo, "scripts", "lib", "plain-gh.mjs"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "lib", "direct-run.mjs"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "lib", "tsx-cli-shim.mjs"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "lib", "local-check-runtime.mts"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "tsx.mjs"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "watch-pr-ci.mjs"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "watch-pr-ci.mts"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "verify-pr-hosted-gates.mjs"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "verify-pr-hosted-gates.mts"), "// canonical\n");
-    writeFileSync(join(repo, "scripts", "pr-lib", "merge.sh"), "# canonical\n");
-    chmodSync(join(repo, "scripts", "pr"), 0o755);
-
+    copyPrWrapperSources(repo);
+    const env = isolatedWrapperEnv(dir);
+    mkdirSync(join(dir, "bin"));
+    writeFileSync(join(dir, "bin/gh"), "#!/bin/sh\nexit 99\n");
+    chmodSync(join(dir, "bin/gh"), 0o755);
     const git = (cwd: string, args: string[]) =>
-      spawnSync("git", args, { cwd, encoding: "utf8", stdio: "pipe" });
+      spawnSync("git", args, { cwd, env, encoding: "utf8", stdio: "pipe" });
     expect(git(repo, ["init", "-b", "main"]).status).toBe(0);
     expect(git(repo, ["config", "user.name", "OpenClaw Test"]).status).toBe(0);
     expect(git(repo, ["config", "user.email", "test@example.invalid"]).status).toBe(0);
-    expect(git(repo, ["add", "scripts", ".github"]).status).toBe(0);
+    expect(git(repo, ["add", "."]).status).toBe(0);
     expect(git(repo, ["commit", "-m", "test: canonical wrapper"]).status).toBe(0);
     // The linked worktree keeps main's wrapper; origin/main anchors trust.
     expect(git(repo, ["update-ref", "refs/remotes/origin/main", "main"]).status).toBe(0);
@@ -733,6 +875,7 @@ describe("scripts/pr wrappers", () => {
     const result = spawnSync(join(linked, "scripts", "pr"), ["ls"], {
       cwd: linked,
       encoding: "utf8",
+      env,
     });
 
     expect(result.stderr).not.toContain("Refusing to silently substitute");
@@ -747,6 +890,7 @@ describe("scripts/pr wrappers", () => {
     const spoofed = spawnSync(join(linked, "scripts", "pr"), ["ls"], {
       cwd: linked,
       encoding: "utf8",
+      env,
     });
     rmSync(dir, { recursive: true, force: true });
 
@@ -779,7 +923,7 @@ exit 1
       ],
       {
         cwd: process.cwd(),
-        env: { ...process.env, OPENCLAW_GH_BIN: gh },
+        env: { ...isolatedWrapperEnv(dir), OPENCLAW_GH_BIN: gh, GH_TOKEN: "synthetic-token" },
         encoding: "utf8",
       },
     );

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -500,6 +500,40 @@ describe("scripts/pr wrappers", () => {
     }
   });
 
+  itPosix("executes extracted helpers through a symlinked temporary root", () => {
+    const fixture = makeMismatchedWrapperRepo({ realModules: true });
+    try {
+      // Exercise the wrapper's own helper path, not a physical path reconstructed by the test.
+      writeFileSync(
+        join(fixture.canonical, "scripts/pr-lib/gates.sh"),
+        `ci_dispatch() { node "$(review_artifacts_helper_path)" template "$1" "${REVIEWED_HEAD}"; }\n`,
+      );
+      fixture.git(fixture.canonical, ["add", "scripts/pr-lib/gates.sh"]);
+      fixture.git(fixture.canonical, ["commit", "-m", "test: real anchor helper dispatch"]);
+      fixture.git(fixture.canonical, ["push", "origin", "main"]);
+      parkCanonicalOffAnchor(fixture);
+      const temporaryAlias = join(fixture.root, "temporary-alias");
+      symlinkSync(fixture.root, temporaryAlias, "dir");
+      const result = spawnSync(
+        join(fixture.linked, "scripts/pr"),
+        ["ci-dispatch", String(REVIEWED_PR)],
+        {
+          cwd: fixture.linked,
+          encoding: "utf8",
+          env: { ...fixture.env, TMPDIR: temporaryAlias },
+        },
+      );
+      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+      expect(result.stderr).toContain("running wrapper code materialized from");
+      expect(result.stdout, "the extracted helper must not silently skip its entrypoint").toContain(
+        REVIEWED_HEAD,
+      );
+      expect(JSON.parse(result.stdout).pr).toEqual({ number: REVIEWED_PR, headSha: REVIEWED_HEAD });
+    } finally {
+      fixture.cleanup();
+    }
+  });
+
   itPosix("executes review artifacts from the extracted anchor dependency closure", () => {
     const fixture = makeMismatchedWrapperRepo({ realModules: true });
     try {


### PR DESCRIPTION
Related: #133913 (trusted PR-wrapper anchor materialization).

## What Problem This Solves

Resolves a problem where maintainers running the native PR review or landing workflow from a stale or wrapper-changing worktree hit missing-module errors after the trusted `origin/main` wrapper was materialized. Review artifact initialization/validation could fail with `ERR_MODULE_NOT_FOUND` for `scripts/lib/record-shared.mjs`, leaving the normal operation lock retained for explicit recovery.

This is a separate tooling repair, not a change to the TLS work where the first failure was observed.

## Why This Change Was Made

Complete the existing `pr_wrapper_components` source inventory rather than patching extracted copies or bypassing wrapper trust. The trace covers review artifacts, shell-resolved attribution tooling, TypeScript CLI shims, hosted gates, CI dispatch, and the publisher's canonical test-planner import closure. The same inventory continues to own dirty-file checks, revision comparisons, extraction, and per-blob verification.

The private extracted tree exposes only the four existing third-party tooling packages it requires (`tsx`, `zod`, `minimatch`, and `yaml`), not a whole `node_modules` link that could resolve unanchored workspace source. Hosted-gate normalization now imports the archived canonical implementation. Candidate build/test commands and candidate workflow inputs retain their existing ownership. There are no new packages, configuration options, runtime dependency resolvers, or fallback paths.

Native verification also exposed a nearby false-success path: a symlinked temporary/check-out path left helper arguments logical while Node canonicalized the module URL, so a direct-run guard could skip the helper and produce an empty artifact with exit 0. Resolve the wrapper's own path physically with `pwd -P`, preserving that canonical path through child execution. A real extracted-wrapper regression covers this path.

Wrapper, lock, and main-refresh fixtures now consume one inventory-driven source copier instead of maintaining incomplete parallel lists. Production LOC: **+84/-3, net +81**, principally 72 explicit source-closure entries plus physical wrapper-path normalization. Tests/support: **+315/-172, net +143**, including the shared fixture helper. Broad directory copies and a new runtime resolver would enlarge the trust surface or introduce another mechanism; restructuring the general test planner is not necessary for this repair.

## User Impact

No bot/runtime product behavior changes. Maintainers using the repaired launcher can execute the real review and gate helpers from a materialized anchor while retaining blob verification, restrictive 0700 temporary-root permissions, protected GitHub routing, and existing lock supervision.

Adoption boundary: an old invoking launcher still contains its old extraction inventory. Use an updated launcher when adopting this fix; advancing the fetched ref does not rewrite already-running or stale launcher bytes. The relevant helper flows still require the existing installed third-party toolchain.

## Evidence

Before the production repair, archiving the exact declared components into a fresh directory and dynamically importing the real review-artifact helper reproduced the missing `record-shared.mjs` error. The new extracted-anchor execution tests also failed against the original production code, exposing missing loader, attribution, and planner dependencies rather than being satisfied by marker stubs.

After repair, the real extracted review helper generates a correctly bound template and validates synthetic authored artifacts. Real CI/hosted-gate shims reach their argument guards, attribution tooling runs, the publisher emits its command, and the trusted planner discovers a non-sibling importing test from a synthetic candidate change. A tampered extracted dependency is refused before execution; the extracted root is asserted to be 0700. All execution proof uses disposable repositories, isolated HOME/Git/GitHub configuration, and fixture-owned or deny-all GitHub executables—no real GitHub writes or operator-state access.

Focused local proof (macOS; Node 24.20.0 and Node 26.8.1):

- Initial owner/sibling run: **315 tests passed** across wrapper, artifact validation, hosted verifier, watcher, CI dispatch, planner, and publisher suites.
- Expanded lock proof caught four incomplete sibling fixture inventories. The existing native cleanup table failed 4/5 before fixture repair and passed 5/5 afterward; no lifecycle assertion or production check was weakened.
- Final wrapper + operation-lock suites, including the physical-path regression: **137 passed**, one Linux-only zombie case skipped on macOS.
- Symlinked temporary-root regression: failed before physical-path normalization with exit 0 and empty output; passed afterward with a correctly PR/head-bound, nonempty template.
- Main-refresh suite: **36 passed**.
- Hosted merge + hosted-gate verifier suites: **100 passed**.
- Explicit Node 24 extracted-anchor execution/tamper selection: **3 passed**.
- Changed-scope checks, formatting, scripts/root-test typechecks, scripts lint, erasability, shell syntax, and `git diff --check`: passed.
- Codex autoreview: scoped-clean at the default P0 threshold.

Commands:

```bash
node scripts/run-vitest.mjs test/scripts/pr-wrappers.test.ts test/scripts/pr-review-artifact-validation.test.ts test/scripts/verify-pr-hosted-gates.test.ts test/scripts/watch-pr-ci.test.ts test/scripts/pr-ci-dispatch.test.ts test/scripts/pr-crabbox-gate-plan.test.ts test/scripts/pr-crabbox-gate-publisher.test.ts
```

```bash
node scripts/run-vitest.mjs test/scripts/pr-operation-lock.test.ts test/scripts/pr-wrappers.test.ts
```

```bash
node scripts/run-vitest.mjs test/scripts/pr-main-refresh.test.ts
```

```bash
node scripts/run-vitest.mjs test/scripts/pr-merge-hosted.test.ts test/scripts/verify-pr-hosted-gates.test.ts
```

```bash
node scripts/run-vitest.mjs test/scripts/pr-wrappers.test.ts -t 'extracted anchor'
```

```bash
node scripts/check-changed.mjs -- scripts/pr scripts/verify-pr-hosted-gates.mts test/scripts/pr-wrappers.test.ts test/scripts/pr-wrapper.test-support.ts test/scripts/pr-operation-lock.test.ts test/scripts/pr-main-refresh.test-support.ts
```

No full local product build/suite or authenticated end-to-end landing was used as proof of the candidate. Exact-head hosted CI and native landing verification remain required. Live open issue/PR searches for quoted `record-shared.mjs` plus `anchor`, and an additional anchor-closure PR search, found no matching open work before publication on 2026-08-31.
