### PR TITLE
refactor: reuse plugin model policies during Gateway requests

### DIFF
--- a/docs/plugins/architecture.md
+++ b/docs/plugins/architecture.md
@@ -144,6 +144,8 @@ Plugin-aware config validation, startup auto-enable, and Gateway plugin bootstra
 
 After startup, runtime readers reuse that inventory without filesystem discovery, manifest rereads, or freshness checks. Narrow plugin selections are in-memory views of the same inventory. Changing config, account state, or an agent's run workspace does not invalidate it. Plugin installs, updates, removals, manifest edits, and discovery-root changes become visible to the runtime after a Gateway restart.
 
+Model-id normalization policies are prepared with each snapshot or narrowed view. Model selection, catalogs, and runtime normalization carry that view forward instead of rebuilding policies from its plugin list. An empty view remains authoritative and cannot inherit policies from a broader process snapshot.
+
 The snapshot and lookup table keep repeated startup decisions on the fast path:
 
 - channel ownership

--- a/packages/model-catalog-core/src/provider-model-id-normalization.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.ts
@@ -44,19 +44,10 @@ export function collectManifestModelIdNormalizationPolicies(
 }
 
 /** Replace the process-local manifest normalization policy snapshot. */
-export function setCurrentManifestModelIdNormalizationRecords(
-  plugins: readonly ManifestModelIdNormalizationRecord[] | undefined,
+export function setCurrentManifestModelIdNormalizationPolicies(
+  policies: ReadonlyMap<string, ManifestModelIdNormalizationProvider> | undefined,
 ): void {
-  currentManifestModelIdNormalizationPolicies = plugins
-    ? collectManifestModelIdNormalizationPolicies(plugins)
-    : undefined;
-}
-
-/** Return the current process-local manifest normalization policy snapshot. */
-function getCurrentManifestModelIdNormalizationPolicies():
-  | ReadonlyMap<string, ManifestModelIdNormalizationProvider>
-  | undefined {
-  return currentManifestModelIdNormalizationPolicies;
+  currentManifestModelIdNormalizationPolicies = policies;
 }
 
 /** Return true when a model id already includes a provider namespace. */
@@ -215,7 +206,7 @@ export function normalizeStaticProviderModelIdWithPolicies(
 export function normalizeConfiguredProviderCatalogModelId(
   provider: string,
   model: string,
-  policies = getCurrentManifestModelIdNormalizationPolicies(),
+  policies = currentManifestModelIdNormalizationPolicies,
 ): string {
   const providerModel = normalizeStaticProviderModelIdWithPolicies(provider, model, policies);
   return normalizeConfiguredProviderCatalogModelRef(providerModel);

--- a/src/agents/agent-command.compaction-rotation.test.ts
+++ b/src/agents/agent-command.compaction-rotation.test.ts
@@ -2,6 +2,7 @@
 import { describe, expect, it } from "vitest";
 import type { InternalSessionEntry, SessionEntry } from "../config/sessions.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import {
   agentCommand,
   agentCommandFromGatewayIngress,
@@ -385,7 +386,10 @@ describe("agentCommand compaction transcript rotation", () => {
     const sessionKey = `agent:main:explicit:${sessionId}`;
     const text = "cli reply generated before compaction";
     const pluginGeneration = {
-      pluginMetadataSnapshot: { workspaceDir: state.workspaceDir },
+      pluginMetadataSnapshot: {
+        ...createPluginMetadataSnapshotFixture(),
+        workspaceDir: state.workspaceDir,
+      },
     } as never;
     let storedEntryBeforeCompaction: SessionEntry | undefined;
     state.runAgentAttemptMock.mockResolvedValueOnce(makeResult({ sessionId, text, runner: "cli" }));

--- a/src/agents/agent-command.compaction.test-support.ts
+++ b/src/agents/agent-command.compaction.test-support.ts
@@ -73,11 +73,14 @@ vi.mock("./agent-runtime-config.js", () => ({
   resolveAgentRuntimeConfig: async () => compactionTestState.cfg,
 }));
 
-vi.mock("../plugins/plugin-metadata-snapshot.js", async () => {
+vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => {
+  const { rebasePluginMetadataSnapshotManifestRegistry } =
+    await importOriginal<typeof import("../plugins/plugin-metadata-snapshot.js")>();
   const { createPluginMetadataSnapshot } =
     await import("../config/plugin-auto-enable.test-helpers.js");
   return {
     isPluginMetadataSnapshotCompatible: () => false,
+    rebasePluginMetadataSnapshotManifestRegistry,
     resolvePluginMetadataSnapshot: () =>
       createPluginMetadataSnapshot({ manifestRegistry: { plugins: [], diagnostics: [] } }),
   };

--- a/src/agents/agent-command.live-model-switch.test.ts
+++ b/src/agents/agent-command.live-model-switch.test.ts
@@ -15,6 +15,7 @@ import {
   runExclusiveSqliteSessionWrite,
 } from "../config/sessions/session-accessor.sqlite-scope.js";
 import { withInstallationTarget } from "../infra/installation-target-context.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import {
   createUserTurnTranscriptRecorder,
   type UserTurnTranscriptRecorder,
@@ -134,7 +135,6 @@ const state = vi.hoisted(() => ({
   resolveSupportedThinkingLevelMock: vi.fn(({ level }: { level?: string }) => level),
   resolveThinkingDefaultMock: vi.fn((_args: unknown) => "low"),
   loadManifestModelCatalogMock: vi.fn((): ModelCatalogSnapshot["entries"] => []),
-  manifestMetadataSnapshot: { plugins: [] },
   resolvePluginMetadataSnapshotMock: vi.fn(),
   listSkillCommandsForWorkspaceMock: vi.fn((_params: unknown) => []),
   loadProviderScopedThinkingCatalogMock: vi.fn(
@@ -165,6 +165,8 @@ const state = vi.hoisted(() => ({
   trajectoryRecorderParamsMock: vi.fn(),
   enqueueExecutionIdentityContextAtAdmissionMock: vi.fn(),
 }));
+
+const manifestMetadataSnapshot = createPluginMetadataSnapshotFixture();
 
 vi.mock("../sessions/session-diff-baseline.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../sessions/session-diff-baseline.js")>();
@@ -407,11 +409,16 @@ vi.mock("./agent-runtime-config.js", () => {
   };
 });
 
-vi.mock("../plugins/plugin-metadata-snapshot.js", () => ({
-  isPluginMetadataSnapshotCompatible: () => false,
-  resolvePluginMetadataSnapshot: (...args: unknown[]) =>
-    state.resolvePluginMetadataSnapshotMock(...args),
-}));
+vi.mock("../plugins/plugin-metadata-snapshot.js", async (importOriginal) => {
+  const { rebasePluginMetadataSnapshotManifestRegistry } =
+    await importOriginal<typeof import("../plugins/plugin-metadata-snapshot.js")>();
+  return {
+    isPluginMetadataSnapshotCompatible: () => false,
+    rebasePluginMetadataSnapshotManifestRegistry,
+    resolvePluginMetadataSnapshot: (...args: unknown[]) =>
+      state.resolvePluginMetadataSnapshotMock(...args),
+  };
+});
 
 vi.mock("../skills/discovery/chat-commands.runtime.js", () => ({
   expandExplicitSkillReferences: ({ text }: { text: string }) => ({ body: text, skills: [] }),
@@ -1022,7 +1029,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     state.resolveThinkingDefaultMock.mockReturnValue("low");
     state.resolveAgentSkillsFilterMock.mockReturnValue(undefined);
     state.loadManifestModelCatalogMock.mockReturnValue([]);
-    state.resolvePluginMetadataSnapshotMock.mockReturnValue(state.manifestMetadataSnapshot);
+    state.resolvePluginMetadataSnapshotMock.mockReturnValue(manifestMetadataSnapshot);
     state.loadProviderScopedThinkingCatalogMock.mockReset().mockResolvedValue(undefined);
     state.loadFullModelCatalogMock.mockClear();
     state.loadPreparedModelCatalogSnapshotMock.mockResolvedValue({
@@ -1207,7 +1214,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
 
   it("uses Gateway command metadata without resolving the agent workspace", async () => {
     const pluginGeneration = {
-      pluginMetadataSnapshot: state.manifestMetadataSnapshot,
+      pluginMetadataSnapshot: manifestMetadataSnapshot,
     } as never;
 
     const prepared = await prepareAgentCommandExecution(
@@ -1216,10 +1223,10 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
       { config: {}, pluginGeneration },
     );
 
-    expect(prepared.manifestMetadataSnapshot).toBe(state.manifestMetadataSnapshot);
+    expect(prepared.manifestMetadataSnapshot).toBe(manifestMetadataSnapshot);
     expect(prepared.commandRuntimeContext?.pluginGeneration).toBe(pluginGeneration);
     expect(state.listSkillCommandsForWorkspaceMock).toHaveBeenCalledWith(
-      expect.objectContaining({ pluginMetadataSnapshot: state.manifestMetadataSnapshot }),
+      expect.objectContaining({ pluginMetadataSnapshot: manifestMetadataSnapshot }),
     );
     expect(state.resolvePluginMetadataSnapshotMock).not.toHaveBeenCalled();
   });
@@ -4177,7 +4184,7 @@ describe("agentCommand – LiveSessionModelSwitchError retry", () => {
     if (allowlisted) {
       expect(state.loadManifestModelCatalogMock).toHaveBeenCalledTimes(1);
       expect(state.loadManifestModelCatalogMock).toHaveBeenCalledWith(
-        expect.objectContaining({ metadataSnapshot: state.manifestMetadataSnapshot }),
+        expect.objectContaining({ metadataSnapshot: manifestMetadataSnapshot }),
       );
     }
     const thinkingArgs = requireRecord(

--- a/src/agents/ai-transport-runtime-host.test.ts
+++ b/src/agents/ai-transport-runtime-host.test.ts
@@ -21,6 +21,7 @@ function buildOwners(): PluginMetadataSnapshotOwnerMaps {
     setupProviders: empty,
     commandAliases: empty,
     contracts: empty,
+    modelIdNormalizationPolicies: new Map(),
     providerEndpoints: [
       { endpointClass: "openai-public", hosts: ["prepared.example"] },
       { endpointClass: "anthropic-public", hosts: ["projected.example"] },

--- a/src/agents/command/prepare.ts
+++ b/src/agents/command/prepare.ts
@@ -278,7 +278,7 @@ export async function prepareAgentCommandExecution(
       resolvePluginMetadataSnapshot({ config: cfg, env: process.env, workspaceDir }))
     : undefined;
   const modelManifestContext = {
-    manifestPlugins: manifestMetadataSnapshot?.plugins ?? [],
+    manifestPlugins: manifestMetadataSnapshot ?? [],
   } satisfies ModelManifestNormalizationContext;
   const configuredModel = resolveConfiguredModelRef({
     cfg,

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -432,6 +432,7 @@ const emptyPluginMetadataSnapshot: PluginMetadataSnapshot = {
     setupProviders: new Map(),
     commandAliases: new Map(),
     contracts: new Map(),
+    modelIdNormalizationPolicies: new Map(),
   },
   metrics: {
     registrySnapshotMs: 0,

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -12,7 +12,7 @@ import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js"
 import { createReplyOperation } from "../../auto-reply/reply/reply-run-registry.js";
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import type { ContextEngine } from "../../context-engine/types.js";
-import type { PluginManifestRecord } from "../../plugins/manifest-registry.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../state/openclaw-agent-db.js";
 import {
   createAssistant,
@@ -1551,24 +1551,23 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
   it("keeps manifest-profiled plugin tools executable during compaction", async () => {
     const toolName = "profiled_plugin_tool";
     const metadataSnapshot = {
-      ...getCurrentPluginMetadataSnapshotMock(),
+      ...createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "profiled-plugin",
+            origin: "workspace",
+            rootDir: join(TEST_WORKSPACE_DIR, "workspace/profiled-plugin"),
+            source: join(TEST_WORKSPACE_DIR, "workspace/profiled-plugin/index.js"),
+            manifestPath: join(
+              TEST_WORKSPACE_DIR,
+              "workspace/profiled-plugin/openclaw.plugin.json",
+            ),
+            contracts: { tools: [toolName] },
+            toolMetadata: { [toolName]: { profiles: ["coding"] } },
+          },
+        ],
+      }),
       workspaceDir: join(TEST_WORKSPACE_DIR, "workspace"),
-      plugins: [
-        {
-          id: "profiled-plugin",
-          channels: [],
-          providers: [],
-          cliBackends: [],
-          skills: [],
-          hooks: [],
-          origin: "workspace",
-          rootDir: join(TEST_WORKSPACE_DIR, "workspace/profiled-plugin"),
-          source: join(TEST_WORKSPACE_DIR, "workspace/profiled-plugin/index.js"),
-          manifestPath: join(TEST_WORKSPACE_DIR, "workspace/profiled-plugin/openclaw.plugin.json"),
-          contracts: { tools: [toolName] },
-          toolMetadata: { [toolName]: { profiles: ["coding"] } },
-        } satisfies PluginManifestRecord,
-      ],
     };
     const preparedModelRuntime = {
       agentId: "main",
@@ -2075,38 +2074,30 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
   });
 
   it("plans direct compaction from the requested workspace metadata without ambient discovery", async () => {
-    const baseMetadataSnapshot = expectDefined(
-      getCurrentPluginMetadataSnapshotMock(),
-      "default plugin metadata snapshot",
-    );
-    getCurrentPluginMetadataSnapshotMock.mockImplementation((params) =>
-      params?.workspaceDir === TEST_WORKSPACE_DIR
-        ? {
-            ...baseMetadataSnapshot,
-            configFingerprint: "workspace-compaction-normalization",
-            plugins: [
-              {
-                id: "compaction-normalizer",
-                channels: [],
-                providers: ["anthropic"],
-                cliBackends: [],
-                skills: [],
-                hooks: [],
-                origin: "workspace",
-                rootDir: TEST_WORKSPACE_DIR,
-                source: `${TEST_WORKSPACE_DIR}/index.js`,
-                manifestPath: `${TEST_WORKSPACE_DIR}/openclaw.plugin.json`,
-                modelIdNormalization: {
-                  providers: {
-                    anthropic: {
-                      aliases: { legacy: "claude-modern" },
-                    },
-                  },
+    const metadataSnapshot = {
+      ...createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "compaction-normalizer",
+            providers: ["anthropic"],
+            origin: "workspace",
+            rootDir: TEST_WORKSPACE_DIR,
+            source: `${TEST_WORKSPACE_DIR}/index.js`,
+            manifestPath: `${TEST_WORKSPACE_DIR}/openclaw.plugin.json`,
+            modelIdNormalization: {
+              providers: {
+                anthropic: {
+                  aliases: { legacy: "claude-modern" },
                 },
-              } satisfies PluginManifestRecord,
-            ],
-          }
-        : undefined,
+              },
+            },
+          },
+        ],
+      }),
+      configFingerprint: "workspace-compaction-normalization",
+    };
+    getCurrentPluginMetadataSnapshotMock.mockImplementation((params) =>
+      params?.workspaceDir === TEST_WORKSPACE_DIR ? metadataSnapshot : undefined,
     );
 
     const result = await compactEmbeddedAgentSessionDirect({

--- a/src/agents/embedded-agent-runner/compact.ts
+++ b/src/agents/embedded-agent-runner/compact.ts
@@ -323,7 +323,7 @@ export async function compactEmbeddedAgentSessionDirect(
   const pluginPlanCandidates = resolveModelCandidateChain({
     cfg: requestedParams.config,
     agentId: requestedAgentIds.sessionAgentId,
-    manifestPlugins: currentPluginMetadataSnapshot?.plugins ?? [],
+    manifestPlugins: currentPluginMetadataSnapshot ?? [],
     provider: pluginPlanCompactionTarget.provider ?? DEFAULT_PROVIDER,
     model: pluginPlanCompactionTarget.model ?? DEFAULT_MODEL,
     requestedRouteResolution: "resolved",
@@ -432,7 +432,7 @@ export async function compactEmbeddedAgentSessionDirect(
       const resolvedPrimaryCandidate = resolveModelCandidateChain({
         cfg: params.config,
         agentId: fallbackAgentId,
-        manifestPlugins: preparedModelRuntime.metadataSnapshot.plugins,
+        manifestPlugins: preparedModelRuntime.metadataSnapshot,
         provider: primaryProvider,
         model: primaryModel,
         requestedRouteResolution: "resolved",
@@ -441,7 +441,7 @@ export async function compactEmbeddedAgentSessionDirect(
       const fallbackSessionKey = params.sandboxSessionKey ?? params.sessionKey ?? params.sessionId;
       const fallbackResult = await runWithModelFallback<EmbeddedAgentCompactResult>({
         cfg: params.config,
-        manifestPlugins: preparedModelRuntime.metadataSnapshot.plugins,
+        manifestPlugins: preparedModelRuntime.metadataSnapshot,
         provider: primaryProvider,
         model: primaryModel,
         requestedRouteResolution: "resolved",

--- a/src/agents/embedded-agent-runner/model.static-catalog.snapshot-cache.test.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.snapshot-cache.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PluginManifestRecord } from "../../plugins/manifest-registry.types.js";
 import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
-import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 
 const manifestMocks = vi.hoisted(() => ({
   getGatewayPluginMetadataSnapshot: vi.fn(),
@@ -86,15 +87,13 @@ function createMistralManifestPlugin() {
       },
       discovery: { mistral: "static" },
     },
-  };
+  } satisfies Partial<PluginManifestRecord>;
 }
 
-function setCurrentManifestPlugins(plugins: unknown[]) {
-  const snapshot = {
-    plugins,
-    manifestRegistry: { plugins },
-    owners: { providerEndpoints: [], providerRequests: new Map() },
-  };
+function setCurrentManifestPlugins(
+  plugins: Array<Partial<PluginManifestRecord> & Pick<PluginManifestRecord, "id">>,
+) {
+  const snapshot = createPluginMetadataSnapshotFixture({ plugins });
   manifestMocks.getCurrentPluginMetadataSnapshot.mockReturnValue(snapshot);
   return snapshot;
 }
@@ -204,10 +203,9 @@ describe("bundled static model catalog snapshot cache", () => {
         },
       },
     };
-    const capturedSnapshot = {
+    const capturedSnapshot = createPluginMetadataSnapshotFixture({
       plugins: [capturedPlugin],
-      manifestRegistry: { plugins: [capturedPlugin] },
-    } as unknown as PluginMetadataSnapshot;
+    });
     const resolveModel = createBundledStaticCatalogModelResolver({
       cfg,
       metadataSnapshot: capturedSnapshot,

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -280,7 +280,7 @@ export function createBundledStaticCatalogModelResolver(params?: {
     workspaceDir: params?.workspaceDir,
   };
   const matchesStaticModelId = params?.metadataSnapshot
-    ? createStaticModelIdMatcher({ manifestPlugins: params.metadataSnapshot.plugins })
+    ? createStaticModelIdMatcher({ manifestPlugins: params.metadataSnapshot })
     : staticModelIdMatches;
   return (lookup) => {
     const provider = normalizeProviderId(lookup.provider);
@@ -549,7 +549,7 @@ function createScopedBundledProviderStaticCatalogModelResolver(
 ) => Promise<ProviderRuntimeModel | undefined> {
   const env = params.env ?? process.env;
   const matchesStaticModelId = params.metadataSnapshot
-    ? createStaticModelIdMatcher({ manifestPlugins: params.metadataSnapshot.plugins })
+    ? createStaticModelIdMatcher({ manifestPlugins: params.metadataSnapshot })
     : staticModelIdMatches;
   const pluginCatalogs = new Map<string, Promise<Map<string, ProviderRuntimeModel[]>>>();
   const providerPluginIds = new Map<string, string[]>();

--- a/src/agents/embedded-agent-runner/run-orchestrator.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.ts
@@ -258,7 +258,7 @@ async function runEmbeddedAgentInternal(
       const runtimePluginSelections = resolveModelCandidateChain({
         cfg: config,
         agentId: requestedWorkspaceResolution.agentId,
-        manifestPlugins: pluginMetadataSnapshot.plugins,
+        manifestPlugins: pluginMetadataSnapshot,
         provider: requestedRuntimeSelection.provider,
         model: requestedRuntimeSelection.modelId,
         requestedRouteResolution: "resolved",

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -106,6 +106,7 @@ const emptyPluginMetadataSnapshot: PluginMetadataSnapshot = {
     setupProviders: new Map(),
     commandAliases: new Map(),
     contracts: new Map(),
+    modelIdNormalizationPolicies: new Map(),
   },
   metrics: {
     registrySnapshotMs: 0,

--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -368,6 +368,7 @@ const emptyPluginMetadataSnapshot: PluginMetadataSnapshot = {
     setupProviders: new Map(),
     commandAliases: new Map(),
     contracts: new Map(),
+    modelIdNormalizationPolicies: new Map(),
   },
   metrics: {
     registrySnapshotMs: 0,

--- a/src/agents/model-catalog.test.ts
+++ b/src/agents/model-catalog.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import {
+  createPluginManifestRecordFixture,
+  createPluginMetadataSnapshotFixture,
+} from "../plugins/plugin-metadata.test-support.js";
 import { resolveOAuthApiKeyMarker } from "./model-auth-markers.js";
 import {
   buildPreparedModelCatalogSnapshot,
@@ -27,10 +31,7 @@ vi.mock("../plugins/provider-runtime.runtime.js", () => ({
   ) => mocks.augmentModelCatalogWithProviderPlugins(...args),
 }));
 
-const metadataSnapshot = {
-  plugins: [],
-  manifestRegistry: { plugins: [] },
-} as unknown as PluginMetadataSnapshot;
+const metadataSnapshot = createPluginMetadataSnapshotFixture();
 
 function providerManifestSnapshot(params: {
   provider: string;
@@ -38,7 +39,7 @@ function providerManifestSnapshot(params: {
   modelIds: string[];
   aliases?: string[];
 }): PluginMetadataSnapshot {
-  const plugin = {
+  const plugin = createPluginManifestRecordFixture({
     id: params.provider,
     origin: "bundled",
     providers: [params.provider],
@@ -54,11 +55,8 @@ function providerManifestSnapshot(params: {
       },
       discovery: { [params.provider]: params.discovery },
     },
-  };
-  return {
-    plugins: [plugin],
-    manifestRegistry: { plugins: [plugin] },
-  } as unknown as PluginMetadataSnapshot;
+  });
+  return createPluginMetadataSnapshotFixture({ plugins: [plugin] });
 }
 
 function registry(entries: ModelCatalogEntry[]): ModelRegistry {
@@ -150,7 +148,7 @@ describe("prepared model catalog builder", () => {
   });
 
   it("carries manifest capability metadata into the prepared catalog", async () => {
-    const plugin = {
+    const plugin = createPluginManifestRecordFixture({
       id: "anthropic",
       origin: "bundled",
       providers: ["anthropic"],
@@ -175,11 +173,8 @@ describe("prepared model catalog builder", () => {
         },
         discovery: { anthropic: "refreshable" },
       },
-    };
-    const snapshot = {
-      plugins: [plugin],
-      manifestRegistry: { plugins: [plugin] },
-    } as unknown as PluginMetadataSnapshot;
+    });
+    const snapshot = createPluginMetadataSnapshotFixture({ plugins: [plugin] });
 
     expect(
       loadManifestModelCatalog({ config: {}, metadataSnapshot: snapshot }).find(
@@ -198,7 +193,7 @@ describe("prepared model catalog builder", () => {
   });
 
   it("drops a base context-window default when an overlay replaces the options list", async () => {
-    const plugin = {
+    const plugin = createPluginManifestRecordFixture({
       id: "anthropic",
       origin: "bundled",
       providers: ["anthropic"],
@@ -220,7 +215,7 @@ describe("prepared model catalog builder", () => {
         },
         discovery: { anthropic: "refreshable" },
       },
-    };
+    });
     // Live provider discovery overlays the manifest row but replaces the
     // options list without restating a default.
     mocks.augmentModelCatalogWithProviderPlugins.mockResolvedValueOnce([
@@ -233,10 +228,7 @@ describe("prepared model catalog builder", () => {
       },
     ]);
     const snapshot = await build({
-      metadataSnapshot: {
-        plugins: [plugin],
-        manifestRegistry: { plugins: [plugin] },
-      } as unknown as PluginMetadataSnapshot,
+      metadataSnapshot: createPluginMetadataSnapshotFixture({ plugins: [plugin] }),
       entries: [{ id: "claude-fable-5", name: "Claude Fable 5", provider: "anthropic" }],
       readOnly: false,
     });

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -451,8 +451,9 @@ export async function buildPreparedModelCatalogSnapshot(
   try {
     const workspaceDir = params.workspaceDir;
     const manifestMetadataSnapshot = params.metadataSnapshot;
-    const manifestPlugins = manifestMetadataSnapshot.plugins;
-    const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer({ manifestPlugins });
+    const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer({
+      manifestPlugins: manifestMetadataSnapshot,
+    });
     const normalizeProvider =
       createPreparedModelCatalogProviderNormalizer(manifestMetadataSnapshot);
     const { buildShouldSuppressBuiltInModelCore } = await loadModelSuppression();
@@ -547,7 +548,7 @@ export async function buildPreparedModelCatalogSnapshot(
     logStage("manifest-models-merged", `entries=${models.length}`);
     const configuredModels = buildConfiguredModelCatalog({
       cfg,
-      manifestPlugins,
+      manifestPlugins: manifestMetadataSnapshot,
     });
     logStage("configured-models-prepared", `entries=${models.length}`);
 

--- a/src/agents/model-fallback.probe.test.ts
+++ b/src/agents/model-fallback.probe.test.ts
@@ -97,6 +97,7 @@ const emptyPluginMetadataSnapshot = vi.hoisted(() => ({
     setupProviders: new Map(),
     commandAliases: new Map(),
     contracts: new Map(),
+    modelIdNormalizationPolicies: new Map(),
   },
   metrics: {
     registrySnapshotMs: 0,

--- a/src/agents/model-ref-shared.test.ts
+++ b/src/agents/model-ref-shared.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata.test-support.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import {
   normalizeConfiguredProviderCatalogModelId,
   normalizeStaticProviderModelId,
@@ -92,54 +93,18 @@ describe("normalizeStaticProviderModelId", () => {
     // Runtime callers use the current metadata snapshot by default, so plugin
     // normalization policy applies even without an explicit manifest list.
     setCurrentPluginMetadataSnapshot(
-      {
-        policyHash: "test-policy",
-        index: {
-          version: 1,
-          hostContractVersion: "test",
-          compatRegistryVersion: "test",
-          migrationVersion: 1,
-          policyHash: "test-policy",
-          generatedAtMs: 0,
-          installRecords: {},
-          plugins: [],
-          diagnostics: [],
-        },
+      createPluginMetadataSnapshotFixture({
         plugins: [
           {
+            id: "custom-normalizer",
             modelIdNormalization: {
               providers: {
-                custom: {
-                  aliases: { latest: "custom/modern-model" },
-                },
+                custom: { aliases: { latest: "custom/modern-model" } },
               },
             },
           },
         ],
-        registryDiagnostics: [],
-        manifestRegistry: { plugins: [] },
-        diagnostics: [],
-        byPluginId: new Map(),
-        normalizePluginId: (pluginId: string) => pluginId,
-        owners: {
-          channels: new Map(),
-          channelConfigs: new Map(),
-          providers: new Map(),
-          modelCatalogProviders: new Map(),
-          cliBackends: new Map(),
-          setupProviders: new Map(),
-          commandAliases: new Map(),
-          contracts: new Map(),
-        },
-        metrics: {
-          registrySnapshotMs: 0,
-          manifestRegistryMs: 0,
-          ownerMapsMs: 0,
-          totalMs: 0,
-          indexPluginCount: 0,
-          manifestPluginCount: 1,
-        },
-      } as never,
+      }),
       { config: {} },
     );
 

--- a/src/agents/model-ref-shared.ts
+++ b/src/agents/model-ref-shared.ts
@@ -9,16 +9,16 @@ import {
   normalizeProviderIdForAuth as normalizeProviderIdForAuthCore,
 } from "@openclaw/model-catalog-core/provider-id";
 import {
-  collectManifestModelIdNormalizationPolicies,
   normalizeBuiltInProviderModelId,
   normalizeConfiguredProviderCatalogModelRef,
-  type ManifestModelIdNormalizationRecord,
   normalizeStaticProviderModelIdWithPolicies,
   stripSelfProviderModelPrefix,
 } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import { normalizeProviderModelIdWithManifest } from "../plugins/manifest-model-id-normalization.js";
-import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
+import {
+  resolveManifestModelIdNormalizationPolicies,
+  type ManifestModelIdNormalizationSource,
+} from "../plugins/manifest-model-id-normalization.js";
 import { modelKey } from "../shared/model-key.js";
 import { normalizeProviderModelIdWithRuntime } from "./provider-model-normalization.runtime.js";
 export { modelKey } from "../shared/model-key.js";
@@ -29,12 +29,11 @@ export type ModelRef = {
 };
 
 export type ModelManifestNormalizationContext = {
-  manifestPlugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
+  manifestPlugins?: ManifestModelIdNormalizationSource;
 };
 
-export type ProviderModelIdNormalizationOptions = {
+export type ProviderModelIdNormalizationOptions = ModelManifestNormalizationContext & {
   allowManifestNormalization?: boolean;
-  manifestPlugins?: readonly ManifestModelIdNormalizationRecord[];
 };
 
 /** Normalize a provider ID using the shared catalog rules. */
@@ -65,22 +64,11 @@ export function normalizeStaticProviderModelId(
   if (options.allowManifestNormalization === false) {
     return normalizeBuiltInProviderModelId(normalizedProvider, model);
   }
-  if (options.manifestPlugins) {
-    return normalizeStaticProviderModelIdWithPolicies(
-      normalizedProvider,
-      model,
-      collectManifestModelIdNormalizationPolicies(options.manifestPlugins),
-    );
-  }
-  const manifestModelId =
-    normalizeProviderModelIdWithManifest({
-      provider: normalizedProvider,
-      context: {
-        provider: normalizedProvider,
-        modelId: model,
-      },
-    }) ?? model;
-  return normalizeBuiltInProviderModelId(normalizedProvider, manifestModelId);
+  return normalizeStaticProviderModelIdWithPolicies(
+    normalizedProvider,
+    model,
+    resolveManifestModelIdNormalizationPolicies({ plugins: options.manifestPlugins }),
+  );
 }
 
 /**
@@ -95,7 +83,9 @@ export function createStaticProviderModelIdNormalizer(
       normalizeBuiltInProviderModelId(normalizeProviderId(provider), model);
   }
   if (options.manifestPlugins) {
-    const policies = collectManifestModelIdNormalizationPolicies(options.manifestPlugins);
+    const policies = resolveManifestModelIdNormalizationPolicies({
+      plugins: options.manifestPlugins,
+    });
     return (provider, model) =>
       normalizeStaticProviderModelIdWithPolicies(normalizeProviderId(provider), model, policies);
   }

--- a/src/agents/model-selection-manifest-workspace.test.ts
+++ b/src/agents/model-selection-manifest-workspace.test.ts
@@ -1,6 +1,7 @@
 // Verifies configured model selection uses manifest policy only in scoped contexts.
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import {
   buildAllowedModelSet,
   buildConfiguredModelCatalog,
@@ -37,19 +38,22 @@ describe("configured model manifest workspace scope", () => {
     getActivePluginRegistryWorkspaceDirFromStateMock.mockReset();
     normalizeProviderModelIdWithRuntimeMock.mockReset();
     getCurrentPluginMetadataSnapshotMock.mockReturnValue(undefined);
-    loadManifestMetadataSnapshotMock.mockReturnValue({
-      plugins: [
-        {
-          modelIdNormalization: {
-            providers: {
-              custom: {
-                prefixWhenBare: "workspace-custom",
+    loadManifestMetadataSnapshotMock.mockReturnValue(
+      createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "workspace-model-normalizer",
+            modelIdNormalization: {
+              providers: {
+                custom: {
+                  prefixWhenBare: "workspace-custom",
+                },
               },
             },
           },
-        },
-      ],
-    });
+        ],
+      }),
+    );
   });
 
   it("does not reuse workspace manifest policies without a workspace context", () => {
@@ -104,19 +108,22 @@ describe("configured model manifest workspace scope", () => {
   });
 
   it("uses an unscoped current snapshot without falling back to a metadata scan", () => {
-    getCurrentPluginMetadataSnapshotMock.mockReturnValue({
-      plugins: [
-        {
-          modelIdNormalization: {
-            providers: {
-              custom: {
-                prefixWhenBare: "global-custom",
+    getCurrentPluginMetadataSnapshotMock.mockReturnValue(
+      createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "workspace-model-normalizer",
+            modelIdNormalization: {
+              providers: {
+                custom: {
+                  prefixWhenBare: "global-custom",
+                },
               },
             },
           },
-        },
-      ],
-    });
+        ],
+      }),
+    );
     const cfg = {
       models: {
         providers: {
@@ -137,7 +144,7 @@ describe("configured model manifest workspace scope", () => {
   });
 
   it("builds configured catalog facts once when resolving allowed models", () => {
-    getCurrentPluginMetadataSnapshotMock.mockReturnValue({ plugins: [] });
+    getCurrentPluginMetadataSnapshotMock.mockReturnValue(createPluginMetadataSnapshotFixture());
     const cfg = {
       models: {
         providers: {
@@ -273,7 +280,11 @@ describe("configured model manifest workspace scope", () => {
         },
       ];
       if (source === "current") {
-        getCurrentPluginMetadataSnapshotMock.mockReturnValue({ plugins: manifestPlugins });
+        getCurrentPluginMetadataSnapshotMock.mockReturnValue(
+          createPluginMetadataSnapshotFixture({
+            plugins: [{ id: "prepared-model-normalizer", ...manifestPlugins[0] }],
+          }),
+        );
       }
       const cfg = {
         agents: { defaults: { models: { "openai/legacy": { alias: "Legacy" } } } },
@@ -296,11 +307,16 @@ describe("configured model manifest workspace scope", () => {
 
   it("preserves workspace manifest policy for default-provider aliases", () => {
     getActivePluginRegistryWorkspaceDirFromStateMock.mockReturnValue("/workspace/a");
-    loadManifestMetadataSnapshotMock.mockReturnValue({
-      plugins: [
-        { modelIdNormalization: { providers: { openai: { aliases: { ops: "workspace-ops" } } } } },
-      ],
-    });
+    loadManifestMetadataSnapshotMock.mockReturnValue(
+      createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "workspace-model-normalizer",
+            modelIdNormalization: { providers: { openai: { aliases: { ops: "workspace-ops" } } } },
+          },
+        ],
+      }),
+    );
     const cfg = {
       agents: { defaults: { models: { "openai/ops": { alias: "Operations" } } } },
     } as unknown as OpenClawConfig;
@@ -340,18 +356,21 @@ describe("configured model manifest workspace scope", () => {
       ],
     },
   ])("normalizes mixed aliases consistently with $name", ({ models }) => {
-    loadManifestMetadataSnapshotMock.mockReturnValue({
-      plugins: [
-        {
-          modelIdNormalization: {
-            providers: {
-              custom: { prefixWhenBare: "workspace-custom" },
-              openai: { aliases: { legacy: "normalized" } },
+    loadManifestMetadataSnapshotMock.mockReturnValue(
+      createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "workspace-model-normalizer",
+            modelIdNormalization: {
+              providers: {
+                custom: { prefixWhenBare: "workspace-custom" },
+                openai: { aliases: { legacy: "normalized" } },
+              },
             },
           },
-        },
-      ],
-    });
+        ],
+      }),
+    );
     const cfg = {
       agents: { defaults: { models: Object.fromEntries(models) } },
     } as unknown as OpenClawConfig;
@@ -437,21 +456,24 @@ describe("configured model manifest workspace scope", () => {
   });
 
   it("uses manifest-normalized configured refs to infer providers for bare defaults", () => {
-    loadManifestMetadataSnapshotMock.mockReturnValue({
-      plugins: [
-        {
-          modelIdNormalization: {
-            providers: {
-              anthropic: {
-                aliases: {
-                  "sonnet-4.6": "claude-sonnet-4-6",
+    loadManifestMetadataSnapshotMock.mockReturnValue(
+      createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "workspace-model-normalizer",
+            modelIdNormalization: {
+              providers: {
+                anthropic: {
+                  aliases: {
+                    "sonnet-4.6": "claude-sonnet-4-6",
+                  },
                 },
               },
             },
           },
-        },
-      ],
-    });
+        ],
+      }),
+    );
     const cfg = {
       agents: {
         defaults: {
@@ -474,24 +496,27 @@ describe("configured model manifest workspace scope", () => {
   });
 
   it("reuses resolved manifest plugins while resolving configured model aliases", () => {
-    loadManifestMetadataSnapshotMock.mockReturnValue({
-      plugins: [
-        {
-          modelIdNormalization: {
-            providers: {
-              anthropic: {
-                aliases: {
-                  "sonnet-4.6": "claude-sonnet-4-6",
+    loadManifestMetadataSnapshotMock.mockReturnValue(
+      createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "workspace-model-normalizer",
+            modelIdNormalization: {
+              providers: {
+                anthropic: {
+                  aliases: {
+                    "sonnet-4.6": "claude-sonnet-4-6",
+                  },
                 },
-              },
-              openrouter: {
-                prefixWhenBare: "openrouter",
+                openrouter: {
+                  prefixWhenBare: "openrouter",
+                },
               },
             },
           },
-        },
-      ],
-    });
+        ],
+      }),
+    );
     const cfg = {
       agents: {
         defaults: {
@@ -515,24 +540,27 @@ describe("configured model manifest workspace scope", () => {
   });
 
   it("reuses resolved manifest plugins while resolving direct primary models", () => {
-    loadManifestMetadataSnapshotMock.mockReturnValue({
-      plugins: [
-        {
-          modelIdNormalization: {
-            providers: {
-              anthropic: {
-                aliases: {
-                  "sonnet-4.6": "claude-sonnet-4-6",
+    loadManifestMetadataSnapshotMock.mockReturnValue(
+      createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "workspace-model-normalizer",
+            modelIdNormalization: {
+              providers: {
+                anthropic: {
+                  aliases: {
+                    "sonnet-4.6": "claude-sonnet-4-6",
+                  },
                 },
-              },
-              openrouter: {
-                prefixWhenBare: "openrouter",
+                openrouter: {
+                  prefixWhenBare: "openrouter",
+                },
               },
             },
           },
-        },
-      ],
-    });
+        ],
+      }),
+    );
     const cfg = {
       agents: {
         defaults: {

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -114,7 +114,7 @@ function resolveManifestPluginsForModelIdNormalization(params: {
     const currentManifestPlugins = getCurrentPluginMetadataSnapshot({
       config: params.cfg,
       env: process.env,
-    })?.plugins;
+    });
     if (currentManifestPlugins) {
       return currentManifestPlugins;
     }
@@ -123,7 +123,7 @@ function resolveManifestPluginsForModelIdNormalization(params: {
     config: params.cfg,
     env: process.env,
     ...(workspaceDir ? { workspaceDir } : {}),
-  }).plugins;
+  });
 }
 
 function createModelManifestPluginContext(params: {
@@ -1354,13 +1354,13 @@ function resolveConfiguredModelManifestPlugins(params: {
     return getCurrentPluginMetadataSnapshot({
       config: params.cfg,
       env: process.env,
-    })?.plugins;
+    });
   }
   return loadManifestMetadataSnapshot({
     config: params.cfg,
     env: process.env,
     ...(workspaceDir ? { workspaceDir } : {}),
-  }).plugins;
+  });
 }
 
 /** Build catalog entries from configured provider model rows. */

--- a/src/agents/model-selection.plugin-runtime.test.ts
+++ b/src/agents/model-selection.plugin-runtime.test.ts
@@ -1,5 +1,6 @@
 // Covers plugin-owned model id normalization through selection surfaces.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 
 const normalizeProviderModelIdWithPluginMock = vi.fn();
 
@@ -15,22 +16,25 @@ function normalizeLegacyFixtureModel({
     : undefined;
 }
 
-const emptyPluginMetadataSnapshot = vi.hoisted(() => ({
+const emptyPluginMetadataSnapshot = {
   configFingerprint: "model-selection-plugin-runtime-test-empty-plugin-metadata",
-  plugins: [
-    {
-      modelIdNormalization: {
-        providers: {
-          google: {
-            aliases: {
-              "gemini-3.1-pro": "gemini-3.1-pro-preview",
+  ...createPluginMetadataSnapshotFixture({
+    plugins: [
+      {
+        id: "google-model-normalizer",
+        modelIdNormalization: {
+          providers: {
+            google: {
+              aliases: {
+                "gemini-3.1-pro": "gemini-3.1-pro-preview",
+              },
             },
           },
         },
       },
-    },
-  ],
-}));
+    ],
+  }),
+};
 const getCurrentPluginMetadataSnapshotMock = vi.hoisted(() => vi.fn());
 const loadPreparedModelCatalogSnapshotMock = vi.hoisted(() => vi.fn());
 

--- a/src/agents/model-selection.test.ts
+++ b/src/agents/model-selection.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, it, expect, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { createWarnLogCapture } from "../logging/test-helpers/warn-log-capture.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { resolveAgentHarnessPolicy } from "./harness/policy.js";
 import {
   getModelRefStatus as getNarrowModelRefStatus,
@@ -33,70 +34,72 @@ import {
 } from "./model-selection.js";
 import { createModelVisibilityPolicy } from "./model-visibility-policy.js";
 
-const manifestNormalizationSnapshot = vi.hoisted(() => ({
+const manifestNormalizationSnapshot = {
   configFingerprint: "model-selection-test-normalizers",
-  plugins: [
-    {
-      id: "model-selection-test-normalizers",
-      modelIdNormalization: {
-        providers: {
-          anthropic: {
-            aliases: {
-              "opus-4.6": "claude-opus-4-6",
-              "opus-4.5": "claude-opus-4-5",
-              "sonnet-4.6": "claude-sonnet-4-6",
-              "sonnet-4.5": "claude-sonnet-4-5",
-            },
-          },
-          google: {
-            aliases: {
-              "gemini-3-pro": "gemini-3.1-pro-preview",
-              "gemini-3-flash": "gemini-3-flash-preview",
-              "gemini-3.1-pro": "gemini-3.1-pro-preview",
-              "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
-              "gemini-3.1-flash": "gemini-3-flash-preview",
-              "gemini-3.1-flash-preview": "gemini-3-flash-preview",
-            },
-          },
-          "google-vertex": {
-            aliases: {
-              "gemini-3-pro": "gemini-3.1-pro-preview",
-              "gemini-3-flash": "gemini-3-flash-preview",
-              "gemini-3.1-pro": "gemini-3.1-pro-preview",
-              "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
-              "gemini-3.1-flash": "gemini-3-flash-preview",
-              "gemini-3.1-flash-preview": "gemini-3-flash-preview",
-            },
-          },
-          xai: { aliases: {} },
-          openrouter: {
-            prefixWhenBare: "openrouter",
-          },
-          huggingface: {
-            stripPrefixes: ["huggingface/"],
-          },
-          "vercel-ai-gateway": {
-            aliases: {
-              "opus-4.6": "claude-opus-4-6",
-              "opus-4.5": "claude-opus-4-5",
-              "sonnet-4.6": "claude-sonnet-4-6",
-              "sonnet-4.5": "claude-sonnet-4-5",
-            },
-            prefixWhenBareAfterAliasStartsWith: [
-              {
-                modelPrefix: "claude-",
-                prefix: "anthropic",
+  ...createPluginMetadataSnapshotFixture({
+    plugins: [
+      {
+        id: "model-selection-test-normalizers",
+        modelIdNormalization: {
+          providers: {
+            anthropic: {
+              aliases: {
+                "opus-4.6": "claude-opus-4-6",
+                "opus-4.5": "claude-opus-4-5",
+                "sonnet-4.6": "claude-sonnet-4-6",
+                "sonnet-4.5": "claude-sonnet-4-5",
               },
-            ],
-          },
-          nvidia: {
-            prefixWhenBare: "nvidia",
+            },
+            google: {
+              aliases: {
+                "gemini-3-pro": "gemini-3.1-pro-preview",
+                "gemini-3-flash": "gemini-3-flash-preview",
+                "gemini-3.1-pro": "gemini-3.1-pro-preview",
+                "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
+                "gemini-3.1-flash": "gemini-3-flash-preview",
+                "gemini-3.1-flash-preview": "gemini-3-flash-preview",
+              },
+            },
+            "google-vertex": {
+              aliases: {
+                "gemini-3-pro": "gemini-3.1-pro-preview",
+                "gemini-3-flash": "gemini-3-flash-preview",
+                "gemini-3.1-pro": "gemini-3.1-pro-preview",
+                "gemini-3.1-flash-lite-preview": "gemini-3.1-flash-lite",
+                "gemini-3.1-flash": "gemini-3-flash-preview",
+                "gemini-3.1-flash-preview": "gemini-3-flash-preview",
+              },
+            },
+            xai: { aliases: {} },
+            openrouter: {
+              prefixWhenBare: "openrouter",
+            },
+            huggingface: {
+              stripPrefixes: ["huggingface/"],
+            },
+            "vercel-ai-gateway": {
+              aliases: {
+                "opus-4.6": "claude-opus-4-6",
+                "opus-4.5": "claude-opus-4-5",
+                "sonnet-4.6": "claude-sonnet-4-6",
+                "sonnet-4.5": "claude-sonnet-4-5",
+              },
+              prefixWhenBareAfterAliasStartsWith: [
+                {
+                  modelPrefix: "claude-",
+                  prefix: "anthropic",
+                },
+              ],
+            },
+            nvidia: {
+              prefixWhenBare: "nvidia",
+            },
           },
         },
       },
-    },
-  ],
-}));
+    ],
+  }),
+};
 
 const providerModelNormalizationMock = vi.hoisted(() => ({
   normalizeProviderModelIdWithRuntime: vi.fn(() => undefined),

--- a/src/agents/models-config.plan.ts
+++ b/src/agents/models-config.plan.ts
@@ -10,7 +10,11 @@ import type { ProviderCatalogOutcome } from "../plugins/provider-catalog.types.j
 import type { PreparedProviderStaticCatalog } from "../plugins/provider-discovery.js";
 import { isRecord } from "../utils.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
-import { modelKey, createConfiguredProviderCatalogModelIdNormalizer } from "./model-ref-shared.js";
+import {
+  modelKey,
+  createConfiguredProviderCatalogModelIdNormalizer,
+  type ModelManifestNormalizationContext,
+} from "./model-ref-shared.js";
 import {
   mergeProviders,
   mergeWithExistingProviderSecrets,
@@ -126,7 +130,7 @@ function buildPluginCatalogWrites(
 
 function buildSourceModelFields(
   sourceProviders: Record<string, ProviderConfig> | undefined,
-  manifestPlugins: PluginMetadataSnapshot["manifestRegistry"]["plugins"] | undefined,
+  manifestPlugins: ModelManifestNormalizationContext["manifestPlugins"],
 ): SourceModelFields {
   const normalizeModelId = createConfiguredProviderCatalogModelIdNormalizer({ manifestPlugins });
   const fields = new Map<
@@ -163,7 +167,7 @@ async function resolveProvidersForModelsJsonWithDeps(
   const cfg = context.cfg.models?.providers
     ? { ...context.cfg, models: { ...context.cfg.models, providers: explicitProviders } }
     : context.cfg;
-  const manifestPlugins = context.pluginMetadataSnapshot?.manifestRegistry.plugins;
+  const manifestPlugins = context.pluginMetadataSnapshot;
   const sourceModelFields = buildSourceModelFields(context.cfg.models?.providers, manifestPlugins);
   // When models.mode is "replace" the user opts out of provider discovery, so
   // skip the (potentially slow) implicit-provider resolver entirely and return
@@ -301,7 +305,7 @@ async function planOpenClawModelsJsonWithDeps(
 
   const mode = cfg.models?.mode ?? "merge";
   const secretRefManagedProviders = new Set<string>();
-  const manifestPlugins = context.pluginMetadataSnapshot?.manifestRegistry.plugins;
+  const manifestPlugins = context.pluginMetadataSnapshot;
   const providerPolicyManifestRegistry =
     context.pluginMetadataSnapshot?.pluginIds === undefined
       ? context.pluginMetadataSnapshot?.manifestRegistry

--- a/src/agents/models-config.providers.implicit.discovery-scope.test.ts
+++ b/src/agents/models-config.providers.implicit.discovery-scope.test.ts
@@ -66,6 +66,7 @@ function metadataOwners(
     setupProviders: new Map(),
     commandAliases: new Map(),
     contracts: new Map(),
+    modelIdNormalizationPolicies: new Map(),
     ...overrides,
   };
 }

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -11,6 +11,7 @@ import { normalizeStringEntries } from "@openclaw/normalization-core/string-norm
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import type { ManifestModelIdNormalizationSource } from "../plugins/manifest-model-id-normalization.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { ProviderCatalogOutcome } from "../plugins/provider-catalog.types.js";
 import {
@@ -268,7 +269,7 @@ function mergeImplicitProviderConfig(params: {
   implicit: ProviderConfig;
   dynamicProviderModels?: boolean;
   sourceModelFields?: SourceModelFields;
-  manifestPlugins?: PluginMetadataSnapshot["manifestRegistry"]["plugins"];
+  manifestPlugins?: ManifestModelIdNormalizationSource;
 }): ProviderConfig {
   const { providerId, existing, implicit } = params;
   if (!existing) {
@@ -483,7 +484,7 @@ async function resolvePluginImplicitProviders(
           providerId,
         }),
         sourceModelFields: ctx.sourceModelFields,
-        manifestPlugins: ctx.pluginMetadataSnapshot?.manifestRegistry.plugins,
+        manifestPlugins: ctx.pluginMetadataSnapshot,
       });
       discovered[providerId] = resolveImplicitProviderAuthMarker({
         ctx,

--- a/src/agents/models-config.providers.normalize.ts
+++ b/src/agents/models-config.providers.normalize.ts
@@ -4,9 +4,12 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { mergeModelCost } from "../config/model-cost.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import type { PluginManifestRecord, PluginManifestRegistry } from "../plugins/manifest-registry.js";
+import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { ensureAuthProfileStore } from "./auth-profiles/store.js";
-import { createConfiguredProviderCatalogModelIdNormalizer } from "./model-ref-shared.js";
+import {
+  createConfiguredProviderCatalogModelIdNormalizer,
+  type ModelManifestNormalizationContext,
+} from "./model-ref-shared.js";
 import {
   normalizeProviderSpecificConfig,
   resolveProviderConfigApiKeyResolver,
@@ -28,9 +31,6 @@ type ModelsConfig = NonNullable<OpenClawConfig["models"]>;
 type ProviderModelConfig = NonNullable<
   NonNullable<ModelsConfig["providers"]>[string]["models"]
 >[number];
-type ProviderModelNormalizationOptions = {
-  manifestPlugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
-};
 
 function getProviderModelId(model: ProviderModelConfig): string | undefined {
   return typeof model.id === "string" && model.id.trim() ? model.id : undefined;
@@ -69,7 +69,7 @@ function mergeNormalizedProviderModel(
 function normalizeProviderModelsForConfig(
   providerKey: string,
   provider: ProviderConfig,
-  options: ProviderModelNormalizationOptions = {},
+  options: ModelManifestNormalizationContext = {},
   completeCatalogCosts = false,
 ): ProviderConfig {
   if (!Array.isArray(provider.models) || provider.models.length === 0) {
@@ -119,7 +119,7 @@ function normalizeProviderModelsForConfig(
 
 export function normalizeProviderCatalogModelsForConfig(
   providers: ModelsConfig["providers"],
-  options: ProviderModelNormalizationOptions = {},
+  options: ModelManifestNormalizationContext = {},
 ): ModelsConfig["providers"] {
   if (!providers) {
     return providers;
@@ -145,7 +145,7 @@ export function normalizeProviders(params: {
   secretDefaults?: SecretDefaults;
   sourceConfigForSecrets?: OpenClawConfig;
   secretRefManagedProviders?: Set<string>;
-  manifestPlugins?: ProviderModelNormalizationOptions["manifestPlugins"];
+  manifestPlugins?: ModelManifestNormalizationContext["manifestPlugins"];
   manifestRegistry?: Pick<PluginManifestRegistry, "plugins">;
 }): ModelsConfig["providers"] {
   const { providers } = params;

--- a/src/agents/models-config.write-serialization.test.ts
+++ b/src/agents/models-config.write-serialization.test.ts
@@ -95,6 +95,7 @@ function createPluginMetadataSnapshot(workspaceDir: string): PluginMetadataSnaps
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
     metrics: {
       registrySnapshotMs: 0,

--- a/src/agents/openclaw-tools.media-factory-plan.test.ts
+++ b/src/agents/openclaw-tools.media-factory-plan.test.ts
@@ -214,6 +214,7 @@ function installSnapshot(
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
     metrics: {
       registrySnapshotMs: 0,

--- a/src/agents/openclaw-tools.session-status.test.ts
+++ b/src/agents/openclaw-tools.session-status.test.ts
@@ -11,6 +11,7 @@ import {
   type InternalHookEvent,
 } from "../hooks/internal-hooks.js";
 import { normalizeLegacySessionEntryDelivery } from "../infra/state-migrations.legacy-session-store.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { MODEL_SELECTION_LOCKED_MESSAGE } from "../sessions/model-overrides.js";
 import { resolvePreferredSessionKeyForSessionIdMatches } from "../sessions/session-id-resolution.js";
 import type { TaskRecord } from "../tasks/task-registry.types.js";
@@ -51,10 +52,10 @@ const listSessionStateEventsSinceMock = vi.hoisted(() =>
     historyGap: false,
   })),
 );
-const emptyPluginMetadataSnapshot = vi.hoisted(() => ({
+const emptyPluginMetadataSnapshot = {
   configFingerprint: "session-status-test-empty-plugin-metadata",
-  plugins: [],
-}));
+  ...createPluginMetadataSnapshotFixture(),
+};
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
 
 const createMockConfig = () => ({

--- a/src/agents/prepared-model-registry.test.ts
+++ b/src/agents/prepared-model-registry.test.ts
@@ -188,6 +188,7 @@ describe("prepared agent model registry", () => {
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     };
     registry.getProviderMetadataOwners.mockReturnValue(providerMetadataOwners);
     mocks.prepareSnapshot.mockResolvedValue(snapshot);

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -208,7 +208,7 @@ export async function prepareWorkspaceBuildGroup(
   );
   const prepare = async () => {
     const matchesStaticModelId = createStaticModelIdMatcher({
-      manifestPlugins: pluginMetadataSnapshot.plugins,
+      manifestPlugins: pluginMetadataSnapshot,
     });
     const mediaCapabilityProviders = reuseRuntimeFacts
       ? reusablePluginGeneration.mediaCapabilityProviders
@@ -370,7 +370,7 @@ export async function prepareWorkspaceBuildGroup(
       reusablePluginGeneration?.configuredCatalogEntries ??
       buildConfiguredModelCatalog({
         cfg: input.config,
-        manifestPlugins: pluginMetadataSnapshot.plugins,
+        manifestPlugins: pluginMetadataSnapshot,
         ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
       });
     const agentFacts: PreparedModelRuntimeAgentFacts[] = [];

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => {
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
   };
   const authStorage = {

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -26,6 +26,7 @@ const preparedModelRuntimeMocks = vi.hoisted(() => ({
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
   },
   preparedAuthStore: undefined as import("./auth-profiles/types.js").AuthProfileStore | undefined,

--- a/src/agents/provider-attribution.test.ts
+++ b/src/agents/provider-attribution.test.ts
@@ -329,6 +329,7 @@ describe("provider attribution", () => {
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
       providerEndpoints: [
         {
           endpointClass: "anthropic-public" as const,

--- a/src/agents/provider-auth-aliases.test.ts
+++ b/src/agents/provider-auth-aliases.test.ts
@@ -130,6 +130,7 @@ function createPluginMetadataSnapshot(params: {
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
     metrics: {
       registrySnapshotMs: 0,

--- a/src/agents/provider-model-normalization.runtime.ts
+++ b/src/agents/provider-model-normalization.runtime.ts
@@ -4,7 +4,7 @@
  * once and caches the result.
  */
 import { createRequire } from "node:module";
-import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
+import type { ManifestModelIdNormalizationSource } from "../plugins/manifest-model-id-normalization.js";
 
 type ProviderRuntimeModule = Pick<
   typeof import("../plugins/provider-runtime.js"),
@@ -44,7 +44,7 @@ function loadProviderRuntime(): ProviderRuntimeModule | null {
 /** Normalizes provider model ids through plugin runtime hooks when available. */
 export function normalizeProviderModelIdWithRuntime(params: {
   provider: string;
-  plugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
+  plugins?: ManifestModelIdNormalizationSource;
   context: {
     provider: string;
     modelId: string;

--- a/src/agents/provider-request-config.test.ts
+++ b/src/agents/provider-request-config.test.ts
@@ -33,6 +33,7 @@ function buildProviderMetadataOwners(
     setupProviders: empty,
     commandAliases: empty,
     contracts: empty,
+    modelIdNormalizationPolicies: new Map(),
     providerEndpoints: endpoints,
     providerRequests: requests,
   };
@@ -49,6 +50,7 @@ describe("provider request config", () => {
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
       providerEndpoints: [],
       providerRequests: new Map([["prepared", { family: "prepared-family" }]]),
     };

--- a/src/agents/sessions/model-registry.test.ts
+++ b/src/agents/sessions/model-registry.test.ts
@@ -94,6 +94,7 @@ function pluginOwnerSnapshotEntries(
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
   };
 }

--- a/src/agents/simple-completion-runtime.generation.test.ts
+++ b/src/agents/simple-completion-runtime.generation.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, expect, it, vi } from "vitest";
 import type { Model } from "../llm/types.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import type { resolveModelAsync } from "./embedded-agent-runner/model.js";
 import { AuthStorage, ModelRegistry } from "./sessions/index.js";
 
@@ -77,10 +78,9 @@ beforeEach(() => {
   mocks.acquireRuntimeLease.mockReset();
   mocks.getApiKeyForModel.mockReset();
   mocks.prepareProviderRuntimeAuth.mockReset();
-  mocks.resolvePluginMetadataSnapshot.mockReset().mockReturnValue({
-    plugins: [],
-    index: { plugins: [] },
-  });
+  mocks.resolvePluginMetadataSnapshot
+    .mockReset()
+    .mockReturnValue(createPluginMetadataSnapshotFixture());
   const authStorage = AuthStorage.inMemory({});
   const modelRegistry = ModelRegistry.inMemory(authStorage);
   mocks.acquireRuntimeLease.mockResolvedValue({
@@ -90,7 +90,7 @@ beforeEach(() => {
       workspaceDir: "/tmp/runtime-workspace",
       config: {},
       authModes: {},
-      metadataSnapshot: { plugins: [], index: { plugins: [] } },
+      metadataSnapshot: createPluginMetadataSnapshotFixture(),
       allowGatewaySubagentBinding: false,
       modelCatalog: { entries: [] },
       configuredRuntimeModels: [],
@@ -224,7 +224,7 @@ it("selects an explicit agent completion model before runtime acquisition", asyn
 });
 
 it("acquires the canonical manifest-derived utility model selection", async () => {
-  const metadataSnapshot = {
+  const metadataSnapshot = createPluginMetadataSnapshotFixture({
     plugins: [
       {
         id: "selected-provider",
@@ -238,8 +238,7 @@ it("acquires the canonical manifest-derived utility model selection", async () =
         },
       },
     ],
-    index: { plugins: [] },
-  };
+  });
   mocks.resolvePluginMetadataSnapshot.mockReturnValue(metadataSnapshot);
 
   const result = await prepareSimpleCompletionModelForAgent({

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -126,7 +126,9 @@ type SimpleCompletionSelectionParams = {
   agentDir?: string;
   modelRef?: string;
   useUtilityModel?: boolean;
-  manifestPlugins?: PluginMetadataSnapshot["plugins"];
+  manifestPlugins?:
+    | PluginMetadataSnapshot["plugins"]
+    | Pick<PluginMetadataSnapshot, "plugins" | "owners">;
 };
 
 type SimpleCompletionSelectionRequest = {
@@ -152,7 +154,12 @@ function resolveSimpleCompletionSelectionRequest(
           agentId: params.agentId,
           primaryProvider: fallbackRef.provider,
           ...(params.manifestPlugins
-            ? { metadataSnapshot: { plugins: params.manifestPlugins } }
+            ? {
+                metadataSnapshot:
+                  "plugins" in params.manifestPlugins
+                    ? params.manifestPlugins
+                    : { plugins: params.manifestPlugins },
+              }
             : {}),
         })
       : undefined) ||
@@ -572,7 +579,7 @@ export async function prepareSimpleCompletionModelForAgent(params: {
   const resolveSelection = () =>
     resolveSimpleCompletionSelectionForAgent({
       ...selectionParams,
-      manifestPlugins: metadataSnapshot.plugins,
+      manifestPlugins: metadataSnapshot,
     });
   let selection = resolveSelection();
   if (!selection) {

--- a/src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts
+++ b/src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts
@@ -61,6 +61,7 @@ export function createEmptyPluginMetadataSnapshot(workspaceDir?: string): Plugin
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
     metrics: {
       registrySnapshotMs: 0,

--- a/src/agents/tools/session-status-tool.ts
+++ b/src/agents/tools/session-status-tool.ts
@@ -526,7 +526,7 @@ async function resolveModelOverride(params: {
           env: process.env,
         });
   const modelManifestContext = {
-    manifestPlugins: manifestMetadataSnapshot?.plugins,
+    manifestPlugins: manifestMetadataSnapshot,
   };
   const policy = createModelVisibilityPolicy({
     cfg: params.cfg,

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -231,6 +231,7 @@ function createVideoProviderSnapshot(params: {
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
     metrics: {
       registrySnapshotMs: 0,

--- a/src/auto-reply/reply/commands-models.test.ts
+++ b/src/auto-reply/reply/commands-models.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vite
 import { testing as cliBackendsTesting } from "../../agents/cli-backends.test-support.js";
 import type { ChannelPlugin } from "../../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   createChannelTestPluginBase,
@@ -367,12 +368,7 @@ describe("handleModelsCommand", () => {
   });
 
   it("scopes the prepared catalog without passing plugin metadata", async () => {
-    const metadataSnapshot = {
-      plugins: [],
-      owners: {
-        cliBackends: new Map<string, string>(),
-      },
-    };
+    const metadataSnapshot = createPluginMetadataSnapshotFixture();
     pluginMetadataMocks.getCurrent.mockReturnValue(metadataSnapshot);
 
     await handleModelsCommand(buildParams("/models"), true);
@@ -501,18 +497,20 @@ describe("handleModelsCommand", () => {
   );
 
   it("shows plugin-normalized allowlist models in browse data", async () => {
-    pluginMetadataMocks.getCurrent.mockReturnValue({
-      plugins: [
-        {
-          modelIdNormalization: {
-            providers: {
-              custom: { aliases: { legacy: "modern" } },
+    pluginMetadataMocks.getCurrent.mockReturnValue(
+      createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "custom-model-normalizer",
+            modelIdNormalization: {
+              providers: {
+                custom: { aliases: { legacy: "modern" } },
+              },
             },
           },
-        },
-      ],
-      owners: { cliBackends: new Map() },
-    });
+        ],
+      }),
+    );
     modelCatalogMocks.loadModelCatalog.mockResolvedValue([
       { provider: "custom", id: "modern", name: "Modern" },
     ]);
@@ -647,12 +645,11 @@ describe("handleModelsCommand", () => {
         },
       ],
     });
-    pluginMetadataMocks.getCurrent.mockReturnValue({
-      plugins: [],
-      owners: {
-        cliBackends: new Map([["acme-cli", "acme"]]),
-      },
-    });
+    pluginMetadataMocks.getCurrent.mockReturnValue(
+      createPluginMetadataSnapshotFixture({
+        plugins: [{ id: "acme", cliBackends: ["acme-cli"] }],
+      }),
+    );
     modelCatalogMocks.loadModelCatalog.mockResolvedValue([
       { provider: "anthropic", id: "claude-opus-4-7", name: "Claude Opus 4.7" },
       { provider: "acme-cli", id: "acme-model", name: "Acme Model" },

--- a/src/auto-reply/reply/model-runtime-normalization.ts
+++ b/src/auto-reply/reply/model-runtime-normalization.ts
@@ -25,7 +25,7 @@ export function resolveRuntimeNormalization(cfg: OpenClawConfig): RuntimeModelNo
     manifestPlugins: getCurrentPluginMetadataSnapshot({
       config: cfg,
       allowWorkspaceScopedSnapshot: true,
-    })?.plugins,
+    }),
   };
 }
 

--- a/src/auto-reply/reply/model-selection.test.ts
+++ b/src/auto-reply/reply/model-selection.test.ts
@@ -77,7 +77,7 @@ vi.mock("../../channels/plugins/session-conversation.js", () => ({
 
 vi.mock("../../plugins/current-plugin-metadata-snapshot.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../../plugins/current-plugin-metadata-snapshot.js")>()),
-  getCurrentPluginMetadataSnapshot: () => ({ plugins: [] }),
+  getCurrentPluginMetadataSnapshot: () => createPluginMetadataSnapshotFixture(),
 }));
 
 vi.mock("./session-entry-persistence.js", () => ({

--- a/src/cli/config-cli-model-normalization.ts
+++ b/src/cli/config-cli-model-normalization.ts
@@ -1,4 +1,3 @@
-import { collectManifestModelIdNormalizationPolicies } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { expectDefined } from "@openclaw/normalization-core";
 import { normalizeSubmittedConfigModelRefs } from "../config/model-input-normalization.js";
 import { normalizeAgentModelRefForConfig } from "../config/model-input.js";
@@ -8,10 +7,7 @@ import type { PathSegment } from "./config-cli-path.js";
 
 export function normalizeConfigMutationModelRefs(cfg: OpenClawConfig): OpenClawConfig {
   const pluginMetadata = loadPluginMetadataSnapshot({ config: cfg, env: process.env });
-  return normalizeSubmittedConfigModelRefs(
-    cfg,
-    collectManifestModelIdNormalizationPolicies(pluginMetadata.plugins),
-  );
+  return normalizeSubmittedConfigModelRefs(cfg, pluginMetadata.owners.modelIdNormalizationPolicies);
 }
 
 export function normalizeConfigMutationExplicitSetPath(path: PathSegment[]): PathSegment[] {

--- a/src/commands/models/list.configured.test.ts
+++ b/src/commands/models/list.configured.test.ts
@@ -3,11 +3,12 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 
-const emptyPluginMetadataSnapshot = vi.hoisted(() => ({
+const emptyPluginMetadataSnapshot = {
   configFingerprint: "models-list-configured-test-empty-plugin-metadata",
-  plugins: [],
-}));
+  ...createPluginMetadataSnapshotFixture(),
+};
 
 const mocks = vi.hoisted(() => ({
   loadPreparedModelCatalogSnapshot: vi.fn(),

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -77,6 +77,7 @@ const mocks = vi.hoisted(() => {
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
     metrics: {
       registrySnapshotMs: 0,

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -483,7 +483,7 @@ export async function appendConfiguredProviderRows(params: {
             provider,
             stripSelfProviderModelPrefix(provider, configuredModel.id),
             {
-              manifestPlugins: params.context.metadataSnapshot?.manifestRegistry.plugins,
+              manifestPlugins: params.context.metadataSnapshot,
             },
           )
         : configuredModel.id;

--- a/src/commands/onboard-custom-config.test.ts
+++ b/src/commands/onboard-custom-config.test.ts
@@ -1,5 +1,5 @@
 // Onboard custom config tests cover provider-specific config merging and context-window bounds.
-import { setCurrentManifestModelIdNormalizationRecords } from "@openclaw/model-catalog-core/provider-model-id-normalization";
+import { setCurrentManifestModelIdNormalizationPolicies } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { describe, expect, it, vi } from "vitest";
 import { CONTEXT_WINDOW_HARD_MIN_TOKENS } from "../agents/context-window-guard.js";
 import * as providerModelNormalizationRuntime from "../agents/provider-model-normalization.runtime.js";
@@ -140,7 +140,7 @@ it("rejects custom aliases already used by the selected agent", () => {
 });
 
 it("validates authored and inherited aliases without discovering plugin metadata", () => {
-  setCurrentManifestModelIdNormalizationRecords(undefined);
+  setCurrentManifestModelIdNormalizationPolicies(undefined);
   const currentSnapshot = vi
     .spyOn(currentPluginMetadataSnapshot, "getCurrentPluginMetadataSnapshot")
     .mockImplementation(() => {
@@ -216,7 +216,7 @@ it("validates authored and inherited aliases without discovering plugin metadata
       }),
     ).toBeUndefined();
   } finally {
-    setCurrentManifestModelIdNormalizationRecords(undefined);
+    setCurrentManifestModelIdNormalizationPolicies(undefined);
     currentSnapshot.mockRestore();
     loadedSnapshot.mockRestore();
     runtimeNormalization.mockRestore();

--- a/src/commands/onboard-inference.test.ts
+++ b/src/commands/onboard-inference.test.ts
@@ -36,6 +36,7 @@ const emptyPluginMetadataSnapshot = vi.hoisted(() => ({
     setupProviders: new Map(),
     commandAliases: new Map(),
     contracts: new Map(),
+    modelIdNormalizationPolicies: new Map(),
   },
   metrics: {
     registrySnapshotMs: 0,

--- a/src/commands/promos/claim.test.ts
+++ b/src/commands/promos/claim.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import type { RuntimeEnv } from "../../runtime.js";
 
 const mocks = vi.hoisted(() => ({
@@ -139,11 +140,11 @@ beforeEach(() => {
   mocks.hasAvailableAuthForProvider.mockResolvedValue(true);
   mocks.resolveManifestProviderAuthChoice.mockReturnValue(authChoice);
   mocks.resolveProviderInstallCatalogEntry.mockReturnValue(undefined);
-  mocks.loadManifestMetadataSnapshot.mockReturnValue({
-    manifestRegistry: {
+  mocks.loadManifestMetadataSnapshot.mockReturnValue(
+    createPluginMetadataSnapshotFixture({
       plugins: [{ id: "openrouter", packageName: "@openclaw/openrouter-provider" }],
-    },
-  });
+    }),
+  );
   mocks.promptYesNo.mockResolvedValue(false);
   mocks.enablePluginInConfig.mockImplementation((cfg: unknown, pluginId: string) => ({
     config: cfg,

--- a/src/config/io.context.plugin-metadata.test.ts
+++ b/src/config/io.context.plugin-metadata.test.ts
@@ -98,6 +98,7 @@ function workspaceSnapshot(
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
     metrics: {
       registrySnapshotMs: 0,

--- a/src/config/io.context.ts
+++ b/src/config/io.context.ts
@@ -1,5 +1,4 @@
 import crypto from "node:crypto";
-import { collectManifestModelIdNormalizationPolicies } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { ensureOwnerDisplaySecret } from "../agents/owner-display.js";
 import { classifyOtelGrpcMigrationOwnership } from "../commands/doctor/shared/include-migration-ownership.js";
 import { applyLegacyDoctorMigrations } from "../commands/doctor/shared/legacy-config-compat.js";
@@ -234,8 +233,4 @@ export function createConfigIoContext(options: ConfigIoFactoryOptions = {}): Con
     resolveRuntimePreflightSourceConfig,
     prepareRecoveryBackupCandidate,
   };
-}
-
-export function resolveModelIdNormalizationPolicies(snapshot: PluginMetadataSnapshot | undefined) {
-  return snapshot ? collectManifestModelIdNormalizationPolicies(snapshot.plugins) : undefined;
 }

--- a/src/config/plugin-auto-enable.test-helpers.ts
+++ b/src/config/plugin-auto-enable.test-helpers.ts
@@ -115,6 +115,7 @@ export function createPluginMetadataSnapshot(params: {
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
     metrics: {
       registrySnapshotMs: 0,

--- a/src/gateway/http-utils.ts
+++ b/src/gateway/http-utils.ts
@@ -185,7 +185,7 @@ export async function resolveOpenAiCompatModelOverride(params: {
     ...(workspaceDir ? { workspaceDir } : {}),
   });
   const modelManifestContext = {
-    manifestPlugins: manifestMetadataSnapshot?.plugins,
+    manifestPlugins: manifestMetadataSnapshot,
   };
   const parsed = parseModelRef(raw, defaultProvider, {
     allowManifestNormalization: true,

--- a/src/gateway/server-methods/chat-metadata-runtime.test-support.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.test-support.ts
@@ -8,6 +8,7 @@ import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model
 import { setPreparedModelRuntimeAuthStore } from "../../agents/prepared-model-runtime-auth.js";
 import type { PreparedModelRuntimeSnapshot } from "../../agents/prepared-model-runtime.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import { createGatewayChatMetadataRuntime } from "./chat-metadata-runtime.js";
 import type { GatewayRequestContext } from "./types.js";
 
@@ -36,7 +37,7 @@ export function createChatMetadataOwner(
     activeProjectKeys: [],
     config,
     authModes: resolveUsableAgentCredentialModes(credentials),
-    metadataSnapshot: { index: { plugins: [] }, plugins: [] } as never,
+    metadataSnapshot: createPluginMetadataSnapshotFixture(),
     allowGatewaySubagentBinding: false,
     modelCatalog: {
       entries: [model],

--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ConfigMutationConflictError } from "../../config/mutation-conflict.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { withEnvAsync } from "../../test-utils/env.js";
@@ -735,9 +736,10 @@ describe("config.patch ID-keyed arrays", () => {
 
 describe("config.patch model input normalization", () => {
   it("uses write-snapshot policies before merging manifest-backed model IDs", async () => {
-    modelNormalizationPluginMetadata = {
+    modelNormalizationPluginMetadata = createPluginMetadataSnapshotFixture({
       plugins: [
         {
+          id: "myproxy-normalizer",
           modelIdNormalization: {
             providers: {
               myproxy: { aliases: { latest: "modern-model" }, prefixWhenBare: "vendor" },
@@ -745,7 +747,7 @@ describe("config.patch model input normalization", () => {
           },
         },
       ],
-    } as unknown as PluginMetadataSnapshot;
+    });
     storedConfig = {
       models: {
         providers: {

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -15,7 +15,6 @@ import {
   validateConfigSetParams,
 } from "../../../packages/gateway-protocol/src/index.js";
 import { readAgentRosterProperty } from "../../agents/agent-scope-config.js";
-import { resolveModelIdNormalizationPolicies } from "../../config/io.context.js";
 import {
   createConfigIO,
   parseConfigJson5,
@@ -931,7 +930,7 @@ export const configHandlers: GatewayRequestHandlers = {
       "config.set",
       snapshot,
       respond,
-      resolveModelIdNormalizationPolicies(writeOptions.basePluginMetadataSnapshot),
+      writeOptions.basePluginMetadataSnapshot?.owners.modelIdNormalizationPolicies,
     );
     if (!parsed) {
       return;
@@ -995,9 +994,8 @@ export const configHandlers: GatewayRequestHandlers = {
       return;
     }
     const { snapshot, writeOptions } = writeSnapshot;
-    const modelIdNormalizationPolicies = resolveModelIdNormalizationPolicies(
-      writeOptions.basePluginMetadataSnapshot,
-    );
+    const modelIdNormalizationPolicies =
+      writeOptions.basePluginMetadataSnapshot?.owners.modelIdNormalizationPolicies;
     if (!snapshot.valid) {
       respond(
         false,
@@ -1219,7 +1217,7 @@ export const configHandlers: GatewayRequestHandlers = {
       "config.apply",
       snapshot,
       respond,
-      resolveModelIdNormalizationPolicies(writeOptions.basePluginMetadataSnapshot),
+      writeOptions.basePluginMetadataSnapshot?.owners.modelIdNormalizationPolicies,
     );
     if (!parsed) {
       return;

--- a/src/gateway/server-methods/models-list-configured-static.ts
+++ b/src/gateway/server-methods/models-list-configured-static.ts
@@ -26,7 +26,7 @@ export function includeConfiguredStaticCatalogEntries(params: {
     defaultModel: params.defaultModel,
     agentId: params.agentId,
     ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
-    manifestPlugins: params.metadataSnapshot.plugins,
+    manifestPlugins: params.metadataSnapshot,
   });
   const configuredKeys = new Set(
     [...policy.configuredKeys].map((key) => {

--- a/src/gateway/server-methods/models-list-result.plugin-runtime.test.ts
+++ b/src/gateway/server-methods/models-list-result.plugin-runtime.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model-catalog.types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import {
   buildModelsListResult,
@@ -25,17 +26,11 @@ function catalogEntry(id: string): ModelCatalogEntry {
 }
 
 function preparedMetadataSnapshot() {
-  return {
-    index: {
-      plugins: [
-        {
-          enabled: true,
-          syntheticAuthRefs: ["custom"],
-        },
-      ],
-    },
+  return createPluginMetadataSnapshotFixture({
     plugins: [
       {
+        id: "custom",
+        syntheticAuthRefs: ["custom"],
         modelIdNormalization: {
           providers: {
             custom: {
@@ -47,7 +42,7 @@ function preparedMetadataSnapshot() {
         },
       },
     ],
-  } as never;
+  });
 }
 
 describe("models.list plugin metadata handoff", () => {

--- a/src/gateway/server-methods/models-list-result.provider-outcomes.test.ts
+++ b/src/gateway/server-methods/models-list-result.provider-outcomes.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { markPreparedModelCatalogFull } from "../../agents/prepared-model-runtime.full-catalog.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../../plugins/plugin-metadata.test-support.js";
 import {
   type PreparedGatewayModelCatalogSnapshot,
   registerGatewayModelCatalogPrivateAccess,
@@ -12,11 +13,7 @@ import {
 } from "./models-list-result.js";
 import type { GatewayRequestContext } from "./types.js";
 
-const metadataSnapshot = {
-  index: { plugins: [] },
-  manifestRegistry: { plugins: [] },
-  plugins: [],
-} as never;
+const metadataSnapshot = createPluginMetadataSnapshotFixture();
 const emptyAuthStore = { version: 1, profiles: {} } as const;
 
 describe("models.list provider catalog outcomes", () => {

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -575,7 +575,7 @@ export async function prepareModelsListResult(
     agentId,
     defaultModel,
     ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
-    manifestPlugins: metadataSnapshot.plugins,
+    manifestPlugins: metadataSnapshot,
   }).byKey;
   if (view === "provider-config") {
     const sourceConfig = getRuntimeConfigSourceSnapshot() ?? cfg;
@@ -636,7 +636,7 @@ export async function prepareModelsListResult(
     defaultModel,
     agentId,
     ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
-    manifestPlugins: metadataSnapshot?.plugins,
+    manifestPlugins: metadataSnapshot,
   });
   const evaluateEntry =
     (usedPreloadedCatalog ? params.catalogProjector?.evaluateEntry : undefined) ??

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -140,6 +140,7 @@ const modelPluginMetadataSnapshot = vi.hoisted(() => {
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
     metrics: {
       registrySnapshotMs: 0,

--- a/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.sticky-model.test.ts
@@ -40,6 +40,7 @@ const emptyPluginMetadataSnapshot = vi.hoisted(() => ({
     setupProviders: new Map(),
     commandAliases: new Map(),
     contracts: new Map(),
+    modelIdNormalizationPolicies: new Map(),
   },
   metrics: {
     registrySnapshotMs: 0,

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -226,6 +226,7 @@ function createLookUpTableForTest(params: {
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
     startup: {
       channelPluginIds: [],

--- a/src/gateway/server-startup-config.recovery.test.ts
+++ b/src/gateway/server-startup-config.recovery.test.ts
@@ -26,6 +26,7 @@ const pluginMetadataSnapshot = vi.hoisted((): PluginMetadataSnapshot => {
     setupProviders: new Map(),
     commandAliases: new Map(),
     contracts: new Map(),
+    modelIdNormalizationPolicies: new Map(),
   };
   const zeroMetrics = {
     registrySnapshotMs: 0,

--- a/src/gateway/server-startup-plugins.test.ts
+++ b/src/gateway/server-startup-plugins.test.ts
@@ -75,6 +75,7 @@ const pluginMetadataSnapshot = vi.hoisted((): PluginMetadataSnapshot => {
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
     metrics: {
       registrySnapshotMs: 0,

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -222,6 +222,7 @@ function createGatewayPluginMetadataSnapshot(config: OpenClawConfig): PluginMeta
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
     metrics: {
       registrySnapshotMs: 0,

--- a/src/gateway/worker-environments/inference-runtime.ts
+++ b/src/gateway/worker-environments/inference-runtime.ts
@@ -379,14 +379,14 @@ async function resolveApprovedModel(params: {
       const defaultModel = dependencies.resolveDefaultModel({
         cfg: lifecycleConfig,
         agentId: target.agentId,
-        manifestPlugins: manifestSnapshot.plugins,
+        manifestPlugins: manifestSnapshot,
         ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
       });
       const aliasIndex = buildModelAliasIndex({
         cfg: lifecycleConfig,
         agentId: target.agentId,
         defaultProvider: defaultModel.provider,
-        manifestPlugins: manifestSnapshot.plugins,
+        manifestPlugins: manifestSnapshot,
         ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
       });
       const resolved = resolveModelRefFromString({
@@ -395,7 +395,7 @@ async function resolveApprovedModel(params: {
         raw: rawRef,
         defaultProvider: defaultModel.provider,
         aliasIndex,
-        manifestPlugins: manifestSnapshot.plugins,
+        manifestPlugins: manifestSnapshot,
         ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
       });
       if (
@@ -413,7 +413,7 @@ async function resolveApprovedModel(params: {
         defaultProvider: defaultModel.provider,
         defaultModel: `${defaultModel.provider}/${defaultModel.model}`,
         agentId: target.agentId,
-        manifestPlugins: manifestSnapshot.plugins,
+        manifestPlugins: manifestSnapshot,
         ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
       });
       const resolvedKey = modelCatalogLogicalKey({

--- a/src/infra/dotenv-workspace-blocklist.test.ts
+++ b/src/infra/dotenv-workspace-blocklist.test.ts
@@ -59,6 +59,7 @@ function emptyOwnerMaps(): PluginMetadataSnapshot["owners"] {
     setupProviders: new Map(),
     commandAliases: new Map(),
     contracts: new Map(),
+    modelIdNormalizationPolicies: new Map(),
   };
 }
 

--- a/src/model-catalog/pricing.ts
+++ b/src/model-catalog/pricing.ts
@@ -2,7 +2,11 @@ import { isIP } from "node:net";
 import type { RemoteModelCatalogPricing } from "@openclaw/model-catalog-core";
 import { MODEL_PRICING_SOURCES } from "@openclaw/model-catalog-core/model-catalog-pricing";
 import type { ModelCatalogCost } from "@openclaw/model-catalog-core/model-catalog-types";
-import { modelKey, normalizeModelRef } from "../agents/model-selection.js";
+import {
+  modelKey,
+  normalizeModelRef,
+  type ModelManifestNormalizationContext,
+} from "../agents/model-selection.js";
 import type { ModelDefinitionConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isInstalledPluginEnabled } from "../plugins/installed-plugin-index.js";
@@ -15,7 +19,7 @@ import { planEffectiveModelCatalogRows } from "./index.js";
 import { getRemoteModelCatalogPricing } from "./remote-overlay.js";
 
 type PricingValue = RemoteModelCatalogPricing | ModelCatalogCost;
-type ManifestPlugins = readonly PluginManifestRegistry["plugins"][number][];
+type ManifestPlugins = ModelManifestNormalizationContext["manifestPlugins"];
 type ExternalPricingPolicy = {
   external: boolean;
   authoritative: boolean;
@@ -94,7 +98,7 @@ function buildPricingContext(config: OpenClawConfig): PricingContext {
   const hosted = snapshot ? (getRemoteModelCatalogPricing(config) ?? {}) : {};
   const normalizedHosted = new Map<string, RemoteModelCatalogPricing>();
   for (const [key, pricing] of Object.entries(hosted).toSorted(([a], [b]) => a.localeCompare(b))) {
-    const normalized = normalizedHostedKey(key, snapshot?.plugins);
+    const normalized = normalizedHostedKey(key, snapshot);
     if (normalized && !normalizedHosted.has(normalized)) {
       normalizedHosted.set(normalized, pricing);
     }
@@ -212,11 +216,9 @@ export function resolveCatalogModelPricing(params: {
   const config = params.config ?? EMPTY_CONFIG;
   const context = getPricingContext(config);
   const normalized = normalizeModelRef(params.provider, params.model, {
-    manifestPlugins: context.snapshot?.plugins,
+    manifestPlugins: context.snapshot,
   });
-  if (
-    !allowsHostedPricing(config, normalized.provider, normalized.model, context.snapshot?.plugins)
-  ) {
+  if (!allowsHostedPricing(config, normalized.provider, normalized.model, context.snapshot)) {
     return undefined;
   }
   const key = modelKey(normalized.provider, normalized.model);

--- a/src/plugin-sdk/agent-runtime-model-catalog-contract.test.ts
+++ b/src/plugin-sdk/agent-runtime-model-catalog-contract.test.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, expectTypeOf, it, vi } from "vitest";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 
 const mocks = vi.hoisted(() => ({
   getSnapshot: vi.fn(),
@@ -64,6 +65,14 @@ describe("agent-runtime model catalog compatibility", () => {
   });
 
   it("accepts legacy options without overriding lifecycle metadata", async () => {
+    type LegacyMetadataSnapshot = Omit<PluginMetadataSnapshot, "owners"> & {
+      owners: Omit<PluginMetadataSnapshot["owners"], "modelIdNormalizationPolicies">;
+    };
+    type AcceptedMetadataSnapshot = NonNullable<
+      NonNullable<Parameters<typeof loadModelCatalog>[0]>["metadataSnapshot"]
+    >;
+    expectTypeOf<LegacyMetadataSnapshot>().toMatchTypeOf<AcceptedMetadataSnapshot>();
+    expectTypeOf<PluginMetadataSnapshot>().toMatchTypeOf<AcceptedMetadataSnapshot>();
     mocks.loadCatalog.mockResolvedValue([]);
     const config = {};
     const env = { OPENCLAW_STATE_DIR: "/tmp/plugin-state" };

--- a/src/plugin-sdk/agent-runtime.ts
+++ b/src/plugin-sdk/agent-runtime.ts
@@ -42,7 +42,11 @@ type LoadModelCatalogCompatibilityParams = LoadPreparedModelCatalogParams & {
   /** @deprecated Use getPreparedModelCatalogSnapshot for new nonblocking readers. */
   cacheOnly?: boolean;
   /** @deprecated Plugin metadata belongs to the published lifecycle generation. */
-  metadataSnapshot?: PluginMetadataSnapshot;
+  metadataSnapshot?: Omit<PluginMetadataSnapshot, "owners"> & {
+    // Shipped callers may supply owner maps from before normalization policies were prepared.
+    owners: Omit<PluginMetadataSnapshot["owners"], "modelIdNormalizationPolicies"> &
+      Partial<Pick<PluginMetadataSnapshot["owners"], "modelIdNormalizationPolicies">>;
+  };
 };
 
 /** @deprecated Use loadPreparedModelCatalog or getPreparedModelCatalogSnapshot. */

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -870,6 +870,7 @@ describe("plugin-sdk facade runtime", () => {
           setupProviders: new Map(),
           commandAliases: new Map(),
           contracts: new Map(),
+          modelIdNormalizationPolicies: new Map(),
         },
         metrics: {
           registrySnapshotMs: 0,

--- a/src/plugins/capability-provider-runtime.test.ts
+++ b/src/plugins/capability-provider-runtime.test.ts
@@ -473,6 +473,7 @@ describe("resolvePluginCapabilityProviders", () => {
         setupProviders: new Map(),
         commandAliases: new Map(),
         contracts: new Map(),
+        modelIdNormalizationPolicies: new Map(),
       },
       metrics: {
         registrySnapshotMs: 0,
@@ -822,6 +823,7 @@ describe("resolvePluginCapabilityProviders", () => {
         setupProviders: new Map(),
         commandAliases: new Map(),
         contracts: new Map(),
+        modelIdNormalizationPolicies: new Map(),
       },
       metrics: {
         registrySnapshotMs: 0,

--- a/src/plugins/current-plugin-metadata-snapshot.test.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.test.ts
@@ -2,7 +2,10 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { normalizeConfiguredProviderCatalogModelId } from "@openclaw/model-catalog-core/provider-model-id-normalization";
+import {
+  collectManifestModelIdNormalizationPolicies,
+  normalizeConfiguredProviderCatalogModelId,
+} from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { describe, expect, it, vi } from "vitest";
 import {
   getCurrentPluginMetadataSnapshot,
@@ -19,7 +22,11 @@ import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import * as pluginControlPlaneContext from "./plugin-control-plane-context.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
-import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
+import {
+  restorePluginMetadataSnapshot,
+  type PluginMetadataSnapshot,
+} from "./plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "./plugin-metadata.test-support.js";
 import { classifyProviderFailoverSignalWithPlugin } from "./provider-failover.js";
 import { resolveProviderRuntimePlugin } from "./provider-hook-runtime.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
@@ -92,6 +99,7 @@ function createSnapshot(
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: collectManifestModelIdNormalizationPolicies(plugins),
     },
     metrics: {
       registrySnapshotMs: 0,
@@ -499,15 +507,27 @@ describe("current plugin metadata snapshot", () => {
 
   it("rejects configless default-discovery reuse for snapshots created with load paths", () => {
     const config = { plugins: { allow: ["demo"], load: { paths: ["/plugins/one"] } } };
-    const snapshot = createSnapshot({ config });
+    const snapshot = createSnapshot({ config, normalizationAlias: "scoped" });
     setCurrentPluginMetadataSnapshot(snapshot, { config });
 
-    expect(
-      getCurrentPluginMetadataSnapshot({
-        allowWorkspaceScopedSnapshot: true,
-        requireDefaultDiscoveryContext: true,
-      }),
-    ).toBeUndefined();
+    try {
+      expect(
+        getCurrentPluginMetadataSnapshot({
+          allowWorkspaceScopedSnapshot: true,
+          requireDefaultDiscoveryContext: true,
+        }),
+      ).toBeUndefined();
+      expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("raw");
+
+      const lease = installTemporaryCurrentPluginMetadataSnapshot(
+        createSnapshot({ normalizationAlias: "temporary" }),
+      );
+      expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("temporary");
+      expect(lease.release()).toBe(true);
+      expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("raw");
+    } finally {
+      clearCurrentPluginMetadataSnapshot();
+    }
   });
 
   it("accepts configless default-discovery reuse for snapshots created without load paths", () => {
@@ -767,26 +787,28 @@ describe("current plugin metadata snapshot", () => {
   });
 
   it("does not release a temporary lease over a newer publication or lifecycle clear", () => {
-    const original = createSnapshot();
-    const temporary = createSnapshot();
-    const newer = createSnapshot();
+    const original = createSnapshot({ normalizationAlias: "original" });
+    const temporary = createSnapshot({ normalizationAlias: "temporary" });
+    const newer = createSnapshot({ normalizationAlias: "newer" });
     setCurrentPluginMetadataSnapshot(original);
 
     const clearedLease = installTemporaryCurrentPluginMetadataSnapshot(temporary);
     clearCurrentPluginMetadataSnapshot();
     expect(clearedLease.release()).toBe(false);
     expect(getCurrentPluginMetadataSnapshot()).toBeUndefined();
+    expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("raw");
 
     const replacedLease = installTemporaryCurrentPluginMetadataSnapshot(temporary);
     setGatewayPluginMetadataSnapshot(newer);
     expect(replacedLease.release()).toBe(false);
     expect(getCurrentPluginMetadataSnapshot()).toBe(newer);
+    expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("newer");
   });
 
   it("unwinds nested temporary leases when they release out of order", () => {
-    const original = createSnapshot();
-    const outerSnapshot = createSnapshot();
-    const innerSnapshot = createSnapshot();
+    const original = createSnapshot({ normalizationAlias: "original" });
+    const outerSnapshot = createSnapshot({ normalizationAlias: "outer" });
+    const innerSnapshot = createSnapshot({ normalizationAlias: "inner" });
     setCurrentPluginMetadataSnapshot(original);
 
     const outer = installTemporaryCurrentPluginMetadataSnapshot(outerSnapshot);
@@ -794,26 +816,60 @@ describe("current plugin metadata snapshot", () => {
 
     expect(outer.release()).toBe(false);
     expect(getCurrentPluginMetadataSnapshot()).toBe(innerSnapshot);
+    expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("inner");
     expect(inner.release()).toBe(true);
     expect(getCurrentPluginMetadataSnapshot()).toBe(original);
+    expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("original");
     expect(inner.release()).toBe(false);
   });
 
-  it("restores the exact captured model normalization records", () => {
-    const original = createSnapshot({ normalizationAlias: "original" });
-    const temporary = createSnapshot({ normalizationAlias: "temporary" });
+  it("publishes and restores prepared model policies without enumerating declarations", () => {
+    const enumerate = vi.fn((target: object) => Reflect.ownKeys(target));
+    const prepare = (alias: string) =>
+      restorePluginMetadataSnapshot(
+        createPluginMetadataSnapshotFixture({
+          plugins: [
+            {
+              id: "fixture",
+              modelIdNormalization: {
+                providers: new Proxy(
+                  { fixture: { aliases: { raw: alias } } },
+                  { ownKeys: (target) => enumerate(target) },
+                ),
+              },
+            },
+          ],
+        }),
+      );
+    const original = prepare("original");
+    const temporary = prepare("temporary");
+    const empty = restorePluginMetadataSnapshot(createPluginMetadataSnapshotFixture());
     const env = {
       HOME: "/home/original-snapshot",
       OPENCLAW_HOME: undefined,
     } as NodeJS.ProcessEnv;
-    setCurrentPluginMetadataSnapshot(original, { env });
-    expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("original");
+    enumerate.mockClear();
 
-    const lease = installTemporaryCurrentPluginMetadataSnapshot(temporary);
-    expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("temporary");
+    try {
+      setCurrentPluginMetadataSnapshot(original, { env });
+      expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("original");
 
-    expect(lease.release()).toBe(true);
-    expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("original");
+      const lease = installTemporaryCurrentPluginMetadataSnapshot(temporary);
+      expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("temporary");
+
+      const emptyLease = installTemporaryCurrentPluginMetadataSnapshot(empty);
+      expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("raw");
+      expect(emptyLease.release()).toBe(true);
+      expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("temporary");
+
+      expect(lease.release()).toBe(true);
+      expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("original");
+      clearCurrentPluginMetadataSnapshot();
+      expect(normalizeConfiguredProviderCatalogModelId("fixture", "raw")).toBe("raw");
+      expect(enumerate).not.toHaveBeenCalled();
+    } finally {
+      clearCurrentPluginMetadataSnapshot();
+    }
   });
 
   it("clears the current snapshot when the persisted installed index changes", () => {

--- a/src/plugins/current-plugin-metadata-snapshot.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.ts
@@ -159,7 +159,9 @@ function publishCurrentPluginMetadataSnapshot(
     configFingerprint,
     compatiblePolicyHashes,
     compatibleConfigFingerprints,
-    owner === "gateway" || defaultDiscoveryCompatible ? snapshot?.plugins : undefined,
+    owner === "gateway" || defaultDiscoveryCompatible
+      ? snapshot?.owners.modelIdNormalizationPolicies
+      : undefined,
     owner,
   );
   if (!snapshot) {
@@ -239,7 +241,7 @@ function restoreCapturedCurrentPluginMetadataSnapshotState(
     state.configFingerprint,
     state.compatiblePolicyHashes,
     state.compatibleConfigFingerprints,
-    state.manifestModelIdNormalizationRecords,
+    state.modelIdNormalizationPolicies,
     state.owner,
   );
 }

--- a/src/plugins/current-plugin-metadata-state.ts
+++ b/src/plugins/current-plugin-metadata-state.ts
@@ -1,8 +1,5 @@
 // Holds current plugin metadata snapshots for process-scoped consumers.
-import {
-  setCurrentManifestModelIdNormalizationRecords,
-  type ManifestModelIdNormalizationRecord,
-} from "@openclaw/model-catalog-core/provider-model-id-normalization";
+import { setCurrentManifestModelIdNormalizationPolicies } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { getPluginCache, getProcessPluginCache } from "./plugin-cache.js";
 import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
@@ -34,7 +31,7 @@ export function setCurrentPluginMetadataSnapshotState(
   configFingerprint: string | undefined,
   compatiblePolicyHashes?: readonly string[],
   compatibleConfigFingerprints?: readonly string[],
-  manifestModelIdNormalizationRecords?: readonly ManifestModelIdNormalizationRecord[],
+  modelIdNormalizationPolicies?: PluginMetadataSnapshot["owners"]["modelIdNormalizationPolicies"],
   owner: "gateway" | "operation" = "operation",
 ): CurrentPluginMetadataSnapshotRevision {
   const state = getProcessPluginCache().metadata.current;
@@ -43,10 +40,8 @@ export function setCurrentPluginMetadataSnapshotState(
   state.configFingerprint = snapshot ? configFingerprint : undefined;
   state.compatiblePolicyHashes = snapshot ? compatiblePolicyHashes : undefined;
   state.compatibleConfigFingerprints = snapshot ? compatibleConfigFingerprints : undefined;
-  state.manifestModelIdNormalizationRecords = snapshot
-    ? manifestModelIdNormalizationRecords
-    : undefined;
-  setCurrentManifestModelIdNormalizationRecords(state.manifestModelIdNormalizationRecords);
+  state.modelIdNormalizationPolicies = snapshot ? modelIdNormalizationPolicies : undefined;
+  setCurrentManifestModelIdNormalizationPolicies(state.modelIdNormalizationPolicies);
   state.revision = Symbol("plugin-metadata-snapshot");
   return state.revision;
 }
@@ -59,8 +54,8 @@ function clearCurrentPluginMetadataSnapshotState(): CurrentPluginMetadataSnapsho
   state.configFingerprint = undefined;
   state.compatiblePolicyHashes = undefined;
   state.compatibleConfigFingerprints = undefined;
-  state.manifestModelIdNormalizationRecords = undefined;
-  setCurrentManifestModelIdNormalizationRecords(undefined);
+  state.modelIdNormalizationPolicies = undefined;
+  setCurrentManifestModelIdNormalizationPolicies(undefined);
   state.revision = Symbol("plugin-metadata-snapshot");
   return state.revision;
 }
@@ -96,16 +91,8 @@ export function getProcessGatewayPluginMetadataSnapshot(): PluginMetadataSnapsho
   return undefined;
 }
 
-/** Returns the process-current plugin metadata snapshot state. */
-export function getCurrentPluginMetadataSnapshotState(): {
-  snapshot: unknown;
-  owner: "gateway" | "operation";
-  configFingerprint: string | undefined;
-  compatiblePolicyHashes: readonly string[] | undefined;
-  compatibleConfigFingerprints: readonly string[] | undefined;
-  manifestModelIdNormalizationRecords: readonly ManifestModelIdNormalizationRecord[] | undefined;
-  revision: CurrentPluginMetadataSnapshotRevision;
-} {
+/** Captures the current snapshot and the policies eligible for process-wide publication. */
+export function getCurrentPluginMetadataSnapshotState() {
   const state = getProcessPluginCache().metadata.current;
   return {
     snapshot: state.snapshot,
@@ -113,7 +100,7 @@ export function getCurrentPluginMetadataSnapshotState(): {
     configFingerprint: state.configFingerprint,
     compatiblePolicyHashes: state.compatiblePolicyHashes,
     compatibleConfigFingerprints: state.compatibleConfigFingerprints,
-    manifestModelIdNormalizationRecords: state.manifestModelIdNormalizationRecords,
+    modelIdNormalizationPolicies: state.modelIdNormalizationPolicies,
     revision: state.revision,
   };
 }

--- a/src/plugins/manifest-model-id-normalization.test.ts
+++ b/src/plugins/manifest-model-id-normalization.test.ts
@@ -1,10 +1,12 @@
 // Verifies model IDs declared by plugin manifests are normalized.
 import fs from "node:fs";
 import path from "node:path";
+import { normalizeConfiguredProviderCatalogModelId } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { withPluginMetadataSnapshotScope } from "./current-plugin-metadata-snapshot.js";
+import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata.test-support.js";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store-write.js";
 import { listOpenClawPluginManifestMetadata } from "./manifest-metadata-scan.js";
 import { normalizeProviderModelIdWithManifest } from "./manifest-model-id-normalization.js";
@@ -119,6 +121,7 @@ describe("manifest model id normalization", () => {
     deleteTestEnvValue("OPENCLAW_BUNDLED_PLUGINS_DIR");
     const snapshot = resolvePluginMetadataSnapshot({ config: {}, env: process.env });
     const narrowed = projectPluginMetadataSnapshot(snapshot, []);
+    setCurrentPluginMetadataSnapshot(snapshot, { config: {}, env: process.env });
     const normalize = (view: typeof snapshot) =>
       withPluginMetadataSnapshotScope(view, () => normalizeDemoModel(), {
         trustConfigIdentity: true,
@@ -126,6 +129,16 @@ describe("manifest model id normalization", () => {
 
     expect(normalize(snapshot)).toBe("scoped/demo-model");
     expect(normalize(narrowed)).toBeUndefined();
+    expect(normalizeConfiguredProviderCatalogModelId("demo", "demo-model")).toBe(
+      "scoped/demo-model",
+    );
+    expect(
+      normalizeConfiguredProviderCatalogModelId(
+        "demo",
+        "demo-model",
+        narrowed.owners.modelIdNormalizationPolicies,
+      ),
+    ).toBe("demo-model");
     expect(normalize(snapshot)).toBe("scoped/demo-model");
   });
 

--- a/src/plugins/manifest-model-id-normalization.ts
+++ b/src/plugins/manifest-model-id-normalization.ts
@@ -2,6 +2,7 @@
 import {
   collectManifestModelIdNormalizationPolicies,
   normalizeProviderModelIdWithPolicies,
+  type ManifestModelIdNormalizationProvider,
 } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
@@ -12,20 +13,29 @@ import {
   getCurrentPluginMetadataSnapshotRuntime,
   resolvePluginMetadataSnapshotRuntime,
 } from "./plugin-metadata-snapshot.runtime.js";
+import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
 import { getActivePluginRegistryWorkspaceDirFromStateCore } from "./runtime-workspace-state.js";
+
+/** Caller-owned declarations or facts from an already selected metadata snapshot. */
+export type ManifestModelIdNormalizationSource =
+  | readonly Pick<PluginManifestRecord, "modelIdNormalization">[]
+  | { owners: Pick<PluginMetadataSnapshot["owners"], "modelIdNormalizationPolicies"> };
 
 type ManifestModelIdNormalizationLookupParams = {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
-  plugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
+  plugins?: ManifestModelIdNormalizationSource;
 };
 
-function resolveManifestModelIdNormalizationRecords(
+export function resolveManifestModelIdNormalizationPolicies(
   params: ManifestModelIdNormalizationLookupParams = {},
-): readonly Pick<PluginManifestRecord, "modelIdNormalization">[] {
+): ReadonlyMap<string, ManifestModelIdNormalizationProvider> {
   if (params.plugins) {
-    return params.plugins;
+    // Prepared views keep their selected generation; caller-owned arrays remain live inputs.
+    return "owners" in params.plugins
+      ? params.plugins.owners.modelIdNormalizationPolicies
+      : collectManifestModelIdNormalizationPolicies(params.plugins);
   }
   const env = params.env ?? process.env;
   const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromStateCore();
@@ -37,7 +47,7 @@ function resolveManifestModelIdNormalizationRecords(
       requireDefaultDiscoveryContext: true,
     });
     if (currentSnapshot) {
-      return currentSnapshot.plugins;
+      return currentSnapshot.owners.modelIdNormalizationPolicies;
     }
   }
   const snapshot = resolvePluginMetadataSnapshotRuntime({
@@ -46,7 +56,7 @@ function resolveManifestModelIdNormalizationRecords(
     workspaceDir,
     allowWorkspaceScopedCurrent: true,
   });
-  return snapshot?.plugins ?? [];
+  return snapshot ? snapshot.owners.modelIdNormalizationPolicies : new Map();
 }
 
 /** Normalizes a provider model id using plugin manifest-declared model-id policies. */
@@ -55,7 +65,7 @@ export function normalizeProviderModelIdWithManifest(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
-  plugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
+  plugins?: ManifestModelIdNormalizationSource;
   context: {
     provider: string;
     modelId: string;
@@ -63,11 +73,7 @@ export function normalizeProviderModelIdWithManifest(params: {
 }): string | undefined {
   return normalizeProviderModelIdWithPolicies({
     provider: params.provider,
-    policies: collectManifestModelIdNormalizationPolicies(
-      resolveManifestModelIdNormalizationRecords(params),
-    ),
-    context: {
-      modelId: params.context.modelId,
-    },
+    policies: resolveManifestModelIdNormalizationPolicies(params),
+    context: params.context,
   });
 }

--- a/src/plugins/plugin-cache-metadata.ts
+++ b/src/plugins/plugin-cache-metadata.ts
@@ -1,4 +1,3 @@
-import type { ManifestModelIdNormalizationRecord } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import type { BundledStaticCatalogState } from "../agents/embedded-agent-runner/model.static-catalog.types.js";
 import type { BundledChannelCatalogEntry } from "../channels/bundled-channel-catalog.types.js";
 import type { ManifestChannelPlugin } from "../channels/plugins/manifest-channel-plugin.types.js";
@@ -15,7 +14,9 @@ type CurrentPluginMetadataCacheState = {
   configFingerprint: string | undefined;
   compatiblePolicyHashes: readonly string[] | undefined;
   compatibleConfigFingerprints: readonly string[] | undefined;
-  manifestModelIdNormalizationRecords: readonly ManifestModelIdNormalizationRecord[] | undefined;
+  modelIdNormalizationPolicies:
+    | PluginMetadataSnapshot["owners"]["modelIdNormalizationPolicies"]
+    | undefined;
   revision: symbol;
   configIdentities: WeakSet<OpenClawConfig>;
 };
@@ -54,7 +55,7 @@ export function createPluginCacheMetadata(): PluginCacheMetadata {
         configFingerprint: undefined,
         compatiblePolicyHashes: undefined,
         compatibleConfigFingerprints: undefined,
-        manifestModelIdNormalizationRecords: undefined,
+        modelIdNormalizationPolicies: undefined,
         revision: Symbol("plugin-metadata-snapshot"),
         configIdentities: new WeakSet(),
       },

--- a/src/plugins/plugin-metadata-provider-facts.ts
+++ b/src/plugins/plugin-metadata-provider-facts.ts
@@ -1,4 +1,5 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import { collectManifestModelIdNormalizationPolicies } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLowercaseStringOrEmpty,
@@ -152,6 +153,7 @@ export function buildPluginMetadataProviderFacts(plugins: readonly PluginManifes
   return {
     providerEndpoints,
     providerRequests,
+    modelIdNormalizationPolicies: collectManifestModelIdNormalizationPolicies(plugins),
     providerAuthAliases: buildPluginMetadataProviderAuthAliases(plugins),
   };
 }

--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -1,5 +1,8 @@
 // Verifies lifecycle snapshot loading, ownership facts, and immutable boundaries.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveDefaultModelForAgent } from "../agents/model-selection-config.js";
+import { buildConfiguredModelCatalog } from "../agents/model-selection-shared.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   adoptCurrentPluginMetadataSnapshotIfAbsent,
   getCurrentPluginMetadataSnapshot,
@@ -14,6 +17,7 @@ import {
 } from "./current-plugin-metadata.test-support.js";
 import type { PluginDiscoveryResult } from "./discovery.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
+import { normalizeProviderModelIdWithManifest } from "./manifest-model-id-normalization.js";
 import { loadPluginManifestRegistryCore } from "./manifest-registry.js";
 import {
   createPluginCache,
@@ -28,6 +32,7 @@ import {
   resolvePluginMetadataSnapshot,
   restorePluginMetadataSnapshot,
 } from "./plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "./plugin-metadata.test-support.js";
 
 const { loadPluginRegistrySnapshotWithMetadata, loadPluginManifestRegistryForInstalledIndex } =
   vi.hoisted(() => {
@@ -709,6 +714,103 @@ describe("plugin metadata snapshot", () => {
     },
   );
 
+  it("reuses prepared model normalization policies without enumerating declarations", () => {
+    const enumeratePolicies = vi.fn(Reflect.ownKeys);
+    const snapshot = restorePluginMetadataSnapshot(
+      createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "first",
+            providers: ["demo"],
+            modelIdNormalization: {
+              providers: { " Demo ": { aliases: { latest: "first-model" } } },
+            },
+          },
+          {
+            id: "last",
+            providers: ["demo"],
+            modelIdNormalization: {
+              providers: new Proxy(
+                { demo: { aliases: { latest: "middle-model", "middle-model": "final-model" } } },
+                { ownKeys: (target) => enumeratePolicies(target) },
+              ),
+            },
+          },
+        ],
+      }),
+    );
+    enumeratePolicies.mockClear();
+
+    const cfg: OpenClawConfig = {
+      agents: { defaults: { model: { primary: "demo/latest" } } },
+      models: {
+        providers: {
+          demo: {
+            api: "openai-completions",
+            baseUrl: "http://127.0.0.1",
+            models: [
+              {
+                id: "latest",
+                name: "Latest",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                maxTokens: 1024,
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    withPluginMetadataSnapshotScope(
+      snapshot,
+      () => {
+        for (let repeat = 0; repeat < 4; repeat += 1) {
+          expect(
+            normalizeProviderModelIdWithManifest({
+              provider: " DEMO ",
+              context: { provider: "demo", modelId: "latest" },
+            }),
+          ).toBe("middle-model");
+          expect(
+            normalizeProviderModelIdWithManifest({
+              provider: "missing",
+              context: { provider: "missing", modelId: "latest" },
+            }),
+          ).toBeUndefined();
+          expect(resolveDefaultModelForAgent({ cfg })).toEqual({
+            provider: "demo",
+            model: "final-model",
+          });
+          expect(buildConfiguredModelCatalog({ cfg })).toMatchObject([
+            { provider: "demo", id: "middle-model" },
+          ]);
+        }
+        const context = { provider: "demo", modelId: "latest" };
+        expect(
+          normalizeProviderModelIdWithManifest({ provider: "demo", context, plugins: [] }),
+        ).toBeUndefined();
+        const providers = { demo: { aliases: { latest: "explicit-model" } } };
+        const plugins = [{ modelIdNormalization: { providers } }];
+        expect(normalizeProviderModelIdWithManifest({ provider: "demo", context, plugins })).toBe(
+          "explicit-model",
+        );
+        plugins.splice(0, 1, {
+          modelIdNormalization: {
+            providers: { demo: { aliases: { latest: "changed-explicit-model" } } },
+          },
+        });
+        expect(normalizeProviderModelIdWithManifest({ provider: "demo", context, plugins })).toBe(
+          "changed-explicit-model",
+        );
+      },
+      { trustConfigIdentity: true },
+    );
+
+    expect(enumeratePolicies).not.toHaveBeenCalled();
+  });
+
   it("prepares normalized CLI ownership, provider endpoint, and request facts", () => {
     const index = makeIndex();
     const registry = makeManifestRegistry();
@@ -770,11 +872,23 @@ describe("plugin metadata snapshot", () => {
         diagnostics: [],
       });
 
+      const registry = makeManifestRegistry();
+      registry.plugins = registry.plugins.map((plugin) => ({
+        ...plugin,
+        modelIdNormalization: { providers: { demo: { aliases: { raw: "prepared-model" } } } },
+      }));
+      loadPluginManifestRegistryForInstalledIndex.mockReturnValue(registry);
       const loaded = loadPluginMetadataSnapshot({ config: {}, env: {}, index });
       const { normalizePluginId: _normalizePluginId, ...transfer } = loaded;
       const snapshot = worker ? restorePluginMetadataSnapshot(structuredClone(transfer)) : loaded;
       expect(snapshot.normalizePluginId(" DEMO ")).toBe("demo");
       expect(snapshot.owners.providers.get("demo")).toEqual(["demo"]);
+      expect(snapshot.owners.modelIdNormalizationPolicies.get("demo")).toEqual({
+        aliases: { raw: "prepared-model" },
+      });
+      expect(() =>
+        (snapshot.owners.modelIdNormalizationPolicies as Map<string, unknown>).clear(),
+      ).toThrow("Plugin metadata snapshots are immutable");
       expect(() => (snapshot.owners.providers as Map<string, string[]>).set("other", [])).toThrow(
         "Plugin metadata snapshots are immutable",
       );

--- a/src/plugins/plugin-metadata-snapshot.types.ts
+++ b/src/plugins/plugin-metadata-snapshot.types.ts
@@ -4,6 +4,7 @@ import type { InstalledPluginIndex } from "./installed-plugin-index-types.js";
 import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.types.js";
 import type {
   PluginDiagnostic,
+  PluginManifestModelIdNormalizationProvider,
   PluginManifestProviderEndpoint,
   PluginManifestProviderRequestProvider,
 } from "./manifest-types.js";
@@ -33,6 +34,8 @@ export type PluginMetadataSnapshotOwnerMaps = {
   setupProviders: ReadonlyMap<string, readonly string[]>;
   commandAliases: ReadonlyMap<string, readonly string[]>;
   contracts: ReadonlyMap<string, readonly string[]>;
+  /** Empty views must not fall through to process-current model normalization policies. */
+  modelIdNormalizationPolicies: ReadonlyMap<string, PluginManifestModelIdNormalizationProvider>;
   providerAuthAliases?: ReadonlyMap<string, readonly PluginProviderAuthAliasCandidate[]>;
   providerEndpoints?: readonly PluginManifestProviderEndpoint[];
   providerRequests?: ReadonlyMap<string, PluginManifestProviderRequestProvider>;

--- a/src/plugins/plugin-metadata.test-support.ts
+++ b/src/plugins/plugin-metadata.test-support.ts
@@ -71,6 +71,7 @@ export function createPluginMetadataSnapshotFixture(
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
     metrics: {
       registrySnapshotMs: 0,

--- a/src/plugins/plugin-registry-contributions.current-snapshot.test.ts
+++ b/src/plugins/plugin-registry-contributions.current-snapshot.test.ts
@@ -89,6 +89,7 @@ function createSnapshot(params: {
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
     metrics: {
       registrySnapshotMs: 0,

--- a/src/plugins/provider-model-compat.prepared.test.ts
+++ b/src/plugins/provider-model-compat.prepared.test.ts
@@ -38,6 +38,7 @@ function makeOwners(provider: string): PluginMetadataSnapshotOwnerMaps {
     setupProviders: new Map(),
     commandAliases: new Map(),
     contracts: new Map(),
+    modelIdNormalizationPolicies: new Map(),
   };
 }
 

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -19,8 +19,11 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { providerUsageLabel } from "../infra/provider-usage.shared.js";
 import type { UsageProviderId } from "../infra/provider-usage.types.js";
 import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
-import { normalizeProviderModelIdWithManifest } from "./manifest-model-id-normalization.js";
-import type { PluginManifestRecord, PluginManifestRegistry } from "./manifest-registry.js";
+import {
+  normalizeProviderModelIdWithManifest,
+  type ManifestModelIdNormalizationSource,
+} from "./manifest-model-id-normalization.js";
+import type { PluginManifestRegistry } from "./manifest-registry.js";
 import type {
   PluginMetadataRegistryView,
   PluginMetadataSnapshot,
@@ -377,7 +380,7 @@ export function normalizeProviderModelIdWithPlugin(params: {
   config?: OpenClawConfig;
   workspaceDir?: string;
   env?: NodeJS.ProcessEnv;
-  plugins?: readonly Pick<PluginManifestRecord, "modelIdNormalization">[];
+  plugins?: ManifestModelIdNormalizationSource;
   context: ProviderNormalizeModelIdContext;
 }): string | undefined {
   const plugin = resolveProviderHookPlugin(params);

--- a/src/plugins/providers.test.ts
+++ b/src/plugins/providers.test.ts
@@ -217,6 +217,7 @@ function createMetadataSnapshotFixture(
       setupProviders: ownerMap([]),
       commandAliases: ownerMap([]),
       contracts: ownerMap([]),
+      modelIdNormalizationPolicies: new Map(),
     },
   };
 }

--- a/src/plugins/runtime/load-context.current-snapshot.test.ts
+++ b/src/plugins/runtime/load-context.current-snapshot.test.ts
@@ -53,6 +53,7 @@ function createSnapshot(params: {
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
     metrics: {
       registrySnapshotMs: 0,

--- a/src/plugins/runtime/load-context.test.ts
+++ b/src/plugins/runtime/load-context.test.ts
@@ -44,6 +44,7 @@ const metadataSnapshot: PluginMetadataSnapshot = {
     setupProviders: new Map(),
     commandAliases: new Map(),
     contracts: new Map(),
+    modelIdNormalizationPolicies: new Map(),
   },
   metrics: {
     registrySnapshotMs: 0,

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -438,6 +438,7 @@ function installToolManifestSnapshots(params: {
       setupProviders: new Map(),
       commandAliases: new Map(),
       contracts: new Map(),
+      modelIdNormalizationPolicies: new Map(),
     },
     metrics: {
       registrySnapshotMs: 0,

--- a/src/skills/loading/workspace-skill-loader.test.ts
+++ b/src/skills/loading/workspace-skill-loader.test.ts
@@ -111,6 +111,7 @@ function createWorkspacePluginMetadataSnapshot(params: {
     setupProviders: new Map(),
     commandAliases: new Map(),
     contracts: new Map(),
+    modelIdNormalizationPolicies: new Map(),
   };
   const index: PluginMetadataSnapshot["index"] = {
     version: 1,

--- a/test/scripts/plugin-sdk-api-diff.test.ts
+++ b/test/scripts/plugin-sdk-api-diff.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync, spawn } from "node:child_process";
-import { chmodSync, existsSync, readdirSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
 import { delimiter, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
@@ -27,6 +27,8 @@ describe("Plugin SDK API diff CLI", () => {
     // Keep revision checkout bounded so startup reaches the child this test cancels.
     const repo = tempDirs.make("plugin-sdk-api-diff-repo-");
     const runnerTemp = tempDirs.make("plugin-sdk-api-diff-temp-");
+    const runnerArtifact = join(runnerTemp, "unrelated-runner-artifact");
+    writeFileSync(runnerArtifact, "retained\n");
     const binDir = tempDirs.make("plugin-sdk-api-diff-bin-");
     const pnpmMarker = join(binDir, "pnpm-started");
 
@@ -107,7 +109,13 @@ describe("Plugin SDK API diff CLI", () => {
       expect(exitCode).toBe(143);
       expect(Date.now() - interruptedAt).toBeLessThan(5_000);
       expect(git(repo, ["worktree", "list"])).not.toContain(runnerTemp);
-      expect(readdirSync(runnerTemp)).toEqual([]);
+      // RUNNER_TEMP is shared with runner tools; the CLI owns only its generated roots.
+      expect(
+        readdirSync(runnerTemp).filter((entry) =>
+          entry.startsWith("openclaw-plugin-sdk-api-diff-"),
+        ),
+      ).toEqual([]);
+      expect(readFileSync(runnerArtifact, "utf8")).toBe("retained\n");
     } finally {
       if (!closed) {
         child.kill("SIGKILL");

--- a/test/scripts/plugin-sdk-api-diff.test.ts
+++ b/test/scripts/plugin-sdk-api-diff.test.ts
@@ -1,6 +1,7 @@
+import assert from "node:assert/strict";
 import { execFileSync, spawn } from "node:child_process";
-import { chmodSync, existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
-import { delimiter, join, resolve } from "node:path";
+import { chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { delimiter, dirname, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
@@ -27,10 +28,10 @@ describe("Plugin SDK API diff CLI", () => {
     // Keep revision checkout bounded so startup reaches the child this test cancels.
     const repo = tempDirs.make("plugin-sdk-api-diff-repo-");
     const runnerTemp = tempDirs.make("plugin-sdk-api-diff-temp-");
-    const runnerArtifact = join(runnerTemp, "unrelated-runner-artifact");
-    writeFileSync(runnerArtifact, "retained\n");
     const binDir = tempDirs.make("plugin-sdk-api-diff-bin-");
     const pnpmMarker = join(binDir, "pnpm-started");
+    const runnerSentinel = join(runnerTemp, "runner-owned.txt");
+    writeFileSync(runnerSentinel, "preserve\n");
 
     git(repo, ["init", "--quiet", "--initial-branch=main"]);
     writeFileSync(join(repo, "README.md"), "fixture\n");
@@ -96,7 +97,14 @@ describe("Plugin SDK API diff CLI", () => {
     try {
       await waitFor(() => existsSync(pnpmMarker) || closed, 10_000);
       expect(closed, stderr).toBe(false);
-      expect(git(repo, ["worktree", "list"])).toContain(runnerTemp);
+      const revisionRoot = git(repo, ["worktree", "list", "--porcelain", "-z"])
+        .split("\0")
+        .filter((record) => record.startsWith("worktree "))
+        .map((record) => resolve(record.slice("worktree ".length)))
+        .find((root) => dirname(dirname(root)) === runnerTemp);
+      assert(revisionRoot, "expected a registered revision worktree under runner temp");
+      const temporaryRoot = dirname(revisionRoot);
+      expect(existsSync(temporaryRoot)).toBe(true);
       const interruptedAt = Date.now();
       child.kill("SIGTERM");
       const exitCode = await Promise.race([
@@ -109,13 +117,9 @@ describe("Plugin SDK API diff CLI", () => {
       expect(exitCode).toBe(143);
       expect(Date.now() - interruptedAt).toBeLessThan(5_000);
       expect(git(repo, ["worktree", "list"])).not.toContain(runnerTemp);
-      // RUNNER_TEMP is shared with runner tools; the CLI owns only its generated roots.
-      expect(
-        readdirSync(runnerTemp).filter((entry) =>
-          entry.startsWith("openclaw-plugin-sdk-api-diff-"),
-        ),
-      ).toEqual([]);
-      expect(readFileSync(runnerArtifact, "utf8")).toBe("retained\n");
+      // Cleanup owns its temporary root, not runner instrumentation beside it.
+      expect(existsSync(temporaryRoot)).toBe(false);
+      expect(readFileSync(runnerSentinel, "utf8")).toBe("preserve\n");
     } finally {
       if (!closed) {
         child.kill("SIGKILL");


### PR DESCRIPTION
Related: #134290.

## What Problem This Solves

Concurrent Gateway history reads, session-list updates, and agent preparation repeatedly rebuild model-normalization policy maps from plugin declarations that remain stable for the process lifetime. This adds avoidable work to a saturated event loop.

## Why This Change Was Made

Prepare normalization policies once in the existing plugin metadata snapshot owner, then carry the selected snapshot through model selection, catalog construction, and runtime fallback. Publication and temporary restoration reuse the exact eligible map. This removes the record-collecting publication setter and duplicate normalization/collection branches.

Empty and narrowed views stay authoritative. Caller-owned arrays retain fresh scalar reads and existing factory capture behavior; the shipped deprecated SDK catalog input still accepts older owner-map shapes. Live authentication, configuration, activation, and access checks are unchanged. There is no new cache lifetime, setting, dependency, or persistent-store change.

Production: +143/-150 (net -7), across 33 files. Tests/support: +605/-372; architecture docs: +2/-0. Most of the 98 changed files are snapshot fixtures or existing callers carrying their prepared snapshot instead of discarding its owner maps.

## User Impact

Model references and provider behavior remain the same, with less repeated plugin-policy work during requests. The residual saturation investigation continues separately; this change does not claim to eliminate all Gateway stalls.

## Evidence

- Recorded failing lookup, publication/restoration, and internal default/catalog reproductions before their corresponding fixes. The repaired tests verify outputs, zero repeated declaration enumeration, duplicate-provider precedence, narrowed/empty views, mutable explicit arrays, and generation restoration.
- Focused owner/caller suites cover configuration writes, model selection, catalog/pricing, worker inference, simple completion, reply selection, and session status. The final selection suite passed 408 tests, and the repaired snapshot/static-catalog suite passed 78. The complete changed check and full source/Control UI build passed. Codex autoreview was clean at the repository's default P0 scope.
- Two test-only issues found during validation were repaired rather than waived: Proxy callback inference in the new enumeration probes, and an older incomplete static-catalog snapshot fixture. All generation-isolation assertions remain.
- Full CI exposed additional incomplete or internally inconsistent snapshot fixtures. They now use the canonical fixture builder; all model, auth, workspace, and generation assertions are retained. The correction passed 463 focused tests, the complete changed-file gate, and a fresh clean Codex review. The SDK diff CLI shared-temp failure was independently repaired on main in #134422. This branch now retains that exact landed test: it discovers the actual registered temporary root, checks its removal, and proves unrelated runner artifacts survive. Our overlapping prefix-based variant was removed. The adopted test also passed locally with all 14 changed checks and a fresh clean Codex review. No CI failure was waived. Exact head `b011826a6b1d5162cf85a253c0ccc8561ea8f9f9` passed [CI run 33435351883](https://github.com/openclaw/openclaw/actions/runs/33435351883), including the required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/33435351883/job/99634054034).
- Synthetic policy benchmark: 64 plugin declarations, 2,000 mixed hit/unchanged/miss lookups, 100 warmup iterations, five samples, setup excluded and outputs checked. Median: 10.91 ms on baseline to 0.35 ms with prepared maps. This microbenchmark does not predict end-to-end Gateway latency.

The paired real built-Gateway profile used Node 26.8.1, isolated HOME/state and loopback ports, a mock streaming provider, and Chromium on the actual Control UI. Both used the same frozen requests-mode observers and 32 turns, 48 seed sessions, 128 updates across four clients, three history clients with bursts of five, six subscribers, a visible observer, 100 ms cadence, and 1,000 ms stream-chunk delay. The 2,000 ms control/handshake budgets were unchanged.

| Metric | Baseline 37db48c3 | Candidate e1768cfa |
| --- | ---: | ---: |
| Turn load | 6,399.6 ms | 6,569.2 ms |
| Readiness maximum | 256.9 ms | 147.4 ms |
| Session list maximum | 388.5 ms | 376.2 ms |
| History p99 / maximum | 423.7 / 523.2 ms | 426.5 / 430.9 ms |
| Control UI HTTP maximum | 361.8 ms | 181.0 ms |
| Handshake | 113.7 ms | 80.8 ms |
| Original operation failures / budget violations | 0 / 0 | 0 / 0 |
| Completed history samples | 550 | 570 |
| Degraded readiness polls | 43 / 47 | 46 / 49 |
| Event-loop utilization median/max | 1 / 1 | 1 / 1 |

The profiled runtime is unchanged by the subsequent test/support-only correction. This is one profile pair with different completed polling counts, so it establishes neither a general latency speedup nor a memory-leak result. Candidate transport validation joined all 1,004 benchmark requests; all 121 observed browser requests received responses. Baseline retained five explicitly incomplete history requests at its first navigation close. Both recovered to two distinct healthy public snapshots in about 3.01 seconds and closed their owned processes, sockets, and temporary state.

CPU audit over every node and signed sample pair: collector inclusive sampled weight fell from 30.251 ms to 0.306 ms over the full profile, and from 23.666 ms during load to no sampled load interval. Both candidate collector stacks were before load. These are sampled wall estimates, not exact call counts; publication/restore behavior is covered by the regression tests. Transaction/query/row processing and other synchronous work remain substantial.

A separate candidate-only run strengthened the post-load observer without changing the original performance pair or its limits. It verified the exact attached selected pane was connected and idle before and after capture, with the expected reply, no active local run, no send/stream/queue, and a done session row. The final image shows “Done in 5 seconds”; the sidebar independently describes another completed session. Its 221 ms drain and 420 ms close barrier stayed inside the existing 5/10-second caps. This supplemental run also passed the original budgets and cleanup; it retained five explicitly incomplete first-navigation history requests and recovered in 4.01 seconds.

The performance runs used the runtime in commit `e1768cfa29e5eec956e2f24eec66592c593db3eb`; the subsequent correction changes only tests and test support.


## Synthetic Control UI recordings

Both complete recordings were inspected before attachment: isolated loopback Gateway, synthetic sessions/provider responses, no credentials or private data. They demonstrate the real UI flow and cleanup, not a general latency speedup.

Baseline from the paired profile (`37db48c3`): selected benchmark reply completes and shows Done in 4 seconds.

https://github.com/user-attachments/assets/81ee7e8e-0bcc-4954-b935-4c79c54acb6d

Supplemental candidate-only terminal-observation run (runtime `e1768cfa`): selected benchmark reply completes and shows Done in 5 seconds. The app header briefly remains Working before describing another synthetic session; the selected-pane state was independently verified by the observer. This is separate UI evidence, not the candidate half of the performance pair above.

https://github.com/user-attachments/assets/615ea5a9-dd24-477e-a79a-ddf3be265ff7

## Reproduction commands

The frozen browser/profile adapter invoked the built Gateway through the existing concurrency harness with these unchanged load parameters. Each run used its own isolated HOME/state, loopback ports, output path, and CPU profile directory.

```sh
node --import ./scripts/tsx.mjs .artifacts/stall-residual/browser-profile/launch.mjs --mode requests --run model-policy-candidate-37db-32-01 --cpu-profile -- --runs 1 --warmup 0 --concurrency 32 --session-count 48 --session-updates 128 --session-update-clients 4 --history-clients 3 --history-burst 5 --subscribers 6 --visible-observer --stream-chunk-delay-ms 1000 --cadence-ms 100 --timeout-ms 120000 --max-control-ms 2000 --max-handshake-ms 2000 --json
```

Final adopted SDK fixture and changed checks:

```sh
node scripts/run-vitest.mjs test/scripts/plugin-sdk-api-diff.test.ts
node scripts/check-changed.mjs --base c8d159a9d861827640b58386fac93d8dd107c5f3 --timed -- test/scripts/plugin-sdk-api-diff.test.ts
```
