### PR TITLE
perf(doctor): avoid loading unused plugin runtimes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Doctor memory:** keep Matrix migration codecs separate from the live client and avoid loading the ACP runtime when no legacy session records need inspection.
 - **Agent prompts:** keep model-identity guidance conditional so ordinary requests are not mistaken for questions about the current model.
 
 - **Update/Doctor:** preserve `update --no-restart` by requiring an offline managed Gateway during updater-owned repair and leaving restart ownership with the parent.

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -657,7 +657,6 @@ extensions/matrix/src/matrix/actions/summary.ts	2
 extensions/matrix/src/matrix/actions/verification.ts	1
 extensions/matrix/src/matrix/client-bootstrap.ts	1
 extensions/matrix/src/matrix/client/config.ts	5
-extensions/matrix/src/matrix/client/file-sync-store.ts	5
 extensions/matrix/src/matrix/client/logging.ts	3
 extensions/matrix/src/matrix/client/runtime.ts	1
 extensions/matrix/src/matrix/config-update.ts	4

--- a/extensions/acpx/src/session-owner-migration.test.ts
+++ b/extensions/acpx/src/session-owner-migration.test.ts
@@ -134,6 +134,34 @@ async function fixture(mode: "persistent" | "oneshot" = "persistent", sessionKey
   };
 }
 
