### PR TITLE
fix(ui): stop pin tooltips repeating session titles

### DIFF
--- a/ui/src/components/app-sidebar-session-row-render.ts
+++ b/ui/src/components/app-sidebar-session-row-render.ts
@@ -245,7 +245,7 @@ export function renderRecentSession(params: {
       (event.currentTarget as HTMLElement).querySelector("[data-session-menu]"),
       (trigger, x, y) => host.sidebarMenus.openSessionMenu(session, x, y, trigger),
     );
-  const pinLabel = `${t(session.pinned ? "sessionsView.unpinSession" : "sessionsView.pinSession")}: ${label}`;
+  const pinLabel = t(session.pinned ? "sessionsView.unpinSession" : "sessionsView.pinSession");
   const menuTooltip = t("chat.sidebar.openSessionMenu");
   const menuLabel = `${menuTooltip}: ${label}`;
   const menuOpen =

--- a/ui/src/e2e/session-management.optimistic-pin.e2e.test.ts
+++ b/ui/src/e2e/session-management.optimistic-pin.e2e.test.ts
@@ -62,7 +62,7 @@ suite.define(() => {
 
       await gateway.deferNext("sessions.patch");
       await row.hover();
-      await row.getByRole("button", { name: "Pin session: Pin me" }).click();
+      await row.getByRole("button", { name: "Pin session" }).click();
 
       // The Gateway response is still held, so this can only come from the
       // optimistic snapshot write in the mutation owner.
@@ -153,13 +153,13 @@ suite.define(() => {
 
       await gateway.deferNext("sessions.patch");
       await row.hover();
-      await row.getByRole("button", { name: "Pin session: Pin me" }).click();
+      await row.getByRole("button", { name: "Pin session" }).click();
       await expect.poll(() => zoneEntry.count()).toBe(1);
 
       await gateway.deferNext("sessions.patch");
       const pinnedRow = zoneEntry.locator(".sidebar-recent-session");
       await pinnedRow.hover();
-      await pinnedRow.getByRole("button", { name: "Unpin session: Pin me" }).click();
+      await pinnedRow.getByRole("button", { name: "Unpin session" }).click();
       await expect.poll(() => row.count()).toBe(1);
       await expect.poll(() => zoneEntry.count()).toBe(0);
 

--- a/ui/src/e2e/session-management.sidebar.e2e.test.ts
+++ b/ui/src/e2e/session-management.sidebar.e2e.test.ts
@@ -366,9 +366,7 @@ suite.define(() => {
         name: "Open session menu: Research notes",
         exact: true,
       });
-      await researchRow
-        .getByRole("button", { name: "Pin session: Research notes", exact: true })
-        .waitFor();
+      await researchRow.getByRole("button", { name: "Pin session", exact: true }).waitFor();
       await followUpRow
         .getByRole("button", { name: "Open session menu: Follow-up work", exact: true })
         .waitFor();

--- a/ui/src/test-helpers/app-sidebar-cases/interactions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/interactions.ts
@@ -60,20 +60,20 @@ describe("AppSidebar context menu boundary", () => {
 });
 
 describe("AppSidebar multi-select", () => {
-  it("names session actions and routes menu hints through the shared tooltip", async () => {
+  it("uses generic pin labels and routes menu hints through the shared tooltip", async () => {
     const { sidebar } = await mountMultiSelect();
 
     for (const key of ["agent:main:a", "agent:main:b"]) {
       const row = sidebar.querySelector<HTMLElement>(`[data-session-key="${key}"]`);
       const label = row?.querySelector(".sidebar-recent-session__name")?.textContent?.trim();
+      const pin = row?.querySelector<HTMLElement>("[data-sidebar-session-pin]");
       const menu = row?.querySelector<HTMLElement>("[data-session-menu]");
       const tooltip = menu?.closest("openclaw-tooltip") as
         | (HTMLElement & { content: string; describe: boolean })
         | null;
       expect(label).toBeTruthy();
-      expect(row?.querySelector("[data-sidebar-session-pin]")?.getAttribute("aria-label")).toBe(
-        `Pin session: ${label}`,
-      );
+      expect(pin?.getAttribute("aria-label")).toBe("Pin session");
+      expect(pin?.getAttribute("title")).toBe("Pin session");
       expect(menu?.getAttribute("aria-label")).toBe(`Open session menu: ${label}`);
       expect(menu?.hasAttribute("title")).toBe(false);
       expect(tooltip?.content).toBe("Open session menu");


### PR DESCRIPTION
Closes #134647

## What Problem This Solves

Fixes an issue where users hovering a sidebar session's pin or unpin action would see the session title repeated in the tooltip, producing redundant and potentially very long action copy.

## Why This Change Was Made

The shared sidebar row renderer now uses the existing localized `Pin session` / `Unpin session` strings directly for the visible tooltip and action label. The neighboring menu keeps its generic visible tooltip while retaining session-specific assistive context in its accessible name.

## User Impact

Sidebar pin and unpin tooltips are now concise and consistent across regular sessions and adopted catalog sessions. Session titles remain visible in the row itself.

## Evidence

| Before | After |
| --- | --- |
| ![Before: Pin session tooltip repeats Research notes](https://github.com/user-attachments/assets/fd837c63-75b3-4535-a1a2-d72e4ff7d049) | ![After: concise Pin session tooltip](https://github.com/user-attachments/assets/3404138c-3c51-4764-b151-557f8a497e8d) |

Focused validation:

- `node scripts/run-vitest.mjs ui/src/components/app-sidebar.test.ts --reporter=dot` — 323 passed
- `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/session-management.sidebar.e2e.test.ts ui/src/e2e/session-management.optimistic-pin.e2e.test.ts --reporter=dot` — 13 passed
- `node scripts/check-changed.mjs -- ui/src/components/app-sidebar-session-row-render.ts ui/src/test-helpers/app-sidebar-cases/interactions.ts ui/src/e2e/session-management.sidebar.e2e.test.ts ui/src/e2e/session-management.optimistic-pin.e2e.test.ts` — passed
- Before/after captures were produced by the same isolated Chromium session-management path and inspected at full resolution.

Known proof gap: the repository's independent autoreview helper was attempted twice but could not authenticate to its isolated review service (`401 Unauthorized`), so it produced no verdict. This patch is a one-line copy change with direct unit and browser regression coverage.
