### PR TITLE
fix(migrate-hermes): preserve source settings and activation policies

### DIFF
--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -202,8 +202,8 @@ The bundled Hermes provider follows `$HERMES_HOME` and the active profile, then 
 
 ### What Hermes imports
 
-- Default model configuration from `config.yaml`.
-- Configured model providers and custom OpenAI-compatible endpoints from `model`, `providers`, and `custom_providers`.
+- Default model configuration from `config.yaml`. `--agent <id>` applies the model to the selected agent without changing shared defaults or other agents.
+- Configured model providers and custom OpenAI-compatible endpoints from `model`, `providers`, and `custom_providers`, including supported Hermes transport aliases, camelCase fields, and model list metadata.
 - MCP server definitions from `mcp_servers` or `mcp.servers`. Exact OpenClaw mappings cover default Streamable HTTP routing, OAuth scope, boolean TLS verification, separate client certificate/key paths, and Hermes native/resource/prompt tool policy. Unsupported Hermes-only runtime or credential fields are reported for manual review.
 - `SOUL.md` and `AGENTS.md` into the OpenClaw agent workspace.
 - `memories/MEMORY.md` and `memories/USER.md` appended to workspace memory files.
@@ -211,8 +211,8 @@ The bundled Hermes provider follows `$HERMES_HOME` and the active profile, then 
   import page) instead copy these files under `memory/imports/hermes/` for
   indexed recall without touching existing workspace memory.
 - Memory config defaults for OpenClaw file memory, plus archive or manual-review items for external memory providers such as Honcho.
-- Skills that include a `SKILL.md` file anywhere under `skills/`; nested skills are flattened into the workspace skill directory.
-- Per-skill config values from `skills.config`.
+- Skills that include a `SKILL.md` file under active directories in `skills/`; nested skills are flattened into the workspace skill directory, and organization mirrors follow `_org/.active_org`.
+- Per-skill config values from `skills.config` and global disabled state from `skills.disabled`.
 - Current Hermes OpenAI Codex OAuth credentials and OpenCode OpenAI OAuth credentials when interactive credential migration is accepted, or when `--include-secrets` is set. Do not keep Hermes and OpenClaw using the same imported refresh grant.
 - Supported API keys and tokens from Hermes `.env` and OpenCode `auth.json` when interactive credential migration is accepted, or when `--include-secrets` is set.
 

--- a/docs/cli/migrate.md
+++ b/docs/cli/migrate.md
@@ -246,6 +246,8 @@ At runtime the plugin calls `api.registerMigrationProvider(...)`. The provider i
 
 Provider plugins can use `openclaw/plugin-sdk/migration` for item construction and summary counts, plus `openclaw/plugin-sdk/migration-runtime` for conflict-aware file copies, archive-only report copies, cached config-runtime wrappers, and migration reports.
 
+In JSON mode, an apply that finishes with item errors or conflicts writes one complete migration report and exits with code `1`. Inspect `summary` and `items` to identify partial results.
+
 ## Onboarding integration
 
 Onboarding can offer migration when a provider detects a known source. Both `openclaw onboard --flow import` and `openclaw setup --wizard --import-from hermes` use the same plugin migration provider and still show a preview before applying. Unlike standalone migration, the fresh-target onboarding path stages local artifacts and imported credentials, verifies or repairs imported inference inside staging, then promotes workspace and agent state before committing configuration. A mode-`0600` promotion journal lets the next run finish or roll back an interrupted publish, including any deferred external activation, without replaying imported local data.

