### PR TITLE
fix(gateway): scrub legacy systemd version metadata on safe restart

### DIFF
--- a/src/cli/daemon-cli/lifecycle-safe-restart.test.ts
+++ b/src/cli/daemon-cli/lifecycle-safe-restart.test.ts
@@ -2,7 +2,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const callGatewayCli = vi.hoisted(() => vi.fn());
+const refreshLegacySystemdServiceMetadata = vi.hoisted(() =>
+  vi.fn<(_env: NodeJS.ProcessEnv, timeoutMs?: number) => Promise<boolean>>(async () => false),
+);
+const resolveGatewayServiceMutationError = vi.hoisted(() => vi.fn<() => Error | null>(() => null));
 const appendGatewayLifecycleAudit = vi.hoisted(() => vi.fn());
+const runtimeError = vi.hoisted(() => vi.fn());
 const runtimeLog = vi.hoisted(() => vi.fn());
 const runtimeWriteJson = vi.hoisted(() => vi.fn());
 
@@ -10,8 +15,17 @@ vi.mock("../../gateway/call.js", () => ({
   callGatewayCli,
 }));
 
+vi.mock("../../daemon/systemd.js", () => ({
+  refreshLegacySystemdServiceMetadata,
+}));
+
+vi.mock("../../infra/gateway-supervision.js", () => ({
+  resolveGatewayServiceMutationError,
+}));
+
 vi.mock("../../runtime.js", () => ({
   defaultRuntime: {
+    error: runtimeError,
     log: runtimeLog,
     writeJson: runtimeWriteJson,
   },
@@ -26,12 +40,19 @@ describe("runSafeGatewayRestart", () => {
   beforeEach(() => {
     callGatewayCli.mockReset();
     appendGatewayLifecycleAudit.mockReset();
+    refreshLegacySystemdServiceMetadata.mockReset().mockResolvedValue(false);
+    resolveGatewayServiceMutationError.mockReset().mockReturnValue(null);
+    runtimeError.mockReset();
     runtimeLog.mockReset();
     runtimeWriteJson.mockReset();
   });
 
-  it("reports that skip-deferral still allows close-stage reply drain", async () => {
+  it("keeps skip-deferral RPC behavior when bounded metadata cleanup fails", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
     const { runSafeGatewayRestart } = await import("./lifecycle-safe-restart.js");
+    refreshLegacySystemdServiceMetadata.mockRejectedValueOnce(
+      new Error("systemd cleanup timed out"),
+    );
     callGatewayCli.mockResolvedValueOnce({
       status: "scheduled",
       preflight: {
@@ -59,6 +80,8 @@ describe("runSafeGatewayRestart", () => {
       params: { reason: "gateway.restart.safe", skipDeferral: true },
       timeoutMs: 10_000,
     });
+    expect(refreshLegacySystemdServiceMetadata).toHaveBeenCalledWith(process.env, 5_000);
+    expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("systemd cleanup timed out"));
     expect(runtimeWriteJson).toHaveBeenCalledWith(
       expect.objectContaining({
         message:
@@ -67,5 +90,24 @@ describe("runSafeGatewayRestart", () => {
         result: "scheduled",
       }),
     );
+  });
+
+  it("keeps the RPC restart while skipping ineligible service mutation", async () => {
+    vi.spyOn(process, "platform", "get").mockReturnValue("linux");
+    resolveGatewayServiceMutationError.mockReturnValueOnce(
+      new Error("gateway lifecycle is managed by an external supervisor"),
+    );
+    const { runSafeGatewayRestart } = await import("./lifecycle-safe-restart.js");
+    callGatewayCli.mockResolvedValueOnce({
+      status: "scheduled",
+      preflight: { blockers: [], summary: "safe to restart now" },
+      restart: { pid: 123 },
+    });
+
+    await expect(runSafeGatewayRestart({ json: true, safe: true })).resolves.toBe(true);
+
+    expect(refreshLegacySystemdServiceMetadata).not.toHaveBeenCalled();
+    expect(callGatewayCli).toHaveBeenCalledOnce();
+    expect(runtimeError).toHaveBeenCalledWith(expect.stringContaining("external supervisor"));
   });
 });

--- a/src/cli/daemon-cli/lifecycle-safe-restart.ts
+++ b/src/cli/daemon-cli/lifecycle-safe-restart.ts
@@ -1,12 +1,17 @@
 import { GATEWAY_SERVER_CAPS } from "../../../packages/gateway-protocol/src/index.js";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
+import { refreshLegacySystemdServiceMetadata } from "../../daemon/systemd.js";
 import { callGatewayCli } from "../../gateway/call.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+import { resolveGatewayServiceMutationError } from "../../infra/gateway-supervision.js";
 import type { SafeGatewayRestartRequestResult } from "../../infra/restart-coordinator.js";
 import type { GatewayRestartIntent } from "../../infra/restart-intent.js";
 import { defaultRuntime, writeRuntimeJson } from "../../runtime.js";
 import { parseDurationMs } from "../parse-duration.js";
 import { appendGatewayLifecycleAudit } from "./lifecycle-audit.js";
 import type { DaemonLifecycleOptions } from "./types.js";
+
+const SAFE_RESTART_METADATA_REFRESH_TIMEOUT_MS = 5_000;
 
 function formatSafeRestartWarnings(result: SafeGatewayRestartRequestResult): string[] | undefined {
   return result.preflight.blockers.length === 0 ? undefined : [result.preflight.summary];
@@ -54,6 +59,29 @@ export async function runSafeGatewayRestart(
   }
   if (skipDeferral) {
     params.skipDeferral = true;
+  }
+  if (process.platform === "linux") {
+    const reportRefreshError = (error: unknown) => {
+      defaultRuntime.error(
+        theme.warn(
+          `Warning: legacy systemd metadata was not refreshed: ${formatErrorMessage(error)}`,
+        ),
+      );
+    };
+    const mutationError = resolveGatewayServiceMutationError(
+      "refresh legacy systemd service metadata",
+      process.env,
+    );
+    if (mutationError) {
+      reportRefreshError(mutationError);
+    } else {
+      // Definition maintenance is best effort. Keep a wedged systemd manager from
+      // suppressing the separately bounded Gateway restart request below.
+      await refreshLegacySystemdServiceMetadata(
+        process.env,
+        SAFE_RESTART_METADATA_REFRESH_TIMEOUT_MS,
+      ).catch(reportRefreshError);
+    }
   }
   const result = await callGatewayCli<SafeGatewayRestartRequestResult>({
     method: "gateway.restart.request",

--- a/src/cli/daemon-cli/lifecycle.external-supervision.test.ts
+++ b/src/cli/daemon-cli/lifecycle.external-supervision.test.ts
@@ -76,10 +76,10 @@ vi.mock("../../daemon/service.js", () => ({
 
 vi.mock("../../daemon/systemd.js", () => ({
   findInstalledSystemdGatewayScope: () => findInstalledSystemdGatewayScope(),
+  refreshLegacySystemdServiceMetadata: vi.fn(async () => false),
   restartSystemdService: vi.fn(),
   stopSystemdService: vi.fn(),
 }));
-
 vi.mock("./restart-health.js", () => ({
   DEFAULT_RESTART_HEALTH_ATTEMPTS: 120,
   DEFAULT_RESTART_HEALTH_DELAY_MS: 500,

--- a/src/cli/daemon-cli/lifecycle.test.ts
+++ b/src/cli/daemon-cli/lifecycle.test.ts
@@ -136,10 +136,10 @@ vi.mock("../../daemon/service.js", () => ({
 
 vi.mock("../../daemon/systemd.js", () => ({
   findInstalledSystemdGatewayScope: () => findInstalledSystemdGatewayScope(),
+  refreshLegacySystemdServiceMetadata: vi.fn(async () => false),
   restartSystemdService: () => restartSystemdService(),
   stopSystemdService: () => stopSystemdService(),
 }));
-
 vi.mock("./launchd-recovery.js", () => ({
   recoverInstalledLaunchAgent: (args: { result: "started" | "restarted" }) =>
     recoverInstalledLaunchAgent(args),

--- a/src/daemon/systemd-definition-mutation.test.ts
+++ b/src/daemon/systemd-definition-mutation.test.ts
@@ -1007,4 +1007,36 @@ describe.skipIf(process.platform === "win32")("systemd definition mutation owner
       }
     },
   );
+
+  it("bounds manager inspection by the mutation deadline", async () => {
+    await withSystemdDefinitionMutation(env, env, async () => undefined, { timeoutMs: 50 });
+
+    expect(busctl).toHaveBeenCalled();
+    for (const call of busctl.mock.calls) {
+      const timeoutMs = call[2];
+      expect(timeoutMs).toBeGreaterThan(0);
+      expect(timeoutMs).toBeLessThanOrEqual(50);
+    }
+  });
+
+  it("bounds lock acquisition by the mutation deadline", async () => {
+    const { promise: barrier, resolve: release } = createDeferred();
+    const { promise: firstStarted, resolve: entered } = createDeferred();
+    const first = withSystemdDefinitionMutation(env, env, async () => {
+      entered();
+      await barrier;
+    });
+    await firstStarted;
+
+    const startedAt = Date.now();
+    try {
+      await expect(
+        withSystemdDefinitionMutation(env, env, async () => undefined, { timeoutMs: 100 }),
+      ).rejects.toMatchObject({ code: "file_lock_timeout" });
+      expect(Date.now() - startedAt).toBeLessThan(2_000);
+    } finally {
+      release();
+      await first;
+    }
+  });
 });

--- a/src/daemon/systemd-definition-mutation.ts
+++ b/src/daemon/systemd-definition-mutation.ts
@@ -201,8 +201,13 @@ export async function withSystemdDefinitionMutation<T>(
   env: GatewayServiceEnv,
   environment: GatewayServiceEnv,
   run: (mutation: SystemdDefinitionMutation) => Promise<T>,
+  options?: { timeoutMs?: number },
 ): Promise<T> {
-  let initial = await inspect(env, environment);
+  const deadlineAt =
+    options?.timeoutMs && options.timeoutMs > 0 ? Date.now() + options.timeoutMs : undefined;
+  const remainingTimeoutMs = () =>
+    deadlineAt === undefined ? undefined : Math.max(1, deadlineAt - Date.now());
+  let initial = await inspect(env, environment, remainingTimeoutMs());
   assertServiceDefinitionWritable(initial.capability);
   const { unit, generated } = resolveMutationTargets(env, environment);
   // Group-writable umasks must not create directories that inspect() would reject.
@@ -216,7 +221,7 @@ export async function withSystemdDefinitionMutation<T>(
     .toSorted();
   const execute = async (): Promise<T> => {
     const refresh = async (unchanged = false, firstUnitPublication = false) => {
-      const current = await inspect(env, environment);
+      const current = await inspect(env, environment, remainingTimeoutMs());
       assertServiceDefinitionWritable(current.capability);
       const expected = new Map(initial.fingerprint);
       // LoadUnit can reveal shared defaults only after the first base publication.
@@ -286,7 +291,7 @@ export async function withSystemdDefinitionMutation<T>(
       if (published === undefined) {
         return;
       }
-      const current = await inspect(env, environment);
+      const current = await inspect(env, environment, remainingTimeoutMs());
       // A refreshed global snapshot never grants ownership of another artifact's edit.
       if (current.capability.kind !== "writable" || current.fingerprint.get(file) !== published) {
         return;
@@ -304,13 +309,21 @@ export async function withSystemdDefinitionMutation<T>(
     };
     return await run({ snapshots: initial.snapshots, publish, restore });
   };
-  const lockOptions = {
-    stale: 60_000,
-    retries: { retries: 100, factor: 1, minTimeout: 50, maxTimeout: 100 },
+  const lockOptions = () => {
+    const timeoutMs = remainingTimeoutMs();
+    return {
+      stale: 60_000,
+      retries: {
+        retries: timeoutMs === undefined ? 100 : Math.max(0, Math.ceil(timeoutMs / 50) - 1),
+        factor: 1,
+        minTimeout: 50,
+        maxTimeout: 100,
+      },
+    };
   };
   const acquire = async (index: number): Promise<T> =>
     index === targets.length
       ? execute()
-      : withFileLock(targets[index]!, lockOptions, () => acquire(index + 1));
+      : withFileLock(targets[index]!, lockOptions(), () => acquire(index + 1));
   return await acquire(0);
 }

--- a/src/daemon/systemd-exec.ts
+++ b/src/daemon/systemd-exec.ts
@@ -315,8 +315,11 @@ export async function disableSystemdUserUnitForRemoval(
   throw new Error(`systemctl disable failed: ${detail || "unknown error"}`);
 }
 
-export async function reloadSystemdUserManager(env: GatewayServiceEnv): Promise<void> {
-  const result = await execSystemctlUser(env, ["daemon-reload"]);
+export async function reloadSystemdUserManager(
+  env: GatewayServiceEnv,
+  timeoutMs?: number,
+): Promise<void> {
+  const result = await execSystemctlUser(env, ["daemon-reload"], timeoutMs);
   if (result.code !== 0) {
     throw new Error(
       `systemctl daemon-reload failed: ${readSystemctlDetail(result) || "unknown error"}`,

--- a/src/daemon/systemd-install.ts
+++ b/src/daemon/systemd-install.ts
@@ -6,7 +6,11 @@ import {
   readStateDirDotEnvFromStateDir,
 } from "../config/state-dir-dotenv.js";
 import { hasErrnoCode } from "../infra/errno.js";
-import { resolveGatewayServiceDescription } from "./constants.js";
+import {
+  GATEWAY_SERVICE_KIND,
+  GATEWAY_SERVICE_MARKER,
+  resolveGatewayServiceDescription,
+} from "./constants.js";
 import { formatLine, writeFormattedLines } from "./output.js";
 import {
   hasEnvironmentFileSource,
@@ -33,6 +37,7 @@ import {
   isSystemdUnitMissingDetail,
   isSystemdUserScopeUnavailable,
   readSystemctlDetail,
+  reloadSystemdUserManager,
 } from "./systemd-exec.js";
 import { assertNoSystemGatewayOwnership } from "./systemd-scope.js";
 import {
@@ -103,17 +108,9 @@ function collectSystemdFileBackedEnvironment(params: {
   return environment;
 }
 
-function sanitizeSystemdUnitBackupContent(params: {
-  content: string;
-  fileManagedKeys: ReadonlySet<string>;
-}): string {
-  if (params.fileManagedKeys.size === 0) {
-    return params.content;
-  }
-  // Backups should not retain file-managed secrets that OpenClaw moved into the
-  // generated EnvironmentFile during this rewrite.
+function removeSystemdInlineEnvironmentKeys(content: string, keys: ReadonlySet<string>): string {
   const sanitizedLines: string[] = [];
-  for (const rawLine of params.content.split("\n")) {
+  for (const rawLine of content.split("\n")) {
     const line = rawLine.trim();
     if (!line.startsWith("Environment=")) {
       sanitizedLines.push(rawLine);
@@ -122,7 +119,7 @@ function sanitizeSystemdUnitBackupContent(params: {
     const assignments = parseSystemdEnvAssignments(line.slice("Environment=".length).trim());
     const keptAssignments = assignments.filter(({ key }) => {
       const normalizedKey = normalizeServiceEnvKey(key);
-      return !normalizedKey || !params.fileManagedKeys.has(normalizedKey);
+      return !normalizedKey || !keys.has(normalizedKey);
     });
     if (keptAssignments.length === assignments.length) {
       sanitizedLines.push(rawLine);
@@ -139,6 +136,110 @@ function sanitizeSystemdUnitBackupContent(params: {
     );
   }
   return sanitizedLines.join("\n");
+}
+
+function sanitizeSystemdUnitBackupContent(params: {
+  content: string;
+  fileManagedKeys: ReadonlySet<string>;
+}): string {
+  if (params.fileManagedKeys.size === 0) {
+    return params.content;
+  }
+  // Backups should not retain file-managed secrets that OpenClaw moved into the
+  // generated EnvironmentFile during this rewrite.
+  return removeSystemdInlineEnvironmentKeys(params.content, params.fileManagedKeys);
+}
+
+function removeLegacyGatewayVersionMetadata(content: string): string {
+  const description =
+    /^Description=OpenClaw Gateway \((?:(profile: [^,)\r\n]+), )?v([^)\r\n]+)\)$/mu.exec(content);
+  if (!description) {
+    return content;
+  }
+  const inlineEnvironment = new Map<string, string>();
+  let inServiceSection = false;
+  for (const rawLine of content.split("\n")) {
+    const line = rawLine.trim();
+    if (/^\[[^\]]+\]$/u.test(line)) {
+      inServiceSection = line === "[Service]";
+      continue;
+    }
+    if (!inServiceSection || !line.startsWith("Environment=")) {
+      continue;
+    }
+    const rawAssignments = line.slice("Environment=".length).trim();
+    if (!rawAssignments) {
+      inlineEnvironment.clear();
+      continue;
+    }
+    for (const assignment of parseSystemdEnvAssignments(rawAssignments)) {
+      inlineEnvironment.set(assignment.key, assignment.value);
+    }
+  }
+  if (
+    inlineEnvironment.get("OPENCLAW_SERVICE_MARKER") !== GATEWAY_SERVICE_MARKER ||
+    inlineEnvironment.get("OPENCLAW_SERVICE_KIND") !== GATEWAY_SERVICE_KIND ||
+    inlineEnvironment.get("OPENCLAW_SERVICE_VERSION") !== description[2]
+  ) {
+    return content;
+  }
+  const replacement = description[1]
+    ? `Description=OpenClaw Gateway (${description[1]})`
+    : "Description=OpenClaw Gateway";
+  const refreshed =
+    content.slice(0, description.index) +
+    replacement +
+    content.slice(description.index + description[0].length);
+  return removeSystemdInlineEnvironmentKeys(refreshed, new Set(["OPENCLAW_SERVICE_VERSION"]));
+}
+
+/** Removes obsolete install-time version stamps without restarting the service. */
+export async function refreshLegacySystemdServiceMetadata(
+  env: GatewayServiceEnv,
+  timeoutMs: number,
+): Promise<boolean> {
+  const deadlineAt = Date.now() + Math.max(1, timeoutMs);
+  const remainingTimeoutMs = () => Math.max(1, deadlineAt - Date.now());
+  const unitPath = resolveSystemdUnitPath(env);
+  const current = await fs.readFile(unitPath, "utf8").catch((error: unknown) => {
+    if (hasErrnoCode(error, "ENOENT")) {
+      return null;
+    }
+    throw error;
+  });
+  if (current === null || removeLegacyGatewayVersionMetadata(current) === current) {
+    return false;
+  }
+
+  await assertNoSystemGatewayOwnership(env, remainingTimeoutMs());
+  return await withSystemdDefinitionMutation(
+    env,
+    env,
+    async (mutation) => {
+      const snapshot = mutation.snapshots.get(unitPath) ?? null;
+      if (!snapshot) {
+        return false;
+      }
+      const previous = snapshot.contents.toString("utf8");
+      const refreshed = removeLegacyGatewayVersionMetadata(previous);
+      if (refreshed === previous) {
+        return false;
+      }
+      // Ownership can change while the mutation snapshot is prepared. Recheck around
+      // publication and restore if a system unit takes ownership during that window.
+      await assertNoSystemGatewayOwnership(env, remainingTimeoutMs());
+      await mutation.publish(unitPath, refreshed, snapshot.mode || 0o644);
+      try {
+        await assertNoSystemGatewayOwnership(env, remainingTimeoutMs());
+        await reloadSystemdUserManager(env, remainingTimeoutMs());
+      } catch (error) {
+        await mutation.restore(unitPath, snapshot);
+        throw error;
+      }
+      return true;
+    },
+    { timeoutMs: remainingTimeoutMs() },
+  );
 }
 
 async function writeSystemdUnit({

--- a/src/daemon/systemd-scope.ts
+++ b/src/daemon/systemd-scope.ts
@@ -33,11 +33,14 @@ type InstalledSystemdGatewayScope = {
   unitPath: string;
 };
 
-export async function assertNoSystemGatewayOwnership(env: GatewayServiceEnv): Promise<void> {
+export async function assertNoSystemGatewayOwnership(
+  env: GatewayServiceEnv,
+  timeoutMs?: number,
+): Promise<void> {
   if (env.OPENCLAW_SERVICE_KIND?.trim() === "node") {
     return;
   }
-  await assertNoSystemSystemdOwnership(`${resolveSystemdServiceName(env)}.service`);
+  await assertNoSystemSystemdOwnership(`${resolveSystemdServiceName(env)}.service`, timeoutMs);
 }
 
 async function findMarkerOwnedSystemSystemdUnit(): Promise<{

--- a/src/daemon/systemd.test.ts
+++ b/src/daemon/systemd.test.ts
@@ -30,7 +30,7 @@ type ExecFileMock = (
 const execFileMock = vi.hoisted(() => vi.fn<ExecFileMock>());
 const existsSyncMock = vi.hoisted(() => vi.fn(() => false));
 const assertNoSystemSystemdOwnershipMock = vi.hoisted(() =>
-  vi.fn<(unitName: string) => Promise<void>>(async () => {}),
+  vi.fn<(unitName: string, timeoutMs?: number) => Promise<void>>(async () => {}),
 );
 const findSystemGatewayServicesMock = vi.hoisted(() =>
   vi.fn<
@@ -53,8 +53,10 @@ vi.mock("./inspect.js", () => ({
 
 vi.mock("./systemd-system.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("./systemd-system.js")>()),
-  assertNoSystemSystemdOwnership: (unitName: string) =>
-    assertNoSystemSystemdOwnershipMock(unitName),
+  assertNoSystemSystemdOwnership: (unitName: string, timeoutMs?: number) =>
+    timeoutMs === undefined
+      ? assertNoSystemSystemdOwnershipMock(unitName)
+      : assertNoSystemSystemdOwnershipMock(unitName, timeoutMs),
 }));
 
 vi.mock("node:fs", async (importOriginal) => ({
@@ -105,6 +107,7 @@ import {
   isSystemdUserServiceAvailable,
   readSystemdServiceRuntime,
   readSystemdServiceExecStart,
+  refreshLegacySystemdServiceMetadata,
   restartSystemdService,
   resolveSystemdUserServiceAccount,
   startSystemdService,
@@ -2370,6 +2373,160 @@ describe("stageSystemdService", () => {
     }));
     assertNoSystemSystemdOwnershipMock.mockReset();
     assertNoSystemSystemdOwnershipMock.mockResolvedValue();
+  });
+
+  it("removes legacy gateway version metadata without restarting the service", async () => {
+    await withStageFixture(async ({ env, unitPath }) => {
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.writeFile(
+        unitPath,
+        [
+          "[Unit]",
+          "Description=OpenClaw Gateway (v2026.7.1-2)",
+          "",
+          "[Service]",
+          "ExecStart=/usr/bin/openclaw gateway run",
+          "Environment=OPENCLAW_SERVICE_MARKER=openclaw",
+          "Environment=OPENCLAW_SERVICE_KIND=gateway",
+          'Environment=OPENCLAW_SERVICE_VERSION=2026.7.1-2 "OTHER_SETTING=kept value"',
+          "Environment=OPENCLAW_GATEWAY_PORT=18789",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+      execFileMock.mockImplementationOnce(systemctlUserSuccess("daemon-reload"));
+
+      await expect(refreshLegacySystemdServiceMetadata(env, 5_000)).resolves.toBe(true);
+
+      const unit = await fs.readFile(unitPath, "utf8");
+      expect(unit).toContain("Description=OpenClaw Gateway\n");
+      expect(unit).not.toContain("OPENCLAW_SERVICE_VERSION");
+      expect(unit).toContain('Environment="OTHER_SETTING=kept value"');
+      expect(unit).toContain("Environment=OPENCLAW_GATEWAY_PORT=18789");
+      expect(execFileMock).toHaveBeenCalledTimes(1);
+      for (const [, timeoutMs] of assertNoSystemSystemdOwnershipMock.mock.calls) {
+        expect(timeoutMs).toBeGreaterThan(0);
+        expect(timeoutMs).toBeLessThanOrEqual(5_000);
+      }
+      expect(assertNoSystemSystemdOwnershipMock).toHaveBeenCalledTimes(3);
+      expect(execFileMock.mock.calls[0]?.[2]).toMatchObject({
+        killSignal: "SIGKILL",
+        timeout: expect.any(Number),
+      });
+    });
+  });
+
+  it("preserves a hand-written unit with the formerly documented version metadata", async () => {
+    await withStageFixture(async ({ env, unitPath }) => {
+      const previous = [
+        "[Unit]",
+        "Description=OpenClaw Gateway (v2026.7.1-2)",
+        "",
+        "[Service]",
+        "ExecStart=/usr/bin/openclaw gateway run",
+        "Environment=OPENCLAW_SERVICE_VERSION=2026.7.1-2",
+        "",
+      ].join("\n");
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.writeFile(unitPath, previous, "utf8");
+      execFileMock.mockImplementationOnce(systemctlUserSuccess("daemon-reload"));
+
+      await expect(refreshLegacySystemdServiceMetadata(env, 5_000)).resolves.toBe(false);
+
+      await expect(fs.readFile(unitPath, "utf8")).resolves.toBe(previous);
+      expect(execFileMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it.each([
+    {
+      label: "version marker does not match the Description",
+      environment: [
+        "Environment=OPENCLAW_SERVICE_MARKER=openclaw",
+        "Environment=OPENCLAW_SERVICE_KIND=gateway",
+        "Environment=OPENCLAW_SERVICE_VERSION=2026.7.1-1",
+      ],
+    },
+    {
+      label: "managed markers were reset",
+      environment: [
+        "Environment=OPENCLAW_SERVICE_MARKER=openclaw OPENCLAW_SERVICE_KIND=gateway",
+        "Environment=",
+        "Environment=OPENCLAW_SERVICE_VERSION=2026.7.1-2",
+      ],
+    },
+  ])("preserves a unit when $label", async ({ environment }) => {
+    await withStageFixture(async ({ env, unitPath }) => {
+      const previous = [
+        "[Unit]",
+        "Description=OpenClaw Gateway (v2026.7.1-2)",
+        "",
+        "[Service]",
+        ...environment,
+        "",
+      ].join("\n");
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.writeFile(unitPath, previous, "utf8");
+
+      await expect(refreshLegacySystemdServiceMetadata(env, 5_000)).resolves.toBe(false);
+
+      await expect(fs.readFile(unitPath, "utf8")).resolves.toBe(previous);
+      expect(assertNoSystemSystemdOwnershipMock).not.toHaveBeenCalled();
+      expect(execFileMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("preserves legacy metadata when the system unit owns the gateway name", async () => {
+    await withStageFixture(async ({ env, unitPath }) => {
+      const previous = [
+        "[Unit]",
+        "Description=OpenClaw Gateway (v2026.7.1-2)",
+        "",
+        "[Service]",
+        "Environment=OPENCLAW_SERVICE_MARKER=openclaw",
+        "Environment=OPENCLAW_SERVICE_KIND=gateway",
+        "Environment=OPENCLAW_SERVICE_VERSION=2026.7.1-2",
+        "",
+      ].join("\n");
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.writeFile(unitPath, previous, "utf8");
+      assertNoSystemSystemdOwnershipMock.mockRejectedValueOnce(new Error("system ownership"));
+
+      await expect(refreshLegacySystemdServiceMetadata(env, 5_000)).rejects.toThrow(
+        "system ownership",
+      );
+
+      await expect(fs.readFile(unitPath, "utf8")).resolves.toBe(previous);
+      expect(execFileMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it("restores legacy metadata when system ownership appears after publication", async () => {
+    await withStageFixture(async ({ env, unitPath }) => {
+      const previous = [
+        "[Unit]",
+        "Description=OpenClaw Gateway (v2026.7.1-2)",
+        "",
+        "[Service]",
+        "Environment=OPENCLAW_SERVICE_MARKER=openclaw",
+        "Environment=OPENCLAW_SERVICE_KIND=gateway",
+        "Environment=OPENCLAW_SERVICE_VERSION=2026.7.1-2",
+        "",
+      ].join("\n");
+      await fs.mkdir(path.dirname(unitPath), { recursive: true });
+      await fs.writeFile(unitPath, previous, "utf8");
+      assertNoSystemSystemdOwnershipMock
+        .mockResolvedValueOnce()
+        .mockResolvedValueOnce()
+        .mockRejectedValueOnce(new Error("system ownership appeared"));
+
+      await expect(refreshLegacySystemdServiceMetadata(env, 5_000)).rejects.toThrow(
+        "system ownership appeared",
+      );
+
+      await expect(fs.readFile(unitPath, "utf8")).resolves.toBe(previous);
+      expect(execFileMock).not.toHaveBeenCalled();
+    });
   });
 
   it("blocks before mutating user files when the same system unit owns the name", async () => {

--- a/src/daemon/systemd.ts
+++ b/src/daemon/systemd.ts
@@ -9,6 +9,7 @@ export {
 } from "./systemd-exec.js";
 export {
   installSystemdService,
+  refreshLegacySystemdServiceMetadata,
   stageSystemdService,
   uninstallSystemdService,
 } from "./systemd-install.js";


### PR DESCRIPTION
## Summary

Fixes #134202.

After an npm global update performed with `--no-restart`, `gateway restart --safe` now removes retired version stamps from a positively identified legacy OpenClaw-managed systemd user unit before sending the Gateway restart request:

- `Description=OpenClaw Gateway (..., v<old>)` becomes the current versionless description.
- `OPENCLAW_SERVICE_VERSION=<old>` is removed.

Safe restart remains RPC-driven and does not call the native service-manager restart path. Cleanup failure is warned; systemd manager calls share a finite five-second budget so a wedged manager cannot indefinitely suppress the restart request.

## Root cause and owner

The 2026.7.1-2 systemd generator recorded install-time version metadata. Current generators intentionally emit no version stamp, but the safe-restart route returns through the Gateway RPC before any definition rewrite. A package-only update therefore starts the new runtime while leaving the old generated unit text intact.

The systemd definition owner now exposes a definition-only cleanup operation. It requires the legacy generator's complete ownership tuple—`OPENCLAW_SERVICE_MARKER=openclaw`, `OPENCLAW_SERVICE_KIND=gateway`, and a Description/version-environment match—before mutation. It preserves adjacent environment assignments, rejects a conflicting system-scope owner before and around publication, reuses `withSystemdDefinitionMutation` for serialization and atomic publication, reloads the user manager, and restores the prior unit if ownership changes or reload fails.

Issue #134202 was opened and self-assigned by a repository write maintainer and explicitly requests refreshed unit metadata after successful safe restart. This patch implements that requested contract only for proven legacy managed units; hand-written units remain byte-identical.

## RED / GREEN

RED on pre-fix/reviewed code:

- The original regression failed because no definition-only cleanup capability existed.
- A documented hand-written canonical unit was rewritten when it carried the retired version field.
- The safe-restart cleanup received no timeout, allowing unbounded pre-RPC systemd calls.

GREEN on exact head `cfd057ecca`:

- 426/426 affected lifecycle, systemd, definition-mutation, ownership-deadline, and child-timeout tests passed.
- Hand-written units, mismatched versions, and reset ownership markers remain byte-identical without ownership probes or reload.
- The exact legacy generator tuple is cleaned while adjacent assignments are preserved.
- All definition inspections, lock waits, ownership probes, and daemon reload receive positive remaining time from one five-second deadline; command execution uses `SIGKILL` at timeout.
- Real lock-contention coverage falls from the pre-fix 5.2-second fresh retry window to bounded rejection in about 100 ms.
- Cleanup rejection still emits a warning and sends the bounded safe-restart RPC.
- `pnpm check:changed` passed core/core-test typechecks, lint, dead-code, database-first, cycle, and auth guards.
- Fresh branch autoreview against current `main`: scoped clean, correctness 0.98.

## Live packaged proof

Ubuntu 24.04.4 LTS, systemd 255, npm-global 2026.7.1-2 → candidate 2026.8.1:

- Before: CLI/Gateway 2026.7.1-2; the generated unit contained the legacy marker/kind tuple and both stale 2026.7.1-2 fields.
- Safe restart returned `result: "scheduled"`.
- After: CLI/Gateway 2026.8.1; the unit contained `Description=OpenClaw Gateway` and no `OPENCLAW_SERVICE_VERSION`.
- Harness emitted `REPRO_GREEN`.

An additional live run with a deliberately noncanonical `OPENCLAW_STATE_DIR` emitted the mutation-policy warning, left the legacy unit unchanged, still returned `result: "scheduled"`, and brought the Gateway up on 2026.8.1. This proves cleanup eligibility does not gate the safe restart itself.

The harness removed only the unrelated 8.1-written `meta.lastTouchedAt` key because current main rejects it before lifecycle dispatch. It did not run Doctor, which would have rewritten the unit under test.

## Review findings addressed

- Cleanup is restricted to the historical generator's complete marker/kind/matching-version tuple; formerly documented hand-written units are preserved byte-for-byte.
- The safe-restart owner supplies a required five-second cleanup budget, propagated as one decreasing deadline through definition inspection, lock acquisition, system-scope ownership checks, and daemon reload.
- Cleanup errors are warned and the safe-restart RPC still runs.
- Canonical service-mutation eligibility gates external-supervisor, conflicting-identity, and noncanonical-state installs.
- Systemd environment parsing removes only `OPENCLAW_SERVICE_VERSION` and preserves adjacent assignments.
- Conflicting system-scope ownership is checked before and immediately after publication; a race restores the byte-identical snapshot before daemon reload.

## Review metrics

- Production: +172/-23 (net +149)
- Tests: +237/-6 (net +231)
- Generated/lockfiles: 0

Positive production LOC is the definition-owner capability plus safe-restart wiring: authoritative legacy provenance parsing, assignment-preserving cleanup, missing-unit no-op, canonical eligibility/ownership/serialization, atomic publish and rollback, and one bounded best-effort deadline through manager reads and lock acquisition. Existing install/Doctor paths perform broader rewrites, while native restart violates safe-restart deferral; no smaller existing owner seam satisfies both contracts.

AI-assisted: yes. No agent transcript included.
