### PR TITLE
fix(lint): report final failures after owned child cleanup

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -272,6 +272,15 @@ detached descendants stopped. Before manually removing an abandoned lock directo
 inspect its `owner.json` and verify all associated build, compiler, and lint
 processes, including detached descendants, have stopped; then retry the command.
 
+Lint reports its final failure on stderr after child joins and artifact ownership
+have settled, including retained ownership when cleanup is uncertain. Standalone
+Oxlint and its shard CLI end with `[oxlint] FAILED (exit N)`; `pnpm lint` owns the
+whole pipeline and ends with one `[lint] FAILED (exit N)` instead. Shard progress
+distinguishes `passed` from `failed (exit N)`, and stdout remains available for
+machine-readable tool output. Successful runs have no failure trailer. Signals
+forwarded during child execution and shard timeouts fail the command; whole-host
+loss or `SIGKILL` of the reporting process can prevent a final line.
+
 Local plugin lint and package-boundary compilation consume native declarations in
 `packages/plugin-sdk/dist` and seven separate plugin API trees in
 `.artifacts/extension-package-boundary/plugins`. Each declaration and compile

--- a/scripts/run-lint.mts
+++ b/scripts/run-lint.mts
@@ -1,64 +1,46 @@
 // Runs the complete lint pipeline after preparing a linked-worktree toolchain.
-import { spawnSync, type SpawnSyncOptions } from "node:child_process";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { runWithFailedTrailer } from "./lib/failed-trailer.mts";
 import {
   ensureRepoToolNodeModulesLink,
   resolveRepoToolBinPath,
 } from "./lib/local-check-runtime.mts";
+import { runManagedCommand } from "./lib/managed-child-process.mts";
+import { main as runOxlintShards } from "./run-oxlint-shards.mts";
+import { runStylelint } from "./run-stylelint.mts";
 
