### PR TITLE
fix(ci): preserve oxlint shard success after graceful drain

### DIFF
--- a/scripts/run-oxlint-shards.mts
+++ b/scripts/run-oxlint-shards.mts
@@ -602,7 +602,8 @@ export async function runShard({ env, extraArgs, runner, shard }: ShardRunnerOpt
       if (graceRemainingMs > 0) {
         await waitForChildProcessGroupExit(child, graceRemainingMs);
       }
-      if (isChildProcessGroupAlive(child)) {
+      const requiresForceKill = isChildProcessGroupAlive(child);
+      if (requiresForceKill) {
         signalChildProcess(child, "SIGKILL");
       }
       await waitForChildProcessGroupExit(child, POST_FORCE_KILL_WAIT_MS);
@@ -615,7 +616,7 @@ export async function runShard({ env, extraArgs, runner, shard }: ShardRunnerOpt
           }),
         );
       } else {
-        finish(status);
+        finish(requiresForceKill ? status || 1 : status);
       }
     };
     child.once("error", (error) => {
@@ -629,7 +630,7 @@ export async function runShard({ env, extraArgs, runner, shard }: ShardRunnerOpt
           ? 124
           : (status ?? 1);
       if (isChildProcessGroupAlive(child)) {
-        void finishAfterForcedTeardown(exitStatus || 1);
+        void finishAfterForcedTeardown(exitStatus);
         return;
       }
       finish(exitStatus);

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -24,7 +24,7 @@ import {
   filterSparseMissingOxlintTargets,
   shouldPrepareExtensionPackageBoundaryArtifacts,
 } from "../../scripts/run-oxlint.mts";
-import { waitForDead, waitForPidFile } from "../helpers/process-wait.js";
+import { waitForDead, waitForFile, waitForPidFile } from "../helpers/process-wait.js";
 import { startProcessWatchdogFixture } from "../helpers/process-watchdog.js";
 import { createScriptTestHarness } from "./test-helpers.js";
 
@@ -35,6 +35,7 @@ const RUN_OXLINT_SHARDS_URL = pathToFileURL(
   join(process.cwd(), "scripts/run-oxlint-shards.mts"),
 ).href;
 type SignalScenario = "forward" | "group" | "ignore";
+type SuccessfulLeaderDescendantMode = "drain" | "persist";
 
 async function captureFailedTrailer(
   run: () => Promise<void> | void,
@@ -90,6 +91,78 @@ function createSignalRunner(mode: SignalScenario, target: string): void {
     "writeFileSync(process.env.READY_FILE, String(process.pid));",
     "setInterval(() => {}, 1000);",
   ]);
+}
+
+function createSuccessfulLeaderRunner(mode: SuccessfulLeaderDescendantMode, target: string): void {
+  const childScript = [
+    "const { existsSync, renameSync, writeFileSync } = require('node:fs');",
+    "const publish = (target, value) => { writeFileSync(target + '.tmp', value); renameSync(target + '.tmp', target); };",
+    "publish(process.env.CHILD_PID_PATH, String(process.pid));",
+    ...(mode === "drain"
+      ? [
+          "process.on('disconnect', () => publish(process.env.DRAINING_FILE, 'ready'));",
+          "setInterval(() => { if (existsSync(process.env.RELEASE_FILE)) process.exit(0); }, 5);",
+        ]
+      : ["process.on('disconnect', () => {});", "setInterval(() => {}, 1000);"]),
+    "publish(process.env.READY_FILE, 'ready');",
+    "process.send?.('ready');",
+  ].join("\n");
+  writeModule(target, [
+    "import { spawn } from 'node:child_process';",
+    `const child = spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { env: process.env, stdio: ['ignore', 'ignore', 'ignore', 'ipc'] });`,
+    "child.once('message', () => process.exit(0));",
+    "child.once('error', () => process.exit(2));",
+  ]);
+}
+
+async function runSuccessfulLeaderDescendantScenario(
+  mode: SuccessfulLeaderDescendantMode,
+): Promise<number> {
+  const tempDir = createTempDir(`openclaw-oxlint-success-${mode}-`);
+  const runner = join(tempDir, "success-runner.mjs");
+  const childPidPath = join(tempDir, "child.pid");
+  const readyFile = join(tempDir, "ready");
+  const drainingFile = join(tempDir, "draining");
+  const releaseFile = join(tempDir, "release");
+  let childPid = 0;
+  createSuccessfulLeaderRunner(mode, runner);
+
+  const completion = runShard({
+    env: {
+      ...process.env,
+      CHILD_PID_PATH: childPidPath,
+      DRAINING_FILE: drainingFile,
+      READY_FILE: readyFile,
+      RELEASE_FILE: releaseFile,
+      OPENCLAW_OXLINT_SHARD_HEARTBEAT_MS: "0",
+      OPENCLAW_OXLINT_SHARD_KILL_GRACE_MS: "1000",
+      OPENCLAW_OXLINT_SHARD_TIMEOUT_MS: "0",
+    },
+    extraArgs: [],
+    runner,
+    shard: { name: `success-${mode}-test`, args: [] },
+  });
+  try {
+    childPid = await waitForPidFile(childPidPath, 15_000);
+    await waitForFile(readyFile, 15_000);
+    expect(isProcessAlive(childPid)).toBe(true);
+    if (mode === "drain") {
+      await waitForFile(drainingFile, 15_000);
+      writeFileSync(releaseFile, "release", "utf8");
+    }
+    const status = await completion;
+    await waitForDead(childPid, 2_000);
+    return status;
+  } finally {
+    await completion.catch(() => undefined);
+    if (!childPid && existsSync(childPidPath)) {
+      childPid = Number(readFileSync(childPidPath, "utf8"));
+    }
+    if (childPid && isProcessAlive(childPid)) {
+      process.kill(childPid, "SIGKILL");
+      await waitForDead(childPid, 2_000);
+    }
+  }
 }
 
 function runParentTerminationScenario(mode: SignalScenario) {
@@ -484,6 +557,20 @@ describe("run-oxlint", () => {
           }
         }
       }
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "preserves a successful shard status when its process group drains during grace",
+    async () => {
+      await expect(runSuccessfulLeaderDescendantScenario("drain")).resolves.toBe(0);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "fails a successful shard when its process group requires SIGKILL",
+    async () => {
+      await expect(runSuccessfulLeaderDescendantScenario("persist")).resolves.toBe(1);
     },
   );
 


### PR DESCRIPTION
## What Problem This Solves

Resolves an intermittent CI failure where a successful oxlint shard could make the release-lint job fail with exit code 1 after every shard had finished and no lint diagnostic was emitted. This occurred when the shard leader exited successfully while a same-process-group descendant was still draining inside the configured cleanup grace period.

Observed failure: https://github.com/openclaw/openclaw/actions/runs/33427356955/job/99604560724

## Why This Change Was Made

The shard runner now carries the leader exit status unchanged through the grace period. A naturally drained group preserves success; a descendant that survives the grace period and requires SIGKILL still converts a successful leader status into failure. Timeout, parent-termination, and process-group cleanup-failure behavior remain unchanged.

Owner boundary: `scripts/run-oxlint-shards.mts` owns shard lifecycle and exit projection. No lint rules, extension code, workflow fanout, or runner-capacity settings change.

Production/tooling LOC: +4/-3. Tests: +88/-1. No obsolete path or compatibility fallback was added.

## User Impact

Maintainers no longer get a false-red oxlint job while short-lived descendants finish normally. Real leaked descendants still fail the shard after forced cleanup.

## Evidence

- Regression-first proof: the natural-drain case failed before the production fix with `expected 0, received 1`.
- Focused owner suite: 64/64 tests passed.
- Targeted lead rerun: both new successful-leader process-group cases passed.
- Changed-scope gate: passed on Blacksmith Testbox `tbx_01m1cptqws05w8r47djk6svpmc`.
- Targeted formatting/lint, `git diff --check`, and changed-check dry run: passed.
- Fresh Codex autoreview: scoped-clean, confidence 0.98.

The regression table covers both sides of the invariant: natural drain preserves status 0, while a persistent descendant requiring SIGKILL returns status 1 and is confirmed dead.
