### PR TITLE
refactor(context): reuse PNG encoder for context maps

### DIFF
--- a/src/auto-reply/reply/commands-context-report.test.ts
+++ b/src/auto-reply/reply/commands-context-report.test.ts
@@ -2,6 +2,7 @@
 import { mkdtemp, readFile, rm, unlink } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { crc32, inflateSync } from "node:zlib";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../../config/config.js";
 import type { SessionEntry } from "../../config/sessions.js";
@@ -380,6 +381,23 @@ describe("buildContextReply", () => {
       expect(png.subarray(12, 16).toString("ascii")).toBe("IHDR");
       expect(png.readUInt32BE(16)).toBe(1280);
       expect(png.readUInt32BE(20)).toBe(860);
+      expect(png.subarray(24, 29)).toEqual(Buffer.from([8, 6, 0, 0, 0]));
+      const imageData: Buffer[] = [];
+      for (let offset = 8; offset < png.length;) {
+        const end = offset + 8 + png.readUInt32BE(offset);
+        expect(crc32(png.subarray(offset + 4, end))).toBe(png.readUInt32BE(end));
+        if (png.toString("ascii", offset + 4, offset + 8) === "IDAT") {
+          imageData.push(png.subarray(offset + 8, end));
+        }
+        offset = end + 4;
+      }
+      const pixels = inflateSync(Buffer.concat(imageData));
+      expect(pixels).toHaveLength(860 * (1280 * 4 + 1));
+      for (let row = 0; row < 860; row += 1) {
+        expect(pixels[row * (1280 * 4 + 1)]).toBe(0);
+      }
+      expect(pixels.subarray(1, 5)).toEqual(Buffer.from([20, 26, 34, 255]));
+      expect(pixels.subarray(-4)).toEqual(Buffer.from([238, 241, 245, 255]));
     } finally {
       await unlink(result.mediaUrl);
     }

--- a/src/auto-reply/reply/context-treemap.ts
+++ b/src/auto-reply/reply/context-treemap.ts
@@ -2,11 +2,11 @@
 import crypto from "node:crypto";
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
-import zlib from "node:zlib";
 import { expectDefined } from "@openclaw/normalization-core";
 import { estimateTokensFromChars } from "@openclaw/normalization-core/cjk-chars";
 import type { SessionSystemPromptReport } from "../../config/sessions/types.js";
 import { resolvePreferredOpenClawTmpDir } from "../../infra/tmp-openclaw-dir.js";
+import { encodePngRgba } from "../../media/png-encode.js";
 
 /** PNG treemap renderer for visualizing prompt context size by section. */
 type Rect = {
@@ -289,48 +289,6 @@ function drawLabel(
   });
 }
 
-function crc32(buffer: Buffer): number {
-  let crc = 0xffffffff;
-  for (const byte of buffer) {
-    crc ^= byte;
-    for (let i = 0; i < 8; i += 1) {
-      crc = (crc >>> 1) ^ (crc & 1 ? 0xedb88320 : 0);
-    }
-  }
-  return (crc ^ 0xffffffff) >>> 0;
-}
-
-function pngChunk(type: string, data: Buffer): Buffer {
-  const typeBuffer = Buffer.from(type, "ascii");
-  const length = Buffer.alloc(4);
-  length.writeUInt32BE(data.length, 0);
-  const crc = Buffer.alloc(4);
-  crc.writeUInt32BE(crc32(Buffer.concat([typeBuffer, data])), 0);
-  return Buffer.concat([length, typeBuffer, data, crc]);
-}
-
-function encodePng(data: Buffer): Buffer {
-  const signature = Buffer.from([137, 80, 78, 71, 13, 10, 26, 10]);
-  const ihdr = Buffer.alloc(13);
-  ihdr.writeUInt32BE(WIDTH, 0);
-  ihdr.writeUInt32BE(HEIGHT, 4);
-  ihdr[8] = 8;
-  ihdr[9] = 6;
-  const stride = WIDTH * 4;
-  const raw = Buffer.alloc((stride + 1) * HEIGHT);
-  for (let y = 0; y < HEIGHT; y += 1) {
-    const rowStart = y * (stride + 1);
-    raw[rowStart] = 0;
-    data.copy(raw, rowStart + 1, y * stride, (y + 1) * stride);
-  }
-  return Buffer.concat([
-    signature,
-    pngChunk("IHDR", ihdr),
-    pngChunk("IDAT", zlib.deflateSync(raw)),
-    pngChunk("IEND", Buffer.alloc(0)),
-  ]);
-}
-
 function treemapGroup(params: { name: string; color: Rgba; leaves: TreemapLeaf[] }): TreemapGroup {
   return { ...params, value: totalValue(params.leaves) };
 }
