### PR TITLE
fix: show WebChat reset denials without admin scope

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -160,6 +160,11 @@ An applicable `commands.allowFrom` policy remains authoritative: a denied
 sender or an explicitly empty list cannot fall back to channel admission.
 Reset access does not grant other command or owner-only authority. Internal
 Gateway callers with explicit scopes still need `operator.admin` to reset.
+When both the request and reply stay in WebChat, rejected `/new` and `/reset`
+commands show a permission denial. A denied command does not perform the
+requested reset or run its follow-up text; normal idle/daily rollover still
+applies. Ask your Gateway administrator to reset the session, or send your
+message without the command.
 
 ## Command list
 
@@ -570,7 +575,7 @@ See [BTW side questions](/tools/btw) for the full behavior.
     - In Control UI, every non-skill slash command can be selected in the middle of a draft. The command runs separately, only the command invocation is removed, and the surrounding draft remains unsent.
     - In Control UI (WebChat), selecting a skill from slash completion inserts the existing `$skill-name` reference into the message (for example, `Please use $weather to check Sydney`).
     - Inline command dispatch follows the same connection, permission, and confirmation checks as sending that command by itself. Typing slash-like prose without selecting or submitting the completion does not execute it.
-    - Unauthorized command-only messages are silently ignored; inline `/...` tokens are treated as plain text.
+    - On external channels, unauthorized command-only messages are silently ignored; inline `/...` tokens are treated as plain text. Reset denials show a permission reply only when the request and reply stay in WebChat.
 
   </Accordion>
   <Accordion title="Argument notes">

--- a/src/auto-reply/reply/commands-reset-hooks.test.ts
+++ b/src/auto-reply/reply/commands-reset-hooks.test.ts
@@ -460,7 +460,18 @@ describe("handleCommands reset hooks", () => {
     expect(clearBootstrapSnapshotSpy).toHaveBeenCalledWith("agent:main:main");
   });
 
