### PR TITLE
fix(macos): stop cookie sync crash-loop from MainActor isolation on dispatch handlers

### DIFF
--- a/apps/macos/Sources/OpenClaw/CookieSyncManager.swift
+++ b/apps/macos/Sources/OpenClaw/CookieSyncManager.swift
@@ -24,6 +24,16 @@ final class CookieSyncManager: NSObject {
         let endpoint: Endpoint
     }
 
+    // `CookieSyncManager` is @MainActor and not Sendable, so its off-main DispatchSource
+    // handlers below (explicitly @Sendable to avoid inheriting @MainActor isolation and
+    // trapping on entry when Dispatch invokes them on `queue`) cannot capture `self`
+    // directly. They read `manager` only from inside a `Task { @MainActor in }` hop, so a
+    // plain unsynchronized weak reference is safe here.
+    private final class OwnerRef: @unchecked Sendable {
+        weak var manager: CookieSyncManager?
+        init(_ manager: CookieSyncManager) { self.manager = manager }
+    }
+
     static let shared = CookieSyncManager()
 
     private(set) var state: State = .stopped
@@ -31,6 +41,7 @@ final class CookieSyncManager: NSObject {
 
     @ObservationIgnored private let logger = Logger(subsystem: "ai.openclaw", category: "cookie-sync")
     @ObservationIgnored private let queue = DispatchQueue(label: "ai.openclaw.cookie-sync")
+    @ObservationIgnored private lazy var ownerRef = OwnerRef(self)
     @ObservationIgnored private weak var appState: AppState?
     @ObservationIgnored private var endpointState: GatewayEndpointState?
     @ObservationIgnored private var endpointTask: Task<Void, Never>?
@@ -43,7 +54,7 @@ final class CookieSyncManager: NSObject {
     @ObservationIgnored private var stderrSource: DispatchSourceRead?
     @ObservationIgnored private var startupWatchdog: DispatchSourceTimer?
     @ObservationIgnored private var stdoutBuffer = Data()
-    @ObservationIgnored private var processGeneration: UUID?
+    @ObservationIgnored var processGeneration: UUID?
     @ObservationIgnored private var runningIntent: SyncIntent?
     @ObservationIgnored private var reconcileGeneration: UInt64 = 0
     @ObservationIgnored private var retryAttempt = 0
@@ -235,12 +246,14 @@ final class CookieSyncManager: NSObject {
             environment["OPENCLAW_GATEWAY_PASSWORD"] = password
         }
         process.environment = environment
-        process.terminationHandler = { [weak self] process in
+        let owner = self.ownerRef
+        let terminationHandler: @Sendable (Process) -> Void = { process in
             let terminationStatus = process.terminationStatus
-            Task { @MainActor [weak self] in
-                self?.childTerminated(generation: generation, status: terminationStatus)
+            Task { @MainActor in
+                owner.manager?.childTerminated(generation: generation, status: terminationStatus)
             }
         }
+        process.terminationHandler = terminationHandler
 
         self.process = process
         self.stdoutPipe = stdoutPipe
@@ -264,44 +277,53 @@ final class CookieSyncManager: NSObject {
         }
     }
 
-    private func installReadSources(stdoutPipe: Pipe, stderrPipe: Pipe, generation: UUID) {
+    func installReadSources(stdoutPipe: Pipe, stderrPipe: Pipe, generation: UUID) {
+        let owner = self.ownerRef
+
         let stdoutDescriptor = stdoutPipe.fileHandleForReading.fileDescriptor
         let stdoutSource = DispatchSource.makeReadSource(fileDescriptor: stdoutDescriptor, queue: self.queue)
-        stdoutSource.setEventHandler { [weak self] in
-            let data = Self.readAvailable(fileDescriptor: stdoutDescriptor, byteCount: stdoutSource.data)
-            Task { @MainActor [weak self] in
-                self?.consumeStdout(data, generation: generation)
+        // Can't capture `stdoutSource` here to size the read off `source.data`: it isn't
+        // Sendable, and this handler is explicitly @Sendable (see installReadSources doc).
+        // Reading up to the existing 64KB cap unconditionally is a harmless simplification.
+        let stdoutHandler: @Sendable () -> Void = {
+            let data = Self.readAvailable(fileDescriptor: stdoutDescriptor)
+            Task { @MainActor in
+                owner.manager?.consumeStdout(data, generation: generation)
             }
         }
+        stdoutSource.setEventHandler(handler: stdoutHandler)
         self.stdoutSource = stdoutSource
         stdoutSource.resume()
 
         let stderrDescriptor = stderrPipe.fileHandleForReading.fileDescriptor
         let stderrSource = DispatchSource.makeReadSource(fileDescriptor: stderrDescriptor, queue: self.queue)
-        stderrSource.setEventHandler { [weak self] in
-            let data = Self.readAvailable(fileDescriptor: stderrDescriptor, byteCount: stderrSource.data)
-            Task { @MainActor [weak self] in
-                self?.consumeStderr(data, generation: generation)
+        let stderrHandler: @Sendable () -> Void = {
+            let data = Self.readAvailable(fileDescriptor: stderrDescriptor)
+            Task { @MainActor in
+                owner.manager?.consumeStderr(data, generation: generation)
             }
         }
+        stderrSource.setEventHandler(handler: stderrHandler)
         self.stderrSource = stderrSource
         stderrSource.resume()
     }
 
     private func installStartupWatchdog(generation: UUID) {
+        let owner = self.ownerRef
         let timer = DispatchSource.makeTimerSource(queue: self.queue)
         timer.schedule(deadline: .now() + 5)
-        timer.setEventHandler { [weak self] in
-            Task { @MainActor [weak self] in
-                guard let self, self.processGeneration == generation else { return }
-                self.startupWatchdog?.cancel()
-                self.startupWatchdog = nil
-                if self.process?.isRunning == true {
-                    self.retryAttempt = 0
-                    self.logger.debug("cookie sync startup watchdog passed")
+        let handler: @Sendable () -> Void = {
+            Task { @MainActor in
+                guard let manager = owner.manager, manager.processGeneration == generation else { return }
+                manager.startupWatchdog?.cancel()
+                manager.startupWatchdog = nil
+                if manager.process?.isRunning == true {
+                    manager.retryAttempt = 0
+                    manager.logger.debug("cookie sync startup watchdog passed")
                 }
             }
         }
+        timer.setEventHandler(handler: handler)
         self.startupWatchdog = timer
         timer.resume()
     }
@@ -399,8 +421,8 @@ final class CookieSyncManager: NSObject {
         self.state = nextState
     }
 
-    private nonisolated static func readAvailable(fileDescriptor: Int32, byteCount: UInt) -> Data {
-        let count = max(1, min(Int(byteCount), 64 * 1024))
+    private nonisolated static func readAvailable(fileDescriptor: Int32) -> Data {
+        let count = 64 * 1024
         var data = Data(count: count)
         let bytesRead = data.withUnsafeMutableBytes { buffer in
             Darwin.read(fileDescriptor, buffer.baseAddress, count)

--- a/apps/macos/Sources/OpenClaw/CookieSyncManager.swift
+++ b/apps/macos/Sources/OpenClaw/CookieSyncManager.swift
@@ -24,14 +24,16 @@ final class CookieSyncManager: NSObject {
         let endpoint: Endpoint
     }
 
-    // `CookieSyncManager` is @MainActor and not Sendable, so its off-main DispatchSource
-    // handlers below (explicitly @Sendable to avoid inheriting @MainActor isolation and
-    // trapping on entry when Dispatch invokes them on `queue`) cannot capture `self`
-    // directly. They read `manager` only from inside a `Task { @MainActor in }` hop, so a
-    // plain unsynchronized weak reference is safe here.
+    /// `CookieSyncManager` is @MainActor and not Sendable, so its off-main DispatchSource
+    /// handlers below (explicitly @Sendable to avoid inheriting @MainActor isolation and
+    /// trapping on entry when Dispatch invokes them on `queue`) cannot capture `self`
+    /// directly. They read `manager` only from inside a `Task { @MainActor in }` hop, so a
+    /// plain unsynchronized weak reference is safe here.
     private final class OwnerRef: @unchecked Sendable {
         weak var manager: CookieSyncManager?
-        init(_ manager: CookieSyncManager) { self.manager = manager }
+        init(_ manager: CookieSyncManager) {
+            self.manager = manager
+        }
     }
 
     static let shared = CookieSyncManager()

--- a/apps/macos/Tests/OpenClawIPCTests/CookieSyncManagerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/CookieSyncManagerTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+#if canImport(Darwin)
+@MainActor
+struct CookieSyncManagerTests {
+    @Test func `stdout read handler survives being invoked off the main actor`() async throws {
+        let manager = CookieSyncManager()
+        let generation = UUID()
+        manager.processGeneration = generation
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        manager.installReadSources(stdoutPipe: stdoutPipe, stderrPipe: stderrPipe, generation: generation)
+
+        try stdoutPipe.fileHandleForWriting.write(contentsOf: Data("hello\n".utf8))
+        try stdoutPipe.fileHandleForWriting.close()
+        try stderrPipe.fileHandleForWriting.close()
+
+        for _ in 0..<100 where manager.lastSummary != "hello" {
+            try await Task.sleep(for: .milliseconds(20))
+        }
+        #expect(manager.lastSummary == "hello")
+    }
+}
+#endif


### PR DESCRIPTION
## What Problem This Solves

Fixes #134430.

With Cookie sync enabled, the macOS app crash-loops with `EXC_BREAKPOINT
(SIGTRAP)` on the `ai.openclaw.cookie-sync` dispatch queue a few seconds
after every launch, as soon as the supervised `openclaw browser cookie-sync
--watch` child writes to stdout or stderr. Disabling the feature (via a shell
`defaults write`, since the app doesn't stay up long enough to reach
Settings) is the only recovery.

`CookieSyncManager` is `@MainActor`. Its stdout/stderr `DispatchSourceRead`
event handlers (`installReadSources`), the startup watchdog timer
(`installStartupWatchdog`), and the process termination handler (`launch`)
are all written as plain trailing closures inside `@MainActor` methods, but
each is registered on `self.queue`, a private background
`DispatchQueue`. A closure literal written inside an actor-isolated context
inherits that actor's isolation unless it is explicitly `@Sendable` — so
each of these handlers carries a `@MainActor` runtime isolation check that
Dispatch invokes on the background queue. The check fails and traps
(`dispatch_assert_queue_fail` → `swift_task_isCurrentExecutorWithFlags` →
the handler closure), exactly matching the crash reports attached to the
issue. The `Task { @MainActor in ... } ` hop inside each handler was already
correct; it's just unreachable.

## Why This Change Was Made

The three handlers are marked explicitly `@Sendable` so they no longer
inherit `@MainActor` isolation and can run on the background queue without
tripping the runtime check. Since `CookieSyncManager` is `@MainActor` and
not `Sendable`, a `@Sendable` closure cannot capture `self` (even weakly)
directly — a small private `OwnerRef: @unchecked Sendable` weak-reference
box is added so the handlers can still route back to the manager, and each
still does its actual work inside a `Task { @MainActor in ... }` hop, same
as before.

One related, smaller change: the stdout/stderr handlers previously read
`stdoutSource.data` / `stderrSource.data` to size the read (an estimate of
bytes available). `DispatchSourceRead` isn't `Sendable` either, so the new
`@Sendable` handlers can't capture the source object to read that property.
`readAvailable` already clamped to a 64KB cap regardless, so the handlers
now just read up to that existing cap unconditionally — a harmless
simplification, not a behavior change for any realistic line size.

Net diff: +45/-23 in `CookieSyncManager.swift`, +27 in a new test file.

## User Impact

The Cookie sync feature (opt-in, off by default) no longer crash-loops the
macOS app once enabled and the supervised child produces any output.

## Evidence

This is a Swift Package (`platforms: [.macOS(.v15)]`, AppKit/Darwin-only)
and cannot be built or tested in this Linux agent sandbox:

```
$ swift build --target OpenClaw
...
OpenClawCameraPTZNative.m:3:9: fatal error: 'CoreFoundation/CoreFoundation.h' file not found
```

Confirmed this is pre-existing and unrelated to this change by stashing the
fix and re-running the identical build on unmodified `main` — same failure,
same file, before reaching any of the touched sources. Swift
lint/format/build/test for `apps/macos` run only on macOS CI runners per
this repo's `AGENTS.md`.

Given that, I extracted the exact isolation-relevant shape into a
standalone, directly-executed Swift program (Swift's `Dispatch` module is
cross-platform and available on this Linux sandbox's toolchain, `swift
6.3.3`), reproducing the bug and the fix byte-for-byte at the level that
actually matters here — Swift's actor-isolation runtime check — without
needing AppKit:

**Pre-fix shape** (a `@MainActor` class, `DispatchSource.makeReadSource`
handler with `[weak self]`, registered on a private background queue,
exactly like current `CookieSyncManager.installReadSources`): writing a
byte to a real pipe and letting the read source fire crashes the process,
twice in a row, with the identical signature reported in the issue:

```
Thread 3 crashed:
  0   _dispatch_assert_queue_fail + 82 in libdispatch.so
  1   dispatch_assert_queue.cold.1 + 102 in libdispatch.so
  2   dispatch_assert_queue + 118 in libdispatch.so
  3   _swift_task_checkIsolatedSwift + 18 in libswift_Concurrency.so
  4   swift_task_isCurrentExecutorWithFlags + 409 in libswift_Concurrency.so
  5   closure #1 in PreFixManager.install(fd:) + 144 in repro2
  ...
  8   _dispatch_source_invoke + 2373 in libdispatch.so
```

**Post-fix shape** (identical scenario, but the handler is explicitly typed
`@Sendable` and routes back to the manager through an `@unchecked Sendable`
weak-owner box, exactly like the actual diff): compiles clean under
`-strict-concurrency=complete -swift-version 6`, and running it delivers the
byte all the way through to `@MainActor` state with no crash:

```
$ ./repro-fixed
start
receivedByte=Optional(65)
did not crash
```

This also caught a real mistake in an earlier draft of this fix: an
`@Sendable`-typed handler that captured the `DispatchSourceRead` object
itself (to read `.data`) fails to compile — `any DispatchSourceRead` isn't
`Sendable` — which is why the final diff drops that capture instead (see
"Why This Change Was Made" above).

### Test

`apps/macos/Tests/OpenClawIPCTests/CookieSyncManagerTests.swift` is a new
`@testable import OpenClaw` test that drives the real, unmodified
production code path directly: it constructs a `CookieSyncManager`, calls
the actual `installReadSources`, writes to a real `Pipe`, and asserts the
data is observed on `lastSummary` — i.e., it exercises the exact closures
this PR changes, on a real background dispatch queue, and will crash the
whole test binary pre-fix (the same isolation trap reproduced above) rather
than merely fail an assertion. `installReadSources` and `processGeneration`
are widened from `private` to internal (module-visible only) so the test
can drive them directly; no other production behavior changes.

I could not run this test in this sandbox (same Darwin/AppKit build
constraint as above) — checking out the pre-fix source
(`git checkout HEAD~1 -- CookieSyncManager.swift`) with the new test file
in place confirms the test references `manager.processGeneration =` and
`manager.installReadSources(...)`, both `private` before this change, so it
does not even compile against the old source, only against the fix.
Real-device/macOS-CI verification of the runtime crash fix is still needed
and is exactly what the standalone reproduction above was built to
de-risk in advance.

### AI-assistance disclosure

This PR was prepared by an autonomous coding agent (Claude/Claude Code)
against the issue text and the shipped source, with a standalone Swift
program written and executed to directly verify both the crash mechanism
and the fix under Swift 6 strict concurrency, since the actual macOS target
cannot be built in this environment.


### Native macOS CI proof (added post-review)

`macos-swift (tests)` ran the added test on a real macOS runner against
this PR's head (`a4eb662d2a1`, https://github.com/openclaw/openclaw/actions/runs/33530429024/job/99932620707):

```
◇ Suite CookieSyncManagerTests started.
◇ Test "stdout read handler survives being invoked off the main actor" started.
✔ Test "stdout read handler survives being invoked off the main actor" passed after 1.123 seconds.
✔ Suite CookieSyncManagerTests passed after 1.141 seconds.
```

That test calls the real, unmodified `CookieSyncManager.installReadSources`
(the exact patched method), writes to a real `Pipe` from the background
dispatch queue, and observes the data land on `@MainActor` state — the same
isolation-crossing this PR fixes, now exercised on actual Darwin/macOS
rather than the standalone Linux Dispatch repro in the body above. This is
a `swift test` unit-target run, not the full app driving a live
`cookie-sync --watch` child process, so it doesn't replace an end-to-end
app run — but no macOS runner/device is available in this sandbox to go
further than that.
