### PR TITLE
fix: activity/logs streams bounce back from the bottom in long sessions

### DIFF
--- a/ui/src/e2e/stream-auto-follow-settle.e2e.test.ts
+++ b/ui/src/e2e/stream-auto-follow-settle.e2e.test.ts
@@ -30,8 +30,8 @@ type LateRowGrowthOptions = {
 
 declare global {
   interface Window {
-    __settleGrowthStarted?: boolean;
-    __settleGrowthDone?: boolean;
+    settleGrowthStarted?: boolean;
+    settleGrowthDone?: boolean;
   }
 }
 
@@ -43,19 +43,19 @@ declare global {
  */
 async function installLateRowGrowth(page: Page, options: LateRowGrowthOptions): Promise<void> {
   await page.addInitScript((opts: LateRowGrowthOptions) => {
-    window.__settleGrowthStarted = false;
-    window.__settleGrowthDone = false;
+    window.settleGrowthStarted = false;
+    window.settleGrowthDone = false;
     const growPxPerFrame = opts.growPxPerFrame ?? 60;
     const growFrames = opts.growFrames ?? 10;
     const startGrowth = (container: Element) => {
-      if (window.__settleGrowthStarted) {
+      if (window.settleGrowthStarted) {
         return;
       }
-      window.__settleGrowthStarted = true;
+      window.settleGrowthStarted = true;
       const rows = container.querySelectorAll(opts.rowSelector);
       const target = rows[Math.max(0, rows.length - 3)];
       if (!(target instanceof HTMLElement)) {
-        window.__settleGrowthDone = true;
+        window.settleGrowthDone = true;
         return;
       }
       let frame = 0;
@@ -66,7 +66,7 @@ async function installLateRowGrowth(page: Page, options: LateRowGrowthOptions): 
         if (frame < growFrames) {
           requestAnimationFrame(step);
         } else {
-          window.__settleGrowthDone = true;
+          window.settleGrowthDone = true;
         }
       };
       requestAnimationFrame(step);
@@ -92,7 +92,7 @@ function distanceFromBottom(stream: Locator): Promise<number> {
 }
 
 async function expectPinnedAfterSettle(page: Page, stream: Locator): Promise<void> {
-  await page.waitForFunction(() => window.__settleGrowthDone === true);
+  await page.waitForFunction(() => window.settleGrowthDone === true);
   // The settle loop chases late growth back to the bottom within its bounded
   // window; give the poll enough room for the full 12-frame chase.
   await expect.poll(() => distanceFromBottom(stream)).toBeLessThan(2);

--- a/ui/src/e2e/stream-auto-follow-settle.e2e.test.ts
+++ b/ui/src/e2e/stream-auto-follow-settle.e2e.test.ts
@@ -1,0 +1,278 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import type { Locator, Page } from "playwright";
+import { beforeEach, expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI stream auto-follow settle mocked Gateway E2E",
+  startServerBeforeBrowser: true,
+  unavailableMessage: (executablePath) => `Playwright Chromium is unavailable at ${executablePath}`,
+});
+
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+let proofDir: string;
+beforeEach(() => {
+  if (captureUiProof) {
+    proofDir = createControlUiE2eArtifactDir("control-ui-stream-autofollow-settle");
+  }
+});
+
+type LateRowGrowthOptions = {
+  containerSelector: string;
+  rowSelector: string;
+  triggerRowCount: number;
+  growPxPerFrame?: number;
+  growFrames?: number;
+};
+
+declare global {
+  interface Window {
+    __settleGrowthStarted?: boolean;
+    __settleGrowthDone?: boolean;
+  }
+}
+
+/**
+ * Simulates the virtualizer's late row re-measurement: once the trigger row
+ * connects, one near-bottom row grows by a fixed amount per animation frame.
+ * The growth starts around the follow scroll and outlasts it by several
+ * frames, which is exactly the sequence that bounced the single-shot scroll.
+ */
+async function installLateRowGrowth(page: Page, options: LateRowGrowthOptions): Promise<void> {
+  await page.addInitScript((opts: LateRowGrowthOptions) => {
+    window.__settleGrowthStarted = false;
+    window.__settleGrowthDone = false;
+    const growPxPerFrame = opts.growPxPerFrame ?? 60;
+    const growFrames = opts.growFrames ?? 10;
+    const startGrowth = (container: Element) => {
+      if (window.__settleGrowthStarted) {
+        return;
+      }
+      window.__settleGrowthStarted = true;
+      const rows = container.querySelectorAll(opts.rowSelector);
+      const target = rows[Math.max(0, rows.length - 3)];
+      if (!(target instanceof HTMLElement)) {
+        window.__settleGrowthDone = true;
+        return;
+      }
+      let frame = 0;
+      const step = () => {
+        frame += 1;
+        const current = Number.parseFloat(target.style.paddingBottom || "0");
+        target.style.paddingBottom = `${current + growPxPerFrame}px`;
+        if (frame < growFrames) {
+          requestAnimationFrame(step);
+        } else {
+          window.__settleGrowthDone = true;
+        }
+      };
+      requestAnimationFrame(step);
+    };
+    const observer = new MutationObserver(() => {
+      const container = document.querySelector(opts.containerSelector);
+      if (
+        container &&
+        container.querySelectorAll(opts.rowSelector).length >= opts.triggerRowCount
+      ) {
+        startGrowth(container);
+      }
+    });
+    // Init scripts run before documentElement exists; document itself does.
+    observer.observe(document, { childList: true, subtree: true });
+  }, options);
+}
+
+function distanceFromBottom(stream: Locator): Promise<number> {
+  return stream.evaluate(
+    (element) => element.scrollHeight - element.scrollTop - element.clientHeight,
+  );
+}
+
+async function expectPinnedAfterSettle(page: Page, stream: Locator): Promise<void> {
+  await page.waitForFunction(() => window.__settleGrowthDone === true);
+  // The settle loop chases late growth back to the bottom within its bounded
+  // window; give the poll enough room for the full 12-frame chase.
+  await expect.poll(() => distanceFromBottom(stream)).toBeLessThan(2);
+  // Pinned must be a steady state, not a frame the next growth undoes.
+  await page.waitForTimeout(700);
+  expect(await distanceFromBottom(stream)).toBeLessThan(2);
+}
+
+const logLines = Array.from({ length: 200 }, (_value, index) =>
+  JSON.stringify({
+    "0": JSON.stringify({ subsystem: "autofollow-settle-e2e" }),
+    "1": `log line ${index + 1}`,
+    time: new Date(Date.UTC(2026, 6, 13, 12, 0, index)).toISOString(),
+    _meta: { logLevelName: "info" },
+  }),
+);
+const appendedLogLine = JSON.stringify({
+  "0": JSON.stringify({ subsystem: "autofollow-settle-e2e" }),
+  "1": "log line 201",
+  time: new Date(Date.UTC(2026, 6, 13, 12, 3, 20)).toISOString(),
+  _meta: { logLevelName: "warn" },
+});
+
+suite.define(() => {
+  it("keeps the logs stream pinned while rows settle after an append", async () => {
+    if (captureUiProof) {
+      await mkdir(path.join(proofDir, "video"), { recursive: true });
+    }
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 800, width: 1_200 },
+        ...(captureUiProof
+          ? {
+              recordVideo: {
+                dir: path.join(proofDir, "video"),
+                size: { height: 800, width: 1_200 },
+              },
+            }
+          : {}),
+      },
+      async ({ page }) => {
+        const pageErrors: string[] = [];
+        page.on("pageerror", (error) => pageErrors.push(String(error)));
+        await installLateRowGrowth(page, {
+          containerSelector: ".log-stream",
+          rowSelector: ".log-row",
+          triggerRowCount: logLines.length + 1,
+        });
+        await installMockGateway(page, {
+          methodResponses: {
+            "logs.tail": {
+              sequence: [
+                {
+                  cursor: logLines.length,
+                  file: "/tmp/openclaw.log",
+                  lines: logLines,
+                  reset: true,
+                },
+                {
+                  cursor: logLines.length + 1,
+                  file: "/tmp/openclaw.log",
+                  lines: [appendedLogLine],
+                  reset: false,
+                },
+                {
+                  cursor: logLines.length + 1,
+                  file: "/tmp/openclaw.log",
+                  lines: [],
+                  reset: false,
+                },
+              ],
+            },
+          },
+        });
+
+        await page.goto(`${suite.server.baseUrl}logs`);
+        const stream = page.locator(".log-stream");
+        await expect.poll(() => page.locator(".log-row").count()).toBe(logLines.length);
+        await expect.poll(() => distanceFromBottom(stream)).toBeLessThan(2);
+
+        // The appended line triggers both the follow scroll and, via the
+        // mutation observer, ten frames of late row growth (+600px total).
+        await expect.poll(() => page.locator(".log-row").count()).toBe(logLines.length + 1);
+        await expectPinnedAfterSettle(page, stream);
+
+        if (captureUiProof) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(proofDir, "logs-stream-pinned-after-settle.png"),
+          });
+        }
+        expect(pageErrors).toEqual([]);
+      },
+    );
+  });
+
+  it("keeps the activity stream pinned while rows settle after an append", async () => {
+    if (captureUiProof) {
+      await mkdir(path.join(proofDir, "video"), { recursive: true });
+    }
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 800, width: 1_200 },
+        ...(captureUiProof
+          ? {
+              recordVideo: {
+                dir: path.join(proofDir, "video"),
+                size: { height: 800, width: 1_200 },
+              },
+            }
+          : {}),
+      },
+      async ({ page }) => {
+        const pageErrors: string[] = [];
+        page.on("pageerror", (error) => pageErrors.push(String(error)));
+        const initialEntries = 40;
+        await installLateRowGrowth(page, {
+          containerSelector: ".activity-stream",
+          rowSelector: ".activity-entry",
+          triggerRowCount: initialEntries + 1,
+        });
+        const gateway = await installMockGateway(page, { sessionKey: "main" });
+        const startedAt = Date.now();
+
+        await page.goto(`${suite.server.baseUrl}activity?view=live`);
+        await page.getByText("No activity yet.", { exact: true }).waitFor();
+
+        const emitToolStart = async (index: number) => {
+          await gateway.emitGatewayEvent("agent", {
+            runId: "run-settle",
+            seq: index + 1,
+            stream: "tool",
+            ts: startedAt + index * 50,
+            sessionKey: "main",
+            data: {
+              phase: "start",
+              name: "settle_probe",
+              toolCallId: `tool-settle-${index}`,
+              args: { index },
+            },
+          });
+        };
+        for (let index = 0; index < initialEntries; index += 1) {
+          await emitToolStart(index);
+        }
+
+        const stream = page.locator(".activity-stream");
+        await expect.poll(() => page.locator(".activity-entry").count()).toBe(initialEntries);
+        await expect
+          .poll(() => stream.evaluate((element) => element.scrollHeight - element.clientHeight))
+          .toBeGreaterThan(0);
+        // The burst's own late layout can leave the stream off the bottom;
+        // take it to the end explicitly so the append starts from a pinned
+        // viewport with atBottom engaged (a user scroll-to-end gesture).
+        await page.waitForTimeout(1_000);
+        await stream.evaluate((element) => {
+          element.scrollTop = element.scrollHeight;
+          element.dispatchEvent(new Event("scroll"));
+        });
+        await expect.poll(() => distanceFromBottom(stream)).toBeLessThan(2);
+
+        // Entry 41 triggers the follow scroll and the late row growth.
+        await emitToolStart(initialEntries);
+        await expect.poll(() => page.locator(".activity-entry").count()).toBe(initialEntries + 1);
+        await expectPinnedAfterSettle(page, stream);
+
+        if (captureUiProof) {
+          await page.screenshot({
+            animations: "disabled",
+            fullPage: true,
+            path: path.join(proofDir, "activity-stream-pinned-after-settle.png"),
+          });
+        }
+        expect(pageErrors).toEqual([]);
+      },
+    );
+  });
+});

