### PR TITLE
fix(subagents): avoid stale agents after lazy loading

### DIFF
--- a/src/auto-reply/reply/commands-subagents.test.ts
+++ b/src/auto-reply/reply/commands-subagents.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../../agents/subagents/registry/subagent-registry-read.js";
 import {
   addSubagentRunForTests,
+  releaseSubagentRun,
   resetSubagentRegistryForTests,
 } from "../../agents/subagents/registry/subagent-registry.test-helpers.js";
 import type { SubagentRunRecord } from "../../agents/subagents/registry/subagent-registry.types.js";
@@ -176,6 +177,64 @@ describe("subagents status", () => {
     for (const blocked of unexpectedText) {
       expect(text).not.toContain(blocked);
     }
+  });
+});
+
+describe("subagents command snapshots", () => {
+  beforeEach(() => {
+    resetSubagentRegistryForTests({ persist: false });
+  });
+
+  afterEach(() => {
+    resetSubagentRegistryForTests({ persist: false });
+  });
+
+  it("captures controlled runs after lazy action loading", async () => {
+    const controllerSessionKey = "agent:main:main";
+    const parentSessionKey = "agent:main:subagent:snapshot-parent";
+    const parentRunId = "snapshot-parent-run";
+
+    await handleSubagentsCommand(
+      buildCommandTestParams("/subagents list", baseCommandTestConfig),
+      true,
+    );
+    addSubagentRunForTests({
+      runId: parentRunId,
+      childSessionKey: parentSessionKey,
+      controllerSessionKey,
+      requesterSessionKey: controllerSessionKey,
+      requesterDisplayKey: "main",
+      task: "removed parent",
+      cleanup: "keep",
+      createdAt: Date.now() - 2_000,
+      startedAt: Date.now() - 2_000,
+      endedAt: Date.now() - 1_000,
+      outcome: { status: "ok" },
+    });
+
+    const pendingReply = handleSubagentsCommand(
+      buildCommandTestParams("/agents", baseCommandTestConfig),
+      true,
+    );
+    queueMicrotask(() => {
+      releaseSubagentRun(parentRunId);
+      addSubagentRunForTests({
+        runId: "snapshot-child-run",
+        childSessionKey: `${parentSessionKey}:subagent:child`,
+        controllerSessionKey: parentSessionKey,
+        requesterSessionKey: parentSessionKey,
+        requesterDisplayKey: parentSessionKey,
+        task: "new child",
+        cleanup: "keep",
+        createdAt: Date.now(),
+        startedAt: Date.now(),
+      });
+    });
+
+    const text = requireReplyText((await pendingReply)?.reply);
+    expect(text).toContain("(none)");
+    expect(text).not.toContain("removed parent");
+    expect(text).not.toContain("waiting on 1 child");
   });
 });
 

--- a/src/auto-reply/reply/commands-subagents.ts
+++ b/src/auto-reply/reply/commands-subagents.ts
@@ -1,11 +1,7 @@
 // Dispatches subagent inspection commands.
 import { createLazyImportLoader } from "../../shared/lazy-promise.js";
 import { commandReply, defineAuthorizedTextCommand, matchCommandPrefix } from "./command-gates.js";
-import {
-  buildSubagentsHelp,
-  resolveRequesterSessionKey,
-  type SubagentsCommandContext,
-} from "./commands-subagents/shared.js";
+import { buildSubagentsHelp, resolveRequesterSessionKey } from "./commands-subagents/shared.js";
 import type { CommandHandler } from "./commands-types.js";
 
 const actionAgentsLoader = createLazyImportLoader(
@@ -53,26 +49,21 @@ export const handleSubagentsCommand: CommandHandler = defineAuthorizedTextComman
       return commandReply("⚠️ Missing session key.");
     }
 
-    const ctx: SubagentsCommandContext = {
+    const actionHandler =
+      action === "agents"
+        ? (await actionAgentsLoader.load()).handleSubagentsAgentsAction
+        : action === "list"
+          ? (await actionListLoader.load()).handleSubagentsListAction
+          : action === "info"
+            ? (await actionInfoLoader.load()).handleSubagentsInfoAction
+            : (await actionLogLoader.load()).handleSubagentsLogAction;
+    const { listControlledSubagentRuns } = await controlRuntimeLoader.load();
+
+    return await actionHandler({
       params,
       requesterKey,
-      runs: (await controlRuntimeLoader.load()).listControlledSubagentRuns(
-        requesterKey,
-        params.agentId,
-        params.cfg,
-      ),
+      runs: listControlledSubagentRuns(requesterKey, params.agentId, params.cfg),
       restTokens,
-    };
-
-    if (action === "agents") {
-      return (await actionAgentsLoader.load()).handleSubagentsAgentsAction(ctx);
-    }
-    if (action === "list") {
-      return (await actionListLoader.load()).handleSubagentsListAction(ctx);
-    }
-    if (action === "info") {
-      return (await actionInfoLoader.load()).handleSubagentsInfoAction(ctx);
-    }
-    return await (await actionLogLoader.load()).handleSubagentsLogAction(ctx);
+    });
   },
 );


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `/agents` could display a removed subagent when the registry changed while its action module was loading. The command could combine a controlled-run list from one point in time with descendant liveness from a later point in time, presenting a parent/child state that never existed.

