### PR TITLE
test(nostr): exercise the registered channel plugin

### DIFF
--- a/extensions/nostr/src/channel.test.ts
+++ b/extensions/nostr/src/channel.test.ts
@@ -31,85 +31,7 @@ describe("nostr target classification", () => {
   });
 });
 
-function normalizeNostrTestEntry(entry: string): string {
-  return entry
-    .trim()
-    .replace(/^nostr:/i, "")
-    .toLowerCase();
-}
-
-function resolveNostrTestDmPolicy(params: {
-  cfg: OpenClawConfig;
-  account: ReturnType<typeof resolveNostrAccount>;
-}) {
-  return {
-    cfg: params.cfg,
-    accountId: params.account.accountId,
-    policy: params.account.config.dmPolicy ?? "pairing",
-    allowFrom: params.account.config.allowFrom ?? [],
-    normalizeEntry: normalizeNostrTestEntry,
-  };
-}
-
-const nostrTestPlugin = {
-  id: "nostr",
-  meta: {
-    label: "Nostr",
-    docsPath: "/channels/nostr",
-    blurb: "Decentralized DMs via Nostr relays (NIP-04)",
-  },
-  capabilities: {
-    chatTypes: ["direct"],
-    media: false,
-  },
-  config: {
-    listAccountIds: listNostrAccountIds,
-    resolveAccount: (cfg: OpenClawConfig, accountId?: string | null) =>
-      resolveNostrAccount({ cfg, accountId }),
-  },
-  messaging: {
-    normalizeTarget: (target: string) => normalizeNostrTestEntry(target),
-    targetResolver: {
-      looksLikeId: (input: string) => {
-        const trimmed = input.trim();
-        return trimmed.startsWith("npub1") || /^[0-9a-fA-F]{64}$/.test(trimmed);
-      },
-    },
-  },
-  outbound: {
-    deliveryMode: "direct",
-    textChunkLimit: 4000,
-  },
-  pairing: {
-    idLabel: "nostrPubkey",
-    normalizeAllowEntry: normalizeNostrTestEntry,
-  },
-  security: {
-    resolveDmPolicy: resolveNostrTestDmPolicy,
-  },
-  status: {
-    defaultRuntime: {
-      accountId: "default",
-      running: false,
-      lastStartAt: null,
-      lastStopAt: null,
-      lastError: null,
-    },
-  },
-  setupWizard: nostrSetupWizard,
-  setup: {
-    resolveAccountId: ({
-      cfg,
-      accountId,
-    }: {
-      cfg: OpenClawConfig;
-      accountId?: string;
-      input: unknown;
-    }) => accountId?.trim() || resolveDefaultNostrAccountId(cfg),
-  },
-};
-
-const nostrConfigure = createPluginSetupWizardConfigure(nostrTestPlugin);
+const nostrConfigure = createPluginSetupWizardConfigure(nostrPlugin);
 
 function withoutNostrPrivateKey<T>(run: () => T): T {
   const hadValue = Object.hasOwn(process.env, "NOSTR_PRIVATE_KEY");
@@ -127,7 +49,7 @@ function withoutNostrPrivateKey<T>(run: () => T): T {
 }
 
 function requireNostrLooksLikeId() {
-  const looksLikeId = nostrTestPlugin.messaging?.targetResolver?.looksLikeId;
+  const looksLikeId = nostrPlugin.messaging?.targetResolver?.looksLikeId;
   if (!looksLikeId) {
     throw new Error("nostr messaging.targetResolver.looksLikeId missing");
   }
@@ -135,7 +57,7 @@ function requireNostrLooksLikeId() {
 }
 
 function requireNostrNormalizeTarget() {
-  const normalize = nostrTestPlugin.messaging?.normalizeTarget;
+  const normalize = nostrPlugin.messaging?.normalizeTarget;
   if (!normalize) {
     throw new Error("nostr messaging.normalizeTarget missing");
   }
@@ -143,7 +65,7 @@ function requireNostrNormalizeTarget() {
 }
 
 function requireNostrPairingNormalizer() {
-  const normalize = nostrTestPlugin.pairing?.normalizeAllowEntry;
+  const normalize = nostrPlugin.pairing?.normalizeAllowEntry;
   if (!normalize) {
     throw new Error("nostr pairing.normalizeAllowEntry missing");
   }
@@ -151,7 +73,7 @@ function requireNostrPairingNormalizer() {
 }
 
 function requireNostrResolveDmPolicy() {
-  const resolveDmPolicy = nostrTestPlugin.security?.resolveDmPolicy;
+  const resolveDmPolicy = nostrPlugin.security?.resolveDmPolicy;
   if (!resolveDmPolicy) {
     throw new Error("nostr security.resolveDmPolicy missing");
   }
@@ -197,40 +119,40 @@ const unresolvedSecretRefPrivateKeyCases = [
 describe("nostrPlugin", () => {
   describe("meta", () => {
     it("has correct id", () => {
-      expect(nostrTestPlugin.id).toBe("nostr");
+      expect(nostrPlugin.id).toBe("nostr");
     });
 
     it("has required meta fields", () => {
-      expect(nostrTestPlugin.meta.label).toBe("Nostr");
-      expect(nostrTestPlugin.meta.docsPath).toBe("/channels/nostr");
-      expect(nostrTestPlugin.meta.blurb).toContain("NIP-04");
+      expect(nostrPlugin.meta.label).toBe("Nostr");
+      expect(nostrPlugin.meta.docsPath).toBe("/channels/nostr");
+      expect(nostrPlugin.meta.blurb).toContain("NIP-04");
     });
   });
 
   describe("capabilities", () => {
     it("supports direct messages", () => {
-      expect(nostrTestPlugin.capabilities.chatTypes).toContain("direct");
+      expect(nostrPlugin.capabilities.chatTypes).toContain("direct");
     });
 
     it("does not support groups (MVP)", () => {
-      expect(nostrTestPlugin.capabilities.chatTypes).not.toContain("group");
+      expect(nostrPlugin.capabilities.chatTypes).not.toContain("group");
     });
 
     it("does not support media (MVP)", () => {
-      expect(nostrTestPlugin.capabilities.media).toBe(false);
+      expect(nostrPlugin.capabilities.media).toBe(false);
     });
   });
 
   describe("config adapter", () => {
     it("listAccountIds returns empty array for unconfigured", () => {
       const cfg = { channels: {} };
-      const ids = withoutNostrPrivateKey(() => nostrTestPlugin.config.listAccountIds(cfg));
+      const ids = withoutNostrPrivateKey(() => nostrPlugin.config.listAccountIds(cfg));
       expect(ids).toStrictEqual([]);
     });
 
     it("listAccountIds returns default for configured", () => {
       const cfg = createConfiguredNostrCfg();
-      const ids = nostrTestPlugin.config.listAccountIds(cfg);
+      const ids = nostrPlugin.config.listAccountIds(cfg);
       expect(ids).toContain("default");
     });
 
@@ -322,17 +244,17 @@ describe("nostrPlugin", () => {
 
   describe("outbound", () => {
     it("has correct delivery mode", () => {
-      expect(nostrTestPlugin.outbound?.deliveryMode).toBe("direct");
+      expect(nostrPlugin.outbound?.deliveryMode).toBe("direct");
     });
 
     it("has reasonable text chunk limit", () => {
-      expect(nostrTestPlugin.outbound?.textChunkLimit).toBe(4000);
+      expect(nostrPlugin.outbound?.textChunkLimit).toBe(4000);
     });
   });
 
   describe("pairing", () => {
     it("has id label for pairing", () => {
-      expect(nostrTestPlugin.pairing?.idLabel).toBe("nostrPubkey");
+      expect(nostrPlugin.pairing?.idLabel).toBe("nostrPubkey");
     });
 
     it("normalizes spaced nostr prefixes in allow entries", () => {
@@ -370,7 +292,7 @@ describe("nostrPlugin", () => {
 
   describe("status", () => {
     it("has default runtime", () => {
-      expect(nostrTestPlugin.status?.defaultRuntime).toEqual({
+      expect(nostrPlugin.status?.defaultRuntime).toEqual({
         accountId: "default",
         running: false,
         lastStartAt: null,
@@ -438,7 +360,7 @@ describe("nostr setup wizard", () => {
 
   it("uses configured defaultAccount when setup accountId is omitted", () => {
     expect(
-      nostrTestPlugin.setup?.resolveAccountId?.({
+      nostrPlugin.setupContract?.resolveAccountId?.({
         cfg: createConfiguredNostrCfg({ defaultAccount: "work" }) as OpenClawConfig,
         accountId: undefined,
         input: {},


### PR DESCRIPTION
The channel suite already imports the registered Nostr plugin, but many assertions still inspect a copied plugin object and copied normalizers. Remove that shadow fixture and run the existing assertions against the actual plugin surfaces, including the current setup contract.

All 45 channel cases and 78 expectation sites remain. The change deletes 78 net test lines and adds no production code. A temporary identity-only production pairing normalizer is accepted by the old copied-fixture test and rejected by the revised existing test; the production file is restored byte-for-byte afterward.

Validation: the current-base 45-case baseline passes; all 105 selected channel, setup, outbound, session-routing, and key cases pass with the revised fixture. Full changed-file checks passed; independent Codex autoreview is clean. This improves coverage and removes copied policy; no elapsed speedup is claimed.
