### PR TITLE
fix(a2a): reject oversized JSON-RPC batches and responses

### DIFF
--- a/docs/channels/a2a.md
+++ b/docs/channels/a2a.md
@@ -167,7 +167,7 @@ Agent Card discovery is intentionally public: anyone who can reach the gateway c
 
 Every JSON-RPC request requires a configured peer bearer token; there is no unauthenticated mode. Each authenticated peer is also the sender identity used for normal OpenClaw channel ingress policy. Use different high-entropy tokens for each peer, keep tokens out of source control, and rotate tokens by updating the gateway environment and restarting.
 
-Requests are limited to 1 MiB. Extracted message text is capped at 64 KiB and includes an explicit truncation marker when shortened. The default sliding-window limit is 30 requests per minute for each peer; set `rateLimitPerMinute` to `0` only on a separately protected network. Rate-limited requests return a JSON-RPC error while keeping HTTP status 200.
+Requests are limited to 1 MiB, JSON-RPC batches to 30 entries, and serialized JSON-RPC responses to 1 MiB. Extracted message text is capped at 64 KiB and includes an explicit truncation marker when shortened. The default sliding-window limit is 30 requests per minute for each peer; schema-invalid requests count toward that limit. Set `rateLimitPerMinute` to `0` only on a separately protected network. Rate-limited requests return a JSON-RPC error while keeping HTTP status 200.
 
 Outbound destinations come only from operator-configured peer URLs. Inbound callers cannot supply a proxy target or redirect OpenClaw to another destination.
 

