### PR TITLE
fix(cli): detect CLI/gateway state-dir split-brain before credential writes

### DIFF
--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -167,6 +167,8 @@ If your config was already in a mixed state (named accounts present and top-leve
 
 ## Login and logout (interactive)
 
+Before `channels add` or `channels login` writes local credentials or configuration, OpenClaw compares the selected CLI state/config paths with the local Gateway or its installed service. A proven mismatch stops before the write. A remote Gateway or an authenticated path that cannot be verified produces a warning instead.
+
 ```bash
 openclaw channels login --channel whatsapp
 openclaw channels logout --channel whatsapp

--- a/docs/cli/configure.md
+++ b/docs/cli/configure.md
@@ -17,6 +17,8 @@ Use `openclaw onboard` or `openclaw setup` for the full guided first-run journey
 
 ## Options
 
+Before `openclaw configure` changes local credentials or configuration, OpenClaw compares the selected CLI state/config paths with the local Gateway or its installed service. A proven mismatch stops before the write. A remote Gateway or an authenticated path that cannot be verified produces a warning instead.
+
 `--section <section>`: repeatable section filter. Available sections:
 
 `workspace`, `model`, `web`, `gateway`, `daemon`, `channels`, `plugins`, `skills`, `health`

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -151,6 +151,8 @@ Manages `agents.defaults.model.fallbacks`. `openclaw models image-fallbacks list
 
 ## Auth profiles
 
+Before a `models auth` command changes the local auth store, OpenClaw compares the selected CLI state/config paths with the local Gateway or its installed service. A proven mismatch stops before the write. A remote Gateway or an authenticated path that cannot be verified produces a warning instead.
+
 ```bash
 openclaw models auth add
 openclaw models auth list [--provider <id>] [--json]

--- a/src/cli/cli-process-child.test-helpers.ts
+++ b/src/cli/cli-process-child.test-helpers.ts
@@ -49,6 +49,7 @@ export async function runCliProcessChild(params: {
   nodeArgs: string[];
   env: NodeJS.ProcessEnv;
   cwd?: string;
+  input?: string;
   onStdout?: (stdout: string) => void;
   timeoutMs?: number;
 }): Promise<CliProcessChildResult> {
@@ -56,8 +57,9 @@ export async function runCliProcessChild(params: {
   const child = spawn(process.execPath, params.nodeArgs, {
     cwd: params.cwd ?? path.resolve("."),
     env: params.env,
-    stdio: ["ignore", "pipe", "pipe"],
+    stdio: ["pipe", "pipe", "pipe"],
   });
+  child.stdin.end(params.input);
   child.stdout.setEncoding("utf8");
   child.stderr.setEncoding("utf8");
   let stdout = "";

--- a/src/cli/command-catalog.ts
+++ b/src/cli/command-catalog.ts
@@ -43,6 +43,7 @@ type CliRoutedCommandId =
 
 export type CliCommandPathPolicy = {
   configGuard: CliConfigGuardPolicy;
+  stateStoreGuard: "run" | "skip";
   loadPlugins: CliCommandPluginLoadPolicy;
   pluginRegistry: CliPluginRegistryPolicy;
   ownsProtocolStdout: boolean;
@@ -186,7 +187,10 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     exact: true,
     policy: { loadPlugins: "never" },
   },
-  { commandPath: ["configure"], policy: { configGuard: "skip", loadPlugins: "never" } },
+  {
+    commandPath: ["configure"],
+    policy: { configGuard: "skip", stateStoreGuard: "run", loadPlugins: "never" },
+  },
   {
     commandPath: ["config"],
     exact: true,
@@ -346,6 +350,7 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
     },
     route: { id: "models-status" },
   },
+  { commandPath: ["models", "auth"], policy: { stateStoreGuard: "run" } },
   {
     commandPath: ["models", "list"],
     exact: true,
@@ -643,8 +648,9 @@ export const cliCommandCatalog: readonly CliCommandCatalogEntry[] = [
   {
     commandPath: ["channels", "add"],
     exact: true,
-    policy: { loadPlugins: "never", networkProxy: "bypass" },
+    policy: { stateStoreGuard: "run", loadPlugins: "never", networkProxy: "bypass" },
   },
+  { commandPath: ["channels", "login"], exact: true, policy: { stateStoreGuard: "run" } },
   {
     commandPath: ["channels", "logs"],
     exact: true,

--- a/src/cli/command-path-policy.test.ts
+++ b/src/cli/command-path-policy.test.ts
@@ -9,6 +9,7 @@ import {
 
 const DEFAULT_EXPECTED_POLICY: CliCommandPathPolicy = {
   configGuard: "run",
+  stateStoreGuard: "skip",
   loadPlugins: "never",
   pluginRegistry: { scope: "all" },
   ownsProtocolStdout: false,
@@ -59,6 +60,25 @@ function expectConfigGuardResolver(
 }
 
 describe("command-path-policy", () => {
+  it.each([
+    { commandPath: ["configure"] },
+    { commandPath: ["models", "auth"] },
+    { commandPath: ["models", "auth", "paste-token"] },
+    { commandPath: ["channels", "add"] },
+    { commandPath: ["channels", "login"] },
+  ])("guards local state writes for $commandPath", ({ commandPath }) => {
+    expect(resolveCliCommandPathPolicy(commandPath).stateStoreGuard).toBe("run");
+  });
+
+  it.each([
+    { commandPath: ["models", "list"] },
+    { commandPath: ["channels", "status"] },
+    { commandPath: ["config", "set"] },
+    { commandPath: ["onboard"] },
+  ])("does not broaden the state-store guard to $commandPath", ({ commandPath }) => {
+    expect(resolveCliCommandPathPolicy(commandPath).stateStoreGuard).toBe("skip");
+  });
+
   it("resolves status policy with shared startup semantics", () => {
     expectResolvedPolicy(["status"], {
       configGuard: "skip",
@@ -150,6 +170,7 @@ describe("command-path-policy", () => {
       pluginRegistry: { scope: "configured-channels" },
     });
     expectResolvedPolicy(["channels", "login"], {
+      stateStoreGuard: "run",
       loadPlugins: "always",
       pluginRegistry: { scope: "configured-channels" },
     });
@@ -158,6 +179,7 @@ describe("command-path-policy", () => {
       pluginRegistry: { scope: "configured-channels" },
     });
     expectResolvedPolicy(["channels", "add"], {
+      stateStoreGuard: "run",
       loadPlugins: "never",
       pluginRegistry: { scope: "configured-channels" },
       networkProxy: "bypass",
@@ -379,6 +401,7 @@ describe("command-path-policy", () => {
     });
     expectResolvedPolicy(["configure"], {
       configGuard: "skip",
+      stateStoreGuard: "run",
       loadPlugins: "never",
     });
     expectResolvedPolicy(["config"], {

--- a/src/cli/command-path-policy.ts
+++ b/src/cli/command-path-policy.ts
@@ -12,6 +12,7 @@ import { resolveParentAwareCommandPath } from "./parent-command-path.js";
 
 const DEFAULT_CLI_COMMAND_PATH_POLICY: CliCommandPathPolicy = {
   configGuard: "run",
+  stateStoreGuard: "skip",
   loadPlugins: "never",
   pluginRegistry: { scope: "all" },
   ownsProtocolStdout: false,

--- a/src/cli/gateway-backed-exit.test-helpers.ts
+++ b/src/cli/gateway-backed-exit.test-helpers.ts
@@ -237,6 +237,37 @@ export async function startGatewayStabilityRpcServer(
   return { authTokens, calls, url: `ws://${host}:${address.port}` };
 }
 
