### PR TITLE
fix(ui): keep mock preview avatars off the operator Gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,6 @@ Docs: https://docs.openclaw.ai
 - Provider error handling: reuse prepared or already loaded provider hooks instead of cold-loading plugins during error classification, avoiding long stalls in failure reporting and model fallback.
 - **Session settings:** restore merging of concurrent first writes after a startup optimization regressed lock ordering, preserving both global and project settings without adding filesystem side effects to missing-settings reads. Thanks @MrSwagatRathod, @obviyus, and @yetval for the original fix.
 - **Control UI startup and history:** reduce configuration-schema construction and skip full-text duplicate comparisons for distinct transcript messages, preserving plugin hints, redaction, and message identity.
-- **Control UI mock preview:** keep synthetic avatar requests on the preview origin instead of contacting the operator Gateway.
 - **Docker source builds:** include the shared package lifecycle module before dependency installation so production and cleanup smoke images build with lifecycle checks enabled.
 - **Subagent completion:** recognize visible final answers delivered to internal and nested parent sessions, preventing false delivery failures while preserving external channel delivery checks.
 - Codex/Linux: wait for a live app-server process to expose its startup command line within the existing inspection deadline, preserving process identity checks and preventing intermittent startup failures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Docs: https://docs.openclaw.ai
 - Provider error handling: reuse prepared or already loaded provider hooks instead of cold-loading plugins during error classification, avoiding long stalls in failure reporting and model fallback.
 - **Session settings:** restore merging of concurrent first writes after a startup optimization regressed lock ordering, preserving both global and project settings without adding filesystem side effects to missing-settings reads. Thanks @MrSwagatRathod, @obviyus, and @yetval for the original fix.
 - **Control UI startup and history:** reduce configuration-schema construction and skip full-text duplicate comparisons for distinct transcript messages, preserving plugin hints, redaction, and message identity.
+- **Control UI mock preview:** keep synthetic avatar requests on the preview origin instead of contacting the operator Gateway.
 - **Docker source builds:** include the shared package lifecycle module before dependency installation so production and cleanup smoke images build with lifecycle checks enabled.
 - **Subagent completion:** recognize visible final answers delivered to internal and nested parent sessions, preventing false delivery failures while preserving external channel delivery checks.
 - Codex/Linux: wait for a live app-server process to expose its startup command line within the existing inspection deadline, preserving process identity checks and preventing intermittent startup failures.

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -968,6 +968,15 @@ pnpm ui:dev
 
 Then point the UI at your Gateway WS URL (e.g. `ws://127.0.0.1:18789`).
 