-  it.each([
+  it.each<{
+    name: string;
+    provider?: string;
+    surface: string;
+    scopes?: string[];
+    allowed: boolean;
+    body?: string;
+    source?: "text" | "native";
+    originatingChannel?: string;
+    commandAuthorized?: boolean;
+    silent?: boolean;
+  }>([
     {
       name: "write scope",
       provider: "webchat",
@@ -510,18 +521,58 @@ describe("handleCommands reset hooks", () => {
       scopes: ["operator.write"],
       allowed: false,
     },
+    ...["/new Create a note", "/reset Create a note", "/reset soft Create a note"].flatMap((body) =>
+      (["text", "native"] as const).flatMap((source) => [
+        {
+          name: `${source} ${body} forwarded from Gateway to external origin`,
+          body,
+          source,
+          provider: "webchat",
+          surface: "webchat",
+          originatingChannel: "telegram",
+          scopes: ["operator.write"],
+          allowed: false,
+          silent: true,
+        },
+        {
+          name: `${source} ${body} from external Provider with internal Surface and origin`,
+          body,
+          source,
+          provider: "telegram",
+          surface: "webchat",
+          originatingChannel: "webchat",
+          commandAuthorized: false,
+          allowed: false,
+          silent: true,
+        },
+      ]),
+    ),
   ])(
-    "preserves internal soft-reset scope policy: $name",
-    async ({ provider, surface, scopes, allowed }) => {
+    "preserves reset authorization and denial routing: $name",
+    async ({
+      provider,
+      surface,
+      scopes,
+      allowed,
+      body = "/reset soft",
+      source = "text",
+      originatingChannel,
+      commandAuthorized = true,
+      silent = false,
+    }) => {
       const params = buildResetParams(
-        "/reset soft",
+        body,
         {
           commands: { text: true },
         } as OpenClawConfig,
         {
           Provider: provider,
           Surface: surface,
-          CommandAuthorized: true,
+          OriginatingChannel: originatingChannel,
+          OriginatingTo: originatingChannel ? "chat:reset-test" : undefined,
+          ExplicitDeliverRoute: originatingChannel !== undefined,
+          CommandSource: source,
+          CommandAuthorized: commandAuthorized,
           GatewayClientScopes: scopes,
         },
       );
@@ -530,8 +581,8 @@ describe("handleCommands reset hooks", () => {
         cfg: params.cfg,
         sessionKey: params.sessionKey,
         isGroup: false,
-        triggerBodyNormalized: "/reset soft",
-        commandAuthorized: true,
+        triggerBodyNormalized: body,
+        commandAuthorized,
       });
       params.sessionEntry = {
         sessionId: "existing-soft-session",
@@ -543,13 +594,22 @@ describe("handleCommands reset hooks", () => {
 
       const result = await maybeHandleResetCommand(params);
 
-      expect(result).toEqual(allowed ? null : { shouldContinue: false });
+      if (allowed) {
+        expect(result).toBeNull();
+      } else if (silent) {
+        expect(result).toStrictEqual({ shouldContinue: false });
+      } else {
+        expect(result?.shouldContinue).toBe(false);
+        expect(result?.reply?.text).toMatch(/not authorized/i);
+        expect(result?.reply?.text).toContain("operator.admin");
+      }
       expect(params.sessionEntry.sessionId).toBe(before.sessionId);
       expect(params.sessionEntry.lifecycleRevision).toBe(before.lifecycleRevision);
       expect(params.command.softResetTriggered === true).toBe(allowed);
       expect(triggerInternalHookMock).toHaveBeenCalledTimes(allowed ? 1 : 0);
       expect(clearBootstrapSnapshotSpy).toHaveBeenCalledTimes(allowed ? 1 : 0);
       expect(routeReplyMock).not.toHaveBeenCalled();
+      expect(resetMocks.resetConfiguredBindingTargetInPlace).not.toHaveBeenCalled();
       if (allowed) {
         expect(params.sessionEntry.cliSessionIds).toBeUndefined();
       } else {

--- a/src/auto-reply/reply/commands-reset.ts
+++ b/src/auto-reply/reply/commands-reset.ts
@@ -5,8 +5,10 @@ import { resetConfiguredBindingTargetInPlace } from "../../channels/plugins/bind
 import { updateSessionEntry } from "../../config/sessions/session-accessor.js";
 import { logVerbose } from "../../globals.js";
 import { isAcpSessionKey } from "../../routing/session-key.js";
+import { isInternalMessageChannel } from "../../utils/message-channel.js";
 import { isResetAuthorizedForContext } from "../command-auth.js";
 import { applyCommandTextToContext } from "./command-context-rewrite.js";
+import { commandReply } from "./command-gates.js";
 import { resolveBoundAcpThreadSessionKey } from "./commands-acp/targets.js";
 import { emitResetCommandHooks, type ResetCommandAction } from "./commands-reset-hooks.js";
 import { parseSoftResetCommand } from "./commands-reset-mode.js";
@@ -35,15 +37,24 @@ function isResetAuthorized(params: HandleCommandsParams): boolean {
 export async function maybeHandleResetCommand(
   params: HandleCommandsParams,
 ): Promise<CommandHandlerResult | null> {
+  const resetMatch = params.command.commandBodyNormalized.match(/^\/(new|reset)(?:\s|$)/i);
+  if (!resetMatch) {
+    return null;
+  }
+  if (!isResetAuthorized(params)) {
+    logVerbose(
+      `Ignoring /${resetMatch[1]} from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
+    );
+    // Internal ingress can forward replies externally; keep those denials silent too.
+    return isInternalMessageChannel(params.ctx.Provider || params.ctx.Surface) &&
+      isInternalMessageChannel(params.command.channel)
+      ? commandReply(
+          "⚠️ You are not authorized to reset this session. Gateway resets require operator.admin and command access. Ask your administrator to reset it, or send your message without the command.",
+        )
+      : { shouldContinue: false };
+  }
   const softReset = parseSoftResetCommand(params.command.commandBodyNormalized);
   if (softReset.matched) {
-    if (!isResetAuthorized(params)) {
-      logVerbose(
-        `Ignoring /reset soft from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-      );
-      return { shouldContinue: false };
-    }
-
     const boundAcpSessionKey = resolveBoundAcpThreadSessionKey(params);
     const boundAcpKey =
       boundAcpSessionKey && isAcpSessionKey(boundAcpSessionKey)
@@ -114,17 +125,6 @@ export async function maybeHandleResetCommand(
     params.command.softResetTriggered = true;
     params.command.softResetTail = softReset.tail;
     return null;
-  }
-
-  const resetMatch = params.command.commandBodyNormalized.match(/^\/(new|reset)(?:\s|$)/i);
-  if (!resetMatch) {
-    return null;
-  }
-  if (!isResetAuthorized(params)) {
-    logVerbose(
-      `Ignoring /reset from unauthorized sender: ${params.command.senderId || "<unknown>"}`,
-    );
-    return { shouldContinue: false };
   }
 
   const commandAction: ResetCommandAction =

--- a/src/auto-reply/reply/session.test.ts
+++ b/src/auto-reply/reply/session.test.ts
@@ -3494,7 +3494,7 @@ describe("initSessionState reset authorization", () => {
 
   it.each<{
     name: string;
-    body?: "/new" | "/reset";
+    body?: string;
     source?: "text" | "native";
     feishuDirect?: boolean;
     admitted?: boolean;
@@ -3529,6 +3529,18 @@ describe("initSessionState reset authorization", () => {
       allowed: false,
     },
     { name: "non-admitted sender", admitted: false, allowed: false },
+    ...[
+      "/new Create a note",
+      "/reset",
+      "/reset Create a note",
+      "/reset soft",
+      "/reset soft Create a note",
+    ].map((body) => ({
+      name: `non-admitted sender stays silent for ${body}`,
+      body,
+      admitted: false,
+      allowed: false,
+    })),
     { name: "unrelated provider command policy", allowFrom: { telegram: [] }, allowed: true },
     { name: "explicit command deny", allowFrom: { buzz: ["other"] }, allowed: false },
     { name: "empty global command allowlist", allowFrom: { "*": [] }, allowed: false },
@@ -3727,14 +3739,17 @@ describe("initSessionState reset authorization", () => {
         if (allowed) {
           expect.soft(resets[0]).toMatchObject({ type: "reset", reason: body.slice(1) });
         }
-        expect.soft(acknowledgement).toEqual(
-          allowed
-            ? {
-                shouldContinue: false,
-                reply: { text: body === "/new" ? "✅ New session started." : "✅ Session reset." },
-              }
-            : { shouldContinue: false },
-        );
+        expect.soft(acknowledgement?.shouldContinue).toBe(false);
+        if (allowed) {
+          expect
+            .soft(acknowledgement?.reply?.text)
+            .toBe(body === "/new" ? "✅ New session started." : "✅ Session reset.");
+        } else if (scopes) {
+          expect.soft(acknowledgement?.reply?.text).toMatch(/not authorized/i);
+          expect.soft(acknowledgement?.reply?.text).toContain("operator.admin");
+        } else {
+          expect.soft(acknowledgement?.reply).toBeUndefined();
+        }
       } finally {
         resetPluginRuntimeStateForTest();
       }

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -8,7 +8,7 @@ import { WebSocket } from "ws";
 import { createDeferred } from "../../test/helpers/promise.js";
 import type { InternalGetReplyOptions } from "../auto-reply/reply/get-reply.types.js";
 import { replyRunRegistry } from "../auto-reply/reply/reply-run-registry.js";
-import { loadSessionEntry } from "../config/sessions/session-accessor.js";
+import { loadSessionEntry, updateSessionEntry } from "../config/sessions/session-accessor.js";
 import { replaceTranscriptEvents } from "../config/sessions/session-accessor.sqlite-transcript-write.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import {
@@ -2517,49 +2517,108 @@ describe("gateway server chat", () => {
     });
   });
 
-  test("chat.send does not rotate sessions for operator.write reset triggers", async () => {
-    await withGatewayServer(async ({ port: portLocal }) => {
-      await withMainSessionStore(async () => {
-        let scopedWs: WebSocket | undefined;
-
-        try {
-          scopedWs = new WebSocket(`ws://127.0.0.1:${portLocal}`);
-          trackConnectChallengeNonce(scopedWs);
-          await new Promise<void>((resolve) => {
-            scopedWs?.once("open", resolve);
-          });
-          await connectOk(scopedWs, {
-            scopes: ["operator.write"],
-          });
-
-          const sendRes = await rpcReq(scopedWs, "chat.send", {
-            sessionKey: "main",
-            message: "/reset",
-            idempotencyKey: "idem-write-scope-reset-no-rotate",
-          });
-          expect(sendRes.ok).toBe(true);
-
-          const waitRes = await rpcReq(scopedWs, "agent.wait", {
-            runId: "idem-write-scope-reset-no-rotate",
-            timeoutMs: 1_000,
-          });
-          expect(waitRes.ok).toBe(true);
-          expect(waitRes.payload?.status).toBe("ok");
-
+  test.each([
+    "/new",
+    "/new Create a note",
+    "/reset",
+    "/reset Create a note",
+    "/reset soft",
+    "/reset soft Create a note",
+  ])(
+    "chat.send does not rotate sessions for operator.write reset triggers and replies with denial: %s",
+    async (message) => {
+      const { getReplyFromConfig } = await import("../auto-reply/reply/get-reply.js");
+      const { withFullRuntimeReplyConfig } =
+        await import("../auto-reply/reply/get-reply-fast-path.js");
+      const replyRun = await import("../auto-reply/reply/get-reply-run.js");
+      const runSpy = vi.spyOn(replyRun, "runPreparedReply").mockResolvedValue(undefined);
+      // Keep real command/session dispatch; only intercept the model-run boundary.
+      mockGetReplyFromConfigOnce((ctx, opts, cfg) =>
+        getReplyFromConfig(ctx, opts, cfg ? withFullRuntimeReplyConfig(cfg) : cfg),
+      );
+      try {
+        await withMainSessionStore(async () => {
           const sessionStorePath = testState.sessionStorePath;
           if (!sessionStorePath) {
             throw new Error("session store path was not initialized");
           }
+          const resetState = {
+            lifecycleRevision: "before-reset",
+            cliSessionIds: { "claude-cli": "existing-cli-binding" },
+          };
           expect(
-            loadSessionEntry({ sessionKey: "agent:main:main", storePath: sessionStorePath })
-              ?.sessionId,
-          ).toBe("sess-main");
-        } finally {
-          scopedWs?.close();
-        }
-      });
-    });
-  });
+            await updateSessionEntry(
+              { sessionKey: "agent:main:main", storePath: sessionStorePath },
+              () => resetState,
+            ),
+          ).not.toBeNull();
+          let scopedWs: WebSocket | undefined;
+
+          try {
+            scopedWs = new WebSocket(`ws://127.0.0.1:${port}`);
+            trackConnectChallengeNonce(scopedWs);
+            await new Promise<void>((resolve) => {
+              scopedWs?.once("open", resolve);
+            });
+            await connectOk(scopedWs, {
+              scopes: ["operator.read", "operator.write"],
+            });
+
+            const runId = `idem-write-scope-reset-${message}`;
+            const finalPromise = onceMessage(
+              scopedWs,
+              (event) =>
+                event.type === "event" &&
+                event.event === "chat" &&
+                event.payload?.state === "final" &&
+                event.payload?.runId === runId,
+            );
+            // Observe both promises immediately so an RPC failure cannot strand the final listener.
+            const [sendRes, final] = await Promise.all([
+              rpcReq(scopedWs, "chat.send", {
+                sessionKey: "main",
+                message,
+                idempotencyKey: runId,
+              }),
+              finalPromise,
+            ]);
+            expect(sendRes.ok).toBe(true);
+            expect(sendRes.payload?.status).toBe("started");
+
+            const waitRes = await rpcReq(scopedWs, "agent.wait", {
+              runId,
+              timeoutMs: 1_000,
+            });
+            expect(waitRes.ok).toBe(true);
+            expect(waitRes.payload?.status).toBe("ok");
+
+            expect(
+              loadSessionEntry({ sessionKey: "agent:main:main", storePath: sessionStorePath }),
+            ).toMatchObject({ sessionId: "sess-main", ...resetState });
+            expect(runSpy).not.toHaveBeenCalled();
+            expect(extractFirstTextBlock(final.payload?.message)).toMatch(/not authorized/i);
+            expect(extractFirstTextBlock(final.payload?.message)).toContain("operator.admin");
+            const history = await rpcReq<{ sessionId?: string; messages?: unknown[] }>(
+              scopedWs,
+              "chat.history",
+              {
+                sessionKey: "main",
+              },
+            );
+            expect(history.ok).toBe(true);
+            expect(history.payload?.sessionId).toBe("sess-main");
+            expect(collectHistoryTextValues(history.payload?.messages ?? [])).toContain(
+              extractFirstTextBlock(final.payload?.message),
+            );
+          } finally {
+            scopedWs?.close();
+          }
+        });
+      } finally {
+        runSpy.mockRestore();
+      }
+    },
+  );
 
   test("agent.wait resolves chat.send runs that finish without lifecycle events", async () => {
     await withMainSessionStore(async () => {


### PR DESCRIPTION
Closes #134679

<details>
<summary>Additional instructions</summary>

This is a maintainer-owned branch in this repository; maintainers can update it.

</details>

## What Problem This Solves

Fixes an issue where users sending `/new` or `/reset` through WebChat would receive no actionable rejection when their authenticated operator profile lacked `operator.admin`. The request could finish with `agent.wait: ok` and no model execution, while the current full-dispatch path substituted a misleading temporary-model-failure message.

## Why This Change Was Made

The reset command now owns one authorization-and-denial path for `/new`, `/reset`, and `/reset soft`, returning a normal command reply only when both ingress and the effective reply destination are WebChat. The existing authorization predicate, scope requirements, session permissions, and downstream reply/history persistence remain unchanged; unauthorized external traffic, including explicitly forwarded destinations, retains its quiet terminal outcome.

Production LOC: **+18/-18 (net 0)**. Tests: **+190/-56 (net +134)**. Docs: **+6/-1**. The duplicate reset denial branch is removed rather than adding another Gateway-specific policy or protocol error path.

## User Impact

Denied WebChat resets now explain the permission requirement and offer two next steps: ask an administrator to reset the session, or send the message without the command. A denied reset does not run its follow-up text or perform the requested reset. Normal idle/daily session rollover remains independent. Admin access, channel admission, authoring permissions, and session permissions are not widened.

The local slash-command documentation is updated for https://docs.openclaw.ai/tools/slash-commands.

## Evidence

### Before and after

Against pre-fix production, all six wire-regression cases failed the permission-denial assertion after proving completed request handling, no requested session rotation, and no model-run invocation. The handler returned no reply; full dispatch rendered “No reply was generated for this message. This is usually a temporary model failure - please try again.”

After the repair, the same cases receive the permission reply in the live `chat` final event and in `chat.history`. They also preserve lifecycle revision and an existing CLI binding, so the proof catches in-place resets that retain the same session ID.

### Local validation

**331 tests passed** across the complete authorization, reset-command, session, and Gateway chat files:

```bash
node scripts/run-vitest.mjs src/auto-reply/command-auth.owner-default.test.ts src/auto-reply/reply/commands-reset-hooks.test.ts src/auto-reply/reply/session.test.ts src/gateway/server.chat.gateway-server-chat.test.ts
```

Changed-scope formatting, production/test typechecks, lint, dead-export checks, import cycles, storage checks, and the remaining architecture guards passed:

```bash
node scripts/check-changed.mjs -- src/auto-reply/reply/commands-reset.ts src/auto-reply/reply/commands-reset-hooks.test.ts src/auto-reply/reply/session.test.ts src/gateway/server.chat.gateway-server-chat.test.ts docs/tools/slash-commands.md
```

```bash
pnpm build qaRuntime
```

```bash
pnpm ui:build
```

```bash
git diff --check
```

Independent Codex autoreview was scoped-clean at its default P0 threshold. The maintainer landing flow also runs a fresh review before publication.

### Isolated real Gateway proof

A real built Gateway used separate home/state/workspace directories and loopback ports, with a synthetic trusted-proxy identity and writer role capped to exactly `operator.read` and `operator.write`. The client requested admin as well, but the negotiated connection did not receive it. Only the provider endpoint was mocked; no live credentials were used.

| Wire submission | Final permission reply | Retained in history | Session identity retained | Additional model requests |
| --- | --- | --- | --- | --- |
| `/new` | Yes | Yes | Yes | 0 |
| `/new Create a note` | Yes | Yes | Yes | 0 |
| `/reset` | Yes | Yes | Yes | 0 |
| `/reset Create a note` | Yes | Yes | Yes | 0 |
| `/reset soft` | Yes | Yes | Yes | 0 |
| `/reset soft Create a note` | Yes | Yes | Yes | 0 |

The real Control UI displayed these Gateway-produced replies and retained them after reload. Direct WebSocket submissions exercised the Gateway boundary; the Control UI exercised rendering and history reload. Its separate client-side reset gate is unchanged. The attached screenshot and short recording were visually inspected and contain only synthetic proof data. All proof servers were stopped afterward.

### Validation caveat

One cold focused attempt failed the existing fixture teardown wait because one retained Gateway root was still active. The unchanged rerun and complete 331-test run passed. A separate follow-up records that teardown-lifecycle investigation; no timeout was raised, assertion weakened, or blanket retry added to production or tests.

![history-reload](https://github.com/user-attachments/assets/851daa62-8cd4-43a5-a0e1-8de5c04b61b2)

https://github.com/user-attachments/assets/7c08f61c-09b9-4193-939f-3de538fb004e