--- a/ui/src/lit/stream-auto-follow-controller.test.ts
+++ b/ui/src/lit/stream-auto-follow-controller.test.ts
@@ -58,8 +58,9 @@ function createController(
 ) {
   const { container, state } = createScrollContainer();
   const host = createHost(container);
+  const isEnabledOption = options.isEnabled;
   const isEnabled =
-    typeof options.isEnabled === "function" ? options.isEnabled : () => options.isEnabled ?? true;
+    typeof isEnabledOption === "function" ? isEnabledOption : () => isEnabledOption ?? true;
   const controller = new StreamAutoFollowController(host, {
     selector: ".scroll",
     isEnabled,
@@ -174,8 +175,8 @@ describe("StreamAutoFollowController", () => {
   });
 
   it("keeps settling while the captured epoch and enablement stay valid", async () => {
-    let current = true;
-    let enabled = true;
+    const current = true;
+    const enabled = true;
     const { controller, state } = createController({
       isEnabled: () => enabled,
       captureCurrent: () => () => current,

--- a/ui/src/lit/stream-auto-follow-controller.test.ts
+++ b/ui/src/lit/stream-auto-follow-controller.test.ts
@@ -1,0 +1,167 @@
+/* @vitest-environment jsdom */
+import type { ReactiveController, ReactiveControllerHost } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StreamAutoFollowController } from "./stream-auto-follow-controller.ts";
+
+type ScrollState = {
+  scrollHeight: number;
+  scrollTop: number;
+  clientHeight: number;
+};
+
+function createScrollContainer(): { container: HTMLElement; state: ScrollState } {
+  const container = document.createElement("div");
+  const state: ScrollState = { scrollHeight: 1000, scrollTop: 0, clientHeight: 200 };
+  Object.defineProperty(container, "scrollHeight", {
+    get: () => state.scrollHeight,
+    configurable: true,
+  });
+  Object.defineProperty(container, "scrollTop", {
+    get: () => state.scrollTop,
+    // Browsers clamp scrollTop to [0, scrollHeight - clientHeight].
+    set: (value: number) => {
+      state.scrollTop = Math.min(value, Math.max(0, state.scrollHeight - state.clientHeight));
+    },
+    configurable: true,
+  });
+  Object.defineProperty(container, "clientHeight", {
+    get: () => state.clientHeight,
+    configurable: true,
+  });
+  return { container, state };
+}
+
+function createHost(container: HTMLElement) {
+  const controllers: ReactiveController[] = [];
+  const host = {
+    isConnected: true,
+    updateComplete: Promise.resolve(true),
+    addController: (controller: ReactiveController) => {
+      controllers.push(controller);
+    },
+    removeController: (controller: ReactiveController) => {
+      const index = controllers.indexOf(controller);
+      if (index !== -1) {
+        controllers.splice(index, 1);
+      }
+    },
+    querySelector: (selector: string) => (selector === ".scroll" ? container : null),
+  };
+  return host as unknown as ReactiveControllerHost & HTMLElement;
+}
+
+function createController(options: { isEnabled?: boolean } = {}) {
+  const { container, state } = createScrollContainer();
+  const host = createHost(container);
+  const controller = new StreamAutoFollowController(host, {
+    selector: ".scroll",
+    isEnabled: () => options.isEnabled ?? true,
+  });
+  return { controller, container, state };
+}
+
+let rafQueue: FrameRequestCallback[] = [];
+
+function runFrame(): void {
+  const queue = rafQueue;
+  rafQueue = [];
+  for (const callback of queue) {
+    callback(0);
+  }
+}
+
+async function flushUpdate(): Promise<void> {
+  await Promise.resolve();
+}
+
+beforeEach(() => {
+  rafQueue = [];
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    rafQueue.push(callback);
+    return rafQueue.length;
+  });
+  vi.stubGlobal("cancelAnimationFrame", (id: number) => {
+    rafQueue[id - 1] = () => undefined;
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("StreamAutoFollowController", () => {
+  it("re-asserts the bottom when content grows right after scrolling", async () => {
+    const { controller, state } = createController();
+    controller.schedule();
+    await flushUpdate();
+    runFrame();
+    expect(state.scrollTop).toBe(800);
+
+    // The virtualizer finishes measuring a tall row one frame later and the
+    // content grows by 500px, leaving the viewport above the bottom.
+    state.scrollHeight = 1500;
+    runFrame();
+    expect(state.scrollTop).toBe(1300);
+    expect(controller.atBottom).toBe(true);
+
+    // Once the layout is stable the settle loop disarms itself.
+    runFrame();
+    expect(rafQueue).toHaveLength(0);
+  });
+
+  it("stops chasing the bottom when the user scrolls up during settle", async () => {
+    const { controller, container, state } = createController();
+    controller.schedule();
+    await flushUpdate();
+    runFrame();
+    expect(state.scrollTop).toBe(800);
+
+    state.scrollHeight = 1500;
+    // User drags upward before the next settle frame lands.
+    state.scrollTop = 500;
+    controller.handleScroll({ currentTarget: container } as unknown as Event);
+    expect(controller.atBottom).toBe(false);
+
+    runFrame();
+    expect(state.scrollTop).toBe(500);
+    expect(rafQueue).toHaveLength(0);
+  });
+
+  it("does not scroll without force while far from the bottom", async () => {
+    const { controller, container, state } = createController();
+    controller.handleScroll({ currentTarget: container } as unknown as Event);
+    expect(controller.atBottom).toBe(false);
+
+    controller.schedule();
+    await flushUpdate();
+    runFrame();
+    expect(state.scrollTop).toBe(0);
+
+    controller.schedule(true);
+    await flushUpdate();
+    runFrame();
+    expect(state.scrollTop).toBe(800);
+  });
+
+  it("respects isEnabled", async () => {
+    const { controller, state } = createController({ isEnabled: false });
+    controller.schedule();
+    await flushUpdate();
+    runFrame();
+    expect(state.scrollTop).toBe(0);
+    expect(rafQueue).toHaveLength(0);
+  });
+
+  it("gives up settling after a bounded number of frames", async () => {
+    const { controller, state } = createController();
+    controller.schedule();
+    await flushUpdate();
+    for (let frame = 0; frame < 20; frame += 1) {
+      // Content keeps growing every frame (e.g. a streaming tool result).
+      state.scrollHeight += 100;
+      runFrame();
+    }
+    expect(rafQueue).toHaveLength(0);
+    expect(state.scrollTop).toBeGreaterThan(0);
+  });
+});

--- a/ui/src/lit/stream-auto-follow-controller.test.ts
+++ b/ui/src/lit/stream-auto-follow-controller.test.ts
@@ -50,12 +50,20 @@ function createHost(container: HTMLElement) {
   return host as unknown as ReactiveControllerHost & HTMLElement;
 }
 
-function createController(options: { isEnabled?: boolean } = {}) {
+function createController(
+  options: {
+    isEnabled?: boolean | (() => boolean);
+    captureCurrent?: () => () => boolean;
+  } = {},
+) {
   const { container, state } = createScrollContainer();
   const host = createHost(container);
+  const isEnabled =
+    typeof options.isEnabled === "function" ? options.isEnabled : () => options.isEnabled ?? true;
   const controller = new StreamAutoFollowController(host, {
     selector: ".scroll",
-    isEnabled: () => options.isEnabled ?? true,
+    isEnabled,
+    captureCurrent: options.captureCurrent,
   });
   return { controller, container, state };
 }
@@ -125,6 +133,63 @@ describe("StreamAutoFollowController", () => {
     runFrame();
     expect(state.scrollTop).toBe(500);
     expect(rafQueue).toHaveLength(0);
+  });
+
+  it("stops settling when auto-follow is turned off mid-settle", async () => {
+    let enabled = true;
+    const { controller, state } = createController({ isEnabled: () => enabled });
+    controller.schedule();
+    await flushUpdate();
+    runFrame();
+    expect(state.scrollTop).toBe(800);
+
+    // Content grows, then the user disables auto-follow before the next
+    // settle frame lands. The loop must not reset scrollTop again.
+    state.scrollHeight = 1500;
+    enabled = false;
+
+    runFrame();
+    expect(state.scrollTop).toBe(800);
+    expect(rafQueue).toHaveLength(0);
+  });
+
+  it("stops settling when the captured stream epoch goes stale mid-settle", async () => {
+    let current = true;
+    const { controller, state } = createController({
+      captureCurrent: () => () => current,
+    });
+    controller.schedule();
+    await flushUpdate();
+    runFrame();
+    expect(state.scrollTop).toBe(800);
+
+    // The stream reconnects after the first settle write; the predicate
+    // captured at schedule time is now stale and must disarm the loop.
+    state.scrollHeight = 1500;
+    current = false;
+
+    runFrame();
+    expect(state.scrollTop).toBe(800);
+    expect(rafQueue).toHaveLength(0);
+  });
+
+  it("keeps settling while the captured epoch and enablement stay valid", async () => {
+    let current = true;
+    let enabled = true;
+    const { controller, state } = createController({
+      isEnabled: () => enabled,
+      captureCurrent: () => () => current,
+    });
+    controller.schedule();
+    await flushUpdate();
+    runFrame();
+    expect(state.scrollTop).toBe(800);
+
+    state.scrollHeight = 1500;
+    runFrame();
+    expect(state.scrollTop).toBe(1300);
+    expect(current).toBe(true);
+    expect(enabled).toBe(true);
   });
 
   it("does not scroll without force while far from the bottom", async () => {

--- a/ui/src/lit/stream-auto-follow-controller.ts
+++ b/ui/src/lit/stream-auto-follow-controller.ts
@@ -52,12 +52,16 @@ export class StreamAutoFollowController implements ReactiveController {
         ) {
           return;
         }
-        this.scrollToBottomUntilSettled(container);
+        this.scrollToBottomUntilSettled(container, isCurrent);
       });
     });
   }
 
-  private scrollToBottomUntilSettled(container: HTMLElement, framesLeft = SETTLE_FRAMES): void {
+  private scrollToBottomUntilSettled(
+    container: HTMLElement,
+    isCurrent: () => boolean,
+    framesLeft = SETTLE_FRAMES,
+  ): void {
     const heightAtScroll = container.scrollHeight;
     container.scrollTop = container.scrollHeight;
     this.atBottom = true;
@@ -66,12 +70,19 @@ export class StreamAutoFollowController implements ReactiveController {
     }
     this.frame = requestAnimationFrame(() => {
       this.frame = null;
+      // The first frame validated enablement and the captured stream epoch,
+      // but both can change while the settle loop is armed: auto-follow can
+      // be toggled off, or the stream can reconnect. Re-check the boundaries
+      // before every settle write so a stale loop never resets scrollTop.
+      if (!isCurrent() || !this.options.isEnabled()) {
+        return;
+      }
       const distance = container.scrollHeight - container.scrollTop - container.clientHeight;
       // Chase the bottom only while content growth pushed us away from it. Stop
       // when the user scrolled up (atBottom flips false in handleScroll) or when
       // content shrank underneath us.
       if (distance > 2 && this.atBottom && container.scrollHeight >= heightAtScroll) {
-        this.scrollToBottomUntilSettled(container, framesLeft - 1);
+        this.scrollToBottomUntilSettled(container, isCurrent, framesLeft - 1);
       }
     });
   }

--- a/ui/src/lit/stream-auto-follow-controller.ts
+++ b/ui/src/lit/stream-auto-follow-controller.ts
@@ -1,6 +1,14 @@
 import type { ReactiveController, ReactiveControllerHost } from "lit";
 
 // Activity and logs intentionally share the audit-frozen 120px follow boundary.
+const AT_BOTTOM_THRESHOLD_PX = 120;
+
+// Row heights settle asynchronously: the virtualizer re-measures content for
+// several frames after we scroll, growing scrollHeight and pushing the viewport
+// away from the bottom again. Re-assert the bottom position for a short settle
+// window so following the tail actually sticks.
+const SETTLE_FRAMES = 12;
+
 export class StreamAutoFollowController implements ReactiveController {
   atBottom = true;
   private frame: number | null = null;
@@ -37,20 +45,44 @@ export class StreamAutoFollowController implements ReactiveController {
         if (!container) {
           return;
         }
-        const distance = container.scrollHeight - container.scrollTop - container.clientHeight;
-        if (!force && (!this.options.isEnabled() || (!this.atBottom && distance >= 120))) {
+        const distance =
+          container.scrollHeight - container.scrollTop - container.clientHeight;
+        if (
+          !force &&
+          (!this.options.isEnabled() || (!this.atBottom && distance >= AT_BOTTOM_THRESHOLD_PX))
+        ) {
           return;
         }
-        container.scrollTop = container.scrollHeight;
-        this.atBottom = true;
+        this.scrollToBottomUntilSettled(container);
       });
+    });
+  }
+
+  private scrollToBottomUntilSettled(container: HTMLElement, framesLeft = SETTLE_FRAMES): void {
+    const heightAtScroll = container.scrollHeight;
+    container.scrollTop = container.scrollHeight;
+    this.atBottom = true;
+    if (framesLeft <= 1) {
+      return;
+    }
+    this.frame = requestAnimationFrame(() => {
+      this.frame = null;
+      const distance = container.scrollHeight - container.scrollTop - container.clientHeight;
+      // Chase the bottom only while content growth pushed us away from it. Stop
+      // when the user scrolled up (atBottom flips false in handleScroll) or when
+      // content shrank underneath us.
+      if (distance > 2 && this.atBottom && container.scrollHeight >= heightAtScroll) {
+        this.scrollToBottomUntilSettled(container, framesLeft - 1);
+      }
     });
   }
 
   handleScroll(event: Event): void {
     const container = event.currentTarget as HTMLElement | null;
     if (container) {
-      this.atBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 120;
+      this.atBottom =
+        container.scrollHeight - container.scrollTop - container.clientHeight <
+        AT_BOTTOM_THRESHOLD_PX;
     }
   }
 

--- a/ui/src/lit/stream-auto-follow-controller.ts
+++ b/ui/src/lit/stream-auto-follow-controller.ts
@@ -45,8 +45,7 @@ export class StreamAutoFollowController implements ReactiveController {
         if (!container) {
           return;
         }
-        const distance =
-          container.scrollHeight - container.scrollTop - container.clientHeight;
+        const distance = container.scrollHeight - container.scrollTop - container.clientHeight;
         if (
           !force &&
           (!this.options.isEnabled() || (!this.atBottom && distance >= AT_BOTTOM_THRESHOLD_PX))


### PR DESCRIPTION
Refs #134625

## What Problem This Solves

Fixes an issue where, in long-running sessions with many tool calls, the **Activity and Logs streams** bounce back up right after a follow scroll, making the newest rows unreachable without repeatedly fighting the scroll position. Both panels share `StreamAutoFollowController`.

Scope note: the chat transcript has its own lifecycle-aware scroll owner (`ui/src/pages/chat/scroll.ts`) and is intentionally **not** changed by this PR; the linked issue remains open for that surface.

## Why This Change Was Made

`schedule()` performed a single-shot `scrollTop = scrollHeight` inside one animation frame. Row heights in the virtualized streams settle asynchronously over the following frames, growing `scrollHeight` and leaving the viewport above the bottom again — with nothing re-asserting the position. The controller now re-asserts the bottom for a short, bounded settle window (12 animation frames) only while content growth keeps pushing the viewport away.

Cancellation boundaries are preserved on every frame, not just the first:

- the settle loop re-checks the captured stream epoch (`captureCurrent`, which binds queued scroll work to the Logs gateway connection) and `isEnabled()` before every write, so toggling Auto-follow off or reconnecting mid-settle disarms the loop immediately;
- the loop stops when the user scrolls up (via the existing `atBottom` tracking in `handleScroll`) or when content shrinks;
- `schedule()`/`hostDisconnected()` still cancel any pending frame, so behavior for disabled follow, far-from-bottom, and unmount paths is unchanged.

## User Impact

Users can scroll to the bottom of long, active Activity/Logs panels and stay there; new streamed rows keep the view pinned instead of bouncing away.

## Evidence

Unit tests in `ui/src/lit/stream-auto-follow-controller.test.ts` (8 cases, all passing), including regressions for both mid-settle invalidations:

- content growth one frame after a follow scroll is chased back to the bottom, then the loop disarms;
- a user scroll-up during the settle window stops the chase immediately;
- turning Auto-follow off mid-settle stops the loop without further writes;
- a stale captured stream epoch (Logs reconnect) mid-settle stops the loop without further writes;
- non-forced schedules still do nothing while far from the bottom; forced schedules still scroll;
- `isEnabled() === false` is still respected;
- continuous per-frame growth exhausts the bounded window instead of looping forever.

```
✓ unit src/lit/stream-auto-follow-controller.test.ts (8 tests)
Test Files  1 passed (1)   Tests  8 passed (8)
```

Real behavior proof from the shipped Control UI bundle (new `ui/src/e2e/stream-auto-follow-settle.e2e.test.ts`, mocked gateway, both panels): after an append triggers the follow scroll, a near-bottom row grows 60px/frame for 10 frames — the sequence that bounced the single-shot scroll — and the stream stays pinned (<2px from bottom, verified again after a 700ms steady-state wait). Screenshots and videos captured with `OPENCLAW_CAPTURE_UI_PROOF=1`:

```
✓ ui-e2e ui/src/e2e/stream-auto-follow-settle.e2e.test.ts (2 tests)
Test Files  1 passed (1)   Tests  2 passed (2)
```

`ui/src/pages/logs/logs-page.test.ts` also passes (9 tests), including the reconnect-cancellation lifecycle cases.
