### PR TITLE
test(changelog): remove fixture-only Git config processes

### DIFF
--- a/test/scripts/check-changelog-attributions.test.ts
+++ b/test/scripts/check-changelog-attributions.test.ts
@@ -30,23 +30,23 @@ function commandOutput(error: unknown): string {
 
 function createRepoWithPrChangelogDiff(entry: string): string {
   const repo = mkdtempSync(path.join(os.tmpdir(), "openclaw-changelog-credit-"));
-  run(repo, "git", ["init", "-q", "--initial-branch=main"]);
-  run(repo, "git", ["config", "user.email", "test@example.com"]);
-  run(repo, "git", ["config", "user.name", "Test User"]);
+  const git = (args: string[]) =>
+    run(repo, "git", ["-c", "user.email=test@example.com", "-c", "user.name=Test User", ...args]);
+  git(["init", "-q", "--initial-branch=main"]);
   writeFileSync(repo + "/CHANGELOG.md", "# Changelog\n\n## Unreleased\n\n### Fixes\n\n", "utf8");
-  run(repo, "git", ["add", "CHANGELOG.md"]);
-  run(repo, "git", ["commit", "-qm", "seed"]);
-  const baseSha = run(repo, "git", ["rev-parse", "HEAD"]);
+  git(["add", "CHANGELOG.md"]);
+  git(["commit", "-qm", "seed"]);
+  const baseSha = git(["rev-parse", "HEAD"]);
   // Direct helper callers capture this base as the operation's main snapshot.
-  run(repo, "git", ["update-ref", "refs/remotes/origin/main", baseSha]);
-  run(repo, "git", ["checkout", "-qb", "feature"]);
+  git(["update-ref", "refs/remotes/origin/main", baseSha]);
+  git(["checkout", "-qb", "feature"]);
   writeFileSync(
     repo + "/CHANGELOG.md",
     `# Changelog\n\n## Unreleased\n\n### Fixes\n\n${entry}\n`,
     "utf8",
   );
-  run(repo, "git", ["add", "CHANGELOG.md"]);
-  run(repo, "git", ["commit", "-qm", "add changelog entry"]);
+  git(["add", "CHANGELOG.md"]);
+  git(["commit", "-qm", "add changelog entry"]);
   return repo;
 }
 


### PR DESCRIPTION
Five changelog-policy fixtures each start two Git processes solely to configure their test identity. Pass the same identity through the fixture-local git -c helper instead, removing ten config-only processes.

The fixtures still create real repositories, both commits, the captured main ref and a feature branch. All ten existing cases retain their actual Bash/Git policy calls and assertions, including ordinary changelog rejection and the explicit release-automation path. Operator Git configuration and production policy are unchanged.

All ten cases pass before and after. Full changed checks and independent Codex autoreview pass. Fixture setup starts 40 Git processes instead of 50; no elapsed-time gain is claimed.
