### PR TITLE
refactor: reuse selected auth snapshot paths

### DIFF
--- a/src/agents/auth-profiles.sqlite-store.test.ts
+++ b/src/agents/auth-profiles.sqlite-store.test.ts
@@ -8,6 +8,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as kyselySync from "../infra/kysely-sync.js";
 import * as nodeSqlite from "../infra/node-sqlite.js";
@@ -23,11 +24,13 @@ import {
 } from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
-import { withEnvAsync } from "../test-utils/env.js";
+import { withEnv, withEnvAsync } from "../test-utils/env.js";
 import { resolveAgentDir } from "./agent-scope.js";
+import * as authProfileClone from "./auth-profiles/clone.js";
 import { loadPersistedAuthProfileStore } from "./auth-profiles/persisted.js";
 import {
   clearRuntimeAuthProfileStoreSnapshots,
+  getRuntimeAuthProfileStoreSnapshotCore,
   replaceRuntimeAuthProfileStoreSnapshots,
 } from "./auth-profiles/runtime-snapshots.js";
 import {
@@ -40,6 +43,7 @@ import {
 } from "./auth-profiles/sqlite.js";
 import {
   ensureAuthProfileStore,
+  ensureAuthProfileStoreWithoutExternalProfiles,
   getRuntimeAuthProfileStoreSnapshotRevision,
   saveAuthProfileStore,
 } from "./auth-profiles/store.js";
@@ -726,6 +730,68 @@ describe("auth profile sqlite store", () => {
         path: resolveAuthProfileDatabasePath(agentDir),
       });
       expect(database.agentId).toBe("coder");
+    });
+  });
+
+  it("resolves database filenames without reverse-owner filesystem discovery", async () => {
+    await withAgentDirEnv("openclaw-auth-filename-", (agentDir, stateDir) => {
+      const alias = path.join(stateDir, "agent-alias");
+      const missing = path.join(stateDir, "missing", "agent");
+      fs.symlinkSync(agentDir, alias, "junction");
+      withEnv({ OPENCLAW_HOME: stateDir }, () => {
+        const databasePath = path.join(agentDir, "openclaw-agent.sqlite");
+        expect(resolveAuthProfileDatabasePath("")).toBe(databasePath);
+        const realpath = vi.spyOn(fs.realpathSync, "native");
+        try {
+          for (const [input, expected] of [
+            [agentDir, databasePath],
+            [path.relative(process.cwd(), agentDir), databasePath],
+            ["~/agents/main/agent", databasePath],
+            [alias, path.join(alias, "openclaw-agent.sqlite")],
+            [missing, path.join(missing, "openclaw-agent.sqlite")],
+            ["", databasePath],
+            ["  ", "openclaw-agent.sqlite"],
+          ] as const) {
+            expect(resolveAuthProfileDatabasePath(input)).toBe(expected);
+          }
+          expect(realpath).not.toHaveBeenCalled();
+          expect(fs.existsSync(missing)).toBe(false);
+        } finally {
+          realpath.mockRestore();
+        }
+      });
+    });
+  });
+
+  it("does not copy an unused same-owner snapshot during runtime reads", async () => {
+    await withAgentDirEnv("openclaw-auth-snapshot-work-", (agentDir) => {
+      const store = { ...apiKeyStore("synthetic"), order: { openai: ["openai:default"] } };
+      replaceRuntimeAuthProfileStoreSnapshots([{ agentDir, store }]);
+      const clone = vi.spyOn(authProfileClone, "cloneAuthProfileStore");
+      try {
+        const loaded = ensureAuthProfileStoreWithoutExternalProfiles(agentDir);
+        expect(loaded).toMatchObject(store);
+        expect(clone.mock.calls.length).toBeLessThanOrEqual(2);
+        expectDefined(loaded.order?.openai, "loaded profile order").push("mutated");
+        expect(getRuntimeAuthProfileStoreSnapshotCore(agentDir)?.order?.openai).toEqual([
+          "openai:default",
+        ]);
+      } finally {
+        clone.mockRestore();
+      }
+    });
+  });
+
+  it("keeps an explicit inherited snapshot authoritative for an omitted agent", async () => {
+    await withAgentDirEnv("openclaw-auth-inherited-selection-", (agentDir, stateDir) => {
+      const inheritedAuthDir = path.join(stateDir, "inherited");
+      replaceRuntimeAuthProfileStoreSnapshots([
+        { agentDir, store: apiKeyStore("shared") },
+        { agentDir: inheritedAuthDir, store: apiKeyStore("inherited") },
+      ]);
+      expect(
+        ensureAuthProfileStoreWithoutExternalProfiles(undefined, { inheritedAuthDir }).profiles,
+      ).toEqual(apiKeyStore("inherited").profiles);
     });
   });
 

