### PR TITLE
fix(doctor): report plugin restart readiness

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -10,6 +10,8 @@ title: "Doctor"
 
 Health checks and quick fixes for the gateway, channels, plugins, skills, model routing, local state, and config migrations. Use it whenever something is not behaving as expected and you want one command to explain what is wrong.
 
+When run for a managed Gateway, Doctor compares active official plugins with the OpenClaw package referenced by the installed service. This check still works when the Gateway is stopped or unreachable. When an older Gateway is still running, Doctor reports its version separately from the post-restart version. If the service package cannot be identified, Doctor reports restart readiness as unknown instead of treating the plugin set as compatible.
+
 When Gateway status reports degraded SecretRef owners, doctor prints a **Secret runtime degradation** warning with every cold or stale owner, affected config path, redacted reason, and the `openclaw secrets reload` retry command.
 
 When channel ingress events are dead-lettered, doctor names each affected channel account and points to [`openclaw channels dead-letters list`](/cli/channels#inbound-dead-letters) for inspection and recovery.

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -484,7 +484,7 @@ only when the connected remote Gateway is at least as new as the app.
 openclaw doctor
 ```
 
-Migrates config, audits DM policies, and checks gateway health. Details: [Doctor](/gateway/doctor)
+Migrates config, audits DM policies, and checks gateway health. Doctor also compares active official plugins with the OpenClaw package the managed service will load after restart. Resolve any plugin restart-readiness warning before continuing. Details: [Doctor](/gateway/doctor)
 
 If you use the unpacked Chrome extension, also run `openclaw browser doctor --browser-profile chrome`.
 For a version-mismatch warning, reload the extension from `chrome://extensions`;

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -828,8 +828,19 @@ describe("gatherDaemonStatus", () => {
         url: "ws://127.0.0.1:18900",
         error: "connect ECONNREFUSED 127.0.0.1:18900",
       });
+      loadInstalledPluginIndexInstallRecords.mockResolvedValueOnce({
+        whatsapp: {
+          source: "npm",
+          resolvedName: "@openclaw/whatsapp",
+          resolvedVersion: "2026.5.4",
+        },
+      } as never);
 
-      const status = await gatherStatus({ requireRpc: true, deep: true });
+      const status = await gatherStatus({
+        requireRpc: true,
+        deep: true,
+        pluginVersionTarget: "restart",
+      });
 
       expect(status.gateway?.probeUrl).toBe("ws://127.0.0.1:18900");
       expect((callArg(callGatewayStatusProbe) as { url?: string }).url).toBe(
@@ -848,6 +859,7 @@ describe("gatherDaemonStatus", () => {
       expect(authInput.cfg).toBe(cliLoadedConfig);
       expect(authInput.env?.OPENCLAW_GATEWAY_PORT).toBe("18900");
       expect(status.service.targetRole).toBe("diagnostic-only");
+      expect(status.pluginVersionRestartReadiness).toBeUndefined();
       expect(inspectGatewayRestart).not.toHaveBeenCalled();
     },
   );

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -1676,6 +1676,117 @@ describe("gatherDaemonStatus", () => {
     expect(status.pluginVersionDrift?.drifts).toEqual([]);
   });
 
+  it.each([
+    { name: "running an older version", runtime: "running", probeVersion: "2026.5.4" },
+    { name: "stopped", runtime: "stopped", probeVersion: undefined },
+    { name: "unreachable", runtime: "running", probeVersion: undefined },
+  ])(
+    "compares Doctor plugin readiness with the installed service when the Gateway is $name",
+    async ({ runtime, probeVersion }) => {
+      const packageRoot = await fs.realpath(
+        await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-restart-readiness-")),
+      );
+      try {
+        await fs.mkdir(path.join(packageRoot, "dist"));
+        await fs.writeFile(
+          path.join(packageRoot, "package.json"),
+          JSON.stringify({ name: "openclaw", version: "2026.6.1" }),
+        );
+        const entrypoint = path.join(packageRoot, "dist", "index.js");
+        await fs.writeFile(entrypoint, "gateway");
+        serviceReadCommand.mockResolvedValueOnce({
+          programArguments: [process.execPath, entrypoint, "gateway", "run"],
+          environment: {
+            OPENCLAW_STATE_DIR: "/tmp/openclaw-daemon",
+            OPENCLAW_CONFIG_PATH: "/tmp/openclaw-daemon/openclaw.json",
+          },
+        });
+        serviceReadRuntime.mockResolvedValueOnce({ status: runtime });
+        callGatewayStatusProbe.mockResolvedValueOnce(
+          probeVersion
+            ? {
+                ok: true,
+                server: { version: probeVersion, connId: "c1" },
+              }
+            : { ok: false, error: "connect failed" },
+        );
+        loadInstalledPluginIndexInstallRecords.mockResolvedValueOnce({
+          whatsapp: {
+            source: "npm",
+            resolvedName: "@openclaw/whatsapp",
+            resolvedVersion: "2026.5.4",
+          },
+        } as never);
+
+        const status = await gatherStatus({ pluginVersionTarget: "restart" });
+
+        expect(status.pluginVersionDrift).toBeUndefined();
+        expect(status.pluginVersionRestartReadiness).toEqual({
+          status: "resolved",
+          report: {
+            gatewayVersion: "2026.6.1",
+            drifts: [expect.objectContaining({ pluginId: "whatsapp" })],
+          },
+          ...(probeVersion ? { runningGatewayVersion: probeVersion } : {}),
+        });
+      } finally {
+        await fs.rm(packageRoot, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it("reports unresolved restart readiness when the service package cannot be identified", async () => {
+    loadInstalledPluginIndexInstallRecords.mockResolvedValueOnce({
+      whatsapp: {
+        source: "npm",
+        resolvedName: "@openclaw/whatsapp",
+        resolvedVersion: "2026.5.4",
+      },
+    } as never);
+    const status = await gatherStatus({ pluginVersionTarget: "restart" });
+
+    expect(status.pluginVersionRestartReadiness).toEqual({
+      status: "unresolved",
+      reason: expect.stringContaining("package version is unavailable"),
+      runningGatewayVersion: "2026.5.6",
+    });
+  });
+
+  it("omits restart readiness when no managed service target exists", async () => {
+    serviceIsLoaded.mockResolvedValueOnce(false);
+    serviceReadCommand.mockResolvedValueOnce(null);
+
+    const status = await gatherStatus({ pluginVersionTarget: "restart" });
+
+    expect(status.pluginVersionRestartReadiness).toBeUndefined();
+    expect(loadInstalledPluginIndexInstallRecords).not.toHaveBeenCalled();
+  });
+
+  it("reports unresolved restart readiness when a loaded service has no command", async () => {
+    serviceReadCommand.mockResolvedValueOnce(null);
+    loadInstalledPluginIndexInstallRecords.mockResolvedValueOnce({
+      whatsapp: {
+        source: "npm",
+        resolvedName: "@openclaw/whatsapp",
+        resolvedVersion: "2026.5.4",
+      },
+    } as never);
+
+    const status = await gatherStatus({ pluginVersionTarget: "restart" });
+
+    expect(status.pluginVersionRestartReadiness).toEqual({
+      status: "unresolved",
+      reason: expect.stringContaining("service command is unavailable"),
+      runningGatewayVersion: "2026.5.6",
+    });
+  });
+
+  it("omits restart readiness when no active official plugins need a version check", async () => {
+    const status = await gatherStatus({ pluginVersionTarget: "restart" });
+
+    expect(status.pluginVersionRestartReadiness).toBeUndefined();
+  });
+
   it("flags drift against the running gateway version when an npm plugin lags behind it", async () => {
     callGatewayStatusProbe.mockResolvedValueOnce({
       ok: true,

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -790,8 +790,8 @@ export async function gatherDaemonStatus(
     try {
       if (opts.pluginVersionTarget === "restart") {
         const runningGatewayVersion = gatewayVersion ?? undefined;
-        if (!targetServiceCommand && !loaded) {
-          // No managed restart target means this diagnostic does not apply.
+        if (!useNativeServiceTargetContext || (!targetServiceCommand && !loaded)) {
+          // Only the authoritative loaded native service can define restart readiness.
         } else {
           const installRecords = await loadInstallRecords();
           if (hasOfficialPluginVersionCandidates({ installRecords, config: daemonCfg })) {

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -22,6 +22,7 @@ import { inspectGatewayHeapLimit, type GatewayHeapLimitReport } from "../../daem
 import type { ExtraGatewayService, FindExtraGatewayServicesOptions } from "../../daemon/inspect.js";
 import type { StaleOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
 import type { ServiceConfigAudit } from "../../daemon/service-audit.js";
+import { summarizeGatewayServiceLayout } from "../../daemon/service-layout.js";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
 import type {
   GatewayServiceCommandConfig,
@@ -64,7 +65,9 @@ import { resolveConfiguredLogFilePath } from "../../logging/log-file-path.js";
 import { loadInstalledPluginIndexInstallRecords } from "../../plugins/installed-plugin-index-record-reader.js";
 import {
   detectPluginVersionDrift,
+  hasOfficialPluginVersionCandidates,
   type PluginVersionDriftReport,
+  type PluginVersionRestartReadiness,
 } from "../../plugins/plugin-version-drift.js";
 import { createLazyPromise } from "../../shared/lazy-promise.js";
 import { VERSION } from "../../version.js";
@@ -346,6 +349,8 @@ export type DaemonStatus = {
    * without a corresponding `openclaw plugins update`.
    */
   pluginVersionDrift?: PluginVersionDriftReport;
+  /** Doctor-only comparison against the installed service package a restart will load. */
+  pluginVersionRestartReadiness?: PluginVersionRestartReadiness;
 };
 
 function shouldReportPortUsage(status: PortUsageStatus | undefined, rpcOk?: boolean) {
@@ -578,6 +583,7 @@ export async function gatherDaemonStatus(
     requireRpc?: boolean;
     deep?: boolean;
     allowExecSecretRefs?: boolean;
+    pluginVersionTarget?: "running" | "restart";
   } & FindExtraGatewayServicesOptions,
 ): Promise<DaemonStatus> {
   const localPortOverride = resolveGatewayLocalPortOverride(opts.rpc);
@@ -766,29 +772,79 @@ export async function gatherDaemonStatus(
       })) ?? undefined;
   }
 
-  // Plugin version drift detection.
-  // Compares active official external plugins against the *running* local
-  // gateway version reported by the probe handshake, falling back to the
-  // invoking CLI VERSION only when no gateway version is available. Reading
-  // records with the merged daemon environment inspects the managed service's
+  // Plugin version drift detection. Status compares with the running Gateway;
+  // Doctor can request the installed service version that a restart will load.
+  // Reading records with the merged daemon environment inspects the managed service's
   // profile/state dir, so remote/explicit URL probes need remote-owned
   // diagnostics instead.
-  // Best-effort: unreadable install records omit this advisory report.
+  // Status omits unreadable advisory data; Doctor reports restart readiness as unresolved.
   // Registry repair lookups belong to deep-status and Doctor command owners;
   // readiness, support, and triage must not wait for the public registry.
   let pluginVersionDrift: PluginVersionDriftReport | undefined;
+  let pluginVersionRestartReadiness: PluginVersionRestartReadiness | undefined;
   if (shouldInspectLocalGateway) {
-    try {
-      const installRecords = await loadInstalledPluginIndexInstallRecords({
+    const loadInstallRecords = () =>
+      loadInstalledPluginIndexInstallRecords({
         env: mergedDaemonEnv as NodeJS.ProcessEnv,
       });
-      pluginVersionDrift = detectPluginVersionDrift({
-        gatewayVersion: gatewayVersion ?? VERSION,
-        installRecords,
-        config: daemonCfg,
-      });
+    try {
+      if (opts.pluginVersionTarget === "restart") {
+        const runningGatewayVersion = gatewayVersion ?? undefined;
+        if (!targetServiceCommand && !loaded) {
+          // No managed restart target means this diagnostic does not apply.
+        } else {
+          const installRecords = await loadInstallRecords();
+          if (hasOfficialPluginVersionCandidates({ installRecords, config: daemonCfg })) {
+            if (!targetServiceCommand) {
+              pluginVersionRestartReadiness = {
+                status: "unresolved",
+                reason:
+                  "Gateway service command is unavailable, so the post-restart OpenClaw version is unknown.",
+                ...(runningGatewayVersion ? { runningGatewayVersion } : {}),
+              };
+            } else {
+              const layout = await summarizeGatewayServiceLayout(targetServiceCommand);
+              if (!layout?.packageVersion) {
+                pluginVersionRestartReadiness = {
+                  status: "unresolved",
+                  reason:
+                    "Gateway service package version is unavailable, so the post-restart OpenClaw version is unknown.",
+                  ...(runningGatewayVersion ? { runningGatewayVersion } : {}),
+                };
+              } else {
+                const report = detectPluginVersionDrift({
+                  gatewayVersion: layout.packageVersion,
+                  installRecords,
+                  config: daemonCfg,
+                });
+                pluginVersionRestartReadiness = {
+                  status: "resolved",
+                  report,
+                  ...(runningGatewayVersion ? { runningGatewayVersion } : {}),
+                };
+              }
+            }
+          }
+        }
+      } else {
+        const installRecords = await loadInstallRecords();
+        pluginVersionDrift = detectPluginVersionDrift({
+          gatewayVersion: gatewayVersion ?? VERSION,
+          installRecords,
+          config: daemonCfg,
+        });
+      }
     } catch {
-      pluginVersionDrift = undefined;
+      if (opts.pluginVersionTarget === "restart") {
+        pluginVersionRestartReadiness = {
+          status: "unresolved",
+          reason:
+            "Plugin restart readiness could not be inspected, so post-restart compatibility is unknown.",
+          ...(gatewayVersion ? { runningGatewayVersion: gatewayVersion } : {}),
+        };
+      } else {
+        pluginVersionDrift = undefined;
+      }
     }
   }
 
@@ -864,6 +920,7 @@ export async function gatherDaemonStatus(
       : {}),
     extraServices,
     ...(pluginVersionDrift ? { pluginVersionDrift } : {}),
+    ...(pluginVersionRestartReadiness ? { pluginVersionRestartReadiness } : {}),
   };
 }
 

--- a/src/commands/doctor-workspace-status.plugin-version-drift.test.ts
+++ b/src/commands/doctor-workspace-status.plugin-version-drift.test.ts
@@ -66,6 +66,34 @@ function detectCodexDrift(installedVersion: string, gatewayVersion: string) {
 }
 
 describe("official Codex plugin version drift doctor evidence", () => {
+  it("reports an unresolved post-restart target instead of silently omitting readiness", () => {
+    const readiness = {
+      status: "unresolved" as const,
+      reason: "Gateway service package version is unavailable.",
+      runningGatewayVersion: "2026.5.30",
+    };
+
+    expect(
+      collectWorkspaceStatusHealthFindings(config, { pluginVersionReadiness: readiness }),
+    ).toEqual([
+      expect.objectContaining({
+        requirement: "plugin-version-restart-readiness",
+        message: expect.stringContaining("Gateway service package version is unavailable"),
+      }),
+    ]);
+
+    const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
+    try {
+      noteWorkspaceStatus(config, { pluginVersionReadiness: readiness });
+      expect(noteSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Running Gateway: OpenClaw 2026.5.30"),
+        "Plugin restart readiness",
+      );
+    } finally {
+      noteSpy.mockRestore();
+    }
+  });
+
   it("reports older and newer pins as advisory drift while accepting correction suffixes", () => {
     const gatewayVersion = "2026.6.1";
 
@@ -91,11 +119,15 @@ describe("official Codex plugin version drift doctor evidence", () => {
         ],
       });
 
-      expect(collectWorkspaceStatusHealthFindings(config, { pluginVersionDrift: report })).toEqual([
+      expect(
+        collectWorkspaceStatusHealthFindings(config, {
+          pluginVersionReadiness: { status: "resolved", report },
+        }),
+      ).toEqual([
         {
           checkId: "core/doctor/workspace-status",
           severity: "warning",
-          message: `Plugin codex is ${installedVersion}, but the Gateway is ${gatewayVersion}.`,
+          message: `Plugin codex is ${installedVersion}, but a Gateway restart will load OpenClaw ${gatewayVersion}.`,
           path: "plugins.entries.codex",
           target: "codex",
           requirement: "plugin-version-drift",
@@ -105,13 +137,15 @@ describe("official Codex plugin version drift doctor evidence", () => {
 
       const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
       try {
-        noteWorkspaceStatus(config, { pluginVersionDrift: report });
+        noteWorkspaceStatus(config, {
+          pluginVersionReadiness: { status: "resolved", report },
+        });
         const driftNotes = noteSpy.mock.calls.filter(
-          ([, title]) => title === "Plugin version drift",
+          ([, title]) => title === "Plugin restart readiness",
         );
         expect(driftNotes).toHaveLength(1);
         expect(driftNotes[0]?.[0]).toContain(
-          `1 active official plugin not on OpenClaw ${gatewayVersion}`,
+          `1 active official plugin not on post-restart OpenClaw ${gatewayVersion}`,
         );
         expect(driftNotes[0]?.[0]).toContain(
           `codex: ${installedVersion} (npm) -> expected ${gatewayVersion}`,
@@ -129,9 +163,11 @@ describe("official Codex plugin version drift doctor evidence", () => {
     ] as const) {
       const report = detectCodexDrift(installedVersion, correctionGatewayVersion);
       expect(report.drifts).toEqual([]);
-      expect(collectWorkspaceStatusHealthFindings(config, { pluginVersionDrift: report })).toEqual(
-        [],
-      );
+      expect(
+        collectWorkspaceStatusHealthFindings(config, {
+          pluginVersionReadiness: { status: "resolved", report },
+        }),
+      ).toEqual([]);
     }
   });
 });

--- a/src/commands/doctor-workspace-status.plugin-version-drift.test.ts
+++ b/src/commands/doctor-workspace-status.plugin-version-drift.test.ts
@@ -94,6 +94,37 @@ describe("official Codex plugin version drift doctor evidence", () => {
     }
   });
 
+  it("reports when compatible plugins still need the older running Gateway restarted", () => {
+    const restartVersion = "2026.6.1";
+    const runningGatewayVersion = "2026.5.30";
+    const readiness = {
+      status: "resolved" as const,
+      runningGatewayVersion,
+      report: detectCodexDrift(restartVersion, restartVersion),
+    };
+
+    expect(
+      collectWorkspaceStatusHealthFindings(config, { pluginVersionReadiness: readiness }),
+    ).toEqual([
+      expect.objectContaining({
+        requirement: "plugin-version-gateway-restart",
+        message: expect.stringContaining(`running Gateway is ${runningGatewayVersion}`),
+        fixHint: "openclaw gateway restart",
+      }),
+    ]);
+
+    const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
+    try {
+      noteWorkspaceStatus(config, { pluginVersionReadiness: readiness });
+      expect(noteSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`Running Gateway: OpenClaw ${runningGatewayVersion}`),
+        "Plugin restart readiness",
+      );
+    } finally {
+      noteSpy.mockRestore();
+    }
+  });
+
   it("reports older and newer pins as advisory drift while accepting correction suffixes", () => {
     const gatewayVersion = "2026.6.1";
 
@@ -165,7 +196,11 @@ describe("official Codex plugin version drift doctor evidence", () => {
       expect(report.drifts).toEqual([]);
       expect(
         collectWorkspaceStatusHealthFindings(config, {
-          pluginVersionReadiness: { status: "resolved", report },
+          pluginVersionReadiness: {
+            status: "resolved",
+            report,
+            runningGatewayVersion: installedVersion,
+          },
         }),
       ).toEqual([]);
     }

--- a/src/commands/doctor-workspace-status.test.ts
+++ b/src/commands/doctor-workspace-status.test.ts
@@ -83,7 +83,9 @@ async function runNoteWorkspaceStatusForTest(
 
   const noteSpy = vi.spyOn(noteModule, "note").mockImplementation(() => {});
   noteWorkspaceStatus(cfg, {
-    pluginVersionDrift: opts?.pluginVersionDrift,
+    pluginVersionReadiness: opts?.pluginVersionDrift
+      ? { status: "resolved", report: opts.pluginVersionDrift }
+      : undefined,
   });
   return noteSpy;
 }
@@ -200,16 +202,19 @@ describe("noteWorkspaceStatus", () => {
         plugins: { entries: { codex: { enabled: true } } },
       },
       {
-        pluginVersionDrift: {
-          gatewayVersion: "2026.6.1",
-          drifts: [
-            {
-              pluginId: "codex",
-              installedVersion: "2026.5.30-beta.1",
-              gatewayVersion: "2026.6.1",
-              source: "npm",
-            },
-          ],
+        pluginVersionReadiness: {
+          status: "resolved",
+          report: {
+            gatewayVersion: "2026.6.1",
+            drifts: [
+              {
+                pluginId: "codex",
+                installedVersion: "2026.5.30-beta.1",
+                gatewayVersion: "2026.6.1",
+                source: "npm",
+              },
+            ],
+          },
         },
       },
     );
@@ -240,24 +245,27 @@ describe("noteWorkspaceStatus", () => {
     const findings = collectWorkspaceStatusHealthFindings(
       { plugins: { entries: { brave: { enabled: true } } } },
       {
-        pluginVersionDrift: {
-          gatewayVersion: "2026.7.1-2",
-          drifts: [
-            {
-              pluginId: "brave",
-              installedVersion: "2026.7.1-beta.2",
-              gatewayVersion: "2026.7.1-2",
-              source: "npm",
-              packageName: "@openclaw/brave-plugin",
-              spec: "@openclaw/brave-plugin@2026.7.1-beta.2",
-              targetResolution: {
-                status: "unresolved",
+        pluginVersionReadiness: {
+          status: "resolved",
+          report: {
+            gatewayVersion: "2026.7.1-2",
+            drifts: [
+              {
+                pluginId: "brave",
+                installedVersion: "2026.7.1-beta.2",
+                gatewayVersion: "2026.7.1-2",
+                source: "npm",
                 packageName: "@openclaw/brave-plugin",
-                requestedTarget: "2026.7.1",
-                error: "npm registry did not resolve @openclaw/brave-plugin@2026.7.1: HTTP 404",
+                spec: "@openclaw/brave-plugin@2026.7.1-beta.2",
+                targetResolution: {
+                  status: "unresolved",
+                  packageName: "@openclaw/brave-plugin",
+                  requestedTarget: "2026.7.1",
+                  error: "npm registry did not resolve @openclaw/brave-plugin@2026.7.1: HTTP 404",
+                },
               },
-            },
-          ],
+            ],
+          },
         },
       },
     );
@@ -375,10 +383,12 @@ describe("noteWorkspaceStatus", () => {
       },
     );
     try {
-      const driftCalls = noteSpy.mock.calls.filter(([, title]) => title === "Plugin version drift");
+      const driftCalls = noteSpy.mock.calls.filter(
+        ([, title]) => title === "Plugin restart readiness",
+      );
       expect(driftCalls).toHaveLength(1);
       const [body] = expectDefined(driftCalls[0], "(driftCalls)[0] test invariant");
-      expect(body).toContain("1 active official plugin not on OpenClaw 2026.6.1");
+      expect(body).toContain("1 active official plugin not on post-restart OpenClaw 2026.6.1");
       expect(body).toContain("codex: 2026.5.30-beta.1 (npm) -> expected 2026.6.1");
       expect(body).toContain("openclaw plugins update codex");
       expect(body).toContain("openclaw gateway restart");
@@ -430,7 +440,9 @@ describe("noteWorkspaceStatus", () => {
       },
     );
     try {
-      const driftCalls = noteSpy.mock.calls.filter(([, title]) => title === "Plugin version drift");
+      const driftCalls = noteSpy.mock.calls.filter(
+        ([, title]) => title === "Plugin restart readiness",
+      );
       expect(driftCalls).toHaveLength(1);
       const [body] = expectDefined(driftCalls[0], "(driftCalls)[0] test invariant");
       expect(body).toContain("openclaw plugins update @openclaw/brave-plugin@2026.6.10-beta.1");
@@ -468,7 +480,9 @@ describe("noteWorkspaceStatus", () => {
       },
     );
     try {
-      expect(noteSpy.mock.calls.map(([, title]) => title)).not.toContain("Plugin version drift");
+      expect(noteSpy.mock.calls.map(([, title]) => title)).not.toContain(
+        "Plugin restart readiness",
+      );
     } finally {
       noteSpy.mockRestore();
     }

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -12,6 +12,7 @@ import type { PluginMetadataSnapshotScopeRunner } from "../plugins/current-plugi
 import {
   resolvePluginVersionDriftUpdateCommand,
   type PluginVersionDriftReport,
+  type PluginVersionRestartReadiness,
 } from "../plugins/plugin-version-drift.js";
 import {
   buildPluginCompatibilityWarnings,
@@ -22,7 +23,7 @@ import { loadTaskRegistryStateFromSqliteReadOnly } from "../tasks/task-registry.
 import type { TaskRecord } from "../tasks/task-registry.types.js";
 
 type NoteWorkspaceStatusOptions = {
-  pluginVersionDrift?: PluginVersionDriftReport;
+  pluginVersionReadiness?: PluginVersionRestartReadiness;
   runWithPluginMetadataSnapshot?: PluginMetadataSnapshotScopeRunner;
 };
 
@@ -98,6 +99,7 @@ function noteFlowRecoveryHints() {
 
 function pluginVersionDriftToHealthFindings(
   drift: PluginVersionDriftReport | undefined,
+  runningGatewayVersion?: string,
 ): HealthFinding[] {
   if (!drift || drift.drifts.length === 0) {
     return [];
@@ -112,7 +114,7 @@ function pluginVersionDriftToHealthFindings(
     return {
       checkId: WORKSPACE_STATUS_CHECK_ID,
       severity: "warning",
-      message: `Plugin ${entry.pluginId} is ${entry.installedVersion}, but the Gateway is ${drift.gatewayVersion}.${updateCommand ? "" : ` Repair target resolution failed: ${targetError}.`}`,
+      message: `Plugin ${entry.pluginId} is ${entry.installedVersion}, but a Gateway restart will load OpenClaw ${drift.gatewayVersion}.${runningGatewayVersion ? ` The running Gateway is ${runningGatewayVersion}.` : ""}${updateCommand ? "" : ` Repair target resolution failed: ${targetError}.`}`,
       path: `plugins.entries.${entry.pluginId}`,
       target: entry.pluginId,
       requirement: "plugin-version-drift",
@@ -121,6 +123,28 @@ function pluginVersionDriftToHealthFindings(
         : `No install command generated; retry openclaw doctor after checking registry availability (${targetError}).`,
     };
   });
+}
+
+function pluginVersionReadinessToHealthFindings(
+  readiness: PluginVersionRestartReadiness | undefined,
+): HealthFinding[] {
+  if (!readiness) {
+    return [];
+  }
+  if (readiness.status === "resolved") {
+    return pluginVersionDriftToHealthFindings(readiness.report, readiness.runningGatewayVersion);
+  }
+  return [
+    {
+      checkId: WORKSPACE_STATUS_CHECK_ID,
+      severity: "warning",
+      message: `Could not check plugin restart readiness: ${readiness.reason}`,
+      path: "plugins",
+      requirement: "plugin-version-restart-readiness",
+      fixHint:
+        "Repair the Gateway service installation, then rerun openclaw doctor before restarting.",
+    },
+  ];
 }
 
 function pluginCompatibilityWarningToHealthFinding(message: string): HealthFinding {
@@ -202,14 +226,28 @@ export function collectWorkspaceStatusHealthFindings(
   }
 
   return [
-    ...pluginVersionDriftToHealthFindings(options.pluginVersionDrift),
+    ...pluginVersionReadinessToHealthFindings(options.pluginVersionReadiness),
     ...workspaceFindings,
     ...collectTaskFlowRecoveryFindings().map(taskFlowRecoveryToHealthFinding),
   ];
 }
 
-function notePluginVersionDrift(drift: PluginVersionDriftReport | undefined) {
-  if (!drift || drift.drifts.length === 0) {
+function notePluginVersionReadiness(readiness: PluginVersionRestartReadiness | undefined) {
+  if (!readiness) {
+    return;
+  }
+  if (readiness.status === "unresolved") {
+    const running = readiness.runningGatewayVersion
+      ? `\nRunning Gateway: OpenClaw ${readiness.runningGatewayVersion}`
+      : "";
+    note(
+      `${readiness.reason}${running}\nRepair the Gateway service installation, then rerun openclaw doctor before restarting.`,
+      "Plugin restart readiness",
+    );
+    return;
+  }
+  const drift = readiness.report;
+  if (drift.drifts.length === 0) {
     return;
   }
   const singleDrift = drift.drifts.length === 1 ? drift.drifts[0] : undefined;
@@ -223,9 +261,12 @@ function notePluginVersionDrift(drift: PluginVersionDriftReport | undefined) {
     .map((command) => formatCliCommand(command));
   const unresolvedRepairs = repairs.filter(({ command }) => !command);
   const lines = [
+    ...(readiness.runningGatewayVersion
+      ? [`Running Gateway: OpenClaw ${readiness.runningGatewayVersion}`]
+      : []),
     `${drift.drifts.length} active official plugin${
       drift.drifts.length === 1 ? "" : "s"
-    } not on OpenClaw ${drift.gatewayVersion}`,
+    } not on post-restart OpenClaw ${drift.gatewayVersion}`,
     ...drift.drifts.map((entry) => {
       const sourceLabel = entry.source === "clawhub" ? "clawhub" : "npm";
       return `- ${entry.pluginId}: ${entry.installedVersion} (${sourceLabel}) -> expected ${drift.gatewayVersion}`;
@@ -250,7 +291,10 @@ function notePluginVersionDrift(drift: PluginVersionDriftReport | undefined) {
           ].join("\n")
         : null,
   ];
-  note(lines.filter((line): line is string => Boolean(line)).join("\n"), "Plugin version drift");
+  note(
+    lines.filter((line): line is string => Boolean(line)).join("\n"),
+    "Plugin restart readiness",
+  );
 }
 
 /** Emits plugin and TaskFlow recovery problem notes for doctor. */
@@ -305,7 +349,7 @@ export function noteWorkspaceStatus(cfg: OpenClawConfig, options: NoteWorkspaceS
       noteForWorkspace();
     }
   }
-  notePluginVersionDrift(options.pluginVersionDrift);
+  notePluginVersionReadiness(options.pluginVersionReadiness);
   noteFlowRecoveryHints();
 
   return {

--- a/src/commands/doctor-workspace-status.ts
+++ b/src/commands/doctor-workspace-status.ts
@@ -8,6 +8,7 @@ import {
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { HealthFinding } from "../flows/health-checks.js";
+import { resolveOpenClawReleaseCohortVersion } from "../infra/npm-registry-spec.js";
 import type { PluginMetadataSnapshotScopeRunner } from "../plugins/current-plugin-metadata-snapshot.js";
 import {
   resolvePluginVersionDriftUpdateCommand,
@@ -101,8 +102,23 @@ function pluginVersionDriftToHealthFindings(
   drift: PluginVersionDriftReport | undefined,
   runningGatewayVersion?: string,
 ): HealthFinding[] {
-  if (!drift || drift.drifts.length === 0) {
+  if (!drift) {
     return [];
+  }
+  if (drift.drifts.length === 0) {
+    if (!isGatewayRestartPending(drift, runningGatewayVersion)) {
+      return [];
+    }
+    return [
+      {
+        checkId: WORKSPACE_STATUS_CHECK_ID,
+        severity: "warning",
+        message: `Active official plugins match post-restart OpenClaw ${drift.gatewayVersion}, but the running Gateway is ${runningGatewayVersion}.`,
+        path: "plugins",
+        requirement: "plugin-version-gateway-restart",
+        fixHint: formatCliCommand("openclaw gateway restart"),
+      },
+    ];
   }
   return drift.drifts.map((entry) => {
     const updateCommand = resolvePluginVersionDriftUpdateCommand(entry);
@@ -123,6 +139,17 @@ function pluginVersionDriftToHealthFindings(
         : `No install command generated; retry openclaw doctor after checking registry availability (${targetError}).`,
     };
   });
+}
+
+function isGatewayRestartPending(
+  drift: PluginVersionDriftReport,
+  runningGatewayVersion: string | undefined,
+): runningGatewayVersion is string {
+  return Boolean(
+    runningGatewayVersion &&
+    resolveOpenClawReleaseCohortVersion(runningGatewayVersion) !==
+      resolveOpenClawReleaseCohortVersion(drift.gatewayVersion),
+  );
 }
 
 function pluginVersionReadinessToHealthFindings(
@@ -248,6 +275,17 @@ function notePluginVersionReadiness(readiness: PluginVersionRestartReadiness | u
   }
   const drift = readiness.report;
   if (drift.drifts.length === 0) {
+    if (!isGatewayRestartPending(drift, readiness.runningGatewayVersion)) {
+      return;
+    }
+    note(
+      [
+        `Running Gateway: OpenClaw ${readiness.runningGatewayVersion}`,
+        `Active official plugins match post-restart OpenClaw ${drift.gatewayVersion}.`,
+        `Fix: ${formatCliCommand("openclaw gateway restart")}.`,
+      ].join("\n"),
+      "Plugin restart readiness",
+    );
     return;
   }
   const singleDrift = drift.drifts.length === 1 ? drift.drifts[0] : undefined;

--- a/src/flows/doctor-health-contribution-runners.workspace.ts
+++ b/src/flows/doctor-health-contribution-runners.workspace.ts
@@ -5,8 +5,8 @@ import type { DoctorHealthFlowContext } from "./doctor-health-contribution-types
 import { resolveDoctorWorkspaceSuggestionScopes } from "./doctor-workspace-suggestion-scopes.js";
 import type { HealthCheckContext, HealthFinding } from "./health-checks.js";
 
-type PluginVersionDriftReport =
-  import("../plugins/plugin-version-drift.js").PluginVersionDriftReport;
+type PluginVersionRestartReadiness =
+  import("../plugins/plugin-version-drift.js").PluginVersionRestartReadiness;
 
 const loadDoctorStateIntegrityModule = async () =>
   await import("../commands/doctor-state-integrity.js");
@@ -82,10 +82,10 @@ export async function runHooksModelHealth(ctx: DoctorHealthFlowContext): Promise
   }
 }
 
-export async function collectWorkspaceStatusPluginVersionDrift(params: {
+export async function collectWorkspaceStatusPluginVersionReadiness(params: {
   cfg: OpenClawConfig;
   options?: Pick<DoctorOptions, "allowExec" | "deep" | "nonInteractive">;
-}): Promise<PluginVersionDriftReport | undefined> {
+}): Promise<PluginVersionRestartReadiness | undefined> {
   if (params.cfg.gateway?.mode === "remote" || !(await shouldManageGatewayService())) {
     return undefined;
   }
@@ -97,28 +97,32 @@ export async function collectWorkspaceStatusPluginVersionDrift(params: {
       requireRpc: false,
       deep: params.options?.deep === true,
       allowExecSecretRefs: params.options?.allowExec === true,
+      pluginVersionTarget: "restart",
     });
-    const hasProbedGatewayVersion =
-      typeof status.gateway?.version === "string" && status.gateway.version.trim() !== "";
-    if (status.pluginVersionDrift && hasProbedGatewayVersion && !status.rpc?.authWarning) {
+    if (status.pluginVersionRestartReadiness?.status === "resolved") {
       const { resolvePluginVersionDriftTargets } =
         await import("../plugins/plugin-version-drift.js");
-      return await resolvePluginVersionDriftTargets(status.pluginVersionDrift);
+      return {
+        ...status.pluginVersionRestartReadiness,
+        report: await resolvePluginVersionDriftTargets(status.pluginVersionRestartReadiness.report),
+      };
     }
+    return status.pluginVersionRestartReadiness;
   } catch {
-    // Best-effort diagnostic: doctor should keep running if daemon status is unavailable.
+    // The core Gateway health check owns general collection failures. Without status we
+    // cannot establish that a managed service and version-bound plugin make this check apply.
+    return undefined;
   }
-  return undefined;
 }
 
 export async function runWorkspaceStatusHealth(ctx: DoctorHealthFlowContext): Promise<void> {
-  const pluginVersionDrift = await collectWorkspaceStatusPluginVersionDrift({
+  const pluginVersionReadiness = await collectWorkspaceStatusPluginVersionReadiness({
     cfg: ctx.cfg,
     options: ctx.options,
   });
   const { noteWorkspaceStatus } = await import("../commands/doctor-workspace-status.js");
   noteWorkspaceStatus(ctx.cfg, {
-    pluginVersionDrift,
+    pluginVersionReadiness,
     ...(ctx.runWithPluginMetadataSnapshot
       ? { runWithPluginMetadataSnapshot: ctx.runWithPluginMetadataSnapshot }
       : {}),

--- a/src/flows/doctor-health-contributions-final.ts
+++ b/src/flows/doctor-health-contributions-final.ts
@@ -22,7 +22,7 @@ import {
 } from "./doctor-health-contribution-runners.gateway.js";
 import {
   collectMemorySearchHealthFindings,
-  collectWorkspaceStatusPluginVersionDrift,
+  collectWorkspaceStatusPluginVersionReadiness,
   runBootstrapSizeHealth,
   runHeartbeatCadenceMigrationHealth,
   runHeartbeatScratchMigrationHealth,
@@ -236,14 +236,14 @@ export function resolveFinalDoctorHealthContributions(params: {
         async detect(ctx) {
           const { collectWorkspaceStatusHealthFindings } =
             await import("../commands/doctor-workspace-status.js");
-          const pluginVersionDrift = await collectWorkspaceStatusPluginVersionDrift({
+          const pluginVersionReadiness = await collectWorkspaceStatusPluginVersionReadiness({
             cfg: ctx.cfg,
             options: { nonInteractive: true, allowExec: ctx.allowExecSecretRefs === true },
           });
           const runWithPluginMetadataSnapshot = (ctx as DoctorHealthCheckContext)
             .runWithPluginMetadataSnapshot;
           return collectWorkspaceStatusHealthFindings(ctx.cfg, {
-            pluginVersionDrift,
+            pluginVersionReadiness,
             ...(runWithPluginMetadataSnapshot ? { runWithPluginMetadataSnapshot } : {}),
           });
         },

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -1589,7 +1589,11 @@ describe("doctor health contributions", () => {
     };
     mocks.gatherDaemonStatus.mockResolvedValueOnce({
       gateway: { version: "2026.6.1" },
-      pluginVersionDrift,
+      pluginVersionRestartReadiness: {
+        status: "resolved",
+        report: pluginVersionDrift,
+        runningGatewayVersion: "2026.6.1",
+      },
     });
     mocks.collectWorkspaceStatusHealthFindings.mockResolvedValueOnce([
       {
@@ -1620,7 +1624,11 @@ describe("doctor health contributions", () => {
       findings: [expect.objectContaining({ checkId: "core/doctor/workspace-status" })],
     });
     expect(mocks.collectWorkspaceStatusHealthFindings).toHaveBeenCalledWith(ctx.cfg, {
-      pluginVersionDrift,
+      pluginVersionReadiness: {
+        status: "resolved",
+        report: pluginVersionDrift,
+        runningGatewayVersion: "2026.6.1",
+      },
     });
     expect(mocks.gatherDaemonStatus).toHaveBeenCalledWith({
       rpc: {
@@ -1631,6 +1639,49 @@ describe("doctor health contributions", () => {
       requireRpc: false,
       deep: false,
       allowExecSecretRefs: true,
+      pluginVersionTarget: "restart",
+    });
+  });
+
+  it("reports plugin drift against the service version that will run after restart", async () => {
+    const contribution = requireDoctorContribution("doctor:workspace-status");
+    mocks.gatherDaemonStatus.mockResolvedValueOnce({
+      gateway: { version: "2026.5.2" },
+      pluginVersionRestartReadiness: {
+        status: "resolved",
+        runningGatewayVersion: "2026.5.2",
+        report: {
+          gatewayVersion: "2026.6.1",
+          drifts: [
+            {
+              pluginId: "whatsapp",
+              installedVersion: "2026.5.2",
+              gatewayVersion: "2026.6.1",
+              source: "npm",
+            },
+          ],
+        },
+      },
+    });
+    const cfg = { plugins: { entries: { whatsapp: { enabled: true } } } };
+
+    await contribution.run(createDoctorHealthFlowContext({ cfg }));
+
+    expect(mocks.noteWorkspaceStatus).toHaveBeenCalledWith(cfg, {
+      pluginVersionReadiness: {
+        status: "resolved",
+        runningGatewayVersion: "2026.5.2",
+        report: {
+          gatewayVersion: "2026.6.1",
+          drifts: [
+            expect.objectContaining({
+              pluginId: "whatsapp",
+              installedVersion: "2026.5.2",
+              gatewayVersion: "2026.6.1",
+            }),
+          ],
+        },
+      },
     });
   });
 
@@ -1650,7 +1701,7 @@ describe("doctor health contributions", () => {
     };
     mocks.gatherDaemonStatus.mockResolvedValueOnce({
       gateway: { version: "2026.6.1" },
-      pluginVersionDrift,
+      pluginVersionRestartReadiness: { status: "resolved", report: pluginVersionDrift },
     });
     const cfg = { plugins: { entries: { codex: { enabled: true } } } };
 
@@ -1676,27 +1727,31 @@ describe("doctor health contributions", () => {
       requireRpc: false,
       deep: false,
       allowExecSecretRefs: false,
+      pluginVersionTarget: "restart",
     });
     expect(fetchNpmPackageTargetStatus).toHaveBeenCalledWith({
       packageName: "@openclaw/codex",
       target: "2026.6.1",
     });
     expect(mocks.noteWorkspaceStatus).toHaveBeenCalledWith(cfg, {
-      pluginVersionDrift: {
-        ...pluginVersionDrift,
-        drifts: [
-          expect.objectContaining({
-            targetResolution: expect.objectContaining({
-              status: "unresolved",
-              error: expect.stringContaining("HTTP 404"),
+      pluginVersionReadiness: {
+        status: "resolved",
+        report: {
+          ...pluginVersionDrift,
+          drifts: [
+            expect.objectContaining({
+              targetResolution: expect.objectContaining({
+                status: "unresolved",
+                error: expect.stringContaining("HTTP 404"),
+              }),
             }),
-          }),
-        ],
+          ],
+        },
       },
     });
   });
 
-  it("omits daemon-context plugin drift when gateway version used the fallback", async () => {
+  it("keeps post-restart plugin readiness when the Gateway is stopped", async () => {
     const contribution = requireDoctorContribution("doctor:workspace-status");
     const pluginVersionDrift = {
       gatewayVersion: "2026.5.2-test",
@@ -1711,7 +1766,7 @@ describe("doctor health contributions", () => {
     };
     mocks.gatherDaemonStatus.mockResolvedValueOnce({
       gateway: { version: null },
-      pluginVersionDrift,
+      pluginVersionRestartReadiness: { status: "resolved", report: pluginVersionDrift },
     });
     const cfg = { plugins: { entries: { codex: { enabled: true } } } };
 
@@ -1723,11 +1778,11 @@ describe("doctor health contributions", () => {
     );
 
     expect(mocks.noteWorkspaceStatus).toHaveBeenCalledWith(cfg, {
-      pluginVersionDrift: undefined,
+      pluginVersionReadiness: { status: "resolved", report: pluginVersionDrift },
     });
   });
 
-  it("omits daemon-context plugin drift when probe auth was skipped", async () => {
+  it("keeps post-restart plugin readiness when the Gateway probe is unavailable", async () => {
     const contribution = requireDoctorContribution("doctor:workspace-status");
     const pluginVersionDrift = {
       gatewayVersion: "2026.6.1",
@@ -1743,7 +1798,7 @@ describe("doctor health contributions", () => {
     mocks.gatherDaemonStatus.mockResolvedValueOnce({
       gateway: {},
       rpc: { authWarning: "exec SecretRef probe auth skipped" },
-      pluginVersionDrift,
+      pluginVersionRestartReadiness: { status: "resolved", report: pluginVersionDrift },
     });
     const cfg = { plugins: { entries: { codex: { enabled: true } } } };
 
@@ -1755,7 +1810,19 @@ describe("doctor health contributions", () => {
     );
 
     expect(mocks.noteWorkspaceStatus).toHaveBeenCalledWith(cfg, {
-      pluginVersionDrift: undefined,
+      pluginVersionReadiness: { status: "resolved", report: pluginVersionDrift },
+    });
+  });
+
+  it("omits plugin readiness when status fails before applicability is known", async () => {
+    const contribution = requireDoctorContribution("doctor:workspace-status");
+    mocks.gatherDaemonStatus.mockRejectedValueOnce(new Error("service inspection failed"));
+    const cfg = {};
+
+    await contribution.run(createDoctorHealthFlowContext({ cfg }));
+
+    expect(mocks.noteWorkspaceStatus).toHaveBeenCalledWith(cfg, {
+      pluginVersionReadiness: undefined,
     });
   });
 
@@ -1773,7 +1840,7 @@ describe("doctor health contributions", () => {
 
     expect(mocks.gatherDaemonStatus).not.toHaveBeenCalled();
     expect(mocks.noteWorkspaceStatus).toHaveBeenCalledWith(cfg, {
-      pluginVersionDrift: undefined,
+      pluginVersionReadiness: undefined,
     });
   });
 
@@ -1787,7 +1854,7 @@ describe("doctor health contributions", () => {
 
     expect(mocks.gatherDaemonStatus).not.toHaveBeenCalled();
     expect(mocks.noteWorkspaceStatus).toHaveBeenCalledWith(cfg, {
-      pluginVersionDrift: undefined,
+      pluginVersionReadiness: undefined,
     });
 
     const ctx = createDoctorLintContext({
@@ -1800,7 +1867,7 @@ describe("doctor health contributions", () => {
 
     expect(mocks.gatherDaemonStatus).not.toHaveBeenCalled();
     expect(mocks.collectWorkspaceStatusHealthFindings).toHaveBeenCalledWith(cfg, {
-      pluginVersionDrift: undefined,
+      pluginVersionReadiness: undefined,
     });
   });
 
@@ -1819,7 +1886,7 @@ describe("doctor health contributions", () => {
     };
     mocks.gatherDaemonStatus.mockResolvedValueOnce({
       gateway: { version: "2026.6.1" },
-      pluginVersionDrift,
+      pluginVersionRestartReadiness: { status: "resolved", report: pluginVersionDrift },
     });
     const cfg = {
       gateway: {
@@ -1848,8 +1915,11 @@ describe("doctor health contributions", () => {
       requireRpc: false,
       deep: false,
       allowExecSecretRefs: false,
+      pluginVersionTarget: "restart",
     });
-    expect(mocks.noteWorkspaceStatus).toHaveBeenCalledWith(cfg, { pluginVersionDrift });
+    expect(mocks.noteWorkspaceStatus).toHaveBeenCalledWith(cfg, {
+      pluginVersionReadiness: { status: "resolved", report: pluginVersionDrift },
+    });
   });
 
   it("ignores remote-only exec SecretRefs for local daemon-context plugin drift probes", async () => {
@@ -1883,6 +1953,7 @@ describe("doctor health contributions", () => {
       requireRpc: false,
       deep: false,
       allowExecSecretRefs: false,
+      pluginVersionTarget: "restart",
     });
   });
 

--- a/src/plugins/plugin-version-drift.ts
+++ b/src/plugins/plugin-version-drift.ts
@@ -33,6 +33,18 @@ export type PluginVersionDriftReport = {
   drifts: PluginVersionDriftEntry[];
 };
 
+export type PluginVersionRestartReadiness =
+  | {
+      status: "resolved";
+      report: PluginVersionDriftReport;
+      runningGatewayVersion?: string;
+    }
+  | {
+      status: "unresolved";
+      reason: string;
+      runningGatewayVersion?: string;
+    };
+
 function resolveExactNpmPinPackageName(entry: PluginVersionDriftEntry): string | undefined {
   if (entry.source !== "npm" || !entry.spec) {
     return undefined;
@@ -131,12 +143,23 @@ function shouldCompareOfficialInstallToGateway(params: {
   return false;
 }
 
+export function hasOfficialPluginVersionCandidates(params: {
+  installRecords: Record<string, PluginInstallRecord>;
+  config?: OpenClawConfig;
+}): boolean {
+  return Object.entries(params.installRecords).some(
+    ([pluginId, record]) =>
+      Boolean(record) &&
+      isPluginEnabled(params.config, pluginId) &&
+      shouldCompareOfficialInstallToGateway({ pluginId, record }),
+  );
+}
+
 /**
- * Compare active official external plugin installs against the running gateway
+ * Compare active official external plugin installs against an OpenClaw host
  * version and return any mismatches.
  *
- * @param params.gatewayVersion The gateway version string (typically the
- *   `version` field of the installed openclaw package.json).
+ * @param params.gatewayVersion The host version the plugins must match.
  * @param params.installRecords The full set of recorded plugin installs (as
  *   produced by `loadInstalledPluginIndexInstallRecords`).
  * @param params.config The merged daemon-side OpenClawConfig (optional).


### PR DESCRIPTION
## What Problem This Solves

After a package-manager upgrade, Doctor could compare official plugins with the currently running Gateway or invoking CLI instead of the managed service package the next restart will load. That can hide an incompatible post-restart plugin cohort.

Related: #133810
Source report/attempt: #133884 (credit: @Finn763)

## Why This Change Was Made

Resolve the managed service entrypoint and package version, then model restart readiness explicitly as resolved or unresolved. Keep the running Gateway version as separate evidence. Ordinary `gateway status`, plugin update behavior, and exact-pin semantics remain unchanged.

## User Impact

`openclaw doctor` now warns before restart when active official plugins do not match the service package, including stopped or unreachable Gateway cases. If the restart target cannot be proven, Doctor reports that uncertainty and a repair path.

## Evidence

- 214 focused tests passed; final status suite 70/70.
- Changed-file formatting, lint, type checks, guards, and import-cycle checks passed.
- Fresh autoreview: no actionable findings.
- Production `+169/-39`; tests `+297/-62`; docs `+3/-1`.
- No live historical global-upgrade reproduction; this PR is diagnostics-only and does not mutate the managed service.
