### PR TITLE
fix: keep inactive channel credentials out of inspection

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3152,7 +3152,7 @@ src/infra/outbound/delivery-queue-preparation.ts	1
 src/infra/outbound/delivery-queue-storage.ts	8
 src/infra/outbound/envelope.ts	2
 src/infra/outbound/format.ts	1
-src/infra/outbound/message-account-selection.ts	4
+src/infra/outbound/message-account-selection.ts	2
 src/infra/outbound/message-action-execution.ts	4
 src/infra/outbound/message-action-runner.ts	1
 src/infra/outbound/message-action-send.ts	2

--- a/docs/cli/channels.md
+++ b/docs/cli/channels.md
@@ -202,7 +202,7 @@ Use the same `accountId` in both calls. Omit it from both to select the default 
 - `{ status: "retry", reason }`: an existing task, start, or stop still owns the account (`task-owned`, `start-in-flight`, or `stop-in-flight`). A running account can return `task-owned` with `started: true`; another start was unnecessary. Wait for an in-flight stop to finish before starting again.
 - `{ status: "skipped", reason }`: startup was skipped, for example because the account is `disabled`, `unconfigured`, or `unlinked`. Repair the named account condition before retrying. Other manager reasons are `unsupported`, `autostart-suppressed`, `ambient-suppressed`, `secret-unavailable`, and `manual-stop`; the manual RPC bypasses automatic-start suppression but does not bypass account configuration or secret checks.
 
-An unavailable configured secret still returns an RPC error instead of starting with another credential.
+Accounts explicitly disabled in channel or account configuration are skipped without resolving inactive credentials. An unavailable configured secret on an enabled account still returns an RPC error instead of starting with another credential.
 
 Unlike this recovery path, `openclaw channels logout` clears the account's credentials and requires login again; `openclaw gateway restart` restarts the whole Gateway. See [Restart recovery](/gateway/restart-recovery) for the crash-loop breaker and its manual `channels.start` override.
 

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -928,6 +928,9 @@ unrelated inbound runtime helpers.
     runtime, including duplicate-account suppression. If `configured` is omitted,
     diagnostics use a recorded Gateway value when available; otherwise they report
     that configuration status is unavailable.
+    Selection before secret redemption also reads this metadata directly. Directory
+    auto-selection requires `configured: true`; callers can still select the channel
+    explicitly when configuration status is unknown.
 
     Create `src/channel.ts`:
 

--- a/src/channels/account-config-enabled.ts
+++ b/src/channels/account-config-enabled.ts
@@ -1,0 +1,16 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveAccountEntry } from "../routing/account-lookup.js";
+
+/** Reads an operator's explicit disable without resolving an operational account. */
+export function isChannelAccountExplicitlyDisabled(params: {
+  cfg: OpenClawConfig;
+  channel: string;
+  accountId: string;
+}): boolean {
+  const channel = asOptionalRecord(params.cfg.channels?.[params.channel]);
+  const account = asOptionalRecord(
+    resolveAccountEntry(asOptionalRecord(channel?.accounts), params.accountId),
+  );
+  return channel?.enabled === false || account?.enabled === false;
+}

