### PR TITLE
fix(ui): separate optionless free-text questions

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -4043,7 +4043,6 @@ ui/src/pages/chat/components/chat-message-timestamp.ts	4
 ui/src/pages/chat/components/chat-model-picker-options.ts	2
 ui/src/pages/chat/components/chat-model-picker.ts	7
 ui/src/pages/chat/components/chat-pane-header.ts	2
-ui/src/pages/chat/components/chat-question-card.ts	1
 ui/src/pages/chat/components/chat-selection-popup.ts	1
 ui/src/pages/chat/components/chat-session-rail.ts	4
 ui/src/pages/chat/components/chat-session-sharing.ts	1

--- a/ui/src/e2e/question-flow.e2e.test.ts
+++ b/ui/src/e2e/question-flow.e2e.test.ts
@@ -471,9 +471,12 @@ suite.define(() => {
     await expect
       .poll(() => panel.getByText("Replaces DEPLOY_API_KEY", { exact: false }).count())
       .toBe(1);
-    const secretInput = panel.locator('input[type="password"]');
+    const secretInput = panel.getByLabel("API key", { exact: true });
     await expect.poll(() => secretInput.count()).toBe(1);
+    expect(await secretInput.getAttribute("type")).toBe("password");
     expect(await secretInput.getAttribute("autocomplete")).toBe("off");
+    expect(await secretInput.getAttribute("placeholder")).toBe("Enter DEPLOY_API_KEY");
+    await expect.poll(() => panel.locator('[role="radiogroup"]').count()).toBe(0);
     const hostsInput = panel.locator(".chat-question-panel__hosts");
     expect(await hostsInput.inputValue()).toBe("api.example.test");
     await screenshot(page, "07-secret-store-pending.png");

--- a/ui/src/e2e/question-flow.e2e.test.ts
+++ b/ui/src/e2e/question-flow.e2e.test.ts
@@ -475,7 +475,7 @@ suite.define(() => {
     await expect.poll(() => secretInput.count()).toBe(1);
     expect(await secretInput.getAttribute("type")).toBe("password");
     expect(await secretInput.getAttribute("autocomplete")).toBe("off");
-    expect(await secretInput.getAttribute("placeholder")).toBe("Enter DEPLOY_API_KEY");
+    expect(await secretInput.getAttribute("placeholder")).toBe("DEPLOY_API_KEY");
     await expect.poll(() => panel.locator('[role="radiogroup"]').count()).toBe(0);
     const hostsInput = panel.locator(".chat-question-panel__hosts");
     expect(await hostsInput.inputValue()).toBe("api.example.test");

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5966,7 +5966,8 @@ export const en: TranslationMap = {
     },
     questions: {
       other: "Type your own answer here",
-      answerPlaceholder: "Enter {label}",
+      answer: "Answer",
+      answerPlaceholder: "{label}",
       submit: "Submit",
       next: "Next",
       back: "Back",

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5966,6 +5966,7 @@ export const en: TranslationMap = {
     },
     questions: {
       other: "Type your own answer here",
+      answerPlaceholder: "Enter {label}",
       submit: "Submit",
       next: "Next",
       back: "Back",

--- a/ui/src/pages/chat/components/chat-question-answer-controls.ts
+++ b/ui/src/pages/chat/components/chat-question-answer-controls.ts
@@ -1,0 +1,113 @@
+// Control UI question module renders selectable and free-text answer controls.
+import { html, nothing } from "lit";
+import type { QuestionPrompt } from "../../../app/question-prompt.ts";
+import { t } from "../../../i18n/index.ts";
+
+type Question = QuestionPrompt["questions"][number];
+
+type QuestionOptionsProps = {
+  question: Question;
+  selected: readonly string[];
+  disabled: boolean;
+  onSelect: (label: string) => void;
+};
+
+type QuestionFreeTextProps = {
+  question: Question;
+  value: string;
+  selected: boolean;
+  disabled: boolean;
+  onInput: (value: string) => void;
+};
+
+export function renderQuestionOptions(props: QuestionOptionsProps) {
+  const { question } = props;
+  if (question.options.length === 0) {
+    return nothing;
+  }
+  return html`
+    <div
+      class="chat-question-panel__options"
+      role=${question.multiSelect ? "group" : "radiogroup"}
+      aria-label=${question.header}
+    >
+      ${question.options.map((option, index) => {
+        const selected = props.selected.includes(option.label);
+        const radioTabIndex = selected || (props.selected.length === 0 && index === 0) ? 0 : -1;
+        return html`
+          <button
+            class="chat-question-panel__option ${selected
+              ? "chat-question-panel__option--selected"
+              : ""}"
+            type="button"
+            role=${question.multiSelect ? "checkbox" : "radio"}
+            aria-checked=${selected ? "true" : "false"}
+            tabindex=${question.multiSelect ? 0 : radioTabIndex}
+            data-option-index=${index}
+            ?disabled=${props.disabled}
+            @click=${() => props.onSelect(option.label)}
+          >
+            <span class="chat-question-panel__option-marker" aria-hidden="true">
+              ${selected ? "✓" : ""}
+            </span>
+            <span class="chat-question-panel__option-copy">
+              <strong>${option.label}</strong>
+              ${option.description ? html`<small>${option.description}</small>` : nothing}
+            </span>
+            <kbd>${index + 1}</kbd>
+          </button>
+        `;
+      })}
+    </div>
+  `;
+}
+
+export function renderQuestionFreeText(props: QuestionFreeTextProps) {
+  const { question } = props;
+  const handleInput = (event: Event) => {
+    if (event.currentTarget instanceof HTMLInputElement) {
+      props.onInput(event.currentTarget.value);
+    }
+  };
+  if (question.options.length === 0) {
+    return html`
+      <label class="field">
+        <span>${question.header}</span>
+        <input
+          class="input"
+          type=${question.isSecret ? "password" : "text"}
+          autocomplete="off"
+          placeholder=${t("chat.questions.answerPlaceholder", {
+            label: question.secretStore?.name ?? question.header,
+          })}
+          .value=${props.value}
+          ?disabled=${props.disabled}
+          @input=${handleInput}
+        />
+      </label>
+    `;
+  }
+  if (!question.isOther) {
+    return nothing;
+  }
+  return html`
+    <label
+      class="chat-question-panel__option chat-question-panel__option--other ${props.selected
+        ? "chat-question-panel__option--selected"
+        : ""}"
+    >
+      <span class="chat-question-panel__option-marker" aria-hidden="true"></span>
+      <input
+        class="chat-question-panel__other"
+        type=${question.isSecret ? "password" : "text"}
+        autocomplete="off"
+        placeholder=${t("chat.questions.other")}
+        aria-label=${t("chat.questions.ownAnswerFor", { header: question.header })}
+        .value=${props.value}
+        ?disabled=${props.disabled}
+        @input=${handleInput}
+      />
+      <kbd>${question.options.length + 1}</kbd>
+    </label>
+  `;
+}

--- a/ui/src/pages/chat/components/chat-question-answer-controls.ts
+++ b/ui/src/pages/chat/components/chat-question-answer-controls.ts
@@ -70,15 +70,16 @@ export function renderQuestionFreeText(props: QuestionFreeTextProps) {
     }
   };
   if (question.options.length === 0) {
+    const answerLabel = question.header || t("chat.questions.answer");
     return html`
       <label class="field">
-        <span>${question.header}</span>
+        <span>${answerLabel}</span>
         <input
           class="input"
           type=${question.isSecret ? "password" : "text"}
           autocomplete="off"
           placeholder=${t("chat.questions.answerPlaceholder", {
-            label: question.secretStore?.name ?? question.header,
+            label: question.secretStore?.name ?? answerLabel,
           })}
           .value=${props.value}
           ?disabled=${props.disabled}

--- a/ui/src/pages/chat/components/chat-question-card.test.ts
+++ b/ui/src/pages/chat/components/chat-question-card.test.ts
@@ -184,7 +184,7 @@ describe("shared question panel", () => {
 
     expect(hosts.value).toBe("api.example.test");
     expect(secret.autocomplete).toBe("off");
-    expect(secret.placeholder).toBe("Enter FAKE_DEPLOYMENT_API_KEY");
+    expect(secret.placeholder).toBe("FAKE_DEPLOYMENT_API_KEY");
     expect(secret.closest("label")?.textContent).toContain("API key");
     expect(container.querySelector(".chat-question-panel__options")).toBeNull();
     expect(container.querySelector(".chat-question-panel__option-marker")).toBeNull();
@@ -241,7 +241,7 @@ describe("shared question panel", () => {
       const input = container.querySelector<HTMLInputElement>("input")!;
       const submit = container.querySelector<HTMLButtonElement>(".chat-question-panel__advance")!;
       expect(input.value).toBe(expected ?? "");
-      expect(input.placeholder).toBe("Enter Value");
+      expect(input.placeholder).toBe("Value");
       expect(submit.disabled).toBe(expected === null);
       submit.click();
       if (expected === null) {
@@ -251,6 +251,26 @@ describe("shared question panel", () => {
       }
     },
   );
+
+  it("labels optionless answers when the compact header is empty", async () => {
+    drawGateway(
+      gatewayPrompt({
+        questions: [
+          {
+            questionId: "value",
+            header: "",
+            question: "Provide a value",
+            options: [],
+          },
+        ],
+      }),
+    );
+    await panelIn(container);
+
+    const input = container.querySelector<HTMLInputElement>("input")!;
+    expect(input.closest("label")?.textContent).toContain("Answer");
+    expect(input.placeholder).toBe("Answer");
+  });
 
   it("keeps environment store requests masked without exposing a destination-host editor", async () => {
     drawGateway(

--- a/ui/src/pages/chat/components/chat-question-card.test.ts
+++ b/ui/src/pages/chat/components/chat-question-card.test.ts
@@ -119,6 +119,11 @@ describe("shared question panel", () => {
       ),
     ).not.toBeNull();
     expect(container.querySelector(".chat-question-panel__option--other kbd")).not.toBeNull();
+    expect(container.querySelector('[role="radiogroup"]')).not.toBeNull();
+    expect(
+      container.querySelector<HTMLInputElement>(".chat-question-panel__option--other input")
+        ?.placeholder,
+    ).toBe("Type your own answer here");
     expect(container.querySelector(".chat-question-panel__progress")?.textContent).toBe("1/2");
     container.querySelector<HTMLButtonElement>('[role="radio"]')?.click();
     await panel.updateComplete;
@@ -179,6 +184,9 @@ describe("shared question panel", () => {
 
     expect(hosts.value).toBe("api.example.test");
     expect(secret.autocomplete).toBe("off");
+    expect(secret.placeholder).toBe("Enter FAKE_DEPLOYMENT_API_KEY");
+    expect(secret.closest("label")?.textContent).toContain("API key");
+    expect(container.querySelector(".chat-question-panel__options")).toBeNull();
     expect(container.querySelector(".chat-question-panel__option-marker")).toBeNull();
     expect(container.querySelector("kbd")).toBeNull();
     expect(container.textContent).toContain("release-agent");
@@ -233,6 +241,7 @@ describe("shared question panel", () => {
       const input = container.querySelector<HTMLInputElement>("input")!;
       const submit = container.querySelector<HTMLButtonElement>(".chat-question-panel__advance")!;
       expect(input.value).toBe(expected ?? "");
+      expect(input.placeholder).toBe("Enter Value");
       expect(submit.disabled).toBe(expected === null);
       submit.click();
       if (expected === null) {
@@ -294,6 +303,29 @@ describe("shared question panel", () => {
 
     expect(container.querySelector('[aria-checked="true"]')).toBeNull();
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it("does not expose an Other shortcut for optionless free text", async () => {
+    drawGateway(
+      gatewayPrompt({
+        questions: [
+          {
+            questionId: "value",
+            header: "Value",
+            question: "Provide a value",
+            options: [],
+            isOther: true,
+          },
+        ],
+      }),
+    );
+    await panelIn(container);
+    const group = container.querySelector<HTMLElement>(".chat-question-panel")!;
+    const event = new KeyboardEvent("keydown", { key: "1", bubbles: true, cancelable: true });
+
+    group.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(false);
   });
 
   it("uses roving radio focus and arrow-key selection", async () => {

--- a/ui/src/pages/chat/components/chat-question-card.test.ts
+++ b/ui/src/pages/chat/components/chat-question-card.test.ts
@@ -109,6 +109,16 @@ describe("shared question panel", () => {
     drawGateway(prompt, { onSubmit });
     const panel = await panelIn(container);
 
+    expect(
+      container.querySelector('[role="radio"] .chat-question-panel__option-marker'),
+    ).not.toBeNull();
+    expect(container.querySelector('[role="radio"] kbd')).not.toBeNull();
+    expect(
+      container.querySelector(
+        ".chat-question-panel__option--other .chat-question-panel__option-marker",
+      ),
+    ).not.toBeNull();
+    expect(container.querySelector(".chat-question-panel__option--other kbd")).not.toBeNull();
     expect(container.querySelector(".chat-question-panel__progress")?.textContent).toBe("1/2");
     container.querySelector<HTMLButtonElement>('[role="radio"]')?.click();
     await panel.updateComplete;
@@ -169,6 +179,8 @@ describe("shared question panel", () => {
 
     expect(hosts.value).toBe("api.example.test");
     expect(secret.autocomplete).toBe("off");
+    expect(container.querySelector(".chat-question-panel__option-marker")).toBeNull();
+    expect(container.querySelector("kbd")).toBeNull();
     expect(container.textContent).toContain("release-agent");
     expect(container.textContent).toContain("agent:main:main");
     expect(container.textContent).toContain("Stores FAKE_DEPLOYMENT_API_KEY as Protected secret");

--- a/ui/src/pages/chat/components/chat-question-card.ts
+++ b/ui/src/pages/chat/components/chat-question-card.ts
@@ -471,7 +471,7 @@ class ChatQuestionPanel extends LitElement {
     const requestProgress = model.requestPosition
       ? `${model.requestPosition.current}/${model.requestPosition.total}`
       : null;
-
+    const freeTextOnly = question.options.length === 0;
     const requestNavigation = requestProgress
       ? html`<div class="chat-question-panel__request-nav">
           <button
@@ -641,28 +641,33 @@ class ChatQuestionPanel extends LitElement {
               </div>
             `
           : nothing}
-        ${question.isOther || question.options.length === 0
+        ${question.isOther || freeTextOnly
           ? html`
               <label
-                class="chat-question-panel__option chat-question-panel__option--other ${this.freeTextValue(
-                  question,
-                )
-                  ? "chat-question-panel__option--selected"
-                  : ""}"
+                class=${freeTextOnly
+                  ? "stack muted"
+                  : `chat-question-panel__option chat-question-panel__option--other ${
+                      this.freeTextValue(question) ? "chat-question-panel__option--selected" : ""
+                    }`}
               >
-                <span class="chat-question-panel__option-marker" aria-hidden="true"></span>
+                ${freeTextOnly
+                  ? nothing
+                  : html`<span
+                      class="chat-question-panel__option-marker"
+                      aria-hidden="true"
+                    ></span>`}
                 <input
-                  class="chat-question-panel__other"
+                  class=${freeTextOnly ? "input" : "chat-question-panel__other"}
                   type=${question.isSecret ? "password" : "text"}
                   autocomplete="off"
-                  placeholder=${t("chat.questions.other")}
+                  placeholder=${freeTextOnly ? "" : t("chat.questions.other")}
                   aria-label=${t("chat.questions.ownAnswerFor", { header: question.header })}
                   .value=${this.freeTextById.get(question.questionId) ?? ""}
                   ?disabled=${disabled}
                   @input=${(event: Event) =>
                     this.setFreeText(model, question, (event.target as HTMLInputElement).value)}
                 />
-                <kbd>${question.options.length + 1}</kbd>
+                ${freeTextOnly ? nothing : html`<kbd>${question.options.length + 1}</kbd>`}
               </label>
             `
           : nothing}

--- a/ui/src/pages/chat/components/chat-question-card.ts
+++ b/ui/src/pages/chat/components/chat-question-card.ts
@@ -5,6 +5,7 @@ import type { QuestionPrompt } from "../../../app/question-prompt.ts";
 import { icons } from "../../../components/icons.ts";
 import { t } from "../../../i18n/index.ts";
 import { formatRelativeTimestamp } from "../../../lib/format.ts";
+import { renderQuestionFreeText, renderQuestionOptions } from "./chat-question-answer-controls.ts";
 
 type QuestionPanelQuestion = QuestionPrompt["questions"][number];
 
@@ -437,7 +438,11 @@ class ChatQuestionPanel extends LitElement {
       this.toggleOption(model, question, question.options[optionIndex].label);
       return;
     }
-    if (question.isOther && optionIndex === question.options.length) {
+    if (
+      question.options.length > 0 &&
+      question.isOther &&
+      optionIndex === question.options.length
+    ) {
       event.preventDefault();
       this.querySelector<HTMLInputElement>(".chat-question-panel__other")?.focus({
         preventScroll: true,
@@ -471,7 +476,6 @@ class ChatQuestionPanel extends LitElement {
     const requestProgress = model.requestPosition
       ? `${model.requestPosition.current}/${model.requestPosition.total}`
       : null;
-    const freeTextOnly = question.options.length === 0;
     const requestNavigation = requestProgress
       ? html`<div class="chat-question-panel__request-nav">
           <button
@@ -537,45 +541,12 @@ class ChatQuestionPanel extends LitElement {
           <span class="chat-question-panel__prompt">${question.question}</span>
         </div>
 
-        <div
-          class="chat-question-panel__options"
-          role=${question.multiSelect ? "group" : "radiogroup"}
-          aria-label=${question.header}
-        >
-          ${question.options.map((option, index) => {
-            const selected = (this.selectedById.get(question.questionId) ?? []).includes(
-              option.label,
-            );
-            const radioTabIndex =
-              selected || (!this.selectedById.get(question.questionId)?.length && index === 0)
-                ? 0
-                : -1;
-            return html`
-              <button
-                class="chat-question-panel__option ${selected
-                  ? "chat-question-panel__option--selected"
-                  : ""}"
-                type="button"
-                role=${question.multiSelect ? "checkbox" : "radio"}
-                aria-checked=${selected ? "true" : "false"}
-                tabindex=${question.multiSelect ? 0 : radioTabIndex}
-                data-option-index=${index}
-                ?disabled=${disabled}
-                @click=${() => this.toggleOption(model, question, option.label)}
-              >
-                <span class="chat-question-panel__option-marker" aria-hidden="true">
-                  ${selected ? "✓" : ""}
-                </span>
-                <span class="chat-question-panel__option-copy">
-                  <strong>${option.label}</strong>
-                  ${option.description ? html`<small>${option.description}</small>` : nothing}
-                </span>
-                <kbd>${index + 1}</kbd>
-              </button>
-            `;
-          })}
-        </div>
-
+        ${renderQuestionOptions({
+          question,
+          selected: this.selectedById.get(question.questionId) ?? [],
+          disabled,
+          onSelect: (label) => this.toggleOption(model, question, label),
+        })}
         ${question.secretStore
           ? html`
               <div class="chat-question-panel__store">
@@ -641,36 +612,13 @@ class ChatQuestionPanel extends LitElement {
               </div>
             `
           : nothing}
-        ${question.isOther || freeTextOnly
-          ? html`
-              <label
-                class=${freeTextOnly
-                  ? "stack muted"
-                  : `chat-question-panel__option chat-question-panel__option--other ${
-                      this.freeTextValue(question) ? "chat-question-panel__option--selected" : ""
-                    }`}
-              >
-                ${freeTextOnly
-                  ? nothing
-                  : html`<span
-                      class="chat-question-panel__option-marker"
-                      aria-hidden="true"
-                    ></span>`}
-                <input
-                  class=${freeTextOnly ? "input" : "chat-question-panel__other"}
-                  type=${question.isSecret ? "password" : "text"}
-                  autocomplete="off"
-                  placeholder=${freeTextOnly ? "" : t("chat.questions.other")}
-                  aria-label=${t("chat.questions.ownAnswerFor", { header: question.header })}
-                  .value=${this.freeTextById.get(question.questionId) ?? ""}
-                  ?disabled=${disabled}
-                  @input=${(event: Event) =>
-                    this.setFreeText(model, question, (event.target as HTMLInputElement).value)}
-                />
-                ${freeTextOnly ? nothing : html`<kbd>${question.options.length + 1}</kbd>`}
-              </label>
-            `
-          : nothing}
+        ${renderQuestionFreeText({
+          question,
+          value: this.freeTextById.get(question.questionId) ?? "",
+          selected: Boolean(this.freeTextValue(question)),
+          disabled,
+          onInput: (value) => this.setFreeText(model, question, value),
+        })}
 
         <div class="chat-question-panel__footer">
           ${model.error


### PR DESCRIPTION
## Summary

- render optionless questions with a dedicated labeled text/password field whose placeholder is only the field-specific name
- keep selectable options and their explicit “Other” answer in their existing option-row presentation
- remove the empty option container, checkbox-like marker, and numeric “Other” shortcut from free-text-only prompts
- preserve a nonempty accessible label (`Answer`) when a valid optionless question has an empty compact header

Fixes #134477

## Root cause

This was not caused by leaving the prompt unanswered. The delay only kept an already-broken prompt visible.

The secret producer correctly emits one free-text question with `options: []`, and the Gateway requires secret-store requests to have that shape. The Control UI then conflated two different interaction modes in one branch: an explicit “Other” choice alongside real options, and an optionless free-text answer. Because the shared template was styled as an option row, the secret input inherited an empty selection marker and the computed shortcut `options.length + 1` (`1`). Neither control had behavior for an optionless question.

The canonical fix is two form presentations:

- real choices render an option group, with the existing optional “Other” row
- zero-option questions render a normal labeled text/password field with a localized, field-specific placeholder

Keyboard handling now follows the same boundary, so an optionless question cannot expose the stale numeric “Other” shortcut. Because the protocol permits an empty compact header, the free-text presentation falls back to the localized label `Answer` rather than producing an unnamed input. No protocol, configuration, persistence, or secret-handling behavior changed.

## Before / after

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/8b2e2e9d-bb5e-4b5b-8470-b8d600698990" alt="Secret prompt with a checkbox-like marker and numeric shortcut" width="560"> | A normal labeled password field: label `API key`, placeholder `DEPLOY_API_KEY`, and no option marker, numeric shortcut, or radiogroup. |

Exact-head browser proof uses only synthetic values. The [Gateway-question E2E assertion](https://github.com/openclaw/openclaw/blob/1b06e244fac62cb6c89226d88f17ce7d42a89b18/ui/src/e2e/question-flow.e2e.test.ts#L475-L479) verifies the password field, bare `DEPLOY_API_KEY` placeholder, and absence of an option group. A 1440×900 exact-head screenshot was also captured and visually inspected locally; the Codex Browser connector exposed no attachable tab during the final upload attempt, so this body does not claim the older intermediate image as final proof.

## Validation

- regression proof: the new assertions fail before the fix on the blank placeholder, empty options container, consumed numeric shortcut, old `Enter …` copy, and empty-header accessible name
- `node scripts/run-vitest.mjs run ui/src/pages/chat/components/chat-question-card.test.ts` — 21 passed
- focused Control UI Gateway-question E2E — 1 passed; exact-head 1440×900 screenshot captured
- responsive browser proof — 390×844 screenshot inspected with no overflow
- `pnpm ui:i18n:baseline` — passed (6,004 source keys)
- full changed-file gate, UI typecheck, i18n verification, lint, dead-code scans, and assertion-safety ratchet — passed
- required pre-publish automated review — no actionable findings
- latest ClawSweeper finding addressed at the rendering owner: localized empty-header fallback plus focused regression coverage

Production delta: +69 net (`chat-question-card.ts` −47, extracted answer-controls module +114, i18n +2); tests +67 net; assertion-safety support baseline −1. Most source growth is moved option/Other markup plus the explicit second form template and its small typed interface. The separation is intentional: it prevents the two interaction models from sharing misleading semantics, while the stateful panel remains the single owner of answer state, submission, navigation, and keyboard orchestration.
