### PR TITLE
test(realtime): await WebSocket receive callbacks directly

### DIFF
--- a/src/realtime-transcription/websocket-session.test.ts
+++ b/src/realtime-transcription/websocket-session.test.ts
@@ -5,6 +5,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import WebSocket, { WebSocketServer } from "ws";
+import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
 import {
   createRealtimeTranscriptionWebSocketSession,
   type RealtimeTranscriptionWebSocketTransport,
@@ -85,17 +86,6 @@ async function createRealtimeServer(params?: {
   return { url: `ws://127.0.0.1:${port}` };
 }
 
-function createSignal() {
-  let resolve: (() => void) | undefined;
-  const promise = new Promise<void>((next) => {
-    resolve = next;
-  });
-  if (!resolve) {
-    throw new Error("Expected frame signal resolver to be initialized");
-  }
-  return { promise, resolve };
-}
-
 function requireFirstMockArg<T>(mock: { mock: { calls: T[][] } }, label: string): T {
   const call = mock.mock.calls[0];
   if (!call) {
@@ -114,7 +104,7 @@ function encodeSequence(value: number): Buffer {
 describe("createRealtimeTranscriptionWebSocketSession", () => {
   it("flushes queued binary audio after an open-ready connection", async () => {
     const frames: Buffer[] = [];
-    const framesReady = createSignal();
+    const framesReady = createDeferred();
     const server = await createRealtimeServer({
       onBinary: (payload) => {
         frames.push(payload);
@@ -144,7 +134,7 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
 
   it("drops the oldest queued audio by bytes and flushes the retained tail in order", async () => {
     const frames: Buffer[] = [];
-    const framesReady = createSignal();
+    const framesReady = createDeferred();
     const server = await createRealtimeServer({
       onBinary: (payload) => {
         frames.push(payload);
@@ -253,7 +243,7 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
   it("flushes a large retained audio tail in order after reconnect", async () => {
     const connections: WebSocket[] = [];
     const frames: Buffer[] = [];
-    const framesReady = createSignal();
+    const framesReady = createDeferred();
     const server = await createRealtimeServer({
       onConnection: (ws) => connections.push(ws),
       onBinary: (payload) => {
@@ -305,7 +295,7 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
 
   it("discards a large queued audio tail when closed before connecting", async () => {
     const frames: Buffer[] = [];
-    const framesReady = createSignal();
+    const framesReady = createDeferred();
     const server = await createRealtimeServer({
       onBinary: (payload) => {
         frames.push(payload);
@@ -667,7 +657,7 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
 
   it("lets providers mark ready after a JSON handshake", async () => {
     const frames: unknown[] = [];
-    const framesReady = createSignal();
+    const framesReady = createDeferred();
     const server = await createRealtimeServer({
       initialEvent: { type: "session.created" },
       onText: (payload) => {
@@ -864,7 +854,8 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
 
   it("reports malformed websocket JSON with an owned parser error", async () => {
     const server = await createRealtimeServer({ initialText: "{not json" });
-    const onError = vi.fn();
+    const received = createDeferred();
+    const onError = vi.fn((_error: Error) => received.resolve());
     const session = createRealtimeTranscriptionWebSocketSession({
       providerId: "test",
       callbacks: { onError },
@@ -878,19 +869,23 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
       },
     });
 
-    await session.connect();
-    await vi.waitFor(() => {
+    try {
+      await session.connect();
+      await withTestTimeout(received.promise, 1_000, "Malformed JSON error not received");
       expect(onError).toHaveBeenCalledTimes(1);
-    });
-    const parseError = requireFirstMockArg(onError, "malformed websocket json error");
-    expect(parseError).toBeInstanceOf(Error);
-    expect(parseError.message).toBe("Realtime transcription websocket received malformed JSON.");
-    session.close();
+      const parseError = requireFirstMockArg(onError, "malformed websocket json error");
+      expect(parseError).toBeInstanceOf(Error);
+      expect(parseError.message).toBe("Realtime transcription websocket received malformed JSON.");
+    } finally {
+      session.close();
+    }
   });
 
   it("keeps error callback failures inside websocket message dispatch", async () => {
     const server = await createRealtimeServer({ initialText: "{not json" });
+    const received = createDeferred();
     const onError = vi.fn((_error: Error) => {
+      received.resolve();
       throw new Error("error observer failed");
     });
     const session = createRealtimeTranscriptionWebSocketSession({
@@ -906,15 +901,17 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
       },
     });
 
-    await session.connect();
-    await vi.waitFor(() => {
+    try {
+      await session.connect();
+      await withTestTimeout(received.promise, 1_000, "Throwing error observer not reached");
       expect(onError).toHaveBeenCalledTimes(1);
-    });
-    const parseError = requireFirstMockArg(onError, "malformed websocket json error");
-    expect(parseError).toBeInstanceOf(Error);
-    expect(parseError.message).toBe("Realtime transcription websocket received malformed JSON.");
-    expect(session.isConnected()).toBe(true);
-    session.close();
+      const parseError = requireFirstMockArg(onError, "malformed websocket json error");
+      expect(parseError).toBeInstanceOf(Error);
+      expect(parseError.message).toBe("Realtime transcription websocket received malformed JSON.");
+      expect(session.isConnected()).toBe(true);
+    } finally {
+      session.close();
+    }
   });
 
   it("reports pre-ready closes separately from connection timeouts", async () => {
@@ -1035,7 +1032,8 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
     const server = await createRealtimeServer({
       initialEvent: { type: "transcript", text: largeText },
     });
-    const onMessage = vi.fn();
+    const received = createDeferred();
+    const onMessage = vi.fn(() => received.resolve());
     const session = createRealtimeTranscriptionWebSocketSession<{ type?: string; text?: string }>({
       providerId: "test",
       callbacks: {},
@@ -1047,13 +1045,15 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
       },
     });
 
-    await session.connect();
-    await vi.waitFor(() => {
+    try {
+      await session.connect();
+      await withTestTimeout(received.promise, 1_000, "Large inbound message not received");
       expect(onMessage).toHaveBeenCalledTimes(1);
-    });
-    const event = requireFirstMockArg(onMessage, "large inbound message");
-    expect(event).toEqual({ type: "transcript", text: largeText });
-    session.close();
+      const event = requireFirstMockArg(onMessage, "large inbound message");
+      expect(event).toEqual({ type: "transcript", text: largeText });
+    } finally {
+      session.close();
+    }
   });
 
   it("drops an oversized inbound message before it reaches the provider parser", async () => {
@@ -1061,7 +1061,8 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
     // oversized upstream message never reaches onMessage/JSON parse.
     const oversized = "x".repeat(16 * 1024 * 1024 + 1);
     const server = await createRealtimeServer({ initialText: oversized });
-    const onError = vi.fn();
+    const received = createDeferred();
+    const onError = vi.fn((_error: Error) => received.resolve());
     const onMessage = vi.fn(() => {
       throw new Error("oversized frame should not reach provider handler");
     });
@@ -1076,15 +1077,17 @@ describe("createRealtimeTranscriptionWebSocketSession", () => {
       },
     });
 
-    await session.connect();
-    await vi.waitFor(() => {
+    try {
+      await session.connect();
+      await withTestTimeout(received.promise, 1_000, "Oversized message error not received");
       expect(onError).toHaveBeenCalledTimes(1);
-    });
-    expect(onMessage).not.toHaveBeenCalled();
-    const overflowError = requireFirstMockArg(onError, "oversized inbound message error");
-    expect(overflowError).toBeInstanceOf(Error);
-    expect(overflowError).toHaveProperty("code", "WS_ERR_UNSUPPORTED_MESSAGE_LENGTH");
-    expect(overflowError.message).toMatch(/max payload/i);
-    session.close();
+      expect(onMessage).not.toHaveBeenCalled();
+      const overflowError = requireFirstMockArg(onError, "oversized inbound message error");
+      expect(overflowError).toBeInstanceOf(Error);
+      expect(overflowError).toHaveProperty("code", "WS_ERR_UNSUPPORTED_MESSAGE_LENGTH");
+      expect(overflowError.message).toMatch(/max payload/i);
+    } finally {
+      session.close();
+    }
   });
 });


### PR DESCRIPTION
Four realtime WebSocket cases waited for a mock count to change on Vitest's polling interval. Resolve the shared deferred from the actual receive/error callback, then run the same count and payload assertions. Keep the existing one-second failure bound through withTestTimeout, which clears its guard after settlement. Five existing signal sites also use the shared deferred, deleting the copied helper.

All 29 expanded cases and 99 expect expressions remain, including real malformed JSON, the throwing observer, the valid 2-MiB message and the oversized 16-MiB-plus-one frame rejected by ws before provider parsing. Reconnect, handshake, backpressure and clock controls retain their behavior. The four changed cases close their session in finally before server teardown. Production +0/-0; tests +52/-49 (net +3).

Validation: all 29 cases pass before, after and after exact fault restoration using the canonical serial, non-isolated route. A scratch fault suppressing only the receive signal fails the existing one-second deadline; diagnostics confirm the error callback still runs, client session closure occurs and real server cleanup joins. Full changed checks and Codex autoreview pass. The first lint run caught the file line limit; shortening only the four timeout diagnostics resolved it, followed by the missing-signal fault, all 29 cases and the full gate again. Removing polling does not establish a fixed 200-ms or whole-run speedup.

Commands:
```sh
node scripts/run-vitest.mjs src/realtime-transcription/websocket-session.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base 765c0cddfd919ecf8ba809eab9af09e9b1aabbfd
```

The existing reconnect and negative lifecycle waits keep their timing semantics; this change concerns positive receive observation and duplicate signal construction.
