### PR TITLE
test(deepgram): observe realtime transcription completion

### DIFF
--- a/extensions/deepgram/realtime-transcription-provider.test.ts
+++ b/extensions/deepgram/realtime-transcription-provider.test.ts
@@ -2,6 +2,7 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type WebSocket from "ws";
 import type { RawData } from "ws";
@@ -186,16 +187,21 @@ describe("buildDeepgramRealtimeTranscriptionProvider", () => {
       },
     });
     const onPartial = vi.fn();
-    const onTranscript = vi.fn();
+    const transcriptReceived = createDeferred<string>();
+    const onTranscript = vi.fn(transcriptReceived.resolve);
     const session = buildDeepgramRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "dummy", baseUrl: server.baseUrl, endpointingMs: 1000 },
       onPartial,
       onTranscript,
     });
 
-    await session.connect();
-    await vi.waitFor(() => expect(onTranscript).toHaveBeenCalledWith("hello world"));
-    session.close();
+    try {
+      await session.connect();
+      await vi.waitFor(() => transcriptReceived.promise);
+      expect(onTranscript).toHaveBeenCalledWith("hello world");
+    } finally {
+      session.close();
+    }
 
     expect(onPartial).toHaveBeenCalledWith("hello");
     expect(onTranscript).toHaveBeenCalledTimes(1);
@@ -209,63 +215,101 @@ describe("buildDeepgramRealtimeTranscriptionProvider", () => {
         sendResult(ws, { text: "hello", isFinal: true, speechFinal: true });
       },
     });
-    const onTranscript = vi.fn();
+    const transcriptReceived = createDeferred<string>();
+    const onTranscript = vi.fn(transcriptReceived.resolve);
     const session = buildDeepgramRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "dummy", baseUrl: server.baseUrl, endpointingMs: 1000 },
       onTranscript,
     });
 
-    await session.connect();
-    await vi.waitFor(() => expect(onTranscript).toHaveBeenCalledWith("hello"));
-    session.close();
+    try {
+      await session.connect();
+      await vi.waitFor(() => transcriptReceived.promise);
+      expect(onTranscript).toHaveBeenCalledWith("hello");
+    } finally {
+      session.close();
+    }
 
     expect(onTranscript).toHaveBeenCalledTimes(1);
   });
 
   it("does not promote a rejected provisional tail on an empty speech-final result", async () => {
+    const deliveryMarker = "rejected-tail frames delivered";
     const server = await createDeepgramRealtimeServer({
       onRequest: () => undefined,
       onConnection: (ws) => {
         sendResult(ws, { text: "delete everything" });
         sendResult(ws, { text: "", isFinal: true, speechFinal: true });
         ws.send(JSON.stringify({ type: "SpeechStarted" }));
+        // An error marker observes delivery without creating another speech turn.
+        ws.send(JSON.stringify({ type: "Error", message: deliveryMarker }));
       },
     });
     const onPartial = vi.fn();
     const onSpeechStart = vi.fn();
+    const framesDelivered = createDeferred<void>();
+    const onError = vi.fn((error: Error) => {
+      if (error.message === deliveryMarker) {
+        framesDelivered.resolve();
+      }
+    });
     const onTranscript = vi.fn();
     const session = buildDeepgramRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "dummy", baseUrl: server.baseUrl, endpointingMs: 1000 },
       onPartial,
+      onError,
       onSpeechStart,
       onTranscript,
     });
 
