### PR TITLE
fix(ai): preserve Responses continuation across admitted tool arguments

### DIFF
--- a/packages/ai/src/transports/openai-responses-client.continuation-unsafe-integer.live.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.continuation-unsafe-integer.live.test.ts
@@ -25,6 +25,17 @@ import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-clien
 // replayed string-typed round-trip`) for the deterministic version of this
 // proof.
 //
+// GlobalFetchRequestCapture also tees each captured response's raw SSE
+// bytes (rawResponseTexts) and extractRawFunctionCallArguments pulls the
+// `response.function_call_arguments.done` event's raw arguments string out
+// of round 1's response, asserting it's a genuine bare/unquoted integer
+// literal on the wire -- not a model-quoted string, which the pre-fix
+// comparison already handled correctly. Without this, asserting only on
+// the post-parser AssistantMessage.arguments value can't tell those two
+// cases apart (both parse to the same string), so it wouldn't actually
+// prove this fix's regression path. Confirmed live: raw wire text was
+// exactly `{"n":9007199254740993}` -- a bare literal.
+//
 // (The call_id-reshaping half of this PR is not exercisable here: a real
 // native OpenAI tool-call id already arrives in the call_*/fc_*-paired shape
 // normalizeOpenAIResponsesToolCallIds produces, so its idempotent
@@ -40,26 +51,95 @@ const LIVE_TIMEOUT_MS = 120_000;
 
 class GlobalFetchRequestCapture {
   readonly requests: Array<Record<string, unknown>> = [];
+  // Raw SSE response bodies, one entry per captured request, in the same
+  // order as `requests`. Captured via a stream tee so the real SDK consumer
+  // is never disturbed -- this exists specifically to inspect the raw wire
+  // bytes api.openai.com actually sent, before any OpenClaw-side parsing
+  // (parseStreamingJson / parseJsonObjectPreservingUnsafeIntegers) can turn
+  // an unsafe integer literal into a string. Without this, a live test that
+  // only asserts on the post-parser AssistantMessage.arguments value can't
+  // tell a real unquoted 9007199254740993 apart from the model having
+  // quoted it as a string itself -- the case the pre-fix comparison already
+  // handled, so it would prove nothing about this fix. (ClawSweeper P2 on
+  // #134423.)
+  readonly rawResponseTexts: string[] = [];
   private readonly realFetch = globalThis.fetch;
 
   install(): void {
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
       const body = init?.body;
-      if (url.includes("api.openai.com") && typeof body === "string") {
+      const isTarget = url.includes("api.openai.com") && typeof body === "string";
+      if (isTarget) {
         try {
           this.requests.push(JSON.parse(body) as Record<string, unknown>);
         } catch {
           // Non-JSON body on this host is unexpected for a Responses call.
         }
       }
-      return this.realFetch(input, init);
+      const response = await this.realFetch(input, init);
+      if (!isTarget || !response.body) {
+        return response;
+      }
+      const [forCaller, forCapture] = response.body.tee();
+      const captureIndex = this.rawResponseTexts.length;
+      this.rawResponseTexts.push("");
+      void (async () => {
+        const reader = forCapture.getReader();
+        const decoder = new TextDecoder();
+        let text = "";
+        try {
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (done) {
+              break;
+            }
+            text += decoder.decode(value, { stream: true });
+          }
+        } catch {
+          // Best-effort capture; the real caller's own stream is unaffected.
+        }
+        this.rawResponseTexts[captureIndex] = text;
+      })();
+      return new Response(forCaller, {
+        status: response.status,
+        statusText: response.statusText,
+        headers: response.headers,
+      });
     }) as typeof fetch;
   }
 
   restore(): void {
     globalThis.fetch = this.realFetch;
   }
