### PR TITLE
fix(ui): delay microphone hover reveal

### DIFF
--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -373,10 +373,10 @@ suite.define(() => {
         .poll(() =>
           microphonePickerShell.evaluate((node) => getComputedStyle(node).transitionDelay),
         )
-        .toBe("0.5s");
+        .toBe("0.75s");
       await expect
         .poll(() => microphonePicker.evaluate((node) => getComputedStyle(node).transitionDelay))
-        .toBe("0.5s, 0.5s, 0.57s, 0s, 0s");
+        .toBe("0.75s, 0.75s, 0.82s, 0s, 0s");
       await page.evaluate(
         () =>
           new Promise<void>((resolve) => {

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -367,10 +367,35 @@ suite.define(() => {
       const pickerWidth = () =>
         microphonePicker.evaluate((node) => node.getBoundingClientRect().width);
       await expect.poll(pickerWidth).toBe(0);
+      await page.emulateMedia({ reducedMotion: "no-preference" });
       await voice.hover();
-      await expect.poll(pickerWidth).toBeGreaterThanOrEqual(12);
-      const voiceBeforeHold = await voice.boundingBox();
+      await expect
+        .poll(() =>
+          microphonePickerShell.evaluate((node) => getComputedStyle(node).transitionDelay),
+        )
+        .toBe("0.5s");
+      await expect
+        .poll(() => microphonePicker.evaluate((node) => getComputedStyle(node).transitionDelay))
+        .toBe("0.5s, 0.5s, 0.57s, 0s, 0s");
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
+      expect(await pickerWidth()).toBe(0);
+      await expect.poll(pickerWidth).toBeGreaterThanOrEqual(27.5);
+      const [voiceBeforeHold, pickerBeforeHold] = await Promise.all([
+        voice.boundingBox(),
+        microphonePicker.boundingBox(),
+      ]);
       expect(voiceBeforeHold).not.toBeNull();
+      expect(pickerBeforeHold).not.toBeNull();
+      expect(
+        Math.abs(
+          (voiceBeforeHold?.x ?? 0) - ((pickerBeforeHold?.x ?? 0) + (pickerBeforeHold?.width ?? 0)),
+        ),
+      ).toBeLessThanOrEqual(0.5);
       await page.mouse.down();
       await expect
         .poll(() =>
@@ -386,6 +411,19 @@ suite.define(() => {
       );
       await page.mouse.up();
       await page.mouse.move(0, 0);
+      await expect.poll(pickerWidth).toBe(0);
+      await voice.hover();
+      await voice.press("Tab");
+      await expect
+        .poll(() => microphonePicker.evaluate((node) => node === document.activeElement))
+        .toBe(true);
+      await expect
+        .poll(() =>
+          microphonePickerShell.evaluate((node) => getComputedStyle(node).transitionDelay),
+        )
+        .toBe("0s, 0s");
+      await expect.poll(pickerWidth).toBeGreaterThanOrEqual(27.5);
+      await textarea.click();
       await expect.poll(pickerWidth).toBe(0);
       await expect
         .poll(() => model.evaluate((node) => node.closest(".agent-chat__composer-footer") != null))

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -4808,7 +4808,7 @@ button.chat-pr__diff {
      the picker grow toward the transcript without replacing the hovered target. */
   flex-direction: row-reverse;
   align-items: center;
-  gap: 2px;
+  gap: 0;
   flex: 0 0 auto;
   border-radius: var(--radius-full);
   background: transparent;
@@ -4860,8 +4860,8 @@ button.chat-pr__diff {
     opacity 120ms ease-out;
 }
 
-/* The captured hold outlives transient hover recalculation during rerenders.
-   Keep it as an explicit reveal owner so the mic and chevron never reflow mid-gesture. */
+/* Focus, open, and captured-hold states reveal immediately so hover dwell never
+   delays keyboard access or lets the mic and chevron reflow mid-gesture. */
 .chat-talk-control--holding .chat-talk-input-picker,
 .chat-talk-control:has(:focus-visible) .chat-talk-input-picker,
 .chat-talk-input-picker[open] {
@@ -4870,9 +4870,11 @@ button.chat-pr__diff {
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .chat-talk-control:hover .chat-talk-input-picker {
+  .chat-talk-control:hover:not(.chat-talk-control--holding):not(:has(:focus-visible))
+    .chat-talk-input-picker:not([open]) {
     width: var(--chat-microphone-picker-width);
     opacity: 1;
+    transition-delay: 500ms;
   }
 }
 
@@ -4942,11 +4944,13 @@ button.chat-pr__diff {
 }
 
 @media (hover: hover) and (pointer: fine) {
-  .chat-talk-control:hover .chat-talk-input-picker__trigger {
+  .chat-talk-control:hover:not(.chat-talk-control--holding):not(:has(:focus-visible))
+    .chat-talk-input-picker:not([open])
+    .chat-talk-input-picker__trigger {
     width: var(--chat-microphone-picker-width);
     opacity: 1;
     transform: translateX(0);
-    transition-delay: 0ms, 0ms, 70ms, 0ms, 0ms;
+    transition-delay: 500ms, 500ms, 570ms, 0ms, 0ms;
     pointer-events: auto;
   }
 }

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -4874,7 +4874,7 @@ button.chat-pr__diff {
     .chat-talk-input-picker:not([open]) {
     width: var(--chat-microphone-picker-width);
     opacity: 1;
-    transition-delay: 500ms;
+    transition-delay: 750ms;
   }
 }
 
@@ -4950,7 +4950,7 @@ button.chat-pr__diff {
     width: var(--chat-microphone-picker-width);
     opacity: 1;
     transform: translateX(0);
-    transition-delay: 500ms, 500ms, 570ms, 0ms, 0ms;
+    transition-delay: 750ms, 750ms, 820ms, 0ms, 0ms;
     pointer-events: auto;
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Moving across the chat composer immediately triggered the microphone device-chevron animation, adding incidental motion. Once expanded, the chevron also sat farther from the microphone than intended.

## Why This Change Was Made

Adds a 750ms dwell only to fine-pointer hover discovery and removes the 2px inter-control gap. Keyboard focus, an open picker, dictation holds, touch devices, reduced-motion users, and collapse remain immediate.

## User Impact

Brief pointer passes no longer animate the microphone picker. Intentional hover still reveals it after three quarters of a second, with the chevron seated directly beside the microphone.

## Evidence

### Before

Reveal completed in 158ms with a 2px final gap.

https://github.com/user-attachments/assets/caa7b843-19ed-42ca-807d-4ee08f83e845

### After

The existing after recording is retained as requested and was captured at the earlier 500ms iteration. It shows the delayed reveal and 0px gap; the final implementation increases the dwell to 750ms.

https://github.com/user-attachments/assets/becd2c28-8c7d-4d0f-a589-a5c0cd1c1bb2

### Validation

- `pnpm test:ui:e2e -- ui/src/e2e/chat-composer-redesign.e2e.test.ts` — 7 tests passed at the final 750ms value.
- Changed-file gates passed through formatting, dependency, localization, and graph checks. The core-test typecheck initially could not resolve a fixture omitted by the sparse checkout; `node scripts/run-tsgo-core-test-shards.mjs` passed after materializing `.github`.
- Both 1280x900 mock-UI recordings were inspected after capture; the existing proof was not rerecorded for the 750ms follow-up.
