### PR TITLE
refactor(browser): consolidate storage mutation parsing

### DIFF
--- a/extensions/browser/src/browser/routes/agent.storage.device.test.ts
+++ b/extensions/browser/src/browser/routes/agent.storage.device.test.ts
@@ -8,15 +8,14 @@ const routeState = vi.hoisted(() => ({
   cookiesSetManyViaPlaywright: vi.fn(async () => ({ added: 2 })),
   setDeviceViaPlaywright: vi.fn(async () => {}),
   setHttpCredentialsViaPlaywright: vi.fn(async () => {}),
+  storageSetViaPlaywright: vi.fn(async () => {}),
+  storageClearViaPlaywright: vi.fn(async () => {}),
   withPlaywrightRouteContext: vi.fn(),
 }));
 
-vi.mock("./agent.shared.js", () => ({
-  readBody: (req: BrowserRequest) => req.body ?? {},
+vi.mock("./agent.shared.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./agent.shared.js")>()),
   resolveProfileContext: () => ({ profile: { driver: routeState.driver } }),
-  resolveTargetIdFromBody: (body: Record<string, unknown>) =>
-    typeof body.targetId === "string" ? body.targetId : undefined,
-  resolveTargetIdFromQuery: () => undefined,
   withPlaywrightRouteContext: routeState.withPlaywrightRouteContext,
 }));
 
@@ -33,6 +32,8 @@ type PlaywrightRouteParams = {
       cookiesSetManyViaPlaywright: typeof routeState.cookiesSetManyViaPlaywright;
       setDeviceViaPlaywright: typeof routeState.setDeviceViaPlaywright;
       setHttpCredentialsViaPlaywright: typeof routeState.setHttpCredentialsViaPlaywright;
+      storageSetViaPlaywright: typeof routeState.storageSetViaPlaywright;
+      storageClearViaPlaywright: typeof routeState.storageClearViaPlaywright;
     };
   }) => Promise<unknown>;
 };
