### PR TITLE
fix(control-ui): keep loading model picker beside microphone

### DIFF
--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -94,6 +94,38 @@ suite.define(() => {
       );
     },
   );
+  it("keeps the loading model picker beside the microphone", async () => {
+    const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
+    const artifactDir = artifactRoot
+      ? createControlUiE2eArtifactDir("chat-composer-redesign", artifactRoot)
+      : undefined;
+    await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
+      const gateway = await installMockGateway(page, {
+        deferredMethods: ["chat.startup"],
+      });
+      await page.goto(`${suite.server.baseUrl}chat`);
+      await gateway.waitForRequest("chat.startup");
+
+      const composer = page.locator(".agent-chat__input");
+      const model = composer.locator('[data-chat-model-select="true"]');
+      const voice = page.getByRole("button", { name: "Start voice input" });
+      await expect.poll(() => model.getAttribute("aria-busy")).toBe("true");
+      await expect.poll(() => voice.isVisible()).toBe(true);
+      if (artifactDir) {
+        await composer.screenshot({
+          animations: "disabled",
+          path: `${artifactDir}/loading-model-picker-spacing.png`,
+        });
+      }
+
+      const measureGap = async () => {
+        const [modelBox, voiceBox] = await Promise.all([model.boundingBox(), voice.boundingBox()]);
+        return modelBox && voiceBox ? voiceBox.x - (modelBox.x + modelBox.width) : null;
+      };
+      await expect.poll(measureGap).toBeGreaterThanOrEqual(0);
+      await expect.poll(measureGap).toBeLessThanOrEqual(16);
+    });
+  });
 
   it("keeps offline status in one bounded composer row", async () => {
     await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -6118,6 +6118,13 @@ button.chat-pr__diff {
   pointer-events: none;
 }
 
+/* Collapse the empty effort slot while loading unless the open model menu
+   needs its anchor. */
+.chat-controls__model-settings:not(:has(.chat-controls__model-picker[open]))
+  .chat-controls__effort-picker--reserved {
+  display: none;
+}
+
 .chat-controls__inline-select {
   min-width: 0;
 }

--- a/ui/src/styles/new-session.css
+++ b/ui/src/styles/new-session.css
@@ -1113,14 +1113,6 @@ wa-popover.new-session-page__project-popover::part(body) {
   cursor: default;
 }
 
-/* The trailing actions already own the stable right edge on /new. Collapse the
-   empty effort slot while loading unless the open model menu needs its anchor. */
-.new-session-page__composer
-  .chat-controls__model-settings:not(:has(.chat-controls__model-picker[open]))
-  .chat-controls__effort-picker--reserved {
-  display: none;
-}
-
 /* Phones (and short landscape): match the chat thread's mobile inset, and
    anchor menus to the trigger row instead of their trigger — a near
    viewport-wide panel under a non-leftmost trigger would otherwise run past


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening the Control UI chat while the model catalog was loading saw an oversized empty gap between the loading model picker and the microphone action.

## Why This Change Was Made

The transient reasoning-effort control remains in the DOM to keep an open model menu anchored, but `visibility: hidden` also reserved its width while that menu was closed. This promotes the existing `/new` behavior to the shared chat-control layout: collapse the reserved slot while the model menu is closed, and retain it while the menu is open.

Best-fix verdict: this is the shared owner-boundary fix. Shrinking the loading skeleton would leave the invisible slot intact, while changing the composer flex layout would affect unrelated controls.

Provenance: clearly made visible by #127823 on 2026-08-26. The blamed code author is @vyctorbrzezowski; the squash PR was merged by @steipete.

## User Impact

The loading model picker now stays visually grouped with the microphone and send actions instead of leaving a phantom-control-sized gap.

Production LOC: +7/-8 (net -1) | Tests: +32/-0

## Evidence

### Before

The browser regression fails on unmodified `main`: expected a gap of at most 16px, received 62.6875px.

![Loading model picker before: oversized gap before microphone](https://github.com/user-attachments/assets/0d88a498-08a8-4f9c-827b-518c8dccfb11)

### After

The same deferred-startup browser scenario passes after the shared layout fix.

![Loading model picker after: compact alignment beside microphone](https://github.com/user-attachments/assets/2f46d7b0-8208-4b21-a7c1-e023a6477524)

Validation:

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-composer-redesign.e2e.test.ts` — 8 passed
- `node scripts/check-changed.mjs -- ui/src/e2e/chat-composer-redesign.e2e.test.ts ui/src/styles/chat/layout.css ui/src/styles/new-session.css` — passed
- `autoreview --mode branch --base origin/main --max-priority P2` — no P0-P2 findings after addressing the overlap-assertion review finding
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/33457963107) — passed on rerun; the initial unrelated browser-extension shard hit a closed-page runner race

Codex boundary check: current Codex source owns [microphone device configuration](https://github.com/openai/codex/blob/6be2a6ca952ac9f70676ce4dd07fda27175aa9dd/codex-rs/config/src/config_toml.rs#L560-L610) and [captured audio-frame handling](https://github.com/openai/codex/blob/6be2a6ca952ac9f70676ce4dd07fda27175aa9dd/codex-rs/core/src/realtime_conversation.rs#L1943-L1947); neither defines this OpenClaw composer layout.

AI-assisted: Codex implemented and reviewed this change; the code path, regression, and visual evidence were manually inspected.
