### PR TITLE
fix: reduce Gateway memory for session lists and cleanup

### DIFF
--- a/src/commands/sessions.default-agent-store.test.ts
+++ b/src/commands/sessions.default-agent-store.test.ts
@@ -164,6 +164,7 @@ describe("sessionsCommand default store agent selection", () => {
     expect(listSessionEntriesMock).toHaveBeenCalledWith({
       agentId: "voice",
       storePath: "/tmp/sessions-voice.json",
+      projection: "list",
     });
     expect(logs[0]).toContain("Session store: /tmp/sessions-voice.voice.sqlite");
   });
@@ -202,10 +203,12 @@ describe("sessionsCommand default store agent selection", () => {
     expect(listSessionEntriesMock).toHaveBeenNthCalledWith(1, {
       agentId: "main",
       storePath: "/tmp/sessions-main.json",
+      projection: "list",
     });
     expect(listSessionEntriesMock).toHaveBeenNthCalledWith(2, {
       agentId: "voice",
       storePath: "/tmp/sessions-voice.json",
+      projection: "list",
     });
     expect(logs[0]).toContain("Session stores: 2 (main, voice)");
     expect(logs[2]).toContain("Agent");

--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -345,7 +345,11 @@ export async function sessionsCommand(
   const classifyCliProvider = prepareCliProviderClassifier(cfg);
   const activeSince = activeMinutes === undefined ? undefined : Date.now() - activeMinutes * 60_000;
   const sessionEntries = targets.flatMap((target) => {
-    return listSessionEntriesReadOnly({ agentId: target.agentId, storePath: target.storePath })
+    return listSessionEntriesReadOnly({
+      agentId: target.agentId,
+      storePath: target.storePath,
+      projection: "list",
+    })
       .filter(
         ({ entry }) =>
           activeSince === undefined ||

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -845,10 +845,12 @@ describe("getStatusSummary", () => {
     expect(statusSummaryMocks.listSessionEntriesCore).toHaveBeenCalledWith({
       agentId: "main",
       storePath: "/tmp/main/sessions.json",
+      projection: "list",
     });
     expect(statusSummaryMocks.listSessionEntriesCore).toHaveBeenCalledWith({
       agentId: "ops",
       storePath: "/tmp/ops/sessions.json",
+      projection: "list",
     });
     expect(summary.sessions.count).toBe(2);
     expect(summary.sessions.byAgent.map((agent) => [agent.agentId, agent.count])).toEqual([

--- a/src/config/sessions/session-accessor.entry.ts
+++ b/src/config/sessions/session-accessor.entry.ts
@@ -396,7 +396,7 @@ export function listSessionEntriesCore(scope: SessionEntryListScope = {}): Sessi
 
 /**
  * Synchronous read view: `get` queries one exact persisted key without alias resolution;
- * `entries` reuses a validated store snapshot. List rows and their nested values are
+ * `entries` caches listing metadata or loads complete entries. Rows and nested values are
  * borrowed: callers must not mutate them and must drop the view before any await.
  */
 export function openSessionEntryReadView(

--- a/src/config/sessions/session-accessor.sqlite-data-version.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-data-version.test.ts
@@ -22,7 +22,6 @@ import { readSessionEntryCache } from "./session-accessor.sqlite-entry-cache.js"
 import { ensureTranscriptSessionRoot } from "./session-accessor.sqlite-transcript-state.js";
 
 const parseSessionEntryCalls = vi.hoisted(() => vi.fn());
-const listProjectionCalls = vi.hoisted(() => vi.fn());
 const sessionNodeVersionScans = vi.hoisted(() => ({
   onScan: undefined as ((database: DatabaseSync) => void) | undefined,
   rowCounts: [] as number[],
@@ -55,18 +54,7 @@ vi.mock("./session-accessor.sqlite-status.js", async (importOriginal) => {
     ...actual,
     parseSessionEntryJson: (row: Parameters<typeof actual.parseSessionEntryJson>[0]) => {
       parseSessionEntryCalls();
-      const entry = actual.parseSessionEntryJson(row);
-      if (entry?.label?.startsWith("projection-probe")) {
-        Object.defineProperty(entry, "__projectionProbe", {
-          configurable: true,
-          enumerable: true,
-          get: () => {
-            listProjectionCalls();
-            return entry.sessionId;
-          },
-        });
-      }
-      return entry;
+      return actual.parseSessionEntryJson(row);
     },
   };
 });
@@ -75,7 +63,6 @@ const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 beforeEach(() => {
   parseSessionEntryCalls.mockClear();
-  listProjectionCalls.mockClear();
   sessionNodeVersionScans.onScan = undefined;
   sessionNodeVersionScans.rowCounts.length = 0;
 });
@@ -148,11 +135,12 @@ function createSessionScope(label: string) {
     agentId: "main",
     env: { ...process.env, OPENCLAW_STATE_DIR: stateDir },
     sessionKey: `agent:main:${label}`,
+    projection: "list" as const,
   };
 }
 
 describe("SQLite session entry cache", () => {
-  it("keeps sqlite-entry-cache list projections shallow, lazy, and memoized per key", async () => {
+  it("retains only listing metadata while full reads preserve saved prompt state", async () => {
     const scope = createSessionScope("lazy-list-projection");
     await upsertSessionEntryCore(scope, {
       label: "projected",
@@ -170,7 +158,8 @@ describe("SQLite session entry cache", () => {
       },
     });
 
-    const fullEntry = listSessionEntriesCore({ ...scope, clone: false })[0]?.entry;
+    const fullEntry = listSessionEntriesCore({ ...scope, clone: false, projection: "full" })[0]
+      ?.entry;
     expect(fullEntry).toBeDefined();
     if (!fullEntry) {
       throw new Error("missing seeded lazy-list-projection entry");
@@ -189,11 +178,24 @@ describe("SQLite session entry cache", () => {
       })[0]?.entry;
 
       expect(first).not.toBe(fullEntry);
-      expect(first?.worktree).toBe(fullEntry.worktree);
+      expect(first?.worktree).toEqual(fullEntry.worktree);
       expect(first?.skillsSnapshot).toBeUndefined();
       expect(first?.systemPromptReport).toBeUndefined();
       expect(second).toBe(first);
       expect(cloneSpy).not.toHaveBeenCalled();
+      const cached = readSessionEntryCache(openOpenClawAgentDatabase(scope), { cache: true });
+      expect(cached.entries.get(scope.sessionKey)).toBe(first);
+      expect(cached.entries.get(scope.sessionKey)?.skillsSnapshot).toBeUndefined();
+      expect(cached.entries.get(scope.sessionKey)?.systemPromptReport).toBeUndefined();
+
+      const fullAgain = listSessionEntriesCore({ ...scope, clone: false, projection: "full" })[0]
+        ?.entry;
+      expect(fullAgain).toEqual(fullEntry);
+      expect(fullAgain?.skillsSnapshot?.prompt).toBe("large skill prompt");
+      expect(fullAgain?.systemPromptReport?.source).toBe("run");
+      expect(listSessionEntriesCore({ ...scope, clone: false, projection: "list" })[0]?.entry).toBe(
+        first,
+      );
     } finally {
       cloneSpy.mockRestore();
     }
@@ -278,7 +280,6 @@ describe("SQLite session entry cache", () => {
       { message: { role: "user", content: [{ type: "text", text: "cache probe" }] }, now: 2 },
     );
     parseSessionEntryCalls.mockClear();
-    listProjectionCalls.mockClear();
 
     const second = listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
 
@@ -286,7 +287,6 @@ describe("SQLite session entry cache", () => {
     expect(second[0]?.entry).toBe(first[0]?.entry);
     expect(second[1]?.entry).toBe(first[1]?.entry);
     expect(parseSessionEntryCalls).not.toHaveBeenCalled();
-    expect(listProjectionCalls).not.toHaveBeenCalled();
     expect(sessionNodeVersionScans.rowCounts).toEqual([]);
   });
 
@@ -326,12 +326,10 @@ describe("SQLite session entry cache", () => {
         .run(JSON.stringify(updated), updated.label, updated.updatedAt, scope.sessionKey);
 
       parseSessionEntryCalls.mockClear();
-      listProjectionCalls.mockClear();
       expect(
         listSessionEntriesCore({ ...scope, clone: false, projection: "list" })[0]?.entry.label,
       ).toBe("projection-probe-after");
       expect(parseSessionEntryCalls).toHaveBeenCalledTimes(2);
-      expect(listProjectionCalls).toHaveBeenCalledTimes(2);
     } finally {
       maintenance.close();
       external.close();
@@ -372,12 +370,10 @@ describe("SQLite session entry cache", () => {
         .run(JSON.stringify(updated), updated.label, scope.sessionKey);
 
       parseSessionEntryCalls.mockClear();
-      listProjectionCalls.mockClear();
       const after = listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
 
       expect(after[0]?.entry.label).toBe("projection-probe-after");
       expect(parseSessionEntryCalls).toHaveBeenCalledTimes(2);
-      expect(listProjectionCalls).toHaveBeenCalledTimes(2);
     } finally {
       maintenance.close();
       external.close();
@@ -479,7 +475,6 @@ describe("SQLite session entry cache", () => {
       .run(removedScope.sessionKey);
 
     parseSessionEntryCalls.mockClear();
-    listProjectionCalls.mockClear();
     const entries = listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
 
     expect(entries.map((row) => row.sessionKey)).toEqual(
@@ -490,7 +485,6 @@ describe("SQLite session entry cache", () => {
       insertedEntry,
     );
     expect(parseSessionEntryCalls).toHaveBeenCalledOnce();
-    expect(listProjectionCalls).toHaveBeenCalledOnce();
   });
 
   it("scales parse and projection work with changed keys instead of store size", async () => {
@@ -523,13 +517,11 @@ describe("SQLite session entry cache", () => {
         .run(JSON.stringify(entry), entry.label, entry.updatedAt, sessionKey);
     }
     parseSessionEntryCalls.mockClear();
-    listProjectionCalls.mockClear();
 
     const entries = listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
 
     expect(entries).toHaveLength(rowCount);
     expect(parseSessionEntryCalls).toHaveBeenCalledTimes(2);
-    expect(listProjectionCalls).toHaveBeenCalledTimes(2);
   });
 
   it("patches only the tracked row after a same-process upsert", async () => {
@@ -553,10 +545,12 @@ describe("SQLite session entry cache", () => {
     const siblingEntryBefore = cachedBefore.entries.get(siblingScope.sessionKey);
 
     parseSessionEntryCalls.mockClear();
-    listProjectionCalls.mockClear();
-    await upsertSessionEntryCore(scope, { label: "projection-probe-after", updatedAt: 2 });
+    await upsertSessionEntryCore(scope, {
+      label: "projection-probe-after",
+      updatedAt: 2,
+      skillsSnapshot: { prompt: "updated skill prompt", skills: [] },
+    });
     parseSessionEntryCalls.mockClear();
-    listProjectionCalls.mockClear();
     const after = listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
 
     expect(after.find((row) => row.sessionKey === scope.sessionKey)?.entry.label).toBe(
@@ -566,16 +560,16 @@ describe("SQLite session entry cache", () => {
       siblingBefore,
     );
     expect(parseSessionEntryCalls).not.toHaveBeenCalled();
-    expect(listProjectionCalls).toHaveBeenCalledOnce();
     expect(sessionNodeVersionScans.rowCounts).toEqual([]);
 
     const cachedAfter = readSessionEntryCache(database, { cache: true });
     expect(cachedAfter.entries).toBe(cachedBefore.entries);
-    expect(cachedAfter.listEntries).toBe(cachedBefore.listEntries);
     expect(cachedAfter.keys).toBe(cachedBefore.keys);
     expect(cachedAfter.entries.get(scope.sessionKey)).not.toBe(changedEntryBefore);
     expect(cachedAfter.entries.get(siblingScope.sessionKey)).toBe(siblingEntryBefore);
-    expect(cachedAfter.listEntries.get(siblingScope.sessionKey)).toBe(siblingBefore);
+    expect(cachedAfter.entries.get(siblingScope.sessionKey)).toBe(siblingBefore);
+    expect(cachedAfter.entries.get(scope.sessionKey)?.skillsSnapshot).toBeUndefined();
+    expect(loadSessionEntry(scope)?.skillsSnapshot?.prompt).toBe("updated skill prompt");
   });
 
   it("adds a tracked upsert to a warm snapshot without reparsing siblings", async () => {
@@ -593,14 +587,12 @@ describe("SQLite session entry cache", () => {
     const insertedScope = { ...scope, sessionKey: "agent:main:write-through-inserted" };
 
     parseSessionEntryCalls.mockClear();
-    listProjectionCalls.mockClear();
     await upsertSessionEntryCore(insertedScope, {
       label: "projection-probe-inserted",
       sessionId: "write-through-inserted",
       updatedAt: 2,
     });
     parseSessionEntryCalls.mockClear();
-    listProjectionCalls.mockClear();
     const after = listSessionEntriesCore({ ...scope, clone: false, projection: "list" });
 
     expect(after.map((row) => row.sessionKey)).toEqual(
@@ -608,14 +600,12 @@ describe("SQLite session entry cache", () => {
     );
     expect(after.find((row) => row.sessionKey === scope.sessionKey)?.entry).toBe(existing);
     expect(parseSessionEntryCalls).not.toHaveBeenCalled();
-    expect(listProjectionCalls).toHaveBeenCalledOnce();
 
     const cachedAfter = readSessionEntryCache(database, { cache: true });
     expect(cachedAfter.entries).toBe(cachedBefore.entries);
-    expect(cachedAfter.listEntries).toBe(cachedBefore.listEntries);
     expect(cachedAfter.keys).toEqual([scope.sessionKey, insertedScope.sessionKey].toSorted());
     expect(cachedAfter.entries.get(scope.sessionKey)).toBe(existingEntry);
-    expect(cachedAfter.listEntries.get(scope.sessionKey)).toBe(existing);
+    expect(cachedAfter.entries.get(scope.sessionKey)).toBe(existing);
   });
 
   it("does not let a tracked write mask an earlier raw connection write", async () => {

--- a/src/config/sessions/session-accessor.sqlite-deletion.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-deletion.test.ts
@@ -6,6 +6,7 @@ import type {
   AgentHarness,
   AgentHarnessSessionDeletionParams,
 } from "../../agents/harness/types.js";
+import * as sqliteQueries from "../../infra/kysely-sync.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import {
   markPluginRegistryActive,
@@ -37,6 +38,11 @@ import {
   replaceTranscriptEventsSync,
 } from "./session-accessor.js";
 import * as sessionArchive from "./session-accessor.sqlite-archive.js";
+import {
+  runSqliteSessionDeletionTransaction,
+  withSqliteSessionDeletions,
+} from "./session-accessor.sqlite-deletion.js";
+import { deleteSessionEntryRows } from "./session-accessor.sqlite-entry-store.js";
 import { applySessionStoreProjection } from "./session-accessor.sqlite-projection.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 
@@ -147,6 +153,47 @@ describe("session deletion and native owner state", () => {
     });
   const read = (key = sessionKey) =>
     loadSessionEntry({ sessionKey: key, storePath, readConsistency: "latest" });
+
+  it("does not materialize surviving prompts when deleting a node with no windows", async () => {
+    const reclaimedKey = "agent:main:reclaimed-node";
+    const survivorKey = "agent:main:untouched-node";
+    const entry = { sessionId: "reclaimed-session", updatedAt: Date.now() };
+    await replaceSessionEntry({ sessionKey: reclaimedKey, storePath }, entry);
+    await replaceSessionEntry(
+      { sessionKey: survivorKey, storePath },
+      {
+        sessionId: "untouched-session",
+        updatedAt: entry.updatedAt,
+        skillsSnapshot: { prompt: "saved skill prompt", skills: [] },
+      },
+    );
+    const scope = {
+      agentId: "main",
+      path: resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" }).path,
+    };
+    const database = openOpenClawAgentDatabase(scope);
+    database.db.prepare("DELETE FROM session_windows WHERE session_key = ?").run(reclaimedKey);
+    const queries = vi.spyOn(sqliteQueries, "executeSqliteQuerySync");
+    try {
+      await withSqliteSessionDeletions(scope, [{ sessionKey: reclaimedKey, entry }], async () => {
+        runSqliteSessionDeletionTransaction((current) => {
+          deleteSessionEntryRows(current, reclaimedKey);
+        }, scope);
+      });
+      const rows = queries.mock.results.flatMap((result) =>
+        result.type === "return" ? result.value.rows : [],
+      );
+      expect(rows).not.toContainEqual(
+        expect.objectContaining({ session_key: survivorKey, entry_json: expect.any(String) }),
+      );
+    } finally {
+      queries.mockRestore();
+    }
+    expect(loadSessionEntry({ sessionKey: reclaimedKey, storePath })).toBeUndefined();
+    expect(loadSessionEntry({ sessionKey: survivorKey, storePath })?.skillsSnapshot?.prompt).toBe(
+      "saved skill prompt",
+    );
+  });
 
   it("patches a case-distinct Matrix room without preparing its admitted sibling for deletion", async () => {
     const mixedKey = "agent:main:matrix:channel:!RoomAbC:example.org";

--- a/src/config/sessions/session-accessor.sqlite-entry-cache.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-cache.ts
@@ -1,5 +1,5 @@
 import type { DatabaseSync } from "node:sqlite";
-import { executeSqliteQuerySync } from "../../infra/kysely-sync.js";
+import { executeSqliteQuerySync, iterateSqliteQuerySync } from "../../infra/kysely-sync.js";
 import {
   deferOpenClawAgentPostCommitPublication,
   type OpenClawAgentDatabase,
@@ -18,17 +18,13 @@ type SessionEntryCacheDatabase = Pick<OpenClawAgentDatabase, "agentId" | "db">;
 export type SessionEntryCacheSnapshot = {
   entries: Map<string, SessionEntry>;
   keys: string[];
-  listEntries: Pick<ReadonlyMap<string, SessionEntry>, "get">;
 };
 
-type SqliteSessionEntryCache = SessionEntryCacheSnapshot & {
-  listProjections: Map<string, SessionEntry>;
-  updatedAtByKey: Map<string, number>;
+type SqliteSessionEntryCache = LoadedSessionEntrySnapshot & {
   validityToken: SqliteSessionEntryCacheValidityToken;
 };
 
 type LoadedSessionEntrySnapshot = SessionEntryCacheSnapshot & {
-  listProjections: Map<string, SessionEntry>;
   updatedAtByKey: Map<string, number>;
 };
 
@@ -44,7 +40,7 @@ type SqliteSessionEntryCacheWriteGeneration = {
 
 const MAX_INCREMENTAL_ENTRY_READ_KEYS = 500;
 
-// One parsed snapshot per opened agent database bounds memory to the process's database set.
+// Retain listing metadata only; complete prompt snapshots belong to the caller's full read.
 // Weak connection ownership lets closed read-only and evicted database handles release their
 // snapshots. The connection-local validity token plus tracked-write invalidation keeps live
 // snapshots current; narrow tracked upserts patch one authoritative row after commit, while
@@ -134,42 +130,26 @@ export function trackSessionEntryCacheWrite(
     : { before, after: readSessionNodesGeneration(database.db) };
 }
 
-function createListProjection(entry: SessionEntry): SessionEntry {
-  // clone:false list consumers treat entries and their nested values as immutable.
-  // Share those nested values instead of deep-cloning large snapshots only to discard them.
-  const projected = { ...entry };
-  delete projected.skillsSnapshot;
-  delete projected.systemPromptReport;
-  return projected;
+function parseSessionEntryProjection(
+  row: Parameters<typeof parseSessionEntryJson>[0],
+  projection: "full" | "list" = "list",
+): SessionEntry | null {
+  const entry = parseSessionEntryJson(row);
+  if (entry && projection === "list") {
+    // Drop caller-owned prompt payloads before either a reload or a tracked write publishes.
+    delete entry.skillsSnapshot;
+    delete entry.systemPromptReport;
+  }
+  return entry;
 }
 
-function createLazyListProjections(
-  entries: ReadonlyMap<string, SessionEntry>,
-  projectedByKey: Map<string, SessionEntry>,
-): Pick<ReadonlyMap<string, SessionEntry>, "get"> {
-  return {
-    get: (sessionKey) => {
-      const cached = projectedByKey.get(sessionKey);
-      if (cached) {
-        return cached;
-      }
-      const entry = entries.get(sessionKey);
-      if (!entry) {
-        return undefined;
-      }
-      // A snapshot projects each key once. clone:false readers share this immutable
-      // value, so replacing it would break identity and reintroduce store-wide cloning.
-      const projected = createListProjection(entry);
-      projectedByKey.set(sessionKey, projected);
-      return projected;
-    },
-  };
-}
-
-function loadSessionEntrySnapshot(database: SessionEntryCacheDatabase): LoadedSessionEntrySnapshot {
+function loadSessionEntrySnapshot(
+  database: SessionEntryCacheDatabase,
+  projection: "full" | "list" = "list",
+): LoadedSessionEntrySnapshot {
   const db = getSessionKysely(database.db);
   const rows = hasSqliteSessionOwnerColumns(database.db)
-    ? executeSqliteQuerySync(
+    ? iterateSqliteQuerySync(
         database.db,
         db
           .selectFrom("session_nodes")
@@ -184,30 +164,32 @@ function loadSessionEntrySnapshot(database: SessionEntryCacheDatabase): LoadedSe
             "owner_assigned_at",
           ])
           .orderBy("session_key"),
-      ).rows
-    : executeSqliteQuerySync(
+      )
+    : iterateSqliteQuerySync(
         database.db,
         db
           .selectFrom("session_nodes")
           .select(["session_key", "entry_json", "updated_at"])
           .orderBy("session_key"),
-      ).rows;
+      );
   const parsedEntries = new Map<string, SessionEntry>();
+  const keys: string[] = [];
+  const updatedAtByKey = new Map<string, number>();
+  // Stream raw JSON so a full read never holds both serialized and parsed store-wide payloads.
   for (const row of rows) {
-    const entry = parseSessionEntryJson(row);
+    keys.push(row.session_key);
+    updatedAtByKey.set(row.session_key, row.updated_at);
+    const entry = parseSessionEntryProjection(row, projection);
     if (!entry) {
       continue;
     }
     parsedEntries.set(row.session_key, entry);
   }
   const entries = projectSqliteSessionParticipantsBatch(database.db, parsedEntries);
-  const listProjections = new Map<string, SessionEntry>();
   return {
     entries,
-    keys: rows.map((row) => row.session_key),
-    listEntries: createLazyListProjections(entries, listProjections),
-    listProjections,
-    updatedAtByKey: new Map(rows.map((row) => [row.session_key, row.updated_at])),
+    keys,
+    updatedAtByKey,
   };
 }
 
@@ -240,14 +222,12 @@ function incrementallyRevalidateSessionEntrySnapshot(
   }
 
   const entries = new Map(cached.entries);
-  const listProjections = new Map(cached.listProjections);
   for (const sessionKey of [...changedKeys, ...removedKeys]) {
     entries.delete(sessionKey);
-    listProjections.delete(sessionKey);
   }
   if (changedKeys.length > 0) {
     const changedRows = hasSqliteSessionOwnerColumns(database.db)
-      ? executeSqliteQuerySync(
+      ? iterateSqliteQuerySync(
           database.db,
           db
             .selectFrom("session_nodes")
@@ -261,16 +241,16 @@ function incrementallyRevalidateSessionEntrySnapshot(
               "owner_assigned_at",
             ])
             .where("session_key", "in", changedKeys),
-        ).rows
-      : executeSqliteQuerySync(
+        )
+      : iterateSqliteQuerySync(
           database.db,
           db
             .selectFrom("session_nodes")
             .select(["session_key", "entry_json"])
             .where("session_key", "in", changedKeys),
-        ).rows;
+        );
     for (const row of changedRows) {
-      const entry = parseSessionEntryJson(row);
+      const entry = parseSessionEntryProjection(row);
       if (entry) {
         entries.set(
           row.session_key,
@@ -282,8 +262,6 @@ function incrementallyRevalidateSessionEntrySnapshot(
   return {
     entries,
     keys: versions.map((row) => row.session_key).toSorted(),
-    listEntries: createLazyListProjections(entries, listProjections),
-    listProjections,
     updatedAtByKey,
     validityToken,
   };
@@ -291,10 +269,15 @@ function incrementallyRevalidateSessionEntrySnapshot(
 
 export function readSessionEntryCache(
   database: SessionEntryCacheDatabase,
-  options: { cache: boolean; latest?: boolean },
+  options: { cache: boolean; latest?: boolean; projection?: "full" | "list" },
 ): SessionEntryCacheSnapshot {
-  if (!options.cache || options.latest || database.db.isTransaction) {
-    return loadSessionEntrySnapshot(database);
+  if (
+    !options.cache ||
+    options.latest ||
+    options.projection === "full" ||
+    database.db.isTransaction
+  ) {
+    return loadSessionEntrySnapshot(database, options.projection);
   }
   const validityToken = readCacheValidityToken(database.db);
   const cached = sessionEntryCaches.get(database.db);
@@ -382,7 +365,7 @@ function publishSqliteSessionEntryCacheUpsert(
           .limit(1),
       ).rows[0]
     : undefined;
-  const parsedEntry = parseSessionEntryJson({
+  const parsedEntry = parseSessionEntryProjection({
     current_session_id: row.current_session_id,
     entry_json: row.entry_json,
     updated_at: row.updated_at,
@@ -407,7 +390,6 @@ function publishSqliteSessionEntryCacheUpsert(
     // Borrowed cache views are synchronous, so the commit owner can update one
     // row in place without cloning every session map on each active-run write.
     cached.entries.set(row.session_key, entry);
-    cached.listProjections.delete(row.session_key);
     const knownKey = cached.updatedAtByKey.has(row.session_key);
     cached.updatedAtByKey.set(row.session_key, row.updated_at);
     if (!knownKey) {

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -328,14 +328,19 @@ export function deleteSessionEntryRows(
     database.db,
     db.selectFrom("session_windows").select("session_id").where("session_key", "=", sessionKey),
   ).rows;
-  const survivingNodes = executeSqliteQuerySync(
-    database.db,
-    db
-      .selectFrom("session_nodes")
-      .select(["current_session_id", "entry_json", "session_key"])
-      .where("session_key", "!=", sessionKey)
-      .orderBy("session_key", "asc"),
-  ).rows;
+  // Maintenance may have reclaimed every window already. Only scan surviving
+  // prompts when a retained window needs an owner; otherwise each deletion reads the whole store.
+  const survivingNodes =
+    windows.length > 0
+      ? executeSqliteQuerySync(
+          database.db,
+          db
+            .selectFrom("session_nodes")
+            .select(["current_session_id", "entry_json", "session_key"])
+            .where("session_key", "!=", sessionKey)
+            .orderBy("session_key", "asc"),
+        ).rows
+      : [];
   for (const window of windows) {
     const survivingNode = survivingNodes.find((node) => {
       if (node.current_session_id === window.session_id) {

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -313,13 +313,12 @@ function listSqliteSessionEntriesFromDatabase(
   scope: SessionEntryListScope,
 ): SessionEntrySummary[] {
   assertCanonicalSqliteSessionKeysCurrent(database);
-  const snapshot = readSessionEntrySnapshot(database, resolved, scope.readConsistency);
-  const entries = scope.projection === "list" ? snapshot.listEntries : snapshot.entries;
+  const snapshot = readSessionEntrySnapshot(database, resolved, scope);
   return snapshot.keys.flatMap((sessionKey) => {
     if (isInternalSessionEffectsKey(sessionKey)) {
       return [];
     }
-    const entry = entries.get(sessionKey);
+    const entry = snapshot.entries.get(sessionKey);
     if (!entry) {
       return [];
     }
@@ -341,7 +340,7 @@ function listSqliteSessionEntriesFromDatabase(
 function readSessionEntrySnapshot(
   database: Pick<OpenClawAgentDatabase, "agentId" | "db" | "path">,
   resolved: ResolvedSqliteScope,
-  readConsistency: SessionAccessScope["readConsistency"],
+  scope: SessionEntryListScope,
 ): SessionEntryCacheSnapshot {
   const cache = !isIncognitoOpenClawAgentSqlitePath(database.path, {
     agentId: database.agentId,
@@ -349,7 +348,8 @@ function readSessionEntrySnapshot(
   });
   return readSessionEntryCache(database, {
     cache,
-    latest: readConsistency === "latest",
+    latest: scope.readConsistency === "latest",
+    projection: scope.projection ?? "full",
   });
 }
 

--- a/src/status/session-stores.ts
+++ b/src/status/session-stores.ts
@@ -27,6 +27,7 @@ export function createStatusSessionStoreReader(
         for (const row of readEntries({
           ...(agentId ? { agentId } : {}),
           storePath,
+          projection: "list",
         })) {
           // The accessor validates canonical keys; only global/unknown buckets lack an agent.
           const owner = parseAgentSessionKey(row.sessionKey)?.agentId;


### PR DESCRIPTION
## What Problem This Solves

Fixes excessive Gateway memory use when listing large session stores and a long pause when resuming a session triggers cleanup. Dashboard/status reads retained saved prompts for every session; cleanup repeatedly materialized those prompts while deleting unrelated rows.

## Why This Change Was Made

The session-entry cache retained complete parsed entries alongside separate lightweight listing projections. Removing prompt fields from the projection did not release the originals. The cache now owns only listing metadata; full reads stream complete entries directly to their caller without populating another long-lived cache. Tracked writes and reloads use the same projection owner, preserving connection-local invalidation, owner/participant metadata, and stable borrowed listing entries.

CLI session listings and the shared status reader now request the existing lightweight projection. This also avoids cloning all saved prompts for a status response that only displays counts and recent sessions. Complete entry reads, persisted data, schemas, configuration, and protocol shapes are unchanged. Full enumeration reparses complete entries when requested; exact session reads already load individual rows.

The retained-payload path is present in stable `v2026.8.1`. The full cache was added in #114453; its raw-parent patch was inspected. This removes the duplicate lazy projection map rather than adding another cache or memory limit.

A second defect surfaced during real CLI conversation testing: `deleteSessionEntryRows` read every surviving node's `entry_json` once per deleted node, even after maintenance had already removed all of that node's windows. The result was unused. The deletion owner now performs that scan only when retained windows need reassignment. Historical-window preservation, shared-generation reassignment, native owner checks, and post-commit invalidation keep the same flow. This defect is also present in stable `v2026.8.1`.

Production LOC: +69/-77 (net -8). Tests: +80/-38 (net +42).

## User Impact

Lower Gateway and CLI memory use for large session stores, including dashboard startup prewarming, session pagination, and repeated status polling. Saved skill prompts and system-prompt reports remain available to session execution and full-entry callers.

## Evidence

Matched baseline/candidate builds on the same macOS host with Node 24.19.0. The fixture contains 2,000 persisted sessions with 64 KiB of saved skill text each. A real built Gateway serves the built Control UI and CLI; plugins are disabled to isolate the session-store cost. These are scale-fixture measurements, not a universal reduction claim or an external-provider/channel test.

| Measurement | Before | After |
| --- | ---: | ---: |
| Retained heap from the listing cache, after GC | 127.11 MiB | 1.46 MiB |
| Retained heap after a full read is released | 127.26 MiB | 1.68 MiB |
| Gateway RSS after pagination/reconnect/status workload | 661.80 MiB | 450.78 MiB |
| Gateway heap after that workload and GC | 367.82 MiB | 216.95 MiB |
| Gateway peak RSS during the matched workload | 2,691.92 MiB | 618.59 MiB |

The allocation profile attributes the original retained payload to session-entry JSON parsing. The same source probe at 500 sessions retains 0.34 MiB after the repair.

Live proof covered 50/200-row pages, all ten enriched pages with 2,000 distinct keys, 20 reconnect/subscription cycles, and 20 status/list cycles. Recorded browser proof covered the Sessions table, next page, refresh, sidebar server pagination, selecting a conversation, and repeated page reloads, with no page errors. CLI session keys/counts match before and after; health and status succeed. Further live checks covered 50 rename/restore patches, archive/unarchive, deletion, and authoritative status counts. A full read after those mutations still returns the saved 64 KiB prompt.

A separate matched conversation fixture starts with 1,998 sessions carrying the same 64 KiB prompts, normal plugins enabled, the maintained local deterministic OpenAI fixture, and unchanged default maintenance. Both runs prune to 500 sessions and return the expected assistant reply. This compares the cache repair alone with the final cleanup repair added:

| Conversation/maintenance measurement | Before cleanup repair | After cleanup repair |
| --- | ---: | ---: |
| End-to-end CLI resume | 49.66 s | 6.63 s |
| Gateway peak RSS, including startup | 3,366.94 MiB | 2,889.56 MiB |

The candidate also completes a fresh message sent from the actual built Web UI: the new `chat.send` run receives its own final reply, displays it, and makes the composer available again. These conversation checks use a local provider fixture; no external provider or channel delivery is claimed. The remaining maintenance peak is still substantial; the removed per-deletion scan explains the measured latency reduction, not every allocation in maintenance.

The cache regression failed on the original implementation because the retained entries still contained prompt state, then passed with the repair. The deletion regression also fails before the repair because it observes the unused survivor payload read. Existing coverage verifies external same-timestamp rewrites, incremental changes, tracked writes, rollback, malformed/owned rows, full-entry behavior, historical placeholders, previous-session window reassignment, and native deletion ownership.

```text
pnpm build
node scripts/run-vitest.mjs \
  src/config/sessions/session-accessor.sqlite-data-version.test.ts \
  src/config/sessions/session-accessor.test.ts \
  src/config/sessions/session-accessor.sqlite-participants.test.ts \
  src/config/sessions/session-accessor.sqlite-session-row.test.ts \
  src/commands/sessions.test.ts \
  src/commands/sessions.default-agent-store.test.ts \
  src/status/summary.read-only.test.ts \
  src/gateway/server-startup-handler-prewarm.test.ts
# 208 passed
node scripts/run-vitest.mjs src/commands/status.summary.test.ts
# 38 passed
node scripts/run-vitest.mjs \
  src/config/sessions/session-accessor.sqlite-cleanup-race.test.ts \
  src/config/sessions/session-accessor.sqlite-deletion.test.ts
# 41 passed
node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental
# passed
# Changed-file typed lint, formatting, native-schema guard: passed
# Independent Codex autoreview at its default P0 threshold: no findings
```

Additional opportunities observed during investigation: older reset-archive fallback reads retain full parsed transcripts in a bounded file-count cache; metadata-only tail/run-ID lookup callers can narrow their projections separately. Current ordinary SQLite resets do not create those older archive files. Neither is included in the measured improvement above.

The landing workflow also exposed a tooling follow-up: #134366 repairs current trusted PR-wrapper bundles, but an older invoking wrapper still extracts its outdated dependency inventory before handing off to the new entrypoint. A pure helper probe confirms the stale-invoker path remains broken. This PR uses the complete canonical wrapper; anchor-owned bundle completion and a historical-invoker regression belong in a separate repair.
