### PR TITLE
fix(ci): keep active Testbox commands alive past idle timeout

### DIFF
--- a/.github/workflows/ci-build-artifacts-testbox.yml
+++ b/.github/workflows/ci-build-artifacts-testbox.yml
@@ -213,7 +213,9 @@ jobs:
         run: bash scripts/ci-hydrate-testbox-env.sh
 
       - name: Run Testbox
-        uses: useblacksmith/run-testbox@3f60ff9ceb2c10c3feefa87dc0c6490cffae059d
+        # Temporary local-listener fix: https://github.com/useblacksmith/run-testbox/pull/15
+        # Return to useblacksmith/run-testbox after the fix lands upstream.
+        uses: steipete/run-testbox@2b6b1be536ec7f3c73757fedf5460a27ab4856b4
         if: github.event_name == 'workflow_dispatch' && always()
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/ci-check-arm-testbox.yml
+++ b/.github/workflows/ci-check-arm-testbox.yml
@@ -121,7 +121,9 @@ jobs:
         run: bash scripts/ci-hydrate-testbox-env.sh
 
       - name: Run Testbox
-        uses: useblacksmith/run-testbox@3f60ff9ceb2c10c3feefa87dc0c6490cffae059d
+        # Temporary local-listener fix: https://github.com/useblacksmith/run-testbox/pull/15
+        # Return to useblacksmith/run-testbox after the fix lands upstream.
+        uses: steipete/run-testbox@2b6b1be536ec7f3c73757fedf5460a27ab4856b4
         if: always()
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/.github/workflows/ci-check-testbox.yml
+++ b/.github/workflows/ci-check-testbox.yml
@@ -116,7 +116,9 @@ jobs:
         run: bash scripts/ci-hydrate-testbox-env.sh
 
       - name: Run Testbox
-        uses: useblacksmith/run-testbox@3f60ff9ceb2c10c3feefa87dc0c6490cffae059d
+        # Temporary local-listener fix: https://github.com/useblacksmith/run-testbox/pull/15
+        # Return to useblacksmith/run-testbox after the fix lands upstream.
+        uses: steipete/run-testbox@2b6b1be536ec7f3c73757fedf5460a27ab4856b4
         if: github.event_name == 'workflow_dispatch' && always()
         env:
           FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"

