### PR TITLE
test(ci): observe exact shard concurrency without timers

### DIFF
--- a/test/scripts/ci-run-node-test-shard.test.ts
+++ b/test/scripts/ci-run-node-test-shard.test.ts
@@ -152,9 +152,7 @@ describe("scripts/ci-run-node-test-shard.mts", () => {
         ) => {
           active += 1;
           peakActive = Math.max(peakActive, active);
-          await new Promise((resolve) => {
-            setTimeout(resolve, 10);
-          });
+          await Promise.resolve();
           seen.push({ args, cache: childEnv.OPENCLAW_VITEST_FS_MODULE_CACHE_PATH, label });
           active -= 1;
           return 0;
@@ -163,7 +161,7 @@ describe("scripts/ci-run-node-test-shard.mts", () => {
       },
     );
     expect(exitCode).toBe(0);
-    expect(peakActive).toBeLessThanOrEqual(2);
+    expect(peakActive).toBe(2);
     expect(seen.map((run) => run.label).toSorted()).toEqual(["a", "b", "c"]);
     expect(new Set(seen.map((run) => run.cache)).size).toBe(3);
   });
@@ -279,9 +277,7 @@ describe("scripts/ci-run-node-test-shard.mts", () => {
           }
           activeCaches.add(cache);
           seenCaches.add(cache);
-          await new Promise((resolve) => {
-            setTimeout(resolve, 10);
-          });
+          await Promise.resolve();
           activeCaches.delete(cache);
           return 0;
         },


### PR DESCRIPTION
The shard runner tests wait ten real milliseconds in seven injected child callbacks just to overlap worker starts. Use one microtask yield and require peak concurrency of two. All seventeen cases and the distinct-cache/shared-writer assertions remain.

A temporary one-worker scheduler, with cache allocation unchanged, passes the old overlap test and fails the revised test. Restoring the owner passes all seventeen cases. Production code is unchanged; tests shrink by four lines. This removes seven requested timer waits, with no elapsed speedup claim.

Validation: seventeen cases pass before and after; the isolated scheduler fault is rejected; full changed checks pass; independent Codex autoreview is clean. Related PR #120161 covers concurrency input validation and worker capping, a separate production behavior.