-    await session.connect();
-    await vi.waitFor(() => expect(onSpeechStart).toHaveBeenCalledTimes(2));
-    session.close();
+    try {
+      await session.connect();
+      await vi.waitFor(() => framesDelivered.promise);
+      expect(onError).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ message: deliveryMarker }),
+      );
+      expect(onSpeechStart).toHaveBeenCalledTimes(2);
+    } finally {
+      session.close();
+    }
 
     expect(onPartial).toHaveBeenCalledWith("delete everything");
     expect(onTranscript).not.toHaveBeenCalled();
   });
 
   it("preserves identical transcripts from consecutive utterances", async () => {
+    const deliveryMarker = "consecutive-utterance frames delivered";
     const server = await createDeepgramRealtimeServer({
       onRequest: () => undefined,
       onConnection: (ws) => {
         sendResult(ws, { text: "yes", isFinal: true, speechFinal: true });
         sendResult(ws, { text: "yes", isFinal: true, speechFinal: true });
+        ws.send(JSON.stringify({ type: "Error", message: deliveryMarker }));
       },
     });
     const onTranscript = vi.fn();
+    const framesDelivered = createDeferred<void>();
+    const onError = vi.fn((error: Error) => {
+      if (error.message === deliveryMarker) {
+        framesDelivered.resolve();
+      }
+    });
     const session = buildDeepgramRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "dummy", baseUrl: server.baseUrl, endpointingMs: 1000 },
       onTranscript,
+      onError,
     });
 
-    await session.connect();
-    await vi.waitFor(() => expect(onTranscript).toHaveBeenCalledTimes(2));
-    session.close();
+    try {
+      await session.connect();
+      await vi.waitFor(() => framesDelivered.promise);
+      expect(onError).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ message: deliveryMarker }),
+      );
+      expect(onTranscript).toHaveBeenCalledTimes(2);
+    } finally {
+      session.close();
+    }
 
     expect(onTranscript.mock.calls).toEqual([["yes"], ["yes"]]);
   });
@@ -287,17 +331,22 @@ describe("buildDeepgramRealtimeTranscriptionProvider", () => {
         });
       },
     });
-    const onTranscript = vi.fn();
+    const transcriptReceived = createDeferred<string>();
+    const onTranscript = vi.fn(transcriptReceived.resolve);
     const session = buildDeepgramRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "dummy", baseUrl: server.baseUrl, endpointingMs: 10_000 },
       onTranscript,
     });
 
-    await session.connect();
-    session.close();
-    await vi.waitFor(() => expect(onTranscript).toHaveBeenCalledWith("good bye"));
-
-    expect(onTranscript).toHaveBeenCalledTimes(1);
+    try {
+      await session.connect();
+      session.close();
+      await vi.waitFor(() => transcriptReceived.promise);
+      expect(onTranscript).toHaveBeenCalledWith("good bye");
+      expect(onTranscript).toHaveBeenCalledTimes(1);
+    } finally {
+      session.close();
+    }
   });
 
   it("flushes finalized text once when finalize produces no result", async () => {
@@ -314,7 +363,12 @@ describe("buildDeepgramRealtimeTranscriptionProvider", () => {
         });
       },
     });
-    const onPartial = vi.fn();
+    const partialReceived = createDeferred<void>();
+    const onPartial = vi.fn((text: string) => {
+      if (text === "good bye") {
+        partialReceived.resolve();
+      }
+    });
     const onTranscript = vi.fn();
     const session = buildDeepgramRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "dummy", baseUrl: server.baseUrl, endpointingMs: 10_000 },
@@ -322,16 +376,28 @@ describe("buildDeepgramRealtimeTranscriptionProvider", () => {
       onTranscript,
     });
 
