### PR TITLE
fix: release session check expects the retired Doctor backup

### DIFF
--- a/scripts/e2e/session-runtime-context-docker-client.ts
+++ b/scripts/e2e/session-runtime-context-docker-client.ts
@@ -180,6 +180,7 @@ async function verifyDoctorRepair(root: string) {
   const stateDir = path.join(root, ".openclaw");
   const configPath = path.join(stateDir, "openclaw.json");
   const sessionFile = await seedBrokenSession(stateDir);
+  const originalTranscript = await fs.readFile(sessionFile);
   await fs.mkdir(path.dirname(configPath), { recursive: true });
   await fs.writeFile(configPath, JSON.stringify({ plugins: { enabled: false } }, null, 2));
 
@@ -240,10 +241,17 @@ async function verifyDoctorRepair(root: string) {
     ),
     "doctor repair left runtime context in active transcript",
   );
-  const backups = (await fs.readdir(path.dirname(sessionFile))).filter((name) =>
-    name.includes(".pre-doctor-branch-repair-"),
+  const archiveDir = path.join(stateDir, "agents", "main", "session-sqlite-import-archive");
+  const archives = (await fs.readdir(archiveDir)).filter((name) =>
+    name.includes(`.${path.basename(sessionFile)}.imported-`),
   );
-  assert(backups.length === 1, `expected one doctor backup, got ${backups.length}`);
+  const [archiveName] = archives;
+  assert(
+    archives.length === 1 && archiveName,
+    `expected one doctor transcript archive, got ${archives.length}`,
+  );
+  const archivedTranscript = await fs.readFile(path.join(archiveDir, archiveName));
+  assert(archivedTranscript.equals(originalTranscript), "doctor changed the archived original");
 }
 
 async function main() {

--- a/test/scripts/plugin-sdk-api-diff.test.ts
+++ b/test/scripts/plugin-sdk-api-diff.test.ts
@@ -1,6 +1,7 @@
+import assert from "node:assert/strict";
 import { execFileSync, spawn } from "node:child_process";
-import { chmodSync, existsSync, readdirSync, writeFileSync } from "node:fs";
-import { delimiter, join, resolve } from "node:path";
+import { chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs";
+import { delimiter, dirname, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
@@ -29,6 +30,8 @@ describe("Plugin SDK API diff CLI", () => {
     const runnerTemp = tempDirs.make("plugin-sdk-api-diff-temp-");
     const binDir = tempDirs.make("plugin-sdk-api-diff-bin-");
     const pnpmMarker = join(binDir, "pnpm-started");
+    const runnerSentinel = join(runnerTemp, "runner-owned.txt");
+    writeFileSync(runnerSentinel, "preserve\n");
 
     git(repo, ["init", "--quiet", "--initial-branch=main"]);
     writeFileSync(join(repo, "README.md"), "fixture\n");
@@ -94,7 +97,14 @@ describe("Plugin SDK API diff CLI", () => {
     try {
       await waitFor(() => existsSync(pnpmMarker) || closed, 10_000);
       expect(closed, stderr).toBe(false);
-      expect(git(repo, ["worktree", "list"])).toContain(runnerTemp);
+      const revisionRoot = git(repo, ["worktree", "list", "--porcelain", "-z"])
+        .split("\0")
+        .filter((record) => record.startsWith("worktree "))
+        .map((record) => resolve(record.slice("worktree ".length)))
+        .find((root) => dirname(dirname(root)) === runnerTemp);
+      assert(revisionRoot, "expected a registered revision worktree under runner temp");
+      const temporaryRoot = dirname(revisionRoot);
+      expect(existsSync(temporaryRoot)).toBe(true);
       const interruptedAt = Date.now();
       child.kill("SIGTERM");
       const exitCode = await Promise.race([
@@ -107,7 +117,9 @@ describe("Plugin SDK API diff CLI", () => {
       expect(exitCode).toBe(143);
       expect(Date.now() - interruptedAt).toBeLessThan(5_000);
       expect(git(repo, ["worktree", "list"])).not.toContain(runnerTemp);
-      expect(readdirSync(runnerTemp)).toEqual([]);
+      // Cleanup owns its temporary root, not runner instrumentation beside it.
+      expect(existsSync(temporaryRoot)).toBe(false);
+      expect(readFileSync(runnerSentinel, "utf8")).toBe("preserve\n");
     } finally {
       if (!closed) {
         child.kill("SIGKILL");


### PR DESCRIPTION
## What Problem This Solves

The release Docker session runtime-context test still expected a `.pre-doctor-branch-repair` backup beside the old JSONL transcript. Public Doctor now stages its repair in SQLite and moves the untouched original into the migration archive; the standalone file-repair API retains the old backup behavior. The packaged test had already verified the migrated active branch and excluded hidden context before failing on the obsolete filename.

## Why This Change Was Made

The packaged-flow change updates that test harness. It captures the original transcript before Doctor, requires exactly one corresponding migration archive, and verifies the complete archived bytes. Existing visible-prompt, active-branch, and hidden-context assertions remain unchanged. No product, schema, storage, lifecycle, timeout, retry, or provider behavior changes.

## User Impact

Internal release-test repair only. The packaged harness changes by +11/-3 lines; the SDK cancellation test is also corrected as described below. Production runtime delta: zero. This restores release verification against the documented migration contract without weakening rollback preservation.

## Evidence

Validation used the exact frozen 594f5003092453884b78320d0417450f035d25a9 package and functional Docker image from full run 33423706952. ZIP digests, package/image manifests, inner archive digest and loaded Docker image IDs were verified. On Linux Node 24.19 with 4 CPUs, the unchanged test reproduced the original backup assertion failure; the one-file candidate passed through the same packaged flow. The canonical one-path changed gate passed, including scripts types, lint, format, and Docker boundary checks, and independent managed review was clean. The two arm timings are not a controlled performance comparison.

## Hosted CI Repair

The first exact-head CI run passed the packaged-flow code checks but failed the SDK comparison cancellation test: a runner bookkeeping file remained in `RUNNER_TEMP`. The comparison CLI only owns its unique child directory, so asserting that the entire runner parent was empty exceeded the cleanup contract. The origin of the hosted bookkeeping file is inferred; the repair does not depend on recognizing that filename.

The test now captures the actual registered revision worktree, asserts that its owned temporary root existed and is removed after cancellation, retains worktree deregistration, exit143 and the five-second deadline, and verifies that an unrelated runner sentinel survives. No production cleanup behavior changes.

A controlled Git wrapper writing bookkeeping beside the tool directory reproduces the original assertion failure and passes with the corrected ownership check. Negative controls that retain the owned root or delete the unowned parent both fail. This strengthens the cleanup contract without deleting runner files or ignoring a named artifact.

The ClawSweeper migration/storage classifier applies to a test of existing archive behavior; no persistent data model or migration implementation is changed. Native archive proof covers the unchanged packaged-flow file. The SDK change has separate real-CLI cancellation proof, canonical changed-gate coverage and combined managed review. Exact-head hosted CI is required before merge.
