### PR TITLE
test(ui): remove duplicate task detail reset case

### DIFF
--- a/ui/src/pages/chat/components/chat-task-detail-state.test.ts
+++ b/ui/src/pages/chat/components/chat-task-detail-state.test.ts
@@ -117,18 +117,7 @@ afterEach(() => {
 });
 
 describe("task detail transcript state", () => {
-  it.each([
-    {
-      label: "the detail slot closes",
-      nextContent: taskContent,
-      nextLayout: closeSlot(openSlot({ columns: [] }, "detail"), "detail"),
-    },
-    {
-      label: "the detail slot switches to a file",
-      nextContent: fileContent,
-      nextLayout: openSlot({ columns: [] }, "detail"),
-    },
-  ])("clears transcript state when $label", ({ nextContent, nextLayout }) => {
+  it("clears transcript state when the detail slot closes", () => {
     const pending = deferred<never>();
     const host = hostWith(vi.fn().mockReturnValue(pending.promise));
     const openDetailLayout = openSlot({ columns: [] }, "detail");
@@ -136,7 +125,7 @@ describe("task detail transcript state", () => {
     renderDetail(host, taskContent, openDetailLayout);
     expect(host.taskDetailState).toBeDefined();
 
-    renderDetail(host, nextContent, nextLayout);
+    renderDetail(host, taskContent, closeSlot(openDetailLayout, "detail"));
     expect(host.taskDetailState).toBeUndefined();
   });
 


### PR DESCRIPTION
## What Problem This Solves

The task-detail state suite tests the task-to-file transition twice. The stable-render case already verifies the same pending transcript state is cleared and additionally checks that repeated renders issue no extra request or reset.

## Why This Change Was Made

Remove the weaker file-switch table row and retain the distinct close-slot case as a plain test. Production is unchanged; tests are +2/-13, and the state suite goes from six cases to five. Child transcript ownership, asynchronous refresh, failure, throttling and hidden-pane cleanup guards remain.

## Evidence

The ordinary owner and sibling group passed all 23 cases before and 22 after, with surviving order and routing preserved. A controlled fault skipped cleanup only when switching to a file: both old file-switch assertions failed, and the retained stable-render assertion still failed after deletion. The separate close-slot case passed under both controls. Production was restored before the normal passing after run.

The retained reset spy calls through the real owner; its extra stable task render returns the existing state without mutation or asynchronous progress. This is state-reset evidence, not DOM rendering or cancellation proof. Independent source and full-log review found no coverage gap. All 18 normal changed checks passed. Managed Codex review was scoped-clean with no actionable P0 finding.

[CI run 33460577224](https://github.com/openclaw/openclaw/actions/runs/33460577224) passed for the reviewed commit `665d96a414d4`. The completed review requested normal exact-head CI and maintainer handling, with no code repair; that CI step is complete.
