### PR TITLE
refactor(infra): share path existence policy

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2103,7 +2103,7 @@ src/agents/transcript-redact.ts	2
 src/agents/transport-message-transform.ts	2
 src/agents/utils/frontmatter.ts	2
 src/agents/utils/tools-manager.ts	2
-src/agents/workspace-legacy-state.ts	3
+src/agents/workspace-legacy-state.ts	2
 src/agents/workspace-state-store.ts	1
 src/agents/workspace.ts	9
 src/agents/worktrees/git.ts	2
@@ -3074,7 +3074,6 @@ src/infra/delivery-queue-sqlite-namespace.ts	3
 src/infra/delivery-queue-sqlite.ts	4
 src/infra/delivery-queue-sqlite.types.ts	1
 src/infra/delivery-recovery.shared.ts	4
-src/infra/device-identity.ts	1
 src/infra/device-pairing-store.ts	6
 src/infra/diagnostic-event-listener-presence.ts	3
 src/infra/diagnostic-events.ts	13
@@ -3092,7 +3091,6 @@ src/infra/exec-approval-reply.ts	2
 src/infra/exec-approvals-allowlist.ts	7
 src/infra/exec-approvals-config.ts	4
 src/infra/exec-approvals-effective.ts	3
-src/infra/exec-approvals-migration-gate.ts	1
 src/infra/exec-approvals-resolver.ts	2
 src/infra/exec-approvals-socket.ts	1
 src/infra/exec-approvals-store.ts	1
@@ -3174,7 +3172,7 @@ src/infra/provider-usage.fetch.minimax.ts	2
 src/infra/push-apns-http2.ts	1
 src/infra/push-apns.relay.ts	1
 src/infra/push-apns.ts	7
-src/infra/push-web.ts	3
+src/infra/push-web.ts	2
 src/infra/question-gateway-resolver.ts	3
 src/infra/question-reaction-runtime.ts	3
 src/infra/restart-coordinator.ts	1
@@ -3216,7 +3214,6 @@ src/infra/state-migrations.channel-pairing.ts	5
 src/infra/state-migrations.config-machine-state.ts	1
 src/infra/state-migrations.cron-run-logs.ts	4
 src/infra/state-migrations.debug-proxy.ts	5
-src/infra/state-migrations.device-identity-repair.ts	1
 src/infra/state-migrations.doctor.ts	7
 src/infra/state-migrations.exec-approvals.ts	1
 src/infra/state-migrations.fs.ts	1
@@ -3232,7 +3229,6 @@ src/infra/state-migrations.node-host.ts	2
 src/infra/state-migrations.runtime-state.ts	7
 src/infra/state-migrations.session-store.ts	12
 src/infra/state-migrations.shared-auth-store.ts	1
-src/infra/state-migrations.source-snapshot.ts	1
 src/infra/state-migrations.state-dir.ts	1
 src/infra/state-migrations.storage.ts	21
 src/infra/state-migrations.task-sidecar-rows.ts	8
@@ -3571,7 +3567,7 @@ src/plugins/trusted-tool-policy.ts	1
 src/plugins/uninstall-config.ts	3
 src/plugins/uninstall-package-config.ts	2
 src/plugins/uninstall-package-plan.ts	1
-src/plugins/uninstall.ts	4
+src/plugins/uninstall.ts	3
 src/plugins/update-channel.ts	2
 src/plugins/update-config.ts	2
 src/plugins/update-installed.ts	5

--- a/src/agents/workspace-legacy-state.ts
+++ b/src/agents/workspace-legacy-state.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { formatCliCommand } from "../cli/command-format.js";
 import { resolveLegacyStateDirs, resolveStateDir } from "../config/paths.js";
 import { root } from "../infra/fs-safe.js";
+import { pathMayExistSync } from "../infra/path-existence.js";
 import { resolveUserPath } from "../utils.js";
 import { resolveWorkspaceStateIdentity } from "./workspace-state-identity.js";
 
