### PR TITLE
test(media): reuse the stateless provider registry graph

### DIFF
--- a/src/media-generation/registry.test.ts
+++ b/src/media-generation/registry.test.ts
@@ -1,5 +1,5 @@
 /** Tests media-generation provider registry aliases and plugin capability integration. */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.js";
 import type {
   ImageGenerationProviderPlugin,
@@ -67,21 +67,22 @@ function requireVideoProvider(
   return provider;
 }
 
-async function loadProviderRegistry(): Promise<ProviderRegistryModule> {
+let registry: ProviderRegistryModule;
+
+beforeAll(async () => {
   vi.resetModules();
-  return import("./registry.js");
-}
+  registry = await import("./registry.js");
+});
 
 beforeEach(() => {
-  vi.resetModules();
   resolvePluginCapabilityProvidersMock.mockReset();
   resolvePluginCapabilityProvidersMock.mockReturnValue([]);
 });
 
 describe("image-generation provider registry", () => {
-  it("delegates provider resolution to the capability provider boundary", async () => {
+  it("delegates provider resolution to the capability provider boundary", () => {
     const cfg = {} as OpenClawConfig;
-    const { listImageGenerationProviders } = await loadProviderRegistry();
+    const { listImageGenerationProviders } = registry;
 
     expect(listImageGenerationProviders(cfg)).toStrictEqual([]);
     expect(resolvePluginCapabilityProvidersMock).toHaveBeenCalledWith({
@@ -90,11 +91,11 @@ describe("image-generation provider registry", () => {
     });
   });
 
-  it("uses active plugin providers without loading from disk", async () => {
+  it("resolves active providers through the capability boundary", () => {
     resolvePluginCapabilityProvidersMock.mockReturnValue([
       createImageProvider({ id: "custom-image" }),
     ]);
-    const { getImageGenerationProvider } = await loadProviderRegistry();
+    const { getImageGenerationProvider } = registry;
 
     const provider = getImageGenerationProvider("custom-image");
 
@@ -105,12 +106,11 @@ describe("image-generation provider registry", () => {
     });
   });
 
-  it("ignores prototype-like provider ids and aliases", async () => {
+  it("ignores prototype-like provider ids and aliases", () => {
     resolvePluginCapabilityProvidersMock.mockReturnValue([
       createImageProvider({ id: "__proto__", aliases: ["constructor", "prototype"] }),
       createImageProvider({ id: "safe-image", aliases: ["safe-alias", "constructor"] }),
     ]);
-    const registry = await loadProviderRegistry();
 
     expect(registry.listImageGenerationProviders().map((provider) => provider.id)).toEqual([
       "safe-image",
@@ -122,11 +122,11 @@ describe("image-generation provider registry", () => {
 });
 
 describe("video-generation provider registry", () => {
-  it("uses active plugin providers without loading from disk", async () => {
+  it("resolves active providers through the capability boundary", () => {
     resolvePluginCapabilityProvidersMock.mockReturnValue([
       createVideoProvider({ id: "custom-video" }),
     ]);
-    const { getVideoGenerationProvider } = await loadProviderRegistry();
+    const { getVideoGenerationProvider } = registry;
 
     const provider = getVideoGenerationProvider("custom-video");
 
@@ -137,12 +137,11 @@ describe("video-generation provider registry", () => {
     });
   });
 
-  it("ignores prototype-like provider ids and aliases", async () => {
+  it("ignores prototype-like provider ids and aliases", () => {
     resolvePluginCapabilityProvidersMock.mockReturnValue([
       createVideoProvider({ id: "__proto__", aliases: ["constructor", "prototype"] }),
       createVideoProvider({ id: "safe-video", aliases: ["safe-alias", "constructor"] }),
     ]);
-    const registry = await loadProviderRegistry();
 
     expect(registry.listVideoGenerationProviders().map((provider) => provider.id)).toEqual([
       "safe-video",


### PR DESCRIPTION
The registry suite resets its module cache twice per case even though the registry factory allocates its mutable provider maps on every call. Import the graph once per suite and keep each case's capability-mock reset. Synchronous lookup cases can then run synchronously.

All five cases and 14 assertions remain, including safe aliases, prototype-key rejection and configuration forwarding; the three shared-map sibling cases remain too. Two test titles now describe the mocked capability boundary they exercise, removing an unsupported claim about disk I/O.

All eight cases pass before and after through their existing test routes. Full changed checks pass; the final title-only correction also passes formatting, all eight cases and independent Codex autoreview. Module resets fall from ten to one and imports from five to one. Production is unchanged; tests shrink by one line. No elapsed-time gain is claimed.
