### PR TITLE
fix(install): keep dry runs from downloading gum

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3722,11 +3722,15 @@ main() {
         return 0
     fi
 
-    # bootstrap_gum_temp may perform network downloads before any spinner is available.
-    echo -e "${INFO}Preparing installer interface...${NC}"
-    bootstrap_gum_temp || true
+    # A dry run must stay side-effect free; gum bootstrap may download binaries.
+    if [[ "$DRY_RUN" != "1" ]]; then
+        echo -e "${INFO}Preparing installer interface...${NC}"
+        bootstrap_gum_temp || true
+    fi
     print_installer_banner
-    print_gum_status
+    if [[ "$DRY_RUN" != "1" ]]; then
+        print_gum_status
+    fi
     detect_os_or_die
 
     if [[ "$OS" == "linux" ]]; then

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -1932,6 +1932,25 @@ EOF
     expect(result.stdout).not.toContain("Upgrade complete");
   });
 
+  it("keeps dry runs from downloading the optional gum interface", () => {
+    const result = runInstallShell(`
+      source "${SCRIPT_PATH}"
+      DRY_RUN=1; INSTALL_METHOD=npm; NO_ONBOARD=1; NO_PROMPT=1
+      bootstrap_gum_temp() { printf 'unexpected-gum-bootstrap\n'; return 1; }
+      print_installer_banner() { :; }
+      print_gum_status() { printf 'unexpected-gum-status\n'; }
+      detect_os_or_die() { OS=linux; }
+      detect_openclaw_checkout() { return 1; }
+      show_install_plan() { printf 'dry-run-plan\n'; }
+      main
+    `);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("dry-run-plan");
+    expect(result.stdout).toContain("Dry run complete (no changes made)");
+    expect(result.stdout).not.toContain("unexpected-gum");
+  });
+
   it.each([
     {
       name: "fresh retained config rejects failed Doctor before success",

--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -1932,23 +1932,27 @@ EOF
     expect(result.stdout).not.toContain("Upgrade complete");
   });
 
-  it("keeps dry runs from downloading the optional gum interface", () => {
-    const result = runInstallShell(`
-      source "${SCRIPT_PATH}"
-      DRY_RUN=1; INSTALL_METHOD=npm; NO_ONBOARD=1; NO_PROMPT=1
-      bootstrap_gum_temp() { printf 'unexpected-gum-bootstrap\n'; return 1; }
-      print_installer_banner() { :; }
-      print_gum_status() { printf 'unexpected-gum-status\n'; }
-      detect_os_or_die() { OS=linux; }
-      detect_openclaw_checkout() { return 1; }
-      show_install_plan() { printf 'dry-run-plan\n'; }
-      main
-    `);
-
-    expect(result.status, result.stderr).toBe(0);
-    expect(result.stdout).toContain("dry-run-plan");
-    expect(result.stdout).toContain("Dry run complete (no changes made)");
-    expect(result.stdout).not.toContain("unexpected-gum");
+  it.each([
+    { name: "flag", args: "--dry-run", dryRunEnv: "0", dryRun: true },
+    { name: "environment", args: "", dryRunEnv: "1", dryRun: true },
+    { name: "normal install", args: "", dryRunEnv: "0", dryRun: false },
+  ])("keeps Gum initialization consistent with $name", ({ args, dryRunEnv, dryRun }) => {
+    const result = runInstallShell(
+      [
+        `source ${JSON.stringify(SCRIPT_PATH)}`,
+        "bootstrap_gum_temp() { printf 'gum-bootstrap\\n'; }",
+        "print_gum_status() { printf 'gum-status\\n'; }",
+        "check_existing_openclaw() { exit 73; }",
+        `parse_args --npm --no-onboard ${args}`,
+        "main",
+      ].join("\n"),
+      { OPENCLAW_DRY_RUN: dryRunEnv },
+    );
+    expect(result.status, result.stdout + result.stderr).toBe(dryRun ? 0 : 73);
+    expect(result.stdout).toContain("Install plan");
+    expect(result.stdout.includes("Dry run complete (no changes made)")).toBe(dryRun);
+    expect(result.stdout.includes("gum-bootstrap")).toBe(!dryRun);
+    expect(result.stdout.includes("gum-status")).toBe(!dryRun);
   });
 
   it.each([
@@ -3530,9 +3534,10 @@ EOF
       expect(warning.status).toBe(0);
       expect(warning.stdout).toContain(`PATH updated in ${fishRc}`);
       expect(warning.stdout).not.toContain("PATH missing user-local bin dir");
-      const fishVersion = spawnSync("fish", ["--version"], { encoding: "utf8" });
-      if (fishVersion.status === 0) {
-        const fresh = spawnSync("fish", ["-lc", "command -v openclaw"], {
+      // Resolve the executable before restricting the child shell's PATH.
+      const fishPath = runInstallShell("command -v fish");
+      if (fishPath.status === 0) {
+        const fresh = spawnSync(fishPath.stdout.trim(), ["-lc", "command -v openclaw"], {
           encoding: "utf8",
           env: { HOME: home, PATH: "/usr/bin:/bin" },
         });


### PR DESCRIPTION
Related: #133869

## What Problem This Solves

An interactive `install.sh --dry-run` could initialize optional Gum UI tooling before reaching its no-change return. When Gum was missing, the preview could create temporary files and attempt a download.

## Why This Change Was Made

Skip Gum bootstrap and status reporting at the main-flow call boundary during dry-run. Keep the plain banner, platform detection, install plan, and successful early return. Normal installation keeps the same optional UI sequence. The two guards add four production lines because the banner must remain between bootstrap and status reporting.

## User Impact

Both `--dry-run` and `OPENCLAW_DRY_RUN=1` display the installation plan without downloading optional UI tooling.

## Evidence

A maintainer-authored equivalent was exercised from trusted main in a **real macOS PTY** with the actual installer main flow and Gum bootstrap. An isolated downloader executable recorded its invocation and returned failure, so no external network request occurred. HOME and temporary state were synthetic.

| Flow | Download attempts | Temporary-directory creations | Observed outcome |
| --- | ---: | ---: | --- |
| Original dry-run | 1 | 1 | Plan and dry-run completion printed |
| Repaired dry-run | 0 | 0 | Plan and dry-run completion printed |
| Repaired normal-flow control | 1 | 1 | Optional bootstrap still runs; harness stops before package work |

HOME remained empty in all cases. This proves dispatch prevention at the real terminal boundary; it does not claim a Gum binary was downloaded or executed. The regression table covers both dry-run inputs and the normal-flow control. Contributor-supplied Windows Git Bash evidence separately covers the main-flow sentinels.

The canonical regression table fails both dry-run cases on the original owner while its normal-flow control passes. The final whole installer suite passed **182/182** cases with Node26.8.1/Vitest4.1.11. Fresh full-candidate Codex review found no actionable P0 findings. Production is+8/−4; tests are+27/−3.

A small existing Fish smoke-test repair is intentionally shared with #134236: resolve the executable before restricting child PATH, while preserving the exact expected command-path assertion. No npm-specific tests or fixture changes are included here. This shared fixture correction is identical in both PRs; an actual merge conflict can absorb it from main.

Final candidate: `0c8ea467a8f40be956bac8633653abe3e2db05eb`. Exact-head hosted CI is green: 173 successful checks, 32 skipped, one neutral, no pending or failed checks. The shared local dependency graph could not complete the broad root-test typecheck because of diagnostics in untouched Telegram, logging, and compression declarations; this gate is not claimed as passing.
