### PR TITLE
ci: reuse Watch build products and repair process cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4543,32 +4543,41 @@ jobs:
               process.stdout.write(simulator.udid);
             '
           )"
-          derived_data_path="$RUNNER_TEMP/openclaw-watch-lifecycle"
-          xcodebuild \
-            -project apps/ios/OpenClaw.xcodeproj \
-            -scheme OpenClawWatchApp \
-            -configuration Debug \
-            -destination "platform=watchOS Simulator,id=${simulator_id}" \
-            -derivedDataPath "$derived_data_path" \
-            -parallel-testing-enabled NO \
-            -only-testing:OpenClawWatchTests/WatchInboxStoreOperationTests \
-            CODE_SIGNING_ALLOWED=NO \
-            build-for-testing
+          # Reuse the Watch products already compiled by the generic iOS build.
+          # Resolve the selected target product from Xcode, not its DerivedData naming.
+          xcodebuild_args=(
+            -project apps/ios/OpenClaw.xcodeproj
+            -scheme OpenClawWatchApp
+            -configuration Debug
+            -destination "platform=watchOS Simulator,id=${simulator_id}"
+            CODE_SIGNING_ALLOWED=NO
+          )
+          test_args=(
+            -parallel-testing-enabled NO
+            -only-testing:OpenClawWatchTests/WatchInboxStoreOperationTests
+          )
+          xcodebuild "${xcodebuild_args[@]}" "${test_args[@]}" build-for-testing
+          app_path="$(
+            xcodebuild "${xcodebuild_args[@]}" -showBuildSettings -json |
+              node --input-type=module -e '
+                import path from "node:path";
+                const chunks = [];
+                for await (const chunk of process.stdin) chunks.push(chunk);
+                const targets = JSON.parse(Buffer.concat(chunks).toString("utf8"))
+                  .filter((target) => target.target === "OpenClawWatchApp");
+                if (targets.length !== 1) throw new Error("Expected one Watch app target from Xcode");
+                const { TARGET_BUILD_DIR, FULL_PRODUCT_NAME } = targets[0].buildSettings;
+                if (!path.isAbsolute(TARGET_BUILD_DIR) || !FULL_PRODUCT_NAME) {
+                  throw new Error("Expected an absolute Watch app product from Xcode");
+                }
+                process.stdout.write(path.join(TARGET_BUILD_DIR, FULL_PRODUCT_NAME));
+              '
+          )"
           xcrun simctl boot "$simulator_id" 2>/dev/null || true
           xcrun simctl bootstatus "$simulator_id" -b
-          xcrun simctl install \
-            "$simulator_id" \
-            "$derived_data_path/Build/Products/Debug-watchsimulator/OpenClawWatchApp.app"
-          xcodebuild \
-            -project apps/ios/OpenClaw.xcodeproj \
-            -scheme OpenClawWatchApp \
-            -configuration Debug \
-            -destination "platform=watchOS Simulator,id=${simulator_id}" \
-            -derivedDataPath "$derived_data_path" \
+          xcrun simctl install "$simulator_id" "$app_path"
+          xcodebuild "${xcodebuild_args[@]}" "${test_args[@]}" \
             -resultBundlePath apps/ios/build/LifecycleTestResults/OpenClawWatchOperationTests.xcresult \
-            -parallel-testing-enabled NO \
-            -only-testing:OpenClawWatchTests/WatchInboxStoreOperationTests \
-            CODE_SIGNING_ALLOWED=NO \
             test-without-building
 
       - name: Upload iOS lifecycle simulator evidence

