### PR TITLE
fix(ui): center the sidebar account row in its footer band

### DIFF
--- a/ui/src/components/sidebar-footer-layout.browser.test.ts
+++ b/ui/src/components/sidebar-footer-layout.browser.test.ts
@@ -34,7 +34,10 @@ afterAll(async () => {
 });
 
 describeBrowserLayout("sidebar footer layout", () => {
-  it("keeps the settings footer the same height as the main sidebar footer", async () => {
+  beforeAll(async () => {
+    if (!chromiumAvailable) {
+      return;
+    }
     await page.setContent(`
       <!doctype html>
       <html data-theme-mode="light">
@@ -42,12 +45,12 @@ describeBrowserLayout("sidebar footer layout", () => {
           <style>${readUiCss()}</style>
           <style>
             .footer-layout-fixture {
-              display: grid;
-              grid-template-columns: 288px 288px;
+              display: flex;
               width: 576px;
-              height: 180px;
+              height: 220px;
             }
             .footer-layout-fixture > * {
+              width: 288px;
               min-height: 0;
             }
           </style>
@@ -57,18 +60,20 @@ describeBrowserLayout("sidebar footer layout", () => {
             <section class="sidebar-shell">
               <div class="sidebar-shell__content"></div>
               <div class="sidebar-shell__footer">
-                <div class="sidebar-footer-bar">
-                  <div class="sidebar-agent-card">
-                    <button class="sidebar-agent-card__main" type="button">
-                      <span class="sidebar-agent-card__avatar"></span>
-                      <span class="sidebar-agent-card__name">Mason</span>
+                <div class="sidebar-footer-bar sidebar-footer-bar--one-action">
+                  <button class="sidebar-identity-card" type="button">
+                    <span class="viewer-avatar viewer-avatar--footer is-fallback">
+                      <span class="viewer-avatar__fallback">M</span>
+                    </span>
+                    <span class="sidebar-identity-card__text">
+                      <span class="sidebar-identity-card__name">Mason</span>
+                    </span>
+                  </button>
+                  <span class="sidebar-footer-actions">
+                    <button class="sidebar-issues-button" type="button">
+                      <span class="sidebar-issues-button__icon"></span>
                     </button>
-                  </div>
-                  <div class="sidebar-footer-actions">
-                    <button class="sidebar-brand__icon sidebar-footer-bar__custodian" type="button">
-                      Inbox
-                    </button>
-                  </div>
+                  </span>
                 </div>
               </div>
             </section>
@@ -83,14 +88,68 @@ describeBrowserLayout("sidebar footer layout", () => {
         </body>
       </html>
     `);
+  });
 
-    const heights = await page.evaluate(() => ({
-      main: document.querySelector(".sidebar-shell__footer")?.getBoundingClientRect().height,
-      settings: document.querySelector(".settings-sidebar__footer")?.getBoundingClientRect().height,
-    }));
+  it("lands both sidebar footers on one divider line", async () => {
+    // Height parity alone stayed true while the main divider sat a shell
+    // gutter higher, so the takeover jumped: measure from the sidebar edge.
+    const geometry = await page.evaluate(() => {
+      const box = (selector: string) => document.querySelector(selector)?.getBoundingClientRect();
+      const shell = box(".sidebar-shell");
+      const shellFooter = box(".sidebar-shell__footer");
+      const settings = box(".settings-sidebar");
+      const settingsFooter = box(".settings-sidebar__footer");
+      if (!(shell && shellFooter && settings && settingsFooter)) {
+        return null;
+      }
+      return {
+        mainHeight: shellFooter.height,
+        settingsHeight: settingsFooter.height,
+        mainDividerFromBottom: shell.bottom - shellFooter.top,
+        settingsDividerFromBottom: settings.bottom - settingsFooter.top,
+        mainOverhang: shell.bottom - shellFooter.bottom,
+      };
+    });
 
-    expect(heights.main).toBeDefined();
-    expect(heights.settings).toBeDefined();
-    expect(heights.settings).toBeCloseTo(heights.main ?? 0, 2);
+    expect(geometry).not.toBeNull();
+    expect(geometry?.settingsHeight).toBeCloseTo(geometry?.mainHeight ?? 0, 2);
+    // The strip is chrome: it bleeds to the sidebar edge instead of sitting on
+    // the shell's bottom content gutter.
+    expect(geometry?.mainOverhang).toBeCloseTo(0, 2);
+    expect(geometry?.settingsDividerFromBottom).toBeCloseTo(
+      geometry?.mainDividerFromBottom ?? 0,
+      2,
+    );
+  });
+
+  it("centers the account row between the divider and the sidebar edge", async () => {
+    const centering = await page.evaluate(() => {
+      const box = (selector: string) => document.querySelector(selector)?.getBoundingClientRect();
+      const shell = box(".sidebar-shell");
+      const footer = box(".sidebar-shell__footer");
+      const card = box(".sidebar-identity-card");
+      const action = box(".sidebar-issues-button");
+      if (!(shell && footer && card && action)) {
+        return null;
+      }
+      const dividerWidth = Number.parseFloat(
+        getComputedStyle(document.querySelector(".sidebar-shell__footer") as Element)
+          .borderBlockStartWidth,
+      );
+      return {
+        above: card.top - (footer.top + dividerWidth),
+        below: shell.bottom - card.bottom,
+        cardCenterY: (card.top + card.bottom) / 2,
+        actionCenterY: (action.top + action.bottom) / 2,
+        leadingInset: card.left - shell.left,
+        trailingInset: shell.right - action.right,
+      };
+    });
+
+    expect(centering).not.toBeNull();
+    // Measured from the divider's inner edge, the band splits evenly.
+    expect(centering?.above).toBeCloseTo(centering?.below ?? 0, 2);
+    expect(centering?.actionCenterY).toBeCloseTo(centering?.cardCenterY ?? 0, 2);
+    expect(centering?.trailingInset).toBeCloseTo(centering?.leadingInset ?? 0, 2);
   });
 });

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -978,6 +978,8 @@ openclaw-settings-save-indicator:empty {
 
 .sidebar-shell {
   --sidebar-pad-x: 10px;
+  /* Both gutters are content insets; the footer strip negates them to bleed. */
+  --sidebar-pad-bottom: 8px;
   display: flex;
   flex-direction: column;
   min-height: 0;
@@ -985,7 +987,7 @@ openclaw-settings-save-indicator:empty {
   /* 9px top pad centers the brand row's 30px icons on the app's shared
      24px chrome centerline (pane-header actions, floating toggles). The
      macOS app overrides this with its 50px titlebar clearance. */
-  padding: 9px var(--sidebar-pad-x) 8px;
+  padding: 9px var(--sidebar-pad-x) var(--sidebar-pad-bottom);
   border: none;
   border-radius: 0;
   background: transparent;
@@ -1096,11 +1098,15 @@ openclaw-settings-save-indicator:empty {
   padding-right: var(--sidebar-pad-x);
 }
 
+/* Chrome, not content: the strip bleeds past both shell gutters. Negating the
+   bottom one puts the divider on the settings takeover's line and lets the
+   symmetric block padding center the row in the band it leaves. */
 .sidebar-shell__footer {
   flex-shrink: 0;
   min-height: var(--shell-sidebar-footer-height);
   margin-inline: calc(-1 * var(--sidebar-pad-x));
-  padding: 4px var(--sidebar-pad-x) 0;
+  margin-block-end: calc(-1 * var(--sidebar-pad-bottom));
+  padding: 4px var(--sidebar-pad-x);
   border-block-start: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
 }
 

--- a/ui/src/styles/layout.mobile.css
+++ b/ui/src/styles/layout.mobile.css
@@ -245,7 +245,8 @@ html:not(.openclaw-native-macos):not(.openclaw-native-nav):not(.openclaw-native-
 
 .shell--mobile-nav .sidebar-shell {
   --sidebar-pad-x: 16px;
-  padding: 18px var(--sidebar-pad-x) 14px;
+  --sidebar-pad-bottom: 14px;
+  padding: 18px var(--sidebar-pad-x) var(--sidebar-pad-bottom);
   border-radius: 0;
 }
 
@@ -350,7 +351,8 @@ html.openclaw-native-macos body .shell--mobile-nav .topnav-shell__actions {
 
   .shell--mobile-nav .sidebar-shell {
     --sidebar-pad-x: 14px;
-    padding: 8px var(--sidebar-pad-x) 10px;
+    --sidebar-pad-bottom: 10px;
+    padding: 8px var(--sidebar-pad-x) var(--sidebar-pad-bottom);
   }
 
   .shell--mobile-nav .nav-item {


### PR DESCRIPTION
## What Problem This Solves

The account row at the bottom of the Control UI sidebar sat visibly high in its footer strip. Measured from the divider to the sidebar's bottom edge, there were 10px of space above the pill and 17px below it, so the row hugged the divider instead of centering in the band. The mobile drawer was worse: 4px above, 18px below at its 14px gutter tier.

The same omission moved the divider itself. The main sidebar's divider sat 61px above the sidebar's bottom edge while the Settings takeover's sat at 53px, so the line jumped 8px when you opened Settings — despite the code comment on `--shell-sidebar-footer-height` claiming the two share bottom divider geometry.

## Why This Change Was Made

`.sidebar-shell__footer` is chrome, not content. It already cancels the shell's horizontal gutter with `margin-inline: calc(-1 * var(--sidebar-pad-x))` so the divider spans the full sidebar width, but it never cancelled the vertical one — the shell's `padding-bottom` stayed underneath the strip and pushed the whole band off-center. One incomplete full-bleed, two symptoms.

This promotes that gutter to `--sidebar-pad-bottom`, negates it on the footer exactly like the horizontal one, and makes the footer's block padding symmetric. Because the strip no longer depends on the gutter, its height stays exactly `--shell-sidebar-footer-height` on every breakpoint, so the Settings-parity contract still holds — and the two dividers now land on the same line instead of merely being the same height. The mobile tiers ride the same token, so they are fixed by the same change rather than by a second magic number. No fallback or compatibility path was added or removed.

## User Impact

The account row is centered between the divider and the sidebar's bottom edge, in both themes and on the mobile drawer, and opening Settings no longer nudges the sidebar divider.

## Evidence

Captured from the running Control UI against the mocked Gateway at 1440x900, cropped to the sidebar's bottom band.

**Before (dark)**

![Before, dark theme](https://github.com/user-attachments/assets/335cfb63-5ab9-4867-bd77-238253199363)

**After (dark)**

![After, dark theme](https://github.com/user-attachments/assets/f9ef6143-1a37-4ea6-ae89-2dee00f2f3f6)

**Before (light)**

![Before, light theme](https://github.com/user-attachments/assets/94d6fe22-33e8-40d1-89bf-f0946c6da896)

**After (light)**

![After, light theme](https://github.com/user-attachments/assets/59f9a96e-1365-4cc2-bbeb-fa57c8afa61e)

Geometry, measured in Chromium against the real stylesheets:

| | before | after |
| --- | --- | --- |
| space above the account pill | 10px | 9px |
| space below the account pill | 17px | 9px |
| main sidebar divider, above sidebar edge | 61px | 53px |
| settings divider, above sidebar edge | 53px | 53px |
| footer height, both sidebars | 53px | 53px |

The existing `sidebar-footer-layout.browser.test.ts` asserted only that the two footers were the same height, which stayed true the whole time the dividers were 8px apart. It now asserts the invariant that was actually violated — that both footers sit flush to their sidebar's edge on one divider line, and that the row splits the remaining band evenly. Both new tests fail on pre-fix CSS for the right reason:

```text
x lands both sidebar footers on one divider line
  -> expected 7.999995231628418 to be close to +0
x centers the account row between the divider and the sidebar edge
  -> expected 9 to be close to 16.999995231628418
```

Validation: `sidebar-footer-layout.browser.test.ts`, `sidebar-account-footer.e2e.test.ts`, `lobster-pet-dismiss-menu-overflow.e2e.test.ts` (the pet perches on this divider), `custodian-panel-toggle.e2e.test.ts`, `sidebar-selection-overflow.e2e.test.ts` and siblings — 25 tests, all passing. `node scripts/check-changed.mjs` clean. Autoreview (Codex, gpt-5.6-sol, high) returned `scoped-clean`.

Production LOC: net +8 in `ui/src/styles` (4 of them comment lines; the functional growth is three `--sidebar-pad-bottom` declarations and one `margin-block-end`). The growth buys the ownership boundary the bug lived in — the gutter is now one named token the footer can negate, instead of the same magic number written separately at three breakpoints.
