### PR TITLE
refactor(state): share transcript event JSON transform

### DIFF
--- a/src/infra/state-migrations.transcript-directives-archives.ts
+++ b/src/infra/state-migrations.transcript-directives-archives.ts
@@ -7,7 +7,6 @@ import {
   encodeSessionArchiveContent,
   SESSION_ARCHIVE_ZSTD_SUFFIX,
 } from "../config/sessions/archive-compression.js";
-import type { TranscriptEvent } from "../config/sessions/session-accessor.sqlite-contract.js";
 import { resolveSqliteTranscriptArchiveDirectory } from "../config/sessions/session-accessor.sqlite-scope.js";
 import { assertAgentDatabaseMaintenanceAuthority } from "../state/openclaw-agent-db-lease.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
@@ -20,7 +19,7 @@ import {
 } from "./kysely-sync.js";
 import { replaceFileAtomicSync } from "./replace-file.js";
 import { runSqliteImmediateTransactionSync } from "./sqlite-transaction.js";
-import { transformHistoricalTranscriptEvent } from "./state-migrations.transcript-directives-transform.js";
+import { transformHistoricalTranscriptEventJson } from "./state-migrations.transcript-directives-transform.js";
 
 export const TRANSCRIPT_DIRECTIVE_MIGRATION_BATCH_SIZE = 32;
 
@@ -44,14 +43,6 @@ type ArchiveRowPlan = {
   sessionId: string;
 };
 
-function parseTranscriptEvent(raw: string, owner: string): TranscriptEvent {
-  try {
-    return JSON.parse(raw);
-  } catch (error) {
-    throw new Error(`${owner} contains invalid transcript JSON`, { cause: error });
-  }
-}
-
 function transformArchiveContent(
   content: string,
   owner: string,
@@ -69,8 +60,7 @@ function transformArchiveContent(
     if (!line) {
       throw new Error(`${owner} contains a blank JSONL record at line ${index + 1}`);
     }
-    const event = parseTranscriptEvent(line, `${owner}:${index + 1}`);
-    const transformed = transformHistoricalTranscriptEvent(event);
+    const transformed = transformHistoricalTranscriptEventJson(line, `${owner}:${index + 1}`);
     changed ||= transformed.changed;
     return transformed.changed ? JSON.stringify(transformed.event) : line;
   });

--- a/src/infra/state-migrations.transcript-directives-transform.test.ts
+++ b/src/infra/state-migrations.transcript-directives-transform.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { transformHistoricalTranscriptEventJson } from "./state-migrations.transcript-directives-transform.js";
+
+describe("transformHistoricalTranscriptEventJson", () => {
+  it.each([
+    { event: 1, name: "scalar", raw: "1" },
+    { event: "text", name: "string", raw: '"text"' },
+    {
+      event: { type: "custom", value: 1 },
+      name: "ordinary object",
+      raw: '{"type":"custom","value":1}',
+    },
+  ])("leaves $name JSON unchanged", ({ event, raw }) => {
+    expect(transformHistoricalTranscriptEventJson(raw, "owner")).toEqual({
+      changed: false,
+      event,
+    });
+  });
+
+  it("preserves the parse owner and SyntaxError cause", () => {
+    expect(() => transformHistoricalTranscriptEventJson("{", "session:4")).toThrow(
+      expect.objectContaining({
+        cause: expect.any(SyntaxError),
+        message: "session:4 contains invalid transcript JSON",
+      }),
+    );
+  });
+});

--- a/src/infra/state-migrations.transcript-directives-transform.ts
+++ b/src/infra/state-migrations.transcript-directives-transform.ts
@@ -26,7 +26,7 @@ function stripLegacyReactionDirectives(message: Record<string, unknown>): void {
   }
 }
 
