### PR TITLE
test(msteams): combine parent-context cache lifecycle phases

### DIFF
--- a/extensions/msteams/src/thread-parent-context.test.ts
+++ b/extensions/msteams/src/thread-parent-context.test.ts
@@ -129,28 +129,19 @@ describe("fetchParentMessageCached", () => {
     vi.useRealTimers();
   });
 
-  it("invokes the fetcher on first call", async () => {
+  it("fetches a parent once and returns the cached value on repeat calls", async () => {
     const mockMsg: GraphThreadMessage = {
       id: "p1",
       body: { content: "hi", contentType: "text" },
     };
     const fetcher = vi.fn(async () => mockMsg);
 
-    const result = await fetchParentMessageCached("tok", "g1", "c1", "p1", fetcher);
+    const first = await fetchParentMessageCached("tok", "g1", "c1", "p1", fetcher);
 
-    expect(result).toEqual(mockMsg);
+    expect(first).toEqual(mockMsg);
     expect(fetcher).toHaveBeenCalledTimes(1);
     expect(fetcher).toHaveBeenCalledWith("tok", "g1", "c1", "p1");
-  });
 
-  it("returns cached value on repeat fetch without invoking fetcher", async () => {
-    const mockMsg: GraphThreadMessage = {
-      id: "p1",
-      body: { content: "hi", contentType: "text" },
-    };
-    const fetcher = vi.fn(async () => mockMsg);
-
-    await fetchParentMessageCached("tok", "g1", "c1", "p1", fetcher);
     await fetchParentMessageCached("tok", "g1", "c1", "p1", fetcher);
     const third = await fetchParentMessageCached("tok", "g1", "c1", "p1", fetcher);
 
@@ -245,22 +236,13 @@ describe("fetchParentMessageCached", () => {
 describe("shouldInjectParentContext / markParentContextInjected", () => {
   beforeEach(loadParentContextModule);
 
-  it("returns true for first observation", () => {
+  it("deduplicates a marked parent while keeping other parents and sessions independent", () => {
     expect(shouldInjectParentContext("session-1", "parent-1")).toBe(true);
-  });
 
-  it("returns false after marking the same parent", () => {
     markParentContextInjected("session-1", "parent-1");
+
     expect(shouldInjectParentContext("session-1", "parent-1")).toBe(false);
-  });
-
-  it("returns true again when a different parent appears in the session", () => {
-    markParentContextInjected("session-1", "parent-1");
     expect(shouldInjectParentContext("session-1", "parent-2")).toBe(true);
-  });
-
-  it("dedupe is scoped per session key", () => {
-    markParentContextInjected("session-1", "parent-1");
     expect(shouldInjectParentContext("session-2", "parent-1")).toBe(true);
   });
 });


### PR DESCRIPTION
The parent-context suite rebuilds the same module-local cache separately to test its first fetch and later hits. Its dedupe cases similarly repeat the setup for successive phases of one marked-parent lifecycle. Combine those phases, keeping the initial-state assertions before the transitions they protect.

All 33 existing assertions remain. Undefined-result caching, composite keys, the full five-minute TTL, Date overflow, 100-entry LRU ordering, HTML/Unicode bounds and independent parent/session behavior retain their checks. Independent stateful scenarios still reload the module.

The owner suite goes from 21 to 17 cases and 12 to eight module loads. All eight handler-level sibling cases pass before and after, including visibility filtering and once-only parent injection. Full changed checks and independent Codex autoreview pass. Production is unchanged; tests shrink by 18 lines. This is a new lifecycle consolidation beyond the earlier stateless-formatting import cleanup.
