### PR TITLE
refactor: streamline agent database read admission

### DIFF
--- a/src/state/openclaw-agent-db-readonly.ts
+++ b/src/state/openclaw-agent-db-readonly.ts
@@ -30,14 +30,6 @@ type OpenClawAgentDatabaseReadOnlyResult<T> =
   | { found: true; value: T }
   | { found: false; reason: "database-missing" | "schema-missing" | "table-missing" };
 
-function isMissingTableError(error: unknown): boolean {
-  return (
-    error instanceof Error &&
-    (error as NodeJS.ErrnoException).code === "ERR_SQLITE_ERROR" &&
-    /\bno such table:/iu.test(error.message)
-  );
-}
-
 /**
  * Look up a process-held handle without adopting writer-side failures.
  *
@@ -74,53 +66,55 @@ export function withOpenClawAgentDatabaseReadOnly<T>(
       ? { found: true, value: operation(database) }
       : { found: false, reason: "database-missing" };
   }
-  // Reusing a handle this process already holds is what keeps row loops cheap:
-  // opening and closing a connection per call made reads scale with row count.
-  // An in-flight transaction is skipped so callers never observe uncommitted
-  // rows that a fresh read-only connection could not have seen.
+  // Borrow only outside a transaction so readers see committed rows.
+  // The writer owns reused handles; this call closes only fresh connections.
   const opened = behavior.allowExtension
     ? undefined
     : findOpenAgentDatabase({ ...options, agentId });
-  if (opened && !opened.db.isTransaction) {
-    // A newer build can migrate this file while the handle stays open, so the
-    // forward-compatibility gate still runs before any reused read.
-    assertSupportedAgentSchemaVersion(opened.db, pathname);
-    assertCanonicalAgentPersistenceVersion(opened.db, pathname);
-    try {
-      return { found: true, value: operation(opened) };
-    } catch (error) {
-      if (isMissingTableError(error) && !behavior.throwOnMissingTable) {
-        return { found: false, reason: "table-missing" };
-      }
-      throw error;
-    }
-  }
-  if (!fs.existsSync(pathname)) {
+  const reusable = opened && !opened.db.isTransaction ? opened : undefined;
+  if (!reusable && !fs.existsSync(pathname)) {
     return { found: false, reason: "database-missing" };
   }
-  const db = openNodeSqliteDatabase(pathname, {
-    readOnly: true,
-    ...(behavior.allowExtension ? { allowExtension: true } : {}),
-  });
+  const database = reusable ?? {
+    agentId,
+    db: openNodeSqliteDatabase(pathname, {
+      readOnly: true,
+      ...(behavior.allowExtension ? { allowExtension: true } : {}),
+    }),
+    path: pathname,
+  };
+  const { db } = database;
   try {
-    db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
-    assertSupportedAgentSchemaVersion(db, pathname);
-    assertCanonicalAgentPersistenceVersion(db, pathname);
-    const schemaMeta = readExistingAgentSchemaMeta(db);
-    if (!schemaMeta) {
-      return { found: false, reason: "schema-missing" };
+    if (!reusable) {
+      db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
     }
-    assertExistingAgentSchemaOwner(schemaMeta, agentId, pathname);
+    // Share only this admission's fresh value; a later read must check again.
+    const userVersion = assertSupportedAgentSchemaVersion(db, pathname);
+    assertCanonicalAgentPersistenceVersion(db, pathname, userVersion);
+    if (!reusable) {
+      const schemaMeta = readExistingAgentSchemaMeta(db);
+      if (!schemaMeta) {
+        return { found: false, reason: "schema-missing" };
+      }
+      assertExistingAgentSchemaOwner(schemaMeta, agentId, pathname);
+    }
     try {
-      return { found: true, value: operation({ agentId, db, path: pathname }) };
+      return { found: true, value: operation(database) };
     } catch (error) {
-      if (isMissingTableError(error) && !behavior.throwOnMissingTable) {
+      if (
+        error instanceof Error &&
+        (error as NodeJS.ErrnoException).code === "ERR_SQLITE_ERROR" &&
+        /\bno such table:/iu.test(error.message) &&
+        !behavior.throwOnMissingTable
+      ) {
         return { found: false, reason: "table-missing" };
       }
       throw error;
     }
   } finally {
-    clearNodeSqliteKyselyCacheForDatabase(db);
-    db.close();
+    if (!reusable) {
+      clearNodeSqliteKyselyCacheForDatabase(db);
+      db.close();
+    }
   }
 }

--- a/src/state/openclaw-agent-db-schema-helpers.ts
+++ b/src/state/openclaw-agent-db-schema-helpers.ts
@@ -249,7 +249,7 @@ export function repairAndAssertOpenClawAgentV14SchemaForMigration(
   }
 }
 
-export function assertSupportedAgentSchemaVersion(db: DatabaseSync, pathname: string): void {
+export function assertSupportedAgentSchemaVersion(db: DatabaseSync, pathname: string): number {
   const userVersion = readSqliteUserVersion(db);
   if (userVersion > OPENCLAW_AGENT_SCHEMA_VERSION) {
     throw createNewerSqliteSchemaVersionError(
@@ -259,14 +259,18 @@ export function assertSupportedAgentSchemaVersion(db: DatabaseSync, pathname: st
       OPENCLAW_AGENT_SCHEMA_VERSION,
     );
   }
+  return userVersion;
 }
 
-/** Versioned data repairs run only through Doctor, never a steady-state reader or writer. */
-export function assertCanonicalAgentPersistenceVersion(db: DatabaseSync, pathname: string): void {
-  const userVersion = readSqliteUserVersion(db);
-  const hasApplicationSchema = db
-    .prepare("SELECT 1 FROM sqlite_master WHERE substr(name, 1, 7) <> 'sqlite_' LIMIT 1")
-    .get();
+/** Readers may pass their immediate check; writers reread the version after integrity work. */
+export function assertCanonicalAgentPersistenceVersion(
+  db: DatabaseSync,
+  pathname: string,
+  userVersion = readSqliteUserVersion(db),
+): void {
+  const hasApplicationSchema =
+    userVersion === 0 &&
+    db.prepare("SELECT 1 FROM sqlite_master WHERE substr(name, 1, 7) <> 'sqlite_' LIMIT 1").get();
   const isNewUnownedDatabase =
     userVersion === 0 && readExistingAgentSchemaMeta(db) === null && !hasApplicationSchema;
   if (userVersion < AGENT_MEDIA_SCHEMA_VERSION && !isNewUnownedDatabase) {

--- a/src/state/openclaw-agent-db.incognito.test.ts
+++ b/src/state/openclaw-agent-db.incognito.test.ts
@@ -110,6 +110,13 @@ describe("incognito agent database", () => {
     expect(first.db.prepare("PRAGMA user_version").get()).toEqual({
       user_version: OPENCLAW_AGENT_SCHEMA_VERSION,
     });
+    expect(() =>
+      withOpenClawAgentDatabaseReadOnly(
+        ({ db }) => db.prepare("SELECT * FROM missing_readonly_table").all(),
+        { agentId: "main", env, path: sentinel },
+      ),
+    ).toThrow(/no such table: missing_readonly_table/);
+    expect(first.db.isOpen).toBe(true);
     expect(fs.existsSync(sentinel)).toBe(false);
     expect(fs.existsSync(path.dirname(sentinel))).toBe(false);
 

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -3,6 +3,7 @@ import { execFileSync, spawn } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
+import type { DatabaseSync } from "node:sqlite";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import {
@@ -23,6 +24,7 @@ import {
   assertAgentDeletionPathFence,
   prepareAgentDeletionPathFence,
 } from "./agent-deletion-journal.js";
+import { AGENT_MEDIA_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
 import {
   assertNoOpenClawAgentDatabaseLeases,
   claimOpenClawAgentDatabaseLease,
@@ -1029,7 +1031,7 @@ describe("openclaw agent database", () => {
     ]);
   });
 
-  it("returns typed not-found without creating a missing read-only database", () => {
+  it("distinguishes absent, unowned and unsupported read-only databases", () => {
     const stateDir = createTempStateDir();
     const options = {
       agentId: "worker-1",
@@ -1042,6 +1044,25 @@ describe("openclaw agent database", () => {
       reason: "database-missing",
     });
     expect(fs.existsSync(databasePath)).toBe(false);
+
+    fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+    const { DatabaseSync } = requireNodeSqlite();
+    const empty = new DatabaseSync(databasePath);
+    empty.close();
+    expect(withOpenClawAgentDatabaseReadOnly(() => "unused", options)).toEqual({
+      found: false,
+      reason: "schema-missing",
+    });
+
+    const unsupported = new DatabaseSync(databasePath);
+    try {
+      unsupported.exec(`PRAGMA user_version = ${OPENCLAW_AGENT_SCHEMA_VERSION + 1};`);
+    } finally {
+      unsupported.close();
+    }
+    expect(() => withOpenClawAgentDatabaseReadOnly(() => "unused", options)).toThrow(
+      `newer schema version ${OPENCLAW_AGENT_SCHEMA_VERSION + 1}`,
+    );
   });
 
   it("opens extension-capable reads separately from the owner without enabling writes", () => {
@@ -1066,42 +1087,125 @@ describe("openclaw agent database", () => {
     expect(result).toEqual({ found: true, value: { agent_id: "worker-1" } });
   });
 
-  it("refuses a newer schema from the read-only database helper", () => {
-    const stateDir = createTempStateDir();
-    const options = {
-      agentId: "worker-1",
-      env: { OPENCLAW_STATE_DIR: stateDir },
-    };
-    const databasePath = resolveOpenClawAgentSqlitePath(options);
-    fs.mkdirSync(path.dirname(databasePath), { recursive: true });
-    const { DatabaseSync } = requireNodeSqlite();
-    const database = new DatabaseSync(databasePath);
-    database.exec(`PRAGMA user_version = ${OPENCLAW_AGENT_SCHEMA_VERSION + 1};`);
-    database.close();
+  it.each([
+    {
+      version: OPENCLAW_AGENT_SCHEMA_VERSION + 1,
+      expectedError: {
+        name: "SqliteSchemaVersionError",
+        message: expect.stringContaining(
+          `newer schema version ${OPENCLAW_AGENT_SCHEMA_VERSION + 1}`,
+        ),
+      },
+    },
+    {
+      version: AGENT_MEDIA_SCHEMA_VERSION - 1,
+      expectedError: {
+        name: "OpenClawAgentDatabaseMediaMigrationRequiredError",
+        message: expect.stringContaining("run openclaw doctor --fix to migrate persisted media"),
+      },
+    },
+    {
+      version: OPENCLAW_AGENT_SCHEMA_VERSION - 1,
+      expectedError: {
+        name: "Error",
+        message: expect.stringContaining(
+          "stop active agents and run openclaw doctor --fix to migrate session identities",
+        ),
+      },
+    },
+  ])(
+    "rejects a committed version change to $version before borrowed and fresh reads",
+    ({ version, expectedError }) => {
+      const stateDir = createTempStateDir();
+      const options = { agentId: "worker-1", env: { OPENCLAW_STATE_DIR: stateDir } };
+      const databasePath = materializeCurrentWorkerAgentDatabase(stateDir);
+      openOpenClawAgentDatabase(options);
+      let admitted: boolean;
+      const read = () =>
+        withOpenClawAgentDatabaseReadOnly(({ db }) => {
+          admitted = true;
+          return db.prepare("SELECT agent_id FROM schema_meta WHERE meta_key = 'primary'").get();
+        }, options);
+      expect(read()).toEqual({ found: true, value: { agent_id: "worker-1" } });
+      admitted = false;
 
-    expect(() => withOpenClawAgentDatabaseReadOnly(() => "unused", options)).toThrow(
-      `newer schema version ${OPENCLAW_AGENT_SCHEMA_VERSION + 1}`,
-    );
-  });
+      const { DatabaseSync } = requireNodeSqlite();
+      const writer = new DatabaseSync(databasePath);
+      try {
+        writer.exec(`BEGIN IMMEDIATE; PRAGMA user_version = ${version}; COMMIT;`);
+      } finally {
+        writer.close();
+      }
+      expect(read).toThrow(expect.objectContaining(expectedError));
+      expect(admitted).toBe(false);
 
-  it("returns typed not-found when a read-only query targets a missing table", () => {
+      expect(closeOpenClawAgentDatabaseByPath(databasePath)).toBe(true);
+      expect(read).toThrow(expect.objectContaining(expectedError));
+      expect(admitted).toBe(false);
+    },
+  );
+
+  it("preserves missing-table adaptation for borrowed and fresh read-only queries", () => {
     const stateDir = createTempStateDir();
     const options = {
       agentId: "worker-1",
       env: { OPENCLAW_STATE_DIR: stateDir },
     };
     const databasePath = materializeCurrentWorkerAgentDatabase(stateDir);
-    const { DatabaseSync } = requireNodeSqlite();
-    const database = new DatabaseSync(databasePath);
-    database.exec("DROP TABLE session_nodes;");
-    database.close();
-
-    expect(
+    const owner = openOpenClawAgentDatabase(options);
+    owner.db.exec("DROP TABLE session_nodes;");
+    let readDb: DatabaseSync | undefined;
+    const read = (throwOnMissingTable = false) =>
       withOpenClawAgentDatabaseReadOnly(
-        ({ db }) => db.prepare("SELECT * FROM session_nodes").all(),
+        ({ db }) => {
+          readDb = db;
+          return db.prepare("SELECT * FROM session_nodes").all();
+        },
         options,
-      ),
-    ).toEqual({ found: false, reason: "table-missing" });
+        { throwOnMissingTable },
+      );
+
+    expect(read()).toEqual({ found: false, reason: "table-missing" });
+    expect(() => read(true)).toThrow(/no such table: session_nodes/);
+    expect(readDb).toBe(owner.db);
+    expect(owner.db.isOpen).toBe(true);
+    expect(closeOpenClawAgentDatabaseByPath(databasePath)).toBe(true);
+    expect(read()).toEqual({ found: false, reason: "table-missing" });
+    expect(readDb?.isOpen).toBe(false);
+    expect(() => read(true)).toThrow(/no such table: session_nodes/);
+    expect(readDb?.isOpen).toBe(false);
+  });
+
+  it("reads committed rows without joining or closing the owner's transaction", () => {
+    const stateDir = createTempStateDir();
+    const options = { agentId: "worker-1", env: { OPENCLAW_STATE_DIR: stateDir } };
+    materializeCurrentWorkerAgentDatabase(stateDir);
+    const owner = openOpenClawAgentDatabase(options);
+    const query = "SELECT updated_at FROM schema_meta WHERE meta_key = 'primary'";
+    const before = owner.db.prepare(query).get() as { updated_at: number };
+    let readDb: DatabaseSync | undefined;
+    const read = () =>
+      withOpenClawAgentDatabaseReadOnly(({ db }) => {
+        readDb = db;
+        return db.prepare(query).get();
+      }, options);
+
+    owner.db.exec("BEGIN IMMEDIATE;");
+    try {
+      owner.db
+        .prepare("UPDATE schema_meta SET updated_at = ? WHERE meta_key = 'primary'")
+        .run(before.updated_at + 1);
+      expect(read()).toEqual({ found: true, value: before });
+      expect(readDb === owner.db).toBe(false);
+      expect(readDb?.isOpen).toBe(false);
+      expect(owner.db.isTransaction).toBe(true);
+    } finally {
+      owner.db.exec("ROLLBACK;");
+    }
+
+    expect(read()).toEqual({ found: true, value: before });
+    expect(readDb).toBe(owner.db);
+    expect(owner.db.isOpen).toBe(true);
   });
 
   it("lists a missing registry without creating the shared state database", () => {
@@ -2165,6 +2269,20 @@ describe("openclaw agent database", () => {
     expect(() =>
       openOpenClawAgentDatabase({ agentId: "worker-2", env, path: database.path }),
     ).toThrow("initialization close failed");
+
+    expect(
+      withOpenClawAgentDatabaseReadOnly(
+        ({ db }) => db.prepare("SELECT agent_id FROM schema_meta WHERE meta_key = 'primary'").get(),
+        { agentId: "worker-1", env, path: database.path },
+      ),
+    ).toEqual({ found: true, value: { agent_id: "worker-1" } });
+    expect(() =>
+      withOpenClawAgentDatabaseReadOnly(() => "unused", {
+        agentId: "worker-2",
+        env,
+        path: database.path,
+      }),
+    ).toThrow("belongs to agent worker-1; requested agent worker-2");
 
     expect(disposeOpenClawAgentDatabaseByPath(database.path, { env })).toBe(true);
     expect(() => assertNoOpenClawAgentDatabaseLeases("worker-2", { env })).not.toThrow();
@@ -4788,29 +4906,43 @@ describe("openclaw agent database", () => {
     },
   );
 
-  it("does not hide a sqlitefoo-only metadata-less v0 database as internal", () => {
-    const stateDir = createTempStateDir();
-    const env = { OPENCLAW_STATE_DIR: stateDir };
-    const databasePath = path.join(stateDir, "populated-v0.sqlite");
-    const { DatabaseSync } = requireNodeSqlite();
-    const populated = new DatabaseSync(databasePath);
-    try {
-      populated.exec("CREATE TABLE sqlitefoo (value TEXT);");
-    } finally {
-      populated.close();
-    }
+  it.each([
+    {
+      kind: "sqlitefoo-only application schema",
+      schema: "CREATE TABLE sqlitefoo (value TEXT);",
+      expectedError: /uses schema version 0; run openclaw doctor --fix/,
+    },
+    {
+      kind: "malformed ownership metadata",
+      schema: "CREATE TABLE schema_meta (meta_key TEXT);",
+      expectedError: /no such column: role/,
+    },
+  ])(
+    "preserves the refusal for a populated v0 database with $kind",
+    ({ schema, expectedError }) => {
+      const stateDir = createTempStateDir();
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      const databasePath = path.join(stateDir, "populated-v0.sqlite");
+      const { DatabaseSync } = requireNodeSqlite();
+      const populated = new DatabaseSync(databasePath);
+      try {
+        populated.exec(schema);
+      } finally {
+        populated.close();
+      }
 
-    expect(() =>
-      withOpenClawAgentDatabaseReadOnly(() => "unused", {
-        agentId: "worker-1",
-        env,
-        path: databasePath,
-      }),
-    ).toThrow("uses schema version 0; run openclaw doctor --fix");
-    expect(() =>
-      openOpenClawAgentDatabase({ agentId: "worker-1", env, path: databasePath }),
-    ).toThrow("uses schema version 0; run openclaw doctor --fix");
-  });
+      expect(() =>
+        withOpenClawAgentDatabaseReadOnly(() => "unused", {
+          agentId: "worker-1",
+          env,
+          path: databasePath,
+        }),
+      ).toThrow(expectedError);
+      expect(() =>
+        openOpenClawAgentDatabase({ agentId: "worker-1", env, path: databasePath }),
+      ).toThrow(expectedError);
+    },
+  );
 
   it("runs full integrity before a pending agent schema migration", () => {
     const stateDir = createTempStateDir();


### PR DESCRIPTION
## What Problem This Solves

Concurrent Gateway session reads repeatedly perform the same SQLite admission work, even when they reuse an already-open agent database. This refactor removes two unnecessary queries from each successful admission to a current-version database: a duplicate `PRAGMA user_version` and a probe for an empty, unversioned application schema.

## Why This Change Was Made

The read-only owner now selects a borrowed or fresh handle and runs one admission/callback path. Its supported-version check returns the freshly read version to the immediately following canonical-version check. Every later admission reads the version again; this is not a process cache for mutable database state. The empty-schema probe remains for version zero, with the existing metadata/error ordering.

Borrowed handles remain writer-owned and are not used during a transaction. Fresh handles retain metadata/agent-owner checks and are closed on success or failure. The writable owner still rereads the version after integrity work. Incognito, extension loading, missing-table behavior and Doctor migration ownership are unchanged. There is no schema, storage, configuration or dependency change. Production: **+47/−49 (net −2)**; tests: **+188/−49 (net +139)**.

## User Impact

Session reads do less repeated admission work without changing which database versions or rows they may read. This is a bounded performance improvement in the continuing Gateway saturation investigation, not a claim that control-plane stalls are resolved.

## Evidence

- Real-SQLite characterization passed **128 tests / 4 existing skips** on both baseline and candidate, in the same file order. Six sibling suites passed **85 tests** covering permissions, session reads, handle lifecycle, maintenance writers, history eviction and Doctor health. Six temporary mutation controls failed at their intended assertions, protecting transaction isolation, both version gates, strict missing-table behavior, fresh-handle disposal and version-zero error ordering.
- The full changed gate, exact source build and managed Codex review passed. The first changed gate found an unused initializer in a new test; it was removed and the complete gate rerun without exemptions. The managed review has no P0 findings; root owner/caller/sibling review and independent source/proof verification are also complete. The subsequent one-line test declaration correction does not alter production or assertions.
- Three alternating baseline/candidate pairs measured **2,000 borrowed reads** per sample: baseline per-process medians **39.67–41.72 ms**, candidate **25.54–25.93 ms**. A separate query observation confirms the two removed queries. Fresh-connection timings varied and do not establish a speedup.
- Identical isolated 32-turn Gateway profiles on base `e27a72435258a05d09ff5e98b2c2ac2fe18d49f4`, with only these four source afterimages changed, sampled read-admission gates at **270.131 → 72.903 ms** during load. The complete read-only subtree was **2121.751 → 2203.877 ms**; required SQL and parsing remain substantial. All original 2,000 ms control budgets passed, with no metadata rescans, but several latency tails increased: sessions.list maximum **1376 → 1765 ms**, history p99/maximum **1488/1621 → 1815/1931 ms**. ELU remained 1.

The visible synthetic Control UI completed its selected reply, but five candidate `tasks.list` RPCs returned `UNAVAILABLE` while registry/access snapshots changed. These are outside the benchmark's original failure counters and are retained as a separate follow-up, not counted as successful UI requests. A separate controlled-schedule proof using real handlers and SQLite produces both existing refusal outcomes on baseline and candidate, followed by quiet recovery; a revoked viewer receives an empty page. The refusals do not require this patch, but their frequency in natural load and the individual invalidating mutations remain unproven. The task-list owners are unchanged by this patch.

Both profile runs used isolated HOME/state, a mock provider and loopback ports, completed 32 wrapped model requests and 128 updates, recovered to two healthy readiness observations, and closed their owned processes/state. No production Gateway was exercised. No overall latency, global UI-idle or memory-leak conclusion is claimed. Fresh comparison with main `5c388e5e16c16ab504bc2d8513811d2a146fcfb0` confirms all four changed baseline files are unchanged. Of 28 selected contract/caller/test/dependency contexts, 25 are byte-identical to the profile base; the other changes are an unrelated active-child agent filter and a root development dependency/importer entry for already-locked pako. The task-list pagination and database contracts are unchanged. The measurements describe the pinned e27a pair, not a fresh profile of later main.

Reproduction workload: 32 turns, 48 seeded sessions, 128 updates across four clients, three history clients with bursts of five, six subscribers, a visible observer, 100 ms cadence and 1,000 ms mock-stream delay. Full commands, source pins, raw profiles, failure joins and cleanup receipts are retained in the task artifacts; no benchmark thresholds were changed.

Exact-head [CI run 33444556480](https://github.com/openclaw/openclaw/actions/runs/33444556480) is successful on `4367ea4c08c20d61a18ffca46fd03a8ff921d812`. Attempt 1 failed while `pnpm dlx` installed Knip because its native parser binary was missing; one failed-job retry passed without source changes or gate exemptions. The latest completed ClawSweeper review had no actionable findings; its current-main comparison and green-CI Rank-up requests are now addressed.
