### PR TITLE
test(plugins): preserve agent identity in task cancellation

### DIFF
--- a/src/plugins/runtime/runtime-tasks.test.ts
+++ b/src/plugins/runtime/runtime-tasks.test.ts
@@ -202,6 +202,7 @@ describe("runtime tasks", () => {
 
     expect(runtimeTaskMocks.cancelSessionMock).toHaveBeenCalledWith({
       cfg: {},
+      agentId: "main",
       sessionKey: "agent:main:subagent:child",
       reason: "task-cancel",
       expectedRunId: "runtime-task-cancel",
@@ -393,6 +394,7 @@ describe("runtime tasks", () => {
     expect(opsCancel.cancelled).toBe(true);
     expect(runtimeTaskMocks.cancelSessionMock).toHaveBeenCalledWith({
       cfg: {},
+      agentId: "ops",
       sessionKey: "agent:ops:acp:child",
       reason: "task-cancel",
       expectedRunId: "ops-global-run",


### PR DESCRIPTION
## What Problem This Solves

Restores the plugin prerelease task-runtime tests after ACP cancellation began
forwarding the selected task agent to the session manager.

The production ownership fix landed in `#134314`, but two plugin-runtime
expectations still asserted the older call shape. This failed the independent
Plugin Prerelease lane in Full Release Validation:

- https://github.com/openclaw/openclaw/actions/runs/33446293188
- https://github.com/openclaw/openclaw/actions/runs/33446235370

## Why This Change Was Made

The exact cancellation call is an ownership boundary. Retaining `agentId` in
these assertions proves that tasks sharing a bare session key cannot cancel a
different agent's ACP session.

No production behavior changes.

## Evidence

- Pre-fix exact frozen SHA: 2 failed, 3 passed
- Pre-fix current main: 2 failed, 3 passed
- Post-fix plugin runtime tasks: 5 passed
- Sibling task executor and Gateway task suites: 61 passed
- Dead-export scan passed
- `git diff --check` passed
- Codex autoreview passed with no findings (`0.98`)

The full local core-test typecheck reached the already-fixed linked-worktree
`pako@1` shared-install mismatch. Repository policy forbids dependency
reconciliation inside this Codex worktree; exact-head CI supplies the fresh
install proof.

Review metrics: production `+0/-0`; tests `+2/-0`.
No changelog entry is required for this test-only correction.
