### PR TITLE
fix(e2e): probe stored dev update routing

### DIFF
--- a/scripts/e2e/lib/update-channel-switch/assertions.mjs
+++ b/scripts/e2e/lib/update-channel-switch/assertions.mjs
@@ -9,7 +9,7 @@ const controlUiHtml = "<!doctype html><title>fixture</title>\n";
 
 function usage() {
   console.error(
-    "usage: assertions.mjs <prepare-git-fixture|write-control-ui|assert-update|assert-dry-run|assert-config-channel|assert-status-kind|assert-installed-version> [...]",
+    "usage: assertions.mjs <prepare-git-fixture|write-control-ui|assert-update|assert-dry-run|resolve-stored-dev-route|assert-config-channel|assert-status-kind|assert-installed-version> [...]",
   );
   process.exit(2);
 }
@@ -214,6 +214,28 @@ function assertDryRun(kind, channel) {
   assert.equal(preview.switchToPackage, false);
 }
 
+function resolveStoredDevRoute() {
+  const preview = JSON.parse(process.env.UPDATE_JSON ?? "");
+  assert.equal(preview.dryRun, true);
+  assert.equal(preview.installKind, "package");
+  assert.equal(preview.storedChannel, "dev");
+  assert.equal(preview.effectiveChannel, "dev");
+  assert.equal(preview.switchToPackage, false);
+  if (preview.updateInstallKind === "git") {
+    assert.equal(preview.mode, "git");
+    assert.equal(preview.switchToGit, true);
+    return "git";
+  }
+  if (preview.updateInstallKind === "package") {
+    assert.equal(preview.mode, "npm");
+    assert.equal(preview.switchToGit, false);
+    return "package";
+  }
+  throw new Error(
+    `expected stored dev dry run to advertise git or package routing, got ${String(preview.updateInstallKind)}`,
+  );
+}
+
 function assertStatusKind(kind) {
   const payload = JSON.parse(process.env.STATUS_JSON ?? "");
   if (payload.update?.installKind !== kind) {
@@ -245,6 +267,9 @@ switch (command) {
     break;
   case "assert-dry-run":
     assertDryRun(args[0], args[1]);
+    break;
+  case "resolve-stored-dev-route":
+    console.log(resolveStoredDevRoute());
     break;
   case "assert-status-kind":
     assertStatusKind(args[0]);

--- a/scripts/e2e/update-channel-switch-docker.sh
+++ b/scripts/e2e/update-channel-switch-docker.sh
@@ -170,9 +170,23 @@ assert_package_dry_run() {
 dev_channel_args=(--channel dev)
 # Legacy package acceptance permits missing channel persistence; keep its explicit switch.
 if [ "$OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT" != "1" ]; then
-  echo "==> package dry-run channel and one-off tag precedence"
+  echo "==> package dry-run channel capability and one-off tag precedence"
   openclaw config set update.channel dev
-  assert_package_dry_run git dev
+  stored_dev_preview="$(openclaw update --dry-run --json --no-restart)"
+  printf "%s\n" "$stored_dev_preview"
+  stored_dev_route="$(UPDATE_JSON="$stored_dev_preview" node scripts/e2e/lib/update-channel-switch/assertions.mjs resolve-stored-dev-route)"
+  case "$stored_dev_route" in
+    git)
+      dev_channel_args=()
+      ;;
+    package)
+      # Frozen packages before stored-channel git routing still support explicit dev.
+      ;;
+    *)
+      echo "unknown stored dev route: $stored_dev_route" >&2
+      exit 1
+      ;;
+  esac
   assert_package_dry_run git dev --channel dev
   assert_package_dry_run git dev --channel dev --tag beta
   assert_package_dry_run package dev --tag beta

--- a/test/scripts/update-channel-switch-assertions.test.ts
+++ b/test/scripts/update-channel-switch-assertions.test.ts
@@ -1,0 +1,47 @@
+// Update-channel switch Docker assertions accept the candidate's advertised dry-run route.
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+const ASSERTIONS_SCRIPT = "scripts/e2e/lib/update-channel-switch/assertions.mjs";
+
+function resolveStoredDevRoute(preview: Record<string, unknown>) {
+  return spawnSync(process.execPath, [ASSERTIONS_SCRIPT, "resolve-stored-dev-route"], {
+    encoding: "utf8",
+    env: { ...process.env, UPDATE_JSON: JSON.stringify(preview) },
+  });
+}
+
+describe("update-channel switch Docker assertions", () => {
+  it.each([
+    ["git", { mode: "git", switchToGit: true, updateInstallKind: "git" }],
+    ["package", { mode: "npm", switchToGit: false, updateInstallKind: "package" }],
+  ])("uses the advertised stored dev %s route", (expectedRoute, route) => {
+    const result = resolveStoredDevRoute({
+      dryRun: true,
+      installKind: "package",
+      storedChannel: "dev",
+      effectiveChannel: "dev",
+      switchToPackage: false,
+      ...route,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout.trim()).toBe(expectedRoute);
+  });
+
+  it("rejects an inconsistent advertised route", () => {
+    const result = resolveStoredDevRoute({
+      dryRun: true,
+      installKind: "package",
+      storedChannel: "dev",
+      effectiveChannel: "dev",
+      mode: "npm",
+      switchToGit: false,
+      switchToPackage: false,
+      updateInstallKind: "git",
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("Expected values to be strictly equal");
+  });
+});


### PR DESCRIPTION
## Summary

Make the update-channel Docker lane select the candidate package’s advertised stored-`dev` routing from its existing `openclaw update --dry-run --json` output. A candidate that reports the modern git route exercises the stored-channel transition; one that reports the older package route uses the documented explicit `--channel dev` transition instead.

The harness rejects malformed or inconsistent dry-run output. It still proves explicit `dev` (including explicit-dev plus tag) and git→package switching for every supported candidate. Current main retains direct CLI unit coverage for the stronger stored-channel-to-git behavior.

## Root cause

The frozen 2026.6.35 candidate predates main commit #123083. It reports `updateInstallKind: package` and `switchToGit: false` for a package install with stored `update.channel: dev`; the newer harness unconditionally asserted the later git behavior, so the candidate full-validation lane failed before testing the explicit transition that it actually supports.

This uses no SHA/version allowlist: only the candidate CLI’s no-mutation dry-run JSON decides which already-advertised routing contract the harness exercises.

## Proof

- Candidate failure: [full-validation child job 99385643608](https://github.com/openclaw/openclaw/actions/runs/33358560442/job/99385643608) showed `installKind: package`, `updateInstallKind: package`, and `switchToGit: false` for stored `dev`, followed by the harness’s incompatible `package !== git` assertion.
- Focused new helper regression: `node scripts/run-vitest.mjs test/scripts/update-channel-switch-assertions.test.ts` — 3 passed. It covers both advertised routes and rejects inconsistent metadata.
- The combined command also ran `src/cli/update-cli.test.ts`; that shard was blocked before test collection by the pre-existing local rolldown worker compiler error (`external` received boolean), while the new helper shard passed.
- Format, `git diff --check`, and `bash -n scripts/e2e/update-channel-switch-docker.sh` passed.

Production delta: 0. Harness/test-support delta: +42/-3; focused regression test delta: +47/-0.

## Best-fix judgment

Changing the frozen package or using a version/SHA exception would make release validation non-generic. The command’s existing dry-run JSON is the exact observable capability the harness needs, and unknown/inconsistent output fails closed.