### PR TITLE
test(memory): remove duplicate nested batch error case

### DIFF
--- a/packages/memory-host-sdk/src/host/batch-error-utils.test.ts
+++ b/packages/memory-host-sdk/src/host/batch-error-utils.test.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK tests cover batch error utils behavior.
 import { describe, expect, it } from "vitest";
 import {
   EmbeddingBatchUnavailableError,
@@ -9,19 +8,13 @@ import {
 } from "../engine-embeddings.js";
 
 describe("extractBatchErrorMessage", () => {
-  it("returns the first top-level error message", () => {
+  it("preserves line order when nested errors precede top-level errors", () => {
     expect(
       extractBatchErrorMessage([
         { response: { body: { error: { message: "nested" } } } },
         { error: { message: "top-level" } },
       ]),
     ).toBe("nested");
-  });
-
-  it("falls back to nested response error message", () => {
-    expect(
-      extractBatchErrorMessage([{ response: { body: { error: { message: "nested-only" } } } }, {}]),
-    ).toBe("nested-only");
   });
 
   it("accepts plain string response bodies", () => {


### PR DESCRIPTION
## What Problem This Solves

Two batch-error tests exercise the same nested-message extraction from the first result. One adds an empty trailing result that is never inspected; the other also proves that a later top-level error cannot override the earlier nested error.

## Why This Change Was Made

Keep the stronger line-order case and give it an accurate name. Remove the weaker duplicate and generic test-file header. Production and test support are unchanged; tests shrink by seven lines, from eight cases to seven.

## Evidence

The full file passed before and after. A controlled fault removing only nested object-body message support caused both old cases to fail, and the retained renamed case still failed after cleanup at the same expected nested-versus-top-level assertion. The production owner was restored before the passing after run. Remaining security redaction, length, UTF-16 and provider-fallback cases are unchanged.

All 19 normal changed checks passed, including formatting, core test types, boundary checks, dead-export scans and targeted lint. Managed review found no accepted findings in its selected P0 scope; a separate source and fault-proof audit confirmed the retained coverage. No runtime, performance or live-provider behavior change is claimed.
