### PR TITLE
test(ui): remove duplicate thinking normalization case

### DIFF
--- a/ui/src/lib/chat/thinking.test.ts
+++ b/ui/src/lib/chat/thinking.test.ts
@@ -1,21 +1,8 @@
-// Control UI tests cover canonical and legacy thinking-level normalization.
 import { describe, expect, it } from "vitest";
-import { normalizeThinkLevel } from "../../../../src/auto-reply/thinking.shared.js";
-import {
-  formatThinkingOverrideLabel,
-  resolveChatThinkingSelectState,
-  resolveThinkingLevelInput,
-} from "./thinking.ts";
+import { resolveChatThinkingSelectState, resolveThinkingLevelInput } from "./thinking.ts";
 
 describe("chat thinking helpers", () => {
-  it("keeps literal Ultra distinct from the legacy ultrathink alias", () => {
-    expect(normalizeThinkLevel("ultra")).toBe("ultra");
-    expect(normalizeThinkLevel("Ultra")).toBe("ultra");
-    expect(normalizeThinkLevel("ultrathink")).toBe("high");
-    expect(formatThinkingOverrideLabel("ultra")).toBe("Ultra");
-  });
-
-  it("accepts Ultra when the gateway advertises it for the session", () => {
+  it("normalizes canonical Ultra command input", () => {
     expect(
       resolveThinkingLevelInput(
         "ultra",


### PR DESCRIPTION
## What Problem This Solves

The UI thinking suite repeats shared normalization checks and a label assertion already protected by a stronger selection test. The duplicate survived after normalization moved to its shared owner and the selection test gained an exact display-label check.

## Why This Change Was Made

Remove the redundant case and unused imports. Keep canonical Ultra and legacy ultrathink coverage at the shared owner, and retain the full unsupported-override selection test and cross-runtime option guard. Rename the remaining parser test to describe what it actually proves: canonical input normalization; command execution separately enforces advertised options.

## User Impact

Production behavior is unchanged. Tests are +2/-15, and the UI helper suite goes from four cases to three. No runtime export, public input or compatibility behavior is removed.

## Evidence

The ordinary UI/core group passed 81 cases before and 80 after. All 77 core cases and surviving UI order are unchanged apart from the declared title correction. A temporary wrong Ultra label made exactly the removed direct assertion and the retained full selection assertion fail; the other two UI cases passed. The owner was restored exactly before the passing after run.

The retained selection test reaches the real formatter because its persisted Ultra override is absent from the advertised Max-only options. It checks the complete unanchored selection, including displayLabel, and the exact option list. This is helper-state coverage; there is no visual or external runtime behavior change.

All 18 normal changed-file checks passed, including formatting, UI/core test typechecking, lint and repository guards. Managed Codex review was scoped-clean with no actionable P0 finding.

Exact-head hosted CI33463319954 completed successfully. The maintainer has read the latest completed ClawSweeper review and its Rank-up list in full; its requests are that review read and the exact-head check completion, both satisfied. No code finding remains. Normal native review/prepare/merge gates still apply.