--- a/scripts/lib/managed-child-process.mts
+++ b/scripts/lib/managed-child-process.mts
@@ -187,12 +187,13 @@ export function inspectManagedProcessGroup(
   }
   try {
     process.kill(-pid, 0);
-    if (
-      platform === "linux" &&
-      (child.exitCode != null || child.signalCode != null) &&
-      isLinuxZombieProcessGroup(pid)
-    ) {
-      return "dead";
+    if (platform === "linux" && (child.exitCode != null || child.signalCode != null)) {
+      if (isLinuxZombieProcessGroup(pid)) {
+        return "dead";
+      }
+      // The group may be reaped while ps runs. Recheck kernel existence without
+      // treating an empty or failed snapshot as proof of completion.
+      process.kill(-pid, 0);
     }
     return "live";
   } catch (error) {

--- a/test/scripts/ios-lifecycle-workflow.test.ts
+++ b/test/scripts/ios-lifecycle-workflow.test.ts
@@ -1,0 +1,151 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+type Command = { tool: string; args: string[] };
+
+const workflow: { jobs: Record<string, { steps: { name?: string; run?: string }[] }> } = parse(
+  readFileSync(".github/workflows/ci.yml", "utf8"),
+);
+const watchStep = workflow.jobs["ios-build"]?.steps.find(
+  (step) => step.name === "Run focused Apple Watch operation simulator tests",
+);
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+function runWatchStep(mode = "ready") {
+  const root = tempDirs.make("openclaw-watch-workflow-");
+  const bin = path.join(root, "bin");
+  const product = path.join(root, "project derived data", "Watch Product.app");
+  mkdirSync(bin, { recursive: true });
+  mkdirSync(product, { recursive: true });
+  const runner = path.join(root, "tools.mjs");
+  writeFileSync(
+    runner,
+    String.raw`
+import { appendFileSync, existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+const [tool, ...args] = process.argv.slice(2);
+const root = process.env.WATCH_FIXTURE_ROOT;
+const mode = process.env.WATCH_FIXTURE_MODE;
+appendFileSync(path.join(root, "commands.jsonl"), JSON.stringify({ tool, args }) + "\n");
+if (tool === "xcrun") {
+  if (args[1] === "list") {
+    console.log(JSON.stringify({ devices: { watch: [
+      { name: "Apple Watch fixture", isAvailable: true, udid: "watch-fixture" }
+    ] } }));
+  } else if (args[1] === "bootstatus" && mode === "boot-failed") {
+    process.exit(23);
+  } else if (args[1] === "install" && !existsSync(args[3])) {
+    process.exit(24);
+  }
+} else if (args.includes("-showBuildSettings")) {
+  const product = {
+    target: "OpenClawWatchApp",
+    buildSettings: {
+      TARGET_BUILD_DIR: mode === "relative-product" ? "relative" : path.join(root, "project derived data"),
+      FULL_PRODUCT_NAME: "Watch Product.app"
+    }
+  };
+  const other = { target: "OtherTarget", buildSettings: { TARGET_BUILD_DIR: "/wrong", FULL_PRODUCT_NAME: "Wrong.app" } };
+  console.log(JSON.stringify(mode === "missing-product" ? [other] :
+    mode === "ambiguous-product" ? [product, product] : [other, product]));
+} else if (args.includes("build-for-testing")) {
+  const derivedIndex = args.indexOf("-derivedDataPath");
+  if (derivedIndex >= 0) {
+    mkdirSync(path.join(args[derivedIndex + 1], "Build/Products/Debug-watchsimulator/OpenClawWatchApp.app"), { recursive: true });
+  }
+}
+`,
+  );
+  for (const tool of ["xcrun", "xcodebuild"]) {
+    const executable = path.join(bin, tool);
+    writeFileSync(executable, `#!/bin/sh\nexec '${process.execPath}' '${runner}' '${tool}' "$@"\n`);
+    chmodSync(executable, 0o755);
+  }
+  if (!watchStep?.run) {
+    throw new Error("Missing Watch simulator workflow step");
+  }
+  const result = spawnSync("bash", ["--noprofile", "--norc", "-c", watchStep.run], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+      RUNNER_TEMP: root,
+      WATCH_FIXTURE_ROOT: root,
+      WATCH_FIXTURE_MODE: mode,
+    },
+  });
+  const commands: Command[] = readFileSync(path.join(root, "commands.jsonl"), "utf8")
+    .trim()
+    .split("\n")
+    .map((line) => JSON.parse(line));
+  return { result, commands, product };
+}
+
+describe.skipIf(process.platform === "win32")("Watch simulator workflow", () => {
+  it("reuses project build products and installs the exact Watch target before running its tests", () => {
+    const { result, commands, product } = runWatchStep();
+    expect(result.status, result.stderr).toBe(0);
+    const xcodeCommands = commands.filter((command) => command.tool === "xcodebuild");
+    for (const command of xcodeCommands) {
+      expect(command.args).not.toContain("-derivedDataPath");
+    }
+    expect(
+      commands.filter((command) => command.tool === "xcrun").map((command) => command.args),
+    ).toEqual([
+      ["simctl", "list", "devices", "available", "--json"],
+      ["simctl", "boot", "watch-fixture"],
+      ["simctl", "bootstatus", "watch-fixture", "-b"],
+      ["simctl", "install", "watch-fixture", product],
+    ]);
+    expect(
+      xcodeCommands.map((command) =>
+        command.args.find((arg) =>
+          ["build-for-testing", "-showBuildSettings", "test-without-building"].includes(arg),
+        ),
+      ),
+    ).toEqual(["build-for-testing", "-showBuildSettings", "test-without-building"]);
+    for (const command of xcodeCommands.filter(
+      (entry) =>
+        entry.args.includes("build-for-testing") || entry.args.includes("test-without-building"),
+    )) {
+      expect(command.args).toEqual(
+        expect.arrayContaining([
+          "OpenClawWatchApp",
+          "Debug",
+          "platform=watchOS Simulator,id=watch-fixture",
+          "-parallel-testing-enabled",
+          "NO",
+          "-only-testing:OpenClawWatchTests/WatchInboxStoreOperationTests",
+          "CODE_SIGNING_ALLOWED=NO",
+        ]),
+      );
+    }
+    expect(
+      xcodeCommands.find((command) => command.args.includes("test-without-building"))?.args,
+    ).toContain("apps/ios/build/LifecycleTestResults/OpenClawWatchOperationTests.xcresult");
+  });
+
+  it.each(["missing-product", "ambiguous-product", "relative-product"])(
+    "rejects %s settings before simulator installation or test execution",
+    (mode) => {
+      const { result, commands } = runWatchStep(mode);
+      expect(result.status).not.toBe(0);
+      expect(commands.some((command) => command.args.includes("install"))).toBe(false);
+      expect(commands.some((command) => command.args.includes("test-without-building"))).toBe(
+        false,
+      );
+    },
+  );
+
+  it("preserves simulator readiness failure without installing or running tests", () => {
+    const { result, commands } = runWatchStep("boot-failed");
+    expect(result.status).toBe(23);
+    expect(commands.some((command) => command.args.includes("install"))).toBe(false);
+    expect(commands.some((command) => command.args.includes("test-without-building"))).toBe(false);
+  });
+});

