### PR TITLE
fix(ui): preserve browser focus during passive follow

### DIFF
--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -444,7 +444,11 @@ export class BrowserPanelController implements ReactiveController {
     }
   }
 
-  async selectTab(targetId: string, route?: BrowserRoute): Promise<void> {
+  async selectTab(
+    targetId: string,
+    route?: BrowserRoute,
+    options?: { focusBrowserTab?: boolean },
+  ): Promise<void> {
     this.native.cancelPendingActivation(targetId);
     const nativeTab = this.native.tabs.find((tab) => tab.id === targetId);
     if (nativeTab) {
@@ -474,10 +478,10 @@ export class BrowserPanelController implements ReactiveController {
     if (!route && this.clearUnavailableView()) {
       return;
     }
-    const focused = await this.runAction(async (actionClient) => {
+    const selectionSucceeded = await this.runAction(async (actionClient) => {
       if (route) {
-        // Listing can observe stopped or blocked tabs; focus needs a running,
-        // accessible tab. A historical target cannot survive a browser restart.
+        // Listing can observe stopped or blocked tabs; focus and capture need a
+        // running, accessible tab. A historical target cannot survive a browser restart.
         await this.refreshTabsOnly(actionClient, () => this.operations.isLive(epoch, actionClient));
         if (!this.operations.isLive(epoch, actionClient)) {
           return;
@@ -492,7 +496,9 @@ export class BrowserPanelController implements ReactiveController {
       if (!selectedTargetId) {
         return;
       }
-      await focusBrowserTab(actionClient, selectedTargetId);
+      if (options?.focusBrowserTab !== false) {
+        await focusBrowserTab(actionClient, selectedTargetId);
+      }
       if (!this.operations.isLive(epoch, actionClient)) {
         return;
       }
@@ -505,7 +511,7 @@ export class BrowserPanelController implements ReactiveController {
         this.operations.markNavigationReconciled(actionClient, selectedTargetId);
       }
     }, false);
-    if (!focused && this.operations.isLive(epoch) && this.activeTargetId === targetId) {
+    if (!selectionSucceeded && this.operations.isLive(epoch) && this.activeTargetId === targetId) {
       if (this.operations.hasPendingNavigation(client, previous.targetId)) {
         // The prior remote document changed while selection failed. Expose an
         // unavailable state instead of restoring a screenshot that no longer owns it.

--- a/ui/src/components/browser/browser-panel-controller.ts
+++ b/ui/src/components/browser/browser-panel-controller.ts
@@ -482,12 +482,17 @@ export class BrowserPanelController implements ReactiveController {
       if (route) {
         // Listing can observe stopped or blocked tabs; focus and capture need a
         // running, accessible tab. A historical target cannot survive a browser restart.
-        await this.refreshTabsOnly(actionClient, () => this.operations.isLive(epoch, actionClient));
+        const refreshed = await this.refreshTabsOnly(actionClient, () =>
+          this.operations.isLive(epoch, actionClient),
+        );
         if (!this.operations.isLive(epoch, actionClient)) {
           return;
         }
         const selected = this.tabs.find((tab) => tab.id === targetId || tab.targetId === targetId);
         this.setState("activeTargetId", this.running === false ? null : (selected?.id ?? targetId));
+        if (refreshed === "accepted" && this.running !== false && !selected) {
+          throw new Error(t("browser.tabUnavailable"));
+        }
         if (this.clearUnavailableView()) {
           return;
         }

--- a/ui/src/components/browser/browser-panel-route.test.ts
+++ b/ui/src/components/browser/browser-panel-route.test.ts
@@ -120,19 +120,21 @@ function controllerFor(panel: Panel): BrowserPanelController {
 describe("browser panel route handoff", () => {
   it("follows session results once on presentation, keeps card choices, and clears session/gateway ownership", async () => {
     const gateway = browserGateway();
+    const focusCount = () =>
+      gateway.request.mock.calls.filter(
+        ([, value]) => (value as BrowserRequestEnvelope).path === "/tabs/focus",
+      ).length;
     const panel = await mountPanel(gateway.client, false);
     expect(gateway.request).not.toHaveBeenCalled();
     panel.presented = true;
     await waitForFast(() => expect(pageTitle(panel)).toBe("managed"));
     expect(panel.shadowRoot?.querySelector(".bp-profile")?.textContent).toBe("managed");
+    expect(focusCount()).toBe(0);
 
     chooseCard(panel, nodeTab);
     await waitForFast(() => expect(pageTitle(panel)).toBe("work"));
-    const focusCount = () =>
-      gateway.request.mock.calls.filter(
-        ([, value]) => (value as BrowserRequestEnvelope).path === "/tabs/focus",
-      ).length;
     const afterClick = focusCount();
+    expect(afterClick).toBe(1);
     panel.preferredTab = { tab: { ...hostTab }, revision: "first" };
     panel.requestUpdate();
     await panel.updateComplete;
@@ -141,6 +143,7 @@ describe("browser panel route handoff", () => {
 
     panel.preferredTab = { tab: hostTab, revision: "second" };
     await waitForFast(() => expect(pageTitle(panel)).toBe("managed"));
+    expect(focusCount()).toBe(afterClick);
     await controllerFor(panel).selectTab("t2");
     panel.preferredTab = { tab: { ...hostTab }, revision: "second" };
     await panel.updateComplete;

--- a/ui/src/components/browser/browser-panel-route.test.ts
+++ b/ui/src/components/browser/browser-panel-route.test.ts
@@ -281,6 +281,72 @@ describe("browser panel route handoff", () => {
     expect(paths()).not.toContain("/tabs/focus");
   });
 
+  it.each([false, true])(
+    "rejects a missing historical tab before capture and preserves the prior view (prior=%s)",
+    async (hasPriorView) => {
+      const missingTarget = "missing-history-target";
+      const gateway = createBrowserClient(
+        async (request) => {
+          if (request.path === "/tabs") {
+            return {
+              running: true,
+              tabs: [createBrowserPanelTestTab("t1", "https://managed.example/", "managed")],
+            };
+          }
+          if (request.body?.targetId === missingTarget) {
+            throw new GatewayRequestError({
+              code: "INVALID_REQUEST",
+              message: "tab not found",
+            });
+          }
+          if (request.path === "/screencast") {
+            throw new GatewayRequestError({
+              code: "INVALID_REQUEST",
+              message: "Screencast unavailable",
+              details: { code: "SCREENCAST_UNSUPPORTED", reason: "node" },
+            });
+          }
+          if (request.path === "/screenshot") {
+            return { path: "/fresh.png", targetId: "raw-t1", url: "https://managed.example/" };
+          }
+          if (request.path === "/act") {
+            return createBrowserPanelTestMetrics("https://managed.example/", "managed");
+          }
+          return { ok: true };
+        },
+        { screencast: true },
+      );
+      const panel = await mountPanel(gateway.client, hasPriorView);
+      if (hasPriorView) {
+        await waitForFast(() => expect(pageTitle(panel)).toBe("managed"));
+      }
+      const controller = controllerFor(panel);
+      const previousView = controller.view;
+      vi.useFakeTimers();
+      panel.preferredTab = {
+        tab: { ...hostTab, targetId: missingTarget },
+        revision: "missing-history",
+      };
+      panel.presented = true;
+      await waitForFast(() => expect(controller.errorText).toBeTruthy());
+
+      const missingCaptures = () =>
+        gateway.request.mock.calls
+          .map(([, value]) => value as BrowserRequestEnvelope)
+          .filter(
+            (request) =>
+              request.body?.targetId === missingTarget &&
+              (request.path === "/screencast" || request.path === "/screenshot"),
+          );
+      expect.soft(controller.activeTargetId).toBe(hasPriorView ? "t1" : null);
+      expect.soft(controller.view).toBe(previousView);
+      expect.soft(controller.loading).toBe(false);
+      expect.soft(missingCaptures()).toEqual([]);
+      await vi.advanceTimersByTimeAsync(21_000);
+      expect(missingCaptures()).toEqual([]);
+    },
+  );
+
   it("keeps a raw target selection when its stable tab alias is not the first tab", async () => {
     const gateway = browserGateway();
     const panel = await mountPanel(gateway.client, false);

--- a/ui/src/components/browser/browser-panel.ts
+++ b/ui/src/components/browser/browser-panel.ts
@@ -203,7 +203,8 @@ class OpenClawBrowserPanel extends OpenClawLitElement implements BrowserPanelCon
     this.consumedPreferredRevision = revision;
     const tab = readBrowserTabTarget(this.preferredTab.tab);
     if (tab) {
-      void this.browserPanelController.selectTab(tab.targetId, tab);
+      // Session results own the panel route and view, not the user's physical browser focus.
+      void this.browserPanelController.selectTab(tab.targetId, tab, { focusBrowserTab: false });
     }
     return true;
   }

--- a/ui/src/e2e/browser-route-handoff.e2e.test.ts
+++ b/ui/src/e2e/browser-route-handoff.e2e.test.ts
@@ -262,6 +262,9 @@ suite.define(() => {
           );
 
           // The same live transport must still carry actionable browser results.
+          const focusCountBeforeBrowserResult = requests.filter(
+            (request) => asNullableRecord(request.params)?.path === "/tabs/focus",
+          ).length;
           await emitTool({
             phase: "start",
             toolCallId: "browser-control",
@@ -293,6 +296,11 @@ suite.define(() => {
               }),
             )
             .toBe(true);
+          expect(
+            (await gateway.getRequests("browser.request")).filter(
+              (request) => asNullableRecord(request.params)?.path === "/tabs/focus",
+            ),
+          ).toHaveLength(focusCountBeforeBrowserResult);
         },
       );
     },
@@ -421,21 +429,18 @@ suite.define(() => {
           ).toBe(false);
           const panel = page.locator("section.bp");
           if (firstOpen === "panel") {
+            const beforePanelOpen = (await gateway.getRequests("browser.request")).length;
             await openChatSidePanelType(page, "Browser");
             await panel.locator('.bp-shot[alt="Node tab"]').waitFor();
             expect(await panel.locator(".bp-profile").textContent()).toBe("work");
-            await expect
-              .poll(async () =>
-                (await gateway.getRequests("browser.request")).map((request) => request.params),
-              )
-              .toContainEqual({
-                method: "POST",
-                path: "/tabs/focus",
-                target: "node",
-                node: "node-a",
-                query: { profile: "work" },
-                body: { targetId: "t1" },
-              });
+            const panelOpenRequests = (await gateway.getRequests("browser.request")).slice(
+              beforePanelOpen,
+            );
+            expect(
+              panelOpenRequests.some(
+                (request) => asNullableRecord(request.params)?.path === "/tabs/focus",
+              ),
+            ).toBe(false);
           }
           const beforeHostOpen = (await gateway.getRequests("browser.request")).length;
           await hostCard.getByRole("button", { name: "Open", exact: true }).click();

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -2286,6 +2286,7 @@ export const en: TranslationMap & {
     navigationBlocked:
       "The current browser navigation rules block this address. Select another tab or enter an allowed address.",
     navigationCheckFailed: "OpenClaw couldn’t verify this tab’s address. Refresh to try again.",
+    tabUnavailable: "This tab is no longer available. Select another tab.",
     title: "Browser",
     open: "Open",
     openPanel: "Open browser panel",


### PR DESCRIPTION
Related: #134400, #139089

## What Problem This Solves

The Browser panel followed session results through the explicit tab-selection path. That sent `/tabs/focus` and activated the result tab in an attached browser, even when the operator had left another tab active.

## Why This Change Was Made

Passive following now skips explicit focus while retaining the shared route, capture, lifecycle, and rollback owners. Card Open and selection of a different panel tab still focus normally. Clicking an already-selected panel tab retains its existing no-op.

The selection owner also rejects a historical target absent from its accepted current tab list before capture. This preserves the validation previously supplied by the focus request, restores a valid prior view when safe, and prevents a missing target from entering repeated stream/screenshot recovery. The error directs the operator to select another tab.

## User Impact

Successful Browser results can update the panel without changing the operator's physical browser tab. The merged capture-owner repair in #134400 remains in place. Current streaming, screenshot fallback, attach-only policy, native and remote routes, configuration, protocol, and Browser-card semantics are preserved.

## Evidence

- A public Control UI agent turn through the real Browser tool reproduced one passive focus request and physical tab activation on pinned main. With the same rendered-tab precondition, the final candidate produced no focus request and preserved the sentinel tab while refreshing the result view.
- Fresh source-blind acceptance also exercised the full selection change: the panel and physical browser initially selected Sentinel; a public Browser evaluation of the other Result page changed the panel to Result, displayed newly changed content through routed screenshot/stream capture, and left Sentinel physically active. Explicit Open and different-tab selection each focused once; later results added no focus. Context changes, unavailable history, and recovery were exercised.
- The passive-focus regression failed on main. Two additional missing-history cases failed on the initial candidate for invalid selection, lost rollback, and repeated capture. The corrected candidate passed 138 focused tests across selection, routes, input, pending navigation, snapshot races, streaming, and native boundaries. Formatting and keyless language checks passed.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34328435157) passed, including all four cases in the changed [Browser route E2E suite](https://github.com/openclaw/openclaw/actions/runs/34328435157/job/102391432114). The native supplemental E2E attempt hit its 4 GiB limit; that failure was retained and the hosted lane supplied the completed check without raising the native limit.

A background Browser-tool screenshot timed out in a separate acceptance attempt. It remains failed evidence, not a passing capture or a claim of general screenshot reliability. The successful evaluation case above verifies the combined background-target selection and fresh-view outcome. Native macOS and remote-node behavior have source/component coverage; no live native-app or remote-node proof is claimed. Raw captures remain private.

Thanks @scotthuang for the original passive-focus correction. Contributor ancestry and prior review history are preserved.
