### PR TITLE
fix(update): preserve automatic update policy and outcomes

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3868,7 +3868,6 @@ ui/src/app/stale-chunk-reload.ts	1
 ui/src/app/startup-settings.ts	1
 ui/src/app/theme.ts	4
 ui/src/app/update-schedule-dto.ts	2
-ui/src/app/update-success-notice.ts	1
 ui/src/app/user-profile.ts	2
 ui/src/app/web-push.runtime.ts	2
 ui/src/components/agent-select.ts	3

--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 347598,
-  "reason": "Automatic update outcome continuity: one scoped pending/verified browser notice, admission deadline, and shared status refresh ownership measured 347598 B in the isolated production build (+821 B, 0.24%); fixed 358400 B cap and allowances unchanged",
+  "startupJsGzipBytes": 347792,
+  "reason": "Final automatic update lifecycle ownership and stale hold response fencing measured 347792 B in the canonical isolated production build (+1015 B, 0.29% from the original baseline); fixed 358400 B cap and allowances unchanged",
   "updatedAt": "2026-09-01"
 }

--- a/config/control-ui-startup-budget-baseline.json
+++ b/config/control-ui-startup-budget-baseline.json
@@ -1,5 +1,5 @@
 {
-  "startupJsGzipBytes": 346777,
-  "reason": "Sender-agent avatars on forwarded cross-session messages (PR #133439): agent-avatar resolution, attribution label rules, and direct-thread identity chrome measured 346777 B, +592 B over the prior baseline; below the 358400 B ceiling; hard cap and allowances unchanged",
-  "updatedAt": "2026-08-30"
+  "startupJsGzipBytes": 347598,
+  "reason": "Automatic update outcome continuity: one scoped pending/verified browser notice, admission deadline, and shared status refresh ownership measured 347598 B in the isolated production build (+821 B, 0.24%); fixed 358400 B cap and allowances unchanged",
+  "updatedAt": "2026-09-01"
 }

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -69,6 +69,10 @@ print progress steps.
 completion profiles and caches are still repaired when needed; installing
 completion in a new shell profile remains an interactive choice.
 
+`--tag` changes only this package update. A saved `update.channel` continues to
+govern later foreground and automatic updates, even after a one-off beta
+install. Use `--channel` to change that policy.
+
 For source checkouts, `--dry-run` previews the update flow without fetching Git
 refs or checking working-tree changes. The real update checks for uncommitted
 changes before modifying the checkout. Use `openclaw update status` to inspect
@@ -256,9 +260,12 @@ aligned:
 
 ### Restart handoff
 
-The Gateway core auto-updater (when enabled via config) launches the CLI
-update path outside the live Gateway request handler. Control-plane
-`update.run` package-manager updates and supervised git-checkout updates use
+The Gateway core auto-updater requires a managed service restart path. It hands
+the CLI update to a detached helper before the Gateway exits. A foreground
+Gateway keeps update hints but leaves installation and activation to the
+operator: stop it, run `openclaw update`, then launch it again.
+
+Control-plane `update.run` package-manager updates and supervised git-checkout updates use
 the same managed-service handoff instead of replacing the package tree or
 rebuilding `dist/` inside the live Gateway process: the Gateway starts a
 detached helper and exits, and that helper runs `openclaw update --yes --json`

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -19,7 +19,7 @@ backup.
 
 ## Recommended: `openclaw update`
 
