### PR TITLE
fix(doctor): finish MCP lint when SQLite is busy

### DIFF
--- a/src/agents/agent-bundle-mcp-materialize.ts
+++ b/src/agents/agent-bundle-mcp-materialize.ts
@@ -605,12 +605,18 @@ export async function materializeBundleMcpToolsForRun(params: {
 
 export async function createBundleMcpToolRuntime(params: {
   workspaceDir: string;
+  agentDir?: string;
   cfg?: OpenClawConfig;
+  excludeServerNames?: ReadonlySet<string>;
   reservedToolNames?: Iterable<string>;
+  safeServerNamesByServer?: ReadonlyMap<string, string>;
   createRuntime?: (params: {
     sessionId: string;
     workspaceDir: string;
+    agentDir?: string;
     cfg?: OpenClawConfig;
+    excludeServerNames?: ReadonlySet<string>;
+    safeServerNamesByServer?: ReadonlyMap<string, string>;
   }) => SessionMcpRuntime;
 }): Promise<BundleMcpToolRuntime> {
   const createRuntime =
@@ -619,6 +625,11 @@ export async function createBundleMcpToolRuntime(params: {
     sessionId: `bundle-mcp:${crypto.randomUUID()}`,
     workspaceDir: params.workspaceDir,
     cfg: params.cfg,
+    ...(params.agentDir ? { agentDir: params.agentDir } : {}),
+    ...(params.excludeServerNames ? { excludeServerNames: params.excludeServerNames } : {}),
+    ...(params.safeServerNamesByServer
+      ? { safeServerNamesByServer: params.safeServerNamesByServer }
+      : {}),
   });
   const materialized = await materializeBundleMcpToolsForRun({
     runtime,

--- a/src/commands/doctor-lint.state-isolation.test.ts
+++ b/src/commands/doctor-lint.state-isolation.test.ts
@@ -1,0 +1,129 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { operatorMcpOAuthIdentity } from "../agents/mcp-oauth-identity.js";
+import { createMcpOAuthClientProvider } from "../agents/mcp-oauth-provider.js";
+import { resolveMcpOAuthAccessToken } from "../agents/mcp-oauth.js";
+import { clearHealthChecksForTest } from "../flows/health-check-registry.js";
+import {
+  closeOpenClawStateDatabaseByPath,
+  closeOpenClawStateDatabaseForTest,
+} from "../state/openclaw-state-db.js";
+import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { runDoctorLintCli } from "./doctor-lint.js";
+
+const mocks = vi.hoisted(() => ({
+  resolveDoctorContributionHealthChecks: vi.fn(),
+}));
+
+vi.mock("../flows/doctor-health-contributions.js", () => ({
+  resolveDoctorContributionHealthChecks: mocks.resolveDoctorContributionHealthChecks,
+}));
+
+const runtime = {
+  log: vi.fn(),
+  error: vi.fn(),
+  exit: vi.fn(),
+};
+
+const originalEnv = {
+  HOME: process.env.HOME,
+  OPENCLAW_CONFIG_PATH: process.env.OPENCLAW_CONFIG_PATH,
+  OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
+};
+
+describe("doctor lint state isolation", () => {
+  beforeEach(() => {
+    clearHealthChecksForTest();
+    mocks.resolveDoctorContributionHealthChecks.mockReset();
+  });
+
+  afterEach(() => {
+    closeOpenClawStateDatabaseForTest();
+    restoreEnv(originalEnv);
+  });
+
+  it("keeps runtime schema OAuth inspection off the writable source state", async () => {
+    const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-lint-oauth-"));
+    const stateDir = path.join(rootDir, "operator-state");
+    const configPath = path.join(stateDir, "openclaw.json");
+    const serverUrl = "https://mcp.example.test/rpc";
+    const identity = operatorMcpOAuthIdentity("oauth-proof", serverUrl);
+    process.env.HOME = stateDir;
+    process.env.OPENCLAW_CONFIG_PATH = configPath;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    fs.mkdirSync(stateDir, { recursive: true });
+    fs.writeFileSync(configPath, "{}\n");
+    await createMcpOAuthClientProvider({ identity }).saveTokens({
+      access_token: "stored-inspection-token-not-real",
+      token_type: "Bearer",
+      expires_in: 3600,
+    });
+    const databasePath = resolveOpenClawStateSqlitePath(process.env);
+    closeOpenClawStateDatabaseByPath(databasePath);
+    const lock = new DatabaseSync(databasePath);
+    lock.exec("BEGIN IMMEDIATE");
+    const before = snapshotSqliteFamily(databasePath);
+    mocks.resolveDoctorContributionHealthChecks.mockResolvedValue([
+      {
+        id: "core/doctor/runtime-tool-schemas",
+        kind: "core",
+        description: "checks OAuth state ownership",
+        async detect() {
+          const token = await resolveMcpOAuthAccessToken({
+            identity,
+            acceptUnknownExpiry: true,
+            signal: AbortSignal.timeout(250),
+          });
+          expect(token).toBe("stored-inspection-token-not-real");
+          return [];
+        },
+      },
+    ]);
+
+    const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+    try {
+      await expect(
+        runDoctorLintCli(runtime, {
+          json: true,
+          onlyIds: ["core/doctor/runtime-tool-schemas"],
+        }),
+      ).resolves.toBe(0);
+      expect(JSON.parse(String(stdout.mock.calls.at(-1)?.[0]))).toMatchObject({
+        ok: true,
+        checksRun: 1,
+        findings: [],
+      });
+      expect(snapshotSqliteFamily(databasePath)).toEqual(before);
+    } finally {
+      stdout.mockRestore();
+      lock.exec("ROLLBACK");
+      lock.close();
+      closeOpenClawStateDatabaseByPath(databasePath);
+      fs.rmSync(rootDir, { recursive: true, force: true });
+    }
+  });
+});
+
+function snapshotSqliteFamily(databasePath: string): Array<{ path: string; sha256: string }> {
+  return ["", "-journal", "-shm", "-wal"]
+    .map((suffix) => `${databasePath}${suffix}`)
+    .filter((candidate) => fs.existsSync(candidate))
+    .map((candidate) => ({
+      path: candidate,
+      sha256: createHash("sha256").update(fs.readFileSync(candidate)).digest("hex"),
+    }));
+}
+
+function restoreEnv(values: typeof originalEnv): void {
+  for (const [key, value] of Object.entries(values)) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}

--- a/src/commands/doctor-lint.state-isolation.test.ts
+++ b/src/commands/doctor-lint.state-isolation.test.ts
@@ -119,11 +119,19 @@ function snapshotSqliteFamily(databasePath: string): Array<{ path: string; sha25
 }
 
 function restoreEnv(values: typeof originalEnv): void {
-  for (const [key, value] of Object.entries(values)) {
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
-    }
+  if (values.HOME === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = values.HOME;
+  }
+  if (values.OPENCLAW_CONFIG_PATH === undefined) {
+    delete process.env.OPENCLAW_CONFIG_PATH;
+  } else {
+    process.env.OPENCLAW_CONFIG_PATH = values.OPENCLAW_CONFIG_PATH;
+  }
+  if (values.OPENCLAW_STATE_DIR === undefined) {
+    delete process.env.OPENCLAW_STATE_DIR;
+  } else {
+    process.env.OPENCLAW_STATE_DIR = values.OPENCLAW_STATE_DIR;
   }
 }

--- a/src/commands/doctor-lint.ts
+++ b/src/commands/doctor-lint.ts
@@ -1,5 +1,6 @@
 /** CLI entrypoint for non-mutating doctor lint health checks. */
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { resolveAgentWorkspaceDir, tryResolveDefaultAgentId } from "../agents/agent-scope.js";
 import { createConfigIO, readConfigFileSnapshot } from "../config/config.js";
@@ -57,6 +58,10 @@ type DoctorLintExecution = {
   findings: readonly HealthFinding[];
   writeOutput: () => void;
 };
+
+type DoctorLintPrivateStateRunner = <T>(run: () => Promise<T>) => Promise<T>;
+
+const RUNTIME_TOOL_SCHEMA_CHECK_ID = "core/doctor/runtime-tool-schemas";
 
 class DoctorLintStateSnapshotError extends Error {
   constructor(cause: unknown) {
@@ -220,7 +225,13 @@ async function executeDoctorLint(
   const extensionChecks = onlyRegisteredExtensionChecks
     ? registeredExtensionChecks
     : listExtensionHealthChecksForDoctor(coreChecks);
-  const coreCtx = { ...ctx, deep: opts.deep === true };
+  const runWithPrivateStateSnapshot: DoctorLintPrivateStateRunner = async (run) =>
+    await stateView.runWithPluginStateSnapshot(async () => await run());
+  const coreCtx = {
+    ...ctx,
+    deep: opts.deep === true,
+    runWithPrivateStateSnapshot,
+  };
 
   const runOpts: DoctorLintRunOptions = {
     checks: [...coreChecks.map((check) => withCoreLintContext(check, coreCtx)), ...extensionChecks],
@@ -269,28 +280,43 @@ async function withReadOnlyPluginStateSnapshot<T>(
   run: (pluginMetadataEnv: NodeJS.ProcessEnv) => Promise<T>,
 ): Promise<T> {
   const sourceDatabasePath = resolveOpenClawStateSqlitePath(sourceEnv);
-  if (!fs.existsSync(sourceDatabasePath)) {
-    return await run(sourceEnv);
-  }
-  let prepared: ReturnType<typeof prepareSqliteReadOnlyLocationSync>;
+  let cleanup: () => boolean;
+  let privateRoot: string;
+  let prepared: ReturnType<typeof prepareSqliteReadOnlyLocationSync> | undefined;
   try {
-    prepared = prepareSqliteReadOnlyLocationSync(sourceDatabasePath);
+    if (fs.existsSync(sourceDatabasePath)) {
+      prepared = prepareSqliteReadOnlyLocationSync(sourceDatabasePath);
+      privateRoot = path.dirname(prepared.location);
+      cleanup = prepared.cleanup;
+    } else {
+      privateRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-lint-state-"));
+      cleanup = () => {
+        try {
+          fs.rmSync(privateRoot, { force: true, recursive: true });
+          return true;
+        } catch {
+          return false;
+        }
+      };
+    }
   } catch (error) {
     throw new DoctorLintStateSnapshotError(error);
   }
   let outcome: { ok: true; value: T } | { ok: false; error: unknown };
   let runStarted = false;
   try {
-    const privateStateDir = path.join(path.dirname(prepared.location), "openclaw-state");
+    const privateStateDir = path.join(privateRoot, "openclaw-state");
     const privateDatabasePath = resolveOpenClawStateSqlitePath({
       ...sourceEnv,
       OPENCLAW_STATE_DIR: privateStateDir,
     });
     fs.mkdirSync(path.dirname(privateDatabasePath), { recursive: true, mode: 0o700 });
-    for (const suffix of ["", "-journal", "-shm", "-wal"]) {
-      const sourcePath = `${prepared.location}${suffix}`;
-      if (fs.existsSync(sourcePath)) {
-        fs.renameSync(sourcePath, `${privateDatabasePath}${suffix}`);
+    if (prepared) {
+      for (const suffix of ["", "-journal", "-shm", "-wal"]) {
+        const sourcePath = `${prepared.location}${suffix}`;
+        if (fs.existsSync(sourcePath)) {
+          fs.renameSync(sourcePath, `${privateDatabasePath}${suffix}`);
+        }
       }
     }
     const sourceConfigPath = resolveConfigPath(sourceEnv, resolveStateDir(sourceEnv));
@@ -300,20 +326,41 @@ async function withReadOnlyPluginStateSnapshot<T>(
       OPENCLAW_STATE_DIR: privateStateDir,
     };
     const installRoots = resolvePluginInstallRoots(sourceEnv);
+    const previousConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+    const previousStateDir = process.env.OPENCLAW_STATE_DIR;
     outcome = {
       ok: true,
-      value: await withPluginInstallRoots(
-        { ...installRoots, stateDir: privateStateDir },
-        async () => {
-          runStarted = true;
-          return await run(privateEnv);
-        },
-      ),
+      value: await (async () => {
+        // OAuth and auth-profile owners still read process.env. Redirect the serialized
+        // lint phase so refresh and challenge writes stay inside this private snapshot.
+        process.env.OPENCLAW_CONFIG_PATH = sourceConfigPath;
+        process.env.OPENCLAW_STATE_DIR = privateStateDir;
+        try {
+          return await withPluginInstallRoots(
+            { ...installRoots, stateDir: privateStateDir },
+            async () => {
+              runStarted = true;
+              return await run(privateEnv);
+            },
+          );
+        } finally {
+          if (previousConfigPath === undefined) {
+            delete process.env.OPENCLAW_CONFIG_PATH;
+          } else {
+            process.env.OPENCLAW_CONFIG_PATH = previousConfigPath;
+          }
+          if (previousStateDir === undefined) {
+            delete process.env.OPENCLAW_STATE_DIR;
+          } else {
+            process.env.OPENCLAW_STATE_DIR = previousStateDir;
+          }
+        }
+      })(),
     };
   } catch (error) {
     outcome = { ok: false, error };
   }
-  if (!prepared.cleanup()) {
+  if (!cleanup()) {
     throw new DoctorLintStateSnapshotError(
       new Error("Temporary doctor lint state snapshot cleanup did not complete."),
     );
@@ -364,12 +411,18 @@ function createStateSnapshotFailureExecution(
 
 function withCoreLintContext(
   check: HealthCheck,
-  ctx: HealthCheckContext & { readonly deep?: boolean },
+  ctx: HealthCheckContext & {
+    readonly deep?: boolean;
+    readonly runWithPrivateStateSnapshot: DoctorLintPrivateStateRunner;
+  },
 ): HealthCheck {
   return {
     ...check,
     detect(_ctx, scope) {
-      return check.detect(ctx, scope);
+      const detect = async () => await check.detect(ctx, scope);
+      return check.id === RUNTIME_TOOL_SCHEMA_CHECK_ID
+        ? ctx.runWithPrivateStateSnapshot(detect)
+        : detect();
     },
   };
 }

--- a/src/flows/doctor-core-checks.runtime.test.ts
+++ b/src/flows/doctor-core-checks.runtime.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GatewayClientRequestError } from "../../packages/gateway-client/src/index.js";
 import { retainGatewayResponsePayload } from "../../packages/gateway-client/src/protocol-request.js";
+import { testing as mcpResolverTesting } from "../agents/mcp-connection-resolver.js";
 import type { AnyAgentTool } from "../agents/tools/common.js";
 import { GATEWAY_HEALTH_RATE_LIMITED_MESSAGE } from "../commands/gateway-health-auth-diagnostic.js";
 import { GatewaySecretRefUnavailableError } from "../gateway/credentials.js";
@@ -102,6 +103,7 @@ function bundleMcpTool(name: string, parameters: unknown): AnyAgentTool {
 
 describe("doctor runtime tool schema checks", () => {
   beforeEach(() => {
+    mcpResolverTesting.setMcpServerConnectionResolversForTest(undefined);
     mocks.createOpenClawCodingTools.mockReset().mockReturnValue([]);
     mocks.createBundleMcpToolRuntime.mockReset().mockReturnValue({
       tools: [],
@@ -440,50 +442,91 @@ describe("doctor runtime tool schema checks", () => {
     );
   });
 
-  it("loads bundled MCP runtime once per distinct agent workspace", async () => {
+  it("reuses one bundled MCP probe for equivalent agent workspaces", async () => {
     mocks.createOpenClawCodingTools.mockReturnValue([]);
-    mocks.createBundleMcpToolRuntime.mockImplementation(
-      async (options: { workspaceDir: string }) => ({
-        tools: options.workspaceDir.includes("worker")
-          ? [
-              bundleMcpTool("fuzzplugin__move_angles", {
-                type: "array",
-                items: { type: "number" },
-              }),
-            ]
-          : [bundleMcpTool("healthy", { type: "object", properties: {} })],
-        dispose: mocks.disposeBundleRuntime,
-      }),
+    mocks.createBundleMcpToolRuntime.mockResolvedValue({
+      tools: [],
+      diagnostics: [
+        {
+          serverName: "fuzzplugin",
+          safeServerName: "fuzzplugin",
+          launchSummary: "node fuzzplugin-mcp.mjs",
+          message: "connection failed",
+        },
+      ],
+      dispose: mocks.disposeBundleRuntime,
+    });
+
+    const findings = await collectRuntimeToolSchemaFindings({
+      mcp: {
+        servers: {
+          fuzzplugin: { command: "node", args: ["fuzzplugin-mcp.mjs"] },
+        },
+      },
+      agents: {
+        list: [
+          { id: "main", default: true, workspace: "/tmp/main-workspace" },
+          { id: "worker", workspace: "/tmp/worker-workspace" },
+        ],
+      },
+    });
+
+    expect(findings).toEqual([
+      {
+        checkId: "core/doctor/runtime-tool-schemas",
+        severity: "error",
+        message:
+          'Configured MCP server "fuzzplugin" could not expose runtime tools for schema validation.',
+        path: "mcp.servers.fuzzplugin",
+        requirement: "connection failed",
+        fixHint:
+          "Fix or disable the offending MCP server, then rerun doctor before relying on assistant tool startup.",
+      },
+    ]);
+    expect(mocks.createBundleMcpToolRuntime).toHaveBeenCalledTimes(1);
+    expect(mocks.createBundleMcpToolRuntime).toHaveBeenCalledWith(
+      expect.objectContaining({ workspaceDir: expect.stringContaining("main-workspace") }),
     );
+    expect(mocks.disposeBundleRuntime).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not probe requester-scoped MCP servers without a requester", async () => {
+    const resolveConnection = vi.fn();
+    mcpResolverTesting.setMcpServerConnectionResolversForTest([
+      {
+        pluginId: "fuzzplugin",
+        serverName: "fuzzplugin",
+        resolve: resolveConnection,
+      },
+    ]);
 
     await expect(
       collectRuntimeToolSchemaFindings({
-        agents: {
-          list: [
-            { id: "main", default: true, workspace: "/tmp/main-workspace" },
-            { id: "worker", workspace: "/tmp/worker-workspace" },
-          ],
+        mcp: {
+          servers: {
+            fuzzplugin: {
+              url: "https://placeholder.invalid/mcp",
+              transport: "streamable-http",
+              auth: "oauth",
+            },
+          },
         },
       }),
     ).resolves.toContainEqual({
       checkId: "core/doctor/runtime-tool-schemas",
-      severity: "error",
+      severity: "info",
       message:
-        "Agent worker tool fuzzplugin__move_angles from plugin bundle-mcp has an unsupported input schema for runtime projection.",
-      path: "mcp.servers",
-      target: "fuzzplugin__move_angles",
-      requirement: 'fuzzplugin__move_angles.parameters.type must be "object"',
-      fixHint:
-        "Disable or update the offending MCP server/tool so its parameters are a JSON object schema, then rerun doctor.",
+        'Configured requester-scoped MCP server "fuzzplugin" was not probed without an authenticated requester.',
+      path: "mcp.servers.fuzzplugin",
+      requirement: "authenticated requester context",
+      fixHint: "Verify this server from an authenticated agent turn.",
     });
-    expect(mocks.createBundleMcpToolRuntime).toHaveBeenCalledTimes(2);
+    expect(resolveConnection).not.toHaveBeenCalled();
     expect(mocks.createBundleMcpToolRuntime).toHaveBeenCalledWith(
-      expect.objectContaining({ workspaceDir: expect.stringContaining("main-workspace") }),
+      expect.objectContaining({
+        excludeServerNames: new Set(["fuzzplugin"]),
+      }),
     );
-    expect(mocks.createBundleMcpToolRuntime).toHaveBeenCalledWith(
-      expect.objectContaining({ workspaceDir: expect.stringContaining("worker-workspace") }),
-    );
-    expect(mocks.disposeBundleRuntime).toHaveBeenCalledTimes(2);
   });
 
   it("does not report bundle MCP schemas filtered out by the final runtime tool policy", async () => {

--- a/src/flows/doctor-core-checks.runtime.ts
+++ b/src/flows/doctor-core-checks.runtime.ts
@@ -1,7 +1,8 @@
 // Doctor runtime checks inspect tool names, browser residue, and runtime state.
 import { redactSensitiveUrlLikeString } from "@openclaw/net-policy/redact-sensitive-url";
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
-import { TOOL_NAME_SEPARATOR } from "../agents/agent-bundle-mcp-names.js";
+import { assignSafeServerNames, TOOL_NAME_SEPARATOR } from "../agents/agent-bundle-mcp-names.js";
+import { loadSessionMcpConfig } from "../agents/agent-bundle-mcp-runtime-config.js";
 import type {
   BundleMcpToolRuntime,
   McpToolCatalogDiagnostic,
@@ -18,6 +19,8 @@ import { resolveConversationCapabilityProfile } from "../agents/conversation-cap
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { applyFinalEffectiveToolPolicy } from "../agents/embedded-agent-runner/effective-tool-policy.js";
 import { shouldCreateBundleMcpRuntimeForAttempt } from "../agents/embedded-agent-runner/run/attempt-tool-construction-plan.js";
+import { resolveMcpAuthProfileId } from "../agents/mcp-auth-profile.js";
+import { partitionMcpServersByConnectionScope } from "../agents/mcp-connection-resolver.js";
 import { findModelInCatalog, type ModelCatalogEntry } from "../agents/model-catalog.js";
 import { resolveDefaultModelForAgent } from "../agents/model-selection.js";
 import { supportsModelTools } from "../agents/model-tool-support.js";
@@ -1002,6 +1005,17 @@ function bundleMcpRuntimeDiagnosticFinding(diagnostic: McpToolCatalogDiagnostic)
   };
 }
 
+function bundleMcpRequesterInspectionFinding(serverName: string): HealthFinding {
+  return {
+    checkId: "core/doctor/runtime-tool-schemas",
+    severity: "info",
+    message: `Configured requester-scoped MCP server "${serverName}" was not probed without an authenticated requester.`,
+    path: `mcp.servers.${serverName}`,
+    requirement: "authenticated requester context",
+    fixHint: "Verify this server from an authenticated agent turn.",
+  };
+}
+
 function makeBundleMcpDiagnosticSentinel(name: string): AnyAgentTool {
   const sentinel: AnyAgentTool = {
     name,
@@ -1127,9 +1141,11 @@ export async function collectRuntimeToolSchemaFindings(
   options?: { runWithPluginMetadataSnapshot?: PluginMetadataSnapshotScopeRunner },
 ): Promise<readonly HealthFinding[]> {
   const findings: HealthFinding[] = [];
-  const bundleRuntimeByWorkspace = new Map<string, BundleMcpToolRuntime>();
-  const bundleRuntimeLoadErrorsByWorkspace = new Map<string, HealthFinding>();
+  const bundleRuntimeByContext = new Map<string, BundleMcpToolRuntime>();
+  const bundleRuntimeLoadErrorsByContext = new Map<string, HealthFinding>();
+  const reportedBundleRuntimeDiagnostics = new Set<string>();
   const reportedBundleRuntimeLoadErrors = new Set<string>();
+  const reportedRequesterScopedServers = new Set<string>();
   try {
     for (const agentId of listAgentIds(cfg)) {
       if (isAcpRuntimeAgent(cfg, agentId)) {
@@ -1137,10 +1153,11 @@ export async function collectRuntimeToolSchemaFindings(
       }
       const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
       const collectForAgent = async () => {
+        const agentDir = resolveAgentDir(cfg, agentId);
         const catalog = await loadPreparedModelCatalog({
           config: cfg,
           agentId,
-          agentDir: resolveAgentDir(cfg, agentId),
+          agentDir,
           readOnly: true,
           providerDiscoveryProviderIds: [],
         });
@@ -1169,36 +1186,81 @@ export async function collectRuntimeToolSchemaFindings(
         if (!shouldCreateBundleMcpRuntimeForAttempt({ toolsEnabled: true })) {
           return;
         }
+        const fullMcpConfig = loadSessionMcpConfig({
+          workspaceDir,
+          cfg,
+          logDiagnostics: false,
+        });
+        const safeServerNamesByServer = assignSafeServerNames(
+          Object.keys(fullMcpConfig.loaded.mcpServers),
+        );
+        const { requesterScopedServerNames } = partitionMcpServersByConnectionScope(
+          fullMcpConfig.loaded.mcpServers,
+        );
+        for (const serverName of requesterScopedServerNames) {
+          if (reportedRequesterScopedServers.has(serverName)) {
+            continue;
+          }
+          const diagnostic: McpToolCatalogDiagnostic = {
+            serverName,
+            safeServerName: safeServerNamesByServer.get(serverName) ?? serverName,
+            launchSummary: "requester-scoped connection",
+            message: "authenticated requester context required",
+          };
+          if (shouldReportBundleMcpRuntimeDiagnostic({ cfg, agentId, modelRef, diagnostic })) {
+            findings.push(bundleMcpRequesterInspectionFinding(serverName));
+            reportedRequesterScopedServers.add(serverName);
+          }
+        }
+        const excludeServerNames = new Set(requesterScopedServerNames);
+        const staticMcpConfig = loadSessionMcpConfig({
+          workspaceDir,
+          cfg,
+          logDiagnostics: false,
+          excludeServerNames,
+          safeServerNamesByServer,
+        });
+        const credentialContext = Object.values(staticMcpConfig.loaded.mcpServers).some(
+          resolveMcpAuthProfileId,
+        )
+          ? agentDir
+          : "shared";
+        // Equivalent static catalogs share one probe. Agent-local auth profiles retain
+        // their agent directory so one agent's credentials cannot validate another's.
+        const runtimeContext = `${staticMcpConfig.fingerprint}\0${credentialContext}`;
         if (
-          !bundleRuntimeByWorkspace.has(workspaceDir) &&
-          !bundleRuntimeLoadErrorsByWorkspace.has(workspaceDir)
+          !bundleRuntimeByContext.has(runtimeContext) &&
+          !bundleRuntimeLoadErrorsByContext.has(runtimeContext)
         ) {
           try {
             const { createBundleMcpToolRuntime } =
               await import("../agents/agent-bundle-mcp-tools.js");
-            bundleRuntimeByWorkspace.set(
-              workspaceDir,
+            bundleRuntimeByContext.set(
+              runtimeContext,
               await createBundleMcpToolRuntime({
                 workspaceDir,
+                agentDir,
                 cfg,
+                excludeServerNames,
+                safeServerNamesByServer,
               }),
             );
           } catch (error) {
-            bundleRuntimeLoadErrorsByWorkspace.set(
-              workspaceDir,
+            bundleRuntimeLoadErrorsByContext.set(
+              runtimeContext,
               bundleMcpRuntimeLoadFailureFinding(error),
             );
           }
         }
-        const bundleRuntimeLoadError = bundleRuntimeLoadErrorsByWorkspace.get(workspaceDir);
+        const bundleRuntimeLoadError = bundleRuntimeLoadErrorsByContext.get(runtimeContext);
         if (bundleRuntimeLoadError) {
-          if (!reportedBundleRuntimeLoadErrors.has(workspaceDir)) {
+          if (!reportedBundleRuntimeLoadErrors.has(runtimeContext)) {
             findings.push(bundleRuntimeLoadError);
-            reportedBundleRuntimeLoadErrors.add(workspaceDir);
+            reportedBundleRuntimeLoadErrors.add(runtimeContext);
           }
           return;
         }
-        const bundleRuntime = bundleRuntimeByWorkspace.get(workspaceDir);
+        const bundleRuntime = bundleRuntimeByContext.get(runtimeContext);
         if (bundleRuntime) {
           if (bundleRuntime.diagnostics && bundleRuntime.diagnostics.length > 0) {
             const policyActiveDiagnostics = filterPolicyActiveBundleMcpDiagnostics({
@@ -1207,7 +1269,13 @@ export async function collectRuntimeToolSchemaFindings(
               agentId,
               modelRef,
             });
-            findings.push(...policyActiveDiagnostics.map(bundleMcpRuntimeDiagnosticFinding));
+            for (const diagnostic of policyActiveDiagnostics) {
+              if (reportedBundleRuntimeDiagnostics.has(diagnostic.serverName)) {
+                continue;
+              }
+              findings.push(bundleMcpRuntimeDiagnosticFinding(diagnostic));
+              reportedBundleRuntimeDiagnostics.add(diagnostic.serverName);
+            }
           }
           findings.push(
             ...collectBundleMcpRuntimeToolSchemaFindings({
@@ -1228,7 +1296,7 @@ export async function collectRuntimeToolSchemaFindings(
       }
     }
   } finally {
-    await Promise.all([...bundleRuntimeByWorkspace.values()].map((runtime) => runtime.dispose()));
+    await Promise.all([...bundleRuntimeByContext.values()].map((runtime) => runtime.dispose()));
   }
   return findings;
 }


### PR DESCRIPTION
Closes #134605

Reported by @pfrederiksen.

## What Problem This Solves

Fixes an issue where operators running `openclaw doctor --lint` could get a false MCP OAuth failure, repeated server findings, and a command that did not finish while the live SQLite state database was busy.

## Why This Change Was Made

Doctor now runs runtime MCP schema inspection against a private copy of state, excludes requester-scoped connections when no requester identity exists, and reuses one probe for equivalent static MCP contexts. Agent-local auth profiles remain isolated by agent directory.

The production increase establishes the missing read-only ownership boundary and keeps requester credentials out of anonymous inspection. It does not add configuration, storage, migration, or compatibility surface.

## User Impact

`openclaw doctor --lint` now finishes without contending on live MCP OAuth state. It emits one server result per effective MCP context and reports requester-scoped servers as an informational inspection limit instead of a broken login.

## Evidence

- Baseline `c50533f9d944e7cced59c650b426d3ea18dfc7d0`: a valid stored bearer reached a loopback MCP server without contention; with `BEGIN IMMEDIATE` held on `state/openclaw.sqlite`, `timeout 45s openclaw doctor --lint --only core/doctor/runtime-tool-schemas` exited `124` after 45 seconds and logged repeated SQLite lock failures.
- Head `faa991f54552f55dead26a2b2868298702a7d310`: the same held-lock command exited `0` in 4 seconds, initialized the MCP server once, returned no findings, used the stored bearer, and left the source SQLite database family byte-identical.
- Regression tests failed on the baseline for locked OAuth inspection, duplicate cross-workspace probing, and requester-scoped inspection. They pass on the head.
- `node scripts/run-vitest.mjs src/commands/doctor-lint.test.ts src/flows/doctor-core-checks.runtime.test.ts src/flows/doctor-core-checks.test.ts src/agents/agent-bundle-mcp-tools.materialize.test.ts src/agents/mcp-connection-resolver.test.ts src/agents/agent-bundle-mcp-manager.requester-connect.test.ts src/agents/mcp-oauth.test.ts`
- Targeted Oxfmt, type-aware Oxlint, max-lines, assertion-safety, import-cycle, coercion-helper, dead-code, and diff checks pass.
- Local Autoreview and the exact-head land gate: no P0 findings; patch judged correct.

Production LOC: +169/-37 (net +132). Tests: +211/-31 (net +180).
