### PR TITLE
fix(agents): stop payload redaction rewriting tool-search counter scopes

### DIFF
--- a/src/agents/tool-search-catalog.ts
+++ b/src/agents/tool-search-catalog.ts
@@ -1,6 +1,6 @@
 import { stableStringify } from "@openclaw/normalization-core";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
-import { generateSecureToken } from "../infra/secure-random.js";
+import { generateSecureHex } from "../infra/secure-random.js";
 import { getPluginToolMeta, type PluginToolMcpMeta } from "../plugins/tool-metadata.js";
 import type { HookContext } from "./agent-tools.before-tool-call.js";
 import {
@@ -109,6 +109,13 @@ function rebindCatalogExecutors(
     : undefined;
 }
 
+// Counter scopes ride inside model-visible telemetry and persisted tool results.
+// Lowercase hex can never form a credential-shaped substring (hf_/sk-/ghp_/…),
+// so tool-payload redaction leaves persisted results embedding the scope intact.
+function generateCounterScope(): string {
+  return generateSecureHex(12);
+}
+
 function restoreToolSearchCatalog(params: {
   catalogRef: ToolSearchCatalogRef;
   entries: ToolSearchCatalogEntry[];
@@ -116,7 +123,7 @@ function restoreToolSearchCatalog(params: {
 }): void {
   const next = {
     entries: params.entries,
-    counterScope: generateSecureToken(12),
+    counterScope: generateCounterScope(),
     searchCount: 0,
     describeCount: 0,
     callCount: 0,
@@ -299,7 +306,7 @@ function registerToolSearchCatalog(params: {
     entries: Array.from(byId.values()).toSorted((a, b) => a.id.localeCompare(b.id)),
     // Appended client tools extend the same counter lifetime. A replacement
     // gets a new scope so telemetry consumers never infer resets from values.
-    counterScope: prior?.counterScope ?? generateSecureToken(12),
+    counterScope: prior?.counterScope ?? generateCounterScope(),
     searchCount: prior?.searchCount ?? 0,
     describeCount: prior?.describeCount ?? 0,
     callCount: prior?.callCount ?? 0,

--- a/src/agents/tool-search.test.ts
+++ b/src/agents/tool-search.test.ts
@@ -1638,7 +1638,10 @@ describe("Tool Search", () => {
       callCount?: number;
     };
     expect(telemetry.catalogSize).toBe(2);
-    expect(telemetry.counterScope).toMatch(/^[A-Za-z0-9_-]{16}$/);
+    // The lowercase-hex alphabet is a contract: a wider alphabet can emit
+    // credential-shaped scopes (e.g. hf_…) that tool-payload redaction rewrites,
+    // breaking byte-exact persistence of results embedding the telemetry.
+    expect(telemetry.counterScope).toMatch(/^[0-9a-f]{24}$/);
     expect(telemetry.searchCount).toBe(1);
     expect(telemetry.describeCount).toBe(1);
     expect(telemetry.callCount).toBe(1);


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes a flaky-by-construction CI failure where `code-mode.result-budget.test.ts` ("keeps 'long failure' Code Mode output complete after yield and provider dispatch") intermittently failed the byte-exact persistence assertion. On run 33367222647 (PR #133913) the Tool Search catalog's randomly generated `counterScope` came out as `9-hf_bepW…VZ (defanged)` — a HuggingFace-token-shaped string — and tool-payload redaction rewrote it to `9-***` inside the persisted result, breaking equality with the fresh producer text.

## Why This Change Was Made

`counterScope` was generated with `generateSecureToken(12)` (base64url), whose alphabet includes `_` and `-`, so random draws can form credential-shaped substrings (`hf_…`, `sk-…`, `ghp_…`) that the redactor in `src/logging/redact-patterns.ts` legitimately masks. The scope is a non-secret uniqueness marker embedded in model-visible telemetry and persisted tool results, so the fix moves it to lowercase hex (`generateSecureHex(12)`, same 96 bits of entropy) via a `generateCounterScope()` helper carrying the invariant comment. Lowercase hex is structurally immune to the entire redaction pattern list — every pattern requires `_`, `-`, uppercase, or letters beyond `f`. Actual secrets (worker credentials, transfer tokens, pairing join codes) keep the token-shaped generator; short diagnostic ids (`cmp-`/`ovf-`/`cmd_`) are too short to complete any credential pattern and are unchanged.

## User Impact

No user-visible behavior change. CI no longer flakes when the random scope happens to look like a credential, and persisted Code Mode results embedding catalog telemetry stay byte-identical across persistence and replay.

## Evidence

- Exact repro of the CI failure: running `redactToolPayloadText` over the exact CI scope value returns `9-***`, matching the CI diff byte-for-byte; a 2000-sample sweep of `generateSecureHex(12)` scopes passes redaction unchanged.
- The regression test pins the generator's shape instead of replaying the coincidence: the telemetry assertion in `src/agents/tool-search.test.ts` now requires `/^[0-9a-f]{24}$/`, which fails deterministically on any revert to a wider alphabet.
- `pnpm test src/agents/tool-search.test.ts src/agents/code-mode.result-budget.test.ts`: 162 tests passed.
- `pnpm check:changed`: green (format, typecheck, lint, import cycles, guard scripts).
- Production LOC: +10/−3 (net +7, of which 4 lines are the invariant comment) | Tests: +4/−1.
