### PR TITLE
fix(config): import shell keys from configured plugins

### DIFF
--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -3,7 +3,7 @@ import { createServer } from "node:http";
 import { Command } from "commander";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { CONFIG_AUDIT_STORE_LABEL } from "../../config/io.audit.js";
-import type { ConfigFileSnapshot } from "../../config/types.js";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../../config/types.js";
 import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../../daemon/constants.js";
 import { createNewerSqliteSchemaVersionError } from "../../infra/sqlite-user-version.js";
 import { SUPERVISOR_HINT_ENV_VARS } from "../../infra/supervisor-markers.js";
@@ -76,7 +76,9 @@ const loadShellEnvFallback = vi.fn((_opts?: unknown) => {
   callOrder.push("shell-env");
 });
 const clearShellEnvAppliedKeys = vi.fn((_keys: readonly string[]) => undefined);
-const resolveShellEnvExpectedKeys = vi.fn((_env?: NodeJS.ProcessEnv) => ["OPENCLAW_GATEWAY_TOKEN"]);
+const resolveShellEnvExpectedKeys = vi.fn((_env?: NodeJS.ProcessEnv, _config?: OpenClawConfig) => [
+  "OPENCLAW_GATEWAY_TOKEN",
+]);
 const resolveShellEnvFallbackTimeoutMs = vi.fn((_env?: NodeJS.ProcessEnv) => 15_000);
 const shouldDeferShellEnvFallback = vi.fn((_env?: NodeJS.ProcessEnv) => false);
 const shouldEnableShellEnvFallback = vi.fn((_env?: NodeJS.ProcessEnv) => false);
