### PR TITLE
fix: retain the selected simple-completion transport

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3260,7 +3260,6 @@ src/infra/windows-port-pids.ts	2
 src/infra/windows-powershell-spawn.ts	1
 src/infra/windows-shell-command.ts	1
 src/interactive/payload.ts	2
-src/llm/model-runtime-binding.ts	2
 src/llm/providers/stream-wrappers/anthropic-family-tool-payload-compat.ts	3
 src/llm/providers/stream-wrappers/google-thinking-payload.ts	3
 src/llm/providers/stream-wrappers/minimax.ts	3

--- a/src/agents/simple-completion-runtime.generation.test.ts
+++ b/src/agents/simple-completion-runtime.generation.test.ts
@@ -1,3 +1,4 @@
+import { createApiRegistry } from "@openclaw/ai";
 import { beforeEach, expect, it, vi } from "vitest";
 import type { Model } from "../llm/types.js";
 import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
@@ -46,7 +47,10 @@ vi.mock("../plugins/provider-runtime.runtime.js", () => ({
 
 vi.mock("./sessions/model-registry-runtime.js", () => ({
   initializeModelRegistryRuntime: vi.fn(),
-  getModelRegistryRuntime: () => ({ llmRuntime: { registry: {}, streamSimple: vi.fn() } }),
+  getModelRegistryRuntime: () => {
+    const apiRegistry = createApiRegistry();
+    return { apiRegistry, llmRuntime: { registry: apiRegistry, streamSimple: vi.fn() } };
+  },
 }));
 
 import {

--- a/src/agents/simple-completion-runtime.plugin-scope.test.ts
+++ b/src/agents/simple-completion-runtime.plugin-scope.test.ts
@@ -1,7 +1,9 @@
 import fs from "node:fs";
+import { createServer } from "node:http";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { loadAndActivateRootPluginRegistry } from "../plugins/loader.js";
 import { resetPluginLoaderTestStateForTest } from "../plugins/loader.test-fixtures.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import {
@@ -12,15 +14,60 @@ import {
 import { createSyncSuiteTempRootTracker } from "../plugins/test-helpers/fs-fixtures.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import type { resolveModelAsync } from "./embedded-agent-runner/model.js";
-import type { PreparedModelRuntimeSnapshot } from "./prepared-model-runtime.js";
+import {
+  acquireAgentRunPreparedModelRuntime,
+  type PreparedModelRuntimeSnapshot,
+} from "./prepared-model-runtime.js";
 import { resetPreparedModelRuntimeSnapshotsForTest } from "./prepared-model-runtime.test-support.js";
 import { AuthStorage, ModelRegistry } from "./sessions/index.js";
 import {
+  completeWithPreparedSimpleCompletionModel,
   prepareSimpleCompletionModel,
   prepareSimpleCompletionModelForAgent,
 } from "./simple-completion-runtime.js";
 
 const tempRoots = createSyncSuiteTempRootTracker("openclaw-simple-completion-plugin-scope");
+
+function createTransportOwnerFixture(rootDir: string, owner: "A" | "B") {
+  fs.mkdirSync(rootDir);
+  const fixture = createColdPluginFixture({
+    rootDir,
+    pluginId: `completion-owner-${owner.toLowerCase()}`,
+    providerId: "completion-owner-provider",
+  });
+  fs.writeFileSync(
+    fixture.runtimeSource,
+    `const fs = require("node:fs");
+const { getApiProvider } = require("openclaw/plugin-sdk/llm");
+const owner = ${JSON.stringify(owner)};
+fs.writeFileSync(${JSON.stringify(fixture.runtimeMarker)}, "loaded", "utf8");
+module.exports = {
+  id: ${JSON.stringify(fixture.pluginId)},
+  register(api) {
+    api.registerProvider({
+      id: ${JSON.stringify(fixture.providerId)}, label: owner, auth: [],
+      async prepareRuntimeAuth() { return { apiKey: "fixture-auth-" + owner }; },
+      createStreamFn() {
+        const source = getApiProvider("openai-completions");
+        if (!source) throw new Error("OpenAI completion transport is not registered");
+        return (model, context, options) => source.streamSimple(
+          { ...model, api: "openai-completions" }, context,
+          { ...options, headers: { ...options?.headers, "x-completion-stream": owner } },
+        );
+      },
+      wrapSimpleCompletionStreamFn({ streamFn }) {
+        return (model, context, options) => streamFn(model, context, {
+          ...options, headers: { ...options?.headers, "x-completion-wrapper": owner },
+        });
+      },
+    });
+  },
+};
+`,
+    "utf8",
+  );
+  return fixture;
+}
 
 afterEach(() => {
   resetPreparedModelRuntimeSnapshotsForTest();
@@ -157,6 +204,180 @@ module.exports = {
       expect(preparedRuntime?.metadataSnapshot.plugins.map((plugin) => plugin.id)).toEqual([
         selected.pluginId,
       ]);
+    },
+  );
+
+  it.each(["acquired", "borrowed", "empty"] as const)(
+    "keeps %s transport ownership across ambient replacement and repeated completion",
+    async (mode) => {
+      const tempRoot = fs.realpathSync(tempRoots.makeTempDir());
+      const selected = createTransportOwnerFixture(path.join(tempRoot, "selected"), "A");
+      const ambient = createTransportOwnerFixture(path.join(tempRoot, "ambient"), "B");
+      const unrelatedRoot = path.join(tempRoot, "unrelated");
+      fs.mkdirSync(unrelatedRoot);
+      const unrelated = createColdPluginFixture({
+        rootDir: unrelatedRoot,
+        pluginId: "unrelated-provider-plugin",
+        providerId: "unrelated-provider",
+      });
+      let requestCount = 0;
+      const server = createServer((request, response) => {
+        request.resume();
+        requestCount += 1;
+        const text = [
+          requestCount,
+          request.headers["x-completion-stream"] ?? "none",
+          request.headers["x-completion-wrapper"] ?? "none",
+          request.headers.authorization,
+        ].join("|");
+        response.writeHead(200, { "content-type": "text/event-stream" });
+        response.end(
+          `data: ${JSON.stringify({
+            id: "completion-owner-response",
+            object: "chat.completion.chunk",
+            model: "selected-model",
+            choices: [{ index: 0, delta: { content: text }, finish_reason: "stop" }],
+          })}\n\ndata: [DONE]\n\n`,
+        );
+      });
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject);
+        server.listen(0, "127.0.0.1", () => {
+          server.removeListener("error", reject);
+          resolve();
+        });
+      });
+      try {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("Completion owner fixture did not expose a TCP port");
+        }
+        const configFor = (fixture: typeof selected): OpenClawConfig => ({
+          agents: {
+            defaults: { workspace: fixture.rootDir, model: `${fixture.providerId}/selected-model` },
+          },
+          models: {
+            providers: {
+              [fixture.providerId]: {
+                api: "openai-completions",
+                apiKey: "fixture-auth-source",
+                baseUrl: `http://127.0.0.1:${address.port}/v1`,
+                models: [
+                  {
+                    id: "selected-model",
+                    name: "Selected",
+                    reasoning: false,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 8192,
+                    maxTokens: 1024,
+                  },
+                ],
+              },
+            },
+          },
+          plugins: {
+            load: { paths: [fixture.rootDir, unrelated.rootDir] },
+            slots: { memory: "none" },
+            entries: {
+              [fixture.pluginId]: { enabled: true },
+              [unrelated.pluginId]: { enabled: true },
+            },
+          },
+        });
+        const cfg = configFor(selected);
+        const env = {
+          ...createColdPluginHermeticEnv(tempRoot, { bundledPluginsDir: tempRoots.makeTempDir() }),
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          OPENCLAW_STATE_DIR: path.join(tempRoot, "state"),
+        };
+        await withEnvAsync(env, async () => {
+          const input = {
+            config: cfg,
+            agentId: "main",
+            agentDir: path.join(tempRoot, "agent"),
+            workspaceDir: selected.rootDir,
+          };
+          const lease =
+            mode === "acquired"
+              ? undefined
+              : await acquireAgentRunPreparedModelRuntime(
+                  {
+                    ...input,
+                    readOnly: mode === "empty",
+                    loadRuntimePlugins: mode === "borrowed",
+                    ...(mode === "borrowed"
+                      ? {
+                          runtimePluginSelections: [
+                            {
+                              provider: selected.providerId,
+                              modelId: "selected-model",
+                              agentId: "main",
+                            },
+                          ],
+                        }
+                      : {}),
+                  },
+                  { catalogMode: "static" },
+                );
+          try {
+            if (mode === "empty") {
+              expect(lease?.snapshot.pluginRegistry).toBeUndefined();
+            }
+            const activateAmbient = () =>
+              loadAndActivateRootPluginRegistry({
+                config: configFor(ambient),
+                workspaceDir: ambient.rootDir,
+                onlyPluginIds: [ambient.pluginId],
+                throwOnLoadError: true,
+              });
+            if (mode !== "acquired") {
+              activateAmbient();
+            }
+            const prepared = await prepareSimpleCompletionModel({
+              cfg,
+              agentId: "main",
+              agentDir: input.agentDir,
+              workspaceDir: input.workspaceDir,
+              provider: selected.providerId,
+              modelId: "selected-model",
+              ...(lease ? { preparedModelRuntime: lease.snapshot } : {}),
+            });
+            if ("error" in prepared) {
+              throw new Error(prepared.error);
+            }
+            if (mode === "acquired") {
+              activateAmbient();
+            }
+            // Callers use the logical API before dispatch, including CLI system-prompt selection.
+            expect(prepared.model.api).toBe("openai-completions");
+            expect(isColdPluginRuntimeLoaded(ambient)).toBe(true);
+            const owner = mode === "empty" ? "none" : "A";
+            const auth = mode === "empty" ? "fixture-auth-source" : "fixture-auth-A";
+            for (const turn of [1, 2]) {
+              const result = await completeWithPreparedSimpleCompletionModel({
+                model: prepared.model,
+                auth: prepared.auth,
+                cfg,
+                context: { messages: [{ role: "user", content: `Turn ${turn}`, timestamp: turn }] },
+              });
+              expect(result).toMatchObject({
+                stopReason: "stop",
+                content: [{ type: "text", text: `${turn}|${owner}|${owner}|Bearer ${auth}` }],
+              });
+            }
+            expect(prepared.model.api).toBe("openai-completions");
+            expect(isColdPluginRuntimeLoaded(unrelated)).toBe(false);
+          } finally {
+            lease?.release();
+          }
+        });
+      } finally {
+        server.closeAllConnections();
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
     },
   );
 });

--- a/src/agents/simple-completion-runtime.test.ts
+++ b/src/agents/simple-completion-runtime.test.ts
@@ -1,5 +1,6 @@
 // Simple completion runtime tests cover model resolution, provider auth, and
 // one-shot completion wiring before requests reach the shared LLM stream path.
+import { createApiRegistry } from "@openclaw/ai";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { Model } from "../llm/types.js";
@@ -39,7 +40,7 @@ vi.mock("../plugins/runtime/generation-scope.js", () => ({
 
 vi.mock("./sessions/model-registry-runtime.js", () => ({
   getModelRegistryRuntime: () => {
-    const apiRegistry = {};
+    const apiRegistry = createApiRegistry();
     return {
       apiRegistry,
       llmRuntime: {
@@ -122,6 +123,7 @@ beforeEach(() => {
     model: {
       provider: "anthropic",
       id: "claude-opus-4-6",
+      api: "anthropic-messages",
     },
     authStorage: {
       setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
@@ -324,6 +326,7 @@ describe("prepareSimpleCompletionModel", () => {
       model: {
         provider: "amazon-bedrock",
         id: "anthropic.claude-sonnet-4-6",
+        api: "bedrock-converse-stream",
       },
       authStorage: {
         setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
@@ -357,6 +360,7 @@ describe("prepareSimpleCompletionModel", () => {
       model: {
         provider: "github-copilot",
         id: "gpt-4.1",
+        api: "openai-completions",
       },
       authStorage: {
         setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
@@ -398,6 +402,7 @@ describe("prepareSimpleCompletionModel", () => {
       model: {
         provider: "github-copilot",
         id: "gpt-4.1",
+        api: "openai-completions",
       },
       authStorage: {
         setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
@@ -434,7 +439,7 @@ describe("prepareSimpleCompletionModel", () => {
       label: "model-auth:github-copilot",
     });
     hoisted.resolveModelMock.mockReturnValueOnce({
-      model: { provider: "github-copilot", id: "gpt-4.1" },
+      model: { provider: "github-copilot", id: "gpt-4.1", api: "openai-completions" },
       authStorage: { setRuntimeApiKey: hoisted.setRuntimeApiKeyMock },
       modelRegistry: {},
     });
@@ -464,6 +469,7 @@ describe("prepareSimpleCompletionModel", () => {
       model: {
         provider: "github-copilot",
         id: "gpt-4.1",
+        api: "openai-completions",
       },
       authStorage: {
         setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
@@ -563,6 +569,7 @@ describe("prepareSimpleCompletionModel", () => {
       model: {
         provider: "amazon-bedrock-mantle",
         id: "anthropic.claude-opus-4-7",
+        api: "anthropic-messages",
         baseUrl: "https://bedrock-mantle.us-east-1.api.aws/anthropic",
       },
       authStorage: {
@@ -623,6 +630,7 @@ describe("prepareSimpleCompletionModel", () => {
       model: {
         provider: "ollama",
         id: "llama3.2:latest",
+        api: "ollama",
       },
       authStorage: {
         setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
@@ -666,6 +674,7 @@ describe("prepareSimpleCompletionModel", () => {
       model: {
         provider: "anthropic",
         id: "claude-opus-4-6",
+        api: "anthropic-messages",
       },
       authStorage: {
         setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,
@@ -702,6 +711,7 @@ describe("prepareSimpleCompletionModel", () => {
       model: {
         provider: "mistral",
         id: "mistral-medium-3-5",
+        api: "mistral-conversations",
       },
       authStorage: {
         setRuntimeApiKey: hoisted.setRuntimeApiKeyMock,

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -16,7 +16,11 @@ import {
 import type { ThinkLevel } from "../auto-reply/thinking.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
-import { bindModelLlmRuntime, getModelLlmRuntime } from "../llm/model-runtime-binding.js";
+import {
+  bindModelLlmRuntime,
+  getModelCompletionTransport,
+  getModelLlmRuntime,
+} from "../llm/model-runtime-binding.js";
 import { completeSimple } from "../llm/stream.js";
 import type {
   AssistantMessage,
@@ -455,15 +459,20 @@ async function prepareSimpleCompletionModelCore(
       : fingerprintResolvedProviderAuth(auth)
     : undefined;
   const modelRuntime = getModelRegistryRuntime(resolved.modelRegistry);
+  const model = applySecretRefHeaderSentinels(
+    applyLocalNoAuthHeaderOverride(resolvedModel, resolvedAuth),
+    params.cfg,
+  );
+  // Select transport hooks before releasing this generation. Keep the logical
+  // model API visible to callers that build prompts before dispatch.
+  const completionTransport = prepareModelForSimpleCompletion({
+    apiRegistry: modelRuntime.apiRegistry,
+    model,
+    cfg: params.cfg,
+  });
 
   return {
-    model: bindModelLlmRuntime(
-      applySecretRefHeaderSentinels(
-        applyLocalNoAuthHeaderOverride(resolvedModel, resolvedAuth),
-        params.cfg,
-      ),
-      modelRuntime.llmRuntime,
-    ),
+    model: bindModelLlmRuntime(model, modelRuntime.llmRuntime, completionTransport),
     auth: resolvedAuth,
     ...(sourceAuthFingerprint ? { sourceAuthFingerprint } : {}),
   };
@@ -654,13 +663,15 @@ export async function completeWithPreparedSimpleCompletionModel(params: {
   options?: SimpleCompletionModelOptions;
 }): Promise<AssistantMessage> {
   const runtime = getModelLlmRuntime(params.model);
-  let completionModel = prepareModelForSimpleCompletion({
-    // Direct SDK callers that did not use the preparation helper keep the shipped
-    // process-default behavior; all prepared host paths carry their lifecycle owner.
-    apiRegistry: runtime?.registry ?? defaultApiRegistry,
-    model: params.model,
-    cfg: params.cfg,
-  });
+  let completionModel =
+    getModelCompletionTransport(params.model) ??
+    prepareModelForSimpleCompletion({
+      // Direct SDK callers that did not use the preparation helper keep the shipped
+      // process-default behavior; all prepared host paths carry their lifecycle owner.
+      apiRegistry: runtime?.registry ?? defaultApiRegistry,
+      model: params.model,
+      cfg: params.cfg,
+    });
   if (runtime) {
     completionModel = bindModelLlmRuntime(completionModel, runtime);
   }

--- a/src/llm/model-runtime-binding.ts
+++ b/src/llm/model-runtime-binding.ts
@@ -5,21 +5,32 @@ const MODEL_LLM_RUNTIME = Symbol("openclaw.modelLlmRuntime");
 const streamLlmRuntimes = new WeakMap<object, LlmRuntime>();
 
 type RuntimeBoundModel = Model & {
-  [MODEL_LLM_RUNTIME]?: LlmRuntime;
+  [MODEL_LLM_RUNTIME]?: {
+    runtime: LlmRuntime;
+    completionTransport?: Model;
+  };
 };
 
 /** Carries the prepared lifecycle runtime without changing the serialized model shape. */
-export function bindModelLlmRuntime(model: Model, runtime: LlmRuntime): Model {
-  const bound = { ...model } as RuntimeBoundModel;
+export function bindModelLlmRuntime(
+  model: Model,
+  runtime: LlmRuntime,
+  completionTransport?: Model,
+): Model {
+  const bound: RuntimeBoundModel = { ...model };
   Object.defineProperty(bound, MODEL_LLM_RUNTIME, {
-    value: runtime,
+    value: { runtime, completionTransport },
     enumerable: false,
   });
   return bound;
 }
 
-export function getModelLlmRuntime(model: Model): LlmRuntime | undefined {
-  return (model as RuntimeBoundModel)[MODEL_LLM_RUNTIME];
+export function getModelLlmRuntime(model: RuntimeBoundModel): LlmRuntime | undefined {
+  return model[MODEL_LLM_RUNTIME]?.runtime;
+}
+
+export function getModelCompletionTransport(model: RuntimeBoundModel): Model | undefined {
+  return model[MODEL_LLM_RUNTIME]?.completionTransport;
 }
 
 /** Associates a prepared stream entry point with the runtime that owns it. */


### PR DESCRIPTION
Related: #130706. This is a focused ownership repair found while splitting the wider Gateway work, not a claim that the CPU/stall incident is resolved.

## What Problem This Solves

A simple completion could prepare authentication using its selected provider, then choose a different provider's stream and wrapper after ambient plugin state changed. The resulting HTTP request mixed the acquired credentials with another generation's transport. An authoritative empty retained generation could also accidentally borrow ambient hooks.

## Why This Change Was Made

Preparation now captures the selected completion transport inside the existing private model runtime binding. Completion consumes that prepared fact instead of rediscovering the provider. The model's logical API remains unchanged, and the same prepared model remains reusable. The existing preparation lease retains ownership; no extra lease, WeakMap, lifecycle owner, public setting, environment variable, dependency, schema, or persistence change is added.

The canonical typed private binding also removes two old type assertions and their assertion-baseline entry. Direct raw SDK model calls keep their existing unprepared completion path.

## Evidence

Source: `1968da946e458d9798fffdf82ea6d79aa5aca315`, based on main `b61485c193bb3e8581dc045821c2f9532ae9cf25`.

- Before repair, HTTP regressions reproduced wrong ambient stream/wrapper selection for acquired, caller-borrowed, and authoritative empty ownership. Two cold controls already passed. After repair, the same cases pass, including repeat completion, unchanged logical API, and unrelated-provider coldness.
- **467 tests across 17 whole files passed:** 307 owner/sibling tests plus 160 current provider-error tests. Older partial registry fixtures now use the existing complete helper without weakening assertions.
- Full changed gate passed. Earlier assertion-ratchet failures led to the typed private owner and deletion of the obsolete baseline entry, not suppression. QA/test audit and deslop are complete. Managed Codex P0 review found no actionable findings at that threshold; no all-priority automated-review claim.
- Fresh ordinary build passed in 293.872 seconds, including all 147 SDK subpaths. All 15,528 build-output entries were verified before and after runtime checks.
- **Seven built-runtime HTTP requests passed against the maintained loopback provider.** Acquired and caller-borrowed generations each retain stream A, wrapper A and auth A across two completions after ambient B appears. The authoritative empty generation repeats twice without ambient hooks. Request seven runs the real `infer model run --local --json` CLI and returns expected provider/model/text. All observed processes, groups and five fixture roots drained.
- The first runtime attempt stopped before any completion request because its readiness probe sent HEAD to the mock's GET-only health endpoint. That failed receipt is retained. The passing run changes only to the maintained GET probe, preserving assertions and deadlines.
- [Exact-head CI run 33456810539](https://github.com/openclaw/openclaw/actions/runs/33456810539) completed successfully. Latest ClawSweeper review has no actionable finding; its pending-CI rank-up requirement is satisfied.

## Size and Limits

Production: **+43 / -21 = +22 lines** in two files. Tests: **+239 / -4 = +235 lines** in three existing suites. Assertion metadata: **-1 line**. Growth records the missing transport fact at its existing owner and removes late discovery; no new test file or production test seam.

Adjacent #112257 concerns the package AI request-transport sentinel path; this cut does not replace that package implementation or claim to resolve it. Its boundary is the prepared model's captured provider transport.

Runtime proof uses a synthetic loopback provider. No authenticated external provider, Gateway/channel delivery, production soak or whole-incident performance claim. External Telegram proof is waived, not passed. Changelogs are written at release time.
