### PR TITLE
test(tooling): reuse mobile release ref lifecycle fixtures

### DIFF
--- a/test/scripts/mobile-release-ref.test.ts
+++ b/test/scripts/mobile-release-ref.test.ts
@@ -1,8 +1,7 @@
 import { execFileSync } from "node:child_process";
-import { copyFileSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
-import os from "node:os";
+import { copyFileSync, mkdirSync, realpathSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   mobileReleaseRefFor,
   parseArgs,
@@ -10,8 +9,10 @@ import {
   recordMobileReleaseRef,
   resolveMobileReleaseRef,
 } from "../../scripts/mobile-release-ref.ts";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const SCRIPT_PATH = path.join(process.cwd(), "scripts", "mobile-release-ref.ts");
+const tempRoots = useAutoCleanupTempDirTracker(afterEach);
 
 function run(command: string, args: string[], cwd: string): string {
   return execFileSync(command, args, {
@@ -25,8 +26,8 @@ function git(cwd: string, args: string[]): string {
   return run("git", args, cwd);
 }
 
-function createFixtureRepo(): { cleanup: () => void; remote: string; root: string; sha: string } {
-  const root = mkdtempSync(path.join(os.tmpdir(), "openclaw-mobile-release-ref-"));
+function createFixtureRepo(): { remote: string; root: string; sha: string } {
+  const root = tempRoots.make("openclaw-mobile-release-ref-");
   const remote = path.join(root, "remote.git");
   const checkout = path.join(root, "checkout");
 
@@ -41,7 +42,6 @@ function createFixtureRepo(): { cleanup: () => void; remote: string; root: strin
   git(checkout, ["push", "origin", "HEAD:main"]);
 
   return {
-    cleanup: () => rmSync(root, { force: true, recursive: true }),
     remote: "origin",
     root: checkout,
     sha,
@@ -114,118 +114,86 @@ describe("mobile-release-ref", () => {
     ).toThrow("Invalid Android versionCode");
   });
 
-  it("creates, resolves, and idempotently accepts an existing same-SHA ref", () => {
+  it("records immutable platform refs and resolves the recorded SHA through the CLI", () => {
     const fixture = createFixtureRepo();
-    try {
-      const options = {
-        build: "8",
-        command: "record" as const,
-        platform: "ios" as const,
-        remote: fixture.remote,
-        rootDir: fixture.root,
-        sha: "HEAD",
-        version: "2026.6.10",
-        versionCode: null,
-      };
+    const iosOptions = {
+      build: "8",
+      command: "record" as const,
+      platform: "ios" as const,
+      remote: fixture.remote,
+      rootDir: fixture.root,
+      sha: "HEAD",
+      version: "2026.6.10",
+      versionCode: null,
+    };
 
-      expect(preflightMobileReleaseRef(options).status).toBe("available");
-      expect(recordMobileReleaseRef(options)).toMatchObject({
-        ref: "refs/openclaw/mobile-releases/ios/2026.6.10-8",
-        sha: fixture.sha,
-        status: "created",
-      });
-      expect(recordMobileReleaseRef(options).status).toBe("already-recorded");
-      expect(resolveMobileReleaseRef(options)).toMatchObject({
-        ref: "refs/openclaw/mobile-releases/ios/2026.6.10-8",
-        sha: fixture.sha,
-      });
-    } finally {
-      fixture.cleanup();
-    }
-  });
+    expect(preflightMobileReleaseRef(iosOptions).status).toBe("available");
+    expect(recordMobileReleaseRef(iosOptions)).toMatchObject({
+      ref: "refs/openclaw/mobile-releases/ios/2026.6.10-8",
+      sha: fixture.sha,
+      status: "created",
+    });
+    expect(recordMobileReleaseRef(iosOptions).status).toBe("already-recorded");
+    expect(resolveMobileReleaseRef(iosOptions)).toMatchObject({
+      ref: "refs/openclaw/mobile-releases/ios/2026.6.10-8",
+      sha: fixture.sha,
+    });
 
-  it("rejects an existing ref at a different SHA", () => {
-    const fixture = createFixtureRepo();
-    try {
-      const first = {
-        build: null,
-        command: "record" as const,
-        platform: "android" as const,
-        remote: fixture.remote,
-        rootDir: fixture.root,
-        sha: "HEAD",
-        version: "2026.6.10",
-        versionCode: "2026061008",
-      };
-      recordMobileReleaseRef(first);
+    const androidOptions = {
+      build: null,
+      command: "record" as const,
+      platform: "android" as const,
+      remote: fixture.remote,
+      rootDir: fixture.root,
+      sha: "HEAD",
+      version: "2026.6.10",
+      versionCode: "2026061008",
+    };
+    recordMobileReleaseRef(androidOptions);
 
-      writeFileSync(path.join(fixture.root, "README.md"), "next\n", "utf8");
-      git(fixture.root, ["add", "README.md"]);
-      git(fixture.root, ["commit", "-m", "next"]);
+    writeFileSync(path.join(fixture.root, "README.md"), "next\n", "utf8");
+    git(fixture.root, ["add", "README.md"]);
+    git(fixture.root, ["commit", "-m", "next"]);
 
-      expect(() => recordMobileReleaseRef(first)).toThrow("already points at");
-    } finally {
-      fixture.cleanup();
-    }
-  });
+    expect(() => recordMobileReleaseRef(androidOptions)).toThrow("already points at");
 
-  it("prints the resolved SHA from the CLI", () => {
-    const fixture = createFixtureRepo();
-    try {
-      recordMobileReleaseRef({
-        build: "9",
-        command: "record",
-        platform: "ios",
-        remote: fixture.remote,
-        rootDir: fixture.root,
-        sha: "HEAD",
-        version: "2026.6.10",
-        versionCode: null,
-      });
+    // CLI resolution must return the recorded build even after checkout HEAD advances.
+    const stdout = run(
+      process.execPath,
+      [
+        "--import",
+        "tsx",
+        SCRIPT_PATH,
+        "resolve",
+        "--platform",
+        "ios",
+        "--version",
+        "2026.6.10",
+        "--build",
+        "8",
+        "--root",
+        fixture.root,
+      ],
+      process.cwd(),
+    );
 
-      const stdout = run(
-        process.execPath,
-        [
-          "--import",
-          "tsx",
-          SCRIPT_PATH,
-          "resolve",
-          "--platform",
-          "ios",
-          "--version",
-          "2026.6.10",
-          "--build",
-          "9",
-          "--root",
-          fixture.root,
-        ],
-        process.cwd(),
-      );
-
-      expect(stdout).toBe(`${fixture.sha}\trefs/openclaw/mobile-releases/ios/2026.6.10-9\n`);
-    } finally {
-      fixture.cleanup();
-    }
+    expect(stdout).toBe(`${fixture.sha}\trefs/openclaw/mobile-releases/ios/2026.6.10-8\n`);
   });
 
   it("runs the CLI entrypoint from a path containing spaces", () => {
-    const root = mkdtempSync(path.join(os.tmpdir(), "openclaw mobile release ref-"));
-    try {
-      const scriptDir = path.join(root, "script dir");
-      const scriptPath = path.join(scriptDir, "mobile-release-ref.ts");
-      mkdirSync(scriptDir, { recursive: true });
-      writeFileSync(path.join(root, "package.json"), '{"type":"module"}\n', "utf8");
-      copyFileSync(SCRIPT_PATH, scriptPath);
+    const root = tempRoots.make("openclaw mobile release ref-");
+    const scriptDir = path.join(root, "script dir");
+    const scriptPath = path.join(scriptDir, "mobile-release-ref.ts");
+    mkdirSync(scriptDir, { recursive: true });
+    writeFileSync(path.join(root, "package.json"), '{"type":"module"}\n', "utf8");
+    copyFileSync(SCRIPT_PATH, scriptPath);
 
-      const stdout = run(
-        process.execPath,
-        ["--import", "tsx", realpathSync(scriptPath), "--help"],
-        process.cwd(),
-      );
+    const stdout = run(
+      process.execPath,
+      ["--import", "tsx", realpathSync(scriptPath), "--help"],
+      process.cwd(),
+    );
 
-      expect(stdout).toContain("scripts/mobile-release-ref.ts preflight");
-    } finally {
-      rmSync(root, { force: true, recursive: true });
-    }
+    expect(stdout).toContain("scripts/mobile-release-ref.ts preflight");
   });
 });


### PR DESCRIPTION
## What problem does this PR solve?

Three mobile release-ref tests repeatedly create the same real Git history. Their fixture allocates a temporary directory before the caller obtains its cleanup callback, so a Git setup failure leaves that directory until the test process exits.

## Why this approach?

Use one real lifecycle to record and resolve an iOS ref, reject an Android SHA mismatch, and resolve the original iOS SHA through the CLI after HEAD advances. Register temporary roots with the canonical cleanup tracker immediately on allocation. Remove two repeated repositories and one redundant record operation: 20 Git process starts.

## User impact

Test-only change; production +0/-0, tests +81/-113. All 15 assertion sites remain. The five cases retain numeric validation, immutable refs, idempotence, real CLI output and paths containing spaces.

## Evidence

Focused mobile and iOS/Android caller tests pass: 39 before, 37 after because three fixture cases become one. Full changed-file checks and Codex autoreview pass.

A temporary fault at the first Git setup call produces the same exit-97 failure on both versions. Before: its directory still exists after per-test cleanup. After: the cleanup hook already removed it. The runner later removes the baseline process directory, so this proves earlier cleanup, not a persistent leak. Both probes restored exact source bytes and verified child-process shutdown.

`node scripts/run-vitest.mjs test/scripts/mobile-release-ref.test.ts test/scripts/android-release-fastlane-gates.test.ts test/scripts/ios-release-fastlane-gates.test.ts`