-function run(command: string, args: string[], options: SpawnSyncOptions) {
-  const result = spawnSync(command, args, options);
-  if (result.error) {
-    throw result.error;
-  }
-  return result.status ?? 1;
-}
+await runWithFailedTrailer("lint", async () => {
+  const oxlintPath = resolveRepoToolBinPath("oxlint");
+  const tsxPath = resolveRepoToolBinPath("tsx");
+  ensureRepoToolNodeModulesLink(oxlintPath);
+  const tsxImportSpecifier = pathToFileURL(createRequire(tsxPath).resolve("tsx")).href;
 
-const oxlintPath = resolveRepoToolBinPath("oxlint");
-const tsxPath = resolveRepoToolBinPath("tsx");
-ensureRepoToolNodeModulesLink(oxlintPath);
-const tsxImportSpecifier = pathToFileURL(createRequire(tsxPath).resolve("tsx")).href;
-
-// Invoke the pre-step directly: running pnpm through a linked node_modules can
-// reconcile the owning checkout's dependency tree instead of merely running it.
-const uiI18nStatus = run(
-  process.execPath,
-  ["--import", tsxImportSpecifier, path.resolve("scripts", "control-ui-i18n-verify.ts"), "verify"],
-  { env: process.env, stdio: "inherit" },
-);
-if (uiI18nStatus !== 0) {
-  process.exitCode = uiI18nStatus;
-} else {
-  const oxlintStatus = run(
-    process.execPath,
-    [
+  // Invoke directly: pnpm through a linked node_modules can reconcile its owner's install.
+  process.exitCode = await runManagedCommand({
+    bin: process.execPath,
+    args: [
       "--import",
       tsxImportSpecifier,
-      path.resolve("scripts", "run-oxlint-shards.mts"),
-      ...process.argv.slice(2),
+      path.resolve("scripts", "control-ui-i18n-verify.ts"),
+      "verify",
     ],
-    { env: process.env, stdio: "inherit" },
-  );
-  if (oxlintStatus !== 0) {
-    process.exitCode = oxlintStatus;
-  } else {
-    // Control UI CSS hygiene: plain stylesheets plus css`` templates in Lit
-    // components. oxlint cannot see inside tagged CSS templates.
-    // Delegate like the steps above: the stylelint runner already resolves and
-    // launches the shim, so this pipeline never handles a tool path itself.
-    process.exitCode = run(
-      process.execPath,
-      [
-        "--import",
-        tsxImportSpecifier,
-        path.resolve("scripts", "run-stylelint.mts"),
-        "ui/src/**/*.css",
-        "ui/src/**/*.ts",
-        "ui/public/themes/*.css",
-      ],
-      { env: process.env, stdio: "inherit" },
-    );
+    env: process.env,
+    requireProcessTreeExit: process.platform !== "win32",
+  });
+  if (process.exitCode !== 0) {
+    return;
   }
-}
+  // Compose the batch so cancellation and final reporting remain with this process.
+  process.exitCode = await runOxlintShards();
+  if (process.exitCode !== 0) {
+    return;
+  }
+  // Oxlint cannot see plain stylesheets or css`` templates in Lit components.
+  process.exitCode = await runStylelint([
+    "ui/src/**/*.css",
+    "ui/src/**/*.ts",
+    "ui/public/themes/*.css",
+  ]);
+});

--- a/scripts/run-oxlint-shards.mts
+++ b/scripts/run-oxlint-shards.mts
@@ -7,6 +7,7 @@ import {
   distArtifactEntryArgs,
   withDistArtifactOwnership,
 } from "./lib/dist-artifact-ownership.mts";
+import { runWithFailedTrailer } from "./lib/failed-trailer.mts";
 import {
   CI_PARALLEL_MIN_MEMORY_BYTES,
   ensureRepoToolNodeModulesLink,
@@ -57,7 +58,7 @@ type ActiveShardChild = { child: ChildProcess; killGraceMs: number };
 const ACTIVE_SHARD_CHILDREN = new Set<ActiveShardChild>();
 let parentTerminationSignal: (typeof PARENT_TERMINATION_SIGNALS)[number] | null = null;
 let parentTerminationForceKill: ReturnType<typeof setTimeout> | null = null;
-let parentSignalForwardingInstalled = false;
+const parentSignalHandlers = new Map<NodeJS.Signals, () => void>();
 
 const CORE_SHARD = {
   name: "core",
@@ -260,7 +261,7 @@ export async function main(
   extraArgs: string[] = process.argv.slice(2),
   runtimeEnv: NodeJS.ProcessEnv = process.env,
 ) {
-  const runner = path.resolve("scripts", "run-oxlint.mjs");
+  const runner = path.resolve("scripts", "run-oxlint.mts");
   const shardArgs = parseShardRunnerArgs(extraArgs);
   const env = resolveLocalCheckEnv(runtimeEnv);
   const hostResources = resolveHostResources();
@@ -292,8 +293,7 @@ export async function main(
         requireProcessTreeExit: process.platform !== "win32",
       });
       if (code !== 0) {
-        process.exitCode = code;
-        return;
+        return code;
       }
     }
     const shardConcurrency = resolveOxlintShardConcurrency({
@@ -314,17 +314,16 @@ export async function main(
       extraArgs: shardArgs.oxlintArgs,
       runner,
     });
-    process.exitCode = results.find((status) => status !== 0) ?? 0;
+    return results.find((status) => status !== 0) ?? 0;
   };
-  if (needsArtifacts) {
-    await withDistArtifactOwnership(process.cwd(), run);
-  } else {
-    await run();
-  }
+  return needsArtifacts ? await withDistArtifactOwnership(process.cwd(), run) : await run();
 }
 
 if (import.meta.main) {
-  await main();
+  // Imported batches leave final reporting to their outer pipeline, after ownership settles.
+  await runWithFailedTrailer("oxlint", async () => {
+    process.exitCode = await main();
+  });
 }
 
 function resolveHostResources(hostResources?: HostResources) {
@@ -520,11 +519,19 @@ export async function runShard({ env, extraArgs, runner, shard }: ShardRunnerOpt
   const heartbeatMs = resolveShardHeartbeatMs(env);
   const timeoutMs = resolveShardTimeoutMs(env);
   const killGraceMs = resolveShardKillGraceMs(env);
-  // The shard batch holds ownership through preparation and every consumer.
+  // The batch owns reporting and artifacts. Raw children must propagate cleanup
+  // errors to the private artifact entry without catching or reporting them here.
   const args =
-    runner === path.resolve("scripts", "run-oxlint.mjs") &&
-    shouldPrepareExtensionPackageBoundaryArtifactsForShards([shard], extraArgs)
-      ? distArtifactEntryArgs(path.resolve("scripts/run-oxlint.mts"), [...shard.args, ...extraArgs])
+    runner === path.resolve("scripts", "run-oxlint.mts")
+      ? shouldPrepareExtensionPackageBoundaryArtifactsForShards([shard], extraArgs)
+        ? distArtifactEntryArgs(runner, [...shard.args, ...extraArgs])
+        : [
+            "--import",
+            new URL("./tsx.mjs", import.meta.url).href,
+            runner,
+            ...shard.args,
+            ...extraArgs,
+          ]
       : [runner, ...shard.args, ...extraArgs];
   const child = spawn(process.execPath, args, {
     stdio: ["inherit", "pipe", "pipe"],
@@ -589,7 +596,9 @@ export async function runShard({ env, extraArgs, runner, shard }: ShardRunnerOpt
       }
       forceKillAt = null;
       unregisterShardChild();
-      console.error(`[oxlint:${shard.name}] finished`);
+      console.error(
+        `[oxlint:${shard.name}] ${status === 0 ? "passed" : `failed (exit ${status})`}`,
+      );
       if (error) {
         reject(error);
       } else {
@@ -757,28 +766,35 @@ function registerShardChild(entry: ActiveShardChild) {
       clearTimeout(parentTerminationForceKill);
       parentTerminationForceKill = null;
     }
+    if (ACTIVE_SHARD_CHILDREN.size === 0) {
+      for (const [signal, handler] of parentSignalHandlers) {
+        process.off(signal, handler);
+      }
+      parentSignalHandlers.clear();
+      process.off("exit", onParentExit);
+    }
   };
 }
 
 function installParentSignalForwarding() {
-  if (parentSignalForwardingInstalled) {
+  if (parentSignalHandlers.size > 0) {
     return;
   }
-  parentSignalForwardingInstalled = true;
   for (const signal of PARENT_TERMINATION_SIGNALS) {
-    process.on(signal, () => {
+    const handler = () => {
       parentTerminationSignal = signal;
       process.exitCode = getSignalExitCode(signal);
-      if (ACTIVE_SHARD_CHILDREN.size === 0) {
-        process.exit(process.exitCode);
-      }
       signalActiveShardChildren(signal);
       scheduleParentTerminationForceKill();
-    });
+    };
+    parentSignalHandlers.set(signal, handler);
+    process.on(signal, handler);
   }
-  process.once("exit", () => {
-    signalActiveShardChildren("SIGTERM");
-  });
+  process.once("exit", onParentExit);
+}
+
+function onParentExit() {
+  signalActiveShardChildren("SIGTERM");
 }
 
 function isParentTerminationRequested() {

--- a/scripts/run-stylelint.mts
+++ b/scripts/run-stylelint.mts
@@ -1,26 +1,25 @@
 // Runs Stylelint through the linked-worktree-aware repository toolchain.
-import { spawnSync } from "node:child_process";
 import path from "node:path";
+import { runWithFailedTrailer } from "./lib/failed-trailer.mts";
 import {
   ensureRepoToolNodeModulesLink,
   resolveRepoToolBinPath,
 } from "./lib/local-check-runtime.mts";
-import { createManagedCommandInvocation } from "./lib/managed-child-process.mts";
+import { runManagedCommand } from "./lib/managed-child-process.mts";
 
-const stylelintPath = resolveRepoToolBinPath("stylelint");
-ensureRepoToolNodeModulesLink(stylelintPath);
-const stylelint = createManagedCommandInvocation({
-  args: ["--config", path.resolve("config", "stylelint.config.mjs"), ...process.argv.slice(2)],
-  bin: stylelintPath,
-  env: process.env,
-});
-const result = spawnSync(stylelint.command, stylelint.args, {
-  env: process.env,
-  shell: stylelint.shell,
-  stdio: "inherit",
-  windowsVerbatimArguments: stylelint.windowsVerbatimArguments,
-});
-if (result.error) {
-  throw result.error;
+export async function runStylelint(args: string[] = process.argv.slice(2)) {
+  const stylelintPath = resolveRepoToolBinPath("stylelint");
+  ensureRepoToolNodeModulesLink(stylelintPath);
+  return await runManagedCommand({
+    args: ["--config", path.resolve("config", "stylelint.config.mjs"), ...args],
+    bin: stylelintPath,
+    env: process.env,
+    requireProcessTreeExit: process.platform !== "win32",
+  });
 }
-process.exitCode = result.status ?? 1;
+
+if (import.meta.main) {
+  await runWithFailedTrailer("stylelint", async () => {
+    process.exitCode = await runStylelint();
+  });
+}

--- a/scripts/test-projects.test-support.mts
+++ b/scripts/test-projects.test-support.mts
@@ -2220,8 +2220,17 @@ const EXACT_TOOLING_TARGETS = new Map<string, string[]>([
   ["scripts/build-stamp.mts", ["src/infra/build-stamp.test.ts"]],
   ["scripts/run-vitest.mjs", ["run-vitest", "test-projects", "vitest-local-scheduling"]],
   ["scripts/run-vitest.mts", ["run-vitest", "test-projects", "vitest-local-scheduling"]],
-  ["scripts/run-oxlint-shards.mts", ["run-oxlint"]],
-  ["scripts/lib/failed-trailer.mts", ["run-oxlint", "run-tsgo", "run-vitest", "changed-lanes"]],
+  ["scripts/run-oxlint-shards.mts", ["run-oxlint", "lint-status"]],
+  ["scripts/run-oxlint.mts", ["run-oxlint", "lint-status"]],
+  ["scripts/run-oxlint.mjs", ["run-oxlint", "lint-status"]],
+  ["scripts/run-lint.mts", ["run-oxlint", "lint-status"]],
+  ["scripts/run-stylelint.mts", ["changed-lanes", "lint-status"]],
+  [
+    "scripts/lib/failed-trailer.mts",
+    ["run-oxlint", "run-tsgo", "run-vitest", "changed-lanes", "lint-status"],
+  ],
+  ["scripts/lib/managed-child-process.mts", ["managed-child-process", "lint-status"]],
+  ["scripts/lib/dist-artifact-ownership.mts", ["dist-artifact-ownership", "lint-status"]],
   ["scripts/docker-e2e-rerun.mts", ["docker-e2e-helper-cli"]],
   ["scripts/openclaw-postpack.mjs", [TOOLING_VITEST_CONFIG]],
   ["scripts/package-manifest.mjs", ["test/openclaw-prepack.test.ts"]],
@@ -2460,7 +2469,7 @@ const SEMANTIC_TOOLING_TARGET_PATTERNS: Array<[RegExp, string[]]> = [
   [/^scripts\/ci-changed-scope\.mjs$/u, [...changedScopeTests, "control-ui-i18n"]],
   [/^scripts\/check-changed\.(?:mjs|mts)$/u, ["changed-lanes"]],
   [/^scripts\/changed-lanes\.(?:mjs|mts)$/u, ["changed-lanes"]],
-  [/^scripts\/(?:lib\/tsx-cli-shim|tsx)\.mjs$/u, ["direct-run-entrypoints"]],
+  [/^scripts\/(?:lib\/tsx-cli-shim|tsx)\.mjs$/u, ["direct-run-entrypoints", "lint-status"]],
   [
     new RegExp(
       [

--- a/test/scripts/lint-status.test.ts
+++ b/test/scripts/lint-status.test.ts
@@ -1,0 +1,417 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { createFixtureLifetime } from "../helpers/fixture-lifetime.js";
+import { isProcessAlive, waitForPidFile } from "../helpers/process-wait.js";
+import { runNodeScript } from "../helpers/run-node-script.js";
+import { formatShimResult } from "./direct-run-entrypoints.test-support.js";
+
+const fixture = createFixtureLifetime();
+afterEach(() => fixture.cleanup());
+const entries = ["run-oxlint.mjs", "run-oxlint-shards.mts", "run-lint.mts"] as const;
+type Entry = (typeof entries)[number];
+type Mode = "success" | "nonzero" | "signal" | "wait" | "throw" | "unjoined";
+
+function createLintFixture(mode: Mode, phase: string, timeout: boolean) {
+  const root = fs.realpathSync(fixture.createTempDir("openclaw-lint-status-"));
+  const write = (relative: string, content: string) => {
+    const target = path.join(root, relative);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, content);
+    return target;
+  };
+  write("package.json", '{"type":"module"}');
+  write("pnpm-workspace.yaml", "packages: []\n");
+  const waitForFile = write(
+    "wait-for-file.mjs",
+    `
+import fs from "node:fs";
+export function waitForFile(file) {
+  return new Promise((resolve, reject) => {
+    const check = () => { if (fs.existsSync(file)) { watcher.close(); resolve(); } };
+    const watcher = fs.watch(".", { persistent: false }, check);
+    watcher.once("error", reject);
+    check();
+  });
+}
+`,
+  );
+  for (const file of [
+    ...entries,
+    "run-oxlint.mts",
+    "run-stylelint.mts",
+    "tsx.mjs",
+    "windows-cmd-helpers.mjs",
+    "lib/tsx-cli-shim.mjs",
+    "lib/local-check-runtime.mts",
+    "lib/direct-run.mjs",
+    "lib/dist-artifact-ownership.mts",
+    "lib/failed-trailer.mts",
+    "lib/managed-child-process.mts",
+    "lib/windows-taskkill.mjs",
+    "lib/repo-root.mjs",
+  ]) {
+    write(`scripts/${file}`, fs.readFileSync(path.resolve("scripts", file), "utf8"));
+  }
+  // Only this disposable fixture gets synthetic binaries; installed tools stay untouched.
+  for (const name of ["tsx", "p-map", "@openclaw/fs-safe"]) {
+    const target = path.join(root, "node_modules", name);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.symlinkSync(path.resolve("node_modules", name), target, "junction");
+  }
+  const toolSource = (step: string) => `
+import fs from "node:fs";
+import { waitForFile } from ${JSON.stringify(pathToFileURL(waitForFile).href)};
+const step = ${JSON.stringify(step)};
+const mode = ${JSON.stringify(step === phase ? mode : "success")};
+const shard = process.argv.includes("scripts") ? "scripts" : process.argv.includes("src") ? "core" : "extensions";
+const name = step === "oxlint" ? shard : step;
+const lock = ".artifacts/dist-artifacts.lock";
+fs.appendFileSync("steps.jsonl", JSON.stringify({ step, shard, pid: process.pid, owned: fs.existsSync(lock + "/owner.json"), claims: fs.existsSync(lock) ? fs.readdirSync(lock).filter(name => name.startsWith("child-")) : [] }) + "\\n");
+process.stdout.write(JSON.stringify({ step, shard }) + "\\n");
+process.stderr.write("diagnostic:" + name + "\\n");
+if (mode === "throw") throw new Error("fixture preparation failure");
+if (mode === "unjoined") throw Object.assign(new Error("fixture cleanup unverified"), { processTreeState: "indeterminate" });
+if (mode === "signal") process.kill(process.pid, "SIGTERM");
+else if (mode === "wait") {
+  const timer = setInterval(() => {}, 1000);
+  // Force the initial deadline to expire before this child can publish readiness.
+  if (${timeout} && step === "oxlint") await waitForFile("watchdog-fired");
+  for (const signal of ["SIGINT", "SIGTERM"]) process.on(signal, () => {
+    process.stderr.write("drained:" + name + ":" + signal + "\\n");
+    clearInterval(timer);
+  });
+  fs.writeFileSync(name + ".pid.tmp", String(process.pid));
+  fs.renameSync(name + ".pid.tmp", name + ".pid");
+} else process.exitCode = mode === "nonzero" ? 7 : 0;
+`;
+  for (const name of ["oxlint", "stylelint"]) {
+    const tool = write(`tools/${name}.mjs`, toolSource(name));
+    const bin = write(
+      `node_modules/.bin/${name}`,
+      `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(tool)} "$@"\n`,
+    );
+    fs.chmodSync(bin, 0o755);
+  }
+  write("scripts/prepare-extension-package-boundary-artifacts.mts", toolSource("prepare"));
+  write("scripts/control-ui-i18n-verify.ts", toolSource("i18n"));
+  const probe = write(
+    "trailer-probe.mjs",
+    `
+import fs from "node:fs";
+import { waitForFile } from ${JSON.stringify(pathToFileURL(waitForFile).href)};
+if (${timeout}) {
+  const schedule = globalThis.setTimeout;
+  globalThis.setTimeout = (callback, ms, ...args) => {
+    if (ms !== 1500) return schedule(callback, ms, ...args);
+    // Gate only the initial shard watchdog, preserving its native clear/unref
+    // handle and restoring real scheduling before readiness, grace, or cleanup.
+    globalThis.setTimeout = schedule;
+    return schedule(() => {
+      fs.writeFileSync("watchdog-fired", JSON.stringify({ childReady: fs.existsSync("extensions.pid") }));
+      void waitForFile("extensions.pid").then(() => callback(...args));
+    }, ms);
+  };
+}
+const write = process.stderr.write.bind(process.stderr);
+process.stderr.write = (chunk, ...args) => {
+  if (String(chunk).includes("FAILED (exit")) fs.appendFileSync("trailers.jsonl", JSON.stringify({
+    text: String(chunk).trim(),
+    owned: fs.existsSync(".artifacts/dist-artifacts.lock/owner.json"),
+    claims: fs.existsSync(".artifacts/dist-artifacts.lock") ? fs.readdirSync(".artifacts/dist-artifacts.lock").filter(name => name.startsWith("child-")) : [],
+    live: fs.existsSync("steps.jsonl") ? fs.readFileSync("steps.jsonl", "utf8").trim().split("\\n").map(line => JSON.parse(line).pid).filter(pid => {
+      try { process.kill(pid, 0); return true; } catch { return false; }
+    }) : [],
+  }) + "\\n");
+  return write(chunk, ...args);
+};
+`,
+  );
+  const env: NodeJS.ProcessEnv = { ...process.env, OPENCLAW_OXLINT_SHARDS_SERIAL: "1" };
+  for (const key of [
+    "NODE_OPTIONS",
+    "NODE_PATH",
+    "PNPM_CONFIG_MODULES_DIR",
+    "npm_config_modules_dir",
+    "OPENCLAW_OXLINT_SKIP_PREPARE",
+  ]) {
+    delete env[key];
+  }
+  return { root, probe, env };
+}
+
+type Step = { step: string; shard: string; pid: number; owned: boolean; claims: string[] };
+
+function readRows<T>(root: string, name: string): T[] {
+  const file = path.join(root, name);
+  return fs.existsSync(file)
+    ? fs
+        .readFileSync(file, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line) as T)
+    : [];
+}
+
+async function runLintFixture(
+  entry: Entry,
+  mode: Mode,
+  signal: AbortSignal,
+  {
+    phase = "oxlint",
+    parallel = false,
+    timeout = false,
+    forwarded,
+  }: {
+    phase?: string;
+    parallel?: boolean;
+    timeout?: boolean;
+    forwarded?: "SIGINT" | "SIGTERM";
+  } = {},
+) {
+  const { root, probe, env } = createLintFixture(mode, phase, timeout);
+  const args =
+    entry === "run-oxlint.mjs"
+      ? ["--tsconfig", "extensions/tsconfig.json", "extensions"]
+      : parallel
+        ? ["--only=core", "--only=extensions", "--only=scripts"]
+        : ["--only=extensions"];
+  const command = fixture.track(
+    runNodeScript(
+      [
+        "--import",
+        pathToFileURL(probe).href,
+        "--import",
+        pathToFileURL(path.join(root, "scripts/tsx.mjs")).href,
+        path.join(root, "scripts", entry),
+        ...args,
+      ],
+      {
+        ...env,
+        OPENCLAW_OXLINT_SHARDS_SERIAL: parallel ? "0" : "1",
+        OPENCLAW_OXLINT_SHARD_HEARTBEAT_MS: "0",
+        OPENCLAW_OXLINT_SHARD_TIMEOUT_MS: timeout ? "1500" : "0",
+      },
+      10_000,
+      {
+        cwd: root,
+        signal,
+        requireProcessTreeExit: true,
+        onReady(child) {
+          if (forwarded) {
+            fixture.track(
+              (async () => {
+                const ready = path.join(
+                  root,
+                  phase === "oxlint" ? "extensions.pid" : `${phase}.pid`,
+                );
+                await waitForPidFile(ready, 5_000);
+                child.kill(forwarded);
+              })(),
+            );
+          }
+        },
+      },
+    ),
+  );
+  const result = await command;
+  const details = formatShimResult(result);
+  expect(result.error, details).toBeUndefined();
+  if (timeout) {
+    expect(readRows(root, "watchdog-fired"), details).toEqual([{ childReady: false }]);
+  }
+  const steps = readRows<Step>(root, "steps.jsonl");
+  expect(steps.length, details).toBeGreaterThan(0);
+  for (const step of steps) {
+    expect(isProcessAlive(step.pid), details).toBe(false);
+  }
+  expect(fs.existsSync(path.join(root, ".artifacts/dist-artifacts.lock/owner.json")), details).toBe(
+    mode === "unjoined",
+  );
+  // Every stdout line remains machine-readable, including parallel sibling output.
+  expect(
+    result.stdout
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line)),
+  ).toHaveLength(steps.length);
+  const trailers = readRows<{ text: string }>(root, "trailers.jsonl");
+  expect(result.stderr.match(/FAILED \(exit/g) ?? [], details).toHaveLength(
+    result.status === 0 ? 0 : 1,
+  );
+  if (result.status !== 0) {
+    expect(result.stderr.trim().split("\n").at(-1), details).toBe(trailers[0]?.text);
+  }
+  return { result, details, steps, trailers };
+}
+
+describe.skipIf(process.platform === "win32")("lint failure reporting boundary", () => {
+  it.for(
+    entries.flatMap((entry) =>
+      (["success", "nonzero", "signal"] as const).map((mode) => ({ entry, mode })),
+    ),
+  )("$entry reports $mode after joining and releasing artifacts", ({ entry, mode }, { signal }) =>
+    fixture.run(async () => {
+      const { result, details, steps, trailers } = await runLintFixture(entry, mode, signal);
+      const code = mode === "success" ? 0 : mode === "signal" ? 143 : 7;
+      expect(result.status, details).toBe(code);
+      const lint = steps.find((step) => step.step === "oxlint");
+      expect(lint, details).toMatchObject({ owned: true });
+      if (entry !== "run-oxlint.mjs") expect(lint!.claims).toHaveLength(1);
+      if (mode === "success" && entry === "run-lint.mts") {
+        expect(steps.map((step) => step.step)).toEqual(["i18n", "prepare", "oxlint", "stylelint"]);
+      }
+      expect(result.stderr.match(/FAILED \(exit/g) ?? []).toHaveLength(code ? 1 : 0);
+      const tool = entry === "run-lint.mts" ? "lint" : "oxlint";
+      expect(trailers, details).toEqual(
+        code
+          ? [{ text: `[${tool}] FAILED (exit ${code})`, owned: false, claims: [], live: [] }]
+          : [],
+      );
+      if (code) {
+        expect(result.stderr.trim().split("\n").at(-1)).toBe(`[${tool}] FAILED (exit ${code})`);
+        expect(result.stderr).not.toContain("[oxlint:extensions] finished");
+      }
+    }),
+  );
+
+  it.for(["run-oxlint-shards.mts", "run-lint.mts"] as const)(
+    "%s reports one timeout after the owned child drains",
+    (entry, { signal }) =>
+      fixture.run(async () => {
+        const { result, details, trailers } = await runLintFixture(entry, "wait", signal, {
+          timeout: true,
+        });
+        expect(result.status, details).toBe(124);
+        expect(result.stderr).toContain("timed out");
+        expect(result.stderr).toContain("drained:extensions:SIGTERM");
+        expect(trailers, details).toEqual([
+          {
+            text: `[${entry === "run-lint.mts" ? "lint" : "oxlint"}] FAILED (exit 124)`,
+            owned: false,
+            claims: [],
+            live: [],
+          },
+        ]);
+      }),
+  );
+
+  it.for(entries)(
+    "%s reports preparation exceptions after releasing ownership",
+    (entry, { signal }) =>
+      fixture.run(async () => {
+        const { result, details, steps, trailers } = await runLintFixture(entry, "throw", signal, {
+          phase: "prepare",
+        });
+        expect(result.status, details).toBe(1);
+        expect(result.stderr).toContain("fixture preparation failure");
+        expect(steps.some((step) => step.step === "oxlint")).toBe(false);
+        expect(trailers, details).toEqual([
+          {
+            text: `[${entry === "run-lint.mts" ? "lint" : "oxlint"}] FAILED (exit 1)`,
+            owned: false,
+            claims: [],
+            live: [],
+          },
+        ]);
+      }),
+  );
+
+  it.for(["run-oxlint-shards.mts", "run-lint.mts"] as const)(
+    "%s joins parallel siblings before one final failure",
+    (entry, { signal }) =>
+      fixture.run(async () => {
+        const { result, details, steps, trailers } = await runLintFixture(
+          entry,
+          "nonzero",
+          signal,
+          { parallel: true },
+        );
+        expect(result.status, details).toBe(7);
+        expect(
+          steps
+            .filter((step) => step.step === "oxlint")
+            .map((step) => step.shard)
+            .sort(),
+        ).toEqual(["core", "extensions", "scripts"]);
+        expect(trailers, details).toEqual([
+          {
+            text: `[${entry === "run-lint.mts" ? "lint" : "oxlint"}] FAILED (exit 7)`,
+            owned: false,
+            claims: [],
+            live: [],
+          },
+        ]);
+        expect(result.stderr.match(/FAILED \(exit/g)).toHaveLength(1);
+      }),
+  );
+
+  it.for([
+    ...entries.flatMap((entry) =>
+      (["SIGINT", "SIGTERM"] as const).map((forwarded) => ({ entry, phase: "oxlint", forwarded })),
+    ),
+    ...["i18n", "prepare", "stylelint"].flatMap((phase) =>
+      (["SIGINT", "SIGTERM"] as const).map((forwarded) => ({
+        entry: "run-lint.mts" as const,
+        phase,
+        forwarded,
+      })),
+    ),
+  ])(
+    "$entry forwards $forwarded during $phase and reports cancellation",
+    ({ entry, phase, forwarded }, { signal }) =>
+      fixture.run(async () => {
+        const { result, details, trailers } = await runLintFixture(entry, "wait", signal, {
+          phase,
+          forwarded,
+        });
+        const code = forwarded === "SIGINT" ? 130 : 143;
+        expect(result.status, details).toBe(code);
+        expect(result.stderr).toContain(
+          `drained:${phase === "oxlint" ? "extensions" : phase}:${forwarded}`,
+        );
+        const trailer = `[${entry === "run-lint.mts" ? "lint" : "oxlint"}] FAILED (exit ${code})`;
+        expect(trailers, details).toEqual([{ text: trailer, owned: false, claims: [], live: [] }]);
+        expect(result.stderr.trim().split("\n").at(-1)).toBe(trailer);
+      }),
+  );
+
+  it.for(["i18n", "stylelint"])("complete lint reports a $0 failure once", (phase, { signal }) =>
+    fixture.run(async () => {
+      const { result, details, trailers } = await runLintFixture(
+        "run-lint.mts",
+        "nonzero",
+        signal,
+        { phase },
+      );
+      expect(result.status, details).toBe(7);
+      expect(trailers, details).toEqual([
+        { text: "[lint] FAILED (exit 7)", owned: false, claims: [], live: [] },
+      ]);
+      expect(result.stderr.match(/FAILED \(exit/g)).toHaveLength(1);
+    }),
+  );
+
+  it.for(["run-oxlint-shards.mts", "run-lint.mts"] as const)(
+    "%s reports after retaining uncertain artifact ownership",
+    (entry, { signal }) =>
+      fixture.run(async () => {
+        // Inject only an uncertainty receipt; the fixture has no escaped/unowned process.
+        const { result, details, trailers } = await runLintFixture(entry, "unjoined", signal, {
+          phase: "prepare",
+        });
+        expect(result.status, details).toBe(1);
+        expect(result.stderr).toContain("fixture cleanup unverified");
+        expect(result.stderr).toContain("child cleanup unverified; retained");
+        expect(trailers, details).toEqual([
+          {
+            text: `[${entry === "run-lint.mts" ? "lint" : "oxlint"}] FAILED (exit 1)`,
+            owned: true,
+            claims: [],
+            live: [],
+          },
+        ]);
+      }),
+  );
+});

--- a/test/scripts/run-oxlint.test.ts
+++ b/test/scripts/run-oxlint.test.ts
@@ -2,7 +2,7 @@
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import { runWithFailedTrailer } from "../../scripts/lib/failed-trailer.mts";
 import {
@@ -371,22 +371,6 @@ describe("run-oxlint", () => {
     );
     expect(shardedLintRunner).toContain("prepare-extension-package-boundary-artifacts.mts");
     expect(shardedLintRunner).toContain('OPENCLAW_OXLINT_SKIP_PREPARE: "1"');
-  });
-
-  it("prepares the worktree toolchain before the complete lint pre-step", () => {
-    const packageJson = JSON.parse(readFileSync("package.json", "utf8")) as {
-      scripts: Record<string, string>;
-    };
-    const lintRunner = readFileSync("scripts/run-lint.mts", "utf8");
-
-    expect(packageJson.scripts.lint).toBe("node --import ./scripts/tsx.mjs scripts/run-lint.mts");
-    expect(lintRunner.indexOf("ensureRepoToolNodeModulesLink(")).toBeGreaterThan(-1);
-    expect(
-      lintRunner.indexOf('path.resolve("scripts", "control-ui-i18n-verify.ts")'),
-    ).toBeGreaterThan(lintRunner.indexOf("ensureRepoToolNodeModulesLink("));
-    expect(lintRunner.indexOf('path.resolve("scripts", "run-oxlint-shards.mts")')).toBeGreaterThan(
-      lintRunner.indexOf('path.resolve("scripts", "control-ui-i18n-verify.ts")'),
-    );
   });
 
   it("serializes broad oxlint shards on constrained local hosts", () => {
@@ -784,7 +768,7 @@ describe("run-oxlint", () => {
     ["--only=core", "--only=wat"],
   ])("rejects invalid shard CLI input before starting work: %s", (...args) => {
     const tempDir = createTempDir("openclaw-oxlint-selector-");
-    const result = spawnSync(process.execPath, [RUN_OXLINT_SHARDS_URL, ...args], {
+    const result = spawnSync(process.execPath, [fileURLToPath(RUN_OXLINT_SHARDS_URL), ...args], {
       cwd: tempDir,
       encoding: "utf8",
       env: {
@@ -795,6 +779,8 @@ describe("run-oxlint", () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).not.toContain("[oxlint:");
+    expect(result.stderr).toMatch(/--only requires a shard name|Unknown oxlint shard selector/u);
+    expect(result.stderr.trim().split("\n").at(-1)).toBe("[oxlint] FAILED (exit 1)");
   });
 
   it("falls back to the full extension shard when Windows extension dirs are unavailable", () => {

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -366,7 +366,10 @@ describe("scripts/test-projects changed-target routing", () => {
   it.each(["scripts/lib/tsx-cli-shim.mjs", "scripts/tsx.mjs"])(
     "routes shared TypeScript tooling changes through wrapper tests for %s",
     (scriptPath) => {
-      expectChangedTargets([scriptPath], ["test/scripts/direct-run-entrypoints.test.ts"]);
+      expectChangedTargets(
+        [scriptPath],
+        ["test/scripts/direct-run-entrypoints.test.ts", "test/scripts/lint-status.test.ts"],
+      );
     },
   );
 
@@ -572,9 +575,24 @@ describe("scripts/test-projects changed-target routing", () => {
     expectChangedTargets(["scripts/verify.mts"], ["test/scripts/verify.test.ts"]);
   });
 
-  it("keeps sharded oxlint runner edits on oxlint runner tests", () => {
-    expectChangedTargets(["scripts/run-oxlint-shards.mts"], ["test/scripts/run-oxlint.test.ts"]);
-  });
+  it.each([
+    ["scripts/run-oxlint-shards.mts", ["run-oxlint"]],
+    ["scripts/run-oxlint.mts", ["run-oxlint"]],
+    ["scripts/run-oxlint.mjs", ["run-oxlint"]],
+    ["scripts/run-lint.mts", ["run-oxlint"]],
+    ["scripts/run-stylelint.mts", ["changed-lanes"]],
+    ["scripts/lib/failed-trailer.mts", ["run-oxlint", "run-tsgo", "run-vitest", "changed-lanes"]],
+    ["scripts/lib/managed-child-process.mts", ["managed-child-process"]],
+    ["scripts/lib/dist-artifact-ownership.mts", ["dist-artifact-ownership"]],
+  ] as const)(
+    "routes %s through the lint status boundary and existing owners",
+    (source, owners) => {
+      expectChangedTargets(
+        [source],
+        [...owners, "lint-status"].map((owner) => `test/scripts/${owner}.test.ts`),
+      );
+    },
+  );
 
   it("keeps env wrapper edits on env wrapper tests", () => {
     expectChangedTargets(["scripts/run-with-env.mts"], ["test/scripts/run-with-env.test.ts"]);
@@ -1369,6 +1387,7 @@ describe("scripts/test-projects changed-target routing", () => {
         includePatterns: [
           "test/scripts/build-all.test.ts",
           "test/scripts/check-dynamic-import-warts.test.ts",
+          "test/scripts/lint-status.test.ts",
           "test/scripts/run-oxlint.test.ts",
           "test/scripts/tsdown-build.test.ts",
         ],


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where developers running plugin lint could receive a nonzero exit but see only `finished` at the end of the shard output, with no final failure-status line. The artifact-owning plugin lint path bypassed the standalone Oxlint shim that previously supplied that trailer, and the complete lint pipeline only propagated the exit code.

Related: #133772 — this is the separately scoped diagnostic follow-up to missing terminal status in the dependency-refresh lint logs, not a repair or diagnosis of the hosted-runner shutdown. Also preserves the graceful-drain versus forced-kill behavior fixed in #134449.

## Why This Change Was Made

Put final reporting at the completed public operation, using the existing failed-trailer helper after child joins and artifact ownership settle. The shard CLI owns `[oxlint] FAILED (exit N)`; the complete lint pipeline composes its operations and owns one `[lint] FAILED (exit N)`. Internal raw lint children propagate outcomes without nested trailers, and per-shard progress now distinguishes `passed` from `failed (exit N)`.

The pipeline uses the existing asynchronous managed launcher for cancellation. Shard signal listeners are removed when idle so they do not terminate a later pipeline stage. Managed-child cleanup, fail-closed artifact ownership, preparation, resource policy, dependencies and timeout defaults are unchanged. No new configuration options or suppression protocol.

## User Impact

Failed lint commands end with one clear failure line on stderr, including ordinary nonzero exits, active-child SIGINT/SIGTERM cancellation and shard timeout. Successful commands emit no failure trailer, stdout remains usable for machine-readable tool output, and uncertain artifact ownership remains retained rather than falsely released.

This is developer-tooling behavior, not a Gateway or plugin-runtime change. Whole-host loss or SIGKILL of the reporting process cannot guarantee final output. The retained hosted shutdowns do not establish OOM, timeout or provider-routing causes, and this PR makes no such claim.

## Evidence

Before changing production code, the real subprocess boundary regression:

```bash
node scripts/run-vitest.mjs test/scripts/lint-status.test.ts -t nonzero
```

failed for both the owned shard CLI and complete lint: each exited `7`, ended with `[oxlint:extensions] finished`, and emitted no failure trailer. Standalone Oxlint already passed. The identical command passes all three cases after the repair.

Final focused verification:

```bash
node scripts/run-vitest.mjs test/scripts/lint-status.test.ts test/scripts/run-oxlint.test.ts test/scripts/test-projects.test.ts
```

**479 tests passed across three files.** The 32 real subprocess boundary cases use disposable synthetic tools and the real wrappers/artifact owner. They check success, ordinary nonzero, tool self-signaling, forwarded SIGINT/SIGTERM, timeout `124`, preparation failure, parallel core/plugin/scripts completion, and retained cleanup uncertainty. Trailer-time assertions verify no live tool PIDs, cleared child claims, settled ownership, exactly one final trailer, and parseable stdout. Timeout proof synchronizes on child-owned readiness without increasing budgets. Source-to-test routing keeps these regressions selected for future lint-owner changes.

Additional owner verification passed **269 tests**, with one Linux-only zombie-reaping test skipped on macOS, covering native declaration preparation, managed-child joins, artifact retention, loader/wrapper policy and local resource policy.

```bash
node scripts/check-changed.mjs -- docs/reference/test.md scripts/run-lint.mts scripts/run-oxlint-shards.mts scripts/run-stylelint.mts scripts/test-projects.test-support.mts test/scripts/lint-status.test.ts test/scripts/run-oxlint.test.ts test/scripts/test-projects.test.ts
```

All **18 selected checks passed**, including scripts/root-test typechecks, formatting, targeted lint and relevant guards. Real installed standalone/shard CLI invalid-input probes each exited `1` with exactly one final failure line. `git diff --check` passed. Independent Codex autoreview was scoped-clean at its default P0 scope.

Local proof ran on macOS with Node 24.20.0. Historical hosted shutdown reproduction was not attempted; local proof used focused synthetic subprocess cases; signal proof covers active child execution, not pre-loader startup or contended lock acquisition. Exact-head pull-request [CI run 33462896802](https://github.com/openclaw/openclaw/actions/runs/33462896802) passed on `e23ad6ff032219a848f6ab1047819f2c93195578` (attempt 1): 115 jobs succeeded, 17 were skipped by scope, and `openclaw/ci-gate` passed. The repository CI watcher finished `GREEN` with no pending checks. No CI retry or merge-ref recovery was needed.

Size: production lint tooling **+91/-94 (net -3)**; test-selection support **+12/-3**; tests **+444/-22**; docs **+9/-0**. The test-support growth wires the real subprocess regressions into existing owner selection; no product-runtime growth.

ClawSweeper follow-up: its [exact-head review](https://github.com/openclaw/openclaw/pull/134668#issuecomment-5488046753) found no correctness or security defect, but could not retrieve current-main objects. The native maintainer review personally checked its exact main snapshot `3c1b351555e0ebc1b022842523191691e89c7684`: the three lint owners, standalone Oxlint paths, failure helper and artifact owner still match the pre-fix task base and retain the reporting gap. The intervening managed-child change in [cc9a9ebeb3dcc363bea09575b34eb55d58af171e](https://github.com/openclaw/openclaw/commit/cc9a9ebeb3dcc363bea09575b34eb55d58af171e) rechecks Linux group existence after the process snapshot; the other differences are unrelated test-routing additions. Those changes were inspected directly and do not implement or conflict with this reporting repair. This resolves the reviewer's current-main evidence limitation; no code change or re-review request was needed.
