### PR TITLE
fix: CI watcher tests time out while loading fixture evidence

### DIFF
--- a/test/scripts/watch-pr-ci.test.ts
+++ b/test/scripts/watch-pr-ci.test.ts
@@ -20,23 +20,29 @@ import placeholderFixture from "../fixtures/watch-pr-ci-queued-placeholder.json"
 
 const sha = "a".repeat(40);
 
-function runWatcher(ghScript: string, headSha = sha, options: string[] = []) {
+function runWatcher(
+  ghScript: string,
+  headSha = sha,
+  options: string[] = [],
+  clock: "poll" | "wall" = "poll",
+) {
   return withTempDir("openclaw-watch-pr-ci-", async (binDir) => {
     const ghPath = join(binDir, "gh");
     writeFileSync(ghPath, ghScript);
     chmodSync(ghPath, 0o755);
     const clockPath = join(binDir, "poll-clock.mjs");
-    // Advance only polling sleep; real elapsed time still bounds GitHub child reads.
+    // Evidence fixtures advance polling only, independent of fake gh startup cost.
+    // Deadline coverage explicitly retains the real clock and child timeout.
     // NODE_OPTIONS reaches the implementation through its unmodified CLI wrapper.
     writeFileSync(
       clockPath,
       `import { syncBuiltinESMExports } from "node:module";
 import timers from "node:timers/promises";
 if (process.argv[1] === ${JSON.stringify(fileURLToPath(new URL("../../scripts/watch-pr-ci.mts", import.meta.url)))}) {
-  const realNow = Date.now;
+  const now = ${clock === "wall" ? "Date.now" : "() => 0"};
   const realSleep = timers.setTimeout;
   let waitedMs = 0;
-  Date.now = () => realNow() + waitedMs;
+  Date.now = () => now() + waitedMs;
   timers.setTimeout = async (milliseconds, value, options) => {
     const result = await realSleep(0, value, options);
     waitedMs += milliseconds;
@@ -94,6 +100,7 @@ function replayPlaceholder(
     merged?: boolean;
     watchTimeout?: number;
     delayFirstAlias?: boolean;
+    clock?: "poll" | "wall";
     afterAliasScan?: unknown;
   } = {},
 ) {
@@ -145,7 +152,10 @@ else throw new Error("unexpected gh invocation: " + JSON.stringify(args));
 console.log(JSON.stringify(value));
 `,
       placeholderFixture.run.head_sha,
-      evidence.watchTimeout === undefined ? [] : ["--timeout", String(evidence.watchTimeout)],
+      evidence.watchTimeout === undefined
+        ? []
+        : ["--timeout", String(evidence.watchTimeout), "--interval", String(evidence.watchTimeout)],
+      evidence.clock,
     );
     return { ...result, calls: readFileSync(calls, "utf8") };
   });
@@ -356,6 +366,7 @@ esac
     it("bounds a slow alias read by the remaining watcher deadline", async () => {
       const result = await replayPlaceholder(structuredClone(placeholderFixture), {
         delayFirstAlias: true,
+        clock: "wall",
       });
       expect(result.status, `${result.stdout}\n${result.stderr}`).toBe(16);
       expect(result.stdout).toContain("pending=1");


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where CI watcher tests time out before reading their fixture evidence when a busy host takes longer to start the fake GitHub CLI. Nine such failures blocked the generated locale repair in [CI 33417646786](https://github.com/openclaw/openclaw/actions/runs/33417646786), despite no watcher source change.

## Why This Change Was Made

Separate the test clock used for evidence scenarios from real subprocess startup time. The existing slow-child deadline case explicitly keeps the wall clock, and real child-process timeout budgets remain unchanged. Evidence scenarios with a five-second budget use the same polling interval so they do not repeat identical outer snapshots. Identity revalidation within each complete evidence pass and all existing assertions remain.

## User Impact

Internal test reliability and runtime improvement only. The production watcher, GitHub requests, release gates, and CLI behavior are unchanged. Test support: +16/-5; production code: +0/-0.

## Evidence

Controlled 400 ms delays per fake alias response make three positive cases fail before the repair; all three and the real-time slow-child deadline case pass afterward. The diagnostic delay is not retained in source.

The final suite passes the same 124 cases. Same-host sequential runs observed 115.9 seconds before and 78.6 seconds after; this is not a controlled hosted-CI speed claim. The unchanged test and watcher source also passed the selected full-release CI shard, supporting the diagnosis of timing-sensitive fixtures rather than a GitHub outage.

The canonical changed-file gate and independent managed Codex review passed. No timeout was increased, no assertion or scenario was removed, and no production injection seam was added.
