### PR TITLE
fix(cron): gateway startup fails on malformed legacy jobs

### DIFF
--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -5,15 +5,18 @@ import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterAll, describe, expect, it } from "vitest";
+import { testing as openclawTestInstanceTesting } from "../../test/helpers/openclaw-test-instance.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { resolveGatewayLockDir } from "../config/paths.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { loadCronJobsStoreWithConfigJobsReadOnly, loadCronQuarantinedJobs } from "../cron/store.js";
 import { hasActiveStartupMigrationLease } from "../infra/startup-migration-checkpoint.js";
 import { getFileLockProcessStartTime } from "../shared/pid-alive.js";
 import {
   ensureOpenClawAgentDatabaseSchema,
   OPENCLAW_AGENT_SCHEMA_VERSION,
 } from "../state/openclaw-agent-db.js";
+import { getFreePort } from "../test-utils/ports.js";
 import {
   createSourceRuntime,
   runIsolatedModuleScript,
@@ -373,6 +376,107 @@ describe("doctor invalid config process exit", () => {
 
 // Synchronous CLI probes must not consume neighboring cases' timeout budgets.
 describe("gateway startup-migration refusal", () => {
+  it("quarantines every invalid legacy automation before Gateway readiness", async () => {
+    const root = await fs.promises.realpath(tempDirs.make("openclaw-cron-upgrade-ready-"));
+    const stateDir = path.join(root, "state");
+    const configPath = path.join(root, "openclaw.json");
+    const storePath = path.join(stateDir, "cron", "jobs.json");
+    const port = await getFreePort();
+    const runtimeRoot = createSourceRuntime(root);
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: root,
+      USERPROFILE: root,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_NO_RESPAWN: "1",
+      OPENCLAW_SKIP_CHANNELS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+      OPENCLAW_TEST_FAST: "1",
+      NO_COLOR: "1",
+    };
+    delete env.NODE_ENV;
+    delete env.OPENCLAW_HOME;
+    delete env.VITEST;
+
+    fs.mkdirSync(path.dirname(storePath), { recursive: true });
+    fs.writeFileSync(
+      configPath,
+      JSON.stringify({ gateway: { mode: "local", auth: { mode: "none" } } }),
+    );
+    const job = {
+      name: "Legacy automation",
+      enabled: true,
+      createdAtMs: 1,
+      updatedAtMs: 1,
+      schedule: { kind: "cron", expr: "0 9 * * *" },
+      sessionTarget: "main",
+      wakeMode: "now",
+      payload: { kind: "systemEvent", text: "tick" },
+      state: {},
+    };
+    fs.writeFileSync(
+      storePath,
+      JSON.stringify({
+        version: 1,
+        jobs: [
+          { ...job, id: "valid-job" },
+          { ...job, id: "invalid-state-job", state: { nextRunAtMs: -1 } },
+          { ...job, id: "invalid-trigger-job", trigger: { script: [] } },
+        ],
+      }),
+    );
+    const stdout = openclawTestInstanceTesting.createBoundedStringLog();
+    const stderr = openclawTestInstanceTesting.createBoundedStringLog();
+    const gateway = spawn(
+      process.execPath,
+      [
+        "--preserve-symlinks",
+        "--preserve-symlinks-main",
+        "--import",
+        "tsx",
+        path.join(runtimeRoot, "src", "entry.ts"),
+        "gateway",
+        "run",
+        "--allow-unconfigured",
+        "--port",
+        String(port),
+      ],
+      { cwd: runtimeRoot, env, stdio: ["ignore", "pipe", "pipe"] },
+    );
+    gateway.stdout.setEncoding("utf8");
+    gateway.stderr.setEncoding("utf8");
+    gateway.stdout.on("data", (chunk) => openclawTestInstanceTesting.appendLogChunk(stdout, chunk));
+    gateway.stderr.on("data", (chunk) => openclawTestInstanceTesting.appendLogChunk(stderr, chunk));
+
+    try {
+      await openclawTestInstanceTesting.waitForGatewayReady(gateway, stdout, stderr, port, 30_000);
+      const response = await fetch(`http://127.0.0.1:${port}/readyz`);
+      await expect(response.json()).resolves.toMatchObject({ ready: true, failing: [] });
+    } finally {
+      expect(
+        await openclawTestInstanceTesting.stopGatewayProcess(gateway, Date.now() + 5_000, 1_500, {
+          forceWindowsTree: true,
+        }),
+      ).toBe(true);
+    }
+
+    const loaded = await loadCronJobsStoreWithConfigJobsReadOnly(storePath, env);
+    expect(loaded.store.jobs.map((entry) => entry.id)).toContain("valid-job");
+    expect(
+      loadCronQuarantinedJobs(storePath, env).map((entry) => ({
+        sourceIndex: entry.sourceIndex,
+        reason: entry.reason,
+        id: entry.job?.id,
+      })),
+    ).toEqual([
+      { sourceIndex: 1, reason: "invalid-state", id: "invalid-state-job" },
+      { sourceIndex: 2, reason: "invalid-trigger", id: "invalid-trigger-job" },
+    ]);
+    expect(fs.existsSync(storePath)).toBe(false);
+    expect(fs.existsSync(`${storePath}.migrated`)).toBe(true);
+  }, 45_000);
+
   it("repairs the stable upgrade config and additive state schema before readiness", async () => {
     const root = await fs.promises.realpath(tempDirs.make("openclaw-stable-upgrade-ready-"));
     const stateDir = path.join(root, "state");

--- a/src/commands/doctor/cron/store-migration.ts
+++ b/src/commands/doctor/cron/store-migration.ts
@@ -638,20 +638,18 @@ export function normalizeStoredCronJobs(
     mutated ||= scheduledPolicyMutated;
 
     const invalidPersistedReason = getInvalidPersistedCronJobReason(raw);
-    if (
-      invalidPersistedReason === "missing-schedule" ||
-      invalidPersistedReason === "invalid-schedule"
-    ) {
-      trackIssue("invalidSchedule");
-      removedJobs.push({ job: structuredClone(raw), reason: invalidPersistedReason, sourceIndex });
-      mutated = true;
-      continue;
-    }
-    if (
-      invalidPersistedReason === "missing-payload" ||
-      invalidPersistedReason === "invalid-payload"
-    ) {
-      trackIssue("invalidPayload");
+    if (invalidPersistedReason) {
+      if (
+        invalidPersistedReason === "missing-schedule" ||
+        invalidPersistedReason === "invalid-schedule"
+      ) {
+        trackIssue("invalidSchedule");
+      } else if (
+        invalidPersistedReason === "missing-payload" ||
+        invalidPersistedReason === "invalid-payload"
+      ) {
+        trackIssue("invalidPayload");
+      }
       removedJobs.push({ job: structuredClone(raw), reason: invalidPersistedReason, sourceIndex });
       mutated = true;
       continue;


### PR DESCRIPTION
Fixes #134458

Reported by @Nielsh82.

## What Problem This Solves

Fixes an issue where a Gateway upgrade could fail to become ready when a legacy cron store contained an invalid state or trigger row. The startup repair kept those rows active, the SQLite persistence guard rejected the full batch, and `openclaw doctor --fix` repeated the same unnamed count without clearing it.

## Why This Change Was Made

Doctor now uses the canonical persisted-job validation result for every invalid reason. It quarantines each invalid row with its source index, identifier, and reason before the strict SQLite save, while valid jobs commit and the legacy source archives atomically.

The persistence guard remains strict. This change removes the Doctor-only reason-list gap instead of adding a fallback or weakening startup readiness.

## User Impact

Gateways can finish upgrading when old cron data contains malformed rows. Valid automations keep running, malformed rows remain recoverable in SQLite quarantine, and startup reaches ready state.

No configuration, protocol, dependency, or SQLite schema surface changes.

## Evidence

Current-main red at `9aa82b18253b9bbe93863968ab891329287ff4f8`:

- A real isolated `gateway run` with one valid job and one invalid-state job reported `Cannot persist cron store with 1 invalid job(s)` and did not serve `/readyz` within 30 seconds.
- The documented `doctor --fix --non-interactive --yes` path repeated the same persistence warning.
- The new owner-boundary regression failed before the production repair with `Cannot persist cron store with 2 invalid job(s)`.

Exact-head green at `786916e4ab2975cd97a5758aecddc38b0be9b4d9`:

- A process regression launches the actual Gateway entry point with the same legacy fixture and waits for `{"ready":true,"failing":[]}` from `/readyz`.
- Downstream inspection found `valid-proof-job` active and `invalid-state-job` quarantined with reason `invalid-state` and source index `1`.
- The legacy `jobs.json` became `jobs.json.migrated`.

Validation:

- 205 focused Doctor, migration, persistence, and runtime cron tests passed.
- All 11 startup-preflight process tests passed.
- Targeted Oxfmt, Oxlint, and `git diff --check` passed.
- Production LOC: `+12/-14` (net `-2`). Tests: `+104/-0`.
- Local type checks and builds were not run because repository policy forbids `tsgo`, `tsc`, test typecheck, and build on this host. Exact-head CI owns those gates.

Provenance: PR #121394 added invalid persisted-state rejection before v2026.8.1, but Doctor's fixed schedule/payload reason list did not expand. The reporter's exact 13 row shapes remain unavailable; this repair covers every current and future non-null canonical invalidity reason rather than guessing a field shape.

Best-fix verdict: this is the owning-boundary fix. Moving row drops into SQLite persistence would lose Doctor's quarantine decision, and ignoring startup warnings would report false readiness.
