### PR TITLE
fix: doctor --fix never completes when a reserved workspace attestation is empty

### DIFF
--- a/docs/concepts/agent-workspace.md
+++ b/docs/concepts/agent-workspace.md
@@ -120,7 +120,10 @@ Older OpenClaw releases wrote `openclaw-workspace-state.json`,
 `.openclaw/workspace-state.json`, and `.attested` workspace sidecars. Current
 runtime uses only the shared SQLite database for that state. If Doctor reports
 one of these files, run `openclaw doctor --fix`; Doctor imports valid legacy
-state and deletes a source only after verifying the database rows.
+state and deletes a source only after verifying the database rows. Empty reserved
+hashed files under `workspace-attestations/` are discarded because they contain
+no importable state; other unreadable sources stay in place and Doctor names
+their paths.
 
 ## Git backup (recommended, private)
 

--- a/src/flows/doctor-health.test.ts
+++ b/src/flows/doctor-health.test.ts
@@ -3,7 +3,6 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { assertNoUnmigratedWorkspaceState } from "../agents/workspace-legacy-state.js";
-import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
 import { readWorkspaceStateSnapshot } from "../agents/workspace-state-store.js";
 import { runCommandWithRuntime } from "../cli/cli-utils.js";
 import {
@@ -1015,46 +1014,6 @@ describe("runDoctorHealthFlow", () => {
       });
     },
   );
-
-  it("completes repair after discarding an empty reserved workspace attestation", async () => {
-    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
-      const cfg: OpenClawConfig = {
-        agents: { defaults: { workspace: state.workspaceDir } },
-      };
-      mocks.config.mockReturnValue(cfg);
-      const identity = resolveWorkspaceStateIdentity(state.workspaceDir);
-      const attestationPath = path.join(
-        state.stateDir,
-        "workspace-attestations",
-        `${identity.workspaceKey}.attested`,
-      );
-      fs.mkdirSync(path.dirname(attestationPath), { recursive: true });
-      fs.writeFileSync(attestationPath, "");
-      mocks.runContributions.mockImplementation(async (ctx) => {
-        const result = await migrateLegacyWorkspaceState({
-          stateDir: state.stateDir,
-          env: state.env,
-          detected: detectLegacyWorkspaceState({
-            cfg: ctx.cfg,
-            stateDir: state.stateDir,
-            env: state.env,
-            homedir: () => state.home,
-            doctorOnlyStateMigrations: true,
-          }),
-        });
-        expect(result.warnings).toEqual([]);
-        expect(result.changes[0]).toContain(attestationPath);
-      });
-      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
-      await runDoctorHealthFlow(runtime, { repair: true, nonInteractive: true });
-      expect(mocks.outro).toHaveBeenCalledWith("Doctor complete.");
-      expect(runtime.exit).not.toHaveBeenCalled();
-      expect(fs.existsSync(attestationPath)).toBe(false);
-      expect(() =>
-        assertNoUnmigratedWorkspaceState({ workspaceDir: state.workspaceDir }),
-      ).not.toThrow();
-    });
-  });
 
   it.each(["missing-state", "missing-agent", "current"])(
     "accepts %s databases without creating or repairing them",

--- a/src/flows/doctor-health.test.ts
+++ b/src/flows/doctor-health.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { assertNoUnmigratedWorkspaceState } from "../agents/workspace-legacy-state.js";
+import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
 import { readWorkspaceStateSnapshot } from "../agents/workspace-state-store.js";
 import { runCommandWithRuntime } from "../cli/cli-utils.js";
 import {
@@ -1014,6 +1015,46 @@ describe("runDoctorHealthFlow", () => {
       });
     },
   );
