### PR TITLE
fix(xai): handle silent transcripts and order upload options

### DIFF
--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -417,6 +417,9 @@ stale context metadata on active 4.20 rows. It does not pin active 4.20
     surface, but the xAI REST STT integration forwards only file and language
     because those map to the current public xAI endpoint.
 
+    Valid empty transcripts are skipped, and OpenClaw tries any configured
+    fallback. Malformed responses and HTTP failures remain errors.
+
   </Accordion>
 
   <Accordion title="Streaming speech-to-text">

--- a/extensions/xai/stt.test.ts
+++ b/extensions/xai/stt.test.ts
@@ -74,6 +74,66 @@ describe("xai stt", () => {
     expect(form.get("language")).toBe("en");
     expect(form.get("prompt")).toBeNull();
     expect(form.get("file")).toBeInstanceOf(Blob);
+    const serialized = await new Request(call.url!, { method: "POST", body: form }).text();
+    const partNames = [
+      ...serialized.matchAll(/Content-Disposition: form-data; name="([^"]+)"/g),
+    ].map((match) => match[1]);
+    expect(partNames).toEqual(["language", "file"]);
+  });
+
+  it.each(["", " \t\n", "  spoken words  "])(
+    "accepts a valid transcript string %j",
+    async (text) => {
+      const release = vi.fn();
+      postTranscriptionRequestMock.mockResolvedValueOnce({
+        response: new Response(JSON.stringify({ text })),
+        release,
+      });
+
+      await expect(
+        buildXaiMediaUnderstandingProvider().transcribeAudio!({
+          buffer: Buffer.from("audio-bytes"),
+          fileName: "sample.wav",
+          mime: "audio/wav",
+          apiKey: "xai-key",
+          timeoutMs: 1000,
+        }),
+      ).resolves.toEqual({ text: text.trim() });
+      expect(release).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each([
+    ...[{}, { text: null }, { text: 0 }, { text: false }, { text: [] }, { text: {} }].map(
+      (payload) => ({
+        body: JSON.stringify(payload),
+        status: 200,
+        error: "xAI transcription response missing text",
+      }),
+    ),
+    ...["null", "[]", '"text"', "0", "false", "{ nope"].map((body) => ({
+      body,
+      status: 200,
+      error: "xai.stt: malformed JSON response",
+    })),
+    { body: "unauthorized", status: 401, error: "xAI audio transcription failed" },
+  ])("rejects status $status response $body", async ({ body, status, error }) => {
+    const release = vi.fn();
+    postTranscriptionRequestMock.mockResolvedValueOnce({
+      response: new Response(body, { status }),
+      release,
+    });
+
+    await expect(
+      buildXaiMediaUnderstandingProvider().transcribeAudio!({
+        buffer: Buffer.from("audio-bytes"),
+        fileName: "sample.wav",
+        mime: "audio/wav",
+        apiKey: "xai-key",
+        timeoutMs: 1000,
+      }),
+    ).rejects.toThrow(error);
+    expect(release).toHaveBeenCalledOnce();
   });
 
   it("registers as an audio media-understanding provider", () => {

--- a/extensions/xai/stt.ts
+++ b/extensions/xai/stt.ts
@@ -8,17 +8,12 @@ import {
   assertOkOrThrowHttpError,
   buildAudioTranscriptionFormData,
   postTranscriptionRequest,
-  readProviderJsonResponse,
-  requireTranscriptionText,
+  readProviderJsonObjectResponse,
   resolveProviderHttpRequestConfig,
 } from "openclaw/plugin-sdk/provider-http";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { createXaiMediaUnderstandingProviderMetadata } from "./capability-provider-metadata.js";
 import { XAI_BASE_URL } from "./model-definitions.js";
-
-type XaiSttResponse = {
-  text?: string;
-};
 
 function resolveXaiSttBaseUrl(value?: string): string {
   return normalizeOptionalString(value ?? process.env.XAI_BASE_URL) ?? XAI_BASE_URL;
@@ -67,10 +62,12 @@ async function transcribeXaiAudio(
 
   try {
     await assertOkOrThrowHttpError(response, "xAI audio transcription failed");
-    const payload = await readProviderJsonResponse<XaiSttResponse>(response, "xai.stt");
-    return {
-      text: requireTranscriptionText(payload.text, "xAI transcription response missing text"),
-    };
+    const payload = await readProviderJsonObjectResponse(response, "xai.stt");
+    if (typeof payload.text !== "string") {
+      throw new Error("xAI transcription response missing text");
+    }
+    // xAI returns an empty transcript for valid audio without detected speech.
+    return { text: payload.text.trim() };
   } finally {
     await release();
   }

--- a/src/media-understanding/shared.ts
+++ b/src/media-understanding/shared.ts
@@ -61,7 +61,7 @@ export function resolveAudioTranscriptionUploadFileName(fileName?: string, mime?
   return baseName;
 }
 
-/** Builds provider-compatible multipart form data for audio transcription requests. */
+/** Places options before the audio file so streaming multipart parsers can apply them. */
 export function buildAudioTranscriptionFormData(params: {
   buffer: Buffer;
   fileName?: string;
@@ -73,13 +73,13 @@ export function buildAudioTranscriptionFormData(params: {
   const blob = new Blob([bytes], {
     type: params.mime ?? "application/octet-stream",
   });
-  form.append("file", blob, resolveAudioTranscriptionUploadFileName(params.fileName, params.mime));
   for (const [name, value] of Object.entries(params.fields ?? {})) {
     const text = typeof value === "string" ? value.trim() : value == null ? "" : String(value);
     if (text) {
       form.append(name, text);
     }
   }
+  form.append("file", blob, resolveAudioTranscriptionUploadFileName(params.fileName, params.mime));
   return form;
 }
 


### PR DESCRIPTION
Related: #134243

## What Problem This Solves

A successful xAI transcription response for silent audio contains an empty text string. OpenClaw treated it as a missing field and raised a processing error before the media runner could record its existing nonfatal empty-output outcome.

The shared multipart builder also put the file before optional fields, contrary to xAI's documented streaming-upload contract.

## Why This Change Was Made

The xAI plugin now uses the existing bounded JSON object reader, requires string-valued text, and returns the trimmed string even when empty. Missing/nonstring text, malformed JSON and failed HTTP responses remain errors. The obsolete unchecked response type is removed; the shared strict text helper and other providers' response policies are unchanged.

The shared multipart builder appends its audio file after the existing options. Field values, filename/MIME handling, auth, routing and deadlines are unchanged. No new configuration, fallback, retry, dependency or persistence shape is introduced. [xAI requires the file to be the last multipart field](https://docs.x.ai/developers/model-capabilities/audio/speech-to-text). Three direct consumers and seven bundled provider paths were audited; no inspected sibling contract requires file-first.

## Evidence

Candidate: `2c2d2ddbec67ca8fed97f045340ca69f8eaeafdc`.

- Identical xAI regression assertions: **12 failures / 7 passes before the fix → 19/19 passing**. Coverage includes valid empty/whitespace/usable strings, malformed roots and text values, HTTP failure, request release and serialized option ordering.
- Six existing sibling files: **66 tests passed**, covering shared adapter requests, DNS handling, empty-output/fallback decisions and file-runtime errors.
- Full four-path changed-file gate passed on the committed file bytes, including core/plugin/test types, formatting, lint, unused exports and boundary guards. Independent Codex review found no actionable P0–P2 findings.
- **Authenticated xAI REST:** synthetic silence returned HTTP 200 with a present empty string before the fix, then the actual plugin raised its missing-text error. After the fix, silence succeeds with an empty result; default and language-configured speech both return recognizable words. All three final probes returned HTTP 200 through the actual plugin, guarded transport and canonical runtime fetch adapter. The configured request serialized `language,file`.
- **Actual plugin → runtime → Discord segment composition:** **8/8 scenarios, 14 loopback HTTP requests**. Empty/whitespace output was skipped, configured fallback progressed, and malformed/non-2xx responses remained failures. Silence reached no downstream consumer; the following voiced segment progressed in normal and transcript-only modes. All requests preserved the exact synthetic WAV bytes and `language,file` order.

Production is **net −3 lines**, tests +60 and docs +3.

## Proof Limits

Both old and corrected multipart orders were accepted by the live service with the same measured transcript length and markers. Ordering is a documented-contract repair, not a demonstrated cause of the silence bug or recognition improvement.

The composition run began on frozen uncommitted source. All eight exercised source hashes and four candidate files stayed unchanged and match the committed blobs; this is source composition proof, not an immutable-start compiled-artifact run. The loopback server closed with zero sockets and its temporary HOME was removed. Discord used a bounded no-reply agent stub, not real capture, model output or playback. The existing attachment disposition still says `failed` when no transcript is produced, separately from the repaired `skipped` attempt/aggregate outcome.

The live probes used an API key and synthetic audio, not OAuth refresh, room audio, Windows process lifetime or a microphone. They confirm the empty-response failure mechanism, not the coincident Gateway process-death claim.

Two initial fixture failures are preserved separately: an observer bypassed runtime FormData normalization and received HTTP 400; the first loopback fixture omitted the documented private-network opt-in and was blocked before any HTTP request. Corrected fixtures use existing transport/configuration contracts without changing product network policy.

Release note: treat valid empty xAI transcripts as nonfatal empty output and send transcription options before audio uploads. Thanks @lordstryfe for the report.

Final hosted validation: [CI run 33425614837](https://github.com/openclaw/openclaw/actions/runs/33425614837) passed on the exact candidate after one unchanged failed-job replay. Attempt 1 failed only an unchanged oc-path parser CPU benchmark (819.141 ms against 800 ms); the original failure is preserved. No source, threshold, fixture or assertion changed, and the overrun cause is not established. The benchmark workload/measurement contract is recorded as a separate follow-up.