--- a/docs/install/migrating-hermes.md
+++ b/docs/install/migrating-hermes.md
@@ -155,7 +155,7 @@ openclaw migrate hermes --dry-run --json
 openclaw migrate apply hermes --json --yes
 ```
 
-With `--json` and no `--yes`, apply prints the plan and does not mutate state — the safest mode for CI and shared scripts.
+`openclaw migrate hermes --json` without `--yes` prints the plan without applying it. Non-interactive `migrate apply` requires `--yes`. A partial apply failure returns the complete JSON report and exits with code `1`.
 
 ## Troubleshooting
 

--- a/docs/install/migrating-hermes.md
+++ b/docs/install/migrating-hermes.md
@@ -67,7 +67,7 @@ Imports require a fresh OpenClaw setup. If you already have local OpenClaw state
     Memory config defaults for OpenClaw file memory. External memory providers such as Honcho are recorded as archive or manual-review items so you can move them deliberately.
   </Accordion>
   <Accordion title="Skills">
-    Skills with a `SKILL.md` file under active directories in `skills/` are discovered recursively, flattened into the OpenClaw workspace skill directory, and copied with their support files. Per-skill config values from `skills.config` and global disabled state from `skills.disabled` are preserved. Only the organization mirror selected by `_org/.active_org` is imported.
+    Skills with a `SKILL.md` file under active directories in `skills/` are discovered recursively, flattened into the OpenClaw workspace skill directory, and copied with their support files. Per-skill config values from `skills.config` and global disabled state from `skills.disabled` are preserved. With `--skill`, only the selected skills' config and disabled state are imported. Only the organization mirror selected by `_org/.active_org` is imported.
   </Accordion>
   <Accordion title="Auth credentials">
     Interactive `openclaw migrate` asks before importing auth credentials, with yes selected by default. Accepted imports include current Hermes OpenAI Codex OAuth entries, OpenCode OpenAI OAuth and GitHub Copilot entries, and the [supported Hermes `.env` keys](/cli/migrate#supported-env-keys). Use `--include-secrets` for non-interactive import, `--no-auth-credentials` to skip credentials, or onboarding's `--import-secrets` flag. After importing Hermes OAuth, do not keep Hermes and OpenClaw using the same refresh grant; reauthenticate one side before running both.

--- a/docs/install/migrating-hermes.md
+++ b/docs/install/migrating-hermes.md
@@ -47,12 +47,15 @@ Imports require a fresh OpenClaw setup. If you already have local OpenClaw state
 
 <AccordionGroup>
   <Accordion title="Model configuration">
-    - Default model selection from Hermes `config.yaml`.
-    - Configured model providers and custom endpoints from `model`, `providers`, and `custom_providers`, including current Hermes Chat Completions, Codex Responses, and Anthropic Messages transports.
+    - Default model selection from Hermes `config.yaml`. With `--agent <id>`, the imported model belongs to that agent; shared defaults and other agents keep their models.
+    - Configured model providers and custom endpoints from `model`, `providers`, and `custom_providers`, including Hermes transport aliases, camelCase provider fields, and model lists with per-model metadata.
 
   </Accordion>
   <Accordion title="MCP servers">
     MCP server definitions from `mcp_servers` or `mcp.servers`, including disabled state, timeouts, parallel-tool support, OAuth scope, compatible TLS fields, and native/resource/prompt tool policy. Literal environment variables and headers require credential-import consent. Hermes-only lifecycle, sampling, elicitation, preflight, keepalive, CA-bundle, password-protected client-key, and pre-registered OAuth-client settings become manual-review items instead of invalid OpenClaw config.
+
+    An empty `tools.include` keeps native tools disabled while preserving the resource and prompt utility settings. OpenClaw tool filters support exact names and `*`; Hermes `?` and bracket patterns need manual review. Unsupported include patterns are omitted, and a server with unsupported exclusion patterns is imported disabled until you replace its filter and enable it.
+
   </Accordion>
   <Accordion title="Workspace files">
     - `SOUL.md` and `AGENTS.md` are copied into the OpenClaw agent workspace.
@@ -64,7 +67,7 @@ Imports require a fresh OpenClaw setup. If you already have local OpenClaw state
     Memory config defaults for OpenClaw file memory. External memory providers such as Honcho are recorded as archive or manual-review items so you can move them deliberately.
   </Accordion>
   <Accordion title="Skills">
-    Skills with a `SKILL.md` file anywhere under `skills/` are discovered recursively, flattened into the OpenClaw workspace skill directory, and copied with their support files. Per-skill config values from `skills.config` are preserved.
+    Skills with a `SKILL.md` file under active directories in `skills/` are discovered recursively, flattened into the OpenClaw workspace skill directory, and copied with their support files. Per-skill config values from `skills.config` and global disabled state from `skills.disabled` are preserved. Only the organization mirror selected by `_org/.active_org` is imported.
   </Accordion>
   <Accordion title="Auth credentials">
     Interactive `openclaw migrate` asks before importing auth credentials, with yes selected by default. Accepted imports include current Hermes OpenAI Codex OAuth entries, OpenCode OpenAI OAuth and GitHub Copilot entries, and the [supported Hermes `.env` keys](/cli/migrate#supported-env-keys). Use `--include-secrets` for non-interactive import, `--no-auth-credentials` to skip credentials, or onboarding's `--import-secrets` flag. After importing Hermes OAuth, do not keep Hermes and OpenClaw using the same refresh grant; reauthenticate one side before running both.

--- a/extensions/migrate-hermes/config-mcp.ts
+++ b/extensions/migrate-hermes/config-mcp.ts
@@ -26,13 +26,18 @@ function readPositiveNumeric(value: unknown): number | undefined {
 
 function readToolFilterList(value: unknown): string[] | undefined {
   if (typeof value === "string") {
-    return value.trim() ? [value.trim()] : undefined;
+    return value.trim() ? [value.trim()] : [];
   }
   if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) {
     return undefined;
   }
   const normalized = [...new Set(value.map((entry) => entry.trim()).filter(Boolean))];
   return normalized;
+}
+
+function hasUnsupportedToolPattern(pattern: string): boolean {
+  // Hermes uses fnmatch; OpenClaw supports only exact names and `*`.
+  return pattern.includes("?") || pattern.includes("[");
 }
 
 function mapHermesToolFilter(value: Record<string, unknown>): Record<string, unknown> | undefined {
@@ -59,15 +64,15 @@ function mapHermesToolFilter(value: Record<string, unknown>): Record<string, unk
   const resourcesEnabled = parseBooleanValue(tools.resources) !== false;
   const promptsEnabled = parseBooleanValue(tools.prompts) !== false;
 
-  // Hermes tests set truthiness here: `include: []` means no whitelist, so native tools remain.
-  if (include && include.length > 0) {
-    return {
-      include: [
-        ...include,
-        ...(resourcesEnabled ? MCP_RESOURCE_UTILITY_TOOLS : []),
-        ...(promptsEnabled ? MCP_PROMPT_UTILITY_TOOLS : []),
-      ],
-    };
+  if (include !== undefined) {
+    const allowed = [
+      ...include.filter((pattern) => !hasUnsupportedToolPattern(pattern)),
+      ...(resourcesEnabled ? MCP_RESOURCE_UTILITY_TOOLS : []),
+      ...(promptsEnabled ? MCP_PROMPT_UTILITY_TOOLS : []),
+    ];
+    // Hermes' explicit empty include disables native tools; OpenClaw's empty
+    // include is unrestricted, so deny everything when no utilities remain.
+    return allowed.length > 0 ? { include: allowed } : { exclude: ["*"] };
   }
   const translatedExclude = [
     ...(exclude ?? []),
@@ -189,6 +194,15 @@ export function mapMcpServer(
   Object.assign(next, mapHermesClientCertificate(value));
   const toolFilter = mapHermesToolFilter(value);
   next.toolFilter = toolFilter;
+  const tools = isRecord(value.tools) ? value.tools : undefined;
+  if (
+    tools &&
+    readToolFilterList(tools.include) === undefined &&
+    readToolFilterList(tools.exclude)?.some(hasUnsupportedToolPattern)
+  ) {
+    // An untranslated exclusion would expose tools Hermes withheld.
+    next.enabled = false;
+  }
   if (includeSecrets) {
     for (const key of ["env", "headers"]) {
       if (value[key] !== undefined) {
@@ -330,6 +344,17 @@ export function mcpManualItems(params: {
   }
 
   const tools = isRecord(raw.tools) ? raw.tools : undefined;
+  const include = tools ? readToolFilterList(tools.include) : undefined;
+  const activePatterns = include ?? (tools ? readToolFilterList(tools.exclude) : undefined);
+  if (activePatterns?.some(hasUnsupportedToolPattern)) {
+    add(
+      "tool-patterns",
+      include === undefined
+        ? `Hermes MCP server "${name}" was imported disabled because its tool exclusions use unsupported fnmatch patterns.`
+        : `Hermes MCP server "${name}" has tool include patterns that were omitted because OpenClaw supports only exact names and "*".`,
+      "Replace ? and bracket patterns with exact tool names or equivalent * patterns in mcp.servers toolFilter, then enable the server if disabled.",
+    );
+  }
   if (
     tools &&
     (Object.keys(tools).some(

--- a/extensions/migrate-hermes/config-provider-contract.ts
+++ b/extensions/migrate-hermes/config-provider-contract.ts
@@ -6,7 +6,7 @@ import {
   mcpValueHasEnvReferences,
   resolveMcpEnvReferences,
 } from "./config-env.js";
-import { childRecord, readStringArray } from "./helpers.js";
+import { childRecord } from "./helpers.js";
 import { normalizeHermesCustomProviderId, normalizeHermesProviderId } from "./model.js";
 
 type OpenClawModelApi =
@@ -38,6 +38,27 @@ export const HERMES_TRANSPORTS: Record<string, OpenClawModelApi> = {
   codex_responses: "openai-responses",
   openai_chat: "openai-completions",
 };
+const HERMES_TRANSPORT_ALIASES: Record<string, string> = {
+  openai: "chat_completions",
+  "openai-chat": "chat_completions",
+  "chat-completions": "chat_completions",
+  chatcompletions: "chat_completions",
+  responses: "codex_responses",
+  openai_responses: "codex_responses",
+  "openai-responses": "codex_responses",
+  anthropic: "anthropic_messages",
+  "anthropic-messages": "anthropic_messages",
+  messages: "anthropic_messages",
+};
+
+export function readProviderTransport(raw: Record<string, unknown>): string | undefined {
+  const transport = (
+    normalizeOptionalString(raw.api_mode) ??
+    normalizeOptionalString(raw.apiMode) ??
+    normalizeOptionalString(raw.transport)
+  )?.toLowerCase();
+  return transport ? (HERMES_TRANSPORT_ALIASES[transport] ?? transport) : undefined;
+}
 const HERMES_MOONSHOT_CN_BASE_URL = "https://api.moonshot.cn/v1";
 const HERMES_MINIMAX_CN_BASE_URL = "https://api.minimaxi.com/anthropic";
 const HERMES_ALIBABA_BASE_URL = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1";
@@ -170,7 +191,7 @@ export function resolveProviderApi(
   raw: Record<string, unknown>,
   providerId?: string,
 ): OpenClawModelApi | undefined {
-  const transport = normalizeOptionalString(raw.transport) ?? normalizeOptionalString(raw.api_mode);
+  const transport = readProviderTransport(raw);
   const sourceProvider = providerId?.trim().toLowerCase() ?? "";
   if (sourceProvider === "openai-codex") {
     return "openai-chatgpt-responses";
@@ -253,9 +274,10 @@ export function readProviderApiKeyEnv(raw: Record<string, unknown>): string | un
   return (
     normalizeOptionalString(raw.key_env) ??
     normalizeOptionalString(raw.api_key_env) ??
+    normalizeOptionalString(raw.keyEnv) ??
     normalizeOptionalString(raw.apiKeyEnv) ??
     normalizeOptionalString(raw.env) ??
-    readEnvReference(raw.api_key)
+    readEnvReference(raw.api_key ?? raw.apiKey)
   );
 }
 
@@ -275,7 +297,9 @@ export function resolveHermesEndpointApiKeyEnv(baseUrl: string): string | undefi
 
 function readModelMetadata(raw: Record<string, unknown>): Omit<HermesModelConfig, "id"> {
   const contextWindow =
-    readPositiveNumber(raw.context_length) ?? readPositiveNumber(raw.contextWindow);
+    readPositiveNumber(raw.context_length) ??
+    readPositiveNumber(raw.contextLength) ??
+    readPositiveNumber(raw.contextWindow);
   const maxTokens =
     readPositiveNumber(raw.max_tokens) ??
     readPositiveNumber(raw.max_output_tokens) ??
@@ -291,10 +315,22 @@ function readModelMetadata(raw: Record<string, unknown>): Omit<HermesModelConfig
 export function collectProviderModels(raw: Record<string, unknown>): HermesModelConfig[] {
   const models = new Map<string, HermesModelConfig>();
   const rootMetadata = readModelMetadata(raw);
-  for (const modelId of readStringArray(raw.models)) {
-    models.set(modelId, { id: modelId, ...rootMetadata });
-  }
-  for (const [modelId, metadata] of Object.entries(childRecord(raw, "models"))) {
+  const entries = Array.isArray(raw.models)
+    ? raw.models.map((model) =>
+        isRecord(model)
+          ? ([
+              normalizeOptionalString(model.id) ?? normalizeOptionalString(model.name),
+              model,
+            ] as const)
+          : ([normalizeOptionalString(model), {}] as const),
+      )
+    : Object.entries(childRecord(raw, "models")).filter(
+        ([id]) => !["__discovered_model_catalog__", "__explicit_model_allowlist__"].includes(id),
+      );
+  for (const [modelId, metadata] of entries) {
+    if (!modelId) {
+      continue;
+    }
     models.set(modelId, {
       id: modelId,
       ...rootMetadata,
@@ -302,7 +338,7 @@ export function collectProviderModels(raw: Record<string, unknown>): HermesModel
     });
   }
   for (const modelId of [
-    normalizeOptionalString(raw.default_model),
+    normalizeOptionalString(raw.default_model) ?? normalizeOptionalString(raw.defaultModel),
     normalizeOptionalString(raw.default),
     normalizeOptionalString(raw.model),
   ]) {

--- a/extensions/migrate-hermes/config-providers.ts
+++ b/extensions/migrate-hermes/config-providers.ts
@@ -9,6 +9,7 @@ import {
   readProviderApiKeyEnv,
   readProviderBaseUrl,
   readProviderHeaders,
+  readProviderTransport,
   resolveHermesEndpointApiKeyEnv,
   resolveHermesImplicitBaseUrl,
   resolveHermesProviderApiKeyEnv,
@@ -265,8 +266,7 @@ export function providerManualItems(
   }
   const items: MigrationItem[] = [];
   for (const { id, raw, source } of entries) {
-    const transport =
-      normalizeOptionalString(raw.transport) ?? normalizeOptionalString(raw.api_mode);
+    const transport = readProviderTransport(raw);
     const baseUrlConfig = readProviderBaseUrl(raw, env);
     const baseUrl = baseUrlConfig.baseUrl ?? resolveHermesImplicitBaseUrl(id);
     const headerConfig = readProviderHeaders(raw, env, includeSecrets);
@@ -299,7 +299,8 @@ export function providerManualItems(
         }),
       );
     }
-    if (normalizeOptionalString(raw.api_key) && !readEnvReference(raw.api_key)) {
+    const inlineKey = raw.api_key ?? raw.apiKey;
+    if (normalizeOptionalString(inlineKey) && !readEnvReference(inlineKey)) {
       items.push(
         createMigrationManualItem({
           id: `manual:model-provider-inline-key:${sanitizeName(id)}`,

--- a/extensions/migrate-hermes/config.test.ts
+++ b/extensions/migrate-hermes/config.test.ts
@@ -1,5 +1,6 @@
 // Migrate Hermes tests cover config plugin behavior.
 import path from "node:path";
+import { readConfigFileSnapshot } from "openclaw/plugin-sdk/health";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/provider-auth";
 import {
   resolvePreferredOpenClawTmpDir,
@@ -174,6 +175,7 @@ describe("Hermes migration config mapping", () => {
         "",
       ].join("\n"),
     );
+    await writeFile(path.join(source, "memories", "MEMORY.md"), "Imported memory\n");
 
     const provider = buildHermesMigrationProvider();
     const result = await provider.apply(
@@ -197,6 +199,18 @@ describe("Hermes migration config mapping", () => {
     );
     expect(config.mcp?.servers?.time?.command).toBe("npx");
     expect(config.skills?.entries?.["ship-it"]?.config?.mode).toBe("fast");
+    expect(config.plugins?.slots?.memory).toBe("memory-core");
+    const configPath = path.join(stateDir, "openclaw.json");
+    await writeFile(configPath, JSON.stringify(config));
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+    const snapshot = await readConfigFileSnapshot({
+      observe: false,
+      isolateEnv: true,
+      pluginValidation: "core-only",
+    });
+    expect(snapshot.issues).toEqual([]);
+    expect(snapshot.valid).toBe(true);
   });
 
   it("drops prototype-bearing provider, MCP, and skill keys during apply", async () => {

--- a/extensions/migrate-hermes/config.test.ts
+++ b/extensions/migrate-hermes/config.test.ts
@@ -137,13 +137,10 @@ describe("Hermes migration config mapping", () => {
       },
     });
 
-    const skillEntries = itemById(plan.items, "config:skill-entries");
-    expect(skillEntries?.details?.value).toEqual({
-      "ship-it": {
-        config: {
-          mode: "fast",
-        },
-      },
+    const skillEntry = itemById(plan.items, "config:skill-entry:ship-it");
+    expect(skillEntry?.details).toEqual({
+      path: ["skills", "entries", "ship-it"],
+      value: { config: { mode: "fast" } },
     });
     expect(plan.warnings).toEqual([
       "Some Hermes settings require manual review before they can be activated safely.",

--- a/extensions/migrate-hermes/config.test.ts
+++ b/extensions/migrate-hermes/config.test.ts
@@ -397,14 +397,14 @@ describe("Hermes migration config mapping", () => {
     expect(itemById(plan.items, "config:mcp-server:utilities_only")?.details?.value).toEqual({
       utilities_only: {
         command: "utilities-only",
-        toolFilter: { exclude: ["resources_list", "resources_read"] },
+        toolFilter: { include: ["prompts_list", "prompts_get"] },
       },
     });
     expect(itemById(plan.items, "config:mcp-server:no_tools")?.details?.value).toEqual({
       no_tools: {
         command: "no-tools",
         toolFilter: {
-          exclude: ["resources_list", "resources_read", "prompts_list", "prompts_get"],
+          exclude: ["*"],
         },
       },
     });

--- a/extensions/migrate-hermes/config.ts
+++ b/extensions/migrate-hermes/config.ts
@@ -61,18 +61,6 @@ export function buildConfigItems(params: {
   if (params.hasMemoryFiles || memoryProvider) {
     items.push(
       createMigrationConfigPatchItem({
-        id: "config:memory",
-        target: "memory",
-        path: ["memory"],
-        value: { backend: "builtin" },
-        message: "Use OpenClaw built-in file memory for imported Hermes memory files.",
-        conflict:
-          !params.ctx.overwrite &&
-          hasMigrationConfigPatchConflict(params.ctx.config, ["memory"], { backend: true }),
-      }),
-    );
-    items.push(
-      createMigrationConfigPatchItem({
         id: "config:memory-plugin-slot",
         target: "plugins.slots",
         path: ["plugins", "slots"],

--- a/extensions/migrate-hermes/config.ts
+++ b/extensions/migrate-hermes/config.ts
@@ -8,6 +8,7 @@ import {
 } from "openclaw/plugin-sdk/migration";
 import type { MigrationItem, MigrationProviderContext } from "openclaw/plugin-sdk/plugin-entry";
 import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { parse as parseYaml } from "yaml";
 import { importsMcpSensitiveValues, mapMcpServer, mcpManualItems } from "./config-mcp.js";
 import { providerConfig } from "./config-provider-contract.js";
 import {
@@ -15,18 +16,34 @@ import {
   collectHermesProviders,
   providerManualItems,
 } from "./config-providers.js";
-import { childRecord, sanitizeName } from "./helpers.js";
+import { childRecord, readStringArray, sanitizeName } from "./helpers.js";
 
 function mapSkillEntries(config: Record<string, unknown>): Record<string, unknown> | undefined {
-  const entries: Record<string, unknown> = {};
-  for (const [skillKey, value] of Object.entries(
-    childRecord(childRecord(config, "skills"), "config"),
-  )) {
+  const skills = childRecord(config, "skills");
+  const entries = new Map<string, { config?: Record<string, unknown>; enabled?: false }>();
+  for (const [skillKey, value] of Object.entries(childRecord(skills, "config"))) {
     if (isRecord(value)) {
-      entries[skillKey] = { config: value };
+      entries.set(skillKey, { config: value });
     }
   }
-  return Object.keys(entries).length > 0 ? entries : undefined;
+  let disabled = skills.disabled;
+  // Hermes config commands also persist JSON/Python array strings. YAML accepts
+  // both list forms without evaluating source code; malformed strings stay names.
+  if (typeof disabled === "string" && disabled.trimStart().startsWith("[")) {
+    try {
+      disabled = parseYaml(disabled);
+    } catch {
+      // Hermes treats a malformed list string as a single skill name.
+    }
+  }
+  for (const value of readStringArray(Array.isArray(disabled) ? disabled : [disabled])) {
+    const skillKey = value.trim();
+    // Hermes always keeps its operating manual active, even in skills.disabled.
+    if (skillKey !== "hermes-agent") {
+      entries.set(skillKey, { ...entries.get(skillKey), enabled: false });
+    }
+  }
+  return entries.size > 0 ? Object.fromEntries(entries) : undefined;
 }
 
 export function buildConfigItems(params: {
@@ -190,7 +207,7 @@ export function buildConfigItems(params: {
         target: "skills.entries",
         path: ["skills", "entries"],
         value: skillEntries,
-        message: "Import Hermes skill config values.",
+        message: "Import Hermes skill config values and global disabled state.",
         conflict:
           !params.ctx.overwrite &&
           hasMigrationConfigPatchConflict(params.ctx.config, ["skills", "entries"], skillEntries),

--- a/extensions/migrate-hermes/config.ts
+++ b/extensions/migrate-hermes/config.ts
@@ -5,9 +5,14 @@ import {
   createMigrationConfigPatchItem,
   createMigrationManualItem,
   hasMigrationConfigPatchConflict,
+  mergeMigrationConfigValue,
 } from "openclaw/plugin-sdk/migration";
 import type { MigrationItem, MigrationProviderContext } from "openclaw/plugin-sdk/plugin-entry";
-import { isRecord, normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  asNonArrayRecord,
+  isRecord,
+  normalizeOptionalString,
+} from "openclaw/plugin-sdk/string-coerce-runtime";
 import { parse as parseYaml } from "yaml";
 import { importsMcpSensitiveValues, mapMcpServer, mcpManualItems } from "./config-mcp.js";
 import { providerConfig } from "./config-provider-contract.js";
@@ -18,7 +23,7 @@ import {
 } from "./config-providers.js";
 import { childRecord, readStringArray, sanitizeName } from "./helpers.js";
 
-function mapSkillEntries(config: Record<string, unknown>): Record<string, unknown> | undefined {
+function mapSkillEntries(config: Record<string, unknown>): Record<string, unknown> {
   const skills = childRecord(config, "skills");
   const entries = new Map<string, { config?: Record<string, unknown>; enabled?: false }>();
   for (const [skillKey, value] of Object.entries(childRecord(skills, "config"))) {
@@ -43,7 +48,8 @@ function mapSkillEntries(config: Record<string, unknown>): Record<string, unknow
       entries.set(skillKey, { ...entries.get(skillKey), enabled: false });
     }
   }
-  return entries.size > 0 ? Object.fromEntries(entries) : undefined;
+  // Apply the shared untrusted-key policy before skill names become path segments.
+  return asNonArrayRecord(mergeMigrationConfigValue({}, Object.fromEntries(entries)));
 }
 
 export function buildConfigItems(params: {
@@ -187,18 +193,18 @@ export function buildConfigItems(params: {
     }
   }
 
-  const skillEntries = mapSkillEntries(params.config);
-  if (skillEntries) {
+  for (const [skillKey, value] of Object.entries(mapSkillEntries(params.config))) {
+    const configPath = ["skills", "entries", skillKey];
     items.push(
       createMigrationConfigPatchItem({
-        id: "config:skill-entries",
-        target: "skills.entries",
-        path: ["skills", "entries"],
-        value: skillEntries,
+        id: `config:skill-entry:${sanitizeName(skillKey)}`,
+        target: configPath.join("."),
+        path: configPath,
+        value,
         message: "Import Hermes skill config values and global disabled state.",
         conflict:
           !params.ctx.overwrite &&
-          hasMigrationConfigPatchConflict(params.ctx.config, ["skills", "entries"], skillEntries),
+          hasMigrationConfigPatchConflict(params.ctx.config, configPath, value),
       }),
     );
   }

--- a/extensions/migrate-hermes/items.ts
+++ b/extensions/migrate-hermes/items.ts
@@ -21,6 +21,7 @@ export const HERMES_REASON_AUTH_PROFILE_WRITE_FAILED = "failed to write auth pro
 export function createHermesModelItem(params: {
   model: string;
   currentModel?: string;
+  targetAgentId?: string;
   overwrite?: boolean;
 }): MigrationItem {
   const alreadyConfigured = params.currentModel === params.model;
@@ -29,7 +30,7 @@ export function createHermesModelItem(params: {
     id: "config:default-model",
     kind: "config",
     action: alreadyConfigured ? "skip" : "update",
-    target: "agents.defaults.model",
+    target: params.targetAgentId ? `agent:${params.targetAgentId}:model` : "agents.defaults.model",
     status: alreadyConfigured ? "skipped" : conflict ? "conflict" : "planned",
     reason: alreadyConfigured
       ? HERMES_REASON_ALREADY_CONFIGURED

--- a/extensions/migrate-hermes/mcp-policy.test.ts
+++ b/extensions/migrate-hermes/mcp-policy.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { buildConfigItems } from "./config.js";
+import { makeContext } from "./test/provider-helpers.js";
+
+const ctx = makeContext({ source: "/hermes", stateDir: "/state", workspaceDir: "/workspace" });
+
+describe("Hermes MCP policy migration", () => {
+  it.each([
+    [false, false, { exclude: ["*"] }],
+    [false, true, { include: ["prompts_list", "prompts_get"] }],
+    [true, false, { include: ["resources_list", "resources_read"] }],
+    [true, true, { include: ["resources_list", "resources_read", "prompts_list", "prompts_get"] }],
+  ])(
+    "preserves an empty native allowlist with resources=%s and prompts=%s",
+    (resources, prompts, toolFilter) => {
+      const items = buildConfigItems({
+        ctx,
+        config: {
+          mcp_servers: {
+            acme: { command: "acme-mcp", tools: { include: [], resources, prompts } },
+          },
+        },
+      });
+      expect(items.find((item) => item.id === "config:mcp-server:acme")?.details?.value).toEqual({
+        acme: { command: "acme-mcp", toolFilter },
+      });
+    },
+  );
+
+  it("preserves an empty string native allowlist", () => {
+    const items = buildConfigItems({
+      ctx,
+      config: {
+        mcp_servers: {
+          acme: {
+            command: "acme-mcp",
+            tools: { include: "", resources: false, prompts: false },
+          },
+        },
+      },
+    });
+    expect(items.find((item) => item.id === "config:mcp-server:acme")?.details?.value).toEqual({
+      acme: { command: "acme-mcp", toolFilter: { exclude: ["*"] } },
+    });
+  });
+
+  it.each(["delete_?", "delete_[ab]"])(
+    "requires review before activating an unsupported exclusion %s",
+    (pattern) => {
+      const items = buildConfigItems({
+        ctx,
+        config: { mcp_servers: { acme: { command: "acme-mcp", tools: { exclude: [pattern] } } } },
+      });
+      expect(
+        items.find((item) => item.id === "config:mcp-server:acme")?.details?.value,
+      ).toMatchObject({
+        acme: { enabled: false },
+      });
+      expect(
+        items.find((item) => item.id === "manual:mcp-server-tool-patterns:acme"),
+      ).toMatchObject({
+        kind: "manual",
+        message: expect.stringContaining("disabled"),
+      });
+    },
+  );
+
+  it("keeps the supported subset of an include policy without broadening its tool surface", () => {
+    const items = buildConfigItems({
+      ctx,
+      config: {
+        mcp_servers: {
+          acme: {
+            command: "acme-mcp",
+            tools: {
+              include: ["read_*", "find_?"],
+              exclude: ["delete_?"],
+              resources: false,
+              prompts: false,
+            },
+          },
+        },
+      },
+    });
+    expect(items.find((item) => item.id === "config:mcp-server:acme")?.details?.value).toEqual({
+      acme: { command: "acme-mcp", toolFilter: { include: ["read_*"] } },
+    });
+    expect(items.find((item) => item.id === "manual:mcp-server-tool-patterns:acme")?.kind).toBe(
+      "manual",
+    );
+  });
+});

--- a/extensions/migrate-hermes/model.apply.test.ts
+++ b/extensions/migrate-hermes/model.apply.test.ts
@@ -176,6 +176,45 @@ describe("Hermes migration model apply", () => {
     expect(lateConfig.agents?.defaults?.model).toBe("anthropic/claude-sonnet-4.6");
   });
 
+  it.each([undefined, { primary: "old/model", fallbacks: ["backup/model"] }])(
+    "applies an explicit target agent without changing shared or sibling models (%j)",
+    async (model) => {
+      const root = testWorkspace.dir;
+      const source = path.join(root, "hermes");
+      const workspaceDir = path.join(root, "workspace");
+      await writeFile(path.join(source, "config.yaml"), "model: imported/model\n");
+      const config: OpenClawConfig = {
+        agents: {
+          defaults: { workspace: workspaceDir, model: "shared/model" },
+          entries: {
+            main: { default: true, model: "main/model" },
+            research: { workspace: workspaceDir, model },
+          },
+        },
+      };
+      const ctx = makeContext({
+        source,
+        stateDir: path.join(root, "state"),
+        workspaceDir,
+        config,
+        targetAgentId: "research",
+        overwrite: true,
+        runtime: makeConfigRuntime(config),
+      });
+      const provider = buildHermesMigrationProvider();
+      const plan = await provider.plan(ctx);
+      const result = await provider.apply(ctx, plan);
+
+      expect(result.summary.errors).toBe(0);
+      expect(config.agents?.defaults?.model).toBe("shared/model");
+      expect(config.agents?.entries?.main?.model).toBe("main/model");
+      expect(config.agents?.entries?.research?.model).toEqual(
+        model ? { ...model, primary: "imported/model" } : "imported/model",
+      );
+      expect(plan.items[0]?.target).toContain("research");
+    },
+  );
+
   it("does not apply a custom default after its provider develops a late conflict", async () => {
     const root = testWorkspace.dir;
     const source = path.join(root, "hermes");

--- a/extensions/migrate-hermes/model.plan.test.ts
+++ b/extensions/migrate-hermes/model.plan.test.ts
@@ -237,4 +237,37 @@ describe("Hermes migration model planning", () => {
       }),
     );
   });
+
+  it.each([
+    ["main/model", "imported/model", "skipped"],
+    ["imported/model", "research/model", "conflict"],
+  ])(
+    "checks the selected agent model instead of the default (%s, %s)",
+    async (main, model, status) => {
+      const root = testWorkspace.dir;
+      const source = path.join(root, "hermes");
+      const workspaceDir = path.join(root, "workspace");
+      await writeFile(path.join(source, "config.yaml"), "model: imported/model\n");
+      const config: OpenClawConfig = {
+        agents: {
+          defaults: { workspace: workspaceDir },
+          entries: {
+            main: { default: true, model: main },
+            research: { workspace: workspaceDir, model },
+          },
+        },
+      };
+      const plan = await buildHermesMigrationProvider().plan(
+        makeContext({
+          source,
+          stateDir: path.join(root, "state"),
+          workspaceDir,
+          config,
+          targetAgentId: "research",
+        }),
+      );
+      expect(plan.items[0]?.status).toBe(status);
+      expect(plan.items[0]?.target).toContain("research");
+    },
+  );
 });

--- a/extensions/migrate-hermes/model.ts
+++ b/extensions/migrate-hermes/model.ts
@@ -335,20 +335,11 @@ export function resolveHermesModelRef(
   return rootModel ? joinHermesProviderModel(config, rootProvider, rootModel, env) : undefined;
 }
 
-function resolveDefaultAgentModelState(config: MigrationProviderContext["config"]): {
-  agentId: string;
-  effectivePrimary?: string;
-} {
-  const agentId = resolveDefaultAgentId(config);
-  const effectivePrimary = resolveAgentEffectiveModelPrimary(config, agentId);
-  return {
-    agentId,
-    effectivePrimary,
-  };
-}
-
 export function resolveCurrentModelRef(ctx: MigrationProviderContext): string | undefined {
-  return resolveDefaultAgentModelState(ctx.config).effectivePrimary;
+  return resolveAgentEffectiveModelPrimary(
+    ctx.config,
+    ctx.targetAgentId ?? resolveDefaultAgentId(ctx.config),
+  );
 }
 
 class ModelApplyAbortError extends Error {
@@ -374,27 +365,32 @@ export async function applyModelItem(
     if (!configApi?.current || !configApi.mutateConfigFile) {
       return hermesItemError(item, HERMES_REASON_CONFIG_RUNTIME_UNAVAILABLE);
     }
-    const currentState = resolveDefaultAgentModelState(
+    const agentId = ctx.targetAgentId ?? resolveDefaultAgentId(ctx.config);
+    const currentModel = resolveAgentEffectiveModelPrimary(
       configApi.current() as MigrationProviderContext["config"],
+      agentId,
     );
-    if (currentState.effectivePrimary === details.model) {
+    if (currentModel === details.model) {
       return hermesItemSkipped(item, HERMES_REASON_ALREADY_CONFIGURED);
     }
-    if (currentState.effectivePrimary && !ctx.overwrite) {
+    if (currentModel && !ctx.overwrite) {
       return hermesItemConflict(item, HERMES_REASON_DEFAULT_MODEL_CONFIGURED);
     }
     await configApi.mutateConfigFile({
       base: "runtime",
       afterWrite: { mode: "auto" },
       mutate(draft) {
-        const mutationState = resolveDefaultAgentModelState(draft);
-        if (mutationState.effectivePrimary === details.model) {
+        const mutationModel = resolveAgentEffectiveModelPrimary(draft, agentId);
+        if (mutationModel === details.model) {
           throw new ModelApplyAbortError("skipped", HERMES_REASON_ALREADY_CONFIGURED);
         }
-        if (mutationState.effectivePrimary && !ctx.overwrite) {
+        if (mutationModel && !ctx.overwrite) {
           throw new ModelApplyAbortError("conflict", HERMES_REASON_DEFAULT_MODEL_CONFIGURED);
         }
-        setAgentEffectiveModelPrimary(draft, mutationState.agentId, details.model);
+        // An explicit migration owner must not rewrite shared defaults when its model is inherited.
+        setAgentEffectiveModelPrimary(draft, agentId, details.model, {
+          forceAgent: Boolean(ctx.targetAgentId),
+        });
       },
     });
     return { ...item, status: "migrated" };

--- a/extensions/migrate-hermes/plan.ts
+++ b/extensions/migrate-hermes/plan.ts
@@ -94,6 +94,7 @@ export async function buildHermesPlan(ctx: MigrationProviderContext): Promise<Mi
       createHermesModelItem({
         model: modelRef,
         currentModel,
+        targetAgentId: ctx.targetAgentId,
         overwrite: ctx.overwrite,
       }),
     );

--- a/extensions/migrate-hermes/provider-contract.test.ts
+++ b/extensions/migrate-hermes/provider-contract.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { collectHermesProviderSecretBindings } from "./config-providers.js";
+import { buildConfigItems } from "./config.js";
+import { makeContext } from "./test/provider-helpers.js";
+
+const ctx = makeContext({ source: "/hermes", stateDir: "/state", workspaceDir: "/workspace" });
+
+function providerItems(raw: Record<string, unknown>) {
+  return buildConfigItems({
+    ctx,
+    config: { providers: { acme: { api: "https://models.example/v1", ...raw } } },
+  });
+}
+
+describe("Hermes provider source contracts", () => {
+  it.each([
+    ["openai", "openai-completions"],
+    ["openai-chat", "openai-completions"],
+    ["chat-completions", "openai-completions"],
+    ["chatcompletions", "openai-completions"],
+    ["responses", "openai-responses"],
+    ["openai_responses", "openai-responses"],
+    ["openai-responses", "openai-responses"],
+    ["anthropic", "anthropic-messages"],
+    ["anthropic-messages", "anthropic-messages"],
+    ["messages", "anthropic-messages"],
+    [" CHAT_COMPLETIONS ", "openai-completions"],
+  ])("imports Hermes transport alias %s as %s", (transport, api) => {
+    const items = providerItems({ transport, default_model: "acme-model" });
+    expect(
+      items.find((item) => item.id === "config:model-provider:acme")?.details?.value,
+    ).toMatchObject({
+      acme: { api, models: [{ id: "acme-model", api }] },
+    });
+    expect(items.filter((item) => item.kind === "manual")).toEqual([]);
+  });
+
+  it("honors canonical field precedence while importing documented camelCase fields", () => {
+    const config = {
+      providers: {
+        acme: {
+          baseUrl: "https://models.example/v1",
+          apiMode: "messages",
+          keyEnv: "ACME_TOKEN",
+          defaultModel: "acme-model",
+          contextLength: 262144,
+        },
+      },
+    };
+    const items = buildConfigItems({ ctx, config, env: { ACME_TOKEN: "test-only-placeholder" } });
+    expect(
+      items.find((item) => item.id === "config:model-provider:acme")?.details?.value,
+    ).toMatchObject({
+      acme: {
+        api: "anthropic-messages",
+        models: [{ id: "acme-model", contextWindow: 262144 }],
+      },
+    });
+    expect(collectHermesProviderSecretBindings(config)).toEqual([
+      { provider: "acme", envVar: "ACME_TOKEN" },
+    ]);
+    expect(
+      providerItems({ api_mode: "chat_completions", transport: "anthropic_messages" })[0]?.details
+        ?.value,
+    ).toMatchObject({
+      acme: { api: "openai-completions" },
+    });
+  });
+
+  it("preserves list model metadata and removes Hermes catalog marker keys", () => {
+    const arrayItems = providerItems({
+      context_length: 32768,
+      models: [
+        " plain-model ",
+        { id: "vision-model", context_length: 65536, max_tokens: 4096, supports_vision: true },
+        { name: "named-model", max_tokens: 2048 },
+      ],
+    });
+    expect(arrayItems[0]?.details?.value).toMatchObject({
+      acme: {
+        models: [
+          { id: "plain-model", contextWindow: 32768 },
+          { id: "vision-model", contextWindow: 65536, maxTokens: 4096, input: ["text", "image"] },
+          { id: "named-model", contextWindow: 32768, maxTokens: 2048 },
+        ],
+      },
+    });
+    expect(
+      providerItems({
+        models: {
+          "acme-model": {},
+          __discovered_model_catalog__: true,
+          __explicit_model_allowlist__: true,
+        },
+      })[0]?.details?.value,
+    ).toMatchObject({
+      acme: { models: [{ id: "acme-model" }] },
+    });
+  });
+});

--- a/extensions/migrate-hermes/provider.test.ts
+++ b/extensions/migrate-hermes/provider.test.ts
@@ -376,11 +376,10 @@ describe("Hermes migration provider", () => {
     );
 
     expect(provider.supportedItemKinds).toEqual(["memory"]);
-    expect(plan.summary.total).toBe(7);
+    expect(plan.summary.total).toBe(6);
     expect(plan.summary.conflicts).toBe(2);
     expect(plan.summary.sensitive).toBe(1);
     expect(itemById(plan.items, "config:default-model")?.status).toBe("conflict");
-    expect(itemById(plan.items, "config:memory")?.status).toBe("planned");
     expect(itemById(plan.items, "config:memory-plugin-slot")?.status).toBe("planned");
     expect(plan.items.some((item) => item.id.startsWith("config:model-provider:"))).toBe(false);
     expect(itemById(plan.items, "workspace:SOUL.md")?.status).toBe("conflict");

--- a/extensions/migrate-hermes/skills-policy.test.ts
+++ b/extensions/migrate-hermes/skills-policy.test.ts
@@ -23,6 +23,54 @@ describe("Hermes skill activation policy migration", () => {
     await workspace.cleanup();
   });
 
+  it("plans skill config and disabled state as independently conflicting entries", async () => {
+    const source = path.join(workspace.dir, "hermes");
+    const workspaceDir = path.join(workspace.dir, "workspace");
+    await writeFile(
+      path.join(source, "config.yaml"),
+      "skills:\n  disabled: [hidden-skill]\n  config:\n    hidden-skill:\n      mode: careful\n    selected-skill:\n      mode: fast\n",
+    );
+    await writeFile(
+      path.join(source, "skills", "hidden-directory", "SKILL.md"),
+      "---\nname: hidden-skill\ndescription: Hidden skill\n---\n",
+    );
+    await writeFile(
+      path.join(source, "skills", "selected-directory", "SKILL.md"),
+      "\uFEFF---\r\nname: selected-skill\r\ndescription: Selected skill\r\n---\r\n",
+    );
+    const ctx = makeContext({ source, stateDir: path.join(workspace.dir, "state"), workspaceDir });
+    ctx.config.skills = { entries: { "hidden-skill": { enabled: true } } };
+
+    const plan = await buildHermesMigrationProvider().plan(ctx);
+
+    expect(plan.items.filter((item) => item.kind === "skill")).toEqual([
+      expect.objectContaining({
+        target: path.join(workspaceDir, "skills", "hidden-directory"),
+        details: expect.objectContaining({ skillName: "hidden-skill" }),
+      }),
+      expect.objectContaining({
+        target: path.join(workspaceDir, "skills", "selected-directory"),
+        details: expect.objectContaining({ skillName: "selected-skill" }),
+      }),
+    ]);
+    expect(plan.items.filter((item) => item.kind === "config")).toEqual([
+      expect.objectContaining({
+        status: "conflict",
+        details: {
+          path: ["skills", "entries", "hidden-skill"],
+          value: { config: { mode: "careful" }, enabled: false },
+        },
+      }),
+      expect.objectContaining({
+        status: "planned",
+        details: {
+          path: ["skills", "entries", "selected-skill"],
+          value: { config: { mode: "fast" } },
+        },
+      }),
+    ]);
+  });
+
   it.each([
     ["YAML list", "[hidden-skill]"],
     ["scalar name", "hidden-skill"],

--- a/extensions/migrate-hermes/skills-policy.test.ts
+++ b/extensions/migrate-hermes/skills-policy.test.ts
@@ -1,0 +1,95 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import {
+  resolvePreferredOpenClawTmpDir,
+  tempWorkspace,
+  type TempWorkspace,
+} from "openclaw/plugin-sdk/temp-path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { buildHermesMigrationProvider } from "./provider.js";
+import { makeConfigRuntime, makeContext, writeFile } from "./test/provider-helpers.js";
+
+let workspace: TempWorkspace;
+
+describe("Hermes skill activation policy migration", () => {
+  beforeEach(async () => {
+    workspace = await tempWorkspace({
+      rootDir: resolvePreferredOpenClawTmpDir(),
+      prefix: "openclaw-hermes-skills-policy-",
+    });
+  });
+
+  afterEach(async () => {
+    await workspace.cleanup();
+  });
+
+  it.each([
+    ["YAML list", "[hidden-skill]"],
+    ["scalar name", "hidden-skill"],
+    ["JSON array string", "'[\"hidden-skill\"]'"],
+    ["Python literal array string", "\"['hidden-skill']\""],
+  ])("keeps globally disabled skills disabled from a %s", async (_, disabled) => {
+    const source = path.join(workspace.dir, "hermes");
+    const workspaceDir = path.join(workspace.dir, "workspace");
+    await writeFile(
+      path.join(source, "config.yaml"),
+      `skills:\n  disabled: ${disabled}\n  config:\n    hidden-skill:\n      mode: careful\n`,
+    );
+    const skillContents = "---\nname: hidden-skill\ndescription: Hidden skill\n---\n# Hidden\n";
+    await writeFile(path.join(source, "skills", "hidden-skill", "SKILL.md"), skillContents);
+    const ctx = makeContext({ source, stateDir: path.join(workspace.dir, "state"), workspaceDir });
+    ctx.runtime = makeConfigRuntime(ctx.config);
+
+    const result = await buildHermesMigrationProvider().apply(ctx);
+
+    expect(result.summary.errors).toBe(0);
+    expect(ctx.config.skills?.entries?.["hidden-skill"]).toEqual({
+      config: { mode: "careful" },
+      enabled: false,
+    });
+    expect(
+      await fs.readFile(path.join(workspaceDir, "skills", "hidden-skill", "SKILL.md"), "utf8"),
+    ).toBe(skillContents);
+  });
+
+  it.each([undefined, "current", "previous", "../previous"])(
+    "imports only the active organization mirror (%s)",
+    async (activeOrg) => {
+      const source = path.join(workspace.dir, "hermes");
+      const workspaceDir = path.join(workspace.dir, "workspace");
+      for (const org of ["current", "previous"]) {
+        await writeFile(
+          path.join(source, "skills", "_org", org, "review", "SKILL.md"),
+          `# ${org} review\n`,
+        );
+      }
+      await writeFile(path.join(source, "skills", "personal", "SKILL.md"), "# Personal\n");
+      if (activeOrg) {
+        await writeFile(path.join(source, "skills", "_org", ".active_org"), `${activeOrg}\n`);
+      }
+      const provider = buildHermesMigrationProvider();
+      const ctx = makeContext({
+        source,
+        stateDir: path.join(workspace.dir, "state"),
+        workspaceDir,
+      });
+      const plan = await provider.plan(ctx);
+      const validOrg = activeOrg === "current" || activeOrg === "previous";
+
+      expect(plan.items.filter((item) => item.kind === "skill").map((item) => item.id)).toEqual([
+        ...(validOrg ? [`skill:_org:${activeOrg}:review`] : []),
+        "skill:personal",
+      ]);
+      expect(plan.summary.conflicts).toBe(0);
+      const result = await provider.apply(ctx, plan);
+      expect(result.summary.errors).toBe(0);
+      if (validOrg) {
+        expect(
+          await fs.readFile(path.join(workspaceDir, "skills", "review", "SKILL.md"), "utf8"),
+        ).toBe(`# ${activeOrg} review\n`);
+      } else {
+        await expect(fs.access(path.join(workspaceDir, "skills", "review"))).rejects.toThrow();
+      }
+    },
+  );
+});

