### PR TITLE
fix: reduce memory spikes in catalogs, resets, and chat

### DIFF
--- a/src/agents/prepared-model-catalog-worker.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.integration.test.ts
@@ -44,6 +44,8 @@ import {
   DURABLE_AUTH_KEY,
   EXTERNAL_AUTH_PROFILE_ID,
   EXTERNAL_AUTH_PATH_ENV,
+  createJwtWithExp,
+  writeCodexAuth,
   writeFixturePlugin,
 } from "./prepared-model-catalog-worker.test-support.js";
 import {
@@ -67,35 +69,12 @@ import {
 const { makeTempDir, retireAfterTest, waitForWorkers, waitForMarker } =
   usePreparedCatalogWorkerFixtures();
 
-function createJwtWithExp(exp: number, marker?: string): string {
-  const payload = Buffer.from(JSON.stringify({ exp, ...(marker ? { marker } : {}) })).toString(
-    "base64url",
-  );
-  return `header.${payload}.signature`;
-}
-
-function writeCodexAuth(codexHome: string, marker: string): void {
-  const authPath = path.join(codexHome, "auth.json");
-  fs.writeFileSync(
-    authPath,
-    JSON.stringify({
-      auth_mode: "chatgpt",
-      tokens: {
-        access_token: createJwtWithExp(Math.floor(Date.now() / 1000) + 3600, marker),
-        refresh_token: `refresh-${marker}-not-real`,
-      },
-    }),
-    "utf8",
-  );
-  const future = new Date(Date.now() + 2_000);
-  fs.utimesSync(authPath, future, future);
-}
-
 function createCatalogFixture(
   spinMs: number,
   envOverride: NodeJS.ProcessEnv = {},
   options?: {
     hydrateExternalCliProviderIds?: readonly string[];
+    builtPluginVersion?: string;
   },
 ) {
   const root = makeTempDir("openclaw-model-catalog-worker-");
@@ -106,7 +85,7 @@ function createCatalogFixture(
   const externalAuthPath = path.join(root, "external-auth.txt");
   fs.mkdirSync(agentDir, { recursive: true });
   fs.mkdirSync(workspaceDir, { recursive: true });
-  const pluginFile = writeFixturePlugin({ root, spinMs });
+  const pluginFile = writeFixturePlugin({ root, spinMs, ...options });
   fs.writeFileSync(externalAuthPath, "A", "utf8");
   const env = {
     ...process.env,
@@ -189,6 +168,9 @@ async function createStaticSnapshot(
   envOverride: NodeJS.ProcessEnv = {},
   options?: {
     hydrateExternalCliProviderIds?: readonly string[];
+    builtPluginVersion?: string;
+    prepareInboundPluginRegistry?: boolean;
+    readOnly?: boolean;
     metadataWorkspace?: "gateway" | "none" | "activation";
     provideMetadataToWorker?: boolean;
   },
@@ -202,6 +184,7 @@ async function createStaticSnapshot(
     workspaceDir,
     config,
     env,
+    ...(options?.readOnly ? { readOnly: true } : {}),
   };
   let current = true;
   const isCurrent = () => current;
@@ -230,6 +213,7 @@ async function createStaticSnapshot(
       input,
       catalogOwner: preparePublishedModelCatalogOwnerIdentity(input),
       isGenerationCurrent: isCurrent,
+      prepareInboundPluginRegistry: options?.prepareInboundPluginRegistry,
     },
     new Map(),
     30_000,
@@ -257,6 +241,51 @@ async function createReadyWorkerFixture(spinMs: number) {
 describe("prepared model catalog worker boundary", () => {
   beforeEach(() => {
     vi.stubEnv("CODEX_HOME", makeTempDir("openclaw-worker-empty-codex-"));
+  });
+
+  it.each([
+    { owner: "configured Gateway", prepareInboundPluginRegistry: true, version: "built" },
+    { owner: "standalone", prepareInboundPluginRegistry: false, version: "v1" },
+  ])("keeps the $owner artifact selection in catalog and auth workers", async (selection) => {
+    const fixture = await createStaticSnapshot(
+      0,
+      {},
+      {
+        builtPluginVersion: "built",
+        prepareInboundPluginRegistry: selection.prepareInboundPluginRegistry,
+      },
+    );
+    const catalog = await fixture.snapshot.loadFullModelCatalog!();
+    expect.soft(catalog.entries).toContainEqual(
+      expect.objectContaining({
+        provider: PROVIDER_ID,
+        id: `plugin-generation-${selection.version}`,
+      }),
+    );
+    const auth = await loadPreparedModelRuntimeAuth(fixture.snapshot, {
+      providerIds: [PROVIDER_ID],
+    });
+    expect(auth?.authStore.profiles[EXTERNAL_AUTH_PROFILE_ID]).toMatchObject({
+      access: `${selection.version}:A`,
+    });
+    expect(
+      new Set(
+        fs
+          .readFileSync(path.join(fixture.root, "discovery-artifacts.txt"), "utf8")
+          .trim()
+          .split("\n"),
+      ),
+    ).toEqual(new Set([selection.version]));
+  });
+
+  it("keeps explicit read-only full inventories discoverable without a runtime registry", async () => {
+    const fixture = await createStaticSnapshot(0, {}, { readOnly: true });
+    expect(fixture.snapshot.pluginRegistry).toBeUndefined();
+
+    const catalog = await fixture.snapshot.loadFullModelCatalog!();
+    expect(catalog.entries).toContainEqual(
+      expect.objectContaining({ provider: PROVIDER_ID, id: "plugin-generation-v1" }),
+    );
   });
 
   it("preserves prepared catalog ownership across ambient environment changes", async () => {

--- a/src/agents/prepared-model-catalog-worker.test-support.ts
+++ b/src/agents/prepared-model-catalog-worker.test-support.ts
@@ -21,20 +21,46 @@ export const DURABLE_AUTH_KEY = "post-startup-durable-key-not-real";
 export const EXTERNAL_AUTH_PROFILE_ID = `${PROVIDER_ID}:external`;
 export const EXTERNAL_AUTH_PATH_ENV = "OPENCLAW_WORKER_EXTERNAL_AUTH_PATH";
 
+export function createJwtWithExp(exp: number, marker?: string): string {
+  const payload = Buffer.from(JSON.stringify({ exp, ...(marker ? { marker } : {}) })).toString(
+    "base64url",
+  );
+  return `header.${payload}.signature`;
+}
+
+export function writeCodexAuth(codexHome: string, marker: string): void {
+  const authPath = path.join(codexHome, "auth.json");
+  fs.writeFileSync(
+    authPath,
+    JSON.stringify({
+      auth_mode: "chatgpt",
+      tokens: {
+        access_token: createJwtWithExp(Math.floor(Date.now() / 1000) + 3600, marker),
+        refresh_token: `refresh-${marker}-not-real`,
+      },
+    }),
+    "utf8",
+  );
+  const future = new Date(Date.now() + 2_000);
+  fs.utimesSync(authPath, future, future);
+}
+
 export function writeFixturePlugin(params: {
   root: string;
   spinMs: number;
   pluginVersion?: string;
+  builtPluginVersion?: string;
 }): string {
   const pluginDir = path.join(params.root, "plugin");
   fs.mkdirSync(pluginDir, { recursive: true });
-  const pluginFile = path.join(pluginDir, "index.cjs");
+  let pluginFile = path.join(pluginDir, "index.cjs");
   const syntheticAuthProbePath = path.join(params.root, "synthetic-auth-probes.txt");
   writeSyntheticAuthDiscoveryFixture({
     root: params.root,
     pluginDir,
     harnessId: HARNESS_ID,
     unrelatedId: UNRELATED_SYNTHETIC_AUTH_ID,
+    pluginVersion: params.pluginVersion ?? "v1",
   });
   fs.writeFileSync(
     pluginFile,
@@ -163,6 +189,27 @@ module.exports = {
 `,
     "utf8",
   );
+  if (params.builtPluginVersion) {
+    const sourceFile = path.join(pluginDir, "index.cts");
+    fs.renameSync(pluginFile, sourceFile);
+    fs.renameSync(
+      path.join(pluginDir, "provider-discovery.cjs"),
+      path.join(pluginDir, "provider-discovery.cts"),
+    );
+    const builtFile = writeFixturePlugin({
+      root: params.root,
+      spinMs: params.spinMs,
+      pluginVersion: params.builtPluginVersion,
+    });
+    const distDir = path.join(pluginDir, "dist");
+    fs.mkdirSync(distDir);
+    fs.renameSync(builtFile, path.join(distDir, "index.cjs"));
+    fs.renameSync(
+      path.join(pluginDir, "provider-discovery.cjs"),
+      path.join(distDir, "provider-discovery.cjs"),
+    );
+    pluginFile = sourceFile;
+  }
   fs.writeFileSync(
     path.join(pluginDir, "openclaw.plugin.json"),
     JSON.stringify({
@@ -180,7 +227,9 @@ module.exports = {
         MISSING_AUTH_HARNESS_ID,
         UNRELATED_SYNTHETIC_AUTH_ID,
       ],
-      providerCatalogEntry: "./provider-discovery.cjs",
+      providerCatalogEntry: params.builtPluginVersion
+        ? "./provider-discovery.cts"
+        : "./provider-discovery.cjs",
       configSchema: { type: "object", additionalProperties: false, properties: {} },
       contracts: { externalAuthProviders: [PROVIDER_ID] },
       modelCatalog: { discovery: { [PROVIDER_ID]: "runtime" }, runtimeAugment: true },

--- a/src/agents/prepared-model-catalog-worker.test.ts
+++ b/src/agents/prepared-model-catalog-worker.test.ts
@@ -8,7 +8,7 @@ vi.mock("../plugins/manifest-registry-installed.js", () => ({
 }));
 
 describe("prepared model catalog worker input", () => {
-  it("preserves SecretRef identity beside materialized literals", () => {
+  it("preserves captured auth identity and distinguishes source from built artifacts", () => {
     const authStore = {
       version: 1,
       profiles: {
@@ -40,7 +40,7 @@ describe("prepared model catalog worker input", () => {
       order: { shared: ["shared:named"] },
       lastGood: { shared: "shared:named" },
     };
-    const workerInput = createPreparedModelCatalogWorkerInput({
+    const params = {
       agentFacts: {
         input: {
           agentDir: "/tmp/agent",
@@ -65,7 +65,8 @@ describe("prepared model catalog worker input", () => {
         index: {} as never,
         plugins: [],
       } as unknown as PluginMetadataSnapshot,
-    });
+    };
+    const workerInput = createPreparedModelCatalogWorkerInput(params);
 
     const cloned = structuredClone(workerInput);
     expect(cloned.authStore.profiles).toEqual({
@@ -86,5 +87,11 @@ describe("prepared model catalog worker input", () => {
     ]);
     expect(cloned.input).not.toHaveProperty("inheritedAuthDir");
     expect(cloned.input).not.toHaveProperty("loadRuntimePlugins");
+    const builtInput = structuredClone(
+      createPreparedModelCatalogWorkerInput({ ...params, preferBuiltPluginArtifacts: true }),
+    );
+    expect(cloned.preferBuiltPluginArtifacts).toBe(false);
+    expect(builtInput.preferBuiltPluginArtifacts).toBe(true);
+    expect(builtInput.generationFingerprint).not.toBe(cloned.generationFingerprint);
   });
 });

--- a/src/agents/prepared-model-catalog-worker.ts
+++ b/src/agents/prepared-model-catalog-worker.ts
@@ -33,6 +33,7 @@ export type PreparedModelCatalogWorkerInput = Readonly<{
   sourceConfigResolutionFacts: ReturnType<typeof serializeConfigResolutionFacts>;
   authStore: AuthProfileStore;
   providerIds: readonly string[];
+  preferBuiltPluginArtifacts: boolean;
   pluginMetadataSnapshot: Omit<PluginMetadataSnapshot, "normalizePluginId">;
 }>;
 
@@ -94,6 +95,7 @@ export function fingerprintPreparedModelCatalogGeneration(params: {
   sourceConfigResolutionFacts: ReturnType<typeof serializeConfigResolutionFacts>;
   authStore: AuthProfileStore;
   providerIds: readonly string[];
+  preferBuiltPluginArtifacts?: boolean;
   pluginMetadataSnapshot: PluginMetadataSnapshot;
 }): string {
   return fingerprintPreparedRuntimeFacts({
@@ -103,6 +105,7 @@ export function fingerprintPreparedModelCatalogGeneration(params: {
     sourceConfigResolutionFacts: params.sourceConfigResolutionFacts,
     authStore: params.authStore,
     providerIds: params.providerIds,
+    preferBuiltPluginArtifacts: params.preferBuiltPluginArtifacts === true,
     pluginFingerprint: fingerprintPreparedModelCatalogPlugins(params.pluginMetadataSnapshot),
   });
 }
@@ -110,6 +113,7 @@ export function fingerprintPreparedModelCatalogGeneration(params: {
 export function createPreparedModelCatalogWorkerInput(params: {
   agentFacts: PreparedModelRuntimeAgentFacts;
   pluginMetadataSnapshot: PluginMetadataSnapshot;
+  preferBuiltPluginArtifacts?: boolean;
 }): PreparedModelCatalogWorkerInput {
   const source = params.agentFacts.input;
   // Registries and closures stay process-local. The worker reconstructs them from this exact
@@ -148,6 +152,7 @@ export function createPreparedModelCatalogWorkerInput(params: {
       sourceConfigResolutionFacts,
       authStore,
       providerIds,
+      preferBuiltPluginArtifacts: params.preferBuiltPluginArtifacts,
       pluginMetadataSnapshot: params.pluginMetadataSnapshot,
     }),
     input,
@@ -156,6 +161,7 @@ export function createPreparedModelCatalogWorkerInput(params: {
     sourceConfigResolutionFacts,
     authStore,
     providerIds,
+    preferBuiltPluginArtifacts: params.preferBuiltPluginArtifacts === true,
     pluginMetadataSnapshot,
   };
 }

--- a/src/agents/prepared-model-catalog.worker.ts
+++ b/src/agents/prepared-model-catalog.worker.ts
@@ -93,12 +93,12 @@ async function prepareWorkerGeneration(value: PreparedModelCatalogWorkerInput) {
   setRuntimeConfigSnapshot(value.input.config, value.sourceConfigForSecrets);
   const { prepareWorkspaceBuildGroup } = await import("./prepared-model-runtime.facts.js");
   // Rediscovery under agent workspaces or runtime activation overlays loses the owner's
-  // metadata generation. Transfer its facts and restore only process-local behavior.
+  // metadata generation. Its source/built artifact selection must survive reconstruction too.
   const metadata = restorePluginMetadataSnapshot(value.pluginMetadataSnapshot);
   const prepared = await prepareWorkspaceBuildGroup(
     [value.input],
     "live",
-    {},
+    { preferBuiltPluginArtifacts: value.preferBuiltPluginArtifacts },
     undefined,
     undefined,
     metadata,
@@ -114,6 +114,7 @@ async function prepareWorkerGeneration(value: PreparedModelCatalogWorkerInput) {
     sourceConfigResolutionFacts: value.sourceConfigResolutionFacts,
     authStore: value.authStore,
     providerIds: value.providerIds,
+    preferBuiltPluginArtifacts: prepared.pluginGeneration.preferBuiltPluginArtifacts,
     pluginMetadataSnapshot: prepared.pluginGeneration.pluginMetadataSnapshot,
   });
   if (reconstructedFingerprint !== value.generationFingerprint) {

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -155,6 +155,7 @@ function createFullModelCatalogAccess(params: {
     input: createPreparedModelCatalogWorkerInput({
       agentFacts: params.agentFacts,
       pluginMetadataSnapshot: params.pluginGeneration.pluginMetadataSnapshot,
+      preferBuiltPluginArtifacts: params.pluginGeneration.preferBuiltPluginArtifacts,
     }),
     isCurrent: params.isCurrent,
   });

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -648,29 +648,36 @@ export async function prepareAgentCatalogSource(
           providerDiscoveryTimeoutMs: MODEL_RUNTIME_PROVIDER_DISCOVERY_TIMEOUT_MS,
         }),
   };
-  if (!persist) {
-    const source = await planOpenClawModelsJsonSource(input.config, input.agentDir, {
-      ...options,
-      ...(sourceOptions.authStore ? { authStore: sourceOptions.authStore } : {}),
-      ...(catalogMode === "live" ? { onProviderCatalogOutcome: recordProviderOutcome } : {}),
-    });
+  const prepareSource = async () => {
+    if (!persist) {
+      const source = await planOpenClawModelsJsonSource(input.config, input.agentDir, {
+        ...options,
+        ...(sourceOptions.authStore ? { authStore: sourceOptions.authStore } : {}),
+        ...(catalogMode === "live" ? { onProviderCatalogOutcome: recordProviderOutcome } : {}),
+      });
+      return {
+        modelsJsonContents: source.modelsJsonContents,
+        pluginCatalogs: source.pluginCatalogs,
+        providerOutcomes: resultOutcomes(),
+      };
+    }
+    if (!input.readOnly) {
+      await ensureOpenClawModelsJson(input.config, input.agentDir, {
+        ...options,
+        ...(catalogMode === "live" ? { onProviderCatalogOutcome: recordProviderOutcome } : {}),
+      });
+    }
+    // Capture immediately after the serialized write. Another owner may share this directory and
+    // publish a different workspace generation before full-catalog parsing begins.
     return {
-      modelsJsonContents: source.modelsJsonContents,
-      pluginCatalogs: source.pluginCatalogs,
+      modelsJsonContents: captureModelsJsonContents(input.agentDir),
+      pluginCatalogs: loadPersistedPluginModelCatalogsReadOnly(input.agentDir),
       providerOutcomes: resultOutcomes(),
     };
-  }
-  if (!input.readOnly) {
-    await ensureOpenClawModelsJson(input.config, input.agentDir, {
-      ...options,
-      ...(catalogMode === "live" ? { onProviderCatalogOutcome: recordProviderOutcome } : {}),
-    });
-  }
-  // Capture immediately after the serialized write. Another owner may share this directory and
-  // publish a different workspace generation before full-catalog parsing begins.
-  return {
-    modelsJsonContents: captureModelsJsonContents(input.agentDir),
-    pluginCatalogs: loadPersistedPluginModelCatalogsReadOnly(input.agentDir),
-    providerOutcomes: resultOutcomes(),
   };
+  const { pluginMetadataSnapshot: metadataSnapshot, pluginRegistry } = pluginGeneration;
+  // Read-only inventories can request live discovery without preparing a runtime registry.
+  return pluginRegistry
+    ? withPluginRuntimeGenerationScope({ metadataSnapshot, pluginRegistry }, prepareSource)
+    : prepareSource();
 }

--- a/src/agents/test-helpers/prepared-model-catalog-worker-fixture.ts
+++ b/src/agents/test-helpers/prepared-model-catalog-worker-fixture.ts
@@ -70,11 +70,13 @@ export function writeSyntheticAuthDiscoveryFixture(params: {
   pluginDir: string;
   harnessId: string;
   unrelatedId: string;
+  pluginVersion: string;
 }): void {
   const probePath = path.join(params.root, "synthetic-auth-probes.txt");
   fs.writeFileSync(
     path.join(params.pluginDir, "provider-discovery.cjs"),
     `const fs = require("node:fs");
+fs.appendFileSync(${JSON.stringify(path.join(params.root, "discovery-artifacts.txt"))}, ${JSON.stringify(params.pluginVersion)} + "\\n");
 module.exports = {
   id: ${JSON.stringify(params.harnessId)},
   hookAliases: [${JSON.stringify(params.unrelatedId)}],

--- a/src/config/sessions/session-accessor.reset-boundary-race.test.ts
+++ b/src/config/sessions/session-accessor.reset-boundary-race.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import * as sqliteQueries from "../../infra/kysely-sync.js";
 import * as agentDatabase from "../../state/openclaw-agent-db.js";
 import {
   applySessionEntryLifecycleMutation,
@@ -12,7 +13,9 @@ import {
   readRecentSessionTranscriptActiveEvents,
   waitForSessionTranscriptProjection,
 } from "./session-accessor.sqlite-active-events.js";
+import { loadTranscriptEventsFromDatabase } from "./session-accessor.sqlite-read.js";
 import { appendTranscriptMessageSync } from "./session-accessor.sqlite-transcript-write.js";
+import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
 
 const transactionInjection = vi.hoisted(() => ({ run: null as (() => void) | null }));
 
@@ -74,16 +77,17 @@ describe("reset boundary concurrency", () => {
           ],
         }),
     },
-  ])("parents the $name boundary after a concurrent accepted message", async ({ reset }) => {
+  ])("parents the $name boundary without hydrating prior message bodies", async ({ reset }) => {
     const scope = {
       sessionId: "current-session",
       sessionKey: "agent:main:reset-race",
       storePath,
     };
     await upsertSessionEntryCore(scope, { sessionId: scope.sessionId, updatedAt: 10 });
+    const body = "retained reset message body ".repeat(8_192);
     appendTranscriptMessageSync(scope, {
       eventId: "initial",
-      message: { role: "user", content: "initial" },
+      message: { role: "user", content: body },
       parentId: null,
     });
     transactionInjection.run = () => {
@@ -94,9 +98,38 @@ describe("reset boundary concurrency", () => {
       });
     };
 
-    await reset(scope);
+    const iterate = sqliteQueries.iterateSqliteQuerySync;
+    let hydratedBodyRows = 0;
+    const reads = vi.spyOn(sqliteQueries, "iterateSqliteQuerySync").mockImplementation(function* <
+      Row,
+    >(...args: Parameters<typeof sqliteQueries.iterateSqliteQuerySync<Row>>) {
+      for (const row of iterate<Row>(...args)) {
+        if (
+          row !== null &&
+          typeof row === "object" &&
+          "event_json" in row &&
+          typeof row.event_json === "string" &&
+          row.event_json.includes(body)
+        ) {
+          hydratedBodyRows += 1;
+        }
+        yield row;
+      }
+    });
+    try {
+      await reset(scope);
+    } finally {
+      reads.mockRestore();
+    }
 
     const raw = await loadTranscriptEvents(scope);
+    expect(raw).toContainEqual(
+      expect.objectContaining({
+        id: "initial",
+        message: expect.objectContaining({ role: "user", content: body }),
+      }),
+    );
+    expect(hydratedBodyRows).toBe(0);
     const boundary = raw.find(
       (event) =>
         event !== null &&
@@ -119,5 +152,67 @@ describe("reset boundary concurrency", () => {
         (event) => (event as { id?: unknown }).id,
       ),
     ).toContain("concurrent");
+  });
+
+  it("preserves navigation nulls and raw parser semantics in reset reads", async () => {
+    const sessionId = "reset-projection";
+    await upsertSessionEntryCore(
+      { sessionKey: "agent:main:reset-projection", storePath },
+      { sessionId, updatedAt: 10 },
+    );
+    const database = agentDatabase.openOpenClawAgentDatabase({
+      agentId: "main",
+      path: resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" }).path,
+    });
+    const navigationEvents = [
+      { type: "message", id: "user", timestamp: 1, message: { role: "user", content: "body" } },
+      { type: "leaf", id: "empty", parentId: null, targetId: null },
+      {
+        type: "leaf",
+        id: "selected",
+        parentId: "empty",
+        targetId: "user",
+        appendParentId: null,
+        appendMode: "side",
+      },
+      { type: "reset", id: "reset", parentId: "user", firstKeptEntryId: "user" },
+    ] as const;
+    const events = [
+      ...navigationEvents,
+      null,
+      "opaque",
+      ["opaque"],
+      JSON.parse(`{"type":"opaque","body":${"[".repeat(1_001)}0${"]".repeat(1_001)}}`) as unknown,
+    ];
+    const insert = database.db.prepare(
+      "INSERT INTO transcript_events (session_id, seq, event_json, created_at) VALUES (?, ?, ?, ?)",
+    );
+    events.forEach((event, seq) => insert.run(sessionId, seq, JSON.stringify(event), seq));
+
+    const projected = loadTranscriptEventsFromDatabase(database, sessionId, {
+      projection: "reset-boundary",
+    });
+    expect(projected[0]).toEqual({
+      type: "message",
+      id: "user",
+      timestamp: 1,
+      message: { role: "user" },
+    });
+    expect(projected[1]).toMatchObject(navigationEvents[1]);
+    expect(projected[1]).not.toHaveProperty("appendParentId");
+    expect(projected[2]).toMatchObject(navigationEvents[2]);
+    expect(projected[3]).toMatchObject(navigationEvents[3]);
+    expect(projected.slice(4)).toEqual(events.slice(4));
+    expect(loadTranscriptEventsFromDatabase(database, sessionId)).toEqual(events);
+    expect(loadTranscriptEventsFromDatabase(database, sessionId, { beforeEventSeq: 2 })).toEqual(
+      events.slice(0, 2),
+    );
+
+    insert.run(sessionId, events.length, "{", events.length);
+    for (const projection of [undefined, "reset-boundary"] as const) {
+      expect(() => loadTranscriptEventsFromDatabase(database, sessionId, { projection })).toThrow(
+        SyntaxError,
+      );
+    }
   });
 });

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -224,7 +224,9 @@ export async function resetSessionEntryLifecycle(
         assertLifecycleTargetUnchanged(transactionDb, params.target, current?.entry, "reset");
         if (shouldAppendResetBoundary && current?.entry.sessionId && params.resetBoundary) {
           const event = buildSessionResetBoundaryEvent({
-            events: loadTranscriptEventsFromDatabase(transactionDb, current.entry.sessionId),
+            events: loadTranscriptEventsFromDatabase(transactionDb, current.entry.sessionId, {
+              projection: "reset-boundary",
+            }),
             ...params.resetBoundary,
           });
           const appended = appendTranscriptEventsInTransaction(

--- a/src/config/sessions/session-accessor.sqlite-projection.ts
+++ b/src/config/sessions/session-accessor.sqlite-projection.ts
@@ -401,7 +401,9 @@ export async function applySessionEntryLifecycleMutation(params: {
         }
         if (resetBoundary && expectedEntry?.sessionId) {
           const event = buildSessionResetBoundaryEvent({
-            events: loadTranscriptEventsFromDatabase(transactionDb, expectedEntry.sessionId),
+            events: loadTranscriptEventsFromDatabase(transactionDb, expectedEntry.sessionId, {
+              projection: "reset-boundary",
+            }),
             ...resetBoundary,
           });
           const appended = appendTranscriptEventsInTransaction(

--- a/src/config/sessions/session-accessor.sqlite-read.ts
+++ b/src/config/sessions/session-accessor.sqlite-read.ts
@@ -28,6 +28,7 @@ import {
   resolveSqliteTranscriptReadScope,
   toDatabaseOptions,
 } from "./session-accessor.sqlite-scope.js";
+import { projectResetBoundaryNavigationSql } from "./session-model-context-projection.js";
 import { resolveSqliteSessionTranscriptReadFence } from "./session-transcript-read-fence.js";
 
 export type SqliteTranscriptSnapshotRow = {
@@ -83,7 +84,9 @@ export function loadTranscriptEventsSync(scope: SessionTranscriptReadScope): Tra
     database.db,
     () => {
       const fence = resolveSqliteSessionTranscriptReadFence({ database, ...resolved });
-      return loadTranscriptEventsFromDatabase(database, resolved.sessionId, fence?.beforeRawSeq);
+      return loadTranscriptEventsFromDatabase(database, resolved.sessionId, {
+        beforeEventSeq: fence?.beforeRawSeq,
+      });
     },
     {
       databaseLabel: database.path,
@@ -204,14 +207,19 @@ export function readTranscriptEventAtSeqSync(
 export function loadTranscriptEventsFromDatabase(
   database: OpenClawAgentDatabase,
   sessionId: string,
-  beforeEventSeq?: number,
+  options: { beforeEventSeq?: number; projection?: "reset-boundary" } = {},
 ): TranscriptEvent[] {
+  const { beforeEventSeq } = options;
   const db = getSessionKysely(database.db);
   const rows = iterateSqliteQuerySync(
     database.db,
     db
       .selectFrom("transcript_events")
-      .select(["event_json"])
+      .select((eb) => [
+        options.projection === "reset-boundary"
+          ? projectResetBoundaryNavigationSql(eb.ref("event_json")).as("event_json")
+          : "event_json",
+      ])
       .where("session_id", "=", sessionId)
       .$if(beforeEventSeq !== undefined, (query) => query.where("seq", "<", beforeEventSeq!))
       .orderBy("seq", "asc"),

--- a/src/config/sessions/session-model-context-projection.ts
+++ b/src/config/sessions/session-model-context-projection.ts
@@ -43,6 +43,22 @@ export function projectTranscriptNavigationSql(event: Expression<string>): RawBu
   return pickJsonObject(event, TRANSCRIPT_NAVIGATION_KEYS);
 }
 
+/** Reset boundaries select ancestry and replay roles without loading message bodies. */
+export function projectResetBoundaryNavigationSql(event: Expression<string>): RawBuilder<string> {
+  const entry = pickJsonObject(event, [
+    ...TRANSCRIPT_NAVIGATION_KEYS,
+    "timestamp",
+    "firstKeptEntryId",
+  ]);
+  // Non-object rows keep their parser behavior; malformed and SQLite-overdepth JSON
+  // must reach JSON.parse unchanged instead of failing inside the metadata projection.
+  return /* kysely-allow-raw: reset planning uses navigation metadata, never durable transcript payloads. */ sql<string>`CASE WHEN json_valid(${event}) THEN
+    CASE WHEN json_type(${event}) = 'object' THEN
+      json_set(${entry}, '$.message', json_object('role', json_extract(${event}, '$.message.role')))
+    ELSE ${event} END
+    ELSE ${event} END`;
+}
+
 /** Lightweight tree/state records; these never serve as persisted transcript evidence. */
 export function projectModelContextNavigationSql(event: Expression<string>): RawBuilder<string> {
   const entry = pickJsonObject(event, [

--- a/src/plugins/plugin-module-loader-cache.ts
+++ b/src/plugins/plugin-module-loader-cache.ts
@@ -321,7 +321,7 @@ export function getCachedPluginModuleLoader(
   return loader;
 }
 
-type PublicSurfaceModuleLoadParams = {
+type PluginModuleBoundaryParams = {
   modulePath: string;
   boundaryRoot: string;
   boundaryLabel: string;
@@ -329,7 +329,8 @@ type PublicSurfaceModuleLoadParams = {
   surfaceLabel: string;
 };
 
-function preparePublicSurfaceModule(params: PublicSurfaceModuleLoadParams) {
+/** Validates an entry once per generation without changing its module export shape. */
+export function preparePluginModule(params: PluginModuleBoundaryParams) {
   const cache = getPluginCache();
   let source = getPluginCacheSource(params.modulePath, cache);
   const boundaryKey = `${getPluginCacheRoot(params.boundaryRoot).rootDir}\0${params.rejectHardlinks}`;
@@ -366,11 +367,11 @@ function preparePublicSurfaceModule(params: PublicSurfaceModuleLoadParams) {
 
 /** Public artifacts and SDK facades share one validated module, including circular imports. */
 export function loadPluginPublicSurfaceModuleSync(
-  params: PublicSurfaceModuleLoadParams & {
+  params: PluginModuleBoundaryParams & {
     loadModule: (modulePath: string) => unknown;
   },
 ): object {
-  const { source, modulePath } = preparePublicSurfaceModule(params);
+  const { source, modulePath } = preparePluginModule(params);
   const cached = source.publicSurface?.exports;
   if (cached) {
     return cached;
@@ -389,11 +390,11 @@ export function loadPluginPublicSurfaceModuleSync(
 }
 
 export async function loadPluginPublicSurfaceModule(
-  params: PublicSurfaceModuleLoadParams & {
+  params: PluginModuleBoundaryParams & {
     loadModule: (modulePath: string) => Promise<object>;
   },
 ): Promise<object> {
-  const { source, modulePath } = preparePublicSurfaceModule(params);
+  const { source, modulePath } = preparePluginModule(params);
   const cached = source.publicSurface;
   if (cached?.exports) {
     return cached.exports;

--- a/src/plugins/plugin-runtime-artifact-resolution.test.ts
+++ b/src/plugins/plugin-runtime-artifact-resolution.test.ts
@@ -123,6 +123,11 @@ describe("resolvePluginRuntimeArtifact", () => {
       sourceName: "setup-entry.ts",
       artifactName: "setup-entry.js",
     },
+    {
+      entryKind: "provider-discovery" as const,
+      sourceName: "provider-discovery.ts",
+      artifactName: "provider-discovery.js",
+    },
   ])(
     "keeps source-external $entryKind entries inside their selected root after packaging",
     ({ entryKind, sourceName, artifactName }) => {
@@ -188,26 +193,29 @@ describe("resolvePluginRuntimeArtifact", () => {
     expect(aliased).toEqual(first);
   });
 
-  it("keeps runtime and setup entries distinct within one plugin root", () => {
-    const fixture = createBundledPluginFixture();
-    const setupSource = path.join(fixture.rootDir, "setup-entry.ts");
-    fs.writeFileSync(setupSource, "export default { register() {} };\n");
-    const runtime = resolveFixture({
-      ...fixture,
-      preferBuiltPluginArtifacts: false,
-    });
-    const setup = resolvePluginRuntimeArtifact({
-      pluginId: "fixture",
-      entryKind: "setup",
-      rootDir: fixture.rootDir,
-      source: fs.realpathSync(setupSource),
-      origin: "bundled",
-      preferBuiltPluginArtifacts: false,
-    });
+  it.each(["setup", "provider-discovery"] as const)(
+    "keeps runtime and %s entries distinct within one plugin root",
+    (entryKind) => {
+      const fixture = createBundledPluginFixture();
+      const setupSource = path.join(fixture.rootDir, "setup-entry.ts");
+      fs.writeFileSync(setupSource, "export default { register() {} };\n");
+      const runtime = resolveFixture({
+        ...fixture,
+        preferBuiltPluginArtifacts: false,
+      });
+      const setup = resolvePluginRuntimeArtifact({
+        pluginId: "fixture",
+        entryKind,
+        rootDir: fixture.rootDir,
+        source: fs.realpathSync(setupSource),
+        origin: "bundled",
+        preferBuiltPluginArtifacts: false,
+      });
 
-    expect(runtime.source).toBe(fixture.source);
-    expect(setup.source).toBe(fs.realpathSync(setupSource));
-  });
+      expect(runtime.source).toBe(fixture.source);
+      expect(setup.source).toBe(fs.realpathSync(setupSource));
+    },
+  );
 
   it("re-resolves after the active registry memo is cleared", () => {
     const fixture = createBundledPluginFixture();

--- a/src/plugins/plugin-runtime-artifact-resolution.ts
+++ b/src/plugins/plugin-runtime-artifact-resolution.ts
@@ -8,7 +8,7 @@ import { resolvePreferredBuiltRuntimeArtifact } from "./plugin-runtime-artifact-
 import type { PluginRegistry } from "./registry-types.js";
 import { getActivePluginRegistry, requireActivePluginRegistry } from "./runtime.js";
 
-type PluginRuntimeArtifactEntryKind = "runtime" | "setup";
+type PluginRuntimeArtifactEntryKind = "runtime" | "setup" | "provider-discovery";
 
 export function clearPluginRuntimeArtifactResolutionMemo(): void {
   getActivePluginRegistry()?.pluginRuntimeArtifacts.clear();

--- a/src/plugins/provider-discovery.runtime.ts
+++ b/src/plugins/provider-discovery.runtime.ts
@@ -5,13 +5,17 @@ import { sortUniqueStrings } from "../../packages/normalization-core/src/string-
 import type { ModelDefinitionConfig, ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { planEffectiveModelCatalogRows } from "../model-catalog/index.js";
+import { shouldRejectHardlinkedPluginFiles } from "./hardlink-policy.js";
 import { loadManifestMetadataSnapshot } from "./manifest-contract-eligibility.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import { withProfile } from "./plugin-load-profile.js";
 import type { PluginMetadataRegistryView } from "./plugin-metadata-snapshot.types.js";
-import { getCachedPluginModuleLoader } from "./plugin-module-loader-cache.js";
+import { getCachedPluginModuleLoader, preparePluginModule } from "./plugin-module-loader-cache.js";
+import { resolvePluginRuntimeArtifact } from "./plugin-runtime-artifact-resolution.js";
 import { resolveDiscoveredProviderPluginIds } from "./providers.js";
 import { resolvePluginProvidersCore } from "./providers.runtime.js";
+import { getPluginRuntimeGenerationRegistry } from "./runtime/generation-scope.js";
+import { getPluginRuntimeLoadContext } from "./runtime/load-context.js";
 import type { ProviderPlugin } from "./types.js";
 
 type ProviderDiscoveryModule =
@@ -54,22 +58,47 @@ function normalizeDiscoveryModule(value: ProviderDiscoveryModule): ProviderPlugi
   return [];
 }
 
-function loadProviderDiscoveryModule(params: {
-  pluginId: string;
-  modulePath: string;
-  rootDir: string;
-}): ProviderDiscoveryModule {
+function loadProviderDiscoveryModule(manifest: PluginManifestRecord): ProviderDiscoveryModule {
+  const registry = getPluginRuntimeGenerationRegistry();
+  const loadContext = getPluginRuntimeLoadContext(registry);
+  // Lightweight entries share the prepared registry's artifact policy, but must
+  // not alias its runtime entry or turn standalone source discovery into a build load.
+  const { source, rootDir } = registry
+    ? resolvePluginRuntimeArtifact({
+        pluginId: manifest.id,
+        entryKind: "provider-discovery",
+        source: manifest.providerDiscoverySource!,
+        rootDir: manifest.rootDir,
+        origin: manifest.origin,
+        packageManifest: manifest.packageManifest,
+        preferBuiltPluginArtifacts: loadContext?.preferBuiltPluginArtifacts === true,
+        registry,
+      })
+    : { source: manifest.providerDiscoverySource!, rootDir: manifest.rootDir };
+  const modulePath = registry
+    ? preparePluginModule({
+        modulePath: source,
+        boundaryRoot: rootDir,
+        boundaryLabel: "plugin root",
+        surfaceLabel: `plugin provider discovery ${manifest.id}`,
+        rejectHardlinks: shouldRejectHardlinkedPluginFiles({
+          origin: manifest.origin,
+          rootDir: manifest.rootDir,
+          env: loadContext?.env,
+        }),
+      }).modulePath
+    : source;
   const moduleLoader = getCachedPluginModuleLoader({
-    modulePath: params.modulePath,
-    rootDir: params.rootDir,
+    modulePath,
+    rootDir,
     importerUrl: import.meta.url,
     loaderFilename: import.meta.url,
     preferBuiltDist: true,
   });
   return withProfile(
-    { pluginId: params.pluginId, source: params.modulePath },
+    { pluginId: manifest.id, source: modulePath },
     "provider-discovery-entry",
-    () => moduleLoader(params.modulePath) as ProviderDiscoveryModule,
+    () => moduleLoader(modulePath) as ProviderDiscoveryModule,
   );
 }
 
@@ -278,11 +307,7 @@ function resolveProviderDiscoveryEntryPlugins(params: {
   const providers: ProviderPlugin[] = [];
   for (const manifest of entryRecords) {
     try {
-      const moduleExport = loadProviderDiscoveryModule({
-        pluginId: manifest.id,
-        modulePath: manifest.providerDiscoverySource!,
-        rootDir: manifest.rootDir,
-      });
+      const moduleExport = loadProviderDiscoveryModule(manifest);
       providers.push(
         ...normalizeDiscoveryModule(moduleExport).map((provider) =>
           Object.assign({}, provider, { pluginId: manifest.id }),

--- a/src/plugins/providers.runtime.consult-current-snapshot.test.ts
+++ b/src/plugins/providers.runtime.consult-current-snapshot.test.ts
@@ -10,7 +10,9 @@ import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-
 import type { PluginManifestRegistry } from "./manifest-registry.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
-import { resetPluginRuntimeStateForTest } from "./runtime.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
+import { withPluginRuntimeGenerationScope } from "./runtime/generation-scope.js";
 
 // Mock the persisted-registry loaders so direct metadata loads are observable.
 // Provider hot paths should reuse a compatible current snapshot and only fall
@@ -138,6 +140,31 @@ describe("provider runtime consults the current plugin metadata snapshot", () =>
   });
 
   describe("resolvePluginProvidersCore", () => {
+    it("keeps prepared provider discovery scoped to its exact generation and requested owners", () => {
+      const config: OpenClawConfig = { plugins: { entries: { demo: { enabled: true } } } };
+      const metadataSnapshot = registerCurrentSnapshot(config);
+      const pluginRegistry = createEmptyPluginRegistry();
+      pluginRegistry.providers = ["demo", "unrelated"].map((pluginId) => ({
+        pluginId,
+        provider: { id: pluginId, label: "prepared", auth: [] },
+        source: `/plugins/${pluginId}/index.js`,
+      }));
+      const activeRegistry = createEmptyPluginRegistry();
+      activeRegistry.providers = [
+        { ...pluginRegistry.providers[0]!, provider: { id: "demo", label: "active", auth: [] } },
+      ];
+      setActivePluginRegistry(activeRegistry, undefined, "default", WORKSPACE);
+      const resolve = (onlyPluginIds = ["demo"]) =>
+        resolvePluginProvidersCore({ config, env: {}, workspaceDir: WORKSPACE, onlyPluginIds });
+
+      withPluginRuntimeGenerationScope({ metadataSnapshot, pluginRegistry }, () => {
+        expect(resolve()).toEqual([{ id: "demo", label: "prepared", auth: [], pluginId: "demo" }]);
+        expect(resolve([])).toEqual([]);
+        expect(withPluginRuntimeGenerationScope({ metadataSnapshot }, resolve)).toEqual([]);
+      });
+      expect(resolve()).toEqual([{ id: "demo", label: "active", auth: [], pluginId: "demo" }]);
+    });
+
     it("reuses a compatible current snapshot without a direct disk load", () => {
       const config: OpenClawConfig = {};
       registerCurrentSnapshot(config);

--- a/src/plugins/providers.runtime.consult-current-snapshot.test.ts
+++ b/src/plugins/providers.runtime.consult-current-snapshot.test.ts
@@ -17,8 +17,15 @@ import { withPluginRuntimeGenerationScope } from "./runtime/generation-scope.js"
 // Mock the persisted-registry loaders so direct metadata loads are observable.
 // Provider hot paths should reuse a compatible current snapshot and only fall
 // back to the loader when no compatible lifecycle-owned snapshot exists.
-const loadPluginRegistrySnapshotWithMetadata = vi.hoisted(() => vi.fn());
-const loadPluginManifestRegistryForInstalledIndex = vi.hoisted(() => vi.fn());
+const { loadPluginRegistrySnapshotWithMetadata, loadPluginManifestRegistryForInstalledIndex } =
+  vi.hoisted(() => {
+    // Shared plugin workers must load this graph after this file's mocks are installed.
+    vi.resetModules();
+    return {
+      loadPluginRegistrySnapshotWithMetadata: vi.fn(),
+      loadPluginManifestRegistryForInstalledIndex: vi.fn(),
+    };
+  });
 
 vi.mock("./plugin-registry-snapshot.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./plugin-registry-snapshot.js")>();

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -27,6 +27,7 @@ import {
   resolveOwningPluginIdsForProviderRef,
 } from "./providers.js";
 import { getActivePluginRegistryWorkspaceDir } from "./runtime.js";
+import { getPluginRuntimeGenerationRegistry } from "./runtime/generation-scope.js";
 import {
   buildPluginRuntimeLoadOptionsFromValues,
   createPluginRuntimeLoaderLogger,
@@ -342,23 +343,32 @@ export function resolvePluginProvidersCore(params: {
     );
   }
   const loadState = resolveRuntimeProviderPluginLoadState(params, base, snapshot);
-  if (params.skipIfLoadInFlight && isPluginRegistryLoadInFlight(loadState.loadOptions)) {
+  const generationRegistry = getPluginRuntimeGenerationRegistry();
+  if (
+    !generationRegistry &&
+    params.skipIfLoadInFlight &&
+    isPluginRegistryLoadInFlight(loadState.loadOptions)
+  ) {
     return [];
   }
+  const onlyPluginIds = loadState.loadOptions.onlyPluginIds;
+  // Prepared discovery must retain its exact runtime artifacts, including an empty selection.
   const registry =
-    loadState.loadOptions.onlyPluginIds?.length === 0
+    onlyPluginIds?.length === 0
       ? undefined
-      : (getLoadedRuntimePluginRegistry({
+      : (generationRegistry ??
+        getLoadedRuntimePluginRegistry({
           env: base.env,
           loadOptions: loadState.loadOptions,
           workspaceDir: base.workspaceDir,
-          requiredPluginIds: loadState.loadOptions.onlyPluginIds,
-        }) ?? getRuntimePluginRegistryForLoadOptions(loadState.loadOptions));
+          requiredPluginIds: onlyPluginIds,
+        }) ??
+        getRuntimePluginRegistryForLoadOptions(loadState.loadOptions));
   if (!registry) {
     return [];
   }
 
-  return registry.providers.map((entry) =>
-    Object.assign({}, entry.provider, { pluginId: entry.pluginId }),
-  );
+  return registry.providers
+    .filter((entry) => !onlyPluginIds || onlyPluginIds.includes(entry.pluginId))
+    .map((entry) => Object.assign({}, entry.provider, { pluginId: entry.pluginId }));
 }

--- a/ui/src/components/markdown-code-blocks.test.ts
+++ b/ui/src/components/markdown-code-blocks.test.ts
@@ -1,5 +1,7 @@
+import { html, nothing, render } from "lit";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { handleMarkdownCodeBlockClick } from "./markdown-code-blocks.ts";
+import { handleMarkdownCodeBlockClick, markdownCodeBlocks } from "./markdown-code-blocks.ts";
 import { toSanitizedMarkdownHtml } from "./markdown.ts";
 
 const originalExecCommand = Object.getOwnPropertyDescriptor(document, "execCommand");
@@ -24,6 +26,54 @@ function renderCodeCopyButton(): HTMLButtonElement {
   button.addEventListener("click", handleMarkdownCodeBlockClick);
   return button;
 }
+
+it("reobserves reused code DOM while fencing scans queued before disconnect", async () => {
+  const observed = new Set<Element>();
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe(target: Element) {
+        observed.add(target);
+      }
+      unobserve(target: Element) {
+        observed.delete(target);
+      }
+      disconnect() {
+        observed.clear();
+      }
+    },
+  );
+  const container = document.body.appendChild(document.createElement("div"));
+  const content = toSanitizedMarkdownHtml("```ts\nconst answer = 42;\n```", {
+    codeBlockInteraction: "interactive",
+  });
+  const part = render(
+    html`<section ${markdownCodeBlocks()}>${unsafeHTML(content)}</section>`,
+    container,
+  );
+  const code = container.querySelector("code");
+
+  try {
+    part.setConnected(false);
+    await Promise.resolve();
+    expect(observed.size).toBe(0);
+
+    part.setConnected(true);
+    await Promise.resolve();
+    expect(observed.size).toBe(2);
+    expect(observed.has(code!)).toBe(true);
+
+    part.setConnected(false);
+    expect(observed.size).toBe(0);
+    part.setConnected(true);
+    await Promise.resolve();
+    expect(container.querySelector("code")).toBe(code);
+    expect(observed.has(code!)).toBe(true);
+    expect(observed.size).toBe(2);
+  } finally {
+    render(nothing, container);
+  }
+});
 
 describe("Markdown code-block clipboard feedback", () => {
   it("visibly reports both denied clipboard paths and restores the idle state", async () => {

--- a/ui/src/components/markdown-code-blocks.ts
+++ b/ui/src/components/markdown-code-blocks.ts
@@ -13,6 +13,9 @@ import rust from "highlight.js/lib/languages/rust";
 import typescript from "highlight.js/lib/languages/typescript";
 import xml from "highlight.js/lib/languages/xml";
 import yaml from "highlight.js/lib/languages/yaml";
+import { nothing } from "lit";
+import { AsyncDirective } from "lit/async-directive.js";
+import { directive, type ElementPart } from "lit/directive.js";
 import { t } from "../i18n/index.ts";
 import { copyToClipboard } from "../lib/clipboard.ts";
 import type { MarkdownRenderEnv } from "./markdown-render-options.ts";
@@ -151,92 +154,96 @@ function updateCodeBlockWidthOverflow(wrapper: HTMLElement): void {
 }
 
 const initializedCodeBlocks = new WeakSet<HTMLElement>();
-const observedCodeBlockNodes = new Set<HTMLElement>();
-const pendingCodeBlockRoots = new Set<ParentNode>();
-const codeBlockResizeObserver =
-  typeof ResizeObserver === "undefined"
-    ? null
-    : new ResizeObserver((entries) => {
-        const wrappers = new Set(
-          entries.map(({ target }) => target.closest<HTMLElement>(".code-block-wrapper")),
-        );
-        for (const wrapper of wrappers) {
-          if (wrapper) {
-            updateCodeBlockWidthOverflow(wrapper);
+class MarkdownCodeBlocksDirective extends AsyncDirective {
+  private root: Element | undefined;
+  private scanPending = false;
+  private readonly observedNodes = new Set<HTMLElement>();
+  private readonly resizeObserver =
+    typeof ResizeObserver === "undefined"
+      ? null
+      : new ResizeObserver((entries) => {
+          const wrappers = new Set(
+            entries.map(({ target }) => target.closest<HTMLElement>(".code-block-wrapper")),
+          );
+          for (const wrapper of wrappers) {
+            if (wrapper) {
+              updateCodeBlockWidthOverflow(wrapper);
+            }
           }
+        });
+
+  render() {
+    return nothing;
+  }
+
+  override update(part: ElementPart) {
+    this.root = part.element;
+    this.scheduleScan();
+    return nothing;
+  }
+
+  protected override disconnected(): void {
+    // A final route-away has no later scan to release detached transcript trees.
+    this.resizeObserver?.disconnect();
+    this.observedNodes.clear();
+  }
+
+  protected override reconnected(): void {
+    this.scheduleScan();
+  }
+
+  private scheduleScan(): void {
+    if (this.scanPending || !this.isConnected) {
+      return;
+    }
+    this.scanPending = true;
+    // Element directives commit before their children. Coalesce after the commit,
+    // and fence queued scans when the host is removed before the microtask runs.
+    queueMicrotask(() => {
+      this.scanPending = false;
+      if (this.isConnected && this.root?.isConnected) {
+        this.scan(this.root);
+      }
+    });
+  }
+
+  private scan(root: Element): void {
+    for (const node of this.observedNodes) {
+      if (!root.contains(node)) {
+        this.resizeObserver?.unobserve(node);
+        this.observedNodes.delete(node);
+      }
+    }
+    for (const wrapper of root.querySelectorAll<HTMLElement>(".code-block-wrapper")) {
+      const viewport = wrapper.querySelector<HTMLElement>(".code-block-viewport");
+      const code = viewport?.querySelector<HTMLElement>("code");
+      if (!viewport || !code) {
+        continue;
+      }
+      if (!initializedCodeBlocks.has(wrapper)) {
+        initializedCodeBlocks.add(wrapper);
+        const expandButton = wrapper.querySelector<HTMLButtonElement>(".code-block-expand");
+        if (expandButton) {
+          const regionId = `code-block-${++codeBlockRegionSequence}`;
+          viewport.id = regionId;
+          expandButton.setAttribute("aria-controls", regionId);
         }
-      });
-
-function observeCodeBlockNode(node: HTMLElement): void {
-  observedCodeBlockNodes.add(node);
-  codeBlockResizeObserver?.observe(node);
-}
-
-/**
- * A transcript re-render replaces its code blocks, and a ResizeObserver keeps its
- * targets alive, so detached nodes are released before each scan instead of
- * accumulating for the life of the session.
- */
-function releaseDetachedCodeBlockNodes(): void {
-  for (const node of observedCodeBlockNodes) {
-    if (!node.isConnected) {
-      codeBlockResizeObserver?.unobserve(node);
-      observedCodeBlockNodes.delete(node);
+      }
+      // A reconnected host reuses initialized DOM but must reacquire observation.
+      for (const node of [viewport, code]) {
+        if (!this.observedNodes.has(node)) {
+          this.observedNodes.add(node);
+          this.resizeObserver?.observe(node);
+        }
+      }
+      if (!this.resizeObserver) {
+        updateCodeBlockWidthOverflow(wrapper);
+      }
     }
   }
 }
 
-function scanMarkdownCodeBlocks(root: ParentNode): void {
-  for (const wrapper of root.querySelectorAll<HTMLElement>(".code-block-wrapper")) {
-    if (initializedCodeBlocks.has(wrapper)) {
-      continue;
-    }
-    const viewport = wrapper.querySelector<HTMLElement>(".code-block-viewport");
-    const code = viewport?.querySelector<HTMLElement>("code");
-    if (!viewport || !code) {
-      continue;
-    }
-    initializedCodeBlocks.add(wrapper);
-    const expandButton = wrapper.querySelector<HTMLButtonElement>(".code-block-expand");
-    if (expandButton) {
-      codeBlockRegionSequence += 1;
-      const regionId = `code-block-${codeBlockRegionSequence}`;
-      viewport.id = regionId;
-      expandButton.setAttribute("aria-controls", regionId);
-    }
-    observeCodeBlockNode(viewport);
-    observeCodeBlockNode(code);
-    // The observer owns initial geometry too, after the browser lays out new blocks.
-    if (!codeBlockResizeObserver) {
-      updateCodeBlockWidthOverflow(wrapper);
-    }
-  }
-}
-
-/**
- * Single measurement owner for interactive fenced code below `root`. It names the
- * reveal region and tracks code width, which is what decides whether the wrap
- * control is offered at all; without it a host renders controls that never appear.
- *
- * The scan is deferred and coalesced because a Lit element `ref` commits before
- * that render's children: scanning inline would miss exactly the blocks the host
- * called about, and the last message of a quiet transcript would never measure.
- */
-export function initializeMarkdownCodeBlocks(root: ParentNode): void {
-  const alreadyScheduled = pendingCodeBlockRoots.size > 0;
-  pendingCodeBlockRoots.add(root);
-  if (alreadyScheduled) {
-    return;
-  }
-  queueMicrotask(() => {
-    const roots = [...pendingCodeBlockRoots];
-    pendingCodeBlockRoots.clear();
-    releaseDetachedCodeBlockNodes();
-    for (const pending of roots) {
-      scanMarkdownCodeBlocks(pending);
-    }
-  });
-}
+export const markdownCodeBlocks = directive(MarkdownCodeBlocksDirective);
 
 /** Highlight a snippet; output is escaped hljs markup safe for unsafeHTML in a code block. */
 export function highlightCodeHtml(text: string, lang: string): string {

--- a/ui/src/e2e/chat-code-block-fences.e2e.test.ts
+++ b/ui/src/e2e/chat-code-block-fences.e2e.test.ts
@@ -134,6 +134,85 @@ describeControlUiE2e("Control UI fenced code blocks", () => {
     }
   });
 
+  it("releases code-block observations when navigation removes the final transcript", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1440 },
+    });
+    const page = await context.newPage();
+    type ObservationWindow = typeof window & {
+      codeBlockObservations: () => { observed: number; connected: number; detached: number };
+    };
+    await page.addInitScript(() => {
+      const NativeResizeObserver = window.ResizeObserver;
+      const targets = new Map<ResizeObserver, Set<Element>>();
+      let observed = 0;
+      window.ResizeObserver = class extends NativeResizeObserver {
+        override observe(target: Element, options?: ResizeObserverOptions) {
+          super.observe(target, options);
+          if (target.matches(".code-block-viewport, .code-block-viewport code")) {
+            const current = targets.get(this) ?? new Set<Element>();
+            current.add(target);
+            targets.set(this, current);
+            observed += 1;
+          }
+        }
+
+        override unobserve(target: Element) {
+          super.unobserve(target);
+          targets.get(this)?.delete(target);
+        }
+
+        override disconnect() {
+          super.disconnect();
+          targets.delete(this);
+        }
+      };
+      (window as ObservationWindow).codeBlockObservations = () => {
+        let connected = 0;
+        let detached = 0;
+        for (const nodes of targets.values()) {
+          for (const node of nodes) {
+            if (node.isConnected) {
+              connected += 1;
+            } else {
+              detached += 1;
+            }
+          }
+        }
+        return { observed, connected, detached };
+      };
+    });
+    await installMockGateway(page, {
+      historyMessages: [
+        { role: "user", content: "Show the launch command.", timestamp: 1_000 },
+        { role: "assistant", content: wideFence, timestamp: 2_000 },
+      ],
+    });
+    const observations = () =>
+      page.evaluate(() => (window as ObservationWindow).codeBlockObservations());
+
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await expect.poll(async () => (await observations()).connected).toBe(2);
+      const sidebar = page.locator("openclaw-app-sidebar");
+      await sidebar.locator(".sidebar-identity-card").click();
+      await sidebar
+        .locator("wa-dropdown.sidebar-identity-menu")
+        .getByRole("menuitem", { exact: true, name: "Settings" })
+        .click();
+      await page.locator('.settings-sidebar__item[href="/logs"]').click();
+      await page.locator("openclaw-logs-page").waitFor({ state: "visible" });
+      expect(await page.locator("openclaw-chat-pane").count()).toBe(0);
+      // A page reload would discard the probe too and cannot prove in-app teardown.
+      expect((await observations()).observed).toBeGreaterThanOrEqual(2);
+      await expect.poll(async () => (await observations()).detached).toBe(0);
+    } finally {
+      await context.close();
+    }
+  });
+
   it.each(["dark", "light"] as const)(
     "keeps code controls correct through disclosure, resize, and virtual remount in %s mode",
     async (theme) => {

--- a/ui/src/pages/chat/components/chat-sidebar-content.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-content.ts
@@ -1,13 +1,12 @@
 import { html, nothing } from "lit";
 import { keyed } from "lit/directives/keyed.js";
-import { ref } from "lit/directives/ref.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
 import { sessionRefFromPath } from "../../../app-session-route-paths.ts";
 import { icons } from "../../../components/icons.ts";
 import type { ImageLightboxItem } from "../../../components/image-lightbox.ts";
 import {
   handleMarkdownCodeBlockClick,
-  initializeMarkdownCodeBlocks,
+  markdownCodeBlocks,
 } from "../../../components/markdown-code-blocks.ts";
 import {
   markdownFileLinkFromEvent,
@@ -401,11 +400,7 @@ export function renderSidebarPanel(
   return html`
     <div
       class=${fillHost ? "sidebar-panel-host--fill" : ""}
-      ${ref((element) => {
-        if (element instanceof HTMLElement) {
-          initializeMarkdownCodeBlocks(element);
-        }
-      })}
+      ${markdownCodeBlocks()}
       @click=${props.onClick}
       @keydown=${props.onKeydown}
     >

--- a/ui/src/pages/chat/components/chat-thread.ts
+++ b/ui/src/pages/chat/components/chat-thread.ts
@@ -4,7 +4,7 @@ import { ref } from "lit/directives/ref.js";
 import { sessionRefFromPath } from "../../../app-session-route-paths.ts";
 import {
   handleMarkdownCodeBlockClick,
-  initializeMarkdownCodeBlocks,
+  markdownCodeBlocks,
 } from "../../../components/markdown-code-blocks.ts";
 import {
   markdownFileLinkFromEvent,
@@ -115,9 +115,9 @@ function renderTranscriptShell(
   return html`
     <div
       class="chat-thread ${projection.isDirectThread ? "chat-thread--direct" : ""}"
+      ${markdownCodeBlocks()}
       ${ref((element) => {
         if (element instanceof HTMLElement) {
-          initializeMarkdownCodeBlocks(element);
           hydrateLinkFavicons(element, props.fetchLinkFavicon);
         }
       })}

--- a/ui/src/pages/custodian/custodian-surface.ts
+++ b/ui/src/pages/custodian/custodian-surface.ts
@@ -6,7 +6,7 @@ import { controlUiPublicAssetPath } from "../../app/public-assets.ts";
 import { icons } from "../../components/icons.ts";
 import {
   handleMarkdownCodeBlockClick,
-  initializeMarkdownCodeBlocks,
+  markdownCodeBlocks,
 } from "../../components/markdown-code-blocks.ts";
 import {
   enhanceMarkdownTables,
@@ -98,11 +98,8 @@ class CustodianSurface extends OpenClawLightDomElement {
     }
     const transcript = this.querySelector<HTMLElement>(".custodian__messages");
     if (transcript) {
-      // Caretaker turns render through the assistant bubble, so they carry the
-      // same interactive code-block and table markup the chat thread emits.
-      // Without this lifecycle those controls render but never do anything.
+      // Assistant bubbles emit table controls that need this transcript owner.
       this.markdownHost = transcript;
-      initializeMarkdownCodeBlocks(transcript);
       enhanceMarkdownTables(transcript);
     }
     const messageId = this.store.messages.at(-1)?.id ?? null;
@@ -194,6 +191,7 @@ class CustodianSurface extends OpenClawLightDomElement {
       >
         <div
           class="custodian__messages"
+          ${markdownCodeBlocks()}
           aria-live="polite"
           @click=${(event: MouseEvent) => {
             handleMarkdownCodeBlockClick(event);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where opening the full model inventory in a built Gateway running alongside plugin source loaded unnecessary source modules, resetting a large transcript hydrated every message body, and leaving a code-heavy chat retained detached DOM through resize observers.

## Why This Change Was Made

- Preserve the prepared generation's artifact choice across the catalog/auth Worker boundary and reuse its exact provider registry. Lightweight discovery reads that registry's existing load context, selects its own artifact kind, and reuses cached file-boundary validation. This keeps runtime and discovery entries distinct and preserves standalone source loading and source-external package rules.
- Project reset ancestry, timestamp, and replay-role fields in SQLite before crossing into JavaScript. Both reset owners keep the read inside their existing transaction; durable transcript bytes and the ordinary full reader remain intact.
- Replace the global strong observer target set with a Lit directive owned by each Markdown host. Removal disconnects immediately; queued work is fenced and reconnecting the same DOM restores observation. Chat, sidebar, and Custodian use the same lifecycle.

Production delta: +226/-147, net +79 (catalog ownership +51, reset projection +28, UI net zero). Tests/support: +409/-56, net +353, including unchanged auth-fixture helpers moved into existing support. The additional production code carries the missing artifact identity and validates selected discovery artifacts, and selects the metadata needed by reset planning. It adds no configuration, dependency, schema, migration, or retention-policy surface.

## User Impact

Lower allocation spikes when opening catalogs and resetting long conversations, and prompt release of detached code-block DOM when navigating away from chat. Catalog membership, transcript contents, reset ordering, and code-block controls remain covered by before/after proof.

## Evidence

Measured from baseline `84e81339c2c3e3dc40b1d72e11fa5388df1f0b5f` on Node 24.19.0 with a built Gateway/UI, normal bundled plugins, isolated SQLite state, and a deterministic local OpenAI-compatible provider. These are observed local scenarios with profiling/forced-GC overhead, not statistical benchmarks or a cloud-provider latency claim.

| Catalog measurement | Before | Final | Reduction |
| --- | ---: | ---: | ---: |
| Peak Gateway process RSS | 2.72 GiB | 1.27 GiB | 53.2% |
| Gateway RSS after main + Worker GC | 1,031 MiB | 694 MiB | 32.7% |
| Catalog Worker used heap after GC | 287.83 MiB | 181.25 MiB | 37.0% |

RSS is process-wide, including the Worker; Worker RSS is not added to main RSS. The final catalog returned 230 models. Two fresh-process first requests completed in about 3.8s, with repeated reads around 60ms. CPU/loader profiling confirmed all 14 lightweight discovery artifacts use built JavaScript, including the eight that previously loaded source.

For the 4,000-message transcript fixture (3,999 approximately 128 KiB tool results), sampled cumulative allocation under the transcript reader fell **988.16 MiB -> 3.50 MiB (99.65%)**. The whole preview/describe/reset/history sequence fell **1,086.72 -> 92.90 MiB**; reset completed in **1,024 -> 399 ms**. Sampling includes collected objects, so this is an allocation reduction, not a retained-heap claim. All original **4,001 event rows / 540,097,925 serialized bytes** retained the same SHA-256 after reset, and a subsequent CLI turn completed.

On the six-fence chat fixture, Chat -> Settings -> Logs left **six detached observed viewports -> zero**, with post-navigation DOM nodes **298,969 -> 73,316** and Chromium embedder heap **44.17 -> 18.02 MiB**. JavaScript used heap stayed roughly flat. The final capture also shows the successful post-reset CLI reply:

| Before | After |
| --- | --- |
| ![Before: synthetic fenced chat](https://github.com/user-attachments/assets/657e7670-192b-4a1f-91bd-e5e9f2cd52c6) | ![After: synthetic fenced chat](https://github.com/user-attachments/assets/28f86901-a23f-45f3-807e-0435ade96134) |

Real Gateway/CLI/browser scenarios passed: 1,998 -> 500 session cleanup; bounded and enriched pagination with 500 unique keys; 20 reconnect/subscribe cycles; 20 status/list cycles; browser pagination/load-more and chat; 25 rename/list/restore cases; archive/unarchive; deletion/status consistency; post-reset CLI work; dark/light code expansion, wrapping, narrow/wide resize, and virtual unmount/remount. Built browser proof had no page/window errors. The source-E2E ResizeObserver warnings were reproduced on the unchanged baseline as well.

Regression tests failed before their respective repairs: built/source Worker identity (including lightweight discovery), both reset owners hydrating message-body rows, and final route-away retaining observed code nodes. Final loader/Worker group: **97 tests / 4 files**, no retries. Earlier wider catalog/provider group: **81 tests / 5 files**; reset owner/planner: **7 tests / 2 files**; UI owner/siblings: **89 tests**, plus **4 fenced-code E2E tests**. Final full build and changed-file gate passed. The first hosted run exposed an order-dependent test bootstrap defect: the artifact test loaded the real metadata graph before the snapshot test installed its mocks. Resetting that graph in the existing hoisted mock factory fixes the binding at its owner. All six failures were reproduced in the original shared-process order; all 23 tests now pass in both orders with unchanged assertions. The production files used for memory measurements are unchanged. The correction also passed the full changed-file gate and a fresh Codex autoreview with no accepted blockers.

Named follow-ups from the investigation: app-lifetime debug event-log payload retention; reply initialization's full session-store hydration; shared-window delete survivor projection; the preexisting source-E2E ResizeObserver feedback warning. Their retention/ownership semantics are separate from this repair.

ClawSweeper follow-through: directly inspected the installed `lit` / `lit-html` 3.3.3 `development/async-directive.js:147-208` and `lit-element` 4.2.2 `development/lit-element.js:151-176`. Clearing a part invokes `disconnected`; reconnect invokes `reconnected` before the next update; LitElement forwards connection changes to the child part. The queued-scan and same-DOM reconnect regressions and built browser proof exercise those contracts. The +79 production lines retain the stated artifact/validation and reset-query boundaries; replacing them with another cache or payload truncation would not repair the same ownership defects. The stored-data heuristic flags do not correspond to a schema or persistence change: discovery reuses existing process-owned registry caches, the Worker helper is test support, and reset projection changes only SELECT output while preserving all durable transcript bytes. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/33466488746) passed on `d3e7e46cf853b0b4061cebb7a75961b5c295609f`, including the repaired shared-process shard, Windows and browser E2E; `openclaw/ci-gate` is green.

The final ClawSweeper review on `d3e7e46cf853` has no actionable findings. Its remaining Codex-auth contract check is also complete: personally inspected [AuthDotJson](https://github.com/openai/codex/blob/94cbbddafc1776d5e377bca1b05932c697e82238/codex-rs/login/src/auth/storage.rs#L39) and [TokenData](https://github.com/openai/codex/blob/94cbbddafc1776d5e377bca1b05932c697e82238/codex-rs/login/src/token_data.rs#L10), then the OpenClaw reader in `src/agents/cli-credentials.ts:257-286,437-470`. The existing synthetic fixture covers the token fields consumed by that reader; it was moved unchanged and is not presented as a complete Codex CLI auth-file round-trip. Catalog/source-external artifact cases, both reset transaction owners, durable transcript preservation, and Lit disconnect/reconnect have the focused and real-flow proof above. The final rank-up checks are satisfied.
