### PR TITLE
test(gateway): share title-retention disk fixtures across isolated readers

### DIFF
--- a/src/gateway/session-transcript-title-reader.retention.test.ts
+++ b/src/gateway/session-transcript-title-reader.retention.test.ts
@@ -1,5 +1,53 @@
 import { spawnSync } from "node:child_process";
-import { expect, test } from "vitest";
+import path from "node:path";
+import { afterAll, beforeAll, expect, test } from "vitest";
+import {
+  persistSessionTranscriptTurn,
+  upsertSessionEntryCore,
+} from "../config/sessions/session-accessor.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { cleanupSessionStateForTest } from "../test-utils/session-state-cleanup.js";
+
+let state: OpenClawTestState;
+let storePath: string;
+
+beforeAll(async () => {
+  state = await createOpenClawTestState({ label: "title-cache-retention", applyEnv: false });
+  storePath = path.join(state.sessionsDir("main"), "sessions.json");
+  const scope = { agentId: "main", env: state.env, storePath };
+  for (let index = 0; index < 128; index++) {
+    const sessionId = `preview-${index}`;
+    const target = { ...scope, sessionId, sessionKey: `agent:main:dashboard:${sessionId}` };
+    await upsertSessionEntryCore(target, { sessionId, updatedAt: 1, displayName: "Named session" });
+    await persistSessionTranscriptTurn(target, {
+      config: {},
+      messages: [
+        { message: { role: "user", content: index + ": " + "abcdefg ".repeat(32 * 1024) } },
+        { message: { role: "assistant", content: "Short reply." } },
+      ],
+      touchSessionEntry: false,
+    });
+  }
+  await persistSessionTranscriptTurn(
+    { ...scope, sessionId: "unicode-preview", sessionKey: "agent:main:unicode-preview" },
+    {
+      config: {},
+      messages: [
+        { message: { role: "user", content: String.fromCharCode(0xd800) + " visible text" } },
+      ],
+      touchSessionEntry: false,
+    },
+  );
+  // Share only committed disk state; each child creates its own title cache and heap.
+  await cleanupSessionStateForTest({ stateDir: state.stateDir });
+}, 20_000);
+
+afterAll(async () => {
+  await state?.cleanup();
+});
 
 test.each(["scalar", "batch"])(
   "releases transcript payloads after caching %s title fields",
@@ -14,12 +62,9 @@ test.each(["scalar", "batch"])(
         "--input-type=module",
         "--eval",
         `
-          import path from "node:path";
           import { setImmediate as yieldTurn } from "node:timers/promises";
-          import { persistSessionTranscriptTurn, upsertSessionEntryCore } from ${JSON.stringify(moduleUrl("../config/sessions/session-accessor.ts"))};
           import { readSessionTitleFieldsFromTranscript, readSessionTitleFieldsFromTranscriptBatch } from ${JSON.stringify(moduleUrl("./session-transcript-title-reader.ts"))};
           import { deriveSessionTitle } from ${JSON.stringify(moduleUrl("./session-utils-core.ts"))};
-          import { withOpenClawTestState } from ${JSON.stringify(moduleUrl("../test-utils/openclaw-test-state.ts"))};
 
           async function heapUsed() {
             await yieldTurn();
@@ -27,49 +72,32 @@ test.each(["scalar", "batch"])(
             return process.memoryUsage().heapUsed;
           }
 
-          await withOpenClawTestState({ label: "title-cache-retention" }, async (state) => {
-            const storePath = path.join(state.sessionsDir("main"), "sessions.json");
-            const scopes = [];
-            for (let index = 0; index < 128; index++) {
-              const sessionId = "preview-" + index;
-              const sessionKey = "agent:main:dashboard:" + sessionId;
-              const scope = { agentId: "main", sessionId, sessionKey, storePath };
-              await upsertSessionEntryCore(scope, { sessionId, updatedAt: 1, displayName: "Named session" });
-              await persistSessionTranscriptTurn(scope, {
-                messages: [
-                  { message: { role: "user", content: index + ": " + "abcdefg ".repeat(32 * 1024) } },
-                  { message: { role: "assistant", content: "Short reply." } },
-                ],
-                touchSessionEntry: false,
-              });
-              scopes.push(scope);
-            }
-            const before = await heapUsed();
-            const listRows = () => {
-              const fields = ${JSON.stringify(mode)} === "scalar"
-                ? scopes.map((scope) => readSessionTitleFieldsFromTranscript(scope))
-                : readSessionTitleFieldsFromTranscriptBatch(scopes);
-              return fields.map((field, index) => ({
-                derivedTitle: deriveSessionTitle({ sessionId: scopes[index].sessionId, updatedAt: 1, displayName: "Named session" }, field.firstUserMessage),
-                lastMessagePreview: field.lastMessagePreview,
-              }));
-            };
-            // Named sessions do not consume the cached first-user preview. Serializing
-            // that unused field here would flatten its slices and hide the retention.
-            const rows = listRows();
-            JSON.stringify(rows);
-            const retainedBytes = (await heapUsed()) - before;
-            const unicodeScope = { ...scopes[0], sessionId: "unicode-preview", sessionKey: "agent:main:unicode-preview" };
-            await persistSessionTranscriptTurn(unicodeScope, {
-              messages: [{ message: { role: "user", content: String.fromCharCode(0xd800) + " visible text" } }],
-              touchSessionEntry: false,
-            });
-            const unicodePreview = readSessionTitleFieldsFromTranscript(unicodeScope).firstUserMessage;
-            process.stdout.write(JSON.stringify({ retainedBytes, rows, unicodePreview }));
+          const storePath = ${JSON.stringify(storePath)};
+          const scopes = Array.from({ length: 128 }, (_, index) => {
+            const sessionId = "preview-" + index;
+            return { agentId: "main", sessionId, sessionKey: "agent:main:dashboard:" + sessionId, storePath };
           });
+          const before = await heapUsed();
+          const listRows = () => {
+            const fields = ${JSON.stringify(mode)} === "scalar"
+              ? scopes.map((scope) => readSessionTitleFieldsFromTranscript(scope))
+              : readSessionTitleFieldsFromTranscriptBatch(scopes);
+            return fields.map((field, index) => ({
+              derivedTitle: deriveSessionTitle({ sessionId: scopes[index].sessionId, updatedAt: 1, displayName: "Named session" }, field.firstUserMessage),
+              lastMessagePreview: field.lastMessagePreview,
+            }));
+          };
+          // Named sessions do not consume the cached first-user preview. Serializing
+          // that unused field here would flatten its slices and hide the retention.
+          const rows = listRows();
+          JSON.stringify(rows);
+          const retainedBytes = (await heapUsed()) - before;
+          const unicodeScope = { ...scopes[0], sessionId: "unicode-preview", sessionKey: "agent:main:unicode-preview" };
+          const unicodePreview = readSessionTitleFieldsFromTranscript(unicodeScope).firstUserMessage;
+          process.stdout.write(JSON.stringify({ retainedBytes, rows, unicodePreview }));
         `,
       ],
-      { cwd: process.cwd(), encoding: "utf8", timeout: 20_000 },
+      { cwd: process.cwd(), env: state.env, encoding: "utf8", timeout: 20_000 },
     );
     expect(result.error).toBeUndefined();
     expect(result.status, result.stderr).toBe(0);


