### PR TITLE
fix(install): fail when OpenClaw is not on PATH

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -2173,8 +2173,9 @@ function Main {
     }
 
     if (-not (Ensure-OpenClawOnPath)) {
-        Write-Host "Install completed, but OpenClaw is not on PATH yet." -ForegroundColor Yellow
+        Write-Host "OpenClaw was installed, but its command is not on PATH." -ForegroundColor Yellow
         Write-Host "Open a new terminal, then run: openclaw doctor" -ForegroundColor Cyan
+        Fail-Install
         return
     }
 

--- a/test/scripts/install-ps1.test.ts
+++ b/test/scripts/install-ps1.test.ts
@@ -67,10 +67,23 @@ function createFailingNodeFixture(source: string): string {
   ].join("\n");
 }
 
-function createDeferredPathSuccessFixture(source: string): string {
+function createMissingPathFailureFixture(source: string, catchFailure = false): string {
   const scriptWithoutEntryPoint = source.replace(ENTRYPOINT_RE, "");
   const entrypointLines = extractEntrypointLines(source);
   expect(scriptWithoutEntryPoint).not.toBe(source);
+
+  const entrypoint = catchFailure
+    ? [
+        "$caught = $false",
+        "try {",
+        ...entrypointLines.map((line) => `  ${line}`),
+        "} catch {",
+        "  if ($_.Exception.Message -ne 'OpenClaw installation failed with exit code 1.') { throw }",
+        "  $caught = $true",
+        "}",
+        "if (-not $caught) { throw 'Missing PATH did not fail the install' }",
+      ]
+    : entrypointLines;
 
   return [
     scriptWithoutEntryPoint,
@@ -84,7 +97,7 @@ function createDeferredPathSuccessFixture(source: string): string {
     "function Ensure-OpenClawOnPath { return $false }",
     "$NoOnboard = $true",
     "",
-    ...entrypointLines,
+    ...entrypoint,
     "",
   ].join("\n");
 }
@@ -686,8 +699,8 @@ describe("install.ps1 failure handling", () => {
         ].join("\n"),
       },
       {
-        name: "scriptblock-deferred-path-success",
-        source: createDeferredPathSuccessFixture(source),
+        name: "scriptblock-missing-path-failure",
+        source: createMissingPathFailureFixture(source, true),
       },
       {
         name: "noisy-git-failure",
@@ -1756,12 +1769,12 @@ try {
   });
 
   runConcurrentIfPowerShell(
-    "exits zero after install succeeds with deferred PATH discovery",
+    "exits non-zero when the installed command is not on PATH",
     async () => {
       const tempDir = mkdtempSync(join(tmpdir(), "openclaw-install-ps1-"));
       const scriptPath = join(tempDir, "install.ps1");
       try {
-        writeFileSync(scriptPath, createDeferredPathSuccessFixture(source));
+        writeFileSync(scriptPath, createMissingPathFailureFixture(source));
         chmodSync(scriptPath, 0o755);
 
         const result = await runPowerShellAsync([
@@ -1773,8 +1786,10 @@ try {
           scriptPath,
         ]);
 
-        expect(result.status).toBe(0);
-        expect(`${result.stdout}\n${result.stderr}`).not.toContain("installation failed");
+        expect(result.status).toBe(1);
+        expect(`${result.stdout}\n${result.stderr}`).toContain(
+          "OpenClaw was installed, but its command is not on PATH",
+        );
       } finally {
         rmSync(tempDir, { force: true, recursive: true });
       }
@@ -1785,8 +1800,8 @@ try {
     expectBatchedPowerShellCase("scriptblock-failure");
   });
 
-  runIfPowerShell("accepts deferred PATH discovery when run as a scriptblock", () => {
-    expectBatchedPowerShellCase("scriptblock-deferred-path-success");
+  runIfPowerShell("fails missing PATH discovery when run as a scriptblock", () => {
+    expectBatchedPowerShellCase("scriptblock-missing-path-failure");
   });
 
   runIfPowerShell("treats noisy Git install false as failure", () => {


### PR DESCRIPTION
Related: #133869

## What Problem This Solves

Fixes an issue where the Windows installer could exit successfully after installing OpenClaw even though it could not find the installed command or add its directory to PATH. Automation saw exit code 0 even though the next documented command could not run.

## Why This Change Was Made

The existing missing-PATH branch now records failure through the installer's canonical `Fail-Install` state before returning. This preserves the actionable PATH guidance while making both script-file and piped/scriptblock callers receive the existing non-zero failure outcome.

## User Impact

Windows users and installation automation now get a failure status when the installed `openclaw` command is unusable from PATH, instead of a false successful install.

## Evidence

Redacted after-fix Windows trace from both installed PowerShell engines:

```text
powershell file:        exit=1, missing-PATH guidance present
powershell scriptblock: caught "OpenClaw installation failed with exit code 1."
pwsh file:              exit=1, missing-PATH guidance present
pwsh scriptblock:       caught "OpenClaw installation failed with exit code 1."
```

The probe exercised `Main` and `Complete-Install` with successful installation stubs and `Ensure-OpenClawOnPath = false`; it did not bypass the changed failure owner.

- Updated the committed script-file fixture to require exit code 1.
- Updated the committed scriptblock fixture to require the canonical terminating error.
- `oxfmt` and `git diff --check` passed.
- Fresh commit-scoped Codex autoreview: no actionable findings, patch correct, confidence 0.87.
- Hosted [Windows installer CI passed](https://github.com/openclaw/openclaw/actions/runs/33428753311/job/99608661561).
