### PR TITLE
test: pin promotional provider pricing fixtures

### DIFF
--- a/extensions/amazon-bedrock-mantle/discovery.test.ts
+++ b/extensions/amazon-bedrock-mantle/discovery.test.ts
@@ -1,4 +1,3 @@
-// Amazon Bedrock Mantle tests cover discovery plugin behavior.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const discoveryDebugSpy = vi.hoisted(() => vi.fn());
@@ -727,6 +726,8 @@ describe("bedrock mantle discovery", () => {
   // ---------------------------------------------------------------------------
 
   it("resolves implicit provider when bearer token is set", async () => {
+    // This fixture uses promotional pricing; the rollover has its own case.
+    vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 8, 1) - 1);
     const mockFetch = vi.fn().mockResolvedValue(
       modelDiscoveryResponse({
         data: [{ id: "anthropic.claude-sonnet-4-6", object: "model" }],

--- a/extensions/anthropic/index.test.ts
+++ b/extensions/anthropic/index.test.ts
@@ -10,9 +10,8 @@ import {
   createTestWizardPrompter,
   registerSingleProviderPlugin,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
-// Anthropic tests cover index plugin behavior.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
 
 const { probeClaudeCliAuthStatusMock } = vi.hoisted(() => ({
   probeClaudeCliAuthStatusMock: vi.fn(),
@@ -719,6 +718,9 @@ describe("anthropic provider replay hooks", () => {
       restoresMissingCost,
       checksCliPolicy,
     }) => {
+      // This table uses promotional pricing; the rollover has its own case.
+      const now = vi.spyOn(Date, "now").mockReturnValue(Date.UTC(2026, 8, 1) - 1);
+      onTestFinished(() => now.mockRestore());
       const provider = await registerSingleProviderPlugin(anthropicPlugin);
       const resolved = provider.resolveDynamicModel?.({
         provider: "anthropic",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where provider tests fail after September 1, 2026 UTC because their promotional-price fixtures use the wall clock. Image cleanup CI reproduced the failures in the Anthropic catalog and Bedrock Mantle discovery tests; a local run reproduced both failures without changing production code.

## Why This Change Was Made

Pin `Date.now()` immediately before the existing pricing rollover in the promotional fixtures. Restore the spy using the fixture's existing teardown or a test-finished hook. The separate rollover cases still assert the later prices at the deadline. Remove two generic test-file header comments while touching these fixtures.

## User Impact

Test runs retain the same meaning before and after the pricing deadline. Production pricing, manifests, model selection and external provider behavior are unchanged.

## Evidence

The complete two-file group failed 2 of 94 cases before the fix and passed all 94 afterward, with identical case names and order. Both existing September 1 rollover cases passed. All 13 sibling registration and manifest cases, the normal changed checks, and managed Codex review passed. Independent source review checked both pricing owners, registration/discovery callers, manifests, test cleanup and the installed Vitest hook behavior.

The production diff is zero; the test diff is +6/-3. No case, assertion, price expectation or timeout was removed or relaxed. This is a fixture-clock repair for existing policy, not a verification of current external pricing.
