### PR TITLE
fix(doctor): report plugin version drift after upgrades

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -245,6 +245,13 @@ openclaw doctor --lint --skip core/doctor/skills-readiness
 
 `openclaw doctor --post-upgrade` runs plugin compatibility probes for chaining after a build or upgrade. Findings go to stdout; exit code is 1 if any finding has `level: "error"`. Add `--json` for a machine-readable envelope (`{ probesRun, findings }`), suitable for CI, the community `fork-upgrade` skill, and other post-upgrade smoke tooling. If the installed plugin index is missing or malformed, JSON mode still emits the envelope with a `plugin.index_unavailable` error finding.
 
+The probes also warn with `plugin.version_drift` when an enabled official plugin
+in the installed index belongs to a different release cohort than the upgraded
+OpenClaw CLI. Follow the reported plugin update command, then restart the
+Gateway. Exact npm pins receive an update command only after the registry
+confirms that target exists. Independently versioned community plugins and
+disabled plugins are excluded; version drift alone does not change the exit code.
+
 Container image startup is the exception to the usual "run doctor after
 updating" flow. When `openclaw gateway run` starts on a new OpenClaw version, it
 runs safe state and plugin repairs before reporting ready. If repair cannot

--- a/src/commands/doctor-post-upgrade.test.ts
+++ b/src/commands/doctor-post-upgrade.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { resetLogger, setLoggerOverride } from "../logging.js";
 import { writePersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store-write.js";
 import { resolveInstalledPluginIndexStorePath } from "../plugins/installed-plugin-index-store.js";
@@ -12,6 +13,7 @@ import {
   closeOpenClawStateDatabaseByPath,
   runOpenClawStateWriteTransaction,
 } from "../state/openclaw-state-db.js";
+import { VERSION } from "../version.js";
 import { runPostUpgradeProbes } from "./doctor-post-upgrade.js";
 
 async function makeFixtureRoot(prefix: string): Promise<string> {
@@ -24,7 +26,10 @@ async function cleanupFixtureRoot(root: string): Promise<void> {
   await fs.rm(root, { recursive: true, force: true });
 }
 
-function createIndex(plugins: InstalledPluginIndex["plugins"]): InstalledPluginIndex {
+function createIndex(
+  plugins: InstalledPluginIndex["plugins"],
+  installRecords: InstalledPluginIndex["installRecords"] = {},
+): InstalledPluginIndex {
   return {
     version: 1,
     hostContractVersion: "test-host",
@@ -32,7 +37,7 @@ function createIndex(plugins: InstalledPluginIndex["plugins"]): InstalledPluginI
     migrationVersion: 1,
     policyHash: "test-policy",
     generatedAtMs: 1,
-    installRecords: {},
+    installRecords,
     plugins,
     diagnostics: [],
   };
@@ -72,6 +77,8 @@ async function writePluginFixture(
     includePackageJsonRecord?: boolean;
     manifest?: Record<string, unknown> | false;
     manifestHash?: string;
+    enabled?: boolean;
+    installRecord?: PluginInstallRecord;
   },
 ) {
   const pluginDir = path.join(root, params.location ?? "user-plugins", params.id);
@@ -95,21 +102,24 @@ async function writePluginFixture(
     await fs.writeFile(manifestPath, JSON.stringify(params.manifest ?? { id: params.id }), "utf-8");
   }
   await writePersistedInstalledPluginIndex(
-    createIndex([
-      {
-        pluginId: params.id,
-        rootDir: pluginDir,
-        enabled: true,
-        origin: params.origin ?? "global",
-        startup: { sidecar: false, memory: false, agentHarnesses: [] },
-        compat: [],
-        ...(hasPackageJson && params.includePackageJsonRecord !== false
-          ? { packageJson: { path: "package.json", hash: "package-hash" } }
-          : {}),
-        manifestPath: params.manifest === false ? "" : manifestPath,
-        manifestHash: params.manifestHash ?? "",
-      },
-    ]),
+    createIndex(
+      [
+        {
+          pluginId: params.id,
+          rootDir: pluginDir,
+          enabled: params.enabled ?? true,
+          origin: params.origin ?? "global",
+          startup: { sidecar: false, memory: false, agentHarnesses: [] },
+          compat: [],
+          ...(hasPackageJson && params.includePackageJsonRecord !== false
+            ? { packageJson: { path: "package.json", hash: "package-hash" } }
+            : {}),
+          manifestPath: params.manifest === false ? "" : manifestPath,
+          manifestHash: params.manifestHash ?? "",
+        },
+      ],
+      params.installRecord ? { [params.id]: params.installRecord } : {},
+    ),
     { stateDir: root },
   );
 }
@@ -608,6 +618,66 @@ describe("runPostUpgradeProbes — plugin.manifest_drift", () => {
       expect(finding).toBeDefined();
       expect(finding?.level).toBe("warn");
       expect(finding?.plugin).toBe("drifted");
+    });
+  });
+});
+
+describe("runPostUpgradeProbes — plugin.version_drift", () => {
+  it.each([
+    {
+      label: "outdated official install",
+      id: "whatsapp",
+      version: "2026.7.1",
+      enabled: true,
+      drift: true,
+    },
+    {
+      label: "matching official install",
+      id: "whatsapp",
+      version: VERSION,
+      enabled: true,
+      drift: false,
+    },
+    {
+      label: "disabled official install",
+      id: "whatsapp",
+      version: "2026.7.1",
+      enabled: false,
+      drift: false,
+    },
+    { label: "community install", id: "community", version: "1.2.3", enabled: true, drift: false },
+  ])("checks $label against the upgraded core", async ({ id, version, enabled, drift }) => {
+    await withFixtureRoot("version-drift", async (root) => {
+      await writePluginFixture(root, {
+        id,
+        enabled,
+        packageJson: { name: `@openclaw/${id}`, version, openclaw: { extensions: ["./index.js"] } },
+        files: { "index.js": "export default {};" },
+        installRecord: {
+          source: "npm",
+          spec: `@openclaw/${id}@latest`,
+          resolvedName: `@openclaw/${id}`,
+          resolvedVersion: version,
+        },
+      });
+
+      const report = await runPostUpgradeProbes({ stateDir: root });
+      expect(report.findings).toEqual(
+        drift
+          ? [
+              expect.objectContaining({
+                code: "plugin.version_drift",
+                level: "warn",
+                plugin: id,
+                message: expect.stringContaining(`openclaw plugins update ${id}`),
+              }),
+            ]
+          : [],
+      );
+      if (drift) {
+        expect(report.findings[0]?.message).toContain(version);
+        expect(report.findings[0]?.message).toContain(VERSION);
+      }
     });
   });
 });

