### PR TITLE
fix(plugins): preserve npm plugin files after uninstall

### DIFF
--- a/scripts/e2e/lib/plugins/assertions.mjs
+++ b/scripts/e2e/lib/plugins/assertions.mjs
@@ -746,6 +746,23 @@ function assertNpmPluginRemoved() {
   }
 }
 
+function assertNpmPluginRetained() {
+  const installPath = fs.readFileSync(scratchFile("plugins-npm-install-path.txt"), "utf8").trim();
+  const dependencyPackagePath = fs
+    .readFileSync(scratchFile("plugins-npm-dependency-path.txt"), "utf8")
+    .trim();
+  assertPluginRemoved({
+    pluginId: "demo-plugin-npm",
+    listFile: scratchFile("plugins-npm-retained.json"),
+  });
+  if (!fs.existsSync(installPath)) {
+    throw new Error(`npm managed package was deleted by --keep-files: ${installPath}`);
+  }
+  if (!fs.existsSync(dependencyPackagePath)) {
+    throw new Error(`npm managed dependency was deleted by --keep-files: ${dependencyPackagePath}`);
+  }
+}
+
 function assertInvalidOpenClawExtensionsRejected() {
   const pluginId = "demo-plugin-invalid-metadata";
   for (const expected of ["openclaw.extensions[1]", "non-empty string"]) {
@@ -1026,6 +1043,7 @@ const commands = {
   "plugin-file-removed": assertPluginFileRemoved,
   "plugin-npm": assertNpmPlugin,
   "plugin-npm-update": assertNpmPluginUpdateUnchanged,
+  "plugin-npm-retained": assertNpmPluginRetained,
   "plugin-npm-removed": assertNpmPluginRemoved,
   "invalid-openclaw-extensions": assertInvalidOpenClawExtensionsRejected,
   "bundle-disabled": assertClaudeBundleDisabled,

--- a/scripts/e2e/lib/plugins/sweep.sh
+++ b/scripts/e2e/lib/plugins/sweep.sh
@@ -149,6 +149,16 @@ node scripts/e2e/lib/plugins/assertions.mjs plugin-npm
 openclaw_e2e_maybe_timeout "$OPENCLAW_PLUGINS_CLI_TIMEOUT" node "$OPENCLAW_ENTRY" plugins update demo-plugin-npm >"$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-update.log" 2>&1
 node scripts/e2e/lib/plugins/assertions.mjs plugin-npm-update
 
+run_plugins_openclaw_logged uninstall-npm-retained plugins uninstall demo-plugin-npm --force --keep-files
+run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-retained.json" plugins list --json
+node scripts/e2e/lib/plugins/assertions.mjs plugin-npm-retained
+
+run_plugins_openclaw_logged reinstall-npm plugins install "npm:@openclaw/demo-plugin-npm@0.0.1" --force
+run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm.json" plugins list --json
+run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-inspect.json" plugins inspect demo-plugin-npm --runtime --json
+run_plugins_shell_logged exec-reinstalled-npm-plugin-cli 'node "$OPENCLAW_ENTRY" demo-npm ping >"$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-cli.txt"'
+node scripts/e2e/lib/plugins/assertions.mjs plugin-npm
+
 run_plugins_openclaw_logged uninstall-npm plugins uninstall demo-plugin-npm --force
 run_plugins_openclaw_capture "$OPENCLAW_PLUGINS_TMP_DIR/plugins-npm-uninstalled.json" plugins list --json
 node scripts/e2e/lib/plugins/assertions.mjs plugin-npm-removed

--- a/src/cli/plugins-cli.uninstall.test.ts
+++ b/src/cli/plugins-cli.uninstall.test.ts
@@ -29,16 +29,16 @@ function expectRuntimeLogIncludes(fragment: string) {
   expect(runtimeLogs.join("\n")).toContain(fragment);
 }
 
-function expectLatestUninstallPlanParams(expected: {
+function expectInitialUninstallPlanParams(expected: {
   pluginId: string;
   deleteFiles: boolean;
   channelIds?: unknown;
 }) {
-  const params = planPluginUninstall.mock.calls[planPluginUninstall.mock.calls.length - 1]?.[0] as
+  const params = planPluginUninstall.mock.calls[0]?.[0] as
     | { pluginId?: string; deleteFiles?: boolean; channelIds?: unknown }
     | undefined;
   if (params === undefined) {
-    throw new Error("expected latest plugin uninstall plan params");
+    throw new Error("expected initial plugin uninstall plan params");
   }
   expect(params.pluginId).toBe(expected.pluginId);
   expect(params.deleteFiles).toBe(expected.deleteFiles);
@@ -178,7 +178,7 @@ describe("plugins cli uninstall", () => {
     await runPluginsCommand(["plugins", "uninstall", "alpha", "--force", "--keep-files"]);
 
     expect(promptYesNo).not.toHaveBeenCalled();
-    expectLatestUninstallPlanParams({ pluginId: "alpha", deleteFiles: false });
+    expectInitialUninstallPlanParams({ pluginId: "alpha", deleteFiles: false });
     expect(writePersistedInstalledPluginIndexInstallRecords).toHaveBeenCalledWith({});
     expect(writeConfigFile).toHaveBeenCalledWith({
       plugins: {
@@ -409,7 +409,7 @@ describe("plugins cli uninstall", () => {
 
     await runPluginsCommand(["plugins", "uninstall", "alpha", "--force"]);
 
-    expectLatestUninstallPlanParams({ pluginId: "alpha", deleteFiles: true });
+    expectInitialUninstallPlanParams({ pluginId: "alpha", deleteFiles: true });
     expect(writeConfigFile).toHaveBeenCalledWith(nextConfig);
     expect(runtimeLogs.at(-2)).toContain('Uninstalled plugin "alpha"');
   });
@@ -448,7 +448,7 @@ describe("plugins cli uninstall", () => {
 
     await runPluginsCommand(["plugins", "uninstall", "alpha", "--force"]);
 
-    expectLatestUninstallPlanParams({ pluginId: "alpha", deleteFiles: true });
+    expectInitialUninstallPlanParams({ pluginId: "alpha", deleteFiles: true });
     expect(writeConfigFile).toHaveBeenCalledWith(nextConfig);
     expect(refreshPluginRegistry).toHaveBeenCalledWith({
       config: nextConfig,
@@ -516,7 +516,7 @@ describe("plugins cli uninstall", () => {
 
     await runPluginsCommand(["plugins", "uninstall", "alpha", "--force", "--keep-files"]);
 
-    expectLatestUninstallPlanParams({
+    expectInitialUninstallPlanParams({
       pluginId: "alpha",
       channelIds: undefined,
       deleteFiles: false,

--- a/src/cli/plugins-install-record-commit.test.ts
+++ b/src/cli/plugins-install-record-commit.test.ts
@@ -8,6 +8,7 @@ import type { PluginInstallRecord } from "../config/types.plugins.js";
 import {
   hasRetainedManagedNpmInstallMarker,
   markRetainedManagedNpmInstall,
+  RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
 } from "../plugins/managed-npm-retention.js";
 import { withEnvAsync } from "../test-utils/env.js";
 
@@ -232,6 +233,114 @@ describe("commitConfigWithPendingPluginInstalls", () => {
       });
 
       expect(hasRetainedManagedNpmInstallMarker(previousInstallPath)).toBe(true);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not retain a normally removed managed npm install", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-record-commit-"));
+    const installPath = path.join(
+      stateDir,
+      "npm",
+      "projects",
+      "kept-plugin-v1",
+      "node_modules",
+      "@openclaw",
+      "kept-plugin",
+    );
+    fs.mkdirSync(installPath, { recursive: true });
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        await commitPluginInstallRecordsWithConfig({
+          previousInstallRecords: {
+            "kept-plugin": {
+              source: "npm",
+              spec: "@openclaw/kept-plugin@1.0.0",
+              installPath,
+            },
+          },
+          nextInstallRecords: {},
+          nextConfig: {},
+        });
+      });
+
+      expect(hasRetainedManagedNpmInstallMarker(installPath)).toBe(false);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("marks a keep-files managed npm uninstall so recovery cannot restore it", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-record-commit-"));
+    const installPath = path.join(
+      stateDir,
+      "npm",
+      "projects",
+      "kept-plugin-v1",
+      "node_modules",
+      "@openclaw",
+      "kept-plugin",
+    );
+    fs.mkdirSync(installPath, { recursive: true });
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        await commitPluginInstallRecordsWithConfig({
+          previousInstallRecords: {
+            "kept-plugin": {
+              source: "npm",
+              spec: "@openclaw/kept-plugin@1.0.0",
+              installPath,
+            },
+          },
+          nextInstallRecords: {},
+          retainRemovedNpmInstallRecord: "kept-plugin",
+          nextConfig: {},
+        });
+      });
+
+      expect(hasRetainedManagedNpmInstallMarker(installPath)).toBe(true);
+      expect(fs.existsSync(installPath)).toBe(true);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("removes a keep-files marker when the install-record commit rolls back", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-record-commit-"));
+    const installPath = path.join(
+      stateDir,
+      "npm",
+      "projects",
+      "kept-plugin-v1",
+      "node_modules",
+      "@openclaw",
+      "kept-plugin",
+    );
+    fs.mkdirSync(installPath, { recursive: true });
+    mocks.replaceConfigFile.mockRejectedValueOnce(new Error("config changed"));
+
+    try {
+      await withEnvAsync({ OPENCLAW_STATE_DIR: stateDir }, async () => {
+        await expect(
+          commitPluginInstallRecordsWithConfig({
+            previousInstallRecords: {
+              "kept-plugin": {
+                source: "npm",
+                spec: "@openclaw/kept-plugin@1.0.0",
+                installPath,
+              },
+            },
+            nextInstallRecords: {},
+            retainRemovedNpmInstallRecord: "kept-plugin",
+            nextConfig: {},
+          }),
+        ).rejects.toThrow("config changed");
+      });
+
+      expect(hasRetainedManagedNpmInstallMarker(installPath)).toBe(false);
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }
@@ -495,7 +604,7 @@ describe("commitConfigWithPendingPluginInstalls", () => {
       packageDir: installPath,
       pluginId: "codex",
       retainedAt: "2026-04-25T00:00:00.000Z",
-      reason: "test-retained-generation",
+      reason: RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
     });
 
     try {

--- a/src/cli/plugins-install-record-commit.ts
+++ b/src/cli/plugins-install-record-commit.ts
@@ -24,6 +24,7 @@ import {
 import {
   clearRetainedManagedNpmInstallMarker,
   markRetainedManagedNpmInstall,
+  RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
   resolveRetainedManagedNpmInstallPackageInfo,
   resolveRetainedManagedNpmInstallMarkerPath,
 } from "../plugins/managed-npm-retention.js";
@@ -114,15 +115,19 @@ function resolveRetainedManagedNpmInstallMarkerTarget(params: {
   previousRecord?: PluginInstallRecord;
   nextRecord?: PluginInstallRecord;
 }): string | null {
-  if (params.previousRecord?.source !== "npm" || params.nextRecord?.source !== "npm") {
+  if (params.previousRecord?.source !== "npm") {
     return null;
   }
   const previousInstallPath = params.previousRecord.installPath?.trim();
-  const nextInstallPath = params.nextRecord.installPath?.trim();
-  if (!previousInstallPath || !nextInstallPath) {
+  const nextInstallPath = params.nextRecord?.installPath?.trim();
+  if (!previousInstallPath || (params.nextRecord && params.nextRecord.source !== "npm")) {
     return null;
   }
-  if (installPathsOverlap(previousInstallPath, nextInstallPath)) {
+  if (
+    params.nextRecord &&
+    nextInstallPath &&
+    installPathsOverlap(previousInstallPath, nextInstallPath)
+  ) {
     return null;
   }
 
@@ -145,7 +150,7 @@ function resolveRetainedManagedNpmInstallMarkerTarget(params: {
   ) {
     return null;
   }
-  if (installPathsOverlap(plan.directoryRemoval.target, nextInstallPath)) {
+  if (nextInstallPath && installPathsOverlap(plan.directoryRemoval.target, nextInstallPath)) {
     return null;
   }
   return plan.directoryRemoval.target;
@@ -174,17 +179,21 @@ function findReplacementNpmRecordForRemovedRecord(params: {
   return null;
 }
 
-async function markRetainedReplacedManagedNpmInstallRecords(params: {
+async function markRetiredManagedNpmInstallRecords(params: {
   previousInstallRecords: Record<string, PluginInstallRecord>;
   nextInstallRecords: Record<string, PluginInstallRecord>;
+  retainRemovedNpmInstallRecord?: string;
   createdMarkerPaths: string[];
 }): Promise<void> {
   const markedPreviousPluginIds = new Set<string>();
-  const markReplacement = async (
+  const markRetiredInstall = async (
     pluginId: string,
     previousRecord: PluginInstallRecord | undefined,
     nextRecord: PluginInstallRecord | undefined,
   ) => {
+    if (!nextRecord && pluginId !== params.retainRemovedNpmInstallRecord) {
+      return;
+    }
     const packageDir = resolveRetainedManagedNpmInstallMarkerTarget({
       pluginId,
       previousRecord,
@@ -198,7 +207,10 @@ async function markRetainedReplacedManagedNpmInstallRecords(params: {
     const marked = await markRetainedManagedNpmInstall({
       packageDir,
       pluginId,
-      reason: "replaced-by-managed-npm-generation-update",
+      reason:
+        nextRecord?.source === "npm"
+          ? "replaced-by-managed-npm-generation-update"
+          : RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
     });
     if (marked && !markerAlreadyExisted) {
       // Record each marker immediately so a later filesystem failure can roll it back.
@@ -208,13 +220,13 @@ async function markRetainedReplacedManagedNpmInstallRecords(params: {
   };
 
   for (const [pluginId, nextRecord] of Object.entries(params.nextInstallRecords)) {
-    await markReplacement(pluginId, params.previousInstallRecords[pluginId], nextRecord);
+    await markRetiredInstall(pluginId, params.previousInstallRecords[pluginId], nextRecord);
   }
   for (const [pluginId, previousRecord] of Object.entries(params.previousInstallRecords)) {
     if (markedPreviousPluginIds.has(pluginId) || params.nextInstallRecords[pluginId]) {
       continue;
     }
-    await markReplacement(
+    await markRetiredInstall(
       pluginId,
       previousRecord,
       findReplacementNpmRecordForRemovedRecord({
@@ -274,6 +286,7 @@ async function restoreClearedRetainedManagedNpmInstallMarkers(
 async function commitPluginInstallRecordsWithWriter(params: {
   previousInstallRecords?: Record<string, PluginInstallRecord>;
   nextInstallRecords: Record<string, PluginInstallRecord>;
+  retainRemovedNpmInstallRecord?: string;
   nextConfig: OpenClawConfig;
   writeOptions?: ConfigWriteOptions;
   commit: ConfigCommit;
@@ -285,9 +298,12 @@ async function commitPluginInstallRecordsWithWriter(params: {
   try {
     await writePersistedInstalledPluginIndexInstallRecords(params.nextInstallRecords);
     try {
-      await markRetainedReplacedManagedNpmInstallRecords({
+      await markRetiredManagedNpmInstallRecords({
         previousInstallRecords,
         nextInstallRecords: params.nextInstallRecords,
+        ...(params.retainRemovedNpmInstallRecord
+          ? { retainRemovedNpmInstallRecord: params.retainRemovedNpmInstallRecord }
+          : {}),
         // Keep partial progress visible to the outer rollback path.
         createdMarkerPaths: retainedMarkerPaths,
       });
@@ -330,6 +346,7 @@ async function commitPluginInstallRecordsWithWriter(params: {
 export async function commitPluginInstallRecordsWithConfig(params: {
   previousInstallRecords?: Record<string, PluginInstallRecord>;
   nextInstallRecords: Record<string, PluginInstallRecord>;
+  retainRemovedNpmInstallRecord?: string;
   nextConfig: OpenClawConfig;
   baseHash?: string;
   writeOptions?: ConfigWriteOptions;

--- a/src/cli/plugins-uninstall-command.ts
+++ b/src/cli/plugins-uninstall-command.ts
@@ -182,6 +182,7 @@ export async function runPluginUninstallCommand(
         previousInstallRecords: installRecords,
         nextInstallRecords,
         nextConfig,
+        ...(keepFiles ? { retainRemovedNpmInstallRecord: pluginId } : {}),
         ...(snapshot.hash !== undefined ? { baseHash: snapshot.hash } : {}),
         writeOptions: {
           afterWrite: { mode: "restart", reason: "plugin source changed" },

--- a/src/plugins/installed-plugin-index-records.test.ts
+++ b/src/plugins/installed-plugin-index-records.test.ts
@@ -22,6 +22,10 @@ import {
   writePersistedInstalledPluginIndexInstallRecordsSync,
 } from "./installed-plugin-index-records.js";
 import { readPersistedInstalledPluginIndex } from "./installed-plugin-index-store.js";
+import {
+  markRetainedManagedNpmInstall,
+  RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
+} from "./managed-npm-retention.js";
 import { writeManagedNpmPlugin } from "./test-helpers/managed-npm-plugin.js";
 
 const tempDirs: string[] = [];
@@ -380,6 +384,30 @@ describe("plugin index install records store", () => {
       installPath: discordDir,
       version: "2026.5.2",
     });
+  });
+
+  it("does not recover a managed npm package retained by an explicit uninstall", async () => {
+    const stateDir = makeStateDir();
+    const pluginDir = writeManagedNpmPlugin({
+      stateDir,
+      packageName: "@openclaw/retained-plugin",
+      pluginId: "retained-plugin",
+      version: "1.0.0",
+    });
+
+    expect(
+      loadInstalledPluginIndexInstallRecordsSync({ stateDir })["retained-plugin"],
+    ).toBeDefined();
+    await markRetainedManagedNpmInstall({
+      packageDir: pluginDir,
+      pluginId: "retained-plugin",
+      reason: RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
+    });
+    clearLoadInstalledPluginIndexInstallRecordsCache();
+
+    expect(
+      loadInstalledPluginIndexInstallRecordsSync({ stateDir })["retained-plugin"],
+    ).toBeUndefined();
   });
 
   it("keeps persisted install record metadata over recovered npm records", async () => {

--- a/src/plugins/managed-npm-retention.test.ts
+++ b/src/plugins/managed-npm-retention.test.ts
@@ -7,6 +7,8 @@ import {
   cleanupRetainedManagedNpmInstallGenerations,
   hasRetainedManagedNpmInstallMarker,
   markRetainedManagedNpmInstall,
+  resolveRetainedManagedNpmInstallMarkerPath,
+  RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
 } from "./managed-npm-retention.js";
 
 describe("managed npm retention", () => {
@@ -68,6 +70,55 @@ describe("managed npm retention", () => {
       ).resolves.toBe(1);
       expect(fs.existsSync(packageDir)).toBe(false);
       expect(hasRetainedManagedNpmInstallMarker(packageDir)).toBe(false);
+    } finally {
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it.each(["project", "legacy"] as const)(
+    "preserves %s packages retained by an explicit keep-files uninstall",
+    async (layout) => {
+      const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-retention-"));
+      const npmDir = path.join(stateDir, "npm");
+      const projectRoot =
+        layout === "legacy"
+          ? npmDir
+          : resolvePluginNpmGenerationProjectDir({
+              npmDir,
+              packageName: "@openclaw/kept-plugin",
+              generationKey: "kept-plugin-v1",
+            });
+      const packageDir = path.join(projectRoot, "node_modules", "@openclaw", "kept-plugin");
+      fs.mkdirSync(packageDir, { recursive: true });
+      await markRetainedManagedNpmInstall({
+        packageDir,
+        pluginId: "kept-plugin",
+        reason: RETAINED_MANAGED_NPM_KEEP_FILES_REASON,
+      });
+
+      try {
+        await expect(cleanupRetainedManagedNpmInstallGenerations({ npmDir })).resolves.toBe(0);
+        expect(fs.existsSync(packageDir)).toBe(true);
+        expect(hasRetainedManagedNpmInstallMarker(packageDir)).toBe(true);
+      } finally {
+        fs.rmSync(stateDir, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("cleans a package when its recovery marker cannot be read", async () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-retention-"));
+    const npmDir = path.join(stateDir, "npm");
+    const packageDir = path.join(npmDir, "node_modules", "@openclaw", "kept-plugin");
+    fs.mkdirSync(packageDir, { recursive: true });
+    const markerPath = resolveRetainedManagedNpmInstallMarkerPath(packageDir);
+    fs.mkdirSync(path.dirname(markerPath), { recursive: true });
+    fs.writeFileSync(markerPath, "{not-json", "utf8");
+
+    try {
+      await expect(cleanupRetainedManagedNpmInstallGenerations({ npmDir })).resolves.toBe(1);
+      expect(fs.existsSync(packageDir)).toBe(false);
+      expect(fs.existsSync(markerPath)).toBe(false);
     } finally {
       fs.rmSync(stateDir, { recursive: true, force: true });
     }

--- a/src/plugins/managed-npm-retention.ts
+++ b/src/plugins/managed-npm-retention.ts
@@ -1,12 +1,24 @@
 // Marks retained managed npm package trees that should stay importable but not recoverable.
 import fs from "node:fs";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { safePathSegmentHashed } from "../infra/install-safe-path.js";
 import { resolveDefaultPluginNpmDir, resolvePluginNpmProjectsDir } from "./install-paths.js";
 import { listManagedPluginNpmRootsSync } from "./npm-project-roots.js";
 
 export const RETAINED_MANAGED_NPM_INSTALL_MARKER = ".openclaw-retained-npm-install.json";
+/** Marker reason for packages preserved by an explicit `plugins uninstall --keep-files`. */
+export const RETAINED_MANAGED_NPM_KEEP_FILES_REASON = "removed-managed-npm-install-retained";
 const RETAINED_MANAGED_NPM_INSTALL_MARKER_DIR = ".openclaw-retained-npm-installs";
+
+function markerPreservesPackageFiles(markerPath: string): boolean {
+  try {
+    const marker: unknown = JSON.parse(fs.readFileSync(markerPath, "utf8"));
+    return isRecord(marker) && marker.reason === RETAINED_MANAGED_NPM_KEEP_FILES_REASON;
+  } catch {
+    return false;
+  }
+}
 
 export function resolveRetainedManagedNpmInstallPackageInfo(packageDir: string): {
   packageName: string;
@@ -151,6 +163,7 @@ async function cleanupRetainedLegacyNpmPackages(params: {
   for (const packageDir of listManagedNpmPackageDirs(params.npmRoot)) {
     if (
       !hasRetainedManagedNpmInstallMarker(packageDir) ||
+      markerPreservesPackageFiles(resolveRetainedManagedNpmInstallMarkerPath(packageDir)) ||
       params.activeInstallPaths.some((installPath) => isPathEqualOrInside(packageDir, installPath))
     ) {
       continue;
@@ -206,6 +219,9 @@ export async function cleanupRetainedManagedNpmInstallGenerations(
     }
     if (
       markerEntries.length === 0 ||
+      markerEntries.some((entry) =>
+        markerPreservesPackageFiles(path.join(markerDir, entry.name)),
+      ) ||
       !isPathEqualOrInside(projectsDir, projectRoot) ||
       activeInstallPaths.some((installPath) => isPathEqualOrInside(projectRoot, installPath))
     ) {


### PR DESCRIPTION
## Summary

Backport the applicable behavior from #113902 using the 2026.6.35 install-record transaction owner. An explicit `plugins uninstall --keep-files` now records the managed NPM package as retained before removing its install record, so a fresh process cannot reconstruct that record from the package files.

The marker is limited to the existing managed-NPM uninstall plan and is requested only by `--keep-files`; a normal uninstall remains unmarked and retains its existing cleanup behavior. Reinstalling an active NPM record clears the marker. Cleanup preserves explicit keep-files markers (and unreadable markers, because recovery already treats marker presence as authoritative).

## Root cause and scope

The candidate already removed the persisted install record for `--keep-files`, but its fresh-list recovery scanned the still-present managed package and reconstructed the record. The Docker `plugins-offline` lane consequently reported the plugin as installed immediately after a keep-files uninstall.

This is the native 2026.6.35 adaptation of source commit `0fe49c5731f31737b0e7ceab52528d93b01ceddd` (#113902), without the newer main install-record lease refactor or any version/SHA-specific condition.

## Proof

- Reproduction: candidate full-validation child [33358560442](https://github.com/openclaw/openclaw/actions/runs/33358560442/job/99385643608) failed `plugins-offline` after `plugins uninstall demo-plugin-npm --force --keep-files`; a fresh `plugins list --json` still contained `demo-plugin-npm`.
- The Docker regression performs that exact uninstall → fresh-list assertion, confirms package and dependency files remain, reinstalls/uses the plugin, then performs normal uninstall.
- Focused tests: `node scripts/run-vitest.mjs src/cli/plugins-install-record-commit.test.ts src/plugins/managed-npm-retention.test.ts src/plugins/installed-plugin-index-records.test.ts` (43 tests passed). These cover the explicit marker, fresh recovery exclusion, normal-uninstall non-marker, active reinstall marker clearing, config-write rollback, and unreadable-marker cleanup safety.
- Formatting: `pnpm exec oxfmt --check --threads=1 …` passed. `node scripts/check-changed.mjs` could not dispatch because the remote Testbox endpoint returned HTTP 429, not because of a source failure.

## Design

The transaction is the canonical owner because it atomically moves the install index with the config mutation and already restores newly-created markers on failure. The CLI supplies explicit retention intent; recovery keeps its generic package scan but recognizes the existing marker contract. No config shape, dependency, SQLite schema, package, tag, or release ref changes.

Production delta: +46/-11 lines across the CLI transaction, uninstall caller, and retention owner. Test/E2E delta: +217/-1. The added production code represents the explicit `--keep-files` lifecycle fact and the cleanup classification required to preserve that public CLI contract.