### PR TITLE
perf: skip discarded Readability HTML in text mode

### DIFF
--- a/extensions/web-readability/web-content-extractor.ts
+++ b/extensions/web-readability/web-content-extractor.ts
@@ -122,16 +122,17 @@ async function extractWithReadability(request: WebContentExtractionRequest) {
   try {
     const [{ Readability }, { parseHTML }] = await loadReadabilityDeps();
     const { document } = parseHTML(cleanHtml, { location: { href: request.url } });
-    const reader = new Readability(document);
+    const textMode = request.extractMode === "text";
+    // Text mode consumes textContent; skip serializing the HTML it would discard.
+    const reader = new Readability(document, textMode ? { serializer: () => "" } : undefined);
     const parsed = reader.parse();
-    if (!parsed?.content) {
+    if (!parsed) {
       return null;
     }
     const title = parsed.title || undefined;
-    const rendered =
-      request.extractMode === "text"
-        ? { text: normalizeWhitespace(parsed.textContent ?? ""), title }
-        : htmlToMarkdown(parsed.content);
+    const rendered = textMode
+      ? { text: normalizeWhitespace(parsed.textContent ?? ""), title }
+      : htmlToMarkdown(parsed.content ?? "");
     const text = stripInvisibleUnicode(rendered.text);
     return text ? { text, title: title ?? rendered.title } : null;
   } catch {


### PR DESCRIPTION
## What Problem This Solves

Readability builds a final HTML string even when web fetch requests plain text and discards that HTML. Text extraction pays for a serialization it does not use.

## Why This Change Was Made

Use Readability's existing serializer option only in text mode. Its actual parser computes text and metadata before invoking the final serializer. Markdown still passes undefined options and uses the default serializer. Size/depth guards, sanitizer, lazy imports, title handling, normalization, fallback ordering and public output stay unchanged.

The owning plugin keeps one extraction path with no cache, new dependency, setting, SDK surface or persistence change. Production is **+7/−6, net +1 line**, including an explanatory ownership comment; tests are unchanged. The extra mode fact selects the supported dependency behavior and replaces the later repeated comparison. An earlier internal Readability serialization remains untouched, so this does not remove all HTML serialization.

## User Impact

Less local parsing work for text-mode web fetch. Default Markdown behavior is retained. This is an internal performance refactor, not a new operator-facing feature or configuration change.

## Evidence

The complete extractor was measured with the actual installed Readability 0.6.0, Linkedom 0.18.13 and SDK helpers. No parser, sanitizer, renderer or loader replacement. Correctness covers 88 paired HTML/mode cases, ten request/order/error controls, two actual-dependency serializer controls and all 20 workload oracles. Independent source review checked the full parser and relevant DOM serialization implementation, canonical primitive request producer, callers, siblings, history and emitted dependency graph.

A fixed 16-process replication used eight before and eight candidate processes in counterbalanced order. All 3,520 measured samples, 1,280 warmups, 320 medians and 4,816 journal entries are retained and independently recomputed. Aggregates below are medians of eight process medians per variant, not pooled samples.

| Complete extraction | Before → candidate | Change | Slower adjacent pairs |
| --- | --- | --- | --- |
| Ordinary text | 214.960 → 205.344 µs | −4.47% | 0/8 |
| Medium text | 815.604 → 765.104 µs | −6.19% | 0/8 |
| Large text | 3183.104 → 3015.083 µs | −5.28% | 0/8 |
| Small text | 530.579 → 533.444 µs | +0.54% | 4/8 |
| Unicode Markdown | 361.976 → 364.049 µs | +0.57% | 4/8 |

The predeclared gate required at least 3% aggregate improvement for medium/large text and rejected any accepted Markdown row with more than 3% cost plus at least six of eight slower pairs. It passed without changing source, workload, sampling or decision rules. No rows were dropped or retried. All other controls and costs remain in the complete 20-row report.

The earlier four-process batch is retained separately: it showed a 5.57% pooled small-Markdown cost and a 3.43% links-Markdown cost. Replication did not consistently repeat those costs; it does not erase them or establish a noise cause. The replicated first lazy extraction costs 36.074 → 37.084 ms; imports follow dependency hashing and are not a cold-filesystem measurement. No default-Markdown, whole-Gateway, startup, retained-memory or statistical-significance claim.

Source capture remains 09595614 and measured execution remains 2fb3364. A separate current-main e42e600 audit matched all 29 other root pins, 33 immutable copies, 1,159 installed files and 33 resolution identities; the thirtieth root pin, package.json, only adds unrelated pricing SDK export/package metadata. The integrated source differs from measured R2 only by the repository formatter and a comment; comment-free single-file compilation is byte-identical.

The baseline and candidate each pass 24 canonical tests across the extractor, dispatch/lifecycle, plugin registry and web-fetch neighborhood. The first changed-code check stopped on formatting; the repository formatter corrected that presentation-only issue. Fresh managed Codex review is scoped-clean at P0, supplemented by the independent all-priority source and raw-evidence reviews. The full changed-code check rerun passed in 183.420 seconds. Commit 9eaec78b47de397e5bab18a265553a7ffc9f8f82 is the reviewed candidate. Its full build passed in 169.885 seconds, and a fresh committed Codex review is scoped-clean at P0 (0.99). Hosted CI run 33435590742, attempt 1, passed on that exact head without a retry.


The exact-head built Gateway completed four real OpenAI turns on the first run: readiness, batched Tool Search, search plus a literal file read, and search plus two sequential web fetches. The task-owned SQLite transcript independently confirms the default Markdown request omitted extractMode and the second requested text. Both fetched the public Node performance documentation with HTTP 200 through Readability, producing distinct 97,622-character Markdown and 66,195-character text bodies, each visibly capped at 2,000 characters with the full content retained in private task artifacts. Three event RPCs, two status projections and twelve session RPCs also passed. Direct checks found the Gateway PID/group and socket gone; temporary config and key FIFO were removed. Default-named CPU profiles distinguish the main thread (19,577 samples) from a separate worker profile. These are integration/diagnostic observations, not comparative Gateway latency or all-thread profiling claims. No user/operator configuration or saved session was changed.


ClawSweeper follow-through: the complete 20:30 review reported no code/security finding, but its environment could not inspect the pinned dependency and still saw a pending extension check. The lead and independent reviewer directly read installed Readability 0.6.0; a fresh upstream fetch is byte-identical (SHA-256 34dcab3d0832d0019f02990eed6b6124e029e8c32b9f0c6f2550544ff8dff174). The [constructor's serializer option](https://github.com/mozilla/readability/blob/0.6.0/Readability.js#L59) defaults to innerHTML, and [parse captures text before final serialization](https://github.com/mozilla/readability/blob/0.6.0/Readability.js#L2766). Actual dependency controls and the real two-mode Gateway run also pass. Its only Rank-up move—finish exact-head changed-extension CI—is satisfied by successful run 33435590742. A later automated review refresh is queued; no unresolved source or proof finding is being skipped.
