### PR TITLE
improve(ui): simplify chat selection popup

### DIFF
--- a/docs/tools/btw.md
+++ b/docs/tools/btw.md
@@ -70,14 +70,12 @@ session companion RPCs and renders their bounded exchange state in the rail.
 ## Selection popup (Control UI)
 
 Highlighting text inside a chat message in the Control UI opens a small
-selection popup with two actions:
+selection popup with one action:
 
-- **More details** immediately asks the session rail companion to explain the
-  highlighted text in the context of the current session.
 - **Ask in side chat** opens the rail and pre-fills its composer with a quoted
   draft so you can type your own question about the selection.
 
-Both actions follow normal `/btw` semantics: the question and answer stay out
+The action follows normal `/btw` semantics: the question and answer stay out
 of session history and the main run is left untouched.
 
 ## When to use it

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -18,7 +18,7 @@ While you watch a running session, the Gateway shows the model's latest safe pre
 
 The companion answers questions about the selected session and its project without entering or interrupting the main agent run. On the first question, the Gateway lazily loads a bounded visible snapshot of the selected session before starting the utility model. If history is temporarily unavailable, the question stays visible with **Retry** instead of being treated as an empty session. The companion uses read-only access to the target session's history/search and agent workspace. Its bounded thread is held in Gateway memory, is restored when you switch sessions in the Control UI, and is cleared by the rail's trash button, a session reset, Gateway restart, or idle expiry. It never enters `chat.history`, and private reference context is not stored as operator dialogue. Type `/btw <question>` or `/side <question>` in the main Control UI composer to open the rail and ask there; other clients keep their existing BTW behavior.
 
