### PR TITLE
test(live): retry GPT-5.6 nonce mismatches

### DIFF
--- a/src/gateway/gateway-models.profiles.live.test.ts
+++ b/src/gateway/gateway-models.profiles.live.test.ts
@@ -1686,6 +1686,18 @@ function shouldSkipToolNonceProbeMissForLiveModel(modelKey?: string): boolean {
   return GATEWAY_LIVE_TOOL_NONCE_MISS_SKIP_MODEL_KEYS.has(normalizedKey);
 }
 
+function shouldRetryToolNonceProbeMissForLiveModel(modelKey?: string): boolean {
+  if (shouldSkipToolNonceProbeMissForLiveModel(modelKey)) {
+    return true;
+  }
+  if (!modelKey) {
+    return false;
+  }
+  const [provider, ...rest] = modelKey.split("/");
+  const modelId = rest.join("/");
+  return provider === "openai" && (modelId === "gpt-5.6" || modelId.startsWith("gpt-5.6-"));
+}
+
 describe("shouldSkipToolNonceProbeMissForLiveModel", () => {
   it.each([
     { modelKey: "anthropic/claude-opus-4-6", expected: true },
@@ -1702,6 +1714,18 @@ describe("shouldSkipToolNonceProbeMissForLiveModel", () => {
     { modelKey: "openai/gpt-5.4", expected: false },
   ])("returns $expected for $modelKey", ({ modelKey, expected }) => {
     expect(shouldSkipToolNonceProbeMissForLiveModel(modelKey)).toBe(expected);
+  });
+});
+
+describe("shouldRetryToolNonceProbeMissForLiveModel", () => {
+  it.each([
+    { modelKey: "openai/gpt-5.6", expected: true },
+    { modelKey: "openai/gpt-5.6-luna", expected: true },
+    { modelKey: "openai/gpt-5.6-sol", expected: true },
+    { modelKey: "openai/gpt-5.5", expected: false },
+    { modelKey: "openai/gpt-5.60", expected: false },
+  ])("returns $expected for $modelKey", ({ modelKey, expected }) => {
+    expect(shouldRetryToolNonceProbeMissForLiveModel(modelKey)).toBe(expected);
   });
 });
 
@@ -3505,7 +3529,7 @@ async function runGatewayModelSuite(params: GatewayModelSuiteParams) {
               const maxToolReadAttempts = 3;
               // Known-variable models already skip after exhausted nonce misses.
               // Use the stricter follow-up prompts before conceding that coverage.
-              const retryKnownToolNonceMiss = shouldSkipToolNonceProbeMissForLiveModel(modelKey);
+              const retryKnownToolNonceMiss = shouldRetryToolNonceProbeMissForLiveModel(modelKey);
               let toolText = "";
               for (
                 let toolReadAttempt = 0;


### PR DESCRIPTION
Backports the bounded tool-read nonce retry from main commit 699a1c0283e (#104939).

Full validation job 99667587058 received successful OpenAI responses from gpt-5.6-luna, but a tool-read reply contained an earlier well-formed nonce pair. The frozen test treated that first mismatch as terminal even though the existing loop already supports three bounded attempts.

This wires only GPT-5.6 / gpt-5.6-* into that existing retry policy; it remains fail-closed after three misses. No product runtime behavior changes.

Proof:
- Failed release job: https://github.com/openclaw/openclaw/actions/runs/33446699978/job/99667587058
- Upstream source: 699a1c0283e (#104939)
- `git diff --check`
- Focused Vitest was attempted locally but the inherited runner did not complete within its 75s timeout; exact-head CI is the pending execution proof.