### PR TITLE
test(flows): load provider flow owners once per suite

### DIFF
--- a/src/flows/provider-flow.test.ts
+++ b/src/flows/provider-flow.test.ts
@@ -1,5 +1,5 @@
 // Provider flow tests cover provider setup prompts and config mutations.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 type ResolveProviderInstallCatalogEntries =
   typeof import("../plugins/provider-install-catalog.js").resolveProviderInstallCatalogEntries;
@@ -58,8 +58,13 @@ function requireFirstMockCall(mock: { mock: { calls: unknown[][] } }, label: str
 }
 
 describe("provider flow install catalog contributions", () => {
-  beforeEach(async () => {
+  beforeAll(async () => {
     vi.resetModules();
+    ({ resolveProviderSetupFlowContributions } = await import("./provider-flow.js"));
+    ({ resolveProviderModelPickerFlowContributions } = await import("./provider-flow.runtime.js"));
+  });
+
+  beforeEach(() => {
     resolveManifestProviderAuthChoices.mockReset();
     resolveManifestProviderAuthChoices.mockReturnValue([]);
     resolveProviderInstallCatalogEntries.mockReset();
@@ -70,8 +75,6 @@ describe("provider flow install catalog contributions", () => {
     resolveProviderModelPickerEntries.mockReturnValue([]);
     resolvePluginProvidersCore.mockReset();
     resolvePluginProvidersCore.mockReturnValue([]);
-    ({ resolveProviderSetupFlowContributions } = await import("./provider-flow.js"));
-    ({ resolveProviderModelPickerFlowContributions } = await import("./provider-flow.runtime.js"));
   });
 
   it("surfaces manifest provider auth choices before setup runtime loads", () => {


### PR DESCRIPTION
The provider-flow suite reloaded both stateless flow owners before every case. Load their fresh mocked graph once in beforeAll, while preserving all five per-case mock resets and default results. Nine resets become one and eighteen owner imports become two; all nine case bodies and 22 assertions remain unchanged.

The flow owners allocate their maps and sets per call. The older stabilization change ran in a shared, non-isolated graph; the current canonical route explicitly isolates this file. The initial reset and hoisted mocks remain, so this does not restore the earlier static-spy setup. No runtime or routing code changes.

All 18 selected provider-flow, model-picker catalog, and provider-wizard tests pass before and after through their owning configurations. The affected suite locally reported 263 ms before and 194 ms after; those are uncontrolled observations, not a suite-wide performance claim. The concrete saving is eight registry resets and sixteen owner imports per run.

Full changed checks passed and independent Codex autoreview is clean. Production delta is zero; tests add three lifecycle lines. Historical hosted execution order is unavailable; current isolated routing and the actual owner/sibling runs are the proof used here.
