### PR TITLE
refactor(claws): share path containment policy

### DIFF
--- a/src/claws/bootstrap.ts
+++ b/src/claws/bootstrap.ts
@@ -1,10 +1,11 @@
 import { createHash } from "node:crypto";
 import { realpath } from "node:fs/promises";
-import { isAbsolute, relative, resolve, sep } from "node:path";
+import { resolve } from "node:path";
 import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../agents/workspace-bootstrap-read.js";
 import { DEFAULT_BOOTSTRAP_FILENAME, seedWorkspaceBootstrap } from "../agents/workspace.js";
 import { root as fsSafeRoot } from "../infra/fs-safe.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db.js";
+import { clawContainedRelativePath } from "./path-containment.js";
 import type { ClawAddPlan } from "./types.js";
 
 export class ClawBootstrapWriteError extends Error {
@@ -19,14 +20,6 @@ export class ClawBootstrapWriteError extends Error {
 
 function contentDigest(content: Uint8Array): string {
   return `sha256:${createHash("sha256").update(content).digest("hex")}`;
-}
-
-function containedRelativePath(root: string, path: string): string | undefined {
-  const child = relative(root, path);
-  if (child === ".." || child.startsWith(`..${sep}`) || isAbsolute(child)) {
-    return undefined;
-  }
-  return child;
 }
 
 export async function seedClawPackageBootstrap(
@@ -62,7 +55,7 @@ export async function seedClawPackageBootstrap(
 
   const packageRoot = await realpath(resolve(plan.claw.packageRoot));
   const sourcePath = resolve(action.source);
-  const sourceRelative = containedRelativePath(packageRoot, sourcePath);
+  const sourceRelative = clawContainedRelativePath(packageRoot, sourcePath);
   if (!sourceRelative) {
     throw new ClawBootstrapWriteError(
       "bootstrap_source_escape",

--- a/src/claws/path-containment.test.ts
+++ b/src/claws/path-containment.test.ts
@@ -1,0 +1,30 @@
+import { join, resolve, sep } from "node:path";
+import { describe, expect, it } from "vitest";
+import { clawContainedRelativePath } from "./path-containment.js";
+
+describe("clawContainedRelativePath", () => {
+  const root = resolve(sep, "claw-root");
+
+  it("returns native relative paths only for strict descendants", () => {
+    expect(clawContainedRelativePath(root, root)).toBeUndefined();
+    expect(clawContainedRelativePath(root, join(root, "file.md"))).toBe("file.md");
+    expect(clawContainedRelativePath(root, join(root, "nested", "file.md"))).toBe(
+      join("nested", "file.md"),
+    );
+  });
+
+  it.each([
+    ["parent", join(root, "..", "outside.md")],
+    ["prefix sibling", join(`${root}-sibling`, "file.md")],
+    ["unrelated absolute root", resolve(sep, "unrelated", "file.md")],
+  ])("rejects %s paths", (_name, target) => {
+    expect(clawContainedRelativePath(root, target)).toBeUndefined();
+  });
+
+  it.runIf(process.platform === "win32")("rejects cross-drive and cross-UNC paths", () => {
+    expect(clawContainedRelativePath("C:\\root", "D:\\root\\file.md")).toBeUndefined();
+    expect(
+      clawContainedRelativePath("\\\\server\\share\\root", "\\\\other\\share\\root\\file.md"),
+    ).toBeUndefined();
+  });
+});

--- a/src/claws/path-containment.ts
+++ b/src/claws/path-containment.ts
@@ -1,0 +1,8 @@
+import { relative } from "node:path";
+import { isPathRelativeEscape } from "../infra/path-safety.js";
+
+export function clawContainedRelativePath(root: string, target: string): string | undefined {
+  const child = relative(root, target);
+  // Claw file actions require a strict descendant, never the root itself.
+  return child !== "" && !isPathRelativeEscape(child) ? child : undefined;
+}

--- a/src/claws/workspace.ts
+++ b/src/claws/workspace.ts
@@ -1,7 +1,7 @@
 // Creates Claw-owned bootstrap and supporting files inside the new agent workspace.
 import { createHash } from "node:crypto";
 import { realpath } from "node:fs/promises";
-import { isAbsolute, relative, resolve, sep } from "node:path";
+import { resolve, sep } from "node:path";
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
 import { root as fsSafeRoot, FsSafeError, type Root } from "../infra/fs-safe.js";
 import {
@@ -9,6 +9,7 @@ import {
   runOpenClawStateWriteTransaction,
   type OpenClawStateDatabaseOptions,
 } from "../state/openclaw-state-db.js";
+import { clawContainedRelativePath } from "./path-containment.js";
 import { parseClawMarkdown } from "./reader.js";
 import type { ClawAddPlan, ClawAddPlanAction, ClawDiagnostic } from "./types.js";
 
@@ -81,14 +82,6 @@ function contentDigest(content: Uint8Array): string {
   return `sha256:${createHash("sha256").update(content).digest("hex")}`;
 }
 
-function containedRelativePath(root: string, path: string): string | undefined {
-  const child = relative(root, path);
-  if (child === ".." || child.startsWith(`..${sep}`) || isAbsolute(child)) {
-    return undefined;
-  }
-  return child;
-}
-
 export async function readClawWorkspaceActionSource(params: {
   action: ClawAddPlanAction;
   packageRoot: string;
@@ -98,7 +91,7 @@ export async function readClawWorkspaceActionSource(params: {
     throw new Error("Workspace file action lacks a source.");
   }
   const sourcePath = resolve(params.action.source);
-  const sourceRelative = containedRelativePath(params.packageRoot, sourcePath);
+  const sourceRelative = clawContainedRelativePath(params.packageRoot, sourcePath);
   if (!sourceRelative) {
     throw new Error("Workspace file source must remain inside the Claw package.");
   }
@@ -365,7 +358,7 @@ export async function createClawWorkspaceFiles(
         );
       }
       const targetPath = resolve(action.target);
-      const targetRelative = containedRelativePath(workspaceRoot, targetPath);
+      const targetRelative = clawContainedRelativePath(workspaceRoot, targetPath);
       if (!targetRelative) {
         throw new ClawWorkspaceWriteError(
           [

--- a/src/infra/path-safety.ts
+++ b/src/infra/path-safety.ts
@@ -5,6 +5,7 @@ import "./fs-safe-defaults.js";
 export {
   isPathInside,
   isPathInsideWithRealpath,
+  isPathRelativeEscape,
   isWithinDir,
   safeRealpathSync,
   safeStatSync,


### PR DESCRIPTION
## What Problem This Solves

Claw bootstrap and workspace writes duplicated the same lexical containment policy before `fs-safe` reads. Keeping two copies makes this security boundary easier to drift as package and workspace flows evolve.

## Why This Change Was Made

This consolidates the exact strict-descendant rule in one private Claw helper. It uses `node:path.relative` plus the existing `@openclaw/fs-safe/path` escape predicate through OpenClaw's internal path-safety facade, while leaving path resolution, realpath, symlink, hardlink, identity, digest, validation order, and diagnostics with their existing owners.

## User Impact

No user-visible behavior changes. Consented Claw file actions retain the same containment and integrity checks through one canonical policy.

Production LOC: +16/-21 (net -5) | Tests: +30/-0

## Evidence

- `node scripts/run-vitest.mjs run src/claws/path-containment.test.ts src/claws/bootstrap.test.ts src/claws/workspace.test.ts src/claws/workspace-update.test.ts`
  - 35 passed, 1 Windows-only test skipped on macOS.
- `pnpm check:import-cycles`
- `pnpm check:madge-import-cycles`
- `pnpm check:max-lines-ratchet`
- `pnpm build`
- `pnpm check:changed`
- `git diff --check`
- `src/infra/fs-safe-import-boundary.test.ts`
  - passed after routing the dependency export through `src/infra/path-safety.ts`, as required by the repository's direct-import boundary.
- Linux Testbox `tbx_01m1d6s6y1qw4k0mm8sbr5ezft`:
  - clean `pnpm build`, `pnpm check:changed`, and the exact four-suite command above passed.
  - run: https://github.com/openclaw/openclaw/actions/runs/33455973483
- Locked dependency contract, inspected from the installed package:
  - root dependency and lock importer both pin `@openclaw/fs-safe` exactly to `0.5.6`.
  - `dist/path.js` implements `relativePath === ".." || relativePath.startsWith(\`..\${path.sep}\`) || path.isAbsolute(relativePath)`.
  - `dist/path.d.ts` declares `isPathRelativeEscape(relativePath: string): boolean`.
- Native Windows proof:
  - `path.win32.relative("C:\\root", "D:\\root\\file.md")` produced `"D:\\root\\file.md"`; it was absolute and `isPathRelativeEscape` returned true.
  - cross-UNC `path.win32.relative()` produced `"\\\\other\\share\\root\\file.md"`; it was absolute and `isPathRelativeEscape` returned true.
  - all 5 direct helper tests passed, including cross-drive and cross-UNC rejection.
  - removing only the installed predicate's `path.isAbsolute(relativePath)` clause made the Windows test fail; restoring it returned all 5 tests to green.
  - the proof step passed; the workflow's later unrelated Scheduled Task preflight failed because the runner session was non-interactive.
  - run: https://github.com/openclaw/openclaw/actions/runs/33458272480
- Mutation proof also rejected root equality, string-prefix containment, and omitted parent-prefix handling.
- Structured autoreview: scoped clean, 0.98 confidence, no actionable findings.

Existing-solution check: `@openclaw/fs-safe/path` already owns the canonical relative-escape predicate, so no new SDK or package seam was added. The one-line internal facade re-export is required by the repository's fs-safe import boundary.
