### PR TITLE
fix: avoid loading the agent runtime for provider auth selection

### DIFF
--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -206,6 +206,13 @@ catalog, API-key auth, and dynamic model resolution.
     `openclaw onboard --acme-ai-api-key <key>` and select
     `acme-ai/acme-large` as their model.
 
+    For provider-key lookup and selection from an already loaded auth store,
+    import `findNormalizedProviderValue` and `resolveAuthProfileOrder` from
+    `openclaw/plugin-sdk/provider-auth`. This keeps provider entrypoints from
+    loading the full agent runtime just to select a credential. The deprecated
+    `agent-runtime` exports remain available for compatibility; use the narrower
+    `provider-auth` route in new code.
+
     A custom interactive auth method that mints a static token or API key can
     request protected persistence on its returned profile:
 

--- a/extensions/codex/src/app-server/auth-bridge.ts
+++ b/extensions/codex/src/app-server/auth-bridge.ts
@@ -12,7 +12,6 @@ import {
   findPersistedAuthProfileCredential,
   loadAuthProfileStoreForSecretsRuntime,
   refreshOAuthCredentialForRuntime,
-  resolveAuthProfileOrder,
   resolveProviderIdForAuth,
   resolveApiKeyForProfile,
   resolveDefaultAgentDir,
@@ -23,6 +22,7 @@ import {
 } from "openclaw/plugin-sdk/agent-runtime";
 import {
   hasUsableOAuthCredential,
+  resolveAuthProfileOrder,
   resolveOpenAICodexAuthIdentity,
 } from "openclaw/plugin-sdk/provider-auth";
 import { readSecretFile } from "openclaw/plugin-sdk/secret-file";

--- a/extensions/codex/src/command-account.ts
+++ b/extensions/codex/src/command-account.ts
@@ -1,15 +1,17 @@
 // Codex plugin module implements command account behavior.
 import {
   ensureAuthProfileStore,
-  findNormalizedProviderValue,
   resolveAuthProfileEligibility,
-  resolveAuthProfileOrder,
   resolveProfileUnusableUntilForDisplay,
   type AuthProfileCredential,
   type AuthProfileFailureReason,
   type AuthProfileStore,
 } from "openclaw/plugin-sdk/agent-runtime";
 import type { PluginCommandContext } from "openclaw/plugin-sdk/plugin-entry";
+import {
+  findNormalizedProviderValue,
+  resolveAuthProfileOrder,
+} from "openclaw/plugin-sdk/provider-auth";
 import {
   normalizeOptionalString,
   normalizeUniqueStringEntries,

--- a/extensions/codex/src/conversation-binding.test.ts
+++ b/extensions/codex/src/conversation-binding.test.ts
@@ -41,13 +41,16 @@ const agentRuntimeMocks = vi.hoisted(() => ({
   ensureAuthProfileStore: vi.fn(),
   loadAuthProfileStoreForSecretsRuntime: vi.fn(),
   resolveApiKeyForProfile: vi.fn(),
-  resolveAuthProfileOrder: vi.fn(),
   resolveDefaultAgentDir: vi.fn(() => "/agent"),
   resolveAgentWorkspaceDir: vi.fn(() => "/agent/workspace"),
   resolvePersistedAuthProfileOwnerAgentDir: vi.fn(),
   resolveProviderIdForAuth: vi.fn((provider: string, _lookup?: { config?: unknown }) => provider),
   resolveSessionAgentIdsStrict: vi.fn(() => ({ defaultAgentId: "main", sessionAgentId: "main" })),
   saveAuthProfileStore: vi.fn(),
+}));
+
+const providerAuthMocks = vi.hoisted(() => ({
+  resolveAuthProfileOrder: vi.fn(),
 }));
 
 const codexRequirementsTomlMock = vi.hoisted(() => vi.fn<() => string | undefined>());
@@ -131,6 +134,10 @@ vi.mock("openclaw/plugin-sdk/exec-approvals-runtime", async (importOriginal) => 
   };
 });
 vi.mock("openclaw/plugin-sdk/agent-runtime", () => agentRuntimeMocks);
