### PR TITLE
refactor(status): consolidate report formatting ownership

### DIFF
--- a/src/commands/status-all/format.test.ts
+++ b/src/commands/status-all/format.test.ts
@@ -3,37 +3,34 @@ import { describe, expect, it } from "vitest";
 import {
   baseStatusExpectedUpdateChannelInfo,
   baseStatusExpectedUpdateChannelLabel,
+  baseStatusOverviewSurface,
+  getStatusOverviewRowValue,
 } from "../status.test-support.ts";
 import {
-  buildStatusGatewaySurfaceValues,
-  buildStatusOverviewRows,
   buildStatusOverviewSurfaceRows,
   buildStatusUpdateSurface,
   buildGatewayStatusJsonPayload,
-  buildGatewayStatusSummaryParts,
-  formatGatewaySelfSummary,
-  resolveStatusDashboardUrl,
-  formatStatusDashboardValue,
-  formatStatusServiceValue,
-  formatStatusTailscaleValue,
 } from "./format.js";
 
 describe("status-all format", () => {
   it("formats gateway self summary consistently", () => {
     expect(
-      formatGatewaySelfSummary({
-        host: "gateway-host",
-        ip: "100.64.0.1",
-        version: "1.2.3",
-        platform: "linux",
+      getStatusOverviewRowValue("Gateway self", {
+        gatewaySelf: {
+          host: "gateway-host",
+          ip: "100.64.0.1",
+          version: "1.2.3",
+          platform: "linux",
+        },
       }),
     ).toBe("gateway-host (100.64.0.1) app 1.2.3 linux");
-    expect(formatGatewaySelfSummary(null)).toBeNull();
+    expect(getStatusOverviewRowValue("Gateway self", { gatewaySelf: null })).toBeUndefined();
   });
 
   it("builds gateway summary parts for fallback remote targets", () => {
     expect(
-      buildGatewayStatusSummaryParts({
+      getStatusOverviewRowValue("Gateway", {
+        gatewaySelf: null,
         gatewayMode: "remote",
         remoteUrlMissing: true,
         gatewayConnection: {
@@ -44,20 +41,27 @@ describe("status-all format", () => {
         gatewayProbe: null,
         gatewayProbeAuth: { token: "tok" },
       }),
-    ).toEqual({
-      targetText: "fallback ws://127.0.0.1:18789",
-      targetTextWithSource:
-        "fallback ws://127.0.0.1:18789 (missing gateway.remote.url (fallback local))",
-      reachText: "misconfigured (remote.url missing)",
-      authText: "",
-      modeLabel: "remote (remote.url missing)",
-    });
+    ).toBe(
+      "remote (remote.url missing) · fallback ws://127.0.0.1:18789 (missing gateway.remote.url (fallback local)) · misconfigured (remote.url missing)",
+    );
   });
 
   it("formats dashboard values consistently", () => {
-    expect(formatStatusDashboardValue("https://openclaw.local")).toBe("https://openclaw.local");
-    expect(formatStatusDashboardValue("")).toBe("disabled");
-    expect(formatStatusDashboardValue(null)).toBe("disabled");
+    expect(
+      getStatusOverviewRowValue("Dashboard", {
+        advertisedControlUiLinks: { httpUrl: "https://openclaw.local", wsUrl: "" },
+      }),
+    ).toBe("https://openclaw.local");
+    expect(
+      getStatusOverviewRowValue("Dashboard", {
+        advertisedControlUiLinks: { httpUrl: "", wsUrl: "" },
+      }),
+    ).toBe("disabled");
+    expect(
+      getStatusOverviewRowValue("Dashboard", {
+        cfg: { gateway: { controlUi: { enabled: false } } },
+      }),
+    ).toBe("disabled");
   });
 
   it("builds shared update surface values", () => {
@@ -93,7 +97,7 @@ describe("status-all format", () => {
 
   it("resolves dashboard urls from gateway config", () => {
     expect(
-      resolveStatusDashboardUrl({
+      getStatusOverviewRowValue("Dashboard", {
         cfg: {
           gateway: {
             bind: "loopback",
@@ -103,7 +107,7 @@ describe("status-all format", () => {
       }),
     ).toBe("http://127.0.0.1:18789/ui/");
     expect(
-      resolveStatusDashboardUrl({
+      getStatusOverviewRowValue("Dashboard", {
         cfg: {
           gateway: {
             bind: "loopback",
@@ -113,36 +117,38 @@ describe("status-all format", () => {
       }),
     ).toBe("https://127.0.0.1:18789/");
     expect(
-      resolveStatusDashboardUrl({
+      getStatusOverviewRowValue("Dashboard", {
         cfg: {
           gateway: {
             controlUi: { enabled: false },
           },
         },
       }),
-    ).toBeNull();
+    ).toBe("disabled");
   });
 
   it("formats tailscale values for terse and detailed views", () => {
     expect(
-      formatStatusTailscaleValue({
+      getStatusOverviewRowValue("Tailscale exposure", {
         tailscaleMode: "serve",
-        dnsName: "box.tail.ts.net",
-        httpsUrl: "https://box.tail.ts.net",
+        tailscaleDns: "box.tail.ts.net",
+        tailscaleHttpsUrl: "https://box.tail.ts.net",
       }),
     ).toBe("serve · box.tail.ts.net · https://box.tail.ts.net");
     expect(
-      formatStatusTailscaleValue({
+      getStatusOverviewRowValue("Tailscale exposure", {
         tailscaleMode: "funnel",
-        backendState: "Running",
+        tailscaleDns: null,
+        tailscaleHttpsUrl: null,
+        tailscaleBackendState: "Running",
         includeBackendStateWhenOn: true,
       }),
     ).toBe("funnel · Running · magicdns unknown");
     expect(
-      formatStatusTailscaleValue({
+      getStatusOverviewRowValue("Tailscale exposure", {
         tailscaleMode: "off",
-        backendState: "Stopped",
-        dnsName: "box.tail.ts.net",
+        tailscaleBackendState: "Stopped",
+        tailscaleDns: "box.tail.ts.net",
         includeBackendStateWhenOff: true,
         includeDnsNameWhenOff: true,
       }),
@@ -151,27 +157,33 @@ describe("status-all format", () => {
 
   it("formats service values across short and detailed runtime surfaces", () => {
     expect(
-      formatStatusServiceValue({
-        label: "LaunchAgent",
-        installed: false,
-        loadedText: "loaded",
+      getStatusOverviewRowValue("Gateway service", {
+        gatewayService: {
+          label: "LaunchAgent",
+          installed: false,
+          loadedText: "loaded",
+        },
       }),
     ).toBe("LaunchAgent not installed");
     expect(
-      formatStatusServiceValue({
-        label: "LaunchAgent",
-        installed: true,
-        managedByOpenClaw: true,
-        loadedText: "loaded",
-        runtimeShort: "running",
+      getStatusOverviewRowValue("Gateway service", {
+        gatewayService: {
+          label: "LaunchAgent",
+          installed: true,
+          managedByOpenClaw: true,
+          loadedText: "loaded",
+          runtimeShort: "running",
+        },
       }),
     ).toBe("LaunchAgent installed · loaded · running");
     expect(
-      formatStatusServiceValue({
-        label: "systemd",
-        installed: true,
-        loadedText: "not loaded",
-        runtime: { status: "failed", pid: 42 },
+      getStatusOverviewRowValue("Gateway service", {
+        gatewayService: {
+          label: "systemd",
+          installed: true,
+          loadedText: "not loaded",
+          runtime: { status: "failed", pid: 42 },
+        },
       }),
     ).toBe("systemd not loaded · failed (pid 42)");
   });
@@ -205,10 +217,12 @@ describe("status-all format", () => {
     },
   ])("keeps inspection errors visible: $expected", ({ expected, ...service }) => {
     expect(
-      formatStatusServiceValue({
-        ...service,
-        label: "LaunchAgent",
-        loadState: { status: "unknown", detail: "permission denied" },
+      getStatusOverviewRowValue("Gateway service", {
+        gatewayService: {
+          ...service,
+          label: "LaunchAgent",
+          loadState: { status: "unknown", detail: "permission denied" },
+        },
       }),
     ).toBe(expected);
   });
@@ -246,7 +260,7 @@ describe("status-all format", () => {
       urlSource: "cli --url",
     };
 
-    const summary = buildGatewayStatusSummaryParts({
+    const summary = getStatusOverviewRowValue("Gateway", {
       gatewayMode: "remote",
       remoteUrlMissing: false,
       gatewayConnection,
@@ -264,6 +278,7 @@ describe("status-all format", () => {
     });
     const output = JSON.stringify({ summary, json });
 
+    expect(summary).toContain("gateway.example/ws");
     expect(output).toContain("gateway.example/ws");
     expect(output).not.toContain("password");
     expect(output).not.toContain("secret");
@@ -273,7 +288,9 @@ describe("status-all format", () => {
 
   it("builds shared gateway surface values for node and gateway views", () => {
     expect(
-      buildStatusGatewaySurfaceValues({
+      buildStatusOverviewSurfaceRows({
+        ...baseStatusOverviewSurface,
+        agentsValue: "2 total",
         cfg: { gateway: { bind: "loopback" } },
         gatewayMode: "remote",
         remoteUrlMissing: false,
@@ -300,20 +317,29 @@ describe("status-all format", () => {
         },
         decorateOk: (value) => `ok(${value})`,
         decorateWarn: (value) => `warn(${value})`,
-      }),
-    ).toEqual({
-      dashboardUrl: "http://127.0.0.1:18789/",
-      gatewayValue:
-        "remote · wss://gateway.example.com (config) · ok(reachable 123ms) · auth token · gateway app 1.2.3",
-      gatewaySelfValue: "gateway app 1.2.3",
-      gatewayServiceValue: "LaunchAgent installed · loaded · running",
-      nodeServiceValue: "node loaded · running (pid 42)",
-    });
+      }).filter((row) =>
+        ["Dashboard", "Gateway", "Gateway self", "Gateway service", "Node service"].includes(
+          row.Item,
+        ),
+      ),
+    ).toEqual([
+      { Item: "Dashboard", Value: "http://127.0.0.1:18789/" },
+      {
+        Item: "Gateway",
+        Value:
+          "remote · wss://gateway.example.com (config) · ok(reachable 123ms) · auth token · gateway app 1.2.3",
+      },
+      { Item: "Gateway self", Value: "gateway app 1.2.3" },
+      { Item: "Gateway service", Value: "LaunchAgent installed · loaded · running" },
+      { Item: "Node service", Value: "node loaded · running (pid 42)" },
+    ]);
   });
 
   it("prefers advertised Control UI links for dashboard values", () => {
     expect(
-      buildStatusGatewaySurfaceValues({
+      buildStatusOverviewSurfaceRows({
+        ...baseStatusOverviewSurface,
+        agentsValue: "2 total",
         cfg: { gateway: { bind: "lan" } },
         advertisedControlUiLinks: {
           httpUrl: "http://10.211.55.3:18789/",
@@ -339,13 +365,15 @@ describe("status-all format", () => {
           installed: true,
           loadedText: "loaded",
         },
-      }).dashboardUrl,
+      }).find((row) => row.Item === "Dashboard")?.Value,
     ).toBe("http://10.211.55.3:18789/");
   });
 
   it("prefers node-only gateway values when present", () => {
     expect(
-      buildStatusGatewaySurfaceValues({
+      buildStatusOverviewSurfaceRows({
+        ...baseStatusOverviewSurface,
+        agentsValue: "2 total",
         cfg: { gateway: { controlUi: { enabled: false } } },
         gatewayMode: "local",
         remoteUrlMissing: false,
@@ -370,42 +398,48 @@ describe("status-all format", () => {
         nodeOnlyGateway: {
           gatewayValue: "node → remote.example:18789 · no local gateway",
         },
-      }),
-    ).toEqual({
-      dashboardUrl: null,
-      gatewayValue: "node → remote.example:18789 · no local gateway",
-      gatewaySelfValue: null,
-      gatewayServiceValue: "LaunchAgent not installed",
-      nodeServiceValue: "node loaded · running",
-    });
+      }).filter((row) =>
+        ["Dashboard", "Gateway", "Gateway self", "Gateway service", "Node service"].includes(
+          row.Item,
+        ),
+      ),
+    ).toEqual([
+      { Item: "Dashboard", Value: "disabled" },
+      { Item: "Gateway", Value: "node → remote.example:18789 · no local gateway" },
+      { Item: "Gateway service", Value: "LaunchAgent not installed" },
+      { Item: "Node service", Value: "node loaded · running" },
+    ]);
   });
 
   it("builds overview rows with shared ordering", () => {
     expect(
-      buildStatusOverviewRows({
+      buildStatusOverviewSurfaceRows({
+        ...baseStatusOverviewSurface,
         prefixRows: [{ Item: "Version", Value: "1.0.0" }],
-        dashboardValue: "https://openclaw.local",
-        tailscaleValue: "serve · https://tail.example",
-        channelLabel: "stable",
-        gitLabel: "main @ v1.0.0",
+        advertisedControlUiLinks: { httpUrl: "https://openclaw.local", wsUrl: "" },
+        gatewayMode: "local",
+        gatewayConnection: { url: "ws://127.0.0.1:18789" },
+        gatewayProbe: { connectLatencyMs: 12 },
+        gatewaySelf: { host: "gateway-host" },
+        gatewayService: { label: "launchd", installed: true, loadedText: "loaded" },
+        nodeService: { label: "node", installed: true, loadedText: "loaded" },
         updateValue: "up to date",
-        gatewayValue: "local · reachable",
-        gatewayAuthWarning: "warning",
+        gatewayAuthWarningValue: "warning",
         middleRows: [{ Item: "Security", Value: "Run: openclaw security audit --deep" }],
-        gatewaySelfValue: "gateway-host",
-        gatewayServiceValue: "launchd loaded",
-        nodeServiceValue: "node loaded",
         agentsValue: "2 total",
         suffixRows: [{ Item: "Secrets", Value: "none" }],
       }),
     ).toEqual([
       { Item: "Version", Value: "1.0.0" },
       { Item: "Dashboard", Value: "https://openclaw.local" },
-      { Item: "Tailscale exposure", Value: "serve · https://tail.example" },
-      { Item: "Channel", Value: "stable" },
-      { Item: "Git", Value: "main @ v1.0.0" },
+      { Item: "Tailscale exposure", Value: "serve · box.tail.ts.net · https://box.tail.ts.net" },
+      { Item: "Channel", Value: baseStatusExpectedUpdateChannelLabel },
+      { Item: "Git", Value: "main · tag v1.2.3" },
       { Item: "Update", Value: "up to date" },
-      { Item: "Gateway", Value: "local · reachable" },
+      {
+        Item: "Gateway",
+        Value: "local · ws://127.0.0.1:18789 · reachable 12ms · auth token · gateway-host",
+      },
       { Item: "Gateway auth warning", Value: "warning" },
       { Item: "Security", Value: "Run: openclaw security audit --deep" },
       { Item: "Gateway self", Value: "gateway-host" },

--- a/src/commands/status-all/format.ts
+++ b/src/commands/status-all/format.ts
@@ -108,13 +108,13 @@ export function buildStatusUpdateSurface(params: {
 }
 
 /** Formats missing dashboard URLs as disabled instead of leaking empty/null into status rows. */
-export function formatStatusDashboardValue(value: string | null | undefined): string {
+function formatStatusDashboardValue(value: string | null | undefined): string {
   const trimmed = normalizeOptionalString(value);
   return trimmed && trimmed.length > 0 ? trimmed : "disabled";
 }
 
 /** Formats Tailscale exposure in a compact, warning-aware status row value. */
-export function formatStatusTailscaleValue(params: {
+function formatStatusTailscaleValue(params: {
   tailscaleMode: string;
   dnsName?: string | null;
   httpsUrl?: string | null;
@@ -157,7 +157,7 @@ export function formatStatusTailscaleValue(params: {
 }
 
 /** Formats launchd/systemd service state into one row-friendly string. */
-export function formatStatusServiceValue(params: StatusManagedService): string {
+function formatStatusServiceValue(params: StatusManagedService): string {
   const inspectionDetail =
     params.loadState?.status === "unknown"
       ? params.loadState.detail
@@ -186,7 +186,7 @@ export function formatStatusServiceValue(params: StatusManagedService): string {
 }
 
 /** Returns the dashboard URL when the Control UI is enabled for the current gateway binding. */
-export function resolveStatusDashboardUrl(params: {
+function resolveStatusDashboardUrl(params: {
   cfg: Pick<OpenClawConfig, "gateway">;
 }): string | null {
   if (!(params.cfg.gateway?.controlUi?.enabled ?? true)) {
@@ -202,7 +202,7 @@ export function resolveStatusDashboardUrl(params: {
 }
 
 /** Builds the ordered overview rows shared by status command variants. */
-export function buildStatusOverviewRows(params: {
+function buildStatusOverviewRows(params: {
   prefixRows?: StatusOverviewRow[];
   dashboardValue: string;
   tailscaleValue: string;
@@ -342,7 +342,7 @@ export function buildStatusOverviewSurfaceRows(params: {
 }
 
 /** Returns which gateway auth material was actually used for the probe. */
-export function formatGatewayAuthUsed(
+function formatGatewayAuthUsed(
   auth: {
     token?: string;
     password?: string;
@@ -363,7 +363,7 @@ export function formatGatewayAuthUsed(
 }
 
 /** Formats gateway self metadata returned by the health endpoint. */
-export function formatGatewaySelfSummary(gatewaySelf: StatusGatewaySelf): string | null {
+function formatGatewaySelfSummary(gatewaySelf: StatusGatewaySelf): string | null {
   return gatewaySelf?.host || gatewaySelf?.ip || gatewaySelf?.version || gatewaySelf?.platform
     ? [
         gatewaySelf.host ? gatewaySelf.host : null,
@@ -377,7 +377,7 @@ export function formatGatewaySelfSummary(gatewaySelf: StatusGatewaySelf): string
 }
 
 /** Builds gateway target, reachability, auth, and mode strings for text status output. */
-export function buildGatewayStatusSummaryParts(params: {
+function buildGatewayStatusSummaryParts(params: {
   gatewayMode: "local" | "remote";
   remoteUrlMissing: boolean;
   gatewayConnection: StatusGatewayConnection;
@@ -417,7 +417,7 @@ export function buildGatewayStatusSummaryParts(params: {
 }
 
 /** Builds gateway/dashboard/service values for overview rows. */
-export function buildStatusGatewaySurfaceValues(params: {
+function buildStatusGatewaySurfaceValues(params: {
   cfg: Pick<OpenClawConfig, "gateway">;
   advertisedControlUiLinks?: { httpUrl: string; wsUrl: string };
   gatewayMode: "local" | "remote";

--- a/src/commands/status.cold-imports.test.ts
+++ b/src/commands/status.cold-imports.test.ts
@@ -54,6 +54,6 @@ describe("status cold imports", () => {
     ]);
 
     expect(scan.scanStatus).toBeTypeOf("function");
-    expect(textRuntime.formatPluginCompatibilityNotice).toBeTypeOf("function");
+    expect(textRuntime.buildStatusCommandReportData).toBeTypeOf("function");
   });
 });

--- a/src/commands/status.command-report-data.test.ts
+++ b/src/commands/status.command-report-data.test.ts
@@ -1,10 +1,17 @@
 // Status command report data tests cover report data assembly from shared status fixtures.
 import { expectDefined } from "@openclaw/normalization-core";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { buildStatusCommandReportData } from "./status.command-report-data.ts";
 import { createStatusCommandReportDataParams } from "./status.test-support.ts";
 
 describe("buildStatusCommandReportData", () => {
+  beforeEach(() => {
+    vi.stubEnv("OPENCLAW_PROFILE", undefined);
+    vi.stubEnv("OPENCLAW_CONTAINER_HINT", undefined);
+  });
+  afterEach(() => vi.unstubAllEnvs());
+
   it("builds report inputs from shared status surfaces", async () => {
     const baseParams = createStatusCommandReportDataParams();
     const result = await buildStatusCommandReportData(
@@ -28,6 +35,8 @@ describe("buildStatusCommandReportData", () => {
                 updatedAt: 1,
                 age: 5_000,
                 model: "gpt-5.4",
+                inputTokens: 3_000,
+                cacheRead: 1_000,
               },
             ],
           },
@@ -39,20 +48,20 @@ describe("buildStatusCommandReportData", () => {
       Item: "OS",
       Value: "macOS · node " + process.versions.node,
     });
-    expect(result.taskMaintenanceHint).toBe(
-      "Task maintenance: cmd:openclaw tasks maintenance --apply",
-    );
-    expect(result.pluginCompatibilityLines).toEqual(["  warn(WARN) legacy"]);
-    expect(result.pairingRecoveryLines[0]).toBe("warn(Gateway pairing approval required.)");
+    expect(result.taskMaintenanceHint).toBe("Task maintenance: openclaw tasks maintenance --apply");
+    expect(result.pluginCompatibilityLines.map(stripAnsi)).toEqual(["  WARN a legacy"]);
+    const pairingTitle = expectDefined(result.pairingRecoveryLines[0], "pairing recovery title");
+    expect(stripAnsi(pairingTitle)).toBe("Gateway pairing approval required.");
     expect(result.modelSelectionLines).toEqual([]);
     expect(result.channelsRows[0]?.Channel).toBe("QuietChat");
-    expect(result.sessionsRows[0]?.Cache).toBe("cache ok");
-    expect(result.healthRows?.[0]).toEqual({
+    expect(result.sessionsRows[0]?.Cache).toBe("25% hit · read 1.0k");
+    const gatewayHealth = expectDefined(result.healthRows?.[0], "Gateway health row");
+    expect({ ...gatewayHealth, Status: stripAnsi(gatewayHealth.Status) }).toEqual({
       Item: "Gateway",
-      Status: "ok(reachable)",
+      Status: "reachable",
       Detail: "42ms",
     });
-    expect(result.footerLines.at(-1)).toBe("  Need to test channels? cmd:openclaw status --deep");
+    expect(result.footerLines.at(-1)).toBe("  Need to test channels? openclaw status --deep");
   });
 
   it("shows skipped audit text when fast status omits the security audit", async () => {
@@ -62,9 +71,9 @@ describe("buildStatusCommandReportData", () => {
       }),
     );
 
-    expect(result.securityAuditLines).toEqual([
-      "muted(Skipped in fast status. Full report: cmd:openclaw security audit)",
-      "muted(Deep probe: cmd:openclaw status --deep)",
+    expect(result.securityAuditLines.map(stripAnsi)).toEqual([
+      "Skipped in fast status. Full report: openclaw security audit",
+      "Deep probe: openclaw status --deep",
     ]);
   });
 
@@ -85,8 +94,8 @@ describe("buildStatusCommandReportData", () => {
       createStatusCommandReportDataParams({ summary, opts: {} }),
     );
 
-    expect(deepResult.retainedLostTaskLine).toBe(
-      "muted(1 lost task retained until 2026-03-30T01:00:00.000Z)",
+    expect(stripAnsi(expectDefined(deepResult.retainedLostTaskLine, "retained lost task"))).toBe(
+      "1 lost task retained until 2026-03-30T01:00:00.000Z",
     );
     expect(fastResult.retainedLostTaskLine).toBeNull();
   });
@@ -106,7 +115,9 @@ describe("buildStatusCommandReportData", () => {
       }),
     );
 
-    expect(result.retainedLostTaskLine).toBe("muted(2 lost tasks retained until cleanupAfter)");
+    expect(stripAnsi(expectDefined(result.retainedLostTaskLine, "retained lost task"))).toBe(
+      "2 lost tasks retained until cleanupAfter",
+    );
   });
 
   it("adds pinned-session model selection lines", async () => {

--- a/src/commands/status.command-report-data.ts
+++ b/src/commands/status.command-report-data.ts
@@ -3,12 +3,22 @@
 
 import { timestampMsToIsoString } from "@openclaw/normalization-core/number-coercion";
 import type { ConnectPairingRequiredReason } from "../../packages/gateway-protocol/src/connect-error-details.js";
-import type { RenderTableOptions, TableColumn } from "../../packages/terminal-core/src/table.js";
+import { renderTable, type TableColumn } from "../../packages/terminal-core/src/table.js";
+import { theme } from "../../packages/terminal-core/src/theme.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import { formatTimeAgo } from "../infra/format-time/format-relative.ts";
 import type { HeartbeatEventPayload } from "../infra/heartbeat-events.js";
 import type { resolveOsSummary } from "../infra/os-summary.js";
+import {
+  resolveMemoryCacheSummary,
+  resolveMemoryFtsState,
+  resolveMemoryVectorState,
+} from "../memory-host-sdk/status.js";
+import { formatPluginCompatibilityNotice } from "../plugins/status-compatibility.js";
 import type { PluginCompatibilityNotice } from "../plugins/status.js";
 import type { SecurityAuditReport } from "../security/audit.js";
-import type { SessionStatus, StatusSummary } from "../status/types.js";
+import type { StatusSummary } from "../status/types.js";
+import { formatHealthChannelLines } from "./health-format.js";
 import type { HealthSummary } from "./health.js";
 import {
   buildStatusChannelsTableRows,
@@ -28,77 +38,64 @@ import {
   buildStatusSystemEventsRows,
   buildStatusSystemEventsTrailer,
   statusHealthColumns,
-  type StatusMemoryStateResolvers,
 } from "./status.command-sections.js";
+import {
+  formatKTokens,
+  formatPromptCacheCompact,
+  formatTokensCompact,
+  shortenText,
+} from "./status.format.js";
 import type { MemoryPluginStatus, MemoryStatusSnapshot } from "./status.scan.shared.js";
+import { formatUpdateAvailableHint } from "./status.update.js";
 
 /** Builds all table rows, section lines, and footer data needed by the status report renderer. */
-export async function buildStatusCommandReportData(
-  params: {
-    env: NodeJS.ProcessEnv;
-    opts: {
-      deep?: boolean;
-      verbose?: boolean;
-    };
-    surface: StatusOverviewSurface;
-    osSummary: ReturnType<typeof resolveOsSummary>;
-    summary: StatusSummary;
-    securityAudit?: SecurityAuditReport;
-    health?: HealthSummary;
-    usageLines?: string[];
-    lastHeartbeat: HeartbeatEventPayload | null;
-    agentStatus: {
-      defaultId?: string | null;
-      bootstrapPendingCount: number;
-      totalSessions: number;
-      agents: AgentLocalStatus[];
-    };
-    channels: {
-      rows: Array<{
-        id: string;
-        label: string;
-        enabled: boolean;
-        state: "ok" | "warn" | "off" | "setup";
-        detail: string;
-      }>;
-    };
-    channelIssues: Array<{
-      channel: string;
-      message: string;
+export async function buildStatusCommandReportData(params: {
+  env: NodeJS.ProcessEnv;
+  opts: {
+    deep?: boolean;
+    verbose?: boolean;
+  };
+  surface: StatusOverviewSurface;
+  osSummary: ReturnType<typeof resolveOsSummary>;
+  summary: StatusSummary;
+  securityAudit?: SecurityAuditReport;
+  health?: HealthSummary;
+  usageLines?: string[];
+  lastHeartbeat: HeartbeatEventPayload | null;
+  agentStatus: {
+    defaultId?: string | null;
+    bootstrapPendingCount: number;
+    totalSessions: number;
+    agents: AgentLocalStatus[];
+  };
+  channels: {
+    rows: Array<{
+      id: string;
+      label: string;
+      enabled: boolean;
+      state: "ok" | "warn" | "off" | "setup";
+      detail: string;
     }>;
-    memory: MemoryStatusSnapshot | null;
-    memoryPlugin: MemoryPluginStatus;
-    pluginCompatibility: PluginCompatibilityNotice[];
-    pairingRecovery: {
-      requestId: string | null;
-      reason: ConnectPairingRequiredReason | null;
-      remediationHint: string | null;
-    } | null;
-    tableWidth: number;
-    ok: (value: string) => string;
-    warn: (value: string) => string;
-    muted: (value: string) => string;
-    shortenText: (value: string, maxLen: number) => string;
-    formatCliCommand: (value: string) => string;
-    formatTimeAgo: (ageMs: number) => string;
-    formatKTokens: (value: number) => string;
-    formatTokensCompact: (value: SessionStatus) => string;
-    formatPromptCacheCompact: (value: SessionStatus) => string | null;
-    formatHealthChannelLines: (summary: HealthSummary, opts: { accountMode: "all" }) => string[];
-    formatPluginCompatibilityNotice: (notice: PluginCompatibilityNotice) => string;
-    formatUpdateAvailableHint: (update: StatusOverviewSurface["update"]) => string | null;
-    accentDim: (value: string) => string;
-    updateValue?: string;
-    updateRestartValue?: string | null;
-    theme: {
-      heading: (value: string) => string;
-      muted: (value: string) => string;
-      warn: (value: string) => string;
-      error: (value: string) => string;
-    };
-    renderTable: (input: RenderTableOptions) => string;
-  } & StatusMemoryStateResolvers,
-) {
+  };
+  channelIssues: Array<{
+    channel: string;
+    message: string;
+  }>;
+  memory: MemoryStatusSnapshot | null;
+  memoryPlugin: MemoryPluginStatus;
+  pluginCompatibility: PluginCompatibilityNotice[];
+  pairingRecovery: {
+    requestId: string | null;
+    reason: ConnectPairingRequiredReason | null;
+    remediationHint: string | null;
+  } | null;
+  tableWidth: number;
+  updateValue?: string;
+  updateRestartValue?: string | null;
+}) {
+  const ok = (value: string) => theme.success(value);
+  const warn = (value: string) => theme.warn(value);
+  const muted = (value: string) => theme.muted(value);
   const overviewRows = buildStatusCommandOverviewRows({
     env: params.env,
     opts: params.opts,
@@ -111,14 +108,14 @@ export async function buildStatusCommandReportData(
     memory: params.memory,
     memoryPlugin: params.memoryPlugin,
     pluginCompatibility: params.pluginCompatibility,
-    ok: params.ok,
-    warn: params.warn,
-    muted: params.muted,
-    formatTimeAgo: params.formatTimeAgo,
-    formatKTokens: params.formatKTokens,
-    resolveMemoryVectorState: params.resolveMemoryVectorState,
-    resolveMemoryFtsState: params.resolveMemoryFtsState,
-    resolveMemoryCacheSummary: params.resolveMemoryCacheSummary,
+    ok,
+    warn,
+    muted,
+    formatTimeAgo,
+    formatKTokens,
+    resolveMemoryVectorState,
+    resolveMemoryFtsState,
+    resolveMemoryCacheSummary,
     updateValue: params.updateValue,
     updateRestartValue: params.updateRestartValue,
   });
@@ -136,98 +133,98 @@ export async function buildStatusCommandReportData(
   const securityAuditLines = params.securityAudit
     ? buildStatusSecurityAuditLines({
         securityAudit: params.securityAudit,
-        theme: params.theme,
-        shortenText: params.shortenText,
-        formatCliCommand: params.formatCliCommand,
+        theme,
+        shortenText,
+        formatCliCommand,
       })
     : [
-        params.theme.muted(
-          `Skipped in fast status. Full report: ${params.formatCliCommand("openclaw security audit")}`,
+        theme.muted(
+          `Skipped in fast status. Full report: ${formatCliCommand("openclaw security audit")}`,
         ),
-        params.theme.muted(`Deep probe: ${params.formatCliCommand("openclaw status --deep")}`),
+        theme.muted(`Deep probe: ${formatCliCommand("openclaw status --deep")}`),
       ];
   const retainedLost = params.summary.taskAuditRetainedLost;
   // Lost task retention is operational noise unless the user requested deep/verbose status.
   const retainedLostLine =
     (params.opts.deep || params.opts.verbose) && retainedLost && retainedLost.count > 0
-      ? params.theme.muted(
+      ? theme.muted(
           `${retainedLost.count} lost task${retainedLost.count === 1 ? "" : "s"} retained until ${timestampMsToIsoString(retainedLost.nextCleanupAfter) ?? "cleanupAfter"}`,
         )
       : null;
 
   return {
-    heading: params.theme.heading,
-    muted: params.theme.muted,
-    renderTable: params.renderTable,
+    heading: theme.heading,
+    muted: theme.muted,
+    renderTable,
     width: params.tableWidth,
     overviewRows,
     showTaskMaintenanceHint: params.summary.taskAudit.errors > 0,
-    taskMaintenanceHint: `Task maintenance: ${params.formatCliCommand("openclaw tasks maintenance --apply")}`,
+    taskMaintenanceHint: `Task maintenance: ${formatCliCommand("openclaw tasks maintenance --apply")}`,
     taskRegistryMigrationHint: params.summary.tasks.warning
-      ? params.theme.warn(params.summary.tasks.warning)
+      ? theme.warn(params.summary.tasks.warning)
       : null,
     retainedLostTaskLine: retainedLostLine,
     pluginCompatibilityLines: buildStatusPluginCompatibilityLines({
       notices: params.pluginCompatibility,
-      formatNotice: params.formatPluginCompatibilityNotice,
-      warn: params.theme.warn,
-      muted: params.theme.muted,
+      formatNotice: formatPluginCompatibilityNotice,
+      warn: theme.warn,
+      muted: theme.muted,
     }),
     pairingRecoveryLines: buildStatusPairingRecoveryLines({
       pairingRecovery: params.pairingRecovery,
-      warn: params.theme.warn,
-      muted: params.theme.muted,
-      formatCliCommand: params.formatCliCommand,
+      warn: theme.warn,
+      muted: theme.muted,
+      formatCliCommand,
     }),
     modelSelectionLines: buildStatusModelSelectionLines({
       recent: params.summary.sessions.recent,
-      shortenText: params.shortenText,
-      warn: params.theme.warn,
-      muted: params.theme.muted,
+      shortenText,
+      warn: theme.warn,
+      muted: theme.muted,
     }),
     securityAuditLines,
     channelsColumns: statusChannelsTableColumns,
     channelsRows: buildStatusChannelsTableRows({
       rows: params.channels.rows,
       channelIssues: params.channelIssues,
-      ok: params.ok,
-      warn: params.warn,
-      muted: params.muted,
-      accentDim: params.accentDim,
-      formatIssueMessage: (message) => params.shortenText(message, 84),
+      ok,
+      warn,
+      muted,
+      accentDim: theme.accentDim,
+      formatIssueMessage: (message) => shortenText(message, 84),
     }),
     sessionsColumns,
     sessionsRows: buildStatusSessionsRows({
       recent: params.summary.sessions.recent,
       verbose: params.opts.verbose,
-      shortenText: params.shortenText,
-      formatTimeAgo: params.formatTimeAgo,
-      formatTokensCompact: params.formatTokensCompact,
-      formatPromptCacheCompact: params.formatPromptCacheCompact,
-      muted: params.muted,
+      shortenText,
+      formatTimeAgo,
+      formatTokensCompact,
+      formatPromptCacheCompact,
+      muted,
     }),
     systemEventsRows: buildStatusSystemEventsRows({
       queuedSystemEvents: params.summary.queuedSystemEvents,
     }),
     systemEventsTrailer: buildStatusSystemEventsTrailer({
       queuedSystemEvents: params.summary.queuedSystemEvents,
-      muted: params.muted,
+      muted,
     }),
     healthColumns: params.health ? statusHealthColumns : undefined,
     healthRows: params.health
       ? buildStatusHealthRows({
           health: params.health,
-          formatHealthChannelLines: params.formatHealthChannelLines,
-          ok: params.ok,
-          warn: params.warn,
-          muted: params.muted,
+          formatHealthChannelLines,
+          ok,
+          warn,
+          muted,
         })
       : undefined,
     usageLines: params.usageLines,
     footerLines: buildStatusFooterLines({
-      updateHint: params.formatUpdateAvailableHint(params.surface.update),
-      warn: params.theme.warn,
-      formatCliCommand: params.formatCliCommand,
+      updateHint: formatUpdateAvailableHint(params.surface.update),
+      warn: theme.warn,
+      formatCliCommand,
       nodeOnlyGateway: params.surface.nodeOnlyGateway,
       gatewayReachable: params.surface.gatewayReachable,
     }),

--- a/src/commands/status.command-sections.ts
+++ b/src/commands/status.command-sections.ts
@@ -276,7 +276,7 @@ export function buildStatusHealthRows(params: {
   warn: (value: string) => string;
   muted: (value: string) => string;
 }) {
-  const rows: Array<Record<string, string>> = [
+  const rows: Array<{ Item: string; Status: string; Detail: string }> = [
     {
       Item: "Gateway",
       Status: params.ok("reachable"),

--- a/src/commands/status.command.text-runtime.ts
+++ b/src/commands/status.command.text-runtime.ts
@@ -1,48 +1,12 @@
 // Text-mode status runtime barrel.
-// Kept separate from command orchestration so JSON/fast status does not import table/theme helpers.
+// Command orchestration loads this owner only for text diagnostics and reports.
 
-export { formatCliCommand } from "../cli/command-format.js";
+export { getTerminalTableWidth } from "../../packages/terminal-core/src/table.js";
+export { theme } from "../../packages/terminal-core/src/theme.js";
 export { info } from "../globals.js";
 export { formatUsageReportLines } from "../infra/provider-usage.format.js";
 export { formatTimeAgo } from "../infra/format-time/format-relative.ts";
-export { formatGitInstallLabel } from "../infra/update-check.js";
-export {
-  resolveMemoryCacheSummary,
-  resolveMemoryFtsState,
-  resolveMemoryVectorState,
-} from "../memory-host-sdk/status.js";
-export {
-  formatPluginCompatibilityNotice,
-  summarizePluginCompatibility,
-} from "../plugins/status-compatibility.js";
-export { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
-export { theme } from "../../packages/terminal-core/src/theme.js";
-export { formatHealthChannelLines } from "./health-format.js";
-export { groupChannelIssuesByChannel } from "./status-all/channel-issues.js";
-export {
-  buildStatusChannelsTableRows,
-  statusChannelsTableColumns,
-} from "./status-all/channels-table.js";
-export {
-  buildStatusGatewaySurfaceValues,
-  buildStatusOverviewSurfaceRows,
-  buildStatusOverviewRows,
-  buildStatusUpdateSurface,
-  buildGatewayStatusSummaryParts,
-  formatStatusDashboardValue,
-  formatGatewayAuthUsed,
-  formatGatewaySelfSummary,
-  resolveStatusUpdateChannelInfo,
-  formatStatusServiceValue,
-  formatStatusTailscaleValue,
-  resolveStatusDashboardUrl,
-} from "./status-all/format.js";
-export {
-  formatDuration,
-  formatKTokens,
-  formatPromptCacheCompact,
-  formatStatusConfigDiagnosticEntries,
-  formatTokensCompact,
-  shortenText,
-} from "./status.format.js";
-export { formatUpdateAvailableHint } from "./status.update.js";
+export { buildStatusUpdateSurface } from "./status-all/format.js";
+export { buildStatusCommandReportData } from "./status.command-report-data.ts";
+export { buildStatusCommandReportLines } from "./status.command-report.ts";
+export { formatStatusConfigDiagnosticEntries } from "./status.format.js";

--- a/src/commands/status.command.ts
+++ b/src/commands/status.command.ts
@@ -22,8 +22,6 @@ import {
   resolveStatusUsageSummary,
 } from "./status-runtime-shared.ts";
 import { formatUpdateRestartStatusValue } from "./status-update-restart.ts";
-import { buildStatusCommandReportData } from "./status.command-report-data.ts";
-import { buildStatusCommandReportLines } from "./status.command-report.ts";
 import { logGatewayConnectionDetails } from "./status.gateway-connection.ts";
 
 const statusScanModuleLoader = createLazyImportLoader(() => import("./status.scan.js"));
@@ -232,23 +230,13 @@ export async function statusCommand(
 
   const rich = true;
   const {
+    buildStatusCommandReportData,
+    buildStatusCommandReportLines,
     buildStatusUpdateSurface,
-    formatCliCommand,
-    formatHealthChannelLines,
-    formatKTokens,
-    formatPromptCacheCompact,
-    formatPluginCompatibilityNotice,
     formatTimeAgo,
-    formatTokensCompact,
     formatUsageReportLines,
-    formatUpdateAvailableHint,
     getTerminalTableWidth,
     info,
-    renderTable,
-    resolveMemoryCacheSummary,
-    resolveMemoryFtsState,
-    resolveMemoryVectorState,
-    shortenText,
     theme,
   } = await statusCommandTextRuntimeLoader.load();
   const muted = (value: string) => (rich ? theme.muted(value) : value);
@@ -353,24 +341,6 @@ export async function statusCommand(
       pluginCompatibility,
       pairingRecovery,
       tableWidth,
-      ok,
-      warn,
-      muted,
-      shortenText,
-      formatCliCommand,
-      formatTimeAgo,
-      formatKTokens,
-      formatTokensCompact,
-      formatPromptCacheCompact,
-      formatHealthChannelLines,
-      formatPluginCompatibilityNotice,
-      formatUpdateAvailableHint,
-      resolveMemoryVectorState,
-      resolveMemoryFtsState,
-      resolveMemoryCacheSummary,
-      accentDim: theme.accentDim,
-      theme,
-      renderTable,
       updateValue: updateSurface.updateAvailable
         ? warn(`available · ${updateSurface.updateLine}`)
         : updateSurface.updateLine,

--- a/src/commands/status.daemon.real-summary.test.ts
+++ b/src/commands/status.daemon.real-summary.test.ts
@@ -1,7 +1,7 @@
 // Status daemon real-summary tests cover the shared service-state path for node services.
 import { expect, it, vi } from "vitest";
 import { createMockGatewayService } from "../daemon/service.test-helpers.js";
-import { formatStatusServiceValue } from "./status-all/format.js";
+import { getStatusOverviewRowValue } from "./status.test-support.ts";
 
 const mocks = vi.hoisted(() => ({
   resolveNodeService: vi.fn(),
@@ -35,7 +35,7 @@ it("renders root-status recovery guidance for a rejected node runtime", async ()
       detail: "node service manager unavailable",
     },
   });
-  expect(formatStatusServiceValue(summary)).toBe(
+  expect(getStatusOverviewRowValue("Node service", { nodeService: summary })).toBe(
     "systemd user disabled (inspection failed: service runtime inspection failed; retry with openclaw status --deep) · unknown",
   );
 });

--- a/src/commands/status.format.ts
+++ b/src/commands/status.format.ts
@@ -1,4 +1,4 @@
-// Formatting helpers for status tokens, durations, prompt-cache stats, and daemon runtime snippets.
+// Formatting helpers for status tokens, prompt-cache stats, and daemon runtime snippets.
 // These helpers are shared by report rows and command output surfaces.
 
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
@@ -8,7 +8,6 @@ import type { BestEffortConfigSnapshot } from "../config/io.js";
 import { formatConfigIssueLines } from "../config/issue-format.js";
 import type { GatewayServiceRuntime } from "../daemon/service-runtime.js";
 import { getSystemdCgroupHygieneSummary } from "../daemon/service-runtime.js";
-import { formatDurationPrecise } from "../infra/format-time/format-duration.ts";
 import { formatRuntimeStatusWithDetails } from "../infra/runtime-status.ts";
 import type { SessionStatus } from "../status/types.js";
 import { formatTokenCount } from "../utils/token-format.js";
@@ -24,14 +23,6 @@ export const formatStatusConfigDiagnosticEntries = (
   ...formatConfigIssueLines(diagnostics.issues, "-", { normalizeRoot: true }),
   `- Fix: ${formatCliCommand("openclaw doctor --fix")}`,
 ];
-
-/** Formats a duration or returns `unknown` for missing/non-finite values. */
-export const formatDuration = (ms: number | null | undefined) => {
-  if (ms == null || !Number.isFinite(ms)) {
-    return "unknown";
-  }
-  return formatDurationPrecise(ms, { decimals: 1 });
-};
 
 /** Formats session token usage and prompt-cache hit rate for the sessions table. */
 export const formatTokensCompact = (

--- a/src/commands/status.service-summary.test.ts
+++ b/src/commands/status.service-summary.test.ts
@@ -8,8 +8,8 @@ import { resolveGatewayService, type GatewayService } from "../daemon/service.js
 import { createMockGatewayService } from "../daemon/service.test-helpers.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import { withMockedPlatform } from "../test-utils/vitest-spies.js";
-import { formatStatusServiceValue } from "./status-all/format.js";
 import { readServiceStatusSummary } from "./status.service-summary.js";
+import { getStatusOverviewRowValue } from "./status.test-support.ts";
 
 function createService(overrides: Partial<GatewayService>): GatewayService {
   return createMockGatewayService({
@@ -71,7 +71,9 @@ describe("readServiceStatusSummary", () => {
       expect(summary.managedByOpenClaw).toBe(false);
       expect(summary.externallyManaged).toBe(false);
       expect(summary.loadedText).toBe("disabled");
-      expect(formatStatusServiceValue(summary)).toBe("systemd not installed");
+      expect(getStatusOverviewRowValue("Gateway service", { gatewayService: summary })).toBe(
+        "systemd not installed",
+      );
     },
   );
 
@@ -108,7 +110,7 @@ describe("readServiceStatusSummary", () => {
             }
           : { status: "not-loaded" },
       );
-      expect(formatStatusServiceValue(summary)).toBe(
+      expect(getStatusOverviewRowValue("Gateway service", { gatewayService: summary })).toBe(
         probe === "load"
           ? "systemd unknown (inspection failed: Error: service manager permission denied) · stopped"
           : probe === "runtime"

--- a/src/commands/status.test-support.ts
+++ b/src/commands/status.test-support.ts
@@ -7,6 +7,7 @@ import type { Tone } from "../memory-host-sdk/status.js";
 import type { PluginCompatibilityNotice } from "../plugins/status.js";
 import type { StatusSummary } from "../status/types.js";
 import { VERSION } from "../version.js";
+import { buildStatusOverviewSurfaceRows } from "./status-all/format.js";
 import type { buildStatusCommandOverviewRows } from "./status-overview-rows.ts";
 import type { StatusOverviewSurface } from "./status-overview-surface.ts";
 import type { AgentLocalStatus } from "./status.agent-local.js";
@@ -101,6 +102,17 @@ export const baseStatusOverviewSurface = {
   ...baseStatusOverviewScanFields,
   ...baseStatusServices,
 } as unknown as StatusOverviewSurface;
+
+export function getStatusOverviewRowValue(
+  item: string,
+  overrides: Partial<Parameters<typeof buildStatusOverviewSurfaceRows>[0]> = {},
+): string | undefined {
+  return buildStatusOverviewSurfaceRows({
+    ...baseStatusOverviewSurface,
+    agentsValue: "2 total",
+    ...overrides,
+  }).find((row) => row.Item === item)?.Value;
+}
 
 const baseStatusSummary = {
   tasks: { total: 3, active: 1, failures: 0, byStatus: { queued: 1, running: 1 } },
@@ -228,32 +240,17 @@ const statusTestDecorators = {
   ok: (value: string) => `ok(${value})`,
   warn: (value: string) => `warn(${value})`,
   muted: (value: string) => `muted(${value})`,
-  accentDim: (value: string) => `accent(${value})`,
 };
 
 const statusTestFormatting = {
-  shortenText: (value: string) => value,
-  formatCliCommand: (value: string) => `cmd:${value}`,
   formatTimeAgo: (value: number) => `${value}ms`,
   formatKTokens: (value: number) => `${Math.round(value / 1000)}k`,
-  formatTokensCompact: () => "12k",
-  formatPromptCacheCompact: () => "cache ok",
-  formatHealthChannelLines: () => ["QuietChat: OK · ready"],
-  formatPluginCompatibilityNotice: (notice: { message?: unknown }) => String(notice.message),
-  formatUpdateAvailableHint: () => "update available",
 };
 
 const statusTestMemoryResolvers = {
   resolveMemoryVectorState: () => ({ state: "ready", tone: "ok" as Tone }),
   resolveMemoryFtsState: () => ({ state: "ready", tone: "warn" as Tone }),
   resolveMemoryCacheSummary: () => ({ text: "cache warm", tone: "muted" as Tone }),
-};
-
-const statusTestTheme = {
-  heading: (value: string) => `# ${value}`,
-  muted: (value: string) => `muted(${value})`,
-  warn: (value: string) => `warn(${value})`,
-  error: (value: string) => `error(${value})`,
 };
 
 export function createStatusCommandOverviewRowsParams(
@@ -313,11 +310,6 @@ export function createStatusCommandReportDataParams(
     pluginCompatibility: baseStatusPluginCompatibility,
     pairingRecovery: { requestId: "req-1", reason: null, remediationHint: null },
     tableWidth: 120,
-    ...statusTestDecorators,
-    ...statusTestFormatting,
-    ...statusTestMemoryResolvers,
-    theme: statusTestTheme,
-    renderTable: ({ rows }: { rows: Array<Record<string, string>> }) => `table:${rows.length}`,
     updateValue: "available · custom update",
     ...overrides,
   };

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -98,7 +98,7 @@ const {
 const { launchFallbackTaskScript, removeStartupEntries } = await import("./schtasks-runtime.js");
 const { createMockGatewayService } = await import("./service.test-helpers.js");
 const { readServiceStatusSummary } = await import("../commands/status.service-summary.js");
-const { formatStatusServiceValue } = await import("../commands/status-all/format.js");
+const { getStatusOverviewRowValue } = await import("../commands/status.test-support.ts");
 
 function createSpawnChild(error?: Error): ChildProcess {
   const child = new EventEmitter() as ChildProcess;
@@ -551,10 +551,12 @@ describe("Windows startup fallback", () => {
         },
         missingUnit: false,
       });
-      expect(formatStatusServiceValue(summary)).toBe(
+      expect(getStatusOverviewRowValue("Gateway service", { gatewayService: summary })).toBe(
         "Scheduled Task missing (inspection failed: service runtime inspection failed) · unknown",
       );
-      expect(formatStatusServiceValue(summary)).not.toContain(detail);
+      expect(
+        getStatusOverviewRowValue("Gateway service", { gatewayService: summary }),
+      ).not.toContain(detail);
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Status report formatting was spread across pass-through dependency lists and unused exports, making ownership and useful contract coverage harder to maintain. This is an internal cleanup, not a new Status feature or a claim of a previously broken operator outcome.

## Why This Change Was Made

Consolidate formatting under the existing report owner. The lazy text-runtime boundary supplies the report builders, and report-data calls the canonical formatters instead of accepting a fixed pass-through list. Remove unused formatting exports while retaining useful report-boundary coverage. Strengthen the health-row producer type to its existing Item/Status/Detail shape.

The initial draft conflicted with the upstream Status usage-routing change. This refresh composes that landed behavior without restoring the removed loaders: full-report usage and agent options still reach their upstream owner, usage remains awaited, and the pure usage formatter stays available. The report's lazy boundary, both report awaits, text/JSON branches, diagnostics and ordering remain intact.

Net change relative to the composed parent: production −78 lines, tests/support +41, whole change −37 across thirteen files.

## User Impact

No intended behavior change from this refactor. Existing Status text/JSON reports, profile-aware commands, service diagnostics and upstream usage behavior remain supported.

## Evidence

- On composed commit `8c40d0cc979741d0146edf1ddcb68bd0923f2b13`: all 194 cases across sixteen whole suites passed, including seven upstream Commander usage-routing cases. The retained 187 case identities and within-suite order were checked.
- The normal changed-file gate completed all thirty planned stages, and the normal default build completed all fourteen stages. Source, index, configuration and generated-output closure were verified.
- Exact-commit Codex review was scoped-clean at P0 across two complete evidence batches. The optional token-format callee remained excluded.
- Historical proof on pre-refresh `415ac1f97efac382f1cff959539ae142eeaee044`: paired 170-case source proof, a subsequent 26-case type-focused proof, and a candidate-only Linux run of twelve real Status CLI variants plus the served Gateway lifecycle. The remote run covered text/verbose/deep/JSON/all/color and stopped/invalid-config paths, with complete evidence retrieval and owned lease cleanup.
- Exact-head hosted CI [run 33466603604](https://github.com/openclaw/openclaw/actions/runs/33466603604) completed successfully on `8c40d0cc979741d0146edf1ddcb68bd0923f2b13`.

## Scope and limits

The historical Linux operator did not run `--usage`; it is not promoted to composed-head operator proof. The new usage-routing cases use the real parser and formatting with mocked scan/usage owners. Source comparison confirms that this refactor preserves the upstream usage/agent forwarding and direct usage-line handoff, but built usage, real auth loading and provider quotas remain unobserved. No operator replay was required merely because the base moved.

This is not paired operator equivalence, installed-package proof, independent compiler equivalence or a latest-main/transitive-source certificate. Historical Darwin and earlier remote setup failures remain failures. Narrow cache/output qualifications retain their old-body and compiler limitations; the observed historical Git process has unknown action provenance. The earlier remote configuration-inode replacement and FETCH_HEAD delta were recorded without exclusive producer attribution.
