### PR TITLE
test(release): use native checksums in ZIP fixtures

### DIFF
--- a/test/scripts/plugin-publication-artifact.test.ts
+++ b/test/scripts/plugin-publication-artifact.test.ts
@@ -11,7 +11,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { deflateRawSync, gzipSync } from "node:zlib";
+import { crc32, deflateRawSync, gzipSync } from "node:zlib";
 import * as tar from "tar";
 import { afterEach, describe, expect, it } from "vitest";
 import {
@@ -159,17 +159,6 @@ function paxRecord(key: string, value: string): Buffer {
     }
     length = actualLength;
   }
-}
-
-function crc32(bytes: Buffer): number {
-  let crc = 0xffffffff;
-  for (const byte of bytes) {
-    crc ^= byte;
-    for (let bit = 0; bit < 8; bit += 1) {
-      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
-    }
-  }
-  return (crc ^ 0xffffffff) >>> 0;
 }
 
 type ZipFile = {
@@ -1016,6 +1005,15 @@ describe("plugin publication artifact", () => {
     tampered[35] = tampered.readUInt8(35) ^ 0xff;
     writeFileSync(tamperFixture.zipPath, tampered);
     expect(() => verifyFixture(tamperFixture)).toThrow(/digest/u);
+  });
+
+  it("rejects changed ZIP payload bytes with matching header checksums", () => {
+    const zip = createZip([{ bytes: Buffer.from("payload"), name: "payload.txt" }]);
+    const dataOffset = 30 + Buffer.byteLength("payload.txt");
+    // Keep both header CRCs unchanged so corruption reaches the payload check.
+    zip[dataOffset] = zip.readUInt8(dataOffset) ^ 0xff;
+
+    expect(() => inspectTestZip(zip)).toThrow(/checksum mismatch for payload\.txt/u);
   });
 
   it("accepts canonical signed data descriptors and rejects noncanonical ZIP structure", () => {

--- a/test/scripts/release-beta-verifier.test.ts
+++ b/test/scripts/release-beta-verifier.test.ts
@@ -3,6 +3,7 @@
 import { createHash } from "node:crypto";
 import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
+import { crc32 } from "node:zlib";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
@@ -40,17 +41,6 @@ function captureCommandError(run: () => unknown): CommandError {
 
 function sha256(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
-}
-
-function crc32(bytes: Uint8Array): number {
-  let crc = 0xffffffff;
-  for (const byte of bytes) {
-    crc ^= byte;
-    for (let bit = 0; bit < 8; bit += 1) {
-      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
-    }
-  }
-  return (crc ^ 0xffffffff) >>> 0;
 }
 
 function createStoredZip(files: Array<{ name: string; bytes: Buffer }>): Buffer {

--- a/test/scripts/release-ci-summary.test.ts
+++ b/test/scripts/release-ci-summary.test.ts
@@ -4,6 +4,7 @@ import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync 
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
+import { crc32 } from "node:zlib";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { buildFullReleaseCandidateRequest } from "../../scripts/full-release-candidate-contract.mjs";
@@ -420,17 +421,6 @@ describe("Release Decision artifact polling", () => {
     }
   });
 });
-
-function crc32(input: Buffer): number {
-  let crc = 0xffffffff;
-  for (const byte of input) {
-    crc ^= byte;
-    for (let bit = 0; bit < 8; bit += 1) {
-      crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
-    }
-  }
-  return (crc ^ 0xffffffff) >>> 0;
-}
 
 function u16(value: number): Buffer {
   const buffer = Buffer.alloc(2);


### PR DESCRIPTION
Three release suites implement their own ZIP CRC32 loops. Use Node's existing native checksum function and retain each specialized archive builder, including intentional local-header and data-descriptor corruption controls. One unchanged 4 MiB+1 expansion-limit fixture alone avoids 67,108,880 JavaScript bit-loop iterations across its two checksum passes.

All 175 existing cases remain. An additional payload-corruption case changes a stored byte after both CRC headers are written and requires the real shared archive reader to reject it. Temporarily removing only that reader comparison makes the new case fail; restoring the exact owner bytes passes the publication suite. Real unzip, tar inspection, immutable publication identities, archive limits and subprocess deadlines remain covered.

The three suites pass 176 cases. The installed Node implementation/types and supported engine floors were checked, and five byte vectors match the removed algorithm. Full changed checks and independent Codex autoreview pass. Production is unchanged; tests are +12/-34. No elapsed-time improvement is claimed.

Follow-up: the beta verifier body-timeout fixture still has a zero-delay observation yield; replacing that signal is separate from checksum construction.
