### PR TITLE
test(cli): reuse startup owners across each suite

### DIFF
--- a/src/cli/command-bootstrap.test.ts
+++ b/src/cli/command-bootstrap.test.ts
@@ -1,5 +1,5 @@
 // Command bootstrap tests cover CLI command bootstrap sequencing and side effects.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const ensureConfigReadyMock = vi.hoisted(() => vi.fn(async () => {}));
 const ensureCliPluginRegistryLoadedMock = vi.hoisted(() => vi.fn(async () => {}));
@@ -15,10 +15,13 @@ vi.mock("./plugin-registry-loader.js", () => ({
 describe("ensureCliCommandBootstrap", () => {
   let ensureCliCommandBootstrap: typeof import("./command-bootstrap.js").ensureCliCommandBootstrap;
 
-  beforeEach(async () => {
-    vi.clearAllMocks();
+  beforeAll(async () => {
     vi.resetModules();
     ({ ensureCliCommandBootstrap } = await import("./command-bootstrap.js"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
   it("runs config guard and plugin loading with shared options", async () => {
@@ -152,7 +155,7 @@ describe("ensureCliCommandBootstrap", () => {
     });
   });
 
-  it("does not evaluate config or plugin runtimes for a gateway-backed agent turn", async () => {
+  it("skips config and plugin activation for a gateway-backed agent turn", async () => {
     await ensureCliCommandBootstrap({
       runtime: {} as never,
       commandPath: ["agent"],

--- a/src/cli/command-execution-startup.test.ts
+++ b/src/cli/command-execution-startup.test.ts
@@ -1,5 +1,5 @@
 // Command execution startup tests cover startup behavior before CLI command execution.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 const emitCliBannerMock = vi.hoisted(() => vi.fn());
 const routeLogsToStderrMock = vi.hoisted(() => vi.fn());
@@ -24,10 +24,13 @@ vi.mock("./command-bootstrap.js", () => ({
 describe("command-execution-startup", () => {
   let mod: typeof import("./command-execution-startup.js");
 
-  beforeEach(async () => {
-    vi.clearAllMocks();
+  beforeAll(async () => {
     vi.resetModules();
     mod = await import("./command-execution-startup.js");
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
   });
 
   it("preserves console exports for a co-sharded subsystem logger", async () => {
@@ -196,7 +199,7 @@ describe("command-execution-startup", () => {
     expect(emitCliBannerMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not import the banner module for JSON output", async () => {
+  it("does not emit the banner for JSON output", async () => {
     await mod.applyCliExecutionStartupPresentation({
       startupPolicy: {
         suppressDoctorStdout: true,


### PR DESCRIPTION
## What Problem This Solves

The CLI startup suites repeatedly evaluate the same module graphs before each case, although their dependency factories are stable and their call histories already reset between cases.

## Why This Change Was Made

Load each owner once in beforeAll, retaining the initial module reset and per-case mock clearing. The config-loader cache holds the same mocked binding; policy and environment inputs remain per invocation. Keep the partial console mock and its co-sharded logger regression.

## User Impact

Remove 16 module resets and 16 repeated owner-graph loads. All 18 owner cases and 32 expect expressions remain. Two names now describe the activation/banner calls actually asserted. Production +0/-0; tests +14/-8. Runtime behavior is unchanged.

## Evidence

All 42 cases pass before and after in the normal non-isolated CLI project with one worker, including startup-policy, timing and registry-loader siblings. Full changed checks and Codex autoreview pass.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/cli/command-bootstrap.test.ts src/cli/command-execution-startup.test.ts src/cli/command-startup-policy.test.ts src/cli/command-startup-timing.test.ts src/cli/plugin-registry-loader.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base 59976298fff187871660111fc068c7629631fb28
```

Source review covered callers, owners, lazy loader, shared-worker cleanup, installed Vitest reset behavior and the historical console-export regression. Recorded file start times are available in local proof; no historical full-shard order, cold-import observation or elapsed-time speedup is claimed.
