### PR TITLE
test(infra): reuse the dev-branch filesystem fixture

### DIFF
--- a/src/infra/dev-install-branch.test.ts
+++ b/src/infra/dev-install-branch.test.ts
@@ -1,20 +1,17 @@
 import fs from "node:fs/promises";
-import os from "node:os";
 import path from "node:path";
-import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { runCommandWithTimeout } from "../process/exec.js";
 
 type RunCommand = typeof runCommandWithTimeout;
 
-const tmpRoots: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterAll);
+let root: string;
 
-async function makeRoot(): Promise<string> {
-  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-dev-branch-"));
-  tmpRoots.push(dir);
-  // macOS tmpdir is a symlink (/var -> /private/var); production compares
-  // canonical package and git roots.
-  return await fs.realpath(dir);
-}
+beforeAll(() => {
+  root = tempDirs.make("openclaw-dev-branch-");
+});
 
 function makeRunCommand(byArg: {
   toplevel?: { code: number; stdout: string };
@@ -55,13 +52,8 @@ afterEach(() => {
   vi.doUnmock("./openclaw-root.js");
 });
 
-afterAll(async () => {
-  await Promise.all(tmpRoots.map((dir) => fs.rm(dir, { recursive: true, force: true })));
-});
-
 describe("resolveDevInstallGitBranch", () => {
   it("returns the branch for a source checkout on a feature branch", async () => {
-    const root = await makeRoot();
     const branch = await resolveBranch({
       root,
       runCommand: makeRunCommand({
@@ -78,7 +70,6 @@ describe("resolveDevInstallGitBranch", () => {
   });
 
   it("returns null when the root is not inside a git repo", async () => {
-    const root = await makeRoot();
     const branch = await resolveBranch({
       root,
       runCommand: makeRunCommand({ toplevel: { code: 128, stdout: "" } }),
@@ -87,7 +78,6 @@ describe("resolveDevInstallGitBranch", () => {
   });
 
   it("returns null when the package root is nested inside an unrelated repo", async () => {
-    const root = await makeRoot();
     const nested = path.join(root, "node_modules", "openclaw");
     await fs.mkdir(nested, { recursive: true });
     const branch = await resolveBranch({
@@ -101,7 +91,6 @@ describe("resolveDevInstallGitBranch", () => {
   });
 
   it.each(["main", "master", "HEAD", ""])("hides mainline/detached state %j", async (name) => {
-    const root = await makeRoot();
     const branch = await resolveBranch({
       root,
       runCommand: makeRunCommand({
@@ -113,7 +102,6 @@ describe("resolveDevInstallGitBranch", () => {
   });
 
   it("returns null when git branch resolution fails", async () => {
-    const root = await makeRoot();
     const branch = await resolveBranch({
       root,
       runCommand: makeRunCommand({


### PR DESCRIPTION
## What Problem This Solves

The dev-checkout branch tests create and remove eight equivalent temporary roots while testing nine resolver outcomes.

## Why This Change Was Made

Share one real canonical root through the existing temporary-directory tracker. The nested-package case still creates its real nested directory; every case keeps its own mocked Git responses and module reset because the production resolver caches its result.

## User Impact

Test setup removes seven directory allocation/removal pairs and repeated fixture canonicalization. All nine resolver cases and their assertions remain. Runtime behavior is unchanged; production +0/-0, tests +7/-19.

## Evidence

All 18 selected cases pass before and after: nine resolver cases and nine canonical temporary-directory helper cases. Full changed checks and Codex autoreview pass. No elapsed-time speedup is claimed.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/infra/dev-install-branch.test.ts test/helpers/temp-dir.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base d48e737b3745f5b00c0d7d3e7dbf1a778fb1e3a2
```

Source review includes the resolver owner, package-root boundary, canonical fixture lifecycle, bootstrap caller and raw test history. The earlier removal of a test-only resolver export remains intact.
