### PR TITLE
fix(gateway): bound unattributable proxy warnings per source

### DIFF
--- a/src/gateway/ingress-attribution.test.ts
+++ b/src/gateway/ingress-attribution.test.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage } from "node:http";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  PROXY_ATTRIBUTION_GUIDANCE,
   createGatewayUnattributableProxyReporter,
   markGatewayIngressTransport,
   prepareGatewayIngressAttribution,
@@ -27,6 +28,10 @@ function request(params?: {
     },
   } as IncomingMessage;
 }
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("gateway ingress attribution", () => {
   it("keeps clean headerless loopback on the ordinary listener local", async () => {
@@ -156,23 +161,112 @@ describe("gateway ingress attribution", () => {
     });
   });
 
-  it("emits one bounded operator warning for repeated unattributable traffic", async () => {
+  it("reports distinct unattributable proxy sources while suppressing repeats", async () => {
     const warn = vi.fn();
     const report = createGatewayUnattributableProxyReporter({ warn });
     const first = prepareGatewayIngressAttribution({
-      req: request({ forwardedFor: "100.64.0.10" }),
+      req: request({ remoteAddress: "192.0.2.10", forwardedFor: "100.64.0.10" }),
     });
     const second = prepareGatewayIngressAttribution({
-      req: request({ forwardedFor: "100.64.0.11" }),
+      req: request({ remoteAddress: "192.0.2.11", forwardedFor: "100.64.0.11" }),
     });
     if (first.kind === "unattributable-proxy") {
+      report(first);
       report(first);
     }
     if (second.kind === "unattributable-proxy") {
       report(second);
     }
 
-    expect(warn).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledTimes(2);
+    expect(warn.mock.calls.map(([message]) => message)).toEqual([
+      expect.stringContaining("192.0.2.10"),
+      expect.stringContaining("192.0.2.11"),
+    ]);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("gateway.trustedProxies"));
+  });
+
+  it("reports a continuing source again after the suppression window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const warn = vi.fn();
+    const report = createGatewayUnattributableProxyReporter({ warn });
+    const attribution = prepareGatewayIngressAttribution({
+      req: request({ remoteAddress: "192.0.2.10", forwardedFor: "100.64.0.10" }),
+    });
+    if (attribution.kind !== "unattributable-proxy") {
+      throw new Error("expected unattributable proxy");
+    }
+
+    report(attribution);
+    vi.advanceTimersByTime(5 * 60_000);
+    report(attribution);
+
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps a source suppressed when the aggregate budget refills beside it", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const warn = vi.fn();
+    const report = createGatewayUnattributableProxyReporter({ warn });
+    const attribution = prepareGatewayIngressAttribution({
+      req: request({ remoteAddress: "192.0.2.10", forwardedFor: "100.64.0.10" }),
+    });
+    if (attribution.kind !== "unattributable-proxy") {
+      throw new Error("expected unattributable proxy");
+    }
+
+    // Warn this source one second before the aggregate budget refills.
+    vi.setSystemTime(5 * 60_000 - 1_000);
+    report(attribution);
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    // The budget refills two seconds later; the source is still inside its own window.
+    vi.setSystemTime(5 * 60_000 + 1_000);
+    report(attribution);
+    expect(warn).toHaveBeenCalledTimes(1);
+
+    // It is reported again only once its own five minutes have elapsed.
+    vi.setSystemTime(5 * 60_000 - 1_000 + 5 * 60_000);
+    report(attribution);
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not let continued traffic keep a source suppressed forever", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    const warn = vi.fn();
+    const report = createGatewayUnattributableProxyReporter({ warn });
+    const attribution = prepareGatewayIngressAttribution({
+      req: request({ remoteAddress: "192.0.2.10", forwardedFor: "100.64.0.10" }),
+    });
+    if (attribution.kind !== "unattributable-proxy") {
+      throw new Error("expected unattributable proxy");
+    }
+
+    // A peer that never stops sending must not refresh its own suppression record.
+    for (let minute = 0; minute <= 6; minute += 1) {
+      vi.setSystemTime(minute * 60_000);
+      report(attribution);
+    }
+
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("bounds warnings from a flood of unique proxy sources", async () => {
+    const warn = vi.fn();
+    const report = createGatewayUnattributableProxyReporter({ warn });
+
+    for (let index = 0; index < 1_000; index += 1) {
+      report({
+        kind: "unattributable-proxy",
+        reason: "proxy_attribution_required",
+        guidance: PROXY_ATTRIBUTION_GUIDANCE,
+        remoteAddress: `192.0.2.${index}`,
+      });
+    }
+
+    expect(warn).toHaveBeenCalledTimes(16);
   });
 });

--- a/src/gateway/ingress-attribution.ts
+++ b/src/gateway/ingress-attribution.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage } from "node:http";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { createDedupeCache } from "../infra/dedupe.js";
 import { readTailscaleWhoisIdentity, type TailscaleWhoisIdentity } from "../infra/tailscale.js";
 import {
   hasForwardedRequestHeaders,
@@ -12,6 +13,11 @@ import {
 export const PROXY_ATTRIBUTION_REQUIRED_REASON = "proxy_attribution_required";
 export const PROXY_ATTRIBUTION_GUIDANCE =
   "Configure gateway.trustedProxies narrowly and make the proxy overwrite or safely rebuild forwarded client headers.";
+// Surface a small fleet's distinct peers while capping hostile unique-source log growth.
+// Each source waits out its own window before warning again, so long-lived Gateways keep
+// reporting later incidents without one noisy peer spending the whole budget.
+const UNATTRIBUTABLE_PROXY_WARNING_WINDOW_MS = 5 * 60_000;
+const UNATTRIBUTABLE_PROXY_WARNING_MAX_SOURCES = 16;
 
 export type GatewayTailscaleIngressMode = "serve" | "funnel";
 
@@ -271,16 +277,34 @@ export type GatewayUnattributableProxyReporter = (
   attribution: Extract<GatewayIngressAttribution, { kind: "unattributable-proxy" }>,
 ) => void;
 
-/** Emits one actionable warning per runtime without attacker-controlled log growth. */
+/** Emits bounded, per-source warnings so one rejected peer cannot hide every later peer. */
 export function createGatewayUnattributableProxyReporter(log: {
   warn: (message: string) => void;
 }): GatewayUnattributableProxyReporter {
-  let emitted = false;
+  const reportedSources = createDedupeCache({
+    ttlMs: UNATTRIBUTABLE_PROXY_WARNING_WINDOW_MS,
+    maxSize: UNATTRIBUTABLE_PROXY_WARNING_MAX_SOURCES,
+  });
+  let windowStartedAt = Date.now();
+  let emittedInWindow = 0;
   return (attribution) => {
-    if (emitted) {
+    const now = Date.now();
+    // The aggregate budget refills on its own schedule. Source suppression is left to the
+    // cache's TTL so a peer warned just before a refill still waits out its own window.
+    if (now < windowStartedAt || now - windowStartedAt >= UNATTRIBUTABLE_PROXY_WARNING_WINDOW_MS) {
+      windowStartedAt = now;
+      emittedInWindow = 0;
+    }
+    if (
+      emittedInWindow >= UNATTRIBUTABLE_PROXY_WARNING_MAX_SOURCES ||
+      // Peek rather than check: continued traffic from a suppressed peer must not keep
+      // refreshing its record, or a persistent source would never be reported again.
+      reportedSources.peek(attribution.remoteAddress, now)
+    ) {
       return;
     }
-    emitted = true;
+    reportedSources.check(attribution.remoteAddress, now);
+    emittedInWindow += 1;
     log.warn(
       `gateway: observed unattributable proxy-shaped traffic from ${attribution.remoteAddress}; Gateway-authenticated routes reject it, while plugin-authenticated routes ignore forwarded claims. ${attribution.guidance}`,
     );


### PR DESCRIPTION
## What Problem This Solves

- report each distinct unattributable proxy source instead of permanently silencing the runtime after its first warning
- suppress repeat warnings per source for five minutes and cap each window at 16 distinct-source warnings
- retain unexpired source suppression across adjacent aggregate windows
- recover promptly from wall-clock rollback instead of retaining future-dated suppression records
- preserve the existing fail-closed 403 behavior for both HTTP and WebSocket ingress

Fixes #134297.

## Root cause and repair

`createUnattributableProxyReporter` used a process-lifetime boolean. Because one reporter instance is shared by the Gateway runtime, the first rejected peer consumed the only diagnostic and every later peer was invisible until restart.

The reporter now reuses the repository's bounded dedupe cache as the canonical owner of per-source suppression, with a separate five-minute budget capping each window at 16 distinct-source warnings. The two bounds are independent: the budget refilling does not clear source records, so a peer warned just before a refill still waits out its own five minutes. Source records are read with `peek` rather than `check`, so continued traffic from a suppressed peer cannot keep refreshing its record and silence it permanently.

Because a source TTL can straddle an aggregate reset, the cache retains two adjacent budgets (32 sources). This is the bounded maximum that can remain unexpired while each five-minute aggregate window emits at most 16 warnings; it prevents new-window traffic from evicting a still-suppressed late-window source.

The reporter also tracks its last observed wall-clock time. If the clock moves backward, it resets both the aggregate budget and the per-source cache; otherwise a future-dated source record could suppress that peer until the clock catches up and another five-minute TTL elapses.

No configuration, persistence, protocol, authorization, or HTTP status behavior changes.

## Evidence

- pre-fix regression run failed the original distinct-peer, window-reset, and bounded unique-source expectations
- the near-boundary case fails on the earlier source (`1 failed | 14 passed`) and passes after separating source TTL from aggregate refill (`15 passed`)
- the adjacent-window capacity case deterministically emits an 18th warning with a 16-entry cache and remains at 17 with the two-budget cache
- focused compatibility run including clock rollback and adjacent-window capacity regressions — 13/13 passed on the current source delta
- `pnpm test src/gateway/ingress-attribution.test.ts` — 15/15 passed on the prior head
- `pnpm test src/gateway/server-runtime-state.tailscale.test.ts` — 7/7 passed on the prior head, including shared HTTP/WebSocket deduplication
- ephemeral real Gateway HTTP flow — two proxy-shaped requests from distinct listener peers both returned 403 and produced two source-specific warnings
- targeted `oxfmt` and `oxlint` passed for both files on the current head
- `pnpm tsgo:core` passed on the prior head
- `git diff --check` passed on the current head

Exact-head CI completed with 169 successful checks, 45 intentional skips, and one neutral check. The only underlying failure was an unrelated `src/gateway/server-methods/models-manual-policy.integration.test.ts` state-polling assertion in `checks-node-compact-large-29`; that shard passed its other 3,046 tests, and `openclaw/ci-gate` is red only because it aggregates the failure. All ingress-attribution checks passed. The author account cannot rerun repository workflows because GitHub requires admin access.

## Diff accounting

- production: +37 / -4 (net +33)
- tests: +149 / -5 (net +144)

The production growth is bounded transient diagnostic state, two-window cache capacity, and explicit wall-clock rollback recovery; the old process-lifetime latch is removed.
