### PR TITLE
fix(release): use a frozen installer update baseline

### DIFF
--- a/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
+++ b/.github/workflows/openclaw-cross-os-release-checks-reusable.yml
@@ -688,7 +688,7 @@ jobs:
                 "$INPUT_TARGET_CONTEXT_REF" == "refs/heads/extended-stable/"* ]]; then
             PUBLISHED_VERSIONS="$RUNNER_TEMP/openclaw-published-versions.json"
             npm view openclaw versions --json > "$PUBLISHED_VERSIONS"
-            BASELINE_SPEC="$(pnpm --dir workflow exec node --import tsx scripts/lib/release-upgrade-baseline.mts \
+            BASELINE_SPEC="$(node workflow/scripts/lib/release-upgrade-baseline.mjs \
               --candidate-version "$(jq -er '.candidateVersion' "$CANDIDATE_JSON")" \
               --target-context-ref "$INPUT_TARGET_CONTEXT_REF" \
               --previous-version "$INPUT_PREVIOUS_VERSION" \

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -1213,7 +1213,7 @@ jobs:
           echo "json=" >> "$GITHUB_OUTPUT"
 
   install_smoke_release_checks:
-    needs: [resolve_target]
+    needs: [resolve_target, resolve_installer_smoke_baseline]
     if: needs.resolve_target.outputs.install_smoke_scheduled == 'true'
     permissions:
       actions: read
@@ -1224,6 +1224,61 @@ jobs:
       allow_unreleased_changelog: ${{ needs.resolve_target.outputs.allow_unreleased_changelog == 'true' }}
       ref: ${{ needs.resolve_target.outputs.revision }}
       run_bun_global_install_smoke: true
+      update_baseline_version: ${{ needs.resolve_installer_smoke_baseline.outputs.value }}
+
+  resolve_installer_smoke_baseline:
+    needs: [resolve_target]
+    if: needs.resolve_target.outputs.install_smoke_scheduled == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    outputs:
+      value: ${{ steps.baseline.outputs.value }}
+    steps:
+      - name: Checkout trusted workflow ref
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.sha }}
+          path: workflow
+          fetch-depth: 1
+
+      - name: Set up Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install trusted workflow validation dependencies
+        working-directory: workflow
+        env:
+          CI: "true"
+        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
+
+      - name: Resolve frozen installer baseline
+        id: baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
+          TARGET_SHA: ${{ needs.resolve_target.outputs.revision }}
+        run: |
+          set -euo pipefail
+          baseline=latest
+          if [[ "$TARGET_CONTEXT_REF" == "extended-stable/"* ||
+                "$TARGET_CONTEXT_REF" == "refs/heads/extended-stable/"* ]]; then
+            candidate_version="$(
+              gh api "repos/${GITHUB_REPOSITORY}/contents/package.json?ref=${TARGET_SHA}" --jq .content |
+                base64 --decode |
+                jq -er '.version | select(type == "string" and length > 0)'
+            )"
+            published_versions="$RUNNER_TEMP/openclaw-published-versions.json"
+            npm view openclaw versions --json > "$published_versions"
+            baseline="$(pnpm --dir workflow exec node --import tsx scripts/lib/release-upgrade-baseline.mts \
+              --candidate-version "$candidate_version" \
+              --target-context-ref "$TARGET_CONTEXT_REF" \
+              --versions-json "$published_versions")"
+          fi
+          echo "value=${baseline}" >> "$GITHUB_OUTPUT"
 
   cross_os_release_checks:
     needs: [resolve_target, prepare_release_package]

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -834,6 +834,7 @@ jobs:
           (startsWith(inputs.target_context_ref, 'extended-stable/') ||
           startsWith(inputs.target_context_ref, 'refs/heads/extended-stable/'))
         env:
+          GH_TOKEN: ${{ github.token }}
           TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
           TARGET_SHA: ${{ steps.ref.outputs.sha }}
         run: |

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -2776,6 +2776,7 @@ jobs:
     needs:
       - resolve_target
       - prepare_release_package
+      - resolve_installer_smoke_baseline
       - install_smoke_release_checks
       - cross_os_release_checks
       - live_repo_e2e_release_checks
@@ -2900,6 +2901,8 @@ jobs:
           VALIDATE_ADVISORY_STATUSES_OUTCOME: ${{ steps.validate_advisory_statuses.outcome }}
           RESOLVE_TARGET_RESULT: ${{ needs.resolve_target.result }}
           PREPARE_RELEASE_PACKAGE_RESULT: ${{ needs.prepare_release_package.result }}
+          RESOLVE_INSTALLER_SMOKE_BASELINE_RESULT: ${{ needs.resolve_installer_smoke_baseline.result }}
+          INSTALL_SMOKE_SCHEDULED: ${{ needs.resolve_target.outputs.install_smoke_scheduled }}
           INSTALL_SMOKE_RELEASE_CHECKS_RESULT: ${{ needs.install_smoke_release_checks.result }}
           CROSS_OS_RELEASE_CHECKS_RESULT: ${{ needs.cross_os_release_checks.result }}
           LIVE_REPO_E2E_RELEASE_CHECKS_RESULT: ${{ needs.live_repo_e2e_release_checks.result }}
@@ -2928,6 +2931,11 @@ jobs:
           failed=0
           release_check_items=("resolve_target=${RESOLVE_TARGET_RESULT}")
           if [[ "$RELEASE_PHASE" != "candidate" ]]; then
