### PR TITLE
fix: prevent device pairing migration crash on contaminated records

### DIFF
--- a/src/infra/device-pairing-migration.test.ts
+++ b/src/infra/device-pairing-migration.test.ts
@@ -55,7 +55,7 @@ function legacyPairedDevice(deviceId: string, extra: Partial<PairedDevice> = {})
 
 async function writeLegacyFiles(
   baseDir: string,
-  files: { paired?: Record<string, PairedDevice>; pending?: unknown; bootstrap?: unknown },
+  files: { paired?: Record<string, unknown>; pending?: unknown; bootstrap?: unknown },
 ): Promise<string> {
   const devicesDir = path.join(baseDir, "devices");
   await fs.mkdir(devicesDir, { recursive: true });
@@ -144,6 +144,35 @@ describe("migrateLegacyDevicePairingStore", () => {
     const result = await migrateLegacyDevicePairingStore({ baseDir });
     expect(result).toEqual({ imported: 0, skippedExisting: 1 });
     expect((await getPairedDevice("device-a", baseDir))?.publicKey).toBe("pk-current");
+  });
+
+  test("imports valid paired rows while skipping pending-shaped entries in paired.json", async () => {
+    const baseDir = await suiteRootTracker.make("contaminated-paired");
+    const devicesDir = await writeLegacyFiles(baseDir, {
+      paired: {
+        "device-a": legacyPairedDevice("device-a"),
+        "request-a": {
+          requestId: "request-a",
+          deviceId: "device-a",
+          publicKey: "pk-device-a",
+          ts: 1_700_000_000_000,
+        },
+        "invalid-timestamp": legacyPairedDevice("invalid-timestamp", {
+          createdAtMs: 1e100,
+        }),
+      },
+    });
+    const warnings: string[] = [];
+
+    const result = await migrateLegacyDevicePairingStore({
+      baseDir,
+      log: { info: () => {}, warn: (message) => warnings.push(message) },
+    });
+
+    expect(result).toEqual({ imported: 1, skippedExisting: 0 });
+    expect((await getPairedDevice("device-a", baseDir))?.publicKey).toBe("pk-device-a");
+    expect(warnings).toEqual(["device pairing store migration skipped 2 invalid paired record(s)"]);
+    expect(await listDeviceFiles(devicesDir)).toEqual(["paired.json.migrated"]);
   });
 
   test("returns null when no legacy files exist", async () => {

--- a/src/infra/device-pairing-migration.test.ts
+++ b/src/infra/device-pairing-migration.test.ts
@@ -146,7 +146,7 @@ describe("migrateLegacyDevicePairingStore", () => {
     expect((await getPairedDevice("device-a", baseDir))?.publicKey).toBe("pk-current");
   });
 
-  test("imports valid paired rows while skipping pending-shaped entries in paired.json", async () => {
+  test("imports valid paired rows while skipping records SQLite cannot persist", async () => {
     const baseDir = await suiteRootTracker.make("contaminated-paired");
     const devicesDir = await writeLegacyFiles(baseDir, {
       paired: {
@@ -160,6 +160,13 @@ describe("migrateLegacyDevicePairingStore", () => {
         "invalid-timestamp": legacyPairedDevice("invalid-timestamp", {
           createdAtMs: 1e100,
         }),
+        "invalid-last-seen": legacyPairedDevice("invalid-last-seen", {
+          lastSeenAtMs: 1e100,
+        }),
+        "invalid-text": {
+          ...legacyPairedDevice("invalid-text"),
+          displayName: { value: "Device" },
+        },
       },
     });
     const warnings: string[] = [];
@@ -171,7 +178,7 @@ describe("migrateLegacyDevicePairingStore", () => {
 
     expect(result).toEqual({ imported: 1, skippedExisting: 0 });
     expect((await getPairedDevice("device-a", baseDir))?.publicKey).toBe("pk-device-a");
-    expect(warnings).toEqual(["device pairing store migration skipped 2 invalid paired record(s)"]);
+    expect(warnings).toEqual(["device pairing store migration skipped 4 invalid paired record(s)"]);
     expect(await listDeviceFiles(devicesDir)).toEqual(["paired.json.migrated"]);
   });
 

--- a/src/infra/device-pairing-migration.test.ts
+++ b/src/infra/device-pairing-migration.test.ts
@@ -146,7 +146,7 @@ describe("migrateLegacyDevicePairingStore", () => {
     expect((await getPairedDevice("device-a", baseDir))?.publicKey).toBe("pk-current");
   });
 
-  test("imports valid paired rows while skipping records SQLite cannot persist", async () => {
+  test("imports usable paired rows while omitting invalid optional fields", async () => {
     const baseDir = await suiteRootTracker.make("contaminated-paired");
     const devicesDir = await writeLegacyFiles(baseDir, {
       paired: {
@@ -176,9 +176,18 @@ describe("migrateLegacyDevicePairingStore", () => {
       log: { info: () => {}, warn: (message) => warnings.push(message) },
     });
 
-    expect(result).toEqual({ imported: 1, skippedExisting: 0 });
+    expect(result).toEqual({ imported: 3, skippedExisting: 0 });
     expect((await getPairedDevice("device-a", baseDir))?.publicKey).toBe("pk-device-a");
-    expect(warnings).toEqual(["device pairing store migration skipped 4 invalid paired record(s)"]);
+    const normalizedLastSeen = await getPairedDevice("invalid-last-seen", baseDir);
+    expect(normalizedLastSeen?.publicKey).toBe("pk-invalid-last-seen");
+    expect(normalizedLastSeen?.lastSeenAtMs).toBeUndefined();
+    const normalizedText = await getPairedDevice("invalid-text", baseDir);
+    expect(normalizedText?.publicKey).toBe("pk-invalid-text");
+    expect(normalizedText?.displayName).toBeUndefined();
+    expect(warnings).toEqual([
+      "device pairing store migration skipped 2 invalid paired record(s)",
+      "device pairing store migration omitted 2 invalid optional field(s)",
+    ]);
     expect(await listDeviceFiles(devicesDir)).toEqual(["paired.json.migrated"]);
   });
 

--- a/src/infra/device-pairing-migration.ts
+++ b/src/infra/device-pairing-migration.ts
@@ -8,6 +8,7 @@
 // setup codes are reissued.
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { withPairedDeviceRecords, type PairedDevice } from "./device-pairing.js";
 import {
   coercePairingStateRecord,
@@ -20,19 +21,36 @@ type LegacyDevicePairingMigrationResult = {
   skippedExisting: number;
 };
 
-function isValidLegacyPairedDevice(record: unknown): record is PairedDevice {
-  if (!record || typeof record !== "object" || Array.isArray(record)) {
+const SQLITE_TEXT_FIELDS = [
+  "displayName",
+  "operatorLabel",
+  "platform",
+  "deviceFamily",
+  "clientId",
+  "clientMode",
+  "browserOrigin",
+  "role",
+  "remoteIp",
+  "approvedVia",
+  "lastSeenReason",
+] as const satisfies readonly (keyof PairedDevice)[];
+
+function isPersistableLegacyPairedDevice(record: PairedDevice): boolean {
+  if (!isRecord(record)) {
     return false;
   }
-  // SAFETY: the object/array guard makes this a safe property-read view; each field is checked below.
-  const candidate = record as Partial<PairedDevice>;
   return (
-    typeof candidate.publicKey === "string" &&
-    candidate.publicKey.trim().length > 0 &&
-    typeof candidate.createdAtMs === "number" &&
-    Number.isSafeInteger(candidate.createdAtMs) &&
-    typeof candidate.approvedAtMs === "number" &&
-    Number.isSafeInteger(candidate.approvedAtMs)
+    typeof record.publicKey === "string" &&
+    record.publicKey.trim().length > 0 &&
+    typeof record.createdAtMs === "number" &&
+    Number.isSafeInteger(record.createdAtMs) &&
+    typeof record.approvedAtMs === "number" &&
+    Number.isSafeInteger(record.approvedAtMs) &&
+    (record.lastSeenAtMs === undefined ||
+      (typeof record.lastSeenAtMs === "number" && Number.isSafeInteger(record.lastSeenAtMs))) &&
+    SQLITE_TEXT_FIELDS.every(
+      (field) => record[field] === undefined || typeof record[field] === "string",
+    )
   );
 }
 
@@ -79,7 +97,7 @@ export async function migrateLegacyDevicePairingStore(params?: {
     return null;
   }
 
-  const legacyPaired = coercePairingStateRecord<unknown>(pairedRaw);
+  const legacyPaired = coercePairingStateRecord<PairedDevice>(pairedRaw);
   let imported = 0;
   let skippedExisting = 0;
   let skippedInvalid = 0;
@@ -87,7 +105,7 @@ export async function migrateLegacyDevicePairingStore(params?: {
     await withPairedDeviceRecords(params?.baseDir, (pairedByDeviceId) => {
       for (const [rawDeviceId, record] of Object.entries(legacyPaired)) {
         const deviceId = rawDeviceId.trim();
-        if (!deviceId || !isValidLegacyPairedDevice(record)) {
+        if (!deviceId || !isPersistableLegacyPairedDevice(record)) {
           skippedInvalid += 1;
           continue;
         }

--- a/src/infra/device-pairing-migration.ts
+++ b/src/infra/device-pairing-migration.ts
@@ -35,23 +35,34 @@ const SQLITE_TEXT_FIELDS = [
   "lastSeenReason",
 ] as const satisfies readonly (keyof PairedDevice)[];
 
-function isPersistableLegacyPairedDevice(record: PairedDevice): boolean {
+function normalizeLegacyPairedDevice(
+  record: PairedDevice,
+): { device: PairedDevice; omittedFields: number } | null {
   if (!isRecord(record)) {
-    return false;
+    return null;
   }
-  return (
-    typeof record.publicKey === "string" &&
-    record.publicKey.trim().length > 0 &&
-    typeof record.createdAtMs === "number" &&
-    Number.isSafeInteger(record.createdAtMs) &&
-    typeof record.approvedAtMs === "number" &&
-    Number.isSafeInteger(record.approvedAtMs) &&
-    (record.lastSeenAtMs === undefined ||
-      (typeof record.lastSeenAtMs === "number" && Number.isSafeInteger(record.lastSeenAtMs))) &&
-    SQLITE_TEXT_FIELDS.every(
-      (field) => record[field] === undefined || typeof record[field] === "string",
-    )
-  );
+  if (
+    typeof record.publicKey !== "string" ||
+    !record.publicKey.trim() ||
+    !Number.isSafeInteger(record.createdAtMs) ||
+    !Number.isSafeInteger(record.approvedAtMs)
+  ) {
+    return null;
+  }
+
+  const device = { ...record };
+  let omittedFields = 0;
+  if (device.lastSeenAtMs !== undefined && !Number.isSafeInteger(device.lastSeenAtMs)) {
+    delete device.lastSeenAtMs;
+    omittedFields += 1;
+  }
+  for (const field of SQLITE_TEXT_FIELDS) {
+    if (device[field] !== undefined && typeof device[field] !== "string") {
+      delete device[field];
+      omittedFields += 1;
+    }
+  }
+  return { device, omittedFields };
 }
 
 async function archiveLegacyFile(filePath: string): Promise<void> {
@@ -101,11 +112,12 @@ export async function migrateLegacyDevicePairingStore(params?: {
   let imported = 0;
   let skippedExisting = 0;
   let skippedInvalid = 0;
+  let omittedInvalidFields = 0;
   if (Object.keys(legacyPaired).length > 0) {
     await withPairedDeviceRecords(params?.baseDir, (pairedByDeviceId) => {
       for (const [rawDeviceId, record] of Object.entries(legacyPaired)) {
         const deviceId = rawDeviceId.trim();
-        if (!deviceId || !isPersistableLegacyPairedDevice(record)) {
+        if (!deviceId) {
           skippedInvalid += 1;
           continue;
         }
@@ -113,7 +125,13 @@ export async function migrateLegacyDevicePairingStore(params?: {
           skippedExisting += 1;
           continue;
         }
-        pairedByDeviceId[deviceId] = { ...record, deviceId };
+        const normalized = normalizeLegacyPairedDevice(record);
+        if (!normalized) {
+          skippedInvalid += 1;
+          continue;
+        }
+        omittedInvalidFields += normalized.omittedFields;
+        pairedByDeviceId[deviceId] = { ...normalized.device, deviceId };
         imported += 1;
       }
       return { value: undefined, persist: imported > 0 };
@@ -123,6 +141,11 @@ export async function migrateLegacyDevicePairingStore(params?: {
   if (skippedInvalid > 0) {
     params?.log?.warn(
       `device pairing store migration skipped ${skippedInvalid} invalid paired record(s)`,
+    );
+  }
+  if (omittedInvalidFields > 0) {
+    params?.log?.warn(
+      `device pairing store migration omitted ${omittedInvalidFields} invalid optional field(s)`,
     );
   }
 

--- a/src/infra/device-pairing-migration.ts
+++ b/src/infra/device-pairing-migration.ts
@@ -20,6 +20,22 @@ type LegacyDevicePairingMigrationResult = {
   skippedExisting: number;
 };
 
+function isValidLegacyPairedDevice(record: unknown): record is PairedDevice {
+  if (!record || typeof record !== "object" || Array.isArray(record)) {
+    return false;
+  }
+  // SAFETY: the object/array guard makes this a safe property-read view; each field is checked below.
+  const candidate = record as Partial<PairedDevice>;
+  return (
+    typeof candidate.publicKey === "string" &&
+    candidate.publicKey.trim().length > 0 &&
+    typeof candidate.createdAtMs === "number" &&
+    Number.isSafeInteger(candidate.createdAtMs) &&
+    typeof candidate.approvedAtMs === "number" &&
+    Number.isSafeInteger(candidate.approvedAtMs)
+  );
+}
+
 async function archiveLegacyFile(filePath: string): Promise<void> {
   try {
     await fs.rename(filePath, `${filePath}.migrated`);
@@ -63,14 +79,16 @@ export async function migrateLegacyDevicePairingStore(params?: {
     return null;
   }
 
-  const legacyPaired = coercePairingStateRecord<PairedDevice>(pairedRaw);
+  const legacyPaired = coercePairingStateRecord<unknown>(pairedRaw);
   let imported = 0;
   let skippedExisting = 0;
+  let skippedInvalid = 0;
   if (Object.keys(legacyPaired).length > 0) {
     await withPairedDeviceRecords(params?.baseDir, (pairedByDeviceId) => {
       for (const [rawDeviceId, record] of Object.entries(legacyPaired)) {
         const deviceId = rawDeviceId.trim();
-        if (!deviceId) {
+        if (!deviceId || !isValidLegacyPairedDevice(record)) {
+          skippedInvalid += 1;
           continue;
         }
         if (pairedByDeviceId[deviceId]) {
@@ -82,6 +100,12 @@ export async function migrateLegacyDevicePairingStore(params?: {
       }
       return { value: undefined, persist: imported > 0 };
     });
+  }
+
+  if (skippedInvalid > 0) {
+    params?.log?.warn(
+      `device pairing store migration skipped ${skippedInvalid} invalid paired record(s)`,
+    );
   }
 
   await Promise.all([


### PR DESCRIPTION
Closes #134340

## What Problem This Solves

Operators upgrading from the retired JSON device-pairing store can have pending requests or malformed values inside `devices/paired.json`. One bad record aborts the full JSON-to-SQLite import, keeps every valid pairing out of SQLite, and repeats the failed migration on each gateway start.

The pairing migration failure is caught and logged. It does not stop gateway startup by itself. The field report also contained a separate legacy session-store blocker.

## Why This Change Was Made

The migration now validates every field that SQLite binds directly. It skips records with invalid required pairing data. When only optional metadata is malformed, it omits that field and preserves the usable pairing. The original legacy store is archived only after the safe import completes.

Validation includes required timestamps, optional `lastSeenAtMs`, and optional text columns. Separate warnings report skipped records and omitted optional fields. The SQLite mapper remains strict, and no schema or fallback path changes.

## User Impact

Valid device pairings survive an upgrade even when the legacy file also contains pending requests or malformed records. The gateway completes the import once and does not retry it after restart.

## Evidence

- Current-main red at `77fee957919f06dbaff09dd5cc7f9664d9655651`: a normal isolated gateway logged `NOT NULL constraint failed: device_pairing_paired.created_at_ms` for a pending-shaped leaf and retained `paired.json`.
- Anti-cheat red: changing the malformed leaf to `lastSeenAtMs: 1e100` logged `cannot store REAL value in INTEGER column device_pairing_paired.last_seen_at_ms`.
- Regression red on contributor head `ee7ea2bfbc5bde3e1b6f90ea58e4d070b7e7ff61`: the expanded boundary test failed with `Provided value cannot be bound to SQLite parameter 47`.
- Fixed-head boundary proof: `node scripts/run-vitest.mjs src/infra/device-pairing-migration.test.ts` passed 7/7; targeted formatting and Oxlint passed.
- Optional-preservation red on `4f47648f1d6bcf279697d4e8ec5044960bb27cf5`: the corrected regression failed because only one row imported instead of preserving three usable pairings.
- Final real gateway proof: startup returned `status=started`, imported three usable pairings, stored malformed optional metadata as `NULL`, skipped one record with invalid required data, archived `paired.json`, and restarted with no migration log.