--- a/test/scripts/managed-child-process.test.ts
+++ b/test/scripts/managed-child-process.test.ts
@@ -1,6 +1,7 @@
 // Managed Child Process tests cover managed child process script behavior.
-import { spawn, spawnSync } from "node:child_process";
+import childProcess, { spawn, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import { syncBuiltinESMExports } from "node:module";
 import os from "node:os";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
@@ -588,6 +589,83 @@ setInterval(() => {}, 1_000);
       ),
     ).toBe("dead");
   });
+
+  it.each<{
+    snapshot: "empty" | "live" | "failed" | "zombie";
+    afterSnapshot: string | null;
+    expected: ReturnType<typeof inspectManagedProcessGroup>;
+    policy?: Parameters<typeof inspectManagedProcessGroup>[1]["errorPolicy"];
+    platform?: NodeJS.Platform;
+    running?: boolean;
+  }>([
+    { snapshot: "empty", afterSnapshot: "ESRCH", expected: "dead" },
+    { snapshot: "live", afterSnapshot: "ESRCH", expected: "dead" },
+    { snapshot: "failed", afterSnapshot: "ESRCH", expected: "dead" },
+    { snapshot: "empty", afterSnapshot: null, expected: "live" },
+    { snapshot: "live", afterSnapshot: null, expected: "live" },
+    { snapshot: "failed", afterSnapshot: null, expected: "live" },
+    { snapshot: "zombie", afterSnapshot: null, expected: "dead" },
+    { snapshot: "empty", afterSnapshot: "EPERM", expected: "live" },
+    {
+      snapshot: "empty",
+      afterSnapshot: "EPERM",
+      policy: "indeterminate",
+      expected: "indeterminate",
+    },
+    { snapshot: "empty", afterSnapshot: "EPERM", policy: "verify-leader", expected: "dead" },
+    {
+      snapshot: "empty",
+      afterSnapshot: "EIO",
+      policy: "indeterminate",
+      expected: "indeterminate",
+    },
+    { snapshot: "empty", afterSnapshot: "EIO", expected: "dead" },
+    { snapshot: "zombie", afterSnapshot: null, platform: "darwin", expected: "live" },
+    { snapshot: "zombie", afterSnapshot: null, running: true, expected: "live" },
+  ])(
+    "checks current group state after $snapshot snapshot ($afterSnapshot, $policy, $platform, $running)",
+    ({
+      snapshot,
+      afterSnapshot,
+      expected,
+      policy = "alive-on-eperm",
+      platform = "linux",
+      running,
+    }) => {
+      let inspected = false;
+      const kill = vi.spyOn(process, "kill").mockImplementation(() => {
+        if (inspected && afterSnapshot) {
+          throw Object.assign(new Error("group lookup failed"), { code: afterSnapshot });
+        }
+        return true;
+      });
+      const ps = vi.spyOn(childProcess, "spawnSync").mockImplementation(() => {
+        inspected = true;
+        return {
+          pid: 12346,
+          output: [],
+          signal: null,
+          status: snapshot === "empty" ? 1 : 0,
+          stdout: snapshot === "zombie" ? "12345 Z\n" : snapshot === "live" ? "12345 S\n" : "",
+          stderr: "",
+          ...(snapshot === "failed" ? { error: new Error("ps unavailable") } : {}),
+        };
+      });
+      syncBuiltinESMExports();
+      try {
+        expect(
+          inspectManagedProcessGroup(
+            { pid: 12345, exitCode: running ? null : 0, signalCode: null },
+            { errorPolicy: policy, platform },
+          ),
+        ).toBe(expected);
+      } finally {
+        ps.mockRestore();
+        kill.mockRestore();
+        syncBuiltinESMExports();
+      }
+    },
+  );
 
   it("bounds process-group waiting when the group remains live", async () => {
     const kill = vi.spyOn(process, "kill").mockReturnValue(true);

--- a/test/scripts/run-additional-boundary-checks.test.ts
+++ b/test/scripts/run-additional-boundary-checks.test.ts
@@ -17,6 +17,7 @@ import {
   runSingleCheck,
   selectChecksForShard,
 } from "../../scripts/run-additional-boundary-checks.mts";
+import { waitForFile, waitForPidFile } from "../helpers/process-wait.js";
 
 function createOutputBuffer() {
   const chunks: string[] = [];
@@ -62,17 +63,6 @@ async function sleep(ms: number): Promise<void> {
   await new Promise((resolve) => {
     setTimeout(resolve, ms);
   });
-}
-
-async function waitForFile(filePath: string, timeoutMs: number): Promise<void> {
-  const deadlineAt = Date.now() + timeoutMs;
-  while (Date.now() < deadlineAt) {
-    if (fs.existsSync(filePath)) {
-      return;
-    }
-    await sleep(5);
-  }
-  throw new Error(`timeout waiting for ${filePath}`);
 }
 
 async function waitForDead(pid: number, timeoutMs: number): Promise<void> {
@@ -393,7 +383,8 @@ describe("run-additional-boundary-checks", () => {
           "const { spawn } = require('node:child_process');",
           "const fs = require('node:fs');",
           `const child = spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' });`,
-          "fs.writeFileSync(process.env.OPENCLAW_TEST_CHILD_PID, String(child.pid));",
+          "fs.writeFileSync(process.env.OPENCLAW_TEST_CHILD_PID + '.tmp', String(child.pid));",
+          "fs.renameSync(process.env.OPENCLAW_TEST_CHILD_PID + '.tmp', process.env.OPENCLAW_TEST_CHILD_PID);",
           "setInterval(() => {}, 1000);",
         ].join("");
 
@@ -411,8 +402,7 @@ describe("run-additional-boundary-checks", () => {
           },
         );
 
-        await waitForFile(childPidPath, 2000);
-        childPid = Number(fs.readFileSync(childPidPath, "utf8"));
+        childPid = await waitForPidFile(childPidPath, 2000);
         const result = await resultPromise;
 
         expect(result.code).toBe(1);
@@ -444,7 +434,8 @@ describe("run-additional-boundary-checks", () => {
           "const { spawn } = require('node:child_process');",
           "const fs = require('node:fs');",
           `const child = spawn(process.execPath, ['-e', ${JSON.stringify(childScript)}], { stdio: 'ignore' });`,
-          "fs.writeFileSync(process.env.OPENCLAW_TEST_CHILD_PID, String(child.pid));",
+          "fs.writeFileSync(process.env.OPENCLAW_TEST_CHILD_PID + '.tmp', String(child.pid));",
+          "fs.renameSync(process.env.OPENCLAW_TEST_CHILD_PID + '.tmp', process.env.OPENCLAW_TEST_CHILD_PID);",
           "fs.writeFileSync(process.env.OPENCLAW_TEST_READY, 'ready');",
           "process.on('SIGTERM', () => process.exit(0));",
           "setInterval(() => {}, 1000);",
@@ -482,7 +473,7 @@ await runChecks(
         });
 
         await waitForFile(readyPath, 2000);
-        childPid = Number(fs.readFileSync(childPidPath, "utf8"));
+        childPid = await waitForPidFile(childPidPath, 2000);
         expect(Number.isInteger(childPid)).toBe(true);
         expect(isProcessAlive(childPid)).toBe(true);
 

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -773,6 +773,7 @@ describe("scripts/test-projects changed-target routing", () => {
         "test/scripts/changed-path-facts.test.ts",
         "test/scripts/ci-changed-node-test-plan.test.ts",
         "test/scripts/full-release-validation-state.test.ts",
+        "test/scripts/ios-lifecycle-workflow.test.ts",
         "test/scripts/macos-native-test-launch.test.ts",
         "test/scripts/openclaw-npm-resume-run.test.ts",
         "test/scripts/package-acceptance-workflow.test.ts",


### PR DESCRIPTION
## Problem

The iOS CI job compiles the Watch app and shared targets during its generic Debug build, then discarded that work by using fresh DerivedData for Watch tests. The later build-for-testing phase took 91.932 seconds in the retained full-release run.

## Change

Reuse Xcode's project DerivedData for the Watch phase. Resolve the exact Watch app from its unique target's JSON build settings, retaining simulator readiness, explicit installation, build-for-testing, test-without-building, and both result bundles. Debug and Release builds, all five iPhone test selections, the Watch selection, signing flags, serial Xcode execution, and screenshot coverage remain unchanged.

The PR's CI exposed a related process-cleanup failure. Independent controlled Linux proof found that a group reaped between a successful kernel existence check and the `ps` snapshot could still be reported live. The shared inspector now rechecks kernel existence after that snapshot, preserving existing error policies and deadlines. Full sibling testing also exposed unsafe PID-file publication: an empty file could become PID 0, and partial digits could become an unrelated PID. Both affected fixtures now publish atomically and reuse the canonical validated PID reader. No retry, timeout, heap budget, or assertion was relaxed. The exact syscall ordering of the historical CI failure, and the signal target of an intermediate local exit 137, were not captured; those causal assignments remain unproven.

## Evidence

[Hosted Xcode 26.6 diagnostic](https://github.com/openclaw/openclaw/actions/runs/33449746903/job/99676992622) passed on macos-26 with all **255 iPhone tests and 13 Watch tests**, zero failures or skips. Both xcresult bundles were downloaded and checked against the Actions artifact digest. The Watch phase compiled only the three Watch test source entries; shared app targets were reused. Build-for-testing took **20.870 seconds versus 91.932 seconds** in the [earlier full-release job](https://github.com/openclaw/openclaw/actions/runs/33442241355/job/99653232918).

The diagnostic selects source `32a267887cd6874656a1b64e520ded634050b00c` with workflow `dc60a57c5694c449f45567127fd6353afcce6cae`. It proves the Watch change before the mechanical main refresh and separate cleanup repair, not final whole-head CI. The iOS workflow section and focused tests are unchanged by that refresh. Total iOS job time was 36m30s versus 41m18s, but unrelated startup/build variation prevents attributing that whole reduction to this patch. The separate early-boot experiment is not included.

Four executable workflow regressions failed before the Watch change; all pass afterward. The cleanup owner has seven failing pre-fix regression cases and a real Linux Node reproduction that changes from incorrect live to correct dead after controlled reaping. Both actual PID producers passed the safe atomic-publication probe without sending unsafe signals. The cleanup owner/sibling/helper run passed 207 tests with one existing platform skip. The final composed six-file run passed **577 tests with one existing platform skip**, and all **18 scoped checks** passed, including both TypeScript lanes, lint and boundary guards. [Exact-head CI33453766420](https://github.com/openclaw/openclaw/actions/runs/33453766420) passed on `41f57ea84cdbe0aff13be6712ab10c664808e46b`: 143 successful jobs, 10 skipped, zero failures, with required gate99691048998 successful. This resolves the latest review’s remaining CI risk and rank-up request.

Independent Codex review of the complete six-file candidate found no actionable P0–P2 findings. Application runtime delta is zero; workflow net +9 and tooling net +1 implement product resolution and the shared inspector repair; tests net +221. No new configuration, dependency, or persistence surface is introduced.
