### PR TITLE
test: unmask native link routing and disposal assertions

### DIFF
--- a/ui/src/app/native-link-routing.test.ts
+++ b/ui/src/app/native-link-routing.test.ts
@@ -50,6 +50,22 @@ function click(anchor: HTMLAnchorElement, init: MouseEventInit = {}) {
   return event;
 }
 
+function clickWithoutNavigation(anchor: HTMLAnchorElement, init: MouseEventInit = {}) {
+  let defaultPrevented: boolean | undefined;
+  const preventNavigation = (event: MouseEvent) => {
+    defaultPrevented = event.defaultPrevented;
+    event.preventDefault();
+  };
+  // Observe after the native router, then suppress jsdom's default navigation.
+  window.addEventListener("click", preventNavigation, { once: true });
+  try {
+    click(anchor, init);
+    return defaultPrevented;
+  } finally {
+    window.removeEventListener("click", preventNavigation);
+  }
+}
+
 function contextMenu(anchor: HTMLAnchorElement) {
   const event = new MouseEvent("contextmenu", {
     bubbles: true,
@@ -192,7 +208,7 @@ describe("native link routing", () => {
     ]);
   });
 
-  it("preserves modifiers, local/file/download links, and non-web schemes", () => {
+  it("preserves modified, local, file, download, and untrusted app-link clicks", () => {
     const bridge = installBridge();
     routing = startNativeLinkRouting();
     const links = [
@@ -202,15 +218,11 @@ describe("native link routing", () => {
       appendLink("mailto:hello@example.com"),
     ];
     for (const anchor of links) {
-      anchor.addEventListener("click", (event) => event.preventDefault());
-      click(anchor);
+      expect(clickWithoutNavigation(anchor)).toBe(false);
     }
     const modified = appendLink("https://example.com/modified");
-    const bubbleHandler = vi.fn((event: Event) => event.preventDefault());
-    modified.addEventListener("click", bubbleHandler);
-    click(modified, { metaKey: true });
+    expect(clickWithoutNavigation(modified, { metaKey: true })).toBe(false);
 
-    expect(bubbleHandler).toHaveBeenCalledOnce();
     expect(bridge.messages).toEqual([]);
   });
 
@@ -317,9 +329,10 @@ describe("native link routing", () => {
 
     routing.dispose();
     routing = undefined;
-    anchor.addEventListener("click", (event) => event.preventDefault());
-    click(anchor);
 
+    expect(document.querySelector("openclaw-native-link-menu")).toBeNull();
+    expect(clickWithoutNavigation(anchor)).toBe(false);
+    expect(contextMenu(anchor).defaultPrevented).toBe(false);
     expect(document.querySelector("openclaw-native-link-menu")).toBeNull();
     expect(bridge.messages).toEqual([]);
   });


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Two native-link tests could pass while routing modified clicks incorrectly or retaining a click listener after disposal. Their anchor handlers cancelled events before the router could make a decision.

## Why This Change Was Made

The router intentionally moved from document capture to window bubbling in #123912 so application cancellation remains authoritative. The old fixtures kept cancelling at the anchor, which masked the behavior they intended to check.

Observe cancellation after the router, then suppress jsdom navigation. Both existing tests now exercise the real handler; disposal also checks that a later context menu cannot reopen the removed menu. The observer is removed in `finally`, and assertions remain outside event callbacks.

## User Impact

No product behavior changes. All 11 native-routing cases remain, together with the browser-routing and navigation-helper suites. Production changes: 0 lines. Tests: +22/-9, net +13 to repair the two misleading oracles.

## Evidence

- All 23 owner and sibling cases pass before and after with normal production code.
- Deliberately bypassing native modifier checks passes the old classification test and fails the revised test at the Meta-click assertion.
- Deliberately retaining the window click listener passes the old disposal test and fails the revised test. Both temporary faults were restored; neither is part of this PR.
- The shared predicate matrix, exact cancelled-click test, browser-panel activation policy and native Chromium E2E remain unchanged. Synthetic jsdom clicks do not claim trusted native-app activation proof.
- Targeted formatting, all 18 normal changed-file checks and managed Codex review passed. Review was scoped-clean at its configured P0 threshold; the owner and sibling paths were also inspected directly.
