### PR TITLE
fix(logs): JSON error summaries hide the actual failure reason

### DIFF
--- a/docs/cli/logs.md
+++ b/docs/cli/logs.md
@@ -66,6 +66,8 @@ In `--json` mode, invalid `--port`, `--limit`, `--interval`, or `--max-bytes` va
 
 In text mode, terminal log-fetch failures print the redacted error reason, selected Gateway connection details, and a doctor hint on stderr. A received RPC rejection is shown as the error, rather than reported as a Gateway reachability failure.
 
+In JSON mode, terminal log-fetch errors use the same redacted failure reason for `message` and `error`, including RPC rejections, timeouts, disconnects, and invalid response payloads. The record retains connection `details` and a doctor `hint` on stderr; the command still exits with status `1`.
+
 ## Related
 
 - [Logging overview](/logging)

--- a/src/cli/logs-cli.port.test.ts
+++ b/src/cli/logs-cli.port.test.ts
@@ -17,7 +17,11 @@ import { registerLogsCli } from "./logs-cli.js";
 afterEach(() => vi.restoreAllMocks());
 
 async function withLogsGateway(
-  options: { source?: "config" | "environment"; denied?: boolean },
+  options: {
+    source?: "config" | "environment";
+    denied?: boolean;
+    failure?: "timeout" | "disconnect" | "malformed";
+  },
   run: (fixture: {
     port: string;
     requests: string[];
@@ -58,6 +62,12 @@ async function withLogsGateway(
               frame.id,
               buildMinimalGatewayHelloOkPayload({ methods: ["logs.tail"] }),
             );
+          } else if (options.failure) {
+            if (options.failure === "disconnect") {
+              socket.terminate();
+            } else if (options.failure === "malformed") {
+              sendMinimalGatewayResponse(socket, frame.id, null);
+            }
           } else if (options.denied) {
             socket.send(
               JSON.stringify({
@@ -134,7 +144,7 @@ describe("logs local port selection", () => {
         if (mode === "json") {
           expect(JSON.parse(output)).toMatchObject({
             type: "error",
-            message: "Gateway not reachable. Is it running and accessible?",
+            message: "logs unavailable for this client",
             error: "logs unavailable for this client",
             details: { url: `ws://127.0.0.1:${port}` },
           });
@@ -142,6 +152,37 @@ describe("logs local port selection", () => {
           expect(output).not.toContain("Gateway not reachable");
           expect(output).toContain(`Gateway target: ws://127.0.0.1:${port}`);
         }
+      });
+    },
+  );
+
+  it.each([
+    { failure: "timeout" as const, error: /timeout|timed out/ },
+    { failure: "disconnect" as const, error: /gateway closed/ },
+    { failure: "malformed" as const, error: /^Unexpected logs\.tail response$/ },
+  ])(
+    "uses the failure reason as the JSON summary after a post-hello $failure",
+    async ({ failure, error }) => {
+      await withLogsGateway({ failure }, async ({ port, requests, stdout, stderr }) => {
+        await expect(
+          runLogs([
+            "--url",
+            `ws://127.0.0.1:${port}`,
+            "--token",
+            "fixture-token",
+            "--json",
+            "--timeout",
+            "1500",
+          ]),
+        ).rejects.toBeInstanceOf(ExitError);
+        expect(requests).toEqual(["connect", "logs.tail"]);
+        expect(stdout.join("")).toBe("");
+        expect(JSON.parse(stderr.join(""))).toMatchObject({
+          type: "error",
+          message: expect.stringMatching(error),
+          error: expect.stringMatching(error),
+          details: { url: `ws://127.0.0.1:${port}` },
+        });
       });
     },
   );

--- a/src/cli/logs-cli.test.ts
+++ b/src/cli/logs-cli.test.ts
@@ -813,7 +813,11 @@ describe("logs cli", () => {
           expect.objectContaining({ type: "raw", raw: "recovered rpc line" }),
         ]),
       );
-      expect(stderrWrites.join("")).toContain("Gateway not reachable");
+      expect(JSON.parse(stderrWrites.join(""))).toMatchObject({
+        type: "error",
+        message: "stop after recovered cursor probe",
+        error: "stop after recovered cursor probe",
+      });
       expect(exitSpy).toHaveBeenCalledWith(1);
     });
 

--- a/src/cli/logs-cli.ts
+++ b/src/cli/logs-cli.ts
@@ -489,7 +489,6 @@ async function emitGatewayError(
   emitJsonLine: (payload: Record<string, unknown>, toStdErr?: boolean) => boolean,
   errorLine: (text: string) => boolean,
 ) {
-  const message = "Gateway not reachable. Is it running and accessible?";
   const hint = `Hint: run \`${formatCliCommand("openclaw doctor")}\`.`;
   const errorText = redactSensitiveUrlLikeString(formatErrorMessage(err));
 
@@ -497,20 +496,16 @@ async function emitGatewayError(
     isGatewayTransportError(err) ? err.connectionDetails : opts.connection,
   );
   if (mode === "json") {
-    if (
-      !emitJsonLine(
-        {
-          type: "error",
-          message,
-          error: errorText,
-          details,
-          hint,
-        },
-        true,
-      )
-    ) {
-      return;
-    }
+    emitJsonLine(
+      {
+        type: "error",
+        message: errorText,
+        error: errorText,
+        details,
+        hint,
+      },
+      true,
+    );
     return;
   }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw logs --json` received a generic “Gateway not reachable” message even when the Gateway returned an RPC rejection or the command failed while reading its log journal. The separate `error` field already contained the useful redacted reason, so consumers choosing `message` received misleading diagnostics.

## Why This Change Was Made

Use that existing reason for both fields at the terminal JSON emitter. This removes the generic constant and a redundant return branch without adding a reachability classifier or changing JSON keys, stderr routing, exit status, redaction, connection details, or the doctor hint. Production is 10 additions and 15 deletions (net −5); tests are net +45 and docs +2.

## User Impact

JSON consumers now receive the actual redacted failure reason in both `message` and `error`, including server rejection, transport failures and invalid responses. The CLI docs describe the corrected message.

## Evidence

The same 54-case regression selection produced five intended failures before the repair and passed after it. It covers the registered Commander command with the real Gateway client and loopback WebSocket responses for rejection, timeout, disconnect and malformed payload, plus the maintained log-journal seam. This proves the changed command path, not a packaged CLI, operator Gateway, or live provider. A subsequent formatting-only edit preserved every assertion and input. Independent P0–P2 review found no actionable defect.

Local proof uses a scoped existing dependency installation; its fast-uri version and Matrix patch differ from the source lock. This is not a claim of full installation or CI parity. The normal canonical changed-scope gate passed all 29 selected phases. Exact-head hosted CI is still pending in this draft.

Closes #134533
