### PR TITLE
test(media): skip file setup for supplied playback probes

### DIFF
--- a/src/media/playback-transcode.test.ts
+++ b/src/media/playback-transcode.test.ts
@@ -66,6 +66,14 @@ async function createSource(fileName: string, contents = "source") {
   return { sourcePath, sourceStat: await fs.stat(sourcePath) };
 }
 
+// Supplied probe facts only need source identity; conversion cases keep real files.
+function createSourceMetadata(fileName: string) {
+  return {
+    sourcePath: path.join(tempHome.home, fileName),
+    sourceStat: { size: 6, mtimeMs: 1, ctimeMs: 1, dev: 1, ino: 1 },
+  };
+}
+
 function createCacheKey(source: {
   path: string;
   size: number;
@@ -150,7 +158,7 @@ describe("playback transcode policy", () => {
   ] as const)(
     "classifies accepted $0 $1 as $2 through the public source resolver",
     async (mimeType, kind, expected, codec) => {
-      const source = await createSource(`${mimeType.replaceAll("/", "-")}-${codec}`);
+      const source = createSourceMetadata(`${mimeType.replaceAll("/", "-")}-${codec}`);
       const probe =
         kind === "audio"
           ? { durationMs: 1000, audioCodec: codec, audioStreamIndex: 0 }
@@ -292,7 +300,7 @@ describe("resolvePlaybackTranscode", () => {
   });
 
   it("scopes cached codec classification by media kind and MIME", async () => {
-    const source = await createSource("dual-track.mp4");
+    const source = createSourceMetadata("dual-track.mp4");
 
     await expect(
       playback.resolvePlaybackModeForSource({
@@ -319,7 +327,7 @@ describe("resolvePlaybackTranscode", () => {
   });
 
   it("does not advertise transcode for a source over the media byte cap", async () => {
-    const source = await createSource("oversized-meta.mp4");
+    const source = createSourceMetadata("oversized-meta.mp4");
     const { mtimeMs, ctimeMs, dev, ino } = source.sourceStat;
     const sourceStat = { size: 16 * 1024 * 1024 + 1, mtimeMs, ctimeMs, dev, ino };
 
@@ -350,7 +358,7 @@ describe("resolvePlaybackTranscode", () => {
   });
 
   it("transcodes nonportable H.264 profiles and pixel formats", async () => {
-    const source = await createSource("high-10.mp4");
+    const source = createSourceMetadata("high-10.mp4");
 
     await expect(
       playback.resolvePlaybackModeForSource({
@@ -369,7 +377,7 @@ describe("resolvePlaybackTranscode", () => {
   });
 
   it("transcodes known-incompatible MP4 audio when H.264 profile facts are unknown", async () => {
-    const source = await createSource("unknown-profile-opus.mp4");
+    const source = createSourceMetadata("unknown-profile-opus.mp4");
 
     await expect(
       playback.resolvePlaybackModeForSource({
@@ -388,7 +396,7 @@ describe("resolvePlaybackTranscode", () => {
   });
 
   it("does not cache native when a selected audio stream has an unknown codec", async () => {
-    const source = await createSource("unknown-audio.mp4");
+    const source = createSourceMetadata("unknown-audio.mp4");
 
     await expect(
       playback.resolvePlaybackModeForSource({


### PR DESCRIPTION
Thirty-eight playback policy cases create a six-byte file, resolve it and stat it even though they already supply probe facts. That resolver path uses source identity for cache/size decisions and never opens the file. Supply the identity directly, retaining each distinct filename so MIME aliases cannot accidentally share an inspection cache entry. This removes 38 files and 114 awaited setup operations: 38 writes, 38 realpath calls and 38 stats.

All 89 expanded cases and 92 expect chains remain. The 32 demuxer rows keep real source/output files, as do descriptor probing, bounded reads, cache reuse, transcode admission, failure cooldown and saturation cases. The public source resolver still owns classification; no filesystem mock or retired policy test seam is introduced. Production +0/-0; tests +14/-6 (net +8).

Validation: the entire 89-case file passes before and after in its original order. The relevant source, fixtures and caller paths are unchanged between the baseline and PR base. Full changed checks and Codex autoreview pass. The operation reduction is structural, not an elapsed-time benchmark; ffmpeg remains mocked at its existing process boundary.

Commands:
```sh
node scripts/run-vitest.mjs src/media/playback-transcode.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base 3c1b351555e0ebc1b022842523191691e89c7684
```

Follow-up: later playback job-completion polls need a causal handle captured while each job is active. The existing completion helper throws if the job has already disappeared and rejects failures, so those waits are retained here.
