### PR TITLE
refactor(delivery): share raw target-field guard

### DIFF
--- a/src/agents/subagents/spawn/acp-spawn-heartbeat.ts
+++ b/src/agents/subagents/spawn/acp-spawn-heartbeat.ts
@@ -6,7 +6,10 @@ import { loadSessionEntryReadOnly } from "../../../config/sessions/session-acces
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { isHeartbeatEnabledForAgent } from "../../../infra/heartbeat-summary.js";
 import { areHeartbeatsEnabled } from "../../../infra/heartbeat-wake.js";
-import { deliveryContextFromSession } from "../../../utils/delivery-context.shared.js";
+import {
+  deliveryContextFromSession,
+  hasDeliveryTargetFields,
+} from "../../../utils/delivery-context.shared.js";
 import { resolveAgentConfig, resolveSessionAgentIds } from "../../agent-scope.js";
 
 export function isHeartbeatEnabledForSessionAgent(params: {
@@ -96,5 +99,5 @@ export function hasSessionLocalHeartbeatRelayRoute(params: {
     clone: false,
   });
   const parentDeliveryContext = deliveryContextFromSession(parentEntry);
-  return Boolean(parentDeliveryContext?.channel && parentDeliveryContext.to);
+  return hasDeliveryTargetFields(parentDeliveryContext);
 }

--- a/src/agents/subagents/spawn/subagent-spawn-thread-binding.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-thread-binding.ts
@@ -108,9 +108,3 @@ export async function bindThreadForSubagentSpawn(params: {
     };
   }
 }
-
-export function hasRoutableDeliveryOrigin(
-  origin?: DeliveryContext,
-): origin is DeliveryContext & { channel: string; to: string } {
-  return Boolean(origin?.channel && origin.to);
-}

--- a/src/agents/subagents/spawn/subagent-spawn.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.ts
@@ -19,6 +19,7 @@ import {
   recordSessionCreated,
   recordSubagentSpawned,
 } from "../../../sessions/session-state-events.js";
+import { hasDeliveryTargetFields } from "../../../utils/delivery-context.shared.js";
 import { hasPromptUnsafeControlCharacter } from "../../sanitize-for-prompt.js";
 import {
   runSpawnPipeline,
@@ -65,10 +66,7 @@ import {
   createInitialSubagentSession,
   persistInitialChildSessionRuntimeModel,
 } from "./subagent-spawn-session-patch.js";
-import {
-  bindThreadForSubagentSpawn,
-  hasRoutableDeliveryOrigin,
-} from "./subagent-spawn-thread-binding.js";
+import { bindThreadForSubagentSpawn } from "./subagent-spawn-thread-binding.js";
 import {
   buildSubagentSystemPrompt,
   emitSessionLifecycleEvent,
@@ -280,7 +278,7 @@ export async function spawnSubagentDirect(
         };
       }
       threadBindingReady = true;
-      hasBoundThreadDeliveryOrigin = hasRoutableDeliveryOrigin(bindResult.deliveryOrigin);
+      hasBoundThreadDeliveryOrigin = hasDeliveryTargetFields(bindResult.deliveryOrigin);
       childSessionOrigin =
         mergeDeliveryContext(bindResult.deliveryOrigin, childSessionOrigin) ?? childSessionOrigin;
     }

--- a/src/config/sessions/delivery-info.ts
+++ b/src/config/sessions/delivery-info.ts
@@ -5,7 +5,10 @@ import {
   resolveSessionStoreKey,
 } from "../../gateway/session-store-key.js";
 import { requiresFoldedSessionKeyAliasProof } from "../../sessions/session-key-utils.js";
-import { deliveryContextFromSession } from "../../utils/delivery-context.shared.js";
+import {
+  deliveryContextFromSession,
+  hasDeliveryTargetFields,
+} from "../../utils/delivery-context.shared.js";
 import { getRuntimeConfig } from "../io.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
 import { resolveSessionStorePathCore } from "./paths.js";
