### PR TITLE
test(azure-speech): clear the socket-close observation timer

### DIFF
--- a/extensions/azure-speech/tts.test.ts
+++ b/extensions/azure-speech/tts.test.ts
@@ -2,6 +2,7 @@
 import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import { installPinnedHostnameTestHooks } from "openclaw/plugin-sdk/test-media-understanding";
+import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   azureSpeechTTS,
@@ -283,12 +284,9 @@ describe("azure speech tts", () => {
       ).rejects.toThrow("Azure Speech TTS API error: malformed audio response");
 
       await expect(
-        Promise.race([
-          socketClosed,
-          new Promise<boolean>((resolve) => {
-            setTimeout(() => resolve(false), 250);
-          }),
-        ]),
+        withTimeout(socketClosed, 250, {
+          message: "Azure Speech malformed-response socket did not close",
+        }),
       ).resolves.toBe(true);
     } finally {
       server.closeAllConnections();


### PR DESCRIPTION
The real malformed-response connection test leaves its 250 ms socket-close observation timer scheduled after the socket closes. Replace that raw race with the existing public timeout helper, which clears the timer when either outcome settles.

The real HTTP server, never-ending JSON response, malformed-audio error, server-side close event, five-second request timeout, 250 ms observation phase and joined teardown remain. No transport mock or shorter deadline replaces the connection proof.

All 23 selected TTS, speech-provider and timeout cases pass before and after, including all 12 TTS cases. The installed helper contract and a direct probe confirm timer cleanup and rejection identity. Suppressing the close notification fails the unchanged guard; restoring the fixture passes all 12 TTS cases. Full changed checks and independent Codex autoreview pass. Production is unchanged; tests shrink by two lines. This removes one residual timer without claiming a 250 ms runtime saving.
