### PR TITLE
fix(e2e): let frozen candidates create the agents-delete roster

### DIFF
--- a/scripts/e2e/agents-delete-shared-workspace-docker.sh
+++ b/scripts/e2e/agents-delete-shared-workspace-docker.sh
@@ -34,6 +34,7 @@ source scripts/lib/openclaw-e2e-instance.sh
 openclaw_e2e_eval_test_state_from_b64 "${OPENCLAW_TEST_STATE_SCRIPT_B64:?missing OPENCLAW_TEST_STATE_SCRIPT_B64}"
 export SHARED_WORKSPACE="$HOME/workspace-shared"
 output_file="$HOME/delete.json"
+agents_file="$HOME/agents.json"
 gateway_log="$HOME/gateway.log"
 gateway_pid=""
 
@@ -50,13 +51,14 @@ trap cleanup EXIT
 trap dump_logs_on_error ERR
 
 mkdir -p "$OPENCLAW_STATE_DIR" "$SHARED_WORKSPACE"
-node scripts/e2e/lib/fixture.mjs agents-delete-config
-
 entry="$(openclaw_e2e_resolve_entrypoint)"
+node "$entry" agents add alpha --workspace "$SHARED_WORKSPACE" --non-interactive
+node "$entry" agents add ops --workspace "$SHARED_WORKSPACE" --non-interactive
 gateway_pid="$(openclaw_e2e_start_gateway "$entry" 18789 "$gateway_log")"
 openclaw_e2e_wait_gateway_ready "$gateway_pid" "$gateway_log" 300 18789
 
 node "$entry" agents delete ops --force --json > "$output_file"
+node "$entry" agents list --json > "$agents_file"
 
-node scripts/e2e/lib/fixture.mjs agents-delete-assert "$output_file"
+node scripts/e2e/lib/fixture.mjs agents-delete-assert "$output_file" "$agents_file"
 '

--- a/scripts/e2e/lib/fixtures/workspace.mjs
+++ b/scripts/e2e/lib/fixtures/workspace.mjs
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { readPositiveIntEnv } from "../env-limits.mjs";
 import { readTextFileTail } from "../text-file-utils.mjs";
