### PR TITLE
fix(agents): keep model identity guidance conditional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Agent prompts:** keep model-identity guidance conditional so ordinary requests are not mistaken for questions about the current model.
+
 - **Update/Doctor:** preserve `update --no-restart` by requiring an offline managed Gateway during updater-owned repair and leaving restart ownership with the parent.
 - **Bun Gateway:** restore Gateway health checks and agent connections under Bun 1.4 while preserving WebSocket frame limits and authenticated request scheduling.
 - **Doctor recovery notes:** show interrupted auth-profile archive recovery failures and completions even when no further migration runs or another migration is declined. (#134009) Thanks @angeliti999.

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -1940,7 +1940,7 @@ describe("prepareCliRunContext", () => {
     expect(context.params.prompt).toBe("history:2\n\nlatest ask");
     expect(context.contextEngineTurnPrompt).toBe("latest ask");
     expect(context.systemPrompt).toBe(
-      `${wrappedPluginSystemContext("prepend system")}\n\nhook system\n\n${wrappedPluginSystemContext("append system")}${SYSTEM_PROMPT_CACHE_BOUNDARY}\nCurrent model identity: test-cli/test-model. Model question: answer this current-run value.`,
+      `${wrappedPluginSystemContext("prepend system")}\n\nhook system\n\n${wrappedPluginSystemContext("append system")}${SYSTEM_PROMPT_CACHE_BOUNDARY}\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.`,
     );
     expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledTimes(1);
     const beforePromptBuildCalls = hookRunner.runBeforePromptBuild.mock.calls as unknown as Array<
@@ -2189,7 +2189,7 @@ describe("prepareCliRunContext", () => {
 
     expect(context.params.prompt).toBe("prompt prepend\n\nlatest ask");
     expect(context.systemPrompt).toBe(
-      `${wrappedPluginSystemContext("prompt prepend system")}\n\nprompt system\n\n${wrappedPluginSystemContext("prompt append system")}${SYSTEM_PROMPT_CACHE_BOUNDARY}\nCurrent model identity: test-cli/test-model. Model question: answer this current-run value.`,
+      `${wrappedPluginSystemContext("prompt prepend system")}\n\nprompt system\n\n${wrappedPluginSystemContext("prompt append system")}${SYSTEM_PROMPT_CACHE_BOUNDARY}\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.`,
     );
     expect(hookRunner.runBeforePromptBuild).toHaveBeenCalledOnce();
     const beforePromptBuildCalls = hookRunner.runBeforePromptBuild.mock.calls as unknown as Array<
@@ -3007,7 +3007,7 @@ describe("prepareCliRunContext", () => {
     });
 
     expect(context.systemPrompt).toBe(
-      `${wrappedPluginSystemContext("hook prepend system")}\n\nhook system${SYSTEM_PROMPT_CACHE_BOUNDARY}active image task\n\nactive video task\n\nCurrent model identity: test-cli/test-model. Model question: answer this current-run value.`,
+      `${wrappedPluginSystemContext("hook prepend system")}\n\nhook system${SYSTEM_PROMPT_CACHE_BOUNDARY}active image task\n\nactive video task\n\nCurrent model identity: test-cli/test-model. If asked what model you are, answer with this value for the current run.`,
     );
     expect(mockBuildActiveImageGenerationTaskPromptContextForSession).toHaveBeenCalledWith(
       "agent:main:test",

--- a/src/agents/system-prompt.test.ts
+++ b/src/agents/system-prompt.test.ts
@@ -196,19 +196,23 @@ describe("buildAgentSystemPrompt", () => {
     expect(tokenA).not.toBe(tokenB);
   });
 
-  it("injects the current model identity into the runtime prompt", () => {
-    const prompt = buildAgentSystemPrompt({
-      workspaceDir: "/tmp/openclaw",
-      runtimeInfo: {
-        agentId: "main",
-        model: "openai/gpt-5.5",
-      },
-    });
+  it.each(["full", "minimal", "none"] as const)(
+    "keeps model identity guidance conditional in %s prompts",
+    (promptMode) => {
+      const prompt = buildAgentSystemPrompt({
+        workspaceDir: "/tmp/openclaw",
+        promptMode,
+        runtimeInfo: {
+          agentId: "main",
+          model: "openai/gpt-5.5",
+        },
+      });
 
-    expect(prompt).toContain(
-      "Current model identity: openai/gpt-5.5. Model question: answer this current-run value.",
-    );
-  });
+      expect(prompt).toContain(
+        "Current model identity: openai/gpt-5.5. If asked what model you are, answer with this value for the current run.",
+      );
+    },
+  );
 
   it("omits extended sections in minimal prompt mode", () => {
     const prompt = buildAgentSystemPrompt({

--- a/src/agents/system-prompt.ts
+++ b/src/agents/system-prompt.ts
@@ -739,7 +739,7 @@ export function buildModelIdentityPromptLine(model?: string): string | undefined
   if (!trimmed) {
     return undefined;
   }
-  return `${MODEL_IDENTITY_PREFIX} ${trimmed}. Model question: answer this current-run value.`;
+  return `${MODEL_IDENTITY_PREFIX} ${trimmed}. If asked what model you are, answer with this value for the current run.`;
 }
 
 export function appendModelIdentitySystemPrompt(params: {


### PR DESCRIPTION
## Problem

Full release verification at d4106771 exposed a MiniMax tool-read failure. The direct route quoted the shared model-identity instruction as a separate task and answered it instead of completing the request. A previous prompt compression changed the conditional sentence into “Model question: answer this current-run value.”

## Change

Restore the conditional wording at the shared model-identity prompt owner. Both full/minimal/none prompts and CLI assembly use that owner. The instruction applies only when the user asks about the model; provider selection, tools, task prompts, retries, deadlines, and live gates are unchanged. Production is net zero lines; tests net +4, plus one changelog entry.

## Validation

- Three prompt-mode contract cases failed before the owner change; 286 tests across six prompt, CLI, and cache sibling files passed after it.
- The actual changed-path gate passed. Adding the changelog preserved that plan and passed its added formatting/attribution checks. All seven generated prompt snapshots remain current.
- Independent Codex review found no actionable P0–P2 findings.
- Focused hosted Docker proof passed on exact source `e0402a4916a4c1d7a7cf77b310e9859299fd88be`: both explicitly selected MiniMax-M3 routes completed the original prompt and file-read probes. Direct MiniMax passed on its third existing attempt; MiniMax Portal passed on its first. The retry budget, nonce checks, model selection, and gates were unchanged.
- Exact-head CI 33446584065 also passed. The earlier full run remains failed evidence for d410; this focused proof does not replace a fresh full release validation.

Original proof: https://github.com/openclaw/openclaw/actions/runs/33442242954/job/99656104609

## Hosted recovery evidence

[Focused run](https://github.com/openclaw/openclaw/actions/runs/33446594704), [terminal MiniMax job](https://github.com/openclaw/openclaw/actions/runs/33446594704/job/99669446158). The trusted workflow stayed at d410; it built and admitted a new source-bound image for e040. Artifact 9778508502 was downloaded and its service digest verified by the consumer. No registry image was published.

| Route | Terminal trace | Tool-read attempts |
| --- | --- | --- |
| minimax/MiniMax-M3 | tool-read 22:46:09Z; done 22:46:12Z | 3 of the existing maximum 3 |
| minimax-portal/MiniMax-M3 | tool-read 22:46:15Z; done 22:46:16Z | 1 |

Both replies contained the two generated file values; neither selected route was skipped. The direct route still refused its first two attempts, so this does not establish that all provider variability is eliminated. A separate optional fallback probe reported missing configuration; that is distinct from the two completed selected routes. The file reported 166 passing tests including its helper cases. The retained baseline is an earlier hosted run, not a controlled same-run comparison.