+export async function startStateDirStatusGateway(target: {
+  stateDir: string;
+  configPath: string;
+}): Promise<{ url: string }> {
+  const wss = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  activeServers.add(wss);
+  wss.on("connection", (ws) => {
+    sendMinimalGatewayConnectChallenge(ws);
+    ws.on("message", (data) => {
+      const frame = parseMinimalGatewayRequestFrame(data);
+      if (frame.type !== "req" || !frame.id) {
+        return;
+      }
+      if (frame.method === "connect") {
+        sendMinimalGatewayResponse(
+          ws,
+          frame.id,
+          buildMinimalGatewayHelloOkPayload({ methods: ["status"], snapshot: target }),
+        );
+        return;
+      }
+      if (frame.method === "status") {
+        sendMinimalGatewayResponse(ws, frame.id, { status: "ok" });
+      }
+    });
+  });
+  await once(wss, "listening");
+  const address = wss.address() as AddressInfo;
+  return { url: `ws://127.0.0.1:${address.port}` };
+}
+
 /** Mock Gateway that answers one agent turn with the requested terminal status. */
 export async function startAgentTurnGateway(params: {
   status: "ok" | "error";

--- a/src/cli/program/preaction-state-store.test.ts
+++ b/src/cli/program/preaction-state-store.test.ts
@@ -1,0 +1,71 @@
+import { Command } from "commander";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CliGatewayStateDirOutcome } from "../state-dir-gateway-check.js";
+
+const mocks = vi.hoisted(() => ({
+  action: vi.fn(),
+  check: vi.fn<() => Promise<CliGatewayStateDirOutcome>>(async () => ({ kind: "allow" })),
+  debug: vi.fn(),
+  ensureBootstrap: vi.fn(async () => {}),
+}));
+
+vi.mock("../state-dir-gateway-check.js", () => ({ checkCliGatewayStateDir: mocks.check }));
+vi.mock("../../logger.js", () => ({ logDebug: mocks.debug }));
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: {
+    log: vi.fn(),
+    error: vi.fn(),
+    writeStdout: vi.fn(),
+    writeJson: vi.fn(),
+    exit: vi.fn(),
+  },
+}));
+vi.mock("../command-execution-startup.js", () => ({
+  applyCliExecutionStartupPresentation: vi.fn(async () => {}),
+  ensureCliExecutionBootstrap: mocks.ensureBootstrap,
+  resolveCliExecutionStartupContext: ({ commandPath }: { commandPath: string[] }) => ({
+    commandPath,
+    startupPolicy: { skipConfigGuard: true },
+  }),
+}));
+
+let program: Command;
+let originalArgv: string[];
+
+beforeAll(async () => {
+  const { registerPreActionHooks } = await import("./preaction.js");
+  program = new Command().name("openclaw");
+  program.command("configure").action(mocks.action);
+  registerPreActionHooks(program, "test");
+});
+
+beforeEach(() => {
+  originalArgv = [...process.argv];
+  vi.clearAllMocks();
+  process.argv = ["node", "openclaw", "configure"];
+});
+
+afterEach(() => {
+  process.argv = originalArgv;
+});
+
+describe("state-store preAction guard", () => {
+  it("refuses before bootstrap and action", async () => {
+    mocks.check.mockResolvedValueOnce({ kind: "refuse", message: "state stores differ" });
+
+    await expect(program.parseAsync(process.argv)).rejects.toThrow("state stores differ");
+
+    expect(mocks.check).toHaveBeenCalledWith({ command: "openclaw configure" });
+    expect(mocks.ensureBootstrap).not.toHaveBeenCalled();
+    expect(mocks.action).not.toHaveBeenCalled();
+  });
+
+  it("allows the action when inspection fails", async () => {
+    mocks.check.mockRejectedValueOnce(new Error("inspection failed"));
+
+    await expect(program.parseAsync(process.argv)).resolves.toBe(program);
+
+    expect(mocks.debug).toHaveBeenCalledWith("state-store guard unavailable: inspection failed");
+    expect(mocks.action).toHaveBeenCalledOnce();
+  });
+});

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -13,6 +13,7 @@ import {
   resolveCliExecutionStartupContext,
 } from "../command-execution-startup.js";
 import { inheritOptionFromParent } from "../command-options.js";
