### PR TITLE
refactor(infra): share filesystem case probes

### DIFF
--- a/src/infra/exec-safe-bin-trust.ts
+++ b/src/infra/exec-safe-bin-trust.ts
@@ -6,6 +6,7 @@ import {
   sortUniqueStrings,
   uniqueStrings,
 } from "@openclaw/normalization-core/string-normalization";
+import { sameFsObject, swapAsciiCase } from "./path-case.js";
 
 // Keep defaults to OS-managed immutable bins only.
 // User/package-manager bins must be opted in via tools.exec.safeBinTrustedDirs.
@@ -28,17 +29,6 @@ export type WritableTrustedSafeBinDir = {
 };
 
 let trustedSafeBinCache: TrustedSafeBinCache | null = null;
-
-function swapAsciiCase(value: string): string {
-  return value.replace(/[A-Za-z]/g, (char) => {
-    const lower = char.toLowerCase();
-    return char === lower ? char.toUpperCase() : lower;
-  });
-}
-
-function sameFsObject(a: fs.Stats, b: fs.Stats): boolean {
-  return a.dev === b.dev && a.ino === b.ino;
-}
 
 function pathCaseInsensitive(value: string): boolean {
   let candidate = value;

--- a/src/infra/path-case.test.ts
+++ b/src/infra/path-case.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { sameFsObject } from "./path-case.js";
+
+type FsObjectIdentity = Parameters<typeof sameFsObject>[0];
+
+function identity(dev: number, ino: number): FsObjectIdentity {
+  return { dev, ino };
+}
+
+describe("sameFsObject", () => {
+  it("treats zero identity fields as exact values rather than wildcards", () => {
+    expect(sameFsObject(identity(0, 11), identity(8, 11))).toBe(false);
+    expect(sameFsObject(identity(7, 0), identity(7, 12))).toBe(false);
+  });
+});

--- a/src/infra/path-case.ts
+++ b/src/infra/path-case.ts
@@ -3,14 +3,18 @@ import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 
-function swapAsciiCase(value: string): string {
+export function swapAsciiCase(value: string): string {
   return value.replace(/[A-Za-z]/g, (char) => {
     const lower = char.toLowerCase();
     return char === lower ? char.toUpperCase() : lower;
   });
 }
 
-function sameFsObject(a: fs.Stats, b: fs.Stats): boolean {
+// Case probes compare dev and ino exactly; zero values are never wildcards.
+export function sameFsObject(
+  a: Pick<fs.Stats, "dev" | "ino">,
+  b: Pick<fs.Stats, "dev" | "ino">,
+): boolean {
   return a.dev === b.dev && a.ino === b.ino;
 }
 


### PR DESCRIPTION
Related: #105194

## What Problem This Solves

Maintainer-requested cleanup of duplicated filesystem case-probe mechanics. The general path-case owner and safe-bin trust path had independently copied ASCII case swapping and strict filesystem-object comparison, allowing security-sensitive behavior to drift.

## Why This Change Was Made

`src/infra/path-case.ts` now owns the shared low-level primitives. Safe-bin trust reuses them while retaining its separate ancestor-walking, fail-closed policy; it does not switch to the general `isPathCaseInsensitive` policy or the relaxed Windows zero-field behavior of `sameFileIdentity`.

Strict identity remains exact: zero-valued `dev` or `ino` fields are values, never wildcards. The duplicate implementation in `src/infra/exec-safe-bin-trust.ts` is removed.

## User Impact

No user-visible behavior change. This prevents future drift between path-case detection and executable trust comparison.

Production LOC: +7/-13 (net -6) | Tests: +15/-0

## Evidence

- Focused Vitest: 17/17 passing across `path-case`, safe-bin trust, agent-dir identity, agent-dir config, and session-store config.
- Mutation: relaxing zero-valued `dev`/`ino` to wildcards made the new contract test fail; restoring exact comparison passed.
- Mutation on case-insensitive APFS: replacing ASCII case swapping with an identity function made the safe-bin case-folding test fail; restoring it passed.
- macOS platform matrix: the focused 17-test set passed with `TMPDIR` on temporary APFS and Case-sensitive APFS volumes. The case-insensitive volume independently proved swapped spellings resolved to identical `dev`/`ino`. Both task-owned images were detached and removed.
- Linux: full `pnpm check:changed` passed on Blacksmith Testbox. The local sparse checkout reached the dead-export scan but lacked tracked `ui/config` inputs; the full remote checkout completed that scan and every remaining gate.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- Structural proof: one production definition each for `swapAsciiCase` and `sameFsObject`.
- `git diff --check`: clean.
- Pinned Sol autoreview: scoped clean, no accepted/actionable findings, 0.99 correctness.
- Overlap: exhaustive audit covered all 2,251 open PRs; a live delta refresh checked every PR updated after that snapshot and found no target-file or semantic collision.
- Codex contract gate: personally inspected `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`; no protocol or runtime coupling.

Callers and siblings checked: `normalizeTrustComparisonPath`, `getTrustedSafeBinDirs`, `isTrustedSafeBinPath`, `tryResolvePathCaseInsensitive`, `isPathCaseInsensitive`, agent-directory identity, and session-store path identity.

No docs, changelog, config, protocol, storage, SDK, or dependency changes.
