### PR TITLE
fix(macos): computer input no longer fails after execution

### DIFF
--- a/apps/macos/Sources/OpenClaw/ComputerActionService.swift
+++ b/apps/macos/Sources/OpenClaw/ComputerActionService.swift
@@ -585,7 +585,7 @@ final class ComputerActionService {
                 guard let self else { throw CancellationError() }
                 try self.executionQueue.checkExecutionAllowed(lifecycleGeneration: generation)
             }
-            return OpenClawComputerActResult(ok: true, cursorX: 0, cursorY: 0)
+            return OpenClawComputerActResult(ok: true)
         }
     }
     #endif

--- a/apps/macos/Sources/OpenClaw/ComputerScreenActionExecutor.swift
+++ b/apps/macos/Sources/OpenClaw/ComputerScreenActionExecutor.swift
@@ -116,8 +116,7 @@ final class ComputerScreenActionExecutor {
             display: display,
             checkExecutionAllowed: checkExecutionAllowed)
         try checkExecutionAllowed()
-        let cursor = self.automation.currentMouseLocation() ?? CGPoint.zero
-        return OpenClawComputerActResult(ok: true, cursorX: cursor.x, cursorY: cursor.y)
+        return OpenClawComputerActResult(ok: true)
     }
 
     // MARK: - Dispatch

--- a/apps/macos/Tests/OpenClawIPCTests/ComputerActionServiceTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ComputerActionServiceTests.swift
@@ -57,7 +57,7 @@ struct ComputerActionServiceTests {
                 await self.releaseFirst.wait()
             }
             try Task.checkCancellation()
-            return OpenClawComputerActResult(ok: true, cursorX: Double(actionID), cursorY: 0)
+            return OpenClawComputerActResult(ok: true)
         }
     }
 