+
+  it("completes repair after discarding an empty reserved workspace attestation", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+      const cfg: OpenClawConfig = {
+        agents: { defaults: { workspace: state.workspaceDir } },
+      };
+      mocks.config.mockReturnValue(cfg);
+      const identity = resolveWorkspaceStateIdentity(state.workspaceDir);
+      const attestationPath = path.join(
+        state.stateDir,
+        "workspace-attestations",
+        `${identity.workspaceKey}.attested`,
+      );
+      fs.mkdirSync(path.dirname(attestationPath), { recursive: true });
+      fs.writeFileSync(attestationPath, "");
+      mocks.runContributions.mockImplementation(async (ctx) => {
+        const result = await migrateLegacyWorkspaceState({
+          stateDir: state.stateDir,
+          env: state.env,
+          detected: detectLegacyWorkspaceState({
+            cfg: ctx.cfg,
+            stateDir: state.stateDir,
+            env: state.env,
+            homedir: () => state.home,
+            doctorOnlyStateMigrations: true,
+          }),
+        });
+        expect(result.warnings).toEqual([]);
+        expect(result.changes[0]).toContain(attestationPath);
+      });
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+      await runDoctorHealthFlow(runtime, { repair: true, nonInteractive: true });
+      expect(mocks.outro).toHaveBeenCalledWith("Doctor complete.");
+      expect(runtime.exit).not.toHaveBeenCalled();
+      expect(fs.existsSync(attestationPath)).toBe(false);
+      expect(() =>
+        assertNoUnmigratedWorkspaceState({ workspaceDir: state.workspaceDir }),
+      ).not.toThrow();
+    });
+  });
 
   it.each(["missing-state", "missing-agent", "current"])(
     "accepts %s databases without creating or repairing them",

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -675,6 +675,40 @@ describe("legacy workspace Doctor migration", () => {
     ).toBeUndefined();
   });
 
