### PR TITLE
refactor(ui): finish the assistant dock rename and drop duplicate work

### DIFF
--- a/ui/src/app/app-shell-view.ts
+++ b/ui/src/app/app-shell-view.ts
@@ -23,7 +23,6 @@ import {
 import { readSessionMethodAccess } from "../lib/session-method-access.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
 import { isTerminalAvailable } from "../lib/terminal-availability.ts";
-import { buildHomeWorkContext } from "../pages/chat/chat-work-context.ts";
 import type { NewSessionTarget } from "../pages/new-session/location.ts";
 import { pluginTabKey, pluginTabRefFromSearch } from "../pages/plugin/route.ts";
 import type { ShellRouteState } from "./app-host-route-state.ts";
@@ -643,7 +642,7 @@ export function renderApplicationShell(host: ShellViewHost) {
         .sessionPage=${activeRoute === "chat"}
         .pageSessionKey=${host.activeSessionKey}
         .pageAgentId=${selectedAgentId}
-        .workContext=${buildHomeWorkContext(context, activeRoute, host.activeSessionKey)}
+        .workPage=${activeRoute}
         .minimizeRequestId=${host.custodianMinimizeRequestId}
       ></openclaw-assistant-panel>
       ${isOptionalElementDefined(host.execApprovalElement)

--- a/ui/src/components/assistant-panel.test.ts
+++ b/ui/src/components/assistant-panel.test.ts
@@ -74,8 +74,8 @@ describe("assistant panel", () => {
 
   afterEach(() => {
     document.body.replaceChildren();
-    document.documentElement.style.removeProperty("--oc-custodian-reserve-bottom");
-    document.documentElement.style.removeProperty("--oc-custodian-reserve-right");
+    document.documentElement.style.removeProperty("--oc-assistant-reserve-bottom");
+    document.documentElement.style.removeProperty("--oc-assistant-reserve-right");
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
@@ -168,7 +168,7 @@ describe("assistant panel", () => {
     await replacement.updateComplete;
     expect(replacement.querySelector("openclaw-home-session")).toBeNull();
     expect(replacement.querySelector("openclaw-custodian-surface")).not.toBeNull();
-    expect(replacement.querySelectorAll(".cp")).toHaveLength(1);
+    expect(replacement.querySelectorAll(".assistant-panel")).toHaveLength(1);
   });
 
   it("minimizes a real page conversation into the dock on route leave", async () => {
@@ -185,11 +185,15 @@ describe("assistant panel", () => {
     await panel.updateComplete;
 
     expect(panel.assistantPanelOpen).toBe(true);
-    expect(document.documentElement.style.getPropertyValue("--oc-custodian-reserve-right")).toBe(
+    expect(document.documentElement.style.getPropertyValue("--oc-assistant-reserve-right")).toBe(
       "440px",
     );
 
-    panel.querySelector<HTMLButtonElement>(".cp-actions .cp-icon:last-child")!.click();
+    panel
+      .querySelector<HTMLButtonElement>(
+        ".assistant-panel-actions .assistant-panel-icon:last-child",
+      )!
+      .click();
     await panel.updateComplete;
     expect(panel.assistantPanelOpen).toBe(false);
 
@@ -254,13 +258,13 @@ describe("assistant panel", () => {
     const postMessage = vi.fn();
     vi.stubGlobal("webkit", { messageHandlers: { openclawWindowDrag: { postMessage } } });
     const cases = [
-      [".cp-header", true],
-      [".cp-title", true],
-      [".cp-actions", true],
-      [".cp-actions button:first-child", false],
-      [".cp-actions button:first-child svg", false],
-      [".cp-actions button:last-child", false],
-      [".cp-actions button:last-child svg", false],
+      [".assistant-panel-header", true],
+      [".assistant-panel-title", true],
+      [".assistant-panel-actions", true],
+      [".assistant-panel-actions button:first-child", false],
+      [".assistant-panel-actions button:first-child svg", false],
+      [".assistant-panel-actions button:last-child", false],
+      [".assistant-panel-actions button:last-child svg", false],
       ["openclaw-custodian-surface", false],
     ] as const;
     for (const [selector, draggable] of cases) {
@@ -281,10 +285,12 @@ describe("assistant panel", () => {
       expect(event.defaultPrevented, selector).toBe(draggable);
     }
 
-    panel.querySelector<HTMLButtonElement>(".cp-actions button:first-child")!.click();
+    panel.querySelector<HTMLButtonElement>(".assistant-panel-actions button:first-child")!.click();
     await panel.updateComplete;
-    expect(panel.querySelector(`.cp--${dock === "right" ? "bottom" : "right"}`)).not.toBeNull();
-    panel.querySelector<HTMLButtonElement>(".cp-actions button:last-child")!.click();
+    expect(
+      panel.querySelector(`.assistant-panel--${dock === "right" ? "bottom" : "right"}`),
+    ).not.toBeNull();
+    panel.querySelector<HTMLButtonElement>(".assistant-panel-actions button:last-child")!.click();
     await panel.updateComplete;
     expect(panel.assistantPanelOpen).toBe(false);
   });
@@ -362,7 +368,11 @@ describe("assistant panel", () => {
     await panel.updateComplete;
 
     expect(
-      (panel.querySelector(".cp-title openclaw-mascot") as HTMLElement & { mood: string }).mood,
+      (
+        panel.querySelector(".assistant-panel-title openclaw-mascot") as HTMLElement & {
+          mood: string;
+        }
+      ).mood,
     ).toBe("thinking");
   });
 });

--- a/ui/src/components/assistant-panel.ts
+++ b/ui/src/components/assistant-panel.ts
@@ -23,11 +23,7 @@ import {
 } from "../lib/sessions/session-key.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { getSafeLocalStorage } from "../local-storage.ts";
-import {
-  buildHomeWorkContext,
-  subscribeChatWorkContext,
-  type ChatWorkContext,
-} from "../pages/chat/chat-work-context.ts";
+import { buildHomeWorkContext, subscribeChatWorkContext } from "../pages/chat/chat-work-context.ts";
 import {
   custodianSessionStore,
   type CustodianSessionStore,
@@ -52,6 +48,8 @@ type AssistantDestination = "home" | "custodian";
 type AssistantDock = Exclude<DockPanelSide, "left">;
 
 const panelLayout = createDockPanelLayout({
+  // Shipped key: operators' saved dock size and placement live here, so the
+  // legacy custodian spelling stays even though the dock is now shared.
   storageKey: "openclaw.custodian.panel.v1",
   minHeight: 240,
   minWidth: 320,
@@ -71,7 +69,8 @@ export class OpenClawAssistantPanel extends OpenClawLightDomElement {
   @property({ type: Boolean }) sessionPage = false;
   @property() pageSessionKey = "";
   @property() pageAgentId = "";
-  @property({ attribute: false }) workContext: ChatWorkContext | undefined;
+  /** Route id of the page being worked on; the dock derives its own snapshot from it. */
+  @property() workPage = "";
   @state() private destination: AssistantDestination = "custodian";
   private readonly homeLoader = new LazyCustomElementRequestController(this);
   @property({ type: Number }) minimizeRequestId = 0;
@@ -79,7 +78,7 @@ export class OpenClawAssistantPanel extends OpenClawLightDomElement {
 
   private readonly dockLayout = new DockLayoutController(this, {
     layout: panelLayout,
-    reservationPrefix: "custodian",
+    reservationPrefix: "assistant",
     isAvailable: () => this.available,
   });
   private readonly onToggleRequest = (event: Event) => this.handleToggleRequest(event);
@@ -99,9 +98,7 @@ export class OpenClawAssistantPanel extends OpenClawLightDomElement {
     window.addEventListener(CUSTODIAN_PANEL_TOGGLE_EVENT, this.onToggleRequest);
     window.addEventListener(HOME_PANEL_TOGGLE_EVENT, this.onToggleRequest);
     this.dockLayout.setSuppressed(this.suppressed);
-    if (this.dockLayout.open && this.destination === "custodian") {
-      void this.store.refreshTranscriptIfIdle();
-    }
+    this.refreshCustodianTranscript(this.dockLayout.open);
   }
 
   override disconnectedCallback(): void {
@@ -169,9 +166,7 @@ export class OpenClawAssistantPanel extends OpenClawLightDomElement {
     } else {
       this.dockLayout.restoreOpenState();
     }
-    if (!wasOpen && this.dockLayout.open && this.destination === "custodian") {
-      void this.store.refreshTranscriptIfIdle();
-    }
+    this.refreshCustodianTranscript(!wasOpen && this.dockLayout.open);
     if (wasOpen && !this.dockLayout.open) {
       this.claimInput("page");
     }
@@ -218,8 +213,19 @@ export class OpenClawAssistantPanel extends OpenClawLightDomElement {
     };
   }
 
+  /** Ask OpenClaw hydrates lazily; only refresh when it actually becomes visible. */
+  private refreshCustodianTranscript(becameVisible: boolean): void {
+    if (becameVisible && this.destination === "custodian") {
+      void this.store.refreshTranscriptIfIdle();
+    }
+  }
+
+  private availableFor(destination: AssistantDestination): boolean {
+    return destination === "home" ? this.homeAvailable : this.custodianAvailable;
+  }
+
   private get available(): boolean {
-    return this.destination === "home" ? this.homeAvailable : this.custodianAvailable;
+    return this.availableFor(this.destination);
   }
 
   private get suppressed(): boolean {
@@ -292,9 +298,7 @@ export class OpenClawAssistantPanel extends OpenClawLightDomElement {
     this.persistTarget();
     this.dockLayout.setOpen(open);
     this.claimInput(open ? "dock" : "page");
-    if (open && this.destination === "custodian") {
-      void this.store.refreshTranscriptIfIdle();
-    }
+    this.refreshCustodianTranscript(open);
   }
 
   toggle(): void {
@@ -312,7 +316,7 @@ export class OpenClawAssistantPanel extends OpenClawLightDomElement {
 
   handleToggleRequest(event: Event): void {
     const destination = event.type === HOME_PANEL_TOGGLE_EVENT ? "home" : "custodian";
-    if (destination === "home" ? !this.homeAvailable : !this.custodianAvailable) {
+    if (!this.availableFor(destination)) {
       return;
     }
     const detail = asNullableRecord(event instanceof CustomEvent ? event.detail : null);
@@ -342,23 +346,24 @@ export class OpenClawAssistantPanel extends OpenClawLightDomElement {
     const dock = this.dockLayout.dock;
     const home = this.homeTarget;
     const homeState = this.homeLoader.visibleState;
-    const workContext =
-      this.context && this.workContext
-        ? buildHomeWorkContext(this.context, this.workContext.page, this.workContext.sessionKey)
-        : this.workContext;
+    // Built here, not by the shell: the dock re-derives on its own work-context
+    // and agent-selection subscriptions without waiting for a shell render.
+    const workContext = this.context
+      ? buildHomeWorkContext(this.context, this.workPage, this.pageSessionKey)
+      : undefined;
     const style =
       dock === "bottom" ? `height:${this.dockLayout.height}px` : `width:${this.dockLayout.width}px`;
     return html`
       <section
-        class="cp cp--${dock}"
+        class="assistant-panel assistant-panel--${dock}"
         style=${style}
         aria-label=${t("assistantPanel.title")}
         @pointerdown=${() => this.claimInput("dock")}
         @focusin=${() => this.claimInput("dock")}
       >
-        ${this.dockLayout.renderResizer("cp", t("assistantPanel.resize"))}
-        <header class="rail-header cp-header" @mousedown=${beginNativeWindowDrag}>
-          <div class="cp-title">
+        ${this.dockLayout.renderResizer("assistant-panel", t("assistantPanel.resize"))}
+        <header class="rail-header assistant-panel-header" @mousedown=${beginNativeWindowDrag}>
+          <div class="assistant-panel-title">
             <openclaw-mascot
               .mood=${this.destination === "custodian" && this.store.sending ? "thinking" : "idle"}
               .size=${16}
@@ -367,7 +372,7 @@ export class OpenClawAssistantPanel extends OpenClawLightDomElement {
               (destination === "home" ? this.homeAvailable : this.custodianAvailable)
                 ? html`<button
                     type="button"
-                    class="cp-tab"
+                    class="assistant-panel-tab"
                     aria-pressed=${this.destination === destination}
                     @click=${() => this.openDestination(destination)}
                   >
@@ -376,10 +381,10 @@ export class OpenClawAssistantPanel extends OpenClawLightDomElement {
                 : nothing,
             )}
           </div>
-          <div class="rail-header__actions cp-actions">
+          <div class="rail-header__actions assistant-panel-actions">
             ${this.destination === "home"
               ? html`<button
-                  class="rail-header__action cp-icon"
+                  class="rail-header__action assistant-panel-icon"
                   type="button"
                   aria-label=${t("assistantPanel.openHome")}
                   @click=${() => this.openHomePage()}
@@ -388,7 +393,7 @@ export class OpenClawAssistantPanel extends OpenClawLightDomElement {
                 </button>`
               : nothing}
             <button
-              class="rail-header__action cp-icon"
+              class="rail-header__action assistant-panel-icon"
               type="button"
               aria-label=${dock === "bottom"
                 ? t("assistantPanel.dockRight")
@@ -398,7 +403,7 @@ export class OpenClawAssistantPanel extends OpenClawLightDomElement {
               ${dock === "bottom" ? icons.panelRightOpen : icons.panelBottomOpen}
             </button>
             <button
-              class="rail-header__action cp-icon"
+              class="rail-header__action assistant-panel-icon"
               type="button"
               aria-label=${t("assistantPanel.close")}
               @click=${() => this.setOpen(false)}

--- a/ui/src/pages/chat/chat-work-context.ts
+++ b/ui/src/pages/chat/chat-work-context.ts
@@ -98,6 +98,8 @@ export function buildHomeWorkContext(
 
 /** A small quoted reference block, never an authorization or instruction channel. */
 export function formatChatWorkContext(context: ChatWorkContext): string {
+  // Exhaustive by construction: a new ChatWorkContext field cannot reach the
+  // model without an explicit bound here.
   const limits = {
     page: 64,
     title: 96,
@@ -107,10 +109,10 @@ export function formatChatWorkContext(context: ChatWorkContext): string {
     workspace: 224,
     file: 224,
     selection: 640,
-  } as const;
+  } as const satisfies Record<keyof ChatWorkContext, number>;
   const snapshot = Object.fromEntries(
     Object.entries(limits).flatMap(([key, limit]) => {
-      // SAFETY: limits is a closed local object whose keys are all ChatWorkContext fields.
+      // SAFETY: the satisfies clause above proves every limits key is a ChatWorkContext field.
       let value = truncateUtf16Safe(context[key as keyof ChatWorkContext]?.trim() ?? "", limit);
       // Bound the serialized form too: quotes/control characters can expand sixfold.
       while (JSON.stringify(value).length > limit) {

--- a/ui/src/styles/assistant-panel.css
+++ b/ui/src/styles/assistant-panel.css
@@ -5,7 +5,7 @@ openclaw-assistant-panel {
   font-family: var(--font-body);
 }
 
-.cp {
+.assistant-panel {
   position: fixed;
   display: flex;
   min-width: 0;
@@ -15,82 +15,82 @@ openclaw-assistant-panel {
   background: var(--bg);
 }
 
-.cp--bottom {
+.assistant-panel--bottom {
   right: calc(var(--oc-terminal-reserve-right, 0px) + var(--oc-browser-reserve-right, 0px));
   bottom: calc(var(--oc-terminal-reserve-bottom, 0px) + var(--oc-browser-reserve-bottom, 0px));
   left: var(--shell-nav-width, 0);
 }
 
-.cp--right {
+.assistant-panel--right {
   top: var(--shell-topbar-height, 0);
   right: calc(var(--oc-terminal-reserve-right, 0px) + var(--oc-browser-reserve-right, 0px));
   bottom: calc(var(--oc-terminal-reserve-bottom, 0px) + var(--oc-browser-reserve-bottom, 0px));
 }
 
-.cp-resizer {
+.assistant-panel-resizer {
   position: absolute;
   z-index: 2;
 }
 
-.cp-resizer--bottom {
+.assistant-panel-resizer--bottom {
   --resize-handle-line-block: 0;
   top: 0;
   right: 0;
   left: 0;
 }
 
-.cp-resizer--right {
+.assistant-panel-resizer--right {
   --resize-handle-line-inline: 0;
   top: 0;
   bottom: 0;
   left: 0;
 }
 
-.cp-title,
-.cp-actions {
+.assistant-panel-title,
+.assistant-panel-actions {
   display: flex;
   align-items: center;
 }
 
-.cp-title {
+.assistant-panel-title {
   min-width: 0;
   gap: 7px;
   color: var(--text-strong);
   font-size: 12px;
 }
 
-.cp-actions {
+.assistant-panel-actions {
   gap: var(--rail-header-action-gap);
 }
 
-.cp-icon {
+.assistant-panel-icon {
   flex: 0 0 auto;
 }
 
-.cp > openclaw-custodian-surface,
-.cp > openclaw-home-session {
+.assistant-panel > openclaw-custodian-surface,
+.assistant-panel > openclaw-home-session {
   display: flex;
   min-height: 0;
   flex: 1 1 0;
 }
 
-.cp .custodian-surface {
+.assistant-panel .custodian-surface {
   width: 100%;
   min-height: 0;
   padding: 0 12px 12px;
 }
 
-.cp .custodian__messages {
+.assistant-panel .custodian__messages {
   padding-block: 16px;
 }
 
-.cp .custodian__option-card {
+.assistant-panel .custodian__option-card {
   margin-right: 0;
   margin-left: 42px;
 }
 
 @media (max-width: 640px) {
-  .cp--right {
+  .assistant-panel--right {
     top: var(--shell-topbar-height, 0);
     right: 0;
     bottom: 0;
@@ -99,7 +99,7 @@ openclaw-assistant-panel {
   }
 }
 
-.cp-tab {
+.assistant-panel-tab {
   border: 0;
   padding: 4px;
   background: transparent;
@@ -108,12 +108,12 @@ openclaw-assistant-panel {
   white-space: nowrap;
 }
 
-.cp-tab[aria-pressed="true"] {
+.assistant-panel-tab[aria-pressed="true"] {
   color: var(--text-strong);
   font-weight: 600;
 }
 
-.cp > openclaw-home-session {
+.assistant-panel > openclaw-home-session {
   flex-direction: column;
   min-width: 0;
 }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -4115,11 +4115,11 @@ wa-dropdown.sidebar-identity-menu::part(menu) {
      panels set these vars; they are 0 when closed. */
   margin-bottom: calc(
     var(--oc-terminal-reserve-bottom, 0px) + var(--oc-browser-reserve-bottom, 0px) +
-      var(--oc-custodian-reserve-bottom, 0px)
+      var(--oc-assistant-reserve-bottom, 0px)
   );
   margin-right: calc(
     var(--oc-terminal-reserve-right, 0px) + var(--oc-browser-reserve-right, 0px) +
-      var(--oc-custodian-reserve-right, 0px)
+      var(--oc-assistant-reserve-right, 0px)
   );
   transition:
     margin-bottom 0.16s ease,


### PR DESCRIPTION
Follow-up cleanup on the Home agent dock landed in #133676.

## What Problem This Solves

The dock was renamed to "assistant panel" when it started hosting both Home and Ask OpenClaw, but its internals kept the old vocabulary, and the feature left two places doing the same work:

- `.cp*` (custodian panel) CSS classes sat in the same stylesheet as the newer `.assistant-panel-context` — two spellings for one concept — and `--oc-custodian-reserve-*` named the layout reservation for a dock that is no longer custodian-only.
- The "refresh Ask OpenClaw's transcript when it becomes visible" policy existed in three places (`connectedCallback`, `willUpdate`, `setOpen`), and the `home ? homeAvailable : custodianAvailable` decision in two.
- The shell called `buildHomeWorkContext()` on every render and passed the result to the panel, which immediately **rebuilt it** from two of its fields. The panel has to rebuild — it re-derives on its own work-context and agent-selection subscriptions without waiting for a shell render — so the shell's copy was redundant scanning of sessions and agents on a hot path.
- `formatChatWorkContext`'s truncation table was a plain literal, so a newly added `ChatWorkContext` field would be silently dropped from the snapshot instead of bounded.

## Why This Change Was Made

One spelling per concept, one owner per decision. The dock's classes and reservation variable are now `assistant-panel*`; the repeated policies collapse into `refreshCustodianTranscript()` and `availableFor(destination)`; the work snapshot is derived once, by the component that subscribes to its inputs, from a narrower `workPage` prop; and the truncation table is `satisfies Record<keyof ChatWorkContext, number>`, so an unbounded new field is a compile error rather than a silent omission.

The shipped `openclaw.custodian.panel.v1` localStorage key deliberately keeps its legacy name — it holds operators' saved dock size and placement, and renaming it would silently reset their layout. A comment now records that so a future cleanup does not "fix" it.

## User Impact

None intended: no visual, behavioral, or persistence change. Saved dock placement and size continue to load from the existing key.

## Evidence

- Mocked Control UI verification at this head: renamed hooks all resolve (`section.assistant-panel`, 2 tabs, 3 icons, 1 resizer), **zero** stale `.cp*` nodes, `--oc-assistant-reserve-right: 440px` / `--oc-assistant-reserve-bottom: 420px` applied with no stale `--oc-custodian-reserve-*`, and `.assistant-panel--bottom` renders on dock switch. Both placements are visually identical to the landed version.

Right dock:

![Assistant dock, right placement, after the rename](https://github.com/user-attachments/assets/e0408b8c-5e67-48f7-9275-a36bbe2ea3a8)

Bottom dock with the work-context snapshot expanded:

![Assistant dock, bottom placement, context expanded](https://github.com/user-attachments/assets/db344d7f-ce97-4e6d-8633-88116991bb1f)
- 7,273 tests pass across 412 files (`ui/src/components`, `ui/src/app`, `ui/src/pages/chat`).
- `node scripts/check-changed.mjs` passes, including the assertion-SAFETY ratchet — the retained type assertion now cites the `satisfies` clause as its proof.
- Structured autoreview (codex, local diff): scoped-clean, 0.98.

### Size

Production `+64/−58` (net +6); the growth is nine short comment lines recording non-obvious contracts (why the legacy storage key stays, why the dock derives its own snapshot, the truncation-table invariant). Non-comment production code is net negative. Tests `+26/−16`.
