### PR TITLE
refactor(process): consolidate command diagnostic tails

### DIFF
--- a/src/process/command-error.test.ts
+++ b/src/process/command-error.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createCommandError } from "./command-error.js";
+import { createCommandError, formatCommandOutput, formatCommandResult } from "./command-error.js";
 import type { SpawnResult } from "./exec-result.js";
 
 const failure: SpawnResult = {
@@ -145,4 +145,95 @@ it.each([
   const detail = error.message.slice(error.message.indexOf(":\n") + 2);
   expect(detail).toBe(present);
   expect(error.message).toContain("exit code 23");
+});
+
+// Buffered capture/launch failures carry an error termination, sometimes with an exit code.
+it.each([23, null])("keeps buffered error exit metadata %#", (code) => {
+  const error = createCommandError(
+    "setup",
+    {
+      ...failure,
+      code,
+      killed: false,
+      stdout: Buffer.alloc(0),
+      stderr: Buffer.alloc(0),
+      termination: "error",
+    },
+    { timeoutMs: 3_000 },
+  );
+  expect(error.message).toBe(code === null ? "setup failed" : "setup failed (exit code 23)");
+});
+
+it.each([0, 1])("keeps zero and tiny output caps surrogate-safe %#", (maxChars) => {
+  expect(formatCommandOutput("🦞", maxChars)).toBe("…\n");
+});
+
+it.each([
+  { stderr: " \tstale\r\tfinal\tfield\t \n", expected: "stderr: final\\tfield\nstdout: recovery" },
+  { stderr: "\u0007\u007f\u0085", expected: "recovery" },
+])("keeps trim and control-only normalization %#", ({ stderr, expected }) => {
+  const error = createCommandError(
+    "setup",
+    {
+      ...failure,
+      code: 23,
+      killed: false,
+      termination: "exit",
+      stderr,
+      stdout: "recovery",
+    },
+    { timeoutMs: 3_000 },
+  );
+  expect(error.message).toBe(`setup failed (exit code 23):\n${expected}`);
+});
+
+it("retains a short already-omitted tail alongside the other stream", () => {
+  const error = createCommandError(
+    "setup",
+    {
+      ...failure,
+      code: 23,
+      killed: false,
+      termination: "exit",
+      stderr: Array.from({ length: 13 }, (_, index) => `note ${index}`).join("\n"),
+      stdout: "recovery",
+    },
+    { timeoutMs: 3_000 },
+  );
+  expect(error.message).toContain("stderr: …\nnote 1\n");
+  expect(error.message).not.toContain("note 0\n");
+  expect(error.message).toContain("note 12\nstdout: recovery");
+  expect(error.message.match(/…/g)).toHaveLength(1);
+});
+
+it.each(["stdout", "stderr"] as const)(
+  "does not widen the result %s cap for a single stream",
+  (stream) => {
+    const result = formatCommandResult("command", {
+      ...failure,
+      code: 23,
+      killed: false,
+      termination: "exit",
+      stdout: "",
+      stderr: "",
+      [stream]: "x".repeat(1_600),
+    });
+    expect(result).toContain(`${stream}:`);
+    expect(result).not.toContain("x".repeat(801));
+    expect(result).toContain("…");
+  },
+);
+
+it("keeps timeout ahead of an output-limit flag", () => {
+  const error = createCommandError(
+    "setup",
+    {
+      ...failure,
+      code: null,
+      termination: "timeout",
+      outputLimitExceeded: true,
+    },
+    { timeoutMs: 3_000 },
+  );
+  expect(error.message).toBe("setup failed (timed out after 3 seconds)");
 });

--- a/src/process/command-error.ts
+++ b/src/process/command-error.ts
@@ -4,60 +4,18 @@ import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text
 import type { SpawnResult } from "./exec-result.js";
 import type { runCommandBuffered } from "./exec.js";
 
-function normalizeCommandOutput(output: string | Buffer): string {
-  const visible = stripAnsi(output.toString())
+export function formatCommandOutput(output: string | Buffer, maxChars = 800): string {
+  // CR redraws replace the current frame; trim before making edge tabs visible.
+  const text = stripAnsi(output.toString())
     .replace(/\r\n/g, "\n")
     .split("\n")
     .map((line) => line.replace(/\r+$/, "").split("\r").at(-1) ?? "")
     .join("\n")
-    .trim();
-  return visible
-    .split("\n")
-    .map((line) => sanitizeTerminalText(line))
-    .join("\n");
-}
-
-function renderCommandOutputTail(output: string, maxChars: number, markerChars = 0): string {
-  const tail = output.split("\n").slice(-12).join("\n");
-  if (tail.length === output.length && tail.length <= maxChars) {
-    return tail;
-  }
-  const contentLimit = Math.max(0, Math.floor(maxChars)) - markerChars;
-  return contentLimit < 0
-    ? ""
-    : `…\n${contentLimit > 0 ? sliceUtf16Safe(tail, -contentLimit) : ""}`;
-}
-
-function formatCommandErrorDetail(stderr: string | Buffer, stdout: string | Buffer): string {
-  const streams = [normalizeCommandOutput(stderr), normalizeCommandOutput(stdout)];
-  const visible = streams.filter(Boolean);
-  if (visible.length < 2) {
-    return visible[0] ? renderCommandOutputTail(visible[0], 2_000) : "";
-  }
-
-  const bodyBudget = 2_000 - "stderr: \nstdout: ".length;
-  const demands = streams.map((output) => {
-    const tail = output.split("\n").slice(-12).join("\n");
-    return tail.length + (tail.length < output.length ? 2 : 0);
-  });
-  let allocations = [...demands];
-  if (demands[0]! + demands[1]! > bodyBudget) {
-    allocations = demands.map((demand) => Math.min(demand, Math.floor(bodyBudget / 2)));
-    const remaining = bodyBudget - allocations[0]! - allocations[1]!;
-    const stderrUnmet = demands[0]! - allocations[0]!;
-    const stdoutUnmet = demands[1]! - allocations[1]!;
-    const index = stderrUnmet >= stdoutUnmet ? 0 : 1;
-    allocations[index] = allocations[index]! + remaining;
-  }
-  return `stderr: ${renderCommandOutputTail(
-    streams[0]!,
-    Math.max(0, Math.floor(allocations[0]!)),
-    2,
-  )}\nstdout: ${renderCommandOutputTail(streams[1]!, Math.max(0, Math.floor(allocations[1]!)), 2)}`;
-}
-
-export function formatCommandOutput(output: string | Buffer, maxChars = 800): string {
-  return renderCommandOutputTail(normalizeCommandOutput(output), maxChars);
+    .trim()
+    .replace(/[^\n]+/g, sanitizeTerminalText);
+  const tail = text.split("\n").slice(-12).join("\n");
+  const omitted = tail.length < text.length || tail.length > maxChars;
+  return `${omitted ? "…\n" : ""}${sliceUtf16Safe(tail, Math.max(0, tail.length - maxChars))}`;
 }
 
 /** Use an operation label, never argv that may contain credentials. */
@@ -67,16 +25,13 @@ export function formatCommandResult(command: string, result: SpawnResult): strin
   const signal = result.signal ? `, signal=${result.signal}` : "";
   const killed = result.killed ? ", killed=true" : "";
   const status = result.code === 0 ? "exited" : "failed";
-  const lines = [
+  return [
     `${label} ${status} (code=${result.code}, termination=${termination}${signal}${killed})`,
-  ];
-  for (const stream of ["stderr", "stdout"] as const) {
-    const output = formatCommandOutput(result[stream]);
-    if (output) {
-      lines.push(`${stream}: ${output}`);
-    }
-  }
-  return lines.join("\n");
+    ...(["stderr", "stdout"] as const).flatMap((stream) => {
+      const output = formatCommandOutput(result[stream]);
+      return output ? [`${stream}: ${output}`] : [];
+    }),
+  ].join("\n");
 }
 
 export function createCommandError(
@@ -84,27 +39,30 @@ export function createCommandError(
   result: SpawnResult | Awaited<ReturnType<typeof runCommandBuffered>>,
   options: { timeoutMs: number },
 ): Error {
-  const detail = formatCommandErrorDetail(result.stderr, result.stdout);
-  const reasons: string[] = [];
-  if (result.termination === "timeout") {
-    reasons.push(`timed out after ${options.timeoutMs / 1000} seconds`);
-  } else if (result.termination === "no-output-timeout") {
-    reasons.push("timed out waiting for output");
-  } else if (
-    result.termination === "output-limit" ||
-    ("outputLimitExceeded" in result && result.outputLimitExceeded)
-  ) {
-    reasons.push("output limit exceeded");
+  const stderr = formatCommandOutput(result.stderr, 2_000);
+  const stdout = formatCommandOutput(result.stdout, 2_000);
+  let detail = stderr || stdout;
+  if (stderr && stdout) {
+    const budget = 2_000 - "stderr: \nstdout: ".length;
+    const first = Math.min(stderr.length, Math.max(Math.ceil(budget / 2), budget - stdout.length));
+    // Pure suffix fitting replaces any earlier marker; normalization runs only once.
+    const tail = (output: string, limit: number) =>
+      output.length <= limit ? output : `…\n${sliceUtf16Safe(output, 2 - limit)}`;
+    detail = `stderr: ${tail(stderr, first)}\nstdout: ${tail(stdout, budget - first)}`;
   }
-  if (result.signal) {
-    reasons.push(`signal ${result.signal}`);
-  } else if (result.termination === "signal" && reasons.length === 0) {
-    reasons.push("terminated");
-  }
-  if (reasons.length === 0 && result.code !== null) {
-    reasons.push(`exit code ${result.code}`);
-  }
+  const signal = result.signal ? `signal ${result.signal}` : "";
+  const limited =
+    "outputLimitExceeded" in result && result.outputLimitExceeded ? "output limit exceeded" : "";
+  const exitReason = limited || (!signal && result.code !== null ? `exit code ${result.code}` : "");
+  const primary = {
+    timeout: `timed out after ${options.timeoutMs / 1000} seconds`,
+    "no-output-timeout": "timed out waiting for output",
+    "output-limit": "output limit exceeded",
+    exit: exitReason,
+    error: exitReason,
+    signal: limited || (!signal ? "terminated" : ""),
+  }[result.termination];
+  const reason = [primary, signal].filter(Boolean).join("; ");
   const label = truncateUtf16Safe(stripAnsi(command).replace(/[\r\n]+/g, " "), 256);
-  const reason = reasons.length > 0 ? ` (${reasons.join("; ")})` : "";
-  return new Error(`${label} failed${reason}${detail ? `:\n${detail}` : ""}`);
+  return new Error(`${label} failed${reason ? ` (${reason})` : ""}${detail ? `:\n${detail}` : ""}`);
 }


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #134428, which fixed lost stdout diagnostics when failed commands also wrote stderr. That repair was merged separately and added a second normalization and allocation path in the command-error formatter. This PR consolidates that ownership while retaining both useful diagnostic tails and their shared output budget.

## Why This Change Was Made

Reuse `formatCommandOutput` for terminal sanitation, carriage-return progress frames, line tails, and UTF-16 boundaries, then fit the prepared suffixes within the mixed-stream budget. This removes the parallel formatter and allocation machinery while preserving timeout, output-limit, signal, and buffered-error reasons. Result summaries retain their separate 800-unit per-stream limits.

Production changes are +38/−80 (net −42); tests are +92/−1. Together with the original repair's +42 production lines, the pair is production-neutral. Vincent Koc's diagnostic and sanitation work is preserved and credited. The Git facade changes owned by #132180 remain outside this PR.

## User Impact

Failed commands continue to show both stdout and stderr recovery information, including uneven stream lengths, without exceeding the shared diagnostic budget or splitting surrogate pairs. This is a consolidation of the landed behavior, not a claim that the new controls fail on the original repair. No configuration, storage, setup-capacity, or public API change is intended.

## Evidence

- The landed formatter passed all 22 baseline cases before this refactor, including the added behavioral controls.
- After the refactor, 80 selected cases passed: 22 formatter, 14 real managed-worktree service, 37 Git facade, and 7 Gmail result-consumer cases. The Gmail file's other 24 cases were intentionally unselected.
- All 29 selected canonical checks passed in the actual `check-changed` process. Its outer protection check then failed because the unrelated primary checkout's index bytes changed. That failure is retained; a separate audit verified unchanged product, dependencies, hooks, protected checkout semantics, and process closure. No cause is attributed and the gate process was not replayed.
- An independent full P0–P2 managed review reported no findings. The source bytes remained unchanged through the checks.

Local proof used Node 26.8.1 and pnpm 12.1.0 on macOS. An earlier service attempt failed the real disk-capacity prerequisite; it remains recorded, and the same 14 cases later passed after available space recovered. This follow-up does not claim a new released-package, Windows, live-provider, or native Codex run. The original repair's separate CLI evidence remains historical.

The nearby snapshot/git-backup stderr-or-stdout paths remain a named follow-up: their 500-unit prefix cap, URL-userinfo redaction before slicing, and no-commit semantics need their own repair and proof.

Related: #134427. Thanks @vincentkoc for the original repair and terminal-safety work.
