### PR TITLE
fix: migrate identical session event replays

### DIFF
--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -1009,7 +1009,7 @@ describe("runDoctorSessionSqlite", () => {
         agentId: "main",
         env: store.env,
         sessionId: "session-1",
-      }).map((event) => event.id),
+      }).map((event) => (event as { id?: string }).id),
     ).toEqual(["session-1", "root", "reply", "selection"]);
 
     const scope = { agentId: "main", env: store.env, sessionId: "session-1" };

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -14,6 +14,12 @@ import {
   upsertSessionEntryCore,
 } from "../config/sessions/session-accessor.sqlite-entry.js";
 import {
+  readSessionTranscriptHistoryEvents,
+  readSessionTranscriptHistoryEventById,
+  readSessionTranscriptHistoryEventCount,
+  readSessionTranscriptHistoryEventPage,
+} from "../config/sessions/session-accessor.sqlite-history-events.js";
+import {
   loadTranscriptEventsSync,
   readTranscriptStatsSync,
 } from "../config/sessions/session-accessor.sqlite-read.js";
@@ -955,6 +961,122 @@ describe("runDoctorSessionSqlite", () => {
       );
     }
     expect(fs.readFileSync(move?.archivePath ?? store.transcriptPath)).toEqual(original);
+  });
+
+  it("archives identical indexed and leaf replays after normalized history verification", async () => {
+    const repeatedMessage = {
+      type: "message",
+      id: "reply",
+      parentId: "root",
+      message: { role: "assistant", content: "same replay" },
+    };
+    const repeatedLeaf = {
+      type: "leaf",
+      id: "selection",
+      parentId: "reply",
+      targetId: "reply",
+    };
+    const store = createLegacyStore({
+      transcriptLines: [
+        JSON.stringify({ type: "session", id: "session-1", version: 3 }),
+        JSON.stringify({
+          type: "message",
+          id: "root",
+          parentId: null,
+          message: { role: "user", content: "root" },
+        }),
+        JSON.stringify(repeatedMessage),
+        JSON.stringify(repeatedMessage),
+        JSON.stringify(repeatedLeaf),
+        JSON.stringify(repeatedLeaf),
+      ],
+    });
+
+    const imported = await runDoctorSessionSqlite({
+      env: store.env,
+      mode: "import",
+      store: store.storePath,
+    });
+
+    expect(imported.targets[0]?.issues).toEqual([]);
+    const move = readMigrationManifest(
+      imported.migrationRun?.manifestPath,
+    ).targets[0]!.completedMoves.find((item) => item.kind === "transcript");
+    expect(move).toBeDefined();
+    expect(fs.existsSync(store.transcriptPath)).toBe(false);
+    expect(
+      loadTranscriptEventsSync({
+        agentId: "main",
+        env: store.env,
+        sessionId: "session-1",
+      }).map((event) => event.id),
+    ).toEqual(["session-1", "root", "reply", "selection"]);
+
+    const scope = { agentId: "main", env: store.env, sessionId: "session-1" };
+    const history = readSessionTranscriptHistoryEvents(scope);
+    expect(history.map((row) => (row.event as { id?: string }).id)).toEqual(["root", "reply"]);
+    expect(readSessionTranscriptHistoryEventCount(scope)).toBe(2);
+    expect(
+      readSessionTranscriptHistoryEventPage(scope, { maxMessages: 1, offset: 0 }),
+    ).toMatchObject({
+      activeLeafEntryId: "reply",
+      totalMessages: 2,
+      events: [expect.objectContaining({ event: expect.objectContaining({ id: "reply" }) })],
+    });
+    expect(readSessionTranscriptHistoryEventById(scope, "reply")).toMatchObject({
+      event: expect.objectContaining({ id: "reply" }),
+    });
+  });
+
+  it("retains complete recovery when durable transcript verification is short", async () => {
+    const store = createLegacyStore({
+      transcriptLines: [
+        JSON.stringify({ type: "session", id: "session-1", version: 3 }),
+        JSON.stringify({
+          type: "message",
+          id: "root",
+          parentId: null,
+          message: { role: "user", content: "root" },
+        }),
+      ],
+    });
+    const snapshot = sqliteReaders.readOnlySqliteValidationSnapshot;
+    const spy = vi
+      .spyOn(sqliteReaders, "readOnlySqliteValidationSnapshot")
+      .mockImplementation((target) => {
+        const result = snapshot(target);
+        if (!result.ok) {
+          return result;
+        }
+        const counts = new Map(result.snapshot.transcriptEventCountsBySessionId);
+        counts.set("session-1", 1);
+        return {
+          ok: true,
+          snapshot: { ...result.snapshot, transcriptEventCountsBySessionId: counts },
+        };
+      });
+    let imported;
+    try {
+      imported = await runDoctorSessionSqlite({
+        env: store.env,
+        mode: "import",
+        store: store.storePath,
+      });
+    } finally {
+      spy.mockRestore();
+    }
+
+    expect(imported.targets[0]?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: "sqlite_transcript_count_mismatch" }),
+      ]),
+    );
+    expect(fs.existsSync(store.transcriptPath)).toBe(true);
+    expect(
+      readMigrationManifest(imported.migrationRun?.manifestPath).targets[0]?.completedMoves.some(
+        (item) => item.kind === "transcript",
+      ),
+    ).toBe(false);
   });
 
   it("retains a recreated archive while resuming an interrupted unlink", async () => {

--- a/src/commands/doctor-session-sqlite.test.ts
+++ b/src/commands/doctor-session-sqlite.test.ts
@@ -19,6 +19,7 @@ import {
   readSessionTranscriptHistoryEventCount,
   readSessionTranscriptHistoryEventPage,
 } from "../config/sessions/session-accessor.sqlite-history-events.js";
+import { importSqliteSessionRows } from "../config/sessions/session-accessor.sqlite-import.js";
 import {
   loadTranscriptEventsSync,
   readTranscriptStatsSync,
@@ -1078,6 +1079,87 @@ describe("runDoctorSessionSqlite", () => {
       ),
     ).toBe(false);
   });
+
+  it.each([
+    {
+      name: "identical",
+      repeated: { role: "assistant", content: "same replay" },
+      archived: true,
+    },
+    {
+      name: "divergent",
+      repeated: { role: "assistant", content: "different replay" },
+      archived: false,
+    },
+  ])(
+    "handles a $name replay against an existing destination and retry",
+    async ({ repeated, archived }) => {
+      const first = {
+        type: "message",
+        id: "reply",
+        parentId: "root",
+        message: { role: "assistant", content: "same replay" },
+      };
+      const sourceEvents = [
+        { type: "session", id: "session-1", version: 3 },
+        {
+          type: "message",
+          id: "root",
+          parentId: null,
+          message: { role: "user", content: "root" },
+        },
+        first,
+        { ...first, message: repeated },
+      ];
+      const store = createLegacyStore({
+        transcriptLines: sourceEvents.map((event) => JSON.stringify(event)),
+      });
+      await importSqliteSessionRows({
+        agentId: "main",
+        env: store.env,
+        sessionKey: "agent:main:main",
+        storePath: store.storePath,
+        entry: { sessionId: "session-1", updatedAt: 1000 },
+        readTranscriptEvents: (append) => sourceEvents.slice(0, 3).forEach(append),
+      });
+
+      const run = () =>
+        runDoctorSessionSqlite({
+          env: store.env,
+          mode: "import",
+          store: store.storePath,
+        });
+      const imported = await run();
+      expect(fs.existsSync(store.transcriptPath)).toBe(!archived);
+      expect(
+        readMigrationManifest(imported.migrationRun?.manifestPath).targets[0]?.completedMoves.some(
+          (item) => item.kind === "transcript",
+        ),
+      ).toBe(archived);
+      expect(
+        imported.targets[0]?.issues.some(
+          (issue) => issue.code === "sqlite_transcript_count_mismatch",
+        ),
+      ).toBe(!archived);
+      expect(
+        loadTranscriptEventsSync({
+          agentId: "main",
+          env: store.env,
+          sessionId: "session-1",
+        }).map((event) => (event as { id?: string }).id),
+      ).toEqual(["session-1", "root", "reply"]);
+
+      if (!archived) {
+        const retried = await run();
+        expect(
+          retried.targets[0]?.issues.some(
+            (issue) => issue.code === "sqlite_transcript_count_mismatch",
+          ),
+        ).toBe(true);
+        expect(fs.existsSync(store.transcriptPath)).toBe(true);
+      }
+    },
+  );
 
   it("retains a recreated archive while resuming an interrupted unlink", async () => {
     const { store, archivePath } = await createVerifiedRecoveryStore();

--- a/src/commands/doctor-session-sqlite.ts
+++ b/src/commands/doctor-session-sqlite.ts
@@ -869,10 +869,11 @@ function validateImportedRecordBeforeArchive(
     return;
   }
   const sqliteEvents = snapshot.transcriptEventCountsBySessionId.get(record.entry.sessionId) ?? 0;
-  if (!record.recovery?.complete && sqliteEvents < (record.recovery?.events ?? result.events)) {
+  const expectedEvents = record.recovery?.events ?? result.events;
+  if (sqliteEvents < expectedEvents) {
     report.issues.push({
       code: "sqlite_transcript_count_mismatch",
-      message: `SQLite transcript has ${sqliteEvents} events; source has ${result.events}.`,
+      message: `SQLite transcript has ${sqliteEvents} events; verified import expects ${expectedEvents}.`,
       sessionKey: record.sessionKey,
     });
   }

--- a/src/config/sessions/session-accessor.sqlite-import-stage.ts
+++ b/src/config/sessions/session-accessor.sqlite-import-stage.ts
@@ -148,7 +148,11 @@ export class SqliteSessionImportStage {
         setClear.run(kind);
       },
     });
+    const repeatedRows = diskSet("repeated");
     const user = this.database.prepare("INSERT OR REPLACE INTO user_keys VALUES (?, ?, ?)");
+    const readRow = this.database.prepare(
+      "SELECT event_json FROM rows WHERE source = ? AND seq = ?",
+    );
     const update = this.database.prepare(
       "UPDATE rows SET event_json = ? WHERE source = ? AND seq = ?",
     );
@@ -161,12 +165,14 @@ export class SqliteSessionImportStage {
     function* entries() {
       for (const row of rows) {
         const entry: unknown = JSON.parse(row.eventJson);
+        let eventJson = row.eventJson;
         if (!isRecord(entry)) {
           recognized = false;
           continue;
         }
         if (normalizeLegacyOpenAICodexTranscriptMetadata([entry]) > 0) {
-          update.run(JSON.stringify(entry), source, row.seq);
+          eventJson = JSON.stringify(entry);
+          update.run(eventJson, source, row.seq);
           changed = true;
         }
         if (entry.type === "session") {
@@ -185,9 +191,22 @@ export class SqliteSessionImportStage {
             strippedKey ?? null,
           );
         }
+        const indexed = isIndexedSessionEntry(entry);
+        const leafControl = isSessionTranscriptLeafControl(entry);
         // Unknown payload stays in the original, never silently declared complete.
-        if (!isIndexedSessionEntry(entry) && !isSessionTranscriptLeafControl(entry)) {
+        if (!indexed && !leafControl) {
           recognized = false;
+        }
+        if (typeof entry.id === "string" && (indexed || leafControl)) {
+          const previous = lookup(entry.id);
+          if (previous) {
+            const previousRow = readRow.get(source, Number(previous.entry.importSeq));
+            if (previousRow && String(previousRow.event_json) === eventJson) {
+              repeatedRows.add(String(row.seq));
+              changed = true;
+              continue;
+            }
+          }
         }
         const metadata = { ...entry };
         delete metadata.message;
@@ -222,6 +241,13 @@ export class SqliteSessionImportStage {
       resetDescendantIds: diskSet("reset"),
       invalidLeafControlIds: diskSet("invalid"),
     });
+    this.database
+      .prepare(
+        `DELETE FROM rows WHERE source = ? AND CAST(seq AS TEXT) IN (
+          SELECT id FROM tree_sets WHERE kind = 'repeated'
+        )`,
+      )
+      .run(source);
     const select = this.database.prepare("INSERT OR REPLACE INTO selected VALUES (?, ?, ?, ?)");
     const selected = this.database.prepare("SELECT 1 FROM selected WHERE id = ?");
     const walk = (leaf: string | null, visible: boolean): boolean => {
@@ -289,9 +315,6 @@ export class SqliteSessionImportStage {
       }
       // Retain the exact header and selected physical rows; rewrite only normalized parent links.
       const chosen = this.database.prepare("SELECT seq, parent_id FROM selected ORDER BY seq");
-      const readRow = this.database.prepare(
-        "SELECT event_json FROM rows WHERE source = ? AND seq = ?",
-      );
       for (const selectedRow of chosen.iterate()) {
         const row = readRow.get(source, selectedRow.seq!);
         // SAFETY: selected rows came from the record-checked navigation pass in this spool.

--- a/src/config/sessions/session-accessor.sqlite-import.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.test.ts
@@ -353,3 +353,88 @@ it.each(["implicit", "leaf", "root", "opaque"])(
     });
   },
 );
+
+it.each([
+  {
+    kind: "indexed",
+    repeated: {
+      type: "message",
+      id: "repeated",
+      parentId: "root",
+      message: { role: "assistant", content: "same replay" },
+    },
+  },
+  {
+    kind: "leaf",
+    repeated: {
+      type: "leaf",
+      id: "repeated",
+      parentId: "root",
+      targetId: "root",
+    },
+  },
+])("repairs an identical repeated $kind event and reruns idempotently", async ({ repeated }) => {
+  await withOpenClawTestState({ label: "import-identical-replay" }, async (state) => {
+    const scope = target(state, "identical-replay");
+    const events = [
+      {
+        type: "session",
+        version: 3,
+        id: "identical-replay",
+        timestamp: "2026-08-30T00:00:00Z",
+        cwd: "/fixture",
+      },
+      {
+        type: "message",
+        id: "root",
+        parentId: null,
+        message: { role: "user", content: "root" },
+      },
+      repeated,
+      repeated,
+    ];
+    const readTranscriptEvents = (append: (event: unknown) => void) => {
+      for (const event of events) {
+        append(event);
+      }
+    };
+
+    const imported = await importSqliteSessionRows({
+      ...scope,
+      repairLegacyTranscript: true,
+      readTranscriptEvents,
+    });
+    expect(imported).toMatchObject({
+      recovery: { complete: true, events: 3, repaired: true },
+      transcriptEvents: 3,
+    });
+    expect(
+      loadTranscriptEventsSync({ ...scope, sessionId: "identical-replay" }).map(
+        (event) => event.id,
+      ),
+    ).toEqual(["identical-replay", "root", "repeated"]);
+
+    await expect(
+      importSqliteSessionRows({
+        ...scope,
+        repairLegacyTranscript: true,
+        readTranscriptEvents,
+      }),
+    ).resolves.toMatchObject({
+      recovery: { complete: true, events: 3, repaired: true },
+      transcriptEvents: 0,
+    });
+    const database = openOpenClawAgentDatabase({ agentId: "main", env: state.env });
+    expect(
+      database.db
+        .prepare(
+          "SELECT event_id, COUNT(*) AS count FROM transcript_event_identities GROUP BY event_id ORDER BY event_id",
+        )
+        .all(),
+    ).toEqual([
+      { event_id: "identical-replay", count: 1 },
+      { event_id: "repeated", count: 1 },
+      { event_id: "root", count: 1 },
+    ]);
+  });
+});

--- a/src/config/sessions/session-accessor.sqlite-import.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-import.test.ts
@@ -410,7 +410,7 @@ it.each([
     });
     expect(
       loadTranscriptEventsSync({ ...scope, sessionId: "identical-replay" }).map(
-        (event) => event.id,
+        (event) => (event as { id?: string }).id,
       ),
     ).toEqual(["identical-replay", "root", "repeated"]);
 


### PR DESCRIPTION
## Summary

- normalize byte-identical repeated indexed and leaf events in the disk-backed legacy transcript import stage
- keep divergent same-ID events fail-closed and retain their legacy source for repair
- require durable SQLite event counts to meet the normalized import expectation before archival, even when recovery reports complete

## Problem

Legacy transcripts can contain byte-identical replayed events. The importer already stores one copy, but branch repair treated every repeated ID as divergent and kept the physical source count. Doctor then reported a transcript count mismatch, retained `sessions.json`, and left the upgraded Gateway unable to start.

## Fix

The migration stage now compares the complete canonical staged event JSON with the previously staged event for that ID. An exact replay is omitted from the normalized spool; any different payload follows the existing blocking path. Doctor validates the resulting durable count against that normalized recovery count before allowing archival.

This changes only legacy migration behavior. It does not alter the SQLite schema, runtime append semantics, generic transcript-tree behavior, or config.

## Verification

- Before the fix, identical indexed and leaf fixtures each reported `complete: false`, `events: 4`, `repaired: false` while SQLite contained three normalized events.
- Before the fix, a forced short durable snapshot was accepted when recovery reported complete.
- Blacksmith Testbox `tbx_01m1d5kd147b35jbxdkdftvsw2`: 13 importer tests passed.
- Blacksmith Testbox `tbx_01m1d5kd147b35jbxdkdftvsw2`: 218 Doctor migration tests passed, with 2 platform-specific skips.
- The successful fixture verifies normal history events, count, page, by-ID lookup, active leaf, canonical identities, archival, and retry idempotence.
- The divergent duplicate fixture verifies the legacy source remains retained.

Fixes #134455