## Why This Change Was Made

The `/subagents` dispatcher now resolves the selected action handler and control runtime before taking the controlled-run snapshot. It invokes the selected handler immediately after that read, so lazy loading cannot split the parent list from the action's registry view.

The architectural owner is `src/auto-reply/reply/commands-subagents.ts`. No registry, action-module, SDK, config, storage, protocol, or public API surface changed.

## User Impact

`/agents` no longer shows a stale removed parent when subagent state changes during lazy command loading. Other `/subagents` actions keep their existing behavior.

## Evidence

### Race reproduction

The regression primes the control loader with `/subagents list`, registers an ended parent, starts `/agents`, then replaces the parent with only its child during lazy action loading.

Pre-fix:

```text
FAIL ... captures controlled runs after lazy action loading
AssertionError: expected 'agents:\n-----\n1. removed parent ...' to contain '(none)'
Tests: 1 failed, 29 skipped
```

Post-fix:

```text
Tests: 1 passed, 29 skipped
```

### Focused and sibling coverage

```text
node scripts/run-vitest.mjs \
  src/auto-reply/reply/commands-subagents.test.ts \
  src/agents/subagents/registry/subagent-control.test.ts \
  src/agents/subagents/registry/subagent-active-context.test.ts

Tests: 96 passed
```

The same focused suite passed again after rebasing onto current `origin/main`.

### Static review

- `node scripts/check-changed.mjs --dry-run -- ...`: classified the files as core production + core test.
- Actual local changed gates passed through core typecheck, then local core-test typecheck stopped on the checkout's unrelated shared-`node_modules` `pako` declaration issue in `ui/vite.config.ts`.
- Local `pnpm build` completed core/package/plugin phases, then the UI phase hit the same unrelated shared-`node_modules` `pako` ESM issue.
- Pinned Codex autoreview: scoped-clean, 0 accepted findings across 3 passes, correctness 0.99.
- `git diff --check`: passed.

### Clean Linux Testbox

- Provider: Blacksmith Testbox
- Lease: `tbx_01m1ddsxm5x5yqxmg0atexwx8k`
- Run: https://github.com/openclaw/openclaw/actions/runs/33463827460
- Exact head: `eaf9f0e98be5ee1ab3aefa9407f90c4566208e64`
- Focused command: 96 tests passed
- `CI=1 pnpm build`: passed, including the Control UI build

### Telegram Test Server rank-up move

Concrete infeasibility at exact head `eaf9f0e98be5ee1ab3aefa9407f90c4566208e64`:

```text
node .agents/skills/telegram-e2e-userbot/scripts/telegram-test-doctor.mjs
{"ok":false,"error":"Could not load the QA broker through the Convex CLI. Ask the user to install and authenticate the convex command, then request access to the OpenClaw broker project."}
```

The repo-pinned Convex CLI's broker preflight returns `401 Unauthorized: MissingAccessToken`, and neither `OPENCLAW_QA_CONVEX_SITE_URL` nor `OPENCLAW_QA_CONVEX_SECRET_CI` is present. The canonical Telegram E2E runner therefore cannot lease the Test Server bot/user credentials or TDLib state, so no real Telegram action or sanitized event timeline can be produced from this machine. The sanitized doctor failure was retained as the proof artifact.

The exact lazy-load transition also cannot be injected by the current public scenario harness: scenario commands run in separate processes and cannot mutate the Gateway's in-memory subagent registry during the lazy-import microtask. Reaching that transition through Telegram would require a new Gateway preload/control seam outside this repair's two-file scope. No mock-only result is substituted as Telegram proof. The exact race remains covered by the real lazy loader + registry regression above.

Exact-head PR CI passed with no pending or failed checks; neutral CodeQL is unchanged.

### Test audit

The new test protects observable `/agents` output and fails on the pre-fix code for the demonstrated ordering race. Existing tests did not mutate registry state across the real lazy-loader boundary. It adds no test-only production seam, module reset, fake timer, or mocked registry.

### LOC

- Production: `+14/-23`, net `-9`
- Tests: `+59/-0`

### Sibling and contract checks

- `/status` already uses the stable controlled-run read context.
- Active prompt generation has no await between its controlled-run and descendant reads.
- Action-time fresh registry reads remain unchanged.
- No exact-file open PR overlap was found before editing or before push.
- Codex hard gate checked: `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; no protocol or runtime coupling.
