### PR TITLE
test(raft): observe bridge startup without polling

### DIFF
--- a/extensions/raft/src/gateway.test.ts
+++ b/extensions/raft/src/gateway.test.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from "node:events";
 import type { ChannelGatewayContext } from "openclaw/plugin-sdk/channel-contract";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { createChannelReplayGuard } from "openclaw/plugin-sdk/persistent-dedupe";
 import { resetPluginStateStoreForTests } from "openclaw/plugin-sdk/plugin-state-test-runtime";
 import {
@@ -7,6 +8,7 @@ import {
   tempWorkspaceSync,
   type TempWorkspaceSync,
 } from "openclaw/plugin-sdk/temp-path";
+import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ResolvedRaftAccount } from "./accounts.js";
 import { startRaftGatewayAccount } from "./gateway.js";
@@ -23,6 +25,12 @@ vi.mock("openclaw/plugin-sdk/process-runtime", async (importOriginal) => ({
 
 class FakeBridge extends EventEmitter {
   pid = 4242;
+  readonly started = createDeferred<{ endpoint: string; token: string }>();
+
+  spawn = (params: { endpoint: string; token: string }) => {
+    this.started.resolve(params);
+    return this;
+  };
 }
 
 const tempWorkspaces: TempWorkspaceSync[] = [];
@@ -134,19 +142,6 @@ function createPersistentWakeDedupe(stateDir: string) {
   });
 }
 
-async function waitFor<T>(getValue: () => T | undefined): Promise<T> {
-  for (let attempt = 0; attempt < 100; attempt += 1) {
-    const value = getValue();
-    if (value !== undefined) {
-      return value;
-    }
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 5);
-    });
-  }
-  throw new Error("Timed out waiting for value.");
-}
-
 afterEach(() => {
   processRuntimeMocks.killProcessTree.mockReset();
   resetPluginStateStoreForTests();
@@ -179,14 +174,16 @@ describe("Raft wake gateway", () => {
       settled = true;
     });
 
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
-    });
-    expect(settled).toBe(false);
-    expect(spawnBridge).not.toHaveBeenCalled();
-
-    controller.abort();
-    await start;
+    try {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      expect(settled).toBe(false);
+      expect(spawnBridge).not.toHaveBeenCalled();
+    } finally {
+      controller.abort();
+      await start;
+    }
   });
 
   it("accepts authenticated content-free wake hints and dedupes retry delivery ids", async () => {
@@ -199,130 +196,130 @@ describe("Raft wake gateway", () => {
       },
     });
     const bridge = new FakeBridge();
-    let endpoint: string | undefined;
-    let token: string | undefined;
     const start = startRaftGatewayAccount(ctx, {
-      spawnBridge: (params) => {
-        endpoint = params.endpoint;
-        token = params.token;
-        return bridge;
-      },
+      spawnBridge: bridge.spawn,
       wakeDedupe,
     });
+    void start.catch(bridge.started.reject);
 
-    const wakeEndpoint = await waitFor(() => endpoint);
-    const bridgeToken = await waitFor(() => token);
-    expect(ctx.getStatus()).toMatchObject({
-      running: true,
-      connected: true,
-      lifecycle: "ready",
-      lastConnectedAt: expect.any(Number),
-      lastError: null,
-      terminalDisconnect: undefined,
-    });
-    await expect(fetch(wakeEndpoint.replace("/wake", "/health"))).resolves.toMatchObject({
-      status: 200,
-    });
-    await expect(fetch(wakeEndpoint, { method: "POST" })).resolves.toMatchObject({ status: 401 });
-    await expect(
-      fetch(wakeEndpoint, {
-        method: "POST",
-        headers: { "x-raft-bridge-token": "x".repeat(bridgeToken.length) },
-      }),
-    ).resolves.toMatchObject({ status: 401 });
-    await expect(
-      fetch(wakeEndpoint, {
-        method: "POST",
-        headers: { "x-raft-bridge-token": "short" },
-      }),
-    ).resolves.toMatchObject({ status: 401 });
-    await expect(
-      fetch(wakeEndpoint, {
-        method: "POST",
-        headers: {
-          "x-raft-bridge-token": bridgeToken,
-        },
-      }),
-    ).resolves.toMatchObject({ status: 400 });
-    await expect(
-      fetch(wakeEndpoint, {
-        method: "POST",
-        headers: {
-          "x-raft-bridge-token": bridgeToken,
-        },
-        body: JSON.stringify({ metadata: { text: "not a wake hint" } }),
-      }),
-    ).resolves.toMatchObject({ status: 400 });
-    await expect(
-      fetch(wakeEndpoint, {
-        method: "POST",
-        headers: {
-          "x-raft-bridge-token": bridgeToken,
-        },
-        body: JSON.stringify({ eventId: "wake-1", timestamp: 1 }),
-      }),
-    ).resolves.toMatchObject({ status: 202 });
-    await expect(
-      fetch(wakeEndpoint.replace("/wake", "/activity/drain?max=50")),
-    ).resolves.toMatchObject({ status: 401 });
-    await expect(
-      fetch(wakeEndpoint.replace("/wake", "/activity/drain?max=50"), {
-        headers: {
-          "x-raft-bridge-token": bridgeToken,
-        },
-      }),
-    ).resolves.toMatchObject({
-      status: 200,
-    });
-    await expect(
-      fetch(wakeEndpoint.replace("/wake", "/activity/drain?max=50"), {
-        headers: {
-          "x-raft-bridge-token": bridgeToken,
-        },
-      }).then((response) => response.json()),
-    ).resolves.toEqual({
-      dropped: 0,
-      events: [],
-      schema: "raft-activity-drain.v1",
-    });
-    await vi.waitFor(() => expect(run).toHaveBeenCalledTimes(1));
-    await expect(
-      fetch(wakeEndpoint, {
-        method: "POST",
-        headers: {
-          "x-raft-bridge-token": bridgeToken,
-        },
-        body: JSON.stringify({ eventId: "wake-1", timestamp: 2 }),
-      }),
-    ).resolves.toMatchObject({ status: 202 });
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 0);
-    });
-    expect(run).toHaveBeenCalledTimes(1);
-    await expect(
-      fetch(wakeEndpoint, {
-        method: "POST",
-        headers: {
-          "x-raft-bridge-token": bridgeToken,
-        },
-        body: JSON.stringify({
-          metadata: {
-            sequence: 1,
-            source: "bridge",
+    try {
+      const { endpoint: wakeEndpoint, token: bridgeToken } = await withTimeout(
+        bridge.started.promise,
+        500,
+        "Raft bridge startup",
+      );
+      expect(ctx.getStatus()).toMatchObject({
+        running: true,
+        connected: true,
+        lifecycle: "ready",
+        lastConnectedAt: expect.any(Number),
+        lastError: null,
+        terminalDisconnect: undefined,
+      });
+      await expect(fetch(wakeEndpoint.replace("/wake", "/health"))).resolves.toMatchObject({
+        status: 200,
+      });
+      await expect(fetch(wakeEndpoint, { method: "POST" })).resolves.toMatchObject({ status: 401 });
+      await expect(
+        fetch(wakeEndpoint, {
+          method: "POST",
+          headers: { "x-raft-bridge-token": "x".repeat(bridgeToken.length) },
+        }),
+      ).resolves.toMatchObject({ status: 401 });
+      await expect(
+        fetch(wakeEndpoint, {
+          method: "POST",
+          headers: { "x-raft-bridge-token": "short" },
+        }),
+      ).resolves.toMatchObject({ status: 401 });
+      await expect(
+        fetch(wakeEndpoint, {
+          method: "POST",
+          headers: {
+            "x-raft-bridge-token": bridgeToken,
           },
         }),
-      }),
-    ).resolves.toMatchObject({ status: 400 });
-    expect(run).toHaveBeenCalledTimes(1);
+      ).resolves.toMatchObject({ status: 400 });
+      await expect(
+        fetch(wakeEndpoint, {
+          method: "POST",
+          headers: {
+            "x-raft-bridge-token": bridgeToken,
+          },
+          body: JSON.stringify({ metadata: { text: "not a wake hint" } }),
+        }),
+      ).resolves.toMatchObject({ status: 400 });
+      await expect(
+        fetch(wakeEndpoint, {
+          method: "POST",
+          headers: {
+            "x-raft-bridge-token": bridgeToken,
+          },
+          body: JSON.stringify({ eventId: "wake-1", timestamp: 1 }),
+        }),
+      ).resolves.toMatchObject({ status: 202 });
+      await expect(
+        fetch(wakeEndpoint.replace("/wake", "/activity/drain?max=50")),
+      ).resolves.toMatchObject({ status: 401 });
+      await expect(
+        fetch(wakeEndpoint.replace("/wake", "/activity/drain?max=50"), {
+          headers: {
+            "x-raft-bridge-token": bridgeToken,
+          },
+        }),
+      ).resolves.toMatchObject({
+        status: 200,
+      });
+      await expect(
+        fetch(wakeEndpoint.replace("/wake", "/activity/drain?max=50"), {
+          headers: {
+            "x-raft-bridge-token": bridgeToken,
+          },
+        }).then((response) => response.json()),
+      ).resolves.toEqual({
+        dropped: 0,
+        events: [],
+        schema: "raft-activity-drain.v1",
+      });
+      await vi.waitFor(() => expect(run).toHaveBeenCalledTimes(1));
+      await expect(
+        fetch(wakeEndpoint, {
+          method: "POST",
+          headers: {
+            "x-raft-bridge-token": bridgeToken,
+          },
+          body: JSON.stringify({ eventId: "wake-1", timestamp: 2 }),
+        }),
+      ).resolves.toMatchObject({ status: 202 });
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0);
+      });
+      expect(run).toHaveBeenCalledTimes(1);
+      await expect(
+        fetch(wakeEndpoint, {
+          method: "POST",
+          headers: {
+            "x-raft-bridge-token": bridgeToken,
+          },
+          body: JSON.stringify({
+            metadata: {
+              sequence: 1,
+              source: "bridge",
+            },
+          }),
+        }),
+      ).resolves.toMatchObject({ status: 400 });
+      expect(run).toHaveBeenCalledTimes(1);
 
-    const input = run.mock.calls[0]?.[0].adapter.ingest({ kind: "wake" });
-    expect(input?.textForAgent).toContain(
-      `raft --profile 'main'"'"'; touch /tmp/pwn; echo '"'"'' message check`,
-    );
-    expect(input?.rawText).not.toContain("wake-1");
-
-    controller.abort();
-    await start;
+      const input = run.mock.calls[0]?.[0].adapter.ingest({ kind: "wake" });
+      expect(input?.textForAgent).toContain(
+        `raft --profile 'main'"'"'; touch /tmp/pwn; echo '"'"'' message check`,
+      );
+      expect(input?.rawText).not.toContain("wake-1");
+    } finally {
+      controller.abort();
+      await start;
+    }
     expect(processRuntimeMocks.killProcessTree).toHaveBeenCalledOnce();
     expect(processRuntimeMocks.killProcessTree).toHaveBeenCalledWith(bridge.pid, {
       graceMs: 5_000,
@@ -334,20 +331,18 @@ describe("Raft wake gateway", () => {
     const { ctx, controller, wakeDedupe } = createContext();
     Object.defineProperty(ctx, "abortSignal", { value: controller.signal });
     const bridge = new FakeBridge();
-    let endpoint: string | undefined;
-    let token: string | undefined;
     const start = startRaftGatewayAccount(ctx, {
-      spawnBridge: (params) => {
-        endpoint = params.endpoint;
-        token = params.token;
-        return bridge;
-      },
+      spawnBridge: bridge.spawn,
       wakeDedupe,
     });
+    void start.catch(bridge.started.reject);
 
-    const wakeEndpoint = await waitFor(() => endpoint);
-    const bridgeToken = await waitFor(() => token);
     try {
+      const { endpoint: wakeEndpoint, token: bridgeToken } = await withTimeout(
+        bridge.started.promise,
+        500,
+        "Raft bridge startup",
+      );
       const response = await fetch(wakeEndpoint, {
         method: "POST",
         headers: {
@@ -371,53 +366,51 @@ describe("Raft wake gateway", () => {
     const { ctx, controller, run, wakeDedupe } = createContext();
     Object.defineProperty(ctx, "abortSignal", { value: controller.signal });
     const bridge = new FakeBridge();
-    let endpoint: string | undefined;
-    let token: string | undefined;
     const start = startRaftGatewayAccount(ctx, {
-      spawnBridge: (params) => {
-        endpoint = params.endpoint;
-        token = params.token;
-        return bridge;
-      },
+      spawnBridge: bridge.spawn,
       wakeDedupe,
     });
+    void start.catch(bridge.started.reject);
 
-    const wakeEndpoint = await waitFor(() => endpoint);
-    const bridgeToken = await waitFor(() => token);
-    await expect(
-      fetch(wakeEndpoint, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          "x-raft-bridge-token": bridgeToken,
-        },
-        body: JSON.stringify({ event: "wake", padding: "x".repeat(17 * 1024) }),
-      }),
-    ).resolves.toMatchObject({ status: 413 });
-    expect(run).not.toHaveBeenCalled();
-
-    controller.abort();
-    await start;
+    try {
+      const { endpoint: wakeEndpoint, token: bridgeToken } = await withTimeout(
+        bridge.started.promise,
+        500,
+        "Raft bridge startup",
+      );
+      await expect(
+        fetch(wakeEndpoint, {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-raft-bridge-token": bridgeToken,
+          },
+          body: JSON.stringify({ event: "wake", padding: "x".repeat(17 * 1024) }),
+        }),
+      ).resolves.toMatchObject({ status: 413 });
+      expect(run).not.toHaveBeenCalled();
+    } finally {
+      controller.abort();
+      await start;
+    }
   });
 
   it("keeps a failed delivery eligible for a bridge retry", async () => {
     const { ctx, controller, run, wakeDedupe } = createContext();
     Object.defineProperty(ctx, "abortSignal", { value: controller.signal });
     const bridge = new FakeBridge();
-    let endpoint: string | undefined;
-    let token: string | undefined;
     const start = startRaftGatewayAccount(ctx, {
-      spawnBridge: (params) => {
-        endpoint = params.endpoint;
-        token = params.token;
-        return bridge;
-      },
+      spawnBridge: bridge.spawn,
       wakeDedupe,
     });
+    void start.catch(bridge.started.reject);
 
-    const wakeEndpoint = await waitFor(() => endpoint);
-    const bridgeToken = await waitFor(() => token);
     try {
+      const { endpoint: wakeEndpoint, token: bridgeToken } = await withTimeout(
+        bridge.started.promise,
+        500,
+        "Raft bridge startup",
+      );
       run.mockRejectedValueOnce(new Error("inbound runtime unavailable"));
       const request = () => ({
         method: "POST",
@@ -446,19 +439,17 @@ describe("Raft wake gateway", () => {
       const first = createContext();
       Object.defineProperty(first.ctx, "abortSignal", { value: first.controller.signal });
       const firstBridge = new FakeBridge();
-      let firstEndpoint: string | undefined;
-      let firstToken: string | undefined;
       const firstStart = startRaftGatewayAccount(first.ctx, {
         wakeDedupe: createPersistentWakeDedupe(stateDir),
-        spawnBridge: (params) => {
-          firstEndpoint = params.endpoint;
-          firstToken = params.token;
-          return firstBridge;
-        },
+        spawnBridge: firstBridge.spawn,
       });
+      void firstStart.catch(firstBridge.started.reject);
       try {
-        const endpoint = await waitFor(() => firstEndpoint);
-        const token = await waitFor(() => firstToken);
+        const { endpoint, token } = await withTimeout(
+          firstBridge.started.promise,
+          500,
+          "Raft bridge startup",
+        );
         await expect(
           fetch(endpoint, {
             method: "POST",
@@ -475,19 +466,17 @@ describe("Raft wake gateway", () => {
       const replay = createContext();
       Object.defineProperty(replay.ctx, "abortSignal", { value: replay.controller.signal });
       const replayBridge = new FakeBridge();
-      let replayEndpoint: string | undefined;
-      let replayToken: string | undefined;
       const replayStart = startRaftGatewayAccount(replay.ctx, {
         wakeDedupe: createPersistentWakeDedupe(stateDir),
-        spawnBridge: (params) => {
-          replayEndpoint = params.endpoint;
-          replayToken = params.token;
-          return replayBridge;
-        },
+        spawnBridge: replayBridge.spawn,
       });
+      void replayStart.catch(replayBridge.started.reject);
       try {
-        const endpoint = await waitFor(() => replayEndpoint);
-        const token = await waitFor(() => replayToken);
+        const { endpoint, token } = await withTimeout(
+          replayBridge.started.promise,
+          500,
+          "Raft bridge startup",
+        );
         await expect(
           fetch(endpoint, {
             method: "POST",
@@ -506,19 +495,17 @@ describe("Raft wake gateway", () => {
         value: otherAccount.controller.signal,
       });
       const otherBridge = new FakeBridge();
-      let otherEndpoint: string | undefined;
-      let otherToken: string | undefined;
       const otherStart = startRaftGatewayAccount(otherAccount.ctx, {
         wakeDedupe: createPersistentWakeDedupe(stateDir),
-        spawnBridge: (params) => {
-          otherEndpoint = params.endpoint;
-          otherToken = params.token;
-          return otherBridge;
-        },
+        spawnBridge: otherBridge.spawn,
       });
+      void otherStart.catch(otherBridge.started.reject);
       try {
-        const endpoint = await waitFor(() => otherEndpoint);
-        const token = await waitFor(() => otherToken);
+        const { endpoint, token } = await withTimeout(
+          otherBridge.started.promise,
+          500,
+          "Raft bridge startup",
+        );
         await expect(
           fetch(endpoint, {
             method: "POST",


### PR DESCRIPTION
The Raft gateway tests copied endpoint/token capture variables and polled them after each real loopback server start. The existing bridge spawn callback already owns both values. Resolve the shared deferred there, await it with the public timeout helper, and delete all fourteen polling call sites across seven starts. Startup observation and assertions now sit inside abort-and-join cleanup, including failure paths.

All seven owner cases and 36 expect sites remain: real HTTP authentication and payload limits, accepted and retried delivery, process shutdown, and actual persistent replay across restarts and accounts. Production is unchanged; tests +193/-206 (net -13). The former 100 accumulated 5-ms intervals become one 500-ms deadline, so scheduler overhead no longer extends that nominal observation budget. The existing zero-delay negative observations and dispatch wait remain unchanged.

Validation: all 14 gateway/account/channel cases pass before and after. A scratch fault suppressing only the spawn signal fails the named startup guard; diagnostics confirm that the real HTTP endpoint closes, process stop is requested and the original gateway task joins. Exact restoration passes all 14. Full changed checks and Codex autoreview pass. This removes polling and copied fixture state; no whole-run elapsed-time gain or live external Raft process proof is claimed.

Commands:
```sh
node scripts/run-vitest.mjs extensions/raft/src/gateway.test.ts extensions/raft/src/accounts.test.ts extensions/raft/src/channel.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base a9c85d401f8f4288491a59725d3e0fd9574eb7ba
```

Follow-up: replacing the post-replay negative observation requires a causal owner completion signal; it is retained here.
