### PR TITLE
fix: keep channel sends on the selected plugin

### DIFF
--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -60,6 +60,12 @@ them with `listMessageReceiptPlatformIds(...)` or
 `resolveMessageReceiptPrimaryId(...)` instead of keeping parallel `messageIds`
 fields.
 
+Channel actions and adapter capabilities come from the selected plugin
+registration. An omitted `actions`, `message`, or `outbound` surface is not
+filled from another plugin with the same channel ID. Prepared delivery handlers
+created inside a registry scope retain that handle when invoked after the caller
+leaves the scope.
+
 Declare live and finalizer capabilities precisely - core uses these to decide
 what a channel can do, and drift between the declared and actual behavior is a
 contract test failure:

--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -1,5 +1,5 @@
 // Amazon Bedrock Mantle tests cover discovery plugin behavior.
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 
 const discoveryDebugSpy = vi.hoisted(() => vi.fn());
 const discoveryLoggerState = vi.hoisted(() => ({ debugEnabled: true }));
@@ -727,6 +727,9 @@ describe("bedrock mantle discovery", () => {
   // ---------------------------------------------------------------------------
 
   it("resolves implicit provider when bearer token is set", async () => {
+    // This catalog includes the promotional contract before the September pricing cutover.
+    const clock = vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 7, 31));
+    onTestFinished(() => clock.mockRestore());
     const mockFetch = vi.fn().mockResolvedValue(
       modelDiscoveryResponse({
         data: [{ id: "anthropic.claude-sonnet-4-6", object: "model" }],

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -12,7 +12,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 // Anthropic tests cover index plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 
 const { probeClaudeCliAuthStatusMock } = vi.hoisted(() => ({
   probeClaudeCliAuthStatusMock: vi.fn(),
@@ -719,6 +719,9 @@ describe("anthropic provider replay hooks", () => {
       restoresMissingCost,
       checksCliPolicy,
     }) => {
+      // This table describes the promotional contract before the September pricing cutover.
+      const clock = vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 7, 31));
+      onTestFinished(() => clock.mockRestore());
       const provider = await registerSingleProviderPlugin(anthropicPlugin);
       const resolved = provider.resolveDynamicModel?.({
         provider: "anthropic",

--- a/src/channels/plugins/message-action-dispatch.registry.test.ts
+++ b/src/channels/plugins/message-action-dispatch.registry.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
+import { dispatchChannelMessageAction } from "./message-action-dispatch.js";
+
+const receipt = { content: [{ type: "text" as const, text: "delivered" }], details: { ok: true } };
+
+afterEach(() => resetPluginRuntimeStateForTest());
+
+describe("message action registration ownership", () => {
+  it.each([true, false])(
+    "uses only the selected scoped action capability (present=%s)",
+    async (present) => {
+      const handleRootAction = vi.fn(async () => receipt);
+      const handleScopedAction = vi.fn(async () => receipt);
+      const base = createChannelTestPluginBase({ id: "scoped-delivery" });
+      const root = { ...base, actions: { handleAction: handleRootAction } };
+      const scoped = {
+        ...base,
+        ...(present ? { actions: { handleAction: handleScopedAction } } : {}),
+      };
+      setActivePluginRegistry(
+        createTestRegistry([{ pluginId: "root", source: "root", origin: "bundled", plugin: root }]),
+      );
+      const registry = createTestRegistry([
+        { pluginId: "scoped", source: "scoped", origin: "config", plugin: scoped },
+      ]);
+
+      const result = await withPluginRuntimeRegistryScope(registry, () =>
+        dispatchChannelMessageAction({
+          cfg: {},
+          channel: base.id,
+          action: "send",
+          params: { to: "recipient", message: "hello" },
+        }),
+      );
+
+      expect(result).toEqual(present ? receipt : null);
+      expect(handleRootAction).not.toHaveBeenCalled();
+      expect(handleScopedAction).toHaveBeenCalledTimes(present ? 1 : 0);
+    },
+  );
+  it("keeps scoped channel read authority external beside a bundled same-id registration", async () => {
+    const handleRootAction = vi.fn(async () => receipt);
+    const handleScopedAction = vi.fn(async () => receipt);
+    const base = createChannelTestPluginBase({ id: "scoped-delivery" });
+    setActivePluginRegistry(
+      createTestRegistry([
+        {
+          pluginId: "root",
+          source: "root",
+          origin: "bundled",
+          plugin: {
+            ...base,
+            actions: { providerOwnedReadGates: true, handleAction: handleRootAction },
+          },
+        },
+      ]),
+    );
+    const registry = createTestRegistry([
+      {
+        pluginId: "scoped",
+        source: "scoped",
+        origin: "config",
+        plugin: {
+          ...base,
+          actions: { providerOwnedReadGates: true, handleAction: handleScopedAction },
+        },
+      },
+    ]);
+    const context = { cfg: {}, channel: base.id, action: "read", params: { to: "recipient" } };
+
+    await withPluginRuntimeRegistryScope(registry, async () => {
+      await expect(
+        dispatchChannelMessageAction({
+          ...context,
+          conversationReadOrigin: "delegated",
+        }),
+      ).rejects.toThrow("requires the exact current conversation and account");
+      expect(handleScopedAction).not.toHaveBeenCalled();
+      expect(handleRootAction).not.toHaveBeenCalled();
+
+      expect(
+        await dispatchChannelMessageAction({
+          ...context,
+          conversationReadOrigin: "direct-operator",
+        }),
+      ).toBe(receipt);
+      expect(
+        await dispatchChannelMessageAction({
+          ...context,
+          conversationReadOrigin: "delegated",
+          accountId: "ops",
+          requesterAccountId: "ops",
+          toolContext: { currentChannelProvider: base.id, currentChannelId: "recipient" },
+        }),
+      ).toBe(receipt);
+      expect(handleScopedAction).toHaveBeenCalledTimes(2);
+      expect(handleRootAction).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/channels/plugins/registry-loaded.ts
+++ b/src/channels/plugins/registry-loaded.ts
@@ -144,10 +144,13 @@ export function getLoadedChannelPluginForRead(id: ChannelId): ChannelPlugin | un
 /**
  * Returns the loaded channel registry entry by normalized plugin id.
  */
-export function getLoadedChannelPluginEntryById(id: string): LoadedChannelPluginEntry | undefined {
+export function getLoadedChannelPluginEntryById(
+  id: string,
+  registry?: ActivePluginChannelRegistry,
+): LoadedChannelPluginEntry | undefined {
   const resolvedId = normalizeOptionalString(id) ?? "";
   if (!resolvedId) {
     return undefined;
   }
-  return resolveChannelPlugins().entriesById.get(resolvedId);
+  return resolveChannelPlugins(registry).entriesById.get(resolvedId);
 }

--- a/src/channels/plugins/registry.test.ts
+++ b/src/channels/plugins/registry.test.ts
@@ -3,6 +3,11 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import type { PluginRegistry } from "../../plugins/registry.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 import {
   getChannelPlugin,
   getLoadedChannelPlugin,
@@ -72,6 +77,47 @@ describe("listChannelPlugins", () => {
           label: "external fallback",
         },
       },
+    });
+  });
+
+  it("keeps the scoped channel implementation and its registration provenance together", () => {
+    const root = createChannelTestPluginBase({ id: "fallback", label: "Root" });
+    const scoped = createChannelTestPluginBase({ id: "fallback", label: "Scoped" });
+    const resolveChannelRuntime = vi.fn();
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "root", plugin: root, origin: "bundled", source: "root" }]),
+    );
+    const registry = createEmptyPluginRegistry();
+    registry.channels = [
+      {
+        pluginId: "scoped",
+        plugin: scoped,
+        origin: "config",
+        source: "scoped",
+        resolveChannelRuntime,
+      },
+    ];
+
+    withPluginRuntimeRegistryScope(registry, () => {
+      expect(resolveChannelPluginRegistration("fallback")).toEqual({
+        plugin: scoped,
+        origin: "config",
+        resolveChannelRuntime,
+      });
+      expect(getChannelPlugin("fallback")).toBe(scoped);
+    });
+    expect(getChannelPlugin("fallback")).toBe(root);
+  });
+
+  it("preserves unrelated root and bundled addressability inside an empty CLI handle", () => {
+    const root = createChannelTestPluginBase({ id: "root-only" });
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "root-only", plugin: root, source: "root" }]),
+    );
+
+    withPluginRuntimeRegistryScope(createEmptyPluginRegistry(), () => {
+      expect(getChannelPlugin("root-only")).toBe(root);
+      expect(resolveChannelPluginRegistration("fallback")?.origin).toBe("bundled");
     });
   });
 

--- a/src/channels/plugins/registry.ts
+++ b/src/channels/plugins/registry.ts
@@ -1,5 +1,6 @@
 /** Active channel plugin registry with bundled fallback. */
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { getPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { normalizeAnyChannelId } from "../registry.js";
 import { getBundledChannelPlugin } from "./bundled.js";
 import {
@@ -44,7 +45,10 @@ export function resolveChannelPluginRegistration(id: ChannelId):
   }
   // Resolve implementation and provenance together. Loaded overrides win and
   // must never borrow bundled authority from the fallback with the same id.
-  const loadedEntry = getLoadedChannelPluginEntryById(resolvedId);
+  const scopedRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
+  const loadedEntry =
+    (scopedRegistry ? getLoadedChannelPluginEntryById(resolvedId, scopedRegistry) : undefined) ??
+    getLoadedChannelPluginEntryById(resolvedId);
   if (loadedEntry) {
     const origin = normalizeOptionalString(loadedEntry.origin) ?? undefined;
     return {

--- a/src/infra/outbound/channel-bootstrap.runtime.test.ts
+++ b/src/infra/outbound/channel-bootstrap.runtime.test.ts
@@ -8,8 +8,14 @@ import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import {
   getActivePluginRegistry,
   resetPluginRuntimeStateForTest,
+  requireActivePluginRegistry,
   setActivePluginRegistry,
 } from "../../plugins/runtime.js";
+import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 
 const loaderMocks = vi.hoisted(() => ({
   loadPluginRegistryHandle: vi.fn(),
@@ -26,8 +32,11 @@ vi.mock("../../plugins/loader.js", () => ({
 
 const { bootstrapOutboundChannelPlugin, resetOutboundChannelBootstrapStateForTests } =
   await import("./channel-bootstrap.runtime.js");
-const { resolveChannelOutboundDirectiveOptions, resolveOutboundDurableFinalDeliverySupport } =
-  await import("./deliver-channel.js");
+const {
+  createChannelHandler,
+  resolveChannelOutboundDirectiveOptions,
+  resolveOutboundDurableFinalDeliverySupport,
+} = await import("./deliver-channel.js");
 const { resolveChannelTargetForDelivery, resolveOutboundSessionRouteForDelivery } =
   await import("../../cron/isolated-agent/delivery-target.runtime.js");
 
@@ -307,6 +316,52 @@ describe("bootstrapOutboundChannelPlugin", () => {
     expect(loaderMocks.loadPluginRegistryHandle).not.toHaveBeenCalled();
   });
 
+  it.each([false, true])(
+    "activates the scoped setup shell without borrowing a same-id root sender (cached=%s)",
+    (cached) => {
+      const base = createChannelTestPluginBase({ id: "discord" });
+      const root = {
+        ...base,
+        ...(!cached ? { outbound: { deliveryMode: "direct" as const, sendText: vi.fn() } } : {}),
+      };
+      const activated = {
+        ...base,
+        outbound: { deliveryMode: "direct" as const, sendText: vi.fn() },
+      };
+      setActivePluginRegistry(
+        createTestRegistry([{ pluginId: "root", source: "root", plugin: root }]),
+      );
+      const setupRegistry = createTestRegistry([
+        { pluginId: "selected", source: "setup", plugin: base },
+      ]);
+      const runtimeRegistry = createTestRegistry([
+        { pluginId: "selected", source: "runtime", plugin: activated },
+      ]);
+      if (cached) {
+        const prior = createTestRegistry([
+          { pluginId: "root", source: "prior", plugin: activated },
+        ]);
+        loaderMocks.loadPluginRegistryHandle.mockReturnValue(prior);
+        expect(bootstrapOutboundChannelPlugin({ channel: "discord", cfg: discordConfig })).toBe(
+          prior,
+        );
+        loaderMocks.loadPluginRegistryHandle.mockClear();
+      }
+      loaderMocks.loadPluginRegistryHandle.mockReturnValue(runtimeRegistry);
+
+      expect(
+        withPluginRuntimeRegistryScope(setupRegistry, () =>
+          bootstrapOutboundChannelPlugin({
+            channel: "discord",
+            cfg: discordConfig,
+          }),
+        ),
+      ).toBe(runtimeRegistry);
+      expect(loaderMocks.loadPluginRegistryHandle).toHaveBeenCalledOnce();
+      expect(getActivePluginRegistry()?.channels[0]?.plugin).toBe(root);
+    },
+  );
+
   it("returns a scoped handle without replacing the process root", () => {
     installDiscordSetupShell();
     const root = getActivePluginRegistry();
@@ -360,6 +415,74 @@ describe("bootstrapOutboundChannelPlugin", () => {
       }),
     ).resolves.toEqual({ ok: true, automaticUnknownSendReconciliation: false });
   });
+
+  it.each(["outbound", "message"] as const)(
+    "retains the scoped %s transport and its durable capabilities through delivery",
+    async (transport) => {
+      const base = createChannelTestPluginBase({ id: "discord" });
+      const rootSend = vi.fn(async () => ({ channel: "discord", messageId: "root" }));
+      const sendRegistries: ReturnType<typeof requireActivePluginRegistry>[] = [];
+      const scopedSend = vi.fn(async () => {
+        sendRegistries.push(requireActivePluginRegistry());
+        return { channel: "discord", messageId: "scoped" };
+      });
+      const message = (send: typeof rootSend, id: string) => ({
+        send: {
+          text: async () => {
+            await send();
+            return {
+              receipt: {
+                primaryPlatformMessageId: id,
+                platformMessageIds: [id],
+                sentAt: 1,
+                parts: [{ platformMessageId: id, kind: "text" as const, index: 0 }],
+              },
+            };
+          },
+        },
+      });
+      const root = {
+        ...base,
+        outbound: { deliveryMode: "direct" as const, sendText: rootSend },
+        message: {
+          ...message(rootSend, "root"),
+          durableFinal: { capabilities: { text: true, silent: true } },
+        },
+      };
+      const scoped = {
+        ...base,
+        ...(transport === "outbound"
+          ? { outbound: { deliveryMode: "direct" as const, sendText: scopedSend } }
+          : { message: message(scopedSend, "scoped") }),
+      };
+      setActivePluginRegistry(
+        createTestRegistry([{ pluginId: "root", source: "root", plugin: root }]),
+      );
+      const registry = createTestRegistry([
+        { pluginId: "scoped", source: "scoped", plugin: scoped },
+      ]);
+
+      const handler = await withPluginRuntimeRegistryScope(registry, async () => {
+        await expect(
+          resolveOutboundDurableFinalDeliverySupport({
+            cfg: discordConfig,
+            channel: "discord",
+            requirements: { silent: true },
+          }),
+        ).resolves.toEqual({ ok: false, reason: "capability_mismatch", capability: "silent" });
+        return await createChannelHandler({
+          cfg: discordConfig,
+          channel: "discord",
+          to: "recipient",
+        });
+      });
+      await expect(handler.sendText("hello")).resolves.toMatchObject({ messageId: "scoped" });
+      expect(sendRegistries).toEqual([registry]);
+      expect(scopedSend).toHaveBeenCalledOnce();
+      expect(rootSend).not.toHaveBeenCalled();
+      expect(loaderMocks.loadPluginRegistryHandle).not.toHaveBeenCalled();
+    },
+  );
 
   it("does not retry an unusable handle in the same generation", () => {
     installDiscordSetupShell();

--- a/src/infra/outbound/channel-bootstrap.runtime.ts
+++ b/src/infra/outbound/channel-bootstrap.runtime.ts
@@ -13,6 +13,7 @@ import { loadPluginRegistryHandle } from "../../plugins/loader.js";
 import type { PluginChannelRegistration } from "../../plugins/registry-types.js";
 import type { PluginRegistry } from "../../plugins/registry.js";
 import { getActivePluginRegistry, getActivePluginRegistryVersion } from "../../plugins/runtime.js";
+import { getPluginRuntimeGatewayRequestScope } from "../../plugins/runtime/gateway-request-scope.js";
 import { pruneMapToMaxSize } from "../map-size.js";
 
 const MAX_BOOTSTRAP_CONFIG_GENERATIONS = 64;
@@ -93,7 +94,9 @@ export function bootstrapOutboundChannelPlugin(params: {
     return undefined;
   }
 
-  const activeRegistry = getActivePluginRegistry();
+  const scopedRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
+  const scopedEntry = findChannelEntry(scopedRegistry ?? null, params.channel);
+  const activeRegistry = scopedEntry ? scopedRegistry : getActivePluginRegistry();
   const activeSendRegistry = resolveSendCapableRegistry(activeRegistry, params.channel);
   if (activeSendRegistry) {
     return activeSendRegistry;
@@ -108,11 +111,15 @@ export function bootstrapOutboundChannelPlugin(params: {
   // collision-free ownerless cache slot.
   const agentId = tryResolveAmbientOwnerAgentId(cfg, params.agentId);
   const outcomeKey = `${agentId ?? ""}\0${params.channel}`;
-  const registries = resolveBootstrapRegistries(cfg);
-  const cachedRegistry = registries.get(outcomeKey);
-  if (cachedRegistry !== undefined) {
-    cacheBootstrapOutcome(registries, outcomeKey, cachedRegistry);
-    return resolveSendCapableRegistry(cachedRegistry, params.channel);
+  // Root-generation memoization cannot replace a selected scoped setup owner.
+  // Its activation uses the loader's own registry-handle cache instead.
+  const registries = scopedEntry ? undefined : resolveBootstrapRegistries(cfg);
+  if (registries) {
+    const cachedRegistry = registries.get(outcomeKey);
+    if (cachedRegistry !== undefined) {
+      cacheBootstrapOutcome(registries, outcomeKey, cachedRegistry);
+      return resolveSendCapableRegistry(cachedRegistry, params.channel);
+    }
   }
 
   const autoEnabled = applyPluginAutoEnable({ config: cfg });
@@ -143,6 +150,8 @@ export function bootstrapOutboundChannelPlugin(params: {
   } catch {
     // Best-effort bootstrap; the caller reports the unavailable channel.
   }
-  cacheBootstrapOutcome(registries, outcomeKey, sendRegistry ?? null);
+  if (registries) {
+    cacheBootstrapOutcome(registries, outcomeKey, sendRegistry ?? null);
+  }
   return sendRegistry;
 }

--- a/src/infra/outbound/channel-resolution.test.ts
+++ b/src/infra/outbound/channel-resolution.test.ts
@@ -1,6 +1,11 @@
 // Verifies outbound channel resolution fast paths, active-registry reads,
 // bootstrap fallback, and runtime facade projection.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
+import {
+  createChannelTestPluginBase,
+  createTestRegistry,
+} from "../../test-utils/channel-plugins.js";
 
 const tryResolveAmbientOwnerAgentIdMock = vi.hoisted(() => vi.fn());
 const resolveAgentWorkspaceDirMock = vi.hoisted(() => vi.fn());
@@ -196,6 +201,43 @@ describe("outbound channel resolution", () => {
         channelResolution.resolveOutboundChannelMessageAdapter({ channel: "alpha" }),
       ),
     ).toBe(message);
+  });
+
+  it.each(["loaded", "bundled"] as const)(
+    "does not borrow a %s message adapter from a scoped outbound-only registration",
+    async (fallback) => {
+      const sibling = { id: "alpha", message: { send: { text: vi.fn() } } };
+      (fallback === "loaded" ? getLoadedChannelPluginMock : getChannelPluginMock).mockReturnValue(
+        sibling,
+      );
+      const scoped = {
+        ...createChannelTestPluginBase({ id: "alpha" }),
+        outbound: { deliveryMode: "direct" as const, sendText: vi.fn() },
+      };
+      const registry = createTestRegistry([{ pluginId: "scoped", plugin: scoped, source: "test" }]);
+      const resolution = await importChannelResolution(`scoped-outbound-only-${fallback}`);
+
+      withPluginRuntimeRegistryScope(registry, () => {
+        expect(resolution.resolveOutboundChannelPlugin({ channel: "alpha" })).toBe(scoped);
+        expect(
+          resolution.resolveOutboundChannelMessageAdapter({ channel: "alpha" }),
+        ).toBeUndefined();
+      });
+      expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("preserves a scoped channel without message sends instead of borrowing a bundled sender", async () => {
+    const scoped = createChannelTestPluginBase({ id: "alpha" });
+    getChannelPluginMock.mockReturnValue({ id: "alpha", message: { send: { text: vi.fn() } } });
+    const registry = createTestRegistry([{ pluginId: "scoped", plugin: scoped, source: "test" }]);
+    const resolution = await importChannelResolution("scoped-missing-send");
+
+    withPluginRuntimeRegistryScope(registry, () => {
+      expect(resolution.resolveOutboundChannelPlugin({ channel: "alpha" })).toBe(scoped);
+      expect(resolution.resolveOutboundChannelMessageAdapter({ channel: "alpha" })).toBeUndefined();
+    });
+    expect(resolveRuntimePluginRegistryMock).not.toHaveBeenCalled();
   });
 
   it("bootstraps configured channel plugins when the active registry is missing the target", async () => {

--- a/src/infra/outbound/channel-resolution.test.ts
+++ b/src/infra/outbound/channel-resolution.test.ts
@@ -193,9 +193,6 @@ describe("outbound channel resolution", () => {
     getLoadedChannelPluginMock.mockReturnValue(undefined);
     getChannelPluginMock.mockReturnValue(undefined);
     const channelResolution = await importChannelResolution("scoped-message-adapter");
-    const { withPluginRuntimeRegistryScope } =
-      await import("../../plugins/runtime/gateway-request-scope.js");
-
     expect(
       withPluginRuntimeRegistryScope(registry, () =>
         channelResolution.resolveOutboundChannelMessageAdapter({ channel: "alpha" }),

--- a/src/infra/outbound/channel-resolution.ts
+++ b/src/infra/outbound/channel-resolution.ts
@@ -77,24 +77,11 @@ function normalizeOutboundChannelForResolution(params: {
   };
 }
 
-function resolveDirectFromRegistry(
-  registry: ReturnType<typeof getActivePluginRegistry>,
-  channel: string,
-): ChannelPlugin | undefined {
-  return findChannelPluginInRegistry(registry, channel);
-}
-
-function messageAdapterCanSendText(
-  message: ChannelMessageAdapterShape | undefined,
-): message is ChannelMessageAdapterShape {
-  return typeof message?.send?.text === "function";
-}
-
 function resolveSendCapableMessageAdapter(
   plugin: ChannelPlugin | undefined,
 ): ChannelMessageAdapterShape | undefined {
   const message = plugin?.message;
-  return messageAdapterCanSendText(message) ? message : undefined;
+  return typeof message?.send?.text === "function" ? message : undefined;
 }
 
 function channelPluginHasRuntimeOutboundSurface(plugin: ChannelPlugin | undefined): boolean {
@@ -148,7 +135,7 @@ function resolveValueFromRuntimeRegistry<TValue>(
   resolveValue: (plugin: ChannelPlugin) => TValue | undefined,
   registry: PluginRegistry | null | undefined = getOutboundRuntimeRegistry(),
 ): TValue | undefined {
-  const plugin = resolveDirectFromRegistry(registry ?? null, channel);
+  const plugin = findChannelPluginInRegistry(registry, channel);
   return plugin ? resolveValue(plugin) : undefined;
 }
 
@@ -187,6 +174,25 @@ export function resolveOutboundChannelPlugin(params: {
   } = normalizeOutboundChannelForResolution(params);
   if (!normalized) {
     return undefined;
+  }
+
+  const scopedPlugin = findChannelPluginInRegistry(
+    bootstrapRegistry ?? getPluginRuntimeGatewayRequestScope()?.pluginRegistry,
+    normalized,
+  );
+  if (scopedPlugin) {
+    // A selected registration owns absent capabilities too. Only explicit
+    // activation may replace a setup shell; never borrow a same-id sender.
+    if (params.allowBootstrap !== true || channelPluginHasActivatedOutboundSurface(scopedPlugin)) {
+      return scopedPlugin;
+    }
+    if (didBootstrap) {
+      return undefined;
+    }
+    return resolveActivatedOutboundPluginFromRuntimeRegistry(
+      normalized,
+      bootstrapOutboundChannelPlugin({ ...params, channel: normalized }),
+    );
   }
 
   const resolveLoaded = () => getLoadedChannelPlugin(normalized);
@@ -235,33 +241,5 @@ export function resolveOutboundChannelMessageAdapter(params: {
   agentId?: string;
   allowBootstrap?: boolean;
 }): ChannelMessageAdapterShape | undefined {
-  const {
-    channel: normalized,
-    didBootstrap,
-    bootstrapRegistry,
-  } = normalizeOutboundChannelForResolution(params);
-  if (!normalized) {
-    return undefined;
-  }
-  const current =
-    resolveSendCapableMessageAdapter(getLoadedChannelPlugin(normalized)) ??
-    resolveValueFromRuntimeRegistry(
-      normalized,
-      resolveSendCapableMessageAdapter,
-      bootstrapRegistry,
-    ) ??
-    resolveSendCapableMessageAdapter(getChannelPlugin(normalized));
-  if (current || params.allowBootstrap !== true || didBootstrap) {
-    return current;
-  }
-  const registry = bootstrapOutboundChannelPlugin({
-    channel: normalized,
-    cfg: params.cfg,
-    agentId: params.agentId,
-  });
-  return (
-    resolveSendCapableMessageAdapter(getLoadedChannelPlugin(normalized)) ??
-    resolveValueFromRuntimeRegistry(normalized, resolveSendCapableMessageAdapter, registry) ??
-    resolveSendCapableMessageAdapter(getChannelPlugin(normalized))
-  );
+  return resolveSendCapableMessageAdapter(resolveOutboundChannelPlugin(params));
 }

--- a/src/infra/outbound/deliver-channel.ts
+++ b/src/infra/outbound/deliver-channel.ts
@@ -7,19 +7,22 @@ import type {
   ChannelMessageSendResult,
 } from "../../channels/message/types.js";
 import { unknownSendReconciliationKinds } from "../../channels/message/types.js";
-import { loadChannelOutboundAdapter } from "../../channels/plugins/outbound/load.js";
+import { createChannelRegistryLoader } from "../../channels/plugins/registry-loader.js";
 import type {
   ChannelOutboundAdapter,
   ChannelOutboundPayloadContext,
   ChannelOutboundTargetRef,
 } from "../../channels/plugins/types.adapters.js";
+import type { ChannelPlugin } from "../../channels/plugins/types.plugin.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import type { PluginRegistry } from "../../plugins/registry-types.js";
-import { withPluginRuntimeRegistryScope } from "../../plugins/runtime/gateway-request-scope.js";
+import {
+  getPluginRuntimeGatewayRequestScope,
+  withPluginRuntimeRegistryScope,
+} from "../../plugins/runtime/gateway-request-scope.js";
 import { createLazyRuntimeModule } from "../../shared/lazy-runtime.js";
 import { formatErrorMessage } from "../errors.js";
-import { resolveOutboundChannelMessageAdapter } from "./channel-resolution.js";
 import type {
   ChannelHandler,
   ChannelHandlerParams,
@@ -40,23 +43,23 @@ const log = createSubsystemLogger("outbound/deliver");
 const loadChannelBootstrapRuntime = createLazyRuntimeModule(
   () => import("./channel-bootstrap.runtime.js"),
 );
+const loadChannelPluginFromRegistry = createChannelRegistryLoader((entry) => entry.plugin);
 export async function resolveChannelOutboundDirectiveOptions(params: {
   cfg: OpenClawConfig;
   agentId?: string;
   channel: string;
 }): Promise<{ extractMarkdownImages?: boolean }> {
-  const { outbound } = await loadBootstrappedOutboundAdapter(params);
+  const { plugin } = await loadBootstrappedChannelPlugin(params);
   return {
-    extractMarkdownImages: outbound?.extractMarkdownImages === true ? true : undefined,
+    extractMarkdownImages: plugin?.outbound?.extractMarkdownImages === true ? true : undefined,
   };
 }
 
 export async function createChannelHandler(params: ChannelHandlerParams): Promise<ChannelHandler> {
-  const { outbound, pluginRegistry } = await loadBootstrappedOutboundAdapter(params);
-  const handler = withPluginRuntimeRegistryScope(pluginRegistry, () => {
-    const message = resolveOutboundChannelMessageAdapter(params);
-    return createPluginHandler({ ...params, outbound, message });
-  });
+  const { plugin, pluginRegistry } = await loadBootstrappedChannelPlugin(params);
+  const handler = withPluginRuntimeRegistryScope(pluginRegistry, () =>
+    createPluginHandler({ ...params, outbound: plugin?.outbound, message: plugin?.message }),
+  );
   if (!handler) {
     const message = `Outbound not configured for channel: ${params.channel}`;
     throw new PlatformMessageNotDispatchedError(message, { cause: new Error(message) });
@@ -64,14 +67,17 @@ export async function createChannelHandler(params: ChannelHandlerParams): Promis
   return scopeChannelHandler(handler, pluginRegistry);
 }
 
-async function loadBootstrappedOutboundAdapter(params: {
+async function loadBootstrappedChannelPlugin(params: {
   cfg: OpenClawConfig;
   agentId?: string;
   channel: string;
-}): Promise<{ outbound?: ChannelOutboundAdapter; pluginRegistry?: PluginRegistry }> {
-  let outbound = await loadChannelOutboundAdapter(params.channel);
-  if (outbound) {
-    return { outbound };
+}): Promise<{ plugin?: ChannelPlugin; pluginRegistry?: PluginRegistry }> {
+  const scopedRegistry = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
+  const plugin = await loadChannelPluginFromRegistry(params.channel);
+  if (plugin?.outbound || plugin?.message?.send?.text) {
+    // Both adapter surfaces belong to this registration, including an omitted
+    // surface. A second lookup could attach another plugin's send lifecycle.
+    return { plugin, pluginRegistry: scopedRegistry };
   }
   const { bootstrapOutboundChannelPlugin } = await loadChannelBootstrapRuntime();
   const pluginRegistry = bootstrapOutboundChannelPlugin({
@@ -79,11 +85,9 @@ async function loadBootstrappedOutboundAdapter(params: {
     cfg: params.cfg,
     agentId: params.agentId,
   });
-  outbound = pluginRegistry?.channels.find((entry) => entry.plugin.id === params.channel)?.plugin
-    .outbound;
   return {
-    ...(outbound ? { outbound } : {}),
-    ...(pluginRegistry ? { pluginRegistry } : {}),
+    plugin: pluginRegistry?.channels.find((entry) => entry.plugin.id === params.channel)?.plugin,
+    pluginRegistry,
   };
 }
 
@@ -169,10 +173,9 @@ export async function resolveOutboundDurableFinalDeliverySupport(params: {
   channel: string;
   requirements?: DurableFinalDeliveryRequirements;
 }): Promise<OutboundDurableDeliverySupport> {
-  const { outbound, pluginRegistry } = await loadBootstrappedOutboundAdapter(params);
-  const message = withPluginRuntimeRegistryScope(pluginRegistry, () =>
-    resolveOutboundChannelMessageAdapter(params),
-  );
+  const { plugin } = await loadBootstrappedChannelPlugin(params);
+  const outbound = plugin?.outbound;
+  const message = plugin?.message;
   if (!message?.send?.text && !outbound?.sendText) {
     return { ok: false, reason: "missing_outbound_handler" };
   }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users sending or broadcasting through an installed channel plugin could invoke a different implementation with the same channel ID, fail before delivery, or use the wrong action handler. The selected account and its credentials could be correct while no message reached the selected transport.

## Why This Change Was Made

Channel registration now keeps the selected implementation, origin, runtime binding, and send capabilities together. Delivery projects both adapters from that registration and retains its registry for later callbacks. Scoped setup activation cannot be replaced by a process-root sender or a previously warmed root cache. Unrelated root channels, bundled discovery, and the shipped installed-plugin bootstrap contract remain available.

The change removes the independent message-adapter fallback search. It adds no configuration option, SDK contract, database schema, or persistent store.

## User Impact

Installed channel plugins receive their own sends and actions. Missing capabilities remain missing on the selected implementation, and a prepared delivery continues to use the same plugin when invoked later.

## Evidence

- 74 focused tests in seven files pass. Before-fix failures cover registration, action provenance, adapter/durable capabilities, scoped bootstrap, warmed cache, and prepared callback ownership. The warmed-cache fixture was corrected and its actual pre-fix failure recaptured.
- Rebuilt CLI: both outbound-only and action-based broadcasts changed from exit1 with no receipt to exit0 with the selected plugin's local transport receipt; directory control stayed green. Credentials resolved correctly throughout. This uses synthetic local transport, not Twilio/provider network delivery.
- Canonical sourcePerformance build passed; the exact ten-file source hashes remained unchanged through build and replay.
- Independent Codex review through P3 is clean. Production delta is +74/−77 (net−3); regression tests +327/−7 after CI fixture cleanup; docs +6.
- Cold missing-SMS Gateway: all eight diagnostics succeed; liveness/UI return200; readiness identifies only the blocked SMS owner; healthy SMS/control plugins stay running; strict manual start reports UNAVAILABLE; Gateway exits0. Candidate runtime served byte-identical pinned UI assets.
- A fresh isolated install resolves locked pako3.0.1 and passes core, core-test, plugin and plugin-test typechecks plus repository guards. The original shared install had obsolete pako1.0.11; no dependency/type shim changes were made.
- Initial CI exposed a redundant test import and two existing promotional-pricing fixtures that read the real clock after September1 UTC. Removed the duplicate import and scoped the historical fixture clocks with automatic cleanup. All27 resolver tests and94 affected provider tests pass; production pricing and the explicit standard-pricing cutover tests are unchanged. Fresh exact-head CI is required before landing.

The broader upgrade retest passed on source 1c9770abaf4ae20442122730510b8d447709942b: 791 existing focused tests; 21 native macOS and 21 native Linux Gateway turns with nine-agent migration/repeat repair; Windows installer and actual package-upgrade workflow 33452237126 with live OpenAI replies. Those results establish the retest baseline, not this candidate's proof.

Regression provenance: exact introducing commit is not established. The installed-plugin CLI contract in 4c52d3fe9df is reachable from stable v2026.8.1 and is preserved.

Related follow-up: the source CLI compile-cache respawn wrapper intermittently exited1 during a synthetic Gateway teardown after channel assertions passed. The paired direct-launch control exited0; this separate launcher lifecycle issue is outside the registration repair.

Compact actual-runtime verdict (candidate production hashes remain unchanged through the test-only CI fixes):

```json
{"builtCli":{"outboundOnly":{"beforeExit":1,"afterExit":0,"intendedLocalReceipt":true},"action":{"beforeExit":1,"afterExit":0,"intendedLocalReceipt":true},"directoryControl":"pass"},"coldGateway":{"diagnosticCommandsPassed":8,"liveness":200,"controlUi":200,"readiness":{"status":503,"failing":["sms"]},"healthySiblingsRunning":true,"strictStart":"UNAVAILABLE","exit":0},"externalTransport":"synthetic local sink"}
```

ClawSweeper follow-through: selected-registration ownership is intentional for this repair. A selected plugin without a capability must report it as unavailable; it must not borrow another registration's adapter or provenance. The stable installed-plugin addressability contract and root/bundled overlay for unrelated scoped IDs remain preserved. No supported same-ID cross-adapter fallback contract was found. The review's remaining rank-up item is exact-head green CI; the follow-up changes only tests and leaves the reviewed production bytes unchanged.

Final CI: [run 33455972821](https://github.com/openclaw/openclaw/actions/runs/33455972821) completed successfully for exact head `d69f770fc683002da1fa3b5ce96772810e49a7fb`, including the repository CI gate. The reviewed ownership decision and exact-head CI rank-up items are satisfied.
