### PR TITLE
fix: report settled heartbeat cron outcomes

### DIFF
--- a/src/cron/active-jobs.test.ts
+++ b/src/cron/active-jobs.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   clearCronJobActive,
   hasActiveCronJobs,
-  hasActiveCronJobsExceptMarker,
+  hasActiveCronJobsExceptMarkers,
   markCronJobActive,
   noteActiveCronJobRemoval,
   noteActiveCronJobScheduleMutation,
@@ -16,12 +16,12 @@ afterEach(() => {
   resetCronActiveJobs();
 });
 
-describe("hasActiveCronJobsExceptMarker", () => {
+describe("hasActiveCronJobsExceptMarkers", () => {
   it("discounts only the named job's own marker", () => {
     const marker = markCronJobActive("nightly-report");
 
     expect(hasActiveCronJobs()).toBe(true);
-    expect(hasActiveCronJobsExceptMarker(marker!)).toBe(false);
+    expect(hasActiveCronJobsExceptMarkers([marker!])).toBe(false);
   });
 
   it("still reports busy while an unrelated job is active", () => {
@@ -30,7 +30,14 @@ describe("hasActiveCronJobsExceptMarker", () => {
 
     // The owning job must not be waved through while another run holds a marker:
     // Cron executes jobs up to the built-in concurrency limit.
-    expect(hasActiveCronJobsExceptMarker(marker!)).toBe(true);
+    expect(hasActiveCronJobsExceptMarkers([marker!])).toBe(true);
+  });
+
+  it("discounts every exact coalesced owner", () => {
+    const first = markCronJobActive("first-report");
+    const second = markCronJobActive("second-report");
+
+    expect(hasActiveCronJobsExceptMarkers([first!, second!])).toBe(false);
   });
 
   it("reports idle once the unrelated job clears", () => {
@@ -38,15 +45,15 @@ describe("hasActiveCronJobsExceptMarker", () => {
     const otherMarker = markCronJobActive("different-job");
     clearCronJobActive("different-job", otherMarker);
 
-    expect(hasActiveCronJobsExceptMarker(marker!)).toBe(false);
+    expect(hasActiveCronJobsExceptMarkers([marker!])).toBe(false);
   });
 
   it("does not discount a replacement marker with the same job id", () => {
     const staleMarker = markCronJobActive("nightly-report");
     const replacementMarker = markCronJobActive("nightly-report");
 
-    expect(hasActiveCronJobsExceptMarker(staleMarker!)).toBe(true);
-    expect(hasActiveCronJobsExceptMarker(replacementMarker!)).toBe(false);
+    expect(hasActiveCronJobsExceptMarkers([staleMarker!])).toBe(true);
+    expect(hasActiveCronJobsExceptMarkers([replacementMarker!])).toBe(false);
   });
 });
 

--- a/src/cron/active-jobs.ts
+++ b/src/cron/active-jobs.ts
@@ -1,4 +1,5 @@
 /** Tracks in-process cron executions so schedulers and wake paths avoid duplicate runs. */
+import type { CommandLaneTaskMarker } from "../process/command-queue.js";
 import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import type { CronPayload } from "./types.js";
 
@@ -25,6 +26,9 @@ export type CronActiveJobMarker = {
   preserveAcrossGenerationAdvance?: boolean;
   onInactive?: Set<() => void>;
   inactiveNotified?: true;
+  heartbeatWait?: {
+    owningCronLaneTaskMarker?: CommandLaneTaskMarker;
+  };
 };
 
 function getCronActiveJobState(): CronActiveJobState {
@@ -237,20 +241,53 @@ export function hasActiveCronJobs() {
   return getActiveCronJobCountForGeneration(getCronActiveJobState()) > 0;
 }
 
-/**
- * Ignore only the caller's own marker. Unrelated runs must still block its wake,
- * because cron jobs may execute concurrently.
- */
-export function hasActiveCronJobsExceptMarker(markerToIgnore: CronActiveJobMarker) {
+/** Ignores only the exact cron executions represented by one coalesced heartbeat wake. */
+export function hasActiveCronJobsExceptMarkers(markersToIgnore: readonly CronActiveJobMarker[]) {
   const state = getCronActiveJobState();
+  const ignoredMarkers = new Set(markersToIgnore);
   for (const marker of state.activeJobs.values()) {
-    const isIgnoredMarker =
-      marker.jobId === markerToIgnore.jobId && marker.token === markerToIgnore.token;
-    if (!isIgnoredMarker && isMarkerActiveInGeneration(marker, state.generation)) {
+    if (!ignoredMarkers.has(marker) && isMarkerActiveInGeneration(marker, state.generation)) {
       return true;
     }
   }
   return false;
+}
+
+/** Records that an exact cron execution is idle until its heartbeat wake settles. */
+export function markCronJobWaitingForHeartbeat(
+  marker: CronActiveJobMarker | undefined,
+  owningCronLaneTaskMarker?: CommandLaneTaskMarker,
+): () => void {
+  if (!marker || !isCronActiveJobMarkerCurrent(marker)) {
+    return () => {};
+  }
+  const heartbeatWait = owningCronLaneTaskMarker ? { owningCronLaneTaskMarker } : {};
+  marker.heartbeatWait = heartbeatWait;
+  return () => {
+    if (marker.heartbeatWait === heartbeatWait) {
+      delete marker.heartbeatWait;
+    }
+  };
+}
+
+/** Returns exact live cron and lane owners currently waiting on heartbeat settlement. */
+export function listCronHeartbeatWaitOwners(): {
+  activeJobMarkers: CronActiveJobMarker[];
+  owningCronLaneTaskMarkers: CommandLaneTaskMarker[];
+} {
+  const state = getCronActiveJobState();
+  const activeJobMarkers: CronActiveJobMarker[] = [];
+  const owningCronLaneTaskMarkers: CommandLaneTaskMarker[] = [];
+  for (const marker of state.activeJobs.values()) {
+    if (!marker.heartbeatWait || !isMarkerActiveInGeneration(marker, state.generation)) {
+      continue;
+    }
+    activeJobMarkers.push(marker);
+    if (marker.heartbeatWait.owningCronLaneTaskMarker) {
+      owningCronLaneTaskMarkers.push(marker.heartbeatWait.owningCronLaneTaskMarker);
+    }
+  }
+  return { activeJobMarkers, owningCronLaneTaskMarkers };
 }
 
 /** Returns the number of active cron runs in this process. */

--- a/src/cron/service.heartbeat-payload.test.ts
+++ b/src/cron/service.heartbeat-payload.test.ts
@@ -2,7 +2,10 @@
 // scheduler: firing it must only poke the heartbeat wake queue.
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import type { HeartbeatRunResult } from "../infra/heartbeat-wake.js";
+import { listCronHeartbeatWaitOwners } from "./active-jobs.js";
 import { heartbeatTaskDeclarationKey } from "./heartbeat-task.js";
+import type { CronEvent } from "./service.js";
 import {
   createCronStoreHarness,
   createNoopLogger,
@@ -17,7 +20,7 @@ installCronTestHooks({ logger: noopLogger });
 describe("heartbeat payload execution", () => {
   it("fires as an interval heartbeat wake without enqueuing a system event", async () => {
     const { storePath, cleanup } = await makeStorePath();
-    const { cron, enqueueSystemEvent, requestHeartbeat } =
+    const { cron, enqueueSystemEvent, requestHeartbeat, requestHeartbeatAndWait } =
       createStartedCronServiceWithFinishedBarrier({ storePath, logger: noopLogger });
     try {
       await cron.start();
@@ -68,16 +71,236 @@ describe("heartbeat payload execution", () => {
       ).rejects.toThrow(/system-owned/);
       const result = await cron.run(job.id, "force");
       expect(result.ok).toBe(true);
-      expect(requestHeartbeat).toHaveBeenCalledWith(
+      expect(requestHeartbeatAndWait).toHaveBeenCalledWith(
         expect.objectContaining({
           source: "interval",
           intent: "scheduled",
           agentId: "main",
           scheduledEveryMs: 60_000,
         }),
+        expect.objectContaining({
+          abortSignal: expect.any(AbortSignal),
+        }),
       );
-      // The monitor never fabricates a system event; the wake is the whole run.
+      expect(requestHeartbeat).not.toHaveBeenCalled();
+      // The monitor never fabricates a system event; its settled wake is the whole run.
       expect(enqueueSystemEvent).not.toHaveBeenCalled();
+    } finally {
+      cron.stop();
+      await cleanup();
+    }
+  });
+
+  it.each([
+    {
+      label: "failure",
+      child: { status: "failed", reason: "agent-runner-failure" } as HeartbeatRunResult,
+      expectedStatus: "error",
+      expectedCompletion: "failed",
+      expectedError: "heartbeat failed: agent-runner-failure",
+      expectedConsecutiveErrors: 1,
+    },
+    {
+      label: "success",
+      child: { status: "ran", durationMs: 75 } as HeartbeatRunResult,
+      expectedStatus: "ok",
+      expectedCompletion: "succeeded",
+      expectedError: undefined,
+      expectedConsecutiveErrors: 0,
+    },
+    {
+      label: "disabled skip",
+      child: { status: "skipped", reason: "disabled" } as HeartbeatRunResult,
+      expectedStatus: "skipped",
+      expectedCompletion: "failed",
+      expectedError: "heartbeat skipped: disabled",
+      expectedConsecutiveErrors: 0,
+    },
+  ])("records the settled heartbeat child $label", async (testCase) => {
+    const { storePath, cleanup } = await makeStorePath();
+    const child = createDeferred<HeartbeatRunResult>();
+    const events: CronEvent[] = [];
+    const { cron, requestHeartbeatAndWait } = createStartedCronServiceWithFinishedBarrier({
+      storePath,
+      logger: noopLogger,
+      requestHeartbeatAndWait: async () => await child.promise,
+      onEvent: (event) => events.push(structuredClone(event)),
+    });
+    try {
+      await cron.start();
+      const added = await cron.add(
+        {
+          declarationKey: "heartbeat:main",
+          name: "heartbeat-main",
+          agentId: "main",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          payload: { kind: "heartbeat" },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+        },
+        { enabledExplicit: true, systemOwned: true },
+      );
+      const job = "job" in added ? added.job : added;
+
+      const runPromise = cron.run(job.id, "force");
+      await vi.waitFor(() => expect(requestHeartbeatAndWait).toHaveBeenCalledOnce());
+      expect(events.some((event) => event.action === "finished")).toBe(false);
+      expect(cron.getJob(job.id)?.state.runningAtMs).toEqual(expect.any(Number));
+
+      child.resolve(testCase.child);
+      await expect(runPromise).resolves.toMatchObject({ ok: true, ran: true });
+
+      const finished = events.findLast(
+        (event) => event.action === "finished" && event.jobId === job.id,
+      );
+      expect(finished).toMatchObject({
+        status: testCase.expectedStatus,
+        completionStatus: testCase.expectedCompletion,
+        ...(testCase.expectedError === undefined ? {} : { error: testCase.expectedError }),
+      });
+      expect(cron.getJob(job.id)?.state).toMatchObject({
+        lastRunStatus: testCase.expectedStatus,
+        lastStatus: testCase.expectedStatus,
+        consecutiveErrors: testCase.expectedConsecutiveErrors,
+      });
+    } finally {
+      cron.stop();
+      await cleanup();
+    }
+  });
+
+  it("settles an enqueued manual heartbeat run without its Cron lane self-blocking", async () => {
+    const { storePath, cleanup } = await makeStorePath();
+    let observedWaitOwners: ReturnType<typeof listCronHeartbeatWaitOwners> | undefined;
+    const { cron, finished } = createStartedCronServiceWithFinishedBarrier({
+      storePath,
+      logger: noopLogger,
+      requestHeartbeatAndWait: async () => {
+        observedWaitOwners = listCronHeartbeatWaitOwners();
+        return { status: "ran", durationMs: 1 };
+      },
+    });
+    try {
+      await cron.start();
+      const added = await cron.add(
+        {
+          declarationKey: "heartbeat:main",
+          name: "heartbeat-main",
+          agentId: "main",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60_000 },
+          payload: { kind: "heartbeat" },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+        },
+        { enabledExplicit: true, systemOwned: true },
+      );
+      const job = "job" in added ? added.job : added;
+      const terminal = finished.waitForOk(job.id);
+
+      await expect(cron.enqueueRun(job.id, "force")).resolves.toMatchObject({
+        ok: true,
+        enqueued: true,
+      });
+      await expect(terminal).resolves.toMatchObject({
+        status: "ok",
+        completionStatus: "succeeded",
+      });
+      expect(observedWaitOwners?.activeJobMarkers).toEqual([
+        expect.objectContaining({ jobId: job.id }),
+      ]);
+      expect(observedWaitOwners?.owningCronLaneTaskMarkers).toEqual([
+        expect.objectContaining({ lane: "cron" }),
+      ]);
+    } finally {
+      cron.stop();
+      await cleanup();
+    }
+  });
+
+  it("times out an unsettled heartbeat wake without authoring success", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-08-31T12:00:00Z"));
+    const { storePath, cleanup } = await makeStorePath();
+    const events: CronEvent[] = [];
+    const { cron, requestHeartbeatAndWait } = createStartedCronServiceWithFinishedBarrier({
+      storePath,
+      logger: noopLogger,
+      requestHeartbeatAndWait: async (_request, lifecycle) =>
+        await new Promise<HeartbeatRunResult>((resolve) => {
+          const onAbort = () => resolve({ status: "failed", reason: "heartbeat wake cancelled" });
+          if (lifecycle.abortSignal?.aborted) {
+            onAbort();
+          } else {
+            lifecycle.abortSignal?.addEventListener("abort", onAbort, { once: true });
+          }
+        }),
+      onEvent: (event) => events.push(structuredClone(event)),
+    });
+    try {
+      await cron.start();
+      const added = await cron.add(
+        {
+          declarationKey: "heartbeat:main",
+          name: "heartbeat-main",
+          agentId: "main",
+          enabled: true,
+          schedule: { kind: "every", everyMs: 60 * 60_000 },
+          payload: { kind: "heartbeat" },
+          sessionTarget: "main",
+          wakeMode: "next-heartbeat",
+        },
+        { enabledExplicit: true, systemOwned: true },
+      );
+      const job = "job" in added ? added.job : added;
+      const runPromise = cron.run(job.id, "force");
+      await vi.waitFor(() => expect(requestHeartbeatAndWait).toHaveBeenCalledOnce());
+
+      await vi.advanceTimersByTimeAsync(10 * 60_000);
+      await expect(runPromise).resolves.toMatchObject({ ok: true, ran: true });
+
+      expect(events.findLast((event) => event.action === "finished")).toMatchObject({
+        status: "error",
+        completionStatus: "failed",
+        error: expect.stringContaining("job execution timed out"),
+      });
+    } finally {
+      cron.stop();
+      await cleanup();
+      vi.useRealTimers();
+    }
+  });
+
+  it("keeps ordinary system-event cron completion dispatch-only", async () => {
+    const { storePath, cleanup } = await makeStorePath();
+    const events: CronEvent[] = [];
+    const { cron, requestHeartbeat, requestHeartbeatAndWait } =
+      createStartedCronServiceWithFinishedBarrier({
+        storePath,
+        logger: noopLogger,
+        onEvent: (event) => events.push(structuredClone(event)),
+      });
+    try {
+      await cron.start();
+      const job = await cron.add({
+        name: "ordinary system event",
+        enabled: true,
+        schedule: { kind: "every", everyMs: 60_000 },
+        payload: { kind: "systemEvent", text: "dispatch this event" },
+        sessionTarget: "main",
+        wakeMode: "next-heartbeat",
+      });
+
+      await expect(cron.run(job.id, "force")).resolves.toMatchObject({ ok: true, ran: true });
+
+      expect(requestHeartbeat).toHaveBeenCalledOnce();
+      expect(requestHeartbeatAndWait).not.toHaveBeenCalled();
+      expect(events.findLast((event) => event.action === "finished")).toMatchObject({
+        status: "ok",
+        completionStatus: "succeeded",
+        summary: "dispatch this event",
+      });
     } finally {
       cron.stop();
       await cleanup();
@@ -283,7 +506,7 @@ describe("heartbeat payload execution", () => {
 
   it("routes migrated task jobs through the guarded task wake path", async () => {
     const { storePath, cleanup } = await makeStorePath();
-    const { cron, enqueueSystemEvent, requestHeartbeat } =
+    const { cron, enqueueSystemEvent, requestHeartbeat, requestHeartbeatAndWait } =
       createStartedCronServiceWithFinishedBarrier({ storePath, logger: noopLogger });
     try {
       await cron.start();
@@ -317,13 +540,19 @@ describe("heartbeat payload execution", () => {
       const job = "job" in added ? added.job : added;
 
       await expect(cron.run(job.id, "force")).resolves.toMatchObject({ ok: true });
-      expect(requestHeartbeat).toHaveBeenCalledWith({
-        source: "interval",
-        intent: "task",
-        reason: `heartbeat-task:${job.id}`,
-        agentId: "main",
-        tasks: [{ jobId: job.id, name: "inbox", prompt: "Check urgent inbox items" }],
-      });
+      expect(requestHeartbeatAndWait).toHaveBeenCalledWith(
+        {
+          source: "interval",
+          intent: "task",
+          reason: `heartbeat-task:${job.id}`,
+          agentId: "main",
+          tasks: [{ jobId: job.id, name: "inbox", prompt: "Check urgent inbox items" }],
+        },
+        expect.objectContaining({
+          abortSignal: expect.any(AbortSignal),
+        }),
+      );
+      expect(requestHeartbeat).not.toHaveBeenCalled();
       expect(enqueueSystemEvent).not.toHaveBeenCalled();
 
       // These stay ordinary cron rows: operators can edit and remove them.

--- a/src/cron/service.test-harness.ts
+++ b/src/cron/service.test-harness.ts
@@ -143,14 +143,20 @@ export function createStartedCronServiceWithFinishedBarrier(params: {
   storePath: string;
   logger: ReturnType<typeof createNoopLogger>;
   runSkillCollectionReview?: CronServiceDeps["runSkillCollectionReview"];
+  requestHeartbeatAndWait?: CronServiceDeps["requestHeartbeatAndWait"];
+  onEvent?: CronServiceDeps["onEvent"];
 }): {
   cron: CronService;
   enqueueSystemEvent: MockFn;
   requestHeartbeat: MockFn;
+  requestHeartbeatAndWait: MockFn;
   finished: ReturnType<typeof createFinishedBarrier>;
 } {
   const enqueueSystemEvent = vi.fn();
   const requestHeartbeat = vi.fn();
+  const requestHeartbeatAndWait = vi.fn(
+    params.requestHeartbeatAndWait ?? (async () => ({ status: "ran" as const, durationMs: 1 })),
+  );
   const finished = createFinishedBarrier();
   const cron = new CronService({
     storePath: params.storePath,
@@ -158,13 +164,17 @@ export function createStartedCronServiceWithFinishedBarrier(params: {
     log: params.logger,
     enqueueSystemEvent,
     requestHeartbeat,
+    requestHeartbeatAndWait,
     runIsolatedAgentJob: vi.fn(async () => ({ status: "ok" as const })),
     ...(params.runSkillCollectionReview
       ? { runSkillCollectionReview: params.runSkillCollectionReview }
       : {}),
-    onEvent: finished.onEvent,
+    onEvent: (event) => {
+      finished.onEvent(event);
+      params.onEvent?.(event);
+    },
   });
-  return { cron, enqueueSystemEvent, requestHeartbeat, finished };
+  return { cron, enqueueSystemEvent, requestHeartbeat, requestHeartbeatAndWait, finished };
 }
 
 export async function withCronServiceForTest(

--- a/src/cron/service/state.ts
+++ b/src/cron/service/state.ts
@@ -171,6 +171,11 @@ export type CronServiceDeps = {
     opts: HeartbeatWakeRequest,
     retry?: Extract<HeartbeatRunResult, { status: "skipped" }>,
   ) => void;
+  /** Waits for the terminal result of a cron-owned coalesced heartbeat wake. */
+  requestHeartbeatAndWait?: (
+    opts: HeartbeatWakeRequest,
+    lifecycle: { abortSignal?: AbortSignal },
+  ) => Promise<HeartbeatRunResult>;
   runHeartbeatOnce?: (opts?: {
     source?: HeartbeatWakeRequest["source"];
     intent?: HeartbeatWakeRequest["intent"];

--- a/src/cron/service/timer-execution.ts
+++ b/src/cron/service/timer-execution.ts
@@ -7,7 +7,11 @@ import {
   isRetryableHeartbeatSkipReason,
 } from "../../infra/heartbeat-wake.js";
 import type { CommandLaneTaskMarker } from "../../process/command-queue.js";
-import { type CronActiveJobMarker, isCronActiveJobMarkerCurrent } from "../active-jobs.js";
+import {
+  type CronActiveJobMarker,
+  isCronActiveJobMarkerCurrent,
+  markCronJobWaitingForHeartbeat,
+} from "../active-jobs.js";
 import { resolveCronJobEffectiveAgentId } from "../agent-id.js";
 import { isHeartbeatTaskCronJob } from "../heartbeat-task.js";
 import { createCronRunDiagnosticsFromError } from "../run-diagnostics.js";
@@ -204,35 +208,52 @@ export async function executeJobCore(
   if (effectiveJob.payload.kind === "heartbeat" || heartbeatTask) {
     // Monitors and migrated tasks share the wake bus, keeping coalescing,
     // quiet hours, cooldown, flood, and busy guards in the heartbeat runner.
-    requestCronHeartbeat(
-      state,
-      heartbeatTask
-        ? {
-            source: "interval",
-            intent: "task",
-            reason: `heartbeat-task:${heartbeatTask.id}`,
-            agentId: heartbeatTask.agentId,
-            tasks: [
-              {
-                jobId: heartbeatTask.id,
-                name: heartbeatTask.name,
-                prompt: heartbeatTask.payload.text,
-              },
-            ],
-          }
-        : {
-            source: "interval",
-            intent: "scheduled",
-            reason: "interval",
-            agentId: effectiveJob.agentId,
-            scheduledEveryMs:
-              effectiveJob.schedule.kind === "every" ? effectiveJob.schedule.everyMs : undefined,
-          },
+    const releaseHeartbeatWait = markCronJobWaitingForHeartbeat(
+      options?.activeJobMarker,
+      options?.owningCronLaneTaskMarker,
     );
-    const result = {
-      status: "ok" as const,
-      summary: heartbeatTask ? "heartbeat task wake requested" : "heartbeat wake requested",
-    };
+    let heartbeatResult: HeartbeatRunResult;
+    try {
+      heartbeatResult = await (state.deps.requestHeartbeatAndWait?.(
+        heartbeatTask
+          ? {
+              source: "interval",
+              intent: "task",
+              reason: `heartbeat-task:${heartbeatTask.id}`,
+              agentId: heartbeatTask.agentId,
+              tasks: [
+                {
+                  jobId: heartbeatTask.id,
+                  name: heartbeatTask.name,
+                  prompt: heartbeatTask.payload.text,
+                },
+              ],
+            }
+          : {
+              source: "interval",
+              intent: "scheduled",
+              reason: "interval",
+              agentId: effectiveJob.agentId,
+              scheduledEveryMs:
+                effectiveJob.schedule.kind === "every" ? effectiveJob.schedule.everyMs : undefined,
+            },
+        abortSignal ? { abortSignal } : {},
+      ) ?? { status: "failed", reason: "heartbeat wake settlement unavailable" });
+    } finally {
+      releaseHeartbeatWait();
+    }
+    if (abortSignal?.aborted) {
+      return resolveAbortError();
+    }
+    const result =
+      heartbeatResult.status === "ran"
+        ? {
+            status: "ok" as const,
+            summary: heartbeatTask ? "heartbeat task completed" : "heartbeat completed",
+          }
+        : heartbeatResult.status === "failed"
+          ? { status: "error" as const, error: `heartbeat failed: ${heartbeatResult.reason}` }
+          : { status: "skipped" as const, error: `heartbeat skipped: ${heartbeatResult.reason}` };
     return triggerEval ? { ...result, triggerEval } : result;
   }
   if (effectiveJob.sessionTarget === "main") {

--- a/src/gateway/server-cron.test.ts
+++ b/src/gateway/server-cron.test.ts
@@ -11,6 +11,7 @@ import type { CliDeps } from "../cli/deps.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { resolveHeartbeatSession } from "../infra/heartbeat-runner-session.js";
+import type { HeartbeatRunResult } from "../infra/heartbeat-wake.js";
 import {
   OutboundDeliveryError,
   PlatformMessageNotDispatchedError,
@@ -33,6 +34,7 @@ const {
   enqueueSystemEventMock,
   systemEventReceiptRemoveMock,
   requestHeartbeatMock,
+  requestHeartbeatAndWaitMock,
   runHeartbeatOnceMock,
   loadConfigMock,
   fetchWithSsrFGuardMock,
@@ -52,6 +54,9 @@ const {
   enqueueSystemEventMock: vi.fn(),
   systemEventReceiptRemoveMock: vi.fn(() => true),
   requestHeartbeatMock: vi.fn(),
+  requestHeartbeatAndWaitMock: vi.fn<(...args: unknown[]) => Promise<HeartbeatRunResult>>(
+    async () => ({ status: "ran", durationMs: 1 }),
+  ),
   runHeartbeatOnceMock: vi.fn<
     (...args: unknown[]) => Promise<{ status: "ran"; durationMs: number }>
   >(async () => ({ status: "ran", durationMs: 1 })),
@@ -136,6 +141,10 @@ function requestHeartbeat(...args: unknown[]) {
   return requestHeartbeatMock(...args);
 }
 
+function requestHeartbeatAndWait(...args: unknown[]) {
+  return requestHeartbeatAndWaitMock(...args);
+}
+
 function runHeartbeatOnce(...args: unknown[]) {
   return runHeartbeatOnceMock(...args);
 }
@@ -152,6 +161,7 @@ vi.mock("../infra/heartbeat-wake.js", async () => {
   return {
     ...actual,
     requestHeartbeat,
+    requestHeartbeatAndWait,
   };
 });
 
@@ -462,6 +472,7 @@ describe("buildGatewayCronService", () => {
     enqueueSystemEventMock.mockClear();
     systemEventReceiptRemoveMock.mockClear();
     requestHeartbeatMock.mockClear();
+    requestHeartbeatAndWaitMock.mockClear();
     runHeartbeatOnceMock.mockClear();
     loadConfigMock.mockClear();
     fetchWithSsrFGuardMock.mockClear();
@@ -2734,6 +2745,45 @@ describe("buildGatewayCronService", () => {
         heartbeat: { target: "last", to: undefined, accountId: undefined },
         scheduledEveryMs: 15 * 60_000,
       });
+    } finally {
+      state.cron.stop();
+    }
+  });
+
+  it("returns the settled heartbeat result through the cron wake adapter", async () => {
+    requestHeartbeatAndWaitMock.mockResolvedValueOnce({
+      status: "failed",
+      reason: "agent-runner-failure",
+    });
+    const state = loadCronService(createCronConfig("server-cron-heartbeat-settlement"));
+    try {
+      const lifecycle = { abortSignal: new AbortController().signal };
+      await expect(
+        getCronState(state).deps.requestHeartbeatAndWait?.(
+          {
+            source: "interval",
+            intent: "task",
+            reason: "heartbeat-task:report",
+            agentId: "main",
+            scheduledEveryMs: 15 * 60_000,
+            tasks: [{ jobId: "report", name: "report", prompt: "Run report" }],
+          },
+          lifecycle,
+        ),
+      ).resolves.toEqual({ status: "failed", reason: "agent-runner-failure" });
+      expect(requestHeartbeatAndWaitMock).toHaveBeenCalledWith(
+        {
+          source: "interval",
+          intent: "task",
+          reason: "heartbeat-task:report",
+          agentId: "main",
+          sessionKey: undefined,
+          heartbeat: undefined,
+          scheduledEveryMs: 15 * 60_000,
+          tasks: [{ jobId: "report", name: "report", prompt: "Run report" }],
+        },
+        lifecycle,
+      );
     } finally {
       state.cron.stop();
     }

--- a/src/gateway/server-cron.ts
+++ b/src/gateway/server-cron.ts
@@ -71,6 +71,7 @@ import { resolveMainScopedEventSessionKey } from "../infra/event-session-routing
 import { runHeartbeatOnce } from "../infra/heartbeat-runner-run.js";
 import {
   requestHeartbeat,
+  requestHeartbeatAndWait,
   requestHeartbeatRetry,
   type HeartbeatWakeRequest,
 } from "../infra/heartbeat-wake.js";
@@ -573,6 +574,8 @@ export function buildGatewayCronService(params: {
           agentId?: string;
           sessionKey?: string;
           heartbeat?: HeartbeatWakeRequest["heartbeat"];
+          scheduledEveryMs?: number;
+          tasks?: HeartbeatWakeRequest["tasks"];
         }
       | undefined,
     direct = false,
@@ -595,6 +598,10 @@ export function buildGatewayCronService(params: {
         heartbeat: direct
           ? resolveCronHeartbeatOverride({ runtimeConfig, agentId, heartbeat: opts?.heartbeat })
           : sanitizeCronHeartbeatOverride(opts?.heartbeat),
+        ...(opts?.scheduledEveryMs !== undefined
+          ? { scheduledEveryMs: opts.scheduledEveryMs }
+          : {}),
+        ...(opts?.tasks?.length ? { tasks: opts.tasks } : {}),
       },
     };
   };
@@ -883,19 +890,14 @@ export function buildGatewayCronService(params: {
       : {}),
     requestHeartbeat: (opts, retry) => {
       const { wake } = resolveCronHeartbeatWake(opts);
-      const request = {
-        ...wake,
-        ...(opts?.scheduledEveryMs !== undefined
-          ? { scheduledEveryMs: opts.scheduledEveryMs }
-          : {}),
-        ...(opts.tasks?.length ? { tasks: opts.tasks } : {}),
-      };
       if (retry) {
-        requestHeartbeatRetry(request, retry);
+        requestHeartbeatRetry(wake, retry);
       } else {
-        requestHeartbeat(request);
+        requestHeartbeat(wake);
       }
     },
+    requestHeartbeatAndWait: (opts, lifecycle) =>
+      requestHeartbeatAndWait(resolveCronHeartbeatWake(opts).wake, lifecycle),
     runHeartbeatOnce: async (opts) => {
       const { runtimeConfig, wake } = resolveCronHeartbeatWake(opts, true);
       return await runHeartbeatOnce({

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -35,8 +35,9 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   hasActiveCronJobs,
-  hasActiveCronJobsExceptMarker,
+  hasActiveCronJobsExceptMarkers,
   isCronActiveJobMarkerCurrent,
+  listCronHeartbeatWaitOwners,
   type CronActiveJobMarker,
 } from "../cron/active-jobs.js";
 import { resolveCronSession } from "../cron/isolated-agent/session.js";
@@ -97,6 +98,7 @@ import {
 } from "./outbound/targets.js";
 
 const log = heartbeatLog;
+const CRON_COMMAND_LANE: string = CommandLane.Cron;
 
 export type HeartbeatDeps = OutboundSendDeps &
   ChannelHeartbeatDeps & {
@@ -232,27 +234,38 @@ export async function resolveHeartbeatWakeStage(opts: HeartbeatRunOptions) {
     return { kind: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT } as const;
   }
 
-  // Ignore only the exact Cron lane task that owns this wake. Other queued or active
-  // Cron work and all CronNested work remain busy signals.
-  const owningCronJobMarker = opts.owningCronJobMarker;
-  const ownsActiveCronRun = owningCronJobMarker
-    ? isCronActiveJobMarkerCurrent(owningCronJobMarker)
-    : false;
+  // Cron executions awaiting heartbeat settlement are idle owners, not competing work.
+  // Keep unrelated Cron work and all CronNested work as busy signals.
+  const heartbeatWaitOwners = listCronHeartbeatWaitOwners();
+  const directOwner =
+    opts.owningCronJobMarker && isCronActiveJobMarkerCurrent(opts.owningCronJobMarker)
+      ? opts.owningCronJobMarker
+      : undefined;
+  const owningCronJobMarkers = [
+    ...heartbeatWaitOwners.activeJobMarkers,
+    ...(directOwner ? [directOwner] : []),
+  ];
   const cronBusy =
-    ownsActiveCronRun && owningCronJobMarker
-      ? hasActiveCronJobsExceptMarker(owningCronJobMarker)
+    owningCronJobMarkers.length > 0
+      ? hasActiveCronJobsExceptMarkers(owningCronJobMarkers)
       : hasActiveCronJobs();
-  const owningCronLaneTaskMarker = opts.owningCronLaneTaskMarker;
-  const ownsCronLaneTask =
-    ownsActiveCronRun &&
-    owningCronLaneTaskMarker?.lane === CommandLane.Cron &&
-    isCommandLaneTaskMarkerCurrent(owningCronLaneTaskMarker);
+  const owningCronLaneTaskIds = new Set(
+    [
+      ...heartbeatWaitOwners.owningCronLaneTaskMarkers,
+      ...(directOwner && opts.owningCronLaneTaskMarker ? [opts.owningCronLaneTaskMarker] : []),
+    ]
+      .filter(
+        (marker): marker is CommandLaneTaskMarker =>
+          marker?.lane === CRON_COMMAND_LANE && isCommandLaneTaskMarkerCurrent(marker),
+      )
+      .map((marker) => marker.taskId),
+  );
   const cronLaneDepth = getSize(CommandLane.Cron);
   // HookDispatch is included so moving hook agent runs off `cron-nested` onto
   // their own lane does not silently stop them from suppressing heartbeats.
   // They are still active agent work; only the lane they occupy changed.
   const cronLaneBusy =
-    cronLaneDepth > (ownsCronLaneTask ? 1 : 0) ||
+    cronLaneDepth > owningCronLaneTaskIds.size ||
     getSize(CommandLane.CronNested) > 0 ||
     getSize(CommandLane.HookDispatch) > 0;
   if (cronBusy || cronLaneBusy) {

--- a/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
+++ b/src/infra/heartbeat-runner.skips-busy-session-lane.test.ts
@@ -14,7 +14,12 @@ import { resolveReplyOperationRunState } from "../auto-reply/reply/reply-operati
 import { createReplyOperation } from "../auto-reply/reply/reply-run-registry.js";
 import { testing as replyRunRegistryTesting } from "../auto-reply/reply/reply-run-registry.test-support.js";
 import type { OpenClawConfig } from "../config/config.js";
-import { markCronJobActive, resetCronActiveJobs } from "../cron/active-jobs.js";
+import {
+  clearCronJobActive,
+  markCronJobActive,
+  markCronJobWaitingForHeartbeat,
+  resetCronActiveJobs,
+} from "../cron/active-jobs.js";
 import { getActivePluginRegistry, setActivePluginRegistry } from "../plugins/runtime.js";
 import { CommandLane } from "../process/lanes.js";
 import { createOutboundTestPlugin, createTestRegistry } from "../test-utils/channel-plugins.js";
@@ -113,6 +118,21 @@ function runHeartbeat(
       ...deps,
     } as HeartbeatDeps,
   });
+}
+
+function markHeartbeatWaitOwners(...jobIds: string[]) {
+  const markers = jobIds
+    .map((jobId) => markCronJobActive(jobId))
+    .filter((marker): marker is NonNullable<typeof marker> => marker !== undefined);
+  const releases = markers.map((marker) => markCronJobWaitingForHeartbeat(marker));
+  return () => {
+    for (const release of releases) {
+      release();
+    }
+    for (const marker of markers) {
+      clearCronJobActive(marker.jobId, marker);
+    }
+  };
 }
 
 describe("heartbeat runner skips when target session lane is busy", () => {
@@ -282,6 +302,48 @@ describe("heartbeat runner skips when target session lane is busy", () => {
 
       expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_CRON_IN_PROGRESS });
       expect(replySpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("ignores every exact cron owner represented by a coalesced wake", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig(storePath);
+      await seedHeartbeatTelegramSession(storePath, cfg);
+      replySpy.mockResolvedValue({ text: "HEARTBEAT_OK" });
+      const releaseOwners = markHeartbeatWaitOwners("report-a", "report-b");
+
+      try {
+        const result = await runHeartbeat(cfg, replySpy, {
+          source: "cron",
+          reason: "heartbeat-task:report-a",
+        });
+
+        expect(result.status).toBe("ran");
+        expect(replySpy).toHaveBeenCalledOnce();
+      } finally {
+        releaseOwners();
+      }
+    });
+  });
+
+  it("keeps unrelated cron work blocking a coalesced owner set", async () => {
+    await withTempHeartbeatSandbox(async ({ storePath, replySpy }) => {
+      const cfg = createHeartbeatTelegramConfig(storePath);
+      await seedHeartbeatTelegramSession(storePath, cfg);
+      const releaseOwners = markHeartbeatWaitOwners("report-a", "report-b");
+      markCronJobActive("unrelated-job");
+
+      try {
+        const result = await runHeartbeat(cfg, replySpy, {
+          source: "cron",
+          reason: "heartbeat-task:report-a",
+        });
+
+        expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_CRON_IN_PROGRESS });
+        expect(replySpy).not.toHaveBeenCalled();
+      } finally {
+        releaseOwners();
+      }
     });
   });
 

--- a/src/infra/heartbeat-wake-settlement.ts
+++ b/src/infra/heartbeat-wake-settlement.ts
@@ -1,0 +1,65 @@
+import type { HeartbeatRunResult } from "./heartbeat-wake-contracts.js";
+
+export type HeartbeatWakeSettlement = {
+  active: boolean;
+  settle: (result: HeartbeatRunResult) => void;
+};
+
+export function activeHeartbeatWakeSettlements(
+  ...groups: Array<readonly HeartbeatWakeSettlement[] | undefined>
+): HeartbeatWakeSettlement[] {
+  return groups.flatMap((group) => group ?? []).filter((settlement) => settlement.active);
+}
+
+export function settleHeartbeatWakeSettlements(
+  settlements: readonly HeartbeatWakeSettlement[] | undefined,
+  result: HeartbeatRunResult,
+) {
+  for (const settlement of settlements ?? []) {
+    settlement.settle(result);
+  }
+}
+
+function createHeartbeatWakeSettlement(abortSignal?: AbortSignal): {
+  result: Promise<HeartbeatRunResult>;
+  settlement: HeartbeatWakeSettlement;
+} {
+  const control: {
+    resolve?: (result: HeartbeatRunResult) => void;
+    removeAbortListener?: () => void;
+  } = {};
+  const result = new Promise<HeartbeatRunResult>((resolve) => {
+    control.resolve = resolve;
+  });
+  const settlement: HeartbeatWakeSettlement = {
+    active: true,
+    settle: (outcome) => {
+      if (!settlement.active) {
+        return;
+      }
+      settlement.active = false;
+      control.removeAbortListener?.();
+      control.resolve?.(outcome);
+    },
+  };
+  const onAbort = () => settlement.settle({ status: "failed", reason: "heartbeat wake cancelled" });
+  control.removeAbortListener = () => abortSignal?.removeEventListener("abort", onAbort);
+  if (abortSignal?.aborted) {
+    onAbort();
+  } else {
+    abortSignal?.addEventListener("abort", onAbort, { once: true });
+  }
+  return { result, settlement };
+}
+
+export function createRequestHeartbeatAndWait<Request>(
+  enqueue: (request: Request, settlements?: HeartbeatWakeSettlement[]) => void,
+) {
+  return (request: Request, lifecycle?: { abortSignal?: AbortSignal }) => {
+    const pending = createHeartbeatWakeSettlement(lifecycle?.abortSignal);
+    if (pending.settlement.active) {
+      enqueue(request, [pending.settlement]);
+    }
+    return pending.result;
+  };
+}

--- a/src/infra/heartbeat-wake.settlement.test.ts
+++ b/src/infra/heartbeat-wake.settlement.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resetGatewayWorkAdmission } from "../process/gateway-work-admission.js";
+import {
+  HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
+  requestHeartbeatAndWait,
+  setHeartbeatWakeHandler,
+} from "./heartbeat-wake.js";
+
+describe("heartbeat wake settlement", () => {
+  let disposeHandler: (() => void) | undefined;
+
+  afterEach(async () => {
+    resetGatewayWorkAdmission();
+    if (vi.isFakeTimers()) {
+      disposeHandler?.();
+      disposeHandler = setHeartbeatWakeHandler(async () => ({
+        status: "skipped",
+        reason: "disabled",
+      }));
+      await vi.runAllTimersAsync();
+    }
+    disposeHandler?.();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function setHandler(handler: Parameters<typeof setHeartbeatWakeHandler>[0]) {
+    disposeHandler = setHeartbeatWakeHandler(handler);
+  }
+
+  it("settles every caller represented by one coalesced wake", async () => {
+    vi.useFakeTimers();
+    const handler = vi.fn().mockResolvedValue({ status: "ran", durationMs: 7 });
+    setHandler(handler);
+    const wake = { source: "interval" as const, intent: "scheduled" as const, reason: "interval" };
+    const resultA = requestHeartbeatAndWait({ ...wake, agentId: "main", coalesceMs: 100 });
+    const resultB = requestHeartbeatAndWait({ ...wake, agentId: "main", coalesceMs: 100 });
+
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(handler).toHaveBeenCalledWith({ ...wake, agentId: "main" });
+    await expect(Promise.all([resultA, resultB])).resolves.toEqual([
+      { status: "ran", durationMs: 7 },
+      { status: "ran", durationMs: 7 },
+    ]);
+  });
+
+  it("keeps an awaited cron wake pending across a retryable skip", async () => {
+    vi.useFakeTimers();
+    const handler = vi
+      .fn()
+      .mockResolvedValueOnce({ status: "skipped", reason: HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT })
+      .mockResolvedValueOnce({ status: "ran", durationMs: 1 });
+    setHandler(handler);
+    const result = requestHeartbeatAndWait({
+      source: "cron",
+      intent: "scheduled",
+      reason: "interval",
+      coalesceMs: 0,
+    });
+    const settled = vi.fn();
+    void result.then(settled);
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledOnce();
+    expect(settled).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await expect(result).resolves.toEqual({ status: "ran", durationMs: 1 });
+    expect(handler).toHaveBeenCalledTimes(2);
+  });
+
+  it("detaches an aborted waiter without cancelling its shared wake", async () => {
+    vi.useFakeTimers();
+    let finishChild: (() => void) | undefined;
+    const child = new Promise<void>((resolve) => {
+      finishChild = resolve;
+    });
+    const handler = vi.fn(async () => {
+      await child;
+      return { status: "ran" as const, durationMs: 1 };
+    });
+    setHandler(handler);
+    const controller = new AbortController();
+    const result = requestHeartbeatAndWait(
+      { source: "interval", intent: "scheduled", reason: "interval", coalesceMs: 0 },
+      { abortSignal: controller.signal },
+    );
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(handler).toHaveBeenCalledOnce();
+    controller.abort();
+    await expect(result).resolves.toEqual({
+      status: "failed",
+      reason: "heartbeat wake cancelled",
+    });
+
+    finishChild?.();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(handler).toHaveBeenCalledOnce();
+  });
+});

--- a/src/infra/heartbeat-wake.test.ts
+++ b/src/infra/heartbeat-wake.test.ts
@@ -9,6 +9,7 @@ import {
   HEARTBEAT_SKIP_CRON_IN_PROGRESS,
   HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
   requestHeartbeat,
+  requestHeartbeatAndWait,
   setHeartbeatWakeHandler as setRuntimeHeartbeatWakeHandler,
 } from "./heartbeat-wake.js";
 
@@ -847,7 +848,7 @@ describe("heartbeat-wake", () => {
     setHeartbeatWakeHandler(handlerA);
 
     // Trigger the handler — it starts running but never finishes
-    requestHeartbeat(wake("interval", { coalesceMs: 0 }));
+    const recovered = requestHeartbeatAndWait(wake("interval", { coalesceMs: 0 }));
     await vi.advanceTimersByTimeAsync(1);
     expect(handlerA).toHaveBeenCalledTimes(1);
 
@@ -861,6 +862,7 @@ describe("heartbeat-wake", () => {
     requestHeartbeat(wake("interval", { agentId: "ready", coalesceMs: 0 }));
     await vi.advanceTimersByTimeAsync(1);
     expect(handlerB.mock.calls.map(([request]) => request.agentId)).toEqual([undefined, "ready"]);
+    await expect(recovered).resolves.toEqual({ status: "ran", durationMs: 1 });
 
     // Clean up the hanging promise
     resolveHang!();

--- a/src/infra/heartbeat-wake.ts
+++ b/src/infra/heartbeat-wake.ts
@@ -19,6 +19,12 @@ import {
   runAbortableHeartbeatWake,
 } from "./heartbeat-wake-lifecycle.js";
 import {
+  activeHeartbeatWakeSettlements,
+  createRequestHeartbeatAndWait,
+  settleHeartbeatWakeSettlements,
+  type HeartbeatWakeSettlement,
+} from "./heartbeat-wake-settlement.js";
+import {
   GLOBAL_HEARTBEAT_WAKE_TARGET_KEY,
   isHeartbeatWakeAfterGlobalBarrier,
   isHeartbeatWakeTargetGroupReady,
@@ -84,6 +90,8 @@ type PendingWakeReason = {
   notBeforeMs?: number;
   /** The wake was deferred with real work that must survive later retries. */
   retainedWork?: boolean;
+  /** Cron callers waiting for this wake's terminal result. */
+  settlements?: HeartbeatWakeSettlement[];
 };
 
 type PendingWakeGroup = {
@@ -159,6 +167,7 @@ function mergePendingWakeReasons(
   const mergedTasks = Array.from(tasksByJobId.values()).toSorted((left, right) =>
     left.jobId.localeCompare(right.jobId),
   );
+  const settlements = activeHeartbeatWakeSettlements(previous.settlements, next.settlements);
   const mixedTaskPair = (previous.intent === "task") !== (next.intent === "task");
   const preferred = mixedTaskPair
     ? previous.intent === "task"
@@ -200,6 +209,7 @@ function mergePendingWakeReasons(
       : {}),
     ...(scheduledEveryMs !== undefined ? { scheduledEveryMs } : {}),
     ...(mergedTasks.length ? { tasks: mergedTasks } : {}),
+    ...(settlements.length ? { settlements } : {}),
   };
   if (!bypassRetainedWork && (previous.retainedWork || next.retainedWork)) {
     merged.retainedWork = true;
@@ -366,7 +376,9 @@ function queuePendingWakeReason(params: {
   notBeforeMs?: number;
   blockTargetUntilMs?: number;
   retainedWork?: boolean;
+  settlements?: HeartbeatWakeSettlement[];
 }) {
+  const settlements = activeHeartbeatWakeSettlements(params.settlements);
   const requestedAt = params.requestedAt ?? performance.now();
   const enqueueSequence = params.enqueueSequence ?? ++wakeEnqueueSequence;
   const normalizedReason = normalizeHeartbeatWakeReason(params.reason);
@@ -401,6 +413,7 @@ function queuePendingWakeReason(params: {
     ...(params.tasks?.length ? { tasks: [...params.tasks] } : {}),
     ...(params.notBeforeMs === undefined ? {} : { notBeforeMs: params.notBeforeMs }),
     ...(params.retainedWork ? { retainedWork: true } : {}),
+    ...(settlements.length ? { settlements } : {}),
   };
   const group = pendingWakes.get(wakeTargetKey) ?? {};
   if (params.blockTargetUntilMs !== undefined) {
@@ -464,6 +477,7 @@ function retryPendingWake(
     ...(retrySchedule.deferWakeOnly
       ? { notBeforeMs: retryAtMs, retainedWork: true }
       : { blockTargetUntilMs: retryAtMs, retainedWork: pendingWake.retainedWork }),
+    settlements: pendingWake.settlements,
   });
   schedule(retrySchedule.delayMs);
 }
@@ -550,6 +564,8 @@ async function dispatchPendingWakeGroup(params: {
         // Retain real task/event work until its spacing guard allows a retry.
         const { delayMs } = resolveHeartbeatRetrySchedule(pendingWake, result);
         retryPendingWake(pendingWake, { delayMs, deferWakeOnly: true });
+      } else {
+        settleHeartbeatWakeSettlements(pendingWake.settlements, result);
       }
     }
   } finally {
@@ -735,17 +751,12 @@ export function setHeartbeatWakeHandler(next: HeartbeatWakeHandler | null): () =
   };
 }
 
-export function requestHeartbeat(opts: {
-  source: HeartbeatWakeSource;
-  intent: HeartbeatWakeIntent;
-  reason?: string;
-  coalesceMs?: number;
-  agentId?: string;
-  sessionKey?: string;
-  heartbeat?: HeartbeatWakeOverride;
-  scheduledEveryMs?: number;
-  tasks?: readonly HeartbeatScheduledTask[];
-}) {
+type HeartbeatRequestOptions = Omit<HeartbeatWakeRequest, "retainedWork"> & { coalesceMs?: number };
+
+function enqueueHeartbeatRequest(
+  opts: HeartbeatRequestOptions,
+  settlements?: HeartbeatWakeSettlement[],
+) {
   const requestedAt = performance.now();
   const { coalesceMs: requestedCoalesceMs, ...wake } = opts;
   const coalesceMs = requestedCoalesceMs ?? DEFAULT_COALESCE_MS;
@@ -757,10 +768,16 @@ export function requestHeartbeat(opts: {
       ...wake,
       requestedAt,
       readyAtMs: requestedAt + resolveTimerTimeoutMs(coalesceMs, DEFAULT_COALESCE_MS, 0),
+      settlements,
     });
     schedule(coalesceMs);
   });
 }
+
+export const requestHeartbeat = (opts: HeartbeatRequestOptions) => enqueueHeartbeatRequest(opts);
+
+/** Requests a coalesced wake and resolves when that shared turn reaches a terminal result. */
+export const requestHeartbeatAndWait = createRequestHeartbeatAndWait(enqueueHeartbeatRequest);
 
 /** Transfers a direct attempt to the wake owner's existing retry lifecycle. */
 export function requestHeartbeatRetry(


### PR DESCRIPTION
Fixes #134327
Refs #134373

## What Problem This Solves

Fixes an issue where heartbeat cron runs were recorded as successful as soon as their wake was accepted, even when the delayed heartbeat agent turn later failed. Operators could therefore see `ok` / `succeeded` history for model work that never completed.

## Why This Change Was Made

Cron task completion accounting is the lifecycle owner. Heartbeat cron work now stays open until the coalesced wake reaches a terminal result, and that result is mapped through the existing cron outcome vocabulary.

The wake queue fans one child result out to every represented cron parent, retains waiters across retryable skips and handler replacement, and detaches only the exact waiter on cancellation. Exact waiting cron and lane owners are excluded from the child's busy check so they cannot block their own work; unrelated cron work remains a blocker.

This uses the existing ten-minute cron watchdog and durable running-receipt recovery. It does not add a protocol status, persistence schema, polling loop, retry that hides failures, or unbounded scheduler wait.

#134373 concerns deletion of completed isolated cron sessions. It does not share this completion transition, so this PR does not change session cleanup.

## User Impact

Heartbeat cron history now reports the eventual heartbeat outcome:

- failed child: `error` / `failed`
- successful child: `ok` / `succeeded`
- disabled heartbeat: `skipped` / `failed`

Coalescing still produces one child turn, manual heartbeat runs use the same contract, and ordinary system-event cron remains dispatch-only.

## Evidence

- Red baseline `1363c4744796e7e18ace354efb70ebbdd00bef2c`: a failed child followed an already-persisted `ok` / `succeeded` parent with summary `heartbeat wake requested`.
- Green head `3fbe17d78ba5c43837bd84f8edbfcfeb76dc4cb2`: the same parent waits and records `error` / `failed` with `heartbeat failed: agent-runner-failure`.
- Red terminal proof (`1363c474…`): https://github.com/user-attachments/assets/be972314-fb81-4542-961e-14a8cb31afb2
- Green terminal proof (`3fbe17d7…`): https://github.com/user-attachments/assets/74b80368-c3f7-4af8-8114-9cec068eee58
- Artifact manifest and SHA-256 checksums: https://gist.github.com/fuller-stack-dev/19496d31c764e81abee95a3f5b2e1e74
- Source-blind behavior validation: five contract clauses passed at confidence 0.94; restart process termination is outside that fixture and covered by the existing durable-receipt recovery plus focused owner tests.
- Focused owner/readers: 218 tests passed across cron execution, coalescing, exact busy-owner exclusions, and the Gateway adapter.
- `node scripts/check-changed.mjs`: passed.
- `$autoreview`: no findings, confidence 0.91.

An expanded local `pnpm test:changed` run completed twelve projects before a Vitest worker exited while another full OpenClaw campaign saturated the host. It produced no assertion failure; exact-head hosted CI remains required before landing.

## Scope and Review Notes

Production LOC: +231/-71 (net +160) | Tests: +473/-20 | Test support: +12/-2

The production growth is the bounded many-parent-to-one-child settlement bridge and exact lifecycle ownership needed to preserve coalescing. Shared settlement and Gateway adapter logic were extracted to avoid duplicate branches.

Related open PRs are not superseded: #133747 covers cancelled-run retry settlement, #132464 covers orphaned heartbeat transcripts, #72677 covers handoff warnings, and #131590 covers one-shot disable visibility. None owns heartbeat child-to-parent completion.

Release-note context: Cron heartbeat jobs now report the settled heartbeat child outcome instead of treating accepted wake dispatch as completed work.
