### PR TITLE
fix: doctor preserves official plugin config before install

### DIFF
--- a/src/commands/doctor/shared/stale-plugin-config.test.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.test.ts
@@ -180,13 +180,14 @@ describe("doctor stale plugin config helpers", () => {
     expect(result.config.plugins?.slots).toEqual({ contextEngine: "none" });
   });
 
-  it("preserves official external plugin config before installation", () => {
+  it("preserves official external plugin lookup ids before installation", () => {
     const result = maybeRepairStalePluginConfig({
       plugins: {
-        allow: ["codex", "missing-plugin"],
-        deny: ["codex", "missing-deny"],
+        allow: ["codex", "qqbot", "missing-plugin"],
+        deny: ["codex", "qqbot", "missing-deny"],
         entries: {
           codex: { enabled: true },
+          qqbot: { enabled: false },
           "missing-plugin": { enabled: true },
         },
       },
@@ -197,9 +198,12 @@ describe("doctor stale plugin config helpers", () => {
       "- plugins.deny: removed 1 stale plugin id (missing-deny)",
       "- plugins.entries: removed 1 stale plugin entry (missing-plugin)",
     ]);
-    expect(result.config.plugins?.allow).toEqual(["codex"]);
-    expect(result.config.plugins?.deny).toEqual(["codex"]);
-    expect(result.config.plugins?.entries).toEqual({ codex: { enabled: true } });
+    expect(result.config.plugins?.allow).toEqual(["codex", "qqbot"]);
+    expect(result.config.plugins?.deny).toEqual(["codex", "qqbot"]);
+    expect(result.config.plugins?.entries).toEqual({
+      codex: { enabled: true },
+      qqbot: { enabled: false },
+    });
   });
 
   it("preserves codex in policy surfaces while the version-bound plugin is absent", () => {

--- a/src/commands/doctor/shared/stale-plugin-config.ts
+++ b/src/commands/doctor/shared/stale-plugin-config.ts
@@ -9,7 +9,7 @@ import { loadInstalledPluginIndexInstallRecordsSync } from "../../../plugins/ins
 import { loadManifestMetadataSnapshot } from "../../../plugins/manifest-contract-eligibility.js";
 import {
   listOfficialExternalPluginCatalogEntries,
-  resolveOfficialExternalPluginId,
+  resolveOfficialExternalPluginLookupIds,
 } from "../../../plugins/official-external-plugin-catalog.js";
 import { defaultSlotIdForKey, type PluginSlotKey } from "../../../plugins/slots.js";
 import { listMutableCodexRouteAgentEntries } from "./codex-route-agent-entries.js";
@@ -29,7 +29,7 @@ type StalePluginConfigHit = {
 
 type StalePluginRegistryState = {
   knownIds: Set<string>;
-  officialIds: Set<string>;
+  officialLookupIds: Set<string>;
   knownChannelIds: Set<string>;
   missingInstalledIds: Set<string>;
   hasDiscoveryErrors: boolean;
@@ -49,9 +49,9 @@ function collectPluginRegistryState(
   }).manifestRegistry;
   const knownIds = new Set(registry.plugins.map((plugin) => plugin.id));
   // Official catalog config remains valid even when its package is not installed yet.
-  const officialIds = new Set(
+  const officialLookupIds = new Set(
     listOfficialExternalPluginCatalogEntries()
-      .map((entry) => normalizePluginId(resolveOfficialExternalPluginId(entry) ?? ""))
+      .flatMap((entry) => resolveOfficialExternalPluginLookupIds(entry).map(normalizePluginId))
       .filter(Boolean),
   );
   const installedIds = new Set<string>();
@@ -84,7 +84,7 @@ function collectPluginRegistryState(
   }
   return {
     knownIds,
-    officialIds,
+    officialLookupIds,
     knownChannelIds,
     missingInstalledIds: new Set([...installedIds].filter((pluginId) => !knownIds.has(pluginId))),
     hasDiscoveryErrors: registry.diagnostics.some((diag) => diag.level === "error"),
@@ -119,7 +119,7 @@ function scanStalePluginConfigWithState(
   registryState: StalePluginRegistryState,
 ): StalePluginConfigHit[] {
   const plugins = asNullableRecord(cfg.plugins);
-  const { knownIds, officialIds } = registryState;
+  const { knownIds, officialLookupIds } = registryState;
   const hits: StalePluginConfigHit[] = [];
   const staleEvidenceIds = new Set(registryState.missingInstalledIds);
 
@@ -133,7 +133,7 @@ function scanStalePluginConfigWithState(
       if (
         !pluginId ||
         knownIds.has(pluginId) ||
-        officialIds.has(pluginId) ||
+        officialLookupIds.has(pluginId) ||
         registryState.knownChannelIds.has(pluginId)
       ) {
         continue;
@@ -150,7 +150,7 @@ function scanStalePluginConfigWithState(
       if (
         !pluginId ||
         knownIds.has(pluginId) ||
-        officialIds.has(pluginId) ||
+        officialLookupIds.has(pluginId) ||
         registryState.knownChannelIds.has(pluginId)
       ) {
         continue;

--- a/src/plugins/official-external-plugin-catalog.ts
+++ b/src/plugins/official-external-plugin-catalog.ts
@@ -1275,7 +1275,7 @@ export function resolveOfficialExternalChannelCompatibilityMigration(
   );
 }
 
-function resolveOfficialExternalPluginLookupIds(
+export function resolveOfficialExternalPluginLookupIds(
   entry: OfficialExternalPluginCatalogEntry,
 ): string[] {
   const manifest = getOfficialExternalPluginCatalogManifest(entry);


### PR DESCRIPTION
Closes #134407

Reported by @abacha.

## What Problem This Solves

Fixes an issue where `openclaw doctor --fix` removed authored configuration for an official plugin before its package was installed when the configuration used the plugin's public channel or provider identity.

An explicit disabled entry could therefore disappear and later allow the plugin to load with its default enabled state.

## Why This Change Was Made

Doctor now uses the official catalog's existing lookup identity set when it decides whether plugin policy is stale. This keeps channel IDs and provider aliases aligned with config validation while retaining cleanup for truly unknown IDs.

The repair stays at the catalog-to-Doctor ownership boundary. It adds no plugin-specific rule, compatibility fallback, or configuration option.

## User Impact

Operators can run Doctor without losing official pre-install plugin policy written through `openclaw config set`, including explicit `enabled: false` entries.

Doctor still removes stale entries that do not match an installed plugin, built-in channel, or official catalog identity.

## Evidence

- Baseline `9aa82b18253b9bbe93863968ab891329287ff4f8`: real built CLI in Testbox removed `plugins.entries.qqbot` during `doctor --fix --non-interactive`: https://github.com/openclaw/openclaw/actions/runs/33464427268
- Exact head `884c392b1cb160fa1d29b4e9264aee4e884423f5`: real `config set` wrote `qqbot`, `openclaw-qqbot`, and `totally-fake-plugin`; Doctor preserved both official identities and removed only the fake entry: https://github.com/openclaw/openclaw/actions/runs/33465028384
- The updated owner-boundary regression failed on baseline production because Doctor removed `qqbot` from allow, deny, and entries. It passes on this head while retaining unknown-ID cleanup.
- `node scripts/run-vitest.mjs src/commands/doctor/shared/stale-plugin-config.test.ts src/plugins/official-external-plugin-catalog.test.ts` — 103 tests passed.
- Focused Oxlint and `git diff --check` passed.
- Autoreview P0 found no actionable defects.
- Production lines: `+9/-9`; tests: `+10/-6`.
