### PR TITLE
perf(ci): avoid duplicate local release package validation

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -2628,15 +2628,15 @@ jobs:
             fi
             cp "${tgzs[0]}" "$target"
           fi
-          echo "Validating Docker E2E package tarball: $target"
-          validator=(node scripts/check-openclaw-package-tarball.mjs)
+          # Local pack validates final bytes; imports need the trusted harness before identity checks.
           if [[ -n "${EXPECTED_PACKAGE_FILE_NAME// }" ]]; then
+            echo "Validating Docker E2E package tarball: $target"
             validator=(bash -c 'cd .release-harness && pnpm exec node scripts/check-openclaw-package-tarball.mjs "$1"' --)
+            started_at="$(date +%s)"
+            timeout --foreground 5m "${validator[@]}" "$GITHUB_WORKSPACE/$target"
+            finished_at="$(date +%s)"
+            echo "Docker E2E package tarball validation finished in $((finished_at - started_at))s."
           fi
-          started_at="$(date +%s)"
-          timeout --foreground 5m "${validator[@]}" "$GITHUB_WORKSPACE/$target"
-          finished_at="$(date +%s)"
-          echo "Docker E2E package tarball validation finished in $((finished_at - started_at))s."
           digest="$(sha256sum "$target" | awk '{print $1}')"
           version="$(tar -xOf "$target" package/package.json | jq -r '.version')"
           name="$(tar -xOf "$target" package/package.json | jq -r '.name')"

--- a/test/scripts/package-source-preflight.test.ts
+++ b/test/scripts/package-source-preflight.test.ts
@@ -196,9 +196,6 @@ if [[ "$1" == "scripts/package-openclaw-for-docker.mjs" ]]; then
   rm -rf "$fixture"
   exit 0
 fi