@@ -180,6 +181,66 @@ describe("browser cookie batch route", () => {
 });
 
 describe("browser storage route boundaries", () => {
+  it.each([
+    { kind: "local", operation: "set", value: "  preserved  " },
+    { kind: "session", operation: "set", value: "" },
+    { kind: "local", operation: "clear", value: undefined },
+    { kind: "session", operation: "clear", value: undefined },
+  ] as const)(
+    "parses $kind storage $operation before dispatch",
+    async ({ kind, operation, value }) => {
+      const response = createBrowserRouteResponse();
+      await getPostHandler(`/storage/:kind/${operation}`)?.(
+        {
+          params: { kind: ` ${kind} ` },
+          query: {},
+          body: { targetId: " requested-tab ", key: " key ", value },
+        },
+        response.res,
+      );
+
+      expect(routeState.withPlaywrightRouteContext).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ targetId: "requested-tab", feature: `storage ${operation}` }),
+      );
+      const mutation =
+        operation === "set"
+          ? routeState.storageSetViaPlaywright
+          : routeState.storageClearViaPlaywright;
+      expect(mutation).toHaveBeenCalledExactlyOnceWith({
+        cdpUrl: "http://127.0.0.1:18800",
+        targetId: "tab-1",
+        kind,
+        ...(operation === "set" ? { key: "key", value } : {}),
+      });
+      expect(response.statusCode).toBe(200);
+      expect(response.body).toEqual({ ok: true, targetId: "tab-1" });
+    },
+  );
+
+  it.each(["set", "clear"])(
+    "rejects an invalid storage kind before %s dispatch",
+    async (operation) => {
+      const response = createBrowserRouteResponse();
+      await getPostHandler(`/storage/:kind/${operation}`)?.(
+        {
+          params: { kind: "invalid" },
+          query: {},
+          body: {
+            key: "",
+            targetId: " requested-tab ",
+          },
+        },
+        response.res,
+      );
+
+      expect(response.statusCode).toBe(400);
+      expect(response.body).toEqual({ error: "kind must be local|session" });
+      expect(routeState.withPlaywrightRouteContext).not.toHaveBeenCalled();
+      expect(routeState.storageSetViaPlaywright).not.toHaveBeenCalled();
+      expect(routeState.storageClearViaPlaywright).not.toHaveBeenCalled();
+    },
+  );
+
   it("keeps cookie reads behind the current-tab URL guard", async () => {
     const { app, getHandlers } = createBrowserRouteApp();
     registerBrowserAgentStorageRoutes(app, {} as never);

--- a/extensions/browser/src/browser/routes/agent.storage.ts
+++ b/extensions/browser/src/browser/routes/agent.storage.ts
@@ -58,52 +58,16 @@ function parseStorageKind(raw: string): StorageKind | null {
   return null;
 }
 
-/** Parse an optional storage mutation request from a route body. */
-function parseStorageMutationRequest(
-  kindParam: unknown,
-  body: Record<string, unknown>,
-): { kind: StorageKind | null; targetId: string | undefined } {
-  return {
-    kind: parseStorageKind(toStringOrEmpty(kindParam)),
-    targetId: resolveTargetIdFromBody(body),
-  };
-}
-
-/** Parse a required storage mutation request and throw on invalid input. */
-function parseRequiredStorageMutationRequest(
-  kindParam: unknown,
-  body: Record<string, unknown>,
-): { kind: StorageKind; targetId: string | undefined } | null {
-  const parsed = parseStorageMutationRequest(kindParam, body);
-  if (!parsed.kind) {
-    return null;
-  }
-  return {
-    kind: parsed.kind,
-    targetId: parsed.targetId,
-  };
-}
-
-function parseStorageMutationOrRespond(
-  res: BrowserResponse,
-  kindParam: unknown,
-  body: Record<string, unknown>,
-) {
-  const parsed = parseRequiredStorageMutationRequest(kindParam, body);
-  if (!parsed) {
+/** Parse storage mutations once at the request boundary. */
+function parseStorageMutationFromRequest(req: BrowserRequest, res: BrowserResponse) {
+  const body = readBody(req);
+  const kind = parseStorageKind(toStringOrEmpty(req.params.kind));
+  const targetId = resolveTargetIdFromBody(body);
+  if (!kind) {
     jsonError(res, 400, "kind must be local|session");
     return null;
   }
-  return parsed;
-}
-
-function parseStorageMutationFromRequest(req: BrowserRequest, res: BrowserResponse) {
-  const body = readBody(req);
-  const parsed = parseStorageMutationOrRespond(res, req.params.kind, body);
-  if (!parsed) {
-    return null;
-  }
-  return { body, parsed };
+  return { body, parsed: { kind, targetId } };
 }
 
 function assertRange(


### PR DESCRIPTION
## What Problem This Solves

Browser local/session storage mutations pass through several private parsing adapters that repeat the same request-boundary work. This is a maintenance cleanup, not a claimed user-visible bug fix.

## Why This Change Was Made

Keep one request-boundary parser using the existing body, kind and target helpers, and remove the three intermediate adapters. Parsing order, kind-error precedence, target/key trimming, empty and whitespace-preserving values, profile selection and Playwright dispatch remain unchanged. The short boundary comment stays.

Production: +6/−42 (net −36). Tests: +66/−5 (net +61). Whole patch: +72/−47 (net +25), measured with Myers against the source commit's raw parent. Six characterization cases use the real body/target helpers.

## User Impact

No intended CLI, HTTP, configuration, authorization, cancellation or browser-storage behavior change. Local and session stores retain their separate semantics. No new settings, schema changes or dependencies.

## Evidence

- Baseline and candidate: the same 63 cases across four whole suites passed with identical case inventory and no skips.
- Normal local changed checks: all 25 commands passed, including five doctor cases. The earlier inherited remote-route gate refusal remains a failed attempt.
- Normal default build: all 14 stages passed. Source/dependency custody and generated-output producer attribution were verified; this is not independent compiler-semantic or release-package equivalence.
- Built CLI/Gateway with an isolated synthetic Chrome-for-Testing profile: 13 scenario rows expanded to 16 ordered attempts covering both stores, set/clear, invalid kind/target and whitespace. Both complete stores were read after each attempt; initial/final stores were empty.
- Precommit and separate exact-signed-commit Codex reviews each completed one normal P0-scoped pass over 25 complete context files, with no actionable P0 findings. The reviewed commit is e131b3f6e66a733ba306177eb909fdee2fc9bac8.

The built operator originally exited 1 because its shutdown observer expected an unformatted log substring. Retained output and the shutdown/logger owners establish the actual formatted clean-shutdown line and successful normal stop. Independent read-only reconciliation and one exact owned-runtime removal were accepted separately; the original failure was not rewritten and scenarios/services were not replayed. Normal isolated startup migration, cron, heartbeat and relay effects were observed, not excluded.

Historical limits remain explicit: an earlier credential-scanner refusal is unresolved; adoption of the current canonical review owner is not scanner clearance. The exact-commit review's optional late process observer captured no reviewer/temp identities. Successful canonical bounded cleanup and current endpoint absence support cleanup, but not an independent historical named-temp or reviewer-group inventory. The earlier state-create argument failure and pre-intent Git pagination refusal remain retained.

This proof does not cover personal/existing profiles, live providers, agent-driven actions, remote nodes, restart persistence, cancellation races or a cold host. Hosted CI run33456185469 attempt2 passed on exact e131, including the required gate; the original concurrency-cancelled run remains retained. [Completed ClawSweeper review](https://github.com/openclaw/openclaw/pull/134585#issuecomment-5487738450) at that head found no correctness/security findings or separate rank-up list. Its ordinary maintainer-review next step has been addressed through direct source/proof inspection and native review artifacts. Native prepare/merge remain pending; no merge or deployment claim.
