### PR TITLE
test(openai): reuse the terminal history frontier lifecycle

### DIFF
--- a/extensions/openai/realtime-transcription-provider.bounds.test.ts
+++ b/extensions/openai/realtime-transcription-provider.bounds.test.ts
@@ -201,7 +201,7 @@ describe("OpenAI realtime transcription terminal history bounds", () => {
     session.close();
   });
 
-  it("does not re-admit a terminal item after the settled frontier fills", async () => {
+  it("preserves terminal history at capacity, fails on overflow, and reconnects", async () => {
     const onError = vi.fn();
     const onPartial = vi.fn();
     const transcripts: string[] = [];
@@ -212,90 +212,75 @@ describe("OpenAI realtime transcription terminal history bounds", () => {
       onPartial,
       onTranscript: (transcript) => transcripts.push(transcript),
     });
-    const socket = await connectFakeSession(session);
+    try {
+      const socket = await connectFakeSession(session);
 
-    emitJson(socket, {
-      type: "conversation.item.input_audio_transcription.completed",
-      item_id: "oldest",
-      transcript: "first",
-    });
-    for (let index = 0; index < 4095; index += 1) {
       emitJson(socket, {
         type: "conversation.item.input_audio_transcription.completed",
-        item_id: `settled-${index}`,
-        transcript: "",
+        item_id: "oldest",
+        transcript: "first",
       });
-    }
-    emitJson(socket, {
-      type: "conversation.item.input_audio_transcription.completed",
-      item_id: "oldest",
-      transcript: "duplicate",
-    });
-    emitJson(socket, {
-      type: "conversation.item.input_audio_transcription.delta",
-      item_id: "oldest",
-      delta: "late partial",
-    });
-
-    expect(transcripts).toEqual(["first"]);
-    expect(onPartial).not.toHaveBeenCalled();
-    expect(onError).not.toHaveBeenCalled();
-    expect(session.isConnected()).toBe(true);
-    session.close();
-  });
-
-  it("fails visibly instead of evicting terminal item history", async () => {
-    const onError = vi.fn();
-    const onTranscript = vi.fn();
-    const provider = buildOpenAIRealtimeTranscriptionProvider();
-    const session = provider.createSession({
-      providerConfig: { apiKey: "sk-test" }, // pragma: allowlist secret
-      onError,
-      onTranscript,
-    });
-    const socket = await connectFakeSession(session);
-
-    for (let index = 0; index < 4096; index += 1) {
+      for (let index = 0; index < 4095; index += 1) {
+        emitJson(socket, {
+          type: "conversation.item.input_audio_transcription.completed",
+          item_id: `settled-${index}`,
+          transcript: "",
+        });
+      }
       emitJson(socket, {
         type: "conversation.item.input_audio_transcription.completed",
-        item_id: `settled-${index}`,
-        transcript: "",
+        item_id: "oldest",
+        transcript: "duplicate",
       });
+      emitJson(socket, {
+        type: "conversation.item.input_audio_transcription.delta",
+        item_id: "oldest",
+        delta: "late partial",
+      });
+
+      expect(transcripts).toEqual(["first"]);
+      expect(onPartial).not.toHaveBeenCalled();
+      expect(onError).not.toHaveBeenCalled();
+      expect(session.isConnected()).toBe(true);
+
+      emitJson(socket, {
+        type: "input_audio_buffer.committed",
+        item_id: "overflow-item",
+        previous_item_id: null,
+      });
+      emitJson(socket, {
+        type: "conversation.item.input_audio_transcription.failed",
+        item_id: "overflow-item",
+        error: { message: "provider failure" },
+      });
+
+      expect(onError).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          message: "OpenAI realtime transcription exceeded the terminal item history limit",
+        }),
+      );
+      expect(transcripts).toEqual(["first"]);
+      expect(session.isConnected()).toBe(false);
+
+      const reconnecting = session.connect();
+      const replacementSocket = await waitForFakeSocket(1);
+      replacementSocket.readyState = FakeWebSocket.OPEN;
+      replacementSocket.emit("open");
+      emitJson(replacementSocket, { type: "session.updated" });
+      await reconnecting;
+      emitJson(replacementSocket, {
+        type: "conversation.item.input_audio_transcription.completed",
+        item_id: "replacement-item",
+        transcript: "replacement transcript",
+      });
+
+      expect(transcripts).toEqual(["first", "replacement transcript"]);
+      expect(onError).toHaveBeenCalledTimes(1);
+    } finally {
+      session.close();
+      // Close the fake peer too so the session releases its graceful-close timer.
+      FakeWebSocket.instances.at(-1)?.close();
     }
-    emitJson(socket, {
-      type: "input_audio_buffer.committed",
-      item_id: "overflow-item",
-      previous_item_id: null,
-    });
-    emitJson(socket, {
-      type: "conversation.item.input_audio_transcription.failed",
-      item_id: "overflow-item",
-      error: { message: "provider failure" },
-    });
-
-    expect(onError).toHaveBeenCalledExactlyOnceWith(
-      expect.objectContaining({
-        message: "OpenAI realtime transcription exceeded the terminal item history limit",
-      }),
-    );
-    expect(onTranscript).not.toHaveBeenCalled();
-    expect(session.isConnected()).toBe(false);
-
-    const reconnecting = session.connect();
-    const replacementSocket = await waitForFakeSocket(1);
-    replacementSocket.readyState = FakeWebSocket.OPEN;
-    replacementSocket.emit("open");
-    emitJson(replacementSocket, { type: "session.updated" });
-    await reconnecting;
-    emitJson(replacementSocket, {
-      type: "conversation.item.input_audio_transcription.completed",
-      item_id: "replacement-item",
-      transcript: "replacement transcript",
-    });
-
-    expect(onTranscript).toHaveBeenCalledExactlyOnceWith("replacement transcript");
-    expect(onError).toHaveBeenCalledTimes(1);
-    session.close();
   });
 
   it("fails visibly when terminal item identities exceed 256 KiB", async () => {


### PR DESCRIPTION
## What problem does this PR solve?

Two adjacent OpenAI transcription tests independently create and dispatch 4,096 completed items to fill the same terminal-history frontier.

## Why this approach?

Use one lifecycle: fill the actual frontier, prove duplicate completion and late partial suppression, trigger the same committed failed overflow item, and verify one visible limit error plus successful delivery after reconnect. Keep the transcript history intact between phases. Close the session and fake peer in finally so the touched case releases its graceful-close timer.

## User impact

Test-only cleanup: production +0/-0; tests +60/-75. This removes 4,096 repeated event dispatches, one session/socket construction and one connection wait. The real 4,096-item bound and separate 256 KiB identity/text limits remain unchanged.

## Evidence

All 40 original bounds/provider tests passed. After combining two cases into one, all 39 pass, including all 32 unchanged provider siblings. Full changed-file checks and Codex autoreview pass. The test continues using its existing fake transport with real provider/session owners; this is not live API proof or an elapsed-time benchmark.

`node scripts/run-vitest.mjs extensions/openai/realtime-transcription-provider.bounds.test.ts extensions/openai/realtime-transcription-provider.test.ts`

Follow-up: settle the fake peer in the remaining sibling cases that leave the graceful-close fallback to expire. This patch owns cleanup for the combined case; it does not claim a production connection leak.