+it.each(["missing", "empty"])(
+  "does not inspect session claims when the legacy directory is %s",
+  async (directoryState) => {
+    const directory = directories.make("acpx-empty-owner-migration-");
+    if (directoryState === "empty") {
+      await fs.mkdir(path.join(directory, "state", "sessions"), { recursive: true });
+    }
+    const context: PluginDoctorStateMigrationContext = {
+      openPluginStateKeyedStore() {
+        throw new Error("No record requires a state store");
+      },
+      async inspectAcpSessionClaims() {
+        throw new Error("No record requires canonical ownership evidence");
+      },
+    };
+    await expect(
+      acpxSessionOwnerMigration.detectLegacyState({
+        config: {},
+        env: { ...process.env, OPENCLAW_STATE_DIR: directory },
+        stateDir: directory,
+        oauthDir: path.join(directory, "oauth"),
+        serviceWorkspaceDir: directory,
+        context,
+      }),
+    ).resolves.toBeNull();
+  },
+);
+
 it.each(["none", "publication", "canonical"])(
   "preserves raw history and resumes idempotently after interruption=%s",
   async (interrupted) => {

--- a/extensions/acpx/src/session-owner-migration.ts
+++ b/extensions/acpx/src/session-owner-migration.ts
@@ -48,6 +48,9 @@ async function legacyRecords(input: MigrationInput): Promise<{ directory: string
     .filter((name) => name.endsWith(".json"))
     .map((name) => decodeURIComponent(name.slice(0, -5)))
     .filter((id) => !id.startsWith("agent:") && !id.startsWith(".openclaw-owner-"));
+  if (ids.length === 0) {
+    return { directory, ids };
+  }
   const evidence = await input.context.inspectAcpSessionClaims?.();
   const { decodeAcpxRuntimeHandleState } = await import("acpx/runtime");
   return {

--- a/extensions/matrix/doctor-contract-api.ts
+++ b/extensions/matrix/doctor-contract-api.ts
@@ -13,19 +13,19 @@ import {
   resolveMatrixDefaultOrOnlyAccountId,
 } from "./src/account-selection.js";
 import {
-  hasMatrixSyncCacheStateInStore,
-  openMatrixSyncCacheStoreOptions,
-  readLegacyMatrixSyncCacheState,
-  writeMatrixSyncCacheStateToStore,
-  type MatrixSyncCacheRecord,
-} from "./src/matrix/client/file-sync-store.js";
-import {
   hasMatrixStorageMetaStateInStore,
   normalizeMatrixStorageMetadata,
   openMatrixStorageMetaStoreOptions,
   writeMatrixStorageMetaStateToStore,
   type MatrixStorageMetadata,
 } from "./src/matrix/client/storage.js";
+import {
+  hasMatrixSyncCacheStateInStore,
+  openMatrixSyncCacheStoreOptions,
+  readLegacyMatrixSyncCacheState,
+  writeMatrixSyncCacheStateToStore,
+  type MatrixSyncCacheRecord,
+} from "./src/matrix/client/sync-cache-state.js";
 import {
   MATRIX_CREDENTIALS_MAX_ENTRIES,
   MATRIX_CREDENTIALS_NAMESPACE,

--- a/extensions/matrix/src/matrix/client/file-sync-store.test.ts
+++ b/extensions/matrix/src/matrix/client/file-sync-store.test.ts
@@ -10,12 +10,9 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { getMatrixRuntime } from "../../runtime.js";
 import { installMatrixTestRuntime } from "../../test-runtime.js";
-import {
-  openMatrixSyncCacheStoreOptions,
-  SqliteBackedMatrixSyncStore,
-  type MatrixSyncCacheRecord,
-} from "./file-sync-store.js";
+import { SqliteBackedMatrixSyncStore } from "./file-sync-store.js";
 import { openMatrixStorageMetaStoreOptions } from "./storage.js";
+import { openMatrixSyncCacheStoreOptions, type MatrixSyncCacheRecord } from "./sync-cache-state.js";
 
 function createSyncResponse(nextBatch: string): ISyncResponse {
   return {

--- a/extensions/matrix/src/matrix/client/file-sync-store.ts
+++ b/extensions/matrix/src/matrix/client/file-sync-store.ts
@@ -1,144 +1,27 @@
-// Matrix plugin module implements SQLite sync cache behavior.
-import { createHash, randomUUID } from "node:crypto";
-import fs from "node:fs/promises";
-import path from "node:path";
+// Matrix plugin module implements the live SDK's SQLite sync store.
 import {
-  Category,
   MemoryStore,
   SyncAccumulator,
   type ISyncData,
-  type IRooms,
   type ISyncResponse,
   type IStoredClientOpts,
 } from "matrix-js-sdk/lib/matrix.js";
-import type {
-  PluginStateKeyedStore,
-  PluginStateSyncKeyedStore,
-} from "openclaw/plugin-sdk/plugin-state-runtime";
-import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import type { PluginStateSyncKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import { getMatrixRuntime } from "../../runtime.js";
 import { createAsyncLock } from "../async-lock.js";
 import { LogService } from "../sdk/logger.js";
-import { resolveMatrixSqliteStateEnv } from "../sqlite-state.js";
 import { claimCurrentTokenStorageState } from "./storage.js";
+import {
+  MATRIX_SYNC_CACHE_VERSION,
+  deleteMatrixSyncCacheStateFromSyncStore,
+  openMatrixSyncCacheStoreOptions,
+  readPersistedStoreFromSyncStore,
+  writeMatrixSyncCacheStateToSyncStore,
+  type MatrixSyncCacheRecord,
+  type PersistedMatrixSyncStore,
+} from "./sync-cache-state.js";
 
-const STORE_VERSION = 1;
 const PERSIST_DEBOUNCE_MS = 250;
-const SYNC_CACHE_NAMESPACE = "sync-cache";
-const SYNC_CACHE_MAX_ENTRIES = 20_000;
-const SYNC_CACHE_MAX_CHUNKS = Math.floor((SYNC_CACHE_MAX_ENTRIES - 1) / 2);
-const SYNC_CACHE_STATE_KEY = "current";
-// PluginState serializes this string inside a row object; 24KB leaves room for JSON escaping.
-const SYNC_CACHE_CHUNK_BYTES = 24_000;
-
-type PersistedMatrixSyncStore = {
-  version: number;
-  savedSync: ISyncData | null;
-  clientOptions?: IStoredClientOpts;
-  cleanShutdown?: boolean;
-};
-
-type MatrixSyncCacheMeta = {
-  kind: "meta";
-  version: number;
-  generation: string;
-  chunkCount: number;
-  syncDigest?: string;
-  clientOptions?: IStoredClientOpts;
-  cleanShutdown?: boolean;
-};
-
-type MatrixSyncCacheChunk = {
-  kind: "sync-chunk";
-  index: number;
-  data: string;
-};
-
-export type MatrixSyncCacheRecord = MatrixSyncCacheMeta | MatrixSyncCacheChunk;
-
-type MatrixSyncCacheAsyncStore = Pick<
-  PluginStateKeyedStore<MatrixSyncCacheRecord>,
-  "delete" | "entries" | "lookup" | "register"
->;
-
-function normalizeRoomsData(value: unknown): IRooms | null {
-  if (!isRecord(value)) {
-    return null;
-  }
-  return {
-    [Category.Join]: isRecord(value[Category.Join]) ? (value[Category.Join] as IRooms["join"]) : {},
-    [Category.Invite]: isRecord(value[Category.Invite])
-      ? (value[Category.Invite] as IRooms["invite"])
-      : {},
-    [Category.Leave]: isRecord(value[Category.Leave])
-      ? (value[Category.Leave] as IRooms["leave"])
-      : {},
-    [Category.Knock]: isRecord(value[Category.Knock])
-      ? (value[Category.Knock] as IRooms["knock"])
-      : {},
-  };
-}
-
-function toPersistedSyncData(value: unknown): ISyncData | null {
-  if (!isRecord(value)) {
-    return null;
-  }
-  if (typeof value.nextBatch === "string" && value.nextBatch.trim()) {
-    const roomsData = normalizeRoomsData(value.roomsData);
-    if (!Array.isArray(value.accountData) || !roomsData) {
-      return null;
-    }
-    return {
-      nextBatch: value.nextBatch,
-      accountData: value.accountData,
-      roomsData,
-    };
-  }
-
-  // Older Matrix state files stored the raw /sync-shaped payload directly.
-  if (typeof value.next_batch === "string" && value.next_batch.trim()) {
-    const roomsData = normalizeRoomsData(value.rooms);
-    if (!roomsData) {
-      return null;
-    }
-    return {
-      nextBatch: value.next_batch,
-      accountData:
-        isRecord(value.account_data) && Array.isArray(value.account_data.events)
-          ? value.account_data.events
-          : [],
-      roomsData,
-    };
-  }
-
-  return null;
-}
-
-function normalizePersistedStore(value: unknown): PersistedMatrixSyncStore | null {
-  if (!isRecord(value) || value.version !== STORE_VERSION) {
-    return null;
-  }
-  return {
-    version: STORE_VERSION,
-    savedSync: toPersistedSyncData(value.savedSync),
-    clientOptions: isRecord(value.clientOptions)
-      ? (value.clientOptions as IStoredClientOpts)
-      : undefined,
-    cleanShutdown: value.cleanShutdown === true,
-  };
-}
-
-function normalizeLegacyPersistedStore(value: unknown): PersistedMatrixSyncStore | null {
-  const persisted = normalizePersistedStore(value);
-  if (persisted) {
-    return persisted;
-  }
-  return {
-    version: STORE_VERSION,
-    savedSync: toPersistedSyncData(value),
-    cleanShutdown: false,
-  };
-}
 
 function cloneJson<T>(value: T): T {
   return structuredClone(value);
@@ -157,7 +40,6 @@ function syncDataToSyncResponse(syncData: ISyncData): ISyncResponse {
 export class SqliteBackedMatrixSyncStore extends MemoryStore {
   private readonly persistLock = createAsyncLock();
   private readonly accumulator = new SyncAccumulator();
-  private readonly stateKey: string;
   private readonly store: PluginStateSyncKeyedStore<MatrixSyncCacheRecord>;
   private readonly storeUnavailableError: unknown;
   private savedSync: ISyncData | null = null;
@@ -172,7 +54,6 @@ export class SqliteBackedMatrixSyncStore extends MemoryStore {
 
   constructor(private readonly storageRootDir: string) {
     super();
-    this.stateKey = SYNC_CACHE_STATE_KEY;
 
     let restoredSavedSync: ISyncData | null = null;
     let restoredClientOptions: IStoredClientOpts | undefined;
@@ -181,7 +62,7 @@ export class SqliteBackedMatrixSyncStore extends MemoryStore {
     let syncCacheStoreUnavailableError: unknown;
     try {
       syncCacheStore = openMatrixSyncCacheStore(storageRootDir);
-      const persisted = readPersistedStoreFromSyncStore(syncCacheStore, this.stateKey);
+      const persisted = readPersistedStoreFromSyncStore(syncCacheStore);
       if (persisted) {
         restoredSavedSync = persisted.savedSync;
         restoredClientOptions = persisted.clientOptions;
@@ -276,15 +157,10 @@ export class SqliteBackedMatrixSyncStore extends MemoryStore {
     this.savedSync = null;
     this.savedClientOptions = undefined;
     this.cleanShutdown = false;
-    this.store.delete(metaKey(this.stateKey));
-    for (const row of this.store.entries()) {
-      if (row.key.startsWith(chunkKeyPrefix(this.stateKey))) {
-        this.store.delete(row.key);
-      }
-    }
-    await fs
-      .rm(resolveLegacySyncCachePath(this.storageRootDir), { force: true })
-      .catch(() => undefined);
+    await deleteMatrixSyncCacheStateFromSyncStore({
+      storageRootDir: this.storageRootDir,
+      store: this.store,
+    });
   }
 
   markCleanShutdown(): void {
@@ -348,14 +224,14 @@ export class SqliteBackedMatrixSyncStore extends MemoryStore {
     this.assertStoreAvailable();
     this.dirty = false;
     const payload: PersistedMatrixSyncStore = {
-      version: STORE_VERSION,
+      version: MATRIX_SYNC_CACHE_VERSION,
       savedSync: this.savedSync ? cloneJson(this.savedSync) : null,
       cleanShutdown: this.cleanShutdown,
       ...(this.savedClientOptions ? { clientOptions: cloneJson(this.savedClientOptions) } : {}),
     };
     try {
       await this.persistLock(async () => {
-        this.writePersistedStore(payload);
+        writeMatrixSyncCacheStateToSyncStore({ payload, store: this.store });
         claimCurrentTokenStorageState({
           rootDir: this.storageRootDir,
         });
@@ -363,19 +239,6 @@ export class SqliteBackedMatrixSyncStore extends MemoryStore {
     } catch (err) {
       this.dirty = true;
       throw err;
-    }
-  }
-
-  private writePersistedStore(payload: PersistedMatrixSyncStore): void {
-    const rows = buildSyncCacheRows(this.stateKey, payload);
-    for (const row of rows.chunks) {
-      this.store.register(row.key, row.value);
-    }
-    this.store.register(rows.meta.key, rows.meta.value);
-    for (const row of this.store.entries()) {
-      if (row.key.startsWith(chunkKeyPrefix(this.stateKey)) && !rows.nextChunkKeys.has(row.key)) {
-        this.store.delete(row.key);
-      }
     }
   }
 
@@ -401,233 +264,10 @@ function createNoopMatrixSyncCacheStore(): PluginStateSyncKeyedStore<MatrixSyncC
   };
 }
 
-function readPersistedStoreFromSyncStore(
-  store: PluginStateSyncKeyedStore<MatrixSyncCacheRecord>,
-  stateKey: string,
-): PersistedMatrixSyncStore | null {
-  const meta = store.lookup(metaKey(stateKey));
-  if (!isSyncCacheMeta(meta)) {
-    return null;
-  }
-  const chunks: string[] = [];
-  for (let index = 0; index < meta.chunkCount; index += 1) {
-    const chunk = store.lookup(chunkKey(stateKey, meta.generation, index));
-    if (!isSyncCacheChunk(chunk) || chunk.index !== index) {
-      return normalizePersistedStore({
-        version: STORE_VERSION,
-        savedSync: null,
-        clientOptions: meta.clientOptions,
-        cleanShutdown: false,
-      });
-    }
-    chunks.push(chunk.data);
-  }
-  let savedSync: ISyncData | null = null;
-  if (chunks.length > 0) {
-    const syncJson = chunks.join("");
-    if (meta.syncDigest !== digestText(syncJson)) {
-      return normalizePersistedStore({
-        version: STORE_VERSION,
-        savedSync: null,
-        clientOptions: meta.clientOptions,
-        cleanShutdown: false,
-      });
-    }
-    try {
-      savedSync = toPersistedSyncData(JSON.parse(syncJson));
-    } catch {
-      savedSync = null;
-    }
-  }
-  return normalizePersistedStore({
-    version: STORE_VERSION,
-    savedSync,
-    clientOptions: meta.clientOptions,
-    cleanShutdown: meta.cleanShutdown,
-  });
-}
-
 function openMatrixSyncCacheStore(
   storageRootDir: string,
 ): PluginStateSyncKeyedStore<MatrixSyncCacheRecord> {
   return getMatrixRuntime().state.openSyncKeyedStore<MatrixSyncCacheRecord>(
     openMatrixSyncCacheStoreOptions(storageRootDir),
   );
-}
-
-function metaKey(stateKey: string): string {
-  return `${stateKey}:meta`;
-}
-
-function chunkKeyPrefix(stateKey: string): string {
-  return `${stateKey}:sync:`;
-}
-
-function chunkKey(stateKey: string, generation: string, index: number): string {
-  return `${chunkKeyPrefix(stateKey)}${generation}:${index}`;
-}
-
-function resolveLegacySyncCachePath(storageRootDir: string): string {
-  return path.join(storageRootDir, "bot-storage.json");
-}
-
-function digestText(value: string): string {
-  return createHash("sha256").update(value, "utf8").digest("hex");
-}
-
-function isSyncCacheMeta(value: unknown): value is MatrixSyncCacheMeta {
-  return (
-    isRecord(value) &&
-    value.kind === "meta" &&
-    value.version === STORE_VERSION &&
-    typeof value.generation === "string" &&
-    value.generation.trim() !== "" &&
-    typeof value.chunkCount === "number" &&
-    Number.isSafeInteger(value.chunkCount) &&
-    value.chunkCount >= 0 &&
-    value.chunkCount <= SYNC_CACHE_MAX_CHUNKS
-  );
-}
-
-function isSyncCacheChunk(value: unknown): value is MatrixSyncCacheChunk {
-  return (
-    isRecord(value) &&
-    value.kind === "sync-chunk" &&
-    typeof value.index === "number" &&
-    Number.isSafeInteger(value.index) &&
-    value.index >= 0 &&
-    typeof value.data === "string"
-  );
-}
-
-function chunkSyncCacheJson(value: string): string[] {
-  const chunks: string[] = [];
-  const pushChunk = (chunk: string) => {
-    if (chunks.length >= SYNC_CACHE_MAX_CHUNKS) {
-      throw new Error("Matrix sync cache exceeds SQLite chunk limit");
-    }
-    chunks.push(chunk);
-  };
-  let current = "";
-  let currentBytes = 0;
-  for (const char of value) {
-    const charBytes = Buffer.byteLength(char, "utf8");
-    if (current && currentBytes + charBytes > SYNC_CACHE_CHUNK_BYTES) {
-      pushChunk(current);
-      current = "";
-      currentBytes = 0;
-    }
-    current += char;
-    currentBytes += charBytes;
-  }
-  if (current) {
-    pushChunk(current);
-  }
-  return chunks;
-}
-
-function buildSyncCacheRows(
-  stateKey: string,
-  payload: PersistedMatrixSyncStore,
-): {
-  meta: { key: string; value: MatrixSyncCacheMeta };
-  chunks: { key: string; value: MatrixSyncCacheChunk }[];
-  nextChunkKeys: Set<string>;
-} {
-  const generation = randomUUID().replaceAll("-", "");
-  const syncJson = payload.savedSync ? JSON.stringify(payload.savedSync) : "";
-  const chunkValues = syncJson ? chunkSyncCacheJson(syncJson) : [];
-  const chunks = chunkValues.map((data, index) => ({
-    key: chunkKey(stateKey, generation, index),
-    value: {
-      kind: "sync-chunk" as const,
-      index,
-      data,
-    },
-  }));
-  return {
-    chunks,
-    nextChunkKeys: new Set(chunks.map((chunk) => chunk.key)),
-    meta: {
-      key: metaKey(stateKey),
-      value: {
-        kind: "meta",
-        version: STORE_VERSION,
-        generation,
-        chunkCount: chunks.length,
-        ...(syncJson ? { syncDigest: digestText(syncJson) } : {}),
-        ...(payload.clientOptions ? { clientOptions: payload.clientOptions } : {}),
-        cleanShutdown: payload.cleanShutdown === true,
-      },
-    },
-  };
-}
-
-export async function readLegacyMatrixSyncCacheState(
-  storageRootDir: string,
-): Promise<PersistedMatrixSyncStore | null> {
-  try {
-    const raw = await fs.readFile(resolveLegacySyncCachePath(storageRootDir), "utf8");
-    const persisted = normalizeLegacyPersistedStore(JSON.parse(raw));
-    if (!persisted?.savedSync && !persisted?.clientOptions) {
-      return null;
-    }
-    return persisted;
-  } catch {
-    return null;
-  }
-}
-
-export async function hasMatrixSyncCacheStateInStore(params: {
-  storageRootDir: string;
-  store: Pick<PluginStateKeyedStore<MatrixSyncCacheRecord>, "lookup">;
-}): Promise<boolean> {
-  const stateKey = SYNC_CACHE_STATE_KEY;
-  const meta = await params.store.lookup(metaKey(stateKey));
-  if (!isSyncCacheMeta(meta) || meta.chunkCount <= 0) {
-    return false;
-  }
-  const chunks: string[] = [];
-  for (let index = 0; index < meta.chunkCount; index += 1) {
-    const chunk = await params.store.lookup(chunkKey(stateKey, meta.generation, index));
-    if (!isSyncCacheChunk(chunk) || chunk.index !== index) {
-      return false;
-    }
-    chunks.push(chunk.data);
-  }
-  const syncJson = chunks.join("");
-  if (meta.syncDigest !== digestText(syncJson)) {
-    return false;
-  }
-  try {
-    return toPersistedSyncData(JSON.parse(syncJson)) !== null;
-  } catch {
-    return false;
-  }
-}
-
-export async function writeMatrixSyncCacheStateToStore(params: {
-  storageRootDir: string;
-  payload: PersistedMatrixSyncStore;
-  store: MatrixSyncCacheAsyncStore;
-}): Promise<void> {
-  const stateKey = SYNC_CACHE_STATE_KEY;
-  const rows = buildSyncCacheRows(stateKey, params.payload);
-  for (const row of rows.chunks) {
-    await params.store.register(row.key, row.value);
-  }
-  await params.store.register(rows.meta.key, rows.meta.value);
-  for (const row of await params.store.entries()) {
-    if (row.key.startsWith(chunkKeyPrefix(stateKey)) && !rows.nextChunkKeys.has(row.key)) {
-      await params.store.delete(row.key);
-    }
-  }
-}
-
-export function openMatrixSyncCacheStoreOptions(storageRootDir: string) {
-  return {
-    namespace: SYNC_CACHE_NAMESPACE,
-    maxEntries: SYNC_CACHE_MAX_ENTRIES,
-    env: resolveMatrixSqliteStateEnv({ stateDir: storageRootDir }),
-  };
 }

--- a/extensions/matrix/src/matrix/client/storage.ts
+++ b/extensions/matrix/src/matrix/client/storage.ts
@@ -395,7 +395,9 @@ export async function maybeMigrateLegacyStorage(params: {
   env?: NodeJS.ProcessEnv;
 }): Promise<void> {
   const hasAccountScopedLegacyStorageFile = fs.existsSync(params.storagePaths.storagePath);
-  const syncCache = hasAccountScopedLegacyStorageFile ? await import("./file-sync-store.js") : null;
+  const syncCache = hasAccountScopedLegacyStorageFile
+    ? await import("./sync-cache-state.js")
+    : null;
   const hasAccountScopedLegacyStorage =
     hasAccountScopedLegacyStorageFile &&
     (await syncCache?.readLegacyMatrixSyncCacheState(params.storagePaths.rootDir)) !== null;
@@ -480,13 +482,13 @@ async function migrateLegacySyncCacheToSqlite(params: {
   moved: LegacyMoveRecord[];
   pendingArchives: LegacyArchiveRecord[];
 }): Promise<void> {
-  const syncCache = await import("./file-sync-store.js");
+  const syncCache = await import("./sync-cache-state.js");
   const persisted = await syncCache.readLegacyMatrixSyncCacheState(params.sourceRootDir);
   if (!persisted) {
     return;
   }
   const store = getMatrixRuntime().state.openKeyedStore<
-    import("./file-sync-store.js").MatrixSyncCacheRecord
+    import("./sync-cache-state.js").MatrixSyncCacheRecord
   >(syncCache.openMatrixSyncCacheStoreOptions(params.targetRootDir));
   if (
     !(await syncCache.hasMatrixSyncCacheStateInStore({

--- a/extensions/matrix/src/matrix/client/sync-cache-state.ts
+++ b/extensions/matrix/src/matrix/client/sync-cache-state.ts
@@ -1,0 +1,385 @@
+// Shared Matrix sync-cache persistence; no live SDK runtime is needed to migrate state.
+import { createHash, randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { ISyncData, IRooms, IStoredClientOpts } from "matrix-js-sdk/lib/matrix.js";
+import type {
+  PluginStateKeyedStore,
+  PluginStateSyncKeyedStore,
+} from "openclaw/plugin-sdk/plugin-state-runtime";
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { resolveMatrixSqliteStateEnv } from "../sqlite-state.js";
+
+export const MATRIX_SYNC_CACHE_VERSION = 1;
+const SYNC_CACHE_NAMESPACE = "sync-cache";
+const SYNC_CACHE_MAX_ENTRIES = 20_000;
+const SYNC_CACHE_MAX_CHUNKS = Math.floor((SYNC_CACHE_MAX_ENTRIES - 1) / 2);
+const SYNC_CACHE_STATE_KEY = "current";
+// PluginState serializes this string inside a row object; 24KB leaves room for JSON escaping.
+const SYNC_CACHE_CHUNK_BYTES = 24_000;
+
+export type PersistedMatrixSyncStore = {
+  version: number;
+  savedSync: ISyncData | null;
+  clientOptions?: IStoredClientOpts;
+  cleanShutdown?: boolean;
+};
+
+type MatrixSyncCacheMeta = {
+  kind: "meta";
+  version: number;
+  generation: string;
+  chunkCount: number;
+  syncDigest?: string;
+  clientOptions?: IStoredClientOpts;
+  cleanShutdown?: boolean;
+};
+
+type MatrixSyncCacheChunk = {
+  kind: "sync-chunk";
+  index: number;
+  data: string;
+};
+
+export type MatrixSyncCacheRecord = MatrixSyncCacheMeta | MatrixSyncCacheChunk;
+
+type MatrixSyncCacheAsyncStore = Pick<
+  PluginStateKeyedStore<MatrixSyncCacheRecord>,
+  "delete" | "entries" | "lookup" | "register"
+>;
+
+function normalizeRoomsData(value: unknown): IRooms | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  // These are the Matrix /sync room categories, shared by persisted SDK snapshots.
+  // Keep protocol keys here without loading the live SDK for Doctor migrations.
+  return {
+    // SAFETY: Joined-room fields remain opaque SDK snapshot data after the record check.
+    join: isRecord(value.join) ? (value.join as IRooms["join"]) : {},
+    // SAFETY: Invited-room fields remain opaque SDK snapshot data after the record check.
+    invite: isRecord(value.invite) ? (value.invite as IRooms["invite"]) : {},
+    // SAFETY: Left-room fields remain opaque SDK snapshot data after the record check.
+    leave: isRecord(value.leave) ? (value.leave as IRooms["leave"]) : {},
+    // SAFETY: Knocked-room fields remain opaque SDK snapshot data after the record check.
+    knock: isRecord(value.knock) ? (value.knock as IRooms["knock"]) : {},
+  };
+}
+
+function toPersistedSyncData(value: unknown): ISyncData | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+  if (typeof value.nextBatch === "string" && value.nextBatch.trim()) {
+    const roomsData = normalizeRoomsData(value.roomsData);
+    if (!Array.isArray(value.accountData) || !roomsData) {
+      return null;
+    }
+    return {
+      nextBatch: value.nextBatch,
+      accountData: value.accountData,
+      roomsData,
+    };
+  }
+
+  // Older Matrix state files stored the raw /sync-shaped payload directly.
+  if (typeof value.next_batch === "string" && value.next_batch.trim()) {
+    const roomsData = normalizeRoomsData(value.rooms);
+    if (!roomsData) {
+      return null;
+    }
+    return {
+      nextBatch: value.next_batch,
+      accountData:
+        isRecord(value.account_data) && Array.isArray(value.account_data.events)
+          ? value.account_data.events
+          : [],
+      roomsData,
+    };
+  }
+
+  return null;
+}
+
+function normalizePersistedStore(value: unknown): PersistedMatrixSyncStore | null {
+  if (!isRecord(value) || value.version !== MATRIX_SYNC_CACHE_VERSION) {
+    return null;
+  }
+  return {
+    version: MATRIX_SYNC_CACHE_VERSION,
+    savedSync: toPersistedSyncData(value.savedSync),
+    clientOptions: isRecord(value.clientOptions)
+      ? (value.clientOptions as IStoredClientOpts) // SAFETY: SDK options remain opaque after record validation.
+      : undefined,
+    cleanShutdown: value.cleanShutdown === true,
+  };
+}
+
+function normalizeLegacyPersistedStore(value: unknown): PersistedMatrixSyncStore | null {
+  const persisted = normalizePersistedStore(value);
+  if (persisted) {
+    return persisted;
+  }
+  return {
+    version: MATRIX_SYNC_CACHE_VERSION,
+    savedSync: toPersistedSyncData(value),
+    cleanShutdown: false,
+  };
+}
+
+export function readPersistedStoreFromSyncStore(
+  store: PluginStateSyncKeyedStore<MatrixSyncCacheRecord>,
+): PersistedMatrixSyncStore | null {
+  const stateKey = SYNC_CACHE_STATE_KEY;
+  const meta = store.lookup(metaKey(stateKey));
+  if (!isSyncCacheMeta(meta)) {
+    return null;
+  }
+  const chunks: string[] = [];
+  for (let index = 0; index < meta.chunkCount; index += 1) {
+    const chunk = store.lookup(chunkKey(stateKey, meta.generation, index));
+    if (!isSyncCacheChunk(chunk) || chunk.index !== index) {
+      return normalizePersistedStore({
+        version: MATRIX_SYNC_CACHE_VERSION,
+        savedSync: null,
+        clientOptions: meta.clientOptions,
+        cleanShutdown: false,
+      });
+    }
+    chunks.push(chunk.data);
+  }
+  let savedSync: ISyncData | null = null;
+  if (chunks.length > 0) {
+    const syncJson = chunks.join("");
+    if (meta.syncDigest !== digestText(syncJson)) {
+      return normalizePersistedStore({
+        version: MATRIX_SYNC_CACHE_VERSION,
+        savedSync: null,
+        clientOptions: meta.clientOptions,
+        cleanShutdown: false,
+      });
+    }
+    try {
+      savedSync = toPersistedSyncData(JSON.parse(syncJson));
+    } catch {
+      savedSync = null;
+    }
+  }
+  return normalizePersistedStore({
+    version: MATRIX_SYNC_CACHE_VERSION,
+    savedSync,
+    clientOptions: meta.clientOptions,
+    cleanShutdown: meta.cleanShutdown,
+  });
+}
+
+function metaKey(stateKey: string): string {
+  return `${stateKey}:meta`;
+}
+
+function chunkKeyPrefix(stateKey: string): string {
+  return `${stateKey}:sync:`;
+}
+
+function chunkKey(stateKey: string, generation: string, index: number): string {
+  return `${chunkKeyPrefix(stateKey)}${generation}:${index}`;
+}
+
+function resolveLegacySyncCachePath(storageRootDir: string): string {
+  return path.join(storageRootDir, "bot-storage.json");
+}
+
+function digestText(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+function isSyncCacheMeta(value: unknown): value is MatrixSyncCacheMeta {
+  return (
+    isRecord(value) &&
+    value.kind === "meta" &&
+    value.version === MATRIX_SYNC_CACHE_VERSION &&
+    typeof value.generation === "string" &&
+    value.generation.trim() !== "" &&
+    typeof value.chunkCount === "number" &&
+    Number.isSafeInteger(value.chunkCount) &&
+    value.chunkCount >= 0 &&
+    value.chunkCount <= SYNC_CACHE_MAX_CHUNKS
+  );
+}
+
+function isSyncCacheChunk(value: unknown): value is MatrixSyncCacheChunk {
+  return (
+    isRecord(value) &&
+    value.kind === "sync-chunk" &&
+    typeof value.index === "number" &&
+    Number.isSafeInteger(value.index) &&
+    value.index >= 0 &&
+    typeof value.data === "string"
+  );
+}
+
+function chunkSyncCacheJson(value: string): string[] {
+  const chunks: string[] = [];
+  const pushChunk = (chunk: string) => {
+    if (chunks.length >= SYNC_CACHE_MAX_CHUNKS) {
+      throw new Error("Matrix sync cache exceeds SQLite chunk limit");
+    }
+    chunks.push(chunk);
+  };
+  let current = "";
+  let currentBytes = 0;
+  for (const char of value) {
+    const charBytes = Buffer.byteLength(char, "utf8");
+    if (current && currentBytes + charBytes > SYNC_CACHE_CHUNK_BYTES) {
+      pushChunk(current);
+      current = "";
+      currentBytes = 0;
+    }
+    current += char;
+    currentBytes += charBytes;
+  }
+  if (current) {
+    pushChunk(current);
+  }
+  return chunks;
+}
+
+function buildSyncCacheRows(
+  stateKey: string,
+  payload: PersistedMatrixSyncStore,
+): {
+  meta: { key: string; value: MatrixSyncCacheMeta };
+  chunks: { key: string; value: MatrixSyncCacheChunk }[];
+  nextChunkKeys: Set<string>;
+} {
+  const generation = randomUUID().replaceAll("-", "");
+  const syncJson = payload.savedSync ? JSON.stringify(payload.savedSync) : "";
+  const chunkValues = syncJson ? chunkSyncCacheJson(syncJson) : [];
+  const chunks = chunkValues.map((data, index) => ({
+    key: chunkKey(stateKey, generation, index),
+    value: {
+      kind: "sync-chunk" as const,
+      index,
+      data,
+    },
+  }));
+  return {
+    chunks,
+    nextChunkKeys: new Set(chunks.map((chunk) => chunk.key)),
+    meta: {
+      key: metaKey(stateKey),
+      value: {
+        kind: "meta",
+        version: MATRIX_SYNC_CACHE_VERSION,
+        generation,
+        chunkCount: chunks.length,
+        ...(syncJson ? { syncDigest: digestText(syncJson) } : {}),
+        ...(payload.clientOptions ? { clientOptions: payload.clientOptions } : {}),
+        cleanShutdown: payload.cleanShutdown === true,
+      },
+    },
+  };
+}
+
+export async function readLegacyMatrixSyncCacheState(
+  storageRootDir: string,
+): Promise<PersistedMatrixSyncStore | null> {
+  try {
+    const raw = await fs.readFile(resolveLegacySyncCachePath(storageRootDir), "utf8");
+    const persisted = normalizeLegacyPersistedStore(JSON.parse(raw));
+    if (!persisted?.savedSync && !persisted?.clientOptions) {
+      return null;
+    }
+    return persisted;
+  } catch {
+    return null;
+  }
+}
+
+export async function hasMatrixSyncCacheStateInStore(params: {
+  storageRootDir: string;
+  store: Pick<PluginStateKeyedStore<MatrixSyncCacheRecord>, "lookup">;
+}): Promise<boolean> {
+  const stateKey = SYNC_CACHE_STATE_KEY;
+  const meta = await params.store.lookup(metaKey(stateKey));
+  if (!isSyncCacheMeta(meta) || meta.chunkCount <= 0) {
+    return false;
+  }
+  const chunks: string[] = [];
+  for (let index = 0; index < meta.chunkCount; index += 1) {
+    const chunk = await params.store.lookup(chunkKey(stateKey, meta.generation, index));
+    if (!isSyncCacheChunk(chunk) || chunk.index !== index) {
+      return false;
+    }
+    chunks.push(chunk.data);
+  }
+  const syncJson = chunks.join("");
+  if (meta.syncDigest !== digestText(syncJson)) {
+    return false;
+  }
+  try {
+    return toPersistedSyncData(JSON.parse(syncJson)) !== null;
+  } catch {
+    return false;
+  }
+}
+
+export async function writeMatrixSyncCacheStateToStore(params: {
+  storageRootDir: string;
+  payload: PersistedMatrixSyncStore;
+  store: MatrixSyncCacheAsyncStore;
+}): Promise<void> {
+  const stateKey = SYNC_CACHE_STATE_KEY;
+  const rows = buildSyncCacheRows(stateKey, params.payload);
+  for (const row of rows.chunks) {
+    await params.store.register(row.key, row.value);
+  }
+  await params.store.register(rows.meta.key, rows.meta.value);
+  for (const row of await params.store.entries()) {
+    if (row.key.startsWith(chunkKeyPrefix(stateKey)) && !rows.nextChunkKeys.has(row.key)) {
+      await params.store.delete(row.key);
+    }
+  }
+}
+
+export function openMatrixSyncCacheStoreOptions(storageRootDir: string) {
+  return {
+    namespace: SYNC_CACHE_NAMESPACE,
+    maxEntries: SYNC_CACHE_MAX_ENTRIES,
+    env: resolveMatrixSqliteStateEnv({ stateDir: storageRootDir }),
+  };
+}
+
+export function writeMatrixSyncCacheStateToSyncStore(params: {
+  payload: PersistedMatrixSyncStore;
+  store: PluginStateSyncKeyedStore<MatrixSyncCacheRecord>;
+}): void {
+  const rows = buildSyncCacheRows(SYNC_CACHE_STATE_KEY, params.payload);
+  for (const row of rows.chunks) {
+    params.store.register(row.key, row.value);
+  }
+  params.store.register(rows.meta.key, rows.meta.value);
+  for (const row of params.store.entries()) {
+    if (
+      row.key.startsWith(chunkKeyPrefix(SYNC_CACHE_STATE_KEY)) &&
+      !rows.nextChunkKeys.has(row.key)
+    ) {
+      params.store.delete(row.key);
+    }
+  }
+}
+
+export async function deleteMatrixSyncCacheStateFromSyncStore(params: {
+  storageRootDir: string;
+  store: PluginStateSyncKeyedStore<MatrixSyncCacheRecord>;
+}): Promise<void> {
+  params.store.delete(metaKey(SYNC_CACHE_STATE_KEY));
+  for (const row of params.store.entries()) {
+    if (row.key.startsWith(chunkKeyPrefix(SYNC_CACHE_STATE_KEY))) {
+      params.store.delete(row.key);
+    }
+  }
+  await fs
+    .rm(resolveLegacySyncCachePath(params.storageRootDir), { force: true })
+    .catch(() => undefined);
+}

--- a/src/plugins/doctor-contract-closure-guard.test.ts
+++ b/src/plugins/doctor-contract-closure-guard.test.ts
@@ -17,6 +17,15 @@ type ClosureKind = "doctor-contract" | "legacy-setup";
 // still share sync runtime modules with these barrels and are a named follow-up.
 const FORBIDDEN_SPECIFIER_RULES = new Map<string, { reason: string; kinds: Set<ClosureKind> }>([
   [
+    "matrix-js-sdk/lib/matrix.js",
+    {
+      reason:
+        "the Matrix SDK barrel loads the live client, crypto and WebRTC graph; " +
+        "keep persisted-state codecs separate from live client stores",
+      kinds: new Set(["doctor-contract"]),
+    },
+  ],
+  [
     FORBIDDEN_SPECIFIER,
     {
       reason:

--- a/test/plugin-cron-registry-owner.e2e.test.ts
+++ b/test/plugin-cron-registry-owner.e2e.test.ts
@@ -246,7 +246,10 @@ async function waitForRequestCount(
   count: number,
 ): Promise<void> {
   await vi.waitFor(() => {
-    expect(requestsContaining(server, marker).length).toBeGreaterThanOrEqual(count);
+    expect(
+      requestsContaining(server, marker).length,
+      `model request marker: ${marker}`,
+    ).toBeGreaterThanOrEqual(count);
   }, WAIT_OPTIONS);
 }
 


### PR DESCRIPTION
Doctor's public low-memory import check exposed unnecessary plugin runtime loading. A native Node 24.19 reproduction exhausted the 256 MiB heap after public repairs completed. Same-process heap snapshots then showed 71.82 MiB of retained module/compiler growth, including MatrixClient and the ACP protocol schema. The snapshots force GC and are diagnostic evidence, not a passing memory test or proof of a transcript-data leak.

This repair keeps Matrix's sync-cache codec and persistence operations in one shared owner, separate from the live SDK store class. Doctor and runtime migration use that owner; the live client keeps its existing canonical SDK entrypoint. Chunk keys, version, digest checks, write/delete order, and migration behavior are unchanged. ACPX now returns after its existing filename validation finds no legacy records, before inspecting unrelated claims or loading its runtime. Nonempty records and explicit migration retain all ownership, process-liveness, and incomplete-evidence checks. No plugin is disabled or skipped, and no heap, timeout, fixture, cache lifetime, config, or schema is changed.

The existing cron timeout assertion message remains in this PR. It identifies the missing model-request marker without changing the timeout, polling, or assertion. The earlier cron failure passed independent original-order replays, so this message is diagnostic improvement, not a claimed cron runtime fix. The Doctor repair was added after this PR's initial CI exposed the unrelated memory failure.

Validation so far:

- The unchanged actual Doctor memory file passed all three native Linux cases in original batch → deep → public order, under 256 MiB and the existing 180-second child/test deadlines. Deep/public still use 100,000 events with 4,096-byte payloads and verify exact event digests, completed projections, and idempotence. Total Vitest time was 93.13s; public migration reported 40.18s. There was no instrumentation, forced cleanup, or remaining process. The [native environment workflow](https://github.com/openclaw/openclaw/actions/runs/33456328446) was pinned to protected main `cc9a9ebeb3dcc363bea09575b34eb55d58af171e`; the applied candidate tree was `f8c29f2d6673edb20d20a129499c35e0d2fc21e3`, with all 35,923 source entries verified before and after. Final reviewed tree `092a8ba65cdaef626d4be33bd8a8fa23a873eb78` differs only by deleting the obsolete assertion-baseline entry; runtime and test bytes are identical.
- All 72 focused tests passed on the composed candidate and current frozen lockfile: Matrix migration/store/SDK behavior, ACPX ownership migration, and the existing Doctor import-boundary guard. The Matrix import guard fails before the split; two ACPX empty/missing-directory regressions fail before the early return. A separate cold import probe verifies zero ACP runtime imports or claim inspections for those cases, with malformed-filename and unexpected-filesystem-error behavior preserved.
- Independent Codex review of all 11 changed files found no actionable P0–P2 findings. The moved assertions now document their existing opaque-data invariants, and the obsolete five-assertion baseline is removed rather than waived.

The complete `pnpm build` passed all canonical stages in 5m51s, including SDK declarations, 63 external plugin builds, CLI checks, and UI size checks. The complete composed scoped gate passed, including core-test, plugin runtime/test and root-test types, all three lint lanes, Doctor declaration/import checks, ratchets, dead-export scans, and architecture guards. Exact-head [CI 33457932206](https://github.com/openclaw/openclaw/actions/runs/33457932206) passed on `c105fadc04f00d05c499efa18047b2b49f98cea3`: 126 successful jobs, 16 skipped, zero failures; required `openclaw/ci-gate` 99703031131 passed. This is not full release certification; a new frozen full verification follows the main landing. Telegram remains advisory.

Production net +30 lines implements the shared Matrix persistence boundary (+27, mostly moved code and required import/assertion documentation) and ACPX's no-work return (+3). Tests net +37, changelog +1, and assertion baseline −1. Broader Memory Wiki/Canvas import cost, Matrix's existing metadata fallback, and crypto snapshot dependency cost remain named follow-up investigations outside this proven boundary.
