### PR TITLE
fix(ci): stabilize macOS Codex queue deadline test

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeCodexThreadCatalogTests.swift
@@ -1360,14 +1360,19 @@ extension MacNodeCodexThreadCatalogTests {
         do {
             // Complete the real handshake before exercising an active or queued deadline.
             _ = try await self.requestEmptyList(client: client, executable: fake.executable)
+        } catch {
+            await client.shutdown()
+            throw error
+        }
 
-            let first = Task {
-                try await self.requestEmptyList(
-                    client: client,
-                    executable: fake.executable,
-                    timeoutSeconds: 0.5)
-            }
-            #expect(await self.waitForFile(
+        let first = Task {
+            try await self.requestEmptyList(
+                client: client,
+                executable: fake.executable,
+                timeoutSeconds: MacNodeCodexThreadCatalog.defaultTimeoutSeconds)
+        }
+        do {
+            try #require(await self.waitForFile(
                 URL(fileURLWithPath: fake.executable.path + ".request-started")))
             let second = Task {
                 try await self.requestEmptyList(
@@ -1379,13 +1384,16 @@ extension MacNodeCodexThreadCatalogTests {
             await #expect(throws: MacNodeCodexThreadCatalog.CatalogError.timedOut) {
                 try await second.value
             }
-            await #expect(throws: MacNodeCodexThreadCatalog.CatalogError.timedOut) {
+            first.cancel()
+            await #expect(throws: CancellationError.self) {
                 try await first.value
             }
             #expect(!FileManager.default.fileExists(atPath: fake.executable.path + ".unexpected-request"))
             #expect(try self.readTrimmed(
                 URL(fileURLWithPath: fake.executable.path + ".processes")) == "1")
         } catch {
+            first.cancel()
+            _ = await first.result
             await client.shutdown()
             throw error
         }


### PR DESCRIPTION
## Summary

- remove a 500 ms readiness race from the macOS Codex queued-deadline test
- keep the active blocker alive on the normal catalog deadline
- cancel and await the blocker after proving the queued request expires without dispatch

## Root cause

The test gave its non-subject blocking request a `0.5` second deadline, then
waited up to two seconds for the fake App Server to publish
`.request-started`. Under the macOS CI job's 12-way Swift parallelism, the
request could expire and terminate the child before the marker was written.

The failure was observed in:
https://github.com/openclaw/openclaw/actions/runs/33427229368/job/99632491409

The production owner is correct: `CodexAppServerThreadClient` starts the
caller-owned wall-clock deadline at queue admission. Codex
`ThreadListParams` has no server timeout field
(`../codex/codex-rs/app-server-protocol/src/protocol/v2/thread.rs:1362`), so
there is no upstream timeout to preserve or change.

## Scope

- production: `+0/-0`
- tests: `+16/-8`
- docs/changelog: not required

This is a maintainer-owned repair for a newly isolated main-CI test race. It is
kept separate from https://github.com/openclaw/openclaw/pull/134275 because
that PR changes only onboarding source organization.

## Validation

- `swiftc -parse`
- SwiftFormat 0.62.1
- changed-region SwiftLint
- `git diff --check`
- autoreview: clean, 0.99
- exact-head macOS CI pending
