### PR TITLE
fix(release): validate frozen packages with bundled activation fixtures

### DIFF
--- a/.github/workflows/openclaw-npm-release.yml
+++ b/.github/workflows/openclaw-npm-release.yml
@@ -450,7 +450,17 @@ jobs:
       - name: Verify release contents
         env:
           OPENCLAW_RELEASE_CHECK_LOCAL_PACKAGE_TARBALL_DIR: ${{ steps.core_package_tarballs.outputs.dir }}
-        run: pnpm release:generated:check && node --import tsx scripts/release-check.ts
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          pnpm release:generated:check
+          tooling_dir="${GITHUB_WORKSPACE}/.artifacts/plugin-sdk-release-tooling"
+          if [[ "$(git -C "$tooling_dir" rev-parse HEAD)" != "$WORKFLOW_SHA" ]] || [[ -n "$(git -C "$tooling_dir" status --porcelain)" ]]; then
+            echo "Trusted release-check tooling does not match the workflow SHA." >&2
+            exit 1
+          fi
+          TSX_TSCONFIG_PATH="$tooling_dir/tsconfig.json" \
+            node --import "$tooling_dir/scripts/tsx.mjs" "$tooling_dir/scripts/release-check.ts"
 
       - name: Exercise all extended-stable plugin npm packages
         id: plugin_npm_preflight

--- a/scripts/lib/plugin-sdk-entries.mts
+++ b/scripts/lib/plugin-sdk-entries.mts
@@ -84,11 +84,6 @@ export const packagedPrivatePluginSdkRuntimeEntrypoints =
     productionPluginSdkEntrypointSet.has(entry),
   );
 
-/** Private entrypoints reserved for local tests and QA builds. */
-const nonProductionPrivatePluginSdkEntrypoints = privateLocalOnlyPluginSdkEntrypoints.filter(
-  (entry) => !productionPluginSdkEntrypointSet.has(entry),
-);
-
 /**
  * Deprecated public plugin SDK subpaths kept for compatibility.
  * @internal Shared repository-script contract.
@@ -158,13 +153,18 @@ export function buildPluginSdkPackageExports() {
  * List all packaged plugin SDK dist artifacts, including production-private runtime JS.
  * @internal Shared repository-script contract.
  */