+  it("restores an empty reserved hashed attestation that changes before claim", async () => {
+    const context = setup();
+    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+    const attestationPath = path.join(
+      context.stateDir,
+      "workspace-attestations",
+      `${identity.workspaceKey}.attested`,
+    );
+    await fsp.mkdir(path.dirname(attestationPath), { recursive: true });
+    await fsp.writeFile(attestationPath, "", "utf8");
+    const replacementPath = path.join(context.homeDir, "empty-attestation-replacement");
+    await fsp.writeFile(replacementPath, "", "utf8");
+    const replacementInode = fs.statSync(replacementPath).ino;
+    const originalInode = fs.statSync(attestationPath).ino;
+
+    const result = await migrateLegacyWorkspaceState({
+      detected: detect(context),
+      env: context.env,
+      stateDir: context.stateDir,
+      beforeClaim: (source) => {
+        if (source.sourcePath === attestationPath) {
+          fs.renameSync(replacementPath, attestationPath);
+        }
+      },
+    });
+
+    expect(result.warnings[0]).toContain(attestationPath);
+    expect(result.warnings[0]).toMatch(/changed before Doctor could claim/i);
+    expect(fs.existsSync(`${attestationPath}.doctor-importing`)).toBe(false);
+    expect(fs.existsSync(attestationPath)).toBe(true);
+    expect(fs.statSync(attestationPath).ino).toBe(replacementInode);
+    expect(fs.statSync(attestationPath).ino).not.toBe(originalInode);
+  });
+
   it("discards an empty reserved hashed attestation claim left by an interrupted import", async () => {
     const context = setup();
     const identity = resolveWorkspaceStateIdentity(context.workspaceDir);

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import { assertNoUnmigratedWorkspaceState } from "../agents/workspace-legacy-state.js";
 import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
 import {
   deleteWorkspaceState,
@@ -630,6 +631,7 @@ describe("legacy workspace Doctor migration", () => {
     const result = await migrate(context);
 
     expect(result.warnings[0]).toMatch(/legacy workspace/i);
+    expect(result.warnings[0]).toContain(sourcePath);
     expect(fs.existsSync(sourcePath)).toBe(true);
     expect(fs.existsSync(`${sourcePath}.doctor-importing`)).toBe(false);
     const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
@@ -638,6 +640,97 @@ describe("legacy workspace Doctor migration", () => {
         .db.prepare("SELECT workspace_key FROM workspace_setup_state WHERE workspace_key = ?")
         .get(identity.workspaceKey),
     ).toBeUndefined();
+  });
+
+  it("discards an empty reserved hashed attestation and unblocks the workspace", async () => {
+    const context = setup();
+    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+    const attestationPath = path.join(
+      context.stateDir,
+      "workspace-attestations",
+      `${identity.workspaceKey}.attested`,
+    );
+    await fsp.mkdir(path.dirname(attestationPath), { recursive: true });
+    await fsp.writeFile(attestationPath, "", "utf8");
+
+    expect(detect(context).hasLegacy).toBe(true);
+    expect(() => assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir })).toThrow(
+      /requires migration/,
+    );
+
+    const result = await migrate(context);
+
+    expect(result.warnings).toEqual([]);
+    expect(result.changes[0]).toContain(attestationPath);
+    expect(fs.existsSync(attestationPath)).toBe(false);
+    expect(fs.existsSync(`${attestationPath}.doctor-importing`)).toBe(false);
+    expect(detect(context).hasLegacy).toBe(false);
+    expect(() =>
+      assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir }),
+    ).not.toThrow();
+    expect(
+      openOpenClawStateDatabase({ env: context.env })
+        .db.prepare("SELECT workspace_key FROM workspace_setup_state WHERE workspace_key = ?")
+        .get(identity.workspaceKey),
+    ).toBeUndefined();
+  });
+
+  it("discards an empty reserved hashed attestation claim left by an interrupted import", async () => {
+    const context = setup();
+    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+    const attestationPath = path.join(
+      context.stateDir,
+      "workspace-attestations",
+      `${identity.workspaceKey}.attested`,
+    );
+    const claimPath = `${attestationPath}.doctor-importing`;
+    await fsp.mkdir(path.dirname(attestationPath), { recursive: true });
+    await fsp.writeFile(claimPath, "", "utf8");
+
+    const result = await migrate(context);
+
+    expect(result.warnings).toEqual([]);
+    expect(fs.existsSync(attestationPath)).toBe(false);
+    expect(fs.existsSync(claimPath)).toBe(false);
+    expect(detect(context).hasLegacy).toBe(false);
+    expect(() =>
+      assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir }),
+    ).not.toThrow();
+  });
+
+  it("retains an empty workspace-sibling file and does not treat it as reserved state", async () => {
+    const context = setup();
+    const siblingPath = `${context.workspaceDir}.attested`;
+    await fsp.writeFile(siblingPath, "", "utf8");
+
+    expect(detect(context).hasLegacy).toBe(false);
+    const result = await migrate(context);
+
+    expect(result.warnings).toEqual([]);
+    expect(fs.existsSync(siblingPath)).toBe(true);
+    expect(() =>
+      assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir }),
+    ).not.toThrow();
+  });
+
+  it("retains an empty reserved hashed attestation that is a hardlink", async () => {
+    const context = setup();
+    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+    const attestationPath = path.join(
+      context.stateDir,
+      "workspace-attestations",
+      `${identity.workspaceKey}.attested`,
+    );
+    const targetPath = path.join(context.homeDir, "attestation-target");
+    await fsp.mkdir(path.dirname(attestationPath), { recursive: true });
+    await fsp.writeFile(targetPath, "", "utf8");
+    await fsp.link(targetPath, attestationPath);
+
+    const result = await migrate(context);
+
+    expect(result.warnings[0]).toContain(attestationPath);
+    expect(fs.existsSync(attestationPath)).toBe(true);
+    expect(fs.existsSync(`${attestationPath}.doctor-importing`)).toBe(false);
   });
 
   it("rejects a setup source beneath a symlinked workspace subdirectory", async () => {

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -23,6 +23,21 @@ const HASH = "a".repeat(64);
 describe("legacy workspace Doctor migration", () => {
   const { detect, migrate, setup } = useWorkspaceMigrationTestFixture();
 
+  async function writeEmptyReservedAttestation(
+    context: ReturnType<typeof setup>,
+    claimed = false,
+  ): Promise<string> {
+    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+    const attestationPath = path.join(
+      context.stateDir,
+      "workspace-attestations",
+      `${identity.workspaceKey}.attested`,
+    );
+    await fsp.mkdir(path.dirname(attestationPath), { recursive: true });
+    await fsp.writeFile(`${attestationPath}${claimed ? ".doctor-importing" : ""}`, "", "utf8");
+    return attestationPath;
+  }
+
   it("detects configured and orphan sources only for explicit Doctor repair", async () => {
     const context = setup();
     const setupPath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
@@ -645,13 +660,7 @@ describe("legacy workspace Doctor migration", () => {
   it("discards an empty reserved hashed attestation and unblocks the workspace", async () => {
     const context = setup();
     const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
-    const attestationPath = path.join(
-      context.stateDir,
-      "workspace-attestations",
-      `${identity.workspaceKey}.attested`,
-    );
-    await fsp.mkdir(path.dirname(attestationPath), { recursive: true });
-    await fsp.writeFile(attestationPath, "", "utf8");
+    const attestationPath = await writeEmptyReservedAttestation(context);
 
     expect(detect(context).hasLegacy).toBe(true);
     expect(() => assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir })).toThrow(
@@ -677,14 +686,7 @@ describe("legacy workspace Doctor migration", () => {
 
   it("restores an empty reserved hashed attestation that changes before claim", async () => {
     const context = setup();
-    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
-    const attestationPath = path.join(
-      context.stateDir,
-      "workspace-attestations",
-      `${identity.workspaceKey}.attested`,
-    );
-    await fsp.mkdir(path.dirname(attestationPath), { recursive: true });
-    await fsp.writeFile(attestationPath, "", "utf8");
+    const attestationPath = await writeEmptyReservedAttestation(context);
     const replacementPath = path.join(context.homeDir, "empty-attestation-replacement");
     await fsp.writeFile(replacementPath, "", "utf8");
     const replacementInode = fs.statSync(replacementPath).ino;
@@ -711,15 +713,8 @@ describe("legacy workspace Doctor migration", () => {
 
   it("discards an empty reserved hashed attestation claim left by an interrupted import", async () => {
     const context = setup();
-    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
-    const attestationPath = path.join(
-      context.stateDir,
-      "workspace-attestations",
-      `${identity.workspaceKey}.attested`,
-    );
+    const attestationPath = await writeEmptyReservedAttestation(context, true);
     const claimPath = `${attestationPath}.doctor-importing`;
-    await fsp.mkdir(path.dirname(attestationPath), { recursive: true });
-    await fsp.writeFile(claimPath, "", "utf8");
 
     const result = await migrate(context);
 
@@ -745,26 +740,6 @@ describe("legacy workspace Doctor migration", () => {
     expect(() =>
       assertNoUnmigratedWorkspaceState({ workspaceDir: context.workspaceDir }),
     ).not.toThrow();
-  });
-
-  it("retains an empty reserved hashed attestation that is a hardlink", async () => {
-    const context = setup();
-    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
-    const attestationPath = path.join(
-      context.stateDir,
-      "workspace-attestations",
-      `${identity.workspaceKey}.attested`,
-    );
-    const targetPath = path.join(context.homeDir, "attestation-target");
-    await fsp.mkdir(path.dirname(attestationPath), { recursive: true });
-    await fsp.writeFile(targetPath, "", "utf8");
-    await fsp.link(targetPath, attestationPath);
-
-    const result = await migrate(context);
-
-    expect(result.warnings[0]).toContain(attestationPath);
-    expect(fs.existsSync(attestationPath)).toBe(true);
-    expect(fs.existsSync(`${attestationPath}.doctor-importing`)).toBe(false);
   });
 
   it("rejects a setup source beneath a symlinked workspace subdirectory", async () => {

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -352,87 +352,11 @@ export function detectLegacyWorkspaceState(params: {
   return { sources, hasLegacy: sources.length > 0 };
 }
 
-function isReservedHashedAttestationSource(source: LegacyWorkspaceStateSource): boolean {
-  return (
-    source.kind === "attestation" &&
-    path.basename(path.dirname(source.sourcePath)) === LEGACY_WORKSPACE_ATTESTATION_DIRNAME &&
-    /^[a-f0-9]{64}\.attested$/.test(path.basename(source.sourcePath))
-  );
-}
-
 function formatLegacyWorkspaceReadWarning(
   source: LegacyWorkspaceStateSource,
   error: unknown,
 ): string {
   return `Failed reading legacy workspace state at ${source.sourcePath}: ${formatErrorMessage(error)}`;
-}
-
-function isEmptyReservedHashedAttestation(
-  source: LegacyWorkspaceStateSource,
-  snapshot: SourceSnapshot,
-): boolean {
-  return isReservedHashedAttestationSource(source) && snapshot.size === 0;
-}
-
-async function discardEmptyReservedAttestation(params: {
-  sourceClaim: LegacyMigrationSourceClaim<SourceSnapshot>;
-  source: LegacyWorkspaceStateSource;
-  snapshot: SourceSnapshot;
-  hasSource: boolean;
-  beforeClaim?: (source: LegacyWorkspaceStateSource) => void;
-  removeSource?: (sourcePath: string) => Promise<void> | void;
-}): Promise<MigrationMessages> {
-  let claimedByThisRun = false;
-  try {
-    let snapshot = params.snapshot;
-    if (params.hasSource) {
-      try {
-        snapshot = await params.sourceClaim.claim({
-          snapshot,
-          beforeClaim: () => {
-            params.beforeClaim?.(params.source);
-            assertConfiguredWorkspaceIdentity(params.source);
-          },
-          mismatchMessage: "legacy workspace source changed before Doctor could claim it",
-        });
-        claimedByThisRun = true;
-      } catch (error) {
-        const restoreError = await params.sourceClaim.restore();
-        return {
-          changes: [],
-          warnings: [
-            `Failed discarding empty reserved workspace attestation at ${params.source.sourcePath}: ${formatErrorMessage(error)}${restoreError ? `; restore failure: ${restoreError}` : ""}`,
-          ],
-        };
-      }
-      if (snapshot.size !== 0) {
-        throw new Error("legacy workspace source changed before Doctor could discard it");
-      }
-    }
-    if (await params.sourceClaim.exists()) {
-      throw new Error("legacy workspace source reappeared during discard");
-    }
-    const unchanged = await params.sourceClaim.read(true);
-    if (!snapshotsMatch(snapshot, unchanged) || unchanged.size !== 0) {
-      throw new Error("legacy workspace claim changed before discard");
-    }
-    await params.sourceClaim.remove({
-      removeSource: params.removeSource,
-      skipSourceCheck: true,
-    });
-    return {
-      changes: [`Discarded empty reserved workspace attestation at ${params.source.sourcePath}.`],
-      warnings: [],
-    };
-  } catch (error) {
-    const restoreError = claimedByThisRun ? await params.sourceClaim.restore() : null;
-    return {
-      changes: [],
-      warnings: [
-        `Failed discarding empty reserved workspace attestation at ${params.source.sourcePath}: ${formatErrorMessage(error)}${restoreError ? `; restore failure: ${restoreError}` : ""}`,
-      ],
-    };
-  }
 }
 
 function assertConfiguredWorkspaceIdentity(source: LegacyWorkspaceStateSource): void {
@@ -585,24 +509,22 @@ async function migrateOneSource(params: {
   }
 
   let snapshot: SourceSnapshot;
-  let parsed: ParsedSource;
+  let parsed: ParsedSource | undefined;
+  let discardEmptyAttestation: boolean;
   let claimedByThisRun = false;
   try {
     snapshot = await sourceClaim.read(!hasSource);
     // Empty reserved hashed markers have no importable state. The runtime gate is
     // presence-only, so leaving them in place blocks agent turns forever.
     // Nonempty, linked, sibling, and unreadable sources stay fail-closed.
-    if (isEmptyReservedHashedAttestation(params.source, snapshot)) {
-      return await discardEmptyReservedAttestation({
-        sourceClaim,
-        source: params.source,
-        snapshot,
-        hasSource,
-        beforeClaim: params.beforeClaim,
-        removeSource: params.removeSource,
-      });
+    discardEmptyAttestation =
+      params.source.kind === "attestation" &&
+      path.basename(path.dirname(params.source.sourcePath)) ===
+        LEGACY_WORKSPACE_ATTESTATION_DIRNAME &&
+      snapshot.size === 0;
+    if (!discardEmptyAttestation) {
+      parsed = parseSource(params.source, snapshot);
     }
-    parsed = parseSource(params.source, snapshot);
   } catch (error) {
     return {
       changes: [],
@@ -626,30 +548,37 @@ async function migrateOneSource(params: {
       return {
         changes: [],
         warnings: [
-          `Failed migrating legacy workspace state: ${formatErrorMessage(error)}${restoreError ? `; restore failure: ${restoreError}` : ""}`,
+          `Failed ${discardEmptyAttestation ? `discarding empty reserved workspace attestation at ${params.source.sourcePath}` : "migrating legacy workspace state"}: ${formatErrorMessage(error)}${restoreError ? `; restore failure: ${restoreError}` : ""}`,
         ],
       };
     }
   }
 
-  let result: ReturnType<typeof importAndRecordReceipt>;
-  try {
-    assertConfiguredWorkspaceIdentity(params.source);
-    result = importAndRecordReceipt({
-      source: params.source,
-      snapshot,
-      parsed,
-      env: params.env,
-      replaceRemovedReceipt: receipt?.removedSource === true,
-    });
-  } catch (error) {
-    const restoreError = claimedByThisRun ? await sourceClaim.restore() : null;
-    return {
-      changes: [],
-      warnings: [
-        `Failed migrating legacy workspace state: ${formatErrorMessage(error)}${restoreError ? `; restore failure: ${restoreError}` : ""}`,
-      ],
-    };
+  let imported:
+    | { parsed: ParsedSource; receipt: ReturnType<typeof importAndRecordReceipt> }
+    | undefined;
+  if (parsed) {
+    try {
+      assertConfiguredWorkspaceIdentity(params.source);
+      imported = {
+        parsed,
+        receipt: importAndRecordReceipt({
+          source: params.source,
+          snapshot,
+          parsed,
+          env: params.env,
+          replaceRemovedReceipt: receipt?.removedSource === true,
+        }),
+      };
+    } catch (error) {
+      const restoreError = claimedByThisRun ? await sourceClaim.restore() : null;
+      return {
+        changes: [],
+        warnings: [
+          `Failed migrating legacy workspace state: ${formatErrorMessage(error)}${restoreError ? `; restore failure: ${restoreError}` : ""}`,
+        ],
+      };
+    }
   }
 
   try {
@@ -660,9 +589,21 @@ async function migrateOneSource(params: {
     if (!snapshotsMatch(snapshot, unchanged)) {
       throw new Error("legacy workspace claim changed after import");
     }
+    assertConfiguredWorkspaceIdentity(params.source);
     await sourceClaim.remove({ removeSource: params.removeSource, skipSourceCheck: true });
-    markLegacyMigrationSourceRemoved(result.sourceKey, params.env);
+    if (imported) {
+      markLegacyMigrationSourceRemoved(imported.receipt.sourceKey, params.env);
+    }
   } catch (error) {
+    if (discardEmptyAttestation) {
+      const restoreError = claimedByThisRun ? await sourceClaim.restore() : null;
+      return {
+        changes: [],
+        warnings: [
+          `Failed discarding empty reserved workspace attestation at ${params.source.sourcePath}: ${formatErrorMessage(error)}${restoreError ? `; restore failure: ${restoreError}` : ""}`,
+        ],
+      };
+    }
     return {
       changes: [],
       warnings: [
@@ -671,10 +612,19 @@ async function migrateOneSource(params: {
     };
   }
 
-  const label = parsed.kind === "setup" ? "workspace setup state" : "workspace attestation";
+  if (!imported) {
+    return {
+      changes: [`Discarded empty reserved workspace attestation at ${params.source.sourcePath}.`],
+      warnings: [],
+    };
+  }
+  const label =
+    imported.parsed.kind === "setup" ? "workspace setup state" : "workspace attestation";
   return {
     changes: [
-      result.imported ? `Migrated ${label} to SQLite.` : `Verified canonical SQLite ${label}.`,
+      imported.receipt.imported
+        ? `Migrated ${label} to SQLite.`
+        : `Verified canonical SQLite ${label}.`,
     ],
     warnings: [],
     notices: ["Removed retired workspace state after verified SQLite import."],

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -352,6 +352,79 @@ export function detectLegacyWorkspaceState(params: {
   return { sources, hasLegacy: sources.length > 0 };
 }
 
+function isReservedHashedAttestationSource(source: LegacyWorkspaceStateSource): boolean {
+  return (
+    source.kind === "attestation" &&
+    path.basename(path.dirname(source.sourcePath)) === LEGACY_WORKSPACE_ATTESTATION_DIRNAME &&
+    /^[a-f0-9]{64}\.attested$/.test(path.basename(source.sourcePath))
+  );
+}
+
+function formatLegacyWorkspaceReadWarning(
+  source: LegacyWorkspaceStateSource,
+  error: unknown,
+): string {
+  return `Failed reading legacy workspace state at ${source.sourcePath}: ${formatErrorMessage(error)}`;
+}
+
+function isEmptyReservedHashedAttestation(
+  source: LegacyWorkspaceStateSource,
+  snapshot: SourceSnapshot,
+): boolean {
+  return isReservedHashedAttestationSource(source) && snapshot.size === 0;
+}
+
+async function discardEmptyReservedAttestation(params: {
+  sourceClaim: LegacyMigrationSourceClaim<SourceSnapshot>;
+  source: LegacyWorkspaceStateSource;
+  snapshot: SourceSnapshot;
+  hasSource: boolean;
+  beforeClaim?: (source: LegacyWorkspaceStateSource) => void;
+  removeSource?: (sourcePath: string) => Promise<void> | void;
+}): Promise<MigrationMessages> {
+  let claimedByThisRun = false;
+  try {
+    let snapshot = params.snapshot;
+    if (params.hasSource) {
+      snapshot = await params.sourceClaim.claim({
+        snapshot,
+        beforeClaim: () => {
+          params.beforeClaim?.(params.source);
+          assertConfiguredWorkspaceIdentity(params.source);
+        },
+        mismatchMessage: "legacy workspace source changed before Doctor could claim it",
+      });
+      claimedByThisRun = true;
+      if (snapshot.size !== 0) {
+        throw new Error("legacy workspace source changed before Doctor could discard it");
+      }
+    }
+    if (await params.sourceClaim.exists()) {
+      throw new Error("legacy workspace source reappeared during discard");
+    }
+    const unchanged = await params.sourceClaim.read(true);
+    if (!snapshotsMatch(snapshot, unchanged) || unchanged.size !== 0) {
+      throw new Error("legacy workspace claim changed before discard");
+    }
+    await params.sourceClaim.remove({
+      removeSource: params.removeSource,
+      skipSourceCheck: true,
+    });
+    return {
+      changes: [`Discarded empty reserved workspace attestation at ${params.source.sourcePath}.`],
+      warnings: [],
+    };
+  } catch (error) {
+    const restoreError = claimedByThisRun ? await params.sourceClaim.restore() : null;
+    return {
+      changes: [],
+      warnings: [
+        `Failed discarding empty reserved workspace attestation at ${params.source.sourcePath}: ${formatErrorMessage(error)}${restoreError ? `; restore failure: ${restoreError}` : ""}`,
+      ],
+    };
+  }
+}
+
 function assertConfiguredWorkspaceIdentity(source: LegacyWorkspaceStateSource): void {
   if (!source.workspaceAliasPath) {
     return;
@@ -462,7 +535,7 @@ async function migrateOneSource(params: {
   } catch (error) {
     return {
       changes: [],
-      warnings: [`Failed reading legacy workspace state: ${formatErrorMessage(error)}`],
+      warnings: [formatLegacyWorkspaceReadWarning(params.source, error)],
     };
   }
   const receipt = readReceipt(params.source, params.env);
@@ -474,7 +547,7 @@ async function migrateOneSource(params: {
   } catch (error) {
     return {
       changes: [],
-      warnings: [`Failed reading legacy workspace state: ${formatErrorMessage(error)}`],
+      warnings: [formatLegacyWorkspaceReadWarning(params.source, error)],
     };
   }
   // One artifact after verified removal is a new generation, including a source
@@ -506,11 +579,24 @@ async function migrateOneSource(params: {
   let claimedByThisRun = false;
   try {
     snapshot = await sourceClaim.read(!hasSource);
+    // Empty reserved hashed markers have no importable state. The runtime gate is
+    // presence-only, so leaving them in place blocks agent turns forever.
+    // Nonempty, linked, sibling, and unreadable sources stay fail-closed.
+    if (isEmptyReservedHashedAttestation(params.source, snapshot)) {
+      return await discardEmptyReservedAttestation({
+        sourceClaim,
+        source: params.source,
+        snapshot,
+        hasSource,
+        beforeClaim: params.beforeClaim,
+        removeSource: params.removeSource,
+      });
+    }
     parsed = parseSource(params.source, snapshot);
   } catch (error) {
     return {
       changes: [],
-      warnings: [`Failed reading legacy workspace state: ${formatErrorMessage(error)}`],
+      warnings: [formatLegacyWorkspaceReadWarning(params.source, error)],
     };
   }
 

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -386,15 +386,25 @@ async function discardEmptyReservedAttestation(params: {
   try {
     let snapshot = params.snapshot;
     if (params.hasSource) {
-      snapshot = await params.sourceClaim.claim({
-        snapshot,
-        beforeClaim: () => {
-          params.beforeClaim?.(params.source);
-          assertConfiguredWorkspaceIdentity(params.source);
-        },
-        mismatchMessage: "legacy workspace source changed before Doctor could claim it",
-      });
-      claimedByThisRun = true;
+      try {
+        snapshot = await params.sourceClaim.claim({
+          snapshot,
+          beforeClaim: () => {
+            params.beforeClaim?.(params.source);
+            assertConfiguredWorkspaceIdentity(params.source);
+          },
+          mismatchMessage: "legacy workspace source changed before Doctor could claim it",
+        });
+        claimedByThisRun = true;
+      } catch (error) {
+        const restoreError = await params.sourceClaim.restore();
+        return {
+          changes: [],
+          warnings: [
+            `Failed discarding empty reserved workspace attestation at ${params.source.sourcePath}: ${formatErrorMessage(error)}${restoreError ? `; restore failure: ${restoreError}` : ""}`,
+          ],
+        };
+      }
       if (snapshot.size !== 0) {
         throw new Error("legacy workspace source changed before Doctor could discard it");
       }


### PR DESCRIPTION
Closes #134445

## What Problem This Solves

`openclaw doctor --fix` parsed a zero-byte reserved workspace attestation before it could classify the file. Parsing failed with `legacy workspace attestation has an invalid header`, so Doctor retained the marker. The presence-only runtime gate then rejected every turn for that workspace and kept telling the operator to rerun a repair that could not converge.

## Fix

Doctor now treats a safe zero-byte file at the reserved hashed attestation path as having no importable state. It uses the existing source claim, snapshot verification, restore, and removal lifecycle to discard that marker. Nonempty, hardlinked, symlinked, and workspace-sibling files remain fail-closed. Read failures now name the source path.

The repair keeps the contributor's original commits and replaces the separate cleanup lifecycle with the canonical migration path. The final source delta is +73/-27, tests +102, and docs +4/-1. The positive production delta provides the new owner-boundary discard outcome and explicit failure reporting; the refactor removed 43 net lines from the contributor head.

## Evidence

Baseline: current `main` at `77fee957919f06dbaff09dd5cc7f9664d9655651`.

```text
$ openclaw doctor --non-interactive --fix --yes
Legacy state detected
Failed reading legacy workspace state: legacy workspace attestation has an invalid header
Doctor could not complete maintenance.
DOCTOR_FIRST_STATUS=1

$ openclaw doctor --non-interactive --fix --yes
Legacy state detected
Failed reading legacy workspace state: legacy workspace attestation has an invalid header
DOCTOR_SECOND_STATUS=1
PROOF_RESULT=blocked
MARKER_PRESENT=yes
```

Exact head: `f308f8bc68f114f63e9aa6f8b79c13e01d429744`.

```text
$ openclaw doctor --non-interactive --fix --yes
Legacy state detected
Doctor changes
Discarded empty reserved workspace attestation at <temp-state>/workspace-attestations/<workspace-key>.attested.
Doctor complete.

$ openclaw doctor --non-interactive --fix --yes
Doctor complete.
PROOF_RESULT=recovered
MARKER_PRESENT=no
```

The second run is the anti-cheat probe: it uses the same state directory and confirms that the migration converged.

## Tests

- Pre-fix regression: the new discard test fails on current main with `legacy workspace attestation has an invalid header`.
- Exact head: `state-migrations.workspace-setup.test.ts` and `state-migrations.source-snapshot.test.ts` pass, 40 tests total.
- Coverage includes an interrupted claim, a source replaced before claim, sibling-file preservation, and the runtime readiness transition.
