### PR TITLE
test(whatsapp): unify profile directory import lifecycles

### DIFF
--- a/extensions/whatsapp/src/auth-store.lazy-dir.test.ts
+++ b/extensions/whatsapp/src/auth-store.lazy-dir.test.ts
@@ -1,57 +1,35 @@
-// Whatsapp tests cover auth store.lazy dir plugin behavior.
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { DEFAULT_ACCOUNT_ID } from "openclaw/plugin-sdk/routing";
 import { captureEnv } from "openclaw/plugin-sdk/test-env";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { expect, it, vi } from "vitest";
 
-describe("WhatsApp auth dir profile resolution", () => {
-  let envSnapshot: ReturnType<typeof captureEnv>;
-  let tempStateDir: string | undefined;
-
-  beforeEach(() => {
-    envSnapshot = captureEnv(["OPENCLAW_STATE_DIR", "OPENCLAW_OAUTH_DIR"]);
-    tempStateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-wa-profile-"));
+it("resolves active-profile directories after import and preserves the legacy string export", async () => {
+  const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR", "OPENCLAW_OAUTH_DIR"]);
+  const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-wa-profile-"));
+  try {
     delete process.env.OPENCLAW_STATE_DIR;
     delete process.env.OPENCLAW_OAUTH_DIR;
     vi.resetModules();
-  });
+    const authStore = await import("./auth-store.js");
+    const accounts = await import("./accounts.js");
 
-  afterEach(() => {
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    const expected = path.join(stateDir, "credentials", "whatsapp", DEFAULT_ACCOUNT_ID);
+    expect(authStore.resolveDefaultWebAuthDir()).toBe(expected);
+    expect(accounts.listWhatsAppAuthDirs({})).toEqual([
+      path.join(stateDir, "credentials"),
+      expected,
+    ]);
+
+    vi.resetModules();
+    const profileAuthStore = await import("./auth-store.js");
+    expect(profileAuthStore.WA_WEB_AUTH_DIR).toBe(expected);
+    expect(typeof profileAuthStore.WA_WEB_AUTH_DIR).toBe("string");
+  } finally {
     envSnapshot.restore();
     vi.resetModules();
-    if (tempStateDir) {
-      fs.rmSync(tempStateDir, { recursive: true, force: true });
-      tempStateDir = undefined;
-    }
-  });
-
-  it("resolves the default web auth dir from OPENCLAW_STATE_DIR at call time", async () => {
-    const authStore = await import("./auth-store.js");
-    process.env.OPENCLAW_STATE_DIR = tempStateDir;
-
-    const expected = path.join(tempStateDir ?? "", "credentials", "whatsapp", DEFAULT_ACCOUNT_ID);
-    expect(authStore.resolveDefaultWebAuthDir()).toBe(expected);
-  });
-
-  it("exports the legacy default auth dir as a primitive string", async () => {
-    process.env.OPENCLAW_STATE_DIR = tempStateDir;
-    const authStore = await import("./auth-store.js");
-
-    const expected = path.join(tempStateDir ?? "", "credentials", "whatsapp", DEFAULT_ACCOUNT_ID);
-    expect(authStore.WA_WEB_AUTH_DIR).toBe(expected);
-    expect(typeof authStore.WA_WEB_AUTH_DIR).toBe("string");
-  });
-
-  it("lists WhatsApp auth dirs under the active profile state dir", async () => {
-    const accounts = await import("./accounts.js");
-    process.env.OPENCLAW_STATE_DIR = tempStateDir;
-
-    const dirs = accounts.listWhatsAppAuthDirs({});
-    expect(dirs).toContain(path.join(tempStateDir ?? "", "credentials"));
-    expect(dirs).toContain(
-      path.join(tempStateDir ?? "", "credentials", "whatsapp", DEFAULT_ACCOUNT_ID),
-    );
-  });
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## What problem does this PR solve?

Three WhatsApp profile-directory tests repeat cold module setup and temporary directories for related import-time and call-time contracts.

## Why this approach?

Exercise the contracts in one lifecycle with two distinct import phases: import without profile overrides, then set the active profile and check call-time resolution; reset and import under that profile to check the legacy primitive string export. Import auth-store and accounts sequentially so failure cleanup cannot race a still-running import. Restore the environment, reset modules and remove the directory in finally.

## User impact

Test-only cleanup. Production +0/-0; tests +21/-43. Three cases become one, removing one cold module phase, three module resets and two temporary directories. The account-directory check now verifies the exact ordered pair instead of two membership assertions.

## Evidence

All 26 original profile/account/facade tests pass. The consolidated selection passes all 24 tests, including the unchanged account/auth and runtime-facade siblings. Full changed-file checks and Codex autoreview pass. No auth, filesystem runtime or compatibility behavior changes; no elapsed-time claim.

`node scripts/run-vitest.mjs extensions/whatsapp/src/accounts.test.ts extensions/whatsapp/src/accounts.whatsapp-auth.test.ts extensions/whatsapp/src/auth-store.lazy-dir.test.ts src/plugins/runtime/runtime-web-channel-plugin.test.ts`
