### PR TITLE
test(gateway): prove live compaction pressure and replay contracts

### DIFF
--- a/src/gateway/gateway-codex-harness.live.test.ts
+++ b/src/gateway/gateway-codex-harness.live.test.ts
@@ -221,6 +221,8 @@ type CodexHarnessAgentResult = {
   usage?: CodexHarnessAttemptUsage;
 };
 
+const CODEX_REDUCED_CONTEXT_AUTO_COMPACT_LIMIT = 4_000;
+const CODEX_REDUCED_CONTEXT_PRESSURE_CHARS = 90_000;
 const CODEX_FULL_CONTEXT_AUTO_COMPACT_LIMIT = 700_000;
 const CODEX_FULL_CONTEXT_EFFECTIVE_WINDOW = 875_900;
 const CODEX_FULL_CONTEXT_STANDARD_WINDOW = 272_000;
@@ -455,8 +457,8 @@ function buildCodexCompactionAppServerArgs(mode: CodexCompactionStressMode): str
       : mode.kind === "reduced"
         ? [
             "model_auto_compact_token_limit_scope=body_after_prefix",
-            // One truncated 300 KB tool result is only a few thousand tokens.
-            "model_auto_compact_token_limit=4000",
+            // Raw nested CodeMode output is not necessarily emitted to model context.
+            `model_auto_compact_token_limit=${CODEX_REDUCED_CONTEXT_AUTO_COMPACT_LIMIT}`,
             "tool_output_token_limit=10000",
           ]
         : undefined;