--- a/test/scripts/install-trufflehog.test.ts
+++ b/test/scripts/install-trufflehog.test.ts
@@ -36,7 +36,7 @@ describe("scripts/install-trufflehog.sh", () => {
     ]) {
       const text = readFileSync(workflow, "utf8");
       const install = text.indexOf('install-trufflehog: "true"');
-      const handoff = text.indexOf("uses: useblacksmith/run-testbox@");
+      const handoff = text.indexOf("- name: Run Testbox");
 
       expect(install, `${workflow} must provision TruffleHog`).toBeGreaterThanOrEqual(0);
       expect(handoff, `${workflow} must hand off to run-testbox`).toBeGreaterThan(install);

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -144,7 +144,7 @@ const SETUP_NODE_V6 = "actions/setup-node@820762786026740c76f36085b0efc47a31fe50
 const DOWNLOAD_ARTIFACT_V8 = "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c";
 const UPLOAD_ARTIFACT_V7 = "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a";
 const RUN_TESTBOX_WITH_FAILURE_REPORTING =
-  "useblacksmith/run-testbox@3f60ff9ceb2c10c3feefa87dc0c6490cffae059d";
+  "steipete/run-testbox@2b6b1be536ec7f3c73757fedf5460a27ab4856b4";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 type WorkflowStep = {
@@ -5342,14 +5342,13 @@ printf '%s\\n' "$DEEPSEEK_API_KEY" "$DEEPINFRA_API_KEY"`,
     expect(checkTestboxJob["timeout-minutes"]).toBe(
       "${{ fromJSON(inputs.timeout_minutes || '120') }}",
     );
-    for (const step of [
-      runTestboxStep,
-      runArmTestboxStep,
-      runBuildArtifactsTestboxStep,
-      windowsTestboxActionMarker,
-    ]) {
+    for (const step of [runTestboxStep, runArmTestboxStep, runBuildArtifactsTestboxStep]) {
       expect(step.uses).toBe(RUN_TESTBOX_WITH_FAILURE_REPORTING);
     }
+    expect(windowsTestboxActionMarker.uses).toBe(
+      "useblacksmith/run-testbox@3f60ff9ceb2c10c3feefa87dc0c6490cffae059d",
+    );
+    expect(windowsTestboxActionMarker.if).toBe("${{ false }}");
     expect(runTestboxStep.if).toBe("github.event_name == 'workflow_dispatch' && always()");
     expect(closeTestboxSshStep.if).toBe("github.event_name == 'workflow_dispatch' && always()");
     expect(closeTestboxSshStep.run).toContain(

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -65,6 +65,10 @@ describe("test runtime prerequisites", () => {
     ["CLI directory", ["src/cli"], "runtime"],
     ["CLI config", ["test/vitest/vitest.cli.config.ts"], "runtime"],
     ["ordinary CLI unit test", ["src/cli/command-path-policy.test.ts"], undefined],
+    ["Doctor Gateway process", ["src/commands/doctor-config-preflight.process.test.ts"], "runtime"],
+    ["commands directory", ["src/commands"], "runtime"],
+    ["commands config", ["test/vitest/vitest.commands.config.ts"], "runtime"],
+    ["ordinary Doctor unit test", ["src/commands/doctor-config-preflight.test.ts"], undefined],
     ["Active Memory Gateway", ["src/gateway/gateway-active-memory.test.ts"], "runtime"],
     ["concurrent Gateway streams", ["src/gateway/gateway-concurrent-streams.test.ts"], "runtime"],
     [


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/134718
Related upstream repair: https://github.com/useblacksmith/run-testbox/pull/15

> **Landing authorized:** The maintainer explicitly requested landing after the close-review reminder. The exception is limited to audited `steipete/run-testbox@2b6b1be536ec7f3c73757fedf5460a27ab4856b4` in these three Linux workflows, until the upstream listener repair merges; then return to a reviewed immutable vendor-owned revision. Do not advance the fork without a new source review. Normal CI and native prepare/merge gates still apply.

<details>
<summary>Additional instructions</summary>

This is a same-repository maintainer branch; maintainers can push follow-up changes.

</details>

## What Problem This Solves

Fixes an issue where maintainers running long commands on a Blacksmith Testbox would lose the lease to idle expiry despite an established SSH connection. The remote command could then be killed during runner teardown while the hosting Actions job still reported success.

The independent short-idle reproduction returned 137 after the native action declared idle and the runner exhausted its 290-second SSH grace. This is not an OpenClaw Gateway timeout or a reason to count the interrupted original soak as green.

## Why This Change Was Made

Adopt the existing owner-level fix in `run-testbox`: resolve sshd's VM-local listener ports and inspect established local-source-port connections, rather than grep for the externally forwarded client port. Preserve the short-command activity marker, external connection information, and existing idle/job limits; failed inspection must not be interpreted as idleness.

The three active Linux consumers now pin `steipete/run-testbox@2b6b1be536ec7f3c73757fedf5460a27ab4856b4`, the exact reviewed head of the still-open upstream repair. Each use explicitly says this fork pin is temporary and must return to `useblacksmith/run-testbox` after the fix lands upstream. No wrapper heartbeat, timeout increase, provider change, new configuration, GitHub permission change, or vendored action is added.

The existing repository tests are updated alongside the pin: TruffleHog still must be provisioned before the named handoff step; Linux finalization checks pin the reviewed action exactly, while Windows separately retains its unchanged vendor pin and explicitly disabled marker. No lifecycle assertion is removed.

**Dependency-source audit:** inspected the complete [pinned action](https://github.com/steipete/run-testbox/blob/2b6b1be536ec7f3c73757fedf5460a27ab4856b4/action.yml), its [full change from the vendor base](https://github.com/steipete/run-testbox/compare/3f60ff9ceb2c10c3feefa87dc0c6490cffae059d...2b6b1be536ec7f3c73757fedf5460a27ab4856b4), README, and executable tests. The four-file repository contains only the composite action, README, test, and test workflow—no JavaScript/Docker runtime or additional execution hooks. The action's runtime delta is +13/-2 lines: local sshd configuration discovery and an established-local-port socket query. Existing credential reads and phone-home destinations are unchanged; no provider/tool-auth file reads, new outbound destination, or credential logging is added. The complete original and candidate action sources were also supplied to independent Codex review. ClawSweeper's source-audit warning recorded a GitHub DNS failure in its worker; these are the inspectable source links and audit details it lacked.

This does **not** claim that the runner lacks credentials. The temporary fork is the explicit, narrowly scoped execution-trust exception authorized above; using the merged vendor revision remains the preferred final source.

Application runtime/tooling delta: **0**. Workflow delta: **+9/-3** (three pin replacements and six explanatory comment lines). Tests: **+11/-8** (net **+3**), including four prerequisite-selection cases for the independently landed Gateway fixture repair. Total: **+20/-11 across six files**; action behavior regression coverage remains with the upstream owner.

## User Impact

Active Linux Testbox commands can remain alive beyond the idle budget, subject to unchanged GitHub job maximums. Truly idle leases still expire, and command exit status—not the hosting job conclusion—remains the validation result.

The check, ARM-check, and build-artifacts workflows share the new immutable action. Windows has a separate inline activity loop and is intentionally unchanged; no Windows lifetime claim is made. Post-action socket cleanup and terminal `stop` idempotency are separate follow-ups, not hidden fixes in this PR.

## Evidence

**Baseline:** [run 33424771197](https://github.com/openclaw/openclaw/actions/runs/33424771197), job 99595578777, used the old action with a two-minute idle limit. Advertised port 64004 versus local port 22; all 29 samples had established local SSH but a false original predicate and unchanged activity marker. Native idle completion → 290-second runner grace → command/wrapper exit 137 without its completion receipt. Hosting job: success. The original long soak remains incomplete, with no claim about its signal sender or missing OOM evidence.

**Local validation:**

- `node_modules/.bin/oxfmt --check .github/workflows/ci-check-testbox.yml .github/workflows/ci-check-arm-testbox.yml .github/workflows/ci-build-artifacts-testbox.yml` — passed.
- `actionlint .github/workflows/ci-check-testbox.yml .github/workflows/ci-check-arm-testbox.yml .github/workflows/ci-build-artifacts-testbox.yml` — passed.
- `node --import ./scripts/tsx.mjs scripts/check-workflows.mts` — passed, including Zizmor and repository workflow guards.
- `python3 -m unittest discover -s .artifacts/testbox-lease-fix/upstream/tests -v` — all five methods passed against the exact downloaded upstream head. The unchanged tests failed seven intended subcases against the original pinned action: active default/non-default/multiple listeners, unrelated peer-port matching, and inspection failures.
- `node scripts/run-vitest.mjs test/scripts/install-trufflehog.test.ts test/scripts/package-acceptance-workflow.test.ts --testNamePattern 'scripts/install-trufflehog.sh|finalizes dispatched Testbox' --reporter=dot` — **9 passed**, including all installer siblings and the changed lifecycle contract. The two stale contract assertions were reproduced failing before their correction.
- `node scripts/check-changed.mjs -- test/scripts/install-trufflehog.test.ts test/scripts/package-acceptance-workflow.test.ts .github/workflows/ci-check-testbox.yml .github/workflows/ci-check-arm-testbox.yml .github/workflows/ci-build-artifacts-testbox.yml` — passed, including root test typechecking and script lint.
- `git diff --check` — passed.

The first classified gate reported an untouched Discord `RESTAPIPoll.question` type error. `pnpm install --frozen-lockfile` reconciled the local dependency tree; the entire gate and nine focused tests passed afterward without any Discord source or type-checking-policy change.

**Independent review:** fresh Codex autoreview of the **complete five-file patch** completed scoped-clean at P0 with the complete upstream action and regression-test source supplied as context; no accepted/actionable findings. One preparation attempt refused a moving source snapshot before model review; the stable retry ran after validation/install processes finished.

**Fresh runtime proof of the exact action revision:** all runs below use workflow commit `6905ce848fdd03d1fb24b5ce0056377012c72b62`, the unchanged configured Blacksmith provider, fresh task-owned leases, and **two-minute** idle limits. The initial test-only follow-up preserved all three workflow files byte-for-byte. Subsequent main refreshes add `go-version: "1.27.0"` to x86/ARM shell preparation, so whole final workflow-file byte identity is **not** claimed. The action revision, handoff and lifetime parameters remain unchanged; the build-artifacts workflow is byte-identical to the tested version.

- **x86-64 passed active and idle sides:** [run 33465917211](https://github.com/openclaw/openclaw/actions/runs/33465917211), job 99725631448, lease `tbx_01m1dfrvrv97qepqwy6rc7jth9`. The same 480-second probe that was killed in the baseline completed in **480.69s**, exit **0**. All 32 samples retained local established SSH, an unchanged marker, and a false original advertised-port predicate; the native action was still running after command completion. Intentional exit **37** propagated. Passive local observation saw the retained SSH transport disappear at **296.890s** after the second command returned, then provider completion at **417.898s**. Native logs confirmed two-minute idle expiry, the exact new action SHA, and a successful hosting job. The lease is completed and its task-created local handles are cleaned.
- **ARM64 passed active and idle sides:** [run 33466864354](https://github.com/openclaw/openclaw/actions/runs/33466864354), job 99728425408, lease `tbx_01m1dgnkm9cwwsdhpf1mm2jg62`. The runner verified `aarch64`; the foreground probe completed in **180.82s**, exit **0**, with all 12 original predicates false, local SSH established, and the marker unchanged. Intentional exit **37** propagated. The corrected passive kernel TCP observer saw transport absent at **305.722s** after command return and provider completion at **382.415s**. Native logs confirmed the exact new action SHA and two-minute idle expiry; hosting job **success**. The lease is completed and its task-created local handles are cleaned. These are observation times, not exact disconnect instants; native 30-second sampling and observer/API latency account for the timing granularity.
- **First ARM64 attempt:** [run 33465917181](https://github.com/openclaw/openclaw/actions/runs/33465917181), job 99725631682. Active proof completed in **180.87s**, exit **0**, with all 12 original predicates false and local SSH established; the native action remained running. Intentional exit **37** propagated. The local passive `lsof` observer then failed, so the harness stopped the lease and the hosting job was **cancelled**. This is **not** an idle-side pass. The exact `lsof` diagnostic was not retained by that initial harness. The successful fresh retry above used a kernel TCP-table observer that retains inspection errors; the tested workflows and action did not change between attempts.

[Hosted Workflow Sanity run 33470571615](https://github.com/openclaw/openclaw/actions/runs/33470571615) passed on the initial completed patch. The PR is now ready for review, with full exact-head CI required before native prepare/merge.

### Landing CI follow-through

The first ready CI runs built a stale synthetic merge that predated the already-landed UI baseline reconciliation in [the release evidence repair](https://github.com/openclaw/openclaw/pull/134820). A patch-identical rebase incorporated that existing repair without changing any UI budget. [Rebased CI 33475227017](https://github.com/openclaw/openclaw/actions/runs/33475227017) then passed the build but exposed two pre-existing test failures. The release inventory overflow was independently reproduced at 1,048,865 captured bytes and has since been fixed by bounded metadata enumeration in [the release CI follow-up](https://github.com/openclaw/openclaw/pull/134824), now included in this branch's base; no duplicate inventory repair or buffer increase is added here.

The Gateway quarantine process test launched the full source CLI through `tsx` inside its 30-second readiness budget. While this PR's bounded repair was being validated, [the startup resolver PR](https://github.com/openclaw/openclaw/pull/134812) landed the canonical repair: reuse the shared test-instance lifecycle and register pre-worker runtime preparation, preserving full sidecar readiness, the migration fixture, and existing deadlines. This branch was rebased to retain that mainline implementation; the duplicate local fixture/tooling edits were removed. Only four added prerequisite-selection cases remain here. The earlier `gateway ready` log in deferred mode is not substituted for `/readyz` readiness.

- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts -t 'test runtime prerequisites' --reporter=verbose` — the added file/directory/config cases failed on the current unpatched owner, then **26 passed** after registration.
- `node scripts/run-vitest.mjs src/commands/doctor-config-preflight.process.test.ts --reporter=verbose` — original-order **intermediate candidate** run: **10 passed, 1 unchanged failure**; the quarantine case passed in **16,682 ms**. The unparseable-config Doctor source case still hit its unchanged 60-second timeout locally. This intermediate fixture was subsequently replaced by the already-landed canonical implementation. Different bases and Node versions prevent an isolated timing comparison; this is not final full-file acceptance proof.
- `node scripts/check-changed.mjs -- scripts/lib/vitest-build-prerequisites.mts src/commands/doctor-config-preflight.process.test.ts test/scripts/test-projects.test.ts` — passed on the intermediate candidate, including core-test, script and root-test typechecks, formatting, guards and lint. The two now-canonical source files have no final PR delta.
- `node scripts/run-vitest.mjs test/scripts/test-projects.test.ts test/scripts/install-trufflehog.test.ts test/scripts/package-acceptance-workflow.test.ts --testNamePattern 'test runtime prerequisites|scripts/install-trufflehog.sh|finalizes dispatched Testbox' --reporter=dot` — **35 passed** on the final six-file scope, without invoking the full Doctor process suite.
- Fresh Codex autoreview of the complete final six-file candidate exited 0, scoped-clean at P0, with no accepted/actionable findings or suspected real credentials. Exact-head hosted CI is recorded in the landing comment.

**Local isolation limitation:** the unchanged Doctor flow's `findOtherStateDirs` enumerates host home roots and checks state-directory metadata even with a synthetic HOME. Its source only checks directory existence/type and reports paths; it does not open or modify those discovered state contents. This observation prevents claiming the complete local Doctor file was fully host-isolated. Further local full-Doctor probes were stopped; scope-aware Doctor discovery is a named follow-up, and remaining process proof uses hosted CI. No operator service was stopped/restarted, stopped lease revived, auth file copied, or raw log published. Native stop's `409 already stopped` response remains distinct from successful natural expiry.

**Review checklist before landing:**

- [x] Maintainer explicitly requested landing after the close-review reminder; the bounded fork exception is recorded above.
- [x] Fresh active-and-idle evidence is recorded; command and hosting-job results are kept distinct.
- [x] Retain only the audited temporary fork SHA until the upstream fix merges, then repin to the reviewed vendor revision.