-export function listPluginSdkDistArtifacts() {
+export function listPluginSdkDistArtifacts(
+  entries: readonly string[] = pluginSdkEntrypoints,
+  privateEntries: readonly string[] = privateLocalOnlyPluginSdkEntrypoints,
+) {
+  const privateSet = new Set(privateEntries);
   return [
-    ...publicPluginSdkEntrypoints.flatMap((entry) => [
-      `dist/plugin-sdk/${entry}.js`,
-      `dist/plugin-sdk/${entry}.d.ts`,
-    ]),
-    ...packagedPrivatePluginSdkRuntimeEntrypoints.map((entry) => `dist/plugin-sdk/${entry}.js`),
+    ...entries
+      .filter((entry) => !privateSet.has(entry))
+      .flatMap((entry) => [`dist/plugin-sdk/${entry}.js`, `dist/plugin-sdk/${entry}.d.ts`]),
+    ...entries
+      .filter((entry) => privateSet.has(entry) && !nonProductionPluginSdkSubpathSet.has(entry))
+      .map((entry) => `dist/plugin-sdk/${entry}.js`),
   ];
 }
 
@@ -174,9 +174,16 @@ export function listPackagedPrivatePluginSdkRuntimeArtifacts() {
 }
 
 /** List private artifacts that must stay out of package output. */
-export function listUnpackagedPrivatePluginSdkDistArtifacts() {
+export function listUnpackagedPrivatePluginSdkDistArtifacts(
+  entries: readonly string[] = pluginSdkEntrypoints,
+  privateEntries: readonly string[] = privateLocalOnlyPluginSdkEntrypoints,
+) {
+  const privateSet = new Set(privateEntries);
+  const privateEntrypoints = entries.filter((entry) => privateSet.has(entry));
   return [
-    ...privateLocalOnlyPluginSdkEntrypoints.map((entry) => `dist/plugin-sdk/${entry}.d.ts`),
-    ...nonProductionPrivatePluginSdkEntrypoints.map((entry) => `dist/plugin-sdk/${entry}.js`),
+    ...privateEntrypoints.map((entry) => `dist/plugin-sdk/${entry}.d.ts`),
+    ...privateEntrypoints
+      .filter((entry) => nonProductionPluginSdkSubpathSet.has(entry))
+      .map((entry) => `dist/plugin-sdk/${entry}.js`),
   ];
 }

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -80,11 +80,19 @@ const rootPackageExcludedExtensionDirs = collectRootPackageExcludedExtensionDirs
 const rootPackageExcludedExtensionPrefixes = [...rootPackageExcludedExtensionDirs].map(
   (extensionId) => `dist/extensions/${extensionId}/`,
 );
+// Trusted tooling can validate an older release checkout. Its SDK inventory
+// belongs to that target, including release-only compatibility entrypoints.
+const targetPluginSdkEntries = JSON.parse(
+  readFileSync(resolve("scripts/lib/plugin-sdk-entrypoints.json"), "utf8"),
+) as string[];
+const targetPrivatePluginSdkEntries = JSON.parse(
+  readFileSync(resolve("scripts/lib/plugin-sdk-private-local-only-subpaths.json"), "utf8"),
+) as string[];
 const requiredPathGroups = [
   PACKAGE_DIST_INVENTORY_RELATIVE_PATH,
   ["dist/index.js", "dist/index.mjs"],
   ["dist/entry.js", "dist/entry.mjs"],
-  ...listPluginSdkDistArtifacts(),
+  ...listPluginSdkDistArtifacts(targetPluginSdkEntries, targetPrivatePluginSdkEntries),
   ...listBundledPluginPackArtifacts(),
   ...listStaticExtensionAssetOutputs().filter((relativePath: string) => {
     const match = /^dist\/extensions\/([^/]+)\//u.exec(relativePath);
@@ -141,7 +149,10 @@ const forbiddenPrefixes = [
   "dist/plugin-sdk/compat.",
   "dist/plugin-sdk/root-alias.",
   "dist/extensionAPI.",
-  ...listUnpackagedPrivatePluginSdkDistArtifacts(),
+  ...listUnpackagedPrivatePluginSdkDistArtifacts(
+    targetPluginSdkEntries,
+    targetPrivatePluginSdkEntries,
+  ),
   "dist/qa-runtime-",
   "dist/plugin-sdk/.tsbuildinfo",
   "docs/.generated/",
@@ -860,7 +871,7 @@ export function writePackedBundledPluginActivationConfig(homeDir: string): void 
           },
         },
         channels: {
-          matrix: {
+          telegram: {
             enabled: true,
           },
         },
@@ -876,7 +887,7 @@ export function writePackedBundledPluginActivationConfig(homeDir: string): void 
         plugins: {
           enabled: true,
           entries: {
-            matrix: {
+            telegram: {
               enabled: true,
             },
           },

--- a/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
@@ -329,9 +329,6 @@ describe("minimal npm extended-stable workflow", () => {
     expect(step(preflight, "Check").if).toBeUndefined();
     const verifyReleaseContents = step(preflight, "Verify release contents");
     expect(verifyReleaseContents.if).toBeUndefined();
-    expect(verifyReleaseContents.run).toBe(
-      "pnpm release:generated:check && node --import tsx scripts/release-check.ts",
-    );
     expect(step(preflight, "Verify prepared npm tarball install").if).toBeUndefined();
 
     const save = step(preflight, "Save preflight build outputs");

--- a/test/scripts/release-check.test.ts
+++ b/test/scripts/release-check.test.ts
@@ -1,8 +1,14 @@
 // Release Check tests cover release check script behavior.
+import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
+import {
+  collectRootPackageExcludedExtensionDirs,
+  listBundledPluginPackArtifacts,
+} from "../../scripts/lib/bundled-plugin-build-entries.mjs";
 import {
   createPackedTarballInstallArgs,
   prepareReleaseCheckLocalPackageTarballs,
@@ -20,6 +26,43 @@ function requirePluginEntries(config: { plugins?: { entries?: Record<string, unk
 }
 
 describe("release-check", () => {
+  it("checks target SDK inventory when release tooling lives in another checkout", () => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-release-check-target-"));
+    try {
+      mkdirSync(join(root, "scripts", "lib"), { recursive: true });
+      mkdirSync(join(root, "extensions"));
+      writeFileSync(join(root, "package.json"), JSON.stringify({ files: ["dist"] }));
+      writeFileSync(
+        join(root, "scripts/lib/plugin-sdk-entrypoints.json"),
+        JSON.stringify(["target-private", "target-public"]),
+      );
+      writeFileSync(
+        join(root, "scripts/lib/plugin-sdk-private-local-only-subpaths.json"),
+        JSON.stringify(["target-private"]),
+      );
+      const moduleUrl = pathToFileURL(resolve("scripts/release-check.ts")).href;
+      const output = execFileSync(
+        process.execPath,
+        [
+          "--import",
+          resolve("scripts/tsx.mjs"),
+          "--input-type=module",
+          "--eval",
+          `const { collectForbiddenPackPaths } = await import(${JSON.stringify(moduleUrl)});\n` +
+            `console.log(JSON.stringify(collectForbiddenPackPaths(["dist/plugin-sdk/target-private.d.ts", "dist/plugin-sdk/target-public.d.ts"])));`,
+        ],
+        {
+          cwd: root,
+          encoding: "utf8",
+          env: { ...process.env, TSX_TSCONFIG_PATH: resolve("tsconfig.json") },
+        },
+      );
+      expect(JSON.parse(output)).toEqual(["dist/plugin-sdk/target-private.d.ts"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("installs the packed core and local sibling package tarballs together", () => {
     expect(createPackedTarballInstallArgs("/tmp/prefix")).toEqual([
       "install",
@@ -204,11 +247,20 @@ describe("release-check", () => {
         plugins?: { entries?: Record<string, unknown> };
       };
 
-      expect(config.channels).toHaveProperty("matrix");
       const pluginEntries = requirePluginEntries(config);
-      expect(pluginEntries).toHaveProperty("matrix");
-      expect(config.channels).not.toHaveProperty("feishu");
-      expect(pluginEntries).not.toHaveProperty("feishu");
+      const channels = Object.keys(config.channels ?? {});
+      expect(channels.length).toBeGreaterThan(0);
+      const excluded = collectRootPackageExcludedExtensionDirs();
+      const artifacts = listBundledPluginPackArtifacts();
+      for (const channel of channels) {
+        expect(pluginEntries).toHaveProperty(channel);
+        expect(excluded.has(channel)).toBe(false);
+        const manifest = JSON.parse(
+          readFileSync(join("extensions", channel, "openclaw.plugin.json"), "utf8"),
+        ) as { channels: string[] };
+        expect(manifest.channels).toContain(channel);
+        expect(artifacts).toContain(`dist/extensions/${channel}/openclaw.plugin.json`);
+      }
     } finally {
       rmSync(homeDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where npm release preflight rejects a valid core package because its bundled activation fixture enables Matrix after Matrix moved to an external plugin. Doctor completes, then `plugins doctor` correctly reports that Matrix is not installed.

## Why This Change Was Made

Use bundled Telegram for the activation fixture and check the fixture against the plugin manifest, root package exclusions, and packaged artifacts. The npm preflight runs the release checker from its existing immutable trusted tooling checkout while retaining the target checkout as the working directory. Required and forbidden SDK artifact lists explicitly consume the target registries, preserving release-only compatibility entrypoints when tooling has advanced.

The existing generated-content checks, Doctor repair, plugin diagnostics, and package-install checks remain required. The workflow verifies the tooling SHA and clean checkout before execution. Runtime production LOC is unchanged; this change is confined to release tooling and its tests.

## User Impact

Maintainers can validate a frozen release with corrected release tooling without modifying its product source. No runtime or configuration behavior changes.

## Evidence

- Original hosted failure: [npm preflight 33453558738](https://github.com/openclaw/openclaw/actions/runs/33453558738/job/99688586698). Doctor completed successfully; `plugins doctor` failed solely because the fixture enabled absent external Matrix.
- Same installed release package in isolated Docker homes: Matrix `plugins doctor` exits 1; Telegram exits 0 with plugin discovery, module loading, compatibility, and configuration checks passed. The local full Doctor replay was inconclusive; the next npm preflight retains the complete fresh-install/Doctor sequence as its gate.
- Two regression tests demonstrated the pre-fix failures: an excluded plugin selected by the activation fixture, and a private SDK declaration missed when tooling runs from another checkout.
- 88 focused release-check and workflow tests pass. `check:changed` and `check:workflows` pass. Independent Codex reviews report no actionable P0–P2 findings. The initial PR CI exposed one stale assertion requiring the former shell command verbatim; the follow-up removes that equality while retaining the cache-validation contract.

ClawSweeper follow-through: the completed review reports no actionable findings. The exact cross-checkout loader runs against the frozen release and matches all 469 required and 215 forbidden private SDK artifacts; the restored compatibility facade remains required. The suggested complete frozen npm preflight is retained as a mandatory post-merge publication gate, rather than duplicated before the corrected tooling is available on main. The smoke fixture writes only ephemeral test configuration; no product schema or persistent-state contract changes. Tooling growth is confined to the verified checker/target-inventory boundary.
