### PR TITLE
perf: score Tool Search queries through term postings

### DIFF
--- a/src/agents/tool-search-ranking.ts
+++ b/src/agents/tool-search-ranking.ts
@@ -1,8 +1,4 @@
-// Lexical ranking shared by Tool Search results and directory-mode hydration.
-//
-// Both surfaces answer the same question — "which tools does this query mean?" —
-// so they index and score through here rather than keeping separate heuristics
-// that can disagree about the same catalog.
+// Lexical ranking for the OpenClaw Tool Search runtime.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 
 /** Collects property names and descriptions from a JSON-Schema-shaped value. */
@@ -341,28 +337,32 @@ export function tokenizeQuery(input: string): WeightedTerm[] {
 
 type RankedDocument<T> = { value: T; terms: readonly string[] };
 
+type IndexedDocument<T> = { readonly value: T; readonly length: number; readonly position: number };
+
 type LexicalIndex<T> = {
-  documents: ReadonlyArray<{ value: T; termCounts: ReadonlyMap<string, number>; length: number }>;
-  documentFrequency: ReadonlyMap<string, number>;
+  postings: ReadonlyMap<string, ReadonlyMap<IndexedDocument<T>, number>>;
+  documentCount: number;
   averageLength: number;
 };
 
 export function buildLexicalIndex<T>(documents: ReadonlyArray<RankedDocument<T>>): LexicalIndex<T> {
-  const documentFrequency = new Map<string, number>();
-  const prepared = documents.map((document) => {
-    const termCounts = new Map<string, number>();
+  const postings = new Map<string, Map<IndexedDocument<T>, number>>();
+  const prepared = documents.map((document, position) => {
+    const indexed = { value: document.value, length: document.terms.length, position };
     for (const term of document.terms) {
-      termCounts.set(term, (termCounts.get(term) ?? 0) + 1);
+      let matches = postings.get(term);
+      if (!matches) {
+        matches = new Map();
+        postings.set(term, matches);
+      }
+      matches.set(indexed, (matches.get(indexed) ?? 0) + 1);
     }
-    for (const term of termCounts.keys()) {
-      documentFrequency.set(term, (documentFrequency.get(term) ?? 0) + 1);
-    }
-    return { value: document.value, termCounts, length: document.terms.length };
+    return indexed;
   });
   const totalLength = prepared.reduce((sum, document) => sum + document.length, 0);
   return {
-    documents: prepared,
-    documentFrequency,
+    postings,
+    documentCount: prepared.length,
     averageLength: prepared.length > 0 ? totalLength / prepared.length : 0,
   };
 }
@@ -384,32 +384,33 @@ export function scoreLexical<T>(
   index: LexicalIndex<T>,
   queryTerms: readonly WeightedTerm[],
 ): Array<{ value: T; score: number; matchedLiteral: boolean }> {
-  if (queryTerms.length === 0 || index.documents.length === 0) {
+  if (queryTerms.length === 0 || index.documentCount === 0) {
     return [];
   }
-  const total = index.documents.length;
+  const total = index.documentCount;
   const results: Array<{ value: T; score: number; matchedLiteral: boolean }> = [];
-  for (const document of index.documents) {
-    let score = 0;
-    let matchedLiteral = false;
-    for (const { term, weight } of queryTerms) {
-      const frequency = document.termCounts.get(term);
-      if (!frequency) {
-        continue;
+  for (const { term, weight } of queryTerms) {
+    const matches = index.postings.get(term);
+    if (!matches) {
+      continue;
+    }
+    const matching = matches.size;
+    const idf = Math.log(1 + (total - matching + 0.5) / (matching + 0.5));
+    for (const [document, frequency] of matches) {
+      let result = results[document.position];
+      if (!result) {
+        result = { value: document.value, score: 0, matchedLiteral: false };
+        results[document.position] = result;
       }
       if (weight >= 1) {
-        matchedLiteral = true;
+        result.matchedLiteral = true;
       }
-      const matching = index.documentFrequency.get(term) ?? 0;
-      const idf = Math.log(1 + (total - matching + 0.5) / (matching + 0.5));
       const normalized = index.averageLength > 0 ? document.length / index.averageLength : 1;
-      score +=
+      result.score +=
         (weight * (idf * (frequency * (BM25_K1 + 1)))) /
         (frequency + BM25_K1 * (1 - BM25_B + BM25_B * normalized));
     }
-    if (score > 0) {
-      results.push({ value: document.value, score, matchedLiteral });
-    }
   }
-  return results;
+  // Sparse slots keep document positions; filter skips holes and preserves catalog order.
+  return results.filter((result) => result.score > 0);
 }


### PR DESCRIPTION
## What Problem This Solves

OpenClaw Tool Search queries use a shared lexical ranker, including searches in directory mode. The scorer currently visits every indexed document for every query term, including documents with no matching terms, and repeats inverse-document-frequency work for each match.

## Why This Change Was Made

Replace the document-oriented term maps and separate document-frequency map with one postings index: each term owns its matching documents and occurrence counts. Score only those matches, computing IDF once per query term. The original query-term accumulation order, document order, literal-match flag and exact floating-point scores stay unchanged. Private indexed-document identities keep equal values from collapsing into one result.

Sparse result positions preserve catalog order without a second map or sort. Exact-name directory hydration uses a separate unique-name lookup and is unaffected; tokenization, query expansion, policy gating and catalog invalidation do not change. No additional cache, dependency, configuration, protocol or storage surface. The integrated production delta is +1 line (+35/−34); no tests change. The private document position preserves output order without a sorting pass. The obsolete header claiming exact-name hydration used this ranker is also corrected.

## User Impact

Repeated Tool Search ranking avoids scanning documents with no matching terms. Returned tools, scores, ordering and available capabilities remain unchanged. This is an internal performance refactor; it does not change a user-facing contract.

## Evidence

### Measurements

Four fresh Node 26.8.1 processes ran 22 fixed workloads in forward/reverse order. All 968 measured samples and 352 warmup samples remain available, with exact workload results checked before and after measurement. The main corpus contains 56 tool IDs/descriptions extracted from source, not a runtime descriptor dump.

| Complete operation on the 56-tool corpus | Before | Candidate | Forward/reverse speed ratio |
| --- | ---: | ---: | ---: |
| Warm literal query, including tokenization | 1.720 µs | 1.145 µs | 1.48× / 1.55× |
| Warm expanded query, including tokenization | 3.126 µs | 1.643 µs | 1.93× / 1.87× |
| Warm eight-query batch, including tokenization | 19.750 µs | 11.511 µs | 1.73× / 1.72× |
| Build index and execute eight-query batch | 132.035 µs | 118.443 µs | 1.11× / 1.12× |

There are retained costs: single-document scoring adds about 10.9 ns (+17.2%); including tokenization, the single-document operation adds 18.4 ns (+1.8%), and construction plus one query adds 25 ns (+0.9%). Empty-index scoring is slower; empty-query and single-no-hit controls have mixed direction. Large replicated and dense synthetic catalogs improve but are stress controls, not estimates of real usage. Cold construction plus one ordinary literal query improves only 1–4% across the two orders.

These are ranking-owner measurements. They do not establish Gateway turn latency, browser latency or retained-index memory improvement. Process CPU/RSS counters were retained but are affected by the mixed schedule and garbage collection.

### Verification

Source-bound differential proof passed 522 exact semantic cases, 36 tokenizer controls, six parameter controls and 22 workload oracles. It covers query order, duplicate document values, ranking order and exceptional numeric weights. An IDF-only alternative was measured and rejected because ordinary workloads regressed. An intermediate postings implementation was correctness-tested but not timed; only the selected implementation earns the measurements above.

Both current-main baseline and integrated candidate passed 254 tests across the canonical ranking, runtime, runtime-config and Tool Search suites. Changed-file checks, including core and core-test type checks, lint and repository guards, passed. Independent source/evidence review found no remaining actionable finding; managed critical-defect review also passed. A built baseline Gateway completed four real OpenAI turns: readiness, batched Tool Search, search followed by a real file read, and search followed by a real web fetch. Twelve session RPCs passed and a Node CPU profile was retained. The Gateway process group and listening socket were removed afterward.

The full candidate `pnpm build` passed at `b0cc821a8a731f11c9d7b147e78189c566074330`. That built candidate completed the same four real OpenAI turns. Its persisted transcript confirms natural-language queries with limit two, so the calls enter lexical scoring rather than the unique exact-name shortcut. The returned tool names, literal file marker and fetched page title/URL were checked. Twelve session RPCs passed, a CPU profile was retained, and the Gateway process, process group and listening socket were verified absent after shutdown. Temporary credentials/configuration were removed. Provider round-trip timings vary and are not used as evidence of a Gateway latency improvement.

Canonical verification commands:

```sh
pnpm test src/agents/tool-search-ranking.test.ts src/agents/tool-search-runtime.test.ts src/agents/tool-search-runtime-config.test.ts src/agents/tool-search.test.ts
node scripts/check-changed.mjs -- src/agents/tool-search-ranking.ts
pnpm build
```

The timing capture remains bound to its original source at `20b2dacb109d3c5bb140efcf7c5dae31082569e4`. The ranking owner is unchanged in the refreshed baseline, and the integrated algorithm is byte-identical to the measured candidate after the corrected header. The candidate build/live proof uses the committed PR head above. No old run is relabeled as a fresh execution. Hosted CI and the native landing workflow remain the final gates.
