### PR TITLE
test(ui): establish pointer state before clearing submenu highlight

### DIFF
--- a/ui/src/components/menu-surface.browser.test.ts
+++ b/ui/src/components/menu-surface.browser.test.ts
@@ -184,6 +184,9 @@ describe.skipIf(!hasPopoverApi)("submenu parent highlight", () => {
     await userEvent.keyboard("{ArrowDown}");
     await expect.poll(() => document.activeElement).toBe(sibling);
     await expect.poll(() => parent.getAttribute("aria-expanded")).toBe("false");
+    // Hover highlights independently of submenu expansion and keyboard focus.
+    await page.elementLocator(sibling).hover();
+    await expect.poll(() => parent.matches(":hover")).toBe(false);
     await expect.poll(() => getComputedStyle(parent).backgroundColor).toBe("rgba(0, 0, 0, 0)");
   });
 });


### PR DESCRIPTION
The submenu browser test checked for a transparent parent after keyboard focus moved to its sibling, without establishing that the pointer had also left the parent. Hover independently keeps that parent highlighted, so the assertion could reject valid styling.

This test-only change hovers the sibling and verifies the parent is no longer hovered before retaining the original transparent-background assertion. The expanded-parent highlight, pointer entry into the child, ArrowLeft/ArrowDown navigation, focus, and aria-expanded checks stay intact. No production CSS, timeouts, polling limits, isolation, or retries change.

A controlled retained-parent-pointer case reproduces the exact color mismatch in both menu classes (2 failures, 5 passes) and passes all seven cases after the correction. The complete original UI shard passes all 284 files / 4,461 tests with the fix; the full changed-file gate and independent Codex P0–P2 review pass. Production delta is zero; tests +3 lines.

The unchanged original shard also passed on macOS and a clean native Linux proof at frozen main 84e81339c2c3e3dc40b1d72e11fa5388df1f0b5f. Thus the exact historical CI trigger remains unconfirmed; the demonstrated defect is the missing input-state precondition. The Linux lease was stopped after proof. [Original full-run failure](https://github.com/openclaw/openclaw/actions/runs/33460191557/job/99708675542).

This PR requires its own exact-head CI before landing and does not certify the still-draining full release run. No release publication.