@@ -1291,6 +1293,20 @@ async function verifyCodexCompactionStress(params: {
   let completedCompactions = 0;
   let reportedCompactions = 0;
   let startedCompactions = 0;
+  const observeTurn = (label: string, result: CodexHarnessAgentResult) => {
+    recordCodexAttemptIdentity({ events: result.events, sessionKey: params.sessionKey });
+    logCodexHarnessTurnMeasurement(label, result);
+    const compaction = readCompletedCodexCompactionStats(result.events);
+    completedCompactions += compaction.count;
+    startedCompactions += compaction.startedCount;
+    reportedCompactions += result.compactionCount;
+    const usage = readCodexNativeUsageSnapshots(result.events).at(-1);
+    if (!usage || usage.promptTokens <= 0) {
+      throw new Error(`${label} emitted no final native prompt usage`);
+    }
+    return { usage, compaction };
+  };
+  let previousUsage: CodexNativeUsageSnapshot | undefined;
   for (let turn = 1; turn <= CODEX_HARNESS_COMPACTION_STRESS_TURNS; turn += 1) {
     const acknowledgement = `CODEX-LARGE-OUTPUT-${turn}-OK`;
     const commandMarker = `OPENCLAW-CODEX-LARGE-OUTPUT-${turn}-${randomBytes(6).toString("hex").toUpperCase()}`;
@@ -1307,17 +1323,12 @@ async function verifyCodexCompactionStress(params: {
     ].join("\n");
     const result = await requestAgentTextWithEvents({
       client: params.client,
-      eventPrefixes: ["codex_app_server.", "compaction", "tool"],
+      eventPrefixes: [...CODEX_HARNESS_CONTEXT_EVENT_PREFIXES, "tool"],
       sessionKey: params.sessionKey,
       message,
     });
     expect(result.text).toContain(acknowledgement);
-    recordCodexAttemptIdentity({ events: result.events, sessionKey: params.sessionKey });
-    logCodexHarnessTurnMeasurement(`reduced-stress-${turn}`, result);
-    const turnCompaction = readCompletedCodexCompactionStats(result.events);
-    completedCompactions += turnCompaction.count;
-    startedCompactions += turnCompaction.startedCount;
-    reportedCompactions += result.compactionCount;
+    previousUsage = observeTurn(`reduced-output-${turn}`, result).usage;
     const history: { messages?: unknown[] } = await params.client.request("chat.history", {
       sessionKey: params.sessionKey,
       limit: 100,
@@ -1331,6 +1342,69 @@ async function verifyCodexCompactionStress(params: {
     });
   }
 
+  // Native output above proves command execution, not CodeMode's outer emission.
+  // Direct input supplies bounded pressure after this wave's warm/cold-resume prefix.
+  let measuredPressureCycles = 0;
+  for (let cycle = 1; cycle <= 2; cycle += 1) {
+    if (!previousUsage) {
+      throw new Error("reduced pressure probe has no preceding native usage");
+    }
+    const denseToken = `CODEX-PRESSURE-${cycle}-OK`;
+    const dense = await requestAgentTextWithEvents({
+      client: params.client,
+      eventPrefixes: CODEX_HARNESS_CONTEXT_EVENT_PREFIXES,
+      sessionKey: params.sessionKey,
+      message: [
+        buildCodexHarnessDenseContext({
+          marker: `PRESSURE-${randomBytes(6).toString("hex").toUpperCase()}`,
+          chars: CODEX_REDUCED_CONTEXT_PRESSURE_CHARS,
+        }),
+        `Do not use tools. Reply exactly ${denseToken} and nothing else.`,
+      ].join("\n\n"),
+    });
+    expect(dense.text.trim()).toBe(denseToken);
+    const pressure = observeTurn(`reduced-pressure-${cycle}`, dense);
+    // A final answer can cross the limit without another sampling opportunity.
+    const triggerToken = `CODEX-PRESSURE-TRIGGER-${cycle}-OK`;
+    const trigger = await requestAgentTextWithEvents({
+      client: params.client,
+      eventPrefixes: CODEX_HARNESS_CONTEXT_EVENT_PREFIXES,
+      sessionKey: params.sessionKey,
+      message: `Do not use tools. Reply exactly ${triggerToken} and nothing else.`,
+    });
+    expect(trigger.text.trim()).toBe(triggerToken);
+    const after = observeTurn(`reduced-trigger-${cycle}`, trigger);
+    const promptGrowth = pressure.usage.promptTokens - previousUsage.promptTokens;
+    // Compaction changes the prefix. Never compare usage across that boundary;
+    // the second fixed pair supplies a fresh interval if the first compacted early.
+    if (pressure.compaction.count === 0) {
+      expect(
+        promptGrowth,
+        "dense input did not create measured prompt pressure",
+      ).toBeGreaterThanOrEqual(CODEX_REDUCED_CONTEXT_AUTO_COMPACT_LIMIT);
+      expect(
+        after.compaction.count,
+        "small trigger did not compact measured pressure",
+      ).toBeGreaterThan(0);
+      // Native compact retains real user messages; total prompt size need not shrink.
+      measuredPressureCycles += 1;
+    }
+    logCodexLiveStep("reduced-pressure-cycle", {
+      cycle,
+      inputChars: CODEX_REDUCED_CONTEXT_PRESSURE_CHARS,
+      beforePromptTokens: previousUsage.promptTokens,
+      densePromptTokens: pressure.usage.promptTokens,
+      afterPromptTokens: after.usage.promptTokens,
+      denseCompactions: pressure.compaction.count,
+      triggerCompactions: after.compaction.count,
+      measured: pressure.compaction.count === 0,
+    });
+    previousUsage = after.usage;
+  }
+  expect(
+    measuredPressureCycles,
+    "wave omitted measured pressure-to-compaction proof",
+  ).toBeGreaterThan(0);
   expect(completedCompactions, "expected at least one native automatic compaction").toBeGreaterThan(
     0,
   );

--- a/src/gateway/gateway-openai-long-context.live.test.ts
+++ b/src/gateway/gateway-openai-long-context.live.test.ts
@@ -1,9 +1,10 @@
 // Process-owned Gateway proof for first-class OpenAI Responses long-context compaction.
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { setTimeout as delay } from "node:timers/promises";
 import { afterEach, describe, expect, it } from "vitest";
+import { GATEWAY_CLIENT_CAPS } from "../../packages/gateway-protocol/src/client-info.js";
 import type { EventFrame } from "../../packages/gateway-protocol/src/index.js";
 import {
   aggregateOpenAILongContextMetric,
@@ -31,6 +32,7 @@ import { isLiveTestEnabled } from "../agents/live-test-helpers.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { loadOrCreateDeviceIdentity } from "../infra/device-identity.js";
 import { extractFirstTextBlock } from "../shared/chat-message-content.js";
+import { loadSqliteTrajectoryRuntimeEvents } from "../trajectory/runtime-store.sqlite.js";
 import type { GatewayClient } from "./client.js";
 import { connectGatewayClient } from "./test-helpers.e2e.js";
 
@@ -242,13 +244,13 @@ async function requestTurn(params: {
     throw new Error(`OpenAI long-context turn failed with status ${String(response.status)}`);
   }
   const elapsedMs = Date.now() - startedAt;
-  const events = params.allEvents
-    .slice(eventOffset)
-    .filter((event) => !event.sessionKey || event.sessionKey === SESSION_KEY);
-  const runId = response.runId ?? events.find((event) => event.runId)?.runId;
+  const runId = response.runId;
   if (!runId) {
     throw new Error(`OpenAI long-context ${params.phase} turn omitted its run id`);
   }
+  const events = params.allEvents
+    .slice(eventOffset)
+    .filter((event) => event.runId === runId && event.sessionKey === SESSION_KEY);
   const firstAssistant = events.find(
     (event) => event.stream === "assistant" && event.receivedAt !== undefined,
   );
@@ -262,6 +264,48 @@ async function requestTurn(params: {
   });
   expect(transport.serviceTier).toBe("priority");
   expect(transport.contextManagement).toBe(true);
+  // The start diagnostic describes prepared params, not continuation/retry egress.
+  // Require every final request in this exact run to retain the assembled prompt.
+  const observations = (
+    await loadSqliteTrajectoryRuntimeEvents({
+      agentId: AGENT_ID,
+      sessionId: params.sessionId,
+      storePath: path.join(params.instance.state.agentDir(AGENT_ID), "openclaw-agent.sqlite"),
+    })
+  ).filter((event) => event.type === "provider.prompt.observed" && event.runId === runId);
+  expect(
+    observations.length,
+    `${params.phase} omitted final-request prompt evidence`,
+  ).toBeGreaterThan(0);
+  for (const observation of observations) {
+    expect(observation).toMatchObject({ sessionId: params.sessionId, sessionKey: SESSION_KEY });
+    expect(observation.data).toMatchObject({
+      promptSource: "instructions",
+      matchesAssembledPrompt: true,
+    });
+    expect(observation.data?.expectedChars).toBeGreaterThan(0);
+    expect(observation.data?.observedChars).toBe(observation.data?.expectedChars);
+    // Both rejected continuation and stripped compaction can rebuild full history.
+    expect(["initial", "reasoning-stripped"]).toContain(observation.data?.payloadVariant);
+  }
+  if (requireSettings().emitMetrics) {
+    console.error(
+      `[gateway-openai-long-context-proof] ${JSON.stringify({
+        phase: params.phase,
+        sessionIdHash: createHash("sha256").update(params.sessionId).digest("hex"),
+        runIdHash: createHash("sha256").update(runId).digest("hex"),
+        preparedRequest: transport,
+        finalPrompts: observations.map(({ data }) => ({
+          egress: data?.egress,
+          payloadVariant: data?.payloadVariant,
+          promptSource: data?.promptSource,
+          expectedChars: data?.expectedChars,
+          observedChars: data?.observedChars,
+          matchesAssembledPrompt: data?.matchesAssembledPrompt,
+        })),
+      })}`,
+    );
+  }
   const result: TurnResult = {
     text: extractResultText(response.result),
     events,
@@ -357,15 +401,11 @@ function assertReplayEgress(
   if (latest.idHash) {
     expect(transport.compactionIdHashes).toContain(latest.idHash);
   }
-  const compactionIndex = transport.inputItemShape.indexOf("compaction");
-  expect(compactionIndex).toBeGreaterThan(0);
-  expect(transport.compactionInputIndexes).toEqual([compactionIndex]);
+  // Inline checkpoints prune the earlier input; the prompt lives in instructions.
+  // Standalone /responses/compact instead requires its entire returned window.
+  expect(transport.inputItemShape[0]).toBe("compaction");
+  expect(transport.compactionInputIndexes).toEqual([0]);
   expect(transport.inputItems).toBe(transport.inputItemShape.length);
-  expect(
-    transport.inputItemShape
-      .slice(0, compactionIndex)
-      .every((item) => /^message:(developer|system)$/u.test(item)),
-  ).toBe(true);
   expect(transport.inputItemShape.at(-1)).toBe("message:user");
 }
 
@@ -419,6 +459,7 @@ describeLive("Gateway OpenAI long-context compaction (live)", () => {
         token: instance.gatewayToken,
         role: "operator",
         scopes: ["operator.admin", "operator.read", "operator.write"],
+        caps: [GATEWAY_CLIENT_CAPS.TOOL_EVENTS],
         deviceIdentity,
         requestTimeoutMs: profile.requestTimeoutMs + 30_000,
         timeoutMs: 60_000,
@@ -645,6 +686,7 @@ describeLive("Gateway OpenAI long-context compaction (live)", () => {
         token: instance.gatewayToken,
         role: "operator",
         scopes: ["operator.admin", "operator.read", "operator.write"],
+        caps: [GATEWAY_CLIENT_CAPS.TOOL_EVENTS],
         deviceIdentity,
         requestTimeoutMs: profile.requestTimeoutMs + 30_000,
         timeoutMs: 60_000,

--- a/src/gateway/gateway-openai-long-context.live.test.ts
+++ b/src/gateway/gateway-openai-long-context.live.test.ts
@@ -370,7 +370,21 @@ function markerStatus(text: string, markers: LongOutputMarkers): Record<string, 
 }
 
 function expectAllMarkers(text: string, markers: LongOutputMarkers): void {
-  expect(markerStatus(text, markers)).toEqual({ begin: true, middle: true, end: true });
+  // Diagnose recall failures without retaining provider text or marker values.
+  const diagnostic = {
+    responseChars: text.length,
+    responseHash: createHash("sha256").update(text).digest("hex"),
+    caseInsensitive: markerStatus(text.toLowerCase(), {
+      begin: markers.begin.toLowerCase(),
+      middle: markers.middle.toLowerCase(),
+      end: markers.end.toLowerCase(),
+    }),
+  };
+  expect(markerStatus(text, markers), JSON.stringify(diagnostic)).toEqual({
+    begin: true,
+    middle: true,
+    end: true,
+  });
 }
 
 function promptTokens(result: TurnResult): number | undefined {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where maintainers running the live compaction/restart suites can get a false failure or incomplete proof despite a working provider contract. The reduced Codex stress test treated large raw command output as model-visible pressure, while the OpenAI Responses test required an input-message prefix that native requests now carry in top-level `instructions`.

This is an explicitly maintainer-requested, tests-only repair of failures observed on `e8811f20648b98639bd897ed8014fb3d5aa11e17`. Both old test files were still unchanged on the refreshed main baseline `1c9770abaf4ae20442122730510b8d447709942b`.

## Why This Change Was Made

Keep raw native-command success/output evidence separate from compaction pressure. After each output wave, two fixed 90,000-character direct-input/small-trigger pairs require a measured same-window prompt increase of at least the unchanged 4,000-token threshold and an automatic compaction on the next turn. Usage comparisons never cross a compaction boundary; native compaction is not required to shrink total prompt size because it retains real user messages.

For inline Responses checkpoints, require index zero and validate every existing final-request `provider.prompt.observed` event for the exact response run and session: nonempty `instructions`, equal expected/observed character counts, and an exact assembled-prompt match. Reject checkpoint-discarding fallback paths. Request the existing `tool-events` capability on both WebSocket connections so the real large-read proof has its required evidence.

All raw-output, lifecycle/result/persisted-count, checkpoint-hash/count/order, pressure, marker, and restart guards remain. No thresholds or timeouts were relaxed. Standalone `/responses/compact` whole-window replay and runtime summary projection are unchanged. There is no new production instrumentation or configuration.

## User Impact

No product behavior changes. Maintainers get stronger live evidence for native Codex compaction and official OpenAI checkpoint replay, including the previously unreached long-output, tool-output, and restart sections.

Production LOC: +0/-0 (net 0). Tests: +153/-23 (net +130), two files. The final 14 net lines add sanitized marker-failure diagnostics only; exact acceptance and marker fixtures are unchanged.

## Evidence

### Current-head refresh

Head: `a5ccee0da84b4db305d4e75ebdd923fc24468932`; source tree: `f51c7e0c916dcde96525ae5818b7301be4a19593`.

The candidate was refreshed after substantial shared agent/lifecycle changes on main. Fresh, cache-disabled `qaRuntime` builds passed on isolated Linux Blacksmith Testbox, Node v24.19.0. All 35,902 tracked source files passed byte/type/mode/symlink verification before and after builds, live runs, and checks.

| Proof | Result |
| --- | --- |
| Full Sol Responses, exact final tree | Passed, 110.83 s: 862,667 peak prompt tokens; first replay 27,360; exact checkpoint hashes/count/index; 11 final-instruction observations with 23,097 expected/observed characters and assembled-prompt equality; no forbidden fallback; exact 384-line/5,454-token output; 800 KB read; persisted checkpoint and all three markers across restart. |
| Sol native, refreshed parent `7b56aa4b1bb` | Passed, 191.01 s: two waves of eight 600 KB outputs, 12 history turns, five cold restarts, and four measured pressure/trigger pairs; all accounting, recall, identity, and deletion/ownership guards passed. |
| Default Luna native, refreshed parent `7b56aa4b1bb` | Passed, 143.42 s: two waves of four 300 KB outputs, four history turns, three cold restarts, and four measured pressure/trigger pairs. |
| Focused owner/sibling tests, exact final tree | 156 passed in eight files, none failed/skipped, 53.46 s. Covers native fixture/usage, final prompt observer, retained whole-window replay, and real HTTP instructions contracts. |
| Changed-scope gates, exact final tree | Passed, 174.63 s: core test types, targeted lint/format, and selected guards. |
| Managed Codex installation | Public `codex/managed-app-server` Doctor check: one check, zero findings, exact 0.151.0 pin. Installation-path proof, not a retrospective physical-client handshake. |

The final commit differs from the refreshed native-proof parent only in the Responses test's failure-message diagnostics; application code and the native test are byte-identical. The mutually exclusive disabled-native-harness test is intentionally skipped in each enabled native run. No full release matrix, OAuth, or external-channel proof is claimed.

Environment: [current Testbox run](https://github.com/openclaw/openclaw/actions/runs/33452636387), lease `tbx_01m1d3y963knf5hgm6j9nadnms`, supported 90-minute idle timeout. That Actions link identifies the prepared environment; the delegated command result and exact source-tree verification determine test success, not the hosting job's eventual shutdown state.

All application imports/builds/tests are remote-only. HOME/USERPROFILE, state/config, CODEX_HOME, tmp, and XDG directories are isolated before imports. Live children receive only the selected API key through supported Testbox hydration; no operator state/auth files are copied. Only sanitized structural evidence is retained.

### Failure accounting and remaining uncertainty

One refreshed-parent Responses run passed checkpoint/hash/index and final-instruction checks but failed all three exact marker matches at first replay. Its reply text was not retained, so the cause is **unknown**—not classified as content loss, casing, or a provider flake. A bounded independent diagnostic then verified the markers in persisted, canonical-active, and bounded model context before compaction and recalled them exactly afterward; it did not reproduce the mismatch and is not counted as full-case proof. The final commit adds only hash/length/case-comparison diagnostics to the unchanged strict assertion. One subsequent complete final-tree case passed as reported above. No retry loop, marker normalization, stimulus change, or acceptance relaxation was added; the failed sample remains recorded.

Earlier implementation runs also caught an invalid newly added total-prompt-shrink assertion and the missing tool-events capability. The former was removed after direct inspection of native retained-user-message behavior; the latter was fixed rather than weakening the read guard. The original frozen run lacked final-instruction observations and did not complete the later Responses sections; it is not claimed as that proof.

### Contract and review checks

Direct dependency inspection covered stock Codex 0.151.0 at `78c290807ce710180111df227df3b7a4fe845452`:

- [Nested output](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/core/src/tools/context.rs#L409-L434) versus [outer CodeMode emission](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/core/src/tools/code_mode/mod.rs#L250-L291).
- [Window-local pressure](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/core/src/session/context_window.rs#L37-L79) and [next-turn trigger opportunity](https://github.com/openai/codex/blob/78c290807ce710180111df227df3b7a4fe845452/codex-rs/core/src/session/turn.rs#L1033-L1059).

OpenAI SDK 7.5.0's `instructions` request contract and the current [inline-versus-standalone compaction guide](https://developers.openai.com/api/docs/guides/compaction) were inspected directly. Prepared `[responses] start` diagnostics establish checkpoint structure; final-request observations establish instructions, not final checkpoint hashes.

Fresh source-aware Codex autoreview on the refreshed candidate: scoped-clean at the configured P0 priority. Local execution was limited to source/Git inspection, normal formatting/content-guard hooks, remote orchestration, and isolated source review; no local application runtime proof. No UI behavior changed, so browser screenshots are not applicable.
