### PR TITLE
test(nostr): consolidate metrics coverage at its owner

### DIFF
--- a/extensions/nostr/src/metrics.test.ts
+++ b/extensions/nostr/src/metrics.test.ts
@@ -1,18 +1,11 @@
-// Nostr tests cover nostr bus.integration plugin behavior.
 import { expectDefined } from "@openclaw/normalization-core";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import { createMetrics, createNoopMetrics, type MetricEvent } from "./metrics.js";
 import { TEST_RELAY_URL } from "./test-fixtures.js";
 
 const TEST_RELAY_URL_1 = "wss://relay1.com";
 const TEST_RELAY_URL_2 = "wss://relay2.com";
 const TEST_RELAY_URL_PRIMARY = "wss://relay.com";
-const TEST_RELAY_URL_GOOD = "wss://good-relay.com";
-const TEST_RELAY_URL_BAD = "wss://bad-relay.com";
-
-afterEach(() => {
-  vi.useRealTimers();
-});
 
 function createCollectingMetrics() {
   const events: MetricEvent[] = [];
@@ -22,17 +15,9 @@ function createCollectingMetrics() {
   };
 }
 
-function createPlainMetrics() {
-  return createMetrics();
-}
-
 function requireRecordEntry<T>(entries: Record<string, T>, key: string, context: string): T {
   return expectDefined(entries[key], context);
 }