+import { resolveCliCommandPathPolicy } from "../command-path-policy.js";
 import { applyResolvedCommandOutputMode } from "../json-output-mode.js";
 import { isModelsPlainMachineOutput } from "../models-output-mode.js";
 import {
@@ -113,6 +114,27 @@ function isGatewayRunAction(actionCommand: Command): boolean {
   );
 }
 
+async function runStateStoreGuard(commandPath: string[]): Promise<void> {
+  if (resolveCliCommandPathPolicy(commandPath).stateStoreGuard !== "run") {
+    return;
+  }
+  let outcome: import("../state-dir-gateway-check.js").CliGatewayStateDirOutcome;
+  try {
+    const { checkCliGatewayStateDir } = await import("../state-dir-gateway-check.js");
+    outcome = await checkCliGatewayStateDir({ command: `openclaw ${commandPath.join(" ")}` });
+  } catch (error) {
+    const { formatErrorMessage } = await import("../../infra/errors.js");
+    const { logDebug } = await import("../../logger.js");
+    logDebug(`state-store guard unavailable: ${formatErrorMessage(error)}`);
+    return;
+  }
+  if (outcome.kind === "warn") {
+    defaultRuntime.log(outcome.message);
+  } else if (outcome.kind === "refuse") {
+    throw new Error(outcome.message);
+  }
+}
+
 /** Register global pre-action bootstrap hooks for every non-help command invocation. */
 export function registerPreActionHooks(program: Command, programVersion: string) {
   program.hook("preAction", async (_thisCommand, actionCommand) => {
@@ -156,6 +178,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
     if (isGuidedConfigAction(actionCommand) || isGuidedConfigCommandPath(commandPath)) {
       return;
     }
+    await runStateStoreGuard(commandPath);
     if (startupPolicy.skipConfigGuard) {
       // Config validation and plugin activation are independent startup policies.
       // A cold config read must not suppress a plugin runtime explicitly required by the command.

--- a/src/cli/state-dir-gateway-check.process.test.ts
+++ b/src/cli/state-dir-gateway-check.process.test.ts
@@ -1,0 +1,74 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { runCliProcessChild } from "./cli-process-child.test-helpers.js";
+import {
+  closeActiveGatewayServers,
+  startStateDirStatusGateway,
+} from "./gateway-backed-exit.test-helpers.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(async () => {
+  await closeActiveGatewayServers();
+});
+
+describe("CLI Gateway state target guard", () => {
+  it("refuses a model credential write when the live Gateway reports another state tree", async () => {
+    const root = tempDirs.make("openclaw-auth-state-mismatch-");
+    const stateDir = path.join(root, "cli-state");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const gatewayStateDir = path.join(root, "gateway-state");
+    const gateway = await startStateDirStatusGateway({
+      stateDir: gatewayStateDir,
+      configPath: path.join(gatewayStateDir, "openclaw.json"),
+    });
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        gateway: {
+          mode: "local",
+          port: Number(new URL(gateway.url).port),
+          auth: { mode: "none" },
+        },
+      }),
+    );
+
+    const result = await runCliProcessChild({
+      nodeArgs: [
+        "--import",
+        "tsx",
+        "src/entry.ts",
+        "models",
+        "auth",
+        "paste-token",
+        "--provider",
+        "test-provider",
+      ],
+      env: {
+        ...process.env,
+        HOME: root,
+        USERPROFILE: root,
+        NODE_DISABLE_COMPILE_CACHE: "1",
+        NODE_ENV: undefined,
+        NODE_OPTIONS: undefined,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        OPENCLAW_GATEWAY_PASSWORD: undefined,
+        OPENCLAW_GATEWAY_TOKEN: undefined,
+        OPENCLAW_GATEWAY_URL: undefined,
+        OPENCLAW_HOME: root,
+        OPENCLAW_NO_RESPAWN: "1",
+        OPENCLAW_STATE_DIR: stateDir,
+        VITEST: undefined,
+      },
+      input: "not-a-real-token\n",
+    });
+
+    expect(result, JSON.stringify(result)).toMatchObject({ code: 1, signal: null });
+    expect(result.stderr).toContain("No credentials or configuration were written");
+    expect(JSON.parse(await fs.readFile(configPath, "utf8"))).not.toHaveProperty("auth.profiles");
+  });
+});

