### PR TITLE
fix(memory): preserve abort errors with native response streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,6 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
-- **Memory response cancellation:** preserve the caller's abort error during pending response reads, preventing canceled JSON and upload requests from returning partial success or misleading parse errors.
 - **Agent prompts:** keep model-identity guidance conditional so ordinary requests are not mistaken for questions about the current model.
 
 - **Update/Doctor:** preserve `update --no-restart` by requiring an offline managed Gateway during updater-owned repair and leaving restart ownership with the parent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **Memory response cancellation:** preserve the caller's abort error during pending response reads, preventing canceled JSON and upload requests from returning partial success or misleading parse errors.
 - **Agent prompts:** keep model-identity guidance conditional so ordinary requests are not mistaken for questions about the current model.
 
 - **Update/Doctor:** preserve `update --no-restart` by requiring an offline managed Gateway during updater-owned repair and leaving restart ownership with the parent.

--- a/packages/memory-host-sdk/src/host/batch-upload.test.ts
+++ b/packages/memory-host-sdk/src/host/batch-upload.test.ts
@@ -1,7 +1,9 @@
 // Memory Host SDK tests cover batch upload behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withTestTimeout } from "../../../../test/helpers/promise.js";
 import { uploadBatchJsonlFile } from "./batch-upload.js";
 import { withRemoteHttpResponse } from "./remote-http.js";
