### PR TITLE
fix(gateway): gateway stays offline after agent restart on Windows

### DIFF
--- a/docs/cli/daemon.md
+++ b/docs/cli/daemon.md
@@ -38,7 +38,7 @@ openclaw daemon uninstall
 - `status --port <port>`: selects a local Gateway using the invoking CLI config for auth and TLS. Cannot combine with `--url`; native service details remain diagnostic-only.
 - `install`: installs the service; `--force` reinstalls/overwrites an existing install.
 - Node is the primary, default, and recommended service runtime. Bun 1.4+ with WAL-reset-safe `node:sqlite` is available as an explicit opt-in with `install --runtime bun`.
-- `restart --safe`: asks the running Gateway to preflight active work and schedule one coalesced restart after work drains, bounded to 5 minutes. When that budget expires, the restart is forced anyway. Plain `restart` uses the service manager directly; `--force` is the immediate override.
+- `restart --safe`: asks the running Gateway to preflight active work and schedule one coalesced restart after work drains, bounded to 5 minutes. When that budget expires, the restart is forced anyway. Plain `restart` normally uses the service manager directly; on Windows, commands launched from a Gateway service automatically use the [safe restart path](/cli/gateway#restart-the-gateway). Explicit lifecycle controls retain their behavior; `--force` is the immediate override.
 - `restart --safe --skip-deferral`: bypasses only the active-work deferral gate. Shutdown may still wait for pending replies to drain before the Gateway process exits. Requires `--safe`.
 
 ## Notes

--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -136,7 +136,11 @@ openclaw gateway restart --wait 30s
 
 `--wait <duration>` overrides the drain budget for a plain (non-safe) restart. Accepts bare milliseconds or unit suffixes `ms`, `s`, `m`, `h`, `d` (e.g. `30s`, `5m`, `1h30m`); `--wait 0` waits indefinitely. Not compatible with `--force` or `--safe`.
 
-`--force` skips the active-work drain and restarts immediately. Plain `restart` (no flags) keeps the existing service-manager restart behavior.
+`--force` skips the active-work drain and restarts immediately. Plain `restart` normally uses the service-manager restart path.
+
+On Windows, a plain restart launched from a Gateway service process, including an agent's shell command, automatically uses the safe restart path. The running Gateway owns the deferred Scheduled Task handoff, so stopping its process tree cannot kill the caller before relaunch. This requires a reachable Gateway; the command acknowledges the restart request, not successor health. Use `openclaw gateway status` afterward to verify recovery.
+
+External terminals without Gateway-service markers, externally supervised Gateways, node services, and non-Windows callers keep their existing routing. Explicit `--force`, `--wait`, `--preserve-definition`, or `--skip-deferral` also retain their existing behavior and validation; they do not implicitly enable `--safe`.
 
 <Warning>
 Inline `--password` can be exposed in local process listings. Prefer `--password-file`, env, or a SecretRef-backed `gateway.auth.password`.

--- a/src/cli/daemon-cli/register-service-commands.test.ts
+++ b/src/cli/daemon-cli/register-service-commands.test.ts
@@ -1,6 +1,8 @@
 // Register service command tests cover daemon service subcommand registration.
 import { Command } from "commander";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../../test-utils/env.js";
+import { mockProcessPlatform } from "../../test-utils/vitest-spies.js";
 import { addGatewayServiceCommands } from "./register-service-commands.js";
 import { registerDaemonCli } from "./register.js";
 
@@ -10,6 +12,17 @@ const runDaemonStart = vi.fn(async (_opts: unknown) => {});
 const runDaemonStatus = vi.fn(async (_opts: unknown) => {});
 const runDaemonStop = vi.fn(async (_opts: unknown) => {});
 const runDaemonUninstall = vi.fn(async (_opts: unknown) => {});
+
+const RESTART_ROUTE_ENV_KEYS = [
+  "OPENCLAW_SERVICE_MARKER",
+  "OPENCLAW_SERVICE_KIND",
+  "OPENCLAW_SUPERVISOR_MODE",
+];
+
+const gatewayServiceEnv = {
+  OPENCLAW_SERVICE_MARKER: "openclaw",
+  OPENCLAW_SERVICE_KIND: "gateway",
+};
 
 vi.mock("./install.runtime.js", () => ({
   runDaemonInstall: (opts: unknown) => runDaemonInstall(opts),
@@ -46,14 +59,34 @@ function expectSingleDaemonCall(mockFn: ReturnType<typeof vi.fn>) {
   return opts;
 }
 
+function setRestartRouteEnv(env: Record<string, string | undefined>) {
+  for (const key of RESTART_ROUTE_ENV_KEYS) {
+    const value = env[key];
+    if (value === undefined) {
+      deleteTestEnvValue(key);
+    } else {
+      setTestEnvValue(key, value);
+    }
+  }
+}
+
 describe("addGatewayServiceCommands", () => {
+  let restartRouteEnvSnapshot: ReturnType<typeof captureEnv>;
+
   beforeEach(() => {
+    restartRouteEnvSnapshot = captureEnv(RESTART_ROUTE_ENV_KEYS);
+    setRestartRouteEnv({});
     runDaemonInstall.mockClear();
     runDaemonRestart.mockClear();
     runDaemonStart.mockClear();
     runDaemonStatus.mockClear();
     runDaemonStop.mockClear();
     runDaemonUninstall.mockClear();
+  });
+
+  afterEach(() => {
+    restartRouteEnvSnapshot.restore();
+    vi.restoreAllMocks();
   });
 
   it.each([
@@ -122,6 +155,101 @@ describe("addGatewayServiceCommands", () => {
     const gateway = createGatewayParentLikeCommand();
     await gateway.parseAsync(argv, { from: "user" });
     assert();
+  });
+
+  it.each([
+    {
+      name: "uses safe restart for a plain Windows Gateway service restart",
+      platform: "win32" as const,
+      env: gatewayServiceEnv,
+      argv: ["restart", "--json"],
+      expected: { safe: true, json: true },
+    },
+    {
+      name: "keeps a plain restart non-safe outside a service process",
+      platform: "win32" as const,
+      env: {},
+      argv: ["restart"],
+      expected: { safe: false },
+    },
+    {
+      name: "keeps a plain restart non-safe inside a node service",
+      platform: "win32" as const,
+      env: { OPENCLAW_SERVICE_MARKER: "openclaw", OPENCLAW_SERVICE_KIND: "node" },
+      argv: ["restart"],
+      expected: { safe: false },
+    },
+    {
+      name: "keeps a plain Gateway service restart non-safe outside Windows",
+      platform: "linux" as const,
+      env: gatewayServiceEnv,
+      argv: ["restart"],
+      expected: { safe: false },
+    },
+    {
+      name: "keeps an externally supervised plain restart non-safe",
+      platform: "win32" as const,
+      env: { ...gatewayServiceEnv, OPENCLAW_SUPERVISOR_MODE: "external" },
+      argv: ["restart"],
+      expected: { safe: false },
+    },
+    {
+      name: "honors normalized external supervisor mode before routing",
+      platform: "win32" as const,
+      env: { ...gatewayServiceEnv, OPENCLAW_SUPERVISOR_MODE: "  ExTeRnAl  " },
+      argv: ["restart"],
+      expected: { safe: false },
+    },
+    {
+      name: "preserves explicit safe restart under external supervision",
+      platform: "win32" as const,
+      env: { ...gatewayServiceEnv, OPENCLAW_SUPERVISOR_MODE: "external" },
+      argv: ["restart", "--safe"],
+      expected: { safe: true },
+    },
+    {
+      name: "preserves leaf force instead of adding implicit safe mode",
+      platform: "win32" as const,
+      env: gatewayServiceEnv,
+      argv: ["restart", "--force"],
+      expected: { safe: false, force: true },
+    },
+    {
+      name: "preserves inherited force instead of adding implicit safe mode",
+      platform: "win32" as const,
+      env: gatewayServiceEnv,
+      argv: ["--force", "restart"],
+      expected: { safe: false, force: true },
+    },
+    {
+      name: "preserves wait instead of adding implicit safe mode",
+      platform: "win32" as const,
+      env: gatewayServiceEnv,
+      argv: ["restart", "--wait", "30s"],
+      expected: { safe: false, wait: "30s" },
+    },
+    {
+      name: "preserves definition control instead of adding implicit safe mode",
+      platform: "win32" as const,
+      env: gatewayServiceEnv,
+      argv: ["restart", "--preserve-definition"],
+      expected: { safe: false, preserveDefinition: true },
+    },
+    {
+      name: "preserves skip-deferral validation instead of adding implicit safe mode",
+      platform: "win32" as const,
+      env: gatewayServiceEnv,
+      argv: ["restart", "--skip-deferral"],
+      expected: { safe: false, skipDeferral: true },
+    },
+  ])("$name", async ({ platform, env, argv, expected }) => {
+    mockProcessPlatform(platform);
+    setRestartRouteEnv(env);
+    const gateway = createGatewayParentLikeCommand().enablePositionalOptions();
+
+    await gateway.parseAsync(argv, { from: "user" });
+
+    expect(expectSingleDaemonCall(runDaemonRestart)).toMatchObject(expected);
   });
 
   it.each(["gateway", "daemon"])("parses preservation only on %s restart", async (name) => {

--- a/src/cli/daemon-cli/register-service-commands.ts
+++ b/src/cli/daemon-cli/register-service-commands.ts
@@ -1,5 +1,7 @@
 // Gateway service command registration shared by `gateway` and legacy `daemon` CLIs.
 import type { Command } from "commander";
+import { isGatewayServiceEnv } from "../../daemon/constants.js";
+import { isGatewayExternallySupervised } from "../../infra/gateway-supervision.js";
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { inheritOptionFromParent } from "../command-options.js";
 import { resolveGatewayRpcOptionsWithLocalPort } from "../gateway-rpc.js";
@@ -32,10 +34,19 @@ function resolveInstallOptions(
 
 function resolveRestartOptions(cmdOpts: DaemonLifecycleOptions, command?: Command) {
   const parentForce = inheritOptionFromParent<boolean>(command, "force");
+  const force = Boolean(cmdOpts.force || parentForce);
+  const safeFromGateway =
+    process.platform === "win32" &&
+    isGatewayServiceEnv(process.env) &&
+    !isGatewayExternallySupervised() &&
+    !force &&
+    cmdOpts.wait === undefined &&
+    !cmdOpts.preserveDefinition &&
+    !cmdOpts.skipDeferral;
   return {
     ...cmdOpts,
-    force: Boolean(cmdOpts.force || parentForce),
-    safe: Boolean(cmdOpts.safe),
+    force,
+    safe: cmdOpts.safe || safeFromGateway,
     json: resolveJsonOption(cmdOpts, command),
   };
 }


### PR DESCRIPTION
Hello! Please review the proposed solution and tests. I chose this route because it executes an existing, known good and reliable restart route. There were some simpler, but more blunt, solutions like routing all the relevant calls instead of filtering them as I have. If you would like me to make changes, please let me know. Codex was used to assist, however, I personally reviewed the code, and made changes as stated herein.

I also did some testing on #120134 and #120230, and decided a different solution was needed.

Thank you for looking, and giving consideration.

Below this point, I have asked the agent to write the remaining portion of the PR based on my notes and progress. 

## What Problem This Solves

Fixes #120134.

A windows user can reliably restart the gateway through the gateway agent.

Fixes an issue where users asking an agent running inside a Windows Gateway to run plain `openclaw gateway restart` would see the Gateway stop and remain offline until someone manually started it again.

The affected workflow is an agent-initiated restart from inside the running Gateway process tree on Windows.

## Why This Change Was Made

For a plain Windows restart issued from the Gateway service environment, this change selects the existing Gateway-aware safe restart path so the running Gateway owns the deferred Scheduled Task handoff.

It deliberately preserves native routing for external callers, external-supervisor mode, stopped-Gateway recovery from external terminals without Gateway-service markers, non-Windows and node-service callers, and explicit `--force`, `--wait`, `--preserve-definition`, and `--skip-deferral` behavior.

## User Impact

This also addresses @nerclid’s September 1, 2026 report in Discord #clawtributors: on Windows 11 Pro with default user permissions, asking the agent to restart the Gateway left it offline.

Users can ask an on-Gateway agent to restart a Windows Scheduled Task Gateway and expect a replacement Gateway to start, become healthy, and reconnect the webchat without manual recovery.

Existing external restart workflows and explicit lifecycle controls retain their prior behavior.

## Evidence

### Maintainer verification (September 1, 2026)

The maintainer independently reproduced the routing regression: with the pre-fix resolver and this PR’s unchanged tests, `pnpm test src/cli/daemon-cli/register-service-commands.test.ts` failed exactly 1/36 cases (`uses safe restart for a plain Windows Gateway service restart`, expected `safe: true`, received `safe: false`). The contributor resolver was restored byte-for-byte afterward; the identical focused command then passed 36/36 with exit 0. The native task cleanup and respawn/helper suites also passed 65/65, and the safe-RPC acknowledgement test passed. The untouched external-supervision suite twice timed out in its 180-second import hook while building worker bundles, so that broader local run is not claimed as passing. Native Windows live execution is unavailable on the maintainer Mac; the Windows observations below remain contributor-reported, not independently repeated live runs. The original exact-head aggregate CI passed, but its Windows job was skipped. A separate [Windows probe](https://github.com/openclaw/openclaw/actions/runs/33572849343), dispatched with the exact contributor SHA as `target_ref`, passed its Windows CI test step; its native Scheduled Task preflight failed because the runner reported `user_interactive=False`, so it does not provide independent live restart proof. After a patch-identical rebase, the focused routing, safe-RPC, respawn/helper, and native cleanup command passed all **103 tests** with exit 0.

Both the Gateway and legacy daemon CLI docs now describe implicit safe routing and distinguish request acceptance from successor health.

### Contributor-reported environment

- Windows 11 Pro, native, guest, with an OpenClaw installation.
- Fresh, unmodified baseline: OpenClaw `2026.8.1`, revision `ea80657`.
- Node.js `24.18.0`.
- Restart initiated by a real model-backed agent from webchat using plain `openclaw gateway restart`.

### Before the change

The failure reproduced in `3/3` independent runs.

In each run, the restart controller was inside the Gateway process tree, the Gateway stopped, the controller did not reach Scheduled Task relaunch, and no replacement Gateway appeared.

### After the change

The same end-to-end webchat-agent workflow passed in `3/3` consecutive runs.

| Test | PID transition | Route | Request to ready | Result |
|---|---:|---|---:|---|
| 1 | `1864 -> 6320` | `safe-rpc mode=deferred` | `30.502 s` | Scheduled Task result `0`, RPC healthy, webchat reconnected |
| 2 | `6320 -> 1196` | `safe-rpc mode=deferred` | `30.294 s` | Scheduled Task result `0`, RPC healthy, webchat reconnected |
| 3 | `1196 -> 6664` | `safe-rpc mode=deferred` | `29.371 s` | Scheduled Task result `0`, RPC healthy, webchat reconnected |

No duplicate task handoff, stale listener, unexpected in-process managed restart, configuration drift, or plugin-version drift was found.

### Routing and preservation

- `11/11` runnable restart transitions completed with distinct replacement PIDs, Scheduled Task result `0`, and healthy RPC.
- Route-selection checks passed `13/13`.
- Original-versus-patched option parity passed `18/18` outside the identified external-supervisor overlap.
- The corrected external-supervisor exclusion passed `10/10` focused offline cases, including normalized mixed-case and whitespace-padded values.
- Explicit `--safe` remains safe in external-supervisor mode.
- External plain restart retains targeted non-safe RPC and successor-health verification.
- Force, wait, preserve-definition, skip-deferral, node-service, non-Windows, direct RPC, and config-watcher paths retain their existing routing.

### Contributor-reported repository validation

- [x] `node scripts/run-vitest.mjs src/cli/daemon-cli/register-service-commands.test.ts` - `36/36` passed on Windows with Node `24.18.0` against base `0f0ae34d9a2b84cff53a4540ab50d3666e197b71`.
- [x] `pnpm build` - passed on Windows with Node `24.18.0` and pnpm `12.1.0` against base `0f0ae34d9a2b84cff53a4540ab50d3666e197b71`; exit `0`, total build time `5m 33.4s`, all `9/9` unified tsdown invocations completed, and no tracked files changed beyond the two candidate files.
- [x] `pnpm check` - passed on Windows with Node `24.18.0` and pnpm `12.1.0` against base `0f0ae34d9a2b84cff53a4540ab50d3666e197b71`; exit `0` in `854.788 s`. All `18` preflight guards, `5` typecheck targets, `23` lint shards, the `32,063`-file format pass, and `8` policy guards completed successfully.
- [-] `pnpm test` - attempted on native Windows with Node `24.18.0` and pnpm `12.1.0`; manually stopped after approximately `16m 40s` when unrelated Windows EPERM, platform, and temporary-file locking failures accumulated. The run produced no final exit status, and no observed failure named either candidate file. The focused candidate suite separately passed `36/36`.

Regression proof: with the test patch applied before the production repair, the same focused command failed exactly `1/36` cases because the plain Windows Gateway-service restart produced `safe: false` instead of `safe: true`; the repaired source-and-test patch then passed `36/36`. The later check cleanup removed a redundant boolean wrapper and formatted the test without changing behavior.

Build proof: the candidate source-and-test patch completed the repository build with exit `0`; the log contained no `FAILED`, `ERROR`, `FATAL`, or `[INEFFECTIVE_DYNAMIC_IMPORT]` markers. The later check cleanup was a semantic no-op in production code and formatter-only in the test.

Check proof: the check first identified one unnecessary boolean conversion and one formatting issue in the candidate; both were corrected minimally. The final tracked diff remains limited to the production resolver and its focused test, `git diff --check` passes, and the lockfile matches `HEAD`.

### Provenance and related-PR clarification

I have observed this behavior throughout my approximately four to five months using OpenClaw. No earlier known-good release or introducing change has been identified, so I believe this should be classified as a longstanding defect with regression provenance unknown, rather than a probable regression.

PR #120230 is not a demonstrated alternative fix, and should not be considered partial overlap. I tested its current head `d4b40a7f32aa597302c7c7852e3db1109c36e33f` in the native model-backed Windows workflow. The restart controller survived and `schtasks /End` succeeded, but the existing Gateway retained the port, no successor Gateway was created, and restart failed. The detailed result is recorded in my comment on that PR.


### Evidence boundaries

The broad `pnpm test` attempt is not claimed as a pass or a failure.

The implicit repair intentionally applies only to a plain Windows Gateway-service restart.

The same command run from an external interactive terminal is not affected.

It does not claim to change Gateway-descendant explicit `--force`, `--wait`, `--preserve-definition`, or `--skip-deferral` behavior, or any non-Windows, node-service, external-caller, stopped-Gateway recovery, or external-supervisor path.

Preservation claims for other entry points rest on the separate `11/11` runnable transitions, `13/13` route-selection checks, `18/18` option-parity checks, and focused external-supervisor matrix rather than an equivalent deep-capture series for every path.

Safe RPC acknowledges the accepted restart request before successor health is known; all three independent external observations nevertheless proved a distinct healthy replacement and webchat reconnection.

External-supervisor mode was not active during the three live runs, so that exclusion is supported by the focused `10/10` routing matrix rather than a live external-supervisor restart.

No UI was changed, so before-and-after screenshots are not applicable.
### Final exact-head gate

Head `0a8b47ddd0e06b8bd953119ad17f1f20125136b6` has [green exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33575522638) and a fresh clean branch autoreview. Rebase preserved both patches exactly and retained @nerclid’s authorship. See the [maintainer review and full evidence boundaries](https://github.com/openclaw/openclaw/pull/134549#issuecomment-5502047352).

`node scripts/check-changed.mjs -- docs/cli/daemon.md docs/cli/gateway.md src/cli/daemon-cli/register-service-commands.ts src/cli/daemon-cli/register-service-commands.test.ts` completed with exit 0 after the rebase, including core/test typechecks, all three zero-entry dead-export scans, targeted lint, and policy guards.
