### PR TITLE
test: exercise shared helper fixture contracts

### DIFF
--- a/src/shared/bounded-serial-queue.test.ts
+++ b/src/shared/bounded-serial-queue.test.ts
@@ -104,8 +104,7 @@ describe("BoundedSerialQueue", () => {
     const queue = new BoundedSerialQueue({ maxPendingCount: 2, maxPendingWeight: 2 });
     const active = queue.enqueue(async () => await first.promise);
     const flush = queue.flush();
-    const repeatedFlushes = Array.from({ length: 10_000 }, () => queue.flush());
-    expect(new Set([flush, ...repeatedFlushes]).size).toBe(1);
+    expect(queue.flush()).toBe(flush);
     const late = queue.enqueue(async () => await second.promise);
     const flushed = vi.fn();
     void flush.then(flushed);

--- a/src/shared/config-eval.test.ts
+++ b/src/shared/config-eval.test.ts
@@ -1,4 +1,3 @@
-// Config eval tests cover dynamic config loading and evaluation guards.
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -230,6 +229,7 @@ describe("evaluateRuntimeEligibility", () => {
   });
 
   it("accepts entries when remote platform satisfies OS requirements", () => {
+    setPlatform("darwin");
     const result = evaluateRuntimeEligibility({
       os: ["linux"],
       remotePlatforms: ["linux"],

--- a/src/shared/global-singleton.test.ts
+++ b/src/shared/global-singleton.test.ts
@@ -1,4 +1,3 @@
-// Global singleton tests cover process-wide singleton creation and reset behavior.
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   drainGlobalSingletonLifecycleState,
@@ -44,18 +43,13 @@ describe("resolveGlobalSingleton", () => {
 });
 
 describe("resolveGlobalMap", () => {
-  it("reuses the same map instance", () => {
+  it("reuses the same map instance and preserves its contents", () => {
     const first = resolveGlobalMap<string, number>(TEST_MAP_KEY);
+    first.set("a", 1);
     const second = resolveGlobalMap<string, number>(TEST_MAP_KEY);
 
     expect(first).toBe(second);
-  });
-
-  it("preserves existing map contents across repeated resolution", () => {
-    const map = resolveGlobalMap<string, number>(TEST_MAP_KEY);
-    map.set("a", 1);
-
-    expect(resolveGlobalMap<string, number>(TEST_MAP_KEY).get("a")).toBe(1);
+    expect(second.get("a")).toBe(1);
   });
 
   it("reuses a prepopulated global map without creating a new one", () => {

--- a/src/shared/tailscale-status.test.ts
+++ b/src/shared/tailscale-status.test.ts
@@ -84,19 +84,15 @@ describe("shared/tailscale-status", () => {
   });
 
   it("returns null for non-zero exits, blank output, or invalid json", async () => {
-    const run = vi
-      .fn()
-      .mockResolvedValueOnce({ code: null, stdout: "boom" })
-      .mockResolvedValueOnce({ code: 1, stdout: "boom" })
-      .mockResolvedValueOnce({ code: 0, stdout: "   " });
-
-    await expect(resolveTailnetHostWithRunner(run)).resolves.toBeNull();
-
-    const invalid = vi.fn().mockResolvedValue({
-      code: 0,
-      stdout: "not-json",
-    });
-    await expect(resolveTailnetHostWithRunner(invalid)).resolves.toBeNull();
+    for (const result of [
+      { code: null, stdout: "boom" },
+      { code: 1, stdout: "boom" },
+      { code: 0, stdout: "   " },
+      { code: 0, stdout: "not-json" },
+    ]) {
+      const run = vi.fn().mockResolvedValue(result);
+      await expect(resolveTailnetHostWithRunner(run)).resolves.toBeNull();
+    }
   });
 
   it("finds persistent HTTPS Serve routes that proxy the gateway root", async () => {


### PR DESCRIPTION
## What Problem This Solves

Two shared-helper fixtures can pass without exercising the behavior their names describe: the Tailscale test queues blank output after both command candidates are exhausted, and the remote-platform test can succeed through the local Linux platform. The queue and singleton suites also repeat setup for contracts that can be checked directly.

## Why This Change Was Made

Give each invalid Tailscale result a fresh runner, and make the remote-platform case explicitly use a different local platform. Keep the existing assertions. Check repeated flush identity once instead of making 10,000 identical calls, and combine map identity and content preservation in one fixture. Lifecycle, overflow, ordering, platform, malformed-input and shipped SDK formatter cases remain.

## User Impact

No production behavior changes. Four test files: +14/-25 lines, net -11; production and test support unchanged. The focused owner/sibling group goes from 64 cases to 63 by consolidating the two map cases. No performance improvement is claimed.

## Evidence

On main `41ee2cc04f0c`, the normal focused wrapper passed all 64 baseline cases and all 63 candidate cases. Every other per-file case name, project, order and result is unchanged. All 20 changed-file checks passed, including core-test types, formatting, lint and repository guards. Fresh managed Codex review is scoped-clean at the configured P0 threshold; manual owner and coverage review is separate.

Two temporary fault controls prove the fixture repairs: disabling remote-platform matching still passes the old fixture with a Linux host but fails the corrected case; returning a non-null marker only for blank Tailscale output passes the old fixture but fails the corrected null assertion. Both original production owners were restored before the ordinary candidate run. The simplified queue assertion also fails against the historical pre-fix owner that allocates a new flush promise on every call. These are test-discrimination checks, not claims of current production defects.

## Review follow-through

Completed ClawSweeper review [5485355515](https://github.com/openclaw/openclaw/pull/134485#issuecomment-5485355515) found no correctness issue. Its request to check the unavailable earlier review is resolved: the retained earlier comment 5485295092 was a review-started placeholder, with no completed verdict or rank-up instruction. The full current comment set has been read. This maintainer-requested cleanup is being handled through the normal native review and landing workflow; no automated closure is requested. Exact-head CI 33443374441 passed.
