### PR TITLE
refactor(wizard): share migration path-entry check

### DIFF
--- a/src/wizard/setup.migration-promotion.ts
+++ b/src/wizard/setup.migration-promotion.ts
@@ -67,7 +67,8 @@ export type SetupMigrationPromotionResume = {
   cleanup: () => Promise<void>;
 };
 
-async function pathExists(candidate: string): Promise<boolean> {
+/** Counts dangling leaf entries as present and propagates non-missing path errors. */
+export async function migrationPathEntryExists(candidate: string): Promise<boolean> {
   try {
     await fs.lstat(candidate);
     return true;
@@ -211,10 +212,10 @@ async function removeCreatedPromotionParents(components: PromotionComponent[]): 
 export async function rollbackComponents(components: PromotionComponent[]): Promise<boolean> {
   try {
     for (const component of components.toReversed()) {
-      const stagedExists = await pathExists(component.stagedPath);
-      const finalExists = await pathExists(component.finalPath);
+      const stagedExists = await migrationPathEntryExists(component.stagedPath);
+      const finalExists = await migrationPathEntryExists(component.finalPath);
       const backupExists = component.emptyTargetBackupPath
-        ? await pathExists(component.emptyTargetBackupPath)
+        ? await migrationPathEntryExists(component.emptyTargetBackupPath)
         : false;
       if (!stagedExists && !finalExists) {
         return false;
@@ -232,7 +233,7 @@ export async function rollbackComponents(components: PromotionComponent[]): Prom
         }
       }
       if (backupExists) {
-        if (await pathExists(component.finalPath)) {
+        if (await migrationPathEntryExists(component.finalPath)) {
           return false;
         }
         await fs.rename(component.emptyTargetBackupPath!, component.finalPath);
@@ -254,8 +255,8 @@ async function hasPublishedPromotionComponent(components: PromotionComponent[]):
       return true;
     }
     const [stagedExists, finalExists] = await Promise.all([
-      pathExists(component.stagedPath),
-      pathExists(component.finalPath),
+      migrationPathEntryExists(component.stagedPath),
+      migrationPathEntryExists(component.finalPath),
     ]);
     if (!stagedExists && finalExists) {
       return true;
@@ -287,9 +288,8 @@ export async function recoverSetupMigrationPromotion(params: {
     );
   }
   const currentConfigHash = hashSetupMigrationConfig(await params.readConfigFile());
-  const allFinal = (
-    await Promise.all(journal.components.map((component) => pathExists(component.finalPath)))
-  ).every(Boolean);
+  const finalPaths = journal.components.map((component) => component.finalPath);
+  const allFinal = (await Promise.all(finalPaths.map(migrationPathEntryExists))).every(Boolean);
   if (journal.status === "completed") {
     return createPromotionResume(found.path, journal);
   }
@@ -335,7 +335,7 @@ export async function recoverSetupMigrationPromotion(params: {
 async function listMissingPromotionParents(target: string): Promise<string[]> {
   const missing: string[] = [];
   let current = path.dirname(target);
-  while (!(await pathExists(current))) {
+  while (!(await migrationPathEntryExists(current))) {
     missing.push(current);
     const parent = path.dirname(current);
     if (parent === current) {
@@ -354,7 +354,7 @@ async function reserveEmptyTargetBackupPath(target: string): Promise<string> {
 
 export async function recordPromotionTargetState(component: PromotionComponent): Promise<void> {
   component.createdParentPaths = await listMissingPromotionParents(component.finalPath);
-  if (!(await pathExists(component.finalPath))) {
+  if (!(await migrationPathEntryExists(component.finalPath))) {
     return;
   }
   const stat = await fs.lstat(component.finalPath);

--- a/src/wizard/setup.migration-stage.test.ts
+++ b/src/wizard/setup.migration-stage.test.ts
@@ -8,6 +8,7 @@ import { updateAuthProfileStoreWithLock } from "../agents/auth-profiles/store.js
 import type { MigrationPlan } from "../plugins/types.js";
 import { listOpenClawRegisteredAgentDatabases } from "../state/openclaw-agent-db-registry.js";
 import type { SetupMigrationPromotionContinuation } from "./setup.migration-promotion.js";
+import { SetupMigrationTargetChangedError } from "./setup.migration-snapshot.js";
 import {
   createSetupMigrationStage,
   recoverSetupMigrationPromotion,
@@ -289,6 +290,43 @@ describe("setup migration stage", () => {
     });
     expect(await fs.readdir(workspaceDir)).toEqual([]);
     expect((await fs.stat(workspaceDir)).mode & 0o777).toBe(0o755);
+    await stage.cleanup();
+  });
+
+  it("rejects a dangling promotion target without replacing it", async () => {
+    const root = tempRoots.make("openclaw-migration-stage-");
+    const stateDir = path.join(root, "state");
+    const workspaceDir = path.join(root, "workspace");
+    const workspaceReferent = path.join(root, "workspace-referent");
+    const reportDir = path.join(stateDir, "migration", "claude", "attempt");
+    await fs.mkdir(workspaceReferent, { recursive: true });
+    await fs.symlink(
+      workspaceReferent,
+      workspaceDir,
+      process.platform === "win32" ? "junction" : "dir",
+    );
+    await fs.rmdir(workspaceReferent);
+    const stage = await createSetupMigrationStage({
+      providerId: "claude",
+      stateDir,
+      workspaceDir,
+      reportDir,
+      targetConfig: { agents: { defaults: { workspace: workspaceDir } } },
+    });
+    await fs.writeFile(path.join(stage.staged.workspaceDir, "MEMORY.md"), "staged\n", "utf8");
+
+    await expect(
+      stage.promote({
+        expectedConfig: {},
+        continuation: continuation(),
+        readConfigFile: async () => ({}),
+        commitConfigFile: async (config) => config,
+      }),
+    ).rejects.toBeInstanceOf(SetupMigrationTargetChangedError);
+
+    expect((await fs.lstat(workspaceDir)).isSymbolicLink()).toBe(true);
+    await expect(fs.access(workspaceReferent)).rejects.toThrow();
+    await expect(fs.access(path.join(reportDir, "onboarding-promotion.json"))).rejects.toThrow();
     await stage.cleanup();
   });
 

--- a/src/wizard/setup.migration-stage.ts
+++ b/src/wizard/setup.migration-stage.ts
@@ -29,6 +29,7 @@ import {
   assertDisjointPromotionTargets,
   assertSupportedStagedStateTree,
   createPromotionResume,
+  migrationPathEntryExists,
   moveRecordedEmptyTarget,
   PROMOTION_JOURNAL_FILE,
   PROMOTION_JOURNAL_VERSION,
@@ -81,21 +82,9 @@ type SetupMigrationStage = {
   cleanup: () => Promise<void>;
 };
 
-async function pathExists(candidate: string): Promise<boolean> {
-  try {
-    await fs.lstat(candidate);
-    return true;
-  } catch (error) {
-    if (isNotFoundPathError(error)) {
-      return false;
-    }
-    throw error;
-  }
-}
-
 async function findExistingAncestor(candidate: string): Promise<string> {
   let current = path.resolve(candidate);
-  while (!(await pathExists(current))) {
+  while (!(await migrationPathEntryExists(current))) {
     const parent = path.dirname(current);
     if (parent === current) {
       throw new Error(`Could not find an existing parent for migration staging at ${candidate}.`);
@@ -388,7 +377,8 @@ export async function createSetupMigrationStage(params: {
       ];
       const existingComponents: PromotionComponent[] = [];
       for (const component of components) {
-        if (component.name === "workspace" || (await pathExists(component.stagedPath))) {
+        const { name, stagedPath } = component;
+        if (name === "workspace" || (await migrationPathEntryExists(stagedPath))) {
           existingComponents.push(component);
         }
       }


### PR DESCRIPTION
Related issue: https://github.com/openclaw/openclaw/issues/112072

## What Problem This Solves

The setup migration stage and promotion owner carried exact duplicate path-entry existence helpers. Keeping the dangling-entry fail-closed rule in two places made it possible for staging and promotion checks to drift.

## Why This Change Was Made

`src/wizard/setup.migration-promotion.ts` now owns and exports the canonical `migrationPathEntryExists` helper because promotion owns target-entry semantics. `src/wizard/setup.migration-stage.ts` imports it and removes its duplicate local path. The helper still uses `lstat`, so dangling leaf entries count as present while non-missing filesystem errors propagate.

No docs, changelog, config, protocol, storage, dependency, or SDK surfaces changed.

## User Impact

No user-visible behavior change. Setup migration continues to fail closed when a promotion target is a dangling directory link instead of replacing that entry.

## Evidence

- Production LOC: `+16/-26` (net `-10`). Tests: `+38/-0`. The audited estimate was production `+14/-24` and tests `+39`; formatting the long call sites introduced two replacement production lines without changing the expected net reduction, and the complete regression fixture fits in 38 lines.
- Structural proof: `await fs.lstat(candidate)` appears exactly once across the stage and promotion modules (before: 2; after: 1).
- Red proof: temporarily replacing the canonical helper's `lstat` with `stat` made `rejects a dangling promotion target without replacing it` fail because promotion attempted the rename instead of raising `SetupMigrationTargetChangedError`.
- Green proof: restored `lstat`; the exact regression test passed.
- Sibling coverage: `node scripts/run-vitest.mjs src/wizard/setup.migration-stage.test.ts src/wizard/setup.migration-transaction.test.ts src/wizard/setup.migration-import.test.ts` passed 42/42 tests after rebasing onto current `origin/main`.
- Changed-lane proof: `node scripts/check-changed.mjs --dry-run -- src/wizard/setup.migration-stage.ts src/wizard/setup.migration-promotion.ts src/wizard/setup.migration-stage.test.ts` selected `core, coreTests`.
- Local `pnpm check:changed` reached core test typechecking but the shared worktree install lacks the current-main `@types/pako` package; no install was run inside the worktree.
- Generic Blacksmith Testbox `CI=1 pnpm check:changed` passed with exit 0 after 24m36s: https://github.com/openclaw/openclaw/actions/runs/33445147984. The existing run was inspected while active, showed ongoing CPU/test progress, and was not duplicated.
- Exact-head hosted CI passed. Its first `checks-node-compact-small-7` attempt failed in unrelated `src/commands/doctor-session-sqlite.memory.test.ts` when the 100,000-event public-transcript child reached its explicit 256 MiB heap limit and aborted (`1 failed / 411 passed / 2 skipped`). No wizard file was implicated; the repo-approved single-job rerun passed, and `openclaw/ci-gate` completed green.
- Native Windows proof is infeasible within this PR's scope. The configured trusted physical host is reachable but has no usable local task key. A trusted Blacksmith native-Windows Testbox warmed the exact branch successfully, but its native `testbox run` SSH sync failed before the command started because the workflow-installed task key was unavailable to Blacksmith's fixed `runner` SSH client: https://github.com/openclaw/openclaw/actions/runs/33446757344. The standard Windows CI inventories do not include this wizard test, so their green status cannot substitute for the requested target-specific junction proof. No paid Azure route was used; fixing the native Testbox key handoff requires workflow/infrastructure changes outside this refactor.
- `git diff --check` passed. The signed commit verifies successfully.
- Pinned autoreview verdict: scoped-clean, no accepted/actionable findings; overall patch correctness 0.98.
- Fresh ClawSweeper review found no actionable code or security findings, reported `Before merge: None`, and listed no `Rank-up moves`.
- Mandatory Codex gate inspected directly: `../codex/codex-rs/cli/src/main.rs:220-245` and `../codex/codex-rs/cli/src/main.rs:2840-2870`.
- Canonical repository owner resolved to the primary OpenClaw checkout. The codebase-memory graph was unavailable because another unverified generation held coordination, so source, tests, callers, sibling implementations, and history were inspected directly.
- Live overlap audit: https://github.com/openclaw/openclaw/pull/126605 has only mechanical stage import/agent-selection overlap; https://github.com/openclaw/openclaw/pull/132477 touches the transaction suite, not this helper or regression. A fresh open-PR search found no new semantic collision.