--- a/src/cli/state-dir-gateway-check.server-fixture.test-support.ts
+++ b/src/cli/state-dir-gateway-check.server-fixture.test-support.ts
@@ -1,0 +1,21 @@
+import { pinRuntimePaths } from "../config/paths.js";
+import { startGatewayServer } from "../gateway/server.js";
+
+pinRuntimePaths();
+const port = Number.parseInt(process.env.OPENCLAW_GATEWAY_PORT ?? "0", 10);
+const token = process.env.OPENCLAW_TEST_GATEWAY_TOKEN ?? "";
+const server = await startGatewayServer(port, {
+  bind: "loopback",
+  auth: { mode: "token", token },
+  controlUiEnabled: false,
+});
+await server.startupSettled;
+process.send?.({ port });
+
+const close = async () => {
+  await server.close();
+  process.exit(0);
+};
+process.once("SIGTERM", () => void close());
+process.once("SIGINT", () => void close());
+setInterval(() => {}, 1_000);

--- a/src/cli/state-dir-gateway-check.server.test.ts
+++ b/src/cli/state-dir-gateway-check.server.test.ts
@@ -1,0 +1,123 @@
+import { fork, type ChildProcess } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { getFreePort } from "../test-utils/ports.js";
+import { checkCliGatewayStateDir } from "./state-dir-gateway-check.js";
+
+describe("state-dir guard with a real token Gateway", () => {
+  const token = "state-dir-test-token";
+  let child: ChildProcess;
+  let root: string;
+  let port: number;
+  let gatewayStateDir: string;
+  let cliStateDir: string;
+
+  const setCliStateDir = (stateDir: string) => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", path.join(stateDir, "openclaw.json"));
+  };
+
+  beforeAll(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-state-dir-server-"));
+    gatewayStateDir = path.join(root, "gateway");
+    cliStateDir = path.join(root, "cli");
+    await fs.mkdir(gatewayStateDir, { recursive: true });
+    await fs.mkdir(cliStateDir, { recursive: true });
+    port = await getFreePort();
+    const gatewayConfigPath = path.join(gatewayStateDir, "openclaw.json");
+    await fs.writeFile(
+      gatewayConfigPath,
+      `${JSON.stringify({ gateway: { mode: "local", port, auth: { mode: "token", token } } })}\n`,
+    );
+    child = fork(
+      fileURLToPath(
+        new URL("./state-dir-gateway-check.server-fixture.test-support.ts", import.meta.url),
+      ),
+      [],
+      {
+        env: {
+          ...process.env,
+          HOME: path.join(root, "gateway-home"),
+          OPENCLAW_STATE_DIR: gatewayStateDir,
+          OPENCLAW_CONFIG_PATH: gatewayConfigPath,
+          OPENCLAW_GATEWAY_PORT: String(port),
+          OPENCLAW_TEST_GATEWAY_TOKEN: token,
+          OPENCLAW_TEST_MINIMAL_GATEWAY: "1",
+          OPENCLAW_SKIP_BROWSER_CONTROL_SERVER: "1",
+          OPENCLAW_SKIP_CANVAS_HOST: "1",
+          OPENCLAW_SKIP_CHANNELS: "1",
+          OPENCLAW_SKIP_CRON: "1",
+          OPENCLAW_SKIP_GMAIL_WATCHER: "1",
+          OPENCLAW_SKIP_PROVIDERS: "1",
+        },
+        execArgv: ["--import", path.resolve("scripts/tsx.mjs")],
+        stdio: ["ignore", "ignore", "pipe", "ipc"],
+      },
+    );
+    let childStderr = "";
+    child.stderr?.on("data", (chunk) => {
+      childStderr += String(chunk);
+    });
+    await new Promise<void>((resolve, reject) => {
+      child.once("message", () => {
+        resolve();
+      });
+      child.once("exit", (code) => {
+        reject(new Error(`Gateway fixture exited early: ${code}\n${childStderr}`));
+      });
+    });
+    vi.stubEnv("HOME", path.join(root, "cli-home"));
+    setCliStateDir(cliStateDir);
+    vi.stubEnv("OPENCLAW_GATEWAY_PORT", String(port));
+    vi.stubEnv("OPENCLAW_SYSTEMD_UNIT", `openclaw-state-dir-server-${process.pid}`);
+  }, 120_000);
+
+  afterAll(async () => {
+    vi.unstubAllEnvs();
+    const exited = new Promise<void>((resolve) => {
+      child.once("exit", () => {
+        resolve();
+      });
+    });
+    child.kill("SIGTERM");
+    await exited;
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  it("allows matching authenticated hello paths", async () => {
+    setCliStateDir(gatewayStateDir);
+    await expect(
+      checkCliGatewayStateDir({
+        command: "openclaw channels add",
+        config: { gateway: { mode: "local", port, auth: { mode: "token", token } } },
+      }),
+    ).resolves.toEqual({ kind: "allow" });
+    setCliStateDir(cliStateDir);
+  });
+
+  it("refuses mismatched authenticated hello paths", async () => {
+    const outcome = await checkCliGatewayStateDir({
+      command: "openclaw channels add",
+      config: { gateway: { mode: "local", port, auth: { mode: "token", token } } },
+    });
+
+    expect(outcome).toMatchObject({ kind: "refuse" });
+    if (outcome.kind !== "refuse") {
+      throw new Error("expected authenticated path mismatch refusal");
+    }
+    expect(outcome.message).toContain(gatewayStateDir);
+    expect(outcome.message).toContain("live Gateway");
+  });
+
+  it("warns when a tokenless CLI can prove only the Gateway protocol", async () => {
+    await expect(
+      checkCliGatewayStateDir({
+        command: "openclaw channels add",
+        config: { gateway: { mode: "local", port, auth: { mode: "token" } } },
+      }),
+    ).resolves.toMatchObject({ kind: "warn" });
+  });
+});

