### PR TITLE
fix(ui): highlight inherited Full Access on initial load

### DIFF
--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -130,7 +130,7 @@ describe("chat pane composer controls", () => {
     ["workspace", "Default (Workspace)"],
     ["full", "Default (Full Access)"],
   ] as const)(
-    "labels inherited permissions for %s without selecting a mode",
+    "renders inherited permissions for %s without selecting a mode",
     (defaultMode, label) => {
       const container = document.createElement("div");
       const onSelect = vi.fn();
@@ -140,9 +140,18 @@ describe("chat pane composer controls", () => {
       );
       const trigger = container.querySelector('[data-chat-permission-select="true"]');
       const option = container.querySelector('[data-chat-permission-option="default"]');
+      const fullAccess = defaultMode === "full";
       expect(trigger?.textContent?.trim()).toBe(label);
       expect(trigger?.getAttribute("aria-label")).toBe(`Permissions: ${label}`);
       expect(trigger?.getAttribute("data-chat-select-value")).toBe("");
+      expect(trigger?.classList.contains("chat-controls__permission-trigger--full")).toBe(
+        fullAccess,
+      );
+      expect(
+        trigger
+          ?.querySelector(".chat-controls__inline-select-label")
+          ?.classList.contains("chat-controls__permission-label--full"),
+      ).toBe(fullAccess);
       expect(
         option?.querySelector(".chat-controls__permission-option-title")?.textContent?.trim(),
       ).toBe(label);

--- a/ui/src/pages/chat/components/chat-permission-picker.ts
+++ b/ui/src/pages/chat/components/chat-permission-picker.ts
@@ -92,7 +92,7 @@ function permissionSelection(value: string | undefined): PermissionSelection | u
 
 export function renderChatPermissionPicker(params: ChatPermissionPickerProps) {
   const disabled = params.disabled || params.applying;
-  const fullAccess = params.mode === "full" && !params.applying;
+  const fullAccess = (params.mode ?? params.defaultMode) === "full" && !params.applying;
   const label = params.applying
     ? t("chat.permissionControls.applying")
     : modeLabel(params.mode, params.defaultMode);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users starting a session that inherits Full Access from the default saw a neutral permission pill on initial load, even though Full Access was effective. The highlighted color appeared only after choosing Full Access explicitly.

## Why This Change Was Made

The permission picker now derives its highlighted state from the effective permission mode (`mode ?? defaultMode`) while preserving the applying-state behavior. Regression coverage exercises every inherited default and verifies that only inherited Full Access receives the highlighted styling.

## User Impact

The permission pill now immediately communicates that Full Access is active, including before the user interacts with the picker.

## Evidence

**Before — inherited Full Access is neutral on initial load**

https://github.com/user-attachments/assets/ea80e408-1347-4311-9afb-30ee2ff47062

**After — inherited Full Access is highlighted immediately**

https://github.com/user-attachments/assets/831fee72-e0a6-422d-83f9-affeeb765bef

Both recordings use the same deterministic mocked-Gateway fixture; only the pre-fix and fixed code differ.

- `node scripts/run-vitest.mjs ui/src/pages/chat/chat-pane-session-controls.test.ts` — 23/23 tests passed.
- `node scripts/check-changed.mjs -- ui/src/pages/chat/components/chat-permission-picker.ts ui/src/pages/chat/chat-pane-session-controls.test.ts` — passed the UI and core-test changed-file gates.
- The inherited-Full-Access regression assertion failed against the pre-fix expression (`expected true, received false`) and passed after the fix.
- Production LOC: +1/-1. Test LOC: +10/-1.
- `git diff --check` passed.

Automated autoreview did not return a verdict: the isolated Codex reviewer received HTTP 401, and the supported Claude fallback was not logged in. No automated-review success is claimed; the complete diff was reviewed manually.

## Worked on by

- Patrick Erichsen (@Patrick-Erichsen)
