### PR TITLE
refactor(policy): share evidence finding builder

### DIFF
--- a/extensions/policy/src/doctor/data-auth-findings.ts
+++ b/extensions/policy/src/doctor/data-auth-findings.ts
@@ -5,11 +5,11 @@ import { CHECK_IDS } from "./check-ids.js";
 import {
   authProfileAllowModesShapeFindings,
   dataHandlingEntries,
-  dataHandlingFinding,
   dataHandlingLabel,
   dataHandlingPolicyShapeFindings,
   secretPolicyShapeFindings,
 } from "./data-auth-shapes.js";
+import { policyEvidenceFinding } from "./policy-evidence-finding.js";
 import { authProfileHasMetadata, requiredAuthProfileMetadata } from "./policy-runtime.js";
 import {
   agentScopedPolicyTargets,
@@ -116,7 +116,7 @@ function dataHandlingFindingsForRule(
         .filter(evidenceFilter)
         .filter((entry) => entry.value === true)
         .map((entry) =>
-          dataHandlingFinding(entry, {
+          policyEvidenceFinding(entry, {
             checkId: CHECK_IDS.policyDataHandlingTelemetryContentCapture,
             message: "Telemetry content capture is enabled.",
             requirement: `oc://${policyDocName}/${requirementBase}/telemetry/denyContentCapture`,
@@ -131,7 +131,7 @@ function dataHandlingFindingsForRule(
         .filter(evidenceFilter)
         .filter((entry) => entry.value !== "enforce")
         .map((entry) =>
-          dataHandlingFinding(entry, {
+          policyEvidenceFinding(entry, {
             checkId: CHECK_IDS.policyDataHandlingSessionRetentionNotEnforced,
             message: `Session retention maintenance mode is '${entry.value ?? "unknown"}'.`,
             requirement: `oc://${policyDocName}/${requirementBase}/retention/requireSessionMaintenance`,
@@ -146,7 +146,7 @@ function dataHandlingFindingsForRule(
         .filter(evidenceFilter)
         .filter((entry) => entry.value === true)
         .map((entry) =>
-          dataHandlingFinding(entry, {
+          policyEvidenceFinding(entry, {
             checkId: CHECK_IDS.policyDataHandlingSessionTranscriptMemory,
             message: `${dataHandlingLabel(entry)} enables session transcript memory indexing.`,
             requirement: `oc://${policyDocName}/${requirementBase}/memory/denySessionTranscriptIndexing`,

--- a/extensions/policy/src/doctor/data-auth-shapes.ts
+++ b/extensions/policy/src/doctor/data-auth-shapes.ts
@@ -2,7 +2,6 @@ import type { HealthFinding } from "openclaw/plugin-sdk/health";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { PolicyDataHandlingEvidence, PolicyEvidence } from "../policy-state.js";
 import { getPolicyPath } from "../policy-value.js";
-import { POLICY_CHECK_IDS } from "./check-ids.js";
 import { SUPPORTED_AUTH_PROFILE_MODES } from "./policy-constants.js";
 import { policyShapeFinding, unsupportedPolicyKey } from "./shape-helpers.js";
 import { ocPathSegment } from "./utils.js";
@@ -176,28 +175,6 @@ export function dataHandlingEntries(
   kind: PolicyDataHandlingEvidence["kind"],
 ): readonly PolicyDataHandlingEvidence[] {
   return (evidence.dataHandling ?? []).filter((entry) => entry.kind === kind);
-}
-
-export function dataHandlingFinding(
-  entry: PolicyDataHandlingEvidence,
-  params: {
-    readonly checkId: (typeof POLICY_CHECK_IDS)[number];
-    readonly message: string;
-    readonly requirement: string;
-    readonly fixHint: string;
-  },
-): HealthFinding {
-  return {
-    checkId: params.checkId,
-    severity: "error",
-    message: params.message,
-    source: "policy",
-    path: "openclaw config",
-    ocPath: entry.source,
-    target: entry.source,
-    requirement: params.requirement,
-    fixHint: params.fixHint,
-  };
 }
 
 export function dataHandlingLabel(entry: PolicyDataHandlingEvidence): string {

--- a/extensions/policy/src/doctor/ingress-findings.ts
+++ b/extensions/policy/src/doctor/ingress-findings.ts
@@ -2,7 +2,8 @@ import type { HealthFinding } from "openclaw/plugin-sdk/health";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { PolicyEvidence, PolicyIngressEvidence } from "../policy-state.js";
 import { ingressPolicyShapeFinding } from "./access-shapes.js";
-import { CHECK_IDS, POLICY_CHECK_IDS } from "./check-ids.js";
+import { CHECK_IDS } from "./check-ids.js";
+import { policyEvidenceFinding as ingressFinding } from "./policy-evidence-finding.js";
 import { normalizePolicyChannelId } from "./policy-runtime.js";
 import { channelScopedPolicyTargets } from "./policy-scope.js";
 import { hasValidScopedPolicy } from "./scoped-policy-shape.js";
@@ -234,28 +235,6 @@ function scopedIngressChannelMatches(
   policyChannelId: string,
 ): boolean {
   return normalizePolicyChannelId(entry.channel ?? "") === policyChannelId;
-}
-
-function ingressFinding(
-  entry: PolicyIngressEvidence,
-  params: {
-    readonly checkId: (typeof POLICY_CHECK_IDS)[number];
-    readonly message: string;
-    readonly requirement: string;
-    readonly fixHint: string;
-  },
-): HealthFinding {
-  return {
-    checkId: params.checkId,
-    severity: "error",
-    message: params.message,
-    source: "policy",
-    path: "openclaw config",
-    ocPath: entry.source,
-    target: entry.source,
-    requirement: params.requirement,
-    fixHint: params.fixHint,
-  };
 }
 
 function ingressLabel(entry: PolicyIngressEvidence): string {

--- a/extensions/policy/src/doctor/policy-evidence-finding.ts
+++ b/extensions/policy/src/doctor/policy-evidence-finding.ts
@@ -1,0 +1,24 @@
+import type { HealthFinding } from "openclaw/plugin-sdk/health";
+import { POLICY_CHECK_IDS } from "./check-ids.js";
+
+export function policyEvidenceFinding(
+  entry: { readonly source: string },
+  params: {
+    readonly checkId: (typeof POLICY_CHECK_IDS)[number];
+    readonly message: string;
+    readonly requirement: string;
+    readonly fixHint: string;
+  },
+): HealthFinding {
+  return {
+    checkId: params.checkId,
+    severity: "error",
+    message: params.message,
+    source: "policy",
+    path: "openclaw config",
+    ocPath: entry.source,
+    target: entry.source,
+    requirement: params.requirement,
+    fixHint: params.fixHint,
+  };
+}

--- a/extensions/policy/src/doctor/sandbox-findings.ts
+++ b/extensions/policy/src/doctor/sandbox-findings.ts
@@ -1,8 +1,9 @@
 import type { HealthFinding } from "openclaw/plugin-sdk/health";
 import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { PolicyEvidence, PolicySandboxPostureEvidence } from "../policy-state.js";
-import { CHECK_IDS, POLICY_CHECK_IDS } from "./check-ids.js";
+import { CHECK_IDS } from "./check-ids.js";
 import { SANDBOX_CONTAINER_POLICY_RULES } from "./metadata.js";
+import { policyEvidenceFinding as sandboxPostureFinding } from "./policy-evidence-finding.js";
 import { agentScopedPolicyTargets, scopedAgentIdMatches } from "./policy-scope.js";
 import { sandboxPolicyShapeFinding } from "./sandbox-gateway-shapes.js";
 import { hasValidScopedPolicy } from "./scoped-policy-shape.js";
@@ -450,28 +451,6 @@ function sandboxPostureEntries(
   kind: PolicySandboxPostureEvidence["kind"],
 ): readonly PolicySandboxPostureEvidence[] {
   return (evidence.sandboxPosture ?? []).filter((entry) => entry.kind === kind);
-}
-
-function sandboxPostureFinding(
-  entry: PolicySandboxPostureEvidence,
-  params: {
-    readonly checkId: (typeof POLICY_CHECK_IDS)[number];
-    readonly message: string;
-    readonly requirement: string;
-    readonly fixHint: string;
-  },
-): HealthFinding {
-  return {
-    checkId: params.checkId,
-    severity: "error",
-    message: params.message,
-    source: "policy",
-    path: "openclaw config",
-    ocPath: entry.source,
-    target: entry.source,
-    requirement: params.requirement,
-    fixHint: params.fixHint,
-  };
 }
 
 function sandboxPostureLabel(entry: PolicySandboxPostureEvidence): string {

--- a/extensions/policy/src/doctor/tool-findings.ts
+++ b/extensions/policy/src/doctor/tool-findings.ts
@@ -5,6 +5,7 @@ import { expandPolicyToolRequirement, toolListCoversTool } from "../tool-policy-
 import { toolPosturePolicyShapeFinding } from "./agent-tool-shapes.js";
 import { CHECK_IDS, POLICY_CHECK_IDS } from "./check-ids.js";
 import { KNOWN_RISK_LEVELS, KNOWN_SENSITIVITY_LEVELS } from "./policy-constants.js";
+import { policyEvidenceFinding as toolPostureFinding } from "./policy-evidence-finding.js";
 import { agentScopedPolicyTargets, scopedToolAgentMatches } from "./policy-scope.js";
 import { hasValidScopedPolicy } from "./scoped-policy-shape.js";
 import { ocPathSegment, readPolicyBoolean, readStringList } from "./utils.js";
@@ -324,28 +325,6 @@ function toolPostureEntries(
   kind: PolicyToolPostureEvidence["kind"],
 ): readonly PolicyToolPostureEvidence[] {
   return (evidence.toolPosture ?? []).filter((entry) => entry.kind === kind);
-}
-
-function toolPostureFinding(
-  entry: PolicyToolPostureEvidence,
-  params: {
-    readonly checkId: (typeof POLICY_CHECK_IDS)[number];
-    readonly message: string;
-    readonly requirement: string;
-    readonly fixHint: string;
-  },
-): HealthFinding {
-  return {
-    checkId: params.checkId,
-    severity: "error",
-    message: params.message,
-    source: "policy",
-    path: "openclaw config",
-    ocPath: entry.source,
-    target: entry.source,
-    requirement: params.requirement,
-    fixHint: params.fixHint,
-  };
 }
 
 function toolPostureLabel(entry: PolicyToolPostureEvidence): string {


### PR DESCRIPTION
Related: #118516
Related: #101916

## What Problem This Solves

The Policy doctor had four byte-identical evidence finding builders spread across data handling, ingress, sandbox, and tool posture modules. That duplication made the shared finding contract easier to drift during the ongoing Policy doctor work overlapping #118516 and #101916.

## Why This Change Was Made

The Policy plugin now owns that repeated construction in one private `policyEvidenceFinding` helper. The July 13, 2026 doctor evaluator split in `d8fb5b404ea` moved the same builder into four domain modules; this change removes those four copies and moves the sole internal data-handling consumer to the canonical helper.

The helper preserves exactly `checkId`, `severity`, `message`, `source`, `path`, `ocPath`, `target`, `requirement`, and `fixHint`. Non-identical builders, including exec approval findings, remain untouched.

Architectural owner: Policy doctor evidence finding construction.

Production LOC: +33/-95 (net -62). Tests: +0/-0.

## User Impact

No user-visible behavior changes. Policy doctor findings retain the same identifiers, severity, messages, paths, targets, requirements, and fix hints while the implementation has one canonical owner.

## Evidence

- `node scripts/run-vitest.mjs extensions/policy/src/doctor/register.test.ts --reporter=dot` - 303 passed on the exact rebased head.
- `pnpm check:import-cycles` - 0 runtime value cycles.
- `node scripts/check-changed.mjs --dry-run -- <six changed paths>` - classified all six files as Policy extension production and selected the extension/extension-test lane.
- `node scripts/check-changed.mjs --timed -- <six changed paths>` - passed conflict, ratchet, formatting, doctor closure, boundary, patch, and dependency guards; stopped at extension typecheck on unrelated Telegram/`grammy` type errors from the shared local install.
- `pnpm build` - all TypeScript, package, plugin, runtime, and SDK declaration phases passed; the final UI phase first exposed sparse-checkout omissions, then stopped on the shared local install's CommonJS `pako` export mismatch.
- `crabbox job run testbox-changed` - passed on Blacksmith Testbox Linux/Node 24, provider `blacksmith-testbox`, lease `tbx_01m1de8qzr5456n958dvr900xf`, Actions run `33464321637`; remote `check:changed` exited 0 in 17m33.9s and the lease stopped cleanly.
- Native Windows proof gap: the repo-local `testbox-changed` job targets Linux and no native Windows job is selected for these platform-neutral Policy doctor files.
- Exact pinned autoreview: `gpt-5.6-sol`, high reasoning, local patch against the pinned merge base - clean, no accepted/actionable findings, correctness 0.99.
- Deslop audit - no functional or style cleanup required.
- `git diff --check` - passed.
- Stable patch ID before/after rebase matched: `c93761aa1fa41f24083c7079c51b6ed75f2b934c`.
- Signed head: `82ceaf510d745d23e03434fbe454ab60aa63cfee`.

Sibling coverage: data handling, ingress, sandbox posture, and tool posture all use the helper; the non-identical exec approval builder remains separate.

Codex source contract checked directly in `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`; those CLI parsing/completion surfaces do not affect this private TypeScript refactor.
