### PR TITLE
fix(export): honor hidden messages in HTML conversations

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -190,6 +190,11 @@ plugins.
     Explicit `/export-session` paths replace existing files inside the
     workspace. Omit the path to generate a collision-safe filename.
 
+    HTML conversation cards omit messages marked hidden. The sidebar's **All**
+    filter includes these records with a **[hidden]** label for debugging.
+    Message counts describe the raw archive. The HTML file and its JSONL download
+    still contain hidden records; hiding a message does not redact the export.
+
     <Note>
       Control UI intercepts typed `/new` to create and switch to a fresh
       dashboard session, except when `session.dmScope: "main"` is configured

--- a/src/auto-reply/reply/commands-export-session.test.ts
+++ b/src/auto-reply/reply/commands-export-session.test.ts
@@ -278,6 +278,21 @@ describe("buildExportSessionReply", () => {
   });
 
   it("injects scripts and session data through the real export template", async () => {
+    const entries = [
+      {
+        type: "message",
+        id: "hidden-input",
+        parentId: null,
+        timestamp: "2026-08-31T12:00:00.000Z",
+        message: {
+          role: "user",
+          content: "Synthetic continuation input",
+          display: false,
+          provenance: { kind: "internal_system", sourceTool: "openclaw_agent_consult" },
+        },
+      },
+    ];
+    hoisted.sessionTranscriptEvents = entries;
     await buildExportSessionReply(makeParams());
 
     const html = writtenHtml();
@@ -291,8 +306,8 @@ describe("buildExportSessionReply", () => {
       Buffer.from(
         JSON.stringify({
           header: null,
-          entries: [],
-          leafId: null,
+          entries,
+          leafId: "hidden-input",
           hasLeafControl: false,
           systemPrompt: "system prompt",
           tools: [],

--- a/src/auto-reply/reply/export-html/template.js
+++ b/src/auto-reply/reply/export-html/template.js
@@ -333,6 +333,12 @@
   let filterMode = "default";
   let searchQuery = "";
 
+  function isHiddenEntry(entry) {
+    return entry.type === "message"
+      ? entry.message.display === false
+      : entry.type === "custom_message" && !entry.display;
+  }
+
   function hasTextContent(content) {
     if (typeof content === "string") {
       return content.trim().length > 0;
@@ -422,6 +428,11 @@
       const label = flatNode.node.label;
       const isCurrentLeaf = entry.id === currentLeafId;
 
+      // All is the raw archive index; hidden input never becomes a conversation card.
+      if (isHiddenEntry(entry) && filterMode !== "all") {
+        return false;
+      }
+
       // Always show current leaf
       if (isCurrentLeaf) {
         return true;
@@ -510,7 +521,8 @@
         if (visibleIds.has(currentId)) {
           return currentId;
         }
-        currentId = entryMap.get(currentId)?.node.entry.parentId;
+        const parentId = entryMap.get(currentId)?.node.entry.parentId;
+        currentId = parentId === currentId ? null : parentId;
       }
       return null;
     }
@@ -751,7 +763,9 @@
    */
   function getTreeNodeDisplayHtml(entry, label) {
     const normalize = (s) => s.replace(/[\n\t]/g, " ").trim();
-    const labelHtml = label ? `<span class="tree-label">[${escapeHtml(label)}]</span> ` : "";
+    const labelHtml =
+      (isHiddenEntry(entry) ? '<span class="tree-muted">[hidden]</span> ' : "") +
+      (label ? `<span class="tree-label">[${escapeHtml(label)}]</span> ` : "");
 
     switch (entry.type) {
       case "message": {
@@ -1355,6 +1369,9 @@
   }
 
   function renderEntry(entry) {
+    if (isHiddenEntry(entry)) {
+      return "";
+    }
     const ts = formatTimestamp(entry.timestamp);
     const tsHtml = ts ? `<div class="message-timestamp">${ts}</div>` : "";
     const entryId = `entry-${escapeHtmlAttr(entry.id)}`;
@@ -1465,7 +1482,7 @@
           </div>`;
     }
 
-    if (entry.type === "custom_message" && entry.display) {
+    if (entry.type === "custom_message") {
       return `<div class="hook-message" id="${entryId}">${tsHtml}
             <div class="hook-type">[${escapeHtml(entry.customType)}]</div>
             <div class="markdown-content">${safeMarkedParse(typeof entry.content === "string" ? entry.content : JSON.stringify(entry.content))}</div>

--- a/src/auto-reply/reply/export-html/template.security.test.ts
+++ b/src/auto-reply/reply/export-html/template.security.test.ts
@@ -81,6 +81,7 @@ async function renderTemplate(sessionData: SessionData) {
 
   const parseHTML = await loadParseHTML();
   const { document } = parseHTML(html);
+  const downloads: Blob[] = [];
 
   const immediateTimeout = (fn: (...args: unknown[]) => void) => {
     fn();
@@ -92,6 +93,14 @@ async function renderTemplate(sessionData: SessionData) {
     clearTimeout: () => {},
     setTimeout: immediateTimeout,
     URLSearchParams,
+    Blob,
+    URL: class extends URL {
+      static override createObjectURL(blob: Blob) {
+        downloads.push(blob);
+        return "blob:session-export";
+      }
+      static override revokeObjectURL() {}
+    },
     TextDecoder,
     atob: (s: string) => Buffer.from(s, "base64").toString("binary"),
     btoa: (s: string) => Buffer.from(s, "binary").toString("base64"),
@@ -107,7 +116,13 @@ async function renderTemplate(sessionData: SessionData) {
   vm.runInContext(markedJs, runtime);
   vm.runInContext(highlightJs, runtime);
   vm.runInContext(templateJs, runtime);
-  return { document };
+  return {
+    document,
+    downloadJson: async () => {
+      vm.runInContext("downloadSessionJson()", runtime);
+      return await expectDefined(downloads.at(-1), "download missing").text();
+    },
+  };
 }
 
 function now() {
@@ -181,6 +196,83 @@ describe("export html sidebar trigger affordance", () => {
 });
 
 describe("export html security hardening", () => {
+  it.each(["consult", "answer"])("honors hidden input with %s selected while preserving raw export", async (leafId) => {
+    const session: SessionData = {
+      header: { id: "session-hidden-input", timestamp: now() },
+      entries: [
+        {
+          id: "hidden-root",
+          parentId: "hidden-root",
+          timestamp: now(),
+          type: "custom_message",
+          customType: "context",
+          content: "Hidden root context",
+          display: false,
+        },
+        {
+          id: "speech",
+          parentId: "hidden-root",
+          timestamp: now(),
+          type: "message",
+          message: { role: "user", content: "Explain the change. Context: Spoken style:" },
+        },
+        {
+          id: "consult",
+          parentId: "speech",
+          timestamp: now(),
+          type: "message",
+          message: {
+            role: "user",
+            content: "Synthetic consultation instructions",
+            display: false,
+            provenance: { kind: "internal_system", sourceTool: "openclaw_agent_consult" },
+          },
+        },
+        {
+          id: "answer",
+          parentId: "consult",
+          timestamp: now(),
+          type: "message",
+          message: { role: "assistant", content: "The change is ready." },
+        },
+      ],
+      leafId,
+      systemPrompt: "",
+      tools: [],
+    };
+
+    const { document, downloadJson } = await renderTemplate(session);
+    expect(document.querySelectorAll(".user-message")).toHaveLength(1);
+    expect(document.getElementById("entry-speech")?.textContent).toContain(
+      "Explain the change. Context: Spoken style:",
+    );
+    expect(document.getElementById("entry-consult")).toBeNull();
+    expect(document.getElementById("entry-hidden-root")).toBeNull();
+    const treeIds = () => Array.from(document.querySelectorAll(".tree-node"), (node) => node.getAttribute("data-id"));
+    expect(treeIds()).toEqual(["speech", "answer"]);
+    const selectFilter = (filter: string) => requireElement(
+      document.querySelector<HTMLButtonElement>(`[data-filter="${filter}"]`), "filter missing",
+    ).click();
+    selectFilter("all");
+    expect(treeIds()).toEqual(["hidden-root", "speech", "consult", "answer"]);
+    expect(document.querySelector('[data-id="consult"]')?.textContent).toContain("[hidden] user:");
+    requireElement(document.querySelector<HTMLElement>('[data-id="consult"]'), "hidden tree entry missing").click();
+    expect(document.getElementById("entry-answer")?.textContent).toContain("The change is ready.");
+    expect(document.getElementById("entry-consult")).toBeNull();
+    selectFilter("user-only");
+    expect(treeIds()).not.toContain("consult");
+    selectFilter("default");
+    expect(treeIds()).toEqual(["speech", "answer"]);
+    expect(document.getElementById("header-container")?.textContent).toContain("2 user, 1 assistant, 1 custom");
+    const encoded = requireElement(document.getElementById("session-data"), "session data missing");
+    expect(JSON.parse(Buffer.from(encoded.textContent ?? "", "base64").toString("utf8"))).toEqual(
+      session,
+    );
+    expect((await downloadJson()).split("\n").map((line) => JSON.parse(line))).toEqual([
+      { type: "header", ...session.header }, ...session.entries,
+    ]);
+  });
+
   it("renders export warnings in the header without interpreting HTML", async () => {
     const warning = 'Backend <img src=x onerror="alert(1)"> transcript is incomplete';
     const session: SessionData = {


### PR DESCRIPTION
Related: #133855 (presentation follow-up only; this issue must remain open)

## What Problem This Solves

Fixes an issue where users opening an HTML session export would see hidden continuation input as an ordinary user message. Browser Talk consults now record this input as hidden, and the existing Goal continuation contract also uses this flag, but the HTML viewer ignored it.

## Why This Change Was Made

One presentation predicate now handles message and custom-message visibility. Conversation cards and ordinary sidebar filters omit hidden entries; **All** retains a marked raw diagnostic index. The existing custom-only card check is absorbed into that predicate. Filtering keeps the complete parent/leaf graph, including visible replies below hidden nodes; the nearest-visible-ancestor walk now also terminates at supported self-parent roots.

No transcript rows, embedded JSON, downloaded JSONL, raw-role counts, model-context eligibility, or persistence semantics change. This does not resolve the broader retention/context or duplicate-assistant questions in #133855, and hidden data is **not redacted from the exported file**.

## User Impact

Generated continuation input no longer appears as something the user said in the HTML conversation. Operators can still inspect hidden records under All and download the complete raw archive. The slash-command docs explain this distinction.

Release-note context: HTML session exports honor hidden-message visibility without dropping raw archive records or descendant replies.

## Evidence

- Failure first on main `c0f1cbfddb9`: the real template DOM test expected one user card and observed two. The candidate hides the generated card while retaining the literal human text, including `Context:` and `Spoken style:`.
- Real Chrome, synthetic data only: before/after HTML renderer, Default/All/User filters, All search, reload, and the actual JSONL download. The download matched all five original rows and their metadata; two assistant replies remained visible. This is real browser/template proof, not a live provider call or a claim to have exercised `/export-session` against a running Gateway.
- `node scripts/run-vitest.mjs src/auto-reply/reply/export-html/template.security.test.ts src/auto-reply/reply/commands-export-session.test.ts`: **55 passed**, exit 0. Tests cover hidden current leaves, hidden custom roots with self-parent links, descendant navigation through All, raw embedded/download equality, escaping, and the real export builder retaining hidden provenance data.
- Full changed-file gate: `node scripts/check-changed.mjs -- docs/tools/slash-commands.md src/auto-reply/reply/export-html/template.js src/auto-reply/reply/export-html/template.security.test.ts src/auto-reply/reply/commands-export-session.test.ts` — exit 0 (formatting, core/test typechecks, lint, dead exports, dependency/ownership and runtime guards).
- Exact-head [CI 33454111101](https://github.com/openclaw/openclaw/actions/runs/33454111101): **success** on `6122f780a7529024a30584d950d46a94c9f58e5a`. Native review artifacts validated. The latest ClawSweeper review has no actionable findings; its pending-CI concern is resolved. No raw-retention or context-policy change is included.
- Independent Codex autoreview: no actionable P0–P2 findings.
- Production: **+17 net lines**; tests: **+107**; docs: **+5**. The growth adds the missing shared presentation boundary, preserves explicit raw diagnostics, and repairs its ancestor traversal; it replaces the custom-only check rather than adding a second archive or provider-specific filtering path.

Before:

![Synthetic HTML export before: hidden consultation appears as a user message](https://github.com/user-attachments/assets/1f5d7629-99fe-4a4a-a324-100650c4da0a)

After:

![Synthetic HTML export after: human input and both replies remain, hidden input omitted](https://github.com/user-attachments/assets/65be51d3-3f55-4dd2-9aac-4ed056ce8fe9)
