### PR TITLE
fix(doctor): discard empty reserved workspace attestations so Doctor converges

### DIFF
--- a/src/agents/workspace-legacy-state.test.ts
+++ b/src/agents/workspace-legacy-state.test.ts
@@ -261,6 +261,50 @@ describe("legacy workspace reset cleanup", () => {
     }
   });
 
+  it("blocks on a zero-byte reserved state-directory attestation until Doctor discards it", async () => {
+    const context = setup();
+    await fs.mkdir(context.workspaceDir, { recursive: true });
+    const attestationPath = context.paths.stateDirAttestationPaths[0]!;
+    await fs.mkdir(path.dirname(attestationPath), { recursive: true });
+    await fs.writeFile(attestationPath, "");
+
+    // Presence-only gate: an empty reserved marker still blocks the workspace
+    // until Doctor's migration removes it.
+    expect(() =>
+      assertWorkspaceStateMigrationReady({
+        workspaceDirs: [context.workspaceDir],
+        env: context.env,
+        homedir: context.homedir,
+      }),
+    ).toThrow(/run openclaw doctor --fix/u);
+
+    const { migrateLegacyWorkspaceState, detectLegacyWorkspaceState } =
+      await import("../infra/state-migrations.workspace-setup.js");
+    const migration = await migrateLegacyWorkspaceState({
+      stateDir: context.stateDir,
+      env: context.env,
+      detected: detectLegacyWorkspaceState({
+        cfg: { agents: { defaults: { workspace: context.workspaceDir } } },
+        stateDir: context.stateDir,
+        env: context.env,
+        homedir: context.homedir,
+        doctorOnlyStateMigrations: true,
+      }),
+    });
+    expect(migration.warnings).toEqual([]);
+    expect(migration.changes).toContain("Discarded empty reserved workspace attestation.");
+    await expect(fs.lstat(attestationPath)).rejects.toHaveProperty("code", "ENOENT");
+    expect(() =>
+      assertWorkspaceStateMigrationReady({
+        workspaceDirs: [context.workspaceDir],
+        env: context.env,
+        homedir: context.homedir,
+      }),
+    ).not.toThrow();
+    const { closeOpenClawStateDatabaseForTest } = await import("../state/openclaw-state-db.js");
+    closeOpenClawStateDatabaseForTest();
+  });
+
   it("does not follow a symlinked attestation directory during reset", async () => {
     const context = setup();
     const markerPath = context.paths.stateDirAttestationPaths[0]!;

--- a/src/gateway/server-startup-workspace-readiness.test.ts
+++ b/src/gateway/server-startup-workspace-readiness.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
 import { writeConfigFile, type OpenClawConfig } from "../config/config.js";
 import {
   detectLegacyWorkspaceState,
@@ -64,5 +65,55 @@ describe("Gateway workspace migration readiness", () => {
     const ready = await fetch(`http://127.0.0.1:${port}/readyz`);
     expect(ready.status).toBe(200);
     await expect(fs.stat(sourcePath)).rejects.toHaveProperty("code", "ENOENT");
+  });
+
+  it("discards a zero-byte reserved attestation during Doctor migration so the workspace can start", async () => {
+    const stateDir = process.env.OPENCLAW_STATE_DIR!;
+    const workspaceDir = path.join(stateDir, "workspace-zero-byte");
+    const cfg: OpenClawConfig = {
+      gateway: { mode: "local", bind: "loopback", auth: { mode: "none" } },
+      agents: {
+        ownership: "explicit",
+        entries: {
+          main: { workspace: path.join(stateDir, "workspace-main") },
+          secondary: { workspace: workspaceDir },
+        },
+      },
+    };
+    await writeConfigFile(cfg);
+    await fs.mkdir(workspaceDir, { recursive: true });
+    const identity = resolveWorkspaceStateIdentity(workspaceDir);
+    const attestationPath = path.join(
+      stateDir,
+      "workspace-attestations",
+      `${identity.workspaceKey}.attested`,
+    );
+    await fs.mkdir(path.dirname(attestationPath), { recursive: true });
+    await fs.writeFile(attestationPath, "");
+    const port = await getGatewayTestPort();
+
+    // The zero-byte reserved marker is a presence-only blocker: the gateway
+    // refuses startup exactly like any other unmigrated workspace state.
+    await expect(startTestGatewayServer(port, { auth: { mode: "none" } })).rejects.toThrow(
+      "Legacy workspace setup state requires migration",
+    );
+    await expect(fetch(`http://127.0.0.1:${port}/readyz`)).rejects.toThrow();
+
+    const migration = await migrateLegacyWorkspaceState({
+      stateDir,
+      detected: detectLegacyWorkspaceState({
+        cfg,
+        stateDir,
+        homedir: os.homedir,
+        doctorOnlyStateMigrations: true,
+      }),
+    });
+    expect(migration.warnings).toEqual([]);
+    expect(migration.changes).toContain("Discarded empty reserved workspace attestation.");
+    await expect(fs.stat(attestationPath)).rejects.toHaveProperty("code", "ENOENT");
+
+    server = await startTestGatewayServer(port, { auth: { mode: "none" } });
+    const ready = await fetch(`http://127.0.0.1:${port}/readyz`);
+    expect(ready.status).toBe(200);
   });
 });

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -2,7 +2,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { resolveWorkspaceStateIdentity } from "../agents/workspace-state-identity.js";
 import {
   deleteWorkspaceState,
@@ -638,6 +638,128 @@ describe("legacy workspace Doctor migration", () => {
         .db.prepare("SELECT workspace_key FROM workspace_setup_state WHERE workspace_key = ?")
         .get(identity.workspaceKey),
     ).toBeUndefined();
+  });
+
+  it("names the exact retained source in the malformed-state warning", async () => {
+    const context = setup();
+    const setupPath = path.join(context.workspaceDir, "openclaw-workspace-state.json");
+    await fsp.writeFile(setupPath, "{invalid", "utf8");
+
+    const result = await migrate(context);
+
+    // Windows temp roots can expose short-name aliases; compare case-insensitively
+    // on the basename and require the "at <path>" phrasing.
+    expect(result.warnings[0]).toMatch(/Failed reading legacy workspace state at /i);
+    expect(result.warnings[0].toLowerCase()).toContain(path.basename(setupPath).toLowerCase());
+    expect(fs.existsSync(setupPath)).toBe(true);
+  });
+
+  it.each(["configured", "orphan"] as const)(
+    "discards a verified zero-byte reserved %s attestation so Doctor converges",
+    async (scope) => {
+      const context = setup();
+      const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+      const key = scope === "configured" ? identity.workspaceKey : "c".repeat(64);
+      const attestationPath = path.join(
+        context.stateDir,
+        "workspace-attestations",
+        `${key}.attested`,
+      );
+      await fsp.mkdir(path.dirname(attestationPath), { recursive: true });
+      await fsp.writeFile(attestationPath, "", "utf8");
+
+      const detected = detect(context);
+      expect(detected.hasLegacy).toBe(true);
+      const result = await migrate(context);
+
+      expect(result.warnings).toEqual([]);
+      expect(result.changes).toContain("Discarded empty reserved workspace attestation.");
+      expect(fs.existsSync(attestationPath)).toBe(false);
+      expect(fs.existsSync(`${attestationPath}.doctor-importing`)).toBe(false);
+      // The same run converges: a second pass finds nothing left to migrate.
+      const retry = await migrate(context);
+      expect(retry.warnings).toEqual([]);
+      expect(retry.changes).toEqual([]);
+    },
+  );
+
+  it("protects a zero-byte sibling attestation next to the workspace", async () => {
+    const context = setup();
+    const siblingPath = `${context.workspaceDir}.attested`;
+    await fsp.writeFile(siblingPath, "", "utf8");
+
+    // Sibling markers require the owned header; an empty sibling is not
+    // surfaced to Doctor and stays untouched.
+    expect(detect(context).hasLegacy).toBe(false);
+    const result = await migrate(context);
+    expect(result.warnings).toEqual([]);
+    expect(result.changes).toEqual([]);
+    expect(fs.existsSync(siblingPath)).toBe(true);
+    expect(fs.existsSync(`${siblingPath}.doctor-importing`)).toBe(false);
+  });
+
+  it("runs removal hooks when discarding an empty reserved attestation", async () => {
+    const context = setup();
+    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+    const attestationPath = path.join(
+      context.stateDir,
+      "workspace-attestations",
+      `${identity.workspaceKey}.attested`,
+    );
+    await fsp.mkdir(path.dirname(attestationPath), { recursive: true });
+    await fsp.writeFile(attestationPath, "", "utf8");
+    let beforeClaimSeen = 0;
+    const removeSource = vi.fn(async () => {
+      throw new Error("simulated unlink failure");
+    });
+
+    const result = await migrateLegacyWorkspaceState({
+      detected: detect(context),
+      env: context.env,
+      stateDir: context.stateDir,
+      beforeClaim: () => {
+        beforeClaimSeen += 1;
+      },
+      removeSource,
+    });
+
+    // The beforeClaim hook runs and the failed removal surfaces the exact
+    // retained source so the operator can resolve it manually.
+    expect(beforeClaimSeen).toBe(1);
+    expect(result.changes).toEqual([]);
+    expect(result.warnings[0]).toContain(attestationPath);
+    expect(removeSource).toHaveBeenCalledTimes(1);
+  });
+
+  it("restores an empty reserved attestation when its claim fails", async () => {
+    const context = setup();
+    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+    const attestationPath = path.join(
+      context.stateDir,
+      "workspace-attestations",
+      `${identity.workspaceKey}.attested`,
+    );
+    await fsp.mkdir(path.dirname(attestationPath), { recursive: true });
+    await fsp.writeFile(attestationPath, "", "utf8");
+
+    const result = await migrateLegacyWorkspaceState({
+      detected: detect(context),
+      env: context.env,
+      stateDir: context.stateDir,
+      beforeClaim: () => {
+        // The workspace identity changes right before the claim, so the
+        // discard aborts and must not leave a stranded claim behind.
+        fs.writeFileSync(
+          attestationPath,
+          "openclaw-workspace-attestation:v1\n2026-07-15T11:00:00.000Z\n",
+          "utf8",
+        );
+      },
+    });
+
+    expect(result.warnings[0]).toMatch(/legacy workspace/i);
+    expect(fs.existsSync(attestationPath)).toBe(true);
+    expect(fs.existsSync(`${attestationPath}.doctor-importing`)).toBe(false);
   });
 
   it("rejects a setup source beneath a symlinked workspace subdirectory", async () => {

--- a/src/infra/state-migrations.workspace-setup.test.ts
+++ b/src/infra/state-migrations.workspace-setup.test.ts
@@ -762,6 +762,45 @@ describe("legacy workspace Doctor migration", () => {
     expect(fs.existsSync(`${attestationPath}.doctor-importing`)).toBe(false);
   });
 
+  it("preserves a reserved attestation recreated after the empty claim", async () => {
+    const context = setup();
+    const identity = resolveWorkspaceStateIdentity(context.workspaceDir);
+    const attestationPath = path.join(
+      context.stateDir,
+      "workspace-attestations",
+      `${identity.workspaceKey}.attested`,
+    );
+    await fsp.mkdir(path.dirname(attestationPath), { recursive: true });
+    await fsp.writeFile(attestationPath, "", "utf8");
+    const sourcePath = attestationPath;
+
+    // An old writer recreates the marker while Doctor removes the claimed
+    // empty file. The discard must not report success while the source exists:
+    // the recreated generation stays visible and readiness keeps blocking.
+    const result = await migrateLegacyWorkspaceState({
+      detected: detect(context),
+      env: context.env,
+      stateDir: context.stateDir,
+      removeSource: async (claimPath) => {
+        await fsp.rm(claimPath);
+        await fsp.writeFile(sourcePath, "", "utf8");
+      },
+    });
+
+    expect(result.changes).toEqual([]);
+    expect(result.warnings[0]).toContain("reappeared during discard");
+    expect(result.warnings[0]).toContain(attestationPath);
+    expect(fs.existsSync(sourcePath)).toBe(true);
+    expect(fs.existsSync(`${sourcePath}.doctor-importing`)).toBe(false);
+
+    // The recreated empty marker is itself discardable on the next run, so a
+    // follow-up Doctor pass converges without manual intervention.
+    const retry = await migrate(context);
+    expect(retry.warnings).toEqual([]);
+    expect(retry.changes).toContain("Discarded empty reserved workspace attestation.");
+    expect(fs.existsSync(sourcePath)).toBe(false);
+  });
+
   it("rejects a setup source beneath a symlinked workspace subdirectory", async () => {
     const context = setup();
     const externalDir = path.join(context.homeDir, "external-workspace-state");

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -462,7 +462,9 @@ async function migrateOneSource(params: {
   } catch (error) {
     return {
       changes: [],
-      warnings: [`Failed reading legacy workspace state: ${formatErrorMessage(error)}`],
+      warnings: [
+        `Failed reading legacy workspace state at ${params.source.sourcePath}: ${formatErrorMessage(error)}`,
+      ],
     };
   }
   const receipt = readReceipt(params.source, params.env);
@@ -474,7 +476,9 @@ async function migrateOneSource(params: {
   } catch (error) {
     return {
       changes: [],
-      warnings: [`Failed reading legacy workspace state: ${formatErrorMessage(error)}`],
+      warnings: [
+        `Failed reading legacy workspace state at ${params.source.sourcePath}: ${formatErrorMessage(error)}`,
+      ],
     };
   }
   // One artifact after verified removal is a new generation, including a source
@@ -502,15 +506,39 @@ async function migrateOneSource(params: {
   }
 
   let snapshot: SourceSnapshot;
-  let parsed: ParsedSource;
-  let claimedByThisRun = false;
   try {
     snapshot = await sourceClaim.read(!hasSource);
-    parsed = parseSource(params.source, snapshot);
   } catch (error) {
     return {
       changes: [],
-      warnings: [`Failed reading legacy workspace state: ${formatErrorMessage(error)}`],
+      warnings: [
+        `Failed reading legacy workspace state at ${params.source.sourcePath}: ${formatErrorMessage(error)}`,
+      ],
+    };
+  }
+  let parsed: ParsedSource;
+  let claimedByThisRun = false;
+  try {
+    parsed = parseSource(params.source, snapshot);
+  } catch (error) {
+    // A verified zero-byte regular file at a reserved state-directory
+    // attestation path carries no state and can never parse. Discard it so
+    // Doctor converges instead of blocking the workspace on every run.
+    if (snapshot.size === 0 && isReservedStateDirAttestation(params.source)) {
+      return await discardEmptyReservedAttestation({
+        sourceClaim,
+        source: params.source,
+        snapshot,
+        hasSource,
+        removeSource: params.removeSource,
+        beforeClaim: params.beforeClaim,
+      });
+    }
+    return {
+      changes: [],
+      warnings: [
+        `Failed reading legacy workspace state at ${params.source.sourcePath}: ${formatErrorMessage(error)}`,
+      ],
     };
   }
 
@@ -583,6 +611,76 @@ async function migrateOneSource(params: {
     warnings: [],
     notices: ["Removed retired workspace state after verified SQLite import."],
   };
+}
+
+/**
+ * Reserved hashed state-directory attestations live under the OpenClaw-owned
+ * `workspace-attestations/` directory. Sibling `.attested` files next to a
+ * workspace are not reserved and must keep their header protection.
+ */
+function isReservedStateDirAttestation(source: LegacyWorkspaceStateSource): boolean {
+  return (
+    source.kind === "attestation" &&
+    path.dirname(source.relativePath) === LEGACY_WORKSPACE_ATTESTATION_DIRNAME
+  );
+}
+
+/**
+ * Discard a verified zero-byte regular file at a reserved state-directory
+ * attestation path. The read already proved it is a non-symlink, non-hardlink
+ * regular file, so an empty snapshot carries no state Doctor could import.
+ */
+async function discardEmptyReservedAttestation(params: {
+  sourceClaim: LegacyMigrationSourceClaim<SourceSnapshot>;
+  source: LegacyWorkspaceStateSource;
+  snapshot: SourceSnapshot;
+  hasSource: boolean;
+  removeSource?: (sourcePath: string) => Promise<void> | void;
+  beforeClaim?: (source: LegacyWorkspaceStateSource) => void;
+}): Promise<MigrationMessages> {
+  try {
+    assertConfiguredWorkspaceIdentity(params.source);
+    let snapshot = params.snapshot;
+    if (params.hasSource) {
+      try {
+        snapshot = await params.sourceClaim.claim({
+          snapshot,
+          beforeClaim: () => {
+            params.beforeClaim?.(params.source);
+            assertConfiguredWorkspaceIdentity(params.source);
+          },
+          mismatchMessage: "legacy workspace source changed before Doctor could claim it",
+        });
+      } catch (error) {
+        const restoreError = await params.sourceClaim.restore();
+        return {
+          changes: [],
+          warnings: [
+            `Failed discarding empty reserved workspace attestation at ${params.source.sourcePath}: ${formatErrorMessage(error)}${restoreError ? `; restore failure: ${restoreError}` : ""}`,
+          ],
+        };
+      }
+    }
+    const unchanged = await params.sourceClaim.read(true);
+    if (!snapshotsMatch(snapshot, unchanged)) {
+      throw new Error("legacy workspace claim changed before discard");
+    }
+    await params.sourceClaim.remove({
+      removeSource: params.removeSource,
+      skipSourceCheck: true,
+    });
+    return {
+      changes: ["Discarded empty reserved workspace attestation."],
+      warnings: [],
+    };
+  } catch (error) {
+    return {
+      changes: [],
+      warnings: [
+        `Failed discarding empty reserved workspace attestation at ${params.source.sourcePath}: ${formatErrorMessage(error)}`,
+      ],
+    };
+  }
 }
 
 /** Import retired workspace files while excluding Gateways that can recreate them. */

--- a/src/infra/state-migrations.workspace-setup.ts
+++ b/src/infra/state-migrations.workspace-setup.ts
@@ -661,6 +661,11 @@ async function discardEmptyReservedAttestation(params: {
         };
       }
     }
+    // Mirror the import path's pre-delete invariant: a source recreated after
+    // the claim must not be silently covered by a reported discard.
+    if (await params.sourceClaim.exists()) {
+      throw new Error("legacy workspace source reappeared during discard");
+    }
     const unchanged = await params.sourceClaim.read(true);
     if (!snapshotsMatch(snapshot, unchanged)) {
       throw new Error("legacy workspace claim changed before discard");
@@ -668,6 +673,9 @@ async function discardEmptyReservedAttestation(params: {
     await params.sourceClaim.remove({
       removeSource: params.removeSource,
       skipSourceCheck: true,
+      // A recreated source is a new generation that must remain visible to
+      // Doctor; never report a successful discard while the source exists.
+      sourceRemainingMessage: "legacy workspace source reappeared during discard",
     });
     return {
       changes: ["Discarded empty reserved workspace attestation."],


### PR DESCRIPTION
The upstream maintainers have already landed this exact fix: PR #134641 (`fix: doctor --fix never completes when a reserved workspace attestation is empty`, merged 2026-09-01T03:21Z) covers the same zero-byte reserved-attestation discard path, includes the same pre-delete source-reappearance check that review requested here, and issue #134445 was closed as completed on that merge.

This PR was opened ~10 minutes before that merge landed, so it is now duplicate work. Closing it in favor of #134641; no further action needed here.