### PR TITLE
fix(cron): run one-shot main-session cron jobs when the heartbeat schedule is disabled

### DIFF
--- a/src/cron/service.wake-now-real-heartbeat.test.ts
+++ b/src/cron/service.wake-now-real-heartbeat.test.ts
@@ -44,7 +44,11 @@ function makeSandbox() {
 
 type WakeNowRunMode = "direct" | "queued" | "scheduled";
 
-async function runMainCronCase(mode: WakeNowRunMode, wakeMode: "now" | "next-heartbeat" = "now") {
+async function runMainCronCase(
+  mode: WakeNowRunMode,
+  wakeMode: "now" | "next-heartbeat" = "now",
+  heartbeatEvery: "5m" | "0m" = "5m",
+) {
   const sandbox = makeSandbox();
   const getReplySpy = vi.fn().mockResolvedValue({ text: "Handled the reminder" });
   const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "155462274" });
@@ -58,7 +62,7 @@ async function runMainCronCase(mode: WakeNowRunMode, wakeMode: "now" | "next-hea
     agents: {
       defaults: {
         workspace: sandbox.dir,
-        heartbeat: { every: "5m", target: "telegram" },
+        heartbeat: { every: heartbeatEvery, target: "telegram" },
       },
     },
     channels: { telegram: { allowFrom: ["*"] } },
@@ -167,6 +171,12 @@ async function runMainCronCase(mode: WakeNowRunMode, wakeMode: "now" | "next-hea
     expect(replyCtx.SessionKey).toBe(expectedMainSessionKey);
     expect(replyCtx.Body).toContain("Reminder: Send the nightly report");
     expect(peekSystemEventEntries(expectedMainSessionKey)).toHaveLength(0);
+    if (heartbeatEvery === "0m") {
+      // One-shot `at` jobs are deleted after their single execution instead of
+      // being left disabled by an impossible dispatch (#134500).
+      const jobs = await cron.list({ includeDisabled: true });
+      expect(jobs.find((j) => j.id === job.id)).toBeUndefined();
+    }
   } finally {
     cron.stop();
     const drained = await waitForActiveCronJobs(5_000);
@@ -186,6 +196,10 @@ describe("main cron with the real heartbeat runner", () => {
 
   it("delivers during a natural scheduled run", async () => {
     await runMainCronCase("scheduled");
+  });
+
+  it("runs a future one-shot scheduled main job once and deletes it when the heartbeat schedule is disabled", async () => {
+    await runMainCronCase("scheduled", "now", "0m");
   });
 
   it("delivers a next-heartbeat event through a later scheduled main-session heartbeat", async () => {

--- a/src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts
+++ b/src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts
@@ -240,6 +240,87 @@ describe("startHeartbeatRunner targeted unscheduled wake dispatch", () => {
     },
   );
 
+  it("runs one targeted cron wake when heartbeat cadence is disabled", async () => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = await expectWakeDispatch({
+      cfg: {
+        agents: { defaults: { heartbeat: { every: "0m" } }, list: [{ id: "main" }] },
+      } as OpenClawConfig,
+      runSpy,
+      wake: {
+        source: "cron",
+        intent: "immediate",
+        reason: "cron:job-1",
+        agentId: "main",
+        coalesceMs: 0,
+      },
+      expectedCall: {
+        agentId: "main",
+        source: "cron",
+        intent: "immediate",
+        reason: "cron:job-1",
+      },
+    });
+    runner.stop();
+  });
+
+  it.each([
+    {
+      name: "with event intent",
+      wake: { agentId: "main", intent: "event" as const },
+    },
+    {
+      name: "with a non-cron reason",
+      wake: { agentId: "main", reason: "wake" },
+    },
+  ])("rejects an unscheduled cron wake $name", async ({ wake }) => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: { defaults: { heartbeat: { every: "0m" } }, list: [{ id: "main" }] },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+    });
+
+    requestHeartbeat({
+      source: "cron",
+      intent: "immediate",
+      reason: "cron:job-1",
+      ...wake,
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runSpy).not.toHaveBeenCalled();
+    runner.stop();
+  });
+
+  it("keeps targeted cron wakes disabled when heartbeats are globally disabled", async () => {
+    useFakeHeartbeatTime();
+    setHeartbeatsEnabled(false);
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: { defaults: { heartbeat: { every: "0m" } }, list: [{ id: "main" }] },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+    });
+
+    requestHeartbeat({
+      source: "cron",
+      intent: "immediate",
+      reason: "cron:job-1",
+      agentId: "main",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runSpy).not.toHaveBeenCalled();
+    runner.stop();
+  });
+
   it("runs one targeted exec-event wake when heartbeat cadence is disabled", async () => {
     useFakeHeartbeatTime();
     const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });

--- a/src/infra/heartbeat-wake-policy.ts
+++ b/src/infra/heartbeat-wake-policy.ts
@@ -77,6 +77,12 @@ export function isTargetedUnscheduledWake(params: TargetedUnscheduledWakeParams)
       return params.intent === "immediate" && hasSessionTarget && reason === "wake";
     case "hook":
       return params.intent === "immediate" && (reason?.startsWith("hook:") ?? false);
+    case "cron":
+      // An admitted immediate cron intent (wakeMode "now") uses the heartbeat
+      // runner as execution transport and must not depend on the periodic
+      // heartbeat schedule being enabled; event-intent cron wakes still ride
+      // the recurring schedule (#134500).
+      return params.intent === "immediate" && (reason?.startsWith("cron:") ?? false);
     case "exec-event":
       return params.intent === "event" && reason === "exec-event";
     case "background-task":


### PR DESCRIPTION
> **AI-assisted: yes**

Fixes #134500

## What Problem This Solves

Fixes an issue where users scheduling a one-shot main-session automation (`--at` + `--wake now`) would see the job deterministically skipped with `skipped: disabled` whenever the periodic heartbeat schedule is off (`agents.defaults.heartbeat.every: "0m"`). After the 30s/60s/300s retry budget the job was left disabled — and never deleted despite `--delete-after-run` — so every `at + main + now` job on such an installation failed (7/7 jobs, 25 run rows in the reporter's case).

## Why This Change Was Made

Cron uses the heartbeat runner purely as execution transport for an already-admitted job execution, but the targeted-unscheduled wake policy (`isTargetedUnscheduledWake`) had narrow admission cases for manual, hook, exec-event, restart-sentinel, and background-task sources and no `cron` case — so the immediate cron wake (`source: "cron"`, `intent: "immediate"`, `reason: "cron:<jobId>"`) could never bypass the cadence gate. The fix adds a `cron` case admitting exactly the immediate cron intent with a `cron:` reason, mirroring the existing narrow per-source shapes. Event-intent cron wakes (`wakeMode: "next-heartbeat"`) still ride the recurring schedule, and global heartbeat disables plus the busy/quiet-hours/unconfigured-agent guards are preserved.

## User Impact

- Immediate (`wakeMode: "now"`) main-session cron jobs now execute even when the recurring heartbeat schedule is disabled; one-shot `at` jobs run once and are deleted as configured.
- Event-intent cron wakes are not admitted by this change; all other safety gates keep their existing semantics.

## Evidence

### Real isolated-gateway run (before/after)

Two real gateway processes (`node scripts/run-node.mjs --dev gateway --port 19850`), each with an isolated `OPENCLAW_STATE_DIR`, isolated workspace, `agents.defaults.heartbeat.every: "0m"`, and a real OpenAI-completions model provider (internal LLM gateway, HTTP 200). Same command in both phases:

```bash
automations create <at+75s> --name "one-shot proof" \
  --session main --system-event "reply OK" --wake now --delete-after-run
```

**Before (origin/main @ cc797c0491c)** — the gateway logs `[heartbeat] disabled`, the job fires, and **zero model calls** are made. `cron list --all --json` after the retry budget (t+420s):

```json
{
  "name": "one-shot proof (before fix)",
  "enabled": false,
  "lastStatus": "skipped",
  "lastError": "disabled",
  "consecutiveSkipped": 4,
  "nextRunAt": null
}
```

The job is left disabled and never deleted despite `--delete-after-run` — exactly the reported failure.

**After (this patch)** — the same setup runs the job for real:

```text
12:00:56 [trace:embedded-run] prep stages: … phase=stream-ready
12:00:56 [model-fetch] start provider=zte api=openai-completions model=Qwen3-235B-A22B method=POST url=<redacted-internal-llm-gateway>
12:00:58 [model-fetch] response provider=zte … status=200 elapsedMs=2267
```

The session transcript shows the cron-fired heartbeat poll at `04:00:47Z`, the model snapshot (`provider=zte`, `Qwen3-235B-A22B`), and the assistant reply `"OK"` at `04:01:01Z`. Polling `cron list --all --json` afterwards shows the job is **gone** — executed once and deleted per `--delete-after-run`, with no `skipped`/`disabled` state ever recorded.

| | origin/main | this patch |
|---|---|---|
| Executions | 0 (`skipped: disabled`) | 1 (real model call, HTTP 200) |
| Assistant reply | none | `"OK"` |
| Job terminal state | disabled, never deleted | deleted after success |

### Focused regression and neighbor tests

```bash
node scripts/run-vitest.mjs run src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts   # 21 passed
node scripts/run-vitest.mjs run src/cron/service.wake-now-real-heartbeat.test.ts              # 5 passed
node scripts/run-vitest.mjs run src/cron/service.runs-one-shot-main-job-disables-it.test.ts \
  src/infra/heartbeat-wake.test.ts src/infra/heartbeat-runner.scheduler.test.ts \
  src/cron/service.main-job-passes-heartbeat-target-last.test.ts                                # 106 passed
```

New cases: a targeted cron wake runs with `every: "0m"`; event-intent and non-cron-reason cron wakes are rejected; the global heartbeat disable still blocks; heartbeat `0m` + future `at` main job runs exactly once and is deleted after execution (previously terminal status `skipped`).

`pnpm tsgo:core`, `pnpm check:test-types`, `oxfmt --check`, `oxlint` — all clean.