@@ -19,20 +22,6 @@ import {
 import { resolveAllAgentSessionStoreTargetsSync } from "./targets.js";
 import { parseSessionThreadInfo } from "./thread-info.js";
 import type { SessionEntry } from "./types.js";
-
-function hasRoutableDeliveryContext(context?: {
-  channel?: string;
-  to?: string;
-  accountId?: string;
-  threadId?: string | number;
-}): context is {
-  channel: string;
-  to: string;
-  accountId?: string;
-  threadId?: string | number;
-} {
-  return Boolean(context?.channel && context?.to);
-}
 
 /**
  * Extracts the routable delivery context and thread id for a persisted session key.
@@ -62,11 +51,11 @@ export function extractDeliveryInfo(
     const lookup = loadDeliverySessionEntry({ cfg, sessionKey, baseSessionKey });
     let entry = lookup.entry;
     let storedDeliveryContext = deliveryContextFromSession(entry);
-    if (!hasRoutableDeliveryContext(storedDeliveryContext) && baseSessionKey !== sessionKey) {
+    if (!hasDeliveryTargetFields(storedDeliveryContext) && baseSessionKey !== sessionKey) {
       entry = lookup.baseEntry;
       storedDeliveryContext = deliveryContextFromSession(entry);
     }
-    if (hasRoutableDeliveryContext(storedDeliveryContext)) {
+    if (hasDeliveryTargetFields(storedDeliveryContext)) {
       deliveryContext = {
         channel: storedDeliveryContext.channel,
         to: storedDeliveryContext.to,
@@ -106,7 +95,7 @@ function findSessionEntryInStore(store: SessionEntryReadView, keys: readonly str
     if (!entry) {
       return;
     }
-    const candidateRoutable = hasRoutableDeliveryContext(deliveryContextFromSession(entry));
+    const candidateRoutable = hasDeliveryTargetFields(deliveryContextFromSession(entry));
     const candidateUpdatedAt = entry.updatedAt ?? 0;
     if (
       !bestEntry ||
@@ -131,7 +120,7 @@ function findSessionEntryInStore(store: SessionEntryReadView, keys: readonly str
     // Exact and alias probes are raw keyed reads; the store is never enumerated here.
     const exactEntry = store.get(normalized);
     if (exactEntry && !hasMismatchedCaseSensitiveDeliveryProof(exactEntry, normalized)) {
-      foundRoutableCandidate ||= hasRoutableDeliveryContext(deliveryContextFromSession(exactEntry));
+      foundRoutableCandidate ||= hasDeliveryTargetFields(deliveryContextFromSession(exactEntry));
       acceptCandidate(exactEntry, exactKeyWins);
     }
     for (const foldedLegacyKey of foldedLegacyKeys) {
@@ -139,16 +128,14 @@ function findSessionEntryInStore(store: SessionEntryReadView, keys: readonly str
       if (!foldedLegacyEntry || !isConfirmedLowercasedLegacyAlias(foldedLegacyEntry, normalized)) {
         continue;
       }
-      foundRoutableCandidate ||= hasRoutableDeliveryContext(
+      foundRoutableCandidate ||= hasDeliveryTargetFields(
         deliveryContextFromSession(foldedLegacyEntry),
       );
       acceptCandidate(foldedLegacyEntry);
     }
     const trimmedEntry = trimmed !== normalized ? store.get(trimmed) : undefined;
     if (trimmedEntry && !hasMismatchedCaseSensitiveDeliveryProof(trimmedEntry, normalized)) {
-      foundRoutableCandidate ||= hasRoutableDeliveryContext(
-        deliveryContextFromSession(trimmedEntry),
-      );
+      foundRoutableCandidate ||= hasDeliveryTargetFields(deliveryContextFromSession(trimmedEntry));
       acceptCandidate(trimmedEntry);
     }
     if (trimmed !== normalized || !foundRoutableCandidate) {
@@ -178,8 +165,8 @@ function buildFreshestSessionEntryIndex(store: SessionEntryReadView): Map<string
     }
     const normalized = normalizeStoreSessionKey(key);
     const existing = index.get(normalized);
-    const entryRoutable = hasRoutableDeliveryContext(deliveryContextFromSession(entry));
-    const existingRoutable = hasRoutableDeliveryContext(deliveryContextFromSession(existing));
+    const entryRoutable = hasDeliveryTargetFields(deliveryContextFromSession(entry));
+    const existingRoutable = hasDeliveryTargetFields(deliveryContextFromSession(existing));
     if (
       !existing ||
       (entryRoutable && !existingRoutable) ||
@@ -194,7 +181,7 @@ function buildFreshestSessionEntryIndex(store: SessionEntryReadView): Map<string
       continue;
     }
     const foldedExisting = index.get(foldedLegacyKey);
-    const foldedExistingRoutable = hasRoutableDeliveryContext(
+    const foldedExistingRoutable = hasDeliveryTargetFields(
       deliveryContextFromSession(foldedExisting),
     );
     if (
@@ -244,8 +231,8 @@ function loadDeliverySessionEntry(params: {
     // Prefer the first store that can actually route delivery; keep a non-routable fallback only
     // so callers can still inspect thread ids when no target-bearing session exists.
     if (
-      hasRoutableDeliveryContext(deliveryContextFromSession(entry)) ||
-      hasRoutableDeliveryContext(deliveryContextFromSession(baseEntry))
+      hasDeliveryTargetFields(deliveryContextFromSession(entry)) ||
+      hasDeliveryTargetFields(deliveryContextFromSession(baseEntry))
     ) {
       return { entry, baseEntry };
     }

--- a/src/gateway/server-restart-sentinel.ts
+++ b/src/gateway/server-restart-sentinel.ts
@@ -52,6 +52,7 @@ import { runWithGatewayIndependentRootWorkAdmission } from "../process/gateway-w
 import { removeCronRunContinuationSessionIfIdle } from "../tasks/cron-run-continuation-cleanup.js";
 import {
   deliveryContextFromSession,
+  hasDeliveryTargetFields,
   mergeDeliveryContext,
   sessionDeliveryOrigin,
 } from "../utils/delivery-context.shared.js";
@@ -89,13 +90,6 @@ function cloneRestartSentinelPayload(
   payload: RestartSentinelPayload | null,
 ): RestartSentinelPayload | null {
   return payload ? structuredClone(payload) : null;
-}
-
-function hasRoutableDeliveryContext(context?: {
-  channel?: string;
-  to?: string;
-}): context is { channel: string; to: string } {
-  return Boolean(context?.channel && context?.to);
 }
 
 function enqueueRestartSentinelWake(
@@ -547,7 +541,7 @@ async function loadRestartSentinelStartupTask(params: {
     let sessionDeliveryContext = deliveryContextFromSession(entry);
     let chatType = sessionDeliveryOrigin(entry)?.chatType ?? "direct";
     if (
-      !hasRoutableDeliveryContext(sessionDeliveryContext) &&
+      !hasDeliveryTargetFields(sessionDeliveryContext) &&
       baseSessionKey &&
       baseSessionKey !== sessionKey
     ) {

--- a/src/talk/agent-consult-runtime.ts
+++ b/src/talk/agent-consult-runtime.ts
@@ -14,6 +14,7 @@ import { parseAgentSessionKey } from "../routing/session-key.js";
 import { isModelSelectionLocked, ModelSelectionLockedError } from "../sessions/model-overrides.js";
 import {
   deliveryContextFromSession,
+  hasDeliveryTargetFields,
   normalizeDeliveryContext,
   normalizeSessionDeliveryState,
   type DeliveryContext,
@@ -114,12 +115,6 @@ function resolveRealtimeVoiceAgentSandboxSessionKey(agentId: string, sessionKey:
   return `agent:${agentId}:${trimmed}`;
 }
 
-function hasRoutableDeliveryContext(
-  context: DeliveryContext | undefined,
-): context is DeliveryContext & { channel: string; to: string } {
-  return Boolean(context?.channel && context?.to);
-}
-
 function resolveDeliverySessionFields(context?: DeliveryContext): Partial<SessionEntry> {
   const normalized = normalizeDeliveryContext(context);
   if (!normalized?.channel || !normalized.to) {
@@ -163,7 +158,7 @@ function resolveRealtimeVoiceAgentDeliveryContext(params: {
         sessionKey: candidate.sessionKey,
       });
       const context = deliveryContextFromSession(entry);
-      if (hasRoutableDeliveryContext(context)) {
+      if (hasDeliveryTargetFields(context)) {
         return context;
       }
     }

--- a/src/utils/delivery-context.shared.ts
+++ b/src/utils/delivery-context.shared.ts
@@ -57,6 +57,13 @@ export function normalizeDeliveryContext(context?: DeliveryContext): DeliveryCon
   return normalized;
 }
 
+/** Checks raw channel/to presence only; does not normalize or validate deliverability. */
+export function hasDeliveryTargetFields(
+  context?: DeliveryContext,
+): context is DeliveryContext & { channel: string; to: string } {
+  return Boolean(context?.channel && context?.to);
+}
+
 /** Normalizes an unknown channel route payload from persisted session/plugin metadata. */
 export function normalizeDeliveryChannelRoute(route?: unknown): ChannelRouteRef | undefined {
   if (!route || typeof route !== "object" || Array.isArray(route)) {

--- a/src/utils/delivery-context.test.ts
+++ b/src/utils/delivery-context.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   deliveryContextKey,
   deliveryContextFromSession,
+  hasDeliveryTargetFields,
   mergeDeliveryContext,
   normalizeDeliveryContext,
   normalizeSessionDeliveryState,
@@ -10,6 +11,20 @@ import {
 } from "./delivery-context.shared.js";
 
 describe("delivery context helpers", () => {
+  it.each([
+    ["undefined", undefined, false],
+    ["empty", {}, false],
+    ["channel only", { channel: "telegram" }, false],
+    ["target only", { to: "-1001" }, false],
+    ["empty channel", { channel: "", to: "-1001" }, false],
+    ["empty target", { channel: "telegram", to: "" }, false],
+    ["whitespace-only fields", { channel: " ", to: " " }, true],
+    ["internal route", { channel: "webchat", to: "dashboard" }, true],
+    ["external route", { channel: "telegram", to: "-1001" }, true],
+  ] as const)("checks raw delivery target fields for %s", (_name, context, expected) => {
+    expect(hasDeliveryTargetFields(context)).toBe(expected);
+  });
+
   it("normalizes channel/to/accountId and drops empty contexts", () => {
     expect(
       normalizeDeliveryContext({


### PR DESCRIPTION
## What Problem This Solves

Five core call paths independently implemented the same raw `channel && to` presence check. The copies used routability-oriented names even though the contract intentionally accepts whitespace and internal delivery contexts, making future normalization drift likely.

## Why This Change Was Made

This moves the exact raw-field predicate to the existing delivery-context owner and deletes the local Gateway, session lookup, Talk, ACP heartbeat, and subagent thread-binding copies. The helper remains private core surface; no SDK, plugin, config, schema, persistence, normalization, or delivery-policy contract changes.

Historical inspection found the copies were added by separate routing features before the current delivery-context owner existed. They are consolidation residue, not separate policies.

## User Impact

No user-visible behavior changes. Session recovery, voice consultation, heartbeat relay, and subagent thread delivery now share one structural target-field invariant.

Exact semantic nonchanges:

- whitespace-only `channel` and `to` remain accepted
- internal `webchat` targets remain accepted
- no trimming, channel normalization, deliverability lookup, or internal-channel exclusion was added

## Evidence

- Focused Vitest: 228 tests passed across `delivery-context`, `delivery-info`, Talk consult runtime/storage, Gateway restart sentinel, subagent thread binding, and ACP spawn suites.
- Import-cycle check: 0 runtime value cycles.
- AutoReview: scoped clean, no accepted/actionable findings, correctness 0.99.
- Blacksmith Testbox:
  - provider: `blacksmith-testbox`
  - lease: `tbx_01m1dejv3n3xw5nkyxk23110n7`
  - run: https://github.com/openclaw/openclaw/actions/runs/33464646811
  - command: clean `pnpm build` followed by the full repo-native changed gate for all eight files
  - result: passed, exit 0; 16m49.938s total
- Gateway benchmark, same command and checkout:
  - before: 75/75 passed; 23.61s real; 1,762,394,112-byte max RSS
  - after: 75/75 passed; 14.18s real; 1,756,332,032-byte max RSS
  - Timing is informational only because the later run had warmer caches.
- Production LOC: `+34/-56`, net `-22`.
- Test LOC: `+15/-0`.
- `git diff --check`: passed.
- Local `pnpm build` completed source, package, plugin, SDK declaration, and runtime postbuild phases, then the UI phase failed because the shared worktree install exposes `pako` as CommonJS without declarations. The changed gate likewise passed through core typecheck before the core-test shard encountered the same unrelated `ui/vite.config.ts` dependency mismatch. The clean Testbox run passed both surfaces.
- Native Windows proof gap: the resolved Crabbox profile exposes only the Linux Testbox target; no native Windows target is configured for this task. The change is platform-neutral TypeScript predicate consolidation.

Maintainer disposition: advance this behavior-neutral private refactor. The latest exact-head ClawSweeper review reports no correctness or security findings; its single remaining item is normal maintainer handling, satisfied by this explicit decision and the completed clean Testbox proof. No re-review is needed because behavior and head did not change after review.

Overlap checked September 1, 2026:

- #133660 changes the `subagent-spawn.ts` import neighborhood and completion-mode logic; this branch preserves that work and only replaces the target-field guard.
- #134003 changes unrelated Talk terminal-outcome handling.
- #134068 adds an unrelated `assertActive` argument in `subagent-spawn.ts`.

Codex hard gate: inspected `../codex/codex-rs/cli/src/main.rs:220-245` and `:2840-2870`. Those sections define hidden CLI/completion structures and prompt newline normalization; they do not participate in delivery-context or routing behavior.
