### PR TITLE
test: initialize upgrade baseline before legacy fixtures

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/config-parking.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/config-parking.mjs
@@ -34,40 +34,6 @@ function snapshotAndReplace(configPath, snapshotPath, authoredConfig, parkedConf
   );
 }
 
-function parkPrepublish(configPath, snapshotPath) {
-  requirePaths("park-prepublish", configPath, snapshotPath);
-  const authoredConfig = fs.readFileSync(configPath);
-  const config = JSON.parse(authoredConfig.toString("utf8"));
-  requireObject(config, "prepublish auth config");
-  for (const key of ["plugins", "channels", "gateway"]) {
-    const value = config[key];
-    if (value !== undefined) {
-      requireObject(value, `prepublish auth config ${key}`);
-    }
-  }
-  if (config.plugins?.allow !== undefined && !Array.isArray(config.plugins.allow)) {
-    throw new Error("prepublish auth config plugins.allow must be an array");
-  }
-  if (config.plugins?.entries !== undefined) {
-    requireObject(config.plugins.entries, "prepublish auth config plugins.entries");
-  }
-  if (config.gateway?.reload !== undefined) {
-    requireObject(config.gateway.reload, "prepublish auth config gateway.reload");
-  }
-  if (Array.isArray(config.plugins?.allow)) {
-    config.plugins.allow = config.plugins.allow.filter((id) => id !== "whatsapp");
-  }
-  if (config.plugins?.entries) {
-    delete config.plugins.entries.whatsapp;
-  }
-  if (config.channels) {
-    delete config.channels.whatsapp;
-  }
-  config.gateway ??= {};
-  config.gateway.reload = { ...config.gateway.reload, mode: "off" };
-  snapshotAndReplace(configPath, snapshotPath, authoredConfig, config);
-}
-
 function parkRestartProbe(configPath, snapshotPath, rawPort) {
   requirePaths("park-restart-probe", configPath, snapshotPath);
   const port = Number(rawPort);
@@ -119,9 +85,6 @@ const [command, configPath, snapshotPath, port] = process.argv.slice(2);
 
 try {
   switch (command) {
-    case "park-prepublish":
-      parkPrepublish(configPath, snapshotPath);
-      break;
     case "park-restart-probe":
       parkRestartProbe(configPath, snapshotPath, port);
       break;
@@ -133,7 +96,7 @@ try {
       break;
     default:
       throw new Error(
-        "usage: config-parking.mjs <park-prepublish|park-restart-probe|park-companion-install|restore> <config-path> <snapshot-path> [port]",
+        "usage: config-parking.mjs <park-restart-probe|park-companion-install|restore> <config-path> <snapshot-path> [port]",
       );
   }
 } catch (error) {

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -128,7 +128,7 @@ SYSTEMCTL_SHIM_LOG="$ARTIFACT_ROOT/systemctl-shim.log"
 SYSTEMCTL_SHIM_PID_FILE="$ARTIFACT_ROOT/systemctl-shim.pid"
 SYSTEMCTL_SHIM_DAEMON_LOG="$ARTIFACT_ROOT/systemctl-shim-gateway.log"
 CONFIG_COVERAGE_JSON="$ARTIFACT_ROOT/config-recipe.json"
-PREPUBLISH_AUTHORED_CONFIG="$RUNTIME_ROOT/prepublish-authored-openclaw.json"
+RESTART_AUTHORED_CONFIG="$RUNTIME_ROOT/restart-authored-openclaw.json"
 export OPENCLAW_UPGRADE_SURVIVOR_CONFIG_COVERAGE_JSON="$CONFIG_COVERAGE_JSON"
 rm -f "$SUMMARY_JSON" "$CONFIG_COVERAGE_JSON"
 : >"$PHASE_LOG"
@@ -354,12 +354,14 @@ trap 'on_signal SIGINT 130' INT
 trap 'on_signal SIGTERM 143' TERM
 
 phase() {
-  local name="$1"
+  local name="$1" phase_status
   shift
   CURRENT_PHASE="$name"
   echo "==> upgrade-survivor:$name"
   json_event "$name" started
   "$@"
+  phase_status=$?
+  [ "$phase_status" -eq 0 ] || return "$phase_status"
   json_event "$name" passed
   CURRENT_PHASE=""
 }
@@ -481,27 +483,22 @@ configure_clawhub_fixture() {
   export OPENCLAW_CLAWHUB_URL="http://127.0.0.1:$(cat "$port_file")"
 }
 
-prepublish_auto_auth_enabled() {
-  [ "$UPDATE_RESTART_MODE" = "auto-auth" ] &&
-    [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ]
-}
-
-park_prepublish_authored_config() {
-  prepublish_auto_auth_enabled || return 0
+park_update_restart_authored_config() {
+  # Establish only the authenticated service target. The candidate update must
+  # receive the untouched migration specimen and own plugin consent/convergence.
   node "${OPENCLAW_UPGRADE_SURVIVOR_CONFIG_PARKING_HELPER:-scripts/e2e/lib/upgrade-survivor/config-parking.mjs}" \
-    park-prepublish "$OPENCLAW_CONFIG_PATH" "$PREPUBLISH_AUTHORED_CONFIG"
+    park-restart-probe "$OPENCLAW_CONFIG_PATH" "$RESTART_AUTHORED_CONFIG" 18789
 }
 
 assert_prepublish_fixture_idle() {
-  prepublish_auto_auth_enabled || return 0
+  [ -n "${OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR:-}" ] || return 0
   node "${OPENCLAW_UPGRADE_SURVIVOR_CLAWHUB_FIXTURE_SERVER:-scripts/e2e/lib/clawhub-fixture-server.cjs}" \
     assert-no-requests "$OPENCLAW_CLAWHUB_URL"
 }
 
-restore_prepublish_authored_config() {
-  prepublish_auto_auth_enabled || return 0
+restore_update_restart_authored_config() {
   node "${OPENCLAW_UPGRADE_SURVIVOR_CONFIG_PARKING_HELPER:-scripts/e2e/lib/upgrade-survivor/config-parking.mjs}" \
-    restore "$OPENCLAW_CONFIG_PATH" "$PREPUBLISH_AUTHORED_CONFIG"
+    restore "$OPENCLAW_CONFIG_PATH" "$RESTART_AUTHORED_CONFIG"
 }
 
 configure_plugin_registry() {
@@ -821,7 +818,7 @@ install_baseline() {
   fi
 }
 
-seed_state() {
+initialize_state() {
   local account_home=""
   openclaw_e2e_eval_test_state_from_b64 "${OPENCLAW_TEST_STATE_FUNCTION_B64:?missing OPENCLAW_TEST_STATE_FUNCTION_B64}"
   if [ "$ROOT_MANAGED_VPS" = "1" ]; then
@@ -847,7 +844,6 @@ seed_state() {
     export OPENCLAW_CONFIG_PATH="$OPENCLAW_STATE_DIR/openclaw.json"
   fi
   export OPENCLAW_UPGRADE_SURVIVOR_BASELINE_VERSION="$baseline_version"
-  node scripts/e2e/lib/upgrade-survivor/assertions.mjs seed
 }
 
 apply_baseline_config_recipe() {
@@ -878,92 +874,6 @@ export OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG="$SYSTEMCTL_SHIM_DAEM
 export OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_JSON="$BASELINE_SERVICE_INSTALL_JSON"
 export OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_ERR="$BASELINE_SERVICE_INSTALL_ERR"
 
-seed_update_restart_probe_device_auth() {
-  node --input-type=module <<'NODE'
-import crypto from "node:crypto";
-import fs from "node:fs";
-import path from "node:path";
-
-const stateDir = process.env.OPENCLAW_STATE_DIR;
-if (!stateDir) {
-  throw new Error("missing OPENCLAW_STATE_DIR");
-}
-
-const base64UrlEncode = (buf) =>
-  buf.toString("base64").replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/g, "");
-const ed25519SpkiPrefix = Buffer.from("302a300506032b6570032100", "hex");
-const { publicKey, privateKey } = crypto.generateKeyPairSync("ed25519");
-const publicKeyPem = publicKey.export({ type: "spki", format: "pem" });
-const privateKeyPem = privateKey.export({ type: "pkcs8", format: "pem" });
-const spki = crypto.createPublicKey(publicKeyPem).export({ type: "spki", format: "der" });
-const rawPublicKey =
-  spki.length === ed25519SpkiPrefix.length + 32 &&
-  spki.subarray(0, ed25519SpkiPrefix.length).equals(ed25519SpkiPrefix)
-    ? spki.subarray(ed25519SpkiPrefix.length)
-    : spki;
-const publicKeyRaw = base64UrlEncode(rawPublicKey);
-const deviceId = crypto.createHash("sha256").update(rawPublicKey).digest("hex");
-const token = base64UrlEncode(crypto.randomBytes(32));
-const now = Date.now();
-const scopes = ["operator.read"];
-
-function writeJson(filePath, value) {
-  fs.mkdirSync(path.dirname(filePath), { recursive: true });
-  fs.writeFileSync(filePath, `${JSON.stringify(value, null, 2)}\n`, { mode: 0o600 });
-  try {
-    fs.chmodSync(filePath, 0o600);
-  } catch {
-    // best-effort inside Docker
-  }
-}
-
-writeJson(path.join(stateDir, "identity", "device.json"), {
-  version: 1,
-  deviceId,
-  publicKeyPem,
-  privateKeyPem,
-  createdAtMs: now,
-});
-writeJson(path.join(stateDir, "identity", "device-auth.json"), {
-  version: 1,
-  deviceId,
-  tokens: {
-    operator: {
-      token,
-      role: "operator",
-      scopes,
-      updatedAtMs: now,
-    },
-  },
-});
-writeJson(path.join(stateDir, "devices", "paired.json"), {
-  [deviceId]: {
-    deviceId,
-    publicKey: publicKeyRaw,
-    displayName: "upgrade survivor restart probe",
-    platform: process.platform,
-    clientId: "upgrade-survivor",
-    clientMode: "probe",
-    role: "operator",
-    roles: ["operator"],
-    scopes,
-    approvedScopes: scopes,
-    tokens: {
-      operator: {
-        token,
-        role: "operator",
-        scopes,
-        createdAtMs: now,
-      },
-    },
-    createdAtMs: now,
-    approvedAtMs: now,
-  },
-});
-writeJson(path.join(stateDir, "devices", "pending.json"), {});
-NODE
-}
-
 write_update_restart_service_env() {
   mkdir -p "$OPENCLAW_STATE_DIR"
   local dotenv_path="$OPENCLAW_STATE_DIR/.env"
@@ -990,25 +900,35 @@ prepare_update_restart_probe() {
   install_update_restart_systemctl_shim
   seed_update_restart_probe_device_auth
   local probe_status=0
-  park_prepublish_authored_config || probe_status=$?
+  local doctor_log="${SYSTEMCTL_SHIM_DAEMON_LOG}.doctor"
+  park_update_restart_authored_config || probe_status=$?
+  if [ "$probe_status" -eq 0 ]; then
+    migrate_update_restart_probe_device_auth "$doctor_log" "$COMMAND_TIMEOUT" || {
+      probe_status=$?
+      echo "baseline probe device identity migration failed" >&2
+      openclaw_e2e_print_log "$doctor_log" >&2
+    }
+  fi
   if [ "$probe_status" -eq 0 ]; then
     write_update_restart_service_env || probe_status=$?
   fi
   if [ "$probe_status" -eq 0 ]; then
-    install_update_restart_probe_gateway 18789 "$COMMAND_TIMEOUT" legacy-ready-log-ok || probe_status=$?
+    run_update_restart_probe_gateway install 18789 "$COMMAND_TIMEOUT" legacy-ready-log-ok || probe_status=$?
   fi
   if [ "$probe_status" -eq 0 ]; then
     assert_prepublish_fixture_idle || probe_status=$?
   fi
+  # Restoring authored reload settings can restart the baseline immediately.
+  # Keep it offline through specimen seeding, migration, and explicit plugin consent.
+  stop_update_restart_probe_gateway "$COMMAND_TIMEOUT" || return "$?"
   local restore_status=0
-  restore_prepublish_authored_config || restore_status=$?
+  restore_update_restart_authored_config || restore_status=$?
   if [ "$probe_status" -ne 0 ]; then
     return "$probe_status"
   fi
   if [ "$restore_status" -ne 0 ]; then
     return "$restore_status"
   fi
-  assert_baseline_state
 }
 
 assert_baseline_state() {
@@ -1199,9 +1119,14 @@ repair_fixture_plugin_consent() {
     assert_survival
   fi
   if [ "$UPDATE_RESTART_MODE" = "auto-auth" ]; then
-    # Repair never restarts. Prove the candidate's automatic update handoff
-    # separately; a manual service restart cannot substitute for that proof.
+    # Start is preparation only. The following updater must replace this exact
+    # supervisor itself; its existing replacement and auth assertions remain required.
+    phase prepare-recovery-service run_update_restart_probe_gateway start 18789 "$COMMAND_TIMEOUT"
+    local preparation_status=$?
+    [ "$preparation_status" -eq 0 ] || return "$preparation_status"
     phase recovery-update-restart update_candidate 1
+    local recovery_status=$?
+    [ "$recovery_status" -eq 0 ] || return "$recovery_status"
     assert_survival
     if [ "$update_repair_required" = "1" ]; then
       node scripts/e2e/lib/upgrade-survivor/assertions.mjs \
@@ -1375,9 +1300,15 @@ phase storage-preflight storage_preflight
 phase validate-update-restart-mode validate_update_restart_mode
 phase reset-run-state reset_run_state
 phase install-baseline install_baseline
-phase seed-state seed_state
+phase initialize-state initialize_state
 phase apply-baseline-config-recipe apply_baseline_config_recipe
 phase validate-baseline-config validate_baseline_config
+phase resolve-candidate resolve_candidate_version
+phase configure-clawhub-fixture configure_clawhub_fixture
+phase prepare-update-restart-probe prepare_update_restart_probe
+# Start the published baseline before adding migration specimens: its startup
+# guards correctly reject them, and baseline Doctor would consume candidate proof.
+phase seed-migration-state node scripts/e2e/lib/upgrade-survivor/assertions.mjs seed
 if [ "$SCENARIO" = "cron-scheduled-authority" ]; then
   # Baseline roster writes must precede ownerless migration specimens: the
   # published CLI correctly refuses topology changes while those jobs exist.
@@ -1398,7 +1329,6 @@ if [ "$SCENARIO" = "recovery-cleanup" ]; then
   phase seed-recovery-state node scripts/e2e/lib/upgrade-survivor/recovery-cleanup.mjs seed
 fi
 phase seed-legacy-runtime-deps-symlink seed_legacy_runtime_deps_symlink
-phase resolve-candidate resolve_candidate_version
 if [ "$SCENARIO" = "recovery-cleanup" ]; then
   if [ "$CANDIDATE_KIND" != "tarball" ]; then
     echo "recovery-cleanup requires one packed candidate tarball" >&2
@@ -1406,8 +1336,6 @@ if [ "$SCENARIO" = "recovery-cleanup" ]; then
   fi
   phase recovery-package-evidence node scripts/e2e/lib/upgrade-survivor/recovery-cleanup.mjs packages "$baseline_spec" "$CANDIDATE_SPEC"
 fi
-phase configure-clawhub-fixture configure_clawhub_fixture
-phase prepare-update-restart-probe prepare_update_restart_probe
 phase configure-plugin-registry configure_plugin_registry
 phase update-candidate update_candidate
 if [ "$SCENARIO" = "sqlite-volume" ] || [ "$SCENARIO" = "recovery-cleanup" ]; then

--- a/scripts/e2e/lib/upgrade-survivor/systemd-fixture.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/systemd-fixture.mjs
@@ -168,6 +168,10 @@ function run() {
     readUnit(true);
     return;
   }
+  if (operation === "load-state" && !args.length) {
+    console.log(readUnit() ? "loaded" : "not-found");
+    return;
+  }
   if (operation === "command" && !args.length) {
     const unit = readUnit();
     if (!unit) {

--- a/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh
@@ -326,10 +326,16 @@ case "$command" in
       exit 0
     fi
     [ "$unit_name" = openclaw-gateway.service ] || exit 1
-    [ "$property" = 'Id,ActiveState,SubState,Result,NRestarts,StartLimitBurst,MainPID,ExecMainStatus,ExecMainCode,KillMode,TasksCurrent,MemoryCurrent' ] || {
+    # The published 2026.8.1 reader omits LoadState; current maintenance requires it.
+    # Keep both exact query contracts and reject unimplemented manager properties.
+    [ "${property/Id,LoadState,/Id,}" = 'Id,ActiveState,SubState,Result,NRestarts,StartLimitBurst,MainPID,ExecMainStatus,ExecMainCode,KillMode,TasksCurrent,MemoryCurrent' ] || {
       echo "systemctl shim unsupported user-scope show: $*" >&2
       exit 1
     }
+    if [[ "$property" == Id,LoadState,* ]]; then
+      load_state="$(node "$manager_script" load-state)"
+      printf 'Id=%s\nLoadState=%s\n' "$unit_name" "$load_state"
+    fi
     if is_running; then
       printf 'ActiveState=active\nSubState=running\nMainPID=%s\n' "$(cat "$pid_file")"
     else
@@ -469,27 +475,109 @@ write_update_restart_service_auth_env() {
   printf 'GATEWAY_AUTH_TOKEN_REF=%s\n' "$GATEWAY_AUTH_TOKEN_REF" >"$OPENCLAW_STATE_DIR/gateway.systemd.env"
 }
 
-install_update_restart_probe_gateway() {
-  local port="$1" command_timeout="$2" readiness_mode="${3:-strict}"
+migrate_update_restart_probe_device_auth() {
+  local doctor_log="$1" command_timeout="$2"
+  # Both setup paths migrate their probe identity under parked, plugin-disabled
+  # config. The published path runs this before creating migration specimens.
+  openclaw_e2e_maybe_timeout \
+    "$command_timeout" \
+    env \
+    OPENCLAW_UPDATE_IN_PROGRESS=1 \
+    OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR=1 \
+    OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE=1 \
+    openclaw doctor --fix --non-interactive >"$doctor_log" 2>&1
+}
+
+assert_update_restart_probe_inactive() {
+  local active_status=0
+  systemctl --user is-active --quiet openclaw-gateway.service || active_status=$?
+  # This fixture's manager returns 3 only for an observed inactive service.
+  # Neither active nor unknown may authorize config restoration or a prepared start.
+  [ "$active_status" -eq 3 ] && return 0
+  echo "gateway service is not confirmed inactive" >&2
+  [ "$active_status" -ne 0 ] || active_status=1
+  return "$active_status"
+}
+
+stop_update_restart_probe_gateway() {
+  local command_timeout="$1" stop_status=0
+  local stop_log="${OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG}.stop"
+  openclaw_e2e_maybe_timeout "$command_timeout" systemctl --user stop openclaw-gateway.service >"$stop_log" 2>&1 || stop_status=$?
+  if [ "$stop_status" -eq 0 ]; then
+    assert_update_restart_probe_inactive >>"$stop_log" 2>&1 || stop_status=$?
+  fi
+  if [ "$stop_status" -ne 0 ]; then
+    echo "gateway service shutdown could not be verified; preserving authored config snapshot" >&2
+    openclaw_e2e_print_log "$stop_log" >&2
+    return "$stop_status"
+  fi
+  gateway_pid=""
+}
+
+hash_update_restart_service_definition() {
+  node --input-type=module <<'NODE'
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+const hash = (file, optional = false) => {
+  try {
+    return createHash("sha256").update(fs.readFileSync(file)).digest("hex");
+  } catch (error) {
+    // The systemd writer omits its generated env file when it has no values.
+    if (optional && error.code === "ENOENT") return null;
+    throw error;
+  }
+};
+process.stdout.write(JSON.stringify({
+  unit: hash(path.join(process.env.HOME, ".config/systemd/user/openclaw-gateway.service")),
+  dotenv: hash(path.join(process.env.OPENCLAW_STATE_DIR, ".env")),
+  serviceEnv: hash(path.join(process.env.OPENCLAW_STATE_DIR, "gateway.systemd.env"), true),
+}) + "\n");
+NODE
+}
+
+run_update_restart_probe_gateway() {
+  local action="$1" port="$2" command_timeout="$3" readiness_mode="${4:-strict}"
   local log_file="$OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG"
-  local install_json="$OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_JSON"
-  local install_err="$OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_ERR"
-  local start_epoch ready_epoch budget install_status=0
-  budget="$(openclaw_e2e_read_positive_int_env OPENCLAW_UPGRADE_SURVIVOR_START_BUDGET_SECONDS 90)"
-  start_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
-  : >"$log_file"
-  # Installation starts the generated unit. Only its manager may publish the PID;
-  # adopting a foreground CLI leaves historical respawn children outside that owner.
-  openclaw_e2e_maybe_timeout "$command_timeout" env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD openclaw gateway install --force --json >"$install_json" 2>"$install_err" || install_status=$?
-  if [ "$install_status" -ne 0 ]; then
-    echo "gateway service install failed" >&2
-    openclaw_e2e_print_log "$install_err" >&2
-    openclaw_e2e_print_log "$install_json" >&2
-    return "$install_status"
+  local result_out="${log_file}.${action}.out" result_err="${log_file}.${action}.err"
+  local readiness_log="${log_file}.${action}.readiness.log"
+  local command=(systemctl --user start openclaw-gateway.service)
+  if [ "$action" = install ]; then
+    command=(env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD openclaw gateway install --force --json)
+    result_out="$OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_JSON"
+    result_err="$OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SERVICE_INSTALL_ERR"
+  else
+    assert_update_restart_probe_inactive || return "$?"
+    hash_update_restart_service_definition >"${log_file}.start-definition-before.json" || return "$?"
+    cp "$log_file" "${log_file}.before-start" || return "$?"
+  fi
+  local start_epoch ready_epoch budget service_status=0
+  budget="$(openclaw_e2e_read_positive_int_env OPENCLAW_UPGRADE_SURVIVOR_START_BUDGET_SECONDS 90)" || return "$?"
+  start_epoch="$(node -e "process.stdout.write(String(Date.now()))")" || return "$?"
+  : >"$log_file" || return "$?"
+  # Install and start both use the existing manager, which alone publishes the PID.
+  # Starting the repaired candidate must not reinstall its unit or replace auth state.
+  openclaw_e2e_maybe_timeout "$command_timeout" "${command[@]}" >"$result_out" 2>"$result_err" || service_status=$?
+  if [ "$service_status" -ne 0 ]; then
+    echo "gateway service $action failed" >&2
+    openclaw_e2e_print_log "$result_err" >&2
+    openclaw_e2e_print_log "$result_out" >&2
+    return "$service_status"
+  fi
+  if [ "$action" = start ]; then
+    hash_update_restart_service_definition >"${log_file}.start-definition-after.json" || return "$?"
+    if ! cmp -s "${log_file}.start-definition-before.json" "${log_file}.start-definition-after.json"; then
+      echo "gateway service start changed its installed unit or environment" >&2
+      return 1
+    fi
   fi
   gateway_pid="$(cat "$OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE")" || return "$?"
-  openclaw_e2e_wait_gateway_ready "$gateway_pid" "$log_file" 360 "$port" "$readiness_mode" || return "$?"
-  ready_epoch="$(node -e "process.stdout.write(String(Date.now()))")"
+  openclaw_e2e_wait_gateway_ready "$gateway_pid" "$log_file" 360 "$port" "$readiness_mode" >"$readiness_log" 2>&1 || service_status=$?
+  if [ "$service_status" -ne 0 ]; then
+    openclaw_e2e_print_log "$readiness_log" >&2
+    return "$service_status"
+  fi
+  ready_epoch="$(node -e "process.stdout.write(String(Date.now()))")" || return "$?"
   start_seconds=$(((ready_epoch - start_epoch + 999) / 1000))
   if [ "$start_seconds" -gt "$budget" ]; then
     echo "gateway startup exceeded survivor budget: ${start_seconds}s > ${budget}s" >&2
@@ -527,21 +615,13 @@ prepare_update_restart_probe_current_install() {
     fi
     return "$probe_status"
   fi
-  # This setup pass migrates candidate device identity while deferring plugin convergence.
-  # Parent-write support lets that migration persist before the real update begins.
-  openclaw_e2e_maybe_timeout \
-    "$command_timeout" \
-    env \
-    OPENCLAW_UPDATE_IN_PROGRESS=1 \
-    OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR=1 \
-    OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE=1 \
-    openclaw doctor --fix --non-interactive >"$doctor_log" 2>&1 || {
+  migrate_update_restart_probe_device_auth "$doctor_log" "$command_timeout" || {
       probe_status=$?
       failure_stage="doctor"
     }
   if [ "$probe_status" -ne 0 ]; then
     echo "candidate device identity migration failed" >&2
-    cat "$doctor_log" >&2 || true
+    openclaw_e2e_print_log "$doctor_log" >&2
   fi
   if [ "$probe_status" -eq 0 ]; then
     write_update_restart_service_auth_env || {
@@ -550,7 +630,7 @@ prepare_update_restart_probe_current_install() {
     }
   fi
   if [ "$probe_status" -eq 0 ]; then
-    install_update_restart_probe_gateway "$port" "$command_timeout" || probe_status=$?
+    run_update_restart_probe_gateway install "$port" "$command_timeout" || probe_status=$?
   fi
   if [ "$failure_stage" = "service-env" ]; then
     echo "failed to write candidate restart service environment" >&2

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -31,6 +31,7 @@ const OPENCLAW_E2E_INSTANCE_HELPER_PATH = "scripts/lib/openclaw-e2e-instance.sh"
 const COMPOSE_SETUP_E2E_PATH = "scripts/e2e/compose-setup.sh";
 const CLI_INSTALLER_DISTRIBUTION_E2E_PATH = "scripts/e2e/cli-installer-distribution-docker.sh";
 const DOCKER_PACKAGE_INSTALL_E2E_PATH = "scripts/e2e/docker-package-install.sh";
+// Preserve the published 2026.8.1 query; the systemd fixture tests use the current reader.
 const SURVIVOR_SERVICE_SHOW_ARGS = [
   "--user",
   "show",
@@ -2832,26 +2833,20 @@ docker_e2e_docker_run_cmd run demo
       expect(script).not.toContain('\nexport FEISHU_APP_SECRET="upgrade-survivor-feishu-secret"\n');
     }
     expectTextToIncludeAll(publishedRunner, [
-      "park_prepublish_authored_config",
-      "park-prepublish",
+      "park_update_restart_authored_config",
+      "park-restart-probe",
       "assert_prepublish_fixture_idle",
       "assert-no-requests",
-      "restore_prepublish_authored_config",
+      "restore_update_restart_authored_config",
       "config-parking.mjs",
       "'^(GATEWAY_AUTH_TOKEN_REF|OPENCLAW_CLAWHUB_URL)='",
       "OPENCLAW_CLAWHUB_URL=%s",
     ]);
-    expect(publishedRunner.indexOf("park_prepublish_authored_config")).toBeLessThan(
+    expect(publishedRunner.indexOf("park_update_restart_authored_config")).toBeLessThan(
       publishedRunner.lastIndexOf("assert_prepublish_fixture_idle"),
     );
     expect(publishedRunner.lastIndexOf("assert_prepublish_fixture_idle")).toBeLessThan(
-      publishedRunner.lastIndexOf("restore_prepublish_authored_config"),
-    );
-    expect(publishedRunner.lastIndexOf("write_update_restart_service_env")).toBeLessThan(
-      publishedRunner.lastIndexOf("install_update_restart_probe_gateway"),
-    );
-    expect(publishedRunner.lastIndexOf("install_update_restart_probe_gateway")).toBeLessThan(
-      publishedRunner.lastIndexOf("restore_prepublish_authored_config"),
+      publishedRunner.lastIndexOf("restore_update_restart_authored_config"),
     );
     for (const script of [runner, updateRestartAuth]) {
       expect(script).not.toContain("assert-no-requests");
@@ -3388,9 +3383,10 @@ fi
     expect(updateRestartAuth).toContain(
       'command_timeout="${OPENCLAW_UPGRADE_SURVIVOR_COMMAND_TIMEOUT:-900s}"',
     );
-    expect(updateRestartAuth).toContain(
-      'openclaw_e2e_maybe_timeout "$command_timeout" env -u OPENCLAW_GATEWAY_TOKEN',
-    );
+    expectTextToIncludeAll(updateRestartAuth, [
+      "command=(env -u OPENCLAW_GATEWAY_TOKEN -u OPENCLAW_GATEWAY_PASSWORD openclaw gateway install --force --json)",
+      'openclaw_e2e_maybe_timeout "$command_timeout" "${command[@]}"',
+    ]);
   });
 
   it.skipIf(process.platform !== "linux").each(["published", "current"])(
@@ -3524,13 +3520,24 @@ ${lane === "published" ? "prepare_update_restart_probe" : 'prepare_update_restar
         expect(result.status, result.stdout + result.stderr).toBe(0);
         expect(readFileSync(configPath, "utf8")).toBe(authored);
         const url = `http://127.0.0.1:${readFileSync(portPath, "utf8")}/readyz`;
+        if (lane === "published") {
+          expect(systemctl("is-active", "openclaw-gateway.service").status).toBe(3);
+          expect(records()).toHaveLength(1);
+          expect(isProcessRunning(records()[0]!.pid)).toBe(false);
+          await expect(fetch(url, { signal: AbortSignal.timeout(1_000) })).rejects.toThrow();
+          expect(systemctl("start", "openclaw-gateway.service").status).toBe(0);
+          for (let attempt = 0; attempt < 200 && records().length < 2; attempt++) await delay(10);
+          expect(records()).toHaveLength(2);
+        }
         const initial = (await (
           await fetch(url, { signal: AbortSignal.timeout(1_000) })
         ).json()) as { pid: number; managed: boolean };
         expect(initial.managed).toBe(true);
         expect(systemctl("restart", "openclaw-gateway.service").status).toBe(0);
-        for (let attempt = 0; attempt < 200 && records().length < 2; attempt++) await delay(10);
-        expect(records()).toHaveLength(2);
+        const expectedStarts = lane === "published" ? 3 : 2;
+        for (let attempt = 0; attempt < 200 && records().length < expectedStarts; attempt++)
+          await delay(10);
+        expect(records()).toHaveLength(expectedStarts);
         const replacement = (await (
           await fetch(url, { signal: AbortSignal.timeout(1_000) })
         ).json()) as { pid: number; managed: boolean };
@@ -3604,6 +3611,7 @@ printf '%s\n' '{"gateway":{"mode":"local"}}' >"$OPENCLAW_CONFIG_PATH"
 unset OPENCLAW_UPDATE_IN_PROGRESS
 unset OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR
 unset OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE
+source "$ROOT_DIR/${OPENCLAW_E2E_INSTANCE_HELPER_PATH}"
 source "$ROOT_DIR/${UPGRADE_SURVIVOR_UPDATE_RESTART_AUTH_PATH}"
 install_update_restart_systemctl_shim() { :; }
 seed_update_restart_probe_device_auth() { :; }
@@ -3756,6 +3764,7 @@ export REAL_CONFIG_PARKING_HELPER="$ROOT_DIR/${UPGRADE_SURVIVOR_CONFIG_PARKING_P
 export OPENCLAW_UPGRADE_SURVIVOR_CONFIG_PARKING_HELPER="$TMPDIR/bin/config-parking-wrapper.mjs"
 mkdir -p "$OPENCLAW_STATE_DIR"
 printf '%s\n' '{"channels":{"discord":{"dm":{"policy":"allowlist"}}}}' >"$OPENCLAW_CONFIG_PATH"
+source "$ROOT_DIR/${OPENCLAW_E2E_INSTANCE_HELPER_PATH}"
 source "$ROOT_DIR/${UPGRADE_SURVIVOR_UPDATE_RESTART_AUTH_PATH}"
 install_update_restart_systemctl_shim() { :; }
 seed_update_restart_probe_device_auth() { :; }
@@ -5518,8 +5527,8 @@ if (starts === 1) {
 
     expect(publishedRunner).toContain('openclaw_e2e_print_log "$BASELINE_INSTALL_LOG"');
     expect(publishedRunner).toContain('openclaw_e2e_print_log "$BASELINE_CONFIG_VALIDATE_LOG"');
-    expect(updateRestartAuth).toContain('openclaw_e2e_print_log "$install_err"');
-    expect(updateRestartAuth).toContain('openclaw_e2e_print_log "$install_json"');
+    expect(updateRestartAuth).toContain('openclaw_e2e_print_log "$result_err"');
+    expect(updateRestartAuth).toContain('openclaw_e2e_print_log "$result_out"');
     expect(publishedRunner).toContain('openclaw_e2e_print_log "$update_err"');
     expect(publishedRunner).toContain('openclaw_e2e_print_log "$update_json"');
     expect(publishedRunner).toContain('openclaw_e2e_print_log "$DOCTOR_LOG"');
@@ -5529,8 +5538,8 @@ if (starts === 1) {
     expect(publishedRunner).toContain('openclaw_e2e_print_log "$log_file"');
     expect(publishedRunner).not.toContain('cat "$BASELINE_INSTALL_LOG"');
     expect(publishedRunner).not.toContain('cat "$BASELINE_CONFIG_VALIDATE_LOG"');
-    expect(updateRestartAuth).not.toContain('cat "$install_err"');
-    expect(updateRestartAuth).not.toContain('cat "$install_json"');
+    expect(updateRestartAuth).not.toContain('cat "$result_err"');
+    expect(updateRestartAuth).not.toContain('cat "$result_out"');
     expect(publishedRunner).not.toContain('cat "$UPDATE_ERR"');
     expect(publishedRunner).not.toContain('cat "$UPDATE_JSON"');
     expect(publishedRunner).not.toContain('cat "$DOCTOR_LOG"');

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -4092,7 +4092,9 @@ describe("package artifact reuse", () => {
     expect(publishedUpgradeSurvivor).toContain("validate_baseline_package_spec");
     expect(publishedUpgradeSurvivor).toContain("OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE");
     expect(publishedUpgradeSurvivor).toContain("seed_update_restart_probe_device_auth");
-    expect(publishedUpgradeSurvivor).toContain("upgrade survivor restart probe");
+    expect(
+      readFileSync("scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh", "utf8"),
+    ).toContain("upgrade survivor restart probe");
     expect(publishedUpgradeSurvivor).toContain("write_update_restart_service_env");
     expect(publishedUpgradeSurvivor).toContain("GATEWAY_AUTH_TOKEN_REF=%s");
     expect(publishedUpgradeSurvivor).toContain("OPENCLAW_CLAWHUB_URL=%s");

--- a/test/scripts/upgrade-survivor-baseline-order.test.ts
+++ b/test/scripts/upgrade-survivor-baseline-order.test.ts
@@ -1,0 +1,186 @@
+import { spawnSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const runner = path.resolve("scripts/e2e/lib/upgrade-survivor/run.sh");
+
+it.each([
+  { scenario: "base", mode: "manual" },
+  { scenario: "base", mode: "auto-auth" },
+  { scenario: "sqlite-volume", mode: "manual" },
+  { scenario: "sqlite-volume", mode: "auto-auth" },
+])("preserves all $scenario migration rows after $mode baseline setup", ({ scenario, mode }) => {
+  const root = tempDirs.make("openclaw-survivor-baseline-order-");
+  const authoredPath = path.join(root, "authored.json");
+  const resultPath = path.join(root, "result.json");
+  const probePath = path.join(root, "probe.mjs");
+  const bin = path.join(root, "bin");
+  mkdirSync(bin);
+  writeFileSync(
+    path.join(bin, "openclaw"),
+    '#!/usr/bin/env bash\nexec node --import "$TSX_IMPORT" "$PROBE_SCRIPT" "$@"\n',
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    path.join(bin, "systemctl"),
+    `#!/usr/bin/env bash
+  case "$2" in
+    stop) rm -f "$PROBE_LIVE" ;;
+    is-active) [ -f "$PROBE_LIVE" ] && exit 0; exit 3 ;;
+    *) exit 97 ;;
+  esac
+`,
+    { mode: 0o755 },
+  );
+  writeFileSync(
+    authoredPath,
+    JSON.stringify({
+      gateway: {
+        mode: "local",
+        auth: {
+          mode: "token",
+          token: { source: "env", provider: "default", id: "GATEWAY_AUTH_TOKEN_REF" },
+        },
+      },
+      plugins: { enabled: true },
+      channels: { discord: { enabled: true } },
+    }),
+  );
+  const startupModule = pathToFileURL(path.resolve("src/config/sessions/startup-migration.ts"));
+  const infraModule = (file: string) =>
+    JSON.stringify(pathToFileURL(path.resolve("src/infra", file)).href);
+  writeFileSync(
+    probePath,
+    `import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { assertSessionStoreMigrationComplete } from ${JSON.stringify(startupModule.href)};
+import { loadDeviceIdentityIfPresent } from ${infraModule("device-identity.ts")};
+import { loadDeviceAuthToken } from ${infraModule("device-auth-store.ts")};
+import { detectLegacyDeviceIdentity, migrateLegacyDeviceIdentity } from ${infraModule("state-migrations.device-identity.ts")};
+import { detectLegacyDeviceAuth, migrateLegacyDeviceAuth } from ${infraModule("state-migrations.device-auth.ts")};
+const state = process.env.OPENCLAW_STATE_DIR;
+const volume = process.env.OPENCLAW_UPGRADE_SURVIVOR_SCENARIO === "sqlite-volume";
+const stores = volume
+  ? ["agents/main/sessions/sessions.json", "agents/ops/sessions/sessions.json"]
+  : ["sessions/sessions.json"];
+const checkStartup = () => assertSessionStoreMigrationComplete({
+  cfg: {}, env: process.env, targets: stores.map(file => ({ storePath: path.join(state, file) })),
+});
+if (process.argv[2] === "doctor") {
+  assert.deepEqual(process.argv.slice(2), ["doctor", "--fix", "--non-interactive"]);
+  for (const name of ["OPENCLAW_UPDATE_IN_PROGRESS", "OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR", "OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE"]) {
+    assert.equal(process.env[name], "1");
+  }
+  checkStartup();
+  assert.equal(fs.existsSync(path.join(state, "cron/jobs.json")), false);
+  assert.equal(JSON.parse(fs.readFileSync(process.env.OPENCLAW_CONFIG_PATH, "utf8")).plugins.enabled, false);
+  const identity = JSON.parse(fs.readFileSync(path.join(state, "identity/device.json"), "utf8"));
+  const auth = JSON.parse(fs.readFileSync(path.join(state, "identity/device-auth.json"), "utf8"));
+  const migration = { stateDir: state, env: process.env, doctorOnlyStateMigrations: true };
+  const importedIdentity = await migrateLegacyDeviceIdentity({ ...migration, detected: detectLegacyDeviceIdentity(migration) });
+  const importedAuth = await migrateLegacyDeviceAuth({ ...migration, detected: detectLegacyDeviceAuth(migration) });
+  assert.equal(importedIdentity.warnings.length, 0, "identity migration failed");
+  assert.equal(importedAuth.warnings.length, 0, "auth migration failed");
+  const canonicalIdentity = loadDeviceIdentityIfPresent({ env: process.env });
+  assert.ok(canonicalIdentity?.deviceId === identity.deviceId, "device identity changed");
+  assert.ok(canonicalIdentity?.privateKeyPem === identity.privateKeyPem, "device key changed");
+  const canonicalAuth = loadDeviceAuthToken({ deviceId: identity.deviceId, role: "operator", env: process.env });
+  assert.ok(canonicalAuth?.token === auth.tokens.operator.token, "device token changed");
+  assert.deepEqual(canonicalAuth?.scopes, ["operator.read"]);
+} else if (process.argv[2] === "startup") {
+  checkStartup();
+  assert.ok(loadDeviceIdentityIfPresent({ env: process.env }), "missing canonical probe identity");
+  fs.writeFileSync(process.env.PROBE_READY, "ready");
+  fs.writeFileSync(process.env.PROBE_LIVE, "live");
+} else {
+  assert.equal(process.argv[2], "update");
+  if (process.env.OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE === "auto-auth") {
+    assert.equal(fs.readFileSync(process.env.PROBE_READY, "utf8"), "ready");
+    assert.equal(fs.existsSync(process.env.PROBE_LIVE), false, "baseline must be offline before specimens and initial update");
+  }
+  assert.throws(checkStartup, /Legacy session store requires migration/);
+  const rows = stores.flatMap(file => Object.values(JSON.parse(fs.readFileSync(path.join(state, file), "utf8"))));
+  assert.equal(rows.length, volume ? 15 : 3);
+  assert.equal(new Set(rows.map(row => row.sessionId)).size, rows.length);
+  for (const id of ["upgrade-main-session", "upgrade-direct-session", "upgrade-group-session"]) {
+    const row = rows.find(row => row.sessionId === id);
+    assert.ok(row, "missing original session " + id);
+    assert.equal(JSON.parse(fs.readFileSync(row.sessionFile, "utf8")).id, id);
+  }
+  assert.equal(rows.filter(row => row.sessionId.startsWith("volume-")).length, volume ? 12 : 0);
+  fs.writeFileSync(process.env.PROBE_RESULT, JSON.stringify({ rows: rows.length, volume }));
+}
+`,
+  );
+  const source = readFileSync(runner, "utf8");
+  const boundary = source.indexOf("phase storage-preflight");
+  const setup = source.slice(0, boundary);
+  const phases = source.slice(boundary);
+  const script = `${setup}
+trap - EXIT ERR INT TERM
+openclaw_e2e_eval_test_state_from_b64() { :; }
+openclaw_test_state_create() {
+  export OPENCLAW_STATE_DIR="$FIXTURE_HOME/.openclaw"
+  export OPENCLAW_CONFIG_PATH="$OPENCLAW_STATE_DIR/openclaw.json"
+  export OPENCLAW_TEST_WORKSPACE_DIR="$FIXTURE_HOME/workspace"
+  mkdir -p "$OPENCLAW_STATE_DIR" "$OPENCLAW_TEST_WORKSPACE_DIR"
+  cp "$AUTHORED_CONFIG" "$OPENCLAW_CONFIG_PATH"
+}
+getent() { printf 'fixture:x:1000:1000:fixture:%s:/bin/bash\n' "$FIXTURE_HOME"; }
+install_update_restart_systemctl_shim() { :; }
+
+assert_baseline_state() { :; }
+run_update_restart_probe_gateway() {
+  node --import "$TSX_IMPORT" "$PROBE_SCRIPT" startup
+}
+phase() {
+  local name="$1"
+  shift
+  case "$name" in
+    install-baseline) baseline_version=2026.8.1 ;;
+    initialize-state|seed-state|seed-migration-state|seed-volume-state|prepare-update-restart-probe) "$@" ;;
+    update-candidate)
+      node --import "$TSX_IMPORT" "$PROBE_SCRIPT" update
+      exit "$?"
+      ;;
+    *) : ;;
+  esac
+}
+${phases}
+`;
+  const result = spawnSync("bash", ["-c", script], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+      HOME: root,
+      FIXTURE_HOME: root,
+      AUTHORED_CONFIG: authoredPath,
+      PROBE_SCRIPT: probePath,
+      PROBE_RESULT: resultPath,
+      PROBE_READY: path.join(root, "ready"),
+      PROBE_LIVE: path.join(root, "live"),
+      TSX_IMPORT: path.resolve("node_modules/tsx/dist/loader.mjs"),
+      OPENCLAW_TEST_STATE_FUNCTION_B64: "Og==",
+      OPENCLAW_UPGRADE_SURVIVOR_BASELINE: "openclaw@2026.8.1",
+      OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE: mode,
+      OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: scenario,
+      OPENCLAW_UPGRADE_SURVIVOR_RUNTIME_ROOT: path.join(root, "runtime"),
+      OPENCLAW_UPGRADE_SURVIVOR_SUMMARY_JSON: path.join(root, "artifacts", "summary.json"),
+      OPENCLAW_UPGRADE_SURVIVOR_VOLUME_SESSIONS: "12",
+      OPENCLAW_UPGRADE_SURVIVOR_VOLUME_EVENTS_PER_SESSION: "3",
+      OPENCLAW_UPGRADE_SURVIVOR_VOLUME_CRON_JOBS: "6",
+      OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR: "",
+    },
+  });
+  expect(result.status, result.stdout + result.stderr).toBe(0);
+  expect(JSON.parse(readFileSync(resultPath, "utf8"))).toEqual({
+    rows: scenario === "sqlite-volume" ? 15 : 3,
+    volume: scenario === "sqlite-volume",
+  });
+});

--- a/test/scripts/upgrade-survivor-config-parking.test.ts
+++ b/test/scripts/upgrade-survivor-config-parking.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
+const PUBLISHED_RUNNER_PATH = path.resolve("scripts/e2e/lib/upgrade-survivor/run.sh");
 const SCRIPT_PATH = path.resolve("scripts/e2e/lib/upgrade-survivor/config-parking.mjs");
 const SURVIVOR_SCRIPT_PATH = path.resolve("scripts/e2e/upgrade-survivor-docker.sh");
 const E2E_INSTANCE_SCRIPT_PATH = path.resolve("scripts/lib/openclaw-e2e-instance.sh");
@@ -17,38 +18,305 @@ function run(...args: string[]) {
 }
 
 describe("upgrade survivor config parking", () => {
-  it("preserves published prepublish parking behavior and restores exact bytes", () => {
-    const root = tempDirs.make("openclaw-prepublish-config-parking-");
-    const configPath = path.join(root, "openclaw.json");
-    const snapshotPath = path.join(root, "openclaw.authored.json");
-    const authoredConfig = `{
-  "gateway": { "mode": "local", "reload": { "mode": "hybrid" } },
-  "plugins": {
-    "allow": ["discord", "whatsapp"],
-    "entries": { "discord": { "enabled": true }, "whatsapp": { "enabled": true } }
-  },
-  "channels": { "discord": { "enabled": true }, "whatsapp": { "enabled": true } }
+  it.each([
+    { registry: false, installStatus: 0, migrationStatus: 0, stopStatus: 0, activeStatus: 3 },
+    { registry: true, installStatus: 0, migrationStatus: 0, stopStatus: 0, activeStatus: 3 },
+    { registry: false, installStatus: 23, migrationStatus: 0, stopStatus: 0, activeStatus: 3 },
+    { registry: true, installStatus: 23, migrationStatus: 0, stopStatus: 0, activeStatus: 3 },
+    { registry: false, installStatus: 0, migrationStatus: 41, stopStatus: 0, activeStatus: 3 },
+    { registry: true, installStatus: 0, migrationStatus: 41, stopStatus: 0, activeStatus: 3 },
+    { registry: false, installStatus: 0, migrationStatus: 0, stopStatus: 29, activeStatus: 0 },
+    { registry: false, installStatus: 0, migrationStatus: 0, stopStatus: 0, activeStatus: 1 },
+  ])(
+    "isolates published auth setup and restores the migration specimen (registry=$registry, install=$installStatus, migration=$migrationStatus, stop=$stopStatus, active=$activeStatus)",
+    ({ registry, installStatus, migrationStatus, stopStatus, activeStatus }) => {
+      const root = tempDirs.make("openclaw-published-auth-parking-");
+      const stateDir = path.join(root, "state");
+      const configPath = path.join(stateDir, "openclaw.json");
+      const capturePath = path.join(root, "service-config.json");
+      mkdirSync(stateDir);
+      const auth = {
+        mode: "token",
+        token: { source: "env", provider: "default", id: "GATEWAY_AUTH_TOKEN_REF" },
+      };
+      const authoredConfig = `${JSON.stringify({
+        gateway: { mode: "local", auth, reload: { mode: "hybrid" } },
+        agents: { defaults: { model: { primary: "openai/gpt-5.5" } } },
+        plugins: {
+          enabled: true,
+          allow: ["codex", "discord", "whatsapp"],
+          entries: { discord: { enabled: true }, whatsapp: { enabled: true } },
+        },
+        channels: { discord: { enabled: true }, whatsapp: { enabled: true } },
+      })}\n`;
+      writeFileSync(configPath, authoredConfig);
+      const parkingWrapper = path.join(root, "parking.mjs");
+      writeFileSync(
+        parkingWrapper,
+        `import fs from "node:fs";
+import { spawnSync } from "node:child_process";
+if (process.argv[2] === "restore") {
+  fs.appendFileSync(process.env.PROBE_EVENTS, fs.existsSync(process.env.PROBE_LIVE) ? "restore-live\\n" : "restore-offline\\n");
 }
+const child = spawnSync(process.execPath, [${JSON.stringify(SCRIPT_PATH)}, ...process.argv.slice(2)], {stdio:"inherit"});
+process.exit(child.status ?? 1);
+`,
+      );
+      const bin = path.join(root, "bin");
+      mkdirSync(bin);
+      writeFileSync(
+        path.join(bin, "systemctl"),
+        `#!/usr/bin/env bash
+  printf '%s\n' "$*" >>"$PROBE_EVENTS"
+  case "$2" in
+    stop)
+      [ "$PROBE_STOP_STATUS" -eq 0 ] || exit "$PROBE_STOP_STATUS"
+      [ "$PROBE_ACTIVE_STATUS" -eq 3 ] && rm -f "$PROBE_LIVE"
+      exit 0 ;;
+    is-active) exit "$PROBE_ACTIVE_STATUS" ;;
+    *) exit 97 ;;
+  esac
+`,
+        { mode: 0o755 },
+      );
+      const source = readFileSync(PUBLISHED_RUNNER_PATH, "utf8");
+      const setup = source.slice(0, source.indexOf("phase storage-preflight"));
+      const script = `${setup}
+trap - EXIT ERR INT TERM
+install_update_restart_systemctl_shim() { :; }
+
+seed_update_restart_probe_device_auth() { :; }
+migrate_update_restart_probe_device_auth() {
+  cp "$OPENCLAW_CONFIG_PATH" "$PROBE_CAPTURE"
+  printf 'synthetic migration diagnostic\n' >"$1"
+  return "$PROBE_MIGRATION_STATUS"
+}
+assert_prepublish_fixture_idle() { :; }
+assert_baseline_state() { :; }
+run_update_restart_probe_gateway() {
+  cp "$OPENCLAW_CONFIG_PATH" "$PROBE_CAPTURE"
+  touch "$PROBE_INSTALLED" "$PROBE_LIVE"
+  return "$PROBE_INSTALL_STATUS"
+}
+probe_status=0
+prepare_update_restart_probe || probe_status=$?
+exit "$probe_status"
 `;
-    writeFileSync(configPath, authoredConfig);
+      const result = spawnSync("bash", ["-c", script], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HOME: root,
+          PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_CONFIG_PATH: configPath,
+          OPENCLAW_UPGRADE_SURVIVOR_BASELINE: "openclaw@2026.8.1",
+          OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE: "auto-auth",
+          OPENCLAW_UPGRADE_SURVIVOR_RUNTIME_ROOT: path.join(root, "runtime"),
+          OPENCLAW_UPGRADE_SURVIVOR_SUMMARY_JSON: path.join(root, "artifacts", "summary.json"),
+          OPENCLAW_UPGRADE_SURVIVOR_CONFIG_PARKING_HELPER: parkingWrapper,
+          OPENCLAW_PREPUBLISH_PLUGIN_REGISTRY_DIR: registry ? path.join(root, "registry") : "",
+          PROBE_CAPTURE: capturePath,
+          PROBE_EVENTS: path.join(root, "events"),
+          PROBE_LIVE: path.join(root, "live"),
+          PROBE_STOP_STATUS: String(stopStatus),
+          PROBE_ACTIVE_STATUS: String(activeStatus),
+          PROBE_INSTALLED: path.join(root, "installed"),
+          PROBE_MIGRATION_STATUS: String(migrationStatus),
+          PROBE_INSTALL_STATUS: String(installStatus),
+        },
+      });
+      const stopped = stopStatus === 0 && activeStatus === 3;
+      expect(result.status, result.stdout + result.stderr).toBe(
+        stopped ? migrationStatus || installStatus : stopStatus || activeStatus,
+      );
+      expect(existsSync(path.join(root, "installed"))).toBe(migrationStatus === 0);
+      expect(JSON.parse(readFileSync(capturePath, "utf8"))).toEqual({
+        plugins: { enabled: false },
+        gateway: {
+          port: 18789,
+          mode: "local",
+          bind: "loopback",
+          controlUi: { enabled: false },
+          auth,
+          reload: { mode: "off" },
+        },
+      });
+      const snapshot = path.join(root, "runtime", "restart-authored-openclaw.json");
+      const events = readFileSync(path.join(root, "events"), "utf8");
+      if (stopped) {
+        expect(events).toContain("--user stop openclaw-gateway.service\n");
+        expect(events).toContain("restore-offline\n");
+        expect(events).not.toContain("restore-live");
+        expect(readFileSync(configPath, "utf8")).toBe(authoredConfig);
+        expect(existsSync(snapshot)).toBe(false);
+      } else {
+        expect(events).not.toContain("restore-");
+        expect(readFileSync(snapshot, "utf8")).toBe(authoredConfig);
+        expect(JSON.parse(readFileSync(configPath, "utf8")).plugins.enabled).toBe(false);
+      }
+    },
+  );
 
-    const park = run("park-prepublish", configPath, snapshotPath);
-    expect(park.status, park.stderr).toBe(0);
-    expect(readFileSync(snapshotPath, "utf8")).toBe(authoredConfig);
-    expect(JSON.parse(readFileSync(configPath, "utf8"))).toEqual({
-      gateway: { mode: "local", reload: { mode: "off" } },
-      plugins: {
-        allow: ["discord"],
-        entries: { discord: { enabled: true } },
-      },
-      channels: { discord: { enabled: true } },
-    });
+  it.each([
+    { startStatus: 0, readyStatus: 0, activeStatus: 3, mutation: "none" },
+    { startStatus: 43, readyStatus: 0, activeStatus: 3, mutation: "none" },
+    { startStatus: 0, readyStatus: 42, activeStatus: 3, mutation: "none" },
+    { startStatus: 0, readyStatus: 0, activeStatus: 0, mutation: "none" },
+    { startStatus: 0, readyStatus: 0, activeStatus: 1, mutation: "none" },
+    { startStatus: 0, readyStatus: 0, activeStatus: 3, mutation: "unit" },
+    { startStatus: 0, readyStatus: 0, activeStatus: 3, mutation: "env" },
+  ])(
+    "requires prepared service readiness before the final updater (start=$startStatus, ready=$readyStatus, active=$activeStatus, mutation=$mutation)",
+    ({ startStatus, readyStatus, activeStatus, mutation }) => {
+      const root = tempDirs.make("openclaw-repaired-service-start-");
+      const bin = path.join(root, "bin");
+      mkdirSync(bin);
+      writeFileSync(
+        path.join(bin, "systemctl"),
+        `#!/usr/bin/env bash
+[ "$*" != '--user is-active --quiet openclaw-gateway.service' ] || exit "$PROBE_ACTIVE_STATUS"
+printf '%s\\n' "$*" >>"$PROBE_EVENTS"
+[ "$*" = '--user start openclaw-gateway.service' ] || exit 97
+printf 'synthetic start diagnostic\\n' >&2
+[ "$PROBE_START_STATUS" -eq 0 ] || exit "$PROBE_START_STATUS"
+printf '42\\n' >"$OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE"
+case "$PROBE_MUTATION" in
+  unit) printf 'changed' >>"$HOME/.config/systemd/user/openclaw-gateway.service" ;;
+  env) printf 'changed' >>"$OPENCLAW_STATE_DIR/gateway.systemd.env" ;;
+esac
+`,
+        { mode: 0o755 },
+      );
+      writeFileSync(path.join(bin, "openclaw"), "#!/usr/bin/env bash\nexit 98\n", { mode: 0o755 });
+      const redactor = path.join(root, "redactor.mjs");
+      writeFileSync(
+        redactor,
+        `import { tsImport } from ${JSON.stringify(path.resolve("node_modules/tsx/dist/esm/api/index.mjs"))};
+export const { redactSensitiveText } = await tsImport(${JSON.stringify(path.resolve("src/logging/redact.ts"))}, import.meta.url);
+`,
+      );
+      const source = readFileSync(PUBLISHED_RUNNER_PATH, "utf8");
+      const setup = source.slice(0, source.indexOf("phase storage-preflight"));
+      const result = spawnSync(
+        "bash",
+        [
+          "-c",
+          `${setup}
+trap - EXIT ERR INT TERM
+update_repair_required=0
+mkdir -p "$HOME/.config/systemd/user" "$OPENCLAW_STATE_DIR"
+printf 'original unit\\n' >"$HOME/.config/systemd/user/openclaw-gateway.service"
+printf 'original env\\n' >"$OPENCLAW_STATE_DIR/gateway.systemd.env"
+printf 'original dotenv\\n' >"$OPENCLAW_STATE_DIR/.env"
+printf 'baseline timeline\\n' >"$OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_DAEMON_LOG"
+: >"$PROBE_EVENTS"
+openclaw_e2e_wait_gateway_ready() {
+  printf 'readiness\\n' >>"$PROBE_EVENTS"
+  return "$PROBE_READY_STATUS"
+}
+# Only the independent updater boundary is substituted; preparation and phases are real.
+update_candidate() { printf 'update\\n' >>"$PROBE_EVENTS"; }
+assert_survival() { printf 'assert-survival\\n' >>"$PROBE_EVENTS"; }
+probe_status=0
+repair_fixture_plugin_consent || probe_status=$?
+exit "$probe_status"
+`,
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+            HOME: root,
+            OPENCLAW_STATE_DIR: path.join(root, "state"),
+            OPENCLAW_UPGRADE_SURVIVOR_BASELINE: "openclaw@2026.8.1",
+            OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE: "auto-auth",
+            OPENCLAW_UPGRADE_SURVIVOR_RUNTIME_ROOT: path.join(root, "runtime"),
+            OPENCLAW_UPGRADE_SURVIVOR_SUMMARY_JSON: path.join(root, "artifacts", "summary.json"),
+            OPENCLAW_CLAWHUB_URL: "",
+            PROBE_EVENTS: path.join(root, "events"),
+            OPENCLAW_E2E_REDACTOR_MODULE: redactor,
+            PROBE_ACTIVE_STATUS: String(activeStatus),
+            PROBE_MUTATION: mutation,
+            PROBE_START_STATUS: String(startStatus),
+            PROBE_READY_STATUS: String(readyStatus),
+          },
+        },
+      );
+      const expected =
+        activeStatus === 3
+          ? startStatus || (mutation !== "none" ? 1 : readyStatus)
+          : activeStatus || 1;
+      expect(result.status, result.stdout + result.stderr).toBe(expected);
+      expect(
+        readFileSync(path.join(root, "events"), "utf8").trimEnd().split("\n").filter(Boolean),
+      ).toEqual(
+        activeStatus !== 3
+          ? []
+          : startStatus || mutation !== "none"
+            ? ["--user start openclaw-gateway.service"]
+            : readyStatus
+              ? ["--user start openclaw-gateway.service", "readiness"]
+              : ["--user start openclaw-gateway.service", "readiness", "update", "assert-survival"],
+      );
+      if (activeStatus === 3) {
+        expect(
+          readFileSync(
+            path.join(root, "artifacts", "systemctl-shim-gateway.log.before-start"),
+            "utf8",
+          ),
+        ).toBe("baseline timeline\n");
+      }
+      if (startStatus) {
+        expect(result.stderr).toContain("synthetic start diagnostic");
+      }
+      const phases = readFileSync(path.join(root, "artifacts", "phases.jsonl"), "utf8");
+      if (expected) {
+        expect(phases).not.toContain('"status":"passed"');
+        expect(phases).not.toContain("recovery-update-restart");
+      }
+    },
+  );
 
-    const restore = run("restore", configPath, snapshotPath);
-    expect(restore.status, restore.stderr).toBe(0);
-    expect(readFileSync(configPath, "utf8")).toBe(authoredConfig);
-    expect(existsSync(snapshotPath)).toBe(false);
-  });
+  it.each([false, true])(
+    "preserves phase failure without disabling normal errexit (conditional=%s)",
+    (conditional) => {
+      const root = tempDirs.make("openclaw-survivor-phase-failure-");
+      const source = readFileSync(PUBLISHED_RUNNER_PATH, "utf8");
+      const setup = source.slice(0, source.indexOf("phase storage-preflight"));
+      const result = spawnSync(
+        "bash",
+        [
+          "-c",
+          `${setup}
+trap - EXIT ERR INT TERM
+handler() {
+  ${conditional ? "return 47" : "bash -c 'exit 47'"}
+  touch "$PROBE_SIDE_EFFECT"
+}
+${conditional ? 'probe_status=0; phase preparation handler || probe_status=$?; exit "$probe_status"' : "phase preparation handler"}
+`,
+        ],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            HOME: root,
+            OPENCLAW_UPGRADE_SURVIVOR_BASELINE: "openclaw@2026.8.1",
+            OPENCLAW_UPGRADE_SURVIVOR_RUNTIME_ROOT: path.join(root, "runtime"),
+            OPENCLAW_UPGRADE_SURVIVOR_SUMMARY_JSON: path.join(root, "artifacts", "summary.json"),
+            PROBE_SIDE_EFFECT: path.join(root, "side-effect"),
+          },
+        },
+      );
+      expect(result.status, result.stdout + result.stderr).toBe(47);
+      expect(existsSync(path.join(root, "side-effect"))).toBe(false);
+      expect(readFileSync(path.join(root, "artifacts", "phases.jsonl"), "utf8")).not.toContain(
+        '"status":"passed"',
+      );
+    },
+  );
 
   it("parks legacy authored config behind a strict restart probe config", () => {
     const root = tempDirs.make("openclaw-restart-config-parking-");
@@ -185,12 +453,12 @@ install_companion_plugins
     const root = tempDirs.make("openclaw-invalid-config-parking-");
     const configPath = path.join(root, "openclaw.json");
     const snapshotPath = path.join(root, "openclaw.authored.json");
-    const authoredConfig = '{"plugins":{"allow":"whatsapp"}}\n';
+    const authoredConfig = "[]\n";
     writeFileSync(configPath, authoredConfig);
 
-    const park = run("park-prepublish", configPath, snapshotPath);
+    const park = run("park-restart-probe", configPath, snapshotPath, "19876");
     expect(park.status).toBe(1);
-    expect(park.stderr).toContain("plugins.allow must be an array");
+    expect(park.stderr).toContain("restart probe config must be an object");
     expect(readFileSync(configPath, "utf8")).toBe(authoredConfig);
     expect(existsSync(snapshotPath)).toBe(false);
   });

--- a/test/scripts/upgrade-survivor-systemd.test.ts
+++ b/test/scripts/upgrade-survivor-systemd.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { join, resolve } from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { afterEach, describe, expect, it } from "vitest";
+import { readSystemdServiceRuntime } from "../../src/daemon/systemd-runtime.js";
 import {
   readSystemdServiceExecStart,
   serializeSystemdEnvironmentFile,
@@ -51,6 +52,10 @@ describe.skipIf(process.platform === "win32")("survivor manager fixture", () => 
     const { home, env, systemctl, unit } = fixture();
     // First install must reach the same effective reader used by the guarded writer.
     expect(await readSystemdServiceExecStart(env, { requireEffective: true })).toBeNull();
+    expect(await readSystemdServiceRuntime(env)).toMatchObject({
+      status: "stopped",
+      missingUnit: true,
+    });
     expect(systemctl("is-enabled", "openclaw-gateway.service").status).not.toBe(0);
     const environmentFile = join(home, "gateway.systemd.env");
     writeFileSync(environmentFile, 'FIXTURE_VALUE="from file"\n');
@@ -75,6 +80,11 @@ describe.skipIf(process.platform === "win32")("survivor manager fixture", () => 
       }),
     );
     const command = await readSystemdServiceExecStart(env, { requireEffective: true });
+    expect(await readSystemdServiceRuntime(env)).toMatchObject({
+      status: "stopped",
+      state: "inactive",
+      systemd: { unit: "openclaw-gateway.service" },
+    });
     expect(command).toMatchObject({
       programArguments,
       workingDirectory: home,
@@ -117,8 +127,13 @@ describe.skipIf(process.platform === "win32")("survivor manager fixture", () => 
     await expect(readSystemdServiceExecStart(env, { requireEffective: true })).rejects.toThrow(
       "could not be inspected",
     );
+    expect(await readSystemdServiceRuntime(env)).toMatchObject({ status: "unknown" });
     rmSync(unit);
     expect(await readSystemdServiceExecStart(env, { requireEffective: true })).toBeNull();
+    expect(await readSystemdServiceRuntime(env)).toMatchObject({
+      status: "stopped",
+      missingUnit: true,
+    });
   });
 
   it("keeps the inspected service alive after the caller terminal closes and drains restart children", async () => {
@@ -195,6 +210,11 @@ raise SystemExit(code if code >= 0 else 128 - code)
       await waitForStarts(1);
       expect.soft(systemctl("is-active", "openclaw-gateway.service").status).toBe(0);
       const inspected = await readSystemdServiceExecStart(env, { requireEffective: true });
+      expect(await readSystemdServiceRuntime(env)).toMatchObject({
+        status: "running",
+        state: "active",
+        pid: Number(readFileSync(env.OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE, "utf8")),
+      });
       expect(records()[0]).toEqual({
         pid: expect.any(Number),
         argv: inspected?.programArguments.slice(2),
@@ -222,7 +242,9 @@ raise SystemExit(code if code >= 0 else 128 - code)
       expect(records()[1]?.pid).not.toBe(records()[0]?.pid);
       expect(() => process.kill(records()[0]!.pid, 0)).toThrow();
     } finally {
-      const stopped = systemctl("stop", "openclaw-gateway.service");
+      const stopped = shell('source "$1"; stop_update_restart_probe_gateway 40s', [
+        resolve("scripts/lib/openclaw-e2e-instance.sh"),
+      ]);
       expect(stopped.status, stopped.stderr).toBe(0);
       for (const { pid } of records()) {
         try {
@@ -235,6 +257,7 @@ raise SystemExit(code if code >= 0 else 128 - code)
         }
       }
       expect(existsSync(env.OPENCLAW_UPGRADE_SURVIVOR_SYSTEMCTL_SHIM_PID_FILE)).toBe(false);
+      expect(await readSystemdServiceRuntime(env)).toMatchObject({ status: "stopped" });
     }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The published-baseline upgrade test tried to start the old Gateway after creating migration specimens and candidate-only plugin configuration. Correct startup and consent guards rejected that state before the candidate updater could be tested. Restoring the authored configuration while the baseline was live also enabled reload and could restart it during migration.

## Why This Change Was Made

Initialize the published baseline and its authenticated service before creating migration specimens. Reuse the existing strict auth-only configuration and probe identity initializer; remove the separate plugin-specific parking path and duplicate identity seeder. Stop the baseline through the fixture manager and require affirmative inactive evidence before restoring the exact authored configuration. Failed or unknown shutdown retains the original snapshot and fails the run.

The candidate then receives the original specimens and owns migration and explicit plugin consent. After that repair, start the same installed service without rewriting its unit or environment or reseeding identity. Require strict readiness and unchanged unit/environment hashes. The following updater must still replace that exact supervisor through its own restart and pass the existing authentication and survival assertions; preparation does not count as restart proof.

The fixture manager now implements the current reader's exact LoadState query alongside the published reader's query, using the canonical unit parser. Unsupported queries still fail. Shared phase reporting propagates failed commands without disabling shell error handling. The current-install sibling retains its existing ordering.

## User Impact

Test harness only. Product startup, consent, migration, service ownership and release gates are unchanged. No new configuration option, retry, timeout increase, relaxed assertion or product fallback. The harness delta is +155/-180 (net -25); regression tests are +541/-53.

## Evidence

The retained failing full release run is 33423706952 at 594f5003092453884b78320d0417450f035d25a9. Focused native runs exposed the earlier consent/startup failures, then the missing manager query and live configuration-reload race. Those runs failed and are not green evidence for this revision.

The final composition on 52aec2337fc85e9114a4e466be01f983f767dbe8 passes 300 local tests, with two existing Linux-only cases skipped on macOS. The actual nine-path changed-file gate and final test-only gate pass. Managed Codex review of the final complete diff found no actionable P0–P2 findings. Regression coverage includes stop-before-restore, failed/unknown shutdown, unchanged unit/environment, native start rather than reinstall, strict prepared readiness, error propagation, and the final updater-owned restart requirement.

The focused packaged upgrade proof now passes in 235.044 seconds on an isolated Linux machine with four CPUs: published `openclaw@2026.8.1` to the canonical package built from `52aec2337fc85e9114a4e466be01f983f767dbe8`, using the exact fixture bytes in this PR. Candidate package SHA-256: `55463c1f50a00ee5889a07650165287db1db7326b276016b0687b94045661840`. The canonical scheduler, full scenario, and container all exited 0; source hashes matched after execution. Initial migration, explicit plugin consent, strict prepared readiness, unchanged unit/environment hashes, updater-owned supervisor replacement, authenticated probes, and state survival all passed. This uses real packaged Gateway processes under the existing simulated systemd manager. [Testbox workflow](https://github.com/openclaw/openclaw/actions/runs/33439062933).

The previous ClawSweeper finding and rank-up request to quiesce before restoration are implemented and covered; native completion evidence is above. Exact-head required CI remains the final landing gate. This component proof does not claim full release verification is green.