@@ -108,17 +109,9 @@ export function resolveLegacyWorkspaceSourcePaths(
 }
 
 function pathOrClaimExists(filePath: string): boolean {
-  for (const candidate of [filePath, `${filePath}${WORKSPACE_DOCTOR_CLAIM_SUFFIX}`]) {
-    try {
-      fs.lstatSync(candidate);
-      return true;
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
-        return true;
-      }
-    }
-  }
-  return false;
+  return (
+    pathMayExistSync(filePath) || pathMayExistSync(`${filePath}${WORKSPACE_DOCTOR_CLAIM_SUFFIX}`)
+  );
 }
 
 function siblingPathIsOwnedMarker(filePath: string): boolean {

--- a/src/infra/device-identity.ts
+++ b/src/infra/device-identity.ts
@@ -1,6 +1,5 @@
 // Gateway/device Ed25519 identity API backed by canonical shared SQLite state.
 import crypto from "node:crypto";
-import fs from "node:fs";
 import path from "node:path";
 import { resolveOpenClawStateDirForDatabasePath } from "../state/openclaw-state-db.paths.js";
 import { acquireDeviceIdentityCoordinator } from "./device-identity-coordinator.js";
@@ -22,6 +21,7 @@ import {
   verifyEd25519Signature,
 } from "./ed25519-signature.js";
 import { pruneMapToMaxSize } from "./map-size.js";
+import { pathMayExistSync } from "./path-existence.js";
 import { createSqliteLifecycleAggregateError } from "./sqlite-coordinator.js";
 
 export type { DeviceIdentity } from "./device-identity-store.js";
@@ -36,15 +36,6 @@ function toDeviceIdentity(stored: StoredDeviceIdentity): DeviceIdentity {
     publicKeyPem: stored.publicKeyPem,
     privateKeyPem: stored.privateKeyPem,
   };
-}
-
-function pathMayExist(filePath: string): boolean {
-  try {
-    fs.lstatSync(filePath);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== "ENOENT";
-  }
 }
 
 /** Exact retired file owned by Doctor migration code. */