--- a/src/commands/doctor-post-upgrade.ts
+++ b/src/commands/doctor-post-upgrade.ts
@@ -5,13 +5,17 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { formatConsoleDiagnosticLine } from "../logging/json-console-line.js";
+import { resolveInstalledPluginIndexInstallOwner } from "../plugins/installed-plugin-index-install-owner.js";
 import { readPersistedInstalledPluginIndex } from "../plugins/installed-plugin-index-store.js";
-import type {
-  InstalledPluginIndex,
-  InstalledPluginIndexRecord,
-} from "../plugins/installed-plugin-index-types.js";
+import type { InstalledPluginIndexRecord } from "../plugins/installed-plugin-index-types.js";
 import { resolvePackageExtensionEntries, type PackageManifest } from "../plugins/manifest.js";
 import { validatePackageExtensionEntriesForInstall } from "../plugins/package-entry-resolution.js";
+import {
+  detectPluginVersionDrift,
+  resolvePluginVersionDriftTargets,
+  resolvePluginVersionDriftUpdateCommand,
+} from "../plugins/plugin-version-drift.js";
+import { VERSION } from "../version.js";
 import {
   POST_UPGRADE_PROBE_CODES,
   type PostUpgradeFinding,
@@ -47,15 +51,6 @@ function isBundledSourceCheckoutPluginRoot(pluginRootDir: string): boolean {
     }
     current = next;
   }
