### PR TITLE
fix(test): avoid lingering CLI helper deadlines

### DIFF
--- a/test/helpers/openclaw-test-instance.test.ts
+++ b/test/helpers/openclaw-test-instance.test.ts
@@ -1,4 +1,5 @@
 // OpenClaw test instance tests cover spawned test instance lifecycle.
+import { AsyncLocalStorage, createHook } from "node:async_hooks";
 import { spawn } from "node:child_process";
 import { EventEmitter, once } from "node:events";
 import fs from "node:fs/promises";
@@ -190,6 +191,14 @@ const env = Object.fromEntries(["HOME", "OPENCLAW_CONFIG_PATH", "OPENCLAW_GATEWA
 appendFileSync(tracePath, JSON.stringify({ argv, config: JSON.parse(readFileSync(process.env.OPENCLAW_CONFIG_PATH, "utf8")), cwd: process.cwd(), env, pid: process.pid, port }) + "\\n");
 const kind = (process.env.OPENCLAW_FAKE_GATEWAY_SEQUENCE || "ready").split(",")[attempt - 1] || "ready";
 process.stdout.write("fake gateway attempt " + attempt + "\\n");
+if (kind === "cli") {
+  process.stderr.write("cli diagnostic\\n");
+  if (argv[0] === "wait") {
+    setInterval(() => {}, 1_000);
+    await new Promise(() => {});
+  }
+  process.exit(Number(argv[0]));
+}
 const refusal = ${JSON.stringify(MIGRATION_CONVERGENCE_REFUSAL)};
 if (kind === "refuse") { process.stderr.write(refusal + " fixture\\n"); process.exit(1); }
 if (kind === "late-refuse") {
@@ -284,6 +293,61 @@ function createGatewayProcessState(
 }
 
 describe("openclaw test instance", () => {
+  it.each([
+    { mode: "0", prepare: false },
+    { mode: "7", prepare: false },
+    { mode: "wait", prepare: false },
+    { mode: "0", prepare: true },
+  ])("releases the CLI deadline after $mode (prepare=$prepare)", async ({ mode, prepare }) => {
+    const control = prepare ? await createGatewayControl() : undefined;
+    await control?.release();
+    const preparation = control ? { url: control.url, holdPreparation: true } : undefined;
+    const { instance, readAttempts } = await createFakeGateway("cli", 1_000, 1_500, preparation);
+    const scope = new AsyncLocalStorage<boolean>();
+    const timers = new Map<number, NodeJS.Timeout>();
+    const hook = createHook({
+      init(id, type, _trigger, resource) {
+        if (type === "Timeout" && scope.getStore()) {
+          // Node's Timeout async resource is the cancellable timer handle.
+          timers.set(id, resource as NodeJS.Timeout);
+        }
+      },
+      destroy(id) {
+        timers.delete(id);
+      },
+    });
+    hook.enable();
+    try {
+      const timeoutMs = mode === "wait" ? 1_000 : 30_000;
+      const command = trackOperation(scope.run(true, () => instance.cli([mode], { timeoutMs })));
+      if (mode === "wait") {
+        await expect(command).rejects.toThrow(`command timed out after ${timeoutMs}ms`);
+      } else {
+        await expect(command).resolves.toEqual({
+          code: Number(mode),
+          signal: null,
+          stdout: "fake gateway attempt 1\n",
+          stderr: "cli diagnostic\n",
+        });
+      }
+      const attempts = await readAttempts();
+      expect(attempts).toHaveLength(1);
+      expect(isProcessAlive(attempts[0]!.pid)).toBe(false);
+      // Deliver Node's queued destroy hooks; elapsed wall time is not the oracle.
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(timers.size, "completed CLI invocation retained a deadline").toBe(0);
+    } finally {
+      hook.disable();
+      scope.disable();
+      // Retain the failing assertion while releasing only this invocation's timers.
+      for (const timer of timers.values()) {
+        clearTimeout(timer);
+      }
+    }
+  });
+
   it("joins concurrent starts until the real readiness response arrives", async () => {
     const control = await createGatewayControl();
     const { instance } = await createFakeGateway("held-ready", 1_000, 1_500, control);

--- a/test/helpers/openclaw-test-instance.ts
+++ b/test/helpers/openclaw-test-instance.ts
@@ -180,36 +180,18 @@ async function prepareGatewayEntrypoint(cwd: string): Promise<string[]> {
     return builtEntrypoint;
   }
 
-  const stdout = createBoundedStringLog();
-  const stderr = createBoundedStringLog();
-  const child = spawn("node", ["scripts/run-node.mjs", "--help"], {
+  // Share command ownership so successful preparation cannot retain its deadline.
+  const completed = await runCommand({
+    args: ["node", "scripts/run-node.mjs", "--help"],
     cwd,
     env: { ...process.env, VITEST: "1" },
-    stdio: ["ignore", "pipe", "pipe"],
-    detached: shouldUseOpenClawTestProcessGroup(),
+    timeoutMs: GATEWAY_ENTRYPOINT_PREPARE_TIMEOUT_MS,
   });
-  child.stdout?.setEncoding("utf8");
-  child.stderr?.setEncoding("utf8");
-  child.stdout?.on("data", (d) => appendLogChunk(stdout, d));
-  child.stderr?.on("data", (d) => appendLogChunk(stderr, d));
-
-  const completed = await Promise.race([
-    new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
-      child.once("error", reject);
-      child.once("exit", (code, signal) => resolve({ code, signal }));
-    }),
-    sleep(GATEWAY_ENTRYPOINT_PREPARE_TIMEOUT_MS).then(() => null),
-  ]);
-
-  if (completed === null) {
-    signalOpenClawTestProcess(child, "SIGKILL");
-    throw new Error(`timeout preparing gateway entrypoint\n${formatLogs(stdout, stderr)}`);
-  }
   if (completed.code !== 0) {
     throw new Error(
       `failed preparing gateway entrypoint (code=${String(completed.code)} signal=${String(
         completed.signal,
-      )})\n${formatLogs(stdout, stderr)}`,
+      )})\n${formatLogs([completed.stdout], [completed.stderr])}`,
     );
   }
 
@@ -680,13 +662,14 @@ async function runCommand(params: {
   child.stdout?.on("data", (d) => appendLogChunk(stdout, d));
   child.stderr?.on("data", (d) => appendLogChunk(stderr, d));
 
+  const deadline = new AbortController();
   const completed = await Promise.race([
     new Promise<{ code: number | null; signal: NodeJS.Signals | null }>((resolve, reject) => {
       child.once("error", reject);
       child.once("exit", (code, signal) => resolve({ code, signal }));
     }),
-    sleep(params.timeoutMs).then(() => null),
-  ]);
+    sleep(params.timeoutMs, deadline.signal).then(() => null),
+  ]).finally(() => deadline.abort());
   if (completed === null) {
     signalOpenClawTestProcess(child, "SIGKILL");
     await waitForGatewayClose(child, GATEWAY_STOP_TIMEOUT_MS);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where developers using the isolated OpenClaw test helper could retain a referenced deadline after a CLI process had already finished. Successful and nonzero commands left their 30-second timer alive; cold entrypoint preparation had a separate instance of the same problem with its 120-second deadline.

This is a maintainer-requested follow-up from release verification, backed by new failing boundary regressions. It does not claim to explain unrelated CI, SQLite, or hosting-cleanup timeouts.

## Why This Change Was Made

The command owner now cancels the losing sleep through its existing AbortSignal contract when the completion race settles. Cold entrypoint preparation reuses that same runner instead of maintaining a second spawn/deadline implementation. Command limits and timeout termination behavior are not weakened.

One table extends the existing synthetic fixture and calls the real `instance.cli()` API for successful exit, nonzero exit, timeout, and cold preparation. Invocation-scoped Node async hooks observe timer destruction; the test does not use elapsed performance as its oracle or expose a new production test seam.

## User Impact

Test and QA drivers no longer retain completed command/preparation deadlines. There are no production-runtime, configuration, storage, dependency, package-version, or release changes.

Production LOC: **0**. Test-support LOC: **−17** (`+8/−25`), removing the duplicated preparation runner. Regression coverage: **+64** lines in the existing test file.

## Evidence

- Before the command fix: successful and nonzero CLI cases both failed with `completed CLI invocation retained a deadline: expected 1 to be +0`; the timeout case passed.
- Before consolidating preparation: the three command cases passed, but the new cold-preparation case failed with the same retained-timer assertion.
- After the fix: all four deadline cases pass. The owner and sibling selection passes **76 tests**, with **3 existing platform-specific skips**, across **4 files / 3 shards**. That selection was repeated successfully after rebasing onto `21f1d7713d9c442769cb580c918650423c9be29c`; both changed files remained byte-identical across the rebase.
- Frozen dependency installation, the classified changed gate (including root-test typechecking), targeted source lint, formatting, and diff checks passed on the byte-identical candidate before the mechanical rebase. Independent Codex autoreview found no actionable findings at its P0 reporting threshold.
- Landing verification for exact published head `d39247f8f74d857a43d993ece4ae08419a3c9a50`: [CI 33431367232, attempt 1](https://github.com/openclaw/openclaw/actions/runs/33431367232) completed successfully; the PR rollup has 119 successful and 76 skipped checks, with none pending or failing. A fresh pre-land Codex autoreview of that exact branch delta completed with no actionable P0 findings and unchanged source.
- The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/134424#issuecomment-5483596268) identified no actionable code/security findings. Its only before-merge step—waiting for exact-head CI—is satisfied. Native review artifacts are complete; no live-product or release proof is claimed.

Commands run in isolated task-owned worktrees with task-owned temporary directories:

```bash
node scripts/run-vitest.mjs test/helpers/openclaw-test-instance.test.ts -t 'releases the CLI deadline' --reporter=verbose
```

```bash
node scripts/run-vitest.mjs test/helpers/openclaw-test-instance.test.ts test/helpers/openclaw-test-instance.acquisition.test.ts src/utils.test.ts packages/retry/src/index.test.ts --reporter=verbose
```

```bash
node scripts/check-changed.mjs -- test/helpers/openclaw-test-instance.ts test/helpers/openclaw-test-instance.test.ts
```

```bash
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json test/helpers/openclaw-test-instance.ts test/helpers/openclaw-test-instance.test.ts
```

```bash
git diff --check
```

Local behavioral proof is macOS arm64 / Node 24.20.0 with real synthetic Node children, not a real product Gateway, provider, native Windows, or release test. An ancillary lint invocation initially used the wrong tsconfig and started declaration preparation; it was cancelled and that worktree's retained ownership record was preserved. Final gates ran in a separate clean worktree with an identical patch and its own dependencies/artifact scope—no ownership gate was bypassed.
