### PR TITLE
test(googlechat): share bounded response fixtures and remove duplicate coverage

### DIFF
--- a/extensions/googlechat/src/targets.test.ts
+++ b/extensions/googlechat/src/targets.test.ts
@@ -637,26 +637,6 @@ describe("sendGoogleChatMessage", () => {
     },
   );
 
-  it("keeps a valid same-space thread resource name", async () => {
-    const fetchMock = stubSuccessfulSend("spaces/AAA/messages/127", "spaces/AAA/threads/xyz");
-
-    await sendGoogleChatMessage({
-      account,
-      space: "spaces/AAA",
-      text: "hello",
-      thread: "spaces/AAA/threads/xyz",
-    });
-
-    const url = mockCallArg(fetchMock);
-    const init = mockCallArg(fetchMock, 0, 1) as RequestInit | undefined;
-    expect(String(url)).toContain("messageReplyOption=REPLY_MESSAGE_FALLBACK_TO_NEW_THREAD");
-    if (typeof init?.body !== "string") {
-      throw new Error("Expected Google Chat request body");
-    }
-    const body = JSON.parse(init.body) as { thread?: { name?: unknown } };
-    expect(body.thread?.name).toBe("spaces/AAA/threads/xyz");
-  });
-
   it("sends cardsV2 with the text fallback", async () => {
     const fetchMock = stubSuccessfulSend("spaces/AAA/messages/125");
     const cardsV2 = [
@@ -944,6 +924,38 @@ describe("verifyGoogleChatRequest", () => {
   });
 
   describe("bounded JSON read (readProviderJsonResponse delegation)", () => {
+    const ONE_MIB = 1024 * 1024;
+    const TOTAL_CHUNKS = 32;
+
+    function createOversizedResponse(chunk: Uint8Array, init: ResponseInit) {
+      let bytesPulled = 0;
+      let canceled = false;
+      return {
+        response: new Response(
+          new ReadableStream<Uint8Array>({
+            pull(controller) {
+              if (bytesPulled >= TOTAL_CHUNKS * ONE_MIB) {
+                controller.close();
+                return;
+              }
+              bytesPulled += chunk.length;
+              controller.enqueue(chunk);
+            },
+            cancel() {
+              canceled = true;
+            },
+          }),
+          init,
+        ),
+        get bytesPulled() {
+          return bytesPulled;
+        },
+        get canceled() {
+          return canceled;
+        },
+      };
+    }
+
     afterEach(() => {
       mocks.fetchWithSsrFGuard.mockClear();
       vi.unstubAllGlobals();
@@ -951,31 +963,13 @@ describe("verifyGoogleChatRequest", () => {
 
     it("cancels oversized cert fetch JSON body via the 16 MiB provider cap", async () => {
       expireGoogleChatCertCache();
-      const ONE_MIB = 1024 * 1024;
-      const TOTAL_CHUNKS = 32;
-      const chunk = new Uint8Array(ONE_MIB);
-
-      let bytesPulled = 0;
-      let canceled = false;
-      const oversizedJson = new Response(
-        new ReadableStream<Uint8Array>({
-          pull(controller) {
-            if (bytesPulled >= TOTAL_CHUNKS * ONE_MIB) {
-              controller.close();
-              return;
-            }
-            bytesPulled += chunk.length;
-            controller.enqueue(chunk);
-          },
-          cancel() {
-            canceled = true;
-          },
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
+      const streamed = createOversizedResponse(new Uint8Array(ONE_MIB), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
       const release = vi.fn(async () => {});
       mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
-        response: oversizedJson,
+        response: streamed.response,
         release,
       });
 
@@ -987,37 +981,19 @@ describe("verifyGoogleChatRequest", () => {
 
       expect(result.ok).toBe(false);
       expect(result.reason).toMatch(/JSON response exceeds 16777216 bytes/);
-      expect(canceled).toBe(true);
-      expect(bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
+      expect(streamed.canceled).toBe(true);
+      expect(streamed.bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
       expect(release).toHaveBeenCalledOnce();
     });
 
     it("rejects oversized sendMessage JSON body via the 16 MiB provider cap", async () => {
-      const ONE_MIB = 1024 * 1024;
-      const TOTAL_CHUNKS = 32;
-      const chunk = new Uint8Array(ONE_MIB);
-
-      let bytesPulled = 0;
-      let canceled = false;
-      const oversizedJson = new Response(
-        new ReadableStream<Uint8Array>({
-          pull(controller) {
-            if (bytesPulled >= TOTAL_CHUNKS * ONE_MIB) {
-              controller.close();
-              return;
-            }
-            bytesPulled += chunk.length;
-            controller.enqueue(chunk);
-          },
-          cancel() {
-            canceled = true;
-          },
-        }),
-        { status: 200, headers: { "Content-Type": "application/json" } },
-      );
+      const streamed = createOversizedResponse(new Uint8Array(ONE_MIB), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
       const release = vi.fn(async () => {});
       mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
-        response: oversizedJson,
+        response: streamed.response,
         release,
       });
 
@@ -1029,36 +1005,18 @@ describe("verifyGoogleChatRequest", () => {
         }),
       ).rejects.toThrow(/Google Chat API request failed: JSON response exceeds 16777216 bytes/);
 
-      expect(canceled).toBe(true);
-      expect(bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
+      expect(streamed.canceled).toBe(true);
+      expect(streamed.bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
     });
 
     it("caps non-OK sendMessage error bodies before formatting the API error", async () => {
-      const ONE_MIB = 1024 * 1024;
-      const TOTAL_CHUNKS = 32;
-      const chunk = new TextEncoder().encode("x".repeat(ONE_MIB));
-
-      let bytesPulled = 0;
-      let canceled = false;
-      const oversizedError = new Response(
-        new ReadableStream<Uint8Array>({
-          pull(controller) {
-            if (bytesPulled >= TOTAL_CHUNKS * ONE_MIB) {
-              controller.close();
-              return;
-            }
-            bytesPulled += chunk.length;
-            controller.enqueue(chunk);
-          },
-          cancel() {
-            canceled = true;
-          },
-        }),
-        { status: 500, statusText: "Internal Server Error" },
-      );
+      const streamed = createOversizedResponse(new TextEncoder().encode("x".repeat(ONE_MIB)), {
+        status: 500,
+        statusText: "Internal Server Error",
+      });
       const release = vi.fn(async () => {});
       mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
-        response: oversizedError,
+        response: streamed.response,
         release,
       });
 
@@ -1070,8 +1028,8 @@ describe("verifyGoogleChatRequest", () => {
         }),
       ).rejects.toThrow(/^Google Chat API 500: x+/);
 
-      expect(canceled).toBe(true);
-      expect(bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
+      expect(streamed.canceled).toBe(true);
+      expect(streamed.bytesPulled).toBeLessThan(TOTAL_CHUNKS * ONE_MIB);
       expect(release).toHaveBeenCalledOnce();
     });
   });


### PR DESCRIPTION
The Google Chat tests repeated the same oversized stream fixture for certificate JSON, successful message JSON and API error bodies. Share that fixture while retaining each entry path, native Response/ReadableStream behavior, one preallocated 1-MiB chunk per case, the 32-chunk source, and all twelve assertions for limits, cancellation and release.

Delete the duplicate valid-thread row: the retained “adds messageReplyOption” case already checks the same query and thread body, plus the returned receipt, text and request timeout. No production change; tests +53/-95 (net -42). No payload, deadline or mock-lifetime changes.

Validation: 82 selected cases pass before and 81 after (43→42 in the edited file). A scratch mutation dropping valid threads in the production API fails the retained stronger case on its reply-option assertion; exact restoration passes all 81. Full changed checks and Codex autoreview pass. No whole-run elapsed-time gain is claimed.

Local dependency limitation: these tests mock Google authentication. The installed google-auth-library is 10.9.1 while the current lockfile pins 11.0.2; landing requires successful exact-head hosted frozen-lockfile setup and checks. The local results do not prove live Google authentication or API compatibility.

Commands:
```sh
node scripts/run-vitest.mjs extensions/googlechat/src/targets.test.ts extensions/googlechat/src/actions.test.ts extensions/googlechat/src/targets.outbound-session.test.ts extensions/googlechat/src/api.fetchok.transport.test.ts extensions/googlechat/src/auth.proof.test.ts extensions/googlechat/src/google-auth.runtime.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base 77fee957919f06dbaff09dd5cc7f9664d9655651
```

Follow-up: the separate media-download fixture's responseClosed assertion occurs after server closure and retains a 100-ms sentinel. This PR does not claim causal response-close proof from that fixture.