-}
-
-async function readInstalledPluginIndex(params: {
-  stateDir?: string;
-}): Promise<Pick<InstalledPluginIndex, "plugins"> | null> {
-  const index = await readPersistedInstalledPluginIndex(
-    params.stateDir ? { stateDir: params.stateDir } : {},
-  );
-  return index ? { plugins: [...index.plugins] } : null;
 }
 
 async function readInstalledPackageJson(
@@ -99,7 +94,7 @@ export async function runPostUpgradeProbes(params: {
   stateDir?: string;
 }): Promise<PostUpgradeReport> {
   const findings: PostUpgradeFinding[] = [];
-  const installs = await readInstalledPluginIndex(params);
+  const installs = await readPersistedInstalledPluginIndex(params);
   if (!installs) {
     findings.push({
       level: "error",
@@ -110,10 +105,31 @@ export async function runPostUpgradeProbes(params: {
     return buildReport(findings);
   }
 
-  for (const record of installs.plugins) {
-    if (!record.enabled) {
-      continue;
-    }
+  const enabledPlugins = installs.plugins.filter((record) => record.enabled);
+  const installRecords = Object.fromEntries(
+    Object.entries(installs.installRecords).filter(([id]) =>
+      enabledPlugins.some(
+        (record) =>
+          record.pluginId === id || resolveInstalledPluginIndexInstallOwner(record) === id,
+      ),
+    ),
+  );
+  // Post-upgrade validates the newly installed CLI even while the old Gateway
+  // is still running; the persisted index owns the selected plugins' enablement.
+  const drift = await resolvePluginVersionDriftTargets(
+    detectPluginVersionDrift({ gatewayVersion: VERSION, installRecords }),
+  );
+  for (const entry of drift.drifts) {
+    const updateCommand = resolvePluginVersionDriftUpdateCommand(entry);
+    findings.push({
+      level: "warn",
+      code: "plugin.version_drift",
+      plugin: entry.pluginId,
+      message: `Plugin ${entry.pluginId} is ${entry.installedVersion}, but OpenClaw is ${VERSION}. ${updateCommand ? `Run \`${updateCommand}\`, then restart the Gateway.` : "No confirmed repair target is available; check registry availability and rerun this command."}`,
+    });
+  }
+
+  for (const record of enabledPlugins) {
     const pkgRelPath = await resolvePackageJsonRelPath(record);
     if (pkgRelPath) {
       let pkg: PackageManifest;

--- a/src/commands/doctor-post-upgrade.types.ts
+++ b/src/commands/doctor-post-upgrade.types.ts
@@ -21,4 +21,5 @@ export const POST_UPGRADE_PROBE_CODES = [
   "plugin.index_unavailable",
   "plugin.entry_unresolved",
   "plugin.manifest_drift",
+  "plugin.version_drift",
 ] as const;


### PR DESCRIPTION
Related: #133984 and #134570 (post-upgrade plugin version diagnostics only; both upgrade umbrellas remain open).

## What Problem This Solves

Fixes an issue where operators running `openclaw doctor --post-upgrade` after a core upgrade received no findings even though an enabled official plugin still belonged to the previous release. The reported example was WhatsApp 2026.7.1 with OpenClaw 2026.8.1. Thanks @Lendersmark for the reproduction.

## Why This Change Was Made

The post-upgrade probe owner checked package entries and manifest hashes but discarded the installed index's durable install records. It now retains that canonical snapshot and reuses the existing official-plugin release-cohort detector and repair-target resolver. The comparison uses the upgraded CLI version, because a still-running old Gateway is not the candidate being validated.

Persisted plugin enablement selects the inspected installs, including explicit install-owner mappings. No plugin runtime executes, plugin pins are not changed, and exact npm update commands are emitted only after the registry confirms the requested version. The redundant index projection is removed. Production LOC: +35/-18 (net +17), required to expose the existing compatibility diagnostic through this command; tests: +87/-17 (net +70).

## User Impact

JSON and text output include an advisory `plugin.version_drift` finding with the installed/core versions and a usable update command. Disabled plugins and plugins without an official release-cohort contract remain excluded. Version warnings retain the command's existing successful exit behavior; error findings still exit 1. There are no new configuration, schema, dependency, or plugin API surfaces.

## Evidence

- Pre-fix regression: an enabled official WhatsApp 2026.7.1 fixture persisted through the real SQLite index returned `findings: []`; the added test failed while the other 28 cases passed.
- `node scripts/run-vitest.mjs src/commands/doctor-post-upgrade.test.ts src/plugins/plugin-version-drift.test.ts src/commands/doctor-workspace-status.plugin-version-drift.test.ts`: 62 tests passed across the post-upgrade owner and canonical drift/Doctor sibling paths.
- Mandatory structured autoreview and a separate isolated direct Codex CLI review: no accepted/actionable findings.
- `pnpm build`: passed, including the CLI bootstrap import guard and all public plugin SDK export checks.
- Real built CLI proof: `node openclaw.mjs doctor --post-upgrade --json` against isolated synthetic config and SQLite index. Floating WhatsApp 2026.7.1 produced the plugin-id update command; an exact 2026.7.1 pin queried the live public npm registry and produced `openclaw plugins update @openclaw/whatsapp@2026.8.1`. Disabled and matching 2026.8.1 fixtures produced no findings. All exited 0, retained the original config/install version/spec, and never executed the fixture plugin runtime.
- `node scripts/check-changed.mjs -- src/commands/doctor-post-upgrade.ts src/commands/doctor-post-upgrade.types.ts src/commands/doctor-post-upgrade.test.ts docs/cli/doctor.md`: passed all selected formatting, core/core-test typechecks, lint, export, schema, runtime import-cycle, and ownership guards.

The reported older WhatsApp inbound crash itself is outside this diagnostic repair; this PR neither attributes nor changes that runtime behavior.
