### PR TITLE
fix(release): run frozen package checks from trusted sparse tooling

### DIFF
--- a/scripts/fixtures/packed-plugin-sdk-type-smoke.ts
+++ b/scripts/fixtures/packed-plugin-sdk-type-smoke.ts
@@ -1,6 +1,5 @@
 // Packed Plugin Sdk Type Smoke script supports OpenClaw repository automation.
 import type { ChannelMessagingAdapter } from "openclaw/plugin-sdk/core";
-import { inspectSessionBindingByConversation } from "openclaw/plugin-sdk/session-binding-runtime";
 type PublicPluginSdkModules = [
   typeof import("openclaw/plugin-sdk/core"),
   typeof import("openclaw/plugin-sdk/channel-entry-contract"),
@@ -10,17 +9,9 @@ type PublicPluginSdkModules = [
 ];
 
 const resolvedModules = null as unknown as PublicPluginSdkModules;
-const routeOwnerResolver: NonNullable<ChannelMessagingAdapter["resolveConversationRouteOwner"]> = ({
-  accountId,
-  conversation,
-}) => {
-  const inspection = inspectSessionBindingByConversation({
-    channel: "fixture-channel",
-    accountId,
-    conversationId: conversation.target ?? conversation.peerId,
-  });
-  return inspection.status === "unavailable" ? { kind: "unavailable" } : undefined;
-};
+const routeOwnerResolver: NonNullable<
+  ChannelMessagingAdapter["resolveConversationRouteOwner"]
+> = () => ({ kind: "unavailable" });
 
 void resolvedModules;
 void routeOwnerResolver;

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -206,8 +206,10 @@ export const PACKED_COMPLETION_SMOKE_ARGS = [
   "--shell",
   "zsh",
 ] as const;
-const PACKED_PLUGIN_SDK_TYPESCRIPT_SMOKE_FIXTURE = resolve(
-  "scripts/fixtures/packed-plugin-sdk-type-smoke.ts",
+// The checker owns fixture bytes; the target checkout supplies package metadata.
+const PACKED_PLUGIN_SDK_TYPESCRIPT_SMOKE_FIXTURE = new URL(
+  "./fixtures/packed-plugin-sdk-type-smoke.ts",
+  import.meta.url,
 );
 
 export function runReleaseCheckCommand(
@@ -1395,14 +1397,7 @@ async function main() {
   const files = results.flatMap((entry) => entry.files ?? []);
   const paths = new Set(files.map((file) => file.path));
 
-  const missing = requiredPathGroups
-    .flatMap((group) => {
-      if (Array.isArray(group)) {
-        return group.some((path) => paths.has(path)) ? [] : [group.join(" or ")];
-      }
-      return paths.has(group) ? [] : [group];
-    })
-    .toSorted((left, right) => left.localeCompare(right));
+  const missing = collectMissingPackPaths(paths);
   const forbidden = collectForbiddenPackPaths(paths);
   const forbiddenContent = collectForbiddenPackContentPaths(paths);
   const sizeErrors = collectNpmPackUnpackedSizeErrors(results);

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -45,6 +45,7 @@ import {
   listPluginSdkDistArtifacts,
   listUnpackagedPrivatePluginSdkDistArtifacts,
 } from "./lib/plugin-sdk-entries.mts";
+import { listStaticExtensionAssetOutputs } from "./lib/static-extension-assets.mts";
 import {
   runInstalledWorkspaceBootstrapSmoke,
   WORKSPACE_TEMPLATE_PACK_PATHS,
@@ -55,7 +56,6 @@ import {
   normalizeInstalledBinaryVersion,
 } from "./openclaw-npm-postpublish-verify.ts";
 import { resolvePnpmRunner } from "./pnpm-runner.mts";
-import { listStaticExtensionAssetOutputs } from "./runtime-postbuild.mts";
 import { sparkleBuildFloorsFromShortVersion, type SparkleBuildFloors } from "./sparkle-build.ts";
 import { buildCmdExeCommandLine, resolveWindowsCmdExePath } from "./windows-cmd-helpers.mjs";
 

--- a/test/release-check.test.ts
+++ b/test/release-check.test.ts
@@ -886,7 +886,6 @@ describe("createPackedPluginSdkTypescriptSmokeProject", () => {
       expect(source).toContain('"openclaw/plugin-sdk/channel-entry-contract"');
       expect(source).toContain('"openclaw/plugin-sdk/config-contracts"');
       expect(source).toContain('"openclaw/plugin-sdk/runtime-env"');
-      expect(source).toContain('"openclaw/plugin-sdk/session-binding-runtime"');
       expect(source).toContain("type PublicPluginSdkModules = [");
       expect(source).not.toContain("TelegramAccountConfig");
       expect(source).not.toContain("openclaw/plugin-sdk/channel-contract-testing");

--- a/test/scripts/release-check.test.ts
+++ b/test/scripts/release-check.test.ts
@@ -68,6 +68,11 @@ describe("release-check", () => {
         join(root, "scripts/lib/plugin-sdk-private-local-only-subpaths.json"),
         JSON.stringify(["target-private"]),
       );
+      mkdirSync(join(root, "scripts", "fixtures"));
+      writeFileSync(
+        join(root, "scripts/fixtures/packed-plugin-sdk-type-smoke.ts"),
+        "stale target fixture",
+      );
       const moduleUrl = pathToFileURL(join(toolingRoot, "scripts/release-check.ts")).href;
       const output = execFileSync(
         process.execPath,
@@ -76,8 +81,10 @@ describe("release-check", () => {
           join(toolingRoot, "scripts/tsx.mjs"),
           "--input-type=module",
           "--eval",
-          `const { collectForbiddenPackPaths, collectMissingPackPaths } = await import(${JSON.stringify(moduleUrl)});\n` +
-            `console.log(JSON.stringify({ forbidden: collectForbiddenPackPaths(["dist/plugin-sdk/target-private.d.ts", "dist/plugin-sdk/target-public.d.ts"]), required: collectMissingPackPaths([]).filter(path => path.startsWith("dist/plugin-sdk/")) }));`,
+          `import { readFileSync } from "node:fs";\n` +
+            `const { collectForbiddenPackPaths, collectMissingPackPaths, createPackedPluginSdkTypescriptSmokeProject } = await import(${JSON.stringify(moduleUrl)});\n` +
+            `createPackedPluginSdkTypescriptSmokeProject({ consumerDir: "consumer", packageSpec: "file:fixture.tgz" });\n` +
+            `console.log(JSON.stringify({ forbidden: collectForbiddenPackPaths(["dist/plugin-sdk/target-private.d.ts", "dist/plugin-sdk/target-public.d.ts"]), required: collectMissingPackPaths([]).filter(path => path.startsWith("dist/plugin-sdk/")), fixture: readFileSync("consumer/src/index.ts", "utf8") }));`,
         ],
         {
           cwd: root,
@@ -86,6 +93,10 @@ describe("release-check", () => {
         },
       );
       expect(JSON.parse(output)).toEqual({
+        fixture: readFileSync(
+          join(toolingRoot, "scripts/fixtures/packed-plugin-sdk-type-smoke.ts"),
+          "utf8",
+        ),
         forbidden: ["dist/plugin-sdk/target-private.d.ts"],
         required: [
           "dist/plugin-sdk/target-private.js",

--- a/test/scripts/release-check.test.ts
+++ b/test/scripts/release-check.test.ts
@@ -1,10 +1,19 @@
 // Release Check tests cover release check script behavior.
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
 import {
   collectRootPackageExcludedExtensionDirs,
   listBundledPluginPackArtifacts,
@@ -26,9 +35,28 @@ function requirePluginEntries(config: { plugins?: { entries?: Record<string, unk
 }
 
 describe("release-check", () => {
-  it("checks target SDK inventory when release tooling lives in another checkout", () => {
+  it("loads sparse release tooling and checks the separate target SDK inventory", () => {
     const root = mkdtempSync(join(tmpdir(), "openclaw-release-check-target-"));
     try {
+      const toolingRoot = join(root, "tooling");
+      const workflow = parse(readFileSync(".github/workflows/openclaw-npm-release.yml", "utf8"));
+      const checkout = workflow.jobs.preflight_openclaw_npm.steps.find(
+        (step: { name?: string }) => step.name === "Checkout trusted Plugin SDK API tooling",
+      );
+      const sparseRoots = checkout.with["sparse-checkout"].trim().split(/\s+/u) as string[];
+      const trackedPaths = execFileSync(
+        "git",
+        ["ls-files", "-z", "--", ":(top,glob)*", ...sparseRoots],
+        { encoding: "utf8", maxBuffer: 10 * 1024 * 1024 },
+      )
+        .split("\0")
+        .filter(Boolean);
+      for (const relativePath of trackedPaths) {
+        const destination = join(toolingRoot, relativePath);
+        mkdirSync(dirname(destination), { recursive: true });
+        copyFileSync(relativePath, destination);
+      }
+      symlinkSync(resolve("node_modules"), join(toolingRoot, "node_modules"), "junction");
       mkdirSync(join(root, "scripts", "lib"), { recursive: true });
       mkdirSync(join(root, "extensions"));
       writeFileSync(join(root, "package.json"), JSON.stringify({ files: ["dist"] }));
@@ -40,24 +68,31 @@ describe("release-check", () => {
         join(root, "scripts/lib/plugin-sdk-private-local-only-subpaths.json"),
         JSON.stringify(["target-private"]),
       );
-      const moduleUrl = pathToFileURL(resolve("scripts/release-check.ts")).href;
+      const moduleUrl = pathToFileURL(join(toolingRoot, "scripts/release-check.ts")).href;
       const output = execFileSync(
         process.execPath,
         [
           "--import",
-          resolve("scripts/tsx.mjs"),
+          join(toolingRoot, "scripts/tsx.mjs"),
           "--input-type=module",
           "--eval",
-          `const { collectForbiddenPackPaths } = await import(${JSON.stringify(moduleUrl)});\n` +
-            `console.log(JSON.stringify(collectForbiddenPackPaths(["dist/plugin-sdk/target-private.d.ts", "dist/plugin-sdk/target-public.d.ts"])));`,
+          `const { collectForbiddenPackPaths, collectMissingPackPaths } = await import(${JSON.stringify(moduleUrl)});\n` +
+            `console.log(JSON.stringify({ forbidden: collectForbiddenPackPaths(["dist/plugin-sdk/target-private.d.ts", "dist/plugin-sdk/target-public.d.ts"]), required: collectMissingPackPaths([]).filter(path => path.startsWith("dist/plugin-sdk/")) }));`,
         ],
         {
           cwd: root,
           encoding: "utf8",
-          env: { ...process.env, TSX_TSCONFIG_PATH: resolve("tsconfig.json") },
+          env: { ...process.env, TSX_TSCONFIG_PATH: join(toolingRoot, "tsconfig.json") },
         },
       );
-      expect(JSON.parse(output)).toEqual(["dist/plugin-sdk/target-private.d.ts"]);
+      expect(JSON.parse(output)).toEqual({
+        forbidden: ["dist/plugin-sdk/target-private.d.ts"],
+        required: [
+          "dist/plugin-sdk/target-private.js",
+          "dist/plugin-sdk/target-public.d.ts",
+          "dist/plugin-sdk/target-public.js",
+        ],
+      });
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -944,6 +944,7 @@ describe("scripts/test-projects changed-target routing", () => {
         "test/scripts/openclaw-npm-resume-run.test.ts",
         "test/scripts/package-source-preflight.test.ts",
         "test/scripts/release-candidate-checklist.test.ts",
+        "test/scripts/release-check.test.ts",
         "test/scripts/release-plan-producer.test.ts",
       ],
     );


### PR DESCRIPTION
## What Problem This Solves

Resolves two connected failures in frozen npm release validation: the trusted sparse checker cannot load an unused UI dependency, and its public SDK consumer fixture is copied from the older target checkout and imports a private module without shipped TypeScript declarations.

## Why This Change Was Made

Import static asset discovery directly from its existing owner. Resolve the consumer template relative to the trusted checker, while package metadata and SDK inventories remain target-owned. The consumer retains five public SDK module imports and the public channel route-owner callback result without invoking private runtime state. The main package gate now calls the same required-artifact validator exercised by the regression.

The existing cross-checkout test reconstructs the tooling tree from the workflow's actual sparse roots, loads the full checker, verifies both target SDK inventories, and proves that a stale target fixture cannot replace the checker-owned template. Test routing includes this workflow-dependent regression. No checkout expansion, validation skip, workflow input, product source, or runtime behavior changes.

## User Impact

Maintainers can run trusted release tooling against frozen package sources while keeping the package under test unchanged.

## Evidence

- [Preflight 33457910578](https://github.com/openclaw/openclaw/actions/runs/33457910578/job/99701715379) completed generated-content checks, then failed to import `ui/src/build-info-normalizers.ts` through unused postbuild code. The sparse regression reproduced the exact error before the direct import fix.
- A complete local checker run then passed fresh installation, Doctor, and plugin diagnostics, exposing the private-module TypeScript fixture error. The repaired complete run passes fresh installation, Doctor, plugin diagnostics, public SDK TypeScript compilation, all three bundled channel/setup entrypoints, completion, and workspace bootstrap. This uses the frozen release source with retained local build bytes; hosted preflight remains required for actual publication bytes.
- The fixture-ownership regression failed when a distinct stale target template was copied, then passed with the checker-owned template. All 74 focused release-check tests pass. The exact changed-test routing case passes after adding its newly discovered workflow-dependent test; the initial PR CI exposed that expected-list adjustment.
- Actual `check:changed` passes scripts/test-root typechecks, formatting, lint, and guards. Independent Codex P0–P2 reviews report no actionable findings.
- Runtime production LOC is unchanged. Release checker tooling is +6/−11, consumer fixture +3/−12, and regression tests +56/−10.
