### PR TITLE
test(plugin-sdk): clear the completed cancellation deadline

### DIFF
--- a/test/scripts/plugin-sdk-api-diff.test.ts
+++ b/test/scripts/plugin-sdk-api-diff.test.ts
@@ -3,6 +3,7 @@ import { execFileSync, spawn } from "node:child_process";
 import { chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import { delimiter, dirname, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { withTestTimeout } from "../helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -107,12 +108,7 @@ describe("Plugin SDK API diff CLI", () => {
       expect(existsSync(temporaryRoot)).toBe(true);
       const interruptedAt = Date.now();
       child.kill("SIGTERM");
-      const exitCode = await Promise.race([
-        close,
-        new Promise<never>((_, reject) => {
-          setTimeout(() => reject(new Error("Plugin SDK API diff ignored SIGTERM")), 5_000);
-        }),
-      ]);
+      const exitCode = await withTestTimeout(close, 5_000, "Plugin SDK API diff ignored SIGTERM");
 
       expect(exitCode).toBe(143);
       expect(Date.now() - interruptedAt).toBeLessThan(5_000);


### PR DESCRIPTION
The SDK API diff cancellation test discards the handle for its five-second observation deadline. When the real child closes first, that timer remains scheduled. Use the existing withTestTimeout helper to clear it on either outcome.

The test still launches the real CLI, sends SIGTERM, requires exit 143, and verifies registered-worktree cleanup, owned-directory deletion and preservation of the neighboring sentinel. All existing 10-second startup, five-second cancellation and 15-second overall bounds remain.

The native case passes before and after. A direct helper probe confirms timer cleanup, rejection identity and unresolved-deadline failure. Full changed checks and independent Codex autoreview pass. Production code is unchanged and tests shrink by four lines; one residual timer is removed, with no claimed five-second runtime saving.