--- a/src/agents/auth-profiles/runtime-snapshots.test.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.test.ts
@@ -6,6 +6,7 @@
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
+import * as authProfileClone from "./clone.js";
 import {
   getPreparedRuntimeAuthMaterializations,
   recordRuntimeAuthMaterialization,
@@ -397,6 +398,48 @@ describe("runtime auth profile snapshots", () => {
       clearRuntimeAuthProfileStoreSnapshots();
     }
   });
+
+  it("copies a prepared same-owner snapshot only once and keeps the result isolated", () => {
+    const agentDir = "/tmp/openclaw-auth-prepared-same-owner";
+    const store = createStore("prepared");
+    setRuntimeAuthProfileStoreSnapshot(store, agentDir);
+    const clone = vi.spyOn(authProfileClone, "cloneAuthProfileStore");
+    try {
+      const prepared = expectDefined(
+        getPreparedRuntimeAuthProfileStoreSnapshotCore(agentDir, agentDir),
+        "prepared same-owner snapshot",
+      );
+      expect(prepared).toMatchObject(store);
+      expect(clone.mock.calls.length).toBeLessThanOrEqual(1);
+      expectDefined(prepared.order?.openai, "prepared profile order").push("mutated");
+      expect(getRuntimeAuthProfileStoreSnapshotCore(agentDir)?.order?.openai).toEqual([
+        "openai:default",
+      ]);
+    } finally {
+      clone.mockRestore();
+      clearRuntimeAuthProfileStoreSnapshots();
+    }
+  });
+
+  it.each(["present", "empty", "missing"] as const)(
+    "resolves omitted-agent preparation with a %s shared snapshot",
+    (shared) => {
+      const inheritedAuthDir = "/tmp/openclaw-auth-prepared-omitted-agent";
+      const inherited = createStore("inherited");
+      const requested = shared === "empty" ? { version: 1, profiles: {} } : createStore("shared");
+      try {
+        setRuntimeAuthProfileStoreSnapshot(inherited, inheritedAuthDir);
+        if (shared !== "missing") {
+          setRuntimeAuthProfileStoreSnapshot(requested);
+        }
+        expect(getPreparedRuntimeAuthProfileStoreSnapshotCore(undefined, inheritedAuthDir)).toEqual(
+          shared === "missing" ? inherited : requested,
+        );
+      } finally {
+        clearRuntimeAuthProfileStoreSnapshots();
+      }
+    },
+  );
 
   it("clears one agent snapshot without disturbing other stores", () => {
     const firstAgentDir = "/tmp/openclaw-auth-runtime-snapshot-first";

--- a/src/agents/auth-profiles/runtime-snapshots.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.ts
@@ -295,12 +295,15 @@ export function getPreparedRuntimeAuthProfileStoreSnapshotCore(
   agentDir?: string,
   inheritedAuthDir?: string,
 ): AuthProfileStore | undefined {
-  const inherited = getRuntimeAuthProfileStoreSnapshotCore(inheritedAuthDir);
-  const requested = getRuntimeAuthProfileStoreSnapshotCore(agentDir);
-  if (!agentDir || resolveRuntimeStoreKey(agentDir) === resolveRuntimeStoreKey(inheritedAuthDir)) {
-    return requested ?? inherited;
+  const inheritedKey = resolveRuntimeStoreKey(inheritedAuthDir);
+  const requestedKey = resolveRuntimeStoreKey(agentDir);
+  const inherited = getRuntimeAuthProfileStoreSnapshotAtDatabasePath(inheritedKey);
+  if (requestedKey === inheritedKey) {
+    return inherited;
   }
-  if (inherited && requested) {
+  const requested = getRuntimeAuthProfileStoreSnapshotAtDatabasePath(requestedKey);
+  // With no agent, the shared snapshot wins without merging the inherited store.
+  if (agentDir && inherited && requested) {
     return mergeAuthProfileStores(inherited, requested, {
       preserveBaseRuntimeExternalProfiles: true,
     });

--- a/src/agents/auth-profiles/sqlite.ts
+++ b/src/agents/auth-profiles/sqlite.ts
@@ -180,31 +180,26 @@ function resolveAuthProfileDatabaseOptions(
   agentDir?: string,
   env: NodeJS.ProcessEnv = process.env,
 ): AuthProfileDatabaseTarget {
-  if (!agentDir) {
-    const pathname = resolveSharedAuthStorePath(env);
-    if (resolveSharedAuthStoreOwnership(env).location === "state-db") {
-      return { kind: "shared-state", path: pathname, env };
-    }
-    const dir = path.dirname(pathname);
-    return {
-      kind: "agent",
-      agentId: resolveRegisteredAgentIdForDir(dir) ?? inferAgentIdFromDir(dir),
-      path: pathname,
-      env,
-    };
+  const pathname = agentDir
+    ? resolveAuthProfileDatabasePath(agentDir)
+    : resolveSharedAuthStorePath(env);
+  if (!agentDir && resolveSharedAuthStoreOwnership(env).location === "state-db") {
+    return { kind: "shared-state", path: pathname, env };
   }
-  const dir = resolveUserPath(agentDir);
+  const dir = path.dirname(pathname);
   return {
     kind: "agent",
     agentId: resolveRegisteredAgentIdForDir(dir) ?? inferAgentIdFromDir(dir),
-    path: path.join(dir, "openclaw-agent.sqlite"),
+    path: pathname,
     env,
   };
 }
 
-/** Resolves the SQLite database path that stores auth profiles for an agent dir. */
+/** Filename-only consumers do not need reverse agent ownership discovery. */
 export function resolveAuthProfileDatabasePath(agentDir: string): string {
-  return resolveAuthProfileDatabaseOptions(agentDir).path;
+  return agentDir
+    ? path.join(resolveUserPath(agentDir), "openclaw-agent.sqlite")
+    : resolveSharedAuthStorePath();
 }
 
 /** Resolves the durable agent owner expected for an auth-profile database. */

--- a/src/agents/auth-profiles/store.ts
+++ b/src/agents/auth-profiles/store.ts
@@ -395,15 +395,12 @@ function resolveRuntimeAuthProfileStore(
     ? resolveAgentAuthPath(options.inheritedAuthDir)
     : resolveSharedAuthPath();
   const requestedKey = agentDir ? resolveAgentAuthPath(agentDir) : resolveSharedAuthPath();
-  const mainStore = getRuntimeAuthProfileStoreSnapshotCore(options?.inheritedAuthDir);
-  const requestedStore = getRuntimeAuthProfileStoreSnapshotCore(agentDir);
+  const mainStore = getRuntimeAuthProfileStoreSnapshotAtDatabasePath(mainKey);
 
   if (!agentDir || requestedKey === mainKey) {
-    if (!mainStore) {
-      return null;
-    }
-    return mainStore;
+    return mainStore ?? null;
   }
+  const requestedStore = getRuntimeAuthProfileStoreSnapshotAtDatabasePath(requestedKey);
 
   if (mainStore && requestedStore) {
     return mergeAuthProfileStores(mainStore, requestedStore, {


### PR DESCRIPTION
## What Problem This Solves

Auth snapshot preparation repeatedly resolves agent ownership to obtain a filename, then clones snapshots whose result is discarded. These operations sit on model preparation paths and add filesystem and allocation work without contributing to the selected auth store.

## Why This Change Was Made

Separate lexical filename resolution from the full database target owner, and carry already-selected database keys into the existing snapshot getter. Ordinary resolution copies only the inherited store when both keys select that store; prepared resolution copies the selected same-owner snapshot once.

The full database target still resolves authoritative agent ownership. Durable ownership checks, external-profile overlays, revision/publication/rollback behavior, and distinct-owner merge precedence remain unchanged. The two existing omitted-agent contracts deliberately stay different: ordinary resolution uses the inherited/main store, while prepared resolution prefers a present shared/requested snapshot, including an empty one, and uses inherited state only when it is absent. Returned data remains owned and mutable without changing stored snapshots.

Production **+22/−27, net −5**; tests **+110/−1, net +109**. No new cache, configuration, SQL, schema, transaction or persistence behavior is introduced.

## User Impact

Repeated model preparation performs less unused filesystem and cloning work. This is a bounded owner-level work reduction; it does not claim that all Gateway saturation is resolved.

## Evidence

- The filename regression records **nine native realpath calls before and zero after** across real absolute, relative, tilde, symlink, missing, empty and whitespace paths. After legitimate shared-owner warming, it preserves the returned lexical filenames and verifies that missing directories are not created. The empty/shared fallback still uses its existing shared-owner resolver, which may read ownership on a cold root; this is not a blanket zero-I/O claim. Existing configured-ID database open/write cases still exercise full ownership.
- Same-owner ordinary preparation drops from three clones to at most two; prepared preparation drops from two to at most one. The regressions fail on the original source. They also mutate returned nested arrays and verify snapshot isolation; the work limits allow a future cheaper implementation.
- **43 focused plus 117 sibling cases pass**, covering shared/scoped storage, selected-owner errors, explicit roots, external overlays, rollback, deep ownership, replacement freshness, inherited precedence, prepared runtime consumers and clearing one owner.
- The full changed-code gate, default build, direct source/dependency review and fresh managed Codex P0 review pass without exemptions.
- Published candidate `d305dc85cc4914e702d6d3fc1279c7c66c3d3ea2` preserves the five tested afterimages on base `ffb1759b6bcd7bd3712794754b53ca08079e8cf3`. All five preimages are still unchanged at inspected main `3c1b351555e0ebc1b022842523191691e89c7684`; 62 adjacent owner/caller/test/dependency contexts were qualified. This source comparison does not relabel prior runs as newer-main execution.

Both plain 32-turn profiles on the original base and candidate pass the unchanged 2,000 ms control/handshake budgets, with zero operation failures and zero metadata rescans. They perform unequal background work and do not establish an overall latency improvement. Whole-profile reverse-lookup sample weight falls from 21.836 to 4.510 ms, consistent with the removed path work; auth JSON-clone weight is effectively unchanged at 4.530/4.540 ms. Neither sample comparison is a load-aligned timing claim.

A separate diagnostic retains the mock log after normal child shutdown: exactly 32 turn generation requests plus five embedding requests were made. The benchmark's aggregate request counter therefore includes memory-indexing work; the earlier pair discarded those raw logs and cannot be retrospectively classified. Event-loop utilization still reaches 1, and degraded readiness polling can reuse cached health observations. No memory-leak or complete saturation-repair claim follows.

All runtime proof uses synthetic state, isolated HOME and a mock provider on loopback, never an operator or production Gateway. A separate channel narration cancellation defect remains a named follow-up; the benchmark uses `deliver:false` and does not exercise that channel path.
