### PR TITLE
perf: reuse prepared transcript projection queries

### DIFF
--- a/src/config/sessions/session-transcript-projection-rebuild.ts
+++ b/src/config/sessions/session-transcript-projection-rebuild.ts
@@ -1,11 +1,12 @@
 import type { DatabaseSync } from "node:sqlite";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import type { ColumnType, Generated } from "kysely";
+import type { ColumnType, Generated, InferResult } from "kysely";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
   iterateSqliteQuerySync,
+  prepareSqliteQuerySync,
 } from "../../infra/kysely-sync.js";
 import { runSqliteDeferredTransactionSync } from "../../infra/sqlite-transaction.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
@@ -240,14 +241,18 @@ export function visitSessionTranscriptProjection(
   const rows =
     visiblePath.length > 0
       ? (function* () {
+          const read = prepareSqliteQuerySync<number, InferResult<typeof query>[number]>(
+            db,
+            (parameter) =>
+              query.where(
+                "seq",
+                "=",
+                parameter((seq) => seq),
+              ),
+          );
           for (const node of visiblePath) {
-            const row = executeSqliteQueryTakeFirstSync(
-              db,
-              query.where("seq", "=", node.entry.seq),
-            );
-            if (row) {
-              yield row;
-            }
+            // The transcript primary key keeps this point read to zero or one row.
+            yield* read(node.entry.seq).rows;
           }
         })()
       : tree.hasLeafControl


### PR DESCRIPTION
## Why

Rebuilding a selected transcript branch reconstructs and compiles the same Kysely point query once per visible event. Native statement caching does not remove this query-builder work. Rewinds, branch changes and projection repair all use this owner.

## Change

Prepare the parameterized point query once inside the lazy selected-path generator, then reuse it for each event sequence. The `(session_id, seq)` primary key limits each read to zero or one row. The query still completes before visitor callbacks; ordering, missing rows, reentry and the existing authorizer/cache policy are preserved. Empty, cleared-leaf and legacy flat paths keep their existing flow.

Production **+13 / −8, net +5** after repository formatting; tests unchanged. The formatter expands the parameter-binding callback; comment-free emitted JavaScript exactly matches the measured candidate. No new cache, dependency, configuration, database schema or persistence path. The existing shared prepared-query helper owns parameter binding and native execution.

## Measurements

Complete real projection/index/transaction/Kysely owners, private in-memory SQLite fixtures, ordinary writable-owner statement caching enabled. Four fresh processes in before/candidate/candidate/before order; 51 fixed workloads, eight warmup blocks and nine measured blocks per workload. All 1,836 measured blocks and 204 first-operation observations are retained. Warmup durations were not retained. Measurements were captured at `2fb3364fd7b0a587b0c1bd808f5458efcbe339ac`; executable graph inputs and the exact selected candidate still match the integration baseline. Unrelated package metadata drift was separately inspected.

| Complete operation | Before → after, forward | Before → after, reverse |
| --- | --- | --- |
| 16-message visit | 115.763 → 90.896 µs | 122.724 → 87.664 µs |
| 16-message prepare | 114.141 → 89.435 µs | 119.401 → 92.479 µs |
| 16-message dirty-mark + transactional reconcile | 286.964 → 257.932 µs | 296.115 → 257.549 µs |
| Single-message prepare control | +1.487 µs / +6.61% cost | 5.04% improvement |
| Legacy visit control | +2.445 µs / +4.84% cost | improvement |
| Legacy prepare control | improvement | +2.102 µs / +3.92% cost |

Thirty-seven rows improve in both orders; fourteen are mixed; none is slower in both. This unweighted tally is not an aggregate product speed estimate. Ordinary 16-message prepare improves 21–23%, and full in-memory reconcile improves 10–13%. Large-payload and 128/1,024/2,048-message cases, explicit no-cache controls and actual-authorizer controls are included in the retained full table. Small and unchanged-path costs remain visible.

These are owner-operation measurements, not disk throughput, worker startup, Gateway latency, memory improvement or statistical significance. They do not establish a fix for the separately observed Linux 256 MiB Doctor-import OOM.

## Verification

The fixed proof passed 98 differential fixtures, 54 contract assertions, four mechanism assertions and eight callback controls. All 51 complete-operation output oracles match and bind every timing process. A four-visible-row witness reduces point-query compilations from four to one without changing native execution. Independent all-priority source and raw-evidence review recomputed all 204 medians and checked the proof, workload order and physical cleanup.

On integration baseline `9b123e263448b9d0cb673768ffb8b9ac185acdac`, all 73 existing tests pass both before and after: projection rebuild, context eligibility, reconcile worker lifecycle, search/FTS, transcript-tree semantics and Kysely execution/cache behavior. No test was weakened or replaced. Managed Codex review is scoped-clean; its P0 scope is supplemented by the independent source review above.

Changed checks pass (234.57 seconds) after a formatting-only correction; the initial formatting failure is retained. The exact `abe24bacd4a9bc715b94010d1f1ebb067509c698` build passes (169.30 seconds). [CI run 33438898488](https://github.com/openclaw/openclaw/actions/runs/33438898488), attempt 1, passed with 185 successful jobs and 17 skipped jobs; no retry. The candidate built-Gateway rewind/branch proof passes. The incoming worker-location and maintenance changes are outside the measured graph and enter the fresh integration checks, not the historical speed comparison.

The latest [ClawSweeper review](https://github.com/openclaw/openclaw/pull/134465#issuecomment-5484573482) found no concrete correctness or security defect. Its remaining installed-dependency/typecheck and CI checks are resolved: the installed Kysely 0.29.5 `dist/util/infer-result.d.ts` declaration and `dist/index.d.ts` export were directly inspected, and the exact-head checks are green. The [official declaration](https://github.com/kysely-org/kysely/blob/v0.29.5/src/util/infer-result.ts) and [API reference](https://kysely-org.github.io/kysely-apidoc/types/InferResult.html) confirm that `InferResult<typeof query>[number]` is the selected row type.


The actual built Gateway completed nine authenticated public requests: history and preview, rewind before the second user message, history and preview, branch listing, switching back to the original final tip, then history and preview. Both visible paths follow **six → two → six** messages across three distinct physical sessions. A read-only audit of the closed SQLite database confirms exact original event JSON, 7/8/9 persisted events, 6/2/6 active and FTS rows, clean index state, both leaf controls and generation-derived display identities. Gateway main-thread V8 coverage records two selected-query preparations and eight row yields across the two mutations; all seven targeted owner/branch sites executed. The task-owned Gateway, client, seed and Doctor process groups, socket and temporary fixture are gone. CPU/coverage evidence is retained; no baseline live latency or memory comparison is claimed.

Two failed harness attempts are retained: the first expected validation-mode counters during a fresh Doctor import; the second expected an array instead of the current pending-input page object. Both were corrected from the actual producer contracts, preserving exact assertions and adding a direct migration-manifest validation check. No product change, timeout increase or weakened behavior check was needed. Before execution, independent review also corrected failure-path database archival so diagnostic state survived a failed client assertion.