--- a/extensions/a2a/src/http.test.ts
+++ b/extensions/a2a/src/http.test.ts
@@ -334,17 +334,44 @@ describe("A2A HTTP authentication and request limits", () => {
   it("replaces oversized RPC results with a bounded error", async () => {
     const harness = await startHttpHarness();
     const task = harness.taskStore.create("ctx-large", "alpha");
-    harness.taskStore.completeNext(task.contextId, "x".repeat(1024 * 1024), "alpha");
-
-    const response = await harness.post({
+    const oversizedText = "x".repeat(1024 * 1024);
+    harness.taskStore.completeNext(task.contextId, oversizedText, "alpha");
+    const requestBody = JSON.stringify({
       jsonrpc: "2.0",
       id: "large-result",
       method: "GetTask",
       params: { id: task.id },
     });
+    const stringifySpy = vi.spyOn(JSON, "stringify");
+
+    const response = await harness.post(requestBody);
 
     await expect(response.json()).resolves.toMatchObject({
       id: "large-result",
+      error: { code: -32000, message: expect.stringContaining("response") },
+    });
+    expect(Buffer.byteLength(await response.text())).toBeLessThan(1_024);
+    expect(
+      stringifySpy.mock.calls.some(
+        ([value]) =>
+          (value as { result?: { artifacts?: Array<{ parts?: Array<{ text?: string }> }> } })
+            ?.result?.artifacts?.[0]?.parts?.[0]?.text === oversizedText,
+      ),
+    ).toBe(false);
+  });
+
+  it("keeps the overflow fallback bounded when its request ID cannot fit", async () => {
+    const harness = await startHttpHarness();
+    const requestBody = JSON.stringify({
+      jsonrpc: "2.0",
+      id: "i".repeat(1024 * 1024 - 25),
+    });
+    expect(Buffer.byteLength(requestBody)).toBeLessThanOrEqual(1024 * 1024);
+
+    const response = await harness.post(requestBody);
+
+    await expect(response.json()).resolves.toMatchObject({
+      id: null,
       error: { code: -32000, message: expect.stringContaining("response") },
     });
     expect(Buffer.byteLength(await response.text())).toBeLessThan(1_024);

--- a/extensions/a2a/src/http.test.ts
+++ b/extensions/a2a/src/http.test.ts
@@ -349,6 +349,33 @@ describe("A2A HTTP authentication and request limits", () => {
     });
     expect(Buffer.byteLength(await response.text())).toBeLessThan(1_024);
   });
+
+  it("preserves batch response IDs when aggregate results exceed the response limit", async () => {
+    const harness = await startHttpHarness();
+    const taskA = harness.taskStore.create("ctx-large-a", "alpha");
+    const taskB = harness.taskStore.create("ctx-large-b", "alpha");
+    harness.taskStore.completeNext(taskA.contextId, "a".repeat(600 * 1024), "alpha");
+    harness.taskStore.completeNext(taskB.contextId, "b".repeat(600 * 1024), "alpha");
+
+    const response = await harness.post([
+      { jsonrpc: "2.0", id: "large-a", method: "GetTask", params: { id: taskA.id } },
+      { jsonrpc: "2.0", id: "large-b", method: "GetTask", params: { id: taskB.id } },
+    ]);
+
+    await expect(response.json()).resolves.toEqual([
+      {
+        jsonrpc: "2.0",
+        id: "large-a",
+        error: { code: -32000, message: expect.stringContaining("response") },
+      },
+      {
+        jsonrpc: "2.0",
+        id: "large-b",
+        error: { code: -32000, message: expect.stringContaining("response") },
+      },
+    ]);
+    expect(Buffer.byteLength(await response.text())).toBeLessThan(1_024);
+  });
 });
 
 describe("A2A JSON-RPC protocol boundary", () => {

--- a/extensions/a2a/src/http.test.ts
+++ b/extensions/a2a/src/http.test.ts
@@ -300,6 +300,55 @@ describe("A2A HTTP authentication and request limits", () => {
       error: expect.stringContaining("1 MiB"),
     });
   });
+
+  it("rejects oversized batches with one bounded error", async () => {
+    const harness = await startHttpHarness();
+    const response = await harness.post(Array.from({ length: 1_000 }, () => null));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      id: null,
+      error: { code: -32000, message: expect.stringContaining("batch") },
+    });
+    expect(Buffer.byteLength(await response.text())).toBeLessThan(1_024);
+  });
+
+  it("charges schema-invalid requests to the peer rate limit", async () => {
+    const harness = await startHttpHarness({ a2aConfig: { rateLimitPerMinute: 1 } });
+
+    const invalid = await harness.post({ jsonrpc: "2.0", id: "invalid" });
+    await expect(invalid.json()).resolves.toMatchObject({ error: { code: -32600 } });
+
+    const limited = await harness.post({
+      jsonrpc: "2.0",
+      id: "limited",
+      method: "GetTask",
+      params: { id: "missing" },
+    });
+    await expect(limited.json()).resolves.toMatchObject({
+      id: "limited",
+      error: { code: -32000, message: expect.stringContaining("rate limited") },
+    });
+  });
+
+  it("replaces oversized RPC results with a bounded error", async () => {
+    const harness = await startHttpHarness();
+    const task = harness.taskStore.create("ctx-large", "alpha");
+    harness.taskStore.completeNext(task.contextId, "x".repeat(1024 * 1024), "alpha");
+
+    const response = await harness.post({
+      jsonrpc: "2.0",
+      id: "large-result",
+      method: "GetTask",
+      params: { id: task.id },
+    });
+
+    await expect(response.json()).resolves.toMatchObject({
+      id: "large-result",
+      error: { code: -32000, message: expect.stringContaining("response") },
+    });
+    expect(Buffer.byteLength(await response.text())).toBeLessThan(1_024);
+  });
 });
 
 describe("A2A JSON-RPC protocol boundary", () => {

--- a/extensions/a2a/src/http.ts
+++ b/extensions/a2a/src/http.ts
@@ -21,6 +21,9 @@ import type { A2aTaskStore } from "./task-store.js";
 import type { A2aChannelConfig } from "./types.js";
 
 const MAX_REQUEST_BODY_BYTES = 1024 * 1024;
+const MAX_RESPONSE_BODY_BYTES = 1024 * 1024;
+// This cap stays enforced when an operator disables the per-peer rate limit.
+const MAX_BATCH_REQUESTS = 30;
 const DEFAULT_REPLY_TIMEOUT_MS = 120_000;
 const DEFAULT_RATE_LIMIT_PER_MINUTE = 30;
 const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -48,14 +51,35 @@ type A2aHttpHandlerParams = {
 };
 
 function writeJsonResponse(response: ServerResponse, statusCode: number, value: unknown): void {
+  writeJsonBody(response, statusCode, JSON.stringify(value));
+}
+
+function writeJsonBody(response: ServerResponse, statusCode: number, body: string): void {
   response.statusCode = statusCode;
   response.setHeader("content-type", "application/json; charset=utf-8");
   response.setHeader("cache-control", "no-store");
-  response.end(JSON.stringify(value));
+  response.end(body);
 }
 
 function createRpcError(id: A2aRpcIdentifier, code: number, message: string): A2aRpcResponse {
   return { jsonrpc: "2.0", id, error: { code, message } };
+}
+
+function writeRpcResponse(
+  response: ServerResponse,
+  value: A2aRpcResponse | A2aRpcResponse[],
+): void {
+  const body = JSON.stringify(value);
+  if (Buffer.byteLength(body) <= MAX_RESPONSE_BODY_BYTES) {
+    writeJsonBody(response, 200, body);
+    return;
+  }
+  const id = Array.isArray(value) ? null : value.id;
+  writeJsonResponse(
+    response,
+    200,
+    createRpcError(id, -32000, "A2A response exceeds the 1 MiB limit"),
+  );
 }
 
 function resolvePeerName(request: IncomingMessage, config: A2aChannelConfig): string | undefined {
@@ -151,20 +175,20 @@ export function createA2aHttpHandler(params: A2aHttpHandlerParams) {
     peerName: string,
   ): Promise<A2aRpcResponse | undefined> {
     const parsed = A2aRpcRequestSchema.safeParse(input);
-    if (!parsed.success) {
-      const candidateId = isRecord(input) ? input.id : undefined;
-      const id =
-        typeof candidateId === "string" || typeof candidateId === "number" ? candidateId : null;
-      return createRpcError(id, -32600, "Invalid JSON-RPC request");
-    }
-
-    const request = parsed.data;
-    const notification = !Object.hasOwn(request, "id");
-    const id: A2aRpcIdentifier = request.id ?? null;
+    const candidateId = isRecord(input) ? input.id : undefined;
+    const id =
+      typeof candidateId === "string" || typeof candidateId === "number" ? candidateId : null;
+    const notification = parsed.success && !Object.hasOwn(parsed.data, "id");
 
     if (isRateLimited(peerName)) {
       return notification ? undefined : createRpcError(id, -32000, "Peer is rate limited");
     }
+
+    if (!parsed.success) {
+      return createRpcError(id, -32600, "Invalid JSON-RPC request");
+    }
+
+    const request = parsed.data;
 
     let result: unknown;
     try {
@@ -300,11 +324,22 @@ export function createA2aHttpHandler(params: A2aHttpHandlerParams) {
         writeJsonResponse(response, 200, createRpcError(null, -32600, "Invalid JSON-RPC request"));
         return true;
       }
+      if (payload.length > MAX_BATCH_REQUESTS) {
+        const error = isRateLimited(peerName)
+          ? createRpcError(null, -32000, "Peer is rate limited")
+          : createRpcError(
+              null,
+              -32000,
+              `A2A batch exceeds the ${MAX_BATCH_REQUESTS} request limit`,
+            );
+        writeRpcResponse(response, error);
+        return true;
+      }
       const responses = (
         await Promise.all(payload.map((entry) => processRpcRequest(entry, peerName)))
       ).filter((entry): entry is A2aRpcResponse => entry !== undefined);
       if (responses.length > 0) {
-        writeJsonResponse(response, 200, responses);
+        writeRpcResponse(response, responses);
       } else {
         response.statusCode = 200;
         response.end();
@@ -314,7 +349,7 @@ export function createA2aHttpHandler(params: A2aHttpHandlerParams) {
 
     const result = await processRpcRequest(payload, peerName);
     if (result) {
-      writeJsonResponse(response, 200, result);
+      writeRpcResponse(response, result);
     } else {
       response.statusCode = 200;
       response.end();

--- a/extensions/a2a/src/http.ts
+++ b/extensions/a2a/src/http.ts
@@ -74,12 +74,11 @@ function writeRpcResponse(
     writeJsonBody(response, 200, body);
     return;
   }
-  const id = Array.isArray(value) ? null : value.id;
-  writeJsonResponse(
-    response,
-    200,
-    createRpcError(id, -32000, "A2A response exceeds the 1 MiB limit"),
-  );
+  const errorMessage = "A2A response exceeds the 1 MiB limit";
+  const bounded = Array.isArray(value)
+    ? value.map((entry) => createRpcError(entry.id, -32000, errorMessage))
+    : createRpcError(value.id, -32000, errorMessage);
+  writeJsonResponse(response, 200, bounded);
 }
 
 function resolvePeerName(request: IncomingMessage, config: A2aChannelConfig): string | undefined {

--- a/extensions/a2a/src/http.ts
+++ b/extensions/a2a/src/http.ts
@@ -3,6 +3,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import { listAgentIds, resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+import { boundedJsonUtf8Bytes } from "openclaw/plugin-sdk/text-utility-runtime";
 import {
   isRequestBodyLimitError,
   readRequestBodyWithLimit,
@@ -69,16 +70,23 @@ function writeRpcResponse(
   response: ServerResponse,
   value: A2aRpcResponse | A2aRpcResponse[],
 ): void {
-  const body = JSON.stringify(value);
-  if (Buffer.byteLength(body) <= MAX_RESPONSE_BODY_BYTES) {
-    writeJsonBody(response, 200, body);
+  const measured = boundedJsonUtf8Bytes(value, MAX_RESPONSE_BODY_BYTES);
+  if (measured.complete) {
+    writeJsonBody(response, 200, JSON.stringify(value));
     return;
   }
   const errorMessage = "A2A response exceeds the 1 MiB limit";
   const bounded = Array.isArray(value)
     ? value.map((entry) => createRpcError(entry.id, -32000, errorMessage))
     : createRpcError(value.id, -32000, errorMessage);
-  writeJsonResponse(response, 200, bounded);
+  // Request IDs can consume nearly the entire inbound budget. Drop correlation
+  // only when an already-oversized response's replacement still cannot fit.
+  const fallback = boundedJsonUtf8Bytes(bounded, MAX_RESPONSE_BODY_BYTES).complete
+    ? bounded
+    : Array.isArray(bounded)
+      ? bounded.map(() => createRpcError(null, -32000, errorMessage))
+      : createRpcError(null, -32000, errorMessage);
+  writeJsonResponse(response, 200, fallback);
 }
 
 function resolvePeerName(request: IncomingMessage, config: A2aChannelConfig): string | undefined {

--- a/src/plugin-sdk/text-utility-runtime.ts
+++ b/src/plugin-sdk/text-utility-runtime.ts
@@ -13,6 +13,7 @@ export {
   resolveLiveToolResultMaxChars,
 } from "../agents/tool-result-limits.js";
 export { escapeHtml } from "../shared/html-escape.js";
+export { boundedJsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 
 type ChannelProbeResult = BaseProbeResult & { elapsedMs?: number };
 


### PR DESCRIPTION
## Summary

Bounds A2A JSON-RPC batch processing and serialized responses so authenticated peers cannot trigger unbounded batch work or oversized replies.

## Changes

- Reject batches larger than 30 entries with one bounded JSON-RPC error.
- Count schema-invalid requests against the peer rate limit.
- Preflight JSON response size before serialization and replace responses larger than 1 MiB with bounded errors.
- Preserve batch arrays and response IDs whenever the replacement envelope fits; keep pathological replacement envelopes within the hard ceiling.
- Reuse the canonical bounded JSON byte counter through the existing plugin SDK runtime boundary.
- Document the enforced A2A request, batch, response, and rate-limit behavior.

## Validation

- `node scripts/run-vitest.mjs extensions/a2a src/infra/json-utf8-bytes.test.ts src/plugin-sdk/text-utility-runtime.test.ts` (127 tests passed)
- `node scripts/check-changed.mjs -- extensions/a2a/src/http.ts extensions/a2a/src/http.test.ts src/plugin-sdk/text-utility-runtime.ts docs/channels/a2a.md`
- Regression provenance: the new pre-serialization and near-limit-ID tests both fail on the prior writer and pass on this head.
- Ephemeral authenticated loopback HTTP proof: a 1,048,576-byte request with a near-limit ID returned one 100-byte bounded error.
- Aggregate-overflow loopback proof: 1,228,800 bytes of valid task results returned a 213-byte response array retaining IDs `large-a` and `large-b`.
- `pnpm build` compiled all bundles, then the local post-build check failed because three expected `@openclaw/ai/dist` artifacts are absent from the linked dependency checkout; `pnpm install` and one retry reproduced the same environment failure.

## Notes

- No configuration, schema, migration, dependency, protocol-version, or persistence changes.
- One additive generic export was added to the existing plugin SDK text runtime; no new subpath or authority is introduced.
- Production `+55/-12`; tests `+103/-0`; docs `+1/-1`.