### PR TITLE
fix: report declared configuration accurately in triage

### DIFF
--- a/docs/cli/triage.md
+++ b/docs/cli/triage.md
@@ -18,6 +18,8 @@ The prompt includes the OpenClaw version, platform, Node.js version, prioritized
 
 Secrets, tokens, raw chat payloads, and raw logs are excluded. Paths inside the prompt are shown relative to `~` or `$OPENCLAW_STATE_DIR`; the saved prompt path, archive path, and printed handoff commands retain the real absolute paths needed by your shell. Doctor checks remain advisory and do not apply repairs.
 
+The archive's config summary counts agent, plugin, and channel entries declared in the saved file. Shared channel settings and `$include` directives are excluded from those counts; diagnostics do not expand included files.
+
 ## Agent handoff
 
 In an interactive terminal, triage detects the agent handoff routes available on the current machine and asks which one to use. A configured OpenClaw embedded agent appears first, followed by Claude Code when `claude` is on `PATH`, Codex CLI when `codex` is on `PATH`, and an option to just print the commands.

--- a/src/logging/diagnostic-support-export.test.ts
+++ b/src/logging/diagnostic-support-export.test.ts
@@ -15,12 +15,6 @@ import {
   stopDiagnosticStabilityRecorder,
 } from "./diagnostic-stability.js";
 import { writeDiagnosticSupportExport } from "./diagnostic-support-export.js";
-import {
-  redactSupportString,
-  redactTextForSupport,
-  sanitizeSupportConfigValue,
-  sanitizeSupportSnapshotValue,
-} from "./diagnostic-support-redaction.js";
 import type { LogTailPayload } from "./log-tail.js";
 
 async function readZipTextEntries(file: string): Promise<Record<string, string>> {
@@ -32,38 +26,6 @@ async function readZipTextEntries(file: string): Promise<Record<string, string>>
     }
   }
   return entries;