-if [[ "$1" == "scripts/check-openclaw-package-tarball.mjs" ]]; then
-  exit 0
-fi
 exit 64
 `,
     { mode: 0o755 },
@@ -653,7 +650,6 @@ describe("package source preflight", () => {
     expect(result.validationResult.status, result.validationResult.stderr).toBe(0);
     expect(result.calls).toEqual([
       expect.stringContaining("scripts/package-openclaw-for-docker.mjs"),
-      expect.stringContaining("scripts/check-openclaw-package-tarball.mjs"),
     ]);
     expect(result.output).toMatchObject({
       file_name: "openclaw-current.tgz",

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import {
   chmodSync,
   existsSync,
@@ -307,6 +308,143 @@ function executeParentFilterValidation(
 }
 
 describe("release validation no-push transport", () => {
+  it.each([
+    { name: "local validated package", imported: false, status: 0, calls: 0 },
+    { name: "imported package", imported: true, status: 0, calls: 1 },
+    { name: "imported validator failure", imported: true, checkExit: 7, status: 7, calls: 1 },
+    {
+      name: "local source mismatch",
+      imported: false,
+      wrongSource: true,
+      status: 1,
+      calls: 0,
+      error: "Exact-target package build commit differs from the selected SHA.",
+    },
+    {
+      name: "imported digest mismatch",
+      imported: true,
+      wrongDigest: true,
+      status: 1,
+      calls: 0,
+      error: "Declared package tarball SHA-256 differs from package_sha256.",
+    },
+    {
+      name: "imported version mismatch",
+      imported: true,
+      wrongVersion: true,
+      status: 1,
+      calls: 1,
+      error: "Resolved package identity differs from the declared immutable tuple.",
+    },
+    {
+      name: "local metadata mismatch",
+      imported: false,
+      wrongMetadata: true,
+      status: 1,
+      calls: 0,
+      error: "Exact-target package metadata does not bind the selected SHA and tarball.",
+    },
+  ])("validates package identity without repeating local pack checks: $name", (fixture) => {
+    const validate = step(
+      job(readWorkflow(LIVE_E2E), "prepare_docker_e2e_image"),
+      "Validate OpenClaw Docker E2E package",
+    );
+    const root = tempDirs.make("release package identity-");
+    const artifacts = join(root, ".artifacts/docker-e2e-package");
+    const bin = join(root, "bin");
+    const calls = join(root, "validator-calls");
+    const output = join(root, "github-output");
+    const source = "a".repeat(40);
+    const version = "2026.8.1";
+    for (const directory of [
+      artifacts,
+      bin,
+      "package/dist",
+      "scripts",
+      ".release-harness/scripts",
+    ]) {
+      mkdirSync(resolve(root, directory), { recursive: true });
+    }
+    writeFileSync(
+      join(root, "package/package.json"),
+      JSON.stringify({ name: "openclaw", version }),
+    );
+    writeFileSync(
+      join(root, "package/dist/build-info.json"),
+      JSON.stringify({ commit: fixture.wrongSource ? "b".repeat(40) : source }),
+    );
+    const fileName = fixture.imported ? "provided package.tgz" : "openclaw-current.tgz";
+    const tarball = join(artifacts, fileName);
+    const pack = spawnSync("tar", ["-czf", tarball, "-C", root, "package"], { encoding: "utf8" });
+    expect(pack.status, pack.stderr).toBe(0);
+    const digest = createHash("sha256").update(readFileSync(tarball)).digest("hex");
+    if (fixture.wrongMetadata) {
+      writeFileSync(
+        join(artifacts, "package-candidate.json"),
+        JSON.stringify({
+          name: "openclaw",
+          packageSourceSha: source,
+          sha256: "b".repeat(64),
+          version,
+        }),
+      );
+    }
+    writeFileSync(output, "");
+    writeFileSync(calls, "");
+    // Instrument only the validator/package-manager boundary; identity checks use real tar, jq and hashes.
+    writeFileSync(
+      join(root, "scripts/check-openclaw-package-tarball.mjs"),
+      'throw new Error("local pack already validated this package");\n',
+    );
+    writeFileSync(
+      join(root, ".release-harness/scripts/check-openclaw-package-tarball.mjs"),
+      'import fs from "node:fs"; fs.appendFileSync(process.env.VALIDATOR_CALLS, JSON.stringify(process.argv.slice(2)) + "\\n"); process.exit(Number(process.env.CHECK_EXIT));\n',
+    );
+    writeFileSync(
+      join(bin, "pnpm"),
+      '#!/usr/bin/env bash\n[[ "$1" == exec ]] || exit 98\nshift\nexec "$@"\n',
+    );
+    chmodSync(join(bin, "pnpm"), 0o755);
+    const result = spawnSync("bash", ["-euo", "pipefail", "-c", validate.run ?? ""], {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        PATH: `${bin}:${process.env.PATH ?? ""}`,
+        CHECK_EXIT: String(fixture.checkExit ?? 0),
+        EXPECTED_PACKAGE_FILE_NAME: fixture.imported ? fileName : "",
+        EXPECTED_PACKAGE_SHA256: fixture.imported
+          ? fixture.wrongDigest
+            ? "b".repeat(64)
+            : digest
+          : "",
+        EXPECTED_PACKAGE_SOURCE_SHA: fixture.imported ? source : "",
+        EXPECTED_PACKAGE_VERSION: fixture.imported
+          ? fixture.wrongVersion
+            ? "2026.7.1"
+            : version
+          : "",
+        GITHUB_OUTPUT: output,
+        GITHUB_STEP_SUMMARY: join(root, "summary"),
+        GITHUB_WORKSPACE: root,
+        SELECTED_SHA: source,
+        SHARED_IMAGE_POLICY: "no-push-artifact",
+        VALIDATOR_CALLS: calls,
+      },
+    });
+    expect(result.status, result.stderr).toBe(fixture.status);
+    if (fixture.error) {
+      expect(result.stderr).toContain(fixture.error);
+    }
+    expect(readFileSync(calls, "utf8")).toBe(
+      fixture.calls ? `${JSON.stringify([join(artifacts, "openclaw-current.tgz")])}\n` : "",
+    );
+    expect(readFileSync(output, "utf8")).toBe(
+      fixture.status === 0
+        ? `sha256=${digest}\nversion=${version}\nfile_name=openclaw-current.tgz\nsource_sha=${source}\ntag=pkg-${digest.slice(0, 32)}\n`
+        : "",
+    );
+  });
+
   it("routes release retries through explicit concrete groups and resource gates", () => {
     const full = readWorkflow(FULL_RELEASE);
     const release = readWorkflow(RELEASE_CHECKS);


### PR DESCRIPTION
## Problem

The release candidate producer validates a locally built tarball twice. The packaging helper already awaits the selected-source checker with the stronger bundled-workspace dependency requirement; the workflow then repeats the structural check on unchanged bytes. That second pass took 21.804 seconds in the retained full-release producer.

## Change

Keep the workflow's trusted-harness validation for imported packages. Locally produced packages rely on their mandatory packaging-owner validation. All common filename, digest, version, build-commit, candidate metadata, and output bindings remain unchanged. No cache, timeout, runner, artifact, publication, or coverage policy changes. Runtime is unchanged; workflow lines are net zero, with 138 test lines added and four obsolete fixture lines removed.

## Validation

- Seven executable cases run the actual YAML Bash boundary with real tar/jq/SHA256 operations: local/imported routing, imported validator failure, and immutable identity mismatches. Three local cases failed before the change; imported controls passed.
- 188 tests passed across source preflight, workflow, matrix planning, package validation, and Control UI tarball lifecycle suites.
- Canonical workflow checks and all 14 actual changed-path checks passed using an independent install matching the frozen lockfile and workspace declarations. An earlier check using the incomplete shared install failed on unrelated missing declarations; no shared dependencies were changed.
- Independent Codex review found no actionable P0–P2 findings.

The expected saving is one roughly 22-second validation pass per local producer, not a measured reduction in total release time. Compilation remains the larger follow-up.

Baseline producer: https://github.com/openclaw/openclaw/actions/runs/33442207246/job/99653075504

The first CI run caught a sibling fixture still expecting the duplicate validator call. That exact failure reproduced locally; the obsolete expected call and stub handler were removed without changing workflow behavior. Final exact-head [CI run 33447621821](https://github.com/openclaw/openclaw/actions/runs/33447621821) passed on `64cba018d9bf53d97e646e0e3576ff52ce66f439`, including required gate 99671612359. The final three-file change has a clean independent Codex review.
