### PR TITLE
fix(ui): show Default permission icon in the macOS composer

### DIFF
--- a/docs/gateway/permission-modes.md
+++ b/docs/gateway/permission-modes.md
@@ -34,7 +34,7 @@ The Control UI permission picker labels Default with the agent's resolved exec p
 
 ## Change permissions during a task
 
-Choose a mode from the chat composer's **Permissions** menu. The picker shows **Applying permissions…** until the running task acknowledges the change. Other clients viewing the same session also see this pending state.
+Choose a mode from the chat composer's **Permissions** menu. The picker immediately shows the selected mode's icon and label while the change settles, and temporarily blocks another selection for that session. Other clients see the mode after the Gateway publishes the updated session. If the change fails, the picker reconciles with the authoritative session state and shows an error; if that state cannot be refreshed yet, it keeps the optimistic selection until the next session update rather than restoring a potentially stale mode.
 
 - **Codex:** OpenClaw interrupts the active native turn and stops its background terminals, then continues in the same conversation with the new permissions and an internal **Permission change** notice. It does not reset the conversation or replay the original request.
 - **OpenClaw native runtime:** OpenClaw refreshes the active tool policy without restarting the conversation. Subsequent tool calls use the updated permissions.

--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -442,6 +442,7 @@ export type SessionsBranchesSwitchResult =
 export type SessionsPatchResult = SessionsPatchResultBase<{
   sessionId: string;
   updatedAt?: number;
+  permissionMode?: GatewaySessionRow["permissionMode"];
   archivedAt?: number;
   contextWindow?: string;
   thinkingLevel?: string;

--- a/ui/src/e2e/assistant-panel-context.e2e.test.ts
+++ b/ui/src/e2e/assistant-panel-context.e2e.test.ts
@@ -64,7 +64,7 @@ suite.define(() => {
           defaults: { modelProvider: "openai", model: "gpt-5.6-luna", contextTokens: null },
           sessions: [renamed, home],
         };
-        await gateway.setMethodResponse("sessions.list", list);
+        await gateway.setSessionsListResponse(list);
         await gateway.emitGatewayEvent("sessions.changed", {
           ...renamed,
           sessionKey: work.key,

--- a/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
@@ -155,7 +155,7 @@ async function installActiveRunSnapshot(
   const snapshot = activeRunSnapshot(runId, prompt, streamText, opts);
   await gateway.setMethodResponse("chat.startup", snapshot);
   await gateway.setMethodResponse("chat.history", snapshot);
-  await gateway.setMethodResponse("sessions.list", {
+  await gateway.setSessionsListResponse({
     count: 1,
     defaults: { contextTokens: null, model: "gpt-5.5", modelProvider: "openai" },
     path: "",
@@ -431,7 +431,7 @@ suite.define(() => {
         });
         await gateway.setMethodResponse("chat.startup", history);
         await gateway.setMethodResponse("chat.history", history);
-        await gateway.setMethodResponse("sessions.list", {
+        await gateway.setSessionsListResponse({
           count: 1,
           sessions: [sessionInfo],
           defaults: {},
@@ -490,7 +490,7 @@ suite.define(() => {
         await gateway.setHistoryMessages(completeHistory.messages);
         await gateway.setMethodResponse("chat.startup", completeHistory);
         await gateway.setMethodResponse("chat.history", completeHistory);
-        await gateway.setMethodResponse("sessions.list", {
+        await gateway.setSessionsListResponse({
           count: 1,
           sessions: [replySessionInfo],
           defaults: {},

--- a/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
+++ b/ui/src/e2e/chat-active-turn-recovery.e2e.test.ts
@@ -97,6 +97,7 @@ function activeRunSnapshot(
       hasActiveRun: true,
       key: "agent:main:main",
       kind: "direct",
+      sessionId: "active-turn-recovery-session",
       status: "running",
       updatedAt: 1_000,
     },

--- a/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
@@ -45,6 +45,7 @@ function sessionsList(
         kind: "direct",
         model: model.id,
         modelProvider: model.provider,
+        sessionId: "capability-menu-session",
         status: "done",
         updatedAt: Date.now(),
         ...(toolOverrides ? { toolOverrides } : {}),

--- a/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-capability-menu.e2e.test.ts
@@ -391,8 +391,7 @@ suite.define(() => {
         .toBe(false);
 
       await gateway.deferNext("tools.effective");
-      await gateway.setMethodResponse(
-        "sessions.list",
+      await gateway.setSessionsListResponse(
         sessionsList(
           { mcpToolsDeny: { github: ["search_items"] } },
           { id: "gpt-5.6", provider: "openai" },

--- a/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
@@ -930,8 +930,7 @@ suite.define(() => {
       await page.getByRole("button", { name: "Queue message" }).click();
       await page.locator(".chat-queue").getByText(queuedPrompt).waitFor({ timeout: 10_000 });
 
-      await gateway.setMethodResponse(
-        "sessions.list",
+      await gateway.setSessionsListResponse(
         chatSessionListResponse([
           {
             activeLeafEntryId: "leaf-active",

--- a/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.active-run-follow-ups.e2e.test.ts
@@ -939,6 +939,8 @@ suite.define(() => {
             key: "global",
             kind: "global",
             label: "Global",
+            sessionId: "global-active-run",
+            status: "running",
             updatedAt: Date.now(),
           },
           {
@@ -948,6 +950,8 @@ suite.define(() => {
             key: "agent:main:main",
             kind: "direct",
             label: "Main",
+            sessionId: "main-active-run",
+            status: "running",
             updatedAt: Date.now(),
           },
         ]),

--- a/ui/src/e2e/chat-flow.messaging.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.messaging.e2e.test.ts
@@ -841,8 +841,7 @@ suite.define(() => {
         key: channelSessionKey,
         clearQueued: true,
       });
-      await gateway.setMethodResponse(
-        "sessions.list",
+      await gateway.setSessionsListResponse(
         chatSessionListResponse([
           {
             activeRunIds: [],

--- a/ui/src/e2e/chat-flow.model-picker-refresh.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.model-picker-refresh.e2e.test.ts
@@ -92,7 +92,7 @@ suite.define(() => {
         .toBe("openai/gpt-5.6-terra");
       await screenshot(page, "06-global-target-after-touch-selection.png");
 
-      await gateway.setMethodResponse("sessions.list", {
+      await gateway.setSessionsListResponse({
         ts: 2,
         path: "",
         count: 1,

--- a/ui/src/e2e/chat-flow.model-picker-refresh.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.model-picker-refresh.e2e.test.ts
@@ -50,7 +50,6 @@ suite.define(() => {
     };
     const gateway = await installMockGateway(page, {
       sessionKey: session.key,
-      sessionInfo: session,
       models: [
         { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" },
         { id: "gpt-5.6-terra", name: "GPT-5.6 Terra", provider: "openai" },

--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -97,6 +97,7 @@ suite.define(() => {
       kind: "direct",
       label: "Session A",
       permissionMode: "guarded",
+      sessionId: "session-a-original",
       sessionRoot: "/workspace/projects/openclaw",
       updatedAt: 2,
     };
@@ -142,6 +143,7 @@ suite.define(() => {
       await pane.locator('[data-chat-permission-option="workspace"]').click();
       const patchRequest = await gateway.waitForRequest("sessions.patch");
       expect(requireRecord(patchRequest.params)).toMatchObject({
+        expectedSessionId: session.sessionId,
         key: session.key,
         permissionMode: "workspace",
       });
@@ -185,8 +187,35 @@ suite.define(() => {
         chatSessionListResponse([{ ...session, permissionMode: undefined, updatedAt: 4 }]),
       );
       await expect.poll(() => trigger.getAttribute("data-chat-select-value")).toBe("");
-      await expect.poll(() => trigger.isEnabled()).toBe(true);
       expect(await trigger.textContent()).toContain("Default");
+
+      await gateway.deferNext("sessions.patch");
+      await trigger.click();
+      await pane.locator('[data-chat-permission-option="full"]').click();
+      const stalePatch = (await waitForRequests(gateway, "sessions.patch", 3))[2];
+      expect(requireRecord(stalePatch?.params)).toMatchObject({
+        expectedSessionId: session.sessionId,
+        key: session.key,
+        permissionMode: "full",
+      });
+      const replacement = {
+        ...session,
+        permissionMode: "read-only",
+        sessionId: "session-after-replacement",
+        updatedAt: 5,
+      };
+      await gateway.setMethodResponse("sessions.list", chatSessionListResponse([replacement]));
+      await gateway.rejectDeferred("sessions.patch", {
+        code: "INVALID_REQUEST",
+        message: "session identity changed; refresh and retry",
+      });
+
+      await expect.poll(() => trigger.getAttribute("data-chat-select-value")).toBe("read-only");
+      await expect.poll(() => trigger.isEnabled()).toBe(true);
+      await pane
+        .locator(".chat-error")
+        .getByText("Failed to update permissions", { exact: false })
+        .waitFor();
     } finally {
       await suite.closeBrowserContext(context);
     }
@@ -876,6 +905,7 @@ suite.define(() => {
             kind: "direct",
             label: "Session A",
             permissionMode: "workspace",
+            sessionId: "session-a-send-barrier",
             updatedAt: 2,
           },
         ]),
@@ -896,6 +926,9 @@ suite.define(() => {
       const patchRequest = await gateway.waitForRequest("sessions.patch");
       expect(requireRecord(patchRequest.params)).toMatchObject({
         key: "agent:main:session-a",
+        ...(setting.label === "Full Access permission"
+          ? { expectedSessionId: "session-a-send-barrier" }
+          : {}),
         ...setting.patch,
       });
 

--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -1,5 +1,4 @@
 import { expect, it } from "vitest";
-import { t } from "../i18n/lib/translate.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
   chatSessionListResponse,
@@ -147,7 +146,6 @@ suite.define(() => {
         permissionMode: "workspace",
       });
       await waitForRequests(gateway, "sessions.list", firstListCount + 1);
-      expect(await trigger.getAttribute("data-chat-select-value")).toBe("guarded");
 
       await gateway.emitGatewayEvent("sessions.changed", {
         ...session,
@@ -156,11 +154,6 @@ suite.define(() => {
         sessionKey: session.key,
         updatedAt: 3,
       });
-      // The initiating picker owns the previous display until its canonical
-      // patch refresh settles, even when a session event arrives first.
-      expect(await trigger.getAttribute("data-chat-select-value")).toBe("guarded");
-      expect(await trigger.textContent()).toContain("Applying permissions");
-      expect(await trigger.isEnabled()).toBe(false);
       await gateway.resolveDeferred(
         "sessions.list",
         chatSessionListResponse([{ ...session, permissionMode: "workspace", updatedAt: 3 }]),
@@ -179,7 +172,6 @@ suite.define(() => {
         permissionMode: null,
       });
       await waitForRequests(gateway, "sessions.list", secondListCount + 1);
-      expect(await trigger.getAttribute("data-chat-select-value")).toBe("workspace");
 
       await gateway.emitGatewayEvent("sessions.changed", {
         ...session,
@@ -188,8 +180,6 @@ suite.define(() => {
         sessionKey: session.key,
         updatedAt: 4,
       });
-      expect(await trigger.getAttribute("data-chat-select-value")).toBe("workspace");
-      expect(await trigger.isEnabled()).toBe(false);
       await gateway.resolveDeferred(
         "sessions.list",
         chatSessionListResponse([{ ...session, permissionMode: undefined, updatedAt: 4 }]),
@@ -197,26 +187,6 @@ suite.define(() => {
       await expect.poll(() => trigger.getAttribute("data-chat-select-value")).toBe("");
       await expect.poll(() => trigger.isEnabled()).toBe(true);
       expect(await trigger.textContent()).toContain("Default");
-
-      const publishRemoteChange = async (permissionModePending: boolean, updatedAt: number) => {
-        const row = { ...session, permissionMode: "read-only", permissionModePending, updatedAt };
-        // Event-triggered roster refreshes must describe the same remote change.
-        await gateway.setMethodResponse("sessions.list", chatSessionListResponse([row]));
-        await gateway.emitGatewayEvent("sessions.changed", {
-          ...row,
-          reason: "patch",
-          sessionKey: session.key,
-        });
-      };
-      await publishRemoteChange(true, 5);
-      await expect.poll(() => trigger.textContent()).toContain("Applying permissions");
-      expect(await trigger.isEnabled()).toBe(false);
-      await publishRemoteChange(false, 6);
-      await expect.poll(() => trigger.getAttribute("data-chat-select-value")).toBe("read-only");
-      await expect.poll(() => trigger.isEnabled()).toBe(true);
-      expect(await trigger.textContent()).toContain(
-        t("chat.permissionControls.modes.read-only.label"),
-      );
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts
@@ -204,7 +204,7 @@ suite.define(() => {
         sessionId: "session-after-replacement",
         updatedAt: 5,
       };
-      await gateway.setMethodResponse("sessions.list", chatSessionListResponse([replacement]));
+      await gateway.setSessionsListResponse(chatSessionListResponse([replacement]));
       await gateway.rejectDeferred("sessions.patch", {
         code: "INVALID_REQUEST",
         message: "session identity changed; refresh and retry",

--- a/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.sidebar-presentation.e2e.test.ts
@@ -207,7 +207,7 @@ suite.define(() => {
           ),
         });
       }
-      await gateway.setMethodResponse("sessions.list", completed);
+      await gateway.setSessionsListResponse(completed);
       const listCount = (await gateway.getRequests("sessions.list")).length;
       await gateway.emitGatewayEvent("session.message", {
         activeRunIds: [],

--- a/ui/src/e2e/chat-permission-refresh.e2e.test.ts
+++ b/ui/src/e2e/chat-permission-refresh.e2e.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import type { ApplicationContext } from "../app/context.ts";
 import {
   chatSessionListResponse,
   controlUiSessionUrl,
@@ -7,6 +8,7 @@ import {
 } from "./chat-flow.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
+type PermissionTestApp = HTMLElement & { runtime?: { context: ApplicationContext } };
 
 suite.define(() => {
   it("keeps a saved permission mode when its list refresh fails", async () => {
@@ -56,6 +58,73 @@ suite.define(() => {
         .locator(".chat-error")
         .getByText("Roster refresh unavailable", { exact: false })
         .waitFor();
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+
+  it("keeps a newer permission event after an older patch response arrives", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const session = {
+      key: "agent:main:permission-ordering",
+      kind: "direct",
+      label: "Permission ordering",
+      permissionMode: "guarded",
+      sessionId: "permission-ordering-generation",
+      updatedAt: 1,
+    };
+    const gateway = await installMockGateway(page, {
+      methodResponses: { "sessions.list": chatSessionListResponse([session]) },
+      sessionKey: session.key,
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, session.key));
+      const pane = page.locator('openclaw-chat-pane[aria-hidden="false"]');
+      const trigger = pane.locator('[data-chat-permission-select="true"]');
+      await expect.poll(() => trigger.getAttribute("data-chat-select-value")).toBe("guarded");
+      const listRequests = (await gateway.getRequests("sessions.list")).length;
+      await gateway.deferNext("sessions.patch", { permissionMode: "workspace" });
+
+      await trigger.click();
+      await pane.locator('[data-chat-permission-option="workspace"]').click();
+      await gateway.waitForRequest("sessions.patch");
+      await gateway.deferNext("sessions.list");
+      await gateway.emitGatewayEvent("sessions.changed", {
+        ...session,
+        sessionKey: session.key,
+        reason: "patch",
+        permissionMode: "full",
+        updatedAt: 3,
+      });
+      await expect
+        .poll(() =>
+          page.evaluate((key) => {
+            const app = document.querySelector("openclaw-app") as PermissionTestApp;
+            return app.runtime?.context.sessions.state.result?.sessions.find(
+              (row) => row.key === key,
+            )?.permissionMode;
+          }, session.key),
+        )
+        .toBe("full");
+      await gateway.waitForRequest("sessions.list", { after: listRequests });
+      await gateway.resolveDeferred("sessions.patch", {
+        key: session.key,
+        entry: {
+          permissionMode: "workspace",
+          sessionId: session.sessionId,
+          updatedAt: 2,
+        },
+      });
+
+      await expect.poll(() => trigger.getAttribute("data-chat-select-value")).toBe("full");
+      await expect.poll(() => trigger.isEnabled()).toBe(true);
+      expect(await gateway.getRequests("sessions.list")).toHaveLength(listRequests + 1);
     } finally {
       await suite.closeBrowserContext(context);
     }

--- a/ui/src/e2e/chat-permission-refresh.e2e.test.ts
+++ b/ui/src/e2e/chat-permission-refresh.e2e.test.ts
@@ -1,0 +1,63 @@
+import { expect, it } from "vitest";
+import {
+  chatSessionListResponse,
+  controlUiSessionUrl,
+  createChatFlowE2eSuite,
+  installMockGateway,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+
+suite.define(() => {
+  it("keeps a saved permission mode when its list refresh fails", async () => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const session = {
+      key: "agent:main:permission-refresh",
+      kind: "direct",
+      label: "Permission refresh",
+      permissionMode: "guarded",
+      sessionId: "permission-refresh-generation",
+      updatedAt: 1,
+    };
+    const gateway = await installMockGateway(page, {
+      methodResponses: { "sessions.list": chatSessionListResponse([session]) },
+      sessionKey: session.key,
+    });
+
+    try {
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, session.key));
+      const pane = page.locator('openclaw-chat-pane[aria-hidden="false"]');
+      const trigger = pane.locator('[data-chat-permission-select="true"]');
+      await expect.poll(() => trigger.getAttribute("data-chat-select-value")).toBe("guarded");
+      const listRequests = (await gateway.getRequests("sessions.list")).length;
+      await gateway.deferNext("sessions.list");
+
+      await trigger.click();
+      await pane.locator('[data-chat-permission-option="workspace"]').click();
+      await gateway.waitForRequest("sessions.patch");
+      await gateway.waitForRequest("sessions.list", { after: listRequests });
+      await gateway.rejectDeferred("sessions.list", {
+        code: "UNAVAILABLE",
+        message: "Roster refresh unavailable",
+      });
+
+      await expect.poll(() => trigger.getAttribute("data-chat-select-value")).toBe("workspace");
+      await expect.poll(() => trigger.isEnabled()).toBe(true);
+      await pane
+        .locator(".chat-error")
+        .getByText("Permissions were saved", { exact: false })
+        .waitFor();
+      await pane
+        .locator(".chat-error")
+        .getByText("Roster refresh unavailable", { exact: false })
+        .waitFor();
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/e2e/cloud-session-disk-space.e2e.test.ts
+++ b/ui/src/e2e/cloud-session-disk-space.e2e.test.ts
@@ -124,7 +124,7 @@ suite.define(() => {
     };
     const refresh = async (diskSpace: SessionPlacementDiskSpace): Promise<void> => {
       const requestCount = (await gateway.getRequests("sessions.list")).length;
-      await gateway.setMethodResponse("sessions.list", sessionsList(diskSpace));
+      await gateway.setSessionsListResponse(sessionsList(diskSpace));
       await gateway.emitGatewayEvent("sessions.changed", {
         reason: "worker-disk-space",
         sessionKey,

--- a/ui/src/e2e/cloud-workspace-conflict.e2e.test.ts
+++ b/ui/src/e2e/cloud-workspace-conflict.e2e.test.ts
@@ -214,7 +214,7 @@ suite.define(() => {
         await capture(page, "03-dismissed-live-notice.png");
 
         await page.setViewportSize({ width: 1440, height: 900 });
-        await gateway.setMethodResponse("sessions.list", sessionsList(false));
+        await gateway.setSessionsListResponse(sessionsList(false));
         await page.reload();
         await page.locator(".chat-workspace-conflict-event").waitFor({ timeout: 10_000 });
         await sessionRow.getByText("Cloud conflict cleared", { exact: true }).waitFor();
@@ -286,7 +286,6 @@ suite.define(() => {
             methodResponses: { "sessions.list": workerRecoverySessionsList(false) },
             sessionKey,
           });
-
           const response = await page.goto(controlUiSessionUrl(suite.server.baseUrl, sessionKey));
           expect(response?.status()).toBe(200);
           await page.getByText("Remote work completed successfully.").waitFor({ timeout: 10_000 });
@@ -303,10 +302,7 @@ suite.define(() => {
             await rename.press("Enter");
             await gateway.waitForRequest("sessions.patch");
           } else {
-            await gateway.setMethodResponse(
-              "sessions.list",
-              workerRecoverySessionsList(true, failedState),
-            );
+            await gateway.setSessionsListResponse(workerRecoverySessionsList(true, failedState));
             await page.reload();
           }
           const alert = page

--- a/ui/src/e2e/desktop-document-mode.e2e.test.ts
+++ b/ui/src/e2e/desktop-document-mode.e2e.test.ts
@@ -197,8 +197,7 @@ suite.define(() => {
           await panel.getByText("Desktop sources", { exact: true }).waitFor();
           expect(await gateway.getRequests("desktop.observe")).toHaveLength(0);
           await gateway.setMethodResponse("environments.list", inventory);
-          await gateway.setMethodResponse(
-            "sessions.list",
+          await gateway.setSessionsListResponse(
             chatSessionListResponse([
               {
                 ...session,

--- a/ui/src/e2e/home-attention.e2e.test.ts
+++ b/ui/src/e2e/home-attention.e2e.test.ts
@@ -54,7 +54,7 @@ async function publishSessionRow(
   gateway: MockGatewayControls,
   row: GatewaySessionRow,
 ): Promise<void> {
-  await gateway.setMethodResponse("sessions.list", sessionsList(row));
+  await gateway.setSessionsListResponse(sessionsList(row));
   const requestCount = (await gateway.getRequests("sessions.list")).length;
   await gateway.emitGatewayEvent("sessions.changed", {
     key: row.key,

--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -482,7 +482,7 @@ suite.define(() => {
         label: string,
         includeNeutral = false,
       ) => {
-        await gateway.setMethodResponse("sessions.list", {
+        await gateway.setSessionsListResponse({
           count: includeNeutral ? 2 : 1,
           path: "",
           defaults: SESSION_LIST_DEFAULTS,
@@ -585,7 +585,7 @@ suite.define(() => {
       const promptBubbles = page.locator(".chat-group.user .chat-bubble", { hasText: message });
       await expect.poll(() => promptBubbles.count()).toBe(1);
 
-      await gateway.setMethodResponse("sessions.list", {
+      await gateway.setSessionsListResponse({
         count: 4,
         path: "",
         defaults: {},

--- a/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-dispatch.e2e.test.ts
@@ -482,6 +482,13 @@ suite.define(() => {
         label: string,
         includeNeutral = false,
       ) => {
+        const placement = {
+          state,
+          generation,
+          createdAtMs: 1,
+          updatedAtMs: generation,
+          stateChangedAtMs: generation,
+        };
         await gateway.setSessionsListResponse({
           count: includeNeutral ? 2 : 1,
           path: "",
@@ -491,14 +498,10 @@ suite.define(() => {
               key: sessionKey,
               kind: "direct",
               label: "Cloud session",
+              sessionId: "session-cloud-e2e",
+              status: "running",
               updatedAt: Date.now(),
-              placement: {
-                state,
-                generation,
-                createdAtMs: 1,
-                updatedAtMs: generation,
-                stateChangedAtMs: generation,
-              },
+              placement,
             },
             ...(includeNeutral
               ? [
@@ -594,9 +597,22 @@ suite.define(() => {
             key: sessionKey,
             kind: "direct",
             label: "Cloud session",
+            sessionId: "session-cloud-e2e",
+            status: "running",
             updatedAt: Date.now(),
             worktree: { id: "worktree-1", branch: "openclaw/cloud-e2e", repoRoot: WORKSPACE },
-            placement: { state: "active" },
+            placement: {
+              state: "active",
+              generation: 5,
+              createdAtMs: 1,
+              updatedAtMs: 5,
+              stateChangedAtMs: 5,
+              environmentId: "worker-1",
+              activeOwnerEpoch: 1,
+              workerBundleHash: "a".repeat(64),
+              workspaceBaseManifestRef: "manifest-1",
+              remoteWorkspaceDir: "/workspace",
+            },
           },
           {
             key: "agent:cloud:managed-e2e",

--- a/ui/src/e2e/people-activity-card.e2e.test.ts
+++ b/ui/src/e2e/people-activity-card.e2e.test.ts
@@ -176,10 +176,7 @@ suite.define(() => {
         expect(initialShift).not.toBe("");
         const listRequests = (await gateway.getRequests("sessions.list")).length;
         const updatedScenario = scenario(updatedRecentLabel);
-        await gateway.setMethodResponse(
-          "sessions.list",
-          updatedScenario.methodResponses["sessions.list"],
-        );
+        await gateway.setSessionsListResponse(updatedScenario.methodResponses["sessions.list"]);
         await gateway.emitGatewayEvent("sessions.changed", {
           reason: "update",
           sessionKey: "agent:main:card-recent",
@@ -246,8 +243,7 @@ suite.define(() => {
         );
         const focusedListRequests = (await gateway.getRequests("sessions.list")).length;
         const focusUpdatedScenario = scenario(focusUpdatedRecentLabel);
-        await gateway.setMethodResponse(
-          "sessions.list",
+        await gateway.setSessionsListResponse(
           focusUpdatedScenario.methodResponses["sessions.list"],
         );
         await gateway.emitGatewayEvent("sessions.changed", {

--- a/ui/src/e2e/session-color.e2e.test.ts
+++ b/ui/src/e2e/session-color.e2e.test.ts
@@ -291,7 +291,7 @@ suite.define(() => {
       await page.keyboard.press("Escape");
       await page.keyboard.press("Escape");
 
-      Object.assign(designReview, { label: "Design review refreshed", color: null });
+      Object.assign(designReview, { label: "Design review refreshed", color: null, icon: "book" });
       await gateway.setSessionsListResponse(sessionsListResponse(sessions));
       await gateway.emitGatewayEvent("sessions.changed", { sessionKey: key, color: null });
       // Only the roster response carries this label; wait for that render so a

--- a/ui/src/e2e/session-color.e2e.test.ts
+++ b/ui/src/e2e/session-color.e2e.test.ts
@@ -292,7 +292,7 @@ suite.define(() => {
       await page.keyboard.press("Escape");
 
       Object.assign(designReview, { label: "Design review refreshed", color: null });
-      await gateway.setMethodResponse("sessions.list", sessionsListResponse(sessions));
+      await gateway.setSessionsListResponse(sessionsListResponse(sessions));
       await gateway.emitGatewayEvent("sessions.changed", { sessionKey: key, color: null });
       // Only the roster response carries this label; wait for that render so a
       // transient event-only clear cannot hide a stale color restored by refresh.

--- a/ui/src/e2e/session-management.archive.e2e.test.ts
+++ b/ui/src/e2e/session-management.archive.e2e.test.ts
@@ -58,7 +58,7 @@ suite.define(() => {
       // The agent's deferred self-archive reaches clients as a committed patch,
       // without running the sidebar menu's optimistic mutation path.
       const archived = { ...target, archived: true, archivedAt: 3, updatedAt: 3 };
-      await gateway.setMethodResponse("sessions.list", sessionsListResponse([main, archived]));
+      await gateway.setSessionsListResponse(sessionsListResponse([main, archived]));
       await gateway.emitGatewayEvent("sessions.changed", {
         ...archived,
         agentId: "main",
@@ -86,7 +86,7 @@ suite.define(() => {
         .click();
       await row.waitFor({ state: "detached" });
 
-      await gateway.setMethodResponse("sessions.list", sessionsListResponse([main, target]));
+      await gateway.setSessionsListResponse(sessionsListResponse([main, target]));
       await gateway.emitGatewayEvent("sessions.changed", {
         ...target,
         agentId: "main",
@@ -945,7 +945,7 @@ suite.define(() => {
         .waitFor({ state: "visible", timeout: 10_000 });
 
       const requestsBeforeDeletion = (await gateway.getRequests("sessions.list")).length;
-      await gateway.setMethodResponse("sessions.list", sessionsListResponse([mainSession]));
+      await gateway.setSessionsListResponse(sessionsListResponse([mainSession]));
       await gateway.emitGatewayEvent("sessions.changed", {
         agentId: "main",
         reason: "delete",

--- a/ui/src/e2e/session-management.created-sort.e2e.test.ts
+++ b/ui/src/e2e/session-management.created-sort.e2e.test.ts
@@ -57,10 +57,7 @@ suite.define(() => {
       await captureUiProof(suite, page, "sidebar-created-sort-before-refresh.png");
       const initialListCount = (await gateway.getRequests("sessions.list")).length;
 
-      await gateway.setMethodResponse(
-        "sessions.list",
-        sessionsListResponse([...olderRows, newestRow]),
-      );
+      await gateway.setSessionsListResponse(sessionsListResponse([...olderRows, newestRow]));
       await gateway.emitGatewayEvent("sessions.changed", {
         key: newestKey,
         kind: "direct",

--- a/ui/src/e2e/session-management.delete.e2e.test.ts
+++ b/ui/src/e2e/session-management.delete.e2e.test.ts
@@ -300,7 +300,7 @@ suite.define(() => {
       const confirmModal = await waitForConfirmModal(page);
       await captureUiProof(suite, page, "sessions-bulk-delete-original-confirm.png");
 
-      await gateway.setMethodResponse("sessions.list", sessionsListResponse([replacement]));
+      await gateway.setSessionsListResponse(sessionsListResponse([replacement]));
       await gateway.emitGatewayEvent("sessions.changed", {
         ...replacement,
         reason: "update",

--- a/ui/src/e2e/session-management.group-identity.e2e.test.ts
+++ b/ui/src/e2e/session-management.group-identity.e2e.test.ts
@@ -98,10 +98,7 @@ suite.define(() => {
         await gateway.waitForRequest("sessions.groups.put");
 
         // Deletion/recreation changes the durable identity, unlike ordinary reset.
-        await gateway.setMethodResponse(
-          "sessions.list",
-          sessionsListResponse([replacement, survivor]),
-        );
+        await gateway.setSessionsListResponse(sessionsListResponse([replacement, survivor]));
         await gateway.emitGatewayEvent("sessions.changed", {
           ...replacement,
           sessionKey: original.key,

--- a/ui/src/e2e/session-management.queue.e2e.test.ts
+++ b/ui/src/e2e/session-management.queue.e2e.test.ts
@@ -64,8 +64,7 @@ suite.define(() => {
       await captureUiProof(suite, page, `${status}-session-ring.png`);
 
       const listRequests = (await gateway.getRequests("sessions.list")).length;
-      await gateway.setMethodResponse(
-        "sessions.list",
+      await gateway.setSessionsListResponse(
         sessionsListResponse([
           sessionRow(mainKey, "Main", 2),
           sessionRow(queuedKey, "Queued repair", 1, {

--- a/ui/src/e2e/session-management.rename-identity.e2e.test.ts
+++ b/ui/src/e2e/session-management.rename-identity.e2e.test.ts
@@ -92,7 +92,7 @@ suite.define(() => {
         await input.fill("Stale rename");
         await capture("editing");
 
-        await gateway.setMethodResponse("sessions.list", sessionsListResponse([replacement]));
+        await gateway.setSessionsListResponse(sessionsListResponse([replacement]));
         await gateway.emitGatewayEvent("sessions.changed", {
           ...replacement,
           sessionKey: original.key,

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -842,7 +842,7 @@ suite.define(() => {
       // Add work metadata only after first layout so the WebKit overlap
       // regression still exercises in-place row growth.
       const listRequests = (await gateway.getRequests("sessions.list")).length;
-      await gateway.setMethodResponse("sessions.list", sessionsListResponse(rows(true)));
+      await gateway.setSessionsListResponse(sessionsListResponse(rows(true)));
       await gateway.emitGatewayEvent("sessions.changed", {
         reason: "update",
         sessionKey: "agent:main:dashboard:0f9d5c1e-6d0f-4c9a-9d84-1c2f3a4b5c6e",

--- a/ui/src/e2e/session-placement.move.e2e.test.ts
+++ b/ui/src/e2e/session-placement.move.e2e.test.ts
@@ -205,7 +205,7 @@ suite.define(() => {
         ...session.placement,
         runner: { kind: "device", status: "available" },
       } as typeof session.placement;
-      await gateway.setMethodResponse("sessions.list", chatSessionListResponse([session]));
+      await gateway.setSessionsListResponse(chatSessionListResponse([session]));
       await gateway.emitGatewayEvent("sessions.changed", { reason: "runner-availability" });
       await page.getByRole("button", { name: "Runs on device" }).waitFor();
       expect(await page.locator(".chat-pane__placement-note").count()).toBe(0);
@@ -214,7 +214,7 @@ suite.define(() => {
         ...session.placement,
         runner: { kind: "device", status: "offline" },
       } as typeof session.placement;
-      await gateway.setMethodResponse("sessions.list", chatSessionListResponse([session]));
+      await gateway.setSessionsListResponse(chatSessionListResponse([session]));
       await gateway.emitGatewayEvent("sessions.changed", { reason: "runner-availability" });
       await page.getByRole("button", { name: "Device offline" }).waitFor();
       const continueAction = page.getByText("Continue on Gateway…", { exact: true });

--- a/ui/src/e2e/sidebar-session-stability.e2e.test.ts
+++ b/ui/src/e2e/sidebar-session-stability.e2e.test.ts
@@ -89,8 +89,7 @@ suite.define(() => {
         status: "done",
         updatedAt: baseTime + 200,
       };
-      await gateway.setMethodResponse(
-        "sessions.list",
+      await gateway.setSessionsListResponse(
         sessionsListResponse([parentRow, completedChild, ...siblingRows]),
       );
       const listCount = (await gateway.getRequests("sessions.list")).length;

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5843,7 +5843,6 @@ export const en: TranslationMap & {
     permissionControls: {
       label: "Permissions",
       help: "Choose permissions for this session.",
-      applying: "Applying permissions…",
       default: "Default",
       defaultDescription: "Follow the agent's configured policy.",
       defaultWithMode: "Default ({mode})",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5848,6 +5848,7 @@ export const en: TranslationMap & {
       defaultWithMode: "Default ({mode})",
       fullRequiresAdmin: "Full access requires operator.admin access.",
       updateFailed: "Failed to update permissions: {error}",
+      refreshFailed: "Permissions were saved, but refreshing the session failed: {error}",
       modes: {
         "read-only": {
           label: "Read Only",

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -106,6 +106,8 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     | readonly [value: string, updatedAt: number]
     | readonly [value: string, updatedAt: undefined, afterRevision: number]
   >();
+  const permissionProjectionRevisions = new Map<string, number>();
+  let permissionProjectionRevision = 0;
   let canonicalListRevision = 0;
   let hydratedClient: SessionGateway["snapshot"]["client"] = null;
   let hydratedSelfUserId: string | null = null;
@@ -113,12 +115,18 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
   let sessionEventSubscriptionError: string | null = null;
   let publishedErrorSource: "session-observer" | "operation" | null = null;
 
-  const thinkingClaimKey = (key: string, agentId?: string | null) => {
+  const sessionClaimKey = (key: string, agentId?: string | null) => {
     const ownerAgentId =
       parseAgentSessionKey(key)?.agentId ??
       agentId ??
       resolveUiSelectedGlobalAgentId(gateway.snapshot);
     return `${normalizeSessionKeyForUiComparison(key)}\0agent:${normalizeAgentId(ownerAgentId)}`;
+  };
+  const claimPermissionProjection = (key: string, agentId?: string | null) => {
+    const identity = sessionClaimKey(key, agentId);
+    const revision = ++permissionProjectionRevision;
+    permissionProjectionRevisions.set(identity, revision);
+    return () => permissionProjectionRevisions.get(identity) === revision;
   };
 
   const settleThinkingLevelClaim = (
@@ -126,7 +134,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     requestRevision: number,
     agentId?: string,
   ) => {
-    const key = thinkingClaimKey(row.key, agentId);
+    const key = sessionClaimKey(row.key, agentId);
     const claim = thinkingLevelClaims.get(key);
     const newer =
       claim?.[1] !== undefined
@@ -219,7 +227,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
 
   const notifyCreated = (key: string, entry?: SessionCreateOutcome["entry"], agentId?: string) => {
     if (typeof entry?.thinkingLevel === "string" && typeof entry.updatedAt === "number") {
-      thinkingLevelClaims.set(thinkingClaimKey(key, agentId), [
+      thinkingLevelClaims.set(sessionClaimKey(key, agentId), [
         entry.thinkingLevel,
         entry.updatedAt,
       ]);
@@ -238,7 +246,8 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     publishedRow: (key) => roster.publishedRow((row) => row.key === key),
     redecorateLists: () => roster.redecorateLists(),
     notifyCreated,
-    clearThink: (key, agentId) => thinkingLevelClaims.delete(thinkingClaimKey(key, agentId)),
+    clearThink: (key, agentId) => thinkingLevelClaims.delete(sessionClaimKey(key, agentId)),
+    claimPermissionProjection,
     retirePullRequestSummary,
   });
 
@@ -378,7 +387,12 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     const reconciled = reconcileSessionChanged(previous, payload, reconcileOptions);
     let claimChanged = false;
     if (reconciled.applied && reconciled.key && eventInfo) {
-      const claimKey = thinkingClaimKey(reconciled.key, eventInfo.agentId);
+      if (eventInfo.hasPermissionMode) {
+        claimPermissionProjection(reconciled.key, eventInfo.agentId ?? state.agentId);
+        // The pending replacement predates this applied event, including its error outcome.
+        roster.invalidateForegroundPublication();
+      }
+      const claimKey = sessionClaimKey(reconciled.key, eventInfo.agentId);
       const claim = thinkingLevelClaims.get(claimKey);
       const thinkingLevel = eventInfo.thinkingLevel;
       const eventIsCurrent =
@@ -462,6 +476,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
       }
       const hadPullRequestSummaries = pullRequestSummaries.size > 0;
       thinkingLevelClaims.clear();
+      permissionProjectionRevisions.clear();
       roster.reset();
       sessionEventSubscription.reset();
       sessionEventSubscriptionError = null;
@@ -629,7 +644,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     setArchivePending: mutations.setArchivePending,
     assignOwner: mutations.assignOwner,
     retireModelOverride: mutations.retireModelOverride,
-    think: (key, agentId) => thinkingLevelClaims.get(thinkingClaimKey(key, agentId))?.[0],
+    think: (key, agentId) => thinkingLevelClaims.get(sessionClaimKey(key, agentId))?.[0],
     patchRowLocal: mutations.patchRowLocal,
     isPreparedWorkSession: mutations.isPreparedWorkSession,
     pullRequestSummary,

--- a/ui/src/lib/sessions/index.ts
+++ b/ui/src/lib/sessions/index.ts
@@ -38,7 +38,7 @@ export type {
   SessionListSnapshot,
   SessionMessageSubscription,
 } from "./session-capability.ts";
-export type { SessionPatch } from "./patch.ts";
+export type { SessionPatch, SessionPatchResult } from "./patch.ts";
 export { DEFAULT_SESSION_LIST_QUERY, SESSIONS_PAGE_DEFAULT_LIMIT } from "./session-requests.ts";
 export { reconcileSessionRunTerminal, type SessionRunTerminal } from "./reconcile.ts";
 export { requestSessionCreate } from "./create.ts";
@@ -234,6 +234,7 @@ export function createSessionCapability(gateway: SessionGateway): SessionCapabil
     readState: () => state,
     publish,
     refreshReplacement: (agentId) => roster.refreshReplacement(agentId),
+    refreshReplacementResult: (agentId) => roster.refreshReplacementResult(agentId),
     publishedRow: (key) => roster.publishedRow((row) => row.key === key),
     redecorateLists: () => roster.redecorateLists(),
     notifyCreated,

--- a/ui/src/lib/sessions/patch.ts
+++ b/ui/src/lib/sessions/patch.ts
@@ -45,8 +45,10 @@ export type SessionPatchOptions = {
   deferListRefresh?: boolean;
 };
 
+export type SessionPatchResult = SessionsPatchResult & { listRefreshError?: string };
+
 export type SessionPatchRoute = (
   key: string,
   patch: SessionPatch,
   options?: SessionPatchOptions,
-) => Promise<SessionsPatchResult | null>;
+) => Promise<SessionPatchResult | null>;

--- a/ui/src/lib/sessions/reconcile.ts
+++ b/ui/src/lib/sessions/reconcile.ts
@@ -76,6 +76,7 @@ type SessionChangedEventInfo = {
   reason: string | null;
   sessionId?: string;
   updatedAt: number | null;
+  hasPermissionMode: boolean;
   thinkingLevel?: string | null;
   agentId: string | null;
   runId: string | null;
@@ -327,6 +328,7 @@ function parseSessionChangedEvent(payload: unknown): ParsedSessionChangedEvent |
       reason,
       sessionId: stringValue(recordValue(source, "sessionId")),
       updatedAt: typeof updatedAt === "number" ? updatedAt : null,
+      hasPermissionMode: Object.hasOwn(source, "permissionMode"),
       thinkingLevel:
         typeof thinkingLevel === "string"
           ? thinkingLevel

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -431,7 +431,11 @@ export function createSessionMutations(host: SessionMutationsHost) {
       // turn a failed refresh into an apparent rollback of the committed patch.
       let refreshOutcome: SessionRefreshOutcome = { status: "refreshed" };
       if (!options.deferListRefresh) {
-        refreshOutcome = await host.refreshReplacementResult(options.agentId);
+        if (Object.hasOwn(patchParams, "permissionMode")) {
+          refreshOutcome = await host.refreshReplacementResult(options.agentId);
+        } else {
+          await host.refreshReplacement(options.agentId);
+        }
         if (!host.connection.isCurrent(scope)) {
           settleOptimisticPatch(false);
           return (await reconcileConfirmedPreviousConnection(scope, options.agentId))

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -3,11 +3,7 @@ import type {
   SessionsAssignOwnerParams,
   SessionsAssignOwnerResult,
 } from "../../../../packages/gateway-protocol/src/index.js";
-import type {
-  GatewaySessionRow,
-  SessionsListResult,
-  SessionsPatchResult,
-} from "../../api/types.ts";
+import type { GatewaySessionRow, SessionsListResult } from "../../api/types.ts";
 import { t } from "../../i18n/index.ts";
 import { formatUiError } from "../format-error.ts";
 import {
@@ -16,7 +12,7 @@ import {
   type SessionCreateParams,
   type SessionCreateOutcome,
 } from "./create.ts";
-import type { SessionPatch, SessionPatchOptions } from "./patch.ts";
+import type { SessionPatch, SessionPatchOptions, SessionPatchResult } from "./patch.ts";
 import { createSessionArchiveState } from "./session-archive-state.ts";
 import type {
   SessionConnectionOwner,
@@ -26,7 +22,9 @@ import type {
   SessionResetResult,
   SessionState,
 } from "./session-capability.ts";
+import { areUiSessionKeysEquivalent } from "./session-key.ts";
 import { requestSessionPatch, requestSessionReset } from "./session-requests.ts";
+import type { SessionRefreshOutcome } from "./session-roster-refresh.ts";
 
 /** The Gateway's single pin fact: `pinned` is a projection of `pinnedAt`. */
 type SessionPinFields = { pinned: boolean; pinnedAt: number | undefined };
@@ -36,6 +34,7 @@ type SessionMutationsHost = {
   readState: () => SessionState;
   publish: (state: SessionState, errorSource?: "session-observer" | "operation") => void;
   refreshReplacement: (agentId?: string | null) => Promise<void>;
+  refreshReplacementResult: (agentId?: string | null) => Promise<SessionRefreshOutcome>;
   publishedRow: (key: string) => GatewaySessionRow | undefined;
   redecorateLists: () => void;
   notifyCreated: (key: string, entry?: SessionCreateOutcome["entry"], agentId?: string) => void;
@@ -98,7 +97,11 @@ export function createSessionMutations(host: SessionMutationsHost) {
     host.publish({ ...state, modelOverrides });
   };
 
-  const patchRowLocal = (key: string, patch: Partial<GatewaySessionRow>) => {
+  const patchRowLocal = (
+    key: string,
+    patch: Partial<GatewaySessionRow>,
+    expectedSessionId?: string,
+  ) => {
     const state = host.readState();
     const normalizedKey = key.trim();
     if (!state.result || !normalizedKey) {
@@ -106,7 +109,10 @@ export function createSessionMutations(host: SessionMutationsHost) {
     }
     let changed = false;
     const sessions = state.result.sessions.map((row) => {
-      if (row.key !== normalizedKey) {
+      if (
+        !areUiSessionKeysEquivalent(row.key, normalizedKey) ||
+        (expectedSessionId !== undefined && row.sessionId !== expectedSessionId)
+      ) {
         return row;
       }
       changed = true;
@@ -225,7 +231,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
     key: string,
     patchParams: SessionPatch,
     options: SessionPatchOptions = {},
-  ): Promise<SessionsPatchResult | null> => {
+  ): Promise<SessionPatchResult | null> => {
     const scope = host.connection.capture();
     if (!scope) {
       return null;
@@ -375,6 +381,18 @@ export function createSessionMutations(host: SessionMutationsHost) {
       if (Object.hasOwn(patchParams, "thinkingLevel")) {
         host.clearThink(normalizedKey, options.agentId);
       }
+      if (Object.hasOwn(patchParams, "permissionMode")) {
+        // The successful RPC is the first durable acknowledgement; events may
+        // drop and the follow-up list may fail, so record its fenced fact now.
+        patchRowLocal(
+          key,
+          {
+            permissionMode: result.entry?.permissionMode,
+            ...(result.entry?.updatedAt === undefined ? {} : { updatedAt: result.entry.updatedAt }),
+          },
+          result.entry?.sessionId,
+        );
+      }
       if (archivedPresentationRow) {
         const archivedAt = result.entry?.archivedAt ?? Date.now();
         const archivedSessionId = result.entry?.sessionId ?? archivedPresentationRow.sessionId;
@@ -409,8 +427,11 @@ export function createSessionMutations(host: SessionMutationsHost) {
         archiveState.clear(normalizedKey);
       }
       confirmPinPatch();
+      // Commit and list reconciliation are separate outcomes. Callers must not
+      // turn a failed refresh into an apparent rollback of the committed patch.
+      let refreshOutcome: SessionRefreshOutcome = { status: "refreshed" };
       if (!options.deferListRefresh) {
-        await host.refreshReplacement(options.agentId);
+        refreshOutcome = await host.refreshReplacementResult(options.agentId);
         if (!host.connection.isCurrent(scope)) {
           settleOptimisticPatch(false);
           return (await reconcileConfirmedPreviousConnection(scope, options.agentId))
@@ -419,7 +440,9 @@ export function createSessionMutations(host: SessionMutationsHost) {
         }
       }
       settleOptimisticPatch(true);
-      return result;
+      return refreshOutcome.status === "failed"
+        ? { ...result, listRefreshError: refreshOutcome.error }
+        : result;
     } catch (error) {
       settleOptimisticPatch(false);
       if (!host.connection.isCurrent(scope)) {

--- a/ui/src/lib/sessions/session-mutations.ts
+++ b/ui/src/lib/sessions/session-mutations.ts
@@ -39,6 +39,7 @@ type SessionMutationsHost = {
   redecorateLists: () => void;
   notifyCreated: (key: string, entry?: SessionCreateOutcome["entry"], agentId?: string) => void;
   clearThink: (key: string, agentId?: string | null) => void;
+  claimPermissionProjection: (key: string, agentId?: string | null) => () => boolean;
   retirePullRequestSummary: (key: string) => void;
 };
 
@@ -243,6 +244,7 @@ export function createSessionMutations(host: SessionMutationsHost) {
     let modelPatchStarted = false;
     let modelPatchRevision = 0;
     const modelPatchToken = Symbol("session-model-patch");
+    let ownsPermissionProjection = () => true;
     const ownsModelOverride = () => options.ownsModelOverride?.() !== false;
     const startModelPatch = () => {
       if (!managesModelOverride || modelPatchStarted || !ownsModelOverride()) {
@@ -373,6 +375,9 @@ export function createSessionMutations(host: SessionMutationsHost) {
         }
       }
       startOptimisticPatch();
+      if (Object.hasOwn(patchParams, "permissionMode")) {
+        ownsPermissionProjection = host.claimPermissionProjection(key, options.agentId);
+      }
       const result = await requestSessionPatch(scope.client, key, patchParams, options);
       if (!host.connection.isCurrent(scope)) {
         settleOptimisticPatch(false);
@@ -382,6 +387,10 @@ export function createSessionMutations(host: SessionMutationsHost) {
         host.clearThink(normalizedKey, options.agentId);
       }
       if (Object.hasOwn(patchParams, "permissionMode")) {
+        if (!ownsPermissionProjection()) {
+          settleOptimisticPatch(true);
+          return result;
+        }
         // The successful RPC is the first durable acknowledgement; events may
         // drop and the follow-up list may fail, so record its fenced fact now.
         patchRowLocal(
@@ -441,6 +450,10 @@ export function createSessionMutations(host: SessionMutationsHost) {
           return (await reconcileConfirmedPreviousConnection(scope, options.agentId))
             ? result
             : null;
+        }
+        if (Object.hasOwn(patchParams, "permissionMode") && !ownsPermissionProjection()) {
+          settleOptimisticPatch(true);
+          return result;
         }
       }
       settleOptimisticPatch(true);

--- a/ui/src/lib/sessions/session-permission-mutations.test.ts
+++ b/ui/src/lib/sessions/session-permission-mutations.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment node
+import { expect, it, vi } from "vitest";
+import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { createSessionCapability } from "./index.ts";
+import { createGatewayHarness, sessionsResult } from "./session-capability.test-support.ts";
+
+it("keeps a confirmed permission mode when its list refresh fails", async () => {
+  const key = "agent:main:permission-refresh";
+  const sessionId = "permission-refresh-generation";
+  let listCalls = 0;
+  const request = vi.fn(async (method: string) => {
+    if (method === "sessions.subscribe") {
+      return { subscribed: true };
+    }
+    if (method === "sessions.list") {
+      listCalls += 1;
+      if (listCalls > 1) {
+        throw new Error("Roster refresh unavailable");
+      }
+      return sessionsResult(
+        [
+          {
+            key,
+            kind: "direct",
+            label: "Permission refresh",
+            permissionMode: "guarded",
+            sessionId,
+            updatedAt: 1,
+          },
+        ],
+        1,
+      );
+    }
+    if (method === "sessions.patch") {
+      return {
+        key,
+        entry: { permissionMode: "workspace", sessionId, updatedAt: 2 },
+      };
+    }
+    throw new Error(`Unexpected request: ${method}`);
+  });
+  const { gateway } = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+  const sessions = createSessionCapability(gateway);
+
+  await sessions.refresh({ force: true });
+  const result = await sessions.patch(key, { permissionMode: "workspace" });
+
+  expect(result).toMatchObject({ listRefreshError: "Roster refresh unavailable" });
+  expect(sessions.state.result?.sessions).toEqual([
+    expect.objectContaining({
+      key,
+      label: "Permission refresh",
+      permissionMode: "workspace",
+      sessionId,
+      updatedAt: 2,
+    }),
+  ]);
+  expect(sessions.state.error).toContain("Roster refresh unavailable");
+  sessions.dispose();
+});

--- a/ui/src/lib/sessions/session-permission-mutations.test.ts
+++ b/ui/src/lib/sessions/session-permission-mutations.test.ts
@@ -1,6 +1,8 @@
 // @vitest-environment node
 import { expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import type { SessionsListResult, SessionsPatchResult } from "../../api/types.ts";
 import { createSessionCapability } from "./index.ts";
 import { createGatewayHarness, sessionsResult } from "./session-capability.test-support.ts";
 
@@ -56,5 +58,132 @@ it("keeps a confirmed permission mode when its list refresh fails", async () => 
     }),
   ]);
   expect(sessions.state.error).toContain("Roster refresh unavailable");
+  sessions.dispose();
+});
+
+it("discards patch A and its refresh after patch B applies first", async () => {
+  const key = "agent:main:permission-ordering";
+  const sessionId = "permission-ordering-generation";
+  const patchA = createDeferred<SessionsPatchResult>();
+  const patchB = createDeferred<SessionsPatchResult>();
+  let listCalls = 0;
+  const request = vi.fn(async (method: string, params?: unknown) => {
+    if (method === "sessions.subscribe") {
+      return { subscribed: true };
+    }
+    if (method === "sessions.list") {
+      listCalls += 1;
+      if (listCalls > 2) {
+        throw new Error("Obsolete refresh should not run");
+      }
+      return sessionsResult(
+        [
+          {
+            key,
+            kind: "direct",
+            permissionMode: listCalls === 1 ? "guarded" : "full",
+            sessionId,
+            updatedAt: listCalls,
+          },
+        ],
+        1,
+      );
+    }
+    if (method === "sessions.patch") {
+      const permissionMode = (params as { permissionMode?: unknown })?.permissionMode;
+      return permissionMode === "workspace" ? patchA.promise : patchB.promise;
+    }
+    throw new Error(`Unexpected request: ${method}`);
+  });
+  const { gateway } = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+  const sessions = createSessionCapability(gateway);
+  await sessions.refresh({ force: true });
+
+  const older = sessions.patch(key, { permissionMode: "workspace" });
+  await vi.waitFor(() =>
+    expect(request).toHaveBeenCalledWith(
+      "sessions.patch",
+      expect.objectContaining({ permissionMode: "workspace" }),
+    ),
+  );
+  const newer = sessions.patch(key, { permissionMode: "full" });
+  await vi.waitFor(() =>
+    expect(request).toHaveBeenCalledWith(
+      "sessions.patch",
+      expect.objectContaining({ permissionMode: "full" }),
+    ),
+  );
+  patchB.resolve({
+    ok: true,
+    path: "/sessions/permission-ordering.jsonl",
+    key,
+    entry: { permissionMode: "full", sessionId, updatedAt: 2 },
+  });
+  await newer;
+  patchA.resolve({
+    ok: true,
+    path: "/sessions/permission-ordering.jsonl",
+    key,
+    entry: { permissionMode: "workspace", sessionId, updatedAt: 3 },
+  });
+  await older;
+
+  expect(sessions.state.result?.sessions).toEqual([
+    expect.objectContaining({ key, permissionMode: "full", sessionId, updatedAt: 2 }),
+  ]);
+  expect(listCalls).toBe(2);
+  sessions.dispose();
+});
+
+it("discards patch A refresh failure after event B applies", async () => {
+  const key = "agent:main:permission-refresh-ordering";
+  const sessionId = "permission-refresh-ordering-generation";
+  const refreshA = createDeferred<SessionsListResult>();
+  let listCalls = 0;
+  const request = vi.fn(async (method: string) => {
+    if (method === "sessions.subscribe") {
+      return { subscribed: true };
+    }
+    if (method === "sessions.list") {
+      listCalls += 1;
+      return listCalls === 1
+        ? sessionsResult(
+            [{ key, kind: "direct", permissionMode: "guarded", sessionId, updatedAt: 1 }],
+            1,
+          )
+        : refreshA.promise;
+    }
+    if (method === "sessions.patch") {
+      return {
+        ok: true,
+        path: "/sessions/permission-refresh-ordering.jsonl",
+        key,
+        entry: { permissionMode: "workspace", sessionId, updatedAt: 2 },
+      };
+    }
+    throw new Error(`Unexpected request: ${method}`);
+  });
+  const { gateway } = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
+  const sessions = createSessionCapability(gateway);
+  await sessions.refresh({ force: true });
+
+  const older = sessions.patch(key, { permissionMode: "workspace" });
+  await vi.waitFor(() => expect(listCalls).toBe(2));
+  sessions.reconcileChanged({
+    sessionKey: key,
+    key,
+    kind: "direct",
+    reason: "patch",
+    permissionMode: "full",
+    sessionId,
+    updatedAt: 3,
+  });
+  refreshA.reject(new Error("obsolete refresh failed"));
+
+  await expect(older).resolves.not.toHaveProperty("listRefreshError");
+  expect(sessions.state.result?.sessions).toEqual([
+    expect.objectContaining({ key, permissionMode: "full", sessionId, updatedAt: 3 }),
+  ]);
+  expect(sessions.state.error).toBeNull();
   sessions.dispose();
 });

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -569,9 +569,8 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
 
   const refreshReplacementResult = (agentId?: string | null): Promise<SessionRefreshOutcome> => {
     const options = { ...lastListOptions };
-    const normalizedAgentId = agentId?.trim();
-    if (normalizedAgentId) {
-      options.agentId = normalizedAgentId;
+    if (agentId?.trim()) {
+      options.agentId = agentId.trim();
     }
     const previousOutcomeRevision = refreshOutcomeRevision;
     return refreshInternal({ ...options, force: true }, false).then(() =>
@@ -580,7 +579,6 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
   };
   const refreshReplacement = (agentId?: string | null) =>
     refreshReplacementResult(agentId).then(() => undefined);
-
   return {
     primaryList: () => primaryList,
     get requestRevision() {
@@ -652,6 +650,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     },
     refreshReplacement,
     refreshReplacementResult,
+    invalidateForegroundPublication: () => void ++foregroundPublicationGeneration,
     /** The row as currently published. The archived/all sidebars render their
      * own snapshot, so a displayed row can be absent from the primary state.
      * Lists refresh independently, so when both hold the row the primary one

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -61,7 +61,6 @@ type ManagedSessionListRefresh = {
 export type SessionRefreshOutcome =
   | { status: "refreshed" | "stale" }
   | { status: "failed"; error: string };
-const STALE_REFRESH = Promise.resolve<SessionRefreshOutcome>({ status: "stale" });
 
 type ManagedSessionListQuery = Readonly<Record<string, unknown>> & { readonly limit: number };
 
@@ -167,13 +166,14 @@ function isForegroundReplacement(options: SessionRefreshOptions): boolean {
 
 export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
   let requestRevision = 0;
-  // A queued foreground replacement owns the next visible roster immediately.
-  // Older loads may finish for their callers, but must not publish across that boundary.
+  // A queued foreground replacement owns publication; older loads may only finish for callers.
   let foregroundPublicationGeneration = 0;
-  let inFlight: Promise<SessionRefreshOutcome> | null = null;
+  let inFlight: Promise<void> | null = null;
+  let refreshOutcomeRevision = 0;
+  let lastRefreshOutcome: SessionRefreshOutcome = { status: "stale" };
   let queuedExplicitRefresh: {
     options: SessionRefreshOptions;
-    completions: Array<(refresh: Promise<SessionRefreshOutcome>) => void>;
+    completions: Array<(refresh?: Promise<void>) => void>;
   } | null = null;
   let eventRefreshQueued = false;
   let lastListOptions: SessionListOptions = {};
@@ -423,7 +423,9 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
         },
         error ? "session-observer" : undefined,
       );
-      return { status: "refreshed" };
+      lastRefreshOutcome = { status: "refreshed" };
+      refreshOutcomeRevision += 1;
+      return lastRefreshOutcome;
     } catch (error) {
       const message = formatUiError(error);
       if (isCurrent()) {
@@ -438,7 +440,9 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
           "operation",
         );
       }
-      return isCurrent() ? { status: "failed", error: message } : { status: "stale" };
+      lastRefreshOutcome = isCurrent() ? { status: "failed", error: message } : { status: "stale" };
+      refreshOutcomeRevision += 1;
+      return lastRefreshOutcome;
     }
   };
 
@@ -458,15 +462,14 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     return { ...options, ownerFirst: true };
   };
 
-  const startRefresh = (options: SessionRefreshOptions, bootstrap = false) => {
+  const startRefresh = (options: SessionRefreshOptions, bootstrap = false): Promise<void> => {
     const scope = host.connection.capture();
     if (!scope) {
-      return STALE_REFRESH;
+      return Promise.resolve();
     }
-    // Claim inFlight before load publishes: subscribers can synchronously request a refresh.
-    // Each caller awaits its own load, never later events in the refresh queue.
-    let settleRefresh!: (refresh: Promise<SessionRefreshOutcome>) => void;
-    const request = new Promise<SessionRefreshOutcome>((resolve) => {
+    // Claim inFlight before load publishes; each caller awaits its own load, never later events.
+    let settleRefresh!: (refresh: Promise<void>) => void;
+    const request = new Promise<void>((resolve) => {
       settleRefresh = resolve;
     }).finally(() => {
       if (inFlight !== request) {
@@ -480,9 +483,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
         if (queued.options.append !== true) {
           absorbPendingEventRefresh();
         }
-        const next = host.connection.isCurrent(scope)
-          ? startRefresh(queued.options)
-          : STALE_REFRESH;
+        const next = host.connection.isCurrent(scope) ? startRefresh(queued.options) : undefined;
         queued.completions.forEach((complete) => complete(next));
       } else if (eventRefreshQueued && pageActive && host.connection.isCurrent(scope)) {
         eventRefreshQueued = false;
@@ -490,20 +491,20 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       }
     });
     inFlight = request;
-    settleRefresh(load(prepareRefreshOptions(options), bootstrap));
+    settleRefresh(load(prepareRefreshOptions(options), bootstrap).then(() => undefined));
     return request;
   };
 
-  const refreshInternalOutcome = (options: SessionRefreshOptions, bootstrap: boolean) => {
+  const refreshInternal = (options: SessionRefreshOptions, bootstrap: boolean): Promise<void> => {
     if (!host.connection.capture()) {
-      return STALE_REFRESH;
+      return Promise.resolve();
     }
     const foregroundReplacement = isForegroundReplacement(options);
     if (inFlight) {
       if (foregroundReplacement) {
         foregroundPublicationGeneration += 1;
       }
-      return new Promise<SessionRefreshOutcome>((complete) => {
+      return new Promise<void>((complete) => {
         if (queuedExplicitRefresh) {
           // Once queued, a foreground owner stays authoritative over weaker refreshes.
           if (foregroundReplacement || !isForegroundReplacement(queuedExplicitRefresh.options)) {
@@ -519,7 +520,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       ([key, value]) => key !== "force" && key !== "backgroundHydrate" && value !== undefined,
     );
     if (host.readState().result && !options.force && !hasListOverrides) {
-      return Promise.resolve<SessionRefreshOutcome>({ status: "refreshed" });
+      return Promise.resolve();
     }
     if (foregroundReplacement) {
       foregroundPublicationGeneration += 1;
@@ -530,22 +531,16 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     return startRefresh(options, bootstrap);
   };
 
-  const refreshInternal = (options: SessionRefreshOptions, bootstrap: boolean): Promise<void> =>
-    refreshInternalOutcome(options, bootstrap).then(() => undefined);
-
-  const refresh = (options: SessionRefreshOptions = {}): Promise<void> =>
-    refreshInternal(options, false);
-
   const refreshFromEvent = () => {
     if (!host.connection.capture()) {
       return Promise.resolve();
     }
     if (inFlight) {
       eventRefreshQueued = true;
-      return inFlight.then(() => undefined);
+      return inFlight;
     }
     eventRefreshQueued = false;
-    return startRefresh({ ...lastListOptions, force: true }).then(() => undefined);
+    return startRefresh({ ...lastListOptions, force: true });
   };
 
   const eventRefreshCoordinator = createSessionEventRefreshCoordinator({
@@ -578,9 +573,12 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     if (normalizedAgentId) {
       options.agentId = normalizedAgentId;
     }
-    return refreshInternalOutcome({ ...options, force: true }, false);
+    const previousOutcomeRevision = refreshOutcomeRevision;
+    return refreshInternal({ ...options, force: true }, false).then(() =>
+      refreshOutcomeRevision > previousOutcomeRevision ? lastRefreshOutcome : { status: "stale" },
+    );
   };
-  const refreshReplacement = (agentId?: string | null): Promise<void> =>
+  const refreshReplacement = (agentId?: string | null) =>
     refreshReplacementResult(agentId).then(() => undefined);
 
   return {
@@ -627,7 +625,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     },
     refreshList(options: SessionRefreshOptions = {}): Promise<void> {
       if (isPrimarySessionListQuery(options)) {
-        return refresh(options);
+        return refreshInternal(options, false);
       }
       const entry = managedList(options);
       return refreshManagedList(entry, {
@@ -648,7 +646,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
           .map((entry) => refreshManagedList(entry, { append: false })),
       );
     },
-    refresh,
+    refresh: (options: SessionRefreshOptions = {}) => refreshInternal(options, false),
     bootstrap(options: SessionRefreshOptions) {
       return refreshInternal(options, true);
     },
@@ -711,7 +709,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       primaryList = { scope: primaryList.scope };
       eventRefreshCoordinator.reset();
       inFlight = null;
-      queuedExplicitRefresh?.completions.forEach((complete) => complete(STALE_REFRESH));
+      queuedExplicitRefresh?.completions.forEach((complete) => complete());
       queuedExplicitRefresh = null;
       eventRefreshQueued = false;
       for (const entry of managedLists.values()) {
@@ -734,7 +732,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
         updatePageLifecycleListeners(false);
       }
       inFlight = null;
-      queuedExplicitRefresh?.completions.forEach((complete) => complete(STALE_REFRESH));
+      queuedExplicitRefresh?.completions.forEach((complete) => complete());
       queuedExplicitRefresh = null;
       eventRefreshQueued = false;
       for (const entry of managedLists.values()) {

--- a/ui/src/lib/sessions/session-roster-refresh.ts
+++ b/ui/src/lib/sessions/session-roster-refresh.ts
@@ -58,6 +58,11 @@ type ManagedSessionListRefresh = {
   invalidated?: true;
 };
 
+export type SessionRefreshOutcome =
+  | { status: "refreshed" | "stale" }
+  | { status: "failed"; error: string };
+const STALE_REFRESH = Promise.resolve<SessionRefreshOutcome>({ status: "stale" });
+
 type ManagedSessionListQuery = Readonly<Record<string, unknown>> & { readonly limit: number };
 
 type ManagedSessionList = {
@@ -165,10 +170,10 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
   // A queued foreground replacement owns the next visible roster immediately.
   // Older loads may finish for their callers, but must not publish across that boundary.
   let foregroundPublicationGeneration = 0;
-  let inFlight: Promise<void> | null = null;
+  let inFlight: Promise<SessionRefreshOutcome> | null = null;
   let queuedExplicitRefresh: {
     options: SessionRefreshOptions;
-    completions: Array<(refresh?: Promise<void>) => void>;
+    completions: Array<(refresh: Promise<SessionRefreshOutcome>) => void>;
   } | null = null;
   let eventRefreshQueued = false;
   let lastListOptions: SessionListOptions = {};
@@ -319,10 +324,10 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
   const load = async (
     options: SessionRefreshOptions,
     bootstrap = false,
-  ): Promise<SessionsListResult | null> => {
+  ): Promise<SessionRefreshOutcome> => {
     const scope = host.connection.capture();
     if (!scope) {
-      return null;
+      return { status: "stale" };
     }
     const publicationGeneration = foregroundPublicationGeneration;
     const isCurrent = () =>
@@ -353,7 +358,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       let issuedRevision = ++requestRevision;
       let result = bootstrap ? await host.bootstrap(scope, listParams) : null;
       if (bootstrap && !isCurrent()) {
-        return null;
+        return { status: "stale" };
       }
       if (!result) {
         // A subscribe acknowledgement without rows starts a separate canonical read.
@@ -363,7 +368,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
         result = await requestSessionListParams(scope.client, listParams);
       }
       if (!isCurrent()) {
-        return null;
+        return { status: "stale" };
       }
       result = host.reconcileList(result, issuedRevision, requestOptions.agentId);
       const currentState = host.readState();
@@ -418,21 +423,22 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
         },
         error ? "session-observer" : undefined,
       );
-      return result;
+      return { status: "refreshed" };
     } catch (error) {
+      const message = formatUiError(error);
       if (isCurrent()) {
         const state = host.readState();
         host.publish(
           {
             ...state,
             loading: backgroundHydrate ? state.loading : false,
-            error: formatUiError(error),
+            error: message,
             deletedSessions: [],
           },
           "operation",
         );
       }
-      return null;
+      return isCurrent() ? { status: "failed", error: message } : { status: "stale" };
     }
   };
 
@@ -452,15 +458,15 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     return { ...options, ownerFirst: true };
   };
 
-  const startRefresh = (options: SessionRefreshOptions, bootstrap = false): Promise<void> => {
+  const startRefresh = (options: SessionRefreshOptions, bootstrap = false) => {
     const scope = host.connection.capture();
     if (!scope) {
-      return Promise.resolve();
+      return STALE_REFRESH;
     }
     // Claim inFlight before load publishes: subscribers can synchronously request a refresh.
     // Each caller awaits its own load, never later events in the refresh queue.
-    let settleRefresh!: (refresh: Promise<void>) => void;
-    const request = new Promise<void>((resolve) => {
+    let settleRefresh!: (refresh: Promise<SessionRefreshOutcome>) => void;
+    const request = new Promise<SessionRefreshOutcome>((resolve) => {
       settleRefresh = resolve;
     }).finally(() => {
       if (inFlight !== request) {
@@ -474,28 +480,30 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
         if (queued.options.append !== true) {
           absorbPendingEventRefresh();
         }
-        const next = host.connection.isCurrent(scope) ? startRefresh(queued.options) : undefined;
+        const next = host.connection.isCurrent(scope)
+          ? startRefresh(queued.options)
+          : STALE_REFRESH;
         queued.completions.forEach((complete) => complete(next));
       } else if (eventRefreshQueued && pageActive && host.connection.isCurrent(scope)) {
         eventRefreshQueued = false;
-        void startRefresh({ ...lastListOptions, force: true }).catch(() => {});
+        void startRefresh({ ...lastListOptions, force: true });
       }
     });
     inFlight = request;
-    settleRefresh(load(prepareRefreshOptions(options), bootstrap).then(() => undefined));
+    settleRefresh(load(prepareRefreshOptions(options), bootstrap));
     return request;
   };
 
-  const refreshInternal = (options: SessionRefreshOptions, bootstrap: boolean): Promise<void> => {
+  const refreshInternalOutcome = (options: SessionRefreshOptions, bootstrap: boolean) => {
     if (!host.connection.capture()) {
-      return Promise.resolve();
+      return STALE_REFRESH;
     }
     const foregroundReplacement = isForegroundReplacement(options);
     if (inFlight) {
       if (foregroundReplacement) {
         foregroundPublicationGeneration += 1;
       }
-      return new Promise<void>((complete) => {
+      return new Promise<SessionRefreshOutcome>((complete) => {
         if (queuedExplicitRefresh) {
           // Once queued, a foreground owner stays authoritative over weaker refreshes.
           if (foregroundReplacement || !isForegroundReplacement(queuedExplicitRefresh.options)) {
@@ -511,7 +519,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       ([key, value]) => key !== "force" && key !== "backgroundHydrate" && value !== undefined,
     );
     if (host.readState().result && !options.force && !hasListOverrides) {
-      return Promise.resolve();
+      return Promise.resolve<SessionRefreshOutcome>({ status: "refreshed" });
     }
     if (foregroundReplacement) {
       foregroundPublicationGeneration += 1;
@@ -522,6 +530,9 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     return startRefresh(options, bootstrap);
   };
 
+  const refreshInternal = (options: SessionRefreshOptions, bootstrap: boolean): Promise<void> =>
+    refreshInternalOutcome(options, bootstrap).then(() => undefined);
+
   const refresh = (options: SessionRefreshOptions = {}): Promise<void> =>
     refreshInternal(options, false);
 
@@ -531,10 +542,10 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     }
     if (inFlight) {
       eventRefreshQueued = true;
-      return inFlight;
+      return inFlight.then(() => undefined);
     }
     eventRefreshQueued = false;
-    return startRefresh({ ...lastListOptions, force: true });
+    return startRefresh({ ...lastListOptions, force: true }).then(() => undefined);
   };
 
   const eventRefreshCoordinator = createSessionEventRefreshCoordinator({
@@ -561,14 +572,16 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
     updatePageLifecycleListeners(true);
   }
 
-  const refreshReplacement = (agentId?: string | null): Promise<void> => {
+  const refreshReplacementResult = (agentId?: string | null): Promise<SessionRefreshOutcome> => {
     const options = { ...lastListOptions };
     const normalizedAgentId = agentId?.trim();
     if (normalizedAgentId) {
       options.agentId = normalizedAgentId;
     }
-    return refresh({ ...options, force: true });
+    return refreshInternalOutcome({ ...options, force: true }, false);
   };
+  const refreshReplacement = (agentId?: string | null): Promise<void> =>
+    refreshReplacementResult(agentId).then(() => undefined);
 
   return {
     primaryList: () => primaryList,
@@ -640,6 +653,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       return refreshInternal(options, true);
     },
     refreshReplacement,
+    refreshReplacementResult,
     /** The row as currently published. The archived/all sidebars render their
      * own snapshot, so a displayed row can be absent from the primary state.
      * Lists refresh independently, so when both hold the row the primary one
@@ -697,7 +711,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
       primaryList = { scope: primaryList.scope };
       eventRefreshCoordinator.reset();
       inFlight = null;
-      queuedExplicitRefresh?.completions.forEach((complete) => complete());
+      queuedExplicitRefresh?.completions.forEach((complete) => complete(STALE_REFRESH));
       queuedExplicitRefresh = null;
       eventRefreshQueued = false;
       for (const entry of managedLists.values()) {
@@ -720,7 +734,7 @@ export function createSessionRosterRefresh(host: SessionRosterRefreshHost) {
         updatePageLifecycleListeners(false);
       }
       inFlight = null;
-      queuedExplicitRefresh?.completions.forEach((complete) => complete());
+      queuedExplicitRefresh?.completions.forEach((complete) => complete(STALE_REFRESH));
       queuedExplicitRefresh = null;
       eventRefreshQueued = false;
       for (const entry of managedLists.values()) {

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -364,7 +364,8 @@ describe("chat pane composer controls", () => {
     expect(state.chatError).toBeNull();
   });
 
-  it("reports an unavailable permission update on the current session", async () => {
+  it("shows the optimistic mode and rolls back an unavailable permission update", async () => {
+    const pending = createDeferred<Record<string, never> | null>();
     const state = {
       chatRunId: "remote-worker-run",
       chatError: null,
@@ -376,7 +377,7 @@ describe("chat pane composer controls", () => {
       sessions: {
         state: { modelOverrides: {} },
         think: () => undefined,
-        patch: vi.fn(async () => null),
+        patch: vi.fn(() => pending.promise),
       },
       chatModelSwitchPromises: {},
       sessionKey: "agent:main:remote-worker",
@@ -402,16 +403,28 @@ describe("chat pane composer controls", () => {
       onModelSetup: vi.fn(),
     };
     const controls = renderChatPaneComposerControls(controlParams);
-
-    await controls.permissionPicker.onSelect("full");
-
-    expect(state.chatError).toContain("Failed to update permissions");
+    const selection = controls.permissionPicker.onSelect("full");
     const container = document.createElement("div");
+
     render(
       renderChatPermissionPicker(renderChatPaneComposerControls(controlParams).permissionPicker),
       container,
     );
     const trigger = container.querySelector<HTMLButtonElement>("[data-chat-permission-select]")!;
+    expect(trigger.textContent).toContain(t("chat.permissionControls.modes.full.label"));
+    expect(trigger.textContent).not.toContain("Applying permissions");
+    expect(trigger.disabled).toBe(true);
+    void controls.permissionPicker.onSelect("guarded");
+    expect(state.sessions.patch).toHaveBeenCalledOnce();
+
+    pending.resolve(null);
+    await selection;
+
+    expect(state.chatError).toContain("Failed to update permissions");
+    render(
+      renderChatPermissionPicker(renderChatPaneComposerControls(controlParams).permissionPicker),
+      container,
+    );
     expect(trigger.textContent).toContain(t("chat.permissionControls.modes.workspace.label"));
     expect(trigger.disabled).toBe(false);
   });

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -459,7 +459,9 @@ describe("chat pane composer controls", () => {
     const patch = vi.fn(
       async (
         _key: string,
-        params: { permissionMode?: string | null },
+        params: {
+          permissionMode?: "workspace" | "read-only" | "guarded" | "full" | null;
+        },
         options?: { expectedSessionId?: string },
       ) => {
         if (options?.expectedSessionId !== originalSessionId) {
@@ -523,6 +525,86 @@ describe("chat pane composer controls", () => {
     expect(selectedSession.sessionId).toBe(replacementSessionId);
     expect(persistedMode).toBe("workspace");
     expect(state.chatError).toContain("Failed to update permissions");
+  });
+
+  it("does not publish an older permission error over a replacement session success", async () => {
+    const firstPatch = createDeferred<Record<string, never>>();
+    const firstRefresh = createDeferred();
+    const selectedSession = {
+      key: "agent:main:replaced-during-permission-change",
+      kind: "direct" as const,
+      permissionMode: "workspace" as "workspace" | "read-only" | "guarded" | "full",
+      sessionId: "permission-session-before-replacement",
+    };
+    const patch = vi.fn(
+      async (
+        _key: string,
+        params: {
+          permissionMode?: "workspace" | "read-only" | "guarded" | "full" | null;
+        },
+        options?: { expectedSessionId?: string; waitFor?: Promise<boolean> },
+      ) => {
+        if (options?.expectedSessionId === "permission-session-before-replacement") {
+          return await firstPatch.promise;
+        }
+        await options?.waitFor;
+        selectedSession.permissionMode = params.permissionMode ?? "workspace";
+        return {};
+      },
+    );
+    const state = {
+      chatRunId: null,
+      chatError: null,
+      lastError: null,
+      connected: true,
+      connectionEpoch: 1,
+      client: {},
+      chatLoading: false,
+      chatModelCatalog: [],
+      sessions: {
+        canonicalListRevision: 1,
+        state: { modelOverrides: {} },
+        think: () => undefined,
+        patch,
+        refreshReplacement: vi.fn(async () => await firstRefresh.promise),
+      },
+      chatModelSwitchPromises: {},
+      sessionKey: selectedSession.key,
+      chatModelsLoading: false,
+      chatSending: false,
+      sessionsResult: null,
+      chatStream: null,
+      requestUpdate: vi.fn(),
+    } as unknown as ChatPageHost;
+    const params = {
+      state,
+      selectedSession,
+      agentDefaultModel: undefined,
+      modelAccess: { allowed: true, requiredScope: "operator.write" } as const,
+      effortAccess: { allowed: true, requiredScope: "operator.write" } as const,
+      permissionAccess: { allowed: true, requiredScope: "operator.write" } as const,
+      canSelectFull: true,
+      onModelSetup: vi.fn(),
+    };
+
+    const olderSelection = renderChatPaneComposerControls(params).permissionPicker.onSelect("full");
+    await vi.waitFor(() => expect(patch).toHaveBeenCalledOnce());
+    selectedSession.sessionId = "permission-session-after-replacement";
+    selectedSession.permissionMode = "read-only";
+    firstPatch.reject(new Error("older permission change failed"));
+    await vi.waitFor(() => expect(state.sessions.refreshReplacement).toHaveBeenCalledOnce());
+    const newerSelection =
+      renderChatPaneComposerControls(params).permissionPicker.onSelect("guarded");
+    await vi.waitFor(() => expect(patch).toHaveBeenCalledTimes(2));
+
+    await newerSelection;
+    expect(selectedSession.permissionMode).toBe("guarded");
+    expect(state.chatError).toBeNull();
+    firstRefresh.resolve();
+    await olderSelection;
+    expect(state.sessions.refreshReplacement).toHaveBeenCalledOnce();
+    expect(state.chatError).toBeNull();
+    expect(state.lastError).toBeNull();
   });
 
   it("keeps the optimistic mode when authoritative reconciliation is unavailable", async () => {

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -269,125 +269,6 @@ describe("chat pane composer controls", () => {
     );
   });
 
-  it("shows an applying state for a permission update from another client", () => {
-    const patch = vi.fn(async () => ({}));
-    const state = {
-      chatRunId: "run-active",
-      connected: true,
-      client: {},
-      chatLoading: false,
-      chatModelCatalog: [],
-      sessions: { state: { modelOverrides: {} }, think: () => undefined, patch },
-      chatModelSwitchPromises: {},
-      sessionKey: "agent:main:permission-notice",
-      chatModelsLoading: false,
-      chatSending: false,
-      sessionsResult: null,
-      chatStream: null,
-    } as unknown as ChatPageHost;
-    const selectedSession = {
-      key: state.sessionKey,
-      kind: "direct" as const,
-      permissionMode: "full" as const,
-      permissionModePending: true,
-    };
-    const controlParams = {
-      state,
-      selectedSession,
-      agentDefaultModel: undefined,
-      modelAccess: { allowed: true, requiredScope: "operator.write" } as const,
-      effortAccess: { allowed: true, requiredScope: "operator.write" } as const,
-      permissionAccess: { allowed: true, requiredScope: "operator.write" } as const,
-      canSelectFull: true,
-      onModelSetup: vi.fn(),
-    };
-    const container = document.createElement("div");
-    const renderPicker = () =>
-      render(
-        renderChatPermissionPicker(renderChatPaneComposerControls(controlParams).permissionPicker),
-        container,
-      );
-
-    renderPicker();
-    const trigger = container.querySelector<HTMLButtonElement>("[data-chat-permission-select]")!;
-    expect(trigger.textContent).toContain("Applying permissions");
-    expect(trigger.getAttribute("aria-label")).not.toContain(
-      t("chat.permissionControls.modes.full.label"),
-    );
-    expect(trigger.disabled).toBe(true);
-
-    selectedSession.permissionModePending = false;
-    renderPicker();
-    expect(trigger.textContent).toContain(t("chat.permissionControls.modes.full.label"));
-    expect(trigger.disabled).toBe(false);
-  });
-
-  it("holds permission display and the send barrier until a Full Access update is applied", async () => {
-    const pending = createDeferred<Record<string, never>>();
-    const state = {
-      chatRunId: null,
-      connected: true,
-      connectionEpoch: 1,
-      client: {},
-      chatLoading: false,
-      chatModelCatalog: [],
-      sessions: {
-        state: { modelOverrides: {} },
-        think: () => undefined,
-        patch: vi.fn(() => pending.promise),
-      },
-      chatModelSwitchPromises: {},
-      sessionKey: "agent:main:remote-worker",
-      chatModelsLoading: false,
-      chatSending: false,
-      sessionsResult: null,
-      chatStream: null,
-    } as unknown as ChatPageHost;
-    const selectedSession = {
-      key: state.sessionKey,
-      kind: "direct" as const,
-      permissionMode: "workspace" as "workspace" | "full",
-    };
-    const controlParams = {
-      state,
-      selectedSession,
-      agentDefaultModel: undefined,
-      modelAccess: { allowed: true, requiredScope: "operator.write" } as const,
-      effortAccess: { allowed: true, requiredScope: "operator.write" } as const,
-      permissionAccess: { allowed: true, requiredScope: "operator.write" } as const,
-      canSelectFull: true,
-      onModelSetup: vi.fn(),
-    };
-    const controls = renderChatPaneComposerControls(controlParams);
-    const selection = controls.permissionPicker.onSelect("full");
-    const container = document.createElement("div");
-    try {
-      expect(getPendingChatPickerPatch(state, state.sessionKey)).toBeDefined();
-      selectedSession.permissionMode = "full";
-      const pendingControls = renderChatPaneComposerControls(controlParams);
-      render(renderChatPermissionPicker(pendingControls.permissionPicker), container);
-      const trigger = container.querySelector<HTMLButtonElement>("[data-chat-permission-select]")!;
-      expect(trigger.textContent).toContain("Applying permissions");
-      expect(trigger.getAttribute("data-chat-select-value")).toBe("workspace");
-      expect(trigger.disabled).toBe(true);
-      void pendingControls.permissionPicker.onSelect("guarded");
-      void controls.permissionPicker.onSelect("read-only");
-      expect(state.sessions.patch).toHaveBeenCalledOnce();
-    } finally {
-      pending.resolve({});
-      await selection;
-    }
-
-    render(
-      renderChatPermissionPicker(renderChatPaneComposerControls(controlParams).permissionPicker),
-      container,
-    );
-    const trigger = container.querySelector<HTMLButtonElement>("[data-chat-permission-select]")!;
-    expect(trigger.textContent).toContain(t("chat.permissionControls.modes.full.label"));
-    expect(trigger.disabled).toBe(false);
-    expect(getPendingChatPickerPatch(state, state.sessionKey)).toBeUndefined();
-  });
-
   it.each([
     {
       label: "successful update after switching sessions",
@@ -507,7 +388,12 @@ describe("chat pane composer controls", () => {
     } as unknown as ChatPageHost;
     const controlParams = {
       state,
-      selectedSession: { key: state.sessionKey, kind: "direct" as const, hasActiveRun: true },
+      selectedSession: {
+        key: state.sessionKey,
+        kind: "direct" as const,
+        hasActiveRun: true,
+        permissionMode: "workspace" as const,
+      },
       agentDefaultModel: undefined,
       modelAccess: { allowed: true, requiredScope: "operator.write" } as const,
       effortAccess: { allowed: true, requiredScope: "operator.write" } as const,
@@ -526,7 +412,7 @@ describe("chat pane composer controls", () => {
       container,
     );
     const trigger = container.querySelector<HTMLButtonElement>("[data-chat-permission-select]")!;
-    expect(trigger.textContent).not.toContain("Applying permissions");
+    expect(trigger.textContent).toContain(t("chat.permissionControls.modes.workspace.label"));
     expect(trigger.disabled).toBe(false);
   });
 

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -270,6 +270,51 @@ describe("chat pane composer controls", () => {
     );
   });
 
+  it("patches an identity-less session while its first identity materializes", async () => {
+    const patchResult = createDeferred<Record<string, never>>();
+    const patch = vi.fn(() => patchResult.promise);
+    const key = "agent:main:first-materialization";
+    const selectedSession = { key, kind: "direct" as const, permissionMode: "guarded" as const };
+    const state = {
+      connected: true,
+      connectionEpoch: 1,
+      client: {},
+      sessions: { state: { modelOverrides: {} }, think: () => undefined, patch },
+      sessionKey: key,
+      sessionsResult: { defaults: {}, sessions: [selectedSession] },
+      chatModelCatalog: [],
+      chatModelSwitchPromises: {},
+    } as unknown as ChatPageHost;
+    const controls = renderChatPaneComposerControls({
+      state,
+      selectedSession,
+      agentDefaultModel: undefined,
+      modelAccess: { allowed: true, requiredScope: "operator.write" },
+      effortAccess: { allowed: true, requiredScope: "operator.write" },
+      permissionAccess: { allowed: true, requiredScope: "operator.write" },
+      canSelectFull: true,
+      onModelSetup: vi.fn(),
+    });
+
+    expect(controls.permissionPicker.disabled).toBe(false);
+    const selection = controls.permissionPicker.onSelect("workspace");
+    await vi.waitFor(() =>
+      expect(patch).toHaveBeenCalledWith(
+        key,
+        { permissionMode: "workspace" },
+        expect.objectContaining({ expectedSessionId: undefined }),
+      ),
+    );
+    state.sessionsResult = {
+      defaults: {},
+      sessions: [{ ...selectedSession, permissionMode: "workspace", sessionId: "materialized" }],
+    } as ChatPageHost["sessionsResult"];
+    patchResult.resolve({});
+    await selection;
+
+    expect(state.chatError).toBeNull();
+  });
+
   it.each([
     {
       label: "successful update after switching sessions",

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -205,6 +205,7 @@ describe("chat pane composer controls", () => {
         key: "agent:main:permission-test",
         kind: "direct",
         permissionMode: "full",
+        sessionId: "permission-test-session",
       },
       agentDefaultModel: undefined,
       agentDefaultPermissionMode: "guarded",
@@ -256,7 +257,7 @@ describe("chat pane composer controls", () => {
     expect(patch).toHaveBeenCalledWith(
       "agent:main:permission-test",
       { permissionMode: "guarded" },
-      expect.objectContaining({ agentId: undefined }),
+      expect.objectContaining({ agentId: undefined, expectedSessionId: "permission-test-session" }),
     );
 
     dropdown?.setAttribute("open", "");
@@ -265,7 +266,7 @@ describe("chat pane composer controls", () => {
     expect(patch).toHaveBeenLastCalledWith(
       "agent:main:permission-test",
       { permissionMode: null },
-      expect.objectContaining({ agentId: undefined }),
+      expect.objectContaining({ agentId: undefined, expectedSessionId: "permission-test-session" }),
     );
   });
 
@@ -343,7 +344,12 @@ describe("chat pane composer controls", () => {
     } as unknown as ChatPageHost;
     const controls = renderChatPaneComposerControls({
       state,
-      selectedSession: { key: state.sessionKey, kind: "direct", hasActiveRun: true },
+      selectedSession: {
+        key: state.sessionKey,
+        kind: "direct",
+        hasActiveRun: true,
+        sessionId: "lifecycle-session",
+      },
       agentDefaultModel: undefined,
       modelAccess: { allowed: true, requiredScope: "operator.write" },
       effortAccess: { allowed: true, requiredScope: "operator.write" },
@@ -364,8 +370,16 @@ describe("chat pane composer controls", () => {
     expect(state.chatError).toBeNull();
   });
 
-  it("shows the optimistic mode and rolls back an unavailable permission update", async () => {
+  it("adopts the persisted mode when permission application fails after commit", async () => {
     const pending = createDeferred<Record<string, never> | null>();
+    let canonicalListRevision = 1;
+    const selectedSession = {
+      key: "agent:main:remote-worker",
+      kind: "direct" as const,
+      hasActiveRun: true,
+      permissionMode: "workspace" as "workspace" | "full",
+      sessionId: "remote-worker-session",
+    };
     const state = {
       chatRunId: "remote-worker-run",
       chatError: null,
@@ -375,9 +389,16 @@ describe("chat pane composer controls", () => {
       chatLoading: false,
       chatModelCatalog: [],
       sessions: {
+        get canonicalListRevision() {
+          return canonicalListRevision;
+        },
         state: { modelOverrides: {} },
         think: () => undefined,
         patch: vi.fn(() => pending.promise),
+        refreshReplacement: vi.fn(async () => {
+          selectedSession.permissionMode = "full";
+          canonicalListRevision += 1;
+        }),
       },
       chatModelSwitchPromises: {},
       sessionKey: "agent:main:remote-worker",
@@ -389,12 +410,7 @@ describe("chat pane composer controls", () => {
     } as unknown as ChatPageHost;
     const controlParams = {
       state,
-      selectedSession: {
-        key: state.sessionKey,
-        kind: "direct" as const,
-        hasActiveRun: true,
-        permissionMode: "workspace" as const,
-      },
+      selectedSession,
       agentDefaultModel: undefined,
       modelAccess: { allowed: true, requiredScope: "operator.write" } as const,
       effortAccess: { allowed: true, requiredScope: "operator.write" } as const,
@@ -416,17 +432,153 @@ describe("chat pane composer controls", () => {
     expect(trigger.disabled).toBe(true);
     void controls.permissionPicker.onSelect("guarded");
     expect(state.sessions.patch).toHaveBeenCalledOnce();
+    expect(state.sessions.patch).toHaveBeenCalledWith(
+      state.sessionKey,
+      { permissionMode: "full" },
+      expect.objectContaining({ expectedSessionId: "remote-worker-session" }),
+    );
 
-    pending.resolve(null);
+    pending.reject(new Error("saved mode could not be applied to the active run"));
     await selection;
 
     expect(state.chatError).toContain("Failed to update permissions");
+    expect(state.sessions.refreshReplacement).toHaveBeenCalledWith(undefined);
     render(
       renderChatPermissionPicker(renderChatPaneComposerControls(controlParams).permissionPicker),
       container,
     );
-    expect(trigger.textContent).toContain(t("chat.permissionControls.modes.workspace.label"));
+    expect(trigger.textContent).toContain(t("chat.permissionControls.modes.full.label"));
     expect(trigger.disabled).toBe(false);
+  });
+
+  it("binds permission choices to the observed session incarnation", async () => {
+    const originalSessionId = "session-before-replacement";
+    const replacementSessionId = "session-after-replacement";
+    let persistedMode = "workspace";
+    let canonicalListRevision = 1;
+    const patch = vi.fn(
+      async (
+        _key: string,
+        params: { permissionMode?: string | null },
+        options?: { expectedSessionId?: string },
+      ) => {
+        if (options?.expectedSessionId !== originalSessionId) {
+          persistedMode = params.permissionMode ?? "default";
+          return {};
+        }
+        return null;
+      },
+    );
+    const selectedSession = {
+      key: "agent:main:recreated",
+      kind: "direct" as const,
+      permissionMode: "workspace" as const,
+      sessionId: originalSessionId,
+    };
+    const state = {
+      chatRunId: null,
+      chatError: null,
+      connected: true,
+      connectionEpoch: 1,
+      client: {},
+      chatLoading: false,
+      chatModelCatalog: [],
+      sessions: {
+        get canonicalListRevision() {
+          return canonicalListRevision;
+        },
+        state: { modelOverrides: {} },
+        think: () => undefined,
+        patch,
+        refreshReplacement: vi.fn(async () => {
+          selectedSession.sessionId = replacementSessionId;
+          canonicalListRevision += 1;
+        }),
+      },
+      chatModelSwitchPromises: {},
+      sessionKey: selectedSession.key,
+      chatModelsLoading: false,
+      chatSending: false,
+      sessionsResult: null,
+      chatStream: null,
+      requestUpdate: vi.fn(),
+    } as unknown as ChatPageHost;
+
+    await renderChatPaneComposerControls({
+      state,
+      selectedSession,
+      agentDefaultModel: undefined,
+      modelAccess: { allowed: true, requiredScope: "operator.write" },
+      effortAccess: { allowed: true, requiredScope: "operator.write" },
+      permissionAccess: { allowed: true, requiredScope: "operator.write" },
+      canSelectFull: true,
+      onModelSetup: vi.fn(),
+    }).permissionPicker.onSelect("full");
+
+    expect(patch).toHaveBeenCalledWith(
+      selectedSession.key,
+      { permissionMode: "full" },
+      expect.objectContaining({ expectedSessionId: originalSessionId }),
+    );
+    expect(selectedSession.sessionId).toBe(replacementSessionId);
+    expect(persistedMode).toBe("workspace");
+    expect(state.chatError).toContain("Failed to update permissions");
+  });
+
+  it("keeps the optimistic mode when authoritative reconciliation is unavailable", async () => {
+    const selectedSession = {
+      key: "agent:main:reconcile-unavailable",
+      kind: "direct" as const,
+      permissionMode: "workspace" as const,
+      sessionId: "reconcile-unavailable-session",
+    };
+    const state = {
+      chatRunId: null,
+      chatError: null,
+      connected: true,
+      connectionEpoch: 1,
+      client: {},
+      chatLoading: false,
+      chatModelCatalog: [],
+      sessions: {
+        canonicalListRevision: 1,
+        state: { modelOverrides: {} },
+        think: () => undefined,
+        patch: vi.fn(async () => {
+          throw new Error("permission apply failed after commit");
+        }),
+        refreshReplacement: vi.fn(async () => undefined),
+      },
+      chatModelSwitchPromises: {},
+      sessionKey: selectedSession.key,
+      chatModelsLoading: false,
+      chatSending: false,
+      sessionsResult: null,
+      chatStream: null,
+      requestUpdate: vi.fn(),
+    } as unknown as ChatPageHost;
+    const params = {
+      state,
+      selectedSession,
+      agentDefaultModel: undefined,
+      modelAccess: { allowed: true, requiredScope: "operator.write" } as const,
+      effortAccess: { allowed: true, requiredScope: "operator.write" } as const,
+      permissionAccess: { allowed: true, requiredScope: "operator.write" } as const,
+      canSelectFull: true,
+      onModelSetup: vi.fn(),
+    };
+
+    await renderChatPaneComposerControls(params).permissionPicker.onSelect("full");
+    const container = document.createElement("div");
+    render(
+      renderChatPermissionPicker(renderChatPaneComposerControls(params).permissionPicker),
+      container,
+    );
+
+    const trigger = container.querySelector<HTMLButtonElement>("[data-chat-permission-select]")!;
+    expect(trigger.textContent).toContain(t("chat.permissionControls.modes.full.label"));
+    expect(trigger.disabled).toBe(false);
+    expect(state.chatError).toContain("Failed to update permissions");
   });
 
   it.each([

--- a/ui/src/pages/chat/chat-pane-session-controls.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.ts
@@ -7,6 +7,7 @@ import {
   type SessionMethodAccess,
 } from "../../lib/session-method-access.ts";
 import { scopedAgentParamsForSession } from "../../lib/sessions/index.ts";
+import { areUiSessionKeysEquivalent } from "../../lib/sessions/session-key.ts";
 import { readChatSessionActionAccess } from "./chat-session-action-access.ts";
 import {
   switchChatContextWindow,
@@ -32,8 +33,11 @@ type SessionActionCallbacks = Pick<
 >;
 
 type PendingPermissionChange = {
+  expectedSessionId: string;
   nextMode: ChatPermissionPickerProps["mode"];
   ownsSelection: () => boolean;
+  pending: boolean;
+  retainUntilRevision?: number;
 };
 
 const pendingPermissionChanges = new WeakMap<ChatPageHost, Map<string, PendingPermissionChange>>();
@@ -111,19 +115,39 @@ export function renderChatPaneComposerControls(params: {
   const client = state.client;
   const connectionEpoch = state.connectionEpoch;
   const agentScope = scopedAgentParamsForSession(state, sessionKey);
+  const expectedSessionId = selectedSession?.sessionId?.trim();
   const permissionScopeKey = JSON.stringify([sessionKey, agentScope.agentId]);
   const permissionChanges =
     pendingPermissionChanges.get(state) ?? new Map<string, PendingPermissionChange>();
   pendingPermissionChanges.set(state, permissionChanges);
-  const ownsSelection = () =>
+  const ownsRoute = () =>
     state.connected &&
     state.sessionKey === sessionKey &&
     state.client === client &&
     state.connectionEpoch === connectionEpoch &&
     scopedAgentParamsForSession(state, sessionKey).agentId === agentScope.agentId;
-  const pendingChange = permissionChanges.get(permissionScopeKey);
+  const ownsSelection = () => {
+    const currentSessionId =
+      state.sessionsResult?.sessions.find((row) => areUiSessionKeysEquivalent(row.key, sessionKey))
+        ?.sessionId ?? selectedSession?.sessionId;
+    return ownsRoute() && currentSessionId === expectedSessionId;
+  };
+  let pendingChange = permissionChanges.get(permissionScopeKey);
+  if (pendingChange && pendingChange.expectedSessionId !== expectedSessionId) {
+    permissionChanges.delete(permissionScopeKey);
+    pendingChange = undefined;
+  }
+  if (
+    pendingChange?.retainUntilRevision !== undefined &&
+    state.sessions.canonicalListRevision > pendingChange.retainUntilRevision
+  ) {
+    permissionChanges.delete(permissionScopeKey);
+    pendingChange = undefined;
+  }
   const currentChange = pendingChange?.ownsSelection() ? pendingChange : undefined;
-  const permissionPending = Boolean(currentChange || selectedSession?.permissionModePending);
+  const permissionPending = Boolean(
+    currentChange?.pending || selectedSession?.permissionModePending,
+  );
   const modelCatalogState = resolveChatModelCatalogState(state);
   const thinkingLevelOverride = state.sessions.think(sessionKey, agentScope.agentId);
   const thinkingSession = thinkingLevelOverride
@@ -183,24 +207,32 @@ export function renderChatPaneComposerControls(params: {
     permissionPicker: {
       canSelectFull,
       defaultMode: agentDefaultPermissionMode,
-      disabled: !permissionAccess.allowed,
-      disabledReason: permissionAccess.allowed ? undefined : permissionAccess.reason,
+      disabled: !permissionAccess.allowed || !expectedSessionId,
+      disabledReason: !permissionAccess.allowed
+        ? permissionAccess.reason
+        : !expectedSessionId
+          ? t("mcpServers.sessionUnavailable")
+          : undefined,
       mode: currentChange ? currentChange.nextMode : selectedSession?.permissionMode,
       pending: permissionPending,
       onSelect: async (permissionMode) => {
+        const activeChange = permissionChanges.get(permissionScopeKey);
         if (
           !permissionAccess.allowed ||
+          !expectedSessionId ||
           !ownsSelection() ||
           selectedSession?.permissionModePending ||
-          permissionChanges.get(permissionScopeKey)?.ownsSelection()
+          (activeChange?.pending && activeChange.ownsSelection())
         ) {
           return;
         }
         // Keep the selected mode visible while the exact runtime update settles.
         // The pending owner rejects duplicates; the shared settings tail serializes later work.
         const change: PendingPermissionChange = {
+          expectedSessionId,
           nextMode: permissionMode ?? undefined,
           ownsSelection,
+          pending: true,
         };
         permissionChanges.set(permissionScopeKey, change);
         state.requestUpdate?.();
@@ -210,7 +242,7 @@ export function renderChatPaneComposerControls(params: {
             state,
             sessionKey,
             { permissionMode },
-            agentScope,
+            { ...agentScope, expectedSessionId },
           );
           if (!ownsSelection()) {
             return;
@@ -219,17 +251,29 @@ export function renderChatPaneComposerControls(params: {
             throw new Error("Session capability is unavailable");
           }
         } catch (error) {
-          if (!ownsSelection()) {
+          if (!ownsRoute()) {
             return;
+          }
+          const revision = state.sessions.canonicalListRevision;
+          await state.sessions.refreshReplacement(agentScope.agentId);
+          if (!ownsRoute()) {
+            return;
+          }
+          if (ownsSelection() && state.sessions.canonicalListRevision === revision) {
+            change.pending = false;
+            change.retainUntilRevision = revision;
           }
           state.chatError = state.lastError = t("chat.permissionControls.updateFailed", {
             error: String(error),
           });
         } finally {
-          if (permissionChanges.get(permissionScopeKey) === change) {
+          if (
+            permissionChanges.get(permissionScopeKey) === change &&
+            change.retainUntilRevision === undefined
+          ) {
             permissionChanges.delete(permissionScopeKey);
           }
-          if (ownsSelection()) {
+          if (ownsRoute()) {
             state.requestUpdate?.();
           }
         }

--- a/ui/src/pages/chat/chat-pane-session-controls.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.ts
@@ -33,7 +33,7 @@ type SessionActionCallbacks = Pick<
 >;
 
 type PendingPermissionChange = {
-  expectedSessionId: string;
+  expectedSessionId?: string;
   nextMode: ChatPermissionPickerProps["mode"];
   ownsSelection: () => boolean;
   pending: boolean;
@@ -208,19 +208,14 @@ export function renderChatPaneComposerControls(params: {
     permissionPicker: {
       canSelectFull,
       defaultMode: agentDefaultPermissionMode,
-      disabled: !permissionAccess.allowed || !expectedSessionId,
-      disabledReason: !permissionAccess.allowed
-        ? permissionAccess.reason
-        : !expectedSessionId
-          ? t("mcpServers.sessionUnavailable")
-          : undefined,
+      disabled: !permissionAccess.allowed,
+      disabledReason: permissionAccess.allowed ? undefined : permissionAccess.reason,
       mode: currentChange ? currentChange.nextMode : selectedSession?.permissionMode,
       pending: permissionPending,
       onSelect: async (permissionMode) => {
         const activeChange = permissionChanges.get(permissionScopeKey);
         if (
           !permissionAccess.allowed ||
-          !expectedSessionId ||
           !ownsSelection() ||
           selectedSession?.permissionModePending ||
           (activeChange?.pending && activeChange.ownsSelection())

--- a/ui/src/pages/chat/chat-pane-session-controls.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.ts
@@ -41,6 +41,7 @@ type PendingPermissionChange = {
 };
 
 const pendingPermissionChanges = new WeakMap<ChatPageHost, Map<string, PendingPermissionChange>>();
+const permissionOutcomeOwners = new WeakMap<ChatPageHost, Map<string, symbol>>();
 
 export function readChatPaneMutationAccess(
   snapshot: ApplicationGatewaySnapshot,
@@ -234,6 +235,11 @@ export function renderChatPaneComposerControls(params: {
           ownsSelection,
           pending: true,
         };
+        const outcomeOwner = Symbol(permissionScopeKey);
+        const outcomeOwners = permissionOutcomeOwners.get(state) ?? new Map<string, symbol>();
+        permissionOutcomeOwners.set(state, outcomeOwners);
+        outcomeOwners.set(permissionScopeKey, outcomeOwner);
+        const ownsOutcome = () => outcomeOwners.get(permissionScopeKey) === outcomeOwner;
         permissionChanges.set(permissionScopeKey, change);
         state.requestUpdate?.();
         try {
@@ -251,12 +257,12 @@ export function renderChatPaneComposerControls(params: {
             throw new Error("Session capability is unavailable");
           }
         } catch (error) {
-          if (!ownsRoute()) {
+          if (!ownsRoute() || !ownsOutcome()) {
             return;
           }
           const revision = state.sessions.canonicalListRevision;
           await state.sessions.refreshReplacement(agentScope.agentId);
-          if (!ownsRoute()) {
+          if (!ownsRoute() || !ownsOutcome()) {
             return;
           }
           if (ownsSelection() && state.sessions.canonicalListRevision === revision) {
@@ -267,6 +273,9 @@ export function renderChatPaneComposerControls(params: {
             error: String(error),
           });
         } finally {
+          if (ownsOutcome()) {
+            outcomeOwners.delete(permissionScopeKey);
+          }
           if (
             permissionChanges.get(permissionScopeKey) === change &&
             change.retainUntilRevision === undefined

--- a/ui/src/pages/chat/chat-pane-session-controls.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.ts
@@ -32,7 +32,7 @@ type SessionActionCallbacks = Pick<
 >;
 
 type PendingPermissionChange = {
-  previousMode: ChatPermissionPickerProps["mode"];
+  nextMode: ChatPermissionPickerProps["mode"];
   ownsSelection: () => boolean;
 };
 
@@ -123,7 +123,6 @@ export function renderChatPaneComposerControls(params: {
     scopedAgentParamsForSession(state, sessionKey).agentId === agentScope.agentId;
   const pendingChange = permissionChanges.get(permissionScopeKey);
   const currentChange = pendingChange?.ownsSelection() ? pendingChange : undefined;
-  const permissionApplying = Boolean(currentChange || selectedSession?.permissionModePending);
   const modelCatalogState = resolveChatModelCatalogState(state);
   const thinkingLevelOverride = state.sessions.think(sessionKey, agentScope.agentId);
   const thinkingSession = thinkingLevelOverride
@@ -183,10 +182,9 @@ export function renderChatPaneComposerControls(params: {
     permissionPicker: {
       canSelectFull,
       defaultMode: agentDefaultPermissionMode,
-      applying: permissionApplying,
-      disabled: !permissionAccess.allowed || permissionApplying,
+      disabled: !permissionAccess.allowed,
       disabledReason: permissionAccess.allowed ? undefined : permissionAccess.reason,
-      mode: currentChange ? currentChange.previousMode : selectedSession?.permissionMode,
+      mode: currentChange ? currentChange.nextMode : selectedSession?.permissionMode,
       onSelect: async (permissionMode) => {
         if (
           !permissionAccess.allowed ||
@@ -196,10 +194,10 @@ export function renderChatPaneComposerControls(params: {
         ) {
           return;
         }
-        // Saved rows can arrive before the runtime ACK. Keep the initiating
-        // picker on its previous mode until the exact update settles.
+        // Keep the selected mode visible while the exact runtime update settles.
+        // The pending owner rejects duplicates; the shared settings tail serializes later work.
         const change: PendingPermissionChange = {
-          previousMode: selectedSession?.permissionMode,
+          nextMode: permissionMode ?? undefined,
           ownsSelection,
         };
         permissionChanges.set(permissionScopeKey, change);

--- a/ui/src/pages/chat/chat-pane-session-controls.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.ts
@@ -256,6 +256,11 @@ export function renderChatPaneComposerControls(params: {
           if (!patched) {
             throw new Error("Session capability is unavailable");
           }
+          if (patched.listRefreshError && ownsOutcome()) {
+            state.chatError = state.lastError = t("chat.permissionControls.refreshFailed", {
+              error: patched.listRefreshError,
+            });
+          }
         } catch (error) {
           if (!ownsRoute() || !ownsOutcome()) {
             return;

--- a/ui/src/pages/chat/chat-pane-session-controls.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.ts
@@ -123,6 +123,7 @@ export function renderChatPaneComposerControls(params: {
     scopedAgentParamsForSession(state, sessionKey).agentId === agentScope.agentId;
   const pendingChange = permissionChanges.get(permissionScopeKey);
   const currentChange = pendingChange?.ownsSelection() ? pendingChange : undefined;
+  const permissionPending = Boolean(currentChange || selectedSession?.permissionModePending);
   const modelCatalogState = resolveChatModelCatalogState(state);
   const thinkingLevelOverride = state.sessions.think(sessionKey, agentScope.agentId);
   const thinkingSession = thinkingLevelOverride
@@ -185,6 +186,7 @@ export function renderChatPaneComposerControls(params: {
       disabled: !permissionAccess.allowed,
       disabledReason: permissionAccess.allowed ? undefined : permissionAccess.reason,
       mode: currentChange ? currentChange.nextMode : selectedSession?.permissionMode,
+      pending: permissionPending,
       onSelect: async (permissionMode) => {
         if (
           !permissionAccess.allowed ||

--- a/ui/src/pages/chat/chat-settings-patches.ts
+++ b/ui/src/pages/chat/chat-settings-patches.ts
@@ -95,6 +95,7 @@ export function patchChatSessionSettings(
   patch: SessionPatch,
   options: {
     agentId?: string;
+    expectedSessionId?: string;
     ownsModelOverride?: () => boolean;
     reconcile?: (result: SessionsPatchResult) => Promise<void> | void;
   } = {},
@@ -106,6 +107,7 @@ export function patchChatSessionSettings(
     // redirect queued intent to a replacement Gateway.
     const result = await host.sessions.patch(sessionKey, patch, {
       agentId: options.agentId,
+      expectedSessionId: options.expectedSessionId,
       ownsModelOverride: options.ownsModelOverride,
       waitFor: previous,
     });

--- a/ui/src/pages/chat/chat-settings-patches.ts
+++ b/ui/src/pages/chat/chat-settings-patches.ts
@@ -1,9 +1,9 @@
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
-import type { SessionsPatchResult } from "../../api/types.ts";
 import {
   resolveSessionKey,
   type SessionCapability,
   type SessionPatch,
+  type SessionPatchResult,
   type SessionScopeHost,
 } from "../../lib/sessions/index.ts";
 import {
@@ -97,9 +97,9 @@ export function patchChatSessionSettings(
     agentId?: string;
     expectedSessionId?: string;
     ownsModelOverride?: () => boolean;
-    reconcile?: (result: SessionsPatchResult) => Promise<void> | void;
+    reconcile?: (result: SessionPatchResult) => Promise<void> | void;
   } = {},
-): Promise<SessionsPatchResult | null> {
+): Promise<SessionPatchResult | null> {
   const previous = getPendingChatPickerPatch(host, sessionKey, options.agentId);
   const operation = (async () => {
     // Run-affecting settings and sends share this canonical per-session tail.
@@ -150,7 +150,7 @@ export async function patchChatCommandSessionSettings(
   patch: SessionPatch,
   options: {
     ownsModelOverride?: () => boolean;
-    reconcile?: (result: SessionsPatchResult) => Promise<void> | void;
+    reconcile?: (result: SessionPatchResult) => Promise<void> | void;
   } = {},
 ): Promise<NonNullable<Awaited<ReturnType<SessionCapability["patch"]>>>> {
   const result = await patchChatSessionSettings(

--- a/ui/src/pages/chat/components/chat-permission-picker.ts
+++ b/ui/src/pages/chat/components/chat-permission-picker.ts
@@ -14,7 +14,6 @@ type PermissionSelection = SessionPermissionMode | null;
 
 export type ChatPermissionPickerProps = {
   canSelectFull: boolean;
-  applying?: boolean;
   disabled?: boolean;
   disabledReason?: string;
   mode?: SessionPermissionMode;
@@ -91,11 +90,9 @@ function permissionSelection(value: string | undefined): PermissionSelection | u
 }
 
 export function renderChatPermissionPicker(params: ChatPermissionPickerProps) {
-  const disabled = params.disabled || params.applying;
-  const fullAccess = (params.mode ?? params.defaultMode) === "full" && !params.applying;
-  const label = params.applying
-    ? t("chat.permissionControls.applying")
-    : modeLabel(params.mode, params.defaultMode);
+  const disabled = params.disabled;
+  const fullAccess = (params.mode ?? params.defaultMode) === "full";
+  const label = modeLabel(params.mode, params.defaultMode);
   const selectMode = (mode: PermissionSelection) => {
     if (disabled || (mode === "full" && !params.canSelectFull)) {
       return;
@@ -129,13 +126,11 @@ export function renderChatPermissionPicker(params: ChatPermissionPickerProps) {
         data-chat-select-value=${params.mode ?? ""}
         aria-label=${`${t("chat.permissionControls.label")}: ${label}`}
         aria-disabled=${disabled ? "true" : "false"}
-        aria-busy=${params.applying ? "true" : "false"}
-        title=${params.disabledReason ??
-        (params.applying ? label : t("chat.permissionControls.help"))}
+        title=${params.disabledReason ?? t("chat.permissionControls.help")}
         ?disabled=${disabled}
       >
         <span class="chat-controls__permission-icon" aria-hidden="true"
-          >${params.applying ? icons.loader : modeIcon(params.mode ?? null)}</span
+          >${modeIcon(params.mode ?? null)}</span
         >
         <span
           class="chat-controls__inline-select-label ${fullAccess

--- a/ui/src/pages/chat/components/chat-permission-picker.ts
+++ b/ui/src/pages/chat/components/chat-permission-picker.ts
@@ -19,6 +19,7 @@ export type ChatPermissionPickerProps = {
   mode?: SessionPermissionMode;
   defaultMode?: SessionPermissionMode;
   onSelect: (mode: PermissionSelection) => unknown;
+  pending?: boolean;
 };
 
 function handlePermissionPickerKeydown(
@@ -90,7 +91,7 @@ function permissionSelection(value: string | undefined): PermissionSelection | u
 }
 
 export function renderChatPermissionPicker(params: ChatPermissionPickerProps) {
-  const disabled = params.disabled;
+  const disabled = params.disabled || params.pending;
   const fullAccess = (params.mode ?? params.defaultMode) === "full";
   const label = modeLabel(params.mode, params.defaultMode);
   const selectMode = (mode: PermissionSelection) => {
@@ -117,7 +118,7 @@ export function renderChatPermissionPicker(params: ChatPermissionPickerProps) {
       <button
         slot="trigger"
         type="button"
-        class="chat-controls__inline-select-trigger chat-controls__permission-trigger ${disabled
+        class="chat-controls__inline-select-trigger chat-controls__permission-trigger ${params.disabled
           ? "chat-controls__inline-select-trigger--disabled"
           : ""} ${params.mode ? "" : "chat-controls__permission-trigger--default"} ${fullAccess
           ? "chat-controls__permission-trigger--full"

--- a/ui/src/test-helpers/control-ui-e2e.sessions.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.sessions.test.ts
@@ -13,6 +13,7 @@ type Controls = {
   resolveDeferred: (method: string, payload?: unknown) => void;
   rejectDeferred: (method: string) => void;
   setMethodResponse: (method: string, payload: unknown) => void;
+  setSessionsListResponse: (payload: { sessions: unknown[] }) => void;
 };
 const flush = () =>
   new Promise<void>((resolve) => {
@@ -370,7 +371,7 @@ it("does not commit rejected patches or unresolved deferrals", async ({ connect 
   ).toMatchObject({ ok: false, error: { code: "INVALID_REQUEST" } });
   expect((await request("sessions.list")).payload.sessions).toEqual(beforeStalePatch);
   const replacementSessionId = "replacement-generation";
-  controls.setMethodResponse("sessions.list", {
+  controls.setSessionsListResponse({
     sessions: [{ ...notes, sessionId: replacementSessionId }],
   });
   expect(
@@ -383,6 +384,16 @@ it("does not commit rejected patches or unresolved deferrals", async ({ connect 
   expect((await request("sessions.list")).payload.sessions).toEqual([
     expect.objectContaining({ sessionId: replacementSessionId, label: "Replacement label" }),
   ]);
+  for (const method of ["sessions.describe", "chat.history", "chat.startup"]) {
+    const params = method === "sessions.describe" ? { key: notes.key } : { sessionKey: notes.key };
+    expect((await request(method, params)).payload).toEqual(
+      expect.objectContaining(
+        method === "sessions.describe"
+          ? { session: expect.objectContaining({ sessionId: replacementSessionId }) }
+          : { sessionId: replacementSessionId },
+      ),
+    );
+  }
 });
 
 it("replays later commits onto an injected list without adopting its stale generation", async ({
@@ -393,11 +404,18 @@ it("replays later commits onto an injected list without adopting its stale gener
   const stale = { ...notes, archived: false, sessionId: "retired-generation" };
   controls.setMethodResponse("sessions.list", { sessions: [stale] });
   expect((await request("sessions.list")).payload.sessions).toEqual([
-    expect.objectContaining(stale),
+    expect.objectContaining({ ...stale, archived: true }),
   ]);
+  expect(
+    await request("sessions.patch", {
+      key: notes.key,
+      expectedSessionId: stale.sessionId,
+      label: "Wrong generation",
+    }),
+  ).toMatchObject({ ok: false, error: { code: "INVALID_REQUEST" } });
   await request("sessions.patch", { key: notes.key, label: "Renamed" });
   expect((await request("sessions.list")).payload.sessions).toEqual([
-    expect.objectContaining({ ...stale, label: "Renamed" }),
+    expect.objectContaining({ ...stale, archived: true, label: "Renamed" }),
   ]);
   expect((await request("sessions.describe", { key: notes.key })).payload).toMatchObject({
     session: { sessionId: notes.sessionId, archived: true, label: "Renamed" },

--- a/ui/src/test-helpers/control-ui-e2e.sessions.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.sessions.test.ts
@@ -422,6 +422,42 @@ it("replays later commits onto an injected list without adopting its stale gener
   });
 });
 
+it("replaces canonical rows and membership without retaining omitted fields", async ({
+  connect,
+}) => {
+  const omitted = { key: "agent:ops:omitted", sessionId: "omitted-generation" };
+  const scenario = { sessions: [notes, omitted] };
+  const { request, controls } = await connect(scenario);
+  await request("sessions.patch", { key: notes.key, color: "purple", label: "Patched" });
+  await request("sessions.create", { key: "agent:ops:materialized", label: "Materialized" });
+  const replacement = { key: notes.key, sessionId: notes.sessionId, label: "Exact replacement" };
+
+  controls.setSessionsListResponse({ sessions: [replacement] });
+
+  const assertReplacement = async (currentRequest: typeof request) => {
+    expect((await currentRequest("sessions.list")).payload.sessions).toEqual([replacement]);
+    expect((await currentRequest("sessions.describe", { key: notes.key })).payload.session).toEqual(
+      replacement,
+    );
+    for (const method of ["chat.history", "chat.startup"]) {
+      expect((await currentRequest(method, { sessionKey: notes.key })).payload).toMatchObject({
+        sessionId: notes.sessionId,
+        sessionInfo: replacement,
+      });
+    }
+    for (const key of [omitted.key, "agent:ops:materialized"]) {
+      expect((await currentRequest("sessions.describe", { key })).payload.session).toBeNull();
+      expect(
+        (await currentRequest("chat.startup", { sessionKey: key })).payload,
+      ).not.toHaveProperty("sessionInfo");
+    }
+  };
+  await assertReplacement(request);
+
+  const reloaded = await connect(scenario);
+  await assertReplacement(reloaded.request);
+});
+
 it("commits only successful patchMany targets", async ({ connect }) => {
   const other = { key: "agent:ops:other", sessionId: "other-generation" };
   const scenario = {

--- a/ui/src/test-helpers/control-ui-e2e.sessions.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.sessions.test.ts
@@ -369,6 +369,20 @@ it("does not commit rejected patches or unresolved deferrals", async ({ connect 
     }),
   ).toMatchObject({ ok: false, error: { code: "INVALID_REQUEST" } });
   expect((await request("sessions.list")).payload.sessions).toEqual(beforeStalePatch);
+  const replacementSessionId = "replacement-generation";
+  controls.setMethodResponse("sessions.list", {
+    sessions: [{ ...notes, sessionId: replacementSessionId }],
+  });
+  expect(
+    await request("sessions.patch", {
+      key: notes.key,
+      expectedSessionId: replacementSessionId,
+      label: "Replacement label",
+    }),
+  ).toMatchObject({ ok: true });
+  expect((await request("sessions.list")).payload.sessions).toEqual([
+    expect.objectContaining({ sessionId: replacementSessionId, label: "Replacement label" }),
+  ]);
 });
 
 it("replays later commits onto an injected list without adopting its stale generation", async ({

--- a/ui/src/test-helpers/control-ui-e2e.sessions.test.ts
+++ b/ui/src/test-helpers/control-ui-e2e.sessions.test.ts
@@ -360,6 +360,15 @@ it("does not commit rejected patches or unresolved deferrals", async ({ connect 
   expect((await request("sessions.list")).payload).toMatchObject({
     sessions: [{ pinned: true, pinnedAt: expect.any(Number) }],
   });
+  const beforeStalePatch = (await request("sessions.list")).payload.sessions;
+  expect(
+    await request("sessions.patch", {
+      key: notes.key,
+      expectedSessionId: "retired-generation",
+      label: "Wrong generation",
+    }),
+  ).toMatchObject({ ok: false, error: { code: "INVALID_REQUEST" } });
+  expect((await request("sessions.list")).payload.sessions).toEqual(beforeStalePatch);
 });
 
 it("replays later commits onto an injected list without adopting its stale generation", async ({

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -1162,6 +1162,7 @@ function installControlUiMockGateway(
   (window as MockGatewayWindow)["__OPENCLAW_CONTROL_UI_BASE_PATH__"] = scenario.basePath;
   const protocolVersion = input.protocolVersion;
   const methodResponseOverridesStorageKey = "openclaw.control-ui-e2e.method-responses.v1";
+  const canonicalSessionsStorageKey = "openclaw.control-ui-e2e.canonical-sessions.v1";
   const methodResponseOverrides: Record<string, unknown> = {};
   try {
     const storedOverrides = window.sessionStorage.getItem(methodResponseOverridesStorageKey);
@@ -1180,10 +1181,29 @@ function installControlUiMockGateway(
   const requestHandlers = new Map<string, ControlUiMockRequestHandler>();
   const methodResponseSequenceIndexes = new Map<string, number>();
   const pendingApprovals = new Map<string, Map<string, Record<string, unknown>>>();
+  let canonicalSessionRows = scenario.sessions;
+  let hasCanonicalSessionsOverride = false;
+  try {
+    const storedCanonicalSessions = window.sessionStorage.getItem(canonicalSessionsStorageKey);
+    const parsedCanonicalSessions = storedCanonicalSessions
+      ? (JSON.parse(storedCanonicalSessions) as unknown)
+      : null;
+    if (Array.isArray(parsedCanonicalSessions)) {
+      canonicalSessionRows = parsedCanonicalSessions as ControlUiSessionFixture[];
+      hasCanonicalSessionsOverride = true;
+    }
+  } catch {
+    // The scenario remains authoritative when browser storage is unavailable.
+  }
   const sessions = createSessions({
-    rows: scenario.sessions,
+    rows: canonicalSessionRows,
     mainKey: scenario.mainSessionKey,
   });
+  if (hasCanonicalSessionsOverride) {
+    // Persisted explicit snapshots bypass scenario-default enrichment so reload
+    // preserves the same exact owner rows used by CAS, describe, and startup.
+    sessions.replaceCanonicalList(canonicalSessionRows);
+  }
   const terminalSessions = new Map<string, MockTerminalSession>();
   let terminalSessionSequence = 0;
   const sessionMessageSubscriptions = new Set<string>();
@@ -2003,7 +2023,9 @@ function installControlUiMockGateway(
         const row = sessions.read(key);
         const info = sessions.sessionInfo(key);
         const override =
-          row.key === sessions.read(scenario.sessionKey).key ? scenario.sessionInfo : null;
+          !hasCanonicalSessionsOverride && row.key === sessions.read(scenario.sessionKey).key
+            ? scenario.sessionInfo
+            : null;
         return {
           messages: scenario.historyMessages,
           sessionId: row.sessionId,
@@ -2592,6 +2614,15 @@ function installControlUiMockGateway(
       // Generic method responses may be stale or delayed. Only this explicit
       // owner transition advances the canonical rows used by mutation CAS.
       sessions.replaceCanonicalList(payload.sessions);
+      hasCanonicalSessionsOverride = true;
+      try {
+        window.sessionStorage.setItem(
+          canonicalSessionsStorageKey,
+          JSON.stringify(payload.sessions),
+        );
+      } catch {
+        // The current document still observes the canonical replacement.
+      }
       this.setMethodResponse("sessions.list", payload);
     },
     setSessionSharingPolicy(policy) {

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -592,6 +592,7 @@ export type MockGatewayControls = {
   setOperatorScopes: (scopes: string[]) => Promise<void>;
   setHistoryMessages: (messages: unknown[]) => Promise<void>;
   setMethodResponse: (method: string, payload: unknown) => Promise<void>;
+  setSessionsListResponse: (payload: { sessions: unknown[] }) => Promise<void>;
   setSessionSharingPolicy: (policy: {
     allowedSessionVisibilities: Array<"shared" | "read-only" | "suggest" | "draft">;
     hasMultipleSessionSharingIdentities: boolean;
@@ -1082,6 +1083,7 @@ export type ControlUiMockGateway = {
   setOperatorScopes: (scopes: string[]) => void;
   setHistoryMessages: (messages: unknown[]) => void;
   setMethodResponse: (method: string, payload: unknown) => void;
+  setSessionsListResponse: (payload: { sessions: unknown[] }) => void;
   setRequestHandler: (method: string, handler: ControlUiMockRequestHandler) => void;
   setSessionSharingPolicy: (policy: {
     allowedSessionVisibilities: Array<"shared" | "read-only" | "suggest" | "draft">;
@@ -1546,7 +1548,7 @@ function installControlUiMockGateway(
     if (method === "sessions.patch" && isRecord(params) && typeof params.key === "string") {
       if (
         typeof params.expectedSessionId === "string" &&
-        sessions.currentListSessionId(params.key) !== params.expectedSessionId
+        sessions.read(params.key).sessionId !== params.expectedSessionId
       ) {
         return {
           __mockError: {
@@ -2572,9 +2574,6 @@ function installControlUiMockGateway(
       requestHandlers.set(method, handler);
     },
     setMethodResponse(method, payload) {
-      if (method === "sessions.list" && isRecord(payload) && Array.isArray(payload.sessions)) {
-        sessions.replaceListSnapshot(payload.sessions);
-      }
       scenario.methodResponses[method] = payload;
       methodResponseSequenceIndexes.delete(method);
       methodResponseOverrides[method] = payload;
@@ -2586,6 +2585,12 @@ function installControlUiMockGateway(
       } catch {
         // Current-document responses still work if browser storage is unavailable.
       }
+    },
+    setSessionsListResponse(payload) {
+      // Generic method responses may be stale or delayed. Only this explicit
+      // owner transition advances the canonical rows used by mutation CAS.
+      sessions.replaceCanonicalList(payload.sessions);
+      this.setMethodResponse("sessions.list", payload);
     },
     setSessionSharingPolicy(policy) {
       scenario.allowedSessionVisibilities = policy.allowedSessionVisibilities;
@@ -2846,6 +2851,15 @@ function createMockGatewayControls(
         },
         { targetMethod: method, responsePayload: payload },
       );
+    },
+    async setSessionsListResponse(payload) {
+      await page.evaluate((responsePayload) => {
+        const gateway = (window as MockGatewayWindow).openclawControlUiE2eGateway;
+        if (!gateway) {
+          throw new Error("Mock Gateway is not installed");
+        }
+        gateway.setSessionsListResponse(responsePayload);
+      }, payload);
     },
     async setSessionSharingPolicy(policy) {
       await page.evaluate((nextPolicy) => {

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -1546,7 +1546,7 @@ function installControlUiMockGateway(
     if (method === "sessions.patch" && isRecord(params) && typeof params.key === "string") {
       if (
         typeof params.expectedSessionId === "string" &&
-        sessions.read(params.key).sessionId !== params.expectedSessionId
+        sessions.currentListSessionId(params.key) !== params.expectedSessionId
       ) {
         return {
           __mockError: {

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -1544,6 +1544,17 @@ function installControlUiMockGateway(
       }
     }
     if (method === "sessions.patch" && isRecord(params) && typeof params.key === "string") {
+      if (
+        typeof params.expectedSessionId === "string" &&
+        sessions.read(params.key).sessionId !== params.expectedSessionId
+      ) {
+        return {
+          __mockError: {
+            code: "INVALID_REQUEST",
+            message: "session identity changed; refresh and retry",
+          },
+        };
+      }
       const result = sessions.patch(params.key, params);
       return "__mockError" in result || (isRecord(response) && Object.keys(response).length === 0)
         ? result

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -571,6 +571,8 @@ export function setSharedControlUiE2eServerBaseUrl(baseUrl: string | null): void
   sharedControlUiE2eServerBaseUrl = baseUrl;
 }
 
+type MockSessionsListResponse = { sessions: unknown[]; [field: string]: unknown };
+
 export type MockGatewayControls = {
   closeLatest: (code?: number, reason?: string) => Promise<void>;
   deliverLatest: (frame: unknown) => Promise<void>;
@@ -592,7 +594,7 @@ export type MockGatewayControls = {
   setOperatorScopes: (scopes: string[]) => Promise<void>;
   setHistoryMessages: (messages: unknown[]) => Promise<void>;
   setMethodResponse: (method: string, payload: unknown) => Promise<void>;
-  setSessionsListResponse: (payload: { sessions: unknown[] }) => Promise<void>;
+  setSessionsListResponse: (payload: MockSessionsListResponse) => Promise<void>;
   setSessionSharingPolicy: (policy: {
     allowedSessionVisibilities: Array<"shared" | "read-only" | "suggest" | "draft">;
     hasMultipleSessionSharingIdentities: boolean;
@@ -1083,7 +1085,7 @@ export type ControlUiMockGateway = {
   setOperatorScopes: (scopes: string[]) => void;
   setHistoryMessages: (messages: unknown[]) => void;
   setMethodResponse: (method: string, payload: unknown) => void;
-  setSessionsListResponse: (payload: { sessions: unknown[] }) => void;
+  setSessionsListResponse: (payload: MockSessionsListResponse) => void;
   setRequestHandler: (method: string, handler: ControlUiMockRequestHandler) => void;
   setSessionSharingPolicy: (policy: {
     allowedSessionVisibilities: Array<"shared" | "read-only" | "suggest" | "draft">;

--- a/ui/src/test-helpers/control-ui-session-fixtures.ts
+++ b/ui/src/test-helpers/control-ui-session-fixtures.ts
@@ -49,6 +49,7 @@ export function createControlUiSessionFixtures(input: {
   mainKey: string;
 }) {
   const records = new Map<string, { row: ControlUiSessionFixture; changed: Set<string> }>();
+  const currentListSessionIds = new Map<string, string>();
   const listed = new Set<string>();
   const materialized = new Set<string>();
   let timestamp = 1_800_000_000_000;
@@ -86,6 +87,9 @@ export function createControlUiSessionFixtures(input: {
       },
       changed: new Set(),
     });
+    if (typeof fixture.sessionId === "string") {
+      currentListSessionIds.set(key, fixture.sessionId);
+    }
     listed.add(key);
   }
   const read = (key: string) => ({ ...record(key).row });
@@ -158,6 +162,9 @@ export function createControlUiSessionFixtures(input: {
   const materialize = (key: string, fields: Partial<ControlUiSessionFixture>) => {
     const value = record(key);
     value.row = { ...value.row, ...fields, key: canonicalKey(key) };
+    if (typeof fields.sessionId === "string") {
+      currentListSessionIds.set(canonicalKey(key), fields.sessionId);
+    }
     listed.add(canonicalKey(key));
     materialized.add(canonicalKey(key));
   };
@@ -189,6 +196,8 @@ export function createControlUiSessionFixtures(input: {
   };
   return {
     read,
+    currentListSessionId: (key: string) =>
+      currentListSessionIds.get(canonicalKey(key)) ?? read(key).sessionId,
     // History publishes a full row replacement. An unseeded wire-only fixture
     // has no canonical metadata to publish until its caller declares the row.
     sessionInfo: (key: string) => (listed.has(canonicalKey(key)) ? read(key) : undefined),
@@ -201,6 +210,9 @@ export function createControlUiSessionFixtures(input: {
       // future cases/sequences or clear unrelated rows' mutation history.
       for (const row of rows) {
         const value = record(row.key);
+        if (typeof row.sessionId === "string") {
+          currentListSessionIds.set(canonicalKey(row.key), row.sessionId);
+        }
         for (const field of Object.keys(row)) {
           value.changed.delete(field);
         }

--- a/ui/src/test-helpers/control-ui-session-fixtures.ts
+++ b/ui/src/test-helpers/control-ui-session-fixtures.ts
@@ -49,7 +49,6 @@ export function createControlUiSessionFixtures(input: {
   mainKey: string;
 }) {
   const records = new Map<string, { row: ControlUiSessionFixture; changed: Set<string> }>();
-  const currentListSessionIds = new Map<string, string>();
   const listed = new Set<string>();
   const materialized = new Set<string>();
   let timestamp = 1_800_000_000_000;
@@ -87,9 +86,6 @@ export function createControlUiSessionFixtures(input: {
       },
       changed: new Set(),
     });
-    if (typeof fixture.sessionId === "string") {
-      currentListSessionIds.set(key, fixture.sessionId);
-    }
     listed.add(key);
   }
   const read = (key: string) => ({ ...record(key).row });
@@ -162,9 +158,6 @@ export function createControlUiSessionFixtures(input: {
   const materialize = (key: string, fields: Partial<ControlUiSessionFixture>) => {
     const value = record(key);
     value.row = { ...value.row, ...fields, key: canonicalKey(key) };
-    if (typeof fields.sessionId === "string") {
-      currentListSessionIds.set(canonicalKey(key), fields.sessionId);
-    }
     listed.add(canonicalKey(key));
     materialized.add(canonicalKey(key));
   };
@@ -196,8 +189,6 @@ export function createControlUiSessionFixtures(input: {
   };
   return {
     read,
-    currentListSessionId: (key: string) =>
-      currentListSessionIds.get(canonicalKey(key)) ?? read(key).sessionId,
     // History publishes a full row replacement. An unseeded wire-only fixture
     // has no canonical metadata to publish until its caller declares the row.
     sessionInfo: (key: string) => (listed.has(canonicalKey(key)) ? read(key) : undefined),
@@ -205,17 +196,26 @@ export function createControlUiSessionFixtures(input: {
     materialize,
     list,
     materializedCount: () => materialized.size,
-    replaceListSnapshot(rows: ControlUiSessionFixture[]) {
-      // Only explicitly replaced fields supersede earlier commits. Do not read
-      // future cases/sequences or clear unrelated rows' mutation history.
+    replaceCanonicalList(rows: unknown[]) {
       for (const row of rows) {
-        const value = record(row.key);
-        if (typeof row.sessionId === "string") {
-          currentListSessionIds.set(canonicalKey(row.key), row.sessionId);
+        if (!row || typeof row !== "object" || !("key" in row) || typeof row.key !== "string") {
+          continue;
         }
-        for (const field of Object.keys(row)) {
-          value.changed.delete(field);
+        const fixture: ControlUiSessionFixture = { ...row, key: row.key };
+        const value = record(fixture.key);
+        const replaced =
+          typeof fixture.sessionId === "string" && fixture.sessionId !== value.row.sessionId;
+        value.row = replaced
+          ? { ...fixture, key: canonicalKey(fixture.key) }
+          : { ...value.row, ...fixture, key: canonicalKey(fixture.key) };
+        if (replaced) {
+          value.changed.clear();
+        } else {
+          for (const field of Object.keys(fixture)) {
+            value.changed.delete(field);
+          }
         }
+        listed.add(canonicalKey(fixture.key));
       }
     },
   };

--- a/ui/src/test-helpers/control-ui-session-fixtures.ts
+++ b/ui/src/test-helpers/control-ui-session-fixtures.ts
@@ -51,6 +51,7 @@ export function createControlUiSessionFixtures(input: {
   const records = new Map<string, { row: ControlUiSessionFixture; changed: Set<string> }>();
   const listed = new Set<string>();
   const materialized = new Set<string>();
+  let materializedSequence = 0;
   let timestamp = 1_800_000_000_000;
   const canonicalKey = (key: string) => (key === "main" ? input.mainKey : key);
   const record = (inputKey: string) => {
@@ -160,6 +161,7 @@ export function createControlUiSessionFixtures(input: {
     value.row = { ...value.row, ...fields, key: canonicalKey(key) };
     listed.add(canonicalKey(key));
     materialized.add(canonicalKey(key));
+    materializedSequence += 1;
   };
   const list = (wireRows?: unknown[]) => {
     const rows = wireRows ?? [...listed].map(read);
@@ -195,27 +197,21 @@ export function createControlUiSessionFixtures(input: {
     patch,
     materialize,
     list,
-    materializedCount: () => materialized.size,
+    materializedCount: () => materializedSequence,
     replaceCanonicalList(rows: unknown[]) {
+      const replacements: ControlUiSessionFixture[] = [];
       for (const row of rows) {
         if (!row || typeof row !== "object" || !("key" in row) || typeof row.key !== "string") {
-          continue;
+          throw new Error("Canonical sessions.list rows require a string key");
         }
-        const fixture: ControlUiSessionFixture = { ...row, key: row.key };
-        const value = record(fixture.key);
-        const replaced =
-          typeof fixture.sessionId === "string" && fixture.sessionId !== value.row.sessionId;
-        value.row = replaced
-          ? { ...fixture, key: canonicalKey(fixture.key) }
-          : { ...value.row, ...fixture, key: canonicalKey(fixture.key) };
-        if (replaced) {
-          value.changed.clear();
-        } else {
-          for (const field of Object.keys(fixture)) {
-            value.changed.delete(field);
-          }
-        }
-        listed.add(canonicalKey(fixture.key));
+        replacements.push({ ...row, key: canonicalKey(row.key) });
+      }
+      records.clear();
+      listed.clear();
+      materialized.clear();
+      for (const fixture of replacements) {
+        records.set(fixture.key, { row: fixture, changed: new Set() });
+        listed.add(fixture.key);
       }
     },
   };


### PR DESCRIPTION
Closes #134409

## What Problem This Solves

The macOS composer could render an empty gap before the inherited `Default` permission label because WebKit collapsed the inline shield SVG to `0 x 0` inside its 16 px wrapper.

Permission changes also replaced the selected mode with a spinner and `Applying permissions...` while the Gateway update settled. The update is normally fast, so that intermediate state appeared as a distracting flash.

## Why This Change Was Made

The permission wrapper already owns the correct icon box. Permission and lock SVGs now fill that box on every desktop engine, matching the existing mobile behavior without relying on intrinsic SVG dimensions.

Permission selection is now optimistic: the selected mode's icon and label render immediately. The in-flight mutation still rejects duplicate permission choices, and chat sends still wait for the exact settings patch. Each mutation carries the observed session incarnation as `expectedSessionId`, so a recreated session under the same key cannot receive stale intent. If a patch fails, the UI refreshes the authoritative session list before releasing the projection; when refresh is unavailable, it keeps the optimistic mode until a later canonical list rather than restoring a potentially stale snapshot. The visible error slot belongs to the newest admitted permission mutation, so a superseded failure cannot publish over a newer success.

A successful patch response is itself an authoritative persisted fact. The session owner projects its returned permission mode into the matching session incarnation before refreshing the list. If that refresh fails or its event was lost, the picker keeps the confirmed mode and visibly reports that permissions were saved but the session refresh failed.

The transient `applying` prop, loader, copy, busy ARIA state, and disabled-opacity presentation were removed. While a patch is pending, the control remains semantically disabled to prevent a silent duplicate choice, but keeps the selected icon and label at full opacity. Focused coverage protects optimistic display, duplicate blocking, authoritative reconciliation, superseded-error suppression, and visible current failures.

## User Impact

- The inherited permission icon is visible in the macOS app instead of leaving a blank gap.
- Choosing a permission mode immediately shows its actual icon and label.
- There is no `Applying permissions...` text, spinner, or temporary dimming.
- Failed updates visibly reconcile to the authoritative mode and report the error.
- Superseded failures do not cover a newer successful choice with an obsolete error.
- A successful permission change remains visible when its follow-up list refresh fails, with an explicit refresh warning instead of a silent rollback.
- Sending remains ordered behind an in-flight permission update.

## Decision Surface

- **Permission selector:** consumes the optimistic mode and always renders that mode's glyph and label; pending updates disable interaction without applying visual dimming.
- **Chat composer:** mounts the selector as its leading control without layout movement during the update.
- **Session mutation owner:** sends `sessions.patch` with the observed session incarnation, rejects duplicate in-flight choices, and reconciles failures from the authoritative list.
- **Visible outcome owner:** assigns the error slot to the newest admitted permission mutation and drops superseded outcomes.
- **Patch response owner:** records the persisted mode from the successful response before the independent list refresh; refresh failure remains a separate visible outcome.
- **Chat send submission and delivery queues:** continue consuming the pending settings promise, so sends wait for permission confirmation.
- **Gateway session rows:** `permissionModePending` still blocks conflicting local selection, but no longer replaces the selected icon and label with transient UI.

## Evidence

### Original WebKit SVG Regression

| Before | After |
| --- | --- |
| ![macOS composer before: blank permission icon gap](https://github.com/user-attachments/assets/423bee65-870b-44f8-a8f2-8d4ae06186ff) | ![macOS composer after: inherited permission shield visible](https://github.com/user-attachments/assets/e2647227-295f-4a39-8517-003a8eb1884e) |

Playwright WebKit measured the permission SVG at `0 x 0` before and `16 x 16` after. Chromium measured `16 x 16` before and after.

### Optimistic Permission Selection

Same Chromium viewport (`1280 x 900`), dark theme, session, transcript, and `Full Access + permissionModePending` fixture:

| Before | After |
| --- | --- |
| ![Before: applying permissions spinner and copy](https://github.com/user-attachments/assets/0a8433f8-99af-42f6-b618-7707559955c0) | ![After: Full Access shield and label remain visible](https://github.com/user-attachments/assets/89d2d37a-60cc-4594-a9bc-c56bf694add3) |

The intermediate state is removed: before shows the loader and `Applying permissions...`; after preserves the selected `Full Access` shield and label with no spinner, copy, or dimming.

The signed macOS app was verified against an isolated Gateway with the selected `Workspace` and `Full Access` icon/label visible in native chrome. Window capture used the app's CGWindow ID and did not steal focus. The native shell does not accept the pending-state mock as a complete Gateway, so the transient before/after comparison above uses the equivalent web fixture rather than publishing a misleading macOS reconnect screen.

### Validation

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-session-controls.test.ts ui/src/test-helpers/control-ui-e2e.sessions.test.ts` (`47` tests passed)
- `node scripts/run-vitest.mjs ui/src/e2e/chat-flow.models-reasoning.e2e.test.ts ui/src/e2e/session-management.rename-identity.e2e.test.ts ui/src/e2e/session-management.group-identity.e2e.test.ts` (`20` tests passed)
- `node scripts/run-vitest.mjs ui/src/e2e/session-management.delete.e2e.test.ts` (`4` tests passed)
- Authoritative session-list fixture sibling sweep (`20` E2E files, `123` tests passed); `23` intentionally wire-only `sessions.list` response sites remain unchanged.
- Re-audit 3 pre-fix proof on `58feaf444ccc355b5f4f0a1c44aa042d9b006742`: successful patch plus failed refresh reverted to the old mode without the required warning, and same-incarnation canonical replacement retained omitted fields and rows.
- Re-audit 3 post-fix proof: `88` session owner/unit tests, `151` authoritative-caller E2E tests, and `38` focused permission/exact-snapshot E2E tests passed.
- Exact-head CI on the first re-audit candidate exposed two send-barrier ordering regressions. The final repair restores the canonical `Promise<void>` refresh completion contract for existing model, pin, and archive patches; only permission mutations consume the detailed refresh outcome. Both regressions and the focused owner/sibling suite passed after the repair (`387` tests).
- `pnpm check:changed`
- Pre-fix re-audit proof on `ec31f7ccf71d35fa407fe598500d5af499bdaaa2`: the stale-error ordering regression and stale-wire mock CAS regression both failed for the intended reason.
- `pnpm ui:i18n:baseline`
- `pnpm docs:list`
- `pnpm docs:check-mdx`
- `pnpm docs:check-links`
- `pnpm docs:check-i18n-glossary`
- `node scripts/check-changed.mjs -- <changed files>`
- Signed macOS app packaging and code-signature verification
- Isolated Gateway and native app connection on `127.0.0.1:18889`
- Exact-head CI run `33609569907` passed for `dfca64a233e091aa79b5896626a13f12bd6e5d76`.

Production LOC before the final ordering fence was `+169/-70` (net `+99`); after rebasing onto current main, the final candidate is `+196/-73` (net `+123`). Tests and test support are `+860/-214`; docs are `+1/-1`. The icon and optimistic presentation itself account for roughly `+30` production lines in `chat-permission-picker` and CSS. The remainder hardens session permission mutations against four concrete state failures: authoritative reconciliation after a post-commit rejection, exact session identity through `expectedSessionId`, error banners bound to the newest outcome, and monotonic ordering for local permission projections and their refreshes. Each behavior has regression coverage; separating any of them would leave the optimistic UI able to display stale or unconfirmed state.




