### PR TITLE
fix(cron): admit immediate main-session wakes when heartbeat is disabled

### DIFF
--- a/src/cron/service.wake-now-real-heartbeat.test.ts
+++ b/src/cron/service.wake-now-real-heartbeat.test.ts
@@ -44,7 +44,11 @@ function makeSandbox() {
 
 type WakeNowRunMode = "direct" | "queued" | "scheduled";
 
-async function runMainCronCase(mode: WakeNowRunMode, wakeMode: "now" | "next-heartbeat" = "now") {
+async function runMainCronCase(
+  mode: WakeNowRunMode,
+  wakeMode: "now" | "next-heartbeat" = "now",
+  options: { heartbeatEvery?: string; deleteAfterRun?: boolean } = {},
+) {
   const sandbox = makeSandbox();
   const getReplySpy = vi.fn().mockResolvedValue({ text: "Handled the reminder" });
   const sendTelegram = vi.fn().mockResolvedValue({ messageId: "m1", chatId: "155462274" });
@@ -58,7 +62,7 @@ async function runMainCronCase(mode: WakeNowRunMode, wakeMode: "now" | "next-hea
     agents: {
       defaults: {
         workspace: sandbox.dir,
-        heartbeat: { every: "5m", target: "telegram" },
+        heartbeat: { every: options.heartbeatEvery ?? "5m", target: "telegram" },
       },
     },
     channels: { telegram: { allowFrom: ["*"] } },
@@ -116,6 +120,7 @@ async function runMainCronCase(mode: WakeNowRunMode, wakeMode: "now" | "next-hea
       sessionTarget: "main",
       wakeMode,
       payload: { kind: "systemEvent", text: "Reminder: Send the nightly report" },
+      ...(options.deleteAfterRun === undefined ? {} : { deleteAfterRun: options.deleteAfterRun }),
     });
 
     if (mode === "direct") {
@@ -167,6 +172,9 @@ async function runMainCronCase(mode: WakeNowRunMode, wakeMode: "now" | "next-hea
     expect(replyCtx.SessionKey).toBe(expectedMainSessionKey);
     expect(replyCtx.Body).toContain("Reminder: Send the nightly report");
     expect(peekSystemEventEntries(expectedMainSessionKey)).toHaveLength(0);
+    if (options.deleteAfterRun) {
+      expect(cron.getJob(job.id)).toBeUndefined();
+    }
   } finally {
     cron.stop();
     const drained = await waitForActiveCronJobs(5_000);
@@ -190,5 +198,9 @@ describe("main cron with the real heartbeat runner", () => {
 
   it("delivers a next-heartbeat event through a later scheduled main-session heartbeat", async () => {
     await runMainCronCase("direct", "next-heartbeat");
+  });
+
+  it("delivers and removes an immediate one-shot when heartbeat cadence is disabled", async () => {
+    await runMainCronCase("scheduled", "now", { heartbeatEvery: "0m", deleteAfterRun: true });
   });
 });

--- a/src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts
+++ b/src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts
@@ -11,6 +11,80 @@ import { requestHeartbeat } from "./heartbeat-wake.js";
 describe("startHeartbeatRunner targeted unscheduled wake dispatch", () => {
   type RunOnce = Parameters<typeof startHeartbeatRunner>[0]["runOnce"];
   type MockRunOnce = RunOnce & { mock: { calls: unknown[][] } };
+  const targetedWakeCases = [
+    {
+      name: "cron",
+      wake: {
+        source: "cron",
+        intent: "immediate",
+        reason: "cron:one-shot",
+        agentId: "main",
+      },
+    },
+    {
+      name: "manual",
+      wake: {
+        source: "manual",
+        intent: "immediate",
+        reason: "wake",
+        sessionKey: "agent:main:main",
+      },
+    },
+    {
+      name: "notification",
+      wake: {
+        source: "notifications-event",
+        intent: "immediate",
+        reason: "wake",
+        sessionKey: "agent:main:main",
+      },
+    },
+    {
+      name: "restart sentinel",
+      wake: {
+        source: "restart-sentinel",
+        intent: "immediate",
+        reason: "wake",
+        sessionKey: "agent:main:main",
+      },
+    },
+    {
+      name: "hook",
+      wake: {
+        source: "hook",
+        intent: "immediate",
+        reason: "hook:123e4567-e89b-12d3-a456-426614174000",
+        agentId: "main",
+      },
+    },
+    {
+      name: "exec event",
+      wake: {
+        source: "exec-event",
+        intent: "event",
+        reason: "exec-event",
+        sessionKey: "agent:main:main",
+      },
+    },
+    {
+      name: "background task",
+      wake: {
+        source: "background-task",
+        intent: "immediate",
+        reason: "background-task",
+        sessionKey: "agent:main:main",
+      },
+    },
+    {
+      name: "blocked background task",
+      wake: {
+        source: "background-task-blocked",
+        intent: "immediate",
+        reason: "background-task-blocked",
+        sessionKey: "agent:main:main",
+      },
+    },
+  ] as const;
   function useFakeHeartbeatTime() {
     vi.useFakeTimers();
     vi.setSystemTime(new Date(0));
@@ -114,27 +188,27 @@ describe("startHeartbeatRunner targeted unscheduled wake dispatch", () => {
     },
   );
 
-  it("runs a targeted immediate cron wake when recurring heartbeats are disabled", async () => {
+  it.each(
+    targetedWakeCases.flatMap((testCase) =>
+      ["0m", "30m"].map((heartbeatEvery) => ({
+        name: testCase.name,
+        wake: testCase.wake,
+        heartbeatEvery,
+      })),
+    ),
+  )("runs one targeted $name wake with heartbeat cadence $heartbeatEvery", async (testCase) => {
     useFakeHeartbeatTime();
     const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
     const runner = await expectWakeDispatch({
       cfg: {
-        agents: { defaults: { heartbeat: { every: "0m" } }, list: [{ id: "main" }] },
+        agents: {
+          defaults: { heartbeat: { every: testCase.heartbeatEvery } },
+          list: [{ id: "main" }],
+        },
       } as OpenClawConfig,
       runSpy,
-      wake: {
-        source: "cron",
-        intent: "immediate",
-        reason: "cron:one-shot",
-        agentId: "main",
-        coalesceMs: 0,
-      },
-      expectedCall: {
-        agentId: "main",
-        source: "cron",
-        intent: "immediate",
-        reason: "cron:one-shot",
-      },
+      wake: { ...testCase.wake, coalesceMs: 0 },
+      expectedCall: testCase.wake,
     });
     runner.stop();
   });
@@ -179,7 +253,7 @@ describe("startHeartbeatRunner targeted unscheduled wake dispatch", () => {
     runner.stop();
   });
 
-  it("keeps targeted manual wakes disabled when heartbeats are globally disabled", async () => {
+  it.each(targetedWakeCases)("keeps targeted $name wakes globally disabled", async (testCase) => {
     useFakeHeartbeatTime();
     setHeartbeatsEnabled(false);
     const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
@@ -190,22 +264,21 @@ describe("startHeartbeatRunner targeted unscheduled wake dispatch", () => {
       runOnce: runSpy,
     });
 
-    requestHeartbeat({
-      source: "manual",
-      intent: "immediate",
-      reason: "wake",
-      sessionKey: "agent:main:main",
-      coalesceMs: 0,
-    });
+    requestHeartbeat({ ...testCase.wake, coalesceMs: 0 });
     await vi.advanceTimersByTimeAsync(1);
 
     expect(runSpy).not.toHaveBeenCalled();
     runner.stop();
   });
 
-  it("keeps targeted cron wakes disabled when heartbeats are globally disabled", async () => {
+  it.each([
+    { name: "event intent", wake: { intent: "event" as const } },
+    { name: "a non-namespaced reason", wake: { reason: "cron" } },
+    { name: "another source's reason", wake: { reason: "wake" } },
+    { name: "a non-cron source", wake: { source: "manual" as const } },
+    { name: "no target", wake: { agentId: undefined } },
+  ])("rejects an unscheduled cron wake with $name", async ({ wake }) => {
     useFakeHeartbeatTime();
-    setHeartbeatsEnabled(false);
     const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
     const runner = startHeartbeatRunner({
       cfg: {
@@ -219,125 +292,12 @@ describe("startHeartbeatRunner targeted unscheduled wake dispatch", () => {
       intent: "immediate",
       reason: "cron:one-shot",
       agentId: "main",
+      ...wake,
       coalesceMs: 0,
     });
     await vi.advanceTimersByTimeAsync(1);
 
     expect(runSpy).not.toHaveBeenCalled();
-    runner.stop();
-  });
-
-  it.each([
-    { name: "session-targeted", sessionKey: "agent:ops:main" },
-    { name: "agent-targeted", sessionKey: undefined },
-  ])("runs one $name hook wake for an agent without a heartbeat schedule", async (testCase) => {
-    useFakeHeartbeatTime();
-    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
-    const runner = await expectWakeDispatch({
-      cfg: {
-        agents: { list: [{ id: "main", heartbeat: { every: "30m" } }, { id: "ops" }] },
-      } as OpenClawConfig,
-      runSpy,
-      wake: {
-        source: "hook",
-        intent: "immediate",
-        reason: "hook:123e4567-e89b-12d3-a456-426614174000",
-        agentId: "ops",
-        sessionKey: testCase.sessionKey,
-        coalesceMs: 0,
-      },
-      expectedCall: {
-        agentId: "ops",
-        source: "hook",
-        intent: "immediate",
-        reason: "hook:123e4567-e89b-12d3-a456-426614174000",
-        sessionKey: testCase.sessionKey,
-      },
-    });
-    runner.stop();
-  });
-
-  it.each([
-    { source: "background-task", reason: "background-task" },
-    { source: "background-task-blocked", reason: "background-task-blocked" },
-  ] as const)(
-    "runs one targeted unscheduled $source wake for a configured agent",
-    async ({ source, reason }) => {
-      useFakeHeartbeatTime();
-      const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
-      const runner = await expectWakeDispatch({
-        cfg: {
-          agents: { list: [{ id: "main", heartbeat: { every: "30m" } }, { id: "ops" }] },
-        } as OpenClawConfig,
-        runSpy,
-        wake: {
-          source,
-          intent: "immediate",
-          reason,
-          sessionKey: "agent:ops:main",
-          coalesceMs: 0,
-        },
-        expectedCall: {
-          agentId: "ops",
-          source,
-          intent: "immediate",
-          reason,
-          sessionKey: "agent:ops:main",
-        },
-      });
-      runner.stop();
-    },
-  );
-
-  it("runs one targeted exec-event wake when heartbeat cadence is disabled", async () => {
-    useFakeHeartbeatTime();
-    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
-    const runner = await expectWakeDispatch({
-      cfg: {
-        agents: { defaults: { heartbeat: { every: "0m" } }, list: [{ id: "main" }] },
-      } as OpenClawConfig,
-      runSpy,
-      wake: {
-        source: "exec-event",
-        intent: "event",
-        reason: "exec-event",
-        sessionKey: "agent:main:main",
-        coalesceMs: 0,
-      },
-      expectedCall: {
-        agentId: "main",
-        source: "exec-event",
-        intent: "event",
-        reason: "exec-event",
-        sessionKey: "agent:main:main",
-      },
-    });
-    runner.stop();
-  });
-
-  it("runs one targeted restart-sentinel wake when heartbeat cadence is disabled", async () => {
-    useFakeHeartbeatTime();
-    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
-    const runner = await expectWakeDispatch({
-      cfg: {
-        agents: { defaults: { heartbeat: { every: "0m" } }, list: [{ id: "main" }] },
-      } as OpenClawConfig,
-      runSpy,
-      wake: {
-        source: "restart-sentinel",
-        intent: "immediate",
-        reason: "wake",
-        sessionKey: "agent:main:main",
-        coalesceMs: 0,
-      },
-      expectedCall: {
-        agentId: "main",
-        source: "restart-sentinel",
-        intent: "immediate",
-        reason: "wake",
-        sessionKey: "agent:main:main",
-      },
-    });
     runner.stop();
   });
 
@@ -377,45 +337,26 @@ describe("startHeartbeatRunner targeted unscheduled wake dispatch", () => {
     runner.stop();
   });
 
-  it("rejects targeted hook wakes for unconfigured agents", async () => {
-    useFakeHeartbeatTime();
-    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
-    const runner = startHeartbeatRunner({
-      cfg: { agents: { list: [{ id: "main", heartbeat: { every: "30m" } }] } } as OpenClawConfig,
-      runOnce: runSpy,
-    });
+  it.each(targetedWakeCases)(
+    "rejects targeted $name wakes for unconfigured agents",
+    async (testCase) => {
+      useFakeHeartbeatTime();
+      const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+      const runner = startHeartbeatRunner({
+        cfg: { agents: { list: [{ id: "main" }] } } as OpenClawConfig,
+        runOnce: runSpy,
+      });
 
-    requestHeartbeat({
-      source: "hook",
-      intent: "immediate",
-      reason: "hook:123e4567-e89b-12d3-a456-426614174000",
-      agentId: "bogus",
-      coalesceMs: 0,
-    });
-    await vi.advanceTimersByTimeAsync(1);
+      requestHeartbeat({
+        ...testCase.wake,
+        agentId: "unknown",
+        sessionKey: "agent:unknown:main",
+        coalesceMs: 0,
+      });
+      await vi.advanceTimersByTimeAsync(1);
 
-    expect(runSpy).not.toHaveBeenCalled();
-    runner.stop();
-  });
-
-  it("rejects targeted cron wakes for unconfigured agents", async () => {
-    useFakeHeartbeatTime();
-    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
-    const runner = startHeartbeatRunner({
-      cfg: { agents: { list: [{ id: "main" }] } } as OpenClawConfig,
-      runOnce: runSpy,
-    });
-
-    requestHeartbeat({
-      source: "cron",
-      intent: "immediate",
-      reason: "cron:one-shot",
-      agentId: "unknown",
-      coalesceMs: 0,
-    });
-    await vi.advanceTimersByTimeAsync(1);
-
-    expect(runSpy).not.toHaveBeenCalled();
-    runner.stop();
-  });
+      expect(runSpy).not.toHaveBeenCalled();
+      runner.stop();
+    },
+  );
 });

--- a/src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts
+++ b/src/infra/heartbeat-runner.targeted-unscheduled-wake.test.ts
@@ -114,6 +114,31 @@ describe("startHeartbeatRunner targeted unscheduled wake dispatch", () => {
     },
   );
 
+  it("runs a targeted immediate cron wake when recurring heartbeats are disabled", async () => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = await expectWakeDispatch({
+      cfg: {
+        agents: { defaults: { heartbeat: { every: "0m" } }, list: [{ id: "main" }] },
+      } as OpenClawConfig,
+      runSpy,
+      wake: {
+        source: "cron",
+        intent: "immediate",
+        reason: "cron:one-shot",
+        agentId: "main",
+        coalesceMs: 0,
+      },
+      expectedCall: {
+        agentId: "main",
+        source: "cron",
+        intent: "immediate",
+        reason: "cron:one-shot",
+      },
+    });
+    runner.stop();
+  });
+
   it.each([
     {
       name: "without a session target",
@@ -170,6 +195,30 @@ describe("startHeartbeatRunner targeted unscheduled wake dispatch", () => {
       intent: "immediate",
       reason: "wake",
       sessionKey: "agent:main:main",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runSpy).not.toHaveBeenCalled();
+    runner.stop();
+  });
+
+  it("keeps targeted cron wakes disabled when heartbeats are globally disabled", async () => {
+    useFakeHeartbeatTime();
+    setHeartbeatsEnabled(false);
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: {
+        agents: { defaults: { heartbeat: { every: "0m" } }, list: [{ id: "main" }] },
+      } as OpenClawConfig,
+      runOnce: runSpy,
+    });
+
+    requestHeartbeat({
+      source: "cron",
+      intent: "immediate",
+      reason: "cron:one-shot",
+      agentId: "main",
       coalesceMs: 0,
     });
     await vi.advanceTimersByTimeAsync(1);
@@ -341,6 +390,27 @@ describe("startHeartbeatRunner targeted unscheduled wake dispatch", () => {
       intent: "immediate",
       reason: "hook:123e4567-e89b-12d3-a456-426614174000",
       agentId: "bogus",
+      coalesceMs: 0,
+    });
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(runSpy).not.toHaveBeenCalled();
+    runner.stop();
+  });
+
+  it("rejects targeted cron wakes for unconfigured agents", async () => {
+    useFakeHeartbeatTime();
+    const runSpy = vi.fn().mockResolvedValue({ status: "ran", durationMs: 1 });
+    const runner = startHeartbeatRunner({
+      cfg: { agents: { list: [{ id: "main" }] } } as OpenClawConfig,
+      runOnce: runSpy,
+    });
+
+    requestHeartbeat({
+      source: "cron",
+      intent: "immediate",
+      reason: "cron:one-shot",
+      agentId: "unknown",
       coalesceMs: 0,
     });
     await vi.advanceTimersByTimeAsync(1);

--- a/src/infra/heartbeat-wake-policy.ts
+++ b/src/infra/heartbeat-wake-policy.ts
@@ -71,6 +71,8 @@ export function isTargetedUnscheduledWake(params: TargetedUnscheduledWakeParams)
   // they cannot broaden the immediate-wake exception.
   const reason = params.reason?.trim();
   switch (params.source) {
+    case "cron":
+      return params.intent === "immediate" && (reason?.startsWith("cron:") ?? false);
     case "manual":
     case "notifications-event":
     case "restart-sentinel":


### PR DESCRIPTION
## What Problem This Solves

Fixes #134500.

One-shot main-session cron jobs with `wakeMode: "now"` were rejected when recurring heartbeat cadence was `0m`. The job stayed disabled even though cron had explicit immediate intent.

## Why This Change Was Made

The shared targeted-wake policy now admits only the cron producer's existing shape: `source: "cron"`, immediate intent, a `cron:<job>` reason, and a configured agent target.

Global heartbeat disable, configured-agent checks, and all other source rules remain authoritative. This adds no scheduler fallback and no configuration surface.

## User Impact

Immediate one-shot main-session cron jobs now run and honor `deleteAfterRun` when periodic heartbeat scheduling is disabled.

## Evidence

- Current main `0229104301ec968634d8f10a34740e2cfa25ae8a`: a real Gateway `cron.add` flow finished `skipped`, sent zero provider requests, and retained the one-shot job.
- Exact head `9845bb021871c94c05d5b269b052af9ddb745470`: the same flow finished `ok`, sent one provider request containing the proof marker, and removed the one-shot job.
- Global-disable control: the exact head still finished `skipped`, sent zero provider requests, and retained the job.
- Focused tests: 46 shared-policy matrix cases and 5 real-runner CronService cases passed.
- The matrix covers cron, manual, notifications, restart sentinel, hooks, exec events, background tasks, and blocked background tasks with `0m` and `30m` cadence, global disable, unconfigured targets, and cron near-miss payloads.
- Local format, Oxlint, conflict-marker, max-lines, assertion-safety, coercion-helper, deprecated-API, test-temp, and diff checks passed. CI owns type checking and build on this host.

Production LOC: `+2/-0`. Tests: `+153/-130`.

AI-assisted: built with Codex
