### PR TITLE
refactor(audit): share execution identity ordering

### DIFF
--- a/src/audit/execution-identity-admission.test.ts
+++ b/src/audit/execution-identity-admission.test.ts
@@ -81,9 +81,9 @@ describe("execution identity admission envelope", () => {
           displayLabel: "Operator OPENAI_API_KEY=sk-1234567890abcdef",
         },
         applicableGrants: [
+          { rawGrantRef: "é", state: "present" },
           { rawGrantRef: "z", state: "present" },
-          { rawGrantRef: "a", state: "present" },
-          { rawGrantRef: "a", state: "present" },
+          { rawGrantRef: "é", state: "present" },
         ],
         assurance: [
           {
@@ -116,8 +116,8 @@ describe("execution identity admission envelope", () => {
       ingress: { kind: "local-cli", boundary: "agent-command.local", state: "present" },
     });
     expect(envelope.applicableGrants).toEqual([
-      { rawGrantRef: "a", state: "present" },
       { rawGrantRef: "z", state: "present" },
+      { rawGrantRef: "é", state: "present" },
     ]);
     expect(envelope.invoker?.state).toBe("present");
     if (envelope.invoker?.state !== "present") {

--- a/src/audit/execution-identity-admission.ts
+++ b/src/audit/execution-identity-admission.ts
@@ -6,6 +6,7 @@ import { type Static, Type } from "typebox";
 import { Value } from "typebox/value";
 import { redactSensitiveText } from "../logging/redact.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { sortUniqueExecutionIdentityEntries } from "./execution-identity-ordering.js";
 import { executionIdentitySpawnAdmission } from "./execution-identity-spawn-admission.js";
 
 const EXECUTION_IDENTITY_ADMISSION_MAX_BYTES = 16 * 1024;
@@ -170,14 +171,6 @@ type ExecutionIdentityAdmissionSink = (work: ExecutionIdentityAdmissionWork) => 
 
 let admissionSink: ExecutionIdentityAdmissionSink | undefined;
 let admissionFailureWarned = false;
-
-function uniqueSorted<T>(values: readonly T[], key: (value: T) => string): T[] {
-  return [...new Map(values.map((value) => [key(value), value])).values()].toSorted((a, b) => {
-    const left = key(a);
-    const right = key(b);
-    return left < right ? -1 : left > right ? 1 : 0;
-  });
-}
 
 function freezeEnvelope<T>(value: T, seen = new WeakSet<object>()): T {
   if (!value || typeof value !== "object" || seen.has(value)) {
@@ -368,11 +361,11 @@ function captureExecutionIdentityAdmissionEnvelope(
       : facts.invoker?.state === "unknown"
         ? { invoker: { state: "unknown" as const } }
         : {}),
-    applicableGrants: uniqueSorted(
+    applicableGrants: sortUniqueExecutionIdentityEntries(
       facts.applicableGrants ?? [],
       (grant) => `${grant.rawGrantRef}\0${grant.state}`,
     ).map((grant) => ({ rawGrantRef: grant.rawGrantRef, state: grant.state })),
-    assurance: uniqueSorted(
+    assurance: sortUniqueExecutionIdentityEntries(
       assurance,
       (item) => `${item.kind}\0${item.rawEvidenceRef}\0${item.strength}`,
     ).map((item) => ({

--- a/src/audit/execution-identity-context-build.ts
+++ b/src/audit/execution-identity-context-build.ts
@@ -4,6 +4,7 @@ import type { ExecutionIdentityContextV1 } from "../../packages/gateway-protocol
 import { validateExecutionIdentityContextV1 } from "../../packages/gateway-protocol/src/index.js";
 import { pseudonymizeExecutionIdentityRef } from "./audit-identity.js";
 import type { ExecutionIdentityAdmissionEnvelope } from "./execution-identity-admission.js";
+import { sortUniqueExecutionIdentityEntries } from "./execution-identity-ordering.js";
 import { executionIdentitySpawnAdmission } from "./execution-identity-spawn-admission.js";
 
 const EXECUTION_IDENTITY_CONTEXT_MAX_BYTES = 16 * 1024;
@@ -48,14 +49,6 @@ function hmacRef(
   });
 }
 
-function uniqueSorted<T>(values: readonly T[], key: (value: T) => string): T[] {
-  return [...new Map(values.map((value) => [key(value), value])).values()].toSorted((a, b) => {
-    const left = key(a);
-    const right = key(b);
-    return left < right ? -1 : left > right ? 1 : 0;
-  });
-}
-
 export function buildExecutionIdentityContext(
   db: DatabaseSync,
   envelope: ExecutionIdentityAdmissionEnvelope,
@@ -93,7 +86,7 @@ export function buildExecutionIdentityContext(
       : envelope.invoker?.state === "unknown"
         ? { state: "unknown" as const }
         : { state: "absent" as const };
-  const assurance = uniqueSorted(
+  const assurance = sortUniqueExecutionIdentityEntries(
     envelope.assurance.map((item) => ({
       kind: item.kind,
       evidenceRef: hmacRef(db, "evidence", `${domainRef}:${item.kind}`, item.rawEvidenceRef),
@@ -101,7 +94,7 @@ export function buildExecutionIdentityContext(
     })),
     (item) => `${item.kind}\0${item.evidenceRef}\0${item.strength}`,
   );
-  const applicableGrants = uniqueSorted(
+  const applicableGrants = sortUniqueExecutionIdentityEntries(
     envelope.applicableGrants.map((grant) => ({
       grantRef: hmacRef(db, "grant", domainRef, grant.rawGrantRef),
       state: grant.state,
@@ -146,7 +139,7 @@ export function buildExecutionIdentityContext(
         depth: lineageFacts.depth,
       }
     : undefined;
-  const missingEvidence = uniqueSorted(
+  const missingEvidence = sortUniqueExecutionIdentityEntries(
     [
       ...(envelope.invoker?.state === "present" ? [] : ["invoker.principal"]),
       ...spawnMissingEvidence,

--- a/src/audit/execution-identity-context.spawn-lineage.test.ts
+++ b/src/audit/execution-identity-context.spawn-lineage.test.ts
@@ -187,4 +187,15 @@ describe("execution identity child lineage", () => {
       "lineage.parent-run",
     ]);
   });
+
+  it("deduplicates sorted missing invoker evidence across admission and spawn lineage", () => {
+    const context = prepareContext(
+      facts("missing-invoker", {
+        spawnMissingEvidence: ["invoker.principal", "acp.native-action-callback"],
+      }),
+      { contextId: "missing-invoker-context", executionId: "missing-invoker-execution" },
+    );
+
+    expect(context.missingEvidence).toEqual(["acp.native-action-callback", "invoker.principal"]);
+  });
 });

--- a/src/audit/execution-identity-ordering.ts
+++ b/src/audit/execution-identity-ordering.ts
@@ -1,0 +1,11 @@
+export function sortUniqueExecutionIdentityEntries<T>(
+  values: readonly T[],
+  key: (value: T) => string,
+): T[] {
+  // Last-key-wins UTF-16 ordering protects canonical execution-identity bytes.
+  return [...new Map(values.map((value) => [key(value), value])).values()].toSorted((a, b) => {
+    const left = key(a);
+    const right = key(b);
+    return left < right ? -1 : left > right ? 1 : 0;
+  });
+}


### PR DESCRIPTION
## What Problem This Solves

Execution-identity admission and context construction each carried a private copy of the same keyed deduplication and deterministic ordering policy. Keeping two copies risks drift in canonical execution-identity bytes.

## Why This Change Was Made

This moves the exact Map-based, last-key-wins UTF-16 ordering behavior into one dependency-free private audit module. Admission and context construction retain ownership of validation, keys, HMAC projection, canonical bytes, and persistence; no protocol, package, SDK, config, or schema surface changes.

The existing primitive `sortUniqueStrings` and spawn-lineage helper are intentionally not reused because they preserve first-seen string values and cannot express keyed last-value selection.

## User Impact

No user-visible behavior changes. Execution-identity canonicalization now has one implementation, reducing the chance that admission and persisted context bytes diverge.

Production LOC: +18/-21 (net -3)  
Tests: +14/-3 (net +11)

## Evidence

- Focused audit suites: 79 passed.
- Mutation proof rejected removed deduplication, locale sorting, default object sorting, and skipped context canonicalization with duplicate cross-source missing evidence.
- `pnpm check:import-cycles`: 0 runtime value cycles.
- `pnpm check:madge-import-cycles`: 0 cycles.
- `pnpm check:max-lines-ratchet`: passed.
- Linux Testbox `tbx_01m1d8adrr7g7bswv0299tf75b` verified the exact five candidate blobs, passed all 79 focused tests, completed `pnpm build`, and passed `pnpm check:changed`: https://github.com/openclaw/openclaw/actions/runs/33457740038
- Exact autoreview: no accepted/actionable findings, correctness 0.99.
- `git diff --check`: passed.
- Exhaustive overlap sweep: 2,265 open PRs checked, including direct blob comparison for 42 PRs with more than 100 files; no competing helper or ordering-policy change found. The mechanical overlap in #120887 carries byte-identical current-main blobs.
- Local `pnpm build` and `pnpm check:changed` reached the UI/typecheck surfaces, then hit the linked shared-worktree `pako` CJS/declaration mismatch. No dependency reconciliation was performed in the worktree; the clean Linux Testbox run above owns those proofs.
- Codex source gate inspected at `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; unrelated to execution-identity ordering.
