### PR TITLE
test(browser): reuse immutable native-host fixtures

### DIFF
--- a/extensions/browser/src/browser/extension-native-host.test.ts
+++ b/extensions/browser/src/browser/extension-native-host.test.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { withEnvAsync } from "openclaw/plugin-sdk/test-env";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker, withEnvAsync } from "openclaw/plugin-sdk/test-env";
+import { withTimeout } from "openclaw/plugin-sdk/text-utility-runtime";
+import { afterAll, describe, expect, it, vi } from "vitest";
 import { relayTestKey } from "../../chrome-extension/relay-key.test-support.js";
 import { parseBrowserNativeHostOrigins, runBrowserNativeHost } from "./extension-native-host.js";
 import {
@@ -21,7 +22,8 @@ const OTHER_ORIGIN = `chrome-extension://${"p".repeat(32)}/`;
 const NONCE = Buffer.alloc(16, 7).toString("base64url");
 const PAIRING = `ws://127.0.0.1:18799/extension#${relayTestKey(1)}`;
 const REQUEST_MAX_BYTES = 4 * 1024;
-const tempRoots: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterAll);
+let defaultFixture: ReturnType<typeof nativeFixture> | undefined;
 
 function frame(payload: Buffer | string): Buffer {
   const body = typeof payload === "string" ? Buffer.from(payload) : payload;
@@ -44,12 +46,6 @@ async function* chunks(...values: Buffer[]) {
     yield value;
   }
 }
-
-afterEach(async () => {
-  await Promise.all(
-    tempRoots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })),
-  );
-});
 
 describe("native messaging framing", () => {
   it("reads a fragmented native-endian frame exactly", async () => {
@@ -95,12 +91,11 @@ describe("native messaging framing", () => {
         };
       },
     };
-    const result = await Promise.race([
+    const result = await withTimeout(
       readBrowserNativeFrame(openPipe),
-      new Promise<"timeout">((resolve) => {
-        setTimeout(() => resolve("timeout"), 100);
-      }),
-    ]);
+      100,
+      "native frame without closing stdin",
+    );
 
     expect(result).toEqual(expected);
   });
@@ -170,8 +165,7 @@ describe("native bootstrap request schema", () => {
 });
 
 async function nativeFixture() {
-  const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-native-host-")));
-  tempRoots.push(root);
+  const root = tempDirs.make("openclaw-native-host-");
   const stateDir = path.join(root, "state");
   const managedDir = path.join(stateDir, "browser", "native-messaging");
   const manifestDir = path.join(root, "chrome", "NativeMessagingHosts");
@@ -195,7 +189,8 @@ async function nativeFixture() {
 }
 
 async function invokeHost(overrides: Partial<Parameters<typeof runBrowserNativeHost>[0]> = {}) {
-  const fixture = await nativeFixture();
+  // Callers that mutate manifests or credentials supply their own private fixture.
+  const fixture = await (defaultFixture ??= nativeFixture());
   const writes: Buffer[] = [];
   const response = await runBrowserNativeHost({
     ...fixture,


### PR DESCRIPTION
## What Problem This Solves

The native-host test suite constructs 36 temporary manifest trees even though most cases only read the same default contents. Its open-stdin framing check also leaves a losing 100ms timer running after success.

## Why This Change Was Made

Reuse one default tree with the existing SDK temp-directory tracker. Keep all five private trees used for manifest changes and relay credentials, fresh request iterators/output buffers, and the real daemon finalizers. The existing SDK timeout helper preserves the 100ms framing bound and clears its timer.

## User Impact

Test-only: no runtime behavior change. The suite removes 30 tree allocations/removals, 60 directory creations and 60 file writes. Canonical temporary-parent resolution remains in the shared helper. Up to six small trees live until suite teardown. No elapsed-time gain is claimed.

## Evidence

All 55 native-host cases and nine relay sibling cases pass before and after. Exact schema/origin/manifest/nonce assertions and both real loopback relay wakeups remain. Full changed checks and Codex autoreview pass. Production +0/-0; tests +12/-17.

The native host only reads its fixture paths. Source review covered the host, framing parser, native entry point, relay spawn/daemon owners, the canonical SDK helpers, and the original bootstrap, Store-origin and relay-wakeup changes.

```sh
OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs extensions/browser/src/browser/extension-native-host.test.ts extensions/browser/src/browser/extension-relay-daemon-spawn.test.ts extensions/browser/src/browser/relay-daemon.test.ts
OPENCLAW_LOCAL_CHECK_MODE=full node scripts/check-changed.mjs --base aec3d0b152b87a9b7c5ae6b6867f5a8cf12aa26f
```

