### PR TITLE
test(providers): simplify model helper assertions

### DIFF
--- a/extensions/fireworks/index.test.ts
+++ b/extensions/fireworks/index.test.ts
@@ -1,4 +1,3 @@
-// Fireworks tests cover index plugin behavior.
 import type { ProviderRuntimeModel } from "openclaw/plugin-sdk/plugin-entry";
 import {
   registerSingleProviderPlugin,
@@ -132,7 +131,7 @@ describe("fireworks provider plugin", () => {
       createProviderDynamicModelContext({
         provider: "fireworks",
         modelId: "accounts/fireworks/models/kimi-k2p5",
-        models: [createFireworksDefaultRuntimeModel({ reasoning: false })],
+        models: [createFireworksDefaultRuntimeModel({ reasoning: true })],
       }),
     );
 
@@ -163,7 +162,7 @@ describe("fireworks provider plugin", () => {
       createProviderDynamicModelContext({
         provider: "fireworks",
         modelId: "accounts/fireworks/routers/kimi-k2.5-turbo",
-        models: [createFireworksDefaultRuntimeModel({ reasoning: false })],
+        models: [createFireworksDefaultRuntimeModel({ reasoning: true })],
       }),
     );
 

--- a/src/plugins/provider-model-helpers.test.ts
+++ b/src/plugins/provider-model-helpers.test.ts
@@ -1,4 +1,3 @@
-// Covers provider model helper behavior for plugin model registries.
 import type { ModelRegistry } from "openclaw/plugin-sdk/agent-sessions";
 import { describe, expect, it } from "vitest";
 import {
@@ -36,34 +35,6 @@ function createTemplateModel(
   } as ProviderRuntimeModel;
 }
 
-function expectClonedTemplateModel(
-  params: Parameters<typeof cloneFirstTemplateModel>[0],
-  expected: Record<string, unknown> | undefined,
-) {
-  const model = cloneFirstTemplateModel(params);
-  if (expected == null) {
-    expect(model).toBeUndefined();
-    return;
-  }
-  expect(model).toEqual(expected);
-}
-
-function expectPrefixMatch(params: {
-  id: string;
-  candidates: readonly string[];
-  expected: boolean;
-}) {
-  expect(matchesExactOrPrefix(params.id, params.candidates)).toBe(params.expected);
-}
-
-function expectPrefixMatchCase(params: {
-  id: string;
-  candidates: readonly string[];
-  expected: boolean;
-}) {
-  expectPrefixMatch(params);
-}
-
 describe("cloneFirstTemplateModel", () => {
   it.each([
     {
@@ -94,7 +65,12 @@ describe("cloneFirstTemplateModel", () => {
       expected: undefined,
     },
   ] as const)("$name", ({ params, expected }) => {
-    expectClonedTemplateModel(params, expected);
+    const model = cloneFirstTemplateModel(params);
+    if (expected == null) {
+      expect(model).toBeUndefined();
+      return;
+    }
+    expect(model).toEqual(expected);
   });
 });
 
@@ -115,7 +91,9 @@ describe("matchesExactOrPrefix", () => {
       candidates: ["minimax-m2.7"],
       expected: false,
     },
-  ] as const)("matches $id against prefixes", expectPrefixMatchCase);
+  ] as const)("matches $id against prefixes", ({ id, candidates, expected }) => {
+    expect(matchesExactOrPrefix(id, candidates)).toBe(expected);
+  });
 });
 
 describe("resolveFamilyForwardCompatModel", () => {


### PR DESCRIPTION
## What Problem This Solves

Two Fireworks tests claim to disable reasoning for dynamically resolved Kimi models, but their default-model fixture already has reasoning disabled. They still pass if the plugin forgets to apply that override. The shared model-helper suite also hides simple table assertions behind three private forwarding functions.

## Why This Change Was Made

Seed the two Fireworks templates with reasoning enabled, matching the actual default GLM catalog row, while retaining the existing false assertions. Inline the shared helper assertions into their sole table callbacks with the same fixtures, branches, production calls and matcher choices. Remove the two generic file headers.

## User Impact

No production behavior, provider policy, public API or configuration changes. All 22 cases remain. Tests are +11/-34 (net -23); production is unchanged.

## Evidence

The ordinary Fireworks index/stream/onboarding and shared model-helper group passed all 22 cases before and after, preserving every case and its order within each file. In a temporary controlled fault, removing only the reasoning field from the clone patch left both old selected tests green. With the corrected fixtures, both failed at the intended true-versus-false assertions. The complete production owner was restored before the passing after run.

The helper cleanup preserves all seven cases, including missing-template handling, exact and prefix matching, cross-provider template selection and synthesis. The two fixture builders remain. Existing stream payload, alias and onboarding coverage is unchanged. No external provider call, API capability or performance claim is made.

The normal changed-file gate passed in 343 seconds. Managed review and independent source/proof review found no actionable issue. A fresh 22-case run on the independent publication base also passed, with all 45 relevant source contexts and both reviewed test afterimages unchanged.


The unrelated Teams inline-code expectation that delayed hosted validation is corrected on main by #134528. All 45 reviewed provider-model source contexts remain unchanged on the captured current main. Exact-head CI [33454902570](https://github.com/openclaw/openclaw/actions/runs/33454902570) completed successfully. The completed ClawSweeper review has no code findings; normal maintainer review and current-source qualification are complete.
