### PR TITLE
fix(doctor): repair keyed multi-agent rosters without ownership

### DIFF
--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -234,6 +234,12 @@ Bindings are deterministic and most-specific wins. See [Channel routing](/channe
 
 For existing multi-agent configs, `openclaw doctor --fix` materializes legacy ambient default routing into channel-wide bindings plus explicit heartbeat, Custodian, and Talk targets. Single-agent configs are unchanged.
 
+For a multi-agent roster defined directly in the main config file without a
+legacy `default: true` marker, Doctor adds `agents.ownership: "explicit"` for
+both keyed `agents.entries` and older `agents.list` rosters, including with
+`--fix --non-interactive`. Existing bindings and per-surface owners remain
+unchanged; Doctor does not choose an agent for unowned surfaces.
+
 ## Multiple accounts / phone numbers
 
 Channels that support multiple accounts (e.g. WhatsApp) use `accountId` to identify each login. Each `accountId` routes to its own agent, so one server can host multiple phone numbers without mixing sessions.

--- a/src/commands/doctor-config-flow.ts
+++ b/src/commands/doctor-config-flow.ts
@@ -2,7 +2,11 @@ import { homedir } from "node:os";
 /** Main doctor config flow: preflight, migrations, previews, repairs, and final write decision. */
 import path from "node:path";
 import { note } from "../../packages/terminal-core/src/note.js";
-import { readAgentRosterProperty, tryResolveSoleAgentId } from "../agents/agent-scope-config.js";
+import {
+  listAgentEntries,
+  readAgentRosterProperty,
+  tryResolveSoleAgentId,
+} from "../agents/agent-scope-config.js";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import { withProgress } from "../cli/progress.js";
@@ -239,7 +243,9 @@ export async function loadAndMaybeMigrateDoctorConfig(params: {
     .filter((source) => source !== undefined)
     .map((source) => migratePersistedImplicitMainRoster(source));
   const rosterMigrations = rawRosterMigrations.filter((migration) => migration.changed);
-  const rosterMigrationNeeded = rosterMigrations.length > 0;
+  const rosterMigrationNeeded =
+    rosterMigrations.length > 0 ||
+    (baseCfg.agents?.ownership === undefined && listAgentEntries(baseCfg).length > 1);
   const legacyDefaultAgentId = rawRosterMigrations
     .map((migration) => migration.retainedLegacyDefaultAgentId)
     .find((agentId) => agentId !== undefined);

--- a/src/commands/doctor-config-flow.workspace-persistence.test.ts
+++ b/src/commands/doctor-config-flow.workspace-persistence.test.ts
@@ -54,6 +54,44 @@ describe("Doctor workspace persistence", () => {
     closeOpenClawStateDatabaseForTest();
   });
 
+  it.each(["entries", "list"])(
+    "persists explicit ownership for a markerless multi-agent %s roster",
+    async (shape) => {
+      await withTempHome(async (home) => {
+        await withEnvOverride({ OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" }, async () => {
+          const entries = {
+            ops: { workspace: path.join(home, "ops") },
+            research: { workspace: path.join(home, "research") },
+          };
+          const configPath = await writeOpenClawConfig(home, {
+            agents:
+              shape === "entries"
+                ? { entries }
+                : {
+                    list: Object.entries(entries).map(([id, entry]) => ({
+                      id,
+                      workspace: entry.workspace,
+                    })),
+                  },
+            gateway: { mode: "local" },
+            plugins: { enabled: false },
+          });
+          expect((await readConfigFileSnapshot()).valid).toBe(false);
+
+          const ctx = await prepareDoctorContext(configPath);
+          await runInitialConfigWriteHealth(ctx);
+
+          const saved = JSON.parse(await fs.readFile(configPath, "utf-8"));
+          expect(saved.agents).toEqual({ ownership: "explicit", entries });
+          expect((await readConfigFileSnapshot()).valid).toBe(true);
+          expect((await prepareDoctorContext(configPath)).configResult.shouldWriteConfig).toBe(
+            false,
+          );
+        });
+      });
+    },
+  );
+
   it.each(["entries", "list", "noncanonical list"])(
     "repairs workspace and heartbeat values from %s through snapshot, doctor, and write",
     async (shape) => {


### PR DESCRIPTION
Related: #133984. This addresses the keyed-roster config repair deadlock; the broader upgrade issue remains open for its other reports.

## What Problem This Solves

Fixes an issue where users upgrading an existing keyed multi-agent roster without a legacy default marker could not repair their config with `openclaw doctor --fix --non-interactive`. Validation requested explicit roster ownership and pointed back to Doctor, but Doctor left that field absent on disk.

Reported by @Lendersmark in #133984.

## Why This Change Was Made

Doctor previously persisted roster repairs only when read-time normalization changed the roster, such as converting an old list into keyed entries. A roster already using keyed entries skipped that branch. Doctor now recognizes missing explicit ownership through the canonical agent-entry reader and uses its existing guarded persistence flow.

Runtime validation and agent selection stay unchanged. The repair preserves existing workspace and per-surface ownership choices, leaves unowned surfaces unassigned, and retains the guard for rosters owned by included files. Production changes are +8/-2 lines (net +6, including import formatting); regression coverage adds 38 lines.

## User Impact

Root-authored multi-agent rosters can complete the same noninteractive ownership repair whether they use `agents.entries` or the legacy `agents.list` shape. The [multi-agent guide](https://docs.openclaw.ai/concepts/multi-agent#routing-rules) documents this behavior.

## Evidence

- Before the fix, the disk-backed snapshot → Doctor → atomic write → reload regression failed for keyed entries because persisted `agents.ownership` was absent; the equivalent legacy list case passed.
- After the fix: `node scripts/run-vitest.mjs src/commands/doctor-config-flow.workspace-persistence.test.ts src/commands/doctor-config-flow.test.ts src/config/legacy.roster.test.ts` — 102 passed. Coverage includes default markers, explicit owners, malformed rosters, include ownership, previews, workspace preservation, and idempotence.
- Actual built CLI, with two disposable state/config directories: `config validate --json` exited 1 before repair, `doctor --fix --non-interactive --no-workspace-suggestions` exited 0, then `config validate --json` exited 0. Both an unowned roster and a roster with an existing `research` system owner retained their exact entries, workspace paths, and owner choices.
- `pnpm build` passed.
- The changed-file gate passed formatting, core/test typechecks, and repository guards before stopping at a fixture-construction lint issue. The fixture was corrected; focused lint and all remaining prescribed guard steps passed. The two disk-persistence regression cases were rerun after that test-only correction.
- Autoreview and a separate isolated, read-only Codex review found no actionable issues. Independent source review also checked the Doctor/runtime ownership boundary and include handling.