-
-// ============================================================================
-// Metrics Integration Tests
-// ============================================================================
 
 describe("Metrics", () => {
   describe("createMetrics", () => {
@@ -60,7 +45,7 @@ describe("Metrics", () => {
     });
 
     it("accumulates counters in snapshot", () => {
-      const metrics = createPlainMetrics();
+      const metrics = createMetrics();
 
       metrics.emit("event.received");
       metrics.emit("event.received");
@@ -76,7 +61,7 @@ describe("Metrics", () => {
     });
 
     it("tracks per-relay stats", () => {
-      const metrics = createPlainMetrics();
+      const metrics = createMetrics();
 
       metrics.emit("relay.connect", 1, { relay: TEST_RELAY_URL_1 });
       metrics.emit("relay.connect", 1, { relay: TEST_RELAY_URL_2 });
@@ -85,9 +70,6 @@ describe("Metrics", () => {
 
       const snapshot = metrics.getSnapshot();
       const relayOne = requireRecordEntry(snapshot.relays, TEST_RELAY_URL_1, "Nostr relay metrics");
-      if (!relayOne) {
-        throw new Error("expected first relay metrics");
-      }
       expect(relayOne.connects).toBe(1);
       expect(relayOne.errors).toBe(2);
       expect(
@@ -99,7 +81,7 @@ describe("Metrics", () => {
     });
 
     it("tracks circuit breaker state changes", () => {
-      const metrics = createPlainMetrics();
+      const metrics = createMetrics();
 
       metrics.emit("relay.circuit_breaker.open", 1, { relay: TEST_RELAY_URL_PRIMARY });
 
@@ -112,6 +94,15 @@ describe("Metrics", () => {
         requireRecordEntry(snapshot.relays, TEST_RELAY_URL_PRIMARY, "Nostr relay metrics")
           .circuitBreakerOpens,
       ).toBe(1);
+
+      metrics.emit("relay.circuit_breaker.half_open", 1, { relay: TEST_RELAY_URL_PRIMARY });
+      expect(
+        requireRecordEntry(
+          metrics.getSnapshot().relays,
+          TEST_RELAY_URL_PRIMARY,
+          "Nostr relay metrics",
+        ).circuitBreakerState,
+      ).toBe("half_open");
 
       metrics.emit("relay.circuit_breaker.close", 1, { relay: TEST_RELAY_URL_PRIMARY });
 
@@ -127,7 +118,7 @@ describe("Metrics", () => {
     });
 
     it("tracks all rejection reasons", () => {
-      const metrics = createPlainMetrics();
+      const metrics = createMetrics();
 
       metrics.emit("event.rejected.invalid_shape");
       metrics.emit("event.rejected.wrong_kind");
@@ -154,7 +145,7 @@ describe("Metrics", () => {
     });
 
     it("tracks relay message types", () => {
-      const metrics = createPlainMetrics();
+      const metrics = createMetrics();
 
       metrics.emit("relay.message.event", 1, { relay: TEST_RELAY_URL_PRIMARY });
       metrics.emit("relay.message.eose", 1, { relay: TEST_RELAY_URL_PRIMARY });
@@ -178,7 +169,7 @@ describe("Metrics", () => {
     });
 
     it("tracks decrypt success/failure", () => {
-      const metrics = createPlainMetrics();
+      const metrics = createMetrics();
 
       metrics.emit("decrypt.success");
       metrics.emit("decrypt.success");
@@ -190,7 +181,7 @@ describe("Metrics", () => {
     });
 
     it("tracks memory gauges (replaces rather than accumulates)", () => {
-      const metrics = createPlainMetrics();
+      const metrics = createMetrics();
 
       metrics.emit("memory.seen_tracker_size", 100);
       metrics.emit("memory.seen_tracker_size", 150);
@@ -201,7 +192,7 @@ describe("Metrics", () => {
     });
 
     it("reset clears all counters", () => {
-      const metrics = createPlainMetrics();
+      const metrics = createMetrics();
 
       metrics.emit("event.received");
       metrics.emit("event.processed");
@@ -234,85 +225,103 @@ describe("Metrics", () => {
   });
 });
 
-// ============================================================================
-// Circuit Breaker Behavior Tests
-// ============================================================================
+describe("Metrics fuzz", () => {
+  describe("invalid metric names", () => {
+    it("handles unknown metric names gracefully", () => {
+      const metrics = createMetrics();
 
-describe("Circuit Breaker Behavior", () => {
-  // Test the circuit breaker logic through metrics emissions
-  it("emits circuit breaker metrics in correct sequence", () => {
-    const { events, metrics } = createCollectingMetrics();
-
-    // Simulate 5 failures -> open
-    for (let i = 0; i < 5; i++) {
-      metrics.emit("relay.error", 1, { relay: TEST_RELAY_URL_PRIMARY });
-    }
-    metrics.emit("relay.circuit_breaker.open", 1, { relay: TEST_RELAY_URL_PRIMARY });
-
-    // Simulate recovery
-    metrics.emit("relay.circuit_breaker.half_open", 1, { relay: TEST_RELAY_URL_PRIMARY });
-    metrics.emit("relay.circuit_breaker.close", 1, { relay: TEST_RELAY_URL_PRIMARY });
-
-    const cbEvents = events.filter((e) => e.name.startsWith("relay.circuit_breaker"));
-    expect(cbEvents).toHaveLength(3);
-    expect(expectDefined(cbEvents[0], "circuit breaker open event").name).toBe(
-      "relay.circuit_breaker.open",
-    );
-    expect(expectDefined(cbEvents[1], "circuit breaker half-open event").name).toBe(
-      "relay.circuit_breaker.half_open",
-    );
-    expect(expectDefined(cbEvents[2], "circuit breaker close event").name).toBe(
-      "relay.circuit_breaker.close",
-    );
+      // Cast to bypass type checking - testing runtime behavior
+      type EmitMetricName = Parameters<typeof metrics.emit>[0];
+      expect(metrics.emit("invalid.metric.name" as EmitMetricName)).toBeUndefined();
+    });
   });
-});
 
-// ============================================================================
-// Health Scoring Behavior Tests
-// ============================================================================
+  describe("invalid label values", () => {
+    it("handles null relay label", () => {
+      const metrics = createMetrics();
+      expect(
+        metrics.emit("relay.connect", 1, { relay: null as unknown as string }),
+      ).toBeUndefined();
+    });
 
-describe("Health Scoring", () => {
-  it("metrics track relay errors for health scoring", () => {
-    const metrics = createPlainMetrics();
+    it("handles undefined relay label", () => {
+      const metrics = createMetrics();
+      expect(
+        metrics.emit("relay.connect", 1, { relay: undefined as unknown as string }),
+      ).toBeUndefined();
+    });
 
-    // Simulate mixed success/failure pattern
-    metrics.emit("relay.connect", 1, { relay: TEST_RELAY_URL_GOOD });
-    metrics.emit("relay.connect", 1, { relay: TEST_RELAY_URL_BAD });
+    it("handles very long relay URL", () => {
+      const metrics = createMetrics();
+      const longUrl = "wss://" + "a".repeat(10000) + ".com";
+      expect(metrics.emit("relay.connect", 1, { relay: longUrl })).toBeUndefined();
 
-    metrics.emit("relay.error", 1, { relay: TEST_RELAY_URL_BAD });
-    metrics.emit("relay.error", 1, { relay: TEST_RELAY_URL_BAD });
-    metrics.emit("relay.error", 1, { relay: TEST_RELAY_URL_BAD });
-
-    const snapshot = metrics.getSnapshot();
-    expect(
-      requireRecordEntry(snapshot.relays, TEST_RELAY_URL_GOOD, "Nostr relay metrics").errors,
-    ).toBe(0);
-    expect(
-      requireRecordEntry(snapshot.relays, TEST_RELAY_URL_BAD, "Nostr relay metrics").errors,
-    ).toBe(3);
+      const snapshot = metrics.getSnapshot();
+      expect(snapshot.relays[longUrl]).toEqual({
+        connects: 1,
+        disconnects: 0,
+        reconnects: 0,
+        errors: 0,
+        messagesReceived: {
+          event: 0,
+          eose: 0,
+          closed: 0,
+          notice: 0,
+          ok: 0,
+          auth: 0,
+        },
+        circuitBreakerState: "closed",
+        circuitBreakerOpens: 0,
+        circuitBreakerCloses: 0,
+      });
+    });
   });
-});
 
-// ============================================================================
-// Reconnect Backoff Tests
-// ============================================================================
+  describe("extreme values", () => {
+    it("handles NaN value", () => {
+      const metrics = createMetrics();
+      expect(metrics.emit("event.received", Number.NaN)).toBeUndefined();
 
-describe("Reconnect Backoff", () => {
-  it("computes delays within expected bounds", () => {
-    // Compute expected delays (1s, 2s, 4s, 8s, 16s, 32s, 60s cap)
-    const BASE = 1000;
-    const MAX = 60000;
-    const JITTER = 0.3;
+      const snapshot = metrics.getSnapshot();
+      expect(Number.isNaN(snapshot.eventsReceived)).toBe(true);
+    });
 
-    for (let attempt = 0; attempt < 10; attempt++) {
-      const exponential = BASE * 2 ** attempt;
-      const capped = Math.min(exponential, MAX);
-      const minDelay = capped * (1 - JITTER);
-      const maxDelay = capped * (1 + JITTER);
+    it("handles Infinity value", () => {
+      const metrics = createMetrics();
+      expect(metrics.emit("event.received", Infinity)).toBeUndefined();
 
-      // These are the expected bounds
-      expect(minDelay).toBeGreaterThanOrEqual(BASE * 0.7);
-      expect(maxDelay).toBeLessThanOrEqual(MAX * 1.3);
-    }
+      const snapshot = metrics.getSnapshot();
+      expect(snapshot.eventsReceived).toBe(Infinity);
+    });
+
+    it("handles negative value", () => {
+      const metrics = createMetrics();
+      metrics.emit("event.received", -1);
+
+      const snapshot = metrics.getSnapshot();
+      expect(snapshot.eventsReceived).toBe(-1);
+    });
+
+    it("handles very large value", () => {
+      const metrics = createMetrics();
+      metrics.emit("event.received", Number.MAX_SAFE_INTEGER);
+
+      const snapshot = metrics.getSnapshot();
+      expect(snapshot.eventsReceived).toBe(Number.MAX_SAFE_INTEGER);
+    });
+  });
+
+  describe("reset during operation", () => {
+    it("handles reset mid-operation safely", () => {
+      const metrics = createMetrics();
+
+      metrics.emit("event.received");
+      metrics.emit("event.received");
+      metrics.reset();
+      metrics.emit("event.received");
+
+      const snapshot = metrics.getSnapshot();
+      expect(snapshot.eventsReceived).toBe(1);
+    });
   });
 });

--- a/extensions/nostr/src/nostr-bus.fuzz.test.ts
+++ b/extensions/nostr/src/nostr-bus.fuzz.test.ts
@@ -1,20 +1,7 @@
 // Nostr tests cover nostr bus.fuzz plugin behavior.
 import { describe, expect, it } from "vitest";
-import { createMetrics } from "./metrics.js";
 import { validatePrivateKey, normalizePubkey } from "./nostr-key-utils.js";
 import { TEST_HEX_PRIVATE_KEY } from "./test-fixtures.js";
-
-function createPlainMetrics() {
-  return createMetrics();
-}
-
-function createCollectingMetrics() {
-  const events: unknown[] = [];
-  return {
-    events,
-    metrics: createMetrics((event) => events.push(event)),
-  };
-}
 
 function expectThrowsError(run: () => unknown): void {
   let error: unknown;
@@ -113,125 +100,6 @@ describe("normalizePubkey fuzz", () => {
     it("normalizes mixed case to lowercase", () => {
       const mixed = "0123456789AbCdEf0123456789AbCdEf0123456789AbCdEf0123456789AbCdEf";
       expect(normalizePubkey(mixed)).toBe(TEST_HEX_PRIVATE_KEY);
-    });
-  });
-});
-
-// ============================================================================
-// Fuzz Tests for Metrics
-// ============================================================================
-
-describe("Metrics fuzz", () => {
-  describe("invalid metric names", () => {
-    it("handles unknown metric names gracefully", () => {
-      const metrics = createPlainMetrics();
-
-      // Cast to bypass type checking - testing runtime behavior
-      type EmitMetricName = Parameters<typeof metrics.emit>[0];
-      expect(metrics.emit("invalid.metric.name" as EmitMetricName)).toBeUndefined();
-    });
-  });
-
-  describe("invalid label values", () => {
-    it("handles null relay label", () => {
-      const metrics = createPlainMetrics();
-      expect(
-        metrics.emit("relay.connect", 1, { relay: null as unknown as string }),
-      ).toBeUndefined();
-    });
-
-    it("handles undefined relay label", () => {
-      const metrics = createPlainMetrics();
-      expect(
-        metrics.emit("relay.connect", 1, { relay: undefined as unknown as string }),
-      ).toBeUndefined();
-    });
-
-    it("handles very long relay URL", () => {
-      const metrics = createPlainMetrics();
-      const longUrl = "wss://" + "a".repeat(10000) + ".com";
-      expect(metrics.emit("relay.connect", 1, { relay: longUrl })).toBeUndefined();
-
-      const snapshot = metrics.getSnapshot();
-      expect(snapshot.relays[longUrl]).toEqual({
-        connects: 1,
-        disconnects: 0,
-        reconnects: 0,
-        errors: 0,
-        messagesReceived: {
-          event: 0,
-          eose: 0,
-          closed: 0,
-          notice: 0,
-          ok: 0,
-          auth: 0,
-        },
-        circuitBreakerState: "closed",
-        circuitBreakerOpens: 0,
-        circuitBreakerCloses: 0,
-      });
-    });
-  });
-
-  describe("extreme values", () => {
-    it("handles NaN value", () => {
-      const metrics = createPlainMetrics();
-      expect(metrics.emit("event.received", Number.NaN)).toBeUndefined();
-
-      const snapshot = metrics.getSnapshot();
-      expect(Number.isNaN(snapshot.eventsReceived)).toBe(true);
-    });
-
-    it("handles Infinity value", () => {
-      const metrics = createPlainMetrics();
-      expect(metrics.emit("event.received", Infinity)).toBeUndefined();
-
-      const snapshot = metrics.getSnapshot();
-      expect(snapshot.eventsReceived).toBe(Infinity);
-    });
-
-    it("handles negative value", () => {
-      const metrics = createPlainMetrics();
-      metrics.emit("event.received", -1);
-
-      const snapshot = metrics.getSnapshot();
-      expect(snapshot.eventsReceived).toBe(-1);
-    });
-
-    it("handles very large value", () => {
-      const metrics = createPlainMetrics();
-      metrics.emit("event.received", Number.MAX_SAFE_INTEGER);
-
-      const snapshot = metrics.getSnapshot();
-      expect(snapshot.eventsReceived).toBe(Number.MAX_SAFE_INTEGER);
-    });
-  });
-
-  describe("rapid emissions", () => {
-    it("handles many rapid emissions", () => {
-      const { events, metrics } = createCollectingMetrics();
-
-      for (let i = 0; i < 10000; i++) {
-        metrics.emit("event.received");
-      }
-
-      expect(events).toHaveLength(10000);
-      const snapshot = metrics.getSnapshot();
-      expect(snapshot.eventsReceived).toBe(10000);
-    });
-  });
-
-  describe("reset during operation", () => {
-    it("handles reset mid-operation safely", () => {
-      const metrics = createPlainMetrics();
-
-      metrics.emit("event.received");
-      metrics.emit("event.received");
-      metrics.reset();
-      metrics.emit("event.received");
-
-      const snapshot = metrics.getSnapshot();
-      expect(snapshot.eventsReceived).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## What problem does this PR solve?

The Nostr integration test file exercises only the metrics owner. Three cases demonstrate copied reconnect/circuit/health logic without invoking the bus, and a separate metrics loop emits 10,000 identical events without testing an additional boundary.

## Why this approach?

Move the metrics cases to their owner-named test file, consolidate metrics fuzz coverage there, and delete the copied demonstrations and repeated emission loop. Preserve counter, callback, reset, malformed input, gauge and relay snapshot checks, and assert the real metrics half-open state explicitly. Key fuzz tests and actual bus outbound tests remain separate.

## User impact

Test-only cleanup. Production +0/-0; rename-aware test diff +112/-235, including moved cases. This removes four low-value cases and 10,000 redundant emissions; it does not change relay behavior or claim a measured elapsed-time improvement.

## Evidence

The original metrics/fuzz/outbound selection passed all 38 tests. The replacement selection passes all 34 tests: 21 metrics, 11 key fuzz and two actual outbound bus cases. Full changed-file checks and Codex autoreview pass.

`node scripts/run-vitest.mjs extensions/nostr/src/metrics.test.ts extensions/nostr/src/nostr-bus.fuzz.test.ts extensions/nostr/src/nostr-bus.outbound.test.ts`

Follow-up: add direct bus-owner evidence for circuit thresholds, half-open recovery and health-ranked relay selection. The deleted hand-written demonstrations never covered those owner paths; the retained metrics state assertions do not substitute for relay integration proof.
