### PR TITLE
fix(update): block restart when plugin readiness fails

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -287,6 +287,10 @@ then refreshes service metadata, restarts the service, and verifies the
 restarted Gateway before reporting `Gateway: restarted and verified.`.
 Doctor repair and plugin validation run before restart; a verified restart
 does not run another Doctor from the old updater process.
+After plugin convergence, the updated CLI also runs any plugin-owned
+post-update readiness checks against an isolated state snapshot. An error keeps
+the Gateway stopped and returns the check's remediation before restart; this
+gate does not run interactive setup, download models, or change config.
 Package-manager updates additionally verify the restarted Gateway reports the
 expected package version; git-checkout updates verify gateway health and
 service readiness after the rebuild.

--- a/extensions/memory-core/src/doctor-health.test.ts
+++ b/extensions/memory-core/src/doctor-health.test.ts
@@ -71,7 +71,10 @@ function context(stateDir: string, provider: string): HealthCheckContext {
 
 describe("managed local embedding setup health check", () => {
   it("stays opt-in outside an explicit pre-cutover selection", () => {
-    expect(captureCheck()).toMatchObject({ defaultEnabled: false });
+    expect(captureCheck()).toMatchObject({
+      defaultEnabled: false,
+      updateReadiness: "post-plugin",
+    });
   });
 
   it("refreshes current host state and re-registers after a registry reset", async () => {

--- a/extensions/memory-core/src/doctor-health.ts
+++ b/extensions/memory-core/src/doctor-health.ts
@@ -38,10 +38,15 @@ type MemoryCoreDoctorRegistrationState = Pick<
   "inspectEmbeddingProviderSetup" | "memoryCoreActive"
 >;
 
+type MemoryCoreDoctorCheck = HealthCheck & {
+  readonly defaultEnabled: false;
+  readonly updateReadiness: "post-plugin";
+};
+
 const registrationsByHost = new WeakMap<
   MemoryCoreDoctorRegistrationHost["registerHealthCheck"],
   {
-    readonly check: HealthCheck & { readonly defaultEnabled: false };
+    readonly check: MemoryCoreDoctorCheck;
     readonly state: MemoryCoreDoctorRegistrationState;
   }
 >();
@@ -64,12 +69,13 @@ function resolveSelectedMemoryProvider(
 
 function createManagedLocalEmbeddingSetupCheck(
   state: MemoryCoreDoctorRegistrationState,
-): HealthCheck & { readonly defaultEnabled: false } {
+): MemoryCoreDoctorCheck {
   return {
     id: MEMORY_MANAGED_LOCAL_EMBEDDING_SETUP_CHECK_ID,
     kind: "plugin",
     source: "memory-core",
     defaultEnabled: false,
+    updateReadiness: "post-plugin",
     description: "Checks existing semantic indexes for required managed local embedding setup.",
     async detect(ctx) {
       if (!state.memoryCoreActive) {

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -283,6 +283,18 @@ vi.mock("../process/exec.js", () => ({
   })),
 }));
 
+vi.mock("./update-cli/update-command-post-plugin-readiness.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("./update-cli/update-command-post-plugin-readiness.js")>();
+  return {
+    ...actual,
+    applyPostPluginUpdateReadiness: vi.fn(
+      async (params: Parameters<typeof actual.applyPostPluginUpdateReadiness>[0]) =>
+        params.pluginUpdate,
+    ),
+  };
+});
+
 vi.mock("../utils.js", async (importOriginal) => {
   const [actual, { isRecord }] = await Promise.all([
     importOriginal<typeof import("../utils.js")>(),

--- a/src/cli/update-cli/update-command-fresh-doctor.test.ts
+++ b/src/cli/update-cli/update-command-fresh-doctor.test.ts
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PostCorePluginUpdateResult } from "./update-command-plugins.js";
+
+const mocks = vi.hoisted(() => ({
+  readConfig: vi.fn(),
+  resolveEntrypoint: vi.fn(),
+  runExec: vi.fn(),
+}));
+
+vi.mock("../../config/config.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../config/config.js")>()),
+  readConfigFileSnapshot: mocks.readConfig,
+}));
+
+vi.mock("../../daemon/gateway-entrypoint.js", () => ({
+  resolveGatewayInstallEntrypoint: mocks.resolveEntrypoint,
+}));
+
+vi.mock("../../process/exec.js", () => ({
+  runExec: mocks.runExec,
+}));
+
+vi.mock("../../runtime.js", () => ({
+  defaultRuntime: { error: vi.fn(), log: vi.fn() },
+}));
+
+vi.mock("./shared.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./shared.js")>()),
+  resolveNodeRunner: vi.fn(() => "/usr/bin/node"),
+}));
+
+import { completePostCorePluginUpdate } from "./update-command-fresh-doctor.js";
+
+const pluginUpdate: PostCorePluginUpdateResult = {
+  status: "ok",
+  changed: true,
+  sync: {
+    changed: false,
+    switchedToBundled: [],
+    switchedToNpm: [],
+    warnings: [],
+    errors: [],
+  },
+  npm: { changed: false, outcomes: [] },
+  integrityDrifts: [],
+  warnings: [],
+};
+
+const validConfigSnapshot = {
+  valid: true as const,
+  parsed: {},
+  config: {},
+  runtimeConfig: {},
+  sourceConfig: {},
+  warnings: [],
+  issues: [],
+  legacyIssues: [],
+};
+
+describe("post-plugin update readiness", () => {
+  beforeEach(() => {
+    mocks.readConfig.mockReset().mockResolvedValue(validConfigSnapshot);
+    mocks.resolveEntrypoint.mockReset().mockResolvedValue("/opt/openclaw/dist/index.js");
+    mocks.runExec.mockReset().mockImplementation(async (_command, args: string[]) => ({
+      stdout: args.includes("--lint")
+        ? `${JSON.stringify({ ok: true, checksRun: 1, checksSkipped: 0, findings: [] })}\n`
+        : "",
+      stderr: "",
+    }));
+  });
+
+  it("runs declared readiness checks in the updated process before accepting restart", async () => {
+    await completePostCorePluginUpdate({
+      root: "/opt/openclaw",
+      pluginUpdate,
+      freshDoctorRequired: true,
+      yes: true,
+      json: true,
+      timeoutMs: 5_000,
+    });
+
+    expect(mocks.runExec.mock.calls.map(([, args]) => args)).toEqual([
+      [
+        "/opt/openclaw/dist/index.js",
+        "doctor",
+        "--repair",
+        "--non-interactive",
+        "--no-workspace-suggestions",
+        "--yes",
+      ],
+      ["/opt/openclaw/dist/index.js", "config", "validate", "--json"],
+      ["/opt/openclaw/dist/index.js", "doctor", "--lint", "--json", "--severity-min", "error"],
+    ]);
+    expect(mocks.runExec.mock.calls[2]?.[2]).toMatchObject({
+      env: { OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: "1" },
+    });
+  });
+
+  it("runs updated readiness checks even when no plugin package changed", async () => {
+    await completePostCorePluginUpdate({
+      root: "/opt/openclaw",
+      pluginUpdate: { ...pluginUpdate, changed: false },
+      freshDoctorRequired: false,
+      yes: true,
+      json: true,
+      timeoutMs: 5_000,
+    });
+
+    expect(mocks.runExec.mock.calls.map(([, args]) => args)).toEqual([
+      ["/opt/openclaw/dist/index.js", "doctor", "--lint", "--json", "--severity-min", "error"],
+    ]);
+  });
+
+  it("returns the owner-provided remediation and refuses restart when readiness fails", async () => {
+    mocks.runExec.mockImplementation(async (_command, args: string[]) => {
+      if (args.includes("--lint")) {
+        throw Object.assign(new Error("readiness failed"), {
+          exitCode: 1,
+          stdout: `${JSON.stringify({
+            ok: false,
+            checksRun: 1,
+            checksSkipped: 0,
+            findings: [
+              {
+                checkId: "memory-core/managed-local-embedding-setup",
+                severity: "error",
+                source: "memory-core",
+                message: "Managed local embeddings are unavailable.",
+                fixHint:
+                  "Run `openclaw models --agent main auth login --provider llama-cpp --method local`.",
+              },
+            ],
+          })}\n`,
+          stderr: "",
+        });
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    const result = await completePostCorePluginUpdate({
+      root: "/opt/openclaw",
+      pluginUpdate,
+      freshDoctorRequired: true,
+      yes: true,
+      json: true,
+      timeoutMs: 5_000,
+    });
+
+    expect(result.pluginUpdate).toMatchObject({
+      status: "error",
+      reason: "post-plugin-update-readiness-failed",
+      warnings: [
+        {
+          pluginId: "memory-core",
+          reason: "memory-core/managed-local-embedding-setup",
+          message: "Managed local embeddings are unavailable.",
+          guidance: [
+            "Run `openclaw models --agent main auth login --provider llama-cpp --method local`.",
+          ],
+        },
+      ],
+    });
+  });
+
+  it.each([
+    {
+      label: "malformed output",
+      stdout: "{not-json\n",
+    },
+    {
+      label: "no declared check",
+      stdout: `${JSON.stringify({ ok: true, checksRun: 0, checksSkipped: 0, findings: [] })}\n`,
+    },
+  ])("fails closed on $label from the updated readiness child", async ({ stdout }) => {
+    mocks.runExec.mockImplementation(async (_command, args: string[]) => ({
+      stdout: args.includes("--lint") ? stdout : "",
+      stderr: "",
+    }));
+
+    const result = await completePostCorePluginUpdate({
+      root: "/opt/openclaw",
+      pluginUpdate,
+      freshDoctorRequired: true,
+      yes: true,
+      json: true,
+      timeoutMs: 5_000,
+    });
+
+    expect(result.pluginUpdate).toMatchObject({
+      status: "error",
+      reason: "post-plugin-update-readiness-execution-failed",
+      warnings: [
+        expect.objectContaining({
+          message: "Updated plugin readiness checks could not be completed before restart.",
+        }),
+      ],
+    });
+  });
+});

--- a/src/cli/update-cli/update-command-fresh-doctor.ts
+++ b/src/cli/update-cli/update-command-fresh-doctor.ts
@@ -1,4 +1,4 @@
-// Runs the post-plugin migration pass without retaining pre-update plugin modules.
+// Runs post-plugin convergence checks without retaining pre-update plugin modules.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   UPDATE_DEFER_CONFIGURED_PLUGIN_INSTALL_REPAIR_ENV,
@@ -13,6 +13,7 @@ import { runExec } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
 import { resolveNodeRunner } from "./shared.js";
 import type { PostCorePluginUpdateResult } from "./update-command-plugins.js";
+import { applyPostPluginUpdateReadiness } from "./update-command-post-plugin-readiness.js";
 import {
   applyPostPluginConfigValidation,
   POST_PLUGIN_DOCTOR_EXECUTION_FAILED_REASON,
@@ -218,6 +219,15 @@ async function applyFreshPostPluginDoctor(params: {
     pluginUpdate = createPostPluginDoctorExecutionFailure(params.pluginUpdate, String(err));
   }
   const configValid = await validatePostPluginConfigInFreshProcess({ ...params, entryPath });
+  if (configValid) {
+    pluginUpdate = await applyPostPluginUpdateReadiness({
+      root: params.root,
+      entryPath,
+      pluginUpdate,
+      timeoutMs: params.timeoutMs,
+      ...(params.nodeRunner ? { nodeRunner: params.nodeRunner } : {}),
+    });
+  }
   return { pluginUpdate, configValid };
 }
 
@@ -248,6 +258,13 @@ export async function completePostCorePluginUpdate(params: {
     });
     pluginUpdate = freshResult.pluginUpdate;
     freshConfigValid = freshResult.configValid;
+  } else if (pluginUpdate.status !== "error") {
+    pluginUpdate = await applyPostPluginUpdateReadiness({
+      root: params.root,
+      pluginUpdate,
+      timeoutMs: params.timeoutMs,
+      ...(params.nodeRunner ? { nodeRunner: params.nodeRunner } : {}),
+    });
   }
 
   const configSnapshot = await withNormalConfigValidation(() => readConfigFileSnapshot());

--- a/src/cli/update-cli/update-command-lease.test-support.ts
+++ b/src/cli/update-cli/update-command-lease.test-support.ts
@@ -10,6 +10,7 @@ export type LeaseScenario = {
   preDoctorChannel?: string;
   invalidConfig?: boolean;
   failDoctor?: "pre" | "post";
+  readinessFailure?: "finding" | "execution";
   hostVersion?: string;
   doctorWrites?: boolean;
   writerConfig?: OpenClawConfig;
@@ -45,6 +46,36 @@ export async function runUpdateLeaseChild(): Promise<void> {
     assert.equal(process.env.OPENCLAW_UPDATE_IN_PROGRESS, "0");
     await record("validate");
     process.exitCode = scenario.invalidConfig ? 1 : 0;
+    return;
+  }
+  if (command === "doctor" && process.argv[3] === "--lint") {
+    assert.deepEqual(process.argv.slice(3), ["--lint", "--json", "--severity-min", "error"]);
+    assert.equal(process.env.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE, "1");
+    await record("readiness");
+    if (scenario.readinessFailure === "execution") {
+      throw new Error("readiness fixture failure");
+    }
+    const findings =
+      scenario.readinessFailure === "finding"
+        ? [
+            {
+              checkId: "fixture/post-plugin-readiness",
+              severity: "error",
+              source: "fixture",
+              message: "Fixture plugin is not ready.",
+              fixHint: "Run the fixture repair command.",
+            },
+          ]
+        : [];
+    process.stdout.write(
+      `${JSON.stringify({
+        ok: findings.length === 0,
+        checksRun: 1,
+        checksSkipped: 0,
+        findings,
+      })}\n`,
+    );
+    process.exitCode = findings.length === 0 ? 0 : 1;
     return;
   }
   const { withPluginLifecycleLease } = await import("../../plugins/plugin-lifecycle-lease.js");

--- a/src/cli/update-cli/update-command-lease.test.ts
+++ b/src/cli/update-cli/update-command-lease.test.ts
@@ -211,6 +211,7 @@ describe("update orchestration lifecycle ownership", () => {
         "post-attempt",
         "post-acquired",
         "validate",
+        "readiness",
       ]);
       if (lane === "current-process") {
         expect(process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION).toBeUndefined();
@@ -329,6 +330,7 @@ describe("update orchestration lifecycle ownership", () => {
         "post-attempt",
         "post-acquired",
         "validate",
+        "readiness",
       ]);
     },
   );
@@ -340,7 +342,7 @@ describe("update orchestration lifecycle ownership", () => {
       mocks.plugins.mockResolvedValueOnce({ ...pluginResult, changed: false });
       await invoke(lane);
       expectSuccess(lane);
-      expect(await events()).toEqual(["pre-attempt", "pre-acquired"]);
+      expect(await events()).toEqual(["pre-attempt", "pre-acquired", "readiness"]);
     },
   );
 
@@ -419,8 +421,69 @@ describe("update orchestration lifecycle ownership", () => {
     expect(mocks.restart).toHaveBeenCalledOnce();
     expect(process.env.OPENCLAW_COMPATIBILITY_HOST_VERSION).toBeUndefined();
     expectDoctorDiagnostics();
-    expect(await events()).toEqual(["post-attempt", "post-acquired", "validate"]);
+    expect(await events()).toEqual(["post-attempt", "post-acquired", "validate", "readiness"]);
   });
+
+  it.each([
+    {
+      lane: "resume" as const,
+      failure: "finding" as const,
+      reason: "post-plugin-update-readiness-failed",
+    },
+    {
+      lane: "resume" as const,
+      failure: "execution" as const,
+      reason: "post-plugin-update-readiness-execution-failed",
+    },
+    {
+      lane: "current-process" as const,
+      failure: "finding" as const,
+      reason: "post-plugin-update-readiness-failed",
+    },
+    {
+      lane: "current-process" as const,
+      failure: "execution" as const,
+      reason: "post-plugin-update-readiness-execution-failed",
+    },
+    {
+      lane: "repair" as const,
+      failure: "finding" as const,
+      reason: "post-plugin-update-readiness-failed",
+    },
+    {
+      lane: "repair" as const,
+      failure: "execution" as const,
+      reason: "post-plugin-update-readiness-execution-failed",
+    },
+  ])(
+    "$lane leaves the Gateway stopped after a readiness $failure",
+    async ({ lane, failure, reason }) => {
+      await writeScenario(lane, {
+        readinessFailure: failure,
+        hostVersion: lane === "repair" ? undefined : "1.0.0",
+      });
+
+      await invoke(lane);
+
+      const output =
+        lane === "current-process"
+          ? mocks.print.mock.lastCall?.[0]
+          : vi.mocked(defaultRuntime.writeJson).mock.lastCall?.[0];
+      expect(output).toMatchObject({
+        status: "error",
+        postUpdate: { plugins: { reason } },
+      });
+      expect(defaultRuntime.exit).toHaveBeenCalledWith(lane === "resume" ? 0 : 1);
+      expect(mocks.restart).not.toHaveBeenCalled();
+      expect(await events()).toEqual([
+        ...(lane === "current-process" ? [] : ["pre-attempt", "pre-acquired"]),
+        "post-attempt",
+        "post-acquired",
+        "validate",
+        "readiness",
+      ]);
+    },
+  );
 
   it.each([
     { lane: "resume", valid: true },
@@ -466,6 +529,7 @@ describe("update orchestration lifecycle ownership", () => {
         "post-attempt",
         "post-acquired",
         "validate",
+        ...(valid ? ["readiness"] : []),
       ]);
     },
   );

--- a/src/cli/update-cli/update-command-post-plugin-readiness.ts
+++ b/src/cli/update-cli/update-command-post-plugin-readiness.ts
@@ -1,0 +1,163 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { UPDATE_POST_CORE_CONVERGENCE_ENV } from "../../commands/doctor/shared/update-phase.js";
+import { resolveGatewayInstallEntrypoint } from "../../daemon/gateway-entrypoint.js";
+import { runExec } from "../../process/exec.js";
+import { resolveNodeRunner } from "./shared.js";
+import type { PostCorePluginUpdateResult } from "./update-command-plugins.js";
+import {
+  disableUpdatedPackageCompileCacheEnv,
+  stripGatewayServiceMarkerEnv,
+} from "./update-command-service-env.js";
+
+type UpdateReadinessFinding = {
+  checkId: string;
+  message: string;
+  source?: string;
+  fixHint?: string;
+};
+
+type UpdateReadinessReport = {
+  ok: boolean;
+  checksRun: number;
+  findings: UpdateReadinessFinding[];
+};
+
+function parseUpdateReadinessReport(stdout: string): UpdateReadinessReport {
+  const result: unknown = JSON.parse(stdout);
+  if (
+    !isRecord(result) ||
+    typeof result.ok !== "boolean" ||
+    typeof result.checksRun !== "number" ||
+    !Number.isInteger(result.checksRun) ||
+    result.checksRun < 0 ||
+    !Array.isArray(result.findings)
+  ) {
+    throw new Error("Updated Doctor returned an invalid readiness result.");
+  }
+  const findings = result.findings.map((finding): UpdateReadinessFinding => {
+    if (
+      !isRecord(finding) ||
+      typeof finding.checkId !== "string" ||
+      typeof finding.message !== "string" ||
+      (finding.source !== undefined && typeof finding.source !== "string") ||
+      (finding.fixHint !== undefined && typeof finding.fixHint !== "string")
+    ) {
+      throw new Error("Updated Doctor returned an invalid readiness finding.");
+    }
+    return {
+      checkId: finding.checkId,
+      message: finding.message,
+      ...(finding.source !== undefined ? { source: finding.source } : {}),
+      ...(finding.fixHint !== undefined ? { fixHint: finding.fixHint } : {}),
+    };
+  });
+  return { ok: result.ok, checksRun: result.checksRun, findings };
+}
+
+function createPostPluginReadinessExecutionFailure(
+  pluginUpdate: PostCorePluginUpdateResult,
+  reason: string,
+): PostCorePluginUpdateResult {
+  return {
+    ...pluginUpdate,
+    status: "error",
+    reason: "post-plugin-update-readiness-execution-failed",
+    warnings: [
+      ...(pluginUpdate.warnings ?? []),
+      {
+        reason,
+        message: "Updated plugin readiness checks could not be completed before restart.",
+        guidance: ["Run `openclaw update repair` to retry post-update readiness checks."],
+      },
+    ],
+  };
+}
+
+export async function applyPostPluginUpdateReadiness(params: {
+  root: string;
+  entryPath?: string;
+  pluginUpdate: PostCorePluginUpdateResult;
+  timeoutMs: number;
+  nodeRunner?: string;
+}): Promise<PostCorePluginUpdateResult> {
+  let entryPath = params.entryPath;
+  if (!entryPath) {
+    try {
+      entryPath = await resolveGatewayInstallEntrypoint(params.root);
+    } catch (error) {
+      return createPostPluginReadinessExecutionFailure(params.pluginUpdate, String(error));
+    }
+  }
+  if (!entryPath) {
+    return createPostPluginReadinessExecutionFailure(
+      params.pluginUpdate,
+      "Updated OpenClaw entrypoint not found for post-plugin readiness checks",
+    );
+  }
+  const args = [entryPath, "doctor", "--lint", "--json", "--severity-min", "error"];
+  const baseEnv = stripGatewayServiceMarkerEnv(disableUpdatedPackageCompileCacheEnv(process.env));
+  delete baseEnv[UPDATE_POST_CORE_CONVERGENCE_ENV];
+  let stdout: string;
+  let executionFailed = false;
+  try {
+    stdout = (
+      await runExec(params.nodeRunner ?? resolveNodeRunner(), args, {
+        cwd: params.root,
+        timeoutMs: params.timeoutMs,
+        maxBuffer: 4 * 1024 * 1024,
+        logOutput: false,
+        baseEnv,
+        env: {
+          OPENCLAW_UPDATE_IN_PROGRESS: "1",
+          [UPDATE_POST_CORE_CONVERGENCE_ENV]: "1",
+        },
+      })
+    ).stdout;
+  } catch (error) {
+    if (!isRecord(error) || typeof error.stdout !== "string") {
+      return createPostPluginReadinessExecutionFailure(params.pluginUpdate, String(error));
+    }
+    executionFailed = true;
+    stdout = error.stdout;
+  }
+
+  let report: UpdateReadinessReport;
+  try {
+    report = parseUpdateReadinessReport(stdout);
+  } catch (error) {
+    return createPostPluginReadinessExecutionFailure(params.pluginUpdate, String(error));
+  }
+  if (report.ok && !executionFailed && report.checksRun > 0 && report.findings.length === 0) {
+    return params.pluginUpdate;
+  }
+  if (report.findings.length === 0) {
+    return createPostPluginReadinessExecutionFailure(
+      params.pluginUpdate,
+      report.checksRun === 0
+        ? "Updated Doctor did not run a declared readiness check."
+        : "Updated Doctor readiness checks failed without a finding.",
+    );
+  }
+  return {
+    ...params.pluginUpdate,
+    status: "error",
+    reason: "post-plugin-update-readiness-failed",
+    warnings: [
+      ...(params.pluginUpdate.warnings ?? []),
+      ...report.findings.map((finding) => {
+        const warning: NonNullable<PostCorePluginUpdateResult["warnings"]>[number] = {
+          reason: finding.checkId,
+          message: finding.message,
+          guidance: [
+            finding.fixHint ??
+              `Resolve this finding, then rerun \`openclaw doctor --lint --only ${finding.checkId}\`.`,
+          ],
+        };
+        if (finding.source) {
+          warning.pluginId = finding.source;
+        }
+        return warning;
+      }),
+    ],
+  };
+}

--- a/src/cli/update-finalization-output.test-support.ts
+++ b/src/cli/update-finalization-output.test-support.ts
@@ -12,6 +12,10 @@ const sourceUrl = (relative: string) => new URL(relative, import.meta.url).href;
 const doctorSource = `
 import { intro, note, outro } from ${JSON.stringify(pathToFileURL(require.resolve("@clack/prompts")).href)};
 export async function doctorCommand() {
+  if (process.argv.includes('--lint')) {
+    console.log(JSON.stringify({ ok: true, checksRun: 1, checksSkipped: 0, findings: [] }));
+    return;
+  }
   intro('OpenClaw doctor');
   note('Doctor panel diagnostic', 'Repair');
   if (!process.argv.includes('--no-workspace-suggestions')) note('Doctor workspace diagnostic', 'Workspace');

--- a/src/commands/doctor-lint.test.ts
+++ b/src/commands/doctor-lint.test.ts
@@ -714,22 +714,13 @@ describe("runDoctorLintCli", () => {
     }
   });
 
-  it("keeps relevant deferred plugin inspection off the source state database", async () => {
+  it("runs post-plugin readiness against an isolated state snapshot", async () => {
     const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-lint-relevant-"));
     const stateDir = path.join(rootDir, "operator-state");
     const configPath = path.join(stateDir, "openclaw.json");
     const config = {
       gateway: { mode: "local" },
       memory: { search: { provider: "local", fallback: "none" } },
-      models: {
-        providers: {
-          "fixture-external": {
-            baseUrl: "http://127.0.0.1:19432/v1",
-            api: "openai-completions",
-            models: [],
-          },
-        },
-      },
     } satisfies OpenClawConfig;
     fs.mkdirSync(stateDir, { recursive: true });
     fs.writeFileSync(configPath, `${JSON.stringify(config)}\n`);
@@ -760,10 +751,12 @@ describe("runDoctorLintCli", () => {
       HOME: process.env.HOME,
       OPENCLAW_CONFIG_PATH: process.env.OPENCLAW_CONFIG_PATH,
       OPENCLAW_STATE_DIR: process.env.OPENCLAW_STATE_DIR,
+      OPENCLAW_UPDATE_POST_CORE_CONVERGENCE: process.env.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE,
     };
     process.env.HOME = stateDir;
     process.env.OPENCLAW_CONFIG_PATH = configPath;
     process.env.OPENCLAW_STATE_DIR = stateDir;
+    process.env.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE = "1";
     mocks.readConfigFileSnapshot.mockImplementation((...args: unknown[]) =>
       mocks.actualReadConfigFileSnapshot(...args),
     );
@@ -774,7 +767,6 @@ describe("runDoctorLintCli", () => {
         runDoctorLintCli(runtime, {
           json: true,
           severityMin: "error",
-          onlyIds: ["memory-core/managed-local-embedding-setup"],
         }),
       ).resolves.toBe(1);
       expect(JSON.parse(String(stdout.mock.calls.at(-1)?.[0]))).toMatchObject({
@@ -1033,6 +1025,7 @@ function restoreDoctorLintTestEnv(values: {
   HOME: string | undefined;
   OPENCLAW_CONFIG_PATH: string | undefined;
   OPENCLAW_STATE_DIR: string | undefined;
+  OPENCLAW_UPDATE_POST_CORE_CONVERGENCE?: string | undefined;
 }): void {
   if (values.HOME === undefined) {
     delete process.env.HOME;
@@ -1048,5 +1041,11 @@ function restoreDoctorLintTestEnv(values: {
     delete process.env.OPENCLAW_STATE_DIR;
   } else {
     process.env.OPENCLAW_STATE_DIR = values.OPENCLAW_STATE_DIR;
+  }
+  if (values.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE === undefined) {
+    delete process.env.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE;
+  } else {
+    process.env.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE =
+      values.OPENCLAW_UPDATE_POST_CORE_CONVERGENCE;
   }
 }

--- a/src/commands/doctor-lint.ts
+++ b/src/commands/doctor-lint.ts
@@ -15,6 +15,7 @@ import { resolveDoctorContributionHealthChecks } from "../flows/doctor-health-co
 import {
   exitCodeFromFindings,
   runDoctorLintChecks,
+  selectUpdateReadinessChecks,
   type DoctorLintRunOptions,
 } from "../flows/doctor-lint-flow.js";
 import { listExtensionHealthChecksForDoctor } from "../flows/health-check-registry.js";
@@ -32,6 +33,7 @@ import {
 } from "../plugins/install-root-context.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { isPostCoreConvergencePass } from "./doctor/shared/update-phase.js";
 
 interface DoctorLintCliOptions {
   readonly json?: boolean;
@@ -41,6 +43,7 @@ interface DoctorLintCliOptions {
   readonly allowExec?: boolean;
   readonly deep?: boolean;
   readonly includeAllChecks?: boolean;
+  readonly updateReadiness?: "post-plugin";
 }
 
 type DoctorLintStateView = {
@@ -109,10 +112,12 @@ async function prepareDoctorLintExecution(
   }
   maybeLoadDotEnvForConfig(process.env);
   const sourceEnv = { ...process.env };
-  const pluginStateMode = resolveBundledHealthCheckPluginStateMode(opts);
+  const updateReadiness = isPostCoreConvergencePass(sourceEnv) ? "post-plugin" : undefined;
+  const effectiveOpts: DoctorLintCliOptions = updateReadiness ? { ...opts, updateReadiness } : opts;
+  const pluginStateMode = resolveBundledHealthCheckPluginStateMode(effectiveOpts);
   let execution: DoctorLintExecution;
   if (pluginStateMode === "direct") {
-    execution = await executeDoctorLint(runtime, opts, sevMin, {
+    execution = await executeDoctorLint(runtime, effectiveOpts, sevMin, {
       pluginMetadataEnv: sourceEnv,
       readConfigSnapshot: () => readConfigFileSnapshot({ observe: false }),
       sourceEnv,
@@ -127,7 +132,7 @@ async function prepareDoctorLintExecution(
       observe: false,
       pluginValidation: "core-only",
     });
-    execution = await executeDoctorLint(runtime, opts, sevMin, {
+    execution = await executeDoctorLint(runtime, effectiveOpts, sevMin, {
       pluginMetadataEnv: sourceEnv,
       readConfigSnapshot: () => configIo.readConfigFileSnapshot(),
       sourceEnv,
@@ -143,7 +148,7 @@ async function prepareDoctorLintExecution(
           configPath: sourceConfigPath,
           observe: false,
         });
-        return await executeDoctorLint(runtime, opts, sevMin, {
+        return await executeDoctorLint(runtime, effectiveOpts, sevMin, {
           pluginMetadataEnv,
           readConfigSnapshot: () => configIo.readConfigFileSnapshot(),
           sourceEnv,
@@ -154,7 +159,7 @@ async function prepareDoctorLintExecution(
       if (!(error instanceof DoctorLintStateSnapshotError)) {
         throw error;
       }
-      execution = createStateSnapshotFailureExecution(runtime, opts, sevMin, error);
+      execution = createStateSnapshotFailureExecution(runtime, effectiveOpts, sevMin, error);
     }
   }
   return execution;
@@ -222,9 +227,15 @@ async function executeDoctorLint(
     : listExtensionHealthChecksForDoctor(coreChecks);
   const coreCtx = { ...ctx, deep: opts.deep === true };
 
+  const checks = [
+    ...coreChecks.map((check) => withCoreLintContext(check, coreCtx)),
+    ...extensionChecks,
+  ];
   const runOpts: DoctorLintRunOptions = {
-    checks: [...coreChecks.map((check) => withCoreLintContext(check, coreCtx)), ...extensionChecks],
-    includeAllChecks: opts.includeAllChecks === true,
+    checks: opts.updateReadiness
+      ? selectUpdateReadinessChecks(checks, opts.updateReadiness)
+      : checks,
+    includeAllChecks: opts.updateReadiness !== undefined || opts.includeAllChecks === true,
     ...(opts.skipIds && opts.skipIds.length > 0 ? { skipIds: opts.skipIds } : {}),
     ...(opts.onlyIds && opts.onlyIds.length > 0 ? { onlyIds: opts.onlyIds } : {}),
   };

--- a/src/flows/bundled-health-checks.test.ts
+++ b/src/flows/bundled-health-checks.test.ts
@@ -108,6 +108,11 @@ describe("registerBundledHealthChecks", () => {
       expected: "isolated",
     },
     {
+      title: "isolates checks selected by the post-plugin update gate",
+      selection: { updateReadiness: "post-plugin" },
+      expected: "isolated",
+    },
+    {
       title: "isolates mixed explicit selections",
       selection: {
         onlyIds: [STATE_DEFERRED_CHECK_ID, "core/doctor/final-config-validation"],

--- a/src/flows/bundled-health-checks.ts
+++ b/src/flows/bundled-health-checks.ts
@@ -57,6 +57,7 @@ type BundledHealthCheckSelection = {
   readonly skipIds?: readonly string[];
   readonly onlyIds?: readonly string[];
   readonly includeAllChecks?: boolean;
+  readonly updateReadiness?: "post-plugin";
 };
 
 type BundledHealthCheckPluginStateMode = "direct" | "deferred" | "isolated";
@@ -71,6 +72,11 @@ function loadMemoryCoreHealthApi(): BundledHealthApi {
 export function resolveBundledHealthCheckPluginStateMode(
   selection: BundledHealthCheckSelection,
 ): BundledHealthCheckPluginStateMode {
+  if (selection.updateReadiness !== undefined) {
+    // Update gates may inspect plugin-owned persistent state. Keep every phase on a private
+    // snapshot so a future tagged check cannot accidentally mutate the live pre-restart owner.
+    return "isolated";
+  }
   if (
     selection.includeAllChecks !== true &&
     (selection.onlyIds === undefined || selection.onlyIds.length === 0)

--- a/src/flows/doctor-lint-flow.test.ts
+++ b/src/flows/doctor-lint-flow.test.ts
@@ -1,6 +1,10 @@
 // Doctor lint flow tests cover lint diagnostics surfaced by doctor.
 import { describe, expect, it } from "vitest";
-import { exitCodeFromFindings, runDoctorLintChecks } from "./doctor-lint-flow.js";
+import {
+  exitCodeFromFindings,
+  runDoctorLintChecks,
+  selectUpdateReadinessChecks,
+} from "./doctor-lint-flow.js";
 import { normalizeHealthCheck } from "./health-check-adapter.js";
 import {
   clearHealthChecksForTest,
@@ -251,6 +255,30 @@ describe("runDoctorLintChecks", () => {
       checksSkipped: 0,
       findings: [expect.objectContaining({ checkId: "targeted" })],
     });
+  });
+
+  it("runs only checks that own the selected update-readiness phase", async () => {
+    const detections: string[] = [];
+    const checks = [
+      Object.assign(
+        check("plugin/example/post-plugin", async () => {
+          detections.push("post-plugin");
+          return [];
+        }),
+        { updateReadiness: "post-plugin" as const },
+      ),
+      check("plugin/example/default", async () => {
+        detections.push("default");
+        return [];
+      }),
+    ];
+
+    const result = await runDoctorLintChecks(ctx, {
+      checks: selectUpdateReadinessChecks(checks, "post-plugin"),
+    });
+
+    expect(result).toEqual({ findings: [], checksRun: 1, checksSkipped: 0 });
+    expect(detections).toEqual(["post-plugin"]);
   });
 
   it("supports single-run checks in lint mode", async () => {

--- a/src/flows/doctor-lint-flow.ts
+++ b/src/flows/doctor-lint-flow.ts
@@ -89,6 +89,14 @@ export async function runDoctorLintChecks(
   };
 }
 
+/** Internal update gate selection; public Doctor lint remains selector-driven. */
+export function selectUpdateReadinessChecks(
+  checks: readonly HealthCheck[],
+  phase: "post-plugin",
+): readonly HealthCheck[] {
+  return checks.filter((check) => "updateReadiness" in check && check.updateReadiness === phase);
+}
+
 function isDefaultDisabled(check: HealthCheck): boolean {
   return "defaultEnabled" in check && check.defaultEnabled === false;
 }

--- a/src/flows/health-check-adapter.ts
+++ b/src/flows/health-check-adapter.ts
@@ -23,6 +23,7 @@ function defineSplitHealthCheck(check: SplitHealthCheckInput): RegisteredHealthC
     description: check.description,
     source: check.source,
     defaultEnabled: check.defaultEnabled,
+    updateReadiness: check.updateReadiness,
     sourceContract: "split",
     detect: (ctx, scope) => check.detect(ctx, scope),
     repair:
@@ -73,6 +74,7 @@ export function normalizeHealthCheck(check: HealthCheckInput): RegisteredHealthC
     description: check.description,
     source: check.source,
     defaultEnabled: check.defaultEnabled,
+    updateReadiness: check.updateReadiness,
     sourceContract: "run",
     async detect(ctx, scope) {
       const result = await check.run({ ...ctx, repair: false }, scope);

--- a/src/flows/health-check-runner-types.ts
+++ b/src/flows/health-check-runner-types.ts
@@ -28,6 +28,7 @@ export interface HealthCheckRunResult extends Omit<HealthRepairResult, "changes"
 /** Internal runner selection metadata. This is intentionally not part of the public SDK type. */
 interface HealthCheckSelectionOptions {
   readonly defaultEnabled?: boolean;
+  readonly updateReadiness?: "post-plugin";
 }
 
 export type SplitHealthCheckDefinition = HealthCheck & HealthCheckSelectionOptions;


### PR DESCRIPTION
## Summary

- add an internal, owner-declared `post-plugin` readiness phase to Doctor health checks
- run that phase in the updated CLI after plugin convergence and before Gateway restart
- enroll Memory Core's managed local embedding check and return its interactive llama.cpp remediation without changing config or downloading a model

Fixes #134204.

## Root cause and repair

The managed local embedding check already owned the exact readiness decision, but update finalization only ran fresh Doctor repair and strict config validation. A retained `memory.search.provider: "local"` configuration could therefore pass update finalization even when the upgraded llama.cpp provider had no managed service/model setup.

The updater now asks the updated process to run only health checks whose owner declares `updateReadiness: "post-plugin"`. The selection contract remains internal (no public Plugin SDK or CLI surface), the updater names no plugin or check ID, and every readiness run uses an isolated plugin-state snapshot. Structured findings become blocking post-update plugin results; malformed output, execution failure, or zero declared checks fail closed. Existing fresh-resume, current-process, and repair lanes all stop before restart.

No compatibility path, config key, schema, migration, model download, or automatic provider setup was added. The issue's non-mutating stop-with-action boundary was approved in https://github.com/openclaw/openclaw/issues/134204#issuecomment-5488258336.

## TDD and validation

RED was captured before implementation across four independent boundaries: phase selection ran unrelated checks, Memory Core did not declare update readiness, update finalization never invoked readiness, and a readiness finding did not block restart or carry remediation.

GREEN:

- affected Doctor/Memory/update suites: 452 passed
- legacy updater orchestration suite: 317 passed
- process-level update lifecycle suite: 26 passed, including readiness finding and execution failure across fresh-resume, current-process, and repair lanes
- `pnpm check:changed`
- `pnpm build`
- npm tarball integrity check with the llama.cpp plugin bundled

Packaged Linux proof used retained local-memory config plus an existing semantic index and missing managed llama.cpp setup. The updated CLI ran exactly one declared check, exited 1, and returned:

`Run openclaw models --agent main auth login --provider llama-cpp --method local in an interactive terminal, then rerun this check.`

The config and semantic-index SHA-256 hashes were unchanged before/after, and no model was downloaded.

## Scope audit

- architectural owner: Memory Core declares the readiness requirement; Doctor owns isolated health execution; update finalization owns restart admission
- caller/callee: fresh post-core resume/current-process/repair -> `completePostCorePluginUpdate` -> updated `doctor --lint` -> Memory Core -> llama.cpp provider policy inspection
- siblings: all three update execution lanes and both structured-finding/execution-failure paths covered
- removed/avoided paths: no core llama.cpp/check-ID special case; no broad `doctor --lint --all`; no public flag or SDK contract; no automatic setup fallback
- production: +224/-10 (net +214)
- tests/test support: +360/-15 (net +345)
- docs: +4/-0

Positive production LOC implements the generic cross-process readiness protocol, strict child-result validation, fail-closed update result mapping, and isolated owner selection; there was no existing post-plugin readiness transport to absorb this into without hardcoding Memory Core policy in the updater.
