### PR TITLE
refactor(googlechat): share approval card text escaping

### DIFF
--- a/extensions/googlechat/src/approval-card-click.test.ts
+++ b/extensions/googlechat/src/approval-card-click.test.ts
@@ -31,7 +31,7 @@ function createApprovalResolveResult(params: {
     params.approvalKind === "exec"
       ? {
           kind: "exec" as const,
-          commandText: "echo hi",
+          commandText: `<tag> & &amp; "double" 'single'`,
           commandPreview: null,
           allowedDecisions: ["allow-once" as const, "deny" as const],
         }
@@ -175,7 +175,11 @@ describe("maybeHandleGoogleChatApprovalCardClick", () => {
       cardsV2: expect.any(Array),
     });
     const cardJson = JSON.stringify(updateGoogleChatMessage.mock.calls[0]?.[0]);
+    const cardText =
+      updateGoogleChatMessage.mock.calls[0]?.[0].cardsV2[0].card.sections[0].widgets[0]
+        .textParagraph.text;
     expect(cardJson).toContain("Exec Approval: Allowed once");
+    expect(cardText).toBe(`&lt;tag&gt; &amp; &amp;amp; "double" 'single'`);
     expect(cardJson).toContain("Resolved by this action");
     expect(cardJson).not.toContain("buttonList");
   });

--- a/extensions/googlechat/src/approval-card-text.ts
+++ b/extensions/googlechat/src/approval-card-text.ts
@@ -1,0 +1,3 @@
+export function escapeGoogleChatApprovalCardText(text: string): string {
+  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+}

--- a/extensions/googlechat/src/approval-handler.runtime.test.ts
+++ b/extensions/googlechat/src/approval-handler.runtime.test.ts
@@ -70,7 +70,7 @@ function createPendingView(): ExecApprovalPendingView {
     agentId: "main",
     warningText: null,
     commandAnalysis: null,
-    commandText: "echo hi",
+    commandText: `<tag> & &amp; "double" 'single'`,
     commandPreview: null,
     cwd: "/tmp",
     envKeys: [],
@@ -233,6 +233,8 @@ describe("googleChatApprovalNativeRuntime", () => {
     });
 
     expect(JSON.stringify(pendingPayload)).toContain("cardsV2");
+    const commandText = getTextParagraphText(pendingPayload, "Command");
+    expect(commandText).toBe(`&lt;tag&gt; &amp; &amp;amp; "double" 'single'`);
     expect(JSON.stringify(pendingPayload.cardsV2)).toContain(
       "https://chat-app.example.test/googlechat",
     );

--- a/extensions/googlechat/src/approval-handler.runtime.ts
+++ b/extensions/googlechat/src/approval-handler.runtime.ts
@@ -22,6 +22,7 @@ import {
   unregisterGoogleChatManualApprovalFollowupSuppression,
   unregisterGoogleChatApprovalCardBindings,
 } from "./approval-card-actions.js";
+import { escapeGoogleChatApprovalCardText as escapeGoogleChatText } from "./approval-card-text.js";
 import {
   isGoogleChatNativeApprovalClientEnabled,
   shouldHandleGoogleChatNativeApprovalRequest,
@@ -86,10 +87,6 @@ function resolveHandlerAccount(
     return null;
   }
   return account;
-}
-
-function escapeGoogleChatText(text: string): string {
-  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 }
 
 function truncateText(text: string, maxChars = MAX_TEXT_PARAGRAPH_CHARS): string {

--- a/extensions/googlechat/src/approval-terminal-card.ts
+++ b/extensions/googlechat/src/approval-terminal-card.ts
@@ -1,13 +1,10 @@
 import type { ApprovalResolveResult } from "openclaw/plugin-sdk/approval-gateway-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { escapeGoogleChatApprovalCardText as escapeGoogleChatText } from "./approval-card-text.js";
 import type { GoogleChatCardV2 } from "./types.js";
 
 const GOOGLECHAT_APPROVAL_CARD_ID = "openclaw-approval";
 const MAX_TEXT_PARAGRAPH_CHARS = 1800;
-
-function escapeGoogleChatText(text: string): string {
-  return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
-}
 
 function truncateText(text: string): string {
   return text.length <= MAX_TEXT_PARAGRAPH_CHARS


### PR DESCRIPTION
## What Problem This Solves

Google Chat pending and terminal approval cards independently implemented the same HTML text escaping rule. The duplicate policy could drift on replacement order, entity handling, quote handling, or truncation order and produce inconsistent approval-card text.

## Why This Change Was Made

This consolidates the exact three-character Google Chat approval-card escaping contract in one private plugin helper. Both callers retain their existing local name and truncation boundary. Ordinary message Markdown formatting, shared HTML helpers, card composition, IDs, SDK surfaces, config, packages, and protocol behavior are unchanged.

## User Impact

No intended visible behavior change. Pending and terminal approval cards continue escaping `&`, `<`, and `>` in that order, double-escaping existing entities, and leaving quotes and apostrophes unchanged.

## Evidence

- Production LOC: `+5/-6` (net `-1`).
- Tests: `+8/-2`.
- Focused approval suites: 2 files, 16 tests passed.
- Full Google Chat extension lane: 33 files, 355 tests passed.
- Exact rendered text covered at both delivery boundaries:
  - input: `<tag> & &amp; "double" 'single'`
  - output: `&lt;tag&gt; &amp; &amp;amp; "double" 'single'`
- In-memory mutation checks rejected all nine reviewed variants: replacement reordering, quote/apostrophe escaping, existing-entity preservation, either caller bypassing the helper, either caller moving escaping before truncation, ordinary Markdown helper reuse, and shared/core HTML helper reuse.
- Structural checks confirm one escaping implementation, two owner-local imports, preserved truncation nesting, and no ordinary Markdown/shared HTML dependency.
- `pnpm check:changed` passed conflict, max-lines, assertion-safety, changelog, doctor, extension boundary, duplicate coverage, dependency, formatting, doctor-contract, plugin-boundary, patch, and test-temp gates. It then stopped in the shared extension typecheck on eight unrelated existing Telegram dependency/type errors, including missing `RichMessageButton` from `grammy/types`; this PR changes only `extensions/googlechat/**`.
- Clean Linux Testbox passed the full Google Chat extension lane (`355/355`) and complete `pnpm check:changed`: Blacksmith lease `tbx_01m1dbd7g91mc1j65dh1hp0r34`, workflow run `33461210429`.
- Exact pinned Codex autoreview: scoped clean, no accepted/actionable findings, correctness `0.99`.
- Test-audit authoring gate: assertions protect observable card payload bytes, target credible extraction regressions, extend existing pending-delivery/card-click boundaries, and add no test-only production seam.
- Codex hard gate inspected directly: `../codex/codex-rs/cli/src/main.rs:220-245` and `../codex/codex-rs/cli/src/main.rs:2840-2870`; unrelated to this plugin-local text contract.
- Live overlap checked immediately before implementation:
  - #123075 touches nearby approval flow/test code but not the escaping implementation.
  - #98577 touches nearby handler code but not the escaping implementation.
- Exact-head CI passed at `8f8d9ae57d1f11fc785d38341a4b20762d9cf733` in workflow run `33461699520`; failed-job rerun recovered a transient `ECONNRESET` while downloading `@matrix-org/matrix-sdk-crypto-nodejs@0.6.6`, and aggregate `openclaw/ci-gate` job `99714357026` succeeded.
