### PR TITLE
fix(ui): replace settings loading text with skeletons

### DIFF
--- a/ui/src/app/app-host-pairing-access.test.ts
+++ b/ui/src/app/app-host-pairing-access.test.ts
@@ -265,7 +265,11 @@ describe("application shell pairing access", () => {
 
     const sidebar = container.querySelector<HTMLElement>(".settings-sidebar");
     expect(sidebar?.getAttribute("aria-busy")).toBe("true");
-    expect(sidebar?.textContent).toContain("Loading…");
+    const loadingSkeleton = sidebar?.querySelector<HTMLElement>(
+      '.settings-sidebar__loading[role="status"][aria-busy="true"]',
+    );
+    expect(loadingSkeleton?.getAttribute("aria-label")).toBe("Loading…");
+    expect(loadingSkeleton?.querySelectorAll(".settings-sidebar__loading-row")).toHaveLength(7);
     expect(loadRenderer).toHaveBeenCalledOnce();
   });
 

--- a/ui/src/components/mcp-servers-card.ts
+++ b/ui/src/components/mcp-servers-card.ts
@@ -25,6 +25,7 @@ import {
   renderDocsLink,
   renderLearnMoreLink,
   renderSettingsEmpty,
+  renderSettingsLoadingSkeleton,
   renderSettingsSection,
   renderSettingsStatus,
 } from "./settings-ui.ts";
