### PR TITLE
test(tooling): share immutable OpenGrep source fixtures

### DIFF
--- a/test/scripts/run-opengrep.test.ts
+++ b/test/scripts/run-opengrep.test.ts
@@ -3,8 +3,9 @@ import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
 import { devNull } from "node:os";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { parse } from "yaml";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
 const { createTempDir } = createScriptTestHarness();
@@ -291,15 +292,13 @@ describe("run-opengrep.sh", () => {
     },
   );
 
-  it.each([
-    { shape: "merge", branch: "main", depth: 2, passes: true },
-    { shape: "linear", branch: "feature", depth: 2, passes: true },
-    { shape: "merge without parents", branch: "main", depth: 1, passes: false },
-    { shape: "linear without base", branch: "feature", depth: 1, passes: false },
-  ])(
-    "prepares and scans a shallow $shape checkout without unrelated base fetches",
-    ({ branch, depth, passes }) => {
-      const source = createTempDir("openclaw-opengrep-source-");
+  describe("shallow checkout preparation", () => {
+    const sourceDirs = useAutoCleanupTempDirTracker(afterAll);
+    let source: string;
+    let staleBase: string;
+
+    beforeAll(() => {
+      source = sourceDirs.make("openclaw-opengrep-source-");
       git(source, "init", "-q", "--initial-branch=main");
       git(source, "config", "user.email", "test@example.com");
       git(source, "config", "user.name", "Test User");
@@ -312,7 +311,7 @@ describe("run-opengrep.sh", () => {
       writeFile(path.join(source, "security/opengrep/precise.yml"), "rules: []\n");
       git(source, "add", ".");
       git(source, "commit", "-qm", "base");
-      const staleBase = git(source, "rev-parse", "HEAD");
+      staleBase = git(source, "rev-parse", "HEAD");
       git(source, "switch", "-q", "-c", "feature");
       writeFile(path.join(source, "src/pr.ts"), "export const pr = true;\n");
       git(source, "add", ".");
@@ -322,59 +321,69 @@ describe("run-opengrep.sh", () => {
       git(source, "add", ".");
       git(source, "commit", "-qm", "main only");
       git(source, "merge", "--no-ff", "feature", "-m", "synthetic merge");
+    });
 
-      const repo = createTempDir("openclaw-opengrep-shallow-");
-      git(
-        source,
-        "clone",
-        "--quiet",
-        "--no-local",
-        `--depth=${depth}`,
-        "--branch",
-        branch,
-        source,
-        repo,
-      );
-      expect(git(repo, "rev-parse", "--is-shallow-repository")).toBe("true");
-      const hasPayloadBase =
-        spawnSync("git", ["cat-file", "-e", `${staleBase}^{commit}`], { cwd: repo }).status === 0;
-      expect(hasPayloadBase).toBe(branch === "feature" && depth === 2);
-      const { argsPath, binDir } = installOpengrepStub(repo);
-      const trace = path.join(createTempDir("openclaw-opengrep-trace-"), "git.jsonl");
-      const result = runChangedPathsWorkflow(repo, staleBase, {
-        ...process.env,
-        PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
-        RUNNER_OS:
-          process.platform === "win32"
-            ? "Windows"
-            : process.platform === "darwin"
-              ? "macOS"
-              : "Linux",
-        GIT_CONFIG_GLOBAL: devNull,
-        GIT_CONFIG_NOSYSTEM: "1",
-        GIT_ALLOW_PROTOCOL: "",
-        GIT_TRACE2_EVENT: trace,
-      });
-      const fetches = fs
-        .readFileSync(trace, "utf8")
-        .trim()
-        .split("\n")
-        .map((line) => JSON.parse(line))
-        .filter((event) => event.event === "cmd_name" && event.name === "fetch");
-      if (!passes) {
-        expect(result.status, result.stderr).not.toBe(0);
-        expect(result.stdout).toContain("Base commit still unavailable");
-        expect(fetches).toHaveLength(5);
-        expect(fs.existsSync(argsPath)).toBe(false);
-        return;
-      }
-      expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
-      expect(fetches).toEqual([]);
-      const args = fs.readFileSync(argsPath, "utf8");
-      expect(args).toContain("src/pr.ts");
-      expect(args).not.toContain("src/main-only.ts");
-    },
-  );
+    it.each([
+      { shape: "merge", branch: "main", depth: 2, passes: true },
+      { shape: "linear", branch: "feature", depth: 2, passes: true },
+      { shape: "merge without parents", branch: "main", depth: 1, passes: false },
+      { shape: "linear without base", branch: "feature", depth: 1, passes: false },
+    ])(
+      "prepares and scans a shallow $shape checkout without unrelated base fetches",
+      ({ branch, depth, passes }) => {
+        const repo = createTempDir("openclaw-opengrep-shallow-");
+        git(
+          source,
+          "clone",
+          "--quiet",
+          "--no-local",
+          `--depth=${depth}`,
+          "--branch",
+          branch,
+          source,
+          repo,
+        );
+        expect(git(repo, "rev-parse", "--is-shallow-repository")).toBe("true");
+        const hasPayloadBase =
+          spawnSync("git", ["cat-file", "-e", `${staleBase}^{commit}`], { cwd: repo }).status === 0;
+        expect(hasPayloadBase).toBe(branch === "feature" && depth === 2);
+        const { argsPath, binDir } = installOpengrepStub(repo);
+        const trace = path.join(createTempDir("openclaw-opengrep-trace-"), "git.jsonl");
+        const result = runChangedPathsWorkflow(repo, staleBase, {
+          ...process.env,
+          PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ""}`,
+          RUNNER_OS:
+            process.platform === "win32"
+              ? "Windows"
+              : process.platform === "darwin"
+                ? "macOS"
+                : "Linux",
+          GIT_CONFIG_GLOBAL: devNull,
+          GIT_CONFIG_NOSYSTEM: "1",
+          GIT_ALLOW_PROTOCOL: "",
+          GIT_TRACE2_EVENT: trace,
+        });
+        const fetches = fs
+          .readFileSync(trace, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line))
+          .filter((event) => event.event === "cmd_name" && event.name === "fetch");
+        if (!passes) {
+          expect(result.status, result.stderr).not.toBe(0);
+          expect(result.stdout).toContain("Base commit still unavailable");
+          expect(fetches).toHaveLength(5);
+          expect(fs.existsSync(argsPath)).toBe(false);
+          return;
+        }
+        expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(0);
+        expect(fetches).toEqual([]);
+        const args = fs.readFileSync(argsPath, "utf8");
+        expect(args).toContain("src/pr.ts");
+        expect(args).not.toContain("src/main-only.ts");
+      },
+    );
+  });
 });
 
 describe("OpenGrep GitHub SARIF uploads", () => {


### PR DESCRIPTION
## What problem does this PR solve?

Four shallow-checkout OpenGrep cases rebuild the same committed source repository and copy the same scripts/actions before making their distinct shallow clones.

## Why this approach?

Build that immutable source graph once in beforeAll and register its directory with the shared afterAll cleanup tracker. Each case still creates its own real --no-local shallow clone and owns its own trace, stub, output and failure state.

## User impact

Test-only cleanup: production +0/-0; tests +72/-63. This removes 39 Git setup launches, three source directories, nine script copies and six action copies. All four merge/linear and depth-one/depth-two scenarios remain.

## Evidence

All 16 OpenGrep/merge-base cases passed in the baseline selection and pass after the change. The shallow cases retain exact zero-fetch successful paths and five denied fetches on missing-base paths, stale payload-base checks, PR-only file scope and no scanner invocation after preparation failure. SARIF coverage is unchanged. Full changed-file checks and Codex autoreview pass; no elapsed-time claim.

`node scripts/run-vitest.mjs test/scripts/run-opengrep.test.ts test/scripts/merge-head-diff-base.test.ts`