-Detects your install type (npm, pnpm, Bun, or git), fetches the latest version, runs `openclaw doctor`, and restarts the gateway.
+Detects your install type (npm, pnpm, Bun, or git), fetches the latest version, runs `openclaw doctor`, and restarts a managed Gateway service.
 
 ```bash
 openclaw update
@@ -42,6 +42,12 @@ openclaw update --dry-run   # preview without applying
 when the beta tag is missing or its version is older than the latest stable
 release. Use `--tag beta` for a one-off package update pinned to the raw npm
 beta dist-tag instead.
+
+A saved `update.channel` remains the channel for future updates, automatic
+checks, and update status. For example, a one-off beta package on a saved stable
+channel keeps checking stable afterward. Use `--channel beta` to subscribe to
+beta updates. Plugins still follow the installed core version where required
+for compatibility.
 
 `--channel extended-stable` is package-only, and installation remains
 foreground-only. OpenClaw reads the public npm `extended-stable` selector,
@@ -376,6 +382,13 @@ specific number of commits behind. It also shows exact and relative build,
 verified install, and last-commit times. Existing checkouts show an unknown
 install time until their next verified successful update.
 
+Automatic installation requires a managed Gateway service that can hand off
+the update and restart safely. A Gateway running directly in a terminal can
+still show update hints, but it does not automatically replace its running
+installation. Stop that Gateway, run `openclaw update`, and launch it again
+afterward, or [install a managed service](/cli/gateway#manage-the-gateway-service) for
+unattended updates.
+
 | Channel           | Behavior                                                                                                                                                            |
 | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `stable`          | After a built-in delay with deterministic jitter for a spread rollout, announces an update campaign.                                                                |
@@ -401,8 +414,7 @@ fixed target and does not move if upstream `main` advances during the countdown.
 
 Every failed apply ends the campaign so the UI does not remain on
 **Updating…**. Failures after a managed-service handoff starts are also recorded
-in the restart sentinel and surface after the Gateway returns; direct
-unsupervised failures remain in the running Gateway's logs.
+in the restart sentinel and surface after the Gateway returns.
 
 `update.checkOnStart: false` disables all automatic update checks, feature
 statistics, and update notices, even when `update.auto.enabled` is `true`.
@@ -411,6 +423,9 @@ External-supervisor mode disables automatic applies; startup update hints can
 still run unless `update.checkOnStart` is also disabled. See
 [Usage telemetry and update checks](/gateway/telemetry) for the information
 sent by the daily check and optional anonymous feature statistics.
+
+Disabling checks also cancels unfinished discovery and its campaign; a late
+response from the previous settings cannot start an update afterward.
 
 The gateway also logs an update hint on startup (disable with
 `update.checkOnStart: false`). Stored extended-stable selections use this

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -372,6 +372,10 @@ Off by default. Enable it in `~/.openclaw/openclaw.json`:
 
 You can also choose the update channel and enable automatic updates from
 **Settings → Updates** (`/settings/updates`) in the Control UI.
+**Check for updates** controls the existing `update.checkOnStart` setting.
+When it is off, **Automatic updates** is disabled but keeps your saved preference;
+turning checks back on resumes discovery and any enabled automatic-update policy.
+This does not change your separate feature-statistics preference.
 Recorded failures on that page include typed **Check status** and **Retry
 update** actions when the connected Gateway supports them. See [Update
 troubleshooting](/install/update-troubleshooting) for reason codes, guided

--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -726,7 +726,8 @@ describe("bedrock mantle discovery", () => {
   // Implicit provider resolution
   // ---------------------------------------------------------------------------
 
-  it("resolves implicit provider when bearer token is set", async () => {
+  it("resolves implicit provider with introductory pricing when bearer token is set", async () => {
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 8, 1) - 1);
     const mockFetch = vi.fn().mockResolvedValue(
       modelDiscoveryResponse({
         data: [{ id: "anthropic.claude-sonnet-4-6", object: "model" }],

--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -1,5 +1,5 @@
 // Amazon Bedrock Mantle tests cover discovery plugin behavior.
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 
 const discoveryDebugSpy = vi.hoisted(() => vi.fn());
 const discoveryLoggerState = vi.hoisted(() => ({ debugEnabled: true }));
@@ -726,8 +726,10 @@ describe("bedrock mantle discovery", () => {
   // Implicit provider resolution
   // ---------------------------------------------------------------------------
 
-  it("resolves implicit provider with introductory pricing when bearer token is set", async () => {
-    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 8, 1) - 1);
+  it("resolves implicit provider when bearer token is set", async () => {
+    // This catalog includes the promotional contract before the September pricing cutover.
+    const clock = vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 7, 31));
+    onTestFinished(() => clock.mockRestore());
     const mockFetch = vi.fn().mockResolvedValue(
       modelDiscoveryResponse({
         data: [{ id: "anthropic.claude-sonnet-4-6", object: "model" }],

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -79,7 +79,6 @@ type Claude5ContractCase = {
   checksMedia?: boolean;
   restoresMissingCost?: boolean;
   checksCliPolicy?: boolean;
-  pricingAtMs?: number;
 };
 
 const ANTHROPIC_SETUP_TOKEN = `sk-ant-oat01-${"a".repeat(80)}`;
@@ -703,11 +702,10 @@ describe("anthropic provider replay hooks", () => {
       checksCliPolicy: true,
     },
     {
-      name: "resolves Claude Sonnet 5 with its introductory API pricing",
+      name: "resolves Claude Sonnet 5 with its exact API contract",
       modelId: "claude-sonnet-5",
       cost: { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
       thinkingLevelMap: { xhigh: "xhigh", max: "max" },
-      pricingAtMs: Date.UTC(2026, 8, 1) - 1,
     },
   ];
 
@@ -720,12 +718,10 @@ describe("anthropic provider replay hooks", () => {
       checksMedia,
       restoresMissingCost,
       checksCliPolicy,
-      pricingAtMs,
     }) => {
-      if (pricingAtMs !== undefined) {
-        const clock = vi.spyOn(Date, "now").mockReturnValue(pricingAtMs);
-        onTestFinished(() => clock.mockRestore());
-      }
+      // This table describes the promotional contract before the September pricing cutover.
+      const clock = vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 7, 31));
+      onTestFinished(() => clock.mockRestore());
       const provider = await registerSingleProviderPlugin(anthropicPlugin);
       const resolved = provider.resolveDynamicModel?.({
         provider: "anthropic",

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -12,7 +12,7 @@ import {
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 // Anthropic tests cover index plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 
 const { probeClaudeCliAuthStatusMock } = vi.hoisted(() => ({
   probeClaudeCliAuthStatusMock: vi.fn(),
@@ -79,6 +79,7 @@ type Claude5ContractCase = {
   checksMedia?: boolean;
   restoresMissingCost?: boolean;
   checksCliPolicy?: boolean;
+  pricingAtMs?: number;
 };
 
 const ANTHROPIC_SETUP_TOKEN = `sk-ant-oat01-${"a".repeat(80)}`;
@@ -702,10 +703,11 @@ describe("anthropic provider replay hooks", () => {
       checksCliPolicy: true,
     },
     {
-      name: "resolves Claude Sonnet 5 with its exact API contract",
+      name: "resolves Claude Sonnet 5 with its introductory API pricing",
       modelId: "claude-sonnet-5",
       cost: { input: 2, output: 10, cacheRead: 0.2, cacheWrite: 2.5 },
       thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+      pricingAtMs: Date.UTC(2026, 8, 1) - 1,
     },
   ];
 
@@ -718,7 +720,12 @@ describe("anthropic provider replay hooks", () => {
       checksMedia,
       restoresMissingCost,
       checksCliPolicy,
+      pricingAtMs,
     }) => {
+      if (pricingAtMs !== undefined) {
+        const clock = vi.spyOn(Date, "now").mockReturnValue(pricingAtMs);
+        onTestFinished(() => clock.mockRestore());
+      }
       const provider = await registerSingleProviderPlugin(anthropicPlugin);
       const resolved = provider.resolveDynamicModel?.({
         provider: "anthropic",

--- a/src/cli/update-cli/update-command-fresh-doctor.ts
+++ b/src/cli/update-cli/update-command-fresh-doctor.ts
@@ -8,6 +8,7 @@ import {
 import { readConfigFileSnapshot } from "../../config/config.js";
 import type { ConfigFileSnapshot } from "../../config/types.openclaw.js";
 import { resolveGatewayInstallEntrypoint } from "../../daemon/gateway-entrypoint.js";
+import { buildUpdateDoctorEnv } from "../../infra/update-runner-doctor.js";
 import { runExec } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
 import { resolveNodeRunner } from "./shared.js";
@@ -128,9 +129,13 @@ export async function runUpdateFinalizationDoctorInFreshProcess(params: {
       logOutput: false,
       baseEnv,
       env: {
-        OPENCLAW_UPDATE_IN_PROGRESS: "1",
-        [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
-        [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
+        // The outer updater owns service refresh and activation after every
+        // migration finishes; a fresh Doctor must not resume its parked service.
+        ...buildUpdateDoctorEnv({
+          allowGatewayServiceRepair: false,
+          allowGatewayActivation: false,
+          deferConfiguredPluginInstallRepair: true,
+        }),
         ...(params.phase === "post-plugin" ? { [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1" } : {}),
       },
     });

--- a/src/cli/update-cli/update-command-lease.test-support.ts
+++ b/src/cli/update-cli/update-command-lease.test-support.ts
@@ -59,6 +59,9 @@ export async function runUpdateLeaseChild(): Promise<void> {
     assert.equal(process.env.OPENCLAW_UPDATE_IN_PROGRESS, "1");
     assert.equal(process.env.OPENCLAW_UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR, "1");
     assert.equal(process.env.OPENCLAW_UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE, "1");
+    assert.equal(process.env.OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION, "0");
+    assert.equal(process.env.OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR, "0");
+    assert.equal(process.env.OPENCLAW_UPDATE_PARENT_SUPPORTS_GATEWAY_RESTART, "1");
     if (scenario.hostVersion) {
       assert.equal(process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION, scenario.hostVersion);
     }

--- a/src/cli/update-cli/update-command-lease.test.ts
+++ b/src/cli/update-cli/update-command-lease.test.ts
@@ -71,6 +71,9 @@ beforeEach(async () => {
       OPENCLAW_UPDATE_POST_CORE_SOURCE_CONFIG_PATH: undefined,
       OPENCLAW_UPDATE_POST_CORE_REQUESTED_CHANNEL: undefined,
       OPENCLAW_UPDATE_POST_CORE_STARTED_AT_MS: undefined,
+      OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION: undefined,
+      OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR: undefined,
+      OPENCLAW_UPDATE_PARENT_SUPPORTS_GATEWAY_RESTART: undefined,
     },
   });
   await state.writeConfig({ plugins: { enabled: false }, update: { channel: "stable" } });
@@ -182,11 +185,15 @@ function expectSuccess(lane: Lane): void {
 
 describe("update orchestration lifecycle ownership", () => {
   it.each(["resume", "current-process", "repair"] as const)(
-    "%s keeps plugin mutation exclusive and releases ownership for fresh doctor and strict validation",
+    "%s releases plugin ownership for fresh doctor without delegating Gateway activation",
     async (lane) => {
       await writeScenario(lane, {
         hostVersion: lane === "repair" ? undefined : "1.0.0",
       });
+      if (lane === "current-process") {
+        vi.stubEnv("OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION", "1");
+        vi.stubEnv("OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR", "1");
+      }
       mocks.plugins.mockImplementationOnce(async () => {
         const result = await runExec(process.execPath, [entrypoint, "probe"], {
           timeoutMs: 15_000,
@@ -196,6 +203,9 @@ describe("update orchestration lifecycle ownership", () => {
       });
       await invoke(lane);
       expectSuccess(lane);
+      expect(process.env.OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION).toBe(
+        lane === "current-process" ? "1" : undefined,
+      );
       expect(await events()).toEqual([
         ...(lane === "current-process" ? [] : ["pre-attempt", "pre-acquired"]),
         "post-attempt",

--- a/src/cli/update-cli/update-command-package.ts
+++ b/src/cli/update-cli/update-command-package.ts
@@ -1,12 +1,5 @@
 import path from "node:path";
 import { theme } from "../../../packages/terminal-core/src/theme.js";
-import {
-  UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV,
-  UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION_ENV,
-  UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR_ENV,
-  UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV,
-  UPDATE_PARENT_SUPPORTS_GATEWAY_RESTART_ENV,
-} from "../../commands/doctor/shared/update-phase.js";
 import { resolveGatewayInstallEntrypoint } from "../../daemon/gateway-entrypoint.js";
 import { createLowDiskSpaceWarning } from "../../infra/disk-space.js";
 import {
@@ -24,6 +17,7 @@ import {
   resolveGlobalInstallTarget,
   type ResolvedGlobalInstallTarget,
 } from "../../infra/update-global.js";
+import { buildUpdateDoctorEnv } from "../../infra/update-runner-doctor.js";
 import {
   resolveUpdateDoctorExecutionPolicy,
   type UpdateRunResult,
@@ -154,21 +148,14 @@ export async function runPackageInstallUpdate(params: {
             serviceEnv: params.managedServiceEnv,
             invocationCwd: params.invocationCwd,
           }),
-          OPENCLAW_UPDATE_IN_PROGRESS: "1",
-          [UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV]: "1",
-          [UPDATE_PARENT_SUPPORTS_DOCTOR_CONFIG_WRITE_ENV]: "1",
-          [UPDATE_PARENT_SUPPORTS_GATEWAY_RESTART_ENV]: "1",
-          [UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR_ENV]: params.allowGatewayServiceRepair
-            ? "1"
-            : "0",
-          [UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION_ENV]: params.allowGatewayActivation ? "1" : "0",
-          ...(doctorPolicy.serviceRepairPolicy
-            ? { OPENCLAW_SERVICE_REPAIR_POLICY: doctorPolicy.serviceRepairPolicy }
-            : {}),
+          ...buildUpdateDoctorEnv({
+            allowGatewayServiceRepair: params.allowGatewayServiceRepair,
+            allowGatewayActivation: params.allowGatewayActivation,
+            deferConfiguredPluginInstallRepair: true,
+            serviceRepairPolicy: doctorPolicy.serviceRepairPolicy,
+            compatibilityHostVersion: candidateHostVersion,
+          }),
           [UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV]: doctorResultPath,
-          ...(candidateHostVersion === null
-            ? {}
-            : { OPENCLAW_COMPATIBILITY_HOST_VERSION: candidateHostVersion }),
         },
         timeoutMs: params.timeoutMs,
       });

--- a/src/cli/update-finalization-output.test-support.ts
+++ b/src/cli/update-finalization-output.test-support.ts
@@ -35,10 +35,6 @@ const stubs = new Map<string, string>([
   [sourceUrl("../commands/doctor.ts"), doctorSource],
   [sourceUrl("../config/config.ts"), snapshotSource],
   [
-    sourceUrl("../infra/update-check.ts"),
-    "export const resolveUpdateInstallKind = async () => { throw new Error('Unexpected install check'); };",
-  ],
-  [
     sourceUrl("../plugins/installed-plugin-index-records.ts"),
     "export const loadInstalledPluginIndexInstallRecords = async () => ({});",
   ],

--- a/src/gateway/server-methods/update-run-campaign.test.ts
+++ b/src/gateway/server-methods/update-run-campaign.test.ts
@@ -53,6 +53,8 @@ const startManagedServiceUpdateHandoffMock = vi.fn<
 }));
 const scheduleGatewaySigusr1RestartMock = vi.fn(() => ({ scheduled: true }));
 const logGatewayInfoMock = vi.fn();
+const writeRestartSentinelMock = vi.fn(async () => undefined);
+const recordLatestUpdateRestartSentinelMock = vi.fn();
 
 vi.mock("../../../packages/gateway-protocol/src/index.js", () => ({
   validateUpdateRunParams: () => true,
@@ -85,7 +87,7 @@ vi.mock("../../infra/restart-sentinel.js", async () => {
   );
   return {
     ...actual,
-    writeRestartSentinel: async () => undefined,
+    writeRestartSentinel: writeRestartSentinelMock,
   };
 });
 
@@ -147,7 +149,7 @@ vi.mock("../../version.js", () => ({
 
 vi.mock("../server-restart-sentinel.js", () => ({
   getLatestUpdateRestartSentinel: () => null,
-  recordLatestUpdateRestartSentinel: () => undefined,
+  recordLatestUpdateRestartSentinel: recordLatestUpdateRestartSentinelMock,
   refreshLatestUpdateRestartSentinel: async () => null,
 }));
 
@@ -202,6 +204,8 @@ beforeEach(() => {
   startManagedServiceUpdateHandoffMock.mockClear();
   scheduleGatewaySigusr1RestartMock.mockClear();
   logGatewayInfoMock.mockClear();
+  writeRestartSentinelMock.mockClear();
+  recordLatestUpdateRestartSentinelMock.mockClear();
 });
 
 function setDevCampaignSchedule(upstreamSha = "frozen-upstream-sha"): void {
@@ -310,6 +314,8 @@ function expectNoUpdateMutation(): void {
   expect(runGatewayUpdatePreflightMock).not.toHaveBeenCalled();
   expect(startManagedServiceUpdateHandoffMock).not.toHaveBeenCalled();
   expect(runGatewayUpdateMock).not.toHaveBeenCalled();
+  expect(writeRestartSentinelMock).not.toHaveBeenCalled();
+  expect(recordLatestUpdateRestartSentinelMock).not.toHaveBeenCalled();
 }
 
 describe("update.run campaign ownership", () => {
@@ -647,11 +653,20 @@ describe("update.run campaign ownership", () => {
     );
   });
 
-  it("clears the campaign adopted by a failed update", async () => {
+  it("records the failure before ending the adopted campaign", async () => {
+    let outcomeWhenCampaignEnded: unknown;
+    clearCampaignMock.mockImplementationOnce(() => {
+      outcomeWhenCampaignEnded = recordLatestUpdateRestartSentinelMock.mock.calls.at(-1)?.[0];
+    });
     await invokeUpdateRun();
 
     expect(adoptCampaignMock).toHaveBeenCalledOnce();
     expect(clearCampaignMock).toHaveBeenCalledOnce();
+    expect(outcomeWhenCampaignEnded).toMatchObject({
+      kind: "update",
+      status: "error",
+      stats: { reason: "build-failed" },
+    });
     expect(logGatewayInfoMock).toHaveBeenCalledWith("update.run failed; adopted campaign cleared", {
       campaignId: "campaign-1",
     });
@@ -701,6 +716,8 @@ describe("update.run campaign ownership", () => {
 
     expect(getCampaignStateMock).toHaveBeenCalledOnce();
     expect(clearCampaignMock).not.toHaveBeenCalled();
+    expect(writeRestartSentinelMock).not.toHaveBeenCalled();
+    expect(recordLatestUpdateRestartSentinelMock).not.toHaveBeenCalled();
     expect(logGatewayInfoMock).not.toHaveBeenCalledWith(
       "update.run failed; adopted campaign cleared",
       expect.anything(),

--- a/src/gateway/server-methods/update.test.ts
+++ b/src/gateway/server-methods/update.test.ts
@@ -197,23 +197,11 @@ vi.mock("./restart-request.js", () => ({
   }),
 }));
 
-vi.mock("../../infra/update-managed-service-handoff.js", () => ({
+vi.mock("../../infra/update-managed-service-handoff.js", async () => ({
+  ...(await vi.importActual<typeof import("../../infra/update-managed-service-handoff.js")>(
+    "../../infra/update-managed-service-handoff.js",
+  )),
   startManagedServiceUpdateHandoff: startManagedServiceUpdateHandoffMock,
-  formatManagedServiceUpdateCommand: (params?: { timeoutMs?: number; channel?: UpdateChannel }) => {
-    const args = ["openclaw", "update", "--yes"];
-    if (params?.channel) {
-      args.push("--channel", params.channel);
-    }
-    if (params?.timeoutMs) {
-      args.push("--timeout", String(Math.ceil(params.timeoutMs / 1000)));
-    }
-    return args.join(" ");
-  },
-  buildManagedServiceHandoffUnavailableMessage: (command: string) =>
-    [
-      "OpenClaw updates cannot safely run inside the live gateway process without a managed-service handoff.",
-      `Run \`${command}\` from a shell outside the gateway service, or restart/update from the host UI.`,
-    ].join("\n"),
 }));
 
 vi.mock("./validation.js", () => ({
@@ -973,7 +961,7 @@ describe("update.run restart scheduling", () => {
       command: "openclaw update --yes --timeout 1800",
       message:
         "OpenClaw updates cannot safely run inside the live gateway process without a managed-service handoff.\n" +
-        "Run `openclaw update --yes --timeout 1800` from a shell outside the gateway service, or restart/update from the host UI.",
+        "Stop the foreground Gateway, run `openclaw update --yes --timeout 1800` from a shell, then launch the Gateway again. For a managed deployment, use its host's stop, update, and restart workflow.",
     });
   });
 

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -232,7 +232,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       | { status: "unavailable"; command: string; message: string }
       | null = null;
     let managedHandoffRestart: ReturnType<typeof scheduleGatewaySigusr1Restart> | null = null;
-    let ownsManagedServiceHandoff = true;
+    let ownsUpdateOutcome = false;
     let adoptedCampaignId: string | undefined;
     const sentinelMeta: UpdateRestartSentinelMeta = {
       ...(sessionKey ? { sessionKey } : {}),
@@ -286,6 +286,7 @@ export const updateHandlers: GatewayRequestHandlers = {
       } else if (adoption?.status === "applying") {
         targetFailureReason = "update-campaign-applying";
       }
+      ownsUpdateOutcome = targetFailureReason === undefined;
       const adoptedCampaign = adoption?.status === "adopted" ? adoption : undefined;
       adoptedCampaignId = adoptedCampaign?.campaignId;
       const adoptedDevTarget =
@@ -413,7 +414,7 @@ export const updateHandlers: GatewayRequestHandlers = {
               handoffId,
               supervisor,
             });
-            ownsManagedServiceHandoff = started.status === "started";
+            ownsUpdateOutcome = started.status === "started";
             sentinelMeta.handoffId = started.handoffId ?? handoffId;
             // The owner pairs helper creation with parent exit before any
             // persistence can fail. Joiners leave both to the active owner.
@@ -453,11 +454,11 @@ export const updateHandlers: GatewayRequestHandlers = {
               status: "skipped",
               mode: installSurface.mode,
               root: installRoot,
-              reason: ownsManagedServiceHandoff
+              reason: ownsUpdateOutcome
                 ? CONTROL_PLANE_UPDATE_HANDOFF_STARTED_REASON
                 : MANAGED_HANDOFF_ALREADY_RUNNING_REASON,
               ...(beforeVersion ? { before: { version: beforeVersion } } : {}),
-              steps: ownsManagedServiceHandoff
+              steps: ownsUpdateOutcome
                 ? [
                     {
                       name: "managed-service update handoff",
@@ -557,9 +558,30 @@ export const updateHandlers: GatewayRequestHandlers = {
 
     result = normalizeControlPlaneUpdateResult(result);
 
-    // A failed RPC owns the adopted campaign until it explicitly releases it;
-    // only a started handoff may leave "applying" for the successor process.
+    const payload: RestartSentinelPayload = buildUpdateRestartSentinelPayload({
+      result,
+      meta: sentinelMeta,
+    });
+
+    // Rejected requests and retired campaigns cannot replace another update's outcome.
+    if (ownsUpdateOutcome && adoptedCampaignId !== undefined) {
+      ownsUpdateOutcome = gatewayUpdateCampaign.getState()?.id === adoptedCampaignId;
+    }
+    let sentinelPersisted = false;
+    if (ownsUpdateOutcome) {
+      try {
+        await writeRestartSentinel(payload);
+        sentinelPersisted = true;
+        recordLatestUpdateRestartSentinel(payload);
+      } catch {
+        // Best effort: the response still reports the update outcome.
+      }
+    }
+
+    // Publish the outcome before the terminal campaign event prompts clients to
+    // read it. Recheck ownership after persistence may have yielded to a replacement.
     if (
+      ownsUpdateOutcome &&
       result.status !== "ok" &&
       handoff?.status !== "started" &&
       adoptedCampaignId !== undefined &&
@@ -569,22 +591,6 @@ export const updateHandlers: GatewayRequestHandlers = {
       context?.logGateway?.info("update.run failed; adopted campaign cleared", {
         campaignId: adoptedCampaignId,
       });
-    }
-
-    const payload: RestartSentinelPayload = buildUpdateRestartSentinelPayload({
-      result,
-      meta: sentinelMeta,
-    });
-
-    let sentinelPersisted = false;
-    if (ownsManagedServiceHandoff) {
-      try {
-        await writeRestartSentinel(payload);
-        sentinelPersisted = true;
-        recordLatestUpdateRestartSentinel(payload);
-      } catch {
-        // Best effort: the response still reports the update outcome.
-      }
     }
 
     // Only restart the gateway when the update actually succeeded.

--- a/src/infra/restart-sentinel-store.ts
+++ b/src/infra/restart-sentinel-store.ts
@@ -591,20 +591,29 @@ export function writeRestartSentinelRowSync(
   rawPayload: RestartSentinelPayload,
 ): RestartSentinel {
   const payload = requireValidPayload(rawPayload);
-  const current = readRestartSentinelRowSync(db);
-  const currentRevision =
-    current.kind === "missing"
-      ? null
-      : current.kind === "valid"
-        ? current.sentinel.revision
-        : current.revision;
-  const revision = nextRevision(
-    maxRevision(currentRevision, readRestartSentinelRevisionFloorSync(db)),
-  );
+  const revision = nextRevision(readRestartSentinelSnapshotSync(db).revision);
   const row = buildRestartSentinelRow(payload, revision);
   upsertRestartSentinelRowSync(db, row);
   advanceRestartSentinelRevisionFloorSync(db, revision);
   return { version: 1, payload, revision };
+}
+
+/** Read inside a transaction; the floor also identifies an absent, consumed notification. */
+export function readRestartSentinelSnapshotSync(db: DatabaseSync): {
+  state: RestartSentinelRowState;
+  revision: number | null;
+} {
+  const state = readRestartSentinelRowSync(db);
+  const currentRevision =
+    state.kind === "missing"
+      ? null
+      : state.kind === "valid"
+        ? state.sentinel.revision
+        : state.revision;
+  return {
+    state,
+    revision: maxRevision(currentRevision, readRestartSentinelRevisionFloorSync(db)),
+  };
 }
 
 export function writeUpdateInstallReceiptRowSync(
@@ -635,14 +644,12 @@ export function writeRestartSentinelRowIfRevisionSync(
   rawPayload: RestartSentinelPayload,
   expectedRevision: number,
 ): RestartSentinel | null {
-  const current = readRestartSentinelRowSync(db);
+  const { state: current, revision: previousRevision } = readRestartSentinelSnapshotSync(db);
   if (current.kind !== "valid" || current.sentinel.revision !== expectedRevision) {
     return null;
   }
   const payload = requireValidPayload(rawPayload);
-  const revision = nextRevision(
-    maxRevision(expectedRevision, readRestartSentinelRevisionFloorSync(db)),
-  );
+  const revision = nextRevision(previousRevision);
   const row = buildRestartSentinelRow(payload, revision);
   const stateDb = getNodeSqliteKysely<GatewayRestartSentinelDatabase>(db);
   const result = executeSqliteQuerySync(

--- a/src/infra/restart-sentinel.ts
+++ b/src/infra/restart-sentinel.ts
@@ -15,6 +15,7 @@ import { resolveOpenClawPackageRoot } from "./openclaw-root.js";
 import {
   deleteRestartSentinelRowSync,
   readRestartSentinelRowSync,
+  readRestartSentinelSnapshotSync,
   readUpdateInstallReceiptRowSync,
   writeRestartSentinelRowIfRevisionSync,
   writeRestartSentinelRowSync,
@@ -56,6 +57,44 @@ export async function writeRestartSentinel(
     ({ db }) => writeRestartSentinelRowSync(db, payload),
     { env },
     { operationLabel: "restart-sentinel.write" },
+  );
+}
+
+/** Publish an outcome only while its producer and the captured notification are unchanged. */
+export async function writeRestartSentinelIfUnchanged(params: {
+  payload: RestartSentinelPayload;
+  expectedRevision: number | null;
+  isCurrent: () => boolean;
+}): Promise<RestartSentinel | null> {
+  return runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      const current = readRestartSentinelSnapshotSync(db);
+      if (current.state.kind === "invalid" || !params.isCurrent()) {
+        return null;
+      }
+      return current.revision === params.expectedRevision
+        ? writeRestartSentinelRowSync(db, params.payload)
+        : null;
+    },
+    {},
+    { operationLabel: "restart-sentinel.write-if-unchanged" },
+  );
+}
+
+export async function readRestartSentinelSnapshot(): Promise<{
+  sentinel: RestartSentinel | null;
+  revision: number | null;
+}> {
+  return runOpenClawStateWriteTransaction(
+    ({ db }) => {
+      const snapshot = readRestartSentinelSnapshotSync(db);
+      return {
+        sentinel: snapshot.state.kind === "valid" ? snapshot.state.sentinel : null,
+        revision: snapshot.revision,
+      };
+    },
+    {},
+    { operationLabel: "restart-sentinel.read-snapshot" },
   );
 }
 

--- a/src/infra/update-campaign.test.ts
+++ b/src/infra/update-campaign.test.ts
@@ -428,6 +428,37 @@ describe("UpdateCampaignController", () => {
     },
   );
 
+  it("keeps the applying campaign owner when a newer target is announced", async () => {
+    const controller = createController();
+    const firstApply = vi.fn(async () => "handoff" as const);
+    const nextApply = vi.fn(async () => "handoff" as const);
+    const onChange = vi.fn();
+    const inspect = createInspectors(() => 0);
+    controller.announce({
+      target: { kind: "package", version: "2.0.0" },
+      inspect,
+      apply: firstApply,
+      onChange,
+    });
+    await vi.advanceTimersByTimeAsync(60_000);
+    const applying = controller.getState();
+    onChange.mockClear();
+
+    controller.announce({
+      target: { kind: "package", version: "3.0.0" },
+      inspect,
+      apply: nextApply,
+      onChange,
+    });
+    await vi.advanceTimersByTimeAsync(15 * 60_000);
+
+    expect(controller.getState()).toEqual(applying);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(firstApply).toHaveBeenCalledOnce();
+    expect(nextApply).not.toHaveBeenCalled();
+    controller.clear();
+  });
+
   it("does not clear a replacement campaign when an earlier apply fails", async () => {
     const controller = createController();
     let resolveApply!: (outcome: "failed") => void;
@@ -447,6 +478,7 @@ describe("UpdateCampaignController", () => {
     await vi.advanceTimersByTimeAsync(60_000);
     expect(controller.getState()).toMatchObject({ id: "campaign-1", state: "applying" });
 
+    controller.clear();
     controller.announce({
       target: { kind: "package", version: "3.0.0" },
       inspect: createInspectors(() => 0),

--- a/src/infra/update-campaign.ts
+++ b/src/infra/update-campaign.ts
@@ -72,7 +72,20 @@ export class UpdateCampaignController {
     return this.campaign;
   }
 
+  reconcileTarget(target: UpdateCampaignTarget): boolean {
+    if (this.campaign?.state === "applying") {
+      return false;
+    }
+    if (this.target && !sameTarget(this.target, target)) {
+      this.clear();
+    }
+    return true;
+  }
+
   announce(announcement: UpdateCampaignAnnouncement): void {
+    if (!this.reconcileTarget(announcement.target)) {
+      return;
+    }
     if (this.target && this.campaign && sameTarget(this.target, announcement.target)) {
       this.announcement = announcement;
       this.reconcile();

--- a/src/infra/update-channels.test.ts
+++ b/src/infra/update-channels.test.ts
@@ -84,9 +84,17 @@ describe("resolveEffectiveUpdateChannel", () => {
       expected: { channel: "beta", source: "config" },
     },
     {
-      name: "uses installed beta version over stale stable config",
+      name: "keeps configured stable after a one-off beta package update",
       params: {
         configChannel: "stable" as const,
+        currentVersion: "2026.5.2-beta.1",
+        installKind: "package" as const,
+      },
+      expected: { channel: "stable", source: "config" },
+    },
+    {
+      name: "uses installed beta version without a configured channel",
+      params: {
         currentVersion: "2026.5.2-beta.1",
         installKind: "package" as const,
       },
@@ -182,7 +190,7 @@ describe("resolveUpdateChannelDisplay labels", () => {
 });
 
 describe("resolveUpdateChannelDisplay", () => {
-  it("labels stale stable config on a beta install from the installed version", () => {
+  it("shows the configured stable channel after a one-off beta package update", () => {
     expect(
       resolveUpdateChannelDisplay({
         configChannel: "stable",
@@ -190,9 +198,9 @@ describe("resolveUpdateChannelDisplay", () => {
         installKind: "package",
       }),
     ).toEqual({
-      channel: "beta",
-      source: "installed-version",
-      label: "beta (installed version)",
+      channel: "stable",
+      source: "config",
+      label: "stable (config)",
     });
   });
 

--- a/src/infra/update-channels.ts
+++ b/src/infra/update-channels.ts
@@ -124,18 +124,13 @@ export function resolveEffectiveUpdateChannel(params: {
   installKind: "git" | "package" | "unknown";
   git?: { tag?: string | null; branch?: string | null };
 }): { channel: UpdateChannel; source: UpdateChannelSource } {
-  if (
-    params.currentVersion &&
-    isBetaTag(params.currentVersion) &&
-    params.configChannel !== "extended-stable" &&
-    params.configChannel !== "beta" &&
-    params.configChannel !== "dev"
-  ) {
-    return { channel: "beta", source: "installed-version" };
-  }
-
+  // A one-off package tag does not replace the operator's saved update policy.
   if (params.configChannel) {
     return { channel: params.configChannel, source: "config" };
+  }
+
+  if (params.currentVersion && isBetaTag(params.currentVersion)) {
+    return { channel: "beta", source: "installed-version" };
   }
 
   if (params.installKind === "package" && params.currentVersion) {

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -7,6 +7,7 @@ import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { formatCliCommand } from "../cli/command-format.js";
 import { resolveGatewayWindowsTaskName } from "../daemon/constants.js";
 import { resolveLaunchAgentLabel } from "../daemon/launchd-label.js";
 import { resolveLaunchAgentPlistPath } from "../daemon/launchd-service-files.js";
@@ -1195,14 +1196,16 @@ function resolveManagedServiceCliArgv(
   return ["openclaw", ...args];
 }
 
-export function formatManagedServiceUpdateCommand(params?: {
-  timeoutMs?: number;
-  channel?: UpdateChannel;
-  tag?: string;
-}): string {
-  return resolveUpdateCliArgv(params ?? {})
-    .toSpliced(3, 1)
-    .join(" ");
+export function formatManagedServiceUpdateCommand(
+  params?: { timeoutMs?: number; channel?: UpdateChannel; tag?: string },
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return formatCliCommand(
+    resolveUpdateCliArgv(params ?? {})
+      .toSpliced(3, 1)
+      .join(" "),
+    env,
+  );
 }
 
 type GatewayServiceRecovery =
@@ -1321,11 +1324,10 @@ async function spawnManagedServiceUpdateHandoff(
     execPath: params.execPath ?? process.execPath,
     argv1: params.argv1 ?? process.argv[1],
   });
-  const commandLabel = formatManagedServiceUpdateCommand({
-    timeoutMs: params.timeoutMs,
-    channel: params.channel,
-    tag: params.tag,
-  });
+  const commandLabel = formatManagedServiceUpdateCommand(
+    { timeoutMs: params.timeoutMs, channel: params.channel, tag: params.tag },
+    params.env,
+  );
   const metaFile: ControlPlaneUpdateSentinelMetaFile = {
     version: 1,
     meta: { ...params.meta, root: rootIdentity },
@@ -1696,7 +1698,7 @@ export async function cancelManagedServiceUpdateHandoff(
 export function buildManagedServiceHandoffUnavailableMessage(command: string): string {
   return [
     "OpenClaw updates cannot safely run inside the live gateway process without a managed-service handoff.",
-    `Run \`${command}\` from a shell outside the gateway service, or restart/update from the host UI.`,
+    `Stop the foreground Gateway, run \`${command}\` from a shell, then launch the Gateway again. For a managed deployment, use its host's stop, update, and restart workflow.`,
   ].join("\n");
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -191,6 +191,7 @@ describe("update-startup", () => {
       layout: "state-only",
       prefix: "openclaw-update-check-suite-",
       env: {
+        OPENCLAW_PROFILE: undefined,
         OPENCLAW_NO_AUTO_UPDATE: undefined,
         OPENCLAW_SUPERVISOR_MODE: undefined,
         OPENCLAW_SERVICE_KIND: undefined,
@@ -2172,6 +2173,7 @@ describe("update-startup", () => {
   });
 
   it("keeps a foreground Gateway serving when automatic update has no restart owner", async () => {
+    process.env.OPENCLAW_PROFILE = "work";
     mockPackageInstallStatus();
     mockNpmChannelTag("beta", "2.0.0-beta.1");
     await runAutoUpdateCheckWithDefaults({ cfg: createBetaAutoUpdateConfig() });
@@ -2184,7 +2186,9 @@ describe("update-startup", () => {
     expect((await readRestartSentinel())?.payload).toMatchObject({
       kind: "update",
       status: "skipped",
-      message: expect.stringContaining("shell"),
+      message: expect.stringMatching(
+        /Stop the foreground Gateway.*`openclaw --profile work update --yes --channel beta --tag 2\.0\.0-beta\.1 --timeout 2700`.*then launch the Gateway again/s,
+      ),
       stats: { reason: "managed-service-handoff-unavailable" },
     });
   });

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -14,10 +14,12 @@ import {
 } from "../test-utils/openclaw-test-state.js";
 import type { GatewayActiveWorkInspectors } from "./gateway-active-work.js";
 import { writeUpdateInstallReceiptRowSync } from "./restart-sentinel-store.js";
+import { readRestartSentinel } from "./restart-sentinel.js";
+import { UpdateCampaignController } from "./update-campaign.js";
 import type { UpdateCheckResult } from "./update-check.js";
-import { parseDevUpdateTargetEnv } from "./update-dev-target.js";
 
 const {
+  cancelManagedServiceUpdateHandoffMock,
   checkTelemetryUpdateMock,
   detectRespawnSupervisorMock,
   getRuntimeConfigMock,
@@ -27,6 +29,9 @@ const {
   startManagedServiceUpdateHandoffMock,
   versionMock,
 } = vi.hoisted(() => ({
+  cancelManagedServiceUpdateHandoffMock: vi.fn<
+    typeof import("./update-managed-service-handoff.js").cancelManagedServiceUpdateHandoff
+  >(async () => "restored-in-process"),
   checkTelemetryUpdateMock: vi.fn<typeof import("./telemetry.js").checkTelemetryUpdate>(),
   detectRespawnSupervisorMock: vi.fn(),
   getRuntimeConfigMock: vi.fn(() => ({})),
@@ -128,7 +133,11 @@ vi.mock("../process/exec.js", () => ({
   runCommandWithTimeout: vi.fn(),
 }));
 
-vi.mock("./update-managed-service-handoff.js", () => ({
+vi.mock("./update-managed-service-handoff.js", async () => ({
+  ...(await vi.importActual<typeof import("./update-managed-service-handoff.js")>(
+    "./update-managed-service-handoff.js",
+  )),
+  cancelManagedServiceUpdateHandoff: cancelManagedServiceUpdateHandoffMock,
   startManagedServiceUpdateHandoff: startManagedServiceUpdateHandoffMock,
 }));
 
@@ -136,6 +145,7 @@ const UPDATE_CHECK_STATE_KEY = "update.checkState";
 
 type PersistedUpdateCheckState = {
   lastCheckedAt?: string;
+  lastCheckedChannel?: "stable" | "extended-stable" | "beta" | "dev";
   lastNotifiedVersion?: string;
   lastNotifiedTag?: string;
   lastAvailableVersion?: string;
@@ -146,8 +156,6 @@ type PersistedUpdateCheckState = {
   autoFirstSeenAt?: string;
   autoLastAttemptVersion?: string;
   autoLastAttemptAt?: string;
-  autoLastSuccessVersion?: string;
-  autoLastSuccessAt?: string;
 };
 
 describe("update-startup", () => {
@@ -163,23 +171,16 @@ describe("update-startup", () => {
   let getUpdateAvailable: (typeof import("./update-startup.js"))["getUpdateAvailable"];
   let getUpdateEffectiveChannel: (typeof import("./update-startup.js"))["getUpdateEffectiveChannel"];
   let getUpdateSchedule: (typeof import("./update-startup.js"))["getUpdateSchedule"];
+  let refreshGatewayUpdateStatus: (typeof import("./update-startup.js"))["refreshGatewayUpdateStatus"];
   let resetUpdateAvailableStateForTest: (typeof import("./update-startup.js"))["resetUpdateAvailableStateForTest"];
   let loaded = false;
-
-  function requireFirstRunCommandCall(): Parameters<typeof runCommandWithTimeout> {
-    const [call] = vi.mocked(runCommandWithTimeout).mock.calls;
-    if (!call) {
-      throw new Error("expected update command run");
-    }
-    return call;
-  }
 
   function readPersistedUpdateCheckState(): PersistedUpdateCheckState | null {
     return readConfigMachineState<PersistedUpdateCheckState>(UPDATE_CHECK_STATE_KEY) ?? null;
   }
 
   function writePersistedUpdateCheckState(state: PersistedUpdateCheckState): void {
-    writeConfigMachineState(UPDATE_CHECK_STATE_KEY, state);
+    writeConfigMachineState(UPDATE_CHECK_STATE_KEY, { lastCheckedChannel: "stable", ...state });
   }
 
   beforeEach(async () => {
@@ -216,6 +217,7 @@ describe("update-startup", () => {
         getUpdateAvailable,
         getUpdateEffectiveChannel,
         getUpdateSchedule,
+        refreshGatewayUpdateStatus,
         resetUpdateAvailableStateForTest,
       } = await import("./update-startup.js"));
       loaded = true;
@@ -242,6 +244,7 @@ describe("update-startup", () => {
     detectRespawnSupervisorMock.mockReturnValue(null);
     scheduleGatewaySigusr1RestartMock.mockClear();
     startManagedServiceUpdateHandoffMock.mockClear();
+    cancelManagedServiceUpdateHandoffMock.mockReset().mockResolvedValue("restored-in-process");
     startManagedServiceUpdateHandoffMock.mockResolvedValue({
       status: "started",
       pid: 12345,
@@ -353,7 +356,7 @@ describe("update-startup", () => {
   }) {
     const upstream = params?.upstream === undefined ? "origin/main" : params.upstream;
     vi.mocked(resolveOpenClawPackageRoot).mockResolvedValue("/opt/openclaw");
-    vi.mocked(checkUpdateStatus).mockResolvedValue({
+    const status = {
       root: "/opt/openclaw",
       installKind: "git",
       packageManager: "pnpm",
@@ -375,7 +378,9 @@ describe("update-startup", () => {
         behind: params?.behind === undefined ? 2 : params.behind,
         fetchOk: params?.fetchOk ?? true,
       },
-    } satisfies UpdateCheckResult);
+    } satisfies UpdateCheckResult;
+    vi.mocked(checkUpdateStatus).mockResolvedValue(status);
+    return status;
   }
 
   async function runUpdateCheckAndReadState(channel: "stable" | "beta") {
@@ -409,8 +414,7 @@ describe("update-startup", () => {
 
   function createAutoUpdateSuccessMock() {
     return vi.fn().mockResolvedValue({
-      ok: true,
-      code: 0,
+      status: "handoff",
     });
   }
 
@@ -555,7 +559,6 @@ describe("update-startup", () => {
       { update: { channel } },
       { surface: "gateway" },
     );
-    expect(resolveNpmChannelTag).not.toHaveBeenCalled();
     expect(log.info).toHaveBeenCalledWith(
       `update available (latest): v2.0.0 (current v1.0.0). Run: ${formatCliCommand("openclaw update")}`,
     );
@@ -585,6 +588,79 @@ describe("update-startup", () => {
     expect(message?.split("Note: ")[1]).toHaveLength(500);
     expect(resolveNpmChannelTag).not.toHaveBeenCalled();
   });
+
+  it.each([
+    { channel: "beta" as const, version: "2.0.0-beta.1", external: false },
+    { channel: "beta" as const, version: "2.0.0-beta.1", external: true },
+    { channel: "extended-stable" as const, version: "2.0.0", external: false },
+  ])(
+    "uses the $channel target for read-only hints with external supervision=$external",
+    async ({ channel, version, external }) => {
+      mockPackageUpdateStatus(channel, version);
+      checkTelemetryUpdateMock.mockResolvedValue({ version: "3.0.0" });
+      if (external) {
+        process.env.OPENCLAW_SUPERVISOR_MODE = "external";
+      }
+
+      await runGatewayUpdateCheck({
+        cfg: { update: { channel, auto: { enabled: external } } },
+        log: { info: vi.fn() },
+        isNixMode: false,
+        allowInTests: true,
+      });
+
+      expect(getUpdateAvailable()).toEqual({
+        currentVersion: "1.0.0",
+        latestVersion: version,
+        channel,
+      });
+      expect(getUpdateSchedule()?.target).toEqual({ kind: "package", version });
+      expect(startManagedServiceUpdateHandoffMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not replace an unavailable exact extended-stable selector with a telemetry hint", async () => {
+    mockPackageInstallStatus();
+    checkTelemetryUpdateMock.mockResolvedValue({ version: "3.0.0" });
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({
+      tag: "extended-stable",
+      version: null,
+      reason: "selector_missing",
+    });
+
+    await runExtendedStableUpdateCheck();
+
+    expect(getUpdateAvailable()).toBeNull();
+    expect(getUpdateSchedule()?.target).toBeUndefined();
+    expect(startManagedServiceUpdateHandoffMock).not.toHaveBeenCalled();
+  });
+
+  it.each([false, true])(
+    "checks the newly selected beta channel after process reset=%s despite a recent stable hint",
+    async (resetProcess) => {
+      mockPackageUpdateStatus("latest", "2.0.0");
+      await runStableUpdateCheck({});
+      if (resetProcess) {
+        resetUpdateAvailableStateForTest();
+      }
+      mockNpmChannelTag("beta", "3.0.0-beta.1");
+      checkTelemetryUpdateMock.mockResolvedValue({ version: "2.0.0" });
+
+      await runGatewayUpdateCheck({
+        cfg: { update: { channel: "beta" } },
+        log: { info: vi.fn() },
+        isNixMode: false,
+        allowInTests: true,
+      });
+
+      expect(getUpdateAvailable()).toEqual({
+        currentVersion: "1.0.0",
+        latestVersion: "3.0.0-beta.1",
+        channel: "beta",
+      });
+      expect(getUpdateSchedule()?.target).toEqual({ kind: "package", version: "3.0.0-beta.1" });
+    },
+  );
 
   it("falls back when the update-check clock is outside Date range", async () => {
     mockPackageUpdateStatus("latest", "2.0.0");
@@ -658,6 +734,7 @@ describe("update-startup", () => {
     async ({ channel, persistedTag, expectedTag }) => {
       writePersistedUpdateCheckState({
         lastCheckedAt: new Date(Date.now()).toISOString(),
+        lastCheckedChannel: channel,
         lastAvailableVersion: "2.0.0",
         lastAvailableTag: persistedTag,
       });
@@ -698,6 +775,7 @@ describe("update-startup", () => {
     async ({ channel, persistedTag }) => {
       writePersistedUpdateCheckState({
         lastCheckedAt: new Date(Date.now()).toISOString(),
+        lastCheckedChannel: channel,
         lastAvailableVersion: "2.0.0",
         lastAvailableTag: persistedTag,
       });
@@ -737,7 +815,6 @@ describe("update-startup", () => {
         { update: { channel: "extended-stable" } },
         { surface: "gateway" },
       );
-      expect(resolveNpmChannelTag).not.toHaveBeenCalled();
       expect(onUpdateAvailableChange).toHaveBeenCalledWith({
         currentVersion: "1.0.0",
         latestVersion: "2.0.0",
@@ -760,7 +837,6 @@ describe("update-startup", () => {
 
     expect(checkUpdateStatus).toHaveBeenCalledTimes(1);
     expect(checkTelemetryUpdateMock).toHaveBeenCalledOnce();
-    expect(resolveNpmChannelTag).not.toHaveBeenCalled();
     expect(getUpdateAvailable()).toEqual({
       currentVersion: "1.0.0",
       latestVersion: "2.0.0",
@@ -771,6 +847,7 @@ describe("update-startup", () => {
   it("honors the shared throttle after a recent extended-stable check marker", async () => {
     writePersistedUpdateCheckState({
       lastCheckedAt: new Date(Date.now()).toISOString(),
+      lastCheckedChannel: "extended-stable",
       lastAvailableVersion: "1.0.0",
       lastAvailableTag: "extended-stable",
     });
@@ -818,7 +895,7 @@ describe("update-startup", () => {
     await expectPathMissing(path.join(tempDir, "update-check.json"));
   });
 
-  it("uses the telemetry endpoint for an installed final extended-stable package", async () => {
+  it("uses the exact selector for an installed final extended-stable package", async () => {
     versionMock.value = "2026.6.33";
     mockPackageUpdateStatus("extended-stable", "2026.7.33");
     const onUpdateAvailableChange = vi.fn();
@@ -832,7 +909,10 @@ describe("update-startup", () => {
     });
 
     expect(checkTelemetryUpdateMock).toHaveBeenCalledWith({}, { surface: "gateway" });
-    expect(resolveNpmChannelTag).not.toHaveBeenCalled();
+    expect(resolveNpmChannelTag).toHaveBeenCalledWith({
+      channel: "extended-stable",
+      timeoutMs: 2500,
+    });
     expect(onUpdateAvailableChange).toHaveBeenCalledWith({
       currentVersion: "2026.6.33",
       latestVersion: "2026.7.33",
@@ -880,7 +960,6 @@ describe("update-startup", () => {
     });
 
     expect(checkTelemetryUpdateMock).toHaveBeenCalledTimes(2);
-    expect(resolveNpmChannelTag).not.toHaveBeenCalled();
     expect(log.info).toHaveBeenCalledTimes(1);
     expect(log.info).toHaveBeenCalledWith(
       `update available (extended-stable): v2.0.0 (current v1.0.0). Run: ${formatCliCommand("openclaw update")}`,
@@ -941,7 +1020,7 @@ describe("update-startup", () => {
     await seedExtendedStableAvailability({ onUpdateAvailableChange });
     seedStableAutoRolloutState();
     onUpdateAvailableChange.mockClear();
-    checkTelemetryUpdateMock.mockResolvedValue({ version });
+    mockNpmChannelTag("extended-stable", version);
     vi.setSystemTime(new Date("2026-01-18T11:00:00Z"));
     const log = { info: vi.fn() };
 
@@ -956,16 +1035,16 @@ describe("update-startup", () => {
       lastNotifiedTag: "extended-stable",
     });
     expect(readPersistedUpdateCheckState()?.lastAvailableVersion).toBeUndefined();
-    expect(readPersistedUpdateCheckState()?.lastAvailableTag).toBe("extended-stable");
+    expect(readPersistedUpdateCheckState()?.lastCheckedChannel).toBe("extended-stable");
     expectStableAutoRolloutStatePreserved();
   });
 
-  it("clears stale extended-stable availability when the telemetry request fails", async () => {
+  it("clears stale extended-stable availability when exact selector resolution fails", async () => {
     const onUpdateAvailableChange = vi.fn();
     await seedExtendedStableAvailability({ onUpdateAvailableChange });
     seedStableAutoRolloutState();
     onUpdateAvailableChange.mockClear();
-    checkTelemetryUpdateMock.mockResolvedValue(null);
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({ tag: "extended-stable", version: null });
     vi.setSystemTime(new Date("2026-01-18T11:00:00Z"));
     const log = { info: vi.fn() };
 
@@ -976,23 +1055,24 @@ describe("update-startup", () => {
     expect(onUpdateAvailableChange).toHaveBeenCalledWith(null);
     expect(getUpdateAvailable()).toBeNull();
     expect(readPersistedUpdateCheckState()?.lastAvailableVersion).toBeUndefined();
-    expect(readPersistedUpdateCheckState()?.lastAvailableTag).toBe("extended-stable");
+    expect(readPersistedUpdateCheckState()?.lastCheckedChannel).toBe("extended-stable");
     expectStableAutoRolloutStatePreserved();
     expect(startManagedServiceUpdateHandoffMock).not.toHaveBeenCalled();
     expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
 
+    const lookupCount = vi.mocked(resolveNpmChannelTag).mock.calls.length;
     await runExtendedStableUpdateCheck({ log, onUpdateAvailableChange });
-    expect(resolveNpmChannelTag).not.toHaveBeenCalled();
+    expect(resolveNpmChannelTag).toHaveBeenCalledTimes(lookupCount);
   });
 
-  it("preserves cross-channel persisted availability when extended-stable resolution fails", async () => {
+  it("discards cross-channel cached availability when extended-stable resolution fails", async () => {
     writePersistedUpdateCheckState({
       lastCheckedAt: "2026-01-16T10:00:00.000Z",
       lastAvailableVersion: "2.0.0",
       lastAvailableTag: "latest",
     });
     mockPackageInstallStatus();
-    checkTelemetryUpdateMock.mockResolvedValue(null);
+    vi.mocked(resolveNpmChannelTag).mockResolvedValue({ tag: "extended-stable", version: null });
     const onUpdateAvailableChange = vi.fn();
 
     await runExtendedStableUpdateCheck({ onUpdateAvailableChange });
@@ -1000,9 +1080,9 @@ describe("update-startup", () => {
     expect(onUpdateAvailableChange).not.toHaveBeenCalled();
     expect(getUpdateAvailable()).toBeNull();
     expect(readPersistedUpdateCheckState()).toMatchObject({
-      lastAvailableVersion: "2.0.0",
-      lastAvailableTag: "latest",
+      lastCheckedChannel: "extended-stable",
     });
+    expect(readPersistedUpdateCheckState()?.lastAvailableVersion).toBeUndefined();
   });
 
   it("does not resolve the npm channel for an extended-stable Git install", async () => {
@@ -1048,7 +1128,10 @@ describe("update-startup", () => {
     });
 
     expect(checkTelemetryUpdateMock).toHaveBeenCalledWith({}, { surface: "gateway" });
-    expect(resolveNpmChannelTag).not.toHaveBeenCalled();
+    expect(resolveNpmChannelTag).toHaveBeenCalledWith({
+      channel: "extended-stable",
+      timeoutMs: 2500,
+    });
   });
 
   it("keeps a configless Git install on dev after schedule population", async () => {
@@ -1165,6 +1248,7 @@ describe("update-startup", () => {
     await vi.advanceTimersByTimeAsync(60_000);
     expect(runAutoUpdate).toHaveBeenCalledWith({
       channel: "dev",
+      mode: "git",
       timeoutMs: 45 * 60 * 1000,
       restartDrainTimeoutMs: 300_000,
       root: "/opt/openclaw",
@@ -1172,41 +1256,6 @@ describe("update-startup", () => {
         mode: "tracked",
         upstreamRef: "origin/main",
         upstreamSha: "upstream-sha",
-      },
-    });
-  });
-
-  it("pins direct dev campaign updates to the announced commit", async () => {
-    mockDevGitStatus({ upstreamSha: "frozen-upstream-sha" });
-    const originalArgv = process.argv.slice();
-    process.argv = [process.execPath, "/opt/openclaw/dist/entry.js"];
-    try {
-      await runGatewayUpdateCheck({
-        cfg: { update: { channel: "dev", auto: { enabled: true } } },
-        log: { info: vi.fn() },
-        isNixMode: false,
-        allowInTests: true,
-        activeWorkInspectors: idleActiveWorkInspectors(),
-      });
-      await vi.advanceTimersByTimeAsync(60_000);
-    } finally {
-      process.argv = originalArgv;
-    }
-
-    const updateCall = vi
-      .mocked(runCommandWithTimeout)
-      .mock.calls.find(([argv]) => argv.includes("update"));
-    const updateOptions = updateCall?.[1];
-    if (!updateOptions || typeof updateOptions === "number") {
-      throw new Error("expected update command options");
-    }
-    expect(updateOptions.timeoutMs).toBe(45 * 60 * 1000);
-    expect(parseDevUpdateTargetEnv(updateOptions.env ?? {})).toEqual({
-      status: "valid",
-      target: {
-        mode: "tracked",
-        upstreamRef: "origin/main",
-        upstreamSha: "frozen-upstream-sha",
       },
     });
   });
@@ -1248,6 +1297,7 @@ describe("update-startup", () => {
       durationMs: 1,
     });
     const log = { info: vi.fn() };
+    const terminalSentinels: Array<ReturnType<typeof readRestartSentinel>> = [];
 
     await runGatewayUpdateCheck({
       cfg: { update: { channel: "dev", auto: { enabled: true } } },
@@ -1255,6 +1305,11 @@ describe("update-startup", () => {
       isNixMode: false,
       allowInTests: true,
       activeWorkInspectors: idleActiveWorkInspectors(),
+      onUpdateScheduleChange: (schedule) => {
+        if (!schedule.campaign) {
+          terminalSentinels.push(readRestartSentinel());
+        }
+      },
     });
     await vi.advanceTimersByTimeAsync(60_000);
 
@@ -1264,6 +1319,11 @@ describe("update-startup", () => {
       "auto-update attempt failed",
       expect.objectContaining({ reason: "preflight-no-good-commit" }),
     );
+    expect((await terminalSentinels.at(-1))?.payload).toMatchObject({
+      kind: "update",
+      status: "error",
+      stats: { reason: "preflight-no-good-commit" },
+    });
   });
 
   it("continues managed dev campaigns from a detached tracked deployment", async () => {
@@ -1558,7 +1618,7 @@ describe("update-startup", () => {
     expect(getUpdateSchedule()?.campaign?.state).toBe("applying");
     expect(runAutoUpdate).toHaveBeenCalledOnce();
     expect(log.info).toHaveBeenCalledWith(
-      "auto-update applied",
+      "auto-update handoff started",
       expect.objectContaining({
         channel: "dev",
         version: "upstream-sha",
@@ -1744,12 +1804,211 @@ describe("update-startup", () => {
     }
   });
 
+  it.each([true, false])(
+    "does not publish stopped discovery over a replacement scheduler with checks enabled=%s",
+    async (enabled) => {
+      const oldGitStatus = mockDevGitStatus({ upstreamSha: "old-upstream" });
+      let releaseOldFetch!: (status: UpdateCheckResult) => void;
+      vi.mocked(checkUpdateStatus)
+        .mockResolvedValueOnce(oldGitStatus)
+        .mockImplementationOnce(
+          () =>
+            new Promise((resolve) => {
+              releaseOldFetch = resolve;
+            }),
+        );
+      process.env.NODE_ENV = "production";
+      const onOldSchedule = vi.fn();
+      const onOldAvailable = vi.fn();
+      const stopOld = scheduleGatewayUpdateCheck({
+        cfg: { update: { channel: "dev", auto: { enabled: true } } },
+        log: { info: vi.fn() },
+        isNixMode: false,
+        activeWorkInspectors: idleActiveWorkInspectors(),
+        onUpdateScheduleChange: onOldSchedule,
+        onUpdateAvailableChange: onOldAvailable,
+      });
+      let stopReplacement: (() => void) | undefined;
+      try {
+        await vi.advanceTimersByTimeAsync(0);
+        expect(releaseOldFetch).toEqual(expect.any(Function));
+        stopOld();
+        mockDevGitStatus({ upstreamSha: "new-upstream", behind: 3 });
+        stopReplacement = scheduleGatewayUpdateCheck({
+          cfg: { update: { channel: "dev", checkOnStart: enabled, auto: { enabled: true } } },
+          log: { info: vi.fn() },
+          isNixMode: false,
+          activeWorkInspectors: idleActiveWorkInspectors(),
+        });
+        await vi.advanceTimersByTimeAsync(0);
+        const replacementSchedule = getUpdateSchedule();
+        const replacementAvailable = getUpdateAvailable();
+        const replacementState = readPersistedUpdateCheckState();
+
+        releaseOldFetch(oldGitStatus);
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(onOldSchedule).not.toHaveBeenCalled();
+        expect(onOldAvailable).not.toHaveBeenCalled();
+        expect(getUpdateSchedule()).toEqual(replacementSchedule);
+        expect(getUpdateAvailable()).toEqual(replacementAvailable);
+        expect(readPersistedUpdateCheckState()).toEqual(replacementState);
+      } finally {
+        stopOld();
+        stopReplacement?.();
+      }
+    },
+  );
+
+  it("refreshes the inferred Dev channel for a configless Git installation", async () => {
+    mockDevGitStatus({ behind: 3 });
+
+    await refreshGatewayUpdateStatus({});
+
+    expect(checkUpdateStatus).toHaveBeenCalledWith({
+      root: "/opt/openclaw",
+      fetchGit: true,
+      includeRegistry: false,
+      useDetachedDevUpstream: true,
+    });
+    expect(getUpdateSchedule()).toMatchObject({
+      channel: "dev",
+      install: { kind: "git", git: { status: "behind", commitsBehind: 3 } },
+    });
+  });
+
+  it.each([false, true])(
+    "does not publish an old Dev status refresh over a replacement channel with inferred=%s",
+    async (inferred) => {
+      const oldGitStatus = mockDevGitStatus();
+      let releaseRefresh!: (status: UpdateCheckResult) => void;
+      vi.mocked(checkUpdateStatus).mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseRefresh = resolve;
+          }),
+      );
+      const refresh = refreshGatewayUpdateStatus(inferred ? {} : { update: { channel: "dev" } });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(releaseRefresh).toEqual(expect.any(Function));
+
+      await runGatewayUpdateCheck({
+        cfg: { update: { channel: "beta", checkOnStart: false } },
+        log: { info: vi.fn() },
+        isNixMode: false,
+        allowInTests: true,
+      });
+      const replacementSchedule = getUpdateSchedule();
+      releaseRefresh(oldGitStatus);
+      await refresh;
+
+      expect(getUpdateSchedule()).toEqual(replacementSchedule);
+    },
+  );
+
+  it("does not launch a managed update after its scheduler stops during preflight", async () => {
+    mockDevGitStatus();
+    detectRespawnSupervisorMock.mockReturnValue("systemd");
+    let releasePreflight!: () => void;
+    runGatewayUpdatePreflightMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          releasePreflight = () => resolve(undefined);
+        }),
+    );
+    process.env.NODE_ENV = "production";
+    const stop = scheduleGatewayUpdateCheck({
+      cfg: { update: { channel: "dev", auto: { enabled: true } } },
+      log: { info: vi.fn() },
+      isNixMode: false,
+      activeWorkInspectors: idleActiveWorkInspectors(),
+    });
+    try {
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(releasePreflight).toEqual(expect.any(Function));
+      stop();
+      releasePreflight();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(startManagedServiceUpdateHandoffMock).not.toHaveBeenCalled();
+      expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+    } finally {
+      stop();
+    }
+  });
+
+  it.each([
+    { joined: false, cancelled: "restored-in-process" as const },
+    { joined: true, cancelled: "restored-in-process" as const },
+    { joined: false, cancelled: false as const },
+    { joined: false, cancelled: "restart-after-exit" as const },
+  ])(
+    "reconciles a late handoff after stop with joined=$joined and cancellation=$cancelled",
+    async ({ joined, cancelled }) => {
+      mockPackageUpdateStatus("beta", "2.0.0-beta.1");
+      detectRespawnSupervisorMock.mockReturnValue("systemd");
+      cancelManagedServiceUpdateHandoffMock.mockResolvedValueOnce(cancelled);
+      let releaseHandoff!: () => void;
+      startManagedServiceUpdateHandoffMock.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            releaseHandoff = () => {
+              const handoff = {
+                pid: 12345,
+                command: "openclaw update --yes --channel beta",
+                logPath: "/tmp/late-handoff.log",
+                handoffId: "late-handoff",
+                installRoot: "/opt/openclaw",
+              };
+              resolve(
+                joined ? { ...handoff, status: "joined" } : { ...handoff, status: "started" },
+              );
+            };
+          }),
+      );
+      process.env.NODE_ENV = "production";
+      const log = { info: vi.fn() };
+      const stop = scheduleGatewayUpdateCheck({
+        cfg: createBetaAutoUpdateConfig(),
+        log,
+        isNixMode: false,
+        activeWorkInspectors: idleActiveWorkInspectors(),
+      });
+      try {
+        await vi.advanceTimersByTimeAsync(60_000);
+        expect(releaseHandoff).toEqual(expect.any(Function));
+        stop();
+        releaseHandoff();
+        await vi.advanceTimersByTimeAsync(0);
+
+        if (joined) {
+          expect(cancelManagedServiceUpdateHandoffMock).not.toHaveBeenCalled();
+        } else {
+          expect(cancelManagedServiceUpdateHandoffMock).toHaveBeenCalledWith({
+            kind: "managed-update-handoff",
+            handoffId: "late-handoff",
+            installRoot: "/opt/openclaw",
+          });
+          if (cancelled !== "restored-in-process") {
+            expect(log.info).toHaveBeenCalledWith(
+              "stopped auto-update handoff cancellation could not be verified",
+              expect.objectContaining({ result: cancelled, logPath: "/tmp/late-handoff.log" }),
+            );
+          }
+        }
+        expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
+        expect(await readRestartSentinel()).toBeNull();
+      } finally {
+        stop();
+      }
+    },
+  );
+
   it("defers stable auto-update until rollout window is due", async () => {
     mockPackageUpdateStatus("latest", "2.0.0");
 
     const runAutoUpdate = vi.fn().mockResolvedValue({
-      ok: true,
-      code: 0,
+      status: "handoff",
     });
     const stableAutoConfig = {
       update: {
@@ -1784,6 +2043,7 @@ describe("update-startup", () => {
     expect(runAutoUpdate).toHaveBeenCalledTimes(1);
     expect(runAutoUpdate).toHaveBeenCalledWith({
       channel: "stable",
+      mode: "npm",
       timeoutMs: 45 * 60 * 1000,
       restartDrainTimeoutMs: 300_000,
       root: "/opt/openclaw",
@@ -1802,11 +2062,51 @@ describe("update-startup", () => {
     expect(runAutoUpdate).toHaveBeenCalledTimes(1);
     expect(runAutoUpdate).toHaveBeenCalledWith({
       channel: "beta",
+      mode: "npm",
       timeoutMs: 45 * 60 * 1000,
       restartDrainTimeoutMs: 300_000,
       root: "/opt/openclaw",
       packageTargetVersion: "2.0.0-beta.1",
     });
+  });
+
+  it("ends a held stable campaign when its replacement target is not yet due", async () => {
+    const campaign = new UpdateCampaignController();
+    const runAutoUpdate = createAutoUpdateSuccessMock();
+    const cfg = { update: { channel: "stable" as const, auto: { enabled: true } } };
+    mockPackageUpdateStatus("latest", "2.0.0");
+    writePersistedUpdateCheckState({
+      autoInstallId: "stable-held-install",
+      autoFirstSeenVersion: "2.0.0",
+      autoFirstSeenTag: "latest",
+      autoFirstSeenAt: new Date(Date.now() - 24 * 60 * 60_000).toISOString(),
+    });
+    const check = () =>
+      runGatewayUpdateCheck({
+        cfg,
+        log: { info: vi.fn() },
+        isNixMode: false,
+        allowInTests: true,
+        activeWorkInspectors: idleActiveWorkInspectors(),
+        updateCampaign: campaign,
+        runAutoUpdate,
+      });
+
+    try {
+      await check();
+      expect(campaign.hold()).toBe(true);
+      vi.setSystemTime(Date.now() + 60 * 60_000);
+      mockNpmChannelTag("latest", "3.0.0");
+
+      await check();
+
+      expect(getUpdateSchedule()?.target).toEqual({ kind: "package", version: "3.0.0" });
+      expect(getUpdateSchedule()?.campaign).toBeUndefined();
+      await vi.advanceTimersByTimeAsync(65_000);
+      expect(runAutoUpdate).not.toHaveBeenCalled();
+    } finally {
+      campaign.clear();
+    }
   });
 
   it("disables all automatic update traffic when checkOnStart is false", async () => {
@@ -1871,52 +2171,22 @@ describe("update-startup", () => {
     });
   });
 
-  it("uses current runtime + entrypoint for default auto-update command execution", async () => {
+  it("keeps a foreground Gateway serving when automatic update has no restart owner", async () => {
     mockPackageInstallStatus();
     mockNpmChannelTag("beta", "2.0.0-beta.1");
-    vi.mocked(runCommandWithTimeout).mockResolvedValue({
-      stdout: "{}",
-      stderr: "",
-      code: 0,
-      signal: null,
-      killed: false,
-      termination: "exit",
-    });
+    await runAutoUpdateCheckWithDefaults({ cfg: createBetaAutoUpdateConfig() });
 
-    const originalArgv = process.argv.slice();
-    process.argv = [process.execPath, "/opt/openclaw/dist/entry.js"];
-    try {
-      await runAutoUpdateCheckWithDefaults({
-        cfg: createBetaAutoUpdateConfig(),
-      });
-    } finally {
-      process.argv = originalArgv;
-    }
-
-    expect(runCommandWithTimeout).toHaveBeenCalledTimes(1);
+    expect(runCommandWithTimeout).not.toHaveBeenCalled();
     expect(startManagedServiceUpdateHandoffMock).not.toHaveBeenCalled();
     expect(scheduleGatewaySigusr1RestartMock).not.toHaveBeenCalled();
-    expect(detectRespawnSupervisorMock).toHaveBeenCalledWith(process.env, process.platform, {
-      includeLinuxOpenClawGatewayServiceMarker: true,
+    expect(getUpdateSchedule()?.campaign).toBeUndefined();
+    expect(getUpdateAvailable()).toMatchObject({ latestVersion: "2.0.0-beta.1" });
+    expect((await readRestartSentinel())?.payload).toMatchObject({
+      kind: "update",
+      status: "skipped",
+      message: expect.stringContaining("shell"),
+      stats: { reason: "managed-service-handoff-unavailable" },
     });
-    const [argv, options] = requireFirstRunCommandCall();
-    expect(argv).toEqual([
-      process.execPath,
-      "/opt/openclaw/dist/entry.js",
-      "update",
-      "--yes",
-      "--channel",
-      "beta",
-      "--tag",
-      "2.0.0-beta.1",
-      "--json",
-    ]);
-    expect(typeof options).toBe("object");
-    if (typeof options !== "object") {
-      throw new Error("expected command options object");
-    }
-    expect(options.timeoutMs).toBe(45 * 60 * 1000);
-    expect(options.env).toBeUndefined();
   });
 
   it("hands supervised auto-updates to a detached service handoff before restarting", async () => {
@@ -2011,6 +2281,7 @@ describe("update-startup", () => {
       Object.assign(new Error("spawn ENOENT"), { code: "ENOENT" }),
     );
     const log = { info: vi.fn() };
+    const terminalSentinels: Array<ReturnType<typeof readRestartSentinel>> = [];
 
     await runGatewayUpdateCheck({
       cfg: createBetaAutoUpdateConfig(),
@@ -2018,6 +2289,11 @@ describe("update-startup", () => {
       isNixMode: false,
       allowInTests: true,
       activeWorkInspectors: idleActiveWorkInspectors(),
+      onUpdateScheduleChange: (schedule) => {
+        if (!schedule.campaign) {
+          terminalSentinels.push(readRestartSentinel());
+        }
+      },
     });
     await vi.advanceTimersByTimeAsync(60_000);
 
@@ -2027,7 +2303,8 @@ describe("update-startup", () => {
       version: "2.0.0-beta.1",
       tag: "beta",
       forced: false,
-      reason: "Error: spawn ENOENT",
+      reason: "managed-service-handoff-failed",
+      message: expect.stringContaining("spawn ENOENT"),
     });
     expect(log.info).toHaveBeenCalledWith(
       "update campaign ended",
@@ -2037,6 +2314,11 @@ describe("update-startup", () => {
       }),
     );
     expect(getUpdateSchedule()?.campaign).toBeUndefined();
+    expect((await terminalSentinels.at(-1))?.payload).toMatchObject({
+      kind: "update",
+      status: "error",
+      stats: { reason: "managed-service-handoff-failed" },
+    });
   });
 
   it("does not schedule another restart when auto-update joins an active handoff", async () => {
@@ -2115,7 +2397,7 @@ describe("update-startup", () => {
       stop();
       await vi.advanceTimersByTimeAsync(24 * 60 * 60 * 1000);
       expect(checkTelemetryUpdateMock).toHaveBeenCalledTimes(2);
-      expect(resolveNpmChannelTag).not.toHaveBeenCalled();
+      expect(resolveNpmChannelTag).toHaveBeenCalledTimes(2);
     } finally {
       stop();
       process.env.NODE_ENV = previousNodeEnv;

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -1,12 +1,9 @@
 // Runs startup update checks and optional auto-update handoff.
 import { createHash, randomUUID } from "node:crypto";
-import fs from "node:fs/promises";
-import path from "node:path";
 import {
   asDateTimestampMs,
   timestampMsToIsoString,
 } from "@openclaw/normalization-core/number-coercion";
-import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type {
   UpdateAvailable,
   UpdateScheduleState,
@@ -29,19 +26,23 @@ import {
 } from "./gateway-supervision.js";
 import { gitCommitPrefixesMatch } from "./git-commit.js";
 import { resolveOpenClawPackageRoot } from "./openclaw-root.js";
-import { readVerifiedGitUpdateReceipt, type VerifiedGitUpdateReceipt } from "./restart-sentinel.js";
+import {
+  readRestartSentinelSnapshot,
+  readVerifiedGitUpdateReceipt,
+  writeRestartSentinelIfUnchanged,
+  type VerifiedGitUpdateReceipt,
+} from "./restart-sentinel.js";
 import {
   normalizeGatewayRestartDelayMs,
   resolveGatewayRestartDeferralTimeoutMs,
   scheduleGatewaySigusr1Restart,
 } from "./restart.js";
-import { detectRespawnSupervisor, type RespawnSupervisor } from "./supervisor-markers.js";
+import { detectRespawnSupervisor } from "./supervisor-markers.js";
 import { checkTelemetryUpdate } from "./telemetry.js";
 import { gatewayUpdateCampaign, type UpdateCampaignController } from "./update-campaign.js";
 import {
   channelToNpmTag,
   DEV_BRANCH,
-  isBetaTag,
   normalizeUpdateChannel,
   resolveEffectiveUpdateChannel,
   DEFAULT_PACKAGE_CHANNEL,
@@ -53,18 +54,21 @@ import {
   checkUpdateStatus,
   type UpdateCheckResult,
 } from "./update-check.js";
-import { CONTROL_PLANE_UPDATE_HANDOFF_STARTED_REASON } from "./update-control-plane-sentinel.js";
-import {
-  applyDevUpdateTargetEnv,
-  devUpdateTargetFromGitTarget,
-  type TrackedDevUpdateTarget,
-} from "./update-dev-target.js";
+import { isPendingControlPlaneUpdateRestartSentinel } from "./update-control-plane-sentinel.js";
+import { devUpdateTargetFromGitTarget, type TrackedDevUpdateTarget } from "./update-dev-target.js";
 import { updateInstallRootsMatch } from "./update-install-root.js";
-import { startManagedServiceUpdateHandoff } from "./update-managed-service-handoff.js";
-import { runGatewayUpdatePreflight } from "./update-runner.js";
+import {
+  buildManagedServiceHandoffUnavailableMessage,
+  cancelManagedServiceUpdateHandoff,
+  formatManagedServiceUpdateCommand,
+  startManagedServiceUpdateHandoff,
+} from "./update-managed-service-handoff.js";
+import { buildUpdateRestartSentinelPayload } from "./update-restart-sentinel-payload.js";
+import { runGatewayUpdatePreflight, type UpdateRunResult } from "./update-runner.js";
 
 type UpdateCheckState = {
   lastCheckedAt?: string;
+  lastCheckedChannel?: UpdateChannel;
   lastNotifiedVersion?: string;
   lastNotifiedTag?: string;
   lastAvailableVersion?: string;
@@ -75,8 +79,6 @@ type UpdateCheckState = {
   autoFirstSeenAt?: string;
   autoLastAttemptVersion?: string;
   autoLastAttemptAt?: string;
-  autoLastSuccessVersion?: string;
-  autoLastSuccessAt?: string;
 };
 
 type AutoUpdatePolicy = {
@@ -86,23 +88,19 @@ type AutoUpdatePolicy = {
   betaCheckIntervalHours: number;
 };
 
-type AutoUpdateRunResult = {
-  ok: boolean;
-  code: number | null;
-  stdout?: string;
-  stderr?: string;
-  reason?: string;
-  command?: string;
-  logPath?: string;
-};
+type AutoUpdateRunResult =
+  | { status: "handoff"; command?: string; logPath?: string }
+  | { status: "failed"; result: UpdateRunResult; message: string };
 
 type AutoUpdateRunParams = {
   channel: "stable" | "beta" | "dev";
+  mode: UpdateRunResult["mode"];
   timeoutMs: number;
   restartDrainTimeoutMs: number | undefined;
   root?: string;
   packageTargetVersion?: string;
   devTarget?: TrackedDevUpdateTarget;
+  signal?: AbortSignal;
 };
 
 type AutoUpdateRunner = (params: AutoUpdateRunParams) => Promise<AutoUpdateRunResult>;
@@ -115,6 +113,7 @@ export type {
 let updateAvailableCache: UpdateAvailable | null = null;
 let updateScheduleCache: UpdateScheduleState | null = null;
 let installStatusInitialization: ReturnType<typeof resolveStartupInstallStatus> | null = null;
+let updateCheckLifecycle: AbortController | undefined;
 
 export function getUpdateAvailable(): UpdateAvailable | null {
   return updateAvailableCache;
@@ -137,6 +136,8 @@ export function resetUpdateAvailableStateForTest(): void {
   updateAvailableCache = null;
   updateScheduleCache = null;
   installStatusInitialization = null;
+  updateCheckLifecycle?.abort();
+  updateCheckLifecycle = undefined;
   gatewayUpdateCampaign.resetForTest();
 }
 
@@ -186,11 +187,11 @@ function resolveCheckIntervalMs(
   return UPDATE_CHECK_INTERVAL_MS;
 }
 
-async function readState(): Promise<UpdateCheckState> {
+function readState(): UpdateCheckState {
   return readConfigMachineState<UpdateCheckState>(UPDATE_CHECK_STATE_KEY) ?? {};
 }
 
-async function writeState(state: UpdateCheckState): Promise<void> {
+function writeState(state: UpdateCheckState): void {
   writeConfigMachineState(UPDATE_CHECK_STATE_KEY, state);
 }
 
@@ -253,6 +254,9 @@ function isPersistedAvailabilityForChannel(params: {
   state: UpdateCheckState;
   channel: UpdateChannel;
 }): boolean {
+  if (params.state.lastCheckedChannel !== params.channel) {
+    return false;
+  }
   const tag = params.state.lastAvailableTag?.trim();
   if (params.channel === "stable") {
     return !tag || tag === "latest";
@@ -283,13 +287,7 @@ function resolvePersistedUpdateAvailable(
   };
 }
 
-function clearPersistedAvailabilityForChannel(
-  nextState: UpdateCheckState,
-  channel: UpdateChannel,
-): void {
-  if (!isPersistedAvailabilityForChannel({ state: nextState, channel })) {
-    return;
-  }
+function clearAvailabilityState(nextState: UpdateCheckState): void {
   delete nextState.lastAvailableVersion;
   delete nextState.lastAvailableTag;
 }
@@ -365,17 +363,73 @@ function resolveStableAutoApplyAtMs(params: {
   return firstSeenMs + baseDelayMs + jitterMs;
 }
 
-async function startManagedServiceAutoUpdateHandoff(
-  params: AutoUpdateRunParams & { supervisor: RespawnSupervisor },
+async function runAutoUpdateCommand(
+  params: AutoUpdateRunParams,
+  log: { info: (msg: string, meta?: Record<string, unknown>) => void },
 ): Promise<AutoUpdateRunResult> {
-  const restartDelayMs = normalizeGatewayRestartDelayMs(
-    params.supervisor === "systemd" ? undefined : 0,
-  );
-  const handoffId = randomUUID();
+  const startedAt = Date.now();
+  const command = formatManagedServiceUpdateCommand({
+    channel: params.channel,
+    ...(params.packageTargetVersion ? { tag: params.packageTargetVersion } : {}),
+    timeoutMs: params.timeoutMs,
+  });
+  const failure = (
+    reason: string,
+    message: string,
+    status: "error" | "skipped" = "error",
+  ): AutoUpdateRunResult => ({
+    status: "failed",
+    result: {
+      status,
+      mode: params.mode,
+      root: params.root,
+      reason,
+      before: { version: VERSION },
+      steps: [],
+      durationMs: Date.now() - startedAt,
+    },
+    message,
+  });
+  if (isGatewayExternallySupervised()) {
+    return failure(
+      EXTERNAL_SUPERVISOR_UPDATE_REQUIRED_REASON,
+      "Use the external supervisor's update workflow to stop, update, and restart the Gateway.",
+      "skipped",
+    );
+  }
+  const supervisor = detectRespawnSupervisor(process.env, process.platform, {
+    includeLinuxOpenClawGatewayServiceMarker: true,
+  });
+  if (!supervisor) {
+    return failure(
+      "managed-service-handoff-unavailable",
+      buildManagedServiceHandoffUnavailableMessage(command),
+      "skipped",
+    );
+  }
+
   try {
+    params.signal?.throwIfAborted();
+    if (params.devTarget) {
+      const result = await runGatewayUpdatePreflight(
+        params.root,
+        params.timeoutMs,
+        params.devTarget,
+      );
+      params.signal?.throwIfAborted();
+      if (result) {
+        return {
+          status: "failed",
+          result,
+          message: `Automatic update preflight failed. Run \`${command}\` from a shell to inspect and retry.`,
+        };
+      }
+    }
     if (!params.root?.trim()) {
       throw new Error("managed auto-update install root is unavailable");
     }
+    const restartDelayMs = normalizeGatewayRestartDelayMs(supervisor === "systemd" ? undefined : 0);
+    const handoffId = randomUUID();
     const started = await startManagedServiceUpdateHandoff({
       root: params.root,
       timeoutMs: params.timeoutMs,
@@ -385,125 +439,48 @@ async function startManagedServiceAutoUpdateHandoff(
       channel: params.channel,
       ...(params.packageTargetVersion ? { tag: params.packageTargetVersion } : {}),
       restartDelayMs,
-      supervisor: params.supervisor,
+      supervisor,
       handoffId,
       ...(params.devTarget ? { devTarget: params.devTarget } : {}),
-      meta: {
-        handoffId,
-        note: "background auto-update",
-      },
+      meta: { handoffId, note: "background auto-update" },
     });
-    // Pair helper creation with restart scheduling before any state persistence
-    // can fail and leave an indefinite handoff waiting on a live parent.
     if (started.status === "started") {
-      const { handoffId: ownerId, installRoot } = started;
+      const successorOwner = {
+        kind: "managed-update-handoff" as const,
+        handoffId: started.handoffId,
+        installRoot: started.installRoot,
+      };
+      if (params.signal?.aborted) {
+        const cancelled = await cancelManagedServiceUpdateHandoff(successorOwner);
+        if (cancelled !== "restored-in-process") {
+          log.info("stopped auto-update handoff cancellation could not be verified", {
+            result: cancelled,
+            command: started.command,
+            logPath: started.logPath,
+          });
+        }
+        params.signal.throwIfAborted();
+      }
+      // Pair owned helper creation with restart scheduling before persistence;
+      // a joined helper belongs to its original caller, including cancellation.
       scheduleGatewaySigusr1Restart({
         delayMs: restartDelayMs,
         reason: "update.auto",
-        successorOwner: { kind: "managed-update-handoff", handoffId: ownerId, installRoot },
+        successorOwner,
         skipCooldown: true,
         skipDeferral: true,
       });
     }
     return {
-      ok: true,
-      code: 0,
-      reason: CONTROL_PLANE_UPDATE_HANDOFF_STARTED_REASON,
+      status: "handoff",
       command: started.command,
       logPath: started.logPath,
     };
   } catch (err) {
-    return {
-      ok: false,
-      code: null,
-      reason: String(err),
-    };
-  }
-}
-
-async function runAutoUpdateCommand(params: AutoUpdateRunParams): Promise<AutoUpdateRunResult> {
-  if (isGatewayExternallySupervised()) {
-    return {
-      ok: false,
-      code: null,
-      reason: EXTERNAL_SUPERVISOR_UPDATE_REQUIRED_REASON,
-    };
-  }
-  const supervisor = detectRespawnSupervisor(process.env, process.platform, {
-    includeLinuxOpenClawGatewayServiceMarker: true,
-  });
-  if (supervisor && params.devTarget) {
-    const failure = await runGatewayUpdatePreflight(
-      params.root,
-      params.timeoutMs,
-      params.devTarget,
+    return failure(
+      "managed-service-handoff-failed",
+      `Automatic update handoff failed: ${String(err)}. Run \`${command}\` from a shell to inspect and retry.`,
     );
-    if (failure) {
-      return { ok: false, code: 1, reason: failure.reason ?? "preflight-failed" };
-    }
-  }
-  if (supervisor) {
-    return await startManagedServiceAutoUpdateHandoff({ ...params, supervisor });
-  }
-
-  const targetArgs = [
-    "--channel",
-    params.channel,
-    ...(params.packageTargetVersion ? ["--tag", params.packageTargetVersion] : []),
-  ];
-  const baseArgs = ["update", "--yes", ...targetArgs, "--json"];
-  const execPath = process.execPath?.trim();
-  const argv1 = process.argv[1]?.trim();
-  const lowerExecBase = execPath ? normalizeLowercaseStringOrEmpty(path.basename(execPath)) : "";
-  const runtimeIsNodeOrBun =
-    lowerExecBase === "node" ||
-    lowerExecBase === "node.exe" ||
-    lowerExecBase === "bun" ||
-    lowerExecBase === "bun.exe";
-  const argv: string[] = [];
-  if (execPath && argv1) {
-    argv.push(execPath, argv1, ...baseArgs);
-  } else if (execPath && !runtimeIsNodeOrBun) {
-    argv.push(execPath, ...baseArgs);
-  } else if (execPath && params.root) {
-    const candidates = [
-      path.join(params.root, "dist", "entry.js"),
-      path.join(params.root, "dist", "entry.mjs"),
-      path.join(params.root, "dist", "index.js"),
-      path.join(params.root, "dist", "index.mjs"),
-    ];
-    for (const candidate of candidates) {
-      try {
-        await fs.access(candidate);
-        argv.push(execPath, candidate, ...baseArgs);
-        break;
-      } catch {
-        // try next candidate
-      }
-    }
-  }
-  if (argv.length === 0) {
-    argv.push("openclaw", ...baseArgs);
-  }
-
-  try {
-    const res = await runCommandWithTimeout(argv, {
-      timeoutMs: params.timeoutMs,
-      ...(params.devTarget ? { env: applyDevUpdateTargetEnv({}, params.devTarget) } : {}),
-    });
-    return {
-      ok: res.code === 0,
-      code: res.code,
-      stdout: res.stdout,
-      stderr: res.stderr,
-      reason: res.code === 0 ? undefined : "non-zero-exit",
-    };
-  } catch (err) {
-    return {
-      ok: false,
-      code: null,
-      reason: String(err),
-    };
   }
 }
 
@@ -636,11 +613,21 @@ function withInstallStatus(
 
 /** Refreshes the read-only Dev checkout comparison used by update.status. */
 export async function refreshGatewayUpdateStatus(cfg: OpenClawConfig): Promise<void> {
-  const channel = normalizeUpdateChannel(cfg.update?.channel) ?? DEFAULT_PACKAGE_CHANNEL;
-  if (channel !== "dev") {
+  const lifecycle = updateCheckLifecycle;
+  const scheduleAtStart = updateScheduleCache;
+  const channel =
+    normalizeUpdateChannel(cfg.update?.channel) ?? (await getUpdateEffectiveChannel());
+  const isCurrent = () =>
+    lifecycle === updateCheckLifecycle &&
+    !lifecycle?.signal.aborted &&
+    (updateScheduleCache === scheduleAtStart || updateScheduleCache?.channel === channel);
+  if (channel !== "dev" || !isCurrent()) {
     return;
   }
   const { root, status, installReceipt } = await resolveStartupInstallStatus(true);
+  if (!isCurrent()) {
+    return;
+  }
   const current =
     updateScheduleCache?.channel === channel
       ? updateScheduleCache
@@ -694,6 +681,7 @@ async function resolveDevGitCommits(params: {
 
 async function runCampaignUpdate(params: {
   channel: "stable" | "beta" | "dev";
+  mode: UpdateRunResult["mode"];
   version: string;
   tag: string;
   forced: boolean;
@@ -701,22 +689,41 @@ async function runCampaignUpdate(params: {
   devTarget?: TrackedDevUpdateTarget;
   log: { info: (msg: string, meta?: Record<string, unknown>) => void };
   runAuto: AutoUpdateRunner;
-}): Promise<"handoff" | "applied" | "failed"> {
+  campaign: UpdateCampaignController;
+  signal?: AbortSignal;
+}): Promise<"handoff" | "failed"> {
+  const campaignId = params.campaign.getState()?.id;
+  const isCurrent = () =>
+    campaignId !== undefined &&
+    !params.signal?.aborted &&
+    params.campaign.getState()?.id === campaignId;
+  if (!isCurrent()) {
+    return "failed";
+  }
+  const { sentinel, revision } = await readRestartSentinelSnapshot();
+  if (!isCurrent()) {
+    return "failed";
+  }
   const attemptAt = resolveUpdateCheckNowMs(Date.now());
-  const attemptState = await readState();
+  const attemptState = readState();
   attemptState.autoLastAttemptVersion = params.version;
   attemptState.autoLastAttemptAt = resolveUpdateCheckTimestamp(attemptAt);
-  await writeState(attemptState);
+  writeState(attemptState);
 
   const outcome = await params.runAuto({
     channel: params.channel,
+    mode: params.mode,
     timeoutMs: AUTO_UPDATE_COMMAND_TIMEOUT_MS,
     restartDrainTimeoutMs: resolveGatewayRestartDeferralTimeoutMs(),
     ...(params.root ? { root: params.root } : {}),
     ...(params.channel === "dev" ? {} : { packageTargetVersion: params.version }),
     ...(params.devTarget ? { devTarget: params.devTarget } : {}),
+    ...(params.signal ? { signal: params.signal } : {}),
   });
-  if (outcome.ok && outcome.reason === CONTROL_PLANE_UPDATE_HANDOFF_STARTED_REASON) {
+  if (!isCurrent()) {
+    return "failed";
+  }
+  if (outcome.status === "handoff") {
     params.log.info("auto-update handoff started", {
       channel: params.channel,
       version: params.version,
@@ -727,25 +734,25 @@ async function runCampaignUpdate(params: {
     });
     return "handoff";
   }
-  if (outcome.ok) {
-    const successState = await readState();
-    successState.autoLastSuccessVersion = params.version;
-    successState.autoLastSuccessAt = resolveUpdateCheckTimestamp(Date.now());
-    await writeState(successState);
-    params.log.info("auto-update applied", {
-      channel: params.channel,
-      version: params.version,
-      tag: params.tag,
-      forced: params.forced,
+  // Publish before campaign-ended observers refresh status. A concurrent restart
+  // or update keeps its notification; this attempt may replace only its snapshot.
+  if (!sentinel || !isPendingControlPlaneUpdateRestartSentinel(sentinel.payload)) {
+    await writeRestartSentinelIfUnchanged({
+      payload: buildUpdateRestartSentinelPayload({
+        result: outcome.result,
+        meta: { root: params.root, note: outcome.message },
+      }),
+      expectedRevision: revision,
+      isCurrent,
     });
-    return "applied";
   }
   params.log.info("auto-update attempt failed", {
     channel: params.channel,
     version: params.version,
     tag: params.tag,
     forced: params.forced,
-    reason: outcome.reason ?? `exit:${outcome.code}`,
+    reason: outcome.result.reason,
+    message: outcome.message,
   });
   return "failed";
 }
@@ -760,7 +767,9 @@ export async function runGatewayUpdateCheck(params: {
   activeWorkInspectors?: Partial<GatewayActiveWorkInspectors>;
   updateCampaign?: UpdateCampaignController;
   runAutoUpdate?: AutoUpdateRunner;
+  signal?: AbortSignal;
 }): Promise<void> {
+  params.signal?.throwIfAborted();
   if (shouldSkipCheck(Boolean(params.allowInTests))) {
     return;
   }
@@ -769,6 +778,8 @@ export async function runGatewayUpdateCheck(params: {
   }
   const configChannel = normalizeUpdateChannel(params.cfg.update?.channel);
   const updateCampaign = params.updateCampaign ?? gatewayUpdateCampaign;
+  const runAuto: AutoUpdateRunner =
+    params.runAutoUpdate ?? ((runParams) => runAutoUpdateCommand(runParams, params.log));
   const auto = resolveAutoUpdatePolicy(params.cfg);
   const autoDisabledByEnv = isTruthyEnvValue(process.env.OPENCLAW_NO_AUTO_UPDATE);
   if (params.cfg.update?.checkOnStart === false || autoDisabledByEnv) {
@@ -790,6 +801,7 @@ export async function runGatewayUpdateCheck(params: {
   }
   const autoDisabledByExternalSupervisor = isGatewayExternallySupervised();
   const initializedInstallStatus = await initializeGatewayUpdateStatus();
+  params.signal?.throwIfAborted();
   const potentialChannel = resolveEffectiveUpdateChannel({
     configChannel,
     currentVersion: VERSION,
@@ -799,6 +811,7 @@ export async function runGatewayUpdateCheck(params: {
   let installStatus = initializedInstallStatus;
   if (potentialChannel === "dev" && installStatus.status.installKind === "git") {
     installStatus = await resolveStartupInstallStatus(true);
+    params.signal?.throwIfAborted();
   }
   const configuredChannel = resolveEffectiveUpdateChannel({
     configChannel,
@@ -813,7 +826,13 @@ export async function runGatewayUpdateCheck(params: {
     auto.enabled &&
     !autoDisabledByExternalSupervisor;
 
-  if (updateScheduleCache?.channel !== configuredChannel) {
+  // The admitted target belongs to the applying owner until it settles.
+  if (updateCampaign.getState()?.state === "applying") {
+    return;
+  }
+  const channelChanged =
+    updateScheduleCache !== null && updateScheduleCache.channel !== configuredChannel;
+  if (channelChanged) {
     updateCampaign.clear();
   }
   const priorSchedule =
@@ -899,7 +918,8 @@ export async function runGatewayUpdateCheck(params: {
     updateCampaign.clear();
   }
   const telemetryUpdate = await checkTelemetryUpdate(params.cfg, { surface: "gateway" });
-  const state = await readState();
+  params.signal?.throwIfAborted();
+  const state = readState();
   const rawNow = Date.now();
   const now = resolveUpdateCheckNowMs(rawNow);
   const rawNowIsValid = asDateTimestampMs(rawNow) !== undefined;
@@ -907,9 +927,8 @@ export async function runGatewayUpdateCheck(params: {
   const persistedAvailable = isDevGit
     ? null
     : resolvePersistedUpdateAvailable(state, configuredChannel);
-  const hasExtendedStableCheckMarker = state.lastAvailableTag?.trim() === "extended-stable";
-  const shouldBypassSharedThrottle =
-    isDevGit || (configuredChannel === "extended-stable" && !hasExtendedStableCheckMarker);
+  const cacheMatchesChannel = state.lastCheckedChannel === configuredChannel;
+  const shouldBypassSharedThrottle = isDevGit || !cacheMatchesChannel;
   setUpdateAvailableCache({
     next: persistedAvailable,
     onUpdateAvailableChange: params.onUpdateAvailableChange,
@@ -952,11 +971,14 @@ export async function runGatewayUpdateCheck(params: {
   const nextState: UpdateCheckState = {
     ...state,
     lastCheckedAt: resolveUpdateCheckTimestamp(now),
+    lastCheckedChannel: configuredChannel,
   };
+  if (!cacheMatchesChannel) {
+    clearAvailabilityState(nextState);
+  }
 
   if (isDevGit) {
-    delete nextState.lastAvailableVersion;
-    delete nextState.lastAvailableTag;
+    clearAvailabilityState(nextState);
     clearAutoState(nextState);
     const git = status.git;
     if (
@@ -975,7 +997,7 @@ export async function runGatewayUpdateCheck(params: {
         next: withoutTarget(updateScheduleCache ?? initialSchedule),
         onUpdateScheduleChange: params.onUpdateScheduleChange,
       });
-      await writeState(nextState);
+      writeState(nextState);
       return;
     }
     const currentSha = git.sha;
@@ -987,6 +1009,7 @@ export async function runGatewayUpdateCheck(params: {
       currentSha,
       upstreamSha,
     });
+    params.signal?.throwIfAborted();
 
     const target: NonNullable<UpdateScheduleState["target"]> = {
       kind: "git",
@@ -994,6 +1017,9 @@ export async function runGatewayUpdateCheck(params: {
       upstreamSha,
       commitsBehind,
     };
+    if (!updateCampaign.reconcileTarget(target)) {
+      return;
+    }
     const nextAvailable: UpdateAvailable = {
       currentVersion: VERSION,
       latestVersion: VERSION,
@@ -1032,7 +1058,6 @@ export async function runGatewayUpdateCheck(params: {
         Number.isFinite(lastAttemptAt) &&
         now - lastAttemptAt < ONE_HOUR_MS;
       if (!recentAttempt) {
-        const runAuto = params.runAutoUpdate ?? runAutoUpdateCommand;
         updateCampaign.announce({
           target,
           inspect: params.activeWorkInspectors,
@@ -1040,6 +1065,7 @@ export async function runGatewayUpdateCheck(params: {
           apply: async ({ forced }) =>
             await runCampaignUpdate({
               channel: "dev",
+              mode: "git",
               version: upstreamSha,
               tag: "dev",
               forced,
@@ -1047,19 +1073,20 @@ export async function runGatewayUpdateCheck(params: {
               devTarget: devUpdateTargetFromGitTarget(target),
               log: params.log,
               runAuto,
+              campaign: updateCampaign,
+              signal: params.signal,
             }),
         });
       }
     } else {
       updateCampaign.clear();
     }
-    await writeState(nextState);
+    writeState(nextState);
     return;
   }
 
   if (status.installKind !== "package") {
-    delete nextState.lastAvailableVersion;
-    delete nextState.lastAvailableTag;
+    clearAvailabilityState(nextState);
     clearAutoState(nextState);
     setUpdateAvailableCache({
       next: null,
@@ -1070,27 +1097,23 @@ export async function runGatewayUpdateCheck(params: {
       next: withoutTarget(updateScheduleCache ?? initialSchedule),
       onUpdateScheduleChange: params.onUpdateScheduleChange,
     });
-    await writeState(nextState);
+    writeState(nextState);
     return;
   }
 
   const channel = configuredChannel;
-  const resolved = shouldRunAutoUpdate
-    ? await resolveNpmChannelTag({ channel, timeoutMs: 2500 })
-    : {
-        tag:
-          channel === "beta" && telemetryUpdate?.version && !isBetaTag(telemetryUpdate.version)
-            ? "latest"
-            : channelToNpmTag(channel),
-        version: telemetryUpdate?.version ?? null,
-      };
+  const resolved =
+    shouldRunAutoUpdate || channel !== "stable"
+      ? await resolveNpmChannelTag({ channel, timeoutMs: 2500 })
+      : {
+          tag: "latest",
+          version: telemetryUpdate?.version ?? null,
+        };
+  params.signal?.throwIfAborted();
   const tag = resolved.tag;
   if (!resolved.version) {
     if (channel === "extended-stable") {
-      clearPersistedAvailabilityForChannel(nextState, channel);
-      if (!nextState.lastAvailableVersion) {
-        nextState.lastAvailableTag = channel;
-      }
+      clearAvailabilityState(nextState);
       setUpdateAvailableCache({
         next: null,
         onUpdateAvailableChange: params.onUpdateAvailableChange,
@@ -1101,7 +1124,7 @@ export async function runGatewayUpdateCheck(params: {
         onUpdateScheduleChange: params.onUpdateScheduleChange,
       });
     }
-    await writeState(nextState);
+    writeState(nextState);
     return;
   }
   const resolvedVersion = resolved.version;
@@ -1117,6 +1140,9 @@ export async function runGatewayUpdateCheck(params: {
       kind: "package",
       version: resolved.version,
     };
+    if (!updateCampaign.reconcileTarget(target)) {
+      return;
+    }
     setUpdateScheduleCache({
       next: { ...(updateScheduleCache ?? initialSchedule), target },
       onUpdateScheduleChange: params.onUpdateScheduleChange,
@@ -1148,7 +1174,6 @@ export async function runGatewayUpdateCheck(params: {
     }
 
     if (shouldRunAutoUpdate && (channel === "stable" || channel === "beta")) {
-      const runAuto = params.runAutoUpdate ?? runAutoUpdateCommand;
       const attemptIntervalMs =
         channel === "beta"
           ? Math.max(ONE_HOUR_MS / 4, Math.floor(auto.betaCheckIntervalHours * ONE_HOUR_MS))
@@ -1194,25 +1219,24 @@ export async function runGatewayUpdateCheck(params: {
           apply: async ({ forced }) =>
             await runCampaignUpdate({
               channel,
+              mode: status.packageManager,
               version: resolvedVersion,
               tag,
               forced,
               root: root ?? status.root ?? undefined,
               log: params.log,
               runAuto,
+              campaign: updateCampaign,
+              signal: params.signal,
             }),
         });
       }
     }
   } else {
     if (channel === "extended-stable") {
-      clearPersistedAvailabilityForChannel(nextState, channel);
-      if (!nextState.lastAvailableVersion) {
-        nextState.lastAvailableTag = channel;
-      }
+      clearAvailabilityState(nextState);
     } else {
-      delete nextState.lastAvailableVersion;
-      delete nextState.lastAvailableTag;
+      clearAvailabilityState(nextState);
       clearAutoState(nextState);
     }
     setUpdateAvailableCache({
@@ -1226,7 +1250,7 @@ export async function runGatewayUpdateCheck(params: {
     });
   }
 
-  await writeState(nextState);
+  writeState(nextState);
 }
 
 export function scheduleGatewayUpdateCheck(params: {
@@ -1237,32 +1261,26 @@ export function scheduleGatewayUpdateCheck(params: {
   onUpdateScheduleChange?: (schedule: UpdateScheduleState) => void;
   activeWorkInspectors?: Partial<GatewayActiveWorkInspectors>;
 }): () => void {
+  updateCheckLifecycle?.abort();
+  const lifecycle = new AbortController();
+  updateCheckLifecycle = lifecycle;
   const stopRemoteCatalogRefresh = scheduleRemoteModelCatalogRefresh(params);
-  const channel = normalizeUpdateChannel(params.cfg.update?.channel) ?? DEFAULT_PACKAGE_CHANNEL;
-  if (channel === "extended-stable" && params.cfg.update?.checkOnStart === false) {
-    return () => {
-      stopRemoteCatalogRefresh();
-      gatewayUpdateCampaign.clear();
-    };
-  }
-  let stopped = false;
   let timer: ReturnType<typeof setTimeout> | null = null;
   let running = false;
 
   const tick = async () => {
-    if (stopped || running) {
+    if (lifecycle.signal.aborted || running) {
       return;
     }
     running = true;
     try {
-      await runGatewayUpdateCheck(params);
+      await runGatewayUpdateCheck({ ...params, signal: lifecycle.signal });
     } catch {
       // Intentionally ignored: update checks should never crash the gateway loop.
     } finally {
       running = false;
     }
-    if (stopped) {
-      gatewayUpdateCampaign.clear();
+    if (lifecycle.signal.aborted) {
       return;
     }
     const intervalMs = resolveCheckIntervalMs(params.cfg, updateScheduleCache?.install?.kind);
@@ -1274,12 +1292,14 @@ export function scheduleGatewayUpdateCheck(params: {
   void tick();
   return () => {
     stopRemoteCatalogRefresh();
-    stopped = true;
+    lifecycle.abort();
     if (timer) {
       clearTimeout(timer);
       timer = null;
     }
-    gatewayUpdateCampaign.clear();
+    if (updateCheckLifecycle === lifecycle) {
+      gatewayUpdateCampaign.clear();
+    }
   };
 }
 

--- a/ui/src/app/overlays-types.ts
+++ b/ui/src/app/overlays-types.ts
@@ -3,7 +3,7 @@ import type { DevicePairSetupAccess, DevicePairSetupLifecycle } from "../lib/dev
 import type { ExecApprovalDecision, ExecApprovalRequest } from "./exec-approval.ts";
 import type { ApplicationStatusBanner, RecordedUpdateAttempt } from "./update-overlay-helpers.ts";
 
-export type ApplicationOverlaySnapshot = {
+export type ApplicationUpdateOverlaySnapshot = {
   updateAvailable: UpdateAvailable | null;
   updateSchedule: UpdateScheduleState | null;
   heldUpdateCampaignId: string | null;
@@ -14,6 +14,9 @@ export type ApplicationOverlaySnapshot = {
   updateStatusBanner: ApplicationStatusBanner | null;
   recordedUpdateAttempt: RecordedUpdateAttempt | null;
   controlUiRefreshRequired: boolean;
+};
+
+export type ApplicationOverlaySnapshot = ApplicationUpdateOverlaySnapshot & {
   approvalQueue: readonly ExecApprovalRequest[];
   approvalBusy: boolean;
   approvalCanGrant: boolean;

--- a/ui/src/app/overlays-update-campaign.test.ts
+++ b/ui/src/app/overlays-update-campaign.test.ts
@@ -12,7 +12,289 @@ import { createApplicationOverlays } from "./overlays.ts";
 
 afterEach(() => vi.useRealTimers());
 
+const AUTO_UPDATE_SCHEDULE = {
+  channel: "stable",
+  autoEnabled: true,
+  target: { kind: "package", version: "2.0.0" },
+  campaign: {
+    id: "campaign-auto",
+    state: "countdown",
+    announcedAtMs: 1_000,
+    applyAtMs: 61_000,
+    forceAtMs: 901_000,
+    updatedAtMs: 1_000,
+  },
+} as const;
+
+function createAutomaticUpdateHarness(request: RequestFn) {
+  const harness = createGatewayHarness(client(request));
+  harness.update({
+    hello: {
+      auth: { role: "operator", scopes: ["operator.admin"] },
+      snapshot: { updateSchedule: AUTO_UPDATE_SCHEDULE },
+    } as ApplicationGatewaySnapshot["hello"],
+  });
+  return harness;
+}
+
 describe("application update campaign overlays", () => {
+  it("owns the running interlock while an automatic campaign applies", async () => {
+    const request = vi.fn<RequestFn>(async () => ({}));
+    const harness = createAutomaticUpdateHarness(request);
+    const overlays = createApplicationOverlays(harness.gateway);
+    try {
+      harness.emitEvent("update.available", {
+        schedule: {
+          ...AUTO_UPDATE_SCHEDULE,
+          campaign: {
+            ...AUTO_UPDATE_SCHEDULE.campaign,
+            state: "applying",
+            updatedAtMs: 61_000,
+          },
+        },
+      });
+
+      // This published fact also suspends writes at the app-lifetime config owner.
+      expect(overlays.snapshot.updateRunning).toBe(true);
+      await overlays.runUpdate();
+      await expect(overlays.holdUpdate()).resolves.toBe(false);
+      expect(request.mock.calls.map(([method]) => method)).not.toContain("update.run");
+      expect(request.mock.calls.map(([method]) => method)).not.toContain("update.hold");
+
+      harness.emitEvent("update.available", {
+        schedule: { channel: "stable", autoEnabled: true },
+      });
+      expect(overlays.snapshot.updateRunning).toBe(false);
+    } finally {
+      overlays.dispose();
+    }
+  });
+
+  it("reads the recorded outcome when an automatic campaign ends between polls", async () => {
+    vi.useFakeTimers();
+    const request = vi.fn<RequestFn>(async (method) =>
+      method === "update.status"
+        ? {
+            sentinel: {
+              kind: "update",
+              status: "error",
+              ts: 62_000,
+              stats: { reason: "build-failed", mode: "git" },
+            },
+            schedule: { channel: "stable", autoEnabled: true },
+          }
+        : {},
+    );
+    const harness = createAutomaticUpdateHarness(request);
+    const overlays = createApplicationOverlays(harness.gateway);
+    try {
+      harness.emitEvent("update.available", {
+        schedule: {
+          ...AUTO_UPDATE_SCHEDULE,
+          campaign: {
+            ...AUTO_UPDATE_SCHEDULE.campaign,
+            state: "applying",
+            updatedAtMs: 61_000,
+          },
+        },
+      });
+      harness.emitEvent("update.available", {
+        schedule: { channel: "stable", autoEnabled: true },
+      });
+      await vi.advanceTimersByTimeAsync(5_000);
+      await flushMicrotasks();
+
+      expect(overlays.snapshot.updateStatusBanner?.text).toContain("build-failed");
+      expect(overlays.snapshot.recordedUpdateAttempt).toMatchObject({
+        timestampMs: 62_000,
+        status: "error",
+        reason: "build-failed",
+      });
+      expect(overlays.snapshot.updateSchedule?.campaign).toBeUndefined();
+      const statusRequests = request.mock.calls.filter(([method]) => method === "update.status");
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(request.mock.calls.filter(([method]) => method === "update.status")).toHaveLength(
+        statusRequests.length,
+      );
+    } finally {
+      overlays.dispose();
+    }
+  });
+
+  it.each(["manual refresh", "campaign poll"])(
+    "does not let a %s replace a newer campaign event",
+    async (source) => {
+      vi.useFakeTimers();
+      const updateStatus = deferred();
+      const request = vi.fn<RequestFn>((method) =>
+        method === "update.status" ? updateStatus.promise : Promise.resolve({}),
+      );
+      const harness = createAutomaticUpdateHarness(request);
+      const overlays = createApplicationOverlays(harness.gateway);
+      try {
+        const refresh = source === "manual refresh" ? overlays.refreshUpdateStatus() : undefined;
+        if (source === "campaign poll") {
+          await vi.advanceTimersByTimeAsync(5_000);
+        }
+        expect(request.mock.calls.filter(([method]) => method === "update.status")).toHaveLength(1);
+        harness.emitEvent("update.available", {
+          schedule: {
+            ...AUTO_UPDATE_SCHEDULE,
+            campaign: {
+              ...AUTO_UPDATE_SCHEDULE.campaign,
+              state: "applying",
+              updatedAtMs: 61_000,
+            },
+          },
+        });
+        updateStatus.resolve({
+          sentinel: {
+            kind: "update",
+            status: "error",
+            ts: 500,
+            stats: { reason: "previous-build-failed" },
+          },
+          schedule: AUTO_UPDATE_SCHEDULE,
+        });
+        await refresh;
+        await flushMicrotasks();
+
+        expect(overlays.snapshot.updateSchedule?.campaign?.state).toBe("applying");
+        expect(overlays.snapshot.updateStatusBanner).toBeNull();
+        expect(overlays.snapshot.updateStatusRefreshing).toBe(false);
+      } finally {
+        updateStatus.resolve({});
+        overlays.dispose();
+      }
+    },
+  );
+
+  it.each(["campaign ended", "disconnect", "dispose"])(
+    "does not restart an in-flight campaign poll after %s",
+    async (boundary) => {
+      vi.useFakeTimers();
+      const updateStatus = deferred();
+      const request = vi.fn<RequestFn>((method) =>
+        method === "update.status" ? updateStatus.promise : Promise.resolve({}),
+      );
+      const harness = createAutomaticUpdateHarness(request);
+      const overlays = createApplicationOverlays(harness.gateway);
+      try {
+        await vi.advanceTimersByTimeAsync(5_000);
+        expect(request.mock.calls.filter(([method]) => method === "update.status")).toHaveLength(1);
+        if (boundary === "campaign ended") {
+          harness.emitEvent("update.available", {
+            schedule: { channel: "stable", autoEnabled: true },
+          });
+        } else if (boundary === "disconnect") {
+          harness.update({ phase: "reconnecting" });
+        } else {
+          overlays.dispose();
+        }
+        updateStatus.resolve({ schedule: AUTO_UPDATE_SCHEDULE });
+        await flushMicrotasks();
+        await vi.advanceTimersByTimeAsync(10_000);
+
+        expect(request.mock.calls.filter(([method]) => method === "update.status")).toHaveLength(1);
+      } finally {
+        updateStatus.resolve({});
+        overlays.dispose();
+      }
+    },
+  );
+
+  it("keeps a manual status check's error visible when campaign polling becomes due", async () => {
+    vi.useFakeTimers();
+    const manualStatus = deferred();
+    const request = vi.fn<RequestFn>((method, params) => {
+      if (method !== "update.status") {
+        return Promise.resolve({});
+      }
+      return (params as { refreshCheckout?: boolean }).refreshCheckout
+        ? manualStatus.promise
+        : Promise.resolve({ schedule: AUTO_UPDATE_SCHEDULE });
+    });
+    const harness = createAutomaticUpdateHarness(request);
+    const overlays = createApplicationOverlays(harness.gateway);
+    try {
+      const refresh = overlays.refreshUpdateStatus();
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(overlays.snapshot.updateStatusRefreshing).toBe(true);
+
+      manualStatus.reject(new Error("manual status unavailable"));
+      await refresh;
+
+      expect(overlays.snapshot.updateStatusRefreshing).toBe(false);
+      expect(overlays.snapshot.updateStatusBanner?.text).toContain("manual status unavailable");
+    } finally {
+      manualStatus.resolve({});
+      overlays.dispose();
+    }
+  });
+
+  it.each([false, true])(
+    "discards an explicit refresh after administrator access is revoked (restored: %s)",
+    async (restoreAdmin) => {
+      const updateStatus = deferred();
+      let statusReads = 0;
+      const request = vi.fn<RequestFn>((method) => {
+        if (method !== "update.status") {
+          return Promise.resolve({});
+        }
+        statusReads += 1;
+        return statusReads === 1
+          ? Promise.resolve({
+              sentinel: {
+                kind: "update",
+                status: "error",
+                ts: 500,
+                stats: { reason: "retained-admin-only-attempt" },
+              },
+            })
+          : updateStatus.promise;
+      });
+      const harness = createAutomaticUpdateHarness(request);
+      const overlays = createApplicationOverlays(harness.gateway);
+      try {
+        await overlays.refreshUpdateStatus();
+        expect(overlays.snapshot.recordedUpdateAttempt?.reason).toBe("retained-admin-only-attempt");
+        const refresh = overlays.refreshUpdateStatus();
+        harness.update({
+          hello: {
+            auth: { role: "operator", scopes: ["operator.read"] },
+            snapshot: { updateSchedule: AUTO_UPDATE_SCHEDULE },
+          } as ApplicationGatewaySnapshot["hello"],
+        });
+        expect(overlays.snapshot.updateStatusBanner).toBeNull();
+        expect(overlays.snapshot.recordedUpdateAttempt).toBeNull();
+        if (restoreAdmin) {
+          harness.update({
+            hello: {
+              auth: { role: "operator", scopes: ["operator.admin"] },
+              snapshot: { updateSchedule: AUTO_UPDATE_SCHEDULE },
+            } as ApplicationGatewaySnapshot["hello"],
+          });
+        }
+        updateStatus.resolve({
+          sentinel: {
+            kind: "update",
+            status: "error",
+            ts: 62_000,
+            stats: { reason: "admin-only-attempt" },
+          },
+        });
+        await refresh;
+
+        expect(overlays.snapshot.updateStatusBanner).toBeNull();
+        expect(overlays.snapshot.recordedUpdateAttempt).toBeNull();
+        expect(overlays.snapshot.updateStatusRefreshing).toBe(false);
+      } finally {
+        updateStatus.resolve({});
+        overlays.dispose();
+      }
+    },
+  );
+
   it("refreshes an explicit dev checkout comparison on demand", async () => {
     const request = vi.fn<RequestFn>(async (method) =>
       method === "update.status"

--- a/ui/src/app/overlays-update-campaign.test.ts
+++ b/ui/src/app/overlays-update-campaign.test.ts
@@ -637,6 +637,61 @@ describe("application update campaign overlays", () => {
     overlays.dispose();
   });
 
+  it.each([
+    { boundary: "applying", reply: "success" },
+    { boundary: "applying", reply: "error" },
+    { boundary: "revoked", reply: "success" },
+    { boundary: "revoked", reply: "error" },
+  ])("does not publish a stale hold $reply after $boundary", async ({ boundary, reply }) => {
+    const holdReply = deferred();
+    const request = vi.fn<RequestFn>((method) =>
+      method === "update.hold" ? holdReply.promise : Promise.resolve({}),
+    );
+    const harness = createAutomaticUpdateHarness(request);
+    const overlays = createApplicationOverlays(harness.gateway);
+    const holding = overlays.holdUpdate();
+    try {
+      if (boundary === "applying") {
+        harness.emitEvent("update.available", {
+          schedule: {
+            ...AUTO_UPDATE_SCHEDULE,
+            campaign: { ...AUTO_UPDATE_SCHEDULE.campaign, state: "applying", updatedAtMs: 61_000 },
+          },
+        });
+      } else {
+        harness.update({
+          hello: {
+            auth: { role: "operator", scopes: ["operator.read"] },
+            snapshot: { updateSchedule: AUTO_UPDATE_SCHEDULE },
+          } as ApplicationGatewaySnapshot["hello"],
+        });
+      }
+      if (reply === "success") {
+        holdReply.resolve({
+          ok: true,
+          schedule: {
+            ...AUTO_UPDATE_SCHEDULE,
+            campaign: { ...AUTO_UPDATE_SCHEDULE.campaign, holdUntilMs: 3_601_000 },
+          },
+        });
+      } else {
+        holdReply.reject(new Error("retired hold response"));
+      }
+      await expect(holding).resolves.toBe(boundary === "applying" && reply === "success");
+
+      expect(overlays.snapshot.updateRunning).toBe(boundary === "applying");
+      expect(overlays.snapshot.updateSchedule?.campaign?.state).toBe(
+        boundary === "applying" ? "applying" : "countdown",
+      );
+      expect(overlays.snapshot.heldUpdateCampaignId).toBeNull();
+      expect(overlays.snapshot.updateStatusBanner).toBeNull();
+    } finally {
+      holdReply.resolve({});
+      await holding;
+      overlays.dispose();
+    }
+  });
+
   it("adopts an authoritative held schedule when update.hold returns false", async () => {
     const request = vi.fn<RequestFn>(async () => ({
       ok: false,

--- a/ui/src/app/overlays-update-continuity.test.ts
+++ b/ui/src/app/overlays-update-continuity.test.ts
@@ -1,0 +1,283 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as buildInfo from "../build-info.ts";
+import { showToast } from "../lib/toast.ts";
+import type { ApplicationGatewaySnapshot } from "./gateway.ts";
+import {
+  client,
+  createGatewayHarness,
+  deferred,
+  flushMicrotasks,
+  type RequestFn,
+} from "./overlays-access.test-support.ts";
+import { createApplicationOverlays } from "./overlays.ts";
+
+vi.mock("../lib/toast.ts", () => ({ showToast: vi.fn() }));
+
+const HANDOFF_MS = 35 * 60_000;
+const HANDOFF_ID = "handoff-current";
+const HANDOFF_RESPONSE = {
+  ok: true,
+  handoff: { status: "started" },
+  result: { status: "skipped", reason: "managed-service-handoff-started" },
+  sentinel: { payload: { stats: { handoffId: HANDOFF_ID } } },
+};
+const HANDOFF_PENDING = {
+  sentinel: {
+    kind: "update",
+    status: "skipped",
+    stats: { handoffId: HANDOFF_ID, reason: "managed-service-handoff-started" },
+  },
+};
+const HANDOFF_SUCCESS = {
+  sentinel: {
+    kind: "update",
+    status: "ok",
+    stats: { handoffId: HANDOFF_ID, after: { version: "2.0.0" } },
+  },
+};
+
+function createUpdateHarness(request: RequestFn) {
+  const harness = createGatewayHarness(client(request));
+  harness.update({
+    hello: {
+      auth: { role: "operator", scopes: ["operator.admin"] },
+      server: { version: "1.0.0" },
+      snapshot: {
+        updateAvailable: { channel: "stable", currentVersion: "1.0.0", latestVersion: "2.0.0" },
+      },
+    } as ApplicationGatewaySnapshot["hello"],
+  });
+  return harness;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(1_000_000);
+  vi.mocked(showToast).mockClear();
+  const values = new Map<string, string>();
+  vi.stubGlobal("sessionStorage", {
+    getItem: (key: string) => values.get(key) ?? null,
+    setItem: (key: string, value: string) => values.set(key, value),
+    removeItem: (key: string) => values.delete(key),
+  });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("application update attempt continuity", () => {
+  it("ends the waiting state when a failed-closed Gateway never reconnects", async () => {
+    const request = vi.fn<RequestFn>(async (method) =>
+      method === "update.run" ? HANDOFF_RESPONSE : {},
+    );
+    const harness = createUpdateHarness(request);
+    const overlays = createApplicationOverlays(harness.gateway);
+    try {
+      await overlays.runUpdate();
+      harness.update({ phase: "reconnecting", hello: null });
+      expect(overlays.snapshot.updateReconciliationPending).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(HANDOFF_MS);
+
+      expect(overlays.snapshot.updateReconciliationPending).toBe(false);
+      expect(overlays.snapshot.updateRunning).toBe(false);
+      expect(overlays.snapshot.updateStatusBanner).toMatchObject({ tone: "danger" });
+      expect(overlays.snapshot.updateStatusBanner?.text).toContain("openclaw update status");
+      expect(showToast).not.toHaveBeenCalled();
+    } finally {
+      overlays.dispose();
+    }
+  });
+
+  it("does not grant another handoff budget on a late reconnect", async () => {
+    const request = vi.fn<RequestFn>(async (method) =>
+      method === "update.run"
+        ? HANDOFF_RESPONSE
+        : method === "update.status"
+          ? HANDOFF_PENDING
+          : {},
+    );
+    const harness = createUpdateHarness(request);
+    const overlays = createApplicationOverlays(harness.gateway);
+    try {
+      await overlays.runUpdate();
+      harness.update({ phase: "reconnecting", hello: null });
+      await vi.advanceTimersByTimeAsync(HANDOFF_MS - 1_000);
+      harness.update({ phase: "connected" });
+      await flushMicrotasks();
+      expect(overlays.snapshot.updateReconciliationPending).toBe(true);
+
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect(overlays.snapshot.updateReconciliationPending).toBe(false);
+      expect(overlays.snapshot.updateStatusBanner?.tone).toBe("danger");
+    } finally {
+      overlays.dispose();
+    }
+  });
+
+  it.each(["before verification", "after verification"])(
+    "resumes after the stale document reloads %s and announces success once",
+    async (reloadMoment) => {
+      const firstRequest = vi.fn<RequestFn>(async (method) =>
+        method === "update.run"
+          ? HANDOFF_RESPONSE
+          : method === "update.status"
+            ? HANDOFF_SUCCESS
+            : {},
+      );
+      const firstHarness = createUpdateHarness(firstRequest);
+      const first = createApplicationOverlays(firstHarness.gateway);
+      await first.runUpdate();
+      if (reloadMoment === "after verification") {
+        vi.spyOn(buildInfo, "reloadControlUiIfStale")
+          .mockReturnValueOnce(true)
+          .mockReturnValue(false);
+        firstHarness.update({ phase: "reconnecting" });
+        firstHarness.update({ phase: "connected" });
+        await flushMicrotasks();
+        expect(first.snapshot.updateReconciliationPending).toBe(false);
+        expect(showToast).not.toHaveBeenCalled();
+      }
+      firstHarness.update({ phase: "reload-required", hello: null });
+      first.dispose();
+
+      const updateStatus = deferred();
+      const nextRequest = vi.fn<RequestFn>((method) =>
+        method === "update.status" ? updateStatus.promise : Promise.resolve({}),
+      );
+      const nextHarness = createUpdateHarness(nextRequest);
+      const next = createApplicationOverlays(nextHarness.gateway);
+      try {
+        await flushMicrotasks();
+        expect(next.snapshot.updateReconciliationPending).toBe(
+          reloadMoment === "before verification",
+        );
+        expect(nextRequest.mock.calls.map(([method]) => method)).toContain("update.status");
+        expect(nextRequest.mock.calls.map(([method]) => method)).not.toContain("update.run");
+
+        if (reloadMoment === "after verification") {
+          expect(showToast).toHaveBeenCalledOnce();
+        }
+        updateStatus.resolve(
+          reloadMoment === "before verification" ? HANDOFF_SUCCESS : { sentinel: null },
+        );
+        await flushMicrotasks();
+        expect(next.snapshot.updateReconciliationPending).toBe(false);
+        expect(showToast).toHaveBeenCalledOnce();
+        next.dispose();
+
+        const reloaded = createApplicationOverlays(nextHarness.gateway);
+        try {
+          await flushMicrotasks();
+          expect(reloaded.snapshot.updateReconciliationPending).toBe(false);
+          expect(showToast).toHaveBeenCalledOnce();
+        } finally {
+          reloaded.dispose();
+        }
+      } finally {
+        updateStatus.resolve({});
+        next.dispose();
+      }
+    },
+  );
+
+  it.each(["different Gateway", "revoked administrator", "expired attempt"] as const)(
+    "does not resume an update for a %s after reload",
+    async (boundary) => {
+      const request = vi.fn<RequestFn>(async (method) =>
+        method === "update.run" ? HANDOFF_RESPONSE : HANDOFF_SUCCESS,
+      );
+      const harness = createUpdateHarness(request);
+      const first = createApplicationOverlays(harness.gateway);
+      await first.runUpdate();
+      first.dispose();
+
+      if (boundary === "different Gateway") {
+        harness.gateway.connection.gatewayUrl = "ws://other-gateway.test";
+      } else if (boundary === "revoked administrator") {
+        harness.update({
+          hello: {
+            auth: { role: "operator", scopes: ["operator.read"] },
+          } as ApplicationGatewaySnapshot["hello"],
+        });
+      } else {
+        await vi.advanceTimersByTimeAsync(HANDOFF_MS + 1);
+      }
+      const reloaded = createApplicationOverlays(harness.gateway);
+      try {
+        await flushMicrotasks();
+        expect(reloaded.snapshot.updateReconciliationPending).toBe(false);
+        expect(showToast).not.toHaveBeenCalled();
+        if (boundary === "revoked administrator") {
+          harness.update({
+            hello: {
+              auth: { role: "operator", scopes: ["operator.admin"] },
+            } as ApplicationGatewaySnapshot["hello"],
+          });
+          await flushMicrotasks();
+          expect(reloaded.snapshot.updateReconciliationPending).toBe(false);
+          expect(showToast).not.toHaveBeenCalled();
+        }
+      } finally {
+        reloaded.dispose();
+      }
+    },
+  );
+
+  it("retires active reconciliation when the selected logical Gateway changes", async () => {
+    const request = vi.fn<RequestFn>(async (method) =>
+      method === "update.run" ? HANDOFF_RESPONSE : HANDOFF_SUCCESS,
+    );
+    const harness = createUpdateHarness(request);
+    const overlays = createApplicationOverlays(harness.gateway);
+    try {
+      await overlays.runUpdate();
+      harness.gateway.connection.gatewayUrl = "ws://other-gateway.test";
+      harness.update({ phase: "connecting", client: client(request), hello: null });
+
+      expect(overlays.snapshot.updateReconciliationPending).toBe(false);
+      harness.update({ phase: "connected" });
+      await flushMicrotasks();
+      expect(showToast).not.toHaveBeenCalled();
+    } finally {
+      overlays.dispose();
+    }
+  });
+
+  it.each(["ok", "error"])("ignores an earlier handoff's %s sentinel", async (status) => {
+    let response = {
+      sentinel: {
+        kind: "update",
+        status,
+        stats: { handoffId: "handoff-earlier", after: { version: "2.0.0" } },
+      },
+    };
+    const request = vi.fn<RequestFn>(async (method) =>
+      method === "update.run" ? HANDOFF_RESPONSE : method === "update.status" ? response : {},
+    );
+    const harness = createUpdateHarness(request);
+    const overlays = createApplicationOverlays(harness.gateway);
+    try {
+      await overlays.runUpdate();
+      harness.update({ phase: "reconnecting" });
+      harness.update({ phase: "connected" });
+      await flushMicrotasks();
+
+      expect(overlays.snapshot.updateReconciliationPending).toBe(true);
+      expect(overlays.snapshot.updateStatusBanner).toBeNull();
+      expect(showToast).not.toHaveBeenCalled();
+
+      response = HANDOFF_SUCCESS;
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(overlays.snapshot.updateReconciliationPending).toBe(false);
+      expect(showToast).toHaveBeenCalledOnce();
+    } finally {
+      overlays.dispose();
+    }
+  });
+});

--- a/ui/src/app/overlays-update-race.test.ts
+++ b/ui/src/app/overlays-update-race.test.ts
@@ -42,6 +42,63 @@ afterEach(() => {
 });
 
 describe("application update reconciliation races", () => {
+  it("preserves a verified campaign outcome when update.run rejects afterward", async () => {
+    const updateRun = deferred();
+    const request = vi.fn<RequestFn>((method) => {
+      if (method === "update.run") {
+        return updateRun.promise;
+      }
+      return Promise.resolve(
+        method === "update.status"
+          ? {
+              sentinel: {
+                kind: "update",
+                status: "ok",
+                stats: { after: { version: "2.0.0" } },
+              },
+            }
+          : [],
+      );
+    });
+    const harness = createGatewayHarness(client(request));
+    const overlays = createApplicationOverlays(harness.gateway);
+    const schedule = {
+      channel: "stable",
+      autoEnabled: true,
+      target: { kind: "package", version: "2.0.0" },
+    };
+    const running = overlays.runUpdate();
+    try {
+      await flushMicrotasks();
+      expect(request).toHaveBeenCalledWith("update.run", {});
+      harness.emitEvent("update.available", {
+        schedule: {
+          ...schedule,
+          campaign: {
+            id: "manual-campaign",
+            state: "applying",
+            announcedAtMs: 1_000,
+            forceAtMs: 1_000,
+            updatedAtMs: 1_000,
+          },
+        },
+      });
+      harness.emitEvent("update.available", { schedule });
+      await flushMicrotasks();
+      expect(overlays.snapshot.updateReconciliationPending).toBe(false);
+      expect(overlays.snapshot.updateStatusBanner).toBeNull();
+
+      updateRun.reject(new Error("late-rpc-rejection"));
+      await running;
+
+      expect(overlays.snapshot.updateStatusBanner).toBeNull();
+    } finally {
+      updateRun.resolve({});
+      await running;
+      overlays.dispose();
+    }
+  });
+
   it("checks the authoritative sentinel when disconnect wins the update.run response race", async () => {
     installUpdateTranslations();
     const updateRun = deferred<{
@@ -256,10 +313,16 @@ describe("application update reconciliation races", () => {
       await overlays.runUpdate();
       expect(overlays.snapshot.updateReconciliationPending).toBe(true);
 
+      const statusRequestsBeforeReconnect = request.mock.calls.filter(
+        ([method]) => method === "update.status",
+      ).length;
       harness.update({ phase: "stopped" });
       harness.update({ phase: "connected" });
       await flushMicrotasks();
       expectUpdateStatusRequested(request);
+      expect(request.mock.calls.filter(([method]) => method === "update.status")).toHaveLength(
+        statusRequestsBeforeReconnect + 1,
+      );
 
       harness.update({
         hello: {
@@ -286,7 +349,9 @@ describe("application update reconciliation races", () => {
         tone: "danger",
         text: UNKNOWN_OUTCOME_TEXT,
       });
-      expect(request.mock.calls.filter(([method]) => method === "update.status")).toHaveLength(1);
+      expect(request.mock.calls.filter(([method]) => method === "update.status")).toHaveLength(
+        statusRequestsBeforeReconnect + 1,
+      );
     } finally {
       updateStatus.resolve({});
       overlays.dispose();

--- a/ui/src/app/overlays-updates.ts
+++ b/ui/src/app/overlays-updates.ts
@@ -1,0 +1,513 @@
+import { gatewayCredentialScope } from "@openclaw/gateway-client/browser";
+import type { GatewayUpdateAvailableEventPayload } from "../../../src/gateway/events.js";
+import type { UpdateHoldResult } from "../api/types.ts";
+import { controlUiBuildDiffersFrom } from "../build-info.ts";
+import { t } from "../i18n/index.ts";
+import { formatUiError } from "../lib/format-error.ts";
+import type { ApplicationGateway } from "./gateway.ts";
+import { readGatewayOperatorAccess } from "./operator-access.ts";
+import type { ApplicationUpdateOverlaySnapshot } from "./overlays-types.ts";
+import {
+  classifyUpdateRunResponse,
+  createUpdateCampaignStatusPoller,
+  createUpdateStatusRefresher,
+  createUpdateVerificationController,
+  projectUpdateStatusResponse,
+  resolveExpectedUpdateSha,
+  resolveUnknownUpdateOutcomeBanner,
+  resolveUpdateStatusBanner,
+  UPDATE_HANDOFF_TIMEOUT_MS,
+  type ApplicationStatusBanner,
+  type PendingUpdateReconciliation,
+  type UpdateRestartStatusResponse,
+  type UpdateRunResponse,
+} from "./update-overlay-helpers.ts";
+import { readUpdateScheduleValue } from "./update-schedule-dto.ts";
+import {
+  projectConnectedUpdateSnapshot,
+  projectUpdateAvailableEvent,
+  resolveHeldUpdateCampaignId,
+} from "./update-schedule-projection.ts";
+import {
+  announceRecordedUpdateSuccess,
+  announceVerifiedUpdateInstall,
+  readUpdateNotice,
+  writeUpdateNotice,
+} from "./update-success-notice.ts";
+
+export type ApplicationUpdateOverlayHooks = {
+  /** Barrier awaited after update-running is published and before update.run
+   * is issued, so in-flight config writes cannot overlap the install. */
+  drainConfigWrites?: () => Promise<void>;
+};
+
+export function createApplicationUpdateOverlays(
+  gateway: ApplicationGateway,
+  onChange: () => void,
+  hooks: ApplicationUpdateOverlayHooks = {},
+) {
+  let snapshot: ApplicationUpdateOverlaySnapshot = {
+    updateAvailable: null,
+    updateSchedule: null,
+    heldUpdateCampaignId: null,
+    updateRunning: false,
+    updateStatusRefreshing: false,
+    updateCampaignStatusHydrated: true,
+    updateReconciliationPending: false,
+    updateStatusBanner: null,
+    recordedUpdateAttempt: null,
+    controlUiRefreshRequired: false,
+  };
+  let disposed = false;
+  let activeClient = gateway.snapshot.client;
+  let activeHello = gateway.snapshot.hello;
+  let connectedSource: NonNullable<typeof activeClient> | null = null;
+  let connectedEpoch = 0;
+  let operatorAccess = readGatewayOperatorAccess(gateway.snapshot);
+  let updateGatewayScope = gatewayCredentialScope(gateway.connection.gatewayUrl);
+  const savedUpdate = readUpdateNotice(updateGatewayScope);
+  let pendingUpdate: PendingUpdateReconciliation | null =
+    savedUpdate && savedUpdate.kind !== "verified" ? savedUpdate : null;
+  let pendingUpdateProfileId = savedUpdate?.profileId ?? null;
+  let pendingUpdateTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  let updateRequestRunning = false;
+  let updateStatusRevision = 0;
+  let updateRunGeneration = 0;
+  let updateHoldInFlight = false;
+
+  function publish() {
+    snapshot = {
+      ...snapshot,
+      updateRunning:
+        updateRequestRunning || snapshot.updateSchedule?.campaign?.state === "applying",
+      // The update RPC can finish before its restart handoff. Keep consumers
+      // locked until the replacement Gateway reports the authoritative result.
+      updateReconciliationPending: pendingUpdate !== null,
+    };
+    onChange();
+  }
+  const isCurrentClient = (client: NonNullable<typeof activeClient>) =>
+    !disposed &&
+    activeClient === client &&
+    gateway.snapshot.client === client &&
+    gateway.snapshot.phase === "connected";
+
+  const publishUpdateBanner = (updateStatusBanner: ApplicationStatusBanner | null) => {
+    snapshot = { ...snapshot, updateStatusBanner };
+    publish();
+  };
+  const publishRecordedUpdateAttempt = (
+    recordedUpdateAttempt: ApplicationUpdateOverlaySnapshot["recordedUpdateAttempt"],
+  ) => {
+    snapshot = { ...snapshot, recordedUpdateAttempt };
+    publish();
+  };
+  const noticeScope = () => ({
+    gateway: updateGatewayScope,
+    profileId: gateway.snapshot.selfUser?.id ?? null,
+  });
+  const clearPendingUpdateTimer = () => {
+    if (pendingUpdateTimer !== null) {
+      globalThis.clearTimeout(pendingUpdateTimer);
+      pendingUpdateTimer = null;
+    }
+  };
+  const setPendingUpdate = (pending: PendingUpdateReconciliation | null) => {
+    pendingUpdate = pending;
+    clearPendingUpdateTimer();
+    writeUpdateNotice(
+      pending
+        ? { ...pending, gateway: updateGatewayScope, profileId: pendingUpdateProfileId }
+        : null,
+    );
+    if (pending) {
+      // This budget belongs to admission, not reconnect. A failed-closed
+      // Gateway may never return to run the verification loop below.
+      pendingUpdateTimer = globalThis.setTimeout(
+        () => {
+          if (disposed || pendingUpdate !== pending) {
+            return;
+          }
+          updateRunGeneration += 1;
+          updateVerification.cancel();
+          updateRequestRunning = false;
+          setPendingUpdate(null);
+          publishUpdateBanner(resolveUnknownUpdateOutcomeBanner());
+        },
+        Math.max(0, pending.deadlineAtMs - Date.now()),
+      );
+    }
+  };
+  const updateVerification = createUpdateVerificationController({
+    getPending: () => pendingUpdate,
+    clearPending: () => {
+      setPendingUpdate(null);
+    },
+    isCurrent: (client, epoch) => epoch === connectedEpoch && isCurrentClient(client),
+    getHello: () => gateway.snapshot.hello,
+    publish,
+    publishBanner: publishUpdateBanner,
+    publishRecordedAttempt: publishRecordedUpdateAttempt,
+    publishRecordedFailure: ({ attempt, banner }) => {
+      // Both facts terminate the same reconciliation. Publishing either first
+      // exposes a false success or a failure without its recorded cause.
+      snapshot = { ...snapshot, recordedUpdateAttempt: attempt, updateStatusBanner: banner };
+      publish();
+    },
+    onVerifiedInstall: (identity) => announceVerifiedUpdateInstall(identity, noticeScope()),
+  });
+  const applyUpdateStatusResponse = (response: UpdateRestartStatusResponse) => {
+    // The admitted attempt has its own identity-aware verifier. A page refresh
+    // must not race it with an unrelated retained sentinel.
+    if (pendingUpdate) {
+      return;
+    }
+    snapshot = {
+      ...snapshot,
+      ...projectUpdateStatusResponse(response, {
+        updateStatusBanner: snapshot.updateStatusBanner,
+        recordedUpdateAttempt: snapshot.recordedUpdateAttempt,
+        heldUpdateCampaignId: snapshot.heldUpdateCampaignId,
+      }),
+      updateCampaignStatusHydrated: true,
+    };
+    publish();
+  };
+  const refreshUpdateStatus = createUpdateStatusRefresher({
+    getClient: () => activeClient,
+    getEpoch: () => connectedEpoch,
+    getRevision: () => updateStatusRevision,
+    canRefresh: () => !disposed && operatorAccess.canAdmin,
+    isCurrent: (client, epoch) => epoch === connectedEpoch && isCurrentClient(client),
+    onRefreshing: (updateStatusRefreshing) => {
+      snapshot = { ...snapshot, updateStatusRefreshing };
+      publish();
+    },
+    onStatus: applyUpdateStatusResponse,
+    onError: (error) => {
+      publishUpdateBanner({
+        tone: "danger",
+        text: t("updates.error", { error: formatUiError(error) }),
+      });
+    },
+  });
+  const updateCampaignPoller = createUpdateCampaignStatusPoller({
+    canPoll: () =>
+      Boolean(activeClient && isCurrentClient(activeClient) && snapshot.updateSchedule?.campaign) &&
+      operatorAccess.canAdmin,
+    refresh: () => refreshUpdateStatus("background"),
+  });
+
+  const synchronizeGateway = (next: ApplicationGateway["snapshot"]) => {
+    const nextGatewayScope = gatewayCredentialScope(gateway.connection.gatewayUrl);
+    if (nextGatewayScope !== updateGatewayScope) {
+      updateRunGeneration += 1;
+      updateStatusRevision += 1;
+      updateVerification.cancel();
+      setPendingUpdate(null);
+      updateRequestRunning = false;
+      updateGatewayScope = nextGatewayScope;
+      snapshot = {
+        ...snapshot,
+        updateStatusBanner: null,
+        recordedUpdateAttempt: null,
+        heldUpdateCampaignId: null,
+      };
+    }
+    const helloChanged = activeHello !== next.hello;
+    const connected = next.phase === "connected";
+    const nextConnectedSource = connected ? next.client : null;
+    const connectedSourceChanged = connectedSource !== nextConnectedSource;
+    const nextOperatorAccess = readGatewayOperatorAccess(next);
+    if (operatorAccess.canAdmin && !nextOperatorAccess.canAdmin) {
+      updateRunGeneration += 1;
+      updateStatusRevision += 1;
+      updateVerification.cancel();
+      const updateStatusBanner = pendingUpdate ? resolveUnknownUpdateOutcomeBanner() : null;
+      setPendingUpdate(null);
+      updateRequestRunning = false;
+      snapshot = {
+        ...snapshot,
+        updateStatusRefreshing: false,
+        updateStatusBanner,
+        recordedUpdateAttempt: null,
+      };
+    }
+    operatorAccess = nextOperatorAccess;
+    activeClient = next.client;
+    activeHello = next.hello;
+    connectedSource = nextConnectedSource;
+    if (connectedSourceChanged) {
+      updateRunGeneration += 1;
+      updateStatusRevision += 1;
+      updateVerification.cancel();
+    }
+    if (!connected || !next.client) {
+      updateRequestRunning = false;
+      snapshot = {
+        ...snapshot,
+        updateAvailable: null,
+        updateSchedule: null,
+        updateStatusRefreshing: false,
+        updateCampaignStatusHydrated: true,
+      };
+      updateCampaignPoller.stop();
+      if (next.phase === "reload-required") {
+        snapshot = { ...snapshot, controlUiRefreshRequired: true };
+      } else if (!next.client) {
+        connectedEpoch = 0;
+        snapshot = { ...snapshot, controlUiRefreshRequired: false };
+      } else if (next.hello) {
+        snapshot = { ...snapshot, controlUiRefreshRequired: true };
+      }
+      publish();
+      return;
+    }
+    if (
+      pendingUpdate &&
+      (!operatorAccess.canAdmin || pendingUpdateProfileId !== (next.selfUser?.id ?? null))
+    ) {
+      updateRunGeneration += 1;
+      updateStatusRevision += 1;
+      updateVerification.cancel();
+      setPendingUpdate(null);
+      snapshot = { ...snapshot, updateStatusBanner: resolveUnknownUpdateOutcomeBanner() };
+    }
+    const serverBuildIdentity = {
+      version: next.hello?.server?.version,
+      buildId: next.hello?.server?.buildId,
+      controlUiBuildSource: next.hello?.server?.controlUiBuildSource,
+    };
+    const exactBuildIdentityAvailable = Boolean(serverBuildIdentity.buildId?.trim());
+    snapshot = {
+      ...snapshot,
+      ...(connectedSourceChanged || helloChanged
+        ? projectConnectedUpdateSnapshot(snapshot, next.hello)
+        : {}),
+      controlUiRefreshRequired: connectedSourceChanged
+        ? (exactBuildIdentityAvailable || connectedEpoch > 0) &&
+          controlUiBuildDiffersFrom(serverBuildIdentity)
+        : snapshot.controlUiRefreshRequired,
+    };
+    publish();
+    updateCampaignPoller.sync();
+    if (connectedSourceChanged) {
+      connectedEpoch += 1;
+      announceRecordedUpdateSuccess(operatorAccess.canAdmin ? noticeScope() : null);
+      if (pendingUpdate && operatorAccess.canAdmin) {
+        void updateVerification.verify(next.client, connectedEpoch);
+      } else if (operatorAccess.canAdmin && !snapshot.updateSchedule?.campaign) {
+        // A new bundle has no in-memory campaign history. Hydrate the Gateway's
+        // retained result so an automatic update failure survives that reload.
+        void refreshUpdateStatus("background");
+      }
+    }
+  };
+
+  // Construction only restores the timer. The outer overlay owner initializes
+  // its snapshot before forwarding the first Gateway state that publishes here.
+  if (pendingUpdate) {
+    setPendingUpdate(pendingUpdate);
+  }
+
+  return {
+    get snapshot() {
+      return snapshot;
+    },
+    synchronizeGateway,
+    handleUpdateAvailable(payload: GatewayUpdateAvailableEventPayload | undefined) {
+      if (disposed) {
+        return;
+      }
+      const previousCampaign = snapshot.updateSchedule?.campaign;
+      updateStatusRevision += 1;
+      snapshot = {
+        ...snapshot,
+        ...projectUpdateAvailableEvent(snapshot, payload),
+      };
+      publish();
+      updateCampaignPoller.sync();
+      if (
+        previousCampaign?.state === "applying" &&
+        snapshot.updateSchedule?.campaign?.state !== "applying" &&
+        activeClient &&
+        operatorAccess.canAdmin
+      ) {
+        // Completion can arrive between polls. The producer records its outcome
+        // before removing the campaign, so removal still needs one final read.
+        if (pendingUpdate) {
+          void updateVerification.verify(activeClient, connectedEpoch);
+        } else {
+          void refreshUpdateStatus("completion");
+        }
+      }
+    },
+    refreshUpdateStatus,
+    async runUpdate(this: void) {
+      const client = gateway.snapshot.client;
+      if (
+        !client ||
+        gateway.snapshot.phase !== "connected" ||
+        disposed ||
+        snapshot.updateRunning ||
+        pendingUpdate !== null ||
+        !readGatewayOperatorAccess(gateway.snapshot).canAdmin
+      ) {
+        return;
+      }
+      const generation = ++updateRunGeneration;
+      updateStatusRevision += 1;
+      updateRequestRunning = true;
+      snapshot = {
+        ...snapshot,
+        updateStatusBanner: null,
+        recordedUpdateAttempt: null,
+      };
+      publish();
+      let admittedPending: PendingUpdateReconciliation | null = null;
+      try {
+        // updateRunning above suspends NEW config writes (bootstrap syncs it
+        // into the runtime-config capability); this barrier drains writes
+        // already in flight so none can commit or restart mid-install.
+        await hooks.drainConfigWrites?.();
+        if (
+          disposed ||
+          generation !== updateRunGeneration ||
+          snapshot.updateSchedule?.campaign?.state === "applying" ||
+          !readGatewayOperatorAccess(gateway.snapshot).canAdmin
+        ) {
+          return;
+        }
+        pendingUpdateProfileId = gateway.snapshot.selfUser?.id ?? null;
+        admittedPending = {
+          kind: "ambiguous",
+          expectedVersion: snapshot.updateAvailable?.latestVersion?.trim() || null,
+          expectedSha: resolveExpectedUpdateSha(snapshot.updateSchedule, snapshot.updateAvailable),
+          handoffId: null,
+          deadlineAtMs: Date.now() + UPDATE_HANDOFF_TIMEOUT_MS,
+        };
+        setPendingUpdate(admittedPending);
+        publish();
+        const response = await client.request<UpdateRunResponse>("update.run", {});
+        if (
+          disposed ||
+          generation !== updateRunGeneration ||
+          pendingUpdate !== admittedPending ||
+          activeClient !== client ||
+          gateway.snapshot.client !== client
+        ) {
+          return;
+        }
+        const accepted = classifyUpdateRunResponse(response, admittedPending);
+        if (accepted) {
+          setPendingUpdate(accepted.pending);
+          if (accepted.banner) {
+            snapshot = { ...snapshot, updateStatusBanner: accepted.banner };
+          }
+          return;
+        }
+        setPendingUpdate(null);
+        snapshot = {
+          ...snapshot,
+          updateStatusBanner: resolveUpdateStatusBanner({
+            status: response.result?.status ?? "error",
+            reason: response.result?.reason,
+          }),
+        };
+      } catch (error) {
+        if (
+          disposed ||
+          generation !== updateRunGeneration ||
+          pendingUpdate !== admittedPending ||
+          activeClient !== client ||
+          gateway.snapshot.client !== client
+        ) {
+          return;
+        }
+        setPendingUpdate(null);
+        snapshot = {
+          ...snapshot,
+          updateStatusBanner: {
+            tone: "danger",
+            text: t("updates.error", {
+              error: formatUiError(error),
+            }),
+          },
+        };
+      } finally {
+        if (
+          !disposed &&
+          generation === updateRunGeneration &&
+          activeClient === client &&
+          gateway.snapshot.client === client
+        ) {
+          updateRequestRunning = false;
+          publish();
+        }
+      }
+    },
+    async holdUpdate(this: void) {
+      const client = gateway.snapshot.client;
+      const campaign = snapshot.updateSchedule?.campaign;
+      const busy = updateHoldInFlight || snapshot.updateRunning || pendingUpdate !== null;
+      if (
+        !client ||
+        gateway.snapshot.phase !== "connected" ||
+        disposed ||
+        busy ||
+        !campaign ||
+        campaign.state === "applying" ||
+        snapshot.heldUpdateCampaignId === campaign.id ||
+        !readGatewayOperatorAccess(gateway.snapshot).canAdmin
+      ) {
+        return false;
+      }
+      const generation = updateRunGeneration;
+      const revision = updateStatusRevision;
+      const isCurrent = () =>
+        generation === updateRunGeneration &&
+        isCurrentClient(client) &&
+        readGatewayOperatorAccess(gateway.snapshot).canAdmin;
+      updateHoldInFlight = true;
+      try {
+        const response = await client.request<UpdateHoldResult>("update.hold", {});
+        if (!isCurrent()) {
+          return false;
+        }
+        const updateSchedule = response.schedule && readUpdateScheduleValue(response.schedule);
+        // Campaign events can beat the hold reply; acknowledge the request
+        // without replacing the newer schedule they already published.
+        if (revision === updateStatusRevision && (updateSchedule !== undefined || response.ok)) {
+          updateStatusRevision += 1;
+          snapshot = {
+            ...snapshot,
+            ...(updateSchedule !== undefined ? { updateSchedule } : {}),
+            heldUpdateCampaignId: response.ok
+              ? campaign.id
+              : resolveHeldUpdateCampaignId(
+                  updateSchedule ?? snapshot.updateSchedule,
+                  snapshot.heldUpdateCampaignId,
+                ),
+          };
+          publish();
+        }
+        return response.ok;
+      } catch (error) {
+        if (isCurrent() && revision === updateStatusRevision) {
+          const message = formatUiError(error);
+          publishUpdateBanner({ tone: "danger", text: t("updates.error", { error: message }) });
+        }
+        return false;
+      } finally {
+        updateHoldInFlight = false;
+      }
+    },
+    dispose() {
+      disposed = true;
+      updateRunGeneration += 1;
+      clearPendingUpdateTimer();
+      updateVerification.cancel();
+      updateCampaignPoller.stop();
+    },
+  };
+}

--- a/ui/src/app/overlays.test.ts
+++ b/ui/src/app/overlays.test.ts
@@ -566,7 +566,7 @@ describe("application approval overlays", () => {
   it("keeps a projected approval's resolve failure visible", async () => {
     let resolveAttempts = 0;
     const request = vi.fn<RequestFn>((method) => {
-      if (method.endsWith(".list")) {
+      if (method !== "exec.approval.resolve") {
         return Promise.resolve([]);
       }
       resolveAttempts += 1;
@@ -619,7 +619,7 @@ describe("application approval overlays", () => {
     const secondResolve = deferred();
     let resolveCalls = 0;
     const request = vi.fn<RequestFn>((method) => {
-      if (method.endsWith(".list")) {
+      if (method !== "exec.approval.resolve") {
         return Promise.resolve([]);
       }
       resolveCalls += 1;
@@ -652,7 +652,7 @@ describe("application approval overlays", () => {
     const firstResolve = deferred();
     let resolveCalls = 0;
     const request = vi.fn<RequestFn>((method) => {
-      if (method.endsWith(".list")) {
+      if (method !== "exec.approval.resolve") {
         return Promise.resolve([]);
       }
       resolveCalls += 1;
@@ -888,6 +888,7 @@ describe("application update overlays", () => {
   it("promotes restart health polling to the managed handoff budget", async () => {
     vi.useFakeTimers();
     let statusRequests = 0;
+    let updateFinished = false;
     const request = vi.fn<RequestFn>((method) => {
       if (method.endsWith(".list")) {
         return Promise.resolve([]);
@@ -901,7 +902,7 @@ describe("application update overlays", () => {
       if (method === "update.status") {
         statusRequests += 1;
         return Promise.resolve(
-          statusRequests <= 11
+          !updateFinished
             ? {
                 sentinel: {
                   kind: "update",
@@ -926,22 +927,24 @@ describe("application update overlays", () => {
 
     try {
       await overlays.runUpdate();
+      const statusRequestsBeforeReconnect = statusRequests;
       harness.update({ phase: "stopped" });
       harness.update({ phase: "connected" });
       await flushMicrotasks();
-      expect(statusRequests).toBe(1);
+      expect(statusRequests).toBe(statusRequestsBeforeReconnect + 1);
 
       harness.update({ sessionKey: "agent:main:next" });
       await vi.advanceTimersByTimeAsync(RESTART_VERIFICATION_TIMEOUT_MS);
       await flushMicrotasks();
 
-      expect(statusRequests).toBe(11);
+      expect(statusRequests).toBe(statusRequestsBeforeReconnect + 11);
       expect(overlays.snapshot.updateReconciliationPending).toBe(true);
 
+      updateFinished = true;
       await vi.advanceTimersByTimeAsync(HANDOFF_POLL_MS);
       await flushMicrotasks();
 
-      expect(statusRequests).toBe(12);
+      expect(statusRequests).toBe(statusRequestsBeforeReconnect + 12);
       expect(overlays.snapshot.updateStatusBanner).toBeNull();
       expect(overlays.snapshot.updateReconciliationPending).toBe(false);
     } finally {
@@ -1001,10 +1004,11 @@ describe("application update overlays", () => {
       expect(overlays.snapshot.updateReconciliationPending).toBe(true);
       expect(overlays.snapshot.updateStatusBanner).toBeNull();
 
+      const statusRequestsBeforeReconnect = statusRequests;
       harness.update({ phase: "stopped" });
       harness.update({ phase: "connected" });
       await flushMicrotasks();
-      expect(statusRequests).toBe(1);
+      expect(statusRequests).toBe(statusRequestsBeforeReconnect + 1);
       expect(overlays.snapshot.updateReconciliationPending).toBe(false);
       expect(overlays.snapshot.updateStatusBanner).toEqual({
         tone: "danger",

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -1,3 +1,4 @@
+import { gatewayCredentialScope } from "@openclaw/gateway-client/browser";
 import {
   GATEWAY_EVENT_UPDATE_AVAILABLE,
   type GatewayUpdateAvailableEventPayload,
@@ -40,7 +41,6 @@ import {
 import type { ApplicationOverlays, ApplicationOverlaySnapshot } from "./overlays-types.ts";
 import {
   classifyUpdateRunResponse,
-  createPendingUpdateReconciliation,
   createUpdateCampaignStatusPoller,
   createUpdateStatusRefresher,
   createUpdateVerificationController,
@@ -48,6 +48,7 @@ import {
   resolveExpectedUpdateSha,
   resolveUnknownUpdateOutcomeBanner,
   resolveUpdateStatusBanner,
+  UPDATE_HANDOFF_TIMEOUT_MS,
   type ApplicationStatusBanner,
   type PendingUpdateReconciliation,
   type UpdateRestartStatusResponse,
@@ -62,6 +63,8 @@ import {
 import {
   announceRecordedUpdateSuccess,
   announceVerifiedUpdateInstall,
+  readUpdateNotice,
+  writeUpdateNotice,
 } from "./update-success-notice.ts";
 
 function isGatewayEvent(value: unknown): value is GatewayEventFrame {
@@ -104,7 +107,14 @@ export function createApplicationOverlays(
   let operatorAccess = readGatewayOperatorAccess(gateway.snapshot);
   let approvalAccessGeneration = 0;
   let approvalGrantGeneration = 0;
-  let pendingUpdate: PendingUpdateReconciliation | null = null;
+  let updateGatewayScope = gatewayCredentialScope(gateway.connection.gatewayUrl);
+  const savedUpdate = readUpdateNotice(updateGatewayScope);
+  let pendingUpdate: PendingUpdateReconciliation | null =
+    savedUpdate && savedUpdate.kind !== "verified" ? savedUpdate : null;
+  let pendingUpdateProfileId = savedUpdate?.profileId ?? null;
+  let pendingUpdateTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  let updateRequestRunning = false;
+  let updateStatusRevision = 0;
   let updateRunGeneration = 0;
   let updateHoldInFlight = false;
   let approvalDecision: {
@@ -130,6 +140,8 @@ export function createApplicationOverlays(
   function publish() {
     snapshot = {
       ...snapshot,
+      updateRunning:
+        updateRequestRunning || snapshot.updateSchedule?.campaign?.state === "applying",
       // The update RPC can finish before its restart handoff. Keep consumers
       // locked until the replacement Gateway reports the authoritative result.
       updateReconciliationPending: pendingUpdate !== null,
@@ -185,10 +197,46 @@ export function createApplicationOverlays(
     snapshot = { ...snapshot, recordedUpdateAttempt };
     publish();
   };
+  const noticeScope = () => ({
+    gateway: updateGatewayScope,
+    profileId: gateway.snapshot.selfUser?.id ?? null,
+  });
+  const clearPendingUpdateTimer = () => {
+    if (pendingUpdateTimer !== null) {
+      globalThis.clearTimeout(pendingUpdateTimer);
+      pendingUpdateTimer = null;
+    }
+  };
+  const setPendingUpdate = (pending: PendingUpdateReconciliation | null) => {
+    pendingUpdate = pending;
+    clearPendingUpdateTimer();
+    writeUpdateNotice(
+      pending
+        ? { ...pending, gateway: updateGatewayScope, profileId: pendingUpdateProfileId }
+        : null,
+    );
+    if (pending) {
+      // This budget belongs to admission, not reconnect. A failed-closed
+      // Gateway may never return to run the verification loop below.
+      pendingUpdateTimer = globalThis.setTimeout(
+        () => {
+          if (disposed || pendingUpdate !== pending) {
+            return;
+          }
+          updateRunGeneration += 1;
+          updateVerification.cancel();
+          updateRequestRunning = false;
+          setPendingUpdate(null);
+          publishUpdateBanner(resolveUnknownUpdateOutcomeBanner());
+        },
+        Math.max(0, pending.deadlineAtMs - Date.now()),
+      );
+    }
+  };
   const updateVerification = createUpdateVerificationController({
     getPending: () => pendingUpdate,
     clearPending: () => {
-      pendingUpdate = null;
+      setPendingUpdate(null);
     },
     isCurrent: (client, epoch) => epoch === connectedEpoch && isCurrentClient(client),
     getHello: () => gateway.snapshot.hello,
@@ -201,9 +249,14 @@ export function createApplicationOverlays(
       snapshot = { ...snapshot, recordedUpdateAttempt: attempt, updateStatusBanner: banner };
       publish();
     },
-    onVerifiedInstall: announceVerifiedUpdateInstall,
+    onVerifiedInstall: (identity) => announceVerifiedUpdateInstall(identity, noticeScope()),
   });
   const applyUpdateStatusResponse = (response: UpdateRestartStatusResponse) => {
+    // The admitted attempt has its own identity-aware verifier. A page refresh
+    // must not race it with an unrelated retained sentinel.
+    if (pendingUpdate) {
+      return;
+    }
     snapshot = {
       ...snapshot,
       ...projectUpdateStatusResponse(response, {
@@ -215,18 +268,11 @@ export function createApplicationOverlays(
     };
     publish();
   };
-  const updateCampaignPoller = createUpdateCampaignStatusPoller({
-    getClient: () => activeClient,
-    getEpoch: () => connectedEpoch,
-    canPoll: () => operatorAccess.canAdmin,
-    getSchedule: () => snapshot.updateSchedule,
-    isCurrent: (client, epoch) => epoch === connectedEpoch && isCurrentClient(client),
-    onStatus: applyUpdateStatusResponse,
-  });
   const refreshUpdateStatus = createUpdateStatusRefresher({
     getClient: () => activeClient,
     getEpoch: () => connectedEpoch,
-    canRefresh: () => operatorAccess.canAdmin,
+    getRevision: () => updateStatusRevision,
+    canRefresh: () => !disposed && operatorAccess.canAdmin,
     isCurrent: (client, epoch) => epoch === connectedEpoch && isCurrentClient(client),
     onRefreshing: (updateStatusRefreshing) => {
       snapshot = { ...snapshot, updateStatusRefreshing };
@@ -240,8 +286,29 @@ export function createApplicationOverlays(
       });
     },
   });
+  const updateCampaignPoller = createUpdateCampaignStatusPoller({
+    canPoll: () =>
+      Boolean(activeClient && isCurrentClient(activeClient) && snapshot.updateSchedule?.campaign) &&
+      operatorAccess.canAdmin,
+    refresh: () => refreshUpdateStatus("background"),
+  });
 
   const synchronizeGateway = (next: ApplicationGateway["snapshot"]) => {
+    const nextGatewayScope = gatewayCredentialScope(gateway.connection.gatewayUrl);
+    if (nextGatewayScope !== updateGatewayScope) {
+      updateRunGeneration += 1;
+      updateStatusRevision += 1;
+      updateVerification.cancel();
+      setPendingUpdate(null);
+      updateRequestRunning = false;
+      updateGatewayScope = nextGatewayScope;
+      snapshot = {
+        ...snapshot,
+        updateStatusBanner: null,
+        recordedUpdateAttempt: null,
+        heldUpdateCampaignId: null,
+      };
+    }
     const previousClient = activeClient;
     const helloChanged = activeHello !== next.hello;
     const connected = next.phase === "connected";
@@ -275,16 +342,16 @@ export function createApplicationOverlays(
       pairingPendingCount.invalidate({ clear: true });
       if (accessTransition.adminRevoked) {
         updateRunGeneration += 1;
+        updateStatusRevision += 1;
         updateVerification.cancel();
-        const updateStatusBanner = pendingUpdate
-          ? resolveUnknownUpdateOutcomeBanner()
-          : snapshot.updateStatusBanner;
-        pendingUpdate = null;
+        const updateStatusBanner = pendingUpdate ? resolveUnknownUpdateOutcomeBanner() : null;
+        setPendingUpdate(null);
+        updateRequestRunning = false;
         snapshot = {
           ...snapshot,
-          updateRunning: false,
           updateStatusRefreshing: false,
           updateStatusBanner,
+          recordedUpdateAttempt: null,
         };
       }
     }
@@ -301,6 +368,7 @@ export function createApplicationOverlays(
     devicePairSetupState.connected = connected;
     if (connectedSourceChanged) {
       updateRunGeneration += 1;
+      updateStatusRevision += 1;
       updateVerification.cancel();
     }
     if (previousClient !== next.client || !connected) {
@@ -316,6 +384,7 @@ export function createApplicationOverlays(
       clearExecApprovalTimers(promptState);
     }
     if (!connected || !next.client) {
+      updateRequestRunning = false;
       promptState.execApprovalQueue = [];
       promptState.execApprovalBusy = false;
       promptState.execApprovalErrors.clear();
@@ -323,7 +392,6 @@ export function createApplicationOverlays(
         ...snapshot,
         updateAvailable: null,
         updateSchedule: null,
-        updateRunning: false,
         updateStatusRefreshing: false,
         updateCampaignStatusHydrated: true,
       };
@@ -339,6 +407,16 @@ export function createApplicationOverlays(
       clearExecApprovalTimers(promptState);
       publish();
       return;
+    }
+    if (
+      pendingUpdate &&
+      (!operatorAccess.canAdmin || pendingUpdateProfileId !== (next.selfUser?.id ?? null))
+    ) {
+      updateRunGeneration += 1;
+      updateStatusRevision += 1;
+      updateVerification.cancel();
+      setPendingUpdate(null);
+      snapshot = { ...snapshot, updateStatusBanner: resolveUnknownUpdateOutcomeBanner() };
     }
     const serverBuildIdentity = {
       version: next.hello?.server?.version,
@@ -367,10 +445,17 @@ export function createApplicationOverlays(
     }
     if (connectedSourceChanged) {
       connectedEpoch += 1;
+      announceRecordedUpdateSuccess(operatorAccess.canAdmin ? noticeScope() : null);
       if (operatorAccess.canReviewApprovals) {
         void refreshApprovals(next.client, connectedEpoch, approvalAccessGeneration);
       }
-      void updateVerification.verify(next.client, connectedEpoch);
+      if (pendingUpdate && operatorAccess.canAdmin) {
+        void updateVerification.verify(next.client, connectedEpoch);
+      } else if (operatorAccess.canAdmin && !snapshot.updateSchedule?.campaign) {
+        // A new bundle has no in-memory campaign history. Hydrate the Gateway's
+        // retained result so an automatic update failure survives that reload.
+        void refreshUpdateStatus("background");
+      }
     } else if (accessTransition.reviewChanged && operatorAccess.canReviewApprovals) {
       void refreshApprovals(next.client, connectedEpoch, approvalAccessGeneration);
     }
@@ -401,12 +486,28 @@ export function createApplicationOverlays(
     }
     if (event.event === GATEWAY_EVENT_UPDATE_AVAILABLE) {
       const payload = event.payload as GatewayUpdateAvailableEventPayload | undefined;
+      const previousCampaign = snapshot.updateSchedule?.campaign;
+      updateStatusRevision += 1;
       snapshot = {
         ...snapshot,
         ...projectUpdateAvailableEvent(snapshot, payload),
       };
       publish();
       updateCampaignPoller.sync();
+      if (
+        previousCampaign?.state === "applying" &&
+        snapshot.updateSchedule?.campaign?.state !== "applying" &&
+        activeClient &&
+        operatorAccess.canAdmin
+      ) {
+        // Completion can arrive between polls. The producer records its outcome
+        // before removing the campaign, so removal still needs one final read.
+        if (pendingUpdate) {
+          void updateVerification.verify(activeClient, connectedEpoch);
+        } else {
+          void refreshUpdateStatus("completion");
+        }
+      }
       return;
     }
     if (
@@ -427,9 +528,10 @@ export function createApplicationOverlays(
       publish();
     }
   });
+  if (pendingUpdate) {
+    setPendingUpdate(pendingUpdate);
+  }
   synchronizeGateway(gateway.snapshot);
-  // A reload started by the previous document's verified install lands here.
-  announceRecordedUpdateSuccess();
 
   return {
     get snapshot() {
@@ -453,13 +555,15 @@ export function createApplicationOverlays(
         return;
       }
       const generation = ++updateRunGeneration;
+      updateStatusRevision += 1;
+      updateRequestRunning = true;
       snapshot = {
         ...snapshot,
-        updateRunning: true,
         updateStatusBanner: null,
         recordedUpdateAttempt: null,
       };
       publish();
+      let admittedPending: PendingUpdateReconciliation | null = null;
       try {
         // updateRunning above suspends NEW config writes (bootstrap syncs it
         // into the runtime-config capability); this barrier drains writes
@@ -468,34 +572,40 @@ export function createApplicationOverlays(
         if (
           disposed ||
           generation !== updateRunGeneration ||
+          snapshot.updateSchedule?.campaign?.state === "applying" ||
           !readGatewayOperatorAccess(gateway.snapshot).canAdmin
         ) {
           return;
         }
-        pendingUpdate = createPendingUpdateReconciliation(
-          "ambiguous",
-          snapshot.updateAvailable?.latestVersion?.trim() || null,
-          resolveExpectedUpdateSha(snapshot.updateSchedule, snapshot.updateAvailable),
-        );
+        pendingUpdateProfileId = gateway.snapshot.selfUser?.id ?? null;
+        admittedPending = {
+          kind: "ambiguous",
+          expectedVersion: snapshot.updateAvailable?.latestVersion?.trim() || null,
+          expectedSha: resolveExpectedUpdateSha(snapshot.updateSchedule, snapshot.updateAvailable),
+          handoffId: null,
+          deadlineAtMs: Date.now() + UPDATE_HANDOFF_TIMEOUT_MS,
+        };
+        setPendingUpdate(admittedPending);
         publish();
         const response = await client.request<UpdateRunResponse>("update.run", {});
         if (
           disposed ||
           generation !== updateRunGeneration ||
+          pendingUpdate !== admittedPending ||
           activeClient !== client ||
           gateway.snapshot.client !== client
         ) {
           return;
         }
-        const accepted = classifyUpdateRunResponse(response, pendingUpdate);
+        const accepted = classifyUpdateRunResponse(response, admittedPending);
         if (accepted) {
-          pendingUpdate = accepted.pending;
+          setPendingUpdate(accepted.pending);
           if (accepted.banner) {
             snapshot = { ...snapshot, updateStatusBanner: accepted.banner };
           }
           return;
         }
-        pendingUpdate = null;
+        setPendingUpdate(null);
         snapshot = {
           ...snapshot,
           updateStatusBanner: resolveUpdateStatusBanner({
@@ -507,12 +617,13 @@ export function createApplicationOverlays(
         if (
           disposed ||
           generation !== updateRunGeneration ||
+          pendingUpdate !== admittedPending ||
           activeClient !== client ||
           gateway.snapshot.client !== client
         ) {
           return;
         }
-        pendingUpdate = null;
+        setPendingUpdate(null);
         snapshot = {
           ...snapshot,
           updateStatusBanner: {
@@ -529,7 +640,7 @@ export function createApplicationOverlays(
           activeClient === client &&
           gateway.snapshot.client === client
         ) {
-          snapshot = { ...snapshot, updateRunning: false };
+          updateRequestRunning = false;
           publish();
         }
       }
@@ -688,6 +799,7 @@ export function createApplicationOverlays(
       disposed = true;
       approvalDecision = null;
       updateRunGeneration += 1;
+      clearPendingUpdateTimer();
       pairingPendingCount.invalidate();
       updateVerification.cancel();
       updateCampaignPoller.stop();

--- a/ui/src/app/overlays.ts
+++ b/ui/src/app/overlays.ts
@@ -1,11 +1,8 @@
-import { gatewayCredentialScope } from "@openclaw/gateway-client/browser";
 import {
   GATEWAY_EVENT_UPDATE_AVAILABLE,
   type GatewayUpdateAvailableEventPayload,
 } from "../../../src/gateway/events.js";
 import type { GatewayEventFrame } from "../api/gateway.ts";
-import type { UpdateHoldResult } from "../api/types.ts";
-import { controlUiBuildDiffersFrom } from "../build-info.ts";
 import { t } from "../i18n/index.ts";
 import {
   closeDevicePairSetup as closeDevicePairSetupState,
@@ -40,32 +37,9 @@ import {
 } from "./overlays-access.ts";
 import type { ApplicationOverlays, ApplicationOverlaySnapshot } from "./overlays-types.ts";
 import {
-  classifyUpdateRunResponse,
-  createUpdateCampaignStatusPoller,
-  createUpdateStatusRefresher,
-  createUpdateVerificationController,
-  projectUpdateStatusResponse,
-  resolveExpectedUpdateSha,
-  resolveUnknownUpdateOutcomeBanner,
-  resolveUpdateStatusBanner,
-  UPDATE_HANDOFF_TIMEOUT_MS,
-  type ApplicationStatusBanner,
-  type PendingUpdateReconciliation,
-  type UpdateRestartStatusResponse,
-  type UpdateRunResponse,
-} from "./update-overlay-helpers.ts";
-import { readUpdateScheduleValue } from "./update-schedule-dto.ts";
-import {
-  projectConnectedUpdateSnapshot,
-  projectUpdateAvailableEvent,
-  resolveHeldUpdateCampaignId,
-} from "./update-schedule-projection.ts";
-import {
-  announceRecordedUpdateSuccess,
-  announceVerifiedUpdateInstall,
-  readUpdateNotice,
-  writeUpdateNotice,
-} from "./update-success-notice.ts";
+  createApplicationUpdateOverlays,
+  type ApplicationUpdateOverlayHooks,
+} from "./overlays-updates.ts";
 
 function isGatewayEvent(value: unknown): value is GatewayEventFrame {
   return Boolean(value && typeof value === "object" && "event" in value);
@@ -73,23 +47,11 @@ function isGatewayEvent(value: unknown): value is GatewayEventFrame {
 
 export function createApplicationOverlays(
   gateway: ApplicationGateway,
-  hooks: {
-    /** Barrier awaited after update-running is published and before update.run
-     * is issued, so in-flight config writes cannot overlap the install. */
-    drainConfigWrites?: () => Promise<void>;
-  } = {},
+  hooks: ApplicationUpdateOverlayHooks = {},
 ): ApplicationOverlays {
+  const updates = createApplicationUpdateOverlays(gateway, publish, hooks);
   let snapshot: ApplicationOverlaySnapshot = {
-    updateAvailable: null,
-    updateSchedule: null,
-    heldUpdateCampaignId: null,
-    updateRunning: false,
-    updateStatusRefreshing: false,
-    updateCampaignStatusHydrated: true,
-    updateReconciliationPending: false,
-    updateStatusBanner: null,
-    recordedUpdateAttempt: null,
-    controlUiRefreshRequired: false,
+    ...updates.snapshot,
     approvalQueue: [],
     approvalBusy: false,
     approvalCanGrant: false,
@@ -101,22 +63,11 @@ export function createApplicationOverlays(
   const listeners = new Set<(next: ApplicationOverlaySnapshot) => void>();
   let disposed = false;
   let activeClient = gateway.snapshot.client;
-  let activeHello = gateway.snapshot.hello;
   let connectedSource: NonNullable<typeof activeClient> | null = null; // Retries start a new source epoch.
   let connectedEpoch = 0;
   let operatorAccess = readGatewayOperatorAccess(gateway.snapshot);
   let approvalAccessGeneration = 0;
   let approvalGrantGeneration = 0;
-  let updateGatewayScope = gatewayCredentialScope(gateway.connection.gatewayUrl);
-  const savedUpdate = readUpdateNotice(updateGatewayScope);
-  let pendingUpdate: PendingUpdateReconciliation | null =
-    savedUpdate && savedUpdate.kind !== "verified" ? savedUpdate : null;
-  let pendingUpdateProfileId = savedUpdate?.profileId ?? null;
-  let pendingUpdateTimer: ReturnType<typeof globalThis.setTimeout> | null = null;
-  let updateRequestRunning = false;
-  let updateStatusRevision = 0;
-  let updateRunGeneration = 0;
-  let updateHoldInFlight = false;
   let approvalDecision: {
     client: NonNullable<typeof activeClient>;
     epoch: number;
@@ -140,11 +91,7 @@ export function createApplicationOverlays(
   function publish() {
     snapshot = {
       ...snapshot,
-      updateRunning:
-        updateRequestRunning || snapshot.updateSchedule?.campaign?.state === "applying",
-      // The update RPC can finish before its restart handoff. Keep consumers
-      // locked until the replacement Gateway reports the authoritative result.
-      updateReconciliationPending: pendingUpdate !== null,
+      ...updates.snapshot,
       approvalQueue: promptState.execApprovalQueue,
       approvalBusy: promptState.execApprovalBusy,
       approvalCanGrant: readGatewayOperatorAccess(gateway.snapshot).canGrantApprovals,
@@ -187,130 +134,8 @@ export function createApplicationOverlays(
     publish,
   });
 
-  const publishUpdateBanner = (updateStatusBanner: ApplicationStatusBanner | null) => {
-    snapshot = { ...snapshot, updateStatusBanner };
-    publish();
-  };
-  const publishRecordedUpdateAttempt = (
-    recordedUpdateAttempt: ApplicationOverlaySnapshot["recordedUpdateAttempt"],
-  ) => {
-    snapshot = { ...snapshot, recordedUpdateAttempt };
-    publish();
-  };
-  const noticeScope = () => ({
-    gateway: updateGatewayScope,
-    profileId: gateway.snapshot.selfUser?.id ?? null,
-  });
-  const clearPendingUpdateTimer = () => {
-    if (pendingUpdateTimer !== null) {
-      globalThis.clearTimeout(pendingUpdateTimer);
-      pendingUpdateTimer = null;
-    }
-  };
-  const setPendingUpdate = (pending: PendingUpdateReconciliation | null) => {
-    pendingUpdate = pending;
-    clearPendingUpdateTimer();
-    writeUpdateNotice(
-      pending
-        ? { ...pending, gateway: updateGatewayScope, profileId: pendingUpdateProfileId }
-        : null,
-    );
-    if (pending) {
-      // This budget belongs to admission, not reconnect. A failed-closed
-      // Gateway may never return to run the verification loop below.
-      pendingUpdateTimer = globalThis.setTimeout(
-        () => {
-          if (disposed || pendingUpdate !== pending) {
-            return;
-          }
-          updateRunGeneration += 1;
-          updateVerification.cancel();
-          updateRequestRunning = false;
-          setPendingUpdate(null);
-          publishUpdateBanner(resolveUnknownUpdateOutcomeBanner());
-        },
-        Math.max(0, pending.deadlineAtMs - Date.now()),
-      );
-    }
-  };
-  const updateVerification = createUpdateVerificationController({
-    getPending: () => pendingUpdate,
-    clearPending: () => {
-      setPendingUpdate(null);
-    },
-    isCurrent: (client, epoch) => epoch === connectedEpoch && isCurrentClient(client),
-    getHello: () => gateway.snapshot.hello,
-    publish,
-    publishBanner: publishUpdateBanner,
-    publishRecordedAttempt: publishRecordedUpdateAttempt,
-    publishRecordedFailure: ({ attempt, banner }) => {
-      // Both facts terminate the same reconciliation. Publishing either first
-      // exposes a false success or a failure without its recorded cause.
-      snapshot = { ...snapshot, recordedUpdateAttempt: attempt, updateStatusBanner: banner };
-      publish();
-    },
-    onVerifiedInstall: (identity) => announceVerifiedUpdateInstall(identity, noticeScope()),
-  });
-  const applyUpdateStatusResponse = (response: UpdateRestartStatusResponse) => {
-    // The admitted attempt has its own identity-aware verifier. A page refresh
-    // must not race it with an unrelated retained sentinel.
-    if (pendingUpdate) {
-      return;
-    }
-    snapshot = {
-      ...snapshot,
-      ...projectUpdateStatusResponse(response, {
-        updateStatusBanner: snapshot.updateStatusBanner,
-        recordedUpdateAttempt: snapshot.recordedUpdateAttempt,
-        heldUpdateCampaignId: snapshot.heldUpdateCampaignId,
-      }),
-      updateCampaignStatusHydrated: true,
-    };
-    publish();
-  };
-  const refreshUpdateStatus = createUpdateStatusRefresher({
-    getClient: () => activeClient,
-    getEpoch: () => connectedEpoch,
-    getRevision: () => updateStatusRevision,
-    canRefresh: () => !disposed && operatorAccess.canAdmin,
-    isCurrent: (client, epoch) => epoch === connectedEpoch && isCurrentClient(client),
-    onRefreshing: (updateStatusRefreshing) => {
-      snapshot = { ...snapshot, updateStatusRefreshing };
-      publish();
-    },
-    onStatus: applyUpdateStatusResponse,
-    onError: (error) => {
-      publishUpdateBanner({
-        tone: "danger",
-        text: t("updates.error", { error: formatUiError(error) }),
-      });
-    },
-  });
-  const updateCampaignPoller = createUpdateCampaignStatusPoller({
-    canPoll: () =>
-      Boolean(activeClient && isCurrentClient(activeClient) && snapshot.updateSchedule?.campaign) &&
-      operatorAccess.canAdmin,
-    refresh: () => refreshUpdateStatus("background"),
-  });
-
   const synchronizeGateway = (next: ApplicationGateway["snapshot"]) => {
-    const nextGatewayScope = gatewayCredentialScope(gateway.connection.gatewayUrl);
-    if (nextGatewayScope !== updateGatewayScope) {
-      updateRunGeneration += 1;
-      updateStatusRevision += 1;
-      updateVerification.cancel();
-      setPendingUpdate(null);
-      updateRequestRunning = false;
-      updateGatewayScope = nextGatewayScope;
-      snapshot = {
-        ...snapshot,
-        updateStatusBanner: null,
-        recordedUpdateAttempt: null,
-        heldUpdateCampaignId: null,
-      };
-    }
     const previousClient = activeClient;
-    const helloChanged = activeHello !== next.hello;
     const connected = next.phase === "connected";
     const nextConnectedSource = connected ? next.client : null;
     const connectedSourceChanged = connectedSource !== nextConnectedSource;
@@ -340,20 +165,6 @@ export function createApplicationOverlays(
       // authorities must also close a pairing-only operator's retained modal.
       closeDevicePairSetupState(devicePairSetupState);
       pairingPendingCount.invalidate({ clear: true });
-      if (accessTransition.adminRevoked) {
-        updateRunGeneration += 1;
-        updateStatusRevision += 1;
-        updateVerification.cancel();
-        const updateStatusBanner = pendingUpdate ? resolveUnknownUpdateOutcomeBanner() : null;
-        setPendingUpdate(null);
-        updateRequestRunning = false;
-        snapshot = {
-          ...snapshot,
-          updateStatusRefreshing: false,
-          updateStatusBanner,
-          recordedUpdateAttempt: null,
-        };
-      }
     }
     if (accessTransition.pairingChanged) {
       pairingPendingCount.invalidate({
@@ -361,16 +172,10 @@ export function createApplicationOverlays(
       });
     }
     activeClient = next.client;
-    activeHello = next.hello;
     connectedSource = nextConnectedSource;
     promptState.client = next.client;
     devicePairSetupState.client = next.client;
     devicePairSetupState.connected = connected;
-    if (connectedSourceChanged) {
-      updateRunGeneration += 1;
-      updateStatusRevision += 1;
-      updateVerification.cancel();
-    }
     if (previousClient !== next.client || !connected) {
       approvalDecision = null;
       pairingPendingCount.invalidate({ clear: true });
@@ -384,58 +189,17 @@ export function createApplicationOverlays(
       clearExecApprovalTimers(promptState);
     }
     if (!connected || !next.client) {
-      updateRequestRunning = false;
       promptState.execApprovalQueue = [];
       promptState.execApprovalBusy = false;
       promptState.execApprovalErrors.clear();
-      snapshot = {
-        ...snapshot,
-        updateAvailable: null,
-        updateSchedule: null,
-        updateStatusRefreshing: false,
-        updateCampaignStatusHydrated: true,
-      };
-      updateCampaignPoller.stop();
-      if (next.phase === "reload-required") {
-        snapshot = { ...snapshot, controlUiRefreshRequired: true };
-      } else if (!next.client) {
+      if (next.phase !== "reload-required" && !next.client) {
         connectedEpoch = 0;
-        snapshot = { ...snapshot, controlUiRefreshRequired: false };
-      } else if (next.hello) {
-        snapshot = { ...snapshot, controlUiRefreshRequired: true };
       }
       clearExecApprovalTimers(promptState);
-      publish();
+      updates.synchronizeGateway(next);
       return;
     }
-    if (
-      pendingUpdate &&
-      (!operatorAccess.canAdmin || pendingUpdateProfileId !== (next.selfUser?.id ?? null))
-    ) {
-      updateRunGeneration += 1;
-      updateStatusRevision += 1;
-      updateVerification.cancel();
-      setPendingUpdate(null);
-      snapshot = { ...snapshot, updateStatusBanner: resolveUnknownUpdateOutcomeBanner() };
-    }
-    const serverBuildIdentity = {
-      version: next.hello?.server?.version,
-      buildId: next.hello?.server?.buildId,
-      controlUiBuildSource: next.hello?.server?.controlUiBuildSource,
-    };
-    const exactBuildIdentityAvailable = Boolean(serverBuildIdentity.buildId?.trim());
-    snapshot = {
-      ...snapshot,
-      ...(connectedSourceChanged || helloChanged
-        ? projectConnectedUpdateSnapshot(snapshot, next.hello)
-        : {}),
-      controlUiRefreshRequired: connectedSourceChanged
-        ? (exactBuildIdentityAvailable || connectedEpoch > 0) &&
-          controlUiBuildDiffersFrom(serverBuildIdentity)
-        : snapshot.controlUiRefreshRequired,
-    };
-    publish();
-    updateCampaignPoller.sync();
+    updates.synchronizeGateway(next);
     if (
       accessTransition.pairingChanged &&
       devicePairSetupState.devicePairSetupOpen &&
@@ -445,16 +209,8 @@ export function createApplicationOverlays(
     }
     if (connectedSourceChanged) {
       connectedEpoch += 1;
-      announceRecordedUpdateSuccess(operatorAccess.canAdmin ? noticeScope() : null);
       if (operatorAccess.canReviewApprovals) {
         void refreshApprovals(next.client, connectedEpoch, approvalAccessGeneration);
-      }
-      if (pendingUpdate && operatorAccess.canAdmin) {
-        void updateVerification.verify(next.client, connectedEpoch);
-      } else if (operatorAccess.canAdmin && !snapshot.updateSchedule?.campaign) {
-        // A new bundle has no in-memory campaign history. Hydrate the Gateway's
-        // retained result so an automatic update failure survives that reload.
-        void refreshUpdateStatus("background");
       }
     } else if (accessTransition.reviewChanged && operatorAccess.canReviewApprovals) {
       void refreshApprovals(next.client, connectedEpoch, approvalAccessGeneration);
@@ -485,29 +241,9 @@ export function createApplicationOverlays(
       return;
     }
     if (event.event === GATEWAY_EVENT_UPDATE_AVAILABLE) {
-      const payload = event.payload as GatewayUpdateAvailableEventPayload | undefined;
-      const previousCampaign = snapshot.updateSchedule?.campaign;
-      updateStatusRevision += 1;
-      snapshot = {
-        ...snapshot,
-        ...projectUpdateAvailableEvent(snapshot, payload),
-      };
-      publish();
-      updateCampaignPoller.sync();
-      if (
-        previousCampaign?.state === "applying" &&
-        snapshot.updateSchedule?.campaign?.state !== "applying" &&
-        activeClient &&
-        operatorAccess.canAdmin
-      ) {
-        // Completion can arrive between polls. The producer records its outcome
-        // before removing the campaign, so removal still needs one final read.
-        if (pendingUpdate) {
-          void updateVerification.verify(activeClient, connectedEpoch);
-        } else {
-          void refreshUpdateStatus("completion");
-        }
-      }
+      updates.handleUpdateAvailable(
+        event.payload as GatewayUpdateAvailableEventPayload | undefined,
+      );
       return;
     }
     if (
@@ -528,9 +264,6 @@ export function createApplicationOverlays(
       publish();
     }
   });
-  if (pendingUpdate) {
-    setPendingUpdate(pendingUpdate);
-  }
   synchronizeGateway(gateway.snapshot);
 
   return {
@@ -541,157 +274,9 @@ export function createApplicationOverlays(
       listeners.add(listener);
       return () => listeners.delete(listener);
     },
-    refreshUpdateStatus,
-    async runUpdate() {
-      const client = gateway.snapshot.client;
-      if (
-        !client ||
-        gateway.snapshot.phase !== "connected" ||
-        disposed ||
-        snapshot.updateRunning ||
-        pendingUpdate !== null ||
-        !readGatewayOperatorAccess(gateway.snapshot).canAdmin
-      ) {
-        return;
-      }
-      const generation = ++updateRunGeneration;
-      updateStatusRevision += 1;
-      updateRequestRunning = true;
-      snapshot = {
-        ...snapshot,
-        updateStatusBanner: null,
-        recordedUpdateAttempt: null,
-      };
-      publish();
-      let admittedPending: PendingUpdateReconciliation | null = null;
-      try {
-        // updateRunning above suspends NEW config writes (bootstrap syncs it
-        // into the runtime-config capability); this barrier drains writes
-        // already in flight so none can commit or restart mid-install.
-        await hooks.drainConfigWrites?.();
-        if (
-          disposed ||
-          generation !== updateRunGeneration ||
-          snapshot.updateSchedule?.campaign?.state === "applying" ||
-          !readGatewayOperatorAccess(gateway.snapshot).canAdmin
-        ) {
-          return;
-        }
-        pendingUpdateProfileId = gateway.snapshot.selfUser?.id ?? null;
-        admittedPending = {
-          kind: "ambiguous",
-          expectedVersion: snapshot.updateAvailable?.latestVersion?.trim() || null,
-          expectedSha: resolveExpectedUpdateSha(snapshot.updateSchedule, snapshot.updateAvailable),
-          handoffId: null,
-          deadlineAtMs: Date.now() + UPDATE_HANDOFF_TIMEOUT_MS,
-        };
-        setPendingUpdate(admittedPending);
-        publish();
-        const response = await client.request<UpdateRunResponse>("update.run", {});
-        if (
-          disposed ||
-          generation !== updateRunGeneration ||
-          pendingUpdate !== admittedPending ||
-          activeClient !== client ||
-          gateway.snapshot.client !== client
-        ) {
-          return;
-        }
-        const accepted = classifyUpdateRunResponse(response, admittedPending);
-        if (accepted) {
-          setPendingUpdate(accepted.pending);
-          if (accepted.banner) {
-            snapshot = { ...snapshot, updateStatusBanner: accepted.banner };
-          }
-          return;
-        }
-        setPendingUpdate(null);
-        snapshot = {
-          ...snapshot,
-          updateStatusBanner: resolveUpdateStatusBanner({
-            status: response.result?.status ?? "error",
-            reason: response.result?.reason,
-          }),
-        };
-      } catch (error) {
-        if (
-          disposed ||
-          generation !== updateRunGeneration ||
-          pendingUpdate !== admittedPending ||
-          activeClient !== client ||
-          gateway.snapshot.client !== client
-        ) {
-          return;
-        }
-        setPendingUpdate(null);
-        snapshot = {
-          ...snapshot,
-          updateStatusBanner: {
-            tone: "danger",
-            text: t("updates.error", {
-              error: formatUiError(error),
-            }),
-          },
-        };
-      } finally {
-        if (
-          !disposed &&
-          generation === updateRunGeneration &&
-          activeClient === client &&
-          gateway.snapshot.client === client
-        ) {
-          updateRequestRunning = false;
-          publish();
-        }
-      }
-    },
-    async holdUpdate() {
-      const client = gateway.snapshot.client;
-      const campaign = snapshot.updateSchedule?.campaign;
-      const busy = updateHoldInFlight || snapshot.updateRunning || pendingUpdate !== null;
-      if (
-        !client ||
-        gateway.snapshot.phase !== "connected" ||
-        disposed ||
-        busy ||
-        !campaign ||
-        campaign.state === "applying" ||
-        snapshot.heldUpdateCampaignId === campaign.id ||
-        !readGatewayOperatorAccess(gateway.snapshot).canAdmin
-      ) {
-        return false;
-      }
-      updateHoldInFlight = true;
-      try {
-        const response = await client.request<UpdateHoldResult>("update.hold", {});
-        if (disposed || gateway.snapshot.client !== client) {
-          return false;
-        }
-        const updateSchedule = response.schedule && readUpdateScheduleValue(response.schedule);
-        if (updateSchedule !== undefined || response.ok) {
-          snapshot = {
-            ...snapshot,
-            ...(updateSchedule !== undefined ? { updateSchedule } : {}),
-            heldUpdateCampaignId: response.ok
-              ? campaign.id
-              : resolveHeldUpdateCampaignId(
-                  updateSchedule ?? snapshot.updateSchedule,
-                  snapshot.heldUpdateCampaignId,
-                ),
-          };
-          publish();
-        }
-        return response.ok;
-      } catch (error) {
-        if (!disposed && gateway.snapshot.client === client) {
-          const message = formatUiError(error);
-          publishUpdateBanner({ tone: "danger", text: t("updates.error", { error: message }) });
-        }
-        return false;
-      } finally {
-        updateHoldInFlight = false;
-      }
-    },
+    refreshUpdateStatus: updates.refreshUpdateStatus,
+    runUpdate: updates.runUpdate,
+    holdUpdate: updates.holdUpdate,
     async decideApproval(decision, approvalId, projectedApproval) {
       const active = approvalId
         ? (promptState.execApprovalQueue.find((entry) => entry.id === approvalId) ??
@@ -798,11 +383,8 @@ export function createApplicationOverlays(
     dispose() {
       disposed = true;
       approvalDecision = null;
-      updateRunGeneration += 1;
-      clearPendingUpdateTimer();
+      updates.dispose();
       pairingPendingCount.invalidate();
-      updateVerification.cancel();
-      updateCampaignPoller.stop();
       closeDevicePairSetupState(devicePairSetupState);
       stopGateway();
       stopEvents();

--- a/ui/src/app/update-overlay-helpers.test.ts
+++ b/ui/src/app/update-overlay-helpers.test.ts
@@ -30,6 +30,8 @@ const translations: Record<string, string> = {
   "updates.failureReasons.dirty": "Commit or stash changes, then retry.",
   "updates.failureReasons.depsInstallFailed":
     "Dependency install failed. Fix the install error and retry.",
+  "updates.failureReasons.managedServiceHandoffUnavailable":
+    "Stop the foreground Gateway, update in the terminal, then launch it again.",
   "updates.failureReasons.default":
     "See the gateway logs for the exact failure and retry once the cause is fixed.",
   "updates.verificationFailed":
@@ -46,6 +48,7 @@ const translations: Record<string, string> = {
   "updates.handoffTimeout":
     "Update handoff started, but completion was not reported after reconnect. Run `openclaw update status` for the final result.",
   "updates.campaign.countdown": "Updating in {time}",
+  "updates.campaign.applying": "Updating…",
   "updates.campaign.held": "Update held · resumes in {time}",
   "updates.campaign.waitingForIdle": "Waiting for active work · forced update in {time}",
 };
@@ -63,7 +66,7 @@ afterEach(() => {
 });
 
 async function verifyUpdate(params: {
-  pending: PendingUpdateReconciliation;
+  pending: Omit<PendingUpdateReconciliation, "handoffId" | "deadlineAtMs">;
   response: unknown;
   hello?: GatewayHelloOk | null;
   advanceToMs?: number;
@@ -72,6 +75,11 @@ async function verifyUpdate(params: {
   vi.useFakeTimers();
   vi.setSystemTime(0);
   let banner: ApplicationStatusBanner | null | undefined;
+  const pending: PendingUpdateReconciliation = {
+    ...params.pending,
+    handoffId: null,
+    deadlineAtMs: 35 * 60_000,
+  };
   const client = {
     request: vi.fn(async () => {
       if (params.advanceToMs !== undefined) {
@@ -81,7 +89,7 @@ async function verifyUpdate(params: {
     }),
   } as unknown as GatewayBrowserClient;
   const controller = createUpdateVerificationController({
-    getPending: () => params.pending,
+    getPending: () => pending,
     clearPending: vi.fn(),
     isCurrent: () => true,
     getHello: () => params.hello ?? null,
@@ -222,6 +230,15 @@ describe("update schedule hydration", () => {
         1_000,
       ),
     ).toBe("Update held · resumes in 12:41");
+    expect(
+      formatUpdateCampaignLabel(
+        {
+          ...schedule,
+          campaign: { ...schedule.campaign, state: "applying", holdUntilMs: 762_000 },
+        },
+        1_000,
+      ),
+    ).toBe("Updating…");
   });
 
   it.each([
@@ -458,18 +475,25 @@ describe("update status localization", () => {
     });
   });
 
-  it("localizes known update failure guidance", () => {
+  it.each([
+    { reason: "dirty", key: "dirty", guidance: "Commit or stash changes, then retry." },
+    {
+      reason: "managed-service-handoff-unavailable",
+      key: "managedServiceHandoffUnavailable",
+      guidance: "Stop the foreground Gateway, update in the terminal, then launch it again.",
+    },
+  ])("localizes known update failure guidance for $reason", ({ reason, key, guidance }) => {
     const translate = installTranslations();
 
-    expect(resolveUpdateStatusBanner({ status: "skipped", reason: "dirty" })).toEqual({
+    expect(resolveUpdateStatusBanner({ status: "skipped", reason })).toEqual({
       tone: "warn",
-      text: "Update skipped: dirty. Commit or stash changes, then retry.",
+      text: `Update skipped: ${reason}. ${guidance}`,
     });
-    expect(translate).toHaveBeenCalledWith("updates.failureReasons.dirty", undefined);
+    expect(translate).toHaveBeenCalledWith(`updates.failureReasons.${key}`, undefined);
     expect(translate).toHaveBeenCalledWith("updates.status", {
       status: "skipped",
-      reason: "dirty",
-      guidance: "Commit or stash changes, then retry.",
+      reason,
+      guidance,
     });
   });
 

--- a/ui/src/app/update-overlay-helpers.test.ts
+++ b/ui/src/app/update-overlay-helpers.test.ts
@@ -467,10 +467,10 @@ describe("update status localization", () => {
       status: "error",
       reason: "build-failed",
       installKind: "git",
-      installedVersion: null,
-      installedSha: "before",
-      targetVersion: null,
-      targetSha: "after",
+      beforeVersion: null,
+      beforeSha: "before",
+      afterVersion: null,
+      afterSha: "after",
       failure: { step: "build", detail: "Type check failed" },
     });
   });

--- a/ui/src/app/update-overlay-helpers.ts
+++ b/ui/src/app/update-overlay-helpers.ts
@@ -72,7 +72,9 @@ const UPDATE_RESTART_HEALTH_PENDING_REASON = "restart-health-pending";
 const UPDATE_RESTART_VERIFICATION_POLL_MS = 250;
 const UPDATE_RESTART_VERIFICATION_TIMEOUT_MS = 10_000;
 const UPDATE_HANDOFF_POLL_MS = 1_000;
-const UPDATE_HANDOFF_TIMEOUT_MS = 35 * 60_000;
+// Manual update.run uses a 30-minute command budget plus restart grace.
+// Automatic campaigns own their separate server-side deadline.
+export const UPDATE_HANDOFF_TIMEOUT_MS = 35 * 60_000;
 const PENDING_UPDATE_HANDOFF_REASONS = new Set([
   UPDATE_HANDOFF_STARTED_REASON,
   UPDATE_RESTART_HEALTH_PENDING_REASON,
@@ -95,6 +97,7 @@ const UPDATE_FAILURE_REASON_KEYS: Record<string, string> = {
   "already-current": "updates.failureReasons.alreadyCurrent",
   "managed-service-handoff-already-running":
     "updates.failureReasons.managedServiceHandoffAlreadyRunning",
+  "managed-service-handoff-unavailable": "updates.failureReasons.managedServiceHandoffUnavailable",
   "doctor-failed": "updates.failureReasons.doctorFailed",
   // The detached helper owns these; its output never reaches the gateway log,
   // so the default "see the gateway logs" guidance would send operators nowhere.
@@ -124,6 +127,7 @@ export type UpdateRestartStatusResponse = {
     stats?: {
       mode?: string | null;
       reason?: string | null;
+      handoffId?: string | null;
       before?: { sha?: string | null; version?: string | null } | null;
       after?: { sha?: string | null; version?: string | null } | null;
       steps?: UpdateSentinelStep[] | null;
@@ -198,6 +202,7 @@ export type UpdateRunResponse = {
   };
   handoff?: { status?: string };
   restart?: { coalesced?: boolean } | null;
+  sentinel?: { payload?: { stats?: { handoffId?: string | null } | null } | null } | null;
 };
 
 async function requestUpdateRestartStatus(
@@ -219,6 +224,7 @@ async function requestUpdateRestartStatus(
 export function createUpdateStatusRefresher(params: {
   getClient: () => GatewayBrowserClient | null;
   getEpoch: () => number;
+  getRevision: () => number;
   canRefresh: () => boolean;
   isCurrent: (client: GatewayBrowserClient, epoch: number) => boolean;
   onRefreshing: (refreshing: boolean) => void;
@@ -226,22 +232,35 @@ export function createUpdateStatusRefresher(params: {
   onError: (error: unknown) => void;
 }) {
   let generation = 0;
-  return async () => {
+  let manualIsCurrent: (() => boolean) | null = null;
+  return async (mode: "manual" | "background" | "completion" = "manual") => {
     const client = params.getClient();
     const epoch = params.getEpoch();
-    if (!client || !params.canRefresh()) {
+    if (
+      !client ||
+      !params.canRefresh() ||
+      !params.isCurrent(client, epoch) ||
+      (mode === "background" && manualIsCurrent?.())
+    ) {
       return;
     }
+    const refreshCheckout = mode === "manual";
     const operationGeneration = ++generation;
-    const isCurrent = () => operationGeneration === generation && params.isCurrent(client, epoch);
-    params.onRefreshing(true);
+    const revision = params.getRevision();
+    const ownsRequest = () => operationGeneration === generation && params.isCurrent(client, epoch);
+    const isCurrent = () =>
+      ownsRequest() && params.canRefresh() && revision === params.getRevision();
+    if (refreshCheckout) {
+      manualIsCurrent = isCurrent;
+      params.onRefreshing(true);
+    }
     try {
       const response = await requestUpdateRestartStatus(
         client,
         5_000,
-        { refreshCheckout: true },
+        refreshCheckout ? { refreshCheckout: true } : {},
         (error) => {
-          if (isCurrent()) {
+          if (mode !== "background" && isCurrent()) {
             params.onError(error);
           }
         },
@@ -250,7 +269,8 @@ export function createUpdateStatusRefresher(params: {
         params.onStatus(response);
       }
     } finally {
-      if (isCurrent()) {
+      if (ownsRequest()) {
+        manualIsCurrent = null;
         params.onRefreshing(false);
       }
     }
@@ -269,17 +289,21 @@ export function classifyUpdateRunResponse(
   const status = response.result?.status ?? (response.ok === true ? "ok" : "error");
   const expectedVersion = response.result?.after?.version?.trim() || pending.expectedVersion;
   const expectedSha = response.result?.after?.sha?.trim() || pending.expectedSha;
+  const handoffId = response.sentinel?.payload?.stats?.handoffId?.trim() || pending.handoffId;
   if (
     response.ok === true &&
     status === "skipped" &&
     response.result?.reason === UPDATE_HANDOFF_STARTED_REASON &&
     response.handoff?.status === "started"
   ) {
-    return { pending: { expectedVersion, expectedSha, kind: "handoff" }, banner: null };
+    return {
+      pending: { ...pending, expectedVersion, expectedSha, handoffId, kind: "handoff" },
+      banner: null,
+    };
   }
   if (response.ok === true && status === "ok") {
     return {
-      pending: { expectedVersion, expectedSha, kind: "restart" },
+      pending: { ...pending, expectedVersion, expectedSha, handoffId, kind: "restart" },
       banner:
         response.restart?.coalesced === true
           ? { tone: "info", text: t("updates.coalescedRestart") }
@@ -301,16 +325,12 @@ export function resolveExpectedUpdateSha(
 export type PendingUpdateReconciliation = {
   expectedVersion: string | null;
   expectedSha: string | null;
+  // A lost response (or an unmanaged restart) has no handoff id. That path
+  // can compare installed identity, but cannot distinguish identical attempts.
+  handoffId: string | null;
+  deadlineAtMs: number;
   kind: "ambiguous" | "handoff" | "restart";
 };
-
-export function createPendingUpdateReconciliation(
-  kind: PendingUpdateReconciliation["kind"],
-  expectedVersion: string | null,
-  expectedSha: string | null,
-): PendingUpdateReconciliation {
-  return { expectedVersion, expectedSha, kind };
-}
 
 type UpdateVerificationWait = {
   timer: ReturnType<typeof globalThis.setTimeout>;
@@ -369,27 +389,39 @@ export function createUpdateVerificationController(params: {
       wait = { timer, resolve };
     });
   const verify = async (client: GatewayBrowserClient, epoch: number) => {
-    const currentGeneration = generation;
+    const currentGeneration = ++generation;
+    settleWait(false);
     const reconciliation = params.getPending();
     if (!reconciliation) {
       return;
     }
     const expectedVersion = reconciliation.expectedVersion?.trim() || null;
     const expectedSha = reconciliation.expectedSha?.trim() || null;
-    const isCurrent = () => currentGeneration === generation && params.isCurrent(client, epoch);
+    const isCurrent = () =>
+      currentGeneration === generation &&
+      params.getPending() === reconciliation &&
+      params.isCurrent(client, epoch);
     const verificationKind = reconciliation.kind === "handoff" ? "handoff" : "restart";
     let { deadline, pollMs } = resolveUpdateVerificationWindow(verificationKind);
+    deadline = Math.min(deadline, reconciliation.deadlineAtMs);
     while (isCurrent() && Date.now() < deadline) {
       const response = await requestUpdateRestartStatus(client, Math.max(0, deadline - Date.now()));
       if (!isCurrent()) {
         return;
       }
-      const sentinel = response?.sentinel;
+      const candidate = response?.sentinel;
+      // A retained result from an earlier attempt is not this handoff's outcome,
+      // even when both installs have the same package version.
+      const sentinel =
+        reconciliation.handoffId && candidate?.stats?.handoffId !== reconciliation.handoffId
+          ? null
+          : candidate;
       if (isPendingUpdateHandoffSentinel(sentinel)) {
         if (reconciliation.kind !== "handoff") {
           // Confirmed updates can become managed handoffs; preserve the longer lifecycle budget.
           reconciliation.kind = "handoff";
           ({ deadline, pollMs } = resolveUpdateVerificationWindow("handoff"));
+          deadline = Math.min(deadline, reconciliation.deadlineAtMs);
           params.publish();
         }
         const remainingMs = deadline - Date.now();
@@ -475,15 +507,13 @@ export function createUpdateVerificationController(params: {
 }
 
 export function createUpdateCampaignStatusPoller(params: {
-  getClient: () => GatewayBrowserClient | null;
-  getEpoch: () => number;
   canPoll: () => boolean;
-  getSchedule: () => UpdateScheduleState | null;
-  isCurrent: (client: GatewayBrowserClient, epoch: number) => boolean;
-  onStatus: (response: UpdateRestartStatusResponse) => void;
+  refresh: () => Promise<void>;
 }) {
   let timer: ReturnType<typeof globalThis.setTimeout> | null = null;
+  let generation = 0;
   const stop = () => {
+    generation += 1;
     if (timer !== null) {
       globalThis.clearTimeout(timer);
       timer = null;
@@ -491,25 +521,16 @@ export function createUpdateCampaignStatusPoller(params: {
   };
   const poll = async () => {
     timer = null;
-    const client = params.getClient();
-    const epoch = params.getEpoch();
-    const campaign = params.getSchedule()?.campaign;
-    if (!client || !params.canPoll() || !campaign) {
-      return;
+    const currentGeneration = generation;
+    if (params.canPoll()) {
+      await params.refresh();
     }
-    const response = await requestUpdateRestartStatus(client, 5_000);
-    const currentCampaign = params.getSchedule()?.campaign;
-    // An event can advance the campaign while this RPC is in flight; never overwrite that fact.
-    const unchangedCampaign =
-      currentCampaign?.id === campaign.id && currentCampaign.updatedAtMs === campaign.updatedAtMs;
-    if (response && unchangedCampaign && params.canPoll() && params.isCurrent(client, epoch)) {
-      params.onStatus(response);
+    if (currentGeneration === generation) {
+      sync();
     }
-    sync();
   };
   const sync = () => {
-    const client = params.getClient();
-    if (!client || !params.canPoll() || !params.getSchedule()?.campaign) {
+    if (!params.canPoll()) {
       stop();
       return;
     }
@@ -588,13 +609,13 @@ export function formatUpdateCampaignLabel(
   if (!campaign) {
     return null;
   }
+  if (campaign.state === "applying") {
+    return t("updates.campaign.applying");
+  }
   if (campaign.holdUntilMs !== undefined && campaign.holdUntilMs > nowMs) {
     return t("updates.campaign.held", {
       time: formatCountdown(campaign.holdUntilMs, nowMs),
     });
-  }
-  if (campaign.state === "applying") {
-    return t("updates.campaign.applying");
   }
   if (campaign.state === "waiting-for-idle") {
     return t("updates.campaign.waitingForIdle", {

--- a/ui/src/app/update-overlay-helpers.ts
+++ b/ui/src/app/update-overlay-helpers.ts
@@ -16,10 +16,10 @@ export type RecordedUpdateAttempt = {
   status: string;
   reason: string;
   installKind: string | null;
-  installedVersion: string | null;
-  installedSha: string | null;
-  targetVersion: string | null;
-  targetSha: string | null;
+  beforeVersion: string | null;
+  beforeSha: string | null;
+  afterVersion: string | null;
+  afterSha: string | null;
   failure: UpdateFailureCause | null;
 };
 
@@ -157,10 +157,10 @@ function readRecordedUpdateAttempt(
     status: sentinel.status,
     reason: stats?.reason?.trim() || "unexpected-error",
     installKind: stats?.mode?.trim() || null,
-    installedVersion: stats?.before?.version?.trim() || null,
-    installedSha: stats?.before?.sha?.trim() || null,
-    targetVersion: stats?.after?.version?.trim() || null,
-    targetSha: stats?.after?.sha?.trim() || null,
+    beforeVersion: stats?.before?.version?.trim() || null,
+    beforeSha: stats?.before?.sha?.trim() || null,
+    afterVersion: stats?.after?.version?.trim() || null,
+    afterSha: stats?.after?.sha?.trim() || null,
     failure: readUpdateFailureCause(sentinel),
   };
 }

--- a/ui/src/app/update-success-notice.test.ts
+++ b/ui/src/app/update-success-notice.test.ts
@@ -29,7 +29,10 @@ describe("update success notice", () => {
   it("announces a non-reloading success when session storage is unavailable", async () => {
     const { announceVerifiedUpdateInstall } = await import("./update-success-notice.ts");
 
-    announceVerifiedUpdateInstall({ version: "2026.8.11", sha: "abcdef1234567890" });
+    announceVerifiedUpdateInstall(
+      { version: "2026.8.11", sha: "abcdef1234567890" },
+      { gateway: "ws://gateway.test", profileId: null },
+    );
 
     expect(showToastMock).toHaveBeenCalledWith({
       message: "Gateway updated · now on abcdef1.",

--- a/ui/src/app/update-success-notice.ts
+++ b/ui/src/app/update-success-notice.ts
@@ -1,15 +1,76 @@
-// A verified install whose bundle differs from this document reloads the page
-// (`reloadControlUiIfStale`), which destroys any in-memory outcome. Record the
-// result before that navigation so the reloaded document still tells the
-// operator the update finished instead of coming back silently.
+// The serving bundle may retire this document before reconnect admits it.
+// Preserve the pending read-only reconciliation and its eventual notice across
+// that reload; neither record authorizes starting another update.
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { reloadControlUiIfStale } from "../build-info.ts";
 import { t } from "../i18n/index.ts";
 import { showToast } from "../lib/toast.ts";
 import { getSafeSessionStorage } from "../local-storage.ts";
+import {
+  UPDATE_HANDOFF_TIMEOUT_MS,
+  type PendingUpdateReconciliation,
+} from "./update-overlay-helpers.ts";
 
-const UPDATE_SUCCESS_NOTICE_KEY = "openclaw:control-ui:update-succeeded:v1";
+const UPDATE_NOTICE_KEY = "openclaw:control-ui:update:v1";
 
 type UpdateInstallIdentity = { version: string | null; sha: string | null };
+type UpdateNoticeScope = { gateway: string; profileId: string | null };
+type VerifiedUpdateNotice = UpdateNoticeScope &
+  UpdateInstallIdentity & {
+    kind: "verified";
+    deadlineAtMs: number;
+  };
+type UpdateNotice = (UpdateNoticeScope & PendingUpdateReconciliation) | VerifiedUpdateNotice;
+
+export function writeUpdateNotice(notice: UpdateNotice | null): void {
+  try {
+    const storage = getSafeSessionStorage();
+    if (notice === null) {
+      storage?.removeItem(UPDATE_NOTICE_KEY);
+    } else {
+      storage?.setItem(UPDATE_NOTICE_KEY, JSON.stringify(notice));
+    }
+  } catch {
+    // Denied storage must not prevent the current document reporting its result.
+  }
+}
+
+function isUpdateNotice(notice: unknown, gateway: string): notice is UpdateNotice {
+  if (
+    !isRecord(notice) ||
+    notice.gateway !== gateway ||
+    (notice.profileId !== null && typeof notice.profileId !== "string") ||
+    (notice.kind !== "verified" &&
+      notice.kind !== "ambiguous" &&
+      notice.kind !== "handoff" &&
+      notice.kind !== "restart") ||
+    typeof notice.deadlineAtMs !== "number" ||
+    !Number.isFinite(notice.deadlineAtMs) ||
+    notice.deadlineAtMs > Date.now() + UPDATE_HANDOFF_TIMEOUT_MS ||
+    (notice.kind === "verified" && notice.deadlineAtMs <= Date.now())
+  ) {
+    return false;
+  }
+  return (
+    notice.kind === "verified"
+      ? [notice.version, notice.sha]
+      : [notice.expectedVersion, notice.expectedSha, notice.handoffId]
+  ).every((value) => value === null || typeof value === "string");
+}
+
+export function readUpdateNotice(gateway: string): UpdateNotice | null {
+  try {
+    const raw = getSafeSessionStorage()?.getItem(UPDATE_NOTICE_KEY);
+    const notice: unknown = raw && raw.length <= 4_096 ? JSON.parse(raw) : null;
+    if (isUpdateNotice(notice, gateway)) {
+      return notice;
+    }
+  } catch {
+    // Invalid or inaccessible transient notices cannot resume reconciliation.
+  }
+  writeUpdateNotice(null);
+  return null;
+}
 
 function formatUpdateSuccess(identity: UpdateInstallIdentity): string {
   // A git install keeps its version across commits, so the commit is the only
@@ -22,45 +83,36 @@ function formatUpdateSuccess(identity: UpdateInstallIdentity): string {
   return version ? t("updates.succeededVersion", { version }) : t("updates.succeeded");
 }
 
-function takeRecordedUpdateSuccess(): string | null {
-  try {
-    const storage = getSafeSessionStorage();
-    const raw = storage?.getItem(UPDATE_SUCCESS_NOTICE_KEY) ?? null;
-    storage?.removeItem(UPDATE_SUCCESS_NOTICE_KEY);
-    return raw;
-  } catch {
-    return null;
-  }
-}
-
 /** Records the outcome, then presents it here unless a reload will present it. */
-export function announceVerifiedUpdateInstall(identity: UpdateInstallIdentity): void {
-  try {
-    getSafeSessionStorage()?.setItem(UPDATE_SUCCESS_NOTICE_KEY, JSON.stringify(identity));
-  } catch {
-    // Storage is best effort; a document that stays put still announces below.
-  }
+export function announceVerifiedUpdateInstall(
+  identity: UpdateInstallIdentity,
+  scope: UpdateNoticeScope,
+): void {
+  writeUpdateNotice({
+    ...identity,
+    ...scope,
+    kind: "verified",
+    deadlineAtMs: Date.now() + UPDATE_HANDOFF_TIMEOUT_MS,
+  });
   if (!reloadControlUiIfStale(identity)) {
-    takeRecordedUpdateSuccess();
+    writeUpdateNotice(null);
     showToast({ message: formatUpdateSuccess(identity) });
   }
 }
 
 /** Presents a recorded install outcome once, then forgets it. */
-export function announceRecordedUpdateSuccess(): void {
-  const raw = takeRecordedUpdateSuccess();
-  if (!raw) {
+export function announceRecordedUpdateSuccess(scope: UpdateNoticeScope | null): void {
+  if (!scope) {
+    writeUpdateNotice(null);
     return;
   }
-  let identity: UpdateInstallIdentity;
-  try {
-    const parsed = JSON.parse(raw) as Partial<UpdateInstallIdentity>;
-    identity = {
-      version: typeof parsed.version === "string" ? parsed.version : null,
-      sha: typeof parsed.sha === "string" ? parsed.sha : null,
-    };
-  } catch {
+  const notice = readUpdateNotice(scope.gateway);
+  if (notice?.kind !== "verified") {
     return;
   }
-  showToast({ message: formatUpdateSuccess(identity) });
+  writeUpdateNotice(null);
+  if (notice.profileId !== scope.profileId) {
+    return;
+  }
+  showToast({ message: formatUpdateSuccess(notice) });
 }

--- a/ui/src/e2e/updates-settings.e2e.test.ts
+++ b/ui/src/e2e/updates-settings.e2e.test.ts
@@ -16,7 +16,7 @@ const suite = createControlUiE2eSuite({
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 
 suite.define(() => {
-  it("locks update policy while an automatic apply runs and reports its terminal failure", async () => {
+  it("locks update policy while an automatic apply runs and shows readable recovery guidance", async () => {
     const artifactDir = captureProof
       ? createControlUiE2eArtifactDir("updates-automatic-lifecycle")
       : null;
@@ -56,6 +56,7 @@ suite.define(() => {
         expect((await page.goto(`${suite.server.baseUrl}settings/updates`))?.status()).toBe(200);
         await gateway.waitForRequest("update.status");
         const policy = page.getByRole("switch", { name: "Automatic updates" });
+        const checks = page.getByRole("switch", { name: "Check for updates" });
         await policy.waitFor();
         await expect.poll(() => policy.isDisabled()).toBe(false);
 
@@ -84,6 +85,7 @@ suite.define(() => {
         }
         expect(await status.textContent()).toContain("Applying update");
         expect(await policy.isDisabled()).toBe(true);
+        expect(await checks.isDisabled()).toBe(true);
         expect(await page.locator("wa-radio-group").getAttribute("disabled")).not.toBeNull();
         expect(
           await page.getByRole("button", { name: "Updating…", exact: true }).isDisabled(),
@@ -92,28 +94,50 @@ suite.define(() => {
         await gateway.setMethodResponse("update.status", {
           sentinel: {
             kind: "update",
-            status: "error",
+            status: "skipped",
             ts: now,
-            stats: { mode: "npm", reason: "global-install-failed" },
+            stats: { mode: "npm", reason: "managed-service-handoff-unavailable" },
           },
           schedule,
         });
         await gateway.emitGatewayEvent("update.available", { schedule });
-        await status.filter({ hasText: "global-install-failed" }).waitFor();
+        await status.filter({ hasText: "Stop the foreground Gateway" }).waitFor();
         expect(await policy.isDisabled()).toBe(false);
+        expect(await checks.isDisabled()).toBe(false);
         expect(await gateway.getRequests("update.run")).toHaveLength(0);
+        await status.scrollIntoViewIfNeeded();
         if (artifactDir) {
           await page.screenshot({
             animations: "disabled",
             fullPage: true,
-            path: path.join(artifactDir, "02-automatic-failure.png"),
+            path: path.join(artifactDir, "02-automatic-recovery.png"),
           });
         }
+        const geometry = await status.evaluate((element) => {
+          const row = element.closest(".settings-row");
+          const title = row?.querySelector(".settings-row__title");
+          if (!row || !title) {
+            throw new Error("Missing update status row or title");
+          }
+          const bounds = element.getBoundingClientRect();
+          const rowBounds = row.getBoundingClientRect();
+          const titleBounds = title.getBoundingClientRect();
+          return {
+            insideRow: bounds.left >= rowBounds.left && bounds.right <= rowBounds.right,
+            overlapsTitle:
+              bounds.left < titleBounds.right &&
+              bounds.right > titleBounds.left &&
+              bounds.top < titleBounds.bottom &&
+              bounds.bottom > titleBounds.top,
+            overflows: element.scrollWidth > element.clientWidth,
+          };
+        });
+        expect(geometry).toEqual({ insideRow: true, overlapsTitle: false, overflows: false });
       },
     );
   });
 
-  it("renders live campaign status without requesting config.schema", async () => {
+  it("resumes disabled update checks through autosave and renders the live campaign", async () => {
     if (captureProof) {
       await mkdir(path.join(suite.artifactDir, "updates-settings"), { recursive: true });
     }
@@ -133,7 +157,9 @@ suite.define(() => {
           : {}),
       },
       async ({ page }) => {
-        const config = { update: { auto: { enabled: true }, channel: "stable" } };
+        const config = {
+          update: { auto: { enabled: true }, channel: "stable", checkOnStart: false },
+        };
         const gateway = await installMockGateway(page, {
           featureMethods: ["config.get", "config.set", "config.apply", "update.run"],
           methodResponses: {
@@ -158,6 +184,37 @@ suite.define(() => {
         await gateway.waitForRequest("config.get");
         expect(await gateway.getRequests("config.schema")).toHaveLength(0);
 
+        const content = page.locator("#control-ui-main");
+        await content.getByText("Updates", { exact: true }).waitFor();
+        const checks = content.getByRole("switch", { name: "Check for updates", exact: true });
+        const automatic = content.getByRole("switch", { name: "Automatic updates", exact: true });
+        await expect.poll(() => automatic.isChecked()).toBe(true);
+        if (captureProof) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(
+              suite.artifactDir,
+              "updates-settings",
+              "00-updates-checks-disabled.png",
+            ),
+          });
+        }
+        expect(await checks.isChecked()).toBe(false);
+        expect(await automatic.isDisabled()).toBe(true);
+        await content
+          .locator(".settings-row__title")
+          .filter({ hasText: /^Check for updates$/ })
+          .click();
+        const checksSaved = await gateway.waitForRequest("config.set");
+        const checksRaw = (checksSaved.params as { raw?: unknown }).raw;
+        expect(typeof checksRaw).toBe("string");
+        expect(JSON.parse(String(checksRaw))).toMatchObject({
+          update: { checkOnStart: true, channel: "stable", auto: { enabled: true } },
+        });
+        await expect.poll(() => automatic.isDisabled()).toBe(false);
+        expect(await automatic.isChecked()).toBe(true);
+
         await gateway.emitGatewayEvent("update.available", {
           updateAvailable: {
             currentVersion: "2026.8.1",
@@ -180,8 +237,6 @@ suite.define(() => {
           },
         });
 
-        const content = page.locator("#control-ui-main");
-        await content.getByText("Updates", { exact: true }).waitFor();
         const timer = content.locator("[role='timer']");
         await expect.poll(() => timer.textContent()).toContain("Updating in 0:");
         const firstCountdown = await timer.textContent();
@@ -200,8 +255,15 @@ suite.define(() => {
           });
         }
 
+        const writesBeforeChannelChange = (await gateway.getRequests("config.set")).length;
         await content.getByRole("radio", { name: "Beta", exact: true }).click();
-        const configSet = await gateway.waitForRequest("config.set");
+        await expect
+          .poll(async () => (await gateway.getRequests("config.set")).length)
+          .toBe(writesBeforeChannelChange + 1);
+        const configSet = (await gateway.getRequests("config.set")).at(-1);
+        if (!configSet) {
+          throw new Error("Missing channel config write");
+        }
         const raw = (configSet.params as { raw?: unknown }).raw;
         expect(typeof raw).toBe("string");
         expect(JSON.parse(String(raw))).toMatchObject({ update: { channel: "beta" } });
@@ -247,6 +309,9 @@ suite.define(() => {
         );
         expect(await page.locator("wa-radio-group").getAttribute("disabled")).not.toBeNull();
         expect(await page.getByRole("switch", { name: "Automatic updates" }).isDisabled()).toBe(
+          true,
+        );
+        expect(await page.getByRole("switch", { name: "Check for updates" }).isDisabled()).toBe(
           true,
         );
         expect(await page.getByRole("button", { name: "Update now" }).isDisabled()).toBe(true);

--- a/ui/src/e2e/updates-settings.e2e.test.ts
+++ b/ui/src/e2e/updates-settings.e2e.test.ts
@@ -2,6 +2,7 @@
 import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -15,6 +16,103 @@ const suite = createControlUiE2eSuite({
 const captureProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
 
 suite.define(() => {
+  it("locks update policy while an automatic apply runs and reports its terminal failure", async () => {
+    const artifactDir = captureProof
+      ? createControlUiE2eArtifactDir("updates-automatic-lifecycle")
+      : null;
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+        ...(artifactDir
+          ? { recordVideo: { dir: artifactDir, size: { height: 900, width: 1280 } } }
+          : {}),
+      },
+      async ({ page }) => {
+        const config = { update: { auto: { enabled: true }, channel: "stable" } };
+        const schedule = {
+          channel: "stable",
+          autoEnabled: true,
+          install: { kind: "package" },
+          target: { kind: "package", version: "2026.8.2" },
+        };
+        const gateway = await installMockGateway(page, {
+          featureMethods: ["config.get", "config.set", "update.run", "update.status"],
+          methodResponses: {
+            "config.get": {
+              config,
+              hash: "automatic-update-config",
+              issues: [],
+              raw: JSON.stringify(config),
+              runtimeConfig: config,
+              valid: true,
+            },
+            "update.status": { sentinel: null, schedule },
+          },
+          operatorScopes: ["operator.read", "operator.admin"],
+        });
+        expect((await page.goto(`${suite.server.baseUrl}settings/updates`))?.status()).toBe(200);
+        await gateway.waitForRequest("update.status");
+        const policy = page.getByRole("switch", { name: "Automatic updates" });
+        await policy.waitFor();
+        await expect.poll(() => policy.isDisabled()).toBe(false);
+
+        const now = Date.now();
+        await gateway.emitGatewayEvent("update.available", {
+          schedule: {
+            ...schedule,
+            campaign: {
+              id: "campaign-automatic",
+              state: "applying",
+              announcedAtMs: now - 60_000,
+              holdUntilMs: now + 3_600_000,
+              forceAtMs: now + 4_500_000,
+              updatedAtMs: now,
+            },
+          },
+        });
+        const status = page.locator("#config-section-update .settings-status");
+        await expect.poll(() => status.textContent()).toMatch(/Applying update|Update held/);
+        if (artifactDir) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "01-automatic-applying.png"),
+          });
+        }
+        expect(await status.textContent()).toContain("Applying update");
+        expect(await policy.isDisabled()).toBe(true);
+        expect(await page.locator("wa-radio-group").getAttribute("disabled")).not.toBeNull();
+        expect(
+          await page.getByRole("button", { name: "Updating…", exact: true }).isDisabled(),
+        ).toBe(true);
+
+        await gateway.setMethodResponse("update.status", {
+          sentinel: {
+            kind: "update",
+            status: "error",
+            ts: now,
+            stats: { mode: "npm", reason: "global-install-failed" },
+          },
+          schedule,
+        });
+        await gateway.emitGatewayEvent("update.available", { schedule });
+        await status.filter({ hasText: "global-install-failed" }).waitFor();
+        expect(await policy.isDisabled()).toBe(false);
+        expect(await gateway.getRequests("update.run")).toHaveLength(0);
+        if (artifactDir) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(artifactDir, "02-automatic-failure.png"),
+          });
+        }
+      },
+    );
+  });
+
   it("renders live campaign status without requesting config.schema", async () => {
     if (captureProof) {
       await mkdir(path.join(suite.artifactDir, "updates-settings"), { recursive: true });
@@ -205,10 +303,14 @@ suite.define(() => {
         await gateway.waitForRequest("update.status");
         const checkStatus = page.getByRole("button", { name: "Check status", exact: true });
         await checkStatus.waitFor();
+        await expect.poll(() => checkStatus.isDisabled()).toBe(false);
+        const statusRequestsBeforeCheck = (await gateway.getRequests("update.status")).length;
 
         await gateway.deferNext("update.status");
         await checkStatus.click();
-        await expect.poll(async () => (await gateway.getRequests("update.status")).length).toBe(2);
+        await expect
+          .poll(async () => (await gateway.getRequests("update.status")).length)
+          .toBe(statusRequestsBeforeCheck + 1);
         expect(await checkStatus.isDisabled()).toBe(true);
 
         await gateway.rejectDeferred("update.status", {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -557,6 +557,8 @@ export const en: TranslationMap = {
       policyTitle: "Update policy",
       channel: "Release channel",
       channelDescription: "Choose which OpenClaw release track this Gateway follows.",
+      checkForUpdates: "Check for updates",
+      checkForUpdatesDescription: "Periodically check for new versions and show update notices.",
       automaticUpdates: "Automatic updates",
       automaticUpdatesDescription:
         "Schedule available updates automatically. Dev auto-updates apply to git checkouts.",
@@ -564,8 +566,7 @@ export const en: TranslationMap = {
         "Automatic dev updates require a source (git) install. This install is a package install — use stable or beta for automatic updates.",
       extendedStableAutomaticHint:
         "Extended stable reports available releases but never installs them automatically.",
-      checksDisabledAutomaticHint:
-        "Update checks are disabled. Set update.checkOnStart to true to resume automatic updates.",
+      checksDisabledAutomaticHint: "Turn on Check for updates to resume automatic updates.",
       statusTitle: "Update status",
       scheduleStatus: "Status",
       commits: "Commits",
@@ -582,8 +583,8 @@ export const en: TranslationMap = {
       updateNowDescription: "Install the available update and restart the Gateway.",
       latestAttempt: "Latest update attempt",
       attemptedAt: "Attempted",
-      attemptTarget: "Target",
-      installedIdentity: "Installed",
+      beforeUpdate: "Before update",
+      afterAttempt: "After attempt",
       attemptInstallKind: "Attempt install type",
       attemptReason: "Reason code",
       failedStep: "Failure details",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -564,6 +564,8 @@ export const en: TranslationMap = {
         "Automatic dev updates require a source (git) install. This install is a package install — use stable or beta for automatic updates.",
       extendedStableAutomaticHint:
         "Extended stable reports available releases but never installs them automatically.",
+      checksDisabledAutomaticHint:
+        "Update checks are disabled. Set update.checkOnStart to true to resume automatic updates.",
       statusTitle: "Update status",
       scheduleStatus: "Status",
       commits: "Commits",
@@ -604,9 +606,9 @@ export const en: TranslationMap = {
     verificationFailedWithIdentity:
       "Update finished, but the running install does not match the expected revision. Expected {expected}, running {actual}.",
     handoffTimeout:
-      "Update handoff started, but completion was not reported after reconnect. Run `openclaw update status` for the final result.",
+      "Update completion was not confirmed. Check `openclaw gateway status` and `openclaw update status` before retrying.",
     outcomeUnknown:
-      "The update request may have been accepted, but the Gateway did not report a final result after reconnect. Run `openclaw update status` before retrying.",
+      "The update outcome is unknown. Check `openclaw gateway status` and `openclaw update status` before retrying.",
     failureReasons: {
       dirty: "Commit or stash changes, then retry.",
       noUpstream: "Set an upstream branch, then retry.",
@@ -634,6 +636,8 @@ export const en: TranslationMap = {
       alreadyCurrent: "This checkout is already at its tracked upstream revision.",
       managedServiceHandoffAlreadyRunning:
         "Another managed update is already running. Wait for it to complete, then refresh update status.",
+      managedServiceHandoffUnavailable:
+        "Stop the foreground Gateway, run `openclaw update`, then launch it again. For automatic updates, install a managed Gateway service.",
       doctorFailed: "Doctor repair failed. Run `openclaw doctor --non-interactive` and retry.",
       managedServiceHandoffFailed:
         "The update helper stopped before finishing. Run `openclaw update` in the terminal to see why.",

--- a/ui/src/pages/config/config-page.test.ts
+++ b/ui/src/pages/config/config-page.test.ts
@@ -851,7 +851,20 @@ describe("ConfigPage Updates integration", () => {
     }
     channel.value = "beta";
     channel.dispatchEvent(new Event("change"));
-    const automatic = container.querySelector<HTMLElement & { checked: boolean }>("wa-switch");
+    const policySwitches = [
+      ...container.querySelectorAll<HTMLElement & { checked: boolean }>("wa-switch"),
+    ];
+    const checks = policySwitches.find(
+      (control) => control.textContent?.trim() === "Check for updates",
+    );
+    if (!checks) {
+      throw new Error("Missing update checks control");
+    }
+    checks.checked = false;
+    checks.dispatchEvent(new Event("change"));
+    const automatic = policySwitches.find(
+      (control) => control.textContent?.trim() === "Automatic updates",
+    );
     if (!automatic) {
       throw new Error("Missing automatic update control");
     }
@@ -863,6 +876,7 @@ describe("ConfigPage Updates integration", () => {
     await nextFrame();
 
     expect(patchForm).toHaveBeenCalledWith(["update", "channel"], "beta");
+    expect(patchForm).toHaveBeenCalledWith(["update", "checkOnStart"], false);
     expect(patchForm).toHaveBeenCalledWith(["update", "auto", "enabled"], true);
     // Settings shares the sidebar card's confirmation gate: nothing runs on the click itself.
     expect(runUpdate).not.toHaveBeenCalled();

--- a/ui/src/pages/config/config-page.ts
+++ b/ui/src/pages/config/config-page.ts
@@ -1103,6 +1103,8 @@ export class ConfigPage extends OpenClawLightDomElement {
         canHoldUpdate: canCallGatewayMethod(gatewaySnapshot, "update.hold", "operator.admin"),
         updateBusy: this.isUpdateBusy(),
         onChannelChange: (channel) => runtimeConfig.patchForm(["update", "channel"], channel),
+        onUpdateChecksChange: (enabled) =>
+          runtimeConfig.patchForm(["update", "checkOnStart"], enabled),
         onAutomaticUpdatesChange: (enabled) =>
           runtimeConfig.patchForm(["update", "auto", "enabled"], enabled),
         onUpdateNow: () =>

--- a/ui/src/pages/config/settings-search.test.ts
+++ b/ui/src/pages/config/settings-search.test.ts
@@ -177,7 +177,7 @@ describe("findSettingsSearchBlocks", () => {
     ]);
   });
 
-  it("does not promise update fields the curated Updates page cannot edit", () => {
+  it("finds existing update checks and channel controls on the curated Updates page", () => {
     const updateSchema = {
       type: "object",
       properties: {
@@ -195,9 +195,6 @@ describe("findSettingsSearchBlocks", () => {
       "update.checkOnStart": { advanced: false },
     };
 
-    // checkOnStart renders nowhere on the Updates page (curated rows only)
-    // and the Advanced page excludes the scoped update section — a search hit
-    // would dead-end. The curated fields still match.
     expect(
       findSettingsSearchBlocks({
         query: "check on start",
@@ -205,7 +202,15 @@ describe("findSettingsSearchBlocks", () => {
         value: {},
         uiHints,
       }),
-    ).toEqual([]);
+    ).toEqual([expect.objectContaining({ routeId: "updates", hash: "#config-section-update" })]);
+    expect(
+      findSettingsSearchBlocks({
+        query: "check for updates",
+        schema: null,
+        value: null,
+        uiHints: {},
+      }),
+    ).toEqual([expect.objectContaining({ routeId: "updates", hash: "#config-section-update" })]);
     expect(
       findSettingsSearchBlocks({
         query: "update channel",

--- a/ui/src/pages/config/settings-search.ts
+++ b/ui/src/pages/config/settings-search.ts
@@ -38,10 +38,10 @@ function resolveStaticSettingsBlock(block: SettingsSearchTarget): StaticSettings
 
 // Curated pages render only a subset of their section's schema; search must
 // promise exactly what the destination page can edit, or the result is a
-// dead-end (e.g. update.checkOnStart matched search but was editable nowhere).
+// dead-end.
 const CURATED_ROUTE_VISIBLE_KEYS: Partial<Record<string, () => readonly string[]>> = {
   memory: memoryVisibleSchemaKeys,
-  updates: () => ["channel", "auto"],
+  updates: () => ["channel", "checkOnStart", "auto"],
 };
 
 function visibleSectionSchema(routeId: string, sectionSchema: JsonSchema): JsonSchema {

--- a/ui/src/pages/config/settings-targets.test.ts
+++ b/ui/src/pages/config/settings-targets.test.ts
@@ -26,6 +26,7 @@ describe("settings search target manifest", () => {
         target.hash,
       ]),
     ).toEqual([
+      ["updates", "/settings/updates", "", "#config-section-update"],
       ["channels", "/settings/channels", "", ""],
       ["security", "/settings/security", "", ""],
       ["secrets", "/settings/secrets", "", ""],

--- a/ui/src/pages/config/settings-targets.ts
+++ b/ui/src/pages/config/settings-targets.ts
@@ -28,6 +28,12 @@ export type SettingsSearchTarget = {
 // Keep destinations and translation keys together without importing page
 // renderers: settings search runs before the destination page is loaded.
 export const SETTINGS_SEARCH_TARGETS = {
+  updates: {
+    routeId: "updates",
+    labelKey: "tabs.updates",
+    hash: "#config-section-update",
+    searchKeys: ["updates.page.checkForUpdates", "updates.page.automaticUpdates"],
+  },
   channels: {
     routeId: "channels",
     labelKey: "quickSettings.channels.title",

--- a/ui/src/pages/config/updates.test.ts
+++ b/ui/src/pages/config/updates.test.ts
@@ -143,6 +143,23 @@ describe("renderUpdates", () => {
     expect(automaticRow.querySelector("wa-switch")?.hasAttribute("disabled")).toBe(true);
   });
 
+  it("explains when disabled update checks prevent automatic installation", () => {
+    render(
+      renderUpdates(
+        createProps({
+          configObject: {
+            update: { channel: "stable", checkOnStart: false, auto: { enabled: true } },
+          },
+          schedule: { channel: "stable", autoEnabled: false },
+        }),
+      ),
+      container,
+    );
+
+    expect(row("Automatic updates").textContent).toContain("update.checkOnStart");
+    expect(row("Automatic updates").textContent).toContain("disabled");
+  });
+
   it.each([
     {
       name: "disables dev package installs",

--- a/ui/src/pages/config/updates.test.ts
+++ b/ui/src/pages/config/updates.test.ts
@@ -2,6 +2,7 @@
 
 import { render } from "lit";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { projectUpdateStatusResponse } from "../../app/update-overlay-helpers.ts";
 import { i18n } from "../../i18n/index.ts";
 import { renderUpdates } from "./updates.ts";
 
@@ -38,6 +39,7 @@ function createProps(overrides: Partial<UpdatesViewProps> = {}): UpdatesViewProp
     updateBusy: false,
     nowMs: 1_000,
     onChannelChange: vi.fn(),
+    onUpdateChecksChange: vi.fn(),
     onAutomaticUpdatesChange: vi.fn(),
     onUpdateNow: vi.fn(),
     onHoldUpdate: vi.fn(async () => true),
@@ -58,10 +60,10 @@ function row(title: string): HTMLElement {
 
 function automaticUpdatesControl(): {
   row: HTMLElement;
-  toggle: HTMLElement;
+  toggle: HTMLElement & { checked: boolean };
 } {
   const automaticRow = row("Automatic updates");
-  const toggle = automaticRow.querySelector<HTMLElement>("wa-switch");
+  const toggle = automaticRow.querySelector<HTMLElement & { checked: boolean }>("wa-switch");
   if (!toggle) {
     throw new Error("Missing automatic updates control");
   }
@@ -143,7 +145,8 @@ describe("renderUpdates", () => {
     expect(automaticRow.querySelector("wa-switch")?.hasAttribute("disabled")).toBe(true);
   });
 
-  it("explains when disabled update checks prevent automatic installation", () => {
+  it("lets an admin resume disabled checks while preserving the automatic-update preference", () => {
+    const onUpdateChecksChange = vi.fn();
     render(
       renderUpdates(
         createProps({
@@ -151,13 +154,27 @@ describe("renderUpdates", () => {
             update: { channel: "stable", checkOnStart: false, auto: { enabled: true } },
           },
           schedule: { channel: "stable", autoEnabled: false },
+          onUpdateChecksChange,
         }),
       ),
       container,
     );
 
-    expect(row("Automatic updates").textContent).toContain("update.checkOnStart");
-    expect(row("Automatic updates").textContent).toContain("disabled");
+    const checks = row("Check for updates").querySelector<HTMLElement & { checked: boolean }>(
+      "wa-switch",
+    );
+    if (!checks) {
+      throw new Error("Missing update checks control");
+    }
+    expect(checks.checked).toBe(false);
+    expect(checks.hasAttribute("disabled")).toBe(false);
+    const automatic = automaticUpdatesControl().toggle;
+    expect(automatic.checked).toBe(true);
+    expect(automatic.hasAttribute("disabled")).toBe(true);
+    expect(row("Automatic updates").textContent).toContain("Check for updates");
+    checks.checked = true;
+    checks.dispatchEvent(new Event("change"));
+    expect(onUpdateChecksChange).toHaveBeenCalledWith(true);
   });
 
   it.each([
@@ -473,45 +490,71 @@ describe("renderUpdates", () => {
     expect(row("Status").querySelector(".settings-status--danger")).not.toBeNull();
   });
 
-  it("renders the recorded failure details and typed recovery actions", () => {
-    const onUpdateNow = vi.fn();
-    const onCheckStatus = vi.fn(async () => undefined);
-    render(
-      renderUpdates(
-        createProps({
-          recordedAttempt: {
-            timestampMs: 500,
-            status: "error",
-            reason: "build-failed",
-            installKind: "git",
-            installedVersion: null,
-            installedSha: "0123456789abcdef",
-            targetVersion: null,
-            targetSha: null,
-            failure: { step: "build", detail: "Type check failed" },
-          },
-          onUpdateNow,
-          onCheckStatus,
-        }),
-      ),
-      container,
-    );
+  it.each([
+    {
+      label: "a failed build with no recorded after identity",
+      status: "error",
+      stats: {
+        mode: "git",
+        reason: "build-failed",
+        before: { sha: "0123456789abcdef" },
+        steps: [{ name: "build", log: { exitCode: 1, stderrTail: "Type check failed" } }],
+      },
+      before: "0123456789ab",
+      after: "Unknown",
+    },
+    {
+      label: "a skipped update that leaves the installed version unchanged",
+      status: "skipped",
+      stats: {
+        mode: "npm",
+        reason: "managed-service-handoff-unavailable",
+        before: { version: "2026.8.1" },
+        after: { version: "2026.8.1" },
+      },
+      before: "v2026.8.1",
+      after: "v2026.8.1",
+    },
+  ])(
+    "renders recorded identities and recovery actions for $label",
+    ({ status, stats, before, after }) => {
+      const onUpdateNow = vi.fn();
+      const onCheckStatus = vi.fn(async () => undefined);
+      const projected = projectUpdateStatusResponse(
+        { sentinel: { kind: "update", status, ts: 500, stats } },
+        { updateStatusBanner: null, recordedUpdateAttempt: null, heldUpdateCampaignId: null },
+      );
+      render(
+        renderUpdates(
+          createProps({
+            recordedAttempt: projected.recordedUpdateAttempt,
+            statusBanner: projected.updateStatusBanner,
+            onUpdateNow,
+            onCheckStatus,
+          }),
+        ),
+        container,
+      );
 
-    expect(row("Reason code").textContent).toContain("build-failed");
-    expect(row("Target").textContent).toContain("v2026.8.2");
-    expect(row("Installed").textContent).toContain("0123456789ab");
-    expect(row("Attempt install type").textContent).toContain("git");
-    expect(row("Failure details").textContent).toContain("Type check failed");
-    const recovery = row("Recovery");
-    recovery.querySelector<HTMLButtonElement>("button")?.click();
-    recovery.querySelectorAll<HTMLButtonElement>("button")[1]?.click();
-    expect(onCheckStatus).toHaveBeenCalledOnce();
-    expect(onUpdateNow).toHaveBeenCalledOnce();
-    expect(
-      container.querySelector<HTMLAnchorElement>("a[href*='update-troubleshooting']"),
-    ).not.toBeNull();
-    expect(row("CLI fallback").textContent).toContain("openclaw update status --json");
-  });
+      expect(row("Reason code").textContent).toContain(stats.reason);
+      expect(row("Before update").textContent).toContain(before);
+      expect(row("After attempt").textContent).toContain(after);
+      expect(row("After attempt").textContent).not.toContain("v2026.8.2");
+      expect(row("Attempt install type").textContent).toContain(stats.mode);
+      if (status === "error") {
+        expect(row("Failure details").textContent).toContain("Type check failed");
+      }
+      const recovery = row("Recovery");
+      recovery.querySelector<HTMLButtonElement>("button")?.click();
+      recovery.querySelectorAll<HTMLButtonElement>("button")[1]?.click();
+      expect(onCheckStatus).toHaveBeenCalledOnce();
+      expect(onUpdateNow).toHaveBeenCalledOnce();
+      expect(
+        container.querySelector<HTMLAnchorElement>("a[href*='update-troubleshooting']"),
+      ).not.toBeNull();
+      expect(row("CLI fallback").textContent).toContain("openclaw update status --json");
+    },
+  );
 
   it("keeps read-only facts visible while locking controls for non-admins", () => {
     render(
@@ -526,6 +569,9 @@ describe("renderUpdates", () => {
       true,
     );
     expect(row("Automatic updates").querySelector("wa-switch")?.hasAttribute("disabled")).toBe(
+      true,
+    );
+    expect(row("Check for updates").querySelector("wa-switch")?.hasAttribute("disabled")).toBe(
       true,
     );
     expect(row("Update now").querySelector<HTMLButtonElement>("button")?.disabled).toBe(true);

--- a/ui/src/pages/config/updates.ts
+++ b/ui/src/pages/config/updates.ts
@@ -46,6 +46,7 @@ type UpdatesViewProps = {
   updateBusy: boolean;
   nowMs?: number;
   onChannelChange: (channel: UpdatesChannel) => void;
+  onUpdateChecksChange: (enabled: boolean) => void;
   onAutomaticUpdatesChange: (enabled: boolean) => void;
   onUpdateNow: () => void;
   onHoldUpdate: () => Promise<boolean>;
@@ -62,13 +63,6 @@ function renderRecordedAttempt(props: UpdatesViewProps) {
     return nothing;
   }
   const canRetry = props.canUpdate && !props.updateBusy;
-  const recordedTarget = attempt
-    ? formatAttemptIdentity(attempt.targetVersion, attempt.targetSha)
-    : null;
-  const target =
-    recordedTarget && recordedTarget !== t("common.unknown")
-      ? recordedTarget
-      : (formatUpdateTargetLabel(props.schedule, props.updateAvailable) ?? t("common.unknown"));
   return renderSettingsSection({ title: t("updates.page.latestAttempt") }, [
     attempt
       ? renderSettingsRow({
@@ -76,15 +70,20 @@ function renderRecordedAttempt(props: UpdatesViewProps) {
           control: renderTimestamp(attempt.timestampMs, props.nowMs),
         })
       : nothing,
-    renderSettingsRow({
-      title: t("updates.page.attemptTarget"),
-      control: renderSettingsValue(target, { mono: true }),
-    }),
     attempt
       ? renderSettingsRow({
-          title: t("updates.page.installedIdentity"),
+          title: t("updates.page.beforeUpdate"),
           control: renderSettingsValue(
-            formatAttemptIdentity(attempt.installedVersion, attempt.installedSha),
+            formatAttemptIdentity(attempt.beforeVersion, attempt.beforeSha),
+            { mono: true },
+          ),
+        })
+      : nothing,
+    attempt
+      ? renderSettingsRow({
+          title: t("updates.page.afterAttempt"),
+          control: renderSettingsValue(
+            formatAttemptIdentity(attempt.afterVersion, attempt.afterSha),
             { mono: true },
           ),
         })
@@ -393,6 +392,13 @@ export function renderUpdates(props: UpdatesViewProps): TemplateResult {
       }),
     }),
     renderSettingsToggleRow({
+      title: t("updates.page.checkForUpdates"),
+      description: t("updates.page.checkForUpdatesDescription"),
+      checked: !checksDisabled,
+      disabled: props.configBusy,
+      onChange: props.onUpdateChecksChange,
+    }),
+    renderSettingsToggleRow({
       title: t("updates.page.automaticUpdates"),
       description: !automaticUpdatesSupported
         ? t("updates.page.extendedStableAutomaticHint")
@@ -402,7 +408,8 @@ export function renderUpdates(props: UpdatesViewProps): TemplateResult {
             ? t("updates.page.checksDisabledAutomaticHint")
             : t("updates.page.automaticUpdatesDescription"),
       checked: automaticUpdatesSupported && settings.autoEnabled,
-      disabled: props.configBusy || !automaticUpdatesSupported || devPackageInstall,
+      disabled:
+        props.configBusy || checksDisabled || !automaticUpdatesSupported || devPackageInstall,
       onChange: props.onAutomaticUpdatesChange,
     }),
   ];

--- a/ui/src/pages/config/updates.ts
+++ b/ui/src/pages/config/updates.ts
@@ -365,6 +365,7 @@ export function renderUpdates(props: UpdatesViewProps): TemplateResult {
     });
   }
   const automaticUpdatesSupported = settings.channel !== "extended-stable";
+  const checksDisabled = asConfigRecord(props.configObject.update)?.checkOnStart === false;
   const devPackageInstall =
     settings.channel === "dev" && props.schedule?.install?.kind === "package";
   const campaign = props.schedule?.campaign;
@@ -397,7 +398,9 @@ export function renderUpdates(props: UpdatesViewProps): TemplateResult {
         ? t("updates.page.extendedStableAutomaticHint")
         : devPackageInstall
           ? t("updates.page.devPackageAutomaticHint")
-          : t("updates.page.automaticUpdatesDescription"),
+          : checksDisabled
+            ? t("updates.page.checksDisabledAutomaticHint")
+            : t("updates.page.automaticUpdatesDescription"),
       checked: automaticUpdatesSupported && settings.autoEnabled,
       disabled: props.configBusy || !automaticUpdatesSupported || devPackageInstall,
       onChange: props.onAutomaticUpdatesChange,

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -639,6 +639,12 @@ textarea.settings-input {
   align-items: center;
   justify-content: flex-end;
   gap: var(--space-3);
+  min-width: 0;
+
+  .settings-status {
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
 }
 
 .updates-attempt-details {


### PR DESCRIPTION
## What Problem This Solves

Fixes cases where saved update policy was displaced by a one-off beta install, stopped discovery could revive an old campaign, and the Updates page lost the result or allowed conflicting changes during installation. Live testing also exposed a managed service restarting twice and an Updates page that could not recover when update checks were disabled.

## Why This Change Was Made

The saved core channel now owns channel selection, cached availability belongs to its channel, and stopped schedulers cannot publish or apply late results. An applying campaign retains its exact target. Failed attempts are recorded before observers refresh, while rejected or retired requests leave the active owner's result intact.

Automatic installation uses the existing managed-service handoff. Foreground Gateways record a skipped attempt with stop → update → launch guidance; backend/CLI instructions preserve the active profile. Fresh Doctor processes and package verification share the existing update policy; the parent updater owns service refresh and activation, preventing the extra restart found in the live test.

The Control UI has one update lifecycle owner for busy state, status refresh, hold responses, and result reconciliation. A bounded Gateway/profile-scoped browser notice preserves reconciliation across reloads; it never replays an update. Historical attempt details show the recorded **Before update** and **After attempt** identities rather than inferring a target from a later available release. Recovery text wraps within its status row.

## User Impact

Channel policy stays consistent across CLI, Gateway, and web updates, including after a one-off `--tag beta`. Controls lock during installation, recorded failures remain visible, and reloading during an update preserves pending reconciliation.

**Settings → Updates → Check for updates** now edits the existing `update.checkOnStart` preference through the normal save flow. Turning checks off disables the Automatic updates control while preserving its saved preference; turning checks on resumes discovery and any enabled automatic-update policy. Both the visible label and existing setting are searchable. No config key, default, SQLite schema, or feature-statistics preference is added or changed.

Foreground automatic installation intentionally becomes a recorded skip with explicit manual recovery guidance. Plugin compatibility channel selection remains unchanged. Old unscoped success toasts are discarded; the new notice is transient per-tab display state.

## Evidence

- 855 unique focused unit/integration tests pass across 24 files, including 225 Control UI tests, scheduler/RPC ownership, real-child Doctor policy, service integration, and CLI output routing.
- All 23 updater browser scenarios pass: applying/read-only controls, disabled-check recovery through autosave, readable recovery guidance, light/dark lifecycle, reconnects, coalesced restarts, and results retained after reload.
- The full changed-code gate passed; the final UI recovery delta also passed typecheck, lint, and localization checks. Independent review of the complete candidate and subsequent test-only alignment found no findings in the requested P0 scope.

| Real Linux/npm scenario | Observed result |
| --- | --- |
| Saved stable policy with a beta installed | CLI status, dry-run, and authenticated Gateway status stay on stable; a one-off beta target does not rewrite the saved channel. |
| Foreground automatic attempt | Real countdown ends in a recorded skip; the package and serving process remain unchanged and healthy. The displayed manual stop/update/launch recovery installs and starts the requested version. |
| Disable checks while old beta discovery is in flight | The old scheduler stops; its late response cannot revive the campaign or mutate the package. |
| Managed update while the beta tag advances | Installs the announced beta.2 after the tag moves to beta.3, with one helper, exactly one service activation, no Doctor-owned restart, a healthy runtime, and a terminal success record. |

These four service cases passed on `48bfd0ba447d60097d5e88e02c664ed66bdd7c6f`; subsequent changes affect UI, tests, docs, and the measured UI baseline. Core production source is unchanged. The original duplicate-activation failure was retained and rerun successfully after the Doctor ownership repair.

The isolated lane uses Linux/ARM64, Node 24.19.0, npm 11.17.0, and native systemd. Release metadata and tarballs use a fixture registry; the compiled CLI, countdown, npm install/swap, Doctor, managed helper, authenticated RPC, and HTTP health checks are real. Synthetic versions contain the same candidate code, so this establishes lifecycle/install behavior rather than historical-release compatibility. No operator Gateway was changed.

The canonical package embeds final commit `c48b22a855d395f462d61ea5a0eb2863c788debf`; its SHA-256 is `3c7a659eb7c9f0f710ab40bfbf3fe2e016224a777e1749aa65254e44859829b6`. All 6,971 non-UI runtime JavaScript files are byte-identical to the package used for the four passing service scenarios. All 187 dependency inputs are unchanged. Build identity, final UI assets, and declaration member/chunk ordering account for the other artifact differences.

The final Gateway-connected browser run used this exact package with no RPC mocks: the browser enabled checks, persisted `checkOnStart: true` while preserving `auto.enabled: true`, observed the production countdown and recorded skipped outcome, then reloaded and recovered the same result. The package stayed unchanged and healthy, controls settled, no update request replayed, no page errors occurred, and HTTP-served JavaScript/CSS matched the installed archive. Final startup JavaScript measured 347,787 bytes, below the existing 348,368-byte limit.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33459367956) passed: 208 successful jobs, including Windows and the real-Gateway and native-browser lanes.

<details>
<summary>Before/after: controls during an automatic apply (controlled browser regression)</summary>

Before, policy controls remained usable during apply:

![Before: automatic apply leaves policy controls enabled](https://github.com/user-attachments/assets/6ab09333-e110-4462-a553-1c0475bf6ece)

After, both policy toggles and update actions are locked while applying:

![After: automatic apply locks policy controls](https://github.com/user-attachments/assets/30c3110a-d0c4-4638-b51f-e358e72f1bd3)

</details>

<details>
<summary>Final real Gateway: disabled checks and recorded recovery</summary>

![Final package: disabled checks preserve the automatic-update preference](https://github.com/user-attachments/assets/da782514-92ea-4e18-a822-796af5b58360)

![Final package: recorded before/after identities and readable recovery](https://github.com/user-attachments/assets/ac3f0b7e-d9fc-4b18-8e83-0af299ddbcbd)

</details>

Uncut 70-second recording, started after authentication, showing the real settings recovery, countdown, terminal outcome and reload:

https://github.com/user-attachments/assets/f1354964-010e-4e37-9c97-9fd597184c44


Production delta: +386 lines; tests/test support: +1,312; docs: +26. Growth owns cancellation, durable outcomes, bounded browser continuity, and an operable existing-setting recovery path. The unsafe foreground subprocess and duplicated status/Doctor policy paths are removed. The measured startup baseline is 347,792 bytes with the existing 348,368-byte enforcement limit; the 358,400-byte hard cap and growth/variance allowances are unchanged.

CI exposed a missing export in a whole-module CLI fixture and two provider fixtures tied to the real UTC pricing cutoff. The unnecessary CLI stub is removed. The provider fixtures match the equivalent fixes already landed in #134564; production pricing is unchanged. Earlier browser CI stopped at the stale intermediate bundle baseline, which is now refreshed from the canonical production measurement. The final exact-head CI run passes. A prior native-browser tab-creation case also passes on the final head without browser-source changes.

The latest review's recovery finding is addressed by the explicit checks control, search, interaction coverage, and connected-browser proof. Foreground compatibility and production growth are documented above.

Remaining boundary: direct CLI invocation still uses the existing install-coordinator contract. This change does not claim cross-process serialization between every direct CLI update and managed helper. Lost RPC responses without a handoff ID retain the existing identity-based reconciliation limit.

Named UI follow-up: expose backend-owned, profile-aware terminal recovery commands in the browser; its current terminal fallback remains generic. The backend/CLI profile-preservation proof does not claim that browser behavior.

Build follow-up: identical source/dependencies can reorder declaration members and change generated chunk names; runtime JavaScript identity is unaffected.
