### PR TITLE
fix(migrations): reject empty unexpected JSON fields

### DIFF
--- a/src/infra/state-migrations.apns.test.ts
+++ b/src/infra/state-migrations.apns.test.ts
@@ -335,6 +335,23 @@ describe("legacy APNs Doctor migration", () => {
     expect(fs.existsSync(sourcePath)).toBe(true);
   });
 
+  it("rejects an empty unexpected field without exposing its later sibling", async () => {
+    const stateDir = useStateDir();
+    const sourcePath = await writeLegacyState(stateDir, {
+      node: directRegistration({ nodeId: "node", "": 1, later: 2 }),
+    });
+    const result = await migrate(stateDir);
+    expect(result.warnings).toEqual([
+      "Failed reading legacy APNs state: Error: legacy APNs registration has an unexpected field",
+    ]);
+    expect(fs.readdirSync(path.dirname(sourcePath))).toEqual(["apns-registrations.json"]);
+    await expect(loadApnsRegistration("node", stateDir)).resolves.toBeNull();
+    const receipt = openOpenClawStateDatabase()
+      .db.prepare("SELECT source_key FROM migration_sources WHERE migration_kind = ?")
+      .get("legacy-apns-registrations-json");
+    expect(receipt).toBeUndefined();
+  });
+
   it("sanitizes malformed JSON warnings", async () => {
     const stateDir = useStateDir();
     const sourcePath = path.join(stateDir, "push", "apns-registrations.json");

--- a/src/infra/state-migrations.apns.ts
+++ b/src/infra/state-migrations.apns.ts
@@ -19,6 +19,7 @@ import {
   normalizeCanonicalApnsRegistration,
   type ApnsRegistration,
 } from "./push-apns-store.js";
+import { assertAllowedJsonFields } from "./state-migrations.json-fields.js";
 import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import {
   markLegacyMigrationSourceRemoved,
@@ -113,13 +114,6 @@ async function readLegacySourceSnapshot(
   };
 }
 
-function assertOnlyKeys(value: Record<string, unknown>, allowed: ReadonlySet<string>): void {
-  const unexpected = Object.keys(value).find((key) => !allowed.has(key));
-  if (unexpected) {
-    throw new Error("legacy APNs registration has an unexpected field");
-  }
-}
-
 function isValidLegacyApnsTimestamp(value: unknown): value is number {
   return (
     typeof value === "number" &&
@@ -141,9 +135,11 @@ function parseLegacyApnsRegistration(
   if (transport !== "direct" && transport !== "relay") {
     throw new Error("legacy APNs registration has invalid transport");
   }
-  assertOnlyKeys(
+  assertAllowedJsonFields(
     rawRegistration,
     transport === "relay" ? RELAY_REGISTRATION_KEYS : DIRECT_REGISTRATION_KEYS,
+    "legacy APNs registration",
+    { reportField: false },
   );
   const normalizedNodeId = normalizeApnsNodeId(rawNodeId);
   if (!isValidApnsNodeId(normalizedNodeId)) {

--- a/src/infra/state-migrations.json-fields.ts
+++ b/src/infra/state-migrations.json-fields.ts
@@ -1,0 +1,17 @@
+export function assertAllowedJsonFields(
+  value: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  label: string,
+  options: { fieldPrefix?: string; reportField?: boolean } = {},
+): void {
+  const unexpected = Object.keys(value).find((key) => !allowed.has(key));
+  // Empty JSON keys are valid; only undefined means every field was allowed.
+  if (unexpected !== undefined) {
+    const field = unexpected === "" ? '""' : unexpected;
+    const detail =
+      options.reportField === false
+        ? "an unexpected field"
+        : `unexpected field ${options.fieldPrefix ?? ""}${field}`;
+    throw new Error(`${label} has ${detail}`);
+  }
+}

--- a/src/infra/state-migrations.managed-outgoing-images.test.ts
+++ b/src/infra/state-migrations.managed-outgoing-images.test.ts
@@ -245,6 +245,27 @@ describe("legacy managed outgoing image migration", () => {
     expect(fs.lstatSync(malformedPath).isSymbolicLink()).toBe(true);
   });
 
+  it.each([
+    ["root before original", true, '""'],
+    ["original only", false, 'original.""'],
+  ])("rejects empty unexpected fields before mutation: %s", async (_label, root, field) => {
+    const legacy = await writeLegacyRecord({ stateDir });
+    const original = { ...legacy.record.original, "": 1, later: 2 };
+    const record = root
+      ? { ...legacy.record, "": 1, later: 2, original }
+      : { ...legacy.record, original };
+    await fsp.writeFile(legacy.sourcePath, JSON.stringify(record));
+    const result = migrate(stateDir);
+    expect(result.warnings).toEqual([
+      `Failed reading legacy managed outgoing image state: Error: legacy managed image record has unexpected field ${field}`,
+    ]);
+    await expect(fsp.access(legacy.originalPath)).resolves.toBeUndefined();
+    expect(fs.readdirSync(path.dirname(legacy.sourcePath))).toEqual([
+      path.basename(legacy.sourcePath),
+    ]);
+    expect(readManagedImageRecord(legacy.record.attachmentId, stateDir)).toBeNull();
+  });
+
   it("keeps JSON when the source changes before cleanup", async () => {
     const legacy = await writeLegacyRecord({ stateDir });
 

--- a/src/infra/state-migrations.managed-outgoing-images.ts
+++ b/src/infra/state-migrations.managed-outgoing-images.ts
@@ -23,6 +23,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
+import { assertAllowedJsonFields } from "./state-migrations.json-fields.js";
 import {
   legacyMigrationSourceSnapshotsMatch as sourceSnapshotsMatch,
   readLegacyMigrationSourceSnapshotSync,
@@ -144,13 +145,10 @@ function parseLegacyManagedImageRecord(params: {
   if (!isRecord(raw) || !isRecord(raw.original)) {
     throw new Error("legacy managed image record must be an object");
   }
-  const unexpectedRecordKey = Object.keys(raw).find((key) => !RECORD_KEYS.has(key));
-  const unexpectedOriginalKey = Object.keys(raw.original).find((key) => !ORIGINAL_KEYS.has(key));
-  if (unexpectedRecordKey || unexpectedOriginalKey) {
-    throw new Error(
-      `legacy managed image record has unexpected field ${unexpectedRecordKey ?? `original.${unexpectedOriginalKey}`}`,
-    );
-  }
+  assertAllowedJsonFields(raw, RECORD_KEYS, "legacy managed image record");
+  assertAllowedJsonFields(raw.original, ORIGINAL_KEYS, "legacy managed image record", {
+    fieldPrefix: "original.",
+  });
 
   const attachmentId = optionalNonEmptyString(raw.attachmentId);
   const sessionKey = optionalNonEmptyString(raw.sessionKey);

--- a/src/infra/state-migrations.node-host.test.ts
+++ b/src/infra/state-migrations.node-host.test.ts
@@ -197,15 +197,37 @@ describe("legacy node-host Doctor migration", () => {
   });
 
   it.each([
-    ["unknown top-level field", legacyConfig({ unknown: true }), "unexpected field unknown"],
-    ["invalid version", legacyConfig({ version: 2 }), "version must be 1"],
-    ["blank node id", legacyConfig({ nodeId: " " }), "nodeId must be a non-empty string"],
+    [
+      "unknown top-level field",
+      legacyConfig({ unknown: true }),
+      "legacy node-host config has unexpected field unknown",
+    ],
+    [
+      "empty top-level field",
+      legacyConfig({ "": 1, later: 2 }),
+      'legacy node-host config has unexpected field ""',
+    ],
+    ["invalid version", legacyConfig({ version: 2 }), "legacy node-host config version must be 1"],
+    [
+      "blank node id",
+      legacyConfig({ nodeId: " " }),
+      "legacy node-host nodeId must be a non-empty string",
+    ],
     [
       "unknown gateway field",
       legacyConfig({ gateway: { host: "gateway.example", unknown: true } }),
-      "unexpected field unknown",
+      "legacy node-host gateway has unexpected field unknown",
     ],
-    ["invalid token", legacyConfig({ token: 42 }), "token must be a string"],
+    [
+      "__proto__ gateway field",
+      legacyConfig({ gateway: { ["__proto__"]: 1, later: 2 } }),
+      "legacy node-host gateway has unexpected field __proto__",
+    ],
+    [
+      "invalid token",
+      legacyConfig({ token: 42 }),
+      "legacy node-host token must be a string when present",
+    ],
   ])("rejects strict legacy shape: %s", async (_label, value, message) => {
     const { env, stateDir } = useStateDir();
     const { sourcePath } = await writeLegacy(stateDir, value);
@@ -215,9 +237,10 @@ describe("legacy node-host Doctor migration", () => {
       stateDir,
     });
 
-    expect(result.warnings[0]).toContain(message);
+    expect(result.warnings[0]).toBe(`Failed reading legacy node-host state: Error: ${message}`);
     expect(readCanonicalRow(env)).toBeUndefined();
     expect(fs.existsSync(sourcePath)).toBe(true);
+    expect(fs.existsSync(`${sourcePath}.doctor-importing`)).toBe(false);
   });
 
   it("keeps a newer canonical snapshot with the same node id", async () => {

--- a/src/infra/state-migrations.node-host.ts
+++ b/src/infra/state-migrations.node-host.ts
@@ -17,6 +17,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
+import { assertAllowedJsonFields } from "./state-migrations.json-fields.js";
 import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import {
   LegacyMigrationSourceClaim,
@@ -52,17 +53,6 @@ export function detectLegacyNodeHostConfig(params: {
   };
 }
 
-function assertOnlyKeys(
-  value: Record<string, unknown>,
-  allowed: ReadonlySet<string>,
-  label: string,
-): void {
-  const unexpected = Object.keys(value).find((key) => !allowed.has(key));
-  if (unexpected) {
-    throw new Error(`${label} has unexpected field ${unexpected}`);
-  }
-}
-
 function optionalLegacyString(value: unknown, label: string): string | undefined {
   if (value === undefined) {
     return undefined;
@@ -90,7 +80,7 @@ function parseLegacyGateway(value: unknown): NodeHostGatewayConfig | undefined {
   if (!isRecord(value)) {
     throw new Error("legacy node-host gateway must be an object");
   }
-  assertOnlyKeys(value, GATEWAY_KEYS, "legacy node-host gateway");
+  assertAllowedJsonFields(value, GATEWAY_KEYS, "legacy node-host gateway");
   const port = value.port;
   if (
     port !== undefined &&
@@ -120,7 +110,7 @@ function parseLegacyNodeHostConfig(snapshot: LegacySourceSnapshot): CanonicalNod
   if (!isRecord(parsed)) {
     throw new Error("legacy node-host config must be an object");
   }
-  assertOnlyKeys(parsed, CONFIG_KEYS, "legacy node-host config");
+  assertAllowedJsonFields(parsed, CONFIG_KEYS, "legacy node-host config");
   if (parsed.version !== 1) {
     throw new Error("legacy node-host config version must be 1");
   }

--- a/src/infra/state-migrations.tui-last-session.test.ts
+++ b/src/infra/state-migrations.tui-last-session.test.ts
@@ -137,6 +137,19 @@ describe("legacy TUI last-session migration", () => {
     await expect(readTuiLastSessionKey({ scopeKey: "terminal", stateDir })).resolves.toBeNull();
   });
 
+  it("rejects an empty unexpected field before claiming or writing", async () => {
+    const stateDir = tempDirs.make("openclaw-tui-migration-");
+    const sourcePath = writeLegacyStore(stateDir, {
+      terminal: { "": 1, later: 2, sessionKey: "agent:main:tui-123", updatedAt: 100 },
+    });
+    const result = migrate(stateDir);
+    expect(result.warnings).toEqual([
+      `Failed reading legacy TUI last-session state ${sourcePath}: Error: legacy TUI last-session record terminal has unexpected field ""`,
+    ]);
+    expect(fs.readdirSync(path.dirname(sourcePath))).toEqual(["last-session.json"]);
+    await expect(readTuiLastSessionKey({ scopeKey: "terminal", stateDir })).resolves.toBeNull();
+  });
+
   it("keeps a newer SQLite pointer and removes its superseded source", async () => {
     const stateDir = tempDirs.make("openclaw-tui-migration-");
     const sourcePath = writeLegacyStore(stateDir, {

--- a/src/infra/state-migrations.tui-last-session.ts
+++ b/src/infra/state-migrations.tui-last-session.ts
@@ -12,6 +12,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
+import { assertAllowedJsonFields } from "./state-migrations.json-fields.js";
 import {
   assertLegacyMigrationSourceUnchanged,
   claimAndRemoveLegacyMigrationSource,
@@ -81,12 +82,11 @@ function parseLegacyTuiLastSessions(raw: string): LegacyTuiLastSession[] {
     if (!isObjectRecord(value)) {
       throw new Error(`legacy TUI last-session record ${scopeKey} must be an object`);
     }
-    const unexpectedKey = Object.keys(value).find((key) => !LEGACY_RECORD_KEYS.has(key));
-    if (unexpectedKey) {
-      throw new Error(
-        `legacy TUI last-session record ${scopeKey} has unexpected field ${unexpectedKey}`,
-      );
-    }
+    assertAllowedJsonFields(
+      value,
+      LEGACY_RECORD_KEYS,
+      `legacy TUI last-session record ${scopeKey}`,
+    );
     const sessionKey = value.sessionKey;
     const updatedAt = value.updatedAt;
     if (

--- a/src/infra/state-migrations.web-push-parse.ts
+++ b/src/infra/state-migrations.web-push-parse.ts
@@ -12,6 +12,7 @@ import {
   type VapidKeyPair,
   type WebPushSubscription,
 } from "./push-web-store.js";
+import { assertAllowedJsonFields } from "./state-migrations.json-fields.js";
 
 const SUBSCRIPTION_STORE_KEYS = new Set(["subscriptionsByEndpointHash"]);
 const SUBSCRIPTION_KEYS = new Set([
@@ -25,23 +26,12 @@ const PUSH_KEYS = new Set(["p256dh", "auth"]);
 const VAPID_KEYS = new Set(["publicKey", "privateKey", "subject"]);
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-function assertOnlyKeys(
-  value: Record<string, unknown>,
-  allowed: ReadonlySet<string>,
-  label: string,
-) {
-  const unexpected = Object.keys(value).find((key) => !allowed.has(key));
-  if (unexpected) {
-    throw new Error(`${label} has unexpected field ${unexpected}`);
-  }
-}
-
 export function parseLegacySubscriptions(raw: string): Map<string, WebPushSubscription> {
   const parsed = JSON.parse(raw) as unknown;
   if (!isRecord(parsed) || !isRecord(parsed.subscriptionsByEndpointHash)) {
     throw new Error("legacy Web Push subscriptions must be an object");
   }
-  assertOnlyKeys(parsed, SUBSCRIPTION_STORE_KEYS, "legacy Web Push subscriptions store");
+  assertAllowedJsonFields(parsed, SUBSCRIPTION_STORE_KEYS, "legacy Web Push subscriptions store");
 
   const subscriptions = new Map<string, WebPushSubscription>();
   const subscriptionIds = new Set<string>();
@@ -51,8 +41,8 @@ export function parseLegacySubscriptions(raw: string): Map<string, WebPushSubscr
     if (!isRecord(rawSubscription) || !isRecord(rawSubscription.keys)) {
       throw new Error("legacy Web Push subscription is not an object");
     }
-    assertOnlyKeys(rawSubscription, SUBSCRIPTION_KEYS, "legacy Web Push subscription");
-    assertOnlyKeys(rawSubscription.keys, PUSH_KEYS, "legacy Web Push subscription keys");
+    assertAllowedJsonFields(rawSubscription, SUBSCRIPTION_KEYS, "legacy Web Push subscription");
+    assertAllowedJsonFields(rawSubscription.keys, PUSH_KEYS, "legacy Web Push subscription keys");
     const { subscriptionId, endpoint, createdAtMs, updatedAtMs } = rawSubscription;
     const p256dh = rawSubscription.keys.p256dh;
     const auth = rawSubscription.keys.auth;
@@ -93,7 +83,7 @@ export function parseLegacyVapidKeys(raw: string, env: NodeJS.ProcessEnv): Vapid
   if (!isRecord(parsed)) {
     throw new Error("legacy Web Push VAPID keys must be an object");
   }
-  assertOnlyKeys(parsed, VAPID_KEYS, "legacy Web Push VAPID keys");
+  assertAllowedJsonFields(parsed, VAPID_KEYS, "legacy Web Push VAPID keys");
   if (parsed.subject !== undefined && typeof parsed.subject !== "string") {
     throw new Error("legacy Web Push VAPID keys are invalid");
   }

--- a/src/infra/state-migrations.web-push.test.ts
+++ b/src/infra/state-migrations.web-push.test.ts
@@ -66,6 +66,15 @@ describe("legacy Web Push Doctor migration", () => {
     };
   }
 
+  function withUnexpectedJsonFields<T extends object>(value: T) {
+    return { "": 1, later: 2, ...value };
+  }
+
+  function subscriptionStore(value: unknown) {
+    const endpoint = subscription().endpoint;
+    return { subscriptionsByEndpointHash: { [hashWebPushEndpoint(endpoint)]: value } };
+  }
+
   async function writeLegacyState(params: {
     stateDir: string;
     subscriptions?: unknown;
@@ -243,6 +252,42 @@ describe("legacy Web Push Doctor migration", () => {
     expect(result.warnings[0]).toContain("VAPID keys are invalid");
     expect(readPersistedVapidKeyPair(stateDir)).toBeNull();
     expect(fs.existsSync(paths.vapidKeysPath!)).toBe(true);
+  });
+
+  it.each([
+    ["subscriptions store", false, withUnexpectedJsonFields({ subscriptionsByEndpointHash: {} })],
+    ["subscription", false, subscriptionStore(withUnexpectedJsonFields(subscription()))],
+    [
+      "subscription keys",
+      false,
+      subscriptionStore({
+        ...subscription(),
+        keys: withUnexpectedJsonFields(subscription().keys),
+      }),
+    ],
+    ["VAPID keys", true, withUnexpectedJsonFields(vapidKeys())],
+  ])("rejects unexpected JSON fields before mutation: %s", async (label, isVapid, value) => {
+    const stateDir = useStateDir();
+    const pushDir = path.join(stateDir, "push");
+    const sourcePath = path.join(
+      pushDir,
+      isVapid ? "vapid-keys.json" : "web-push-subscriptions.json",
+    );
+    await fsp.mkdir(pushDir, { recursive: true });
+    await fsp.writeFile(sourcePath, JSON.stringify(value), "utf8");
+
+    const result = await migrateLegacyWebPush({
+      detected: detectLegacyWebPush({ stateDir, doctorOnlyStateMigrations: true }),
+      stateDir,
+    });
+
+    expect(result.warnings[0]).toBe(
+      `Failed reading legacy Web Push state: Error: legacy Web Push ${label} has unexpected field ""`,
+    );
+    expect(listWebPushSubscriptions(stateDir)).toEqual([]);
+    expect(readPersistedVapidKeyPair(stateDir)).toBeNull();
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    expect(fs.existsSync(`${sourcePath}.doctor-importing`)).toBe(false);
   });
 
   it("removes an empty valid store only after opening SQLite", async () => {


### PR DESCRIPTION
## What Problem This Solves

Doctor migrations used `Object.keys(...).find(...)` followed by a truthiness check. When the first unexpected JSON key was `""`, the validator treated it as no match, ignored later unknown fields, and could claim/write invalid legacy state.

Pre-fix proof:

- Raw `{"":1,"other":2}` was accepted on the original migration validators.
- Before the expansion source edits, the five owner suites reported 9 failures and 83 passes: APNs, managed outgoing images, and TUI returned no warning, while node-host and Web Push still rendered the empty field as an ambiguous trailing blank.
- Restoring `if (unexpected)` in the canonical helper made all nine empty-key boundaries fail again.

## Why This Change Was Made

The migration-only `assertAllowedJsonFields` helper is now the canonical owner. It preserves `Object.keys` first-key ordering and rejects whenever the result is not `undefined`. Empty keys render visibly as `""`; APNs keeps its intentionally redacted message; managed-image nested fields retain the `original.` prefix.

Local validators were removed from:

- `src/infra/state-migrations.node-host.ts`
- `src/infra/state-migrations.web-push-parse.ts`
- `src/infra/state-migrations.apns.ts`
- `src/infra/state-migrations.managed-outgoing-images.ts`
- `src/infra/state-migrations.tui-last-session.ts`

No barrel, SDK, schema, transaction, persistence, config, protocol, dependency, or public API changed. Validation remains before every claim and SQLite write.

Production LOC: `+40/-49` (net `-9`). Test LOC: `+125/-6`; the approved expansion adds 53 raw test lines, under its 55-line cap. Existing unique node-host version, node-id, token, and ordinary unknown-field coverage remains intact.

## User Impact

Doctor now rejects an empty unexpected JSON key across node-host, Web Push, APNs, managed outgoing images, and TUI last-session imports. Rejections preserve legacy sources and attachments, create no claim, and leave canonical rows, receipts, and pointers unchanged.

No material SQLite approval is required because invalid input is rejected before mutation and no persistence contract changes.

Release-note context: fixes fail-closed validation for legacy JSON state imports. No CHANGELOG entry was added for this internal migration repair.

## Evidence

- Focused exact-head proof: 92/92 tests passed across all five owner suites.
- Exact warnings cover all six existing node-host/Web Push labels, APNs redaction, managed root-before-`original` precedence, nested `original.""`, and dynamic TUI scope/path text.
- Boundary coverage includes first-key ordering, raw `__proto__`, empty key plus `later`, retained source/attachment, and no claim/row/receipt/pointer.
- Mutation checks killed:
  - original truthiness restoration
  - omitted Web Push, APNs, managed-image, and TUI callsites
  - sorted/last-key selection and managed root/original precedence reversal
  - generic/hidden field messages and lost `original.` prefix
  - `__proto__` omission
  - APNs offending-field leakage
  - validation moved after SQLite mutation
- Structural gates passed:
  - `pnpm check:database-first-legacy-stores`
  - `pnpm check:import-cycles`
  - `pnpm check:madge-import-cycles`
  - `git diff --check`
- Local `pnpm build` and `pnpm check:changed` reached the UI build/core-test typecheck, then failed because the shared local install resolves stale `pako@1.0.11` while the lockfile and current main require `3.0.1`. Worktree policy forbids dependency reconciliation there; clean Linux Testbox is the authoritative full gate.
- Exact-candidate Linux Testbox (`tbx_01m1d9kxxbwm261nnh5qdz686z`) proved tree `a400cf652e567b131bb1ad493605554f90428ae2`, then passed dependency install, all three structural gates, `pnpm build`, `pnpm check:changed`, `git diff --check`, and the final numstat.
- Exact-head CI workflow `33459169936` passed after rerunning only failed job `99705625339`. Its first attempt had one unrelated fixed-20-second `spawnSync` `ETIMEDOUT` in `src/gateway/session-transcript-title-reader.retention.test.ts:74` after 2,970 tests passed and 2 skipped; rerun job `99707894960` passed.
- Pinned Codex Sol autoreview against exact rebased scope: scoped-clean, no P0/P1 findings, correctness 0.98.
- Codex source gate inspected directly: `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; those CLI command/config paths do not affect migration validation.
- History checked:
  - https://github.com/openclaw/openclaw/commit/766742c67463648f58c3494d72037c55294264b7
  - https://github.com/openclaw/openclaw/commit/8ff4f0161fca74422a19ad31af199d9853b235d3
- Live overlap audit: 2,258 open PRs; no exact helper filename, empty-key migration, or APNs diagnostic match.
- Latest exact-head ClawSweeper review found no introduced defect or actionable finding; all prior rank-up moves are implemented. Exact-head CI is green.
- Signed head: `a400cf652e567b131bb1ad493605554f90428ae2`.
