### PR TITLE
perf(sessions): bound health and status session reads

### DIFF
--- a/src/commands/health.plugins.test.ts
+++ b/src/commands/health.plugins.test.ts
@@ -28,8 +28,7 @@ describe("collectGatewayHealthSnapshot plugin state", () => {
       resolveSessionStorePathCore: () => sessionStorePath,
     }));
     vi.doMock("../config/sessions/session-accessor.js", () => ({
-      listSessionEntriesCore: () => [],
-      listSessionEntriesReadOnly: () => [],
+      readSessionStoreSummaryReadOnly: () => ({ count: 0, recent: [], byAgent: new Map() }),
     }));
     vi.doMock("../channels/plugins/read-only.js", () => ({
       listReadOnlyChannelPluginsForConfig: () => [],

--- a/src/commands/health.snapshot.test-support.ts
+++ b/src/commands/health.snapshot.test-support.ts
@@ -1,7 +1,9 @@
 import { vi } from "vitest";
 import type { ChannelPlugin } from "../channels/plugins/types.public.js";
+import { isInternalSessionEffectsKey } from "../config/sessions/internal-session-key.js";
 import type { collectGatewayHealthSnapshot } from "../gateway/health/collector.js";
 import type { HealthSummary } from "../gateway/health/types.js";
+import { parseAgentSessionKey } from "../routing/session-key.js";
 
 export type LegacyHealthSnapshotParams = Partial<
   Omit<Parameters<typeof collectGatewayHealthSnapshot>[0], "audience">
@@ -49,12 +51,38 @@ export async function loadFreshHealthModulesForTest(params: {
     resolveSessionStorePathCore: params.getSessionStorePath,
   }));
   vi.doMock("../config/sessions/session-accessor.js", () => ({
-    listSessionEntriesReadOnly: (scope?: { agentId?: string; storePath?: string }) => {
-      params.onSessionRead?.(scope ?? {});
-      return Object.entries(params.getSessions()).map(([sessionKey, entry]) => ({
-        sessionKey,
-        entry,
-      }));
+    readSessionStoreSummaryReadOnly: (
+      ...[scope, options]: Parameters<
+        typeof import("../config/sessions/session-accessor.js").readSessionStoreSummaryReadOnly
+      >
+    ) => {
+      params.onSessionRead?.(scope);
+      const entries = Object.entries(params.getSessions())
+        .filter(
+          ([sessionKey]) =>
+            parseAgentSessionKey(sessionKey) !== null && !isInternalSessionEffectsKey(sessionKey),
+        )
+        .map(([sessionKey, entry]) => ({
+          sessionKey,
+          entry: { sessionId: sessionKey, updatedAt: 0, ...entry },
+        }))
+        .toSorted(
+          (left, right) =>
+            right.entry.updatedAt - left.entry.updatedAt ||
+            (left.sessionKey < right.sessionKey ? -1 : 1),
+        );
+      return {
+        count: entries.length,
+        recent: entries.slice(0, options.recentLimit),
+        byAgent: new Map(
+          options.agentIds.map((agentId) => {
+            const owned = entries.filter(
+              ({ sessionKey }) => parseAgentSessionKey(sessionKey)?.agentId === agentId,
+            );
+            return [agentId, { count: owned.length, recent: owned.slice(0, options.recentLimit) }];
+          }),
+        ),
+      };
     },
   }));
   vi.doMock("../plugins/runtime/runtime-web-channel-plugin.js", () => ({

--- a/src/commands/health.snapshot.test.ts
+++ b/src/commands/health.snapshot.test.ts
@@ -1002,8 +1002,8 @@ describe("collectGatewayHealthSnapshot", () => {
       { agentId: "ops", path: path.join(storeDir, "openclaw-agent.ops.sqlite") },
     ]);
     expect(listHealthSessionEntriesCalls).toEqual([
-      { agentId: "main", clone: false, projection: "list", storePath: sessionStorePath },
-      { agentId: "ops", clone: false, projection: "list", storePath: sessionStorePath },
+      { agentId: "main", storePath: sessionStorePath },
+      { agentId: "ops", storePath: sessionStorePath },
     ]);
   });
 });

--- a/src/commands/status.agent-local.test.ts
+++ b/src/commands/status.agent-local.test.ts
@@ -16,7 +16,7 @@ vi.mock("../config/sessions/paths.js", () => ({
     `/tmp/${scope.agentId}/sessions.json`,
 }));
 vi.mock("../config/sessions/session-accessor.js", () => ({
-  listSessionEntriesReadOnly: () => [],
+  readSessionStoreSummaryReadOnly: () => ({ count: 0, recent: [], byAgent: new Map() }),
 }));
 vi.mock("../infra/fs-safe.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../infra/fs-safe.js")>()),

--- a/src/commands/status.agent-local.ts
+++ b/src/commands/status.agent-local.ts
@@ -35,9 +35,9 @@ export async function getAgentLocalStatuses(
   const agentList = listGatewayAgentsBasic(cfg);
   const now = Date.now();
 
-  const sessionStores = readStatusSessionStores(cfg, agentList.agents);
+  const sessionStores = readStatusSessionStores(cfg, agentList.agents, 1);
   const statuses: AgentLocalStatus[] = [];
-  for (const { agent, path: sessionsPath, sessions } of sessionStores.byAgent) {
+  for (const { agent, path: sessionsPath, count, recent } of sessionStores.byAgent) {
     const agentId = agent.id;
     const workspaceDir = (() => {
       try {
@@ -51,10 +51,7 @@ export async function getAgentLocalStatuses(
     const bootstrapPath = workspaceDir != null ? path.join(workspaceDir, "BOOTSTRAP.md") : null;
     const bootstrapPending = bootstrapPath != null ? await pathExists(bootstrapPath) : null;
 
-    const lastUpdatedAt = sessions.reduce(
-      (max, session) => Math.max(max, session.entry.updatedAt ?? 0),
-      0,
-    );
+    const lastUpdatedAt = recent[0]?.entry.updatedAt ?? 0;
     const resolvedLastUpdatedAt = lastUpdatedAt > 0 ? lastUpdatedAt : null;
     const lastActiveAgeMs = resolvedLastUpdatedAt ? now - resolvedLastUpdatedAt : null;
 
@@ -64,7 +61,7 @@ export async function getAgentLocalStatuses(
       workspaceDir,
       bootstrapPending,
       sessionsPath,
-      sessionsCount: sessions.length,
+      sessionsCount: count,
       lastUpdatedAt: resolvedLastUpdatedAt,
       lastActiveAgeMs,
     });
@@ -78,7 +75,7 @@ export async function getAgentLocalStatuses(
     ownership: agentList.ownership ?? (agentList.selectionRequired === true ? "explicit" : "sole"),
     selectionRequired: agentList.selectionRequired === true,
     agents: statuses,
-    totalSessions: sessionStores.sessions.length,
+    totalSessions: sessionStores.count,
     bootstrapPendingCount,
   };
 }

--- a/src/commands/status.summary.test.ts
+++ b/src/commands/status.summary.test.ts
@@ -23,6 +23,8 @@ const statusSummaryMocks = vi.hoisted(() => ({
       entry: Record<string, unknown>;
     }>
   >(() => []),
+  loadExactSessionEntryReadOnly:
+    vi.fn<typeof import("../config/sessions/session-accessor.js").loadExactSessionEntryReadOnly>(),
   taskRegistrySummary: {
     total: 0,
     active: 0,
@@ -148,14 +150,41 @@ vi.mock("../config/sessions/paths.js", () => ({
 }));
 
 vi.mock("../config/sessions/session-accessor.js", () => ({
-  loadExactSessionEntryReadOnly: ({ sessionKey }: { sessionKey: string }) => {
-    const entry = statusSummaryMocks
-      .listSessionEntriesCore()
-      .find((candidate) => candidate.sessionKey === sessionKey)?.entry;
-    return entry ? { sessionKey, entry } : undefined;
+  loadExactSessionEntryReadOnly: statusSummaryMocks.loadExactSessionEntryReadOnly,
+  readSessionStoreSummaryReadOnly: (
+    scope: Parameters<
+      typeof import("../config/sessions/session-accessor.js").readSessionStoreSummaryReadOnly
+    >[0],
+    options: Parameters<
+      typeof import("../config/sessions/session-accessor.js").readSessionStoreSummaryReadOnly
+    >[1],
+  ) => {
+    const entries = statusSummaryMocks
+      .listSessionEntriesCore(scope)
+      .filter(({ sessionKey }) => sessionKey.startsWith("agent:"))
+      .map(({ sessionKey, entry }) => ({
+        sessionKey,
+        entry: { sessionId: sessionKey, updatedAt: 0, ...entry },
+      }))
+      .toSorted(
+        (left, right) =>
+          right.entry.updatedAt - left.entry.updatedAt ||
+          (left.sessionKey < right.sessionKey ? -1 : left.sessionKey > right.sessionKey ? 1 : 0),
+      );
+    const summarize = (rows: typeof entries) => ({
+      count: rows.length,
+      recent: rows.slice(0, options.recentLimit),
+    });
+    return {
+      ...summarize(entries),
+      byAgent: new Map(
+        options.agentIds.map((agentId) => [
+          agentId,
+          summarize(entries.filter(({ sessionKey }) => sessionKey.startsWith(`agent:${agentId}:`))),
+        ]),
+      ),
+    };
   },
-  listSessionEntriesCore: statusSummaryMocks.listSessionEntriesCore,
-  listSessionEntriesReadOnly: statusSummaryMocks.listSessionEntriesCore,
 }));
 
 vi.mock("../gateway/agent-list.js", () => ({
@@ -258,6 +287,14 @@ describe("getStatusSummary", () => {
           : undefined,
     );
     statusSummaryMocks.listSessionEntriesCore.mockReturnValue([]);
+    statusSummaryMocks.loadExactSessionEntryReadOnly.mockImplementation(({ sessionKey }) => {
+      const entry = statusSummaryMocks
+        .listSessionEntriesCore()
+        .find((candidate) => candidate.sessionKey === sessionKey)?.entry;
+      return entry
+        ? { sessionKey, entry: { sessionId: sessionKey, updatedAt: 0, ...entry } }
+        : undefined;
+    });
     vi.mocked(statusSummaryRuntime.resolveAuthoredModelContextTokens).mockReturnValue(undefined);
     vi.mocked(statusSummaryRuntime.resolveContextTokensForModel).mockReturnValue(200_000);
     vi.mocked(statusSummaryRuntime.resolveSessionRuntime).mockReturnValue({
@@ -348,6 +385,23 @@ describe("getStatusSummary", () => {
 
     expect(summary.heartbeat.agents[0]?.waitingForRoute).toBe(waitingForRoute);
   });
+
+  it.each([
+    { target: "owner", every: "0m", enabled: false },
+    { target: "none", every: "30m", enabled: true },
+    { target: "telegram", every: "30m", enabled: true },
+  ])(
+    "does not read an unused heartbeat route for $target/$every",
+    async ({ target, every, enabled }) => {
+      const summary = await getStatusSummary({
+        config: { agents: { defaults: { heartbeat: { target, every } } } },
+        includeChannelSummary: false,
+      });
+
+      expect(summary.heartbeat.agents[0]).toMatchObject({ enabled, waitingForRoute: false });
+      expect(statusSummaryMocks.loadExactSessionEntryReadOnly).not.toHaveBeenCalled();
+    },
+  );
 
   it("skips session model discovery and projection when sensitive output is disabled", async () => {
     statusSummaryMocks.listSessionEntriesCore.mockReturnValue([
@@ -744,82 +798,6 @@ describe("getStatusSummary", () => {
     });
   });
 
-  it("hydrates only recent session rows while preserving total counts", async () => {
-    const store = Object.fromEntries(
-      Array.from({ length: 12 }, (_, index) => {
-        const number = index + 1;
-        return [
-          `agent:main:session-${number}`,
-          {
-            sessionId: `session-${number}`,
-            updatedAt: number,
-          },
-        ];
-      }),
-    );
-    statusSummaryMocks.listSessionEntriesCore.mockReturnValue(toSessionEntrySummaries(store));
-
-    const summary = await getStatusSummary();
-
-    expect(summary.sessions.count).toBe(12);
-    expect(summary.sessions.byAgent[0]?.count).toBe(12);
-    expect(summary.sessions.recent.map((session) => session.key)).toEqual([
-      "agent:main:session-12",
-      "agent:main:session-11",
-      "agent:main:session-10",
-      "agent:main:session-9",
-      "agent:main:session-8",
-      "agent:main:session-7",
-      "agent:main:session-6",
-      "agent:main:session-5",
-      "agent:main:session-4",
-      "agent:main:session-3",
-    ]);
-    expect(summary.sessions.byAgent[0]?.recent.map((session) => session.key)).toEqual(
-      summary.sessions.recent.map((session) => session.key),
-    );
-
-    const hydratedKeys = vi
-      .mocked(statusSummaryRuntime.resolveSessionRuntime)
-      .mock.calls.map(([params]) => params.sessionKey);
-    expect(hydratedKeys).not.toContain("agent:main:session-1");
-    expect(hydratedKeys).not.toContain("agent:main:session-2");
-  });
-
-  it("preserves store order for tied recent session timestamps", async () => {
-    const store = Object.fromEntries(
-      Array.from({ length: 11 }, (_, index) => {
-        const number = index + 1;
-        return [
-          `agent:main:session-${number}`,
-          {
-            sessionId: `session-${number}`,
-            updatedAt: 1,
-          },
-        ];
-      }),
-    );
-    statusSummaryMocks.listSessionEntriesCore.mockReturnValue(toSessionEntrySummaries(store));
-
-    const summary = await getStatusSummary();
-
-    expect(summary.sessions.recent.map((session) => session.key)).toEqual([
-      "agent:main:session-1",
-      "agent:main:session-2",
-      "agent:main:session-3",
-      "agent:main:session-4",
-      "agent:main:session-5",
-      "agent:main:session-6",
-      "agent:main:session-7",
-      "agent:main:session-8",
-      "agent:main:session-9",
-      "agent:main:session-10",
-    ]);
-    expect(summary.sessions.byAgent[0]?.recent.map((session) => session.key)).toEqual(
-      summary.sessions.recent.map((session) => session.key),
-    );
-  });
-
   it("passes agent scope when listing configured agent session stores", async () => {
     vi.mocked(listGatewayAgentsBasic).mockReturnValue({
       defaultId: "main",
@@ -845,12 +823,10 @@ describe("getStatusSummary", () => {
     expect(statusSummaryMocks.listSessionEntriesCore).toHaveBeenCalledWith({
       agentId: "main",
       storePath: "/tmp/main/sessions.json",
-      projection: "list",
     });
     expect(statusSummaryMocks.listSessionEntriesCore).toHaveBeenCalledWith({
       agentId: "ops",
       storePath: "/tmp/ops/sessions.json",
-      projection: "list",
     });
     expect(summary.sessions.count).toBe(2);
     expect(summary.sessions.byAgent.map((agent) => [agent.agentId, agent.count])).toEqual([

--- a/src/config/sessions/session-accessor.entry.ts
+++ b/src/config/sessions/session-accessor.entry.ts
@@ -36,6 +36,7 @@ import {
   resolveSessionEntry,
   upsertSessionEntryCore,
 } from "./session-accessor.sqlite-entry.js";
+import { readSessionStoreSummaryReadOnly } from "./session-accessor.sqlite-summary.js";
 import type {
   SessionAccessScope,
   LogicalSessionAccessScope,
@@ -88,6 +89,7 @@ export {
   // fresh-reads and checks sessionId inside its locked commit, and void/entry has no rebound signal.
   replaceSessionEntrySync,
   resolveSessionEntryFromStore,
+  readSessionStoreSummaryReadOnly,
   upsertSessionEntryCore,
 };
 

--- a/src/config/sessions/session-accessor.readonly.test.ts
+++ b/src/config/sessions/session-accessor.readonly.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it } from "vitest";
 import {
   cleanupTempDirs,
@@ -7,9 +8,11 @@ import {
 } from "../../../test/helpers/temp-dir.js";
 import {
   closeOpenClawAgentDatabasesForTest,
+  getOpenClawAgentDatabaseIfOpen,
   isOpenClawAgentDatabaseOpen,
   openOpenClawAgentDatabase,
   resolveOpenClawAgentSqlitePath,
+  runOpenClawAgentWriteTransaction,
 } from "../../state/openclaw-agent-db.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -24,9 +27,12 @@ import {
   readSessionTranscriptWatermark,
   readSessionTranscriptWatermarkBatch,
   readSessionIdentityEvidenceBatch,
+  readSessionStoreSummaryReadOnly,
+  replaceSessionEntrySync,
   resolveTranscriptSessionKeyBySessionId,
   upsertSessionEntryCore,
 } from "./session-accessor.js";
+import { ensureTranscriptSessionRoot } from "./session-accessor.sqlite-transcript-state.js";
 
 const tempDirs: string[] = [];
 const autoTempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -63,10 +69,25 @@ describe("session accessor readonly listing", () => {
       { sessionId: "session-2", updatedAt: 20 },
     );
     const writableEntries = listSessionEntriesCore(listScope);
+    const database = expectDefined(getOpenClawAgentDatabaseIfOpen(listScope), "held agent store");
+    const handle = database.db;
+    const expectedSummary = {
+      count: 2,
+      recent: writableEntries.toReversed(),
+      byAgent: new Map([[listScope.agentId, { count: 2, recent: writableEntries.toReversed() }]]),
+    };
+    const summaryOptions = { recentLimit: 2, agentIds: [listScope.agentId] };
+
+    expect(readSessionStoreSummaryReadOnly(listScope, summaryOptions)).toEqual(expectedSummary);
+    expect(getOpenClawAgentDatabaseIfOpen(listScope)).toBe(database);
+    expect(database.db).toBe(handle);
+    expect(handle.isOpen).toBe(true);
+    expect(handle.isTransaction).toBe(false);
     closeOpenClawAgentDatabasesForTest();
 
     expect(listSessionEntriesReadOnly(listScope)).toEqual(writableEntries);
     expect(openSessionEntryReadView(listScope).entries()).toEqual(writableEntries);
+    expect(readSessionStoreSummaryReadOnly(listScope, summaryOptions)).toEqual(expectedSummary);
     expect(isOpenClawAgentDatabaseOpen(resolveOpenClawAgentSqlitePath(listScope))).toBe(false);
   });
 
@@ -79,8 +100,100 @@ describe("session accessor readonly listing", () => {
 
     expect(listSessionEntriesReadOnly({ agentId, env })).toEqual([]);
     expect(openSessionEntryReadView({ agentId, env }).entries()).toEqual([]);
+    expect(
+      readSessionStoreSummaryReadOnly(
+        { agentId, env },
+        {
+          recentLimit: 10,
+          agentIds: [agentId],
+        },
+      ),
+    ).toEqual({
+      count: 0,
+      recent: [],
+      byAgent: new Map([[agentId, { count: 0, recent: [] }]]),
+    });
     expect(fs.existsSync(databasePath)).toBe(false);
     expect(countRegisteredAgentDatabases(env)).toBe(0);
+  });
+
+  it("summarizes pending rows, hidden keys, retained windows, and ties with listing semantics", () => {
+    const env = { OPENCLAW_STATE_DIR: autoTempDirs.make("openclaw-session-summary-rows-") };
+    const scope = { agentId: "main", env };
+    for (const [key, updatedAt] of [
+      ["zero", 0],
+      ["tie-b", 20],
+      ["tie-a", 20],
+      ["pending", 10],
+      ["bad-json", 15],
+      ["bad-timestamp", 16],
+      ["ordinary:internal-session-effects:visible", 5],
+      ["internal-session-effects:hidden", 999],
+    ] as const) {
+      replaceSessionEntrySync(
+        { ...scope, sessionKey: `agent:main:${key}` },
+        { sessionId: key, updatedAt },
+      );
+    }
+    for (const sessionKey of ["global", "unknown"]) {
+      replaceSessionEntrySync({ ...scope, sessionKey }, { sessionId: sessionKey, updatedAt: 1000 });
+    }
+    runOpenClawAgentWriteTransaction((database) => {
+      ensureTranscriptSessionRoot(
+        database,
+        { ...scope, sessionKey: "agent:main:retained", sessionId: "retained" },
+        2000,
+      );
+    }, scope);
+    listSessionEntriesReadOnly(scope);
+    const database = openOpenClawAgentDatabase(scope);
+    const update = database.db.prepare(
+      "UPDATE session_nodes SET entry_json = ?, updated_at = ? WHERE session_key = ?",
+    );
+    update.run(
+      JSON.stringify({ sessionId: "pending-updated", updatedAt: 30, label: "fresh" }),
+      30,
+      "agent:main:pending",
+    );
+    update.run("{", 40, "agent:main:bad-json");
+    update.run(
+      JSON.stringify({ sessionId: "bad-timestamp", updatedAt: 99 }),
+      50,
+      "agent:main:bad-timestamp",
+    );
+    const expectedKeys = [
+      "agent:main:pending",
+      "agent:main:tie-a",
+      "agent:main:tie-b",
+      "agent:main:ordinary:internal-session-effects:visible",
+      "agent:main:zero",
+    ];
+    const options = { recentLimit: 3, agentIds: [scope.agentId] };
+
+    const listed = listSessionEntriesReadOnly({ ...scope, readConsistency: "latest" });
+    expect(
+      listed
+        .filter(({ sessionKey }) => !["global", "unknown"].includes(sessionKey))
+        .map(({ sessionKey }) => sessionKey)
+        .toSorted(),
+    ).toEqual(expectedKeys.toSorted());
+    const summary = readSessionStoreSummaryReadOnly(scope, options);
+    expect(summary.count).toBe(5);
+    expect(summary.recent.map(({ sessionKey }) => sessionKey)).toEqual(expectedKeys.slice(0, 3));
+    expect(summary.recent[0]?.entry).toMatchObject({
+      sessionId: "pending-updated",
+      label: "fresh",
+    });
+    expectDefined(summary.recent[0], "recent pending session").entry.label = "caller-owned";
+    expect(readSessionStoreSummaryReadOnly(scope, options).recent[0]?.entry.label).toBe("fresh");
+    expect(readSessionStoreSummaryReadOnly(scope, { ...options, recentLimit: 0 })).toEqual({
+      count: 5,
+      recent: [],
+      byAgent: new Map([[scope.agentId, { count: 5, recent: [] }]]),
+    });
+
+    closeOpenClawAgentDatabasesForTest();
+    expect(() => readSessionStoreSummaryReadOnly(scope, options)).toThrow("openclaw doctor --fix");
   });
 
   it("surfaces missing canonical transcript tables through single and batched reads", async () => {

--- a/src/config/sessions/session-accessor.sqlite-summary.ts
+++ b/src/config/sessions/session-accessor.sqlite-summary.ts
@@ -1,0 +1,117 @@
+import {
+  executeSqliteQueryTakeFirstSync,
+  iterateSqliteQuerySync,
+} from "../../infra/kysely-sync.js";
+import { runSqliteDeferredTransactionSync } from "../../infra/sqlite-transaction.js";
+import { parseAgentSessionKey } from "../../routing/session-key.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
+import { isInternalSessionEffectsKey } from "./internal-session-key.js";
+import type {
+  SessionAccessScope,
+  SessionEntrySummary,
+} from "./session-accessor.sqlite-contract.js";
+import { projectSqliteSessionParticipants } from "./session-accessor.sqlite-participant-projection.js";
+import {
+  getSessionKysely,
+  resolveSqliteScope,
+  toDatabaseOptions,
+} from "./session-accessor.sqlite-scope.js";
+import { parseSessionEntryJson } from "./session-accessor.sqlite-status.js";
+import {
+  assertCanonicalSqliteSessionKeysCurrent,
+  canonicalSessionKeyMigrationRequiredError,
+} from "./session-canonical-key.js";
+import { resolveDeliveryProvenCanonicalSessionKey } from "./store-entry.js";
+
+type SessionStoreSummary = { count: number; recent: SessionEntrySummary[] };
+
+/** Reads counts and bounded recent session payloads without warming the store cache. */
+export function readSessionStoreSummaryReadOnly(
+  scope: Pick<SessionAccessScope, "agentId" | "defaultAgentId" | "env" | "storePath">,
+  options: {
+    recentLimit: number;
+    agentIds: readonly string[];
+  },
+): SessionStoreSummary & { byAgent: Map<string, SessionStoreSummary> } {
+  const resolved = resolveSqliteScope({ ...scope, sessionKey: "" });
+  const summary: SessionStoreSummary & { byAgent: Map<string, SessionStoreSummary> } = {
+    count: 0,
+    recent: [],
+    byAgent: new Map<string, SessionStoreSummary>(
+      options.agentIds.map((agentId) => [agentId, { count: 0, recent: [] }]),
+    ),
+  };
+  const result = withOpenClawAgentDatabaseReadOnly(
+    (database) =>
+      runSqliteDeferredTransactionSync(database.db, () => {
+        assertCanonicalSqliteSessionKeysCurrent(database);
+        const db = getSessionKysely(database.db);
+        // The read transaction keeps count, ordering, and selected payloads on one
+        // generation. Existing keys/indexes bound JSON work, not the cold canonical check.
+        for (const row of iterateSqliteQuerySync(
+          database.db,
+          db
+            .selectFrom("session_nodes")
+            .select(["session_key", "entry_valid"])
+            .orderBy("updated_at", "desc")
+            .orderBy("session_key", "asc"),
+        )) {
+          const owner = parseAgentSessionKey(row.session_key)?.agentId;
+          if (!owner || isInternalSessionEffectsKey(row.session_key)) {
+            continue;
+          }
+          const agent = summary.byAgent.get(owner);
+          const needsRecent =
+            summary.recent.length < options.recentLimit ||
+            (agent !== undefined && agent.recent.length < options.recentLimit);
+          if (row.entry_valid === 1 && !needsRecent) {
+            summary.count += 1;
+            if (agent) {
+              agent.count += 1;
+            }
+            continue;
+          }
+          // Raw updates clear entry_valid. Preserve listing's warm-row semantics:
+          // skip unreadable JSON/retained placeholders, but include readable pending rows.
+          const stored = executeSqliteQueryTakeFirstSync(
+            database.db,
+            db.selectFrom("session_nodes").selectAll().where("session_key", "=", row.session_key),
+          );
+          if (!stored) {
+            continue;
+          }
+          const { current_session_id: _currentSessionId, ...listRow } = stored;
+          const parsed = parseSessionEntryJson(listRow);
+          if (!parsed) {
+            continue;
+          }
+          const entry = projectSqliteSessionParticipants(database.db, row.session_key, parsed);
+          const deliveryCanonicalKey = resolveDeliveryProvenCanonicalSessionKey(
+            row.session_key,
+            entry,
+          );
+          if (deliveryCanonicalKey !== row.session_key) {
+            throw canonicalSessionKeyMigrationRequiredError(
+              `non-canonical persisted row resolves to session key ${deliveryCanonicalKey}`,
+            );
+          }
+          summary.count += 1;
+          const selected = { sessionKey: row.session_key, entry };
+          if (summary.recent.length < options.recentLimit) {
+            summary.recent.push(selected);
+          }
+          if (agent) {
+            agent.count += 1;
+            // The global newest rows may all belong to another agent. Select each
+            // requested owner's window in this scan, sharing each parsed payload.
+            if (agent.recent.length < options.recentLimit) {
+              agent.recent.push(selected);
+            }
+          }
+        }
+        return summary;
+      }),
+    toDatabaseOptions(resolved),
+  );
+  return result.found ? result.value : summary;
+}

--- a/src/config/sessions/session-accessor.ts
+++ b/src/config/sessions/session-accessor.ts
@@ -159,6 +159,7 @@ export {
   patchSessionEntryTarget,
   patchSessionEntryWithKey,
   readSessionUpdatedAtCore,
+  readSessionStoreSummaryReadOnly,
   replaceSessionEntry,
   replaceSessionEntrySync,
   resolveSessionEntryAccessTarget,

--- a/src/gateway/health/collector.deadline.test.ts
+++ b/src/gateway/health/collector.deadline.test.ts
@@ -14,7 +14,11 @@ let testConfig: OpenClawConfig = {};
 let healthPluginsForTest: ChannelPlugin[] = [];
 const tempDirs = createTempDirTracker();
 let sessionStorePath: string;
-const listSessionEntriesReadOnly = vi.fn(() => []);
+const readSessionStoreSummaryReadOnly = vi.fn(() => ({
+  count: 0,
+  recent: [],
+  byAgent: new Map(),
+}));
 let collectGatewayHealthSnapshot: typeof import("./collector.js").collectGatewayHealthSnapshot;
 let createChannelTestPluginBase: typeof import("../../test-utils/channel-plugins.js").createChannelTestPluginBase;
 
@@ -65,7 +69,7 @@ describe("gateway health collection deadline", () => {
       resolveSessionStorePathCore: () => sessionStorePath,
     }));
     vi.doMock("../../config/sessions/session-accessor.js", () => ({
-      listSessionEntriesReadOnly,
+      readSessionStoreSummaryReadOnly,
     }));
     vi.doMock("../../channels/plugins/read-only.js", () => ({
       listReadOnlyChannelPluginsForConfig: () => healthPluginsForTest,
@@ -83,7 +87,7 @@ describe("gateway health collection deadline", () => {
       tempDirs.make("openclaw-health-deadline-sessions-"),
       "sessions.json",
     );
-    listSessionEntriesReadOnly.mockReset();
+    readSessionStoreSummaryReadOnly.mockReset();
     testConfig = {};
     healthPluginsForTest = [];
     await collectGatewayHealthSnapshot({ audience: "admin", probe: false, timeoutMs: 50 });
@@ -98,9 +102,9 @@ describe("gateway health collection deadline", () => {
     vi.useFakeTimers();
     const probe = vi.fn(async () => ({ ok: true }));
     healthPluginsForTest = [createDeadlinePlugin({ accountIds: ["default"], probe })];
-    listSessionEntriesReadOnly.mockImplementationOnce(() => {
+    readSessionStoreSummaryReadOnly.mockImplementationOnce(() => {
       vi.advanceTimersByTime(50);
-      return [];
+      return { count: 0, recent: [], byAgent: new Map() };
     });
 
     const snap = await collectDeadlineSnapshot({ timeoutMs: 50 });

--- a/src/gateway/health/collector.legacy-owner.test.ts
+++ b/src/gateway/health/collector.legacy-owner.test.ts
@@ -54,7 +54,7 @@ describe("collectGatewayHealthSnapshot legacy owner projection", () => {
       resolveSessionStorePathCore: () => sessionStorePath,
     }));
     vi.doMock("../../config/sessions/session-accessor.js", () => ({
-      listSessionEntriesReadOnly: () => [],
+      readSessionStoreSummaryReadOnly: () => ({ count: 0, recent: [], byAgent: new Map() }),
     }));
     vi.doMock("../../channels/plugins/read-only.js", () => ({
       listReadOnlyChannelPluginsForConfig: () => healthPluginsForTest,

--- a/src/gateway/health/collector.queue-health.test.ts
+++ b/src/gateway/health/collector.queue-health.test.ts
@@ -12,7 +12,7 @@ vi.mock("../../config/sessions/paths.js", () => ({
 }));
 
 vi.mock("../../config/sessions/session-accessor.js", () => ({
-  listSessionEntriesReadOnly: () => [],
+  readSessionStoreSummaryReadOnly: () => ({ count: 0, recent: [], byAgent: new Map() }),
 }));
 
 vi.mock("../../channels/plugins/read-only.js", () => ({

--- a/src/gateway/health/collector.session-store-path.test.ts
+++ b/src/gateway/health/collector.session-store-path.test.ts
@@ -1,24 +1,35 @@
 import fs from "node:fs";
 import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import * as configRuntime from "../../config/config.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
 import * as sessionAccessor from "../../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../../config/sessions/session-sqlite-target.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   resolveOpenClawAgentSqlitePath,
 } from "../../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
-import { collectGatewayHealthSnapshot } from "./collector.js";
+import {
+  buildHealthAgentSummaries,
+  collectGatewayHealthSnapshot,
+  resolveHealthAgentOrder,
+} from "./collector.js";
+
+vi.mock("../../channels/plugins/read-only.js", () => ({
+  listReadOnlyChannelPluginsForConfig: () => [],
+}));
 
 async function summarizeStore(storePath: string, agentId: string) {
-  vi.spyOn(configRuntime, "getRuntimeConfig").mockReturnValue({
+  const cfg: OpenClawConfig = {
     agents: { ownership: "explicit", entries: { [agentId]: {} } },
     session: { store: storePath },
-  });
-  return (await collectGatewayHealthSnapshot({ audience: "admin", probe: false })).sessions;
+  };
+  const agents = await buildHealthAgentSummaries(cfg, resolveHealthAgentOrder(cfg));
+  return expectDefined(agents[0], "health agent summary").sessions;
 }
 
 describe("health session store paths", () => {
@@ -50,42 +61,76 @@ describe("health session store paths", () => {
     expect(fs.existsSync(summary.path)).toBe(true);
   });
 
-  it("counts and orders lightweight session projections without cloning full entries", async () => {
-    const stateDir = tempDirs.make("openclaw-health-session-projection-");
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    const agentId = "main";
-    const storePath = resolveSessionStorePathCore(undefined, { agentId, env });
-    const now = vi.spyOn(Date, "now");
-    for (const updatedAt of [30, 70, 10, 60, 40, 20, 50]) {
-      now.mockReturnValue(updatedAt);
-      await sessionAccessor.upsertSessionEntryCore(
-        { agentId, env, sessionKey: `agent:${agentId}:session-${updatedAt}`, storePath },
-        {
-          sessionId: `session-${updatedAt}`,
-          updatedAt,
-          skillsSnapshot: { prompt: "large runtime prompt", skills: [{ name: "demo" }] },
+  it.each(["agent", "shared"] as const)(
+    "counts and orders bounded %s session projections without cloning full entries",
+    async (layout) => {
+      const stateDir = tempDirs.make("openclaw-health-session-projection-");
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      const agentIds = layout === "shared" ? ["main", "other"] : ["main"];
+      const storePath =
+        layout === "shared"
+          ? path.join(stateDir, "shared.sqlite")
+          : resolveSessionStorePathCore(undefined, { agentId: "main", env });
+      const now = vi.spyOn(Date, "now");
+      for (const agentId of agentIds) {
+        for (const timestamp of [30, 70, 10, 60, 40, 20, 50]) {
+          const updatedAt = timestamp + (agentId === "other" ? 100 : 0);
+          now.mockReturnValue(updatedAt);
+          await sessionAccessor.upsertSessionEntryCore(
+            { agentId, env, sessionKey: `agent:${agentId}:session-${timestamp}`, storePath },
+            {
+              sessionId: `session-${agentId}-${timestamp}`,
+              updatedAt,
+              skillsSnapshot: { prompt: "large runtime prompt", skills: [{ name: "demo" }] },
+            },
+          );
+        }
+      }
+      const inspectedAt = layout === "shared" ? 200 : 100;
+      now.mockReturnValue(inspectedAt);
+      // Cold-open canonical validation is separate from the warm health projection.
+      sessionAccessor.loadExactSessionEntryReadOnly({
+        agentId: "main",
+        env,
+        sessionKey: "agent:main:session-70",
+        storePath,
+      });
+      const clone = vi.spyOn(globalThis, "structuredClone");
+      const parse = vi.spyOn(JSON, "parse");
+      const cfg: OpenClawConfig = {
+        agents: {
+          ownership: "explicit",
+          entries: Object.fromEntries(agentIds.map((agentId) => [agentId, {}])),
         },
+        session: { store: storePath },
+      };
+
+      const agents = await buildHealthAgentSummaries(cfg, resolveHealthAgentOrder(cfg));
+
+      expect(clone).not.toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: expect.stringMatching(/^session-/) }),
       );
-    }
-    now.mockReturnValue(100);
-    const clone = vi.spyOn(globalThis, "structuredClone");
-
-    const summary = await summarizeStore(storePath, agentId);
-
-    expect(clone).not.toHaveBeenCalledWith(
-      expect.objectContaining({ sessionId: expect.stringMatching(/^session-/) }),
-    );
-    expect(summary).toMatchObject({
-      count: 7,
-      recent: [
-        { key: "agent:main:session-70", updatedAt: 70, age: 30 },
-        { key: "agent:main:session-60", updatedAt: 60, age: 40 },
-        { key: "agent:main:session-50", updatedAt: 50, age: 50 },
-        { key: "agent:main:session-40", updatedAt: 40, age: 60 },
-        { key: "agent:main:session-30", updatedAt: 30, age: 70 },
-      ],
-    });
-  });
+      expect(
+        parse.mock.calls.filter(
+          ([value]) => typeof value === "string" && /session-(main|other)-(10|20)"/u.test(value),
+        ),
+      ).toHaveLength(0);
+      expect(agents.map((agent) => agent.agentId)).toEqual(agentIds);
+      for (const agent of agents) {
+        expect(agent.sessions).toMatchObject({
+          count: 7,
+          recent: [70, 60, 50, 40, 30].map((timestamp) => {
+            const updatedAt = timestamp + (agent.agentId === "other" ? 100 : 0);
+            return {
+              key: `agent:${agent.agentId}:session-${timestamp}`,
+              updatedAt,
+              age: inspectedAt - updatedAt,
+            };
+          }),
+        });
+      }
+    },
+  );
 
   it.each(["template", "shared"] as const)(
     "scopes %s stores and recovers from transient reads",
@@ -107,6 +152,11 @@ describe("health session store paths", () => {
         env,
       }).path;
 
+      expect(populatedStorePath).toBe(
+        layout === "shared"
+          ? path.join(stateDir, "stores", "shared.sqlite")
+          : path.join(stateDir, "stores", populatedAgentId, "sessions.json"),
+      );
       await sessionAccessor.upsertSessionEntryCore(
         {
           agentId: populatedAgentId,
@@ -140,7 +190,7 @@ describe("health session store paths", () => {
         agents: { ownership: "explicit", entries: { helper: {}, third: {} } },
         session: { store: storeTemplate },
       });
-      const reads = vi.spyOn(sessionAccessor, "listSessionEntriesReadOnly");
+      const reads = vi.spyOn(sessionAccessor, "readSessionStoreSummaryReadOnly");
       const collect = () => collectGatewayHealthSnapshot({ audience: "admin", probe: false });
       const summary = await collect();
       expect(summary.agents.map((agent) => [agent.agentId, agent.sessions.count])).toEqual([

--- a/src/gateway/health/collector.ts
+++ b/src/gateway/health/collector.ts
@@ -110,65 +110,52 @@ export function resolveHealthAgentOrder(cfg: OpenClawConfig) {
   return { defaultAgentId, ordered };
 }
 
-async function createHealthSessionStoreReader() {
+async function createHealthSessionStoreReader(agentIds: readonly string[]) {
   const { createStatusSessionStoreReader } = await import("../../status/session-stores.js");
-  const { listSessionEntriesReadOnly } = await import("../../config/sessions/session-accessor.js");
+  const { readSessionStoreSummaryReadOnly } =
+    await import("../../config/sessions/session-accessor.js");
   const { isTransientSqliteError } = await import("../../infra/unhandled-rejections.js");
-  return createStatusSessionStoreReader((scope) => {
+  return createStatusSessionStoreReader(agentIds, HEALTH_RECENT_SESSION_LIMIT, (scope, options) => {
     try {
-      return listSessionEntriesReadOnly({ ...scope, clone: false, projection: "list" });
+      return readSessionStoreSummaryReadOnly(scope, options);
     } catch (error) {
       if (!isTransientSqliteError(error)) {
         throw error;
       }
       // Health is best-effort: one empty snapshot beats repeated transient lock failures.
-      return [];
+      return { count: 0, recent: [], byAgent: new Map() };
     }
   });
 }
 
-function projectHealthSessions(path: string, sessions: SessionEntrySummary[]) {
-  const recentSessions: Array<{ key: string; updatedAt: number }> = [];
-  for (const { sessionKey: key, entry } of sessions) {
-    const session = { key, updatedAt: entry.updatedAt ?? 0 };
-    const insertAt = recentSessions.findIndex(
-      (recentSession) => session.updatedAt > recentSession.updatedAt,
-    );
-    // Health returns only five rows. Keep the projection bounded while scanning
-    // so refreshes never sort the complete session snapshot.
-    if (insertAt >= 0) {
-      recentSessions.splice(insertAt, 0, session);
-      if (recentSessions.length > HEALTH_RECENT_SESSION_LIMIT) {
-        recentSessions.pop();
-      }
-    } else if (recentSessions.length < HEALTH_RECENT_SESSION_LIMIT) {
-      recentSessions.push(session);
-    }
-  }
-  const recent = recentSessions.map((session) => ({
-    key: session.key,
-    updatedAt: session.updatedAt || null,
-    age: session.updatedAt ? Date.now() - session.updatedAt : null,
+function projectHealthSessions(
+  path: string,
+  summary: { count: number; recent: SessionEntrySummary[] },
+) {
+  const recent = summary.recent.map(({ sessionKey: key, entry }) => ({
+    key,
+    updatedAt: entry.updatedAt || null,
+    age: entry.updatedAt ? Date.now() - entry.updatedAt : null,
   }));
   return {
     path,
-    count: sessions.length,
+    count: summary.count,
     recent,
   } satisfies HealthSummary["sessions"];
 }
 
 async function buildHealthSessionSummary(storePath: string, agentId?: string) {
-  const reader = await createHealthSessionStoreReader();
+  const reader = await createHealthSessionStoreReader(agentId ? [agentId] : []);
   const store = reader.read(storePath, agentId);
-  return projectHealthSessions(store.path, store.sessions);
+  return projectHealthSessions(store.path, store);
 }
 
-/** Projects borrowed rows synchronously before returning the owned health summaries. */
+/** Shares one bounded session snapshot across every configured agent in this collection. */
 export async function buildHealthAgentSummaries(
   cfg: OpenClawConfig,
   { defaultAgentId, ordered }: ReturnType<typeof resolveHealthAgentOrder>,
 ): Promise<AgentHealthSummary[]> {
-  const reader = await createHealthSessionStoreReader();
+  const reader = await createHealthSessionStoreReader(ordered.map((entry) => entry.id));
   return ordered.map((entry) => {
     const store = reader.read(
       resolveSessionStorePathCore(cfg.session?.store, { agentId: entry.id }),
@@ -179,7 +166,7 @@ export async function buildHealthAgentSummaries(
       name: entry.name,
       isDefault: entry.id === defaultAgentId,
       heartbeat: resolveHeartbeatSummary(cfg, entry.id),
-      sessions: projectHealthSessions(store.path, store.sessions),
+      sessions: projectHealthSessions(store.path, store),
     };
   });
 }

--- a/src/status/session-stores.ts
+++ b/src/status/session-stores.ts
@@ -1,50 +1,29 @@
 import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
-import {
-  listSessionEntriesReadOnly,
-  type SessionEntrySummary,
-} from "../config/sessions/session-accessor.js";
+import { readSessionStoreSummaryReadOnly } from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import type { OpenClawConfig } from "../config/types.js";
-import { parseAgentSessionKey } from "../routing/session-key.js";
 
-type StatusSessionStore = {
-  sessions: SessionEntrySummary[];
-  byAgent: Map<string, SessionEntrySummary[]>;
-};
-
-/** One collection owns the snapshot; borrowed read policies must finish before an await. */
+/** One collection owns each physical store's bounded snapshot, including its agent windows. */
 export function createStatusSessionStoreReader(
-  readEntries: typeof listSessionEntriesReadOnly = listSessionEntriesReadOnly,
+  agentIds: readonly string[],
+  recentLimit: number,
+  readSummary: typeof readSessionStoreSummaryReadOnly = readSessionStoreSummaryReadOnly,
 ) {
-  const stores = new Map<string, StatusSessionStore>();
+  const stores = new Map<string, ReturnType<typeof readSessionStoreSummaryReadOnly>>();
   return {
     stores,
     read(storePath: string, agentId?: string) {
       const path = resolveSqliteTargetFromSessionStorePath(storePath, { agentId }).path;
       let store = stores.get(path);
       if (!store) {
-        store = { sessions: [], byAgent: new Map() };
-        for (const row of readEntries({
-          ...(agentId ? { agentId } : {}),
-          storePath,
-          projection: "list",
-        })) {
-          // The accessor validates canonical keys; only global/unknown buckets lack an agent.
-          const owner = parseAgentSessionKey(row.sessionKey)?.agentId;
-          if (!owner) {
-            continue;
-          }
-          store.sessions.push(row);
-          const agentSessions = store.byAgent.get(owner);
-          if (agentSessions) {
-            agentSessions.push(row);
-          } else {
-            store.byAgent.set(owner, [row]);
-          }
-        }
+        store = readSummary(
+          { ...(agentId ? { agentId } : {}), storePath },
+          { agentIds, recentLimit },
+        );
         stores.set(path, store);
       }
-      return { path, sessions: agentId ? (store.byAgent.get(agentId) ?? []) : store.sessions };
+      const summary = agentId ? store.byAgent.get(agentId) : store;
+      return { path, count: summary?.count ?? 0, recent: summary?.recent ?? [] };
     },
   };
 }
@@ -53,8 +32,12 @@ export function createStatusSessionStoreReader(
 export function readStatusSessionStores(
   cfg: OpenClawConfig,
   agents: ReadonlyArray<{ id: string; name?: string }>,
+  recentLimit: number,
 ) {
-  const reader = createStatusSessionStoreReader();
+  const reader = createStatusSessionStoreReader(
+    agents.map((agent) => agent.id),
+    recentLimit,
+  );
   const byAgent = agents.map((agent) => ({
     agent,
     ...reader.read(
@@ -64,7 +47,8 @@ export function readStatusSessionStores(
   }));
   return {
     paths: [...reader.stores.keys()],
-    sessions: [...reader.stores.values()].flatMap((store) => store.sessions),
+    count: [...reader.stores.values()].reduce((count, store) => count + store.count, 0),
+    recent: [...reader.stores.values()].flatMap((store) => store.recent),
     byAgent,
   };
 }

--- a/src/status/summary.read-only.test.ts
+++ b/src/status/summary.read-only.test.ts
@@ -9,6 +9,7 @@ import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
 import * as sessionAccessor from "../config/sessions/session-accessor.js";
 import {
   replaceSessionEntry,
+  replaceSessionEntrySync,
   upsertSessionEntryCore,
 } from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
@@ -127,7 +128,7 @@ describe("getStatusSummary read-only session access", () => {
           (agentId) => resolveSqliteTargetFromSessionStorePath(storePath, { agentId }).path,
         );
         const uniquePaths = [...new Set(expectedPaths)];
-        const listEntries = vi.spyOn(sessionAccessor, "listSessionEntriesReadOnly");
+        const readSummary = vi.spyOn(sessionAccessor, "readSessionStoreSummaryReadOnly");
         const now = vi.spyOn(Date, "now").mockReturnValue(100);
         try {
           const summary = await getStatusSummary({ includeChannelSummary: false, config });
@@ -145,9 +146,9 @@ describe("getStatusSummary read-only session access", () => {
             ["main", expectedPaths[0], 1, [["main", "agent:main:main"]]],
             ["ops", expectedPaths[1], 1, [["ops", "agent:ops:main"]]],
           ]);
-          expect(listEntries).toHaveBeenCalledTimes(uniquePaths.length);
+          expect(readSummary).toHaveBeenCalledTimes(uniquePaths.length);
 
-          listEntries.mockClear();
+          readSummary.mockClear();
           const local = await getAgentLocalStatuses(config);
           expect(local.totalSessions).toBe(2);
           expect(
@@ -161,10 +162,10 @@ describe("getStatusSummary read-only session access", () => {
             ["main", 1, 10, 90],
             ["ops", 1, 20, 80],
           ]);
-          expect(listEntries).toHaveBeenCalledTimes(uniquePaths.length);
+          expect(readSummary).toHaveBeenCalledTimes(uniquePaths.length);
           expect(uniquePaths.every((databasePath) => fs.existsSync(databasePath))).toBe(true);
         } finally {
-          listEntries.mockRestore();
+          readSummary.mockRestore();
           now.mockRestore();
         }
       } finally {
@@ -198,5 +199,62 @@ describe("getStatusSummary read-only session access", () => {
         }
       },
     );
+  });
+
+  it("bounds session payload hydration to the recent status window", async () => {
+    await withOpenClawTestState({ prefix: "openclaw-status-recent-window-" }, async (state) => {
+      const config = {
+        agents: { defaults: { heartbeat: { every: "0m" } }, entries: { main: {} } },
+      };
+      const storePath = resolveSessionStorePathCore(undefined, {
+        agentId: "main",
+        env: state.env,
+      });
+      for (let index = 1; index <= 24; index += 1) {
+        replaceSessionEntrySync(
+          { agentId: "main", storePath, sessionKey: `agent:main:history-${index}` },
+          {
+            sessionId: `status-history-${index}`,
+            updatedAt: index,
+            pluginExtensions: {
+              fixture: { history: Array.from({ length: 64 }, () => "x".repeat(128)) },
+            },
+          },
+        );
+      }
+      await getStatusSummary({ config, includeChannelSummary: false });
+      const clone = vi.spyOn(globalThis, "structuredClone");
+      const parse = vi.spyOn(JSON, "parse");
+      const parsedSessionPayloads = () =>
+        parse.mock.calls.filter(([json]) => json.includes('"sessionId":"status-history-'));
+      try {
+        const summary = await getStatusSummary({ config, includeChannelSummary: false });
+
+        expect(parsedSessionPayloads()).toHaveLength(10);
+        expect(summary.sessions.count).toBe(24);
+        expect(summary.sessions.byAgent[0]?.count).toBe(24);
+        expect(summary.sessions.recent.map(({ key }) => key)).toEqual(
+          Array.from({ length: 10 }, (_, index) => `agent:main:history-${24 - index}`),
+        );
+        expect(
+          clone.mock.calls.filter(([value]) => {
+            const sessionId = (value as { sessionId?: unknown })?.sessionId;
+            return typeof sessionId === "string" && sessionId.startsWith("status-history-");
+          }),
+        ).toHaveLength(0);
+
+        parse.mockClear();
+        const hidden = await getStatusSummary({
+          config,
+          includeChannelSummary: false,
+          includeSensitive: false,
+        });
+        expect(hidden.sessions.count).toBe(24);
+        expect(parsedSessionPayloads()).toHaveLength(0);
+      } finally {
+        parse.mockRestore();
+        clone.mockRestore();
+      }
+    });
   });
 });

--- a/src/status/summary.runtime.ts
+++ b/src/status/summary.runtime.ts
@@ -6,7 +6,10 @@ import {
   normalizeOptionalString,
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
-import { readAcpSessionMeta } from "../acp/runtime/session-meta.js";
+import {
+  readAcpSessionMetaForEntry,
+  resolveSessionStorePathForAcp,
+} from "../acp/runtime/session-meta.js";
 import { resolveCurrentSessionAgentRuntimeMetadata } from "../agents/agent-runtime-metadata.js";
 import { resolveAgentConfig } from "../agents/agent-scope-config.js";
 import { resolveConfiguredProviderFallback } from "../agents/configured-provider-fallback.js";
@@ -210,7 +213,18 @@ function resolveSessionRuntime(params: {
         sessionKey: params.sessionKey,
       })
     : params.sessionKey;
-  const acpMeta = readAcpSessionMeta({ cfg: params.cfg, sessionKey: acpSessionKey });
+  const { agentId: acpAgentId } = resolveSessionStorePathForAcp({
+    cfg: params.cfg,
+    sessionKey: acpSessionKey,
+  });
+  // The summary already captured the session generation. Rereading its store
+  // could pair runtime metadata with a replacement row and reopen cold history.
+  const acpMeta = readAcpSessionMetaForEntry({
+    cfg: params.cfg,
+    sessionKey: acpSessionKey,
+    agentId: acpAgentId,
+    entry: params.entry,
+  });
   const runtime = resolveCurrentSessionAgentRuntimeMetadata({
     cfg: params.cfg,
     agentId: params.agentId ?? "",

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -402,36 +402,41 @@ export async function getStatusSummary(
   const agentList = listGatewayAgentsBasic(cfg);
   const heartbeatAgents: HeartbeatStatus[] = agentList.agents.map((agent) => {
     const summary = resolveHeartbeatSummaryForAgent(cfg, agent.id);
-    const heartbeatSession = resolveHeartbeatSessionKey(
-      cfg,
-      agent.id,
-      summary.session === undefined ? undefined : { session: summary.session },
-    );
-    // Status must not create, register, or migrate an absent session database.
-    const entry = loadExactSessionEntryReadOnly({
-      agentId: agent.id,
-      storePath: heartbeatSession.storePath,
-      sessionKey: heartbeatSession.sessionKey,
-    })?.entry;
-    const route = deliveryContextFromSession(entry);
-    const heartbeat = {
-      ...cfg.agents?.defaults?.heartbeat,
-      ...resolveAgentConfig(cfg, agent.id)?.heartbeat,
-    };
-    // Owner status uses the runner's synchronous stage-1 decision.
-    // The shared probe requires positive direct proof before reporting ready.
-    const hasDeliveryRoute =
-      summary.target === "last"
-        ? Boolean(route?.channel && route.to)
-        : summary.target === "owner"
-          ? hasResolvableHeartbeatOwnerRoute({ cfg, agentId: agent.id, entry, heartbeat })
-          : true;
+    let waitingForRoute = false;
+    if (summary.enabled && (summary.target === "last" || summary.target === "owner")) {
+      const heartbeatSession = resolveHeartbeatSessionKey(
+        cfg,
+        agent.id,
+        summary.session === undefined ? undefined : { session: summary.session },
+      );
+      // Only these enabled targets consume the session route. Keep the probe
+      // read-only so status cannot create, register, or migrate an absent store.
+      const entry = loadExactSessionEntryReadOnly({
+        agentId: agent.id,
+        storePath: heartbeatSession.storePath,
+        sessionKey: heartbeatSession.sessionKey,
+      })?.entry;
+      const route = deliveryContextFromSession(entry);
+      // Owner status uses the runner's synchronous stage-1 decision.
+      waitingForRoute =
+        summary.target === "last"
+          ? !(route?.channel && route.to)
+          : !hasResolvableHeartbeatOwnerRoute({
+              cfg,
+              agentId: agent.id,
+              entry,
+              heartbeat: {
+                ...cfg.agents?.defaults?.heartbeat,
+                ...resolveAgentConfig(cfg, agent.id)?.heartbeat,
+              },
+            });
+    }
     return {
       agentId: agent.id,
       enabled: summary.enabled,
       every: summary.every,
       everyMs: summary.everyMs,
-      waitingForRoute: summary.enabled && !hasDeliveryRoute,
+      waitingForRoute,
     } satisfies HeartbeatStatus;
   });
   const channelSummary = needsChannelPlugins
@@ -467,22 +472,22 @@ export async function getStatusSummary(
 
   const sessionDetails = includeSensitive ? await prepareSessionStatusDetails(cfg, now) : undefined;
 
-  const sessionStores = readStatusSessionStores(cfg, agentList.agents);
+  const sessionStores = readStatusSessionStores(
+    cfg,
+    agentList.agents,
+    includeSensitive ? RECENT_SESSION_LIMIT : 0,
+  );
   const byAgent = await Promise.all(
-    sessionStores.byAgent.map(async ({ agent, path, sessions }) => ({
+    sessionStores.byAgent.map(async ({ agent, path, count, recent }) => ({
       agentId: agent.id,
       path: includeSensitive ? path : "[redacted]",
-      count: sessions.length,
-      recent: sessionDetails
-        ? await sessionDetails.buildSessionRows(
-            selectRecentSessionCandidates(sessions, RECENT_SESSION_LIMIT),
-          )
-        : [],
+      count,
+      recent: sessionDetails ? await sessionDetails.buildSessionRows(recent) : [],
     })),
   );
   const recent = sessionDetails
     ? await sessionDetails.buildSessionRows(
-        selectRecentSessionCandidates(sessionStores.sessions, RECENT_SESSION_LIMIT),
+        selectRecentSessionCandidates(sessionStores.recent, RECENT_SESSION_LIMIT),
       )
     : [];
   const hostDesktopStatus =
@@ -532,7 +537,7 @@ export async function getStatusSummary(
     ...(taskAuditRetainedLost.count > 0 ? { taskAuditRetainedLost } : {}),
     sessions: {
       paths: includeSensitive ? sessionStores.paths : [],
-      count: sessionStores.sessions.length,
+      count: sessionStores.count,
       defaults: sessionDetails?.defaults ?? { model: null, contextTokens: null },
       recent,
       byAgent,


### PR DESCRIPTION
Related: #130324. Split from #130706; the broader CPU/stall investigation remains separate.

## What Problem This Solves

Health and status loaded every stored session payload to report counts and a small recent window. Large stores therefore performed work proportional to all historical payloads even when the response needed only five or ten entries.

## Why This Change Was Made

One read-only SQLite summary owner counts canonical visible rows and hydrates only the required recent windows. Each physical store supplies one collection snapshot, including separate windows for configured agents. The existing canonical-key, readable pending-row, participant projection, and read-only database contracts are retained. Cold canonical validation remains complete.

The old full-entry listing/grouping/projection path is removed from health/status summaries. ACP metadata projection uses the already captured entry instead of rereading a possibly replaced generation. Disabled heartbeats and targets that do not consume a session route avoid that unnecessary read.

This preserves main's listing-metadata cache/data-version and pending-input receipt work. It adds no schema, index, retention, write transaction, configuration option, migration, or persistent-state design.

## Evidence

Current head: `42721f8ba7bd0c911788d88a63b4a13af8e063b5`, integrated on main `e27a72435258a05d09ff5e98b2c2ac2fe18d49f4`.

- Fresh unchanged-main reproduction failed both bounded-payload cases: old session payloads were parsed two/four times instead of zero. The identical focused command passed after the repair. These are work assertions, not timing thresholds.
- The ordered complete owner/sibling cohort passed **432 tests across 23 files**, with one existing platform-specific SQLite lock skip. Main's cache, deletion, default-agent listing, and pending-input suites are included. No retries or deadline changes.
- The complete staged changed gate passed. QA/test audit and deslop are complete. Managed Codex P0 review returned scoped-clean with no findings; no all-priority review claim. Source/index hashes remained unchanged through validation and match the committed tree.
- The fresh ordinary declaration-enabled full build passed on this exact head. All **15,523 emitted entries** stayed unchanged through both subsequent runs; source remained clean and identical. Actual emitted owner/export and protocol bindings were inspected before execution.
- Both first-attempt built Gateway runs passed: **four separate agent stores** and **one shared physical store**, each with four logical agents and **1,000 sessions per agent**, using 8 KiB payloads. First and warm status returned **4,000 total / 10 global recent**, with **1,000 / 10** per agent. First and warm health returned **1,000 / 5** per agent. Every recorded key, timestamp, and ordering matched the seeded rows plus normal label updates.
- In both layouts, the two fixed ordinary callbacks retained the exact open owner/database identities with no transaction held. Private controls passed a completed synchronous transaction, rejected the deliberately held transaction, and passed again after rollback. These bounded observations do not attribute the historical arbitrary-inspector failures.
- All recorded child leaders and process groups joined; both owned fixture roots were removed. The frozen driver retained Gateway stream hashes/byte counts, not raw bodies or numeric ports; no warning-free, numeric-port rebind, or zero-background-network claim is made. Readiness included a transient probe timeout before succeeding within the unchanged deadline; no scenario retry was used.
- Required exact-head [CI passed](https://github.com/openclaw/openclaw/actions/runs/33444377569), including `openclaw/ci-gate`.

Fresh redacted runtime results are above. Per-agent receipt SHA-256: `68b16d7b793e4b76eb1ad1c206d2b4d6d67993fb5f0aeca7464e562bfe3a7c35`; shared receipt: `32c21de39fa0bde0bdab390790d1b06bf54885a462c62ffc444f4fa0dafdf786`. The build/both-layout closeout binds their native results and unchanged inputs: `ea5d67ac70806f059b2d36c227c67029a147a91aa9d5ce1d3e3c3dd0ef2fe537`. This addresses the current review's fresh-runtime prerequisite and rank-up move without claiming a measured before/after speedup.

Historical d28 proof remains historical: its ordinary build and both physical layouts (four separate agent stores and one shared store, four logical agents with 1,000 sessions each) passed real built health/status reads, count/order assertions, and read-transaction cleanup checks. Seventeen of the nineteen refreshed files are byte-identical; two accessor barrels preserve newer main's comment and receipt export. That does not relabel the older runtime results as current-head proof.

Earlier interrupted profiling experiments and an earlier unmocked health timeout remain unexplained and are not counted as successful proof. No authenticated provider/channel, production soak, or whole-incident speedup claim. Telegram remains waived, not passed.

Latest-main inspection through `fdbd16728060b31d3380f3bd8394e131fa921266` found no direct overlap in these 19 paths. Its shared database reader consolidates fresh/reused admission while preserving transaction exclusion and fresh-handle-only closure; its immediate schema-version result is reused only within the synchronous admission. The summary's existing owner contract remains intact. Later build-cache inventory changes preserve sorted output identity and do not change this runtime capability.

## Size and Tradeoff

| Area | Added | Removed | Net |
| --- | ---: | ---: | ---: |
| Production, 8 files | 220 | 113 | +107 |
| Tests, 10 existing files | 340 | 140 | +200 |
| Test support, 1 existing file | 34 | 6 | +28 |

Production growth is the new bounded read capability and its shared collection owner. Reusing the old full-entry accessor would retain the original payload work; per-consumer caches would duplicate ownership and risk stale summaries. The implementation reuses existing Kysely, transaction, key-validation, participant, and database-handle helpers.

Changelogs are written at release time; no changelog edit or committed proof harness is included.
