### PR TITLE
perf: skip unused ordinary-table SQL normalization

### DIFF
--- a/src/infra/sqlite-schema-contract.ts
+++ b/src/infra/sqlite-schema-contract.ts
@@ -439,7 +439,10 @@ function collectSqliteTableContract(
     name: trigger.name,
     sql: normalizeSchemaSql(trigger.sql),
   }));
-  const normalizedTableSql = normalizeSchemaSql(table.sql);
+  // This literal prefix cannot become CREATE VIRTUAL TABLE after normalization.
+  const normalizedTableSql = table.sql?.startsWith("CREATE TABLE ")
+    ? null
+    : normalizeSchemaSql(table.sql);
   const isVirtualTable =
     normalizedTableSql !== null && /^CREATE VIRTUAL TABLE /iu.test(normalizedTableSql);
 


### PR DESCRIPTION
## Why

Schema inspection normalizes every table's full CREATE SQL just to determine whether it describes a virtual table. When a definition already begins with the literal `CREATE TABLE ` prefix, normalization cannot turn it into `CREATE VIRTUAL TABLE `.

## Change

Skip that classification-only normalization for the exact ordinary prefix. All other prefixes and null SQL retain the original normalizer; malformed definitions still reach the unchanged parser. Column and constraint parsing, table metadata, indexes, triggers, native query order, authorizers and the existing expected-schema cache are unchanged. The repository-formatted diff is **+4 / −1, net +3 production lines**, including the invariant comment, and introduces no cache, dependency, option, schema version or storage path.

## Measured scope

The real complete schema inspector ran against private in-memory SQLite databases, including both canonical OpenClaw schemas. Four fixed fresh processes ran before/candidate/candidate/before, with twelve workloads, four warmup blocks and eleven measured blocks per row. All 528 measured blocks, 192 warmups and 48 first calls are retained; no recalibration, dropped sample or retry.

| Complete inspection | Before → candidate, forward | Before → candidate, reverse |
| --- | --- | --- |
| Canonical state schema | 12.066 → 11.116 ms | 12.103 → 11.154 ms |
| Canonical agent schema | 3.342 → 3.245 ms | 3.412 → 3.105 ms |
| Ordinary 32-column table | 81.630 → 58.471 µs | 80.505 → 61.089 µs |
| Ordinary small table | 16.264 → 16.298 µs | 16.257 → 15.904 µs |

The state-schema case improved about 8% and the wide-table case 24–28%; the ordinary small case is essentially flat. All four slower median observations remain: small-table +0.034 µs forward, missing-table +0.020 µs forward, empty-contract +0.023 µs reverse, warm-name control +0.008 µs reverse. Six slower first calls remain, including mixed ordinary/virtual +167 µs forward. These are workload-local first calls after imports, not process-cold startup measurements.

The unchanged named-index control also improved 4–6%, so these results do not support attributing every faster row to the patch or claiming an aggregate speedup. No whole-Gateway, startup, disk, memory, statistical-significance or allocation improvement is claimed. Candidate maximum RSS was slightly higher in both process pairs and remains recorded.

## Correctness and provenance

The full proof passed 76 exact paired classifications/assertions, native query traces and authorizer sequences. Each variant retained 16,788 native observations and 20,442 authorizer observations; twelve independent saved-output hashes bind all timing rows. The root and an independent agent checked every raw pair and recomputed the timing medians. Ordinary, virtual/FTS, mixed, quoted/commented, malformed catalog, additive compatibility, migration, optional index/trigger and denial/recovery cases remain intact.

The first proof attempt failed during synthetic corrupt-catalog construction under Node's defensive mode, before either inspector. That failed run and its 59 completed pairs remain preserved. The corrected fixture briefly permits the same synthetic metadata write, then restores writable-schema OFF and defensive mode ON before either implementation runs; no production protection changed. All prior 59 pair results match the successful run. The immutable manifest's historical proof-reference label is documented as stale; every actual timing authorization, executable gate and result binds the successful second proof by hash.

Source capture, compilation and measurement commits remain separately identified. The baseline compiled graph was prepared at e42; the successful correctness and timing executions used `9b123e263448b9d0cb673768ffb8b9ac185acdac` with an explicitly recorded unrelated projection edit. No evidence is relabelled as the later integration commit. All owned processes, groups and temporary runtime directories were physically verified gone.

