### PR TITLE
fix(ui): move agent scope label into picker

### DIFF
--- a/ui/src/components/agent-scope-control.test.ts
+++ b/ui/src/components/agent-scope-control.test.ts
@@ -48,7 +48,7 @@ describe("renderAgentScopeControl", () => {
     expect(container.querySelector(".agent-scope-control")).not.toBeNull();
   });
 
-  it("does not wrap dropdown options in a label that reactivates the trigger", async () => {
+  it("moves the scope label into the dropdown title without wrapping its options", async () => {
     const container = document.createElement("div");
     document.body.append(container);
 
@@ -67,6 +67,8 @@ describe("renderAgentScopeControl", () => {
     await select?.updateComplete;
 
     expect(select?.closest("label")).toBeNull();
+    expect(container.querySelector(".agent-scope-control__label")).toBeNull();
+    expect(select?.querySelector(".agent-select__menu-title")?.textContent).toBe("Agent scope");
     expect(select?.querySelector(".agent-select__trigger")?.getAttribute("aria-label")).toContain(
       "Agent",
     );

--- a/ui/src/components/agent-scope-control.test.ts
+++ b/ui/src/components/agent-scope-control.test.ts
@@ -68,7 +68,7 @@ describe("renderAgentScopeControl", () => {
 
     expect(select?.closest("label")).toBeNull();
     expect(container.querySelector(".agent-scope-control__label")).toBeNull();
-    expect(select?.querySelector(".agent-select__menu-title")?.textContent).toBe("Agent scope");
+    expect(select?.querySelector(".agent-select__menu-title")?.textContent).toBe("Agent");
     expect(select?.querySelector(".agent-select__trigger")?.getAttribute("aria-label")).toContain(
       "Agent",
     );

--- a/ui/src/components/agent-scope-control.ts
+++ b/ui/src/components/agent-scope-control.ts
@@ -63,15 +63,13 @@ export function renderAgentScopeControl(params: AgentScopeControlParams) {
       agent,
     })),
   ];
-  // The picker already labels its own trigger. A wrapping native label would
-  // forward an option click to that trigger and reopen the closed dropdown.
   return html`
     <div class="agent-scope-control">
-      <span class="agent-scope-control__label">${t("agentScope.label")}</span>
       <openclaw-agent-select
         .options=${options}
         .value=${selected}
         .accessibleLabel=${t("agentScope.label")}
+        .menuLabel=${t("agentScope.label")}
         .onSelect=${(value: string) =>
           allowAll ? params.selection.setScope(value || null) : params.selection.set(value || null)}
       ></openclaw-agent-select>

--- a/ui/src/components/menu-surface.browser.test.ts
+++ b/ui/src/components/menu-surface.browser.test.ts
@@ -136,6 +136,39 @@ describe.skipIf(!hasPopoverApi)("sidebar menu stacking", () => {
   });
 });
 
+describe.skipIf(!hasPopoverApi)("agent picker surface", () => {
+  it("stays opaque while the Web Awesome menu animates open", async () => {
+    await useDesktopViewport();
+    const dropdown = document.createElement("wa-dropdown") as HTMLElement & {
+      updateComplete: Promise<unknown>;
+    };
+    dropdown.className = "agent-select";
+    const trigger = document.createElement("button");
+    trigger.slot = "trigger";
+    trigger.textContent = "Agent";
+    const item = document.createElement("wa-dropdown-item");
+    item.textContent = "All agents";
+    dropdown.append(trigger, item);
+    document.body.append(dropdown);
+    await dropdown.updateComplete;
+
+    const menu = dropdown.shadowRoot?.querySelector<HTMLElement>('[part="menu"]');
+    expect(menu).not.toBeNull();
+    menu!.style.setProperty("--show-duration", "1s");
+    trigger.click();
+    await expect.poll(() => menu!.getAnimations().length).toBe(1);
+
+    const animation = menu!.getAnimations()[0];
+    if (!animation) {
+      throw new Error("expected the agent picker menu to be animating");
+    }
+    animation.pause();
+    animation.currentTime = 500;
+    expect(getComputedStyle(menu!).opacity).toBe("1");
+    expect(getComputedStyle(menu!).scale).not.toBe("1");
+  });
+});
+
 describe.skipIf(!hasPopoverApi)("submenu parent highlight", () => {
   it.each([
     ["session-menu__item", "keyboard"],

--- a/ui/src/i18n/locales/en-agents.ts
+++ b/ui/src/i18n/locales/en-agents.ts
@@ -15,7 +15,7 @@ export const agentChip = {
 };
 
 export const agentScope = {
-  label: "Agent scope",
+  label: "Agent",
   allAgents: "All agents",
 };
 

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3702,13 +3702,18 @@ td.data-table-key-col {
   min-width: 0;
 }
 
-.agent-scope-control__label {
+.agent-scope-control__label,
+.agent-scope-control .agent-select__menu-title {
   color: var(--muted);
   font-size: 11px;
   font-weight: 650;
   letter-spacing: 0.06em;
   text-transform: uppercase;
   white-space: nowrap;
+}
+
+.agent-scope-control .agent-select__menu-title {
+  padding: 4px 8px 2px;
 }
 
 .agent-scope-control openclaw-agent-select {

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3756,6 +3756,9 @@ td.data-table-key-col {
   background: var(--bg-elevated);
   box-shadow: var(--overlay-shadow);
   color: var(--text);
+  /* Keep page content from showing through Web Awesome's menu fade.
+   * The scale animation still communicates that the picker opened. */
+  opacity: 1 !important;
 }
 
 .agent-select__trigger {


### PR DESCRIPTION
## What Problem This Solves

Pages with the shared agent picker repeated the visible `Agent scope` label beside the control, consuming header space even though the picker can label its own menu. The menu also faded as a complete surface during its opening animation, briefly allowing page content to show through it.

## Why This Change Was Made

The shared `renderAgentScopeControl` owner removes the external label and passes `Agent` through `AgentSelect.menuLabel`. This applies once across all six callers: Models, Automations, Sessions, Tasks, Usage, and Workboard. The same shared picker surface now remains fully opaque while preserving Web Awesome's scale animation.

The title styling remains scoped to `.agent-scope-control`, so the separate New Session picker keeps its existing typography. Memory is intentionally unchanged because its picker already uses `Agent`, not the repeated `Agent scope` label.

Production LOC: +11 / -5 (net +6). Test LOC: +36 / -1 (net +35).

## User Impact

The six affected page headers are cleaner. Opening the picker shows the shorter `Agent` title, and underlying page controls never bleed through the menu while it opens.

## Evidence

### Before / after

Each after screenshot freezes Web Awesome's opening scale animation at 16.7 ms. The menu still reports opacity `1` with an opaque `rgb(255, 255, 255)` background, so this proves the transient frame that previously failed rather than only the settled state.

| Page | Before | After |
| --- | --- | --- |
| Models | ![Models before](https://github.com/user-attachments/assets/e8526028-aa74-457e-a72b-a2bff57fd02a) | ![Models after](https://github.com/user-attachments/assets/56e65757-a322-419c-b50b-adbaf894c054) |
| Automations | ![Automations before](https://github.com/user-attachments/assets/22bfcfda-4f5c-491e-8738-3b3e6665a965) | ![Automations after](https://github.com/user-attachments/assets/ac67edbc-a007-4086-97ea-aaeeebbcf090) |
| Sessions | ![Sessions before](https://github.com/user-attachments/assets/9b8c90e0-ff21-44e2-a21e-d8d1241b7a8d) | ![Sessions after](https://github.com/user-attachments/assets/7658b17b-3c85-4a09-b488-c33f75f42590) |
| Tasks | ![Tasks before](https://github.com/user-attachments/assets/f31aa3eb-6ffb-47c6-82bc-eb10aeb10af5) | ![Tasks after](https://github.com/user-attachments/assets/90f4b11e-3c37-455d-b20f-215158f2720e) |
| Usage | ![Usage before](https://github.com/user-attachments/assets/d19262ab-b8f4-47f0-8a3c-23e451daaa3e) | ![Usage after](https://github.com/user-attachments/assets/f9dc563a-deb3-4744-95d8-b509dd80e93f) |
| Workboard | ![Workboard before](https://github.com/user-attachments/assets/036f542f-b0e1-4929-a0dc-2d991707720a) | ![Workboard after](https://github.com/user-attachments/assets/f5ab6344-2017-496d-ada8-ff34ededa252) |

Browser assertions on every after route: external `.agent-scope-control__label` count is `0`; visible dropdown title is `Agent`; mid-animation opacity is `1`; background is opaque. Responsive checks passed at 390×844, 768×1024, 1366×768, and 1440×900.

### Regression proof

The real-browser test stretches the Web Awesome animation to one second, pauses it halfway, and inspects the rendered menu. It fails before the fix with opacity `0.802403` and passes after the shared picker surface forces opacity `1` while scale remains animated.

### Validation

- `pnpm exec vitest run --config vitest.config.ts --project browser src/components/menu-surface.browser.test.ts` — 8 passed
- `pnpm exec vitest run --config vitest.config.ts --project unit src/components/agent-scope-control.test.ts` — 6 passed
- `pnpm ui:i18n:baseline` — passed; baseline unchanged
- `pnpm lint:ui:styles` — passed
- `pnpm ui:build` — passed; performance budgets verified
- `pnpm check:changed -- <five changed UI files>` — passed
- Structured autoreview — clean, no actionable findings