+            if [[ "$INSTALL_SMOKE_SCHEDULED" == "true" ]]; then
+              release_check_items+=(
+                "resolve_installer_smoke_baseline=${RESOLVE_INSTALLER_SMOKE_BASELINE_RESULT}"
+              )
+            fi
             release_check_items+=(
               "install_smoke_release_checks=${INSTALL_SMOKE_RELEASE_CHECKS_RESULT}"
               "live_repo_e2e_release_checks=${LIVE_REPO_E2E_RELEASE_CHECKS_RESULT}"
@@ -3047,6 +3055,11 @@ jobs:
               result="$(release_check_result "$name" "$raw_result")"
             else
               result="$raw_result"
+            fi
+            if [[ "$name" == "resolve_installer_smoke_baseline" && "$result" != "success" ]]; then
+              echo "::error::${name} ended with ${result} while installer smoke was scheduled"
+              failed=1
+              continue
             fi
             if [[ "$name" == "qa_live_telegram_release_checks" ]]; then
               # Only an identified child execution is advisory; dispatch provenance remains a gate.

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -808,25 +808,6 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       # A frozen extended-stable target must not downgrade from npm latest.
-      - name: Set up Node.js for frozen installer baseline
-        if: >-
-          steps.inputs.outputs.install_smoke_scheduled == 'true' &&
-          (startsWith(inputs.target_context_ref, 'extended-stable/') ||
-          startsWith(inputs.target_context_ref, 'refs/heads/extended-stable/'))
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Install trusted workflow validation dependencies
-        if: >-
-          steps.inputs.outputs.install_smoke_scheduled == 'true' &&
-          (startsWith(inputs.target_context_ref, 'extended-stable/') ||
-          startsWith(inputs.target_context_ref, 'refs/heads/extended-stable/'))
-        working-directory: workflow
-        env:
-          CI: "true"
-        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
-
       - name: Resolve frozen installer update baseline
         id: frozen_installer_smoke_baseline
         if: >-
@@ -844,7 +825,7 @@ jobs:
               base64 --decode |
               jq -er '.version | select(type == "string" and length > 0)'
           )"
-          baseline="$(pnpm --dir workflow exec node --import tsx scripts/lib/release-upgrade-baseline.mts \
+          baseline="$(node workflow/scripts/lib/release-upgrade-baseline.mjs \
             --candidate-version "$candidate_version" \
             --target-context-ref "$TARGET_CONTEXT_REF")"
           echo "value=${baseline#openclaw@}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -169,6 +169,7 @@ jobs:
       package_required: ${{ steps.inputs.outputs.package_required }}
       docker_required: ${{ steps.inputs.outputs.docker_required }}
       install_smoke_scheduled: ${{ steps.inputs.outputs.install_smoke_scheduled }}
+      installer_smoke_update_baseline: ${{ steps.frozen_installer_smoke_baseline.outputs.value }}
       fail_fast: ${{ steps.inputs.outputs.fail_fast }}
       run_maturity_scorecard: ${{ steps.inputs.outputs.run_maturity_scorecard }}
       allow_unreleased_changelog: ${{ steps.inputs.outputs.allow_unreleased_changelog }}
@@ -806,6 +807,47 @@ jobs:
             printf 'qa_parity_scheduled=%s\n' "$qa_parity_scheduled"
           } >> "$GITHUB_OUTPUT"
 
+      # A frozen extended-stable target must not downgrade from npm latest.
+      - name: Set up Node.js for frozen installer baseline
+        if: >-
+          steps.inputs.outputs.install_smoke_scheduled == 'true' &&
+          (startsWith(inputs.target_context_ref, 'extended-stable/') ||
+          startsWith(inputs.target_context_ref, 'refs/heads/extended-stable/'))
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install trusted workflow validation dependencies
+        if: >-
+          steps.inputs.outputs.install_smoke_scheduled == 'true' &&
+          (startsWith(inputs.target_context_ref, 'extended-stable/') ||
+          startsWith(inputs.target_context_ref, 'refs/heads/extended-stable/'))
+        working-directory: workflow
+        env:
+          CI: "true"
+        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
+
+      - name: Resolve frozen installer update baseline
+        id: frozen_installer_smoke_baseline
+        if: >-
+          steps.inputs.outputs.install_smoke_scheduled == 'true' &&
+          (startsWith(inputs.target_context_ref, 'extended-stable/') ||
+          startsWith(inputs.target_context_ref, 'refs/heads/extended-stable/'))
+        env:
+          TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
+          TARGET_SHA: ${{ steps.ref.outputs.sha }}
+        run: |
+          set -euo pipefail
+          candidate_version="$(
+            gh api "repos/${GITHUB_REPOSITORY}/contents/package.json?ref=${TARGET_SHA}" --jq .content |
+              base64 --decode |
+              jq -er '.version | select(type == "string" and length > 0)'
+          )"
+          baseline="$(pnpm --dir workflow exec node --import tsx scripts/lib/release-upgrade-baseline.mts \
+            --candidate-version "$candidate_version" \
+            --target-context-ref "$TARGET_CONTEXT_REF")"
+          echo "value=${baseline}" >> "$GITHUB_OUTPUT"
+
       - name: Summarize validated ref
         env:
           RELEASE_REF: ${{ inputs.ref }}
@@ -1213,7 +1255,7 @@ jobs:
           echo "json=" >> "$GITHUB_OUTPUT"
 
   install_smoke_release_checks:
-    needs: [resolve_target, resolve_installer_smoke_baseline]
+    needs: [resolve_target]
     if: needs.resolve_target.outputs.install_smoke_scheduled == 'true'
     permissions:
       actions: read
@@ -1224,61 +1266,7 @@ jobs:
       allow_unreleased_changelog: ${{ needs.resolve_target.outputs.allow_unreleased_changelog == 'true' }}
       ref: ${{ needs.resolve_target.outputs.revision }}
       run_bun_global_install_smoke: true
-      update_baseline_version: ${{ needs.resolve_installer_smoke_baseline.outputs.value }}
-
-  resolve_installer_smoke_baseline:
-    needs: [resolve_target]
-    if: needs.resolve_target.outputs.install_smoke_scheduled == 'true'
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    permissions:
-      contents: read
-    outputs:
-      value: ${{ steps.baseline.outputs.value }}
-    steps:
-      - name: Checkout trusted workflow ref
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-          ref: ${{ github.sha }}
-          path: workflow
-          fetch-depth: 1
-
-      - name: Set up Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Install trusted workflow validation dependencies
-        working-directory: workflow
-        env:
-          CI: "true"
-        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
-
-      - name: Resolve frozen installer baseline
-        id: baseline
-        env:
-          GH_TOKEN: ${{ github.token }}
-          TARGET_CONTEXT_REF: ${{ inputs.target_context_ref }}
-          TARGET_SHA: ${{ needs.resolve_target.outputs.revision }}
-        run: |
-          set -euo pipefail
-          baseline=latest
-          if [[ "$TARGET_CONTEXT_REF" == "extended-stable/"* ||
-                "$TARGET_CONTEXT_REF" == "refs/heads/extended-stable/"* ]]; then
-            candidate_version="$(
-              gh api "repos/${GITHUB_REPOSITORY}/contents/package.json?ref=${TARGET_SHA}" --jq .content |
-                base64 --decode |
-                jq -er '.version | select(type == "string" and length > 0)'
-            )"
-            published_versions="$RUNNER_TEMP/openclaw-published-versions.json"
-            npm view openclaw versions --json > "$published_versions"
-            baseline="$(pnpm --dir workflow exec node --import tsx scripts/lib/release-upgrade-baseline.mts \
-              --candidate-version "$candidate_version" \
-              --target-context-ref "$TARGET_CONTEXT_REF" \
-              --versions-json "$published_versions")"
-          fi
-          echo "value=${baseline}" >> "$GITHUB_OUTPUT"
+      update_baseline_version: ${{ needs.resolve_target.outputs.installer_smoke_update_baseline || 'latest' }}
 
   cross_os_release_checks:
     needs: [resolve_target, prepare_release_package]
