### PR TITLE
test(process): reuse supervisor factories across fresh instances

### DIFF
--- a/src/process/supervisor/supervisor.scope-extinction.test.ts
+++ b/src/process/supervisor/supervisor.scope-extinction.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import {
   createSilentIdleArgv,
@@ -24,9 +24,12 @@ vi.mock("./adapters/pty.js", () => ({
 let createProcessSupervisor: typeof import("./supervisor.js").createProcessSupervisor;
 
 describe("process supervisor scope extinction", () => {
-  beforeEach(async () => {
+  beforeAll(async () => {
     vi.resetModules();
     ({ createProcessSupervisor } = await import("./supervisor.js"));
+  });
+
+  beforeEach(() => {
     createChildAdapterMock.mockReset();
     createPtyAdapterMock.mockReset();
     vi.useRealTimers();

--- a/src/process/supervisor/supervisor.test.ts
+++ b/src/process/supervisor/supervisor.test.ts
@@ -1,6 +1,6 @@
 // Process supervisor tests cover lifecycle, restart, and termination behavior.
 import { performance } from "node:perf_hooks";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { mockProcessPlatform } from "../../test-utils/vitest-spies.js";
 import {
@@ -28,9 +28,12 @@ vi.mock("./adapters/pty.js", () => ({
 let createProcessSupervisor: typeof import("./supervisor.js").createProcessSupervisor;
 
 describe("process supervisor", () => {
-  beforeEach(async () => {
+  beforeAll(async () => {
     vi.resetModules();
     ({ createProcessSupervisor } = await import("./supervisor.js"));
+  });
+
+  beforeEach(() => {
     createChildAdapterMock.mockReset();
     createPtyAdapterMock.mockReset();
     vi.useRealTimers();


### PR DESCRIPTION
The two supervisor suites rebuilt the module graph before every case even though createProcessSupervisor allocates a new registry, active-run maps, startup fences and shutdown state per call. Import the factory once per suite after an initial reset. Keep each case's fresh supervisor, adapter resets, timer setup, spy restoration and assertions unchanged.

This removes 28 module resets and owner evaluations across 30 cases. All 134 expect sites and the cancellation, replacement, extinction, output and deadline scenarios remain. The process-wide singleton is a separate owner and is not used by these suites; only the lazy diagnostic logger is reused between their spawn-failure cases.

The entire current process configuration passed before and after in one shared worker: 376 passed and the same 61 skipped, with identical test identities/outcomes. Four registry tests also passed both times. The affected suites locally fell from about 66.6 ms to 15.9 ms of test time, while full-run wall time varied; no suite-wide elapsed speedup is claimed.

Full changed checks passed; independent Codex autoreview is clean. Production is unchanged; tests add six lifecycle lines. The existing cross-file runner cleanup and both suites' initial fresh graph remain intact.
