### PR TITLE
docs: clarify mistaken 2026.9.1 beta publication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,8 @@ Docs: https://docs.openclaw.ai
 
 ## 2026.8.1
 
+> **Release correction:** The package published as `2026.9.1-beta.1` was incorrectly versioned and is actually `2026.8.1-beta.4`. It should not be interpreted as newer than stable `2026.8.1`.
+
 ### Highlights
 
 - **Find past conversations:** search visible conversation text by exact words or phrases and reopen the surrounding messages from a matching result. (#105057, #105635, #105585) Thanks @hercial61.

--- a/docs/releases/2026.8.1.md
+++ b/docs/releases/2026.8.1.md
@@ -16,6 +16,12 @@ keywords:
 
 For the story behind this release, read [OpenClaw 2.0, Accidentally](https://openclaw.ai/blog/openclaw-2-accidentally).
 
+<Warning>
+**Mistaken beta publication**
+
+The package published as `2026.9.1-beta.1` was incorrectly versioned and is actually `2026.8.1-beta.4`. It should not be interpreted as newer than stable `2026.8.1`; stable users should install or update to `2026.8.1`.
+</Warning>
+
 This update touches every part of OpenClaw, including installation, messaging, memory, skills, models, automations, the browser and native apps, plugins, security, and many smaller fixes.
 
 The sections below describe the user-facing result, with the complete PR and commit record available inside each subsection when someone wants to dig into it.


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where users and coding agents could interpret the mistakenly published `2026.9.1-beta.1` package as newer than stable `2026.8.1`, leading them to treat the stable update as a downgrade.

## Why This Change Was Made

Adds the same explicit historical correction to the detailed `2026.8.1` release notes and the current changelog. The immutable Git tag and npm metadata are intentionally unchanged by this PR.

## User Impact

Users reading either source-controlled release record can see that `2026.9.1-beta.1` is actually `2026.8.1-beta.4` and that stable users should use `2026.8.1`.

## Evidence

- Confirmed the incorrect version wording in the live `v2026.8.1` GitHub release description.
- Confirmed npm currently resolves the `beta` dist-tag to `2026.9.1-beta.1`.
- `git diff --check`
- Docs/changelog-only change; no runtime tests required.

AI-assisted.