+vi.mock("openclaw/plugin-sdk/provider-auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/provider-auth")>()),
+  resolveAuthProfileOrder: providerAuthMocks.resolveAuthProfileOrder,
+}));
 vi.mock("openclaw/plugin-sdk/agent-scope-runtime", async (importOriginal) => ({
   ...(await importOriginal<typeof import("openclaw/plugin-sdk/agent-scope-runtime")>()),
   resolveSessionAgentIdsStrict: agentRuntimeMocks.resolveSessionAgentIdsStrict,
@@ -426,7 +433,7 @@ describe("codex conversation binding", () => {
     agentRuntimeMocks.ensureAuthProfileStore.mockReset();
     agentRuntimeMocks.loadAuthProfileStoreForSecretsRuntime.mockReset();
     agentRuntimeMocks.resolveApiKeyForProfile.mockReset();
-    agentRuntimeMocks.resolveAuthProfileOrder.mockReset();
+    providerAuthMocks.resolveAuthProfileOrder.mockReset();
     agentRuntimeMocks.resolveDefaultAgentDir.mockClear();
     agentRuntimeMocks.resolvePersistedAuthProfileOwnerAgentDir.mockReset();
     agentRuntimeMocks.resolveProviderIdForAuth.mockClear();
@@ -443,7 +450,7 @@ describe("codex conversation binding", () => {
       version: 1,
       profiles: {},
     });
-    agentRuntimeMocks.resolveAuthProfileOrder.mockReturnValue([]);
+    providerAuthMocks.resolveAuthProfileOrder.mockReturnValue([]);
     agentRuntimeMocks.resolveDefaultAgentDir.mockReturnValue("/agent");
     agentRuntimeMocks.resolveProviderIdForAuth.mockImplementation(
       (provider: string, _lookup?: { config?: unknown }) => provider,
@@ -720,7 +727,7 @@ describe("codex conversation binding", () => {
         },
       },
     });
-    agentRuntimeMocks.resolveAuthProfileOrder.mockReturnValue(["openai:default"]);
+    providerAuthMocks.resolveAuthProfileOrder.mockReturnValue(["openai:default"]);
     sharedClientMocks.getSharedCodexAppServerClient.mockResolvedValue({
       request: vi.fn(async (method: string, requestParams: Record<string, unknown>) => {
         requests.push({ method, params: requestParams });
@@ -740,7 +747,7 @@ describe("codex conversation binding", () => {
       modelProvider: "openai",
     });
 
-    const authOrderParams = mockCallArg(agentRuntimeMocks.resolveAuthProfileOrder) as {
+    const authOrderParams = mockCallArg(providerAuthMocks.resolveAuthProfileOrder) as {
       cfg?: unknown;
       provider?: unknown;
     };

--- a/extensions/github-copilot/auth.test.ts
+++ b/extensions/github-copilot/auth.test.ts
@@ -8,13 +8,17 @@ const coerceSecretRefMock = vi.hoisted(() => vi.fn());
 const resolveConfiguredSecretInputWithFallbackMock = vi.hoisted(() => vi.fn());
 const resolveRequiredConfiguredSecretRefInputStringMock = vi.hoisted(() => vi.fn());
 
-vi.mock("openclaw/plugin-sdk/provider-auth", async () => {
+vi.mock("openclaw/plugin-sdk/provider-auth", async (importOriginal) => {
+  const { findNormalizedProviderValue, resolveAuthProfileOrder } =
+    await importOriginal<typeof import("openclaw/plugin-sdk/provider-auth")>();
   const { normalizeOptionalString } = await import("openclaw/plugin-sdk/string-coerce-runtime");
   return {
     coerceSecretRef: coerceSecretRefMock,
     ensureAuthProfileStore: ensureAuthProfileStoreMock,
+    findNormalizedProviderValue,
     listProfilesForProvider: listProfilesForProviderMock,
     normalizeOptionalSecretInput: normalizeOptionalString,
+    resolveAuthProfileOrder,
   };
 });
 

--- a/extensions/github-copilot/auth.ts
+++ b/extensions/github-copilot/auth.ts
@@ -1,15 +1,13 @@
 // Github Copilot plugin module implements auth behavior.
-import {
-  findNormalizedProviderValue,
-  resolveAuthProfileOrder,
-} from "openclaw/plugin-sdk/agent-runtime";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import type { ProviderPrepareDynamicModelContext } from "openclaw/plugin-sdk/plugin-entry";
 import {
   coerceSecretRef,
   ensureAuthProfileStore,
+  findNormalizedProviderValue,
   listProfilesForProvider,
   normalizeOptionalSecretInput,
+  resolveAuthProfileOrder,
 } from "openclaw/plugin-sdk/provider-auth";
 import {
   resolveConfiguredSecretInputWithFallback,

--- a/scripts/plugin-sdk-surface-report.mts
+++ b/scripts/plugin-sdk-surface-report.mts
@@ -329,7 +329,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: strict session-agent resolution aliases preserve shipped Plugin SDK behavior.
       // +1: manifest-owned plugin capability secret availability guard.
       // +1: canonical diagnostic flag checker through its focused subpath.
-      4353,
+      // +2: focused provider-auth routes for shipped auth ordering and provider-map lookup.
+      4355,
       env,
     ),
     publicFunctionExports: readPluginSdkSurfaceBudgetEnv(
@@ -435,7 +436,8 @@ export function readPluginSdkSurfaceBudgets(env: NodeJS.ProcessEnv = process.env
       // +2: strict session-agent resolution aliases preserve shipped Plugin SDK behavior.
       // +1: manifest-owned plugin capability secret availability guard.
       // +1: canonical diagnostic flag checker through its focused subpath.
-      2591,
+      // +2: focused provider-auth routes for shipped auth ordering and provider-map lookup.
+      2593,
       env,
     ),
     publicDeprecatedExports: readPluginSdkSurfaceBudgetEnv(

--- a/src/plugin-sdk/provider-auth.ts
+++ b/src/plugin-sdk/provider-auth.ts
@@ -54,7 +54,8 @@ export type { ProviderAuthResult } from "../plugins/types.js";
 export type { ProviderAuthContext } from "../plugins/types.js";
 export type { AuthProfileStore, OAuthCredential } from "../agents/auth-profiles/types.js";
 
-export { normalizeGithubCopilotDomain };
+export { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
+export { normalizeGithubCopilotDomain, resolveAuthProfileOrder };
 export { CLAUDE_CLI_PROFILE_ID, CODEX_CLI_PROFILE_ID } from "../agents/auth-profiles/constants.js";
 export {
   ensureAuthProfileStore,

--- a/src/plugin-sdk/test-helpers/provider-discovery-contract.ts
+++ b/src/plugin-sdk/test-helpers/provider-discovery-contract.ts
@@ -138,15 +138,9 @@ function providerModelIds(provider: Record<string, unknown>): Array<unknown> {
 function installDiscoveryHooks(state: DiscoveryState, options: DiscoveryContractOptions) {
   beforeAll(async () => {
     vi.resetModules();
-    vi.doMock("openclaw/plugin-sdk/agent-runtime", async (importOriginal) => {
-      const actual = await importOriginal<typeof import("../agent-runtime.js")>();
-      return {
-        ...actual,
-        ensureAuthProfileStore: ensureAuthProfileStoreMock,
-        listProfilesForProvider: listProfilesForProviderMock,
-      };
-    });
-    vi.doMock("openclaw/plugin-sdk/provider-auth", () => {
+    vi.doMock("openclaw/plugin-sdk/provider-auth", async (importOriginal) => {
+      const { findNormalizedProviderValue, resolveAuthProfileOrder } =
+        await importOriginal<typeof import("../provider-auth.js")>();
       return {
         DEFAULT_COPILOT_API_BASE_URL: "https://api.individual.githubcopilot.com",
         MINIMAX_OAUTH_MARKER: "minimax-oauth",
@@ -169,6 +163,7 @@ function installDiscoveryHooks(state: DiscoveryState, options: DiscoveryContract
         coerceSecretRef: asNullableRecord,
         ensureApiKeyFromOptionEnvOrPrompt: vi.fn(),
         ensureAuthProfileStore: ensureAuthProfileStoreMock,
+        findNormalizedProviderValue,
         listProfilesForProvider: listProfilesForProviderMock,
         normalizeApiKeyInput: (value: unknown) => (typeof value === "string" ? value.trim() : ""),
         normalizeGithubCopilotDomain: (raw: unknown) => {
@@ -178,6 +173,7 @@ function installDiscoveryHooks(state: DiscoveryState, options: DiscoveryContract
             : "github.com";
         },
         normalizeOptionalSecretInput: normalizeOptionalString,
+        resolveAuthProfileOrder,
         resolveNonEnvSecretRefApiKeyMarker: (source: unknown) =>
           typeof source === "string" ? source : "",
         upsertAuthProfile: vi.fn(),


### PR DESCRIPTION
Related: #130706.

## What Problem This Solves

Loading the GitHub Copilot plugin pulled in the broad agent runtime merely to select from an already-loaded auth store. That import sits on plugin discovery and contributed avoidable cold-load memory in the Gateway investigation.

## Why This Change Was Made

Copilot now imports two existing generic helpers through its already-used `provider-auth` SDK entrypoint. Both bundled Codex consumers use that preferred route too. The implementation reuses the existing auth-order binding and pure provider-map lookup; it adds no auth logic, settings, dependencies or credential writes.

The old `agent-runtime` exports remain available because they shipped in stable releases, including v2026.8.1 and v2026.7.1-2. The documented additive route is accepted as part of this maintainer refactor; no third-party migration is required. Existing tests and shared fixtures follow the new import boundary without weakening behavior assertions.

## Evidence

Source: `f2f3f770c3a3b0c32aba1ce69afbfbeccd344409`, based on main `b61485c193bb3e8581dc045821c2f9532ae9cf25`. None of the nine changed files or their immediate auth-order/provider-map owners changed on main through `d48e737b3745f5b00c0d7d3e7dbf1a778fb1e3a2`.

- 479 tests passed across 22 distinct files: 464 owner/sibling cases, 10 unchanged SDK budget cases, and five Doctor cases. The full changed gate passed, including typechecks, SDK checks and zero runtime value import cycles.
- The initial SDK surface check correctly rejected two unaccounted exports. The final hand-maintained counters account for exactly two exports and two callable exports, with no spare headroom. Budget rejection tests are unchanged; no override or suppression.
- Managed Codex P0 autoreview found no actionable findings at that threshold. This is not an all-priority automated-review claim.
- An ordinary full candidate build passed. The same isolated profiler loaded the actual built Copilot entry before and after, with Node 24.19.0, compile cache disabled and identical options.
- Maximum RSS fell from **596.641 MiB to 377.313 MiB**, a **219.328 MiB reduction**. Empty-child baselines were 46.297 and 46.250 MiB. This is one matched pair, not a statistical benchmark or a whole-Gateway CPU result. Source and built outputs stayed unchanged during profiling; all observed processes and fixture roots drained.
- The candidate inventory retained SDK declarations produced by the earlier changed gate; those files were unchanged and outside the profiler's selected root entry. No pristine-output-shape equivalence is claimed.
- The canonical SDK renderer and comparison cover all 147 public entrypoints at both commits: exactly two added exports (`findNormalizedProviderValue` and `resolveAuthProfileOrder` on `provider-auth`), zero removed exports, zero changed signatures or reachable declarations. Digest: `abd38d52`. Both renderers exited 0 and drained. The first full-CLI attempt timed out during temporary-checkout/dependency provisioning; the successful comparison used the same unmodified renderer sequentially on clean commits in the existing private checkout, whose dependency manifests and renderer sources are identical across these commits. No API surface was filtered. The ordinary PR CI report job intentionally skips rendering, so its green status is not counted as this proof.
- Exact-head CI [33459825806](https://github.com/openclaw/openclaw/actions/runs/33459825806) and the required CI gate passed. The latest ClawSweeper review found no actionable code issue; its additive-SDK-route acknowledgement and CI requirements are addressed here.

## Scope and Risk

Production **+9/-8 = +1 line**, with no added executable function statements. Tests/support **+22/-15 = +7**; SDK policy tooling **+4/-2 = +2**; docs **+7**. No new test files or production test seams.

Auth ordering, credential persistence, model behavior and old public imports are preserved. This cut does not resolve the entire Gateway CPU/stall incident. No authenticated-provider or Telegram proof is claimed; external Telegram proof was waived for this investigation. Changelogs are written at release time.

