### PR TITLE
fix(gateway): fall back to email-backed profile when Cloudflare Access IdP is not GitHub

### DIFF
--- a/src/gateway/github-user-identity.test.ts
+++ b/src/gateway/github-user-identity.test.ts
@@ -471,14 +471,6 @@ describe("authenticated GitHub identity sync", () => {
       }),
     },
     {
-      name: "non-GitHub IdP",
-      access: githubResponse({
-        id: 58493,
-        email: "ada@example.com",
-        idp: { type: "google" },
-      }),
-    },
-    {
       name: "invalid account id",
       access: githubResponse({
         id: "58493",
@@ -493,6 +485,33 @@ describe("authenticated GitHub identity sync", () => {
       const sync = cloudflareSync({});
       await expect(sync?.()).rejects.toThrow();
       expect(getUserProfileListItem(profile.id).githubIdentity).toBeNull();
+    });
+  });
+
+  it("resolves a non-GitHub IdP to an email-backed profile without GitHub enrichment", async () => {
+    await withOpenClawTestState({ scenario: "minimal" }, async () => {
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+        githubResponse({
+          id: 58493,
+          email: "ada@example.com",
+          name: "Ada Google",
+          idp: { id: "google-oauth", type: "google" },
+        }),
+      );
+
+      const sync = cloudflareSync({});
+      const result = await sync?.();
+
+      expect(result).toMatchObject({ profileId: expect.any(String) });
+      expect(getUserProfileListItem(result!.profileId)).toMatchObject({
+        emails: ["ada@example.com"],
+      });
+      expect(getUserProfileListItem(result!.profileId).githubIdentity).toBeNull();
+      // Only the Access identity lookup runs; no GitHub API call follows.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(
+        "https://team.cloudflareaccess.com/cdn-cgi/access/get-identity",
+      );
     });
   });
 

--- a/src/gateway/github-user-identity.ts
+++ b/src/gateway/github-user-identity.ts
@@ -4,7 +4,7 @@ import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/st
 import type { GatewayAuthConfig } from "../config/types.gateway.js";
 import { resolveCachedGitHubIdentity } from "../state/user-profile-github-identity.js";
 import { classifyTailscaleLogin } from "../state/user-profiles-tailscale-login.js";
