### PR TITLE
fix(release): permit core publication with Android handled separately

### DIFF
--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -83,6 +83,11 @@ on:
         required: true
         default: true
         type: boolean
+      publish_android:
+        description: Authorize and dispatch Android APK publication for stable core releases
+        required: true
+        default: true
+        type: boolean
       publish_docker_only:
         description: Publish Docker only after independently verifying an already-published beta, stable, or extended-stable npm package
         required: true
@@ -1250,7 +1255,7 @@ jobs:
             --output "${notes_file}"
 
       - name: Write Android release approval
-        if: ${{ inputs.publish_openclaw_npm && !contains(inputs.tag, '-alpha.') && !contains(inputs.tag, '-beta.') }}
+        if: ${{ inputs.publish_openclaw_npm && inputs.publish_android && !contains(inputs.tag, '-alpha.') && !contains(inputs.tag, '-beta.') }}
         env:
           RELEASE_PUBLISH_BRANCH: ${{ github.ref_name }}
           RELEASE_PUBLISH_FULL_REF: ${{ github.ref }}
@@ -1286,13 +1291,13 @@ jobs:
           NODE
 
       - name: Attest Android release approval
-        if: ${{ inputs.publish_openclaw_npm && !contains(inputs.tag, '-alpha.') && !contains(inputs.tag, '-beta.') }}
+        if: ${{ inputs.publish_openclaw_npm && inputs.publish_android && !contains(inputs.tag, '-alpha.') && !contains(inputs.tag, '-beta.') }}
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: ${{ runner.temp }}/android-release-approval/approval.json
 
       - name: Upload Android release approval
