### PR TITLE
refactor(migrate-hermes): consolidate provider and config plumbing

### DIFF
--- a/extensions/migrate-hermes/apply.ts
+++ b/extensions/migrate-hermes/apply.ts
@@ -1,7 +1,8 @@
-// Migrate Hermes plugin module implements apply behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
 import {
+  applyMigrationConfigPatchItem,
+  applyMigrationManualItem,
   markMigrationItemConflict,
   markMigrationItemError,
   summarizeMigrationItems,
@@ -22,7 +23,6 @@ import type {
 import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
 import { resolvePreferredOpenClawTmpDir, withTempWorkspace } from "openclaw/plugin-sdk/temp-path";
 import { applyAuthItem } from "./auth.js";
-import { applyConfigItem, applyManualItem } from "./config.js";
 import { appendItem } from "./helpers.js";
 import {
   findHermesModelProviderDependency,
@@ -181,9 +181,9 @@ export async function applyHermesPlan(params: {
         appliedItem = await applyModelItem(applyCtx, item);
       }
     } else if (item.kind === "config") {
-      appliedItem = await applyConfigItem(applyCtx, item);
+      appliedItem = await applyMigrationConfigPatchItem(applyCtx, item);
     } else if (item.kind === "manual") {
-      appliedItem = applyManualItem(item);
+      appliedItem = applyMigrationManualItem(item);
     } else if (item.action === "archive") {
       appliedItem = await archiveHermesItem(item, reportDir);
     } else if (item.kind === "auth") {

--- a/extensions/migrate-hermes/config-mcp.ts
+++ b/extensions/migrate-hermes/config-mcp.ts
@@ -31,8 +31,7 @@ function readToolFilterList(value: unknown): string[] | undefined {
   if (!Array.isArray(value) || !value.every((entry) => typeof entry === "string")) {
     return undefined;
   }
-  const normalized = [...new Set(value.map((entry) => entry.trim()).filter(Boolean))];
-  return normalized;
+  return [...new Set(value.map((entry) => entry.trim()).filter(Boolean))];
 }
 
 function hasUnsupportedToolPattern(pattern: string): boolean {
@@ -192,8 +191,7 @@ export function mapMcpServer(
   next.auth = normalizeOptionalString(value.auth) === "oauth" ? "oauth" : undefined;
   next.oauth = mapHermesMcpOauth(value);
   Object.assign(next, mapHermesClientCertificate(value));
-  const toolFilter = mapHermesToolFilter(value);
-  next.toolFilter = toolFilter;
+  next.toolFilter = mapHermesToolFilter(value);
   const tools = isRecord(value.tools) ? value.tools : undefined;
   if (
     tools &&

--- a/extensions/migrate-hermes/config-providers.ts
+++ b/extensions/migrate-hermes/config-providers.ts
@@ -29,7 +29,27 @@ type HermesProviderSource = {
   id: string;
   raw: Record<string, unknown>;
   source: string;
+  custom: boolean;
 };
+
+function* providerSources(config: Record<string, unknown>): Generator<HermesProviderSource> {
+  for (const [id, raw] of Object.entries(childRecord(config, "providers"))) {
+    if (isRecord(raw)) {
+      yield { id, raw, source: `config.yaml:providers.${id}`, custom: false };
+    }
+  }
+  if (Array.isArray(config.custom_providers)) {
+    for (const raw of config.custom_providers) {
+      if (!isRecord(raw)) {
+        continue;
+      }
+      const id = normalizeOptionalString(raw.name) ?? normalizeOptionalString(raw.id);
+      if (id) {
+        yield { id, raw, source: `config.yaml:custom_providers.${id}`, custom: true };
+      }
+    }
+  }
+}
 
 export function collectHermesProviders(
   config: Record<string, unknown>,
@@ -55,58 +75,27 @@ export function collectHermesProviders(
       ],
     };
   };
-  for (const [id, raw] of Object.entries(childRecord(config, "providers"))) {
-    if (!isRecord(raw)) {
-      continue;
-    }
+  for (const { id, raw, custom } of providerSources(config)) {
     const resolvedBaseUrl = readProviderBaseUrl(raw, env);
-    const baseUrl = resolvedBaseUrl.baseUrl ?? resolveHermesImplicitBaseUrl(id);
+    const baseUrl =
+      resolvedBaseUrl.baseUrl ?? (custom ? undefined : resolveHermesImplicitBaseUrl(id));
     const api = resolveProviderApi(baseUrl ? { ...raw, base_url: baseUrl } : raw, id);
     if (!baseUrl || !api) {
       continue;
     }
     const headerConfig = readProviderHeaders(raw, env, includeSecrets);
-    upsert({
-      id: resolveHermesConfiguredProviderId(config, id, env),
-      baseUrl,
-      api,
-      apiKeyEnv: readProviderApiKeyEnv(raw) ?? resolveHermesEndpointApiKeyEnv(baseUrl),
-      headers: headerConfig.headers,
-      models: collectProviderModels(raw),
-      sensitive: resolvedBaseUrl.sensitive || headerConfig.sensitive,
-    });
-  }
-
-  const customProviders = config.custom_providers;
-  if (Array.isArray(customProviders)) {
-    for (const raw of customProviders) {
-      if (!isRecord(raw)) {
-        continue;
-      }
-      const id = normalizeOptionalString(raw.name) ?? normalizeOptionalString(raw.id);
-      if (!id) {
-        continue;
-      }
-      const resolvedBaseUrl = readProviderBaseUrl(raw, env);
-      const baseUrl = resolvedBaseUrl.baseUrl;
-      const api = resolveProviderApi(baseUrl ? { ...raw, base_url: baseUrl } : raw, id);
-      if (!baseUrl || !api) {
-        continue;
-      }
-      const headerConfig = readProviderHeaders(raw, env, includeSecrets);
-      upsert(
-        {
-          id: resolveHermesConfiguredProviderId(config, id, env),
-          baseUrl,
-          api,
-          apiKeyEnv: readProviderApiKeyEnv(raw) ?? resolveHermesEndpointApiKeyEnv(baseUrl),
-          headers: headerConfig.headers,
-          models: collectProviderModels(raw),
-          sensitive: resolvedBaseUrl.sensitive || headerConfig.sensitive,
-        },
-        { fallbackOnly: true },
-      );
-    }
+    upsert(
+      {
+        id: resolveHermesConfiguredProviderId(config, id, env),
+        baseUrl,
+        api,
+        apiKeyEnv: readProviderApiKeyEnv(raw) ?? resolveHermesEndpointApiKeyEnv(baseUrl),
+        headers: headerConfig.headers,
+        models: collectProviderModels(raw),
+        sensitive: resolvedBaseUrl.sensitive || headerConfig.sensitive,
+      },
+      { fallbackOnly: custom },
+    );
   }
 
   const model = config.model;
@@ -160,31 +149,14 @@ export function collectHermesProviderSecretBindings(
   const bindings = collectHermesProviders(config, env).flatMap((entry) =>
     entry.apiKeyEnv ? [{ envVar: entry.apiKeyEnv, provider: entry.id }] : [],
   );
-  for (const [sourceProvider, raw] of Object.entries(childRecord(config, "providers"))) {
-    if (!isRecord(raw)) {
-      continue;
-    }
-    const envVar = readProviderApiKeyEnv(raw) ?? resolveHermesProviderApiKeyEnv(sourceProvider);
+  for (const { id, raw, custom } of providerSources(config)) {
+    const envVar =
+      readProviderApiKeyEnv(raw) ?? (custom ? undefined : resolveHermesProviderApiKeyEnv(id));
     if (envVar) {
       bindings.push({
         envVar,
-        provider: resolveHermesConfiguredProviderId(config, sourceProvider, env),
+        provider: resolveHermesConfiguredProviderId(config, id, env),
       });
-    }
-  }
-  if (Array.isArray(config.custom_providers)) {
-    for (const raw of config.custom_providers) {
-      if (!isRecord(raw)) {
-        continue;
-      }
-      const sourceProvider = normalizeOptionalString(raw.name) ?? normalizeOptionalString(raw.id);
-      const envVar = readProviderApiKeyEnv(raw);
-      if (sourceProvider && envVar) {
-        bindings.push({
-          envVar,
-          provider: resolveHermesConfiguredProviderId(config, sourceProvider, env),
-        });
-      }
     }
   }
   const model = isRecord(config.model) ? config.model : undefined;
@@ -229,26 +201,12 @@ export function providerManualItems(
   env: Record<string, string>,
   includeSecrets: boolean,
 ): MigrationItem[] {
-  const entries: HermesProviderSource[] = [];
   const currentProviderIds = new Set(
     Object.keys(childRecord(config, "providers")).map(normalizeHermesCustomProviderId),
   );
-  for (const [id, raw] of Object.entries(childRecord(config, "providers"))) {
-    if (isRecord(raw)) {
-      entries.push({ id, raw, source: `config.yaml:providers.${id}` });
-    }
-  }
-  if (Array.isArray(config.custom_providers)) {
-    for (const raw of config.custom_providers) {
-      if (!isRecord(raw)) {
-        continue;
-      }
-      const id = normalizeOptionalString(raw.name) ?? normalizeOptionalString(raw.id);
-      if (id && !currentProviderIds.has(normalizeHermesCustomProviderId(id))) {
-        entries.push({ id, raw, source: `config.yaml:custom_providers.${id}` });
-      }
-    }
-  }
+  const entries = [...providerSources(config)].filter(
+    ({ id, custom }) => !custom || !currentProviderIds.has(normalizeHermesCustomProviderId(id)),
+  );
   if (isRecord(config.model)) {
     const provider = normalizeOptionalString(config.model.provider);
     const baseUrl =
@@ -261,6 +219,7 @@ export function providerManualItems(
           : "custom",
         raw: config.model,
         source: "config.yaml:model",
+        custom: false,
       });
     }
   }

--- a/extensions/migrate-hermes/config.ts
+++ b/extensions/migrate-hermes/config.ts
@@ -1,7 +1,4 @@
-// Migrate Hermes helper module supports config behavior.
 import {
-  applyMigrationConfigPatchItem,
-  applyMigrationManualItem,
   createMigrationConfigPatchItem,
   createMigrationManualItem,
   hasMigrationConfigPatchConflict,
@@ -61,24 +58,27 @@ export function buildConfigItems(params: {
   hasMemoryFiles?: boolean;
 }): MigrationItem[] {
   const items: MigrationItem[] = [];
+  const addConfigPatch = (patch: Parameters<typeof createMigrationConfigPatchItem>[0]) => {
+    items.push(
+      createMigrationConfigPatchItem({
+        ...patch,
+        conflict:
+          !params.ctx.overwrite &&
+          hasMigrationConfigPatchConflict(params.ctx.config, patch.path, patch.value),
+      }),
+    );
+  };
   const memory = childRecord(params.config, "memory");
   const memoryProvider = normalizeOptionalString(memory.provider);
 
   if (params.hasMemoryFiles || memoryProvider) {
-    items.push(
-      createMigrationConfigPatchItem({
-        id: "config:memory-plugin-slot",
-        target: "plugins.slots",
-        path: ["plugins", "slots"],
-        value: { memory: "memory-core" },
-        message: "Select the default OpenClaw memory plugin for imported file memory.",
-        conflict:
-          !params.ctx.overwrite &&
-          hasMigrationConfigPatchConflict(params.ctx.config, ["plugins", "slots"], {
-            memory: true,
-          }),
-      }),
-    );
+    addConfigPatch({
+      id: "config:memory-plugin-slot",
+      target: "plugins.slots",
+      path: ["plugins", "slots"],
+      value: { memory: "memory-core" },
+      message: "Select the default OpenClaw memory plugin for imported file memory.",
+    });
   }
 
   if (memoryProvider === "honcho") {
@@ -88,18 +88,13 @@ export function buildConfigItems(params: {
         config: childRecord(memory, "honcho"),
       },
     };
-    items.push(
-      createMigrationConfigPatchItem({
-        id: "config:memory-plugin:honcho",
-        target: "plugins.entries.honcho",
-        path: ["plugins", "entries"],
-        value,
-        message: "Preserve Hermes Honcho memory settings as a plugin entry for manual activation.",
-        conflict:
-          !params.ctx.overwrite &&
-          hasMigrationConfigPatchConflict(params.ctx.config, ["plugins", "entries"], value),
-      }),
-    );
+    addConfigPatch({
+      id: "config:memory-plugin:honcho",
+      target: "plugins.entries.honcho",
+      path: ["plugins", "entries"],
+      value,
+      message: "Preserve Hermes Honcho memory settings as a plugin entry for manual activation.",
+    });
     items.push(
       createMigrationManualItem({
         id: "manual:memory-provider:honcho",
@@ -129,19 +124,14 @@ export function buildConfigItems(params: {
   addSelectedModelToProvider(providers, params.modelRef);
   for (const provider of providers) {
     const value = { [provider.id]: providerConfig(provider) };
-    items.push(
-      createMigrationConfigPatchItem({
-        id: `config:model-provider:${sanitizeName(provider.id)}`,
-        target: `models.providers.${provider.id}`,
-        path: ["models", "providers"],
-        value,
-        message: `Import Hermes provider and custom endpoint config for "${provider.id}".`,
-        sensitive: provider.sensitive,
-        conflict:
-          !params.ctx.overwrite &&
-          hasMigrationConfigPatchConflict(params.ctx.config, ["models", "providers"], value),
-      }),
-    );
+    addConfigPatch({
+      id: `config:model-provider:${sanitizeName(provider.id)}`,
+      target: `models.providers.${provider.id}`,
+      path: ["models", "providers"],
+      value,
+      message: `Import Hermes provider and custom endpoint config for "${provider.id}".`,
+      sensitive: provider.sensitive,
+    });
   }
   items.push(
     ...providerManualItems(params.config, params.env ?? {}, Boolean(params.ctx.includeSecrets)),
@@ -167,19 +157,14 @@ export function buildConfigItems(params: {
       const server = mapMcpServer(rawServer, Boolean(params.ctx.includeSecrets), mcpEnv);
       if (Object.keys(server).length > 0) {
         const value = { [name]: server };
-        items.push(
-          createMigrationConfigPatchItem({
-            id: `config:mcp-server:${sanitizeName(name)}`,
-            target: `mcp.servers.${name}`,
-            path: ["mcp", "servers"],
-            value,
-            message: `Import Hermes MCP server definition "${name}".`,
-            sensitive: importsMcpSensitiveValues(rawServer, Boolean(params.ctx.includeSecrets)),
-            conflict:
-              !params.ctx.overwrite &&
-              hasMigrationConfigPatchConflict(params.ctx.config, ["mcp", "servers"], value),
-          }),
-        );
+        addConfigPatch({
+          id: `config:mcp-server:${sanitizeName(name)}`,
+          target: `mcp.servers.${name}`,
+          path: ["mcp", "servers"],
+          value,
+          message: `Import Hermes MCP server definition "${name}".`,
+          sensitive: importsMcpSensitiveValues(rawServer, Boolean(params.ctx.includeSecrets)),
+        });
       }
       items.push(
         ...mcpManualItems({
@@ -195,30 +180,14 @@ export function buildConfigItems(params: {
 
   for (const [skillKey, value] of Object.entries(mapSkillEntries(params.config))) {
     const configPath = ["skills", "entries", skillKey];
-    items.push(
-      createMigrationConfigPatchItem({
-        id: `config:skill-entry:${sanitizeName(skillKey)}`,
-        target: configPath.join("."),
-        path: configPath,
-        value,
-        message: "Import Hermes skill config values and global disabled state.",
-        conflict:
-          !params.ctx.overwrite &&
-          hasMigrationConfigPatchConflict(params.ctx.config, configPath, value),
-      }),
-    );
+    addConfigPatch({
+      id: `config:skill-entry:${sanitizeName(skillKey)}`,
+      target: configPath.join("."),
+      path: configPath,
+      value,
+      message: "Import Hermes skill config values and global disabled state.",
+    });
   }
 
   return items;
-}
-
-export async function applyConfigItem(
-  ctx: MigrationProviderContext,
-  item: MigrationItem,
-): Promise<MigrationItem> {
-  return applyMigrationConfigPatchItem(ctx, item);
-}
-
-export function applyManualItem(item: MigrationItem): MigrationItem {
-  return applyMigrationManualItem(item);
 }


### PR DESCRIPTION
Related: #134426

## What Problem This Solves

Reduces duplicated Hermes migration plumbing after the migration correctness repairs. Provider discovery was repeated independently for config, credential bindings, and manual-review items, and every config patch repeated the same conflict policy.

## Why This Change Was Made

Use one plugin-owned provider-source iterator while preserving provider-map precedence, legacy custom-provider fallback behavior, source labels, and credential defaults. Centralize config-patch conflict calculation and call the existing SDK apply functions directly. Remove two pass-through wrappers, redundant intermediate variables, and generic comments.

## User Impact

No intended behavior change. Existing selected-agent, skill-selection, provider, secret, memory, and MCP behavior is preserved.

## Evidence

- All 137 Hermes migration tests pass unchanged.
- Changed-file checks pass, including extension/test typechecks, lint, dead-export scans, and architecture guards.
- Diff-scoped deslop and fresh Codex autoreview complete; no accepted/actionable P0 findings.
- Rebase onto current main is patch-identical; the Hermes plugin and shared migration SDK had no intervening changes.

Production delta: **94 added / 168 removed, net -74 lines** across four files. Tests, dependencies, config surfaces, and schemas are unchanged.

Current-head live Linux proof passed on Blacksmith Testbox `tbx_01m1daxggcwqz13ecfc3rzgqja` ([run](https://github.com/openclaw/openclaw/actions/runs/33460660272)): full `pnpm build`, real CLI plan/apply with verified backup, 12 migrated/zero conflicts or errors, selected-agent isolation, disabled skill preservation, inactive organization exclusion, live stdio MCP filtering, SQLite archive readback, repeat-import idempotence, and a single parseable partial-failure report with exit1.

The fixture includes both provider-map and legacy custom-provider definitions for the same provider: map precedence and custom-list model merging were verified. The imported provider then completed an Anthropic Messages request with HTTP200 after ambient provider keys were removed. Reports were checked for credential redaction, and temporary state was removed.