+}
+
+/** Extracts the raw (pre-parser) arguments string from a captured SSE response's
+ * `response.function_call_arguments.done` event -- the exact wire text the
+ * provider sent for the tool call's arguments, before any OpenClaw-side JSON
+ * parsing normalizes an unsafe integer literal into a string. */
+function extractRawFunctionCallArguments(rawSse: string): string | undefined {
+  for (const line of rawSse.split("\n")) {
+    const trimmed = line.startsWith("data:") ? line.slice(5).trim() : "";
+    if (!trimmed || trimmed === "[DONE]") {
+      continue;
+    }
+    let event: unknown;
+    try {
+      event = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    if (
+      event &&
+      typeof event === "object" &&
+      (event as { type?: unknown }).type === "response.function_call_arguments.done" &&
+      typeof (event as { arguments?: unknown }).arguments === "string"
+    ) {
+      return (event as { arguments: string }).arguments;
+    }
+  }
+  return undefined;
 }
 
 function userMessage(text: string, timestamp: number) {
@@ -129,6 +209,25 @@ describeLive(
           expect(toolCall).toBeDefined();
           expect(String(toolCall?.arguments.n)).toBe(unsafeInt);
 
+          // Prove the provider actually emitted a bare, unquoted numeric literal
+          // on the wire -- not a model-quoted string, which the pre-fix
+          // comparison already handled and would make this whole test prove
+          // nothing about the fix. Inspects raw SSE bytes, before any
+          // OpenClaw-side parsing.
+          const rawArguments = extractRawFunctionCallArguments(capture.rawResponseTexts[0] ?? "");
+          expect(
+            rawArguments,
+            `expected a response.function_call_arguments.done event in the raw SSE response; got ${capture.rawResponseTexts.length} captured response(s)`,
+          ).toBeDefined();
+          expect(
+            rawArguments,
+            `raw wire arguments must contain the bare unquoted integer ${unsafeInt}, not a quoted string; got: ${rawArguments}`,
+          ).toMatch(new RegExp(`"n"\\s*:\\s*${unsafeInt}(?!")`));
+          expect(
+            rawArguments,
+            `raw wire arguments must NOT have quoted the integer as a string; got: ${rawArguments}`,
+          ).not.toMatch(new RegExp(`"n"\\s*:\\s*"${unsafeInt}"`));
+
           const toolResultMsg = {
             role: "toolResult" as const,
             toolCallId: toolCall?.id ?? "",
@@ -149,7 +248,9 @@ describeLive(
           const secondRequest = capture.requests[1];
           expect(secondRequest).toHaveProperty("previous_response_id");
           expect(typeof secondRequest?.previous_response_id).toBe("string");
-          expect((secondRequest?.previous_response_id as string).length).toBeGreaterThan(0);
+          expect(
+            (secondRequest?.previous_response_id as string | undefined)?.length ?? 0,
+          ).toBeGreaterThan(0);
           // toolCall.id is OpenClaw's own internal call_id|fc_id pairing;
           // the wire delta's call_id must be restored to the bare provider
           // call_id (the part before the pairing separator), not the

--- a/packages/ai/src/transports/openai-responses-client.continuation-unsafe-integer.live.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.continuation-unsafe-integer.live.test.ts
@@ -1,0 +1,172 @@
+import type { AssistantMessage, Context, Model } from "@openclaw/llm-core";
+import { afterEach, describe, expect, it } from "vitest";
+import { cleanupSessionResources } from "../session-resources.js";
+import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
+
+// Live coverage, against the real native api.openai.com endpoint, for the
+// argument-canonicalization half of this PR: HTTP continuation must still
+// hold across a real multi-round tool-calling turn whose argument contains
+// an integer value ABOVE Number.MAX_SAFE_INTEGER. This isolates the
+// native-only path this PR's own code (claimOpenAIResponsesHttpContinuation)
+// actually gates on, rather than the stack this PR's prior live evidence
+// used, which also carried #128633's separate compat-endpoint opt-in.
+//
+// This test caught a real regression on first run: an earlier revision of
+// this fix tagged the cached side's unsafe integer to distinguish it from a
+// genuine same-digits string, but AssistantMessage.arguments already stores
+// every unsafe integer as a string (parseJsonObjectPreservingUnsafeIntegers,
+// precision-preserving), so an *unmodified* replay of this exact call always
+// re-serializes it as a same-digits string -- tagging only the cached side
+// made every real large-integer tool call permanently ineligible for
+// continuation on its very next round. Confirmed live: this test failed
+// (fell through to a full-history resend) before that tag was removed, and
+// passes now. See the unit regression test with the same shape
+// (`treats a cached number-typed unsafe integer as equal to its own
+// replayed string-typed round-trip`) for the deterministic version of this
+// proof.
+//
+// (The call_id-reshaping half of this PR is not exercisable here: a real
+// native OpenAI tool-call id already arrives in the call_*/fc_*-paired shape
+// normalizeOpenAIResponsesToolCallIds produces, so its idempotent
+// short-circuit correctly leaves it unchanged -- an earlier version of this
+// test asserted the id WOULD change and failed for exactly that reason.
+// That half stays covered by the existing unit tests using the real
+// transform function directly.)
+const LIVE = process.env.OPENCLAW_LIVE_TEST === "1";
+const OPENAI_KEY = process.env.OPENAI_API_KEY ?? "";
+const describeLive = LIVE && OPENAI_KEY ? describe : describe.skip;
+const LIVE_MODEL_ID = process.env.OPENCLAW_LIVE_RESPONSES_MODEL || "gpt-5.6-luna";
+const LIVE_TIMEOUT_MS = 120_000;
+
+class GlobalFetchRequestCapture {
+  readonly requests: Array<Record<string, unknown>> = [];
+  private readonly realFetch = globalThis.fetch;
+
+  install(): void {
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      const body = init?.body;
+      if (url.includes("api.openai.com") && typeof body === "string") {
+        try {
+          this.requests.push(JSON.parse(body) as Record<string, unknown>);
+        } catch {
+          // Non-JSON body on this host is unexpected for a Responses call.
+        }
+      }
+      return this.realFetch(input, init);
+    }) as typeof fetch;
+  }
+
+  restore(): void {
+    globalThis.fetch = this.realFetch;
+  }
+}
+
+function userMessage(text: string, timestamp: number) {
+  return { role: "user" as const, content: text, timestamp };
+}
+
+const recordValueTool = {
+  name: "record_value",
+  description: "Record an integer value for the test harness.",
+  parameters: { type: "object", properties: { n: { type: "integer" } }, required: ["n"] },
+};
+
+function model(): Model<"openai-responses"> {
+  return {
+    id: LIVE_MODEL_ID,
+    name: LIVE_MODEL_ID,
+    api: "openai-responses",
+    provider: "openai",
+    baseUrl: "https://api.openai.com/v1",
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 8192,
+  } satisfies Model<"openai-responses">;
+}
+
+async function run(context: Context, sessionId: string): Promise<AssistantMessage> {
+  const stream = await createOpenAIResponsesTransportStreamFn()(model(), context, {
+    apiKey: OPENAI_KEY,
+    sessionId,
+    transport: "sse",
+    reasoningEffort: "low",
+    maxTokens: 256,
+    onPayload: (payload: Record<string, unknown>) => ({ ...payload, store: true }),
+  } as never);
+  return stream.result();
+}
+
+describeLive(
+  "HTTP continuation across a real unsafe-integer tool-call argument (real api.openai.com)",
+  () => {
+    afterEach(() => {
+      cleanupSessionResources();
+    });
+
+    it(
+      "continues a real tool-calling round whose argument is above Number.MAX_SAFE_INTEGER",
+      async () => {
+        const capture = new GlobalFetchRequestCapture();
+        capture.install();
+        try {
+          const sessionId = "live-toolcall-arg-canonicalization";
+          const unsafeInt = "9007199254740993"; // > Number.MAX_SAFE_INTEGER
+          const firstUser = userMessage(
+            `This is an automated test. Call the record_value tool with exactly n=${unsafeInt}. ` +
+              "Do not round or alter the number.",
+            1,
+          );
+          const callTurn = await run(
+            { messages: [firstUser], tools: [recordValueTool] },
+            sessionId,
+          );
+          const toolCall = callTurn.content.find((block) => block.type === "toolCall") as
+            | { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }
+            | undefined;
+          expect(toolCall).toBeDefined();
+          expect(String(toolCall?.arguments.n)).toBe(unsafeInt);
+
+          const toolResultMsg = {
+            role: "toolResult" as const,
+            toolCallId: toolCall?.id ?? "",
+            content: [{ type: "text" as const, text: "recorded" }],
+            timestamp: 2,
+          };
+          const round1Messages: Context["messages"] = [firstUser, callTurn, toolResultMsg];
+          const afterToolResult = await run(
+            { messages: round1Messages, tools: [recordValueTool] },
+            sessionId,
+          );
+          expect(afterToolResult.stopReason).toBe("stop");
+
+          // Exactly two requests reached the real API -- a rejected
+          // previous_response_id (the recovery path is a silent
+          // full-history resend) would show up as a third.
+          expect(capture.requests).toHaveLength(2);
+          const secondRequest = capture.requests[1];
+          expect(secondRequest).toHaveProperty("previous_response_id");
+          expect(typeof secondRequest?.previous_response_id).toBe("string");
+          expect((secondRequest?.previous_response_id as string).length).toBeGreaterThan(0);
+          // toolCall.id is OpenClaw's own internal call_id|fc_id pairing;
+          // the wire delta's call_id must be restored to the bare provider
+          // call_id (the part before the pairing separator), not the
+          // compound internal id.
+          const rawCallId = toolCall?.id.split("|")[0];
+          expect(secondRequest?.input).toEqual([
+            {
+              type: "function_call_output",
+              call_id: rawCallId,
+              output: "recorded",
+            },
+          ]);
+        } finally {
+          capture.restore();
+        }
+      },
+      LIVE_TIMEOUT_MS,
+    );
+  },
+);

--- a/packages/ai/src/transports/openai-responses-client.continuation-unsafe-integer.live.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.continuation-unsafe-integer.live.test.ts
@@ -1,290 +1,95 @@
-import type { AssistantMessage, Context, Model } from "@openclaw/llm-core";
+import type { Context, Model } from "@openclaw/llm-core";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanupSessionResources } from "../session-resources.js";
 import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
+import type { OpenAIResponsesOptions } from "./openai-responses-contracts.js";
+import { captureOpenAIResponses } from "./openai-responses-live-capture.test-support.js";
 
-// Live coverage, against the real native api.openai.com endpoint, for the
-// argument-canonicalization half of this PR: HTTP continuation must still
-// hold across a real multi-round tool-calling turn whose argument contains
-// an integer value ABOVE Number.MAX_SAFE_INTEGER. This isolates the
-// native-only path this PR's own code (claimOpenAIResponsesHttpContinuation)
-// actually gates on, rather than the stack this PR's prior live evidence
-// used, which also carried #128633's separate compat-endpoint opt-in.
-//
-// This test caught a real regression on first run: an earlier revision of
-// this fix tagged the cached side's unsafe integer to distinguish it from a
-// genuine same-digits string, but AssistantMessage.arguments already stores
-// every unsafe integer as a string (parseJsonObjectPreservingUnsafeIntegers,
-// precision-preserving), so an *unmodified* replay of this exact call always
-// re-serializes it as a same-digits string -- tagging only the cached side
-// made every real large-integer tool call permanently ineligible for
-// continuation on its very next round. Confirmed live: this test failed
-// (fell through to a full-history resend) before that tag was removed, and
-// passes now. See the unit regression test with the same shape
-// (`treats a cached number-typed unsafe integer as equal to its own
-// replayed string-typed round-trip`) for the deterministic version of this
-// proof.
-//
-// GlobalFetchRequestCapture also tees each captured response's raw SSE
-// bytes (rawResponseTexts) and extractRawFunctionCallArguments pulls the
-// `response.function_call_arguments.done` event's raw arguments string out
-// of round 1's response, asserting it's a genuine bare/unquoted integer
-// literal on the wire -- not a model-quoted string, which the pre-fix
-// comparison already handled correctly. Without this, asserting only on
-// the post-parser AssistantMessage.arguments value can't tell those two
-// cases apart (both parse to the same string), so it wouldn't actually
-// prove this fix's regression path. Confirmed live: raw wire text was
-// exactly `{"n":9007199254740993}` -- a bare literal.
-//
-// (The call_id-reshaping half of this PR is not exercisable here: a real
-// native OpenAI tool-call id already arrives in the call_*/fc_*-paired shape
-// normalizeOpenAIResponsesToolCallIds produces, so its idempotent
-// short-circuit correctly leaves it unchanged -- an earlier version of this
-// test asserted the id WOULD change and failed for exactly that reason.
-// That half stays covered by the existing unit tests using the real
-// transform function directly.)
-const LIVE = process.env.OPENCLAW_LIVE_TEST === "1";
-const OPENAI_KEY = process.env.OPENAI_API_KEY ?? "";
-const describeLive = LIVE && OPENAI_KEY ? describe : describe.skip;
-const LIVE_MODEL_ID = process.env.OPENCLAW_LIVE_RESPONSES_MODEL || "gpt-5.6-luna";
-const LIVE_TIMEOUT_MS = 120_000;
-
-class GlobalFetchRequestCapture {
-  readonly requests: Array<Record<string, unknown>> = [];
-  // Raw SSE response bodies, one entry per captured request, in the same
-  // order as `requests`. Captured via a stream tee so the real SDK consumer
-  // is never disturbed -- this exists specifically to inspect the raw wire
-  // bytes api.openai.com actually sent, before any OpenClaw-side parsing
-  // (parseStreamingJson / parseJsonObjectPreservingUnsafeIntegers) can turn
-  // an unsafe integer literal into a string. Without this, a live test that
-  // only asserts on the post-parser AssistantMessage.arguments value can't
-  // tell a real unquoted 9007199254740993 apart from the model having
-  // quoted it as a string itself -- the case the pre-fix comparison already
-  // handled, so it would prove nothing about this fix. (ClawSweeper P2 on
-  // #134423.)
-  readonly rawResponseTexts: string[] = [];
-  // One promise per captured response, in the same order as `requests` /
-  // `rawResponseTexts`. The tee's capture branch is read in the background so
-  // the real SDK consumer is never blocked on it, but that means
-  // rawResponseTexts[i] is not populated yet when fetch() itself resolves --
-  // a caller MUST await captureCompletions[i] before reading it, or it may
-  // observe an empty or partial string depending on scheduling (ClawSweeper
-  // P2 on #134423).
-  readonly captureCompletions: Array<Promise<void>> = [];
-  private readonly realFetch = globalThis.fetch;
-
-  install(): void {
-    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-      const body = init?.body;
-      const isTarget = url.includes("api.openai.com") && typeof body === "string";
-      if (isTarget) {
-        try {
-          this.requests.push(JSON.parse(body) as Record<string, unknown>);
-        } catch {
-          // Non-JSON body on this host is unexpected for a Responses call.
-        }
-      }
-      const response = await this.realFetch(input, init);
-      if (!isTarget || !response.body) {
-        return response;
-      }
-      const [forCaller, forCapture] = response.body.tee();
-      const captureIndex = this.rawResponseTexts.length;
-      this.rawResponseTexts.push("");
-      this.captureCompletions.push(
-        (async () => {
-          const reader = forCapture.getReader();
-          const decoder = new TextDecoder();
-          let text = "";
-          try {
-            for (;;) {
-              const { done, value } = await reader.read();
-              if (done) {
-                break;
-              }
-              text += decoder.decode(value, { stream: true });
-            }
-          } catch {
-            // Best-effort capture; the real caller's own stream is unaffected.
-          }
-          this.rawResponseTexts[captureIndex] = text;
-        })(),
-      );
-      return new Response(forCaller, {
-        status: response.status,
-        statusText: response.statusText,
-        headers: response.headers,
-      });
-    }) as typeof fetch;
-  }
-
-  restore(): void {
-    globalThis.fetch = this.realFetch;
-  }
-}
-
-/** Extracts the raw (pre-parser) arguments string from a captured SSE response's
- * `response.function_call_arguments.done` event -- the exact wire text the
- * provider sent for the tool call's arguments, before any OpenClaw-side JSON
- * parsing normalizes an unsafe integer literal into a string. */
-function extractRawFunctionCallArguments(rawSse: string): string | undefined {
-  for (const line of rawSse.split("\n")) {
-    const trimmed = line.startsWith("data:") ? line.slice(5).trim() : "";
-    if (!trimmed || trimmed === "[DONE]") {
-      continue;
-    }
-    let event: unknown;
-    try {
-      event = JSON.parse(trimmed);
-    } catch {
-      continue;
-    }
-    if (
-      event &&
-      typeof event === "object" &&
-      (event as { type?: unknown }).type === "response.function_call_arguments.done" &&
-      typeof (event as { arguments?: unknown }).arguments === "string"
-    ) {
-      return (event as { arguments: string }).arguments;
-    }
-  }
-  return undefined;
-}
-
-function userMessage(text: string, timestamp: number) {
-  return { role: "user" as const, content: text, timestamp };
-}
-
-const recordValueTool = {
+const apiKey = process.env.OPENAI_API_KEY ?? "";
+const describeLive = process.env.OPENCLAW_LIVE_TEST === "1" && apiKey ? describe : describe.skip;
+const modelId = process.env.OPENCLAW_LIVE_RESPONSES_MODEL || "gpt-5.6-luna";
+const model = {
+  id: modelId,
+  name: modelId,
+  api: "openai-responses",
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: true,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 200_000,
+  maxTokens: 8192,
+} satisfies Model<"openai-responses">;
+const tool = {
   name: "record_value",
-  description: "Record an integer value for the test harness.",
+  description: "Record the supplied integer value.",
   parameters: { type: "object", properties: { n: { type: "integer" } }, required: ["n"] },
 };
 
-function model(): Model<"openai-responses"> {
-  return {
-    id: LIVE_MODEL_ID,
-    name: LIVE_MODEL_ID,
-    api: "openai-responses",
-    provider: "openai",
-    baseUrl: "https://api.openai.com/v1",
-    reasoning: true,
-    input: ["text"],
-    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-    contextWindow: 200_000,
-    maxTokens: 8192,
-  } satisfies Model<"openai-responses">;
-}
-
-async function run(context: Context, sessionId: string): Promise<AssistantMessage> {
-  const stream = await createOpenAIResponsesTransportStreamFn()(model(), context, {
-    apiKey: OPENAI_KEY,
-    sessionId,
+async function run(messages: Context["messages"]) {
+  const options = {
+    apiKey,
+    sessionId: "live-unsafe-integer-continuation",
     transport: "sse",
     reasoningEffort: "low",
     maxTokens: 256,
-    onPayload: (payload: Record<string, unknown>) => ({ ...payload, store: true }),
-  } as never);
+    onPayload: (payload) => ({ ...(payload as Record<string, unknown>), store: true }),
+  } satisfies OpenAIResponsesOptions;
+  const stream = await createOpenAIResponsesTransportStreamFn()(
+    model,
+    { messages, tools: [tool] },
+    options,
+  );
   return stream.result();
 }
 
-describeLive(
-  "HTTP continuation across a real unsafe-integer tool-call argument (real api.openai.com)",
-  () => {
-    afterEach(() => {
-      cleanupSessionResources();
-    });
+describeLive("native Responses continuation after an unsafe integer tool call", () => {
+  afterEach(() => cleanupSessionResources());
 
-    it(
-      "continues a real tool-calling round whose argument is above Number.MAX_SAFE_INTEGER",
-      async () => {
-        const capture = new GlobalFetchRequestCapture();
-        capture.install();
-        try {
-          const sessionId = "live-toolcall-arg-canonicalization";
-          const unsafeInt = "9007199254740993"; // > Number.MAX_SAFE_INTEGER
-          const firstUser = userMessage(
-            `This is an automated test. Call the record_value tool with exactly n=${unsafeInt}. ` +
-              "Do not round or alter the number.",
-            1,
-          );
-          const callTurn = await run(
-            { messages: [firstUser], tools: [recordValueTool] },
-            sessionId,
-          );
-          const toolCall = callTurn.content.find((block) => block.type === "toolCall") as
-            | { type: "toolCall"; id: string; name: string; arguments: Record<string, unknown> }
-            | undefined;
-          expect(toolCall).toBeDefined();
-          expect(String(toolCall?.arguments.n)).toBe(unsafeInt);
+  it("reuses the provider response after preserving a bare integer argument", async () => {
+    const user = {
+      role: "user" as const,
+      content:
+        "Call record_value with exactly n=9007199254740993. Do not round or alter the number.",
+      timestamp: 1,
+    };
+    const first = await captureOpenAIResponses(() => run([user]));
+    expect(first.result.stopReason).toBe("toolUse");
+    expect(first.requests).toHaveLength(1);
+    const call = first.result.content.find((block) => block.type === "toolCall");
+    expect(call?.arguments).toEqual({ n: "9007199254740993" });
+    if (!call) {
+      throw new Error("Expected a completed tool call");
+    }
 
-          // Prove the provider actually emitted a bare, unquoted numeric literal
-          // on the wire -- not a model-quoted string, which the pre-fix
-          // comparison already handled and would make this whole test prove
-          // nothing about the fix. Inspects raw SSE bytes, before any
-          // OpenClaw-side parsing. Must await the capture's own completion
-          // first: it fills in rawResponseTexts[0] on a background task, in
-          // parallel with (not blocking) the real SDK's own stream consumer,
-          // so reading it before this resolves would race an unfinished or
-          // empty capture.
-          await capture.captureCompletions[0];
-          const rawArguments = extractRawFunctionCallArguments(capture.rawResponseTexts[0] ?? "");
-          expect(
-            rawArguments,
-            `expected a response.function_call_arguments.done event in the raw SSE response; got ${capture.rawResponseTexts.length} captured response(s)`,
-          ).toBeDefined();
-          expect(
-            rawArguments,
-            `raw wire arguments must contain the bare unquoted integer ${unsafeInt}, not a quoted string; got: ${rawArguments}`,
-          ).toMatch(new RegExp(`"n"\\s*:\\s*${unsafeInt}(?!")`));
-          expect(
-            rawArguments,
-            `raw wire arguments must NOT have quoted the integer as a string; got: ${rawArguments}`,
-          ).not.toMatch(new RegExp(`"n"\\s*:\\s*"${unsafeInt}"`));
+    // A provider-quoted string already worked before this fix; prove a bare wire literal.
+    const rawArguments = first.responseTexts[0]
+      ?.split("\n")
+      .filter((line) => line.startsWith("data:") && line.slice(5).trim() !== "[DONE]")
+      .map((line) => JSON.parse(line.slice(5)) as { type: string; arguments?: string })
+      .find((event) => event.type === "response.function_call_arguments.done")?.arguments;
+    expect(rawArguments).toMatch(/"n"\s*:\s*9007199254740993\s*[,}]/);
 
-          const toolResultMsg = {
-            role: "toolResult" as const,
-            toolCallId: toolCall?.id ?? "",
-            toolName: "record_value",
-            isError: false,
-            content: [{ type: "text" as const, text: "recorded" }],
-            timestamp: 2,
-          };
-          const round1Messages: Context["messages"] = [firstUser, callTurn, toolResultMsg];
-          const afterToolResult = await run(
-            { messages: round1Messages, tools: [recordValueTool] },
-            sessionId,
-          );
-          expect(afterToolResult.stopReason).toBe("stop");
-
-          // Exactly two requests reached the real API -- a rejected
-          // previous_response_id (the recovery path is a silent
-          // full-history resend) would show up as a third.
-          expect(capture.requests).toHaveLength(2);
-          const secondRequest = capture.requests[1];
-          expect(secondRequest).toHaveProperty("previous_response_id");
-          expect(typeof secondRequest?.previous_response_id).toBe("string");
-          expect(
-            (secondRequest?.previous_response_id as string | undefined)?.length ?? 0,
-          ).toBeGreaterThan(0);
-          // toolCall.id is OpenClaw's own internal call_id|fc_id pairing;
-          // the wire delta's call_id must be restored to the bare provider
-          // call_id (the part before the pairing separator), not the
-          // compound internal id.
-          const rawCallId = toolCall?.id.split("|")[0];
-          expect(secondRequest?.input).toEqual([
-            {
-              type: "function_call_output",
-              call_id: rawCallId,
-              output: "recorded",
-            },
-          ]);
-        } finally {
-          capture.restore();
-        }
-      },
-      LIVE_TIMEOUT_MS,
+    const second = await captureOpenAIResponses(() =>
+      run([
+        user,
+        first.result,
+        {
+          role: "toolResult",
+          toolCallId: call.id,
+          toolName: call.name,
+          isError: false,
+          content: [{ type: "text", text: "recorded" }],
+          timestamp: 2,
+        },
+      ]),
     );
-  },
-);
+    expect(second.result.stopReason).toBe("stop");
+    // A rejected response reference would cause an extra request with full history.
+    expect(second.requests).toHaveLength(1);
+    expect(second.requests[0]?.previous_response_id).toEqual(expect.any(String));
+    expect(second.requests[0]?.input).toEqual([
+      { type: "function_call_output", call_id: call.id.split("|")[0], output: "recorded" },
+    ]);
+  }, 120_000);
+});

--- a/packages/ai/src/transports/openai-responses-client.continuation-unsafe-integer.live.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.continuation-unsafe-integer.live.test.ts
@@ -63,6 +63,14 @@ class GlobalFetchRequestCapture {
   // handled, so it would prove nothing about this fix. (ClawSweeper P2 on
   // #134423.)
   readonly rawResponseTexts: string[] = [];
+  // One promise per captured response, in the same order as `requests` /
+  // `rawResponseTexts`. The tee's capture branch is read in the background so
+  // the real SDK consumer is never blocked on it, but that means
+  // rawResponseTexts[i] is not populated yet when fetch() itself resolves --
+  // a caller MUST await captureCompletions[i] before reading it, or it may
+  // observe an empty or partial string depending on scheduling (ClawSweeper
+  // P2 on #134423).
+  readonly captureCompletions: Array<Promise<void>> = [];
   private readonly realFetch = globalThis.fetch;
 
   install(): void {
@@ -84,23 +92,25 @@ class GlobalFetchRequestCapture {
       const [forCaller, forCapture] = response.body.tee();
       const captureIndex = this.rawResponseTexts.length;
       this.rawResponseTexts.push("");
-      void (async () => {
-        const reader = forCapture.getReader();
-        const decoder = new TextDecoder();
-        let text = "";
-        try {
-          for (;;) {
-            const { done, value } = await reader.read();
-            if (done) {
-              break;
+      this.captureCompletions.push(
+        (async () => {
+          const reader = forCapture.getReader();
+          const decoder = new TextDecoder();
+          let text = "";
+          try {
+            for (;;) {
+              const { done, value } = await reader.read();
+              if (done) {
+                break;
+              }
+              text += decoder.decode(value, { stream: true });
             }
-            text += decoder.decode(value, { stream: true });
+          } catch {
+            // Best-effort capture; the real caller's own stream is unaffected.
           }
-        } catch {
-          // Best-effort capture; the real caller's own stream is unaffected.
-        }
-        this.rawResponseTexts[captureIndex] = text;
-      })();
+          this.rawResponseTexts[captureIndex] = text;
+        })(),
+      );
       return new Response(forCaller, {
         status: response.status,
         statusText: response.statusText,
@@ -213,7 +223,12 @@ describeLive(
           // on the wire -- not a model-quoted string, which the pre-fix
           // comparison already handled and would make this whole test prove
           // nothing about the fix. Inspects raw SSE bytes, before any
-          // OpenClaw-side parsing.
+          // OpenClaw-side parsing. Must await the capture's own completion
+          // first: it fills in rawResponseTexts[0] on a background task, in
+          // parallel with (not blocking) the real SDK's own stream consumer,
+          // so reading it before this resolves would race an unfinished or
+          // empty capture.
+          await capture.captureCompletions[0];
           const rawArguments = extractRawFunctionCallArguments(capture.rawResponseTexts[0] ?? "");
           expect(
             rawArguments,

--- a/packages/ai/src/transports/openai-responses-client.continuation-unsafe-integer.live.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.continuation-unsafe-integer.live.test.ts
@@ -231,6 +231,8 @@ describeLive(
           const toolResultMsg = {
             role: "toolResult" as const,
             toolCallId: toolCall?.id ?? "",
+            toolName: "record_value",
+            isError: false,
             content: [{ type: "text" as const, text: "recorded" }],
             timestamp: 2,
           };

--- a/packages/ai/src/transports/openai-responses-client.continuation.integration.test.ts
+++ b/packages/ai/src/transports/openai-responses-client.continuation.integration.test.ts
@@ -1,0 +1,235 @@
+import { createServer } from "node:http";
+import type { Context, Model } from "@openclaw/llm-core";
+import OpenAI from "openai";
+import { expect, it, vi } from "vitest";
+import { WebSocketServer } from "ws";
+import { cleanupSessionResources } from "../session-resources.js";
+import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
+
+const model = {
+  id: "scripted-model",
+  name: "Scripted Model",
+  api: "openai-responses",
+  provider: "openai",
+  baseUrl: "https://api.openai.com/v1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 8192,
+  maxTokens: 256,
+} satisfies Model<"openai-responses">;
+
+const tool = {
+  name: "record_value",
+  description: "Record the supplied value.",
+  parameters: { type: "object", properties: { n: { type: "integer" } }, required: ["n"] },
+};
+
+function responseEvents(first: boolean) {
+  const item = first
+    ? {
+        type: "function_call",
+        id: "fc_number",
+        call_id: "call_number",
+        name: tool.name,
+        arguments: '{"n":9007199254740993}',
+        status: "completed",
+      }
+    : {
+        type: "message",
+        id: "msg_done",
+        role: "assistant",
+        status: "completed",
+        content: [{ type: "output_text", text: "recorded", annotations: [] }],
+      };
+  return [
+    ...(first
+      ? [
+          {
+            type: "response.output_item.added",
+            output_index: 0,
+            item: { ...item, arguments: "", status: "in_progress" },
+          },
+          {
+            type: "response.function_call_arguments.delta",
+            output_index: 0,
+            item_id: item.id,
+            delta: '{"n":9007199254740993}',
+          },
+          { type: "response.output_item.done", output_index: 0, item },
+        ]
+      : []),
+    {
+      type: "response.completed",
+      response: {
+        id: first ? "resp_number" : "resp_done",
+        status: "completed",
+        output: [item],
+        usage: { input_tokens: 5, output_tokens: 3, total_tokens: 8 },
+      },
+    },
+  ];
+}
+
+it.each([
+  ["sse", "none"],
+  ["sse", "response-value"],
+  ["sse", "sent-type"],
+  ["websocket-cached", "none"],
+  ["websocket-cached", "response-value"],
+  ["websocket-cached", "sent-type"],
+] as const)(
+  "preserves real %s continuation with edited arguments=%s",
+  async (transport, edited) => {
+    const requests: Array<Record<string, unknown>> = [];
+    const eventsForRequest = (body: string) => {
+      requests.push(JSON.parse(body) as Record<string, unknown>);
+      return responseEvents(requests.length === 1);
+    };
+    const server = createServer((request, response) => {
+      request.setEncoding("utf8");
+      let body = "";
+      request.on("data", (chunk: string) => {
+        body += chunk;
+      });
+      request.on("end", () => {
+        response.writeHead(200, { "content-type": "text/event-stream" });
+        for (const event of eventsForRequest(body)) {
+          response.write(`data: ${JSON.stringify(event)}\n\n`);
+        }
+        response.end();
+      });
+    });
+    const sockets = new WebSocketServer({ server });
+    sockets.on("connection", (socket) => {
+      socket.on("message", (body) => {
+        if (!Buffer.isBuffer(body)) {
+          throw new Error("Expected a Buffer from the WebSocket server");
+        }
+        for (const event of eventsForRequest(body.toString("utf8"))) {
+          socket.send(JSON.stringify(event));
+        }
+      });
+    });
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Expected a loopback TCP address");
+    }
+    // The replacement calls this original method with the active SDK client as `this`.
+    // oxlint-disable-next-line typescript/unbound-method
+    const buildURL = OpenAI.prototype.buildURL;
+    // Route only the network destination; native eligibility, the SDK, and all request bytes stay real.
+    vi.spyOn(OpenAI.prototype, "buildURL").mockImplementation(
+      function (this: OpenAI, path, query, baseURL) {
+        const url = new URL(buildURL.call(this, path, query, baseURL));
+        expect(url.origin).toBe("https://api.openai.com");
+        expect(url.pathname).toBe("/v1/responses");
+        url.protocol = "http:";
+        url.hostname = "127.0.0.1";
+        url.port = String(address.port);
+        return url.href;
+      },
+    );
+    const run = async (messages: Context["messages"]) => {
+      const stream = await createOpenAIResponsesTransportStreamFn()(
+        model,
+        { messages, tools: [tool] },
+        {
+          apiKey: "synthetic-continuation-key",
+          sessionId: `wire-${transport}-${edited}`,
+          transport,
+          onPayload: (payload) => ({ ...(payload as Record<string, unknown>), store: true }),
+        },
+      );
+      return stream.result();
+    };
+    try {
+      const user = { role: "user" as const, content: "Record 9007199254740993.", timestamp: 1 };
+      const first = await run([user]);
+      expect(first.stopReason).toBe("toolUse");
+      const call = first.content.find((block) => block.type === "toolCall");
+      expect(call?.arguments).toEqual({ n: "9007199254740993" });
+      if (!call) {
+        throw new Error("Expected a completed tool call");
+      }
+      const replay = structuredClone(first);
+      const editedValue = edited === "sent-type" ? 9007199254740992 : "9007199254740992";
+      if (edited !== "none") {
+        replay.content = [{ ...call, arguments: { n: editedValue } }];
+      }
+      const result = {
+        role: "toolResult" as const,
+        toolCallId: call.id,
+        toolName: call.name,
+        content: [{ type: "text" as const, text: "ok" }],
+        isError: false,
+        timestamp: 2,
+      };
+      const second = await run([user, replay, result]);
+      expect(second.stopReason).toBe("stop");
+      expect(requests).toHaveLength(2);
+      expect(requests.map((request) => request.type)).toEqual(
+        transport === "websocket-cached"
+          ? ["response.create", "response.create"]
+          : [undefined, undefined],
+      );
+      if (edited !== "none") {
+        expect(requests[1]).not.toHaveProperty("previous_response_id");
+        expect(requests[1]?.input).toContainEqual(
+          expect.objectContaining({
+            type: "function_call",
+            arguments: JSON.stringify({ n: editedValue }),
+          }),
+        );
+      } else {
+        expect(requests[1]).toMatchObject({
+          previous_response_id: "resp_number",
+          input: [{ type: "function_call_output", call_id: "call_number", output: "ok" }],
+        });
+      }
+      expect(first.content.find((block) => block.type === "toolCall")?.arguments).toEqual({
+        n: "9007199254740993",
+      });
+      if (edited === "sent-type") {
+        const changedReplay = {
+          ...replay,
+          content: [{ ...call, arguments: { n: "9007199254740992" } }],
+        };
+        const third = await run([
+          user,
+          changedReplay,
+          result,
+          second,
+          { role: "user", content: "Continue.", timestamp: 3 },
+        ]);
+        expect(third.stopReason).toBe("stop");
+        expect(requests).toHaveLength(3);
+        expect(requests[2]?.type).toBe(
+          transport === "websocket-cached" ? "response.create" : undefined,
+        );
+        expect(requests[2]).not.toHaveProperty("previous_response_id");
+        expect(requests[2]?.input).toHaveLength(5);
+        expect(requests[2]?.input).toContainEqual(
+          expect.objectContaining({ type: "function_call", arguments: '{"n":"9007199254740992"}' }),
+        );
+      }
+    } finally {
+      cleanupSessionResources();
+      vi.restoreAllMocks();
+      for (const socket of sockets.clients) {
+        socket.terminate();
+      }
+      await new Promise<void>((resolve, reject) => {
+        sockets.close((error) => (error ? reject(error) : resolve()));
+      });
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeAllConnections();
+      });
+    }
+  },
+);

--- a/packages/ai/src/transports/openai-responses-continuation.test.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.test.ts
@@ -147,113 +147,169 @@ describe("OpenAI Responses continuation", () => {
     );
   });
 
-  it("does not treat two different unsafe-integer arguments as equal (lossless comparison)", () => {
-    // Number.MAX_SAFE_INTEGER + 1 and + 2 both round to the same double
-    // under plain JSON.parse; a lossless comparator must still tell them
-    // apart so a genuinely changed argument is never mistaken for a
-    // re-serialization whitespace difference.
-    const toolCall = {
-      type: "function_call",
-      id: "fc_1",
-      status: "completed",
-      call_id: "call_original_abc",
-      name: "exec",
-      arguments: '{"n":9007199254740993}',
-    };
-    const state: ResponsesContinuationState = {
-      lastRequest: { model: "gpt-5.6-luna", store: true, input: [firstUser] as never },
-      lastResponseId: "resp_1",
-      lastResponseItems: [toolCall] as never,
-    };
-    const replayedToolCall = { ...toolCall, arguments: '{"n": 9007199254740994}' };
-    const toolResult = {
-      type: "function_call_output",
-      call_id: "call_original_abc",
-      output: "hi\n",
-    };
-    const nextRoundRequest: ResponsesContinuationRequest = {
-      model: "gpt-5.6-luna",
-      store: true,
-      input: [firstUser, replayedToolCall, toolResult] as never,
-    };
-
-    expect(resolveResponsesContinuationRequest(state, nextRoundRequest).continuationStatus).toBe(
+  it.each([
+    [
+      "unsafe integer round-trip",
+      '{"n":9007199254740993}',
+      '{"n":"9007199254740993"}',
+      "continued",
+    ],
+    [
+      "negative unsafe round-trip",
+      '{"n":-9007199254740993}',
+      '{"n":"-9007199254740993"}',
+      "continued",
+    ],
+    [
+      "provider whitespace in nested arguments",
+      '{ "b": {"n":9007199254740993,"a":true},"a":[1] }',
+      '{"b":{"n":"9007199254740993","a":true},"a":[1]}',
+      "continued",
+    ],
+    [
+      "reordered keys remain conservative",
+      '{"b":{"n":9007199254740993,"a":true},"a":[1]}',
+      '{"a":[1],"b":{"a":true,"n":"9007199254740993"}}',
       "history_changed",
-    );
-  });
-
-  it("treats a cached number-typed unsafe integer as equal to its own replayed string-typed round-trip", () => {
-    // Real shape, confirmed live against a real tool-calling round: the
-    // cached side is the raw provider text (a bare, unsafe-integer number),
-    // but AssistantMessage.arguments already stores every unsafe integer as
-    // a string (parseJsonObjectPreservingUnsafeIntegers,
-    // transport-stream-shared.ts, precision-preserving), so the *unmodified*
-    // replay of this exact same historical tool call always re-serializes it
-    // back as a same-digits JSON string. This is the client's own necessary
-    // representation of the same value, not a real argument change -- an
-    // earlier revision of this fix (a distinguishing tag on the cached side
-    // only) treated this as a genuine change, permanently breaking
-    // continuation for the very next round of any real tool call carrying an
-    // out-of-range integer.
-    const toolCall = {
-      type: "function_call",
-      id: "fc_1",
-      status: "completed",
-      call_id: "call_original_abc",
-      name: "exec",
-      arguments: '{"n":9007199254740993}',
-    };
-    const state: ResponsesContinuationState = {
-      lastRequest: { model: "gpt-5.6-luna", store: true, input: [firstUser] as never },
-      lastResponseId: "resp_1",
-      lastResponseItems: [toolCall] as never,
-    };
-    const replayedToolCall = { ...toolCall, arguments: '{"n":"9007199254740993"}' };
-    const toolResult = {
-      type: "function_call_output",
-      call_id: "call_original_abc",
-      output: "hi\n",
-    };
-    const nextRoundRequest: ResponsesContinuationRequest = {
-      model: "gpt-5.6-luna",
-      store: true,
-      input: [firstUser, replayedToolCall, toolResult] as never,
-    };
-
-    expect(resolveResponsesContinuationRequest(state, nextRoundRequest).continuationStatus).toBe(
+    ],
+    [
+      "positive binary64 collision",
+      '{"n":9007199254740992}',
+      '{"n":9007199254740993}',
+      "history_changed",
+    ],
+    [
+      "negative binary64 collision",
+      '{"n":-9007199254740992}',
+      '{"n":-9007199254740993}',
+      "history_changed",
+    ],
+    [
+      "edited preserved integer",
+      '{"n":9007199254740993}',
+      '{"n":"9007199254740992"}',
+      "history_changed",
+    ],
+    [
+      "provider string changed to bare unsafe integer",
+      '{"n":"9007199254740992"}',
+      '{"n":9007199254740992}',
+      "history_changed",
+    ],
+    [
+      "admitted integer string changed to Number",
+      '{"n":9007199254740992}',
+      '{"n":9007199254740992}',
+      "history_changed",
+    ],
+    ["safe integer versus string", '{"n":42}', '{"n":"42"}', "history_changed"],
+    [
+      "safe boundary versus string",
+      '{"n":9007199254740991}',
+      '{"n":"9007199254740991"}',
+      "history_changed",
+    ],
+    [
+      "quoted digits and escapes",
+      '{"text":"\\\"9007199254740993\\\"","n":9007199254740993}',
+      '{"text":"\\\"9007199254740993\\\"","n":"9007199254740993"}',
       "continued",
-    );
-  });
-
-  it("treats a whitespace-only re-serialization of the same unsafe integer as equal", () => {
-    const toolCall = {
-      type: "function_call",
-      id: "fc_1",
-      status: "completed",
-      call_id: "call_original_abc",
-      name: "exec",
-      arguments: '{"n":9007199254740993}',
-    };
-    const state: ResponsesContinuationState = {
-      lastRequest: { model: "gpt-5.6-luna", store: true, input: [firstUser] as never },
-      lastResponseId: "resp_1",
-      lastResponseItems: [toolCall] as never,
-    };
-    const replayedToolCall = { ...toolCall, arguments: '{"n": 9007199254740993}' };
-    const toolResult = {
-      type: "function_call_output",
-      call_id: "call_original_abc",
-      output: "hi\n",
-    };
-    const nextRoundRequest: ResponsesContinuationRequest = {
-      model: "gpt-5.6-luna",
-      store: true,
-      input: [firstUser, replayedToolCall, toolResult] as never,
-    };
-
-    expect(resolveResponsesContinuationRequest(state, nextRoundRequest).continuationStatus).toBe(
+    ],
+    ["unchanged incomplete JSON", '{"n":', '{"n":', "continued"],
+    ["changed incomplete JSON", '{"n":', '{"n": }', "history_changed"],
+    [
+      "invalid leading zero",
+      '{"n":09007199254740993}',
+      '{"n":"9007199254740993"}',
+      "history_changed",
+    ],
+    ["non-object array", "[42]", "[42.0]", "history_changed"],
+    ["non-object null", "null", " null ", "history_changed"],
+    ["safe fraction", '{"n":4.20}', '{"n":4.2}', "continued"],
+    ["safe exponent", '{"n":4.2e1}', '{"n":42}', "continued"],
+    ["safe exponent versus string", '{"n":4.2e1}', '{"n":"42"}', "history_changed"],
+    [
+      "unsafe exponent follows terminal Number serialization",
+      '{"n":1e16}',
+      '{"n":10000000000000000}',
       "continued",
-    );
+    ],
+    [
+      "unsafe fraction follows terminal Number serialization",
+      '{"n":10000000000000000.0}',
+      '{"n":10000000000000000}',
+      "continued",
+    ],
+  ] as const)(
+    "compares admitted provider tool arguments: %s",
+    (_name, rawArguments, replayedArguments, expectedStatus) => {
+      const state = continuationState();
+      const call = {
+        type: "function_call" as const,
+        id: "fc_1",
+        status: "completed" as const,
+        call_id: "call_1",
+        name: "record_value",
+        arguments: rawArguments,
+      };
+      state.lastResponseItems = [call];
+      const output = {
+        type: "function_call_output" as const,
+        call_id: "call_1",
+        output: "recorded",
+      };
+      const request = {
+        ...state.lastRequest,
+        input: [
+          ...(state.lastRequest.input ?? []),
+          { ...call, arguments: replayedArguments },
+          output,
+        ],
+      };
+      const before = structuredClone({ state, request });
+      const resolved = resolveResponsesContinuationRequest(state, request);
+      expect(resolved.continuationStatus).toBe(expectedStatus);
+      if (expectedStatus === "continued") {
+        expect(resolved.request).toMatchObject({ previous_response_id: "resp_1", input: [output] });
+      } else {
+        expect(resolved.request).toBe(request);
+      }
+      expect({ state, request }).toEqual(before);
+    },
+  );
+
+  it.each([
+    ['{"n":9007199254740992}', '{"n":"9007199254740992"}', "history_changed"],
+    ['{"n":"9007199254740992"}', '{"n":9007199254740992}', "history_changed"],
+    ['{"n":9007199254740992}', '{"n":9007199254740993}', "history_changed"],
+    ['{"n":9007199254740992}', '{"n":9007199254740992}', "continued"],
+  ] as const)("keeps already-sent arguments strict: %s -> %s", (sent, current, expectedStatus) => {
+    const state = continuationState();
+    const call = {
+      type: "function_call" as const,
+      call_id: "sent_call",
+      name: "record_value",
+      arguments: sent,
+    };
+    const output = {
+      type: "function_call_output" as const,
+      call_id: "sent_call",
+      output: "recorded",
+    };
+    state.lastRequest.input = [...(state.lastRequest.input ?? []), call, output];
+    const request = nextRequest();
+    const [user, ...next] = request.input ?? [];
+    if (!user) {
+      throw new Error("Expected the fixture's first user message");
+    }
+    request.input = [user, { ...call, arguments: current }, output, ...next];
+    const before = structuredClone({ state, request });
+    const resolved = resolveResponsesContinuationRequest(state, request);
+    expect(resolved.continuationStatus).toBe(expectedStatus);
+    if (expectedStatus === "history_changed") {
+      expect(resolved.request).toBe(request);
+    }
+    expect({ state, request }).toEqual(before);
   });
 
   it("ignores turn correlation headers but isolates explicit authorization", () => {

--- a/packages/ai/src/transports/openai-responses-continuation.test.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.test.ts
@@ -147,6 +147,115 @@ describe("OpenAI Responses continuation", () => {
     );
   });
 
+  it("does not treat two different unsafe-integer arguments as equal (lossless comparison)", () => {
+    // Number.MAX_SAFE_INTEGER + 1 and + 2 both round to the same double
+    // under plain JSON.parse; a lossless comparator must still tell them
+    // apart so a genuinely changed argument is never mistaken for a
+    // re-serialization whitespace difference.
+    const toolCall = {
+      type: "function_call",
+      id: "fc_1",
+      status: "completed",
+      call_id: "call_original_abc",
+      name: "exec",
+      arguments: '{"n":9007199254740993}',
+    };
+    const state: ResponsesContinuationState = {
+      lastRequest: { model: "gpt-5.6-luna", store: true, input: [firstUser] as never },
+      lastResponseId: "resp_1",
+      lastResponseItems: [toolCall] as never,
+    };
+    const replayedToolCall = { ...toolCall, arguments: '{"n": 9007199254740994}' };
+    const toolResult = {
+      type: "function_call_output",
+      call_id: "call_original_abc",
+      output: "hi\n",
+    };
+    const nextRoundRequest: ResponsesContinuationRequest = {
+      model: "gpt-5.6-luna",
+      store: true,
+      input: [firstUser, replayedToolCall, toolResult] as never,
+    };
+
+    expect(resolveResponsesContinuationRequest(state, nextRoundRequest).continuationStatus).toBe(
+      "history_changed",
+    );
+  });
+
+  it("treats a cached number-typed unsafe integer as equal to its own replayed string-typed round-trip", () => {
+    // Real shape, confirmed live against a real tool-calling round: the
+    // cached side is the raw provider text (a bare, unsafe-integer number),
+    // but AssistantMessage.arguments already stores every unsafe integer as
+    // a string (parseJsonObjectPreservingUnsafeIntegers,
+    // transport-stream-shared.ts, precision-preserving), so the *unmodified*
+    // replay of this exact same historical tool call always re-serializes it
+    // back as a same-digits JSON string. This is the client's own necessary
+    // representation of the same value, not a real argument change -- an
+    // earlier revision of this fix (a distinguishing tag on the cached side
+    // only) treated this as a genuine change, permanently breaking
+    // continuation for the very next round of any real tool call carrying an
+    // out-of-range integer.
+    const toolCall = {
+      type: "function_call",
+      id: "fc_1",
+      status: "completed",
+      call_id: "call_original_abc",
+      name: "exec",
+      arguments: '{"n":9007199254740993}',
+    };
+    const state: ResponsesContinuationState = {
+      lastRequest: { model: "gpt-5.6-luna", store: true, input: [firstUser] as never },
+      lastResponseId: "resp_1",
+      lastResponseItems: [toolCall] as never,
+    };
+    const replayedToolCall = { ...toolCall, arguments: '{"n":"9007199254740993"}' };
+    const toolResult = {
+      type: "function_call_output",
+      call_id: "call_original_abc",
+      output: "hi\n",
+    };
+    const nextRoundRequest: ResponsesContinuationRequest = {
+      model: "gpt-5.6-luna",
+      store: true,
+      input: [firstUser, replayedToolCall, toolResult] as never,
+    };
+
+    expect(resolveResponsesContinuationRequest(state, nextRoundRequest).continuationStatus).toBe(
+      "continued",
+    );
+  });
+
+  it("treats a whitespace-only re-serialization of the same unsafe integer as equal", () => {
+    const toolCall = {
+      type: "function_call",
+      id: "fc_1",
+      status: "completed",
+      call_id: "call_original_abc",
+      name: "exec",
+      arguments: '{"n":9007199254740993}',
+    };
+    const state: ResponsesContinuationState = {
+      lastRequest: { model: "gpt-5.6-luna", store: true, input: [firstUser] as never },
+      lastResponseId: "resp_1",
+      lastResponseItems: [toolCall] as never,
+    };
+    const replayedToolCall = { ...toolCall, arguments: '{"n": 9007199254740993}' };
+    const toolResult = {
+      type: "function_call_output",
+      call_id: "call_original_abc",
+      output: "hi\n",
+    };
+    const nextRoundRequest: ResponsesContinuationRequest = {
+      model: "gpt-5.6-luna",
+      store: true,
+      input: [firstUser, replayedToolCall, toolResult] as never,
+    };
+
+    expect(resolveResponsesContinuationRequest(state, nextRoundRequest).continuationStatus).toBe(
+      "continued",
+    );
+  });
+
   it("ignores turn correlation headers but isolates explicit authorization", () => {
     const first = claim({ turn: "1" });
     first?.commit(continuationState().lastRequest, {

--- a/packages/ai/src/transports/openai-responses-continuation.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.ts
@@ -3,7 +3,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ResponseInput, ResponseOutputItem } from "openai/resources/responses/responses.js";
 import { getAiTransportHost, resolveAiTransportHeaderSentinels } from "../host.js";
 import { registerSessionResourceCleanup } from "../session-resources.js";
-import { quoteUnsafeIntegerLiterals } from "./json-unsafe-integers.js";
+import { parseJsonObjectPreservingUnsafeIntegers } from "./json-unsafe-integers.js";
 import { sha256Hex } from "./transport-utils.js";
 
 const HTTP_CONTINUATION_IDLE_TTL_MS = 5 * 60 * 1000;
@@ -35,14 +35,7 @@ function jsonValuesEqual(left: object, right: object): boolean {
 }
 
 function requestWithoutInput(request: ResponsesContinuationRequest): ResponsesContinuationRequest {
-  // `instructions` (like `input`) carries the system prompt for every
-  // non-Codex Responses request now, rebuilt fresh from live runtime state
-  // on every attempt -- see resolveOpenAIResponsesInstructions in
-  // openai-responses-params-internal.ts. It is sent on the wire on every
-  // request regardless of continuation status (spread from the original
-  // request below), so excluding it here loses no freshness; comparing it
-  // would just move the same false-positive rejection this module already
-  // guards against in `input` into `request_changed` instead.
+  // Instructions are rebuilt and sent on every request; exclude them from history matching.
   const {
     input: _input,
     previous_response_id: _previousResponseId,
@@ -60,48 +53,7 @@ function requestWithoutInput(request: ResponsesContinuationRequest): ResponsesCo
   return { ...rest, metadata };
 }
 
-// A function_call's `arguments` is a JSON-encoded string, not a nested
-// object -- jsonValuesEqual only normalizes key order at the *parsed* level,
-// so two byte-different-but-semantically-identical encodings (e.g. a
-// re-`JSON.stringify` picking up different whitespace) would otherwise read
-// as a real content change. Round-trip through parse/stringify so only the
-// actual argument values are compared; leave non-JSON strings untouched.
-// quoteUnsafeIntegerLiterals runs first: plain JSON.parse silently rounds any
-// integer literal past Number.MAX_SAFE_INTEGER, so two genuinely DIFFERENT
-// unsafe integers could otherwise parse to the same JS number and wrongly
-// compare equal, sending a stale delta instead of the real changed argument.
-//
-// No distinguishing tag: an earlier revision quoted unsafe integers with a
-// tag to also catch a stringified unsafe integer colliding with a genuine
-// same-digits JSON string -- but on the *cached* side this compares against,
-// `arguments` is the raw provider text (a bare number), while the *replayed*
-// side is rebuilt from AssistantMessage.arguments, which
-// parseJsonObjectPreservingUnsafeIntegers (transport-stream-shared.ts)
-// already stores as a string for every unsafe integer, precision-preserving.
-// So a real, unmodified tool-calling round *always* replays an unsafe
-// integer as a same-digits string against a cached bare number -- tagging
-// only the cached side made every real large-integer tool call permanently
-// ineligible for continuation on its very next round (confirmed live: an
-// actual tool call with a real out-of-range integer, replayed unmodified,
-// still landed as history_changed). Plain (untagged) quoting can't tell a
-// converted integer apart from a genuine same-digit string either, but that
-// is not the risk here: both sides of this comparison replay the *same*
-// historical tool call, and the client-side "unsafe integers become
-// strings" convention already applies uniformly to how that call is cached
-// and replayed -- there is no independent second call in this comparison
-// for a same-digit string to collide with.
-function normalizeFunctionCallArguments(value: unknown): unknown {
-  if (typeof value !== "string") {
-    return value;
-  }
-  try {
-    return JSON.stringify(JSON.parse(quoteUnsafeIntegerLiterals(value)));
-  } catch {
-    return value;
-  }
-}
-
-function normalizeAssistantReplayInput(input: readonly unknown[]): unknown[] {
+function normalizeAssistantReplayInput(input: readonly unknown[], fromResponse = false): unknown[] {
   return input.map((item) => {
     if (!isRecord(item)) {
       return item;
@@ -113,8 +65,10 @@ function normalizeAssistantReplayInput(input: readonly unknown[]): unknown[] {
       return item;
     }
     const { id: _id, status: _status, ...stableItem } = item;
-    if (item.type === "function_call" && "arguments" in stableItem) {
-      stableItem.arguments = normalizeFunctionCallArguments(stableItem.arguments);
+    if (fromResponse && item.type === "function_call") {
+      // Only provider output crosses terminal admission; sent arguments must retain real type edits.
+      const args = parseJsonObjectPreservingUnsafeIntegers(stableItem.arguments);
+      stableItem.arguments = args ? JSON.stringify(args) : stableItem.arguments;
     }
     if (item.type === "message" && Array.isArray(stableItem.content)) {
       stableItem.content = stableItem.content.map((part) => {
@@ -157,7 +111,7 @@ export function resolveResponsesContinuationRequest(
     ) ||
     !jsonValuesEqual(
       normalizeAssistantReplayInput(currentInput.slice(previousInput.length, baselineLength)),
-      normalizeAssistantReplayInput(continuation.lastResponseItems),
+      normalizeAssistantReplayInput(continuation.lastResponseItems, true),
     )
   ) {
     return { request, continuationStatus: "history_changed" };

--- a/packages/ai/src/transports/openai-responses-continuation.ts
+++ b/packages/ai/src/transports/openai-responses-continuation.ts
@@ -3,6 +3,7 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import type { ResponseInput, ResponseOutputItem } from "openai/resources/responses/responses.js";
 import { getAiTransportHost, resolveAiTransportHeaderSentinels } from "../host.js";
 import { registerSessionResourceCleanup } from "../session-resources.js";
+import { quoteUnsafeIntegerLiterals } from "./json-unsafe-integers.js";
 import { sha256Hex } from "./transport-utils.js";
 
 const HTTP_CONTINUATION_IDLE_TTL_MS = 5 * 60 * 1000;
@@ -59,6 +60,47 @@ function requestWithoutInput(request: ResponsesContinuationRequest): ResponsesCo
   return { ...rest, metadata };
 }
 
+// A function_call's `arguments` is a JSON-encoded string, not a nested
+// object -- jsonValuesEqual only normalizes key order at the *parsed* level,
+// so two byte-different-but-semantically-identical encodings (e.g. a
+// re-`JSON.stringify` picking up different whitespace) would otherwise read
+// as a real content change. Round-trip through parse/stringify so only the
+// actual argument values are compared; leave non-JSON strings untouched.
+// quoteUnsafeIntegerLiterals runs first: plain JSON.parse silently rounds any
+// integer literal past Number.MAX_SAFE_INTEGER, so two genuinely DIFFERENT
+// unsafe integers could otherwise parse to the same JS number and wrongly
+// compare equal, sending a stale delta instead of the real changed argument.
+//
+// No distinguishing tag: an earlier revision quoted unsafe integers with a
+// tag to also catch a stringified unsafe integer colliding with a genuine
+// same-digits JSON string -- but on the *cached* side this compares against,
+// `arguments` is the raw provider text (a bare number), while the *replayed*
+// side is rebuilt from AssistantMessage.arguments, which
+// parseJsonObjectPreservingUnsafeIntegers (transport-stream-shared.ts)
+// already stores as a string for every unsafe integer, precision-preserving.
+// So a real, unmodified tool-calling round *always* replays an unsafe
+// integer as a same-digits string against a cached bare number -- tagging
+// only the cached side made every real large-integer tool call permanently
+// ineligible for continuation on its very next round (confirmed live: an
+// actual tool call with a real out-of-range integer, replayed unmodified,
+// still landed as history_changed). Plain (untagged) quoting can't tell a
+// converted integer apart from a genuine same-digit string either, but that
+// is not the risk here: both sides of this comparison replay the *same*
+// historical tool call, and the client-side "unsafe integers become
+// strings" convention already applies uniformly to how that call is cached
+// and replayed -- there is no independent second call in this comparison
+// for a same-digit string to collide with.
+function normalizeFunctionCallArguments(value: unknown): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(JSON.parse(quoteUnsafeIntegerLiterals(value)));
+  } catch {
+    return value;
+  }
+}
+
 function normalizeAssistantReplayInput(input: readonly unknown[]): unknown[] {
   return input.map((item) => {
     if (!isRecord(item)) {
@@ -71,6 +113,9 @@ function normalizeAssistantReplayInput(input: readonly unknown[]): unknown[] {
       return item;
     }
     const { id: _id, status: _status, ...stableItem } = item;
+    if (item.type === "function_call" && "arguments" in stableItem) {
+      stableItem.arguments = normalizeFunctionCallArguments(stableItem.arguments);
+    }
     if (item.type === "message" && Array.isArray(stableItem.content)) {
       stableItem.content = stableItem.content.map((part) => {
         if (!isRecord(part) || part.type !== "output_text") {

--- a/packages/ai/src/transports/openai-responses-live-capture.test-support.ts
+++ b/packages/ai/src/transports/openai-responses-live-capture.test-support.ts
@@ -1,0 +1,45 @@
+export async function captureOpenAIResponses<T>(run: () => Promise<T>): Promise<{
+  result: T;
+  requests: Array<Record<string, unknown>>;
+  responseTexts: string[];
+}> {
+  const requests: Array<Record<string, unknown>> = [];
+  const captures: Array<Promise<{ text: string } | { error: unknown }>> = [];
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = async (input, init) => {
+    const url = new URL(
+      typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
+    );
+    if (url.origin !== "https://api.openai.com" || url.pathname !== "/v1/responses") {
+      return realFetch(input, init);
+    }
+    if (typeof init?.body !== "string") {
+      throw new Error("Expected a JSON Responses request body");
+    }
+    requests.push(JSON.parse(init.body) as Record<string, unknown>);
+    const response = await realFetch(input, init);
+    // Await the clone before assertions; preserve the SDK's original response and stream.
+    captures.push(
+      response
+        .clone()
+        .text()
+        .then(
+          (text) => ({ text }),
+          (error: unknown) => ({ error }),
+        ),
+    );
+    return response;
+  };
+  try {
+    const result = await run();
+    const responseTexts = (await Promise.all(captures)).map((capture) => {
+      if ("error" in capture) {
+        throw new Error("Responses wire capture failed", { cause: capture.error });
+      }
+      return capture.text;
+    });
+    return { result, requests, responseTexts };
+  } finally {
+    globalThis.fetch = realFetch;
+  }
+}

--- a/packages/ai/src/transports/openai-responses-payload-policy.instructions.live.test.ts
+++ b/packages/ai/src/transports/openai-responses-payload-policy.instructions.live.test.ts
@@ -2,17 +2,9 @@ import type { AssistantMessage, Context, Model } from "@openclaw/llm-core";
 import { afterEach, describe, expect, it } from "vitest";
 import { cleanupSessionResources } from "../session-resources.js";
 import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
+import { captureOpenAIResponses } from "./openai-responses-live-capture.test-support.js";
 
-// Live coverage for the instructions-field default against the *real* native
-// OpenAI Responses API. The committed loopback integration test
-// (openai-responses-payload-policy.instructions.integration.test.ts) proves
-// openclaw's own request-building logic; it cannot prove the real API
-// actually accepts top-level `instructions` the way openclaw assumes, or
-// that HTTP continuation still works once the system prompt moved out of
-// `input`. This test captures the literal request bytes that leave the
-// process for the real API by wrapping globalThis.fetch. This avoids a proxy
-// while retaining the explicit native OpenAI baseUrl below; a loopback proxy
-// baseUrl would itself defeat the native-route classification under test.
+// Capture the real native endpoint: a proxy base URL would disable continuation eligibility.
 const LIVE = process.env.OPENCLAW_LIVE_TEST === "1";
 const OPENAI_KEY = process.env.OPENAI_API_KEY ?? "";
 const describeLive = LIVE && OPENAI_KEY ? describe : describe.skip;
@@ -21,31 +13,6 @@ const LIVE_TIMEOUT_MS = 120_000;
 
 function userMessage(text: string, timestamp: number) {
   return { role: "user" as const, content: text, timestamp };
-}
-
-async function captureOpenAIRequests<T>(run: () => Promise<T>): Promise<{
-  result: T;
-  requests: Array<Record<string, unknown>>;
-}> {
-  const requests: Array<Record<string, unknown>> = [];
-  const realFetch = globalThis.fetch;
-  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
-    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
-    if (url.includes("api.openai.com") && typeof init?.body === "string") {
-      try {
-        requests.push(JSON.parse(init.body) as Record<string, unknown>);
-      } catch {
-        // Non-JSON body (unexpected for this endpoint) -- skip capture, still forward the real call.
-      }
-    }
-    return realFetch(input, init);
-  }) as typeof fetch;
-  try {
-    const result = await run();
-    return { result, requests };
-  } finally {
-    globalThis.fetch = realFetch;
-  }
 }
 
 async function runTurn(
@@ -72,15 +39,6 @@ describeLive("instructions-field default on the real native OpenAI Responses API
   it(
     "carries the system prompt via top-level instructions and still continues via previous_response_id",
     async () => {
-      // Explicit canonical baseUrl: usesKnownNativeOpenAIRoute classifies
-      // this as native via endpointClass "openai-public" either way, but
-      // continuation eligibility (supportsNativeOpenAIResponsesEndpoint in
-      // openai-responses-websocket.ts) is stricter -- it requires an exact
-      // https://api.openai.com/v1 origin/path match and returns false for
-      // an absent baseUrl outright, unlike this PR's own instructions-field
-      // policy which treats "no baseUrl + provider openai" as native too.
-      // A loopback proxy baseUrl would fail that same exact-match check,
-      // which is why capture happens via a fetch wrapper instead (see above).
       const model: Model<"openai-responses"> = {
         id: LIVE_MODEL_ID,
         name: LIVE_MODEL_ID,
@@ -102,7 +60,7 @@ describeLive("instructions-field default on the real native OpenAI Responses API
         1,
       );
 
-      const { result: first, requests: firstRequests } = await captureOpenAIRequests(() =>
+      const { result: first, requests: firstRequests } = await captureOpenAIResponses(() =>
         runTurn(
           model,
           { systemPrompt: "You are a terse test assistant.", messages: [firstUser], tools: [] },
@@ -116,7 +74,7 @@ describeLive("instructions-field default on the real native OpenAI Responses API
       expect(firstRequests[0]?.instructions).toBe("You are a terse test assistant.");
       expect(firstRequests[0]).not.toHaveProperty("previous_response_id");
 
-      const { result: second, requests: secondRequests } = await captureOpenAIRequests(() =>
+      const { result: second, requests: secondRequests } = await captureOpenAIResponses(() =>
         runTurn(
           model,
           {


### PR DESCRIPTION
OpenAI Responses tool arguments arrive as raw JSON text. Terminal admission preserves unsafe integers as strings, and replay serializes that accepted object. Comparing replay with the raw provider output therefore discarded otherwise valid continuation state and resent the full conversation.

Normalize only cached provider output through the existing admission parser and replay serialization. Keep current and previously sent arguments strict: a real value or type edit must still force full replay. This also removes the duplicate stringifier and condenses the continuation-owner comment to the durable invariant requested in the ClawSweeper review. Request and cache objects remain unchanged.

The regression fixture uses the actual OpenAI SDK over loopback HTTP/SSE and cached WebSocket connections. It proves unchanged unsafe-integer output uses a continuation delta, edited output uses full history, and changing an already-sent Number to String on a third turn cannot be hidden by normalization. WebSocket assertions reject an HTTP fallback masquerading as WebSocket coverage.

Validation for the source published in e27f428f29e280c1c64043daf952d320d5499e02:

- Reproduced the original unchanged-output failure on both transports; edited-value controls passed. Separately reproduced both third-turn type-edit failures before the final repair.
- Final isolated run: 146 tests across eight files passed, including 22 provider-output comparison cases, four prior-input strictness cases, and both actual SDK transports. Every changed-file native gate passed. All six post-test source hashes match this commit.
- A separate official-endpoint probe using the registry-verified OpenAI 7.5.0 SDK observed raw bare `9007199254740993`, then successfully submitted only its tool output with `previous_response_id`: exactly two POSTs, no fallback or retry. It loaded no PR code. The credential-dependent hosted PR fixtures were not run; this probe establishes the external contract while the loopback fixture exercises the changed implementation. A separate instructions control observed the expected content but failed its exact-string check on whitespace; it is not counted as a passing test.
- Independent managed Codex review completed with no actionable findings and verified final source integrity.

The shared owner is the continuation comparator, used by HTTP and WebSocket paths. Upstream Codex was inspected directly at `94cbbddafc1776d5e377bca1b05932c697e82238` (`codex-rs/core/src/client.rs:330`, `:1331`, `:2197`; `codex-rs/protocol/src/models.rs:1037`; `codex-rs/codex-api/src/sse/responses.rs:354`, `:479`). Its raw-string history differs from OpenClaw's accepted-object replay boundary; this change preserves that distinction.

Production delta against the PR base: +9/-10, net -1. Tests and support: net +498. No new configuration, dependency, storage, or numeric policy. Arbitrary rewrites of already-sent JSON remain a conservative full replay.

Thanks @hartmark for the original fix and regression investigation.
