### PR TITLE
perf(build): scope cache inventories to one checkout

### DIFF
--- a/scripts/lib/build-artifact-cache.mts
+++ b/scripts/lib/build-artifact-cache.mts
@@ -26,24 +26,27 @@ function cacheEntryIncludesFile(entry: BuildCachePath, filePath: string) {
   return entry.extensions.some((extension) => filePath.endsWith(extension));
 }
 
-function listFilesRecursively(
+function collectCacheFiles(
   rootPath: string,
   fsImpl: typeof fs,
-  cacheEntry: BuildCachePath = { path: rootPath },
+  cacheEntry: BuildCachePath,
+  out: string[],
 ) {
   let stat;
   try {
     stat = fsImpl.statSync(rootPath);
   } catch {
-    return [];
+    return;
   }
   if (stat.isFile()) {
-    return cacheEntryIncludesFile(cacheEntry, rootPath) ? [rootPath] : [];
+    if (cacheEntryIncludesFile(cacheEntry, rootPath)) {
+      out.push(rootPath);
+    }
+    return;
   }
   if (!stat.isDirectory()) {
-    return [];
+    return;
   }
-  const out: string[] = [];
   const entries = fsImpl.readdirSync(rootPath, { withFileTypes: true });
   const recursive = cacheEntry.recursive !== false;
   for (const dirent of entries) {
@@ -55,19 +58,21 @@ function listFilesRecursively(
       continue;
     }
     if (dirent.isDirectory() && recursive) {
-      out.push(...listFilesRecursively(entryPath, fsImpl, cacheEntry));
+      collectCacheFiles(entryPath, fsImpl, cacheEntry, out);
     } else if (dirent.isFile() && cacheEntryIncludesFile(cacheEntry, entryPath)) {
       out.push(entryPath);
     }
   }
-  return out;
 }
 
 export function listCacheFiles(rootDir: string, entries: BuildCacheEntry[], fsImpl: typeof fs) {
-  return entries
-    .map((entry) => (typeof entry === "string" ? { path: entry } : entry))
-    .flatMap((entry) => listFilesRecursively(path.resolve(rootDir, entry.path), fsImpl, entry))
-    .toSorted();
+  // One inventory avoids copying each subtree and spreading unbounded argument lists.
+  const files: string[] = [];
+  for (const entry of entries) {
+    const cacheEntry = typeof entry === "string" ? { path: entry } : entry;
+    collectCacheFiles(path.resolve(rootDir, cacheEntry.path), fsImpl, cacheEntry, files);
+  }
+  return files.toSorted();
 }
 
 export function portableRelativePath(rootDir: string, filePath: string) {

--- a/scripts/tsdown-build.mts
+++ b/scripts/tsdown-build.mts
@@ -147,6 +147,8 @@ export const TSDOWN_UNIFIED_CACHE_INPUTS = [
       ".local",
       ".agents",
       ".claude",
+      // Other checkouts cannot invalidate this checkout's declaration generation.
+      ".worktrees",
     ],
   },
 ];

