### PR TITLE
test(doctor): load pairing diagnostics once per suite

### DIFF
--- a/src/commands/doctor-device-pairing.test.ts
+++ b/src/commands/doctor-device-pairing.test.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 // Doctor device pairing tests cover device-pairing checks, repair prompts, and diagnostics.
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { storeDeviceAuthToken } from "../infra/device-auth-store.js";
 import {
   loadOrCreateDeviceIdentity,
@@ -92,12 +92,15 @@ describe("noteDevicePairingHealth", () => {
     });
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     vi.resetModules();
-    callGatewayMock.mockReset();
-    noteMock.mockReset();
     ({ collectDevicePairingHealthFindings, noteDevicePairingHealth } =
       await import("./doctor-device-pairing.js"));
+  });
+
+  beforeEach(() => {
+    callGatewayMock.mockReset();
+    noteMock.mockReset();
   });
 
   afterEach(() => {
@@ -215,13 +218,16 @@ describe("noteDevicePairingHealth", () => {
   it("warns when the local cached device token predates the gateway rotation", async () => {
     await withApprovedOperatorPairing(async ({ identity }) => {
       const now = vi.spyOn(Date, "now").mockReturnValue(1);
-      storeDeviceAuthToken({
-        deviceId: identity.deviceId,
-        role: "operator",
-        token: "stale-local-token",
-        scopes: ["operator.read"],
-      });
-      now.mockRestore();
+      try {
+        storeDeviceAuthToken({
+          deviceId: identity.deviceId,
+          role: "operator",
+          token: "stale-local-token",
+          scopes: ["operator.read"],
+        });
+      } finally {
+        now.mockRestore();
+      }
 
       const rotated = await rotateDeviceToken({
         deviceId: identity.deviceId,


### PR DESCRIPTION
The nine doctor pairing cases reset and import the same diagnostics owner with unchanged mock factories. Move that fresh import to beforeAll while retaining the initial reset, per-case gateway/note mock resets, and each local case's separate state directory. This removes eight registry resets and eight repeated owner-graph evaluations.

All nine cases and 37 expect chains remain in their original declaration order, including the read-only no-database-creation regression, legacy input preservation, real pairing/token operations, local and remote diagnostics, sanitization and shell quoting. The existing clock spy now restores in finally around token fixture creation. Production +0/-0; tests +17/-11 (net +6).

Validation: the full nine-case file passes before, after and after exact fault restoration. A scratch token-write failure confirms Date.now is restored inside the case before outer teardown. Full changed checks and Codex autoreview pass. No elapsed-time gain is claimed.

Commands:
```sh
node scripts/run-vitest.mjs src/commands/doctor-device-pairing.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base 3c1b351555e0ebc1b022842523191691e89c7684
```

The static fixture writers still belong to their original pre-reset module graph; sharing the doctor import does not mean every database connection is shared. Follow-up: the existing approved-pairing fixture removes its directory without explicitly closing all cached writable handles. This PR does not claim handle-leak repair or Windows deletion proof; a separately demonstrated issue should be repaired through the canonical state-fixture lifecycle.
