### PR TITLE
refactor(gateway): share loopback URL policy

### DIFF
--- a/src/commands/status.scan.shared.test.ts
+++ b/src/commands/status.scan.shared.test.ts
@@ -309,6 +309,43 @@ describe("resolveGatewayProbeSnapshot", () => {
     expect(result.gatewayProbeAuthWarning).toBe("warn");
   });
 
+  it("does not use the local status RPC fallback for dotted localhost", async () => {
+    mocks.buildGatewayConnectionDetailsWithResolvers.mockReturnValue({
+      url: "ws://localhost.:18789",
+      urlSource: "local loopback",
+      message: "Gateway target: ws://localhost.:18789",
+    });
+    mocks.resolveGatewayProbeTarget.mockReturnValue({
+      mode: "local",
+      gatewayMode: "local",
+      remoteUrlMissing: false,
+    });
+    mocks.probeGateway.mockResolvedValue({
+      ok: false,
+      url: "ws://localhost.:18789",
+      connectLatencyMs: null,
+      error: "timeout",
+      close: null,
+      auth: {
+        role: null,
+        scopes: [],
+        capability: "unknown",
+      },
+      health: null,
+      status: null,
+      presence: null,
+      configSnapshot: null,
+    });
+
+    const result = await resolveGatewayProbeSnapshot({
+      cfg: {},
+      opts: {},
+    });
+
+    expect(mocks.callGateway).not.toHaveBeenCalled();
+    expect(result.gatewayProbe?.ok).toBe(false);
+  });
+
   it("uses built-in probe defaults for the local status RPC fallback", async () => {
     mocks.resolveGatewayProbeTarget.mockReturnValue({
       mode: "local",

--- a/src/commands/status.scan.shared.ts
+++ b/src/commands/status.scan.shared.ts
@@ -3,7 +3,6 @@
 
 import { existsSync } from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
-import { isLoopbackIpAddress } from "@openclaw/net-policy/ip";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
@@ -16,6 +15,7 @@ import { listAgentEntries } from "../agents/agent-scope-config.js";
 import type { OpenClawConfig } from "../config/types.js";
 import { buildGatewayConnectionDetailsWithResolvers } from "../gateway/connection-details.js";
 import { normalizeControlUiBasePath } from "../gateway/control-ui-shared.js";
+import { isLoopbackGatewayUrl } from "../gateway/net.js";
 import { resolveGatewayProbeTarget } from "../gateway/probe-target.js";
 import type { GatewayProbeResult, probeGateway as probeGatewayFn } from "../gateway/probe.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
@@ -156,17 +156,6 @@ type StatusMemorySearchManagerResolver = (params: {
 }) => Promise<{
   manager: StatusMemorySearchManager | null;
 }>;
-
-function isLoopbackGatewayUrl(rawUrl: string): boolean {
-  try {
-    const hostname = new URL(rawUrl).hostname.toLowerCase();
-    const unbracketed =
-      hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
-    return unbracketed === "localhost" || isLoopbackIpAddress(unbracketed);
-  } catch {
-    return false;
-  }
-}
 
 function shouldTryLocalStatusRpcFallback(params: {
   gatewayMode: "local" | "remote";

--- a/src/gateway/call.test.ts
+++ b/src/gateway/call.test.ts
@@ -602,6 +602,16 @@ describe("callGateway url resolution", () => {
     expect(lastClientOptions?.deviceIdentity).toBeNull();
   });
 
+  it("keeps device identity for dotted-localhost shared-token auth", async () => {
+    await callGateway({
+      method: "health",
+      url: "ws://localhost.:18789",
+      token: "explicit-token",
+    });
+
+    expect(lastClientOptions?.deviceIdentity).toEqual(deviceIdentityState.value);
+  });
+
   it("fails before opening a websocket when backend token auth has no shared or paired credential", async () => {
     setGatewayConfig({ mode: "local", bind: "loopback", auth: { mode: "token" } });
     setGatewayNetworkDefaults();

--- a/src/gateway/call.ts
+++ b/src/gateway/call.ts
@@ -1,7 +1,6 @@
 // Gateway RPC call helper.
 // Builds a GatewayClient, resolves auth/scopes, and performs one request.
 import { randomUUID } from "node:crypto";
-import { isLoopbackIpAddress } from "@openclaw/net-policy/ip";
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
@@ -95,6 +94,7 @@ import {
   resolveLeastPrivilegeOperatorScopesForMethod,
   type OperatorScope,
 } from "./method-scopes.js";
+import { isLoopbackGatewayUrl } from "./net.js";
 import {
   GatewayTransportError,
   type GatewayTransportErrorKind,
@@ -455,17 +455,6 @@ export function buildGatewayConnectionDetails(
     resolveConfigPath: (env) => resolveGatewayConfigPath(env),
     resolveGatewayPort: (config, env) => resolveGatewayPortValue(config, env),
   });
-}
-
-function isLoopbackGatewayUrl(rawUrl: string): boolean {
-  try {
-    const hostname = new URL(rawUrl).hostname.toLowerCase();
-    const unbracketed =
-      hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
-    return unbracketed === "localhost" || isLoopbackIpAddress(unbracketed);
-  } catch {
-    return false;
-  }
 }
 
 function shouldOmitDeviceIdentityForGatewayCall(params: {

--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -10,6 +10,7 @@ import {
   defaultGatewayBindMode,
   isContainerEnvironment,
   isLocalishHost,
+  isLoopbackGatewayUrl,
   isLoopbackHost,
   isPrivateOrLoopbackAddress,
   isPrivateOrLoopbackHost,
@@ -86,6 +87,24 @@ describe("isLoopbackHost", () => {
   it("accepts localhost absolute-form hostnames", () => {
     expect(isLoopbackHost("localhost.")).toBe(true);
     expect(isLoopbackHost("LOCALHOST...")).toBe(true);
+  });
+});
+
+describe("isLoopbackGatewayUrl", () => {
+  it.each([
+    ["ws://LOCALHOST:18789", true],
+    ["ws://localhost.:18789", false],
+    ["ws://127.42.0.1:18789", true],
+    ["ws://[::1]:18789", true],
+    ["ws://[0:0:0:0:0:0:0:1]:18789", true],
+    ["ws://[::ffff:127.0.0.1]:18789", true],
+    ["ws://192.168.1.2:18789", false],
+    ["not-a-url", false],
+    ["/relative", false],
+    ["http://localhost:18789", true],
+    ["https://localhost:18789", true],
+  ] as const)("classifies %s as %s", (url, expected) => {
+    expect(isLoopbackGatewayUrl(url)).toBe(expected);
   });
 });
 

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -427,6 +427,18 @@ export function isLoopbackHost(host: string): boolean {
   return isLoopbackAddress(parsed.unbracketedHost);
 }
 
+// Gateway-local policy rejects dotted localhost and intentionally allows any URL scheme.
+export function isLoopbackGatewayUrl(rawUrl: string): boolean {
+  try {
+    const hostname = new URL(rawUrl).hostname.toLowerCase();
+    const unbracketed =
+      hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+    return unbracketed === "localhost" || isLoopbackIpAddress(unbracketed);
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Local-facing host check for inbound requests:
  * - loopback hosts (localhost/127.x/::1 and mapped forms)


### PR DESCRIPTION
## What Problem This Solves

The Gateway CLI call path and status probe path independently owned identical URL classification policy. That duplication made security-sensitive local-Gateway behavior vulnerable to semantic drift.

## Why This Change Was Made

Moves the exact `isLoopbackGatewayUrl` policy into the Gateway network owner and imports it from both consumers.

The invariant is intentionally narrow:

- `localhost` is case-insensitive, but dotted `localhost.` remains rejected.
- IPv4 loopback uses the full `127/8` range.
- bracketed, expanded, and IPv4-mapped IPv6 loopback remain accepted.
- malformed and relative URLs remain rejected by WHATWG URL parsing.
- the scheme remains unrestricted because this predicate gates Gateway-local policy, not WebSocket transport validity.

This does not use `isLoopbackHost`, which strips trailing dots and would widen the policy. It is not re-exported through plugin SDK or public barrels. No config, protocol, SQLite, SDK, dependency, docs, or changelog surfaces changed.

## User Impact

No intended user-visible behavior change. Gateway-local authentication identity handling and status fallback decisions now share one canonical predicate while preserving shipped semantics.

Production delta: `+14/-24` (net `-10`).
Test delta: `+66/-0`.

## Evidence

Local focused proof on exact head:

- `node scripts/run-vitest.mjs run src/gateway/net.test.ts src/gateway/call.test.ts src/commands/status.scan.shared.test.ts` - 319 passed.
- `node scripts/run-vitest.mjs run src/commands/status.cold-imports.test.ts src/commands/status.scan.fast-json-cold-imports.test.ts` - 3 passed.
- `pnpm check:import-cycles` - 0 runtime value cycles.
- `pnpm check:madge-import-cycles` - 0 cycles.
- `git diff --check origin/main...HEAD` - clean.
- pinned Sol autoreview with `--base origin/main` - scoped clean, no actionable findings, correctness 0.98.

Mutation proof:

- Replacing the predicate with `isLoopbackHost` made the canonical, call, and status boundary tests fail on dotted localhost.
- Restricting loopback to exact `localhost`, `127.0.0.1`, and `::1` failed `127/8` and mapped-IPv6 cases.
- Accepting parse failures failed malformed and relative URL cases.
- Restricting schemes failed HTTP and HTTPS cases.
- Removing the local bracket slice did not fail because the dependency-owned `isLoopbackIpAddress` independently strips IPv6 brackets before parsing; this is an equivalent dependency-backed path, so no implementation-coupled mock was added.

Local broad-gate note:

- `pnpm build` passed plugin assets, package/unified builds, external plugin builds, CLI bootstrap guard, runtime postbuild, and plugin SDK declarations, then local `ui:build` reached an unrelated shared-install mismatch: the canonical shared `node_modules` resolves `pako@1.0.11` while current manifests/lock require `3.0.1`; the local Node version is also unsupported v26. No install was run inside the worktree.
- `pnpm check:changed` passed all gates through typechecks, then its dead-export scan reached the same stale `pako` resolution after the tracked sparse `ui/config` inputs were materialized.
- Hydrated Blacksmith Testbox `tbx_01m1d1xwwrvk27zn2v08fpzcft`, Node `v24.19.0`: exact candidate tree `1a0e5cbadac4a86de9f9cd4d11d1ad8b92ccc870`, full `pnpm build`, and `CI=1 pnpm check:changed` all passed (exit 0). Run: https://github.com/openclaw/openclaw/actions/runs/33450204296.
- Exact-head required Windows CI: pending.
- Latest ClawSweeper review: no findings. Its only `Rank-up moves:` item is to mark the draft ready and let required checks run against the exact head.

No paid cloud was used or requested.

Codex source gate:

- Personally inspected sibling `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870` before implementation and publication. Those CLI runtime sections do not define or alter this Gateway URL policy.

Live overlap recheck:

- https://github.com/openclaw/openclaw/pull/125374 - unrelated Tailscale URL formatting hunks in status files.
- https://github.com/openclaw/openclaw/pull/88504 - unrelated memory-slot hunks in status files.
- https://github.com/openclaw/openclaw/pull/105781 - unrelated gateway network ownership refactor.
- https://github.com/openclaw/openclaw/pull/80921 - unrelated Gateway bind timeout/listener refactor.
- https://github.com/openclaw/openclaw/pull/68280 - unrelated status fallback test in the shared test file.
- GitHub API search found no open PR mentioning `isLoopbackGatewayUrl`.

Head: `903614285c2c281d03abb37895d70c15cf4f340e`.
Base: `eeedc956088a3f9fac0786c8130c2e7cd388e24a`.
