### PR TITLE
fix(test): preserve shard crash exit codes and failure reports

### DIFF
--- a/scripts/test-projects.mts
+++ b/scripts/test-projects.mts
@@ -117,12 +117,12 @@ function runPnpmSpecCommand(spec: VitestRunSpec, pnpmArgs: string[], workerRun?:
 
     completion.then(
       ({ code, signal }) => {
-        const forwardedSignal = getForwardedSignal();
-        if (forwardedSignal) {
-          resolve({ code: 143, noOutputTimedOut, signal: forwardedSignal });
-          return;
-        }
-        resolve({ code: code ?? (signal ? 143 : 1), noOutputTimedOut, signal });
+        const exitSignal = getForwardedSignal() ?? signal;
+        resolve({
+          code: exitSignal ? signalExitCode(exitSignal) : (code ?? 1),
+          noOutputTimedOut,
+          signal: exitSignal,
+        });
       },
       (error: unknown) => {
         reject(error instanceof Error ? error : new Error(String(error)));

--- a/test/scripts/vitest-report-fixture.ts
+++ b/test/scripts/vitest-report-fixture.ts
@@ -87,7 +87,12 @@ export function createVitestReportFixture(root: string, evidence = path.join(roo
 
   return async (
     mode: ReportFixtureMode,
-    options: { nativeArgs?: string[]; entry?: "projects" | "batch-cli"; report?: boolean } = {},
+    options: {
+      nativeArgs?: string[];
+      entry?: "projects" | "batch-cli";
+      report?: boolean;
+      crashSignal?: "SIGABRT" | "SIGKILL";
+    } = {},
   ) => {
     const deadline = performance.now() + 45000;
     const output = path.join(evidence, "result.json");
@@ -99,6 +104,7 @@ export function createVitestReportFixture(root: string, evidence = path.join(roo
       const prelude = `import fs from 'node:fs';
 ${mode === "teardown-timeout" && index === 0 ? "setInterval(()=>{},1000);" : ""}
 const merging = process.argv.includes('--mergeReports');
+${options.crashSignal && index === 0 ? `if(!merging){process.kill(process.pid,${JSON.stringify(options.crashSignal)});await new Promise(()=>setInterval(()=>{},1000));}` : ""}
 const output = process.argv.find(arg => arg.startsWith('--outputFile.json='))?.slice('--outputFile.json='.length);
 ${mode === "coverage-missing" && index === 0 ? `if(!merging)process.once('exit',()=>{const dir=process.argv.find(arg=>arg.startsWith('--coverage.reportsDirectory='))?.split('=').slice(1).join('=');if(dir&&fs.existsSync(dir+'/lcov.info')){fs.copyFileSync(dir+'/lcov.info',dir+'/lcov.info.native-original');fs.unlinkSync(dir+'/lcov.info');}});` : ""}
 ${mode === "merge-failure" ? `if(merging)throw new Error('owned native merge failure');` : ""}

--- a/test/scripts/vitest-report-owner.test.ts
+++ b/test/scripts/vitest-report-owner.test.ts
@@ -25,6 +25,39 @@ describe.skipIf(process.platform === "win32")("native multi-invocation report ow
   const run = (mode: ReportFixtureMode) => createVitestReportFixture(dirs.make("oc-report-"))(mode);
 
   it.each([
+    ["serial", "projects", false, "SIGABRT", 134],
+    ["parallel", "projects", false, "SIGABRT", 134],
+    ["serial", undefined, false, "SIGABRT", 134],
+    ["parallel", undefined, false, "SIGABRT", 134],
+    ["serial", "projects", true, "SIGABRT", 134],
+    ["parallel", "projects", true, "SIGABRT", 134],
+    ["parallel", "projects", true, "SIGKILL", 137],
+  ] as const)(
+    "preserves shard crashes: %s entry=%s report=%s signal=%s",
+    { timeout: 60000 },
+    async (mode, entry, report, crashSignal, exitCode) => {
+      const result = await createVitestReportFixture(dirs.make("oc-report-crash-"))(mode, {
+        entry,
+        report,
+        crashSignal,
+      });
+      expect(result.code !== 0 || result.signal !== null, result.stderr).toBe(true);
+      expect(result.signal === crashSignal || result.code === exitCode, result.stderr).toBe(true);
+      expect(result.stderr).not.toMatch(/\[test\] passed /u);
+      expect(result.stderr.trimEnd().split("\n").at(-1)).toBe(`[test] FAILED (exit ${exitCode})`);
+      if (report) {
+        const index = json(path.join(result.reportSet!, "index.json"));
+        expect(index.complete).toBe(false);
+        expect(index.entries[0].attempts[0].outcome).toMatchObject({
+          code: exitCode,
+          signal: crashSignal,
+        });
+        expect(fs.existsSync(result.output)).toBe(false);
+      }
+    },
+  );
+
+  it.each([
     "serial",
     "parallel",
     "batch",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a Vitest shard killed by SIGABRT or SIGKILL was recorded as exit 143 in the test wrapper's failure digest and retained report index.

This follows a report that an OOM during `pnpm test src/commands` printed `passed 2 Vitest shards` and exited zero. Current main already removed that historical signal-loss path in #133309 and #132716. This PR corrects the remaining result mismatch and adds real-process regression coverage for the original false-success contract.

## Why This Change Was Made

Normalize the effective forwarded or child signal once at the shard completion boundary using the existing `signalExitCode` helper. The scheduler, report owner, and failure digest now receive the same nonzero signal-derived code. Ordinary numeric exits retain their existing behavior.

Production/tooling LOC: +6/-6. Test and fixture LOC: +40/-1. No new production API, option, dependency, or fallback.

## User Impact

Test-wrapper failure evidence accurately records SIGABRT as 134 and SIGKILL as 137. Regression tests require both serial and parallel crashes to fail, omit a passing summary, and end with a failure trailer through the project runner and JavaScript wrapper.

## Evidence

- Before the change: the new seven-case crash matrix had four passing cases and three failures because reports recorded 143 instead of 134/137.
- After the change: 15 focused crash, success, ordinary failure, and cancellation cases passed:
  `node scripts/run-vitest.mjs test/scripts/vitest-report-owner.test.ts -t 'preserves shard crashes|retains the exact case union.*serial|retains the exact case union.*parallel|publishes complete evidence.*failure|never publishes incomplete.*cancel'`
- Manual real OOM proof: a child launched at the Vitest process boundary with `--max-old-space-size=16` exhausted its heap during the `src/commands` runner flow. The fatal V8 OOM remained visible; the runner exited 134 and its final stderr line was `[test] FAILED (exit 134)`.
- Fresh Codex autoreview completed with no accepted/actionable findings at its default P0 threshold. Formatting and `git diff --check` passed. Changed-file validation passed on Blacksmith Testbox `tbx_01m1de6770rh777tz9etkp3zks`, [Actions run 33464239543](https://github.com/openclaw/openclaw/actions/runs/33464239543); the one-shot lease stopped successfully. [Exact-head hosted CI 33464291816](https://github.com/openclaw/openclaw/actions/runs/33464291816) passed at `95bf5027ea570cb42425253f9c5ba77889290497`.
- Dependency contract: Node's child-process exit event reports a null code and a signal on signal termination: https://nodejs.org/api/child_process.html#event-exit.

The crash tests use real Vitest processes and synthetic temporary configs, with no production test seam. POSIX signal assertions are skipped on Windows. This does not diagnose or fix the original command-suite heap growth.

Follow-up identified during sibling inspection: the plugin batch runner separately records `code ?? 1` for signaled report outcomes. Its owner still propagates termination and rejects incomplete reports; normalizing those report codes belongs with its own batch/trailer coverage.
