### PR TITLE
test(codex): cover forced launcher cleanup

### DIFF
--- a/extensions/codex/src/app-server/transport-startup.test.ts
+++ b/extensions/codex/src/app-server/transport-startup.test.ts
@@ -58,13 +58,13 @@ describe.skipIf(process.platform === "win32")("Codex failed launcher startup", (
   });
 
   it.each([
-    ["signal", "inspection"],
-    ["clean", "inspection"],
-    ["signal", "commit"],
-    ["clean", "commit"],
+    ["available", "inspection"],
+    ["unavailable", "inspection"],
+    ["available", "commit"],
+    ["unavailable", "commit"],
   ] as const)(
-    "reaps inherited-pipe descendants before settling a %s launcher after %s refusal",
-    async (exitMode, failure) => {
+    "reaps inherited-pipe descendants with %s containment after %s refusal",
+    async (containment, failure) => {
       const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-startup-launcher-"));
       vi.stubEnv("OPENCLAW_STATE_DIR", path.join(root, "state"));
       const { createPluginStateSyncKeyedStore } =
@@ -89,17 +89,16 @@ fs.writeSync(2, "launcher startup diagnostic\\n");
 fs.writeFileSync(ready, String(process.pid));
 `,
       );
-      // Matches the pinned npm launcher: inherited pipes and signal forwarding,
-      // with an additional clean-exit wrapper proving cleanup cause precedence.
+      // Match the pinned npm launcher's inherited pipes and signal mirroring.
+      // Clean EOF refusal coverage lives at the shared/isolated startup owner.
       await fs.writeFile(
         wrapperPath,
         `
 import { spawn } from "node:child_process";
-const [native, ready, input, exitMode] = process.argv.slice(2);
+const [native, ready, input] = process.argv.slice(2);
 const child = spawn(process.execPath, [native, ready, input], { stdio: "inherit" });
 for (const signal of ["SIGINT", "SIGTERM", "SIGHUP"]) process.on(signal, () => child.kill(signal));
 child.on("exit", (code, signal) => {
-  if (exitMode === "clean") process.exit(0);
   if (signal) process.kill(process.pid, signal);
   else process.exit(code ?? 1);
 });
@@ -119,6 +118,19 @@ child.on("exit", (code, signal) => {
         return child;
       });
       const readCommand = processSnapshot.readCodexAppServerProcessCommand;
+      const readSnapshot = processSnapshot.readCodexAppServerProcessSnapshot;
+      let containmentRefused = false;
+      if (containment === "unavailable") {
+        vi.spyOn(processSnapshot, "readCodexAppServerProcessSnapshot").mockImplementation(
+          (deadline, pids) => {
+            if (pids === undefined) {
+              containmentRefused = true;
+              return Promise.reject(new processSnapshot.ProcessInspectionError("unavailable"));
+            }
+            return readSnapshot(deadline, pids);
+          },
+        );
+      }
       let inspected!: () => void;
       const inspection = new Promise<void>((resolve) => {
         inspected = resolve;
@@ -148,7 +160,7 @@ child.on("exit", (code, signal) => {
         transport: "stdio",
         command: process.execPath,
         commandSource: "config",
-        args: [wrapperPath, nativePath, readyPath, inputPath, exitMode],
+        args: [wrapperPath, nativePath, readyPath, inputPath],
       }).catch((error: unknown) => error);
       try {
         await Promise.race([
@@ -157,14 +169,12 @@ child.on("exit", (code, signal) => {
             throw new Error("Startup settled before fixture inspection");
           }),
         ]);
-        // Observe actual cleanup before awaiting startup: an outer acquire timeout
-        // must not make an unregistered native descendant look safely settled.
+        // Observe actual cleanup independently of the injected inspection failure;
+        // an outer acquire timeout must not make a live descendant look settled.
         await expect
           .poll(
             async () => {
-              const snapshot = await processSnapshot.readCodexAppServerProcessSnapshot(
-                Date.now() + 2_000,
-              );
+              const snapshot = await readSnapshot(Date.now() + 2_000);
               expect(snapshot?.some(({ pid }) => pid === process.pid)).toBe(true);
               const row = snapshot?.find(({ pid }) => pid === nativePid);
               return row !== undefined && !row.state.startsWith("Z");
@@ -188,8 +198,9 @@ child.on("exit", (code, signal) => {
         await expect(fs.access(inputPath)).rejects.toMatchObject({ code: "ENOENT" });
         expect(wrapper?.stdout?.destroyed).toBe(true);
         expect(wrapper?.stderr?.destroyed).toBe(true);
-        expect(wrapper?.exitCode).toBe(exitMode === "clean" ? 0 : null);
-        expect(wrapper?.signalCode).toBe(exitMode === "clean" ? null : "SIGKILL");
+        expect(containmentRefused).toBe(containment === "unavailable");
+        expect(wrapper?.exitCode).toBeNull();
+        expect(wrapper?.signalCode).toBe("SIGKILL");
       } finally {
         vi.restoreAllMocks();
         nativePid ??= Number(await fs.readFile(readyPath, "utf8").catch(() => "")) || undefined;


### PR DESCRIPTION
The full release plugin shard failed because its synthetic clean-exit launcher required exit code 0 even when bounded process inspection could not contain the process tree. In that case the existing cleanup path kills the process group, including the launcher. The real pinned Codex npm launcher mirrors its child's termination signal.

Keep the inherited-pipe fixture aligned with that launcher and exercise both available and unavailable containment after inspection and registration-commit refusals. The observer still inspects real OS processes independently of the injected failure. Original refusal diagnostics, no initialization, one spawn, closed pipes, and dead descendants remain required. Existing shared and isolated startup tests retain cleanup-caused clean-exit coverage.

A controlled Node 24 reproduction failed both old clean-wrapper cases with the same assertion: expected 0, received null; both processes had exited with SIGKILL and all cleanup/error assertions had passed. The revised owner and sibling suites pass 60 tests. Managed Codex review is clean through P2. No runtime changes, retry changes, deadline increases, or release-gate changes. Test delta: +29/-18 lines.

The hosted failure did not record the containment result or signal, so its precise trigger remains unmeasured; the controlled reproduction demonstrates the invalid expectation. Source contract checked directly at Codex tag rust-v0.151.0: `codex-cli/bin/codex.js` signal mirroring and `codex-rs/app-server/src/message_processor.rs` pre-initialize rejection.

Failure: https://github.com/openclaw/openclaw/actions/runs/33442244049/job/99653236859