@@ -226,7 +227,7 @@ class McpServersCard extends OpenClawLightDomElement {
     const blockedReason = this.mutationBlockedReason();
     const rows = this.rows;
     const body = !rows
-      ? html`<div class="mcp-server-loading" role="status">${t("common.loading")}</div>`
+      ? renderSettingsLoadingSkeleton({ rows: 2 })
       : rows.length === 0
         ? renderSettingsEmpty(html`
             ${t("mcpPage.noServers")} ${renderDocsLink(this.docsUrl, t("mcpPage.setUpFirstServer"))}

--- a/ui/src/components/settings-sidebar-lazy.ts
+++ b/ui/src/components/settings-sidebar-lazy.ts
@@ -1,4 +1,4 @@
-import { html } from "lit";
+import { html, nothing } from "lit";
 import { t } from "../i18n/index.ts";
 import { icons } from "./icons.ts";
 
@@ -24,7 +24,7 @@ export function renderLazySettingsSidebar(
   if (!failed) {
     host.loadSettingsSidebarRenderer();
   }
-  return html`<aside class="settings-sidebar" aria-busy=${failed ? "false" : "true"}>
+  return html`<aside class="settings-sidebar" aria-busy=${failed ? nothing : "true"}>
     <header class="settings-sidebar__header">
       <button type="button" class="settings-sidebar__back" @click=${props.onExit}>
         <span class="settings-sidebar__back-icon" aria-hidden="true">${icons.arrowLeft}</span>

--- a/ui/src/components/settings-sidebar-lazy.ts
+++ b/ui/src/components/settings-sidebar-lazy.ts
@@ -1,4 +1,4 @@
-import { html, nothing } from "lit";
+import { html } from "lit";
 import { t } from "../i18n/index.ts";
 import { icons } from "./icons.ts";
 
@@ -24,7 +24,7 @@ export function renderLazySettingsSidebar(
   if (!failed) {
     host.loadSettingsSidebarRenderer();
   }
-  return html`<aside class="settings-sidebar" aria-busy=${failed ? nothing : "true"}>
+  return html`<aside class="settings-sidebar" aria-busy=${failed ? "false" : "true"}>
     <header class="settings-sidebar__header">
       <button type="button" class="settings-sidebar__back" @click=${props.onExit}>
         <span class="settings-sidebar__back-icon" aria-hidden="true">${icons.arrowLeft}</span>
@@ -32,17 +32,29 @@ export function renderLazySettingsSidebar(
       </button>
       <h1 class="settings-sidebar__title">${t("nav.settings")}</h1>
     </header>
-    <div class="settings-sidebar__empty" role=${failed ? "alert" : "status"}>
-      ${failed ? t("nav.settingsLoadFailed") : t("common.loading")}
-      ${failed
-        ? html`<button
+    ${failed
+      ? html`<div class="settings-sidebar__empty" role="alert">
+          ${t("nav.settingsLoadFailed")}
+          <button
             class="btn btn--sm"
             type="button"
             @click=${() => host.retrySettingsSidebarRenderer()}
           >
             ${t("common.retry")}
-          </button>`
-        : nothing}
-    </div>
+          </button>
+        </div>`
+      : html`<div
+          class="settings-loading-skeleton settings-sidebar__loading"
+          role="status"
+          aria-busy="true"
+          aria-label=${t("common.loading")}
+        >
+          <div class="settings-sidebar__loading-rows" aria-hidden="true">
+            ${Array.from(
+              { length: 7 },
+              () => html`<span class="skeleton settings-sidebar__loading-row"></span>`,
+            )}
+          </div>
+        </div>`}
   </aside>`;
 }

--- a/ui/src/components/settings-ui.ts
+++ b/ui/src/components/settings-ui.ts
@@ -374,6 +374,42 @@ export function renderSettingsEmpty(message: unknown): TemplateResult {
   return html`<div class="settings-empty">${message}</div>`;
 }
 
+/** Shape-matched placeholder for settings rows whose content has not loaded yet. */
+export function renderSettingsLoadingSkeleton(
+  options: { label?: unknown; rows?: number } = {},
+): TemplateResult {
+  const rowCount = Math.max(1, options.rows ?? 3);
+  return html`
+    <div
+      class="settings-loading-skeleton"
+      role="status"
+      aria-busy="true"
+      aria-label=${options.label ?? t("common.loading")}
+    >
+      <div class="settings-loading-skeleton__rows" aria-hidden="true">
+        ${Array.from(
+          { length: rowCount },
+          (_, index) => html`
+            <div class="settings-row settings-loading-skeleton__row">
+              <div class="settings-row__text">
+                <span class="skeleton settings-loading-skeleton__title"></span>
+                <span class="skeleton settings-loading-skeleton__description"></span>
+              </div>
+              <div class="settings-row__control">
+                <span
+                  class="skeleton settings-loading-skeleton__control ${index % 2 === 0
+                    ? "settings-loading-skeleton__control--wide"
+                    : ""}"
+                ></span>
+              </div>
+            </div>
+          `,
+        )}
+      </div>
+    </div>
+  `;
+}
+
 /** Secret text input with an inset reveal toggle — one field, no trailing
  * button, so secret rows line up with plain input rows in the same group. */
 export function renderSettingsSecretInput(props: {

--- a/ui/src/e2e/settings-loading-skeletons.e2e.test.ts
+++ b/ui/src/e2e/settings-loading-skeletons.e2e.test.ts
@@ -1,0 +1,474 @@
+import { mkdir } from "node:fs/promises";
+import path from "node:path";
+import { expect, it } from "vitest";
+import {
+  defaultControlUiFeatureMethods,
+  installMockGateway,
+  startControlUiE2eServer,
+  waitForControlUiRoute,
+} from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Control UI settings loading skeletons mocked Gateway E2E",
+  startServer: () => startControlUiE2eServer(undefined, { source: true }),
+  startServerBeforeBrowser: true,
+});
+
+const proofStage = process.env.OPENCLAW_UI_PROOF_STAGE ?? "after";
+const proofDir = path.join(
+  process.cwd(),
+  ".artifacts",
+  "control-ui-e2e",
+  "settings-loading-skeletons",
+  proofStage,
+);
+
+async function captureLoadingState(
+  target: import("playwright").Locator,
+  name: string,
+): Promise<void> {
+  await target.waitFor({ state: "visible" });
+  await mkdir(proofDir, { recursive: true });
+  await target.screenshot({
+    animations: "disabled",
+    path: path.join(proofDir, `${name}.png`),
+  });
+  if (proofStage === "before") {
+    return;
+  }
+  const skeletons = target.locator(".settings-loading-skeleton");
+  await expect.poll(() => skeletons.count()).toBeGreaterThan(0);
+  expect(await target.textContent()).not.toContain("Loading");
+}
+
+async function withPage(run: (page: import("playwright").Page) => Promise<void>): Promise<void> {
+  await suite.withPage(
+    {
+      colorScheme: "dark",
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 1000, width: 1440 },
+    },
+    async ({ page }) => run(page),
+  );
+}
+
+suite.define(() => {
+  it("renders the Models initial load as a skeleton", async () => {
+    await withPage(async (page) => {
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "agents.list": {
+            agents: [
+              { id: "main", name: "Main" },
+              { id: "reviewer", name: "Reviewer" },
+            ],
+            defaultId: "main",
+            mainKey: "main",
+            scope: "agent",
+          },
+          "config.get": {
+            config: {},
+            hash: "settings-loading-models",
+            issues: [],
+            raw: "{}",
+            valid: true,
+          },
+          "models.list": { models: [] },
+          "models.authStatus": { providers: [], ts: Date.now() },
+          "sessions.usage": { aggregates: { byProvider: [] } },
+          "usage.status": { providers: [] },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}settings/model-providers`);
+      await waitForControlUiRoute(page, {
+        pathname: "/settings/model-providers",
+        routeId: "model-providers",
+      });
+      await gateway.waitForRequest("models.authStatus");
+      const authStatusRequestCount = (await gateway.getRequests("models.authStatus")).length;
+      await gateway.deferNext("models.authStatus");
+      await gateway.deferNext("models.authStatus");
+      await gateway.deferNext("models.authStatus");
+      const agentPicker = page.locator(".agent-scope-control openclaw-agent-select");
+      await agentPicker.locator(".agent-select__trigger").click();
+      await agentPicker.locator('wa-dropdown-item[aria-label="Reviewer"]').click();
+      await expect
+        .poll(async () => (await agentPicker.locator(".agent-select__label").textContent())?.trim())
+        .toBe("Reviewer");
+      await gateway.waitForRequest("models.authStatus", { after: authStatusRequestCount });
+      await captureLoadingState(page.locator(".settings-page").first(), "models");
+    });
+  });
+
+  it("renders the Channels pairing load as a skeleton", async () => {
+    await withPage(async (page) => {
+      await installMockGateway(page, {
+        heldMethods: ["channels.pairing.list"],
+        methodResponses: {
+          "channels.status": {
+            channelAccounts: {},
+            channelDefaultAccountId: {},
+            channelLabels: {},
+            channelMeta: [],
+            channelOrder: [],
+            channels: {},
+            ts: Date.now(),
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}settings/channels`);
+      await waitForControlUiRoute(page, {
+        pathname: "/settings/channels",
+        routeId: "channels",
+      });
+      await captureLoadingState(page.locator(".settings-page").first(), "channels-pairing");
+    });
+  });
+
+  it("renders the Secrets initial load as a skeleton", async () => {
+    await withPage(async (page) => {
+      await installMockGateway(page, {
+        featureMethods: ["secrets.store.list"],
+        heldMethods: ["secrets.store.list"],
+      });
+      await page.goto(`${suite.server.baseUrl}settings/secrets`);
+      await waitForControlUiRoute(page, {
+        pathname: "/settings/secrets",
+        routeId: "secrets",
+      });
+      await captureLoadingState(page.locator(".settings-page").first(), "secrets");
+    });
+  });
+
+  it("renders the Devices inventory load as one skeleton", async () => {
+    await withPage(async (page) => {
+      const gateway = await installMockGateway(page, {
+        methodResponses: {
+          "device.pair.list": { paired: [], pending: [] },
+          "node.list": { nodes: [] },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}settings/devices`);
+      await waitForControlUiRoute(page, {
+        pathname: "/settings/devices",
+        routeId: "devices",
+      });
+      await gateway.waitForRequest("device.pair.list");
+      await gateway.deferNext("device.pair.list");
+      await gateway.emitGatewayEvent("device.pair.requested", {});
+      await captureLoadingState(
+        page.locator(".settings-section", { hasText: "Devices" }).first(),
+        "devices",
+      );
+    });
+  });
+
+  it("renders the MCP server load as a skeleton", async () => {
+    await withPage(async (page) => {
+      await installMockGateway(page, { heldMethods: ["config.get"] });
+      await page.goto(`${suite.server.baseUrl}settings/mcp`);
+      await waitForControlUiRoute(page, {
+        pathname: "/settings/mcp",
+        routeId: "mcp",
+      });
+      await captureLoadingState(page.locator(".mcp-server-list"), "mcp");
+    });
+  });
+
+  it("renders the Plugins catalog load as a skeleton", async () => {
+    await withPage(async (page) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: [...defaultControlUiFeatureMethods, "plugins.list"],
+        heldMethods: ["plugins.list"],
+      });
+      await page.goto(`${suite.server.baseUrl}settings/plugins`);
+      await gateway.waitForRequest("plugins.list");
+      await captureLoadingState(page.locator(".plugins-panel"), "plugins-panel");
+    });
+  });
+
+  it("renders the Plugins MCP config load as a skeleton", async () => {
+    await withPage(async (page) => {
+      await installMockGateway(page, {
+        featureMethods: [...defaultControlUiFeatureMethods, "plugins.list"],
+        heldMethods: ["config.get"],
+        methodResponses: {
+          "plugins.list": {
+            diagnostics: [],
+            mutationAllowed: true,
+            plugins: [],
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}settings/plugins`);
+      const mcpSection = page.locator(".settings-section", { hasText: "MCP servers" }).first();
+      await captureLoadingState(mcpSection, "plugins-mcp");
+    });
+  });
+
+  it("renders the Profile identity load as a skeleton", async () => {
+    await withPage(async (page) => {
+      const profileId = "11111111-1111-4111-8111-111111111111";
+      const gateway = await installMockGateway(page, {
+        heldMethods: ["users.self"],
+        presenceUsers: [
+          {
+            self: true,
+            id: profileId,
+            name: "Test Person",
+            email: "test@example.com",
+          },
+        ],
+      });
+      await page.goto(`${suite.server.baseUrl}settings/profile`);
+      await waitForControlUiRoute(page, { pathname: "/settings/profile", routeId: "profile" });
+      await gateway.waitForRequest("users.self");
+      await captureLoadingState(page.locator("#settings-profile-identity"), "profile-identity");
+    });
+  });
+
+  it("renders both Agent Tools data loads as skeletons", async () => {
+    await withPage(async (page) => {
+      const config = {
+        agents: { entries: { main: { default: true, tools: { profile: "full" } } } },
+      };
+      const gateway = await installMockGateway(page, {
+        heldMethods: ["tools.catalog", "tools.effective"],
+        methodResponses: {
+          "agents.list": {
+            agents: [{ id: "main", name: "Main agent" }],
+            defaultId: "main",
+            mainKey: "main",
+            scope: "agent",
+          },
+          "config.get": {
+            config,
+            sourceConfig: config,
+            runtimeConfig: config,
+            hash: "settings-loading-tools",
+            issues: [],
+            raw: JSON.stringify(config),
+            valid: true,
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}settings/agents/main/tools`);
+      await gateway.waitForRequest("tools.catalog");
+      await gateway.waitForRequest("tools.effective");
+      const panel = page.locator("#agent-panel");
+      await captureLoadingState(
+        panel.locator(".settings-section", { hasText: "Available right now" }).first(),
+        "agent-tools-available",
+      );
+      await captureLoadingState(
+        proofStage === "before"
+          ? panel.locator(".callout", { hasText: "Loading runtime tool catalog" }).first()
+          : panel.locator(".settings-section", { hasText: "Tool catalog" }).first(),
+        "agent-tools-catalog",
+      );
+    });
+  });
+
+  it("renders the Custodian history load as a skeleton", async () => {
+    await withPage(async (page) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: [...defaultControlUiFeatureMethods, "openclaw.changes.list"],
+        heldMethods: ["openclaw.changes.list"],
+      });
+      await page.goto(`${suite.server.baseUrl}custodian`);
+      await waitForControlUiRoute(page, { pathname: "/custodian", routeId: "custodian" });
+      await page.getByRole("button", { name: "History", exact: true }).click();
+      await gateway.waitForRequest("openclaw.changes.list");
+      await captureLoadingState(page.locator(".custodian__history"), "custodian-history");
+    });
+  });
+
+  it("uses a compact spinner when Custodian refreshes existing history", async () => {
+    await withPage(async (page) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: [...defaultControlUiFeatureMethods, "openclaw.changes.list"],
+        methodResponses: {
+          "openclaw.changes.list": {
+            entries: [
+              {
+                at: Date.now() - 5_000,
+                id: "system-agent-audit:3",
+                kind: "operation",
+                source: "system-agent",
+                summary: "Set config gateway.port",
+              },
+            ],
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}custodian`);
+      await waitForControlUiRoute(page, { pathname: "/custodian", routeId: "custodian" });
+      const historyToggle = page.getByRole("button", { name: "History", exact: true });
+      await historyToggle.click();
+      await gateway.waitForRequest("openclaw.changes.list");
+      await page.locator(".custodian__change-card").waitFor();
+
+      const requestCount = (await gateway.getRequests("openclaw.changes.list")).length;
+      await gateway.deferNext("openclaw.changes.list");
+      await historyToggle.click();
+      await historyToggle.click();
+      await gateway.waitForRequest("openclaw.changes.list", { after: requestCount });
+
+      const history = page.locator(".custodian__history");
+      const spinner = history.locator(".custodian__history-spinner");
+      await spinner.waitFor({ state: "visible" });
+      expect(await history.locator(".settings-loading-skeleton").count()).toBe(0);
+      await history.screenshot({
+        animations: "disabled",
+        path: path.join(proofDir, "custodian-refresh.png"),
+      });
+    });
+  });
+
+  it("renders the Approvals history load as a skeleton", async () => {
+    await withPage(async (page) => {
+      const gateway = await installMockGateway(page, {
+        featureMethods: [...defaultControlUiFeatureMethods, "approval.history"],
+        heldMethods: ["approval.history"],
+        operatorScopes: ["operator.admin", "operator.read", "operator.write", "operator.approvals"],
+      });
+      await page.goto(`${suite.server.baseUrl}settings/approvals`);
+      await waitForControlUiRoute(page, {
+        pathname: "/settings/approvals",
+        routeId: "approvals",
+      });
+      await gateway.waitForRequest("approval.history");
+      await captureLoadingState(page.locator(".settings-page").first(), "approvals-history");
+    });
+  });
+
+  it("renders the Channels config schema load as a skeleton", async () => {
+    await withPage(async (page) => {
+      const config = { channels: { whatsapp: { enabled: true } } };
+      const gateway = await installMockGateway(page, {
+        heldMethods: ["config.schema"],
+        methodResponses: {
+          "channels.pairing.list": {
+            accounts: [],
+            requests: [],
+            commandOwnerConfigured: true,
+            limits: { pendingPerAccount: 3, ttlMs: 3_600_000 },
+          },
+          "channels.status": {
+            ts: Date.now(),
+            channelOrder: ["whatsapp"],
+            channelLabels: { whatsapp: "WhatsApp" },
+            channels: {
+              whatsapp: {
+                configured: true,
+                linked: true,
+                running: true,
+                connected: true,
+                reconnectAttempts: 0,
+              },
+            },
+            channelAccounts: {},
+            channelDefaultAccountId: {},
+          },
+          "config.get": {
+            config,
+            hash: "settings-loading-channel-schema",
+            issues: [],
+            raw: JSON.stringify(config),
+            valid: true,
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}settings/channels`);
+      await waitForControlUiRoute(page, { pathname: "/settings/channels", routeId: "channels" });
+      await gateway.waitForRequest("config.schema");
+      await page.locator(".channels-item", { hasText: "WhatsApp" }).first().click();
+      await captureLoadingState(page.locator(".channels-detail"), "channels-schema");
+    });
+  });
+
+  it("preserves the schema-driven Config spinner", async () => {
+    await withPage(async (page) => {
+      const gateway = await installMockGateway(page, {
+        heldMethods: ["config.schema"],
+        methodResponses: {
+          "config.get": {
+            config: {},
+            hash: "settings-loading-config-schema",
+            issues: [],
+            raw: "{}",
+            valid: true,
+          },
+        },
+      });
+      await page.goto(`${suite.server.baseUrl}settings/infrastructure`);
+      await waitForControlUiRoute(page, {
+        pathname: "/settings/infrastructure",
+        routeId: "infrastructure",
+      });
+      await gateway.waitForRequest("config.schema");
+      const panel = page.locator("#config-section-panel");
+      const spinner = panel.locator(".config-loading__spinner");
+      await spinner.waitFor({ state: "visible" });
+      expect(await spinner.isVisible()).toBe(true);
+      expect(await panel.locator(".settings-loading-skeleton").count()).toBe(0);
+      await mkdir(proofDir, { recursive: true });
+      await panel.screenshot({
+        animations: "disabled",
+        path: path.join(proofDir, "config-schema.png"),
+      });
+    });
+  });
+
+  it("wraps row-shaped loading controls at the compact breakpoint", async () => {
+    await suite.withPage(
+      {
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 844, width: 390 },
+      },
+      async ({ page }) => {
+        await installMockGateway(page, {
+          featureMethods: ["secrets.store.list"],
+          heldMethods: ["secrets.store.list"],
+        });
+        await page.goto(`${suite.server.baseUrl}settings/secrets`);
+        const row = page.locator(".settings-loading-skeleton__row").first();
+        const text = row.locator(".settings-row__text");
+        const control = row.locator(".settings-row__control");
+        await row.waitFor();
+        const [textBox, controlBox] = await Promise.all([
+          text.boundingBox(),
+          control.boundingBox(),
+        ]);
+        expect(textBox).not.toBeNull();
+        expect(controlBox).not.toBeNull();
+        expect(controlBox!.y).toBeGreaterThanOrEqual(textBox!.y + textBox!.height);
+        await captureLoadingState(page.locator(".settings-page").first(), "secrets-mobile");
+      },
+    );
+  });
+
+  it("renders the lazy Settings sidebar as navigation skeletons", async () => {
+    await withPage(async (page) => {
+      let releaseSidebar: (() => void) | undefined;
+      const sidebarRelease = new Promise<void>((resolve) => {
+        releaseSidebar = resolve;
+      });
+      await page.route("**/src/components/settings-sidebar.ts*", async (route) => {
+        await sidebarRelease;
+        await route.continue();
+      });
+      await installMockGateway(page);
+      try {
+        await page.goto(`${suite.server.baseUrl}settings/appearance`);
+        await captureLoadingState(page.locator(".settings-sidebar"), "settings-sidebar");
+      } finally {
+        releaseSidebar?.();
+      }
+    });
+  });
+});

--- a/ui/src/e2e/settings-loading-skeletons.e2e.test.ts
+++ b/ui/src/e2e/settings-loading-skeletons.e2e.test.ts
@@ -1,4 +1,3 @@
-import { mkdir } from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import {
@@ -16,25 +15,29 @@ const suite = createControlUiE2eSuite({
 });
 
 const proofStage = process.env.OPENCLAW_UI_PROOF_STAGE ?? "after";
-const proofDir = path.join(
-  process.cwd(),
-  ".artifacts",
-  "control-ui-e2e",
-  "settings-loading-skeletons",
-  proofStage,
-);
+const captureUiProof = process.env.OPENCLAW_CAPTURE_UI_PROOF === "1";
+const captureBeforeProof = captureUiProof && proofStage === "before";
+
+async function captureScreenshot(
+  target: import("playwright").Locator,
+  name: string,
+): Promise<void> {
+  if (!captureUiProof) {
+    return;
+  }
+  await target.screenshot({
+    animations: "disabled",
+    path: path.join(suite.artifactDir, `${proofStage}-${name}.png`),
+  });
+}
 
 async function captureLoadingState(
   target: import("playwright").Locator,
   name: string,
 ): Promise<void> {
   await target.waitFor({ state: "visible" });
-  await mkdir(proofDir, { recursive: true });
-  await target.screenshot({
-    animations: "disabled",
-    path: path.join(proofDir, `${name}.png`),
-  });
-  if (proofStage === "before") {
+  await captureScreenshot(target, name);
+  if (captureBeforeProof) {
     return;
   }
   const skeletons = target.locator(".settings-loading-skeleton");
@@ -149,6 +152,7 @@ suite.define(() => {
           "device.pair.list": { paired: [], pending: [] },
           "node.list": { nodes: [] },
         },
+        presenceUsers: [{ host: "Gateway", id: "gateway", mode: "gateway" }],
       });
       await page.goto(`${suite.server.baseUrl}settings/devices`);
       await waitForControlUiRoute(page, {
@@ -263,7 +267,7 @@ suite.define(() => {
         "agent-tools-available",
       );
       await captureLoadingState(
-        proofStage === "before"
+        captureBeforeProof
           ? panel.locator(".callout", { hasText: "Loading runtime tool catalog" }).first()
           : panel.locator(".settings-section", { hasText: "Tool catalog" }).first(),
         "agent-tools-catalog",
@@ -320,10 +324,7 @@ suite.define(() => {
       const spinner = history.locator(".custodian__history-spinner");
       await spinner.waitFor({ state: "visible" });
       expect(await history.locator(".settings-loading-skeleton").count()).toBe(0);
-      await history.screenshot({
-        animations: "disabled",
-        path: path.join(proofDir, "custodian-refresh.png"),
-      });
+      await captureScreenshot(history, "custodian-refresh");
     });
   });
 
@@ -414,11 +415,7 @@ suite.define(() => {
       await spinner.waitFor({ state: "visible" });
       expect(await spinner.isVisible()).toBe(true);
       expect(await panel.locator(".settings-loading-skeleton").count()).toBe(0);
-      await mkdir(proofDir, { recursive: true });
-      await panel.screenshot({
-        animations: "disabled",
-        path: path.join(proofDir, "config-schema.png"),
-      });
+      await captureScreenshot(panel, "config-schema");
     });
   });
 

--- a/ui/src/pages/agents/panels-tools-skills.ts
+++ b/ui/src/pages/agents/panels-tools-skills.ts
@@ -15,6 +15,7 @@ import type {
 } from "../../api/types.ts";
 import {
   renderSettingsEmpty,
+  renderSettingsLoadingSkeleton,
   renderSettingsRow,
   renderSettingsSection,
   renderSettingsToggle,
@@ -370,7 +371,7 @@ export function renderAgentTools(params: {
   const runtimeAvailability = !params.runtimeSessionMatchesSelectedAgent
     ? renderSettingsEmpty(t("agentTools.switchAgent"))
     : params.toolsEffectiveLoading && !params.toolsEffectiveResult && !params.toolsEffectiveError
-      ? renderSettingsEmpty(t("agentTools.loadingAvailable"))
+      ? renderSettingsLoadingSkeleton({ label: t("agentTools.loadingAvailable"), rows: 2 })
       : params.toolsEffectiveError
         ? renderSettingsEmpty(t("agentTools.availableError"))
         : (params.toolsEffectiveResult?.groups?.length ?? 0) === 0
@@ -420,9 +421,6 @@ export function renderAgentTools(params: {
       : nothing}
     ${hasGlobalAllow
       ? html`<div class="callout info">${t("agentTools.globalAllowlist")}</div>`
-      : nothing}
-    ${params.toolsCatalogLoading && !params.toolsCatalogResult && !params.toolsCatalogError
-      ? html`<div class="callout info">${t("agentTools.loadingCatalog")}</div>`
       : nothing}
     ${params.toolsCatalogError
       ? html`<div class="callout info">${t("agentTools.catalogFallback")}</div>`
@@ -519,7 +517,15 @@ export function renderAgentTools(params: {
     ${renderSettingsSection(
       { title: t("agentTools.catalogTitle") },
       html`
-        <div class="agents-panel-body agent-tools-grid">
+        ${params.toolsCatalogLoading && !params.toolsCatalogResult && !params.toolsCatalogError
+          ? renderSettingsLoadingSkeleton({ label: t("agentTools.loadingCatalog") })
+          : nothing}
+        <div
+          class="agents-panel-body agent-tools-grid"
+          ?hidden=${params.toolsCatalogLoading &&
+          !params.toolsCatalogResult &&
+          !params.toolsCatalogError}
+        >
           ${toolSections.map((section) => {
             const sortedTools = sortSectionTools(section.tools);
             const enabledSectionCount = section.tools.filter(

--- a/ui/src/pages/approvals/approvals-page.ts
+++ b/ui/src/pages/approvals/approvals-page.ts
@@ -22,6 +22,8 @@ import { parseApprovalResolvedEvent } from "../../app/exec-approval.ts";
 import { readGatewayOperatorAccess } from "../../app/operator-access.ts";
 import {
   renderLearnMoreLink,
+  renderSettingsGroup,
+  renderSettingsLoadingSkeleton,
   renderSettingsPage,
   renderSettingsPageHeader,
 } from "../../components/settings-ui.ts";
@@ -428,6 +430,11 @@ class ApprovalsPage extends OpenClawLightDomElement {
   }
 
   private renderTable() {
+    if (this.loading && this.items.length === 0) {
+      return renderSettingsGroup(
+        renderSettingsLoadingSkeleton({ label: t("approvalHistory.loading") }),
+      );
+    }
     return html`
       <div class="data-table-container">
         <table class="data-table approval-history-table">
@@ -448,11 +455,9 @@ class ApprovalsPage extends OpenClawLightDomElement {
                   <tr>
                     <td colspan="7" class="data-table-empty-cell">
                       <div class="data-table-empty-state" role="status" aria-live="polite">
-                        ${this.loading
-                          ? t("approvalHistory.loading")
-                          : this.error || !this.hasLoaded
-                            ? t("approvalHistory.unknown")
-                            : t("approvalHistory.empty")}
+                        ${this.error || !this.hasLoaded
+                          ? t("approvalHistory.unknown")
+                          : t("approvalHistory.empty")}
                       </div>
                     </td>
                   </tr>

--- a/ui/src/pages/channels/view.config.ts
+++ b/ui/src/pages/channels/view.config.ts
@@ -8,6 +8,7 @@ import {
   schemaType,
   type JsonSchema,
 } from "../../components/config-form.ts";
+import { renderSettingsLoadingSkeleton } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { formatChannelExtraValue, resolveChannelConfigValue } from "../../lib/channels/index.ts";
 import type { ChannelsProps } from "./view.types.ts";
@@ -134,20 +135,21 @@ function renderChannelConfigForm(props: ChannelConfigFormProps) {
 export function renderChannelConfigSection(params: { channelId: string; props: ChannelsProps }) {
   const { channelId, props } = params;
   const disabled = props.configSaving || props.configSchemaLoading;
+  if (props.configSchemaLoading) {
+    return renderSettingsLoadingSkeleton({ label: t("channels.config.loadingSchema"), rows: 2 });
+  }
   return html`
     <div class="settings-row settings-row--stacked">
-      ${props.configSchemaLoading
-        ? html`<div class="settings-row__desc">${t("channels.config.loadingSchema")}</div>`
-        : renderChannelConfigForm({
-            channelId,
-            configValue: props.configForm,
-            schema: props.configSchema,
-            uiHints: props.configUiHints,
-            disabled,
-            showAdvanced: props.showAdvancedSettings,
-            onShowAdvanced: props.onShowAdvancedSettings,
-            onPatch: props.onConfigPatch,
-          })}
+      ${renderChannelConfigForm({
+        channelId,
+        configValue: props.configForm,
+        schema: props.configSchema,
+        uiHints: props.configUiHints,
+        disabled,
+        showAdvanced: props.showAdvancedSettings,
+        onShowAdvanced: props.onShowAdvancedSettings,
+        onPatch: props.onConfigPatch,
+      })}
       ${props.configError
         ? html`<div class="callout danger" role="alert">${props.configError}</div>`
         : null}

--- a/ui/src/pages/channels/view.pairing.ts
+++ b/ui/src/pages/channels/view.pairing.ts
@@ -6,6 +6,7 @@ import "../../components/modal-dialog.ts";
 import { renderPicker } from "../../components/select-picker.ts";
 import {
   renderSettingsEmpty,
+  renderSettingsLoadingSkeleton,
   renderSettingsSection,
   renderSettingsStatus,
 } from "../../components/settings-ui.ts";
@@ -197,7 +198,7 @@ export function renderChannelPairingQueue(props: ChannelsProps) {
                 : nothing}
               ${snapshot ? renderFilters(props) : nothing}
               ${props.pairingLoading && !snapshot
-                ? html`<div class="settings-row">${t("common.loading")}</div>`
+                ? renderSettingsLoadingSkeleton({ rows: 2 })
                 : accounts.length === 0
                   ? renderSettingsEmpty(t("channels.pairing.noAccounts"))
                   : requests.length === 0

--- a/ui/src/pages/custodian/custodian-history.ts
+++ b/ui/src/pages/custodian/custodian-history.ts
@@ -1,7 +1,9 @@
 import type { SystemChangeEntry } from "@openclaw/gateway-protocol";
 import { html, nothing } from "lit";
+import { renderSettingsLoadingSkeleton } from "../../components/settings-ui.ts";
 import { t } from "../../i18n/index.ts";
 import { formatRelativeTimestamp } from "../../lib/format.ts";
+import "../../styles/settings.css";
 
 function changeSourceLabel(source: SystemChangeEntry["source"]): string {
   switch (source) {
@@ -76,18 +78,24 @@ export function renderCustodianChangeHistory(params: {
             </button>
           </div>`
         : nothing}
-      <div class="custodian__change-list">
-        ${params.entries.map(renderHistoryCard)}
-        ${params.loading
-          ? html`<div class="custodian__history-state" role="status">
-              ${t("custodian.history.loading")}
-            </div>`
-          : params.loaded && params.entries.length === 0 && !params.error
-            ? html`<div class="custodian__history-state" role="status">
-                ${t("custodian.history.empty")}
-              </div>`
-            : nothing}
-      </div>
+      ${params.loading && params.entries.length === 0
+        ? renderSettingsLoadingSkeleton({ label: t("custodian.history.loading") })
+        : html`<div class="custodian__change-list">
+            ${params.entries.map(renderHistoryCard)}
+            ${params.loading
+              ? html`<div
+                  class="custodian__history-state"
+                  role="status"
+                  aria-label=${t("custodian.history.loading")}
+                >
+                  <span class="custodian__history-spinner" aria-hidden="true"></span>
+                </div>`
+              : params.loaded && params.entries.length === 0 && !params.error
+                ? html`<div class="custodian__history-state" role="status">
+                    ${t("custodian.history.empty")}
+                  </div>`
+                : nothing}
+          </div>`}
       ${params.nextCursor
         ? html`<button
             class="btn btn--ghost custodian__history-more"

--- a/ui/src/pages/devices/view-inventory.ts
+++ b/ui/src/pages/devices/view-inventory.ts
@@ -89,11 +89,11 @@ export function renderDeviceInventory(props: DevicesProps) {
   const empty = groups.length === 0 && !gatewayPresence;
   const deviceRows = html`
     ${gatewayPresence ? renderPresenceRow({ kind: "gateway", entry: gatewayPresence }) : nothing}
-    ${empty
-      ? loading
-        ? renderSettingsLoadingSkeleton()
-        : renderSettingsEmpty(t("devices.inventory.empty"))
-      : groups.map((group) => renderInventoryGroup(group, props))}
+    ${loading && groups.length === 0
+      ? renderSettingsLoadingSkeleton()
+      : empty
+        ? renderSettingsEmpty(t("devices.inventory.empty"))
+        : groups.map((group) => renderInventoryGroup(group, props))}
   `;
   return html`
     ${props.devicesError ? html`<div class="callout danger">${props.devicesError}</div>` : nothing}

--- a/ui/src/pages/devices/view-inventory.ts
+++ b/ui/src/pages/devices/view-inventory.ts
@@ -5,6 +5,7 @@ import type { PresenceEntry } from "../../api/types.ts";
 import { icons } from "../../components/icons.ts";
 import {
   renderSettingsEmpty,
+  renderSettingsLoadingSkeleton,
   renderSettingsSection,
   renderSettingsStatus,
 } from "../../components/settings-ui.ts";
@@ -37,7 +38,7 @@ function inventorySummary(
   loading: boolean,
 ): string {
   if (loading && groups.length === 0) {
-    return t("common.loading");
+    return "";
   }
   const connected = groups.filter((group) => group.primary.connected).length;
   const parts = [
@@ -89,7 +90,9 @@ export function renderDeviceInventory(props: DevicesProps) {
   const deviceRows = html`
     ${gatewayPresence ? renderPresenceRow({ kind: "gateway", entry: gatewayPresence }) : nothing}
     ${empty
-      ? renderSettingsEmpty(loading ? t("common.loading") : t("devices.inventory.empty"))
+      ? loading
+        ? renderSettingsLoadingSkeleton()
+        : renderSettingsEmpty(t("devices.inventory.empty"))
       : groups.map((group) => renderInventoryGroup(group, props))}
   `;
   return html`

--- a/ui/src/pages/model-providers/view.ts
+++ b/ui/src/pages/model-providers/view.ts
@@ -9,6 +9,7 @@ import {
   renderSettingsEmpty,
   renderSettingsDefaultDescription,
   renderSettingsGroup,
+  renderSettingsLoadingSkeleton,
   renderSettingsPage,
   renderSettingsRow,
   renderSettingsSection,
@@ -589,8 +590,7 @@ export function renderModelProviders(props: ModelProvidersViewProps) {
   }
   if (props.loading) {
     return renderSettingsPage(html`
-      ${renderModelBehavior(props)}
-      <div aria-busy="true">${renderSettingsGroup(renderSettingsEmpty(t("common.loading")))}</div>
+      ${renderModelBehavior(props)} ${renderSettingsGroup(renderSettingsLoadingSkeleton())}
     `);
   }
   const providerRows = html`

--- a/ui/src/pages/plugins/view.ts
+++ b/ui/src/pages/plugins/view.ts
@@ -12,6 +12,8 @@ import "../../components/modal-dialog.ts";
 import "../../components/openclaw-mascot.ts";
 import {
   renderSettingsEmpty,
+  renderSettingsGroup,
+  renderSettingsLoadingSkeleton,
   renderSettingsPage,
   renderSettingsSection,
   renderSettingsSegmented,
@@ -749,7 +751,7 @@ function renderMcpSection(props: PluginsViewProps) {
     return nothing;
   }
   const body = !servers
-    ? html`<div class="plugins-search-state" role="status">${t("pluginsPage.loading")}</div>`
+    ? renderSettingsLoadingSkeleton({ label: t("pluginsPage.loading"), rows: 2 })
     : servers.length === 0
       ? renderSettingsEmpty(t("pluginsPage.mcpEmpty"))
       : repeat(
@@ -1343,7 +1345,7 @@ export function renderPlugins(props: PluginsViewProps) {
         aria-labelledby=${`plugins-tab-${props.activeTab}`}
       >
         ${panelState === "loading"
-          ? html`<div class="plugins-search-state" role="status">${t("pluginsPage.loading")}</div>`
+          ? renderSettingsGroup(renderSettingsLoadingSkeleton({ label: t("pluginsPage.loading") }))
           : panelState === "error"
             ? nothing
             : panelState === "offline"

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -29,6 +29,7 @@ import {
   renderLearnMoreLink,
   renderSettingsEmpty,
   renderSettingsGroup,
+  renderSettingsLoadingSkeleton,
   renderSettingsNavRow,
   renderSettingsPage,
   renderSettingsSection,
@@ -363,20 +364,20 @@ export class ProfilePage extends OpenClawLightDomElement {
     if (!this.ownProfile) {
       // users.self is the idempotent gateway-owned profile ensure path. Retrying
       // keeps profile ids and authenticated email linkage authoritative server-side.
-      const emptyState = this.identityLoading
-        ? t("profilePage.identity.loading")
-        : this.identityError
-          ? this.identityError
-          : html`<div class="profile-identity-empty">
-              <span>${t("profilePage.identity.notSet")}</span>
-              <button type="button" class="btn btn--sm" @click=${() => void this.loadIdentity()}>
-                ${t("profilePage.identity.setIdentity")}
-              </button>
-            </div>`;
+      const emptyState = this.identityError
+        ? this.identityError
+        : html`<div class="profile-identity-empty">
+            <span>${t("profilePage.identity.notSet")}</span>
+            <button type="button" class="btn btn--sm" @click=${() => void this.loadIdentity()}>
+              ${t("profilePage.identity.setIdentity")}
+            </button>
+          </div>`;
       return html`<div id=${PROFILE_SETTINGS_TARGET_IDS.identity}>
         ${renderSettingsSection(
           { title: t("profilePage.identity.title") },
-          renderSettingsEmpty(emptyState),
+          this.identityLoading
+            ? renderSettingsLoadingSkeleton({ label: t("profilePage.identity.loading"), rows: 2 })
+            : renderSettingsEmpty(emptyState),
         )}
       </div>`;
     }

--- a/ui/src/pages/secrets/view.ts
+++ b/ui/src/pages/secrets/view.ts
@@ -6,6 +6,7 @@ import "../../components/modal-dialog.ts";
 import {
   renderDocsLink,
   renderSettingsEmpty,
+  renderSettingsLoadingSkeleton,
   renderSettingsPage,
   renderSettingsSection,
 } from "../../components/settings-ui.ts";
@@ -105,7 +106,7 @@ function renderTable(props: SecretsStoreViewProps): TemplateResult {
     return renderSettingsEmpty(t("secretsStore.unavail"));
   }
   if (props.loading && !props.entries.length) {
-    return renderSettingsEmpty(t("common.loading"));
+    return renderSettingsLoadingSkeleton();
   }
   if (!props.entries.length) {
     return html`

--- a/ui/src/styles/config.css
+++ b/ui/src/styles/config.css
@@ -1058,12 +1058,6 @@
   color: var(--danger);
 }
 
-.mcp-server-loading {
-  padding: var(--space-4);
-  color: var(--muted);
-  font-size: var(--control-ui-text-sm);
-}
-
 /* Advanced Settings accordion navigation, rendered by view.ts. */
 .config-accordion-nav {
   margin-bottom: 20px;

--- a/ui/src/styles/custodian.css
+++ b/ui/src/styles/custodian.css
@@ -427,6 +427,29 @@ openclaw-custodian-page {
   font-size: 12px;
 }
 
+.custodian__history-spinner {
+  display: block;
+  width: 14px;
+  height: 14px;
+  margin: 6px auto;
+  border: 2px solid color-mix(in srgb, currentcolor 35%, transparent);
+  border-top-color: currentcolor;
+  border-radius: var(--radius-full);
+  animation: custodian-history-spin 0.7s linear infinite;
+}
+
+@keyframes custodian-history-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .custodian__history-spinner {
+    animation: none;
+  }
+}
+
 .custodian__change-list {
   display: flex;
   min-height: 0;

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -532,6 +532,29 @@ html.openclaw-native-web-chrome .shell-chrome-controls {
   line-height: 1.45;
 }
 
+.settings-sidebar__loading {
+  padding: 10px 12px;
+}
+
+.settings-sidebar__loading-rows {
+  display: grid;
+  gap: 12px;
+}
+
+.settings-sidebar__loading-row {
+  display: block;
+  width: 82%;
+  height: 12px;
+}
+
+.settings-sidebar__loading-row:nth-child(3n + 2) {
+  width: 68%;
+}
+
+.settings-sidebar__loading-row:nth-child(3n) {
+  width: 74%;
+}
+
 .settings-sidebar__group {
   display: flex;
   flex-direction: column;

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -706,6 +706,45 @@ textarea.settings-input {
   text-align: center;
 }
 
+.settings-loading-skeleton,
+.settings-loading-skeleton__rows {
+  width: 100%;
+}
+
+.settings-loading-skeleton__title,
+.settings-loading-skeleton__description,
+.settings-loading-skeleton__control {
+  display: block;
+}
+
+.settings-loading-skeleton__title {
+  width: min(42%, 220px);
+  height: 14px;
+}
+
+.settings-loading-skeleton__description {
+  width: min(72%, 420px);
+  height: 11px;
+}
+
+.settings-loading-skeleton__row:nth-child(3n + 2) .settings-loading-skeleton__title {
+  width: min(34%, 180px);
+}
+
+.settings-loading-skeleton__row:nth-child(3n) .settings-loading-skeleton__description {
+  width: min(58%, 340px);
+}
+
+.settings-loading-skeleton__control {
+  width: 72px;
+  height: 30px;
+  flex: 0 0 auto;
+}
+
+.settings-loading-skeleton__control--wide {
+  width: 104px;
+}
+
 /* ── Key/value facts (About build info, agent facts) ── */
 
 .settings-kv {


### PR DESCRIPTION
## Summary

- replace page-level settings placeholders that only displayed “Loading…” with shape-matched skeleton rows
- keep the existing Config schema spinner and use a compact spinner when Custodian refreshes already-visible history
- centralize accessible settings skeleton markup and cover every audited state with mocked-Gateway Playwright tests

## Visual proof

Playwright-generated before/after captures were checked for every audited state:

| Surface | Before | After / decision |
| --- | --- | --- |
| Models | centered `Loading…` empty state | three model-setting skeleton rows |
| Channels pairing | bare `Loading…` row | two request-row skeletons |
| Channels schema | `Loading schema…` description | two configuration-row skeletons |
| Secrets | centered `Loading…` empty state | three secret-row skeletons |
| Devices | duplicate summary and empty-state loading copy | one inventory skeleton group |
| MCP settings | `Loading…` div | two server-row skeletons |
| Plugins catalog | `Loading plugins…` div | three plugin-row skeletons |
| Plugins MCP section | `Loading plugins…` div | two server-row skeletons |
| Profile identity | identity loading text | two identity-row skeletons |
| Agent Tools availability | loading empty state | two tool-row skeletons |
| Agent Tools catalog | loading info callout | three catalog-row skeletons |
| Custodian initial history | loading status text | three history-row skeletons |
| Custodian retained-history refresh | loading status text below existing rows | compact spinner; existing content remains visible |
| Approvals history | loading copy inside the empty table | three approval-row skeletons |
| Settings sidebar | centered `Loading…` copy | seven navigation skeletons |
| Config schema | existing animated spinner | spinner preserved unchanged |

The E2E captures the real rendered regions with animations disabled, rejects visible `Loading` copy for skeleton states, verifies compact wrapping at 390px, and explicitly rejects a skeleton on the preserved Config spinner state.

## Validation

- `settings-loading-skeletons.e2e.test.ts`: 16/16 passed with opt-in, per-test Playwright captures on `2c17d59830be3309a2affd9738c3edf4fc758b11`
- focused Devices ordering proof (Gateway presence before inventory) and isolated Custodian spinner capture: passed
- focused OXlint, Stylelint, Oxfmt, and `git diff --check`: passed
- exact-head GitHub validation: 146 checks passed, 0 failed or pending across all five workflows
- structured pre-publish review and exact-head ClawSweeper review: no findings; no unresolved review threads