@@ -2776,7 +2764,6 @@ jobs:
     needs:
       - resolve_target
       - prepare_release_package
-      - resolve_installer_smoke_baseline
       - install_smoke_release_checks
       - cross_os_release_checks
       - live_repo_e2e_release_checks
@@ -2901,8 +2888,6 @@ jobs:
           VALIDATE_ADVISORY_STATUSES_OUTCOME: ${{ steps.validate_advisory_statuses.outcome }}
           RESOLVE_TARGET_RESULT: ${{ needs.resolve_target.result }}
           PREPARE_RELEASE_PACKAGE_RESULT: ${{ needs.prepare_release_package.result }}
-          RESOLVE_INSTALLER_SMOKE_BASELINE_RESULT: ${{ needs.resolve_installer_smoke_baseline.result }}
-          INSTALL_SMOKE_SCHEDULED: ${{ needs.resolve_target.outputs.install_smoke_scheduled }}
           INSTALL_SMOKE_RELEASE_CHECKS_RESULT: ${{ needs.install_smoke_release_checks.result }}
           CROSS_OS_RELEASE_CHECKS_RESULT: ${{ needs.cross_os_release_checks.result }}
           LIVE_REPO_E2E_RELEASE_CHECKS_RESULT: ${{ needs.live_repo_e2e_release_checks.result }}
@@ -2931,11 +2916,6 @@ jobs:
           failed=0
           release_check_items=("resolve_target=${RESOLVE_TARGET_RESULT}")
           if [[ "$RELEASE_PHASE" != "candidate" ]]; then
