### PR TITLE
fix(plugins): recover orphan installs without weakening ownership

### DIFF
--- a/src/cli/plugins-cli.uninstall.test.ts
+++ b/src/cli/plugins-cli.uninstall.test.ts
@@ -756,42 +756,6 @@ describe("plugins cli uninstall", () => {
       plugins: [],
       diagnostics: [],
     });
-    primeUninstallPlan(nextConfig, { actions: { channelConfig: true } });
-
-    await runPluginsCommand(["plugins", "uninstall", "alpha", "--force", "--keep-files"]);
-
-    expectLatestUninstallPlanParams({
-      pluginId: "alpha",
-      channelIds: undefined,
-      deleteFiles: false,
-    });
-    expectInstallRecordsWrittenWithLease({}, nextConfig);
-    expect(configWriteMock).toHaveBeenCalledWith(nextConfig);
-    expectRuntimeLogIncludes("channel config (channels.alpha)");
-    expect(pluginsCliRuntimeLogs.at(-2)).toContain('Uninstalled plugin "alpha"');
-  });
-
-  it("removes owner-keyed channel config for an exact orphan install record", async () => {
-    const pluginId = "orphan-channel-plugin";
-    const installRecords = {
-      [pluginId]: {
-        source: "path",
-        sourcePath: "/tmp/missing-orphan-channel-source",
-        installPath: "/tmp/missing-orphan-channel-install",
-      },
-    } as const;
-    const baseConfig = {
-      channels: {
-        [pluginId]: { enabled: true },
-        discord: { enabled: true },
-      },
-    } as OpenClawConfig;
-    pluginCliConfigMock.mockReturnValue(baseConfig);
-    setInstalledPluginIndexInstallRecords(installRecords);
-    buildPluginSnapshotReportMock.mockReturnValue({
-      plugins: [],
-      diagnostics: [],
-    });
     const actualUninstall =
       await vi.importActual<typeof import("../plugins/uninstall.js")>("../plugins/uninstall.js");
     planPluginUninstallMock.mockImplementation((params) =>
@@ -806,21 +770,17 @@ describe("plugins cli uninstall", () => {
         createTestInstalledPluginIndex({ policyHash: "orphan-channel", installRecords }),
       );
     try {
-      await runPluginsCommand(["plugins", "uninstall", pluginId, "--force", "--keep-files"]);
+      await runPluginsCommand(["plugins", "uninstall", "alpha", "--force", "--keep-files"]);
 
       expectLatestUninstallPlanParams({
-        pluginId,
+        pluginId: "alpha",
         channelIds: undefined,
         deleteFiles: false,
       });
-      expectInstallRecordsWrittenWithLease(
-        {},
-        {
-          channels: {
-            discord: { enabled: true },
-          },
-        },
-      );
+      expectInstallRecordsWrittenWithLease({}, nextConfig);
+      expect(configWriteMock).toHaveBeenCalledWith(nextConfig);
+      expectRuntimeLogIncludes("channel config (channels.alpha)");
+      expect(pluginsCliRuntimeLogs.at(-2)).toContain('Uninstalled plugin "alpha"');
     } finally {
       indexSpy.mockRestore();
     }

--- a/src/cli/plugins-cli.uninstall.test.ts
+++ b/src/cli/plugins-cli.uninstall.test.ts
@@ -771,6 +771,61 @@ describe("plugins cli uninstall", () => {
     expect(pluginsCliRuntimeLogs.at(-2)).toContain('Uninstalled plugin "alpha"');
   });
 
+  it("removes owner-keyed channel config for an exact orphan install record", async () => {
+    const pluginId = "orphan-channel-plugin";
+    const installRecords = {
+      [pluginId]: {
+        source: "path",
+        sourcePath: "/tmp/missing-orphan-channel-source",
+        installPath: "/tmp/missing-orphan-channel-install",
+      },
+    } as const;
+    const baseConfig = {
+      channels: {
+        [pluginId]: { enabled: true },
+        discord: { enabled: true },
+      },
+    } as OpenClawConfig;
+    pluginCliConfigMock.mockReturnValue(baseConfig);
+    setInstalledPluginIndexInstallRecords(installRecords);
+    buildPluginSnapshotReportMock.mockReturnValue({
+      plugins: [],
+      diagnostics: [],
+    });
+    const actualUninstall =
+      await vi.importActual<typeof import("../plugins/uninstall.js")>("../plugins/uninstall.js");
+    planPluginUninstallMock.mockImplementation((params) =>
+      actualUninstall.planPluginUninstall(
+        params as Parameters<typeof actualUninstall.planPluginUninstall>[0],
+      ),
+    );
+    const installedIndexModule = await import("../plugins/installed-plugin-index.js");
+    const indexSpy = vi
+      .spyOn(installedIndexModule, "loadInstalledPluginIndex")
+      .mockReturnValue(
+        createTestInstalledPluginIndex({ policyHash: "orphan-channel", installRecords }),
+      );
+    try {
+      await runPluginsCommand(["plugins", "uninstall", pluginId, "--force", "--keep-files"]);
+
+      expectLatestUninstallPlanParams({
+        pluginId,
+        channelIds: undefined,
+        deleteFiles: false,
+      });
+      expectInstallRecordsWrittenWithLease(
+        {},
+        {
+          channels: {
+            discord: { enabled: true },
+          },
+        },
+      );
+    } finally {
+      indexSpy.mockRestore();
+    }
+  });
+
   it("exits when uninstall target is not managed by plugin install records", async () => {
     pluginCliConfigMock.mockReturnValue({
       plugins: {

--- a/src/cli/plugins-cli.update.test.ts
+++ b/src/cli/plugins-cli.update.test.ts
@@ -1266,7 +1266,7 @@ describe("plugins cli update", () => {
     expect(configWriteMock).not.toHaveBeenCalled();
   });
 
-  it("preserves skip behavior for plugin records whose source cannot be updated", async () => {
+  it("skips an exact orphan path record during bulk update", async () => {
     const cfg = {
       plugins: {
         installs: {
@@ -1283,12 +1283,23 @@ describe("plugins cli update", () => {
     primePluginUpdate(cfg, [
       { pluginId: "linked", status: "skipped", message: "Skipping linked." },
     ]);
+    const installedIndexModule = await import("../plugins/installed-plugin-index.js");
+    const indexSpy = vi.spyOn(installedIndexModule, "loadInstalledPluginIndex").mockReturnValue(
+      createTestInstalledPluginIndex({
+        policyHash: "orphan-path-update",
+        installRecords: cfg.plugins?.installs ?? {},
+      }),
+    );
+    try {
+      await runPluginsCommand(["plugins", "update", "--all"]);
 
-    await runPluginsCommand(["plugins", "update", "--all"]);
-
-    expect(updateNpmInstalledPluginsMock).toHaveBeenCalledOnce();
-    expect(updateNpmInstalledHookPacksMock).not.toHaveBeenCalled();
-    expect(configWriteMock).not.toHaveBeenCalled();
+      expect(runtimeErrors).toEqual([]);
+      expect(updateNpmInstalledPluginsMock).toHaveBeenCalledOnce();
+      expect(updateNpmInstalledHookPacksMock).not.toHaveBeenCalled();
+      expect(configWriteMock).not.toHaveBeenCalled();
+    } finally {
+      indexSpy.mockRestore();
+    }
   });
 
   it("preserves skip behavior for ClawHub records missing package metadata", async () => {

--- a/src/cli/plugins-uninstall-command.ts
+++ b/src/cli/plugins-uninstall-command.ts
@@ -139,16 +139,18 @@ async function runPluginUninstallCommandUnlocked(
   }
   const { installOwner: pluginId, pluginIds: ownedPluginIds } = ownership.value;
   const policyPluginIds = ownedPluginIds.length > 0 ? ownedPluginIds : [pluginId];
-  const channelIds =
-    ownedPluginIds.length === 1 && ownedPluginIds[0] === requestedPluginId
-      ? plugin?.channelIds
-      : [
-          ...new Set(
-            ownedPluginIds.flatMap(
-              (entryId) => report.plugins.find((entry) => entry.id === entryId)?.channelIds ?? [],
-            ),
-          ),
-        ];
+  let channelIds: string[] | undefined;
+  if (ownedPluginIds.length === 1 && ownedPluginIds[0] === requestedPluginId) {
+    channelIds = plugin?.channelIds;
+  } else if (ownedPluginIds.length > 1) {
+    channelIds = [
+      ...new Set(
+        ownedPluginIds.flatMap(
+          (entryId) => report.plugins.find((entry) => entry.id === entryId)?.channelIds ?? [],
+        ),
+      ),
+    ];
+  }
   const initialPlan = planPluginUninstall(
     recordPluginPackageUninstallPlan(
       {

--- a/src/cli/plugins-uninstall-command.ts
+++ b/src/cli/plugins-uninstall-command.ts
@@ -138,6 +138,7 @@ async function runPluginUninstallCommandUnlocked(
     return;
   }
   const { installOwner: pluginId, pluginIds: ownedPluginIds } = ownership.value;
+  const policyPluginIds = ownedPluginIds.length > 0 ? ownedPluginIds : [pluginId];
   const channelIds =
     ownedPluginIds.length === 1 && ownedPluginIds[0] === requestedPluginId
       ? plugin?.channelIds
@@ -158,7 +159,7 @@ async function runPluginUninstallCommandUnlocked(
         extensionsDir,
       },
       {
-        runtimePluginIds: ownedPluginIds,
+        runtimePluginIds: policyPluginIds,
         runtimeLoadPaths: ownedPluginIds.flatMap(
           (entryId) => report.plugins.find((entry) => entry.id === entryId)?.source ?? [],
         ),
@@ -278,7 +279,7 @@ async function runPluginUninstallCommandUnlocked(
     if (plan.directoryRemoval) {
       const disabledConfig = prepareConfigForPendingPluginDirectoryRemovalSet(
         sourceConfig,
-        ownedPluginIds,
+        policyPluginIds,
       );
       const disabledCommit = await tracePluginLifecyclePhaseAsync(
         "config disable",
@@ -321,7 +322,7 @@ async function runPluginUninstallCommandUnlocked(
             extensionsDir,
           },
           {
-            runtimePluginIds: ownedPluginIds,
+            runtimePluginIds: policyPluginIds,
             runtimeLoadPaths: ownedPluginIds.flatMap(
               (entryId) => report.plugins.find((entry) => entry.id === entryId)?.source ?? [],
             ),

--- a/src/cli/plugins-uninstall-command.ts
+++ b/src/cli/plugins-uninstall-command.ts
@@ -65,7 +65,7 @@ async function runPluginUninstallCommandUnlocked(
   }
 
   const { loadInstalledPluginIndex } = await import("../plugins/installed-plugin-index.js");
-  const { resolveInstalledPluginPackageOwnership } =
+  const { resolveInstalledPluginLifecycleOwnership } =
     await import("../plugins/installed-plugin-package-ownership.js");
   const {
     loadInstalledPluginIndexInstallRecords,
@@ -131,7 +131,7 @@ async function runPluginUninstallCommandUnlocked(
   }
   const { plugin } = selection.value;
   const requestedPluginId = selection.value.pluginId;
-  const ownership = resolveInstalledPluginPackageOwnership(installedIndex, requestedPluginId);
+  const ownership = resolveInstalledPluginLifecycleOwnership(installedIndex, requestedPluginId);
   if (!ownership.ok) {
     runtime.error(ownership.error);
     runtime.exit(1);

--- a/src/cli/plugins-update-command.ts
+++ b/src/cli/plugins-update-command.ts
@@ -41,7 +41,7 @@ import {
   withPluginInstallRecords,
 } from "../plugins/installed-plugin-index-records.js";
 import { loadInstalledPluginIndex } from "../plugins/installed-plugin-index.js";
-import { resolveInstalledPluginPackageOwnership } from "../plugins/installed-plugin-package-ownership.js";
+import { resolveInstalledPluginLifecycleOwnership } from "../plugins/installed-plugin-package-ownership.js";
 import { configReferencesNpmInstallPath } from "../plugins/installs.js";
 import { withPluginLifecycleLease } from "../plugins/plugin-lifecycle-lease.js";
 import {
@@ -241,7 +241,7 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
     ...installedPluginIndex.plugins.map((plugin) => plugin.pluginId),
     ...Object.keys(pluginInstallRecords),
   ])) {
-    const ownership = resolveInstalledPluginPackageOwnership(installedPluginIndex, pluginId);
+    const ownership = resolveInstalledPluginLifecycleOwnership(installedPluginIndex, pluginId);
     if (!ownership.ok) {
       rejectedPluginIds.set(pluginId, ownership.error);
       continue;
@@ -283,7 +283,7 @@ async function runPluginUpdateCommandUnlocked(params: RunPluginUpdateCommandPara
   const packageUpdateSnapshot = packageUpdateSnapshotResult.value;
   const packagePluginIds = Object.fromEntries(
     pluginSelection.pluginIds.flatMap((pluginId) => {
-      const ownership = resolveInstalledPluginPackageOwnership(installedPluginIndex, pluginId);
+      const ownership = resolveInstalledPluginLifecycleOwnership(installedPluginIndex, pluginId);
       return ownership.ok ? [[ownership.value.installOwner, ownership.value.pluginIds]] : [];
     }),
   );

--- a/src/plugins/installed-plugin-package-ownership.ts
+++ b/src/plugins/installed-plugin-package-ownership.ts
@@ -92,16 +92,6 @@ export function resolveInstalledPluginPackageOwnership(
     )
     .map((entry) => entry.pluginId)
     .toSorted();
-  if (pluginIds.length === 0) {
-    return ownershipError(
-      pluginId,
-      `package owner "${installOwner}" has no authoritative runtime child list`,
-    );
-  }
-  if (target && !pluginIds.includes(target.pluginId)) {
-    return ownershipError(pluginId, `does not belong to package owner "${installOwner}"`);
-  }
-
   const hasUnsafePackageEntry = index.plugins.some(
     (entry) =>
       installRecordPathMatchesPluginRoot(installRecord, entry.rootDir, env) &&
@@ -111,6 +101,21 @@ export function resolveInstalledPluginPackageOwnership(
   if (hasUnsafePackageEntry) {
     return ownershipError(pluginId, `package owner "${installOwner}" has conflicting child rows`);
   }
+  if (pluginIds.length === 0) {
+    if (target) {
+      return ownershipError(
+        pluginId,
+        `package owner "${installOwner}" has no authoritative runtime child list`,
+      );
+    }
+    // The exact durable owner still identifies an unambiguous tombstone after its
+    // package files disappear. Keep it actionable for update skipping and uninstall.
+    return { ok: true, value: { installOwner, installRecord, pluginIds } };
+  }
+  if (target && !pluginIds.includes(target.pluginId)) {
+    return ownershipError(pluginId, `does not belong to package owner "${installOwner}"`);
+  }
+
   return { ok: true, value: { installOwner, installRecord, pluginIds } };
 }
 

--- a/src/plugins/installed-plugin-package-ownership.ts
+++ b/src/plugins/installed-plugin-package-ownership.ts
@@ -92,6 +92,16 @@ export function resolveInstalledPluginPackageOwnership(
     )
     .map((entry) => entry.pluginId)
     .toSorted();
+  if (pluginIds.length === 0) {
+    return ownershipError(
+      pluginId,
+      `package owner "${installOwner}" has no authoritative runtime child list`,
+    );
+  }
+  if (target && !pluginIds.includes(target.pluginId)) {
+    return ownershipError(pluginId, `does not belong to package owner "${installOwner}"`);
+  }
+
   const hasUnsafePackageEntry = index.plugins.some(
     (entry) =>
       installRecordPathMatchesPluginRoot(installRecord, entry.rootDir, env) &&
@@ -101,22 +111,40 @@ export function resolveInstalledPluginPackageOwnership(
   if (hasUnsafePackageEntry) {
     return ownershipError(pluginId, `package owner "${installOwner}" has conflicting child rows`);
   }
-  if (pluginIds.length === 0) {
-    if (target) {
-      return ownershipError(
-        pluginId,
-        `package owner "${installOwner}" has no authoritative runtime child list`,
-      );
-    }
-    // The exact durable owner still identifies an unambiguous tombstone after its
-    // package files disappear. Keep it actionable for update skipping and uninstall.
-    return { ok: true, value: { installOwner, installRecord, pluginIds } };
-  }
-  if (target && !pluginIds.includes(target.pluginId)) {
-    return ownershipError(pluginId, `does not belong to package owner "${installOwner}"`);
-  }
-
   return { ok: true, value: { installOwner, installRecord, pluginIds } };
+}
+
+export function resolveInstalledPluginLifecycleOwnership(
+  index: InstalledPluginIndex,
+  pluginId: string,
+  env: NodeJS.ProcessEnv = process.env,
+): InstalledPluginPackageOwnershipResult {
+  const ownership = resolveInstalledPluginPackageOwnership(index, pluginId, env);
+  if (ownership.ok) {
+    return ownership;
+  }
+  const installRecord = index.installRecords[pluginId];
+  if (
+    !Object.hasOwn(index.installRecords, pluginId) ||
+    !installRecord ||
+    collectDuplicateInstallRecordOwners(index, env).has(pluginId)
+  ) {
+    return ownership;
+  }
+  const hasConflictingEntry = index.plugins.some(
+    (entry) =>
+      entry.pluginId === pluginId ||
+      installRecordPathMatchesPluginRoot(installRecord, entry.rootDir, env),
+  );
+  if (hasConflictingEntry) {
+    return ownership;
+  }
+  // Cleanup and pre-update planning may act on an exact durable tombstone.
+  // Replacement reconciliation keeps using the strict package resolver.
+  return {
+    ok: true,
+    value: { installOwner: pluginId, installRecord, pluginIds: [] },
+  };
 }
 
 function installRecordPathMatchesPluginRoot(

--- a/src/plugins/installed-plugin-package-ownership.ts
+++ b/src/plugins/installed-plugin-package-ownership.ts
@@ -38,11 +38,24 @@ function collectDuplicateInstallRecordOwners(
 export type InstalledPluginPackageOwnership = {
   installOwner: string;
   installRecord: InstalledPluginInstallRecordInfo;
-  pluginIds: string[];
+  pluginIds: [string, ...string[]];
 };
+
+export type InstalledPluginLifecycleOwnership =
+  | ({ kind: "package" } & InstalledPluginPackageOwnership)
+  | {
+      kind: "orphan";
+      installOwner: string;
+      installRecord: InstalledPluginInstallRecordInfo;
+      pluginIds: [];
+    };
 
 type InstalledPluginPackageOwnershipResult =
   | { ok: true; value: InstalledPluginPackageOwnership }
+  | { ok: false; error: string };
+
+type InstalledPluginLifecycleOwnershipResult =
+  | { ok: true; value: InstalledPluginLifecycleOwnership }
   | { ok: false; error: string };
 
 function ownershipError(pluginId: string, detail: string): InstalledPluginPackageOwnershipResult {
@@ -84,7 +97,7 @@ export function resolveInstalledPluginPackageOwnership(
     return ownershipError(pluginId, `shares package path ownership with "${installOwner}"`);
   }
 
-  const pluginIds = index.plugins
+  const [firstPluginId, ...remainingPluginIds] = index.plugins
     .filter(
       (entry) =>
         resolveInstalledPluginIndexInstallOwner(entry) === installOwner &&
@@ -92,12 +105,13 @@ export function resolveInstalledPluginPackageOwnership(
     )
     .map((entry) => entry.pluginId)
     .toSorted();
-  if (pluginIds.length === 0) {
+  if (!firstPluginId) {
     return ownershipError(
       pluginId,
       `package owner "${installOwner}" has no authoritative runtime child list`,
     );
   }
+  const pluginIds: [string, ...string[]] = [firstPluginId, ...remainingPluginIds];
   if (target && !pluginIds.includes(target.pluginId)) {
     return ownershipError(pluginId, `does not belong to package owner "${installOwner}"`);
   }
@@ -111,17 +125,20 @@ export function resolveInstalledPluginPackageOwnership(
   if (hasUnsafePackageEntry) {
     return ownershipError(pluginId, `package owner "${installOwner}" has conflicting child rows`);
   }
-  return { ok: true, value: { installOwner, installRecord, pluginIds } };
+  return {
+    ok: true,
+    value: { installOwner, installRecord, pluginIds },
+  };
 }
 
 export function resolveInstalledPluginLifecycleOwnership(
   index: InstalledPluginIndex,
   pluginId: string,
   env: NodeJS.ProcessEnv = process.env,
-): InstalledPluginPackageOwnershipResult {
+): InstalledPluginLifecycleOwnershipResult {
   const ownership = resolveInstalledPluginPackageOwnership(index, pluginId, env);
   if (ownership.ok) {
-    return ownership;
+    return { ok: true, value: { kind: "package", ...ownership.value } };
   }
   const installRecord = index.installRecords[pluginId];
   if (
@@ -143,7 +160,7 @@ export function resolveInstalledPluginLifecycleOwnership(
   // Replacement reconciliation keeps using the strict package resolver.
   return {
     ok: true,
-    value: { installOwner: pluginId, installRecord, pluginIds: [] },
+    value: { kind: "orphan", installOwner: pluginId, installRecord, pluginIds: [] },
   };
 }
 

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -93,7 +93,10 @@ import {
   withoutPluginInstallRecords,
 } from "./installed-plugin-index-records.js";
 import { isInstalledPluginEnabled } from "./installed-plugin-index.js";
-import { resolveInstalledPluginPackageOwnership } from "./installed-plugin-package-ownership.js";
+import {
+  resolveInstalledPluginLifecycleOwnership,
+  resolveInstalledPluginPackageOwnership,
+} from "./installed-plugin-package-ownership.js";
 import { ManagedPluginLifecycleError } from "./management-lifecycle-error.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import type { PluginDiagnostic } from "./manifest-types.js";
@@ -2053,7 +2056,7 @@ export async function uninstallManagedPlugin(params: {
     if (!record && !Object.hasOwn(installRecords, pluginId)) {
       throw new ManagedPluginLifecycleError(`Plugin not found: ${pluginId}`);
     }
-    const ownership = resolveInstalledPluginPackageOwnership(metadata.index, pluginId, env);
+    const ownership = resolveInstalledPluginLifecycleOwnership(metadata.index, pluginId, env);
     if (!ownership.ok) {
       throw new ManagedPluginLifecycleError(ownership.error);
     }

--- a/src/plugins/management-service.ts
+++ b/src/plugins/management-service.ts
@@ -2058,6 +2058,7 @@ export async function uninstallManagedPlugin(params: {
       throw new ManagedPluginLifecycleError(ownership.error);
     }
     const { installOwner, pluginIds: ownedPluginIds } = ownership.value;
+    const policyPluginIds = ownedPluginIds.length > 0 ? ownedPluginIds : [installOwner];
     const ownedManifests = ownedPluginIds.flatMap((entryId) => {
       const manifest = metadata.byPluginId.get(entryId);
       return manifest ? [manifest] : [];
@@ -2077,7 +2078,7 @@ export async function uninstallManagedPlugin(params: {
           extensionsDir,
         },
         {
-          runtimePluginIds: ownedPluginIds,
+          runtimePluginIds: policyPluginIds,
           runtimeLoadPaths: ownedPluginIds.flatMap(
             (entryId) => metadata.byPluginId.get(entryId)?.source ?? [],
           ),
@@ -2093,7 +2094,7 @@ export async function uninstallManagedPlugin(params: {
     if (plan.directoryRemoval) {
       const disabledConfig = prepareConfigForPendingPluginDirectoryRemovalSet(
         snapshot.config,
-        ownedPluginIds,
+        policyPluginIds,
       );
       await replaceConfigFile({
         nextConfig: disabledConfig,
@@ -2125,7 +2126,7 @@ export async function uninstallManagedPlugin(params: {
             extensionsDir,
           },
           {
-            runtimePluginIds: ownedPluginIds,
+            runtimePluginIds: policyPluginIds,
             runtimeLoadPaths: ownedPluginIds.flatMap(
               (entryId) => metadata.byPluginId.get(entryId)?.source ?? [],
             ),

--- a/src/plugins/management-service.uninstall-ownership.test.ts
+++ b/src/plugins/management-service.uninstall-ownership.test.ts
@@ -166,6 +166,41 @@ describe("plugin management uninstall channel ownership", () => {
     expect(mocks.commitRecords).not.toHaveBeenCalled();
   });
 
+  it("fails closed when an orphan record path overlaps a discovered plugin", async () => {
+    const pluginId = "orphaned-plugin";
+    const installPath = "/tmp/openclaw-managed-conflicting-orphan";
+    const installRecord = { source: "path", sourcePath: installPath, installPath } as const;
+    mocks.readConfig.mockResolvedValue({
+      snapshot: {
+        valid: true,
+        parsed: {},
+        path: "/tmp/openclaw.json",
+        sourceConfig: {},
+        hash: "base-hash",
+      },
+      writeOptions: { expectedConfigPath: "/tmp/openclaw.json" },
+    });
+    mocks.installRecords.mockResolvedValue({ [pluginId]: installRecord });
+    mocks.metadata.mockReturnValue({
+      index: {
+        plugins: [
+          recordInstalledPluginIndexInstallOwner(
+            { pluginId: "other", origin: "global", enabled: true, rootDir: installPath },
+            "other",
+          ),
+        ],
+        installRecords: { [pluginId]: installRecord },
+      },
+      byPluginId: new Map(),
+      normalizePluginId: (rawPluginId: string) => rawPluginId,
+    });
+
+    await expect(uninstallManagedPlugin({ pluginId, env: {} })).rejects.toThrow(
+      "no authoritative runtime child list",
+    );
+    expect(mocks.commitRecords).not.toHaveBeenCalled();
+  });
+
   it("removes an exact orphan owner record with no discovered plugin code", async () => {
     const pluginId = "orphaned-plugin";
     const installRecord = {

--- a/src/plugins/management-service.uninstall-ownership.test.ts
+++ b/src/plugins/management-service.uninstall-ownership.test.ts
@@ -166,6 +166,45 @@ describe("plugin management uninstall channel ownership", () => {
     expect(mocks.commitRecords).not.toHaveBeenCalled();
   });
 
+  it("removes an exact orphan owner record with no discovered plugin code", async () => {
+    const pluginId = "orphaned-plugin";
+    const installRecord = {
+      source: "path",
+      sourcePath: "/tmp/missing-orphan-source",
+      installPath: "/tmp/missing-orphan-install",
+    } as const;
+    mocks.readConfig.mockResolvedValue({
+      snapshot: {
+        valid: true,
+        parsed: {},
+        path: "/tmp/openclaw.json",
+        sourceConfig: { plugins: { entries: { [pluginId]: { enabled: true } } } },
+        hash: "base-hash",
+      },
+      writeOptions: { expectedConfigPath: "/tmp/openclaw.json" },
+    });
+    mocks.installRecords.mockResolvedValue({ [pluginId]: installRecord });
+    mocks.metadata.mockReturnValue({
+      index: {
+        plugins: [],
+        installRecords: { [pluginId]: installRecord },
+      },
+      byPluginId: new Map(),
+      normalizePluginId: (rawPluginId: string) => rawPluginId,
+    });
+
+    const result = await uninstallManagedPlugin({ pluginId, env: {} });
+
+    expect(mocks.commitRecords).toHaveBeenCalledWith(
+      expect.objectContaining({
+        nextConfig: {},
+        nextInstallRecords: {},
+      }),
+    );
+    expect(result.pluginId).toBe(pluginId);
+    expect(result.removed).toContain("install record");
+  });
+
   it("resolves a child request to one package owner and removes every sibling policy", async () => {
     const installPath = "/tmp/openclaw-managed-linked-pack";
     const installRecord = { source: "path", sourcePath: installPath, installPath } as const;

--- a/src/plugins/manifest-registry-installed.test.ts
+++ b/src/plugins/manifest-registry-installed.test.ts
@@ -12,6 +12,7 @@ import { readPersistedInstalledPluginIndex } from "./installed-plugin-index-stor
 import { loadInstalledPluginIndex, type InstalledPluginIndex } from "./installed-plugin-index.js";
 import {
   hasMissingInstalledPluginOwnerMetadata,
+  resolveInstalledPluginLifecycleOwnership,
   resolveInstalledPluginPackageOwnership,
 } from "./installed-plugin-package-ownership.js";
 import { resolvePluginManifestInstallOwner } from "./manifest-install-owner.js";
@@ -548,7 +549,8 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
         },
       },
     };
-    expect(resolveInstalledPluginPackageOwnership(orphanedOwner, "orphaned")).toMatchObject({
+    expect(resolveInstalledPluginPackageOwnership(orphanedOwner, "orphaned").ok).toBe(false);
+    expect(resolveInstalledPluginLifecycleOwnership(orphanedOwner, "orphaned")).toMatchObject({
       ok: true,
       value: { installOwner: "orphaned", pluginIds: [] },
     });

--- a/src/plugins/manifest-registry-installed.test.ts
+++ b/src/plugins/manifest-registry-installed.test.ts
@@ -548,7 +548,10 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
         },
       },
     };
-    expect(resolveInstalledPluginPackageOwnership(orphanedOwner, "orphaned").ok).toBe(false);
+    expect(resolveInstalledPluginPackageOwnership(orphanedOwner, "orphaned")).toMatchObject({
+      ok: true,
+      value: { installOwner: "orphaned", pluginIds: [] },
+    });
     expect(hasMissingInstalledPluginOwnerMetadata(orphanedOwner, env)).toBe(false);
 
     const legacyAmbiguous = {

--- a/src/plugins/manifest-registry-installed.test.ts
+++ b/src/plugins/manifest-registry-installed.test.ts
@@ -552,7 +552,7 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
     expect(resolveInstalledPluginPackageOwnership(orphanedOwner, "orphaned").ok).toBe(false);
     expect(resolveInstalledPluginLifecycleOwnership(orphanedOwner, "orphaned")).toMatchObject({
       ok: true,
-      value: { installOwner: "orphaned", pluginIds: [] },
+      value: { kind: "orphan", installOwner: "orphaned", pluginIds: [] },
     });
     expect(hasMissingInstalledPluginOwnerMetadata(orphanedOwner, env)).toBe(false);
 
@@ -564,6 +564,7 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
       },
     };
     expect(resolveInstalledPluginPackageOwnership(legacyAmbiguous, "pack/one").ok).toBe(false);
+    expect(resolveInstalledPluginLifecycleOwnership(legacyAmbiguous, "pack/one").ok).toBe(false);
     expect(hasMissingInstalledPluginOwnerMetadata(legacyAmbiguous, env)).toBe(true);
 
     const packageAlias = path.join(stateDir, "pack-alias");
@@ -580,6 +581,7 @@ describe("loadPluginManifestRegistryForInstalledIndex", () => {
       },
     };
     expect(resolveInstalledPluginPackageOwnership(aliasedAmbiguous, "pack/one").ok).toBe(false);
+    expect(resolveInstalledPluginLifecycleOwnership(aliasedAmbiguous, "pack/one").ok).toBe(false);
     expect(hasMissingInstalledPluginOwnerMetadata(aliasedAmbiguous, env)).toBe(true);
 
     const unrelatedOwner = "unrelated";

--- a/src/plugins/plugin-package-update.test.ts
+++ b/src/plugins/plugin-package-update.test.ts
@@ -178,6 +178,59 @@ describe("plugin package update policy reconciliation", () => {
     expect(result).toEqual({ ok: true, config });
   });
 
+  it("fails closed when a tombstone replacement still has no authoritative child rows", () => {
+    const before = index("/packages/pack-v1", []);
+    const snapshot = capturePluginPackageUpdateSnapshot({
+      index: before,
+      installOwners: ["pack"],
+    });
+    expect(snapshot.ok).toBe(true);
+    if (!snapshot.ok) {
+      throw new Error(snapshot.error);
+    }
+    const after = {
+      ...index("/packages/pack-v2", []),
+      installRecords: {
+        pack: {
+          ...before.installRecords.pack!,
+          installPath: "/packages/pack-v2",
+          version: "2.0.0",
+        },
+      },
+    };
+
+    const result = reconcilePluginPackageUpdateConfig({
+      config: {},
+      beforeIndex: before,
+      afterIndex: after,
+      snapshot: snapshot.value,
+    });
+
+    expect(result).toMatchObject({ ok: false });
+  });
+
+  it("accepts a valid package restored from an exact tombstone", () => {
+    const before = index("/packages/pack-v1", []);
+    const snapshot = capturePluginPackageUpdateSnapshot({
+      index: before,
+      installOwners: ["pack"],
+    });
+    expect(snapshot.ok).toBe(true);
+    if (!snapshot.ok) {
+      throw new Error(snapshot.error);
+    }
+    const after = index("/packages/pack-v2", [record("pack/one", "/packages/pack-v2")]);
+
+    const result = reconcilePluginPackageUpdateConfig({
+      config: {},
+      beforeIndex: before,
+      afterIndex: after,
+      snapshot: snapshot.value,
+    });
+
+    expect(result).toEqual({ ok: true, config: {} });
+  });
+
   it("detects exact child load-path cleanup before an update starts", () => {
     const rootDir = "/packages/pack-v1";
     const before = index(rootDir, [record("pack/one", rootDir)]);

--- a/src/plugins/plugin-package-update.test.ts
+++ b/src/plugins/plugin-package-update.test.ts
@@ -142,6 +142,42 @@ describe("plugin package update policy reconciliation", () => {
     expect(result).toMatchObject({ ok: false });
   });
 
+  it("skips an exact tombstone while reconciling another package update", () => {
+    const orphanRecord = {
+      source: "path",
+      sourcePath: "/missing/orphan-source",
+      installPath: "/missing/orphan-install",
+    } as const;
+    const beforePack = index("/packages/pack-v1", [record("pack/one", "/packages/pack-v1")]);
+    const afterPack = index("/packages/pack-v2", [record("pack/one", "/packages/pack-v2")]);
+    const before = {
+      ...beforePack,
+      installRecords: { orphan: orphanRecord, ...beforePack.installRecords },
+    };
+    const after = {
+      ...afterPack,
+      installRecords: { orphan: orphanRecord, ...afterPack.installRecords },
+    };
+    const snapshot = capturePluginPackageUpdateSnapshot({
+      index: before,
+      installOwners: ["orphan", "pack"],
+    });
+    expect(snapshot.ok).toBe(true);
+    if (!snapshot.ok) {
+      throw new Error(snapshot.error);
+    }
+    const config = { plugins: { entries: { "pack/one": { enabled: true } } } };
+
+    const result = reconcilePluginPackageUpdateConfig({
+      config,
+      beforeIndex: before,
+      afterIndex: after,
+      snapshot: snapshot.value,
+    });
+
+    expect(result).toEqual({ ok: true, config });
+  });
+
   it("detects exact child load-path cleanup before an update starts", () => {
     const rootDir = "/packages/pack-v1";
     const before = index(rootDir, [record("pack/one", rootDir)]);

--- a/src/plugins/plugin-package-update.ts
+++ b/src/plugins/plugin-package-update.ts
@@ -62,6 +62,9 @@ export function reconcilePluginPackageUpdateConfig(params: {
 }): { ok: true; config: OpenClawConfig } | { ok: false; error: string } {
   let config = params.config;
   for (const [installOwner, before] of params.snapshot) {
+    if (before.pluginIds.length === 0) {
+      continue;
+    }
     const nextInstallOwner = params.installOwnerMigrations?.[installOwner] ?? installOwner;
     const after = resolveInstalledPluginPackageOwnership(
       params.afterIndex,

--- a/src/plugins/plugin-package-update.ts
+++ b/src/plugins/plugin-package-update.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import {
+  resolveInstalledPluginLifecycleOwnership,
   resolveInstalledPluginPackageOwnership,
   type InstalledPluginPackageOwnership,
 } from "./installed-plugin-package-ownership.js";
@@ -18,7 +19,7 @@ export function capturePluginPackageUpdateSnapshot(params: {
 }): { ok: true; value: PluginPackageUpdateSnapshot } | { ok: false; error: string } {
   const snapshot = new Map<string, InstalledPluginPackageOwnership>();
   for (const installOwner of new Set(params.installOwners)) {
-    const ownership = resolveInstalledPluginPackageOwnership(
+    const ownership = resolveInstalledPluginLifecycleOwnership(
       params.index,
       installOwner,
       params.env,

--- a/src/plugins/plugin-package-update.ts
+++ b/src/plugins/plugin-package-update.ts
@@ -1,23 +1,24 @@
+import { isDeepStrictEqual } from "node:util";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import {
   resolveInstalledPluginLifecycleOwnership,
   resolveInstalledPluginPackageOwnership,
-  type InstalledPluginPackageOwnership,
+  type InstalledPluginLifecycleOwnership,
 } from "./installed-plugin-package-ownership.js";
 import {
   hasMatchingPluginLoadPath,
   removePluginRuntimePolicyFromConfig,
 } from "./uninstall-package-config.js";
 
-type PluginPackageUpdateSnapshot = ReadonlyMap<string, InstalledPluginPackageOwnership>;
+type PluginPackageUpdateSnapshot = ReadonlyMap<string, InstalledPluginLifecycleOwnership>;
 
 export function capturePluginPackageUpdateSnapshot(params: {
   index: InstalledPluginIndex;
   installOwners: readonly string[];
   env?: NodeJS.ProcessEnv;
 }): { ok: true; value: PluginPackageUpdateSnapshot } | { ok: false; error: string } {
-  const snapshot = new Map<string, InstalledPluginPackageOwnership>();
+  const snapshot = new Map<string, InstalledPluginLifecycleOwnership>();
   for (const installOwner of new Set(params.installOwners)) {
     const ownership = resolveInstalledPluginLifecycleOwnership(
       params.index,
@@ -62,15 +63,31 @@ export function reconcilePluginPackageUpdateConfig(params: {
 }): { ok: true; config: OpenClawConfig } | { ok: false; error: string } {
   let config = params.config;
   for (const [installOwner, before] of params.snapshot) {
-    if (before.pluginIds.length === 0) {
-      continue;
-    }
     const nextInstallOwner = params.installOwnerMigrations?.[installOwner] ?? installOwner;
     const after = resolveInstalledPluginPackageOwnership(
       params.afterIndex,
       nextInstallOwner,
       params.env,
     );
+    if (before.kind === "orphan") {
+      const lifecycleAfter = resolveInstalledPluginLifecycleOwnership(
+        params.afterIndex,
+        nextInstallOwner,
+        params.env,
+      );
+      const unchangedOrphan =
+        nextInstallOwner === installOwner &&
+        isDeepStrictEqual(
+          params.afterIndex.installRecords[nextInstallOwner],
+          before.installRecord,
+        ) &&
+        lifecycleAfter.ok &&
+        lifecycleAfter.value.kind === "orphan";
+      if (!after.ok && !unchangedOrphan) {
+        return after;
+      }
+      continue;
+    }
     if (!after.ok) {
       return after;
     }


### PR DESCRIPTION
Closes #134321

## What Problem This Solves

Operators could not run `openclaw plugins update --all` or uninstall a path-source plugin after both tracked plugin paths disappeared. Registry refresh succeeded but left the durable install record behind, so both commands failed on the same ownership check.

## Why This Change Was Made

Plugin lifecycle ownership now distinguishes an active package from an exact orphan record. Update and uninstall may act on an orphan only after duplicate-path and conflicting-plugin checks pass. Inspection, capability consent, active packages, and restored packages keep strict package ownership.

Post-update reconciliation accepts an unchanged safe orphan while another package updates. If an orphan install record changes, the replacement must restore a strictly valid package before any update can commit.

Uninstall removes owner-keyed plugin and channel policy plus the durable install record. Child policy remains based only on authoritative discovered children.

## User Impact

Operators can update their remaining plugins and remove stale path-source install records without editing OpenClaw state by hand. Ambiguous, conflicting, and invalid replacement packages still fail closed.

## Evidence

Current `main` at `77fee957919f06dbaff09dd5cc7f9664d9655651` failed through the real command-line flow after a local plugin was installed and both tracked paths were moved away:

```text
$ openclaw plugins update --all --dry-run
Plugin "orphan-proof" package owner "orphan-proof" has no authoritative runtime child list.
Exit 1

$ openclaw plugins uninstall orphan-proof --force
Plugin "orphan-proof" package owner "orphan-proof" has no authoritative runtime child list.
Exit 1

$ openclaw plugins registry --refresh
Plugin registry refreshed: 0/0 enabled plugins indexed.
Exit 0

$ openclaw plugins update --all --dry-run
Plugin "orphan-proof" package owner "orphan-proof" has no authoritative runtime child list.
Exit 1
```

Exact head `06de2f66734fd338e457f50a3060e2d625288274` passed the same flow:

```text
$ openclaw plugins update --all --dry-run
Skipping "orphan-proof" (source: path).
Exit 0

$ openclaw plugins uninstall orphan-proof --force
Uninstalled plugin "orphan-proof". Removed: config entry, install record.
Exit 0

$ openclaw plugins update --all --dry-run
No tracked plugins or hook packs to update.
Exit 0
```

The contributor head initially accepted a changed orphan install record with no authoritative children. The new owner-boundary regression failed with `{ ok: true }` before the maintainer repair and passes after it.

Validation:

- `node scripts/run-vitest.mjs src/plugins/manifest-registry-installed.test.ts src/plugins/management-service.uninstall-ownership.test.ts src/plugins/plugin-package-update.test.ts src/cli/plugins-cli.update.test.ts src/cli/plugins-cli.uninstall.test.ts` — 129 passed.
- Targeted Oxfmt and Oxlint — passed.
- Max-lines and assertion-safety ratchets — passed.
- Coercion, deprecated-API, dead-export, native-schema, and import-cycle guards — passed.
- `git diff --check` — passed.
- Local type checking was not run because host policy requires CI for OpenClaw type checks.

The proof fixture, isolated states, removed plugin copies, and proof manifest remain in the durable maintainer worktree.
