### PR TITLE
fix(workers): avoid unrelated inspection and move cleanup during recovery

### DIFF
--- a/docs/gateway/cloud-workers.md
+++ b/docs/gateway/cloud-workers.md
@@ -443,6 +443,8 @@ unsynced-file and in-flight-work loss boundary as the Control UI confirmation.
 
 Placement moves through a durable state machine (`local → requested → provisioning → syncing → starting → active`), so a Gateway restart mid-dispatch reconciles instead of leaking machines. A failed model turn keeps the active placement available for a retry. Workspace path conflicts keep the local version, apply the rest of the cloud result, and preserve the staged cloud ref for inspection; other reconciliation or lifecycle failures retain their durable recovery fence and diagnostic tail until recovery can safely retry or reclaim the environment.
 
+Recovery requested for one worker inspects that environment and resumes only its associated workspace results and moves. Regular background sweeps still reconcile all environments. Recovery continues to wait for earlier placement operations to finish.
+
 If a turn reports `Cloud worker finished, but its workspace result could not be reconciled`, inspect the cause after the colon. A failed node manifest capture includes its bounded, redacted stderr, or its termination status when stderr is empty. Node cleanup preserves manifests needed between upload and verification, including when other workers finish simultaneously; increasing transfer timeouts does not repair a missing manifest.
 
 ## What survives a dead machine

--- a/src/gateway/worker-environments/placement-dispatch-pending-results.ts
+++ b/src/gateway/worker-environments/placement-dispatch-pending-results.ts
@@ -61,7 +61,7 @@ export type PlacementRecoveryDeps = {
     sessionKey: string;
     agentId: string;
   }) => Promise<WorkerWorkspaceResultConflict | undefined>;
-  recoverPlacementMoves?: () => Promise<Set<string>>;
+  recoverPlacementMoves?: (environmentId?: string) => Promise<Set<string>>;
   prepareAcceptedWorkspacePublication?: (claim: WorkerSessionTurnClaim) => Promise<void>;
   publishAcceptedWorkspace?: (claim: WorkerSessionTurnClaim) => Promise<void>;
 };