+import { createPendingResponse } from "./response-snippet.test-harness.js";
 
 vi.mock("./remote-http.js", () => ({
   withRemoteHttpResponse: vi.fn(),
@@ -29,23 +31,6 @@ function streamingTextResponse(params: {
     },
   });
   return new Response(stream, { status: params.status, headers: params.headers });
-}
-
-function stallingResponse(params: { status: number; onCancel: () => void }): Response {
-  const reader = {
-    read: () => new Promise<ReadableStreamReadResult<Uint8Array>>(() => {}),
-    cancel: async () => {
-      params.onCancel();
-    },
-    releaseLock: () => undefined,
-  } as ReadableStreamDefaultReader<Uint8Array>;
-
-  return {
-    status: params.status,
-    ok: params.status >= 200 && params.status < 300,
-    headers: new Headers(),
-    body: { getReader: () => reader },
-  } as Response;
 }
 
 describe("uploadBatchJsonlFile", () => {
@@ -150,18 +135,12 @@ describe("uploadBatchJsonlFile", () => {
   });
 
   it("passes caller abort signals through non-ok file-upload response snippets", async () => {
-    let canceled = false;
+    const fixture = createPendingResponse({ status: 500 });
     remoteHttpMock.mockImplementationOnce(async (params) => {
-      return await params.onResponse(
-        stallingResponse({
-          status: 500,
-          onCancel: () => {
-            canceled = true;
-          },
-        }),
-      );
+      return await params.onResponse(fixture.response);
     });
     const controller = new AbortController();
+    const expected = new Error("upload aborted");
     const upload = uploadBatchJsonlFile({
       client: {
         baseUrl: "https://memory.example/v1",
@@ -171,30 +150,35 @@ describe("uploadBatchJsonlFile", () => {
       errorPrefix: "file upload failed",
       signal: controller.signal,
     });
+    const settled = upload.then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    try {
+      await withTestTimeout(fixture.readStarted, 1_000, "upload snippet read did not start");
+      expect(fixture.response.body?.locked).toBe(true);
+      controller.abort(expected);
 
-    await new Promise((resolve) => {
-      setTimeout(resolve, 0);
-    });
-    controller.abort(new Error("upload aborted"));
-
-    await expect(upload).rejects.toThrow("upload aborted");
-    expect(canceled).toBe(true);
-    expect(remoteHttpMock.mock.calls[0]?.[0].signal).toBe(controller.signal);
+      await expect(
+        withTestTimeout(settled, 1_000, "upload snippet abort did not settle"),
+      ).resolves.toBe(expected);
+      expect(fixture.cancel).toHaveBeenCalledOnce();
+      expect(fixture.response.body?.locked).toBe(false);
+      expect(remoteHttpMock.mock.calls[0]?.[0].signal).toBe(controller.signal);
+    } finally {
+      controller.abort(expected);
+      fixture.dispose();
+      await withTestTimeout(settled, 1_000, "upload snippet cleanup did not settle");
+    }
   });
 
   it("passes caller abort signals through successful file-upload JSON reads", async () => {
-    let canceled = false;
+    const fixture = createPendingResponse({ status: 200 });
     remoteHttpMock.mockImplementationOnce(async (params) => {
-      return await params.onResponse(
-        stallingResponse({
-          status: 200,
-          onCancel: () => {
-            canceled = true;
-          },
-        }),
-      );
+      return await params.onResponse(fixture.response);
     });
     const controller = new AbortController();
+    const expected = new Error("upload json aborted");
     const upload = uploadBatchJsonlFile({
       client: {
         baseUrl: "https://memory.example/v1",
@@ -204,14 +188,25 @@ describe("uploadBatchJsonlFile", () => {
       errorPrefix: "file upload failed",
       signal: controller.signal,
     });
+    const settled = upload.then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    try {
+      await withTestTimeout(fixture.readStarted, 1_000, "upload JSON read did not start");
+      expect(fixture.response.body?.locked).toBe(true);
+      controller.abort(expected);
 
-    await new Promise((resolve) => {
-      setTimeout(resolve, 0);
-    });
-    controller.abort(new Error("upload json aborted"));
-
-    await expect(upload).rejects.toThrow("upload json aborted");
-    expect(canceled).toBe(true);
-    expect(remoteHttpMock.mock.calls[0]?.[0].signal).toBe(controller.signal);
+      await expect(
+        withTestTimeout(settled, 1_000, "upload JSON abort did not settle"),
+      ).resolves.toBe(expected);
+      expect(fixture.cancel).toHaveBeenCalledOnce();
+      expect(fixture.response.body?.locked).toBe(false);
+      expect(remoteHttpMock.mock.calls[0]?.[0].signal).toBe(controller.signal);
+    } finally {
+      controller.abort(expected);
+      fixture.dispose();
+      await withTestTimeout(settled, 1_000, "upload JSON cleanup did not settle");
+    }
   });
 });

--- a/packages/memory-host-sdk/src/host/post-json.test.ts
+++ b/packages/memory-host-sdk/src/host/post-json.test.ts
@@ -1,7 +1,9 @@
 // Memory Host SDK tests cover post json behavior.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withTestTimeout } from "../../../../test/helpers/promise.js";
 import { postJson } from "./post-json.js";
 import { withRemoteHttpResponse } from "./remote-http.js";
+import { createPendingResponse } from "./response-snippet.test-harness.js";
 
 vi.mock("./remote-http.js", () => ({
   withRemoteHttpResponse: vi.fn(),
@@ -33,23 +35,6 @@ function streamingTextResponse(params: {
     },
   });
   return new Response(stream, { status: params.status, headers: params.headers });
-}
-
-function stallingSuccessResponse(onCancel: () => void): Response {
-  const reader = {
-    read: () => new Promise<ReadableStreamReadResult<Uint8Array>>(() => {}),
-    cancel: async () => {
-      onCancel();
-    },
-    releaseLock: () => undefined,
-  } as ReadableStreamDefaultReader<Uint8Array>;
-
-  return {
-    body: { getReader: () => reader },
-    headers: new Headers(),
-    ok: true,
-    status: 200,
-  } as Response;
 }
 
 describe("postJson", () => {
@@ -91,14 +76,11 @@ describe("postJson", () => {
   });
 
   it("applies abort signals while reading successful response bodies", async () => {
-    let canceled = false;
+    const fixture = createPendingResponse();
     const controller = new AbortController();
+    const expected = new Error("body aborted");
     remoteHttpMock.mockImplementationOnce(async (params) => {
-      return await params.onResponse(
-        stallingSuccessResponse(() => {
-          canceled = true;
-        }),
-      );
+      return await params.onResponse(fixture.response);
     });
 
     const read = postJson({
@@ -109,14 +91,25 @@ describe("postJson", () => {
       errorPrefix: "post failed",
       parse: () => ({}),
     });
+    const settled = read.then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    try {
+      await withTestTimeout(fixture.readStarted, 1_000, "POST JSON read did not start");
+      expect(fixture.response.body?.locked).toBe(true);
+      controller.abort(expected);
 
-    await new Promise((resolve) => {
-      setTimeout(resolve, 0);
-    });
-    controller.abort(new Error("body aborted"));
-
-    await expect(read).rejects.toThrow("body aborted");
-    expect(canceled).toBe(true);
+      await expect(withTestTimeout(settled, 1_000, "POST JSON abort did not settle")).resolves.toBe(
+        expected,
+      );
+      expect(fixture.cancel).toHaveBeenCalledOnce();
+      expect(fixture.response.body?.locked).toBe(false);
+    } finally {
+      controller.abort(expected);
+      fixture.dispose();
+      await withTestTimeout(settled, 1_000, "POST JSON cleanup did not settle");
+    }
   });
 
   it("attaches status to thrown error when requested", async () => {

--- a/packages/memory-host-sdk/src/host/response-snippet.test-harness.ts
+++ b/packages/memory-host-sdk/src/host/response-snippet.test-harness.ts
@@ -1,0 +1,36 @@
+import { vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
+
+export function createPendingResponse(params: { prefix?: string; status?: number } = {}) {
+  const readStarted = createDeferred();
+  const cancel = vi.fn();
+  let prefix = params.prefix;
+  let bodyController: ReadableStreamDefaultController<Uint8Array> | undefined;
+  const response = new Response(
+    new ReadableStream<Uint8Array>(
+      {
+        start(controller) {
+          bodyController = controller;
+        },
+        pull(controller) {
+          if (prefix !== undefined) {
+            controller.enqueue(new TextEncoder().encode(prefix));
+            prefix = undefined;
+          } else {
+            readStarted.resolve();
+          }
+        },
+        cancel,
+      },
+      // A pull must mean a reader is waiting, not background prefetch.
+      { highWaterMark: 0 },
+    ),
+    { status: params.status ?? 200 },
+  );
+  return {
+    response,
+    readStarted: readStarted.promise,
+    cancel,
+    dispose: () => bodyController?.error(new Error("response fixture disposed")),
+  };
+}

--- a/packages/memory-host-sdk/src/host/response-snippet.test.ts
+++ b/packages/memory-host-sdk/src/host/response-snippet.test.ts
@@ -1,9 +1,11 @@
 // Memory Host SDK tests cover response snippet behavior.
 import { describe, expect, it, vi } from "vitest";
+import { withTestTimeout } from "../../../../test/helpers/promise.js";
 import {
   readMemoryHostResponseTextSnippet,
   readResponseJsonWithLimit,
 } from "./response-snippet.js";
+import { createPendingResponse } from "./response-snippet.test-harness.js";
 
 describe("readMemoryHostResponseTextSnippet", () => {
   it.each(["prefix", "overflow", "length", "preabort"] as const)(
@@ -62,21 +64,6 @@ describe("readMemoryHostResponseTextSnippet", () => {
     },
   );
 
-  function stallingResponse(onCancel: () => void): Response {
-    const reader = {
-      read: () => new Promise<ReadableStreamReadResult<Uint8Array>>(() => {}),
-      cancel: async () => {
-        onCancel();
-      },
-      releaseLock: () => undefined,
-    } as ReadableStreamDefaultReader<Uint8Array>;
-
-    return {
-      body: { getReader: () => reader },
-      headers: new Headers(),
-    } as Response;
-  }
-
   it("does not wait for another chunk after reading the byte cap exactly", async () => {
     let canceled = false;
     const stream = new ReadableStream<Uint8Array>({
@@ -114,44 +101,65 @@ describe("readMemoryHostResponseTextSnippet", () => {
   });
 
   it("cancels snippet body reads when the caller signal aborts", async () => {
-    let canceled = false;
-    const response = stallingResponse(() => {
-      canceled = true;
-    });
+    const fixture = createPendingResponse();
     const controller = new AbortController();
-    const read = readMemoryHostResponseTextSnippet(response, {
+    const expected = new Error("snippet aborted");
+    const read = readMemoryHostResponseTextSnippet(fixture.response, {
       maxBytes: 1024,
       signal: controller.signal,
     });
+    const settled = read.then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    try {
+      await withTestTimeout(fixture.readStarted, 1_000, "snippet read did not start");
+      expect(fixture.response.body?.locked).toBe(true);
+      controller.abort(expected);
 
-    await new Promise((resolve) => {
-      setTimeout(resolve, 0);
-    });
-    controller.abort(new Error("snippet aborted"));
-
-    await expect(read).rejects.toThrow("snippet aborted");
-    expect(canceled).toBe(true);
+      await expect(withTestTimeout(settled, 1_000, "snippet abort did not settle")).resolves.toBe(
+        expected,
+      );
+      expect(fixture.cancel).toHaveBeenCalledOnce();
+      expect(fixture.response.body?.locked).toBe(false);
+    } finally {
+      controller.abort(expected);
+      fixture.dispose();
+      await withTestTimeout(settled, 1_000, "snippet cleanup did not settle");
+    }
   });
 
-  it("cancels JSON body reads when the caller signal aborts", async () => {
-    let canceled = false;
-    const response = stallingResponse(() => {
-      canceled = true;
-    });
-    const controller = new AbortController();
-    const read = readResponseJsonWithLimit(response, {
-      errorPrefix: "remote memory",
-      signal: controller.signal,
-    });
+  it.each([undefined, '{"ok":true}'])(
+    "cancels JSON body reads when the caller signal aborts (prefix: %s)",
+    async (prefix) => {
+      const fixture = createPendingResponse({ prefix });
+      const controller = new AbortController();
+      const expected = new Error("json aborted");
+      const read = readResponseJsonWithLimit(fixture.response, {
+        errorPrefix: "remote memory",
+        signal: controller.signal,
+      });
+      const settled = read.then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      try {
+        await withTestTimeout(fixture.readStarted, 1_000, "JSON read did not start");
+        expect(fixture.response.body?.locked).toBe(true);
+        controller.abort(expected);
 
-    await new Promise((resolve) => {
-      setTimeout(resolve, 0);
-    });
-    controller.abort(new Error("json aborted"));
-
-    await expect(read).rejects.toThrow("json aborted");
-    expect(canceled).toBe(true);
-  });
+        await expect(withTestTimeout(settled, 1_000, "JSON abort did not settle")).resolves.toBe(
+          expected,
+        );
+        expect(fixture.cancel).toHaveBeenCalledOnce();
+        expect(fixture.response.body?.locked).toBe(false);
+      } finally {
+        controller.abort(expected);
+        fixture.dispose();
+        await withTestTimeout(settled, 1_000, "JSON cleanup did not settle");
+      }
+    },
+  );
 
   it("rejects a JSON body with invalid UTF-8 bytes", async () => {
     const body = new Uint8Array([

--- a/packages/memory-host-sdk/src/host/response-snippet.ts
+++ b/packages/memory-host-sdk/src/host/response-snippet.ts
@@ -92,8 +92,8 @@ async function readChunkWithAbort(
   let removeAbortListener: (() => void) | undefined;
   const abortPromise = new Promise<ReadableStreamReadResult<Uint8Array>>((_resolve, reject) => {
     const onAbort = () => {
+      reject(toAbortError(signal, fallbackMessage)); // Cancel resolves pending reads.
       void reader.cancel().catch(() => undefined);
-      reject(toAbortError(signal, fallbackMessage));
     };
     signal.addEventListener("abort", onAbort, { once: true });
     removeAbortListener = () => signal.removeEventListener("abort", onAbort);


### PR DESCRIPTION
Canceling a pending native response read can settle it as end-of-stream before the memory reader's abort rejection wins. A canceled successful JSON response may therefore be returned as success, while empty responses replace the caller's error with a malformed-JSON or status error. The existing fake readers never settled their pending reads when canceled and hid this behavior.

Reject the abort promise before starting cancellation at the shared response reader. Cancellation stays non-awaited so an open capture/clone branch cannot block release. Replace five fake-reader cases and their timer sleeps with native Response/ReadableStream fixtures, plus one complete-JSON-prefix case. Every wait is bounded and observes an actual pending read; cases check exact abort identity, once-only cancellation, and lock release.

The six revised abort cases fail against the original owner; all twenty unaffected cases remain green. After the fix, all 62 selected reader, upload, POST, embedding, retry, and guarded-release tests pass. Three standalone native-stream probes and six real loopback HTTP scenarios through postJson, the remote HTTP owner, and guarded fetch also pass on Node 24.19.0:

| Pending HTTP body | Before, with and without an open clone | After, both modes |
| --- | --- | --- |
| Empty successful JSON | Malformed JSON error | Original abort error |
| Complete JSON prefix, no EOF | Returned parsed JSON after abort | Original abort error |
| Empty non-OK response | Status error with empty snippet | Original abort error |

All HTTP cases release the reader. The loopback proof uses the runtime dispatcher adapter and preserves native read promises; an initial global-fetch/dispatcher mismatch was a probe setup failure and is excluded from behavioral evidence. No external provider service was contacted.

Production +1/-1 (net zero); tests/support +162/-130 (net +32). Existing byte caps, UTF-8 handling, and four clone/cancellation cases remain. Full changed checks passed; independent Codex autoreview is clean. The same ordering exists in stable tag v2026.8.1. No configuration or storage contract changes.

Release note: Memory response cancellation now preserves the caller's abort error during pending response reads, preventing canceled JSON and upload requests from returning partial success or misleading parse errors. The release generator owns CHANGELOG.md; this PR supplies its release-note context here.
