### PR TITLE
refactor: avoid duplicate workspace Git initialization

### DIFF
--- a/src/agents/workspace.provisioning.test.ts
+++ b/src/agents/workspace.provisioning.test.ts
@@ -1,22 +1,27 @@
-// Focused coverage for runtime-managed-implicit workspace provisioning (#92015).
+// Workspace provisioning covers directory-only ACP and concurrent first-turn setup.
 import fs from "node:fs/promises";
+import { devNull } from "node:os";
 import path from "node:path";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { setImmediate as checkpoint } from "node:timers/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
+import * as commandExec from "../process/exec.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
-import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../test-utils/openclaw-test-state.js";
 import { resetLegacyWorkspaceStateCheckForTest } from "./workspace-legacy-state.test-support.js";
-import { readWorkspaceStateSnapshot } from "./workspace-state-store.js";
+import * as workspaceState from "./workspace-state-store.js";
 import {
   DEFAULT_AGENTS_FILENAME,
   DEFAULT_BOOTSTRAP_FILENAME,
+  DEFAULT_USER_FILENAME,
   ensureAgentWorkspace,
 } from "./workspace.js";
 
 let testState: OpenClawTestState | undefined;
+let disposeGitCohort: (() => Promise<void>) | undefined;
 
 beforeEach(async () => {
   resetLegacyWorkspaceStateCheckForTest();
@@ -27,10 +32,15 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  closeOpenClawStateDatabaseForTest();
-  resetLegacyWorkspaceStateCheckForTest();
-  await testState?.cleanup();
-  testState = undefined;
+  try {
+    await disposeGitCohort?.();
+  } finally {
+    disposeGitCohort = undefined;
+    closeOpenClawStateDatabaseForTest();
+    resetLegacyWorkspaceStateCheckForTest();
+    await testState?.cleanup();
+    testState = undefined;
+  }
 });
 
 async function expectPathMissing(filePath: string): Promise<void> {
@@ -39,7 +49,7 @@ async function expectPathMissing(filePath: string): Promise<void> {
 
 describe("ensureAgentWorkspace runtime-managed-implicit provisioning", () => {
   it("creates only the directory for runtime-managed-implicit provisioning (#92015)", async () => {
-    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    const tempDir = testState!.path("implicit-parent");
     const targetDir = path.join(tempDir, "implicit-acp-workspace");
 
     const result = await ensureAgentWorkspace({
@@ -56,11 +66,11 @@ describe("ensureAgentWorkspace runtime-managed-implicit provisioning", () => {
     await expectPathMissing(path.join(targetDir, DEFAULT_AGENTS_FILENAME));
     await expectPathMissing(path.join(targetDir, DEFAULT_BOOTSTRAP_FILENAME));
     await expectPathMissing(path.join(targetDir, ".git"));
-    expect(readWorkspaceStateSnapshot(targetDir).setupExists).toBe(false);
+    expect(workspaceState.readWorkspaceStateSnapshot(targetDir).setupExists).toBe(false);
   });
 
   it("runtime-managed-implicit provisioning preserves pre-existing workspace content", async () => {
-    const tempDir = await makeTempWorkspace("openclaw-workspace-");
+    const tempDir = testState!.path("implicit-parent");
     const targetDir = path.join(tempDir, "implicit-acp-workspace");
     await fs.mkdir(targetDir, { recursive: true });
     await fs.writeFile(path.join(targetDir, "user-notes.md"), "keep me\n");
@@ -74,5 +84,205 @@ describe("ensureAgentWorkspace runtime-managed-implicit provisioning", () => {
     expect(await fs.readFile(path.join(targetDir, "user-notes.md"), "utf8")).toBe("keep me\n");
     await expectPathMissing(path.join(targetDir, DEFAULT_AGENTS_FILENAME));
     await expectPathMissing(path.join(targetDir, ".git"));
+  });
+});
+
+function startGitProvisioning(directories: string[], retryAfterFailure = false) {
+  const dirs = directories.map((dir) => path.resolve(dir));
+  const initGates = new Map(dirs.map((dir) => [dir, createDeferred()]));
+  const admitted = createDeferred();
+  const templates = createDeferred();
+  const setup = createDeferred();
+  const lateCaller = createDeferred();
+  let agentsWrites = 0;
+  let userWrites = 0;
+  let setupWrites = 0;
+  if (!retryAfterFailure) {
+    lateCaller.resolve();
+  }
+  const realWrite = fs.writeFile.bind(fs);
+  const writeSpy = vi.spyOn(fs, "writeFile").mockImplementation(async (file, data, options) => {
+    const owned = typeof file === "string" && initGates.has(path.dirname(file));
+    if (owned && path.basename(file) === DEFAULT_AGENTS_FILENAME) {
+      if (++agentsWrites === dirs.length) {
+        admitted.resolve();
+      }
+      // No seeding until all callers passed the real new-workspace admission.
+      await admitted.promise;
+    }
+    try {
+      return await realWrite(file, data, options);
+    } finally {
+      if (owned && path.basename(file) === DEFAULT_USER_FILENAME) {
+        const last = ++userWrites === dirs.length;
+        if (last) {
+          templates.resolve();
+        }
+        // Finish real template writes before any caller can inspect customization.
+        await templates.promise;
+        if (last) {
+          await lateCaller.promise;
+        }
+      }
+    }
+  });
+  const realMerge = workspaceState.mergeWorkspaceSetupState;
+  const mergeSpy = vi
+    .spyOn(workspaceState, "mergeWorkspaceSetupState")
+    .mockImplementation((...args) => {
+      const result = realMerge(...args);
+      if (initGates.has(args[0]) && ++setupWrites === dirs.length - Number(retryAfterFailure)) {
+        setup.resolve();
+      }
+      return result;
+    });
+  const reads: Promise<void>[] = [];
+  const realStat = fs.stat.bind(fs);
+  const statSpy = vi.spyOn(fs, "stat").mockImplementation((file, options) => {
+    const pending = realStat(file, options);
+    if (
+      typeof file === "string" &&
+      path.basename(file) === ".git" &&
+      initGates.has(path.dirname(file))
+    ) {
+      reads.push(
+        pending.then(
+          () => undefined,
+          () => undefined,
+        ),
+      );
+    }
+    return pending;
+  });
+  const baseEnv: NodeJS.ProcessEnv = {
+    PATH: process.env.PATH,
+    SystemRoot: process.env.SystemRoot,
+    WINDIR: process.env.WINDIR,
+    PATHEXT: process.env.PATHEXT,
+    COMSPEC: process.env.COMSPEC,
+    HOME: testState!.home,
+    USERPROFILE: testState!.home,
+    TMPDIR: testState!.root,
+    TEMP: testState!.root,
+    TMP: testState!.root,
+    GIT_CONFIG_NOSYSTEM: "1",
+    GIT_CONFIG_GLOBAL: devNull,
+    GIT_TERMINAL_PROMPT: "0",
+  };
+  const realRun = commandExec.runCommandWithTimeout;
+  const attempts: string[] = [];
+  let availability: Promise<unknown> | undefined;
+  const commandSpy = vi
+    .spyOn(commandExec, "runCommandWithTimeout")
+    .mockImplementation(async (argv, options) => {
+      if (argv[0] !== "git") {
+        return realRun(argv, options);
+      }
+      const settings = typeof options === "number" ? { timeoutMs: options } : options;
+      if (argv[1] === "init") {
+        const gate = settings.cwd && initGates.get(settings.cwd);
+        if (!gate || !settings.cwd) {
+          throw new Error("Refusing Git initialization outside the test workspace");
+        }
+        const fail = retryAfterFailure && attempts.length === 0;
+        attempts.push(settings.cwd);
+        await gate.promise;
+        if (fail) {
+          throw new Error("Injected Git initialization failure");
+        }
+      }
+      const pending = realRun(argv, { ...settings, baseEnv });
+      if (argv[1] === "--version") {
+        availability = pending;
+      }
+      return pending;
+    });
+  const calls = directories.map((dir) => {
+    const pending = ensureAgentWorkspace({ dir, ensureBootstrapFiles: true });
+    void pending.catch(() => undefined);
+    return pending;
+  });
+  disposeGitCohort = async () => {
+    for (const gate of [admitted, templates, lateCaller, ...initGates.values()]) {
+      gate.resolve();
+    }
+    await Promise.allSettled(calls);
+    for (const spy of [commandSpy, statSpy, mergeSpy, writeSpy]) {
+      spy.mockRestore();
+    }
+  };
+  const waitFor = <T>(pending: PromiseLike<T>) =>
+    withTestTimeout(pending, 5_000, "Workspace provisioning did not reach the held Git operation");
+  return {
+    calls,
+    attempts,
+    release: (dir: string) => initGates.get(dir)!.resolve(),
+    releaseLate: () => lateCaller.resolve(),
+    async ready() {
+      await waitFor(setup.promise);
+      // Setup publication immediately precedes Git. Drain actual metadata/probe
+      // work while init is held; no guessed delay decides the dispatch count.
+      await waitFor(Promise.all(reads));
+      await checkpoint();
+      if (availability) {
+        await waitFor(availability);
+      }
+      await checkpoint();
+    },
+    async expectRepository(dir: string) {
+      const result = await realRun(["git", "rev-parse", "--show-toplevel"], {
+        cwd: dir,
+        timeoutMs: 5_000,
+        baseEnv,
+      });
+      expect(result.code).toBe(0);
+      expect(await fs.realpath(result.stdout.trim())).toBe(await fs.realpath(dir));
+    },
+  };
+}
+
+describe("ensureAgentWorkspace concurrent Git initialization", () => {
+  it("shares initialization for concurrent callers resolving to the same workspace", async () => {
+    const dir = testState!.path("git-workspace");
+    const cohort = startGitProvisioning([dir, `${dir}${path.sep}.`]);
+    await cohort.ready();
+    expect(cohort.attempts).toEqual([dir]);
+    cohort.release(dir);
+    await Promise.all(cohort.calls);
+    await cohort.expectRepository(dir);
+    await ensureAgentWorkspace({ dir, ensureBootstrapFiles: true });
+    expect(cohort.attempts).toEqual([dir]);
+  });
+
+  it("lets an independent workspace finish while another initialization is held", async () => {
+    const first = testState!.path("git-first");
+    const second = testState!.path("git-second");
+    const cohort = startGitProvisioning([first, second]);
+    await cohort.ready();
+    expect(cohort.attempts.toSorted()).toEqual([first, second]);
+    cohort.release(second);
+    await cohort.calls[1];
+    await cohort.expectRepository(second);
+    await expectPathMissing(path.join(first, ".git"));
+    cohort.release(first);
+    await cohort.calls[0];
+    await cohort.expectRepository(first);
+  });
+
+  it("retries failed initialization only for a caller already admitted as brand-new", async () => {
+    const dir = testState!.path("git-retry");
+    const cohort = startGitProvisioning([dir, dir], true);
+    await cohort.ready();
+    expect(cohort.attempts).toEqual([dir]);
+    cohort.release(dir);
+    await Promise.race(cohort.calls);
+    await expectPathMissing(path.join(dir, ".git"));
+    // A newly started call sees seeded files and must not become retry-eligible.
+    await ensureAgentWorkspace({ dir, ensureBootstrapFiles: true });
+    expect(cohort.attempts).toEqual([dir]);
+    cohort.releaseLate();
+    await Promise.all(cohort.calls);
+    expect(cohort.attempts).toEqual([dir, dir]);
+    await cohort.expectRepository(dir);
   });
 });

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -28,6 +28,7 @@ import {
 import { runCommandWithTimeout } from "../process/exec.js";
 import { isCronSessionKey, isSubagentSessionKey } from "../routing/session-key.js";
 import { deriveSessionChatTypeFromKey } from "../sessions/session-chat-type-shared.js";
+import { createLazyPromise, getOrCreatePromise } from "../shared/lazy-promise.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
 import { resolveUserPath } from "../utils.js";
 import {
@@ -82,8 +83,7 @@ const TRANSIENT_WORKSPACE_READ_MESSAGE = /Unknown system error -(?:11|4)\b/i;
 const workspaceLogger = createSubsystemLogger("workspace");
 
 const workspaceTemplateCache = new Map<string, Promise<string>>();
-// Git availability is process-stable; cache the probe result, including failure, until restart.
-let gitAvailabilityPromise: Promise<boolean> | null = null;
+const gitInitializationInFlight = new Map<string, Promise<void>>();
 
 // File content cache keyed by stable file identity to avoid stale reads.
 const workspaceFileCache = new Map<string, { content: string; identity: string }>();
@@ -858,47 +858,40 @@ export async function isWorkspaceBootstrapPending(dir: string): Promise<boolean>
   return (await resolveWorkspaceBootstrapStatus(dir)) === "pending";
 }
 
-async function hasGitRepo(dir: string): Promise<boolean> {
+// Git availability is process-stable; cache the probe result, including failure, until restart.
+const isGitAvailable = createLazyPromise(async () => {
   try {
-    await fs.stat(path.join(dir, ".git"));
-    return true;
+    const result = await runCommandWithTimeout(["git", "--version"], { timeoutMs: 2_000 });
+    return result.code === 0;
   } catch {
     return false;
   }
-}
-
-async function isGitAvailable(): Promise<boolean> {
-  if (gitAvailabilityPromise) {
-    return gitAvailabilityPromise;
-  }
-
-  gitAvailabilityPromise = (async () => {
-    try {
-      const result = await runCommandWithTimeout(["git", "--version"], { timeoutMs: 2_000 });
-      return result.code === 0;
-    } catch {
-      return false;
-    }
-  })();
-
-  return gitAvailabilityPromise;
-}
+});
 
 async function ensureGitRepo(dir: string, isBrandNewWorkspace: boolean) {
   if (!isBrandNewWorkspace) {
     return;
   }
-  if (await hasGitRepo(dir)) {
-    return;
-  }
-  if (!(await isGitAvailable())) {
-    return;
-  }
-  try {
-    await runCommandWithTimeout(["git", "init"], { cwd: dir, timeoutMs: 10_000 });
-  } catch {
-    // Ignore git init failures; workspace creation should still succeed.
-  }
+  // Concurrent first turns can all observe missing Git metadata. Join only the
+  // current initialization; later calls must inspect the workspace again.
+  await getOrCreatePromise(
+    gitInitializationInFlight,
+    dir,
+    async () => {
+      if (await fs.stat(path.join(dir, ".git")).catch(() => undefined)) {
+        return;
+      }
+      if (!(await isGitAvailable())) {
+        return;
+      }
+      try {
+        await runCommandWithTimeout(["git", "init"], { cwd: dir, timeoutMs: 10_000 });
+      } catch {
+        // Ignore git init failures; workspace creation should still succeed.
+      }
+    },
+    { evictOnSettled: true },
+  );
 }
 
 export async function ensureAgentWorkspace(params?: {


### PR DESCRIPTION
## What Problem This Solves

Concurrent first turns admitted to a new workspace can each observe missing Git metadata and start their own `git init`. The isolated 32-caller reproduction completes successfully but dispatches 32 initializations for the same directory.

## Why This Change Was Made

The workspace owner now shares only its active initialization per resolved directory, using the existing keyed-promise helper. Settlement evicts that operation: later eligible calls inspect the filesystem again, and an already-admitted caller can retry a failed attempt. Independent workspaces remain independent. The old single-use existence helper and handwritten availability-promise bookkeeping are removed.

Git availability remains process-stable, including a failed probe. Brand-new admission, caller-specific bootstrap policy, ACP directory-only provisioning, best-effort failures, subprocess arguments/environment/timeouts and per-session baseline ownership stay unchanged. This is same-process coalescing of resolved path strings, not a cross-process lock or symlink-identity cache. Production **+27/−34, net −7**; tests **+221/−11, net +210**. No schema, persistence, configuration, dependency or protocol change.

## User Impact

Concurrent first turns avoid redundant initialization without changing workspace contents or requiring operator action. This bounded work reduction does not claim that residual Gateway saturation is resolved.

## Evidence

- The original regression fails on base `83f3d9d43b316aaaaf848ae9ecf7813ff2115d30`: two same-directory callers dispatch two initializations. The candidate covers shared initialization, independent-directory progress and retry eligibility using real Git repositories. The separate 32-caller probe records **32 → 1 init attempts**, one availability probe on each side, 32 fulfilled calls and a usable repository. The observation wrapper can widen the race; these are process counts, not latency measurements.
- Refreshed head `82d8c7572ebb9687358e376d9290520279b95647` is based on `a6fdf556d0ba10d77226de89f47e004c0bc9c0e5` with exactly the same two reviewed afterimages. Both owner/test preimages are unchanged on that base. Of 77 checked owner/caller/test contexts, only downstream skill-override selection changed; workspace admission is unchanged. Dependencies were installed from the refreshed lockfile.
- All **97 cases in six focused/sibling suites** pass on the refreshed head: workspace provisioning, workspace behavior, SQLite safety, attestation survival, ACP provisioning and shared promise lifecycle. The complete changed-code gate passes without exemptions. Managed Codex P0 review and direct owner/dependency review found no actionable defect; the refresh preserves the reviewed patch.
- The previous CI blockers have upstream repairs in the new base. The original ordered Linux Node 24.19.0 Doctor batch/deep/public sequence passes on clean `a6fdf556` with the unchanged 256 MiB heap limit and 100,000-event deep/public cases. This parent proof is separate from the refreshed PR's required exact-head hosted CI.

Historical exact-source builds and the paired isolated 32-turn profile on `83f3` and the original candidate both passed the original 2,000 ms budgets. That pair did **not** show overall latency improvement: sessions-list maxima were 989/1,189 ms, history maxima 1,184/1,331 ms, UI HTTP maxima 1,094/1,159 ms, and readiness maxima 706/716 ms. Original operation failures and metadata rescans were zero. ELU remained 1; repeated degraded polls included reused health snapshots. These are historical measurements, not timings of the refreshed head, and no memory-leak or global UI-idle claim follows.

All runtime proof used isolated HOME/state, a mock provider and loopback ports, never a production Gateway. The unchanged workload is 32 turns, 48 seeded sessions, 128 updates/four clients, three history clients × five, six subscribers, visible observer, 100 ms cadence and 1,000 ms mock-stream delay. No thresholds were increased.

The latest ClawSweeper review and its Rank-up move were read in full. Its remaining request is completed exact-head CI; normal hosted preparation and merge remain gated on that proof. The original introduction of the duplicate initialization is unknown; a later availability-cache change is not credited as introducing it.
