### PR TITLE
fix(build): bind declaration caches to plugin selection

### DIFF
--- a/scripts/build-all.mts
+++ b/scripts/build-all.mts
@@ -33,6 +33,7 @@ import {
   TSDOWN_DECLARATION_EXTENSIONS,
   TSDOWN_DECLARATION_TOOL_INPUTS,
   TSDOWN_PACKAGES_CACHE_INPUT,
+  TSDOWN_UNIFIED_CACHE_ENV,
   TSDOWN_UNIFIED_CACHE_INPUTS,
   resolveTsdownBuildPlan,
   type MemoryLimitParams,
@@ -127,7 +128,7 @@ export const BUILD_ALL_STEPS: BuildAllStep[] = [
       ...TSDOWN_NON_SDK_DTS_CONFIG_GROUPS.flatMap((group) => ["--filter", group]),
     ),
     cache: {
-      env: ["OPENCLAW_BUILD_PRIVATE_QA", "OPENCLAW_RUN_NODE_SKIP_DTS_BUILD"],
+      env: [...TSDOWN_UNIFIED_CACHE_ENV, "OPENCLAW_RUN_NODE_SKIP_DTS_BUILD"],
       inputs: TSDOWN_UNIFIED_CACHE_INPUTS,
       outputs: declarationCacheOutputs(["dist"]),
       // Shared declaration snapshots cannot make a replaced live dist complete.

--- a/scripts/lib/bundled-plugin-build-entries.mjs
+++ b/scripts/lib/bundled-plugin-build-entries.mjs
@@ -7,7 +7,10 @@ import {
   bundledDistPluginFile,
   bundledPluginFile,
 } from "./bundled-plugin-paths.mjs";
-import { shouldBuildBundledCluster } from "./optional-bundled-clusters.mjs";
+import {
+  OPTIONAL_BUNDLED_BUILD_ENV,
+  shouldBuildBundledCluster,
+} from "./optional-bundled-clusters.mjs";
 import { collectRootPackageExcludedExtensionDirs } from "./root-package-bundled-plugin-excludes.mjs";
 
 export { collectRootPackageExcludedExtensionDirs };
@@ -19,6 +22,12 @@ const EXCLUDED_CORE_BUNDLED_PLUGIN_DIRS = new Set(["qqbot", "whatsapp"]);
 const BUNDLED_PLUGIN_BUILD_IDS_ENV = "OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS";
 /** @internal Shared repository-script contract. */
 export const DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV = "OPENCLAW_INTERNAL_DOCKER_BUILD_PLUGIN_IDS";
+// Declaration caches must distinguish every selector that changes this entry graph.
+export const BUNDLED_PLUGIN_BUILD_ENV_NAMES = [
+  BUNDLED_PLUGIN_BUILD_IDS_ENV,
+  DOCKER_SELECTED_PLUGIN_BUILD_IDS_ENV,
+  OPTIONAL_BUNDLED_BUILD_ENV,
+];
 const PLUGIN_ID_RE = /^[a-z0-9][a-z0-9-]*$/u;
 const TOP_LEVEL_PRIVATE_TEST_SURFACE_RE =
   /(?:^|[._-])(?:test|spec|test-support|test-helpers|test-fixtures|test-harness|mock-setup)(?:[._-]|$)/u;

--- a/scripts/lib/optional-bundled-clusters.mjs
+++ b/scripts/lib/optional-bundled-clusters.mjs
@@ -21,7 +21,7 @@ const optionalBundledClusters = [
  */
 export const optionalBundledClusterSet = new Set(optionalBundledClusters);
 
-const OPTIONAL_BUNDLED_BUILD_ENV = "OPENCLAW_INCLUDE_OPTIONAL_BUNDLED";
+export const OPTIONAL_BUNDLED_BUILD_ENV = "OPENCLAW_INCLUDE_OPTIONAL_BUNDLED";
 
 function isOptionalBundledCluster(cluster) {
   return optionalBundledClusterSet.has(cluster);

--- a/scripts/tsdown-build.mts
+++ b/scripts/tsdown-build.mts
@@ -14,6 +14,7 @@ import os from "node:os";
 import path from "node:path";
 import { isPathInside } from "@openclaw/fs-safe/path";
 import { decodeMountInfoPath } from "../packages/normalization-core/src/mountinfo-path.ts";
+import { BUNDLED_PLUGIN_BUILD_ENV_NAMES } from "./lib/bundled-plugin-build-entries.mjs";
 import { BUNDLED_PLUGIN_PATH_PREFIX } from "./lib/bundled-plugin-paths.mjs";
 import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import {
@@ -126,6 +127,10 @@ export const TSDOWN_PACKAGES_CACHE_INPUT = {
   extensions: TSDOWN_SOURCE_EXTENSIONS,
   excludeDirectories: ["dist", "node_modules"],
 };
+export const TSDOWN_UNIFIED_CACHE_ENV = [
+  "OPENCLAW_BUILD_PRIVATE_QA",
+  ...BUNDLED_PLUGIN_BUILD_ENV_NAMES,
+];
 export const TSDOWN_UNIFIED_CACHE_INPUTS = [
   ...TSDOWN_DECLARATION_TOOL_INPUTS,
   "tsdown.config.ts",

--- a/scripts/write-plugin-sdk-entry-dts.ts
+++ b/scripts/write-plugin-sdk-entry-dts.ts
@@ -9,6 +9,7 @@ import { TSDOWN_PLUGIN_SDK_DTS_CONFIG_GROUPS } from "./lib/tsdown-config-groups.
 import {
   prepareTsdownBuildExecution,
   TSDOWN_DECLARATION_EXTENSIONS,
+  TSDOWN_UNIFIED_CACHE_ENV,
   TSDOWN_UNIFIED_CACHE_INPUTS,
 } from "./tsdown-build.mts";
 
@@ -67,7 +68,7 @@ try {
     const step: BuildCacheStep = {
       label: "tsdown-plugin-sdk",
       cache: {
-        env: ["OPENCLAW_BUILD_PRIVATE_QA"],
+        env: TSDOWN_UNIFIED_CACHE_ENV,
         inputs: [
           ...TSDOWN_UNIFIED_CACHE_INPUTS,
           "scripts/write-plugin-sdk-entry-dts.ts",

--- a/test/scripts/build-all.test.ts
+++ b/test/scripts/build-all.test.ts
@@ -26,6 +26,7 @@ import {
   restoreBuildStepCacheOutputs,
   finalizeBuildStepCache,
 } from "../../scripts/lib/build-artifact-cache.mts";
+import { listBundledPluginBuildEntries } from "../../scripts/lib/bundled-plugin-build-entries.mjs";
 import { listPluginSdkDistArtifacts } from "../../scripts/lib/plugin-sdk-entries.mts";
 import {
   TSDOWN_NON_SDK_DTS_CONFIG_GROUPS,
@@ -1227,6 +1228,52 @@ describe("resolveBuildStepCacheState", () => {
       fs.rmSync(rootDir, { force: true, recursive: true });
     }
   });
+
+  it.each<{ name: string; before: NodeJS.ProcessEnv; after: NodeJS.ProcessEnv }>([
+    { name: "bounded plugins", before: { OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS: "plain" }, after: {} },
+    { name: "optional plugins", before: { OPENCLAW_INCLUDE_OPTIONAL_BUNDLED: "0" }, after: {} },
+    {
+      name: "Docker plugins",
+      before: {},
+      after: { OPENCLAW_INTERNAL_DOCKER_BUILD_PLUGIN_IDS: "external" },
+    },
+  ])(
+    "invalidates declaration signatures when $name change the real entry graph",
+    ({ before, after }) => {
+      withBuildCacheFixture(({ rootDir }) => {
+        for (const id of ["plain", "acpx", "external"]) {
+          const directory = path.join(rootDir, "extensions", id);
+          fs.mkdirSync(directory, { recursive: true });
+          fs.writeFileSync(path.join(directory, "openclaw.plugin.json"), JSON.stringify({ id }));
+          fs.writeFileSync(path.join(directory, "index.ts"), "export {};\n");
+          fs.writeFileSync(
+            path.join(directory, "package.json"),
+            JSON.stringify({
+              name: `@openclaw/${id}`,
+              openclaw: { build: { bundledDist: id !== "external" } },
+            }),
+          );
+        }
+        expect(listBundledPluginBuildEntries({ cwd: rootDir, env: after })).not.toEqual(
+          listBundledPluginBuildEntries({ cwd: rootDir, env: before }),
+        );
+        const unified = getBuildAllStep("tsdown-unified");
+        const initial = resolveBuildStepCacheState(unified, { rootDir, env: before });
+        expect(resolveBuildStepCacheState(unified, { rootDir, env: after }).signature).not.toBe(
+          initial.signature,
+        );
+        expect(resolveBuildStepCacheState(unified, { rootDir, env: before }).signature).toBe(
+          initial.signature,
+        );
+        for (const label of ["tsdown-ai", "tsdown-packages"]) {
+          const step = getBuildAllStep(label);
+          expect(resolveBuildStepCacheState(step, { rootDir, env: after }).signature).toBe(
+            resolveBuildStepCacheState(step, { rootDir, env: before }).signature,
+          );
+        }
+      });
+    },
+  );
 
   it("marks cacheable steps fresh when the input signature matches", () => {
     withBuildCacheFixture(({ rootDir, step }) => {

--- a/test/scripts/write-plugin-sdk-entry-dts.test.ts
+++ b/test/scripts/write-plugin-sdk-entry-dts.test.ts
@@ -28,12 +28,16 @@ const declarationInputs = [
   { file: "src/actual.cts", specifier: "../actual.cjs", name: "EmittedCts" },
 ] as const;
 
-function runFixture(root: string, args: string[], privateQa = false) {
+function runFixture(root: string, args: string[], privateQa = false, env: NodeJS.ProcessEnv = {}) {
   return spawnSync(process.execPath, args, {
     cwd: root,
     encoding: "utf8",
     env: {
       ...process.env,
+      OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS: undefined,
+      OPENCLAW_INTERNAL_DOCKER_BUILD_PLUGIN_IDS: undefined,
+      OPENCLAW_INCLUDE_OPTIONAL_BUNDLED: undefined,
+      ...env,
       OPENCLAW_BUILD_PRIVATE_QA: privateQa ? "1" : "0",
       OPENCLAW_RUN_NODE_SKIP_DTS_BUILD: "0",
       // Use the build owner's existing direct-tool path, without a fixture pnpm shim.
@@ -207,8 +211,8 @@ function createFixture() {
   };
 }
 
-function runWriter(root: string, privateQa = false) {
-  return runFixture(root, ["--import", loader, writer], privateQa);
+function runWriter(root: string, privateQa = false, env: NodeJS.ProcessEnv = {}) {
+  return runFixture(root, ["--import", loader, writer], privateQa, env);
 }
 
 function treeHashes(root: string) {
@@ -259,6 +263,55 @@ function expectStagingClean(root: string) {
 }
 
 describe("write-plugin-sdk-entry-dts", () => {
+  it.each<{ name: string; badPlugin: string; before: NodeJS.ProcessEnv; after: NodeJS.ProcessEnv }>(
+    [
+      {
+        name: "bounded plugins",
+        badPlugin: "broken",
+        before: { OPENCLAW_BUNDLED_PLUGIN_BUILD_IDS: "plain" },
+        after: {},
+      },
+      {
+        name: "optional plugins",
+        badPlugin: "acpx",
+        before: { OPENCLAW_INCLUDE_OPTIONAL_BUNDLED: "0" },
+        after: {},
+      },
+      {
+        name: "Docker plugins",
+        badPlugin: "external",
+        before: {},
+        after: { OPENCLAW_INTERNAL_DOCKER_BUILD_PLUGIN_IDS: "external" },
+      },
+    ],
+  )(
+    "rejects newly selected $name instead of restoring their previous SDK cache",
+    ({ badPlugin, before, after }) => {
+      const { root, write } = createFixture();
+      for (const id of ["plain", badPlugin]) {
+        write(`extensions/${id}/openclaw.plugin.json`, JSON.stringify({ id }));
+        write(
+          `extensions/${id}/package.json`,
+          JSON.stringify({
+            name: `@openclaw/${id}`,
+            openclaw: { build: { bundledDist: id !== "external" } },
+          }),
+        );
+        if (id !== badPlugin) {
+          write(`extensions/${id}/index.ts`, "export {};\n");
+        }
+      }
+      const initial = runWriter(root, false, before);
+      expect(initial.status, initial.stdout + initial.stderr).toBe(0);
+      const published = treeHashes(path.join(root, "dist"));
+      const selected = runWriter(root, false, after);
+      expect(selected.status, selected.stdout + selected.stderr).toBeGreaterThan(0);
+      expect(selected.stdout + selected.stderr).toContain(`extensions/${badPlugin}/index.ts`);
+      expect(treeHashes(path.join(root, "dist"))).toEqual(published);
+      expectStagingClean(root);
+    },
+  );
+
   it("publishes fresh canonical partitions with stable bytes and public nominal identity", () => {
     const { root, write, writeDeclarations, production, qa } = createFixture();
     expect(production).toEqual(


### PR DESCRIPTION
## Why

Declaration caches could return artifacts built for a different bundled-plugin selection. The entry selector already honors bounded, Docker, and optional-plugin build settings, but the unified and SDK declaration cache signatures omitted those inputs. In the actual repository, selecting 88 plugins / 731 entries and selecting one plugin / six entries produced the same old signature.

## Change

Expose the existing selector names from their canonical owner and share that semantic-input list through the existing tsdown cache metadata. Both declaration cache consumers now invalidate when the selected plugin graph changes. There are no new options, cache mechanisms, compiler shortcuts, or changes to output guards. Existing cache stamps naturally invalidate once through their changed signature.

Production/tooling is +20 / -4 (net +16), which is one shared input list and its two consumers; tests are +103 / -3. Runtime behavior and the AI/workspace declaration groups are unchanged. No release speedup is claimed by this correctness repair: safe reuse first requires complete cache identity.

## Proof

- Six regressions failed on the original owners and pass on this change. They exercise the real selector and installed compiler: warm the SDK cache while a missing plugin entry is excluded, then select that entry without changing the source inventory. The old writer incorrectly returned cached success; the repaired writer rebuilds and rejects the missing entry while preserving published output and cleaning staging/lock state.
- 330 tests passed across six owner/sibling suites, including signature identity, exact snapshot restoration, tamper rejection, live SDK prerequisites, and staged declaration publication.
- Exact-head [CI 33449151798](https://github.com/openclaw/openclaw/actions/runs/33449151798) passed on `7265d60b84b5fc1f240652ab9be82938d48cc720`, including the required `openclaw/ci-gate`.
- All 18 commands selected by the actual seven-path changed-file gate passed, including scripts/test types and canonical lint. Independent managed review found no actionable P0–P2 findings.
- The actual repository now produces distinct signatures for 88/731 and 1/6 selections, while repeating the same selection is stable.

An earlier syntax-error fixture was rejected as an invalid oracle: the installed declaration plugin intentionally stubs sources outside its selected declaration set. The final regression uses its complete input-resolution contract instead; this change does not widen syntax validation.

Broader package cache reuse remains separate work: requested versus resolved Node identity, DTS mode normalization, nested trusted-harness inventory, and cleaned live outputs must be reconciled without weakening the staged-output contract.

The completed ClawSweeper review found no actionable defects. Its intentional one-time cache invalidation is accepted: rebuilding is required to stop restoring declarations for a different plugin selection. Exact-head CI and independent managed P0–P2 review passed. Landed as `3e67e3a64bc44aa49cd972440fdef3fd25e19871`.
