### PR TITLE
fix: repair v17 agent schema before index validation

### DIFF
--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -705,16 +705,15 @@ export function ensureOpenClawAgentDatabaseSchema(
   options: OpenClawAgentDatabaseOptions & { register?: boolean },
 ): void {
   const agentId = normalizeAgentId(options.agentId);
-  const databaseOptions = { ...options, agentId };
-  const pathname = resolveOpenClawAgentSqlitePath(databaseOptions);
-  ensureOpenClawAgentDatabasePermissions(pathname, databaseOptions);
+  const pathname = resolveOpenClawAgentSqlitePath({ ...options, agentId });
+  ensureOpenClawAgentDatabasePermissions(pathname, options);
   db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
   assertSupportedAgentSchemaVersion(db, pathname);
   assertExistingAgentSchemaOwner(readExistingAgentSchemaMeta(db), agentId, pathname);
   if (readSqliteUserVersion(db) === AGENT_MEDIA_SCHEMA_VERSION) {
     maintenanceAuthority.assertAgentDatabaseMaintenanceAuthority();
     const legacySql = withLegacySessionParticipantsSchema(OPENCLAW_AGENT_SCHEMA_SQL);
-    // Keep canonical index recovery reachable before rebuilding the v17 identity table.
+    ensureSessionAdditiveColumns(db);
     verifyAndRepairCanonicalSqliteIndexes(db, pathname, legacySql, {
       allowMissingColumns: true,
       validateAfterRepair: () =>
@@ -730,7 +729,7 @@ export function ensureOpenClawAgentDatabaseSchema(
     busyTimeoutMs: OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
   });
   ensureAgentSchema(db, agentId, pathname);
-  ensureOpenClawAgentDatabasePermissions(pathname, databaseOptions);
+  ensureOpenClawAgentDatabasePermissions(pathname, options);
   if (options.register === true) {
     registerOpenClawAgentDatabase({ agentId, path: pathname, env: options.env });
   }

--- a/src/state/openclaw-agent-participants-migration.test.ts
+++ b/src/state/openclaw-agent-participants-migration.test.ts
@@ -90,6 +90,37 @@ describe("participant identity migration", () => {
     });
   });
 
+  it("upgrades a v17 database when the route-context trigger is absent", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const initial = openOpenClawAgentDatabase({ agentId: "main", env: state.env });
+      const databasePath = initial.path;
+      initial.db.exec(`
+        DROP TABLE session_participants;
+        DROP TRIGGER session_conversations_route_context_invalidate_after_update;
+        ALTER TABLE session_conversations DROP COLUMN route_context_json;
+        DROP INDEX idx_agent_transcript_event_identity_sequence;
+        PRAGMA user_version = 17;
+        UPDATE schema_meta SET schema_version = 17;
+      `);
+      closeOpenClawAgentDatabasesForTest();
+
+      const result = await compactDoctorSessionSqliteTarget(
+        { agentId: "main", storePath: databasePath },
+        { env: state.env, operation: "import-finalize" },
+      );
+      expect(result.skipped).toBe(false);
+      const reopened = openOpenClawAgentDatabase({ agentId: "main", env: state.env });
+      expect(reopened.db.prepare("PRAGMA user_version").get()?.user_version).toBe(19);
+      expect(
+        reopened.db
+          .prepare(
+            "SELECT name FROM sqlite_schema WHERE type = 'trigger' AND name = 'session_conversations_route_context_invalidate_after_update'",
+          )
+          .get(),
+      ).toEqual({ name: "session_conversations_route_context_invalidate_after_update" });
+    });
+  });
+
   it.each(["absent", "rollback", "unknown-column", "marker-mismatch"] as const)(
     "handles %s atomically",
     async (scenario) => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators running `doctor --fix` or import finalization on a pre-existing v17 agent database could be blocked by canonical SQLite index repair when the same-version route-context invalidation trigger was absent.

## Why This Change Was Made

The v17 maintenance preflight now installs the existing additive session columns and trigger before validating repaired canonical indexes. The participant migration and legacy-schema validation remain unchanged; the regression covers a v17-shaped database with the participant table, route-context column, trigger, and transcript identity index absent.

## User Impact

Pre-existing v17 agent databases with this valid historical drift can complete maintenance migration to the current schema instead of failing inside canonical index repair. No live state or migration policy is changed.

## Evidence

- Base reproduction at `ace8a13f19ccc2805b3d458026de3ab4bbbd8878`: the new focused regression failed with `SQLite canonical index idx_agent_transcript_event_identity_sequence failed ... missing or drifted trigger session_conversations_route_context_invalidate_after_update`.
- Fixed regression: `node scripts/run-vitest.mjs run src/state/openclaw-agent-participants-migration.test.ts -t "route-context trigger"` — 1 passed.
- Full focused suite: `node scripts/run-vitest.mjs run src/state/openclaw-agent-participants-migration.test.ts` — 15 passed.
- Adjacent suites: `node scripts/run-vitest.mjs run src/state/openclaw-agent-db-session-migrations.test.ts src/state/openclaw-agent-db.test.ts` — 123 passed, 4 skipped.
- Production typecheck: `node scripts/run-tsgo.mjs -p tsconfig.core.json --incremental --tsBuildInfoFile /tmp/openclaw-v17-core.tsbuildinfo` — passed.
- Changed-file formatting and focused lint — passed; fresh P0 autoreview reported no actionable findings.
- `check:changed` structural lanes passed; its broad core test typecheck was blocked by the existing shared dependency environment missing `pako` declarations at `ui/vite.config.ts:9`, unrelated to this diff.

Exact branch head: `7886723c6d000b4a5b06c35f19a69d48e022c11c` (parent `ace8a13f19ccc2805b3d458026de3ab4bbbd8878`).
