### PR TITLE
perf: reduce repeated work in Control UI history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Docs: https://docs.openclaw.ai
 - **Control UI sidebar usage:** remove the provider usage quota row from the expanded sidebar while keeping usage details available in the chat composer and Usage page. Thanks @shakkernerd.
 - **Android chat code highlighting:** render fenced Kotlin, Swift, TypeScript, JavaScript, Python, Bash, and JSON blocks with bounded, theme-aware syntax colors while preserving plain rendering for unknown, partial, or oversized blocks. (#100217)
 - **Gateway TTS playback:** add an operator-scoped `tts.speak` RPC that returns configured-provider speech as inline whole-clip audio for remote clients. (#100708, #100770)
+- **Control UI history rendering:** reuse parsed tool cards across transcript views, skip inactive tool-title preparation, and avoid redundant browser chrome updates while speeding up configuration-tier matching.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Docs: https://docs.openclaw.ai
 - **Control UI sidebar usage:** remove the provider usage quota row from the expanded sidebar while keeping usage details available in the chat composer and Usage page. Thanks @shakkernerd.
 - **Android chat code highlighting:** render fenced Kotlin, Swift, TypeScript, JavaScript, Python, Bash, and JSON blocks with bounded, theme-aware syntax colors while preserving plain rendering for unknown, partial, or oversized blocks. (#100217)
 - **Gateway TTS playback:** add an operator-scoped `tts.speak` RPC that returns configured-provider speech as inline whole-clip audio for remote clients. (#100708, #100770)
-- **Control UI history rendering:** reuse parsed tool cards across transcript views, skip inactive tool-title preparation, and avoid redundant browser chrome updates while speeding up configuration-tier matching.
+- **Control UI history rendering:** reuse parsed tool cards across transcript views, skip inactive tool-title preparation, and avoid redundant browser chrome updates while speeding up configuration-tier matching. (#134369)
 
 ### Fixes
 

--- a/src/config/schema.test.ts
+++ b/src/config/schema.test.ts
@@ -1310,6 +1310,150 @@ describe("config schema", () => {
     expect(hints["custom.tuningMs"]?.advanced).toBe(true);
   });
 
+  it.each([
+    [
+      "leading wildcard specificity",
+      [
+        ["custom.*.*", false],
+        ["*.item.value", true],
+      ],
+      "custom.item.value",
+      true,
+    ],
+    [
+      "earlier leading wildcard",
+      [
+        ["*.item.value", true],
+        ["custom.item.*", false],
+      ],
+      "custom.item.value",
+      true,
+    ],
+    [
+      "earlier rooted wildcard",
+      [
+        ["custom.item.*", false],
+        ["*.item.value", true],
+      ],
+      "custom.item.value",
+      false,
+    ],
+    [
+      "exact before wildcard",
+      [
+        ["custom.item.*", true],
+        ["custom.item.value", false],
+      ],
+      "custom.item.value",
+      false,
+    ],
+    [
+      "last exact alias",
+      [
+        ["custom..item.value", true],
+        ["custom.item.value", false],
+      ],
+      "custom.item.value",
+      false,
+    ],
+    [
+      "first array alias",
+      [
+        ["custom.items[]", true],
+        ["custom.items.*", false],
+      ],
+      "custom.items.*",
+      true,
+    ],
+    [
+      "first wildcard alias",
+      [
+        ["custom.items.*", false],
+        ["custom.items[]", true],
+      ],
+      "custom.items.*",
+      false,
+    ],
+  ] as const)("preserves tier precedence for %s", (_name, entries, target, expected) => {
+    const hints = applyResolvedConfigTierHints(
+      {
+        type: "object",
+        properties: {
+          custom: {
+            type: "object",
+            properties: {
+              item: { type: "object", properties: { value: { type: "string" } } },
+              items: { type: "array", items: { type: "string" } },
+            },
+          },
+        },
+      },
+      Object.fromEntries(entries.map(([key, advanced]) => [key, { advanced }])),
+    );
+    expect(hints[target]?.advanced).toBe(expected);
+  });
+
+  it.each(["anyOf", "oneOf", "allOf"])(
+    "resolves numeric %s branches before inheriting child tiers",
+    (composition) => {
+      const branches = [
+        { type: "object", properties: { child: { type: "string" } } },
+        { type: "integer" },
+      ];
+      for (const variants of [branches, branches.toReversed()]) {
+        const hints = applyResolvedConfigTierHints(
+          {
+            type: "object",
+            properties: {
+              custom: {
+                type: "object",
+                properties: { choice: { [composition]: variants } },
+              },
+            },
+          },
+          { custom: { advanced: false } },
+        );
+        expect(hints["custom.choice"]?.advanced).toBe(true);
+        expect(hints["custom.choice.child"]?.advanced).toBe(true);
+      }
+    },
+  );
+
+  it.each([false, true])(
+    "ranks generated numeric wildcards with authored tiers (explicit common=%s)",
+    (explicitCommon) => {
+      const hints = applyResolvedConfigTierHints(
+        {
+          type: "object",
+          properties: {
+            custom: {
+              type: "object",
+              properties: {
+                group: {
+                  type: "object",
+                  properties: {
+                    item: {
+                      type: "object",
+                      properties: { value: { type: "string" } },
+                      additionalProperties: { type: "integer" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+        {
+          custom: { advanced: false },
+          "custom.*.*.value": { advanced: false },
+          ...(explicitCommon ? { "custom.group.item.value": { advanced: false } } : {}),
+        },
+      );
+      expect(hints["custom.group.item.*"]?.advanced).toBe(true);
+      expect(hints["custom.group.item.value"]?.advanced).toBe(!explicitCommon);
+    },
+  );
+
   it("looks up root config schema children without returning the full schema tree", () => {
     const lookup = lookupConfigSchema(baseSchema, ".");
     expect(lookup?.path).toBe(".");

--- a/src/config/schema.tiers.ts
+++ b/src/config/schema.tiers.ts
@@ -192,11 +192,10 @@ function splitPath(path: string): string[] {
 }
 
 function createTierMatcher(hints: ConfigUiHints): (path: string) => boolean | undefined {
+  type TierRule = { parts: string[]; advanced: boolean; wildcardCount: number; order: number };
   const exact = new Map<string, boolean>();
-  const wildcardByLength = new Map<
-    number,
-    Array<{ parts: string[]; advanced: boolean; wildcardCount: number }>
-  >();
+  const wildcardsByPrefix = new Map<string, TierRule[]>();
+  let order = 0;
   for (const [hintPath, hint] of Object.entries(hints)) {
     if (typeof hint.advanced !== "boolean") {
       continue;
@@ -207,42 +206,53 @@ function createTierMatcher(hints: ConfigUiHints): (path: string) => boolean | un
       exact.set(parts.join("."), hint.advanced);
       continue;
     }
-    const bucket = wildcardByLength.get(parts.length) ?? [];
-    bucket.push({ parts, advanced: hint.advanced, wildcardCount });
-    wildcardByLength.set(parts.length, bucket);
+    const prefix = parts.slice(0, parts.indexOf("*")).join(".");
+    const key = `${parts.length}:${prefix}`;
+    const bucket = wildcardsByPrefix.get(key) ?? [];
+    bucket.push({ parts, advanced: hint.advanced, wildcardCount, order: order++ });
+    wildcardsByPrefix.set(key, bucket);
   }
-  for (const bucket of wildcardByLength.values()) {
+  for (const bucket of wildcardsByPrefix.values()) {
     bucket.sort((left, right) => left.wildcardCount - right.wildcardCount);
   }
   return (path) => {
+    const canonical = exact.get(path);
+    if (canonical !== undefined) {
+      return canonical;
+    }
     const parts = splitPath(path);
     const direct = exact.get(parts.join("."));
     if (direct !== undefined) {
       return direct;
     }
-    for (const candidate of wildcardByLength.get(parts.length) ?? []) {
-      if (candidate.parts.every((part, index) => part === "*" || part === parts[index])) {
-        return candidate.advanced;
+    let best: TierRule | undefined;
+    let prefix = parts.slice(0, -1).join(".");
+    // Prefixes narrow the search; specificity and authored order still decide
+    // precedence across buckets, including the empty prefix for leading wildcards.
+    for (;;) {
+      const candidate = wildcardsByPrefix
+        .get(`${parts.length}:${prefix}`)
+        ?.find((rule) => rule.parts.every((part, index) => part === "*" || part === parts[index]));
+      if (
+        candidate &&
+        (!best ||
+          candidate.wildcardCount < best.wildcardCount ||
+          (candidate.wildcardCount === best.wildcardCount && candidate.order < best.order))
+      ) {
+        best = candidate;
       }
+      if (!prefix) {
+        break;
+      }
+      prefix = prefix.slice(0, Math.max(0, prefix.lastIndexOf(".")));
     }
-    return undefined;
+    return best?.advanced;
   };
 }
 
 function isNumericSchema(schema: ConfigJsonSchemaObject): boolean {
   const types = Array.isArray(schema.type) ? schema.type : [schema.type];
   return types.includes("number") || types.includes("integer");
-}
-
-function isNumericCommonException(path: string): boolean {
-  return splitPath(path).at(-1) === "port";
-}
-
-function resolveTier(params: { inheritedTier: boolean; ownTier: boolean | undefined }): boolean {
-  if (params.ownTier !== undefined) {
-    return params.ownTier;
-  }
-  return params.inheritedTier;
 }
 
 function mergeTierHint(hints: ConfigUiHints, path: string, advanced: boolean): void {
@@ -311,42 +321,30 @@ export function applyConfigTierHints(
   return next;
 }
 
-function applyNumericTuningTierHints(
+/** Materialize the resolved tier on every schema path for RPC/UI consumers. */
+export function applyResolvedConfigTierHints(
   schema: Record<string, unknown>,
   hints: ConfigUiHints,
 ): ConfigUiHints {
   const next = { ...hints };
   const authoredTier = createTierMatcher(hints);
+  // Discover numeric defaults across every composition branch before resolving
+  // inheritance; generated wildcard hints participate in normal tier precedence.
   visitSchemaNodes(schema, undefined, (node, path) => {
     if (
       path &&
       isNumericSchema(node) &&
-      !isNumericCommonException(path) &&
+      splitPath(path).at(-1) !== "port" &&
       authoredTier(path) === undefined
     ) {
       mergeTierHint(next, path, true);
     }
     return undefined;
   });
-  return next;
-}
-
-/** Materialize the resolved tier on every schema path for RPC/UI consumers. */
-export function applyResolvedConfigTierHints(
-  schema: Record<string, unknown>,
-  hints: ConfigUiHints,
-): ConfigUiHints {
-  const tierHints = applyNumericTuningTierHints(schema, hints);
-  const next = { ...tierHints };
-  const matchTier = createTierMatcher(tierHints);
+  const matchTier = createTierMatcher(next);
 
   visitSchemaNodes(schema, true, (_node, path, inheritedTier) => {
-    const advanced = path
-      ? resolveTier({
-          inheritedTier,
-          ownTier: matchTier(path),
-        })
-      : inheritedTier;
+    const advanced = path ? (matchTier(path) ?? inheritedTier) : inheritedTier;
     if (path) {
       mergeTierHint(next, path, advanced);
     }

--- a/ui/src/app/app-host-native-shell.test.ts
+++ b/ui/src/app/app-host-native-shell.test.ts
@@ -20,7 +20,7 @@ type ShellNavigationState = {
   handleNativeHistoryState: (event: Event) => void;
   nativeHistoryState: { canGoBack: boolean; canGoForward: boolean };
   onboarding: boolean;
-  updated: () => void;
+  updated: (changedProperties: Map<string, unknown>) => void;
 };
 
 type ShellSettingsEscapeState = ShellKeyboardState & {
@@ -457,10 +457,10 @@ describe("OpenClaw native shell", () => {
       } as unknown as ApplicationContext,
     };
 
-    shell.updated();
-    shell.updated();
+    shell.updated(new Map());
+    shell.updated(new Map());
     snapshot.navCollapsed = true;
-    shell.updated();
+    shell.updated(new Map());
 
     expect(postMessage.mock.calls).toEqual([
       [{ type: "nav-state", collapsed: false, width: 280 }],

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -1,3 +1,4 @@
+import type { PropertyValues } from "lit";
 import { property, query, state } from "lit/decorators.js";
 import type { GatewayBrowserClient, GatewayEventFrame } from "../api/gateway.ts";
 import "../components/app-topbar.ts";
@@ -649,9 +650,13 @@ class OpenClawShell
     }
   }
 
-  override updated() {
+  override updated(changed: PropertyValues<this>) {
     this.syncDocumentTitle();
-    syncControlUiSystemChrome();
+    // Theme and breakpoint owners sync their changes; route/runtime changes
+    // can change whether the committed shell uses the chat background.
+    if (changed.has("routeState") || changed.has("runtime")) {
+      syncControlUiSystemChrome();
+    }
     // Render-gated pending lazy actions replay on the update that first
     // renders their element, independent of further context updates.
     this.restorePendingLazyAction();

--- a/ui/src/e2e/theme-typography.e2e.test.ts
+++ b/ui/src/e2e/theme-typography.e2e.test.ts
@@ -10,6 +10,7 @@ import { finishElementAnimations } from "../test-helpers/animations.ts";
 import {
   controlUiBundledGatewayUrl,
   installMockGateway,
+  waitForControlUiRoute,
   waitForControlUiSettingsTakeover,
 } from "../test-helpers/control-ui-e2e.ts";
 import { requireRecord, requireString } from "./chat-flow.test-support.ts";
@@ -398,8 +399,116 @@ suite.define(() => {
     },
   );
 
+  it("keeps system chrome with the mounted route across shell and viewport lifecycles", async () => {
+    const { page } = await openThemedChat("claw", "light");
+    await page.setViewportSize({ width: 720, height: 900 });
+    await page.goto(`${suite.server.baseUrl}chat`);
+    await page.locator(".agent-chat__composer-combobox textarea").waitFor();
+
+    const readChrome = () =>
+      page.evaluate(() => ({
+        color: document.documentElement.style.getPropertyValue(
+          "--control-ui-system-chrome-background",
+        ),
+        metas: Array.from(
+          document.querySelectorAll<HTMLMetaElement>('meta[name="theme-color"]'),
+          (meta) => ({ color: meta.content, media: meta.getAttribute("media") }),
+        ),
+      }));
+    const expectChrome = async (color: string) => {
+      await expect.poll(readChrome).toEqual({
+        color,
+        metas: [
+          { color, media: null },
+          { color, media: null },
+        ],
+      });
+    };
+    const pageColor = "#faf9f7";
+    const chatColor = "#f4f1ec";
+    await expectChrome(chatColor);
+
+    // Use the shell's actual shortcut and browser history without rebuilding the runtime.
+    await page.locator(".shell-skip-link").focus();
+    await page.keyboard.press("ControlOrMeta+Shift+,");
+    await waitForControlUiRoute(page, { pathname: "/settings/appearance", routeId: "appearance" });
+    await expectChrome(pageColor);
+    await page.goBack();
+    await page.locator(".agent-chat__composer-combobox textarea").waitFor();
+    await expectChrome(chatColor);
+    await page.locator(".chat-pane__nav-toggle").first().click();
+    await page.locator("openclaw-app-sidebar .sidebar-brand__new-thread").click();
+    await page.locator(".new-session-page__message").waitFor();
+    await expectChrome(chatColor);
+
+    for (const [width, height, color] of [
+      [1280, 900, pageColor],
+      [900, 450, chatColor],
+      [900, 900, pageColor],
+      [720, 900, chatColor],
+    ] as const) {
+      await page.setViewportSize({ width, height });
+      await expectChrome(color);
+    }
+
+    // Runtime removal renders nothing; restoration must rebind the existing router.
+    const runtimeLifecycle = await page.locator("openclaw-app-shell").evaluate(async (element) => {
+      const shell = element as HTMLElement & {
+        runtime?: import("../app/bootstrap.ts").ApplicationRuntime;
+        updateComplete: Promise<boolean>;
+      };
+      const runtime = shell.runtime;
+      const color = () =>
+        document.documentElement.style.getPropertyValue("--control-ui-system-chrome-background");
+      try {
+        shell.runtime = undefined;
+        await shell.updateComplete;
+        const removed = { color: color(), chat: Boolean(shell.querySelector(".shell--chat")) };
+        shell.runtime = runtime;
+        await shell.updateComplete;
+        return {
+          removed,
+          restored: { color: color(), chat: Boolean(shell.querySelector(".shell--chat")) },
+        };
+      } finally {
+        shell.runtime = runtime;
+      }
+    });
+    expect(runtimeLifecycle).toEqual({
+      removed: { color: pageColor, chat: false },
+      restored: { color: chatColor, chat: true },
+    });
+    await expectChrome(chatColor);
+
+    const reconnect = await page.locator("openclaw-app-shell").evaluate(async (element) => {
+      const shell = element as HTMLElement & { updateComplete: Promise<boolean> };
+      const parent = shell.parentNode!;
+      const next = shell.nextSibling;
+      const color = () =>
+        document.documentElement.style.getPropertyValue("--control-ui-system-chrome-background");
+      try {
+        shell.remove();
+        const removed = color();
+        parent.insertBefore(shell, next);
+        await shell.updateComplete;
+        return {
+          removed,
+          reconnected: color(),
+          sameShell: document.querySelector("openclaw-app-shell") === shell,
+        };
+      } finally {
+        if (!shell.isConnected) {
+          parent.insertBefore(shell, next);
+        }
+      }
+    });
+    expect(reconnect).toEqual({ removed: pageColor, reconnected: chatColor, sameShell: true });
+    await expectChrome(chatColor);
+  });
+
   it("publishes a runtime palette only when its colors are ready and ignores superseded loads", async () => {
-    const { page, gateway } = await openThemedChat("knot", "dark");
+    const { page, gateway } = await openThemedChat("knot", "light");
+    await page.setViewportSize({ width: 720, height: 900 });
     let releasePalette!: () => void;
     const paletteGate = new Promise<void>((resolve) => {
       releasePalette = resolve;
@@ -413,7 +522,7 @@ suite.define(() => {
     await page.evaluate(() => {
       const root = document.documentElement;
       new MutationObserver(() => {
-        if (root.dataset.theme === "tide") {
+        if (root.dataset.theme === "tide-light") {
           root.dataset.observedThemeBackground = getComputedStyle(root)
             .getPropertyValue("--bg")
             .trim();
@@ -421,21 +530,21 @@ suite.define(() => {
       }).observe(root, { attributes: true, attributeFilter: ["data-theme"] });
     });
     const changeTheme = async (theme: string) => {
-      await gateway.setMethodResponse("config.get", themeConfigResponse(theme, "dark"));
+      await gateway.setMethodResponse("config.get", themeConfigResponse(theme, "light"));
       await gateway.emitGatewayEvent("config.changed", { hash: `theme-${theme}`, ts: Date.now() });
     };
     try {
       const request = page.waitForRequest("**/themes/tide.css");
       await changeTheme("tide");
       await request;
-      expect(await page.locator("html").getAttribute("data-theme")).toBe("openknot");
+      expect(await page.locator("html").getAttribute("data-theme")).toBe("openknot-light");
       expect(
         await page.evaluate(() =>
           getComputedStyle(document.documentElement).getPropertyValue("--bg").trim(),
         ),
-      ).toBe("#080808");
+      ).toBe("#f9f9fb");
       await changeTheme("beacon");
-      await expect.poll(() => page.locator("html").getAttribute("data-theme")).toBe("beacon");
+      await expect.poll(() => page.locator("html").getAttribute("data-theme")).toBe("beacon-light");
       const response = page.waitForResponse("**/themes/tide.css");
       releasePalette();
       await response;
@@ -445,16 +554,16 @@ suite.define(() => {
             requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
           }),
       );
-      expect(await page.locator("html").getAttribute("data-theme")).toBe("beacon");
+      expect(await page.locator("html").getAttribute("data-theme")).toBe("beacon-light");
       await changeTheme("tide");
       await expect
         .poll(() => page.locator("html").getAttribute("data-observed-theme-background"))
-        .toBe("#10151b");
+        .toBe("#f7f9fb");
       expect(await page.locator('meta[name="theme-color"]').first().getAttribute("content")).toBe(
-        "#10151b",
+        "#eef2f7",
       );
       await changeTheme("claw");
-      await expect.poll(() => page.locator("html").getAttribute("data-theme")).toBe("dark");
+      await expect.poll(() => page.locator("html").getAttribute("data-theme")).toBe("light");
     } finally {
       releasePalette();
     }

--- a/ui/src/lib/chat/browser-tab-preview.test.ts
+++ b/ui/src/lib/chat/browser-tab-preview.test.ts
@@ -44,7 +44,7 @@ function screenshotClient() {
 }
 
 describe("browser tab previews", () => {
-  it("keeps anonymous result revisions stable across rendering prefixes but distinct across results", () => {
+  it("keeps anonymous result revisions stable across reads but distinct across results", () => {
     const message = {
       role: "toolResult",
       toolName: "browser",
@@ -52,7 +52,7 @@ describe("browser tab previews", () => {
     };
     const initial = latestBrowserTabCards([message], []).get(tabKey())?.revision;
     expect(initial).toBeTruthy();
-    expect(extractToolCardsCached(message, "visible-row")[0]?.previewRevision).toBe(initial);
+    expect(extractToolCardsCached(message)[0]?.previewRevision).toBe(initial);
     expect(latestBrowserTabCards([message, { ...message }], []).get(tabKey())?.revision).not.toBe(
       initial,
     );

--- a/ui/src/lib/chat/tool-cards.ts
+++ b/ui/src/lib/chat/tool-cards.ts
@@ -252,14 +252,8 @@ function resolveToolCardId(
   item: Record<string, unknown>,
   message: Record<string, unknown>,
   index: number,
-  prefix = "tool",
 ): string {
-  const explicitId = resolveToolCallId(item, message);
-  if (explicitId) {
-    return `${prefix}:${explicitId}`;
-  }
-  const name = resolveToolName(item, message);
-  return `${prefix}:${name}:${index}`;
+  return resolveToolCallId(item, message) ?? `${resolveToolName(item, message)}:${index}`;
 }
 
 function serializeToolInput(args: unknown): string | undefined {
@@ -349,10 +343,9 @@ export function resolveCollapsedToolArgumentPreview(args: unknown): string | und
   return undefined;
 }
 
-const anonymousPreviewRevisions = new WeakMap<object, number>();
 let nextPreviewRevision = 0;
 
-function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] {
+function extractToolCards(message: unknown): ToolCard[] {
   const m = message as Record<string, unknown>;
   const role = typeof m.role === "string" ? m.role.toLowerCase() : "";
   const isStandaloneToolMessage =
@@ -389,7 +382,7 @@ function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] {
       const callId = resolveToolCallId(item, m);
       const details = item.details ?? m.details;
       cards.push({
-        id: resolveToolCardId(item, m, index, prefix),
+        id: resolveToolCardId(item, m, index),
         ...(callId ? { callId } : {}),
         name: resolveToolName(item, m),
         args,
@@ -406,7 +399,7 @@ function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] {
 
     if (isToolResultContentType(item.type)) {
       const name = resolveToolName(item, m);
-      const cardId = resolveToolCardId(item, m, index, prefix);
+      const cardId = resolveToolCardId(item, m, index);
       const callId = resolveToolCallId(item, m);
       const existing =
         cards.find((card) => card.id === cardId) ??
@@ -477,7 +470,7 @@ function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] {
     const callId = resolveToolCallId({}, m);
     const exitCode = readToolExitCode(m, m.details, text ? parseJsonRecord(text) : undefined);
     cards.push({
-      id: resolveToolCardId({}, m, 0, prefix),
+      id: resolveToolCardId({}, m, 0),
       ...(callId ? { callId } : {}),
       name,
       completed: isToolResultMessage(message) || role === "tool" || role === "function",
@@ -490,36 +483,28 @@ function extractToolCards(message: unknown, prefix = "tool"): ToolCard[] {
     });
   }
 
+  let revision: number | undefined;
   for (const [index, card] of cards.entries()) {
     if (card.preview?.kind !== "browser-tab" || card.callId || card.messageId) {
       continue;
     }
-    let revision = anonymousPreviewRevisions.get(m);
-    if (revision === undefined) {
-      revision = ++nextPreviewRevision;
-      anonymousPreviewRevisions.set(m, revision);
-    }
+    revision ??= ++nextPreviewRevision;
     card.previewRevision = `${revision}:${index}`;
   }
   return cards;
 }
 
-const toolCardsByMessage = new WeakMap<object, Map<string, ToolCard[]>>();
+const toolCardsByMessage = new WeakMap<object, ToolCard[]>();
 
-export function extractToolCardsCached(message: unknown, prefix = "tool"): ToolCard[] {
+export function extractToolCardsCached(message: unknown): ToolCard[] {
   if (!message || typeof message !== "object") {
-    return extractToolCards(message, prefix);
+    return extractToolCards(message);
   }
-  let byPrefix = toolCardsByMessage.get(message);
-  if (!byPrefix) {
-    byPrefix = new Map();
-    toolCardsByMessage.set(message, byPrefix);
-  }
-  const cached = byPrefix.get(prefix);
+  const cached = toolCardsByMessage.get(message);
   if (cached) {
     return cached;
   }
-  const cards = extractToolCards(message, prefix);
-  byPrefix.set(prefix, cards);
+  const cards = extractToolCards(message);
+  toolCardsByMessage.set(message, cards);
   return cards;
 }

--- a/ui/src/pages/chat/chat-thread-items.ts
+++ b/ui/src/pages/chat/chat-thread-items.ts
@@ -99,7 +99,7 @@ export function extractChatMessagePreview(toolMessage: unknown): ChatMessagePrev
   if (!safeNormalizeMessage(toolMessage)) {
     return null;
   }
-  const cards = extractToolCardsCached(toolMessage, "preview");
+  const cards = extractToolCardsCached(toolMessage);
   for (let index = cards.length - 1; index >= 0; index--) {
     const card = cards[index];
     if (card?.preview?.kind === "canvas") {

--- a/ui/src/pages/chat/chat-thread.nested-activity.test.ts
+++ b/ui/src/pages/chat/chat-thread.nested-activity.test.ts
@@ -61,20 +61,14 @@ describe("durable nested activity composition", () => {
   it("repositions separately arriving completions without changing raw history", () => {
     const exec = completedCall("exec", "exec", 1);
     const second = completedCall("second", "read", 3, { afterRawSeq: 1, startOrder: 1 });
-    expect(renderedToolIds([user, exec, second])).toEqual(["tool:exec", "tool:second"]);
+    expect(renderedToolIds([user, exec, second])).toEqual(["exec", "second"]);
 
     const wait = completedCall("wait", "wait", 4);
     const first = completedCall("first", "read", 5, { afterRawSeq: 1, startOrder: 0 });
     const third = completedCall("third", "read", 6, { afterRawSeq: 4, startOrder: 2 });
     const history = [user, exec, second, wait, first, third];
     const original = structuredClone(history);
-    expect(renderedToolIds(history)).toEqual([
-      "tool:exec",
-      "tool:first",
-      "tool:second",
-      "tool:wait",
-      "tool:third",
-    ]);
+    expect(renderedToolIds(history)).toEqual(["exec", "first", "second", "wait", "third"]);
     expect(history).toEqual(original);
   });
 
@@ -89,11 +83,7 @@ describe("durable nested activity composition", () => {
       __openclawToolStreamResultReceived: true,
       timestamp: 0,
     };
-    expect(renderedToolIds([user, exec, wait, first], [live])).toEqual([
-      "tool:exec",
-      "tool:first",
-      "tool:wait",
-    ]);
+    expect(renderedToolIds([user, exec, wait, first], [live])).toEqual(["exec", "first", "wait"]);
   });
 
   it.each([
@@ -143,13 +133,7 @@ describe("durable nested activity composition", () => {
         return cards.length > 0 ? cards.map((card) => card.id) : [item.role];
       });
     });
-    expect(visibleOrder).toEqual([
-      "user",
-      "stream",
-      "tool:exec",
-      ...ids.map((id) => `tool:${id}`),
-      "tool:wait",
-    ]);
+    expect(visibleOrder).toEqual(["user", "stream", "exec", ...ids, "wait"]);
     const rendered = items.flatMap((item) =>
       item.kind === "group" ? item.messages.map(({ message }) => message) : [],
     );
@@ -183,11 +167,7 @@ describe("durable nested activity composition", () => {
       __openclawToolStreamResultReceived: true,
       timestamp: 0,
     };
-    expect(renderedToolIds([user, exec, wait, first], [live])).toEqual([
-      "tool:first",
-      "tool:exec",
-      "tool:wait",
-    ]);
+    expect(renderedToolIds([user, exec, wait, first], [live])).toEqual(["first", "exec", "wait"]);
   });
 
   it("uses a completed anchor's physical position rather than its relocated start", () => {
@@ -196,10 +176,10 @@ describe("durable nested activity composition", () => {
     const earlier = completedCall("earlier", "read", 5, { afterRawSeq: 1, startOrder: 0 });
     const later = completedCall("later", "read", 6, { afterRawSeq: 5, startOrder: 1 });
     expect(renderedToolIds([user, exec, wait, earlier, later])).toEqual([
-      "tool:exec",
-      "tool:earlier",
-      "tool:wait",
-      "tool:later",
+      "exec",
+      "earlier",
+      "wait",
+      "later",
     ]);
   });
 });

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -10,6 +10,7 @@ import type { MessageGroup } from "../../lib/chat/chat-types.ts";
 import { summarizeToolGroup } from "../../lib/chat/tool-call-grouping.ts";
 import * as toolCards from "../../lib/chat/tool-cards.ts";
 import { coalesceAgentRunFrames } from "./chat-agent-run-grouping.ts";
+import * as threadItems from "./chat-thread-items.ts";
 import {
   assistantGroupCanOwnActiveRunStatus,
   buildCachedChatItems,
@@ -1940,17 +1941,14 @@ describe("buildCachedChatItems working spark", () => {
 describe("buildCachedChatItems", () => {
   it("does not inspect ordinary transcript messages for tool previews", () => {
     const messages = [userMessage("hello", 1_000), assistantMessage("reply", 1_001)];
-    const previewExtraction = vi.spyOn(toolCards, "extractToolCardsCached");
+    const previewExtraction = vi.spyOn(threadItems, "extractChatMessagePreview");
+    try {
+      buildCachedChatItems(createProps({ paneId: "ordinary-transcript", messages }));
 
-    buildCachedChatItems(createProps({ paneId: "ordinary-transcript", messages }));
-
-    expect(
-      previewExtraction.mock.calls.filter(
-        ([message, prefix]) =>
-          messages.includes(message as (typeof messages)[number]) && prefix === "preview",
-      ),
-    ).toEqual([]);
-    previewExtraction.mockRestore();
+      expect(previewExtraction).not.toHaveBeenCalled();
+    } finally {
+      previewExtraction.mockRestore();
+    }
   });
 
   it("sender provenance separates namespaces without splitting profile renames", () => {
@@ -2230,7 +2228,7 @@ describe("buildCachedChatItems", () => {
     expect(groups).toHaveLength(1);
     expect(groupAt(groups, 0).role).toBe("tool");
     expect(groupAt(groups, 0).messages).toHaveLength(1);
-    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message, "coalesced");
+    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message);
     expect(cards).toHaveLength(1);
     expect(cards[0]).toMatchObject({
       callId: "call-shell",
@@ -2271,7 +2269,7 @@ describe("buildCachedChatItems", () => {
 
     expect(groups).toHaveLength(1);
     expect(groupAt(groups, 0).messages).toHaveLength(1);
-    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message, "native-reversed");
+    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message);
     expect(cards).toHaveLength(1);
     expect(cards[0]).toMatchObject({
       callId: "call-native",
@@ -2309,9 +2307,7 @@ describe("buildCachedChatItems", () => {
     });
 
     expect(groups).toHaveLength(1);
-    const cards = groupAt(groups, 0).messages.flatMap((entry, index) =>
-      extractToolCards(entry.message, `native-same-name-${index}`),
-    );
+    const cards = groupAt(groups, 0).messages.flatMap((entry) => extractToolCards(entry.message));
     expect(cards).toHaveLength(2);
     expect(cards.find((card) => card.callId === "call-a")).toMatchObject({
       args: { path: "a.ts" },
@@ -2347,7 +2343,7 @@ describe("buildCachedChatItems", () => {
 
     expect(groups).toHaveLength(1);
     expect(groupAt(groups, 0).messages).toHaveLength(1);
-    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message, "bundled-reversed");
+    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message);
     expect(cards.map((card) => [card.callId, card.args, card.outputText])).toEqual([
       ["call-a", { path: "a.ts" }, "contents of a"],
       ["call-b", { path: "b.ts" }, "contents of b"],
@@ -2376,7 +2372,7 @@ describe("buildCachedChatItems", () => {
 
     expect(groups).toHaveLength(1);
     const entries = groupAt(groups, 0).messages;
-    const cards = entries.flatMap((entry) => extractToolCards(entry.message, entry.key));
+    const cards = entries.flatMap((entry) => extractToolCards(entry.message));
     expect(cards.map((card) => [card.callId, card.args, card.outputText])).toEqual([
       ["call-a", { path: "a.ts" }, "contents of a"],
       ["call-b", { path: "b.ts" }, "contents of b"],
@@ -2397,9 +2393,7 @@ describe("buildCachedChatItems", () => {
     expect(groups).toHaveLength(1);
     expect(groupAt(groups, 0).role).toBe("tool");
     expect(groupAt(groups, 0).messages).toHaveLength(2);
-    const cards = groupAt(groups, 0).messages.flatMap((entry, index) =>
-      extractToolCards(entry.message, `interleaved-${index}`),
-    );
+    const cards = groupAt(groups, 0).messages.flatMap((entry) => extractToolCards(entry.message));
     expect(cards).toHaveLength(2);
     expect(cards[0]).toMatchObject({ callId: "call-a", outputText: "contents of a" });
     expect(cards[1]).toMatchObject({ callId: "call-b", outputText: "contents of b" });
@@ -2416,7 +2410,7 @@ describe("buildCachedChatItems", () => {
 
     expect(groups).toHaveLength(1);
     expect(groupAt(groups, 0).messages).toHaveLength(1);
-    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message, "repeated-snapshot");
+    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message);
     expect(cards).toHaveLength(1);
     expect(cards[0]).toMatchObject({
       callId: "call-x",
@@ -2452,7 +2446,7 @@ describe("buildCachedChatItems", () => {
       );
     const cardsFor = (messages: unknown[], toolMessages: unknown[] = []) =>
       messageGroups({ messages, toolMessages }).flatMap((group) =>
-        group.messages.flatMap((entry) => extractToolCards(entry.message, entry.key)),
+        group.messages.flatMap((entry) => extractToolCards(entry.message)),
       );
 
     it.each([
@@ -2511,7 +2505,7 @@ describe("buildCachedChatItems", () => {
         });
         const visible = groups.flatMap((group) =>
           group.messages.flatMap((entry) => {
-            const cards = extractToolCards(entry.message, entry.key);
+            const cards = extractToolCards(entry.message);
             return cards.length ? cards : [requireRecord(entry.message).content];
           }),
         );
@@ -2568,7 +2562,7 @@ describe("buildCachedChatItems", () => {
           toolMessages: [live],
         });
         const cards = groups.flatMap((group) =>
-          group.messages.flatMap((entry) => extractToolCards(entry.message, entry.key)),
+          group.messages.flatMap((entry) => extractToolCards(entry.message)),
         );
         expect(cards).toHaveLength(2);
         expect(cards.filter((card) => card.outputText === "working")).toHaveLength(1);
@@ -2644,7 +2638,7 @@ describe("buildCachedChatItems", () => {
         toolMessages: [snapshot("a"), snapshot("b")],
       });
       const entries = groups.flatMap((group) => group.messages);
-      const cards = entries.flatMap((entry) => extractToolCards(entry.message, entry.key));
+      const cards = entries.flatMap((entry) => extractToolCards(entry.message));
       expect(cards).toHaveLength(2);
       expect(cards.find((card) => card.callId === "a")).toMatchObject({
         args: { command: "first" },
@@ -2854,9 +2848,7 @@ describe("buildCachedChatItems", () => {
 
     expect(groups).toHaveLength(1);
     expect(groupAt(groups, 0).messages).toHaveLength(17);
-    const cards = groupAt(groups, 0).messages.flatMap((entry, index) =>
-      extractToolCards(entry.message, `many-open-${index}`),
-    );
+    const cards = groupAt(groups, 0).messages.flatMap((entry) => extractToolCards(entry.message));
     expect(cards).toHaveLength(17);
     expect(cards.find((card) => card.callId === "call-0")).toMatchObject({
       outputText: "first contents",
@@ -2880,9 +2872,7 @@ describe("buildCachedChatItems", () => {
 
     expect(groups).toHaveLength(1);
     expect(groupAt(groups, 0).messages).toHaveLength(2);
-    const cards = groupAt(groups, 0).messages.flatMap((entry, index) =>
-      extractToolCards(entry.message, `bundled-results-${index}`),
-    );
+    const cards = groupAt(groups, 0).messages.flatMap((entry) => extractToolCards(entry.message));
     expect(cards.map((card) => [card.callId, card.outputText])).toEqual([
       ["call-a", "contents of a"],
       ["call-b", "contents of b"],
@@ -2907,7 +2897,7 @@ describe("buildCachedChatItems", () => {
     expect(groups).toHaveLength(1);
     expect(groupAt(groups, 0).role).toBe("tool");
     expect(groupAt(groups, 0).messages).toHaveLength(1);
-    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message, "canonical-parallel");
+    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message);
     expect(cards).toHaveLength(2);
     expect(cards[0]).toMatchObject({
       callId: "call-a",
@@ -2944,7 +2934,7 @@ describe("buildCachedChatItems", () => {
     expect(groups).toHaveLength(1);
     expect(groupAt(groups, 0).role).toBe("tool");
     expect(groupAt(groups, 0).messages).toHaveLength(1);
-    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message, "canonical-provider");
+    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message);
     expect(cards.map((card) => [card.callId, card.outputText])).toEqual([
       ["call-a", "contents of a"],
       ["call-b", "contents of b"],
@@ -3019,7 +3009,7 @@ describe("buildCachedChatItems", () => {
 
     expect(groups).toHaveLength(1);
     expect(groupAt(groups, 0).messages).toHaveLength(1);
-    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message, "provider-coalesced");
+    const cards = extractToolCards(messageAt(groupAt(groups, 0), 0).message);
     expect(cards).toHaveLength(1);
     expect(cards[0]).toMatchObject({
       callId: "provider-call",
@@ -3679,8 +3669,8 @@ describe("buildCachedChatItems", () => {
       ],
     });
 
-    const cards = groups.flatMap((group, index) =>
-      group.messages.flatMap((entry) => extractToolCards(entry.message, `restored-${index}`)),
+    const cards = groups.flatMap((group) =>
+      group.messages.flatMap((entry) => extractToolCards(entry.message)),
     );
     expect(cards).toHaveLength(1);
     expect(cards[0]).toMatchObject({ callId: "call-read", name: "read" });

--- a/ui/src/pages/chat/chat-thread.ts
+++ b/ui/src/pages/chat/chat-thread.ts
@@ -393,17 +393,14 @@ export function getExpandedUserMessages(sessionKey: string): Map<string, boolean
   return getOrCreateSessionCacheValue(expandedUserMessagesBySession, sessionKey, () => new Map());
 }
 
-export function collectToolTitleCandidates(items: readonly (ChatItem | MessageGroup)[]) {
-  return items.flatMap((item) =>
-    item.kind === "group"
-      ? item.messages.flatMap((entry) =>
-          extractToolCardsCached(entry.message, entry.key).map(({ args, name }) => ({
-            args,
-            name,
-          })),
-        )
-      : [],
-  );
+export function* collectToolTitleCandidates(items: readonly (ChatItem | MessageGroup)[]) {
+  for (const item of items) {
+    if (item.kind === "group") {
+      for (const entry of item.messages) {
+        yield* extractToolCardsCached(entry.message);
+      }
+    }
+  }
 }
 
 export type AssistantMessageExpansionState =
@@ -466,7 +463,7 @@ export function syncToolCardExpansionState(
       continue;
     }
     for (const entry of item.messages) {
-      const cards = extractToolCardsCached(entry.message, entry.key);
+      const cards = extractToolCardsCached(entry.message);
       for (let cardIndex = 0; cardIndex < cards.length; cardIndex++) {
         const disclosureId = `${entry.key}:toolcard:${cardIndex}`;
         currentToolCardIds.add(disclosureId);

--- a/ui/src/pages/chat/chat-tool-activity-coalesce.ts
+++ b/ui/src/pages/chat/chat-tool-activity-coalesce.ts
@@ -69,7 +69,7 @@ function readProjections(item: MessageItem, index: number): Projection[] {
   // Resolve no-id fallback once through the card owner. Keep anonymous pairs
   // in the source while identified siblings still join the invocation registry.
   if (blocks.some((block) => !resolveToolBlockId(asRecord(block)!, message!))) {
-    const pending = [...extractToolCardsCached(message, item.key)];
+    const pending = [...extractToolCardsCached(message)];
     content = content.flatMap((block) => {
       if (!isToolBlock(block)) {
         return [block];
@@ -100,7 +100,7 @@ function readProjections(item: MessageItem, index: number): Projection[] {
   }
   const standalone = blocks.length === 0;
   if (standalone) {
-    const [card] = extractToolCardsCached(message, item.key);
+    const [card] = extractToolCardsCached(message);
     if (!card?.callId) {
       return [];
     }

--- a/ui/src/pages/chat/components/chat-json-text.test.ts
+++ b/ui/src/pages/chat/components/chat-json-text.test.ts
@@ -126,7 +126,12 @@ describe("tool JSON details", () => {
     render(
       renderToolCard(
         { id: "json-tool", name: "lookup", outputText: text, completed: true },
-        { expanded: true, onToggleExpanded: vi.fn(), onOpenSidebar: openSidebar },
+        {
+          messageKey: "test-message",
+          expanded: true,
+          onToggleExpanded: vi.fn(),
+          onOpenSidebar: openSidebar,
+        },
       ),
       container,
     );

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -88,7 +88,6 @@ function canonicalImageMessageKey(message: unknown, sessionKey: string | undefin
 function renderInlineToolCards(
   toolCards: ToolCard[],
   opts: Omit<Parameters<typeof renderToolCard>[1], "expanded" | "onToggleExpanded"> & {
-    messageKey: string;
     isToolExpanded?: (toolCardId: string) => boolean;
     onToggleToolExpanded?: (toolCardId: string, expanded?: boolean) => void;
   },
@@ -258,7 +257,7 @@ export function renderGroupedMessage(
   const isToolShell = normalizedRole === "tool";
   const isStandaloneToolMessage = isStandaloneToolMessageForDisplay(message);
 
-  const toolCards = (opts.showToolCalls ?? true) ? extractToolCardsCached(message, messageKey) : [];
+  const toolCards = (opts.showToolCalls ?? true) ? extractToolCardsCached(message) : [];
   const hasToolCards = toolCards.length > 0;
   schedulePairingQrExpiryRefresh(messageKey, message, opts.onRequestUpdate);
   const images = extractImages(message);

--- a/ui/src/pages/chat/components/chat-message-group.ts
+++ b/ui/src/pages/chat/components/chat-message-group.ts
@@ -185,12 +185,10 @@ export function renderActivityGroup(
     return nothing;
   }
   const cards = groups.flatMap((group) =>
-    group.messages.flatMap((item) => extractToolCardsCached(item.message, item.key)),
+    group.messages.flatMap((item) => extractToolCardsCached(item.message)),
   );
   const latestGroup = groups[groups.length - 1] ?? firstGroup;
-  const latestCards = latestGroup.messages.flatMap((item) =>
-    extractToolCardsCached(item.message, item.key),
-  );
+  const latestCards = latestGroup.messages.flatMap((item) => extractToolCardsCached(item.message));
   // While a run is live, the newest still-running call names the group so
   // the collapsed header reads like a status line; afterwards it aggregates.
   const runningCard = opts.runActive
@@ -311,7 +309,7 @@ function isActivityMessageGroup(group: MessageGroup): boolean {
   if (normalizeRoleForGrouping(group.role) !== "tool") {
     return false;
   }
-  const cards = group.messages.flatMap((item) => extractToolCardsCached(item.message, item.key));
+  const cards = group.messages.flatMap((item) => extractToolCardsCached(item.message));
   return (
     group.messages.length > 1 ||
     cards.length > 1 ||

--- a/ui/src/pages/chat/components/chat-tool-card-identity.browser.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-card-identity.browser.test.ts
@@ -1,0 +1,149 @@
+import { html, nothing, render } from "lit";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { renderGroupedMessage } from "./chat-message-bubble.ts";
+
+const containers: HTMLElement[] = [];
+afterEach(() => {
+  for (const container of containers.splice(0)) {
+    render(nothing, container);
+    container.remove();
+  }
+  window.getSelection()?.removeAllRanges();
+});
+
+function fixture(mode: "inline" | "standalone") {
+  const rows = ["a", "b"].map((suffix) => {
+    const output = `Applied ${suffix}`;
+    const args = JSON.stringify({
+      changes: [
+        { path: `src/${suffix}.ts`, kind: { type: "update" }, diff: "@@ -1 +1 @@\n-old\n+new\n" },
+      ],
+    });
+    return {
+      key: `message:${suffix}`,
+      output,
+      message: {
+        role: "assistant",
+        timestamp: 1_700_000_000_000,
+        ...(mode === "standalone" ? { toolCallId: "shared-call", toolName: "apply_patch" } : {}),
+        content: [
+          ...(mode === "standalone" ? [{ type: "text", text: output }] : []),
+          { type: "toolcall", id: "shared-call", name: "apply_patch", arguments: args },
+          { type: "toolresult", id: "shared-call", name: "apply_patch", text: output },
+        ],
+      },
+    };
+  });
+  const container = document.body.appendChild(document.createElement("div"));
+  containers.push(container);
+  const toggledKeys: string[] = [];
+  const expansion = new Map<string, boolean>();
+  for (const row of rows) {
+    expansion.set(`${row.key}:toolcard:0`, true);
+    expansion.set(`toolmsg:${row.key}`, true);
+  }
+  const draw = () =>
+    render(
+      html`${rows.map((row) =>
+        renderGroupedMessage(row.message, row.key, {
+          isStreaming: false,
+          showReasoning: false,
+          showToolCalls: true,
+          isToolExpanded: (key) => expansion.get(key) ?? false,
+          isToolMessageExpanded: (key) => expansion.get(key),
+          onToggleToolExpanded: toggle,
+          onToggleToolMessageExpanded: toggle,
+        }),
+      )}`,
+      container,
+    );
+  function toggle(key: string) {
+    toggledKeys.push(key);
+    expansion.set(key, !expansion.get(key));
+    draw();
+  }
+  return { rows, container, draw, toggledKeys };
+}
+
+async function settleTabs(container: HTMLElement) {
+  await Promise.all(
+    ["wa-tab-group", "wa-tab", "wa-tab-panel"].map((tag) => customElements.whenDefined(tag)),
+  );
+  await Promise.all(
+    Array.from(
+      container.querySelectorAll<HTMLElement & { updateComplete: Promise<unknown> }>(
+        "wa-tab-group, wa-tab, wa-tab-panel",
+      ),
+      (element) => element.updateComplete,
+    ),
+  );
+}
+
+describe
+  .skipIf(navigator.userAgent.toLowerCase().includes("jsdom"))
+  .each(["inline", "standalone"] as const)("%s tool message disclosures", (mode) => {
+  it("preserves message-scoped IDs and independent Raw tabs for reused call IDs", async () => {
+    const { rows, container, draw, toggledKeys } = fixture(mode);
+    draw();
+    await settleTabs(container);
+    const bubbles = Array.from(container.querySelectorAll<HTMLElement>(".chat-bubble"));
+    expect(bubbles.map((bubble) => bubble.dataset.messageId)).toEqual(rows.map((row) => row.key));
+    expect(container.querySelectorAll(".chat-tools-inline")).toHaveLength(
+      mode === "inline" ? 2 : 0,
+    );
+    expect(container.querySelectorAll("wa-tab-group")).toHaveLength(2);
+    const ids = Array.from(
+      container.querySelectorAll("wa-tab, wa-tab-panel"),
+      (element) => element.id,
+    );
+    expect(ids).toEqual(
+      rows.flatMap(({ key }) =>
+        ["diff-tab", "raw-tab", "diff-panel", "raw-panel"].map(
+          (suffix) => `${key}:shared-call-${suffix}`,
+        ),
+      ),
+    );
+    expect(new Set(ids).size).toBe(8);
+
+    await vi.waitFor(() => {
+      for (const bubble of bubbles) {
+        for (const name of ["diff", "raw"]) {
+          const tab = bubble.querySelector(`wa-tab[panel="${name}"]`)!;
+          const panel = bubble.querySelector(`wa-tab-panel[name="${name}"]`)!;
+          expect(tab.getAttribute("aria-controls")).toBe(panel.id);
+          expect(panel.getAttribute("aria-labelledby")).toBe(tab.id);
+        }
+      }
+    });
+
+    const toggleSelector =
+      mode === "inline" ? ".chat-tool-row__toggle" : "button.chat-tool-msg-summary";
+    const disclosureKey =
+      mode === "inline" ? `${rows[0]!.key}:toolcard:0` : `toolmsg:${rows[0]!.key}`;
+    bubbles[0]!.querySelector<HTMLButtonElement>(toggleSelector)!.click();
+    expect(toggledKeys).toEqual([disclosureKey]);
+    expect(bubbles[0]!.querySelector("wa-tab-group")).toBeNull();
+    expect(bubbles[1]!.querySelector("wa-tab-group")).not.toBeNull();
+    bubbles[0]!.querySelector<HTMLButtonElement>(toggleSelector)!.click();
+    expect(toggledKeys).toEqual([disclosureKey, disclosureKey]);
+    await settleTabs(container);
+
+    bubbles[0]!.querySelector<HTMLElement>('wa-tab[panel="raw"]')!.click();
+    await settleTabs(container);
+    expect(bubbles[0]!.querySelector('wa-tab-panel[name="raw"]')!.hasAttribute("active")).toBe(
+      true,
+    );
+    expect(bubbles[0]!.querySelector('wa-tab-panel[name="diff"]')!.hasAttribute("active")).toBe(
+      false,
+    );
+    expect(bubbles[1]!.querySelector('wa-tab-panel[name="diff"]')!.hasAttribute("active")).toBe(
+      true,
+    );
+    expect(bubbles[1]!.querySelector('wa-tab-panel[name="raw"]')!.hasAttribute("active")).toBe(
+      false,
+    );
+    expect(
+      bubbles.map((bubble) => bubble.querySelector('wa-tab-panel[name="raw"] code')!.textContent),
+    ).toEqual(rows.map((row) => row.output));
+  });
+});

--- a/ui/src/pages/chat/components/chat-tool-cards.highlight.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.highlight.test.ts
@@ -45,7 +45,10 @@ describe("tool-card source highlighting", () => {
       render(null, container);
     });
     render(
-      renderToolCard({ id: "highlight", ...card }, { expanded: true, onToggleExpanded: vi.fn() }),
+      renderToolCard(
+        { id: "highlight", ...card },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn() },
+      ),
       container,
     );
     await vi.dynamicImportSettled();
@@ -118,7 +121,7 @@ describe("tool-card source highlighting", () => {
             args,
             ...(format === "structured" && !multiple ? { outputText: "Applied patch" } : {}),
           },
-          { expanded: true, onToggleExpanded: vi.fn() },
+          { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn() },
         ),
         container,
       );

--- a/ui/src/pages/chat/components/chat-tool-cards.node.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.node.test.ts
@@ -285,30 +285,27 @@ describe("tool-card extraction", () => {
   });
 
   it("pretty-prints structured args and pairs tool output onto the same card", () => {
-    const cards = extractToolCards(
-      {
-        role: "assistant",
-        toolCallId: "call-1",
-        content: [
-          {
-            type: "toolcall",
-            id: "call-1",
-            name: "browser.open",
-            arguments: { url: "https://example.com", retry: 0 },
-          },
-          {
-            type: "toolresult",
-            id: "call-1",
-            name: "browser.open",
-            text: "Opened page",
-          },
-        ],
-      },
-      "msg:1",
-    );
+    const cards = extractToolCards({
+      role: "assistant",
+      toolCallId: "call-1",
+      content: [
+        {
+          type: "toolcall",
+          id: "call-1",
+          name: "browser.open",
+          arguments: { url: "https://example.com", retry: 0 },
+        },
+        {
+          type: "toolresult",
+          id: "call-1",
+          name: "browser.open",
+          text: "Opened page",
+        },
+      ],
+    });
 
     expect(cards).toHaveLength(1);
-    expect(cards[0]?.id).toBe("msg:1:call-1");
+    expect(cards[0]?.id).toBe("call-1");
     expect(cards[0]?.name).toBe("browser.open");
     expect(cards[0]?.completed).toBe(true);
     expect(cards[0]?.outputText).toBe("Opened page");
@@ -319,20 +316,17 @@ describe("tool-card extraction", () => {
   });
 
   it("preserves string args verbatim and keeps empty-output cards", () => {
-    const cards = extractToolCards(
-      {
-        role: "assistant",
-        toolCallId: "call-2",
-        content: [
-          {
-            type: "toolcall",
-            name: "deck_manage",
-            arguments: "with Example Deck",
-          },
-        ],
-      },
-      "msg:2",
-    );
+    const cards = extractToolCards({
+      role: "assistant",
+      toolCallId: "call-2",
+      content: [
+        {
+          type: "toolcall",
+          name: "deck_manage",
+          arguments: "with Example Deck",
+        },
+      ],
+    });
 
     expect(cards).toHaveLength(1);
     expect(cards[0]?.inputText).toBe("with Example Deck");
@@ -341,20 +335,17 @@ describe("tool-card extraction", () => {
   });
 
   it("preserves tool-call input payloads from tool_use blocks", () => {
-    const cards = extractToolCards(
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            id: "call-2b",
-            name: "deck_manage",
-            input: { deck: "Example Deck", mode: "preview" },
-          },
-        ],
-      },
-      "msg:2b",
-    );
+    const cards = extractToolCards({
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          id: "call-2b",
+          name: "deck_manage",
+          input: { deck: "Example Deck", mode: "preview" },
+        },
+      ],
+    });
 
     expect(cards).toHaveLength(1);
     expect(cards[0]?.inputText).toBe(`{
@@ -364,54 +355,48 @@ describe("tool-card extraction", () => {
   });
 
   it("preserves legacy callId tool block identities", () => {
-    const cards = extractToolCards(
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            callId: "legacy-call-id",
-            name: "bash",
-            input: { command: "pwd" },
-          },
-        ],
-      },
-      "legacy-call",
-    );
+    const cards = extractToolCards({
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          callId: "legacy-call-id",
+          name: "bash",
+          input: { command: "pwd" },
+        },
+      ],
+    });
 
     expect(cards[0]?.callId).toBe("legacy-call-id");
-    expect(cards[0]?.id).toBe("legacy-call:legacy-call-id");
+    expect(cards[0]?.id).toBe("legacy-call-id");
   });
 
   it("pairs interleaved nameless tool results in content order", () => {
-    const cards = extractToolCards(
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            name: "browser.open",
-            input: { url: "https://example.com/a" },
-          },
-          {
-            type: "tool_result",
-            name: "browser.open",
-            text: "Opened A",
-          },
-          {
-            type: "tool_use",
-            name: "browser.open",
-            input: { url: "https://example.com/b" },
-          },
-          {
-            type: "tool_result",
-            name: "browser.open",
-            text: "Opened B",
-          },
-        ],
-      },
-      "msg:ordered",
-    );
+    const cards = extractToolCards({
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          name: "browser.open",
+          input: { url: "https://example.com/a" },
+        },
+        {
+          type: "tool_result",
+          name: "browser.open",
+          text: "Opened A",
+        },
+        {
+          type: "tool_use",
+          name: "browser.open",
+          input: { url: "https://example.com/b" },
+        },
+        {
+          type: "tool_result",
+          name: "browser.open",
+          text: "Opened B",
+        },
+      ],
+    });
 
     expect(cards).toHaveLength(2);
     expect(cards[0]?.inputText).toBe('{\n  "url": "https://example.com/a"\n}');
@@ -421,34 +406,31 @@ describe("tool-card extraction", () => {
   });
 
   it("pairs sequential nameless same-name tool results with the earliest unmatched call", () => {
-    const cards = extractToolCards(
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            name: "read",
-            input: { path: "a.txt" },
-          },
-          {
-            type: "tool_use",
-            name: "read",
-            input: { path: "b.txt" },
-          },
-          {
-            type: "tool_result",
-            name: "read",
-            text: "A contents",
-          },
-          {
-            type: "tool_result",
-            name: "read",
-            text: "B contents",
-          },
-        ],
-      },
-      "msg:sequential",
-    );
+    const cards = extractToolCards({
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          name: "read",
+          input: { path: "a.txt" },
+        },
+        {
+          type: "tool_use",
+          name: "read",
+          input: { path: "b.txt" },
+        },
+        {
+          type: "tool_result",
+          name: "read",
+          text: "A contents",
+        },
+        {
+          type: "tool_result",
+          name: "read",
+          text: "B contents",
+        },
+      ],
+    });
 
     expect(cards).toHaveLength(2);
     expect(cards[0]?.inputText).toBe('{\n  "path": "a.txt"\n}');
@@ -467,27 +449,24 @@ describe("tool-card extraction", () => {
   ])(
     "keeps a same-name result with different %s separate from an open call",
     (_label, resultId) => {
-      const cards = extractToolCards(
-        {
-          role: "assistant",
-          content: [
-            {
-              type: "tool_use",
-              id: "call-a",
-              name: "read",
-              input: { path: "a.txt" },
-            },
-            {
-              type: "tool_result",
-              ...resultId,
-              name: "read",
-              text: "B failed",
-              isError: true,
-            },
-          ],
-        },
-        "msg:separate-owners",
-      );
+      const cards = extractToolCards({
+        role: "assistant",
+        content: [
+          {
+            type: "tool_use",
+            id: "call-a",
+            name: "read",
+            input: { path: "a.txt" },
+          },
+          {
+            type: "tool_result",
+            ...resultId,
+            name: "read",
+            text: "B failed",
+            isError: true,
+          },
+        ],
+      });
 
       expect(cards).toHaveLength(2);
       expect(cards[0]).toMatchObject({ callId: "call-a", name: "read" });
@@ -508,26 +487,23 @@ describe("tool-card extraction", () => {
     ["only the call owns an ID", { id: "call-a" }, {}],
     ["only the result owns an ID", {}, { tool_use_id: "call-b" }],
   ])("preserves legacy same-name fallback when %s", (_label, callId, resultId) => {
-    const cards = extractToolCards(
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            ...callId,
-            name: "read",
-            input: { path: "legacy.txt" },
-          },
-          {
-            type: "tool_result",
-            ...resultId,
-            name: "read",
-            text: "Legacy contents",
-          },
-        ],
-      },
-      "msg:legacy-owner",
-    );
+    const cards = extractToolCards({
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          ...callId,
+          name: "read",
+          input: { path: "legacy.txt" },
+        },
+        {
+          type: "tool_result",
+          ...resultId,
+          name: "read",
+          text: "Legacy contents",
+        },
+      ],
+    });
 
     expect(cards).toHaveLength(1);
     expect(cards[0]).toMatchObject({
@@ -538,34 +514,31 @@ describe("tool-card extraction", () => {
   });
 
   it("does not reuse nameless same-name calls after an empty result", () => {
-    const cards = extractToolCards(
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "tool_use",
-            name: "read",
-            input: { path: "empty.txt" },
-          },
-          {
-            type: "tool_use",
-            name: "read",
-            input: { path: "next.txt" },
-          },
-          {
-            type: "tool_result",
-            name: "read",
-            text: "",
-          },
-          {
-            type: "tool_result",
-            name: "read",
-            text: "Next contents",
-          },
-        ],
-      },
-      "msg:empty-result",
-    );
+    const cards = extractToolCards({
+      role: "assistant",
+      content: [
+        {
+          type: "tool_use",
+          name: "read",
+          input: { path: "empty.txt" },
+        },
+        {
+          type: "tool_use",
+          name: "read",
+          input: { path: "next.txt" },
+        },
+        {
+          type: "tool_result",
+          name: "read",
+          text: "",
+        },
+        {
+          type: "tool_result",
+          name: "read",
+          text: "Next contents",
+        },
+      ],
+    });
 
     expect(cards).toHaveLength(2);
     expect(cards[0]?.inputText).toBe('{\n  "path": "empty.txt"\n}');
@@ -576,111 +549,96 @@ describe("tool-card extraction", () => {
   });
 
   it("extracts tool result output from text block content arrays", () => {
-    const cards = extractToolCards(
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolcall",
-            id: "call-read",
-            name: "read",
-            input: { path: "README.md" },
-          },
-          {
-            type: "tool_result",
-            id: "call-read",
-            name: "read",
-            content: [
-              { type: "text", text: "# Heading" },
-              { type: "text", text: "file body" },
-            ],
-          },
-        ],
-      },
-      "msg:read",
-    );
+    const cards = extractToolCards({
+      role: "assistant",
+      content: [
+        {
+          type: "toolcall",
+          id: "call-read",
+          name: "read",
+          input: { path: "README.md" },
+        },
+        {
+          type: "tool_result",
+          id: "call-read",
+          name: "read",
+          content: [
+            { type: "text", text: "# Heading" },
+            { type: "text", text: "file body" },
+          ],
+        },
+      ],
+    });
 
     expect(cards).toHaveLength(1);
     expect(cards[0]?.outputText).toBe("# Heading\nfile body");
   });
 
   it("preserves explicit tool error flags from tool result items and messages", () => {
-    const pairedCards = extractToolCards(
-      {
-        role: "assistant",
-        content: [
-          {
-            type: "toolcall",
-            id: "call-error",
-            name: "lookup",
-          },
-          {
-            type: "tool_result",
-            id: "call-error",
-            name: "lookup",
-            text: "lookup failed",
-            isError: true,
-          },
-        ],
-      },
-      "msg:error-item",
-    );
+    const pairedCards = extractToolCards({
+      role: "assistant",
+      content: [
+        {
+          type: "toolcall",
+          id: "call-error",
+          name: "lookup",
+        },
+        {
+          type: "tool_result",
+          id: "call-error",
+          name: "lookup",
+          text: "lookup failed",
+          isError: true,
+        },
+      ],
+    });
 
     expect(pairedCards[0]?.isError).toBe(true);
 
-    const messageFlagCards = extractToolCards(
-      {
-        role: "toolResult",
-        isError: true,
-        content: [
-          {
-            type: "tool_result",
-            id: "call-message-error",
-            name: "lookup",
-            text: "lookup failed",
-          },
-        ],
-      },
-      "msg:error-message-flag",
-    );
+    const messageFlagCards = extractToolCards({
+      role: "toolResult",
+      isError: true,
+      content: [
+        {
+          type: "tool_result",
+          id: "call-message-error",
+          name: "lookup",
+          text: "lookup failed",
+        },
+      ],
+    });
 
     expect(messageFlagCards[0]?.isError).toBe(true);
 
-    const standaloneCards = extractToolCards(
-      {
-        role: "tool",
-        toolName: "lookup",
-        content: "lookup failed",
-        isError: true,
-      },
-      "msg:error-message",
-    );
+    const standaloneCards = extractToolCards({
+      role: "tool",
+      toolName: "lookup",
+      content: "lookup failed",
+      isError: true,
+    });
 
     expect(standaloneCards[0]?.isError).toBe(true);
   });
 
   it("extracts canvas handle payloads into canvas previews", () => {
-    const [card] = extractToolCards(
-      {
-        role: "tool",
-        toolName: "canvas_render",
-        content: JSON.stringify({
-          kind: "canvas",
-          view: {
-            backend: "canvas",
-            id: "cv_inline",
-            url: "/__openclaw__/canvas/documents/cv_inline/index.html",
-          },
-          presentation: {
-            target: "assistant_message",
-            title: "Inline demo",
-            preferred_height: 420,
-            sandbox: "scripts",
-          },
-        }),
-      },
-      "msg:view:1",
-    );
+    const [card] = extractToolCards({
+      role: "tool",
+      toolName: "canvas_render",
+      content: JSON.stringify({
+        kind: "canvas",
+        view: {
+          backend: "canvas",
+          id: "cv_inline",
+          url: "/__openclaw__/canvas/documents/cv_inline/index.html",
+        },
+        presentation: {
+          target: "assistant_message",
+          title: "Inline demo",
+          preferred_height: 420,
+          sandbox: "scripts",
+        },
+      }),
+    });
 
     expect(card?.preview).toMatchObject({
       kind: "canvas",
@@ -695,39 +653,33 @@ describe("tool-card extraction", () => {
   });
 
   it("uses transcript metadata ids for history-backed tool messages", () => {
-    const [card] = extractToolCards(
-      {
-        role: "tool",
-        toolName: "browser.open",
-        content: [{ type: "text", text: "Opened page" }],
-        __openclaw: { id: "msg-tool-history-1", seq: 7 },
-      },
-      "msg:history",
-    );
+    const [card] = extractToolCards({
+      role: "tool",
+      toolName: "browser.open",
+      content: [{ type: "text", text: "Opened page" }],
+      __openclaw: { id: "msg-tool-history-1", seq: 7 },
+    });
 
     expect(card?.messageId).toBe("msg-tool-history-1");
     expect(card?.outputText).toBe("Opened page");
   });
 
   it("extracts MCP App previews from sanitized result details", () => {
-    const [card] = extractToolCards(
-      {
-        role: "tool",
-        toolName: "demo__show",
-        content: [{ type: "text", text: "original result" }],
-        details: {
-          mcpAppPreview: {
-            kind: "canvas",
-            view: {
-              id: "cv_app",
-            },
-            presentation: { target: "assistant_message", sandbox: "scripts" },
-            mcpApp: { viewId: "cv_app" },
+    const [card] = extractToolCards({
+      role: "tool",
+      toolName: "demo__show",
+      content: [{ type: "text", text: "original result" }],
+      details: {
+        mcpAppPreview: {
+          kind: "canvas",
+          view: {
+            id: "cv_app",
           },
+          presentation: { target: "assistant_message", sandbox: "scripts" },
+          mcpApp: { viewId: "cv_app" },
         },
       },
-      "msg:mcp-app",
-    );
+    });
 
     expect(card?.outputText).toBe("original result");
     expect(card?.preview).toMatchObject({
@@ -799,14 +751,11 @@ describe("tool-card extraction", () => {
     ] as const;
 
     for (const testCase of cases) {
-      const [card] = extractToolCards(
-        {
-          role: "tool",
-          toolName: testCase.toolName,
-          content: testCase.content,
-        },
-        `msg:view:${testCase.name}`,
-      );
+      const [card] = extractToolCards({
+        role: "tool",
+        toolName: testCase.toolName,
+        content: testCase.content,
+      });
 
       expect(card?.preview, testCase.name).toBeUndefined();
     }

--- a/ui/src/pages/chat/components/chat-tool-cards.outcome.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.outcome.test.ts
@@ -24,6 +24,7 @@ describe("tool-card outcomes", () => {
       const show = () =>
         render(
           renderToolCard(card, {
+            messageKey: "test-message",
             expanded: true,
             onToggleExpanded: vi.fn(),
             runActive: true,
@@ -69,7 +70,7 @@ describe("tool-card outcomes", () => {
             message: "BRAVE_API_KEY is not configured",
           }),
         },
-        { expanded: true, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -99,7 +100,7 @@ describe("tool-card outcomes", () => {
           name: "sessions_spawn",
           outputText: JSON.stringify({ status: "error" }),
         },
-        { expanded: true, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -120,7 +121,7 @@ describe("tool-card outcomes", () => {
           name: "Unknown",
           outputText: "Tool not found",
         },
-        { expanded: false, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: false, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -143,7 +144,7 @@ describe("tool-card outcomes", () => {
           outputText: "lookup failed",
           isError: true,
         },
-        { expanded: true, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -164,7 +165,7 @@ describe("tool-card outcomes", () => {
           name: "lookup",
           isError: true,
         },
-        { expanded: true, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -188,7 +189,7 @@ describe("tool-card outcomes", () => {
           }),
           isError: false,
         },
-        { expanded: false, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: false, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -208,7 +209,7 @@ describe("tool-card outcomes", () => {
           name: "browser.open",
           outputText: "Opened page",
         },
-        { expanded: true, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -244,7 +245,7 @@ describe("tool-card outcomes", () => {
           outputText: "Progress card updated",
           completed: true,
         },
-        { expanded: true, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn() },
       ),
       container,
     );

--- a/ui/src/pages/chat/components/chat-tool-cards.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.test.ts
@@ -115,7 +115,7 @@ describe("tool-cards", () => {
           name: "web_search",
           args: { query: "openclaw" },
         },
-        { expanded: false, onToggleExpanded: toggle },
+        { messageKey: "test-message", expanded: false, onToggleExpanded: toggle },
       ),
       container,
     );
@@ -144,7 +144,7 @@ describe("tool-cards", () => {
           args: { command: "pnpm test" },
           live: true,
         },
-        { expanded: false, runActive: true, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: false, runActive: true, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -167,7 +167,7 @@ describe("tool-cards", () => {
           inputText: '{\n  "url": "https://example.com"\n}',
           outputText: "Opened page",
         },
-        { expanded: true, onToggleExpanded: toggle },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: toggle },
       ),
       container,
     );
@@ -214,7 +214,7 @@ describe("tool-cards", () => {
           },
           outputText: "Applied patch",
         },
-        { expanded: true, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -275,7 +275,7 @@ describe("tool-cards", () => {
           },
           outputText: "Applied patch",
         },
-        { expanded: true, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -298,7 +298,7 @@ describe("tool-cards", () => {
           completed: true,
           isError: true,
         },
-        { expanded: true, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -336,7 +336,7 @@ describe("tool-cards", () => {
           },
           completed: true,
         },
-        { expanded: false, onOpenWorkspaceFile, onToggleExpanded },
+        { messageKey: "test-message", expanded: false, onOpenWorkspaceFile, onToggleExpanded },
       ),
       container,
     );
@@ -401,7 +401,7 @@ describe("tool-cards", () => {
           args: { patch },
           completed: true,
         },
-        { expanded: false, onOpenWorkspaceFile, onToggleExpanded },
+        { messageKey: "test-message", expanded: false, onOpenWorkspaceFile, onToggleExpanded },
       ),
       container,
     );
@@ -486,6 +486,7 @@ describe("tool-cards", () => {
               ...state.card,
             },
             {
+              messageKey: "test-message",
               expanded: true,
               onToggleExpanded: vi.fn(),
               runActive: state.runActive,
@@ -561,7 +562,7 @@ describe("tool-cards", () => {
             args: tool.args,
             completed: true,
           },
-          { expanded: true, onToggleExpanded: vi.fn(), onOpenSidebar },
+          { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn(), onOpenSidebar },
         ),
         container,
       );
@@ -615,6 +616,7 @@ describe("tool-cards", () => {
           completed: true,
         },
         {
+          messageKey: "test-message",
           expanded: true,
           onOpenWorkspaceFile,
           onToggleExpanded: vi.fn(),
@@ -641,7 +643,7 @@ describe("tool-cards", () => {
           args: { path: "/repo/src/a.ts", offset: 40, limit: 20 },
           inputText: JSON.stringify({ path: "/repo/src/a.ts", offset: 40, limit: 20 }),
         },
-        { expanded: true, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -671,6 +673,7 @@ describe("tool-cards", () => {
           outputText: "Proposal created",
         },
         {
+          messageKey: "test-message",
           expanded: true,
           onOpenSidebar: vi.fn(),
           onToggleExpanded: vi.fn(),
@@ -700,7 +703,7 @@ describe("tool-cards", () => {
           args: { mode: "session", thread: true },
           inputText: '{\n  "mode": "session",\n  "thread": true\n}',
         },
-        { expanded: true, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -729,7 +732,7 @@ describe("tool-cards", () => {
           args: { mode: "run" },
           inputText: '{\n  "mode": "run"\n}',
         },
-        { expanded: false, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: false, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -757,7 +760,7 @@ describe("tool-cards", () => {
           },
           inputText: "message input",
         },
-        { expanded: false, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: false, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -795,7 +798,7 @@ describe("tool-cards", () => {
           inputText: '{\n  "action": "create"\n}',
           outputText: "Proposal created",
         },
-        { expanded: false, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: false, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -820,7 +823,7 @@ describe("tool-cards", () => {
           args: "with Example Deck",
           inputText: "with Example Deck",
         },
-        { expanded: false, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: false, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -838,7 +841,7 @@ describe("tool-cards", () => {
           args: "with Example Deck",
           inputText: "with Example Deck",
         },
-        { expanded: true, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -887,7 +890,7 @@ describe("tool-cards", () => {
           args: rawInput,
           inputText: rawInput,
         },
-        { expanded: false, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: false, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -928,7 +931,7 @@ describe("tool-cards", () => {
             preferredHeight: 480,
           },
         },
-        { expanded: true, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -983,7 +986,7 @@ describe("tool-cards", () => {
             url: "/__openclaw__/canvas/documents/qr_preview/index.html",
           },
         },
-        { expanded: true, onToggleExpanded: vi.fn() },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn() },
       ),
       container,
     );
@@ -1027,7 +1030,7 @@ describe("tool-cards", () => {
             preferredHeight: 360,
           },
         },
-        { expanded: true, onToggleExpanded: vi.fn(), onOpenSidebar },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn(), onOpenSidebar },
       ),
       container,
     );
@@ -1057,11 +1060,7 @@ describe("tool-cards", () => {
           outputText: "Opened page",
           messageId: "msg-tool-full",
         },
-        {
-          expanded: true,
-          onToggleExpanded: vi.fn(),
-          onOpenSidebar,
-        },
+        { messageKey: "test-message", expanded: true, onToggleExpanded: vi.fn(), onOpenSidebar },
       ),
       container,
     );

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -45,7 +45,7 @@ export function renderBrowserTabPreviews(
   options: { sessionKey?: string; latestBrowserTabs?: ReadonlyMap<string, BrowserTabSelection> },
 ) {
   const cards = groups.flatMap((group) =>
-    group.messages.flatMap((item) => extractToolCardsCached(item.message, item.key)),
+    group.messages.flatMap((item) => extractToolCardsCached(item.message)),
   );
   // One card per tab per rendered group: open/navigate/screenshot in a single
   // turn all describe the same tab, and stacked near-identical cards are noise.

--- a/ui/src/pages/chat/components/chat-tool-content.ts
+++ b/ui/src/pages/chat/components/chat-tool-content.ts
@@ -318,11 +318,14 @@ function renderTerminalBlock(command: string, output: string | undefined) {
 
 function renderToolCardModes(
   card: ToolCard,
+  messageKey: string,
   diff: NonNullable<ToolCallView["diff"]>,
   outcome: ToolCardOutcome,
   isError: boolean,
   file: DiffFilePaths,
 ) {
+  // Call IDs repeat across messages; scope DOM identity without copying source cards.
+  const id = `${messageKey}:${card.id}`;
   const active = isError ? "raw" : "diff";
   const modeLabel = t("chat.toolCards.viewMode");
   return html`
@@ -334,16 +337,16 @@ function renderToolCardModes(
       without-scroll-controls
       ${ref((element) => syncTabGroupLabel(element, modeLabel))}
     >
-      <wa-tab slot="nav" id=${`${card.id}-diff-tab`} panel="diff" ?active=${active === "diff"}>
+      <wa-tab slot="nav" id=${`${id}-diff-tab`} panel="diff" ?active=${active === "diff"}>
         ${t("chat.toolCards.diff")}
       </wa-tab>
-      <wa-tab slot="nav" id=${`${card.id}-raw-tab`} panel="raw" ?active=${active === "raw"}>
+      <wa-tab slot="nav" id=${`${id}-raw-tab`} panel="raw" ?active=${active === "raw"}>
         ${t("chat.toolCards.raw")}
       </wa-tab>
-      <wa-tab-panel id=${`${card.id}-diff-panel`} name="diff" ?active=${active === "diff"}>
+      <wa-tab-panel id=${`${id}-diff-panel`} name="diff" ?active=${active === "diff"}>
         ${renderDiffBlock(diff, outcome, undefined, file)}
       </wa-tab-panel>
-      <wa-tab-panel id=${`${card.id}-raw-panel`} name="raw" ?active=${active === "raw"}>
+      <wa-tab-panel id=${`${id}-raw-panel`} name="raw" ?active=${active === "raw"}>
         ${renderToolDataBlock({
           ...(isError ? { label: t("chat.toolCards.toolError") } : {}),
           text: card.outputText!,
@@ -360,6 +363,7 @@ function serializeDiff(lines: readonly { kind: string; text: string }[]): string
 }
 
 export type ToolRenderOptions = {
+  messageKey: string;
   runActive?: boolean;
   onOpenSidebar?: (content: SidebarContent) => void;
   onOpenWorkspaceFile?: (target: { path: string; line?: number | null }) => void;
@@ -367,7 +371,7 @@ export type ToolRenderOptions = {
 
 export function renderExpandedToolCardContent(
   card: ToolCard,
-  { onOpenSidebar, runActive, onOpenWorkspaceFile }: ToolRenderOptions,
+  { messageKey, onOpenSidebar, runActive, onOpenWorkspaceFile }: ToolRenderOptions,
 ) {
   const view = resolveToolCallView({ name: card.name, args: card.args, details: card.details });
   const display = resolveToolDisplay({ name: card.name, args: card.args });
@@ -442,7 +446,7 @@ export function renderExpandedToolCardContent(
           <div class="chat-tool-card__actions">${diffCopyAction}${sidebarAction}</div>
         </div>
         ${hasOutput
-          ? renderToolCardModes(card, view.diff, outcome, isError, file)
+          ? renderToolCardModes(card, messageKey, view.diff, outcome, isError, file)
           : renderDiffBlock(view.diff, outcome, undefined, file)}
         ${renderToolOutcome(outcome, card.exitCode)}
       </div>

--- a/ui/src/pages/chat/tool-titles.test.ts
+++ b/ui/src/pages/chat/tool-titles.test.ts
@@ -177,8 +177,8 @@ describe("title fetch batching", () => {
     expect(requestedIds.size).toBe(commands.length);
   });
 
-  it.each(["new-version", "new-owner"] as const)(
-    "resumes when transcript retention removes the saturation cursor on %s",
+  it.each(["new-version", "new-owner", "cursor-reappears"] as const)(
+    "resumes title admission after a missing saturation cursor on %s",
     async (transition) => {
       vi.useFakeTimers();
       const requestedIds = new Set<string>();
@@ -229,9 +229,9 @@ describe("title fetch batching", () => {
       expect(requestedIds.size).toBe(48);
 
       renderTranscript(
-        retainedCommands,
+        transition === "cursor-reappears" ? commands : retainedCommands,
         transition === "new-owner" ? secondHistoryOwner : firstHistoryOwner,
-        transition === "new-owner" ? retainedHistoryVersion : ++historyVersion,
+        transition === "new-version" ? ++historyVersion : retainedHistoryVersion,
       );
       await vi.advanceTimersByTimeAsync(1_000);
       expect(requestedIds.size).toBe(96);

--- a/ui/src/pages/chat/tool-titles.ts
+++ b/ui/src/pages/chat/tool-titles.ts
@@ -173,27 +173,39 @@ function saturateSession(ownerKey: string, resumeAfterKey: string | null): void 
   );
 }
 
-function resolveTranscriptStartIndex(
+function prepareTranscriptRequests(
   ownerKey: string,
-  requests: readonly { key: string }[],
-): number | null {
+  candidates: Iterable<{ name: string; args?: unknown }>,
+): { requests: Array<{ key: string; input: string; name: string }>; startIndex: number } | null {
   const saturation = readLru(saturatedSessions, ownerKey);
-  if (!saturation) {
-    return 0;
-  }
-  if (saturation.expiresAt > Date.now()) {
+  if (saturation && saturation.expiresAt > Date.now()) {
     return null;
+  }
+  const requests: Array<{ key: string; input: string; name: string }> = [];
+  const seen = new Set<string>();
+  for (const candidate of candidates) {
+    const request = resolveToolTitleRequest(candidate.name, candidate.args);
+    if (!request || seen.has(request.key)) {
+      continue;
+    }
+    seen.add(request.key);
+    requests.push({ ...request, name: candidate.name });
+  }
+  if (!saturation) {
+    return { requests, startIndex: 0 };
   }
   if (saturation.resumeAfterKey === null) {
     saturatedSessions.delete(ownerKey);
-    return 0;
+    return { requests, startIndex: 0 };
   }
+  // Live rows can restore the cursor without changing the history revision.
+  // Search before suppressing another render of a previously missing cursor.
   const cursorIndex = requests.findIndex((request) => request.key === saturation.resumeAfterKey);
   if (cursorIndex >= 0) {
     // Resume after the last admitted row. Re-admitting LRU-evicted rows before
     // this cursor would spend every later bounded window without making progress.
     saturatedSessions.delete(ownerKey);
-    return cursorIndex + 1;
+    return { requests, startIndex: cursorIndex + 1 };
   }
   if (saturation.cursorMissingHistoryVersion === null) {
     saturation.cursorMissingHistoryOwner = activeHistoryOwner;
@@ -209,7 +221,7 @@ function resolveTranscriptStartIndex(
   // The prior complete projection did not contain the cursor, so retention or
   // compaction removed it. Resume from this projection's first remaining row.
   saturatedSessions.delete(ownerKey);
-  return 0;
+  return { requests, startIndex: 0 };
 }
 
 function discardQueuedOwner(ownerKey: string): void {
@@ -314,31 +326,19 @@ export function getToolCallTitle(name: string, args: unknown): string | undefine
 }
 
 export function scheduleToolTitlesForTranscript(
-  candidates: readonly { name: string; args: unknown }[],
+  candidates: Iterable<{ name: string; args?: unknown }>,
 ): void {
   if (!activeSchedulingEnabled || titlesDisabledByGateway || !activeClient || !activeSessionKey) {
     return;
   }
-  const requests: Array<{ key: string; input: string; name: string }> = [];
-  const seen = new Set<string>();
-  for (const candidate of candidates) {
-    const request = resolveToolTitleRequest(candidate.name, candidate.args);
-    if (!request || seen.has(request.key)) {
-      continue;
-    }
-    seen.add(request.key);
-    requests.push({ ...request, name: candidate.name });
-  }
   const ownerKey = queueOwnerKey(activeSessionKey, activeAgentId);
-  const startIndex = resolveTranscriptStartIndex(ownerKey, requests);
-  if (startIndex === null) {
+  const prepared = prepareTranscriptRequests(ownerKey, candidates);
+  if (!prepared) {
     return;
   }
+  const { requests, startIndex } = prepared;
   for (let index = startIndex; index < requests.length; index++) {
-    const request = requests[index];
-    if (!request) {
-      continue;
-    }
+    const request = requests[index]!;
     scheduleTitleRequest(request.name, request);
     if (saturatedSessions.has(ownerKey)) {
       break;


### PR DESCRIPTION
Related: #134209 (the preceding Control UI history performance pass).

## What Problem This Solves

Large Control UI histories still spend avoidable CPU preparing tool cards and titles, updating browser chrome, and resolving configuration tiers during startup. This maintainer-requested performance pass follows profiles from a real development Gateway serving the built UI.

## Why This Change Was Made

Parsed tool cards now belong to their source message, so preview, activity, title, and rendering consumers reuse one representation. Message-specific IDs are applied only when emitting DOM elements; disclosure keys and independent Raw/Diff panels remain unchanged. Lazy title candidates allow inactive, disabled, disconnected, and cooldown paths to stop before scanning the transcript.

Schema tier rules are indexed by path length and literal prefix while preserving exact-alias, wildcard-specificity, authored-order, and composition-branch precedence. Numeric discovery and inheritance share one hints clone. Browser chrome updates run when route/runtime changes; existing theme and viewport lifecycle owners retain their own updates. Production delta: **+114/−128 (net −14)**. Tests: **+760/−431**, including mechanical caller migration and browser lifecycle/identity coverage.

## User Impact

The existing initial 800-message and subsequent 1,000-message limits remain unchanged. The larger timing series measured a lower median initial history load. Paging, saved-position return, and rendering behavior are preserved; these measurements do not establish better cold startup or scroll smoothness.

## Evidence

A real isolated Gateway used its ordinary sourcePerformance runtime build, built UI, normal plugin startup, token-authenticated dashboard handoff, and canonical session SQLite storage. The synthetic fixture contains 3,000 rich Markdown messages and 375 completed tool call/result pairs; a second session exercises saved-position return. No provider calls or operator data were used. Linux Node 24.19.0 and Chromium 151.0.7922.34; baseline commit `ce8ea4a28efa65e8a01edfc2a7536dd3e88c0c02`. Clean-machine proof ran on [Testbox hydration run 33415101514](https://github.com/openclaw/openclaw/actions/runs/33415101514); the CLI-owned test commands completed before the lease was stopped.

The expanded unprofiled A-B-B-A series used 8 fresh browser contexts per block, 16 per variant (32 total). CPU profiles were collected separately. Every completed flow retained message counts, response sizes, viewport geometry, and the exact saved anchor, with zero browser errors or anchor drift.

| Median | Before | After |
| --- | ---: | ---: |
| Initial 800-message paint | 713.75 ms | 647.60 ms |
| Prepend 1,000-message paint | 329.00 ms | 331.85 ms |
| Saved-position return | 107.45 ms | 110.30 ms |
| Initial-load long-task duration | 283.00 ms | 296.50 ms |
| Prepend long-task duration | 166.00 ms | 211.00 ms |

Results vary: the earlier smaller series (4 contexts/variant) was slower for the candidate: 886.3→951.8 ms initial, 335.35→385.3 ms prepend, and 114.4→120.9 ms return. The two first-context samples per variant also did not improve. The larger series' initial-load median is about 9% lower; paging/return are effectively flat, and long-task duration is not improved.

A separate alternating same-process tier benchmark on Node 26.8.1 (6,287 hints, 64 iterations/variant) measured 44.28→33.36 ms median. Diagnostic profiles sampled less work in tier resolution (172.2→95.5 ms inclusive), browser chrome synchronization (45.0→7.5 ms), and cached tool extraction (26.1→13.9 ms). These are owner-level observations, not universal latency guarantees.

Validation: **589 focused tests and 11 measurement probes passed**. Four complete schema responses and 410 tier fixtures preserved values, key order, tags, and input ownership. Chromium proof covers repeated call IDs, unique DOM IDs, ARIA linkage, independent Raw/Diff state, route and viewport changes, runtime removal/restoration, reconnect, and delayed/superseded palettes. Title probes cover no-work admission and cursor recovery without a history-version change.

Core/UI/package typechecks, formatting, changed-file lint/style, and architecture guards passed across the full changed-check run and focused continuations. The original run caught stale test-only prefix arguments; these were migrated and the full 225-case transcript suite rerun. Browser fixtures and one test cleanup style issue were also corrected. No production test seam, dependency, config/default, protocol, or persistent-store change was added.

### Before and after

Inspected synthetic-only captures from the same real Gateway fixture; they demonstrate unchanged rendering, not elapsed time.

Before:

![Before: initial 800-message history with a completed tool card](https://github.com/user-attachments/assets/60f840ed-f7b1-40fc-9c1a-a27730ef77f9)

After:

![After: the same history window and tool card](https://github.com/user-attachments/assets/58a36b1f-aba4-492f-9255-f3907bcabb29)

### Follow-up

Doctor startup still loads some plugin TypeScript through Jiti despite compiled artifacts being available (1,361.7 ms sampled inclusive). Selecting the compiled artifact also requires resolving its validated execution root and stored artifact hash; that persistence/identity design is intentionally recorded for separate discussion. The preceding PR's intermittent deep session-import heap failure passed its exact CI rerun with byte-identical parent/candidate import bundles; no heap limit or assertion was weakened here.

### Maintainer review disposition

The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/134369#issuecomment-5482738303) was checked before landing. Its changelog finding and matching rank-up move are intentionally declined: this landing retains the user-facing entry under the maintainer's explicit standing instruction. Release context also remains in this PR body.

The review's current-main evidence gap is resolved by the native checkout comparison at `b790784b49c0c79951b5d28facf5bb46af4c782a`, with no further changes to the 11 affected production files since the rebased base. The stored-data warning is a false classification: `src/config/schema.tiers.ts` resolves configuration UI hints; it changes no SQLite schema, stored data, index, migration, or persistence semantics. Schema output equivalence was verified as described above.

[Exact-head CI run 33424628679](https://github.com/openclaw/openclaw/actions/runs/33424628679) completed successfully for `393b52de7e55fcf1d4a762249bc7e1a6d254b07f`; the native CI watcher reached GREEN. Fresh autoreview and native review artifacts have no blocking findings. No behavior changed after the bot review, so an additional re-review request is unnecessary.