-Highlighting text in a chat message offers **More details**, which asks the companion immediately, and **Ask in side chat**, which opens the rail with a quoted draft ready to edit.
+Highlighting text in a chat message offers **Ask in side chat**, which opens the rail with a quoted draft ready to edit.
 
 The headline owns that run's sidebar subtitle instead of heuristic live activity. It is shared with the official iOS and Android session lists. A final done or failed digest remains visible while the session is unread, then the row returns to its normal work subtitle.
 

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -6019,7 +6019,6 @@ export const en: TranslationMap = {
       currentMessage: "current message",
       actions: "Message actions",
       selectionActions: "Selection actions",
-      moreDetails: "More details",
       askInSideChat: "Ask in side chat",
       rewind: "Rewind",
       rewindConfirm: "Rewind to before this message?",

--- a/ui/src/lib/chat/companion-question.test.ts
+++ b/ui/src/lib/chat/companion-question.test.ts
@@ -1,17 +1,10 @@
 import { describe, expect, it } from "vitest";
 import {
   buildCompanionQuestionPrefill,
-  buildMoreDetailsCompanionQuestion,
   extractCompanionCommandQuestion,
 } from "./companion-question.ts";
 
 describe("companion selection questions", () => {
-  it("builds a bounded single-line details question", () => {
-    expect(buildMoreDetailsCompanionQuestion("Let's Encrypt cert\nis valid")).toBe(
-      'Explain "Let\'s Encrypt cert is valid" from this conversation in more detail.',
-    );
-  });
-
   it("builds a rail composer prefill without changing the main composer", () => {
     expect(buildCompanionQuestionPrefill("cron scan job")).toBe('Regarding "cron scan job": ');
   });

--- a/ui/src/lib/chat/companion-question.ts
+++ b/ui/src/lib/chat/companion-question.ts
@@ -7,11 +7,6 @@ function collapseChatSelectionSnippet(text: string): string {
   return truncateUtf16Safe(collapsed, CHAT_SELECTION_SNIPPET_MAX_CHARS);
 }
 
-export function buildMoreDetailsCompanionQuestion(selection: string): string | null {
-  const snippet = collapseChatSelectionSnippet(selection);
-  return snippet ? `Explain "${snippet}" from this conversation in more detail.` : null;
-}
-
 export function buildCompanionQuestionPrefill(selection: string): string | null {
   const snippet = collapseChatSelectionSnippet(selection);
   return snippet ? `Regarding "${snippet}": ` : null;

--- a/ui/src/pages/chat/chat-pane-render.ts
+++ b/ui/src/pages/chat/chat-pane-render.ts
@@ -628,7 +628,6 @@ export class ChatPane extends ChatPaneLayoutRender {
         suggestionViewer || catalogKey
           ? undefined
           : (draft, submissionAction) => submitChatGoalDraft(state, draft, submissionAction),
-      onCompanionQuestion: (question) => void this.submitSessionCompanionQuestion(question),
       onCompanionPrefill: this.prefillSessionCompanionQuestion,
       replyTarget: state.chatReplyTarget ?? null,
       onClearReply: () => {

--- a/ui/src/pages/chat/chat-view.ts
+++ b/ui/src/pages/chat/chat-view.ts
@@ -189,8 +189,6 @@ export function renderChat(props: ChatProps) {
         : undefined,
       onRetryQueuedMessage: props.connected && canCompose ? props.onQueueRetry : undefined,
       onDiscardQueuedMessage: props.onQueueRemove,
-      onCompanionQuestion:
-        props.canSend && !props.suggestionComposer ? props.onCompanionQuestion : undefined,
       onCompanionPrefill:
         props.canSend && !props.suggestionComposer ? props.onCompanionPrefill : undefined,
       onOpenSession: props.onSessionSelect,

--- a/ui/src/pages/chat/components/chat-selection-popup.test.ts
+++ b/ui/src/pages/chat/components/chat-selection-popup.test.ts
@@ -39,13 +39,11 @@ function selectRange(node: Text, start: number, end: number) {
 
 function pointerUp(thread: HTMLElement) {
   handleChatSelectionPointerUp({ currentTarget: thread } as unknown as PointerEvent, {
-    onMoreDetails: onMoreDetailsSpy,
     onAskSideChat: onAskSideChatSpy,
   });
   vi.runAllTimers();
 }
 
-const onMoreDetailsSpy = vi.fn();
 const onAskSideChatSpy = vi.fn();
 
 describe("chat selection popup", () => {
@@ -53,12 +51,11 @@ describe("chat selection popup", () => {
     removeChatSelectionPopup();
     window.getSelection()?.removeAllRanges();
     document.body.innerHTML = "";
-    onMoreDetailsSpy.mockReset();
     onAskSideChatSpy.mockReset();
     vi.useRealTimers();
   });
 
-  it("shows the toolbar over bubble selections and fires the actions", () => {
+  it("shows one text-only side-chat action over bubble selections", () => {
     vi.useFakeTimers();
     const { thread, textNode } = buildThreadWithBubble("Let's Encrypt cert is valid");
     selectRange(textNode, 0, 18);
@@ -68,26 +65,12 @@ describe("chat selection popup", () => {
     expect(popup).not.toBeNull();
     expect(popup?.getAttribute("aria-label")).toBe("Selection actions");
     const buttons = [...(popup?.querySelectorAll("button") ?? [])];
-    expect(buttons.map((button) => button.textContent)).toEqual([
-      "More details",
-      "Ask in side chat",
-    ]);
+    expect(buttons.map((button) => button.textContent)).toEqual(["Ask in side chat"]);
+    expect(buttons[0]?.querySelector("svg")).toBeNull();
 
     buttons[0]?.click();
-    expect(onMoreDetailsSpy).toHaveBeenCalledWith("Let's Encrypt cert");
+    expect(onAskSideChatSpy).toHaveBeenCalledWith("Let's Encrypt cert");
     expect(document.body.querySelector(".chat-selection-popup")).toBeNull();
-  });
-
-  it("routes the second button to the side-chat action", () => {
-    vi.useFakeTimers();
-    const { thread, textNode } = buildThreadWithBubble("cron scan job is installed");
-    selectRange(textNode, 0, 13);
-    pointerUp(thread);
-
-    const buttons = document.body.querySelectorAll(".chat-selection-popup button");
-    (buttons[1] as HTMLButtonElement | undefined)?.click();
-    expect(onAskSideChatSpy).toHaveBeenCalledWith("cron scan job");
-    expect(onMoreDetailsSpy).not.toHaveBeenCalled();
   });
 
   it("ignores selections outside chat bubbles and collapsed selections", () => {
@@ -110,7 +93,6 @@ describe("chat selection popup", () => {
     const { thread, textNode } = buildThreadWithBubble("tear down before the selection settles");
     selectRange(textNode, 0, 9);
     handleChatSelectionPointerUp({ currentTarget: thread } as unknown as PointerEvent, {
-      onMoreDetails: onMoreDetailsSpy,
       onAskSideChat: onAskSideChatSpy,
     });
 
@@ -123,25 +105,23 @@ describe("chat selection popup", () => {
   it("keeps only the latest pending selection popup", () => {
     vi.useFakeTimers();
     const { thread, textNode } = buildThreadWithBubble("replacement selection");
-    const firstMoreDetails = vi.fn();
-    const secondMoreDetails = vi.fn();
+    const firstAskSideChat = vi.fn();
+    const secondAskSideChat = vi.fn();
     selectRange(textNode, 0, 11);
     const pendingTimerCount = vi.getTimerCount();
     handleChatSelectionPointerUp({ currentTarget: thread } as unknown as PointerEvent, {
-      onMoreDetails: firstMoreDetails,
-      onAskSideChat: onAskSideChatSpy,
+      onAskSideChat: firstAskSideChat,
     });
     handleChatSelectionPointerUp({ currentTarget: thread } as unknown as PointerEvent, {
-      onMoreDetails: secondMoreDetails,
-      onAskSideChat: onAskSideChatSpy,
+      onAskSideChat: secondAskSideChat,
     });
 
     expect(vi.getTimerCount()).toBe(pendingTimerCount + 1);
     vi.advanceTimersToNextTimer();
     (document.body.querySelector(".chat-selection-popup button") as HTMLButtonElement).click();
 
-    expect(firstMoreDetails).not.toHaveBeenCalled();
-    expect(secondMoreDetails).toHaveBeenCalledWith("replacement");
+    expect(firstAskSideChat).not.toHaveBeenCalled();
+    expect(secondAskSideChat).toHaveBeenCalledWith("replacement");
   });
 
   it("dismisses when the selection collapses", () => {

--- a/ui/src/pages/chat/components/chat-selection-popup.ts
+++ b/ui/src/pages/chat/components/chat-selection-popup.ts
@@ -1,11 +1,10 @@
-// Floating toolbar over selected chat text: "More details" asks the session
-// companion immediately; "Ask in side chat" pre-fills the session rail.
+// Floating toolbar over selected chat text: "Ask in side chat" pre-fills the
+// session rail.
 // Mirrors the imperative reply-context-menu pattern in chat-thread.ts.
 
 import { t } from "../../../i18n/index.ts";
 
 type ChatSelectionPopupActions = {
-  onMoreDetails: (selection: string) => void;
   onAskSideChat: (selection: string) => void;
 };
 
@@ -43,34 +42,11 @@ function selectionTextWithinChatBubble(
   return text.trim() ? text : null;
 }
 
-function createSelectionPopupButton(
-  label: string,
-  iconPath: string,
-  onActivate: () => void,
-): HTMLButtonElement {
+function createSelectionPopupButton(label: string, onActivate: () => void): HTMLButtonElement {
   const button = document.createElement("button");
   button.type = "button";
   button.setAttribute("aria-label", label);
-
-  const icon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
-  icon.setAttribute("viewBox", "0 0 24 24");
-  icon.setAttribute("width", "14");
-  icon.setAttribute("height", "14");
-  icon.setAttribute("fill", "none");
-  icon.setAttribute("stroke", "currentColor");
-  icon.setAttribute("stroke-width", "2");
-  icon.setAttribute("stroke-linecap", "round");
-  icon.setAttribute("stroke-linejoin", "round");
-  icon.setAttribute("aria-hidden", "true");
-  icon.setAttribute("focusable", "false");
-  const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
-  path.setAttribute("d", iconPath);
-  icon.appendChild(path);
-
-  const text = document.createElement("span");
-  text.textContent = label;
-
-  button.append(icon, text);
+  button.textContent = label;
   // pointerdown would collapse the selection before click fires; the popup
   // must keep the selection alive until the action reads it.
   button.addEventListener("pointerdown", (event) => event.preventDefault());
@@ -96,15 +72,8 @@ function showChatSelectionPopup(
     action(selectionText);
   };
   popup.append(
-    createSelectionPopupButton(
-      t("chat.messages.moreDetails"),
-      "M12 3v2m0 14v2M5.6 5.6l1.5 1.5m9.8 9.8 1.5 1.5M3 12h2m14 0h2M5.6 18.4l1.5-1.5m9.8-9.8 1.5-1.5",
-      () => activate(actions.onMoreDetails),
-    ),
-    createSelectionPopupButton(
-      t("chat.messages.askInSideChat"),
-      "M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z",
-      () => activate(actions.onAskSideChat),
+    createSelectionPopupButton(t("chat.messages.askInSideChat"), () =>
+      activate(actions.onAskSideChat),
     ),
   );
   document.body.appendChild(popup);

--- a/ui/src/pages/chat/components/chat-thread-interactions.ts
+++ b/ui/src/pages/chat/components/chat-thread-interactions.ts
@@ -23,10 +23,7 @@ import type {
   ChatQueueItem,
   ChatStreamSegment,
 } from "../../../lib/chat/chat-types.ts";
-import {
-  buildCompanionQuestionPrefill,
-  buildMoreDetailsCompanionQuestion,
-} from "../../../lib/chat/companion-question.ts";
+import { buildCompanionQuestionPrefill } from "../../../lib/chat/companion-question.ts";
 import type { EmbedSandboxMode } from "../../../lib/chat/tool-display.ts";
 import { fnv1aUtf16 } from "../../../lib/fnv1a.ts";
 import type { UiSessionDefaultsHost } from "../../../lib/sessions/session-key.ts";
@@ -149,7 +146,6 @@ export type ChatThreadProps = ChatSendStatusActions & {
   onRewindMessage?: (entryId: string) => Promise<boolean> | boolean;
   onForkMessage?: (entryId: string) => Promise<void> | void;
   onFocusComposer?: () => void;
-  onCompanionQuestion?: (question: string) => void;
   onCompanionPrefill?: (question: string) => void;
   onOpenSession?: (sessionKey: string) => void;
   modelSetupRequired?: boolean;
@@ -166,7 +162,6 @@ type TranscriptInteractionProps = Pick<
   | "onRewindMessage"
   | "onForkMessage"
   | "onFocusComposer"
-  | "onCompanionQuestion"
   | "onCompanionPrefill"
 >;
 
@@ -413,21 +408,10 @@ function toggleTouchMessageMeta(event: PointerEvent): void {
 
 export function handleTranscriptPointerUp(event: PointerEvent, props: TranscriptInteractionProps) {
   toggleTouchMessageMeta(event);
-  if (
-    event.button !== 0 ||
-    event.ctrlKey ||
-    typeof props.onCompanionQuestion !== "function" ||
-    typeof props.onCompanionPrefill !== "function"
-  ) {
+  if (event.button !== 0 || event.ctrlKey || typeof props.onCompanionPrefill !== "function") {
     return;
   }
   handleChatSelectionPointerUp(event, {
-    onMoreDetails: (selection) => {
-      const question = buildMoreDetailsCompanionQuestion(selection);
-      if (question) {
-        props.onCompanionQuestion?.(question);
-      }
-    },
     onAskSideChat: (selection) => {
       const question = buildCompanionQuestionPrefill(selection);
       if (question) {

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2138,12 +2138,6 @@ button.chat-reply-preview--message:disabled {
   outline: none;
 }
 
-.chat-selection-popup button svg {
-  width: 14px;
-  height: 14px;
-  flex-shrink: 0;
-  color: var(--muted);
-}
 /* Keep size containment outside the flex surface: retained mobile panes can be
    measured at zero width, and containment there collapses the editor subtree. */
 .agent-chat__composer-shell,


### PR DESCRIPTION
## What Problem This Solves

The chat text-selection popup presents two competing actions for the same companion workflow, and both actions use icons even though the remaining action is clear on its own.

## Why This Change Was Made

The popup now exposes one canonical, text-only **Ask in side chat** action. The removed immediate-question path is deleted through its UI owner, wiring, helper, translation, styling, tests, and documentation instead of being hidden downstream.

## User Impact

Selecting text in a Control UI chat message now shows only **Ask in side chat**, without an icon. Choosing it still opens the session rail with an editable quoted draft.

## Evidence

| Before | After |
| --- | --- |
| ![Before: More details and Ask in side chat actions with icons](https://github.com/user-attachments/assets/ed2604ef-1b7f-4545-9aab-e0add814ac25) | ![After: one text-only Ask in side chat action](https://github.com/user-attachments/assets/d0a6e1fc-7bac-47ca-8e42-b0c40b419ce9) |

- Playwright mock-flow proof at 390×844, 768×1024, 1366×768, and 1440×900: one `Ask in side chat` button, zero SVG icons, no clipping or overlap.
- `pnpm test ui/src/pages/chat/components/chat-selection-popup.test.ts ui/src/lib/chat/companion-question.test.ts` — 7 tests passed.
- `pnpm check:changed` — passed, including UI/core typechecks, i18n verification, lint, and dead-export scans.
- `pnpm docs:check-mdx` — passed across 751 files.
- Exact-head autoreview — no accepted/actionable findings; patch rated correct (0.99).
- Judged LOC: production +8/-70, tests +10/-37, docs +3/-5.