-export function transformHistoricalTranscriptEvent(event: TranscriptEvent): {
+function transformHistoricalTranscriptEvent(event: TranscriptEvent): {
   changed: boolean;
   event: TranscriptEvent;
 } {
@@ -43,4 +43,14 @@ export function transformHistoricalTranscriptEvent(event: TranscriptEvent): {
   stripLegacyReactionDirectives(event.message);
   applyAssistantDeliveryDirectives(event.message);
   return { changed: JSON.stringify(event.message) !== before, event };
+}
+
+export function transformHistoricalTranscriptEventJson(raw: string, owner: string) {
+  let event: TranscriptEvent;
+  try {
+    event = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`${owner} contains invalid transcript JSON`, { cause: error });
+  }
+  return transformHistoricalTranscriptEvent(event);
 }

--- a/src/infra/state-migrations.transcript-directives.test.ts
+++ b/src/infra/state-migrations.transcript-directives.test.ts
@@ -133,8 +133,8 @@ function readMigrationCursor(databasePath: string): unknown {
       .prepare(
         "SELECT app_version FROM schema_meta WHERE meta_key = 'historical-transcript-directives-v1'",
       )
-      .get() as { app_version: string };
-    return JSON.parse(row.app_version);
+      .get() as { app_version: string } | undefined;
+    return row ? JSON.parse(row.app_version) : undefined;
   } finally {
     database.close();
   }
@@ -653,6 +653,53 @@ describe("historical transcript directive migration", () => {
     } finally {
       database.close();
     }
+  });
+
+  it("reports a malformed active row without changing its source or cursor", async () => {
+    const env = { OPENCLAW_STATE_DIR: makeTempDir(tempDirs, "directive-invalid-row-") };
+    const opened = openOpenClawAgentDatabase({ agentId: "main", env });
+    const raw = '{"marker":"[[';
+    insertSession(opened.db, { events: [{ timestamp: 1 }], generation: "g", sessionId: "s" });
+    opened.db.prepare("UPDATE transcript_events SET event_json=? WHERE session_id='s'").run(raw);
+    closeOpenClawAgentDatabasesForTest();
+    expect((await migrateHistoricalTranscriptDirectives({ env })).warnings[0]).toContain(
+      `${opened.path}:s:0 contains invalid transcript JSON`,
+    );
+    expect(readEventJson(opened.path, "s", 0)).toBe(raw);
+    expect(readMigrationCursor(opened.path)).toBeUndefined();
+  });
+
+  it("reports a malformed archive line without changing durable archive state", async () => {
+    const env = { OPENCLAW_STATE_DIR: makeTempDir(tempDirs, "directive-invalid-archive-") };
+    const opened = openOpenClawAgentDatabase({ agentId: "main", env });
+    const bytes = Buffer.from('{"marker":"[[\n', "utf8");
+    const sha256 = createHash("sha256").update(bytes).digest("hex");
+    opened.db.exec(
+      `INSERT INTO session_transcript_archives(session_id,generation,session_key,reason,encoding,archive_blob,archive_sha256,archive_name,created_at,published_at)
+       VALUES('a','g','agent:main:a','deleted','identity',X'${bytes.toString("hex")}','${sha256}','a',1,2);
+       INSERT INTO schema_meta(meta_key,role,schema_version,agent_id,app_version,created_at,updated_at)
+       VALUES('historical-transcript-directives-v1','agent',1,'main','{"generation":"","phase":"archives","sessionId":""}',1,1);`,
+    );
+    closeOpenClawAgentDatabasesForTest();
+
+    expect((await migrateHistoricalTranscriptDirectives({ env })).warnings[0]).toContain(
+      "a:g:1 contains invalid transcript JSON",
+    );
+    const database = openNodeSqliteDatabase(opened.path, { readOnly: true });
+    const row = database
+      .prepare(
+        "SELECT hex(archive_blob) blob,archive_sha256,encoding,published_at FROM session_transcript_archives",
+      )
+      .get();
+    database.close();
+    expect(row).toEqual({
+      blob: bytes.toString("hex").toUpperCase(),
+      archive_sha256: sha256,
+      encoding: "identity",
+      published_at: 2,
+    });
+    const cursor = readMigrationCursor(opened.path);
+    expect(cursor).toEqual({ generation: "", phase: "archives", sessionId: "" });
   });
 
   it("leaves canonical archives and their active writer untouched", async () => {

--- a/src/infra/state-migrations.transcript-directives.ts
+++ b/src/infra/state-migrations.transcript-directives.ts
@@ -1,6 +1,5 @@
 import type { DatabaseSync } from "node:sqlite";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import type { TranscriptEvent } from "../config/sessions/session-accessor.sqlite-contract.js";
 import { updateSqliteTranscriptEventJsonInTransaction } from "../config/sessions/session-accessor.sqlite-transcript-store.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db-contract.js";
 import {
@@ -32,7 +31,7 @@ import {
   TRANSCRIPT_DIRECTIVE_MIGRATION_BATCH_SIZE,
   transcriptDirectiveArchivesNeedMigration,
 } from "./state-migrations.transcript-directives-archives.js";
-import { transformHistoricalTranscriptEvent } from "./state-migrations.transcript-directives-transform.js";
+import { transformHistoricalTranscriptEventJson } from "./state-migrations.transcript-directives-transform.js";
 import type { MigrationMessages } from "./state-migrations.types.js";
 
 const MIGRATION_META_KEY = "historical-transcript-directives-v1";
@@ -147,14 +146,6 @@ function writeMigrationCursor(
   );
 }
 
-function parseTranscriptEvent(raw: string, owner: string): TranscriptEvent {
-  try {
-    return JSON.parse(raw);
-  } catch (error) {
-    throw new Error(`${owner} contains invalid transcript JSON`, { cause: error });
-  }
-}
-
 function listTranscriptSessionBatch(database: DatabaseSync, afterSessionId: string): string[] {
   const db = getNodeSqliteKysely<TranscriptDirectiveMigrationDatabase>(database);
   return executeSqliteQuerySync(
@@ -185,8 +176,10 @@ function planTranscriptSession(
       .where("event_json", "like", "%[[%")
       .orderBy("seq", "asc"),
   ).rows.map((row) => {
-    const event = parseTranscriptEvent(row.event_json, `${pathname}:${sessionId}:${row.seq}`);
-    const transformed = transformHistoricalTranscriptEvent(event);
+    const transformed = transformHistoricalTranscriptEventJson(
+      row.event_json,
+      `${pathname}:${sessionId}:${row.seq}`,
+    );
     return {
       eventJson: row.event_json,
       rewrittenEventJson: transformed.changed ? JSON.stringify(transformed.event) : row.event_json,


### PR DESCRIPTION
## What Problem This Solves

The active-transcript and archive migration paths separately parsed transcript JSON and rebuilt the same owner-qualified parse error. Keeping that boundary policy duplicated makes parse provenance and transformation order easier to drift.

## Why This Change Was Made

Moves JSON parsing into the existing historical transcript transform owner and has both migration consumers call one parse-and-transform function. The helper catches only `JSON.parse` failures; transformation errors, row ordering, source revalidation, archive encoding/checksums, transaction boundaries, publication state, and migration cursors are unchanged.

This is an internal duplicate consolidation. Existing libraries or plugins cannot replace this migration-owned policy without adding a worse dependency or SDK seam.

## User Impact

No intended user-visible behavior change. Malformed historical transcript records retain their exact row or archive-line owner in warnings, while valid records keep the same migration output and durable-state behavior.

Production LOC: +18/-25 (net -7) | Tests: +77/-2 (net +75)

## Evidence

- `node scripts/run-vitest.mjs run src/infra/state-migrations.transcript-directives-transform.test.ts src/infra/state-migrations.transcript-directives.test.ts` — 21 passed.
- Mutation proof rejected non-object-only handling, false changed/unconditional serialization, lost parse owner/cause, and dropped active-row/archive-line ownership.
- `pnpm check:database-first-legacy-stores` — passed.
- `pnpm check:import-cycles` — 0 runtime value cycles.
- `pnpm check:madge-import-cycles` — 0 cycles.
- `pnpm check:max-lines-ratchet` — passed.
- Clean Blacksmith Testbox `tbx_01m1d56k9xtcxxv70q90ddqpc8` — `pnpm build`, `pnpm check:changed`, and the focused 21-test suite passed on Linux; exit 0 in 16m42s ([run](https://github.com/openclaw/openclaw/actions/runs/33454106254)).
- Local `pnpm check:changed` and `pnpm build` reached an unrelated shared-install `pako` mismatch; the clean Testbox run above passed both commands.
- Exact Codex gate inspected at `codex-rs/cli/src/main.rs:220-245` and `codex-rs/cli/src/main.rs:2840-2870`; unrelated to this migration.
- Required Sol autoreview: scoped clean, 0.99, no actionable findings or exposed credentials.

No SQLite schema, persistent interpretation, transaction, downgrade, or publication semantics change.
