### PR TITLE
docs: clarify configured media fallback selection

### DIFF
--- a/docs/tools/image-generation.md
+++ b/docs/tools/image-generation.md
@@ -229,12 +229,13 @@ translation.
 
 ### Provider selection order
 
-OpenClaw tries providers in this order:
+For `image_generate`, OpenClaw tries providers in this order:
 
-1. **`model` parameter** from the tool call (if the agent specifies one).
+1. **`model` parameter** from the tool call. When set, only this model is tried.
 2. **`agents.defaults.mediaModels.image.primary`** from config.
 3. **`agents.defaults.mediaModels.image.fallbacks`** in order.
-4. **Auto-detection** - auth-backed provider defaults only:
+4. **Auto-detection** - only when neither a primary nor fallback model is
+   configured, using configured provider defaults:
    - current default provider first;
    - remaining registered image-generation providers in provider-id order.
 
@@ -247,10 +248,10 @@ from each attempt.
     A per-call `model` override tries only that provider/model and does
     not continue to configured primary/fallback or auto-detected providers.
   </Accordion>
-  <Accordion title="Auto-detection is auth-aware">
-    A provider default only enters the candidate list when OpenClaw can
-    actually authenticate that provider. Automatic fallback across authenticated
-    providers is always enabled; a per-call `model` remains authoritative.
+  <Accordion title="Auto-detection uses configured providers">
+    Auto-detection considers provider defaults whose readiness or auth checks pass.
+    Explicit image model configuration limits fallback to the configured list;
+    OpenClaw does not append auto-detected providers.
   </Accordion>
   <Accordion title="Timeouts">
     Set `agents.defaults.mediaModels.image.timeoutMs` for slow image

--- a/docs/tools/music-generation.md
+++ b/docs/tools/music-generation.md
@@ -253,12 +253,13 @@ openclaw tasks cancel <taskId>
 
 ### Provider selection order
 
-OpenClaw tries providers in this order:
+For `music_generate`, OpenClaw tries providers in this order:
 
-1. `model` parameter from the tool call (if the agent specifies one).
+1. `model` parameter from the tool call. When set, only this model is tried.
 2. `agents.defaults.mediaModels.music.primary` from config.
 3. `agents.defaults.mediaModels.music.fallbacks` in order.
-4. Auto-detection using auth-backed provider defaults only:
+4. When neither a primary nor fallback model is configured, auto-detection using
+   configured provider defaults:
    - current default text-model provider first, if it also offers music
      generation;
    - remaining registered music-generation providers, alphabetically by
@@ -267,8 +268,8 @@ OpenClaw tries providers in this order:
 If a provider fails, the next candidate is tried automatically. If all
 fail, the error includes details from each attempt.
 
-Automatic fallback across authenticated providers is always enabled. A per-call
-`model` remains authoritative.
+Explicit music model configuration limits fallback to the configured list;
+OpenClaw does not append auto-detected providers.
 
 ## Provider notes
 

--- a/docs/tools/video-generation.md
+++ b/docs/tools/video-generation.md
@@ -286,20 +286,20 @@ aggregated error includes the skip reason for each.
 
 ## Model selection
 
-OpenClaw resolves the model in this order:
+For `video_generate`, OpenClaw resolves the model in this order:
 
-1. **`model` tool parameter** - if the agent specifies one in the call.
+1. **`model` tool parameter** - when set, only this model is tried.
 2. **`agents.defaults.mediaModels.video.primary`** from config.
 3. **`agents.defaults.mediaModels.video.fallbacks`** in order.
-4. **Auto-detection** - providers that have valid auth, starting with the
-   current default provider, then remaining providers in alphabetical
-   order.
+4. **Auto-detection** - only when neither a primary nor fallback model is
+   configured, using configured provider defaults. The current default provider
+   comes first, then remaining providers in alphabetical order.
 
 If a provider fails, the next candidate is tried automatically. If all
 candidates fail, the error includes details from each attempt.
 
-Automatic fallback across authenticated providers is always enabled. A per-call
-`model` remains authoritative.
+Explicit video model configuration limits fallback to the configured list;
+OpenClaw does not append auto-detected providers.
 
 ```json5
 {


### PR DESCRIPTION
## What Problem This Solves

The image, music and video agent-tool pages say automatic fallback across providers is always enabled. The tools actually stop adding automatically discovered candidates when a primary or fallback model is explicitly configured.

## Why This Change Was Made

Describe the existing selection order at each named agent-tool boundary: a per-call model override is exclusive, configured primary/fallback models bound the candidate list, and automatic selection applies when neither is configured. Describe provider readiness without assuming that every provider uses the same authentication path.

## User Impact

Operators can tell which providers their configured agent tools may try. Runtime behavior, configuration, CLI defaults and plugin SDK contracts are unchanged. Configured fallback models still run in order. The correction is scoped to the agent tools because direct CLI/SDK runtime callers retain their own defaults.

## Evidence

Read the complete pages, all three tool and runtime owners, shared selectors, configuration helpers and direct CLI/SDK callers. Explicitness comes from a nonblank primary or fallback, not a timeout-only slot. The tools pass the existing automatic-fallback flag to their runtime; Image also applies it during reference-capability candidate selection. The runtime retains configured candidates even when automatic discovery is disabled.

All 41 relevant source contexts were checked, including the pending Image wrapper cleanup's equivalent argument flow. Local stable-tag and available raw-parent comparisons corroborate the existing policy; the original introduction lies beyond shallow history. All ten normal docs-only changed checks, formatting and managed review passed. No runtime code or test changed; docs are +21/-19. No external provider call or new provider-specific claim is made.