@@ -505,7 +463,7 @@ export async function renderContextTreemapPng(params: {
     resolvePreferredOpenClawTmpDir(),
     `openclaw-context-map-${crypto.randomUUID()}.png`,
   );
-  await writeFile(outPath, encodePng(canvas.data));
+  await writeFile(outPath, encodePngRgba(canvas.data, WIDTH, HEIGHT));
   const caption = [
     "Context treemap",
     `Source: ${params.report.source}`,


### PR DESCRIPTION
## What Problem This Solves

Context maps had a private copy of PNG serialization alongside the shared image encoder. Keeping both implementations in sync adds maintenance risk. This is an internal cleanup, not a claimed user-visible bug fix.

## Why This Change Was Made

Use the existing RGBA encoder at the same file-write boundary and remove the duplicate CRC table, CRC calculation, chunk builder and PNG encoder. Drawing, layout, token estimates, file naming, captions and media flags are unchanged. The shared encoder and its public exports remain intact.

Production: +2/−44 (net −42). Tests: +18/−0 (net +18). Whole patch: −24 lines. The added characterization extends the existing real-PNG command case; it does not add a production test seam or another rendering harness.

## User Impact

No intended output, CLI, configuration, SDK or persistence change. Context maps retain their dimensions, pixels, caption and cleanup behavior. No new dependency.

## Evidence

- Baseline and candidate each passed the same 53 cases across the two complete context-report/info suites, with matching identities and within-file order and no skips.
- Four existing scenarios—populated, native-unverified, transcript and model-only—produced byte-identical PNG pairs and equal complete normalized replies. All eight original generated paths were removed. Permanent assertions independently check PNG chunks/CRC, inflated scanlines and literal pixels.
- The temporary retention overlay was removed before the final normal changed checks (29 stages) and default build (14 stages), which passed. The paired 53-case run itself was not repeated after removing the overlay.
- Precommit and separate exact-signed-commit Codex reviews each completed one P0-scoped pass over 23 complete context files without actionable findings. Exact reviewed commit: fadfce94ff61d19e09e2e759e1904058b05f20a7.

The first exact-review launch preparation refused a PATH mismatch before any reviewer started. A separately approved measurement from the actual execution directory corrected only that environment binding; no PATH entries were removed, and the subsequent exact review ran once. The original refusal remains retained.

The earlier precommit live-process observer missed historical reviewer/temp identities; successful canonical cleanup and current absence do not establish exhaustive historical descendants. The exact review captured process/group and temporary-path names, then verified their absence, without claiming precise exit timing. Tests/builds were not rerun by the reviewer, and external Node source/types and installed dependency inventories were not supplied as review datasets.

This is real command-owner fixture output, not delivered-channel, provider or release-package proof. Exact-head CI run 33460171649, attempt 1, passed on fadfce94. Normal native main/PR review and artifact validation passed at that head with zero findings. The final captured main 3c1b3515 preserves all 23 reviewed context files relative to the previously inspected main snapshot, including both changed preimages and the encoder/caller neighborhood. Current-main dependency composition and final native landing remain pending; package/tooling changes are not treated as equivalent proof.

The completed ClawSweeper review reported no correctness or security findings. Its generic stored-data warning is inapplicable: the unchanged temporary PNG write is a product artifact, not a persistent store or schema migration; the same path cleanup and sensitive/trusted-local media flags remain.