-            if [[ "$INSTALL_SMOKE_SCHEDULED" == "true" ]]; then
-              release_check_items+=(
-                "resolve_installer_smoke_baseline=${RESOLVE_INSTALLER_SMOKE_BASELINE_RESULT}"
-              )
-            fi
             release_check_items+=(
               "install_smoke_release_checks=${INSTALL_SMOKE_RELEASE_CHECKS_RESULT}"
               "live_repo_e2e_release_checks=${LIVE_REPO_E2E_RELEASE_CHECKS_RESULT}"
@@ -3055,11 +3035,6 @@ jobs:
               result="$(release_check_result "$name" "$raw_result")"
             else
               result="$raw_result"
-            fi
-            if [[ "$name" == "resolve_installer_smoke_baseline" && "$result" != "success" ]]; then
-              echo "::error::${name} ended with ${result} while installer smoke was scheduled"
-              failed=1
-              continue
             fi
             if [[ "$name" == "qa_live_telegram_release_checks" ]]; then
               # Only an identified child execution is advisory; dispatch provenance remains a gate.

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -846,7 +846,7 @@ jobs:
           baseline="$(pnpm --dir workflow exec node --import tsx scripts/lib/release-upgrade-baseline.mts \
             --candidate-version "$candidate_version" \
             --target-context-ref "$TARGET_CONTEXT_REF")"
-          echo "value=${baseline}" >> "$GITHUB_OUTPUT"
+          echo "value=${baseline#openclaw@}" >> "$GITHUB_OUTPUT"
 
       - name: Summarize validated ref
         env:

--- a/scripts/lib/release-upgrade-baseline.mjs
+++ b/scripts/lib/release-upgrade-baseline.mjs
@@ -3,19 +3,10 @@ import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { compareReleaseVersions, parseReleaseVersion } from "./release-version.mjs";
 
-function normalizeStringifiedOptionalString(value) {
-  if (typeof value === "string") {
-    const normalized = value.trim();
-    return normalized || undefined;
-  }
-  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
-    return String(value);
-  }
-  return undefined;
-}
-
 function parseVersion(version) {
-  return parseReleaseVersion(normalizeStringifiedOptionalString(version) ?? "") ?? undefined;
+  return typeof version === "string"
+    ? (parseReleaseVersion(version.trim()) ?? undefined)
+    : undefined;
 }
 
 function compareOpenClawVersions(leftVersion, rightVersion) {
@@ -30,8 +21,9 @@ function normalizePublishedVersions(publishedVersions) {
   return [
     ...new Set(
       publishedVersions
-        .map((version) => normalizeStringifiedOptionalString(version))
-        .filter((version) => version !== undefined),
+        .filter((version) => typeof version === "string")
+        .map((version) => version.trim())
+        .filter(Boolean),
     ),
   ]
     .filter((version) => parseVersion(version)?.channel === "stable")
@@ -39,7 +31,7 @@ function normalizePublishedVersions(publishedVersions) {
 }
 
 function normalizeTargetContextRef(value) {
-  const raw = normalizeStringifiedOptionalString(value) ?? "";
+  const raw = typeof value === "string" ? value.trim() : "";
   return raw.replace(/^refs\/heads\//u, "");
 }
 
@@ -86,14 +78,12 @@ export function resolveFrozenExtendedStableUpgradeBaseline(
     candidate.patch < 33
   ) {
     throw new Error(
-      `candidate ${normalizeStringifiedOptionalString(candidateVersion) ?? ""} is incompatible with frozen extended-stable context ${targetContextRef}`,
+      `candidate ${typeof candidateVersion === "string" ? candidateVersion.trim() : ""} is incompatible with frozen extended-stable context ${targetContextRef}`,
     );
   }
 
   const published = normalizePublishedVersions(publishedVersions);
-  const requestedBaseline = parseVersion(
-    normalizeStringifiedOptionalString(context.previousVersion) ?? "",
-  );
+  const requestedBaseline = parseVersion(context.previousVersion);
   if (context.previousVersion !== undefined && !requestedBaseline) {
     throw new Error("previous_version must be a final published extended-stable predecessor");
   }
@@ -123,7 +113,7 @@ export function resolveFrozenExtendedStableUpgradeBaseline(
 export function resolveDefaultReleaseUpgradeBaseline(candidateVersion, publishedVersions) {
   const candidate = parseVersion(candidateVersion);
   if (!candidate) {
-    const candidateText = normalizeStringifiedOptionalString(candidateVersion) ?? "";
+    const candidateText = typeof candidateVersion === "string" ? candidateVersion.trim() : "";
     throw new Error(`invalid candidate OpenClaw version: ${candidateText}`);
   }
 

--- a/scripts/lib/release-upgrade-baseline.mjs
+++ b/scripts/lib/release-upgrade-baseline.mjs
@@ -1,14 +1,24 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
-import { normalizeStringifiedOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { compareReleaseVersions, parseReleaseVersion } from "./release-version.mjs";
 
-function parseVersion(version: unknown) {
+function normalizeStringifiedOptionalString(value) {
+  if (typeof value === "string") {
+    const normalized = value.trim();
+    return normalized || undefined;
+  }
+  if (typeof value === "number" || typeof value === "boolean" || typeof value === "bigint") {
+    return String(value);
+  }
+  return undefined;
+}
+
+function parseVersion(version) {
   return parseReleaseVersion(normalizeStringifiedOptionalString(version) ?? "") ?? undefined;
 }
 
-function compareOpenClawVersions(leftVersion: string, rightVersion: string) {
+function compareOpenClawVersions(leftVersion, rightVersion) {
   const comparison = compareReleaseVersions(leftVersion, rightVersion);
   if (comparison === null) {
     throw new Error(`cannot compare OpenClaw versions: ${leftVersion} ${rightVersion}`);
@@ -16,32 +26,24 @@ function compareOpenClawVersions(leftVersion: string, rightVersion: string) {
   return comparison;
 }
 
-function normalizePublishedVersions(publishedVersions: readonly unknown[]) {
+function normalizePublishedVersions(publishedVersions) {
   return [
     ...new Set(
       publishedVersions
         .map((version) => normalizeStringifiedOptionalString(version))
-        .filter((version): version is string => version !== undefined),
+        .filter((version) => version !== undefined),
     ),
   ]
     .filter((version) => parseVersion(version)?.channel === "stable")
     .toSorted((left, right) => compareOpenClawVersions(right, left));
 }
 
-type FrozenExtendedStableUpgradeContext = {
-  previousVersion?: unknown;
-  targetContextRef: unknown;
-};
-
-function normalizeTargetContextRef(value: unknown) {
+function normalizeTargetContextRef(value) {
   const raw = normalizeStringifiedOptionalString(value) ?? "";
   return raw.replace(/^refs\/heads\//u, "");
 }
 
-function isEarlierFinalSameExtendedStableLine(params: {
-  baseline: ReturnType<typeof parseVersion>;
-  candidate: NonNullable<ReturnType<typeof parseVersion>>;
-}) {
+function isEarlierFinalSameExtendedStableLine(params) {
   const { baseline, candidate } = params;
   return (
     baseline?.channel === "stable" &&
@@ -58,9 +60,9 @@ function isEarlierFinalSameExtendedStableLine(params: {
  * the same line. A current latest install can have a newer SQLite schema.
  */
 export function resolveFrozenExtendedStableUpgradeBaseline(
-  candidateVersion: unknown,
-  publishedVersions: readonly unknown[],
-  context: FrozenExtendedStableUpgradeContext,
+  candidateVersion,
+  publishedVersions,
+  context,
 ) {
   const targetContextRef = normalizeTargetContextRef(context.targetContextRef);
   if (!targetContextRef.startsWith("extended-stable/")) {
@@ -118,10 +120,7 @@ export function resolveFrozenExtendedStableUpgradeBaseline(
   return `openclaw@${baseline}`;
 }
 
-export function resolveDefaultReleaseUpgradeBaseline(
-  candidateVersion: unknown,
-  publishedVersions: readonly unknown[],
-) {
+export function resolveDefaultReleaseUpgradeBaseline(candidateVersion, publishedVersions) {
   const candidate = parseVersion(candidateVersion);
   if (!candidate) {
     const candidateText = normalizeStringifiedOptionalString(candidateVersion) ?? "";
@@ -144,8 +143,8 @@ export function resolveDefaultReleaseUpgradeBaseline(
   throw new Error(`no published stable OpenClaw baseline is <= candidate ${candidate.version}`);
 }
 
-export function parseArgs(argv: readonly string[]) {
-  const args = new Map<string, string>();
+export function parseArgs(argv) {
+  const args = new Map();
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
     if (arg === undefined) {
@@ -165,10 +164,10 @@ export function parseArgs(argv: readonly string[]) {
   return args;
 }
 
-function readPublishedVersions(args: Map<string, string>): unknown[] {
+function readPublishedVersions(args) {
   const versionsJson = args.get("versions-json");
   if (versionsJson) {
-    const parsed: unknown = JSON.parse(readFileSync(versionsJson, "utf8"));
+    const parsed = JSON.parse(readFileSync(versionsJson, "utf8"));
     if (!Array.isArray(parsed)) {
       throw new Error(`npm versions list must be a JSON array: ${versionsJson}`);
     }
@@ -182,7 +181,7 @@ function readPublishedVersions(args: Map<string, string>): unknown[] {
       stdio: ["ignore", "pipe", "inherit"],
     },
   );
-  const parsed: unknown = JSON.parse(raw);
+  const parsed = JSON.parse(raw);
   if (!Array.isArray(parsed)) {
     throw new Error("npm returned a non-array openclaw versions payload");
   }

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -169,9 +169,9 @@ describe("cross-OS release checks workflow", () => {
       TARGET_CONTEXT_REF: "${{ inputs.target_context_ref }}",
       TARGET_SHA: "${{ needs.resolve_target.outputs.revision }}",
     });
-    expect(baseline.run).toContain('baseline=latest');
+    expect(baseline.run).toContain("baseline=latest");
     expect(baseline.run).toContain('"$TARGET_CONTEXT_REF" == "extended-stable/"*');
-    expect(baseline.run).toContain('contents/package.json?ref=${TARGET_SHA}');
+    expect(baseline.run).toContain("contents/package.json?ref=${TARGET_SHA}");
     expect(baseline.run).toContain("npm view openclaw versions --json");
     expect(baseline.run).toContain("scripts/lib/release-upgrade-baseline.mts");
     expect(baseline.run).toContain('--target-context-ref "$TARGET_CONTEXT_REF"');

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -24,6 +24,7 @@ type WorkflowStep = {
 
 type WorkflowJob = {
   if?: string;
+  needs?: string | string[];
   outputs?: Record<string, unknown>;
   steps?: WorkflowStep[];
   with?: Record<string, unknown>;
@@ -154,6 +155,31 @@ describe("cross-OS release checks workflow", () => {
       'import { resolveNpmJsonEntries } from "./scripts/lib/npm-json-output.mts";',
     );
     expect(baselineMetadata.run).toContain("const entry = resolveNpmJsonEntries(payload).at(-1);");
+  });
+
+  it("uses the frozen extended-stable predecessor for installer update smoke", () => {
+    const release = readWorkflow(RELEASE_CHECKS_PATH);
+    const resolver = job(release, "resolve_installer_smoke_baseline");
+    const baseline = step(resolver, "Resolve frozen installer baseline");
+    const installSmoke = job(release, "install_smoke_release_checks");
+
+    expect(resolver.needs).toEqual(["resolve_target"]);
+    expect(resolver.if).toBe("needs.resolve_target.outputs.install_smoke_scheduled == 'true'");
+    expect(baseline.env).toMatchObject({
+      TARGET_CONTEXT_REF: "${{ inputs.target_context_ref }}",
+      TARGET_SHA: "${{ needs.resolve_target.outputs.revision }}",
+    });
+    expect(baseline.run).toContain('baseline=latest');
+    expect(baseline.run).toContain('"$TARGET_CONTEXT_REF" == "extended-stable/"*');
+    expect(baseline.run).toContain('contents/package.json?ref=${TARGET_SHA}');
+    expect(baseline.run).toContain("npm view openclaw versions --json");
+    expect(baseline.run).toContain("scripts/lib/release-upgrade-baseline.mts");
+    expect(baseline.run).toContain('--target-context-ref "$TARGET_CONTEXT_REF"');
+    expect(baseline.run).toContain('--versions-json "$published_versions"');
+    expect(installSmoke.needs).toEqual(["resolve_target", "resolve_installer_smoke_baseline"]);
+    expect(installSmoke.with?.update_baseline_version).toBe(
+      "${{ needs.resolve_installer_smoke_baseline.outputs.value }}",
+    );
   });
 
   it("installs trusted workflow dependencies for artifact resolution and upgrade metadata", () => {

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -169,6 +169,7 @@ describe("cross-OS release checks workflow", () => {
     expect(baseline.if).toContain("steps.inputs.outputs.install_smoke_scheduled == 'true'");
     expect(baseline.if).toContain("startsWith(inputs.target_context_ref, 'extended-stable/')");
     expect(baseline.env).toMatchObject({
+      GH_TOKEN: "${{ github.token }}",
       TARGET_CONTEXT_REF: "${{ inputs.target_context_ref }}",
       TARGET_SHA: "${{ steps.ref.outputs.sha }}",
     });

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -157,28 +157,27 @@ describe("cross-OS release checks workflow", () => {
     expect(baselineMetadata.run).toContain("const entry = resolveNpmJsonEntries(payload).at(-1);");
   });
 
-  it("uses the frozen extended-stable predecessor for installer update smoke", () => {
+  it("passes a frozen-line predecessor from target resolution to installer update smoke", () => {
     const release = readWorkflow(RELEASE_CHECKS_PATH);
-    const resolver = job(release, "resolve_installer_smoke_baseline");
-    const baseline = step(resolver, "Resolve frozen installer baseline");
+    const target = job(release, "resolve_target");
+    const baseline = step(target, "Resolve frozen installer update baseline");
     const installSmoke = job(release, "install_smoke_release_checks");
 
-    expect(resolver.needs).toEqual(["resolve_target"]);
-    expect(resolver.if).toBe("needs.resolve_target.outputs.install_smoke_scheduled == 'true'");
+    expect(target.outputs?.installer_smoke_update_baseline).toBe(
+      "${{ steps.frozen_installer_smoke_baseline.outputs.value }}",
+    );
+    expect(baseline.if).toContain("steps.inputs.outputs.install_smoke_scheduled == 'true'");
+    expect(baseline.if).toContain("startsWith(inputs.target_context_ref, 'extended-stable/')");
     expect(baseline.env).toMatchObject({
       TARGET_CONTEXT_REF: "${{ inputs.target_context_ref }}",
-      TARGET_SHA: "${{ needs.resolve_target.outputs.revision }}",
+      TARGET_SHA: "${{ steps.ref.outputs.sha }}",
     });
-    expect(baseline.run).toContain("baseline=latest");
-    expect(baseline.run).toContain('"$TARGET_CONTEXT_REF" == "extended-stable/"*');
     expect(baseline.run).toContain("contents/package.json?ref=${TARGET_SHA}");
-    expect(baseline.run).toContain("npm view openclaw versions --json");
     expect(baseline.run).toContain("scripts/lib/release-upgrade-baseline.mts");
     expect(baseline.run).toContain('--target-context-ref "$TARGET_CONTEXT_REF"');
-    expect(baseline.run).toContain('--versions-json "$published_versions"');
-    expect(installSmoke.needs).toEqual(["resolve_target", "resolve_installer_smoke_baseline"]);
+    expect(installSmoke.needs).toEqual(["resolve_target"]);
     expect(installSmoke.with?.update_baseline_version).toBe(
-      "${{ needs.resolve_installer_smoke_baseline.outputs.value }}",
+      "${{ needs.resolve_target.outputs.installer_smoke_update_baseline || 'latest' }}",
     );
   });
 

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -143,7 +143,7 @@ describe("cross-OS release checks workflow", () => {
     });
     expect(baseline.run).toContain('"$INPUT_TARGET_CONTEXT_REF" == "extended-stable/"*');
     expect(baseline.run).toContain("npm view openclaw versions --json");
-    expect(baseline.run).toContain("scripts/lib/release-upgrade-baseline.mts");
+    expect(baseline.run).toContain("scripts/lib/release-upgrade-baseline.mjs");
     expect(baseline.run).toContain('--target-context-ref "$INPUT_TARGET_CONTEXT_REF"');
     expect(baseline.run).toContain('--previous-version "$INPUT_PREVIOUS_VERSION"');
     expect(baseline.run).toContain('BASELINE_VERSION="$(npm view openclaw@latest version)"');
@@ -174,7 +174,7 @@ describe("cross-OS release checks workflow", () => {
       TARGET_SHA: "${{ steps.ref.outputs.sha }}",
     });
     expect(baseline.run).toContain("contents/package.json?ref=${TARGET_SHA}");
-    expect(baseline.run).toContain("scripts/lib/release-upgrade-baseline.mts");
+    expect(baseline.run).toContain("scripts/lib/release-upgrade-baseline.mjs");
     expect(baseline.run).toContain('--target-context-ref "$TARGET_CONTEXT_REF"');
     expect(baseline.run).toContain('echo "value=${baseline#openclaw@}"');
     expect(installSmoke.needs).toEqual(["resolve_target"]);

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -175,9 +175,13 @@ describe("cross-OS release checks workflow", () => {
     expect(baseline.run).toContain("contents/package.json?ref=${TARGET_SHA}");
     expect(baseline.run).toContain("scripts/lib/release-upgrade-baseline.mts");
     expect(baseline.run).toContain('--target-context-ref "$TARGET_CONTEXT_REF"');
+    expect(baseline.run).toContain('echo "value=${baseline#openclaw@}"');
     expect(installSmoke.needs).toEqual(["resolve_target"]);
     expect(installSmoke.with?.update_baseline_version).toBe(
       "${{ needs.resolve_target.outputs.installer_smoke_update_baseline || 'latest' }}",
+    );
+    expect(readFileSync("scripts/docker/install-sh-smoke/run.sh", "utf8")).toContain(
+      '"${PACKAGE_NAME}@${UPDATE_BASELINE_VERSION}"',
     );
   });
 

--- a/test/scripts/openclaw-cross-os-release-workflow.test.ts
+++ b/test/scripts/openclaw-cross-os-release-workflow.test.ts
@@ -173,16 +173,10 @@ describe("cross-OS release checks workflow", () => {
       TARGET_CONTEXT_REF: "${{ inputs.target_context_ref }}",
       TARGET_SHA: "${{ steps.ref.outputs.sha }}",
     });
-    expect(baseline.run).toContain("contents/package.json?ref=${TARGET_SHA}");
-    expect(baseline.run).toContain("scripts/lib/release-upgrade-baseline.mjs");
-    expect(baseline.run).toContain('--target-context-ref "$TARGET_CONTEXT_REF"');
+    expect(baseline.run).toContain("node workflow/scripts/lib/release-upgrade-baseline.mjs");
     expect(baseline.run).toContain('echo "value=${baseline#openclaw@}"');
-    expect(installSmoke.needs).toEqual(["resolve_target"]);
     expect(installSmoke.with?.update_baseline_version).toBe(
       "${{ needs.resolve_target.outputs.installer_smoke_update_baseline || 'latest' }}",
-    );
-    expect(readFileSync("scripts/docker/install-sh-smoke/run.sh", "utf8")).toContain(
-      '"${PACKAGE_NAME}@${UPDATE_BASELINE_VERSION}"',
     );
   });
 

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1676,6 +1676,8 @@ function runReleaseChecksSummary(params: {
   currentAttempt: string;
   currentResult: "cancelled" | "failure" | "skipped" | "success";
   discordResult?: "failure" | "skipped" | "success";
+  installSmokeScheduled?: boolean;
+  installerBaselineResult?: "cancelled" | "failure" | "skipped" | "success";
   phase?: "all" | "candidate" | "independent";
   resolveResult?: "failure" | "success";
   resultOverrides?: Record<string, "cancelled" | "failure" | "skipped" | "success">;
@@ -1706,6 +1708,7 @@ function runReleaseChecksSummary(params: {
       DOCKER_E2E_RELEASE_CHECKS_RESULT: "success",
       GITHUB_RUN_ATTEMPT: params.currentAttempt,
       GITHUB_RUN_ID: runId,
+      INSTALL_SMOKE_SCHEDULED: String(params.installSmokeScheduled ?? true),
       INSTALL_SMOKE_RELEASE_CHECKS_RESULT: "success",
       LIVE_REPO_E2E_RELEASE_CHECKS_RESULT: "success",
       MATURITY_SCORECARD_RELEASE_CHECKS_RESULT: "skipped",
@@ -1728,6 +1731,7 @@ function runReleaseChecksSummary(params: {
       RELEASE_CHECK_TARGET_SHA: targetSha,
       RELEASE_PHASE: params.phase ?? "all",
       RESOLVE_ADVISORY_EVIDENCE_OUTCOME: "success",
+      RESOLVE_INSTALLER_SMOKE_BASELINE_RESULT: params.installerBaselineResult ?? "success",
       RESOLVE_TARGET_RESULT: params.resolveResult ?? "success",
       RUNTIME_TOOL_COVERAGE_RELEASE_CHECKS_RESULT: "skipped",
       VALIDATE_ADVISORY_STATUSES_OUTCOME: "success",
@@ -7955,6 +7959,20 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
       },
       status: 1,
     },
+    ...(["cancelled", "failure", "skipped"] as const).map((installerBaselineResult) => ({
+      emptyStderr: false,
+      expected: [
+        `::error::resolve_installer_smoke_baseline ended with ${installerBaselineResult} while installer smoke was scheduled`,
+      ],
+      name: `rejects a ${installerBaselineResult} installer baseline resolver when installer smoke is scheduled`,
+      params: {
+        currentAttempt: "2",
+        currentResult: "skipped",
+        installerBaselineResult,
+        telegramSelected: false,
+      },
+      status: 1,
+    })),
     {
       emptyStderr: false,
       expected: [
@@ -8005,6 +8023,18 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
       );
     },
   );
+
+  it("does not require the installer baseline resolver when installer smoke is not scheduled", () => {
+    const result = runReleaseChecksSummary({
+      currentAttempt: "2",
+      currentResult: "skipped",
+      installSmokeScheduled: false,
+      installerBaselineResult: "skipped",
+      telegramSelected: false,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+  });
 
   it("validates only jobs owned by the selected release-check phase", () => {
     const independent = runReleaseChecksSummary({
@@ -9193,8 +9223,13 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       "installer_smoke_nonroot",
     ]);
     expect(jobNeeds(releaseSummary)).toContain("install_smoke_release_checks");
+    expect(jobNeeds(releaseSummary)).toContain("resolve_installer_smoke_baseline");
     const releaseInstallPath = [
       timeoutForProfile(releaseChecks.jobs?.resolve_target?.["timeout-minutes"], "stable"),
+      timeoutForProfile(
+        releaseChecks.jobs?.resolve_installer_smoke_baseline?.["timeout-minutes"],
+        "stable",
+      ),
       timeoutForProfile(installSmoke.jobs?.preflight?.["timeout-minutes"], "stable"),
       Math.max(
         timeoutForProfile(
@@ -9210,9 +9245,13 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       timeoutForProfile(installSmoke.jobs?.installer_smoke?.["timeout-minutes"], "stable"),
       timeoutForProfile(releaseChecks.jobs?.summary?.["timeout-minutes"], "stable"),
     ];
-    expect(releaseInstallPath).toEqual([30, 15, 75, 120, 5, 5]);
+    expect(releaseInstallPath).toEqual([30, 15, 15, 75, 120, 5, 5]);
     const releaseInstallNonrootPath = [
       timeoutForProfile(releaseChecks.jobs?.resolve_target?.["timeout-minutes"], "stable"),
+      timeoutForProfile(
+        releaseChecks.jobs?.resolve_installer_smoke_baseline?.["timeout-minutes"],
+        "stable",
+      ),
       timeoutForProfile(installSmoke.jobs?.preflight?.["timeout-minutes"], "stable"),
       Math.max(
         timeoutForProfile(
@@ -9228,7 +9267,7 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       timeoutForProfile(installSmoke.jobs?.installer_smoke?.["timeout-minutes"], "stable"),
       timeoutForProfile(releaseChecks.jobs?.summary?.["timeout-minutes"], "stable"),
     ];
-    expect(releaseInstallNonrootPath).toEqual([30, 15, 75, 60, 5, 5]);
+    expect(releaseInstallNonrootPath).toEqual([30, 15, 15, 75, 60, 5, 5]);
 
     const releaseQaLive = workflowJob(RELEASE_CHECKS_WORKFLOW, "qa_live_release_checks");
     expect(jobNeeds(releaseQaLive)).toEqual(["resolve_target"]);
@@ -9264,8 +9303,8 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       ).toBeGreaterThanOrEqual(60);
     }
     expect(releaseCrossOsPath.reduce((total, timeout) => total + timeout, 0)).toBe(200);
-    expect(releaseInstallPath.reduce((total, timeout) => total + timeout, 0)).toBe(250);
-    expect(releaseInstallNonrootPath.reduce((total, timeout) => total + timeout, 0)).toBe(190);
+    expect(releaseInstallPath.reduce((total, timeout) => total + timeout, 0)).toBe(265);
+    expect(releaseInstallNonrootPath.reduce((total, timeout) => total + timeout, 0)).toBe(205);
     expect(releaseQaLivePath.reduce((total, timeout) => total + timeout, 0)).toBe(165);
 
     expect(

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -7967,7 +7967,7 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
       name: `rejects a ${installerBaselineResult} installer baseline resolver when installer smoke is scheduled`,
       params: {
         currentAttempt: "2",
-        currentResult: "skipped",
+        currentResult: "skipped" as const,
         installerBaselineResult,
         telegramSelected: false,
       },

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -1676,8 +1676,6 @@ function runReleaseChecksSummary(params: {
   currentAttempt: string;
   currentResult: "cancelled" | "failure" | "skipped" | "success";
   discordResult?: "failure" | "skipped" | "success";
-  installSmokeScheduled?: boolean;
-  installerBaselineResult?: "cancelled" | "failure" | "skipped" | "success";
   phase?: "all" | "candidate" | "independent";
   resolveResult?: "failure" | "success";
   resultOverrides?: Record<string, "cancelled" | "failure" | "skipped" | "success">;
@@ -1708,7 +1706,6 @@ function runReleaseChecksSummary(params: {
       DOCKER_E2E_RELEASE_CHECKS_RESULT: "success",
       GITHUB_RUN_ATTEMPT: params.currentAttempt,
       GITHUB_RUN_ID: runId,
-      INSTALL_SMOKE_SCHEDULED: String(params.installSmokeScheduled ?? true),
       INSTALL_SMOKE_RELEASE_CHECKS_RESULT: "success",
       LIVE_REPO_E2E_RELEASE_CHECKS_RESULT: "success",
       MATURITY_SCORECARD_RELEASE_CHECKS_RESULT: "skipped",
@@ -1731,7 +1728,6 @@ function runReleaseChecksSummary(params: {
       RELEASE_CHECK_TARGET_SHA: targetSha,
       RELEASE_PHASE: params.phase ?? "all",
       RESOLVE_ADVISORY_EVIDENCE_OUTCOME: "success",
-      RESOLVE_INSTALLER_SMOKE_BASELINE_RESULT: params.installerBaselineResult ?? "success",
       RESOLVE_TARGET_RESULT: params.resolveResult ?? "success",
       RUNTIME_TOOL_COVERAGE_RELEASE_CHECKS_RESULT: "skipped",
       VALIDATE_ADVISORY_STATUSES_OUTCOME: "success",
@@ -7959,20 +7955,6 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
       },
       status: 1,
     },
-    ...(["cancelled", "failure", "skipped"] as const).map((installerBaselineResult) => ({
-      emptyStderr: false,
-      expected: [
-        `::error::resolve_installer_smoke_baseline ended with ${installerBaselineResult} while installer smoke was scheduled`,
-      ],
-      name: `rejects a ${installerBaselineResult} installer baseline resolver when installer smoke is scheduled`,
-      params: {
-        currentAttempt: "2",
-        currentResult: "skipped" as const,
-        installerBaselineResult,
-        telegramSelected: false,
-      },
-      status: 1,
-    })),
     {
       emptyStderr: false,
       expected: [
@@ -8023,18 +8005,6 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
       );
     },
   );
-
-  it("does not require the installer baseline resolver when installer smoke is not scheduled", () => {
-    const result = runReleaseChecksSummary({
-      currentAttempt: "2",
-      currentResult: "skipped",
-      installSmokeScheduled: false,
-      installerBaselineResult: "skipped",
-      telegramSelected: false,
-    });
-
-    expect(result.status, result.stderr).toBe(0);
-  });
 
   it("validates only jobs owned by the selected release-check phase", () => {
     const independent = runReleaseChecksSummary({
@@ -9187,10 +9157,7 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     expect(releaseCrossOsPath).toEqual([30, 15, 90, 60, 5]);
 
     const releaseInstall = workflowJob(RELEASE_CHECKS_WORKFLOW, "install_smoke_release_checks");
-    expect(jobNeeds(releaseInstall)).toEqual([
-      "resolve_target",
-      "resolve_installer_smoke_baseline",
-    ]);
+    expect(jobNeeds(releaseInstall)).toEqual(["resolve_target"]);
     expect(jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "root_dockerfile_image"))).toEqual(
       ["preflight"],
     );
@@ -9223,13 +9190,8 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       "installer_smoke_nonroot",
     ]);
     expect(jobNeeds(releaseSummary)).toContain("install_smoke_release_checks");
-    expect(jobNeeds(releaseSummary)).toContain("resolve_installer_smoke_baseline");
     const releaseInstallPath = [
       timeoutForProfile(releaseChecks.jobs?.resolve_target?.["timeout-minutes"], "stable"),
-      timeoutForProfile(
-        releaseChecks.jobs?.resolve_installer_smoke_baseline?.["timeout-minutes"],
-        "stable",
-      ),
       timeoutForProfile(installSmoke.jobs?.preflight?.["timeout-minutes"], "stable"),
       Math.max(
         timeoutForProfile(
@@ -9245,13 +9207,9 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       timeoutForProfile(installSmoke.jobs?.installer_smoke?.["timeout-minutes"], "stable"),
       timeoutForProfile(releaseChecks.jobs?.summary?.["timeout-minutes"], "stable"),
     ];
-    expect(releaseInstallPath).toEqual([30, 15, 15, 75, 120, 5, 5]);
+    expect(releaseInstallPath).toEqual([30, 15, 75, 120, 5, 5]);
     const releaseInstallNonrootPath = [
       timeoutForProfile(releaseChecks.jobs?.resolve_target?.["timeout-minutes"], "stable"),
-      timeoutForProfile(
-        releaseChecks.jobs?.resolve_installer_smoke_baseline?.["timeout-minutes"],
-        "stable",
-      ),
       timeoutForProfile(installSmoke.jobs?.preflight?.["timeout-minutes"], "stable"),
       Math.max(
         timeoutForProfile(
@@ -9267,7 +9225,7 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       timeoutForProfile(installSmoke.jobs?.installer_smoke?.["timeout-minutes"], "stable"),
       timeoutForProfile(releaseChecks.jobs?.summary?.["timeout-minutes"], "stable"),
     ];
-    expect(releaseInstallNonrootPath).toEqual([30, 15, 15, 75, 60, 5, 5]);
+    expect(releaseInstallNonrootPath).toEqual([30, 15, 75, 60, 5, 5]);
 
     const releaseQaLive = workflowJob(RELEASE_CHECKS_WORKFLOW, "qa_live_release_checks");
     expect(jobNeeds(releaseQaLive)).toEqual(["resolve_target"]);
@@ -9303,8 +9261,8 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
       ).toBeGreaterThanOrEqual(60);
     }
     expect(releaseCrossOsPath.reduce((total, timeout) => total + timeout, 0)).toBe(200);
-    expect(releaseInstallPath.reduce((total, timeout) => total + timeout, 0)).toBe(265);
-    expect(releaseInstallNonrootPath.reduce((total, timeout) => total + timeout, 0)).toBe(205);
+    expect(releaseInstallPath.reduce((total, timeout) => total + timeout, 0)).toBe(250);
+    expect(releaseInstallNonrootPath.reduce((total, timeout) => total + timeout, 0)).toBe(190);
     expect(releaseQaLivePath.reduce((total, timeout) => total + timeout, 0)).toBe(165);
 
     expect(

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -9157,7 +9157,10 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     expect(releaseCrossOsPath).toEqual([30, 15, 90, 60, 5]);
 
     const releaseInstall = workflowJob(RELEASE_CHECKS_WORKFLOW, "install_smoke_release_checks");
-    expect(jobNeeds(releaseInstall)).toEqual(["resolve_target"]);
+    expect(jobNeeds(releaseInstall)).toEqual([
+      "resolve_target",
+      "resolve_installer_smoke_baseline",
+    ]);
     expect(jobNeeds(workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "root_dockerfile_image"))).toEqual(
       ["preflight"],
     );

--- a/test/scripts/release-upgrade-baseline.test.ts
+++ b/test/scripts/release-upgrade-baseline.test.ts
@@ -3,7 +3,7 @@ import {
   parseArgs,
   resolveDefaultReleaseUpgradeBaseline,
   resolveFrozenExtendedStableUpgradeBaseline,
-} from "../../scripts/lib/release-upgrade-baseline.mts";
+} from "../../scripts/lib/release-upgrade-baseline.mjs";
 
 describe("release upgrade baseline resolver", () => {
   it("rejects short flag values before resolving baselines", () => {


### PR DESCRIPTION
## What Problem This Solves

Frozen extended-stable validation must upgrade from its published same-line predecessor, not from npm `latest`. Updating from a newer release into an older candidate can make the candidate reject a newer SQLite state schema.

## Canonical Fix

`resolve_target` already owns target admission and scheduling. When installer smoke is scheduled for a canonical `extended-stable/*` target, it reads only that target’s `package.json`, uses the trusted workflow checkout’s existing baseline resolver, converts its `openclaw@version` result to the installer’s documented bare-version input, and exposes that as an output. The install-smoke caller consumes the output and otherwise keeps its existing `latest` default.

There is no extra resolver job, summary exception, drain-budget edge, or compatibility path. A resolver/install failure fails `resolve_target`, so the existing generic target-admission gate stops downstream work.

## Impact

No product, package, or release-contract change. For .35, the installer update smoke moves from the unsupported `2026.8.1 → 2026.6.35` downgrade to the supported `2026.6.34 → 2026.6.35` upgrade. All non-extended-stable release contexts still use `latest`.

## Evidence

- Reproduction: [installer update job 99668403596](https://github.com/openclaw/openclaw/actions/runs/33446699978/job/99668403596) installed schema 15 from `2026.8.1`; the .35 candidate supports schema 1.
- Focused workflow and baseline-resolver tests: 287 passing.
- `actionlint`, format check, `git diff --check`, and Codex autoreview pass.
- Final diff: workflow +43/-0; tests +29/-0. The deleted standalone resolver/summary bookkeeping is absent from the final PR diff.