On fresh integration baseline `f0e5968666b08693a99eb2c83380bc48909ca53d`, both baseline and candidate schema/index/state/agent suites pass: **356 tests and five skipped**. All measured executable inputs remain unchanged; only two verification documentation files drifted and were read. Formatting changes only the candidate ternary layout; full parser-based whitespace-minified JavaScript is identical. Managed Codex P0 review is scoped-clean and is supplemented by independent all-priority source and raw-evidence review. Changed checks pass in 248.18 seconds. Candidate commit is `91719536f94f6b0d2047de772a40bf4c8b0458bc`; its exact native-checkout build, real Gateway proof and CI now pass.

## Current validation status

Exact-head [CI run33443510142](https://github.com/openclaw/openclaw/actions/runs/33443510142) is green. The local full build failed before the unified compiler ran: the independently changed build-cache scanner traversed nested worktrees and exceeded Node’s variadic argument stack. That failure is retained and was repaired separately in [PR #134501](https://github.com/openclaw/openclaw/pull/134501). This PR’s unchanged published commit was then fully built in its native managed checkout in 172.70 seconds. No partial build was used. Its real Gateway completed four OpenAI turns (ready, Tool Search, local read and two sequential web fetch modes), plus three system-event calls, two status calls and twelve session-list calls. The closed transcript contains 27 rows and the exact Markdown/text dispatch/result pairs. All 12,308 build artifact hashes remained unchanged; the process/group and loopback port are gone, and temporary configuration and key pipe were removed.

I read the [latest ClawSweeper review and Rank-up moves](https://github.com/openclaw/openclaw/pull/134486#issuecomment-5485265364). The retained raw benchmark rows were independently checked and every reported median recomputed; the complete before/candidate proof and counter-order controls remain the basis for the limited claims above. The automatic persisted-table warning is not applicable: this patch changes an in-memory classification fast path, with no schema SQL, stored table, migration, version, write or query change. The existing migration/compatibility suites pass on both revisions.

The retained main-thread CPU profile has 18,540 samples and includes the changed schema-contract collector (11 call-tree nodes, 25 self and 68 inclusive samples). These are sampled execution evidence, not invocation counts, prefix-branch coverage or comparative performance. A separate worker profile is retained without combining its timing scope. Fresh committed Codex review is scoped-clean; independent source and raw timing audits are complete.

The latest ClawSweeper review (22:24 UTC, same exact head) again found no correctness/security issue. Its optional raw-evidence rank-up is addressed below with every recorded block and first call, stripped of local paths and unrelated runtime fields. The persisted-table warning remains inapplicable for the source reasons above; the owner-level classification invariant and full behavior proof support landing.

<details>
<summary>Raw fixed-workload timing observations</summary>

Nanoseconds. Each sample/warmup is a complete block; divide by the row’s iteration count for per-call time. All four fixed process runs, twelve rows, 528 measured blocks, 192 warmup blocks and 48 first calls are included. These are the original observations, not a new run. The original result hash accompanies each run.

```json
{"units":"nanoseconds; divide each block by iterations for per-call durations","order":["F-before","F-candidate","R-candidate","R-before"],"measuredBlocks":528,"warmupBlocks":192,"firstCalls":48,"runs":[{"run":"F-before","rawResultSha256":"d6da534236de500cd372547b9a17475247edc316b4d5ec7311e899a2cf039654","rows":[{"id":"empty-contract","iterations":128,"firstNs":161084,"warmupBlockNs":[64875,32709,36000,37916],"sampleBlockNs":[23458,23959,19708,17292,13958,15084,15333,30250,15209,13458,30917],"medianNsPerCall":135.09375},{"id":"missing-table","iterations":128,"firstNs":999709,"warmupBlockNs":[540542,466000,472000,466833],"sampleBlockNs":[473250,455583,433459,455292,442958,425583,445000,442333,472792,440625,482416],"medianNsPerCall":3476.5625},{"id":"ordinary-small","iterations":64,"firstNs":235875,"warmupBlockNs":[1628750,1843333,1302500,1154792],"sampleBlockNs":[1153917,1040333,1040917,1102250,2055917,1184083,1209792,977417,978416,948250,1003459],"medianNsPerCall":16264.328125},{"id":"ordinary-compound","iterations":16,"firstNs":1146375,"warmupBlockNs":[3416625,2879708,3223375,3801166],"sampleBlockNs":[2679167,3480875,2708375,2657583,3573875,2685000,2767666,3617875,2533166,2592792,3224625],"medianNsPerCall":169273.4375},{"id":"ordinary-quoted-comments","iterations":32,"firstNs":212334,"warmupBlockNs":[825667,672833,779291,640292],"sampleBlockNs":[656167,659875,1059500,587958,585833,574958,608083,567250,564625,577625,583417],"medianNsPerCall":18307.28125},{"id":"ordinary-wide","iterations":16,"firstNs":328250,"warmupBlockNs":[1418875,1222292,1319584,1211916],"sampleBlockNs":[1426542,1240125,1306084,1447584,1187833,1298708,1172750,1249708,1416000,1336666,1424750],"medianNsPerCall":81630.25},{"id":"canonical-state","iterations":2,"firstNs":30971541,"warmupBlockNs":[25087666,24540000,23662375,24220375],"sampleBlockNs":[24465958,23999125,24332333,23893875,23806917,24174542,23992584,23648500,24358334,24750500,24132792],"medianNsPerCall":12066396.0},{"id":"canonical-agent","iterations":2,"firstNs":9330750,"warmupBlockNs":[7322458,6516000,7205958,6784375],"sampleBlockNs":[6449292,6676709,6348833,6643041,6422541,7027583,6750583,6782667,6782667,7001166,6684041],"medianNsPerCall":3342020.5},{"id":"fts-virtual","iterations":16,"firstNs":335333,"warmupBlockNs":[1626292,1702042,1629000,2705250],"sampleBlockNs":[1642375,1701708,1674875,1833500,1893167,3060208,1695917,1821292,1673291,1776958,1692834],"medianNsPerCall":106356.75},{"id":"mixed-ordinary-virtual","iterations":8,"firstNs":893166,"warmupBlockNs":[2511333,2421917,2343792,2489667],"sampleBlockNs":[3047458,2211667,2358334,3009750,2075292,2102958,2414000,3385542,2262209,2346917,2408875],"medianNsPerCall":294791.75},{"id":"named-index-control","iterations":64,"firstNs":96333,"warmupBlockNs":[1026875,1094833,1034250,1610708],"sampleBlockNs":[905500,935958,1090167,1014209,1053333,967041,1022541,968709,915292,943250,934167],"medianNsPerCall":15110.015625},{"id":"warm-canonical-names-control","iterations":128,"firstNs":34834,"warmupBlockNs":[24625,22083,21583,33500],"sampleBlockNs":[21667,21875,21708,514292,20417,24875,22459,18667,19250,19208,18208],"medianNsPerCall":169.2734375}]},{"run":"F-candidate","rawResultSha256":"de995b03d1dc74eba16b90febda13ef1f52ce86e8e2948632d51f3398325239c","rows":[{"id":"empty-contract","iterations":128,"firstNs":150708,"warmupBlockNs":[57750,32792,35541,31667],"sampleBlockNs":[22708,23083,19500,16125,16125,14958,15833,15583,12291,13333,20833],"medianNsPerCall":125.9765625},{"id":"missing-table","iterations":128,"firstNs":842500,"warmupBlockNs":[557042,490291,483458,473834],"sampleBlockNs":[493375,459417,440417,465416,431625,435209,449209,445917,447541,437334,557584],"medianNsPerCall":3496.4140625},{"id":"ordinary-small","iterations":64,"firstNs":212083,"warmupBlockNs":[1727459,1840000,1206875,1072583],"sampleBlockNs":[1077125,997167,1061625,1092083,991750,1043083,1190208,1935667,818708,890750,867500],"medianNsPerCall":16298.171875},{"id":"ordinary-compound","iterations":16,"firstNs":971375,"warmupBlockNs":[2718416,2945250,3715834,2657917],"sampleBlockNs":[2640084,2485000,3807584,2656250,2383250,2581166,3481875,2742875,2422000,3359042,2249750],"medianNsPerCall":165005.25},{"id":"ordinary-quoted-comments","iterations":32,"firstNs":167000,"warmupBlockNs":[731416,533417,523375,536375],"sampleBlockNs":[537375,579166,573875,557375,693625,560334,1285792,591833,511709,505291,505750],"medianNsPerCall":17510.4375},{"id":"ordinary-wide","iterations":16,"firstNs":284375,"warmupBlockNs":[1132667,1143042,1209125,947250],"sampleBlockNs":[972000,1209834,931375,920625,935541,1231958,950750,928666,931334,1060125,931041],"medianNsPerCall":58471.3125},{"id":"canonical-state","iterations":2,"firstNs":29355042,"warmupBlockNs":[23324416,22155333,22787042,22359209],"sampleBlockNs":[22255584,21875583,22813250,22231292,22151041,22506959,22271042,21657958,22515333,21803833,22043458],"medianNsPerCall":11115646.0},{"id":"canonical-agent","iterations":2,"firstNs":7990834,"warmupBlockNs":[6940500,6050334,6477792,6044834],"sampleBlockNs":[6576458,6714708,5575375,6913125,6699750,5883333,6489125,5877916,6637875,6383959,5371250],"medianNsPerCall":3244562.5},{"id":"fts-virtual","iterations":16,"firstNs":334333,"warmupBlockNs":[1802083,1954667,1535958,1566417],"sampleBlockNs":[1679167,1583083,1665459,1676500,3211375,1530833,1517875,1486542,1483042,1551000,1843500],"medianNsPerCall":98942.6875},{"id":"mixed-ordinary-virtual","iterations":8,"firstNs":1059833,"warmupBlockNs":[2547042,2327333,2176917,2270292],"sampleBlockNs":[2220792,3159708,1901666,2279417,1981792,1941166,1953667,3548458,2191584,2103917,2096875],"medianNsPerCall":262989.625},{"id":"named-index-control","iterations":64,"firstNs":89250,"warmupBlockNs":[1033125,982125,913583,923333],"sampleBlockNs":[923292,1530500,872042,879292,924583,1127417,1024584,1076041,960375,924542,904875],"medianNsPerCall":14446.609375},{"id":"warm-canonical-names-control","iterations":128,"firstNs":21167,"warmupBlockNs":[24125,22000,21167,35834],"sampleBlockNs":[21084,22667,21417,26833,19208,19416,18875,24792,17667,17875,17500],"medianNsPerCall":151.6875}]},{"run":"R-candidate","rawResultSha256":"6d218470434a1a20b12ec22938d1ac92bf174bca5e864b56f44ce5bf3bc52846","rows":[{"id":"empty-contract","iterations":128,"firstNs":172750,"warmupBlockNs":[67500,28708,35584,37375],"sampleBlockNs":[23708,23125,19500,16334,24542,26583,30833,20250,12417,18875,32167],"medianNsPerCall":180.6640625},{"id":"missing-table","iterations":128,"firstNs":916875,"warmupBlockNs":[515167,506167,453916,548500],"sampleBlockNs":[507625,482416,432375,453791,432625,453541,409708,418292,419625,544167,444458],"medianNsPerCall":3472.328125},{"id":"ordinary-small","iterations":64,"firstNs":189000,"warmupBlockNs":[1512584,1954958,1087166,1078333],"sampleBlockNs":[1095041,998833,1017875,1047792,1129417,1008625,1106042,2186625,949542,925542,887292],"medianNsPerCall":15904.296875},{"id":"ordinary-compound","iterations":16,"firstNs":950875,"warmupBlockNs":[2707292,2782500,3668959,2418875],"sampleBlockNs":[2396791,2467458,3854958,2537708,2641459,2668250,3562500,2383167,2317500,3510542,2354917],"medianNsPerCall":158606.75},{"id":"ordinary-quoted-comments","iterations":32,"firstNs":194834,"warmupBlockNs":[735667,578042,558500,584958],"sampleBlockNs":[607625,569916,584042,584584,628583,700000,1315167,528209,541250,551375,649792],"medianNsPerCall":18268.25},{"id":"ordinary-wide","iterations":16,"firstNs":268834,"warmupBlockNs":[1077625,960000,1328459,978625],"sampleBlockNs":[996875,1200375,977417,959167,939709,1069625,1055250,924791,927250,1038708,885459],"medianNsPerCall":61088.5625},{"id":"canonical-state","iterations":2,"firstNs":29044625,"warmupBlockNs":[22834417,22298625,22682125,23215292],"sampleBlockNs":[22820583,21996292,22362792,22307459,22021000,22876000,21826500,22254875,22358375,22644875,22097125],"medianNsPerCall":11153729.5},{"id":"canonical-agent","iterations":2,"firstNs":8351375,"warmupBlockNs":[6790542,5898375,6419250,6329291],"sampleBlockNs":[5597916,6209500,5525250,6191708,6596125,6277042,6474792,6294375,5680625,6484375,5837667],"medianNsPerCall":3104750.0},{"id":"fts-virtual","iterations":16,"firstNs":351208,"warmupBlockNs":[2037083,1737041,1821458,1570875],"sampleBlockNs":[1564875,1752708,1887417,1816458,2887459,1528083,1491875,1874000,1675208,1792708,1669833],"medianNsPerCall":109544.25},{"id":"mixed-ordinary-virtual","iterations":8,"firstNs":976750,"warmupBlockNs":[2538250,2054375,2010458,2025167],"sampleBlockNs":[1996833,3368500,1913458,1963250,1936625,2095208,3722000,2061083,2259125,2068125,2215208],"medianNsPerCall":258515.625},{"id":"named-index-control","iterations":64,"firstNs":102083,"warmupBlockNs":[1130459,1074833,985833,1482916],"sampleBlockNs":[928000,1099959,1090833,1123000,1042625,965459,991500,926084,953958,917458,939292],"medianNsPerCall":15085.296875},{"id":"warm-canonical-names-control","iterations":128,"firstNs":32958,"warmupBlockNs":[20667,19375,18750,28000],"sampleBlockNs":[20709,31375,20666,26500,25917,19833,18708,24250,17292,17791,17334],"medianNsPerCall":161.453125}]},{"run":"R-before","rawResultSha256":"5cccd68b03ca31c11cf558e6aa24a76094454ea2a1b3a6e0167518adfbce1355","rows":[{"id":"empty-contract","iterations":128,"firstNs":158084,"warmupBlockNs":[45750,28708,35292,35917],"sampleBlockNs":[23584,25208,18291,16750,25958,15500,14417,23292,20209,24584,19791],"medianNsPerCall":157.8828125},{"id":"missing-table","iterations":128,"firstNs":986792,"warmupBlockNs":[573334,477625,460459,482584],"sampleBlockNs":[474292,473292,451125,556000,498166,450584,449750,460916,514417,443000,478167],"medianNsPerCall":3697.59375},{"id":"ordinary-small","iterations":64,"firstNs":262334,"warmupBlockNs":[1662875,1896917,1194958,1113917],"sampleBlockNs":[1080458,1044291,1044917,1141791,1964875,1040417,941917,952375,902584,894917,912750],"medianNsPerCall":16256.515625},{"id":"ordinary-compound","iterations":16,"firstNs":894125,"warmupBlockNs":[3592083,3045917,3158417,3721542],"sampleBlockNs":[2816083,3557000,2691083,2611958,3298583,2662125,2753042,3333375,2574834,2565625,3173500],"medianNsPerCall":172065.125},{"id":"ordinary-quoted-comments","iterations":32,"firstNs":216667,"warmupBlockNs":[821500,608750,641291,638083],"sampleBlockNs":[668750,766250,1149541,595875,605333,673291,690417,607250,608000,603084,599959],"medianNsPerCall":19000.0},{"id":"ordinary-wide","iterations":16,"firstNs":294625,"warmupBlockNs":[1491792,1338709,1446375,1257708],"sampleBlockNs":[1336584,1285500,1292875,1499875,1237625,1390292,1213083,1393917,1164166,1223167,1288083],"medianNsPerCall":80505.1875},{"id":"canonical-state","iterations":2,"firstNs":31723459,"warmupBlockNs":[24170625,24262250,24283208,24944042],"sampleBlockNs":[23405875,23737291,24242583,23831042,24648417,24206208,24510375,25007167,23763042,24389375,24054875],"medianNsPerCall":12103104.0},{"id":"canonical-agent","iterations":2,"firstNs":9101208,"warmupBlockNs":[6835250,7049250,7126292,6858041],"sampleBlockNs":[6706125,6980000,6867792,7112958,6821500,6454708,5940417,6496459,7398583,6824625,7191583],"medianNsPerCall":3412312.5},{"id":"fts-virtual","iterations":16,"firstNs":365333,"warmupBlockNs":[1712250,1857042,1696875,2604125],"sampleBlockNs":[1709125,1786500,1794541,1758458,2001250,2950708,1741666,1727125,1710500,1738459,1772166],"medianNsPerCall":109903.625},{"id":"mixed-ordinary-virtual","iterations":8,"firstNs":954917,"warmupBlockNs":[2538792,2167042,2393250,3476167],"sampleBlockNs":[2145750,2310625,2339583,3424833,2247709,2226500,2331416,3131166,2280708,2174125,2220416],"medianNsPerCall":285088.5},{"id":"named-index-control","iterations":64,"firstNs":80750,"warmupBlockNs":[1012542,1058334,1083958,1548042],"sampleBlockNs":[956292,957958,945334,1057208,1055917,1044542,1014959,1041000,1027875,1029834,1027375],"medianNsPerCall":16060.546875},{"id":"warm-canonical-names-control","iterations":128,"firstNs":16292,"warmupBlockNs":[24292,21709,22292,28292],"sampleBlockNs":[22083,21625,517708,28375,20000,19667,19083,18084,18083,17958,17500],"medianNsPerCall":153.6484375}]}]}
```

</details>


Independent live archive audit: all 77 checks pass, including six exact tool pairs, 27 ordered transcript rows, producer-owned run IDs and both complete saved fetch bodies. Read/web turns retain `replayInvalid:true`, which records compaction/retry safety rather than SQL validity; this proof makes no replay-safety claim. Private evidence and `.last-good` metadata remain mode 0600; the primary task config, key pipe, Gateway process/group and listener are gone. No additional provider run was needed.