+For a standalone preview with synthetic data, use:
+
+```bash
+pnpm dev:ui:mock -- --port 19321
+```
+
+The mock preview selects its own origin for Gateway resources, including
+avatars, so those requests stay on the preview server.
+
 ## Blank Control UI page
 
 If the browser loads a blank dashboard and DevTools shows no useful error, an extension or early content script may have prevented the JavaScript module app from evaluating. The static page includes a plain HTML recovery panel that appears when `<openclaw-app>` does not complete its first render after startup.

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -3107,22 +3107,24 @@ function installControlUiStatefulMocks(
   custodianReplyDelayMs: number,
   chatReplyDelayMs: number,
 ): void {
-  // The WebSocket mock does not intercept HTTP. Bind startup to this preview
-  // before Vite's default Gateway URL can send synthetic avatars to port 18789.
-  const gatewayUrl = new URL(window.location.origin);
-  gatewayUrl.protocol = gatewayUrl.protocol === "https:" ? "wss:" : "ws:";
-  window.__OPENCLAW_NATIVE_CONTROL_AUTH__ = { gatewayUrl: gatewayUrl.origin };
-
   type MockGatewayControls = {
     deferNext: (method: string) => void;
     emit: (event: string, payload: unknown) => void;
     resolveDeferred: (method: string, payload: unknown) => void;
   };
   type MockWindow = Window & {
+    __OPENCLAW_NATIVE_CONTROL_AUTH__?: { gatewayUrl: string };
     openclawControlUiE2eGateway?: MockGatewayControls;
   };
 
-  const gateway = (window as MockWindow).openclawControlUiE2eGateway;
+  const mockWindow = window as MockWindow;
+  // The WebSocket mock does not intercept HTTP. Bind startup to this preview
+  // before Vite's default Gateway URL can send synthetic avatars to port 18789.
+  const gatewayUrl = new URL(window.location.origin);
+  gatewayUrl.protocol = gatewayUrl.protocol === "https:" ? "wss:" : "ws:";
+  mockWindow["__OPENCLAW_NATIVE_CONTROL_AUTH__"] = { gatewayUrl: gatewayUrl.origin };
+
+  const gateway = mockWindow.openclawControlUiE2eGateway;
   const MockWebSocket = window.WebSocket;
   if (!gateway || !MockWebSocket) {
     return;

--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -3107,6 +3107,12 @@ function installControlUiStatefulMocks(
   custodianReplyDelayMs: number,
   chatReplyDelayMs: number,
 ): void {
+  // The WebSocket mock does not intercept HTTP. Bind startup to this preview
+  // before Vite's default Gateway URL can send synthetic avatars to port 18789.
+  const gatewayUrl = new URL(window.location.origin);
+  gatewayUrl.protocol = gatewayUrl.protocol === "https:" ? "wss:" : "ws:";
+  window.__OPENCLAW_NATIVE_CONTROL_AUTH__ = { gatewayUrl: gatewayUrl.origin };
+
   type MockGatewayControls = {
     deferNext: (method: string) => void;
     emit: (event: string, payload: unknown) => void;

--- a/ui/src/e2e/board-fixture.e2e.test.ts
+++ b/ui/src/e2e/board-fixture.e2e.test.ts
@@ -166,6 +166,45 @@ describeStandaloneMockServer("standalone Control UI mock server", () => {
     await stopFixtureServer(fixtureServer);
   });
 
+  it("keeps synthetic avatar requests on the preview origin across reloads", async () => {
+    const context = await browser.newContext();
+    const previewOrigin = new URL(fixtureServer.url).origin;
+    const externalRequests: string[] = [];
+    const avatarRequests: string[] = [];
+    try {
+      // A failing regression must never reach a developer's real Gateway.
+      await context.route("**/*", (route) => {
+        const url = route.request().url();
+        if (new URL(url).origin !== previewOrigin) {
+          externalRequests.push(url);
+          return route.abort();
+        }
+        return route.continue();
+      });
+      const page = await context.newPage();
+      page.on("request", (request) => {
+        if (new URL(request.url()).pathname === "/api/users/presence-riley/avatar") {
+          avatarRequests.push(request.url());
+        }
+      });
+      await page.goto(`${previewOrigin}/chat/main?skillLibrary=collaborator&nav=collapsed`);
+      for (const reload of [false, true]) {
+        if (reload) {
+          avatarRequests.length = 0;
+          await page.reload();
+        }
+        await page.getByRole("textbox", { name: "Message Molty" }).waitFor();
+        await expect.poll(() => avatarRequests.length).toBeGreaterThan(0);
+        expect([...new Set(avatarRequests.map((url) => new URL(url).origin))]).toEqual([
+          previewOrigin,
+        ]);
+        expect(externalRequests).toEqual([]);
+      }
+    } finally {
+      await context.close();
+    }
+  });
+
   for (const mode of ["dark", "light"] as const) {
     it(`themes dropdown items and widget frames in ${mode} mode`, async () => {
       const context = await browser.newContext({ colorScheme: mode });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where opening the standalone Control UI mock preview at `/chat/main?skillLibrary=collaborator&nav=collapsed` sends synthetic user-avatar requests to the operator Gateway on port 18789.

## Why This Change Was Made

The preview replaced WebSocket traffic but left the app using Vite's default Gateway URL. The production avatar resolver correctly used that selected Gateway for HTTP requests. The standalone initializer now supplies the preview origin through the existing one-shot startup handoff before the app connects. Production avatar trust, authentication, and cross-origin behavior remain unchanged; no consumer error handling or browser checks are relaxed.

## User Impact

Developers can preview synthetic chat data without sending avatar requests to their operator Gateway. The preview keeps its existing image fallback for fixture users without an image. The real Gateway was neither started nor stopped, and its state and credentials were not inspected.

## Evidence

- Regression reproduced before the repair: the new actual-server browser test expected the allocated preview origin but observed `http://127.0.0.1:18789`. Its external-request guard records and rejects every off-origin request so a regression cannot reach an operator Gateway.
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/board-fixture.e2e.test.ts`: all 7 tests passed, including nonempty avatar traffic and zero off-origin HTTP requests on cold load and reload, plus board themes, catalog navigation, startup, and chat sending.
- `node scripts/run-vitest.mjs ui/src/lib/identity-avatar.test.ts ui/src/app/settings.node.test.ts ui/src/app/bootstrap.gateway-credentials.test.ts ui/src/test-helpers/control-ui-e2e.mock-gateway.test.ts`: 69 tests passed, preserving production origin trust, settings defaults, credential scoping, and mock WebSocket behavior.
- Live browser replay on port 19321: before, `/api/users/presence-riley/avatar` targeted `localhost:18789` (blocked only during reproduction to protect the operator Gateway); after, GETs target `localhost:19321` with normal browser networking. The local Vite HTML fallback is rejected by the existing avatar MIME validation, retaining the existing visual fallback.
- Initial CI caught a missing script-local `Window` property declaration and its property-access lint style; both were corrected in the preview initializer. Script typecheck and targeted lint passed, and the cold-load/reload browser regression passed again.
- Codex autoreview: no accepted/actionable findings at its default P0 scope.
- LOC: production runtime +0; preview tooling net +8; focused browser test +39; docs +9. The eight net tooling lines establish the previously missing startup-origin boundary using an existing handoff; no new configuration, dependency, or compatibility path.

Before (synthetic preview):

![Before: synthetic chat preview](https://github.com/user-attachments/assets/9b19b574-6e1c-46bf-a34c-f505ee7b45cf)

After (same preview, avatar traffic stays on port 19321):

![After: isolated synthetic chat preview](https://github.com/user-attachments/assets/fe543ad1-7b65-49da-b009-556dfd6bef17)

Release-note context: Control UI mock previews keep synthetic avatar requests on the preview origin instead of contacting the operator Gateway. Root `CHANGELOG.md` is left to the release workflow, as required by native prepare.
