### PR TITLE
fix(markdown): preserve trailing inline-code whitespace

### DIFF
--- a/packages/markdown-core/src/ir.test.ts
+++ b/packages/markdown-core/src/ir.test.ts
@@ -218,3 +218,60 @@ describe("sliceMarkdownIR surrogate pair boundaries", () => {
     expect(sliced.text).toBe("");
   });
 });
+
+describe("Markdown final code content", () => {
+  it.each([
+    {
+      name: "terminal inline code",
+      markdown: "Copy `name `",
+      expected: {
+        text: "Copy name ",
+        styles: [{ start: 5, end: 10, style: "code" }],
+        links: [],
+      },
+    },
+    {
+      name: "terminal inline code in a link label",
+      markdown: "[`name `](https://example.com)",
+      expected: {
+        text: "name ",
+        styles: [{ start: 0, end: 5, style: "code" }],
+        links: [{ start: 0, end: 5, href: "https://example.com" }],
+      },
+    },
+    {
+      name: "standalone one-space inline code",
+      markdown: "` `",
+      expected: {
+        text: " ",
+        styles: [{ start: 0, end: 1, style: "code" }],
+        links: [],
+      },
+    },
+    {
+      name: "inline code followed by prose",
+      markdown: "Copy `name ` next",
+      expected: {
+        text: "Copy name  next",
+        styles: [{ start: 5, end: 10, style: "code" }],
+        links: [],
+      },
+    },
+    {
+      name: "ordinary trailing prose whitespace",
+      markdown: "Copy name   ",
+      expected: { text: "Copy name", styles: [], links: [] },
+    },
+    {
+      name: "fenced code trailing whitespace",
+      markdown: "```\nname \n```",
+      expected: {
+        text: "name \n",
+        styles: [{ start: 0, end: 6, style: "code_block" }],
+        links: [],
+      },
+    },
+  ])("preserves final code payload: $name", ({ markdown, expected }) => {
+    expect(markdownToIR(markdown)).toEqual(expected);
+  });
+});

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -1670,18 +1670,17 @@ export function markdownToIRWithMeta(
   renderTokens(tokens as MarkdownToken[], state);
   closeRemainingStyles(state);
 
+  // Preserve trailing whitespace inside code; trim generated trailing separators.
   const trimmedText = state.text.trimEnd();
   const trimmedLength = trimmedText.length;
-  let codeBlockEnd = 0;
+  let codeEnd = 0;
   for (const span of state.styles) {
-    if (span.style !== "code_block") {
+    if (span.style !== "code" && span.style !== "code_block") {
       continue;
     }
-    if (span.end > codeBlockEnd) {
-      codeBlockEnd = span.end;
-    }
+    codeEnd = Math.max(codeEnd, span.end);
   }
-  const finalLength = Math.max(trimmedLength, codeBlockEnd);
+  const finalLength = Math.max(trimmedLength, codeEnd);
   const finalText =
     finalLength === state.text.length ? state.text : state.text.slice(0, finalLength);
   const annotations = mergeAnnotationSpans(clampAnnotationSpans(state.annotations, finalLength));

--- a/packages/markdown-core/src/render.crossing.test.ts
+++ b/packages/markdown-core/src/render.crossing.test.ts
@@ -44,3 +44,36 @@ describe("renderMarkdownWithMarkers crossing spans", () => {
     ).toBe(html);
   });
 });
+
+describe("renderMarkdownWithMarkers code content", () => {
+  it.each([
+    {
+      name: "terminal inline code",
+      markdown: "Copy `name `",
+      html: "Copy <code>name </code>",
+    },
+    {
+      name: "terminal inline code in a link label",
+      markdown: "[`name `](https://example.com)",
+      html: '<a href="https://example.com"><code>name </code></a>',
+    },
+    {
+      name: "inline code followed by prose",
+      markdown: "Copy `name ` next",
+      html: "Copy <code>name </code> next",
+    },
+  ])("renders authored code whitespace: $name", ({ markdown, html }) => {
+    expect(
+      renderMarkdownWithMarkers(markdownToIR(markdown), {
+        styleMarkers: { code: { open: "<code>", close: "</code>" } },
+        escapeText: (text) => text,
+        buildLink: (link) => ({
+          start: link.start,
+          end: link.end,
+          open: `<a href="${link.href}">`,
+          close: "</a>",
+        }),
+      }),
+    ).toBe(html);
+  });
+});


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Resolves a problem where Markdown ending in inline code lost a literal trailing space. For example, the code content `name ` became `name`, including when used as a link label; an inline-code span containing just one space disappeared entirely.

## Why This Change Was Made

The Markdown IR finalizer protected trailing content inside code blocks but omitted inline-code spans. It now uses the existing code-span boundaries for both forms, preserving parser-normalized code content and its style/link endpoints while still trimming generated trailing separators. No parser, renderer fallback, or new option is added.

## User Impact

Consumers of the shared Markdown IR receive the complete terminal inline-code content. Ordinary trailing prose trimming remains unchanged. This does not alter channel-specific trim policies, table-cell cleanup, or downstream chunk whitespace policy.

## Evidence

- The same six focused IR cases changed from **3 failures / 3 controls passing** to **all 6 passing**, covering terminal code, linked code, one-space code, followed-by-prose, plain prose trimming, and fenced code.
- **85 tests passed** across the full IR owner and four sibling suites, including links, block metadata, nested lists, and blockquote spacing. This includes the six focused cases above.
- A separate original-source renderer run produced **2 failures / 1 control passing**; after the repair, **all 7 renderer tests passed**, including four existing crossing-span controls. The actual marker renderer now retains the space in `Copy <code>name </code>` and `<a href="https://example.com"><code>name </code></a>`.
- Normal formatting completed. Full P0–P2 managed source review found no actionable findings. The canonical changed-path gate completed all **28 checks**, including core and core-test type checks, changed-file lint, formatting, and dead-export scans. This is local proof on the recorded base, not CI or current-main validation.

Production: **+5 / -6 (net -1)**. Tests: **+90 / -0**.

The renderer evidence exercises the shared IR-to-marker path with fixed ASCII inputs, not a live channel or general HTML escaping. Named follow-up: inspect post-IR chunk whitespace handling independently; Signal's explicit final trim, table-cell cleanup, and hidden list-content endpoints remain outside this repair.

Related: #82421 closed without merging and changes final chunk slicing/shared trimming. This repair preserves inline-code content earlier, during `markdownToIR` finalization; downstream chunk whitespace policy remains a separate follow-up.

Fixes #134450
