### PR TITLE
test(ui): retain manual agent-file capture artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2403,15 +2403,6 @@ jobs:
           --configLoader runner
           ui/src/e2e/usage-sessions-owner-attribution.e2e.test.ts
 
-      - name: Upload sanitized Control UI real-Gateway proof
-        if: always() && github.event_name == 'workflow_dispatch' && inputs.capture_ui_proof
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: control-ui-real-gateway-proof-${{ github.run_id }}-${{ github.run_attempt }}
-          path: .artifacts/control-ui-e2e/real-gateway
-          if-no-files-found: error
-          retention-days: 14
-
       - name: Test Control UI Logs lifecycle with a real Gateway
         run: >-
           node scripts/run-vitest.mjs run
@@ -2420,11 +2411,23 @@ jobs:
           ui/src/e2e/logs-lifecycle.e2e.test.ts
 
       - name: Test Control UI agent file lifecycle with a real Gateway
+        env:
+          OPENCLAW_CAPTURE_UI_PROOF: ${{ github.event_name == 'workflow_dispatch' && inputs.capture_ui_proof && '1' || '0' }}
+          OPENCLAW_UI_E2E_ARTIFACT_DIR: .artifacts/control-ui-e2e/real-gateway
         run: >-
           node scripts/run-vitest.mjs run
           --config test/vitest/vitest.ui-e2e.config.ts
           --configLoader runner
           ui/src/e2e/agent-file-lifecycle.real-gateway.e2e.test.ts
+
+      - name: Upload sanitized Control UI real-Gateway proof
+        if: always() && github.event_name == 'workflow_dispatch' && inputs.capture_ui_proof
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: control-ui-real-gateway-proof-${{ github.run_id }}-${{ github.run_attempt }}
+          path: .artifacts/control-ui-e2e/real-gateway
+          if-no-files-found: error
+          retention-days: 14
 
   control-ui-i18n:
     permissions:

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -8852,6 +8852,26 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(realGatewayRunContract).not.toContain("--retry");
     expect(realGatewayRunContract).not.toContain("--hookTimeout");
     expect(realGatewayRunContract).not.toContain("--testTimeout");
+
+    const proofUploadIndex = uiE2eRealGateway.steps.findIndex(
+      (step: WorkflowStep) => step.name === "Upload sanitized Control UI real-Gateway proof",
+    );
+    const proofUpload = uiE2eRealGateway.steps[proofUploadIndex];
+    for (const name of [
+      "Test Control UI auth transports with a real Gateway",
+      "Test Control UI usage sessions owner attribution with a real Gateway",
+      "Test Control UI agent file lifecycle with a real Gateway",
+    ]) {
+      const captureIndex = uiE2eRealGateway.steps.findIndex(
+        (step: WorkflowStep) => step.name === name,
+      );
+      expect(uiE2eRealGateway.steps[captureIndex].env, name).toEqual({
+        OPENCLAW_CAPTURE_UI_PROOF:
+          "${{ github.event_name == 'workflow_dispatch' && inputs.capture_ui_proof && '1' || '0' }}",
+        OPENCLAW_UI_E2E_ARTIFACT_DIR: proofUpload.with.path,
+      });
+      expect(proofUploadIndex, name).toBeGreaterThan(captureIndex);
+    }
   });
 
   it("builds artifacts once and smoke-tests the built CLI with Node and Bun", () => {

--- a/ui/src/e2e/agent-file-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/agent-file-lifecycle.e2e.test.ts
@@ -2,7 +2,6 @@
 import { expect, it } from "vitest";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import {
-  captureAgentFileProof,
   agentFileProofDir,
   captureAgentFileScreenshot,
   selectAgentFileWorkspace,
@@ -72,7 +71,7 @@ suite.define(() => {
         locale: "en-US",
         serviceWorkers: "block",
         viewport: { height: 900, width: 1440 },
-        ...(captureAgentFileProof
+        ...(agentFileProofDir
           ? { recordVideo: { dir: agentFileProofDir, size: { height: 900, width: 1440 } } }
           : {}),
       },
@@ -178,7 +177,7 @@ suite.define(() => {
         locale: "en-US",
         serviceWorkers: "block",
         viewport: { height: 900, width: 1440 },
-        ...(captureAgentFileProof
+        ...(agentFileProofDir
           ? { recordVideo: { dir: agentFileProofDir, size: { height: 900, width: 1440 } } }
           : {}),
       },

--- a/ui/src/e2e/agent-file-lifecycle.test-support.ts
+++ b/ui/src/e2e/agent-file-lifecycle.test-support.ts
@@ -1,21 +1,17 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import type { Page } from "playwright";
 import { expect } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 
-export const captureAgentFileProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-export const agentFileProofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "agent-file-lifecycle",
-);
+export const agentFileProofDir =
+  process.env.OPENCLAW_CAPTURE_UI_PROOF === "1"
+    ? createControlUiE2eArtifactDir("agent-file-lifecycle")
+    : undefined;
 
 export async function captureAgentFileScreenshot(page: Page, name: string) {
-  if (!captureAgentFileProof) {
+  if (!agentFileProofDir) {
     return;
   }
-  await mkdir(agentFileProofDir, { recursive: true });
   await page.screenshot({
     animations: "disabled",
     fullPage: true,


### PR DESCRIPTION
## Summary

Manual `capture_ui_proof` runs did not retain the agent-file browser screenshot: its test step did not receive the capture environment, the helper ignored the configured artifact parent, and upload ran before the test. This is the separately tracked test/tooling follow-up from #134136; it changes no product behavior.

Pass the existing capture settings to that step, allocate its screenshot/video directory through the shared exclusive artifact helper, and upload after all real-Gateway test steps. Remove the duplicate capture flag and directory creation; both real and mocked agent-file cases use the same optional directory. The workflow guard checks all three capture-producing steps against their shared upload parent and upload order.

## Verification

- Before: the new routing assertion fails for the missing environment. The real browser save test passes, but the requested artifact directory is absent and its screenshot is written elsewhere.
- After: routing passes; all three real/mocked browser cases pass. Nine screenshots are retained under the configured parent in two exclusive scenario directories and were inspected. Two optional videos are retained but are not claimed as inspected proof.
- Workflow validation and the required scoped checks pass; final review is clean at the requested blocking priority.

No assertions or deadlines change. Production LOC: zero. Workflow: +3 net lines; tests and test support: +15 net lines. The existing manual-dispatch screenshot upload remains opt-in. No package or release publication is performed.