--- a/src/cli/state-dir-gateway-check.test.ts
+++ b/src/cli/state-dir-gateway-check.test.ts
@@ -1,0 +1,157 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+
+const mocks = vi.hoisted(() => ({
+  callGateway: vi.fn(),
+  probeGateway: vi.fn(),
+  readGatewayServiceState: vi.fn(),
+  resolveGatewayService: vi.fn(() => ({})),
+}));
+
+vi.mock("../gateway/call.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../gateway/call.js")>()),
+  callGateway: mocks.callGateway,
+}));
+vi.mock("../gateway/probe.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../gateway/probe.js")>()),
+  probeGateway: mocks.probeGateway,
+}));
+vi.mock("../daemon/service.js", () => ({
+  readGatewayServiceState: mocks.readGatewayServiceState,
+  resolveGatewayService: mocks.resolveGatewayService,
+}));
+
+const { GatewayCredentialsRequiredError } =
+  await vi.importActual<typeof import("../gateway/call.js")>("../gateway/call.js");
+import { checkCliGatewayStateDir, compareCliGatewayStateDirs } from "./state-dir-gateway-check.js";
+
+describe("state-dir-gateway-check", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+  let root: string;
+  let cliStateDir: string;
+  let cliConfigPath: string;
+
+  beforeEach(async () => {
+    root = tempDirs.make("openclaw-state-dir-check-");
+    cliStateDir = path.join(root, "cli");
+    cliConfigPath = path.join(cliStateDir, "openclaw.json");
+    await fs.mkdir(cliStateDir, { recursive: true });
+    vi.stubEnv("OPENCLAW_STATE_DIR", cliStateDir);
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", cliConfigPath);
+    mocks.callGateway.mockReset().mockRejectedValue(new Error("ECONNREFUSED"));
+    mocks.probeGateway.mockReset().mockResolvedValue({ ok: false });
+    mocks.readGatewayServiceState.mockReset().mockResolvedValue({
+      installed: false,
+      env: {},
+    });
+    mocks.resolveGatewayService.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses canonical path identity for a missing config below a symlink", async () => {
+    const gatewayStateDir = path.join(root, "gateway");
+    const gatewayConfigPath = path.join(gatewayStateDir, "openclaw.json");
+    await fs.mkdir(gatewayStateDir);
+    const stateLink = path.join(root, "gateway-link");
+    await fs.symlink(gatewayStateDir, stateLink);
+
+    expect(
+      compareCliGatewayStateDirs({
+        cliStateDir: stateLink,
+        cliConfigPath: path.join(stateLink, "openclaw.json"),
+        gatewayStateDir,
+        gatewayConfigPath,
+        source: "live Gateway",
+        mode: "refuse",
+        command: "openclaw configure",
+      }),
+    ).toEqual({ kind: "allow" });
+  });
+
+  it.each([true, false, undefined])(
+    "refuses an installed service mismatch when running is %s",
+    async (running) => {
+      const gatewayStateDir = path.join(root, "service");
+      const gatewayConfigPath = path.join(gatewayStateDir, "openclaw.json");
+      await fs.mkdir(gatewayStateDir);
+      mocks.readGatewayServiceState.mockImplementation(
+        async (_service: unknown, options: { env: NodeJS.ProcessEnv }) => ({
+          installed: true,
+          running,
+          env: {
+            ...options.env,
+            OPENCLAW_STATE_DIR: gatewayStateDir,
+            OPENCLAW_CONFIG_PATH: gatewayConfigPath,
+          },
+        }),
+      );
+
+      await expect(
+        checkCliGatewayStateDir({ command: "openclaw channels add", config: {} }),
+      ).resolves.toMatchObject({ kind: "refuse" });
+      const inspectedEnv = mocks.readGatewayServiceState.mock.calls[0]?.[1]?.env;
+      expect(inspectedEnv).not.toHaveProperty("OPENCLAW_STATE_DIR");
+      expect(inspectedEnv).not.toHaveProperty("OPENCLAW_CONFIG_PATH");
+    },
+  );
+
+  it("allows a matching installed service without probing", async () => {
+    mocks.readGatewayServiceState.mockResolvedValue({
+      installed: true,
+      running: false,
+      env: {
+        OPENCLAW_STATE_DIR: cliStateDir,
+        OPENCLAW_CONFIG_PATH: cliConfigPath,
+      },
+    });
+
+    await expect(
+      checkCliGatewayStateDir({ command: "openclaw models auth", config: {} }),
+    ).resolves.toEqual({ kind: "allow" });
+    expect(mocks.probeGateway).not.toHaveBeenCalled();
+  });
+
+  it("warns only when a credential-blocked protocol probe reaches an unowned Gateway", async () => {
+    mocks.callGateway.mockRejectedValue(
+      new GatewayCredentialsRequiredError({ method: "status", configPath: cliConfigPath }),
+    );
+    mocks.probeGateway.mockResolvedValue({ ok: false, gatewayReached: true });
+
+    await expect(
+      checkCliGatewayStateDir({
+        command: "openclaw models auth",
+        config: { gateway: { auth: { mode: "token" } } },
+      }),
+    ).resolves.toMatchObject({ kind: "warn" });
+    expect(mocks.probeGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeDetails: false,
+        suppressStoredDeviceAuth: true,
+        timeoutMs: 3_000,
+      }),
+    );
+  });
+
+  it("allows an offline command and does not probe an ordinary transport failure", async () => {
+    await expect(
+      checkCliGatewayStateDir({ command: "openclaw configure", config: {} }),
+    ).resolves.toEqual({ kind: "allow" });
+    expect(mocks.probeGateway).not.toHaveBeenCalled();
+  });
+
+  it("warns for a remote Gateway without local inspection", async () => {
+    await expect(
+      checkCliGatewayStateDir({
+        command: "openclaw configure",
+        config: { gateway: { mode: "remote", remote: { url: "wss://gateway.example" } } },
+      }),
+    ).resolves.toMatchObject({ kind: "warn" });
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+    expect(mocks.readGatewayServiceState).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/state-dir-gateway-check.ts
+++ b/src/cli/state-dir-gateway-check.ts
@@ -1,0 +1,148 @@
+import path from "node:path";
+import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { readGatewayServiceState, resolveGatewayService } from "../daemon/service.js";
+import {
+  buildGatewayConnectionDetails,
+  callGateway,
+  isGatewayCredentialsRequiredError,
+} from "../gateway/call.js";
+import type { GatewayClientOptions } from "../gateway/client.js";
+import { ADMIN_SCOPE } from "../gateway/method-scopes.js";
+import { isLoopbackGatewayUrl } from "../gateway/net.js";
+import { probeGateway } from "../gateway/probe.js";
+import { resolveIdentityPathViaExistingAncestorSync } from "../infra/boundary-path.js";
+import { quoteCliArg } from "./quote-cli-arg.js";
+
+const STATE_DIR_CHECK_TIMEOUT_MS = 3_000;
+export type GatewayHello = Parameters<NonNullable<GatewayClientOptions["onHelloOk"]>>[0];
+
+export type CliGatewayStateDirOutcome =
+  | { kind: "allow" }
+  | { kind: "warn"; message: string }
+  | { kind: "refuse"; message: string };
+
+export function compareCliGatewayStateDirs(params: {
+  cliStateDir: string;
+  cliConfigPath: string;
+  gatewayStateDir: string;
+  gatewayConfigPath?: string;
+  source: "live Gateway" | "installed Gateway service";
+  mode: "refuse" | "warn";
+  command?: string;
+}): CliGatewayStateDirOutcome {
+  const cliStateDir = resolveIdentityPathViaExistingAncestorSync(params.cliStateDir);
+  const cliConfigPath = resolveIdentityPathViaExistingAncestorSync(params.cliConfigPath);
+  const gatewayStateDir = resolveIdentityPathViaExistingAncestorSync(params.gatewayStateDir);
+  const gatewayConfigPath = resolveIdentityPathViaExistingAncestorSync(
+    params.gatewayConfigPath ?? path.join(gatewayStateDir, "openclaw.json"),
+  );
+  const differences = [
+    cliStateDir !== gatewayStateDir &&
+      `state directories (CLI: ${params.cliStateDir}; Gateway: ${gatewayStateDir})`,
+    cliConfigPath !== gatewayConfigPath &&
+      `config paths (CLI: ${params.cliConfigPath}; Gateway: ${gatewayConfigPath})`,
+  ].filter((difference): difference is string => Boolean(difference));
+  if (differences.length === 0) {
+    return { kind: "allow" };
+  }
+  const detail = differences.join(" and ");
+  if (params.mode === "warn") {
+    return {
+      kind: "warn",
+      message: `CLI and ${params.source} use different ${detail}. Local commands may read or write state the Gateway does not use.`,
+    };
+  }
+  return {
+    kind: "refuse",
+    message: [
+      `No credentials or configuration were written. CLI and ${params.source} use different ${detail}.`,
+      `Fix: run OPENCLAW_STATE_DIR=${quoteCliArg(gatewayStateDir)} OPENCLAW_CONFIG_PATH=${quoteCliArg(gatewayConfigPath)} ${params.command ?? "openclaw configure"}.`,
+      params.source === "live Gateway"
+        ? "To write another local store intentionally, stop the running Gateway first."
+        : "To write another local store intentionally, uninstall or reconfigure the divergent Gateway service first.",
+    ].join(" "),
+  };
+}
+
+export async function checkCliGatewayStateDir(params: {
+  command: string;
+  config?: OpenClawConfig;
+}): Promise<CliGatewayStateDirOutcome> {
+  const cliStateDir = resolveStateDir(process.env);
+  const cliConfigPath = resolveConfigPath(process.env);
+  const details = buildGatewayConnectionDetails({ config: params.config });
+  if (!isLoopbackGatewayUrl(details.url)) {
+    return {
+      kind: "warn",
+      message: `Gateway target ${details.url} is remote. Local credentials and configuration do not reach that Gateway.`,
+    };
+  }
+
+  let hello: GatewayHello | undefined;
+  let connectionError: unknown;
+  try {
+    await callGateway({
+      config: params.config,
+      method: "status",
+      params: { includeChannelSummary: false },
+      scopes: [ADMIN_SCOPE],
+      sharedStateMode: "read-only",
+      timeoutMs: STATE_DIR_CHECK_TIMEOUT_MS,
+      onHelloOk: (value) => {
+        hello = value;
+      },
+    });
+  } catch (error) {
+    connectionError = error;
+  }
+  if (hello?.snapshot.stateDir) {
+    return compareCliGatewayStateDirs({
+      cliStateDir,
+      cliConfigPath,
+      gatewayStateDir: hello.snapshot.stateDir,
+      gatewayConfigPath: hello.snapshot.configPath,
+      source: "live Gateway",
+      mode: "refuse",
+      command: params.command,
+    });
+  }
+
+  const serviceEnv = { ...process.env };
+  // Caller path overrides select the write target, not the installed service definition.
+  delete serviceEnv.OPENCLAW_STATE_DIR;
+  delete serviceEnv.OPENCLAW_CONFIG_PATH;
+  const serviceState = await readGatewayServiceState(resolveGatewayService(), {
+    env: serviceEnv,
+    timeoutMs: STATE_DIR_CHECK_TIMEOUT_MS,
+  });
+  if (serviceState.installed) {
+    return compareCliGatewayStateDirs({
+      cliStateDir,
+      cliConfigPath,
+      gatewayStateDir: resolveStateDir(serviceState.env),
+      gatewayConfigPath: resolveConfigPath(serviceState.env),
+      source: "installed Gateway service",
+      mode: "refuse",
+      command: params.command,
+    });
+  }
+
+  if (isGatewayCredentialsRequiredError(connectionError)) {
+    const probe = await probeGateway({
+      url: details.url,
+      config: params.config,
+      timeoutMs: STATE_DIR_CHECK_TIMEOUT_MS,
+      includeDetails: false,
+      suppressStoredDeviceAuth: true,
+    });
+    if (probe.gatewayReached) {
+      return {
+        kind: "warn",
+        message:
+          "Gateway is reachable but requires credentials, so its state and config paths could not be verified. Local writes may not reach it.",
+      };
+    }
+  }
+  return { kind: "allow" };
+}

--- a/src/commands/doctor-gateway-health.test.ts
+++ b/src/commands/doctor-gateway-health.test.ts
@@ -1,5 +1,5 @@
 // Doctor gateway health tests cover gateway probe failures, auth requirements, and repair messages.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayClientRequestError } from "../../packages/gateway-client/src/index.js";
 import { retainGatewayResponsePayload } from "../../packages/gateway-client/src/protocol-request.js";
 import type { OpenClawConfig } from "../config/config.js";
@@ -68,6 +68,41 @@ describe("checkGatewayHealth", () => {
     note.mockReset();
   });
 
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("reports a live state-directory mismatch and continues Doctor", async () => {
+    vi.stubEnv("OPENCLAW_STATE_DIR", "/tmp/doctor-cli-state");
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", "/tmp/doctor-cli-state/openclaw.json");
+    callGateway.mockImplementation(
+      async (options: {
+        method?: string;
+        onHelloOk?: (hello: { snapshot: { stateDir: string; configPath: string } }) => void;
+      }) => {
+        if (options.method === "status") {
+          options.onHelloOk?.({
+            snapshot: {
+              stateDir: "/tmp/doctor-gateway-state",
+              configPath: "/tmp/doctor-gateway-state/openclaw.json",
+            },
+          });
+        }
+        return {};
+      },
+    );
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+    await expect(
+      checkGatewayHealth({ runtime: runtime as never, cfg: {} as OpenClawConfig }),
+    ).resolves.toMatchObject({ authenticated: true, healthOk: true });
+
+    expect(note).toHaveBeenCalledWith(
+      expect.stringContaining("CLI and live Gateway use different"),
+      "Gateway state directory mismatch",
+    );
+  });
+
   it("uses a lightweight status RPC for the restart liveness gate", async () => {
     callGateway.mockResolvedValueOnce({ ok: true }).mockResolvedValueOnce({});
     const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
@@ -76,12 +111,15 @@ describe("checkGatewayHealth", () => {
       checkGatewayHealth({ runtime: runtime as never, cfg, timeoutMs: 3000 }),
     ).resolves.toEqual({ authenticated: true, healthOk: true, status: { ok: true } });
 
-    expect(callGateway).toHaveBeenNthCalledWith(1, {
-      method: "status",
-      params: { includeChannelSummary: false },
-      timeoutMs: 3000,
-      config: cfg,
-    });
+    expect(callGateway).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        method: "status",
+        params: { includeChannelSummary: false },
+        timeoutMs: 3000,
+        config: cfg,
+      }),
+    );
     expect(callGateway).toHaveBeenNthCalledWith(2, {
       method: "channels.status",
       params: { probe: true, timeoutMs: 5000 },

--- a/src/commands/doctor-gateway-health.ts
+++ b/src/commands/doctor-gateway-health.ts
@@ -3,6 +3,8 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { probeGatewayStatus } from "../cli/daemon-cli/probe.js";
+import { compareCliGatewayStateDirs, type GatewayHello } from "../cli/state-dir-gateway-check.js";
+import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   buildGatewayConnectionDetails,
@@ -91,6 +93,22 @@ export async function checkGatewayHealth(params: {
       params: { includeChannelSummary: false },
       timeoutMs,
       config: params.cfg,
+      onHelloOk: ({ snapshot }: GatewayHello) => {
+        if (!snapshot.stateDir) {
+          return;
+        }
+        const comparison = compareCliGatewayStateDirs({
+          cliStateDir: resolveStateDir(process.env),
+          cliConfigPath: resolveConfigPath(process.env),
+          gatewayStateDir: snapshot.stateDir,
+          gatewayConfigPath: snapshot.configPath,
+          source: "live Gateway",
+          mode: "warn",
+        });
+        if (comparison.kind === "warn") {
+          note(comparison.message, "Gateway state directory mismatch");
+        }
+      },
     });
     healthOk = true;
     noteCliGatewayVersionSkew(status);


### PR DESCRIPTION
## What Problem This Solves

Local credential and configuration commands could report success while writing to a state directory that the running Gateway never reads. This happens when the CLI and Gateway use different `OPENCLAW_STATE_DIR` or `OPENCLAW_CONFIG_PATH` values.

## Why This Change Was Made

The CLI command catalog now marks `models auth`, `channels add`, `channels login`, and `configure` as local state writers. One global Commander pre-action checks those commands before bootstrap or action code can persist state.

The check uses this evidence order:

1. An authenticated admin hello provides the live Gateway paths.
2. If no hello arrives, an installed Gateway service provides its configured paths, whether running or stopped.
3. If credentials block the hello and no service exists, a read-only protocol probe can warn that a Gateway is present but cannot expose its paths.

Proven path mismatches refuse the write. Remote or unverifiable Gateway paths warn. An offline host with no installed service stays silent. The check adds no waiver flag, config key, protocol field, or storage migration.

Doctor reuses the same path comparison in warning mode after its existing authenticated status hello.

## User Impact

Operators no longer get a false success from the guarded local setup and credential commands when a live or installed Gateway uses another state tree. The refusal shows the exact quoted state/config environment needed to target the Gateway.

Intentional writes to another local tree require stopping the running Gateway, or uninstalling or reconfiguring the divergent installed service first.

## Evidence

- Baseline `e44c4b8a3e0e9e8bae58ebf1a50e239176d8e4cd`: a real `channels add` command returned success and wrote the Telegram token into the CLI config while an authenticated admin hello reported a different Gateway state directory. The refusal contract failed.
- Head `41d56a74efa55ad36634fa4f87ff7138db1ced09`: the same command raised `No credentials or configuration were written`; the CLI config contained no token; the same authenticated hello still reported the different Gateway directory.
- Anti-cheat: the proof read the Gateway path from the post-command authenticated admin hello. It did not infer the path from the CLI environment or an open TCP port.
- Real Gateway coverage: matching token-auth paths allow, mismatched token-auth paths refuse, and a tokenless CLI against a token Gateway warns from protocol evidence only.
- Focused local proof: 55 CLI tests and 21 Doctor tests passed; targeted Oxlint, Oxfmt, and `git diff --check` passed. Local TypeScript build/typecheck commands were not run under the host safety rule; exact-head CI owns them.
- Pre-commit Autoreview: clean, no accepted P0 finding.
- Size: production `+198/-2`, tests and test support `+548/-8`, docs `+6`.

<!-- team-session: source-thread 01a040d7-aa3d-7433-83eb-de7f49979443 -->
