### PR TITLE
test(elevenlabs): observe realtime transcription completion

### DIFF
--- a/extensions/elevenlabs/realtime-transcription-provider.test.ts
+++ b/extensions/elevenlabs/realtime-transcription-provider.test.ts
@@ -2,6 +2,7 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type WebSocket from "ws";
 import { WebSocketServer } from "ws";
@@ -198,17 +199,20 @@ describe("buildElevenLabsRealtimeTranscriptionProvider", () => {
     const baseUrl = await createRealtimeServer(() => undefined, {
       events: [{ message_type: messageType, error: message }],
     });
-    const onError = vi.fn();
+    const errorReceived = createDeferred<Error>();
+    const onError = vi.fn(errorReceived.resolve);
     const session = buildElevenLabsRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "fixture-value", baseUrl },
       onError,
     });
 
-    await session.connect();
-    await vi.waitFor(() => {
+    try {
+      await session.connect();
+      await vi.waitFor(() => errorReceived.promise);
       expect(onError).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ message }));
-    });
-    session.close();
+    } finally {
+      session.close();
+    }
   });
 
   it("rejects pre-ready provider errors with their original actionable detail", async () => {
@@ -232,17 +236,20 @@ describe("buildElevenLabsRealtimeTranscriptionProvider", () => {
     const baseUrl = await createRealtimeServer(() => undefined, {
       events: [{ message_type: "input_error", message }],
     });
-    const onError = vi.fn();
+    const errorReceived = createDeferred<Error>();
+    const onError = vi.fn(errorReceived.resolve);
     const session = buildElevenLabsRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "fixture-value", baseUrl },
       onError,
     });
 
-    await session.connect();
-    await vi.waitFor(() => {
+    try {
+      await session.connect();
+      await vi.waitFor(() => errorReceived.promise);
       expect(onError).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ message }));
-    });
-    session.close();
+    } finally {
+      session.close();
+    }
   });
 
   it("keeps ordinary partial and committed transcripts outside error dispatch", async () => {
@@ -254,7 +261,8 @@ describe("buildElevenLabsRealtimeTranscriptionProvider", () => {
     });
     const onError = vi.fn();
     const onPartial = vi.fn();
-    const onTranscript = vi.fn();
+    const transcriptReceived = createDeferred<string>();
+    const onTranscript = vi.fn(transcriptReceived.resolve);
     const session = buildElevenLabsRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "fixture-value", baseUrl },
       onError,
@@ -262,13 +270,15 @@ describe("buildElevenLabsRealtimeTranscriptionProvider", () => {
       onTranscript,
     });
 
-    await session.connect();
-    await vi.waitFor(() => {
+    try {
+      await session.connect();
+      await vi.waitFor(() => transcriptReceived.promise);
       expect(onPartial).toHaveBeenCalledExactlyOnceWith("hello");
       expect(onTranscript).toHaveBeenCalledExactlyOnceWith("hello there");
-    });
-    expect(onError).not.toHaveBeenCalled();
-    session.close();
+      expect(onError).not.toHaveBeenCalled();
+    } finally {
+      session.close();
+    }
   });
 
   it.each([
@@ -357,7 +367,12 @@ describe("buildElevenLabsRealtimeTranscriptionProvider", () => {
       events: [...events, { message_type: "partial_transcript", text: deliveryMarker }],
     });
     const onError = vi.fn();
-    const onPartial = vi.fn();
+    const framesDelivered = createDeferred<void>();
+    const onPartial = vi.fn((text: string) => {
+      if (text === deliveryMarker) {
+        framesDelivered.resolve();
+      }
+    });
     const onSpeechStart = vi.fn();
     const onTranscript = vi.fn();
     const session = buildElevenLabsRealtimeTranscriptionProvider().createSession({
@@ -368,12 +383,16 @@ describe("buildElevenLabsRealtimeTranscriptionProvider", () => {
       onTranscript,
     });
 
-    await session.connect();
-    await vi.waitFor(() => expect(onPartial).toHaveBeenCalledWith(deliveryMarker));
-    expect(onTranscript.mock.calls.map(([text]) => text)).toEqual(transcripts);
-    expect(onError).not.toHaveBeenCalled();
-    expect(onSpeechStart).not.toHaveBeenCalled();
-    session.close();
+    try {
+      await session.connect();
+      await vi.waitFor(() => framesDelivered.promise);
+      expect(onPartial).toHaveBeenCalledWith(deliveryMarker);
+      expect(onTranscript.mock.calls.map(([text]) => text)).toEqual(transcripts);
+      expect(onError).not.toHaveBeenCalled();
+      expect(onSpeechStart).not.toHaveBeenCalled();
+    } finally {
+      session.close();
+    }
   });
 
   it("does not suppress a timestamp-only transcript from a replacement session", async () => {
@@ -391,7 +410,15 @@ describe("buildElevenLabsRealtimeTranscriptionProvider", () => {
         ],
       ],
     });
-    const onPartial = vi.fn();
+    const firstSessionDelivered = createDeferred<void>();
+    const replacementSessionDelivered = createDeferred<void>();
+    const onPartial = vi.fn((text: string) => {
+      if (text === firstMarker) {
+        firstSessionDelivered.resolve();
+      } else if (text === secondMarker) {
+        replacementSessionDelivered.resolve();
+      }
+    });
     const onTranscript = vi.fn();
     const session = buildElevenLabsRealtimeTranscriptionProvider().createSession({
       providerConfig: { apiKey: "fixture-value", baseUrl },
@@ -399,14 +426,19 @@ describe("buildElevenLabsRealtimeTranscriptionProvider", () => {
       onTranscript,
     });
 
-    await session.connect();
-    await vi.waitFor(() => expect(onPartial).toHaveBeenCalledWith(firstMarker));
-    expect(onTranscript).toHaveBeenCalledExactlyOnceWith("yes");
+    try {
+      await session.connect();
+      await vi.waitFor(() => firstSessionDelivered.promise);
+      expect(onPartial).toHaveBeenCalledWith(firstMarker);
+      expect(onTranscript).toHaveBeenCalledExactlyOnceWith("yes");
 
-    await session.connect();
-    await vi.waitFor(() => expect(onPartial).toHaveBeenCalledWith(secondMarker));
-    expect(onTranscript.mock.calls).toEqual([["yes"], ["yes"]]);
-    session.close();
+      await session.connect();
+      await vi.waitFor(() => replacementSessionDelivered.promise);
+      expect(onPartial).toHaveBeenCalledWith(secondMarker);
+      expect(onTranscript.mock.calls).toEqual([["yes"], ["yes"]]);
+    } finally {
+      session.close();
+    }
   });
 
   it("rejects whitespace-only environment keys before session creation", () => {


### PR DESCRIPTION
## What problem does this PR solve?

ElevenLabs realtime transcription tests wait for polling intervals even when the provider has already delivered the expected event.

## Why this approach?

Resolve the existing bounded waits directly from the real provider callbacks. Keep the existing final-frame markers for ordered transcript histories and separate markers for both connection generations. Each changed case closes its session in finally, including assertion and connection failures.

## User impact

Test-only change: production +0/-0; tests +63/-31. All 22 provider cases remain. Seventeen positive observation waits across 16 cases now follow callback completion, preserving the error taxonomy, transcript contents/order, duplicate suppression and reconnect coverage. Production timers and local WebSocket transport remain unchanged.

## Evidence

The baseline transcription selection included all 22 ElevenLabs and 29 shared WebSocket cases; all 51 pass again after the change. Full changed-file checks and Codex autoreview pass. The shared selection retains real reconnect, close, payload-limit and error-dispatch checks. This is local socket proof; no live provider result or elapsed-time estimate is claimed.

`node scripts/run-vitest.mjs extensions/elevenlabs/realtime-transcription-provider.test.ts src/realtime-transcription/websocket-session.test.ts`
