### PR TITLE
fix(docs): list channel dead-letter commands in CLI index

### DIFF
--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -168,6 +168,7 @@ openclaw [--dev] [--profile <name>] <command>
     capabilities
     resolve
     logs
+    dead-letters list|resubmit
     add
     remove
     login


### PR DESCRIPTION
## What Problem This Solves

The CLI index omits `channels dead-letters list` and `channels dead-letters resubmit`, although the Channels CLI registers both and its detailed reference documents the recovery flow.

## Why This Change Was Made

Add `dead-letters list|resubmit` to the existing Channels command tree, using the same grouped subcommand notation as neighboring commands. The detailed Channels reference remains the owner of usage, scope, and recovery behavior.

## User Impact

Operators browsing the CLI index can discover the existing commands for inspecting and resubmitting failed inbound events. No channel, queue, storage, retry, or authentication behavior changes. Thanks @qingminglong.

## Evidence

- Source inspection: complete `docs/cli/index.md`, `docs/cli/channels.md`, `src/cli/channels-cli.ts`, and `src/commands/channels/dead-letters.ts`; the registrar exposes exactly `list` and `resubmit`, while current main lacks the index entry.
- Trusted main tooling checked the candidate Markdown as data: docs listing, MDX compilation, canonical formatter configuration, internal links (7,143 checked; zero broken), and whitespace all passed. Commands: `node scripts/docs-list.js`, `node scripts/check-docs-mdx.mjs docs/cli/index.md`, `node_modules/.bin/oxfmt --check --config .oxfmtrc.jsonc --disable-nested-config docs/cli/index.md`, `node scripts/docs-link-audit.mjs`, and `git diff --check` (tooling invoked from trusted main against the candidate file).
- Full candidate Codex autoreview passed with no accepted P0 findings.
- Production/test LOC: zero; docs: +1/-0. No runtime regression test was added for static index content. No event resubmission or live-channel execution is claimed.

Public documentation: https://docs.openclaw.ai/cli and https://docs.openclaw.ai/cli/channels#inbound-dead-letters.
