### PR TITLE
refactor: simplify terminal regression fixtures

### DIFF
--- a/packages/terminal-core/src/stream-writer.test.ts
+++ b/packages/terminal-core/src/stream-writer.test.ts
@@ -1,47 +1,37 @@
-// Terminal Core tests cover stream writer behavior.
 import { describe, expect, it } from "vitest";
 import { createSafeStreamWriter } from "./stream-writer.js";
 
-function createSpy<Args extends unknown[], ReturnValue>(
-  implementation?: (...args: Args) => ReturnValue,
-) {
-  const calls: Args[] = [];
-  const spy = (...args: Args) => {
-    calls.push(args);
-    return implementation?.(...args) as ReturnValue;
-  };
-  spy.calls = calls;
-  spy.clear = () => {
-    calls.length = 0;
-  };
-  return spy;
-}
-
 describe("createSafeStreamWriter", () => {
   it("signals broken pipes and closes the writer", () => {
-    const onBrokenPipe = createSpy<[], void>();
-    const writer = createSafeStreamWriter({ onBrokenPipe });
+    let brokenPipeCount = 0;
+    const writer = createSafeStreamWriter({
+      onBrokenPipe: () => {
+        brokenPipeCount += 1;
+      },
+    });
     const stream = {
-      write: createSpy<[string], boolean>(() => {
+      write: () => {
         const err = new Error("EPIPE") as NodeJS.ErrnoException;
         err.code = "EPIPE";
         throw err;
-      }),
+      },
     } as unknown as NodeJS.WriteStream;
 
     expect(writer.writeLine(stream, "hello")).toBe(false);
     expect(writer.isClosed()).toBe(true);
-    expect(onBrokenPipe.calls).toHaveLength(1);
+    expect(brokenPipeCount).toBe(1);
 
-    onBrokenPipe.clear();
+    brokenPipeCount = 0;
     expect(writer.writeLine(stream, "again")).toBe(false);
-    expect(onBrokenPipe.calls).toHaveLength(0);
+    expect(brokenPipeCount).toBe(0);
   });
 
   it("treats broken pipes from beforeWrite as closed", () => {
-    const onBrokenPipe = createSpy<[], void>();
+    let brokenPipeCount = 0;
     const writer = createSafeStreamWriter({
-      onBrokenPipe,
+      onBrokenPipe: () => {
+        brokenPipeCount += 1;
+      },
       beforeWrite: () => {
         const err = new Error("EIO") as NodeJS.ErrnoException;
         err.code = "EIO";
@@ -49,11 +39,11 @@ describe("createSafeStreamWriter", () => {
       },
     });
     const stream = {
-      write: createSpy<[string], boolean>(() => true),
+      write: () => true,
     } as unknown as NodeJS.WriteStream;
 
     expect(writer.write(stream, "hi")).toBe(false);
     expect(writer.isClosed()).toBe(true);
-    expect(onBrokenPipe.calls).toHaveLength(1);
+    expect(brokenPipeCount).toBe(1);
   });
 });

--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -1,4 +1,3 @@
-// Terminal Core tests cover table behavior.
 import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -87,7 +86,7 @@ describe("renderTable", () => {
     expect(segment).not.toHaveBeenCalled();
   });
 
-  it.each([0, 3, 150_000])("renders all %i rows without an argument-count limit", (count) => {
+  it.each([0, 3])("renders all %i rows without an argument-count limit", (count) => {
     const out = renderTable({
       border: "ascii",
       columns: [{ key: "Key", header: "Key" }],
@@ -117,14 +116,25 @@ const output = renderTable({
   columns: [{ key: "Key", header: "Key" }],
   rows: Array.from({ length: 150_000 }, () => ({ Key: "session" })),
 });
-console.log(JSON.stringify({ rows: output.split("\\n").filter(line => line === "| session |").length }));`,
+const lines = output.trimEnd().split("\\n");
+console.log(JSON.stringify({
+  lineCount: lines.length,
+  rows: lines.filter(line => line === "| session |").length,
+  header: lines[1],
+  firstLine: lines[0],
+  lastLine: lines.at(-1),
+}));`,
       ],
       { encoding: "utf8", timeout: 30_000 },
     );
 
     expect(result.error).toBeUndefined();
     expect(result.status, result.stderr).toBe(0);
-    expect(JSON.parse(result.stdout)).toEqual({ rows: 150_000 });
+    const rendered = JSON.parse(result.stdout);
+    expect(rendered.lineCount).toBe(150_004);
+    expect(rendered.rows).toBe(150_000);
+    expect(rendered.header).toMatch(/^\| Key +\|$/u);
+    expect(rendered.lastLine).toBe(rendered.firstLine);
   });
 
   it("prefers shrinking flex columns to avoid wrapping non-flex labels", () => {


### PR DESCRIPTION
## What Problem This Solves

Terminal-core renders the same 150,000-row table twice: once in the Vitest worker and again in a native Node subprocess. Its stream-writer tests also carry a generic call-tracking helper even though they only observe notification counts.

## Why This Change Was Made

Keep the subprocess regression for the native stack limit and move the worker case's line-count, row-count, header and border assertions into it. Keep the zero-row and three-row worker cases. The subprocess still uses the same Node executable, preload, inputs and 30-second deadline, and returns only five scalar observations.

Replace the custom spy with test-local counters and ordinary write functions. Both stream-writer cases and all eight assertions remain, including clearing only the observed notification count before writing to the same closed writer again. Plain counters also preserve this file's existing unit-fast project; importing the framework mock API would change its routing and setup.

## User Impact

No production changes. Test changes are +31/-31 lines across two files: one generic helper and one duplicate large-row case removed, with the large-row assertions retained in the stronger existing subprocess check.

## Evidence

The unchanged baseline passes all 70 cases. The final candidate passes 69, and a complete comparison confirms identical remaining project names, case names and execution order: two stream-writer cases in unit-fast, followed by 67 table cases in unit-fast-isolated. There is no routing override, concurrency change or weaker assertion.

A temporary historical-fault control restores the original Math.max spread implementation. The retained subprocess case fails with RangeError: Maximum call stack size exceeded; the production owner was restored afterward. This directly checks that removing the duplicate worker case preserves detection of the original failure.

All 19 changed-file checks pass, including package test types, lint, boundaries and dead exports. Managed Codex review is scoped-clean at the configured P0 threshold, supplemented by direct owner, caller, classifier, configuration and dependency inspection. No performance improvement or live-provider behavior is claimed.
