### PR TITLE
fix(update): detect metadata-free npm installs

### DIFF
--- a/src/infra/update-check-status.test.ts
+++ b/src/infra/update-check-status.test.ts
@@ -649,6 +649,30 @@ describe("checkUpdateStatus", () => {
     },
   );
 
+  it("detects a metadata-free lockless OpenClaw npm install", async () => {
+    await withTestDir({ prefix: "openclaw-update-check-lockless-npm-" }, async (base) => {
+      const root = path.join(base, "prefix", "node_modules", "openclaw");
+      await fs.mkdir(root, { recursive: true });
+      await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
+
+      const status = await checkUpdateStatus({
+        root,
+        includeRegistry: false,
+        fetchGit: false,
+        timeoutMs: 1000,
+      });
+
+      expect(status.installKind).toBe("package");
+      expect(status.packageManager).toBe("npm");
+      expect(status.deps).toMatchObject({
+        manager: "npm",
+        lockfilePath: path.join(root, "package-lock.json"),
+        status: "unknown",
+        reason: "lockfile missing",
+      });
+    });
+  });
+
   it("reports a missing dependency marker and accepts an older valid marker", async () => {
     await withTestDir({ prefix: "openclaw-update-check-deps-" }, async (root) => {
       await fs.writeFile(

--- a/src/infra/update-check.ts
+++ b/src/infra/update-check.ts
@@ -211,7 +211,10 @@ async function isLocklessOpenClawNpmInstall(params: {
   root: string;
   manager: PackageManager;
 }): Promise<boolean> {
-  if (params.manager !== "pnpm" || (await exists(path.join(params.root, "pnpm-lock.yaml")))) {
+  if (
+    ["npm", "bun"].includes(params.manager) ||
+    (await exists(path.join(params.root, "pnpm-lock.yaml")))
+  ) {
     return false;
   }
   try {


### PR DESCRIPTION
Fixes #134203

## Summary

- classify metadata-free lockless OpenClaw package roots as npm when topology rules out pnpm and Bun
- preserve the existing packed-pnpm-metadata correction
- cover the exact staged 2026.8.1 package shape

## Root cause

The published 2026.8.1 package has neither a package-manager field nor a lockfile. Generic detection therefore returns unknown. The installed-root topology correction only inspected roots initially classified as pnpm, so the metadata-free result bypassed the correction even though the same direct `node_modules/openclaw` topology proves npm ownership.

## Validation

- RED: the new metadata-free npm regression failed with `expected npm, received unknown`
- GREEN: `node scripts/run-vitest.mjs src/infra/update-check-status.test.ts` (23/23)
- `pnpm lint`
- live package layout: extracted the published 2026.8.1 tarball beneath `prefix/node_modules/openclaw`; current source reports package and dependency manager `npm`

## LOC

- production: +4/-1 (net +3) to admit the already-supported unknown detection state into the existing topology classifier
- tests: +24/-0

## Risk

Low. Explicit npm and Bun classifications still bypass correction. Unknown or packed-pnpm roots must pass the existing OpenClaw name, direct node_modules topology, pnpm ownership, and Bun ownership checks before becoming npm.
