### PR TITLE
fix(macos): show confirmed setup cancellation clearly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Docs: https://docs.openclaw.ai
 
 ### Fixes
 
+- **macOS AI setup:** show confirmed capability-review cancellation and retry guidance directly instead of a misleading Gateway failure headline. (#134573)
 - **Doctor memory:** keep Matrix migration codecs separate from the live client and avoid loading the ACP runtime when no legacy session records need inspection.
 - **Agent prompts:** keep model-identity guidance conditional so ordinary requests are not mistaken for questions about the current model.
 

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetup.swift
@@ -913,10 +913,9 @@ extension OnboardingAISetupModel {
             }
         } catch {
             guard self.isCurrentAttempt(context) else { return }
-            // Cancellation, decoding, and transport failures after dispatch are
-            // ambiguous. Keep the marker; model-label detection is not proof that
-            // this activation and its credential mutation completed safely.
-            let failure = Self.transportFailure(error.localizedDescription)
+            // Confirmed wizard cancellation is an operator outcome; only other
+            // errors need transport diagnostics and may require reconciliation.
+            let failure = Self.activationFailure(error)
             self.exposeActivationFailure(failure, for: request)
             if Self.activationFailureIsDefinitive(error) {
                 self.pendingActivationVerification = false

--- a/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
+++ b/apps/macos/Sources/OpenClaw/OnboardingAISetupSupport.swift
@@ -459,6 +459,13 @@ extension OnboardingAISetupModel {
             : 150_000
     }
 
+    static func activationFailure(_ error: Error) -> Failure {
+        if case OnboardingAISetupError.activationCancelled = error {
+            return Failure(summary: error.localizedDescription, detail: nil)
+        }
+        return self.transportFailure(error.localizedDescription)
+    }
+
     static func activationFailureIsDefinitive(_ error: Error) -> Bool {
         if case OnboardingAISetupError.activationCancelled = error {
             return true

--- a/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OnboardingAISetupTests.swift
@@ -1040,6 +1040,29 @@ struct OnboardingAISetupTests {
         #expect(model.connected == (decision == "accept"))
         #expect(model.pendingActivationVerification == (decision == "error" || decision == "retry-cancel"))
         #expect(model.activeAuthOption == nil)
+        if decision != "accept" {
+            let failure: OnboardingAISetupModel.Failure
+            if manual {
+                failure = try #require(model.manualError)
+            } else {
+                guard case let .failed(candidateFailure) = model.statuses["codex-cli"] else {
+                    Issue.record("Expected a visible activation failure")
+                    return
+                }
+                failure = candidateFailure
+            }
+            if decision == "decline" || decision == "cancel" {
+                #expect(failure.summary ==
+                    "AI setup was cancelled. No inference route was selected. Choose a connection to try again.")
+                #expect(failure.detail == nil)
+            } else {
+                #expect(failure.summary ==
+                    "The Gateway setup request failed. Show details to inspect or copy the error.")
+                #expect(failure.detail == (decision == "error"
+                        ? "AI access was saved, but could not be applied."
+                        : "AI setup ended before its result was received. OpenClaw will verify the Gateway before trying again."))
+            }
+        }
         let requests = await recorder.snapshot()
         #expect(!requests.methods.contains("openclaw.setup.activate"))
         #expect(requests.methods.filter { $0 == "openclaw.setup.activate.start" }.count == 1)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where macOS users declining runtime plugin capability review or cancelling AI activation saw “The Gateway setup request failed” even though cancellation had been confirmed. The actual cancellation and retry guidance was hidden under details.

Fixes #134573.

## Why This Change Was Made

Preserve the typed confirmed-cancellation outcome at the shared activation presentation boundary. Both detected connections and manual API-key setup now show the existing cancellation message directly. Genuine transport errors and unknown activation outcomes retain their original diagnostic presentation, receipt ownership, reconciliation, and retry behavior. No protocol, configuration, persistence, consent, or provider-auth dismissal policy changes.

The UI renderer cannot recover a type that has already been reduced to a string, and string-matching in the generic transport formatter would misclassify arbitrary Gateway errors. The activation owner is the narrow shared boundary. Production changes are +10/-4 lines (net +6), including one small formatter in the existing support module to keep the lifecycle function within its complexity limit; tests add 23 lines to the existing matrix, with no new fixture or production test seam.

## User Impact

Confirmed cancellation visibly says that AI setup was cancelled and invites choosing a connection to retry. It no longer implies a broken Gateway.

## Evidence

- Before: personally reproduced through Computer Use in the real signed macOS app and an isolated real Gateway while verifying #133793. Declining review preserved configuration, installed no runtime plugin, and allowed retry; the row incorrectly showed the generic Gateway headline. See https://github.com/openclaw/openclaw/issues/133793#issuecomment-5486751935.
- Extended the existing shared-wizard matrix to check actual candidate/manual failure presentation for decline, cancel, accepted activation, terminal failure, and unresolved cancellation. Existing transport and ownership-race coverage remains intact.
- Independent source inspection and managed Codex autoreview found no accepted/actionable findings in the requested scope. The owner still consumes the authoritative wizard result; Codex turn-interrupt semantics are unchanged.
- Exact-head [CI 33461866326](https://github.com/openclaw/openclaw/actions/runs/33461866326) passed, including all 10 consent cases, 1,906 app tests, 1,546 shared-kit tests, and named-profile coverage. The actual changed gate passed with pinned Swift tools and all seven selected Mac tooling shards. Signed after-fix GUI proof passed through Computer Use on exact app/worker revision `7a04eca510749a966fe6f3e15505a5675b146b77`: unchecked Submit and the Cancel button both show the cancellation/retry sentence directly, retry returns to review, and configuration remains byte-identical with no Codex install or model route. Developer ID signing and the 42,829-file artifact name scan passed. This was an arm64 debug proof build, not a published release.
- Sanitized before screenshot is retained locally. GitHub's attachment endpoint returned HTTP 403 and the repository artifact broker reported `artifact_upload_unavailable`; no uploaded image URL is claimed. Sanitized before/after captures were inspected and retained locally; the upload limitation remains.

ClawSweeper disposition (reviewed 2026-09-01 02:21 UTC): the runtime design is accepted as the correct owner boundary. Retaining the one-line changelog entry under the active maintainer instructions for user-visible fixes; this is maintainer release-note bookkeeping, not a contributor requirement. The six production lines preserve the typed presentation contract without duplicating the lifecycle or widening the generic transport formatter. Its other rank-up request is complete: signed after-fix GUI proof and exact-head native CI both pass.

Maintainer closeout: this is the follow-up to the release-verification defect in #133793/#134573. Native preparation used the documented `OPENCLAW_ALLOW_ROOT_CHANGELOG_PR=1` closeout mode while retaining exact-head hosted CI and all review gates. No release artifacts are published by this PR.

Non-blocking environment follow-up: after this GUI proof, the isolated Gateway reported clean shutdown and closed its listener, but Node 24.19.0 lingered in `CompileCacheHandler::Persist` → synchronous filesystem rename during process exit. The exact task process was terminated after the prolonged cache flush; the stack sample is retained for a separate Node compile-cache shutdown-latency investigation. This does not change the cancellation or configuration evidence above, and no operator Gateway was stopped.
