### PR TITLE
test: keep transient lifecycle markers out of Git fixtures

### DIFF
--- a/scripts/e2e/lib/package-git-fixture.mjs
+++ b/scripts/e2e/lib/package-git-fixture.mjs
@@ -2,6 +2,7 @@
 // Prepares package-derived Docker E2E fixtures for git-style npm installs.
 import fs from "node:fs";
 import path from "node:path";
+import { PACKAGE_LIFECYCLE_PENDING_RELATIVE_PATH } from "../../lib/package-lifecycle-marker.mjs";
 
 const [command, rootArg] = process.argv.slice(2);
 
@@ -30,7 +31,12 @@ function ensureDependencyIgnores(root) {
   const gitignorePath = path.join(root, ".gitignore");
   const existing = fs.existsSync(gitignorePath) ? fs.readFileSync(gitignorePath, "utf8") : "";
   const lines = new Set(existing.split(/\r?\n/u));
-  const required = ["node_modules", "**/node_modules/", "pnpm-lock.yaml"];
+  const required = [
+    "node_modules",
+    "**/node_modules/",
+    "pnpm-lock.yaml",
+    PACKAGE_LIFECYCLE_PENDING_RELATIVE_PATH,
+  ];
   const missing = required.filter((entry) => !lines.has(entry));
   if (missing.length === 0) {
     return;

--- a/test/scripts/update-channel-switch-fixture.test.ts
+++ b/test/scripts/update-channel-switch-fixture.test.ts
@@ -1,27 +1,25 @@
 import { execFileSync, execSync } from "node:child_process";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { afterEach, expect, it } from "vitest";
-import { runBundledPluginPostinstall } from "../../scripts/postinstall-bundled-plugins.mjs";
+import { writePackageDistInventoryForPublish } from "../../scripts/lib/package-dist-inventory.ts";
+import { PACKAGE_LIFECYCLE_PENDING_RELATIVE_PATH } from "../../scripts/lib/package-lifecycle-marker.mjs";
+import { completePendingPackageLifecycle } from "../../src/infra/package-lifecycle.js";
 import { collectGitRuntimeErrors } from "../../src/infra/update-git-runtime.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-it("builds the package-derived Git fixture with its own checkout identity", async () => {
+it("preserves the package-derived Git fixture identity through build and lifecycle completion", async () => {
   const root = tempDirs.make("update-channel-git-fixture-");
   const packageCommit = "a".repeat(40);
   const runtimeEntry = "export {};\n";
   mkdirSync(join(root, "dist"));
   writeFileSync(
     join(root, "package.json"),
-    JSON.stringify({ name: "openclaw", version: "2026.8.1" }),
+    JSON.stringify({ name: "openclaw", version: "2026.8.1", engines: { node: ">=22.22.3" } }),
   );
   writeFileSync(join(root, "dist/entry.js"), runtimeEntry);
-  writeFileSync(
-    join(root, "dist/postinstall-inventory.json"),
-    JSON.stringify(["dist/entry.js", "dist/build-info.json", "dist/control-ui/index.html"]),
-  );
   writeFileSync(
     join(root, "dist/build-info.json"),
     JSON.stringify({ commit: packageCommit, version: "2026.8.1" }),
@@ -32,6 +30,16 @@ it("builds the package-derived Git fixture with its own checkout identity", asyn
     "prepare-git-fixture",
     root,
   ]);
+  mkdirSync(join(root, "scripts/lib"), { recursive: true });
+  for (const file of [
+    "node-version.mjs",
+    "scripts/preinstall-package-manager-warning.mjs",
+    "scripts/postinstall-bundled-plugins.mjs",
+    "scripts/lib/package-lifecycle-marker.mjs",
+  ]) {
+    copyFileSync(file, join(root, file));
+  }
+  await writePackageDistInventoryForPublish(root);
   const git = (args: string[]) => execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
   git(["init", "-q"]);
   git(["add", "."]);
@@ -51,15 +59,34 @@ it("builds the package-derived Git fixture with its own checkout identity", asyn
     scripts: { build: string };
   };
   const preflight = tempDirs.make("update-channel-preflight-");
+  const home = tempDirs.make("update-channel-lifecycle-home-");
   execFileSync("git", ["clone", "--quiet", root, preflight]);
   for (const checkout of [preflight, root]) {
     expect(await collectGitRuntimeErrors({ root: checkout, sha })).not.toEqual([]);
     execSync(manifest.scripts.build, { cwd: checkout });
-    runBundledPluginPostinstall({
-      packageRoot: checkout,
-      env: { HOME: join(root, "home"), OPENCLAW_STATE_DIR: join(root, "state") },
-    });
     expect(await collectGitRuntimeErrors({ root: checkout, sha })).toEqual([]);
+    writeFileSync(join(checkout, PACKAGE_LIFECYCLE_PENDING_RELATIVE_PATH), "pending\n");
+    expect(
+      await completePendingPackageLifecycle({
+        packageRoot: checkout,
+        runScript: ({ relativePath }) => {
+          execFileSync(process.execPath, [join(checkout, relativePath)], {
+            cwd: checkout,
+            env: {
+              ...process.env,
+              HOME: home,
+              OPENCLAW_HOME: home,
+              OPENCLAW_STATE_DIR: join(home, "state"),
+              OPENCLAW_CONFIG_PATH: join(home, "config.json"),
+              STATE_DIRECTORY: undefined,
+              OPENCLAW_DISABLE_BUNDLED_PLUGIN_POSTINSTALL: undefined,
+            },
+          });
+        },
+      }),
+    ).toBe(true);
+    expect(await collectGitRuntimeErrors({ root: checkout, sha })).toEqual([]);
+    expect(existsSync(join(checkout, PACKAGE_LIFECYCLE_PENDING_RELATIVE_PATH))).toBe(false);
     expect(JSON.parse(readFileSync(join(checkout, "dist/build-info.json"), "utf8"))).toEqual({
       commit: sha,
       version: "2026.8.1",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the package-derived Git checkout used by release verification becomes dirty after successful package lifecycle completion. The package's pending-lifecycle marker was committed into the synthetic checkout; completing the lifecycle deleted that tracked file.

## Why This Change Was Made

Main already preserves the fixture's source-directory identity after #134328. This follow-up retains those anchors exactly and excludes only the canonical transient lifecycle marker from fixture Git inputs. The existing regression now executes the real complete lifecycle, including actual preinstall and postinstall scripts, instead of calling postinstall directly.

No product lifecycle, package pruning, runtime verifier, timeout, or assertion is weakened. Test support changes by +7/-1 and the existing test by +39/-12; product runtime delta is zero.

## User Impact

There is no shipped behavior change. Release tests can complete the real package lifecycle while retaining a clean, correctly identified Git fixture.

## Evidence

- Tests-only reproduction on main `ad8a92aada5867d8e713a239bbeca4cec0975556` failed at the existing clean-Git assertion with `D .openclaw-lifecycle-pending`; the preceding runtime/stamp checks passed.
- The narrowed fix passes 79 tests across five files, with no skips, including actual lifecycle completion in both the original fixture and a fresh Git clone; pending completion, runtime identity, entry-byte preservation, and clean Git state are asserted. Siblings cover published-package pruning, source preservation, lifecycle failure/concurrency/legacy recovery, and npm/pnpm/Bun source activation.
- The canonical two-file changed gate passed with the matching independent dependency installation, including test-root typechecking, script lint, Docker E2E boundaries/catalog, and all remaining guards. Formatting and `git diff --check` also passed.
- Native Docker proof for the earlier frozen `594f5003` package plus the original helper overlay reproduced the missing-stamp failure (exit1,108.799s) and then passed the unchanged complete `update-channel-switch` lane (exit0,159.897s). This is not an exact new-main tree claim. The narrowed producer retains identical marker-ignore and package-preparation logic; its only difference from the earlier candidate is main's source-anchor block. Current-main RED/GREEN separately proves the remaining marker defect. No timing improvement is claimed from a failing-versus-passing run.

The final PR helper at `7c9f213b97466f9cd43213271c1d72d02cfb93f3` also passed the complete native update-channel-switch lane against the sealed `594f5003` package/images: one attempt, canonical scheduler status `passed`, exact Docker exit0, and helper hash verified after execution. This closes the earlier pending final-helper proof. A batch observer was interrupted to suppress an obsolete queued auth experiment; the approved container continued and its exit was recovered by exact container ID, independently of log text. No scenario was retried. This remains final-helper/frozen-package proof, not a new-main package build.

The review's upstream overlap is resolved: the refreshed branch retains main's source anchors exactly and adds only marker hygiene plus the full lifecycle regression. Managed review of this narrowed delta is clean.