--- a/extensions/migrate-hermes/skills.ts
+++ b/extensions/migrate-hermes/skills.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { createMigrationItem, MIGRATION_REASON_TARGET_EXISTS } from "openclaw/plugin-sdk/migration";
 import type { MigrationItem } from "openclaw/plugin-sdk/plugin-entry";
-import { exists, sanitizeName } from "./helpers.js";
+import { exists, readText, sanitizeName } from "./helpers.js";
 import type { HermesSource } from "./source.js";
 import type { PlannedTargets } from "./targets.js";
 
@@ -33,20 +33,30 @@ const EXCLUDED_SKILL_DIRS = new Set([
 const SKILL_SUPPORT_DIRS = new Set(["references", "templates", "assets", "scripts"]);
 
 async function discoverSkillRoots(root: string): Promise<string[]> {
-  const hasSkill = await exists(path.join(root, "SKILL.md"));
-  const entries = await fs.readdir(root, { withFileTypes: true }).catch(() => []);
-  const roots: string[] = hasSkill ? [root] : [];
-  for (const entry of entries.toSorted((left, right) => left.name.localeCompare(right.name))) {
-    if (
-      !entry.isDirectory() ||
-      EXCLUDED_SKILL_DIRS.has(entry.name) ||
-      (hasSkill && SKILL_SUPPORT_DIRS.has(entry.name))
-    ) {
-      continue;
+  const orgRoot = path.join(root, "_org");
+  const activeOrg = (await readText(path.join(orgRoot, ".active_org")))?.trim();
+  async function visit(dir: string): Promise<string[]> {
+    const hasSkill = await exists(path.join(dir, "SKILL.md"));
+    const entries = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
+    const roots: string[] = hasSkill ? [dir] : [];
+    for (const entry of entries.toSorted((left, right) => left.name.localeCompare(right.name))) {
+      const child = path.join(dir, entry.name);
+      // Hermes retains old org mirrors on disk, but only the marked org is active.
+      const inactiveOrg =
+        (child === orgRoot && !activeOrg) || (dir === orgRoot && entry.name !== activeOrg);
+      if (
+        !entry.isDirectory() ||
+        EXCLUDED_SKILL_DIRS.has(entry.name) ||
+        (hasSkill && SKILL_SUPPORT_DIRS.has(entry.name)) ||
+        inactiveOrg
+      ) {
+        continue;
+      }
+      roots.push(...(await visit(child)));
     }
-    roots.push(...(await discoverSkillRoots(path.join(root, entry.name))));
+    return roots;
   }
-  return roots;
+  return await visit(root);
 }
 
 export async function buildSkillItems(params: {

--- a/extensions/migrate-hermes/skills.ts
+++ b/extensions/migrate-hermes/skills.ts
@@ -3,13 +3,15 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { createMigrationItem, MIGRATION_REASON_TARGET_EXISTS } from "openclaw/plugin-sdk/migration";
 import type { MigrationItem } from "openclaw/plugin-sdk/plugin-entry";
-import { exists, readText, sanitizeName } from "./helpers.js";
+import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { exists, parseHermesConfig, readText, sanitizeName } from "./helpers.js";
 import type { HermesSource } from "./source.js";
 import type { PlannedTargets } from "./targets.js";
 
 type PlannedSkill = {
   id: string;
   name: string;
+  skillName: string;
   source: string;
   target: string;
 };
@@ -73,6 +75,14 @@ export async function buildSkillItems(params: {
     if (!name) {
       continue;
     }
+    const content = await readText(path.join(source, "SKILL.md"));
+    const frontmatter = content?.match(/^\uFEFF?---\r?\n([\s\S]*?)\r?\n---[ \t]*(?:\r?\n|$)/u)?.[1];
+    let skillName = path.basename(source);
+    try {
+      skillName = normalizeOptionalString(parseHermesConfig(frontmatter).name) ?? skillName;
+    } catch {
+      // Keep copying malformed source files; the skill loader reports invalid frontmatter.
+    }
     plannedSkills.push({
       id: `skill:${path
         .relative(params.source.skillsDir, source)
@@ -81,6 +91,7 @@ export async function buildSkillItems(params: {
         .filter(Boolean)
         .join(":")}`,
       name,
+      skillName,
       source,
       target: path.join(params.targets.workspaceDir, "skills", name),
     });
@@ -100,6 +111,7 @@ export async function buildSkillItems(params: {
         action: "copy",
         source: skill.source,
         target: skill.target,
+        details: { skillName: skill.skillName },
         status: collides ? "conflict" : targetExists && !params.overwrite ? "conflict" : "planned",
         reason: collides
           ? `multiple Hermes skill directories normalize to "${skill.name}"`

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -1256,6 +1256,49 @@ describe("migrateApplyCommand", () => {
     expect(mocks.backupCreateCommand).toHaveBeenCalled();
   });
 
+  it.each(["planned", "conflict"] as const)(
+    "keeps --skill configuration inside the selected copy when unselected policy is %s",
+    async (unselectedStatus) => {
+      const planned = plan({
+        items: [
+          {
+            id: "skill:folder",
+            kind: "skill",
+            action: "copy",
+            status: "planned",
+            source: "/tmp/hermes/skills/folder",
+            details: { skillName: "selected" },
+          },
+          ...["selected", "unselected", "target-only"].map((key) => ({
+            id: `config:skill:${key}`,
+            kind: "config" as const,
+            action: "merge" as const,
+            status: key === "selected" ? ("planned" as const) : unselectedStatus,
+            details: { path: ["skills", "entries", key], value: { enabled: false } },
+          })),
+          { id: "other-config", kind: "config", action: "merge", status: "planned" },
+        ],
+      });
+      mocks.provider.plan.mockResolvedValue(planned);
+      mocks.provider.apply.mockImplementation(async (_ctx, selectedPlan: MigrationPlan) => ({
+        ...selectedPlan,
+        summary: { ...selectedPlan.summary, planned: 0, migrated: 3 },
+        items: selectedPlan.items.map((item) =>
+          item.status === "planned" ? { ...item, status: "migrated" as const } : item,
+        ),
+      }));
+
+      await migrateApplyCommand(runtime, { provider: "hermes", yes: true, skills: ["folder"] });
+
+      expect(
+        firstAppliedPlan()
+          .items.filter((item) => item.status === "planned")
+          .map((item) => item.id),
+      ).toEqual(["skill:folder", "config:skill:selected", "other-config"]);
+      expect(firstAppliedPlan().summary.conflicts).toBe(0);
+    },
+  );
+
   it("filters explicit Codex plugins before apply", async () => {
     const planned = codexPluginPlan();
     mocks.provider.plan.mockResolvedValue(planned);

--- a/src/commands/migrate.test.ts
+++ b/src/commands/migrate.test.ts
@@ -3,7 +3,7 @@ import fs from "node:fs/promises";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MigrationApplyResult, MigrationPlan } from "../plugins/types.js";
-import type { RuntimeEnv } from "../runtime.js";
+import { createNonExitingRuntime, ExitError, type RuntimeEnv } from "../runtime.js";
 
 const mocks = vi.hoisted(() => ({
   backupCreateCommand: vi.fn(),
@@ -1434,6 +1434,7 @@ describe("migrateApplyCommand", () => {
     const logs: string[] = [];
     const jsonRuntime: RuntimeEnv = {
       ...runtime,
+      exit: createNonExitingRuntime().exit,
       log(message) {
         logs.push(String(message));
       },
@@ -1443,7 +1444,7 @@ describe("migrateApplyCommand", () => {
 
     await expect(
       migrateApplyCommand(jsonRuntime, { provider: "hermes", yes: true, json: true }),
-    ).rejects.toThrow("Migration finished with 1 error");
+    ).rejects.toBeInstanceOf(ExitError);
 
     expect(logs).toHaveLength(1);
     const logPayload = JSON.parse(logs[0] ?? "{}") as {
@@ -1474,6 +1475,7 @@ describe("migrateApplyCommand", () => {
     const logs: string[] = [];
     const jsonRuntime: RuntimeEnv = {
       ...runtime,
+      exit: createNonExitingRuntime().exit,
       log(message) {
         logs.push(String(message));
       },
@@ -1483,7 +1485,7 @@ describe("migrateApplyCommand", () => {
 
     await expect(
       migrateApplyCommand(jsonRuntime, { provider: "hermes", yes: true, json: true }),
-    ).rejects.toThrow("Migration finished with 1 conflict");
+    ).rejects.toBeInstanceOf(ExitError);
 
     expect(logs).toHaveLength(1);
     const logPayload = JSON.parse(logs[0] ?? "{}") as {

--- a/src/commands/migrate/apply.ts
+++ b/src/commands/migrate/apply.ts
@@ -1,5 +1,6 @@
 /** Applies migration plans with backup, filtering, reporting, and progress output. */
 import fs from "node:fs/promises";
+import { exitCliAfterOutput } from "../../cli/one-shot-exit.js";
 import { withProgress } from "../../cli/progress.js";
 import type { ProgressReporter } from "../../cli/progress.js";
 import { resolveStateDir } from "../../config/paths.js";
@@ -134,7 +135,16 @@ export async function runMigrationApply(params: {
       );
   writeApplyResult(params.runtime, params.opts, withBackup);
   if (!params.opts.allowPartialResult) {
-    assertApplySucceeded(withBackup);
+    try {
+      assertApplySucceeded(withBackup);
+    } catch (error) {
+      // The JSON result already describes partial failure; a generic error would
+      // append a second document and make stdout impossible to parse as JSON.
+      if (params.opts.json) {
+        exitCliAfterOutput(params.runtime, 1);
+      }
+      throw error;
+    }
   }
   return withBackup;
 }

--- a/src/commands/migrate/selection.test.ts
+++ b/src/commands/migrate/selection.test.ts
@@ -263,12 +263,19 @@ describe("applyMigrationSkillSelection", () => {
       plan([
         skillItem({ id: "skill:alpha", name: "alpha" }),
         skillItem({ id: "skill:beta", name: "beta" }),
+        {
+          id: "config:skill:alpha",
+          kind: "config",
+          action: "merge",
+          status: "planned",
+          details: { path: ["skills", "entries", "alpha"], value: { enabled: false } },
+        },
       ]),
       new Set(),
     );
 
-    expectSummaryFields(selected.summary, { planned: 0, skipped: 2 });
-    expect(selected.items.map((item) => item.status)).toEqual(["skipped", "skipped"]);
+    expectSummaryFields(selected.summary, { planned: 0, skipped: 3 });
+    expect(selected.items.map((item) => item.status)).toEqual(["skipped", "skipped", "skipped"]);
   });
 
   it("defaults interactive selection to planned skills only", () => {

--- a/src/commands/migrate/selection.ts
+++ b/src/commands/migrate/selection.ts
@@ -260,13 +260,36 @@ export function formatMigrationPluginSelectionHint(item: MigrationItem): string 
   return marketplace ? `${marketplace} plugin ${reason}` : reason;
 }
 
-/** Marks unselected selectable skill items as skipped and recomputes plan summary. */
+/** Keeps skill copies and their per-skill config patches inside the same selection. */
 export function applyMigrationSelectedSkillItemIds(
   plan: MigrationPlan,
   selectedItemIds: ReadonlySet<string>,
 ): MigrationPlan {
-  const selectableIds = new Set(getSelectableMigrationSkillItems(plan).map((item) => item.id));
+  const selectable = getSelectableMigrationSkillItems(plan);
+  const selectableIds = new Set(selectable.map((item) => item.id));
+  const selectedSkillNames = new Set(
+    selectable
+      .filter((item) => selectedItemIds.has(item.id))
+      .map(
+        (item) =>
+          readMigrationSkillName(item) ?? (item.source ? path.basename(item.source) : undefined),
+      )
+      .filter((name) => name !== undefined),
+  );
   const items = plan.items.map((item) => {
+    const configPath = item.kind === "config" ? item.details?.path : undefined;
+    // Per-skill patches keep conflicts independent, so a deselected skill's
+    // policy cannot mutate the target or block an otherwise valid import.
+    if (
+      Array.isArray(configPath) &&
+      configPath.length === 3 &&
+      configPath[0] === "skills" &&
+      configPath[1] === "entries" &&
+      !selectedSkillNames.has(configPath[2]) &&
+      (item.status === "planned" || item.status === "conflict")
+    ) {
+      return markMigrationItemSkipped(item, MIGRATION_NOT_SELECTED_REASON);
+    }
     if (!selectableIds.has(item.id) || selectedItemIds.has(item.id)) {
       return item;
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes Hermes imports that change the selected agent or activate tools and skills that Hermes withheld. Supported provider aliases and object-form model catalogs were also losing their transport or metadata. A real CLI migration exposed two further failures: the importer still wrote the retired `memory.backend` key, and a partial failure in JSON mode emitted two JSON documents.

## Why This Change Was Made

Keep source-format translation in the Hermes plugin and reuse OpenClaw's existing agent model setter, skill enablement, MCP filters, and config validation. Explicit `--agent` imports pin the model to that agent even when it previously inherited a shared default. Remove the obsolete memory-backend patch; built-in memory is already the canonical engine. The shared migration command uses the existing deferred-exit path after a failed JSON report so the entrypoint does not append a second error document.

## User Impact

- Provider transport aliases, camelCase fields, model list metadata, and discovered-catalog markers import correctly.
- Global skill disablement survives migration; inactive organization mirrors are excluded. Skill copies and their individual config/activation patches obey `--skill`, including names declared in frontmatter.
- Empty MCP native-tool allowlists stay empty while resource/prompt utility settings remain independent. Unsupported fnmatch include patterns are omitted with manual guidance; unsupported active exclusion patterns import the server disabled until the operator translates its filter.
- Model imports respect the selected agent, memory imports pass the current schema, and partial failures return one complete JSON report with exit code 1.

No new configuration options, schema changes, dependencies, or credential formats.

## Evidence

Before editing, the existing 103 Hermes tests passed. Added/strengthened regression coverage demonstrated failures for source-format mapping, activation policy, selected-agent model ownership, current-schema memory config, and the post-output failure path.

Passed locally:

```text
node scripts/run-vitest.mjs extensions/migrate-hermes src/commands/migrate.test.ts src/commands/migrate/apply.test.ts
# 137 Hermes tests + 44 migration command tests
node scripts/run-vitest.mjs src/agents/mcp-tool-filter.test.ts src/agents/agent-scope.test.ts
# 76 passing shared-owner tests; one existing skipped test
node scripts/run-vitest.mjs src/commands/migrate/selection.test.ts
# 19 selection tests
node scripts/check-changed.mjs
```

Fresh Codex autoreview reported no accepted/actionable P0 findings. Direct upstream inspection used Hermes revision `e721b03f63ffc332a03cb8ae02a26fed3b4acad9`: [provider normalization](https://github.com/NousResearch/hermes-agent/blob/e721b03f63ffc332a03cb8ae02a26fed3b4acad9/hermes_cli/config.py#L1351), [MCP allowlists](https://github.com/NousResearch/hermes-agent/blob/e721b03f63ffc332a03cb8ae02a26fed3b4acad9/tools/mcp_tool.py#L7180), and [skill activation](https://github.com/NousResearch/hermes-agent/blob/e721b03f63ffc332a03cb8ae02a26fed3b4acad9/agent/skill_utils.py#L446). The model-owner bug is also present in OpenClaw's stable `v2026.8.1` source; no individual introduction is attributed.

Real Linux CLI proof used Blacksmith Testbox `tbx_01m1ckjxhn7cry1esj4g7e0fx7` ([run](https://github.com/openclaw/openclaw/actions/runs/33428948813)), an isolated Hermes source and OpenClaw state, and a full `pnpm build`. The first run caught the retired memory key; the repaired build passed:

- Plan, apply, verified backup, and redacted report: 12 migrated, zero errors/conflicts.
- Selected `research` agent changed; shared and sibling models remained unchanged.
- Disabled skill stayed disabled; stale organization mirror stayed absent.
- A running stdio MCP fixture advertised one native tool; the imported policy exposed zero and reported one filtered tool.
- SQLite archive remained readable with the expected row; repeated import did not duplicate memory.
- The imported custom provider completed a real Anthropic Messages request (`claude-sonnet-4-6`, HTTP 200, `hermes-live-ok`) after ambient Anthropic keys were removed, proving use of the migrated credential.
- An intentionally invalid MCP config produced exactly one parseable failure report and exit code 1.

Temporary source, credentials, target state, and backups were removed. Testbox cleanup can leave the enclosing Actions lifecycle run cancelled; the build and live commands both returned exit 0.

ClawSweeper's `--skill` finding and rank-up request are addressed: the aggregate skill config patch is replaced by independent per-skill patches, and the shared selection owner filters those patches before conflict checks. Selected copies carry the source frontmatter name, so directory aliases still select the correct activation state. This also fixes selection of existing `skills.config` values. The shared migration sanitizer filters unsafe keys before they become path segments.

New CLI regressions fail before the selection fix for both unselected planned policy and unselected conflicts. A fresh Testbox (`tbx_01m1cnjqsqmbdcnvgedf803xgj`, [run](https://github.com/openclaw/openclaw/actions/runs/33432144876)) reproduced the actual CLI changing unrelated skill state, then passed after repair with the selected skill disabled and unrelated/target-only entries unchanged, without `--overwrite` despite unrelated conflicts. The complete original live flow also passed again on the final code, including the real provider request. The remaining review notes are covered by the direct upstream references above and the production-growth rationale below; the review worker's DNS failure did not affect the maintainer's source inspection.

Follow-ups identified during review: safely materialize symlinked skill packages; preserve identity for description-only skills whose directory name changes during flattening; surface per-platform skill restrictions/external skill directories; coordinate disabled-provider migration with default-model and credential ownership. These existing gaps are not claimed fixed here. The first hosted CI run also failed an unrelated, unchanged `oc-path` CPU-budget test (2344 ms versus 400 ms); a recurrence should be profiled in its original shared-worker order versus a fresh process, without loosening the threshold.

Change size: production **+126 lines**, tests **+469**, docs **+5**. Growth is source-contract translation for provider aliases/catalog shapes and activation policy; the obsolete memory-backend writer and default-agent-only model resolver were removed. Existing runtime/config APIs are reused.
