### PR TITLE
fix: align Teams inline-code checks with preserved whitespace

### DIFF
--- a/extensions/msteams/src/format.test.ts
+++ b/extensions/msteams/src/format.test.ts
@@ -1,7 +1,9 @@
+import MarkdownIt from "markdown-it";
 import { describe, expect, it } from "vitest";
 import { formatMSTeamsMarkdown } from "./format.js";
 
 describe("formatMSTeamsMarkdown", () => {
+  const commonmark = new MarkdownIt("commonmark");
   const fixtures = [
     {
       name: "falls headings back to bold text",
@@ -112,6 +114,7 @@ describe("formatMSTeamsMarkdown", () => {
       name: "keeps inline code delimiters that protect embedded backticks",
       before: "``value `with` ticks``",
       after: "``value `with` ticks``",
+      codeHtml: "<code>value `with` ticks</code>",
     },
     {
       name: "includes escaped backticks when choosing inline code delimiters",
@@ -119,9 +122,10 @@ describe("formatMSTeamsMarkdown", () => {
       after: "``a \\` b``",
     },
     {
-      name: "preserves inline code semantics while normalizing boundary spaces",
+      name: "preserves both boundary spaces in inline code",
       before: "`  foo  `",
-      after: "` foo`",
+      after: "`  foo  `",
+      codeHtml: "<code> foo </code>",
     },
     {
       name: "serializes link destinations with angle brackets",
@@ -142,7 +146,13 @@ describe("formatMSTeamsMarkdown", () => {
 
   for (const fixture of fixtures) {
     it(fixture.name, () => {
-      expect(formatMSTeamsMarkdown(fixture.before, "off")).toBe(fixture.after);
+      const rendered = formatMSTeamsMarkdown(fixture.before, "off");
+      expect(rendered).toBe(fixture.after);
+      if ("codeHtml" in fixture) {
+        // CommonMark payloads distinguish semantic spaces from delimiter padding.
+        expect(commonmark.renderInline(fixture.before)).toBe(fixture.codeHtml);
+        expect(commonmark.renderInline(rendered)).toBe(fixture.codeHtml);
+      }
     });
   }
 


### PR DESCRIPTION
Related: #134451, #134537, #134536

## What Problem This Solves

Resolves a problem where the Teams formatting test rejects correctly preserved inline-code whitespace after #134451. The stale expectation drops a significant trailing space, causing unrelated PRs to fail the Teams test shard.

## Why This Change Was Made

Correct the expected Markdown and check the input and emitted output against literal code HTML with the existing markdown-it parser. The existing embedded-backtick case receives the same semantic check; every exact formatting assertion remains.

This follows [CommonMark's code-span rule](https://spec.commonmark.org/0.31.2/#code-spans): delimiter padding and significant payload spaces are different. The production formatter and shared parser already preserve the intended payload and are unchanged.

## User Impact

No runtime behavior change. Maintainers regain a valid formatting check without reverting the whitespace repair or weakening assertions. Production delta: 0; tests: +13/-3.

## Evidence

- Fresh main `1f71c763ead35137f3b9f45460346cbc51b9bb34`, with its frozen dependency install: the original file reports 1 failure and 50 passes; the corrected file passes all 51 cases.
- Command: `node scripts/run-vitest.mjs extensions/msteams/src/format.test.ts --maxWorkers=1 --reporter=verbose`.
- All 19 changed checks pass, including extension test types, lint, boundaries and the dead-export scan.
- Managed Codex review completed with no findings in its default P0 scope.
- The [original CI failure](https://github.com/openclaw/openclaw/actions/runs/33450588860/job/99679513895) tested merge `5c4d0d1ba17be2d851311e0ce923cd982224ff73`, containing #134451. The separate Doctor heap failure is under investigation and is not claimed fixed by this test correction.
