### PR TITLE
test: check changed-bench arguments through the parser owner

### DIFF
--- a/test/scripts/bench-test-changed.test.ts
+++ b/test/scripts/bench-test-changed.test.ts
@@ -3,6 +3,7 @@ import { spawnSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
 import {
   formatRss,
+  parseArgs,
   parseMaxRssBytes,
   resolveBenchRssResult,
 } from "../../scripts/bench-test-changed.mts";
@@ -59,45 +60,26 @@ describe("bench-test-changed script", () => {
     });
   });
 
-  it("rejects malformed max worker values before inspecting git state", () => {
-    const malformed = runBenchTestChanged(["--max-workers", "2abc"]);
-
-    expect(malformed.status).toBe(1);
-    expect(malformed.stdout).toBe("");
-    expect(malformed.stderr).toContain("--max-workers must be a positive integer");
-    expect(malformed.stderr).not.toContain("at ");
-
-    const fractional = runBenchTestChanged(["--max-workers", "1.5"]);
-
-    expect(fractional.status).toBe(1);
-    expect(fractional.stdout).toBe("");
-    expect(fractional.stderr).toContain("--max-workers must be a positive integer");
-    expect(fractional.stderr).not.toContain("at ");
+  it("rejects malformed max worker values", () => {
+    expect(() => parseArgs(["--max-workers", "2abc"])).toThrow(
+      "--max-workers must be a positive integer",
+    );
+    expect(() => parseArgs(["--max-workers", "1.5"])).toThrow(
+      "--max-workers must be a positive integer",
+    );
   });
 
-  it("rejects missing max worker values before inspecting git state", () => {
-    const result = runBenchTestChanged(["--max-workers"]);
-
-    expect(result.status).toBe(1);
-    expect(result.stdout).toBe("");
-    expect(result.stderr).toContain("--max-workers requires a value");
-    expect(result.stderr).not.toContain("at ");
-
-    const nextFlag = runBenchTestChanged(["--max-workers", "--no-rss"]);
-
-    expect(nextFlag.status).toBe(1);
-    expect(nextFlag.stdout).toBe("");
-    expect(nextFlag.stderr).toContain("--max-workers requires a value");
-    expect(nextFlag.stderr).not.toContain("at ");
+  it("rejects missing max worker values", () => {
+    expect(() => parseArgs(["--max-workers"])).toThrow("--max-workers requires a value");
+    expect(() => parseArgs(["--max-workers", "--no-rss"])).toThrow(
+      "--max-workers requires a value",
+    );
   });
 
-  it("rejects duplicate max worker values before inspecting git state", () => {
-    const result = runBenchTestChanged(["--max-workers", "2", "--max-workers", "3"]);
-
-    expect(result.status).toBe(1);
-    expect(result.stdout).toBe("");
-    expect(result.stderr).toContain("--max-workers was provided more than once");
-    expect(result.stderr).not.toContain("at ");
+  it("rejects duplicate max worker values", () => {
+    expect(() => parseArgs(["--max-workers", "2", "--max-workers", "3"])).toThrow(
+      "--max-workers was provided more than once",
+    );
   });
 
   it("rejects unknown options before collecting changed paths", () => {


### PR DESCRIPTION
Five invalid worker-argument vectors launch cold Node/tsx processes even though this suite already imports the argument parser's module. Exercise those vectors through the existing parseArgs export, and retain the real unknown-option CLI case for the shared error adapter: exit status, empty stdout, exact diagnostic, and no stack trace.

All seven benchmark cases, six invalid argument vectors, and RSS checks remain. The selected benchmark and shared-parser suites pass all 86 cases before and after. Five CLI process launches disappear; production code is unchanged and tests shrink by 18 lines. No elapsed speedup is claimed.

Full changed checks passed; independent Codex autoreview is clean.
