### PR TITLE
test: seed legacy cron jobs after baseline configuration

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -376,9 +376,6 @@ function seedState() {
   if (scenario === "meeting-transcripts-sqlite") {
     seedLegacyMeetingTranscripts(stateDir);
   }
-  if (scenario === "cron-scheduled-authority") {
-    seedLegacyCronScheduledAuthority(stateDir);
-  }
   if (scenario === "auth-profile-v2026-7-2-beta-5") {
     const fixture = readJson(
       path.join(
@@ -1533,6 +1530,9 @@ if (command === "list-scenarios") {
   process.stdout.write(`${JSON.stringify([...SCENARIOS])}\n`);
 } else if (command === "seed") {
   seedState();
+} else if (command === "seed-cron") {
+  assert(getScenario() === "cron-scheduled-authority", "seed-cron requires the cron scenario");
+  seedLegacyCronScheduledAuthority(requireEnv("OPENCLAW_STATE_DIR"));
 } else if (command === "seed-volume") {
   assert(getScenario() === "sqlite-volume", "seed-volume requires the sqlite-volume scenario");
   const stateDir = requireEnv("OPENCLAW_STATE_DIR");

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -1378,6 +1378,11 @@ phase install-baseline install_baseline
 phase seed-state seed_state
 phase apply-baseline-config-recipe apply_baseline_config_recipe
 phase validate-baseline-config validate_baseline_config
+if [ "$SCENARIO" = "cron-scheduled-authority" ]; then
+  # Baseline roster writes must precede ownerless migration specimens: the
+  # published CLI correctly refuses topology changes while those jobs exist.
+  phase seed-cron-state node scripts/e2e/lib/upgrade-survivor/assertions.mjs seed-cron
+fi
 phase install-baseline-plugin-dependencies install_baseline_plugin_dependencies
 phase seed-legacy-plugin-dependency-debris seed_legacy_plugin_dependency_debris
 phase assert-legacy-plugin-dependency-debris assert_legacy_plugin_dependency_debris_present

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -581,6 +581,9 @@ else
   openclaw_test_state_create upgrade-survivor upgrade-survivor
 fi
 node scripts/e2e/lib/upgrade-survivor/assertions.mjs seed
+if [ "${OPENCLAW_UPGRADE_SURVIVOR_SCENARIO:-base}" = "cron-scheduled-authority" ]; then
+  node scripts/e2e/lib/upgrade-survivor/assertions.mjs seed-cron
+fi
 
 CURRENT_PHASE="install-candidate"
 openclaw_e2e_install_package "$OPENCLAW_UPGRADE_SURVIVOR_ARTIFACT_ROOT/install.log" "upgrade survivor package" "$npm_config_prefix"

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -1174,6 +1174,39 @@ process.stdout.write(sessionDir + "\\n");
     },
   );
 
+  it("defers legacy cron specimens until the baseline is configured", () => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-cron-"));
+    try {
+      const stateDir = join(root, "state");
+      const workspace = join(root, "workspace");
+      const env = {
+        ...process.env,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_TEST_WORKSPACE_DIR: workspace,
+        OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: "cron-scheduled-authority",
+        OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE: "baseline",
+      };
+      const run = (command: string) =>
+        spawnSync(process.execPath, [ASSERTIONS_PATH, command], { env, encoding: "utf8" });
+      const seeded = run("seed");
+      expect(seeded.status, seeded.stderr).toBe(0);
+      const cronStore = join(stateDir, "cron", "jobs.json");
+      expect(() => readFileSync(cronStore)).toThrow(/ENOENT/);
+      const cronSeeded = run("seed-cron");
+      expect(cronSeeded.status, cronSeeded.stderr).toBe(0);
+      const baseline = run("assert-state");
+      expect(baseline.status, baseline.stderr).toBe(0);
+      const store = JSON.parse(readFileSync(cronStore, "utf8"));
+      store.jobs.pop();
+      writeJson(cronStore, store);
+      const missingRow = run("assert-state");
+      expect(missingRow.status).not.toBe(0);
+      expect(missingRow.stderr).toContain("legacy cron authority fixture row count changed");
+    } finally {
+      rmSync(root, { force: true, recursive: true });
+    }
+  });
+
   it("accepts the ACPX OpenClaw tools bridge scenario during seed", () => {
     const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-survivor-acpx-"));
     try {


### PR DESCRIPTION
## What Problem This Solves

The published-version cron upgrade scenario failed before it could test an upgrade. It created five intentionally ambiguous legacy jobs, then asked the published CLI to configure a new agent roster. The CLI correctly refused that ownership-changing write while unresolved jobs existed.

## Why This Change Was Made

Finish the baseline configuration before seeding the cron migration specimens. Both published-version and current-package harnesses use the same scenario-checked seed command; other state setup keeps its existing order. The five-row producer and all baseline and post-migration assertions remain unchanged.

This fixes the fixture at its producer instead of bypassing the real configuration guard or running baseline Doctor, which would consume the migration specimens before the candidate could exercise them.

## User Impact

Internal release verification only. No product runtime, schema, config surface, baseline version, timeout, retry or ownership policy changes. Three harness files total +11/-3; the existing test gains 33 lines.

## Evidence

The unchanged native scenario reproduced the actual ownerless-jobs refusal. The permanent regression also failed before the fix, then passed, and still rejects a missing fixture row. The four-file local suite passed 353 tests with two existing platform skips; the canonical changed-file gate and independent managed Codex review passed.

The complete native upgrade from published `openclaw@2026.8.1` then passed using the exact `594f5003092453884b78320d0417450f035d25a9` release package and images plus this harness patch. All ten configuration steps, baseline checks, candidate update, Doctor, survival checks, and Gateway health/readiness/status passed. The unchanged assertions verified all five SQLite jobs, recovered the encoded owner account, and granted no scheduled authority to the four ambiguous jobs.

The native failing arm took 22.4 seconds and passing arm 198.4 seconds; these are scenario outcomes, not a performance comparison or full-release green claim. The separate auth fixture repair applies cleanly to the other runner functions.

Follow-up: failed recipe-step diagnostics should expose bounded, redacted child error details so a native reproduction is not needed merely to recover the cause. This PR does not upload raw configuration or arguments.
