### PR TITLE
test(tooling): advance the realtime smoke verdict clock

### DIFF
--- a/test/scripts/realtime-talk-live-smoke.test.ts
+++ b/test/scripts/realtime-talk-live-smoke.test.ts
@@ -2,6 +2,8 @@ import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
 import type { RealtimeVoiceBridgeCreateRequest } from "../../src/talk/provider-types.js";
 
+const backend = vi.hoisted(() => ({ onFirstAudio: () => {} }));
+
 const browser = vi.hoisted(() => ({
   close: vi.fn(async () => {}),
   contextClose: vi.fn(async () => {}),
@@ -34,6 +36,7 @@ vi.mock("playwright", () => ({
 vi.mock("../../extensions/openai/realtime-voice-provider.ts", () => ({
   buildOpenAIRealtimeVoiceProvider: () => ({
     createBridge: (options: RealtimeVoiceBridgeCreateRequest) => {
+      const onFirstAudio = backend.onFirstAudio;
       let responded = false;
       return {
         connect: async () => {},
@@ -44,6 +47,7 @@ vi.mock("../../extensions/openai/realtime-voice-provider.ts", () => ({
             return;
           }
           responded = true;
+          onFirstAudio();
           options.onAudio(Buffer.alloc(1024));
           options.onTranscript?.("user", "glacier", true);
           options.onTranscript?.("assistant", "glacier", true);
@@ -68,6 +72,8 @@ const originalArgv = process.argv;
 const originalExitCode = process.exitCode;
 
 afterEach(() => {
+  vi.useRealTimers();
+  backend.onFirstAudio = () => {};
   process.argv = originalArgv;
   process.exitCode = originalExitCode;
   vi.unstubAllEnvs();
@@ -155,7 +161,21 @@ it.each([
     ];
     process.exitCode = undefined;
 
-    await import("../../scripts/dev/realtime-talk-live-smoke.ts");
+    const firstAudio = new Promise<void>((resolve) => {
+      backend.onFirstAudio = () => resolve();
+    });
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    const command = import("../../scripts/dev/realtime-talk-live-smoke.ts");
+    // Let imports reach streaming before advancing the pacing and close-observation timers.
+    await Promise.race([
+      firstAudio,
+      command.then(() => {
+        throw new Error("Smoke command completed before sending backend audio");
+      }),
+    ]);
+    await vi.runAllTimersAsync();
+    await command;
+    expect(vi.getTimerCount()).toBe(0);
 
     expect(output).toHaveBeenCalledWith("openai-backend-bridge: ok", expect.any(Object));
     expect(output).toHaveBeenCalledWith("openai-backend-audio-roundtrip: ok", expect.any(Object));


### PR DESCRIPTION
## What problem does this PR solve?

The six smoke-command verdict tests use mocked audio and browser results but still wait for real audio pacing and close-observation timers. Together they request 1,740 ms of wall-clock delay unrelated to the browser verdicts they check.

## Why this approach?

Install fake timeout functions before importing the command, then wait for the existing mock bridge to receive its first audio before advancing the clock. This lets module loading finish normally and retains every pacing callback, the original command result, all six browser-verdict cases, and their existing output, exit-code and cleanup assertions. Each case also checks that no timers remain; teardown restores the real clock and existing process/global state.

## User impact

Test-only change: production +0/-0; tests +21/-1. The source-derived saving is 6 × (38 × 5 ms + 100 ms) of requested delay, with all 234 timer callbacks retained. This is not a measured suite-wide speedup or live provider/browser proof.

## Evidence

All 66 selected tests pass before and after: six smoke-command verdicts and 60 development-tooling safety cases. Full changed-file checks and Codex autoreview pass.

`node scripts/run-vitest.mjs test/scripts/realtime-talk-live-smoke.test.ts test/scripts/dev-tooling-safety.test.ts`

A temporary fault withheld only the mock response completion event. The existing backend-success assertion failed after the unchanged 60,000 ms virtual deadline and 100 ms close observation. All 38 audio chunks were still sent; the command recorded the failed round trip, set exit code 1, closed the browser and context, and left zero timers and no unhandled errors. The diagnostic joined its process tree and restored the exact source, real timers, argv and exit code.

Follow-up: the unchanged Google Live browser callback calls a Node-imported error formatter after clearing its timer. Direct source and installed Playwright inspection show that this helper is not available in the serialized browser callback, which can leave completion and cleanup pending after a processing error. This is source evidence, not a live reproduction; a separate repair needs a real browser-realm/local-WebSocket failure probe. These OpenAI-only verdict tests do not cover that Google path.