-import { syncGitHubIdentity } from "../state/user-profiles.js";
+import { ensureProfileForEmail, syncGitHubIdentity } from "../state/user-profiles.js";
 import { normalizeGitHubLogin } from "../utils/github-login.js";
 import type { GatewayAuthResult } from "./auth.js";
 import {
@@ -27,6 +27,9 @@ const ACCESS_IDENTITY_MAX_BYTES = 64 * 1024;
 const JWT_SEGMENT_PATTERN = /^[A-Za-z0-9_-]+$/u;
 
 type ResolvedGitHubUserIdentity = { accountId: number; login: string; name?: string };
+type ResolvedCloudflareAccessIdentity =
+  | { kind: "github"; accountId: number; initialDisplayName?: string }
+  | { kind: "email-only" };
 type AuthenticatedGitHubIdentitySyncResult = { profileId: string; updatedAt: number };
 export type AuthenticatedGitHubIdentitySync = () => Promise<AuthenticatedGitHubIdentitySyncResult>;
 
@@ -75,7 +78,7 @@ function cloudflareAccessIssuer(assertion: string): URL {
 async function resolveCloudflareAccessIdentity(
   assertion: string,
   authenticatedPrincipal: string,
-): Promise<{ accountId: number; initialDisplayName?: string }> {
+): Promise<ResolvedCloudflareAccessIdentity> {
   const issuer = cloudflareAccessIssuer(assertion);
   let payload: unknown;
   try {
@@ -101,15 +104,22 @@ async function resolveCloudflareAccessIdentity(
   if (!email || email.toLowerCase() !== authenticatedPrincipal.trim().toLowerCase()) {
     throw new Error("Cloudflare Access identity principal did not match");
   }
+  const initialDisplayName =
+    typeof payload.name === "string" && payload.name.trim() ? payload.name : undefined;
   if (!isRecord(payload.idp) || payload.idp.type !== "github") {
-    throw new Error("Cloudflare Access identity is not GitHub-backed");
+    // A non-GitHub IdP has no GitHub account id to enrich; resolve a durable
+    // email-backed profile instead of failing so the connection is never left
+    // pending on GitHub enrichment the IdP cannot provide.
+    return { kind: "email-only" };
   }
   if (typeof payload.id !== "number" || !Number.isSafeInteger(payload.id) || payload.id <= 0) {
     throw new Error("Cloudflare Access GitHub account id is invalid");
   }
-  const initialDisplayName =
-    typeof payload.name === "string" && payload.name.trim() ? payload.name : undefined;
-  return { accountId: payload.id, ...(initialDisplayName ? { initialDisplayName } : {}) };
+  return {
+    kind: "github",
+    accountId: payload.id,
+    ...(initialDisplayName ? { initialDisplayName } : {}),
+  };
 }
 
 async function resolveGitHubUserIdentityByLogin(
@@ -237,6 +247,10 @@ export function createAuthenticatedGitHubIdentitySync(params: {
       access.assertion,
       access.principal,
     );
+    if (accessIdentity.kind === "email-only") {
+      const profile = ensureProfileForEmail(access.principal);
+      return { profileId: profile.id, updatedAt: profile.updatedAt };
+    }
     if (params.preferCachedIdentity) {
       const cached = resolveCachedGitHubIdentity({
         accountId: accessIdentity.accountId,


### PR DESCRIPTION
## What Problem This Solves

Google-backed Cloudflare Access authenticates the operator but leaves the Control UI profile permanently pending: every session/chat request fails with `Authenticated profile verification is unavailable; retry the request.` The identity-enrichment sync throws `Cloudflare Access identity is not GitHub-backed` when the Access IdP is not GitHub, and the connection stays in `authenticatedGitHubIdentitySync && !authenticatedUserProfile`, so `isGatewayClientProfilePending` never clears.

## Why This Change Was Made

The gateway declares the Access principal verified the moment the identity lookup confirms the email matches the authenticated user (`principal did not match` is already a hard failure above). Requiring GitHub enrichment after that point turns optional attribution into a permanent lockout for non-GitHub IdPs, even though Cloudflare Access documents Access identity generally and never states that the Control UI requires a GitHub-backed IdP.

## Changes

- **`src/gateway/github-user-identity.ts`** — `resolveCloudflareAccessIdentity` now returns a discriminated result instead of throwing for a non-GitHub IdP: `{ kind: "github", accountId, ... }` keeps the existing enrichment path unchanged, while `{ kind: "email-only" }` resolves a durable email-backed profile via `ensureProfileForEmail` inside the sync. The connection therefore always obtains a verified profile; GitHub-backed IdPs keep the identical cached/re-enrichment behavior.
- **`src/gateway/github-user-identity.test.ts`** — the previous "non-GitHub IdP fails safely" expectation is replaced by coverage proving a Google IdP yields an email-backed profile with no GitHub API call at all (single identity lookup).

## Evidence

- New test `resolves a non-GitHub IdP to an email-backed profile without GitHub enrichment`: Google IdP → sync resolves `{ profileId, updatedAt }`, profile has the Access email and `githubIdentity: null`, and only the `cdn-cgi/access/get-identity` lookup runs (no `api.github.com` call).
- All 56 tests in `github-user-identity.test.ts` pass, including the existing enrichment, cached-identity, retry, and fail-closed suites.
- `server.auth.trusted-proxy-device-autoapprove.test.ts` (13 tests) passes unchanged.
- `pnpm tsgo:core` typecheck and full `pnpm build` pass.

## Related

Fixes #134467
