### PR TITLE
fix(proxy): isolate webhook rate limits by client

### DIFF
--- a/extensions/telegram/src/miniapp/routes.ts
+++ b/extensions/telegram/src/miniapp/routes.ts
@@ -10,6 +10,7 @@ import type { OpenClawPluginApi } from "openclaw/plugin-sdk/plugin-entry";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import {
   createFixedWindowRateLimiter,
+  resolveRequestClientIp,
   WEBHOOK_RATE_LIMIT_DEFAULTS,
 } from "openclaw/plugin-sdk/webhook-ingress";
 import { readJsonWebhookBodyOrReject } from "openclaw/plugin-sdk/webhook-request-guards";
@@ -93,7 +94,13 @@ async function handleAuth(
     sendText(res, 415, "Unsupported media type");
     return;
   }
-  const ip = req.socket.remoteAddress ?? "unknown";
+  const cfg = currentConfig(api);
+  const ip =
+    resolveRequestClientIp(
+      req,
+      cfg.gateway?.trustedProxies,
+      cfg.gateway?.allowRealIpFallback === true,
+    ) ?? "unknown";
   if (!consumeRateLimit(ip)) {
     sendText(res, 429, "Too many requests");
     return;
@@ -117,7 +124,6 @@ async function handleAuth(
     return;
   }
   const accountId = normalizeAccountId(authBody.accountId ?? DEFAULT_ACCOUNT_ID);
-  const cfg = currentConfig(api);
   const account = resolveTelegramAccount({ cfg, accountId });
   const validated = validateTelegramMiniAppInitData({
     initData: authBody.initData,

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -23,7 +23,7 @@ import {
   isLocalDirectRequest,
   isLoopbackAddress,
   resolveLocalInterfaceAddressMatch,
-  resolveRequestClientIp,
+  resolveRequestClientIpFromHeaders,
   isTrustedProxyAddress,
 } from "./net.js";
 import { checkBrowserOrigin } from "./origin-check.js";
@@ -120,7 +120,7 @@ function resolveGatewayAuthRequestContext(
       : params.ingressAttribution;
   const fallbackIp =
     attributed?.clientIp ??
-    resolveRequestClientIp(req, trustedProxies, params.allowRealIpFallback === true) ??
+    resolveRequestClientIpFromHeaders(req, trustedProxies, params.allowRealIpFallback === true) ??
     req?.socket?.remoteAddress;
   const localDirect = attributed
     ? attributed.kind === "direct-local"

--- a/src/gateway/ingress-attribution.ts
+++ b/src/gateway/ingress-attribution.ts
@@ -6,7 +6,7 @@ import {
   isLoopbackAddress,
   isTrustedProxyAddress,
   resolveClientIp,
-  resolveRequestClientIp,
+  resolveRequestClientIpFromHeaders,
 } from "./net.js";
 
 export const PROXY_ATTRIBUTION_REQUIRED_REASON = "proxy_attribution_required";
@@ -226,7 +226,7 @@ function resolveGatewayIngressAttribution(params: {
     return attributed("direct-local", remoteAddress);
   }
   if (isTrustedProxyAddress(remoteAddress, params.trustedProxies)) {
-    const clientIp = resolveRequestClientIp(
+    const clientIp = resolveRequestClientIpFromHeaders(
       req,
       params.trustedProxies,
       params.allowRealIpFallback === true,

--- a/src/gateway/net.ts
+++ b/src/gateway/net.ts
@@ -243,7 +243,7 @@ function headerValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
 }
 
-export function resolveRequestClientIp(
+export function resolveRequestClientIpFromHeaders(
   req?: IncomingMessage,
   trustedProxies?: string[],
   allowRealIpFallback = false,

--- a/src/gateway/server/hooks-request-handler.ts
+++ b/src/gateway/server/hooks-request-handler.ts
@@ -37,7 +37,7 @@ import {
 } from "../hooks.js";
 import { sendJson } from "../http-common.js";
 import { readPreparedGatewayIngressAttribution } from "../ingress-attribution.js";
-import { resolveRequestClientIp } from "../net.js";
+import { resolveRequestClientIpFromHeaders } from "../net.js";
 import { DEDUPE_MAX, DEDUPE_TTL_MS } from "../server-constants.js";
 
 type SubsystemLogger = ReturnType<typeof createSubsystemLogger>;
@@ -209,7 +209,7 @@ export function createHooksRequestHandler(
     }
     const clientIpConfig = getClientIpConfig?.();
     const clientIp =
-      resolveRequestClientIp(
+      resolveRequestClientIpFromHeaders(
         req,
         clientIpConfig?.trustedProxies,
         clientIpConfig?.allowRealIpFallback === true,

--- a/src/gateway/watch-node-http.ts
+++ b/src/gateway/watch-node-http.ts
@@ -67,7 +67,11 @@ import {
 } from "./http-common.js";
 import { readPreparedGatewayIngressAttribution } from "./ingress-attribution.js";
 import { ADMIN_SCOPE, PAIRING_SCOPE, WRITE_SCOPE } from "./method-scopes.js";
-import { hasForwardedRequestHeaders, isLoopbackAddress, resolveRequestClientIp } from "./net.js";
+import {
+  hasForwardedRequestHeaders,
+  isLoopbackAddress,
+  resolveRequestClientIpFromHeaders,
+} from "./net.js";
 import { resolveEffectiveComputerUseDescriptor } from "./node-computer-use-descriptor.js";
 import { reconcileNodePairingOnConnect } from "./node-connect-reconcile.js";
 import type { NodeReapprovalCoordinator } from "./node-reapproval-coordinator.js";
@@ -173,7 +177,7 @@ function resolveWatchClientAddress(
     };
   }
   const trustedProxies = config.gateway?.trustedProxies ?? [];
-  const clientIp = resolveRequestClientIp(
+  const clientIp = resolveRequestClientIpFromHeaders(
     req,
     trustedProxies,
     config.gateway?.allowRealIpFallback === true,

--- a/src/plugin-sdk/webhook-ingress.test.ts
+++ b/src/plugin-sdk/webhook-ingress.test.ts
@@ -1,0 +1,29 @@
+import type { IncomingMessage } from "node:http";
+import { describe, expect, it } from "vitest";
+import { withPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
+import { resolveRequestClientIp } from "./webhook-ingress.js";
+
+function request(): IncomingMessage {
+  return {
+    headers: { "x-forwarded-for": "192.0.2.99" },
+    socket: { remoteAddress: "127.0.0.1" },
+  } as unknown as IncomingMessage;
+}
+
+describe("resolveRequestClientIp", () => {
+  it("prefers Gateway-validated attribution over raw proxy headers", () => {
+    const clientIp = withPluginRuntimeGatewayRequestScope(
+      {
+        client: { clientIp: "198.51.100.42" } as never,
+        isWebchatConnect: () => false,
+      },
+      () => resolveRequestClientIp(request(), ["127.0.0.1"]),
+    );
+
+    expect(clientIp).toBe("198.51.100.42");
+  });
+
+  it("retains configured-proxy resolution outside Gateway request scope", () => {
+    expect(resolveRequestClientIp(request(), ["127.0.0.1"])).toBe("192.0.2.99");
+  });
+});

--- a/src/plugin-sdk/webhook-ingress.ts
+++ b/src/plugin-sdk/webhook-ingress.ts
@@ -1,6 +1,10 @@
 /**
  * Public SDK subpath for webhook ingress guards, targets, and request helpers.
  */
+import type { IncomingMessage } from "node:http";
+import { resolveRequestClientIpFromHeaders } from "../gateway/net.js";
+import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
+
 export {
   createBoundedCounter,
   createFixedWindowRateLimiter,
@@ -45,7 +49,17 @@ export {
   type RegisteredWebhookTarget,
   type WebhookTargetMatchResult,
 } from "./webhook-targets.js";
-export { resolveRequestClientIp } from "../gateway/net.js";
+export function resolveRequestClientIp(
+  req?: IncomingMessage,
+  trustedProxies?: string[],
+  allowRealIpFallback = false,
+): string | undefined {
+  // The Gateway validates managed ingress before plugin dispatch; raw requests remain fallback.
+  return (
+    getPluginRuntimeGatewayRequestScope()?.client?.clientIp ??
+    resolveRequestClientIpFromHeaders(req, trustedProxies, allowRealIpFallback)
+  );
+}
 export { createAuthRateLimiter } from "../gateway/auth-rate-limit.js";
 export type { AuthRateLimiter, RateLimitConfig } from "../gateway/auth-rate-limit.js";
 export { rawDataToString } from "../infra/ws.js";


### PR DESCRIPTION
## Summary

Prefer Gateway-validated client attribution when plugin webhook surfaces choose rate-limit subjects, preventing unrelated clients behind managed proxy ingress from sharing one quota.

## Changes

- make the existing public webhook client-IP resolver consume validated Gateway request scope before its raw-header fallback
- rename the internal raw-header resolver to distinguish it from the behavior-complete SDK helper
- migrate Telegram Mini App authentication to the shared resolver
- add regression coverage for validated attribution and direct trusted-proxy fallback

## Validation

- `node scripts/check-changed.mjs --base upstream/main`
- `corepack pnpm plugin-sdk:surface:check`
- `corepack pnpm build`
- 170 focused Gateway and SDK tests, including ingress attribution, runtime scope propagation, managed Funnel isolation, authentication, hooks, and Watch HTTP
- 73 focused plugin route tests across Discord Activities, Google Chat, Telegram Mini App, and TaskFlow webhooks
- pre-fix regression confirmed raw proxy attribution won; repaired regression confirms validated Gateway attribution wins while outside-scope fallback is preserved
- exact-head hosted CI: 252 successful checks, zero failures, zero pending

## Notes

- no configuration, protocol, persistence, dependency, or public API signature changes
- production delta: +24/-12 across seven files; test delta: +29
- merge-risk decision: retain the one canonical SDK resolver because it is the behavior owner that can combine Gateway-validated attribution with the existing direct-handler fallback; moving this policy into individual plugins would duplicate it, while importing plugin request scope into the low-level Gateway network module would invert the core/plugin boundary
- the positive production delta is therefore justified by the security invariant and owner boundary; the implementation removes the old same-name raw resolver ambiguity and adds no parallel policy, compatibility shim, or fallback stack