--- a/src/commands/message.test.ts
+++ b/src/commands/message.test.ts
@@ -294,6 +294,9 @@ describe("messageCommand", () => {
 
   it("scopes unqualified broadcast secrets to channels accepting the explicit account", async () => {
     const slackPlugin = createAccountPlugin("slack", ["shared"]);
+    slackPlugin.config.isEnabled = vi.fn(() => {
+      throw new Error("runtime enablement must not receive inspection metadata");
+    });
     const telegramPlugin = createAccountPlugin("telegram", ["default"]);
     setActivePluginRegistry(
       createTestRegistry([
@@ -329,6 +332,7 @@ describe("messageCommand", () => {
       candidateChannels: ["slack", "telegram"],
       secretChannels: ["slack"],
     });
+    expect(slackPlugin.config.isEnabled).not.toHaveBeenCalled();
   });
 
   it("keeps unresolved SecretRefs for a legacy single-account broadcast plugin", async () => {

--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -43,6 +43,7 @@ import {
   listActiveDegradedSecretOwners,
   setActiveDegradedSecretOwners,
 } from "../secrets/runtime-degraded-state.js";
+import { startChannelHealthMonitor } from "./channel-health-monitor.js";
 import { evaluateChannelHealth } from "./channel-health-policy.js";
 import { channelReadyPatch, createTransportActivityStatusPatch } from "./channel-status-patches.js";
 import { restartRunningChannelAccounts } from "./channel-thaw-restart.js";
@@ -2990,37 +2991,79 @@ describe("server-channels auto restart", () => {
     expect(manager.getRuntimeSnapshot().channelAccounts.discord?.default).toMatchObject(recorded);
   });
 
-  it("inspects disabled accounts without resolving inactive credentials", () => {
-    const resolveAccount = vi.fn(() => {
-      throw new Error("inactive credential must not resolve");
-    });
-    const describeAccount = vi.fn(() => {
-      throw new Error("runtime descriptor must not receive an inspection");
-    });
-    const plugin = createTestPlugin({ resolveAccount, describeAccount });
-    plugin.config.inspectAccount = () => ({
-      enabled: false,
-      configured: true,
-      tokenStatus: "configured_unavailable",
-      name: "Disabled account",
-      mode: "webhook",
+  it("starts enabled accounts without requiring diagnostic inspection", async () => {
+    const startAccount = vi.fn(async () => {});
+    const plugin = createTestPlugin({ startAccount });
+    plugin.config.inspectAccount = vi.fn(() => {
+      throw new Error("diagnostic inspector unavailable");
     });
     installTestRegistry(plugin);
     const manager = createManager();
 
-    expect(manager.getRuntimeSnapshot().channelAccounts.discord?.default).toMatchObject({
-      accountId: "default",
-      name: "Disabled account",
-      mode: "webhook",
-      enabled: false,
-      configured: true,
-      running: false,
-      tokenStatus: "configured_unavailable",
-      stateReason: "disabled",
-    });
-    expect(resolveAccount).not.toHaveBeenCalled();
-    expect(describeAccount).not.toHaveBeenCalled();
+    await expect(manager.startChannel("discord", DEFAULT_ACCOUNT_ID)).resolves.toEqual(
+      new Map([[DEFAULT_ACCOUNT_ID, { status: "handed-off" }]]),
+    );
+    expect(startAccount).toHaveBeenCalledOnce();
+    expect(plugin.config.inspectAccount).not.toHaveBeenCalled();
   });
+
+  it.each(["channel", "account"] as const)(
+    "inspects and skips accounts disabled at %s scope without resolving inactive credentials",
+    async (scope) => {
+      const resolveAccount = vi.fn((_cfg: OpenClawConfig, accountId?: string | null) => {
+        if (accountId === "missing") {
+          throw new Error("unknown account");
+        }
+        throw new Error("inactive credential must not resolve");
+      });
+      const describeAccount = vi.fn(() => {
+        throw new Error("runtime descriptor must not receive an inspection");
+      });
+      const startAccount = vi.fn(async () => {});
+      const plugin = createTestPlugin({ resolveAccount, describeAccount, startAccount });
+      plugin.config.inspectAccount = () => ({
+        enabled: false,
+        configured: true,
+        tokenStatus: "configured_unavailable",
+        name: "Disabled account",
+        mode: "webhook",
+      });
+      installTestRegistry(plugin);
+      const manager = createManager({
+        getRuntimeConfig: () => ({
+          channels: {
+            discord:
+              scope === "channel"
+                ? { enabled: false }
+                : { accounts: { default: { enabled: false } } },
+          },
+        }),
+      });
+
+      expect(manager.getRuntimeSnapshot().channelAccounts.discord?.default).toMatchObject({
+        accountId: "default",
+        name: "Disabled account",
+        mode: "webhook",
+        enabled: false,
+        configured: true,
+        running: false,
+        tokenStatus: "configured_unavailable",
+        stateReason: "disabled",
+      });
+      await expect(
+        manager.startChannel("discord", DEFAULT_ACCOUNT_ID, { manual: true }),
+      ).resolves.toEqual(
+        new Map([[DEFAULT_ACCOUNT_ID, { status: "skipped", reason: "disabled" }]]),
+      );
+      expect(startAccount).not.toHaveBeenCalled();
+      expect(resolveAccount).not.toHaveBeenCalled();
+      expect(describeAccount).not.toHaveBeenCalled();
+      await expect(manager.startChannel("discord", "missing", { manual: true })).rejects.toThrow(
+        "unknown account",
+      );
+      expect(resolveAccount).toHaveBeenCalledExactlyOnceWith(expect.anything(), "missing");
+    },
+  );
 
   it("keeps only the degraded channel account cold", async () => {
     const discordStart = vi.fn(async (_context: ChannelGatewayContext<TestAccount>) => {});
@@ -3605,18 +3648,70 @@ describe("server-channels auto restart", () => {
     expect(manager.isHealthMonitorEnabled("discord", DEFAULT_ACCOUNT_ID)).toBe(false);
   });
 
-  it("fails closed when account resolution throws during health monitor gating", () => {
-    installTestRegistry(
-      createTestPlugin({
-        resolveAccount: () => {
-          throw new Error("unresolved SecretRef");
-        },
-      }),
+  it("monitors a healthy sibling without resolving disabled or blocked credentials", async () => {
+    const resolveAccount = vi.fn((_cfg: OpenClawConfig, accountId?: string | null) => {
+      if (accountId !== "healthy") {
+        throw new Error("unresolved SecretRef");
+      }
+      return { enabled: true, configured: true };
+    });
+    const startAccount = vi.fn(
+      async ({ setStatus, abortSignal }: ChannelGatewayContext<TestAccount>) => {
+        setStatus({
+          accountId: "healthy",
+          running: true,
+          connected: true,
+          lastTransportActivityAt: Date.now(),
+        });
+        await new Promise<void>((resolve) => {
+          abortSignal.addEventListener("abort", () => resolve(), { once: true });
+        });
+      },
     );
-
+    const plugin = createTestPlugin({
+      listAccountIds: () => ["broken", "disabled", "healthy"],
+      resolveAccount,
+      startAccount,
+    });
+    plugin.config.inspectAccount = (_cfg, accountId) => ({
+      enabled: accountId !== "disabled",
+      configured: true,
+    });
+    installTestRegistry(plugin);
+    setActiveDegradedSecretOwners([
+      {
+        ownerKind: "account",
+        ownerId: "discord:broken",
+        state: "unavailable",
+        paths: ["channels.discord.accounts.broken.token"],
+        refKeys: ["env:default:BROKEN_TOKEN"],
+        reason: "secret reference was not found",
+      },
+    ]);
     const manager = createManager();
-
-    expect(manager.isHealthMonitorEnabled("discord", DEFAULT_ACCOUNT_ID)).toBe(false);
+    await manager.startChannel("discord", "healthy");
+    const restart = vi.spyOn(manager, "startChannel");
+    const monitor = startChannelHealthMonitor({
+      channelManager: manager,
+      timing: { monitorStartupGraceMs: 2, channelConnectGraceMs: 0, staleEventThresholdMs: 1 },
+    });
+    try {
+      await vi.advanceTimersByTimeAsync(2);
+      await monitor.waitForIdle();
+      expect(restart).toHaveBeenCalledExactlyOnceWith("discord", "healthy");
+      expect(startAccount).toHaveBeenCalledTimes(2);
+      expect(resolveAccount.mock.calls.map(([, accountId]) => accountId)).toEqual([
+        "healthy",
+        "healthy",
+      ]);
+      expect(manager.getRuntimeSnapshot().channelAccounts.discord).toMatchObject({
+        broken: { enabled: true, configured: true, lifecycle: "blocked", running: false },
+        disabled: { enabled: false, running: false },
+        healthy: { enabled: true, running: true },
+      });
+    } finally {
+      monitor.shutdown();
+    }
   });
 
   it("does not treat an empty account id as the default account when matching raw overrides", () => {

--- a/src/gateway/server-channels.ts
+++ b/src/gateway/server-channels.ts
@@ -1,6 +1,7 @@
 // Gateway channel manager.
 // Starts, stops, restarts, and snapshots plugin channel account runtimes.
 import { RetrySupervisor } from "../../packages/retry/src/index.js";
+import { isChannelAccountExplicitlyDisabled } from "../channels/account-config-enabled.js";
 import { getCredentialUnavailableDiagnostics } from "../channels/account-snapshot-fields.js";
 import { buildChannelAccountSnapshotFromInspection } from "../channels/account-summary.js";
 import { isChannelIngressUnavailableError } from "../channels/message/ingress-unavailable.js";
@@ -378,22 +379,6 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
       return channelOverride;
     }
 
-    const registration = resolveChannelPluginRegistration(channelId);
-    const plugin = registration?.plugin;
-    if (!plugin) {
-      return true;
-    }
-    try {
-      // Probe only: health-monitor config is read directly from raw channel config above.
-      // This call exists solely to fail closed if resolver-side config loading is broken.
-      plugin.config.resolveAccount(cfg, accountId);
-    } catch (err) {
-      ensureChannelLog(channelId).warn?.(
-        `[${channelId}:${accountId}] health-monitor: failed to resolve account; skipping monitor (${formatErrorMessage(err)})`,
-      );
-      return false;
-    }
-
     return true;
   };
 
@@ -665,12 +650,32 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             log.error?.(`[${id}] ${label}: ${formatErrorMessage(error)}`);
           }
         };
+        const skipDisabledAccount = () => {
+          setRuntime(channelId, id, {
+            accountId: id,
+            enabled: false,
+            running: false,
+            restartPending: false,
+          });
+          startOutcomes.set(id, { status: "skipped", reason: "disabled" });
+        };
 
         try {
-          // Reject the account before plugin resolution so an explicit failed SecretRef cannot
+          // Reject active accounts before plugin resolution so an explicit failed SecretRef cannot
           // drift into a channel-specific environment or file fallback.
           const secretOwnerId = `${channelId}:${normalizeAccountId(id)}`;
           clearActiveCredentialDegradedOwner("account", secretOwnerId);
+          // Explicitly disabled accounts need no credentials. Unlisted requests still go
+          // through the plugin resolver so a disable cannot hide account-selection errors.
+          if (
+            isChannelAccountExplicitlyDisabled({ cfg, channel: channelId, accountId: id }) &&
+            plugin.config
+              .listAccountIds(cfg)
+              .some((listed) => normalizeAccountId(listed) === normalizeAccountId(id))
+          ) {
+            skipDisabledAccount();
+            return;
+          }
           try {
             assertSecretOwnerAvailable("account", secretOwnerId);
           } catch (error) {
@@ -692,13 +697,7 @@ export function createChannelManager(opts: ChannelManagerOptions): ChannelManage
             ? plugin.config.isEnabled(account, cfg)
             : isAccountEnabled(account);
           if (!enabled) {
-            setRuntime(channelId, id, {
-              accountId: id,
-              enabled: false,
-              running: false,
-              restartPending: false,
-            });
-            startOutcomes.set(id, { status: "skipped", reason: "disabled" });
+            skipDisabledAccount();
             return;
           }
 

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -339,7 +339,7 @@ describe("resolveMessageChannelSelection", () => {
       resolve: () => {
         throw new Error("unresolved SecretRef");
       },
-      configured: () => false,
+      configured: (): boolean => false,
       expected: true,
       inspectCalls: ["default"],
       resolveCalls: 0,
@@ -355,7 +355,7 @@ describe("resolveMessageChannelSelection", () => {
       enabled: () => {
         throw new Error("runtime enablement must not receive inspection metadata");
       },
-      configured: () => true,
+      configured: (): boolean => true,
       expected: true,
       inspectCalls: ["default"],
       resolveCalls: 0,
@@ -368,7 +368,7 @@ describe("resolveMessageChannelSelection", () => {
       resolve: () => {
         throw new Error("strict resolution must not run");
       },
-      configured: () => true,
+      configured: (): boolean => true,
       expected: false,
       inspectCalls: ["default"],
       resolveCalls: 0,

--- a/src/infra/outbound/channel-selection.test.ts
+++ b/src/infra/outbound/channel-selection.test.ts
@@ -345,6 +345,35 @@ describe("resolveMessageChannelSelection", () => {
       resolveCalls: 0,
     },
     {
+      name: "defaults omitted inspection enablement without calling runtime hooks",
+      accountResolution: "read_only" as const,
+      accountIds: ["default"],
+      inspect: () => ({ configured: true }),
+      resolve: () => {
+        throw new Error("strict resolution must not run");
+      },
+      enabled: () => {
+        throw new Error("runtime enablement must not receive inspection metadata");
+      },
+      configured: () => true,
+      expected: true,
+      inspectCalls: ["default"],
+      resolveCalls: 0,
+    },
+    {
+      name: "keeps omitted inspection configuration unknown without calling runtime hooks",
+      accountResolution: "read_only" as const,
+      accountIds: ["default"],
+      inspect: () => ({ enabled: true }),
+      resolve: () => {
+        throw new Error("strict resolution must not run");
+      },
+      configured: () => true,
+      expected: false,
+      inspectCalls: ["default"],
+      resolveCalls: 0,
+    },
+    {
       name: "keeps strict selection on runtime account callbacks",
       accountResolution: undefined,
       accountIds: ["default"],
@@ -426,7 +455,8 @@ describe("resolveMessageChannelSelection", () => {
       accountIds: scenario.accountIds,
       inspectAccount,
       resolveAccount,
-      isEnabled: (account) => (account as { enabled?: boolean }).enabled !== false,
+      isEnabled:
+        scenario.enabled ?? ((account) => (account as { enabled?: boolean }).enabled !== false),
       isConfigured,
     });
     mocks.listChannelPlugins.mockReturnValue([plugin]);
@@ -450,6 +480,9 @@ describe("resolveMessageChannelSelection", () => {
       scenario.inspectCalls,
     );
     expect(resolveAccount).toHaveBeenCalledTimes(scenario.resolveCalls);
+    if (scenario.accountResolution === "read_only" && scenario.inspect) {
+      expect(isConfigured).not.toHaveBeenCalled();
+    }
   });
 
   it("allows bootstrap while checking explicit and fallback channels", async () => {

--- a/src/infra/outbound/channel-selection.ts
+++ b/src/infra/outbound/channel-selection.ts
@@ -12,7 +12,6 @@ import {
 } from "../../plugins/official-external-plugin-repair-hints.js";
 import { defaultRuntime } from "../../runtime.js";
 import { isAccountEnabled } from "../../shared/account-enabled.js";
-import { asBoolean } from "../../utils/boolean.js";
 import {
   isDeliverableMessageChannel,
   normalizeMessageChannel,
@@ -144,16 +143,20 @@ async function isPluginConfigured(
   const accountIds = plugin.config.listAccountIds(cfg);
   for (const accountId of accountIds) {
     let operation: "inspectAccount" | "resolveAccount" = "inspectAccount";
-    let inspection: Record<string, unknown> | undefined;
     let account: unknown;
     try {
-      inspection = asOptionalRecord(
-        accountResolution === "read_only"
-          ? await plugin.config.inspectAccount?.(cfg, accountId)
-          : undefined,
-      );
+      if (accountResolution === "read_only") {
+        const inspection = asOptionalRecord(await plugin.config.inspectAccount?.(cfg, accountId));
+        if (inspection) {
+          // Inspection is metadata, never input to runtime account hooks.
+          if (isAccountEnabled(inspection) && inspection.configured === true) {
+            return true;
+          }
+          continue;
+        }
+      }
       operation = "resolveAccount";
-      account = inspection ?? plugin.config.resolveAccount(cfg, accountId);
+      account = plugin.config.resolveAccount(cfg, accountId);
     } catch (error) {
       logChannelSelectionError({
         pluginId: plugin.id,
@@ -163,17 +166,14 @@ async function isPluginConfigured(
       });
       continue;
     }
-    const enabled =
-      asBoolean(inspection?.enabled) ??
-      (plugin.config.isEnabled ? plugin.config.isEnabled(account, cfg) : isAccountEnabled(account));
+    const enabled = plugin.config.isEnabled
+      ? plugin.config.isEnabled(account, cfg)
+      : isAccountEnabled(account);
     if (!enabled) {
       continue;
     }
     try {
-      const configured =
-        asBoolean(inspection?.configured) ??
-        (await plugin.config.isConfigured?.(account, cfg)) ??
-        true;
+      const configured = (await plugin.config.isConfigured?.(account, cfg)) ?? true;
       if (configured) {
         return true;
       }

--- a/src/infra/outbound/message-account-selection.ts
+++ b/src/infra/outbound/message-account-selection.ts
@@ -1,4 +1,5 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { isChannelAccountExplicitlyDisabled } from "../../channels/account-config-enabled.js";
 import { resolveChannelAccountEnabled } from "../../channels/account-summary.js";
 import { resolveChannelDefaultAccountId } from "../../channels/plugins/helpers.js";
 import { getChannelPlugin } from "../../channels/plugins/index.js";
@@ -6,8 +7,8 @@ import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import type { ChannelId } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { normalizeOptionalAccountId } from "../../routing/account-id.js";
-import { resolveAccountEntry } from "../../routing/account-lookup.js";
 import { assertSecretOwnerAvailable } from "../../secrets/runtime-degraded-state.js";
+import { isAccountEnabled } from "../../shared/account-enabled.js";
 import { isDeliverableMessageChannel } from "../../utils/message-channel.js";
 import { resolveOutboundChannelPlugin } from "./channel-resolution.js";
 import { isConfiguredChannel } from "./channel-selection.js";
@@ -38,27 +39,6 @@ function resolveListedAccountId(params: {
   return normalizeOptionalAccountId(defaultAccountId) === params.accountId
     ? defaultAccountId
     : undefined;
-}
-
-function isExplicitAccountDisabled(params: {
-  cfg: OpenClawConfig;
-  channel: string;
-  listedAccountId: string;
-}): boolean {
-  const channelConfig = (params.cfg.channels as Record<string, unknown> | undefined)?.[
-    params.channel
-  ];
-  if (!channelConfig || typeof channelConfig !== "object" || Array.isArray(channelConfig)) {
-    return false;
-  }
-  const channelRecord = channelConfig as {
-    enabled?: unknown;
-    accounts?: Record<string, { enabled?: unknown }>;
-  };
-  if (channelRecord.enabled === false) {
-    return true;
-  }
-  return resolveAccountEntry(channelRecord.accounts, params.listedAccountId)?.enabled === false;
 }
 
 /**
@@ -106,7 +86,13 @@ export function validateExplicitMessageAccountSelection(params: {
       "message-account:known",
     );
   }
-  if (isExplicitAccountDisabled({ cfg: params.cfg, channel: plugin.id, listedAccountId })) {
+  if (
+    isChannelAccountExplicitlyDisabled({
+      cfg: params.cfg,
+      channel: plugin.id,
+      accountId: listedAccountId,
+    })
+  ) {
     throw new MessageActionDeniedError(
       `Account "${listedAccountId}" for channel ${channel} is disabled.`,
       "message_account_disabled",
@@ -190,20 +176,14 @@ export function resolveMessageBroadcastAccountPlan(params: {
       });
       // Prefer the SecretRef-safe metadata view. Legacy plugins without it keep
       // their existing resolver contract; a resolver that cannot read refs fails closed.
-      const accountForEnablement =
-        plugin.config.inspectAccount?.(params.cfg, accountId) ??
-        plugin.config.resolveAccount(params.cfg, accountId);
-      if (
-        accountForEnablement === undefined ||
-        !resolveChannelAccountEnabled({
-          plugin,
-          account: accountForEnablement,
-          cfg: params.cfg,
-        })
-      ) {
-        throw new Error(`Account "${accountId}" for channel ${plugin.id} is disabled.`);
-      }
-      return [plugin.id];
+      const inspection = plugin.config.inspectAccount?.(params.cfg, accountId);
+      const account = inspection ?? plugin.config.resolveAccount(params.cfg, accountId);
+      const enabled =
+        account !== undefined &&
+        (inspection != null
+          ? isAccountEnabled(inspection)
+          : resolveChannelAccountEnabled({ plugin, account, cfg: params.cfg }));
+      return enabled ? [plugin.id] : [];
     } catch {
       return [];
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where directory auto-selection and unscoped broadcasts could pass diagnostic account metadata to runtime hooks, incorrectly reporting no available channel or skipping the account's secret resolution. Explicitly disabled accounts with missing credentials could also fail a manual channel start instead of returning the documented disabled outcome.

## Why This Change Was Made

Selection before secret redemption now consumes inspection metadata directly: omitted enablement uses the existing enabled default, while omitted configuration remains unknown. Actual operational resolution and runtime hooks remain on the strict path. Channel startup and explicit message selection share the existing raw configuration disable predicate, so inactive credentials need not be resolved and enabled startup does not depend on a diagnostic hook.

The health monitor no longer performs a discarded operational account resolution after reading its configuration. Its recorded lifecycle snapshot and existing health policy already keep disabled or blocked accounts cold; actual restarts still use strict account resolution. The old duplicate probe and local disable predicate are removed.

## User Impact

Disabled channel/account configuration produces a recorded disabled skip. Enabled missing credentials still reject startup, unknown account requests retain their resolver errors, and healthy sibling accounts can recover independently. Directory auto-selection requires known configured metadata; explicit channel selection remains available when that metadata is unknown. The CLI and plugin documentation describe these boundaries.

## Evidence

The regressions failed on the previous code: inspection-only broadcast/directory selection, disabled-account startup, and a real manager/health-monitor sibling recovery scenario. An intermediate implementation also exposed a new diagnostic dependency during review; a synthetic plugin with a throwing inspector and working operational resolver/start now starts successfully, with zero inspector calls, on both the original and final code.

Final focused validation passed 237 tests across seven files, including real WebSocket channel-start outcomes and real manager/monitor lifecycle tests. The QA runtime build and independent P3 review passed. The actual built Gateway passed missing-secret, disabled-account, and resolved-secret variants: liveness, served UI, health/status/channel CLI, and dashboard handoff remained usable. Missing enabled credentials made readiness accurately degraded while a healthy sibling stayed running; disabled credentials returned a recorded skip. A real three-crash breaker replay passed manual-start ownership/skip/error outcomes and dashboard access. The earlier baseline resolved/breaker dashboard commands hit the unchanged 45-second harness bound; every final variant passed under that same bound. Actual built CLI directory selection also passed. The changed-file gate found contextual return-type inference in three test table callbacks; explicit boolean annotations fixed the owning infra typecheck and all 33 table tests passed again. The complete changed-file gate then passed. Production bytes are unchanged from the actual Gateway proof.

Production LOC: +71/-76, net -5, including the shared 16-line helper. Tests: +169/-37, net +132. Documentation: net +3; assertion baseline shrinks two removed casts. No options, dependency changes, schema changes, or new persistence semantics.

Provenance: the metadata/runtime mixing and discarded monitor resolver probe are present in v2026.8.1; the introducing commit is unverified at the local shallow history boundary.

Remaining limits and follow-ups: this does not claim an actual Twilio send. The regular-plugin fixture reached the same bundled SMS pre-dispatch rejection for both explicit and repaired unscoped broadcast, so it proves secret selection but not delivery. The prepared-plugin/action-dispatch boundary needs a separate investigation; this is not evidence of a general external-plugin delivery regression. Strict runtime channel enumeration also still logs resolver failures for disabled/cold accounts; the repaired inspection path and Gateway status/start outcomes are verified separately.
