### PR TITLE
test(process): observe lane publication without timer flushing

### DIFF
--- a/src/process/command-queue.publish-transaction.test.ts
+++ b/src/process/command-queue.publish-transaction.test.ts
@@ -1,16 +1,10 @@
 /**
- * Atomic lane-configuration publication.
- *
- * Round-4 review (fiducian-spencer-001) asked specifically for a regression
- * that "would fail if any member drains during publication before the group is
- * installed, not just a post-state assertion". A post-state check is too weak:
- * work admitted above budget during the publication window can complete before
- * the assertion runs, leaving final counts looking correct.
- *
- * These tests therefore observe PEAK concurrency across the window, using tasks
- * that park so nothing can retire before it is counted.
+ * Atomic lane publication must never admit work before the group budget exists.
+ * Park admitted tasks and sample peak concurrency at task entry so an excess
+ * admission cannot disappear before the assertion observes it.
  */
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 import {
   clearCommandLane,
   enqueueCommandInLane,
@@ -36,22 +30,6 @@ function clearCommandLaneGroup(group: string): void {
   publishLaneConfiguration({ clearGroups: [group] });
 }
 
-function gate() {
-  let release!: () => void;
-  const promise = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  return { promise, release };
-}
-
-async function settle(): Promise<void> {
-  for (let i = 0; i < 5; i++) {
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
-    });
-  }
-}
-
 beforeEach(() => {
   resetAllLanes();
   clearCommandLaneGroup(GROUP);
@@ -75,10 +53,11 @@ describe("publishLaneConfiguration", () => {
 
     let active = 0;
     let peak = 0;
-    const gates: Array<{ release: () => void }> = [];
+    const publishedStarts = createDeferred();
+    const gates: Array<{ resolve: () => void }> = [];
     const runs: Array<Promise<unknown>> = [];
     const park = (lane: string) => {
-      const g = gate();
+      const g = createDeferred();
       gates.push(g);
       runs.push(
         enqueueCommandInLane(lane, async () => {
@@ -86,6 +65,9 @@ describe("publishLaneConfiguration", () => {
           // Peak is sampled on entry, before anything can retire, so work
           // admitted inside the publication window cannot escape the count.
           peak = Math.max(peak, active);
+          if (active >= 8) {
+            publishedStarts.resolve();
+          }
           await g.promise;
           active -= 1;
         }),
@@ -97,30 +79,40 @@ describe("publishLaneConfiguration", () => {
     for (let i = 0; i < 6; i++) {
       park(HOOK);
     }
-    await settle();
     expect(active).toBe(0); // nothing may run before publication
+    expect(getCommandLaneSnapshot(CRON).activeCount).toBe(0);
+    expect(getCommandLaneSnapshot(HOOK).activeCount).toBe(0);
 
-    publishLaneConfiguration({
-      lanes: { [CRON]: 8, [HOOK]: 4 },
-      groups: {
-        [GROUP]: {
-          budget: 8,
-          members: [CRON, HOOK],
-          reservations: { [HOOK]: 1 },
+    try {
+      publishLaneConfiguration({
+        lanes: { [CRON]: 8, [HOOK]: 4 },
+        groups: {
+          [GROUP]: {
+            budget: 8,
+            members: [CRON, HOOK],
+            reservations: { [HOOK]: 1 },
+          },
         },
-      },
-    });
-    await settle();
+      });
 
-    // The assertion the review asked for: peak, not final state.
-    expect(peak).toBeLessThanOrEqual(8);
-    // And not vacuous — publication must actually have dispatched to the cap.
-    expect(peak).toBe(8);
+      await withTestTimeout(
+        publishedStarts.promise,
+        1_000,
+        "publication did not start the shared group budget",
+      );
 
-    for (const g of gates) {
-      g.release();
+      // Sample task entry while all admitted tasks remain parked.
+      expect(peak).toBeLessThanOrEqual(8);
+      // And not vacuous — publication must actually have dispatched to the cap.
+      expect(peak).toBe(8);
+    } finally {
+      for (const g of gates) {
+        g.resolve();
+      }
+      clearCommandLane(CRON);
+      clearCommandLane(HOOK);
+      await Promise.allSettled(runs);
     }
-    await Promise.all(runs);
   });
 
   test("commit dispatch uses group order rather than publication object order", async () => {
@@ -128,12 +120,15 @@ describe("publishLaneConfiguration", () => {
     setCommandLaneConcurrency(HOOK, 0);
 
     const starts: string[] = [];
-    const cronGate = gate();
-    const hookGate = gate();
+    const cronStarted = createDeferred();
+    const hookStarted = createDeferred();
+    const cronGate = createDeferred();
+    const hookGate = createDeferred();
     const olderCron = enqueueCommandInLane(
       CRON,
       async () => {
         starts.push(CRON);
+        cronStarted.resolve();
         await cronGate.promise;
       },
       { priority: "background" },
@@ -142,26 +137,41 @@ describe("publishLaneConfiguration", () => {
       HOOK,
       async () => {
         starts.push(HOOK);
+        hookStarted.resolve();
         await hookGate.promise;
       },
       { priority: "background" },
     );
 
-    // Deliberately publish HOOK first in both objects. The older CRON head must
-    // still own the single shared slot.
-    publishLaneConfiguration({
-      lanes: { [HOOK]: 1, [CRON]: 1 },
-      groups: { [GROUP]: { budget: 1, members: [HOOK, CRON] } },
-    });
-    await settle();
-    expect(starts).toEqual([CRON]);
+    try {
+      // Deliberately publish HOOK first in both objects. The older CRON head must
+      // still own the single shared slot.
+      publishLaneConfiguration({
+        lanes: { [HOOK]: 1, [CRON]: 1 },
+        groups: { [GROUP]: { budget: 1, members: [HOOK, CRON] } },
+      });
+      await withTestTimeout(
+        cronStarted.promise,
+        1_000,
+        "publication did not start the older cron task",
+      );
+      expect(starts).toEqual([CRON]);
 
-    cronGate.release();
-    await olderCron;
-    await settle();
-    expect(starts).toEqual([CRON, HOOK]);
-    hookGate.release();
-    await newerHook;
+      cronGate.resolve();
+      await olderCron;
+      await withTestTimeout(
+        hookStarted.promise,
+        1_000,
+        "cron completion did not start the queued hook",
+      );
+      expect(starts).toEqual([CRON, HOOK]);
+    } finally {
+      cronGate.resolve();
+      hookGate.resolve();
+      clearCommandLane(CRON);
+      clearCommandLane(HOOK);
+      await Promise.allSettled([olderCron, newerHook]);
+    }
   });
 
   test("moving a busy member wakes queued work in its previous group", async () => {
@@ -170,11 +180,10 @@ describe("publishLaneConfiguration", () => {
       groups: { [GROUP]: { budget: 1, members: [CRON, HOOK] } },
     });
 
-    const cronGate = gate();
+    const cronGate = createDeferred();
     const cronRun = enqueueCommandInLane(CRON, async () => await cronGate.promise);
-    const hookGate = gate();
+    const hookGate = createDeferred();
     const hookRun = enqueueCommandInLane(HOOK, async () => await hookGate.promise);
-    await settle();
     expect(getCommandLaneSnapshot(HOOK)).toMatchObject({ activeCount: 0, queuedCount: 1 });
 
     // CRON's active task stops counting against the old group as soon as it is
@@ -182,7 +191,6 @@ describe("publishLaneConfiguration", () => {
     publishLaneConfiguration({
       groups: { [MOVED_GROUP]: { budget: 1, members: [CRON, DELIVERY] } },
     });
-    await settle();
     expect(getCommandLaneSnapshot(HOOK)).toMatchObject({
       group: GROUP,
       activeCount: 1,
@@ -190,16 +198,15 @@ describe("publishLaneConfiguration", () => {
     });
     expect(getCommandLaneSnapshot(CRON).group).toBe(MOVED_GROUP);
 
-    cronGate.release();
-    hookGate.release();
+    cronGate.resolve();
+    hookGate.resolve();
     await Promise.all([cronRun, hookRun]);
   });
 
   test("a rejected configuration does not leave lanes widened and dispatching", async () => {
     setCommandLaneConcurrency(CRON, 0);
-    const gates = Array.from({ length: 4 }, () => gate());
+    const gates = Array.from({ length: 4 }, () => createDeferred());
     const runs = gates.map((g) => enqueueCommandInLane(CRON, async () => await g.promise));
-    await settle();
 
     // sum(reservations) > budget is rejected. Validation must happen before any
     // drain, or the lane is left open at width 8 governed by no group at all.
@@ -215,12 +222,11 @@ describe("publishLaneConfiguration", () => {
         },
       }),
     ).toThrow(/reserves 3 slots but its budget is 2/);
-    await settle();
 
     expect(getCommandLaneSnapshot(CRON).activeCount).toBe(0);
 
     for (const g of gates) {
-      g.release();
+      g.resolve();
     }
     // The lane never opened, so this work is still queued. resetAllLanes
     // PRESERVES queued entries by design, so it would never settle these —
@@ -236,9 +242,8 @@ describe("publishLaneConfiguration", () => {
     // the new width governed by NO group, and the next unrelated drain trigger
     // dispatches the preserved queue ungoverned.
     setCommandLaneConcurrency(CRON, 0);
-    const gates = Array.from({ length: 4 }, () => gate());
+    const gates = Array.from({ length: 4 }, () => createDeferred());
     const runs = gates.map((g) => enqueueCommandInLane(CRON, async () => await g.promise));
-    await settle();
     expect(getCommandLaneSnapshot(CRON).maxConcurrent).toBe(0);
 
     expect(() =>
@@ -253,7 +258,6 @@ describe("publishLaneConfiguration", () => {
         },
       }),
     ).toThrow(/reserves 3 slots but its budget is 2/);
-    await settle();
 
     // The lane must be exactly as it was before the rejected publish.
     expect(getCommandLaneSnapshot(CRON).maxConcurrent).toBe(0);
@@ -261,21 +265,20 @@ describe("publishLaneConfiguration", () => {
 
     // And a later drain trigger must not dispatch the queue that was preserved
     // across the failed publish.
-    const extra = gate();
+    const extra = createDeferred();
     const extraRun = enqueueCommandInLane(CRON, async () => await extra.promise);
-    await settle();
     expect(getCommandLaneSnapshot(CRON).activeCount).toBe(0);
 
     for (const g of gates) {
-      g.release();
+      g.resolve();
     }
-    extra.release();
+    extra.resolve();
     clearCommandLane(CRON);
     await Promise.allSettled([...runs, extraRun]);
   });
 
   test("a rejected replacement does not tear down the existing group first", async () => {
-    // costaff round-5: combining clearGroups with an invalid replacement is the
+    // Combining clearGroups with an invalid replacement is the
     // worst case — the old group could be removed before the new one throws,
     // leaving BOTH lane width and group membership partially committed. Phase 0
     // validation has to run before the clear, not just before the install.
@@ -309,30 +312,26 @@ describe("publishLaneConfiguration", () => {
   });
 
   test("publication wakes members when a replacement frees capacity", async () => {
-    // costaff round-5: the exported primitive's "replace" semantics were not
-    // self-waking. publishLaneConfiguration drains at commit, but a direct
-    // A publication that widens a budget or drops a reservation would
-    // leave queued members stuck until some unrelated enqueue poked the lane.
+    // Replacing a group must wake queued members when its new budget has room,
+    // without waiting for an unrelated enqueue to trigger another drain.
     setCommandLaneConcurrency(CRON, 8);
     setCommandLaneConcurrency(HOOK, 1);
     setCommandLaneGroup(GROUP, { budget: 2, members: [CRON, HOOK] });
 
-    const gates = Array.from({ length: 5 }, () => gate());
+    const gates = Array.from({ length: 5 }, () => createDeferred());
     const runs = gates.map((g) => enqueueCommandInLane(CRON, async () => await g.promise));
-    await settle();
     expect(getCommandLaneSnapshot(CRON).activeCount).toBe(2);
     expect(getCommandLaneSnapshot(CRON).queuedCount).toBe(3);
 
-    // Widen the budget via the bare primitive — no publication involved.
+    // Publish a wider group budget without changing individual lane widths.
     setCommandLaneGroup(GROUP, { budget: 5, members: [CRON, HOOK] });
-    await settle();
 
     // The queued work must start on the replacement itself.
     expect(getCommandLaneSnapshot(CRON).activeCount).toBe(5);
     expect(getCommandLaneSnapshot(CRON).queuedCount).toBe(0);
 
     for (const g of gates) {
-      g.release();
+      g.resolve();
     }
     await Promise.all(runs);
   });
@@ -345,9 +344,8 @@ describe("publishLaneConfiguration", () => {
       },
     });
 
-    const gates = Array.from({ length: 3 }, () => gate());
+    const gates = Array.from({ length: 3 }, () => createDeferred());
     const runs = gates.map((g) => enqueueCommandInLane(CRON, async () => await g.promise));
-    await settle();
     expect(getCommandLaneSnapshot(CRON).activeCount).toBe(3);
 
     // Narrowing mid-flight cannot evict running work, but it must not admit
@@ -358,17 +356,16 @@ describe("publishLaneConfiguration", () => {
         [GROUP]: { budget: 2, members: [CRON, HOOK], reservations: { [HOOK]: 1 } },
       },
     });
-    const extra = gate();
+    const extra = createDeferred();
     const blocked = enqueueCommandInLane(CRON, async () => await extra.promise);
-    await settle();
 
     expect(getCommandLaneSnapshot(CRON).activeCount).toBe(3);
     expect(getCommandLaneSnapshot(CRON).blockedBy).toBe("group-budget");
 
     for (const g of gates) {
-      g.release();
+      g.resolve();
     }
-    extra.release();
+    extra.resolve();
     clearCommandLane(CRON);
     await Promise.allSettled([...runs, blocked]);
   });


### PR DESCRIPTION
The lane-publication suite flushes five timer turns after each queue operation, even though admission snapshots are committed synchronously. Use those snapshots directly and bounded task-entry promises where the test must observe actual peak concurrency or dispatch order. This removes 75 zero-delay callbacks and the local gate implementation.

All eight publication cases and their 28 original assertions remain, with two added pre-publication admission checks. The two task-entry observation cases now release parked work and await settlements in `finally`. Production +0/-0; tests +93/-96.

Validation: 29 publication/capacity-group cases pass before and after in one non-isolated worker, plus four gateway-lane cases. A temporary early-drain fault makes the revised peak test fail with 12 active tasks against the limit of 8; the owner was restored byte-for-byte and all 33 cases pass again. Full changed-file checks passed; independent Codex autoreview is clean. This claims removal of unnecessary timer work, not a controlled wall-clock benchmark.

Follow-up: the six other publication cases retain their existing assertion-failure cleanup; extending fixture-owned teardown to those flows is separate from the observed task-entry waits.