@@ -201,7 +203,8 @@ vi.mock("../../infra/dotenv-global.js", () => ({
 }));
 
 vi.mock("../../config/shell-env-expected-keys.js", () => ({
-  resolveShellEnvExpectedKeys: (env?: NodeJS.ProcessEnv) => resolveShellEnvExpectedKeys(env),
+  resolveShellEnvExpectedKeys: (...args: Parameters<typeof resolveShellEnvExpectedKeys>) =>
+    resolveShellEnvExpectedKeys(...args),
 }));
 
 vi.mock("../../infra/shell-env.js", () => ({
@@ -686,6 +689,10 @@ describe("gateway run option collisions", () => {
         logger: expect.any(Object),
         timeoutMs: 1234,
       });
+      expect(resolveShellEnvExpectedKeys).toHaveBeenCalledWith(
+        expect.objectContaining({ OPENCLAW_GATEWAY_TOKEN: "config-token" }),
+        finalConfig,
+      );
       expect(readConfigFileSnapshotWithPluginMetadata).toHaveBeenCalledWith(
         expect.objectContaining({
           lowerPrecedenceEnv: { OPENCLAW_GATEWAY_TOKEN: "shell-token" },

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -351,7 +351,7 @@ async function resolveGatewayRunShellEnvFallbackPlan(
   const { resolveShellEnvExpectedKeys } = await import("../../config/shell-env-expected-keys.js");
   return {
     enabled: true,
-    expectedKeys: resolveShellEnvExpectedKeys(planEnv),
+    expectedKeys: resolveShellEnvExpectedKeys(planEnv, cfg),
     timeoutMs: cfg.env?.shellEnv?.timeoutMs ?? resolveShellEnvFallbackTimeoutMs(planEnv),
   };
 }

--- a/src/config/io.context.ts
+++ b/src/config/io.context.ts
@@ -85,7 +85,7 @@ export function createConfigIoContext(options: ConfigIoFactoryOptions = {}): Con
       loadShellEnvFallback({
         enabled: true,
         env: deps.env,
-        expectedKeys: resolveShellEnvExpectedKeys(deps.env),
+        expectedKeys: resolveShellEnvExpectedKeys(deps.env, cfg),
         logger: deps.logger,
         timeoutMs: cfg.env?.shellEnv?.timeoutMs ?? resolveShellEnvFallbackTimeoutMs(deps.env),
       });

--- a/src/config/io.shell-env-expected-keys.test.ts
+++ b/src/config/io.shell-env-expected-keys.test.ts
@@ -1,48 +1,86 @@
 // Verifies shell environment key metadata used by config IO.
-import { describe, expect, it, vi } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createGeneratedPluginTempRoot,
+  installGeneratedPluginTempRootCleanup,
+  writeJson,
+} from "../plugins/generated-plugin-test-helpers.js";
+import { createConfigIO } from "./io.js";
 
-const listKnownChannelEnvVarNames = vi.hoisted(() => vi.fn(() => ["DISCORD_BOT_TOKEN"]));
-const listKnownProviderAuthEnvVarNames = vi.hoisted(() => vi.fn(() => ["OPENAI_API_KEY"]));
+const loadShellEnvFallback = vi.hoisted(() =>
+  vi.fn<typeof import("../infra/shell-env.js").loadShellEnvFallback>(),
+);
 
-vi.mock("../secrets/channel-env-vars.js", () => ({
-  listKnownChannelEnvVarNames,
+vi.mock("../infra/shell-env.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../infra/shell-env.js")>()),
+  loadShellEnvFallback,
 }));
 
-vi.mock("../secrets/provider-env-vars.js", () => ({
-  listKnownProviderAuthEnvVarNames,
-  resolveProviderAuthLookupMaps: () => ({
-    aliasMap: {},
-    envCandidateMap: {},
-    authEvidenceMap: {},
-  }),
-}));
+installGeneratedPluginTempRootCleanup();
 
 describe("config io shell env expected keys", () => {
-  it("includes provider and channel env vars from manifest-driven plugin metadata", async () => {
-    listKnownProviderAuthEnvVarNames.mockReturnValueOnce([
-      "OPENAI_API_KEY",
-      "ARCEEAI_API_KEY",
-      "FIREWORKS_ALT_API_KEY",
-    ]);
-    listKnownChannelEnvVarNames.mockReturnValueOnce([
-      "DISCORD_BOT_TOKEN",
-      "SLACK_BOT_TOKEN",
-      "SLACK_APP_TOKEN",
-    ]);
-
-    vi.resetModules();
-    const { resolveShellEnvExpectedKeys } = await import("./shell-env-expected-keys.js");
-
-    const expectedKeys = resolveShellEnvExpectedKeys({} as NodeJS.ProcessEnv);
-    expect(expectedKeys).toEqual([
-      "OPENAI_API_KEY",
-      "ARCEEAI_API_KEY",
-      "FIREWORKS_ALT_API_KEY",
-      "DISCORD_BOT_TOKEN",
-      "SLACK_BOT_TOKEN",
-      "SLACK_APP_TOKEN",
-      "OPENCLAW_GATEWAY_TOKEN",
-      "OPENCLAW_GATEWAY_PASSWORD",
-    ]);
+  beforeEach(() => {
+    loadShellEnvFallback.mockClear();
   });
+
+  it.each(["loadConfig", "readBestEffortConfig"] as const)(
+    "%s includes env keys from a configured plugin without executing its runtime",
+    async (read) => {
+      const home = createGeneratedPluginTempRoot("openclaw-shell-env-metadata-");
+      const pluginDir = path.join(home, "configured-plugin");
+      const configPath = path.join(home, "state", "openclaw.json");
+      writeJson(path.join(pluginDir, "openclaw.plugin.json"), {
+        id: "shell-fixture",
+        providers: ["shell-fixture"],
+        channels: ["shell-fixture"],
+        channelConfigs: { "shell-fixture": { schema: { type: "object" } } },
+        setup: {
+          requiresRuntime: false,
+          providers: [{ id: "shell-fixture", envVars: ["SHELL_FIXTURE_PROVIDER_KEY"] }],
+        },
+        configSchema: { type: "object", properties: {} },
+      });
+      writeJson(path.join(pluginDir, "package.json"), {
+        name: "shell-fixture",
+        version: "1.0.0",
+        openclaw: {
+          extensions: ["./index.js"],
+          channel: {
+            id: "shell-fixture",
+            configuredState: {
+              env: {
+                allOf: ["SHELL_FIXTURE_CHANNEL_KEY"],
+                anyOf: ["SHELL_FIXTURE_PROVIDER_KEY"],
+              },
+            },
+          },
+        },
+      });
+      fs.writeFileSync(path.join(pluginDir, "index.js"), 'throw new Error("metadata only");\n');
+      writeJson(configPath, {
+        env: { shellEnv: { enabled: true } },
+        plugins: { allow: ["shell-fixture"], load: { paths: [pluginDir] } },
+      });
+      const env = {
+        HOME: home,
+        OPENCLAW_STATE_DIR: path.dirname(configPath),
+        OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(home, "empty-bundled"),
+      };
+      fs.mkdirSync(env.OPENCLAW_BUNDLED_PLUGINS_DIR);
+
+      await createConfigIO({ configPath, env, homedir: () => home, observe: false })[read]();
+
+      expect(loadShellEnvFallback).toHaveBeenCalledOnce();
+      const { expectedKeys } = loadShellEnvFallback.mock.calls[0]![0];
+      expect(expectedKeys.filter((key) => key.startsWith("SHELL_FIXTURE_"))).toEqual([
+        "SHELL_FIXTURE_PROVIDER_KEY",
+        "SHELL_FIXTURE_CHANNEL_KEY",
+      ]);
+      expect(expectedKeys).toEqual(
+        expect.arrayContaining(["OPENCLAW_GATEWAY_TOKEN", "OPENCLAW_GATEWAY_PASSWORD"]),
+      );
+    },
+  );
 });

--- a/src/config/shell-env-expected-keys.ts
+++ b/src/config/shell-env-expected-keys.ts
@@ -2,19 +2,18 @@
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import { listKnownChannelEnvVarNames } from "../secrets/channel-env-vars.js";
 import { listKnownProviderAuthEnvVarNames } from "../secrets/provider-env-vars.js";
+import type { OpenClawConfig } from "./types.openclaw.js";
 
 const CORE_SHELL_ENV_EXPECTED_KEYS = ["OPENCLAW_GATEWAY_TOKEN", "OPENCLAW_GATEWAY_PASSWORD"];
 
-/**
- * Lists env vars worth importing from login-shell fallback for this config load.
- *
- * Provider/channel helpers inspect the current environment so optional plugin
- * and auth aliases only trigger shell probing when their configured keys matter.
- */
-export function resolveShellEnvExpectedKeys(env: NodeJS.ProcessEnv): string[] {
+/** Includes configured plugin paths when selecting keys for login-shell import. */
+export function resolveShellEnvExpectedKeys(
+  env: NodeJS.ProcessEnv,
+  config?: OpenClawConfig,
+): string[] {
   return uniqueStrings([
-    ...listKnownProviderAuthEnvVarNames({ env }),
-    ...listKnownChannelEnvVarNames({ env }),
+    ...listKnownProviderAuthEnvVarNames({ config, env }),
+    ...listKnownChannelEnvVarNames({ config, env }),
     ...CORE_SHELL_ENV_EXPECTED_KEYS,
   ]);
 }


### PR DESCRIPTION
Related: #130324. Split from #130706. This PR addresses the shell-import metadata boundary; the broader Gateway CPU investigation remains open.

## What Problem This Solves

Fixes an issue where operators using a plugin from a configured load path could have its authentication environment variables omitted from login-shell import, even though the plugin was present in their selected config.

## Why This Change Was Made

Config IO and Gateway startup already know the selected config, but discarded it when asking which environment keys to import. Forward that config through the existing shell-key helper to the provider and channel metadata readers. Their existing metadata and trust policies remain the owners; no plugin runtime needs to execute and no new config, cache, dependency, or discovery path is added.

Production: +10/−11 (net −1) across three files. Tests: +86/−41 (net +45) across two existing files. The former mocked list test is replaced with two real manifest/config-reader cases; the existing Gateway startup test now checks the exact config handoff.

## User Impact

Configured plugins can supply their declared provider and channel environment-key names to login-shell import. Unlisted shell variables remain excluded, and existing core Gateway keys remain included. This does not change credential precedence or execute plugin code during metadata discovery.

## Evidence

On main 25486048f8a95c0e1115c525aa5b7948d7f82555, both config-reader cases failed because the configured plugin keys were missing; the Gateway startup case failed because the selected config was not forwarded. All three passed after the fix.

The nine-file cohort passed 192 tests. The canonical changed gate passed all 29 checks, including production and test typechecks, lint, and architecture guards. Managed Codex review found no P0 findings in the complete five-file candidate.

Real source-entrypoint proof passed both loadConfig and readBestEffortConfig in separate synthetic homes with a real zsh login shell: the profile ran once, the declared fixture key was imported, an unlisted control key was ignored, and the plugin runtime did not execute. Both child process groups were verified absent afterward. Fixture artifacts were retained. This is real login-shell/config-IO proof, not a built Gateway, authenticated provider, or live channel test. No application build was required for this argument-forwarding change; runtime module boundaries and published surfaces are unchanged.

Telegram proof remains explicitly waived for the split work. This cut does not establish that the complete long-running Gateway CPU problem is fixed.
