### PR TITLE
perf(ui): avoid unused Workboard lifecycle lookups

### DIFF
--- a/ui/src/lib/workboard/derived.ts
+++ b/ui/src/lib/workboard/derived.ts
@@ -117,14 +117,15 @@ export function workboardCardMatchesHealthKey(
   sessions: readonly GatewaySessionRow[],
   task?: WorkboardTaskSummary,
 ): boolean {
-  const lifecycle = getWorkboardLifecycle(card, sessions, task);
   switch (key) {
     case "running":
-      return card.status === "running" || lifecycle.state === "running";
+      return card.status === key || getWorkboardLifecycle(card, sessions, task).state === key;
     case "blocked":
       return card.status === "blocked";
     case "stale":
-      return Boolean(card.metadata?.stale || lifecycle.state === "stale");
+      return Boolean(
+        card.metadata?.stale || getWorkboardLifecycle(card, sessions, task).state === key,
+      );
     case "readyUnassigned":
       return card.status === "ready" && !card.agentId?.trim() && !card.metadata?.claim;
     case "missingProof":
@@ -145,7 +146,6 @@ export function filterWorkboardCardsForPreset(params: {
   const defaultAgentId = params.defaultAgentId?.trim();
   return params.cards.filter((card) => {
     const task = params.tasksByCardId.get(card.id);
-    const lifecycle = getWorkboardLifecycle(card, params.sessions, task);
     switch (params.preset) {
       case "all":
         return true;
@@ -156,13 +156,12 @@ export function filterWorkboardCardsForPreset(params: {
       case "ready":
         return card.status === "ready";
       case "running":
-        return card.status === "running" || lifecycle.state === "running";
+      case "stale":
+        return workboardCardMatchesHealthKey(card, params.preset, params.sessions, task);
       case "blocked":
         return card.status === "blocked";
       case "review":
         return card.status === "review";
-      case "stale":
-        return Boolean(card.metadata?.stale) || lifecycle.state === "stale";
       case "missing_proof":
         return card.status === "done" && !hasWorkboardProofEvidence(card);
       case "recently_done":

--- a/ui/src/pages/workboard/workboard.e2e.test.ts
+++ b/ui/src/pages/workboard/workboard.e2e.test.ts
@@ -13,6 +13,7 @@ import type {
   WorkboardCard,
   WorkboardStatus,
 } from "../../lib/workboard/index.ts";
+import { createControlUiE2eArtifactDir } from "../../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   controlUiE2eWaitTimeoutMs,
   installMockGateway,
@@ -27,7 +28,6 @@ const suite = createControlUiE2eSuite({
 });
 
 const captureUiProofEnabled = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
-const artifactDir = path.resolve(process.cwd(), ".artifacts/control-ui-e2e/workboard");
 const viewport = { height: 1000, width: 2400 };
 const baseTime = Date.parse("2026-06-01T18:00:00.000Z");
 const linkedSessionKey = "agent:main:workboard-proof";
@@ -51,9 +51,18 @@ type RecordedPage = {
 };
 
 type ProofArtifacts = {
+  directory: string;
   screenshots: string[];
   videos: string[];
 };
+
+function createProofArtifacts(scope: string): ProofArtifacts {
+  return {
+    directory: captureUiProofEnabled ? createControlUiE2eArtifactDir(scope) : "",
+    screenshots: [],
+    videos: [],
+  };
+}
 
 const requireRecord = createRequireRecord("record", "expected-object-value");
 
@@ -297,12 +306,12 @@ function cardInColumn(page: Page, status: string, title: string) {
 }
 
 async function newRecordedPage(
+  artifacts: ProofArtifacts,
   label: string,
   options: { hasTouch?: boolean } = {},
 ): Promise<RecordedPage> {
-  const rawVideoDir = path.join(artifactDir, `${label}-raw`);
+  const rawVideoDir = path.join(artifacts.directory, `${label}-raw`);
   if (captureUiProofEnabled) {
-    await rm(rawVideoDir, { force: true, recursive: true });
     await mkdir(rawVideoDir, { recursive: true });
   }
   let context: BrowserContext | undefined;
@@ -321,9 +330,6 @@ async function newRecordedPage(
   } catch (error) {
     await page?.close().catch(() => {});
     await context?.close().catch(() => {});
-    if (captureUiProofEnabled) {
-      await rm(rawVideoDir, { force: true, recursive: true });
-    }
     throw error;
   }
 }
@@ -336,7 +342,7 @@ async function captureScreenshot(
   if (!captureUiProofEnabled) {
     return;
   }
-  const screenshotPath = path.join(artifactDir, `${name}.png`);
+  const screenshotPath = path.join(artifacts.directory, `${name}.png`);
   await page.screenshot({ fullPage: true, path: screenshotPath });
   artifacts.screenshots.push(screenshotPath);
 }
@@ -347,28 +353,21 @@ async function closeRecordedPage(
   label: string,
 ): Promise<void> {
   const video = recorded.page.video();
-  try {
-    await recorded.context.close();
-    if (!video) {
-      return;
-    }
-    const rawVideoPath = await video.path();
-    const videoPath = path.join(artifactDir, `${label}.webm`);
-    await copyFile(rawVideoPath, videoPath);
-    artifacts.videos.push(videoPath);
-  } finally {
-    if (captureUiProofEnabled) {
-      await rm(recorded.rawVideoDir, { force: true, recursive: true });
-    }
+  await recorded.context.close();
+  if (!video) {
+    return;
   }
+  const rawVideoPath = await video.path();
+  const videoPath = path.join(artifacts.directory, `${label}.webm`);
+  await copyFile(rawVideoPath, videoPath);
+  artifacts.videos.push(videoPath);
+  // Preserve the raw recording if close or copy fails; only remove the retained copy's source.
+  await rm(recorded.rawVideoDir, { force: true, recursive: true });
 }
 
 suite.define(() => {
   it("persists Workboard create, edit, running move, lifecycle sync, reload, and read-only state", async () => {
-    if (captureUiProofEnabled) {
-      await rm(artifactDir, { force: true, recursive: true });
-    }
-    const artifacts: ProofArtifacts = { screenshots: [], videos: [] };
+    const artifacts = createProofArtifacts("workboard-lifecycle");
     const createdCard = card({
       id: "card-1",
       labels: ["ui", "proof"],
@@ -410,7 +409,7 @@ suite.define(() => {
       updatedAt: baseTime + 5,
     });
 
-    const writable = await newRecordedPage("workboard-writable");
+    const writable = await newRecordedPage(artifacts, "workboard-writable");
     await writable.page.clock.install();
     try {
       const writableGateway = await installMockGateway(writable.page, {
@@ -708,7 +707,7 @@ suite.define(() => {
       await closeRecordedPage(writable, artifacts, "workboard-writable");
     }
 
-    const readOnly = await newRecordedPage("workboard-read-only");
+    const readOnly = await newRecordedPage(artifacts, "workboard-read-only");
     try {
       const readOnlyGateway = await installMockGateway(readOnly.page, {
         methodResponses: {
@@ -755,7 +754,7 @@ suite.define(() => {
 
     if (captureUiProofEnabled) {
       await writeFile(
-        path.join(artifactDir, "manifest.json"),
+        path.join(artifacts.directory, "manifest.json"),
         `${JSON.stringify(artifacts, null, 2)}\n`,
         "utf-8",
       );
@@ -763,7 +762,7 @@ suite.define(() => {
   });
 
   it("keeps card titles visible when a column overflows its height", async () => {
-    const artifacts: ProofArtifacts = { screenshots: [], videos: [] };
+    const artifacts = createProofArtifacts("workboard-overflow");
     const crowdedColumnCardCount = 8;
     const overflowTitle = (index: number) =>
       `Overflowing backlog card ${index + 1} with a long title that wraps onto two lines`;
@@ -778,7 +777,7 @@ suite.define(() => {
       }),
     );
 
-    const recorded = await newRecordedPage("workboard-overflow");
+    const recorded = await newRecordedPage(artifacts, "workboard-overflow");
     try {
       await installMockGateway(recorded.page, {
         methodResponses: {
@@ -816,7 +815,7 @@ suite.define(() => {
   });
 
   it("collapses empty stages into rails without squeezing active columns", async () => {
-    const artifacts: ProofArtifacts = { screenshots: [], videos: [] };
+    const artifacts = createProofArtifacts("workboard-collapsed-columns");
     const reviewCard = card({
       id: "review-card",
       status: "review",
@@ -827,7 +826,7 @@ suite.define(() => {
       status: "done",
       title: "Previously completed work",
     });
-    const recorded = await newRecordedPage("workboard-collapsed-columns");
+    const recorded = await newRecordedPage(artifacts, "workboard-collapsed-columns");
     try {
       const gateway = await installMockGateway(recorded.page, {
         methodResponses: {
@@ -989,7 +988,7 @@ suite.define(() => {
   });
 
   it("filters persisted boards and keeps the selection in the URL", async () => {
-    const artifacts: ProofArtifacts = { screenshots: [], videos: [] };
+    const artifacts = createProofArtifacts("workboard-board-filter");
     const defaultCard = card({ id: "default-card", title: "Default board work" });
     const opsCard = card({
       id: "ops-card",
@@ -1016,7 +1015,7 @@ suite.define(() => {
         archivedAt: baseTime,
       },
     ];
-    const recorded = await newRecordedPage("workboard-board-filter");
+    const recorded = await newRecordedPage(artifacts, "workboard-board-filter");
     try {
       await installMockGateway(recorded.page, {
         methodResponses: {


### PR DESCRIPTION
## What Problem This Solves

Workboard prepares lifecycle state while evaluating filters that never use it. A normal board view evaluates the active preset, health totals and all nine preset counts, repeating session searches and task-state projection for discarded results.

## Why This Change Was Made

Resolve lifecycle only in the running/stale health predicates, and reuse those existing predicates for the matching presets. The lifecycle owner, task precedence, stale/recent-done thresholds, ordering and card identity remain unchanged. There is no cache or shared clock snapshot. The production diff is **+6/−7, net −1 line**.

While obtaining browser evidence, the existing recorder was found to delete a shared capture directory and remove raw video even after a failed copy. The same PR adopts the existing exclusive artifact allocator per recording scenario and removes raw video only after a successful retained copy. All assertions, fixtures, viewports and waits are unchanged; test delta is **+32/−33, net −1 line**. The identical capture-only repair was used for both production variants.

## User Impact

Less CPU work in Workboard data preparation, with unchanged filtering and presentation. Workboard remains an optional plugin. This is an internal performance/refactoring change, without a new setting, schema, dependency or user-facing contract.

Running-only filtering is a measured tradeoff: it still needs lifecycle resolution and now calls the shared predicate. Its isolated cost increased by 0.009–0.014 µs for one mixed card, 0.039–0.058 µs for 12 mixed cards, and 0.147–0.206 µs for 12 eligible cards. These costs are retained, not described as wins.

## Evidence

Measured the complete changed-owner data composition used by the initial `all` view: active preset, health summary and nine preset counts. This excludes the page's other filters, grouping, translations, Lit and DOM rendering; **these are not browser-render or Gateway latency numbers**.

| Cards | Before → candidate, forward | Before → candidate, reverse |
| --- | --- | --- |
| 1 mixed | 0.541 → 0.459 µs | 0.544 → 0.437 µs |
| 12 mixed | 5.743 → 3.756 µs | 5.952 → 3.849 µs |
| 100 mixed | 264.579 → 67.967 µs | 263.025 → 67.725 µs |

The ordinary 12-card operation improved 34.6%/35.3%. All nonempty health-summary controls improved in both orders. The 50-row inventory contains 39 rows faster in both orders, four slower in both, and seven mixed; it is not a traffic-weighted speedup. Besides the running-only costs above, eligible stale has a reverse cost of 0.002 µs; the empty composition costs less than 0.001 µs. All rows and samples, including adverse controls, are retained locally.

Four fresh processes used before/candidate/candidate/before order, fixed workload order and iteration counts, eight warmups and nine measured blocks per row. All **1,800 measured blocks and 200 first-call observations** are retained and independently recomputed; 1,600 warmup durations were discarded. There was no calibration, dropped sample or timing retry. First calls are not startup measurements. Source/compile capture was `71785b8`; proof/timing ran at `37db48c`, with a separate current-source audit at `ad6a81d` confirming no relevant drift.

Correctness proof covers 607 differential fixtures with producer checks, 53 independent assertions and 50 overlapping workload oracles; these counts must not be added as independent scenarios. It covers every preset/health key, clock boundaries, task/session precedence, order/aliasing and nonmutation. The supported producer is normalized JSON data with native Maps, not arbitrary accessors or Proxies. Canonical Workboard suites passed 269 tests before; the candidate plus existing artifact-allocator suite passed 276. Changed-file checks, typechecking, i18n validation and lint passed. The full `pnpm build` passed on committed head `4d306bc88e2` in 158 seconds; this duration is verification, not a speedup measurement. Independent source/evidence review found no actionable issue; managed Codex review was clean at its P0 threshold.

The actual UI bundle ran in signed Chrome with a fresh profile and the canonical mock Gateway. **All five scenarios passed before and after**, covering create/edit/drag, lifecycle/reload/read-only behavior, overflow, collapsed desktop/mobile columns, touch and board selection. Each run retained 14 screenshots and five videos in separate directories; all 35 observed processes and nine process groups were gone afterward. No live user profile, credential or external channel was involved. This proves the UI flow, not backend reconciliation or render latency. Four screenshot pairs are byte-identical; other pairs differ, including two with one-pixel page-height differences. Overall pixel identity is not claimed.

Before — synthetic running-card fixture:

![Workboard before](https://github.com/user-attachments/assets/228dabfc-85a7-4140-80f2-0a4e838a82fa)

After — the same fixture, byte-identical capture:

![Workboard after](https://github.com/user-attachments/assets/e22f76ac-56d4-42f1-b2dd-2a3f562709e4)

The capture fix is deliberately bounded. Related evidence-retention follow-ups remain in `ui/src/pages/workboard/workboard-routing.e2e.test.ts`, `ui/src/pages/skill-workshop/evaluation.e2e.test.ts` and `ui/src/pages/tasks/tasks.e2e.test.ts`; this PR does not claim those recorders are repaired. An initial candidate-test invocation named the nonexistent allocator test without its `.node` suffix and failed before tests; the corrected canonical invocation passed. Earlier compiler preparation failures and all original artifacts remain retained.

Review follow-up: the fresh ClawSweeper review found no correctness/security finding and accepted the UI evidence. Its stored-data classifier flags “vector/embedding metadata” in `derived.ts`, but this diff changes only read-only predicate evaluation and test artifact paths. Workboard stored types, normalization, Gateway writes, database definitions and migration code are unchanged; there is no data-model change requiring an upgrade migration. The performance tradeoffs remain explicitly accepted for this owner. Normal exact-head CI and the authorized maintainer landing are still required.
