### PR TITLE
fix(tooling): expose pako to linked worktrees

### DIFF
--- a/package.json
+++ b/package.json
@@ -2155,6 +2155,7 @@
     "oxfmt": "0.60.0",
     "oxlint": "1.79.0",
     "oxlint-tsgolint": "7.0.2001",
+    "pako": "3.0.1",
     "playwright": "1.62.1",
     "postcss": "8.5.26",
     "postcss-lit": "1.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,6 +458,9 @@ importers:
       oxlint-tsgolint:
         specifier: 7.0.2001
         version: 7.0.2001
+      pako:
+        specifier: 3.0.1
+        version: 3.0.1
       playwright:
         specifier: 1.62.1
         version: 1.62.1


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where linked OpenClaw worktrees running script typechecks could
resolve the transitive root `pako@1` package instead of the UI-owned typed
`pako@3`, causing `TS7016` in `ui/vite.config.ts`.

## Why This Change Was Made

The script toolchain imports the UI Vite config, while linked worktrees expose
only the root `node_modules`. Declaring the same pinned `pako@3.0.1` package at
the root makes that shared importer resolve the intended runtime and published
types. The UI dependency remains unchanged, and JSZip retains its locked
`pako@1` dependency.

## User Impact

Developers can run script typechecks and changed-file gates from linked
worktrees without package-resolution failures. There is no production runtime
change.

## Evidence

- dependency pin guard passed
- root dependency ownership audit passed
- manifest and lockfile formatting/order checks passed
- `git diff --check` passed
- Codex autoreview passed with no findings (`0.99`)
- exact-head CI will provide the required fresh-install and script-typecheck proof

Review metrics: production `+0/-0`; tests `+0/-0`; dependency metadata `+4/-0`.
No changelog entry is required for this internal tooling correction.
