### PR TITLE
perf: avoid unused system-event snapshots

### DIFF
--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -123,7 +123,8 @@ export function enqueueSystemEventEntry(
   text: string,
   options: SystemEventOptions,
 ): SystemEvent | null {
-  return enqueueOwnedSystemEventEntry(text, options);
+  const event = enqueueOwnedSystemEventEntry(text, options);
+  return event ? cloneSystemEvent(event) : null;
 }
 
 function enqueueOwnedSystemEventEntry(
@@ -170,11 +171,11 @@ function enqueueOwnedSystemEventEntry(
   if (entry.queue.length > MAX_EVENTS) {
     entry.queue.shift();
   }
-  return cloneSystemEvent(event);
+  return event;
 }
 
 export function enqueueSystemEvent(text: string, options: SystemEventOptions) {
-  return enqueueSystemEventEntry(text, options) !== null;
+  return enqueueOwnedSystemEventEntry(text, options) !== null;
 }
 
 /** Enqueues one occurrence and returns one-use removal ownership for its UUID. */
@@ -192,12 +193,17 @@ export function enqueueSystemEventWithReceipt(
 }
 
 export function drainSystemEventEntries(sessionKey: string): SystemEvent[] {
+  return drainSystemEventsWith(sessionKey, cloneSystemEvent);
+}
+
+function drainSystemEventsWith<T>(sessionKey: string, project: (event: SystemEvent) => T): T[] {
   const key = requireSessionKey(sessionKey);
   const entry = getSessionQueue(key);
   if (!entry || entry.queue.length === 0) {
     return [];
   }
-  const out = entry.queue.map(cloneSystemEvent);
+  const out = entry.queue.map(project);
+  // Reentrant consumers may hold this array; clear it in place before removing the queue.
   entry.queue.length = 0;
   entry.lastContextKey = null;
   queues.delete(key);
@@ -258,7 +264,7 @@ function replaceSystemEventEntry(text: string, options: SystemEventOptions): Sys
     entry.queue.shift();
   }
   entry.lastContextKey = normalizedContextKey;
-  return cloneSystemEvent(event);
+  return event;
 }
 
 function isDuplicateSystemEvent(
@@ -359,7 +365,7 @@ export function consumeSelectedSystemEventEntries(
 }
 
 export function drainSystemEvents(sessionKey: string): string[] {
-  return drainSystemEventEntries(sessionKey).map((event) => event.text);
+  return drainSystemEventsWith(sessionKey, (event) => event.text);
 }
 
 export function peekSystemEventEntries(sessionKey: string): SystemEvent[] {
@@ -367,7 +373,7 @@ export function peekSystemEventEntries(sessionKey: string): SystemEvent[] {
 }
 
 export function peekSystemEvents(sessionKey: string): string[] {
-  return peekSystemEventEntries(sessionKey).map((event) => event.text);
+  return getSessionQueue(sessionKey)?.queue.map((event) => event.text) ?? [];
 }
 
 export function hasSystemEvents(sessionKey: string) {


### PR DESCRIPTION
## What Problem This Solves

System-event callers that only need a boolean, removal receipt or string list currently construct event snapshots they immediately discard. This repeats object, delivery-context and ownership-copy work in the transient queue used by status, prompt and event-delivery flows.

## Why This Change Was Made

Keep queued occurrences private and clone at the public event-snapshot boundary. Boolean enqueue and receipt creation now use the private occurrence directly; public entry APIs still return fresh snapshots with copied route data and WeakMap ownership. String peek/drain project text directly.

Both drain APIs share one private projection function. It preserves the existing map → clear the original array in place → reset context → delete queue sequence, including consumers that reenter while holding the original array. There is no second queue algorithm, cache, public alias, persistence or policy change. Production is **+13/−7, net +6 lines**; the private projector keeps this lifecycle rule in one owner. Tests are unchanged.

## User Impact

Less allocation and copying for ordinary event flows. Queue capacity, duplicate/replacement rules, order, IDs, owner isolation, receipt one-use behavior, returned snapshot independence and reset behavior stay unchanged. This is an internal performance refactor, without settings, dependencies, schema or protocol changes.

## Evidence

Measured complete synthetic enqueue → peek → receipt-consume/drain → context-check flows, including checksum work. These numbers are **not standalone status-peek or whole-Gateway latency measurements**.

| Complete flow | Before → candidate, forward | Before → candidate, reverse |
| --- | --- | --- |
| One Boolean enqueue, routed, string projection | 0.486 → 0.429 µs | 0.493 → 0.430 µs |
| Eight Boolean enqueues, owner-marked, string projection | 7.290 → 3.377 µs | 7.558 → 3.284 µs |
| Eight public entry enqueues, owner-marked, string projection | 7.024 → 4.180 µs | 7.621 → 4.363 µs |
| Twenty Boolean enqueues, owner-marked, entry snapshots | 17.479 → 14.563 µs | 17.589 → 14.662 µs |

All 36 nonempty string-flow rows improved in both orders by 5.8–56.6%. An enqueue-only ablation left 2.1–47.3% of measured string-flow improvement unused, supporting the single coherent boundary refactor rather than splitting it.

Costs are retained: the blank Boolean/entry-projection control slowed by 0.088 µs (66.0%) forward and 0.074 µs (53.2%) reverse. The largest single-order absolute cost was twenty owner-marked public entry enqueues, +0.553 µs (3.2%) reverse while forward improved 2.1%. Across all 80 controls, 63 improved in both orders, one slowed in both, and 16 were mixed. That is not a weighted product speedup; all adverse rows remain in the local report.

Six fresh processes used before/enqueue-only/candidate/candidate/enqueue-only/before order. Each had the same 80 rows, four warmups and eleven measured blocks of 256 complete operations. All **5,280 measured and 1,920 warmup values** are retained, with no calibration, retries or dropped rows. The lead and independent reviewer recomputed all 480 medians/min/max. One process per variant/order limits confidence in small differences. No startup, retained-memory or statistical-significance claim.

Correctness proof compares all three variants: 726 counted assertions per variant means 86 direct assertions plus 640 checks over 80 workload oracles, not 726 independent scenarios. Coverage includes getter/reentry behavior, stale/copied IDs, snapshot mutation, receipt replacement/eviction/one-use, duplicate module ownership, capacity, delivery context, duplicates and restart. The saved proof records zero product I/O; actual Node loader reads are tracked separately. Earlier pre-product loader failures remain retained.

Canonical baseline and the integrated candidate each pass **66 tests** across the queue, Gateway event-routing and session-reset suites. Independent all-priority owner/caller/history/dependency/evidence review found no actionable production defect. Managed Codex review is scoped-clean at its P0 threshold. Source capture remains `20b2dac`; proof/timing ran at `71785b8`. A separate `09595614` audit confirms all 72 source and 130 installed inputs unchanged; the only contract drift is an unrelated Windows test-script addition in package.json, without a runtime/dependency/export change.

The earlier built baseline Gateway completed four real OpenAI turns including Tool Search/read/web, then three system-event RPCs (A, A, B) and two status reads returning exactly A, B, followed by 12 session RPCs. This validates duplicate suppression and nondestructive string projection at the real caller boundary; it is not live SDK string-drain proof. Candidate changed-code checks passed in 244.981 s and the full build passed on exact head `2fb3364` in 169.135 s. The exact-head candidate built Gateway also completed all four real OpenAI turns, three system-event RPCs (A, A, B), both status reads returning exactly A, B, and 12 session RPCs. The task-owned SQLite transcript confirms actual Tool Search and tool dispatch, the literal local-file marker, and HTTP 200 web content via the Readability plugin. Independent parent checks found the Gateway PID/group and port gone; temporary config/key FIFO were removed and the exact owned web spill was retained before cleanup. The CPU profile is retained as a diagnostic, without a whole-process or unique-thread coverage claim. Candidate readiness was 3.819 s; the four turn durations were 1.710/4.427/5.400/6.681 s, integration observations only—not a controlled latency comparison. A task-local helper cleanup repair is outside the production diff; no failure-injection or universal cleanup bound is claimed.

Fresh committed Codex review of `2fb3364` is scoped-clean at P0 (0.99); the separate all-priority source/evidence review found no actionable defect. Hosted CI run `33432081994`, attempt 1, completed successfully on exact head `2fb3364fd7b0a587b0c1bd808f5458efcbe339ac`. The initial draft event skipped CI; the first full ready-for-review run passed without a retry. The fresh ClawSweeper review at 19:48 UTC found no correctness/security defect and no Rank-up moves; its remaining items are exact-head CI and normal maintainer handling. CI is now green, and this is part of the explicitly authorized maintainer performance campaign.
