### PR TITLE
test(music): remove redundant registration coverage

### DIFF
--- a/config/max-lines-baseline.txt
+++ b/config/max-lines-baseline.txt
@@ -406,7 +406,6 @@ src/agents/tools/image-tool.ts
 src/agents/tools/media-generate-background-shared.test.ts
 src/agents/tools/message-tool.test.ts
 src/agents/tools/music-generate-tool.test.ts
-src/agents/tools/music-generate-tool.ts
 src/agents/tools/session-status-tool.ts
 src/agents/tools/sessions-send-tool.ts
 src/agents/tools/sessions-spawn-tool.test.ts

--- a/src/agents/tools/music-generate-tool.test.ts
+++ b/src/agents/tools/music-generate-tool.test.ts
@@ -288,20 +288,6 @@ describe("createMusicGenerateTool", () => {
     ).toBeNull();
   });
 
-  it("registers when music-generation config is present", () => {
-    expectMusicGenerateTool(
-      createMusicGenerateTool({
-        config: asConfig({
-          agents: {
-            defaults: {
-              musicGenerationModel: { primary: "google/lyria-3-clip-preview" },
-            },
-          },
-        }),
-      }),
-    );
-  });
-
   it("tells song requests to generate audio instead of only lyrics", () => {
     const tool = expectMusicGenerateTool(
       createMusicGenerateTool({

--- a/src/agents/tools/music-generate-tool.ts
+++ b/src/agents/tools/music-generate-tool.ts
@@ -127,24 +127,6 @@ const MusicGenerateToolSchema = Type.Object({
   ),
 });
 
-function resolveMusicGenerationModelConfigForTool(params: {
-  cfg?: OpenClawConfig;
-  workspaceDir?: string;
-  agentDir?: string;
-  authStore?: AuthProfileStore;
-  modelOverride?: string;
-}): ToolModelConfig | null {
-  return resolveCapabilityModelConfigForTool({
-    cfg: params.cfg,
-    workspaceDir: params.workspaceDir,
-    agentDir: params.agentDir,
-    authStore: params.authStore,
-    modelConfig: params.cfg?.agents?.defaults?.mediaModels?.music,
-    modelOverride: params.modelOverride,
-    providers: () => listRuntimeMusicGenerationProviders({ config: params.cfg }),
-  });
-}
-
 function resolveSelectedMusicGenerationProvider(params: {
   config?: OpenClawConfig;
   providers?: MusicGenerationProvider[];
@@ -571,12 +553,14 @@ export function createMusicGenerateTool(options?: {
       }
 
       const model = readToolStringParam(args, "model");
-      const musicGenerationModelConfig = resolveMusicGenerationModelConfigForTool({
+      const musicGenerationModelConfig = resolveCapabilityModelConfigForTool({
         cfg,
         workspaceDir: options?.workspaceDir,
         agentDir: options?.agentDir,
         authStore: options?.authProfileStore,
+        modelConfig: cfg.agents?.defaults?.mediaModels?.music,
         modelOverride: model,
+        providers: () => listRuntimeMusicGenerationProviders({ config: cfg }),
       });
       if (!musicGenerationModelConfig) {
         throw new ToolInputError("No music-generation model configured.");
@@ -729,4 +713,3 @@ export function createMusicGenerateTool(options?: {
     },
   };
 }
-/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */


### PR DESCRIPTION
## What Problem This Solves

The music tool has two registration tests with the same configured-model invocation. The stronger case also makes provider discovery throw and verifies it never ran. A private model-selection forwarding function has one caller and no independent contract.

## Why This Change Was Made

Remove the duplicate registration case and call the shared model-selection owner directly, preserving configuration, workspace, agent directory, auth store, call override and lazy provider discovery. The shorter file no longer needs its max-lines exemption, so remove that suppression and its exact baseline row.

## User Impact

Runtime and public tool behavior are unchanged. Production is +3/-20 (net -17), tests -14, and the lint baseline loses one entry. Explicit-model laziness, timeout overrides, cancellation, detached-task continuation, SSRF, persistence rollback and delivery protection retain their coverage. The separately landed fallback documentation correction is preserved; this PR does not change fallback policy.

## Evidence

The ordinary Music/shared-helper group passed 52 cases before and 51 after, removing exactly the duplicate registration case. Four temporary fault controls were captured and restored: inverted availability failed both old registration cases and the stronger retained case; eager discovery failed the retained explicit-execution case before and after deletion. The final suppression/baseline cleanup does not change executable or test bytes.

Full changed checks and the standard build passed for the reviewed three-file patch, including SDK declarations, CLI bootstrap and UI budgets. Managed review and independent owner/lifecycle inspection found no actionable issue. These are retained results from their recorded source bases, not new build results after this refresh.

Hosted CI subsequently failed unrelated Teams inline-code and unpinned promotional-price fixtures. This failure-justified refresh incorporates the canonical repairs from #134528 and #134564. All three candidate afterimages and the complete binary patch remain unchanged. The canonical pricing repair's 107-case main proof retains all 20 source contexts; it is not claimed as a new branch run.

Because the base updates TypeBox to 1.3.17, the composed commit was run through the ordinary Music/shared-helper group again: all 51 cases passed with the exact inventory and order preserved. A fresh managed Codex review of the complete composed diff is scoped-clean at the configured P0 threshold. Exact-head hosted CI 33462496843 completed successfully; the latest completed review has no findings.

This is internal composition proof using existing provider, persistence and task fixtures. It does not claim a live provider call, performance improvement or durable background-task proof. No assertion is weakened and no timeout, mock surface, dependency or public API is added by this PR.

The same 51-case group also passed on the current-main composition at 9597f653, including its changed transitive auth imports, with exact case names and execution order. An independent closeout verified the complete patch, source contexts, raw logs and restoration. This is a Music owner composition check, not independent auth-storage validation.
