### PR TITLE
fix(release): recognize frozen subagent live-test opt-in

### DIFF
--- a/scripts/test-live-shard.mts
+++ b/scripts/test-live-shard.mts
@@ -30,6 +30,8 @@ const OPTIONAL_LIVE_SHARD_FILE_ENVS = new Map([
   ["src/agents/embedded-agent-runner.cache.live.test.ts", ["OPENCLAW_LIVE_CACHE_TEST"]],
   ["src/agents/live-cache-regression.live.test.ts", ["OPENCLAW_LIVE_CACHE_TEST"]],
   ["src/agents/provider-headers.live.test.ts", ["OPENCLAW_LIVE_CACHE_TEST"]],
+  // Frozen release candidates before the announce-family move retain this path.
+  ["src/agents/subagent-announce.live.test.ts", ["OPENCLAW_LIVE_SUBAGENT_E2E"]],
   [
     "src/agents/sessions/agent-session.openai-compaction.live.test.ts",
     ["OPENCLAW_LIVE_OPENAI_COMPACTION"],

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -491,6 +491,11 @@ describe("scripts/test-live-shard", () => {
 
   it.each([
     ["src/skills/workshop/experience-review.live.test.ts", "OPENCLAW_LIVE_SKILL_EXPERIENCE_REVIEW"],
+    ["src/agents/subagent-announce.live.test.ts", "OPENCLAW_LIVE_SUBAGENT_E2E"],
+    [
+      "src/agents/subagents/announce/subagent-announce.live.test.ts",
+      "OPENCLAW_LIVE_SUBAGENT_E2E",
+    ],
     [
       "src/agents/sessions/agent-session.openai-compaction.live.test.ts",
       "OPENCLAW_LIVE_OPENAI_COMPACTION",

--- a/test/scripts/test-live-shard.test.ts
+++ b/test/scripts/test-live-shard.test.ts
@@ -492,10 +492,7 @@ describe("scripts/test-live-shard", () => {
   it.each([
     ["src/skills/workshop/experience-review.live.test.ts", "OPENCLAW_LIVE_SKILL_EXPERIENCE_REVIEW"],
     ["src/agents/subagent-announce.live.test.ts", "OPENCLAW_LIVE_SUBAGENT_E2E"],
-    [
-      "src/agents/subagents/announce/subagent-announce.live.test.ts",
-      "OPENCLAW_LIVE_SUBAGENT_E2E",
-    ],
+    ["src/agents/subagents/announce/subagent-announce.live.test.ts", "OPENCLAW_LIVE_SUBAGENT_E2E"],
     [
       "src/agents/sessions/agent-session.openai-compaction.live.test.ts",
       "OPENCLAW_LIVE_OPENAI_COMPACTION",


### PR DESCRIPTION
## What problem this solves

Extended-stable validation can select the frozen legacy subagent announce live test at `src/agents/subagent-announce.live.test.ts`. The harness only recognized the current post-move path, so it rejected the intentionally disabled `OPENCLAW_LIVE_SUBAGENT_E2E` test as having no passing assertions.

## Change

Recognize both legacy and current paths as the same explicit `OPENCLAW_LIVE_SUBAGENT_E2E` opt-in, with focused coverage for each location. Per-file proof remains required when the opt-in is enabled.

## Impact

Release-validation tooling only; no runtime product change and no reduction in enabled live-test coverage.

## Evidence

- Failing validation job: https://github.com/openclaw/openclaw/actions/runs/33446699978/job/99667587097
- `node scripts/run-vitest.mjs test/scripts/test-live-shard.test.ts` — 32 passed
- `./node_modules/.bin/oxlint --tsconfig config/tsconfig/oxlint.scripts.json scripts/test-live-shard.mts` — passed
- `git diff --check` — passed

The repository `pnpm` wrapper itself is malformed in this checkout before executing the requested commands; its unrelated plugin-SDK declaration preflight also fails on current `main`. The direct focused checks above completed successfully.
