### PR TITLE
fix(update): route stored dev package installs to git

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -5608,6 +5608,47 @@ describe("update-cli", () => {
     expect(runDaemonRestart).not.toHaveBeenCalled();
     expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
   });
+
+  it("routes a stored dev channel from a package install to the git update flow", async () => {
+    const packageRoot = createCaseDir("openclaw-update-package-root");
+    mockPackageInstallStatus(packageRoot);
+    const config = { update: { channel: "dev" } } as OpenClawConfig;
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
+      ...baseSnapshot,
+      parsed: config,
+      resolved: config,
+      sourceConfig: config,
+      runtimeConfig: config,
+      config,
+    });
+    await updateCommand({ dryRun: true, json: true, restart: false });
+
+    const preview = lastWriteJsonCall() as
+      | { updateInstallKind?: string; switchToGit?: boolean }
+      | undefined;
+    expect(preview?.updateInstallKind).toBe("git");
+    expect(preview?.switchToGit).toBe(true);
+    expect(packageInstallCommandCall()).toBeUndefined();
+  });
+
+  it("keeps a stored-dev package install on the package path for a one-off tag", async () => {
+    const packageRoot = createCaseDir("openclaw-update-package-root");
+    mockPackageInstallStatus(packageRoot);
+    const config = { update: { channel: "dev" } } as OpenClawConfig;
+    vi.mocked(readConfigFileSnapshot).mockResolvedValue({
+      ...baseSnapshot,
+      parsed: config,
+      resolved: config,
+      sourceConfig: config,
+      runtimeConfig: config,
+      config,
+    });
+
+    await updateCommand({ tag: "latest", yes: true, restart: false });
+
+    expect(runGatewayUpdate).not.toHaveBeenCalled();
+    expectPackageInstallSpec("openclaw@latest");
+  });
   it("explains why git updates cannot run with edited files", async () => {
     vi.mocked(defaultRuntime.log).mockClear();
     vi.mocked(defaultRuntime.error).mockClear();

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -3401,7 +3401,12 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
     });
     return;
   }
-  const switchToGit = requestedChannel === "dev" && installKind !== "git";
+  // A configured dev channel is a Git checkout too. A one-off package tag
+  // deliberately stays package-scoped, unless the caller explicitly selects dev.
+  const explicitTag = normalizeTag(opts.tag);
+  const switchToGit =
+    installKind !== "git" &&
+    (requestedChannel === "dev" || (selectedChannel === "dev" && explicitTag === null));
   const switchToPackage =
     requestedChannel !== null && requestedChannel !== "dev" && installKind === "git";
   const updateInstallKind = switchToGit ? "git" : switchToPackage ? "package" : installKind;
@@ -3411,7 +3416,6 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
   const devTargetRef =
     channel === "dev" ? process.env.OPENCLAW_UPDATE_DEV_TARGET_REF?.trim() || undefined : undefined;
 
-  const explicitTag = normalizeTag(opts.tag);
   if (channel === "extended-stable" && explicitTag) {
     await reportPreMutationUpdateFailure({
       root,


### PR DESCRIPTION
## Summary

Backports the stored `update.channel: dev` routing contract to the extended-stable candidate. A package install with stored `dev` now switches to the Git update flow; a one-off `--tag` remains package-scoped, while explicit `--channel dev` still takes precedence.

This replaces the main-only acceptance workaround proposed in #134394: the candidate package is the behavior under test, so its documented update contract belongs in `update-command.ts`, not in a capability-based test exemption.

## Evidence

- Prior release check: update-channel Docker lane expected Git but candidate returned npm/package routing: [job 99385643608](https://github.com/openclaw/openclaw/actions/runs/33358560442/job/99385643608).
- Candidate docs already define `dev` as a Git checkout, including package-to-Git switching: `docs/install/development-channels.md`.
- Focused test runs in this checkout are blocked before collection by the known local Vitest/Rolldown worker stall; `oxlint` for both touched files and `git diff --check` pass. Hosted exact-head CI is the required runtime proof.

## Scope

Production: +6/-2. Tests: +41/-0. No dependency, tag, npm, schema, or config-shape change.