### PR TITLE
test(macos): synchronize worker backpressure fixture

### DIFF
--- a/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacNodeHostWorkerTests.swift
@@ -708,35 +708,43 @@ struct MacNodeHostWorkerTests {
     }
 
     @Test func `worker drains stdout while a large stdin frame is backpressured`() async throws {
+        let directory = try makeTempDirForTests()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let firstReceived = directory.appendingPathComponent("first-received.pid")
         let worker = MacNodeHostWorker(session: GatewayNodeSession())
         let script = """
         printf '%s\\n' '{"type":"ready","version":"test","manifest":{"caps":["system"],"commands":["system.run"],"pathEnv":"/usr/bin:/bin"},"inventory":{"skills":null,"pluginTools":[]}}'
         IFS= read -r first
+        printf '%s\\n' "$$" > "$1"
+        # Wait for the large write to begin before filling stdout. Neither pipe
+        # can finish unless the app drains output independently of its writer.
+        head -c 1 >/dev/null
         printf '{"type":"invoke-result","generation":0,"result":{"id":"first","ok":true,"payload":{"blob":"'
         head -c 2097152 /dev/zero | tr '\\000' x
         printf '"}}}\\n'
-        IFS= read -r second
+        # Buffer the remaining frame instead of timing the shell's large-line read.
+        head -n 1 >/dev/null
         printf '%s\\n' '{"type":"invoke-result","generation":0,"result":{"id":"second","ok":true,"payload":{"done":true}}}'
+        while IFS= read -r line; do :; done
         """
         _ = try await worker.start(launch: MacNodeHostWorkerLaunch(
-            command: ["/bin/sh", "-c", script]))
-
-        let first = Task {
-            await worker.invoke(BridgeInvokeRequest(
-                id: "first",
-                command: "system.run",
-                paramsJSON: #"{"command":["/usr/bin/true"]}"#))
-        }
-        try await Task.sleep(for: .milliseconds(20))
-        let largeParams = #"{"blob":""# + String(repeating: "x", count: 2 * 1024 * 1024) + #""}"#
-        let second = Task {
-            await worker.invoke(BridgeInvokeRequest(
-                id: "second",
-                command: "system.run",
-                paramsJSON: largeParams))
-        }
+            command: ["/bin/sh", "-c", script, "worker", firstReceived.path]))
 
         do {
+            let first = Task {
+                await worker.invoke(BridgeInvokeRequest(
+                    id: "first",
+                    command: "system.run",
+                    paramsJSON: #"{"command":["/usr/bin/true"]}"#))
+            }
+            _ = try await TestProcessSupport.waitForPID(in: firstReceived)
+            let largeParams = #"{"blob":""# + String(repeating: "x", count: 2 * 1024 * 1024) + #""}"#
+            let second = Task {
+                await worker.invoke(BridgeInvokeRequest(
+                    id: "second",
+                    command: "system.run",
+                    paramsJSON: largeParams))
+            }
             let responses = try await AsyncTimeout.withTimeout(
                 seconds: 5,
                 onTimeout: { WorkerBackpressureTimeout() },
@@ -744,6 +752,8 @@ struct MacNodeHostWorkerTests {
             await worker.stop()
             let allResponsesSucceeded = responses.allSatisfy(\.ok)
             #expect(allResponsesSucceeded)
+            let firstPayload = try #require(responses[0].payload?.value as? [String: Any])
+            #expect((firstPayload["blob"] as? String)?.count == 2 * 1024 * 1024)
         } catch {
             await worker.stop()
             throw error


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where macOS release verification times out in the worker backpressure regression under parallel test load, even though stdout drains independently of the large stdin write.

## Why This Change Was Made

The fixture used the shell's slow line reader for a 2 MiB input and a 20 ms sleep to guess request ordering. It now uses the existing child PID receipt helper to establish the first request, waits for the second frame to begin before filling stdout, and drains the remaining input with buffered `head`. This guarantees the intended pipe overlap without spending the test budget on shell line consumption.

Both 2 MiB payloads and the 5-second timeout remain unchanged. The test additionally verifies the complete response blob and lets the app own child shutdown. Production transport code is unchanged; test delta is +27/-17.

## User Impact

There is no shipped behavior change. Release verification retains meaningful deadlock coverage with deterministic ordering and less fixture overhead.

## Evidence

- The original CI job failed this test after 5.507 seconds. Standalone native pipe proof using its unchanged shell fixture and request order reproduced deadline misses in all 12 controlled parallel cases (7.9–8.8s), despite independent stdout draining. This stress proof does not reproduce the full failing CI schedule, which used three test workers.
- Changing only the large-line reader made all 12 control cases pass in 0.061–0.070 seconds. The final ordered fixture also passes all 12 cases with full 2 MiB output verified.
- A negative control that postpones output draining until input finishes still deadlocks and fails at the unchanged 5-second bound. All proof children and threads were joined.
- Swift syntax, canonical formatting and diff checks pass. The actual changed-file gate passed app lint but encountered separate existing elevation-host TypeScript test timeouts; those are under investigation. These standalone probes do not replace the actual Swift worker suite; exact-head hosted macos-swift CI must pass before merge. Native app tests were not run on an operator desktop.