### PR DESCRIPTION
The scalar and batch heap-regression cases each construct the same real SQLite fixture inside a fresh child. Share one committed disk fixture, drain and close its parent writer handles, then keep the two independent reader children. This removes 128 duplicate session upserts, 129 transcript writes, and one state allocation/removal. Production is unchanged; tests +72/-44.

Both children still read all 128 large prompts and retain independent caches and GC baselines. All ten assertions, the lone-surrogate check, 8 MiB retained-heap limit, 20-second child limit, and 30-second row limit remain. Setup now has its own 20-second hook limit, so the phase budget changes. Cold reader/database initialization now contributes to each heap delta; no title-cache prewarming or cached-preview serialization is introduced.

Validation: both original retention cases pass; all 31 focused candidate cases pass. Temporarily removing only the production UTF-16 copy makes both original and both candidate modes fail at the unchanged heap assertion, retaining over 31 MiB. An injected seed failure proves the parent removes its owned fixture root. After exact restoration, the captured two-worker gateway core/client group passes 3,364 cases with two existing skips. Full changed checks and Codex autoreview pass.

The motivating CI failure was a scalar child timeout in #134611, not a failed heap assertion. Its slow phase is unknown. The replay preserves the captured selection and configuration order, not the original per-worker scheduling; macOS results do not establish a Linux timing gain. Exact-head hosted CI is required before landing. No elapsed-time speedup is claimed.

Follow-ups: attribute child cold-start phases if the Linux timeout recurs; remove or relocate the orphaned transcript-copy JSDoc at the end of the entry accessor in an owning-accessor cleanup. No runtime behavior, config, schema, or dependency changes.
