### PR TITLE
fix(ui): retire interrupted runs from history

### DIFF
--- a/ui/src/pages/chat/chat-history-stream.ts
+++ b/ui/src/pages/chat/chat-history-stream.ts
@@ -154,6 +154,7 @@ export function applyHistoryRun(params: {
       terminalRunId &&
       (sessionInfo.status === "done" ||
         sessionInfo.status === "failed" ||
+        sessionInfo.status === "killed" ||
         sessionInfo.status === "timeout") &&
       sessionInfo.hasActiveRun !== true &&
       !isSessionRunActive(sessionInfo) &&
@@ -162,7 +163,7 @@ export function applyHistoryRun(params: {
         (item) =>
           item.sendState === "sending" && item.sendRunId && item.sendRunId !== terminalRunId,
       ) &&
-      (!knownRun ||
+      ((sessionInfo.status !== "killed" && !knownRun) ||
         state.chatRunId === terminalRunId ||
         getChatRunOwner(state) === terminalRunId) &&
       runProjectionsUnchanged(previousRunProjections, runProjectionsBeforeApply)

--- a/ui/src/pages/chat/chat-history.inflight.test.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test.ts
@@ -86,6 +86,43 @@ function failedHistory(): ChatHistoryResult {
 }
 
 describe("chat history in-flight assistant recovery", () => {
+  it("retires an interrupted run from authoritative history after missing its live terminal", async () => {
+    const active = activeHistory("run-interrupted");
+    const interrupted: ChatHistoryResult = {
+      messages: [],
+      sessionInfo: {
+        ...active.sessionInfo!,
+        hasActiveRun: false,
+        activeRunIds: [],
+        lastRunId: "run-interrupted",
+        status: "killed",
+      },
+      pendingInputs: {
+        items: [
+          {
+            id: "input-interrupted-before-turn",
+            runId: "queued-input",
+            acceptedAt: 1,
+            state: "interrupted",
+            message: { role: "user", content: "Open a PR to fix it" },
+          },
+        ],
+        total: 1,
+      },
+    };
+    const request = vi.fn().mockResolvedValueOnce(active).mockResolvedValueOnce(interrupted);
+    const state = createState(active);
+    state.client = { request } as unknown as GatewayBrowserClient;
+
+    await loadChatHistory(state);
+    expect(state.chatRunId).toBe("run-interrupted");
+
+    await loadChatHistory(state);
+
+    expect(state.chatRunId).toBeNull();
+    expect(state.chatStream).toBeNull();
+  });
+
   it.each(["chat.startup", "chat.history"] as const)(
     "recovers a failure missed before route subscription through %s",
     async (method) => {


### PR DESCRIPTION
## Summary

- treat the Gateway's canonical `killed` session status as terminal when authoritative history confirms it belongs to the pane's currently owned run
- clear the stale local run/stream through the existing run-lifecycle reconciler, so the composer stops showing a spinner/timer and no longer offers Stop for dead work
- retain the existing safeguard that an unowned historical cancellation must not create a new failure projection

## Root cause

The Gateway session contract includes `killed` as a terminal status (`packages/gateway-protocol/src/schema/sessions-row.ts:19`) and maps cancellation to it (`src/gateway/session-lifecycle-state.ts:90`). The Control UI's missed-terminal history fallback in `ui/src/pages/chat/chat-history-stream.ts` recognized `done`, `failed`, and `timeout`, but omitted `killed`.

If the live terminal event was missed or raced with the accepted-input custody refresh, history could therefore render an input as “Interrupted before its turn” while preserving the old `chatRunId`. That stale owner drove the working spinner, elapsed timer, and Stop affordance even though the run had already ended.

The fix adds `killed` to the canonical terminal path only when the exact run is already owned by the pane. It reuses `reconcileChatRunFromSessionRow`; no parallel cleanup path is added.

Codex contract checked directly: `../codex/codex-rs/app-server/README.md:1155-1167` says interruption completes with `turn/completed` / `status: interrupted`, and `../codex/codex-rs/app-server/src/bespoke_event_handling.rs:1518-1540` emits that terminal status. OpenClaw's provider runtime already consumes that contract; the leak was the Control UI's persisted-history fallback.

## Regression proof

The new test reproduces the reported order:

1. history adopts an active run;
2. its live terminal is absent;
3. the next authoritative history response carries `status: killed` and an accepted input with `state: interrupted`;
4. before this patch, `chatRunId` remains `run-interrupted` (focused test fails);
5. after this patch, both `chatRunId` and `chatStream` are cleared.

## Validation

- `pnpm test ui/src/pages/chat/chat-history.inflight.test.ts ui/src/pages/chat/chat-history.run-error.test.ts ui/src/pages/chat/chat-pending-inputs.test.ts ui/src/pages/chat/run-lifecycle.test.ts` (160 passed)
- post-rebase: `pnpm test ui/src/pages/chat/chat-history.inflight.test.ts ui/src/pages/chat/chat-history.run-error.test.ts` (88 passed)
- changed-file checks: formatting, UI/core-test typecheck, i18n verification, dead-export scan, dependency/patch guards, targeted lint
- `pnpm ui:build`
- `git diff --check`

## UI proof limitation

The reporter's screenshot is the before-state. A deterministic after screenshot would require deliberately dropping the exact live terminal event while allowing the subsequent history response, which the normal UI/Gateway flow does not expose without a test-only event-transport bypass. The boundary regression exercises that precise ordering without weakening production behavior.

## Scope / LOC

- production: +2 / -1
- tests: +37 / -0
- no protocol, persistence, config, or user-visible copy changes
