### PR TITLE
chore: prune Android screenshot source mirrors

### DIFF
--- a/test/scripts/android-screenshots.test.ts
+++ b/test/scripts/android-screenshots.test.ts
@@ -3,8 +3,6 @@ import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 
 const SCRIPT = "scripts/android-screenshots.sh";
-const SCREENSHOT_FIXTURE =
-  "apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotFixture.kt";
 
 function runAndroidScreenshots(args: string[], env: NodeJS.ProcessEnv = {}) {
   return spawnSync("bash", [SCRIPT, ...args], {
@@ -48,83 +46,26 @@ describe("android screenshots script", () => {
     expect(result.stdout).not.toContain(`Android screenshot artifacts: ${process.env.HOME}\n`);
   });
 
-  it("waits for fixture content unique to the chat, settings, and gateway screens", () => {
+  it("keeps fixture readiness and device restoration aligned", () => {
     const script = readFileSync(SCRIPT, "utf8");
-    const fixture = readFileSync(SCREENSHOT_FIXTURE, "utf8");
-
-    expect(script).toContain("chat) printf '%s\\n' \"Draft a short status update for the team.\"");
-    expect(script).not.toContain("chat) printf '%s\\n' \"Ready when you are\"");
-    expect(script).toContain('if [[ "$FORM_FACTOR" == "wear" ]]');
-    expect(script).toContain("voice) printf '%s\\n' \"Dictate\"");
-    expect(script).not.toContain("Ready to talk");
-    expect(fixture).toContain('"Draft a short status update for the team."');
-    expect(script).toContain("settings) printf '%s\\n' \"OpenClaw mobile\"");
-    expect(script).not.toContain("settings) printf '%s\\n' \"Settings\"");
-    expect(script).toContain(
-      "gateway) printf '%s\\n' \"Connection between this phone and OpenClaw.\"",
+    const fixture = readFileSync(
+      "apps/android/app/src/main/java/ai/openclaw/app/AndroidScreenshotFixture.kt",
+      "utf8",
     );
-    expect(script).not.toContain("gateway) printf '%s\\n' \"Add Gateway\"");
-  });
+    const chatReady = "Draft a short status update for the team.";
 
-  it("scales and restores display density with the screenshot size", () => {
-    const script = readFileSync(SCRIPT, "utf8");
-
-    expect(script).toContain('SCREENSHOT_SIZE="${ANDROID_SCREENSHOT_SIZE:-1440x2560}"');
-    expect(script).toContain('shell wm density "$SCREENSHOT_DENSITY"');
-    expect(script).toContain('shell wm density "$ORIGINAL_WM_DENSITY"');
-    expect(script).toContain("shell wm density reset");
-  });
-
-  it("pins the device timezone before rendering seeded timestamps", () => {
-    const script = readFileSync(SCRIPT, "utf8");
-    const requireEmulatorIndex = script.indexOf('require_emulator_device "$ADB_BIN" "$ADB_SERIAL"');
-    const stabilizeDeviceIndex = script.indexOf(
-      'stabilize_device_for_screenshots "$ADB_BIN" "$ADB_SERIAL"',
-    );
-
-    expect(script).toContain("shell cmd time_zone_detector set_auto_detection_enabled false");
-    expect(script).toContain("shell cmd alarm set-timezone UTC");
-    expect(script).toContain('shell cmd alarm set-timezone "$ORIGINAL_TIME_ZONE"');
-    expect(script).toContain(
+    expect(fixture).toContain(`"${chatReady}"`);
+    expect(script).toContain(`chat) printf '%s\\n' "${chatReady}"`);
+    for (const marker of [
+      'shell wm density "$ORIGINAL_WM_DENSITY"',
+      "shell wm density reset",
+      'shell cmd alarm set-timezone "$ORIGINAL_TIME_ZONE"',
       'shell cmd time_zone_detector set_auto_detection_enabled "$ORIGINAL_AUTO_TIME_ZONE"',
-    );
-    expect(requireEmulatorIndex).toBeGreaterThan(-1);
-    expect(stabilizeDeviceIndex).toBeGreaterThan(requireEmulatorIndex);
-  });
-
-  it("dismisses the first-run Wear charging overlay before checking scene readiness", () => {
-    const script = readFileSync(SCRIPT, "utf8");
-
-    expect(script).toContain("com.google.android.wearable.sysui:id/charging_container");
-    expect(script).toContain("shell input keyevent 4");
-  });
-
-  it("provisions a retained no-cutout screenshot emulator by default", () => {
-    const script = readFileSync(SCRIPT, "utf8");
-
-    expect(script).toContain('DEFAULT_SCREENSHOT_AVD="OpenClaw_Screenshots_API36"');
-    expect(script).toContain('DEFAULT_SCREENSHOT_DEVICE_PROFILE="pixel_2"');
-    expect(script).toContain('DEFAULT_WEAR_SCREENSHOT_AVD="OpenClaw_Wear_Screenshots_API34"');
-    expect(script).toContain('DEFAULT_WEAR_SCREENSHOT_DEVICE_PROFILE="wearos_large_round"');
-    expect(script).toContain('GRADLE_ASSEMBLE_TASK=":wear:assembleDebug"');
-    expect(script).toContain('OUTPUT_TYPE="wearScreenshots"');
-    expect(script).toContain('ensure_screenshot_avd "$avd"');
-    expect(script).toContain('--device "$SCREENSHOT_DEVICE_PROFILE"');
-    expect(script).toContain("is not the screenshot AVD");
-  });
-
-  it("prefers avdmanager from the configured SDK over an unrelated PATH install", () => {
-    const script = readFileSync(SCRIPT, "utf8");
-    const functionStart = script.indexOf("avdmanager_bin() {");
-    const sdkLookup = script.indexOf(
-      'for sdk_root in "${ANDROID_HOME:-}" "${ANDROID_SDK_ROOT:-}" "$HOME/Library/Android/sdk"; do',
-      functionStart,
-    );
-    const pathLookup = script.indexOf("if command -v avdmanager", functionStart);
-
-    expect(functionStart).toBeGreaterThan(-1);
-    expect(sdkLookup).toBeGreaterThan(functionStart);
-    expect(pathLookup).toBeGreaterThan(sdkLookup);
+      "com.google.android.wearable.sysui:id/charging_container",
+      "shell input keyevent 4",
+    ]) {
+      expect(script).toContain(marker);
+    }
   });
 
   it.each(["../escape", "en/US", ".hidden", "en..US", ""])(


### PR DESCRIPTION
## What Problem This Solves

The Android screenshot test carried broad shell and fixture source mirrors that duplicated implementation structure and caused churn. The useful contract is narrower: executable dry-run/input behavior plus the fixture readiness marker and device-restoration invariants that cannot run hermetically in this suite.

## Why This Change Was Made

Remove the broad source inventories while retaining a compact focused check connecting the chat fixture to `scene_ready_text` and preserving density, timezone, and Wear-overlay restoration markers.

## User Impact

No user-visible behavior changes. Android release behavior is unchanged, with executable validation and the device-only restoration contract retained.

## Evidence

- `pnpm test test/scripts/android-screenshots.test.ts` — 11 passed
- `node scripts/check-changed.mjs -- test/scripts/android-screenshots.test.ts`
- Structured autoreview: scoped clean, 0.94 confidence, no accepted/actionable findings