--- a/src/gateway/worker-environments/placement-dispatch-recovery.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.ts
@@ -234,7 +234,11 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
   // Runtime sweeps must not classify a live dispatch preparation as a crash. They only repair
   // durable active ownership and retry teardown already fenced by a previous failure.
   const reconcileActive = async (environmentId?: string): Promise<void> => {
-    await environments.reconcileOnce();
+    if (environmentId === undefined) {
+      await environments.reconcileOnce();
+    } else {
+      await environments.reconcileEnvironment(environmentId);
+    }
     const cleanupOrphans = orphanCleanupPending && environmentId === undefined;
     const pendingResultOwners = await recoverPendingWorkspaceResults(
       deps,
@@ -245,7 +249,7 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
       orphanCleanupPending = false;
     }
     const journalOwners = blockingWorkspaceJournalSessions(placements);
-    const moveOwners = (await deps.recoverPlacementMoves?.()) ?? new Set<string>();
+    const moveOwners = (await deps.recoverPlacementMoves?.(environmentId)) ?? new Set<string>();
     for (const placement of placements.listForReconcile()) {
       if (
         journalOwners.has(placement.sessionId) ||

--- a/src/gateway/worker-environments/placement-dispatch-recovery.ts
+++ b/src/gateway/worker-environments/placement-dispatch-recovery.ts
@@ -234,11 +234,7 @@ export function createPlacementRecoveryActions(deps: PlacementRecoveryDeps) {
   // Runtime sweeps must not classify a live dispatch preparation as a crash. They only repair
   // durable active ownership and retry teardown already fenced by a previous failure.
   const reconcileActive = async (environmentId?: string): Promise<void> => {
-    if (environmentId === undefined) {
-      await environments.reconcileOnce();
-    } else {
-      await environments.reconcileEnvironment(environmentId);
-    }
+    await environments.reconcileOnce(environmentId);
     const cleanupOrphans = orphanCleanupPending && environmentId === undefined;
     const pendingResultOwners = await recoverPendingWorkspaceResults(
       deps,

--- a/src/gateway/worker-environments/placement-dispatch.ts
+++ b/src/gateway/worker-environments/placement-dispatch.ts
@@ -138,7 +138,6 @@ function isExactAttachedEnvironment(
 export function createWorkerPlacementDispatchService(options: WorkerPlacementDispatchOptions) {
   const { environments, placements } = options;
   const failure = createPlacementFailureActions({ environments, placements });
-  let recoverPlacementMoves = async (): Promise<Set<string>> => new Set();
 
   const reportTransition = (
     observer: ((placement: WorkerDispatchPlacement) => void) | undefined,
@@ -174,7 +173,7 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
       ? { reportWorkspaceResultRecoveryFailure: options.reportWorkspaceResultRecoveryFailure }
       : {}),
     resolveWorkspaceResultConflict: options.resolveWorkspaceResultConflict,
-    recoverPlacementMoves: () => recoverPlacementMoves(),
+    recoverPlacementMoves: (environmentId) => moveService.recoverAll(environmentId),
     workspaceOperations: options.workspaceOperations,
     ...(options.prepareAcceptedWorkspacePublication
       ? { prepareAcceptedWorkspacePublication: options.prepareAcceptedWorkspacePublication }
@@ -708,7 +707,6 @@ export function createWorkerPlacementDispatchService(options: WorkerPlacementDis
     abandonSource: abandonment.abandonSource,
     resolveDestination: options.resolveMoveDestination,
   });
-  recoverPlacementMoves = moveService.recoverAll;
 
   return {
     dispatch,

--- a/src/gateway/worker-environments/placement-move-service.ts
+++ b/src/gateway/worker-environments/placement-move-service.ts
@@ -319,10 +319,20 @@ export function createWorkerPlacementMoveService(options: {
     }
   };
 
-  const recoverAll = async (): Promise<Set<string>> => {
+  const recoverAll = async (environmentId?: string): Promise<Set<string>> => {
     const protectedSessions = new Set<string>();
     for (const intent of options.placements.listPlacementMoves()) {
-      const state = options.placements.get(intent.sessionId)?.state;
+      const placement = options.placements.get(intent.sessionId);
+      // Source cleanup can leave a local placement; destination activation keeps the
+      // move intent until completion. Either owner must be able to finish that move.
+      if (
+        environmentId !== undefined &&
+        intent.source.environmentId !== environmentId &&
+        placement?.environmentId !== environmentId
+      ) {
+        continue;
+      }
+      const state = placement?.state;
       if (
         (intent.abandonSource && state !== "local") ||
         state === "draining" ||

--- a/src/gateway/worker-environments/placement-targeted-recovery.test.ts
+++ b/src/gateway/worker-environments/placement-targeted-recovery.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { installWorkerPlacementReconcileGuard } from "../server-worker-placement-reconcile-guard.js";
+import { coordinateWorkerPlacementDispatch } from "./placement-dispatch-coordinator.js";
+import { REQUEST, seedActivePlacement } from "./placement-dispatch-test-fixtures.js";
+import { createHarness } from "./placement-dispatch-test-harness.js";
+import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
+import { createWorkerSessionPlacementStore } from "./placement-store.js";
+import type { WorkerEnvironmentService } from "./service.js";
+import * as support from "./service.test-support.js";
+import { createWorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
+
+function seedAttached(environmentId: string) {
+  support.seedBootstrapping(environmentId);
+  support.testState.store.transition({
+    environmentId,
+    from: "bootstrapping",
+    to: "ready",
+    patch: support.readyPatch(environmentId, {
+      ...support.BOOTSTRAP_RECEIPT,
+      protocolFeatures: [WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE],
+    }),
+  });
+  return support.testState.store.transition({
+    environmentId,
+    from: "ready",
+    to: "attached",
+    patch: support.attachedPatch(environmentId, REQUEST.sessionId),
+  });
+}
+
+function createDispatch(
+  environments: WorkerEnvironmentService,
+  placements: ReturnType<typeof createWorkerSessionPlacementStore>,
+) {
+  return coordinateWorkerPlacementDispatch(
+    createWorkerPlacementDispatchService({
+      placements,
+      environments,
+      runnerAvailability: { read: () => undefined, version: () => 0 },
+      workspaceOperations: createWorkerWorkspaceOperationCoordinator(),
+      runLocalBarrier: async ({ startDispatch }) => startDispatch(),
+      runRecoveryBarrier: async ({ run }) => await run(support.testState.root),
+      runActivationBarrier: async ({ activate }) => activate(),
+      runMoveBarrier: async ({ begin }) => begin(),
+      resolveMoveDestination: async () => undefined,
+      runReclaimPreparation: async ({ run, authorize }) => await run(authorize),
+      runReclaimBarrier: async ({ begin, reclaim }) =>
+        await reclaim(support.testState.root, begin()),
+      runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
+      resolveWorkspacePath: async () => support.testState.root,
+      reportWorkspaceResultConflict: async () => {},
+      resolveWorkspaceResultConflict: async () => undefined,
+    }),
+  );
+}
+
+describe("targeted worker placement recovery", () => {
+  support.setupWorkerEnvironmentServiceSuite();
+  beforeEach(() => {
+    support.testState.prepareInstallation = async () => ({
+      ...support.BUNDLE_ARTIFACT,
+      protocolFeatures: [WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE],
+    });
+  });
+
+  it("does not wait for a sibling provider inspection; full sweeps still inspect and maintain it", async () => {
+    const targetId = "worker-target";
+    const siblingId = "worker-sibling";
+    const identity = seedAttached(targetId);
+    support.seedReady(siblingId);
+    const placements = createWorkerSessionPlacementStore({ database: support.testState.stateDb });
+    seedActivePlacement(placements, {
+      environmentId: targetId,
+      ownerEpoch: identity.ownerEpoch,
+      executionMode: "remote-exec",
+    });
+    const inspectionStarted = createDeferredCore();
+    const releaseInspection = createDeferredCore();
+    const inspected: string[] = [];
+    const maintainProviders = vi.fn(async () => {});
+    const environments = support.createService(
+      support.createProvider({
+        inspect: async ({ leaseId }) => {
+          inspected.push(leaseId);
+          if (leaseId === `lease:${siblingId}`) {
+            inspectionStarted.resolve();
+            await releaseInspection.promise;
+          }
+          return { status: "active" };
+        },
+      }),
+      { maintainProviders },
+    );
+    const dispatch = createDispatch(environments, placements);
+    const uninstall = installWorkerPlacementReconcileGuard({
+      placements,
+      environments,
+      dispatch,
+      isStopping: () => false,
+    });
+    const targeted = dispatch.reconcileActive(targetId);
+    let first;
+    let inspectedBeforeRelease: string[];
+    try {
+      first = await Promise.race([
+        targeted.then(() => "target-finished"),
+        inspectionStarted.promise.then(() => "sibling-inspection"),
+      ]);
+      inspectedBeforeRelease = [...inspected];
+    } finally {
+      releaseInspection.resolve();
+      await targeted;
+      await uninstall();
+    }
+    inspected.length = 0;
+    maintainProviders.mockClear();
+    const prune = vi.spyOn(support.testState.store, "pruneTerminalEnvironments");
+    await dispatch.reconcileActive();
+    expect(inspected.toSorted()).toEqual([`lease:${siblingId}`, `lease:${targetId}`]);
+    expect(maintainProviders).toHaveBeenCalledOnce();
+    expect(prune).toHaveBeenCalledOnce();
+    expect(placements.get(REQUEST.sessionId)?.state).toBe("active");
+    expect(first).toBe("target-finished");
+    expect(inspectedBeforeRelease).toEqual([`lease:${targetId}`]);
+  });
+
+  it("leaves an unrelated move for the full sweep instead of waiting for its workspace cleanup", async () => {
+    const placements = createWorkerSessionPlacementStore({ database: support.testState.stateDb });
+    const cleanupStarted = createDeferredCore();
+    const releaseCleanup = createDeferredCore();
+    const harness = createHarness(placements, {
+      workspacePath: support.testState.root,
+      reconcileChanged: false,
+      reconcileCommitsManifest: false,
+      afterReconcile: async () => {
+        cleanupStarted.resolve();
+        await releaseCleanup.promise;
+      },
+    });
+    const active = await harness.service.dispatch(REQUEST);
+    seedAttached(active.environmentId);
+    placements.beginPlacementMove({
+      sessionId: active.sessionId,
+      source: {
+        generation: active.generation,
+        environmentId: active.environmentId,
+        ownerEpoch: active.activeOwnerEpoch,
+      },
+      target: { kind: "gateway" },
+    });
+    const dispatch = coordinateWorkerPlacementDispatch(harness.service);
+    const targeted = dispatch.reconcileActive("worker-unrelated");
+    let first;
+    let retainedAfterTarget;
+    try {
+      first = await Promise.race([
+        targeted.then(() => "target-finished"),
+        cleanupStarted.promise.then(() => "unrelated-move-cleanup"),
+      ]);
+      retainedAfterTarget = placements.getPlacementMove(active.sessionId);
+    } finally {
+      releaseCleanup.resolve();
+      await targeted;
+    }
+    await dispatch.reconcileActive();
+    expect(placements.get(active.sessionId)?.state).toBe("local");
+    expect(placements.getPlacementMove(active.sessionId)).toBeUndefined();
+    expect(harness.log.filter((event) => event === "workspace:reconcile")).toHaveLength(1);
+    expect(harness.environments.destroy).toHaveBeenCalledOnce();
+    expect(first).toBe("target-finished");
+    expect(retainedAfterTarget).toBeDefined();
+  });
+
+  it.each(["source", "destination"] as const)(
+    "recovers a move selected by its %s after source cleanup already completed",
+    async (match) => {
+      const sourceId = "worker-move-source";
+      const destinationId = "worker-move-destination";
+      const sourceIdentity = seedAttached(sourceId);
+      const placements = createWorkerSessionPlacementStore({ database: support.testState.stateDb });
+      const active = seedActivePlacement(placements, {
+        environmentId: sourceId,
+        ownerEpoch: sourceIdentity.ownerEpoch,
+        executionMode: "remote-exec",
+      });
+      const begun = placements.beginPlacementMove({
+        sessionId: active.sessionId,
+        source: {
+          generation: active.generation,
+          environmentId: sourceId,
+          ownerEpoch: sourceIdentity.ownerEpoch,
+        },
+        target: { kind: "profile", profileId: "development" },
+      });
+      const reconciling = placements.startReconcile({
+        sessionId: active.sessionId,
+        environmentId: sourceId,
+        ownerEpoch: sourceIdentity.ownerEpoch,
+        expectedGeneration: begun.placement.generation,
+      });
+      placements.completePlacementMoveSourceToLocal({
+        operationId: begun.intent.operationId,
+        sessionId: active.sessionId,
+        expectedGeneration: reconciling.generation,
+      });
+      const environments = support.createService(support.createProvider());
+      await environments.destroy(sourceId);
+      if (match === "destination") {
+        const destination = seedAttached(destinationId);
+        seedActivePlacement(placements, {
+          environmentId: destinationId,
+          ownerEpoch: destination.ownerEpoch,
+          executionMode: "remote-exec",
+        });
+      }
+      const dispatch = createDispatch(environments, placements);
+      await dispatch.reconcileActive(match === "source" ? sourceId : destinationId);
+      expect(placements.getPlacementMove(active.sessionId)).toBeUndefined();
+      expect(placements.get(active.sessionId)?.state).toBe(
+        match === "source" ? "failed" : "active",
+      );
+      if (match === "source") {
+        expect(placements.get(active.sessionId)?.recoveryError).toContain("authority expired");
+      }
+    },
+  );
+});

--- a/src/gateway/worker-environments/service-lifetime.test.ts
+++ b/src/gateway/worker-environments/service-lifetime.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
 import * as support from "./service.test-support.js";
 import type { WorkerTunnelManager } from "./tunnel.js";
 
@@ -109,6 +110,53 @@ describe("worker environment service", () => {
 
     await support.createService(support.createProvider()).reconcileOnce();
 
+    expect(prune).toHaveBeenCalledOnce();
+  });
+
+  it("coalesces targeted and full inspection while retaining full-sweep maintenance", async () => {
+    const targetId = "worker-targeted-overlap";
+    const siblingId = "worker-full-sweep-sibling";
+    support.seedReady(targetId);
+    support.seedReady(siblingId);
+    const targetStarted = createDeferred();
+    const siblingStarted = createDeferred();
+    const finishTarget = createDeferred();
+    const inspect = vi.fn(async ({ leaseId }: WorkerLifecycleLease) => {
+      if (leaseId === `lease:${targetId}`) {
+        targetStarted.resolve();
+        await finishTarget.promise;
+      } else {
+        siblingStarted.resolve();
+      }
+      return { status: "active" as const };
+    });
+    const maintainProviders = vi.fn(async () => {});
+    const prune = vi.spyOn(support.testState.store, "pruneTerminalEnvironments");
+    const workerService = support.createService(support.createProvider({ inspect }), {
+      maintainProviders,
+    });
+    const uninstall = workerService.installReconcileEnvironmentGuard(async (_id, core) => {
+      await core();
+    });
+    const targeted = workerService.reconcileOnce(targetId);
+    let direct: Promise<void> | undefined;
+    let full: Promise<void> | undefined;
+    try {
+      await targetStarted.promise;
+      expect(inspect.mock.calls.map(([lease]) => lease.leaseId)).toEqual([`lease:${targetId}`]);
+      expect(maintainProviders).not.toHaveBeenCalled();
+      expect(prune).not.toHaveBeenCalled();
+      direct = workerService.reconcileEnvironment(targetId);
+      full = workerService.reconcileOnce();
+      await siblingStarted.promise;
+      expect(inspect).toHaveBeenCalledTimes(2);
+    } finally {
+      finishTarget.resolve();
+      await Promise.all([targeted, direct, full]);
+      await uninstall();
+    }
+    expect(inspect).toHaveBeenCalledTimes(2);
+    expect(maintainProviders).toHaveBeenCalledOnce();
     expect(prune).toHaveBeenCalledOnce();
   });
 
@@ -269,47 +317,50 @@ describe("worker environment service", () => {
     expect(inspect).toHaveBeenCalledTimes(2);
   });
 
-  it("closes guarded reconciliation admission and drains admitted recovery during stop", async () => {
-    const environmentId = "worker-guard-stop";
-    support.seedReady(environmentId);
-    const inspect = vi.fn(async () => ({ status: "active" as const }));
-    const workerService = support.createService(support.createProvider({ inspect }));
-    let releaseGuard: (() => void) | undefined;
-    const guardPending = new Promise<void>((resolve) => {
-      releaseGuard = resolve;
-    });
-    let signalGuardStarted: (() => void) | undefined;
-    const guardStarted = new Promise<void>((resolve) => {
-      signalGuardStarted = resolve;
-    });
-    let guardCompleted = false;
-    const uninstallGuard = workerService.installReconcileEnvironmentGuard(
-      async (_guardedEnvironmentId, reconcileCore) => {
-        signalGuardStarted?.();
-        await guardPending;
-        await reconcileCore();
-        guardCompleted = true;
-      },
-    );
-    const admitted = workerService.reconcileEnvironment(environmentId);
-    await guardStarted;
+  it.each(["reconcileEnvironment", "reconcileOnce"] as const)(
+    "closes guarded reconciliation admission and drains admitted %s recovery during stop",
+    async (method) => {
+      const environmentId = "worker-guard-stop";
+      support.seedReady(environmentId);
+      const inspect = vi.fn(async () => ({ status: "active" as const }));
+      const workerService = support.createService(support.createProvider({ inspect }));
+      let releaseGuard: (() => void) | undefined;
+      const guardPending = new Promise<void>((resolve) => {
+        releaseGuard = resolve;
+      });
+      let signalGuardStarted: (() => void) | undefined;
+      const guardStarted = new Promise<void>((resolve) => {
+        signalGuardStarted = resolve;
+      });
+      let guardCompleted = false;
+      const uninstallGuard = workerService.installReconcileEnvironmentGuard(
+        async (_guardedEnvironmentId, reconcileCore) => {
+          signalGuardStarted?.();
+          await guardPending;
+          await reconcileCore();
+          guardCompleted = true;
+        },
+      );
+      const admitted = workerService[method](environmentId);
+      await guardStarted;
 
-    let stopped = false;
-    const stopping = workerService.stop().then(() => {
-      stopped = true;
-    });
-    await workerService.reconcileEnvironment(environmentId);
-    await Promise.resolve();
-    expect(stopped).toBe(false);
-    expect(guardCompleted).toBe(false);
-    expect(inspect).not.toHaveBeenCalled();
+      let stopped = false;
+      const stopping = workerService.stop().then(() => {
+        stopped = true;
+      });
+      await workerService[method](environmentId);
+      await Promise.resolve();
+      expect(stopped).toBe(false);
+      expect(guardCompleted).toBe(false);
+      expect(inspect).not.toHaveBeenCalled();
 
-    releaseGuard?.();
-    await Promise.all([admitted, stopping]);
-    await uninstallGuard();
-    expect(guardCompleted).toBe(true);
-    expect(inspect).not.toHaveBeenCalled();
-  });
+      releaseGuard?.();
+      await Promise.all([admitted, stopping]);
+      await uninstallGuard();
+      expect(guardCompleted).toBe(true);
+      expect(inspect).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects a create queued before service shutdown once its lock is acquired", async () => {
     let finishBootstrap: (() => void) | undefined;

--- a/src/gateway/worker-environments/service.ts
+++ b/src/gateway/worker-environments/service.ts
@@ -424,18 +424,23 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     return async () => await closeReconcileEnvironmentGuard(guard);
   };
 
-  const reconcilePass = async () => {
-    const tasks = store
-      .listForReconcile()
-      .map(
-        (candidate) => () =>
-          reconcileEnvironment(candidate.environmentId).catch(() =>
-            warn(
-              `Worker environment reconcile failed (${candidate.environmentId}, ${candidate.providerId})`,
-            ),
+  const reconcilePass = async (environmentId?: string) => {
+    const candidates =
+      environmentId === undefined
+        ? store.listForReconcile()
+        : [store.get(environmentId)].filter((candidate) => candidate !== undefined);
+    const tasks = candidates.map(
+      (candidate) => () =>
+        reconcileEnvironment(candidate.environmentId).catch(() =>
+          warn(
+            `Worker environment reconcile failed (${candidate.environmentId}, ${candidate.providerId})`,
           ),
-      );
+        ),
+    );
     await runTasksWithConcurrency({ tasks, limit: 8 });
+    if (environmentId !== undefined) {
+      return;
+    }
     try {
       store.pruneTerminalEnvironments();
     } catch (error) {
@@ -447,9 +452,14 @@ export function createWorkerEnvironmentService(options: WorkerEnvironmentService
     }
   };
 
-  const reconcileOnce = () => {
+  const reconcileOnce = (environmentId?: string) => {
     if (stopping) {
       return Promise.resolve();
+    }
+    if (environmentId !== undefined) {
+      // Preserve per-environment failure reporting without joining unrelated sweep work.
+      // Shutdown still owns this pass; the installed guard coalesces its exact environment.
+      return trackOperation(reconcilePass(environmentId));
     }
     if (options.maintainProviders && !maintenanceInFlight) {
       // Keep cleanup off the placement/reconcile wait path, but retain the actual promise

--- a/src/gateway/worker-environments/worker-turn-launcher-reconcile-error.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-reconcile-error.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE,
+  WORKER_RPC_SET_VERSION,
+} from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { NODE_WORKER_ENVIRONMENT_STOP_COMMAND } from "../../infra/node-commands.js";
+import { openOpenClawStateDatabase } from "../../state/openclaw-state-db.js";
+import { installWorkerPlacementReconcileGuard } from "../server-worker-placement-reconcile-guard.js";
+import { StaleWorkerBuildError } from "./admission.js";
+import { hashWorkerCredential } from "./credential.js";
+import { createNodeWorkerTunnelManager } from "./node-worker-tunnel.js";
+import { transport, workspaceTransfer } from "./node-worker-tunnel.test-support.js";
+import { coordinateWorkerPlacementDispatch } from "./placement-dispatch-coordinator.js";
+import { createWorkerPlacementDispatchService } from "./placement-dispatch.js";
+import { createWorkerSessionPlacementGate } from "./placement-worker-gate.js";
+import { createWorkerEnvironmentService } from "./service.js";
+import { BUNDLE_ARTIFACT, createProvider } from "./service.test-support.js";
+import { createWorkerEnvironmentStore } from "./store.js";
+import {
+  ENVIRONMENT_ID,
+  MANIFEST_REF,
+  SESSION_ID,
+  SESSION_KEY,
+  cleanupWorkerTurnLauncherTest,
+  createWorkerSessionTurnPlacementProvider,
+  placements,
+  root,
+  setupWorkerTurnLauncherTest,
+  turn,
+} from "./worker-turn-launcher.test-support.js";
+import { createWorkerWorkspaceOperationCoordinator } from "./workspace-operation-coordinator.js";
+
+describe("worker turn recovery after environment reconciliation errors", () => {
+  beforeEach(setupWorkerTurnLauncherTest);
+  afterEach(cleanupWorkerTurnLauncherTest);
+
+  it("settles a stale-build turn when a lost shared node rejects its stop acknowledgement", async () => {
+    const store = createWorkerEnvironmentStore({ database: openOpenClawStateDatabase() });
+    let installation = {
+      ...BUNDLE_ARTIFACT,
+      protocolFeatures: [WORKER_EXECUTION_CONTEXT_PROTOCOL_FEATURE],
+    };
+    const nodeTransport = transport();
+    let rejectStop = true;
+    const stopRequests = vi.spyOn(nodeTransport, "invoke").mockImplementation(async (request) => {
+      expect(request.command).toBe(NODE_WORKER_ENVIRONMENT_STOP_COMMAND);
+      return rejectStop
+        ? { ok: false, error: { code: "UNAVAILABLE" } }
+        : { ok: true, payloadJSON: "null" };
+    });
+    const transfer = workspaceTransfer();
+    transfer.closeAll = vi.fn(async () => {});
+    const nodeTunnelManager = createNodeWorkerTunnelManager({
+      gatewayDeviceId: "gateway-recovery-fixture",
+      getEnvironment: store.get,
+      listEnvironments: store.list,
+      getTransport: () => nodeTransport,
+      launchNodeWorker: vi.fn(),
+      validateWorkerTurn: (claim) => placements.validateTurnClaim(claim),
+      workspaceTransfer: transfer,
+    });
+    const inspect = vi.fn(async () => ({ status: "destroyed" as const }));
+    const provider = createProvider({ supportedExecutionModes: ["worker-turn"], inspect });
+    const warn = vi.fn();
+    const environments = createWorkerEnvironmentService({
+      store,
+      getConfig: () => ({}),
+      resolveProvider: () => provider,
+      prepareInstallation: async () => installation,
+      bootstrapWorker: vi.fn(),
+      executeInference: vi.fn(),
+      placementStore: createWorkerSessionPlacementGate(placements),
+      nodeTunnelManager,
+      logger: { warn },
+    });
+    const workspaceOperations = createWorkerWorkspaceOperationCoordinator();
+    const dispatch = coordinateWorkerPlacementDispatch(
+      createWorkerPlacementDispatchService({
+        placements,
+        environments,
+        runnerAvailability: { read: () => undefined, version: () => 0 },
+        workspaceOperations,
+        runLocalBarrier: async ({ startDispatch }) => startDispatch(),
+        runRecoveryBarrier: async ({ run }) => await run(root),
+        runActivationBarrier: async ({ activate }) => activate(),
+        runMoveBarrier: async ({ begin }) => begin(),
+        resolveMoveDestination: async () => undefined,
+        runReclaimPreparation: async ({ run, authorize }) => await run(authorize),
+        runReclaimBarrier: async ({ begin, reclaim }) => await reclaim(root, begin()),
+        runFailedReclaimBarrier: async ({ reclaim }) => await reclaim(),
+        resolveWorkspacePath: async () => root,
+        reportWorkspaceResultConflict: async () => {},
+        resolveWorkspaceResultConflict: async () => undefined,
+      }),
+    );
+    const uninstall = installWorkerPlacementReconcileGuard({
+      placements,
+      environments,
+      dispatch,
+      isStopping: () => false,
+    });
+    try {
+      store.createIntent({
+        environmentId: ENVIRONMENT_ID,
+        providerId: provider.id,
+        profileId: "development",
+        profileSnapshot: { executionMode: "worker-turn", settings: { device: "node-1" } },
+        provisionOperationId: "shared-node-recovery",
+      });
+      store.transition({ environmentId: ENVIRONMENT_ID, from: "requested", to: "provisioning" });
+      const ready = store.transition({
+        environmentId: ENVIRONMENT_ID,
+        from: "provisioning",
+        to: "ready",
+        patch: {
+          leaseId: "shared-node-lease",
+          nodeDeviceId: "node-1",
+          sharedHost: true,
+          credential: {
+            credentialHash: hashWorkerCredential("ready-worker-recovery-fixture"),
+            sessionId: null,
+            rpcSetVersion: WORKER_RPC_SET_VERSION,
+            expiresAtMs: Date.now() + 60_000,
+          },
+          bootstrapReceipt: {
+            bundleHash: installation.bundleHash,
+            openclawVersion: installation.openclawVersion,
+            protocolFeatures: installation.protocolFeatures,
+            installKind: "bundle",
+          },
+        },
+      });
+      const attached = await environments.attachSession({
+        environmentId: ENVIRONMENT_ID,
+        ownerEpoch: ready.ownerEpoch,
+        sessionId: SESSION_ID,
+      });
+      let placement = placements.startDispatch({
+        sessionId: SESSION_ID,
+        sessionKey: SESSION_KEY,
+        agentId: "main",
+        executionMode: "worker-turn",
+      });
+      placement = placements.transition({
+        sessionId: SESSION_ID,
+        from: "requested",
+        to: "provisioning",
+        expectedGeneration: placement.generation,
+        patch: { environmentId: ENVIRONMENT_ID },
+      });
+      placement = placements.transition({
+        sessionId: SESSION_ID,
+        from: "provisioning",
+        to: "syncing",
+        expectedGeneration: placement.generation,
+        patch: { workerBundleHash: installation.bundleHash },
+      });
+      placement = placements.transition({
+        sessionId: SESSION_ID,
+        from: "syncing",
+        to: "starting",
+        expectedGeneration: placement.generation,
+        patch: { remoteWorkspaceDir: "/worker/workspace", workspaceBaseManifestRef: MANIFEST_REF },
+      });
+      placements.transition({
+        sessionId: SESSION_ID,
+        from: "starting",
+        to: "active",
+        expectedGeneration: placement.generation,
+        patch: { activeOwnerEpoch: attached.ownerEpoch },
+      });
+      installation = { ...installation, bundleHash: "d".repeat(64) };
+      const startTunnel = vi.spyOn(environments, "startTunnel");
+      const launcher = createWorkerSessionTurnPlacementProvider({
+        placements,
+        environments,
+        workspaceOperations,
+        reconcileActivePlacement: dispatch.reconcileActive,
+      });
+      const runId = "stale-build-shared-node-stop-failed";
+      const failure = await launcher
+        .executeTurn(
+          { sessionId: SESSION_ID, sessionKey: SESSION_KEY, agentId: "main", runId },
+          turn(runId),
+          vi.fn(),
+        )
+        .catch((error: unknown) => error);
+
+      expect(startTunnel).toHaveBeenCalledOnce();
+      await expect(startTunnel.mock.results[0]?.value).rejects.toBeInstanceOf(
+        StaleWorkerBuildError,
+      );
+      expect(inspect).toHaveBeenCalledOnce();
+      expect(stopRequests).toHaveBeenCalled();
+      expect(store.getCredential(ENVIRONMENT_ID)).toBeUndefined();
+      expect(placements.listPendingWorkspaceResults()).toEqual([]);
+      expect(placements.get(SESSION_ID)).toMatchObject({ state: "failed", turnClaim: null });
+      expect(failure).toBeInstanceOf(Error);
+      expect(warn).toHaveBeenCalledWith(
+        `Worker environment reconcile failed (${ENVIRONMENT_ID}, ${provider.id})`,
+      );
+    } finally {
+      rejectStop = false;
+      await uninstall();
+      await environments.stop();
+    }
+  });
+});


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Recovery after a worker turn failure could wait for an unrelated provider inspection or interrupted move's workspace cleanup. A request to recover one environment started a full provider sweep and recovered every pending move before filtering placements.

## Why This Change Was Made

The existing environment sweep now accepts a target and reads only that environment. It keeps the same guarded inspection, failure reporting and placement-settlement order, while the service tracks the targeted pass through shutdown. Moves are selected by either their recorded source or current placement, preserving recovery after source cleanup and destination activation. The initial no-op move callback and its later reassignment are removed.

Global placement fences, strict direct/startup reconciliation, full background sweeps, provider maintenance/pruning and cleanup ownership remain unchanged. Provider stop failures still allow canonical placement settlement to run; a failed destination that needs teardown retains its move intent. No launcher catch or claim-release policy was added.

## User Impact

A one-worker recovery pass no longer starts unrelated provider inspection or move cleanup. It still waits behind earlier placement operations. Healthy turns on already-active workers are unchanged. There is no prepared-capacity, persistence, configuration or protocol change.

## Evidence

- The unchanged four-case regression produced two ordering failures and two passing controls on the original baseline, then four passes after the repair. It covers provider/move isolation, full-sweep maintenance and cleanup, and source/current-destination move selection.
- A follow-up regression composed the actual launcher, environment service, reconciliation guard, SQLite stores and node tunnel manager. A stale build plus a failed shared-node stop acknowledgement exposed a stranded claim in the initial candidate. The unchanged regression passes after preserving the existing sweep error boundary; the original stale-build caller test passes too.
- The final candidate passed 187 tests in eleven focused recovery, launcher, service-lifetime, coordinator, guard and provisioning-replay suites, plus the separate stop-error regression. Targeted/full same-environment coalescing and targeted shutdown ownership are covered.
- All required changed-scope stages passed. An unbound test callback lint diagnostic was corrected, then affected/remaining checks passed without repeating earlier successful stages. Fresh full-scope managed Codex review was scoped-clean at P0. Normal commit hooks passed; committed bytes match the validated source.
- Production delta: +37/-19, net +18 across five owners. The additional source carries the target through existing service/move owners, preserves the service error and shutdown contracts, and checks both move identities without adding state or a new coordination mechanism.

The final candidate also passed an actual compiled Gateway, paired-node and worker flow on Node 24.19.0. After an unrelated move failed and fully settled, the target worker uploaded its terminal result and returned its public reconciliation error in **306.25 ms**, with **zero unrelated recovery invocations**. Pending result/claim ownership remained intact; the normal periodic sweep subsequently settled both sessions. The experiment used task-owned filesystem faults and a loopback mock model. It measures failure recovery, not cloud startup or p95. All test processes were joined and the sole Testbox was stopped and confirmed completed.

Exact-head CI [33435165154](https://github.com/openclaw/openclaw/actions/runs/33435165154) passed: 167 successful jobs and 17 skipped, including the required gate and all five core-test type stripes. Windows was skipped. The initial draft run skipped CI; the ready run above provides the landing evidence.

The latest ClawSweeper review reported no actionable findings. Its compactness/history questions are covered by the baseline and current-main source comparison and the production delta above. Its storage-path heuristic does not correspond to a schema or record-format change. Current main's result handoff before owner revocation composes with this change and does not remove the need to preserve the observed sweep error boundary.
