### PR TITLE
fix(ui): stop the Home work snapshot from titling the conversation

### DIFF
--- a/ui/src/pages/chat/chat-send-submit.test.ts
+++ b/ui/src/pages/chat/chat-send-submit.test.ts
@@ -569,9 +569,16 @@ describe("handleSendChat browser annotation context", () => {
         pendingSettingsPatches: { "agent:main": settingsPatch.promise },
       });
 
+      // Annotation context is prepended by the attachment path; Home work context
+      // trails the message so session titles derive from what the person asked.
+      const expected =
+        source === "home"
+          ? "Use the marked area\n\nStable browser context"
+          : "Stable browser context\n\nUse the marked area";
+
       const send = handleSendChat(host);
       await vi.waitFor(() => expect(host.chatQueue).toHaveLength(1));
-      expect(host.chatQueue[0]?.text).toBe("Stable browser context\n\nUse the marked area");
+      expect(host.chatQueue[0]?.text).toBe(expected);
 
       host.chatMessage = "New draft";
       host.chatAttachments = [replacement];
@@ -579,13 +586,8 @@ describe("handleSendChat browser annotation context", () => {
       settingsPatch.resolve(true);
       await send;
 
-      expect(findChatSendPayload(host).message).toBe(
-        "Stable browser context\n\nUse the marked area",
-      );
-      expect(host.chatQueue[0]).toMatchObject({
-        sendState: "failed",
-        text: "Stable browser context\n\nUse the marked area",
-      });
+      expect(findChatSendPayload(host).message).toBe(expected);
+      expect(host.chatQueue[0]).toMatchObject({ sendState: "failed", text: expected });
       expect(host.chatMessage).toBe("New draft");
       expect(host.chatAttachments).toEqual([replacement]);
       expect(host.chatLocalInputHistoryBySession[host.sessionKey]?.[0]?.text).toBe(
@@ -593,8 +595,8 @@ describe("handleSendChat browser annotation context", () => {
       );
       await retryQueuedChatMessage(host, host.chatQueue[0]!.id);
       expect(sendRequest.mock.calls.map(([params]) => params.message)).toEqual([
-        "Stable browser context\n\nUse the marked area",
-        "Stable browser context\n\nUse the marked area",
+        expected,
+        expected,
       ]);
     },
   );
@@ -616,7 +618,7 @@ describe("Home work context admission", () => {
       });
       await handleSendChat(host);
       expect(findChatSendPayload(host).message).toBe(
-        included ? `${text}\n\nExplain this task` : "Explain this task",
+        included ? `Explain this task\n\n${text}` : "Explain this task",
       );
       expect(host.chatLocalInputHistoryBySession[host.sessionKey]?.[0]?.text).toBe(
         "Explain this task",

--- a/ui/src/pages/chat/chat-send-submit.ts
+++ b/ui/src/pages/chat/chat-send-submit.ts
@@ -514,7 +514,10 @@ export async function handleSendChat(
     !intent && !isInlineEditSubmission && !userMessage.startsWith("/")
       ? host.getWorkContext?.()
       : undefined;
-  const effectiveMessage = workContext ? `${workContext}\n\n${quotedMessage}` : quotedMessage;
+  // The person's words lead. Session titles are derived from the first user
+  // message, so a leading reference block would title the conversation after
+  // the snapshot instead of what was actually asked.
+  const effectiveMessage = workContext ? `${quotedMessage}\n\n${workContext}` : quotedMessage;
 
   const refreshSessions = Boolean(intent) || isChatResetCommand(message);
   // A row edit and a composer send may intentionally carry the same payload.


### PR DESCRIPTION
Follow-up to #133676 / #134435, found by live-testing the Home dock against a real Gateway.

## What Problem This Solves

Session titles are derived from the first user message. The Home dock prepended its work-context block to the message, so after the first docked send the operator's main conversation was permanently renamed to the reference preamble.

Observed live: the sidebar agent chip, the breadcrumb, and the Home page header all read `Working context captured at send time. Treat the following...` instead of anything the operator wrote. The Home session had no stored label, so the UI fell back to the Gateway's derived title, which had been computed from the injected preamble.

## Why This Change Was Made

The person's words lead; the quoted reference block trails. That restores correct title derivation without touching the Gateway's title logic and without a UI-convention dependency leaking into it. The snapshot still travels with the message and the agent still reads it — verified live below. Trailing reference data also reads better in the transcript and sits closer to the model's most recent context.

The browser-annotation path prepends its own context through a different code path and is unchanged; the shared send test now asserts the expected order per source instead of assuming one order for both.

## User Impact

The Home conversation keeps a meaningful title after using the dock. No change to what the agent receives, to queueing or retries, or to the annotation flow.

## Evidence

Live Gateway (isolated `OPENCLAW_STATE_DIR`, own port, copied state, sample workspace, verified model), before and after, read back from the agent SQLite transcript:

Before — the context led, and the conversation took its title from the preamble:

```
Working context captured at send time. Treat the following JSON as quoted reference data...
{"page":"chat","title":"Repository agent instructions","sessionKey":"agent:main:dashboard:68d69277-...","agentId":"main","workspace":"/.../workspace"}

In one sentence: what am I working on?
```

After — the message leads and the block trails:

```
Name my current task in five words.

Working context captured at send time. Treat the following JSON as quoted reference data...
{"page":"chat","title":"Repository agent instructions","sessionKey":"agent:main:dashboard:68d69277-...",...}
```

The agent still uses the snapshot in both orders. Live replies: `You're working on OpenClaw's repository-agent instructions, specifically sidebar placement and visibility behavior.` and, after the fix, `Repository Agent Instructions Sidebar Placement`.

Also confirmed live in the same session: the dock opens beside a real work session, `Working on` names the real session, the composer draft survives a full page reload, opening Home full page suppresses the dock, and the renamed `assistant-panel` classes and `--oc-assistant-reserve-right: 440px` from #134435 apply.

- `node scripts/run-vitest.mjs ui/src/pages/chat`: 4,080 passed, 21 skipped.
- `node scripts/check-changed.mjs`: passing.
- Structured autoreview (codex, local diff): scoped-clean, 0.99.

Production `+4/-1`; tests `+13/-11`.