--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -1057,6 +1057,51 @@ describe("build-all timing output", () => {
 });
 
 describe("resolveBuildStepCacheState", () => {
+  it("lists large nested inventories without an argument-count limit", () => {
+    withBuildCacheFixture(({ rootDir }) => {
+      // Builds run on the main Node thread; Vitest workers have a different stack budget.
+      const result = spawnSync(
+        process.execPath,
+        [
+          "--import",
+          "./scripts/tsx.mjs",
+          "--input-type=module",
+          "-e",
+          `
+            import assert from "node:assert/strict";
+            import fs from "node:fs";
+            import path from "node:path";
+            import { listCacheFiles } from "./scripts/lib/build-artifact-cache.mts";
+            const root = process.argv[1];
+            const directory = path.join(root, "src");
+            const [template] = fs.readdirSync(directory, { withFileTypes: true });
+            const entries = Array.from({ length: 200_000 }, (_, index) =>
+              new Proxy(template, {
+                get(target, key, receiver) {
+                  return key === "name" ? index + ".ts" : Reflect.get(target, key, receiver);
+                },
+              }),
+            );
+            const wideFs = new Proxy(fs, {
+              get(target, key, receiver) {
+                return key === "readdirSync"
+                  ? (file, options) => file === directory ? entries : fs.readdirSync(file, options)
+                  : Reflect.get(target, key, receiver);
+              },
+            });
+            assert.deepEqual(
+              listCacheFiles(root, [{ path: ".", extensions: [".ts"] }], wideFs),
+              entries.map((entry) => path.join(directory, entry.name)).toSorted(),
+            );
+          `,
+          rootDir,
+        ],
+        { encoding: "utf8", timeout: 10_000 },
+      );
+      expect(result.status, result.stderr).toBe(0);
+    });
+  });
+
   it("rejects a snapshot replaced after lookup without changing live outputs", () => {
     withBuildCacheFixture(({ rootDir, outputPath, step }) => {
       const state = resolveBuildStepCacheState(step, { rootDir });
@@ -1183,6 +1228,7 @@ describe("resolveBuildStepCacheState", () => {
       ["packages/ai/dist/index.d.ts", "export declare const ai = 1;"],
       ["packages/net-policy/dist/index.d.ts", "export declare const net = 1;"],
       ["dist/index.d.ts", "export declare const core = 1;"],
+      [".worktrees/pr-123/src/index.ts", "export const otherCheckout = 1;"],
     ] as const;
 
     try {
@@ -1197,6 +1243,13 @@ describe("resolveBuildStepCacheState", () => {
           rootDir,
         });
       }
+
+      const signature = resolveBuildStepCacheState(unified, { rootDir }).signature;
+      fs.writeFileSync(
+        path.join(rootDir, ".worktrees/pr-123/src/index.ts"),
+        "export const otherCheckout = 2;",
+      );
+      expect(resolveBuildStepCacheState(unified, { rootDir }).signature).toBe(signature);
 
       fs.writeFileSync(sourcePath, "export const core = 2;");
       expect(resolveBuildStepCacheState(ai, { rootDir }).fresh).toBe(true);


### PR DESCRIPTION
## Why

A full build in a checkout containing managed PR worktrees crashed while collecting declaration-cache inputs. The broad unified input descriptor included other checkouts beneath `.worktrees`, and the recursive collector passed an entire subtree as arguments to `push`. The observed checkout had 307,977 selected files beneath that directory; the failure was argument space, not a deeply recursive directory tree. Smaller sibling checkouts also changed the current checkout’s cache signature whenever their files changed.

## Change

Keep the intentionally broad current-checkout input coverage, but exclude the managed `.worktrees` directory in the unified declaration descriptor. The shared file collector now appends to one private inventory and retains its final `toSorted()` result, eliminating per-subtree arrays, unbounded argument spreading and top-level flattening. Other callers still enumerate exactly the roots they request; `.worktrees` is not globally hidden by the generic helper. Explicit files, duplicate descriptors, extension filters, direct-only traversal, lexical ordering, symlinks and error boundaries retain their behavior.

This is net +7 production lines and +53 test lines. The modest growth expresses the existing complete-inventory and checkout-ownership contracts; it adds no dependency, cache format, configuration surface, storage or compatibility path. This is internal build tooling, with no application UI or user-data behavior change.

## Validation

The two regressions fail against unchanged source: a 200,000-entry nested inventory throws on the normal Node main thread, and unrelated worktree edits change the canonical unified signature. The first wide test ran inside a Vitest worker and did not reproduce; that failed test design is retained. The final test uses the existing build loader in a bounded fresh child, with complete sorted inventory equality and no stack override. Node workers have a different stack budget: [Node26 worker contract](https://github.com/nodejs/node/blob/v26.8.1/src/node_worker.h#L110), [ARM64 variadic argument check](https://github.com/nodejs/node/blob/v26.8.1/deps/v8/src/builtins/arm64/builtins-arm64.cc#L2511).

All 303 build/cache/tsdown/staged-SDK/package-boundary tests pass. The final bounded child test passes with the other 78 build-all cases. Changed checks pass; the first check failure was the repository’s preference for `toSorted()` over in-place `sort()`, corrected without a suppression. The original failure, both RED runs and the successful checks remain preserved. Independent all-priority source review found no actionable issue; managed Codex review is also clean at its configured scope.

Four fixed fresh processes ran before/candidate/candidate/before, reversing row order for the second pair. All 308 measured calls, 112 warmup calls and 28 first calls are retained. The full owner runs on real APFS fixture trees; setup, imports and assertions are outside the timed calls. Root independently recomputed all 28 medians and checked raw output hashes, exact inventories, process/group exit and private runtime removal.

| Complete inventory, milliseconds | Before → candidate, forward | Before → candidate, reverse |
| --- | --- | --- |
| Empty directory | 0.017709 → 0.017042 | 0.012375 → 0.012125 |
| Two explicit duplicate file entries | 0.007666 → 0.006583 | 0.004417 → 0.004209 |
| Eight files | 0.049000 → 0.049375 | 0.030666 → 0.032625 |
| 512 flat files | 0.562292 → 0.557791 | 0.446791 → 0.441375 |
| 4,096 nested files | 8.098417 → 8.297875 | 7.997792 → 7.704084 |
| Checkout without nested worktree | 4.403125 → 4.556458 | 4.470875 → 4.343417 |
| Checkout plus equal-size nested worktree | 9.147459 → 4.573958 | 9.966083 → 4.522041 |

The last row improves 50–55%, and stat/directory calls fall from 69 each to 34 each. It intentionally excludes 4,096 other-checkout files, so this is the combined scoped-inventory repair, not an equal-output collector comparison. Unchanged ordinary rows are mixed: eight-file median costs +0.375/+1.959 µs, nested forward +0.199 ms, clean-checkout forward +0.153 ms. Five slower first-call observations remain, largest +0.489 ms for the clean checkout. The collector removes intermediate arrays structurally, but these results do not establish a general collector speedup.

Fixtures and raw evidence remain retained; private runtime directories and all four native process groups are gone. Metadata validation warms the filesystem, so first calls are not cold-disk measurements. No compiler, whole-build, Gateway, RSS or statistical-significance improvement is claimed. The full build of exact commit `b6cb259` passed in 173.42 seconds, and the built CLI version smoke passed with the matching build-info commit. The original parent build crashed before compilation, so this is recovery proof, not a comparative build-time claim.

## Follow-up

The separate native boundary-resolution namespace walker also lacks a `.worktrees` exclusion. Its linked-package and authoritative resolution semantics require a distinct reproduction before changing it; this PR neither repairs nor counts that source-only lead.

## Review follow-through

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33446294810) passed on the first attempt: 112 successful and 18 skipped jobs. A fresh committed Codex review is clean at its configured scope. An independent audit recomputed every sample/median, checked all fixture and source pins, and verified process cleanup; the measured dirty diff corresponds exactly to committed `b6cb259`.

The [latest ClawSweeper review](https://github.com/openclaw/openclaw/pull/134501#issuecomment-5485674683) found no actionable regression. Its two follow-through items are resolved: the +7 production lines remain confined to the inventory owner and its descriptor, justified by complete unbounded inventory without argument spreading; exact-head checks and the full build now pass. The +53 test lines cover both failures against the parent. No additional scope or mitigation path was added.
