### PR TITLE
fix(imessage): sends keep failing with an opaque timeout after the private-API bridge dies

### DIFF
--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -533,9 +533,11 @@ describe("IMessageRpcClient bridge-stall cache invalidation", () => {
     await client.stop();
   });
 
-  // send.ts detects a send timeout with /imsg rpc timeout \(send\)/i, so the
-  // original wording has to survive as a prefix of the decorated message.
-  it("keeps the client-side timeout wording send.ts matches on", async () => {
+  // A client-side timeout means our wrapper gave up, not that the bridge is
+  // dead, so it is left completely alone: no eviction, no `imsg launch`
+  // guidance, and the exact wording send.ts matches with
+  // /imsg rpc timeout \(send\)/i preserved.
+  it("leaves a client-side timeout undecorated", async () => {
     vi.useFakeTimers();
     const client = new IMessageRpcClient({ cliPath: "/tmp/imsg-stall-clienttimeout" });
     await client.start();
@@ -546,7 +548,7 @@ describe("IMessageRpcClient bridge-stall cache invalidation", () => {
     const error = (await pending.catch((cause: unknown) => cause)) as Error;
     vi.useRealTimers();
     expect(/imsg rpc timeout \(send\)/i.test(error.message)).toBe(true);
-    expect(error.message).toContain("imsg launch");
+    expect(error.message).not.toContain("imsg launch");
 
     child.emit("close", 0, null);
     await client.stop();

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -578,6 +578,7 @@ describe("IMessageRpcClient bridge-stall cache invalidation", () => {
 
     child.emit("close", 0, null);
     await client.stop();
-    privateApiStatus.invalidateCachedIMessagePrivateApiStatus(cliPath);
+    privateApiStatus.recordIMessageBridgeStall(cliPath);
+    privateApiStatus.recordIMessageBridgeAlive(cliPath);
   });
 });

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -456,6 +456,40 @@ describe("IMessageRpcClient bridge-stall cache invalidation", () => {
     await client.stop();
   });
 
+  // actions.ts caches the probe under the raw `account.config.cliPath` and
+  // hands that same unexpanded string to this client, which then expands it for
+  // spawning. Invalidating under the expanded path would miss the entry for any
+  // `~`-relative cliPath and silently do nothing, which is the exact failure
+  // mode this change exists to remove.
+  it("invalidates under the configured cli path, not the expanded one", async () => {
+    const cliPath = "~/imsg-stall-tilde/imsg";
+    privateApiStatus.setCachedIMessagePrivateApiStatus(cliPath, { ...seeded });
+
+    const client = new IMessageRpcClient({ cliPath });
+    await client.start();
+    const pending = client.request("send", {}, { timeoutMs: 0 });
+    pending.catch(() => {});
+    child.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          error: {
+            code: -32603,
+            message: "Timed out waiting for response to 'send-message'",
+          },
+        })}\n`,
+      ),
+    );
+
+    await pending.catch((cause: unknown) => cause);
+    expect(privateApiStatus.getCachedIMessagePrivateApiStatus(cliPath)).toBeUndefined();
+
+    child.emit("close", 0, null);
+    await client.stop();
+  });
+
   // The cache is what keeps the bridge off the hot path, so an ordinary
   // rejection must not cost every later send a re-probe.
   it("keeps the cached verdict when the request is merely rejected", async () => {

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { IMessagePrivateApiStatus } from "./private-api-status.js";
 
 const spawnMock = vi.hoisted(() => vi.fn());
 
@@ -399,12 +400,14 @@ describe("IMessageRpcClient child stream error handling", () => {
 describe("IMessageRpcClient bridge-stall cache invalidation", () => {
   let child: MockChild;
 
-  const seeded = {
+  // Not `as const`: rpcMethods would widen to `readonly []`, which is not
+  // assignable to the mutable string[] on IMessagePrivateApiStatus.
+  const seeded: IMessagePrivateApiStatus = {
     available: true,
     v2Ready: true,
     selectors: {},
     rpcMethods: [],
-  } as const;
+  };
 
   beforeEach(() => {
     vi.stubEnv("NODE_ENV", "development");

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -578,7 +578,6 @@ describe("IMessageRpcClient bridge-stall cache invalidation", () => {
 
     child.emit("close", 0, null);
     await client.stop();
-    privateApiStatus.recordIMessageBridgeStall(cliPath);
-    privateApiStatus.recordIMessageBridgeAlive(cliPath);
+    privateApiStatus.invalidateCachedIMessagePrivateApiStatus(cliPath);
   });
 });

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -49,10 +49,14 @@ function createMockChild(): MockChild {
 
 let IMessageRpcClient: typeof import("./client.js").IMessageRpcClient;
 let IMessageRpcRequestError: typeof import("./client.js").IMessageRpcRequestError;
+let privateApiStatus: typeof import("./private-api-status.js");
 
 beforeAll(async () => {
   vi.resetModules();
   ({ IMessageRpcClient, IMessageRpcRequestError } = await import("./client.js"));
+  // Imported after resetModules so this is the same module instance the client
+  // mutates; a separate copy would hold a different cache map.
+  privateApiStatus = await import("./private-api-status.js");
 });
 
 afterAll(() => {
@@ -389,5 +393,98 @@ describe("IMessageRpcClient child stream error handling", () => {
     );
     child.emit("close", 0, null);
     await client.stop();
+  });
+});
+
+describe("IMessageRpcClient bridge-stall cache invalidation", () => {
+  let child: MockChild;
+
+  const seeded = {
+    available: true,
+    v2Ready: true,
+    selectors: {},
+    rpcMethods: [],
+  } as const;
+
+  beforeEach(() => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.stubEnv("VITEST", "");
+    child = createMockChild();
+    spawnMock.mockReset().mockReturnValue(child);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  // A successful probe is cached with expiresAt=0 and therefore never expires.
+  // Before this path existed, a bridge that wedged after that probe was never
+  // re-evaluated: Messages.app stayed alive with the dylib mapped, so nothing
+  // else could notice, and every later send was dispatched into a dead bridge
+  // and failed with an opaque -32603 instead of the actionable
+  // "run imsg launch" guidance. Dropping the entry here makes the next action
+  // re-probe. This test fails without the invalidation in request().
+  it("discards the cached verdict when imsg reports its own wait timeout", async () => {
+    const cliPath = "/tmp/imsg-stall-invalidation";
+    privateApiStatus.setCachedIMessagePrivateApiStatus(cliPath, { ...seeded });
+    expect(privateApiStatus.getCachedIMessagePrivateApiStatus(cliPath)?.available).toBe(true);
+
+    const client = new IMessageRpcClient({ cliPath });
+    await client.start();
+    const pending = client.request("send", {}, { timeoutMs: 0 });
+    pending.catch(() => {});
+    child.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          error: {
+            code: -32603,
+            message: "Timed out waiting for response to 'send-message'",
+          },
+        })}\n`,
+      ),
+    );
+
+    const error = await pending.catch((cause: unknown) => cause);
+    expect(error).toBeInstanceOf(IMessageRpcRequestError);
+    expect(privateApiStatus.getCachedIMessagePrivateApiStatus(cliPath)).toBeUndefined();
+
+    child.emit("close", 0, null);
+    await client.stop();
+  });
+
+  // The cache is what keeps the bridge off the hot path, so an ordinary
+  // rejection must not cost every later send a re-probe.
+  it("keeps the cached verdict when the request is merely rejected", async () => {
+    const cliPath = "/tmp/imsg-stall-preserved";
+    privateApiStatus.setCachedIMessagePrivateApiStatus(cliPath, { ...seeded });
+
+    const client = new IMessageRpcClient({ cliPath });
+    await client.start();
+    const pending = client.request("send", {}, { timeoutMs: 0 });
+    pending.catch(() => {});
+    child.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          error: {
+            code: -32602,
+            message: 'Unknown target "nobody" for iMessage',
+          },
+        })}\n`,
+      ),
+    );
+
+    await pending.catch((cause: unknown) => cause);
+    expect(privateApiStatus.getCachedIMessagePrivateApiStatus(cliPath)?.available).toBe(true);
+
+    child.emit("close", 0, null);
+    await client.stop();
+    privateApiStatus.invalidateCachedIMessagePrivateApiStatus(cliPath);
   });
 });

--- a/extensions/imessage/src/client.test.ts
+++ b/extensions/imessage/src/client.test.ts
@@ -490,6 +490,65 @@ describe("IMessageRpcClient bridge-stall cache invalidation", () => {
     await client.stop();
   });
 
+  // Normal outbound sends never read the private-API cache (send.ts builds a
+  // client and dispatches directly), so eviction alone would leave them
+  // repeating an opaque -32603. The decorated message is what reaches the
+  // operator on the very first failed send.
+  it("appends actionable guidance to a stalled send", async () => {
+    const client = new IMessageRpcClient({ cliPath: "/tmp/imsg-stall-guidance" });
+    await client.start();
+    const pending = client.request("send", {}, { timeoutMs: 0 });
+    pending.catch(() => {});
+    child.stdout.emit(
+      "data",
+      Buffer.from(
+        `${JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          error: {
+            code: -32603,
+            message: "Timed out waiting for response to 'send-message'",
+            data: { disposition: "not_started", retry_safe: true },
+          },
+        })}\n`,
+      ),
+    );
+
+    const error = (await pending.catch((cause: unknown) => cause)) as Error;
+    expect(error.message).toContain("Timed out waiting for response to 'send-message'");
+    expect(error.message).toContain("imsg launch");
+    expect(error.message).toContain("channels status --probe");
+    // send.ts reconciles delayed sends off these, so decorating must not drop
+    // the class, code, or data.
+    expect(error).toBeInstanceOf(IMessageRpcRequestError);
+    expect(error).toMatchObject({
+      code: -32603,
+      data: { disposition: "not_started", retry_safe: true },
+    });
+
+    child.emit("close", 0, null);
+    await client.stop();
+  });
+
+  // send.ts detects a send timeout with /imsg rpc timeout \(send\)/i, so the
+  // original wording has to survive as a prefix of the decorated message.
+  it("keeps the client-side timeout wording send.ts matches on", async () => {
+    vi.useFakeTimers();
+    const client = new IMessageRpcClient({ cliPath: "/tmp/imsg-stall-clienttimeout" });
+    await client.start();
+    const pending = client.request("send", {}, { timeoutMs: 10 });
+    pending.catch(() => {});
+    await vi.advanceTimersByTimeAsync(20);
+
+    const error = (await pending.catch((cause: unknown) => cause)) as Error;
+    vi.useRealTimers();
+    expect(/imsg rpc timeout \(send\)/i.test(error.message)).toBe(true);
+    expect(error.message).toContain("imsg launch");
+
+    child.emit("close", 0, null);
+    await client.stop();
+  });
+
   // The cache is what keeps the bridge off the hot path, so an ordinary
   // rejection must not cost every later send a re-probe.
   it("keeps the cached verdict when the request is merely rejected", async () => {

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -7,7 +7,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
 import { expandIMessageUserPath } from "./cli-path.js";
 import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
-import { invalidateCachedIMessagePrivateApiStatus } from "./private-api-status.js";
+import { recordIMessageBridgeAlive, recordIMessageBridgeStall } from "./private-api-status.js";
 
 type IMessageRpcError = {
   code?: number;
@@ -273,7 +273,11 @@ export class IMessageRpcClient {
       this.failTransport(err, this.child);
     }
     try {
-      return await response;
+      const value = await response;
+      // First-hand evidence the bridge answered, which releases a recorded
+      // stall without waiting out its window.
+      recordIMessageBridgeAlive(this.configuredCliPath);
+      return value;
     } catch (err) {
       // Every private-API action funnels through here, so this is the one place
       // that learns the bridge went away. Without it the cached "available"
@@ -282,7 +286,7 @@ export class IMessageRpcClient {
       // "run imsg launch" guidance. Clearing the entry makes the next action
       // re-probe and report the real state.
       if (isIMessageBridgeStall(err)) {
-        invalidateCachedIMessagePrivateApiStatus(this.configuredCliPath);
+        recordIMessageBridgeStall(this.configuredCliPath);
         throw describeIMessageBridgeStall(err);
       }
       throw err;

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -48,15 +48,18 @@ export class IMessageRpcRequestError extends Error {
   }
 }
 
-// A stalled bridge, as opposed to a rejected request.
+// A stalled bridge, as opposed to a rejected or merely slow request.
 //
-// Two shapes mean the same thing — the injected helper never answered:
-//   - imsg replies with a JSON-RPC error carrying its own wait timeout, e.g.
-//     "Internal error: code=-32603 Timed out waiting for response to 'send-message'"
-//   - the request outlives our own client-side timer ("imsg rpc timeout (...)")
+// Matches only imsg's own structured wait error, e.g.
+//   "Internal error: code=-32603 Timed out waiting for response to 'send-message'"
+// which imsg raises after publishing a request to the injected helper and
+// getting nothing back. That is first-hand evidence about the bridge.
 //
-// Deliberately narrow. An ordinary rejection (bad target, unknown chat) says
-// nothing about bridge health and must not discard the capability cache.
+// Deliberately excludes our own client-side timer ("imsg rpc timeout (...)"):
+// it fires when the local wrapper is slow or blocked while imsg itself is
+// healthy, so treating it as a dead bridge would evict a good capability cache
+// and point operators at `imsg launch`, the wrong repair. An ordinary rejection
+// (bad target, unknown chat) says nothing about bridge health either.
 // Module-private: request() is the only production caller, and the behavior is
 // covered through that boundary rather than by calling this directly.
 function isIMessageBridgeStall(error: unknown): boolean {
@@ -65,10 +68,7 @@ function isIMessageBridgeStall(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false;
   }
-  return (
-    error.message.includes("Timed out waiting for response") ||
-    error.message.includes("imsg rpc timeout")
-  );
+  return error.message.includes("Timed out waiting for response");
 }
 
 const BRIDGE_STALL_GUIDANCE =

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -90,6 +90,11 @@ function normalizeIMessageFullDiskAccessError(message: string): string | undefin
 
 export class IMessageRpcClient {
   private readonly cliPath: string;
+  // The private-API cache is keyed by the *configured* cliPath (see
+  // actions.ts, which passes `account.config.cliPath` to both the probe and
+  // this client), so invalidation has to use the same unexpanded string. Using
+  // the expanded one silently misses for any `~`-relative cliPath.
+  private readonly configuredCliPath: string;
   private readonly dbPath?: string;
   private readonly runtime?: RuntimeEnv;
   private readonly onNotification?: (msg: IMessageRpcNotification) => void;
@@ -109,7 +114,8 @@ export class IMessageRpcClient {
   private publicProcessError: string | null = null;
 
   constructor(opts: IMessageRpcClientOptions = {}) {
-    this.cliPath = expandIMessageUserPath(opts.cliPath?.trim() || "imsg");
+    this.configuredCliPath = opts.cliPath?.trim() || "imsg";
+    this.cliPath = expandIMessageUserPath(this.configuredCliPath);
     const dbPath = opts.dbPath?.trim();
     // An explicitly remote database belongs to the Messages Mac. Only local
     // database paths are relative to the Gateway user's home directory.
@@ -248,7 +254,7 @@ export class IMessageRpcClient {
       // "run imsg launch" guidance. Clearing the entry makes the next action
       // re-probe and report the real state.
       if (isIMessageBridgeStall(err)) {
-        invalidateCachedIMessagePrivateApiStatus(this.cliPath);
+        invalidateCachedIMessagePrivateApiStatus(this.configuredCliPath);
       }
       throw err;
     }

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -57,9 +57,18 @@ export class IMessageRpcRequestError extends Error {
 //
 // Deliberately narrow. An ordinary rejection (bad target, unknown chat) says
 // nothing about bridge health and must not discard the capability cache.
-export function isIMessageBridgeStall(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error ?? "");
-  return message.includes("Timed out waiting for response") || message.includes("imsg rpc timeout");
+// Module-private: request() is the only production caller, and the behavior is
+// covered through that boundary rather than by calling this directly.
+function isIMessageBridgeStall(error: unknown): boolean {
+  // Only an Error can carry a stall. Stringifying an arbitrary value here would
+  // render most objects as "[object Object]" and match nothing anyway.
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return (
+    error.message.includes("Timed out waiting for response") ||
+    error.message.includes("imsg rpc timeout")
+  );
 }
 
 const BRIDGE_STALL_GUIDANCE =

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -62,6 +62,34 @@ export function isIMessageBridgeStall(error: unknown): boolean {
   return message.includes("Timed out waiting for response") || message.includes("imsg rpc timeout");
 }
 
+const BRIDGE_STALL_GUIDANCE =
+  "The imsg private API bridge stopped responding. Run `imsg launch` to re-inject the dylib, " +
+  "then `openclaw channels status --probe` to refresh capability detection.";
+
+// Append the actionable cause without rewriting the error.
+//
+// Normal outbound sends never consult the private-API status cache (send.ts
+// builds a client and dispatches directly), so evicting that cache alone leaves
+// them repeating an opaque timeout. Decorating here reaches every caller.
+//
+// Preserve the class, code, data, and original message text: send.ts keys
+// delayed-send reconciliation off `data.disposition`/`data.retry_safe` and
+// matches `imsg rpc timeout (send)` by regex, so the original wording has to
+// survive as a prefix.
+function describeIMessageBridgeStall(error: unknown): unknown {
+  if (error instanceof IMessageRpcRequestError) {
+    return new IMessageRpcRequestError(
+      `${error.message} ${BRIDGE_STALL_GUIDANCE}`,
+      error.code,
+      error.data,
+    );
+  }
+  if (error instanceof Error) {
+    return new Error(`${error.message} ${BRIDGE_STALL_GUIDANCE}`, { cause: error });
+  }
+  return error;
+}
+
 type PendingRequest = {
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
@@ -255,6 +283,7 @@ export class IMessageRpcClient {
       // re-probe and report the real state.
       if (isIMessageBridgeStall(err)) {
         invalidateCachedIMessagePrivateApiStatus(this.configuredCliPath);
+        throw describeIMessageBridgeStall(err);
       }
       throw err;
     }

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -7,7 +7,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
 import { expandIMessageUserPath } from "./cli-path.js";
 import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
-import { recordIMessageBridgeAlive, recordIMessageBridgeStall } from "./private-api-status.js";
+import { invalidateCachedIMessagePrivateApiStatus } from "./private-api-status.js";
 
 type IMessageRpcError = {
   code?: number;
@@ -273,11 +273,7 @@ export class IMessageRpcClient {
       this.failTransport(err, this.child);
     }
     try {
-      const value = await response;
-      // First-hand evidence the bridge answered, which releases a recorded
-      // stall without waiting out its window.
-      recordIMessageBridgeAlive(this.configuredCliPath);
-      return value;
+      return await response;
     } catch (err) {
       // Every private-API action funnels through here, so this is the one place
       // that learns the bridge went away. Without it the cached "available"
@@ -286,7 +282,7 @@ export class IMessageRpcClient {
       // "run imsg launch" guidance. Clearing the entry makes the next action
       // re-probe and report the real state.
       if (isIMessageBridgeStall(err)) {
-        recordIMessageBridgeStall(this.configuredCliPath);
+        invalidateCachedIMessagePrivateApiStatus(this.configuredCliPath);
         throw describeIMessageBridgeStall(err);
       }
       throw err;

--- a/extensions/imessage/src/client.ts
+++ b/extensions/imessage/src/client.ts
@@ -7,6 +7,7 @@ import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coer
 import { resolveUserPath } from "openclaw/plugin-sdk/text-utility-runtime";
 import { expandIMessageUserPath } from "./cli-path.js";
 import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
+import { invalidateCachedIMessagePrivateApiStatus } from "./private-api-status.js";
 
 type IMessageRpcError = {
   code?: number;
@@ -45,6 +46,20 @@ export class IMessageRpcRequestError extends Error {
     super(message);
     this.name = "IMessageRpcRequestError";
   }
+}
+
+// A stalled bridge, as opposed to a rejected request.
+//
+// Two shapes mean the same thing — the injected helper never answered:
+//   - imsg replies with a JSON-RPC error carrying its own wait timeout, e.g.
+//     "Internal error: code=-32603 Timed out waiting for response to 'send-message'"
+//   - the request outlives our own client-side timer ("imsg rpc timeout (...)")
+//
+// Deliberately narrow. An ordinary rejection (bad target, unknown chat) says
+// nothing about bridge health and must not discard the capability cache.
+export function isIMessageBridgeStall(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return message.includes("Timed out waiting for response") || message.includes("imsg rpc timeout");
 }
 
 type PendingRequest = {
@@ -223,7 +238,20 @@ export class IMessageRpcClient {
     } catch (err) {
       this.failTransport(err, this.child);
     }
-    return await response;
+    try {
+      return await response;
+    } catch (err) {
+      // Every private-API action funnels through here, so this is the one place
+      // that learns the bridge went away. Without it the cached "available"
+      // verdict never expires and each later send is dispatched into a dead
+      // bridge, surfacing an opaque -32603 instead of the actionable
+      // "run imsg launch" guidance. Clearing the entry makes the next action
+      // re-probe and report the real state.
+      if (isIMessageBridgeStall(err)) {
+        invalidateCachedIMessagePrivateApiStatus(this.cliPath);
+      }
+      throw err;
+    }
   }
 
   private async stopChild(child: ChildProcessWithoutNullStreams): Promise<void> {

--- a/extensions/imessage/src/private-api-status.bridge-stall.test.ts
+++ b/extensions/imessage/src/private-api-status.bridge-stall.test.ts
@@ -1,16 +1,13 @@
-// Imessage plugin tests cover treating an observed RPC stall as first-hand
-// evidence that outranks imsg's own status claim.
-import { describe, expect, it, vi } from "vitest";
+// Imessage plugin tests cover discarding a cached bridge verdict when the
+// injected helper stops answering.
+import { describe, expect, it } from "vitest";
 import { isIMessageBridgeStall } from "./client.js";
 import {
   getCachedIMessagePrivateApiStatus,
   type IMessagePrivateApiStatus,
-  isIMessageBridgeStalled,
-  recordIMessageBridgeAlive,
-  recordIMessageBridgeStall,
+  invalidateCachedIMessagePrivateApiStatus,
   setCachedIMessagePrivateApiStatus,
 } from "./private-api-status.js";
-import { probeIMessagePrivateApi } from "./probe.js";
 
 const available: IMessagePrivateApiStatus = {
   available: true,
@@ -36,8 +33,8 @@ describe("isIMessageBridgeStall", () => {
   });
 
   it("ignores ordinary rejections, which say nothing about bridge health", () => {
-    // Treating these as a stall would suppress the bridge for a minute over an
-    // ordinary bad argument.
+    // Discarding the capability cache on these would force a needless re-probe
+    // on every bad argument the model supplies.
     expect(isIMessageBridgeStall(new Error('Unknown target "***" for iMessage.'))).toBe(false);
     expect(
       isIMessageBridgeStall(new Error("bridge transport requires an existing chat target")),
@@ -46,81 +43,36 @@ describe("isIMessageBridgeStall", () => {
   });
 });
 
-describe("recordIMessageBridgeStall", () => {
+describe("invalidateCachedIMessagePrivateApiStatus", () => {
   it("drops a positive verdict that would otherwise never expire", () => {
     // A successful probe is cached with expiresAt=0, so before this existed the
-    // verdict outlived the bridge and every later action was dispatched into a
-    // dead one.
+    // verdict outlived the bridge and every later send was dispatched into a
+    // dead one, surfacing an opaque -32603 rather than "run imsg launch".
     const cliPath = "/tmp/imsg-stall-fixture";
     setCachedIMessagePrivateApiStatus(cliPath, available);
     expect(getCachedIMessagePrivateApiStatus(cliPath)?.available).toBe(true);
 
-    recordIMessageBridgeStall(cliPath);
+    invalidateCachedIMessagePrivateApiStatus(cliPath);
 
     expect(getCachedIMessagePrivateApiStatus(cliPath)).toBeUndefined();
-    recordIMessageBridgeAlive(cliPath);
   });
 
-  it("normalizes the cli path the same way the cache does", () => {
+  it("normalizes the cli path the same way the setter does", () => {
     setCachedIMessagePrivateApiStatus("imsg", available);
-    recordIMessageBridgeStall("  imsg  ");
+    expect(getCachedIMessagePrivateApiStatus("  imsg  ")?.available).toBe(true);
+
+    invalidateCachedIMessagePrivateApiStatus("  imsg  ");
+
     expect(getCachedIMessagePrivateApiStatus("imsg")).toBeUndefined();
-    expect(isIMessageBridgeStalled("imsg")).toBe(true);
-    recordIMessageBridgeAlive("imsg");
   });
 
   it("leaves other cli paths alone", () => {
     setCachedIMessagePrivateApiStatus("/tmp/imsg-a", available);
     setCachedIMessagePrivateApiStatus("/tmp/imsg-b", available);
 
-    recordIMessageBridgeStall("/tmp/imsg-a");
+    invalidateCachedIMessagePrivateApiStatus("/tmp/imsg-a");
 
     expect(getCachedIMessagePrivateApiStatus("/tmp/imsg-a")).toBeUndefined();
     expect(getCachedIMessagePrivateApiStatus("/tmp/imsg-b")?.available).toBe(true);
-    expect(isIMessageBridgeStalled("/tmp/imsg-b")).toBe(false);
-    recordIMessageBridgeAlive("/tmp/imsg-a");
-  });
-
-  it("is released by first-hand evidence that the bridge answered", () => {
-    const cliPath = "/tmp/imsg-stall-release";
-    recordIMessageBridgeStall(cliPath);
-    expect(isIMessageBridgeStalled(cliPath)).toBe(true);
-
-    recordIMessageBridgeAlive(cliPath);
-
-    expect(isIMessageBridgeStalled(cliPath)).toBe(false);
-  });
-
-  it("lapses on its own so a repaired bridge is not suppressed forever", () => {
-    const cliPath = "/tmp/imsg-stall-lapse";
-    recordIMessageBridgeStall(cliPath);
-    expect(isIMessageBridgeStalled(cliPath)).toBe(true);
-
-    vi.useFakeTimers();
-    try {
-      vi.setSystemTime(Date.now() + 61 * 1000);
-      expect(isIMessageBridgeStalled(cliPath)).toBe(false);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-});
-
-describe("probeIMessagePrivateApi", () => {
-  // The whole point: `imsg status --json` reports the bridge connected from a
-  // stale handshake during this exact wedge, so a probe that trusts it re-caches
-  // the false positive the eviction just cleared. A recorded stall has to win.
-  // The short-circuit also means no `imsg` subprocess is spawned here.
-  it("reports unavailable while a stall is recorded, without consulting imsg status", async () => {
-    const cliPath = "/tmp/imsg-probe-stalled";
-    recordIMessageBridgeStall(cliPath);
-    try {
-      const status = await probeIMessagePrivateApi(cliPath, 5_000);
-      expect(status.available).toBe(false);
-      expect(status.error).toContain("imsg launch");
-      expect(status.error).toContain("stopped responding to RPC");
-    } finally {
-      recordIMessageBridgeAlive(cliPath);
-    }
   });
 });

--- a/extensions/imessage/src/private-api-status.bridge-stall.test.ts
+++ b/extensions/imessage/src/private-api-status.bridge-stall.test.ts
@@ -1,7 +1,9 @@
 // Imessage plugin tests cover discarding a cached bridge verdict when the
 // injected helper stops answering.
+//
+// The stall matcher itself is module-private to client.ts; its behavior is
+// covered through request() in client.test.ts rather than by calling it here.
 import { describe, expect, it } from "vitest";
-import { isIMessageBridgeStall } from "./client.js";
 import {
   getCachedIMessagePrivateApiStatus,
   type IMessagePrivateApiStatus,
@@ -15,33 +17,6 @@ const available: IMessagePrivateApiStatus = {
   selectors: {},
   rpcMethods: [],
 };
-
-describe("isIMessageBridgeStall", () => {
-  it("matches imsg's own wait timeout, the shape a wedged bridge produces", () => {
-    // Verbatim from a 2026-08-31 incident where a flight-arrival notification
-    // was dropped: Messages.app was alive and the dylib was still mapped, but
-    // the injected helper had stopped answering.
-    expect(
-      isIMessageBridgeStall(
-        new Error("Internal error: code=-32603 Timed out waiting for response to 'send-message'"),
-      ),
-    ).toBe(true);
-  });
-
-  it("matches a client-side request timeout", () => {
-    expect(isIMessageBridgeStall(new Error("imsg rpc timeout (send)"))).toBe(true);
-  });
-
-  it("ignores ordinary rejections, which say nothing about bridge health", () => {
-    // Discarding the capability cache on these would force a needless re-probe
-    // on every bad argument the model supplies.
-    expect(isIMessageBridgeStall(new Error('Unknown target "***" for iMessage.'))).toBe(false);
-    expect(
-      isIMessageBridgeStall(new Error("bridge transport requires an existing chat target")),
-    ).toBe(false);
-    expect(isIMessageBridgeStall(undefined)).toBe(false);
-  });
-});
 
 describe("invalidateCachedIMessagePrivateApiStatus", () => {
   it("drops a positive verdict that would otherwise never expire", () => {

--- a/extensions/imessage/src/private-api-status.bridge-stall.test.ts
+++ b/extensions/imessage/src/private-api-status.bridge-stall.test.ts
@@ -1,13 +1,16 @@
-// Imessage plugin tests cover discarding a cached bridge verdict when the
-// injected helper stops answering.
-import { describe, expect, it } from "vitest";
+// Imessage plugin tests cover treating an observed RPC stall as first-hand
+// evidence that outranks imsg's own status claim.
+import { describe, expect, it, vi } from "vitest";
 import { isIMessageBridgeStall } from "./client.js";
 import {
   getCachedIMessagePrivateApiStatus,
   type IMessagePrivateApiStatus,
-  invalidateCachedIMessagePrivateApiStatus,
+  isIMessageBridgeStalled,
+  recordIMessageBridgeAlive,
+  recordIMessageBridgeStall,
   setCachedIMessagePrivateApiStatus,
 } from "./private-api-status.js";
+import { probeIMessagePrivateApi } from "./probe.js";
 
 const available: IMessagePrivateApiStatus = {
   available: true,
@@ -33,8 +36,8 @@ describe("isIMessageBridgeStall", () => {
   });
 
   it("ignores ordinary rejections, which say nothing about bridge health", () => {
-    // Discarding the capability cache on these would force a needless re-probe
-    // on every bad argument the model supplies.
+    // Treating these as a stall would suppress the bridge for a minute over an
+    // ordinary bad argument.
     expect(isIMessageBridgeStall(new Error('Unknown target "***" for iMessage.'))).toBe(false);
     expect(
       isIMessageBridgeStall(new Error("bridge transport requires an existing chat target")),
@@ -43,36 +46,81 @@ describe("isIMessageBridgeStall", () => {
   });
 });
 
-describe("invalidateCachedIMessagePrivateApiStatus", () => {
+describe("recordIMessageBridgeStall", () => {
   it("drops a positive verdict that would otherwise never expire", () => {
     // A successful probe is cached with expiresAt=0, so before this existed the
-    // verdict outlived the bridge and every later send was dispatched into a
-    // dead one, surfacing an opaque -32603 rather than "run imsg launch".
+    // verdict outlived the bridge and every later action was dispatched into a
+    // dead one.
     const cliPath = "/tmp/imsg-stall-fixture";
     setCachedIMessagePrivateApiStatus(cliPath, available);
     expect(getCachedIMessagePrivateApiStatus(cliPath)?.available).toBe(true);
 
-    invalidateCachedIMessagePrivateApiStatus(cliPath);
+    recordIMessageBridgeStall(cliPath);
 
     expect(getCachedIMessagePrivateApiStatus(cliPath)).toBeUndefined();
+    recordIMessageBridgeAlive(cliPath);
   });
 
-  it("normalizes the cli path the same way the setter does", () => {
+  it("normalizes the cli path the same way the cache does", () => {
     setCachedIMessagePrivateApiStatus("imsg", available);
-    expect(getCachedIMessagePrivateApiStatus("  imsg  ")?.available).toBe(true);
-
-    invalidateCachedIMessagePrivateApiStatus("  imsg  ");
-
+    recordIMessageBridgeStall("  imsg  ");
     expect(getCachedIMessagePrivateApiStatus("imsg")).toBeUndefined();
+    expect(isIMessageBridgeStalled("imsg")).toBe(true);
+    recordIMessageBridgeAlive("imsg");
   });
 
   it("leaves other cli paths alone", () => {
     setCachedIMessagePrivateApiStatus("/tmp/imsg-a", available);
     setCachedIMessagePrivateApiStatus("/tmp/imsg-b", available);
 
-    invalidateCachedIMessagePrivateApiStatus("/tmp/imsg-a");
+    recordIMessageBridgeStall("/tmp/imsg-a");
 
     expect(getCachedIMessagePrivateApiStatus("/tmp/imsg-a")).toBeUndefined();
     expect(getCachedIMessagePrivateApiStatus("/tmp/imsg-b")?.available).toBe(true);
+    expect(isIMessageBridgeStalled("/tmp/imsg-b")).toBe(false);
+    recordIMessageBridgeAlive("/tmp/imsg-a");
+  });
+
+  it("is released by first-hand evidence that the bridge answered", () => {
+    const cliPath = "/tmp/imsg-stall-release";
+    recordIMessageBridgeStall(cliPath);
+    expect(isIMessageBridgeStalled(cliPath)).toBe(true);
+
+    recordIMessageBridgeAlive(cliPath);
+
+    expect(isIMessageBridgeStalled(cliPath)).toBe(false);
+  });
+
+  it("lapses on its own so a repaired bridge is not suppressed forever", () => {
+    const cliPath = "/tmp/imsg-stall-lapse";
+    recordIMessageBridgeStall(cliPath);
+    expect(isIMessageBridgeStalled(cliPath)).toBe(true);
+
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(Date.now() + 61 * 1000);
+      expect(isIMessageBridgeStalled(cliPath)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("probeIMessagePrivateApi", () => {
+  // The whole point: `imsg status --json` reports the bridge connected from a
+  // stale handshake during this exact wedge, so a probe that trusts it re-caches
+  // the false positive the eviction just cleared. A recorded stall has to win.
+  // The short-circuit also means no `imsg` subprocess is spawned here.
+  it("reports unavailable while a stall is recorded, without consulting imsg status", async () => {
+    const cliPath = "/tmp/imsg-probe-stalled";
+    recordIMessageBridgeStall(cliPath);
+    try {
+      const status = await probeIMessagePrivateApi(cliPath, 5_000);
+      expect(status.available).toBe(false);
+      expect(status.error).toContain("imsg launch");
+      expect(status.error).toContain("stopped responding to RPC");
+    } finally {
+      recordIMessageBridgeAlive(cliPath);
+    }
   });
 });

--- a/extensions/imessage/src/private-api-status.bridge-stall.test.ts
+++ b/extensions/imessage/src/private-api-status.bridge-stall.test.ts
@@ -1,0 +1,78 @@
+// Imessage plugin tests cover discarding a cached bridge verdict when the
+// injected helper stops answering.
+import { describe, expect, it } from "vitest";
+import { isIMessageBridgeStall } from "./client.js";
+import {
+  getCachedIMessagePrivateApiStatus,
+  type IMessagePrivateApiStatus,
+  invalidateCachedIMessagePrivateApiStatus,
+  setCachedIMessagePrivateApiStatus,
+} from "./private-api-status.js";
+
+const available: IMessagePrivateApiStatus = {
+  available: true,
+  v2Ready: true,
+  selectors: {},
+  rpcMethods: [],
+};
+
+describe("isIMessageBridgeStall", () => {
+  it("matches imsg's own wait timeout, the shape a wedged bridge produces", () => {
+    // Verbatim from a 2026-08-31 incident where a flight-arrival notification
+    // was dropped: Messages.app was alive and the dylib was still mapped, but
+    // the injected helper had stopped answering.
+    expect(
+      isIMessageBridgeStall(
+        new Error("Internal error: code=-32603 Timed out waiting for response to 'send-message'"),
+      ),
+    ).toBe(true);
+  });
+
+  it("matches a client-side request timeout", () => {
+    expect(isIMessageBridgeStall(new Error("imsg rpc timeout (send)"))).toBe(true);
+  });
+
+  it("ignores ordinary rejections, which say nothing about bridge health", () => {
+    // Discarding the capability cache on these would force a needless re-probe
+    // on every bad argument the model supplies.
+    expect(isIMessageBridgeStall(new Error('Unknown target "***" for iMessage.'))).toBe(false);
+    expect(
+      isIMessageBridgeStall(new Error("bridge transport requires an existing chat target")),
+    ).toBe(false);
+    expect(isIMessageBridgeStall(undefined)).toBe(false);
+  });
+});
+
+describe("invalidateCachedIMessagePrivateApiStatus", () => {
+  it("drops a positive verdict that would otherwise never expire", () => {
+    // A successful probe is cached with expiresAt=0, so before this existed the
+    // verdict outlived the bridge and every later send was dispatched into a
+    // dead one, surfacing an opaque -32603 rather than "run imsg launch".
+    const cliPath = "/tmp/imsg-stall-fixture";
+    setCachedIMessagePrivateApiStatus(cliPath, available);
+    expect(getCachedIMessagePrivateApiStatus(cliPath)?.available).toBe(true);
+
+    invalidateCachedIMessagePrivateApiStatus(cliPath);
+
+    expect(getCachedIMessagePrivateApiStatus(cliPath)).toBeUndefined();
+  });
+
+  it("normalizes the cli path the same way the setter does", () => {
+    setCachedIMessagePrivateApiStatus("imsg", available);
+    expect(getCachedIMessagePrivateApiStatus("  imsg  ")?.available).toBe(true);
+
+    invalidateCachedIMessagePrivateApiStatus("  imsg  ");
+
+    expect(getCachedIMessagePrivateApiStatus("imsg")).toBeUndefined();
+  });
+
+  it("leaves other cli paths alone", () => {
+    setCachedIMessagePrivateApiStatus("/tmp/imsg-a", available);
+    setCachedIMessagePrivateApiStatus("/tmp/imsg-b", available);
+
+    invalidateCachedIMessagePrivateApiStatus("/tmp/imsg-a");
+
+    expect(getCachedIMessagePrivateApiStatus("/tmp/imsg-a")).toBeUndefined();
+    expect(getCachedIMessagePrivateApiStatus("/tmp/imsg-b")?.available).toBe(true);
+  });
+});

--- a/extensions/imessage/src/private-api-status.ts
+++ b/extensions/imessage/src/private-api-status.ts
@@ -75,6 +75,18 @@ export function getCachedIMessagePrivateApiStatus(
   return entry.status;
 }
 
+// Drop a cached verdict so the next action re-probes.
+//
+// A successful probe is cached without expiry (see cacheProbeResult), which is
+// right for the hot path but leaves no way back once the bridge dies: the
+// helper dylib can stop answering while Messages.app stays alive and the
+// injection stays mapped, and nothing about that is observable from the cache.
+// The RPC client calls this when the bridge stops answering, so the stale
+// "available" verdict cannot outlive the bridge it describes.
+export function invalidateCachedIMessagePrivateApiStatus(cliPath?: string | null): void {
+  bridgeStatusCache.delete(normalizeCliPath(cliPath));
+}
+
 export function setCachedIMessagePrivateApiStatus(
   cliPath: string,
   status: IMessagePrivateApiStatus,

--- a/extensions/imessage/src/private-api-status.ts
+++ b/extensions/imessage/src/private-api-status.ts
@@ -75,16 +75,45 @@ export function getCachedIMessagePrivateApiStatus(
   return entry.status;
 }
 
-// Drop a cached verdict so the next action re-probes.
+// How long an observed stall outranks imsg's own status claim.
 //
-// A successful probe is cached without expiry (see cacheProbeResult), which is
-// right for the hot path but leaves no way back once the bridge dies: the
-// helper dylib can stop answering while Messages.app stays alive and the
-// injection stays mapped, and nothing about that is observable from the cache.
-// The RPC client calls this when the bridge stops answering, so the stale
-// "available" verdict cannot outlive the bridge it describes.
-export function invalidateCachedIMessagePrivateApiStatus(cliPath?: string | null): void {
-  bridgeStatusCache.delete(normalizeCliPath(cliPath));
+// The probe decides availability from `imsg status --json`, but that reports
+// the injected helper as connected from a stale handshake and keeps saying so
+// while the helper is wedged. Evicting the cache alone therefore re-caches the
+// same false positive on the next probe. A stall is first-hand RPC evidence and
+// has to outrank the claim until either real traffic proves the bridge answers
+// again or this window lapses.
+const BRIDGE_STALL_TTL_MS = 60 * 1000;
+
+const bridgeStallUntil = new Map<string, number>();
+
+// Record first-hand evidence that the bridge stopped answering RPC.
+export function recordIMessageBridgeStall(cliPath?: string | null): void {
+  const key = normalizeCliPath(cliPath);
+  bridgeStallUntil.set(key, Date.now() + BRIDGE_STALL_TTL_MS);
+  bridgeStatusCache.delete(key);
+}
+
+// Record first-hand evidence that the bridge answered.
+//
+// Any successful RPC clears the stall. Normal sends are not capability-gated,
+// so one working send releases the capability path immediately instead of
+// making it wait out the window.
+export function recordIMessageBridgeAlive(cliPath?: string | null): void {
+  bridgeStallUntil.delete(normalizeCliPath(cliPath));
+}
+
+export function isIMessageBridgeStalled(cliPath?: string | null): boolean {
+  const key = normalizeCliPath(cliPath);
+  const until = bridgeStallUntil.get(key);
+  if (until === undefined) {
+    return false;
+  }
+  if (until <= Date.now()) {
+    bridgeStallUntil.delete(key);
+    return false;
+  }
+  return true;
 }
 
 export function setCachedIMessagePrivateApiStatus(

--- a/extensions/imessage/src/private-api-status.ts
+++ b/extensions/imessage/src/private-api-status.ts
@@ -75,45 +75,16 @@ export function getCachedIMessagePrivateApiStatus(
   return entry.status;
 }
 
-// How long an observed stall outranks imsg's own status claim.
+// Drop a cached verdict so the next action re-probes.
 //
-// The probe decides availability from `imsg status --json`, but that reports
-// the injected helper as connected from a stale handshake and keeps saying so
-// while the helper is wedged. Evicting the cache alone therefore re-caches the
-// same false positive on the next probe. A stall is first-hand RPC evidence and
-// has to outrank the claim until either real traffic proves the bridge answers
-// again or this window lapses.
-const BRIDGE_STALL_TTL_MS = 60 * 1000;
-
-const bridgeStallUntil = new Map<string, number>();
-
-// Record first-hand evidence that the bridge stopped answering RPC.
-export function recordIMessageBridgeStall(cliPath?: string | null): void {
-  const key = normalizeCliPath(cliPath);
-  bridgeStallUntil.set(key, Date.now() + BRIDGE_STALL_TTL_MS);
-  bridgeStatusCache.delete(key);
-}
-
-// Record first-hand evidence that the bridge answered.
-//
-// Any successful RPC clears the stall. Normal sends are not capability-gated,
-// so one working send releases the capability path immediately instead of
-// making it wait out the window.
-export function recordIMessageBridgeAlive(cliPath?: string | null): void {
-  bridgeStallUntil.delete(normalizeCliPath(cliPath));
-}
-
-export function isIMessageBridgeStalled(cliPath?: string | null): boolean {
-  const key = normalizeCliPath(cliPath);
-  const until = bridgeStallUntil.get(key);
-  if (until === undefined) {
-    return false;
-  }
-  if (until <= Date.now()) {
-    bridgeStallUntil.delete(key);
-    return false;
-  }
-  return true;
+// A successful probe is cached without expiry (see cacheProbeResult), which is
+// right for the hot path but leaves no way back once the bridge dies: the
+// helper dylib can stop answering while Messages.app stays alive and the
+// injection stays mapped, and nothing about that is observable from the cache.
+// The RPC client calls this when the bridge stops answering, so the stale
+// "available" verdict cannot outlive the bridge it describes.
+export function invalidateCachedIMessagePrivateApiStatus(cliPath?: string | null): void {
+  bridgeStatusCache.delete(normalizeCliPath(cliPath));
 }
 
 export function setCachedIMessagePrivateApiStatus(

--- a/extensions/imessage/src/probe.ts
+++ b/extensions/imessage/src/probe.ts
@@ -20,7 +20,6 @@ import { createIMessageRpcClient } from "./client.js";
 import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
 import {
   getCachedIMessagePrivateApiStatus,
-  isIMessageBridgeStalled,
   setCachedIMessagePrivateApiStatus,
   type IMessagePrivateApiStatus,
 } from "./private-api-status.js";
@@ -244,21 +243,6 @@ export async function probeIMessagePrivateApi(
     if (cached) {
       return cached;
     }
-  }
-  // A stall observed on a real RPC outranks whatever `status --json` claims.
-  // The wedge this guards against is precisely the one where imsg keeps
-  // reporting the bridge connected, so trusting the claim here would re-cache
-  // the same false positive that the eviction just cleared.
-  if (isIMessageBridgeStalled(key)) {
-    return {
-      available: false,
-      v2Ready: false,
-      selectors: {},
-      rpcMethods: [],
-      error:
-        "The imsg private API bridge stopped responding to RPC. Run `imsg launch` to re-inject " +
-        "the dylib, then `openclaw channels status --probe` to refresh capability detection.",
-    };
   }
   try {
     const result = await runCommandWithTimeout([expandIMessageUserPath(key), "status", "--json"], {

--- a/extensions/imessage/src/probe.ts
+++ b/extensions/imessage/src/probe.ts
@@ -20,6 +20,7 @@ import { createIMessageRpcClient } from "./client.js";
 import { DEFAULT_IMESSAGE_PROBE_TIMEOUT_MS } from "./constants.js";
 import {
   getCachedIMessagePrivateApiStatus,
+  isIMessageBridgeStalled,
   setCachedIMessagePrivateApiStatus,
   type IMessagePrivateApiStatus,
 } from "./private-api-status.js";
@@ -243,6 +244,21 @@ export async function probeIMessagePrivateApi(
     if (cached) {
       return cached;
     }
+  }
+  // A stall observed on a real RPC outranks whatever `status --json` claims.
+  // The wedge this guards against is precisely the one where imsg keeps
+  // reporting the bridge connected, so trusting the claim here would re-cache
+  // the same false positive that the eviction just cleared.
+  if (isIMessageBridgeStalled(key)) {
+    return {
+      available: false,
+      v2Ready: false,
+      selectors: {},
+      rpcMethods: [],
+      error:
+        "The imsg private API bridge stopped responding to RPC. Run `imsg launch` to re-inject " +
+        "the dylib, then `openclaw channels status --probe` to refresh capability detection.",
+    };
   }
   try {
     const result = await runCommandWithTimeout([expandIMessageUserPath(key), "status", "--json"], {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators using the iMessage private-API bridge get an opaque internal error on every send once the bridge dies, with no indication of the cause or the repair.

The bridge is a helper dylib injected into Messages.app. It can stop answering RPC while Messages.app stays alive and the dylib stays mapped, so `pgrep`, `openclaw channels status`, and `imsg status` all keep reporting it healthy. Sends then fail with:

```
Internal error: code=-32603 Timed out waiting for response to 'send-message'
```

rather than the actionable `run imsg launch, then openclaw channels status --probe` guidance the unavailable path already produces.

## Why This Change Was Made

**The actionable error (the user-visible fix).** Normal outbound delivery never consults the private-API capability cache: `send.ts` builds an RPC client and dispatches directly. So cache work alone cannot help it. `IMessageRpcClient.request()` is the single choke point every private-API action *and* every normal send funnels through, so the stall is annotated there. The first failed send now carries the cause and the repair, instead of the second or none.

The original error is preserved rather than replaced, because two consumers depend on it: `normalizeIMessageRpcSendError` reads `data.disposition`/`data.retry_safe`, and `isIMessageRpcSendTimeout` matches `/imsg rpc timeout \(send\)/i`. Class, code, data, and the original message text all survive, with guidance appended.

**The cache correctness (a precondition, not a recovery).** A successful probe is cached with `expiresAt = 0`, which `getCachedIMessagePrivateApiStatus` treats as never expiring, while a failed probe gets a TTL. That asymmetry is backwards, and `assertPrivateApiEnabled` only re-probes when `available !== true`, so a bridge that died after one successful probe is never re-evaluated. This PR evicts that entry on an observed stall and fixes the key mismatch that made eviction a no-op for `~`-relative `cliPath`.

**To be explicit about what eviction does not do:** on its own it does not recover the stale-status wedge. The re-probe calls `imsg status --json`, and current imsg reports `advanced_features` from a static SIP-and-dylib check while discarding the outcome of its own live bridge probe. So it can immediately recache the same false positive. That is fixed at the source in **openclaw/imsg#253** (green, proof accepted). Eviction here is the necessary precondition that makes the corrected upstream signal reachable; it is not claimed as a standalone recovery.

## The imsg timeout contract this relies on

Verified against `openclaw/imsg@674f7c6` (the reviewer noted upstream inspection was unavailable):

- `IMsgBridgeClient.swift:487` returns `IMsgBridgeError.timeout(action:)` for a non-mutation action whose published request never got a reply.
- `IMsgBridgeProtocol.swift:157` renders it as `"Timed out waiting for response to '<action>'"`. That exact string is what this PR matches.
- `IMsgBridgeClient.swift:455` returns `.bridgeNotReady` from `prepublicationError`, raised *before* a request is published (launch, queue-write, cancellation). Deliberately not matched: no reply was expected.
- openclaw's own client-side deadline (`client.ts`, `imsg rpc timeout (<method>)`) is also deliberately not matched. It fires when the local wrapper is slow or blocked while imsg is healthy, including the documented SSH-wrapper buffering case, so diagnosing it as a dead dylib would evict good capability state and send operators to the wrong repair.

## User Impact

When the bridge stops answering, the next iMessage send reports the real cause and the repair instead of an opaque `-32603`. No behavior change when the bridge is healthy: the cache still keeps the probe off the hot path, and a local wrapper timeout is passed through untouched.

## Evidence

**Pre-fix incident (root cause).** Production gateway log, 2026-08-31, a flight-arrival notification dropped. The agent composed both messages and called the tool with valid targets; both failed:

```
[tools] message failed: Internal error: code=-32603 Timed out waiting for response
to 'send-message' raw_params={"channel":"imessage","target":"+1XXXXXXXXXX",...}
```

Concurrently `imsg status` reported `Advanced features: Available - IMCore bridge connected`, and `vmmap` confirmed the correct dylib still mapped into a live Messages.app.

**Deterministic integration at the changed boundary.** Tests in `client.test.ts` drive the real `IMessageRpcClient` over the existing mock-child harness:

- `discards the cached verdict when imsg reports its own wait timeout` — verified to fail without the fix.
- `invalidates under the configured cli path, not the expanded one` — verified to fail against the expanded-path form.
- `appends actionable guidance to a stalled send` — asserts the decorated message keeps the original text and preserves class, `code`, and `data`.
- `leaves a client-side timeout undecorated` — asserts no eviction, no guidance, and that `/imsg rpc timeout \(send\)/i` still matches.
- `keeps the cached verdict when the request is merely rejected`.

Full `extensions/imessage` suite: **56 files, 1209 tests passing**. CI green. Codex autoreview on the committed branch: no P0.

**Not claimed.** I attempted exact-path runtime proof by driving the real client against a real `imsg rpc` child with a deliberately broken bridge, and it did not reproduce the stall: both a killed and a `SIGSTOP`-ed Messages.app yielded pre-publication `.bridgeNotReady`, because a freshly spawned rpc child never establishes a bridge session and short-circuits before contacting it. I could not induce a genuine hung-helper wedge on demand. The evidence above is deterministic-integration plus incident, not live exact-path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012monyCroSJnkAo2uiTyXXH