@@ -581,7 +581,7 @@ struct ComputerActionServiceTests {
         let action = Task { @MainActor in
             try await queue.perform(params, lifecycleGeneration: 0) { _, _ in
                 taskBox.task?.cancel()
-                return OpenClawComputerActResult(ok: true, cursorX: 1, cursorY: 0)
+                return OpenClawComputerActResult(ok: true)
             }
         }
         taskBox.task = action

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -660,12 +660,10 @@ struct MacNodeRuntimeTests {
         #expect(received?.action == .leftClick)
         #expect(received?.x == 12)
         let payloadJSON = try #require(response.payloadJSON)
-        let payload = try #require(
-            JSONSerialization.jsonObject(with: Data(payloadJSON.utf8)) as? [String: Any])
-        #expect(payload.keys.sorted() == ["ok"])
-        #expect(payload["ok"] as? Bool == true)
         let result = try JSONDecoder().decode(OpenClawComputerActResult.self, from: Data(payloadJSON.utf8))
         #expect(result.ok == true)
+        let object = try #require(JSONSerialization.jsonObject(with: Data(payloadJSON.utf8)) as? [String: Any])
+        #expect(object.keys.sorted() == ["ok"])
     }
 
     @Test func `provider selection owns both snapshot and action without cross-provider fallback`() async throws {

--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeRuntimeTests.swift
@@ -268,7 +268,7 @@ struct MacNodeRuntimeTests {
             if let actError {
                 throw actError
             }
-            return OpenClawComputerActResult(ok: true, cursorX: params.x ?? 0, cursorY: params.y ?? 0)
+            return OpenClawComputerActResult(ok: true)
         }
 
         func releaseHeldInput(lifecycleGeneration: UInt64) async {
@@ -660,9 +660,12 @@ struct MacNodeRuntimeTests {
         #expect(received?.action == .leftClick)
         #expect(received?.x == 12)
         let payloadJSON = try #require(response.payloadJSON)
+        let payload = try #require(
+            JSONSerialization.jsonObject(with: Data(payloadJSON.utf8)) as? [String: Any])
+        #expect(payload.keys.sorted() == ["ok"])
+        #expect(payload["ok"] as? Bool == true)
         let result = try JSONDecoder().decode(OpenClawComputerActResult.self, from: Data(payloadJSON.utf8))
         #expect(result.ok == true)
-        #expect(result.cursorX == 12)
     }
 
     @Test func `provider selection owns both snapshot and action without cross-provider fallback`() async throws {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ComputerCommands.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ComputerCommands.swift
@@ -281,7 +281,7 @@ public struct OpenClawComputerEscalation: Codable, Sendable, Equatable {
     }
 }
 
-/// Result of a `computer.act` input action.
+/// Canonical result of a `computer.act` action.
 public struct OpenClawComputerActResult: Codable, Sendable, Equatable {
     public var ok: Bool
     public var effect: OpenClawComputerActionEffect?

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ComputerCommands.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ComputerCommands.swift
@@ -281,26 +281,13 @@ public struct OpenClawComputerEscalation: Codable, Sendable, Equatable {
     }
 }
 
-/// Result of a `computer.act` input action. Optional v2 fields are omitted for
-/// v1 actions so their existing JSON payload remains byte-for-byte unchanged.
+/// Result of a `computer.act` input action.
 public struct OpenClawComputerActResult: Codable, Sendable, Equatable {
     public var ok: Bool
-    public var cursorX: Double?
-    public var cursorY: Double?
     public var effect: OpenClawComputerActionEffect?
     public var observation: OpenClawComputerObservation?
     public var escalation: OpenClawComputerEscalation?
     public var details: [String: AnyCodable]?
-
-    public init(ok: Bool, cursorX: Double, cursorY: Double) {
-        self.ok = ok
-        self.cursorX = cursorX
-        self.cursorY = cursorY
-        self.effect = nil
-        self.observation = nil
-        self.escalation = nil
-        self.details = nil
-    }
 
     public init(
         ok: Bool,
@@ -310,8 +297,6 @@ public struct OpenClawComputerActResult: Codable, Sendable, Equatable {
         details: [String: AnyCodable]? = nil)
     {
         self.ok = ok
-        self.cursorX = nil
-        self.cursorY = nil
         self.effect = effect
         self.observation = observation
         self.escalation = escalation

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ComputerInputGeometryTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ComputerInputGeometryTests.swift
@@ -271,7 +271,7 @@ struct ComputerInputGeometryTests {
         #expect(holdParams.durationMs == 2000)
     }
 
-    @Test func `successful input result encodes the canonical envelope`() throws {
+    @Test func `input result encoding uses the canonical success envelope`() throws {
         let data = try JSONEncoder().encode(OpenClawComputerActResult(ok: true))
         let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
 

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ComputerInputGeometryTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ComputerInputGeometryTests.swift
@@ -271,17 +271,12 @@ struct ComputerInputGeometryTests {
         #expect(holdParams.durationMs == 2000)
     }
 
-    @Test func `v1 result encoding omits every additive v2 field`() throws {
-        let data = try JSONEncoder().encode(OpenClawComputerActResult(
-            ok: true,
-            cursorX: 12,
-            cursorY: 34))
+    @Test func `successful input result encodes the canonical envelope`() throws {
+        let data = try JSONEncoder().encode(OpenClawComputerActResult(ok: true))
         let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
 
-        #expect(object.keys.sorted() == ["cursorX", "cursorY", "ok"])
+        #expect(object.keys.sorted() == ["ok"])
         #expect(object["ok"] as? Bool == true)
-        #expect(object["cursorX"] as? Double == 12)
-        #expect(object["cursorY"] as? Double == 34)
     }
 
     @Test func `decodes v2 window observation and element delivery fields`() throws {

--- a/src/cli/help-exit.process.test.ts
+++ b/src/cli/help-exit.process.test.ts
@@ -492,8 +492,11 @@ describe("JSON console style process output", () => {
   );
 
   it("preserves structured entry startup tracing across a normal respawn", async () => {
+    // Gateway status skips warning-only respawn. A missing call method exercises
+    // startup respawn without contacting a Gateway.
     const result = await runCliProcess({
-      args: ["gateway", "status"],
+      args: ["gateway", "call"],
+      expectedExitCode: 1,
       allowRespawn: true,
       config: loggingConfig,
       env: { OPENCLAW_GATEWAY_STARTUP_TRACE: "1" },

--- a/src/plugins/computer-use-contract.test.ts
+++ b/src/plugins/computer-use-contract.test.ts
@@ -212,6 +212,13 @@ describe("Computer Use wire contract", () => {
     }
   });
 
+  it("accepts canonical input success and rejects obsolete cursor fields", () => {
+    expect(parseComputerActResult({ ok: true })).toEqual({ ok: true });
+    expect(() => parseComputerActResult({ ok: true, cursorX: 12, cursorY: 34 })).toThrow(
+      "COMPUTER_CONTRACT_MISMATCH",
+    );
+  });
+
   it("caps semantic observations and provider detail records", () => {
     const element = {
       elementRef: "element-1",
@@ -248,12 +255,6 @@ describe("Computer Use wire contract", () => {
         ),
       }),
     ).toThrow("COMPUTER_CONTRACT_MISMATCH");
-  });
-
-  it("rejects the legacy cursor-only action result", () => {
-    expect(() => parseComputerActResult({ ok: true, cursorX: 12, cursorY: 34 })).toThrow(
-      "COMPUTER_CONTRACT_MISMATCH",
-    );
   });
 
   it("validates the bounded node capability descriptor", () => {

--- a/src/plugins/computer-use-contract.test.ts
+++ b/src/plugins/computer-use-contract.test.ts
@@ -250,6 +250,12 @@ describe("Computer Use wire contract", () => {
     ).toThrow("COMPUTER_CONTRACT_MISMATCH");
   });
 
+  it("rejects the legacy cursor-only action result", () => {
+    expect(() => parseComputerActResult({ ok: true, cursorX: 12, cursorY: 34 })).toThrow(
+      "COMPUTER_CONTRACT_MISMATCH",
+    );
+  });
+
   it("validates the bounded node capability descriptor", () => {
     expect(
       parseComputerUseCapabilityDescriptor({


### PR DESCRIPTION
## What Problem This Solves

A macOS screen input action could succeed on the desktop and then report `COMPUTER_CONTRACT_MISMATCH`. The native result included obsolete cursor fields that the strict `computer.act` consumer rejects, so retrying the apparent failure could repeat the input.

## Why This Change Was Made

Return the existing canonical success envelope and remove the obsolete cursor fields/initializer from the native result owner. Native bridge and serialization assertions use that same contract. The shared validator stays strict, and window-action effect, observation, escalation and details fields retain their existing behavior. Production code shrinks by 16 lines.

The first stable release containing this computer-action surface, `v2026.8.1` (`ea806575e6450e4d1efdfc72c19f04be982a1b9b`), already made the Swift cursor fields optional while its TypeScript result schema rejected additional keys. Compiling the unchanged stable Swift decoder against the candidate `{"ok":true}` result succeeds with both optional cursor values absent. The earlier v1 byte-stability comment concerns the pre-stable shape; this repair retains the working stable wire contract. This evidence does not claim source compatibility for unknown third-party Swift initializer callers.

## User Impact

Successful screen input returns `{"ok":true}` to the existing consumer. Input permissions, lifecycle revalidation, provider selection and failure handling retain their existing behavior.

## Evidence

A signed isolated macOS fixture ran the actual screen executor, pinned Peekaboo dependency and shared Swift serializer against a synthetic AppKit window. Its produced JSON was then passed through the actual TypeScript strict decoder:

- Before: typing delivered the text exactly once, and a key press appended one space; both returned results were rejected for their cursor fields.
- After: identical desktop effects, both exact `{"ok":true}` results accepted.
- Empty text, invalid screen index and unsupported action retained their errors and produced no additional input.
- All before/after captures were inspected and contain only the synthetic test window.

This proves the changed screen-executor and result boundary. It does not claim a full paired Gateway or packaged-app run. The existing background-window live rig exercises another executor, so it would not demonstrate this reported screen-input failure. This limitation explicitly addresses the broader paired-flow request in the previous ClawSweeper review.

All 11 TypeScript contract tests and 18 shared Swift geometry/serialization tests passed. Pinned SwiftFormat checked all six touched Swift files, and independent P0 review found no actionable issues. Exact final-head hosted CI remains pending the maintainer publication cycle. Thanks @gaoanze888 for the producer-contract repair.

Fixes #134621

Before: input reached the synthetic window once, but the returned cursor fields made the strict consumer reject success.

![Before: synthetic screen input completed](https://github.com/user-attachments/assets/534b27fe-6479-4489-9ecb-28f5dabffba6)

After: the same desktop effect occurs once and the canonical `{"ok":true}` result is accepted. The matching screenshots are expected; the decoder verdicts above establish the repaired result behavior.

![After: synthetic screen input completed](https://github.com/user-attachments/assets/4cab1d5a-8fc1-410e-a149-bd9a7caf1191)

The same PR also corrects a stale CLI startup-respawn test: `gateway status` intentionally skips warning-only respawn, so the fixture now invokes `gateway call` without its required method and expects argument-validation exit 1. This exercises normal startup respawn without a Gateway RPC and retains the existing trace assertion and deadlines. It changes tests only (+4/-1). The changed case passed on macOS and Linux, the complete changed-file gate passed, and the combined eight-file P0 review found no actionable issue.

This fixture change does not claim to fix the separate 100-second CI help-trace timeout. The macOS candidate whole-file run had 24 passing tests and two unrelated model-list child timeouts. Fixture execution proof used a newer trusted-main CLI cleanup implementation than this branch; final exact-head hosted CI remains required.