-import { assert, readJson, requireArg, write, writeJson } from "./common.mjs";
+import { assert, readJson, requireArg, write } from "./common.mjs";
 
 const AGENTS_DELETE_OUTPUT_MAX_BYTES = readPositiveIntEnv(
   "OPENCLAW_FIXTURE_AGENTS_DELETE_OUTPUT_MAX_BYTES",
@@ -23,25 +23,9 @@ function writeOpenWebUiWorkspace() {
   fs.rmSync(path.join(workspace, "BOOTSTRAP.md"), { force: true });
 }
 
-function writeAgentsDeleteConfig() {
-  const stateDir = requireArg(process.env.OPENCLAW_STATE_DIR, "OPENCLAW_STATE_DIR");
-  const sharedWorkspace = requireArg(process.env.SHARED_WORKSPACE, "SHARED_WORKSPACE");
-  const gatewayToken = process.env.OPENCLAW_GATEWAY_TOKEN?.trim();
-  fs.mkdirSync(sharedWorkspace, { recursive: true });
-  writeJson(path.join(stateDir, "openclaw.json"), {
-    agents: {
-      ownership: "explicit",
-      entries: {
-        main: { workspace: sharedWorkspace },
-        ops: { workspace: sharedWorkspace },
-      },
-    },
-    ...(gatewayToken ? { gateway: { auth: { mode: "token", token: gatewayToken } } } : {}),
-  });
-}
-
-function assertAgentsDeleteResult([outputPath]) {
+function assertAgentsDeleteResult([outputPath, agentsPath]) {
   const resolvedOutputPath = requireArg(outputPath, "outputPath");
+  const resolvedAgentsPath = requireArg(agentsPath, "agentsPath");
   const outputStat = fs.statSync(resolvedOutputPath);
   if (outputStat.isFile() && outputStat.size > AGENTS_DELETE_OUTPUT_MAX_BYTES) {
     throw new Error(
@@ -72,23 +56,23 @@ function assertAgentsDeleteResult([outputPath]) {
     assert(actual === expected, `${label} mismatch: ${JSON.stringify(actual)}`);
   }
   assert(
-    Array.isArray(parsed.workspaceSharedWith) && parsed.workspaceSharedWith.includes("main"),
-    "missing shared-with main marker",
+    Array.isArray(parsed.workspaceSharedWith) && parsed.workspaceSharedWith.includes("alpha"),
+    "missing shared-with alpha marker",
   );
   assert(fs.existsSync(process.env.SHARED_WORKSPACE), "shared workspace was removed");
-  const remaining =
-    readJson(path.join(process.env.OPENCLAW_STATE_DIR, "openclaw.json"))?.agents?.entries ?? {};
+  const agents = readJson(resolvedAgentsPath);
+  assert(Array.isArray(agents), "agents list did not emit an array");
+  assert(!agents.some((entry) => entry?.id === "ops"), "deleted agent remained in agent list");
   assert(
-    remaining && typeof remaining === "object" && !Array.isArray(remaining),
-    "agents entries missing after delete",
+    agents.some(
+      (entry) => entry?.id === "alpha" && entry?.workspace === process.env.SHARED_WORKSPACE,
+    ),
+    "shared surviving agent missing from agent list",
   );
-  assert(!Object.hasOwn(remaining, "ops"), "deleted agent remained in config");
-  assert(Object.hasOwn(remaining, "main"), "main agent missing after delete");
   console.log("agents delete shared workspace smoke ok");
 }
 
 export const workspaceCommands = {
   "openwebui-workspace": writeOpenWebUiWorkspace,
-  "agents-delete-config": writeAgentsDeleteConfig,
   "agents-delete-assert": assertAgentsDeleteResult,
 };

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -7559,9 +7559,13 @@ done
     const runner = readFileSync(AGENTS_DELETE_SHARED_WORKSPACE_DOCKER_E2E_PATH, "utf8");
     expectTextToIncludeAll(runner, [
       'entry="$(openclaw_e2e_resolve_entrypoint)"',
+      'node "$entry" agents add alpha --workspace "$SHARED_WORKSPACE" --non-interactive',
+      'node "$entry" agents add ops --workspace "$SHARED_WORKSPACE" --non-interactive',
       'gateway_pid="$(openclaw_e2e_start_gateway "$entry" 18789 "$gateway_log")"',
       'openclaw_e2e_wait_gateway_ready "$gateway_pid" "$gateway_log" 300 18789',
       'node "$entry" agents delete ops --force --json > "$output_file"',
+      'node "$entry" agents list --json > "$agents_file"',
+      'node scripts/e2e/lib/fixture.mjs agents-delete-assert "$output_file" "$agents_file"',
       'openclaw_e2e_terminate_gateways "${gateway_pid:-}"',
       'openclaw_e2e_print_log "$gateway_log" >&2',
       "trap cleanup EXIT",

--- a/test/scripts/fixtures-workspace.test.ts
+++ b/test/scripts/fixtures-workspace.test.ts
@@ -8,27 +8,25 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 const FIXTURE_SCRIPT = "scripts/e2e/lib/fixture.mjs";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
-function runAgentsDeleteAssert(root: string, outputPath: string, env: Record<string, string> = {}) {
-  return spawnSync(process.execPath, [FIXTURE_SCRIPT, "agents-delete-assert", outputPath], {
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      OPENCLAW_STATE_DIR: path.join(root, "state"),
-      SHARED_WORKSPACE: path.join(root, "workspace"),
-      ...env,
+function runAgentsDeleteAssert(
+  root: string,
+  outputPath: string,
+  agentsPath: string,
+  env: Record<string, string> = {},
+) {
+  return spawnSync(
+    process.execPath,
+    [FIXTURE_SCRIPT, "agents-delete-assert", outputPath, agentsPath],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        OPENCLAW_STATE_DIR: path.join(root, "state"),
+        SHARED_WORKSPACE: path.join(root, "workspace"),
+        ...env,
+      },
     },
-  });
-}
-
-function runAgentsDeleteConfig(root: string) {
-  const stateDir = path.join(root, "state");
-  const workspace = path.join(root, "workspace");
-  mkdirSync(stateDir, { recursive: true });
-  const result = spawnSync(process.execPath, [FIXTURE_SCRIPT, "agents-delete-config"], {
-    encoding: "utf8",
-    env: { ...process.env, OPENCLAW_STATE_DIR: stateDir, SHARED_WORKSPACE: workspace },
-  });
-  return { result, stateDir, workspace };
+  );
 }
 
 function runOpenWebUiWorkspace(workspaceDir: string) {
@@ -42,15 +40,20 @@ function runOpenWebUiWorkspace(workspaceDir: string) {
 }
 
 describe("workspace fixture assertions", () => {
-  it("writes only the shared-workspace ownership inputs needed by the delete smoke", () => {
+  it("requires gateway deletion and retains the shared surviving agent", () => {
     const root = tempDirs.make("openclaw-fixture-workspace-");
-    const { result, stateDir, workspace } = runAgentsDeleteConfig(root);
+    const workspace = path.join(root, "workspace");
+    const outputPath = path.join(root, "agents-delete.json");
+    const agentsPath = path.join(root, "agents.json");
+    mkdirSync(workspace, { recursive: true });
+    writeFileSync(
+      outputPath,
+      `${JSON.stringify({ agentId: "ops", workspace, workspaceRetained: true, workspaceRetainedReason: "shared", workspaceSharedWith: ["alpha"], transport: "gateway" })}\n`,
+    );
+    writeFileSync(agentsPath, `${JSON.stringify([{ id: "alpha", workspace }])}\n`);
 
+    const result = runAgentsDeleteAssert(root, outputPath, agentsPath);
     expect(result.status).toBe(0);
-    expect(JSON.parse(readFileSync(path.join(stateDir, "openclaw.json"), "utf8")).agents).toEqual({
-      ownership: "explicit",
-      entries: { main: { workspace }, ops: { workspace } },
-    });
   });
 
   it("prepares Open WebUI without retired workspace setup state", () => {
@@ -74,6 +77,7 @@ describe("workspace fixture assertions", () => {
   it("rejects oversized agents delete output before parsing it", () => {
     const root = tempDirs.make("openclaw-fixture-workspace-");
     const outputPath = path.join(root, "agents-delete.json");
+    const agentsPath = path.join(root, "agents.json");
     mkdirSync(root, { recursive: true });
     writeFileSync(
       outputPath,
@@ -81,7 +85,7 @@ describe("workspace fixture assertions", () => {
       "utf8",
     );
 
-    const result = runAgentsDeleteAssert(root, outputPath, {
+    const result = runAgentsDeleteAssert(root, outputPath, agentsPath, {
       OPENCLAW_FIXTURE_AGENTS_DELETE_OUTPUT_MAX_BYTES: "1024",
     });
 
@@ -94,6 +98,7 @@ describe("workspace fixture assertions", () => {
   it("bounds invalid agents delete JSON diagnostics", () => {
     const root = tempDirs.make("openclaw-fixture-workspace-");
     const outputPath = path.join(root, "agents-delete.json");
+    const agentsPath = path.join(root, "agents.json");
     mkdirSync(root, { recursive: true });
     writeFileSync(
       outputPath,
@@ -101,7 +106,7 @@ describe("workspace fixture assertions", () => {
       "utf8",
     );
 
-    const result = runAgentsDeleteAssert(root, outputPath, {
+    const result = runAgentsDeleteAssert(root, outputPath, agentsPath, {
       OPENCLAW_FIXTURE_AGENTS_DELETE_OUTPUT_MAX_BYTES: "131072",
     });
 
@@ -111,35 +116,52 @@ describe("workspace fixture assertions", () => {
     expect(result.stderr).not.toContain("DO_NOT_DUMP_OLD_INVALID_JSON");
   });
 
-  it.each([undefined, "local"])(
-    "rejects agents delete output without gateway transport (%s)",
-    (transport) => {
-      const root = tempDirs.make("openclaw-fixture-workspace-");
-      const stateDir = path.join(root, "state");
-      const workspace = path.join(root, "workspace");
-      const outputPath = path.join(root, "agents-delete.json");
-      mkdirSync(stateDir, { recursive: true });
-      mkdirSync(workspace, { recursive: true });
-      writeFileSync(
-        path.join(stateDir, "openclaw.json"),
-        `${JSON.stringify({ agents: { entries: { main: { workspace } } } })}\n`,
-      );
-      writeFileSync(
-        outputPath,
-        `${JSON.stringify({
-          agentId: "ops",
-          workspace,
-          workspaceRetained: true,
-          workspaceRetainedReason: "shared",
-          workspaceSharedWith: ["main"],
-          ...(transport ? { transport } : {}),
-        })}\n`,
-      );
+  it("rejects an agents delete result that explicitly reports local transport", () => {
+    const root = tempDirs.make("openclaw-fixture-workspace-");
+    const workspace = path.join(root, "workspace");
+    const outputPath = path.join(root, "agents-delete.json");
+    const agentsPath = path.join(root, "agents.json");
+    mkdirSync(workspace, { recursive: true });
+    writeFileSync(
+      outputPath,
+      `${JSON.stringify({
+        agentId: "ops",
+        workspace,
+        workspaceRetained: true,
+        workspaceRetainedReason: "shared",
+        workspaceSharedWith: ["alpha"],
+        transport: "local",
+      })}\n`,
+    );
+    writeFileSync(agentsPath, `${JSON.stringify([{ id: "alpha", workspace }])}\n`);
 
-      const result = runAgentsDeleteAssert(root, outputPath);
+    const result = runAgentsDeleteAssert(root, outputPath, agentsPath);
 
-      expect(result.status).not.toBe(0);
-      expect(result.stderr).toContain("transport mismatch");
-    },
-  );
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("transport mismatch");
+  });
+
+  it("rejects deletion output without the gateway transport marker", () => {
+    const root = tempDirs.make("openclaw-fixture-workspace-");
+    const workspace = path.join(root, "workspace");
+    const outputPath = path.join(root, "agents-delete.json");
+    const agentsPath = path.join(root, "agents.json");
+    mkdirSync(workspace, { recursive: true });
+    writeFileSync(
+      outputPath,
+      `${JSON.stringify({
+        agentId: "ops",
+        workspace,
+        workspaceRetained: true,
+        workspaceRetainedReason: "shared",
+        workspaceSharedWith: ["alpha"],
+      })}\n`,
+    );
+    writeFileSync(agentsPath, `${JSON.stringify([{ id: "alpha", workspace }])}\n`);
+
+    const result = runAgentsDeleteAssert(root, outputPath, agentsPath);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("transport mismatch");
+  });
 });


### PR DESCRIPTION
## What Problem This Solves

Full release validation of the frozen 2026.6.35 Docker artifact wrote the current `agents.entries` config directly. That candidate only accepts its shipped `agents.list` representation, so the gateway rejected the harness config before the smoke could exercise deletion.

## Canonical Fix

The trusted harness no longer inspects schemas or writes either representation. It asks the candidate CLI to create `alpha` and `ops` with the same workspace through its stable non-interactive `agents add` command. The candidate therefore writes its own canonical config shape (`agents.list` on 2026.6.35; `agents.entries` on current main). After gateway deletion, the harness checks the stable `agents list --json` result: `ops` is gone and `alpha` still owns the shared workspace.

The smoke still requires the deletion JSON to report `transport: "gateway"`. The frozen candidate already emits that field on its successful gateway path, so accepting a missing field would have weakened the original regression assertion.

## Evidence

- Failed validation: [root Dockerfile smoke job 99668990448](https://github.com/openclaw/openclaw/actions/runs/33446699978/job/99668990448). Candidate `1c01739393b62d8826334153cbac9fe33dcffb65` rejected the harness's `agents.entries` config before gateway startup.
- Candidate `src/config/zod-schema.agents.ts` accepts only `agents.list`; current `src/config/zod-schema.agents.ts` accepts only `agents.entries` plus explicit multi-agent ownership. Both expose the same `agents add <name> --workspace <dir> --non-interactive` and `agents list --json` CLI contracts.
- Candidate `src/commands/agents.commands.delete.ts` includes `transport: "gateway"` in the gateway-success JSON response, as does current main.
- `node scripts/run-vitest.mjs test/scripts/fixtures-workspace.test.ts test/scripts/docker-build-helper.test.ts --testNamePattern='(workspace fixture assertions|runs agents delete shared workspace smoke)'` — 7 assertions passed.
- `bash -n scripts/e2e/agents-delete-shared-workspace-docker.sh`; `actionlint`; `node node_modules/oxfmt/bin/oxfmt --check …`; `git diff --check`; Codex autoreview — passed.
- Direct script lint was blocked before linting by existing unrelated plugin-SDK declaration errors (for example `packages/ai/src/providers/google-shared.ts` references a missing `FinishReason.TOO_MANY_TOOL_CALLS`); this PR changes no dependencies or declarations.

Production delta: trusted E2E harness/fixture +20/-8 lines (net +12); test support +82/-94 lines (net -12). No product-runtime, npm publication, schema, or compatibility change.