### PR TITLE
perf(gateway): reduce repeated turn preparation work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Docs: https://docs.openclaw.ai
 - **Agent prompts:** keep model-identity guidance conditional so ordinary requests are not mistaken for questions about the current model.
 
 - **Update/Doctor:** preserve `update --no-restart` by requiring an offline managed Gateway during updater-owned repair and leaving restart ownership with the parent.
+- **Gateway turn preparation:** avoid repeated plugin-config normalization and unrelated session copies during chat admission and transcript persistence, preserving session identity checks and durable input handling.
 - **Bun Gateway:** restore Gateway health checks and agent connections under Bun 1.4 while preserving WebSocket frame limits and authenticated request scheduling.
 - **Doctor recovery notes:** show interrupted auth-profile archive recovery failures and completions even when no further migration runs or another migration is declined. (#134009) Thanks @angeliti999.
 - Matrix lifecycle: drain in-flight monitor tasks without deadlocking shared-client retirement, and reject late acquisitions after their owning task closes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,6 @@ Docs: https://docs.openclaw.ai
 - **Agent prompts:** keep model-identity guidance conditional so ordinary requests are not mistaken for questions about the current model.
 
 - **Update/Doctor:** preserve `update --no-restart` by requiring an offline managed Gateway during updater-owned repair and leaving restart ownership with the parent.
-- **Gateway turn preparation:** avoid repeated plugin-config normalization and unrelated session copies during chat admission and transcript persistence, preserving session identity checks and durable input handling.
 - **Bun Gateway:** restore Gateway health checks and agent connections under Bun 1.4 while preserving WebSocket frame limits and authenticated request scheduling.
 - **Doctor recovery notes:** show interrupted auth-profile archive recovery failures and completions even when no further migration runs or another migration is declined. (#134009) Thanks @angeliti999.
 - Matrix lifecycle: drain in-flight monitor tasks without deadlocking shared-client retirement, and reject late acquisitions after their owning task closes.

--- a/src/agents/command/prepare.ts
+++ b/src/agents/command/prepare.ts
@@ -12,7 +12,6 @@ import type { InternalSessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { resolveAgentExplicitRecipientSession } from "../../infra/outbound/agent-delivery.js";
 import { buildOutboundSessionContext } from "../../infra/outbound/session-context.js";
-import { normalizePluginsConfig } from "../../plugins/config-state.js";
 import { resolvePluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
 import {
   classifySessionKeyShape,
@@ -271,7 +270,7 @@ export async function prepareAgentCommandExecution(
   const cwd =
     normalizeOptionalString(opts.cwd) ?? normalizeOptionalString(sessionEntryRaw?.spawnedCwd);
   const agentDir = resolveAgentDir(cfg, sessionAgentId);
-  const pluginsEnabled = normalizePluginsConfig(cfg.plugins).enabled;
+  const pluginsEnabled = cfg.plugins?.enabled !== false;
   const preparedMetadataSnapshot = runtimeContext?.pluginGeneration.pluginMetadataSnapshot;
   const manifestMetadataSnapshot = pluginsEnabled
     ? (preparedMetadataSnapshot ??

--- a/src/agents/configured-provider-model.ts
+++ b/src/agents/configured-provider-model.ts
@@ -2,7 +2,6 @@
 import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
 import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { normalizePluginsConfig } from "../plugins/config-state.js";
 
 type ConfiguredProviderModelParams = {
   cfg?: OpenClawConfig;
@@ -37,7 +36,7 @@ export function allowsPluginModelNormalization(params: ConfiguredProviderModelPa
   if (!provider) {
     return true;
   }
-  if (!normalizePluginsConfig(params.cfg?.plugins).enabled) {
+  if (params.cfg?.plugins?.enabled === false) {
     return false;
   }
   const model = params.model.trim();

--- a/src/agents/model-fallback-candidates.ts
+++ b/src/agents/model-fallback-candidates.ts
@@ -8,7 +8,6 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
-import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import { resolvePluginControlPlaneFingerprint } from "../plugins/plugin-control-plane-context.js";
 import { isPluginProvidersLoadInFlight } from "../plugins/providers.runtime.js";
@@ -294,9 +293,7 @@ function resolveFallbackCandidatesUncached(
       }),
       manifestPlugins: params.manifestPlugins,
     });
-  const allowPluginModelAliases = params.cfg
-    ? normalizePluginsConfig(params.cfg.plugins).enabled
-    : true;
+  const allowPluginModelAliases = params.cfg?.plugins?.enabled !== false;
   const normalizedPrimary = normalizeCandidateRef(providerRaw, modelRaw);
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg ?? {},

--- a/src/agents/runtime-plan/auth.ts
+++ b/src/agents/runtime-plan/auth.ts
@@ -4,7 +4,6 @@
  * safely forwarded.
  */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import { normalizePluginsConfig } from "../../plugins/config-state.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
 import { normalizeOptionalAgentRuntimeId } from "../agent-runtime-id.js";
 import {
@@ -50,8 +49,7 @@ export function buildAgentRuntimeAuthPlan(params: {
   allowHarnessAuthProfileForwarding?: boolean;
 }): AgentRuntimeAuthPlan {
   const providerAuthAliasesEnabled =
-    params.providerAuthAliasesEnabled ??
-    (params.config ? normalizePluginsConfig(params.config.plugins).enabled : true);
+    params.providerAuthAliasesEnabled ?? params.config?.plugins?.enabled !== false;
   const metadataSnapshot =
     params.metadataSnapshot ??
     (providerAuthAliasesEnabled ? undefined : EMPTY_PROVIDER_AUTH_ALIAS_METADATA);

--- a/src/agents/runtime-plugins.ts
+++ b/src/agents/runtime-plugins.ts
@@ -6,7 +6,6 @@ import {
   listRuntimePluginIdsFromRegistry,
   registryContainsRuntimePluginIds,
 } from "../plugins/active-runtime-registry.js";
-import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "../plugins/installed-plugin-index-install-records.js";
 import { loadPluginRegistryHandle } from "../plugins/loader.js";
 import { adoptRuntimeMemoryRegistrations } from "../plugins/memory-state.js";
@@ -49,7 +48,7 @@ function resolveAgentRuntimePluginRegistryLoad(params: AgentRuntimePluginRegistr
     typeof params.workspaceDir === "string" && params.workspaceDir.trim()
       ? resolveUserPath(params.workspaceDir)
       : undefined;
-  if (params.config && !normalizePluginsConfig(params.config.plugins).enabled) {
+  if (params.config?.plugins?.enabled === false) {
     return {
       loadOptions: {
         config: params.config,
@@ -151,13 +150,14 @@ export async function withAgentPluginRegistry<T>(params: {
   if (getPluginRuntimeGatewayRequestScope()?.pluginRegistry) {
     return await params.run();
   }
-  const metadataSnapshot = normalizePluginsConfig(params.config.plugins).enabled
-    ? loadPluginMetadataSnapshot({
-        config: params.config,
-        env: process.env,
-        workspaceDir: params.workspaceDir,
-      })
-    : undefined;
+  const metadataSnapshot =
+    params.config.plugins?.enabled !== false
+      ? loadPluginMetadataSnapshot({
+          config: params.config,
+          env: process.env,
+          workspaceDir: params.workspaceDir,
+        })
+      : undefined;
   const pluginRegistry = loadAgentRuntimePluginRegistryHandle({
     basePluginIds: [],
     config: params.config,

--- a/src/agents/tool-policy-declared-context.ts
+++ b/src/agents/tool-policy-declared-context.ts
@@ -57,17 +57,6 @@ function denylistBlocksPlugin(params: { pluginId: string; denylist: ToolDenylist
   );
 }
 
-function denylistBlocksPluginTool(params: {
-  pluginId: string;
-  toolName: string;
-  denylist: ToolDenylist;
-}): boolean {
-  return (
-    denylistBlocksPlugin({ pluginId: params.pluginId, denylist: params.denylist }) ||
-    denylistBlocksName(params.toolName, params.denylist)
-  );
-}
-
 function collectConfiguredMcpServerNames(params: {
   config?: OpenClawConfig;
   toolDenylist?: string[];
@@ -101,14 +90,7 @@ function collectAvailableManifestToolNames(params: {
   denylist: ToolDenylist;
 }): string[] {
   return (params.plugin.contracts?.tools ?? [])
-    .filter(
-      (toolName) =>
-        !denylistBlocksPluginTool({
-          pluginId: params.plugin.id,
-          toolName,
-          denylist: params.denylist,
-        }),
-    )
+    .filter((toolName) => !denylistBlocksName(toolName, params.denylist))
     .filter((toolName) =>
       hasManifestToolAvailability({
         plugin: params.plugin,
@@ -163,9 +145,8 @@ function collectDeclaredPluginContext(params: {
         snapshot,
         plugin,
         config: params.config,
+        normalizedConfig: normalizedPlugins,
       }) ||
-      normalizedPlugins.entries[plugin.id]?.enabled === false ||
-      normalizedPlugins.deny.includes(plugin.id) ||
       denylistBlocksPlugin({ pluginId: plugin.id, denylist })
     ) {
       continue;

--- a/src/agents/tool-policy-pipeline.test.ts
+++ b/src/agents/tool-policy-pipeline.test.ts
@@ -2,6 +2,11 @@
 // warning dedupe, and plugin-aware policy application.
 import { beforeEach, describe, expect, test, vi } from "vitest";
 import { markFrozenClawToolAllowPolicy } from "../claws/tool-policy-runtime.js";
+import {
+  createPluginMetadataSnapshot,
+  makeRegistry,
+} from "../config/plugin-auto-enable.test-helpers.js";
+import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata.test-support.js";
 import { buildDeclaredToolAllowlistContext } from "./tool-policy-declared-context.js";
 import {
   applyToolPolicyPipeline,
@@ -301,23 +306,44 @@ describe("tool-policy-pipeline", () => {
     ]);
   });
 
-  test("declared context excludes disabled plugin tools", () => {
-    const declared = buildDeclaredToolAllowlistContext({
-      config: { plugins: { entries: { browser: { enabled: false } } } },
-      workspaceDir: process.cwd(),
-    });
-
-    expect(Array.from(declared?.pluginToolNames ?? [])).not.toContain("browser");
-  });
-
-  test("declared context excludes denied plugin tools", () => {
-    const declared = buildDeclaredToolAllowlistContext({
-      config: { plugins: { entries: { browser: { enabled: true } } } },
-      workspaceDir: process.cwd(),
-      toolDenylist: ["browser"],
-    });
-
-    expect(Array.from(declared?.pluginToolNames ?? [])).not.toContain("browser");
+  test.each([
+    {
+      name: "disabled owner",
+      plugins: { entries: { "blocked-owner": { enabled: false } } },
+      toolDenylist: undefined,
+    },
+    { name: "denied owner", plugins: { deny: ["blocked-owner"] }, toolDenylist: undefined },
+    { name: "tool-denied owner", plugins: {}, toolDenylist: ["blocked-owner"] },
+    { name: "denied tool", plugins: {}, toolDenylist: ["blocked_tool"] },
+  ])("declared context excludes a $name and keeps eligible tools", ({ plugins, toolDenylist }) => {
+    const config = { plugins };
+    const workspaceDir = process.cwd();
+    const manifestRegistry = makeRegistry([
+      {
+        id: "Allowed-Owner",
+        origin: "bundled",
+        channels: [],
+        contracts: { tools: ["allowed_tool"] },
+      },
+      {
+        id: "Blocked-Owner",
+        origin: "bundled",
+        channels: [],
+        contracts: { tools: ["blocked_tool"] },
+      },
+    ]);
+    setCurrentPluginMetadataSnapshot(
+      createPluginMetadataSnapshot({ config, manifestRegistry, workspaceDir }),
+      { config, workspaceDir },
+    );
+    try {
+      expect(buildDeclaredToolAllowlistContext({ config, workspaceDir, toolDenylist })).toEqual({
+        pluginIds: ["Allowed-Owner"],
+        pluginToolNames: ["allowed_tool"],
+      });
+    } finally {
+      setCurrentPluginMetadataSnapshot(undefined);
+    }
   });
 
   test("declared context excludes disabled MCP servers", () => {

--- a/src/agents/tools/manifest-capability-availability.ts
+++ b/src/agents/tools/manifest-capability-availability.ts
@@ -4,6 +4,7 @@
  * Combines plugin contracts, availability, config signals, auth profiles, env candidates, and base URL guards.
  */
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { normalizePluginsConfig } from "../../plugins/config-state.js";
 import { getCurrentPluginMetadataSnapshot } from "../../plugins/current-plugin-metadata-snapshot.js";
 import { isManifestPluginAvailableForControlPlane } from "../../plugins/manifest-contract-eligibility.js";
 import type { PluginManifestRecord } from "../../plugins/manifest-registry.js";
@@ -70,18 +71,6 @@ function listCapabilityAuthSignals(params: {
   );
 }
 
-function isPluginAvailableForCapability(params: {
-  snapshot: CapabilityMetadataSnapshot;
-  plugin: PluginManifestRecord;
-  config?: OpenClawConfig;
-}): boolean {
-  return isManifestPluginAvailableForControlPlane({
-    snapshot: params.snapshot,
-    plugin: params.plugin,
-    config: params.config,
-  });
-}
-
 function hasAvailableCapabilityPlugin(
   params: {
     snapshot: CapabilityMetadataSnapshot;
@@ -92,21 +81,16 @@ function hasAvailableCapabilityPlugin(
   if (params.config?.plugins?.enabled === false) {
     return false;
   }
-  for (const plugin of params.snapshot.plugins) {
-    if (
-      !isPluginAvailableForCapability({
+  const normalizedConfig = normalizePluginsConfig(params.config?.plugins);
+  return params.snapshot.plugins.some(
+    (plugin) =>
+      isManifestPluginAvailableForControlPlane({
         snapshot: params.snapshot,
         plugin,
         config: params.config,
-      })
-    ) {
-      continue;
-    }
-    if (accepts(plugin)) {
-      return true;
-    }
-  }
-  return false;
+        normalizedConfig,
+      }) && accepts(plugin),
+  );
 }
 
 function hasConfiguredCapabilityProviderSignal(params: {

--- a/src/config/sessions/session-accessor.sqlite-entry-store.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry-store.ts
@@ -38,11 +38,7 @@ import {
 import { projectSqliteSessionParticipants } from "./session-accessor.sqlite-participant-projection.js";
 import { resolveSessionEntryProvenanceRow } from "./session-accessor.sqlite-provenance.js";
 import { collectSessionStateIdsForEntry } from "./session-accessor.sqlite-references.js";
-import {
-  cloneSessionEntry,
-  getSessionKysely,
-  normalizeSqliteSessionKey,
-} from "./session-accessor.sqlite-scope.js";
+import { getSessionKysely, normalizeSqliteSessionKey } from "./session-accessor.sqlite-scope.js";
 import {
   bindSessionNode,
   bindSessionRoot,
@@ -116,6 +112,7 @@ export function parseReadableSqliteSessionEntryRow(
   );
 }
 
+/** Exact reads already own nested values; retain them through identity publication. */
 export function readSessionIdentitySnapshot(
   database: OpenClawAgentDatabase,
   sessionKeys: Iterable<string>,
@@ -124,16 +121,10 @@ export function readSessionIdentitySnapshot(
   for (const sessionKey of uniqueStrings([...sessionKeys].map((key) => key.trim()))) {
     const row = readExactSessionEntryRow(database, sessionKey);
     if (row) {
-      snapshot.set(sessionKey, cloneSessionEntry(row.entry));
+      snapshot.set(sessionKey, row.entry);
     }
   }
   return snapshot;
-}
-
-export function createSessionIdentitySnapshot(
-  rows: readonly { entry: SessionEntry; sessionKey: string }[],
-): Map<string, SessionEntry> {
-  return new Map(rows.map((row) => [row.sessionKey, cloneSessionEntry(row.entry)]));
 }
 
 export function readSessionEntryRow(

--- a/src/config/sessions/session-accessor.sqlite-entry.ts
+++ b/src/config/sessions/session-accessor.sqlite-entry.ts
@@ -37,7 +37,6 @@ import {
 } from "./session-accessor.sqlite-entry-equality.js";
 import {
   collectSessionEntryLookupKeys,
-  createSessionIdentitySnapshot,
   parseReadableSqliteSessionEntryRow,
   readExactSessionEntryRowValidated,
   readSessionEntryRow,
@@ -545,7 +544,8 @@ async function patchSqliteSessionEntrySnapshot(
         result = cloneSessionEntry(writeBase);
         return;
       }
-      previousIdentity = createSessionIdentitySnapshot(fresh);
+      // Commit reads own these entries; update callbacks only receive detached copies.
+      previousIdentity = new Map(fresh.map((row) => [row.sessionKey, row.entry]));
       const selectedPreviousEntry = fresh[0]?.entry ?? writeBase;
       const persisted = writeSessionEntry(writeDatabase, sessionKey, next, {
         previousEntry: selectedPreviousEntry,

--- a/src/config/sessions/session-accessor.sqlite-session-row.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-session-row.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
-import { afterEach, describe, expect, it } from "vitest";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { createCanonicalFixtureSkill } from "../../skills/test-support/test-helpers.js";
 import {
@@ -37,7 +38,15 @@ describe("SQLite session row persistence", () => {
         OPENCLAW_STATE_DIR: fs.realpathSync(tempDirs.make("session-commit-fact-")),
       };
       const scope = { agentId: "main", env, sessionKey: "agent:main:commit-fact" };
-      await upsertSessionEntryCore(scope, { sessionId: "predecessor", updatedAt: 10 });
+      const skillsSnapshot = {
+        prompt: "Prepared session skills.",
+        skills: [{ name: "existing", requiredEnv: ["EXISTING_ENV"] }],
+      };
+      await upsertSessionEntryCore(scope, {
+        sessionId: "predecessor",
+        updatedAt: 10,
+        skillsSnapshot,
+      });
       const controller = new AbortController();
       const cancelled = new Error("cancelled after identity publication");
       const revoked = new Error("writer revoked before commit");
@@ -53,6 +62,7 @@ describe("SQLite session row persistence", () => {
         });
         controller.abort(cancelled);
       });
+      const clone = vi.spyOn(globalThis, "structuredClone");
       try {
         const options = {
           onCommitted: (entry: InternalSessionEntry) => {
@@ -78,12 +88,26 @@ describe("SQLite session row persistence", () => {
           expect(facts).toHaveLength(1);
           expect(observed).toEqual([{ acceptedId: "successor", persistedId: "successor" }]);
           expect(controller.signal.reason).toBe(cancelled);
+          // Only caller inputs and retained outputs need copies; decoded identity rows are owned.
+          expect(
+            clone.mock.calls.filter(
+              ([entry]) =>
+                isRecord(entry) &&
+                (entry.sessionId === "predecessor" || entry.sessionId === "successor"),
+            ).length,
+          ).toBeLessThanOrEqual(4);
+          const retainedSkills = facts[0]?.skillsSnapshot?.skills;
+          expect(retainedSkills).toEqual(skillsSnapshot.skills);
+          retainedSkills?.push({ name: "observer-only" });
+          expect((await pending)?.skillsSnapshot).toEqual(skillsSnapshot);
+          expect(loadSessionEntry(scope)?.skillsSnapshot).toEqual(skillsSnapshot);
         } else {
           expect(facts).toEqual([]);
           expect(observed).toEqual([]);
           expect(loadSessionEntry(scope)?.sessionId).toBe("predecessor");
         }
       } finally {
+        clone.mockRestore();
         unsubscribe();
       }
     },
@@ -121,7 +145,19 @@ describe("SQLite session row persistence", () => {
           await patchSessionEntryCore(scope, () => replacement, { replaceEntry: true }),
         ).toMatchObject(stamp);
       } else {
-        replaceSessionEntrySync(scope, replacement);
+        const clone = vi.spyOn(globalThis, "structuredClone");
+        try {
+          replaceSessionEntrySync(scope, replacement);
+          expect(
+            clone.mock.calls.filter(
+              ([entry]) =>
+                isRecord(entry) &&
+                (entry.sessionId === "original" || entry.sessionId === "replacement"),
+            ),
+          ).toHaveLength(0);
+        } finally {
+          clone.mockRestore();
+        }
       }
       expect(loadSessionEntry(scope)).toMatchObject({ sessionId: "replacement", ...stamp });
       const row = openOpenClawAgentDatabase({ agentId: "main", env })

--- a/src/gateway/server-methods/chat-send-pending-inputs.test.ts
+++ b/src/gateway/server-methods/chat-send-pending-inputs.test.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
@@ -14,11 +15,13 @@ import {
   loadSessionEntry,
   loadTranscriptEventsSync,
   patchSessionEntryCore,
+  replaceSessionEntrySync,
 } from "../../config/sessions/session-accessor.js";
 import {
   resolveSqliteScope,
   toDatabaseOptions,
 } from "../../config/sessions/session-accessor.sqlite-scope.js";
+import { rotateAgentEventLifecycleGeneration } from "../../infra/agent-events.js";
 import { initializeGlobalHookRunner } from "../../plugins/hook-runner-global.js";
 import type { PluginHookBeforeMessageWriteEvent } from "../../plugins/types.js";
 import { getSessionWorkAdmissionRelease } from "../../sessions/session-lifecycle-admission.js";
@@ -59,6 +62,11 @@ describe("ordinary browser input admission", () => {
           sessionId: scope.sessionId,
           updatedAt: Date.now(),
           status: active ? "running" : "done",
+        },
+        unrelated: {
+          sessionId: "unrelated-browser-session",
+          updatedAt: Date.now(),
+          skillsSnapshot: { prompt: "Unrelated session context. ".repeat(128), skills: [] },
         },
       },
     });
@@ -161,6 +169,7 @@ describe("ordinary browser input admission", () => {
 
   it("durably stages the approved cloud follow-up before ACK without changing the active transcript", async () => {
     const fixture = await createBrowserFollowupFixture();
+    const clone = vi.spyOn(globalThis, "structuredClone");
     const { scope, params, approvedContent, activeTranscript } = fixture;
     let transcriptAtAck: ReturnType<typeof loadTranscriptEventsSync> | undefined;
     let pendingAtAck: ReturnType<typeof listSessionPendingInputs> | undefined;
@@ -198,13 +207,21 @@ describe("ordinary browser input admission", () => {
           },
         ],
       });
+      // Initial resolution detaches the store; custody needs only the current target binding.
+      expect(
+        clone.mock.calls.filter(
+          ([entry]) => isRecord(entry) && entry.sessionId === "unrelated-browser-session",
+        ).length,
+      ).toBeLessThanOrEqual(1);
     } finally {
+      clone.mockRestore();
       await fixture.cleanup();
     }
   });
 
   it("commits an existing idle session input before ACK through restart-safe admission", async () => {
     const fixture = await createBrowserFollowupFixture({ active: false });
+    const clone = vi.spyOn(globalThis, "structuredClone");
     let transcriptAtAck: ReturnType<typeof loadTranscriptEventsSync> | undefined;
     const respond = vi.fn<RespondFn>((ok) => {
       if (ok) {
@@ -228,7 +245,13 @@ describe("ordinary browser input admission", () => {
         },
       });
       expect(listSessionPendingInputs(fixture.scope)).toEqual({ items: [], total: 0 });
+      expect(
+        clone.mock.calls.filter(
+          ([entry]) => isRecord(entry) && entry.sessionId === "unrelated-browser-session",
+        ).length,
+      ).toBeLessThanOrEqual(1);
     } finally {
+      clone.mockRestore();
       await fixture.cleanup();
     }
   });
@@ -278,34 +301,54 @@ describe("ordinary browser input admission", () => {
     }
   });
 
-  it("revalidates cancellation after message approval before committing custody", async () => {
-    const fixture = await createBrowserFollowupFixture();
-    fixture.beforeApprove.mockImplementation(() => {
-      const active = fixture.context.chatAbortControllers.get(fixture.params.idempotencyKey);
-      if (!active) {
-        throw new Error("Expected the browser admission to own its cancellation controller");
+  it.each(["cancellation", "lifecycle rotation", "session replacement"] as const)(
+    "revalidates %s after message approval before committing custody",
+    async (change) => {
+      const fixture = await createBrowserFollowupFixture();
+      fixture.beforeApprove.mockImplementation(() => {
+        if (change === "lifecycle rotation") {
+          rotateAgentEventLifecycleGeneration();
+          return;
+        }
+        if (change === "session replacement") {
+          replaceSessionEntrySync(fixture.scope, {
+            sessionId: "successor-session",
+            updatedAt: Date.now(),
+          });
+          return;
+        }
+        const active = fixture.context.chatAbortControllers.get(fixture.params.idempotencyKey);
+        if (!active) {
+          throw new Error("Expected the browser admission to own its cancellation controller");
+        }
+        active.abortStopReason = "rpc";
+        active.controller.abort();
+      });
+      try {
+        const respond = await fixture.send();
+        expect(fixture.beforeApprove).toHaveBeenCalledOnce();
+        expect(respond).toHaveBeenCalledOnce();
+        expect(respond).not.toHaveBeenCalledWith(
+          true,
+          expect.objectContaining({ status: "started" }),
+          undefined,
+          expect.anything(),
+        );
+        expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+        expect(listSessionPendingInputs(fixture.scope)).toEqual({ items: [], total: 0 });
+        expect(loadTranscriptEventsSync(fixture.scope)).toEqual(fixture.activeTranscript);
+        if (change === "session replacement") {
+          expect(loadSessionEntry(fixture.scope)?.sessionId).toBe("successor-session");
+          expect(
+            loadTranscriptEventsSync({ ...fixture.scope, sessionId: "successor-session" }),
+          ).toEqual([]);
+        }
+        expect(fixture.context.chatAbortControllers.has(fixture.params.idempotencyKey)).toBe(false);
+      } finally {
+        await fixture.cleanup();
       }
-      active.abortStopReason = "rpc";
-      active.controller.abort();
-    });
-    try {
-      const respond = await fixture.send();
-      expect(fixture.beforeApprove).toHaveBeenCalledOnce();
-      expect(respond).toHaveBeenCalledOnce();
-      expect(respond).not.toHaveBeenCalledWith(
-        true,
-        expect.objectContaining({ status: "started" }),
-        undefined,
-        expect.anything(),
-      );
-      expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
-      expect(listSessionPendingInputs(fixture.scope)).toEqual({ items: [], total: 0 });
-      expect(loadTranscriptEventsSync(fixture.scope)).toEqual(fixture.activeTranscript);
-      expect(fixture.context.chatAbortControllers.has(fixture.params.idempotencyKey)).toBe(false);
-    } finally {
-      await fixture.cleanup();
-    }
-  });
+    },
+  );
 
   it("keeps one approved source when an accepted browser request is retried", async () => {
     const fixture = await createBrowserFollowupFixture();

--- a/src/gateway/server-methods/chat-user-turn-recorder.ts
+++ b/src/gateway/server-methods/chat-user-turn-recorder.ts
@@ -97,21 +97,21 @@ export function createGatewayChatUserTurnController(params: {
     input: baseInput,
     resolveInput: () => inputPromise,
     target: () => {
-      const { storePath, store, entry } = loadSessionEntry(
-        session.sessionKey,
-        session.sessionLoadOptions,
-      );
-      const targetEntry = entry ?? admission.initialSessionEntry;
-      if (!targetEntry?.sessionId || targetEntry.sessionId !== admission.sessionBinding.sessionId) {
+      // Retain only the current binding; transcript writers recheck it at commit.
+      const { storePath, entry } = loadSessionEntry(session.sessionKey, {
+        ...session.sessionLoadOptions,
+        clone: false,
+      });
+      const sessionId = (entry ?? admission.initialSessionEntry)?.sessionId;
+      if (!sessionId || sessionId !== admission.sessionBinding.sessionId) {
         return undefined;
       }
       return {
-        sessionId: targetEntry.sessionId,
-        expectedSessionId: targetEntry.sessionId,
+        sessionId,
+        expectedSessionId: sessionId,
         initialSessionEntry: admission.initialSessionEntry,
         sessionKey: session.sessionKey,
-        sessionEntry: targetEntry,
-        sessionStore: store,
+        sessionEntry: undefined,
         storePath,
         agentId: session.agentId,
         config: session.cfg,

--- a/src/plugins/manifest-contract-eligibility.test.ts
+++ b/src/plugins/manifest-contract-eligibility.test.ts
@@ -1,5 +1,6 @@
 // Covers manifest contract eligibility decisions.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { normalizePluginsConfig } from "./config-state.js";
 
 const mocks = vi.hoisted(() => ({
   loadPluginMetadataSnapshot: vi.fn(),
@@ -213,13 +214,24 @@ describe("bundled manifest contract availability", () => {
   });
 
   it("preserves globally disabled bundled metadata for the named speech compatibility path", () => {
+    const config = { plugins: { enabled: false } };
+    const normalizedConfig = normalizePluginsConfig(config.plugins);
     expect(
       isManifestPluginAvailableForControlPlane({
         snapshot,
         plugin,
-        config: { plugins: { enabled: false } },
+        config,
+        normalizedConfig,
       }),
     ).toBe(true);
+    expect(
+      listAvailableManifestContractValues({
+        snapshot,
+        config,
+        contract: "imageGenerationProviders",
+      }),
+    ).toEqual(["google"]);
+    expect(normalizedConfig.enabled).toBe(false);
   });
 
   it("preserves the shipped provider-contract compatibility mode", () => {

--- a/src/plugins/manifest-contract-eligibility.ts
+++ b/src/plugins/manifest-contract-eligibility.ts
@@ -7,7 +7,7 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { readBundledDiscoveryModeMemoized } from "./bundled-discovery-state.js";
 import { isBundledProviderCompatContract } from "./bundled-provider-compat.js";
-import { normalizePluginsConfig } from "./config-state.js";
+import { normalizePluginsConfig, type NormalizedPluginsConfig } from "./config-state.js";
 import { isInstalledPluginEnabled } from "./installed-plugin-index.js";
 import { resolveManifestOwnerBasePolicyBlock } from "./manifest-owner-policy.js";
 import type { PluginManifestContractListKey, PluginManifestRecord } from "./manifest-registry.js";
@@ -24,6 +24,8 @@ export function isManifestPluginOwnerAllowedByControlPlanePolicy(params: {
     channels?: readonly string[];
   };
   config?: OpenClawConfig;
+  /** Batch callers carry the policy normalized from this same config. */
+  normalizedConfig?: NormalizedPluginsConfig;
   allowRestrictiveAllowlistBypass?: boolean;
   allowBundledProviderCompat?: boolean;
   /** Callers scoped to an explicit env read compat from that env's state root. */
@@ -33,7 +35,7 @@ export function isManifestPluginOwnerAllowedByControlPlanePolicy(params: {
     return true;
   }
   const config = params.config;
-  const normalized = normalizePluginsConfig(config.plugins);
+  const normalized = params.normalizedConfig ?? normalizePluginsConfig(config.plugins);
   // Global disable is owned by each runtime surface; bundled speech remains intentionally usable.
   const normalizedConfig = normalized.enabled ? normalized : { ...normalized, enabled: true };
   const block = resolveManifestOwnerBasePolicyBlock({
@@ -70,6 +72,7 @@ export function isManifestPluginAvailableForControlPlane(params: {
     "id" | "origin" | "enabledByDefault" | "enabledByDefaultOnPlatforms"
   > & { channels?: readonly string[] };
   config?: OpenClawConfig;
+  normalizedConfig?: NormalizedPluginsConfig;
   allowRestrictiveAllowlistBypass?: boolean;
   allowBundledProviderCompat?: boolean;
   env?: NodeJS.ProcessEnv;
@@ -104,6 +107,7 @@ export function listAvailableManifestContractPlugins(params: {
   config?: OpenClawConfig;
   env?: NodeJS.ProcessEnv;
 }): PluginManifestRecord[] {
+  const normalizedConfig = normalizePluginsConfig(params.config?.plugins);
   return params.snapshot.plugins.filter(
     (plugin) =>
       hasManifestContractValue({
@@ -115,6 +119,7 @@ export function listAvailableManifestContractPlugins(params: {
         snapshot: params.snapshot,
         plugin,
         config: params.config,
+        normalizedConfig,
         env: params.env,
         allowBundledProviderCompat: isBundledProviderCompatContract(params.contract),
       }),

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -582,15 +582,6 @@ function listManifestToolNamesForAllowlist(params: {
   return uniqueStrings([...defaultToolNames, ...matchedToolNames]);
 }
 
-function listManifestToolNamesForAvailability(params: {
-  plugin: PluginManifestRecord;
-  toolNames: readonly string[];
-  pluginId: string;
-  allowlist: Set<string>;
-}): string[] {
-  return listManifestToolNamesForAllowlist(params);
-}
-
 function isManifestToolNameAvailable(params: {
   plugin: PluginManifestRecord;
   toolName: string;
@@ -652,13 +643,8 @@ function resolvePluginToolRuntimePluginIds(params: {
         snapshot,
         plugin,
         config: params.config,
+        normalizedConfig: normalizedPlugins,
       })
-    ) {
-      continue;
-    }
-    if (
-      normalizedPlugins.entries[plugin.id]?.enabled === false ||
-      normalizedPlugins.deny.includes(plugin.id)
     ) {
       continue;
     }
@@ -666,7 +652,7 @@ function resolvePluginToolRuntimePluginIds(params: {
       continue;
     }
     const toolNames = plugin.contracts?.tools ?? [];
-    const selectedToolNames = listManifestToolNamesForAvailability({
+    const selectedToolNames = listManifestToolNamesForAllowlist({
       toolNames,
       plugin,
       pluginId: plugin.id,
@@ -879,6 +865,7 @@ function resolveCachedPluginTools(params: {
   const tools: AnyAgentTool[] = [];
   const handledPluginIds = new Set<string>();
   const onlyPluginIdSet = new Set(params.onlyPluginIds);
+  const normalizedConfig = normalizePluginsConfig(params.config?.plugins);
   for (const plugin of params.snapshot.plugins) {
     if (!onlyPluginIdSet.has(plugin.id)) {
       continue;
@@ -891,12 +878,13 @@ function resolveCachedPluginTools(params: {
         snapshot: params.snapshot,
         plugin,
         config: params.config,
+        normalizedConfig,
       })
     ) {
       continue;
     }
     const contractToolNames = plugin.contracts?.tools ?? [];
-    const allowedToolNames = listManifestToolNamesForAvailability({
+    const allowedToolNames = listManifestToolNamesForAllowlist({
       plugin,
       toolNames: contractToolNames,
       pluginId: plugin.id,
@@ -1104,8 +1092,7 @@ function resolvePluginToolLoadState(params: {
         env,
         workspaceDir: params.context.workspaceDir,
       });
-  const normalized = normalizePluginsConfig(context.config.plugins);
-  if (!normalized.enabled) {
+  if (context.config.plugins?.enabled === false) {
     return undefined;
   }
 
@@ -1526,7 +1513,7 @@ export function resolvePluginTools(params: {
     if (!manifestPlugin) {
       continue;
     }
-    const availableToolNames = listManifestToolNamesForAvailability({
+    const availableToolNames = listManifestToolNamesForAllowlist({
       plugin: manifestPlugin,
       toolNames: manifestPlugin.contracts?.tools ?? [],
       pluginId,


### PR DESCRIPTION
## What Problem This Solves

Gateway turns repeated plugin-policy preparation and copied session data that the turn only needed to identify its current session. These costs accumulated during model/tool discovery, browser chat admission, and transcript persistence.

Related: #134246, the earlier per-turn preparation improvement. This is the requested follow-up performance and simplification pass.

## Why This Change Was Made

Reuse each scan's normalized plugin policy, read the global enabled flag directly where it is the only needed fact, and keep policy decisions in the existing eligibility owner. Remove forwarding helpers and repeated owner checks after the owner has already passed the outer gate.

Transcript targeting carries the current session ID without retaining or copying the cached store. Private identity snapshots retain freshly decoded entries; caller callbacks and returned results retain their isolation copies. Existing current-session checks, durable input admission, cancellation ordering, plugin deny/allow rules, installed-plugin activation, and named bundled compatibility remain intact. No config, persistence schema, migration, dependency, or protocol change.

## User Impact

Less repeated local work during turn preparation with the same available tools and durable chat behavior. This does not claim a repeatable end-to-end latency improvement: provider latency, shared-host load, and garbage collection varied between runs.

## Evidence

- Earlier isolated real-API measurements reduced plugin normalization from 5,678 to 1,422 calls across two turns (75%), and session-entry copies from 508 to 476 across two turns (6.3%). All 32 redundant identity-snapshot copies disappeared. Timing and precise counting used separate runs.
- The last measured plain preparation median was 115.25 → 97.93 ms, while Gateway CPU was effectively flat. These historical measurements were made on `e339ce2e2fb3d9c4e1d42c9473a35479ccaffe9b` plus the preceding local performance passes. They are not final-head timing claims; newer main changes full-store caching.
- The three local passes validated 338, 160, and 86 real OpenAI turns respectively, covering plain responses, workspace file reads, session-status tools, and browser-protocol admission. Same saved state and full builds were used for comparisons. No task-owned test/build/review jobs overlapped timed runs.
- The identity-copy regression failed before the fix in three cases: six async copies exceeded a budget of four, and two synchronous cases each made two copies against a budget of zero. Existing tests retain stale-write, recovery, checkpoint, provenance, and cancellation-ordering proof. Final cleanup adds direct callback/result isolation, shared prepared-policy immutability, and a positive-control owner-denial table row.
- Runtime validation on `faa28eb7040adaaf11c84496eb2b30063c206a66`: **155 tests across nine files passed**, covering policy selection, manifest eligibility, browser admission, exact session rows, conformance, recovery, transcript initialization, parent forks, and replacement projection. The full build and changed-file gate passed; Codex Autoreview found no actionable finding at its configured P0 threshold.
- Fresh real-API smoke on that rebased build: **six of six turns passed** through the authenticated browser Gateway protocol. Two plain turns returned the exact expected text; two workspace reads completed their command tool and returned the fixture; two session-status turns completed `session_status` and returned the configured public model. Gateway health returned HTTP 200. This is behavior proof, not a new timing claim.
- Earlier focused passes: 333, 352, and 84 tests passed; matching full builds and changed checks passed. Local final checks used the checkout’s existing resolved dependencies; hosted CI supplies the current frozen-lockfile environment. [CI for the runtime-change commit](https://github.com/openclaw/openclaw/actions/runs/33463227376) passed: 190 jobs successful, 15 skipped, no failures. The final follow-up `858138db7e15547a29ab3cd7f1434f5f239c99be` only removes the changelog line; source and tests match the validated commit byte-for-byte. Its focused Autoreview passed, and [final-head CI](https://github.com/openclaw/openclaw/actions/runs/33464072969) is green.

Production LOC: net **−59**. Tests: net **+117**. The tests reuse existing owner fixtures and add no production-only test seam.

Follow-up: startup-only `preserveTemporarySessionMapping` has another fresh-row copy to investigate separately. A direct exact-reader substitution for Gateway whole-store lookup is intentionally excluded because hidden-row visibility, sparse-store shape, and unrelated-row validation differ.

ClawSweeper follow-through: its current review found the runtime patch correct. The changelog removal finding/rank-up move is addressed: the release-owned changelog is unchanged, and the release-note context remains in this PR body. The first native prepare attempt correctly rejected the changelog line; no release-only override was used. The exact-head CI rank-up move is satisfied by the green final-head run.