-    await session.connect();
-    await vi.waitFor(() => expect(onPartial).toHaveBeenCalledWith("good bye"));
-    vi.useFakeTimers();
-    session.close();
-    session.close();
-    await vi.advanceTimersByTimeAsync(5_000);
+    try {
+      await session.connect();
+      await vi.waitFor(() => partialReceived.promise);
+      expect(onPartial).toHaveBeenCalledWith("good bye");
+      vi.useFakeTimers();
+      session.close();
+      session.close();
+      await vi.advanceTimersByTimeAsync(5_000);
 
-    expect(finalizeRequests).toBe(1);
-    expect(onTranscript).toHaveBeenCalledTimes(1);
-    expect(onTranscript).toHaveBeenCalledWith("good");
+      expect(finalizeRequests).toBe(1);
+      expect(onTranscript).toHaveBeenCalledTimes(1);
+      expect(onTranscript).toHaveBeenCalledWith("good");
+    } finally {
+      if (vi.isFakeTimers()) {
+        session.close();
+      } else {
+        // A failed observation can leave finalized text; close must own its fallback clock.
+        vi.useFakeTimers();
+        session.close();
+        await vi.advanceTimersByTimeAsync(5_000).catch(() => undefined);
+      }
+    }
   });
 
   it("does not commit a turn on an utterance-end gap before speech-final", async () => {
@@ -343,15 +409,20 @@ describe("buildDeepgramRealtimeTranscriptionProvider", () => {
         sendResult(ws, { text: "speaking", isFinal: true, speechFinal: true });
       },
     });
-    const onTranscript = vi.fn();
+    const transcriptReceived = createDeferred<string>();
+    const onTranscript = vi.fn(transcriptReceived.resolve);
     const session = buildDeepgramRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "dummy", baseUrl: server.baseUrl, endpointingMs: 25 },
       onTranscript,
     });
 
-    await session.connect();
-    await vi.waitFor(() => expect(onTranscript).toHaveBeenCalledWith("still speaking"));
-    session.close();
+    try {
+      await session.connect();
+      await vi.waitFor(() => transcriptReceived.promise);
+      expect(onTranscript).toHaveBeenCalledWith("still speaking");
+    } finally {
+      session.close();
+    }
 
     expect(onTranscript).toHaveBeenCalledTimes(1);
   });
@@ -457,20 +528,24 @@ describe("buildDeepgramRealtimeTranscriptionProvider", () => {
         sendResult(ws, { text: "y" });
       },
     });
-    const onError = vi.fn();
+    const errorReceived = createDeferred<Error>();
+    const onError = vi.fn(errorReceived.resolve);
     const session = buildDeepgramRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "dummy", baseUrl: server.baseUrl, endpointingMs: 1000 },
       onError,
     });
 
-    await session.connect();
-    await vi.waitFor(() =>
+    try {
+      await session.connect();
+      await vi.waitFor(() => errorReceived.promise);
       expect(onError).toHaveBeenCalledWith(
         expect.objectContaining({
           message: expect.stringContaining("retained transcript exceeded"),
         }),
-      ),
-    );
-    session.close();
+      );
+      expect(session.isConnected()).toBe(false);
+    } finally {
+      session.close();
+    }
   });
 });


### PR DESCRIPTION
## What problem does this PR solve?

Deepgram's local WebSocket tests poll mock call counts after frames have already arrived. Two count-based waits can also complete before the final fixture frame is processed.

## Why this approach?

Resolve bounded completion promises from the existing provider callbacks. The two multi-frame negative/count cases wait for a distinct final error marker on the same ordered WebSocket before asserting the complete callback history. Keep the existing fake-clock deadline tests and production timeouts unchanged.

Each changed session owns close in finally. If the no-result finalization case fails before installing its clock, cleanup installs the clock before close and drains the existing five-second fallback window. The overflow case now checks disconnection before test cleanup.

## User impact

Test-only change: production +0/-0; tests +116/-41. Eight positive polling observations become callback-backed waits; all 18 Deepgram cases and their existing semantic assertions remain. Local sockets and the real provider/session owners remain in use.

## Evidence

All 69 selected Deepgram, ElevenLabs and shared WebSocket tests pass before and after. Full changed-file checks and Codex autoreview pass.

A deliberate missing completion signal produced exactly the original one-second waitFor failure. Before real server teardown, cleanup had drained both timers, emitted one Finalize request and the retained transcript once, and marked the session disconnected. Real server teardown completed, Vitest reported no unhandled errors, and the joined probe restored exact source bytes. This is local transport and failure-cleanup proof, not a live provider result or an elapsed-time benchmark.

`node scripts/run-vitest.mjs extensions/deepgram/realtime-transcription-provider.test.ts extensions/elevenlabs/realtime-transcription-provider.test.ts src/realtime-transcription/websocket-session.test.ts`