-}
-
-function fakeAwsSecretAccessKey(): string {
-  return fakeRepeatedToken(["A", "b", "9", "/"]);
-}
-
-function fakeAwsSecretAccessKeyWithPadding(): string {
-  return fakeRepeatedToken(["A", "b", "9", "="]);
-}
-
-function fakeJwtAwsSecretShapedSegment(): string {
-  return fakeRepeatedToken(["A", "b", "9", "C"]);
-}
-
-function fakeCommitHash(): string {
-  return `${"0123456789abcdef".repeat(2)}01234567`;
-}
-
-function fakeLowercaseBase36Identifier(): string {
-  return `${"z".repeat(39)}1`;
-}
-
-function fakeFlyTokenWithAwsShapedBody(): string {
-  return `FlyV1 fm123_${fakeAwsSecretAccessKeyWithPadding()}_${"tail".repeat(20)}`;
-}
-
-function fakeCommaDelimitedFlyTokenWithAwsShapedBody(): string {
-  return `FlyV1 fm123_headheadheadheadheadheadheadhead,${fakeAwsSecretAccessKeyWithPadding()},${"tail".repeat(20)}`;
-}
-
-function fakeRepeatedToken(chars: readonly string[], length = 40): string {
-  return Array.from({ length }, (_entry, index) => chars[index % chars.length] ?? "A").join("");
 }
 
 describe("diagnostic support export", () => {
@@ -110,6 +72,7 @@ describe("diagnostic support export", () => {
             mode: "local",
             bind: "loopback",
             port: 18789,
+            tailscale: { mode: "serve" },
             auth: {
               mode: "token",
               token: fakeToken,
@@ -144,6 +107,9 @@ describe("diagnostic support export", () => {
             },
           },
           channels: {
+            $include: "./other-channels.json",
+            defaults: { groupPolicy: "disabled" },
+            modelByChannel: {},
             telegram: {
               accounts: {
                 "15555551212": {
@@ -154,7 +120,22 @@ describe("diagnostic support export", () => {
               },
             },
           },
-          agents: [{ name: "personal-agent", instructions: privateChat }],
+          agents: {
+            ownership: "explicit",
+            entries: {
+              $include: "./other-agents.json",
+              main: { name: "personal-agent", instructions: privateChat },
+            },
+          },
+          plugins: {
+            enabled: false,
+            allow: ["telegram", "slack"],
+            entries: {
+              $include: "./other-plugins.json",
+              telegram: { enabled: true },
+              slack: { enabled: false },
+            },
+          },
         },
         null,
         2,
@@ -418,12 +399,18 @@ describe("diagnostic support export", () => {
     expect(health.data?.channels?.telegram?.accounts).toEqual({ count: 1 });
 
     const configShape = JSON.parse(entries["config/shape.json"] ?? "{}") as {
-      gateway?: { mode?: string; authMode?: string };
-      channels?: { ids?: string[] };
+      gateway?: { mode?: string; authMode?: string; tailscale?: string };
+      channels?: { count?: number; ids?: string[] };
+      plugins?: { count?: number; ids?: string[] };
+      agents?: { count?: number };
     };
     expect(configShape.gateway?.mode).toBe("local");
     expect(configShape.gateway?.authMode).toBe("token");
-    expect(configShape.channels?.ids).toEqual(["telegram"]);
+    expect(configShape.gateway?.tailscale).toBe("serve");
+    expect(configShape.channels).toEqual({ count: 1, ids: ["telegram"] });
+    expect(configShape.plugins).toEqual({ count: 2, ids: ["slack", "telegram"] });
+    expect(configShape.agents).toEqual({ count: 1 });
+    expect(JSON.parse(entries["diagnostics.json"] ?? "{}").config).toEqual(configShape);
 
     const sanitizedConfig = JSON.parse(entries["config/sanitized.json"] ?? "{}") as {
       gateway?: {
@@ -445,7 +432,7 @@ describe("diagnostic support export", () => {
       logging?: {
         redactSensitive?: string;
       };
-      agents?: Array<{ name?: string; instructions?: string }>;
+      agents?: { entries?: Record<string, { name?: string; instructions?: string }> };
       models?: {
         providers?: {
           supportProxy?: {
@@ -470,6 +457,7 @@ describe("diagnostic support export", () => {
       mode: "local",
       bind: "loopback",
       port: 18789,
+      tailscale: { mode: "serve" },
       auth: {
         mode: "token",
         token: "<redacted>",
@@ -493,9 +481,37 @@ describe("diagnostic support export", () => {
     expect(sanitizedTelegramAccount?.botToken).toBe("<redacted>");
     expect(sanitizedTelegramAccount?.allowFrom).toEqual({ redacted: true, count: 1 });
     expect(sanitizedTelegramAccount?.ownerId).toBe("<redacted>");
-    expect(sanitizedConfig.agents?.[0]?.name).toBe("personal-agent");
-    expect(sanitizedConfig.agents?.[0]?.instructions).toBe("<redacted>");
+    expect(sanitizedConfig.agents?.entries?.main?.name).toBe("personal-agent");
+    expect(sanitizedConfig.agents?.entries?.main?.instructions).toBe("<redacted>");
   });
+
+  it.each([
+    { agents: { list: [{ id: "legacy" }] }, expected: undefined },
+    { agents: { defaults: {} }, expected: undefined },
+    { agents: { entries: [] }, expected: undefined },
+    { agents: { entries: {} }, expected: { count: 0 } },
+  ])(
+    "distinguishes an absent canonical agent roster from an empty one: $agents",
+    async ({ agents, expected }) => {
+      const configPath = path.join(tempDir, "openclaw.json");
+      fs.writeFileSync(configPath, JSON.stringify({ agents }));
+      const result = await writeDiagnosticSupportExport({
+        env: { HOME: tempDir, OPENCLAW_CONFIG_PATH: configPath },
+        stateDir: tempDir,
+        readLogTail: async () => ({
+          file: path.join(tempDir, "openclaw.log"),
+          cursor: 0,
+          size: 0,
+          truncated: false,
+          reset: false,
+          lines: [],
+        }),
+      });
+      const entries = await readZipTextEntries(result.path);
+      expect(JSON.parse(entries["config/shape.json"] ?? "{}").agents).toEqual(expected);
+      expect(JSON.parse(entries["diagnostics.json"] ?? "{}").config.agents).toEqual(expected);
+    },
+  );
 
   it("sanitizes imported stability bundles before adding them to support exports", async () => {
     const bundlePath = path.join(tempDir, "imported-stability.json");
@@ -674,225 +690,6 @@ describe("diagnostic support export", () => {
         ciaoSuppressed: true,
       },
     });
-  });
-
-  it("redacts numeric private fields in support snapshots and config", () => {
-    const redaction = {
-      env: {
-        HOME: tempDir,
-        OPENCLAW_STATE_DIR: tempDir,
-      },
-      stateDir: tempDir,
-    };
-
-    expect(sanitizeSupportSnapshotValue(15555551212, redaction, "chatId")).toBe("<redacted>");
-    expect(sanitizeSupportSnapshotValue(15555551212, redaction, "messageId")).toBe("<redacted>");
-    expect(sanitizeSupportSnapshotValue(200, redaction, "statusCode")).toBe(200);
-    expect(sanitizeSupportConfigValue(15555551212, redaction, "ownerId")).toBe("<redacted>");
-    expect(sanitizeSupportConfigValue(18789, redaction, "port")).toBe(18789);
-  });
-
-  it("blocks prototype keys and caps support sanitizer width", () => {
-    const redaction = {
-      env: {
-        HOME: tempDir,
-        OPENCLAW_STATE_DIR: tempDir,
-      },
-      stateDir: tempDir,
-    };
-    const wideSnapshot: Record<string, unknown> = {
-      ["__proto__"]: "polluted",
-      constructor: "polluted",
-      prototype: "polluted",
-    };
-    for (let index = 0; index < 1005; index += 1) {
-      wideSnapshot[`field${String(index).padStart(4, "0")}`] = index;
-    }
-
-    const snapshot = sanitizeSupportSnapshotValue(wideSnapshot, redaction) as Record<
-      string,
-      unknown
-    >;
-
-    expect(Object.getPrototypeOf(snapshot)).toBe(null);
-    expect(Object.hasOwn(snapshot, "__proto__")).toBe(false);
-    expect(snapshot.constructor).toBeUndefined();
-    expect(snapshot.prototype).toBeUndefined();
-    expect(snapshot.field0000).toBe(0);
-    expect(snapshot.field0999).toBe(999);
-    expect(snapshot.field1000).toBeUndefined();
-    expect(snapshot["<truncated>"]).toEqual({
-      truncated: true,
-      count: 1008,
-      limit: 1000,
-    });
-
-    const array = sanitizeSupportConfigValue(
-      Array.from({ length: 1005 }, (_entry, index) => ({ name: `item-${index}` })),
-      redaction,
-    ) as Record<string, unknown>;
-
-    expect(Array.isArray(array)).toBe(false);
-    expect((array.items as unknown[]).length).toBe(1000);
-    expect(array.truncated).toBe(true);
-    expect(array.count).toBe(1005);
-    expect(array.limit).toBe(1000);
-  });
-
-  it("redacts support text identifiers without hiding useful URL hosts", () => {
-    const fakeAwsKey = ["ASIA", "IOSFODNN7EXAMPLE"].join("");
-    const fakeAwsSecretKey = fakeAwsSecretAccessKey();
-    const fakeJwt = [
-      "eyJhbGciOiJIUzI1NiIs",
-      "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4i",
-      "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
-    ].join(".");
-    const jwtWithAwsSecretShapedSegment = [
-      "eyJheaderabcd",
-      fakeJwtAwsSecretShapedSegment(),
-      "signatureabcd123456",
-    ].join(".");
-    const awsShapedDataUrl = `data:application/octet-stream;base64,${Array.from(
-      { length: 40 },
-      (_entry, index) => (["A", "b", "9", "+"] as const)[index % 4] ?? "A",
-    ).join("")}`;
-    const cases = [
-      [
-        "connect wss://support-user:support-password@gateway.example/ws?token=short-token&ok=1",
-        "connect wss://<redacted>:<redacted>@gateway.example/ws?token=<redacted>&ok=1",
-      ],
-      [
-        "connect https://gateway.example/ws?access-token=short-token",
-        "connect https://gateway.example/ws?access-token=<redacted>",
-      ],
-      [
-        "connect https://gateway.example/ws?hook-token=hook-secret",
-        "connect https://gateway.example/ws?hook-token=<redacted>",
-      ],
-      ["connect https://token@gateway.example/ws", "connect https://<redacted>@gateway.example/ws"],
-      ["auth Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==", "auth Basic <redacted>"],
-      ["Cookie: sid=secret; theme=light", "Cookie: <redacted>"],
-      [`aws ${fakeAwsKey}`, "aws <redacted-aws-key>"],
-      [`aws secret ${fakeAwsSecretKey}`, "aws secret <redacted-aws-secret-key>"],
-      [
-        `aws padded secret ${fakeAwsSecretAccessKeyWithPadding()}`,
-        "aws padded secret <redacted-aws-secret-key>",
-      ],
-      [`data ${awsShapedDataUrl}`, `data ${awsShapedDataUrl}`],
-      [`jwt ${fakeJwt}`, "jwt <redacted-jwt>"],
-      [`jwt ${jwtWithAwsSecretShapedSegment}`, "jwt <redacted-jwt>"],
-      [`provider ${fakeFlyTokenWithAwsShapedBody()}`, "provider FlyV1 …tail"],
-      [`provider ${fakeCommaDelimitedFlyTokenWithAwsShapedBody()}`, "provider FlyV1 …tail"],
-      [`commit ${fakeCommitHash()}`, `commit ${fakeCommitHash()}`],
-      [`id ${fakeLowercaseBase36Identifier()}`, `id ${fakeLowercaseBase36Identifier()}`],
-      ["email alice@example.com", "email <redacted-email>"],
-      ["matrix @support-user:matrix.example.com", "matrix <redacted-matrix-user>"],
-      ["room !support-room:matrix.example.com", "room <redacted-matrix-room>"],
-      ["event $F0Zlxky8bavuqH6MK75Av_c7UWFLp550WTQ1EA-F0KM", "event <redacted-matrix-event>"],
-      ["notify @support_bot now", "notify <redacted-handle> now"],
-      ["phone 15555551212", "phone <redacted-id>"],
-      [
-        `config password = ${["support", "password", "1234567890"].join("-")}`,
-        "config password = suppor…7890",
-      ],
-      [
-        ["config password", " = ", '"', ["support", "password", "1234567890"].join("-"), '"'].join(
-          "",
-        ),
-        'config password = "suppor…7890"',
-      ],
-      [
-        `config db_password = ${["support", "password", "1234567890"].join("-")}`,
-        "config db_password = suppor…7890",
-      ],
-      [
-        `config readonly_db_password = ${["support", "password", "1234567890"].join("-")}`,
-        "config readonly_db_password = suppor…7890",
-      ],
-      [
-        `config jdbc.password=${["support", "password", "1234567890"].join("-")}`,
-        "config jdbc.password=suppor…7890",
-      ],
-    ] as const;
-
-    for (const [input, expected] of cases) {
-      expect(redactTextForSupport(input)).toBe(expected);
-    }
-  });
-
-  it("truncates support strings without splitting UTF-16 surrogate pairs", () => {
-    const redaction = {
-      env: {
-        HOME: tempDir,
-        OPENCLAW_STATE_DIR: tempDir,
-      },
-      stateDir: tempDir,
-    };
-    const truncationSuffix = "...<truncated>";
-
-    expect(redactSupportString("abcd😀tail", redaction, { maxLength: 5 })).toBe(
-      `abcd${truncationSuffix}`,
-    );
-
-    const redactedPathPrefix = `$OPENCLAW_STATE_DIR${path.sep}`;
-    expect(
-      redactSupportString(path.join(tempDir, "abcd😀tail"), redaction, {
-        maxLength: redactedPathPrefix.length + 5,
-      }),
-    ).toBe(`${redactedPathPrefix}abcd${truncationSuffix}`);
-  });
-
-  it("redacts Windows USERPROFILE paths when HOME is unset", () => {
-    const userProfile = "C:\\Users\\support-user";
-    const stateDir = `${userProfile}\\AppData\\Roaming\\openclaw`;
-    const redaction = {
-      env: {
-        USERPROFILE: userProfile,
-        OPENCLAW_STATE_DIR: stateDir,
-      },
-      stateDir,
-    };
-
-    expect(redactSupportString(`${stateDir}\\logs\\gateway.log`, redaction)).toBe(
-      "$OPENCLAW_STATE_DIR\\logs\\gateway.log",
-    );
-    expect(
-      redactSupportString(`failed at ${userProfile}\\Documents\\snapshot-error.txt`, redaction),
-    ).toBe("failed at ~\\Documents\\snapshot-error.txt");
-    expect(
-      redactSupportString(
-        "failed at c:\\users\\support-user\\Documents\\snapshot-error.txt",
-        redaction,
-      ),
-    ).toBe("failed at ~\\Documents\\snapshot-error.txt");
-
-    const status = sanitizeSupportSnapshotValue(
-      {
-        service: {
-          command: {
-            programArguments: [
-              "node",
-              `${userProfile}\\openclaw\\dist\\index.js`,
-              "--config",
-              `${stateDir}\\openclaw.json`,
-              `--aws-secret-access-key=${fakeAwsSecretAccessKey()}`,
-              "--awsSecretAccessKey",
-              fakeAwsSecretAccessKey(),
-            ],
-            sourcePath: "c:\\users\\support-user\\AppData\\Local\\openclaw\\gateway-service.json",
-          },
-        },
-      },
-      redaction,
-    );
-    const serialized = JSON.stringify(status);
-    expect(serialized).not.toContain("support-user");
-    expect(serialized).not.toContain(fakeAwsSecretAccessKey());
-    expect(serialized).toContain("~\\\\openclaw\\\\dist\\\\index.js");
-    expect(serialized).toContain("$OPENCLAW_STATE_DIR\\\\openclaw.json");
-    expect(serialized).toContain("--aws-secret-access-key=<redacted>");
-    expect(serialized).toContain("--awsSecretAccessKey");
-    expect(serialized).toContain("~\\\\AppData\\\\Local\\\\openclaw\\\\gateway-service.json");
   });
 
   it("keeps writing when status and health snapshots fail", async () => {

--- a/src/logging/diagnostic-support-export.ts
+++ b/src/logging/diagnostic-support-export.ts
@@ -3,6 +3,8 @@ import fs from "node:fs";
 import path from "node:path";
 import process from "node:process";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { isChannelConfigMetadataKey } from "../channels/config-metadata.js";
+import { INCLUDE_KEY } from "../config/includes.js";
 import { parseConfigJson5 } from "../config/io.js";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import { redactConfigObject } from "../config/redact-snapshot.js";
@@ -221,8 +223,10 @@ function resolveBonjourEnvOverride(
   return disabled === false ? "force-enabled" : "unrecognized";
 }
 
-function sortedObjectKeys(value: unknown): string[] {
-  return Object.keys(asOptionalRecord(value) ?? {}).toSorted((a, b) => a.localeCompare(b));
+function sortedConfigEntryKeys(value: unknown): string[] {
+  return Object.keys(asOptionalRecord(value) ?? {})
+    .filter((key) => key !== INCLUDE_KEY)
+    .toSorted((a, b) => a.localeCompare(b));
 }
 
 function sanitizeConfigShape(
@@ -238,7 +242,7 @@ function sanitizeConfigShape(
   const mdns = asOptionalRecord(discovery?.mdns);
   const channels = asOptionalRecord(root.channels);
   const plugins = asOptionalRecord(root.plugins);
-  const agents = Array.isArray(root.agents) ? root.agents : undefined;
+  const agents = asOptionalRecord(asOptionalRecord(root.agents)?.entries);
 
   const shape: ConfigShape = {
     path: configPath,
@@ -246,7 +250,7 @@ function sanitizeConfigShape(
     parseOk: true,
     bytes: stat.size,
     mtime: stat.mtime.toISOString(),
-    topLevelKeys: sortedObjectKeys(root),
+    topLevelKeys: Object.keys(root).toSorted((a, b) => a.localeCompare(b)),
   };
 
   if (gateway) {
@@ -255,7 +259,7 @@ function sanitizeConfigShape(
       bind: safeScalar(gateway.bind),
       port: safeScalar(gateway.port),
       authMode: safeScalar(auth?.mode),
-      tailscale: safeScalar(gateway.tailscale),
+      tailscale: safeScalar(asOptionalRecord(gateway.tailscale)?.mode),
     };
   }
 
@@ -268,21 +272,17 @@ function sanitizeConfigShape(
   }
 
   if (channels) {
-    shape.channels = {
-      count: Object.keys(channels).length,
-      ids: sortedObjectKeys(channels),
-    };
+    const ids = sortedConfigEntryKeys(channels).filter((key) => !isChannelConfigMetadataKey(key));
+    shape.channels = { count: ids.length, ids };
   }
 
   if (plugins) {
-    shape.plugins = {
-      count: Object.keys(plugins).length,
-      ids: sortedObjectKeys(plugins),
-    };
+    const ids = sortedConfigEntryKeys(plugins.entries);
+    shape.plugins = { count: ids.length, ids };
   }
 
   if (agents) {
-    shape.agents = { count: agents.length };
+    shape.agents = { count: sortedConfigEntryKeys(agents).length };
   }
 
   return shape;

--- a/src/logging/diagnostic-support-redaction.test.ts
+++ b/src/logging/diagnostic-support-redaction.test.ts
@@ -1,0 +1,264 @@
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  redactSupportString,
+  redactTextForSupport,
+  sanitizeSupportConfigValue,
+  sanitizeSupportSnapshotValue,
+} from "./diagnostic-support-redaction.js";
+
+function fakeAwsSecretAccessKey(): string {
+  return fakeRepeatedToken(["A", "b", "9", "/"]);
+}
+
+function fakeAwsSecretAccessKeyWithPadding(): string {
+  return fakeRepeatedToken(["A", "b", "9", "="]);
+}
+
+function fakeJwtAwsSecretShapedSegment(): string {
+  return fakeRepeatedToken(["A", "b", "9", "C"]);
+}
+
+function fakeCommitHash(): string {
+  return `${"0123456789abcdef".repeat(2)}01234567`;
+}
+
+function fakeLowercaseBase36Identifier(): string {
+  return `${"z".repeat(39)}1`;
+}
+
+function fakeFlyTokenWithAwsShapedBody(): string {
+  return `FlyV1 fm123_${fakeAwsSecretAccessKeyWithPadding()}_${"tail".repeat(20)}`;
+}
+
+function fakeCommaDelimitedFlyTokenWithAwsShapedBody(): string {
+  return `FlyV1 fm123_headheadheadheadheadheadheadhead,${fakeAwsSecretAccessKeyWithPadding()},${"tail".repeat(20)}`;
+}
+
+function fakeRepeatedToken(chars: readonly string[], length = 40): string {
+  return Array.from({ length }, (_entry, index) => chars[index % chars.length] ?? "A").join("");
+}
+
+describe("diagnostic support redaction", () => {
+  const tempDir = path.join(os.tmpdir(), "openclaw-support-redaction-test");
+
+  it("redacts numeric private fields in support snapshots and config", () => {
+    const redaction = {
+      env: {
+        HOME: tempDir,
+        OPENCLAW_STATE_DIR: tempDir,
+      },
+      stateDir: tempDir,
+    };
+
+    expect(sanitizeSupportSnapshotValue(15555551212, redaction, "chatId")).toBe("<redacted>");
+    expect(sanitizeSupportSnapshotValue(15555551212, redaction, "messageId")).toBe("<redacted>");
+    expect(sanitizeSupportSnapshotValue(200, redaction, "statusCode")).toBe(200);
+    expect(sanitizeSupportConfigValue(15555551212, redaction, "ownerId")).toBe("<redacted>");
+    expect(sanitizeSupportConfigValue(18789, redaction, "port")).toBe(18789);
+  });
+
+  it("blocks prototype keys and caps support sanitizer width", () => {
+    const redaction = {
+      env: {
+        HOME: tempDir,
+        OPENCLAW_STATE_DIR: tempDir,
+      },
+      stateDir: tempDir,
+    };
+    const wideSnapshot: Record<string, unknown> = {
+      ["__proto__"]: "polluted",
+      constructor: "polluted",
+      prototype: "polluted",
+    };
+    for (let index = 0; index < 1005; index += 1) {
+      wideSnapshot[`field${String(index).padStart(4, "0")}`] = index;
+    }
+
+    const snapshot = sanitizeSupportSnapshotValue(wideSnapshot, redaction) as Record<
+      string,
+      unknown
+    >;
+
+    expect(Object.getPrototypeOf(snapshot)).toBe(null);
+    expect(Object.hasOwn(snapshot, "__proto__")).toBe(false);
+    expect(snapshot.constructor).toBeUndefined();
+    expect(snapshot.prototype).toBeUndefined();
+    expect(snapshot.field0000).toBe(0);
+    expect(snapshot.field0999).toBe(999);
+    expect(snapshot.field1000).toBeUndefined();
+    expect(snapshot["<truncated>"]).toEqual({
+      truncated: true,
+      count: 1008,
+      limit: 1000,
+    });
+
+    const array = sanitizeSupportConfigValue(
+      Array.from({ length: 1005 }, (_entry, index) => ({ name: `item-${index}` })),
+      redaction,
+    ) as Record<string, unknown>;
+
+    expect(Array.isArray(array)).toBe(false);
+    expect((array.items as unknown[]).length).toBe(1000);
+    expect(array.truncated).toBe(true);
+    expect(array.count).toBe(1005);
+    expect(array.limit).toBe(1000);
+  });
+
+  it("redacts support text identifiers without hiding useful URL hosts", () => {
+    const fakeAwsKey = ["ASIA", "IOSFODNN7EXAMPLE"].join("");
+    const fakeAwsSecretKey = fakeAwsSecretAccessKey();
+    const fakeJwt = [
+      "eyJhbGciOiJIUzI1NiIs",
+      "eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4i",
+      "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
+    ].join(".");
+    const jwtWithAwsSecretShapedSegment = [
+      "eyJheaderabcd",
+      fakeJwtAwsSecretShapedSegment(),
+      "signatureabcd123456",
+    ].join(".");
+    const awsShapedDataUrl = `data:application/octet-stream;base64,${Array.from(
+      { length: 40 },
+      (_entry, index) => (["A", "b", "9", "+"] as const)[index % 4] ?? "A",
+    ).join("")}`;
+    const cases = [
+      [
+        "connect wss://support-user:support-password@gateway.example/ws?token=short-token&ok=1",
+        "connect wss://<redacted>:<redacted>@gateway.example/ws?token=<redacted>&ok=1",
+      ],
+      [
+        "connect https://gateway.example/ws?access-token=short-token",
+        "connect https://gateway.example/ws?access-token=<redacted>",
+      ],
+      [
+        "connect https://gateway.example/ws?hook-token=hook-secret",
+        "connect https://gateway.example/ws?hook-token=<redacted>",
+      ],
+      ["connect https://token@gateway.example/ws", "connect https://<redacted>@gateway.example/ws"],
+      ["auth Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==", "auth Basic <redacted>"],
+      ["Cookie: sid=secret; theme=light", "Cookie: <redacted>"],
+      [`aws ${fakeAwsKey}`, "aws <redacted-aws-key>"],
+      [`aws secret ${fakeAwsSecretKey}`, "aws secret <redacted-aws-secret-key>"],
+      [
+        `aws padded secret ${fakeAwsSecretAccessKeyWithPadding()}`,
+        "aws padded secret <redacted-aws-secret-key>",
+      ],
+      [`data ${awsShapedDataUrl}`, `data ${awsShapedDataUrl}`],
+      [`jwt ${fakeJwt}`, "jwt <redacted-jwt>"],
+      [`jwt ${jwtWithAwsSecretShapedSegment}`, "jwt <redacted-jwt>"],
+      [`provider ${fakeFlyTokenWithAwsShapedBody()}`, "provider FlyV1 …tail"],
+      [`provider ${fakeCommaDelimitedFlyTokenWithAwsShapedBody()}`, "provider FlyV1 …tail"],
+      [`commit ${fakeCommitHash()}`, `commit ${fakeCommitHash()}`],
+      [`id ${fakeLowercaseBase36Identifier()}`, `id ${fakeLowercaseBase36Identifier()}`],
+      ["email alice@example.com", "email <redacted-email>"],
+      ["matrix @support-user:matrix.example.com", "matrix <redacted-matrix-user>"],
+      ["room !support-room:matrix.example.com", "room <redacted-matrix-room>"],
+      ["event $F0Zlxky8bavuqH6MK75Av_c7UWFLp550WTQ1EA-F0KM", "event <redacted-matrix-event>"],
+      ["notify @support_bot now", "notify <redacted-handle> now"],
+      ["phone 15555551212", "phone <redacted-id>"],
+      [
+        `config password = ${["support", "password", "1234567890"].join("-")}`,
+        "config password = suppor…7890",
+      ],
+      [
+        ["config password", " = ", '"', ["support", "password", "1234567890"].join("-"), '"'].join(
+          "",
+        ),
+        'config password = "suppor…7890"',
+      ],
+      [
+        `config db_password = ${["support", "password", "1234567890"].join("-")}`,
+        "config db_password = suppor…7890",
+      ],
+      [
+        `config readonly_db_password = ${["support", "password", "1234567890"].join("-")}`,
+        "config readonly_db_password = suppor…7890",
+      ],
+      [
+        `config jdbc.password=${["support", "password", "1234567890"].join("-")}`,
+        "config jdbc.password=suppor…7890",
+      ],
+    ] as const;
+
+    for (const [input, expected] of cases) {
+      expect(redactTextForSupport(input)).toBe(expected);
+    }
+  });
+
+  it("truncates support strings without splitting UTF-16 surrogate pairs", () => {
+    const redaction = {
+      env: {
+        HOME: tempDir,
+        OPENCLAW_STATE_DIR: tempDir,
+      },
+      stateDir: tempDir,
+    };
+    const truncationSuffix = "...<truncated>";
+
+    expect(redactSupportString("abcd😀tail", redaction, { maxLength: 5 })).toBe(
+      `abcd${truncationSuffix}`,
+    );
+
+    const redactedPathPrefix = `$OPENCLAW_STATE_DIR${path.sep}`;
+    expect(
+      redactSupportString(path.join(tempDir, "abcd😀tail"), redaction, {
+        maxLength: redactedPathPrefix.length + 5,
+      }),
+    ).toBe(`${redactedPathPrefix}abcd${truncationSuffix}`);
+  });
+
+  it("redacts Windows USERPROFILE paths when HOME is unset", () => {
+    const userProfile = "C:\\Users\\support-user";
+    const stateDir = `${userProfile}\\AppData\\Roaming\\openclaw`;
+    const redaction = {
+      env: {
+        USERPROFILE: userProfile,
+        OPENCLAW_STATE_DIR: stateDir,
+      },
+      stateDir,
+    };
+
+    expect(redactSupportString(`${stateDir}\\logs\\gateway.log`, redaction)).toBe(
+      "$OPENCLAW_STATE_DIR\\logs\\gateway.log",
+    );
+    expect(
+      redactSupportString(`failed at ${userProfile}\\Documents\\snapshot-error.txt`, redaction),
+    ).toBe("failed at ~\\Documents\\snapshot-error.txt");
+    expect(
+      redactSupportString(
+        "failed at c:\\users\\support-user\\Documents\\snapshot-error.txt",
+        redaction,
+      ),
+    ).toBe("failed at ~\\Documents\\snapshot-error.txt");
+
+    const status = sanitizeSupportSnapshotValue(
+      {
+        service: {
+          command: {
+            programArguments: [
+              "node",
+              `${userProfile}\\openclaw\\dist\\index.js`,
+              "--config",
+              `${stateDir}\\openclaw.json`,
+              `--aws-secret-access-key=${fakeAwsSecretAccessKey()}`,
+              "--awsSecretAccessKey",
+              fakeAwsSecretAccessKey(),
+            ],
+            sourcePath: "c:\\users\\support-user\\AppData\\Local\\openclaw\\gateway-service.json",
+          },
+        },
+      },
+      redaction,
+    );
+    const serialized = JSON.stringify(status);
+    expect(serialized).not.toContain("support-user");
+    expect(serialized).not.toContain(fakeAwsSecretAccessKey());
+    expect(serialized).toContain("~\\\\openclaw\\\\dist\\\\index.js");
+    expect(serialized).toContain("$OPENCLAW_STATE_DIR\\\\openclaw.json");
+    expect(serialized).toContain("--aws-secret-access-key=<redacted>");
+    expect(serialized).toContain("--awsSecretAccessKey");
+    expect(serialized).toContain("~\\\\AppData\\\\Local\\\\openclaw\\\\gateway-service.json");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users collecting `openclaw triage` diagnostics would lose the agent count and see configuration metadata reported as plugins or channels. The saved Tailscale mode was also absent from the summary.

## Why This Change Was Made

The support exporter now reads the current agent and plugin entry maps, uses the shared channel metadata predicate, and derives each count from its emitted entry list. It excludes `$include` directives without expanding files and reads the Tailscale mode from its configuration object. This removes obsolete shape assumptions inside the existing export owner; runtime configuration, activation, and redaction policy are unchanged.

## User Impact

The diagnostics archive accurately describes entries declared in the saved config, including disabled entries. Both `config/shape.json` and `diagnostics.json.config` carry the same summary. Documentation makes the distinction between declarations in this file and the resolved installation explicit.

## Evidence

Before the fix, a real built `triage --json` run with nine agents reported no agent count, plugin IDs `enabled` and `entries`, and channel IDs `defaults` and `modelByChannel`. Legacy and malformed-config controls still produced bounded private handoff prompts and archives, preserving config bytes and creating no state database.

The existing ZIP export regression was updated to the current config shape with modular-config directives, shared channel settings, disabled plugin entries, and Tailscale mode. It fails on the previous implementation. Existing credential, prompt, and malformed-config assertions remain in place.

The rebuilt candidate passed the same real CLI matrix: nine canonical agents, the expected plugin IDs, and zero channels for shared metadata alone. Legacy and malformed rosters remain unreported. All three commands exited 0, preserved config bytes, created no state database, and wrote owner-only prompts.

The export test file reached the lint line limit, so five existing pure redaction tests moved unchanged to their own owner suite, without filesystem setup. Both suites pass all 16 tests.

Validation: 16 export/redaction tests and 24 triage sibling tests passed; full baseline build and final dist-backed CLI build passed; independent P3 review found no actionable findings. The final changed-file gate passed. The earlier file-size lint failure was resolved by moving the existing pure redaction tests; no assertions were removed.

Production LOC: +14/-14 (net 0). Tests: net +61, with 257 existing helper/test lines moved to the redaction suite. Documentation: +2/-0. No configuration options, schema changes, dependencies, or persistent runtime state changes.

Review note: the automated vector/embedding metadata classification is not applicable to this diff. The changed function builds a redacted export artifact from a saved JSON file; it does not write any runtime database or embedding metadata. The real CLI controls preserved config bytes and created no state database.