@@ -64,9 +55,9 @@ function assertNoPendingLegacyIdentity(options: DeviceIdentityStoreOptions): voi
   const legacyPath = resolveLegacyDeviceIdentityPath(options);
   if (
     // Claims first, source last: both migration owners restore claim -> source atomically.
-    pathMayExist(`${legacyPath}${DOCTOR_CLAIM_SUFFIX}`) ||
-    pathMayExist(`${legacyPath}${NATIVE_CLAIM_SUFFIX}`) ||
-    pathMayExist(legacyPath)
+    pathMayExistSync(`${legacyPath}${DOCTOR_CLAIM_SUFFIX}`) ||
+    pathMayExistSync(`${legacyPath}${NATIVE_CLAIM_SUFFIX}`) ||
+    pathMayExistSync(legacyPath)
   ) {
     throw new Error(
       `Legacy device identity exists at ${legacyPath}. Run "openclaw doctor --fix" before starting the gateway or connecting this client.`,
@@ -120,7 +111,7 @@ function loadOrCreateDeviceIdentityOwned(options: DeviceIdentityStoreOptions): D
   const { databasePath } = resolveDeviceIdentityStore(options);
   // A downgrade can recreate retired JSON after SQLite migration. Once this profile has
   // a canonical row, keep it authoritative and leave the retired source for Doctor.
-  const existing = pathMayExist(databasePath) ? readStoredDeviceIdentity(options) : null;
+  const existing = pathMayExistSync(databasePath) ? readStoredDeviceIdentity(options) : null;
   if (existing) {
     return toDeviceIdentity(existing);
   }

--- a/src/infra/exec-approvals-migration-gate.ts
+++ b/src/infra/exec-approvals-migration-gate.ts
@@ -1,7 +1,7 @@
 // Blocks runtime use while retired exec approval state still awaits Doctor import.
-import fs from "node:fs";
 import path from "node:path";
 import { resolveExecApprovalsPath } from "./exec-approvals-config.js";
+import { pathMayExistSync } from "./path-existence.js";
 
 const DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
 // Doctor usually runs in another process, so cache only the steady-state absence;
@@ -30,15 +30,6 @@ export class ExecApprovalsMigrationRequiredError extends Error {
   }
 }
 
-function pathMayExist(filePath: string): boolean {
-  try {
-    fs.lstatSync(filePath);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== "ENOENT";
-  }
-}
-
 /** Refuse runtime access until Doctor owns the one-time legacy import. */
 export function assertNoPendingLegacyExecApprovals(
   options: { pathMayExist?: (filePath: string) => boolean } = {},
@@ -47,7 +38,7 @@ export function assertNoPendingLegacyExecApprovals(
   if (legacyAbsenceCache.has(sourcePath)) {
     return;
   }
-  const probe = options.pathMayExist ?? pathMayExist;
+  const probe = options.pathMayExist ?? pathMayExistSync;
   // Bound both Doctor rename directions: source -> claim and claim -> source.
   const sourceBefore = probe(sourcePath);
   const claim = probe(`${sourcePath}${DOCTOR_CLAIM_SUFFIX}`);

--- a/src/infra/path-existence.test.ts
+++ b/src/infra/path-existence.test.ts
@@ -1,0 +1,24 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { pathMayExistSync } from "./path-existence.js";
+
+it("distinguishes definite absence from paths that may still exist", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-path-existence-"));
+  try {
+    const present = path.join(root, "present");
+    fs.writeFileSync(present, "");
+    expect(pathMayExistSync(present)).toBe(true);
+    expect(pathMayExistSync(path.join(root, "missing"))).toBe(false);
+
+    const dangling = path.join(root, "dangling");
+    fs.symlinkSync("missing-target", dangling);
+    expect(pathMayExistSync(dangling)).toBe(true);
+    const blockedByFile = path.join(present, "child");
+    expect(() => fs.lstatSync(blockedByFile)).toThrow(expect.objectContaining({ code: "ENOTDIR" }));
+    expect(pathMayExistSync(blockedByFile)).toBe(true);
+  } finally {
+    fs.rmSync(root, { force: true, recursive: true });
+  }
+});

--- a/src/infra/path-existence.ts
+++ b/src/infra/path-existence.ts
@@ -1,0 +1,12 @@
+import fs from "node:fs";
+import { hasErrnoCode } from "./errno.js";
+
+/** Only a definite missing leaf permits callers to treat a path as absent. */
+export function pathMayExistSync(filePath: string): boolean {
+  try {
+    fs.lstatSync(filePath);
+    return true;
+  } catch (error) {
+    return !hasErrnoCode(error, "ENOENT");
+  }
+}

--- a/src/infra/push-web.ts
+++ b/src/infra/push-web.ts
@@ -1,10 +1,10 @@
 // Stores and verifies web push subscriptions and delivery payloads.
 import { randomUUID } from "node:crypto";
-import fs from "node:fs";
 import path from "node:path";
 import { expectDefined, normalizeOptionalString } from "@openclaw/normalization-core";
 import { resolveStateDir } from "../config/paths.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
+import { pathMayExistSync } from "./path-existence.js";
 import {
   WebPushSubscriptionBindingError,
   createWebPushVapidKeyPair,
@@ -63,16 +63,6 @@ const loadWebPushRuntime = createLazyRuntimeModule(() =>
   import("web-push").then((mod: WebPushRuntimeModule) => mod.default ?? mod),
 );
 
-function legacyWebPushPathMayExist(filePath: string): boolean {
-  try {
-    fs.lstatSync(filePath);
-    return true;
-  } catch (error) {
-    // Only a definite absence permits creating a new signing identity.
-    return (error as NodeJS.ErrnoException).code !== "ENOENT";
-  }
-}
-
 // Production callers run under the Gateway's lifetime state/config lock. Doctor must
 // acquire those same locks before claiming legacy files, so this check remains stable
 // through the following SQLite operation or asynchronous delivery fan-out.
@@ -80,10 +70,7 @@ function assertLegacyWebPushMigrationComplete(baseDir?: string): void {
   const stateDir = baseDir ?? resolveStateDir();
   const pendingLegacyPath = LEGACY_WEB_PUSH_PATHS.find((relativePath) => {
     const sourcePath = path.join(stateDir, relativePath);
-    return (
-      legacyWebPushPathMayExist(sourcePath) ||
-      legacyWebPushPathMayExist(`${sourcePath}.doctor-importing`)
-    );
+    return pathMayExistSync(sourcePath) || pathMayExistSync(`${sourcePath}.doctor-importing`);
   });
   if (pendingLegacyPath) {
     throw new Error(

--- a/src/infra/state-migrations.device-identity-repair.ts
+++ b/src/infra/state-migrations.device-identity-repair.ts
@@ -1,5 +1,4 @@
 // Owner-authorized detection and Doctor-only replacement for invalid device identity rows.
-import fs from "node:fs";
 import path from "node:path";
 import {
   DeviceIdentityStorageError,
@@ -8,6 +7,7 @@ import {
   repairInvalidStoredDeviceIdentity,
 } from "./device-identity-store.js";
 import { formatErrorMessage } from "./errors.js";
+import { pathMayExistSync } from "./path-existence.js";
 import type { LegacyDeviceIdentityDetection } from "./state-migrations.device-identity.types.js";
 import type { MigrationMessages } from "./state-migrations.types.js";
 
@@ -15,15 +15,6 @@ const LEGACY_IDENTITY_RELATIVE_PATH = path.join("identity", "device.json");
 const DOCTOR_CLAIM_SUFFIX = ".doctor-importing";
 const NATIVE_CLAIM_SUFFIX = ".native-importing";
 const IDENTITY_KEY = "primary";
-
-function pathMayExist(filePath: string): boolean {
-  try {
-    fs.lstatSync(filePath);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== "ENOENT";
-  }
-}
 
 /** Detect retired paths for an authorized importer; only Doctor may rotate invalid SQLite state. */
 export function detectLegacyDeviceIdentity(params: {
@@ -54,16 +45,18 @@ export function detectLegacyDeviceIdentity(params: {
     nativeClaimPath,
     hasLegacy:
       importAuthorized &&
-      (pathMayExist(claimPath) || pathMayExist(nativeClaimPath) || pathMayExist(sourcePath)),
+      (pathMayExistSync(claimPath) ||
+        pathMayExistSync(nativeClaimPath) ||
+        pathMayExistSync(sourcePath)),
     hasInvalidCanonical,
   };
 }
 
 export function hasLegacyDeviceIdentityPath(detected: LegacyDeviceIdentityDetection): boolean {
   return (
-    pathMayExist(detected.claimPath) ||
-    pathMayExist(detected.nativeClaimPath) ||
-    pathMayExist(detected.sourcePath)
+    pathMayExistSync(detected.claimPath) ||
+    pathMayExistSync(detected.nativeClaimPath) ||
+    pathMayExistSync(detected.sourcePath)
   );
 }
 

--- a/src/infra/state-migrations.mcp-oauth.ts
+++ b/src/infra/state-migrations.mcp-oauth.ts
@@ -11,6 +11,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
+import { pathMayExistSync } from "./path-existence.js";
 import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import { parseLegacyMcpOAuthStore } from "./state-migrations.mcp-oauth-format.js";
 import { withRootBoundedLegacyFileLock } from "./state-migrations.mcp-oauth-lock.js";
@@ -25,7 +26,6 @@ import {
 } from "./state-migrations.receipts.js";
 import {
   LegacyMigrationSourceClaim,
-  legacyMigrationPathMayExist,
   legacyMigrationSourceSnapshotsMatch as snapshotsMatch,
   readLegacyMigrationSourceSnapshot,
   resolveLegacyMigrationRelativePath,
@@ -101,7 +101,7 @@ export function detectLegacyMcpOAuthStores(params: {
     const sourcePaths = listLegacySourcePaths(sourceDir);
     return { sourceDir, sourcePaths, hasLegacy: sourcePaths.length > 0 };
   } catch {
-    return { sourceDir, sourcePaths: [], hasLegacy: legacyMigrationPathMayExist(sourceDir) };
+    return { sourceDir, sourcePaths: [], hasLegacy: pathMayExistSync(sourceDir) };
   }
 }
 

--- a/src/infra/state-migrations.source-snapshot.ts
+++ b/src/infra/state-migrations.source-snapshot.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import type { Root } from "@openclaw/fs-safe";
+import { pathMayExistSync } from "./path-existence.js";
 
 /** The stable source identity every doctor-owned import verifies before cleanup. */
 export type LegacyMigrationSourceSnapshot = {
@@ -180,24 +181,11 @@ export async function claimLegacyMigrationSourceClaims<
   }
 }
 
-/** A source may be inaccessible; only a proven absence permits skipping repair. */
-export function legacyMigrationPathMayExist(filePath: string): boolean {
-  try {
-    fs.lstatSync(filePath);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== "ENOENT";
-  }
-}
-
 export function legacyMigrationSourceOrClaimMayExist(
   sourcePath: string,
   claimSuffix = ".doctor-importing",
 ): boolean {
-  return (
-    legacyMigrationPathMayExist(sourcePath) ||
-    legacyMigrationPathMayExist(`${sourcePath}${claimSuffix}`)
-  );
+  return pathMayExistSync(sourcePath) || pathMayExistSync(`${sourcePath}${claimSuffix}`);
 }
 
 /** Constrain migration reads and moves to the original trusted state root. */

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -18,10 +18,10 @@ import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identit
 import { resolveLegacyStateDirs } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "./errors.js";
+import { pathMayExistSync } from "./path-existence.js";
 import { withLegacyMigrationStateLock } from "./state-migrations.lock.js";
 import {
   LegacyMigrationSourceClaim,
-  legacyMigrationPathMayExist as pathMayExist,
   legacyMigrationSourceOrClaimMayExist as sourceOrClaimMayExist,
   legacyMigrationSourceSnapshotsMatch as snapshotsMatch,
 } from "./state-migrations.source-snapshot.js";
@@ -284,7 +284,7 @@ function addLegacyWorkspaceSources(params: {
   }
   for (const [index, sourcePath] of paths.siblingAttestationPaths.entries()) {
     if (
-      !pathMayExist(`${sourcePath}${CLAIM_SUFFIX}`) &&
+      !pathMayExistSync(`${sourcePath}${CLAIM_SUFFIX}`) &&
       !siblingAttestationNeedsDoctor(sourcePath)
     ) {
       continue;

--- a/src/plugins/uninstall.ts
+++ b/src/plugins/uninstall.ts
@@ -1,11 +1,11 @@
 // Removes installed plugins and updates plugin index records.
-import { lstatSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { readOpenClawManagedNpmRootOverrides } from "../infra/npm-managed-root.js";
+import { pathMayExistSync } from "../infra/path-existence.js";
 import { createSafeNpmInstallEnv } from "../infra/safe-package-install.js";
 import { runCommandWithTimeout } from "../process/exec.js";
 import {
@@ -453,12 +453,7 @@ export function planPluginUninstall(params: UninstallPluginParams): PluginUninst
 }
 
 export function pluginUninstallTargetExists(target: string): boolean {
-  try {
-    lstatSync(target);
-    return true;
-  } catch (error) {
-    return (error as NodeJS.ErrnoException).code !== "ENOENT";
-  }
+  return pathMayExistSync(target);
 }
 
 function isOwnedNpmRemoval(removal: PluginUninstallDirectoryRemoval): boolean {


### PR DESCRIPTION
## What Problem This Solves

Several runtime, Doctor, Web Push, workspace, device identity, and plugin uninstall paths independently implemented the same conservative filesystem-existence rule. Keeping seven copies made a security-sensitive fail-closed policy easy to drift.

## Why This Change Was Made

This consolidates the exact shipped rule in one private infrastructure helper: `lstatSync` success means present, only `ENOENT` means absent, and every other error remains potentially present. Existing migration and uninstall policy wrappers remain with their owners; no SDK, barrel, config, package, or SQLite surface was added.

`@openclaw/fs-safe` was not reused because its existence helper follows links with `statSync` and treats every error as absence, which would change dangling-symlink and `ENOTDIR` behavior.

## User Impact

No intended user-visible behavior change. Operators keep the same fail-closed handling for inaccessible or ambiguous retired state, with one canonical policy instead of seven copies.

## Evidence

- Focused owner proof: 253 tests passed across infrastructure, agent workspace migration, Web Push, device identity, MCP OAuth, workspace setup, and plugin uninstall.
- Contract coverage: present path, definite `ENOENT`, dangling symlink, and explicit `ENOTDIR`.
- Structural proof: all seven duplicate implementations removed; `pathOrClaimExists`, `legacyMigrationSourceOrClaimMayExist`, and `pluginUninstallTargetExists` remain as owner policy wrappers.
- Architecture proof: import-cycle check 0; Madge cycle check 0; max-lines ratchet passed; assertion-safety debt shrank by seven.
- Local sparse-worktree `pnpm check:changed` and `pnpm build` reached the unchanged omitted `ui/config/*` inputs; the clean full-checkout Linux Testbox supersedes those local sparse-only failures.
- Clean Linux Blacksmith Testbox `tbx_01m1dasyh85xcdg357tpw3zq5q` passed `pnpm build` and `pnpm check:changed` at exact head `5fd6e62d3acde8432d240d3699eb6c04aef78d68`: https://github.com/openclaw/openclaw/actions/runs/33460538479. The first changed-file attempt exposed a depth-1 `origin/main` graft; after `git fetch --deepen=512 origin main` restored merge-base `131215a34bf4599b7b7b2b858f7ea05948d34774`, the unchanged command passed.
- Autoreview: scoped clean, correct at 0.99 confidence.
- Production LOC: +40/-86, net -46. Tests: +24. Guard metadata: +3/-7.
- Overlap checked against #125906, #103607, #133393, #133910, and #88504; none implements this consolidation or changes the predicate contract.
- Codex source checked at `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; unrelated to this filesystem policy.
