### PR TITLE
test(firecrawl): check the complete count diagnostic

### DIFF
--- a/extensions/firecrawl/src/firecrawl-tools.test.ts
+++ b/extensions/firecrawl/src/firecrawl-tools.test.ts
@@ -1184,7 +1184,7 @@ describe("firecrawl tools", () => {
         query: "web search",
         count: 6.5,
       }),
-    ).rejects.toThrow("count must be an integer from 1 to 10");
+    ).rejects.toThrow(/^count must be an integer from 1 to 100$/);
     await expect(
       searchTool.execute("call-search-timeout", {
         query: "web search",


### PR DESCRIPTION
## What Problem This Solves

The standalone Firecrawl search test expects an error mentioning a count from 1 to 10, although its schema, validator and documentation use 1 to 100. The test passes because the string matcher accepts substrings.

## Why This Change Was Made

Match the complete documented diagnostic with an anchored regex. This fixes the existing false oracle without adding a test or changing validation, provider policy or production code. The generic web-search provider's separate 1-to-10 limit remains unchanged.

## User Impact

No runtime change. All 60 cases remain; tests are +1/-1 and production is unchanged.

## Evidence

The ordinary whole-file run passed all 60 cases before and after with identical names and order. A temporary production fault changed only the standalone error message from 100 to 10, leaving both numeric maxima at 100: the old selected test passed, and the corrected test failed at its intended assertion. Production was restored before the passing after run.

The installed Vitest/Chai source confirms string containment versus regex matching. This proves diagnostic discrimination, not acceptance of counts 11–100 or rejection of 101. Existing timeout, no-dispatch, cache, auth and network-boundary cases remain unchanged.

All 19 normal changed checks passed, as did managed review and independent source/proof review. The independent branch preserves all 37 qualified source contexts. No live provider call or performance claim is made.

Exact-head [CI run 33455063977](https://github.com/openclaw/openclaw/actions/runs/33455063977) completed successfully at `27fb35e1674aed7487c79e0739343d60bcd59f82`. The completed ClawSweeper review identified no patch defect and requested this execution confirmation because its checkout lacked installed matcher sources. Maintainer inspection of the installed Vitest/Chai implementation and the retained before/after fault runs independently cover that limitation; the separate generic provider limit remains unchanged.