-        if: ${{ inputs.publish_openclaw_npm && !contains(inputs.tag, '-alpha.') && !contains(inputs.tag, '-beta.') }}
+        if: ${{ inputs.publish_openclaw_npm && inputs.publish_android && !contains(inputs.tag, '-alpha.') && !contains(inputs.tag, '-beta.') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: android-release-approval-${{ github.run_id }}
@@ -1321,6 +1326,7 @@ jobs:
           PLUGIN_PUBLISH_SCOPE: ${{ inputs.plugin_publish_scope }}
           PLUGINS: ${{ inputs.plugins }}
           PUBLISH_OPENCLAW_NPM: ${{ inputs.publish_openclaw_npm && 'true' || 'false' }}
+          PUBLISH_ANDROID: ${{ inputs.publish_android && 'true' || 'false' }}
           WAIT_FOR_CLAWHUB: ${{ inputs.wait_for_clawhub && 'true' || 'false' }}
           PREFLIGHT_ARTIFACT_NAME: ${{ needs.resolve_release_target.outputs.preflight_artifact_name }}
           NPM_TELEGRAM_RUN_ID: ${{ inputs.npm_telegram_run_id }}
@@ -1352,7 +1358,11 @@ jobs:
               echo "- OpenClaw npm publish: skipped by input"
             fi
             if is_android_release && [[ "${PUBLISH_OPENCLAW_NPM}" == "true" ]]; then
-              echo "- Android APK: dispatched alongside the OpenClaw npm publish; monitor and approve its run separately, completion does not block core publication"
+              if [[ "${PUBLISH_ANDROID}" == "true" ]]; then
+                echo "- Android APK: dispatched alongside the OpenClaw npm publish; monitor its run separately, completion does not block core publication"
+              else
+                echo "- Android APK: skipped by input (publish_android=false)"
+              fi
             fi
             if is_stable_release && [[ "${PUBLISH_OPENCLAW_NPM}" == "true" ]]; then
               echo "- Windows Hub promotion: promoted concurrently with the OpenClaw npm publish; required before the GitHub release can be published"
@@ -1496,6 +1506,7 @@ jobs:
           PLUGIN_PUBLISH_SCOPE: ${{ inputs.plugin_publish_scope }}
           PLUGINS: ${{ inputs.plugins }}
           PUBLISH_OPENCLAW_NPM: ${{ inputs.publish_openclaw_npm && 'true' || 'false' }}
+          PUBLISH_ANDROID: ${{ inputs.publish_android && 'true' || 'false' }}
           WAIT_FOR_CLAWHUB: ${{ inputs.wait_for_clawhub && 'true' || 'false' }}
           PREFLIGHT_ARTIFACT_NAME: ${{ needs.resolve_release_target.outputs.preflight_artifact_name }}
           NPM_TELEGRAM_RUN_ID: ${{ inputs.npm_telegram_run_id }}

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -598,7 +598,9 @@ release needs:
 4. Dispatch `Plugin NPM Release` with `publish_scope=all-publishable` and `ref=<release-sha>`.
 5. Dispatch `Plugin ClawHub Release` with the same scope and SHA.
 6. Dispatch `OpenClaw NPM Release` with the release tag, npm dist-tag, and saved `preflight_run_id` after verifying the saved `full_release_validation_run_id` and exact run attempt.
-7. Verify the published npm package and selector readback, then call reusable `Docker Release` with the immutable tag and SHA. For stable releases, create or update the GitHub release as a draft, dispatch `Windows Node Release` with the explicit `windows_node_tag` and candidate-approved `windows_node_installer_digests`, and verify the canonical Windows installer/checksum assets. Also dispatch `Android Release` to build the exact-tag signed APK plus checksum and provenance. Finalize the GitHub release after Docker and the Windows asset contract succeed; Android completion is independent and does not hold the core release.
+7. Verify the published npm package and selector readback, then call reusable `Docker Release` with the immutable tag and SHA. For stable releases, create or update the GitHub release as a draft, dispatch `Windows Node Release` with the explicit `windows_node_tag` and candidate-approved `windows_node_installer_digests`, and verify the canonical Windows installer/checksum assets. By default, also dispatch `Android Release` to build the exact-tag signed APK plus checksum and provenance. Pass `publish_android=false` when Android publication is outside the approved release scope. Finalize the GitHub release after Docker and the Windows asset contract succeed; Android completion is independent and does not hold the core release.
+
+Set `-f publish_android=false` on `OpenClaw Release Publish` to omit Android approval, attestation, and child dispatch. The workflow records this exclusion in its summary and release verification notes; npm, plugins, Docker, and Windows retain their normal publication gates. This does not cancel an Android run dispatched by an earlier parent. The explicit failed-publisher closeout recovery path still requires complete platform assets, including Android.
 
 Android approval binds the release tag and target SHA to the approving parent's
 run ID, exact attempt, full ref, and workflow SHA. The child verifies the attested
@@ -610,8 +612,7 @@ completed failed parent. Before provenance publication and each asset upload,
 Android rechecks the live release tag target and stable classification, protected
 tooling identity, and exact parent attempt/state. These are fresh boundary checks,
 not an atomic GitHub validation-and-write transaction. A dispatched run link is
-pending publication evidence, not an APK download claim. Monitor and approve the
-linked Android run separately;
+pending publication evidence, not an APK download claim. Monitor the linked Android run separately;
 if dispatch cannot be confirmed, inspect existing runs before retrying.
 For explicit Android recovery, pass `release_publish_run_attempt`,
 `release_publish_full_ref`, and `release_publish_workflow_sha` from that same
@@ -782,6 +783,7 @@ readback confirms that every exact package and `extended-stable` tag converged.
 - `plugin_publish_scope`: defaults to `all-publishable`; use `selected` only for focused plugin-only repair work with `publish_openclaw_npm=false`
 - `plugins`: comma-separated `@openclaw/*` package names when `plugin_publish_scope=selected`
 - `publish_openclaw_npm`: defaults to `true`; set `false` only when using the workflow as a plugin-only repair orchestrator
+- `publish_android`: defaults to `true`; set `false` to omit Android authorization and publication from this parent run
 - `release_profile`: release coverage profile used for release evidence summaries; defaults to `from-validation`, which reads it from the validation manifest, or override with `beta`, `stable`, or `full`
 - `wait_for_clawhub`: defaults to `false` so npm availability is not blocked by the ClawHub sidecar; set `true` only when workflow completion must include ClawHub completion
 

--- a/scripts/lib/release-publish-children.sh
+++ b/scripts/lib/release-publish-children.sh
@@ -885,6 +885,11 @@ promote_android_release_asset() {
   if ! is_android_release; then
     return 0
   fi
+  if [[ "${PUBLISH_ANDROID:-true}" == "false" ]]; then
+    android_release_note="- Android APK: skipped by input (publish_android=false)"
+    echo "${android_release_note}" >> "${GITHUB_STEP_SUMMARY}"
+    return 0
+  fi
   # Retry-safe: the asset contract is the done-condition, so a prior
   # publish run's verified APK promotion is reused instead of
   # re-running the Android child workflow.

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2412,7 +2412,21 @@ describe("package acceptance workflow", () => {
       "Attest Android release approval",
       "Upload Android release approval",
     ]) {
-      expect(workflowStep(publishJob, stepName).if).toContain("inputs.publish_openclaw_npm");
+      expect(workflowStep(publishJob, stepName).if).toBe(
+        "${{ inputs.publish_openclaw_npm && inputs.publish_android && !contains(inputs.tag, '-alpha.') && !contains(inputs.tag, '-beta.') }}",
+      );
+    }
+
+    expect(
+      readWorkflow(RELEASE_PUBLISH_WORKFLOW).on?.workflow_dispatch?.inputs?.publish_android,
+    ).toMatchObject({
+      type: "boolean",
+      default: true,
+    });
+    for (const stepName of ["Dispatch publish workflows", "Complete publish workflows"]) {
+      expect(workflowStep(publishJob, stepName).env?.PUBLISH_ANDROID).toBe(
+        "${{ inputs.publish_android && 'true' || 'false' }}",
+      );
     }
 
     expect(publishOrchestration.env?.PARENT_WORKFLOW_SHA).toBe("${{ github.sha }}");
@@ -2441,12 +2455,15 @@ describe("package acceptance workflow", () => {
   });
 
   it.each([
-    [false, false],
-    [true, false],
-    [false, true],
+    [false, false, undefined, "v2026.8.1"],
+    [true, false, "true", "v2026.8.1"],
+    [false, true, "true", "v2026.8.1"],
+    [false, false, "false", "v2026.8.1"],
+    [false, true, "false", "v2026.8.1"],
+    [false, false, "true", "v2026.8.1-beta.1"],
   ])(
-    "does not block core publication on Android completion (dispatch failure: %s, existing assets: %s)",
-    (dispatchFailure, assetsVerified) => {
+    "honors Android publication scope without blocking core (dispatch failure: %s, existing assets: %s, enabled: %s, tag: %s)",
+    (dispatchFailure, assetsVerified, publishAndroid, tag) => {
       const script = releasePublishOrchestration(
         workflowJob(RELEASE_PUBLISH_WORKFLOW, "publish"),
       ).run;
@@ -2455,15 +2472,16 @@ describe("package acceptance workflow", () => {
       const end = script.indexOf('if [[ ( -n "${openclaw_npm_run_id}"', start);
       if (start < 0 || end < start) throw new Error("Missing native publication stage");
       const root = tempDirs.make("android-detached-publish-");
+      writeFileSync(join(root, "summary"), "");
       const result = spawnSync(
         "bash",
         [
           "-c",
           `
 set -euo pipefail
-is_android_release() { return 0; }
-verify_android_release_asset_contract() { return ${assetsVerified ? 0 : 1}; }
-dispatch_workflow_at_ref() { ${dispatchFailure ? "return 1" : "echo 456"}; }
+${shellFunctionSource(script, "is_android_release")}
+verify_android_release_asset_contract() { echo assets >> "$RUNNER_TEMP/android-calls"; return ${assetsVerified ? 0 : 1}; }
+dispatch_workflow_at_ref() { echo dispatch >> "$RUNNER_TEMP/android-calls"; ${dispatchFailure ? "return 1" : "echo 456"}; }
 wait_for_run() { echo unexpected-android-wait >&2; return 1; }
 promote_windows_release_assets() { echo 789 > "$RUNNER_TEMP/windows-node-run-id.txt"; }
 ${shellFunctionSource(script, "promote_android_release_asset")}
@@ -2480,12 +2498,13 @@ printf 'core_failed=%s\n' "$failed"
             GITHUB_REPOSITORY: "openclaw/openclaw",
             GITHUB_RUN_ID: "123",
             GITHUB_RUN_ATTEMPT: "2",
-            RELEASE_TAG: "v2026.8.1",
+            RELEASE_TAG: tag,
             TARGET_SHA: "a".repeat(40),
             PARENT_WORKFLOW_BRANCH: "main",
             PARENT_WORKFLOW_FULL_REF: "refs/heads/main",
             PARENT_WORKFLOW_SHA: "d".repeat(40),
             PUBLISH_OPENCLAW_NPM: "true",
+            ...(publishAndroid === undefined ? {} : { PUBLISH_ANDROID: publishAndroid }),
             openclaw_npm_run_id: "",
             clawhub_pid: "",
             clawhub_result: "",
@@ -2498,7 +2517,15 @@ printf 'core_failed=%s\n' "$failed"
       expect(result.stdout).toContain("core_failed=0");
       expect(result.stderr).not.toContain("unexpected-android-wait");
       const summary = readFileSync(join(root, "summary"), "utf8");
-      if (assetsVerified) {
+      expect(readFileSync(join(root, "windows-node-run-id.txt"), "utf8").trim()).toBe("789");
+      if (publishAndroid === "false" || tag.includes("-beta.")) {
+        expect(readdirSync(root)).not.toContain("android-calls");
+        expect(summary).not.toContain("actions/runs/456");
+        expect(summary).not.toContain("previously published assets verified");
+        if (publishAndroid === "false") {
+          expect(summary).toContain("Android APK: skipped by input (publish_android=false)");
+        }
+      } else if (assetsVerified) {
         expect(summary).toContain("previously published assets verified");
         expect(summary).toContain("releases/download/v2026.8.1/OpenClaw-Android.apk");
         expect(summary).not.toContain("actions/runs/456");


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a stable core release would authorize and dispatch Android publication even when the operator had excluded Android from the release scope. Cancelling the child after dispatch cannot safely enforce that scope.

## Why This Change Was Made

Adds the explicit `publish_android` workflow input, defaulting to `true`. Setting it to `false` suppresses Android approval creation, attestation, upload, asset checks, and child dispatch, and records the exclusion in the publisher summary and release verification notes. Windows promotion and the npm, plugin, and Docker gates retain their existing behavior.

## User Impact

Release operators can publish core with Android handled separately by passing `-f publish_android=false`. Default stable releases continue to dispatch Android. Existing Android runs are unaffected; the explicit failed-publisher closeout recovery path still requires complete platform assets.

## Evidence

- Extended the existing executable publication fixture: both opt-out cases fail on the prior code because Android asset checks still execute; all eight focused checks pass after the change. Coverage retains default stable dispatch, verified-asset reuse, dispatch failure, beta non-dispatch, and Windows promotion.
- Parsed workflow checks bind the input default and both publisher phases, and require all three Android authority-artifact steps to honor the opt-out.
- `node scripts/check-changed.mjs` passed, including test-root typechecking and script lint.
- `pnpm check:workflows` passed with Python 3.12, including actionlint, zizmor, and repository guards. The initial local invocation used the system Python, which could not install the pinned pre-commit version; no checker or dependency pin changed.
- Independent Codex P0–P2 review found no actionable findings. Subsequent edits only corrected the summary and matching documentation to say “monitor” rather than imply an additional Android approval gate.
- No release was published during this proof. Product code and closeout policy are unchanged; this adds one operator-controlled publication capability to release tooling.
